### PR TITLE
fix: credential-based prerequisites, cross-track upgrades & level protection

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -65,7 +65,7 @@ Quick-reference for developers. Full details in [SPEC.md](./SPEC.md).
 
 Config is the singleton root. It holds `xp_mint` (Token-2022 mint), `backend_signer`, and `authority`. Config PDA is also the update authority for all Metaplex Core track collection NFTs.
 
-Each Course is independent. Enrollment PDAs are children of a Course × learner pair. An Enrollment stores the lesson bitmap, `completed_at` timestamp, and the `credential_asset` pubkey once issued. That pubkey is the on-chain source of truth for create-vs-upgrade decisions in `issue_credential`.
+Each Course is independent and stores a `track_collection: Pubkey` linking it to its track's Metaplex Core collection. Enrollment PDAs are children of a Course × learner pair. An Enrollment stores the lesson bitmap, `completed_at` timestamp, and the `credential_asset` pubkey once issued. The backend uses Helius DAS API to determine create-vs-upgrade; `upgrade_credential` verifies the credential on-chain via `BaseAssetV1` deserialization (ownership + collection membership).
 
 MinterRole PDAs are independent of Course. Any registered minter (including the backend signer, auto-registered at initialize) can call `reward_xp` and `award_achievement`.
 
@@ -81,7 +81,7 @@ Credential NFTs are Metaplex Core assets. One exists per learner per track. It b
 1. ENROLL
    Learner ──sign──► enroll(course_id)
    - Check: course.is_active
-   - Check: prerequisite Enrollment.completed_at.is_some() (if set)
+   - Check: prerequisite credential NFT via remaining_accounts (if set)
    - Init: Enrollment PDA (lesson_flags = 0, completed_at = None)
    - Emit: Enrolled
 
@@ -104,16 +104,26 @@ Credential NFTs are Metaplex Core assets. One exists per learner per track. It b
    - Increment: course.total_completions
    - Emit: CourseFinalized
 
-4. ISSUE CREDENTIAL
+4a. ISSUE CREDENTIAL  (first course in track)
    Backend ──sign──► issue_credential(credential_name, metadata_uri, courses_completed, total_xp)
    - Check: enrollment.completed_at.is_some()
-   - If enrollment.credential_asset == None:
-       - Metaplex Core createV2 CPI (PermanentFreezeDelegate + Attributes plugins)
-       - Set: enrollment.credential_asset = new asset pubkey
-       - Emit: CredentialIssued (credential_created = true)
-   - If enrollment.credential_asset == Some(pubkey):
-       - Metaplex Core updateV1 + updatePluginV1 CPI
-       - Emit: CredentialIssued (credential_upgraded = true)
+   - Check: enrollment.credential_asset.is_none() (guard against double-issue)
+   - Check: track_collection.key() == course.track_collection
+   - Metaplex Core createV2 CPI (PermanentFreezeDelegate + Attributes plugins)
+   - Set: enrollment.credential_asset = new asset pubkey
+   - Emit: CredentialIssued
+   (Config PDA signs as collection update authority)
+
+4b. UPGRADE CREDENTIAL  (subsequent courses in same track)
+   Backend ──sign──► upgrade_credential(credential_name, metadata_uri, courses_completed, total_xp)
+   - Check: enrollment.completed_at.is_some()
+   - Verify: BaseAssetV1 deserialization → asset.owner == learner, asset.update_authority == Collection(track_collection)
+   - Read: current credential level from Attributes plugin
+   - Compute: effective_level = max(current_level, course.track_level) (prevent downgrade)
+   - Check: track_collection.key() == course.track_collection
+   - Metaplex Core updateV1 + updatePluginV1 CPI
+   - Propagate: enrollment.credential_asset = credential pubkey
+   - Emit: CredentialUpgraded
    (Config PDA signs as collection update authority)
 
 5. CLOSE ENROLLMENT  (optional — reclaims rent)
@@ -193,7 +203,7 @@ R = read, W = write, I = init, C = close
 | complete_lesson | R | R | W | | | | R | W (learner) | |
 | finalize_course | R | W | W | | | | R | W (learner + creator) | |
 | issue_credential | R | R | W | | | | | | W |
-| upgrade_credential | R | R | R | | | | | | W |
+| upgrade_credential | R | R | W | | | | | | W |
 | close_enrollment | | | C | | | | | | |
 | register_minter | R | | | W/I | | | | | |
 | revoke_minter | R | | | C | | | | | |
@@ -209,7 +219,7 @@ R = read, W = write, I = init, C = close
 | Account | Discriminator | Data | Reserved | Total | Rent |
 |---------|---------------|------|----------|-------|------|
 | Config | 8 B | 97 B | 8 B | 113 B | ~0.001 SOL |
-| Course | 8 B | ~176 B | 8 B | 192 B | ~0.002 SOL |
+| Course | 8 B | ~208 B | 8 B | 224 B | ~0.003 SOL |
 | Enrollment | 8 B | ~115 B | 4 B | 127 B | ~0.001 SOL |
 | MinterRole | 8 B | ~94 B | 8 B | 110 B | ~0.001 SOL |
 | AchievementType | 8 B | ~322 B | 8 B | 338 B | ~0.003 SOL |
@@ -226,7 +236,7 @@ R = read, W = write, I = init, C = close
 | update_config | ~5K | Field updates |
 | create_course | ~15K | Course PDA init |
 | update_course | ~10K | Field updates |
-| enroll | ~15K | Enrollment PDA init + prerequisite check |
+| enroll | ~17K | Enrollment PDA init + prerequisite check (credential NFT deserialization if prerequisite set) |
 | complete_lesson | ~30K | Bitmap write + Token-2022 mint CPI |
 | finalize_course | ~50K | Bitmap verify + 2× Token-2022 mint CPI |
 | issue_credential | ~50–100K | Metaplex Core createV2 or updateV1 CPI |

--- a/docs/ENHANCEMENT_CREDENTIAL_PREREQUISITE.md
+++ b/docs/ENHANCEMENT_CREDENTIAL_PREREQUISITE.md
@@ -1,0 +1,406 @@
+# Enhancement: Credential-Based Prerequisites, Cross-Track Upgrades & Level Protection
+
+## Overview
+
+This document details three interconnected bugs in the on-chain program's credential and prerequisite system, the alternative approaches we evaluated, the reasoning behind our chosen solution, and the resulting UX improvements.
+
+---
+
+## Problems Identified
+
+### Bug 1: Prerequisite Check Breaks After Enrollment Closure
+
+**Symptom:** A learner who completed a prerequisite course and reclaimed their enrollment rent could never enroll in the dependent (advanced) course.
+
+**Root cause:** The `enroll` instruction verified prerequisites by deserializing the prerequisite Enrollment PDA from `remaining_accounts`. The `close_enrollment` instruction deletes this PDA (via Anchor's `close = learner` constraint), returning rent to the learner. Once closed, the enrollment account no longer exists on-chain, so deserialization fails and the prerequisite check reverts.
+
+**Impact:** Learners faced an impossible choice — keep the Enrollment PDA alive (forfeiting ~0.002 SOL in rent) or reclaim rent and lose the ability to progress in a track. This directly contradicts the platform's promise that enrollment is ephemeral and rent-reclaimable.
+
+```
+Before fix:
+  Complete Course A → Close Enrollment (reclaim rent) → Enroll in Course B (requires A) → ❌ FAILS
+```
+
+### Bug 2: `upgrade_credential` Broken for Multi-Course Tracks
+
+**Symptom:** Upgrading a credential after completing a second course in the same track failed when using Course Y's enrollment, even though the learner held a valid credential NFT.
+
+**Root cause:** `upgrade_credential` read `enrollment.credential_asset` to find the existing credential NFT address. But credentials are per-track (not per-course). When a learner completes Course Y (the second course in a track), Course Y's enrollment has `credential_asset = None` because the credential was originally issued via Course X's enrollment. The instruction would hit `enrollment.credential_asset.ok_or(CourseNotFinalized)` and revert.
+
+**Workaround (fragile):** The backend could pass Course X's enrollment PDA (which has `credential_asset` set) instead of Course Y's. This worked only if Course X's enrollment was still open. Once the learner closed Course X's enrollment to reclaim rent, `credential_asset` was lost and upgrade became impossible — combining Bug 1 and Bug 2 into a complete blocker.
+
+**Impact:** The upgrade flow had no reliable path for multi-course track progression. The workaround of using Course X's enrollment was fragile (broken by rent reclaim) and required the backend to track which enrollment originally issued the credential — coupling that should not exist.
+
+```
+Before fix:
+  Issue credential via Course X enrollment → Complete Course Y → Upgrade via Course Y enrollment → ❌ FAILS
+  (Course Y enrollment has credential_asset = None)
+
+  Workaround: Upgrade via Course X enrollment → ⚠️ WORKS only if Course X enrollment is still open
+  Close Course X enrollment (reclaim rent) → Upgrade via Course X enrollment → ❌ FAILS (PDA deleted)
+```
+
+### Bug 3: Credential Level Can Downgrade
+
+**Symptom:** A learner who completed courses out of order (e.g., level-2 before level-1) could have their credential level downgraded.
+
+**Root cause:** Both `issue_credential` and `upgrade_credential` blindly set the credential's `level` attribute from `course.track_level`. No comparison was made against the credential's current level. If a learner completed a level-2 course first (credential level = 2), then completed a level-1 course and triggered an upgrade, the credential level would be overwritten to 1.
+
+**Impact:** Learner achievements could be silently eroded. The credential NFT — visible in wallets and meant to represent track progression — would show a lower level than actually earned.
+
+---
+
+## Approaches Evaluated
+
+### Approach A: New `CompletionRecord` PDA (Rejected)
+
+**Concept:** Introduce a new PDA type (`CompletionRecord`) seeded by `[b"completion", course_id, learner]` that persists permanently after course completion, independent of the enrollment lifecycle.
+
+**Pros:**
+- Clean separation: enrollment is transient, completion is permanent
+- Prerequisite checks would read `CompletionRecord` instead of enrollment
+- No dependency on Metaplex Core for prerequisite logic
+
+**Cons:**
+- **New PDA = new rent cost:** Every completed course would require an additional ~0.001 SOL permanent rent deposit. At scale (thousands of learners × dozens of courses), this adds up significantly.
+- **Storage bloat:** Two PDAs per completed course per learner (enrollment + completion record) during the active phase
+- **Migration complexity:** Existing completed enrollments would need a migration instruction or off-chain backfill
+- **Doesn't fix Bug 2 or Bug 3:** Would still need additional changes for credential upgrade and level logic
+
+**Verdict:** Rejected. Adds permanent on-chain cost for something the credential NFT already proves.
+
+### Approach B: Prevent Enrollment Closure for Prerequisite Courses (Rejected)
+
+**Concept:** Add a check in `close_enrollment` that refuses to close an enrollment if any active course references it as a prerequisite.
+
+**Pros:**
+- Minimal code change (one `require!` in `close_enrollment`)
+- No new state or PDAs
+
+**Cons:**
+- **Defeats the purpose of rent reclamation:** Learners who complete prerequisite courses can never reclaim rent, which is the entire point of `close_enrollment`
+- **Scaling problem:** As more courses are added with prerequisites, an increasingly large portion of enrollments become permanently locked
+- **Poor UX:** "You completed the course but can't get your rent back" is confusing
+- **Still doesn't fix Bug 2 or Bug 3**
+
+**Verdict:** Rejected. Treats the symptom, not the cause. Makes UX worse.
+
+### Approach C: Credential NFT as Proof of Completion (Chosen)
+
+**Concept:** Use the learner's existing Metaplex Core credential NFT as proof of prerequisite completion. The credential already exists, is soulbound, and carries track/level metadata. Verify it on-chain via `BaseAssetV1` deserialization.
+
+**Pros:**
+- **Zero additional rent cost:** No new PDAs. The credential NFT already exists as part of the normal flow.
+- **Fixes all three bugs simultaneously:**
+  - Bug 1: Credential persists regardless of enrollment closure
+  - Bug 2: Credential is looked up by collection membership, not enrollment
+  - Bug 3: Current level is read from the credential and `max()` is applied
+- **Stronger security:** Credential ownership and collection membership are verified on-chain (not just PDA derivation)
+- **Aligns incentives:** Learners are now incentivized to collect their credential NFT before closing enrollment (which they would naturally do anyway)
+- **Enables rent reclamation:** Enrollment becomes truly ephemeral — close it anytime after credential issuance
+
+**Cons:**
+- **Requires `track_collection: Pubkey` on Course PDA:** +32 bytes per course (192 → 224 bytes). Acceptable since courses are created by admins, not at learner scale.
+- **Metaplex Core CPI dependency in `enroll`:** Previously `enroll` had no external CPI. Now it reads (but doesn't write) a Metaplex Core account. Read-only access adds minimal CU overhead (~2,000 CU for deserialization).
+- **Prerequisite requires credential issuance:** Learners must collect their credential NFT before enrolling in the next course. This is a feature, not a bug — it ensures the track progression is explicit.
+
+**Verdict:** Chosen. Solves all three bugs, improves UX, adds no per-learner cost, and leverages existing infrastructure.
+
+---
+
+## Implementation Details
+
+### 1. Course PDA: `track_collection` Field
+
+```rust
+// state/course.rs
+pub struct Course {
+    // ... existing fields ...
+    pub track_level: u8,
+    pub track_collection: Pubkey,  // NEW: Metaplex Core collection for this track
+    pub prerequisite: Option<Pubkey>,
+    // ... remaining fields ...
+}
+```
+
+**SIZE:** 192 → 224 bytes (+32 for the `Pubkey`).
+
+**Purpose:** Links each course to its track's Metaplex Core collection on-chain. This enables:
+- Prerequisite verification: "Does the learner hold a credential from the prerequisite course's track?"
+- Credential issuance/upgrade: Constraint `track_collection.key() == course.track_collection` prevents passing the wrong collection.
+
+### 2. Prerequisite Check (Bug 1 Fix)
+
+**Before:**
+```
+remaining_accounts = [prereq_course_pda, prereq_enrollment_pda]
+→ Deserialize enrollment → Check completed_at → Verify PDA seeds
+```
+
+**After:**
+```
+remaining_accounts = [prereq_course_pda, credential_nft]
+→ Verify credential owner == mpl_core::ID
+→ Deserialize BaseAssetV1
+→ Check asset.owner == learner
+→ Check asset.update_authority == Collection(prereq_course.track_collection)
+```
+
+**Security layers:**
+1. Account owner check (`mpl_core::ID`) — rejects non-Metaplex accounts
+2. `BaseAssetV1` deserialization — rejects malformed data
+3. `asset.owner == learner` — rejects credentials owned by others
+4. `UpdateAuthority::Collection(track_collection)` — rejects credentials from wrong tracks
+
+### 3. Credential Verification in `upgrade_credential` (Bug 2 Fix)
+
+**Before:**
+```rust
+let existing_asset = enrollment.credential_asset.ok_or(CourseNotFinalized)?;
+require!(credential_asset.key() == existing_asset, CredentialAssetMismatch);
+```
+
+**After:**
+```rust
+let asset = BaseAssetV1::try_from(&ctx.accounts.credential_asset)?;
+require!(asset.owner == learner.key(), InvalidCredentialOwner);
+require!(asset.update_authority == UpdateAuthority::Collection(track_collection.key()), TrackCollectionMismatch);
+```
+
+The credential is now verified by its on-chain properties (ownership + collection membership), not by an enrollment field that may not exist for the current course.
+
+After upgrade, the credential address is propagated back: `enrollment.credential_asset = Some(credential_asset.key())`.
+
+### 4. Max-Level Logic (Bug 3 Fix)
+
+```rust
+let current_level = fetch_asset_plugin::<Attributes>(&credential_asset, PluginType::Attributes)
+    .ok()
+    .and_then(|(_, attrs, _)| {
+        attrs.attribute_list.iter()
+            .find(|a| a.key == "level")
+            .and_then(|a| a.value.parse::<u8>().ok())
+    })
+    .unwrap_or(0);
+
+let effective_level = std::cmp::max(current_level, course.track_level);
+```
+
+The `level` attribute on the credential NFT is read via `fetch_asset_plugin`, parsed, and compared against the course's `track_level`. The higher value wins. This guarantees monotonic level progression regardless of course completion order.
+
+### 5. New Error Variants
+
+```rust
+#[msg("Credential is not owned by the learner")]
+InvalidCredentialOwner,
+
+#[msg("Credential does not belong to the track collection")]
+TrackCollectionMismatch,
+```
+
+Specific errors for credential validation failures, distinct from the existing `PrerequisiteNotMet` (which covers the prerequisite enrollment flow).
+
+---
+
+## UX Improvements
+
+### Rent Reclamation Flow
+
+The previous design created a hidden trap: learners who completed a prerequisite course and responsibly reclaimed their enrollment rent would be blocked from progressing. The new flow makes enrollment truly ephemeral:
+
+```
+New learner journey:
+1. Enroll in Course A (pay ~0.002 SOL rent)
+2. Complete all lessons → Finalize
+3. Collect credential NFT (soulbound, lives in wallet forever)
+4. Close enrollment → Get rent back ✅
+5. Enroll in Course B (requires Course A) — pass credential NFT as proof ✅
+6. Close Course A enrollment at any time — it's no longer needed
+```
+
+### Future Enhancement: Auto-Close on Credential Collection
+
+With the credential NFT now serving as the permanent proof of completion, the enrollment PDA becomes unnecessary after credential issuance. A natural next step is to **auto-close the enrollment when the learner collects their credential NFT**, combining two transactions into one:
+
+```
+Current (2 transactions):
+  1. issue_credential → credential minted to learner
+  2. close_enrollment → rent returned to learner
+
+Future (1 transaction):
+  1. issue_credential_and_close → credential minted + enrollment closed + rent returned
+```
+
+This could be implemented as either:
+- A new `issue_credential_and_close` instruction (atomic, single tx)
+- Backend-initiated via the existing `issue_credential` with an additional `close_enrollment` ix in the same transaction
+
+The on-chain changes in this PR make this possible by eliminating all dependencies on the enrollment PDA for prerequisite checks and credential upgrades. The enrollment's only remaining purpose after credential issuance is as a historical record — and the credential NFT itself fulfills that role better (visible in wallets, carries metadata, immutable on-chain).
+
+### Credential as Universal Proof
+
+The credential NFT now serves as the single source of truth for track progression:
+
+| Use Case | Before | After |
+|----------|--------|-------|
+| Prerequisite check | Enrollment PDA (deleted on close) | Credential NFT (permanent) |
+| Credential upgrade | `enrollment.credential_asset` (per-course) | On-chain BaseAssetV1 (per-track) |
+| Level tracking | Blindly overwritten | `max(current, new)` monotonic |
+| Wallet visibility | N/A | Soulbound NFT in learner's wallet |
+| Rent reclamation | Blocked by prerequisite dependency | Free to close anytime |
+
+---
+
+## Files Changed
+
+| File | Change | Lines |
+|------|--------|-------|
+| `state/course.rs` | Added `track_collection: Pubkey`, SIZE 192→224 | +5/-1 |
+| `errors.rs` | Added `InvalidCredentialOwner`, `TrackCollectionMismatch` | +4 |
+| `instructions/create_course.rs` | Added `track_collection` to params + handler | +2 |
+| `instructions/enroll.rs` | Credential NFT prerequisite check | +24/-27 |
+| `instructions/upgrade_credential.rs` | On-chain verification + max-level + propagation | +37/-16 |
+| `instructions/issue_credential.rs` | Added `track_collection` constraint | +5/-2 |
+| `tests/rust/src/test_course.rs` | Updated SIZE + `track_collection` in structs | +7/-3 |
+| `tests/onchain-academy.ts` | Added `trackCollection` params, rewrote prerequisite tests | +130/-55 |
+
+---
+
+## Security Analysis
+
+| Attack Vector | Mitigated? | Mechanism |
+|---------------|-----------|-----------|
+| Wrong credential for prerequisite | Yes | `asset.update_authority` checked against `prereq_course.track_collection` |
+| Credential from different track | Yes | Collection mismatch caught by `UpdateAuthority::Collection` comparison |
+| Non-Metaplex-Core account as credential | Yes | Account owner checked against `mpl_core::ID` before deserialization |
+| Someone else's credential | Yes | `asset.owner == learner.key()` |
+| Backend passes wrong track_collection | Yes | Anchor constraint `track_collection.key() == course.track_collection` |
+| Credential level downgrade | Yes | `max(current_level, course.track_level)` enforced on-chain |
+| Double credential issuance (same enrollment) | Yes | `enrollment.credential_asset.is_none()` guard unchanged |
+| Malformed BaseAssetV1 data | Yes | `try_from` + `map_err` returns appropriate error |
+
+---
+
+## Test Coverage
+
+### Rust Unit Tests (77 passing)
+
+- `course_size_constant_is_correct` — Verifies SIZE = 224
+- `course_serialization_roundtrip` — Includes `track_collection` field
+- `course_with_prerequisite_roundtrip` — Includes `track_collection` field
+- `course_serialized_size_with_max_id_and_all_options` — Validates serialized size matches SIZE constant
+
+### TypeScript Integration Tests (66 passing)
+
+**Existing tests updated:**
+- All 19 `createCourse` calls include `trackCollection` parameter
+- Credential issuance and upgrade tests use `track_collection` constraint
+
+**Prerequisite tests (rewritten for credential-based verification):**
+
+| # | Test Name | What It Verifies | Expected Result |
+|---|-----------|-----------------|-----------------|
+| 1 | "enroll fails without remaining accounts for prerequisite" | No remaining accounts passed for a course with prerequisite | `PrerequisiteNotMet` error |
+| 2 | "enroll fails with non-Metaplex-Core account as credential" | Passes an enrollment PDA (program-owned) instead of a Metaplex Core credential NFT | `PrerequisiteNotMet` error |
+| 3 | "enroll with credential NFT succeeds" | Full flow: create course with real collection → complete all lessons → finalize → issue credential → enroll in dependent course using credential NFT | Enrollment succeeds |
+
+**Regression tests (new — covering all 3 bugs):**
+
+| # | Test Name | Bug | What It Verifies | Expected Result |
+|---|-----------|-----|-----------------|-----------------|
+| 4 | "prerequisite succeeds after close_enrollment (rent reclaim)" | Bug 1 | Complete prereq course → issue credential → close enrollment (reclaim rent) → enroll in dependent course using credential NFT | Enrollment succeeds despite closed enrollment |
+| 5 | "prerequisite fails with credential from wrong track" | Bug 1 | Hold credential from Track A → attempt to enroll in course requiring Track B completion | `PrerequisiteNotMet` error |
+| 6 | "upgrade_credential succeeds from second course in same track (Bug 2 regression)" | Bug 2 | Issue credential via Course X → complete Course Y in same track → upgrade credential via Course Y enrollment | Upgrade succeeds, `enrollment.credential_asset` propagated |
+| 7 | "credential level never downgrades (Bug 3 regression)" | Bug 3 | Complete level-2 course → issue credential (level=2) → complete level-1 course → upgrade credential → verify level remains 2 | Credential level = 2, not downgraded to 1 |
+
+### Test Output
+
+```
+  Onchain Academy
+    Phase 1: Initialization
+      ✔ initializes config and XP mint
+    Phase 2: Course creation
+      ✔ creates a course
+      ✔ fails with duplicate courseId
+      ✔ fails with empty courseId
+      ✔ fails with too-long courseId
+      ✔ fails with lessonCount = 0
+      ✔ fails with invalid difficulty
+      ✔ creates a course with prerequisite
+      ✔ creates a second active course for update tests
+    Phase 3: Course updates
+      ✔ updates course content tx ID
+      ✔ updates XP per lesson
+      ✔ deactivates a course
+      ✔ reactivates a course
+      ✔ fails when non-authority tries to update
+    Phase 4: Enrollment
+      ✔ enrolls a learner
+      ✔ fails duplicate enrollment
+      ✔ fails enrollment in inactive course
+    Phase 5: Lesson completion & finalization
+      ✔ completes a lesson and mints XP
+      ✔ fails duplicate lesson completion
+      ✔ fails out-of-bounds lesson index
+      ✔ completes remaining lessons
+      ✔ finalizes course and mints bonus + creator XP
+      ✔ fails double finalization
+    Phase 6: Credentials
+      ✔ issues credential NFT for completed course
+      ✔ double issue_credential fails
+      ✔ upgrades existing credential
+      ✔ fails with wrong credential asset on upgrade
+      ✔ upgrade_credential succeeds from second course in same track (Bug 2 regression)
+      ✔ credential level never downgrades (Bug 3 regression)
+    Phase 7: Close enrollment
+      ✔ fails to close before 24h for incomplete enrollment
+      ✔ closes completed enrollment immediately
+      ✔ closes incomplete enrollment after 24h
+    Phase 8: Minter roles
+      ✔ registers a minter
+      ✔ minter rewards XP
+      ✔ fails with zero amount
+      ✔ fails when exceeding max per call
+      ✔ revokes minter
+      ✔ fails reward after revocation
+    Phase 9: Backend signer rotation
+      ✔ rotates backend signer
+      ✔ old signer fails
+      ✔ new signer succeeds
+    Phase 10: Achievements
+      ✔ creates achievement type
+      ✔ awards achievement with NFT and XP
+      ✔ double award fails (receipt PDA collision)
+      ✔ deactivates achievement type
+      ✔ fails award after deactivation
+    Phase 11: Edge cases
+      ✔ fails finalize before all lessons complete
+      ✔ fails credential before finalize
+      ✔ close_enrollment with credential still works
+      ✔ re-enroll after close
+      ✔ second learner full flow
+      ✔ creator reward only after min completions
+      ✔ max lesson count (255) course creation
+      ✔ enroll in course with no prerequisite (no remaining accounts needed)
+    Phase 12: Prerequisite enforcement
+      ✔ enroll fails without remaining accounts for prerequisite
+      ✔ enroll fails with non-Metaplex-Core account as credential
+      ✔ enroll with credential NFT succeeds
+      ✔ prerequisite succeeds after close_enrollment (rent reclaim)
+      ✔ prerequisite fails with credential from wrong track
+    Phase 13: Full track flow
+      ✔ complete track: enroll → lessons → finalize → credential → next course
+    Phase 14: Multiple enrollments
+      ✔ two learners in same course, independent progress
+    Phase 15: Achievement supply cap
+      ✔ respects max supply
+    Phase 16: Minter cap enforcement
+      ✔ minter with unlimited cap (maxXpPerCall=0)
+      ✔ minter cap boundary: exact amount succeeds, +1 fails
+    Phase 17: Content update
+      ✔ updates content tx ID without affecting enrollments
+    Phase 18: Multi-course XP accumulation
+      ✔ XP accumulates across courses
+
+  66 passing (2m)
+```

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -89,7 +89,7 @@ const [receiptPda] = PublicKey.findProgramAddressSync(
 
 #### enroll
 
-Enrolls the connected wallet in a course. If the course has a prerequisite, pass the prerequisite Course PDA and the learner's completed Enrollment PDA as remaining accounts.
+Enrolls the connected wallet in a course. If the course has a prerequisite, pass the prerequisite Course PDA and the learner's credential NFT (from the prerequisite track) as remaining accounts. The credential NFT is verified on-chain: account owner must be `mpl_core::ID`, `asset.owner == learner`, and `asset.update_authority == Collection(prereq_course.track_collection)`.
 
 ```typescript
 await program.methods
@@ -103,10 +103,12 @@ await program.methods
   // If course has prerequisite:
   .remainingAccounts([
     { pubkey: prereqCoursePda, isWritable: false, isSigner: false },
-    { pubkey: prereqEnrollmentPda, isWritable: false, isSigner: false },
+    { pubkey: credentialNftPubkey, isWritable: false, isSigner: false },
   ])
   .rpc();
 ```
+
+> **Note:** The prerequisite check uses the learner's credential NFT, not an enrollment PDA. This means learners can safely close their enrollment (reclaim rent) after collecting their credential — the credential serves as permanent proof of track completion.
 
 #### close_enrollment
 
@@ -275,6 +277,7 @@ await program.methods
     xpPerLesson: 100,
     trackId: 1,
     trackLevel: 1,
+    trackCollection: trackCollectionPubkey,
     prerequisite: null,
     creatorRewardXp: 50,
     minCompletionsForReward: 3,
@@ -592,7 +595,9 @@ Common error codes:
 | `CourseNotCompleted` | Finalize before all lessons done |
 | `CourseAlreadyFinalized` | Double finalize |
 | `CourseNotFinalized` | Credential before finalize |
-| `PrerequisiteNotMet` | Missing prerequisite course |
+| `PrerequisiteNotMet` | Missing or invalid prerequisite credential |
+| `InvalidCredentialOwner` | Credential NFT not owned by learner |
+| `TrackCollectionMismatch` | Credential from wrong track collection |
 | `UnenrollCooldown` | Close too early (24h cooldown) |
 | `MinterNotActive` | Revoked minter |
 | `MinterAmountExceeded` | Over per-call XP cap |

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -17,7 +17,7 @@ Superteam Academy is a decentralized learning platform on Solana that issues ver
 | Account | Seeds | Size | Closeable | Purpose |
 |---------|-------|------|-----------|---------|
 | Config | `["config"]` | 113 B | No | Singleton: platform authority, backend signer, XP mint |
-| Course | `["course", course_id.as_bytes()]` | 192 B | No | Course metadata, creator, XP amounts, lesson count, prerequisite |
+| Course | `["course", course_id.as_bytes()]` | 224 B | No | Course metadata, creator, XP amounts, lesson count, track collection, prerequisite |
 | Enrollment | `["enrollment", course_id.as_bytes(), user.key()]` | 127 B | Yes | Per-learner progress: lesson bitmap, timestamps, credential ref |
 | MinterRole | `["minter", minter.key()]` | 110 B | Yes (via revoke_minter) | Registered XP minter: label, per-call cap, active flag |
 | AchievementType | `["achievement", achievement_id.as_bytes()]` | 338 B | No | Achievement definition: name, metadata URI, collection, supply cap |
@@ -46,7 +46,7 @@ Superteam Academy is a decentralized learning platform on Solana that issues ver
 
 | Instruction | Who Signs | Description |
 |-------------|-----------|-------------|
-| `enroll` | learner | Create Enrollment PDA; checks course is active and prerequisite completed |
+| `enroll` | learner | Create Enrollment PDA; checks course is active and prerequisite completed (via credential NFT in remaining_accounts) |
 | `complete_lesson` | backend_signer | Set lesson bit in bitmap, mint `xp_per_lesson` to learner |
 | `finalize_course` | backend_signer | Verify full bitmap, mint completion bonus to learner, mint creator reward (if threshold met), set `completed_at` |
 | `issue_credential` | backend_signer | Create Metaplex Core credential NFT for the learner's track. Params: `credential_name`, `metadata_uri`, `courses_completed: u32`, `total_xp: u64` |
@@ -75,11 +75,11 @@ Superteam Academy is a decentralized learning platform on Solana that issues ver
 
 ### Learner Journey
 
-- Learner calls `enroll` — Enrollment PDA created, prerequisite checked on-chain
+- Learner calls `enroll` — Enrollment PDA created, prerequisite verified via credential NFT (if set)
 - Backend validates quiz or content progress, then signs and submits `complete_lesson` for each lesson — XP minted per lesson
 - Backend verifies full bitmap and submits `finalize_course` — completion bonus and creator reward minted
-- Backend submits `issue_credential` — Metaplex Core NFT created (first track course) or upgraded (subsequent track courses); asset pubkey stored in Enrollment
-- Learner optionally calls `close_enrollment` to reclaim rent; credential NFT remains in wallet permanently
+- Backend submits `issue_credential` — Metaplex Core NFT created (first track course) or `upgrade_credential` (subsequent track courses); asset pubkey stored in Enrollment
+- Learner optionally calls `close_enrollment` to reclaim rent; credential NFT remains in wallet permanently and serves as prerequisite proof for dependent courses
 - Learner can unenroll from an incomplete course after 24 hours by calling `close_enrollment`
 
 ### Admin Management
@@ -127,7 +127,13 @@ The completion bonus is computed as `floor((xp_per_lesson * lesson_count) / 2)` 
 
 Credentials are Metaplex Core NFTs — soulbound via PermanentFreezeDelegate plugin, universally visible in Phantom, Backpack, and Solflare. One credential NFT exists per learner per track (e.g., one for the Anchor track, one for the DeFi track). The credential upgrades in place as the learner completes higher-level courses in the same track — the NFT address never changes.
 
-Config PDA is the update authority for all track collection NFTs. This means only the program (signing as Config PDA) can create or upgrade credentials via Metaplex Core CPI. The Enrollment account stores the `credential_asset` pubkey once issued — this field is the on-chain source of truth for create-vs-upgrade decisions, eliminating any DAS API dependency for writes.
+Each Course PDA stores a `track_collection: Pubkey` linking it to its track's Metaplex Core collection. Config PDA is the update authority for all track collection NFTs. This means only the program (signing as Config PDA) can create or upgrade credentials via Metaplex Core CPI.
+
+**Create vs. upgrade decision:** `issue_credential` creates a new credential NFT (guarded by `enrollment.credential_asset.is_none()`). `upgrade_credential` updates an existing credential NFT, verified on-chain via `BaseAssetV1` deserialization — checking `asset.owner == learner` and `asset.update_authority == Collection(course.track_collection)`. The backend determines which to call by querying the learner's existing credentials via Helius DAS API.
+
+**Level protection:** `upgrade_credential` reads the current credential level from the Attributes plugin and applies `max(current_level, course.track_level)`, preventing downgrades when courses are completed out of order.
+
+**Prerequisite verification:** `enroll` verifies prerequisites by checking the learner's credential NFT (passed via `remaining_accounts`), not the enrollment PDA. This allows learners to reclaim enrollment rent while retaining prerequisite eligibility — the credential NFT in their wallet is permanent proof of track completion.
 
 Achievement NFTs are distinct from track credentials — each is a separate Metaplex Core asset in its own collection, awarded once per recipient per achievement type.
 
@@ -153,7 +159,7 @@ Achievement NFTs are distinct from track credentials — each is a separate Meta
 - Creator reward gating — `min_completions_for_reward` blocks alt-account farming
 - AchievementReceipt PDA init — account collision prevents double-awarding
 - MinterRole cap — `max_xp_per_call` (0 = unlimited) limits per-call damage from a compromised minter
-- Prerequisite enforcement — Enrollment checks completed_at on prerequisite Enrollment PDA at enroll time
+- Prerequisite enforcement — `enroll` verifies learner's credential NFT (ownership + track collection membership) via `remaining_accounts`
 
 ---
 
@@ -178,6 +184,8 @@ Achievement NFTs are distinct from track credentials — each is a separate Meta
 | `InvalidDifficulty` | Difficulty must be 1, 2, or 3 |
 | `CredentialAssetMismatch` | Credential asset does not match enrollment record |
 | `CredentialAlreadyIssued` | Credential already issued for this enrollment |
+| `InvalidCredentialOwner` | Credential is not owned by the learner |
+| `TrackCollectionMismatch` | Credential does not belong to the track collection |
 | `MinterNotActive` | Minter role is not active |
 | `MinterAmountExceeded` | Amount exceeds minter's per-call limit |
 | `LabelTooLong` | Minter label exceeds max length |
@@ -220,7 +228,7 @@ Achievement NFTs are distinct from track credentials — each is a separate Meta
 | Account | Size | Rent | Closeable |
 |---------|------|------|-----------|
 | Config | 113 B | ~0.001 SOL | No |
-| Course | 192 B | ~0.002 SOL | No |
+| Course | 224 B | ~0.003 SOL | No |
 | Enrollment | 127 B | ~0.001 SOL | Yes — reclaimed on close |
 | MinterRole | 110 B | ~0.001 SOL | Yes (via revoke_minter) |
 | AchievementType | 338 B | ~0.003 SOL | No |

--- a/onchain-academy/programs/onchain-academy/src/errors.rs
+++ b/onchain-academy/programs/onchain-academy/src/errors.rs
@@ -56,4 +56,8 @@ pub enum AcademyError {
     InvalidAmount,
     #[msg("XP reward must be greater than zero")]
     InvalidXpReward,
+    #[msg("Credential is not owned by the learner")]
+    InvalidCredentialOwner,
+    #[msg("Credential does not belong to the track collection")]
+    TrackCollectionMismatch,
 }

--- a/onchain-academy/programs/onchain-academy/src/instructions/create_course.rs
+++ b/onchain-academy/programs/onchain-academy/src/instructions/create_course.rs
@@ -14,6 +14,7 @@ pub struct CreateCourseParams {
     pub xp_per_lesson: u32,
     pub track_id: u16,
     pub track_level: u8,
+    pub track_collection: Pubkey,
     pub prerequisite: Option<Pubkey>,
     pub creator_reward_xp: u32,
     pub min_completions_for_reward: u16,
@@ -43,6 +44,7 @@ pub fn handler(ctx: Context<CreateCourse>, params: CreateCourseParams) -> Result
     course.xp_per_lesson = params.xp_per_lesson;
     course.track_id = params.track_id;
     course.track_level = params.track_level;
+    course.track_collection = params.track_collection;
     course.prerequisite = params.prerequisite;
     course.creator_reward_xp = params.creator_reward_xp;
     course.min_completions_for_reward = params.min_completions_for_reward;

--- a/onchain-academy/programs/onchain-academy/src/instructions/enroll.rs
+++ b/onchain-academy/programs/onchain-academy/src/instructions/enroll.rs
@@ -1,4 +1,6 @@
 use anchor_lang::prelude::*;
+use mpl_core::accounts::BaseAssetV1;
+use mpl_core::types::UpdateAuthority;
 
 use crate::errors::AcademyError;
 use crate::events::Enrolled;
@@ -16,54 +18,42 @@ pub fn handler<'info>(
 
     // Prerequisite check via remaining accounts:
     //   remaining_accounts[0] = prerequisite Course PDA
-    //   remaining_accounts[1] = prerequisite Enrollment PDA (must belong to this learner)
+    //   remaining_accounts[1] = credential NFT (Metaplex Core asset proving completion)
     if let Some(prerequisite_course) = course.prerequisite {
         let remaining = ctx.remaining_accounts;
         require!(remaining.len() >= 2, AcademyError::PrerequisiteNotMet);
 
         let prereq_course_info = &remaining[0];
-        let prereq_enrollment_info = &remaining[1];
+        let credential_info = &remaining[1];
 
         require!(
             prereq_course_info.owner == ctx.program_id,
             AcademyError::PrerequisiteNotMet
         );
         require!(
-            prereq_enrollment_info.owner == ctx.program_id,
-            AcademyError::PrerequisiteNotMet
-        );
-
-        // Verify the prerequisite course account matches
-        require!(
             prereq_course_info.key() == prerequisite_course,
             AcademyError::PrerequisiteNotMet
         );
+
         let prereq_course = Account::<Course>::try_from(prereq_course_info)
             .map_err(|_| AcademyError::PrerequisiteNotMet)?;
 
-        let prereq_enrollment = Account::<Enrollment>::try_from(prereq_enrollment_info)
-            .map_err(|_| AcademyError::PrerequisiteNotMet)?;
-
+        // Verify credential is a Metaplex Core asset
         require!(
-            prereq_enrollment.course == prerequisite_course,
-            AcademyError::PrerequisiteNotMet
-        );
-        require!(
-            prereq_enrollment.completed_at.is_some(),
+            credential_info.owner == &mpl_core::ID,
             AcademyError::PrerequisiteNotMet
         );
 
-        // Verify the enrollment PDA belongs to this learner via seed derivation
-        let (expected_pda, _) = Pubkey::find_program_address(
-            &[
-                b"enrollment",
-                prereq_course.course_id.as_bytes(),
-                ctx.accounts.learner.key().as_ref(),
-            ],
-            ctx.program_id,
+        // Deserialize credential and verify ownership + collection
+        let asset =
+            BaseAssetV1::try_from(credential_info).map_err(|_| AcademyError::PrerequisiteNotMet)?;
+
+        require!(
+            asset.owner == ctx.accounts.learner.key(),
+            AcademyError::PrerequisiteNotMet
         );
         require!(
-            prereq_enrollment_info.key() == expected_pda,
+            asset.update_authority == UpdateAuthority::Collection(prereq_course.track_collection),
             AcademyError::PrerequisiteNotMet
         );
     }

--- a/onchain-academy/programs/onchain-academy/src/instructions/issue_credential.rs
+++ b/onchain-academy/programs/onchain-academy/src/instructions/issue_credential.rs
@@ -119,8 +119,11 @@ pub struct IssueCredential<'info> {
     #[account(mut)]
     pub credential_asset: Signer<'info>,
 
-    /// CHECK: Metaplex Core collection for this track. Validated by Metaplex Core CPI.
-    #[account(mut)]
+    /// CHECK: Metaplex Core collection for this track.
+    #[account(
+        mut,
+        constraint = track_collection.key() == course.track_collection @ AcademyError::TrackCollectionMismatch,
+    )]
     pub track_collection: AccountInfo<'info>,
 
     #[account(mut)]

--- a/onchain-academy/programs/onchain-academy/src/instructions/upgrade_credential.rs
+++ b/onchain-academy/programs/onchain-academy/src/instructions/upgrade_credential.rs
@@ -1,7 +1,9 @@
 use anchor_lang::prelude::*;
 use mpl_core::{
+    accounts::BaseAssetV1,
+    fetch_asset_plugin,
     instructions::{UpdatePluginV1CpiBuilder, UpdateV1CpiBuilder},
-    types::{Attribute, Attributes, Plugin},
+    types::{Attribute, Attributes, Plugin, PluginType, UpdateAuthority},
 };
 
 use crate::errors::AcademyError;
@@ -24,14 +26,33 @@ pub fn handler(
         AcademyError::CourseNotFinalized
     );
 
-    let existing_asset = enrollment
-        .credential_asset
-        .ok_or(AcademyError::CourseNotFinalized)?;
+    // Bug 2 fix: verify credential on-chain instead of via enrollment.credential_asset
+    let asset = BaseAssetV1::try_from(&ctx.accounts.credential_asset)
+        .map_err(|_| AcademyError::CredentialAssetMismatch)?;
 
     require!(
-        ctx.accounts.credential_asset.key() == existing_asset,
-        AcademyError::CredentialAssetMismatch
+        asset.owner == ctx.accounts.learner.key(),
+        AcademyError::InvalidCredentialOwner
     );
+    require!(
+        asset.update_authority == UpdateAuthority::Collection(ctx.accounts.track_collection.key()),
+        AcademyError::TrackCollectionMismatch
+    );
+
+    // Bug 3 fix: read current credential level, only allow upgrades (never downgrade)
+    let current_level: u8 =
+        fetch_asset_plugin::<Attributes>(&ctx.accounts.credential_asset, PluginType::Attributes)
+            .ok()
+            .and_then(|(_, attrs, _)| {
+                attrs
+                    .attribute_list
+                    .iter()
+                    .find(|a| a.key == "level")
+                    .and_then(|a| a.value.parse::<u8>().ok())
+            })
+            .unwrap_or(0);
+
+    let effective_level = std::cmp::max(current_level, course.track_level);
 
     let config_bump = config.bump;
     let config_seeds: &[&[u8]] = &[b"config", &[config_bump]];
@@ -61,7 +82,7 @@ pub fn handler(
                 },
                 Attribute {
                     key: "level".into(),
-                    value: course.track_level.to_string(),
+                    value: effective_level.to_string(),
                 },
                 Attribute {
                     key: "courses_completed".into(),
@@ -75,11 +96,15 @@ pub fn handler(
         }))
         .invoke_signed(signer_seeds)?;
 
+    // Propagate credential_asset to this enrollment
+    let enrollment_mut = &mut ctx.accounts.enrollment;
+    enrollment_mut.credential_asset = Some(ctx.accounts.credential_asset.key());
+
     emit!(CredentialUpgraded {
         learner: ctx.accounts.learner.key(),
         track_id: course.track_id,
         credential_asset: ctx.accounts.credential_asset.key(),
-        current_level: course.track_level,
+        current_level: effective_level,
         timestamp: Clock::get()?.unix_timestamp,
     });
 
@@ -101,6 +126,7 @@ pub struct UpgradeCredential<'info> {
     pub course: Account<'info, Course>,
 
     #[account(
+        mut,
         seeds = [b"enrollment", course.course_id.as_bytes(), learner.key().as_ref()],
         bump = enrollment.bump,
         constraint = enrollment.course == course.key() @ AcademyError::EnrollmentCourseMismatch,
@@ -110,13 +136,16 @@ pub struct UpgradeCredential<'info> {
     /// CHECK: Tied to enrollment PDA via seeds constraint.
     pub learner: AccountInfo<'info>,
 
-    /// Existing credential NFT asset — not a signer, validated against enrollment record.
-    /// CHECK: Validated against enrollment.credential_asset.
+    /// Existing credential NFT asset — validated on-chain via BaseAssetV1 deserialization.
+    /// CHECK: Validated against learner ownership and track collection membership.
     #[account(mut)]
     pub credential_asset: AccountInfo<'info>,
 
-    /// CHECK: Metaplex Core collection for this track. Validated by Metaplex Core CPI.
-    #[account(mut)]
+    /// CHECK: Metaplex Core collection for this track.
+    #[account(
+        mut,
+        constraint = track_collection.key() == course.track_collection @ AcademyError::TrackCollectionMismatch,
+    )]
     pub track_collection: AccountInfo<'info>,
 
     #[account(mut)]

--- a/onchain-academy/programs/onchain-academy/src/state/course.rs
+++ b/onchain-academy/programs/onchain-academy/src/state/course.rs
@@ -14,6 +14,7 @@ pub struct Course {
     pub xp_per_lesson: u32,
     pub track_id: u16,
     pub track_level: u8,
+    pub track_collection: Pubkey,
     pub prerequisite: Option<Pubkey>,
     pub creator_reward_xp: u32,
     pub min_completions_for_reward: u16,
@@ -37,6 +38,7 @@ impl Course {
     // + 4 (xp_per_lesson)
     // + 2 (track_id)
     // + 1 (track_level)
+    // + 32 (track_collection)
     // + (1 + 32) (prerequisite)
     // + 4 (creator_reward_xp)
     // + 2 (min_completions_for_reward)
@@ -57,6 +59,7 @@ impl Course {
         + 4
         + 2
         + 1
+        + 32
         + (1 + 32)
         + 4
         + 2
@@ -66,5 +69,5 @@ impl Course {
         + 8
         + 8
         + 8
-        + 1; // 192
+        + 1; // 224
 }

--- a/onchain-academy/tests/onchain-academy.ts
+++ b/onchain-academy/tests/onchain-academy.ts
@@ -277,6 +277,7 @@ describe("onchain-academy", () => {
           xpPerLesson: XP_PER_LESSON,
           trackId: 1,
           trackLevel: 1,
+          trackCollection: Keypair.generate().publicKey,
           prerequisite: null,
           creatorRewardXp: CREATOR_REWARD_XP,
           minCompletionsForReward: MIN_COMPLETIONS_FOR_REWARD,
@@ -331,6 +332,7 @@ describe("onchain-academy", () => {
             xpPerLesson: 10,
             trackId: 1,
             trackLevel: 1,
+            trackCollection: Keypair.generate().publicKey,
             prerequisite: null,
             creatorRewardXp: 0,
             minCompletionsForReward: 0,
@@ -371,6 +373,7 @@ describe("onchain-academy", () => {
             xpPerLesson: 10,
             trackId: 1,
             trackLevel: 1,
+            trackCollection: Keypair.generate().publicKey,
             prerequisite: null,
             creatorRewardXp: 0,
             minCompletionsForReward: 0,
@@ -411,6 +414,7 @@ describe("onchain-academy", () => {
             xpPerLesson: 10,
             trackId: 1,
             trackLevel: 1,
+            trackCollection: Keypair.generate().publicKey,
             prerequisite: null,
             creatorRewardXp: 0,
             minCompletionsForReward: 0,
@@ -450,6 +454,7 @@ describe("onchain-academy", () => {
             xpPerLesson: 10,
             trackId: 1,
             trackLevel: 1,
+            trackCollection: Keypair.generate().publicKey,
             prerequisite: null,
             creatorRewardXp: 0,
             minCompletionsForReward: 0,
@@ -489,6 +494,7 @@ describe("onchain-academy", () => {
             xpPerLesson: 10,
             trackId: 1,
             trackLevel: 1,
+            trackCollection: Keypair.generate().publicKey,
             prerequisite: null,
             creatorRewardXp: 0,
             minCompletionsForReward: 0,
@@ -527,6 +533,7 @@ describe("onchain-academy", () => {
           xpPerLesson: 10,
           trackId: 1,
           trackLevel: 1,
+          trackCollection: Keypair.generate().publicKey,
           prerequisite: null,
           creatorRewardXp: 0,
           minCompletionsForReward: 0,
@@ -562,6 +569,7 @@ describe("onchain-academy", () => {
             xpPerLesson: 10,
             trackId: 10,
             trackLevel: difficulty,
+            trackCollection: Keypair.generate().publicKey,
             prerequisite: null,
             creatorRewardXp: 0,
             minCompletionsForReward: 0,
@@ -1115,6 +1123,7 @@ describe("onchain-academy", () => {
           xpPerLesson: 10,
           trackId: 2,
           trackLevel: 1,
+          trackCollection: Keypair.generate().publicKey,
           prerequisite: null,
           creatorRewardXp: 10,
           minCompletionsForReward: 1,
@@ -1236,6 +1245,7 @@ describe("onchain-academy", () => {
           xpPerLesson: 10,
           trackId: 3,
           trackLevel: 1,
+          trackCollection: Keypair.generate().publicKey,
           prerequisite: null,
           creatorRewardXp: 0,
           minCompletionsForReward: 0,
@@ -1487,6 +1497,7 @@ describe("onchain-academy", () => {
           xpPerLesson: 10,
           trackId: 5,
           trackLevel: 1,
+          trackCollection: Keypair.generate().publicKey,
           prerequisite: null,
           creatorRewardXp: 0,
           minCompletionsForReward: 0,
@@ -1616,6 +1627,7 @@ describe("onchain-academy", () => {
           xpPerLesson: 50,
           trackId: 7,
           trackLevel: 1,
+          trackCollection: Keypair.generate().publicKey,
           prerequisite: null,
           creatorRewardXp: 100,
           minCompletionsForReward: 10,
@@ -1750,24 +1762,78 @@ describe("onchain-academy", () => {
   // 12. Prerequisite enforcement
   // ===========================================================================
   describe("12. Prerequisite enforcement", () => {
+    const MPL_CORE_PROGRAM_ID = new PublicKey(
+      "CoREENxT6tW1HoK8ypY1SxRMZTcVPm7R94rH4PZNhX7d"
+    );
+
+    const prereqCourseId = "prereq-base";
+    let prereqCoursePda: PublicKey;
     const advancedId = "advanced-course";
     let advancedCoursePda: PublicKey;
     const prereqLearner = Keypair.generate();
     let prereqLearnerTokenAccount: PublicKey;
+    let prereqCollectionAddress: PublicKey;
+    let prereqCredentialKeypair: Keypair;
 
     before(async () => {
       const sig = await provider.connection.requestAirdrop(
         prereqLearner.publicKey,
-        5 * LAMPORTS_PER_SOL
+        10 * LAMPORTS_PER_SOL
       );
       await provider.connection.confirmTransaction(sig, "confirmed");
 
+      // Create a real Metaplex Core collection for the prerequisite track
+      const umi = createUmi("http://127.0.0.1:8899").use(mplCore());
+      const umiAuthority = umi.eddsa.createKeypairFromSecretKey(
+        authority.payer.secretKey
+      );
+      umi.use(signerIdentity(umiCreateSignerFromKeypair(umi, umiAuthority)));
+
+      const collectionSigner = generateSigner(umi);
+      await createCollectionV2(umi, {
+        collection: collectionSigner,
+        name: "Prereq Track Credentials",
+        uri: "https://arweave.net/prereq-collection",
+        updateAuthority: fromWeb3JsPublicKey(configPda),
+      }).sendAndConfirm(umi);
+
+      prereqCollectionAddress = toWeb3JsPublicKey(collectionSigner.publicKey);
+
+      // Create prerequisite base course with real collection
+      [prereqCoursePda] = PublicKey.findProgramAddressSync(
+        [Buffer.from("course"), Buffer.from(prereqCourseId)],
+        program.programId
+      );
+
+      await program.methods
+        .createCourse({
+          courseId: prereqCourseId,
+          creator: creator.publicKey,
+          contentTxId: contentTxId,
+          lessonCount: 1,
+          difficulty: 1,
+          xpPerLesson: 100,
+          trackId: 10,
+          trackLevel: 1,
+          trackCollection: prereqCollectionAddress,
+          prerequisite: null,
+          creatorRewardXp: 0,
+          minCompletionsForReward: 0,
+        })
+        .accountsPartial({
+          course: prereqCoursePda,
+          config: configPda,
+          authority: authority.publicKey,
+          systemProgram: SystemProgram.programId,
+        })
+        .rpc();
+
+      // Create advanced course that requires prereq-base
       [advancedCoursePda] = PublicKey.findProgramAddressSync(
         [Buffer.from("course"), Buffer.from(advancedId)],
         program.programId
       );
 
-      // Create advanced course that requires solana-101 completion
       await program.methods
         .createCourse({
           courseId: advancedId,
@@ -1776,9 +1842,10 @@ describe("onchain-academy", () => {
           lessonCount: 1,
           difficulty: 3,
           xpPerLesson: 200,
-          trackId: 1,
+          trackId: 10,
           trackLevel: 2,
-          prerequisite: coursePda, // requires solana-101
+          trackCollection: prereqCollectionAddress,
+          prerequisite: prereqCoursePda,
           creatorRewardXp: 0,
           minCompletionsForReward: 0,
         })
@@ -1810,7 +1877,7 @@ describe("onchain-academy", () => {
       await provider.sendAndConfirm(tx);
     });
 
-    it("enroll in prerequisite course fails without completed enrollment", async () => {
+    it("enroll fails without remaining accounts for prerequisite", async () => {
       const [advEnrollPda] = PublicKey.findProgramAddressSync(
         [
           Buffer.from("enrollment"),
@@ -1820,7 +1887,6 @@ describe("onchain-academy", () => {
         program.programId
       );
 
-      // Try to enroll without providing any remaining accounts
       try {
         await program.methods
           .enroll(advancedId)
@@ -1842,28 +1908,7 @@ describe("onchain-academy", () => {
       }
     });
 
-    it("enroll with incomplete prerequisite enrollment fails", async () => {
-      // Enroll prereqLearner in solana-101 but do NOT complete it
-      const [prereqEnrollPda] = PublicKey.findProgramAddressSync(
-        [
-          Buffer.from("enrollment"),
-          Buffer.from(courseId),
-          prereqLearner.publicKey.toBuffer(),
-        ],
-        program.programId
-      );
-
-      await program.methods
-        .enroll(courseId)
-        .accountsPartial({
-          course: coursePda,
-          enrollment: prereqEnrollPda,
-          learner: prereqLearner.publicKey,
-          systemProgram: SystemProgram.programId,
-        })
-        .signers([prereqLearner])
-        .rpc();
-
+    it("enroll fails with non-Metaplex-Core account as credential", async () => {
       const [advEnrollPda] = PublicKey.findProgramAddressSync(
         [
           Buffer.from("enrollment"),
@@ -1873,7 +1918,28 @@ describe("onchain-academy", () => {
         program.programId
       );
 
-      // Pass the incomplete enrollment as remaining account
+      // Pass a program-owned enrollment PDA (not a Metaplex Core asset)
+      const [fakeEnrollPda] = PublicKey.findProgramAddressSync(
+        [
+          Buffer.from("enrollment"),
+          Buffer.from(prereqCourseId),
+          prereqLearner.publicKey.toBuffer(),
+        ],
+        program.programId
+      );
+
+      // First enroll in prereq course so the enrollment exists
+      await program.methods
+        .enroll(prereqCourseId)
+        .accountsPartial({
+          course: prereqCoursePda,
+          enrollment: fakeEnrollPda,
+          learner: prereqLearner.publicKey,
+          systemProgram: SystemProgram.programId,
+        })
+        .signers([prereqLearner])
+        .rpc();
+
       try {
         await program.methods
           .enroll(advancedId)
@@ -1885,12 +1951,12 @@ describe("onchain-academy", () => {
           })
           .remainingAccounts([
             {
-              pubkey: coursePda,
+              pubkey: prereqCoursePda,
               isWritable: false,
               isSigner: false,
             },
             {
-              pubkey: prereqEnrollPda,
+              pubkey: fakeEnrollPda,
               isWritable: false,
               isSigner: false,
             },
@@ -1907,38 +1973,38 @@ describe("onchain-academy", () => {
       }
     });
 
-    it("enroll with completed prerequisite succeeds", async () => {
-      // Complete all lessons + finalize for prereqLearner on solana-101
+    it("enroll with credential NFT succeeds", async () => {
+      // Complete the prereq course + finalize + issue credential
       const [prereqEnrollPda] = PublicKey.findProgramAddressSync(
         [
           Buffer.from("enrollment"),
-          Buffer.from(courseId),
+          Buffer.from(prereqCourseId),
           prereqLearner.publicKey.toBuffer(),
         ],
         program.programId
       );
 
-      for (let i = 0; i < LESSON_COUNT; i++) {
-        await program.methods
-          .completeLesson(i)
-          .accountsPartial({
-            config: configPda,
-            course: coursePda,
-            enrollment: prereqEnrollPda,
-            learner: prereqLearner.publicKey,
-            learnerTokenAccount: prereqLearnerTokenAccount,
-            xpMint: xpMintKeypair.publicKey,
-            backendSigner: authority.publicKey,
-            tokenProgram: TOKEN_2022_PROGRAM_ID,
-          })
-          .rpc();
-      }
+      // Complete the single lesson
+      await program.methods
+        .completeLesson(0)
+        .accountsPartial({
+          config: configPda,
+          course: prereqCoursePda,
+          enrollment: prereqEnrollPda,
+          learner: prereqLearner.publicKey,
+          learnerTokenAccount: prereqLearnerTokenAccount,
+          xpMint: xpMintKeypair.publicKey,
+          backendSigner: authority.publicKey,
+          tokenProgram: TOKEN_2022_PROGRAM_ID,
+        })
+        .rpc();
 
+      // Finalize
       await program.methods
         .finalizeCourse()
         .accountsPartial({
           config: configPda,
-          course: coursePda,
+          course: prereqCoursePda,
           enrollment: prereqEnrollPda,
           learner: prereqLearner.publicKey,
           learnerTokenAccount: prereqLearnerTokenAccount,
@@ -1950,7 +2016,26 @@ describe("onchain-academy", () => {
         })
         .rpc();
 
-      // Now enroll in advanced course with completed prereq
+      // Issue credential NFT
+      prereqCredentialKeypair = Keypair.generate();
+      await program.methods
+        .issueCredential("Prereq Track - Level 1", "https://arweave.net/prereq-cred", 1, new anchor.BN(100))
+        .accountsPartial({
+          config: configPda,
+          course: prereqCoursePda,
+          enrollment: prereqEnrollPda,
+          learner: prereqLearner.publicKey,
+          credentialAsset: prereqCredentialKeypair.publicKey,
+          trackCollection: prereqCollectionAddress,
+          payer: authority.publicKey,
+          backendSigner: authority.publicKey,
+          mplCoreProgram: MPL_CORE_PROGRAM_ID,
+          systemProgram: SystemProgram.programId,
+        })
+        .signers([prereqCredentialKeypair])
+        .rpc();
+
+      // Now enroll in advanced course with credential NFT as proof
       const [advEnrollPda] = PublicKey.findProgramAddressSync(
         [
           Buffer.from("enrollment"),
@@ -1970,12 +2055,12 @@ describe("onchain-academy", () => {
         })
         .remainingAccounts([
           {
-            pubkey: coursePda,
+            pubkey: prereqCoursePda,
             isWritable: false,
             isSigner: false,
           },
           {
-            pubkey: prereqEnrollPda,
+            pubkey: prereqCredentialKeypair.publicKey,
             isWritable: false,
             isSigner: false,
           },
@@ -1987,6 +2072,287 @@ describe("onchain-academy", () => {
       expect(enrollment.course.toBase58()).to.equal(
         advancedCoursePda.toBase58()
       );
+    });
+
+    it("prerequisite succeeds after close_enrollment (rent reclaim)", async () => {
+      // Close the prereq enrollment — reclaim rent (completed enrollments skip cooldown)
+      const [prereqEnrollPda] = PublicKey.findProgramAddressSync(
+        [
+          Buffer.from("enrollment"),
+          Buffer.from(prereqCourseId),
+          prereqLearner.publicKey.toBuffer(),
+        ],
+        program.programId
+      );
+
+      await program.methods
+        .closeEnrollment()
+        .accountsPartial({
+          course: prereqCoursePda,
+          enrollment: prereqEnrollPda,
+          learner: prereqLearner.publicKey,
+        })
+        .signers([prereqLearner])
+        .rpc();
+
+      // Verify prereq enrollment is gone
+      const closedAccount = await provider.connection.getAccountInfo(prereqEnrollPda);
+      expect(closedAccount).to.be.null;
+
+      // Create a second advanced course that also requires prereq-base
+      const advancedId2 = "advanced-course-2";
+      const [advancedCourse2Pda] = PublicKey.findProgramAddressSync(
+        [Buffer.from("course"), Buffer.from(advancedId2)],
+        program.programId
+      );
+
+      await program.methods
+        .createCourse({
+          courseId: advancedId2,
+          creator: creator.publicKey,
+          contentTxId: contentTxId,
+          lessonCount: 1,
+          difficulty: 3,
+          xpPerLesson: 200,
+          trackId: 10,
+          trackLevel: 3,
+          trackCollection: prereqCollectionAddress,
+          prerequisite: prereqCoursePda,
+          creatorRewardXp: 0,
+          minCompletionsForReward: 0,
+        })
+        .accountsPartial({
+          course: advancedCourse2Pda,
+          config: configPda,
+          authority: authority.publicKey,
+          systemProgram: SystemProgram.programId,
+        })
+        .rpc();
+
+      // Enroll in advanced-course-2 — prereq enrollment is deleted but credential NFT still exists
+      const [advEnroll2Pda] = PublicKey.findProgramAddressSync(
+        [
+          Buffer.from("enrollment"),
+          Buffer.from(advancedId2),
+          prereqLearner.publicKey.toBuffer(),
+        ],
+        program.programId
+      );
+
+      await program.methods
+        .enroll(advancedId2)
+        .accountsPartial({
+          course: advancedCourse2Pda,
+          enrollment: advEnroll2Pda,
+          learner: prereqLearner.publicKey,
+          systemProgram: SystemProgram.programId,
+        })
+        .remainingAccounts([
+          {
+            pubkey: prereqCoursePda,
+            isWritable: false,
+            isSigner: false,
+          },
+          {
+            pubkey: prereqCredentialKeypair.publicKey,
+            isWritable: false,
+            isSigner: false,
+          },
+        ])
+        .signers([prereqLearner])
+        .rpc();
+
+      const enrollment = await program.account.enrollment.fetch(advEnroll2Pda);
+      expect(enrollment.course.toBase58()).to.equal(
+        advancedCourse2Pda.toBase58()
+      );
+    });
+
+    it("prerequisite fails with credential from wrong track", async () => {
+      // Create a different track collection
+      const umi = createUmi("http://127.0.0.1:8899").use(mplCore());
+      const umiAuthority = umi.eddsa.createKeypairFromSecretKey(
+        authority.payer.secretKey
+      );
+      umi.use(signerIdentity(umiCreateSignerFromKeypair(umi, umiAuthority)));
+
+      const wrongCollectionSigner = generateSigner(umi);
+      await createCollectionV2(umi, {
+        collection: wrongCollectionSigner,
+        name: "Wrong Track",
+        uri: "https://arweave.net/wrong-track",
+        updateAuthority: fromWeb3JsPublicKey(configPda),
+      }).sendAndConfirm(umi);
+
+      const wrongTrackCollection = toWeb3JsPublicKey(wrongCollectionSigner.publicKey);
+
+      // Create a course in the wrong track and complete it
+      const wrongTrackCourseId = "wrong-track-course";
+      const [wrongTrackCoursePda] = PublicKey.findProgramAddressSync(
+        [Buffer.from("course"), Buffer.from(wrongTrackCourseId)],
+        program.programId
+      );
+
+      await program.methods
+        .createCourse({
+          courseId: wrongTrackCourseId,
+          creator: creator.publicKey,
+          contentTxId: contentTxId,
+          lessonCount: 1,
+          difficulty: 1,
+          xpPerLesson: 10,
+          trackId: 99,
+          trackLevel: 1,
+          trackCollection: wrongTrackCollection,
+          prerequisite: null,
+          creatorRewardXp: 0,
+          minCompletionsForReward: 0,
+        })
+        .accountsPartial({
+          course: wrongTrackCoursePda,
+          config: configPda,
+          authority: authority.publicKey,
+          systemProgram: SystemProgram.programId,
+        })
+        .rpc();
+
+      const wrongLearner = Keypair.generate();
+      const airdropSig = await provider.connection.requestAirdrop(
+        wrongLearner.publicKey,
+        5 * LAMPORTS_PER_SOL
+      );
+      await provider.connection.confirmTransaction(airdropSig, "confirmed");
+
+      // Create ATA for wrong learner
+      const wrongLearnerTokenAccount = getAssociatedTokenAddressSync(
+        xpMintKeypair.publicKey,
+        wrongLearner.publicKey,
+        false,
+        TOKEN_2022_PROGRAM_ID,
+        ASSOCIATED_TOKEN_PROGRAM_ID
+      );
+      const createAtaIx2 = createAssociatedTokenAccountInstruction(
+        authority.publicKey,
+        wrongLearnerTokenAccount,
+        wrongLearner.publicKey,
+        xpMintKeypair.publicKey,
+        TOKEN_2022_PROGRAM_ID,
+        ASSOCIATED_TOKEN_PROGRAM_ID
+      );
+      await provider.sendAndConfirm(new anchor.web3.Transaction().add(createAtaIx2));
+
+      // Enroll, complete, finalize in wrong track
+      const [wrongEnrollPda] = PublicKey.findProgramAddressSync(
+        [
+          Buffer.from("enrollment"),
+          Buffer.from(wrongTrackCourseId),
+          wrongLearner.publicKey.toBuffer(),
+        ],
+        program.programId
+      );
+
+      await program.methods
+        .enroll(wrongTrackCourseId)
+        .accountsPartial({
+          course: wrongTrackCoursePda,
+          enrollment: wrongEnrollPda,
+          learner: wrongLearner.publicKey,
+          systemProgram: SystemProgram.programId,
+        })
+        .signers([wrongLearner])
+        .rpc();
+
+      await program.methods
+        .completeLesson(0)
+        .accountsPartial({
+          config: configPda,
+          course: wrongTrackCoursePda,
+          enrollment: wrongEnrollPda,
+          learner: wrongLearner.publicKey,
+          learnerTokenAccount: wrongLearnerTokenAccount,
+          xpMint: xpMintKeypair.publicKey,
+          backendSigner: authority.publicKey,
+          tokenProgram: TOKEN_2022_PROGRAM_ID,
+        })
+        .rpc();
+
+      await program.methods
+        .finalizeCourse()
+        .accountsPartial({
+          config: configPda,
+          course: wrongTrackCoursePda,
+          enrollment: wrongEnrollPda,
+          learner: wrongLearner.publicKey,
+          learnerTokenAccount: wrongLearnerTokenAccount,
+          creatorTokenAccount: creatorTokenAccount,
+          creator: creator.publicKey,
+          xpMint: xpMintKeypair.publicKey,
+          backendSigner: authority.publicKey,
+          tokenProgram: TOKEN_2022_PROGRAM_ID,
+        })
+        .rpc();
+
+      // Issue credential in wrong track
+      const wrongCredKeypair = Keypair.generate();
+      await program.methods
+        .issueCredential("Wrong Track Cred", "https://arweave.net/wrong-cred", 1, new anchor.BN(10))
+        .accountsPartial({
+          config: configPda,
+          course: wrongTrackCoursePda,
+          enrollment: wrongEnrollPda,
+          learner: wrongLearner.publicKey,
+          credentialAsset: wrongCredKeypair.publicKey,
+          trackCollection: wrongTrackCollection,
+          payer: authority.publicKey,
+          backendSigner: authority.publicKey,
+          mplCoreProgram: MPL_CORE_PROGRAM_ID,
+          systemProgram: SystemProgram.programId,
+        })
+        .signers([wrongCredKeypair])
+        .rpc();
+
+      // Now try to enroll this learner in advanced course (requires prereq track 10)
+      // but pass the wrong-track credential (track 99)
+      const [advEnrollPda2] = PublicKey.findProgramAddressSync(
+        [
+          Buffer.from("enrollment"),
+          Buffer.from(advancedId),
+          wrongLearner.publicKey.toBuffer(),
+        ],
+        program.programId
+      );
+
+      try {
+        await program.methods
+          .enroll(advancedId)
+          .accountsPartial({
+            course: advancedCoursePda,
+            enrollment: advEnrollPda2,
+            learner: wrongLearner.publicKey,
+            systemProgram: SystemProgram.programId,
+          })
+          .remainingAccounts([
+            {
+              pubkey: prereqCoursePda,
+              isWritable: false,
+              isSigner: false,
+            },
+            {
+              pubkey: wrongCredKeypair.publicKey,
+              isWritable: false,
+              isSigner: false,
+            },
+          ])
+          .signers([wrongLearner])
+          .rpc();
+        expect.fail("Should have thrown");
+      } catch (err) {
+        if (err instanceof AnchorError) {
+          expect(err.error.errorCode.code).to.equal("PrerequisiteNotMet");
+        } else {
+          expect(err.toString()).to.contain("PrerequisiteNotMet");
+        }
+      }
     });
   });
 
@@ -2048,6 +2414,7 @@ describe("onchain-academy", () => {
           xpPerLesson: 50,
           trackId: 1,
           trackLevel: 1,
+          trackCollection: collectionAddress,
           prerequisite: null,
           creatorRewardXp: 0,
           minCompletionsForReward: 0,
@@ -2354,6 +2721,248 @@ describe("onchain-academy", () => {
         }
       }
     });
+
+    it("upgrade_credential succeeds from second course in same track (Bug 2 regression)", async () => {
+      // Create a second course in the same track
+      const credCourse2Id = "cred-test-course-2";
+      const [credCourse2Pda] = PublicKey.findProgramAddressSync(
+        [Buffer.from("course"), Buffer.from(credCourse2Id)],
+        program.programId
+      );
+
+      await program.methods
+        .createCourse({
+          courseId: credCourse2Id,
+          creator: creator.publicKey,
+          contentTxId: contentTxId,
+          lessonCount: 1,
+          difficulty: 2,
+          xpPerLesson: 100,
+          trackId: 1,
+          trackLevel: 2,
+          trackCollection: collectionAddress,
+          prerequisite: null,
+          creatorRewardXp: 0,
+          minCompletionsForReward: 0,
+        })
+        .accountsPartial({
+          course: credCourse2Pda,
+          config: configPda,
+          authority: authority.publicKey,
+          systemProgram: SystemProgram.programId,
+        })
+        .rpc();
+
+      // Enroll credLearner in course 2
+      const [credEnroll2Pda] = PublicKey.findProgramAddressSync(
+        [
+          Buffer.from("enrollment"),
+          Buffer.from(credCourse2Id),
+          credLearner.publicKey.toBuffer(),
+        ],
+        program.programId
+      );
+
+      await program.methods
+        .enroll(credCourse2Id)
+        .accountsPartial({
+          course: credCourse2Pda,
+          enrollment: credEnroll2Pda,
+          learner: credLearner.publicKey,
+          systemProgram: SystemProgram.programId,
+        })
+        .signers([credLearner])
+        .rpc();
+
+      // Complete + finalize course 2
+      await program.methods
+        .completeLesson(0)
+        .accountsPartial({
+          config: configPda,
+          course: credCourse2Pda,
+          enrollment: credEnroll2Pda,
+          learner: credLearner.publicKey,
+          learnerTokenAccount: credLearnerTokenAccount,
+          xpMint: xpMintKeypair.publicKey,
+          backendSigner: authority.publicKey,
+          tokenProgram: TOKEN_2022_PROGRAM_ID,
+        })
+        .rpc();
+
+      await program.methods
+        .finalizeCourse()
+        .accountsPartial({
+          config: configPda,
+          course: credCourse2Pda,
+          enrollment: credEnroll2Pda,
+          learner: credLearner.publicKey,
+          learnerTokenAccount: credLearnerTokenAccount,
+          creatorTokenAccount: creatorTokenAccount,
+          creator: creator.publicKey,
+          xpMint: xpMintKeypair.publicKey,
+          backendSigner: authority.publicKey,
+          tokenProgram: TOKEN_2022_PROGRAM_ID,
+        })
+        .rpc();
+
+      // Upgrade credential via course 2 enrollment — course 2's enrollment has credential_asset = None
+      // Before the fix this would fail with CourseNotFinalized
+      const enrollment2Before = await program.account.enrollment.fetch(credEnroll2Pda);
+      expect(enrollment2Before.credentialAsset).to.be.null;
+
+      const sig = await program.methods
+        .upgradeCredential("Track 1 - Level 2", "https://arweave.net/cred-v3", 3, new anchor.BN(1500))
+        .accountsPartial({
+          config: configPda,
+          course: credCourse2Pda,
+          enrollment: credEnroll2Pda,
+          learner: credLearner.publicKey,
+          credentialAsset: credentialKeypair.publicKey,
+          trackCollection: collectionAddress,
+          payer: authority.publicKey,
+          backendSigner: authority.publicKey,
+          mplCoreProgram: MPL_CORE_PROGRAM_ID,
+          systemProgram: SystemProgram.programId,
+        })
+        .rpc();
+      await provider.connection.confirmTransaction(sig, "confirmed");
+
+      // Verify credential was updated
+      const umi = createUmi(provider.connection.rpcEndpoint, { commitment: "confirmed" }).use(mplCore());
+      const asset = await fetchAssetV1(
+        umi,
+        fromWeb3JsPublicKey(credentialKeypair.publicKey)
+      );
+      expect(asset.name).to.equal("Track 1 - Level 2");
+
+      // Verify level was upgraded to 2
+      const levelAttr = asset.attributes.attributeList.find((a) => a.key === "level");
+      expect(levelAttr.value).to.equal("2");
+
+      // Verify credential_asset was propagated to course 2's enrollment
+      const enrollment2After = await program.account.enrollment.fetch(credEnroll2Pda);
+      expect(enrollment2After.credentialAsset).to.not.be.null;
+      expect(enrollment2After.credentialAsset.toBase58()).to.equal(
+        credentialKeypair.publicKey.toBase58()
+      );
+    });
+
+    it("credential level never downgrades (Bug 3 regression)", async () => {
+      // Credential is currently at level 2 (from previous test)
+      // Create a level-1 course in the same track
+      const lowLevelCourseId = "cred-low-level";
+      const [lowLevelCoursePda] = PublicKey.findProgramAddressSync(
+        [Buffer.from("course"), Buffer.from(lowLevelCourseId)],
+        program.programId
+      );
+
+      await program.methods
+        .createCourse({
+          courseId: lowLevelCourseId,
+          creator: creator.publicKey,
+          contentTxId: contentTxId,
+          lessonCount: 1,
+          difficulty: 1,
+          xpPerLesson: 10,
+          trackId: 1,
+          trackLevel: 1, // Lower than current credential level (2)
+          trackCollection: collectionAddress,
+          prerequisite: null,
+          creatorRewardXp: 0,
+          minCompletionsForReward: 0,
+        })
+        .accountsPartial({
+          course: lowLevelCoursePda,
+          config: configPda,
+          authority: authority.publicKey,
+          systemProgram: SystemProgram.programId,
+        })
+        .rpc();
+
+      // Enroll, complete, finalize
+      const [lowEnrollPda] = PublicKey.findProgramAddressSync(
+        [
+          Buffer.from("enrollment"),
+          Buffer.from(lowLevelCourseId),
+          credLearner.publicKey.toBuffer(),
+        ],
+        program.programId
+      );
+
+      await program.methods
+        .enroll(lowLevelCourseId)
+        .accountsPartial({
+          course: lowLevelCoursePda,
+          enrollment: lowEnrollPda,
+          learner: credLearner.publicKey,
+          systemProgram: SystemProgram.programId,
+        })
+        .signers([credLearner])
+        .rpc();
+
+      await program.methods
+        .completeLesson(0)
+        .accountsPartial({
+          config: configPda,
+          course: lowLevelCoursePda,
+          enrollment: lowEnrollPda,
+          learner: credLearner.publicKey,
+          learnerTokenAccount: credLearnerTokenAccount,
+          xpMint: xpMintKeypair.publicKey,
+          backendSigner: authority.publicKey,
+          tokenProgram: TOKEN_2022_PROGRAM_ID,
+        })
+        .rpc();
+
+      await program.methods
+        .finalizeCourse()
+        .accountsPartial({
+          config: configPda,
+          course: lowLevelCoursePda,
+          enrollment: lowEnrollPda,
+          learner: credLearner.publicKey,
+          learnerTokenAccount: credLearnerTokenAccount,
+          creatorTokenAccount: creatorTokenAccount,
+          creator: creator.publicKey,
+          xpMint: xpMintKeypair.publicKey,
+          backendSigner: authority.publicKey,
+          tokenProgram: TOKEN_2022_PROGRAM_ID,
+        })
+        .rpc();
+
+      // Upgrade credential with level-1 course — level should stay at 2
+      const sig = await program.methods
+        .upgradeCredential("Track 1 - Still Level 2", "https://arweave.net/cred-v4", 4, new anchor.BN(2000))
+        .accountsPartial({
+          config: configPda,
+          course: lowLevelCoursePda,
+          enrollment: lowEnrollPda,
+          learner: credLearner.publicKey,
+          credentialAsset: credentialKeypair.publicKey,
+          trackCollection: collectionAddress,
+          payer: authority.publicKey,
+          backendSigner: authority.publicKey,
+          mplCoreProgram: MPL_CORE_PROGRAM_ID,
+          systemProgram: SystemProgram.programId,
+        })
+        .rpc();
+      await provider.connection.confirmTransaction(sig, "confirmed");
+
+      // Verify level is still 2, NOT downgraded to 1
+      const umi = createUmi(provider.connection.rpcEndpoint, { commitment: "confirmed" }).use(mplCore());
+      const asset = await fetchAssetV1(
+        umi,
+        fromWeb3JsPublicKey(credentialKeypair.publicKey)
+      );
+
+      const levelAttr = asset.attributes.attributeList.find((a) => a.key === "level");
+      expect(levelAttr.value).to.equal("2"); // max(2, 1) = 2, not downgraded
+
+      // Verify other attributes were updated
+      expect(asset.name).to.equal("Track 1 - Still Level 2");
+      const coursesAttr = asset.attributes.attributeList.find((a) => a.key === "courses_completed");
+      expect(coursesAttr.value).to.equal("4");
+    });
   });
 
   // ===========================================================================
@@ -2392,6 +3001,7 @@ describe("onchain-academy", () => {
           xpPerLesson: 10,
           trackId: 20,
           trackLevel: 1,
+          trackCollection: Keypair.generate().publicKey,
           prerequisite: null,
           creatorRewardXp: 0,
           minCompletionsForReward: 0,
@@ -2548,6 +3158,7 @@ describe("onchain-academy", () => {
           xpPerLesson: 75,
           trackId: 30,
           trackLevel: 1,
+          trackCollection: Keypair.generate().publicKey,
           prerequisite: null,
           creatorRewardXp: 0,
           minCompletionsForReward: 0,
@@ -2672,6 +3283,7 @@ describe("onchain-academy", () => {
           xpPerLesson: 200,
           trackId: 31,
           trackLevel: 1,
+          trackCollection: Keypair.generate().publicKey,
           prerequisite: null,
           creatorRewardXp: 10,
           minCompletionsForReward: 1,
@@ -3505,6 +4117,7 @@ describe("onchain-academy", () => {
           xpPerLesson: 10,
           trackId: 40,
           trackLevel: 1,
+          trackCollection: Keypair.generate().publicKey,
           prerequisite: null,
           creatorRewardXp: 0,
           minCompletionsForReward: 0,
@@ -3641,6 +4254,7 @@ describe("onchain-academy", () => {
           xpPerLesson: 10,
           trackId: 41,
           trackLevel: 1,
+          trackCollection: Keypair.generate().publicKey,
           prerequisite: null,
           creatorRewardXp: 0,
           minCompletionsForReward: 0,

--- a/onchain-academy/tests/rust/src/test_course.rs
+++ b/onchain-academy/tests/rust/src/test_course.rs
@@ -7,11 +7,12 @@ use onchain_academy::state::{Course, MAX_COURSE_ID_LEN};
 fn course_size_constant_is_correct() {
     // 8 (discriminator) + (4 + 32) (course_id String) + 32 (creator)
     // + 32 (content_tx_id) + 2 (version) + 1 (lesson_count) + 1 (difficulty)
-    // + 4 (xp_per_lesson) + 2 (track_id) + 1 (track_level) + (1 + 32) (prerequisite Option<Pubkey>)
+    // + 4 (xp_per_lesson) + 2 (track_id) + 1 (track_level) + 32 (track_collection)
+    // + (1 + 32) (prerequisite Option<Pubkey>)
     // + 4 (creator_reward_xp) + 2 (min_completions_for_reward)
     // + 4 (total_completions) + 4 (total_enrollments) + 1 (is_active)
     // + 8 (created_at) + 8 (updated_at) + 8 (_reserved) + 1 (bump)
-    assert_eq!(Course::SIZE, 192);
+    assert_eq!(Course::SIZE, 224);
 }
 
 #[test]
@@ -31,6 +32,7 @@ fn course_serialization_roundtrip() {
         xp_per_lesson: 100,
         track_id: 5,
         track_level: 2,
+        track_collection: Pubkey::new_unique(),
         prerequisite: None,
         creator_reward_xp: 50,
         min_completions_for_reward: 10,
@@ -57,6 +59,7 @@ fn course_serialization_roundtrip() {
     assert_eq!(deserialized.xp_per_lesson, 100);
     assert_eq!(deserialized.track_id, 5);
     assert_eq!(deserialized.track_level, 2);
+    assert_eq!(deserialized.track_collection, course.track_collection);
     assert_eq!(deserialized.prerequisite, None);
     assert_eq!(deserialized.creator_reward_xp, 50);
     assert_eq!(deserialized.min_completions_for_reward, 10);
@@ -82,6 +85,7 @@ fn course_with_prerequisite_roundtrip() {
         xp_per_lesson: 200,
         track_id: 1,
         track_level: 2,
+        track_collection: Pubkey::new_unique(),
         prerequisite: Some(prereq),
         creator_reward_xp: 20,
         min_completions_for_reward: 5,
@@ -148,6 +152,7 @@ fn course_serialized_size_with_max_id_and_all_options() {
         xp_per_lesson: 0,
         track_id: 0,
         track_level: 0,
+        track_collection: Pubkey::new_unique(),
         prerequisite: Some(Pubkey::new_unique()),
         creator_reward_xp: 0,
         min_completions_for_reward: 0,
@@ -179,6 +184,7 @@ fn course_serialized_size_shorter_id_fits_within_allocation() {
         xp_per_lesson: 0,
         track_id: 0,
         track_level: 0,
+        track_collection: Pubkey::new_unique(),
         prerequisite: None,
         creator_reward_xp: 0,
         min_completions_for_reward: 0,


### PR DESCRIPTION
# PR: fix: credential-based prerequisites, cross-track upgrades & level protection

---

## Summary

- **Bug 1 fix:** Prerequisite check now uses credential NFT instead of enrollment PDA, so learners can reclaim enrollment rent without losing track progression
- **Bug 2 fix:** `upgrade_credential` verifies credential on-chain via `BaseAssetV1` deserialization instead of relying on `enrollment.credential_asset`, enabling multi-course track upgrades
- **Bug 3 fix:** Credential level uses `max(current_level, course.track_level)` to prevent downgrades when courses are completed out of order
- Added `track_collection: Pubkey` to Course PDA (SIZE 192→224) to link courses to their Metaplex Core collection on-chain
- Added `track_collection` constraint to `issue_credential` and `upgrade_credential` for server-side validation

## Problem

Three interconnected bugs in the credential and prerequisite system:

1. **Prerequisite fails after rent reclaim:** `enroll.rs` deserialized the prerequisite Enrollment PDA from `remaining_accounts`. After `close_enrollment` deletes it, learners who reclaimed rent could never satisfy prerequisites — permanently blocked from track progression.

2. **`upgrade_credential` broken for multi-course tracks:** The instruction read `enrollment.credential_asset` to find the existing credential NFT. But credentials are per-track, not per-course. Course Y's enrollment has `credential_asset = None` (only Course X's enrollment that originally issued the credential has it), so upgrade failed when using Course Y's enrollment. A workaround existed — pass Course X's enrollment instead — but this only worked while Course X's enrollment remained open. Once the learner reclaimed rent (closing Course X's enrollment), the workaround broke too, combining with Bug 1 into a complete blocker.

3. **Credential level can downgrade:** Both `issue_credential` and `upgrade_credential` blindly set `level` from `course.track_level`. A learner completing a level-2 course first, then level-1, would have their credential downgraded from 2 to 1.

## Approaches Evaluated

| Approach | Description | Rejected Because |
|----------|-------------|------------------|
| **New `CompletionRecord` PDA** | Permanent PDA per completion | Adds per-learner rent cost, storage bloat, migration needed, doesn't fix Bug 2/3 |
| **Block enrollment closure for prereq courses** | Refuse to close if any course references it | Defeats rent reclamation purpose, poor UX, doesn't fix Bug 2/3 |
| **Credential NFT as proof** (chosen) | Verify Metaplex Core credential on-chain | Fixes all 3 bugs, zero additional rent, leverages existing infrastructure |

Full analysis in [`docs/ENHANCEMENT_CREDENTIAL_PREREQUISITE.md`](https://github.com/0xharp/superteam-academy/blob/onchain-program-enhancements/docs/ENHANCEMENT_CREDENTIAL_PREREQUISITE.md).

## Solution

**No new PDAs. No new instructions.** Three targeted changes using existing Metaplex Core infrastructure:

### 1. `track_collection: Pubkey` on Course PDA

Links each course to its track's Metaplex Core collection address. Enables on-chain verification that a credential belongs to the correct track.

### 2. Credential NFT as Prerequisite Proof (Bug 1)

`enroll.rs` remaining_accounts changed from `[prereq_course, prereq_enrollment]` to `[prereq_course, credential_nft]`.

Verification chain:
1. Account owner == `mpl_core::ID` (rejects non-Metaplex accounts)
2. `BaseAssetV1::try_from()` (rejects malformed data)
3. `asset.owner == learner` (rejects other learners' credentials)
4. `asset.update_authority == Collection(prereq_course.track_collection)` (rejects wrong-track credentials)

### 3. On-Chain Credential Verification (Bug 2)

`upgrade_credential.rs` no longer reads `enrollment.credential_asset`. Instead:
- Deserializes `BaseAssetV1` from the credential account
- Verifies `asset.owner == learner` and `asset.update_authority == Collection(track_collection)`
- Propagates `credential_asset` back to enrollment after successful upgrade

### 4. Max-Level Protection (Bug 3)

```rust
let current_level = fetch_asset_plugin::<Attributes>(&credential_asset, PluginType::Attributes)
    .ok()
    .and_then(|(_, attrs, _)| attrs.attribute_list.iter()
        .find(|a| a.key == "level")
        .and_then(|a| a.value.parse::<u8>().ok()))
    .unwrap_or(0);

let effective_level = std::cmp::max(current_level, course.track_level);
```

## UX Improvement: Enrollment as Truly Ephemeral State

The credential NFT now serves as the **single source of truth** for track progression. This means enrollment becomes truly ephemeral:

```
New learner journey:
1. Enroll in Course A (pay ~0.002 SOL rent for Enrollment PDA)
2. Complete all lessons → Finalize course
3. Collect credential NFT (soulbound, permanent, visible in wallet)
4. Close enrollment → Rent returned to learner ✅
5. Enroll in Course B (requires A) → Pass credential NFT as proof ✅
```

**Before:** Learners had to choose between keeping rent locked or losing prerequisite eligibility.
**After:** Learners reclaim rent freely. The credential NFT in their wallet is all they need.

### Future: Auto-Close Enrollment on Credential Collection

With enrollment no longer needed for prerequisites or upgrades, the next logical step is combining credential issuance with enrollment closure in a single transaction — the learner collects their credential NFT and gets their rent back atomically. The changes in this PR are prerequisites for that optimization.

## Files Changed

| File | What Changed |
|------|-------------|
| `state/course.rs` | +`track_collection: Pubkey`, SIZE 192→224 |
| `errors.rs` | +`InvalidCredentialOwner`, +`TrackCollectionMismatch` |
| `instructions/create_course.rs` | `track_collection` in params + handler |
| `instructions/enroll.rs` | Credential NFT prerequisite check (was enrollment PDA) |
| `instructions/upgrade_credential.rs` | On-chain credential verification + max-level + enrollment propagation |
| `instructions/issue_credential.rs` | `track_collection` constraint |
| `tests/rust/src/test_course.rs` | SIZE 192→224, `track_collection` in all Course structs |
| `tests/onchain-academy.ts` | `trackCollection` params everywhere, rewritten prereq tests |
| `docs/ENHANCEMENT_CREDENTIAL_PREREQUISITE.md` | Full design document |

## Security

| Attack Vector | Prevented By |
|---------------|-------------|
| Wrong credential for prerequisite | `asset.update_authority == Collection(prereq_course.track_collection)` |
| Credential from different track | `UpdateAuthority::Collection` mismatch |
| Non-Metaplex-Core account as credential | Account owner check against `mpl_core::ID` |
| Someone else's credential | `asset.owner == learner.key()` |
| Backend passes wrong track_collection | Anchor constraint `track_collection.key() == course.track_collection` |
| Credential level downgrade | `max(current_level, course.track_level)` |
| Double credential issuance | `enrollment.credential_asset.is_none()` unchanged |

## Test Plan

### Automated Tests (all passing)

- [x] `anchor build` — compiles without errors
- [x] `cargo fmt && cargo clippy -- -W clippy::all` — no warnings (excluding pre-existing Anchor macro warnings)
- [x] `cargo test --manifest-path onchain-academy/tests/rust/Cargo.toml` — **77 Rust unit tests passing**
- [x] `anchor test` — **66 TypeScript integration tests passing** (was 62, +4 regression tests)

### Prerequisite Tests (rewritten)

- [x] **"enroll fails without remaining accounts for prerequisite"** — No remaining accounts → `PrerequisiteNotMet`
- [x] **"enroll fails with non-Metaplex-Core account as credential"** — Passes enrollment PDA (program-owned) as credential → `PrerequisiteNotMet`
- [x] **"enroll with credential NFT succeeds"** — Full flow: create course with real collection → complete → finalize → issue credential → enroll in dependent course using credential NFT as proof

### Regression Tests (new)

- [x] **"prerequisite succeeds after close_enrollment (rent reclaim)"** — Bug 1: complete prereq → issue credential → close enrollment → enroll in dependent course with credential NFT
- [x] **"prerequisite fails with credential from wrong track"** — Bug 1: credential from Track A rejected for Track B prerequisite
- [x] **"upgrade_credential succeeds from second course in same track"** — Bug 2: issue credential via Course X → complete Course Y → upgrade via Course Y enrollment
- [x] **"credential level never downgrades"** — Bug 3: complete level-2 course → issue credential (level=2) → complete level-1 course → upgrade → verify level stays 2

### Credential Tests (existing, updated)

- [x] **"issues credential NFT for completed course"** — Now validates `track_collection` constraint
- [x] **"upgrades existing credential"** — Verifies on-chain credential verification works
- [x] **"fails with wrong credential asset on upgrade"** — Verifies `CredentialAssetMismatch` for non-existent assets
- [x] **"double issue_credential fails"** — `CredentialAlreadyIssued` guard unchanged

### Test Output

```
  Phase 6: Credentials
    ✔ issues credential NFT for completed course
    ✔ double issue_credential fails
    ✔ upgrades existing credential
    ✔ fails with wrong credential asset on upgrade
    ✔ upgrade_credential succeeds from second course in same track (Bug 2 regression)
    ✔ credential level never downgrades (Bug 3 regression)

  Phase 12: Prerequisite enforcement
    ✔ enroll fails without remaining accounts for prerequisite
    ✔ enroll fails with non-Metaplex-Core account as credential
    ✔ enroll with credential NFT succeeds
    ✔ prerequisite succeeds after close_enrollment (rent reclaim)
    ✔ prerequisite fails with credential from wrong track

  66 passing (2m)
```

## Breaking Changes

- **`create_course` instruction:** Now requires `trackCollection: Pubkey` parameter. All existing course creation calls must be updated.
- **`enroll` remaining_accounts:** Changed from `[prereq_course, prereq_enrollment]` to `[prereq_course, credential_nft]`. Frontend/backend must update prerequisite enrollment flows.
- **Course PDA size:** 192 → 224 bytes. New courses will allocate 224 bytes. Existing courses would need reallocation if migrated (not applicable for fresh devnet deploys).
