### PR TITLE
fix: unlock speed-runner achievement on course finalize

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ For details, see [docs/ADMIN.md](docs/ADMIN.md).
 The on-chain program is feature-complete with 16 instructions covering the full learning lifecycle. The following items are scoped for future iterations:
 
 - **Track collection enforcement**: `track_collection` is validated server-side during credential issuance but is not yet enforced on-chain as an account constraint (future program upgrade).
-- **Cross-course achievements**: Three achievement types (Anchor Expert, Full Stack Solana, Rust Rookie) have partial frontend logic but lack proper cross-course tracking infrastructure. `full-stack-solana` is hardcoded to `false`; `anchor-expert` and `rust-rookie` use lesson ID pattern matching instead of course-level completion checks.
+- **Cross-course achievements**: `rust-rookie`, `anchor-expert`, and `full-stack-solana` are wired via webhook enrollment/progress checks. `speed-runner` uses enrollment timestamps (`enrolled_at` → `completed_at`) and is re-evaluated on course finalize. `perfect-score` still needs challenge attempt tracking (DB + API).
 - **Build server**: Compilation features (`buildable` Rust challenges + program deployment) require a separately deployed Rust/Axum build server on GCP Cloud Run. See the [Deployment](#deployment) section for setup details.
 
 ## Code Quality

--- a/apps/web/src/lib/gamification/__tests__/achievements.test.ts
+++ b/apps/web/src/lib/gamification/__tests__/achievements.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildAchievementUserState,
+  checkNewAchievements,
+  computeFastestCourseCompletionHours,
+  type AchievementDefinition,
+} from "../achievements";
+
+describe("computeFastestCourseCompletionHours", () => {
+  it("returns null when no completed enrollments have both timestamps", () => {
+    expect(
+      computeFastestCourseCompletionHours([
+        { course_id: "a", enrolled_at: null, completed_at: "2026-01-02T00:00:00.000Z" },
+        { course_id: "b", enrolled_at: "2026-01-01T00:00:00.000Z", completed_at: null },
+      ])
+    ).toBeNull();
+  });
+
+  it("returns the minimum completion window in hours", () => {
+    const hours = computeFastestCourseCompletionHours([
+      {
+        course_id: "slow",
+        enrolled_at: "2026-01-01T00:00:00.000Z",
+        completed_at: "2026-01-03T00:00:00.000Z",
+      },
+      {
+        course_id: "fast",
+        enrolled_at: "2026-01-01T00:00:00.000Z",
+        completed_at: "2026-01-01T12:00:00.000Z",
+      },
+    ]);
+    expect(hours).toBe(12);
+  });
+});
+
+describe("buildAchievementUserState", () => {
+  it("unlocks speed-runner when fastest completion is under 24 hours", () => {
+    const state = buildAchievementUserState({
+      progressRowCount: 10,
+      completedCourseCount: 1,
+      completedCourseIds: new Set(["course-anchor-framework"]),
+      courseLessonCounts: new Map([["course-rust-for-solana", 1]]),
+      currentStreak: 3,
+      enrollmentRows: [
+        {
+          course_id: "course-anchor-framework",
+          enrolled_at: "2026-01-01T00:00:00.000Z",
+          completed_at: "2026-01-01T10:00:00.000Z",
+        },
+      ],
+      userNumber: 50,
+      solanaDevPathCourses: ["course-a", "course-b"],
+    });
+
+    const defs: AchievementDefinition[] = [
+      {
+        id: "achievement-speed-runner",
+        name: "Speed Runner",
+        description: "Finish a course in under 24 hours",
+        icon: "bolt",
+        glyph: "SR",
+        solTier: true,
+        category: "learning",
+      },
+    ];
+
+    const unlocked = checkNewAchievements(defs, state, []);
+    expect(unlocked.map((a) => a.id)).toContain("achievement-speed-runner");
+  });
+});

--- a/apps/web/src/lib/gamification/achievements.ts
+++ b/apps/web/src/lib/gamification/achievements.ts
@@ -29,6 +29,75 @@ export interface UserState {
   totalCommunityXp: number;
 }
 
+export interface EnrollmentTimingRow {
+  course_id: string;
+  enrolled_at: string | null;
+  completed_at: string | null;
+}
+
+/**
+ * Fastest course completion window in hours (enrolled_at → completed_at).
+ * Returns null when no completed enrollment has both timestamps.
+ */
+export function computeFastestCourseCompletionHours(
+  enrollments: EnrollmentTimingRow[]
+): number | null {
+  let fastest: number | null = null;
+
+  for (const row of enrollments) {
+    if (!row.completed_at || !row.enrolled_at) continue;
+    const enrolledMs = Date.parse(row.enrolled_at);
+    const completedMs = Date.parse(row.completed_at);
+    if (!Number.isFinite(enrolledMs) || !Number.isFinite(completedMs)) continue;
+    if (completedMs < enrolledMs) continue;
+
+    const hours = (completedMs - enrolledMs) / (1000 * 60 * 60);
+    if (fastest === null || hours < fastest) {
+      fastest = hours;
+    }
+  }
+
+  return fastest;
+}
+
+export interface BuildAchievementUserStateInput {
+  progressRowCount: number;
+  completedCourseCount: number;
+  completedCourseIds: Set<string>;
+  courseLessonCounts: Map<string, number>;
+  currentStreak: number;
+  enrollmentRows: EnrollmentTimingRow[];
+  userNumber: number;
+  solanaDevPathCourses: readonly string[];
+}
+
+export function buildAchievementUserState(
+  input: BuildAchievementUserStateInput
+): UserState {
+  return {
+    completedLessons: input.progressRowCount,
+    completedCourses: input.completedCourseCount,
+    currentStreak: input.currentStreak,
+    hasCompletedRustLesson:
+      (input.courseLessonCounts.get("course-rust-for-solana") ?? 0) >= 1,
+    hasCompletedAnchorCourse: input.completedCourseIds.has(
+      "course-anchor-framework"
+    ),
+    hasCompletedAllTracks: input.solanaDevPathCourses.every((id) =>
+      input.completedCourseIds.has(id)
+    ),
+    courseCompletionTimeHours: computeFastestCourseCompletionHours(
+      input.enrollmentRows
+    ),
+    allTestsPassedFirstTry: false,
+    userNumber: input.userNumber,
+    totalThreads: 0,
+    totalAnswers: 0,
+    acceptedAnswers: 0,
+    totalCommunityXp: 0,
+  };
+}
+
 /**
  * Programmatic unlock conditions keyed by achievement ID.
  * IDs must match the naming convention used in Sanity (Sanity _id minus the "achievement-" prefix).

--- a/apps/web/src/lib/helius/event-handlers.ts
+++ b/apps/web/src/lib/helius/event-handlers.ts
@@ -16,7 +16,7 @@ import {
 import { fetchEnrollment, fetchCourse } from "@/lib/solana/academy-reads";
 import { getProgramId } from "@/lib/solana/pda";
 import { isAllLessonsComplete } from "@/lib/solana/bitmap";
-import { checkNewAchievements } from "@/lib/gamification/achievements";
+import { buildAchievementUserState, checkNewAchievements } from "@/lib/gamification/achievements";
 import {
   getCourseById,
   getDeployedAchievements,
@@ -320,6 +320,9 @@ export async function handleCourseFinalized(
 
   // 4. Issue credential NFT
   await tryIssueCredential(userId, courseId, event.learner, connection);
+
+  // 5. Re-check achievements now that completed_at is set (speed-runner, etc.)
+  await checkAndAwardAchievements(userId, event.learner, supabase);
 }
 
 // ---------------------------------------------------------------------------
@@ -674,7 +677,7 @@ async function checkAndAwardAchievements(
         .eq("user_id", userId),
       supabase
         .from("enrollments")
-        .select("course_id, completed_at")
+        .select("course_id, enrolled_at, completed_at")
         .eq("user_id", userId),
     ]);
 
@@ -734,26 +737,16 @@ async function checkAndAwardAchievements(
 
     const newAchievements = checkNewAchievements(
       deployedAchievements,
-      {
-        completedLessons: progressRows?.length ?? 0,
-        completedCourses: completedCourseCount,
+      buildAchievementUserState({
+        progressRowCount: progressRows?.length ?? 0,
+        completedCourseCount,
+        completedCourseIds,
+        courseLessonCounts,
         currentStreak: xpData?.current_streak ?? 0,
-        hasCompletedRustLesson:
-          (courseLessonCounts.get("course-rust-for-solana") ?? 0) >= 1,
-        hasCompletedAnchorCourse: completedCourseIds.has(
-          "course-anchor-framework"
-        ),
-        hasCompletedAllTracks: SOLANA_DEV_PATH_COURSES.every((id) =>
-          completedCourseIds.has(id)
-        ),
-        courseCompletionTimeHours: null,
-        allTestsPassedFirstTry: false,
+        enrollmentRows: enrollmentRows ?? [],
         userNumber: userNumber ?? 999,
-        totalThreads: 0,
-        totalAnswers: 0,
-        acceptedAnswers: 0,
-        totalCommunityXp: 0,
-      },
+        solanaDevPathCourses: SOLANA_DEV_PATH_COURSES,
+      }),
       alreadyUnlocked
     );
 

--- a/apps/web/src/lib/services/hybrid-progress-service.ts
+++ b/apps/web/src/lib/services/hybrid-progress-service.ts
@@ -198,11 +198,25 @@ export class HybridProgressService implements LearningProgressService {
       .eq("user_id", userId)
       .single();
 
+    const oneYearAgo = new Date();
+    oneYearAgo.setDate(oneYearAgo.getDate() - 270);
+    const { data: activityRows } = await this.supabase
+      .from("xp_transactions")
+      .select("created_at")
+      .eq("user_id", userId)
+      .gte("created_at", oneYearAgo.toISOString());
+
+    const streakHistory: Record<string, number> = {};
+    for (const row of activityRows ?? []) {
+      const dateStr = (row.created_at ?? "").split("T")[0] as string;
+      streakHistory[dateStr] = (streakHistory[dateStr] ?? 0) + 1;
+    }
+
     return {
       currentStreak: data?.current_streak ?? 0,
       longestStreak: data?.longest_streak ?? 0,
       lastActivityDate: data?.last_activity_date ?? "",
-      streakHistory: {},
+      streakHistory,
     };
   }
 


### PR DESCRIPTION
## Summary
- Compute fastest course completion time from enrollment \nrolled_at\ → \completed_at\ so \chievement-speed-runner\ can unlock (<24h).
- Re-run achievement checks in \handleCourseFinalized\ after \completed_at\ is persisted (previously speed-runner could never fire).
- Populate \HybridProgressService.getStreak().streakHistory\ from \xp_transactions\ (matches dashboard heatmap logic).
- Add unit tests for completion timing + speed-runner unlock.

## Superteam Brazil LMS bounty
Submission for [Build the Superteam Brazil Learning Management System dApp](https://superteam.fun/listings/bounty/superteam-academy).

## Test plan
- [ ] Complete a course on devnet within 24h of enrollment and verify speed-runner achievement mints after finalize webhook
- [ ] Confirm streak heatmap data via \HybridProgressService.getStreak()\
- [ ] Run \pnpm --filter @superteam-lms/web test\ in apps/web

Made with [Cursor](https://cursor.com)