### PR TITLE
fix(db): enforce RLS on community_stats via security_invoker (P0-B1)

### DIFF
--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -1348,7 +1348,11 @@ CREATE POLICY "Authenticated users can create flags"
 -- Community Stats View
 -- ============================================================
 
-CREATE VIEW community_stats AS
+-- security_invoker = true makes the view run with the querying role's
+-- privileges, so RLS on the underlying tables is enforced. Without it the
+-- view runs as its owner and bypasses RLS, leaking aggregates for private
+-- profiles (profiles SELECT is gated to is_public = true) to anon.
+CREATE VIEW community_stats WITH (security_invoker = true) AS
 SELECT
   p.id AS user_id,
   COUNT(DISTINCT t.id) AS total_threads,
@@ -1360,3 +1364,8 @@ LEFT JOIN threads t ON t.author_id = p.id
 LEFT JOIN answers a ON a.author_id = p.id
 LEFT JOIN xp_transactions xt ON xt.user_id = p.id
 GROUP BY p.id;
+
+-- Explicit grants: the view stays publicly queryable, but security_invoker
+-- ensures each caller only sees rows their own RLS permits.
+REVOKE ALL ON community_stats FROM PUBLIC, anon, authenticated;
+GRANT SELECT ON community_stats TO anon, authenticated;


### PR DESCRIPTION
The community_stats view ran with its owner's privileges, bypassing RLS on the underlying tables. Since profiles SELECT is gated to is_public = true, anon queries leaked aggregate stats for private profiles.

Recreate the view WITH (security_invoker = true) so it respects the querying role's RLS, and set explicit REVOKE/GRANT so it stays publicly queryable while each caller only sees rows their own RLS permits.

Closes #109