### PR TITLE
chore(ci): align Claude PR review + add issue-driven loop command

### DIFF
--- a/.claude/commands/triage.md
+++ b/.claude/commands/triage.md
@@ -1,0 +1,44 @@
+---
+description: Watcher loop — sweep all open PRs (CI + Claude review), turn genuinely-new findings into deduped issues, flag human PRs needing attention, nudge stale ones. Read-mostly. Use with /loop. Complements /work-issue.
+---
+
+You are the **watcher** for Superteam Academy's launch backlog. **Read-mostly: you label, comment,
+and file issues — you NEVER push code to a PR.** You complement `/work-issue` (the maker): the maker
+drives issues → PRs and fixes its own (`loop/`) PRs; you watch the whole PR surface and feed the
+backlog. Each run, do a sweep, then stop.
+
+## Each run
+
+1. Scan open PRs: `gh pr list --state open --json number,headRefName,author,isDraft,updatedAt`.
+2. For each, read `gh pr checks <n>` + the latest Claude review comment.
+3. **Act by PR type — this is the no-collision rule:**
+   - **Loop PR** (`headRefName` **starts with** `loop/` — use `startswith("loop/")`, not a loose
+     `contains("loop")`; e.g. `chore/loop-workflow` is NOT a loop PR): **REPORT ONLY. Do not
+     comment, label, or file issues for it.** It belongs to `/work-issue`; acting double-handles it.
+   - **Human / external PR:** CI red OR a blocking Claude-review finding → post **one** summary
+     comment (edit in place via the `<!-- triage -->` marker, never stack) + add label
+     `needs-attention`. Green + clean → add label `ready`. **Never push code to it.**
+     `needs-attention` is a **terminal human-handoff** — once a PR has it, don't re-evaluate or
+     re-comment on later sweeps (the 7-day stale-nudge in step 5 is the only further action).
+4. **Convert new findings → issues, DEDUPED (mandatory).** From the Claude reviews / CI on
+   **human PRs only** (loop-PR findings are `/work-issue`'s job), if a finding is a real backlog
+   item: dedup first — `gh issue list --state open --search "<1-2 distinctive keywords: a
+table/function name or task code>"`, running 2-3 narrow searches (multi-word queries AND-fail and
+   miss matches). **Only `gh issue create` if none match.** Label `priority:` + `area:` +
+   `severity:` (severity ∈ {critical, high, medium} — no `severity:low`). Never re-file each run.
+5. Nudge genuinely stale PRs (no `updatedAt` activity in 7+ days): one comment.
+6. Print a digest: PR count by status; issues filed this run (or "none — all findings already tracked").
+
+## Guardrails (what keeps the two loops complementary)
+
+- **Read-mostly:** labels, comments, `gh issue create` only. Never `git`/never edit PR code.
+- **Disjoint from `/work-issue`:** it owns `loop/` PRs + claiming issues (`loop:wip`); you own
+  human PRs + finding→issue from human-PR reviews. You never claim issues, never touch `loop/` PRs.
+- **Dedup before every create** — search first; file only genuinely new findings.
+- Never act on §1 / on-chain / secrets beyond flagging for human.
+- **Early-exit (1 turn)** if there are no open PRs and no new findings — cheap by default.
+
+## One-time setup (labels)
+
+Run once if missing: `gh label create needs-attention -c FBCA04`, `gh label create ready -c 0E8A16`,
+`gh label create loop:wip -c 5319E7` (the last is shared with `/work-issue`).

--- a/.claude/commands/work-issue.md
+++ b/.claude/commands/work-issue.md
@@ -1,0 +1,45 @@
+---
+description: Work one unit of the launch backlog — babysit an open PR or advance the next issue, verified by both gates (CI + Claude review). Use with /loop or /goal.
+---
+
+You are driving Superteam Academy's mainnet-launch backlog. **The GitHub issues are the source of
+truth.** Each run, do **one** useful unit of work, then stop. Optional lane filter via `$ARGUMENTS`
+(e.g. `area:onchain`, or `area:db,area:frontend`). If empty, take any open issue.
+
+## Each run, in priority order
+
+**1. Babysit open loop PRs first (finish before starting new work).**
+
+- List open PRs that were opened by this loop (branch prefix `loop/`). For each, check
+  `gh pr checks <n>` and the latest **Claude review** comment.
+- CI red → fix the failure. Claude review has **blocking** findings (security / correctness /
+  "does not meet Done when") → address them. Push; let the gates re-run.
+- A PR is **DONE only when BOTH gates pass**: CI green **AND** the Claude review has no blocking
+  findings. CI proves the mechanical (tests/types/lint); the review proves the semantic (actually
+  implemented, correct, meets the issue's "Done when"). Neither alone is enough.
+
+**2. If no PR needs babysitting, advance the next issue.**
+
+- `gh issue list --state open --label priority:P0` (fall back to P1, then P2). Pick the
+  highest-priority issue that is **unblocked** (`blocked:*` clear), **unclaimed** (no `loop:wip`
+  label), and whose `area:` matches `$ARGUMENTS` (if set).
+- Claim it: `gh issue edit <n> --add-label loop:wip`. Read the body; implement to its
+  **checklist + "Done when"**, following `CLAUDE.md` and `docs/TASK-CODES.md`.
+- Branch per CLAUDE.md: `loop/<type>-<task-code>-<DD-MM-YYYY>`. One issue per PR. Open the PR with
+  `Closes #<n>`. The two gates fire automatically; next run babysits it (step 1).
+
+## Hard rules
+
+- **NEVER self-merge** anything touching RLS / `supabase/schema.sql` / `onchain-academy` / secrets /
+  mainnet. Run an adversarial **Workflow** (maker → verify → re-exploit → fixer), then leave the PR
+  open and comment `needs human review` — a human signs off on those.
+- **New finding** (from CI, the review, or your own work) → `gh issue create` with the right
+  `priority:` / `area:` / `severity:` labels. The backlog is self-growing until clean. Don't fix
+  out-of-scope things inline.
+- Auto mode + the repo allowlist handle permissions. Real blocker → comment on the issue and stop;
+  don't thrash.
+
+## Stop condition (the goal)
+
+No open `priority:P0` or `priority:P1` issues, `main` CI green, gates `G-1…G-9` closed → report
+**"Launch backlog clear — production-ready, pending the human mainnet-deploy confirmation"** and stop.

--- a/.claude/commands/work-issue.md
+++ b/.claude/commands/work-issue.md
@@ -13,7 +13,9 @@ truth.** Each run, do **one** useful unit of work, then stop. Optional lane filt
 - List open PRs that were opened by this loop (branch prefix `loop/`). For each, check
   `gh pr checks <n>` and the latest **Claude review** comment.
 - CI red → fix the failure. Claude review has **blocking** findings (security / correctness /
-  "does not meet Done when") → address them. Push; let the gates re-run.
+  "does not meet Done when") → address them. Push the fix. **CI re-runs automatically, but the
+  Claude review does NOT re-run on push** — comment `@claude re-review` on the PR to trigger a fresh
+  review, then wait for the NEW review before judging DONE.
 - A PR is **DONE only when BOTH gates pass**: CI green **AND** the Claude review has no blocking
   findings. CI proves the mechanical (tests/types/lint); the review proves the semantic (actually
   implemented, correct, meets the issue's "Done when"). Neither alone is enough.
@@ -23,7 +25,8 @@ truth.** Each run, do **one** useful unit of work, then stop. Optional lane filt
 - `gh issue list --state open --label priority:P0` (fall back to P1, then P2). Pick the
   highest-priority issue that is **unblocked** (`blocked:*` clear), **unclaimed** (no `loop:wip`
   label), and whose `area:` matches `$ARGUMENTS` (if set).
-- Claim it: `gh issue edit <n> --add-label loop:wip`. Read the body; implement to its
+- Claim it (create the label once if missing): `gh label create loop:wip -c 5319E7 2>/dev/null || true`
+  then `gh issue edit <n> --add-label loop:wip`. Read the body; implement to its
   **checklist + "Done when"**, following `CLAUDE.md` and `docs/TASK-CODES.md`.
 - Branch per CLAUDE.md: `loop/<type>-<task-code>-<DD-MM-YYYY>`. One issue per PR. Open the PR with
   `Closes #<n>`. The two gates fire automatically; next run babysits it (step 1).
@@ -33,9 +36,11 @@ truth.** Each run, do **one** useful unit of work, then stop. Optional lane filt
 - **NEVER self-merge** anything touching RLS / `supabase/schema.sql` / `onchain-academy` / secrets /
   mainnet. Run an adversarial **Workflow** (maker → verify → re-exploit → fixer), then leave the PR
   open and comment `needs human review` — a human signs off on those.
-- **New finding** (from CI, the review, or your own work) → `gh issue create` with the right
-  `priority:` / `area:` / `severity:` labels. The backlog is self-growing until clean. Don't fix
-  out-of-scope things inline.
+- **New finding** (from CI, the review, or your own work) → **dedup first**:
+  `gh issue list --state open --search "<1-2 distinctive keywords: a table/function name or task code>"`
+  (run 2-3 narrow searches — multi-word queries AND-fail and miss matches). Only if none match →
+  `gh issue create` with `priority:` + `area:` + `severity:` labels (severity ∈ {critical, high,
+  medium} — there is no `severity:low`). Self-growing until clean; don't fix out-of-scope inline.
 - Auto mode + the repo allowlist handle permissions. Real blocker → comment on the issue and stop;
   don't thrash.
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,13 +2,10 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize, ready_for_review, reopened]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
+    # Cost: review on open / ready / reopen — NOT on every `synchronize` (every push),
+    # which re-reviews a PR on each commit and burns the OAuth-token budget. Re-trigger a
+    # fresh review by commenting `@claude review` (claude.yml) or reopening.
+    types: [opened, ready_for_review, reopened]
 
 jobs:
   claude-review:
@@ -38,7 +35,31 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
+          # Academy bar: this is an on-chain education platform where correctness and
+          # security are financial-trust-grade (on-chain XP mints, soulbound credentials,
+          # RLS-protected user data). Hold a high bar; correctness/security over style.
+          prompt: |
+            Run /code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}
+            with these Superteam Academy priorities layered on top.
+
+            First read CLAUDE.md and docs/TASK-CODES.md for conventions and the task-code system.
+            If the PR body says "Closes #N", verify the diff actually meets that issue's "Done when".
+
+            Scrutinize these hardest — the project's NEVER-ship-broken areas:
+            - RLS / supabase/schema.sql: no policy that lets a user write rows the platform later
+              trusts (user_progress, enrollments, user_xp, achievements). Trusted writes are
+              service-role-only. Flag any forgeable progress/XP path.
+            - On-chain (onchain-academy/**): checked arithmetic only (no raw +,-,*), no
+              unwrap()/expect()/panic!, stored canonical PDA bumps, validated account
+              owner/signer/PDA, pinned CPI target program IDs.
+            - Secrets: nothing server-only (ADMIN_SECRET, service-role key, RPC/Helius keys)
+              reaching a client bundle or a NEXT_PUBLIC_ var.
+            - Trust boundaries: server is authoritative — no client-trusted validation
+              (challenge "passed", XP amounts, completion flags) and no solutions/hidden tests
+              shipped in a client payload.
+
+            Output: lead with BLOCKING findings (correctness / security / does-not-meet-Done-when),
+            then non-blocking suggestions. Be decisive, cite file:line, don't pad with nits.
+            This review is ADVISORY — CI is the hard gate, and a human signs off on anything
+            touching RLS, on-chain, secrets, or mainnet (it must never imply a self-merge of those).
 


### PR DESCRIPTION
Two operational pieces for the launch loop:

- **`claude-code-review.yml`** — reviews against `CLAUDE.md`/`TASK-CODES.md`, verifies the PR meets its issue's "Done when", and scrutinizes the never-ship-broken areas (forgeable RLS, on-chain checked-arithmetic/no-unwrap, secrets-in-client, client-trusted validation). Triggers on opened/ready/reopened (drops per-push `synchronize`) to control review cost.
- **`.claude/commands/work-issue.md`** — the launch loop: one unit per run (babysit a loop PR, else advance the next issue), DONE only when BOTH gates pass (CI + Claude review), never self-merges RLS/on-chain/secrets. Drives the GitHub issues as the source of truth. Run with `/loop /work-issue` or `/goal`.

No app/program code changes.