### PR TITLE
fix(test): green the frontend test suite [P1-1]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,10 +55,9 @@ jobs:
         run: pnpm typecheck
 
       - name: Unit tests
-        # RATCHET: report-only until P1-1 (red frontend test suite) lands.
-        # Flip continue-on-error to false when `pnpm --filter web test` is green.
-        continue-on-error: true
-        # Test env defaults so unit tests run without prod secrets (see P1-1 / P0-C2).
+        # P1-1 landed: the frontend suite is green and is now a hard gate.
+        # Env defaults below mirror apps/web/vitest.setup.ts so the suite also
+        # runs without prod secrets (see P1-1 / P0-C2).
         env:
           NEXT_PUBLIC_PROGRAM_ID: 7NeJaSRyb4Wxay3Tcd9bdpD7T3GWYUQSFyrhG8SgwE8V
           NEXT_PUBLIC_SOLANA_NETWORK: devnet

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: "node",
+    setupFiles: ["./vitest.setup.ts"],
   },
   resolve: {
     alias: {

--- a/apps/web/vitest.setup.ts
+++ b/apps/web/vitest.setup.ts
@@ -1,0 +1,5 @@
+// Test env defaults. Vitest does not load .env.local into process.env, so
+// modules that read NEXT_PUBLIC_* at import time (e.g. lib/solana/pda.ts) need
+// these set before any test file is collected. Override by exporting the var.
+process.env.NEXT_PUBLIC_PROGRAM_ID ??=
+  "7NeJaSRyb4Wxay3Tcd9bdpD7T3GWYUQSFyrhG8SgwE8V";


### PR DESCRIPTION
Closes #117

## What

The frontend unit-test suite (`pnpm test`) was red: `lib/solana/pda.ts` reads `NEXT_PUBLIC_PROGRAM_ID` at import time and throws `"NEXT_PUBLIC_PROGRAM_ID env var is required"` when unset. Vitest does not load `.env.local` into `process.env`, so `pda.test.ts` failed to even collect (0 tests), while `bitmap.test.ts` passed.

## Changes

- **`apps/web/vitest.setup.ts`** (new): defaults `NEXT_PUBLIC_PROGRAM_ID` to the canonical devnet program ID `7NeJaSRyb4Wxay3Tcd9bdpD7T3GWYUQSFyrhG8SgwE8V` — the same value already in `.env.local` and the IDL `address`, and the value `pda.test.ts` asserts. Uses `??=` so a real exported env var still wins.
- **`apps/web/vitest.config.ts`**: wires the setup file via `setupFiles`. It runs before any test module is collected, so the module-level `getProgramId()` call in `pda.test.ts` sees the var.
- **`.github/workflows/ci.yml`**: flips the frontend unit-test step from the report-only ratchet (`continue-on-error: true`) to a hard gate, as the CI comment explicitly tied to P1-1 instructed once the suite is green.

## Done when (issue #117)

- `pnpm test` green → **yes**: `2 test files | 23 tests passed`.

## Verification

```
pnpm --filter @superteam-lms/web test   # 23 passed
pnpm typecheck                           # clean
pnpm lint                                # only pre-existing import-order warnings (untouched files)
prettier --check vitest.setup.ts vitest.config.ts  # clean
```

The fix is self-contained (no reliance on CI-injected env), so a fresh `pnpm test` on any machine is green.