### PR TITLE
ci(review): grant Claude review workflows write scope so reviews post

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -18,8 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write # post the review summary + inline comments on the PR
+      issues: write # PR conversation comments use the issues-comments API
       id-token: write
 
     steps:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -20,8 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write # @claude must reply / post review comments on PRs
+      issues: write # post comments on issues and PR conversations
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:


### PR DESCRIPTION
## Why

The `claude-review` check reports **"Successful"** but the Claude review gate posts nothing — verified on #158 (zero reviews, zero comments). `claude-code-action` is advisory and exits 0 regardless, so the green check is misleading.

Root cause: both Claude workflows run with `pull-requests: read` / `issues: read`. The action runs the review but cannot publish it.

Evidence (PR #158, run `28052019339`):
- Job `GITHUB_TOKEN`: `PullRequests: read`
- Result envelope: `permission_denials_count: 1`
- Post step: `No buffered inline comments`

## Change

Grant `pull-requests: write` + `issues: write` to both:
- **`claude-code-review.yml`** — auto PR review can post its summary + inline comments.
- **`claude.yml`** — the `@claude` / re-review path the loop's babysit step relies on can actually reply.

## Must merge to `main` to take effect ⚠️

`claude-code-action` validates its own workflow against the **default branch** and *skips* in agent mode when a PR modifies it:

> "The workflow file must have identical content to the version on the repository's default branch... your workflow will begin working once you merge your PR."

(Observed on #158 run `28052623321` after the same edit was placed on a feature branch.) So this fix **cannot be demonstrated on its own PR** — it only activates once on `main`.

## After merge — how to verify

1. Comment `@claude review` on an open PR (e.g. #158), or open a fresh PR.
2. Confirm a Claude review/summary comment is posted.

## Note

`needs human review` — this grants write scope to workflows that hold the `CLAUDE_CODE_OAUTH_TOKEN` secret. Not self-merged.