### PR TITLE
ci(review): force tag mode so auto-review-on-open actually posts

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -33,6 +33,11 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Without this, agent mode runs the review but never publishes it
+          # (permission_denials_count + "No buffered inline comments"). Forcing tag
+          # mode posts the review as a tracking comment — the same mechanism the
+          # @claude path uses. Supported on pull_request opened/ready_for_review/reopened.
+          track_progress: true
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           # Academy bar: this is an on-chain education platform where correctness and


### PR DESCRIPTION
## Why

Follow-up to #159. With write perms granted, the **auto review-on-open** (`claude-code-review.yml`, agent mode + `code-review` plugin) still posts nothing — run shows `permission_denials_count: 1` and `No buffered inline comments`. Agent mode doesn't create a tracking comment, and the plugin's inline-comment tool is denied by default.

The `@claude` tag path posts fine (demonstrated on #158) because tag mode publishes a tracking comment. This change forces the auto-review onto that same proven mechanism.

## Change

`track_progress: true` on the `claude-code-action@v1` step.

Per [`action.yml`](https://github.com/anthropics/claude-code-action/blob/main/action.yml): *"Force tag mode with tracking comments... Only applicable to pull_request (opened, synchronize, ready_for_review, reopened)..."* — our workflow triggers on `opened, ready_for_review, reopened`, all supported.

## Must merge to `main` to take effect ⚠️

Same constraint as #159: `claude-code-action` validates its workflow against the **default branch** and skips agent-mode runs when a PR modifies it. Can't be self-demonstrated on its own PR.

## Verify after merge

Reopen an existing PR (e.g. #158, once its workflow matches main) or open a fresh PR → confirm a Claude review **tracking comment** is posted automatically, no `@claude` nudge needed.

## Note

`needs human review` — modifies a workflow holding the `CLAUDE_CODE_OAUTH_TOKEN` secret.