### PR TITLE
feat(web): add zod env-validation layer with fail-fast boot checks (P0-C2)

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -4,6 +4,11 @@ const withNextIntl = createNextIntlPlugin("./src/lib/i18n/request.ts");
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  // Enable the instrumentation hook so src/instrumentation.ts runs at startup
+  // (validates env vars). Stable in Next 15; opt-in in Next 14.
+  experimental: {
+    instrumentationHook: true,
+  },
   transpilePackages: ["@superteam-lms/types", "@superteam-lms/sanity"],
   images: {
     remotePatterns: [

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -66,7 +66,8 @@
     "sucrase": "^3.35.1",
     "tailwind-merge": "^2.4.0",
     "tailwindcss-animate": "^1.0.7",
-    "tweetnacl": "^1.0.3"
+    "tweetnacl": "^1.0.3",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@tailwindcss/typography": "^0.5.19",

--- a/apps/web/src/instrumentation.ts
+++ b/apps/web/src/instrumentation.ts
@@ -1,0 +1,11 @@
+/**
+ * Next.js instrumentation hook — runs once at server startup.
+ * Eagerly validates environment variables so a missing/malformed var fails fast
+ * with a clear, named error instead of a deep SDK crash at first request.
+ */
+export async function register() {
+  if (process.env.NEXT_RUNTIME === "nodejs") {
+    await import("@/lib/env");
+    await import("@/lib/env.server");
+  }
+}

--- a/apps/web/src/lib/env.server.ts
+++ b/apps/web/src/lib/env.server.ts
@@ -1,0 +1,21 @@
+import "server-only";
+import { z } from "zod";
+import { formatEnvError } from "./env";
+
+/**
+ * Server-only secrets. Never imported into client code (`server-only` enforces
+ * this). Validated eagerly at boot via `instrumentation.ts`.
+ */
+const serverEnvSchema = z.object({
+  SUPABASE_SERVICE_ROLE_KEY: z.string().min(1),
+});
+
+const parsed = serverEnvSchema.safeParse({
+  SUPABASE_SERVICE_ROLE_KEY: process.env.SUPABASE_SERVICE_ROLE_KEY,
+});
+
+if (!parsed.success) {
+  throw new Error(formatEnvError("server", parsed.error));
+}
+
+export const serverEnv = parsed.data;

--- a/apps/web/src/lib/env.server.ts
+++ b/apps/web/src/lib/env.server.ts
@@ -8,10 +8,15 @@ import { formatEnvError } from "./env";
  */
 const serverEnvSchema = z.object({
   SUPABASE_SERVICE_ROLE_KEY: z.string().min(1),
+  // Optional: only needed for admin Sanity writes. Validated as non-empty when
+  // present so a blank token surfaces here rather than as a silent
+  // unauthenticated client at the Sanity API call.
+  SANITY_ADMIN_TOKEN: z.string().min(1).optional(),
 });
 
 const parsed = serverEnvSchema.safeParse({
   SUPABASE_SERVICE_ROLE_KEY: process.env.SUPABASE_SERVICE_ROLE_KEY,
+  SANITY_ADMIN_TOKEN: process.env.SANITY_ADMIN_TOKEN,
 });
 
 if (!parsed.success) {

--- a/apps/web/src/lib/env.ts
+++ b/apps/web/src/lib/env.ts
@@ -1,0 +1,48 @@
+import { z } from "zod";
+
+/**
+ * Validated environment access.
+ *
+ * This module covers the **public** (`NEXT_PUBLIC_*`) variables that are inlined
+ * into the client bundle at build time. Server-only secrets are validated in
+ * `env.server.ts`. Both are eagerly checked at boot via `instrumentation.ts` so a
+ * missing or malformed variable produces a clear, named error instead of a deep
+ * SDK crash (e.g. the `Invalid supabaseUrl` trap).
+ *
+ * NOTE: each `NEXT_PUBLIC_*` value must be referenced with a static
+ * `process.env.NEXT_PUBLIC_X` access below — Next.js only inlines literal
+ * references into the client bundle, not dynamic `process.env[key]` lookups.
+ */
+
+/** Formats a ZodError into a readable, per-variable boot error. */
+export function formatEnvError(scope: string, error: z.ZodError): string {
+  const details = error.issues
+    .map((issue) => `  - ${issue.path.join(".") || "(root)"}: ${issue.message}`)
+    .join("\n");
+  return [
+    `Invalid ${scope} environment variables:`,
+    details,
+    "",
+    "Check your environment configuration (see .env.example).",
+  ].join("\n");
+}
+
+const publicEnvSchema = z.object({
+  NEXT_PUBLIC_SUPABASE_URL: z.url(),
+  NEXT_PUBLIC_SUPABASE_ANON_KEY: z.string().min(1),
+  NEXT_PUBLIC_SANITY_PROJECT_ID: z.string().min(1),
+  NEXT_PUBLIC_SANITY_DATASET: z.string().min(1).default("production"),
+});
+
+const parsed = publicEnvSchema.safeParse({
+  NEXT_PUBLIC_SUPABASE_URL: process.env.NEXT_PUBLIC_SUPABASE_URL,
+  NEXT_PUBLIC_SUPABASE_ANON_KEY: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+  NEXT_PUBLIC_SANITY_PROJECT_ID: process.env.NEXT_PUBLIC_SANITY_PROJECT_ID,
+  NEXT_PUBLIC_SANITY_DATASET: process.env.NEXT_PUBLIC_SANITY_DATASET,
+});
+
+if (!parsed.success) {
+  throw new Error(formatEnvError("public", parsed.error));
+}
+
+export const env = parsed.data;

--- a/apps/web/src/lib/env.ts
+++ b/apps/web/src/lib/env.ts
@@ -28,7 +28,14 @@ export function formatEnvError(scope: string, error: z.ZodError): string {
 }
 
 const publicEnvSchema = z.object({
-  NEXT_PUBLIC_SUPABASE_URL: z.url(),
+  // Require https in production; allow http (e.g. localhost) in dev/test.
+  NEXT_PUBLIC_SUPABASE_URL: z
+    .url()
+    .refine(
+      (value) =>
+        process.env.NODE_ENV !== "production" || value.startsWith("https://"),
+      { error: "must use https:// in production" }
+    ),
   NEXT_PUBLIC_SUPABASE_ANON_KEY: z.string().min(1),
   NEXT_PUBLIC_SANITY_PROJECT_ID: z.string().min(1),
   NEXT_PUBLIC_SANITY_DATASET: z.string().min(1).default("production"),

--- a/apps/web/src/lib/sanity/admin-mutations.ts
+++ b/apps/web/src/lib/sanity/admin-mutations.ts
@@ -1,11 +1,12 @@
 import "server-only";
 import { createClient } from "next-sanity";
 import { env } from "@/lib/env";
+import { serverEnv } from "@/lib/env.server";
 
 const sanityAdmin = createClient({
   projectId: env.NEXT_PUBLIC_SANITY_PROJECT_ID,
   dataset: env.NEXT_PUBLIC_SANITY_DATASET,
-  token: process.env.SANITY_ADMIN_TOKEN,
+  token: serverEnv.SANITY_ADMIN_TOKEN,
   useCdn: false,
   apiVersion: "2024-01-01",
 });

--- a/apps/web/src/lib/sanity/admin-mutations.ts
+++ b/apps/web/src/lib/sanity/admin-mutations.ts
@@ -1,9 +1,10 @@
 import "server-only";
 import { createClient } from "next-sanity";
+import { env } from "@/lib/env";
 
 const sanityAdmin = createClient({
-  projectId: process.env.NEXT_PUBLIC_SANITY_PROJECT_ID!,
-  dataset: process.env.NEXT_PUBLIC_SANITY_DATASET ?? "production",
+  projectId: env.NEXT_PUBLIC_SANITY_PROJECT_ID,
+  dataset: env.NEXT_PUBLIC_SANITY_DATASET,
   token: process.env.SANITY_ADMIN_TOKEN,
   useCdn: false,
   apiVersion: "2024-01-01",

--- a/apps/web/src/lib/sanity/client.ts
+++ b/apps/web/src/lib/sanity/client.ts
@@ -1,17 +1,9 @@
 import { createClient, type QueryParams } from "next-sanity";
-
-const projectId = process.env.NEXT_PUBLIC_SANITY_PROJECT_ID;
-const dataset = process.env.NEXT_PUBLIC_SANITY_DATASET;
-
-if (!projectId || !dataset) {
-  throw new Error(
-    "Missing Sanity environment variables. Set NEXT_PUBLIC_SANITY_PROJECT_ID and NEXT_PUBLIC_SANITY_DATASET."
-  );
-}
+import { env } from "@/lib/env";
 
 export const client = createClient({
-  projectId,
-  dataset,
+  projectId: env.NEXT_PUBLIC_SANITY_PROJECT_ID,
+  dataset: env.NEXT_PUBLIC_SANITY_DATASET,
   apiVersion: "2024-01-01",
   useCdn: process.env.NODE_ENV === "production",
 });

--- a/apps/web/src/lib/supabase/admin.ts
+++ b/apps/web/src/lib/supabase/admin.ts
@@ -1,12 +1,12 @@
 import "server-only";
 import { createClient } from "@supabase/supabase-js";
+import { env } from "@/lib/env";
+import { serverEnv } from "@/lib/env.server";
 import type { Database } from "@/lib/supabase/types";
 
 export function createAdminClient() {
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
-  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
-  if (!url || !serviceKey) {
-    throw new Error("Missing Supabase env vars for admin client");
-  }
-  return createClient<Database>(url, serviceKey);
+  return createClient<Database>(
+    env.NEXT_PUBLIC_SUPABASE_URL,
+    serverEnv.SUPABASE_SERVICE_ROLE_KEY
+  );
 }

--- a/apps/web/src/lib/supabase/client.ts
+++ b/apps/web/src/lib/supabase/client.ts
@@ -2,11 +2,12 @@
 
 import { createBrowserClient } from "@supabase/ssr";
 import type { Database } from "./types";
+import { env } from "@/lib/env";
 
 export function createClient() {
   return createBrowserClient<Database>(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    env.NEXT_PUBLIC_SUPABASE_URL,
+    env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
     {
       auth: {
         // Bypass Web Locks API to prevent deadlocks in React StrictMode.

--- a/apps/web/src/lib/supabase/server.ts
+++ b/apps/web/src/lib/supabase/server.ts
@@ -1,13 +1,14 @@
 import { createServerClient } from "@supabase/ssr";
 import { cookies } from "next/headers";
 import type { Database } from "./types";
+import { env } from "@/lib/env";
 
 export async function createClient() {
   const cookieStore = await cookies();
 
   return createServerClient<Database>(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    env.NEXT_PUBLIC_SUPABASE_URL,
+    env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
     {
       cookies: {
         getAll() {

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createServerClient } from "@supabase/ssr";
 import createIntlMiddleware from "next-intl/middleware";
+import { env } from "@/lib/env";
 import { locales, defaultLocale } from "@/lib/i18n/config";
 
 const ADMIN_SESSION_MAX_AGE_MS = 86400 * 1000;
@@ -97,8 +98,8 @@ export async function middleware(request: NextRequest) {
   let supabaseResponse = NextResponse.next({ request });
 
   const supabase = createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    env.NEXT_PUBLIC_SUPABASE_URL,
+    env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
     {
       cookies: {
         getAll() {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -200,6 +200,9 @@ importers:
       tweetnacl:
         specifier: ^1.0.3
         version: 1.0.3
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@tailwindcss/typography':
         specifier: ^0.5.19
@@ -4018,6 +4021,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     resolution: {integrity: sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==}
@@ -6551,6 +6555,7 @@ packages:
   json-2-csv@5.5.10:
     resolution: {integrity: sha512-Dep8wO3Fr5wNjQevO2Z8Y7yeee/nYSGRsi7q6zJDKEVHxXkXT+v21vxHmDX923UzmCXXkSo62HaTz6eTWzFLaw==}
     engines: {node: '>= 16'}
+    deprecated: A security vulnerability has been reported with the preventCsvInjection option which has been fixed in version 5.5.11. Please upgrade as soon as possible.
 
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
@@ -7184,6 +7189,7 @@ packages:
   next-sanity@12.1.0:
     resolution: {integrity: sha512-zokqCJFxQ1EpG0LM6vfnQDydJJNI+gyf8/bAkZLyE61jVkQ/d1PehnFvKRamVFTbu2v8i1ojbzxIPp9zQ3q1gg==}
     engines: {node: '>=20.19 <22 || >=22.12'}
+    deprecated: This version is not recommended for usage with Next.js v16, please see https://www.sanity.io/docs/help/nextjs-16-sanitylive-status
     peerDependencies:
       '@sanity/client': ^7.14.1
       next: ^16.0.0-0
@@ -8650,6 +8656,7 @@ packages:
   tar@7.5.7:
     resolution: {integrity: sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==}
     engines: {node: '>=18'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   terser-webpack-plugin@5.3.16:
     resolution: {integrity: sha512-h9oBFCWrq78NyWWVcSwZarJkZ01c2AyGrzs1crmHZO3QUg9D61Wu4NPjBy69n7JqylFF5y+CsUZYmYEIZ3mR+Q==}
@@ -8797,6 +8804,7 @@ packages:
   tsconfck@3.1.6:
     resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
     engines: {node: ^18 || >=20}
+    deprecated: unmaintained
     hasBin: true
     peerDependencies:
       typescript: ^5.0.0
@@ -9112,10 +9120,12 @@ packages:
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuidv7@0.4.4:
@@ -9499,6 +9509,9 @@ packages:
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
   zustand@5.0.11:
     resolution: {integrity: sha512-fdZY+dk7zn/vbWNCYmzZULHRrss0jx5pPFiOuMZ/5HJN6Yv3u+1Wswy/4MpZEkEGhtNH+pwxZB8OKgUBPzYAGg==}
@@ -20822,6 +20835,8 @@ snapshots:
       readable-stream: 4.7.0
 
   zod@3.25.76: {}
+
+  zod@4.4.3: {}
 
   zustand@5.0.11(@types/react@18.3.28)(immer@10.2.0)(react@18.3.1)(use-sync-external-store@1.6.0(react@18.3.1)):
     optionalDependencies:


### PR DESCRIPTION
Replace the 7 unchecked `process.env.X!` assertions (Supabase URL/anon key in client/server/middleware + Sanity project id in admin-mutations) with a validated env module so a missing/placeholder var produces a clear, named error instead of a deep SDK crash (e.g. the `Invalid supabaseUrl` trap).

- src/lib/env.ts: zod schema for public NEXT_PUBLIC_* vars (URL format for the Supabase URL, non-empty keys, Sanity dataset defaulting to 'production'). Statically references each var so Next inlines them in the client bundle.
- src/lib/env.server.ts: zod schema for server-only secrets (service role key), guarded by 'server-only'.
- src/instrumentation.ts + next.config experimental.instrumentationHook: parse both at startup (nodejs runtime) so boot fails fast naming each invalid var.
- Add zod dependency (installed with pnpm 9 to keep lockfile v9).

Closes #112