### PR TITLE
docs(env): document missing env vars [P0-D1]

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,11 @@ HELIUS_API_KEY=
 # Shared secret for Helius webhook Authorization header validation
 HELIUS_WEBHOOK_SECRET=
 
+# ── AI lesson assistant (optional — server-only) ──────────────────────────────
+# Google Gemini API key for the AI chat/suggest routes (apps/web/src/app/api/ai/*).
+# Omit to disable the in-lesson AI assistant.
+GEMINI_API_KEY=
+
 # ── Auth ──────────────────────────────────────────────────────────────────────
 NEXT_PUBLIC_GOOGLE_CLIENT_ID=your-google-client-id.apps.googleusercontent.com
 
@@ -54,6 +59,9 @@ PROGRAM_AUTHORITY_SECRET=
 # On devnet: same value as PROGRAM_AUTHORITY_SECRET.
 # On mainnet: rotate to a dedicated hot wallet via update_config.
 BACKEND_SIGNER_SECRET=
+# JSON array of the XP mint authority keypair bytes (64 elements). Signs XP token
+# mints (apps/web/src/lib/solana/xp-mint.ts). Omit to disable on-chain XP minting.
+XP_MINT_AUTHORITY_SECRET=
 # Simple password for /admin dashboard (min 32 chars recommended)
 ADMIN_SECRET=
 # Write-enabled Sanity API token — create at sanity.io/manage → API → Tokens

--- a/README.md
+++ b/README.md
@@ -126,7 +126,10 @@ pnpm install
 
 # 2. Configure environment
 cp .env.example apps/web/.env.local
-# Fill in required values (see Environment Variables below)
+# Replace every placeholder with a real value — .env.example holds illustrative
+# defaults, not working credentials. Minimum to boot (see Environment Variables):
+# NEXT_PUBLIC_SUPABASE_URL, NEXT_PUBLIC_SUPABASE_ANON_KEY, SUPABASE_SERVICE_ROLE_KEY,
+# NEXT_PUBLIC_SANITY_PROJECT_ID, NEXT_PUBLIC_SANITY_DATASET.
 
 # 3. Set up the database
 # Create a Supabase project, then run supabase/schema.sql in the SQL Editor.
@@ -217,12 +220,13 @@ Copy `.env.example` to `apps/web/.env.local` and fill in values.
 
 ### Admin / Signing (Required for admin panel and on-chain operations)
 
-| Variable                   | Scope  | Description                                                                                |
-| -------------------------- | ------ | ------------------------------------------------------------------------------------------ |
-| `PROGRAM_AUTHORITY_SECRET` | Server | JSON array of authority keypair bytes (64 elements). The keypair that signed `initialize`. |
-| `BACKEND_SIGNER_SECRET`    | Server | JSON array of backend signer keypair bytes. On devnet, same as `PROGRAM_AUTHORITY_SECRET`. |
-| `ADMIN_SECRET`             | Server | Admin panel password (min 32 chars, random string)                                         |
-| `SANITY_ADMIN_TOKEN`       | Server | Write-enabled Sanity API token for course sync in admin panel                              |
+| Variable                   | Scope  | Description                                                                                      |
+| -------------------------- | ------ | ------------------------------------------------------------------------------------------------ |
+| `PROGRAM_AUTHORITY_SECRET` | Server | JSON array of authority keypair bytes (64 elements). The keypair that signed `initialize`.       |
+| `BACKEND_SIGNER_SECRET`    | Server | JSON array of backend signer keypair bytes. On devnet, same as `PROGRAM_AUTHORITY_SECRET`.       |
+| `XP_MINT_AUTHORITY_SECRET` | Server | JSON array of XP mint authority keypair bytes. Signs XP token mints; omit to disable XP minting. |
+| `ADMIN_SECRET`             | Server | Admin panel password (min 32 chars, random string)                                               |
+| `SANITY_ADMIN_TOKEN`       | Server | Write-enabled Sanity API token for course sync in admin panel                                    |
 
 ### Auth (Optional)
 
@@ -236,6 +240,12 @@ Copy `.env.example` to `apps/web/.env.local` and fill in values.
 | ---------------------- | ------ | ----------------------------------------------------------------------- |
 | `BUILD_SERVER_URL`     | Server | Cloud Run service URL                                                   |
 | `BUILD_SERVER_API_KEY` | Server | API key for `X-API-Key` header (same as `ACADEMY_API_KEY` on Cloud Run) |
+
+### AI Lesson Assistant (Optional)
+
+| Variable         | Scope  | Description                                                    |
+| ---------------- | ------ | -------------------------------------------------------------- |
+| `GEMINI_API_KEY` | Server | Google Gemini API key for the in-lesson AI chat/suggest routes |
 
 ### Analytics (Optional -- platform works without these)
 


### PR DESCRIPTION
Closes #114

Documents the two env vars used in code but absent from `.env.example` + README, plus a placeholder-replacement note at the setup step.

## Changes
- `.env.example`: add `GEMINI_API_KEY` (optional, server-only — AI chat/suggest routes) and `XP_MINT_AUTHORITY_SECRET` (JSON array of keypair bytes — signs XP token mints).
- `README.md`: add both to the env tables (new "AI Lesson Assistant" table + the Admin / Signing table) and a note at the `cp .env.example` step that placeholders must be replaced, naming the minimum-to-boot vars.

## Note
`XP_MINT_AUTHORITY_SECRET` is parsed via `JSON.parse` to a `Uint8Array` (`xp-mint.ts:63`) — a JSON byte array, not base58 — documented accordingly.

Done when: required vars are documented so a fresh clone does not hit the `Invalid supabaseUrl` trap.