### PR TITLE
fix(security): gate AI routes with auth, rate limit, and input caps (P0-B4)

### DIFF
--- a/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/lesson-client.tsx
+++ b/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/lesson-client.tsx
@@ -556,8 +556,8 @@ export function LessonPageClient({
           open={isAiChatOpen}
           onClose={() => setIsAiChatOpen(false)}
           lessonId={lesson._id}
-          lessonTitle={lesson.title}
-          lessonContent={lesson.content}
+          courseSlug={courseSlug}
+          lessonSlug={lesson.slug}
         />
       </div>
     );
@@ -802,8 +802,8 @@ export function LessonPageClient({
         open={isAiChatOpen}
         onClose={() => setIsAiChatOpen(false)}
         lessonId={lesson._id}
-        lessonTitle={lesson.title}
-        lessonContent={lesson.content}
+        courseSlug={courseSlug}
+        lessonSlug={lesson.slug}
       />
     </div>
   );

--- a/apps/web/src/app/api/ai/chat/route.ts
+++ b/apps/web/src/app/api/ai/chat/route.ts
@@ -1,6 +1,16 @@
 import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { isRateLimited } from "@/lib/rate-limit";
 
 const GEMINI_API_KEY = process.env.GEMINI_API_KEY;
+
+// Input caps (defense against oversized prompts / cost abuse).
+const MAX_BODY_CHARS = 200_000;
+const MAX_MESSAGE_CHARS = 4_000;
+const MAX_LESSON_CONTENT_CHARS = 60_000;
+const MAX_LESSON_TITLE_CHARS = 300;
+const MAX_HISTORY_MESSAGES = 20;
+const MAX_HISTORY_CHARS = 4_000;
 const GEMINI_URL =
   "https://generativelanguage.googleapis.com/v1beta/models/gemini-flash-latest:generateContent";
 
@@ -39,9 +49,41 @@ export async function POST(request: NextRequest) {
     );
   }
 
+  // Require an authenticated user.
+  const supabase = await createClient();
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+  if (authError || !user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  // Per-user rate limit (20 requests/min).
+  if (
+    isRateLimited("ai:chat", user.id, {
+      maxTokens: 20,
+      refillIntervalMs: 60_000,
+    })
+  ) {
+    return NextResponse.json(
+      { error: "Rate limit exceeded. Please wait before trying again." },
+      { status: 429 }
+    );
+  }
+
+  // Cap the raw body before parsing to reject oversized payloads.
+  const raw = await request.text();
+  if (raw.length > MAX_BODY_CHARS) {
+    return NextResponse.json(
+      { error: "Request body too large" },
+      { status: 413 }
+    );
+  }
+
   let body: ChatRequestBody;
   try {
-    body = await request.json();
+    body = JSON.parse(raw);
   } catch {
     return NextResponse.json(
       { error: "Invalid request body" },
@@ -49,12 +91,32 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  const { message, history, lessonContent, lessonTitle } = body;
+  const { message, lessonContent, lessonTitle } = body;
+  const history = Array.isArray(body.history) ? body.history : [];
 
-  if (!message || !lessonContent) {
+  if (
+    typeof message !== "string" ||
+    typeof lessonContent !== "string" ||
+    !message ||
+    !lessonContent
+  ) {
     return NextResponse.json(
       { error: "Missing required fields" },
       { status: 400 }
+    );
+  }
+
+  // Enforce per-field input caps.
+  if (
+    message.length > MAX_MESSAGE_CHARS ||
+    lessonContent.length > MAX_LESSON_CONTENT_CHARS ||
+    (lessonTitle?.length ?? 0) > MAX_LESSON_TITLE_CHARS ||
+    history.length > MAX_HISTORY_MESSAGES ||
+    history.some((m) => (m?.text?.length ?? 0) > MAX_HISTORY_CHARS)
+  ) {
+    return NextResponse.json(
+      { error: "Input exceeds maximum allowed size" },
+      { status: 413 }
     );
   }
 

--- a/apps/web/src/app/api/ai/chat/route.ts
+++ b/apps/web/src/app/api/ai/chat/route.ts
@@ -1,14 +1,16 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 import { isRateLimited } from "@/lib/rate-limit";
+import { getLessonBySlug } from "@/lib/sanity/queries";
 
 const GEMINI_API_KEY = process.env.GEMINI_API_KEY;
 
 // Input caps (defense against oversized prompts / cost abuse).
-const MAX_BODY_CHARS = 200_000;
+// Lesson content/title are fetched server-side from Sanity (not client-supplied),
+// so only the user-authored fields are capped here.
+const MAX_BODY_CHARS = 50_000;
 const MAX_MESSAGE_CHARS = 4_000;
-const MAX_LESSON_CONTENT_CHARS = 60_000;
-const MAX_LESSON_TITLE_CHARS = 300;
+const MAX_SLUG_CHARS = 256;
 const MAX_HISTORY_MESSAGES = 20;
 const MAX_HISTORY_CHARS = 4_000;
 const GEMINI_URL =
@@ -37,8 +39,8 @@ interface ChatMessage {
 interface ChatRequestBody {
   message: string;
   history: ChatMessage[];
-  lessonContent: string;
-  lessonTitle: string;
+  courseSlug: string;
+  lessonSlug: string;
 }
 
 export async function POST(request: NextRequest) {
@@ -91,14 +93,16 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  const { message, lessonContent, lessonTitle } = body;
+  const { message, courseSlug, lessonSlug } = body;
   const history = Array.isArray(body.history) ? body.history : [];
 
   if (
     typeof message !== "string" ||
-    typeof lessonContent !== "string" ||
+    typeof courseSlug !== "string" ||
+    typeof lessonSlug !== "string" ||
     !message ||
-    !lessonContent
+    !courseSlug ||
+    !lessonSlug
   ) {
     return NextResponse.json(
       { error: "Missing required fields" },
@@ -106,11 +110,11 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  // Enforce per-field input caps.
+  // Enforce per-field input caps on the user-authored fields.
   if (
     message.length > MAX_MESSAGE_CHARS ||
-    lessonContent.length > MAX_LESSON_CONTENT_CHARS ||
-    (lessonTitle?.length ?? 0) > MAX_LESSON_TITLE_CHARS ||
+    courseSlug.length > MAX_SLUG_CHARS ||
+    lessonSlug.length > MAX_SLUG_CHARS ||
     history.length > MAX_HISTORY_MESSAGES ||
     history.some((m) => (m?.text?.length ?? 0) > MAX_HISTORY_CHARS)
   ) {
@@ -119,6 +123,17 @@ export async function POST(request: NextRequest) {
       { status: 413 }
     );
   }
+
+  // Resolve lesson content server-side from Sanity. Never trust client-supplied
+  // lesson text — interpolating it into the system prompt is a prompt-injection
+  // surface (a caller could send a fake "--- END LESSON ---" to escape the guard).
+  const lesson = await getLessonBySlug(courseSlug, lessonSlug);
+  if (!lesson) {
+    return NextResponse.json({ error: "Lesson not found" }, { status: 404 });
+  }
+  const lessonTitle = lesson.title;
+  const lessonContent =
+    typeof lesson.content === "string" ? lesson.content : "";
 
   // Build conversation history for Gemini
   const contents = [

--- a/apps/web/src/app/api/ai/chat/route.ts
+++ b/apps/web/src/app/api/ai/chat/route.ts
@@ -70,7 +70,7 @@ export async function POST(request: NextRequest) {
   ) {
     return NextResponse.json(
       { error: "Rate limit exceeded. Please wait before trying again." },
-      { status: 429 }
+      { status: 429, headers: { "Retry-After": "60" } }
     );
   }
 
@@ -154,10 +154,12 @@ export async function POST(request: NextRequest) {
         },
       ],
     },
-    // Append chat history
+    // Append chat history. Sanitize role (only "user"/"model" are valid for
+    // Gemini) and coerce text to a string so a malformed client payload can't
+    // break the API call or inject an unexpected role.
     ...history.map((msg) => ({
-      role: msg.role,
-      parts: [{ text: msg.text }],
+      role: msg.role === "model" ? "model" : "user",
+      parts: [{ text: typeof msg.text === "string" ? msg.text : "" }],
     })),
     // Current message
     {

--- a/apps/web/src/app/api/ai/suggest/route.ts
+++ b/apps/web/src/app/api/ai/suggest/route.ts
@@ -1,6 +1,15 @@
 import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { isRateLimited } from "@/lib/rate-limit";
 
 const GEMINI_API_KEY = process.env.GEMINI_API_KEY;
+
+// Input caps (defense against oversized prompts / cost abuse).
+const MAX_BODY_CHARS = 120_000;
+const MAX_CODE_CHARS = 20_000;
+const MAX_DESCRIPTION_CHARS = 5_000;
+const MAX_CONSOLE_CHARS = 10_000;
+const MAX_TEST_ITEMS = 50;
 const GEMINI_URL =
   "https://generativelanguage.googleapis.com/v1beta/models/gemini-flash-latest:generateContent";
 
@@ -38,9 +47,41 @@ export async function POST(request: NextRequest) {
     );
   }
 
+  // Require an authenticated user.
+  const supabase = await createClient();
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+  if (authError || !user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  // Per-user rate limit (10 requests/min — heavier generation than chat).
+  if (
+    isRateLimited("ai:suggest", user.id, {
+      maxTokens: 10,
+      refillIntervalMs: 60_000,
+    })
+  ) {
+    return NextResponse.json(
+      { error: "Rate limit exceeded. Please wait before trying again." },
+      { status: 429 }
+    );
+  }
+
+  // Cap the raw body before parsing to reject oversized payloads.
+  const raw = await request.text();
+  if (raw.length > MAX_BODY_CHARS) {
+    return NextResponse.json(
+      { error: "Request body too large" },
+      { status: 413 }
+    );
+  }
+
   let body: SuggestRequestBody;
   try {
-    body = await request.json();
+    body = JSON.parse(raw);
   } catch {
     return NextResponse.json(
       { error: "Invalid request body" },
@@ -51,10 +92,29 @@ export async function POST(request: NextRequest) {
   const { code, tests, testResults, consoleOutput, description, language } =
     body;
 
-  if (!code || !language) {
+  if (
+    typeof code !== "string" ||
+    typeof language !== "string" ||
+    !code ||
+    !language
+  ) {
     return NextResponse.json(
       { error: "Missing required fields" },
       { status: 400 }
+    );
+  }
+
+  // Enforce per-field input caps.
+  if (
+    code.length > MAX_CODE_CHARS ||
+    (description?.length ?? 0) > MAX_DESCRIPTION_CHARS ||
+    (consoleOutput?.length ?? 0) > MAX_CONSOLE_CHARS ||
+    (tests?.length ?? 0) > MAX_TEST_ITEMS ||
+    (testResults?.length ?? 0) > MAX_TEST_ITEMS
+  ) {
+    return NextResponse.json(
+      { error: "Input exceeds maximum allowed size" },
+      { status: 413 }
     );
   }
 

--- a/apps/web/src/app/api/ai/suggest/route.ts
+++ b/apps/web/src/app/api/ai/suggest/route.ts
@@ -68,7 +68,7 @@ export async function POST(request: NextRequest) {
   ) {
     return NextResponse.json(
       { error: "Rate limit exceeded. Please wait before trying again." },
-      { status: 429 }
+      { status: 429, headers: { "Retry-After": "60" } }
     );
   }
 

--- a/apps/web/src/app/api/ai/suggest/route.ts
+++ b/apps/web/src/app/api/ai/suggest/route.ts
@@ -10,6 +10,8 @@ const MAX_CODE_CHARS = 20_000;
 const MAX_DESCRIPTION_CHARS = 5_000;
 const MAX_CONSOLE_CHARS = 10_000;
 const MAX_TEST_ITEMS = 50;
+const MAX_TEST_DESCRIPTION_CHARS = 500;
+const MAX_TEST_IO_CHARS = 2_000;
 const GEMINI_URL =
   "https://generativelanguage.googleapis.com/v1beta/models/gemini-flash-latest:generateContent";
 
@@ -104,13 +106,26 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  // Enforce per-field input caps.
+  // Enforce per-field input caps, including per-item caps on test arrays —
+  // each item's strings are interpolated into the prompt, so array length
+  // alone isn't enough to bound attacker-controlled text.
   if (
     code.length > MAX_CODE_CHARS ||
     (description?.length ?? 0) > MAX_DESCRIPTION_CHARS ||
     (consoleOutput?.length ?? 0) > MAX_CONSOLE_CHARS ||
     (tests?.length ?? 0) > MAX_TEST_ITEMS ||
-    (testResults?.length ?? 0) > MAX_TEST_ITEMS
+    (testResults?.length ?? 0) > MAX_TEST_ITEMS ||
+    tests?.some(
+      (t) =>
+        (t?.description?.length ?? 0) > MAX_TEST_DESCRIPTION_CHARS ||
+        (t?.input?.length ?? 0) > MAX_TEST_IO_CHARS ||
+        (t?.expectedOutput?.length ?? 0) > MAX_TEST_IO_CHARS
+    ) ||
+    testResults?.some(
+      (r) =>
+        (r?.description?.length ?? 0) > MAX_TEST_DESCRIPTION_CHARS ||
+        (r?.actual?.length ?? 0) > MAX_TEST_IO_CHARS
+    )
   ) {
     return NextResponse.json(
       { error: "Input exceeds maximum allowed size" },

--- a/apps/web/src/components/ai/ai-chat-sidebar.tsx
+++ b/apps/web/src/components/ai/ai-chat-sidebar.tsx
@@ -25,16 +25,16 @@ interface AiChatSidebarProps {
   open: boolean;
   onClose: () => void;
   lessonId: string;
-  lessonTitle: string;
-  lessonContent: string;
+  courseSlug: string;
+  lessonSlug: string;
 }
 
 export function AiChatSidebar({
   open,
   onClose,
   lessonId,
-  lessonTitle,
-  lessonContent,
+  courseSlug,
+  lessonSlug,
 }: AiChatSidebarProps) {
   const t = useTranslations("lesson");
 
@@ -87,8 +87,8 @@ export function AiChatSidebar({
         body: JSON.stringify({
           message: trimmed,
           history: messages,
-          lessonContent,
-          lessonTitle,
+          courseSlug,
+          lessonSlug,
         }),
       });
 
@@ -109,7 +109,7 @@ export function AiChatSidebar({
     } finally {
       setIsLoading(false);
     }
-  }, [input, isLoading, limitReached, messages, lessonContent, lessonTitle, t]);
+  }, [input, isLoading, limitReached, messages, courseSlug, lessonSlug, t]);
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLTextAreaElement>) => {


### PR DESCRIPTION
The ai/chat and ai/suggest routes were unauthenticated and uncapped — anyone could drive Gemini cost and exfiltrate quota. Add:

- supabase.auth.getUser() guard → 401 for unauthenticated callers.
- Per-user rate limiting via the shared isRateLimited helper (chat 20/min, suggest 10/min). Keyed by user id; namespaced ai:chat / ai:suggest.
- Input caps: a raw-body size guard (413) plus per-field length/count caps (message/lessonContent/history for chat; code/description/console/test counts for suggest), and stricter type checks on required fields.

Rate limiting reuses the in-memory helper used across the community routes; moving it to a shared store is tracked by P1-7.

Closes #115