### PR TITLE
fix(security): split server/browser RPC env + remove silent devnet fallback (P0-C7)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,7 +9,14 @@ NEXT_PUBLIC_SANITY_DATASET=production
 SANITY_API_TOKEN=                          # Only needed for seed import (sanity/seed/import.mjs)
 
 # ── Solana ────────────────────────────────────────────────────────────────────
-NEXT_PUBLIC_SOLANA_RPC_URL=https://devnet.helius-rpc.com/?api-key=YOUR_KEY
+# PUBLIC browser RPC endpoint — inlined into the client bundle. MUST NOT carry a
+# privileged Helius API key. Use a rate-limited public endpoint or a Helius
+# domain-restricted key safe for client exposure.
+NEXT_PUBLIC_SOLANA_RPC_URL=https://api.devnet.solana.com
+# SERVER-ONLY RPC endpoint — never sent to the browser (`server-only` enforced).
+# This is the one that may carry the privileged Helius API key. Required: a
+# missing value fails loudly at boot instead of silently using public devnet.
+SOLANA_RPC_URL=https://devnet.helius-rpc.com/?api-key=YOUR_KEY
 NEXT_PUBLIC_SOLANA_NETWORK=devnet
 
 # On-chain program (see docs/DEPLOY-PROGRAM.md for deployment guide)

--- a/apps/web/src/app/api/admin/achievements/sync/route.ts
+++ b/apps/web/src/app/api/admin/achievements/sync/route.ts
@@ -2,6 +2,7 @@ import "server-only";
 
 import { NextRequest, NextResponse } from "next/server";
 import { Connection, PublicKey } from "@solana/web3.js";
+import { serverEnv } from "@/lib/env.server";
 import {
   requireAdminAuth,
   adminUnauthorizedResponse,
@@ -67,9 +68,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     );
   }
 
-  const rpcUrl =
-    process.env.NEXT_PUBLIC_SOLANA_RPC_URL ?? "https://api.devnet.solana.com";
-  const connection = new Connection(rpcUrl, "confirmed");
+  const connection = new Connection(serverEnv.SOLANA_RPC_URL, "confirmed");
   const [achPda] = findAchievementTypePDA(achievementId, getProgramId());
   const accountInfo = await connection.getAccountInfo(achPda);
 

--- a/apps/web/src/app/api/admin/courses/sync/route.ts
+++ b/apps/web/src/app/api/admin/courses/sync/route.ts
@@ -2,6 +2,7 @@ import "server-only";
 
 import { NextRequest, NextResponse } from "next/server";
 import { Connection } from "@solana/web3.js";
+import { serverEnv } from "@/lib/env.server";
 import {
   requireAdminAuth,
   adminUnauthorizedResponse,
@@ -77,9 +78,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     );
   }
 
-  const rpcUrl =
-    process.env.NEXT_PUBLIC_SOLANA_RPC_URL ?? "https://api.devnet.solana.com";
-  const connection = new Connection(rpcUrl, "confirmed");
+  const connection = new Connection(serverEnv.SOLANA_RPC_URL, "confirmed");
   const [coursePda] = findCoursePDA(courseId, getProgramId());
   const accountInfo = await connection.getAccountInfo(coursePda);
 

--- a/apps/web/src/app/api/admin/resync/route.ts
+++ b/apps/web/src/app/api/admin/resync/route.ts
@@ -8,6 +8,7 @@ import {
   getAssociatedTokenAddressSync,
   TOKEN_2022_PROGRAM_ID,
 } from "@solana/spl-token";
+import { serverEnv } from "@/lib/env.server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import {
   fetchEnrollment,
@@ -38,9 +39,8 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const rpcUrl = process.env.NEXT_PUBLIC_SOLANA_RPC_URL;
   const xpMintAddress = process.env.NEXT_PUBLIC_XP_MINT_ADDRESS;
-  if (!rpcUrl || !xpMintAddress) {
+  if (!xpMintAddress) {
     return NextResponse.json(
       { error: "Server misconfigured" },
       { status: 500 }
@@ -67,7 +67,7 @@ export async function POST(req: NextRequest) {
   }
 
   const supabase = createAdminClient();
-  const connection = new Connection(rpcUrl);
+  const connection = new Connection(serverEnv.SOLANA_RPC_URL);
   const wallet = new PublicKey(walletAddress);
   const XP_MINT = new PublicKey(xpMintAddress);
 

--- a/apps/web/src/app/api/admin/status/route.ts
+++ b/apps/web/src/app/api/admin/status/route.ts
@@ -2,6 +2,7 @@ import "server-only";
 
 import { NextRequest, NextResponse } from "next/server";
 import { Connection } from "@solana/web3.js";
+import { serverEnv } from "@/lib/env.server";
 import {
   requireAdminAuth,
   adminUnauthorizedResponse,
@@ -34,9 +35,7 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
     throw e;
   }
 
-  const rpcUrl =
-    process.env.NEXT_PUBLIC_SOLANA_RPC_URL ?? "https://api.devnet.solana.com";
-  const connection = new Connection(rpcUrl, "confirmed");
+  const connection = new Connection(serverEnv.SOLANA_RPC_URL, "confirmed");
 
   const [courses, achievements, authorityCheck] = await Promise.all([
     getAllCoursesAdmin(),

--- a/apps/web/src/lib/env.server.ts
+++ b/apps/web/src/lib/env.server.ts
@@ -8,6 +8,11 @@ import { formatEnvError } from "./env";
  */
 const serverEnvSchema = z.object({
   SUPABASE_SERVICE_ROLE_KEY: z.string().min(1),
+  // Server-only Solana RPC endpoint. This is the one that may carry a
+  // privileged Helius API key — it is never inlined into the client bundle
+  // (`server-only` enforces that). Required so a misconfigured deployment
+  // fails loudly here instead of silently falling back to public devnet.
+  SOLANA_RPC_URL: z.url(),
   // Optional: only needed for admin Sanity writes. Validated as non-empty when
   // present so a blank token surfaces here rather than as a silent
   // unauthenticated client at the Sanity API call.
@@ -16,6 +21,7 @@ const serverEnvSchema = z.object({
 
 const parsed = serverEnvSchema.safeParse({
   SUPABASE_SERVICE_ROLE_KEY: process.env.SUPABASE_SERVICE_ROLE_KEY,
+  SOLANA_RPC_URL: process.env.SOLANA_RPC_URL,
   SANITY_ADMIN_TOKEN: process.env.SANITY_ADMIN_TOKEN,
 });
 

--- a/apps/web/src/lib/env.ts
+++ b/apps/web/src/lib/env.ts
@@ -39,6 +39,10 @@ const publicEnvSchema = z.object({
   NEXT_PUBLIC_SUPABASE_ANON_KEY: z.string().min(1),
   NEXT_PUBLIC_SANITY_PROJECT_ID: z.string().min(1),
   NEXT_PUBLIC_SANITY_DATASET: z.string().min(1).default("production"),
+  // Public, rate-limited browser RPC endpoint. MUST NOT carry a privileged
+  // Helius API key — it is inlined into the client bundle. The Helius-keyed
+  // endpoint lives server-side as SOLANA_RPC_URL in env.server.ts.
+  NEXT_PUBLIC_SOLANA_RPC_URL: z.url(),
 });
 
 const parsed = publicEnvSchema.safeParse({
@@ -46,6 +50,7 @@ const parsed = publicEnvSchema.safeParse({
   NEXT_PUBLIC_SUPABASE_ANON_KEY: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
   NEXT_PUBLIC_SANITY_PROJECT_ID: process.env.NEXT_PUBLIC_SANITY_PROJECT_ID,
   NEXT_PUBLIC_SANITY_DATASET: process.env.NEXT_PUBLIC_SANITY_DATASET,
+  NEXT_PUBLIC_SOLANA_RPC_URL: process.env.NEXT_PUBLIC_SOLANA_RPC_URL,
 });
 
 if (!parsed.success) {

--- a/apps/web/src/lib/services/hybrid-progress-service.ts
+++ b/apps/web/src/lib/services/hybrid-progress-service.ts
@@ -6,12 +6,13 @@ import type {
   Credential,
 } from "@superteam-lms/types";
 import type { SupabaseClient } from "@supabase/supabase-js";
-import { Connection, PublicKey, clusterApiUrl } from "@solana/web3.js";
+import { Connection, PublicKey } from "@solana/web3.js";
 import {
   getAccount,
   getAssociatedTokenAddressSync,
   TOKEN_2022_PROGRAM_ID,
 } from "@solana/spl-token";
+import { env } from "@/lib/env";
 import type { Database } from "@/lib/supabase/types";
 
 // ---------------------------------------------------------------------------
@@ -30,9 +31,10 @@ export class HybridProgressService implements LearningProgressService {
   private readonly xpMint: PublicKey | null;
 
   constructor(private readonly supabase: SupabaseClient<Database>) {
-    const rpcUrl =
-      process.env.NEXT_PUBLIC_SOLANA_RPC_URL ?? clusterApiUrl("devnet");
-    this.connection = new Connection(rpcUrl);
+    // This service runs in the browser (dashboard/profile client pages), so it
+    // uses the public, rate-limited RPC endpoint. XP balance reads are
+    // non-privileged and do not need the server-only Helius-keyed endpoint.
+    this.connection = new Connection(env.NEXT_PUBLIC_SOLANA_RPC_URL);
 
     const mintAddress = process.env.NEXT_PUBLIC_XP_MINT_ADDRESS;
     this.xpMint = mintAddress ? new PublicKey(mintAddress) : null;

--- a/apps/web/src/lib/solana/academy-program.ts
+++ b/apps/web/src/lib/solana/academy-program.ts
@@ -6,7 +6,6 @@ import {
   SystemProgram,
   PublicKey,
   TransactionInstruction,
-  clusterApiUrl,
 } from "@solana/web3.js";
 import { BN } from "@coral-xyz/anchor";
 import {
@@ -28,6 +27,7 @@ import {
   findMinterRolePDA,
   getProgramId,
 } from "./pda";
+import { serverEnv } from "@/lib/env.server";
 
 export { getProgramId } from "./pda";
 
@@ -81,9 +81,7 @@ let _connection: Connection | null = null;
 
 export function getConnection(): Connection {
   if (_connection) return _connection;
-  const rpcUrl =
-    process.env.NEXT_PUBLIC_SOLANA_RPC_URL ?? clusterApiUrl("devnet");
-  _connection = new Connection(rpcUrl, "confirmed");
+  _connection = new Connection(serverEnv.SOLANA_RPC_URL, "confirmed");
   return _connection;
 }
 

--- a/apps/web/src/lib/solana/admin-signer.ts
+++ b/apps/web/src/lib/solana/admin-signer.ts
@@ -11,13 +11,7 @@
  */
 import "server-only";
 
-import {
-  Connection,
-  Keypair,
-  PublicKey,
-  SystemProgram,
-  clusterApiUrl,
-} from "@solana/web3.js";
+import { Connection, Keypair, PublicKey, SystemProgram } from "@solana/web3.js";
 import { AnchorProvider, Program } from "@coral-xyz/anchor";
 import type { Idl } from "@coral-xyz/anchor";
 import NodeWallet from "@coral-xyz/anchor/dist/cjs/nodewallet";
@@ -36,6 +30,7 @@ import {
   findAchievementTypePDA,
   getProgramId,
 } from "./pda";
+import { serverEnv } from "@/lib/env.server";
 
 // ---------------------------------------------------------------------------
 // Anchor method builder types — mirrors the pattern in academy-program.ts
@@ -161,9 +156,7 @@ function initialize(): { ready: boolean } {
   }
   _initialized = true;
 
-  const rpcUrl =
-    process.env.NEXT_PUBLIC_SOLANA_RPC_URL ?? clusterApiUrl("devnet");
-  _connection = new Connection(rpcUrl, "confirmed");
+  _connection = new Connection(serverEnv.SOLANA_RPC_URL, "confirmed");
 
   const authoritySecret = process.env.PROGRAM_AUTHORITY_SECRET;
   if (!authoritySecret) {
@@ -429,11 +422,9 @@ export async function deployCourseTrackCollection(params: {
   }
 
   try {
-    const rpcUrl =
-      process.env.NEXT_PUBLIC_SOLANA_RPC_URL ?? clusterApiUrl("devnet");
     const [configPDA] = findConfigPDA(getProgramId());
 
-    const umi = createUmi(rpcUrl)
+    const umi = createUmi(serverEnv.SOLANA_RPC_URL)
       .use(mplCore())
       .use(keypairIdentity(fromWeb3JsKeypair(_authority)));
 

--- a/apps/web/src/lib/solana/wallet-provider.tsx
+++ b/apps/web/src/lib/solana/wallet-provider.tsx
@@ -7,7 +7,7 @@ import {
   WalletProvider,
 } from "@solana/wallet-adapter-react";
 import { WalletModalProvider } from "@solana/wallet-adapter-react-ui";
-import { clusterApiUrl } from "@solana/web3.js";
+import { env } from "@/lib/env";
 import { WalletAuthHandler } from "@/components/auth/wallet-auth-handler";
 
 import "@solana/wallet-adapter-react-ui/styles.css";
@@ -17,10 +17,7 @@ interface SolanaWalletProviderProps {
 }
 
 export function SolanaWalletProvider({ children }: SolanaWalletProviderProps) {
-  const endpoint = useMemo(
-    () => process.env.NEXT_PUBLIC_SOLANA_RPC_URL ?? clusterApiUrl("devnet"),
-    []
-  );
+  const endpoint = useMemo(() => env.NEXT_PUBLIC_SOLANA_RPC_URL, []);
 
   // Wallet Standard auto-discovers installed wallets (Phantom, Solflare,
   // Backpack, MetaMask Snap, etc.)

--- a/apps/web/src/lib/solana/xp-mint.ts
+++ b/apps/web/src/lib/solana/xp-mint.ts
@@ -13,7 +13,7 @@ import "server-only";
  * This module must ONLY be imported from API routes (server-side).
  */
 
-import { Connection, Keypair, PublicKey, clusterApiUrl } from "@solana/web3.js";
+import { Connection, Keypair, PublicKey } from "@solana/web3.js";
 import {
   burn,
   getAccount,
@@ -22,6 +22,7 @@ import {
   mintTo,
   TOKEN_2022_PROGRAM_ID,
 } from "@solana/spl-token";
+import { serverEnv } from "@/lib/env.server";
 
 // ---------------------------------------------------------------------------
 // Lazy-loaded singletons (initialized on first call)
@@ -38,9 +39,7 @@ function initialize(): { ready: boolean } {
   }
   _initialized = true;
 
-  const rpcUrl =
-    process.env.NEXT_PUBLIC_SOLANA_RPC_URL ?? clusterApiUrl("devnet");
-  _connection = new Connection(rpcUrl, "confirmed");
+  _connection = new Connection(serverEnv.SOLANA_RPC_URL, "confirmed");
 
   const mintAddress = process.env.NEXT_PUBLIC_XP_MINT_ADDRESS;
   if (!mintAddress) {


### PR DESCRIPTION
Closes #154

## Problem
The Helius API key shipped in the **public client bundle** via `NEXT_PUBLIC_SOLANA_RPC_URL`, and every RPC consumer silently fell back to devnet (`?? clusterApiUrl("devnet")` / `?? "https://api.devnet.solana.com"`) when config was missing — so a misconfigured production deploy would silently run against public devnet instead of failing.

## Changes
Built on the validated env layer (PR #162).

**Env split**
- `env.server.ts`: added server-only **`SOLANA_RPC_URL`** (the endpoint that may carry the Helius key; `import "server-only"` keeps it out of the client bundle). Required → missing value throws at boot.
- `env.ts`: **`NEXT_PUBLIC_SOLANA_RPC_URL`** is now validated as the public, non-privileged browser endpoint.

**Server-side RPC → `serverEnv.SOLANA_RPC_URL`**
- `lib/solana/academy-program.ts` (`getConnection`)
- `lib/solana/admin-signer.ts` (×2: signer connection + `createUmi`)
- `lib/solana/xp-mint.ts`
- `app/api/admin/status/route.ts`, `app/api/admin/courses/sync/route.ts`, `app/api/admin/achievements/sync/route.ts`, `app/api/admin/resync/route.ts`

**Browser/client RPC → `env.NEXT_PUBLIC_SOLANA_RPC_URL`**
- `lib/solana/wallet-provider.tsx`
- `lib/services/hybrid-progress-service.ts` (runs in dashboard/profile client pages; XP reads are non-privileged)

**Fail-loud**
- Removed every `?? clusterApiUrl("devnet")` and `?? "https://api.devnet.solana.com"` silent fallback. Missing RPC config now throws via the env layer instead of defaulting to devnet.

**Docs**
- `.env.example` documents the split: public non-keyed `NEXT_PUBLIC_SOLANA_RPC_URL` vs server-only Helius-keyed `SOLANA_RPC_URL`.

> Note: a public, non-privileged `NEXT_PUBLIC_SOLANA_RPC_URL` value must be provisioned per environment (a rate-limited public RPC or a Helius **domain-restricted** key safe for client exposure). `.env.example` uses `https://api.devnet.solana.com` as the placeholder.

## Verification
- `pnpm --filter @superteam-lms/web typecheck` → **pass** (exit 0)
- `pnpm --filter @superteam-lms/web build` → **pass**. This is the real proof of the boundary: any server-only module (`import "server-only"`) pulled into a client/edge bundle would make the build throw — it didn't.
- **Client-bundle leak grep** (built with a sentinel `SOLANA_RPC_URL` host + `LEAK_CANARY` api-key):
  - server sentinel host **absent** from `.next/static` ✅
  - leak-canary api-key **absent** from `.next/static` ✅
  - server value present in `.next/server` (expected) ✅
  - public devnet endpoint present in `.next/static` (expected) ✅
- Confirmed the Zod schema rejects a missing `SOLANA_RPC_URL` (throws, no devnet default).

**Done when** ✅ no Helius key reaches the client bundle AND missing RPC config throws instead of defaulting to devnet.