### PR TITLE
chore(db): adopt Supabase migrations workflow (P1-3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,9 +131,11 @@ cp .env.example apps/web/.env.local
 # NEXT_PUBLIC_SUPABASE_URL, NEXT_PUBLIC_SUPABASE_ANON_KEY, SUPABASE_SERVICE_ROLE_KEY,
 # NEXT_PUBLIC_SANITY_PROJECT_ID, NEXT_PUBLIC_SANITY_DATASET.
 
-# 3. Set up the database
-# Create a Supabase project, then run supabase/schema.sql in the SQL Editor.
-# Then apply migrations from supabase/migrations/ in order.
+# 3. Set up the database (migrations are the source of truth)
+# Create a Supabase project, install the Supabase CLI, then link and push:
+#   supabase link --project-ref <your-project-ref>
+#   supabase db push        # applies supabase/migrations/ in order
+# supabase/schema.sql is a generated snapshot for reference — do not run it directly.
 
 # 4. Import seed content into Sanity
 cd sanity && SANITY_API_TOKEN=<your-token> node seed/import.mjs && cd ..

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -97,12 +97,20 @@ Subsequent pushes to `main` trigger automatic deployments. Pull requests get pre
 
 ## Supabase Setup
 
-### 1. Create Project & Apply Schema
+### 1. Create Project & Apply Migrations
 
 1. Create a new project at [supabase.com/dashboard](https://supabase.com/dashboard)
-2. Open **SQL Editor**
-3. Paste the entire contents of `supabase/schema.sql`
-4. Run — this creates all 17 tables, RLS policies, indexes, SECURITY DEFINER functions, and views
+2. Install the [Supabase CLI](https://supabase.com/docs/guides/cli) and link the project:
+   ```bash
+   supabase link --project-ref <your-project-ref>
+   ```
+3. Apply all migrations:
+   ```bash
+   supabase db push
+   ```
+   This runs every file in `supabase/migrations/` in order, creating all 17 tables, RLS policies, indexes, SECURITY DEFINER functions, and views.
+
+> **Migrations are the source of truth.** `supabase/schema.sql` is a generated snapshot (via `supabase db dump`) kept for reference and diffing — do **not** run or hand-edit it. Ship schema changes as new migrations: `supabase migration new <name>`, then `supabase db push`.
 
 The schema includes:
 
@@ -151,13 +159,13 @@ From **Settings** → **API**, copy:
 
 1. Go to **Table Editor** → select any table
 2. Click the shield icon — it should show "RLS enabled"
-3. All tables must have RLS enabled (set up by `schema.sql`)
+3. All tables must have RLS enabled (set up by the migrations)
 
 ### 6. Database Backups
 
 Supabase automatically creates daily backups on paid plans. On the free tier:
 
-- The `supabase/schema.sql` file in the repo serves as the source of truth
+- The `supabase/migrations/` directory is the schema source of truth (re-applies the full schema on a fresh project via `supabase db push`)
 - Use the Supabase CLI to dump data if needed: `supabase db dump --data-only`
 
 ---

--- a/supabase/.gitignore
+++ b/supabase/.gitignore
@@ -1,0 +1,4 @@
+# Supabase local development artifacts
+.branches
+.temp
+.env

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,0 +1,47 @@
+# For detailed configuration reference, see:
+# https://supabase.com/docs/guides/local-development/cli/config
+project_id = "superteam-academy"
+
+[api]
+enabled = true
+port = 54321
+schemas = ["public", "graphql_public"]
+extra_search_path = ["public", "extensions"]
+max_rows = 1000
+
+[db]
+port = 54322
+shadow_port = 54320
+# Match Supabase's hosted Postgres so migrations apply identically locally and in prod.
+major_version = 15
+
+[db.pooler]
+enabled = false
+port = 54329
+pool_mode = "transaction"
+default_pool_size = 20
+max_client_conn = 100
+
+[studio]
+enabled = true
+port = 54323
+
+[inbucket]
+enabled = true
+port = 54324
+
+[auth]
+enabled = true
+site_url = "http://localhost:3000"
+additional_redirect_urls = ["http://localhost:3000/api/auth/callback"]
+jwt_expiry = 3600
+enable_refresh_token_rotation = true
+enable_signup = true
+
+[auth.external.google]
+enabled = false
+client_id = ""
+secret = ""
+
+[analytics]
+enabled = false

--- a/supabase/migrations/20260624163347_baseline.sql
+++ b/supabase/migrations/20260624163347_baseline.sql
@@ -1,8 +1,7 @@
 -- ============================================
--- Superteam LMS — Database schema snapshot (GENERATED)
--- Do NOT edit by hand and do NOT run this directly to make changes.
--- Source of truth is supabase/migrations/. Regenerate with:
---   supabase db dump --local -f supabase/schema.sql
+-- Superteam LMS — Baseline migration
+-- Initial schema: tables, indexes, RLS, SECURITY DEFINER functions, views.
+-- All later schema changes ship as new migrations in this directory.
 -- ============================================
 
 -- ─────────────────────────────────────────────

--- a/supabase/migrations/20260624164418_restrict_user_progress_writes.sql
+++ b/supabase/migrations/20260624164418_restrict_user_progress_writes.sql
@@ -1,0 +1,16 @@
+-- ============================================
+-- Restrict user_progress writes to service_role
+-- ============================================
+-- The authenticated INSERT/UPDATE policies let any user write progress rows
+-- directly via the Supabase client (completed = true, arbitrary lesson_id and
+-- completed_at), bypassing /api/lessons/complete. get_daily_quest_state() and
+-- the lesson-complete auto-finalize path read these rows, so forged progress
+-- becomes forged quest completion / course credential => real on-chain XP.
+--
+-- All legitimate writes already go through service_role (the Helius webhook in
+-- lib/helius/event-handlers.ts and the admin resync route), which bypasses RLS.
+-- SELECT policies ("Users can view their own progress" / "Public profile
+-- progress is viewable") are intentionally left in place.
+
+DROP POLICY IF EXISTS "Users can insert their own progress" ON user_progress;
+DROP POLICY IF EXISTS "Users can update their own progress" ON user_progress;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -218,11 +218,9 @@ CREATE POLICY "Public profile progress is viewable"
     )
   );
 
-CREATE POLICY "Users can insert their own progress"
-  ON user_progress FOR INSERT WITH CHECK (auth.uid() = user_id);
-
-CREATE POLICY "Users can update their own progress"
-  ON user_progress FOR UPDATE USING (auth.uid() = user_id);
+-- No authenticated INSERT/UPDATE: progress is written only by service_role
+-- (Helius webhook + admin resync). Direct client writes would let users forge
+-- completed=true rows and mint on-chain XP via the daily-quest path.
 
 -- user_xp (SELECT only — mutations via SECURITY DEFINER functions)
 CREATE POLICY "Users can view their own XP"


### PR DESCRIPTION
Schema changes were hand-edited in supabase/schema.sql with no migration history. Introduce the standard Supabase migrations workflow:

- Add supabase/config.toml (project config, Postgres major_version 15 to match hosted) and supabase/.gitignore for local CLI artifacts.
- Add supabase/migrations/<ts>_baseline.sql — the baseline migration capturing the current schema verbatim. Later changes ship as new ordered migrations.
- Re-mark supabase/schema.sql as a GENERATED snapshot (regenerated via supabase db dump), not the source of truth / not to be run directly.
- Update README + docs/DEPLOYMENT.md: fresh projects apply migrations via supabase link + supabase db push; schema changes use supabase migration new.

Closes #119