### PR TITLE
fix(security): stop passing ADMIN_SECRET into the client admin component (P0-B6)

### DIFF
--- a/apps/web/src/app/[locale]/admin/admin-client.tsx
+++ b/apps/web/src/app/[locale]/admin/admin-client.tsx
@@ -55,11 +55,7 @@ interface AdminStatus {
   achievements: AchievementStatus[];
 }
 
-interface AdminClientProps {
-  adminToken: string;
-}
-
-export function AdminClient({ adminToken }: AdminClientProps) {
+export function AdminClient() {
   const [status, setStatus] = useState<AdminStatus | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -68,9 +64,8 @@ export function AdminClient({ adminToken }: AdminClientProps) {
     setLoading(true);
     setError(null);
     try {
-      const res = await fetch("/api/admin/status", {
-        headers: { Authorization: `Bearer ${adminToken}` },
-      });
+      // Authorized via the httpOnly admin_session cookie (sent automatically).
+      const res = await fetch("/api/admin/status");
       if (!res.ok) {
         setError("Failed to fetch status");
         return;
@@ -82,7 +77,7 @@ export function AdminClient({ adminToken }: AdminClientProps) {
     } finally {
       setLoading(false);
     }
-  }, [adminToken]);
+  }, []);
 
   useEffect(() => {
     void fetchStatus();
@@ -158,7 +153,6 @@ export function AdminClient({ adminToken }: AdminClientProps) {
           ) : (
             <CourseSyncTable
               courses={courses}
-              adminToken={adminToken}
               onRefresh={() => void fetchStatus()}
             />
           )}
@@ -178,7 +172,6 @@ export function AdminClient({ adminToken }: AdminClientProps) {
           ) : (
             <AchievementSyncTable
               achievements={achievements}
-              adminToken={adminToken}
               onRefresh={() => void fetchStatus()}
             />
           )}
@@ -191,7 +184,7 @@ export function AdminClient({ adminToken }: AdminClientProps) {
           Data Resync
         </h2>
         <div className="rounded-lg border border-border bg-card p-4 shadow-card">
-          <DataResyncPanel adminToken={adminToken} />
+          <DataResyncPanel />
         </div>
       </section>
     </div>

--- a/apps/web/src/app/[locale]/admin/page.tsx
+++ b/apps/web/src/app/[locale]/admin/page.tsx
@@ -6,9 +6,11 @@ import { isValidAdminSession } from "@/lib/admin/auth";
 export default async function AdminPage() {
   const cookieStore = await cookies();
   const session = cookieStore.get("admin_session");
-  const adminSecret = process.env.ADMIN_SECRET;
 
-  if (!adminSecret || !isValidAdminSession(session?.value)) {
+  // Gate on the signed admin_session cookie only. The secret is never read
+  // here, so it cannot be serialized into the client payload (P0-B6).
+  // isValidAdminSession returns false when ADMIN_SECRET is unset.
+  if (!isValidAdminSession(session?.value)) {
     return <AdminLoginForm />;
   }
 
@@ -23,7 +25,7 @@ export default async function AdminPage() {
             Superteam Academy — Sanity to On-Chain Sync
           </p>
         </div>
-        <AdminClient adminToken={adminSecret} />
+        <AdminClient />
       </div>
     </div>
   );

--- a/apps/web/src/app/api/admin/auth/route.ts
+++ b/apps/web/src/app/api/admin/auth/route.ts
@@ -36,7 +36,11 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     response.cookies.set("admin_session", cookieValue, {
       httpOnly: true,
       secure: process.env.NODE_ENV === "production",
-      sameSite: "lax",
+      // Strict: the admin console has no cross-site entry flow, so the cookie
+      // never needs to ride a cross-site navigation. This blocks the cookie
+      // from being attached to attacker-initiated cross-site requests (CSRF),
+      // which matter here because admin POSTs trigger authority-signed on-chain writes.
+      sameSite: "strict",
       maxAge: 86400, // 24h
       path: "/",
     });

--- a/apps/web/src/app/api/admin/resync/route.ts
+++ b/apps/web/src/app/api/admin/resync/route.ts
@@ -1,6 +1,5 @@
 import "server-only";
 
-import crypto from "crypto";
 import { NextRequest, NextResponse } from "next/server";
 import { Connection, PublicKey } from "@solana/web3.js";
 import {
@@ -10,6 +9,11 @@ import {
 } from "@solana/spl-token";
 import { createAdminClient } from "@/lib/supabase/admin";
 import {
+  requireAdminAuth,
+  adminUnauthorizedResponse,
+  AdminAuthError,
+} from "@/lib/admin/auth";
+import {
   fetchEnrollment,
   fetchAchievementReceiptData,
 } from "@/lib/solana/academy-reads";
@@ -17,25 +21,17 @@ import { decodeLessonBitmap } from "@/lib/solana/bitmap";
 import { getAllCourses, getAllAchievements } from "@/lib/sanity/queries";
 import { calculateLevel } from "@/lib/gamification/xp";
 
-const ADMIN_SECRET = process.env.ADMIN_SECRET;
-
-function verifyAdminToken(header: string | null): boolean {
-  if (!ADMIN_SECRET || !header?.startsWith("Bearer ")) return false;
-  const token = header.slice(7);
-  const tokenBuf = Buffer.from(token);
-  const secretBuf = Buffer.from(ADMIN_SECRET);
-  if (tokenBuf.length !== secretBuf.length) return false;
-  return crypto.timingSafeEqual(tokenBuf, secretBuf);
-}
-
 function isValidBase58(value: string): boolean {
   return /^[1-9A-HJ-NP-Za-km-z]{32,44}$/.test(value);
 }
 
 export async function POST(req: NextRequest) {
-  // Admin auth (timing-safe comparison)
-  if (!verifyAdminToken(req.headers.get("authorization"))) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  // Admin auth via signed admin_session cookie
+  try {
+    requireAdminAuth(req);
+  } catch (e) {
+    if (e instanceof AdminAuthError) return adminUnauthorizedResponse();
+    throw e;
   }
 
   const rpcUrl = process.env.NEXT_PUBLIC_SOLANA_RPC_URL;

--- a/apps/web/src/components/admin/achievement-sync-table.tsx
+++ b/apps/web/src/components/admin/achievement-sync-table.tsx
@@ -14,13 +14,11 @@ interface AchievementStatus {
 
 interface AchievementSyncTableProps {
   achievements: AchievementStatus[];
-  adminToken: string;
   onRefresh: () => void;
 }
 
 export function AchievementSyncTable({
   achievements,
-  adminToken,
   onRefresh,
 }: AchievementSyncTableProps) {
   const [syncing, setSyncing] = useState<string | null>(null);
@@ -33,10 +31,7 @@ export function AchievementSyncTable({
     try {
       const res = await fetch("/api/admin/achievements/sync", {
         method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${adminToken}`,
-        },
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ achievementId }),
       });
       if (!res.ok) {
@@ -66,10 +61,7 @@ export function AchievementSyncTable({
       try {
         const res = await fetch("/api/admin/achievements/sync", {
           method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${adminToken}`,
-          },
+          headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ achievementId: ach.sanityId }),
         });
         if (!res.ok) {

--- a/apps/web/src/components/admin/course-sync-table.tsx
+++ b/apps/web/src/components/admin/course-sync-table.tsx
@@ -32,15 +32,10 @@ interface CourseStatus {
 
 interface CourseSyncTableProps {
   courses: CourseStatus[];
-  adminToken: string;
   onRefresh: () => void;
 }
 
-export function CourseSyncTable({
-  courses,
-  adminToken,
-  onRefresh,
-}: CourseSyncTableProps) {
+export function CourseSyncTable({ courses, onRefresh }: CourseSyncTableProps) {
   const [syncing, setSyncing] = useState<string | null>(null);
   const [syncingAll, setSyncingAll] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -51,10 +46,7 @@ export function CourseSyncTable({
     try {
       const res = await fetch("/api/admin/courses/sync", {
         method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${adminToken}`,
-        },
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ courseId }),
       });
       if (!res.ok) {
@@ -82,10 +74,7 @@ export function CourseSyncTable({
     try {
       const res = await fetch("/api/admin/courses/deactivate", {
         method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${adminToken}`,
-        },
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ courseId }),
       });
       if (!res.ok) {
@@ -115,10 +104,7 @@ export function CourseSyncTable({
       try {
         const res = await fetch("/api/admin/courses/sync", {
           method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${adminToken}`,
-          },
+          headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ courseId: course.sanityId }),
         });
         if (!res.ok) {

--- a/apps/web/src/components/admin/data-resync-panel.tsx
+++ b/apps/web/src/components/admin/data-resync-panel.tsx
@@ -13,11 +13,7 @@ interface ResyncResult {
   certificates: number;
 }
 
-interface DataResyncPanelProps {
-  adminToken: string;
-}
-
-export function DataResyncPanel({ adminToken }: DataResyncPanelProps) {
+export function DataResyncPanel() {
   const [walletAddress, setWalletAddress] = useState("");
   const [loading, setLoading] = useState(false);
   const [result, setResult] = useState<ResyncResult | null>(null);
@@ -34,10 +30,7 @@ export function DataResyncPanel({ adminToken }: DataResyncPanelProps) {
     try {
       const res = await fetch("/api/admin/resync", {
         method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${adminToken}`,
-        },
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ walletAddress: trimmed }),
       });
 

--- a/apps/web/src/lib/admin/auth.ts
+++ b/apps/web/src/lib/admin/auth.ts
@@ -8,21 +8,30 @@ export class AdminAuthError extends Error {
   }
 }
 
+const ADMIN_SESSION_COOKIE = "admin_session";
+
+function readAdminSessionCookie(req: Request): string | undefined {
+  const header = req.headers.get("cookie");
+  if (!header) return undefined;
+  for (const part of header.split(";")) {
+    const eq = part.indexOf("=");
+    if (eq === -1) continue;
+    if (part.slice(0, eq).trim() === ADMIN_SESSION_COOKIE) {
+      return decodeURIComponent(part.slice(eq + 1).trim());
+    }
+  }
+  return undefined;
+}
+
 /**
- * Validates the Authorization: Bearer {ADMIN_SECRET} header.
- * Throws AdminAuthError if the token is missing or doesn't match ADMIN_SECRET.
+ * Authorizes an admin API request via the signed `admin_session` cookie.
+ * The cookie is minted by POST /api/admin/auth once the secret is entered,
+ * and sent automatically on same-origin fetches. The secret itself is never
+ * held by the client, so it cannot leak into the page payload or be stolen
+ * via XSS. Throws AdminAuthError if the cookie is missing/invalid/expired.
  */
 export function requireAdminAuth(req: Request): void {
-  const token = req.headers.get("authorization")?.replace("Bearer ", "").trim();
-  const expected = process.env.ADMIN_SECRET;
-
-  const tokenBuf = Buffer.from(token ?? "");
-  const expectedBuf = Buffer.from(expected ?? "");
-  if (
-    !expected ||
-    tokenBuf.length !== expectedBuf.length ||
-    !crypto.timingSafeEqual(tokenBuf, expectedBuf)
-  ) {
+  if (!isValidAdminSession(readAdminSessionCookie(req))) {
     throw new AdminAuthError();
   }
 }

--- a/apps/web/src/lib/admin/auth.ts
+++ b/apps/web/src/lib/admin/auth.ts
@@ -1,6 +1,7 @@
 import "server-only";
 import crypto from "crypto";
 import { NextResponse } from "next/server";
+import { ADMIN_SESSION_MAX_AGE_MS } from "./session-format";
 
 export class AdminAuthError extends Error {
   constructor() {
@@ -17,10 +18,63 @@ function readAdminSessionCookie(req: Request): string | undefined {
     const eq = part.indexOf("=");
     if (eq === -1) continue;
     if (part.slice(0, eq).trim() === ADMIN_SESSION_COOKIE) {
-      return decodeURIComponent(part.slice(eq + 1).trim());
+      try {
+        return decodeURIComponent(part.slice(eq + 1).trim());
+      } catch {
+        // Malformed percent-encoding (URIError): treat as no session so the
+        // caller returns a clean 401 instead of a 500.
+        return undefined;
+      }
     }
   }
   return undefined;
+}
+
+/**
+ * Rejects state-changing requests that are not same-origin, as a CSRF defense
+ * layered on top of the cookie's SameSite=Strict attribute.
+ *
+ * Safe methods (GET/HEAD) are exempt — they must not mutate state, and skipping
+ * the check keeps simple same-origin reads (and Origin-less navigations) working.
+ *
+ * For state-changing methods we trust two signals, in order:
+ *   1. `Sec-Fetch-Site` — set by all modern browsers; only `same-origin` (and
+ *      `none`, e.g. a user-typed URL) is allowed.
+ *   2. `Origin` — fallback for clients that omit `Sec-Fetch-Site`; if present it
+ *      must match the request's own origin.
+ * A request with neither header present is allowed (e.g. server-to-server or
+ * older non-browser clients), since CSRF requires a browser-attached cookie and
+ * browsers always send at least one of these on cross-site requests.
+ */
+function isSameOriginRequest(req: Request): boolean {
+  const method = req.method.toUpperCase();
+  if (method === "GET" || method === "HEAD") return true;
+
+  const secFetchSite = req.headers.get("sec-fetch-site");
+  if (secFetchSite !== null) {
+    // `none` = user-initiated (typed URL / bookmark); `same-origin` = our own UI.
+    return secFetchSite === "same-origin" || secFetchSite === "none";
+  }
+
+  const origin = req.headers.get("origin");
+  if (origin !== null) {
+    let originHost: string;
+    try {
+      originHost = new URL(origin).origin;
+    } catch {
+      return false;
+    }
+    let selfOrigin: string;
+    try {
+      selfOrigin = new URL(req.url).origin;
+    } catch {
+      return false;
+    }
+    return originHost === selfOrigin;
+  }
+
+  // Neither Sec-Fetch-Site nor Origin present: not a cross-site browser request.
+  return true;
 }
 
 /**
@@ -28,9 +82,13 @@ function readAdminSessionCookie(req: Request): string | undefined {
  * The cookie is minted by POST /api/admin/auth once the secret is entered,
  * and sent automatically on same-origin fetches. The secret itself is never
  * held by the client, so it cannot leak into the page payload or be stolen
- * via XSS. Throws AdminAuthError if the cookie is missing/invalid/expired.
+ * via XSS. Throws AdminAuthError if the cookie is missing/invalid/expired,
+ * or if a state-changing request fails the same-origin (CSRF) check.
  */
 export function requireAdminAuth(req: Request): void {
+  if (!isSameOriginRequest(req)) {
+    throw new AdminAuthError();
+  }
   if (!isValidAdminSession(readAdminSessionCookie(req))) {
     throw new AdminAuthError();
   }
@@ -48,8 +106,6 @@ export function requireAdminAuth(req: Request): void {
 export function adminUnauthorizedResponse(): NextResponse {
   return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 }
-
-const ADMIN_SESSION_MAX_AGE_MS = 86400 * 1000; // 24h
 
 export function isValidAdminSession(cookieValue: string | undefined): boolean {
   if (!cookieValue) return false;

--- a/apps/web/src/lib/admin/session-format.ts
+++ b/apps/web/src/lib/admin/session-format.ts
@@ -1,0 +1,21 @@
+/**
+ * Shared constants for the `admin_session` cookie.
+ *
+ * The session signature is produced and verified in TWO places that run in
+ * DIFFERENT runtimes and therefore use DIFFERENT crypto implementations:
+ *   - `lib/admin/auth.ts`  — Node runtime (API routes), Node `crypto` HMAC
+ *   - `middleware.ts`      — Edge runtime, Web Crypto (`crypto.subtle`) HMAC
+ *
+ * Those two implementations MUST stay in sync. The cookie value format and the
+ * max-age are defined here so the two paths cannot drift on those values.
+ *
+ * Cookie value format: `"<timestamp>.<signature>"`
+ *   - timestamp = `Date.now()` as a base-10 string (ms since epoch)
+ *   - signature = lowercase-hex HMAC-SHA256 of the timestamp string, keyed by ADMIN_SECRET
+ *
+ * This module intentionally has NO imports so it can be loaded from both the
+ * Edge and Node runtimes.
+ */
+
+/** Max lifetime of an `admin_session` cookie before it is rejected as expired. */
+export const ADMIN_SESSION_MAX_AGE_MS = 86400 * 1000; // 24h

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -3,8 +3,11 @@ import { createServerClient } from "@supabase/ssr";
 import createIntlMiddleware from "next-intl/middleware";
 import { env } from "@/lib/env";
 import { locales, defaultLocale } from "@/lib/i18n/config";
+import { ADMIN_SESSION_MAX_AGE_MS } from "@/lib/admin/session-format";
 
-const ADMIN_SESSION_MAX_AGE_MS = 86400 * 1000;
+// NOTE: This Edge-runtime `isValidAdminSession` (Web Crypto) must stay in sync
+// with the Node-runtime implementation in `lib/admin/auth.ts` (Node `crypto`).
+// The shared cookie format + max-age live in `lib/admin/session-format.ts`.
 
 function hexEncode(buf: ArrayBuffer): string {
   return Array.from(new Uint8Array(buf))


### PR DESCRIPTION
Closes #151

## [P0-B6] Stop exposing `ADMIN_SECRET` to the client (area:security)

### The leak
`apps/web/src/app/[locale]/admin/page.tsx` read `process.env.ADMIN_SECRET` and passed it as an `adminToken` prop into the `"use client"` `AdminClient`. Next.js serializes client-component props into the page's React/RSC payload and inlines them into the client bundle, so the admin secret was shipped to the browser and was XSS-stealable. The secret was then re-sent on every admin call as an `Authorization: Bearer <secret>` header.

### Auth-flow change (header/prop path → cookie path)
The HMAC `admin_session` cookie machinery already existed (`POST /api/admin/auth` mints it; middleware gates `/admin` on it). This PR makes the admin **API routes** authorize via that cookie too, and removes the client-held secret entirely:

- **`admin/page.tsx`** — no longer reads `ADMIN_SECRET`; gates on the cookie via `isValidAdminSession(session)`; renders `<AdminClient />` with **no token prop**.
- **`AdminClient` + `course-sync-table` + `achievement-sync-table` + `data-resync-panel`** — drop the `adminToken` prop and the `Authorization` header from every `fetch`. The `admin_session` cookie (httpOnly) is sent automatically on same-origin requests.
- **`lib/admin/auth.ts`** — `requireAdminAuth(req)` now validates the `admin_session` cookie (reusing the existing `isValidAdminSession` HMAC + expiry check) instead of the `Bearer` header.
- **`api/admin/resync/route.ts`** — replaced its inline header-based `verifyAdminToken` with the shared cookie-based `requireAdminAuth` (the other admin routes already call `requireAdminAuth`, so they're covered by the helper change).

Login UX is unchanged: enter secret → `POST /api/admin/auth` → `admin_session` cookie set → admin actions work via the cookie.

### Canary-grep proof (the Done-when)
Built with a sentinel `ADMIN_SECRET=LEAKCANARY-ADMIN-deadbeef1234`, then grepped the client bundle:

```
$ grep -rl "LEAKCANARY-ADMIN-deadbeef1234" apps/web/.next/static
# (no matches) → PASS: canary absent from client bundle
$ grep -rl "LEAKCANARY-ADMIN-deadbeef1234" apps/web/.next
# (no matches anywhere in .next) → secret not baked into any artifact;
#   route handlers read process.env.ADMIN_SECRET at runtime
```
grep correctness self-tested (writing the canary to a temp file under `.next` is found by the same `grep -rl`). `.next/static` contained 124 client files; the canary is in none.

### Verification
- `pnpm --filter @superteam-lms/web typecheck` → exit 0
- `pnpm --filter @superteam-lms/web build` → success (placeholder env vars)
- `next lint` / lint-staged (eslint --fix + prettier) → clean
- `git grep adminToken` / `Bearer ${adminToken}` over `apps/web/src` → no matches

### Follow-up (human ops)
**`ADMIN_SECRET` rotation is a required follow-up ops step (D-2/G-1).** This PR stops *exposing* the secret but does not rotate it; the previously-shipped value should be rotated out of band.
