### PR TITLE
chore(loop): make the adversarial review mandatory for SENSITIVE PRs

### DIFF
--- a/.claude/commands/work-issue.md
+++ b/.claude/commands/work-issue.md
@@ -31,10 +31,13 @@ context degrades as it fills, and a `/goal` run spans many turns.
     - **SENSITIVE** — any changed path under `supabase/schema.sql`, `onchain-academy/**`,
       real env/secret files (`.env`, `.env.local`, `.env.*` — but NOT public `*.example`
       templates), `.github/workflows/**`, or `.claude/**`; OR issue label ∈
-      {`area:security`, `area:onchain`, `area:db`, `area:ci`}: run an adversarial **Workflow**
-      (maker → verify → re-exploit → fixer), then **leave the PR open**, add label
-      `needs-human-review`, comment `needs human review`, and **stop babysitting it**. NEVER
-      self-merge these — a human signs off.
+      {`area:security`, `area:onchain`, `area:db`, `area:ci`}: **MANDATORY, never skipped as
+      "redundant"** — dispatch an **independent adversarial reviewer** (a fresh, skeptical agent
+      told to BREAK the security claim, not confirm it). The single `claude[bot]` gate is NOT
+      sufficient: it has OK'd loop PRs that would have broken prod (a CSP that blocked the Monaco
+      CDN app-wide) and shipped a CSRF hole on on-chain-authority routes. **Fix everything it
+      finds and re-verify.** THEN **leave the PR open**, add label `needs-human-review`, comment
+      `needs human review`, and **stop babysitting it**. NEVER self-merge these — a human signs off.
     - **SAFE** — everything else (`area:frontend`/`docs`/`testing`/`ops`):
       `gh pr merge <n> --squash --delete-branch`. The issue auto-closes via `Closes #<n>`.
 


### PR DESCRIPTION
Makes the adversarial-review step **mandatory and non-skippable** for SENSITIVE PRs in the `/work-issue` loop skill.

## Why
During the `/goal` warm-up I skipped the adversarial pass on sensitive PRs as "redundant," relying on the single `claude[bot]` gate. That was wrong. When an independent skeptical review was finally run across the three loop-generated security PRs, it caught defects the gate had rated **"no blocking"**:
- **#170** (CSP) — blocked the Monaco CDN → would have broken every code editor + the challenge sandbox app-wide in prod.
- **#171** (admin auth) — a **CSRF regression** on routes that sign on-chain mutations with the platform authority key.

Both were one merge from shipping. The gate is necessary but **not sufficient** for sensitive code.

## Change
The SENSITIVE branch of `work-issue.md` now states the adversarial reviewer (a fresh, skeptical agent told to BREAK the security claim) is MANDATORY and never skipped, with the concrete evidence inline so the rule cannot be re-rationalized away.

SENSITIVE (touches `.claude/**`) → human sign-off, not self-merged.