### PR TITLE
fix(db): tighten leaderboard/XP data exposure (P1-6)

### DIFF
--- a/apps/web/src/app/[locale]/(marketing)/page.tsx
+++ b/apps/web/src/app/[locale]/(marketing)/page.tsx
@@ -20,7 +20,7 @@ export default async function LandingPage() {
   try {
     const supabase = await createClient();
     const [xpResult, enrollResult, certResult] = await Promise.all([
-      supabase.from("user_xp").select("total_xp"),
+      supabase.from("public_user_xp").select("total_xp"),
       supabase.from("profiles").select("id", { count: "exact", head: true }),
       supabase
         .from("certificates")

--- a/apps/web/src/app/[locale]/(platform)/profile/[username]/page.tsx
+++ b/apps/web/src/app/[locale]/(platform)/profile/[username]/page.tsx
@@ -155,7 +155,7 @@ export default function PublicProfilePage() {
           enrollmentResult,
         ] = await Promise.all([
           supabase
-            .from("user_xp")
+            .from("public_user_xp")
             .select("total_xp, level")
             .eq("user_id", userId)
             .single(),

--- a/apps/web/src/app/api/community/search/route.ts
+++ b/apps/web/src/app/api/community/search/route.ts
@@ -61,7 +61,7 @@ export async function GET(request: NextRequest) {
     let authorLevels: Record<string, number> = {};
     if (authorIds.length > 0) {
       const { data: xpData } = await supabase
-        .from("user_xp")
+        .from("public_user_xp")
         .select("user_id, level")
         .in("user_id", authorIds);
       if (xpData) {

--- a/apps/web/src/app/api/community/threads/[id]/route.ts
+++ b/apps/web/src/app/api/community/threads/[id]/route.ts
@@ -58,7 +58,7 @@ export async function GET(
     ];
     const uniqueAuthorIds = [...new Set(allAuthorIds)];
     const { data: xpData } = await supabase
-      .from("user_xp")
+      .from("public_user_xp")
       .select("user_id, level")
       .in("user_id", uniqueAuthorIds);
     const authorLevels: Record<string, number> = Object.fromEntries(

--- a/apps/web/src/app/api/community/threads/route.ts
+++ b/apps/web/src/app/api/community/threads/route.ts
@@ -136,7 +136,7 @@ export async function GET(request: NextRequest) {
     let authorLevels: Record<string, number> = {};
     if (authorIds.length > 0) {
       const { data: xpData } = await supabase
-        .from("user_xp")
+        .from("public_user_xp")
         .select("user_id, level")
         .in("user_id", authorIds);
       if (xpData) {

--- a/apps/web/src/lib/supabase/types.ts
+++ b/apps/web/src/lib/supabase/types.ts
@@ -848,6 +848,14 @@ export type Database = {
         };
         Relationships: [];
       };
+      public_user_xp: {
+        Row: {
+          level: number | null;
+          total_xp: number | null;
+          user_id: string | null;
+        };
+        Relationships: [];
+      };
     };
     Functions: {
       award_community_xp: {

--- a/supabase/migrations/20260624181348_tighten_leaderboard_exposure.sql
+++ b/supabase/migrations/20260624181348_tighten_leaderboard_exposure.sql
@@ -1,0 +1,120 @@
+-- ============================================
+-- Tighten leaderboard / XP data exposure (P1-6)
+-- ============================================
+-- The broad "USING (true)" SELECT policies on user_xp and xp_transactions let
+-- anon/authenticated read every user's raw XP ledger (amount, reason,
+-- tx_signature, created_at) and full user_xp rows (incl. streak fields). Lock
+-- both down while keeping the public features that need aggregate XP working:
+--
+--   * get_leaderboard() -> SECURITY DEFINER, so the public leaderboard keeps
+--     working off non-sensitive columns without the broad table policies.
+--   * public_user_xp: a new non-sensitive view exposing only
+--     (user_id, total_xp, level) for is_public profiles, for public reads
+--     (marketing stats, public profiles, community author level badges).
+--   * community_stats: owner-privilege view with an explicit (is_public OR own)
+--     guard, so its community-XP aggregate keeps working without re-exposing
+--     xp_transactions — preserving P0-B1's guarantee that anon can't read
+--     private-profile aggregates.
+--
+-- The own-row SELECT policies remain, so users still read their own rows.
+
+-- 1. Leaderboard RPC: read all rows via definer rights; returns only
+--    user_id / username / avatar_url / total_xp / level / rank.
+CREATE OR REPLACE FUNCTION public.get_leaderboard(p_timeframe TEXT DEFAULT 'alltime', p_limit INT DEFAULT 20)
+RETURNS TABLE (
+  user_id UUID,
+  username TEXT,
+  avatar_url TEXT,
+  total_xp BIGINT,
+  level INT,
+  rank BIGINT
+)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+  IF p_timeframe = 'alltime' THEN
+    RETURN QUERY
+      SELECT
+        ux.user_id,
+        p.username,
+        p.avatar_url,
+        ux.total_xp::BIGINT,
+        ux.level,
+        ROW_NUMBER() OVER (ORDER BY ux.total_xp DESC)::BIGINT AS rank
+      FROM public.user_xp ux
+      JOIN public.profiles p ON p.id = ux.user_id
+      WHERE ux.total_xp > 0
+        AND p.username IS NOT NULL
+        AND p.username <> ''
+      ORDER BY ux.total_xp DESC
+      LIMIT p_limit;
+  ELSE
+    RETURN QUERY
+      SELECT
+        sub.user_id,
+        sub.username,
+        sub.avatar_url,
+        sub.total_xp,
+        COALESCE(ux.level, FLOOR(SQRT(sub.total_xp / 100.0))::INT) AS level,
+        ROW_NUMBER() OVER (ORDER BY sub.total_xp DESC)::BIGINT AS rank
+      FROM (
+        SELECT
+          xt.user_id,
+          p.username,
+          p.avatar_url,
+          SUM(xt.amount)::BIGINT AS total_xp
+        FROM public.xp_transactions xt
+        JOIN public.profiles p ON p.id = xt.user_id
+        WHERE p.username IS NOT NULL
+          AND p.username <> ''
+          AND xt.created_at >= CASE
+            WHEN p_timeframe = 'weekly'  THEN NOW() - INTERVAL '7 days'
+            WHEN p_timeframe = 'monthly' THEN NOW() - INTERVAL '1 month'
+          END
+        GROUP BY xt.user_id, p.username, p.avatar_url
+      ) sub
+      LEFT JOIN public.user_xp ux ON ux.user_id = sub.user_id
+      ORDER BY sub.total_xp DESC
+      LIMIT p_limit;
+  END IF;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_leaderboard(TEXT, INT) TO authenticated, anon;
+
+-- 2. Drop the broad SELECT policies (own-row policies remain).
+DROP POLICY IF EXISTS "Leaderboard: anyone can view XP rankings" ON user_xp;
+DROP POLICY IF EXISTS "Anyone can view XP transactions for leaderboard" ON xp_transactions;
+
+-- 3. Non-sensitive public view: per-user total_xp / level for public profiles.
+CREATE OR REPLACE VIEW public_user_xp AS
+  SELECT ux.user_id, ux.total_xp, ux.level
+  FROM user_xp ux
+  JOIN profiles p ON p.id = ux.user_id
+  WHERE p.is_public = true;
+
+REVOKE ALL ON public_user_xp FROM PUBLIC, anon, authenticated;
+GRANT SELECT ON public_user_xp TO anon, authenticated;
+
+-- 4. community_stats: owner-privilege view + explicit privacy guard so the
+--    community-XP aggregate works without xp_transactions being client-readable.
+DROP VIEW IF EXISTS community_stats;
+CREATE VIEW community_stats AS
+SELECT
+  p.id AS user_id,
+  COUNT(DISTINCT t.id) AS total_threads,
+  COUNT(DISTINCT a.id) AS total_answers,
+  COUNT(DISTINCT a.id) FILTER (WHERE a.is_accepted) AS accepted_answers,
+  COALESCE(SUM(xt.amount) FILTER (WHERE xt.reason LIKE 'community:%'), 0) AS total_community_xp
+FROM profiles p
+LEFT JOIN threads t ON t.author_id = p.id
+LEFT JOIN answers a ON a.author_id = p.id
+LEFT JOIN xp_transactions xt ON xt.user_id = p.id
+WHERE p.is_public = true OR p.id = auth.uid()
+GROUP BY p.id;
+
+REVOKE ALL ON community_stats FROM PUBLIC, anon, authenticated;
+GRANT SELECT ON community_stats TO anon, authenticated;

--- a/supabase/migrations/20260624181348_tighten_leaderboard_exposure.sql
+++ b/supabase/migrations/20260624181348_tighten_leaderboard_exposure.sql
@@ -47,10 +47,11 @@ BEGIN
       FROM public.user_xp ux
       JOIN public.profiles p ON p.id = ux.user_id
       WHERE ux.total_xp > 0
+        AND p.is_public = true
         AND p.username IS NOT NULL
         AND p.username <> ''
       ORDER BY ux.total_xp DESC
-      LIMIT p_limit;
+      LIMIT LEAST(p_limit, 100);
   ELSE
     RETURN QUERY
       SELECT
@@ -68,7 +69,8 @@ BEGIN
           SUM(xt.amount)::BIGINT AS total_xp
         FROM public.xp_transactions xt
         JOIN public.profiles p ON p.id = xt.user_id
-        WHERE p.username IS NOT NULL
+        WHERE p.is_public = true
+          AND p.username IS NOT NULL
           AND p.username <> ''
           AND xt.created_at >= CASE
             WHEN p_timeframe = 'weekly'  THEN NOW() - INTERVAL '7 days'
@@ -78,7 +80,7 @@ BEGIN
       ) sub
       LEFT JOIN public.user_xp ux ON ux.user_id = sub.user_id
       ORDER BY sub.total_xp DESC
-      LIMIT p_limit;
+      LIMIT LEAST(p_limit, 100);
   END IF;
 END;
 $$;
@@ -90,6 +92,9 @@ DROP POLICY IF EXISTS "Leaderboard: anyone can view XP rankings" ON user_xp;
 DROP POLICY IF EXISTS "Anyone can view XP transactions for leaderboard" ON xp_transactions;
 
 -- 3. Non-sensitive public view: per-user total_xp / level for public profiles.
+--    INVARIANT: the is_public filter is the SOLE access guard — this is an
+--    owner-privilege view that bypasses RLS on user_xp, so removing the filter
+--    would make every user's XP publicly readable. Do not remove it.
 CREATE OR REPLACE VIEW public_user_xp AS
   SELECT ux.user_id, ux.total_xp, ux.level
   FROM user_xp ux
@@ -99,8 +104,13 @@ CREATE OR REPLACE VIEW public_user_xp AS
 REVOKE ALL ON public_user_xp FROM PUBLIC, anon, authenticated;
 GRANT SELECT ON public_user_xp TO anon, authenticated;
 
--- 4. community_stats: owner-privilege view + explicit privacy guard so the
---    community-XP aggregate works without xp_transactions being client-readable.
+-- 4. community_stats: owner-privilege view + explicit privacy guard.
+--    NOTE: this intentionally reverts P0-B1's security_invoker = true. With
+--    security_invoker the view runs as the caller, who can no longer read other
+--    users' xp_transactions (P1-6 locks that down), so total_community_xp would
+--    be zeroed for every row except the caller's own. Running as owner restores
+--    the aggregate; the explicit (is_public OR own) guard below preserves
+--    P0-B1's guarantee that anon cannot see private-profile aggregates.
 DROP VIEW IF EXISTS community_stats;
 CREATE VIEW community_stats AS
 SELECT

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -222,19 +222,15 @@ CREATE POLICY "Public profile progress is viewable"
 -- (Helius webhook + admin resync). Direct client writes would let users forge
 -- completed=true rows and mint on-chain XP via the daily-quest path.
 
--- user_xp (SELECT only — mutations via SECURITY DEFINER functions)
+-- user_xp (SELECT own only — public total_xp/level served via public_user_xp view;
+-- leaderboard served via get_leaderboard(); mutations via SECURITY DEFINER functions)
 CREATE POLICY "Users can view their own XP"
   ON user_xp FOR SELECT USING (auth.uid() = user_id);
 
-CREATE POLICY "Leaderboard: anyone can view XP rankings"
-  ON user_xp FOR SELECT USING (true);
-
--- xp_transactions (SELECT only — inserts via award_xp function)
+-- xp_transactions (SELECT own only — raw rows never exposed to anon; aggregates
+-- served via get_leaderboard()/community_stats; inserts via award_xp function)
 CREATE POLICY "Users can view their own XP transactions"
   ON xp_transactions FOR SELECT USING (auth.uid() = user_id);
-
-CREATE POLICY "Anyone can view XP transactions for leaderboard"
-  ON xp_transactions FOR SELECT USING (true);
 
 -- user_achievements (SELECT only — inserts via unlock_achievement function)
 CREATE POLICY "Users can view their own achievements"
@@ -421,7 +417,7 @@ RETURNS TABLE (
 )
 LANGUAGE plpgsql
 STABLE
-SECURITY INVOKER
+SECURITY DEFINER
 SET search_path = ''
 AS $$
 BEGIN
@@ -474,6 +470,20 @@ END;
 $$;
 
 GRANT EXECUTE ON FUNCTION public.get_leaderboard(TEXT, INT) TO authenticated, anon;
+
+-- Non-sensitive public XP view: exposes only (user_id, total_xp, level) for
+-- public profiles. Owner-privilege view (bypasses RLS on user_xp), so the
+-- is_public filter is the access control. Used for public reads (marketing
+-- stats, public profiles, community author level badges) now that user_xp is
+-- own-row-only.
+CREATE OR REPLACE VIEW public_user_xp AS
+  SELECT ux.user_id, ux.total_xp, ux.level
+  FROM user_xp ux
+  JOIN profiles p ON p.id = ux.user_id
+  WHERE p.is_public = true;
+
+REVOKE ALL ON public_user_xp FROM PUBLIC, anon, authenticated;
+GRANT SELECT ON public_user_xp TO anon, authenticated;
 
 -- ─────────────────────────────────────────────
 -- 6. RESTRICT SECURITY DEFINER FUNCTIONS
@@ -1402,11 +1412,11 @@ CREATE POLICY "Authenticated users can create flags"
 -- Community Stats View
 -- ============================================================
 
--- security_invoker = true makes the view run with the querying role's
--- privileges, so RLS on the underlying tables is enforced. Without it the
--- view runs as its owner and bypasses RLS, leaking aggregates for private
--- profiles (profiles SELECT is gated to is_public = true) to anon.
-CREATE VIEW community_stats WITH (security_invoker = true) AS
+-- Owner-privilege view (bypasses RLS) so it can aggregate community XP from
+-- xp_transactions, which is no longer client-readable (P1-6). The explicit
+-- "is_public OR own" guard preserves the P0-B1 guarantee that anon cannot see
+-- aggregates for private profiles (and authenticated users still see their own).
+CREATE VIEW community_stats AS
 SELECT
   p.id AS user_id,
   COUNT(DISTINCT t.id) AS total_threads,
@@ -1417,9 +1427,10 @@ FROM profiles p
 LEFT JOIN threads t ON t.author_id = p.id
 LEFT JOIN answers a ON a.author_id = p.id
 LEFT JOIN xp_transactions xt ON xt.user_id = p.id
+WHERE p.is_public = true OR p.id = auth.uid()
 GROUP BY p.id;
 
--- Explicit grants: the view stays publicly queryable, but security_invoker
--- ensures each caller only sees rows their own RLS permits.
+-- Explicit grants: publicly queryable, but the WHERE guard limits each caller
+-- to public profiles plus their own row.
 REVOKE ALL ON community_stats FROM PUBLIC, anon, authenticated;
 GRANT SELECT ON community_stats TO anon, authenticated;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -433,10 +433,11 @@ BEGIN
       FROM public.user_xp ux
       JOIN public.profiles p ON p.id = ux.user_id
       WHERE ux.total_xp > 0
+        AND p.is_public = true
         AND p.username IS NOT NULL
         AND p.username <> ''
       ORDER BY ux.total_xp DESC
-      LIMIT p_limit;
+      LIMIT LEAST(p_limit, 100);
   ELSE
     RETURN QUERY
       SELECT
@@ -454,7 +455,8 @@ BEGIN
           SUM(xt.amount)::BIGINT AS total_xp
         FROM public.xp_transactions xt
         JOIN public.profiles p ON p.id = xt.user_id
-        WHERE p.username IS NOT NULL
+        WHERE p.is_public = true
+          AND p.username IS NOT NULL
           AND p.username <> ''
           AND xt.created_at >= CASE
             WHEN p_timeframe = 'weekly'  THEN NOW() - INTERVAL '7 days'
@@ -464,7 +466,7 @@ BEGIN
       ) sub
       LEFT JOIN public.user_xp ux ON ux.user_id = sub.user_id
       ORDER BY sub.total_xp DESC
-      LIMIT p_limit;
+      LIMIT LEAST(p_limit, 100);
   END IF;
 END;
 $$;
@@ -476,6 +478,8 @@ GRANT EXECUTE ON FUNCTION public.get_leaderboard(TEXT, INT) TO authenticated, an
 -- is_public filter is the access control. Used for public reads (marketing
 -- stats, public profiles, community author level badges) now that user_xp is
 -- own-row-only.
+-- INVARIANT: the is_public filter is the SOLE access guard — removing it would
+-- make every user's XP publicly readable. Do not remove it.
 CREATE OR REPLACE VIEW public_user_xp AS
   SELECT ux.user_id, ux.total_xp, ux.level
   FROM user_xp ux
@@ -1413,9 +1417,13 @@ CREATE POLICY "Authenticated users can create flags"
 -- ============================================================
 
 -- Owner-privilege view (bypasses RLS) so it can aggregate community XP from
--- xp_transactions, which is no longer client-readable (P1-6). The explicit
--- "is_public OR own" guard preserves the P0-B1 guarantee that anon cannot see
--- aggregates for private profiles (and authenticated users still see their own).
+-- xp_transactions, which is no longer client-readable (P1-6).
+-- NOTE: this intentionally reverts P0-B1's security_invoker = true. With
+-- security_invoker the view runs as the caller, who can no longer read other
+-- users' xp_transactions, so total_community_xp would be zeroed for every row
+-- except the caller's own. Running as owner restores the aggregate; the explicit
+-- "is_public OR own" guard below preserves the P0-B1 guarantee that anon cannot
+-- see aggregates for private profiles (and authenticated users still see their own).
 CREATE VIEW community_stats AS
 SELECT
   p.id AS user_id,


### PR DESCRIPTION
Drop the broad USING(true) SELECT policies on user_xp and xp_transactions so anon/authenticated can no longer read other users' raw XP ledger (amount, reason, tx_signature) or full user_xp rows (incl. streak). Own-row SELECT policies remain.

Replace the public read paths that depended on those policies:
- get_leaderboard() -> SECURITY DEFINER (serves non-sensitive cols only).
- New non-sensitive view public_user_xp(user_id, total_xp, level) for is_public profiles; migrate marketing stats, public profile page, and community author level badges to it.
- community_stats -> owner-privilege view with an explicit (is_public OR own) guard so its community-XP aggregate keeps working without re-exposing xp_transactions, preserving P0-B1's no-private-leak guarantee.

Ships as a forward migration (+ snapshot + regenerated view types). Verified all remaining user_xp/xp_transactions client reads are own-row or service_role.

Closes #122