### PR TITLE
fix(observability): style global-error + correct Sentry debug-strip option (#174 review follow-ups)

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -155,11 +155,10 @@ const sentryBuildOptions = {
   authToken: process.env.SENTRY_AUTH_TOKEN,
   // Silence the build-time logger unless CI explicitly opts in.
   silent: !process.env.CI,
-  webpack: {
-    treeshake: {
-      // Strip Sentry SDK debug-logging statements from production bundles.
-      removeDebugLogging: true,
-    },
+  // Tree-shake the Sentry SDK's internal debug/logger statements out of
+  // production bundles (depends on the bundler's tree-shaking being enabled).
+  bundleSizeOptimizations: {
+    excludeDebugStatements: true,
   },
 };
 

--- a/apps/web/src/app/global-error.tsx
+++ b/apps/web/src/app/global-error.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import "@/styles/globals.css";
 import { useEffect } from "react";
 import * as Sentry from "@sentry/nextjs";
 


### PR DESCRIPTION
Two non-blocking findings from the now-merged Sentry-wiring PR #174.

## 1. `global-error.tsx` rendered unstyled
`apps/web/src/app/global-error.tsx` replaces the **root layout** entirely, so `apps/web/src/styles/globals.css` — imported only by `app/layout.tsx` — never loaded for this boundary. Its Tailwind classes (`flex`, `min-h-screen`, `text-6xl`, …) were therefore no-ops, leaving the root error page unstyled.

**Fix:** add `import "@/styles/globals.css";` at the top of the file (right after `"use client";`), matching the exact alias the root layout uses.

## 2. Invalid Sentry build option in `next.config.mjs`
`sentryBuildOptions` passed:

```js
webpack: { treeshake: { removeDebugLogging: true } }
```

This is **not** a recognized `@sentry/nextjs` v10 option. `withSentryConfig`'s options have no `webpack.treeshake` path (the top-level `webpack` key, where it exists, is a Next.js `WebpackConfigFunction | null`, not a Sentry tree-shake object), so the setting was **silently ignored** — the debug-log stripping never happened, and the accompanying comment claiming it did was misleading.

**Fix:** replaced with the correct top-level option:

```js
bundleSizeOptimizations: { excludeDebugStatements: true }
```

Verified against the installed **`@sentry/nextjs@10.38.0`** types: `SentryBuildOptions.bundleSizeOptimizations.excludeDebugStatements?: boolean` is the current API for tree-shaking the SDK's internal debug/logger statements out of production bundles. Comment updated to match.

> Note: a top-level `treeshake.removeDebugLogging` *does* also exist in v10 — the original code's bug was nesting it under `webpack`, not the leaf name. This PR uses the `bundleSizeOptimizations` form as specified.

## Scope
Only these two fixes. The CSP `headers()` / `securityHeaders` block in `next.config.mjs` is **byte-identical** to `main`; nothing else changed.

## Verification
- `pnpm --filter @superteam-lms/web typecheck` → exit **0**
- `pnpm --filter @superteam-lms/web build` → **`✓ Compiled successfully`**, `✓ Generating static pages (60/60)`, exit **0** (with dummy env). Confirms `withSentryConfig` accepts the new option (no warning/rejection) and `global-error.tsx` compiles with the CSS import.