### PR TITLE
chore(loop): triage non-blocking review findings before merge

### DIFF
--- a/.claude/commands/work-issue.md
+++ b/.claude/commands/work-issue.md
@@ -28,6 +28,10 @@ context degrades as it fills, and a `/goal` run spans many turns.
     auto-review does NOT re-run on push), and **wait for the NEW `claude[bot]` comment** next turn
     before judging.
   - **BOTH gates pass** (CI green AND latest verdict = approve / no blocking) → **MERGE STEP:**
+    - **First, triage the review's NON-BLOCKING findings — never merge-and-forget.** For each
+      one: **fix** the cheap, real, in-scope ones and push (then re-verify); **file** the rest as
+      deduped issues; **decline** genuine over-engineering with a one-line reason in the PR. A
+      "non-blocking" note left neither fixed nor tracked is lost work — not allowed. Only then:
     - **SENSITIVE** — any changed path under `supabase/schema.sql`, `onchain-academy/**`,
       real env/secret files (`.env`, `.env.local`, `.env.*` — but NOT public `*.example`
       templates), `.github/workflows/**`, or `.claude/**`; OR issue label ∈


### PR DESCRIPTION
Adds a **triage step** to the `/work-issue` merge step so the loop never "merge-and-forgets" non-blocking review findings.

## Why
The merge step jumped straight from "both gates pass" to the SENSITIVE/SAFE merge, ignoring the review non-blocking findings entirely. On #174 (Sentry) that left two real, cheap issues dangling — an unstyled `global-error.tsx` (the prod error page renders with no CSS) and a silently-invalid Sentry build option (the debug-strip never happened). Both were one merge from shipping; #175 fixed them after the fact.

## Change
Before merging or handing off, the loop triages each non-blocking finding: **fix** the cheap/real/in-scope ones (push + re-verify), **file** the rest as deduped issues, **decline** genuine over-engineering with a one-line reason. A note left neither fixed nor tracked is lost work.

SENSITIVE (touches `.claude/**`) → human sign-off; not self-merged.