### PR TITLE
fix(db): lock down forgeable enrollments RLS (service_role-write-only) + constraints (P0-B5)

### DIFF
--- a/supabase/migrations/20260624190000_lockdown_enrollments_rls.sql
+++ b/supabase/migrations/20260624190000_lockdown_enrollments_rls.sql
@@ -1,0 +1,58 @@
+-- ============================================
+-- Lock down enrollments writes to service_role + add integrity constraints
+-- ============================================
+-- The authenticated INSERT/DELETE policies let any user write/remove their own
+-- enrollment rows directly via the Supabase client. A user could delete and
+-- re-insert their enrollment to forge a fresh enrolled_at, faking a sub-24h
+-- enrolled->completed window. The Speed Runner achievement check reads
+-- enrolled_at vs completed_at, so a forged window mints a real on-chain
+-- achievement (this blocks #99) and pollutes enrollment data.
+--
+-- All legitimate writes already go through service_role, which bypasses RLS:
+--   * the Helius enroll/unenroll/finalize webhook (lib/helius/event-handlers.ts)
+--   * its retry queue (lib/solana/onchain-queue.ts)
+--   * the admin resync route (app/api/admin/resync/route.ts)
+-- The client only submits the on-chain tx and lets the webhook sync the row, so
+-- dropping these policies does not affect enroll/unenroll. SELECT policies
+-- ("Users can view their own enrollments" / "Public profile enrollments are
+-- viewable") are intentionally left in place. Mirrors the user_progress
+-- lockdown in 20260624164418_restrict_user_progress_writes.sql.
+
+DROP POLICY IF EXISTS "Users can enroll themselves" ON enrollments;
+DROP POLICY IF EXISTS "Users can delete their own enrollments" ON enrollments;
+
+-- Integrity constraints. PG15 has no ADD CONSTRAINT IF NOT EXISTS for CHECKs,
+-- so guard each add for idempotency.
+
+-- A course can only be completed at or after it was enrolled. Closes the forged
+-- sub-24h enrolled->completed window. NULL completed_at (not yet finished)
+-- passes, so this rejects no existing valid row. No FK on course_id: courses
+-- live in Sanity, not Postgres.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'chk_enrollments_completed_after_enrolled'
+      AND conrelid = 'public.enrollments'::regclass
+  ) THEN
+    ALTER TABLE enrollments
+      ADD CONSTRAINT chk_enrollments_completed_after_enrolled
+      CHECK (completed_at IS NULL OR completed_at >= enrolled_at);
+  END IF;
+END $$;
+
+-- A completion timestamp may only exist on a completed row. Legit writers
+-- (Helius webhook + admin resync) always set completed = true alongside
+-- completed_at, so this rejects no valid row.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'chk_user_progress_completed_at_requires_completed'
+      AND conrelid = 'public.user_progress'::regclass
+  ) THEN
+    ALTER TABLE user_progress
+      ADD CONSTRAINT chk_user_progress_completed_at_requires_completed
+      CHECK (completed_at IS NULL OR completed = true);
+  END IF;
+END $$;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -143,6 +143,21 @@ ALTER TABLE user_xp
 ALTER TABLE xp_transactions
   ADD CONSTRAINT chk_xp_transactions_amount_positive CHECK (amount > 0);
 
+-- A course can only be completed at or after it was enrolled. Closes the
+-- forged sub-24h enrolled->completed window that fakes Speed Runner. NULL
+-- completed_at (not yet finished) passes. No FK on course_id: courses live in
+-- Sanity, not Postgres.
+ALTER TABLE enrollments
+  ADD CONSTRAINT chk_enrollments_completed_after_enrolled
+  CHECK (completed_at IS NULL OR completed_at >= enrolled_at);
+
+-- A completion timestamp may only exist on a completed row. Legit writers
+-- (Helius webhook + admin resync) always set completed = true alongside
+-- completed_at, so this rejects no valid row.
+ALTER TABLE user_progress
+  ADD CONSTRAINT chk_user_progress_completed_at_requires_completed
+  CHECK (completed_at IS NULL OR completed = true);
+
 -- ─────────────────────────────────────────────
 -- 2. INDEXES
 -- ─────────────────────────────────────────────
@@ -190,11 +205,14 @@ CREATE POLICY "Users can update their own profile"
 CREATE POLICY "Users can view their own enrollments"
   ON enrollments FOR SELECT USING (auth.uid() = user_id);
 
-CREATE POLICY "Users can enroll themselves"
-  ON enrollments FOR INSERT WITH CHECK (auth.uid() = user_id);
-
-CREATE POLICY "Users can delete their own enrollments"
-  ON enrollments FOR DELETE USING (auth.uid() = user_id);
+-- No authenticated INSERT/DELETE/UPDATE: enrollment rows are written only by
+-- service_role (the Helius enroll/unenroll/finalize webhook in
+-- lib/helius/event-handlers.ts, its retry queue in lib/solana/onchain-queue.ts,
+-- and the admin resync route). The client only submits the on-chain tx and lets
+-- the webhook sync the row. A direct client INSERT/DELETE would let a user
+-- delete + re-insert their own enrollment to forge a fresh enrolled_at, faking a
+-- sub-24h enrolled->completed window and minting the Speed Runner achievement.
+-- SELECT policies (own + public-profile) are intentionally left in place.
 
 CREATE POLICY "Public profile enrollments are viewable"
   ON enrollments FOR SELECT USING (


### PR DESCRIPTION
Closes #149

## [P0-B5] Lock down forgeable `enrollments` RLS

`user_progress` was already locked to service_role-only writes (#prior, migration `20260624164418`). This PR closes the **remaining gap**: `enrollments` was still client-writable, letting an authenticated browser client **delete + re-insert its own enrollment** to forge a fresh `enrolled_at` — desyncing the DB from on-chain truth and (once #99 wires the time-based check) faking a sub-24h enrolled→completed window to mint the **Speed Runner** achievement. This issue **blocks #99**.

## What changed
**SQL only** — no TypeScript touched.

- **`supabase/schema.sql`**
  - Dropped the two client write policies on `enrollments`: `"Users can enroll themselves"` (INSERT) and `"Users can delete their own enrollments"` (DELETE). Replaced with an explanatory comment mirroring the `user_progress` lockdown. **SELECT policies kept** (own + public-profile). `enrollments` is now service_role-write-only, like `user_progress`.
  - Added two CHECK constraints (see below).
- **`supabase/migrations/20260624190000_lockdown_enrollments_rls.sql`** (new) — idempotent-safe (`DROP POLICY IF EXISTS`; `ADD CONSTRAINT` guarded by `pg_constraint` existence checks, since PG15 has no `ADD CONSTRAINT IF NOT EXISTS` for CHECKs). Mirrors `schema.sql`.

## Verify-first result (did NOT break enroll/unenroll)
Confirmed **no client/anon-key path** inserts or deletes `enrollments`:
- `use-on-chain-enroll.ts` / `use-on-chain-unenroll.ts` submit the **on-chain tx only**; both end with `// On-chain TX succeeded — Helius webhook will sync to Supabase`. No Supabase write.
- Repo-wide grep: every client-component `enrollments` reference is `.select(...)` (read). The only writes (upsert/delete/update) are in:
  - `lib/helius/event-handlers.ts` (Helius enroll/unenroll/finalize webhook)
  - `lib/solana/onchain-queue.ts` (its retry queue; `server-only`, imported only by API routes)
  - `app/api/admin/resync/route.ts` (admin resync)
- All three obtain their client via `createAdminClient()` → `SUPABASE_SERVICE_ROLE_KEY`, which **bypasses RLS**. Dropping the client policies therefore does **not** affect these legit writers.

## Constraints added
1. `enrollments.chk_enrollments_completed_after_enrolled`: `completed_at IS NULL OR completed_at >= enrolled_at` — a course can't be completed before it was enrolled; directly closes the forged-window direction. NULL `completed_at` (not yet finished) passes, so no existing valid row is rejected.
2. `user_progress.chk_user_progress_completed_at_requires_completed`: `completed_at IS NULL OR completed = true` — a completion timestamp may only exist on a completed row. Both legit writers (webhook + resync) always set `completed = true` alongside `completed_at`, so this rejects no valid row.

**FK not feasible** for `course_id` / `lesson_id`: these are Sanity `_id` strings; courses/lessons live in **Sanity, not Postgres** — there is no referenced Postgres table, so no FK can be added. Stated rather than invented.

## Verification
- `pnpm --filter @superteam-lms/web typecheck` — pass.
- `pnpm --filter @superteam-lms/web build` — pass (full route table compiled, incl. `/api/lessons/complete`, `/api/quests/daily`, `/api/webhooks/helius`).
- `pnpm vitest run` (web) — 23/23 pass.
- SQL verified **structurally** (no Postgres/docker available locally): syntax matches the existing constraint/policy style; `schema.sql` adds the constraints after the `CREATE TABLE`s; CHECK-with-NULL semantics confirmed (NULL → UNKNOWN → row allowed, never a false rejection). Service_role webhook writes are unaffected because service_role bypasses RLS entirely.

## Honest note for review
In the **current** code, `courseCompletionTimeHours` is hardcoded to `null` at both achievement call sites (`achievements.ts:129`, `event-handlers.ts:749`), so the Speed Runner time check isn't wired up **yet** — the forgery is **latent**, realized once #99 computes `completed_at − enrolled_at`. Independently, the dropped client policies were a real **data-integrity** hole today (a user could pollute their own `enrolled_at` / `tx_signature` / `completed_at` and desync from on-chain). This fix is the precondition that makes #99 safe.

> **SENSITIVE** — DB change. The migration `supabase/migrations/20260624190000_lockdown_enrollments_rls.sql` **must be applied** on merge for the lockdown + constraints to take effect.
