### PR TITLE
fix(onchain): cumulative XP ceiling + backend_signer gate in reward_xp (P0-A3)

### DIFF
--- a/apps/web/src/lib/solana/academy-program.ts
+++ b/apps/web/src/lib/solana/academy-program.ts
@@ -454,6 +454,7 @@ export async function rewardXp(
       xpMint: xpMint,
       recipientTokenAccount: recipientTokenAccount,
       minter: signer.publicKey,
+      backendSigner: signer.publicKey,
       tokenProgram: TOKEN_2022_PROGRAM_ID,
     })
     .rpc();

--- a/apps/web/src/lib/solana/idl/superteam_academy.json
+++ b/apps/web/src/lib/solana/idl/superteam_academy.json
@@ -856,6 +856,10 @@
           "signer": true
         },
         {
+          "name": "backend_signer",
+          "signer": true
+        },
+        {
           "name": "token_program",
           "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
         }
@@ -1242,41 +1246,46 @@
     },
     {
       "code": 6019,
+      "name": "MinterCapExceeded",
+      "msg": "Cumulative minted XP would exceed minter's total cap"
+    },
+    {
+      "code": 6020,
       "name": "LabelTooLong",
       "msg": "Minter label exceeds max length"
     },
     {
-      "code": 6020,
+      "code": 6021,
       "name": "AchievementNotActive",
       "msg": "Achievement type is not active"
     },
     {
-      "code": 6021,
+      "code": 6022,
       "name": "AchievementSupplyExhausted",
       "msg": "Achievement max supply reached"
     },
     {
-      "code": 6022,
+      "code": 6023,
       "name": "AchievementIdTooLong",
       "msg": "Achievement ID exceeds max length"
     },
     {
-      "code": 6023,
+      "code": 6024,
       "name": "AchievementNameTooLong",
       "msg": "Achievement name exceeds max length"
     },
     {
-      "code": 6024,
+      "code": 6025,
       "name": "AchievementUriTooLong",
       "msg": "Achievement URI exceeds max length"
     },
     {
-      "code": 6025,
+      "code": 6026,
       "name": "InvalidAmount",
       "msg": "Amount must be greater than zero"
     },
     {
-      "code": 6026,
+      "code": 6027,
       "name": "InvalidXpReward",
       "msg": "XP reward must be greater than zero"
     }
@@ -1973,6 +1982,10 @@
             "type": "u64"
           },
           {
+            "name": "max_total_xp",
+            "type": "u64"
+          },
+          {
             "name": "timestamp",
             "type": "i64"
           }
@@ -2035,10 +2048,14 @@
             "type": "i64"
           },
           {
-            "name": "_reserved",
-            "type": {
-              "array": ["u8", 8]
-            }
+            "name": "max_total_xp",
+            "docs": [
+              "Cumulative XP ceiling for this role. 0 = unlimited.",
+              "Occupies the 8 bytes formerly reserved, so the account size is",
+              "unchanged and pre-existing roles deserialize with this field = 0",
+              "(unlimited), preserving prior behavior until an admin sets a cap."
+            ],
+            "type": "u64"
           },
           {
             "name": "bump",
@@ -2062,6 +2079,11 @@
           },
           {
             "name": "max_xp_per_call",
+            "type": "u64"
+          },
+          {
+            "name": "max_total_xp",
+            "docs": ["Cumulative XP ceiling for this role. 0 = unlimited."],
             "type": "u64"
           }
         ]

--- a/apps/web/src/lib/solana/program-errors.ts
+++ b/apps/web/src/lib/solana/program-errors.ts
@@ -115,41 +115,46 @@ const ERROR_MAP: Record<number, ProgramErrorEntry> = {
     fallback: "Amount exceeds minter limit.",
   },
   6019: {
+    name: "MinterCapExceeded",
+    i18nKey: "minterCapExceeded",
+    fallback: "This would exceed the minter's cumulative XP cap.",
+  },
+  6020: {
     name: "LabelTooLong",
     i18nKey: "labelTooLong",
     fallback: "Label exceeds maximum length.",
   },
-  6020: {
+  6021: {
     name: "AchievementNotActive",
     i18nKey: "achievementNotActive",
     fallback: "This achievement is not currently active.",
   },
-  6021: {
+  6022: {
     name: "AchievementSupplyExhausted",
     i18nKey: "achievementSupplyExhausted",
     fallback: "This achievement has reached its maximum supply.",
   },
-  6022: {
+  6023: {
     name: "AchievementIdTooLong",
     i18nKey: "achievementIdTooLong",
     fallback: "Achievement ID exceeds maximum length.",
   },
-  6023: {
+  6024: {
     name: "AchievementNameTooLong",
     i18nKey: "achievementNameTooLong",
     fallback: "Achievement name exceeds maximum length.",
   },
-  6024: {
+  6025: {
     name: "AchievementUriTooLong",
     i18nKey: "achievementUriTooLong",
     fallback: "Achievement URI exceeds maximum length.",
   },
-  6025: {
+  6026: {
     name: "InvalidAmount",
     i18nKey: "invalidAmount",
     fallback: "Amount must be greater than zero.",
   },
-  6026: {
+  6027: {
     name: "InvalidXpReward",
     i18nKey: "invalidXpReward",
     fallback: "XP reward must be greater than zero.",

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -586,6 +586,7 @@
     "credentialAssetMismatch": "Credential asset does not match enrollment record.",
     "minterNotActive": "Minter role is not active.",
     "minterAmountExceeded": "Amount exceeds minter limit.",
+    "minterCapExceeded": "This would exceed the minter's cumulative XP cap.",
     "labelTooLong": "Label exceeds maximum length.",
     "achievementIdTooLong": "Achievement ID exceeds maximum length.",
     "achievementNameTooLong": "Achievement name exceeds maximum length.",

--- a/apps/web/src/messages/es.json
+++ b/apps/web/src/messages/es.json
@@ -586,6 +586,7 @@
     "credentialAssetMismatch": "El activo de la credencial no corresponde al registro de inscripción.",
     "minterNotActive": "El rol de minter no está activo.",
     "minterAmountExceeded": "La cantidad excede el límite del minter.",
+    "minterCapExceeded": "Esto excedería el límite acumulado de XP del minter.",
     "labelTooLong": "La etiqueta excede la longitud máxima.",
     "achievementIdTooLong": "El ID del logro excede la longitud máxima.",
     "achievementNameTooLong": "El nombre del logro excede la longitud máxima.",

--- a/apps/web/src/messages/pt-BR.json
+++ b/apps/web/src/messages/pt-BR.json
@@ -586,6 +586,7 @@
     "credentialAssetMismatch": "O ativo da credencial não corresponde ao registro de matrícula.",
     "minterNotActive": "O papel de minter não está ativo.",
     "minterAmountExceeded": "A quantidade excede o limite do minter.",
+    "minterCapExceeded": "Isso excederia o limite cumulativo de XP do minter.",
     "labelTooLong": "O rótulo excede o comprimento máximo.",
     "achievementIdTooLong": "O ID da conquista excede o comprimento máximo.",
     "achievementNameTooLong": "O nome da conquista excede o comprimento máximo.",

--- a/onchain-academy/programs/onchain-academy/src/errors.rs
+++ b/onchain-academy/programs/onchain-academy/src/errors.rs
@@ -40,6 +40,8 @@ pub enum AcademyError {
     MinterNotActive,
     #[msg("Amount exceeds minter's per-call limit")]
     MinterAmountExceeded,
+    #[msg("Cumulative minted XP would exceed minter's total cap")]
+    MinterCapExceeded,
     #[msg("Minter label exceeds max length")]
     LabelTooLong,
     #[msg("Achievement type is not active")]

--- a/onchain-academy/programs/onchain-academy/src/events.rs
+++ b/onchain-academy/programs/onchain-academy/src/events.rs
@@ -83,6 +83,7 @@ pub struct MinterRegistered {
     pub minter: Pubkey,
     pub label: String,
     pub max_xp_per_call: u64,
+    pub max_total_xp: u64,
     pub timestamp: i64,
 }
 

--- a/onchain-academy/programs/onchain-academy/src/instructions/initialize.rs
+++ b/onchain-academy/programs/onchain-academy/src/instructions/initialize.rs
@@ -90,7 +90,7 @@ pub fn handler(ctx: Context<Initialize>) -> Result<()> {
     minter_role.total_xp_minted = 0;
     minter_role.is_active = true;
     minter_role.created_at = Clock::get()?.unix_timestamp;
-    minter_role._reserved = [0u8; 8];
+    minter_role.max_total_xp = 0; // unlimited
     minter_role.bump = ctx.bumps.backend_minter_role;
 
     Ok(())

--- a/onchain-academy/programs/onchain-academy/src/instructions/register_minter.rs
+++ b/onchain-academy/programs/onchain-academy/src/instructions/register_minter.rs
@@ -9,6 +9,8 @@ pub struct RegisterMinterParams {
     pub minter: Pubkey,
     pub label: String,
     pub max_xp_per_call: u64,
+    /// Cumulative XP ceiling for this role. 0 = unlimited.
+    pub max_total_xp: u64,
 }
 
 pub fn handler(ctx: Context<RegisterMinter>, params: RegisterMinterParams) -> Result<()> {
@@ -24,13 +26,14 @@ pub fn handler(ctx: Context<RegisterMinter>, params: RegisterMinterParams) -> Re
     role.total_xp_minted = 0;
     role.is_active = true;
     role.created_at = Clock::get()?.unix_timestamp;
-    role._reserved = [0u8; 8];
+    role.max_total_xp = params.max_total_xp;
     role.bump = ctx.bumps.minter_role;
 
     emit!(MinterRegistered {
         minter: params.minter,
         label: params.label,
         max_xp_per_call: params.max_xp_per_call,
+        max_total_xp: params.max_total_xp,
         timestamp: role.created_at,
     });
 

--- a/onchain-academy/programs/onchain-academy/src/instructions/reward_xp.rs
+++ b/onchain-academy/programs/onchain-academy/src/instructions/reward_xp.rs
@@ -18,6 +18,18 @@ pub fn handler(ctx: Context<RewardXp>, amount: u64, memo: String) -> Result<()> 
         );
     }
 
+    let new_total = role
+        .total_xp_minted
+        .checked_add(amount)
+        .ok_or(AcademyError::Overflow)?;
+
+    if role.max_total_xp > 0 {
+        require!(
+            new_total <= role.max_total_xp,
+            AcademyError::MinterCapExceeded
+        );
+    }
+
     let config = &ctx.accounts.config;
     let config_seeds: &[&[u8]] = &[b"config", &[config.bump]];
 
@@ -31,10 +43,7 @@ pub fn handler(ctx: Context<RewardXp>, amount: u64, memo: String) -> Result<()> 
     )?;
 
     let role_mut = &mut ctx.accounts.minter_role;
-    role_mut.total_xp_minted = role_mut
-        .total_xp_minted
-        .checked_add(amount)
-        .ok_or(AcademyError::Overflow)?;
+    role_mut.total_xp_minted = new_total;
 
     emit!(XpRewarded {
         minter: ctx.accounts.minter.key(),
@@ -77,6 +86,11 @@ pub struct RewardXp<'info> {
     pub recipient_token_account: AccountInfo<'info>,
 
     pub minter: Signer<'info>,
+
+    #[account(
+        constraint = backend_signer.key() == config.backend_signer @ AcademyError::Unauthorized,
+    )]
+    pub backend_signer: Signer<'info>,
 
     /// CHECK: Validated by address constraint.
     #[account(address = spl_token_2022::id())]

--- a/onchain-academy/programs/onchain-academy/src/state/minter_role.rs
+++ b/onchain-academy/programs/onchain-academy/src/state/minter_role.rs
@@ -14,7 +14,11 @@ pub struct MinterRole {
     pub total_xp_minted: u64,
     pub is_active: bool,
     pub created_at: i64,
-    pub _reserved: [u8; 8],
+    /// Cumulative XP ceiling for this role. 0 = unlimited.
+    /// Occupies the 8 bytes formerly reserved, so the account size is
+    /// unchanged and pre-existing roles deserialize with this field = 0
+    /// (unlimited), preserving prior behavior until an admin sets a cap.
+    pub max_total_xp: u64,
     pub bump: u8,
 }
 
@@ -26,7 +30,7 @@ impl MinterRole {
     // + 8 (total_xp_minted)
     // + 1 (is_active)
     // + 8 (created_at)
-    // + 8 (_reserved)
+    // + 8 (max_total_xp, formerly _reserved)
     // + 1 (bump)
     pub const SIZE: usize = 8 + 32 + (4 + MAX_LABEL_LEN) + 8 + 8 + 1 + 8 + 8 + 1; // 110
 }

--- a/onchain-academy/tests/onchain-academy.ts
+++ b/onchain-academy/tests/onchain-academy.ts
@@ -2849,12 +2849,17 @@ describe("onchain-academy", () => {
       await provider.sendAndConfirm(tx);
     });
 
+    // Per-call cap 1000, cumulative cap 1200 — lets us exercise both ceilings.
+    const MINTER_MAX_PER_CALL = 1000;
+    const MINTER_MAX_TOTAL = 1200;
+
     it("register_minter", async () => {
       await program.methods
         .registerMinter({
           minter: testMinter.publicKey,
           label: "test-minter",
-          maxXpPerCall: new BN(1000),
+          maxXpPerCall: new BN(MINTER_MAX_PER_CALL),
+          maxTotalXp: new BN(MINTER_MAX_TOTAL),
         })
         .accountsPartial({
           config: configPda,
@@ -2868,7 +2873,8 @@ describe("onchain-academy", () => {
       const role = await program.account.minterRole.fetch(testMinterRolePda);
       expect(role.minter.toBase58()).to.equal(testMinter.publicKey.toBase58());
       expect(role.label).to.equal("test-minter");
-      expect(role.maxXpPerCall.toNumber()).to.equal(1000);
+      expect(role.maxXpPerCall.toNumber()).to.equal(MINTER_MAX_PER_CALL);
+      expect(role.maxTotalXp.toNumber()).to.equal(MINTER_MAX_TOTAL);
       expect(role.totalXpMinted.toNumber()).to.equal(0);
       expect(role.isActive).to.equal(true);
     });
@@ -2882,6 +2888,7 @@ describe("onchain-academy", () => {
           xpMint: xpMintKeypair.publicKey,
           recipientTokenAccount: minterRecipientTokenAccount,
           minter: testMinter.publicKey,
+          backendSigner: authority.publicKey,
           tokenProgram: TOKEN_2022_PROGRAM_ID,
         })
         .signers([testMinter])
@@ -2900,6 +2907,63 @@ describe("onchain-academy", () => {
       expect(role.totalXpMinted.toNumber()).to.equal(500);
     });
 
+    it("reward_xp fails without backend_signer (active minter alone is insufficient)", async () => {
+      try {
+        await program.methods
+          .rewardXp(new BN(100), "no backend signer")
+          .accountsPartial({
+            config: configPda,
+            minterRole: testMinterRolePda,
+            xpMint: xpMintKeypair.publicKey,
+            recipientTokenAccount: minterRecipientTokenAccount,
+            minter: testMinter.publicKey,
+            // backend_signer set to the minter itself, which is NOT
+            // config.backend_signer — the constraint must reject it.
+            backendSigner: testMinter.publicKey,
+            tokenProgram: TOKEN_2022_PROGRAM_ID,
+          })
+          .signers([testMinter])
+          .rpc();
+        expect.fail("Should have thrown");
+      } catch (err) {
+        const anchorErr = err as AnchorError;
+        expect(anchorErr.error.errorCode.code).to.equal("Unauthorized");
+      }
+    });
+
+    it("reward_xp fails with wrong backend_signer", async () => {
+      const wrongSigner = Keypair.generate();
+      const airdropSig = await provider.connection.requestAirdrop(
+        wrongSigner.publicKey,
+        LAMPORTS_PER_SOL
+      );
+      await provider.connection.confirmTransaction(airdropSig, "confirmed");
+
+      try {
+        await program.methods
+          .rewardXp(new BN(100), "wrong backend signer")
+          .accountsPartial({
+            config: configPda,
+            minterRole: testMinterRolePda,
+            xpMint: xpMintKeypair.publicKey,
+            recipientTokenAccount: minterRecipientTokenAccount,
+            minter: testMinter.publicKey,
+            backendSigner: wrongSigner.publicKey,
+            tokenProgram: TOKEN_2022_PROGRAM_ID,
+          })
+          .signers([testMinter, wrongSigner])
+          .rpc();
+        expect.fail("Should have thrown");
+      } catch (err) {
+        const anchorErr = err as AnchorError;
+        expect(anchorErr.error.errorCode.code).to.equal("Unauthorized");
+      }
+
+      // State must be untouched: still 500 from the one successful reward.
+      const role = await program.account.minterRole.fetch(testMinterRolePda);
+      expect(role.totalXpMinted.toNumber()).to.equal(500);
+    });
+
     it("reward_xp fails when exceeding max", async () => {
       try {
         await program.methods
@@ -2910,6 +2974,7 @@ describe("onchain-academy", () => {
             xpMint: xpMintKeypair.publicKey,
             recipientTokenAccount: minterRecipientTokenAccount,
             minter: testMinter.publicKey,
+            backendSigner: authority.publicKey,
             tokenProgram: TOKEN_2022_PROGRAM_ID,
           })
           .signers([testMinter])
@@ -2931,6 +2996,7 @@ describe("onchain-academy", () => {
             xpMint: xpMintKeypair.publicKey,
             recipientTokenAccount: minterRecipientTokenAccount,
             minter: testMinter.publicKey,
+            backendSigner: authority.publicKey,
             tokenProgram: TOKEN_2022_PROGRAM_ID,
           })
           .signers([testMinter])
@@ -2939,6 +3005,78 @@ describe("onchain-academy", () => {
       } catch (err) {
         const anchorErr = err as AnchorError;
         expect(anchorErr.error.errorCode.code).to.equal("InvalidAmount");
+      }
+    });
+
+    it("reward_xp fails when cumulative cap would be exceeded", async () => {
+      // total_xp_minted is 500; per-call cap (1000) allows 800, but
+      // 500 + 800 = 1300 > 1200 cumulative cap, so it must be rejected.
+      try {
+        await program.methods
+          .rewardXp(new BN(800), "over cumulative cap")
+          .accountsPartial({
+            config: configPda,
+            minterRole: testMinterRolePda,
+            xpMint: xpMintKeypair.publicKey,
+            recipientTokenAccount: minterRecipientTokenAccount,
+            minter: testMinter.publicKey,
+            backendSigner: authority.publicKey,
+            tokenProgram: TOKEN_2022_PROGRAM_ID,
+          })
+          .signers([testMinter])
+          .rpc();
+        expect.fail("Should have thrown");
+      } catch (err) {
+        const anchorErr = err as AnchorError;
+        expect(anchorErr.error.errorCode.code).to.equal("MinterCapExceeded");
+      }
+
+      // Rejected mint must not have moved any state.
+      const role = await program.account.minterRole.fetch(testMinterRolePda);
+      expect(role.totalXpMinted.toNumber()).to.equal(500);
+    });
+
+    it("reward_xp succeeds up to exactly the cumulative cap", async () => {
+      // 500 + 700 = 1200 == cap, which is allowed (<=).
+      const sig = await program.methods
+        .rewardXp(new BN(700), "reach cap")
+        .accountsPartial({
+          config: configPda,
+          minterRole: testMinterRolePda,
+          xpMint: xpMintKeypair.publicKey,
+          recipientTokenAccount: minterRecipientTokenAccount,
+          minter: testMinter.publicKey,
+          backendSigner: authority.publicKey,
+          tokenProgram: TOKEN_2022_PROGRAM_ID,
+        })
+        .signers([testMinter])
+        .rpc();
+      await provider.connection.confirmTransaction(sig, "confirmed");
+
+      const role = await program.account.minterRole.fetch(testMinterRolePda);
+      expect(role.totalXpMinted.toNumber()).to.equal(MINTER_MAX_TOTAL);
+    });
+
+    it("reward_xp fails once the cumulative cap is reached", async () => {
+      // total is now 1200 == cap; even +1 must be rejected.
+      try {
+        await program.methods
+          .rewardXp(new BN(1), "past cap")
+          .accountsPartial({
+            config: configPda,
+            minterRole: testMinterRolePda,
+            xpMint: xpMintKeypair.publicKey,
+            recipientTokenAccount: minterRecipientTokenAccount,
+            minter: testMinter.publicKey,
+            backendSigner: authority.publicKey,
+            tokenProgram: TOKEN_2022_PROGRAM_ID,
+          })
+          .signers([testMinter])
+          .rpc();
+        expect.fail("Should have thrown");
+      } catch (err) {
+        const anchorErr = err as AnchorError;
+        expect(anchorErr.error.errorCode.code).to.equal("MinterCapExceeded");
       }
     });
 
@@ -2975,6 +3113,7 @@ describe("onchain-academy", () => {
             xpMint: xpMintKeypair.publicKey,
             recipientTokenAccount: minterRecipientTokenAccount,
             minter: testMinter.publicKey,
+            backendSigner: authority.publicKey,
             tokenProgram: TOKEN_2022_PROGRAM_ID,
           })
           .signers([testMinter])

--- a/onchain-academy/tests/rust/src/test_minter_role.rs
+++ b/onchain-academy/tests/rust/src/test_minter_role.rs
@@ -1,13 +1,13 @@
 use crate::helpers::*;
 use anchor_lang::{AnchorDeserialize, AnchorSerialize};
-use solana_sdk::pubkey::Pubkey;
 use onchain_academy::state::{MinterRole, MAX_LABEL_LEN};
+use solana_sdk::pubkey::Pubkey;
 
 #[test]
 fn minter_role_size_constant_is_correct() {
     // 8 (discriminator) + 32 (minter) + (4 + 32) (label)
     // + 8 (max_xp_per_call) + 8 (total_xp_minted)
-    // + 1 (is_active) + 8 (created_at) + 8 (_reserved) + 1 (bump)
+    // + 1 (is_active) + 8 (created_at) + 8 (max_total_xp) + 1 (bump)
     assert_eq!(MinterRole::SIZE, 110);
 }
 
@@ -25,7 +25,7 @@ fn minter_role_serialization_roundtrip() {
         total_xp_minted: 12000,
         is_active: true,
         created_at: 1700000000,
-        _reserved: [0u8; 8],
+        max_total_xp: 1_000_000,
         bump: 253,
     };
 
@@ -40,7 +40,7 @@ fn minter_role_serialization_roundtrip() {
     assert_eq!(deserialized.total_xp_minted, 12000);
     assert!(deserialized.is_active);
     assert_eq!(deserialized.created_at, 1700000000);
-    assert_eq!(deserialized._reserved, [0u8; 8]);
+    assert_eq!(deserialized.max_total_xp, 1_000_000);
     assert_eq!(deserialized.bump, 253);
 }
 
@@ -53,7 +53,7 @@ fn minter_role_serialized_size_matches_constant() {
         total_xp_minted: 0,
         is_active: true,
         created_at: 0,
-        _reserved: [0u8; 8],
+        max_total_xp: 0,
         bump: 0,
     };
 
@@ -73,7 +73,7 @@ fn minter_role_shorter_label_fits_within_allocation() {
         total_xp_minted: 0,
         is_active: true,
         created_at: 0,
-        _reserved: [0u8; 8],
+        max_total_xp: 0,
         bump: 0,
     };
 
@@ -92,38 +92,55 @@ fn minter_role_unlimited_xp_cap() {
         total_xp_minted: 0,
         is_active: true,
         created_at: 0,
-        _reserved: [0u8; 8],
+        max_total_xp: 0,
         bump: 1,
     };
 
-    // 0 = unlimited per the field doc
+    // 0 = unlimited per the field docs
     assert_eq!(minter_role.max_xp_per_call, 0);
+    assert_eq!(minter_role.max_total_xp, 0);
 }
 
+/// max_total_xp occupies the bytes formerly reserved (`[u8; 8]`). A legacy
+/// MinterRole whose trailing 8 bytes are zero must deserialize with
+/// max_total_xp == 0 (unlimited), so the new ceiling is opt-in and existing
+/// roles keep their prior behavior. This encodes the zero-init migration
+/// guarantee at the byte level.
 #[test]
-fn minter_role_reserved_bytes_are_zeroed() {
+fn legacy_zeroed_reserved_bytes_deserialize_as_unlimited_cap() {
+    // Serialize a role with the former `_reserved` slot left zero (which is
+    // exactly the byte layout of every account written before this change).
     let minter_role = MinterRole {
         minter: Pubkey::new_unique(),
-        label: "test".to_string(),
-        max_xp_per_call: 0,
-        total_xp_minted: 0,
+        label: "legacy".to_string(),
+        max_xp_per_call: 500,
+        total_xp_minted: 9000,
         is_active: true,
-        created_at: 0,
-        _reserved: [0u8; 8],
-        bump: 1,
+        created_at: 1700000000,
+        max_total_xp: 0,
+        bump: 7,
     };
 
-    assert_eq!(minter_role._reserved, [0u8; 8]);
-    assert_eq!(minter_role._reserved.len(), 8);
+    let mut buf = Vec::new();
+    minter_role.serialize(&mut buf).unwrap();
+
+    // The 8 bytes immediately before the trailing `bump` are the max_total_xp
+    // slot; for a legacy (reserved-zeroed) account they are all zero.
+    let bump_offset = buf.len() - 1;
+    let cap_bytes = &buf[bump_offset - 8..bump_offset];
+    assert_eq!(cap_bytes, &[0u8; 8]);
+
+    let deserialized = MinterRole::deserialize(&mut buf.as_slice()).unwrap();
+    assert_eq!(deserialized.max_total_xp, 0);
+    assert_eq!(deserialized.bump, 7);
+    assert_eq!(deserialized.total_xp_minted, 9000);
 }
 
 #[test]
 fn minter_role_pda_is_deterministic() {
     let minter = Pubkey::new_unique();
-    let (pda1, bump1) =
-        Pubkey::find_program_address(&[b"minter", minter.as_ref()], &PROGRAM_ID);
-    let (pda2, bump2) =
-        Pubkey::find_program_address(&[b"minter", minter.as_ref()], &PROGRAM_ID);
+    let (pda1, bump1) = Pubkey::find_program_address(&[b"minter", minter.as_ref()], &PROGRAM_ID);
+    let (pda2, bump2) = Pubkey::find_program_address(&[b"minter", minter.as_ref()], &PROGRAM_ID);
     assert_eq!(pda1, pda2);
     assert_eq!(bump1, bump2);
 }
@@ -132,9 +149,7 @@ fn minter_role_pda_is_deterministic() {
 fn different_minters_yield_different_pdas() {
     let minter_a = Pubkey::new_unique();
     let minter_b = Pubkey::new_unique();
-    let (pda_a, _) =
-        Pubkey::find_program_address(&[b"minter", minter_a.as_ref()], &PROGRAM_ID);
-    let (pda_b, _) =
-        Pubkey::find_program_address(&[b"minter", minter_b.as_ref()], &PROGRAM_ID);
+    let (pda_a, _) = Pubkey::find_program_address(&[b"minter", minter_a.as_ref()], &PROGRAM_ID);
+    let (pda_b, _) = Pubkey::find_program_address(&[b"minter", minter_b.as_ref()], &PROGRAM_ID);
     assert_ne!(pda_a, pda_b);
 }


### PR DESCRIPTION
Closes #107

Hardens `reward_xp` against a compromised minter key with **two** independent controls. SENSITIVE on-chain change — please give it an adversarial review.

## Part A — cumulative XP ceiling (#107)
Previously `reward_xp` enforced only a per-call cap (`max_xp_per_call`) and tracked `total_xp_minted`, but had **no cumulative ceiling** — a compromised minter key could mint unbounded XP across many calls.

- Added `max_total_xp: u64` to `MinterRole` (`0` = unlimited).
- Enforced in the handler, **before** the `mint_xp` CPI, alongside the existing per-call check:
  ```rust
  let new_total = role.total_xp_minted.checked_add(amount).ok_or(Overflow)?;
  if role.max_total_xp > 0 {
      require!(new_total <= role.max_total_xp, AcademyError::MinterCapExceeded);
  }
  ```
  (`new_total` is reused to update `total_xp_minted`, so the checked-add isn't computed twice.)
- New error variant `MinterCapExceeded` (code **6019**).
- Threaded `max_total_xp` into `register_minter` (`RegisterMinterParams`, default `0`) and the `MinterRegistered` event. `initialize`'s auto-registered "backend" role sets it to `0` (unlimited), matching its `max_xp_per_call`.

### MinterRole size / migration decision (no size change, no migration)
`max_total_xp` **consumes the existing `_reserved: [u8; 8]` field in place** — it sits in the exact same byte offset (after `created_at`, before `bump`). Therefore:
- `MinterRole::SIZE` is **unchanged (110 bytes)** — verified by `minter_role_size_constant_is_correct`.
- **Existing on-chain `MinterRole` accounts deserialize unchanged**: their previously-zeroed reserved bytes now read as `max_total_xp = 0` (= unlimited), preserving current behavior until an admin registers a new minter with a cap. There is **no account migration** and no realloc.
- This byte-level guarantee is pinned by a new Rust test, `legacy_zeroed_reserved_bytes_deserialize_as_unlimited_cap`.

> Note: only `register_minter` sets `max_total_xp` — there is **no `update_minter` instruction** in the program, so an existing role's cap can't be changed in place (it would have to be revoked + re-registered). Flagging in case a settable cap is desired later.

## Part B — backend_signer authorization gate (folded in from #185's adversarial review)
`reward_xp` was gated **only** by an active `MinterRole`. Since `register_minter` can register any pubkey and `MinterRole` ≠ `config.backend_signer`, an active minter alone could mint arbitrary XP — violating #106's invariant that XP mints require the backend signer.

- Added `backend_signer: Signer<'info>` to `RewardXp` with `constraint = backend_signer.key() == config.backend_signer @ AcademyError::Unauthorized` — copied verbatim from the pattern in `complete_lesson.rs` / `award_achievement.rs`.
- `reward_xp` now requires **both** an active `MinterRole` for `minter` **and** a signature from `config.backend_signer`.

## Frontend / IDL changes
- **IDL** (`apps/web/src/lib/solana/idl/superteam_academy.json`): regenerated from `anchor build`. Structural diff vs. the previous IDL is *exactly* the intended changes — `backend_signer` on `reward_xp`, `max_total_xp` on `MinterRole`/`RegisterMinterParams`/`MinterRegistered`, and the new `MinterCapExceeded` error (which shifts subsequent error codes 6019→6027).
- **Call-site** (`academy-program.ts` `rewardXp()`): one-line account add — `backendSigner: signer.publicKey`. The backend keypair already signs the tx and is both `minter` and `backend_signer`, so no extra signer plumbing. The two other callers (`/api/quests/daily`, `onchain-queue.ts`) go through this same wrapper, so they need no change.
- **Error map** (`program-errors.ts`): inserted `MinterCapExceeded` at 6019 and renumbered `LabelTooLong`…`InvalidXpReward` (6019→6020 … 6026→6027) to stay in sync with `errors.rs`. This map is hand-maintained and keyed by numeric code, so it *had* to shift.
- **i18n**: added `programErrors.minterCapExceeded` to all three locales (en, pt-BR, es).
- No frontend `registerMinter` JS caller exists (it lives only in the IDL + on-chain), so nothing else needed updating for Part A.

## Tests
On-chain integration (`onchain-academy.ts`, block "15. Minter Roles" — test minter registered with `maxXpPerCall=1000`, `maxTotalXp=1200`):
- happy path still works (`reward_xp` 500 → success);
- **`reward_xp` fails without backend_signer** (active minter alone insufficient) → `Unauthorized`;
- **`reward_xp` fails with wrong backend_signer** → `Unauthorized`, state untouched;
- **cumulative cap blocks** the over-cap call (`500 + 800 > 1200`) → `MinterCapExceeded`, state untouched;
- **boundary**: `500 + 700 == 1200` succeeds (total hits the cap exactly);
- **at-cap** `+1` → `MinterCapExceeded`;
- existing per-call / amount=0 / revoke tests still pass (each updated to pass `backendSigner`).

Rust unit (`test_minter_role.rs`): size constant unchanged, serialization round-trips the new field, and the new legacy-deserialization test pins the zero-init migration guarantee.

## Verification (run locally — actual results)
- `anchor build` → ✅ compiles; IDL regenerated and synced to frontend.
- `cargo fmt --check` → ✅ clean.
- `cargo clippy -- -W clippy::all` → ✅ no new warnings (only pre-existing Anchor-macro `anchor-debug`/glob-reexport noise; none reference the changed files).
- `cargo test --manifest-path tests/rust/Cargo.toml` → ✅ **77 passed; 0 failed**.
- `anchor test` (local validator, program preloaded at the declared ID + mpl_core fixture) → ✅ **67 passing**, including all new/updated minter-role tests.
- `program_autofixer` on `reward_xp.rs`, `register_minter.rs`, `minter_role.rs` → ✅ no issues, `require_another_tool_call_after_fixing: false`.
- `apps/web` `tsc --noEmit` → ✅ no errors.
