### PR TITLE
fix(security): enforce server-only boundary on achievements + admin-signer

### DIFF
--- a/apps/web/src/components/gamification/streak-display.tsx
+++ b/apps/web/src/components/gamification/streak-display.tsx
@@ -4,11 +4,16 @@ import { useTranslations } from "next-intl";
 import { useLocale } from "next-intl";
 import { Fire } from "@phosphor-icons/react";
 import type { StreakData } from "@superteam-lms/types";
+// Import directly from the source module, not the @/lib/gamification barrel.
+// The barrel re-exports `achievements.ts`, which is `server-only`; importing
+// these client-safe streak helpers straight from their source keeps that
+// server-only module out of this "use client" bundle's import graph entirely
+// (defense in depth beyond tree-shaking).
 import {
   isActiveToday,
   generateWeekCalendar,
   getStreakMilestones,
-} from "@/lib/gamification";
+} from "@/lib/gamification/streaks";
 import { cn, todayDateString } from "@/lib/utils";
 
 interface StreakDisplayProps {

--- a/apps/web/src/lib/gamification/achievements.ts
+++ b/apps/web/src/lib/gamification/achievements.ts
@@ -1,3 +1,5 @@
+import "server-only";
+
 import { createAdminClient } from "@/lib/supabase/admin";
 import { getAllAchievements } from "@/lib/sanity/queries";
 

--- a/apps/web/src/lib/solana/admin-signer.ts
+++ b/apps/web/src/lib/solana/admin-signer.ts
@@ -1,3 +1,5 @@
+import "server-only";
+
 /**
  * Server-side authority signer for on-chain admin operations.
  *
@@ -9,8 +11,6 @@
  *
  * This module MUST ONLY be imported from API routes (server-side).
  */
-import "server-only";
-
 import { Connection, Keypair, PublicKey, SystemProgram } from "@solana/web3.js";
 import { AnchorProvider, Program } from "@coral-xyz/anchor";
 import type { Idl } from "@coral-xyz/anchor";


### PR DESCRIPTION
Closes #167

## What

Convert the implicit tree-shaking guarantee that keeps two server secrets out of the client bundle into a **build-enforced** one by adding `import "server-only";` as **line 1** of both modules:

- `apps/web/src/lib/gamification/achievements.ts` — uses `createAdminClient` (`SUPABASE_SERVICE_ROLE_KEY`). Guard added at line 1.
- `apps/web/src/lib/solana/admin-signer.ts` — reads `PROGRAM_AUTHORITY_SECRET` (hot-wallet key). Guard already existed at line 12 (after the doc comment); **moved to line 1** so `server-only` is evaluated first and the literal done-criteria is met.

With `server-only` in place, the build now **hard-fails** if either module is ever pulled into a client bundle, instead of silently relying on the bundler to tree-shake the unused barrel re-export.

## Client-import rewiring (the fragility the issue flagged)

The barrel `apps/web/src/lib/gamification/index.ts` re-exports `checkNewAchievements` from the now-`server-only` `achievements.ts`. Three `"use client"` components import from that barrel:

| Consumer | What it imports from the barrel | Runtime edge into `achievements.ts`? |
|---|---|---|
| `streak-display.tsx` | `isActiveToday`, `generateWeekCalendar`, `getStreakMilestones` (**value** imports, all defined in `./streaks`) | Yes — value imports create a static module-graph edge through the barrel |
| `dashboard-identity-panel.tsx` | `type AchievementDefinition` (**type-only**) | No — `import type` is erased at compile time |
| `achievement-grid.tsx` | `type AchievementDefinition` (**type-only**) | No — erased |

The production build **passed without rewiring** (the bundler does tree-shake the re-export today), so the issue's literal "done when" was already satisfiable with just the two guards. But to remove the fragile edge entirely rather than depend on tree-shaking, I rewired the one client component with a real runtime edge — `streak-display.tsx` — to import its three streak helpers **directly from `@/lib/gamification/streaks`** instead of via the barrel. This keeps the `server-only` module out of that client bundle's import graph entirely (defense in depth). The two type-only consumers were left unchanged: `import type` never produces a runtime import, so they cannot pull the secret module.

## How I confirmed the secret is not client-reachable

1. **Build enforcement (primary proof):** `pnpm --filter @superteam-lms/web build` — `✓ Compiled successfully`, types checked, `✓ Generating static pages (61/61)`. `server-only` only errors when a *client* bundle imports the module; a green production build (which builds all client bundles, including the `dashboard`/`settings`/`community` pages that render these gamification components) is the proof the module never lands client-side.
2. **Empirical canary (same method as the #162 audit):** built with a placeholder `SUPABASE_SERVICE_ROLE_KEY`, then grepped `.next/static/**`. None of the placeholder secret, `createAdminClient`, `checkNewAchievements`, or `UNLOCK_CHECKS` (an internal symbol of `achievements.ts`) appear in any client chunk.

## Build result

Production build green. The only build-time messages are benign artifacts of placeholder env vars used to run the build in this worktree (`Dataset not found` from a fake Sanity project id; a pre-existing `Dynamic server usage` notice on `/api/quests/daily` which uses `cookies`) — neither is a `server-only`/client-boundary error. No `.env` file was created or committed; placeholders were passed inline to the build command only.

## Files changed
- `apps/web/src/lib/gamification/achievements.ts` (+`server-only` line 1)
- `apps/web/src/lib/solana/admin-signer.ts` (moved `server-only` to line 1)
- `apps/web/src/components/gamification/streak-display.tsx` (barrel value import → direct `./streaks` import)