### PR TITLE
feat(credentials): pin credential metadata to Arweave at mint (P1-11)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -65,8 +65,25 @@ BUILD_SERVER_URL=https://academy-build-server-HASH.a.run.app
 # API key for X-API-Key header (same value as ACADEMY_API_KEY on Cloud Run)
 BUILD_SERVER_API_KEY=                      # PRIVATE — server-only
 
-# ── App URL (for sitemap, OG tags, NFT metadata URI) ─────────────────────────
+# ── App URL (for sitemap, OG tags, NFT metadata URI fallback) ────────────────
 NEXT_PUBLIC_APP_URL=http://localhost:3000
+
+# ── Arweave / Irys — permanent credential metadata (server-only) ─────────────
+# At credential mint, certificate metadata is pinned to Arweave via Irys so the
+# on-chain Metaplex Core asset URI resolves independently of app uptime
+# (apps/web/src/lib/solana/arweave.ts). If unset, mint falls back to the
+# app-served /api/certificates/metadata URL (logs a warning) — minting still
+# works, but issued credentials will NOT resolve if the app is offline.
+#
+# Value: 64-element JSON array of a SOLANA keypair's secret-key bytes (same
+# shape as BACKEND_SIGNER_SECRET). Irys is funded with this wallet's SOL — NOT
+# an Arweave JWK. The human must fund it:
+#   - devnet (NEXT_PUBLIC_SOLANA_NETWORK=devnet): uses https://devnet.irys.xyz,
+#     free, but uploads are pruned after ~60 days — NOT truly permanent.
+#   - mainnet (NEXT_PUBLIC_SOLANA_NETWORK=mainnet-beta): uses
+#     https://uploader.irys.xyz, permanent, paid in SOL from this wallet's Irys
+#     balance (top up at irys.xyz before mainnet minting).
+ARWEAVE_UPLOADER_SECRET=
 
 # ── Admin operations (server-only — never expose to browser) ──────────────────
 # JSON array of authority keypair bytes (64 elements), e.g. [12,34,...]

--- a/.env.example
+++ b/.env.example
@@ -71,9 +71,13 @@ NEXT_PUBLIC_APP_URL=http://localhost:3000
 # ── Arweave / Irys — permanent credential metadata (server-only) ─────────────
 # At credential mint, certificate metadata is pinned to Arweave via Irys so the
 # on-chain Metaplex Core asset URI resolves independently of app uptime
-# (apps/web/src/lib/solana/arweave.ts). If unset, mint falls back to the
-# app-served /api/certificates/metadata URL (logs a warning) — minting still
-# works, but issued credentials will NOT resolve if the app is offline.
+# (apps/web/src/lib/solana/arweave.ts). The uploader returns an Irys GATEWAY URL
+# (https://gateway.irys.xyz/<id>) — NOT https://arweave.net/<txid> — and that is
+# the exact string written on-chain. On mainnet the data settles on Arweave, so
+# the same <id> is also reachable via https://arweave.net/<id> and ar://<id>.
+# If unset, mint falls back to the app-served /api/certificates/metadata URL
+# (logs a warning) — minting still works, but issued credentials will NOT
+# resolve if the app is offline.
 #
 # Value: 64-element JSON array of a SOLANA keypair's secret-key bytes (same
 # shape as BACKEND_SIGNER_SECRET). Irys is funded with this wallet's SOL — NOT

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -340,6 +340,14 @@ HELIUS_WEBHOOK_SECRET=             # Helius webhook signature verification
 XP_MINT_AUTHORITY_SECRET=          # XP mint authority keypair (JSON array of 64 keypair bytes)
 PROGRAM_AUTHORITY_SECRET=          # Program authority keypair (JSON array of 64 keypair bytes)
 
+# Optional — Permanent credential storage (server-only)
+# Funds Irys uploads that pin credential metadata to Arweave at mint, so the
+# on-chain asset URI resolves independently of app uptime. SOLANA keypair (JSON
+# array of 64 bytes, like BACKEND_SIGNER_SECRET) — funded with SOL, NOT an
+# Arweave JWK. Unset → mint falls back to /api/certificates/metadata (warns).
+# REQUIRED (funded on mainnet-beta via irys.xyz) for permanent mainnet creds.
+ARWEAVE_UPLOADER_SECRET=
+
 # Optional — Analytics (platform works without these)
 NEXT_PUBLIC_GA4_MEASUREMENT_ID=
 NEXT_PUBLIC_POSTHOG_KEY=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -342,9 +342,12 @@ PROGRAM_AUTHORITY_SECRET=          # Program authority keypair (JSON array of 64
 
 # Optional — Permanent credential storage (server-only)
 # Funds Irys uploads that pin credential metadata to Arweave at mint, so the
-# on-chain asset URI resolves independently of app uptime. SOLANA keypair (JSON
-# array of 64 bytes, like BACKEND_SIGNER_SECRET) — funded with SOL, NOT an
-# Arweave JWK. Unset → mint falls back to /api/certificates/metadata (warns).
+# on-chain asset URI resolves independently of app uptime. The uploader returns
+# an Irys GATEWAY URL (https://gateway.irys.xyz/<id>) — NOT arweave.net — and
+# that is what gets pinned on-chain; on mainnet the same <id> also resolves via
+# https://arweave.net/<id> and ar://<id>. SOLANA keypair (JSON array of 64
+# bytes, like BACKEND_SIGNER_SECRET) — funded with SOL, NOT an Arweave JWK.
+# Unset → mint falls back to /api/certificates/metadata (warns).
 # REQUIRED (funded on mainnet-beta via irys.xyz) for permanent mainnet creds.
 ARWEAVE_UPLOADER_SECRET=
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -18,6 +18,7 @@
     "@metaplex-foundation/umi": "^1.4.1",
     "@metaplex-foundation/umi-bundle-defaults": "^1.4.1",
     "@metaplex-foundation/umi-signer-wallet-adapters": "^1.4.1",
+    "@metaplex-foundation/umi-uploader-irys": "^1.5.0",
     "@metaplex-foundation/umi-web3js-adapters": "^1.5.1",
     "@monaco-editor/react": "^4.7.0",
     "@noble/hashes": "^1.8.0",

--- a/apps/web/src/app/api/certificates/mint/route.ts
+++ b/apps/web/src/app/api/certificates/mint/route.ts
@@ -8,6 +8,7 @@ import { getCourseById } from "@/lib/sanity/queries";
 import { issueCredential, getConnection } from "@/lib/solana/academy-program";
 import { fetchEnrollment, fetchCourse } from "@/lib/solana/academy-reads";
 import { getProgramId } from "@/lib/solana/pda";
+import { uploadCertificateMetadata } from "@/lib/solana/arweave";
 import { logError } from "@/lib/logging";
 import { ERROR_IDS } from "@/constants/errorIds";
 
@@ -158,7 +159,9 @@ export async function POST(request: NextRequest) {
       seller_fee_basis_points: 0,
     };
 
-    // Store metadata in Supabase
+    // Store metadata in Supabase. Kept as the app-served fallback so
+    // /api/certificates/metadata resolves for already-issued credentials and
+    // whenever Arweave pinning is unavailable.
     const { data: metadataRow, error: metaError } = await adminClient
       .from("nft_metadata")
       .insert({ data: metadataJson })
@@ -172,7 +175,14 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const metadataUri = `${process.env.NEXT_PUBLIC_APP_URL ?? ""}/api/certificates/metadata?id=${metadataRow.id}`;
+    const appMetadataUri = `${process.env.NEXT_PUBLIC_APP_URL ?? ""}/api/certificates/metadata?id=${metadataRow.id}`;
+
+    // Pin metadata to Arweave so the on-chain asset URI is permanent and
+    // resolves independently of app uptime. Falls back to the app-served URL
+    // when ARWEAVE_UPLOADER_SECRET is unset or the upload fails (never blocks
+    // minting). uploadCertificateMetadata logs the reason for any fallback.
+    const arweaveUri = await uploadCertificateMetadata(metadataJson);
+    const metadataUri = arweaveUri ?? appMetadataUri;
 
     // Count how many certificates this user already has (the current one is not yet inserted)
     const { count: existingCertCount } = await adminClient

--- a/apps/web/src/lib/helius/event-handlers.ts
+++ b/apps/web/src/lib/helius/event-handlers.ts
@@ -15,6 +15,7 @@ import {
 } from "@/lib/solana/academy-program";
 import { fetchEnrollment, fetchCourse } from "@/lib/solana/academy-reads";
 import { getProgramId } from "@/lib/solana/pda";
+import { uploadCertificateMetadata } from "@/lib/solana/arweave";
 import { isAllLessonsComplete } from "@/lib/solana/bitmap";
 import { checkNewAchievements } from "@/lib/gamification/achievements";
 import {
@@ -576,7 +577,16 @@ async function tryIssueCredential(
       throw new Error(metaError?.message ?? "Failed to store NFT metadata");
     }
 
-    const metadataUri = `${process.env.NEXT_PUBLIC_APP_URL ?? ""}/api/certificates/metadata?id=${metadataRow.id}`;
+    const appMetadataUri = `${process.env.NEXT_PUBLIC_APP_URL ?? ""}/api/certificates/metadata?id=${metadataRow.id}`;
+
+    // This is the PRIMARY (automatic) credential path, so it must pin metadata
+    // to Arweave too — otherwise most issued credentials would point at the
+    // app-served URL and defeat the decoupling from app uptime. Falls back to
+    // the app URL when ARWEAVE_UPLOADER_SECRET is unset/malformed or the upload
+    // fails; uploadCertificateMetadata never throws and logs any fallback. The
+    // Supabase row is kept regardless as the app-served fallback.
+    const arweaveUri = await uploadCertificateMetadata(metadataJson);
+    const metadataUri = arweaveUri ?? appMetadataUri;
 
     let mintSignature: string;
     let mintAddress: PublicKey;

--- a/apps/web/src/lib/solana/__tests__/arweave.test.ts
+++ b/apps/web/src/lib/solana/__tests__/arweave.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// `arweave.ts` is a server-only module that pulls in the UMI Irys uploader and
+// the validated server env. Stub all three so the unit under test is just the
+// secret parsing + graceful-fallback logic — no network, no env boot.
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/env.server", () => ({
+  serverEnv: { SOLANA_RPC_URL: "https://api.devnet.solana.com" },
+}));
+// If a test ever reaches the uploader, fail loudly: the fallback paths must
+// return BEFORE constructing UMI / hitting Irys.
+const uploadJson = vi.fn(() => {
+  throw new Error("uploader should not be reached on the fallback path");
+});
+vi.mock("@metaplex-foundation/umi-bundle-defaults", () => ({
+  createUmi: () => ({
+    use: () => ({ use: () => ({ uploader: { uploadJson } }) }),
+  }),
+}));
+vi.mock("@metaplex-foundation/umi", () => ({ keypairIdentity: () => ({}) }));
+vi.mock("@metaplex-foundation/umi-web3js-adapters", () => ({
+  fromWeb3JsKeypair: () => ({}),
+}));
+vi.mock("@metaplex-foundation/umi-uploader-irys", () => ({
+  irysUploader: () => ({}),
+}));
+
+import { uploadCertificateMetadata } from "../arweave";
+
+const METADATA = { name: "Test Credential", symbol: "STACAD" };
+
+describe("uploadCertificateMetadata — graceful fallback", () => {
+  const originalSecret = process.env.ARWEAVE_UPLOADER_SECRET;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    uploadJson.mockClear();
+  });
+
+  afterEach(() => {
+    if (originalSecret === undefined) delete process.env.ARWEAVE_UPLOADER_SECRET;
+    else process.env.ARWEAVE_UPLOADER_SECRET = originalSecret;
+    errorSpy.mockRestore();
+    warnSpy.mockRestore();
+  });
+
+  it("returns null (not throw) when the secret is absent", async () => {
+    delete process.env.ARWEAVE_UPLOADER_SECRET;
+    await expect(uploadCertificateMetadata(METADATA)).resolves.toBeNull();
+    expect(uploadJson).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it("returns null (not throw) when the secret is not valid JSON", async () => {
+    process.env.ARWEAVE_UPLOADER_SECRET = "not-json-at-all";
+    await expect(uploadCertificateMetadata(METADATA)).resolves.toBeNull();
+    expect(uploadJson).not.toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
+  it("returns null (not throw) when the secret is JSON but not 64 bytes", async () => {
+    process.env.ARWEAVE_UPLOADER_SECRET = JSON.stringify([1, 2, 3]);
+    await expect(uploadCertificateMetadata(METADATA)).resolves.toBeNull();
+    expect(uploadJson).not.toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/solana/__tests__/arweave.test.ts
+++ b/apps/web/src/lib/solana/__tests__/arweave.test.ts
@@ -9,7 +9,7 @@ vi.mock("@/lib/env.server", () => ({
 }));
 // If a test ever reaches the uploader, fail loudly: the fallback paths must
 // return BEFORE constructing UMI / hitting Irys.
-const uploadJson = vi.fn(() => {
+const uploadJson = vi.fn((): string => {
   throw new Error("uploader should not be reached on the fallback path");
 });
 vi.mock("@metaplex-foundation/umi-bundle-defaults", () => ({
@@ -25,9 +25,15 @@ vi.mock("@metaplex-foundation/umi-uploader-irys", () => ({
   irysUploader: () => ({}),
 }));
 
+import { Keypair } from "@solana/web3.js";
 import { uploadCertificateMetadata } from "../arweave";
 
 const METADATA = { name: "Test Credential", symbol: "STACAD" };
+
+// A genuinely valid ed25519 secret key, so `getUploaderKeypair` accepts it and
+// execution reaches the upload path (the URL guard). The UMI adapter is mocked,
+// so this key is never used to sign anything.
+const VALID_SECRET = JSON.stringify(Array.from(Keypair.generate().secretKey));
 
 describe("uploadCertificateMetadata — graceful fallback", () => {
   const originalSecret = process.env.ARWEAVE_UPLOADER_SECRET;
@@ -41,7 +47,8 @@ describe("uploadCertificateMetadata — graceful fallback", () => {
   });
 
   afterEach(() => {
-    if (originalSecret === undefined) delete process.env.ARWEAVE_UPLOADER_SECRET;
+    if (originalSecret === undefined)
+      delete process.env.ARWEAVE_UPLOADER_SECRET;
     else process.env.ARWEAVE_UPLOADER_SECRET = originalSecret;
     errorSpy.mockRestore();
     warnSpy.mockRestore();
@@ -66,5 +73,23 @@ describe("uploadCertificateMetadata — graceful fallback", () => {
     await expect(uploadCertificateMetadata(METADATA)).resolves.toBeNull();
     expect(uploadJson).not.toHaveBeenCalled();
     expect(errorSpy).toHaveBeenCalled();
+  });
+
+  it("returns null (not throw) when the uploader returns a non-https URL", async () => {
+    // Valid keypair → the upload path runs and reaches the URL guard.
+    process.env.ARWEAVE_UPLOADER_SECRET = VALID_SECRET;
+    // Malformed-but-non-throwing return must not be pinned on-chain.
+    uploadJson.mockReturnValueOnce("ar://deadbeef");
+    await expect(uploadCertificateMetadata(METADATA)).resolves.toBeNull();
+    expect(uploadJson).toHaveBeenCalledTimes(1);
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
+  it("returns the gateway URL when the uploader returns a valid https URL", async () => {
+    process.env.ARWEAVE_UPLOADER_SECRET = VALID_SECRET;
+    const gatewayUrl = "https://gateway.irys.xyz/abc123";
+    uploadJson.mockReturnValueOnce(gatewayUrl);
+    await expect(uploadCertificateMetadata(METADATA)).resolves.toBe(gatewayUrl);
+    expect(uploadJson).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/src/lib/solana/arweave.ts
+++ b/apps/web/src/lib/solana/arweave.ts
@@ -1,0 +1,105 @@
+/**
+ * Permanent metadata storage on Arweave via Irys (Bundlr).
+ *
+ * Credential metadata that backs a Metaplex Core asset URI must outlive the
+ * app: if the frontend is ever offline, an issued credential still has to
+ * resolve. Serving it from `/api/certificates/metadata` couples the on-chain
+ * asset to app uptime. Uploading the JSON to Arweave and pointing the asset
+ * URI at the immutable gateway URL removes that coupling.
+ *
+ * Uploads go through the UMI Irys uploader (already in the dependency tree via
+ * `@metaplex-foundation/umi`). Irys settles the data on Arweave and returns a
+ * permanent gateway URL.
+ *
+ * Funding model: Irys here is funded with a **Solana keypair** (Irys's Solana
+ * currency), NOT a raw Arweave JWK. The keypair is read from
+ * `ARWEAVE_UPLOADER_SECRET` (64-element JSON array of secret-key bytes — same
+ * shape as `BACKEND_SIGNER_SECRET`). The human funds that wallet:
+ *   - devnet  → free, but data is NOT permanent (Irys devnet prunes after ~60d)
+ *   - mainnet → permanent, paid in SOL from the uploader wallet's Irys balance
+ *
+ * If `ARWEAVE_UPLOADER_SECRET` is absent, `uploadCertificateMetadata` returns
+ * `null` so the caller can fall back to the app-served metadata URL. Mint must
+ * keep working before Arweave is provisioned — this never hard-crashes.
+ *
+ * This module MUST ONLY be imported from API routes (server-side).
+ */
+import "server-only";
+
+import { Keypair } from "@solana/web3.js";
+import { createUmi } from "@metaplex-foundation/umi-bundle-defaults";
+import { keypairIdentity } from "@metaplex-foundation/umi";
+import { fromWeb3JsKeypair } from "@metaplex-foundation/umi-web3js-adapters";
+import { irysUploader } from "@metaplex-foundation/umi-uploader-irys";
+import { serverEnv } from "@/lib/env.server";
+
+// Irys node URLs. Devnet uploads are free (funded with devnet SOL) but are
+// pruned after ~60 days — only mainnet gives true permanence.
+const IRYS_MAINNET_NODE = "https://uploader.irys.xyz";
+const IRYS_DEVNET_NODE = "https://devnet.irys.xyz";
+
+let _uploaderMissingWarned = false;
+
+/**
+ * Loads the Solana keypair that funds Irys uploads, or `null` if unset.
+ * A malformed value throws (a misconfigured secret should fail loudly), but an
+ * absent value is a supported state (pre-Arweave-setup fallback).
+ */
+function getUploaderKeypair(): Keypair | null {
+  const secret = process.env.ARWEAVE_UPLOADER_SECRET;
+  if (!secret) return null;
+
+  const parsed: unknown = JSON.parse(secret);
+  if (!Array.isArray(parsed) || parsed.length !== 64) {
+    throw new Error("ARWEAVE_UPLOADER_SECRET must be a 64-element JSON array");
+  }
+  return Keypair.fromSecretKey(Uint8Array.from(parsed as number[]));
+}
+
+/**
+ * Uploads credential metadata JSON to Arweave via Irys and returns the
+ * permanent gateway URL (e.g. `https://arweave.net/<txid>`).
+ *
+ * Returns `null` when `ARWEAVE_UPLOADER_SECRET` is unset OR the upload fails,
+ * signalling the caller to fall back to the app-served metadata URL. Never
+ * throws on upload failure — pinning is best-effort so a transient Irys outage
+ * (or an unfunded wallet) does not block minting.
+ */
+export async function uploadCertificateMetadata(
+  metadata: Record<string, unknown>
+): Promise<string | null> {
+  const keypair = getUploaderKeypair();
+  if (!keypair) {
+    if (!_uploaderMissingWarned) {
+      console.warn(
+        "[arweave] ARWEAVE_UPLOADER_SECRET not set — credential metadata will " +
+          "be served from the app (/api/certificates/metadata) instead of " +
+          "Arweave. Issued credentials will NOT resolve if the app is offline. " +
+          "Set ARWEAVE_UPLOADER_SECRET (a funded Irys/Solana keypair) before mainnet."
+      );
+      _uploaderMissingWarned = true;
+    }
+    return null;
+  }
+
+  const network = process.env.NEXT_PUBLIC_SOLANA_NETWORK ?? "devnet";
+  const irysNode =
+    network === "mainnet-beta" ? IRYS_MAINNET_NODE : IRYS_DEVNET_NODE;
+
+  try {
+    const umi = createUmi(serverEnv.SOLANA_RPC_URL)
+      .use(keypairIdentity(fromWeb3JsKeypair(keypair)))
+      .use(irysUploader({ address: irysNode }));
+
+    // uploadJson serializes the object, uploads it, and returns the permanent
+    // gateway URL for the resulting Arweave transaction.
+    const uri = await umi.uploader.uploadJson(metadata);
+    return uri;
+  } catch (err) {
+    console.error(
+      "[arweave] Irys upload failed — falling back to app-served metadata.",
+      err instanceof Error ? err.message : String(err)
+    );
+    return null;
+  }
+}

--- a/apps/web/src/lib/solana/arweave.ts
+++ b/apps/web/src/lib/solana/arweave.ts
@@ -8,8 +8,12 @@
  * URI at the immutable gateway URL removes that coupling.
  *
  * Uploads go through the UMI Irys uploader (already in the dependency tree via
- * `@metaplex-foundation/umi`). Irys settles the data on Arweave and returns a
- * permanent gateway URL.
+ * `@metaplex-foundation/umi`). `uploadJson` returns an **Irys gateway** URL of
+ * the form `https://gateway.irys.xyz/<id>` — NOT `https://arweave.net/<txid>`.
+ * That gateway URL is what gets pinned on-chain as the Metaplex Core asset URI.
+ * On mainnet the data settles on Arweave, so the same `<id>` is also reachable
+ * via `https://arweave.net/<id>` and `ar://<id>`; on devnet only the Irys
+ * gateway resolves (and uploads are pruned after ~60 days).
  *
  * Funding model: Irys here is funded with a **Solana keypair** (Irys's Solana
  * currency), NOT a raw Arweave JWK. The keypair is read from
@@ -76,13 +80,18 @@ function getUploaderKeypair(): Keypair | null {
 
 /**
  * Uploads credential metadata JSON to Arweave via Irys and returns the
- * permanent gateway URL (e.g. `https://arweave.net/<txid>`).
+ * permanent **Irys gateway** URL (`https://gateway.irys.xyz/<id>`). This is the
+ * exact string pinned on-chain as the Metaplex Core asset URI. On mainnet the
+ * data settles on Arweave, so the same `<id>` also resolves via
+ * `https://arweave.net/<id>` and `ar://<id>`; on devnet only the Irys gateway
+ * resolves.
  *
- * Returns `null` when `ARWEAVE_UPLOADER_SECRET` is unset or malformed, OR the
- * upload fails — signalling the caller to fall back to the app-served metadata
- * URL. NEVER throws: pinning is best-effort, so a misconfigured secret, a
- * transient Irys outage, or an unfunded wallet does not block minting (and does
- * not leave an orphaned `nft_metadata` row from a half-completed mint).
+ * Returns `null` when `ARWEAVE_UPLOADER_SECRET` is unset or malformed, the
+ * upload fails, OR the uploader hands back a missing/non-`https` URL —
+ * signalling the caller to fall back to the app-served metadata URL. NEVER
+ * throws: pinning is best-effort, so a misconfigured secret, a transient Irys
+ * outage, or an unfunded wallet does not block minting (and does not leave an
+ * orphaned `nft_metadata` row from a half-completed mint).
  */
 export async function uploadCertificateMetadata(
   metadata: Record<string, unknown>
@@ -114,8 +123,22 @@ export async function uploadCertificateMetadata(
       .use(irysUploader({ address: irysNode }));
 
     // uploadJson serializes the object, uploads it, and returns the permanent
-    // gateway URL for the resulting Arweave transaction.
+    // Irys gateway URL (`https://gateway.irys.xyz/<id>`) for the upload.
     const uri = await umi.uploader.uploadJson(metadata);
+
+    // Guard the URL before the caller pins it irreversibly on-chain. A
+    // missing or non-`https` value (uploader contract drift, a relative path,
+    // an `ar://`/`http://` scheme) must NOT be written to the asset URI — fall
+    // back to the app-served URL instead.
+    if (typeof uri !== "string" || !uri.startsWith("https://")) {
+      console.error(
+        "[arweave] Irys upload returned a missing or non-https URL — falling " +
+          "back to app-served metadata rather than pinning it on-chain.",
+        JSON.stringify(uri)
+      );
+      return null;
+    }
+
     return uri;
   } catch (err) {
     console.error(

--- a/apps/web/src/lib/solana/arweave.ts
+++ b/apps/web/src/lib/solana/arweave.ts
@@ -18,9 +18,11 @@
  *   - devnet  → free, but data is NOT permanent (Irys devnet prunes after ~60d)
  *   - mainnet → permanent, paid in SOL from the uploader wallet's Irys balance
  *
- * If `ARWEAVE_UPLOADER_SECRET` is absent, `uploadCertificateMetadata` returns
- * `null` so the caller can fall back to the app-served metadata URL. Mint must
- * keep working before Arweave is provisioned — this never hard-crashes.
+ * If `ARWEAVE_UPLOADER_SECRET` is absent OR malformed,
+ * `uploadCertificateMetadata` returns `null` so the caller can fall back to the
+ * app-served metadata URL. Mint must keep working before Arweave is provisioned
+ * — this never hard-crashes (a misconfigured secret degrades gracefully, it
+ * does not 500 the mint or leave an orphaned `nft_metadata` row).
  *
  * This module MUST ONLY be imported from API routes (server-side).
  */
@@ -38,46 +40,66 @@ import { serverEnv } from "@/lib/env.server";
 const IRYS_MAINNET_NODE = "https://uploader.irys.xyz";
 const IRYS_DEVNET_NODE = "https://devnet.irys.xyz";
 
-let _uploaderMissingWarned = false;
-
 /**
- * Loads the Solana keypair that funds Irys uploads, or `null` if unset.
- * A malformed value throws (a misconfigured secret should fail loudly), but an
- * absent value is a supported state (pre-Arweave-setup fallback).
+ * Loads the Solana keypair that funds Irys uploads.
+ *
+ * Returns `null` for BOTH the absent and the malformed case, and NEVER throws.
+ * The only caller (`uploadCertificateMetadata`) treats `null` as "fall back to
+ * the app-served metadata URL", so neither state may escape as an exception:
+ *   - absent    → supported pre-Arweave-setup state
+ *   - malformed → a misconfiguration (not JSON, or not a 64-byte secret key).
+ *     We log it loudly (`console.error`) but still degrade gracefully rather
+ *     than letting the throw propagate to the mint route, which would 500 the
+ *     mint AND orphan the already-inserted `nft_metadata` row.
  */
 function getUploaderKeypair(): Keypair | null {
   const secret = process.env.ARWEAVE_UPLOADER_SECRET;
   if (!secret) return null;
 
-  const parsed: unknown = JSON.parse(secret);
-  if (!Array.isArray(parsed) || parsed.length !== 64) {
-    throw new Error("ARWEAVE_UPLOADER_SECRET must be a 64-element JSON array");
+  try {
+    const parsed: unknown = JSON.parse(secret);
+    if (!Array.isArray(parsed) || parsed.length !== 64) {
+      throw new Error("must be a 64-element JSON array of secret-key bytes");
+    }
+    return Keypair.fromSecretKey(Uint8Array.from(parsed as number[]));
+  } catch (err) {
+    console.error(
+      "[arweave] ARWEAVE_UPLOADER_SECRET is set but malformed — credential " +
+        "metadata will fall back to the app-served URL " +
+        "(/api/certificates/metadata) instead of Arweave. Fix the secret (a " +
+        "64-element JSON array of Solana secret-key bytes) before mainnet.",
+      err instanceof Error ? err.message : String(err)
+    );
+    return null;
   }
-  return Keypair.fromSecretKey(Uint8Array.from(parsed as number[]));
 }
 
 /**
  * Uploads credential metadata JSON to Arweave via Irys and returns the
  * permanent gateway URL (e.g. `https://arweave.net/<txid>`).
  *
- * Returns `null` when `ARWEAVE_UPLOADER_SECRET` is unset OR the upload fails,
- * signalling the caller to fall back to the app-served metadata URL. Never
- * throws on upload failure — pinning is best-effort so a transient Irys outage
- * (or an unfunded wallet) does not block minting.
+ * Returns `null` when `ARWEAVE_UPLOADER_SECRET` is unset or malformed, OR the
+ * upload fails — signalling the caller to fall back to the app-served metadata
+ * URL. NEVER throws: pinning is best-effort, so a misconfigured secret, a
+ * transient Irys outage, or an unfunded wallet does not block minting (and does
+ * not leave an orphaned `nft_metadata` row from a half-completed mint).
  */
 export async function uploadCertificateMetadata(
   metadata: Record<string, unknown>
 ): Promise<string | null> {
+  // `getUploaderKeypair` already logs the malformed case. A missing keypair
+  // here means either unset or malformed; in both cases the caller falls back
+  // to the app-served URL. (Serverless cold starts reset module state, so we do
+  // not deduplicate this warning — it is cheap and useful on each invocation.)
   const keypair = getUploaderKeypair();
   if (!keypair) {
-    if (!_uploaderMissingWarned) {
+    if (!process.env.ARWEAVE_UPLOADER_SECRET) {
       console.warn(
         "[arweave] ARWEAVE_UPLOADER_SECRET not set — credential metadata will " +
           "be served from the app (/api/certificates/metadata) instead of " +
           "Arweave. Issued credentials will NOT resolve if the app is offline. " +
           "Set ARWEAVE_UPLOADER_SECRET (a funded Irys/Solana keypair) before mainnet."
       );
-      _uploaderMissingWarned = true;
     }
     return null;
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       '@metaplex-foundation/umi-signer-wallet-adapters':
         specifier: ^1.4.1
         version: 1.4.1(@metaplex-foundation/umi@1.4.1)(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))
+      '@metaplex-foundation/umi-uploader-irys':
+        specifier: ^1.5.0
+        version: 1.5.0(@metaplex-foundation/umi@1.4.1)(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(@types/node@22.19.9)(arweave@1.15.7)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@metaplex-foundation/umi-web3js-adapters':
         specifier: ^1.5.1
         version: 1.5.1(@metaplex-foundation/umi@1.4.1)(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))
@@ -1508,6 +1511,84 @@ packages:
     resolution: {integrity: sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
+  '@ethersproject/abstract-provider@5.8.0':
+    resolution: {integrity: sha512-wC9SFcmh4UK0oKuLJQItoQdzS/qZ51EJegK6EmAWlh+OptpQ/npECOR3QqECd8iGHC0RJb4WKbVdSfif4ammrg==}
+
+  '@ethersproject/abstract-signer@5.8.0':
+    resolution: {integrity: sha512-N0XhZTswXcmIZQdYtUnd79VJzvEwXQw6PK0dTl9VoYrEBxxCPXqS0Eod7q5TNKRxe1/5WUMuR0u0nqTF/avdCA==}
+
+  '@ethersproject/address@5.8.0':
+    resolution: {integrity: sha512-GhH/abcC46LJwshoN+uBNoKVFPxUuZm6dA257z0vZkKmU1+t8xTn8oK7B9qrj8W2rFRMch4gbJl6PmVxjxBEBA==}
+
+  '@ethersproject/base64@5.8.0':
+    resolution: {integrity: sha512-lN0oIwfkYj9LbPx4xEkie6rAMJtySbpOAFXSDVQaBnAzYfB4X2Qr+FXJGxMoc3Bxp2Sm8OwvzMrywxyw0gLjIQ==}
+
+  '@ethersproject/basex@5.8.0':
+    resolution: {integrity: sha512-PIgTszMlDRmNwW9nhS6iqtVfdTAKosA7llYXNmGPw4YAI1PUyMv28988wAb41/gHF/WqGdoLv0erHaRcHRKW2Q==}
+
+  '@ethersproject/bignumber@5.8.0':
+    resolution: {integrity: sha512-ZyaT24bHaSeJon2tGPKIiHszWjD/54Sz8t57Toch475lCLljC6MgPmxk7Gtzz+ddNN5LuHea9qhAe0x3D+uYPA==}
+
+  '@ethersproject/bytes@5.8.0':
+    resolution: {integrity: sha512-vTkeohgJVCPVHu5c25XWaWQOZ4v+DkGoC42/TS2ond+PARCxTJvgTFUNDZovyQ/uAQ4EcpqqowKydcdmRKjg7A==}
+
+  '@ethersproject/constants@5.8.0':
+    resolution: {integrity: sha512-wigX4lrf5Vu+axVTIvNsuL6YrV4O5AXl5ubcURKMEME5TnWBouUh0CDTWxZ2GpnRn1kcCgE7l8O5+VbV9QTTcg==}
+
+  '@ethersproject/hash@5.8.0':
+    resolution: {integrity: sha512-ac/lBcTbEWW/VGJij0CNSw/wPcw9bSRgCB0AIBz8CvED/jfvDoV9hsIIiWfvWmFEi8RcXtlNwp2jv6ozWOsooA==}
+
+  '@ethersproject/hdnode@5.8.0':
+    resolution: {integrity: sha512-4bK1VF6E83/3/Im0ERnnUeWOY3P1BZml4ZD3wcH8Ys0/d1h1xaFt6Zc+Dh9zXf9TapGro0T4wvO71UTCp3/uoA==}
+
+  '@ethersproject/json-wallets@5.8.0':
+    resolution: {integrity: sha512-HxblNck8FVUtNxS3VTEYJAcwiKYsBIF77W15HufqlBF9gGfhmYOJtYZp8fSDZtn9y5EaXTE87zDwzxRoTFk11w==}
+
+  '@ethersproject/keccak256@5.8.0':
+    resolution: {integrity: sha512-A1pkKLZSz8pDaQ1ftutZoaN46I6+jvuqugx5KYNeQOPqq+JZ0Txm7dlWesCHB5cndJSu5vP2VKptKf7cksERng==}
+
+  '@ethersproject/logger@5.8.0':
+    resolution: {integrity: sha512-Qe6knGmY+zPPWTC+wQrpitodgBfH7XoceCGL5bJVejmH+yCS3R8jJm8iiWuvWbG76RUmyEG53oqv6GMVWqunjA==}
+
+  '@ethersproject/networks@5.8.0':
+    resolution: {integrity: sha512-egPJh3aPVAzbHwq8DD7Po53J4OUSsA1MjQp8Vf/OZPav5rlmWUaFLiq8cvQiGK0Z5K6LYzm29+VA/p4RL1FzNg==}
+
+  '@ethersproject/pbkdf2@5.8.0':
+    resolution: {integrity: sha512-wuHiv97BrzCmfEaPbUFpMjlVg/IDkZThp9Ri88BpjRleg4iePJaj2SW8AIyE8cXn5V1tuAaMj6lzvsGJkGWskg==}
+
+  '@ethersproject/properties@5.8.0':
+    resolution: {integrity: sha512-PYuiEoQ+FMaZZNGrStmN7+lWjlsoufGIHdww7454FIaGdbe/p5rnaCXTr5MtBYl3NkeoVhHZuyzChPeGeKIpQw==}
+
+  '@ethersproject/providers@5.8.0':
+    resolution: {integrity: sha512-3Il3oTzEx3o6kzcg9ZzbE+oCZYyY+3Zh83sKkn4s1DZfTUjIegHnN2Cm0kbn9YFy45FDVcuCLLONhU7ny0SsCw==}
+
+  '@ethersproject/random@5.8.0':
+    resolution: {integrity: sha512-E4I5TDl7SVqyg4/kkA/qTfuLWAQGXmSOgYyO01So8hLfwgKvYK5snIlzxJMk72IFdG/7oh8yuSqY2KX7MMwg+A==}
+
+  '@ethersproject/rlp@5.8.0':
+    resolution: {integrity: sha512-LqZgAznqDbiEunaUvykH2JAoXTT9NV0Atqk8rQN9nx9SEgThA/WMx5DnW8a9FOufo//6FZOCHZ+XiClzgbqV9Q==}
+
+  '@ethersproject/sha2@5.8.0':
+    resolution: {integrity: sha512-dDOUrXr9wF/YFltgTBYS0tKslPEKr6AekjqDW2dbn1L1xmjGR+9GiKu4ajxovnrDbwxAKdHjW8jNcwfz8PAz4A==}
+
+  '@ethersproject/signing-key@5.8.0':
+    resolution: {integrity: sha512-LrPW2ZxoigFi6U6aVkFN/fa9Yx/+4AtIUe4/HACTvKJdhm0eeb107EVCIQcrLZkxaSIgc/eCrX8Q1GtbH+9n3w==}
+
+  '@ethersproject/strings@5.8.0':
+    resolution: {integrity: sha512-qWEAk0MAvl0LszjdfnZ2uC8xbR2wdv4cDabyHiBh3Cldq/T8dPH3V4BbBsAYJUeonwD+8afVXld274Ls+Y1xXg==}
+
+  '@ethersproject/transactions@5.8.0':
+    resolution: {integrity: sha512-UglxSDjByHG0TuU17bDfCemZ3AnKO2vYrL5/2n2oXvKzvb7Cz+W9gOWXKARjp2URVwcWlQlPOEQyAviKwT4AHg==}
+
+  '@ethersproject/wallet@5.8.0':
+    resolution: {integrity: sha512-G+jnzmgg6UxurVKRKvw27h0kvG75YKXZKdlLYmAHeF32TGUzHkOFd7Zn6QHOTYRFWnfjtSSFjBowKo7vfrXzPA==}
+
+  '@ethersproject/web@5.8.0':
+    resolution: {integrity: sha512-j7+Ksi/9KfGviws6Qtf9Q7KCqRhpwrYKQPs+JBA/rKVFF/yaWLHJEH3zfVP2plVu+eys0d2DlFmhoQJayFewcw==}
+
+  '@ethersproject/wordlists@5.8.0':
+    resolution: {integrity: sha512-2df9bbXicZws2Sb5S6ET493uJ0Z84Fjr3pC4tu/qlnZERibZCeUVuqdtt+7Tv9xxhUxHoIekIA7avrKUWHrezg==}
+
   '@exodus/bytes@1.11.0':
     resolution: {integrity: sha512-wO3vd8nsEHdumsXrjGO/v4p6irbg7hy9kvIeR6i2AwylZSk4HJdWgL0FNaVquW1+AweJcdvU1IEpuIWk/WaPnA==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
@@ -1697,6 +1778,43 @@ packages:
       '@types/node':
         optional: true
 
+  '@irys/arweave@0.0.2':
+    resolution: {integrity: sha512-ddE5h4qXbl0xfGlxrtBIwzflaxZUDlDs43TuT0u1OMfyobHul4AA1VEX72Rpzw2bOh4vzoytSqA1jCM7x9YtHg==}
+
+  '@irys/bundles@0.0.1':
+    resolution: {integrity: sha512-yeQNzElERksFbfbNxJQsMkhtkI3+tNqIMZ/Wwxh76NVBmCnCP5huefOv7ET0MOO7TEQL+TqvKSqmFklYSvTyHw==}
+
+  '@irys/bundles@0.0.3':
+    resolution: {integrity: sha512-zSorcWJO0W7WHBPaTF6C3FNig1ZrCSKIDqnkk91SLl9jcybz5bWmthUFL2D7ywzh1XV5tZQC09bkNJRcXeeGOA==}
+
+  '@irys/query@0.0.9':
+    resolution: {integrity: sha512-uBIy8qeOQupUSBzR+1KU02JJXFp5Ue9l810PIbBF/ylUB8RTreUFkyyABZ7J3FUaOIXFYrT7WVFSJSzXM7P+8w==}
+    engines: {node: '>=16.10.0'}
+
+  '@irys/upload-core@0.0.10':
+    resolution: {integrity: sha512-E7kCNSOTPqwBbnd2wnnklPrR0HtLnENmu5NVhgs+B9cUeyN9AcvzRDOJLKNmYS6q514bDwb/PUgB+vP/070now==}
+
+  '@irys/upload-core@0.0.9':
+    resolution: {integrity: sha512-Ha4pX8jgYBA3dg5KHDPk+Am0QO+SmvnmgCwKa6uiDXZKuVr0neSx4V1OAHoP+As+j7yYgfChdsdrvsNzZGGehA==}
+
+  '@irys/upload-solana@0.1.8':
+    resolution: {integrity: sha512-pJyG8uJ3NIpbIGDA9hYRHij5xF1DrU0QMa4i2mVJlYwbSdQfNdcJ8SdT4ZsrTh1g/+OWMzbo2l/ziMY1Js9HGA==}
+
+  '@irys/upload@0.0.14':
+    resolution: {integrity: sha512-6XdkyS5cVINcPjv1MzA6jDsawfG7Bw6sq5wilNx5B4X7nNotBPC3SuRrZs06G/0BTUj15W+TRO/tZTDWRUfZzA==}
+
+  '@irys/upload@0.0.15':
+    resolution: {integrity: sha512-VS1ieI8Hipv7F/odL2rDfn0S9VCwj3GFhROI8el0RjzpcaXCobezP0V4yuvppyB+E4Oiu6xQTXooaIBh/S7xPA==}
+
+  '@irys/web-upload-solana@0.1.8':
+    resolution: {integrity: sha512-jzPihVOFbvTiJRwsWDOiip8CNk2I5TAkyZwWbkeFJQRvX95HOw1iI4KlbeBTDc6EJcyj8BWsxkMqIE/cBqlKoQ==}
+
+  '@irys/web-upload@0.0.14':
+    resolution: {integrity: sha512-vBIslG2KSGyeJjZNTbSvLmGO/bbHS1jcDkD0A1aLgx7xkiTpfdbXOrn4hznPkzQhPtluX4aL44On0GXrEcD8eQ==}
+
+  '@irys/web-upload@0.0.15':
+    resolution: {integrity: sha512-ajwy+CHEL+OH6UpO3dDT6xAK5XmJy2xK9Qb4aj+7uphSUczEiSxuSsO0sz/ekAgO/Ymwgkdozk3U1WAnUjbxMg==}
+
   '@isaacs/balanced-match@4.0.1':
     resolution: {integrity: sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==}
     engines: {node: 20 || >=22}
@@ -1875,6 +1993,12 @@ packages:
       '@metaplex-foundation/umi': ^1.4.1
       '@solana/web3.js': ^1.72.0
 
+  '@metaplex-foundation/umi-uploader-irys@1.5.0':
+    resolution: {integrity: sha512-Zi9bkwlJUbozlPgpG5Cj6SjyTfyckQv29ef4au8UkYf8EEPmPEf5i46FDkDuY+1ClFugqDr+IYOg5D2YDVlJWQ==}
+    peerDependencies:
+      '@metaplex-foundation/umi': ^1.5.1
+      '@solana/web3.js': ^1.72.0
+
   '@metaplex-foundation/umi-web3js-adapters@1.5.1':
     resolution: {integrity: sha512-6W3JElD0B0EbgHofVKqk4PbP/JDrUHIKWciM7tEuXTDXbuXbSECDe7qlTU0JZXmVZNfYufI6FHnkCfPys2ZnIQ==}
     peerDependencies:
@@ -1986,9 +2110,16 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@noble/curves@1.7.0':
+    resolution: {integrity: sha512-UTMhXK9SeDhFJVrHeUJ5uZlI6ajXg10O6Ddocf9S6GjbSBVZsJo88HzKwXznNfGpMTRDyJkqMjNDPYgf0qFWnw==}
+    engines: {node: ^14.21.3 || >=16}
+
   '@noble/curves@1.9.7':
     resolution: {integrity: sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==}
     engines: {node: ^14.21.3 || >=16}
+
+  '@noble/ed25519@1.7.5':
+    resolution: {integrity: sha512-xuS0nwRMQBvSxDa7UxMb61xTiH3MxTgUfhyPUALVIe0FlOAz4sjELwyDRyUvqeEYfRSG9qNjFIycqLZppg4RSA==}
 
   '@noble/hashes@1.8.0':
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
@@ -2795,6 +2926,12 @@ packages:
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
+  '@randlabs/communication-bridge@1.0.1':
+    resolution: {integrity: sha512-CzS0U8IFfXNK7QaJFE4pjbxDGfPjbXBEsEaCn9FN15F+ouSAEUQkva3Gl66hrkBZOGexKFEWMwUHIDKpZ2hfVg==}
+
+  '@randlabs/myalgo-connect@1.4.2':
+    resolution: {integrity: sha512-K9hEyUi7G8tqOp7kWIALJLVbGCByhilcy6123WfcorxWwiE1sbQupPyIU5f3YdQK6wMjBsyTWiLW52ZBMp7sXA==}
+
   '@react-native-async-storage/async-storage@1.24.0':
     resolution: {integrity: sha512-W4/vbwUOYOjco0x3toB8QCr7EjIP6nE9G7o8PMguvvjYT5Awg09lyV4enACRx4s++PPulBiBSjL0KTFx2u0Z/g==}
     peerDependencies:
@@ -3298,6 +3435,12 @@ packages:
     resolution: {integrity: sha512-c8LmzR5Wx93zJ10ohhp0XlmPrTNSFyvPcLbNY/sN45Wj5VOngz4FbBMbX9j64sSQLt+676U6OhiVfjs1yw3YCw==}
     engines: {node: '>=20.0.0'}
 
+  '@scure/base@1.2.1':
+    resolution: {integrity: sha512-DGmGtC8Tt63J5GfHgfl5CuAXh96VF/LD8K9Hr/Gv0J2lAoRGlPOMpqMpMbCTOoOJMZCk2Xt+DskdDyn6dEFdzQ==}
+
+  '@scure/starknet@1.1.0':
+    resolution: {integrity: sha512-83g3M6Ix2qRsPN4wqLDqiRZ2GBNbjVWfboJE/9UjfG+MHr6oDSu/CWgy8hsBSJejr09DkkL+l0Ze4KVrlCIdtQ==}
+
   '@sentry-internal/browser-utils@10.38.0':
     resolution: {integrity: sha512-UOJtYmdcxHCcV0NPfXFff/a95iXl/E0EhuQ1y0uE0BuZDMupWSF5t2BgC4HaE5Aw3RTjDF3XkSHWoIF6ohy7eA==}
     engines: {node: '>=18'}
@@ -3696,6 +3839,9 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@starknet-io/types-js@0.7.10':
+    resolution: {integrity: sha512-1VtCqX4AHWJlRRSYGSn+4X1mqolI1Tdq62IwzoU2vUuEE72S1OlEeGhpvd6XsdqXcfHmVzYfj8k1XtKBQqwo9w==}
+
   '@supabase/auth-js@2.95.3':
     resolution: {integrity: sha512-vD2YoS8E2iKIX0F7EwXTmqhUpaNsmbU6X2R0/NdFcs02oEfnHyNP/3M716f3wVJ2E5XHGiTFXki6lRckhJ0Thg==}
     engines: {node: '>=20.0.0'}
@@ -3724,6 +3870,10 @@ packages:
   '@supabase/supabase-js@2.95.3':
     resolution: {integrity: sha512-Fukw1cUTQ6xdLiHDJhKKPu6svEPaCEDvThqCne3OaQyZvuq2qjhJAd91kJu3PXLG18aooCgYBaB6qQz35hhABg==}
     engines: {node: '>=20.0.0'}
+
+  '@supercharge/promise-pool@3.3.0':
+    resolution: {integrity: sha512-qGzCltMN05ohRRQAXB8TPWt+0Coz9Va266gr9nYN1qc/f/EIaup3VRg7b59mtRaeKTRcxreF20l/udCM/gOqNg==}
+    engines: {node: '>=8'}
 
   '@swc/counter@0.1.3':
     resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
@@ -4244,6 +4394,10 @@ packages:
   '@xtuc/long@4.2.2':
     resolution: {integrity: sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==}
 
+  abi-wan-kanabi@2.2.4:
+    resolution: {integrity: sha512-0aA81FScmJCPX+8UvkXLki3X1+yPQuWxEkqXBVKltgPAK79J+NB+Lp5DouMXa7L6f+zcRlIA/6XO7BN/q9fnvg==}
+    hasBin: true
+
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
     engines: {node: '>=6.5'}
@@ -4281,6 +4435,9 @@ packages:
     resolution: {integrity: sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==}
     engines: {node: '>=12.0'}
 
+  aes-js@3.0.0:
+    resolution: {integrity: sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw==}
+
   agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
@@ -4311,6 +4468,14 @@ packages:
 
   ajv@8.17.1:
     resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
+
+  algo-msgpack-with-bigint@2.1.1:
+    resolution: {integrity: sha512-F1tGh056XczEaEAqu7s+hlZUDWwOBT70Eq0lfMpBP2YguSQVyxRbprLq5rELXKQOyOaixTWYhMeMQMzP0U5FoQ==}
+    engines: {node: '>= 10'}
+
+  algosdk@1.24.1:
+    resolution: {integrity: sha512-9moZxdqeJ6GdE4N6fA/GlUP4LrbLZMYcYkt141J4Ss68OfEgH9qW0wBuZ3ZOKEx/xjc5bg7mLP2Gjg7nwrkmww==}
+    engines: {node: '>=14.0.0'}
 
   anser@1.4.10:
     resolution: {integrity: sha512-hCv9AqTQ8ycjpSd3upOJd7vFwW1JaoYQ7tpham03GJ1ca8/65rqn0RpaWpItOAd6ylW9wAw6luXYPJIyPFVOww==}
@@ -4368,6 +4533,9 @@ packages:
   archiver@7.0.1:
     resolution: {integrity: sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ==}
     engines: {node: '>= 14'}
+
+  arconnect@0.4.2:
+    resolution: {integrity: sha512-Jkpd4QL3TVqnd3U683gzXmZUVqBUy17DdJDuL/3D9rkysLgX6ymJ2e+sR+xyZF5Rh42CBqDXWNMmCjBXeP7Gbw==}
 
   arg@5.0.2:
     resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
@@ -4433,8 +4601,20 @@ packages:
     resolution: {integrity: sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==}
     engines: {node: '>=8'}
 
+  arweave-stream-tx@1.2.2:
+    resolution: {integrity: sha512-bNt9rj0hbAEzoUZEF2s6WJbIz8nasZlZpxIw03Xm8fzb9gRiiZlZGW3lxQLjfc9Z0VRUWDzwtqoYeEoB/JDToQ==}
+    peerDependencies:
+      arweave: ^1.10.0
+
+  arweave@1.15.7:
+    resolution: {integrity: sha512-F+Y4iWU1qea9IsKQ/YNmLsY4DHQVsaJBuhEbFxQn9cfGHOmtXE+bwo14oY8xqymsqSNf/e1PeIfLk7G7qN/hVA==}
+    engines: {node: '>=18'}
+
   asap@2.0.6:
     resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
+
+  asn1.js@5.4.1:
+    resolution: {integrity: sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==}
 
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
@@ -4449,6 +4629,9 @@ packages:
 
   async-mutex@0.4.1:
     resolution: {integrity: sha512-WfoBo4E/TbCX1G95XTjbWTE3X2XLG0m1Xbv2cwOtuPdyH9CZvnaA5nCt1ucjaKEgW2A5IF71hxrRhr83Je5xjA==}
+
+  async-retry@1.3.3:
+    resolution: {integrity: sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==}
 
   async@3.2.6:
     resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
@@ -4473,6 +4656,9 @@ packages:
   axe-core@4.11.1:
     resolution: {integrity: sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A==}
     engines: {node: '>=4'}
+
+  axios@1.18.1:
+    resolution: {integrity: sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
@@ -4555,9 +4741,16 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
+  base64url@3.0.1:
+    resolution: {integrity: sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A==}
+    engines: {node: '>=6.0.0'}
+
   baseline-browser-mapping@2.9.19:
     resolution: {integrity: sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==}
     hasBin: true
+
+  bech32@1.1.4:
+    resolution: {integrity: sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==}
 
   before-after-hook@4.0.0:
     resolution: {integrity: sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==}
@@ -4585,6 +4778,9 @@ packages:
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
+  bn.js@4.12.3:
+    resolution: {integrity: sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==}
+
   bn.js@5.2.2:
     resolution: {integrity: sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw==}
 
@@ -4603,6 +4799,9 @@ packages:
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
+
+  brorand@1.1.0:
+    resolution: {integrity: sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==}
 
   browserify-zlib@0.1.4:
     resolution: {integrity: sha512-19OEpq7vWgsH6WkvkBJQDFvJS1uPcbFOQ4v9CU839dO+ZZXUZO6XpE6hNCqvlIIj+4fZvRiJ6DsAQ382GwiyTQ==}
@@ -4819,6 +5018,10 @@ packages:
     resolution: {integrity: sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==}
     engines: {node: '>=18'}
 
+  cli-width@3.0.0:
+    resolution: {integrity: sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==}
+    engines: {node: '>= 10'}
+
   cli-width@4.1.0:
     resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
     engines: {node: '>= 12'}
@@ -5004,6 +5207,12 @@ packages:
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  csv-parse@5.6.0:
+    resolution: {integrity: sha512-l3nz3euub2QMg5ouu5U09Ew9Wf6/wQ8I++ch1loQ0ljmzhmfZYrH9fflS22i/PQEvsPvxCwxgz5q7UB8K1JO4Q==}
+
+  csv-stringify@6.8.0:
+    resolution: {integrity: sha512-Ya0OOHb6XbgPaZKH7dcdmwXe3azUS0TwmlbVdS75HoAhnHApSkiQcfEJoC/s5WwGsrXwOjBDr3FTmCZPjkssgg==}
 
   custom-media-element@1.4.5:
     resolution: {integrity: sha512-cjrsQufETwxjvwZbYbKBCJNvmQ2++G9AvT45zDi7NXL9k2PdVcs2h0jQz96J6G4TMKRCcEsoJ+QTgQD00Igtjw==}
@@ -5243,6 +5452,9 @@ packages:
 
   electron-to-chromium@1.5.286:
     resolution: {integrity: sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==}
+
+  elliptic@6.6.1:
+    resolution: {integrity: sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==}
 
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
@@ -5618,8 +5830,15 @@ packages:
       picomatch:
         optional: true
 
+  fetch-cookie@3.0.1:
+    resolution: {integrity: sha512-ZGXe8Y5Z/1FWqQ9q/CrJhkUD73DyBU9VF0hBQmEO/wPHe4A9PKTjplFDLeFX8aOsYypZUcX5Ji/eByn3VCVO3Q==}
+
   fflate@0.4.8:
     resolution: {integrity: sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==}
+
+  figures@3.2.0:
+    resolution: {integrity: sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==}
+    engines: {node: '>=8'}
 
   file-entry-cache@6.0.1:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
@@ -5708,6 +5927,15 @@ packages:
       debug:
         optional: true
 
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
@@ -5749,6 +5977,10 @@ packages:
 
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
+
+  fs-extra@10.1.0:
+    resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
+    engines: {node: '>=12'}
 
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
@@ -5954,6 +6186,9 @@ packages:
     resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
     engines: {node: '>= 0.4'}
 
+  hash.js@1.1.7:
+    resolution: {integrity: sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==}
+
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
@@ -6004,6 +6239,9 @@ packages:
   hermes-parser@0.32.0:
     resolution: {integrity: sha512-g4nBOWFpuiTqjR3LZdRxKUkij9iyveWeuks7INEsMX741f3r9xxrOe8TeQfUxtda0eXmiIFiMQzoeSQEno33Hw==}
 
+  hi-base32@0.5.1:
+    resolution: {integrity: sha512-EmBBpvdYh/4XxsnUybsPag6VikPYnN30td+vQk+GI3qpahVEG9+gTkG0aXVxTjBqQ5T6ijbWIu77O+C5WFWsnA==}
+
   highlight.js@11.11.1:
     resolution: {integrity: sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==}
     engines: {node: '>=12.0.0'}
@@ -6013,6 +6251,9 @@ packages:
 
   hls.js@1.6.15:
     resolution: {integrity: sha512-E3a5VwgXimGHwpRGV+WxRTKeSp2DW5DI5MWv34ulL3t5UNmyJWCQ1KmLEHbYzcfThfXG8amBL+fCYPneGHC4VA==}
+
+  hmac-drbg@1.0.1:
+    resolution: {integrity: sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==}
 
   hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
@@ -6142,6 +6383,10 @@ packages:
     peerDependenciesMeta:
       '@types/node':
         optional: true
+
+  inquirer@8.2.7:
+    resolution: {integrity: sha512-UjOaSel/iddGZJ5xP/Eixh6dY1XghiBw4XK13rCCIJcJfyhhoul/7KhLLUGtebEj6GDYM6Vnx/mVsjx2L/mFIA==}
+    engines: {node: '>=12.0.0'}
 
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
@@ -6425,6 +6670,9 @@ packages:
     resolution: {integrity: sha512-E8YkGyPY3a/U5s0WOoc8Ok+3SWL/33yn2IHCoxCFLBUUPVy9WGa++akJZFxQCcJIhI+UvYhbrbnTIFQkHKZbgA==}
     engines: {node: '>=20.19.5'}
 
+  isomorphic-fetch@3.0.0:
+    resolution: {integrity: sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==}
+
   isomorphic-ws@4.0.1:
     resolution: {integrity: sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==}
     peerDependencies:
@@ -6510,6 +6758,15 @@ packages:
   js-base64@3.7.8:
     resolution: {integrity: sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==}
 
+  js-sha256@0.9.0:
+    resolution: {integrity: sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA==}
+
+  js-sha3@0.8.0:
+    resolution: {integrity: sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==}
+
+  js-sha512@0.8.0:
+    resolution: {integrity: sha512-PWsmefG6Jkodqt+ePTvBZCSMFgN7Clckjd0O7su3I0+BW2QWUTJNzjktHsztGLhncP2h8mcF9V9Y2Ha59pAViQ==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -6557,6 +6814,9 @@ packages:
     engines: {node: '>= 16'}
     deprecated: A security vulnerability has been reported with the preventCsvInjection option which has been fixed in version 5.5.11. Please upgrade as soon as possible.
 
+  json-bigint@1.0.0:
+    resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
+
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
@@ -6593,9 +6853,16 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  jsonfile@6.2.1:
+    resolution: {integrity: sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==}
+
   jsx-ast-utils@3.3.5:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
+
+  keccak@3.0.4:
+    resolution: {integrity: sha512-3vKuW0jV8J3XNTzvfyicFR5qvxrSAGl7KIhvgOu5cmWwM7tZRj3fMbj/pfIf4be7aznbc+prBWGjywox/g2Y6Q==}
+    engines: {node: '>=10.0.0'}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -6713,6 +6980,9 @@ packages:
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
+
+  lossless-json@4.3.0:
+    resolution: {integrity: sha512-ToxOC+SsduRmdSuoLZLYAr5zy1Qu7l5XhmPWM3zefCZ5IcrzW/h108qbJUKfOlDlhvhjUK84+8PSVX0kxnit0g==}
 
   lowlight@3.3.0:
     resolution: {integrity: sha512-0JNhgFoPvP6U6lE/UdVsSq99tn6DhjjpAj5MxG49ewd2mOBVtwWYIT8ClyABhq198aXXODMU6Ox8DrGy/CpTZQ==}
@@ -7054,6 +7324,12 @@ packages:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
 
+  minimalistic-assert@1.0.1:
+    resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
+
+  minimalistic-crypto-utils@1.0.1:
+    resolution: {integrity: sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==}
+
   minimatch@10.1.2:
     resolution: {integrity: sha512-fu656aJ0n2kcXwsnwnv9g24tkU5uSmOlTjd6WyyaKm2Z+h1qmY6bAjrcaIxF/BslFqbZ8UBtbJi7KgQOZD2PTw==}
     engines: {node: 20 || >=22}
@@ -7133,6 +7409,12 @@ packages:
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  multistream@4.1.0:
+    resolution: {integrity: sha512-J1XDiAmmNpRCBfIWJv+n0ymC4ABcf/Pl+5YvC5B/D2f/2+8PtHvCNxMPKiQcZyi922Hq69J2YOpb1pTywfifyw==}
+
+  mute-stream@0.0.8:
+    resolution: {integrity: sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==}
 
   mute-stream@2.0.0:
     resolution: {integrity: sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==}
@@ -7221,6 +7503,12 @@ packages:
         optional: true
       sass:
         optional: true
+
+  node-addon-api@2.0.2:
+    resolution: {integrity: sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==}
+
+  node-addon-api@5.1.0:
+    resolution: {integrity: sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA==}
 
   node-fetch@2.7.0:
     resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
@@ -7790,6 +8078,10 @@ packages:
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
+  proxy-from-env@2.1.0:
+    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
+    engines: {node: '>=10'}
+
   psl@1.15.0:
     resolution: {integrity: sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==}
 
@@ -8119,6 +8411,10 @@ packages:
     resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
     engines: {node: '>=18'}
 
+  retry@0.13.1:
+    resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
+    engines: {node: '>= 4'}
+
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
@@ -8153,6 +8449,10 @@ packages:
 
   rrweb-cssom@0.8.0:
     resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
+
+  run-async@2.4.1:
+    resolution: {integrity: sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==}
+    engines: {node: '>=0.12.0'}
 
   run-async@4.0.6:
     resolution: {integrity: sha512-IoDlSLTs3Yq593mb3ZoKWKXMNu3UpObxhgA/Xuid5p4bbfi2jdY1Hj0m1K+0/tEuQTxIGMhQDqGjKb7RuxGpAQ==}
@@ -8231,6 +8531,13 @@ packages:
   scrollmirror@1.2.4:
     resolution: {integrity: sha512-UkEHHOV6j5cE3IsObQRK6vO4twSuhE4vtLD4UmX+doHgrtg2jRwXkz4O6cz0jcoxK5NGU7rFjyvLcWHzw7eQ5A==}
 
+  scrypt-js@3.0.1:
+    resolution: {integrity: sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==}
+
+  secp256k1@5.0.1:
+    resolution: {integrity: sha512-lDFs9AAIaWP9UCdtWrotXWWF9t8PWgQDcxqgAnpM9rMqxb3Oaq2J0thzPVSxBwdJgyQtkU/sYtFtbM1RSt/iYA==}
+    engines: {node: '>=18.0.0'}
+
   seek-bzip@1.0.6:
     resolution: {integrity: sha512-e1QtP3YL5tWww8uKaOCQ18UxIT2laNBXHjV/S2WYCiK4udiv8lkG89KRIoCjUagnAmCBurjF4zEVX2ByBbnCjQ==}
     hasBin: true
@@ -8268,6 +8575,9 @@ packages:
 
   set-blocking@2.0.0:
     resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
+
+  set-cookie-parser@2.7.2:
+    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -8429,6 +8739,9 @@ packages:
   stacktrace-parser@0.1.11:
     resolution: {integrity: sha512-WjlahMgHmCJpqzU8bIBy4qtsZdU9lRlcZE3Lvyej6t4tuOuv1vk57OW3MBrj6hXBFx/nNoC9MPMTcr5YA7NQbg==}
     engines: {node: '>=6'}
+
+  starknet@6.24.1:
+    resolution: {integrity: sha512-g7tiCt73berhcNi41otlN3T3kxZnIvZhMi8WdC21Y6GC6zoQgbI2z1t7JAZF9c4xZiomlanwVnurcpyfEdyMpg==}
 
   state-local@1.0.7:
     resolution: {integrity: sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==}
@@ -8742,6 +9055,13 @@ packages:
     resolution: {integrity: sha512-nqpKFC53CgopKPjT6Wfb6tpIcZXHcI6G37hesvikhx0EmUGPkZrujRyAjgnmp1SHNgpQfKVanZ+KfpANFt2Hxw==}
     hasBin: true
 
+  tmp-promise@3.0.3:
+    resolution: {integrity: sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==}
+
+  tmp@0.2.7:
+    resolution: {integrity: sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==}
+    engines: {node: '>=14.14'}
+
   tmpl@1.0.5:
     resolution: {integrity: sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==}
 
@@ -8800,6 +9120,9 @@ packages:
 
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
+
+  ts-mixer@6.0.4:
+    resolution: {integrity: sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA==}
 
   tsconfck@3.1.6:
     resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
@@ -9014,6 +9337,10 @@ packages:
   universalify@0.2.0:
     resolution: {integrity: sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==}
     engines: {node: '>= 4.0.0'}
+
+  universalify@2.0.1:
+    resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
+    engines: {node: '>= 10.0.0'}
 
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
@@ -9240,6 +9567,9 @@ packages:
   vlq@1.0.1:
     resolution: {integrity: sha512-gQpnTgkubC6hQgdIcRdYGDSDc+SaujOdyesZQMv6JlfQee/9Mp0Qhnys6WxDWvQnL5WZdT7o2Ul187aSt0Rq+w==}
 
+  vlq@2.0.4:
+    resolution: {integrity: sha512-aodjPa2wPQFkra1G8CzJBTHXhgk3EVSwxSWXNPr1fgdFLUb8kvLV1iEb6rFgasIsjP82HWI6dsb5Io26DDnasA==}
+
   void-elements@3.1.0:
     resolution: {integrity: sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==}
     engines: {node: '>=0.10.0'}
@@ -9403,6 +9733,18 @@ packages:
     peerDependencies:
       bufferutil: ^4.0.1
       utf-8-validate: ^5.0.2
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  ws@8.18.0:
+    resolution: {integrity: sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
     peerDependenciesMeta:
       bufferutil:
         optional: true
@@ -10849,6 +11191,221 @@ snapshots:
 
   '@eslint/js@8.57.1': {}
 
+  '@ethersproject/abstract-provider@5.8.0':
+    dependencies:
+      '@ethersproject/bignumber': 5.8.0
+      '@ethersproject/bytes': 5.8.0
+      '@ethersproject/logger': 5.8.0
+      '@ethersproject/networks': 5.8.0
+      '@ethersproject/properties': 5.8.0
+      '@ethersproject/transactions': 5.8.0
+      '@ethersproject/web': 5.8.0
+
+  '@ethersproject/abstract-signer@5.8.0':
+    dependencies:
+      '@ethersproject/abstract-provider': 5.8.0
+      '@ethersproject/bignumber': 5.8.0
+      '@ethersproject/bytes': 5.8.0
+      '@ethersproject/logger': 5.8.0
+      '@ethersproject/properties': 5.8.0
+
+  '@ethersproject/address@5.8.0':
+    dependencies:
+      '@ethersproject/bignumber': 5.8.0
+      '@ethersproject/bytes': 5.8.0
+      '@ethersproject/keccak256': 5.8.0
+      '@ethersproject/logger': 5.8.0
+      '@ethersproject/rlp': 5.8.0
+
+  '@ethersproject/base64@5.8.0':
+    dependencies:
+      '@ethersproject/bytes': 5.8.0
+
+  '@ethersproject/basex@5.8.0':
+    dependencies:
+      '@ethersproject/bytes': 5.8.0
+      '@ethersproject/properties': 5.8.0
+
+  '@ethersproject/bignumber@5.8.0':
+    dependencies:
+      '@ethersproject/bytes': 5.8.0
+      '@ethersproject/logger': 5.8.0
+      bn.js: 5.2.2
+
+  '@ethersproject/bytes@5.8.0':
+    dependencies:
+      '@ethersproject/logger': 5.8.0
+
+  '@ethersproject/constants@5.8.0':
+    dependencies:
+      '@ethersproject/bignumber': 5.8.0
+
+  '@ethersproject/hash@5.8.0':
+    dependencies:
+      '@ethersproject/abstract-signer': 5.8.0
+      '@ethersproject/address': 5.8.0
+      '@ethersproject/base64': 5.8.0
+      '@ethersproject/bignumber': 5.8.0
+      '@ethersproject/bytes': 5.8.0
+      '@ethersproject/keccak256': 5.8.0
+      '@ethersproject/logger': 5.8.0
+      '@ethersproject/properties': 5.8.0
+      '@ethersproject/strings': 5.8.0
+
+  '@ethersproject/hdnode@5.8.0':
+    dependencies:
+      '@ethersproject/abstract-signer': 5.8.0
+      '@ethersproject/basex': 5.8.0
+      '@ethersproject/bignumber': 5.8.0
+      '@ethersproject/bytes': 5.8.0
+      '@ethersproject/logger': 5.8.0
+      '@ethersproject/pbkdf2': 5.8.0
+      '@ethersproject/properties': 5.8.0
+      '@ethersproject/sha2': 5.8.0
+      '@ethersproject/signing-key': 5.8.0
+      '@ethersproject/strings': 5.8.0
+      '@ethersproject/transactions': 5.8.0
+      '@ethersproject/wordlists': 5.8.0
+
+  '@ethersproject/json-wallets@5.8.0':
+    dependencies:
+      '@ethersproject/abstract-signer': 5.8.0
+      '@ethersproject/address': 5.8.0
+      '@ethersproject/bytes': 5.8.0
+      '@ethersproject/hdnode': 5.8.0
+      '@ethersproject/keccak256': 5.8.0
+      '@ethersproject/logger': 5.8.0
+      '@ethersproject/pbkdf2': 5.8.0
+      '@ethersproject/properties': 5.8.0
+      '@ethersproject/random': 5.8.0
+      '@ethersproject/strings': 5.8.0
+      '@ethersproject/transactions': 5.8.0
+      aes-js: 3.0.0
+      scrypt-js: 3.0.1
+
+  '@ethersproject/keccak256@5.8.0':
+    dependencies:
+      '@ethersproject/bytes': 5.8.0
+      js-sha3: 0.8.0
+
+  '@ethersproject/logger@5.8.0': {}
+
+  '@ethersproject/networks@5.8.0':
+    dependencies:
+      '@ethersproject/logger': 5.8.0
+
+  '@ethersproject/pbkdf2@5.8.0':
+    dependencies:
+      '@ethersproject/bytes': 5.8.0
+      '@ethersproject/sha2': 5.8.0
+
+  '@ethersproject/properties@5.8.0':
+    dependencies:
+      '@ethersproject/logger': 5.8.0
+
+  '@ethersproject/providers@5.8.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@ethersproject/abstract-provider': 5.8.0
+      '@ethersproject/abstract-signer': 5.8.0
+      '@ethersproject/address': 5.8.0
+      '@ethersproject/base64': 5.8.0
+      '@ethersproject/basex': 5.8.0
+      '@ethersproject/bignumber': 5.8.0
+      '@ethersproject/bytes': 5.8.0
+      '@ethersproject/constants': 5.8.0
+      '@ethersproject/hash': 5.8.0
+      '@ethersproject/logger': 5.8.0
+      '@ethersproject/networks': 5.8.0
+      '@ethersproject/properties': 5.8.0
+      '@ethersproject/random': 5.8.0
+      '@ethersproject/rlp': 5.8.0
+      '@ethersproject/sha2': 5.8.0
+      '@ethersproject/strings': 5.8.0
+      '@ethersproject/transactions': 5.8.0
+      '@ethersproject/web': 5.8.0
+      bech32: 1.1.4
+      ws: 8.18.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@ethersproject/random@5.8.0':
+    dependencies:
+      '@ethersproject/bytes': 5.8.0
+      '@ethersproject/logger': 5.8.0
+
+  '@ethersproject/rlp@5.8.0':
+    dependencies:
+      '@ethersproject/bytes': 5.8.0
+      '@ethersproject/logger': 5.8.0
+
+  '@ethersproject/sha2@5.8.0':
+    dependencies:
+      '@ethersproject/bytes': 5.8.0
+      '@ethersproject/logger': 5.8.0
+      hash.js: 1.1.7
+
+  '@ethersproject/signing-key@5.8.0':
+    dependencies:
+      '@ethersproject/bytes': 5.8.0
+      '@ethersproject/logger': 5.8.0
+      '@ethersproject/properties': 5.8.0
+      bn.js: 5.2.2
+      elliptic: 6.6.1
+      hash.js: 1.1.7
+
+  '@ethersproject/strings@5.8.0':
+    dependencies:
+      '@ethersproject/bytes': 5.8.0
+      '@ethersproject/constants': 5.8.0
+      '@ethersproject/logger': 5.8.0
+
+  '@ethersproject/transactions@5.8.0':
+    dependencies:
+      '@ethersproject/address': 5.8.0
+      '@ethersproject/bignumber': 5.8.0
+      '@ethersproject/bytes': 5.8.0
+      '@ethersproject/constants': 5.8.0
+      '@ethersproject/keccak256': 5.8.0
+      '@ethersproject/logger': 5.8.0
+      '@ethersproject/properties': 5.8.0
+      '@ethersproject/rlp': 5.8.0
+      '@ethersproject/signing-key': 5.8.0
+
+  '@ethersproject/wallet@5.8.0':
+    dependencies:
+      '@ethersproject/abstract-provider': 5.8.0
+      '@ethersproject/abstract-signer': 5.8.0
+      '@ethersproject/address': 5.8.0
+      '@ethersproject/bignumber': 5.8.0
+      '@ethersproject/bytes': 5.8.0
+      '@ethersproject/hash': 5.8.0
+      '@ethersproject/hdnode': 5.8.0
+      '@ethersproject/json-wallets': 5.8.0
+      '@ethersproject/keccak256': 5.8.0
+      '@ethersproject/logger': 5.8.0
+      '@ethersproject/properties': 5.8.0
+      '@ethersproject/random': 5.8.0
+      '@ethersproject/signing-key': 5.8.0
+      '@ethersproject/transactions': 5.8.0
+      '@ethersproject/wordlists': 5.8.0
+
+  '@ethersproject/web@5.8.0':
+    dependencies:
+      '@ethersproject/base64': 5.8.0
+      '@ethersproject/bytes': 5.8.0
+      '@ethersproject/logger': 5.8.0
+      '@ethersproject/properties': 5.8.0
+      '@ethersproject/strings': 5.8.0
+
+  '@ethersproject/wordlists@5.8.0':
+    dependencies:
+      '@ethersproject/bytes': 5.8.0
+      '@ethersproject/hash': 5.8.0
+      '@ethersproject/logger': 5.8.0
+      '@ethersproject/properties': 5.8.0
+      '@ethersproject/strings': 5.8.0
+
   '@exodus/bytes@1.11.0(@noble/hashes@1.8.0)':
     optionalDependencies:
       '@noble/hashes': 1.8.0
@@ -11036,6 +11593,235 @@ snapshots:
   '@inquirer/type@3.0.10(@types/node@22.19.9)':
     optionalDependencies:
       '@types/node': 22.19.9
+
+  '@irys/arweave@0.0.2':
+    dependencies:
+      asn1.js: 5.4.1
+      async-retry: 1.3.3
+      axios: 1.18.1
+      base64-js: 1.5.1
+      bignumber.js: 9.3.1
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
+  '@irys/bundles@0.0.1(arweave@1.15.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@ethersproject/bytes': 5.8.0
+      '@ethersproject/hash': 5.8.0
+      '@ethersproject/providers': 5.8.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      '@ethersproject/signing-key': 5.8.0
+      '@ethersproject/transactions': 5.8.0
+      '@ethersproject/wallet': 5.8.0
+      '@irys/arweave': 0.0.2
+      '@noble/ed25519': 1.7.5
+      base64url: 3.0.1
+      bs58: 4.0.1
+      keccak: 3.0.4
+      secp256k1: 5.0.1
+    optionalDependencies:
+      '@randlabs/myalgo-connect': 1.4.2
+      algosdk: 1.24.1
+      arweave-stream-tx: 1.2.2(arweave@1.15.7)
+      multistream: 4.1.0
+      tmp-promise: 3.0.3
+    transitivePeerDependencies:
+      - arweave
+      - bufferutil
+      - debug
+      - encoding
+      - supports-color
+      - utf-8-validate
+
+  '@irys/bundles@0.0.3(arweave@1.15.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@ethersproject/bytes': 5.8.0
+      '@ethersproject/hash': 5.8.0
+      '@ethersproject/providers': 5.8.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      '@ethersproject/signing-key': 5.8.0
+      '@ethersproject/transactions': 5.8.0
+      '@ethersproject/wallet': 5.8.0
+      '@irys/arweave': 0.0.2
+      '@noble/ed25519': 1.7.5
+      base64url: 3.0.1
+      bs58: 4.0.1
+      keccak: 3.0.4
+      secp256k1: 5.0.1
+      starknet: 6.24.1
+    optionalDependencies:
+      '@randlabs/myalgo-connect': 1.4.2
+      algosdk: 1.24.1
+      arweave-stream-tx: 1.2.2(arweave@1.15.7)
+      multistream: 4.1.0
+      tmp-promise: 3.0.3
+    transitivePeerDependencies:
+      - arweave
+      - bufferutil
+      - debug
+      - encoding
+      - supports-color
+      - utf-8-validate
+
+  '@irys/query@0.0.9':
+    dependencies:
+      async-retry: 1.3.3
+      axios: 1.18.1
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
+  '@irys/upload-core@0.0.10(arweave@1.15.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@irys/bundles': 0.0.3(arweave@1.15.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      '@irys/query': 0.0.9
+      '@supercharge/promise-pool': 3.3.0
+      async-retry: 1.3.3
+      axios: 1.18.1
+      base64url: 3.0.1
+      bignumber.js: 9.3.1
+    transitivePeerDependencies:
+      - arweave
+      - bufferutil
+      - debug
+      - encoding
+      - supports-color
+      - utf-8-validate
+
+  '@irys/upload-core@0.0.9(arweave@1.15.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@irys/bundles': 0.0.1(arweave@1.15.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      '@irys/query': 0.0.9
+      '@supercharge/promise-pool': 3.3.0
+      async-retry: 1.3.3
+      axios: 1.18.1
+      base64url: 3.0.1
+      bignumber.js: 9.3.1
+    transitivePeerDependencies:
+      - arweave
+      - bufferutil
+      - debug
+      - encoding
+      - supports-color
+      - utf-8-validate
+
+  '@irys/upload-solana@0.1.8(@types/node@22.19.9)(arweave@1.15.7)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@irys/bundles': 0.0.3(arweave@1.15.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      '@irys/upload': 0.0.15(@types/node@22.19.9)(arweave@1.15.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      '@irys/upload-core': 0.0.10(arweave@1.15.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      '@solana/spl-token': 0.4.14(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      async-retry: 1.3.3
+      bignumber.js: 9.3.1
+      bs58: 5.0.0
+      tweetnacl: 1.0.3
+    transitivePeerDependencies:
+      - '@types/node'
+      - arweave
+      - bufferutil
+      - debug
+      - encoding
+      - fastestsmallesttextencoderdecoder
+      - supports-color
+      - typescript
+      - utf-8-validate
+
+  '@irys/upload@0.0.14(@types/node@22.19.9)(arweave@1.15.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@irys/bundles': 0.0.1(arweave@1.15.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      '@irys/upload-core': 0.0.9(arweave@1.15.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      async-retry: 1.3.3
+      axios: 1.18.1
+      base64url: 3.0.1
+      bignumber.js: 9.3.1
+      csv-parse: 5.6.0
+      csv-stringify: 6.8.0
+      inquirer: 8.2.7(@types/node@22.19.9)
+      mime-types: 2.1.35
+    transitivePeerDependencies:
+      - '@types/node'
+      - arweave
+      - bufferutil
+      - debug
+      - encoding
+      - supports-color
+      - utf-8-validate
+
+  '@irys/upload@0.0.15(@types/node@22.19.9)(arweave@1.15.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@irys/bundles': 0.0.3(arweave@1.15.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      '@irys/upload-core': 0.0.10(arweave@1.15.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      async-retry: 1.3.3
+      axios: 1.18.1
+      base64url: 3.0.1
+      bignumber.js: 9.3.1
+      csv-parse: 5.6.0
+      csv-stringify: 6.8.0
+      inquirer: 8.2.7(@types/node@22.19.9)
+      mime-types: 2.1.35
+    transitivePeerDependencies:
+      - '@types/node'
+      - arweave
+      - bufferutil
+      - debug
+      - encoding
+      - supports-color
+      - utf-8-validate
+
+  '@irys/web-upload-solana@0.1.8(arweave@1.15.7)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@irys/bundles': 0.0.3(arweave@1.15.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      '@irys/upload-core': 0.0.10(arweave@1.15.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      '@irys/web-upload': 0.0.15(arweave@1.15.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      '@solana/spl-token': 0.4.14(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      async-retry: 1.3.3
+      bignumber.js: 9.3.1
+      bs58: 5.0.0
+      tweetnacl: 1.0.3
+    transitivePeerDependencies:
+      - arweave
+      - bufferutil
+      - debug
+      - encoding
+      - fastestsmallesttextencoderdecoder
+      - supports-color
+      - typescript
+      - utf-8-validate
+
+  '@irys/web-upload@0.0.14(arweave@1.15.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@irys/bundles': 0.0.1(arweave@1.15.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      '@irys/upload-core': 0.0.9(arweave@1.15.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      async-retry: 1.3.3
+      axios: 1.18.1
+      base64url: 3.0.1
+      bignumber.js: 9.3.1
+      mime-types: 2.1.35
+    transitivePeerDependencies:
+      - arweave
+      - bufferutil
+      - debug
+      - encoding
+      - supports-color
+      - utf-8-validate
+
+  '@irys/web-upload@0.0.15(arweave@1.15.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@irys/bundles': 0.0.3(arweave@1.15.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      '@irys/upload-core': 0.0.10(arweave@1.15.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      async-retry: 1.3.3
+      axios: 1.18.1
+      base64url: 3.0.1
+      bignumber.js: 9.3.1
+      mime-types: 2.1.35
+    transitivePeerDependencies:
+      - arweave
+      - bufferutil
+      - debug
+      - encoding
+      - supports-color
+      - utf-8-validate
 
   '@isaacs/balanced-match@4.0.1': {}
 
@@ -11268,6 +12054,29 @@ snapshots:
       '@metaplex-foundation/umi-web3js-adapters': 1.5.1(@metaplex-foundation/umi@1.4.1)(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))
       '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
 
+  '@metaplex-foundation/umi-uploader-irys@1.5.0(@metaplex-foundation/umi@1.4.1)(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(@types/node@22.19.9)(arweave@1.15.7)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@irys/upload': 0.0.14(@types/node@22.19.9)(arweave@1.15.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      '@irys/upload-solana': 0.1.8(@types/node@22.19.9)(arweave@1.15.7)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@irys/web-upload': 0.0.14(arweave@1.15.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      '@irys/web-upload-solana': 0.1.8(arweave@1.15.7)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@metaplex-foundation/umi': 1.4.1
+      '@metaplex-foundation/umi-web3js-adapters': 1.5.1(@metaplex-foundation/umi@1.4.1)(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@supercharge/promise-pool': 3.3.0
+      bignumber.js: 9.3.1
+      buffer: 6.0.3
+    transitivePeerDependencies:
+      - '@types/node'
+      - arweave
+      - bufferutil
+      - debug
+      - encoding
+      - fastestsmallesttextencoderdecoder
+      - supports-color
+      - typescript
+      - utf-8-validate
+
   '@metaplex-foundation/umi-web3js-adapters@1.5.1(@metaplex-foundation/umi@1.4.1)(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))':
     dependencies:
       '@metaplex-foundation/umi': 1.4.1
@@ -11370,9 +12179,15 @@ snapshots:
   '@next/swc-win32-x64-msvc@14.2.33':
     optional: true
 
+  '@noble/curves@1.7.0':
+    dependencies:
+      '@noble/hashes': 1.8.0
+
   '@noble/curves@1.9.7':
     dependencies:
       '@noble/hashes': 1.8.0
+
+  '@noble/ed25519@1.7.5': {}
 
   '@noble/hashes@1.8.0': {}
 
@@ -12250,6 +13065,14 @@ snapshots:
 
   '@radix-ui/rect@1.1.1': {}
 
+  '@randlabs/communication-bridge@1.0.1':
+    optional: true
+
+  '@randlabs/myalgo-connect@1.4.2':
+    dependencies:
+      '@randlabs/communication-bridge': 1.0.1
+    optional: true
+
   '@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@18.3.1)(utf-8-validate@5.0.10))':
     dependencies:
       merge-options: 3.0.4
@@ -13079,6 +13902,13 @@ snapshots:
 
   '@sanity/webhook@4.0.4': {}
 
+  '@scure/base@1.2.1': {}
+
+  '@scure/starknet@1.1.0':
+    dependencies:
+      '@noble/curves': 1.7.0
+      '@noble/hashes': 1.8.0
+
   '@sentry-internal/browser-utils@10.38.0':
     dependencies:
       '@sentry/core': 10.38.0
@@ -13725,6 +14555,8 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
+  '@starknet-io/types-js@0.7.10': {}
+
   '@supabase/auth-js@2.95.3':
     dependencies:
       tslib: 2.8.1
@@ -13767,6 +14599,8 @@ snapshots:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
+
+  '@supercharge/promise-pool@3.3.0': {}
 
   '@swc/counter@0.1.3': {}
 
@@ -14346,6 +15180,13 @@ snapshots:
 
   '@xtuc/long@4.2.2': {}
 
+  abi-wan-kanabi@2.2.4:
+    dependencies:
+      ansicolors: 0.3.2
+      cardinal: 2.1.1
+      fs-extra: 10.1.0
+      yargs: 17.7.2
+
   abort-controller@3.0.0:
     dependencies:
       event-target-shim: 5.0.1
@@ -14374,6 +15215,8 @@ snapshots:
   acorn@8.15.0: {}
 
   adm-zip@0.5.16: {}
+
+  aes-js@3.0.0: {}
 
   agent-base@6.0.2:
     dependencies:
@@ -14409,6 +15252,25 @@ snapshots:
       fast-uri: 3.1.0
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
+
+  algo-msgpack-with-bigint@2.1.1:
+    optional: true
+
+  algosdk@1.24.1:
+    dependencies:
+      algo-msgpack-with-bigint: 2.1.1
+      buffer: 6.0.3
+      cross-fetch: 3.2.0
+      hi-base32: 0.5.1
+      js-sha256: 0.9.0
+      js-sha3: 0.8.0
+      js-sha512: 0.8.0
+      json-bigint: 1.0.0
+      tweetnacl: 1.0.3
+      vlq: 2.0.4
+    transitivePeerDependencies:
+      - encoding
+    optional: true
 
   anser@1.4.10: {}
 
@@ -14469,6 +15331,11 @@ snapshots:
     transitivePeerDependencies:
       - bare-abort-controller
       - react-native-b4a
+
+  arconnect@0.4.2:
+    dependencies:
+      arweave: 1.15.7
+    optional: true
 
   arg@5.0.2: {}
 
@@ -14559,7 +15426,28 @@ snapshots:
 
   arrify@2.0.1: {}
 
+  arweave-stream-tx@1.2.2(arweave@1.15.7):
+    dependencies:
+      arweave: 1.15.7
+      exponential-backoff: 3.1.3
+    optional: true
+
+  arweave@1.15.7:
+    dependencies:
+      arconnect: 0.4.2
+      asn1.js: 5.4.1
+      base64-js: 1.5.1
+      bignumber.js: 9.3.1
+    optional: true
+
   asap@2.0.6: {}
+
+  asn1.js@5.4.1:
+    dependencies:
+      bn.js: 4.12.3
+      inherits: 2.0.4
+      minimalistic-assert: 1.0.1
+      safer-buffer: 2.1.2
 
   assertion-error@2.0.1: {}
 
@@ -14570,6 +15458,10 @@ snapshots:
   async-mutex@0.4.1:
     dependencies:
       tslib: 2.8.1
+
+  async-retry@1.3.3:
+    dependencies:
+      retry: 0.13.1
 
   async@3.2.6: {}
 
@@ -14591,6 +15483,16 @@ snapshots:
   aws4@1.13.2: {}
 
   axe-core@4.11.1: {}
+
+  axios@1.18.1:
+    dependencies:
+      follow-redirects: 1.16.0
+      form-data: 4.0.5
+      https-proxy-agent: 5.0.1
+      proxy-from-env: 2.1.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
 
   axobject-query@4.1.0: {}
 
@@ -14695,7 +15597,11 @@ snapshots:
 
   base64-js@1.5.1: {}
 
+  base64url@3.0.1: {}
+
   baseline-browser-mapping@2.9.19: {}
+
+  bech32@1.1.4: {}
 
   before-after-hook@4.0.0: {}
 
@@ -14726,6 +15632,8 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
+  bn.js@4.12.3: {}
+
   bn.js@5.2.2: {}
 
   boolbase@1.0.0: {}
@@ -14748,6 +15656,8 @@ snapshots:
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
+
+  brorand@1.1.0: {}
 
   browserify-zlib@0.1.4:
     dependencies:
@@ -14967,6 +15877,8 @@ snapshots:
       slice-ansi: 5.0.0
       string-width: 7.2.0
 
+  cli-width@3.0.0: {}
+
   cli-width@4.1.0: {}
 
   client-only@0.0.1: {}
@@ -15160,6 +16072,10 @@ snapshots:
       lru-cache: 11.2.5
 
   csstype@3.2.3: {}
+
+  csv-parse@5.6.0: {}
+
+  csv-stringify@6.8.0: {}
 
   custom-media-element@1.4.5: {}
 
@@ -15401,6 +16317,16 @@ snapshots:
       jake: 10.9.4
 
   electron-to-chromium@1.5.286: {}
+
+  elliptic@6.6.1:
+    dependencies:
+      bn.js: 4.12.3
+      brorand: 1.1.0
+      hash.js: 1.1.7
+      hmac-drbg: 1.0.1
+      inherits: 2.0.4
+      minimalistic-assert: 1.0.1
+      minimalistic-crypto-utils: 1.0.1
 
   emoji-regex@10.6.0: {}
 
@@ -15944,7 +16870,16 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.3
 
+  fetch-cookie@3.0.1:
+    dependencies:
+      set-cookie-parser: 2.7.2
+      tough-cookie: 4.1.4
+
   fflate@0.4.8: {}
+
+  figures@3.2.0:
+    dependencies:
+      escape-string-regexp: 1.0.5
 
   file-entry-cache@6.0.1:
     dependencies:
@@ -16036,6 +16971,8 @@ snapshots:
     optionalDependencies:
       debug: 4.4.3(supports-color@8.1.1)
 
+  follow-redirects@1.16.0: {}
+
   for-each@0.3.5:
     dependencies:
       is-callable: 1.2.7
@@ -16075,6 +17012,12 @@ snapshots:
       readable-stream: 2.3.8
 
   fs-constants@1.0.0: {}
+
+  fs-extra@10.1.0:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 6.2.1
+      universalify: 2.0.1
 
   fs.realpath@1.0.0: {}
 
@@ -16311,6 +17254,11 @@ snapshots:
     dependencies:
       has-symbols: 1.1.0
 
+  hash.js@1.1.7:
+    dependencies:
+      inherits: 2.0.4
+      minimalistic-assert: 1.0.1
+
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
@@ -16419,6 +17367,9 @@ snapshots:
     dependencies:
       hermes-estree: 0.32.0
 
+  hi-base32@0.5.1:
+    optional: true
+
   highlight.js@11.11.1: {}
 
   history@5.3.0:
@@ -16426,6 +17377,12 @@ snapshots:
       '@babel/runtime': 7.28.6
 
   hls.js@1.6.15: {}
+
+  hmac-drbg@1.0.1:
+    dependencies:
+      hash.js: 1.1.7
+      minimalistic-assert: 1.0.1
+      minimalistic-crypto-utils: 1.0.1
 
   hoist-non-react-statics@3.3.2:
     dependencies:
@@ -16558,6 +17515,26 @@ snapshots:
       rxjs: 7.8.2
     optionalDependencies:
       '@types/node': 22.19.9
+
+  inquirer@8.2.7(@types/node@22.19.9):
+    dependencies:
+      '@inquirer/external-editor': 1.0.3(@types/node@22.19.9)
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      cli-cursor: 3.1.0
+      cli-width: 3.0.0
+      figures: 3.2.0
+      lodash: 4.17.23
+      mute-stream: 0.0.8
+      ora: 5.4.1
+      run-async: 2.4.1
+      rxjs: 7.8.2
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      through: 2.3.8
+      wrap-ansi: 6.2.0
+    transitivePeerDependencies:
+      - '@types/node'
 
   internal-slot@1.1.0:
     dependencies:
@@ -16806,6 +17783,13 @@ snapshots:
       - canvas
       - supports-color
 
+  isomorphic-fetch@3.0.0:
+    dependencies:
+      node-fetch: 2.7.0
+      whatwg-fetch: 3.6.20
+    transitivePeerDependencies:
+      - encoding
+
   isomorphic-ws@4.0.1(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10)):
     dependencies:
       ws: 7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10)
@@ -16951,6 +17935,14 @@ snapshots:
 
   js-base64@3.7.8: {}
 
+  js-sha256@0.9.0:
+    optional: true
+
+  js-sha3@0.8.0: {}
+
+  js-sha512@0.8.0:
+    optional: true
+
   js-tokens@4.0.0: {}
 
   js-yaml@3.14.2:
@@ -17029,6 +18021,11 @@ snapshots:
       deeks: 3.1.0
       doc-path: 4.1.1
 
+  json-bigint@1.0.0:
+    dependencies:
+      bignumber.js: 9.3.1
+    optional: true
+
   json-buffer@3.0.1: {}
 
   json-lexer@1.2.0: {}
@@ -17053,12 +18050,24 @@ snapshots:
 
   json5@2.2.3: {}
 
+  jsonfile@6.2.1:
+    dependencies:
+      universalify: 2.0.1
+    optionalDependencies:
+      graceful-fs: 4.2.11
+
   jsx-ast-utils@3.3.5:
     dependencies:
       array-includes: 3.1.9
       array.prototype.flat: 1.3.3
       object.assign: 4.1.7
       object.values: 1.2.1
+
+  keccak@3.0.4:
+    dependencies:
+      node-addon-api: 2.0.2
+      node-gyp-build: 4.8.4
+      readable-stream: 3.6.2
 
   keyv@4.5.4:
     dependencies:
@@ -17187,6 +18196,8 @@ snapshots:
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
+
+  lossless-json@4.3.0: {}
 
   lowlight@3.3.0:
     dependencies:
@@ -17850,6 +18861,10 @@ snapshots:
 
   min-indent@1.0.1: {}
 
+  minimalistic-assert@1.0.1: {}
+
+  minimalistic-crypto-utils@1.0.1: {}
+
   minimatch@10.1.2:
     dependencies:
       '@isaacs/brace-expansion': 5.0.1
@@ -17926,6 +18941,14 @@ snapshots:
   ms@2.0.0: {}
 
   ms@2.1.3: {}
+
+  multistream@4.1.0:
+    dependencies:
+      once: 1.4.0
+      readable-stream: 3.6.2
+    optional: true
+
+  mute-stream@0.0.8: {}
 
   mute-stream@2.0.0: {}
 
@@ -18022,12 +19045,15 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
+  node-addon-api@2.0.2: {}
+
+  node-addon-api@5.1.0: {}
+
   node-fetch@2.7.0:
     dependencies:
       whatwg-url: 5.0.0
 
-  node-gyp-build@4.8.4:
-    optional: true
+  node-gyp-build@4.8.4: {}
 
   node-html-parser@6.1.13:
     dependencies:
@@ -18549,6 +19575,8 @@ snapshots:
 
   proxy-from-env@1.1.0: {}
 
+  proxy-from-env@2.1.0: {}
+
   psl@1.15.0:
     dependencies:
       punycode: 2.3.1
@@ -18997,6 +20025,8 @@ snapshots:
       onetime: 7.0.0
       signal-exit: 4.1.0
 
+  retry@0.13.1: {}
+
   reusify@1.1.0: {}
 
   rfdc@1.4.1: {}
@@ -19061,6 +20091,8 @@ snapshots:
   rrweb-cssom@0.6.0: {}
 
   rrweb-cssom@0.8.0: {}
+
+  run-async@2.4.1: {}
 
   run-async@4.0.6: {}
 
@@ -19474,6 +20506,14 @@ snapshots:
 
   scrollmirror@1.2.4: {}
 
+  scrypt-js@3.0.1: {}
+
+  secp256k1@5.0.1:
+    dependencies:
+      elliptic: 6.6.1
+      node-addon-api: 5.1.0
+      node-gyp-build: 4.8.4
+
   seek-bzip@1.0.6:
     dependencies:
       commander: 2.20.3
@@ -19520,6 +20560,8 @@ snapshots:
   server-only@0.0.1: {}
 
   set-blocking@2.0.0: {}
+
+  set-cookie-parser@2.7.2: {}
 
   set-function-length@1.2.2:
     dependencies:
@@ -19692,6 +20734,22 @@ snapshots:
   stacktrace-parser@0.1.11:
     dependencies:
       type-fest: 0.7.1
+
+  starknet@6.24.1:
+    dependencies:
+      '@noble/curves': 1.7.0
+      '@noble/hashes': 1.8.0
+      '@scure/base': 1.2.1
+      '@scure/starknet': 1.1.0
+      abi-wan-kanabi: 2.2.4
+      fetch-cookie: 3.0.1
+      isomorphic-fetch: 3.0.0
+      lossless-json: 4.3.0
+      pako: 2.1.0
+      starknet-types-07: '@starknet-io/types-js@0.7.10'
+      ts-mixer: 6.0.4
+    transitivePeerDependencies:
+      - encoding
 
   state-local@1.0.7: {}
 
@@ -20066,6 +21124,14 @@ snapshots:
     dependencies:
       tldts-core: 7.0.22
 
+  tmp-promise@3.0.3:
+    dependencies:
+      tmp: 0.2.7
+    optional: true
+
+  tmp@0.2.7:
+    optional: true
+
   tmpl@1.0.5: {}
 
   to-buffer@1.2.2:
@@ -20116,6 +21182,8 @@ snapshots:
   ts-brand@0.2.0: {}
 
   ts-interface-checker@0.1.13: {}
+
+  ts-mixer@6.0.4: {}
 
   tsconfck@3.1.6(typescript@5.9.3):
     optionalDependencies:
@@ -20335,6 +21403,8 @@ snapshots:
 
   universalify@0.2.0: {}
 
+  universalify@2.0.1: {}
+
   unpipe@1.0.0: {}
 
   unplugin@1.0.1:
@@ -20547,6 +21617,9 @@ snapshots:
 
   vlq@1.0.1: {}
 
+  vlq@2.0.4:
+    optional: true
+
   void-elements@3.1.0: {}
 
   w3c-keyname@2.2.8: {}
@@ -20749,6 +21822,11 @@ snapshots:
       signal-exit: 3.0.7
 
   ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10):
+    optionalDependencies:
+      bufferutil: 4.1.0
+      utf-8-validate: 5.0.10
+
+  ws@8.18.0(bufferutil@4.1.0)(utf-8-validate@5.0.10):
     optionalDependencies:
       bufferutil: 4.1.0
       utf-8-validate: 5.0.10


### PR DESCRIPTION
Closes #127

## What

At credential mint, certificate metadata is now pinned to **Arweave** (via Irys) and the on-chain Metaplex Core asset URI points at the **immutable** Arweave gateway URL instead of `/api/certificates/metadata`. This decouples issued credentials from app uptime — the goal of #127.

## Upload flow

`apps/web/src/app/api/certificates/mint/route.ts`:
1. Build the metadata JSON (unchanged).
2. Insert it into the Supabase `nft_metadata` row (**kept** as the app-served fallback).
3. `uploadCertificateMetadata(metadataJson)` → new module `apps/web/src/lib/solana/arweave.ts`:
   - Builds a UMI instance (`createUmi` + `keypairIdentity` + `irysUploader`) — UMI is already in the dep tree.
   - `umi.uploader.uploadJson(...)` settles the JSON on Arweave and returns the permanent gateway URL.
   - Picks the Irys node by `NEXT_PUBLIC_SOLANA_NETWORK` (`mainnet-beta` → `https://uploader.irys.xyz`, else devnet `https://devnet.irys.xyz`).
4. The on-chain `issueCredential(...)` call and the `certificates.metadata_uri` record both use the Arweave URL when available, else the app URL.

New dependency: `@metaplex-foundation/umi-uploader-irys@^1.5.0` (resolves to the Node plugin server-side).

## New env var (needs funding — human prerequisite)

`ARWEAVE_UPLOADER_SECRET` (server-only) — documented in `.env.example` + `CLAUDE.md`.

- **Value:** 64-element JSON array of a **Solana** keypair's secret-key bytes (same shape as `BACKEND_SIGNER_SECRET`). Irys is funded with this wallet's **SOL** (Irys's Solana currency) — **not** a raw Arweave JWK. I chose the Solana-keypair approach (over the issue's `ARWEAVE_KEY_JWK` suggestion) because the whole stack is Solana + UMI and Irys funds natively from SOL; flagging the naming/approach for your call below.
- The **code reads + uses** the key. The **human provides + funds** it:
  - devnet → free, but Irys devnet uploads are **pruned after ~60 days** (not truly permanent — fine for testing).
  - mainnet → permanent, paid in SOL from this wallet's Irys balance (top up at irys.xyz before mainnet minting).

## Fallback behavior (mint never hard-crashes)

If `ARWEAVE_UPLOADER_SECRET` is **absent** or the upload **fails** (unfunded wallet, Irys outage), `uploadCertificateMetadata` returns `null` and mint falls back to the existing `/api/certificates/metadata?id=…` URL, logging a clear server-side warning. So mint keeps working before Arweave is provisioned. `/api/certificates/metadata` is unchanged and still serves already-issued credentials.

## ⚠️ Needs maintainer sign-off (@thomgabriel)

The issue says to coordinate the asset-URI shape with @thomgabriel. I made a documented default:

- **Asset-URI shape:** whatever `umi.uploader.uploadJson` returns — an Irys/Arweave gateway URL (`https://arweave.net/<txid>` form). **Please confirm this is the final on-chain URI shape before mainnet** (e.g. if you'd prefer `ar://<txid>` or a specific gateway host, that's a one-line change).
- **Env var name/approach:** `ARWEAVE_UPLOADER_SECRET` as a Solana keypair vs the issue's `ARWEAVE_KEY_JWK` — confirm the funding model you want.

## Verification

- `pnpm --filter @superteam-lms/web typecheck` ✅
- `pnpm --filter @superteam-lms/web build` ✅ (`/api/certificates/mint` compiles with the new import)
- eslint clean on both changed files.

**Untested:** the **live Arweave upload** — it requires a funded `ARWEAVE_UPLOADER_SECRET`, which is a human prerequisite. Verified: it compiles, the Node Irys plugin resolves at runtime, and the **fallback path** (no key → app URL + warning) is exercised by the existing build. The happy-path upload itself has not run against a live Irys node.
