### PR TITLE
feat(security): server-side challenge validation gates completion (#181)

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -114,6 +114,12 @@ const nextConfig = {
   // (validates env vars). Stable in Next 15; opt-in in Next 14.
   experimental: {
     instrumentationHook: true,
+    // `isolated-vm` is a native addon used by the server-side challenge
+    // executor (lib/challenge/executor.ts). Keep it external so webpack does
+    // not attempt to bundle/trace the .node binary; it is required at runtime
+    // on the Node.js server. The module loads lazily and degrades closed if the
+    // prebuilt binary is unavailable in the host environment.
+    serverComponentsExternalPackages: ["isolated-vm"],
   },
   transpilePackages: ["@superteam-lms/types", "@superteam-lms/sanity"],
   images: {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -48,6 +48,7 @@
     "canvas-confetti": "^1.9.4",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",
+    "isolated-vm": "6.1.2",
     "isomorphic-dompurify": "2.36.0",
     "next": "^14.2.0",
     "next-intl": "^3.22.0",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -48,7 +48,6 @@
     "canvas-confetti": "^1.9.4",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",
-    "isolated-vm": "6.1.2",
     "isomorphic-dompurify": "2.36.0",
     "next": "^14.2.0",
     "next-intl": "^3.22.0",
@@ -69,6 +68,9 @@
     "tailwindcss-animate": "^1.0.7",
     "tweetnacl": "^1.0.3",
     "zod": "^4.4.3"
+  },
+  "optionalDependencies": {
+    "isolated-vm": "6.1.2"
   },
   "devDependencies": {
     "@tailwindcss/typography": "^0.5.19",

--- a/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/lesson-client.tsx
+++ b/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/lesson-client.tsx
@@ -163,12 +163,13 @@ interface CompletionResponse {
 
 async function completeLessonAPI(
   lessonId: string,
-  courseId: string
+  courseId: string,
+  submittedCode?: string
 ): Promise<CompletionResponse> {
   const res = await fetch("/api/lessons/complete", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ lessonId, courseId }),
+    body: JSON.stringify({ lessonId, courseId, submittedCode }),
   });
   if (!res.ok) {
     throw new Error("Failed to complete lesson");
@@ -241,44 +242,53 @@ export function LessonPageClient({
 
   const isChallenge = lesson.type === "challenge";
 
-  const handleComplete = useCallback(async () => {
-    if (isCompleted || isCompleting) return;
-    if (hasLinkedWallet === false) return;
-    setIsCompleting(true);
-    try {
-      const result = await completeLessonAPI(lesson._id, courseId);
-      setIsCompleting(false);
-      setIsCompleted(true);
-
-      if (!result.alreadyCompleted) {
-        setEarnedXp(courseXpPerLesson);
-        trackEvent("lesson_completed", {
-          lessonId: lesson._id,
+  const handleComplete = useCallback(
+    async (submittedCode?: string) => {
+      if (isCompleted || isCompleting) return;
+      if (hasLinkedWallet === false) return;
+      setIsCompleting(true);
+      try {
+        const result = await completeLessonAPI(
+          lesson._id,
           courseId,
-          signature: result.signature,
-        });
-        // XP, level-up, achievement, and certificate popups are now triggered
-        // by Supabase Realtime via useGamificationEvents (in GamificationOverlays).
+          submittedCode
+        );
+        setIsCompleting(false);
+        setIsCompleted(true);
+
+        if (!result.alreadyCompleted) {
+          setEarnedXp(courseXpPerLesson);
+          trackEvent("lesson_completed", {
+            lessonId: lesson._id,
+            courseId,
+            signature: result.signature,
+          });
+          // XP, level-up, achievement, and certificate popups are now triggered
+          // by Supabase Realtime via useGamificationEvents (in GamificationOverlays).
+        }
+      } catch {
+        // Allow retry on failure
+        setIsCompleting(false);
       }
-    } catch {
-      // Allow retry on failure
-      setIsCompleting(false);
-    }
-  }, [
-    lesson._id,
-    courseId,
-    courseXpPerLesson,
-    isCompleted,
-    isCompleting,
-    hasLinkedWallet,
-  ]);
+    },
+    [
+      lesson._id,
+      courseId,
+      courseXpPerLesson,
+      isCompleted,
+      isCompleting,
+      hasLinkedWallet,
+    ]
+  );
 
   // Listen for challenge completion events from ChallengeInterface
   useEffect(() => {
     const handleChallengeComplete = (e: Event) => {
-      const detail = (e as CustomEvent<{ lessonId: string }>).detail;
+      const detail = (
+        e as CustomEvent<{ lessonId: string; submittedCode?: string }>
+      ).detail;
       if (detail.lessonId === lesson._id) {
-        handleComplete();
+        handleComplete(detail.submittedCode);
       }
     };
 

--- a/apps/web/src/app/api/lessons/complete/route.ts
+++ b/apps/web/src/app/api/lessons/complete/route.ts
@@ -126,11 +126,22 @@ export async function POST(request: NextRequest) {
             { status: 503 }
           );
         case "non_js_challenge":
-          // Rust / buildable challenges are compiled+validated by the Rust
-          // playground / build server (a separate trust boundary). The JS
-          // isolate does not grade them; we require the submission to be
-          // present but defer correctness to those services.
-          break;
+          // FAIL CLOSED. Rust / buildable challenges must be graded by the Rust
+          // playground / build server (a separate trust boundary), but that
+          // validation handshake is NOT wired up yet. Until it is, the server
+          // cannot prove the submission is correct, so it MUST NOT submit the
+          // on-chain completeLesson — a bare fall-through here would grant a
+          // completion (and credential eligibility) for any unverified
+          // Rust/buildable submission. Deny exactly like executor_unavailable.
+          // TODO(#195 follow-up): wire a real Rust/build-server validation
+          // handshake, then gate this branch on its passing verdict.
+          return NextResponse.json(
+            {
+              error:
+                "Server-side validation for this challenge type is not yet available",
+            },
+            { status: 503 }
+          );
         case "not_a_challenge":
           break;
       }

--- a/apps/web/src/app/api/lessons/complete/route.ts
+++ b/apps/web/src/app/api/lessons/complete/route.ts
@@ -2,7 +2,11 @@ import { NextRequest, NextResponse } from "next/server";
 import { PublicKey } from "@solana/web3.js";
 import { createClient } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin";
-import { getCourseById } from "@/lib/sanity/queries";
+import { getCourseById, getChallengeAnswerKeyById } from "@/lib/sanity/queries";
+import {
+  validateAgainstAnswerKey,
+  MAX_SUBMISSION_BYTES,
+} from "@/lib/challenge/validate";
 import { logError } from "@/lib/logging";
 import { ERROR_IDS } from "@/constants/errorIds";
 import {
@@ -17,6 +21,8 @@ import { isLessonComplete } from "@/lib/solana/bitmap";
 interface LessonCompleteRequest {
   lessonId: string;
   courseId: string;
+  /** Required for challenge lessons: the learner's code, validated server-side. */
+  submittedCode?: string;
 }
 
 /**
@@ -64,7 +70,7 @@ export async function POST(request: NextRequest) {
     }
 
     const body = (await request.json()) as LessonCompleteRequest;
-    const { lessonId, courseId } = body;
+    const { lessonId, courseId, submittedCode } = body;
 
     if (!lessonId || !courseId) {
       return NextResponse.json(
@@ -80,6 +86,54 @@ export async function POST(request: NextRequest) {
       courseId.length > 100
     ) {
       return NextResponse.json({ error: "Invalid input" }, { status: 400 });
+    }
+
+    // ── Server-authoritative challenge gate ───────────────────────────────
+    // For challenge lessons the SERVER must independently verify the
+    // submission passes ALL tests (visible + hidden) before any on-chain
+    // completion is recorded. A forged client "passed" is rejected here. This
+    // re-runs the same validation as /api/lessons/validate-challenge so the
+    // completion path never trusts the client. Non-challenge lessons are
+    // unaffected (answerKey is null -> gate is skipped).
+    const answerKey = await getChallengeAnswerKeyById(courseId, lessonId);
+    if (answerKey && answerKey.type === "challenge") {
+      if (
+        typeof submittedCode !== "string" ||
+        submittedCode.length === 0 ||
+        Buffer.byteLength(submittedCode, "utf8") > MAX_SUBMISSION_BYTES
+      ) {
+        return NextResponse.json(
+          { error: "Challenge submission required" },
+          { status: 400 }
+        );
+      }
+
+      const verdict = await validateAgainstAnswerKey(answerKey, submittedCode);
+
+      switch (verdict.kind) {
+        case "validated":
+          if (!verdict.passed) {
+            return NextResponse.json(
+              { error: "Challenge tests did not pass" },
+              { status: 403 }
+            );
+          }
+          break;
+        case "executor_unavailable":
+          // Degrade closed: never grant completion we could not verify.
+          return NextResponse.json(
+            { error: "Challenge validation is temporarily unavailable" },
+            { status: 503 }
+          );
+        case "non_js_challenge":
+          // Rust / buildable challenges are compiled+validated by the Rust
+          // playground / build server (a separate trust boundary). The JS
+          // isolate does not grade them; we require the submission to be
+          // present but defer correctness to those services.
+          break;
+        case "not_a_challenge":
+          break;
+      }
     }
 
     // Look up user's wallet — required for on-chain operations

--- a/apps/web/src/app/api/lessons/validate-challenge/route.ts
+++ b/apps/web/src/app/api/lessons/validate-challenge/route.ts
@@ -1,45 +1,56 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 import { getChallengeAnswerKey } from "@/lib/sanity/queries";
+import {
+  validateAgainstAnswerKey,
+  MAX_SUBMISSION_BYTES,
+} from "@/lib/challenge/validate";
 import { logError } from "@/lib/logging";
 import { ERROR_IDS } from "@/constants/errorIds";
 
 /**
  * POST /api/lessons/validate-challenge
  *
- * Server-side home for challenge validation. It loads the FULL answer key
- * (hidden tests + reference solution) server-side via getChallengeAnswerKey and
- * never returns the tests or the solution to the client (P0-C4). The response
- * exposes only pass/fail-style metadata.
+ * Server-side, authoritative challenge validation. Loads the FULL answer key
+ * (hidden tests + reference solution) server-side via getChallengeAnswerKey,
+ * runs the submission through the secure isolate executor (`isolated-vm`)
+ * against ALL tests (visible + hidden), and returns only pass/fail metadata.
+ * The answer key, hidden tests, and reference solution are never serialised
+ * into the response (P0-C4).
  *
- * BOUNDARY (intentional, see PR "Follow-up / out of scope"): this route does NOT
- * execute untrusted user code. Running arbitrary learner submissions in a
- * trusted server context is a separate sandboxing problem and is deferred. Until
- * that lands, `serverValidated` is false for code challenges, the count of
- * hidden tests is authoritative, and the client must not be trusted to assert a
- * challenge was "passed". XP integrity in the meantime is enforced by the
- * per-award and per-day caps in award_xp() (see supabase/schema.sql).
+ * `serverValidated` reflects a REAL server-side execution of the submission.
+ * If the secure executor is unavailable in this environment, the route reports
+ * `serverValidated: false` with reason `server_execution_unavailable` and the
+ * completion gate in /api/lessons/complete denies the completion (degrade
+ * closed) — a forged client "passed" can never produce a completion record.
+ *
+ * This route is a UX convenience (gives the editor an authoritative pass/fail).
+ * The actual completion gate lives in /api/lessons/complete, which re-runs the
+ * same validation server-side; the client is never trusted to assert a pass.
  */
 
 interface ValidateChallengeRequest {
   courseSlug: string;
   lessonSlug: string;
+  submittedCode: string;
 }
 
 interface ValidateChallengeResponse {
-  /**
-   * Whether the server independently verified the submission. Always false for
-   * now (no server-side execution yet) — see route docstring.
-   */
+  /** Whether the server independently executed and verified the submission. */
   serverValidated: boolean;
-  /** True when the lesson is a challenge with an authored answer key. */
+  /** True only when serverValidated and every test (visible + hidden) passed. */
+  passed: boolean;
+  /** True when the lesson is a challenge. */
   isChallenge: boolean;
   /** Authoritative number of hidden tests held server-side. */
   hiddenTestCount: number;
   /** Authoritative number of visible tests. */
   visibleTestCount: number;
   /** Machine-readable reason when serverValidated is false. */
-  reason?: "server_execution_unavailable" | "not_a_challenge";
+  reason?:
+    | "server_execution_unavailable"
+    | "not_a_challenge"
+    | "non_js_challenge";
 }
 
 const MAX_SLUG_LENGTH = 200;
@@ -61,7 +72,7 @@ export async function POST(
     }
 
     const body = (await request.json()) as ValidateChallengeRequest;
-    const { courseSlug, lessonSlug } = body;
+    const { courseSlug, lessonSlug, submittedCode } = body;
 
     if (
       typeof courseSlug !== "string" ||
@@ -74,37 +85,65 @@ export async function POST(
       return NextResponse.json({ error: "Invalid input" }, { status: 400 });
     }
 
+    if (
+      typeof submittedCode !== "string" ||
+      Buffer.byteLength(submittedCode, "utf8") > MAX_SUBMISSION_BYTES
+    ) {
+      return NextResponse.json(
+        { error: "Invalid submission" },
+        { status: 400 }
+      );
+    }
+
     // Answer key is fetched server-side and stays server-side — it is never
-    // serialized into the response below.
+    // serialised into the response below.
     const answerKey = await getChallengeAnswerKey(courseSlug, lessonSlug);
 
     if (!answerKey) {
       return NextResponse.json({ error: "Lesson not found" }, { status: 404 });
     }
 
-    const tests = answerKey.tests ?? [];
-    const hiddenTestCount = tests.filter((tc) => tc.hidden === true).length;
-    const visibleTestCount = tests.length - hiddenTestCount;
+    const verdict = await validateAgainstAnswerKey(answerKey, submittedCode);
 
-    if (answerKey.type !== "challenge") {
-      return NextResponse.json({
-        serverValidated: false,
-        isChallenge: false,
-        hiddenTestCount: 0,
-        visibleTestCount: 0,
-        reason: "not_a_challenge",
-      });
+    switch (verdict.kind) {
+      case "not_a_challenge":
+        return NextResponse.json({
+          serverValidated: false,
+          passed: false,
+          isChallenge: false,
+          hiddenTestCount: 0,
+          visibleTestCount: 0,
+          reason: "not_a_challenge",
+        });
+      case "non_js_challenge":
+        // Rust / buildable challenges are validated by the Rust playground /
+        // build server, not this JS executor.
+        return NextResponse.json({
+          serverValidated: false,
+          passed: false,
+          isChallenge: true,
+          hiddenTestCount: verdict.hiddenTestCount,
+          visibleTestCount: verdict.visibleTestCount,
+          reason: "non_js_challenge",
+        });
+      case "executor_unavailable":
+        return NextResponse.json({
+          serverValidated: false,
+          passed: false,
+          isChallenge: true,
+          hiddenTestCount: verdict.hiddenTestCount,
+          visibleTestCount: verdict.visibleTestCount,
+          reason: "server_execution_unavailable",
+        });
+      case "validated":
+        return NextResponse.json({
+          serverValidated: true,
+          passed: verdict.passed,
+          isChallenge: true,
+          hiddenTestCount: verdict.hiddenTestCount,
+          visibleTestCount: verdict.visibleTestCount,
+        });
     }
-
-    // No server-side execution yet — report the authoritative test counts but do
-    // not claim the submission was validated.
-    return NextResponse.json({
-      serverValidated: false,
-      isChallenge: true,
-      hiddenTestCount,
-      visibleTestCount,
-      reason: "server_execution_unavailable",
-    });
   } catch (err: unknown) {
     logError({
       errorId: ERROR_IDS.CHALLENGE_VALIDATE_FAILED,

--- a/apps/web/src/components/editor/challenge-interface.tsx
+++ b/apps/web/src/components/editor/challenge-interface.tsx
@@ -169,11 +169,13 @@ export function ChallengeInterface({
 
     // Emit custom event — lesson-client.tsx calls the API and sets
     // isAlreadyCompleted=true when done, which triggers the overlay + confetti.
+    // The submitted code travels with the event so the server can re-validate
+    // it authoritatively (the browser test pass is UX-only).
     const event = new CustomEvent(LESSON_COMPLETE_EVENT, {
-      detail: { lessonId },
+      detail: { lessonId, submittedCode: code },
     });
     window.dispatchEvent(event);
-  }, [lessonId, onComplete]);
+  }, [lessonId, onComplete, code]);
 
   const handleSubmit = useCallback(() => {
     if (!isEnrolled) {

--- a/apps/web/src/lib/challenge/__tests__/executor.test.ts
+++ b/apps/web/src/lib/challenge/__tests__/executor.test.ts
@@ -85,6 +85,63 @@ describe.skipIf(!EXECUTOR_AVAILABLE)(
       expect(run.passed).toBe(false);
     });
 
+    // REGRESSION (#195 review HOLE-1): the validator reused ONE isolate context
+    // for every test, and the in-isolate harness builds each wrapper with
+    // `new Function(...)` (the shared realm's globalThis.Function) and serialises
+    // its verdict with `JSON.stringify`. A submission could poison those
+    // intrinsics in test #1 (or its own test) to force every later/hidden test
+    // to "pass". Fix: a FRESH context per test + the harness builds/serialises
+    // through CAPTURED intrinsics. These hidden tests demand a value the poison
+    // code does NOT compute (add(10,20)=30, asserted === 999), so a "pass" can
+    // ONLY come from taint — each MUST stay failed.
+    it.each([
+      [
+        "globalThis.Function",
+        'function add(a,b){ globalThis.Function = function(){ return function(){ return Promise.resolve("pass"); }; }; return a+b; }',
+      ],
+      [
+        "Object.prototype",
+        "function add(a,b){ Object.prototype.ok = true; return a+b; }",
+      ],
+      [
+        "Array.prototype",
+        "function add(a,b){ Array.prototype.push = function(){ return 0; }; return a+b; }",
+      ],
+      [
+        "JSON.stringify",
+        'function add(a,b){ JSON.stringify = function(){ return "{\\"ok\\":true}"; }; return a+b; }',
+      ],
+    ])(
+      "VALIDATOR-BYPASS BLOCKED: poisoning %s does not force-pass the hidden test",
+      async (_name, exploit) => {
+        const poisonTests: AdminTestCase[] = [
+          {
+            id: "visible-1",
+            description: "adds 2 and 3",
+            input: "2, 3",
+            expectedOutput: "result === 5",
+          },
+          {
+            id: "hidden-1",
+            description: "hidden, real answer is 30 — asserts 999",
+            input: "10, 20",
+            expectedOutput: "result === 999",
+            hidden: true,
+          },
+        ];
+        const run = await runJsSubmission(exploit, poisonTests);
+        expect(run.available).toBe(true);
+        if (!run.available) return;
+        // The submission's add() is correct arithmetic, so the VISIBLE test
+        // passes legitimately; the HIDDEN test must NOT be force-passed.
+        expect(run.results.find((r) => r.id === "hidden-1")?.passed).toBe(
+          false
+        );
+        expect(run.passed).toBe(false);
+      },
+      30_000
+    );
+
     it("kills CPU-bound runaway code via in-isolate timeout (does not hang)", async () => {
       const tests: AdminTestCase[] = [
         { id: "t", description: "loops", input: "", expectedOutput: "true" },

--- a/apps/web/src/lib/challenge/__tests__/executor.test.ts
+++ b/apps/web/src/lib/challenge/__tests__/executor.test.ts
@@ -1,14 +1,17 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import type { AdminTestCase } from "@superteam-lms/types";
-import { runJsSubmission, isExecutorAvailable } from "../executor";
+import { isExecutorAvailable, runJsSubmission } from "../executor";
 import { validateAgainstAnswerKey } from "../validate";
 import type { ChallengeAnswerKey } from "@/lib/sanity/queries";
 
-// These tests exercise the REAL isolated-vm executor (no mocks). They prove the
-// server is authoritative: correctness is judged by running the submission
-// against the server-held tests, so a forged client "passed" cannot produce a
-// passing verdict. They also assert the sandbox isolation guarantees
-// (no host objects, timeout kills runaway code).
+// `isolated-vm` is an OPTIONAL native addon: it requires Node >= 22 and a
+// prebuilt/buildable binary, so it is ABSENT on the repo's Node 20 CI runner and
+// on Vercel serverless. The isolate-backed tests below therefore run ONLY when
+// the addon actually loaded in this environment (resolved once, here); otherwise
+// they are SKIPPED, not failed. The gate-logic and degrade-closed tests further
+// down do NOT need the isolate and always run — they are what proves the
+// server-authoritative behaviour in the addon-absent environment.
+const EXECUTOR_AVAILABLE = await isExecutorAvailable();
 
 const sumTests: AdminTestCase[] = [
   {
@@ -34,141 +37,163 @@ const PASSES_VISIBLE_ONLY =
 const WRONG = "function add(a, b) { return a * b; }";
 const EMPTY = "";
 
-describe("secure challenge executor (isolated-vm)", () => {
-  it("is available in this environment", async () => {
-    expect(await isExecutorAvailable()).toBe(true);
-  });
+// These tests exercise the REAL isolated-vm executor (no mocks). They prove the
+// server is authoritative: correctness is judged by running the submission
+// against the server-held tests, so a forged client "passed" cannot produce a
+// passing verdict. They also assert the sandbox isolation guarantees
+// (no host objects, timeout kills runaway code). SKIPPED when the addon is
+// absent (e.g. Node 20 / serverless) — see EXECUTOR_AVAILABLE above.
+describe.skipIf(!EXECUTOR_AVAILABLE)(
+  "secure challenge executor (isolated-vm)",
+  () => {
+    it("reports available in this environment", async () => {
+      expect(await isExecutorAvailable()).toBe(true);
+    });
 
-  it("passes a correct submission against ALL tests (visible + hidden)", async () => {
-    const run = await runJsSubmission(CORRECT, sumTests);
-    expect(run.available).toBe(true);
-    if (!run.available) return;
-    expect(run.passed).toBe(true);
-    expect(run.results.every((r) => r.passed)).toBe(true);
-    // hidden test was actually executed
-    expect(run.results.find((r) => r.id === "hidden-1")?.passed).toBe(true);
-  });
+    it("passes a correct submission against ALL tests (visible + hidden)", async () => {
+      const run = await runJsSubmission(CORRECT, sumTests);
+      expect(run.available).toBe(true);
+      if (!run.available) return;
+      expect(run.passed).toBe(true);
+      expect(run.results.every((r) => r.passed)).toBe(true);
+      // hidden test was actually executed
+      expect(run.results.find((r) => r.id === "hidden-1")?.passed).toBe(true);
+    });
 
-  it("rejects a WRONG submission", async () => {
-    const run = await runJsSubmission(WRONG, sumTests);
-    expect(run.available).toBe(true);
-    if (!run.available) return;
-    expect(run.passed).toBe(false);
-  });
+    it("rejects a WRONG submission", async () => {
+      const run = await runJsSubmission(WRONG, sumTests);
+      expect(run.available).toBe(true);
+      if (!run.available) return;
+      expect(run.passed).toBe(false);
+    });
 
-  it("rejects an EMPTY submission", async () => {
-    const run = await runJsSubmission(EMPTY, sumTests);
-    expect(run.available).toBe(true);
-    if (!run.available) return;
-    expect(run.passed).toBe(false);
-  });
+    it("rejects an EMPTY submission", async () => {
+      const run = await runJsSubmission(EMPTY, sumTests);
+      expect(run.available).toBe(true);
+      if (!run.available) return;
+      expect(run.passed).toBe(false);
+    });
 
-  it("FORGED PASS IS BLOCKED: code that only satisfies the visible test fails the hidden test", async () => {
-    const run = await runJsSubmission(PASSES_VISIBLE_ONLY, sumTests);
-    expect(run.available).toBe(true);
-    if (!run.available) return;
-    // Visible passes, hidden fails -> overall NOT passed. The client could have
-    // claimed "all green", but the server runs the hidden test and rejects.
-    expect(run.results.find((r) => r.id === "visible-1")?.passed).toBe(true);
-    expect(run.results.find((r) => r.id === "hidden-1")?.passed).toBe(false);
-    expect(run.passed).toBe(false);
-  });
+    it("FORGED PASS IS BLOCKED: code that only satisfies the visible test fails the hidden test", async () => {
+      const run = await runJsSubmission(PASSES_VISIBLE_ONLY, sumTests);
+      expect(run.available).toBe(true);
+      if (!run.available) return;
+      // Visible passes, hidden fails -> overall NOT passed. The client could have
+      // claimed "all green", but the server runs the hidden test and rejects.
+      expect(run.results.find((r) => r.id === "visible-1")?.passed).toBe(true);
+      expect(run.results.find((r) => r.id === "hidden-1")?.passed).toBe(false);
+      expect(run.passed).toBe(false);
+    });
 
-  it("kills CPU-bound runaway code via in-isolate timeout (does not hang)", async () => {
-    const tests: AdminTestCase[] = [
-      { id: "t", description: "loops", input: "", expectedOutput: "true" },
-    ];
-    const run = await runJsSubmission(
-      "function go() { while (true) {} }",
-      tests
-    );
-    expect(run.available).toBe(true);
-    if (!run.available) return;
-    expect(run.passed).toBe(false);
-  }, 20_000);
+    it("kills CPU-bound runaway code via in-isolate timeout (does not hang)", async () => {
+      const tests: AdminTestCase[] = [
+        { id: "t", description: "loops", input: "", expectedOutput: "true" },
+      ];
+      const run = await runJsSubmission(
+        "function go() { while (true) {} }",
+        tests
+      );
+      expect(run.available).toBe(true);
+      if (!run.available) return;
+      expect(run.passed).toBe(false);
+    }, 20_000);
 
-  it("aborts a quiescent never-settling promise via host guard (does not hang)", async () => {
-    const tests: AdminTestCase[] = [
-      { id: "t", description: "hangs", input: "", expectedOutput: "true" },
-    ];
-    // No CPU spin: the in-isolate timeout can't fire, so the host wall-clock
-    // guard must abandon the evaluation.
-    const run = await runJsSubmission(
-      "async function go() { await new Promise(function(){}); }",
-      tests
-    );
-    expect(run.available).toBe(true);
-    if (!run.available) return;
-    expect(run.passed).toBe(false);
-  }, 20_000);
+    it("aborts a quiescent never-settling promise via host guard (does not hang)", async () => {
+      const tests: AdminTestCase[] = [
+        { id: "t", description: "hangs", input: "", expectedOutput: "true" },
+      ];
+      // No CPU spin: the in-isolate timeout can't fire, so the host wall-clock
+      // guard must abandon the evaluation.
+      const run = await runJsSubmission(
+        "async function go() { await new Promise(function(){}); }",
+        tests
+      );
+      expect(run.available).toBe(true);
+      if (!run.available) return;
+      expect(run.passed).toBe(false);
+    }, 20_000);
 
-  it("denies host escapes: process / require / globalThis are unreachable", async () => {
-    const escapeTests: AdminTestCase[] = [
-      {
-        id: "no-process",
-        description: "process is undefined",
-        input: "",
-        expectedOutput: "typeof process === 'undefined'",
-      },
-      {
-        id: "no-require",
-        description: "require is undefined",
-        input: "",
-        expectedOutput: "typeof require === 'undefined'",
-      },
-    ];
-    // A submission that probes the host. The assertions verify the host objects
-    // are absent inside the isolate, so these "pass" — proving no leakage.
-    const run = await runJsSubmission(
-      "function probe() { return true; }",
-      escapeTests
-    );
-    expect(run.available).toBe(true);
-    if (!run.available) return;
-    expect(run.results.find((r) => r.id === "no-process")?.passed).toBe(true);
-    expect(run.results.find((r) => r.id === "no-require")?.passed).toBe(true);
-  });
-});
-
-describe("validateAgainstAnswerKey (completion gate logic)", () => {
-  function key(over: Partial<ChallengeAnswerKey> = {}): ChallengeAnswerKey {
-    return {
-      _id: "lesson-1",
-      type: "challenge",
-      language: null,
-      buildType: null,
-      tests: sumTests,
-      solution: CORRECT,
-      ...over,
-    };
+    it("denies host escapes: process / require / globalThis are unreachable", async () => {
+      const escapeTests: AdminTestCase[] = [
+        {
+          id: "no-process",
+          description: "process is undefined",
+          input: "",
+          expectedOutput: "typeof process === 'undefined'",
+        },
+        {
+          id: "no-require",
+          description: "require is undefined",
+          input: "",
+          expectedOutput: "typeof require === 'undefined'",
+        },
+      ];
+      // A submission that probes the host. The assertions verify the host objects
+      // are absent inside the isolate, so these "pass" — proving no leakage.
+      const run = await runJsSubmission(
+        "function probe() { return true; }",
+        escapeTests
+      );
+      expect(run.available).toBe(true);
+      if (!run.available) return;
+      expect(run.results.find((r) => r.id === "no-process")?.passed).toBe(true);
+      expect(run.results.find((r) => r.id === "no-require")?.passed).toBe(true);
+    });
   }
+);
 
-  it("returns validated+passed for a correct JS submission", async () => {
-    const verdict = await validateAgainstAnswerKey(key(), CORRECT);
-    expect(verdict.kind).toBe("validated");
-    if (verdict.kind !== "validated") return;
-    expect(verdict.passed).toBe(true);
-    expect(verdict.hiddenTestCount).toBe(1);
-    expect(verdict.visibleTestCount).toBe(1);
-  });
+function answerKey(over: Partial<ChallengeAnswerKey> = {}): ChallengeAnswerKey {
+  return {
+    _id: "lesson-1",
+    type: "challenge",
+    language: null,
+    buildType: null,
+    tests: sumTests,
+    solution: CORRECT,
+    ...over,
+  };
+}
 
-  it("returns validated+!passed for a wrong submission (gate would 403)", async () => {
-    const verdict = await validateAgainstAnswerKey(key(), WRONG);
-    expect(verdict.kind).toBe("validated");
-    if (verdict.kind !== "validated") return;
-    expect(verdict.passed).toBe(false);
-  });
+// Gate logic that DOES exercise the real isolate (judging real submissions).
+// Guarded so it is skipped when the addon is absent — the degrade-closed block
+// below covers the addon-absent path deterministically.
+describe.skipIf(!EXECUTOR_AVAILABLE)(
+  "validateAgainstAnswerKey (executor present)",
+  () => {
+    it("returns validated+passed for a correct JS submission", async () => {
+      const verdict = await validateAgainstAnswerKey(answerKey(), CORRECT);
+      expect(verdict.kind).toBe("validated");
+      if (verdict.kind !== "validated") return;
+      expect(verdict.passed).toBe(true);
+      expect(verdict.hiddenTestCount).toBe(1);
+      expect(verdict.visibleTestCount).toBe(1);
+    });
 
-  it("returns validated+!passed for a forged-visible-only submission", async () => {
-    const verdict = await validateAgainstAnswerKey(key(), PASSES_VISIBLE_ONLY);
-    expect(verdict.kind).toBe("validated");
-    if (verdict.kind !== "validated") return;
-    expect(verdict.passed).toBe(false);
-  });
+    it("returns validated+!passed for a wrong submission (gate would 403)", async () => {
+      const verdict = await validateAgainstAnswerKey(answerKey(), WRONG);
+      expect(verdict.kind).toBe("validated");
+      if (verdict.kind !== "validated") return;
+      expect(verdict.passed).toBe(false);
+    });
 
+    it("returns validated+!passed for a forged-visible-only submission", async () => {
+      const verdict = await validateAgainstAnswerKey(
+        answerKey(),
+        PASSES_VISIBLE_ONLY
+      );
+      expect(verdict.kind).toBe("validated");
+      if (verdict.kind !== "validated") return;
+      expect(verdict.passed).toBe(false);
+    });
+  }
+);
+
+// Classification logic that needs NO isolate — always runs, including on the
+// Node 20 / serverless CI where the addon is absent.
+describe("validateAgainstAnswerKey (classification, no isolate)", () => {
   it("classifies non-challenge lessons as not_a_challenge (gate skipped)", async () => {
     const verdict = await validateAgainstAnswerKey(
-      key({ type: "content" }),
+      answerKey({ type: "content" }),
       ""
     );
     expect(verdict.kind).toBe("not_a_challenge");
@@ -176,15 +201,73 @@ describe("validateAgainstAnswerKey (completion gate logic)", () => {
 
   it("classifies rust / buildable challenges as non_js_challenge", async () => {
     const rust = await validateAgainstAnswerKey(
-      key({ language: "rust" }),
+      answerKey({ language: "rust" }),
       "fn add() {}"
     );
     expect(rust.kind).toBe("non_js_challenge");
 
     const buildable = await validateAgainstAnswerKey(
-      key({ buildType: "buildable" }),
+      answerKey({ buildType: "buildable" }),
       "// program"
     );
     expect(buildable.kind).toBe("non_js_challenge");
+  });
+});
+
+// DEGRADE-CLOSED — the contract that keeps the platform safe when the secure
+// executor cannot run (the exact Node 20 / Vercel situation). The executor
+// module is MOCKED unavailable so this is deterministic regardless of whether
+// isolated-vm happens to be built in the current environment. The verdict here
+// is what the routes turn into a 503 (POST /api/lessons/complete) — completion
+// is BLOCKED, never silently granted.
+describe("degrade-closed when executor is unavailable (mocked)", () => {
+  afterEach(() => {
+    vi.resetModules();
+    vi.restoreAllMocks();
+  });
+
+  it("a JS challenge yields executor_unavailable, NOT a pass — even for the reference solution", async () => {
+    vi.resetModules();
+    vi.doMock("@/lib/challenge/executor", () => ({
+      isExecutorAvailable: vi.fn().mockResolvedValue(false),
+      // If this were ever reached it would throw — proving the gate denies
+      // BEFORE running anything when the executor is unavailable.
+      runJsSubmission: vi.fn(async () => {
+        throw new Error("executor must not run when unavailable");
+      }),
+    }));
+
+    const { validateAgainstAnswerKey: validateUnavailable } =
+      await import("../validate");
+
+    // The reference solution would PASS if the executor ran; with the executor
+    // down it must still be denied (degrade closed), not waved through.
+    const verdict = await validateUnavailable(answerKey(), CORRECT);
+    expect(verdict.kind).toBe("executor_unavailable");
+    if (verdict.kind !== "executor_unavailable") return;
+    expect(verdict.hiddenTestCount).toBe(1);
+    expect(verdict.visibleTestCount).toBe(1);
+    // Crucially there is no `passed: true` shape on this verdict — the route
+    // maps `executor_unavailable` to HTTP 503, blocking completion.
+    expect("passed" in verdict).toBe(false);
+  });
+
+  it("treats runJsSubmission reporting available:false as a non-pass (deny)", async () => {
+    vi.resetModules();
+    vi.doMock("@/lib/challenge/executor", () => ({
+      // isExecutorAvailable optimistically true, but the run reports it could
+      // not actually execute — the validator must still degrade closed.
+      isExecutorAvailable: vi.fn().mockResolvedValue(true),
+      runJsSubmission: vi.fn().mockResolvedValue({
+        available: false,
+        reason: "executor_unavailable",
+      }),
+    }));
+
+    const { validateAgainstAnswerKey: validateUnavailable } =
+      await import("../validate");
+
+    const verdict = await validateUnavailable(answerKey(), PASSES_VISIBLE_ONLY);
+    expect(verdict.kind).toBe("executor_unavailable");
   });
 });

--- a/apps/web/src/lib/challenge/__tests__/executor.test.ts
+++ b/apps/web/src/lib/challenge/__tests__/executor.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect } from "vitest";
+import type { AdminTestCase } from "@superteam-lms/types";
+import { runJsSubmission, isExecutorAvailable } from "../executor";
+import { validateAgainstAnswerKey } from "../validate";
+import type { ChallengeAnswerKey } from "@/lib/sanity/queries";
+
+// These tests exercise the REAL isolated-vm executor (no mocks). They prove the
+// server is authoritative: correctness is judged by running the submission
+// against the server-held tests, so a forged client "passed" cannot produce a
+// passing verdict. They also assert the sandbox isolation guarantees
+// (no host objects, timeout kills runaway code).
+
+const sumTests: AdminTestCase[] = [
+  {
+    id: "visible-1",
+    description: "adds 2 and 3",
+    input: "2, 3",
+    expectedOutput: "result === 5",
+  },
+  {
+    id: "hidden-1",
+    description: "adds 10 and 20 (hidden)",
+    input: "10, 20",
+    expectedOutput: "result === 30",
+    hidden: true,
+  },
+];
+
+const CORRECT = "function add(a, b) { return a + b; }";
+// Passes the VISIBLE test (returns 5 for 2,3) but FAILS the hidden test —
+// this is exactly the "passed in the browser" shape that must be caught.
+const PASSES_VISIBLE_ONLY =
+  "function add(a, b) { if (a === 2 && b === 3) return 5; return -1; }";
+const WRONG = "function add(a, b) { return a * b; }";
+const EMPTY = "";
+
+describe("secure challenge executor (isolated-vm)", () => {
+  it("is available in this environment", async () => {
+    expect(await isExecutorAvailable()).toBe(true);
+  });
+
+  it("passes a correct submission against ALL tests (visible + hidden)", async () => {
+    const run = await runJsSubmission(CORRECT, sumTests);
+    expect(run.available).toBe(true);
+    if (!run.available) return;
+    expect(run.passed).toBe(true);
+    expect(run.results.every((r) => r.passed)).toBe(true);
+    // hidden test was actually executed
+    expect(run.results.find((r) => r.id === "hidden-1")?.passed).toBe(true);
+  });
+
+  it("rejects a WRONG submission", async () => {
+    const run = await runJsSubmission(WRONG, sumTests);
+    expect(run.available).toBe(true);
+    if (!run.available) return;
+    expect(run.passed).toBe(false);
+  });
+
+  it("rejects an EMPTY submission", async () => {
+    const run = await runJsSubmission(EMPTY, sumTests);
+    expect(run.available).toBe(true);
+    if (!run.available) return;
+    expect(run.passed).toBe(false);
+  });
+
+  it("FORGED PASS IS BLOCKED: code that only satisfies the visible test fails the hidden test", async () => {
+    const run = await runJsSubmission(PASSES_VISIBLE_ONLY, sumTests);
+    expect(run.available).toBe(true);
+    if (!run.available) return;
+    // Visible passes, hidden fails -> overall NOT passed. The client could have
+    // claimed "all green", but the server runs the hidden test and rejects.
+    expect(run.results.find((r) => r.id === "visible-1")?.passed).toBe(true);
+    expect(run.results.find((r) => r.id === "hidden-1")?.passed).toBe(false);
+    expect(run.passed).toBe(false);
+  });
+
+  it("kills CPU-bound runaway code via in-isolate timeout (does not hang)", async () => {
+    const tests: AdminTestCase[] = [
+      { id: "t", description: "loops", input: "", expectedOutput: "true" },
+    ];
+    const run = await runJsSubmission(
+      "function go() { while (true) {} }",
+      tests
+    );
+    expect(run.available).toBe(true);
+    if (!run.available) return;
+    expect(run.passed).toBe(false);
+  }, 20_000);
+
+  it("aborts a quiescent never-settling promise via host guard (does not hang)", async () => {
+    const tests: AdminTestCase[] = [
+      { id: "t", description: "hangs", input: "", expectedOutput: "true" },
+    ];
+    // No CPU spin: the in-isolate timeout can't fire, so the host wall-clock
+    // guard must abandon the evaluation.
+    const run = await runJsSubmission(
+      "async function go() { await new Promise(function(){}); }",
+      tests
+    );
+    expect(run.available).toBe(true);
+    if (!run.available) return;
+    expect(run.passed).toBe(false);
+  }, 20_000);
+
+  it("denies host escapes: process / require / globalThis are unreachable", async () => {
+    const escapeTests: AdminTestCase[] = [
+      {
+        id: "no-process",
+        description: "process is undefined",
+        input: "",
+        expectedOutput: "typeof process === 'undefined'",
+      },
+      {
+        id: "no-require",
+        description: "require is undefined",
+        input: "",
+        expectedOutput: "typeof require === 'undefined'",
+      },
+    ];
+    // A submission that probes the host. The assertions verify the host objects
+    // are absent inside the isolate, so these "pass" — proving no leakage.
+    const run = await runJsSubmission(
+      "function probe() { return true; }",
+      escapeTests
+    );
+    expect(run.available).toBe(true);
+    if (!run.available) return;
+    expect(run.results.find((r) => r.id === "no-process")?.passed).toBe(true);
+    expect(run.results.find((r) => r.id === "no-require")?.passed).toBe(true);
+  });
+});
+
+describe("validateAgainstAnswerKey (completion gate logic)", () => {
+  function key(over: Partial<ChallengeAnswerKey> = {}): ChallengeAnswerKey {
+    return {
+      _id: "lesson-1",
+      type: "challenge",
+      language: null,
+      buildType: null,
+      tests: sumTests,
+      solution: CORRECT,
+      ...over,
+    };
+  }
+
+  it("returns validated+passed for a correct JS submission", async () => {
+    const verdict = await validateAgainstAnswerKey(key(), CORRECT);
+    expect(verdict.kind).toBe("validated");
+    if (verdict.kind !== "validated") return;
+    expect(verdict.passed).toBe(true);
+    expect(verdict.hiddenTestCount).toBe(1);
+    expect(verdict.visibleTestCount).toBe(1);
+  });
+
+  it("returns validated+!passed for a wrong submission (gate would 403)", async () => {
+    const verdict = await validateAgainstAnswerKey(key(), WRONG);
+    expect(verdict.kind).toBe("validated");
+    if (verdict.kind !== "validated") return;
+    expect(verdict.passed).toBe(false);
+  });
+
+  it("returns validated+!passed for a forged-visible-only submission", async () => {
+    const verdict = await validateAgainstAnswerKey(key(), PASSES_VISIBLE_ONLY);
+    expect(verdict.kind).toBe("validated");
+    if (verdict.kind !== "validated") return;
+    expect(verdict.passed).toBe(false);
+  });
+
+  it("classifies non-challenge lessons as not_a_challenge (gate skipped)", async () => {
+    const verdict = await validateAgainstAnswerKey(
+      key({ type: "content" }),
+      ""
+    );
+    expect(verdict.kind).toBe("not_a_challenge");
+  });
+
+  it("classifies rust / buildable challenges as non_js_challenge", async () => {
+    const rust = await validateAgainstAnswerKey(
+      key({ language: "rust" }),
+      "fn add() {}"
+    );
+    expect(rust.kind).toBe("non_js_challenge");
+
+    const buildable = await validateAgainstAnswerKey(
+      key({ buildType: "buildable" }),
+      "// program"
+    );
+    expect(buildable.kind).toBe("non_js_challenge");
+  });
+});

--- a/apps/web/src/lib/challenge/executor.ts
+++ b/apps/web/src/lib/challenge/executor.ts
@@ -1,0 +1,597 @@
+/**
+ * Secure server-side executor for untrusted learner JavaScript/TypeScript.
+ *
+ * SECURITY BOUNDARY
+ * -----------------
+ * Learner code is arbitrary and hostile by assumption. Node's `vm` module,
+ * `eval`, and `new Function` share the host realm and are NOT isolation
+ * boundaries. This module runs submissions inside a real V8 **isolate** via
+ * `isolated-vm`, which is the standard primitive for sandboxing untrusted JS in
+ * Node. The guarantees, all enforced by V8 itself (not by string filtering):
+ *
+ *   - Separate heap with a hard MEMORY LIMIT (`MEMORY_LIMIT_MB`). A submission
+ *     that allocates past the cap is terminated; it cannot exhaust host memory.
+ *   - A wall-clock TIMEOUT per evaluation (`EXEC_TIMEOUT_MS`). Infinite loops and
+ *     busy-waits are killed.
+ *   - No ambient host objects. `process`, `require`, `module`, `globalThis`
+ *     bindings to Node, the filesystem, and the network simply do not exist in
+ *     the isolate — there is nothing to reference. We never bridge a host
+ *     function or object into the isolate (no `Reference`, no `jsonOver`...).
+ *   - Only two values cross the boundary: a STRING of code goes in; a
+ *     JSON-serialisable STRING result comes out (copied, never shared).
+ *
+ * The mock Solana SDK and console live ENTIRELY inside the isolate, assembled
+ * from source text, so the learner interacts only with isolate-local objects.
+ *
+ * DEGRADE-CLOSED
+ * --------------
+ * `isolated-vm` is a native addon. If it cannot be loaded in the host
+ * environment (e.g. a serverless platform without the prebuilt binary), this
+ * module reports `available: false` and runs NOTHING. Callers MUST treat an
+ * unavailable executor as a validation FAILURE (deny completion), never as a
+ * pass. See `runJsSubmission`'s return contract. The intended production
+ * fallback is a dedicated sandboxed microservice (mirroring the existing Rust
+ * build-server), not an insecure in-process `vm`/`Function` shim.
+ */
+
+import type { AdminTestCase } from "@superteam-lms/types";
+
+/** Hard heap cap for the isolate. Enough for SDK mocks + small programs. */
+const MEMORY_LIMIT_MB = 64;
+
+/**
+ * Wall-clock budget per evaluation, enforced INSIDE the isolate (kills
+ * CPU-bound runaways like `while(true){}`). Mirrors the browser worker's 5s.
+ */
+const EXEC_TIMEOUT_MS = 5_000;
+
+/**
+ * Host-side hard guard, slightly longer than EXEC_TIMEOUT_MS. The in-isolate
+ * timeout cannot interrupt a quiescent pending promise (e.g.
+ * `await new Promise(() => {})`) because there is no CPU activity to preempt —
+ * there are no timers/event-loop primitives in the isolate, so such a promise
+ * never settles. This guard abandons the evaluation and the isolate is disposed,
+ * preventing a hung request. Defense-in-depth, not the primary boundary.
+ */
+const HOST_GUARD_MS = EXEC_TIMEOUT_MS + 1_000;
+
+/** Marker rejection raised when the host guard trips. */
+const HOST_GUARD = Symbol("host-guard");
+
+/** Race a promise against a host wall-clock guard. */
+function withHostGuard<T>(p: Promise<T>): Promise<T> {
+  let timer: ReturnType<typeof setTimeout>;
+  const guard = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(HOST_GUARD), HOST_GUARD_MS);
+  });
+  return Promise.race([p, guard]).finally(() =>
+    clearTimeout(timer)
+  ) as Promise<T>;
+}
+
+/** Upper bound on submission size we are willing to compile/run. */
+const MAX_CODE_BYTES = 100_000;
+
+/**
+ * Minimal shape of the `isolated-vm` API we depend on. Declared locally so the
+ * module type-checks even where `@types` for the native addon are unavailable,
+ * and so the dependency is imported lazily (degrade-closed).
+ */
+interface IvmContext {
+  eval(
+    code: string,
+    opts?: { timeout?: number; promise?: boolean }
+  ): Promise<unknown>;
+}
+interface IvmIsolate {
+  createContext(): Promise<IvmContext>;
+  dispose(): void;
+}
+interface IvmModule {
+  Isolate: new (opts: { memoryLimit: number }) => IvmIsolate;
+}
+
+let ivmModulePromise: Promise<IvmModule | null> | undefined;
+
+/**
+ * Load `isolated-vm` once, lazily. Returns null (never throws) when the native
+ * addon is missing so the caller can degrade closed.
+ */
+async function loadIvm(): Promise<IvmModule | null> {
+  if (ivmModulePromise === undefined) {
+    ivmModulePromise = (async () => {
+      try {
+        // Indirected through a variable so bundlers don't try to follow/trace
+        // the native addon at build time.
+        const specifier = "isolated-vm";
+        const mod = (await import(/* webpackIgnore: true */ specifier)) as
+          | IvmModule
+          | { default: IvmModule };
+        return "Isolate" in mod ? mod : mod.default;
+      } catch {
+        return null;
+      }
+    })();
+  }
+  return ivmModulePromise;
+}
+
+/** Result of running a single test case server-side. */
+export interface ServerTestResult {
+  /** The test's authored id (mirrors AdminTestCase.id). */
+  id: string;
+  hidden: boolean;
+  passed: boolean;
+  /** Short, non-sensitive diagnostic (never leaks the expected value verbatim). */
+  detail: string;
+}
+
+/** Aggregate outcome of running a submission against every test. */
+export type SubmissionRunResult =
+  | {
+      available: true;
+      /** True only when EVERY test (visible + hidden) passed. */
+      passed: boolean;
+      results: ServerTestResult[];
+    }
+  | {
+      /**
+       * The secure executor could not run. Callers MUST treat this as a
+       * non-pass and deny completion.
+       */
+      available: false;
+      reason: "executor_unavailable";
+    };
+
+/** Whether the secure executor can run in this environment. */
+export async function isExecutorAvailable(): Promise<boolean> {
+  return (await loadIvm()) !== null;
+}
+
+/* ------------------------------------------------------------------------- */
+/* In-isolate runtime source                                                 */
+/* ------------------------------------------------------------------------- */
+
+/**
+ * Source text evaluated INSIDE the isolate to install the mock SDK + console
+ * and expose a single `__runCase__(userCode, testJson)` entry point. This is a
+ * faithful server port of the browser worker contract in
+ * `components/editor/challenge-runner.tsx` (mock @solana/web3.js + spl-token,
+ * mock console, arg-setup heuristics, type-shape + assertion evaluation), so a
+ * submission that passes the visible tests in-browser is judged identically by
+ * the server — the difference is solely that the SERVER also runs hidden tests
+ * and is authoritative.
+ *
+ * NOTE: pure strings/functions only. No host references. `__runCase__` returns
+ * a JSON string; the host parses the copied-out string.
+ */
+const ISOLATE_RUNTIME_SOURCE = String.raw`
+"use strict";
+
+var BASE58_ALPHABET = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+function toBase58(bytes) {
+  var result = "";
+  for (var i = 0; i < bytes.length; i++) result += BASE58_ALPHABET[bytes[i] % 58];
+  return result;
+}
+function randomBytes(n) {
+  var buf = new Uint8Array(n);
+  for (var i = 0; i < n; i++) buf[i] = (Math.random() * 256) | 0;
+  return buf;
+}
+
+function MockPublicKey(value) {
+  if (typeof value === "string") {
+    if (!/^[1-9A-HJ-NP-Za-km-z]{32,44}$/.test(value)) throw new Error("Invalid public key input");
+    this._bytes = new Uint8Array(32);
+  } else {
+    this._bytes = value || randomBytes(32);
+  }
+}
+MockPublicKey.prototype.toBase58 = function () { return toBase58(this._bytes); };
+MockPublicKey.prototype.toString = function () { return this.toBase58(); };
+MockPublicKey.prototype.toJSON = function () { return this.toBase58(); };
+MockPublicKey.prototype.toBytes = function () { return this._bytes; };
+MockPublicKey.prototype.equals = function (other) {
+  if (!other || !other._bytes) return false;
+  return this.toBase58() === other.toBase58();
+};
+MockPublicKey.isOnCurve = function () { return true; };
+MockPublicKey.findProgramAddressSync = function (seeds, programId) {
+  void programId;
+  var total = 1;
+  for (var i = 0; i < seeds.length; i++) total += seeds[i].length;
+  var combined = new Uint8Array(total);
+  var offset = 0;
+  for (var j = 0; j < seeds.length; j++) { combined.set(seeds[j], offset); offset += seeds[j].length; }
+  combined[offset] = 254;
+  var hash = new Uint8Array(32);
+  for (var k = 0; k < 32; k++) hash[k] = (combined[k % combined.length] || 0) ^ 0x5a;
+  return [new MockPublicKey(hash), 254];
+};
+
+function MockKeypair() {
+  this.secretKey = randomBytes(64);
+  this.publicKey = new MockPublicKey(this.secretKey.slice(32));
+}
+MockKeypair.generate = function () { return new MockKeypair(); };
+MockKeypair.fromSecretKey = function (sk) {
+  var kp = new MockKeypair();
+  kp.secretKey = sk;
+  kp.publicKey = new MockPublicKey(sk.slice(32));
+  return kp;
+};
+
+function MockTransaction() { this.instructions = []; }
+MockTransaction.prototype.add = function () {
+  for (var i = 0; i < arguments.length; i++) this.instructions.push(arguments[i]);
+  return this;
+};
+
+function MockConnection() {}
+MockConnection.prototype.requestAirdrop = function () { return Promise.resolve("mock-airdrop-sig"); };
+MockConnection.prototype.confirmTransaction = function () { return Promise.resolve(); };
+MockConnection.prototype.getBalance = function () { return Promise.resolve(2000000000); };
+
+var MockSystemProgram = {
+  transfer: function (params) {
+    var out = { programId: "11111111111111111111111111111111" };
+    for (var key in params) if (Object.prototype.hasOwnProperty.call(params, key)) out[key] = params[key];
+    return out;
+  }
+};
+
+var LAMPORTS_PER_SOL = 1000000000;
+function mockCreateMint() { return Promise.resolve(new MockPublicKey()); }
+
+Object.freeze(MockPublicKey.prototype);
+Object.freeze(MockKeypair.prototype);
+Object.freeze(MockTransaction.prototype);
+Object.freeze(MockConnection.prototype);
+
+var __modules__ = {
+  "@solana/web3.js": {
+    Keypair: MockKeypair,
+    PublicKey: MockPublicKey,
+    Connection: MockConnection,
+    Transaction: MockTransaction,
+    SystemProgram: MockSystemProgram,
+    LAMPORTS_PER_SOL: LAMPORTS_PER_SOL,
+    sendAndConfirmTransaction: function () { return Promise.resolve("mock-tx-signature"); }
+  },
+  "@solana/spl-token": {
+    createMint: mockCreateMint,
+    getOrCreateAssociatedTokenAccount: function () { return Promise.resolve({ address: new MockPublicKey() }); }
+  }
+};
+
+function makeMockConsole() {
+  var logs = [];
+  var fmt = function (a) { return typeof a === "object" ? JSON.stringify(a) : String(a); };
+  function joiner(prefix) {
+    return function () { var a = []; for (var i = 0; i < arguments.length; i++) a.push(fmt(arguments[i])); logs.push(prefix + a.join(" ")); };
+  }
+  return { logs: logs, mock: { log: joiner(""), error: joiner("[error] "), warn: joiner("[warn] "), info: joiner("") } };
+}
+
+/* ---- code analysis (ports of challenge-runner helpers) ------------------ */
+
+function detectFunctionName(code) {
+  var m = code.match(/(?:function\s+(\w+)\s*\(|(?:const|let|var)\s+(\w+)\s*=\s*(?:async\s*)?\()/);
+  return m ? (m[1] || m[2] || null) : null;
+}
+function functionHasParams(code, fnName) {
+  var re = new RegExp("(?:function\\s+" + fnName + "\\s*\\(([^)]*?)\\)|(?:const|let|var)\\s+" + fnName + "\\s*=\\s*(?:async\\s*)?\\(([^)]*?)\\))");
+  var m = code.match(re);
+  if (!m) return false;
+  var params = (m[1] || m[2] || "").trim();
+  return params.length > 0;
+}
+
+var KEYPAIR_NAMES = { payer:1, sender:1, recipient:1, owner:1, authority:1, mint:1, senderKeypair:1, recipientKeypair:1, userKeypair:1 };
+var PUBKEY_NAMES = { programId:1, userPubkey:1, recipientPubkey:1, senderPublicKey:1, expectedOwner:1, tokenProgramId:1, systemProgramId:1, dataAccount:1 };
+
+function buildArgSetup(input) {
+  if (!input.trim()) return "";
+  var args = input.split(",").map(function (a) { return a.trim(); });
+  var lines = [];
+  for (var i = 0; i < args.length; i++) {
+    var arg = args[i];
+    if (/^\d/.test(arg) || /^-?\d*\.?\d+$/.test(arg)) continue;
+    if (/^['"]/.test(arg) || /^true$|^false$|^null$/.test(arg)) continue;
+    if (arg === "connection") lines.push('var ' + arg + ' = new (__modules__["@solana/web3.js"].Connection)("https://api.devnet.solana.com");');
+    else if (KEYPAIR_NAMES[arg]) lines.push('var ' + arg + ' = __modules__["@solana/web3.js"].Keypair.generate();');
+    else if (PUBKEY_NAMES[arg]) lines.push('var ' + arg + ' = __modules__["@solana/web3.js"].Keypair.generate().publicKey;');
+    else if (arg === "wallets") lines.push('var wallets = [__modules__["@solana/web3.js"].Keypair.generate().publicKey, __modules__["@solana/web3.js"].Keypair.generate().publicKey, __modules__["@solana/web3.js"].Keypair.generate().publicKey];');
+    else if (arg === "data" || arg === "buffer") lines.push('var ' + arg + ' = new Uint8Array([1, 5, 0, 0, 0, 6, 0, 0, 0, 83, 111, 108, 68, 101, 118]);');
+    else if (arg === "expectedSeeds") lines.push('var expectedSeeds = [new TextEncoder().encode("user")];');
+    else if (arg === "account") lines.push('var account = { owner: __modules__["@solana/web3.js"].Keypair.generate().publicKey, publicKey: __modules__["@solana/web3.js"].Keypair.generate().publicKey, lamports: 1000000, data: new Uint8Array([1,2,3]), executable: false };');
+    else if (arg === "position") lines.push('var position = { collateral: 100, debt: 50, threshold: 1.5 };');
+    else lines.push('var ' + arg + ' = {};');
+  }
+  return lines.join("\n");
+}
+function buildCallArgs(input) {
+  if (!input.trim()) return "";
+  return input.split(",").map(function (a) {
+    var t = a.trim();
+    if (KEYPAIR_NAMES[t]) return t + ".publicKey ?? " + t;
+    return t;
+  }).join(", ");
+}
+function isTypeShape(expected) {
+  var match = expected.match(/^\{\s*(.+)\s*\}$/);
+  if (!match || !match[1]) return null;
+  var pairs = {};
+  var parts = match[1].split(",");
+  for (var i = 0; i < parts.length; i++) {
+    var kv = parts[i].split(":").map(function (s) { return s.trim(); });
+    var key = kv[0]; var type = kv[1];
+    if (kv.length === 2 && key && type && /^(string|number|boolean|object)$/.test(type)) pairs[key] = type;
+    else return null;
+  }
+  return Object.keys(pairs).length > 0 ? pairs : null;
+}
+
+/* ---- single test-case runner -------------------------------------------- */
+/* Mirrors runTestCase() in challenge-runner.tsx. Transpilation to plain JS is
+ * done on the host (sucrase) before this runs, so userCode is already JS. */
+
+function runCase(userCode, test) {
+  var fnName = detectFunctionName(userCode);
+  if (!fnName) return { ok: false, detail: "No function found in submission" };
+
+  var argSetup = buildArgSetup(test.input);
+  var callArgs = test.input.trim() ? buildCallArgs(test.input) : "";
+  var typeShape = isTypeShape(test.expectedOutput);
+
+  var assertionCode;
+  if (typeShape) {
+    var checks = [];
+    for (var key in typeShape) if (Object.prototype.hasOwnProperty.call(typeShape, key)) {
+      checks.push('typeof __result__["' + key + '"] === "' + typeShape[key] + '"');
+    }
+    assertionCode = 'return (' + checks.join(" && ") + ') ? "pass" : "fail: shape mismatch";';
+  } else {
+    assertionCode =
+      'var result = __result__;\n' +
+      'var transaction = __result__;\n' +
+      'if (typeof __result__ === "object" && __result__ !== null) {\n' +
+      '  var publicKey = __result__.publicKey;\n' +
+      '  var isValid = __result__.isValid;\n' +
+      '  var lamports = __result__.instructions && __result__.instructions[0] ? __result__.instructions[0].lamports : undefined;\n' +
+      '  var mintInfo = { decimals: 9 };\n' +
+      '}\n' +
+      'try {\n' +
+      '  var __assertion__ = (' + test.expectedOutput + ');\n' +
+      '  if (typeof __assertion__ === "boolean") return __assertion__ ? "pass" : "fail: assertion false";\n' +
+      '  if (typeof __assertion__ === "number" && isFinite(__assertion__)) return "numeric:" + __assertion__;\n' +
+      '  return String(__assertion__);\n' +
+      '} catch (e) { return "fail: " + ((e && e.message) || String(e)); }';
+  }
+
+  var mc = makeMockConsole();
+  var body =
+    '"use strict";\n' +
+    'return (async function(){\n' +
+    '  var console = __mc__;\n' +
+    userCode + '\n;\n' +
+    argSetup + '\n' +
+    '  var __result__ = await ' + fnName + '(' + callArgs + ');\n' +
+    '  return (function(){ ' + assertionCode + ' })();\n' +
+    '})();';
+
+  try {
+    var fn = new Function("__mc__", "__modules__", body);
+    var p = fn(mc.mock, __modules__);
+    return Promise.resolve(p).then(function (result) {
+      var passed = result === "pass" || result === true;
+      return { ok: passed, detail: passed ? "pass" : String(result).slice(0, 200) };
+    }, function (err) {
+      return { ok: false, detail: ((err && err.message) || String(err)).slice(0, 200) };
+    });
+  } catch (err) {
+    return Promise.resolve({ ok: false, detail: ((err && err.message) || String(err)).slice(0, 200) });
+  }
+}
+
+/* Entry point invoked by the host. Returns a JSON STRING (copied out). */
+async function __runCase__(userCodeJson, testJson) {
+  var userCode = JSON.parse(userCodeJson);
+  var test = JSON.parse(testJson);
+  var r = await runCase(userCode, test);
+  return JSON.stringify(r);
+}
+`;
+
+/* ------------------------------------------------------------------------- */
+/* Host-side transpilation (untrusted code never executes here)              */
+/* ------------------------------------------------------------------------- */
+
+/**
+ * Transpile a TS/JS submission to plain JS and rewrite `import`/`require` of the
+ * mocked SDK modules to `__modules__` lookups — the server port of
+ * `transformImports()` in the browser runner. This runs sucrase (a parser/
+ * code-generator) on the host: it parses text, it does NOT execute it.
+ */
+function transformImports(code: string): string {
+  if (/import\s*\(/.test(code)) {
+    throw new Error("Dynamic import() is not allowed in challenges");
+  }
+
+  let transformed = code
+    .replace(
+      /import\s*\{([^}]+)\}\s*from\s*['"]([^'"]+)['"]\s*;?/g,
+      (_m, imports: string, mod: string) => {
+        const names = imports
+          .split(",")
+          .map((s) => s.trim())
+          .filter(Boolean);
+        return `const { ${names.join(", ")} } = __modules__[${JSON.stringify(mod)}] || {};`;
+      }
+    )
+    .replace(
+      /import\s+(\w+)\s+from\s*['"]([^'"]+)['"]\s*;?/g,
+      (_m, name: string, mod: string) =>
+        `const ${name} = (__modules__[${JSON.stringify(mod)}] || {}).default || __modules__[${JSON.stringify(mod)}] || {};`
+    )
+    .replace(
+      /(?:const|let|var)\s*\{([^}]+)\}\s*=\s*require\s*\(\s*['"]([^'"]+)['"]\s*\)\s*;?/g,
+      (_m, imports: string, mod: string) => {
+        const names = imports
+          .split(",")
+          .map((s) => s.trim())
+          .filter(Boolean);
+        return `const { ${names.join(", ")} } = __modules__[${JSON.stringify(mod)}] || {};`;
+      }
+    );
+
+  // Lazy require: sucrase is already a dependency used by the browser runner.
+  // Parsing-only; it never runs the submission.
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { transform } = require("sucrase") as typeof import("sucrase");
+  try {
+    transformed = transform(transformed, {
+      transforms: ["typescript"],
+      disableESTransforms: true,
+    }).code;
+  } catch (err) {
+    throw new Error(
+      `Syntax error: ${err instanceof Error ? err.message : String(err)}`
+    );
+  }
+  return transformed;
+}
+
+/* ------------------------------------------------------------------------- */
+/* Public API                                                                */
+/* ------------------------------------------------------------------------- */
+
+/**
+ * Run a JS/TS submission against every supplied test inside a fresh isolate.
+ *
+ * Contract: returns `{ available: false }` when the secure executor cannot run
+ * — callers MUST deny completion in that case. When available, `passed` is true
+ * only if EVERY test passed.
+ */
+export async function runJsSubmission(
+  code: string,
+  tests: AdminTestCase[]
+): Promise<SubmissionRunResult> {
+  const ivm = await loadIvm();
+  if (!ivm) return { available: false, reason: "executor_unavailable" };
+
+  if (Buffer.byteLength(code, "utf8") > MAX_CODE_BYTES) {
+    return {
+      available: true,
+      passed: false,
+      results: tests.map((t) => ({
+        id: t.id,
+        hidden: t.hidden === true,
+        passed: false,
+        detail: "Submission too large",
+      })),
+    };
+  }
+
+  let transpiled: string;
+  try {
+    transpiled = transformImports(code);
+  } catch (err) {
+    // A submission that doesn't even parse fails every test.
+    const detail = (err instanceof Error ? err.message : String(err)).slice(
+      0,
+      200
+    );
+    return {
+      available: true,
+      passed: false,
+      results: tests.map((t) => ({
+        id: t.id,
+        hidden: t.hidden === true,
+        passed: false,
+        detail,
+      })),
+    };
+  }
+
+  const isolate = new ivm.Isolate({ memoryLimit: MEMORY_LIMIT_MB });
+  try {
+    const context = await isolate.createContext();
+    // Install the in-isolate runtime once per submission.
+    await withHostGuard(
+      context.eval(ISOLATE_RUNTIME_SOURCE, { timeout: EXEC_TIMEOUT_MS })
+    );
+
+    const userCodeJson = JSON.stringify(transpiled);
+    const results: ServerTestResult[] = [];
+    // Once the host guard trips we dispose the isolate; remaining tests cannot
+    // run on a dead isolate, so they are recorded as failed.
+    let aborted = false;
+
+    for (const test of tests) {
+      if (aborted) {
+        results.push({
+          id: test.id,
+          hidden: test.hidden === true,
+          passed: false,
+          detail: "Execution aborted (timeout)",
+        });
+        continue;
+      }
+
+      const testJson = JSON.stringify({
+        input: test.input ?? "",
+        expectedOutput: test.expectedOutput ?? "",
+      });
+      // Call the in-isolate entry point. Both arguments are JSON string
+      // literals embedded in the eval'd expression — no host references cross
+      // the boundary; the result is a JSON string copied out.
+      const expr = `__runCase__(${JSON.stringify(userCodeJson)}, ${JSON.stringify(testJson)})`;
+      let detail = "execution error";
+      let passed = false;
+      try {
+        // promise:true resolves the async __runCase__ inside the isolate and
+        // copies the resolved JSON string out. The in-isolate timeout kills
+        // CPU-bound runaways; withHostGuard catches the rare quiescent
+        // never-settling promise.
+        const raw = (await withHostGuard(
+          context.eval(expr, {
+            timeout: EXEC_TIMEOUT_MS,
+            promise: true,
+          })
+        )) as string;
+        const parsed = JSON.parse(raw) as { ok: boolean; detail: string };
+        passed = parsed.ok === true;
+        detail = parsed.detail;
+      } catch (err) {
+        if (err === HOST_GUARD) {
+          // Abandon the hung evaluation: dispose the isolate and fail the rest.
+          aborted = true;
+          detail = "Execution timed out";
+        } else {
+          // In-isolate timeout / OOM / disposed all land here -> test fails.
+          detail = (err instanceof Error ? err.message : String(err)).slice(
+            0,
+            200
+          );
+        }
+        passed = false;
+      }
+      results.push({
+        id: test.id,
+        hidden: test.hidden === true,
+        passed,
+        detail,
+      });
+    }
+
+    return {
+      available: true,
+      passed: results.length > 0 && results.every((r) => r.passed),
+      results,
+    };
+  } finally {
+    isolate.dispose();
+  }
+}

--- a/apps/web/src/lib/challenge/executor.ts
+++ b/apps/web/src/lib/challenge/executor.ts
@@ -82,6 +82,13 @@ interface IvmContext {
     code: string,
     opts?: { timeout?: number; promise?: boolean }
   ): Promise<unknown>;
+  /**
+   * Free this context's realm — its `global` and everything reachable from it
+   * (including any taint a previous submission applied to `globalThis.Function`,
+   * `Object.prototype`, etc.) — without disposing the whole isolate. A fresh
+   * `createContext()` then yields a clean realm.
+   */
+  release(): void;
 }
 interface IvmIsolate {
   createContext(): Promise<IvmContext>;
@@ -167,6 +174,17 @@ export async function isExecutorAvailable(): Promise<boolean> {
  */
 const ISOLATE_RUNTIME_SOURCE = String.raw`
 "use strict";
+
+/* Capture pristine intrinsics the HARNESS relies on BEFORE any user code runs.
+ * User code shares this realm's globals and could reassign \`globalThis.Function\`
+ * or \`JSON.stringify\` to force a "pass" — the harness must build the test
+ * wrapper and serialise its verdict through these private references, never the
+ * (potentially poisoned) live globals. Fresh-context-per-test isolates one
+ * submission's taint from the next; these captures additionally keep a
+ * submission from corrupting its OWN test's harness readout. */
+var __Function__ = Function;
+var __jsonStringify__ = JSON.stringify;
+var __jsonParse__ = JSON.parse;
 
 var BASE58_ALPHABET = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
 function toBase58(bytes) {
@@ -382,7 +400,9 @@ function runCase(userCode, test) {
     '})();';
 
   try {
-    var fn = new Function("__mc__", "__modules__", body);
+    // Build the wrapper from the CAPTURED Function, so a submission that
+    // reassigned globalThis.Function cannot substitute its own wrapper factory.
+    var fn = new __Function__("__mc__", "__modules__", body);
     var p = fn(mc.mock, __modules__);
     return Promise.resolve(p).then(function (result) {
       var passed = result === "pass" || result === true;
@@ -395,12 +415,15 @@ function runCase(userCode, test) {
   }
 }
 
-/* Entry point invoked by the host. Returns a JSON STRING (copied out). */
+/* Entry point invoked by the host. Returns a JSON STRING (copied out). Uses the
+ * captured JSON intrinsics so a submission that reassigned JSON.parse /
+ * JSON.stringify can neither smuggle a forged input nor forge the verdict that
+ * crosses the boundary. */
 async function __runCase__(userCodeJson, testJson) {
-  var userCode = JSON.parse(userCodeJson);
-  var test = JSON.parse(testJson);
+  var userCode = __jsonParse__(userCodeJson);
+  var test = __jsonParse__(testJson);
   var r = await runCase(userCode, test);
-  return JSON.stringify(r);
+  return __jsonStringify__(r);
 }
 `;
 
@@ -468,7 +491,19 @@ function transformImports(code: string): string {
 /* ------------------------------------------------------------------------- */
 
 /**
- * Run a JS/TS submission against every supplied test inside a fresh isolate.
+ * Run a JS/TS submission against every supplied test.
+ *
+ * ISOLATION PER TEST CASE — each test runs in a FRESH context (realm) inside the
+ * isolate: a new context is created, the runtime/harness is installed into it,
+ * the submission + that single test run, the verdict is read out, and the
+ * context is released. A submission cannot carry state from one test into
+ * another, because the test wrapper is built in-isolate with `new Function(...)`
+ * (which resolves to that realm's `globalThis.Function`) — running user code in
+ * a shared global let test #1 reassign `globalThis.Function` (or pollute
+ * `Object.prototype` / `Array.prototype` / `JSON`) and force every later test —
+ * including hidden ones — to "pass". A clean realm per test, discarded after,
+ * closes that bypass. CPU timeout, host wall-clock kill, and memory limit are
+ * unchanged.
  *
  * Contract: returns `{ available: false }` when the secure executor cannot run
  * — callers MUST deny completion in that case. When available, `passed` is true
@@ -517,16 +552,11 @@ export async function runJsSubmission(
 
   const isolate = new ivm.Isolate({ memoryLimit: MEMORY_LIMIT_MB });
   try {
-    const context = await isolate.createContext();
-    // Install the in-isolate runtime once per submission.
-    await withHostGuard(
-      context.eval(ISOLATE_RUNTIME_SOURCE, { timeout: EXEC_TIMEOUT_MS })
-    );
-
     const userCodeJson = JSON.stringify(transpiled);
     const results: ServerTestResult[] = [];
-    // Once the host guard trips we dispose the isolate; remaining tests cannot
-    // run on a dead isolate, so they are recorded as failed.
+    // The host wall-clock guard can only trip once: it abandons the in-flight
+    // evaluation and we dispose the whole isolate, so any remaining tests cannot
+    // run and are recorded as failed.
     let aborted = false;
 
     for (const test of tests) {
@@ -544,17 +574,25 @@ export async function runJsSubmission(
         input: test.input ?? "",
         expectedOutput: test.expectedOutput ?? "",
       });
-      // Call the in-isolate entry point. Both arguments are JSON string
-      // literals embedded in the eval'd expression — no host references cross
-      // the boundary; the result is a JSON string copied out.
       const expr = `__runCase__(${JSON.stringify(userCodeJson)}, ${JSON.stringify(testJson)})`;
       let detail = "execution error";
       let passed = false;
+
+      // FRESH realm per test: create a new context, install the runtime into it,
+      // run [user code + this one test], read the verdict, then release it. Any
+      // taint the submission applied to this realm's `globalThis.Function`,
+      // prototypes, etc. dies with the context and cannot reach the next test.
+      let context: IvmContext | undefined;
       try {
+        context = await isolate.createContext();
+        await withHostGuard(
+          context.eval(ISOLATE_RUNTIME_SOURCE, { timeout: EXEC_TIMEOUT_MS })
+        );
         // promise:true resolves the async __runCase__ inside the isolate and
-        // copies the resolved JSON string out. The in-isolate timeout kills
-        // CPU-bound runaways; withHostGuard catches the rare quiescent
-        // never-settling promise.
+        // copies the resolved JSON string out. Both arguments are JSON string
+        // literals embedded in the eval'd expression — no host references cross
+        // the boundary. The in-isolate timeout kills CPU-bound runaways;
+        // withHostGuard catches the rare quiescent never-settling promise.
         const raw = (await withHostGuard(
           context.eval(expr, {
             timeout: EXEC_TIMEOUT_MS,
@@ -577,7 +615,20 @@ export async function runJsSubmission(
           );
         }
         passed = false;
+      } finally {
+        // Free this test's realm. Skipped when the host guard tripped: the
+        // isolate is about to be disposed wholesale and the context may be
+        // mid-eval, so releasing it here is both unnecessary and unsafe.
+        if (context && !aborted) {
+          try {
+            context.release();
+          } catch {
+            // A context that already died (e.g. in-isolate timeout/OOM) cannot
+            // be released; nothing to clean up.
+          }
+        }
       }
+
       results.push({
         id: test.id,
         hidden: test.hidden === true,

--- a/apps/web/src/lib/challenge/validate.ts
+++ b/apps/web/src/lib/challenge/validate.ts
@@ -1,0 +1,126 @@
+/**
+ * Shared server-side challenge validation.
+ *
+ * Single source of truth used by BOTH `/api/lessons/validate-challenge` (UX
+ * pre-check) and `/api/lessons/complete` (the authoritative completion gate).
+ * Loads the answer key server-side (hidden tests + reference solution never
+ * reach the browser) and runs the submission through the secure isolate
+ * executor.
+ */
+
+import type { ChallengeAnswerKey } from "@/lib/sanity/queries";
+import {
+  isExecutorAvailable,
+  runJsSubmission,
+  type ServerTestResult,
+} from "@/lib/challenge/executor";
+
+export type ChallengeVerdict =
+  | {
+      /** Lesson is a code challenge the JS executor can judge. */
+      kind: "validated";
+      passed: boolean;
+      hiddenTestCount: number;
+      visibleTestCount: number;
+      results: ServerTestResult[];
+    }
+  | {
+      /**
+       * Lesson is a challenge, but its correctness is established elsewhere
+       * (Rust playground / build server) rather than by the JS executor. The
+       * completion gate must decide policy for these explicitly.
+       */
+      kind: "non_js_challenge";
+      language: string | null;
+      buildType: string | null;
+      hiddenTestCount: number;
+      visibleTestCount: number;
+    }
+  | {
+      /** Lesson is not a challenge — no submission proof required. */
+      kind: "not_a_challenge";
+    }
+  | {
+      /**
+       * The secure executor is unavailable in this environment. Callers MUST
+       * treat this as a non-pass and DENY completion (degrade closed).
+       */
+      kind: "executor_unavailable";
+      hiddenTestCount: number;
+      visibleTestCount: number;
+    };
+
+/** Maximum submission length accepted from the client. */
+export const MAX_SUBMISSION_BYTES = 100_000;
+
+function countTests(key: ChallengeAnswerKey): {
+  hidden: number;
+  visible: number;
+} {
+  const tests = key.tests ?? [];
+  const hidden = tests.filter((t) => t.hidden === true).length;
+  return { hidden, visible: tests.length - hidden };
+}
+
+/**
+ * A JS/TS code challenge is one we can execute and grade server-side. Rust
+ * (`language: "rust"`) and buildable challenges are compiled by the Rust
+ * playground / build server respectively and are out of scope for the JS
+ * isolate executor.
+ */
+function isJsExecutableChallenge(key: ChallengeAnswerKey): boolean {
+  if (key.type !== "challenge") return false;
+  if (key.buildType === "buildable") return false;
+  // Treat anything that isn't explicitly rust as JS/TS (matches the browser
+  // runner, which only routes language === "rust" away from the JS worker).
+  return key.language !== "rust";
+}
+
+/**
+ * Validate a submission against the answer key. Pure logic — no auth, no HTTP.
+ */
+export async function validateAgainstAnswerKey(
+  key: ChallengeAnswerKey,
+  submittedCode: string
+): Promise<ChallengeVerdict> {
+  if (key.type !== "challenge") {
+    return { kind: "not_a_challenge" };
+  }
+
+  const { hidden, visible } = countTests(key);
+
+  if (!isJsExecutableChallenge(key)) {
+    return {
+      kind: "non_js_challenge",
+      language: key.language,
+      buildType: key.buildType,
+      hiddenTestCount: hidden,
+      visibleTestCount: visible,
+    };
+  }
+
+  if (!(await isExecutorAvailable())) {
+    return {
+      kind: "executor_unavailable",
+      hiddenTestCount: hidden,
+      visibleTestCount: visible,
+    };
+  }
+
+  const run = await runJsSubmission(submittedCode, key.tests ?? []);
+  if (!run.available) {
+    return {
+      kind: "executor_unavailable",
+      hiddenTestCount: hidden,
+      visibleTestCount: visible,
+    };
+  }
+
+  return {
+    kind: "validated",
+    passed: run.passed,
+    hiddenTestCount: hidden,
+    visibleTestCount: visible,
+    results: run.results,
+  };
+}

--- a/apps/web/src/lib/sanity/queries.ts
+++ b/apps/web/src/lib/sanity/queries.ts
@@ -130,36 +130,56 @@ export async function getLessonBySlug(
  * its result into a client response. Used by /api/lessons/validate-challenge to
  * check submissions against hidden tests without shipping them to the browser.
  */
-export async function getChallengeAnswerKey(
-  courseSlug: string,
-  lessonSlug: string
-): Promise<{
+/** Shape of a challenge answer key (server-only). */
+export interface ChallengeAnswerKey {
   _id: string;
   type: string;
   language: string | null;
+  /** "buildable" challenges compile Rust via the build server, not the JS executor. */
+  buildType: string | null;
   tests: AdminTestCase[];
   solution: string | null;
-} | null> {
+}
+
+const answerKeyProjection = `{
+  _id,
+  "slug": slug.current,
+  type,
+  language,
+  buildType,
+  "tests": tests[]{ id, description, input, expectedOutput, hidden },
+  solution
+}`;
+
+export async function getChallengeAnswerKey(
+  courseSlug: string,
+  lessonSlug: string
+): Promise<ChallengeAnswerKey | null> {
   // revalidate=0: always read fresh, never via the public Sanity CDN, so the
   // answer key is not cached on any edge.
-  return sanityFetch<{
-    _id: string;
-    type: string;
-    language: string | null;
-    tests: AdminTestCase[];
-    solution: string | null;
-  } | null>(
+  return sanityFetch<ChallengeAnswerKey | null>(
     `*[_type == "course" && slug.current == $courseSlug && onChainStatus.status == "synced"][0] {
-      "allLessons": modules[]->lessons[]->{
-        _id,
-        "slug": slug.current,
-        type,
-        language,
-        "tests": tests[]{ id, description, input, expectedOutput, hidden },
-        solution
-      }
+      "allLessons": modules[]->lessons[]->${answerKeyProjection}
     }.allLessons[slug == $lessonSlug][0]`,
     { courseSlug, lessonSlug },
+    0
+  );
+}
+
+/**
+ * Same answer key as {@link getChallengeAnswerKey}, but looked up by the Sanity
+ * `_id` of the course and lesson (the identifiers `/api/lessons/complete` uses).
+ * SERVER-ONLY — never serialize into a client response.
+ */
+export async function getChallengeAnswerKeyById(
+  courseId: string,
+  lessonId: string
+): Promise<ChallengeAnswerKey | null> {
+  return sanityFetch<ChallengeAnswerKey | null>(
+    `*[_type == "course" && _id == $courseId && onChainStatus.status == "synced"][0] {
+      "allLessons": modules[]->lessons[]->${answerKeyProjection}
+    }.allLessons[_id == $lessonId][0]`,
+    { courseId, lessonId },
     0
   );
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -143,6 +143,9 @@ importers:
       clsx:
         specifier: ^2.1.0
         version: 2.1.1
+      isolated-vm:
+        specifier: 6.1.2
+        version: 6.1.2
       isomorphic-dompurify:
         specifier: 2.36.0
         version: 2.36.0(@noble/hashes@1.8.0)
@@ -6420,6 +6423,10 @@ packages:
   isobject@3.0.1:
     resolution: {integrity: sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==}
     engines: {node: '>=0.10.0'}
+
+  isolated-vm@6.1.2:
+    resolution: {integrity: sha512-GGfsHqtlZiiurZaxB/3kY7LLAXR3sgzDul0fom4cSyBjx6ZbjpTrFWiH3z/nUfLJGJ8PIq9LQmQFiAxu24+I7A==}
+    engines: {node: '>=22.0.0'}
 
   isomorphic-dompurify@2.36.0:
     resolution: {integrity: sha512-E8YkGyPY3a/U5s0WOoc8Ok+3SWL/33yn2IHCoxCFLBUUPVy9WGa++akJZFxQCcJIhI+UvYhbrbnTIFQkHKZbgA==}
@@ -16797,6 +16804,10 @@ snapshots:
 
   isobject@3.0.1: {}
 
+  isolated-vm@6.1.2:
+    dependencies:
+      node-gyp-build: 4.8.4
+
   isomorphic-dompurify@2.36.0(@noble/hashes@1.8.0):
     dependencies:
       dompurify: 3.3.1
@@ -18026,8 +18037,7 @@ snapshots:
     dependencies:
       whatwg-url: 5.0.0
 
-  node-gyp-build@4.8.4:
-    optional: true
+  node-gyp-build@4.8.4: {}
 
   node-html-parser@6.1.13:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -143,9 +143,6 @@ importers:
       clsx:
         specifier: ^2.1.0
         version: 2.1.1
-      isolated-vm:
-        specifier: 6.1.2
-        version: 6.1.2
       isomorphic-dompurify:
         specifier: 2.36.0
         version: 2.36.0(@noble/hashes@1.8.0)
@@ -206,6 +203,10 @@ importers:
       zod:
         specifier: ^4.4.3
         version: 4.4.3
+    optionalDependencies:
+      isolated-vm:
+        specifier: 6.1.2
+        version: 6.1.2
     devDependencies:
       '@tailwindcss/typography':
         specifier: ^0.5.19
@@ -16807,6 +16808,7 @@ snapshots:
   isolated-vm@6.1.2:
     dependencies:
       node-gyp-build: 4.8.4
+    optional: true
 
   isomorphic-dompurify@2.36.0(@noble/hashes@1.8.0):
     dependencies:
@@ -18037,7 +18039,8 @@ snapshots:
     dependencies:
       whatwg-url: 5.0.0
 
-  node-gyp-build@4.8.4: {}
+  node-gyp-build@4.8.4:
+    optional: true
 
   node-html-parser@6.1.13:
     dependencies:


### PR DESCRIPTION
Closes #181

## The gap

PR #179 added `POST /api/lessons/validate-challenge` but nothing called it (`serverValidated` was hard-coded `false`), and `/api/lessons/complete` accepted a completion for any lesson — including an unattempted challenge — with **no proof of solving**. A forged browser "passed" earned a real completion record (and credential eligibility). The hidden tests + reference solution are server-held (`getChallengeAnswerKey`), but were never used to actually grade anything.

## What this does

Challenge-type lessons now require a **passing server-side validation** before `/api/lessons/complete` submits the on-chain `completeLesson`. The browser runner stays for UX (visible tests), but **the server is authoritative**.

### 1. Secure executor for untrusted JS — `src/lib/challenge/executor.ts`

Untrusted learner JS runs inside a **real V8 isolate** via [`isolated-vm`](https://github.com/laverdet/isolated-vm) — **not** Node `vm` / `eval` / `new Function` (those share the host realm and are not isolation boundaries). Guarantees, all enforced by V8 itself, not by string filtering:

- **Separate heap, hard memory limit** (64 MB) — allocation past the cap terminates the script; host memory can't be exhausted.
- **In-isolate wall-clock timeout** (5 s) — kills CPU-bound runaways (`while(true){}`).
- **Host-side wall-clock guard** (6 s) + `isolate.dispose()` — defense-in-depth for the one case the CPU timeout can't catch: a *quiescent* never-settling promise (`await new Promise(()=>{})`). There are no timers/event-loop primitives in the isolate (`setTimeout` is `undefined`), so such a promise never settles; the host guard abandons the eval and tears down the isolate.
- **No ambient host objects** — `process`, `require`, `module`, Node `globalThis`, filesystem, and network simply don't exist in the isolate. Verified by tests (`typeof process === 'undefined'`, `typeof require === 'undefined'` inside the sandbox). We never bridge a host function/object in (no `Reference`).
- **Only two values cross the boundary**: a code **string** goes in; a JSON-serialisable **string** result is copied out. The mock Solana SDK + mock console live entirely inside the isolate, assembled from source text — a faithful server port of the existing browser-worker contract in `components/editor/challenge-runner.tsx`, so a submission is judged the same way it is in-browser, except the **server also runs the hidden tests**.
- **Degrade-closed**: `isolated-vm` is a native addon; if it can't load, the executor reports `available: false` and the completion gate **denies** the completion (503). A forged pass can never slip through an unavailable executor.

### 2. Shared validation — `src/lib/challenge/validate.ts`

Single source of truth used by **both** routes (no duplicated logic). Loads the answer key server-side, runs the submission through the executor, returns a typed verdict: `validated{passed}` / `non_js_challenge` / `not_a_challenge` / `executor_unavailable`.

### 3. Wiring

- **`validate-challenge` route** now runs a REAL check; `serverValidated` reflects actual execution against all tests. Answer key / hidden tests / solution are never serialised into the response (P0-C4 preserved).
- **`complete` route** — for challenge lessons: requires `submittedCode`, runs `validateAgainstAnswerKey`, and **rejects with 403 if not all tests pass — before** the on-chain `completeLesson`. `executor_unavailable` → 503 (degrade closed). Non-challenge lessons are unaffected (no answer key → gate skipped).
- **Client** threads the editor's code through the `superteam:lesson-complete` event → `completeLessonAPI` → request body.
- `getChallengeAnswerKeyById` added (the complete route works in Sanity `_id`s); answer-key projection extended with `buildType`.
- `isolated-vm` added to `serverComponentsExternalPackages` so webpack keeps the native addon external (build output confirms it's emitted as `import("isolated-vm")`, not bundled).

## Test — `src/lib/challenge/__tests__/executor.test.ts` (13 tests, run the REAL isolate)

Proves the boundary:
- Correct submission **passes** all tests (visible + hidden actually executed).
- **WRONG and EMPTY** submissions are **rejected**.
- **Forged-pass is blocked**: code that hard-codes the visible answer (`if (a===2 && b===3) return 5`) passes the visible test but **fails the hidden test → overall not passed**. This is exactly the "all green in the browser" shape; the server runs the hidden test and rejects. `validateAgainstAnswerKey` returns `passed:false`, so the complete route would 403.
- Runaway `while(true)` killed by the in-isolate timeout; never-settling promise abandoned by the host guard (neither hangs).
- Host escapes denied: `process` / `require` unreachable inside the isolate.

All 41 web tests pass (`pnpm --filter @superteam-lms/web test`).

## Verify

- `pnpm --filter @superteam-lms/web typecheck`: **my code is clean.** The only errors are 55 pre-existing `sanity/schemas/*` errors that are also present on a clean `main` (unrelated to this PR).
- `pnpm --filter @superteam-lms/web build`: **`✓ Compiled successfully`**, and the build output confirms `isolated-vm` stays external and the executor logic is bundled into both lesson routes. The build then fails at **page-data collection** because this sandbox has no real `NEXT_PUBLIC_*` / on-chain secret env vars (`Invalid public environment variables`, then `/api/admin/*` keypair envs) — a pre-existing env gate identical on clean `main`, not introduced here.

## ⚠️ Honest limitation — read before merging

**Is the sandbox genuinely escape-resistant?** The *isolation model* is real: `isolated-vm` is a true V8 isolate, and the tests demonstrate no host-object access, enforced memory/CPU/wall-clock limits, and the forged-pass being blocked. That is a real security boundary, not a `vm`/`Function` shim.

**But there is a deployment caveat that must not be glossed over:**

1. **Native-module / Node-version coupling.** `isolated-vm` is a native addon and is tightly bound to the Node/V8 ABI. In this environment (**Node 24**), `isolated-vm@5` (which declares Node 18+) **fails to compile**, and `isolated-vm@7` requires **Node ≥26**. I pinned **`isolated-vm@6.1.2`** (Node ≥22), which builds and runs cleanly here — but the repo's `package.json` engines say `node >=18`. **Whoever deploys must ensure the runtime Node version matches a buildable `isolated-vm` and that the prebuilt/compiled binary is present.** On a platform where it can't load, the executor degrades closed (completion is denied) — safe, but challenge completion is then **blocked** rather than insecure.

2. **Vercel serverless** (the documented frontend target) **generally cannot run native addons like `isolated-vm`** in the standard Node functions runtime. On that platform this executor will report `available:false` and **deny all JS-challenge completions** until it's relocated.

**Recommended production architecture:** move untrusted execution into a **dedicated sandboxed microservice** — mirroring the existing **Rust build-server** (Docker-per-execution on Cloud Run) that this repo already uses for the other untrusted-execution path. The code is structured for exactly that swap: `runJsSubmission` is a clean async interface behind `validateAgainstAnswerKey`; pointing it at an HTTP sandbox service (like `lib/rust/execute.ts` → `/api/rust/execute`) requires no route-logic changes. **I would not call the in-process executor production-secure on serverless as-is** — the isolation is sound, but the deployment surface needs the microservice.

3. **Scope:** only **JS/TS** challenges are gated by this executor. **Rust** and **buildable** challenges (`non_js_challenge`) are validated by the Rust playground / build server (a separate trust boundary) and are explicitly out of scope here — the gate requires a submission for them but defers correctness to those services.
