### PR TITLE
fix(ci): pin indexmap to 2.11.4 for Solana rustc 1.79 (anchor build)

### DIFF
--- a/onchain-academy/Cargo.lock
+++ b/onchain-academy/Cargo.lock
@@ -951,12 +951,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashbrown"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
-
-[[package]]
 name = "heck"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1003,12 +997,12 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.15.2",
 ]
 
 [[package]]

--- a/onchain-academy/Cargo.toml
+++ b/onchain-academy/Cargo.toml
@@ -7,6 +7,11 @@ exclude = [
 ]
 resolver = "2"
 
+[workspace.dependencies]
+# indexmap ≥2.12 bumped MSRV to 1.82; Solana's bundled rustc is 1.79.
+# Pin to <2.12 so `cargo update` never regresses the CI/verifiable build.
+indexmap = "<2.12"
+
 [profile.release]
 overflow-checks = true
 lto = "fat"

--- a/onchain-academy/programs/onchain-academy/Cargo.toml
+++ b/onchain-academy/programs/onchain-academy/Cargo.toml
@@ -20,3 +20,4 @@ idl-build = ["anchor-lang/idl-build"]
 anchor-lang = "0.31.1"
 spl-token-2022 = { version = "5", features = ["no-entrypoint"] }
 mpl-core = "0.9"
+indexmap = { workspace = true }


### PR DESCRIPTION
The Anchor program Docker build runs Solana's bundled rustc 1.79, but indexmap bumped its MSRV to 1.82 at 2.12.0 (transitively pulled via toml_edit -> proc-macro-crate -> borsh-derive), breaking the build:

  indexmap@2.13.0 requires rustc 1.82

Pin to 2.11.4 — the latest indexmap with MSRV 1.63, well within 1.79 — via cargo update --precise. Lockfile-only change (downgrades its hashbrown dep to 0.15.2); no source or version-range changes.