### PR TITLE
feat(onchain): authority-gated close_course to free a Course PDA (Course-resize migration)

### DIFF
--- a/apps/web/src/lib/solana/idl/superteam_academy.json
+++ b/apps/web/src/lib/solana/idl/superteam_academy.json
@@ -135,6 +135,56 @@
       "args": []
     },
     {
+      "name": "close_course",
+      "discriminator": [157, 252, 239, 166, 213, 174, 160, 34],
+      "accounts": [
+        {
+          "name": "config",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [99, 111, 110, 102, 105, 103]
+              }
+            ]
+          }
+        },
+        {
+          "name": "course",
+          "docs": [
+            "for `course_id`) and `owner = crate::ID` (program-owned). Loaded as",
+            "`UncheckedAccount` rather than `Account<Course>` so a stale, size-mismatched",
+            "(pre-resize, 192-byte) account can still be closed. The handler also",
+            "verifies the `Course` discriminator before draining/freeing it."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [99, 111, 117, 114, 115, 101]
+              },
+              {
+                "kind": "arg",
+                "path": "course_id"
+              }
+            ]
+          }
+        },
+        {
+          "name": "authority",
+          "signer": true,
+          "relations": ["config"]
+        }
+      ],
+      "args": [
+        {
+          "name": "course_id",
+          "type": "string"
+        }
+      ]
+    },
+    {
       "name": "close_enrollment",
       "discriminator": [236, 137, 133, 253, 91, 138, 217, 91],
       "accounts": [
@@ -1114,6 +1164,10 @@
       "discriminator": [40, 241, 230, 122, 11, 19, 198, 194]
     },
     {
+      "name": "CourseClosed",
+      "discriminator": [35, 195, 37, 254, 25, 107, 100, 12]
+    },
+    {
       "name": "CourseCreated",
       "discriminator": [205, 144, 55, 47, 150, 170, 123, 214]
     },
@@ -1308,6 +1362,11 @@
       "code": 6029,
       "name": "EnrollmentFinalized",
       "msg": "Finalized or credentialed enrollment cannot be closed"
+    },
+    {
+      "code": 6030,
+      "name": "InvalidCourseAccount",
+      "msg": "Account is not a valid Course PDA"
     }
   ],
   "types": [
@@ -1622,6 +1681,26 @@
           {
             "name": "bump",
             "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "CourseClosed",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "course",
+            "type": "pubkey"
+          },
+          {
+            "name": "course_id",
+            "type": "string"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
           }
         ]
       }

--- a/apps/web/src/lib/solana/program-errors.ts
+++ b/apps/web/src/lib/solana/program-errors.ts
@@ -170,6 +170,11 @@ const ERROR_MAP: Record<number, ProgramErrorEntry> = {
     fallback:
       "This enrollment is finalized and can no longer be unenrolled or closed.",
   },
+  6030: {
+    name: "InvalidCourseAccount",
+    i18nKey: "invalidCourseAccount",
+    fallback: "Account is not a valid course.",
+  },
 };
 
 // Reverse lookup: error name → entry

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -595,6 +595,7 @@
     "invalidAmount": "Amount must be greater than zero.",
     "invalidXpReward": "XP reward must be greater than zero.",
     "enrollmentFinalized": "This enrollment is finalized and can no longer be unenrolled or closed.",
+    "invalidCourseAccount": "Account is not a valid course.",
     "unknown": "Transaction failed. Please try again."
   },
   "community": {

--- a/apps/web/src/messages/es.json
+++ b/apps/web/src/messages/es.json
@@ -595,6 +595,7 @@
     "invalidAmount": "La cantidad debe ser mayor que cero.",
     "invalidXpReward": "La recompensa de XP debe ser mayor que cero.",
     "enrollmentFinalized": "Esta inscripción está finalizada y ya no se puede cancelar ni cerrar.",
+    "invalidCourseAccount": "La cuenta no es un curso válido.",
     "unknown": "La transacción falló. Inténtalo de nuevo."
   },
   "community": {

--- a/apps/web/src/messages/pt-BR.json
+++ b/apps/web/src/messages/pt-BR.json
@@ -595,6 +595,7 @@
     "invalidAmount": "A quantidade deve ser maior que zero.",
     "invalidXpReward": "A recompensa de XP deve ser maior que zero.",
     "enrollmentFinalized": "Esta inscrição foi finalizada e não pode mais ser cancelada ou encerrada.",
+    "invalidCourseAccount": "A conta não é um curso válido.",
     "unknown": "Transação falhou. Tente novamente."
   },
   "community": {

--- a/onchain-academy/programs/onchain-academy/src/errors.rs
+++ b/onchain-academy/programs/onchain-academy/src/errors.rs
@@ -62,4 +62,6 @@ pub enum AcademyError {
     InvalidXpReward,
     #[msg("Finalized or credentialed enrollment cannot be closed")]
     EnrollmentFinalized,
+    #[msg("Account is not a valid Course PDA")]
+    InvalidCourseAccount,
 }

--- a/onchain-academy/programs/onchain-academy/src/events.rs
+++ b/onchain-academy/programs/onchain-academy/src/events.rs
@@ -129,3 +129,10 @@ pub struct AchievementTypeDeactivated {
     pub achievement_id: String,
     pub timestamp: i64,
 }
+
+#[event]
+pub struct CourseClosed {
+    pub course: Pubkey,
+    pub course_id: String,
+    pub timestamp: i64,
+}

--- a/onchain-academy/programs/onchain-academy/src/instructions/close_course.rs
+++ b/onchain-academy/programs/onchain-academy/src/instructions/close_course.rs
@@ -1,0 +1,92 @@
+use anchor_lang::prelude::*;
+use anchor_lang::system_program;
+use anchor_lang::Discriminator;
+
+use crate::errors::AcademyError;
+use crate::events::CourseClosed;
+use crate::state::{Config, Course};
+
+/// Authority-gated close of a `Course` PDA.
+///
+/// Migration tool: #184 resized `Course` (192 -> 224) with no migration path, so
+/// pre-resize 192-byte accounts can no longer be loaded as `Account<Course>`.
+/// This instruction takes the course as an `UncheckedAccount` so it can touch a
+/// stale / size-mismatched account, validates it is the genuine Course PDA owned
+/// by this program, then manually drains its lamports to the authority and frees
+/// the PDA so `create_course` can recreate it (at the new size) in a later tx.
+///
+/// Enrollments are separate PDAs keyed by `course_id` and are untouched here.
+pub fn handler(ctx: Context<CloseCourse>, course_id: String) -> Result<()> {
+    let course_ai = ctx.accounts.course.to_account_info();
+
+    // Defensive: ensure this is a genuine Course PDA, not some other
+    // program-owned account whose address happens to collide with the seeds.
+    // The discriminator is derived from the account name and is stable across
+    // the 192 -> 224 resize, so this check holds for the stale accounts too.
+    {
+        let data = course_ai.try_borrow_data()?;
+        require!(
+            data.len() >= Course::DISCRIMINATOR.len(),
+            AcademyError::InvalidCourseAccount
+        );
+        require!(
+            data[..Course::DISCRIMINATOR.len()] == *Course::DISCRIMINATOR,
+            AcademyError::InvalidCourseAccount
+        );
+    }
+
+    let course_key = course_ai.key();
+    let now = Clock::get()?.unix_timestamp;
+
+    // Drain all lamports to the authority with checked math.
+    let authority_ai = ctx.accounts.authority.to_account_info();
+    let course_lamports = course_ai.lamports();
+
+    let new_authority_lamports = authority_ai
+        .lamports()
+        .checked_add(course_lamports)
+        .ok_or(AcademyError::Overflow)?;
+
+    **authority_ai.try_borrow_mut_lamports()? = new_authority_lamports;
+    **course_ai.try_borrow_mut_lamports()? = 0;
+
+    // Free the PDA: zero the data and hand ownership back to the System Program
+    // so the address is a plain (empty, 0-lamport) system account that
+    // `create_course` / Anchor `init` can re-create in a later transaction.
+    course_ai.realloc(0, false)?;
+    course_ai.assign(&system_program::ID);
+
+    emit!(CourseClosed {
+        course: course_key,
+        course_id,
+        timestamp: now,
+    });
+
+    Ok(())
+}
+
+#[derive(Accounts)]
+#[instruction(course_id: String)]
+pub struct CloseCourse<'info> {
+    #[account(
+        seeds = [b"config"],
+        bump = config.bump,
+        has_one = authority @ AcademyError::Unauthorized,
+    )]
+    pub config: Account<'info, Config>,
+
+    /// CHECK: Validated by the PDA `seeds`/`bump` constraint (correct Course PDA
+    /// for `course_id`) and `owner = crate::ID` (program-owned). Loaded as
+    /// `UncheckedAccount` rather than `Account<Course>` so a stale, size-mismatched
+    /// (pre-resize, 192-byte) account can still be closed. The handler also
+    /// verifies the `Course` discriminator before draining/freeing it.
+    #[account(
+        mut,
+        seeds = [b"course", course_id.as_bytes()],
+        bump,
+        owner = crate::ID @ AcademyError::InvalidCourseAccount,
+    )]
+    pub course: UncheckedAccount<'info>,
+
+    pub authority: Signer<'info>,
+}

--- a/onchain-academy/programs/onchain-academy/src/instructions/mod.rs
+++ b/onchain-academy/programs/onchain-academy/src/instructions/mod.rs
@@ -1,4 +1,5 @@
 pub mod award_achievement;
+pub mod close_course;
 pub mod close_enrollment;
 pub mod complete_lesson;
 pub mod create_achievement_type;
@@ -16,6 +17,7 @@ pub mod update_course;
 pub mod upgrade_credential;
 
 pub use award_achievement::*;
+pub use close_course::*;
 pub use close_enrollment::*;
 pub use complete_lesson::*;
 pub use create_achievement_type::*;

--- a/onchain-academy/programs/onchain-academy/src/lib.rs
+++ b/onchain-academy/programs/onchain-academy/src/lib.rs
@@ -33,6 +33,10 @@ pub mod onchain_academy {
         instructions::update_course::handler(ctx, params)
     }
 
+    pub fn close_course(ctx: Context<CloseCourse>, course_id: String) -> Result<()> {
+        instructions::close_course::handler(ctx, course_id)
+    }
+
     pub fn enroll<'info>(
         ctx: Context<'_, '_, 'info, 'info, Enroll<'info>>,
         course_id: String,

--- a/onchain-academy/tests/onchain-academy.ts
+++ b/onchain-academy/tests/onchain-academy.ts
@@ -4457,4 +4457,240 @@ describe("onchain-academy", () => {
       expect(roleFinal.isActive).to.equal(false);
     });
   });
+
+  // ===========================================================================
+  // 20. Close Course (Course-resize migration)
+  // ===========================================================================
+  describe("20. Close Course (migration)", () => {
+    // Isolated course id so we never touch the shared "solana-101" state.
+    const migCourseId = "close-course-mig";
+    let migCoursePda: PublicKey;
+    let migCourseBump: number;
+
+    const migLearner = Keypair.generate();
+    let migEnrollmentPda: PublicKey;
+
+    const migContentTxId = new Array(32).fill(7);
+
+    before(async () => {
+      [migCoursePda, migCourseBump] = PublicKey.findProgramAddressSync(
+        [Buffer.from("course"), Buffer.from(migCourseId)],
+        program.programId
+      );
+      [migEnrollmentPda] = PublicKey.findProgramAddressSync(
+        [
+          Buffer.from("enrollment"),
+          Buffer.from(migCourseId),
+          migLearner.publicKey.toBuffer(),
+        ],
+        program.programId
+      );
+
+      const sig = await provider.connection.requestAirdrop(
+        migLearner.publicKey,
+        2 * LAMPORTS_PER_SOL
+      );
+      await provider.connection.confirmTransaction(sig, "confirmed");
+
+      // Create the course to be closed.
+      await program.methods
+        .createCourse({
+          courseId: migCourseId,
+          creator: creator.publicKey,
+          contentTxId: migContentTxId,
+          lessonCount: 2,
+          difficulty: 1,
+          xpPerLesson: 10,
+          trackId: 9,
+          trackLevel: 1,
+          prerequisite: null,
+          creatorRewardXp: 0,
+          minCompletionsForReward: 0,
+          collection: null,
+        })
+        .accountsPartial({
+          course: migCoursePda,
+          config: configPda,
+          authority: authority.publicKey,
+          systemProgram: SystemProgram.programId,
+        })
+        .rpc();
+
+      // Enroll a learner so we can prove enrollments survive the close.
+      await program.methods
+        .enroll(migCourseId)
+        .accountsPartial({
+          course: migCoursePda,
+          enrollment: migEnrollmentPda,
+          learner: migLearner.publicKey,
+          systemProgram: SystemProgram.programId,
+        })
+        .signers([migLearner])
+        .rpc();
+
+      const enrollment =
+        await program.account.enrollment.fetch(migEnrollmentPda);
+      expect(enrollment.course.toBase58()).to.equal(migCoursePda.toBase58());
+    });
+
+    it("rejects a non-authority signer with Unauthorized", async () => {
+      const imposter = Keypair.generate();
+      const airdropSig = await provider.connection.requestAirdrop(
+        imposter.publicKey,
+        LAMPORTS_PER_SOL
+      );
+      await provider.connection.confirmTransaction(airdropSig, "confirmed");
+
+      try {
+        await program.methods
+          .closeCourse(migCourseId)
+          .accountsPartial({
+            config: configPda,
+            course: migCoursePda,
+            authority: imposter.publicKey,
+          })
+          .signers([imposter])
+          .rpc();
+        expect.fail("Should have thrown");
+      } catch (err) {
+        if (err instanceof AnchorError) {
+          expect(err.error.errorCode.code).to.equal("Unauthorized");
+        } else {
+          expect(err.toString()).to.contain("Unauthorized");
+        }
+      }
+
+      // Course must still be intact after the failed attempt.
+      const stillThere = await program.account.course.fetch(migCoursePda);
+      expect(stillThere.courseId).to.equal(migCourseId);
+    });
+
+    it("rejects an account that is not the course PDA for the given id", async () => {
+      // Passing the config PDA as `course` while the course_id derives a
+      // different PDA → the seeds/bump constraint must reject it.
+      try {
+        await program.methods
+          .closeCourse(migCourseId)
+          .accountsPartial({
+            config: configPda,
+            course: configPda,
+            authority: authority.publicKey,
+          })
+          .rpc();
+        expect.fail("Should have thrown");
+      } catch (err) {
+        if (err instanceof AnchorError) {
+          expect(err.error.errorCode.code).to.equal("ConstraintSeeds");
+        } else {
+          expect(err.toString()).to.contain("Error");
+        }
+      }
+
+      // Both the config and the course must be untouched.
+      const cfg = await program.account.config.fetch(configPda);
+      expect(cfg.bump).to.equal(configBump);
+      const stillThere = await program.account.course.fetch(migCoursePda);
+      expect(stillThere.courseId).to.equal(migCourseId);
+    });
+
+    it("rejects a course_id whose PDA is not an existing program account", async () => {
+      // A never-created course id derives a system-owned (non-program) PDA.
+      // The `owner = crate::ID` constraint must reject it.
+      const ghostId = "ghost-course-xyz";
+      const [ghostPda] = PublicKey.findProgramAddressSync(
+        [Buffer.from("course"), Buffer.from(ghostId)],
+        program.programId
+      );
+
+      try {
+        await program.methods
+          .closeCourse(ghostId)
+          .accountsPartial({
+            config: configPda,
+            course: ghostPda,
+            authority: authority.publicKey,
+          })
+          .rpc();
+        expect.fail("Should have thrown");
+      } catch (err) {
+        // AccountOwnedByWrongProgram / ConstraintOwner depending on state.
+        expect(err.toString()).to.match(
+          /owner|Owner|not owned|AccountNotInitialized|InvalidCourseAccount/
+        );
+      }
+    });
+
+    it("authority closes the course → PDA is freed (0 lamports, gone)", async () => {
+      const authBefore = await provider.connection.getBalance(
+        authority.publicKey
+      );
+      const courseInfoBefore =
+        await provider.connection.getAccountInfo(migCoursePda);
+      expect(courseInfoBefore).to.not.be.null;
+      const courseRent = courseInfoBefore!.lamports;
+      expect(courseRent).to.be.greaterThan(0);
+
+      await program.methods
+        .closeCourse(migCourseId)
+        .accountsPartial({
+          config: configPda,
+          course: migCoursePda,
+          authority: authority.publicKey,
+        })
+        .rpc();
+
+      // The PDA is fully freed: no account at the address anymore.
+      const courseInfoAfter =
+        await provider.connection.getAccountInfo(migCoursePda);
+      expect(courseInfoAfter).to.be.null;
+
+      // Rent returned to the authority (minus tx fee, so just assert it grew
+      // by roughly the rent — allow for the 5000-lamport signature fee).
+      const authAfter = await provider.connection.getBalance(
+        authority.publicKey
+      );
+      expect(authAfter).to.be.greaterThan(authBefore + courseRent - 100_000);
+    });
+
+    it("enrollment for the closed course still exists", async () => {
+      const enrollment =
+        await program.account.enrollment.fetch(migEnrollmentPda);
+      expect(enrollment.course.toBase58()).to.equal(migCoursePda.toBase58());
+    });
+
+    it("create_course succeeds again at the same course_id after close", async () => {
+      await program.methods
+        .createCourse({
+          courseId: migCourseId,
+          creator: creator.publicKey,
+          contentTxId: migContentTxId,
+          lessonCount: 5,
+          difficulty: 3,
+          xpPerLesson: 25,
+          trackId: 9,
+          trackLevel: 2,
+          prerequisite: null,
+          creatorRewardXp: 0,
+          minCompletionsForReward: 0,
+          collection: null,
+        })
+        .accountsPartial({
+          course: migCoursePda,
+          config: configPda,
+          authority: authority.publicKey,
+          systemProgram: SystemProgram.programId,
+        })
+        .rpc();
+
+      const recreated = await program.account.course.fetch(migCoursePda);
+      expect(recreated.courseId).to.equal(migCourseId);
+      // Fresh account: version resets to 1, new field values applied.
+      expect(recreated.version).to.equal(1);
+      expect(recreated.lessonCount).to.equal(5);
+      expect(recreated.difficulty).to.equal(3);
+      expect(recreated.trackLevel).to.equal(2);
+      expect(recreated.totalEnrollments).to.equal(0);
+      expect(recreated.bump).to.equal(migCourseBump);
+    });
+  });
 });

--- a/onchain-academy/tests/rust/src/lib.rs
+++ b/onchain-academy/tests/rust/src/lib.rs
@@ -5,6 +5,8 @@ mod test_completion;
 #[cfg(test)]
 mod test_course;
 #[cfg(test)]
+mod test_close_course;
+#[cfg(test)]
 mod test_enrollment;
 #[cfg(test)]
 mod test_initialize;

--- a/onchain-academy/tests/rust/src/test_close_course.rs
+++ b/onchain-academy/tests/rust/src/test_close_course.rs
@@ -1,0 +1,41 @@
+use crate::helpers::*;
+use anchor_lang::solana_program::hash::hash;
+use anchor_lang::Discriminator;
+use onchain_academy::state::Course;
+use solana_sdk::pubkey::Pubkey;
+
+#[test]
+fn course_discriminator_is_eight_bytes() {
+    // close_course reads the first 8 bytes of a stale (pre-resize) account and
+    // compares them to this constant, so it must be exactly 8 bytes.
+    assert_eq!(Course::DISCRIMINATOR.len(), 8);
+}
+
+#[test]
+fn course_discriminator_matches_account_name_hash() {
+    // The discriminator is sha256("account:Course")[..8] — derived from the
+    // account name, not the byte layout. It is therefore identical for the
+    // legacy 192-byte account and the resized account, which is the invariant
+    // the defensive discriminator check in close_course relies on.
+    let h = hash(b"account:Course");
+    assert_eq!(Course::DISCRIMINATOR, &h.to_bytes()[..8]);
+}
+
+#[test]
+fn close_course_uses_same_pda_seeds_as_create() {
+    // The close instruction must target the identical PDA that create_course
+    // allocated for a given course_id; otherwise stale accounts can't be freed.
+    let course_id = "close-course-mig";
+    let (pda, bump) = course_pda(course_id);
+    let derived =
+        Pubkey::create_program_address(&[b"course", course_id.as_bytes(), &[bump]], &PROGRAM_ID);
+    assert!(derived.is_ok());
+    assert_eq!(derived.unwrap(), pda);
+}
+
+#[test]
+fn different_course_ids_close_distinct_pdas() {
+    let (a, _) = course_pda("course-a");
+    let (b, _) = course_pda("course-b");
+    assert_ne!(a, b);
+}


### PR DESCRIPTION
Closes #200

## Why
#184 resized `Course` (192 → 224, adding `collection`) with **no migration path**. The 6 live 192-byte `Course` accounts on devnet become undeserializable as `Account<Course>` the moment the resized program deploys, and there is no on-chain way to free or recreate those PDAs. This adds an authority-gated `close_course` so the deploy sequence becomes safe: **deploy → `close_course` the 6 → re-sync recreates them at 224** via `create_course` (in a later tx). Enrollments are separate PDAs keyed by `course_id` and survive the close+recreate.

## Design
- **Authority-gated.** Mirrors `update_config`/`update_course`: `config: Account<Config>` (seeds `[b"config"]`, `bump = config.bump`) with `has_one = authority @ Unauthorized`, plus an `authority: Signer`. Only `Config.authority` can close.
- **Course as `UncheckedAccount`** (not `Account<Course>`) so a stale, size-mismatched 192-byte account still loads. It is constrained to the derived PDA `seeds = [b"course", course_id.as_bytes()], bump`, **required `owner = crate::ID`** (program-owned), and the handler additionally checks the first 8 bytes equal `Course::DISCRIMINATOR` before touching it.
- **No enrollment guard** — this is an admin migration/close tool.

## Close mechanism (the sensitive part)
Anchor's `close =` won't run on a stale `UncheckedAccount`, so the close is manual:
1. Defensive discriminator check (`Course::DISCRIMINATOR`, 8 bytes). The discriminator is derived from the account *name*, so it is identical for the legacy 192-byte and resized 224-byte layouts — the check holds for stale accounts.
2. Drain lamports to the authority with **checked math** (`checked_add` → `Overflow`), then zero the course's lamports.
3. `course.realloc(0, false)?` then `course.assign(&system_program::ID)` — the PDA becomes a plain, empty, 0-lamport system account that `create_course` / Anchor `init` can re-create later.

No `unwrap`/`expect`; all arithmetic checked; `CourseClosed { course, course_id, timestamp }` emitted.

## Security constraints (summary for review)
- Authorization: `has_one = authority` against `Config.authority` (signer required).
- Account identity: PDA `seeds`/`bump` bind the account to `course_id`; `owner = crate::ID` rejects non-program accounts; discriminator check rejects program-owned non-`Course` accounts.
- Lamport move uses `checked_add`; `realloc(0)` + `assign(system_program)` fully frees the PDA (re-creatable).

## Errors / IDL / frontend
- New error `InvalidCourseAccount` (code **6030**) for the owner/discriminator checks (`Unauthorized` is reused for the authority gate). `program-errors.ts` + all three locale files (en/pt-BR/es) synced; the IDL was regenerated and **surgically merged** into the committed file so the diff is purely additive (no reformat churn). `declare_id` `7NeJaSRyb4Wxay3Tcd9bdpD7T3GWYUQSFyrhG8SgwE8V` preserved. `tsc` passes.

## Tests
**Rust unit (`tests/rust/src/test_close_course.rs`):** discriminator is 8 bytes; discriminator == sha256("account:Course")[..8] (stable across struct size — the invariant the defensive check relies on); close uses the same PDA seeds as create; distinct ids → distinct PDAs.

**TS integration (`onchain-academy.ts` §20, isolated `close-course-mig` id):**
- non-authority → `Unauthorized`
- account that is not the course PDA for the id → rejected (`ConstraintSeeds`)
- `course_id` whose PDA is not an existing program account → rejected (owner check)
- authority closes → PDA freed (account gone, 0 lamports; rent returned to authority)
- enrollment for the closed course still exists
- `create_course` succeeds again at the same `course_id` after close (version resets to 1, new fields applied)

## Verification (actual results)
- `anchor build` — success
- `cargo fmt` — program crate clean (`--check` passes)
- `cargo clippy -- -W clippy::all` — program clean (only pre-existing `cfg`/ambiguous-glob noise; new files clean)
- `cargo test --manifest-path tests/rust/Cargo.toml` — **84 passing** (+4)
- `anchor test` — **78 passing, 0 failing** (incl. all 6 close_course tests; run against a local validator with the mpl_core fixture)
- `program_autofixer` (solana-mcp) — clean, no further passes required
- frontend `tsc --noEmit` — passes; Prettier clean on all changed files
