### PR TITLE
ci: gate commits on Rust fmt + clippy in husky pre-commit [P2-3]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,9 +97,9 @@ jobs:
         run: cargo fmt --manifest-path onchain-academy/Cargo.toml --all --check
 
       - name: Clippy (program workspace)
-        # RATCHET: report-only until P2-7 (on-chain housekeeping) clears the
-        # cosmetic clippy warnings. Then flip continue-on-error to false. Owner: @thomgabriel.
-        continue-on-error: true
+        # Enforced: the program crate is clippy-clean under -D warnings as of
+        # P2-3 (added the unexpected_cfgs + ambiguous_glob_reexports allows).
+        # Kept in lockstep with the pre-commit hook (.husky/pre-commit).
         run: cargo clippy --manifest-path onchain-academy/Cargo.toml --all-targets -- -D warnings
 
       # tests/rust is a SEPARATE cargo workspace (own [workspace] table).
@@ -127,9 +127,8 @@ jobs:
         run: cargo fmt --manifest-path apps/build-server/Cargo.toml --all --check
 
       - name: Clippy
-        # RATCHET: report-only until build-server clippy warnings are cleared,
-        # then flip continue-on-error to false.
-        continue-on-error: true
+        # Enforced: build-server is clippy-clean under -D warnings. Kept in
+        # lockstep with the pre-commit hook (.husky/pre-commit).
         run: cargo clippy --manifest-path apps/build-server/Cargo.toml --all-targets -- -D warnings
 
       - name: Tests

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,45 @@
-pnpm exec lint-staged
+pnpm exec lint-staged || exit 1
+
+# --- Rust gating (P2-3) -------------------------------------------------------
+# Only runs when Rust sources/manifests in a workspace are staged, so pure
+# frontend commits stay fast. Mirrors the CI checks (.github/workflows/ci.yml):
+# `cargo fmt --check` + `cargo clippy --all-targets -- -D warnings`. clippy
+# compiles every target, so it also gates type errors (the "typecheck"
+# requirement) — a separate `cargo check` would just double the compile.
+
+staged_files=$(git diff --cached --name-only --diff-filter=ACMR)
+
+needs_rust() {
+  echo "$staged_files" | grep -qE "$1"
+}
+
+rust_gate() {
+  manifest="$1"
+  label="$2"
+  echo "🦀 Rust pre-commit checks: $label"
+  if ! cargo fmt --manifest-path "$manifest" --all --check; then
+    echo "✗ rustfmt failed — run: cargo fmt --manifest-path $manifest --all"
+    exit 1
+  fi
+  if ! cargo clippy --manifest-path "$manifest" --all-targets -- -D warnings; then
+    echo "✗ clippy failed — fix the warnings/type errors above before committing."
+    exit 1
+  fi
+}
+
+ONCHAIN='^onchain-academy/.*\.rs$|^onchain-academy/.*Cargo\.(toml|lock)$'
+BUILD_SERVER='^apps/build-server/.*\.rs$|^apps/build-server/.*Cargo\.(toml|lock)$'
+
+if needs_rust "$ONCHAIN" || needs_rust "$BUILD_SERVER"; then
+  if ! command -v cargo >/dev/null 2>&1; then
+    echo "⚠ Rust files are staged but 'cargo' is not installed — skipping local"
+    echo "  Rust gating. CI will still enforce fmt/clippy on this change."
+  else
+    if needs_rust "$ONCHAIN"; then
+      rust_gate onchain-academy/Cargo.toml "onchain-academy"
+    fi
+    if needs_rust "$BUILD_SERVER"; then
+      rust_gate apps/build-server/Cargo.toml "build-server"
+    fi
+  fi
+fi

--- a/onchain-academy/programs/onchain-academy/Cargo.toml
+++ b/onchain-academy/programs/onchain-academy/Cargo.toml
@@ -16,6 +16,14 @@ no-idl = []
 no-log-ix-name = []
 idl-build = ["anchor-lang/idl-build"]
 
+[lints.rust]
+# Anchor's #[program] macro expands solana-program cfgs (custom-heap,
+# custom-panic, target_os = "solana") that aren't declared in this crate, so
+# rustc's check-cfg lint flags them under modern toolchains. They're
+# macro-internal and out of our control — allow them so `clippy -D warnings`
+# (CI + the pre-commit hook) stays green.
+unexpected_cfgs = { level = "allow" }
+
 [dependencies]
 anchor-lang = "0.31.1"
 spl-token-2022 = { version = "5", features = ["no-entrypoint"] }

--- a/onchain-academy/programs/onchain-academy/src/instructions/mod.rs
+++ b/onchain-academy/programs/onchain-academy/src/instructions/mod.rs
@@ -1,3 +1,9 @@
+// Each instruction module defines a `handler` fn that is re-exported below and
+// always invoked qualified (e.g. `award_achievement::handler`). The glob
+// re-exports collide on the `handler` name, which is harmless here — allow the
+// lint so `clippy -D warnings` (CI + the pre-commit hook) stays green.
+#![allow(ambiguous_glob_reexports)]
+
 pub mod award_achievement;
 pub mod close_course;
 pub mod close_enrollment;


### PR DESCRIPTION
P2-3 — Pre-commit Rust gating

  Closes #131

  Extends .husky/pre-commit (previously just lint-staged) to block commits on Rust format/lint/type
  failures, mirroring CI.

  The hook (.husky/pre-commit)

  When a Rust workspace's sources/manifests are staged, runs the same checks as CI
  (.github/workflows/ci.yml):
  - cargo fmt --manifest-path <ws> --all --check
  - cargo clippy --manifest-path <ws> --all-targets -- -D warnings

  for onchain-academy and apps/build-server.
  
  - clippy = the typecheck: clippy --all-targets compiles every target, so it gates type errors too. A
  separate cargo check would just double the compile, so it's intentionally omitted (documented in the
  hook).
  - Only runs when relevant files are staged (git diff --cached matches *.rs / Cargo.{toml,lock} in a
  workspace) — pure-frontend commits stay fast.
  - Graceful without cargo: warns and skips (CI still enforces) so a frontend-only contributor touching
  e.g. Cargo.lock isn't hard-blocked.

  Prerequisite: make onchain clippy -D warnings clean

  The gate (and CI's existing clippy job) couldn't pass on the program crate under modern rustc — -D 
  warnings turned two lint classes fatal:
  - 29× unexpected_cfgs (custom-heap, custom-panic, target_os="solana") emitted by Anchor's #[program]
  macro → Cargo.toml [lints.rust] unexpected_cfgs = "allow" (macro-internal, not ours).
  - 1× ambiguous_glob_reexports — each instruction module's handler collides under glob re-export, but
  every handler is called qualified (award_achievement::handler), so it's harmless →
  #![allow(ambiguous_glob_reexports)] in instructions/mod.rs.

  After these, clippy --all-targets -- -D warnings exits 0 for onchain (build-server was already clean).
  Lint-level only — no logic changes.
  
  Verification

  - All four checks pass locally: onchain fmt+clippy, build-server fmt+clippy (all exit 0).
  - The hook self-tested on commit: committing the onchain change triggered 🦀 Rust pre-commit checks: 
  onchain-academy and ran fmt+clippy before allowing the commit; the hook-only commit correctly skipped
  the Rust gate (no Rust files staged).
  
  Note for reviewers

  The onchain touches (Cargo.toml, instructions/mod.rs) are in @thomgabriel's ownership zone — tiny
  lint-allow declarations required to make the gate (and the existing CI clippy job) green. Flagging for
  a quick onchain review.