### PR TITLE
refactor(web): replace raw <img> with next/image (P2-4)

### DIFF
--- a/apps/web/src/app/[locale]/(platform)/dashboard/page.tsx
+++ b/apps/web/src/app/[locale]/(platform)/dashboard/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState, useCallback } from "react";
 import { useTranslations, useLocale } from "next-intl";
 import Link from "next/link";
+import Image from "next/image";
 import { Transaction } from "@solana/web3.js";
 import { useConnection, useWallet } from "@solana/wallet-adapter-react";
 import { useWalletModal } from "@solana/wallet-adapter-react-ui";
@@ -826,7 +827,7 @@ export default function DashboardPage() {
 
                   <Link href={`/${locale}/courses/${course.slug}`}>
                     <div className="cc-thumb" aria-hidden="true">
-                      <img
+                      <Image
                         src={course.thumbnail || "/cover.png"}
                         alt=""
                         width={400}

--- a/apps/web/src/app/[locale]/(platform)/leaderboard/leaderboard-client.tsx
+++ b/apps/web/src/app/[locale]/(platform)/leaderboard/leaderboard-client.tsx
@@ -3,6 +3,7 @@
 import { useState, useCallback } from "react";
 import { useTranslations, useLocale } from "next-intl";
 import Link from "next/link";
+import Image from "next/image";
 import { Trophy, Crown, Lightning, Medal } from "@phosphor-icons/react";
 import type { LeaderboardEntry } from "@superteam-lms/types";
 import { LevelBadge } from "@/components/gamification/level-badge";
@@ -63,9 +64,12 @@ function PodiumCard({
         {/* Avatar */}
         <div className={cn("podium-avatar", rank === 1 && "gold")}>
           {entry.avatarUrl ? (
-            <img
+            <Image
               src={entry.avatarUrl}
               alt=""
+              width={64}
+              height={64}
+              unoptimized
               className="h-full w-full rounded-full object-cover"
             />
           ) : (
@@ -116,9 +120,12 @@ function RankedRow({
 
         <div className="lb-av" aria-hidden="true">
           {entry.avatarUrl ? (
-            <img
+            <Image
               src={entry.avatarUrl}
               alt=""
+              width={64}
+              height={64}
+              unoptimized
               className="h-full w-full rounded-full object-cover"
             />
           ) : (

--- a/apps/web/src/components/course/course-card.tsx
+++ b/apps/web/src/components/course/course-card.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import Image from "next/image";
 import { CheckCircle } from "@phosphor-icons/react";
 import { useTranslations, useLocale } from "next-intl";
 
@@ -47,7 +48,7 @@ export function CourseCard({
     >
       {/* Thumbnail */}
       <div className="course-card-thumb" aria-hidden="true">
-        <img
+        <Image
           src={thumbnail || "/cover.png"}
           alt=""
           width={400}

--- a/apps/web/src/components/course/learning-path-section.tsx
+++ b/apps/web/src/components/course/learning-path-section.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { useTranslations, useLocale } from "next-intl";
 import Link from "next/link";
+import Image from "next/image";
 import { CaretDown, Lock, CheckCircle } from "@phosphor-icons/react";
 import { cn } from "@/lib/utils";
 import type { LearningPath } from "@/lib/sanity/types";
@@ -160,7 +161,7 @@ export function LearningPathSection({
             <div className="path-step-inner">
               {/* Small thumbnail */}
               <div className="path-step-thumb" aria-hidden="true">
-                <img
+                <Image
                   src={course.thumbnail || "/cover.png"}
                   alt=""
                   width={80}


### PR DESCRIPTION
Convert all 5 raw <img> sites to next/image, clearing the @next/next/no-img-element warnings:

- Course thumbnails (course-card, learning-path-section, dashboard): keep the existing width/height; parent CSS (.course-card-thumb img etc.) still sizes the inner <img>. Sources are Sanity CDN / local, both allowed by next.config remotePatterns, so optimization stays on.
- Leaderboard avatars (podium + row): user/OAuth avatar_url can be an arbitrary host, so mark these unoptimized to avoid a next/image remote-host runtime throw; keep the h-full w-full object-cover styling.

No raw <img> tags remain; pnpm typecheck clean.

Closes #132 