### PR TITLE
chore(web): frontend lint/type polish (P2-5)

### DIFF
--- a/apps/web/src/app/api/deploy/save/route.ts
+++ b/apps/web/src/app/api/deploy/save/route.ts
@@ -1,5 +1,4 @@
 import { NextRequest, NextResponse } from "next/server";
-import type { SupabaseClient } from "@supabase/supabase-js";
 import { createClient } from "@/lib/supabase/server";
 
 interface SaveDeployRequest {
@@ -8,16 +7,9 @@ interface SaveDeployRequest {
   programId: string;
 }
 
-// The deployed_programs table exists but isn't in the generated types yet.
-// Use a typed helper to avoid `never` inference.
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function db(supabase: SupabaseClient<any>) {
-  return supabase;
-}
-
 export async function POST(request: NextRequest) {
   try {
-    const supabase = db(await createClient());
+    const supabase = await createClient();
     const {
       data: { user },
     } = await supabase.auth.getUser();
@@ -82,7 +74,7 @@ export async function POST(request: NextRequest) {
 //   - lessonId (optional) — narrow to a specific lesson
 export async function GET(request: NextRequest) {
   try {
-    const supabase = db(await createClient());
+    const supabase = await createClient();
     const {
       data: { user },
     } = await supabase.auth.getUser();

--- a/apps/web/src/components/community/answer-card.tsx
+++ b/apps/web/src/components/community/answer-card.tsx
@@ -9,8 +9,8 @@ import { VoteButton } from "./vote-button";
 import { AcceptAnswerButton } from "./accept-answer-button";
 import { FlagButton } from "./flag-button";
 import { DeleteButton } from "./delete-button";
-import { cn } from "@/lib/utils";
 import { LevelBadge } from "@/components/gamification/level-badge";
+import { cn } from "@/lib/utils";
 
 interface Author {
   username: string | null;

--- a/apps/web/src/components/community/thread-list.tsx
+++ b/apps/web/src/components/community/thread-list.tsx
@@ -2,8 +2,8 @@
 
 import { useState } from "react";
 import { useTranslations } from "next-intl";
-import { ThreadCard } from "./thread-card";
 import { ThreadFilters } from "./thread-filters";
+import { ThreadCard } from "./thread-card";
 import { useThreads } from "@/hooks/use-threads";
 import { useVote } from "@/hooks/use-vote";
 import { Button } from "@/components/ui/button";

--- a/apps/web/src/components/editor/challenge-interface.tsx
+++ b/apps/web/src/components/editor/challenge-interface.tsx
@@ -23,6 +23,8 @@ import type {
   CodeEditorHandle,
   ExecutionResult,
 } from "./types";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
 import {
   Dialog,
   DialogContent,
@@ -31,8 +33,6 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { Button } from "@/components/ui/button";
-import { cn } from "@/lib/utils";
 
 const LESSON_COMPLETE_EVENT = "superteam:lesson-complete";
 

--- a/apps/web/src/lib/helius/__tests__/event-decoder.test.ts
+++ b/apps/web/src/lib/helius/__tests__/event-decoder.test.ts
@@ -1,3 +1,6 @@
+/* eslint-disable import/order -- vi.mock() must sit between the vitest import
+   and the module-under-test import (vitest hoists mocks), so imports can't be
+   contiguous as import/order wants. */
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // Mock the Anchor coder so we control decode() without crafting real Borsh bytes.

--- a/apps/web/src/lib/solana/__tests__/arweave.test.ts
+++ b/apps/web/src/lib/solana/__tests__/arweave.test.ts
@@ -1,3 +1,6 @@
+/* eslint-disable import/order -- vi.mock() must sit between the vitest import
+   and the module-under-test import (vitest hoists mocks), so imports can't be
+   contiguous as import/order wants. */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 // `arweave.ts` is a server-only module that pulls in the UMI Irys uploader and

--- a/apps/web/src/lib/solana/onchain-queue.ts
+++ b/apps/web/src/lib/solana/onchain-queue.ts
@@ -1,11 +1,7 @@
 import "server-only";
 
 import { PublicKey } from "@solana/web3.js";
-import {
-  fetchAchievementReceipt,
-  fetchEnrollment,
-  fetchCourse,
-} from "./academy-reads";
+import { getProgramId } from "./pda";
 import {
   getConnection,
   awardAchievement,
@@ -13,7 +9,11 @@ import {
   issueCredential,
   rewardXp,
 } from "./academy-program";
-import { getProgramId } from "./pda";
+import {
+  fetchAchievementReceipt,
+  fetchEnrollment,
+  fetchCourse,
+} from "./academy-reads";
 import { ERROR_IDS } from "@/constants/errorIds";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { logError } from "@/lib/logging";


### PR DESCRIPTION
- next lint --fix cleared 35 import/order warnings across ~28 files (import reordering only, no logic changes).
- 2 remaining import/order warnings were in test files where vi.mock() must sit between the vitest import and the module-under-test import (vitest hoists mocks) — added a scoped, commented file-level eslint-disable for those.
- deploy/save/route.ts: removed the db() helper + SupabaseClient<any> + eslint-disable; deployed_programs is now in the generated types, so the typed createClient() resolves correctly (no never inference, no any).

pnpm lint clean (0 warnings/errors); typecheck green; affected tests pass.

Closes #133 