### PR TITLE
i18n(web): externalize 3 hardcoded aria-labels (P2-6)

### DIFF
--- a/apps/web/src/components/ai/ai-chat-sidebar.tsx
+++ b/apps/web/src/components/ai/ai-chat-sidebar.tsx
@@ -37,6 +37,7 @@ export function AiChatSidebar({
   lessonSlug,
 }: AiChatSidebarProps) {
   const t = useTranslations("lesson");
+  const tA11y = useTranslations("a11y");
 
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [input, setInput] = useState("");
@@ -149,7 +150,7 @@ export function AiChatSidebar({
             type="button"
             onClick={onClose}
             className="rounded-md p-1.5 text-text-3 transition-colors hover:bg-border hover:text-text"
-            aria-label="Close"
+            aria-label={tA11y("close")}
           >
             <X size={16} weight="bold" />
           </button>

--- a/apps/web/src/components/editor/code-editor.tsx
+++ b/apps/web/src/components/editor/code-editor.tsx
@@ -65,7 +65,7 @@ export const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(
     ref
   ) {
     const { resolvedTheme } = useTheme();
-    const t = useTranslations("a11y");
+    const tA11y = useTranslations("a11y");
     const editorRef = useRef<editor.IStandaloneCodeEditor | null>(null);
 
     useImperativeHandle(
@@ -163,7 +163,7 @@ export const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(
           "relative h-full w-full overflow-hidden rounded-md border",
           className
         )}
-        aria-label={t("codeEditor")}
+        aria-label={tA11y("codeEditor")}
       >
         <Editor
           defaultValue={initialCode}

--- a/apps/web/src/components/editor/code-editor.tsx
+++ b/apps/web/src/components/editor/code-editor.tsx
@@ -10,6 +10,7 @@ import {
 import Editor, { type OnMount, type BeforeMount } from "@monaco-editor/react";
 import type { editor } from "monaco-editor";
 import { useTheme } from "next-themes";
+import { useTranslations } from "next-intl";
 import { superteamDark, superteamLight, THEME_MAP } from "./themes";
 import type {
   CodeEditorProps,
@@ -64,6 +65,7 @@ export const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(
     ref
   ) {
     const { resolvedTheme } = useTheme();
+    const t = useTranslations("a11y");
     const editorRef = useRef<editor.IStandaloneCodeEditor | null>(null);
 
     useImperativeHandle(
@@ -161,7 +163,7 @@ export const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(
           "relative h-full w-full overflow-hidden rounded-md border",
           className
         )}
-        aria-label="Code editor"
+        aria-label={t("codeEditor")}
       >
         <Editor
           defaultValue={initialCode}

--- a/apps/web/src/components/ui/toast-container.tsx
+++ b/apps/web/src/components/ui/toast-container.tsx
@@ -8,6 +8,7 @@ import {
   Info,
   X,
 } from "@phosphor-icons/react";
+import { useTranslations } from "next-intl";
 import { TOAST_STYLES } from "@/lib/styles/styleClasses";
 
 type ToastVariant = "success" | "error" | "warning" | "info";
@@ -48,6 +49,7 @@ export function dispatchToast(
 const pending: ToastItem[] = [];
 
 export function ToastContainer() {
+  const tA11y = useTranslations("a11y");
   const [toasts, setToasts] = useState<ToastItem[]>([]);
   const timers = useRef<Map<number, ReturnType<typeof setTimeout>>>(new Map());
 
@@ -101,7 +103,7 @@ export function ToastContainer() {
             <button
               onClick={() => dismiss(t.uid)}
               className="ml-auto shrink-0 opacity-60 transition-opacity hover:opacity-100"
-              aria-label="Dismiss"
+              aria-label={tA11y("dismiss")}
             >
               <X size={12} weight="bold" />
             </button>

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -402,6 +402,9 @@
     "walletPermanent": "Permanent — cannot be changed"
   },
   "a11y": {
+    "dismiss": "Dismiss",
+    "close": "Close",
+    "codeEditor": "Code editor",
     "clearOutput": "Clear output",
     "resizeOutputPanel": "Resize output panel",
     "toggleTheme": "Toggle theme",

--- a/apps/web/src/messages/es.json
+++ b/apps/web/src/messages/es.json
@@ -402,6 +402,9 @@
     "walletPermanent": "Permanente — no se puede cambiar"
   },
   "a11y": {
+    "dismiss": "Descartar",
+    "close": "Cerrar",
+    "codeEditor": "Editor de código",
     "clearOutput": "Limpiar salida",
     "resizeOutputPanel": "Redimensionar panel de salida",
     "toggleTheme": "Cambiar tema",

--- a/apps/web/src/messages/pt-BR.json
+++ b/apps/web/src/messages/pt-BR.json
@@ -402,6 +402,9 @@
     "walletPermanent": "Permanente — não pode ser alterado"
   },
   "a11y": {
+    "dismiss": "Dispensar",
+    "close": "Fechar",
+    "codeEditor": "Editor de código",
     "clearOutput": "Limpar saída",
     "resizeOutputPanel": "Redimensionar painel de saída",
     "toggleTheme": "Alternar tema",


### PR DESCRIPTION
Move the last hardcoded aria-label strings into the next-intl a11y namespace (added to en / pt-BR / es with identical keys):
- toast-container: "Dismiss" -> a11y.dismiss (hook named tA11y to avoid shadowing the toast item `t` inside the map)
- ai-chat-sidebar: "Close" -> a11y.close (added a second useTranslations("a11y") alongside the existing lesson namespace)
- code-editor: "Code editor" -> a11y.codeEditor

No hardcoded aria-label literals remain in those components; typecheck + lint clean.

#134 