### PR TITLE
docs: reconcile docs with source [P2-9]

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,7 +22,6 @@ NEXT_PUBLIC_SOLANA_NETWORK=devnet
 # On-chain program (see docs/DEPLOY-PROGRAM.md for deployment guide)
 NEXT_PUBLIC_PROGRAM_ID=                    # Program ID from anchor deploy
 NEXT_PUBLIC_XP_MINT_ADDRESS=               # XP mint pubkey (from initialize.ts output)
-NEXT_PUBLIC_BACKEND_SIGNER=                # Authority pubkey (same as deployer on devnet)
 
 # ── Helius ───────────────────────────────────────────────────────────────────
 # Server-only API key for webhook management + DAS API (same key as in RPC URL)
@@ -35,8 +34,10 @@ HELIUS_WEBHOOK_SECRET=
 # Omit to disable the in-lesson AI assistant.
 GEMINI_API_KEY=
 
-# ── Auth ──────────────────────────────────────────────────────────────────────
-NEXT_PUBLIC_GOOGLE_CLIENT_ID=your-google-client-id.apps.googleusercontent.com
+# ── Rust playground (optional — server-only) ─────────────────────────────────
+# Upstream for /api/rust/execute. Defaults to https://play.rust-lang.org/execute
+# when unset (apps/web/src/app/api/rust/execute/route.ts).
+RUST_PLAYGROUND_URL=
 
 # ── Analytics (optional — platform works without these) ───────────────────────
 # Google Analytics 4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,6 @@ Superteam Academy is a **decentralized learning platform on Solana**. Learners e
 - `docs/CUSTOMIZATION.md` — Theming, i18n, and extensibility
 - `docs/ADMIN.md` — Admin panel guide for Sanity-to-on-chain sync
 - `docs/DEPLOY-PROGRAM.md` — Devnet program deployment guide
-- `audit/SPEC.md` — Program specification v3.0 (archival copy)
 
 ## Communication Style
 
@@ -79,7 +78,7 @@ superteam-academy/
 │   │   │   │   │       ├── leaderboard/
 │   │   │   │   │       ├── certificates/ (list + [id])
 │   │   │   │   │       └── settings/
-│   │   │   │   ├── api/                    # See API Routes table below (29 routes)
+│   │   │   │   ├── api/                    # See API Routes table below (34 routes)
 │   │   │   │   ├── studio/[[...tool]]/     # Embedded Sanity Studio
 │   │   │   │   ├── error.tsx          # Global error (inline i18n)
 │   │   │   │   ├── not-found.tsx      # Global 404 (inline i18n)
@@ -150,7 +149,7 @@ superteam-academy/
 │   ├── seed/                      # Seed data JSON files + import.mjs script (includes quests.json)
 │   └── sanity.config.ts
 ├── supabase/
-│   └── schema.sql                 # Complete DB schema (17 tables, indexes, RLS, functions, views)
+│   └── schema.sql                 # Complete DB schema (19 tables, indexes, RLS, functions, views)
 ├── wallets/                       ← Keypairs (gitignored)
 ├── scripts/                       ← Helper scripts
 └── .claude/
@@ -187,7 +186,7 @@ superteam-academy/
 
 16 instructions, 6 PDA types, 27 error variants, 15 events.
 
-See `audit/SPEC.md` for program specification and `docs/ARCHITECTURE.md` for frontend integration details.
+See `docs/ARCHITECTURE.md` for the program specification and frontend integration details (the on-chain program source is under `onchain-academy/programs/`).
 
 ### Key Design Decisions
 
@@ -198,7 +197,7 @@ See `audit/SPEC.md` for program specification and `docs/ARCHITECTURE.md` for fro
 - **Rotatable backend signer** — stored in Config, rotatable via `update_config`
 - **Reserved bytes** on all accounts for future-proofing
 
-## Frontend API Routes (29 routes)
+## Frontend API Routes (34 routes)
 
 ### Auth
 
@@ -212,17 +211,25 @@ See `audit/SPEC.md` for program specification and `docs/ARCHITECTURE.md` for fro
 
 ### Core Platform
 
-| Route                        | Method   | Auth     | Purpose                                                           |
-| ---------------------------- | -------- | -------- | ----------------------------------------------------------------- |
-| `/api/lessons/complete`      | POST     | Required | Mark lesson complete, award XP, auto-finalize, check achievements |
-| `/api/leaderboard`           | GET      | None     | XP rankings (alltime/weekly/monthly)                              |
-| `/api/certificates/metadata` | GET      | None     | Serve NFT metadata JSON by UUID                                   |
-| `/api/certificates/mint`     | POST     | Required | Manual credential mint with retry queue                           |
-| `/api/build-program`         | POST     | Required | Proxy Anchor build to build server                                |
-| `/api/deploy/save`           | POST     | Required | Save deployed program record                                      |
-| `/api/deploy/[uuid]`         | GET      | Required | Download compiled .so binary                                      |
-| `/api/rust/execute`          | POST     | Required | Proxy basic Rust execution to Rust Playground                     |
-| `/api/quests/daily`          | GET/POST | Required | Get daily quest state / award quest XP (on-chain minting)         |
+| Route                             | Method   | Auth     | Purpose                                                           |
+| --------------------------------- | -------- | -------- | ----------------------------------------------------------------- |
+| `/api/lessons/complete`           | POST     | Required | Mark lesson complete, award XP, auto-finalize, check achievements |
+| `/api/lessons/validate-challenge` | POST     | Required | Server-side challenge validation (gates lesson completion)        |
+| `/api/leaderboard`                | GET      | None     | XP rankings (alltime/weekly/monthly)                              |
+| `/api/certificates/metadata`      | GET      | None     | Serve NFT metadata JSON by UUID                                   |
+| `/api/certificates/mint`          | POST     | Required | Manual credential mint with retry queue                           |
+| `/api/build-program`              | POST     | Required | Proxy Anchor build to build server                                |
+| `/api/deploy/save`                | POST     | Required | Save deployed program record                                      |
+| `/api/deploy/[uuid]`              | GET      | Required | Download compiled .so binary                                      |
+| `/api/rust/execute`               | POST     | Required | Proxy basic Rust execution to Rust Playground                     |
+| `/api/quests/daily`               | GET/POST | Required | Get daily quest state / award quest XP (on-chain minting)         |
+
+### AI Lesson Assistant
+
+| Route             | Method | Auth     | Purpose                                                         |
+| ----------------- | ------ | -------- | --------------------------------------------------------------- |
+| `/api/ai/chat`    | POST   | Required | Lesson tutor chat (Gemini); rate-limited + input-capped         |
+| `/api/ai/suggest` | POST   | Required | Challenge code suggestion (Gemini); rate-limited + input-capped |
 
 ### Community Forum
 
@@ -230,8 +237,10 @@ See `audit/SPEC.md` for program specification and `docs/ARCHITECTURE.md` for fro
 | ------------------------------------ | -------- | -------- | ------------------------------------------------ |
 | `/api/community/threads`             | GET/POST | Varies   | List threads (cursor pagination) / create thread |
 | `/api/community/threads/[id]`        | GET      | None     | Thread detail with answers                       |
+| `/api/community/threads/[id]/delete` | POST     | Required | Soft-delete own thread (author only)             |
 | `/api/community/answers`             | POST     | Required | Post answer to a thread                          |
 | `/api/community/answers/[id]/accept` | POST     | Required | Accept an answer (thread author only)            |
+| `/api/community/answers/[id]/delete` | POST     | Required | Soft-delete own answer (author only)             |
 | `/api/community/votes`               | POST     | Required | Upvote/downvote thread or answer                 |
 | `/api/community/flags`               | POST     | Required | Flag content for moderation                      |
 | `/api/community/search`              | GET      | None     | Full-text search across threads                  |
@@ -277,13 +286,13 @@ See `audit/SPEC.md` for program specification and `docs/ARCHITECTURE.md` for fro
 
 ### Database (Supabase)
 
-- **RLS enabled** on all 17 tables
+- **RLS enabled** on all 19 tables
 - **Core tables** (10): profiles, enrollments, user_progress, user_xp, xp_transactions, user_achievements, certificates, nft_metadata, siws_nonces, deployed_programs
-- **Community tables** (5): forum_categories, threads, answers, votes, flags
-- **Queue/quest tables** (2): pending_onchain_actions, user_daily_quests
-- **View**: `community_stats` (aggregated thread/answer/accepted counts per user)
+- **Community tables** (6): forum_categories, threads, answers, votes, flags, thread_views
+- **Queue/quest/infra tables** (3): pending_onchain_actions, user_daily_quests, rate_limits
+- **Views**: `community_stats` (per-user thread/answer/accepted counts) and `public_user_xp` (non-sensitive user_id/total_xp/level for public profiles)
 - Users can only SELECT/INSERT/UPDATE their own rows (verified via `auth.uid()`)
-- Leaderboard data (user_xp, xp_transactions) has a public SELECT policy
+- Leaderboard data is served via the `get_leaderboard()` SECURITY DEFINER function + `public_user_xp` view; `user_xp`/`xp_transactions` are own-row SELECT only (no broad public policy)
 - Community data (forum_categories, threads, answers, votes) has public SELECT policies
 - `award_xp()`, `unlock_achievement()`, and `get_daily_quest_state()` are **SECURITY DEFINER** functions
 - **REVOKE**d from `authenticated`, `anon`, and `public` roles — **GRANT**ed only to `service_role`
@@ -336,9 +345,13 @@ NEXT_PUBLIC_PROGRAM_ID=            # Deployed program ID (used by webhook decode
 ADMIN_SECRET=                      # Admin panel authentication secret (HMAC-signed cookies)
 BUILD_SERVER_URL=                  # Cloud Run build server URL (server-only, proxied via /api)
 BUILD_SERVER_API_KEY=              # Build server authentication key
+HELIUS_API_KEY=                    # Helius key for webhook management + DAS API (lib/helius)
 HELIUS_WEBHOOK_SECRET=             # Helius webhook signature verification
 XP_MINT_AUTHORITY_SECRET=          # XP mint authority keypair (JSON array of 64 keypair bytes)
 PROGRAM_AUTHORITY_SECRET=          # Program authority keypair (JSON array of 64 keypair bytes)
+
+# Optional — Rust playground proxy (server-only)
+RUST_PLAYGROUND_URL=               # /api/rust/execute upstream (default: play.rust-lang.org/execute)
 
 # Optional — Permanent credential storage (server-only)
 # Funds Irys uploads that pin credential metadata to Arweave at mint, so the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -211,18 +211,18 @@ See `docs/ARCHITECTURE.md` for the program specification and frontend integratio
 
 ### Core Platform
 
-| Route                             | Method   | Auth     | Purpose                                                           |
-| --------------------------------- | -------- | -------- | ----------------------------------------------------------------- |
-| `/api/lessons/complete`           | POST     | Required | Mark lesson complete, award XP, auto-finalize, check achievements |
-| `/api/lessons/validate-challenge` | POST     | Required | Server-side challenge validation (gates lesson completion)        |
-| `/api/leaderboard`                | GET      | None     | XP rankings (alltime/weekly/monthly)                              |
-| `/api/certificates/metadata`      | GET      | None     | Serve NFT metadata JSON by UUID                                   |
-| `/api/certificates/mint`          | POST     | Required | Manual credential mint with retry queue                           |
-| `/api/build-program`              | POST     | Required | Proxy Anchor build to build server                                |
-| `/api/deploy/save`                | POST     | Required | Save deployed program record                                      |
-| `/api/deploy/[uuid]`              | GET      | Required | Download compiled .so binary                                      |
-| `/api/rust/execute`               | POST     | Required | Proxy basic Rust execution to Rust Playground                     |
-| `/api/quests/daily`               | GET/POST | Required | Get daily quest state / award quest XP (on-chain minting)         |
+| Route                             | Method   | Auth     | Purpose                                                                                      |
+| --------------------------------- | -------- | -------- | -------------------------------------------------------------------------------------------- |
+| `/api/lessons/complete`           | POST     | Required | Mark lesson complete, award XP, auto-finalize, check achievements                            |
+| `/api/lessons/validate-challenge` | POST     | Required | Server-side challenge validation (UX pass/fail; completion gated in `/api/lessons/complete`) |
+| `/api/leaderboard`                | GET      | None     | XP rankings (alltime/weekly/monthly)                                                         |
+| `/api/certificates/metadata`      | GET      | None     | Serve NFT metadata JSON by UUID                                                              |
+| `/api/certificates/mint`          | POST     | Required | Manual credential mint with retry queue                                                      |
+| `/api/build-program`              | POST     | Required | Proxy Anchor build to build server                                                           |
+| `/api/deploy/save`                | POST     | Required | Save deployed program record                                                                 |
+| `/api/deploy/[uuid]`              | GET      | Required | Download compiled .so binary                                                                 |
+| `/api/rust/execute`               | POST     | Required | Proxy basic Rust execution to Rust Playground                                                |
+| `/api/quests/daily`               | GET/POST | Required | Get daily quest state / award quest XP (on-chain minting)                                    |
 
 ### AI Lesson Assistant
 

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Open [http://localhost:3000](http://localhost:3000).
 
 **Minimum variables for basic dev** (no on-chain features): `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY`, `NEXT_PUBLIC_SANITY_PROJECT_ID`, `NEXT_PUBLIC_SANITY_DATASET`.
 
-**Full on-chain features** require: `NEXT_PUBLIC_PROGRAM_ID`, `NEXT_PUBLIC_XP_MINT_ADDRESS`, `NEXT_PUBLIC_BACKEND_SIGNER`, `PROGRAM_AUTHORITY_SECRET`, `BACKEND_SIGNER_SECRET`. See [Program Deployment](docs/DEPLOY-PROGRAM.md) for the deploy and initialize workflow.
+**Full on-chain features** require: `NEXT_PUBLIC_PROGRAM_ID`, `NEXT_PUBLIC_XP_MINT_ADDRESS`, `PROGRAM_AUTHORITY_SECRET`, `BACKEND_SIGNER_SECRET`. See [Program Deployment](docs/DEPLOY-PROGRAM.md) for the deploy and initialize workflow.
 
 ### Development Commands
 
@@ -218,7 +218,6 @@ Copy `.env.example` to `apps/web/.env.local` and fill in values.
 | `NEXT_PUBLIC_SOLANA_NETWORK`  | Client | Network name (`devnet`)                                 |
 | `NEXT_PUBLIC_PROGRAM_ID`      | Client | Program ID from `anchor deploy`                         |
 | `NEXT_PUBLIC_XP_MINT_ADDRESS` | Client | XP mint pubkey from `initialize` output                 |
-| `NEXT_PUBLIC_BACKEND_SIGNER`  | Client | Authority pubkey (same as deployer on devnet)           |
 
 ### Admin / Signing (Required for admin panel and on-chain operations)
 
@@ -230,18 +229,13 @@ Copy `.env.example` to `apps/web/.env.local` and fill in values.
 | `ADMIN_SECRET`             | Server | Admin panel password (min 32 chars, random string)                                               |
 | `SANITY_ADMIN_TOKEN`       | Server | Write-enabled Sanity API token for course sync in admin panel                                    |
 
-### Auth (Optional)
-
-| Variable                       | Scope  | Description            |
-| ------------------------------ | ------ | ---------------------- |
-| `NEXT_PUBLIC_GOOGLE_CLIENT_ID` | Client | Google OAuth client ID |
-
 ### Build Server (Optional -- for code compilation features)
 
-| Variable               | Scope  | Description                                                             |
-| ---------------------- | ------ | ----------------------------------------------------------------------- |
-| `BUILD_SERVER_URL`     | Server | Cloud Run service URL                                                   |
-| `BUILD_SERVER_API_KEY` | Server | API key for `X-API-Key` header (same as `ACADEMY_API_KEY` on Cloud Run) |
+| Variable               | Scope  | Description                                                                      |
+| ---------------------- | ------ | -------------------------------------------------------------------------------- |
+| `BUILD_SERVER_URL`     | Server | Cloud Run service URL                                                            |
+| `BUILD_SERVER_API_KEY` | Server | API key for `X-API-Key` header (same as `ACADEMY_API_KEY` on Cloud Run)          |
+| `RUST_PLAYGROUND_URL`  | Server | Upstream for `/api/rust/execute` (default: `https://play.rust-lang.org/execute`) |
 
 ### AI Lesson Assistant (Optional)
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -47,7 +47,7 @@ System architecture, component structure, data flow, and service interfaces for 
 | `packages/types/`    | Shared TypeScript interfaces (`Course`, `UserProfile`, `Progress`)                       |
 | `packages/config/`   | Shared ESLint, TypeScript, Tailwind configs                                              |
 | `sanity/`            | Sanity Studio schemas (`course`, `module`, `lesson`, `achievement`, `quest`) + seed data |
-| `supabase/`          | Complete Postgres schema (17 tables, indexes, RLS, functions, views)                     |
+| `supabase/`          | Complete Postgres schema (19 tables, indexes, RLS, functions, views)                     |
 
 ### Deployment Model
 
@@ -488,7 +488,7 @@ Mirror writes are non-fatal: if a Supabase write fails after an on-chain TX succ
 - **Generic errors**: No stack traces or internal details in API responses
 - **Env var guards**: API routes fail-fast with 500 if required vars are missing
 
-### RLS Model (17 tables, all with RLS enabled)
+### RLS Model (19 tables, all with RLS enabled)
 
 #### Core Tables
 

--- a/docs/DEPLOY-PROGRAM.md
+++ b/docs/DEPLOY-PROGRAM.md
@@ -4,7 +4,7 @@
 
 Each bounty applicant deploys their own program instance on devnet. This gives you full authority over the program — no shared keys, no waiting on others, and a clean environment to test your frontend against.
 
-Architecture reference: [ARCHITECTURE.md](./ARCHITECTURE.md) | Program specification: [audit/SPEC.md](../audit/SPEC.md)
+Architecture reference: [ARCHITECTURE.md](./ARCHITECTURE.md) (program specification + on-chain details)
 
 ---
 

--- a/docs/DEPLOY-PROGRAM.md
+++ b/docs/DEPLOY-PROGRAM.md
@@ -261,7 +261,6 @@ Add these to your `.env.local`:
 # Public (safe to expose)
 NEXT_PUBLIC_PROGRAM_ID=<YOUR_PROGRAM_ID>
 NEXT_PUBLIC_XP_MINT_ADDRESS=<YOUR_XP_MINT_ADDRESS>
-NEXT_PUBLIC_BACKEND_SIGNER=<YOUR_AUTHORITY_PUBKEY>
 NEXT_PUBLIC_SOLANA_NETWORK=devnet
 
 # Server-side only (never expose to client)
@@ -269,7 +268,7 @@ BACKEND_SIGNER_SECRET=<BASE58_PRIVATE_KEY>
 PROGRAM_AUTHORITY_SECRET=<BASE58_PRIVATE_KEY>
 ```
 
-For devnet, `NEXT_PUBLIC_BACKEND_SIGNER` is the same as your authority public key. `BACKEND_SIGNER_SECRET` and `PROGRAM_AUTHORITY_SECRET` can be the same keypair (as base58). In production these are separate keys.
+For devnet, `BACKEND_SIGNER_SECRET` and `PROGRAM_AUTHORITY_SECRET` can be the same keypair (as base58). In production these are separate keys.
 
 To extract the base58 private key from a Solana keypair JSON file:
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -108,31 +108,33 @@ Subsequent pushes to `main` trigger automatic deployments. Pull requests get pre
    ```bash
    supabase db push
    ```
-   This runs every file in `supabase/migrations/` in order, creating all 17 tables, RLS policies, indexes, SECURITY DEFINER functions, and views.
+   This runs every file in `supabase/migrations/` in order, creating all 19 tables, RLS policies, indexes, SECURITY DEFINER functions, and views.
 
 > **Migrations are the source of truth.** `supabase/schema.sql` is a generated snapshot (via `supabase db dump`) kept for reference and diffing — do **not** run or hand-edit it. Ship schema changes as new migrations: `supabase migration new <name>`, then `supabase db push`.
 
 The schema includes:
 
-| Table                     | Purpose                       |
-| ------------------------- | ----------------------------- |
-| `profiles`                | User profiles (wallet, email) |
-| `enrollments`             | Course enrollments            |
-| `user_progress`           | Lesson completion tracking    |
-| `user_xp`                 | Total XP per user             |
-| `xp_transactions`         | XP change log                 |
-| `user_achievements`       | Unlocked achievements         |
-| `certificates`            | NFT certificate records       |
-| `siws_nonces`             | SIWS replay protection        |
-| `nft_metadata`            | NFT metadata storage          |
-| `deployed_programs`       | Student program deployments   |
-| `pending_onchain_actions` | On-chain retry queue          |
-| `user_daily_quests`       | Daily quest progress tracking |
-| `forum_categories`        | Community forum sections      |
-| `threads`                 | Community discussion threads  |
-| `answers`                 | Thread replies                |
-| `votes`                   | Upvotes/downvotes             |
-| `flags`                   | Content moderation flags      |
+| Table                     | Purpose                         |
+| ------------------------- | ------------------------------- |
+| `profiles`                | User profiles (wallet, email)   |
+| `enrollments`             | Course enrollments              |
+| `user_progress`           | Lesson completion tracking      |
+| `user_xp`                 | Total XP per user               |
+| `xp_transactions`         | XP change log                   |
+| `user_achievements`       | Unlocked achievements           |
+| `certificates`            | NFT certificate records         |
+| `siws_nonces`             | SIWS replay protection          |
+| `nft_metadata`            | NFT metadata storage            |
+| `deployed_programs`       | Student program deployments     |
+| `pending_onchain_actions` | On-chain retry queue            |
+| `user_daily_quests`       | Daily quest progress tracking   |
+| `forum_categories`        | Community forum sections        |
+| `threads`                 | Community discussion threads    |
+| `answers`                 | Thread replies                  |
+| `votes`                   | Upvotes/downvotes               |
+| `flags`                   | Content moderation flags        |
+| `thread_views`            | Per-user thread view dedup      |
+| `rate_limits`             | Cross-instance API rate limiter |
 
 ### 2. Auth Redirect URLs
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -61,9 +61,9 @@ Add all environment variables in **Vercel → Project → Settings → Environme
 | `NEXT_PUBLIC_APP_URL`           | Public          | Your Vercel URL (e.g., `https://solarium.courses`)                                                                    |
 | `NEXT_PUBLIC_PROGRAM_ID`        | Public          | Program ID from `anchor deploy` (see [DEPLOY-PROGRAM.md](./DEPLOY-PROGRAM.md))                                        |
 | `NEXT_PUBLIC_XP_MINT_ADDRESS`   | Public          | XP mint pubkey from `initialize.ts` output                                                                            |
-| `NEXT_PUBLIC_BACKEND_SIGNER`    | Public          | Authority pubkey (same as deployer on devnet)                                                                         |
 | `BUILD_SERVER_URL`              | **Server-only** | Cloud Run service URL (e.g., `https://academy-build-server-HASH.a.run.app`)                                           |
 | `BUILD_SERVER_API_KEY`          | **Server-only** | Same value as `ACADEMY_API_KEY` on Cloud Run                                                                          |
+| `HELIUS_API_KEY`                | **Server-only** | Helius key for webhook management + DAS API (`lib/helius`)                                                            |
 | `PROGRAM_AUTHORITY_SECRET`      | **Server-only** | Base58 private key of the Config PDA authority — required for admin panel on-chain deployments                        |
 | `BACKEND_SIGNER_SECRET`         | **Server-only** | Base58 private key of the backend signer registered in `Config.backend_signer` — signs lesson completion transactions |
 | `ADMIN_SECRET`                  | **Server-only** | Admin panel password (min 32 chars). Required to access `/{locale}/admin`                                             |
@@ -73,13 +73,13 @@ Add all environment variables in **Vercel → Project → Settings → Environme
 
 #### Optional Variables
 
-| Variable                         | Type   | Notes                                           |
-| -------------------------------- | ------ | ----------------------------------------------- |
-| `NEXT_PUBLIC_GOOGLE_CLIENT_ID`   | Public | Google OAuth (see [setup](#google-oauth-setup)) |
-| `NEXT_PUBLIC_GA4_MEASUREMENT_ID` | Public | Google Analytics 4                              |
-| `NEXT_PUBLIC_POSTHOG_KEY`        | Public | PostHog project key                             |
-| `NEXT_PUBLIC_POSTHOG_HOST`       | Public | PostHog instance URL                            |
-| `NEXT_PUBLIC_SENTRY_DSN`         | Public | Sentry error tracking (DSN is safe to expose)   |
+| Variable                         | Type            | Notes                                                      |
+| -------------------------------- | --------------- | ---------------------------------------------------------- |
+| `RUST_PLAYGROUND_URL`            | **Server-only** | `/api/rust/execute` upstream (default: play.rust-lang.org) |
+| `NEXT_PUBLIC_GA4_MEASUREMENT_ID` | Public          | Google Analytics 4                                         |
+| `NEXT_PUBLIC_POSTHOG_KEY`        | Public          | PostHog project key                                        |
+| `NEXT_PUBLIC_POSTHOG_HOST`       | Public          | PostHog instance URL                                       |
+| `NEXT_PUBLIC_SENTRY_DSN`         | Public          | Sentry error tracking (DSN is safe to expose)              |
 
 > **Tip**: Variables prefixed with `NEXT_PUBLIC_` are bundled into the client-side JavaScript bundle. All others are server-only and only accessible in API routes and server components.
 
@@ -234,11 +234,9 @@ Google OAuth lets users sign in without a wallet. It requires configuration in b
 3. Paste the Client ID and Client Secret
 4. Copy the **Callback URL** Supabase shows — this must match what's in Google Cloud Console
 
-### 3. Set Environment Variable
+### 3. No App Env Var Needed
 
-```bash
-NEXT_PUBLIC_GOOGLE_CLIENT_ID=<your-client-id>.apps.googleusercontent.com
-```
+Google OAuth runs through Supabase Auth — enter the **Client ID** and **Client Secret** in the Supabase dashboard (**Authentication → Providers → Google**), not in the app's environment. The app has no `NEXT_PUBLIC_GOOGLE_CLIENT_ID`.
 
 > **Note**: The `profiles` table has a `github_id` column in the schema for future GitHub OAuth, but it is not currently implemented in the app.
 
@@ -259,7 +257,6 @@ After deployment, add these to your `.env.local`:
 ```bash
 NEXT_PUBLIC_PROGRAM_ID=<your-program-id>
 NEXT_PUBLIC_XP_MINT_ADDRESS=<xp-mint-pubkey-from-initialize-output>
-NEXT_PUBLIC_BACKEND_SIGNER=<your-authority-pubkey>
 ```
 
 On devnet, the deployer wallet serves as both `authority` and `backend_signer`.


### PR DESCRIPTION
## P2-9 — Reconcile docs with source

Closes #137

Verified every number/var against the actual source. **The real counts are 34/19, not the issue's 33/18** — `main` grew since the issue was filed (one route added; `rate_limits` table from the merged P1-7). Matched source, not the stale issue text.

### Counts
- **API routes 29 → 34** (CLAUDE.md count in 2 places). Also added the 5 route rows the table was missing so it actually lists 34: `ai/chat`, `ai/suggest`, `lessons/validate-challenge`, `community/threads/[id]/delete`, `community/answers/[id]/delete`.
- **DB tables 17 → 19** (CLAUDE.md, ARCHITECTURE.md ×2, DEPLOYMENT.md count + table). Added `thread_views` + `rate_limits` to the breakdowns/lists.

### Broken `audit/SPEC.md` link
The file doesn't exist (no `audit/`). Removed/repointed all refs (CLAUDE.md ×2, DEPLOY-PROGRAM.md) → `docs/ARCHITECTURE.md` + `onchain-academy/programs/`.

### Env vars
- **Removed dead** `NEXT_PUBLIC_GOOGLE_CLIENT_ID` + `NEXT_PUBLIC_BACKEND_SIGNER` (no source usage — Google OAuth is configured in Supabase, not app env) from `.env.example`, `README.md`, `docs/DEPLOYMENT.md`, `docs/DEPLOY-PROGRAM.md`.
- **Added** `RUST_PLAYGROUND_URL` (`.env.example`, README, CLAUDE.md, DEPLOYMENT.md) and `HELIUS_API_KEY` (CLAUDE.md env block, DEPLOYMENT.md) — both used in source.

### Bonus accuracy fix
Corrected CLAUDE.md's now-stale "`user_xp`/`xp_transactions` public SELECT" note — P1-6 removed those policies; leaderboard is served via `get_leaderboard()` + the `public_user_xp` view.

### Verification
`git grep` confirms: 0 stale "29 routes"/"17 tables", 0 `audit/SPEC.md` refs, 0 dead-var declarations in any tracked doc; CLAUDE route table = exactly 34 rows.

### Scope note
Skipped `docs/GRANT-PROPOSAL.md`, `docs/ISSUES.md`, `docs/MAINNET-READINESS.md` — they're **untracked** local working files, not committed docs.
