### PR TITLE
fix(db): reconcile community grant hardening (anon UPDATE + definer-trigger execute) (#210)

### DIFF
--- a/supabase/migrations/20260626140000_harden_community_anon_and_definer_trigger_grants.sql
+++ b/supabase/migrations/20260626140000_harden_community_anon_and_definer_trigger_grants.sql
@@ -1,0 +1,23 @@
+-- Reconcile fresh / migration-based deploys with the live-DB community-grant
+-- hardening (issue #210). The baseline migration already column-scopes
+-- authenticated UPDATE on threads/answers, but two gaps remained that were
+-- applied to the live DB and are mirrored here:
+--
+--   1. anon must not hold UPDATE on threads/answers. No anon UPDATE RLS policy
+--      exists, so the grant is inert, but Supabase default privileges can grant
+--      it on a fresh deploy — revoke it for defense-in-depth.
+--   2. The SECURITY DEFINER denormalized-counter trigger functions
+--      (update_vote_score / update_answer_count / update_last_activity) carry
+--      the default PUBLIC execute grant. They run only in trigger context
+--      (which does not require EXECUTE), so they must never be callable via
+--      PostgREST RPC. Revoke it. Triggers continue to fire normally (trigger
+--      execution does not check EXECUTE).
+--
+-- Idempotent: REVOKE of an absent privilege is a no-op.
+
+REVOKE UPDATE ON public.threads FROM anon;
+REVOKE UPDATE ON public.answers FROM anon;
+
+REVOKE EXECUTE ON FUNCTION public.update_vote_score()    FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.update_answer_count()  FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.update_last_activity() FROM PUBLIC, anon, authenticated;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -1188,6 +1188,15 @@ CREATE TRIGGER trg_update_last_activity
   AFTER INSERT ON answers
   FOR EACH ROW EXECUTE FUNCTION update_last_activity();
 
+-- update_vote_score / update_answer_count / update_last_activity are SECURITY
+-- DEFINER (they write protected denormalized columns regardless of the caller's
+-- column privileges). They run only in trigger context, which does not require
+-- EXECUTE, so drop the default PUBLIC execute grant — they must never be
+-- callable via PostgREST RPC.
+REVOKE EXECUTE ON FUNCTION update_vote_score()    FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION update_answer_count()  FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION update_last_activity() FROM PUBLIC, anon, authenticated;
+
 -- Maintain updated_at on genuine content edits only (not on the denormalized
 -- counter updates above, which would otherwise make updated_at track activity
 -- rather than edits). updated_at is server-owned — the author GRANTs below do
@@ -1505,6 +1514,9 @@ REVOKE UPDATE ON threads FROM authenticated;
 -- updated_at is omitted: it is maintained server-side by trg_threads_set_updated_at.
 GRANT UPDATE (title, body, type, category_id, course_id, lesson_id)
   ON threads TO authenticated;
+-- anon has no UPDATE RLS policy, so this grant is inert, but revoke it for
+-- defense-in-depth (Supabase default privileges may grant it on fresh deploys).
+REVOKE UPDATE ON threads FROM anon;
 
 -- No DELETE policy needed. Soft delete is handled via soft_delete_thread() SECURITY DEFINER function.
 
@@ -1529,6 +1541,7 @@ CREATE POLICY "Authors can update own answers"
 REVOKE UPDATE ON answers FROM authenticated;
 -- updated_at is omitted: it is maintained server-side by trg_answers_set_updated_at.
 GRANT UPDATE (body) ON answers TO authenticated;
+REVOKE UPDATE ON answers FROM anon;
 
 -- No DELETE policy needed. Soft delete is handled via soft_delete_answer() SECURITY DEFINER function.
 


### PR DESCRIPTION
## Summary
Reconciles the repo with the community-grant hardening already applied to the **live LMS DB**, so fresh / migration-based deploys reproduce the hardened state. Two gaps remained after the baseline migration (which already column-scopes `authenticated` UPDATE on `threads`/`answers`):

1. **`anon` UPDATE on `threads`/`answers`** — no anon UPDATE RLS policy exists, so the grant is inert, but Supabase default privileges can grant it on a fresh deploy. Revoked for defense-in-depth.
2. **PUBLIC execute on the SECURITY DEFINER counter-trigger functions** (`update_vote_score` / `update_answer_count` / `update_last_activity`) — they run only in trigger context (no `EXECUTE` required) and must never be callable via PostgREST RPC. Triggers continue to fire normally.

**Changes:** `supabase/schema.sql` (canonical) + new idempotent migration `20260626140000_harden_community_anon_and_definer_trigger_grants.sql`.

## Context
Found during the live-DB reconciliation pass that closed a **HIGH forgeable-write gap**: the live DB held *table-level* `UPDATE` on `threads`/`answers` for `authenticated`+`anon`, which — combined with the row-scoped `"Authors can update own ..."` RLS policy — let an author forge `vote_score` (ranking), `is_solved`/`accepted_answer_id` (self-accept), `is_pinned`, and the denormalized counters on their **own** rows (RLS gates rows, not columns). That exploit is **already fixed on the live DB**. The `authenticated` column-scoping is already present in the baseline migration (`20260624163347_baseline.sql:1349/1373`), so this PR only adds the remaining `anon` + definer-trigger-execute revokes.

The live DB already has equivalent migrations applied (via MCP); this migration is **idempotent** (a `REVOKE` of an absent privilege is a no-op), so applying it there later is safe.

Closes #210.