### PR TITLE
ci: add Lighthouse CI gate for frontend thresholds (G-6)

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,0 +1,61 @@
+name: Lighthouse
+
+# G-6 — frontend Lighthouse gate (Performance 90+, Accessibility 95+,
+# Best Practices 95+, SEO 90+). Thresholds are asserted in lighthouserc.json.
+#
+# REPORT-ONLY for now: the build + Lighthouse steps use continue-on-error so this
+# never blocks required checks while the setup is validated and the four scores
+# are brought to target. Once a run is green, remove the continue-on-error lines
+# to make G-6 a hard gate.
+#
+# NOTE: this builds + serves the app with placeholder env (P0-C2 validation
+# throws otherwise), so data-fetching pages degrade to empty/fallback states —
+# scores are indicative, not production-accurate. For true scores, point
+# Lighthouse at a real preview deployment (e.g. the Vercel preview URL) instead
+# of the locally-served build.
+
+on:
+  pull_request:
+    types: [opened, ready_for_review, reopened]
+
+env:
+  NODE_VERSION: "20"
+  # Placeholder env — NOT real credentials — so the app boots for measurement.
+  NEXT_PUBLIC_SUPABASE_URL: "https://placeholder.supabase.co"
+  NEXT_PUBLIC_SUPABASE_ANON_KEY: "placeholder-anon-key"
+  SUPABASE_SERVICE_ROLE_KEY: "placeholder-service-role-key"
+  NEXT_PUBLIC_SANITY_PROJECT_ID: "placeholder"
+  NEXT_PUBLIC_SANITY_DATASET: "production"
+  NEXT_PUBLIC_SOLANA_RPC_URL: "https://api.devnet.solana.com"
+  NEXT_PUBLIC_SOLANA_NETWORK: "devnet"
+  NEXT_PUBLIC_PROGRAM_ID: "7NeJaSRyb4Wxay3Tcd9bdpD7T3GWYUQSFyrhG8SgwE8V"
+
+jobs:
+  lighthouse:
+    name: Lighthouse (report-only)
+    runs-on: ubuntu-latest
+    if: github.event.action != 'labeled'
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build web app
+        # RATCHET: report-only (see header). Building with placeholder env may
+        # fail on statically-prerendered data fetches until env/preview is wired.
+        continue-on-error: true
+        run: pnpm --filter @superteam-lms/web build
+
+      - name: Lighthouse CI
+        # RATCHET: report-only — flip to a hard gate (remove continue-on-error)
+        # once all four thresholds pass.
+        continue-on-error: true
+        run: pnpm dlx @lhci/cli@0.14 autorun

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -16,7 +16,9 @@ name: Lighthouse
 
 on:
   pull_request:
-    types: [opened, ready_for_review, reopened]
+    # Include synchronize so every pushed commit is retested — otherwise only the
+    # first commit is ever checked (critical once this becomes a hard gate).
+    types: [opened, synchronize, ready_for_review, reopened]
 
 env:
   NODE_VERSION: "20"
@@ -34,7 +36,6 @@ jobs:
   lighthouse:
     name: Lighthouse (report-only)
     runs-on: ubuntu-latest
-    if: github.event.action != 'labeled'
     steps:
       - uses: actions/checkout@v4
 
@@ -58,4 +59,4 @@ jobs:
         # RATCHET: report-only — flip to a hard gate (remove continue-on-error)
         # once all four thresholds pass.
         continue-on-error: true
-        run: pnpm dlx @lhci/cli@0.14 autorun
+        run: pnpm dlx @lhci/cli@0.14.0 autorun

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -1,0 +1,24 @@
+{
+  "ci": {
+    "collect": {
+      "startServerCommand": "pnpm --filter @superteam-lms/web start",
+      "startServerReadyPattern": "Ready in",
+      "startServerReadyTimeout": 120000,
+      "url": [
+        "http://localhost:3000/en",
+        "http://localhost:3000/en/courses",
+        "http://localhost:3000/en/leaderboard"
+      ],
+      "numberOfRuns": 3
+    },
+    "assert": {
+      "assertions": {
+        "categories:performance": ["error", { "minScore": 0.9 }],
+        "categories:accessibility": ["error", { "minScore": 0.95 }],
+        "categories:best-practices": ["error", { "minScore": 0.95 }],
+        "categories:seo": ["error", { "minScore": 0.9 }]
+      }
+    },
+    "upload": { "target": "temporary-public-storage" }
+  }
+}


### PR DESCRIPTION
## G-6 — Frontend Lighthouse gate

Closes #143

Operationalizes the gate as a CI check that asserts the four targets, so "done when Lighthouse meets all four thresholds" becomes measurable + enforceable.

### What's added
- **`lighthouserc.json`** — asserts the targets on the public routes (`/en`, `/en/courses`, `/en/leaderboard`), 3 runs each:
  - Performance ≥ 0.90, Accessibility ≥ 0.95, Best Practices ≥ 0.95, SEO ≥ 0.90
- **`.github/workflows/lighthouse.yml`** — on PRs: install → build web → `@lhci/cli autorun` (results uploaded to temporary-public-storage for viewing).

### Report-only ratchet (matches the repo's prettier/clippy/audit pattern)
The build + Lighthouse steps are `continue-on-error`, so this **never blocks required checks** while the setup is validated and scores are brought to target. Flip them off (remove `continue-on-error`) to make G-6 a hard gate once a run is green.

### Honest caveats (I could not run Lighthouse from here — no browser/app/env)
- It serves the app with **placeholder env** (P0-C2 env validation throws otherwise), so data-fetching pages degrade to fallback/empty states — **scores are indicative, not production-accurate**. The `next build` step may even fail on statically-prerendered Sanity fetches with placeholder creds (hence build is also report-only).
- For **production-accurate** scores, the better long-term setup is to point Lighthouse at a real **preview deployment** (e.g. the Vercel preview URL) instead of the locally-served build. I can switch the workflow to that if you'd prefer — it needs the preview URL wired in.
- **Performance ≥ 90** is the most likely to fall short for a wallet-adapter-heavy Next app; the first CI run will show real numbers and where the gaps are.

### Next step
Merge (safe — report-only), watch the first Lighthouse run in Actions, then we either harden to a hard gate (if green) or open targeted fix PRs for whatever audits fail.
