### PR TITLE
feat(challenge): server-side validation for non-JS (Rust function) challenges (#197)

### DIFF
--- a/apps/web/src/app/api/lessons/complete/route.ts
+++ b/apps/web/src/app/api/lessons/complete/route.ts
@@ -124,15 +124,18 @@ export async function POST(request: NextRequest) {
             { status: 503 }
           );
         case "non_js_challenge":
-          // FAIL CLOSED. Rust / buildable challenges must be graded by the Rust
-          // playground / build server (a separate trust boundary), but that
-          // validation handshake is NOT wired up yet. Until it is, the server
-          // cannot prove the submission is correct, so it MUST NOT submit the
-          // on-chain completeLesson — a bare fall-through here would grant a
-          // completion (and credential eligibility) for any unverified
-          // Rust/buildable submission. Deny exactly like executor_unavailable.
-          // TODO(#195 follow-up): wire a real Rust/build-server validation
-          // handshake, then gate this branch on its passing verdict.
+          // FAIL CLOSED. Reaches here ONLY for `buildType: "buildable"` (Anchor)
+          // challenges: the Cloud Run build server is compile-only and cannot
+          // run a submission against the hidden tests, so there is no
+          // non-forgeable way to prove correctness (grading "it compiled" as
+          // "passed" would be forgeable). A bare fall-through would grant a
+          // completion (and credential eligibility) for any compiling Anchor
+          // submission. Deny exactly like executor_unavailable. Rust *function*
+          // challenges are now graded by the Rust executor (validate.ts) and
+          // return `validated`, so they no longer land here.
+          // TODO(#197 follow-up): a build-server "run tests against submission"
+          // endpoint (or #196-style microservice) would let buildable be graded
+          // non-forgeably; gate this branch on its passing verdict then.
           return NextResponse.json(
             {
               error:

--- a/apps/web/src/lib/challenge/__tests__/executor.test.ts
+++ b/apps/web/src/lib/challenge/__tests__/executor.test.ts
@@ -256,18 +256,115 @@ describe("validateAgainstAnswerKey (classification, no isolate)", () => {
     expect(verdict.kind).toBe("not_a_challenge");
   });
 
-  it("classifies rust / buildable challenges as non_js_challenge", async () => {
-    const rust = await validateAgainstAnswerKey(
-      answerKey({ language: "rust" }),
-      "fn add() {}"
-    );
-    expect(rust.kind).toBe("non_js_challenge");
-
+  it("classifies BUILDABLE (Anchor) challenges as non_js_challenge (deny — compile-only substrate)", async () => {
     const buildable = await validateAgainstAnswerKey(
       answerKey({ buildType: "buildable" }),
       "// program"
     );
     expect(buildable.kind).toBe("non_js_challenge");
+
+    // Buildable wins even when language is rust — there is still no
+    // run-against-tests substrate for it.
+    const buildableRust = await validateAgainstAnswerKey(
+      answerKey({ language: "rust", buildType: "buildable" }),
+      "// program"
+    );
+    expect(buildableRust.kind).toBe("non_js_challenge");
+  });
+});
+
+// Rust function challenges are now graded by the Rust executor (Rust Playground).
+// The executor module is MOCKED so these are deterministic and never touch the
+// network — they prove validate.ts ROUTES rust away from the JS isolate, maps a
+// passing/failing run to validated, and degrades closed on substrate failure.
+describe("validateAgainstAnswerKey — rust routing (rust-executor mocked)", () => {
+  afterEach(() => {
+    vi.resetModules();
+    vi.restoreAllMocks();
+  });
+
+  async function importWithRust(
+    run: () => Promise<unknown>,
+    available = true
+  ): Promise<typeof import("../validate")> {
+    vi.resetModules();
+    vi.doMock("@/lib/challenge/rust-executor", () => ({
+      isRustExecutorAvailable: vi.fn().mockResolvedValue(available),
+      runRustSubmission: vi.fn(run),
+    }));
+    // The JS executor must NOT be consulted for a rust challenge — make it throw
+    // if it ever is, so a routing regression fails loudly.
+    vi.doMock("@/lib/challenge/executor", () => ({
+      isExecutorAvailable: vi.fn(async () => {
+        throw new Error("JS executor must not run for a rust challenge");
+      }),
+      runJsSubmission: vi.fn(async () => {
+        throw new Error("JS executor must not run for a rust challenge");
+      }),
+    }));
+    return import("../validate");
+  }
+
+  it("routes rust → runRustSubmission and returns validated+passed", async () => {
+    const { validateAgainstAnswerKey: validate } = await importWithRust(
+      async () => ({
+        available: true,
+        passed: true,
+        results: [
+          { id: "visible-1", hidden: false, passed: true, detail: "pass" },
+          { id: "hidden-1", hidden: true, passed: true, detail: "pass" },
+        ],
+      })
+    );
+    const verdict = await validate(
+      answerKey({ language: "rust" }),
+      "fn add(a:i32,b:i32)->i32{a+b}"
+    );
+    expect(verdict.kind).toBe("validated");
+    if (verdict.kind !== "validated") return;
+    expect(verdict.passed).toBe(true);
+    expect(verdict.hiddenTestCount).toBe(1);
+    expect(verdict.visibleTestCount).toBe(1);
+  });
+
+  it("returns validated+!passed when the rust run fails the hidden test (gate would 403)", async () => {
+    const { validateAgainstAnswerKey: validate } = await importWithRust(
+      async () => ({
+        available: true,
+        passed: false,
+        results: [
+          { id: "visible-1", hidden: false, passed: true, detail: "pass" },
+          { id: "hidden-1", hidden: true, passed: false, detail: "got 200" },
+        ],
+      })
+    );
+    const verdict = await validate(
+      answerKey({ language: "rust" }),
+      "fn add(){}"
+    );
+    expect(verdict.kind).toBe("validated");
+    if (verdict.kind !== "validated") return;
+    expect(verdict.passed).toBe(false);
+  });
+
+  it("degrades CLOSED: rust substrate unavailable ⇒ executor_unavailable, not a pass", async () => {
+    const { validateAgainstAnswerKey: validate } = await importWithRust(
+      async () => {
+        throw new Error("runRustSubmission must not run when unavailable");
+      },
+      false // isRustExecutorAvailable → false
+    );
+    const verdict = await validate(answerKey({ language: "rust" }), CORRECT);
+    expect(verdict.kind).toBe("executor_unavailable");
+    expect("passed" in verdict).toBe(false);
+  });
+
+  it("degrades CLOSED: rust run reports available:false ⇒ executor_unavailable", async () => {
+    const { validateAgainstAnswerKey: validate } = await importWithRust(
+      async () => ({ available: false, reason: "executor_unavailable" })
+    );
+    const verdict = await validate(answerKey({ language: "rust" }), CORRECT);
+    expect(verdict.kind).toBe("executor_unavailable");
   });
 });
 

--- a/apps/web/src/lib/challenge/__tests__/rust-executor.test.ts
+++ b/apps/web/src/lib/challenge/__tests__/rust-executor.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { AdminTestCase } from "@superteam-lms/types";
+import { isRustExecutorAvailable, runRustSubmission } from "../rust-executor";
+
+/**
+ * These tests never reach the real Rust Playground. The substrate is mocked at
+ * `globalThis.fetch`, and the per-run marker nonce is pinned, so we can assert
+ * the exact harness/grading behaviour deterministically:
+ *
+ *   - a submission passes ONLY when the SERVER observes every nonce-tagged PASS
+ *     marker in real stdout (server-authoritative, non-forgeable),
+ *   - HIDDEN tests are injected into the harness and gate the verdict,
+ *   - a submission cannot forge a pass by println!-ing a marker (unpredictable
+ *     nonce), and
+ *   - any substrate failure degrades CLOSED (`available: false` ⇒ deny).
+ */
+
+// runRustSubmission derives its marker nonce as `crypto.randomUUID()` with
+// dashes stripped. We pin the UUID below; FIXED_NONCE is that UUID dash-stripped,
+// i.e. exactly what the grader scans for.
+const FIXED_UUID =
+  "deadbeef-cafe-babe-0000-000000000000" as `${string}-${string}-${string}-${string}-${string}`;
+const FIXED_NONCE = FIXED_UUID.replace(/-/g, "");
+
+const sumTests: AdminTestCase[] = [
+  {
+    id: "visible-1",
+    description: "adds 2 and 3",
+    input: "2, 3",
+    expectedOutput: "5",
+  },
+  {
+    id: "hidden-1",
+    description: "adds 10 and 20 (hidden)",
+    input: "10, 20",
+    expectedOutput: "30",
+    hidden: true,
+  },
+];
+
+const CORRECT = "fn add(a: i32, b: i32) -> i32 { a + b }";
+
+/**
+ * Stand in for the Rust Playground. Compiles+runs the harness "for real" by
+ * emitting the PASS/FAIL markers a correctly-graded run would produce, given a
+ * map of test index → did the submission satisfy it. The marker text is keyed by
+ * the pinned nonce so it matches what the grader scans for.
+ */
+function playgroundOk(markerLines: string): Response {
+  return {
+    ok: true,
+    json: async () => ({
+      success: true,
+      stdout: markerLines,
+      stderr: "",
+    }),
+  } as unknown as Response;
+}
+
+function mockFetchOnce(impl: () => Response | Promise<Response>): void {
+  vi.spyOn(globalThis, "fetch").mockImplementation(async () => await impl());
+}
+
+beforeEach(() => {
+  // Pin the nonce so the test's mock stdout matches the grader's markers.
+  vi.spyOn(globalThis.crypto, "randomUUID").mockReturnValue(FIXED_UUID);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("isRustExecutorAvailable", () => {
+  it("is available when the playground URL is configured (default)", async () => {
+    expect(await isRustExecutorAvailable()).toBe(true);
+  });
+});
+
+describe("runRustSubmission — grading from real output", () => {
+  it("passes a correct submission against ALL tests (visible + hidden)", async () => {
+    mockFetchOnce(() =>
+      playgroundOk(`TEST_${FIXED_NONCE}_0_PASS\nTEST_${FIXED_NONCE}_1_PASS\n`)
+    );
+
+    const run = await runRustSubmission(CORRECT, sumTests);
+    expect(run.available).toBe(true);
+    if (!run.available) return;
+    expect(run.passed).toBe(true);
+    // The hidden test was actually graded.
+    expect(run.results.find((r) => r.id === "hidden-1")?.passed).toBe(true);
+    expect(run.results.find((r) => r.id === "hidden-1")?.hidden).toBe(true);
+  });
+
+  it("HIDDEN TEST GATES COMPLETION: visible passes, hidden fails ⇒ overall not passed", async () => {
+    // Mirrors a submission that satisfies the visible test but not the hidden one.
+    mockFetchOnce(() =>
+      playgroundOk(
+        `TEST_${FIXED_NONCE}_0_PASS\nTEST_${FIXED_NONCE}_1_FAIL: expected 30, got 200\n`
+      )
+    );
+
+    const run = await runRustSubmission(CORRECT, sumTests);
+    expect(run.available).toBe(true);
+    if (!run.available) return;
+    expect(run.results.find((r) => r.id === "visible-1")?.passed).toBe(true);
+    expect(run.results.find((r) => r.id === "hidden-1")?.passed).toBe(false);
+    expect(run.passed).toBe(false);
+  });
+
+  it("rejects a submission that fails to compile (no markers in stdout)", async () => {
+    // Compilation failure ⇒ success may even be false, stdout has no markers.
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        success: false,
+        stdout: "",
+        stderr: "error[E0308]: mismatched types",
+      }),
+    } as unknown as Response);
+
+    const run = await runRustSubmission('fn add() -> i32 { "nope" }', sumTests);
+    expect(run.available).toBe(true);
+    if (!run.available) return;
+    expect(run.passed).toBe(false);
+    expect(run.results.every((r) => !r.passed)).toBe(true);
+  });
+
+  it("FORGED PASS IS BLOCKED: a submission cannot println! a passing marker it can't predict", async () => {
+    // The submission prints a marker with a GUESSED nonce ("aaaa"), but the
+    // server's real nonce is FIXED_NONCE. Even though the forged line is in
+    // stdout, it does not match the grader's pattern, so the test stays failed.
+    mockFetchOnce(() =>
+      playgroundOk(
+        // forged (wrong nonce) + the real FAIL the harness actually produced
+        `TEST_aaaa_0_PASS\nTEST_aaaa_1_PASS\n` +
+          `TEST_${FIXED_NONCE}_0_FAIL: expected 5, got 6\n` +
+          `TEST_${FIXED_NONCE}_1_FAIL: expected 30, got 60\n`
+      )
+    );
+
+    const run = await runRustSubmission(
+      "fn add(a: i32, b: i32) -> i32 { a + b + 1 }",
+      sumTests
+    );
+    expect(run.available).toBe(true);
+    if (!run.available) return;
+    expect(run.passed).toBe(false);
+    expect(run.results.every((r) => !r.passed)).toBe(true);
+  });
+
+  it("fails every test when no gradable top-level function is found", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const run = await runRustSubmission("// just a comment", sumTests);
+    expect(run.available).toBe(true);
+    if (!run.available) return;
+    expect(run.passed).toBe(false);
+    // Never even called the substrate — nothing gradable to run.
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("treats an empty test set as a non-pass (nothing the server can prove)", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const run = await runRustSubmission(CORRECT, []);
+    expect(run.available).toBe(true);
+    if (!run.available) return;
+    expect(run.passed).toBe(false);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("runRustSubmission — degrade closed", () => {
+  it("returns available:false when the substrate is unreachable (network error)", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("ECONNREFUSED"));
+    const run = await runRustSubmission(CORRECT, sumTests);
+    expect(run.available).toBe(false);
+  });
+
+  it("returns available:false on a non-2xx from the substrate", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: false,
+      status: 502,
+      json: async () => ({}),
+    } as unknown as Response);
+    const run = await runRustSubmission(CORRECT, sumTests);
+    expect(run.available).toBe(false);
+  });
+
+  it("returns available:false on a malformed substrate response", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => {
+        throw new Error("not json");
+      },
+    } as unknown as Response);
+    const run = await runRustSubmission(CORRECT, sumTests);
+    expect(run.available).toBe(false);
+  });
+});

--- a/apps/web/src/lib/challenge/rust-executor.ts
+++ b/apps/web/src/lib/challenge/rust-executor.ts
@@ -1,0 +1,299 @@
+/**
+ * Server-side, non-forgeable executor for untrusted learner RUST submissions.
+ *
+ * SECURITY BOUNDARY
+ * -----------------
+ * This is the Rust analog of {@link "./executor".runJsSubmission}. The JS path
+ * runs submissions in an in-process V8 isolate; Rust cannot be sandboxed
+ * in-process, so the execution substrate is the **Rust Playground**
+ * (`play.rust-lang.org/execute`), called SERVER-TO-SERVER. The Playground
+ * compiles the submission and runs its `main()`, returning real stdout/stderr.
+ * Untrusted Rust therefore executes ONLY inside the Playground's own sandbox,
+ * never on our server.
+ *
+ * NON-FORGEABLE GRADING
+ * ---------------------
+ * The server synthesises a test harness around the learner's code (mirroring the
+ * browser runner's `buildRustTestHarness`, so a submission that passes the
+ * visible tests in-browser is judged identically), then grades by scanning the
+ * REAL compiler stdout for per-test PASS/FAIL markers. Two properties make a
+ * forged pass impossible:
+ *
+ *   1. The HIDDEN tests (their `input`/`expectedOutput`) live only in the
+ *      server-held answer key and are injected into the harness here — they
+ *      never reach the browser, so the client cannot know what to satisfy.
+ *   2. Each run's markers are tagged with an UNPREDICTABLE per-run nonce
+ *      (`TEST_<nonce>_<i>_PASS`). A submission cannot pre-`println!` a passing
+ *      marker because it cannot guess the nonce. The browser harness omits this
+ *      (it is non-authoritative UX); the server MUST have it.
+ *
+ * DEGRADE-CLOSED
+ * --------------
+ * Any substrate failure — Playground unreachable, non-2xx, timeout, malformed
+ * response, or a code shape we cannot build a harness for — returns
+ * `available: false`. Callers MUST treat that as a non-pass and DENY completion
+ * (it maps to HTTP 503 in the completion gate). A submission is graded as passed
+ * ONLY when the server itself observed every test's PASS marker in real output.
+ */
+
+import type { AdminTestCase } from "@superteam-lms/types";
+import type { ServerTestResult, SubmissionRunResult } from "./executor";
+
+/** Upper bound on submission size we are willing to compile/run. */
+const MAX_CODE_BYTES = 100_000;
+
+/**
+ * Wall-clock budget for the Playground round trip. The Playground itself caps
+ * compile+run; this guards against a hung connection. On trip we degrade closed.
+ */
+const UPSTREAM_TIMEOUT_MS = 30_000;
+
+const RUST_PLAYGROUND_URL =
+  process.env.RUST_PLAYGROUND_URL ?? "https://play.rust-lang.org/execute";
+
+/** Strip ANSI colour codes the compiler emits, mirroring the browser runner. */
+// eslint-disable-next-line no-control-regex
+const ANSI_REGEX = /\x1b\[[0-9;]*m/g;
+function stripAnsi(str: string): string {
+  return str.replace(ANSI_REGEX, "");
+}
+
+interface RustPlaygroundPayload {
+  channel: "stable" | "beta" | "nightly";
+  mode: "debug" | "release";
+  edition: "2015" | "2018" | "2021";
+  crateType: "bin" | "lib";
+  tests: boolean;
+  backtrace: boolean;
+  code: string;
+}
+
+interface RustPlaygroundResponse {
+  success: boolean;
+  stdout: string;
+  stderr: string;
+}
+
+/**
+ * Build a Rust program that exercises the learner's function against every test
+ * and prints a NONCE-tagged PASS/FAIL marker per test. Faithful server port of
+ * `buildRustTestHarness` in `components/editor/challenge-runner.tsx`, with the
+ * marker nonce added so a submission cannot forge a passing line.
+ *
+ * Returns `null` when no gradable top-level function is found (or the only one
+ * is `main`) — the caller treats that as a non-pass for every test rather than
+ * silently compiling the submission as-is.
+ */
+function buildRustTestHarness(
+  userCode: string,
+  tests: AdminTestCase[],
+  nonce: string
+): string | null {
+  // Match top-level fn declarations (start of line, no indentation). This skips
+  // methods inside impl blocks, which are always indented.
+  const topLevelFns = [...userCode.matchAll(/^fn\s+(\w+)\s*\(/gm)];
+  const lastMatch = topLevelFns[topLevelFns.length - 1];
+  const fnName = lastMatch?.[1] ?? null;
+
+  if (!fnName || fnName === "main") {
+    return null;
+  }
+
+  const testCalls = tests.map((tc, index) => {
+    const args = tc.input.trim();
+    const expected = tc.expectedOutput.trim();
+
+    if (expected.includes("__result__")) {
+      // Capture debug repr before the test expression, which may move __result__.
+      return `
+    let __result__ = ${fnName}(${args});
+    let __dbg__ = format!("{:?}", &__result__);
+    if ${expected} {
+        println!("TEST_${nonce}_${index}_PASS");
+    } else {
+        println!("TEST_${nonce}_${index}_FAIL: got {}", __dbg__);
+    }`;
+    }
+
+    return `
+    let __result__ = ${fnName}(${args});
+    let __expected__ = ${expected};
+    if __result__ == __expected__ {
+        println!("TEST_${nonce}_${index}_PASS");
+    } else {
+        println!("TEST_${nonce}_${index}_FAIL: expected {:?}, got {:?}", __expected__, __result__);
+    }`;
+  });
+
+  const codeWithoutMain = userCode.replace(
+    /fn\s+main\s*\(\s*\)\s*\{[\s\S]*?\n\}/,
+    ""
+  );
+
+  return `${codeWithoutMain}
+
+fn main() {
+${testCalls.join("\n")}
+}`;
+}
+
+/**
+ * Grade Playground output. A test passes ONLY when its nonce-tagged PASS marker
+ * is present in real stdout. Missing marker (e.g. compilation failed, or the
+ * submission panicked before reaching it) is a FAIL. Mirrors
+ * `parseRustTestResults` but keyed by the per-run nonce.
+ */
+function gradeFromOutput(
+  stdout: string,
+  tests: AdminTestCase[],
+  nonce: string
+): ServerTestResult[] {
+  const cleanStdout = stripAnsi(stdout);
+  return tests.map((tc, index) => {
+    const passPattern = `TEST_${nonce}_${index}_PASS`;
+    const failPattern = new RegExp(`TEST_${nonce}_${index}_FAIL:?\\s*(.*)`);
+    const hidden = tc.hidden === true;
+
+    if (cleanStdout.includes(passPattern)) {
+      return { id: tc.id, hidden, passed: true, detail: "pass" };
+    }
+
+    const failMatch = cleanStdout.match(failPattern);
+    if (failMatch) {
+      return {
+        id: tc.id,
+        hidden,
+        passed: false,
+        detail: (failMatch[1]?.trim() || "assertion failed").slice(0, 200),
+      };
+    }
+
+    return {
+      id: tc.id,
+      hidden,
+      passed: false,
+      detail: "no result (compilation failed or panicked)",
+    };
+  });
+}
+
+/** Build the result that fails every test with a shared detail. */
+function failAll(
+  tests: AdminTestCase[],
+  detail: string
+): Extract<SubmissionRunResult, { available: true }> {
+  return {
+    available: true,
+    passed: false,
+    results: tests.map((t) => ({
+      id: t.id,
+      hidden: t.hidden === true,
+      passed: false,
+      detail,
+    })),
+  };
+}
+
+/**
+ * Whether the Rust execution substrate is reachable in this environment.
+ *
+ * Unlike the JS executor (a native addon that is either loadable or not), the
+ * Rust substrate is a remote HTTP service whose reachability is only known by
+ * actually calling it. To preserve fail-closed semantics WITHOUT a probe on
+ * every keystroke, this returns false only when the substrate is structurally
+ * impossible to reach — i.e. the upstream URL is empty/unset. The real
+ * unreachable/timeout cases surface as `available: false` from
+ * {@link runRustSubmission}, which callers already treat as deny.
+ */
+export async function isRustExecutorAvailable(): Promise<boolean> {
+  return RUST_PLAYGROUND_URL.trim().length > 0;
+}
+
+/**
+ * Run a Rust function-challenge submission against every supplied test via the
+ * Rust Playground, server-to-server.
+ *
+ * Contract (identical to {@link "./executor".runJsSubmission}): returns
+ * `{ available: false }` when the substrate could not run — callers MUST deny
+ * completion in that case. When available, `passed` is true only if EVERY test
+ * (visible + hidden) passed, judged from real compiler stdout.
+ */
+export async function runRustSubmission(
+  code: string,
+  tests: AdminTestCase[]
+): Promise<SubmissionRunResult> {
+  if (RUST_PLAYGROUND_URL.trim().length === 0) {
+    return { available: false, reason: "executor_unavailable" };
+  }
+
+  if (Buffer.byteLength(code, "utf8") > MAX_CODE_BYTES) {
+    return failAll(tests, "Submission too large");
+  }
+
+  // No tests to grade ⇒ nothing the server can prove. Treat as a non-pass.
+  if (tests.length === 0) {
+    return { available: true, passed: false, results: [] };
+  }
+
+  // Per-run nonce: an unpredictable token a submission cannot pre-print to forge
+  // a passing marker. Alphanumeric only so it is a safe Rust identifier fragment.
+  const nonce = globalThis.crypto.randomUUID().replace(/-/g, "");
+
+  const harness = buildRustTestHarness(code, tests, nonce);
+  if (harness === null) {
+    return failAll(tests, "No gradable function found in submission");
+  }
+
+  const payload: RustPlaygroundPayload = {
+    channel: "stable",
+    mode: "debug",
+    edition: "2021",
+    crateType: "bin",
+    // The harness provides its own main(); compile+run as a binary (NOT the
+    // #[test] runner) so our println! markers reach stdout.
+    tests: false,
+    backtrace: false,
+    code: harness,
+  };
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), UPSTREAM_TIMEOUT_MS);
+
+  let upstream: Response;
+  try {
+    upstream = await fetch(RUST_PLAYGROUND_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+      signal: controller.signal,
+    });
+  } catch {
+    // Network error or timeout abort ⇒ degrade closed (deny completion).
+    return { available: false, reason: "executor_unavailable" };
+  } finally {
+    clearTimeout(timeout);
+  }
+
+  if (!upstream.ok) {
+    // The substrate is up but errored (5xx/4xx). We cannot prove the submission
+    // passed ⇒ degrade closed rather than guess.
+    return { available: false, reason: "executor_unavailable" };
+  }
+
+  let result: RustPlaygroundResponse;
+  try {
+    result = (await upstream.json()) as RustPlaygroundResponse;
+  } catch {
+    return { available: false, reason: "executor_unavailable" };
+  }
+
+  // A failed COMPILATION is a legitimate non-pass of the submission (not a
+  // substrate outage): no PASS markers will be present, so every test fails.
+  const results = gradeFromOutput(result.stdout ?? "", tests, nonce);
+
+  return {
+    available: true,
+    passed: results.length > 0 && results.every((r) => r.passed),
+    results,
+  };
+}

--- a/apps/web/src/lib/challenge/validate.ts
+++ b/apps/web/src/lib/challenge/validate.ts
@@ -4,8 +4,10 @@
  * Single source of truth used by BOTH `/api/lessons/validate-challenge` (UX
  * pre-check) and `/api/lessons/complete` (the authoritative completion gate).
  * Loads the answer key server-side (hidden tests + reference solution never
- * reach the browser) and runs the submission through the secure isolate
- * executor.
+ * reach the browser) and runs the submission through the appropriate secure
+ * executor: the in-process V8 isolate for JS/TS, or the Rust executor (Rust
+ * Playground, server-to-server) for rust function challenges. `buildable`
+ * (Anchor) challenges have no non-forgeable substrate and fail closed.
  */
 
 import type { ChallengeAnswerKey } from "@/lib/sanity/queries";
@@ -14,6 +16,10 @@ import {
   runJsSubmission,
   type ServerTestResult,
 } from "@/lib/challenge/executor";
+import {
+  isRustExecutorAvailable,
+  runRustSubmission,
+} from "@/lib/challenge/rust-executor";
 
 export type ChallengeVerdict =
   | {
@@ -26,9 +32,16 @@ export type ChallengeVerdict =
     }
   | {
       /**
-       * Lesson is a challenge, but its correctness is established elsewhere
-       * (Rust playground / build server) rather than by the JS executor. The
-       * completion gate must decide policy for these explicitly.
+       * Lesson is a challenge whose correctness CANNOT be established
+       * non-forgeably with the substrates we have. In practice this is the
+       * `buildType: "buildable"` (Anchor) path: the Cloud Run build server is
+       * compile-only — it can prove a submission compiles, but has no
+       * run-the-submission-against-hidden-tests capability, so grading "it
+       * compiled" as "passed" would be forgeable test validation. The
+       * completion gate MUST treat this as deny (fail closed) until a real
+       * grading substrate exists (a build-server test endpoint / #196-style
+       * microservice). Rust *function* challenges do NOT land here — they are
+       * graded by the Rust executor and return `validated`.
        */
       kind: "non_js_challenge";
       language: string | null;
@@ -63,21 +76,42 @@ function countTests(key: ChallengeAnswerKey): {
 }
 
 /**
- * A JS/TS code challenge is one we can execute and grade server-side. Rust
- * (`language: "rust"`) and buildable challenges are compiled by the Rust
- * playground / build server respectively and are out of scope for the JS
- * isolate executor.
+ * A `buildable` (Anchor) challenge is compiled by the Cloud Run build server,
+ * which is COMPILE-ONLY — it cannot run a submission against tests. We therefore
+ * cannot grade it non-forgeably and must fail closed (see the `non_js_challenge`
+ * verdict). This takes precedence over the language check: a buildable challenge
+ * is buildable even if `language === "rust"`.
  */
-function isJsExecutableChallenge(key: ChallengeAnswerKey): boolean {
-  if (key.type !== "challenge") return false;
-  if (key.buildType === "buildable") return false;
-  // Treat anything that isn't explicitly rust as JS/TS (matches the browser
-  // runner, which only routes language === "rust" away from the JS worker).
-  return key.language !== "rust";
+function isBuildableChallenge(key: ChallengeAnswerKey): boolean {
+  return key.type === "challenge" && key.buildType === "buildable";
+}
+
+/**
+ * A Rust *function* challenge: `language === "rust"` and NOT buildable. Graded
+ * server-side by compiling + running the submission via the Rust executor
+ * (Rust Playground), mirroring the browser runner's rust path. Everything that
+ * is neither buildable nor rust is treated as JS/TS and graded by the isolate
+ * executor (matches the browser runner, which only routes `language === "rust"`
+ * away from the JS worker).
+ */
+function isRustExecutableChallenge(key: ChallengeAnswerKey): boolean {
+  return (
+    key.type === "challenge" &&
+    key.buildType !== "buildable" &&
+    key.language === "rust"
+  );
 }
 
 /**
  * Validate a submission against the answer key. Pure logic — no auth, no HTTP.
+ *
+ * Routing:
+ *   - buildable (Anchor)  → `non_js_challenge` (deny; substrate is compile-only)
+ *   - rust function       → graded by the Rust executor (Rust Playground)
+ *   - everything else     → graded by the JS isolate executor
+ *
+ * Both executable paths degrade closed: an unavailable/erroring substrate yields
+ * `executor_unavailable` (a non-pass), never a silent pass.
  */
 export async function validateAgainstAnswerKey(
   key: ChallengeAnswerKey,
@@ -88,8 +122,15 @@ export async function validateAgainstAnswerKey(
   }
 
   const { hidden, visible } = countTests(key);
+  const unavailable: ChallengeVerdict = {
+    kind: "executor_unavailable",
+    hiddenTestCount: hidden,
+    visibleTestCount: visible,
+  };
 
-  if (!isJsExecutableChallenge(key)) {
+  // Buildable (Anchor) challenges have no non-forgeable grading substrate — the
+  // build server is compile-only. Fail closed (deny) until one exists.
+  if (isBuildableChallenge(key)) {
     return {
       kind: "non_js_challenge",
       language: key.language,
@@ -99,21 +140,23 @@ export async function validateAgainstAnswerKey(
     };
   }
 
-  if (!(await isExecutorAvailable())) {
-    return {
-      kind: "executor_unavailable",
-      hiddenTestCount: hidden,
-      visibleTestCount: visible,
-    };
+  // Pick the substrate. Rust function challenges compile+run via the Rust
+  // executor; all other challenges run in the JS isolate. Each runner shares the
+  // same availability/result contract (SubmissionRunResult).
+  const rust = isRustExecutableChallenge(key);
+
+  if (
+    rust ? !(await isRustExecutorAvailable()) : !(await isExecutorAvailable())
+  ) {
+    return unavailable;
   }
 
-  const run = await runJsSubmission(submittedCode, key.tests ?? []);
+  const run = rust
+    ? await runRustSubmission(submittedCode, key.tests ?? [])
+    : await runJsSubmission(submittedCode, key.tests ?? []);
+
   if (!run.available) {
-    return {
-      kind: "executor_unavailable",
-      hiddenTestCount: hidden,
-      visibleTestCount: visible,
-    };
+    return unavailable;
   }
 
   return {


### PR DESCRIPTION
## Summary
Implements non-forgeable, server-side validation for **Rust function** challenges, so they can be completed (previously the `non_js_challenge` path fail-closed with 503 — #195 HOLE 2). Mirrors the JS isolate executor's contract with a new `runRustSubmission`.

## Design
- **New `apps/web/src/lib/challenge/rust-executor.ts`** — `runRustSubmission(code, tests)`, the Rust analog of `runJsSubmission`. Untrusted Rust cannot be sandboxed in-process, so it executes **server-to-server in the Rust Playground sandbox** (`play.rust-lang.org/execute`), never on our server.
- **`validate.ts` routing**: `buildable` (Anchor) → `non_js_challenge` (still fail-closed); `language === "rust"` && !buildable → graded by the Rust executor → `validated`; everything else → JS isolate. Both executable paths degrade closed (`executor_unavailable` → 503), never a silent pass.

## Why this is non-forgeable
1. **Per-run nonce**: the server synthesises a test harness emitting `TEST_<nonce>_<i>_PASS` markers with an unpredictable per-run nonce, and grades by scanning the **real** Playground stdout. A submission cannot pre-`println!` a passing marker because it cannot guess the nonce.
2. **Hidden tests stay server-side**: hidden `input`/`expectedOutput` are injected into the harness here; they never reach the browser.
3. **Degrade-closed**: Playground unreachable / non-2xx / timeout / malformed / no gradable function ⇒ `available: false` ⇒ deny. `passed` is true only if the server observed every test's PASS marker.

## Scope — partially addresses #197
- ✅ **Rust function challenges** — fully implemented + graded non-forgeably.
- ⏸️ **`buildable` (Anchor) challenges** — intentionally still fail-closed. The Cloud Run build server is **compile-only**; grading "it compiled" as "passed" would be forgeable. Deferred until a build-server "run tests against submission" endpoint exists (overlaps #196). The route + verdict comments document this precisely.

## Tests
`apps/web/src/lib/challenge/__tests__/rust-executor.test.ts` (10) + extended `executor.test.ts` — pass, fail, fail-closed-on-unavailable/timeout/non-2xx, hidden-test gating, nonce anti-forgery. Local: typecheck clean, 33 challenge tests green.

Partially addresses #197 (Rust-function path). Buildable/Anchor validation tracked as follow-up.