### PR TITLE
ci(onchain): de-flake anchor-localnet via test validator startup_wait

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,8 +237,15 @@ jobs:
       - name: Anchor test (localnet)
         # Override the cluster to localnet so anchor test runs against the local
         # validator it spins up (the tests airdrop heavily, which only works on
-        # localnet) instead of Anchor.toml's devnet default.
-        run: anchor test --provider.cluster localnet
+        # localnet) instead of Anchor.toml's devnet default. On failure, dump the
+        # test-validator log so a validator crash (vs. slow startup) is visible.
+        run: |
+          anchor test --provider.cluster localnet || {
+            echo "::group::test-ledger-log.txt"
+            cat .anchor/test-ledger/test-ledger-log.txt 2>/dev/null || echo "(no test-ledger-log found)"
+            echo "::endgroup::"
+            exit 1
+          }
         working-directory: onchain-academy
 
   # ── Verifiable build + program-hash publishing (P1-4, feeds G-3) ────────────

--- a/onchain-academy/Anchor.toml
+++ b/onchain-academy/Anchor.toml
@@ -24,6 +24,12 @@ url = "https://api.apr.dev"
 cluster = "devnet"
 wallet = "../wallets/signer.json"
 
+# CI runners are slow to bring the test validator up (esp. with the mpl_core
+# genesis program); the default 5s wait is too short -> "validator does not look
+# started". Give it generous headroom.
+[test]
+startup_wait = 60000
+
 [test.validator]
 bind_address = "127.0.0.1"
 


### PR DESCRIPTION
## De-flake `anchor-localnet` — bump validator `startup_wait`

Closes #217

P1-10 (#126) enabled `anchor test` on a local validator, but the job **flakes**: on slower runners the test validator misses Anchor's default 5s startup window and the run fails with *"Test validator does not look started… Consider increasing [test.startup_wait]."* Faster runners pass — pure timing flake.

This `startup_wait` bump is the missing reliability tail of P1-10/#126 (and the P1-13/#209 pnpm work). It was committed to the #211 branch **after** #211 was squash-merged, so it never reached `main` and got orphaned — this PR lands it cleanly on its own branch (cherry-picked off current `main`, so the diff is *only* the two files below).

### Changes
- **`onchain-academy/Anchor.toml`** — `[test] startup_wait = 60000` (generous headroom for the mpl_core genesis on cold CI runners).
- **`.github/workflows/ci.yml`** — on `anchor test` failure, dump `.anchor/test-ledger/test-ledger-log.txt` (grouped) so a genuine validator crash is distinguishable from slow startup.

### Verification
This exact change ran green on the #211 branch (`anchor-localnet` job `success`, 5m53s) before it was orphaned. Net diff vs `main` is 2 files / +15 −2.

`Anchor.toml` is in @thomgabriel's ownership zone.
