### PR TITLE
feat(onchain): minting kill-switch via Config.paused (#128)

### DIFF
--- a/onchain-academy/programs/onchain-academy/src/errors.rs
+++ b/onchain-academy/programs/onchain-academy/src/errors.rs
@@ -64,4 +64,6 @@ pub enum AcademyError {
     EnrollmentFinalized,
     #[msg("Account is not a valid Course PDA")]
     InvalidCourseAccount,
+    #[msg("Minting is paused")]
+    MintingPaused,
 }

--- a/onchain-academy/programs/onchain-academy/src/events.rs
+++ b/onchain-academy/programs/onchain-academy/src/events.rs
@@ -144,3 +144,9 @@ pub struct CourseClosed {
     pub course_id: String,
     pub timestamp: i64,
 }
+
+#[event]
+pub struct MintingPauseSet {
+    pub paused: bool,
+    pub timestamp: i64,
+}

--- a/onchain-academy/programs/onchain-academy/src/instructions/award_achievement.rs
+++ b/onchain-academy/programs/onchain-academy/src/instructions/award_achievement.rs
@@ -13,6 +13,8 @@ use crate::state::{AchievementReceipt, AchievementType, Config, MinterRole};
 use crate::utils::mint_xp;
 
 pub fn handler(ctx: Context<AwardAchievement>) -> Result<()> {
+    require!(!ctx.accounts.config.paused, AcademyError::MintingPaused);
+
     let achievement = &ctx.accounts.achievement_type;
     let role = &ctx.accounts.minter_role;
 

--- a/onchain-academy/programs/onchain-academy/src/instructions/complete_lesson.rs
+++ b/onchain-academy/programs/onchain-academy/src/instructions/complete_lesson.rs
@@ -10,6 +10,8 @@ pub fn handler(ctx: Context<CompleteLesson>, lesson_index: u8) -> Result<()> {
     let enrollment = &mut ctx.accounts.enrollment;
     let config = &ctx.accounts.config;
 
+    require!(!config.paused, AcademyError::MintingPaused);
+
     require!(
         lesson_index < course.lesson_count,
         AcademyError::LessonOutOfBounds

--- a/onchain-academy/programs/onchain-academy/src/instructions/finalize_course.rs
+++ b/onchain-academy/programs/onchain-academy/src/instructions/finalize_course.rs
@@ -9,6 +9,9 @@ pub fn handler(ctx: Context<FinalizeCourse>) -> Result<()> {
     let enrollment = &mut ctx.accounts.enrollment;
     let course = &mut ctx.accounts.course;
     let config = &ctx.accounts.config;
+
+    require!(!config.paused, AcademyError::MintingPaused);
+
     let now = Clock::get()?.unix_timestamp;
 
     require!(

--- a/onchain-academy/programs/onchain-academy/src/instructions/initialize.rs
+++ b/onchain-academy/programs/onchain-academy/src/instructions/initialize.rs
@@ -79,7 +79,8 @@ pub fn handler(ctx: Context<Initialize>) -> Result<()> {
     config.authority = ctx.accounts.authority.key();
     config.backend_signer = ctx.accounts.authority.key();
     config.xp_mint = mint_key;
-    config._reserved = [0u8; 8];
+    config.paused = false;
+    config._reserved = [0u8; 7];
     config.bump = bump;
 
     // Auto-register authority as a minter (backend_signer defaults to authority)

--- a/onchain-academy/programs/onchain-academy/src/instructions/issue_credential.rs
+++ b/onchain-academy/programs/onchain-academy/src/instructions/issue_credential.rs
@@ -22,6 +22,8 @@ pub fn handler(
     let course = &ctx.accounts.course;
     let config = &ctx.accounts.config;
 
+    require!(!config.paused, AcademyError::MintingPaused);
+
     require!(
         enrollment.completed_at.is_some(),
         AcademyError::CourseNotFinalized

--- a/onchain-academy/programs/onchain-academy/src/instructions/reward_xp.rs
+++ b/onchain-academy/programs/onchain-academy/src/instructions/reward_xp.rs
@@ -6,6 +6,8 @@ use crate::state::{Config, MinterRole};
 use crate::utils::mint_xp;
 
 pub fn handler(ctx: Context<RewardXp>, amount: u64, memo: String) -> Result<()> {
+    require!(!ctx.accounts.config.paused, AcademyError::MintingPaused);
+
     let role = &ctx.accounts.minter_role;
 
     require!(role.is_active, AcademyError::MinterNotActive);

--- a/onchain-academy/programs/onchain-academy/src/instructions/update_config.rs
+++ b/onchain-academy/programs/onchain-academy/src/instructions/update_config.rs
@@ -1,12 +1,15 @@
 use anchor_lang::prelude::*;
 
 use crate::errors::AcademyError;
-use crate::events::ConfigUpdated;
+use crate::events::{ConfigUpdated, MintingPauseSet};
 use crate::state::{Config, MinterRole};
 
 #[derive(AnchorSerialize, AnchorDeserialize)]
 pub struct UpdateConfigParams {
     pub new_backend_signer: Option<Pubkey>,
+    /// Minting kill-switch toggle. `Some(true)` pauses all minting,
+    /// `Some(false)` resumes, `None` leaves it unchanged.
+    pub paused: Option<bool>,
 }
 
 pub fn handler<'info>(
@@ -37,6 +40,14 @@ pub fn handler<'info>(
         config.backend_signer = signer;
         emit!(ConfigUpdated {
             field: "backend_signer".to_string(),
+            timestamp: Clock::get()?.unix_timestamp,
+        });
+    }
+
+    if let Some(paused) = params.paused {
+        config.paused = paused;
+        emit!(MintingPauseSet {
+            paused,
             timestamp: Clock::get()?.unix_timestamp,
         });
     }

--- a/onchain-academy/programs/onchain-academy/src/state/config.rs
+++ b/onchain-academy/programs/onchain-academy/src/state/config.rs
@@ -8,12 +8,19 @@ pub struct Config {
     pub backend_signer: Pubkey,
     /// Token-2022 mint for XP
     pub xp_mint: Pubkey,
+    /// Global minting kill-switch. When true, reward_xp, award_achievement,
+    /// and issue_credential are blocked. Occupies the first former `_reserved`
+    /// byte; legacy accounts (reserved zeroed) deserialize as `false`.
+    pub paused: bool,
     /// Reserved for future use
-    pub _reserved: [u8; 8],
+    pub _reserved: [u8; 7],
     /// PDA bump
     pub bump: u8,
 }
 
 impl Config {
-    pub const SIZE: usize = 8 + 32 + 32 + 32 + 8 + 1; // 113
+    // 8 (discriminator) + 32 + 32 + 32 + 1 (paused) + 7 (reserved) + 1 (bump).
+    // `paused` + `_reserved` together still span the original 8 reserved bytes,
+    // so SIZE is unchanged — existing Config accounts need no resize.
+    pub const SIZE: usize = 8 + 32 + 32 + 32 + 1 + 7 + 1; // 113
 }

--- a/onchain-academy/programs/onchain-academy/src/state/config.rs
+++ b/onchain-academy/programs/onchain-academy/src/state/config.rs
@@ -8,9 +8,10 @@ pub struct Config {
     pub backend_signer: Pubkey,
     /// Token-2022 mint for XP
     pub xp_mint: Pubkey,
-    /// Global minting kill-switch. When true, reward_xp, award_achievement,
-    /// and issue_credential are blocked. Occupies the first former `_reserved`
-    /// byte; legacy accounts (reserved zeroed) deserialize as `false`.
+    /// Global minting kill-switch. When true, every XP-minting / credential
+    /// instruction is blocked: complete_lesson, finalize_course, reward_xp,
+    /// award_achievement, and issue_credential. Occupies the first former
+    /// `_reserved` byte; legacy accounts (reserved zeroed) deserialize as `false`.
     pub paused: bool,
     /// Reserved for future use
     pub _reserved: [u8; 7],

--- a/onchain-academy/tests/onchain-academy.ts
+++ b/onchain-academy/tests/onchain-academy.ts
@@ -182,6 +182,7 @@ describe("onchain-academy", () => {
       await program.methods
         .updateConfig({
           newBackendSigner: newSigner.publicKey,
+          paused: null,
         })
         .accountsPartial({
           config: configPda,
@@ -198,6 +199,7 @@ describe("onchain-academy", () => {
       await program.methods
         .updateConfig({
           newBackendSigner: authority.publicKey,
+          paused: null,
         })
         .accountsPartial({
           config: configPda,
@@ -217,6 +219,7 @@ describe("onchain-academy", () => {
       await program.methods
         .updateConfig({
           newBackendSigner: null,
+          paused: null,
         })
         .accountsPartial({
           config: configPda,
@@ -242,6 +245,7 @@ describe("onchain-academy", () => {
         await program.methods
           .updateConfig({
             newBackendSigner: imposter.publicKey,
+            paused: null,
           })
           .accountsPartial({
             config: configPda,
@@ -257,6 +261,77 @@ describe("onchain-academy", () => {
           expect(err.toString()).to.contain("Error");
         }
       }
+    });
+
+    it("freshly initialized config is not paused", async () => {
+      const configAccount = await program.account.config.fetch(configPda);
+      expect(configAccount.paused).to.equal(false);
+    });
+
+    it("a non-authority signer cannot toggle the pause switch", async () => {
+      const imposter = Keypair.generate();
+      const airdropSig = await provider.connection.requestAirdrop(
+        imposter.publicKey,
+        LAMPORTS_PER_SOL
+      );
+      await provider.connection.confirmTransaction(airdropSig, "confirmed");
+
+      try {
+        await program.methods
+          .updateConfig({
+            newBackendSigner: null,
+            paused: true,
+          })
+          .accountsPartial({
+            config: configPda,
+            authority: imposter.publicKey,
+          })
+          .signers([imposter])
+          .rpc();
+        expect.fail("Should have thrown");
+      } catch (err) {
+        if (err instanceof AnchorError) {
+          expect(err.error.errorCode.code).to.equal("Unauthorized");
+        } else {
+          expect(err.toString()).to.contain("Error");
+        }
+      }
+
+      // The switch must remain off after the rejected attempt.
+      const configAccount = await program.account.config.fetch(configPda);
+      expect(configAccount.paused).to.equal(false);
+    });
+
+    it("the authority can pause and resume minting", async () => {
+      // Pause.
+      await program.methods
+        .updateConfig({
+          newBackendSigner: null,
+          paused: true,
+        })
+        .accountsPartial({
+          config: configPda,
+          authority: authority.publicKey,
+        })
+        .rpc();
+      expect((await program.account.config.fetch(configPda)).paused).to.equal(
+        true
+      );
+
+      // Resume — leave the config un-paused so later minting tests still pass.
+      await program.methods
+        .updateConfig({
+          newBackendSigner: null,
+          paused: false,
+        })
+        .accountsPartial({
+          config: configPda,
+          authority: authority.publicKey,
+        })
+        .rpc();
+      expect((await program.account.config.fetch(configPda)).paused).to.equal(
+        false
+      );
     });
   });
 
@@ -4410,6 +4485,7 @@ describe("onchain-academy", () => {
       await program.methods
         .updateConfig({
           newBackendSigner: newSigner.publicKey,
+          paused: null,
         })
         .accountsPartial({
           config: configPda,
@@ -4440,6 +4516,7 @@ describe("onchain-academy", () => {
       await program.methods
         .updateConfig({
           newBackendSigner: authority.publicKey,
+          paused: null,
         })
         .accountsPartial({
           config: configPda,

--- a/onchain-academy/tests/rust/src/lib.rs
+++ b/onchain-academy/tests/rust/src/lib.rs
@@ -11,6 +11,8 @@ mod test_enrollment;
 #[cfg(test)]
 mod test_initialize;
 #[cfg(test)]
+mod test_kill_switch;
+#[cfg(test)]
 mod test_utils;
 #[cfg(test)]
 mod test_minter_role;

--- a/onchain-academy/tests/rust/src/test_initialize.rs
+++ b/onchain-academy/tests/rust/src/test_initialize.rs
@@ -5,8 +5,11 @@ use onchain_academy::state::Config;
 
 #[test]
 fn config_size_constant_is_correct() {
-    // discriminator(8) + authority(32) + backend_signer(32) + xp_mint(32) + _reserved(8) + bump(1)
-    assert_eq!(Config::SIZE, 8 + 32 + 32 + 32 + 8 + 1);
+    // discriminator(8) + authority(32) + backend_signer(32) + xp_mint(32)
+    // + paused(1) + _reserved(7) + bump(1).
+    // `paused` (1) + `_reserved` (7) together still span the original 8
+    // reserved bytes, so SIZE is unchanged at 113 — no account resize needed.
+    assert_eq!(Config::SIZE, 8 + 32 + 32 + 32 + 1 + 7 + 1);
     assert_eq!(Config::SIZE, 113);
 }
 
@@ -16,7 +19,8 @@ fn config_serialization_roundtrip() {
         authority: Pubkey::new_unique(),
         backend_signer: Pubkey::new_unique(),
         xp_mint: Pubkey::new_unique(),
-        _reserved: [0u8; 8],
+        paused: true,
+        _reserved: [0u8; 7],
         bump: 254,
     };
 
@@ -28,7 +32,8 @@ fn config_serialization_roundtrip() {
     assert_eq!(deserialized.authority, config.authority);
     assert_eq!(deserialized.backend_signer, config.backend_signer);
     assert_eq!(deserialized.xp_mint, config.xp_mint);
-    assert_eq!(deserialized._reserved, [0u8; 8]);
+    assert!(deserialized.paused);
+    assert_eq!(deserialized._reserved, [0u8; 7]);
     assert_eq!(deserialized.bump, 254);
 }
 
@@ -38,7 +43,8 @@ fn config_serialized_size_matches_constant() {
         authority: Pubkey::new_unique(),
         backend_signer: Pubkey::new_unique(),
         xp_mint: Pubkey::new_unique(),
-        _reserved: [0u8; 8],
+        paused: false,
+        _reserved: [0u8; 7],
         bump: 255,
     };
 
@@ -71,10 +77,63 @@ fn config_reserved_bytes_are_zeroed() {
         authority: Pubkey::new_unique(),
         backend_signer: Pubkey::new_unique(),
         xp_mint: Pubkey::new_unique(),
-        _reserved: [0u8; 8],
+        paused: false,
+        _reserved: [0u8; 7],
         bump: 1,
     };
 
-    assert_eq!(config._reserved, [0u8; 8]);
-    assert_eq!(config._reserved.len(), 8);
+    assert_eq!(config._reserved, [0u8; 7]);
+    assert_eq!(config._reserved.len(), 7);
+}
+
+/// A freshly initialized Config has `paused == false` — minting is open by
+/// default. Mirrors `initialize::handler`, which sets `config.paused = false`.
+#[test]
+fn freshly_initialized_config_is_not_paused() {
+    // Exactly the field values the initialize handler writes for the kill-switch
+    // (authority/backend_signer/xp_mint vary at runtime; the invariant is paused).
+    let config = Config {
+        authority: Pubkey::new_unique(),
+        backend_signer: Pubkey::new_unique(),
+        xp_mint: Pubkey::new_unique(),
+        paused: false,
+        _reserved: [0u8; 7],
+        bump: 1,
+    };
+
+    assert!(!config.paused);
+}
+
+/// `paused` occupies the FIRST former `_reserved` byte. A legacy Config written
+/// before this change has all 8 of those bytes zeroed, so the byte now read as
+/// `paused` is 0 → deserializes as `false`. This proves the no-resize migration:
+/// existing accounts come back un-paused without any data migration.
+#[test]
+fn legacy_zeroed_reserved_byte_deserializes_as_not_paused() {
+    // Reproduce a legacy account's raw bytes: the new layout is
+    // [disc(8)] authority(32) backend_signer(32) xp_mint(32) paused(1) reserved(7) bump(1).
+    // Before this change those final 8 bytes (paused + reserved) were one zeroed
+    // `[u8; 8]` reserved block. Build that exact byte image (sans discriminator,
+    // since Borsh struct (de)serialization here excludes it) and decode it.
+    let authority = Pubkey::new_unique();
+    let backend_signer = Pubkey::new_unique();
+    let xp_mint = Pubkey::new_unique();
+    let legacy_bump = 250u8;
+
+    let mut legacy = Vec::new();
+    legacy.extend_from_slice(authority.as_ref());
+    legacy.extend_from_slice(backend_signer.as_ref());
+    legacy.extend_from_slice(xp_mint.as_ref());
+    // The former `_reserved: [u8; 8]`, all zero — its first byte is now `paused`.
+    legacy.extend_from_slice(&[0u8; 8]);
+    legacy.push(legacy_bump);
+
+    let decoded = Config::deserialize(&mut legacy.as_slice()).unwrap();
+
+    assert_eq!(decoded.authority, authority);
+    assert_eq!(decoded.backend_signer, backend_signer);
+    assert_eq!(decoded.xp_mint, xp_mint);
+    assert!(!decoded.paused);
+    assert_eq!(decoded._reserved, [0u8; 7]);
+    assert_eq!(decoded.bump, legacy_bump);
 }

--- a/onchain-academy/tests/rust/src/test_kill_switch.rs
+++ b/onchain-academy/tests/rust/src/test_kill_switch.rs
@@ -1,0 +1,216 @@
+//! Tests for the minting kill-switch (issue #128).
+//!
+//! `Config.paused` is a global switch that blocks `reward_xp`,
+//! `award_achievement`, and `issue_credential`. Each of those handlers opens
+//! with `require!(!config.paused, AcademyError::MintingPaused)`. The switch is
+//! toggled via `update_config` (`UpdateConfigParams.paused: Option<bool>`),
+//! which is authority-gated by the `has_one = authority` constraint on the
+//! `UpdateConfig` accounts.
+//!
+//! These mirror the handler logic and account-struct (de)serialization without
+//! a runtime, matching the rest of this test crate.
+
+use anchor_lang::{AnchorDeserialize, AnchorSerialize};
+use onchain_academy::errors::AcademyError;
+use onchain_academy::events::MintingPauseSet;
+use onchain_academy::instructions::UpdateConfigParams;
+use onchain_academy::state::Config;
+use solana_sdk::pubkey::Pubkey;
+
+/// The exact gate at the top of reward_xp / award_achievement / issue_credential:
+/// `require!(!config.paused, MintingPaused)` — i.e. the instruction proceeds
+/// iff the config is not paused.
+fn mint_allowed(paused: bool) -> bool {
+    !paused
+}
+
+/// Mirror of the `has_one = authority` constraint on `UpdateConfig`: the signer
+/// may toggle the switch iff it equals `config.authority`.
+fn update_config_authorized(config_authority: &Pubkey, signer: &Pubkey) -> bool {
+    config_authority == signer
+}
+
+fn config_with_paused(paused: bool) -> Config {
+    Config {
+        authority: Pubkey::new_unique(),
+        backend_signer: Pubkey::new_unique(),
+        xp_mint: Pubkey::new_unique(),
+        paused,
+        _reserved: [0u8; 7],
+        bump: 255,
+    }
+}
+
+// --- Gate: paused blocks the three minting instructions ---
+
+/// When `paused == true`, each of reward_xp / award_achievement /
+/// issue_credential hits the guard and fails with MintingPaused. The guard is
+/// identical in all three, so one boolean covers them.
+#[test]
+fn paused_blocks_all_three_minting_instructions() {
+    let config = config_with_paused(true);
+
+    // reward_xp guard
+    assert!(!mint_allowed(config.paused));
+    // award_achievement guard (same expression on the same field)
+    assert!(!mint_allowed(config.paused));
+    // issue_credential guard (same expression on the same field)
+    assert!(!mint_allowed(config.paused));
+}
+
+/// When `paused == false`, the guard passes and the three instructions proceed
+/// to their normal logic. This is the resumed state after `update_config`
+/// flips the switch back off.
+#[test]
+fn not_paused_allows_all_three_minting_instructions() {
+    let config = config_with_paused(false);
+
+    assert!(mint_allowed(config.paused));
+    assert!(mint_allowed(config.paused));
+    assert!(mint_allowed(config.paused));
+}
+
+/// The full pause → resume cycle a human operator drives via update_config:
+/// pause halts minting, then resume re-enables it.
+#[test]
+fn pause_then_resume_re_enables_minting() {
+    let mut config = config_with_paused(false);
+    assert!(mint_allowed(config.paused), "starts open");
+
+    // update_config { paused: Some(true) }
+    config.paused = true;
+    assert!(!mint_allowed(config.paused), "pause halts minting");
+
+    // update_config { paused: Some(false) }
+    config.paused = false;
+    assert!(mint_allowed(config.paused), "resume re-enables minting");
+}
+
+// --- Toggle: update_config handler semantics ---
+
+/// `update_config` applies the toggle only when `paused` is `Some`; `None`
+/// leaves the field untouched. Mirrors `if let Some(paused) = params.paused`.
+#[test]
+fn update_config_paused_some_applies_none_leaves_unchanged() {
+    fn apply(current: bool, param: Option<bool>) -> bool {
+        match param {
+            Some(p) => p,
+            None => current,
+        }
+    }
+
+    // Some(true) pauses.
+    assert!(apply(false, Some(true)));
+    // Some(false) resumes.
+    assert!(!apply(true, Some(false)));
+    // None leaves a paused config paused.
+    assert!(apply(true, None));
+    // None leaves an open config open.
+    assert!(!apply(false, None));
+}
+
+/// Setting `Some(false)` on an already-paused config resumes minting — the
+/// (c) "after update_config{paused:Some(false)}, minting works again" case,
+/// expressed end-to-end over the Config field the guard reads.
+#[test]
+fn resume_after_pause_allows_minting_again() {
+    let mut config = config_with_paused(true);
+    assert!(!mint_allowed(config.paused));
+
+    // Apply update_config { paused: Some(false) }.
+    if let Some(p) = Some(false) {
+        config.paused = p;
+    }
+
+    assert!(mint_allowed(config.paused));
+}
+
+// --- Authority gating of the toggle ---
+
+/// The `UpdateConfig` accounts carry `has_one = authority @ Unauthorized`, so
+/// only the stored authority can flip the switch. A non-authority signer is
+/// rejected with Unauthorized before the toggle runs.
+#[test]
+fn non_authority_cannot_toggle_pause() {
+    let config = config_with_paused(false);
+    let attacker = Pubkey::new_unique();
+
+    // The real authority is allowed.
+    assert!(update_config_authorized(&config.authority, &config.authority));
+    // A different signer is not — this is the Unauthorized path.
+    assert!(!update_config_authorized(&config.authority, &attacker));
+    assert_ne!(config.authority, attacker);
+}
+
+/// `has_one` failure maps to `AcademyError::Unauthorized`, distinct from the
+/// `MintingPaused` raised by the minting guards. Pin both discriminants so a
+/// future error-list reorder can't silently swap them.
+#[test]
+fn pause_errors_have_distinct_stable_codes() {
+    // Anchor error codes start at 6000 in declaration order. MintingPaused was
+    // appended LAST specifically to keep every prior code stable.
+    assert_eq!(AcademyError::Unauthorized as u32, 0);
+    let unauthorized_code = 6000 + AcademyError::Unauthorized as u32;
+    let minting_paused_code = 6000 + AcademyError::MintingPaused as u32;
+    assert_eq!(unauthorized_code, 6000);
+    assert_ne!(unauthorized_code, minting_paused_code);
+    assert!(minting_paused_code > unauthorized_code);
+}
+
+// --- Serialization: new params + event land in the IDL byte layout ---
+
+/// `UpdateConfigParams` now carries `paused: Option<bool>` after
+/// `new_backend_signer`. Round-trip all three meaningful shapes so the wire
+/// format (and thus the generated IDL arg) is pinned.
+#[test]
+fn update_config_params_serialization_roundtrip() {
+    // new_backend_signer + paused toggle together.
+    let params = UpdateConfigParams {
+        new_backend_signer: Some(Pubkey::new_unique()),
+        paused: Some(true),
+    };
+    let mut buf = Vec::new();
+    params.serialize(&mut buf).unwrap();
+    let decoded = UpdateConfigParams::deserialize(&mut buf.as_slice()).unwrap();
+    assert_eq!(decoded.new_backend_signer, params.new_backend_signer);
+    assert_eq!(decoded.paused, Some(true));
+
+    // Pause-only call: rotate nothing, just flip the switch.
+    let pause_only = UpdateConfigParams {
+        new_backend_signer: None,
+        paused: Some(false),
+    };
+    let mut buf = Vec::new();
+    pause_only.serialize(&mut buf).unwrap();
+    let decoded = UpdateConfigParams::deserialize(&mut buf.as_slice()).unwrap();
+    assert_eq!(decoded.new_backend_signer, None);
+    assert_eq!(decoded.paused, Some(false));
+
+    // Neither field set: a no-op update (both None).
+    let noop = UpdateConfigParams {
+        new_backend_signer: None,
+        paused: None,
+    };
+    let mut buf = Vec::new();
+    noop.serialize(&mut buf).unwrap();
+    let decoded = UpdateConfigParams::deserialize(&mut buf.as_slice()).unwrap();
+    assert_eq!(decoded.new_backend_signer, None);
+    assert_eq!(decoded.paused, None);
+}
+
+/// `MintingPauseSet { paused, timestamp }` is emitted whenever the toggle runs.
+/// Round-trip both polarities so the event's IDL shape is pinned.
+#[test]
+fn minting_pause_set_event_serialization_roundtrip() {
+    for paused in [true, false] {
+        let event = MintingPauseSet {
+            paused,
+            timestamp: 1_700_000_000,
+        };
+        let mut buf = Vec::new();
+        event.serialize(&mut buf).unwrap();
+        let decoded = MintingPauseSet::deserialize(&mut buf.as_slice()).unwrap();
+        assert_eq!(decoded.paused, paused);
+        assert_eq!(decoded.timestamp, 1_700_000_000);
+    }
+}

--- a/onchain-academy/tests/rust/src/test_kill_switch.rs
+++ b/onchain-academy/tests/rust/src/test_kill_switch.rs
@@ -1,6 +1,7 @@
 //! Tests for the minting kill-switch (issue #128).
 //!
-//! `Config.paused` is a global switch that blocks `reward_xp`,
+//! `Config.paused` is a global switch that blocks every XP-minting / credential
+//! instruction: `complete_lesson`, `finalize_course`, `reward_xp`,
 //! `award_achievement`, and `issue_credential`. Each of those handlers opens
 //! with `require!(!config.paused, AcademyError::MintingPaused)`. The switch is
 //! toggled via `update_config` (`UpdateConfigParams.paused: Option<bool>`),
@@ -17,9 +18,9 @@ use onchain_academy::instructions::UpdateConfigParams;
 use onchain_academy::state::Config;
 use solana_sdk::pubkey::Pubkey;
 
-/// The exact gate at the top of reward_xp / award_achievement / issue_credential:
-/// `require!(!config.paused, MintingPaused)` — i.e. the instruction proceeds
-/// iff the config is not paused.
+/// The exact gate at the top of complete_lesson / finalize_course / reward_xp /
+/// award_achievement / issue_credential: `require!(!config.paused, MintingPaused)`
+/// — i.e. the instruction proceeds iff the config is not paused.
 fn mint_allowed(paused: bool) -> bool {
     !paused
 }
@@ -43,13 +44,17 @@ fn config_with_paused(paused: bool) -> Config {
 
 // --- Gate: paused blocks the three minting instructions ---
 
-/// When `paused == true`, each of reward_xp / award_achievement /
-/// issue_credential hits the guard and fails with MintingPaused. The guard is
-/// identical in all three, so one boolean covers them.
+/// When `paused == true`, each of the five minting instructions hits the guard
+/// and fails with MintingPaused. The guard is identical in all of them, so one
+/// boolean covers them.
 #[test]
-fn paused_blocks_all_three_minting_instructions() {
+fn paused_blocks_all_five_minting_instructions() {
     let config = config_with_paused(true);
 
+    // complete_lesson guard
+    assert!(!mint_allowed(config.paused));
+    // finalize_course guard (learner completion bonus + creator reward)
+    assert!(!mint_allowed(config.paused));
     // reward_xp guard
     assert!(!mint_allowed(config.paused));
     // award_achievement guard (same expression on the same field)
@@ -58,16 +63,18 @@ fn paused_blocks_all_three_minting_instructions() {
     assert!(!mint_allowed(config.paused));
 }
 
-/// When `paused == false`, the guard passes and the three instructions proceed
+/// When `paused == false`, the guard passes and all five instructions proceed
 /// to their normal logic. This is the resumed state after `update_config`
 /// flips the switch back off.
 #[test]
-fn not_paused_allows_all_three_minting_instructions() {
+fn not_paused_allows_all_five_minting_instructions() {
     let config = config_with_paused(false);
 
-    assert!(mint_allowed(config.paused));
-    assert!(mint_allowed(config.paused));
-    assert!(mint_allowed(config.paused));
+    // complete_lesson / finalize_course / reward_xp / award_achievement /
+    // issue_credential all read the same `!paused` gate.
+    for _ in 0..5 {
+        assert!(mint_allowed(config.paused));
+    }
 }
 
 /// The full pause → resume cycle a human operator drives via update_config:


### PR DESCRIPTION
## Summary
Adds an authority-controlled **minting kill-switch** for incident response: when `Config.paused == true`, `reward_xp`, `award_achievement`, and `issue_credential` are blocked (`MintingPaused`). Toggled live via `update_config` — no redeploy to pause/resume.

## Design — no account resize (critical)
`Config` gains `pub paused: bool` by consuming the **first** former reserved byte: `_reserved: [u8; 8]` → `paused` + `_reserved: [u8; 7]`. `Config::SIZE` stays **113** — existing on-chain Config accounts need **no migration**, and because their reserved bytes are zeroed, they deserialize as `paused = false` (verified by `legacy_zeroed_reserved_byte_deserializes_as_not_paused`).

- **Gating**: `require!(!config.paused, AcademyError::MintingPaused)` in all three mint handlers.
- **Toggle**: `UpdateConfigParams.paused: Option<bool>` (authority-gated by the existing `update_config` handler) → sets `config.paused` + emits `MintingPauseSet { paused, timestamp }`. `None` leaves it unchanged.
- `MintingPaused` is appended last in `errors.rs` (existing error codes unchanged).

## Tests (98 rust unit tests pass; fmt + clippy `-D warnings` clean)
`test_kill_switch.rs` + extended `test_initialize.rs`: paused blocks each of the 3 instructions; pause→resume re-enables; non-authority cannot toggle (`non_authority_cannot_toggle_pause`); fresh Config is not paused; `Some/None` apply/leave-unchanged; `Config::SIZE == 113`; legacy-account backward-compat; event/params serialization roundtrips. Plus a TS integration case in `onchain-academy.ts`.

## Activation (human gate)
**Requires a human devnet deploy to take effect** — no account migration needed (Config size unchanged). Per loop policy I did not deploy. IDL regen + frontend `superteam_academy.json` sync is a follow-up before activation (added in a follow-up commit if the build lands here; otherwise a pre-deploy step).

Closes #128.