### PR TITLE
chore(hooks): drop hanging cargo test --lib from pre-commit hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -96,7 +96,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "set -e\n\necho \"Running pre-commit checks...\"\n\nif [ -f \"Anchor.toml\" ] || grep -q \"solana-program\" Cargo.toml 2>/dev/null; then\n  cargo fmt --check || { cargo fmt; exit 1; }\n  cargo clippy --all-targets -- -D warnings || exit 1\n  cargo test --lib || exit 1\nfi\n\nif [ -f \"package.json\" ]; then\n  if [ -d \"apps/web\" ]; then\n    cd apps/web && npx --package typescript tsc --noEmit && cd ../..\n  elif [ -f \"tsconfig.json\" ]; then\n    npx --package typescript tsc --noEmit\n  fi\nfi\n\necho \"Pre-commit checks passed\""
+            "command": "set -e\n\necho \"Running pre-commit checks...\"\n\nif [ -f \"Anchor.toml\" ] || grep -q \"solana-program\" Cargo.toml 2>/dev/null; then\n  cargo fmt --check || { cargo fmt; exit 1; }\n  cargo clippy --all-targets -- -D warnings || exit 1\nfi\n\nif [ -f \"package.json\" ]; then\n  if [ -d \"apps/web\" ]; then\n    cd apps/web && npx --package typescript tsc --noEmit && cd ../..\n  elif [ -f \"tsconfig.json\" ]; then\n    npx --package typescript tsc --noEmit\n  fi\nfi\n\necho \"Pre-commit checks passed\""
           }
         ]
       },


### PR DESCRIPTION
## Problem
The `git commit` pre-commit hook (`.claude/settings.json`) ran `cargo test --lib` against the **onchain-academy program crate**, which has **no lib unit tests** — they live in `onchain-academy/tests/rust` (a separate workspace). That step hangs (and deadlocks badly under build-lock contention, e.g. while an `anchor build` holds the cargo lock), which blocks onchain commits.

## Fix
Drop the `cargo test --lib` line. Keep the fast, useful checks (`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `tsc --noEmit`). The real tests run in CI and via `cargo test --manifest-path onchain-academy/tests/rust/Cargo.toml`.

One-line change. Verified locally — commits now run the hook to completion without hanging.