### PR TITLE
fix(web): force-dynamic on cookie/auth API GET routes (Vercel build)

### DIFF
--- a/apps/web/src/app/api/admin/status/route.ts
+++ b/apps/web/src/app/api/admin/status/route.ts
@@ -27,6 +27,9 @@ import {
   getMissingAchievementFields,
 } from "@/lib/admin/sync-diff";
 
+// Auth/cookie + per-request DB access — never statically prerender (DYNAMIC_SERVER_USAGE).
+export const dynamic = "force-dynamic";
+
 export async function GET(req: NextRequest): Promise<NextResponse> {
   try {
     requireAdminAuth(req);

--- a/apps/web/src/app/api/auth/callback/route.ts
+++ b/apps/web/src/app/api/auth/callback/route.ts
@@ -25,6 +25,9 @@ function sanitizeRedirect(raw: string, fallback: string): string {
   }
 }
 
+// Auth/cookie + per-request DB access — never statically prerender (DYNAMIC_SERVER_USAGE).
+export const dynamic = "force-dynamic";
+
 export async function GET(request: NextRequest) {
   const requestUrl = new URL(request.url);
   const code = requestUrl.searchParams.get("code");

--- a/apps/web/src/app/api/auth/nonce/route.ts
+++ b/apps/web/src/app/api/auth/nonce/route.ts
@@ -7,6 +7,9 @@ import { ERROR_IDS } from "@/constants/errorIds";
 const NONCE_TTL_MS = 5 * 60 * 1000; // 5 minutes
 const MAX_PENDING_PER_IP = 10;
 
+// Auth/cookie + per-request DB access — never statically prerender (DYNAMIC_SERVER_USAGE).
+export const dynamic = "force-dynamic";
+
 export async function GET(request: NextRequest) {
   try {
     if (

--- a/apps/web/src/app/api/certificates/metadata/route.ts
+++ b/apps/web/src/app/api/certificates/metadata/route.ts
@@ -10,6 +10,9 @@ const CACHE_HEADERS = {
  *
  * `?id=<uuid>` — reads metadata from the `nft_metadata` table
  */
+// Auth/cookie + per-request DB access — never statically prerender (DYNAMIC_SERVER_USAGE).
+export const dynamic = "force-dynamic";
+
 export async function GET(request: NextRequest) {
   const id = request.nextUrl.searchParams.get("id");
 

--- a/apps/web/src/app/api/community/search/route.ts
+++ b/apps/web/src/app/api/community/search/route.ts
@@ -1,6 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 
+// Auth/cookie + per-request DB access — never statically prerender (DYNAMIC_SERVER_USAGE).
+export const dynamic = "force-dynamic";
+
 export async function GET(request: NextRequest) {
   try {
     const { searchParams } = new URL(request.url);

--- a/apps/web/src/app/api/community/threads/[id]/route.ts
+++ b/apps/web/src/app/api/community/threads/[id]/route.ts
@@ -3,6 +3,9 @@ import { createClient } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { logError } from "@/lib/logging";
 
+// Auth/cookie + per-request DB access — never statically prerender (DYNAMIC_SERVER_USAGE).
+export const dynamic = "force-dynamic";
+
 export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }

--- a/apps/web/src/app/api/community/threads/route.ts
+++ b/apps/web/src/app/api/community/threads/route.ts
@@ -5,6 +5,9 @@ import { createAdminClient } from "@/lib/supabase/admin";
 import { checkCommunityAchievements } from "@/lib/gamification/achievements";
 import { isRateLimited } from "@/lib/rate-limit";
 
+// Auth/cookie + per-request DB access — never statically prerender (DYNAMIC_SERVER_USAGE).
+export const dynamic = "force-dynamic";
+
 export async function GET(request: NextRequest) {
   try {
     const { searchParams } = new URL(request.url);

--- a/apps/web/src/app/api/deploy/[uuid]/route.ts
+++ b/apps/web/src/app/api/deploy/[uuid]/route.ts
@@ -24,6 +24,9 @@ function serveBinary(binary: ArrayBuffer): NextResponse {
  * successful builds) to avoid Cloud Run instance routing misses.
  * Falls back to proxying directly to the build server if not cached.
  */
+// Auth/cookie + per-request DB access — never statically prerender (DYNAMIC_SERVER_USAGE).
+export const dynamic = "force-dynamic";
+
 export async function GET(
   _request: NextRequest,
   { params }: { params: Promise<{ uuid: string }> }

--- a/apps/web/src/app/api/deploy/save/route.ts
+++ b/apps/web/src/app/api/deploy/save/route.ts
@@ -7,6 +7,9 @@ interface SaveDeployRequest {
   programId: string;
 }
 
+// Auth/cookie + per-request DB access — never statically prerender (DYNAMIC_SERVER_USAGE).
+export const dynamic = "force-dynamic";
+
 export async function POST(request: NextRequest) {
   try {
     const supabase = await createClient();

--- a/apps/web/src/app/api/leaderboard/route.ts
+++ b/apps/web/src/app/api/leaderboard/route.ts
@@ -4,6 +4,9 @@ import { getProgressService } from "@/lib/services";
 
 const VALID_TIMEFRAMES = new Set(["weekly", "monthly", "alltime"]);
 
+// Auth/cookie + per-request DB access — never statically prerender (DYNAMIC_SERVER_USAGE).
+export const dynamic = "force-dynamic";
+
 export async function GET(request: NextRequest) {
   const timeframe = request.nextUrl.searchParams.get("timeframe") ?? "weekly";
 

--- a/apps/web/src/app/api/quests/daily/route.ts
+++ b/apps/web/src/app/api/quests/daily/route.ts
@@ -10,6 +10,9 @@ import { nextMidnightUtc } from "@/lib/gamification/daily-reset";
 import { logError } from "@/lib/logging";
 import { ERROR_IDS } from "@/constants/errorIds";
 
+// Auth/cookie + per-request DB access — never statically prerender (DYNAMIC_SERVER_USAGE).
+export const dynamic = "force-dynamic";
+
 export async function GET() {
   try {
     if (


### PR DESCRIPTION
## Fix Vercel build: force-dynamic on cookie/auth API GET routes

### Symptom
`next build` fails / logs `DYNAMIC_SERVER_USAGE`:
> Route /api/quests/daily couldn't be rendered statically because it used `cookies`.

### Root cause
Next.js statically prerenders `GET` route handlers at build time. These routes call the Supabase **server** client (`createClient()` → reads cookies) or do other per-request work, which is invalid during prerender → Next throws `DYNAMIC_SERVER_USAGE`. The routes' own `try/catch` then swallows it and logs it as an "Unexpected error", and the route risks being statically cached as an error/stale response.

### Fix
Add `export const dynamic = "force-dynamic"` to the 11 dynamic GET API routes so Next always renders them at request time (never prerenders/caches):
`auth/nonce`, `auth/callback`, `quests/daily`, `deploy/[uuid]`, `deploy/save`, `admin/status`, `leaderboard`, `certificates/metadata`, `community/threads`, `community/threads/[id]`, `community/search`.

POST-only routes are unaffected (Next doesn't prerender them). Typecheck passes; verified each directive sits after imports and before the handler.
