### PR TITLE
fix(auth): Wallet Standard signIn for SIWS (fixes Backpack login) + CSP Google Fonts + kill-switch IDL sync

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -39,9 +39,10 @@ const cspDirectives = [
   "script-src 'self' 'unsafe-eval' 'unsafe-inline' blob: https://cdn.jsdelivr.net https://www.googletagmanager.com https://*.posthog.com",
 
   // Styles: 'unsafe-inline' required by Next.js (and Sanity Studio) inline CSS.
-  "style-src 'self' 'unsafe-inline' https://cdn.sanity.io",
+  // fonts.googleapis.com allows the Google Fonts stylesheet (DM Sans) link.
+  "style-src 'self' 'unsafe-inline' https://cdn.sanity.io https://fonts.googleapis.com",
 
-  // Fonts: self-hosted via next/font. gstatic kept as a harmless fallback.
+  // Fonts: self-hosted via next/font + Google Fonts (gstatic serves the files).
   "font-src 'self' data: https://fonts.gstatic.com",
 
   // Images: avatars (Google), NFT art (Arweave), Supabase storage, Sanity CDN +

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -58,7 +58,7 @@ const cspDirectives = [
   [
     "connect-src 'self'",
     "https://*.supabase.co wss://*.supabase.co",
-    "https://api.sanity.io https://cdn.sanity.io https://apicdn.sanity.io https://*.api.sanity.io wss://*.api.sanity.io https://media.sanity.io",
+    "https://api.sanity.io https://cdn.sanity.io https://apicdn.sanity.io https://*.apicdn.sanity.io https://*.api.sanity.io wss://*.api.sanity.io https://media.sanity.io",
     "https://*.helius-rpc.com https://api.devnet.solana.com https://api.mainnet-beta.solana.com",
     "https://accounts.google.com https://*.googleapis.com",
     "https://www.googletagmanager.com https://www.google-analytics.com https://*.google-analytics.com https://stats.g.doubleclick.net",

--- a/apps/web/src/components/auth/wallet-auth-handler.tsx
+++ b/apps/web/src/components/auth/wallet-auth-handler.tsx
@@ -20,7 +20,7 @@ type AuthOverlayState =
 export function WalletAuthHandler() {
   const locale = useLocale();
   const t = useTranslations("auth");
-  const { publicKey, signMessage, connected } = useWallet();
+  const { publicKey, signMessage, signIn, connected } = useWallet();
   const hasTriedAuth = useRef(false);
   const isAuthenticating = useRef(false);
   const [overlayState, setOverlayState] = useState<AuthOverlayState>({
@@ -28,7 +28,8 @@ export function WalletAuthHandler() {
   });
 
   const authenticate = useCallback(async () => {
-    if (!publicKey || !signMessage || isAuthenticating.current) return;
+    if (!publicKey || (!signIn && !signMessage) || isAuthenticating.current)
+      return;
 
     // Check if already authenticated
     const supabase = createClient();
@@ -51,20 +52,46 @@ export function WalletAuthHandler() {
         domain: string;
       };
       const address = publicKey.toBase58();
+      const statement = "Sign this message to verify your wallet ownership";
 
-      const siwsMessage = createSIWSMessage({
-        domain,
-        address,
-        statement: "Sign this message to verify your wallet ownership",
-        nonce,
-      });
-
-      const messageText = formatSIWSMessage(siwsMessage);
-      const messageBytes = new TextEncoder().encode(messageText);
-
-      let signature: Uint8Array;
+      // Prefer the Wallet Standard signIn (SIWS): the wallet builds AND signs the
+      // message and returns the EXACT bytes it signed, which the server verifies
+      // directly. Raw signMessage + server-side message reconstruction breaks
+      // with wallets that re-serialize SIWS messages (e.g. Backpack) — the
+      // signature is over different bytes, yielding "Invalid signature". Fall
+      // back to signMessage for wallets without signIn.
+      let messageText: string;
+      let signatureArray: number[];
+      let signerAddress: string;
       try {
-        signature = await signMessage(messageBytes);
+        if (signIn) {
+          const now = new Date();
+          const output = await signIn({
+            domain,
+            statement,
+            nonce,
+            issuedAt: now.toISOString(),
+            expirationTime: new Date(
+              now.getTime() + 2 * 60 * 1000
+            ).toISOString(),
+          });
+          messageText = new TextDecoder().decode(output.signedMessage);
+          signatureArray = Array.from(output.signature);
+          signerAddress = output.account.address;
+        } else if (signMessage) {
+          const messageBytes = new TextEncoder().encode(
+            formatSIWSMessage(
+              createSIWSMessage({ domain, address, statement, nonce })
+            )
+          );
+          messageText = new TextDecoder().decode(messageBytes);
+          signatureArray = Array.from(await signMessage(messageBytes));
+          signerAddress = address;
+        } else {
+          setOverlayState({ status: "idle" });
+          isAuthenticating.current = false;
+          return;
+        }
       } catch {
         // User intentionally declined signing — dismiss silently
         setOverlayState({ status: "idle" });
@@ -77,8 +104,8 @@ export function WalletAuthHandler() {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           message: messageText,
-          signature: Array.from(signature),
-          publicKey: address,
+          signature: signatureArray,
+          publicKey: signerAddress,
         }),
       });
 
@@ -117,7 +144,7 @@ export function WalletAuthHandler() {
       });
       isAuthenticating.current = false;
     }
-  }, [publicKey, signMessage, locale, t]);
+  }, [publicKey, signMessage, signIn, locale, t]);
 
   const handleRetry = useCallback(() => {
     hasTriedAuth.current = false;
@@ -135,11 +162,16 @@ export function WalletAuthHandler() {
 
   // Auto-trigger SIWS when wallet connects
   useEffect(() => {
-    if (connected && publicKey && signMessage && !hasTriedAuth.current) {
+    if (
+      connected &&
+      publicKey &&
+      (signIn || signMessage) &&
+      !hasTriedAuth.current
+    ) {
       hasTriedAuth.current = true;
       authenticate();
     }
-  }, [connected, publicKey, signMessage, authenticate]);
+  }, [connected, publicKey, signIn, signMessage, authenticate]);
 
   // Reset when wallet disconnects
   useEffect(() => {

--- a/apps/web/src/lib/solana/idl/superteam_academy.json
+++ b/apps/web/src/lib/solana/idl/superteam_academy.json
@@ -9,16 +9,7 @@
   "instructions": [
     {
       "name": "award_achievement",
-      "discriminator": [
-        75,
-        47,
-        156,
-        253,
-        124,
-        231,
-        84,
-        12
-      ],
+      "discriminator": [75, 47, 156, 253, 124, 231, 84, 12],
       "accounts": [
         {
           "name": "config",
@@ -26,14 +17,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  99,
-                  111,
-                  110,
-                  102,
-                  105,
-                  103
-                ]
+                "value": [99, 111, 110, 102, 105, 103]
               }
             ]
           }
@@ -45,19 +29,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  97,
-                  99,
-                  104,
-                  105,
-                  101,
-                  118,
-                  101,
-                  109,
-                  101,
-                  110,
-                  116
-                ]
+                "value": [97, 99, 104, 105, 101, 118, 101, 109, 101, 110, 116]
               },
               {
                 "kind": "account",
@@ -75,25 +47,8 @@
               {
                 "kind": "const",
                 "value": [
-                  97,
-                  99,
-                  104,
-                  105,
-                  101,
-                  118,
-                  101,
-                  109,
-                  101,
-                  110,
-                  116,
-                  95,
-                  114,
-                  101,
-                  99,
-                  101,
-                  105,
-                  112,
-                  116
+                  97, 99, 104, 105, 101, 118, 101, 109, 101, 110, 116, 95, 114,
+                  101, 99, 101, 105, 112, 116
                 ]
               },
               {
@@ -115,14 +70,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  109,
-                  105,
-                  110,
-                  116,
-                  101,
-                  114
-                ]
+                "value": [109, 105, 110, 116, 101, 114]
               },
               {
                 "kind": "account",
@@ -133,9 +81,7 @@
         },
         {
           "name": "asset",
-          "docs": [
-            "New achievement NFT keypair"
-          ],
+          "docs": ["New achievement NFT keypair"],
           "writable": true,
           "signer": true
         },
@@ -190,16 +136,7 @@
     },
     {
       "name": "close_course",
-      "discriminator": [
-        157,
-        252,
-        239,
-        166,
-        213,
-        174,
-        160,
-        34
-      ],
+      "discriminator": [157, 252, 239, 166, 213, 174, 160, 34],
       "accounts": [
         {
           "name": "config",
@@ -207,14 +144,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  99,
-                  111,
-                  110,
-                  102,
-                  105,
-                  103
-                ]
+                "value": [99, 111, 110, 102, 105, 103]
               }
             ]
           }
@@ -232,14 +162,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  99,
-                  111,
-                  117,
-                  114,
-                  115,
-                  101
-                ]
+                "value": [99, 111, 117, 114, 115, 101]
               },
               {
                 "kind": "arg",
@@ -251,9 +174,7 @@
         {
           "name": "authority",
           "signer": true,
-          "relations": [
-            "config"
-          ]
+          "relations": ["config"]
         }
       ],
       "args": [
@@ -265,16 +186,7 @@
     },
     {
       "name": "close_enrollment",
-      "discriminator": [
-        236,
-        137,
-        133,
-        253,
-        91,
-        138,
-        217,
-        91
-      ],
+      "discriminator": [236, 137, 133, 253, 91, 138, 217, 91],
       "accounts": [
         {
           "name": "course",
@@ -282,14 +194,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  99,
-                  111,
-                  117,
-                  114,
-                  115,
-                  101
-                ]
+                "value": [99, 111, 117, 114, 115, 101]
               },
               {
                 "kind": "account",
@@ -306,18 +211,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  101,
-                  110,
-                  114,
-                  111,
-                  108,
-                  108,
-                  109,
-                  101,
-                  110,
-                  116
-                ]
+                "value": [101, 110, 114, 111, 108, 108, 109, 101, 110, 116]
               },
               {
                 "kind": "account",
@@ -341,16 +235,7 @@
     },
     {
       "name": "complete_lesson",
-      "discriminator": [
-        77,
-        217,
-        53,
-        132,
-        204,
-        150,
-        169,
-        58
-      ],
+      "discriminator": [77, 217, 53, 132, 204, 150, 169, 58],
       "accounts": [
         {
           "name": "config",
@@ -358,14 +243,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  99,
-                  111,
-                  110,
-                  102,
-                  105,
-                  103
-                ]
+                "value": [99, 111, 110, 102, 105, 103]
               }
             ]
           }
@@ -376,14 +254,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  99,
-                  111,
-                  117,
-                  114,
-                  115,
-                  101
-                ]
+                "value": [99, 111, 117, 114, 115, 101]
               },
               {
                 "kind": "account",
@@ -400,18 +271,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  101,
-                  110,
-                  114,
-                  111,
-                  108,
-                  108,
-                  109,
-                  101,
-                  110,
-                  116
-                ]
+                "value": [101, 110, 114, 111, 108, 108, 109, 101, 110, 116]
               },
               {
                 "kind": "account",
@@ -454,16 +314,7 @@
     },
     {
       "name": "create_achievement_type",
-      "discriminator": [
-        231,
-        38,
-        39,
-        228,
-        103,
-        4,
-        229,
-        19
-      ],
+      "discriminator": [231, 38, 39, 228, 103, 4, 229, 19],
       "accounts": [
         {
           "name": "config",
@@ -471,14 +322,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  99,
-                  111,
-                  110,
-                  102,
-                  105,
-                  103
-                ]
+                "value": [99, 111, 110, 102, 105, 103]
               }
             ]
           }
@@ -490,19 +334,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  97,
-                  99,
-                  104,
-                  105,
-                  101,
-                  118,
-                  101,
-                  109,
-                  101,
-                  110,
-                  116
-                ]
+                "value": [97, 99, 104, 105, 101, 118, 101, 109, 101, 110, 116]
               },
               {
                 "kind": "arg",
@@ -513,9 +345,7 @@
         },
         {
           "name": "collection",
-          "docs": [
-            "New Metaplex Core collection keypair"
-          ],
+          "docs": ["New Metaplex Core collection keypair"],
           "writable": true,
           "signer": true
         },
@@ -550,16 +380,7 @@
     },
     {
       "name": "create_course",
-      "discriminator": [
-        120,
-        121,
-        154,
-        164,
-        107,
-        180,
-        167,
-        241
-      ],
+      "discriminator": [120, 121, 154, 164, 107, 180, 167, 241],
       "accounts": [
         {
           "name": "course",
@@ -568,14 +389,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  99,
-                  111,
-                  117,
-                  114,
-                  115,
-                  101
-                ]
+                "value": [99, 111, 117, 114, 115, 101]
               },
               {
                 "kind": "arg",
@@ -590,14 +404,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  99,
-                  111,
-                  110,
-                  102,
-                  105,
-                  103
-                ]
+                "value": [99, 111, 110, 102, 105, 103]
               }
             ]
           }
@@ -606,9 +413,7 @@
           "name": "authority",
           "writable": true,
           "signer": true,
-          "relations": [
-            "config"
-          ]
+          "relations": ["config"]
         },
         {
           "name": "system_program",
@@ -628,16 +433,7 @@
     },
     {
       "name": "deactivate_achievement_type",
-      "discriminator": [
-        185,
-        21,
-        222,
-        243,
-        192,
-        118,
-        71,
-        191
-      ],
+      "discriminator": [185, 21, 222, 243, 192, 118, 71, 191],
       "accounts": [
         {
           "name": "config",
@@ -645,14 +441,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  99,
-                  111,
-                  110,
-                  102,
-                  105,
-                  103
-                ]
+                "value": [99, 111, 110, 102, 105, 103]
               }
             ]
           }
@@ -664,19 +453,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  97,
-                  99,
-                  104,
-                  105,
-                  101,
-                  118,
-                  101,
-                  109,
-                  101,
-                  110,
-                  116
-                ]
+                "value": [97, 99, 104, 105, 101, 118, 101, 109, 101, 110, 116]
               },
               {
                 "kind": "account",
@@ -695,16 +472,7 @@
     },
     {
       "name": "enroll",
-      "discriminator": [
-        58,
-        12,
-        36,
-        3,
-        142,
-        28,
-        1,
-        43
-      ],
+      "discriminator": [58, 12, 36, 3, 142, 28, 1, 43],
       "accounts": [
         {
           "name": "course",
@@ -713,14 +481,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  99,
-                  111,
-                  117,
-                  114,
-                  115,
-                  101
-                ]
+                "value": [99, 111, 117, 114, 115, 101]
               },
               {
                 "kind": "arg",
@@ -736,18 +497,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  101,
-                  110,
-                  114,
-                  111,
-                  108,
-                  108,
-                  109,
-                  101,
-                  110,
-                  116
-                ]
+                "value": [101, 110, 114, 111, 108, 108, 109, 101, 110, 116]
               },
               {
                 "kind": "arg",
@@ -779,16 +529,7 @@
     },
     {
       "name": "finalize_course",
-      "discriminator": [
-        68,
-        189,
-        122,
-        239,
-        39,
-        121,
-        16,
-        218
-      ],
+      "discriminator": [68, 189, 122, 239, 39, 121, 16, 218],
       "accounts": [
         {
           "name": "config",
@@ -796,14 +537,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  99,
-                  111,
-                  110,
-                  102,
-                  105,
-                  103
-                ]
+                "value": [99, 111, 110, 102, 105, 103]
               }
             ]
           }
@@ -815,14 +549,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  99,
-                  111,
-                  117,
-                  114,
-                  115,
-                  101
-                ]
+                "value": [99, 111, 117, 114, 115, 101]
               },
               {
                 "kind": "account",
@@ -839,18 +566,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  101,
-                  110,
-                  114,
-                  111,
-                  108,
-                  108,
-                  109,
-                  101,
-                  110,
-                  116
-                ]
+                "value": [101, 110, 114, 111, 108, 108, 109, 101, 110, 116]
               },
               {
                 "kind": "account",
@@ -895,16 +611,7 @@
     },
     {
       "name": "initialize",
-      "discriminator": [
-        175,
-        175,
-        109,
-        31,
-        13,
-        152,
-        155,
-        237
-      ],
+      "discriminator": [175, 175, 109, 31, 13, 152, 155, 237],
       "accounts": [
         {
           "name": "config",
@@ -913,14 +620,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  99,
-                  111,
-                  110,
-                  102,
-                  105,
-                  103
-                ]
+                "value": [99, 111, 110, 102, 105, 103]
               }
             ]
           }
@@ -949,14 +649,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  109,
-                  105,
-                  110,
-                  116,
-                  101,
-                  114
-                ]
+                "value": [109, 105, 110, 116, 101, 114]
               },
               {
                 "kind": "account",
@@ -978,16 +671,7 @@
     },
     {
       "name": "issue_credential",
-      "discriminator": [
-        255,
-        193,
-        171,
-        224,
-        68,
-        171,
-        194,
-        87
-      ],
+      "discriminator": [255, 193, 171, 224, 68, 171, 194, 87],
       "accounts": [
         {
           "name": "config",
@@ -995,14 +679,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  99,
-                  111,
-                  110,
-                  102,
-                  105,
-                  103
-                ]
+                "value": [99, 111, 110, 102, 105, 103]
               }
             ]
           }
@@ -1013,14 +690,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  99,
-                  111,
-                  117,
-                  114,
-                  115,
-                  101
-                ]
+                "value": [99, 111, 117, 114, 115, 101]
               },
               {
                 "kind": "account",
@@ -1037,18 +707,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  101,
-                  110,
-                  114,
-                  111,
-                  108,
-                  108,
-                  109,
-                  101,
-                  110,
-                  116
-                ]
+                "value": [101, 110, 114, 111, 108, 108, 109, 101, 110, 116]
               },
               {
                 "kind": "account",
@@ -1116,16 +775,7 @@
     },
     {
       "name": "register_minter",
-      "discriminator": [
-        58,
-        224,
-        74,
-        142,
-        170,
-        95,
-        116,
-        191
-      ],
+      "discriminator": [58, 224, 74, 142, 170, 95, 116, 191],
       "accounts": [
         {
           "name": "config",
@@ -1133,14 +783,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  99,
-                  111,
-                  110,
-                  102,
-                  105,
-                  103
-                ]
+                "value": [99, 111, 110, 102, 105, 103]
               }
             ]
           }
@@ -1152,14 +795,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  109,
-                  105,
-                  110,
-                  116,
-                  101,
-                  114
-                ]
+                "value": [109, 105, 110, 116, 101, 114]
               },
               {
                 "kind": "arg",
@@ -1196,16 +832,7 @@
     },
     {
       "name": "revoke_minter",
-      "discriminator": [
-        33,
-        91,
-        131,
-        167,
-        62,
-        37,
-        38,
-        105
-      ],
+      "discriminator": [33, 91, 131, 167, 62, 37, 38, 105],
       "accounts": [
         {
           "name": "config",
@@ -1213,14 +840,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  99,
-                  111,
-                  110,
-                  102,
-                  105,
-                  103
-                ]
+                "value": [99, 111, 110, 102, 105, 103]
               }
             ]
           }
@@ -1232,14 +852,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  109,
-                  105,
-                  110,
-                  116,
-                  101,
-                  114
-                ]
+                "value": [109, 105, 110, 116, 101, 114]
               },
               {
                 "kind": "account",
@@ -1259,16 +872,7 @@
     },
     {
       "name": "reward_xp",
-      "discriminator": [
-        144,
-        187,
-        117,
-        238,
-        89,
-        118,
-        224,
-        145
-      ],
+      "discriminator": [144, 187, 117, 238, 89, 118, 224, 145],
       "accounts": [
         {
           "name": "config",
@@ -1276,14 +880,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  99,
-                  111,
-                  110,
-                  102,
-                  105,
-                  103
-                ]
+                "value": [99, 111, 110, 102, 105, 103]
               }
             ]
           }
@@ -1295,14 +892,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  109,
-                  105,
-                  110,
-                  116,
-                  101,
-                  114
-                ]
+                "value": [109, 105, 110, 116, 101, 114]
               },
               {
                 "kind": "account",
@@ -1313,16 +903,12 @@
         },
         {
           "name": "xp_mint",
-          "docs": [
-            "Token-2022 XP mint"
-          ],
+          "docs": ["Token-2022 XP mint"],
           "writable": true
         },
         {
           "name": "recipient_token_account",
-          "docs": [
-            "Recipient's Token-2022 ATA for XP"
-          ],
+          "docs": ["Recipient's Token-2022 ATA for XP"],
           "writable": true
         },
         {
@@ -1351,16 +937,7 @@
     },
     {
       "name": "update_config",
-      "discriminator": [
-        29,
-        158,
-        252,
-        191,
-        10,
-        83,
-        219,
-        99
-      ],
+      "discriminator": [29, 158, 252, 191, 10, 83, 219, 99],
       "accounts": [
         {
           "name": "config",
@@ -1369,14 +946,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  99,
-                  111,
-                  110,
-                  102,
-                  105,
-                  103
-                ]
+                "value": [99, 111, 110, 102, 105, 103]
               }
             ]
           }
@@ -1384,9 +954,7 @@
         {
           "name": "authority",
           "signer": true,
-          "relations": [
-            "config"
-          ]
+          "relations": ["config"]
         }
       ],
       "args": [
@@ -1402,16 +970,7 @@
     },
     {
       "name": "update_course",
-      "discriminator": [
-        81,
-        217,
-        18,
-        192,
-        129,
-        233,
-        129,
-        231
-      ],
+      "discriminator": [81, 217, 18, 192, 129, 233, 129, 231],
       "accounts": [
         {
           "name": "config",
@@ -1419,14 +978,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  99,
-                  111,
-                  110,
-                  102,
-                  105,
-                  103
-                ]
+                "value": [99, 111, 110, 102, 105, 103]
               }
             ]
           }
@@ -1438,14 +990,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  99,
-                  111,
-                  117,
-                  114,
-                  115,
-                  101
-                ]
+                "value": [99, 111, 117, 114, 115, 101]
               },
               {
                 "kind": "account",
@@ -1458,9 +1003,7 @@
         {
           "name": "authority",
           "signer": true,
-          "relations": [
-            "config"
-          ]
+          "relations": ["config"]
         }
       ],
       "args": [
@@ -1476,16 +1019,7 @@
     },
     {
       "name": "update_minter",
-      "discriminator": [
-        164,
-        129,
-        164,
-        88,
-        75,
-        29,
-        91,
-        38
-      ],
+      "discriminator": [164, 129, 164, 88, 75, 29, 91, 38],
       "accounts": [
         {
           "name": "config",
@@ -1493,14 +1027,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  99,
-                  111,
-                  110,
-                  102,
-                  105,
-                  103
-                ]
+                "value": [99, 111, 110, 102, 105, 103]
               }
             ]
           }
@@ -1512,14 +1039,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  109,
-                  105,
-                  110,
-                  116,
-                  101,
-                  114
-                ]
+                "value": [109, 105, 110, 116, 101, 114]
               },
               {
                 "kind": "account",
@@ -1547,16 +1067,7 @@
     },
     {
       "name": "upgrade_credential",
-      "discriminator": [
-        2,
-        121,
-        77,
-        255,
-        103,
-        187,
-        252,
-        169
-      ],
+      "discriminator": [2, 121, 77, 255, 103, 187, 252, 169],
       "accounts": [
         {
           "name": "config",
@@ -1564,14 +1075,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  99,
-                  111,
-                  110,
-                  102,
-                  105,
-                  103
-                ]
+                "value": [99, 111, 110, 102, 105, 103]
               }
             ]
           }
@@ -1582,14 +1086,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  99,
-                  111,
-                  117,
-                  114,
-                  115,
-                  101
-                ]
+                "value": [99, 111, 117, 114, 115, 101]
               },
               {
                 "kind": "account",
@@ -1605,18 +1102,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  101,
-                  110,
-                  114,
-                  111,
-                  108,
-                  108,
-                  109,
-                  101,
-                  110,
-                  116
-                ]
+                "value": [101, 110, 114, 111, 108, 108, 109, 101, 110, 116]
               },
               {
                 "kind": "account",
@@ -1685,304 +1171,101 @@
   "accounts": [
     {
       "name": "AchievementReceipt",
-      "discriminator": [
-        149,
-        5,
-        79,
-        178,
-        116,
-        231,
-        43,
-        248
-      ]
+      "discriminator": [149, 5, 79, 178, 116, 231, 43, 248]
     },
     {
       "name": "AchievementType",
-      "discriminator": [
-        13,
-        187,
-        114,
-        66,
-        217,
-        154,
-        85,
-        137
-      ]
+      "discriminator": [13, 187, 114, 66, 217, 154, 85, 137]
     },
     {
       "name": "Config",
-      "discriminator": [
-        155,
-        12,
-        170,
-        224,
-        30,
-        250,
-        204,
-        130
-      ]
+      "discriminator": [155, 12, 170, 224, 30, 250, 204, 130]
     },
     {
       "name": "Course",
-      "discriminator": [
-        206,
-        6,
-        78,
-        228,
-        163,
-        138,
-        241,
-        106
-      ]
+      "discriminator": [206, 6, 78, 228, 163, 138, 241, 106]
     },
     {
       "name": "Enrollment",
-      "discriminator": [
-        249,
-        210,
-        64,
-        145,
-        197,
-        241,
-        57,
-        51
-      ]
+      "discriminator": [249, 210, 64, 145, 197, 241, 57, 51]
     },
     {
       "name": "MinterRole",
-      "discriminator": [
-        21,
-        246,
-        6,
-        133,
-        142,
-        211,
-        33,
-        193
-      ]
+      "discriminator": [21, 246, 6, 133, 142, 211, 33, 193]
     }
   ],
   "events": [
     {
       "name": "AchievementAwarded",
-      "discriminator": [
-        127,
-        212,
-        93,
-        231,
-        175,
-        0,
-        69,
-        150
-      ]
+      "discriminator": [127, 212, 93, 231, 175, 0, 69, 150]
     },
     {
       "name": "AchievementTypeCreated",
-      "discriminator": [
-        189,
-        36,
-        173,
-        243,
-        25,
-        232,
-        198,
-        153
-      ]
+      "discriminator": [189, 36, 173, 243, 25, 232, 198, 153]
     },
     {
       "name": "AchievementTypeDeactivated",
-      "discriminator": [
-        133,
-        12,
-        218,
-        127,
-        151,
-        28,
-        1,
-        222
-      ]
+      "discriminator": [133, 12, 218, 127, 151, 28, 1, 222]
     },
     {
       "name": "ConfigUpdated",
-      "discriminator": [
-        40,
-        241,
-        230,
-        122,
-        11,
-        19,
-        198,
-        194
-      ]
+      "discriminator": [40, 241, 230, 122, 11, 19, 198, 194]
     },
     {
       "name": "CourseClosed",
-      "discriminator": [
-        35,
-        195,
-        37,
-        254,
-        25,
-        107,
-        100,
-        12
-      ]
+      "discriminator": [35, 195, 37, 254, 25, 107, 100, 12]
     },
     {
       "name": "CourseCreated",
-      "discriminator": [
-        205,
-        144,
-        55,
-        47,
-        150,
-        170,
-        123,
-        214
-      ]
+      "discriminator": [205, 144, 55, 47, 150, 170, 123, 214]
     },
     {
       "name": "CourseFinalized",
-      "discriminator": [
-        18,
-        195,
-        195,
-        25,
-        165,
-        189,
-        194,
-        56
-      ]
+      "discriminator": [18, 195, 195, 25, 165, 189, 194, 56]
     },
     {
       "name": "CourseUpdated",
-      "discriminator": [
-        124,
-        141,
-        110,
-        224,
-        149,
-        124,
-        26,
-        141
-      ]
+      "discriminator": [124, 141, 110, 224, 149, 124, 26, 141]
     },
     {
       "name": "CredentialIssued",
-      "discriminator": [
-        194,
-        216,
-        28,
-        159,
-        89,
-        29,
-        72,
-        177
-      ]
+      "discriminator": [194, 216, 28, 159, 89, 29, 72, 177]
     },
     {
       "name": "CredentialUpgraded",
-      "discriminator": [
-        198,
-        142,
-        252,
-        191,
-        210,
-        200,
-        253,
-        133
-      ]
+      "discriminator": [198, 142, 252, 191, 210, 200, 253, 133]
     },
     {
       "name": "Enrolled",
-      "discriminator": [
-        129,
-        156,
-        102,
-        214,
-        94,
-        196,
-        220,
-        127
-      ]
+      "discriminator": [129, 156, 102, 214, 94, 196, 220, 127]
     },
     {
       "name": "EnrollmentClosed",
-      "discriminator": [
-        197,
-        4,
-        145,
-        238,
-        217,
-        4,
-        175,
-        77
-      ]
+      "discriminator": [197, 4, 145, 238, 217, 4, 175, 77]
     },
     {
       "name": "LessonCompleted",
-      "discriminator": [
-        248,
-        174,
-        148,
-        235,
-        186,
-        49,
-        11,
-        163
-      ]
+      "discriminator": [248, 174, 148, 235, 186, 49, 11, 163]
     },
     {
       "name": "MinterRegistered",
-      "discriminator": [
-        104,
-        203,
-        87,
-        105,
-        23,
-        33,
-        231,
-        1
-      ]
+      "discriminator": [104, 203, 87, 105, 23, 33, 231, 1]
     },
     {
       "name": "MinterRevoked",
-      "discriminator": [
-        138,
-        76,
-        227,
-        247,
-        141,
-        92,
-        77,
-        127
-      ]
+      "discriminator": [138, 76, 227, 247, 141, 92, 77, 127]
     },
     {
       "name": "MinterUpdated",
-      "discriminator": [
-        8,
-        124,
-        66,
-        45,
-        176,
-        53,
-        49,
-        153
-      ]
+      "discriminator": [8, 124, 66, 45, 176, 53, 49, 153]
+    },
+    {
+      "name": "MintingPauseSet",
+      "discriminator": [232, 11, 219, 8, 116, 65, 178, 74]
     },
     {
       "name": "XpRewarded",
-      "discriminator": [
-        140,
-        182,
-        232,
-        144,
-        16,
-        155,
-        237,
-        182
-      ]
+      "discriminator": [140, 182, 232, 144, 16, 155, 237, 182]
     }
   ],
   "errors": [
@@ -2140,6 +1423,11 @@
       "code": 6030,
       "name": "InvalidCourseAccount",
       "msg": "Account is not a valid Course PDA"
+    },
+    {
+      "code": 6031,
+      "name": "MintingPaused",
+      "msg": "Minting is paused"
     }
   ],
   "types": [
@@ -2182,9 +1470,7 @@
         "fields": [
           {
             "name": "asset",
-            "docs": [
-              "Metaplex Core NFT address"
-            ],
+            "docs": ["Metaplex Core NFT address"],
             "type": "pubkey"
           },
           {
@@ -2213,16 +1499,12 @@
           },
           {
             "name": "metadata_uri",
-            "docs": [
-              "Default metadata URI for minted NFTs"
-            ],
+            "docs": ["Default metadata URI for minted NFTs"],
             "type": "string"
           },
           {
             "name": "collection",
-            "docs": [
-              "Metaplex Core collection for this achievement"
-            ],
+            "docs": ["Metaplex Core collection for this achievement"],
             "type": "pubkey"
           },
           {
@@ -2231,9 +1513,7 @@
           },
           {
             "name": "max_supply",
-            "docs": [
-              "0 = unlimited supply"
-            ],
+            "docs": ["0 = unlimited supply"],
             "type": "u32"
           },
           {
@@ -2242,9 +1522,7 @@
           },
           {
             "name": "xp_reward",
-            "docs": [
-              "XP awarded alongside the NFT (0 = no XP)"
-            ],
+            "docs": ["XP awarded alongside the NFT (0 = no XP)"],
             "type": "u32"
           },
           {
@@ -2258,10 +1536,7 @@
           {
             "name": "_reserved",
             "type": {
-              "array": [
-                "u8",
-                8
-              ]
+              "array": ["u8", 8]
             }
           },
           {
@@ -2326,42 +1601,39 @@
         "fields": [
           {
             "name": "authority",
-            "docs": [
-              "Platform multisig (Squads)"
-            ],
+            "docs": ["Platform multisig (Squads)"],
             "type": "pubkey"
           },
           {
             "name": "backend_signer",
-            "docs": [
-              "Rotatable backend signer for completions"
-            ],
+            "docs": ["Rotatable backend signer for completions"],
             "type": "pubkey"
           },
           {
             "name": "xp_mint",
-            "docs": [
-              "Token-2022 mint for XP"
-            ],
+            "docs": ["Token-2022 mint for XP"],
             "type": "pubkey"
           },
           {
-            "name": "_reserved",
+            "name": "paused",
             "docs": [
-              "Reserved for future use"
+              "Global minting kill-switch. When true, every XP-minting / credential",
+              "instruction is blocked: complete_lesson, finalize_course, reward_xp,",
+              "award_achievement, and issue_credential. Occupies the first former",
+              "`_reserved` byte; legacy accounts (reserved zeroed) deserialize as `false`."
             ],
+            "type": "bool"
+          },
+          {
+            "name": "_reserved",
+            "docs": ["Reserved for future use"],
             "type": {
-              "array": [
-                "u8",
-                8
-              ]
+              "array": ["u8", 7]
             }
           },
           {
             "name": "bump",
-            "docs": [
-              "PDA bump"
-            ],
+            "docs": ["PDA bump"],
             "type": "u8"
           }
         ]
@@ -2402,10 +1674,7 @@
           {
             "name": "content_tx_id",
             "type": {
-              "array": [
-                "u8",
-                32
-              ]
+              "array": ["u8", 32]
             }
           },
           {
@@ -2477,10 +1746,7 @@
           {
             "name": "_reserved",
             "type": {
-              "array": [
-                "u8",
-                8
-              ]
+              "array": ["u8", 8]
             }
           },
           {
@@ -2650,10 +1916,7 @@
           {
             "name": "content_tx_id",
             "type": {
-              "array": [
-                "u8",
-                32
-              ]
+              "array": ["u8", 32]
             }
           },
           {
@@ -2790,23 +2053,17 @@
         "fields": [
           {
             "name": "course",
-            "docs": [
-              "The Course PDA this enrollment belongs to"
-            ],
+            "docs": ["The Course PDA this enrollment belongs to"],
             "type": "pubkey"
           },
           {
             "name": "enrolled_at",
-            "docs": [
-              "When learner enrolled"
-            ],
+            "docs": ["When learner enrolled"],
             "type": "i64"
           },
           {
             "name": "completed_at",
-            "docs": [
-              "When course was completed (None if in progress)"
-            ],
+            "docs": ["When course was completed (None if in progress)"],
             "type": {
               "option": "i64"
             }
@@ -2818,10 +2075,7 @@
               "lesson_count is u8 (max 255), so all valid indices fit within this bitmap."
             ],
             "type": {
-              "array": [
-                "u64",
-                4
-              ]
+              "array": ["u64", 4]
             }
           },
           {
@@ -2839,17 +2093,12 @@
               "Reserved for future use (4 bytes — differs from 8 on other accounts; cannot resize without migration)"
             ],
             "type": {
-              "array": [
-                "u8",
-                4
-              ]
+              "array": ["u8", 4]
             }
           },
           {
             "name": "bump",
-            "docs": [
-              "PDA bump"
-            ],
+            "docs": ["PDA bump"],
             "type": "u8"
           }
         ]
@@ -2966,9 +2215,7 @@
         "fields": [
           {
             "name": "minter",
-            "docs": [
-              "Wallet or program PDA authorized to mint XP"
-            ],
+            "docs": ["Wallet or program PDA authorized to mint XP"],
             "type": "pubkey"
           },
           {
@@ -2980,16 +2227,12 @@
           },
           {
             "name": "max_xp_per_call",
-            "docs": [
-              "Per-call XP cap. 0 = unlimited."
-            ],
+            "docs": ["Per-call XP cap. 0 = unlimited."],
             "type": "u64"
           },
           {
             "name": "total_xp_minted",
-            "docs": [
-              "Lifetime XP minted through this role"
-            ],
+            "docs": ["Lifetime XP minted through this role"],
             "type": "u64"
           },
           {
@@ -3042,6 +2285,22 @@
       }
     },
     {
+      "name": "MintingPauseSet",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "paused",
+            "type": "bool"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
       "name": "RegisterMinterParams",
       "type": {
         "kind": "struct",
@@ -3060,9 +2319,7 @@
           },
           {
             "name": "max_total_xp",
-            "docs": [
-              "Cumulative XP ceiling for this role. 0 = unlimited."
-            ],
+            "docs": ["Cumulative XP ceiling for this role. 0 = unlimited."],
             "type": "u64"
           }
         ]
@@ -3078,6 +2335,16 @@
             "type": {
               "option": "pubkey"
             }
+          },
+          {
+            "name": "paused",
+            "docs": [
+              "Minting kill-switch toggle. `Some(true)` pauses all minting,",
+              "`Some(false)` resumes, `None` leaves it unchanged."
+            ],
+            "type": {
+              "option": "bool"
+            }
           }
         ]
       }
@@ -3091,10 +2358,7 @@
             "name": "new_content_tx_id",
             "type": {
               "option": {
-                "array": [
-                  "u8",
-                  32
-                ]
+                "array": ["u8", 32]
               }
             }
           },
@@ -3141,9 +2405,7 @@
         "fields": [
           {
             "name": "max_xp_per_call",
-            "docs": [
-              "New per-call XP cap. 0 = unlimited."
-            ],
+            "docs": ["New per-call XP cap. 0 = unlimited."],
             "type": "u64"
           },
           {


### PR DESCRIPTION
## Summary

Three fixes that unblock the local/devnet platform (login + enrollment were both broken):

### 1. Wallet login — Backpack \`Invalid signature\` (401) → fixed
`wallet-auth-handler.tsx` now uses the **Wallet Standard `signIn` (SIWS)** flow instead of raw `signMessage` + server-side message reconstruction. The wallet builds *and* signs the message and returns the exact bytes it signed (`output.signedMessage` + `output.signature`), which the server verifies directly. The old flow had the server reconstruct the SIWS text and verify against *that* — Backpack re-serializes SIWS messages, so the signature was over different bytes → `Invalid signature`. Falls back to `signMessage` for wallets without `signIn`.

**Server unchanged** (`verify-siws.ts`): it already accepts a standard SIWS message — proven by a known-good signature returning 200. So the bug was 100% client-side.

### 2. CSP — Google Fonts stylesheet blocked
Added `https://fonts.googleapis.com` to `style-src` (the DM Sans `<link>` was blocked). `font-src` already allowed `fonts.gstatic.com`.

### 3. IDL sync
Frontend IDL synced to the deployed kill-switch program (`Config.paused`, `MintingPaused`, `UpdateConfigParams.paused`) so reads/decodes match on-chain.

## Verification
- Login: confirmed working with Backpack (user-tested).
- SIWS: server returns 200 on the signIn-format message.
- `tsc --noEmit` clean.

## Note (separate from this PR)
Enrollment was *also* broken (`ConstraintSeeds 0x7d6`) — root cause was stale 192-byte Course PDAs vs the redeployed 224-byte program (the `collection` field, #184). Fixed by an on-chain close+recreate migration of all 6 courses (devnet), verified: enroll now simulates `err: null`. That's an on-chain operation, not code in this PR. Follow-up filed to automate the migration in admin tooling.

## Security note for review
This touches auth. Key invariant: the server verifies `nacl.sign.detached.verify(message, signature, publicKey)` where `publicKey` is the signer from the wallet — so a client can only authenticate as a key it controls. Nonce is server-issued (replay protection) and bound into the signed message; domain is validated against the request host; message has a 2-min expiry.