### PR TITLE
fix(env): extend server env validation to remaining secrets + fix empty-string dataset

### DIFF
--- a/apps/web/src/instrumentation.ts
+++ b/apps/web/src/instrumentation.ts
@@ -17,6 +17,11 @@ export async function register() {
   }
 
   if (process.env.NEXT_RUNTIME === "edge") {
+    // Validate public env vars in the edge runtime as well so a bad
+    // NEXT_PUBLIC_* var fails at startup rather than on every request
+    // (middleware imports env.ts at load time, so a bad var would 500
+    // every route otherwise).
+    await import("@/lib/env");
     await import("../sentry.edge.config");
   }
 }

--- a/apps/web/src/lib/env.server.ts
+++ b/apps/web/src/lib/env.server.ts
@@ -5,6 +5,10 @@ import { formatEnvError } from "./env";
 /**
  * Server-only secrets. Never imported into client code (`server-only` enforces
  * this). Validated eagerly at boot via `instrumentation.ts`.
+ *
+ * Required vars must be non-empty or the app refuses to start. Optional vars
+ * are validated for format/non-emptiness when present so a set-but-blank value
+ * surfaces here rather than as a silent failure deep in a route handler.
  */
 const serverEnvSchema = z.object({
   SUPABASE_SERVICE_ROLE_KEY: z.string().min(1),
@@ -13,16 +17,30 @@ const serverEnvSchema = z.object({
   // (`server-only` enforces that). Required so a misconfigured deployment
   // fails loudly here instead of silently falling back to public devnet.
   SOLANA_RPC_URL: z.url(),
-  // Optional: only needed for admin Sanity writes. Validated as non-empty when
-  // present so a blank token surfaces here rather than as a silent
-  // unauthenticated client at the Sanity API call.
+  // Optional: only needed for admin Sanity writes.
   SANITY_ADMIN_TOKEN: z.string().min(1).optional(),
+  // Admin panel HMAC cookie signing key.
+  ADMIN_SECRET: z.string().min(1).optional(),
+  // Helius webhook HMAC verification secret.
+  HELIUS_WEBHOOK_SECRET: z.string().min(1).optional(),
+  // On-chain keypairs (JSON array of 64 bytes).
+  XP_MINT_AUTHORITY_SECRET: z.string().min(1).optional(),
+  PROGRAM_AUTHORITY_SECRET: z.string().min(1).optional(),
+  // Anchor build-server proxy.
+  BUILD_SERVER_URL: z.url().optional(),
+  BUILD_SERVER_API_KEY: z.string().min(1).optional(),
 });
 
 const parsed = serverEnvSchema.safeParse({
   SUPABASE_SERVICE_ROLE_KEY: process.env.SUPABASE_SERVICE_ROLE_KEY,
   SOLANA_RPC_URL: process.env.SOLANA_RPC_URL,
   SANITY_ADMIN_TOKEN: process.env.SANITY_ADMIN_TOKEN,
+  ADMIN_SECRET: process.env.ADMIN_SECRET,
+  HELIUS_WEBHOOK_SECRET: process.env.HELIUS_WEBHOOK_SECRET,
+  XP_MINT_AUTHORITY_SECRET: process.env.XP_MINT_AUTHORITY_SECRET,
+  PROGRAM_AUTHORITY_SECRET: process.env.PROGRAM_AUTHORITY_SECRET,
+  BUILD_SERVER_URL: process.env.BUILD_SERVER_URL,
+  BUILD_SERVER_API_KEY: process.env.BUILD_SERVER_API_KEY,
 });
 
 if (!parsed.success) {

--- a/apps/web/src/lib/env.ts
+++ b/apps/web/src/lib/env.ts
@@ -38,7 +38,12 @@ const publicEnvSchema = z.object({
     ),
   NEXT_PUBLIC_SUPABASE_ANON_KEY: z.string().min(1),
   NEXT_PUBLIC_SANITY_PROJECT_ID: z.string().min(1),
-  NEXT_PUBLIC_SANITY_DATASET: z.string().min(1).default("production"),
+  // Preprocess "" to undefined so a set-but-blank var takes the default
+  // instead of failing min(1) (z.default only activates on undefined, not "").
+  NEXT_PUBLIC_SANITY_DATASET: z.preprocess(
+    (v) => (v === "" ? undefined : v),
+    z.string().min(1).default("production")
+  ),
   // Public, rate-limited browser RPC endpoint. MUST NOT carry a privileged
   // Helius API key — it is inlined into the client bundle. The Helius-keyed
   // endpoint lives server-side as SOLANA_RPC_URL in env.server.ts.


### PR DESCRIPTION
## What

Closes #163 — adds the 6 remaining server-only secrets to `env.server.ts`:
- `ADMIN_SECRET`, `HELIUS_WEBHOOK_SECRET`, `XP_MINT_AUTHORITY_SECRET`, `PROGRAM_AUTHORITY_SECRET`, `BUILD_SERVER_URL`, `BUILD_SERVER_API_KEY`

Each is optional (a fresh dev clone without them still boots), but a **set-but-blank value** now fails fast with a named error instead of silently passing an empty string deep into a route handler.

Related to #178 (partial —closes itens 2 & 3) — two robustness fixes in `env.ts` / `instrumentation.ts`:

1. **`NEXT_PUBLIC_SANITY_DATASET` empty-string footgun**: `z.default()` only fires on `undefined`, not `""`. A set-but-blank env var was failing `min(1)` with a boot error instead of falling back to `"production"`. Fixed by preprocessing `""` → `undefined` before zod.

2. **Edge runtime validation**: `instrumentation.ts` now also imports `@/lib/env` in the edge branch, so a bad `NEXT_PUBLIC_*` var surfaces at edge startup rather than on every middleware request (`middleware.ts` imports `env.ts` at module load, meaning an invalid var would 500 every route in the edge runtime).

## Testing

- `pnpm typecheck` — clean
- Set `NEXT_PUBLIC_SANITY_DATASET=` (blank) in `.env.local` → server now boots with `"production"` default instead of crashing
- Set `ADMIN_SECRET=` (blank) → boot error naming `ADMIN_SECRET: String must contain at least 1 character(s)`