### PR TITLE
fix(csp): allow Sanity project-subdomain CDN requests in connect-src

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -57,7 +57,7 @@ const cspDirectives = [
   [
     "connect-src 'self'",
     "https://*.supabase.co wss://*.supabase.co",
-    "https://api.sanity.io https://cdn.sanity.io https://apicdn.sanity.io https://*.api.sanity.io wss://*.api.sanity.io https://media.sanity.io",
+    "https://api.sanity.io https://cdn.sanity.io https://*.apicdn.sanity.io https://*.api.sanity.io wss://*.api.sanity.io https://media.sanity.io",
     "https://*.helius-rpc.com https://api.devnet.solana.com https://api.mainnet-beta.solana.com",
     "https://accounts.google.com https://*.googleapis.com",
     "https://www.googletagmanager.com https://www.google-analytics.com https://*.google-analytics.com https://stats.g.doubleclick.net",


### PR DESCRIPTION
Closes #228

## What changed

`next.config.mjs` CSP `connect-src`:

```diff
- https://apicdn.sanity.io
+ https://*.apicdn.sanity.io
```

## Why

Sanity's JS client routes browser queries through `https://<project-id>.apicdn.sanity.io`. The bare-host entry `https://apicdn.sanity.io` never matched that subdomain pattern, so every client-side Sanity query was blocked — courses and achievements on the dashboard failed to load with a CSP violation.

## Testing

- Open dashboard in production/preview — courses and achievements load without CSP errors in the browser console.