### PR TITLE
fix(enroll): handle AccountAlreadyInUse (0x0) + on-chain enrollment fallback

### DIFF
--- a/apps/web/src/app/[locale]/(platform)/courses/[slug]/course-detail-client.tsx
+++ b/apps/web/src/app/[locale]/(platform)/courses/[slug]/course-detail-client.tsx
@@ -12,7 +12,7 @@ import {
   Wallet,
   ChatCircleDots,
 } from "@phosphor-icons/react";
-import { useWallet } from "@solana/wallet-adapter-react";
+import { useConnection, useWallet } from "@solana/wallet-adapter-react";
 import { Button } from "@/components/ui/button";
 import { CurriculumAccordion } from "@/components/course/curriculum-accordion";
 import { ProgressBar } from "@/components/course/progress-bar";
@@ -20,6 +20,7 @@ import { createClient } from "@/lib/supabase/client";
 import { AuthModal } from "@/components/auth/auth-modal";
 import { useAuth } from "@/lib/auth/auth-provider";
 import { useOnChainEnroll } from "@/hooks/use-on-chain-enroll";
+import { findEnrollmentPDA } from "@/lib/solana/pda";
 import { ThreadList } from "@/components/community/thread-list";
 import { CreateThreadModal } from "@/components/community/create-thread-modal";
 import type { Course } from "@/lib/sanity/types";
@@ -32,6 +33,7 @@ export function CourseDetailClient({ course }: CourseDetailClientProps) {
   const t = useTranslations("courses");
   const tCommon = useTranslations("common");
   const locale = useLocale();
+  const { connection } = useConnection();
   const { publicKey } = useWallet();
 
   const modules = course.modules ?? [];
@@ -59,7 +61,9 @@ export function CourseDetailClient({ course }: CourseDetailClientProps) {
     try {
       const supabase = createClient();
 
-      // Check enrollment status
+      // Check enrollment status — Supabase first, then on-chain fallback.
+      // The fallback catches the case where the Helius webhook missed the sync
+      // (enrollment PDA exists on-chain but Supabase has no record).
       const { data: enrollment } = await supabase
         .from("enrollments")
         .select("id")
@@ -67,7 +71,19 @@ export function CourseDetailClient({ course }: CourseDetailClientProps) {
         .eq("course_id", course._id)
         .maybeSingle();
 
-      setIsEnrolled(!!enrollment);
+      let enrolled = !!enrollment;
+
+      if (!enrolled && publicKey) {
+        try {
+          const [enrollmentPDA] = findEnrollmentPDA(course._id, publicKey);
+          const info = await connection.getAccountInfo(enrollmentPDA);
+          if (info && info.data.length > 0) enrolled = true;
+        } catch {
+          // ignore — fall through to show unenrolled state
+        }
+      }
+
+      setIsEnrolled(enrolled);
 
       // Fetch completed lessons for this course
       if (enrollment) {
@@ -85,7 +101,7 @@ export function CourseDetailClient({ course }: CourseDetailClientProps) {
     } finally {
       setIsLoading(false);
     }
-  }, [course._id, userId]);
+  }, [course._id, userId, publicKey, connection]);
 
   useEffect(() => {
     if (authLoading) return;

--- a/apps/web/src/hooks/use-on-chain-enroll.ts
+++ b/apps/web/src/hooks/use-on-chain-enroll.ts
@@ -89,6 +89,17 @@ export function useOnChainEnroll({
         });
       } catch (err: unknown) {
         const parsed = parseProgramError(err);
+
+        // code 0 = SystemError::AccountAlreadyInUse: the enrollment PDA already
+        // exists on-chain (Helius webhook fell behind or a prior tx succeeded but
+        // timed out before confirmation). Treat as success so the user reaches
+        // the course rather than seeing a cryptic error.
+        if (parsed.code === 0) {
+          dispatchToast("Enrolled successfully!", "success");
+          onSuccess?.();
+          return;
+        }
+
         const msg = parsed.fallback;
         setEnrollError(msg);
         dispatchToast(msg, "warning");

--- a/apps/web/src/lib/solana/program-errors.ts
+++ b/apps/web/src/lib/solana/program-errors.ts
@@ -219,6 +219,9 @@ export function parseProgramError(err: unknown): ParsedProgramError {
         fallback: entry.fallback,
       };
     }
+    // Unknown code — preserve it for callers that branch on specific values
+    // (e.g. code 0 = SystemError::AccountAlreadyInUse).
+    return { code, name: null, i18nKey: null, fallback: raw };
   }
 
   // 2. Try decimal error code


### PR DESCRIPTION
Closes #232

## Root cause

Two independent issues combined to produce "custom program error: 0x0":

**1. `parseProgramError` dropped the extracted code for unknown errors**
It extracted `code=0` from `"0x0"` but only returned it when there was an `ERROR_MAP` entry — there isn't one for code 0. Callers received `code: null` and couldn't detect the already-enrolled state.

**2. Enrollment state check was Supabase-only**
When the Helius webhook missed a sync (enrollment PDA exists on-chain but no Supabase record), the UI showed the "Enroll" button. Clicking it tried to `init` the enrollment PDA again — the System Program returned `AccountAlreadyInUse` (0x0).

## Fixes

**`parse-program-error.ts`** — return `code` for ALL extracted hex errors, not only ones with known `ERROR_MAP` entries.

**`use-on-chain-enroll.ts`** — code 0 = `SystemError::AccountAlreadyInUse`: the enrollment PDA already exists on-chain. Treat as success (`onSuccess()`) instead of showing a cryptic error, so the user reaches the course.

**`course-detail-client.tsx`** — add an on-chain `getAccountInfo` fallback after the Supabase check. If the enrollment PDA has data, show the user as enrolled regardless of webhook sync state. Re-runs when wallet connects so a freshly-connected wallet gets the correct state.

## Testing

1. Enroll in a course → works normally (no regression).
2. Simulate a missed webhook: enroll on-chain, delete the Supabase record → page shows "Continue" (not "Enroll").
3. With stale Supabase, click "Enroll" again → gets 0x0 → redirects to course as if enrolled (no error toast).