### PR TITLE
fix(progress): write user_progress directly on lesson complete

### DIFF
--- a/apps/web/src/app/api/lessons/complete/route.ts
+++ b/apps/web/src/app/api/lessons/complete/route.ts
@@ -42,8 +42,9 @@ async function deriveLessonIndex(
 }
 
 /**
- * Mark a lesson as complete on-chain. Supabase writes (XP, progress,
- * achievements, credentials) are handled by the Helius webhook handler.
+ * Mark a lesson as complete on-chain. user_progress is written directly here
+ * for immediate dashboard visibility. XP, achievements, and credentials are
+ * handled by the Helius webhook handler.
  */
 export async function POST(request: NextRequest) {
   try {
@@ -202,18 +203,34 @@ export async function POST(request: NextRequest) {
     if (alreadyOnChain) {
       // Sync progress in case the Helius webhook missed this completion.
       // ignoreDuplicates avoids overwriting an existing tx_signature with null.
-      await supabaseAdmin.from("user_progress").upsert(
-        {
-          user_id: user.id,
-          course_id: courseId,
-          lesson_id: lessonId,
-          completed: true,
-          completed_at: new Date().toISOString(),
-          tx_signature: null,
-          lesson_index: lessonIndex,
-        },
-        { onConflict: "user_id,lesson_id", ignoreDuplicates: true }
-      );
+      const { error: recoveryError } = await supabaseAdmin
+        .from("user_progress")
+        .upsert(
+          {
+            user_id: user.id,
+            course_id: courseId,
+            lesson_id: lessonId,
+            completed: true,
+            completed_at: new Date().toISOString(),
+            tx_signature: null,
+            lesson_index: lessonIndex,
+          },
+          { onConflict: "user_id,lesson_id", ignoreDuplicates: true }
+        );
+
+      if (recoveryError) {
+        logError({
+          errorId: ERROR_IDS.LESSON_COMPLETE_FAILED,
+          error: new Error(recoveryError.message),
+          context: {
+            route: "/api/lessons/complete",
+            step: "recovery_sync",
+            userId: user.id,
+            courseId,
+            lessonId,
+          },
+        });
+      }
       return NextResponse.json({
         success: true,
         alreadyCompleted: true,

--- a/apps/web/src/app/api/lessons/complete/route.ts
+++ b/apps/web/src/app/api/lessons/complete/route.ts
@@ -200,6 +200,20 @@ export async function POST(request: NextRequest) {
     );
 
     if (alreadyOnChain) {
+      // Sync progress in case the Helius webhook missed this completion.
+      // ignoreDuplicates avoids overwriting an existing tx_signature with null.
+      await supabaseAdmin.from("user_progress").upsert(
+        {
+          user_id: user.id,
+          course_id: courseId,
+          lesson_id: lessonId,
+          completed: true,
+          completed_at: new Date().toISOString(),
+          tx_signature: null,
+          lesson_index: lessonIndex,
+        },
+        { onConflict: "user_id,lesson_id", ignoreDuplicates: true }
+      );
       return NextResponse.json({
         success: true,
         alreadyCompleted: true,
@@ -207,12 +221,44 @@ export async function POST(request: NextRequest) {
       });
     }
 
-    // Execute on-chain completeLesson — webhook handles all Supabase writes
+    // Execute on-chain completeLesson
     const signature = await onChainCompleteLesson(
       courseId,
       walletPubkey,
       lessonIndex
     );
+
+    // Write directly to Supabase so progress is visible on the dashboard
+    // immediately, without depending on Helius webhook delivery timing.
+    // The webhook will upsert the same row again (idempotent) when it arrives.
+    const { error: progressError } = await supabaseAdmin
+      .from("user_progress")
+      .upsert(
+        {
+          user_id: user.id,
+          course_id: courseId,
+          lesson_id: lessonId,
+          completed: true,
+          completed_at: new Date().toISOString(),
+          tx_signature: signature,
+          lesson_index: lessonIndex,
+        },
+        { onConflict: "user_id,lesson_id" }
+      );
+
+    if (progressError) {
+      logError({
+        errorId: ERROR_IDS.LESSON_COMPLETE_FAILED,
+        error: new Error(progressError.message),
+        context: {
+          route: "/api/lessons/complete",
+          step: "sync_progress",
+          userId: user.id,
+          courseId,
+          lessonId,
+        },
+      });
+    }
 
     return NextResponse.json({ success: true, signature });
   } catch (err: unknown) {


### PR DESCRIPTION
Closes #233

## Root cause

`POST /api/lessons/complete` fired the on-chain `completeLesson` tx and returned immediately — no direct Supabase write. All `user_progress` writes were delegated to the Helius webhook. When webhook delivery failed or was delayed (common on devnet), `user_progress` stayed empty and the dashboard showed 0/N lessons.

The same gap existed in the idempotency path: `alreadyOnChain = true` triggered an early return without syncing, so a missed-webhook lesson was never recovered even on retry.

## Fix

**`apps/web/src/app/api/lessons/complete/route.ts`**

- **Main path**: upsert `user_progress` immediately after `onChainCompleteLesson` returns, using the real `tx_signature`. Log any Supabase write error but don't fail the response (on-chain tx already succeeded).
- **`alreadyOnChain` path**: upsert with `ignoreDuplicates: true` before early return — fills the gap from a missed webhook without overwriting an existing `tx_signature` with `null`.

The Helius webhook still runs and upserts the same row (idempotent via `onConflict: "user_id,lesson_id"`). XP award stays in the webhook — it uses a tx-signature-keyed idempotency guard so no double-award is possible.

## Testing

1. Complete a lesson → navigate to dashboard → progress shows N/N immediately (not after webhook).
2. Complete the same lesson again (idempotency path) → dashboard still shows correct count.
3. Disable the Helius webhook, complete a lesson → progress still persists to dashboard.