### PR TITLE
fix(env): add BACKEND_SIGNER_SECRET to server env validation

### DIFF
--- a/apps/web/src/lib/env.server.ts
+++ b/apps/web/src/lib/env.server.ts
@@ -36,6 +36,11 @@ const serverEnvSchema = z.object({
   // Helius webhook HMAC verification secret.
   HELIUS_WEBHOOK_SECRET: optStr,
   // On-chain keypairs (JSON array of 64 bytes).
+  // BACKEND_SIGNER_SECRET is the rotatable backend signer stored in the Config
+  // PDA. Required for all server-side on-chain instructions (completeLesson,
+  // finalizeCourse, issueCredential, awardAchievement, rewardXp). On devnet
+  // this is typically the same keypair as PROGRAM_AUTHORITY_SECRET.
+  BACKEND_SIGNER_SECRET: optStr,
   XP_MINT_AUTHORITY_SECRET: optStr,
   PROGRAM_AUTHORITY_SECRET: optStr,
   // Anchor build-server proxy.
@@ -49,6 +54,7 @@ const parsed = serverEnvSchema.safeParse({
   SANITY_ADMIN_TOKEN: process.env.SANITY_ADMIN_TOKEN,
   ADMIN_SECRET: process.env.ADMIN_SECRET,
   HELIUS_WEBHOOK_SECRET: process.env.HELIUS_WEBHOOK_SECRET,
+  BACKEND_SIGNER_SECRET: process.env.BACKEND_SIGNER_SECRET,
   XP_MINT_AUTHORITY_SECRET: process.env.XP_MINT_AUTHORITY_SECRET,
   PROGRAM_AUTHORITY_SECRET: process.env.PROGRAM_AUTHORITY_SECRET,
   BUILD_SERVER_URL: process.env.BUILD_SERVER_URL,

--- a/apps/web/src/lib/solana/academy-program.ts
+++ b/apps/web/src/lib/solana/academy-program.ts
@@ -89,7 +89,7 @@ let _backendSigner: Keypair | null = null;
 
 export function getBackendSigner(): Keypair {
   if (_backendSigner) return _backendSigner;
-  const secret = process.env.BACKEND_SIGNER_SECRET;
+  const secret = serverEnv.BACKEND_SIGNER_SECRET;
   if (!secret) {
     throw new Error(
       "BACKEND_SIGNER_SECRET env var not set. Required for on-chain instructions."


### PR DESCRIPTION
## Root cause

`BACKEND_SIGNER_SECRET` was read directly via `process.env` in `academy-program.ts`, completely bypassing `env.server.ts`. With the var blank/unset on Vercel, `getBackendSigner()` threw unconditionally, making **every server-side on-chain instruction** (`completeLesson`, `finalizeCourse`, `issueCredential`, `awardAchievement`, `rewardXp`) hit the outer catch and return 500. This is why `POST /api/lessons/complete` has been returning 500 in production.

## Changes

- **`env.server.ts`**: add `BACKEND_SIGNER_SECRET` as `optStr` — coerces blank `""` → `undefined`, consistent with the other optional keypair vars; validated if present, cleared error at boot if malformed
- **`academy-program.ts`**: read from `serverEnv.BACKEND_SIGNER_SECRET` instead of `process.env` directly

## Required action before / alongside merging

**Set `BACKEND_SIGNER_SECRET` in the Vercel environment** to the 64-byte JSON array of the backend signer keypair. On devnet this is the same keypair as `PROGRAM_AUTHORITY_SECRET`. The public key is `AWFHfDZzmgZKgyv6ZFVjNBrtAKvjdThkG3JjJj4uC7cM`.

Without setting the env var this code change alone will not fix the 500 — it only ensures the var is validated through the standard schema path.