### PR TITLE
fix(gamification): enable Realtime for XP tables + optimistic header XP counter

### DIFF
--- a/apps/web/src/components/layout/header.tsx
+++ b/apps/web/src/components/layout/header.tsx
@@ -51,7 +51,37 @@ export function Header() {
 
   const { balance: onChainXp } = useXpBalance();
 
-  // XP fetching
+  // Animate the XP counter from prevXp up to newXp (eased count-up + glow).
+  const animateXpTo = useCallback((prevXp: number, newXp: number) => {
+    if (newXp > prevXp && prevXp > 0) {
+      setGlowing(true);
+      const diff = newXp - prevXp;
+      const duration = Math.min(800, Math.max(300, diff * 20));
+      const startTime = performance.now();
+
+      const animate = (now: number) => {
+        const elapsed = now - startTime;
+        const progress = Math.min(elapsed / duration, 1);
+        const eased = 1 - Math.pow(1 - progress, 3);
+        setDisplayedXp(Math.round(prevXp + diff * eased));
+
+        if (progress < 1) {
+          rafRef.current = requestAnimationFrame(animate);
+        } else {
+          setDisplayedXp(newXp);
+          setTimeout(() => setGlowing(false), 400);
+        }
+      };
+      cancelAnimationFrame(rafRef.current);
+      rafRef.current = requestAnimationFrame(animate);
+    } else {
+      setDisplayedXp(newXp);
+    }
+  }, []);
+
+  // XP fetching — reconciles the badge with the source of truth. The target is
+  // the max of (Supabase user_xp, on-chain balance, current target), so the
+  // counter only ever climbs and can't undo an optimistic gain.
   const fetchXp = useCallback(async () => {
     const supabase = createClient();
     const {
@@ -70,36 +100,11 @@ export function Header() {
       const newXp = Math.max(supabaseXp, targetXpRef.current);
       const prevXp = targetXpRef.current;
       targetXpRef.current = newXp;
-      const newLevel = calculateLevel(newXp);
-      prevLevelRef.current = newLevel;
-      setLevel(newLevel);
-
-      if (newXp > prevXp && prevXp > 0) {
-        setGlowing(true);
-        const diff = newXp - prevXp;
-        const duration = Math.min(800, Math.max(300, diff * 20));
-        const startTime = performance.now();
-
-        const animate = (now: number) => {
-          const elapsed = now - startTime;
-          const progress = Math.min(elapsed / duration, 1);
-          const eased = 1 - Math.pow(1 - progress, 3);
-          setDisplayedXp(Math.round(prevXp + diff * eased));
-
-          if (progress < 1) {
-            rafRef.current = requestAnimationFrame(animate);
-          } else {
-            setDisplayedXp(newXp);
-            setTimeout(() => setGlowing(false), 400);
-          }
-        };
-        cancelAnimationFrame(rafRef.current);
-        rafRef.current = requestAnimationFrame(animate);
-      } else {
-        setDisplayedXp(newXp);
-      }
+      prevLevelRef.current = calculateLevel(newXp);
+      setLevel(calculateLevel(newXp));
+      animateXpTo(prevXp, newXp);
     }
-  }, []);
+  }, [animateXpTo]);
 
   useEffect(() => {
     if (user) fetchXp();
@@ -122,15 +127,27 @@ export function Header() {
         setXpGainAmount(amount);
         clearTimeout(xpGainTimerRef.current);
         xpGainTimerRef.current = setTimeout(() => setXpGainAmount(null), 2600);
+
+        // Optimistically count the badge up by the gained amount so it tracks
+        // the +XP popup immediately — instead of staying frozen while the stale
+        // on-chain balance (captured at mount) sits ahead of Supabase. fetchXp
+        // and the on-chain effect reconcile via Math.max, so this never
+        // double-counts (they can't exceed the optimistic target).
+        const prevXp = targetXpRef.current;
+        const optimisticXp = prevXp + amount;
+        targetXpRef.current = optimisticXp;
+        prevLevelRef.current = calculateLevel(optimisticXp);
+        setLevel(calculateLevel(optimisticXp));
+        animateXpTo(prevXp, optimisticXp);
       }
-      setTimeout(fetchXp, 500);
+      setTimeout(fetchXp, 800);
     };
     window.addEventListener("xp-gain", handleXpGain);
     return () => {
       window.removeEventListener("xp-gain", handleXpGain);
       clearTimeout(xpGainTimerRef.current);
     };
-  }, [fetchXp]);
+  }, [fetchXp, animateXpTo]);
 
   const isLoggedIn = !!user && !!profile;
   const { xpInCurrentLevel, xpRequiredForNext } = xpToNextLevel(displayedXp);

--- a/apps/web/src/components/layout/header.tsx
+++ b/apps/web/src/components/layout/header.tsx
@@ -48,36 +48,53 @@ export function Header() {
   const prevLevelRef = useRef(0);
   const rafRef = useRef<number>(0);
   const xpGainTimerRef = useRef<ReturnType<typeof setTimeout>>();
+  const fetchXpTimerRef = useRef<ReturnType<typeof setTimeout>>();
+  // Mirrors `displayedXp` so an interrupted count-up resumes from the value
+  // actually on screen, not the previous target. Without it, a second gain
+  // arriving mid-animation snaps the counter up to the old target before
+  // continuing — a visible jump.
+  const displayedXpRef = useRef(0);
 
   const { balance: onChainXp } = useXpBalance();
 
-  // Animate the XP counter from prevXp up to newXp (eased count-up + glow).
-  const animateXpTo = useCallback((prevXp: number, newXp: number) => {
-    if (newXp > prevXp && prevXp > 0) {
-      setGlowing(true);
-      const diff = newXp - prevXp;
-      const duration = Math.min(800, Math.max(300, diff * 20));
-      const startTime = performance.now();
-
-      const animate = (now: number) => {
-        const elapsed = now - startTime;
-        const progress = Math.min(elapsed / duration, 1);
-        const eased = 1 - Math.pow(1 - progress, 3);
-        setDisplayedXp(Math.round(prevXp + diff * eased));
-
-        if (progress < 1) {
-          rafRef.current = requestAnimationFrame(animate);
-        } else {
-          setDisplayedXp(newXp);
-          setTimeout(() => setGlowing(false), 400);
-        }
-      };
-      cancelAnimationFrame(rafRef.current);
-      rafRef.current = requestAnimationFrame(animate);
-    } else {
-      setDisplayedXp(newXp);
-    }
+  // Single setter so the ref and the rendered state never drift apart.
+  const setDisplayed = useCallback((value: number) => {
+    displayedXpRef.current = value;
+    setDisplayedXp(value);
   }, []);
+
+  // Animate the XP counter up to newXp (eased count-up + glow), starting from
+  // whatever is currently rendered so a mid-animation interruption is seamless.
+  const animateXpTo = useCallback(
+    (newXp: number) => {
+      const fromXp = displayedXpRef.current;
+      if (newXp > fromXp && fromXp > 0) {
+        setGlowing(true);
+        const diff = newXp - fromXp;
+        const duration = Math.min(800, Math.max(300, diff * 20));
+        const startTime = performance.now();
+
+        const animate = (now: number) => {
+          const elapsed = now - startTime;
+          const progress = Math.min(elapsed / duration, 1);
+          const eased = 1 - Math.pow(1 - progress, 3);
+          setDisplayed(Math.round(fromXp + diff * eased));
+
+          if (progress < 1) {
+            rafRef.current = requestAnimationFrame(animate);
+          } else {
+            setDisplayed(newXp);
+            setTimeout(() => setGlowing(false), 400);
+          }
+        };
+        cancelAnimationFrame(rafRef.current);
+        rafRef.current = requestAnimationFrame(animate);
+      } else {
+        setDisplayed(newXp);
+      }
+    },
+    [setDisplayed]
+  );
 
   // XP fetching — reconciles the badge with the source of truth. The target is
   // the max of (Supabase user_xp, on-chain balance, current target), so the
@@ -98,11 +115,10 @@ export function Header() {
     if (data) {
       const supabaseXp = data.total_xp ?? 0;
       const newXp = Math.max(supabaseXp, targetXpRef.current);
-      const prevXp = targetXpRef.current;
       targetXpRef.current = newXp;
       prevLevelRef.current = calculateLevel(newXp);
       setLevel(calculateLevel(newXp));
-      animateXpTo(prevXp, newXp);
+      animateXpTo(newXp);
     }
   }, [animateXpTo]);
 
@@ -114,10 +130,10 @@ export function Header() {
   useEffect(() => {
     if (onChainXp > 0 && onChainXp > targetXpRef.current) {
       targetXpRef.current = onChainXp;
-      setDisplayedXp(onChainXp);
+      setDisplayed(onChainXp);
       setLevel(calculateLevel(onChainXp));
     }
-  }, [onChainXp]);
+  }, [onChainXp, setDisplayed]);
 
   useEffect(() => {
     const handleXpGain = (e: Event) => {
@@ -138,14 +154,16 @@ export function Header() {
         targetXpRef.current = optimisticXp;
         prevLevelRef.current = calculateLevel(optimisticXp);
         setLevel(calculateLevel(optimisticXp));
-        animateXpTo(prevXp, optimisticXp);
+        animateXpTo(optimisticXp);
       }
-      setTimeout(fetchXp, 800);
+      clearTimeout(fetchXpTimerRef.current);
+      fetchXpTimerRef.current = setTimeout(fetchXp, 800);
     };
     window.addEventListener("xp-gain", handleXpGain);
     return () => {
       window.removeEventListener("xp-gain", handleXpGain);
       clearTimeout(xpGainTimerRef.current);
+      clearTimeout(fetchXpTimerRef.current);
     };
   }, [fetchXp, animateXpTo]);
 

--- a/supabase/migrations/20260630120000_enable_realtime_gamification.sql
+++ b/supabase/migrations/20260630120000_enable_realtime_gamification.sql
@@ -1,0 +1,33 @@
+-- Enable Supabase Realtime for the gamification tables.
+--
+-- The client (hooks/use-gamification-events.ts, mounted globally via
+-- GamificationOverlays) subscribes to postgres_changes on these tables and
+-- dispatches the XP / level-up / achievement / certificate popups. The rows are
+-- written by the Helius webhook handler. Without the tables in the
+-- `supabase_realtime` publication, those INSERT/UPDATE events are never
+-- delivered to the browser, so completing a lesson awards XP but shows no
+-- animation. Supabase tables are NOT realtime-enabled by default and no prior
+-- migration added them.
+--
+-- Idempotent: only adds tables not already members of the publication, so it is
+-- safe to re-run and safe if some tables were toggled on via the dashboard.
+DO $$
+DECLARE
+  t text;
+BEGIN
+  FOREACH t IN ARRAY ARRAY[
+    'xp_transactions',
+    'user_xp',
+    'user_achievements',
+    'certificates'
+  ] LOOP
+    IF NOT EXISTS (
+      SELECT 1 FROM pg_publication_tables
+      WHERE pubname = 'supabase_realtime'
+        AND schemaname = 'public'
+        AND tablename = t
+    ) THEN
+      EXECUTE format('ALTER PUBLICATION supabase_realtime ADD TABLE public.%I', t);
+    END IF;
+  END LOOP;
+END $$;


### PR DESCRIPTION
Completing a lesson awarded XP on-chain and in Supabase, but the UI gave no feedback. Two causes, both fixed:

## 1. Realtime never delivered the XP events (migration)
The client (`useGamificationEvents`, mounted globally) subscribes to `postgres_changes` on `xp_transactions`/`user_xp`/`user_achievements`/`certificates` to fire the XP / level-up / achievement / certificate popups. But **none of those tables were in the `supabase_realtime` publication** (no migration ever added them; Supabase tables aren't realtime by default), so the INSERTs were never pushed to the browser → no popup.

`supabase/migrations/20260630120000_enable_realtime_gamification.sql` adds them (idempotent). **Already applied to the live DB**; verified the four tables are now published.

## 2. Header XP counter stayed frozen
The badge reads the **on-chain** XP balance (`useXpBalance`, fetched once on mount, never refetched on `xp-gain`) via `Math.max` with Supabase `user_xp`. After the webhook outage the on-chain balance is ~35 XP **ahead** of Supabase, so new Supabase XP couldn't push the max past the stale on-chain value — the counter looked frozen while +XP popups fired.

Now each `xp-gain` optimistically counts the badge up by the gained amount; `fetchXp` + the on-chain effect still reconcile via `Math.max`, so it can't double-count. `tsc` clean.

## Verified
- Realtime publication now lists all four tables (SQL).
- User's `user_xp.total_xp` == `sum(xp_transactions)` == 1290 (8 tx) — webhook sync is correct; the gap is on-chain (1325) vs Supabase, a separate backfill.