### PR TITLE
fix(ci): align packageManager with pnpm 10 lockfile

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
       "@noble/hashes": "^1.8.0"
     }
   },
-  "packageManager": "pnpm@9.15.0",
+  "packageManager": "pnpm@10.34.4+sha512.8768be55200ae3f2226b6527fcca2687e14bc4e5f12d7721a0f25da3df47915177058648db4177baf348120fa0ba2752d8d8d93f6beaf1fe64ae18da8de961af",
   "engines": {
     "node": ">=18"
   }


### PR DESCRIPTION
## Summary

Fixes the CI `Frontend (lint · typecheck · test)` failure where `pnpm install --frozen-lockfile` was rejected before `pnpm typecheck` could run.

## Root cause

- `package.json` pinned `"packageManager": "pnpm@9.15.0"`
- `pnpm-lock.yaml` (`lockfileVersion: '9.0'`) was generated by **pnpm 10.x**
- `pnpm/action-setup@v4` installs the pinned 9.15.0 and `--frozen-lockfile` rejects the pnpm-10-generated lockfile

Vercel auto-selected pnpm 10 and only warned, masking the issue there — but CI hard-failed.

## Change

Bump `packageManager` to `pnpm@10.34.4` via `corepack use pnpm@10` so the pinned manager matches the lockfile. **Lockfile content is unchanged** (it was already pnpm-10-compatible) — only the `packageManager` field moves.

## Verification

```
pnpm install --frozen-lockfile   # exit 0
pnpm typecheck                    # 5 tasks successful
```

Closes #239
