### PR TITLE
fix(csp): nonce-based script-src for the app + pin wildcards (#177)

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -4,38 +4,28 @@ import { withSentryConfig } from "@sentry/nextjs";
 const withNextIntl = createNextIntlPlugin("./src/lib/i18n/request.ts");
 
 /**
- * Content-Security-Policy.
+ * Static Content-Security-Policy FALLBACK for routes the middleware does not
+ * run on — namely `/studio/*` (Sanity Studio) and `/api/*`. The user-facing app
+ * gets a stricter, per-request nonce CSP built in `middleware.ts` + `lib/csp.ts`
+ * (no `'unsafe-inline'` for scripts); middleware response headers override these
+ * static ones where both apply, so the nonce policy wins for matched routes.
  *
- * This is an ENFORCING policy tuned to keep every legitimate integration
- * working. Where a directive can't be locked down without breaking runtime
- * behaviour it is left permissive on purpose (see inline `unsafe-*` notes and
- * `TODO tighten` markers). Tightening any of these requires runtime QA of the
- * affected feature first.
+ * Studio KEEPS `'unsafe-inline'` + `'unsafe-eval'` for scripts: it is a
+ * third-party SPA bundle that cannot be nonced and relies on eval. `/api/*`
+ * returns JSON/binary (no inline scripts), so the script policy is moot there.
+ * Keep the non-script directives here in rough sync with `lib/csp.ts`.
  *
  * Notable allowances:
- * - `'unsafe-eval'` in script-src — REQUIRED. The in-browser code-challenge
- *   sandbox (`components/editor/challenge-runner.tsx`) runs learner code via
- *   `new Function()`, and Monaco's tokenizer/worker bootstrap also relies on
- *   it. Removing it WILL break the editor and challenge runner.
- * - `'unsafe-inline'` in script-src/style-src — Next.js injects an inline
- *   bootstrap script and inline critical CSS; nonces are not wired up.
- * - Server-only externals (Gemini, Rust Playground, build server) are NOT
- *   listed: the browser only ever talks to same-origin `/api/*` routes that
- *   proxy them.
- *
- * KNOWN DEFERRED LIMITATION: `'unsafe-inline'` + `'unsafe-eval'` keep the
- * script CSP weak — together they neutralise CSP's XSS protection for inline
- * and eval'd scripts. Closing this requires a nonce- (or hash-) based script
- * CSP wired through Next.js's inline bootstrap; that is intentionally NOT
- * attempted here. Tracked by the `TODO tighten` marker below.
+ * - `'unsafe-eval'` in script-src — REQUIRED for Studio (and Monaco, on the
+ *   middleware path). - Server-only externals (Gemini, Rust Playground, build
+ *   server) are NOT listed: the browser only talks to same-origin `/api/*`.
  */
 const cspDirectives = [
   "default-src 'self'",
 
-  // Scripts: self + GA4 tag loader + PostHog. 'unsafe-eval' for the code
-  // sandbox / Monaco; 'unsafe-inline' for the Next.js bootstrap + analytics
-  // snippets; blob: for Monaco/worker bootstrap; jsdelivr for the Monaco
-  // editor loader (@monaco-editor/react fetches loader.js + vs/* from the CDN).
+  // Scripts (Studio/API fallback): 'unsafe-inline' is REQUIRED for the Sanity
+  // Studio bundle, which cannot be nonced. The user-facing app does NOT use
+  // this — its middleware CSP replaces 'unsafe-inline' with a per-request nonce.
   "script-src 'self' 'unsafe-eval' 'unsafe-inline' blob: https://cdn.jsdelivr.net https://www.googletagmanager.com https://*.posthog.com",
 
   // Styles: 'unsafe-inline' required by Next.js (and Sanity Studio) inline CSS.
@@ -47,14 +37,16 @@ const cspDirectives = [
 
   // Images: avatars (Google), NFT art (Arweave), Supabase storage, Sanity CDN +
   // Studio media library, GA4 measurement pixel (doubleclick). data:/blob:
-  // cover inline SVGs, canvas-confetti, and wallet QR codes.
+  // cover inline SVGs, canvas-confetti, and wallet QR codes. Supabase stays a
+  // wildcard here (Studio/API fallback); the app's middleware CSP pins it.
   "img-src 'self' data: blob: https://cdn.sanity.io https://media.sanity.io https://lh3.googleusercontent.com https://arweave.net https://*.arweave.net https://*.supabase.co https://stats.g.doubleclick.net",
 
   // Network: Supabase (REST + realtime wss), Sanity (CDN/API + listen wss),
   // Solana/Helius RPC, Google OAuth/identity, and analytics (GA4, PostHog,
-  // Sentry). Wildcards because project subdomains differ per environment.
-  // TODO tighten — pin Supabase/Helius/Sanity to concrete project subdomains
-  // once the production hostnames are fixed.
+  // Sentry). Wildcards here because this fallback is build-time and serves
+  // Studio (admin-only); the app's middleware CSP pins Supabase + the Solana
+  // RPC to concrete hosts at request time. Sanity/PostHog/Sentry stay wildcards
+  // in both — regional/multi-subdomain ingest hosts, pinning risks breakage.
   [
     "connect-src 'self'",
     "https://*.supabase.co wss://*.supabase.co",
@@ -83,10 +75,6 @@ const cspDirectives = [
 
 const securityHeaders = [
   {
-    key: "Content-Security-Policy",
-    value: cspDirectives.join("; "),
-  },
-  {
     key: "Strict-Transport-Security",
     value: "max-age=63072000; includeSubDomains; preload",
   },
@@ -108,6 +96,14 @@ const securityHeaders = [
     value: "camera=(), microphone=(), geolocation=(), interest-cohort=()",
   },
 ];
+
+// Static CSP header, applied ONLY to routes the middleware skips (`/studio/*`,
+// `/api/*`). Matched app routes get the per-request nonce CSP from middleware,
+// which overrides this where both apply.
+const staticCspHeader = {
+  key: "Content-Security-Policy",
+  value: cspDirectives.join("; "),
+};
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
@@ -134,8 +130,22 @@ const nextConfig = {
   async headers() {
     return [
       {
+        // Global hardening headers (HSTS, X-Frame-Options, etc.). No CSP here —
+        // the app's CSP comes from middleware; Studio/API CSP is added below.
         source: "/:path*",
         headers: securityHeaders,
+      },
+      {
+        // Sanity Studio is excluded from middleware, so apply the static CSP
+        // fallback (keeps 'unsafe-inline'/'unsafe-eval' for the Studio bundle).
+        source: "/studio/:path*",
+        headers: [staticCspHeader],
+      },
+      {
+        // API routes are excluded from middleware too. They serve JSON/binary,
+        // so the script policy is moot, but keep a CSP for defense-in-depth.
+        source: "/api/:path*",
+        headers: [staticCspHeader],
       },
     ];
   },

--- a/apps/web/src/app/[locale]/layout.tsx
+++ b/apps/web/src/app/[locale]/layout.tsx
@@ -1,3 +1,4 @@
+import { headers } from "next/headers";
 import { NextIntlClientProvider } from "next-intl";
 import { getMessages } from "next-intl/server";
 import { notFound } from "next/navigation";
@@ -25,12 +26,17 @@ export default async function LocaleLayout({
 
   const messages = await getMessages();
 
+  // CSP nonce set by middleware (lib/csp.ts). next-themes stamps it onto its
+  // inline theme-flash-prevention <script> so it satisfies the nonce policy.
+  const nonce = (await headers()).get("x-nonce") ?? undefined;
+
   return (
     <ThemeProvider
       attribute="data-theme"
       defaultTheme="dark"
       enableSystem
       disableTransitionOnChange
+      nonce={nonce}
     >
       <NextIntlClientProvider messages={messages}>
         <SolanaWalletProvider>

--- a/apps/web/src/lib/csp.ts
+++ b/apps/web/src/lib/csp.ts
@@ -93,8 +93,10 @@ export function buildCsp(nonce: string): string {
 
     // Styles: 'unsafe-inline' required by Next.js (and Sanity Studio) inline
     // CSS — out of scope for nonce'ing. fonts.googleapis.com allows the Google
-    // Fonts stylesheet link.
-    "style-src 'self' 'unsafe-inline' https://cdn.sanity.io https://fonts.googleapis.com",
+    // Fonts stylesheet link; cdn.jsdelivr.net allows Monaco's editor.main.css —
+    // the challenge-runner editor loads its stylesheet from the CDN, so without
+    // this the editor renders unstyled/broken.
+    "style-src 'self' 'unsafe-inline' https://cdn.sanity.io https://cdn.jsdelivr.net https://fonts.googleapis.com",
 
     // Fonts: self-hosted via next/font + Google Fonts (gstatic serves the files).
     "font-src 'self' data: https://fonts.gstatic.com",
@@ -121,6 +123,8 @@ export function buildCsp(nonce: string): string {
       "connect-src 'self'",
       `${supabase.http} ${supabase.ws}`,
       "https://api.sanity.io https://cdn.sanity.io https://*.apicdn.sanity.io https://*.api.sanity.io wss://*.api.sanity.io https://media.sanity.io",
+      // Monaco fetches its source maps (loader.js.map, vs/*.map) from jsdelivr.
+      "https://cdn.jsdelivr.net",
       ...solanaRpcSources(),
       "https://accounts.google.com https://*.googleapis.com",
       "https://www.googletagmanager.com https://www.google-analytics.com https://*.google-analytics.com https://stats.g.doubleclick.net",

--- a/apps/web/src/lib/csp.ts
+++ b/apps/web/src/lib/csp.ts
@@ -1,0 +1,157 @@
+/**
+ * Per-request Content-Security-Policy builder (used by `middleware.ts`).
+ *
+ * This is the ENFORCING policy for the user-facing app. It is built per request
+ * so `script-src` can carry a fresh `'nonce-<value>'` instead of
+ * `'unsafe-inline'` — Next.js extracts that nonce from the `Content-Security-
+ * Policy` request header and stamps it onto its inline bootstrap/hydration
+ * scripts (see middleware). Inline analytics are injected programmatically, not
+ * as inline `<script>` tags, so they ride the host allowlist below.
+ *
+ * Scope: this CSP only applies to routes the middleware matches. `/studio/*`
+ * (Sanity Studio) and `/api/*` are EXCLUDED from middleware, so they fall back
+ * to the static CSP in `next.config.mjs` — keep the two in rough sync when
+ * editing the non-script directives. Studio genuinely needs `'unsafe-inline'`/
+ * `'unsafe-eval'` for scripts (third-party bundle that can't be nonced), which
+ * is why it stays on the static fallback rather than this nonce policy.
+ *
+ * Notable script-src allowances:
+ * - `'unsafe-eval'` — REQUIRED. The in-browser code-challenge sandbox
+ *   (`components/editor/challenge-runner.tsx`) runs learner code via
+ *   `new Function()` in a Worker, and Monaco's tokenizer/worker bootstrap also
+ *   relies on it. Removing it WILL break the editor and challenge runner.
+ * - NO `'strict-dynamic'` — intentionally omitted. `@monaco-editor/react`
+ *   loads Monaco's AMD `loader.js` + `vs/*` chunks from jsdelivr by host, and
+ *   `'strict-dynamic'` would discard the host allowlist (breaking that CDN
+ *   loader). Without it, nonce'd inline scripts and host-allowlisted external
+ *   scripts (Monaco CDN, GA4, PostHog) coexist — exactly what we need.
+ * - `'unsafe-inline'` is DROPPED for scripts (the point of this change). It is
+ *   still present for `style-src` (Next.js + Sanity inject inline CSS that
+ *   can't be nonced easily — out of scope).
+ */
+
+/** Extracts the `scheme://host[:port]` origin from a URL, or null if invalid. */
+function originOf(url: string | undefined): string | null {
+  if (!url) return null;
+  try {
+    return new URL(url).origin;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Pins `*.supabase.co` to the concrete project origin from
+ * NEXT_PUBLIC_SUPABASE_URL (required, stable per deployment). Returns both the
+ * https origin and its wss:// equivalent (Supabase Realtime). Falls back to the
+ * `*.supabase.co` wildcard if the env var is missing/malformed so connectivity
+ * is never broken by a config gap.
+ */
+function supabaseSources(): { http: string; ws: string } {
+  const origin = originOf(process.env.NEXT_PUBLIC_SUPABASE_URL);
+  if (!origin) {
+    return { http: "https://*.supabase.co", ws: "wss://*.supabase.co" };
+  }
+  return { http: origin, ws: origin.replace(/^https:/, "wss:") };
+}
+
+/**
+ * The browser only ever talks to NEXT_PUBLIC_SOLANA_RPC_URL, so pin
+ * `connect-src` to that exact origin instead of the broad `*.helius-rpc.com`
+ * wildcard. The two public Solana endpoints stay allowed as fallbacks. If the
+ * env var is malformed, keep the Helius wildcard so RPC is never blocked.
+ */
+function solanaRpcSources(): string[] {
+  const origin = originOf(process.env.NEXT_PUBLIC_SOLANA_RPC_URL);
+  const base = [
+    "https://api.devnet.solana.com",
+    "https://api.mainnet-beta.solana.com",
+  ];
+  if (!origin) return ["https://*.helius-rpc.com", ...base];
+  // Avoid duplicating one of the public endpoints if that's what's configured.
+  return base.includes(origin) ? base : [origin, ...base];
+}
+
+/**
+ * Builds the full CSP directive string for a request, embedding `nonce` into
+ * `script-src`. Keep non-script directives in sync with the static fallback in
+ * `next.config.mjs`.
+ */
+export function buildCsp(nonce: string): string {
+  const supabase = supabaseSources();
+
+  const directives = [
+    "default-src 'self'",
+
+    // Scripts: self + per-request nonce (Next.js inline bootstrap) + GA4 tag
+    // loader + PostHog. 'unsafe-eval' for the code sandbox / Monaco; blob: for
+    // Monaco/worker bootstrap; jsdelivr for the Monaco editor loader
+    // (@monaco-editor/react fetches loader.js + vs/* from the CDN). No
+    // 'unsafe-inline' (replaced by the nonce) and no 'strict-dynamic' (see
+    // module docblock).
+    `script-src 'self' 'nonce-${nonce}' 'unsafe-eval' blob: https://cdn.jsdelivr.net https://www.googletagmanager.com https://*.posthog.com`,
+
+    // Styles: 'unsafe-inline' required by Next.js (and Sanity Studio) inline
+    // CSS — out of scope for nonce'ing. fonts.googleapis.com allows the Google
+    // Fonts stylesheet link.
+    "style-src 'self' 'unsafe-inline' https://cdn.sanity.io https://fonts.googleapis.com",
+
+    // Fonts: self-hosted via next/font + Google Fonts (gstatic serves the files).
+    "font-src 'self' data: https://fonts.gstatic.com",
+
+    // Images: avatars (Google), NFT art (Arweave), Supabase storage (pinned to
+    // the project host), Sanity CDN + Studio media library, GA4 measurement
+    // pixel (doubleclick). data:/blob: cover inline SVGs, canvas-confetti, and
+    // wallet QR codes.
+    [
+      "img-src 'self' data: blob:",
+      "https://cdn.sanity.io https://media.sanity.io",
+      "https://lh3.googleusercontent.com",
+      "https://arweave.net https://*.arweave.net",
+      supabase.http,
+      "https://stats.g.doubleclick.net",
+    ].join(" "),
+
+    // Network: Supabase (REST + realtime wss, pinned to the project host),
+    // Sanity (CDN/API + listen wss — wildcards kept: regional/multi-subdomain),
+    // Solana RPC (pinned to the configured browser endpoint), Google
+    // OAuth/identity, and analytics (GA4, PostHog, Sentry — wildcards kept:
+    // region-dependent ingest subdomains).
+    [
+      "connect-src 'self'",
+      `${supabase.http} ${supabase.ws}`,
+      "https://api.sanity.io https://cdn.sanity.io https://*.apicdn.sanity.io https://*.api.sanity.io wss://*.api.sanity.io https://media.sanity.io",
+      ...solanaRpcSources(),
+      "https://accounts.google.com https://*.googleapis.com",
+      "https://www.googletagmanager.com https://www.google-analytics.com https://*.google-analytics.com https://stats.g.doubleclick.net",
+      "https://*.posthog.com https://*.sentry.io https://*.ingest.sentry.io",
+    ].join(" "),
+
+    // Frames: Sanity Studio is a same-origin embed; Google OAuth may use frames.
+    "frame-src 'self' https://accounts.google.com",
+
+    // Workers: code sandbox + Monaco spawn workers from blob: URLs; Monaco also
+    // loads its language workers (ts/json/css/html) directly from jsdelivr.
+    "worker-src 'self' blob: https://cdn.jsdelivr.net",
+
+    // Forms may post to self and the Google OAuth endpoint.
+    "form-action 'self' https://accounts.google.com",
+
+    // Hardening directives.
+    "base-uri 'self'",
+    "object-src 'none'",
+    "frame-ancestors 'self'",
+  ];
+
+  return directives.join("; ");
+}
+
+/** Generates a fresh base64 nonce for a request (Edge/Web Crypto safe). */
+export function generateNonce(): string {
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  // btoa is available in the Edge runtime; avoid Node Buffer for portability.
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary);
+}

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -4,6 +4,7 @@ import createIntlMiddleware from "next-intl/middleware";
 import { env } from "@/lib/env";
 import { locales, defaultLocale } from "@/lib/i18n/config";
 import { ADMIN_SESSION_MAX_AGE_MS } from "@/lib/admin/session-format";
+import { buildCsp, generateNonce } from "@/lib/csp";
 
 // NOTE: This Edge-runtime `isValidAdminSession` (Web Crypto) must stay in sync
 // with the Node-runtime implementation in `lib/admin/auth.ts` (Node `crypto`).
@@ -97,6 +98,17 @@ function isProtectedRoute(pathname: string): boolean {
 }
 
 export async function middleware(request: NextRequest) {
+  // Per-request CSP nonce. Set on the REQUEST headers so (a) Next.js extracts
+  // the nonce from the Content-Security-Policy request header and stamps it onto
+  // its inline bootstrap scripts, and (b) server components can read x-nonce.
+  // next-intl copies request.headers when forwarding, and the Supabase
+  // NextResponse.next({ request }) calls below pick up the same mutated headers,
+  // so setting them here is enough to propagate the nonce to the renderer.
+  const nonce = generateNonce();
+  const csp = buildCsp(nonce);
+  request.headers.set("x-nonce", nonce);
+  request.headers.set("Content-Security-Policy", csp);
+
   // Create a response that we'll modify
   let supabaseResponse = NextResponse.next({ request });
 
@@ -131,8 +143,13 @@ export async function middleware(request: NextRequest) {
     data: { user },
   } = await supabase.auth.getUser();
 
-  // Now run intl middleware (after Supabase may have modified request cookies)
+  // Now run intl middleware (after Supabase may have modified request cookies).
+  // next-intl forwards request.headers (incl. the nonce + CSP set above) to the
+  // renderer, so Next.js can apply the nonce to its inline bootstrap scripts.
   const intlResponse = intlMiddleware(request);
+
+  // Enforce the CSP in the browser by also setting it on the response.
+  intlResponse.headers.set("Content-Security-Policy", csp);
 
   // Copy Supabase cookies from supabaseResponse to intlResponse,
   // preserving all options (httpOnly, maxAge, sameSite, secure, path, etc.)
@@ -151,7 +168,11 @@ export async function middleware(request: NextRequest) {
         const locale =
           locales.find((l) => request.nextUrl.pathname.startsWith(`/${l}`)) ??
           defaultLocale;
-        return NextResponse.redirect(new URL(`/${locale}/admin`, request.url));
+        const adminRedirect = NextResponse.redirect(
+          new URL(`/${locale}/admin`, request.url)
+        );
+        adminRedirect.headers.set("Content-Security-Policy", csp);
+        return adminRedirect;
       }
     }
     return intlResponse;
@@ -165,6 +186,7 @@ export async function middleware(request: NextRequest) {
         defaultLocale;
       const redirectUrl = new URL(`/${locale}`, request.url);
       const redirectResponse = NextResponse.redirect(redirectUrl);
+      redirectResponse.headers.set("Content-Security-Policy", csp);
       // Copy Supabase cookies even to redirect responses (preserve all options)
       supabaseResponse.cookies.getAll().forEach((cookie) => {
         redirectResponse.cookies.set(cookie);


### PR DESCRIPTION
Closes #177.

## What changed
Splits the CSP into two policies:
- **App routes** → a per-request **nonce** `script-src` (built in `middleware.ts` + new `lib/csp.ts`), dropping `'unsafe-inline'` for scripts.
- **`/studio/*` + `/api/*`** (excluded from middleware) → keep the static `'unsafe-inline'` fallback in `next.config.mjs` (Sanity Studio is a third-party bundle that can't be nonced; API serves JSON).

Key decisions:
- **`'unsafe-eval'` KEPT** — the challenge sandbox (`new Function`) + Monaco need it.
- **No `'strict-dynamic'`** — it would discard the host allowlist and break Monaco's jsdelivr AMD loader.
- Nonce stamped onto Next's inline bootstrap + the `next-themes` inline script; analytics (GA4/PostHog) load as **host-allowlisted external** scripts, so they need no nonce.
- **Wildcard pinning:** Supabase + the Solana RPC pinned to their configured origins, each with a wildcard fallback so a config gap can't break connectivity. Sanity/PostHog/Sentry kept as wildcards (regional/multi-subdomain ingest hosts — pinning risks breakage).

## Verification status — ⚠️ runtime check still required
- CI validates build + unit tests.
- I've **design-reviewed** this end-to-end (nonce propagation path, unsafe-eval retained, analytics external, conservative pinning) — it's sound.
- **NOT yet done:** a live-browser runtime check that Next actually propagates the nonce to its inline bootstrap and that Monaco / the challenge runner / Sanity Studio / analytics load with **zero CSP violations**. This is the real gate for a CSP change (a prior CSP change broke Monaco app-wide), so **do not merge until that live check passes.**

`needs-human-review` — high-risk CSP change; verify in a live preview first.