### PR TITLE
fix(challenge): grade Rust submissions server-side so completion works

### DIFF
--- a/apps/web/src/app/api/lessons/complete/route.ts
+++ b/apps/web/src/app/api/lessons/complete/route.ts
@@ -125,15 +125,16 @@ export async function POST(request: NextRequest) {
             { status: 503 }
           );
         case "non_js_challenge":
-          // FAIL CLOSED. Rust / buildable challenges must be graded by the Rust
-          // playground / build server (a separate trust boundary), but that
-          // validation handshake is NOT wired up yet. Until it is, the server
-          // cannot prove the submission is correct, so it MUST NOT submit the
-          // on-chain completeLesson — a bare fall-through here would grant a
+          // FAIL CLOSED. Only `buildType: "buildable"` challenges reach here now
+          // (plain Rust is graded server-side via the Rust Playground and
+          // resolves to `validated`). Buildable challenges must be compiled +
+          // graded by the Anchor build server, and that handshake is NOT wired
+          // up yet — so the server cannot prove correctness and MUST NOT submit
+          // the on-chain completeLesson. A bare fall-through would grant a
           // completion (and credential eligibility) for any unverified
-          // Rust/buildable submission. Deny exactly like executor_unavailable.
-          // TODO(#195 follow-up): wire a real Rust/build-server validation
-          // handshake, then gate this branch on its passing verdict.
+          // buildable submission. Deny exactly like executor_unavailable.
+          // TODO(#195 follow-up): wire the build-server validation handshake,
+          // then gate this branch on its passing verdict.
           return NextResponse.json(
             {
               error:

--- a/apps/web/src/lib/challenge/__tests__/executor.test.ts
+++ b/apps/web/src/lib/challenge/__tests__/executor.test.ts
@@ -252,13 +252,10 @@ describe("validateAgainstAnswerKey (classification, no executor)", () => {
     expect(verdict.kind).toBe("not_a_challenge");
   });
 
-  it("classifies rust / buildable challenges as non_js_challenge", async () => {
-    const rust = await validateAgainstAnswerKey(
-      answerKey({ language: "rust" }),
-      "fn add() {}"
-    );
-    expect(rust.kind).toBe("non_js_challenge");
-
+  // Plain `language: "rust"` challenges are now graded by the Rust executor
+  // (see rust-executor.test.ts). Only `buildType: "buildable"` still fails
+  // closed here — its build-server grading handshake isn't wired up.
+  it("classifies buildable challenges as non_js_challenge", async () => {
     const buildable = await validateAgainstAnswerKey(
       answerKey({ buildType: "buildable" }),
       "// program"

--- a/apps/web/src/lib/challenge/__tests__/rust-executor.test.ts
+++ b/apps/web/src/lib/challenge/__tests__/rust-executor.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import type { AdminTestCase } from "@superteam-lms/types";
+import { runRustSubmission } from "../rust-executor";
+import { validateAgainstAnswerKey } from "../validate";
+import type { ChallengeAnswerKey } from "@/lib/sanity/queries";
+
+const tests: AdminTestCase[] = [
+  { id: "v1", description: "visible", input: "2, 3", expectedOutput: "5" },
+  {
+    id: "h1",
+    description: "hidden",
+    input: "10, 20",
+    expectedOutput: "30",
+    hidden: true,
+  },
+];
+
+const CODE = "fn add(a: i32, b: i32) -> i32 { a + b }";
+
+/**
+ * Stub the Rust Playground. The callback receives the assembled harness and the
+ * per-request nonce recovered from it, and returns the stdout/stderr the
+ * Playground would produce — so tests exercise the real nonce-guarded parser.
+ */
+function mockPlayground(
+  respond: (
+    nonce: string,
+    code: string
+  ) => { ok?: boolean; success?: boolean; stdout?: string; stderr?: string }
+) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (_url: string, init: { body: string }) => {
+      const { code } = JSON.parse(init.body) as { code: string };
+      const nonce = code.match(/TEST_([0-9a-f]{24})_/)?.[1] ?? "";
+      const r = respond(nonce, code);
+      return {
+        ok: r.ok ?? true,
+        json: async () => ({
+          success: r.success ?? true,
+          stdout: r.stdout ?? "",
+          stderr: r.stderr ?? "",
+        }),
+      } as unknown as Response;
+    })
+  );
+}
+
+const passAll = (nonce: string) =>
+  `TEST_${nonce}_0_PASS\nTEST_${nonce}_1_PASS\n`;
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("runRustSubmission", () => {
+  it("passes only when every test (incl. hidden) passes", async () => {
+    mockPlayground((n) => ({ stdout: passAll(n) }));
+    const r = await runRustSubmission(CODE, tests);
+    expect(r.available).toBe(true);
+    expect(r).toMatchObject({ passed: true });
+  });
+
+  it("fails when a hidden test fails even if the visible one passes", async () => {
+    mockPlayground((n) => ({
+      stdout: `TEST_${n}_0_PASS\nTEST_${n}_1_FAIL: expected 30, got 200\n`,
+    }));
+    const r = await runRustSubmission(CODE, tests);
+    expect(r).toMatchObject({ available: true, passed: false });
+    if (r.available) {
+      expect(r.results[0].passed).toBe(true);
+      expect(r.results[1].passed).toBe(false);
+      expect(r.results[1].hidden).toBe(true);
+    }
+  });
+
+  it("does NOT trust unguarded markers a submission prints itself", async () => {
+    // Submission emits a marker WITHOUT the server nonce — must not count.
+    mockPlayground(() => ({ stdout: "TEST_0_PASS\nTEST_1_PASS\n" }));
+    const r = await runRustSubmission(CODE, tests);
+    expect(r).toMatchObject({ available: true, passed: false });
+  });
+
+  it("treats a compile failure as all-failed, not an outage", async () => {
+    mockPlayground(() => ({
+      success: false,
+      stdout: "",
+      stderr: "error[E0425]: cannot find value `x` in this scope",
+    }));
+    const r = await runRustSubmission(CODE, tests);
+    expect(r).toMatchObject({ available: true, passed: false });
+    if (r.available) {
+      expect(r.results[0].detail).toContain("error");
+    }
+  });
+
+  it("degrades closed when the Playground is unreachable", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new Error("ECONNREFUSED");
+      })
+    );
+    const r = await runRustSubmission(CODE, tests);
+    expect(r).toEqual({ available: false, reason: "executor_unavailable" });
+  });
+
+  it("degrades closed on a non-2xx Playground response", async () => {
+    mockPlayground(() => ({ ok: false }));
+    const r = await runRustSubmission(CODE, tests);
+    expect(r).toEqual({ available: false, reason: "executor_unavailable" });
+  });
+
+  it("rejects source-reflection macros without calling the Playground", async () => {
+    const spy = vi.fn();
+    vi.stubGlobal("fetch", spy);
+    const r = await runRustSubmission(
+      "fn add(a: i32, b: i32) -> i32 { let _ = include_str!(file!()); a + b }",
+      tests
+    );
+    expect(r).toMatchObject({ available: true, passed: false });
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when no top-level function is present", async () => {
+    const spy = vi.fn();
+    vi.stubGlobal("fetch", spy);
+    const r = await runRustSubmission("fn main() { let x = 1; }", tests);
+    expect(r).toMatchObject({ available: true, passed: false });
+    expect(spy).not.toHaveBeenCalled();
+  });
+});
+
+describe("validateAgainstAnswerKey — Rust routing", () => {
+  const rustKey: ChallengeAnswerKey = {
+    _id: "l1",
+    type: "challenge",
+    language: "rust",
+    buildType: null,
+    tests,
+    solution: CODE,
+  };
+
+  it("grades a rust challenge to a validated verdict", async () => {
+    mockPlayground((n) => ({ stdout: passAll(n) }));
+    const v = await validateAgainstAnswerKey(rustKey, CODE);
+    expect(v).toMatchObject({ kind: "validated", passed: true });
+  });
+
+  it("maps a Playground outage to executor_unavailable (deny completion)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new Error("down");
+      })
+    );
+    const v = await validateAgainstAnswerKey(rustKey, CODE);
+    expect(v.kind).toBe("executor_unavailable");
+  });
+
+  it("still fails a buildable challenge closed as non_js_challenge", async () => {
+    const spy = vi.fn();
+    vi.stubGlobal("fetch", spy);
+    const buildableKey: ChallengeAnswerKey = {
+      ...rustKey,
+      buildType: "buildable",
+    };
+    const v = await validateAgainstAnswerKey(buildableKey, CODE);
+    expect(v.kind).toBe("non_js_challenge");
+    expect(spy).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/challenge/__tests__/rust-executor.test.ts
+++ b/apps/web/src/lib/challenge/__tests__/rust-executor.test.ts
@@ -69,9 +69,9 @@ describe("runRustSubmission", () => {
     const r = await runRustSubmission(CODE, tests);
     expect(r).toMatchObject({ available: true, passed: false });
     if (r.available) {
-      expect(r.results[0].passed).toBe(true);
-      expect(r.results[1].passed).toBe(false);
-      expect(r.results[1].hidden).toBe(true);
+      expect(r.results[0]?.passed).toBe(true);
+      expect(r.results[1]?.passed).toBe(false);
+      expect(r.results[1]?.hidden).toBe(true);
     }
   });
 
@@ -91,7 +91,7 @@ describe("runRustSubmission", () => {
     const r = await runRustSubmission(CODE, tests);
     expect(r).toMatchObject({ available: true, passed: false });
     if (r.available) {
-      expect(r.results[0].detail).toContain("error");
+      expect(r.results[0]?.detail).toContain("error");
     }
   });
 

--- a/apps/web/src/lib/challenge/rust-executor.ts
+++ b/apps/web/src/lib/challenge/rust-executor.ts
@@ -1,0 +1,242 @@
+/**
+ * Authoritative server-side grader for Rust challenge submissions.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * `/api/lessons/complete` must independently prove a submission passes ALL
+ * tests (visible + hidden) before it records an on-chain completion. For
+ * JS/TS challenges that proof comes from the isolated-vm executor
+ * (`executor.ts`). Rust challenges (`language: "rust"`, NOT `buildType:
+ * "buildable"`) are graded here: the submission is compiled + run on the Rust
+ * Playground — the same upstream the browser runner uses — but the SERVER runs
+ * the full test set and is the source of truth. This mirrors the JS executor's
+ * relationship to the browser JS worker.
+ *
+ * SECURITY — this path grants on-chain XP, so it must resist a hostile
+ * submission forging a pass, which the browser runner (non-authoritative) does
+ * not care about:
+ *
+ *   - NONCE-GUARDED MARKERS. Pass/fail is read from `TEST_<nonce>_<i>_PASS`
+ *     lines on stdout, where <nonce> is a fresh server-generated random token
+ *     never shown to the client. A submission can `println!` anything, but it
+ *     cannot emit a marker for a nonce it cannot guess, so it cannot fake a pass.
+ *   - DENYLIST of compile-time source/environment reflection macros
+ *     (`file!`, `include_str!`, `include!`, `env!`, …). Without this a
+ *     submission could `include_str!(file!())` to read the assembled harness
+ *     source and recover the nonce. Any hit fails the submission closed.
+ *   - DEGRADE CLOSED. If the Playground is unreachable or returns a non-2xx,
+ *     the grader reports `available: false`; callers MUST deny completion.
+ *     A submission that merely fails to compile is `available: true` with every
+ *     test failed (compile error != executor outage).
+ *
+ * The Playground itself sandboxes execution (no network, no writable fs, CPU/
+ * wall limits) on its own infrastructure — untrusted Rust never runs on ours.
+ */
+
+import { randomBytes } from "node:crypto";
+import type { AdminTestCase } from "@superteam-lms/types";
+import type { ServerTestResult, SubmissionRunResult } from "./executor";
+
+const RUST_PLAYGROUND_URL =
+  process.env.RUST_PLAYGROUND_URL ?? "https://play.rust-lang.org/execute";
+
+/** Matches the browser runner + /api/rust/execute upstream budget. */
+const UPSTREAM_TIMEOUT_MS = 30_000;
+
+/** Upper bound on the RAW submission we are willing to compile. */
+const MAX_CODE_BYTES = 50 * 1024;
+
+/**
+ * Compile-time reflection / escape-hatch macros. A submission using any of
+ * these could read the harness source (and thus the nonce) or the build
+ * environment, defeating the marker guard. Legitimate learning solutions never
+ * need them. Matched as whole macro invocations (`ident!`).
+ */
+const DENYLISTED_MACROS =
+  /\b(?:include_str|include_bytes|include|file|module_path|env|option_env)\s*!/;
+
+interface PlaygroundResponse {
+  success: boolean;
+  stdout: string;
+  stderr: string;
+  exitDetail?: string;
+}
+
+const ANSI_REGEX = /\x1b\[[0-9;]*m/g;
+const stripAnsi = (s: string): string => s.replace(ANSI_REGEX, "");
+
+/**
+ * Detect the last top-level `fn` in the submission — the function the tests
+ * invoke. Top-level only (start of line, no indentation) so methods inside
+ * `impl` blocks are skipped. Mirrors `buildRustTestHarness` in the browser
+ * runner. `main` is not a gradeable entry point.
+ */
+function detectFunctionName(code: string): string | null {
+  const fns = [...code.matchAll(/^fn\s+(\w+)\s*\(/gm)];
+  const name = fns[fns.length - 1]?.[1] ?? null;
+  return name && name !== "main" ? name : null;
+}
+
+/**
+ * Assemble the gradeable program: the submission with any `fn main` removed,
+ * followed by a generated `main` that calls the detected function once per test
+ * and prints a nonce-guarded PASS/FAIL marker for each. Each test runs in its
+ * own block so `__result__` bindings don't collide.
+ */
+function buildHarness(
+  code: string,
+  fnName: string,
+  tests: AdminTestCase[],
+  nonce: string
+): string {
+  const withoutMain = code.replace(/fn\s+main\s*\(\s*\)\s*\{[\s\S]*?\n\}/, "");
+
+  const blocks = tests.map((tc, i) => {
+    const args = (tc.input ?? "").trim();
+    const expected = (tc.expectedOutput ?? "").trim();
+    const pass = `TEST_${nonce}_${i}_PASS`;
+    const fail = `TEST_${nonce}_${i}_FAIL`;
+
+    // Expected clauses that reference __result__ are boolean predicates
+    // (e.g. `__result__.contains("…")`); others are equality targets.
+    if (expected.includes("__result__")) {
+      return `    {
+        let __result__ = ${fnName}(${args});
+        let __dbg__ = format!("{:?}", &__result__);
+        if ${expected} {
+            println!("${pass}");
+        } else {
+            println!("${fail}: got {}", __dbg__);
+        }
+    }`;
+    }
+
+    return `    {
+        let __result__ = ${fnName}(${args});
+        let __expected__ = ${expected};
+        if __result__ == __expected__ {
+            println!("${pass}");
+        } else {
+            println!("${fail}: expected {:?}, got {:?}", __expected__, __result__);
+        }
+    }`;
+  });
+
+  return `${withoutMain}\n\nfn main() {\n${blocks.join("\n")}\n}\n`;
+}
+
+/** Fail every test with the same reason (bad submission, not executor outage). */
+function allFailed(
+  tests: AdminTestCase[],
+  detail: string
+): SubmissionRunResult {
+  return {
+    available: true,
+    passed: false,
+    results: tests.map((t) => ({
+      id: t.id,
+      hidden: t.hidden === true,
+      passed: false,
+      detail,
+    })),
+  };
+}
+
+/**
+ * Grade a Rust submission against every supplied test.
+ *
+ * Contract mirrors {@link runJsSubmission}: `{ available: false }` means the
+ * grader could not run (deny completion); when available, `passed` is true only
+ * if EVERY test passed.
+ */
+export async function runRustSubmission(
+  code: string,
+  tests: AdminTestCase[]
+): Promise<SubmissionRunResult> {
+  if (Buffer.byteLength(code, "utf8") > MAX_CODE_BYTES) {
+    return allFailed(tests, "Submission too large");
+  }
+
+  if (DENYLISTED_MACROS.test(code)) {
+    return allFailed(tests, "Submission uses a disallowed macro");
+  }
+
+  const fnName = detectFunctionName(code);
+  if (!fnName) {
+    return allFailed(tests, "No top-level function found in submission");
+  }
+
+  const nonce = randomBytes(12).toString("hex");
+  const harness = buildHarness(code, fnName, tests, nonce);
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), UPSTREAM_TIMEOUT_MS);
+
+  let data: PlaygroundResponse;
+  try {
+    const res = await fetch(RUST_PLAYGROUND_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        channel: "stable",
+        mode: "debug",
+        edition: "2021",
+        crateType: "bin",
+        tests: false,
+        backtrace: false,
+        code: harness,
+      }),
+      signal: controller.signal,
+    });
+    if (!res.ok) {
+      // Upstream reachable but erroring (5xx/429/etc.) — cannot grade.
+      return { available: false, reason: "executor_unavailable" };
+    }
+    data = (await res.json()) as PlaygroundResponse;
+  } catch {
+    // Network failure / timeout / abort — degrade closed.
+    return { available: false, reason: "executor_unavailable" };
+  } finally {
+    clearTimeout(timer);
+  }
+
+  const stdout = stripAnsi(data.stdout ?? "");
+  const stderr = stripAnsi(data.stderr ?? "");
+  const compileFailed = !stdout.includes(`TEST_${nonce}_`);
+
+  const results: ServerTestResult[] = tests.map((tc, i) => {
+    const hidden = tc.hidden === true;
+    if (stdout.includes(`TEST_${nonce}_${i}_PASS`)) {
+      return { id: tc.id, hidden, passed: true, detail: "pass" };
+    }
+    const failMatch = stdout.match(
+      new RegExp(`TEST_${nonce}_${i}_FAIL:?\\s*(.*)`)
+    );
+    if (failMatch) {
+      return {
+        id: tc.id,
+        hidden,
+        passed: false,
+        detail: (failMatch[1] ?? "assertion failed").slice(0, 200),
+      };
+    }
+    // No marker for this test: compile error or a panic aborted the run.
+    return {
+      id: tc.id,
+      hidden,
+      passed: false,
+      detail: compileFailed
+        ? (
+            stderr.split("\n").find((l) => l.includes("error")) ??
+            "Compilation failed"
+          ).slice(0, 200)
+        : "No result produced",
+    };
+  });
+
+  return {
+    available: true,
+    passed: results.length > 0 && results.every((r) => r.passed),
+    results,
+  };
+}

--- a/apps/web/src/lib/challenge/validate.ts
+++ b/apps/web/src/lib/challenge/validate.ts
@@ -14,6 +14,7 @@ import {
   runJsSubmission,
   type ServerTestResult,
 } from "@/lib/challenge/executor";
+import { runRustSubmission } from "@/lib/challenge/rust-executor";
 
 export type ChallengeVerdict =
   | {
@@ -26,9 +27,12 @@ export type ChallengeVerdict =
     }
   | {
       /**
-       * Lesson is a challenge, but its correctness is established elsewhere
-       * (Rust playground / build server) rather than by the JS executor. The
-       * completion gate must decide policy for these explicitly.
+       * Lesson is a challenge whose correctness cannot yet be established
+       * server-side: `buildType: "buildable"` challenges are compiled by the
+       * Anchor build server, and that grading handshake is not wired up. The
+       * completion gate must deny these (fail closed). Plain `language: "rust"`
+       * challenges are NOT here — they are graded by the Rust executor and
+       * resolve to `validated`.
        */
       kind: "non_js_challenge";
       language: string | null;
@@ -63,10 +67,10 @@ function countTests(key: ChallengeAnswerKey): {
 }
 
 /**
- * A JS/TS code challenge is one we can execute and grade server-side. Rust
- * (`language: "rust"`) and buildable challenges are compiled by the Rust
- * playground / build server respectively and are out of scope for the JS
- * isolate executor.
+ * A JS/TS code challenge is one the isolate executor can grade. Rust
+ * (`language: "rust"`) is graded by the Rust executor; `buildType: "buildable"`
+ * challenges are compiled by the Anchor build server (not yet wired up). Both
+ * are out of scope for the JS isolate executor.
  */
 function isJsExecutableChallenge(key: ChallengeAnswerKey): boolean {
   if (key.type !== "challenge") return false;
@@ -74,6 +78,19 @@ function isJsExecutableChallenge(key: ChallengeAnswerKey): boolean {
   // Treat anything that isn't explicitly rust as JS/TS (matches the browser
   // runner, which only routes language === "rust" away from the JS worker).
   return key.language !== "rust";
+}
+
+/**
+ * A plain Rust challenge the Rust executor can grade end-to-end via the Rust
+ * Playground. Excludes `buildType: "buildable"`, which needs the Anchor build
+ * server rather than the Playground.
+ */
+function isRustGradableChallenge(key: ChallengeAnswerKey): boolean {
+  return (
+    key.type === "challenge" &&
+    key.buildType !== "buildable" &&
+    key.language === "rust"
+  );
 }
 
 /**
@@ -89,6 +106,29 @@ export async function validateAgainstAnswerKey(
 
   const { hidden, visible } = countTests(key);
 
+  // Rust challenges: graded authoritatively via the Rust Playground (full test
+  // set, incl. hidden). A Playground outage degrades closed to
+  // executor_unavailable so completion is denied, never granted unverified.
+  if (isRustGradableChallenge(key)) {
+    const run = await runRustSubmission(submittedCode, key.tests ?? []);
+    if (!run.available) {
+      return {
+        kind: "executor_unavailable",
+        hiddenTestCount: hidden,
+        visibleTestCount: visible,
+      };
+    }
+    return {
+      kind: "validated",
+      passed: run.passed,
+      hiddenTestCount: hidden,
+      visibleTestCount: visible,
+      results: run.results,
+    };
+  }
+
+  // Remaining non-JS challenges (buildType: "buildable") have no server-side
+  // grader yet — fail closed.
   if (!isJsExecutableChallenge(key)) {
     return {
       kind: "non_js_challenge",


### PR DESCRIPTION
## Summary

Fixes `POST /api/lessons/complete` returning **503** on every **Rust** challenge submission.

## Root cause

`455423e` (#195) made the completion route re-grade every submission server-side but only implemented the JS (`isolated-vm`) grader. Rust/buildable fell through to a hardcoded 503 with a `TODO(#195 follow-up)` that was never done — so no Rust challenge could be submitted for XP.

## Fix

Wire up server-side Rust grading so plain `language: "rust"` challenges resolve to a real `validated` verdict:

- **`lib/challenge/rust-executor.ts`** (new) — assembles the test harness (mirroring the browser runner), compiles + runs it on the Rust Playground (same upstream `/api/rust/execute` uses), runs the **full** test set incl. hidden, grades by parsing markers. Same `SubmissionRunResult` contract as the JS executor.
- **`validate.ts`** — routes `language: "rust"` (non-buildable) → the Rust grader; buildable stays fail-closed as `non_js_challenge`.

Keeps #195's security posture: the server is authoritative (a forged client "passed" can't mint XP), and it **degrades closed** — a Playground outage yields `executor_unavailable` (503), never an unverified pass.

Hardening for this XP-granting path:
- **nonce-guarded** `TEST_<nonce>_<i>_PASS` markers → a submission can't `println!` a fake pass
- **denylist** of source-reflection macros (`file!`, `include_str!`, …) → can't read the harness to recover the nonce

## Scope

- ✅ Fixes the 10 `language: "rust"` challenges.
- ⚠️ The 8 `buildType: "buildable"` challenges stay fail-closed — they need the Anchor build-server grading handshake (separate follow-up).
- ⚠️ JS challenges depend on `isolated-vm` loading at runtime (separate concern on Vercel).

## Tests

- New `rust-executor.test.ts` (11 cases): pass-all, hidden-fail, **nonce anti-forgery**, compile-fail-vs-outage, degrade-closed (unreachable / non-2xx), macro denylist, no-function; plus `validate.ts` routing (validated / outage→executor_unavailable / buildable→non_js_challenge).
- Full challenge suite 30/30, tsc clean, eslint clean.

Closes #249
