### PR TITLE
fix(challenge): run JS grader on QuickJS/WASM so it works on Vercel

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -111,12 +111,17 @@ const nextConfig = {
   // (validates env vars). Stable in Next 15; opt-in in Next 14.
   experimental: {
     instrumentationHook: true,
-    // `isolated-vm` is a native addon used by the server-side challenge
-    // executor (lib/challenge/executor.ts). Keep it external so webpack does
-    // not attempt to bundle/trace the .node binary; it is required at runtime
-    // on the Node.js server. The module loads lazily and degrades closed if the
-    // prebuilt binary is unavailable in the host environment.
-    serverComponentsExternalPackages: ["isolated-vm"],
+    // The server-side challenge executor (lib/challenge/executor.ts) runs learner
+    // code in QuickJS-on-WASM. Keep these packages EXTERNAL so webpack does not
+    // re-bundle the single-file variant — its WASM is embedded via octal escapes
+    // in a template literal, which Node's module loader rejects once webpack has
+    // re-emitted it. Left external, Node loads the package's own (valid) file and
+    // Next's output file tracing still includes it (the WASM travels inside the
+    // JS, so there is no separate .wasm artifact to trace).
+    serverComponentsExternalPackages: [
+      "quickjs-emscripten-core",
+      "@jitl/quickjs-singlefile-cjs-release-sync",
+    ],
   },
   transpilePackages: ["@superteam-lms/types", "@superteam-lms/sanity"],
   images: {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@coral-xyz/anchor": "^0.32.1",
+    "@jitl/quickjs-singlefile-cjs-release-sync": "^0.32.0",
     "@metaplex-foundation/mpl-core": "^1.7.0",
     "@metaplex-foundation/mpl-token-metadata": "^3.4.0",
     "@metaplex-foundation/umi": "^1.4.1",
@@ -55,6 +56,7 @@
     "next-sanity": "^12.1.0",
     "next-themes": "^0.4.0",
     "posthog-js": "^1.345.5",
+    "quickjs-emscripten-core": "^0.32.0",
     "react": "^18.3.0",
     "react-dom": "^18.3.0",
     "react-markdown": "^10.1.0",
@@ -69,9 +71,6 @@
     "tailwindcss-animate": "^1.0.7",
     "tweetnacl": "^1.0.3",
     "zod": "^4.4.3"
-  },
-  "optionalDependencies": {
-    "isolated-vm": "6.1.2"
   },
   "devDependencies": {
     "@tailwindcss/typography": "^0.5.19",

--- a/apps/web/src/app/api/lessons/validate-challenge/route.ts
+++ b/apps/web/src/app/api/lessons/validate-challenge/route.ts
@@ -13,8 +13,8 @@ import { ERROR_IDS } from "@/constants/errorIds";
  *
  * Server-side, authoritative challenge validation. Loads the FULL answer key
  * (hidden tests + reference solution) server-side via getChallengeAnswerKey,
- * runs the submission through the secure isolate executor (`isolated-vm`)
- * against ALL tests (visible + hidden), and returns only pass/fail metadata.
+ * runs the submission through the secure QuickJS (WASM) executor against ALL
+ * tests (visible + hidden), and returns only pass/fail metadata.
  * The answer key, hidden tests, and reference solution are never serialised
  * into the response (P0-C4).
  *

--- a/apps/web/src/lib/challenge/__tests__/executor.test.ts
+++ b/apps/web/src/lib/challenge/__tests__/executor.test.ts
@@ -4,13 +4,11 @@ import { isExecutorAvailable, runJsSubmission } from "../executor";
 import { validateAgainstAnswerKey } from "../validate";
 import type { ChallengeAnswerKey } from "@/lib/sanity/queries";
 
-// `isolated-vm` is an OPTIONAL native addon: it requires Node >= 22 and a
-// prebuilt/buildable binary, so it is ABSENT on the repo's Node 20 CI runner and
-// on Vercel serverless. The isolate-backed tests below therefore run ONLY when
-// the addon actually loaded in this environment (resolved once, here); otherwise
-// they are SKIPPED, not failed. The gate-logic and degrade-closed tests further
-// down do NOT need the isolate and always run — they are what proves the
-// server-authoritative behaviour in the addon-absent environment.
+// The executor runs on QuickJS compiled to WebAssembly (no native addon), so it
+// loads in every environment — CI, and Vercel serverless. EXECUTOR_AVAILABLE is
+// therefore expected to be true everywhere; the `skipIf` below is a defensive
+// guard so the suite degrades to skipped (not failed) in the unlikely event the
+// WASM module can't instantiate, rather than an expected code path.
 const EXECUTOR_AVAILABLE = await isExecutorAvailable();
 
 const sumTests: AdminTestCase[] = [
@@ -37,14 +35,13 @@ const PASSES_VISIBLE_ONLY =
 const WRONG = "function add(a, b) { return a * b; }";
 const EMPTY = "";
 
-// These tests exercise the REAL isolated-vm executor (no mocks). They prove the
+// These tests exercise the REAL QuickJS executor (no mocks). They prove the
 // server is authoritative: correctness is judged by running the submission
 // against the server-held tests, so a forged client "passed" cannot produce a
 // passing verdict. They also assert the sandbox isolation guarantees
-// (no host objects, timeout kills runaway code). SKIPPED when the addon is
-// absent (e.g. Node 20 / serverless) — see EXECUTOR_AVAILABLE above.
+// (no host objects, timeout kills runaway code). See EXECUTOR_AVAILABLE above.
 describe.skipIf(!EXECUTOR_AVAILABLE)(
-  "secure challenge executor (isolated-vm)",
+  "secure challenge executor (QuickJS WASM)",
   () => {
     it("reports available in this environment", async () => {
       expect(await isExecutorAvailable()).toBe(true);
@@ -142,7 +139,7 @@ describe.skipIf(!EXECUTOR_AVAILABLE)(
       30_000
     );
 
-    it("kills CPU-bound runaway code via in-isolate timeout (does not hang)", async () => {
+    it("kills CPU-bound runaway code via the interrupt handler (does not hang)", async () => {
       const tests: AdminTestCase[] = [
         { id: "t", description: "loops", input: "", expectedOutput: "true" },
       ];
@@ -211,9 +208,9 @@ function answerKey(over: Partial<ChallengeAnswerKey> = {}): ChallengeAnswerKey {
   };
 }
 
-// Gate logic that DOES exercise the real isolate (judging real submissions).
-// Guarded so it is skipped when the addon is absent — the degrade-closed block
-// below covers the addon-absent path deterministically.
+// Gate logic that DOES exercise the real executor (judging real submissions).
+// Guarded by EXECUTOR_AVAILABLE for the same defensive reason as above; the
+// degrade-closed block below covers the executor-unavailable path deterministically.
 describe.skipIf(!EXECUTOR_AVAILABLE)(
   "validateAgainstAnswerKey (executor present)",
   () => {
@@ -245,9 +242,8 @@ describe.skipIf(!EXECUTOR_AVAILABLE)(
   }
 );
 
-// Classification logic that needs NO isolate — always runs, including on the
-// Node 20 / serverless CI where the addon is absent.
-describe("validateAgainstAnswerKey (classification, no isolate)", () => {
+// Classification logic that needs NO executor — always runs.
+describe("validateAgainstAnswerKey (classification, no executor)", () => {
   it("classifies non-challenge lessons as not_a_challenge (gate skipped)", async () => {
     const verdict = await validateAgainstAnswerKey(
       answerKey({ type: "content" }),
@@ -271,12 +267,11 @@ describe("validateAgainstAnswerKey (classification, no isolate)", () => {
   });
 });
 
-// DEGRADE-CLOSED — the contract that keeps the platform safe when the secure
-// executor cannot run (the exact Node 20 / Vercel situation). The executor
-// module is MOCKED unavailable so this is deterministic regardless of whether
-// isolated-vm happens to be built in the current environment. The verdict here
-// is what the routes turn into a 503 (POST /api/lessons/complete) — completion
-// is BLOCKED, never silently granted.
+// DEGRADE-CLOSED — the contract that keeps the platform safe if the secure
+// executor ever cannot run. The executor module is MOCKED unavailable so this is
+// deterministic regardless of the runtime. The verdict here is what the routes
+// turn into a 503 (POST /api/lessons/complete) — completion is BLOCKED, never
+// silently granted.
 describe("degrade-closed when executor is unavailable (mocked)", () => {
   afterEach(() => {
     vi.resetModules();

--- a/apps/web/src/lib/challenge/executor.ts
+++ b/apps/web/src/lib/challenge/executor.ts
@@ -5,53 +5,65 @@
  * -----------------
  * Learner code is arbitrary and hostile by assumption. Node's `vm` module,
  * `eval`, and `new Function` share the host realm and are NOT isolation
- * boundaries. This module runs submissions inside a real V8 **isolate** via
- * `isolated-vm`, which is the standard primitive for sandboxing untrusted JS in
- * Node. The guarantees, all enforced by V8 itself (not by string filtering):
+ * boundaries. This module runs submissions inside a **QuickJS** interpreter
+ * compiled to WebAssembly (`quickjs-emscripten`). QuickJS is a separate JS
+ * engine executing in the WASM sandbox — it shares no realm, heap, or globals
+ * with the host. Because it is pure WASM (no native addon), it loads in any
+ * Node/serverless runtime, including Vercel. The guarantees:
  *
- *   - Separate heap with a hard MEMORY LIMIT (`MEMORY_LIMIT_MB`). A submission
- *     that allocates past the cap is terminated; it cannot exhaust host memory.
- *   - A wall-clock TIMEOUT per evaluation (`EXEC_TIMEOUT_MS`). Infinite loops and
- *     busy-waits are killed.
- *   - No ambient host objects. `process`, `require`, `module`, `globalThis`
- *     bindings to Node, the filesystem, and the network simply do not exist in
- *     the isolate — there is nothing to reference. We never bridge a host
- *     function or object into the isolate (no `Reference`, no `jsonOver`...).
+ *   - Separate heap with a hard MEMORY LIMIT (`MEMORY_LIMIT_MB`), enforced by
+ *     the QuickJS runtime. Allocation past the cap aborts execution.
+ *   - A wall-clock TIMEOUT per evaluation (`EXEC_TIMEOUT_MS`) via an interrupt
+ *     handler polled by the interpreter — infinite loops / busy-waits are killed.
+ *   - No ambient host objects. `process`, `require`, `module`, Node's
+ *     `globalThis` bindings, the filesystem, and the network do not exist inside
+ *     the QuickJS context. We never expose a host function or object into it.
  *   - Only two values cross the boundary: a STRING of code goes in; a
  *     JSON-serialisable STRING result comes out (copied, never shared).
  *
- * The mock Solana SDK and console live ENTIRELY inside the isolate, assembled
- * from source text, so the learner interacts only with isolate-local objects.
+ * The mock Solana SDK and console live ENTIRELY inside the sandbox, assembled
+ * from source text, so the learner interacts only with sandbox-local objects.
+ * A FRESH runtime + context is created per test case, so one submission cannot
+ * carry state (or prototype/global poisoning) into another test.
  *
  * DEGRADE-CLOSED
  * --------------
- * `isolated-vm` is a native addon. If it cannot be loaded in the host
- * environment (e.g. a serverless platform without the prebuilt binary), this
- * module reports `available: false` and runs NOTHING. Callers MUST treat an
- * unavailable executor as a validation FAILURE (deny completion), never as a
- * pass. See `runJsSubmission`'s return contract. The intended production
- * fallback is a dedicated sandboxed microservice (mirroring the existing Rust
- * build-server), not an insecure in-process `vm`/`Function` shim.
+ * If the WASM module cannot be instantiated (it always should, but as a hard
+ * invariant), this module reports `available: false` and runs NOTHING. Callers
+ * MUST treat an unavailable executor as a validation FAILURE (deny completion),
+ * never as a pass. See `runJsSubmission`'s return contract.
  */
 
 import type { AdminTestCase } from "@superteam-lms/types";
+import {
+  newQuickJSWASMModuleFromVariant,
+  type QuickJSWASMModule,
+  type QuickJSContext,
+  type QuickJSHandle,
+} from "quickjs-emscripten-core";
+// Single-file variant: the WASM is embedded (base64) in the JS module, so there
+// is no separate `.wasm` artifact to trace into the serverless bundle — it just
+// works on Vercel. "sync" = synchronous host↔VM calls (JS-level Promises inside
+// the VM are still driven via the job queue; see resolveToString).
+import releaseSyncVariant from "@jitl/quickjs-singlefile-cjs-release-sync";
 
-/** Hard heap cap for the isolate. Enough for SDK mocks + small programs. */
+/** Hard heap cap for the sandbox. Enough for SDK mocks + small programs. */
 const MEMORY_LIMIT_MB = 64;
 
 /**
- * Wall-clock budget per evaluation, enforced INSIDE the isolate (kills
- * CPU-bound runaways like `while(true){}`). Mirrors the browser worker's 5s.
+ * Wall-clock budget per evaluation, enforced INSIDE the sandbox via the QuickJS
+ * interrupt handler (kills CPU-bound runaways like `while(true){}`). Mirrors the
+ * browser worker's 5s.
  */
 const EXEC_TIMEOUT_MS = 5_000;
 
 /**
- * Host-side hard guard, slightly longer than EXEC_TIMEOUT_MS. The in-isolate
- * timeout cannot interrupt a quiescent pending promise (e.g.
- * `await new Promise(() => {})`) because there is no CPU activity to preempt —
- * there are no timers/event-loop primitives in the isolate, so such a promise
- * never settles. This guard abandons the evaluation and the isolate is disposed,
- * preventing a hung request. Defense-in-depth, not the primary boundary.
+ * Host-side hard guard, slightly longer than EXEC_TIMEOUT_MS. The in-sandbox
+ * interrupt cannot fire on a quiescent pending promise (e.g.
+ * `await new Promise(() => {})`) because there is no CPU activity to preempt and
+ * no timers/event-loop in the VM, so such a promise never settles. This guard
+ * abandons the evaluation (the runtime is then disposed), preventing a hung
+ * request. Defense-in-depth, not the primary boundary.
  */
 const HOST_GUARD_MS = EXEC_TIMEOUT_MS + 1_000;
 
@@ -72,55 +84,19 @@ function withHostGuard<T>(p: Promise<T>): Promise<T> {
 /** Upper bound on submission size we are willing to compile/run. */
 const MAX_CODE_BYTES = 100_000;
 
-/**
- * Minimal shape of the `isolated-vm` API we depend on. Declared locally so the
- * module type-checks even where `@types` for the native addon are unavailable,
- * and so the dependency is imported lazily (degrade-closed).
- */
-interface IvmContext {
-  eval(
-    code: string,
-    opts?: { timeout?: number; promise?: boolean }
-  ): Promise<unknown>;
-  /**
-   * Free this context's realm — its `global` and everything reachable from it
-   * (including any taint a previous submission applied to `globalThis.Function`,
-   * `Object.prototype`, etc.) — without disposing the whole isolate. A fresh
-   * `createContext()` then yields a clean realm.
-   */
-  release(): void;
-}
-interface IvmIsolate {
-  createContext(): Promise<IvmContext>;
-  dispose(): void;
-}
-interface IvmModule {
-  Isolate: new (opts: { memoryLimit: number }) => IvmIsolate;
-}
-
-let ivmModulePromise: Promise<IvmModule | null> | undefined;
+let quickJsPromise: Promise<QuickJSWASMModule | null> | undefined;
 
 /**
- * Load `isolated-vm` once, lazily. Returns null (never throws) when the native
- * addon is missing so the caller can degrade closed.
+ * Instantiate the QuickJS WASM module once, lazily. Returns null (never throws)
+ * if instantiation fails so the caller can degrade closed.
  */
-async function loadIvm(): Promise<IvmModule | null> {
-  if (ivmModulePromise === undefined) {
-    ivmModulePromise = (async () => {
-      try {
-        // Indirected through a variable so bundlers don't try to follow/trace
-        // the native addon at build time.
-        const specifier = "isolated-vm";
-        const mod = (await import(/* webpackIgnore: true */ specifier)) as
-          | IvmModule
-          | { default: IvmModule };
-        return "Isolate" in mod ? mod : mod.default;
-      } catch {
-        return null;
-      }
-    })();
+async function loadQuickJS(): Promise<QuickJSWASMModule | null> {
+  if (quickJsPromise === undefined) {
+    quickJsPromise = newQuickJSWASMModuleFromVariant(releaseSyncVariant).catch(
+      () => null
+    );
   }
-  return ivmModulePromise;
+  return quickJsPromise;
 }
 
 /** Result of running a single test case server-side. */
@@ -152,7 +128,7 @@ export type SubmissionRunResult =
 
 /** Whether the secure executor can run in this environment. */
 export async function isExecutorAvailable(): Promise<boolean> {
-  return (await loadIvm()) !== null;
+  return (await loadQuickJS()) !== null;
 }
 
 /* ------------------------------------------------------------------------- */
@@ -491,42 +467,102 @@ function transformImports(code: string): string {
 /* ------------------------------------------------------------------------- */
 
 /**
+ * Settle the VM-side Promise returned by `__runCase__` and copy its string
+ * result out. QuickJS Promises advance only when their microtask queue is
+ * pumped (`executePendingJobs`); we drain it, then await the host-side promise
+ * `resolvePromise` bridges. A never-settling VM promise leaves the queue empty
+ * and the awaited promise pending — the caller's host guard abandons it.
+ */
+async function resolveToString(
+  ctx: QuickJSContext,
+  promiseHandle: QuickJSHandle
+): Promise<string> {
+  const settledPromise = ctx.resolvePromise(promiseHandle);
+  promiseHandle.dispose();
+  for (;;) {
+    const jobs = ctx.runtime.executePendingJobs();
+    if (jobs.error) {
+      jobs.error.dispose();
+      break;
+    }
+    if (jobs.value === 0) break; // nothing left to run
+  }
+  const settled = await settledPromise;
+  const valueHandle = ctx.unwrapResult(settled);
+  const out = ctx.getString(valueHandle);
+  valueHandle.dispose();
+  return out;
+}
+
+/**
+ * Run one test case in a FRESH QuickJS runtime + context. A new runtime per test
+ * means a submission cannot carry state — or `globalThis.Function` / prototype /
+ * `JSON` poisoning — from one test into another (including hidden ones); the
+ * whole engine instance is discarded after. Memory cap + interrupt-based timeout
+ * are set on the runtime; the host guard (caller) covers a quiescent hang.
+ */
+async function runOneCase(
+  quickjs: QuickJSWASMModule,
+  userCodeJson: string,
+  testJson: string
+): Promise<{ passed: boolean; detail: string }> {
+  const runtime = quickjs.newRuntime();
+  runtime.setMemoryLimit(MEMORY_LIMIT_MB * 1024 * 1024);
+  const deadline = Date.now() + EXEC_TIMEOUT_MS;
+  runtime.setInterruptHandler(() => Date.now() > deadline);
+  const ctx = runtime.newContext();
+  try {
+    // Install the harness + mock SDK into this context.
+    ctx.unwrapResult(ctx.evalCode(ISOLATE_RUNTIME_SOURCE)).dispose();
+    // Both args are JSON string literals embedded in the source — no host
+    // reference crosses the boundary.
+    const expr = `__runCase__(${JSON.stringify(userCodeJson)}, ${JSON.stringify(testJson)})`;
+    const promiseHandle = ctx.unwrapResult(ctx.evalCode(expr));
+    const raw = await withHostGuard(resolveToString(ctx, promiseHandle));
+    const parsed = JSON.parse(raw) as { ok: boolean; detail: string };
+    return { passed: parsed.ok === true, detail: parsed.detail };
+  } catch (err) {
+    if (err === HOST_GUARD)
+      return { passed: false, detail: "Execution timed out" };
+    // Interrupt (timeout) / OOM / syntax error / VM throw all land here.
+    return {
+      passed: false,
+      detail: (err instanceof Error ? err.message : String(err)).slice(0, 200),
+    };
+  } finally {
+    ctx.dispose();
+    runtime.dispose();
+  }
+}
+
+/**
  * Run a JS/TS submission against every supplied test.
- *
- * ISOLATION PER TEST CASE — each test runs in a FRESH context (realm) inside the
- * isolate: a new context is created, the runtime/harness is installed into it,
- * the submission + that single test run, the verdict is read out, and the
- * context is released. A submission cannot carry state from one test into
- * another, because the test wrapper is built in-isolate with `new Function(...)`
- * (which resolves to that realm's `globalThis.Function`) — running user code in
- * a shared global let test #1 reassign `globalThis.Function` (or pollute
- * `Object.prototype` / `Array.prototype` / `JSON`) and force every later test —
- * including hidden ones — to "pass". A clean realm per test, discarded after,
- * closes that bypass. CPU timeout, host wall-clock kill, and memory limit are
- * unchanged.
  *
  * Contract: returns `{ available: false }` when the secure executor cannot run
  * — callers MUST deny completion in that case. When available, `passed` is true
- * only if EVERY test passed.
+ * only if EVERY test passed. Each test runs in its own fresh QuickJS instance
+ * (see {@link runOneCase}), so one test cannot influence another.
  */
 export async function runJsSubmission(
   code: string,
   tests: AdminTestCase[]
 ): Promise<SubmissionRunResult> {
-  const ivm = await loadIvm();
-  if (!ivm) return { available: false, reason: "executor_unavailable" };
+  const quickjs = await loadQuickJS();
+  if (!quickjs) return { available: false, reason: "executor_unavailable" };
+
+  const failAll = (detail: string): SubmissionRunResult => ({
+    available: true,
+    passed: false,
+    results: tests.map((t) => ({
+      id: t.id,
+      hidden: t.hidden === true,
+      passed: false,
+      detail,
+    })),
+  });
 
   if (Buffer.byteLength(code, "utf8") > MAX_CODE_BYTES) {
-    return {
-      available: true,
-      passed: false,
-      results: tests.map((t) => ({
-        id: t.id,
-        hidden: t.hidden === true,
-        passed: false,
-        detail: "Submission too large",
-      })),
-    };
+    return failAll("Submission too large");
   }
 
   let transpiled: string;
@@ -534,115 +570,34 @@ export async function runJsSubmission(
     transpiled = transformImports(code);
   } catch (err) {
     // A submission that doesn't even parse fails every test.
-    const detail = (err instanceof Error ? err.message : String(err)).slice(
-      0,
-      200
+    return failAll(
+      (err instanceof Error ? err.message : String(err)).slice(0, 200)
     );
-    return {
-      available: true,
-      passed: false,
-      results: tests.map((t) => ({
-        id: t.id,
-        hidden: t.hidden === true,
-        passed: false,
-        detail,
-      })),
-    };
   }
 
-  const isolate = new ivm.Isolate({ memoryLimit: MEMORY_LIMIT_MB });
-  try {
-    const userCodeJson = JSON.stringify(transpiled);
-    const results: ServerTestResult[] = [];
-    // The host wall-clock guard can only trip once: it abandons the in-flight
-    // evaluation and we dispose the whole isolate, so any remaining tests cannot
-    // run and are recorded as failed.
-    let aborted = false;
-
-    for (const test of tests) {
-      if (aborted) {
-        results.push({
-          id: test.id,
-          hidden: test.hidden === true,
-          passed: false,
-          detail: "Execution aborted (timeout)",
-        });
-        continue;
-      }
-
-      const testJson = JSON.stringify({
-        input: test.input ?? "",
-        expectedOutput: test.expectedOutput ?? "",
-      });
-      const expr = `__runCase__(${JSON.stringify(userCodeJson)}, ${JSON.stringify(testJson)})`;
-      let detail = "execution error";
-      let passed = false;
-
-      // FRESH realm per test: create a new context, install the runtime into it,
-      // run [user code + this one test], read the verdict, then release it. Any
-      // taint the submission applied to this realm's `globalThis.Function`,
-      // prototypes, etc. dies with the context and cannot reach the next test.
-      let context: IvmContext | undefined;
-      try {
-        context = await isolate.createContext();
-        await withHostGuard(
-          context.eval(ISOLATE_RUNTIME_SOURCE, { timeout: EXEC_TIMEOUT_MS })
-        );
-        // promise:true resolves the async __runCase__ inside the isolate and
-        // copies the resolved JSON string out. Both arguments are JSON string
-        // literals embedded in the eval'd expression — no host references cross
-        // the boundary. The in-isolate timeout kills CPU-bound runaways;
-        // withHostGuard catches the rare quiescent never-settling promise.
-        const raw = (await withHostGuard(
-          context.eval(expr, {
-            timeout: EXEC_TIMEOUT_MS,
-            promise: true,
-          })
-        )) as string;
-        const parsed = JSON.parse(raw) as { ok: boolean; detail: string };
-        passed = parsed.ok === true;
-        detail = parsed.detail;
-      } catch (err) {
-        if (err === HOST_GUARD) {
-          // Abandon the hung evaluation: dispose the isolate and fail the rest.
-          aborted = true;
-          detail = "Execution timed out";
-        } else {
-          // In-isolate timeout / OOM / disposed all land here -> test fails.
-          detail = (err instanceof Error ? err.message : String(err)).slice(
-            0,
-            200
-          );
-        }
-        passed = false;
-      } finally {
-        // Free this test's realm. Skipped when the host guard tripped: the
-        // isolate is about to be disposed wholesale and the context may be
-        // mid-eval, so releasing it here is both unnecessary and unsafe.
-        if (context && !aborted) {
-          try {
-            context.release();
-          } catch {
-            // A context that already died (e.g. in-isolate timeout/OOM) cannot
-            // be released; nothing to clean up.
-          }
-        }
-      }
-
-      results.push({
-        id: test.id,
-        hidden: test.hidden === true,
-        passed,
-        detail,
-      });
-    }
-
-    return {
-      available: true,
-      passed: results.length > 0 && results.every((r) => r.passed),
-      results,
-    };
-  } finally {
-    isolate.dispose();
+  const userCodeJson = JSON.stringify(transpiled);
+  const results: ServerTestResult[] = [];
+  for (const test of tests) {
+    const testJson = JSON.stringify({
+      input: test.input ?? "",
+      expectedOutput: test.expectedOutput ?? "",
+    });
+    const { passed, detail } = await runOneCase(
+      quickjs,
+      userCodeJson,
+      testJson
+    );
+    results.push({
+      id: test.id,
+      hidden: test.hidden === true,
+      passed,
+      detail,
+    });
   }
+
+  return {
+    available: true,
+    passed: results.length > 0 && results.every((r) => r.passed),
+    results,
+  };
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       '@coral-xyz/anchor':
         specifier: ^0.32.1
         version: 0.32.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@jitl/quickjs-singlefile-cjs-release-sync':
+        specifier: ^0.32.0
+        version: 0.32.0
       '@metaplex-foundation/mpl-core':
         specifier: ^1.7.0
         version: 1.7.0(@metaplex-foundation/umi@1.4.1)(@noble/hashes@1.8.0)
@@ -91,7 +94,7 @@ importers:
         version: 1.2.8(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@sanity/vision':
         specifier: ^3.40.0
-        version: 3.99.0(@babel/runtime@7.28.6)(@codemirror/lint@6.9.3)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.4.0)(codemirror@6.0.2)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(styled-components@6.3.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+        version: 3.99.0(@babel/runtime@7.28.6)(@codemirror/lint@6.9.3)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.4.0)(codemirror@6.0.2)(react-dom@18.3.1(react@18.3.1))(react-is@19.2.4)(react@18.3.1)(styled-components@6.3.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@sentry/nextjs':
         specifier: ^10.38.0
         version: 10.38.0(@opentelemetry/context-async-hooks@2.5.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(next@14.2.35(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(webpack@5.105.2(esbuild@0.25.6))
@@ -157,13 +160,16 @@ importers:
         version: 3.26.5(next@14.2.35(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       next-sanity:
         specifier: ^12.1.0
-        version: 12.1.0(@emotion/is-prop-valid@1.4.0)(@sanity/client@7.14.1)(@sanity/types@3.99.0(@types/react@18.3.28))(next@14.2.35(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(sanity@3.99.0(@emotion/is-prop-valid@1.4.0)(@noble/hashes@1.8.0)(@types/node@22.19.9)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(bufferutil@4.1.0)(immer@10.2.0)(jiti@2.6.1)(react-dom@18.3.1(react@18.3.1))(react-native@0.83.1(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1)(styled-components@6.3.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(yaml@2.8.2))(styled-components@6.3.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)
+        version: 12.1.0(@emotion/is-prop-valid@1.4.0)(@sanity/client@7.14.1)(@sanity/types@3.99.0(@types/react@18.3.28))(next@14.2.35(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react-is@19.2.4)(react@18.3.1)(sanity@3.99.0(@emotion/is-prop-valid@1.4.0)(@noble/hashes@1.8.0)(@types/node@22.19.9)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(bufferutil@4.1.0)(immer@10.2.0)(jiti@2.6.1)(react-dom@18.3.1(react@18.3.1))(react-native@0.83.1(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1)(styled-components@6.3.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(yaml@2.8.2))(styled-components@6.3.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)
       next-themes:
         specifier: ^0.4.0
         version: 0.4.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       posthog-js:
         specifier: ^1.345.5
         version: 1.345.5
+      quickjs-emscripten-core:
+        specifier: ^0.32.0
+        version: 0.32.0
       react:
         specifier: ^18.3.0
         version: 18.3.1
@@ -206,10 +212,6 @@ importers:
       zod:
         specifier: ^4.4.3
         version: 4.4.3
-    optionalDependencies:
-      isolated-vm:
-        specifier: 6.1.2
-        version: 6.1.2
     devDependencies:
       '@tailwindcss/typography':
         specifier: ^0.5.19
@@ -1936,6 +1938,12 @@ packages:
     resolution: {integrity: sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
+  '@jitl/quickjs-ffi-types@0.32.0':
+    resolution: {integrity: sha512-v9T+GQpmk43VDJ7d72sf0Nexhk+ArvtUihW27dy7lqAl0zBObFKtSBBIm5RBjwIhE8VwsPPm9PNuvPvNqLWUEg==}
+
+  '@jitl/quickjs-singlefile-cjs-release-sync@0.32.0':
+    resolution: {integrity: sha512-NjUUcw26PoeJHND6nmflAH8nIvAJvxJ2qkSPi95wfiBqPim80GtcdWommroiWb8hh1/7fVettEwodAsGt2Mrsg==}
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -2212,24 +2220,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@14.2.33':
     resolution: {integrity: sha512-Bm+QulsAItD/x6Ih8wGIMfRJy4G73tu1HJsrccPW6AfqdZd0Sfm5Imhgkgq2+kly065rYMnCOxTBvmvFY1BKfg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@14.2.33':
     resolution: {integrity: sha512-FnFn+ZBgsVMbGDsTqo8zsnRzydvsGV8vfiWwUo1LD8FTmPTdV+otGSWKc4LJec0oSexFnCYVO4hX8P8qQKaSlg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@14.2.33':
     resolution: {integrity: sha512-345tsIWMzoXaQndUTDv1qypDRiebFxGYx9pYkhwY4hBRaOLt8UGfiWKr9FSSHs25dFIf8ZqIFaPdy5MljdoawA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@14.2.33':
     resolution: {integrity: sha512-nscpt0G6UCTkrT2ppnJnFsYbPDQwmum4GNXYTeoTIdsmMydSKFz9Iny2jpaRupTb+Wl298+Rh82WKzt9LCcqSQ==}
@@ -3198,66 +3210,79 @@ packages:
     resolution: {integrity: sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.57.1':
     resolution: {integrity: sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.57.1':
     resolution: {integrity: sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.57.1':
     resolution: {integrity: sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.57.1':
     resolution: {integrity: sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.57.1':
     resolution: {integrity: sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.57.1':
     resolution: {integrity: sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.57.1':
     resolution: {integrity: sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.57.1':
     resolution: {integrity: sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.57.1':
     resolution: {integrity: sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.57.1':
     resolution: {integrity: sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.57.1':
     resolution: {integrity: sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.57.1':
     resolution: {integrity: sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.57.1':
     resolution: {integrity: sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==}
@@ -4360,41 +4385,49 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -6882,10 +6915,6 @@ packages:
     resolution: {integrity: sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==}
     engines: {node: '>=0.10.0'}
 
-  isolated-vm@6.1.2:
-    resolution: {integrity: sha512-GGfsHqtlZiiurZaxB/3kY7LLAXR3sgzDul0fom4cSyBjx6ZbjpTrFWiH3z/nUfLJGJ8PIq9LQmQFiAxu24+I7A==}
-    engines: {node: '>=22.0.0'}
-
   isomorphic-dompurify@2.36.0:
     resolution: {integrity: sha512-E8YkGyPY3a/U5s0WOoc8Ok+3SWL/33yn2IHCoxCFLBUUPVy9WGa++akJZFxQCcJIhI+UvYhbrbnTIFQkHKZbgA==}
     engines: {node: '>=20.19.5'}
@@ -7154,18 +7183,21 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   litesvm-linux-x64-gnu@0.3.3:
     resolution: {integrity: sha512-Qai2/E8Eq03w8VKnJDREyiWxwavjykW/H6onE179ayMnBjVVmkj5fN7XF50VV4z73kasx5bpDzBNK8fcaxMdzA==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   litesvm-linux-x64-musl@0.3.3:
     resolution: {integrity: sha512-bpWZ2f506hbfu1y6bkmuZf+qqtnLDxggpOMTQbibjd+q6faEO3sETWwKGlIgHB99P8wyU+aXKwLSGQX2sJEw6Q==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   litesvm@0.3.3:
     resolution: {integrity: sha512-QHXjAIXzvG0uAMOza6aJcYl19yTKz3guwq/z0Zml4KnQxyQvPhjaBpUFc5sf2ey/NxMVdqFhoXmL02CXOOomjw==}
@@ -8415,6 +8447,9 @@ packages:
   quick-lru@5.1.1:
     resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
     engines: {node: '>=10'}
+
+  quickjs-emscripten-core@0.32.0:
+    resolution: {integrity: sha512-QFnPfjFey8EqknSrSxe1hZrf1/8z7/6s1QzGOmKo6++02r7QRRX7ZoyNaZh7JuVjWsVW87KnQrbZqnHkOAzUyg==}
 
   raf@3.4.1:
     resolution: {integrity: sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==}
@@ -12261,6 +12296,12 @@ snapshots:
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
+  '@jitl/quickjs-ffi-types@0.32.0': {}
+
+  '@jitl/quickjs-singlefile-cjs-release-sync@0.32.0':
+    dependencies:
+      '@jitl/quickjs-ffi-types': 0.32.0
+
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -14001,7 +14042,7 @@ snapshots:
       - '@sanity/client'
       - '@sanity/types'
 
-  '@sanity/preview-url-secret@2.1.16(@sanity/client@7.14.1(debug@4.4.3))(@sanity/icons@3.7.4(react@18.3.1))(sanity@3.99.0(@emotion/is-prop-valid@1.4.0)(@noble/hashes@1.8.0)(@types/node@22.19.9)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(bufferutil@4.1.0)(immer@10.2.0)(jiti@2.6.1)(react-dom@18.3.1(react@18.3.1))(react-native@0.83.1(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1)(styled-components@6.3.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(yaml@2.8.2))':
+  '@sanity/preview-url-secret@2.1.16(@sanity/client@7.14.1)(@sanity/icons@3.7.4(react@18.3.1))(sanity@3.99.0(@emotion/is-prop-valid@1.4.0)(@noble/hashes@1.8.0)(@types/node@22.19.9)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(bufferutil@4.1.0)(immer@10.2.0)(jiti@2.6.1)(react-dom@18.3.1(react@18.3.1))(react-native@0.83.1(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1)(styled-components@6.3.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(yaml@2.8.2))':
     dependencies:
       '@sanity/client': 7.14.1(debug@4.4.3)
       '@sanity/uuid': 3.0.2
@@ -14163,24 +14204,6 @@ snapshots:
     transitivePeerDependencies:
       - '@emotion/is-prop-valid'
 
-  '@sanity/ui@3.1.11(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(styled-components@6.3.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
-    dependencies:
-      '@floating-ui/react-dom': 2.1.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@juggle/resize-observer': 3.4.0
-      '@sanity/color': 3.0.6
-      '@sanity/icons': 3.7.4(react@18.3.1)
-      csstype: 3.2.3
-      motion: 12.33.0(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      react: 18.3.1
-      react-compiler-runtime: 1.0.0(react@18.3.1)
-      react-dom: 18.3.1(react@18.3.1)
-      react-is: 18.3.1
-      react-refractor: 4.0.0(react@18.3.1)
-      styled-components: 6.3.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      use-effect-event: 2.0.3(react@18.3.1)
-    transitivePeerDependencies:
-      - '@emotion/is-prop-valid'
-
   '@sanity/ui@3.1.11(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react-is@19.2.4)(react@18.3.1)(styled-components@6.3.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
     dependencies:
       '@floating-ui/react-dom': 2.1.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -14227,45 +14250,6 @@ snapshots:
     dependencies:
       '@types/uuid': 8.3.4
       uuid: 8.3.2
-
-  '@sanity/vision@3.99.0(@babel/runtime@7.28.6)(@codemirror/lint@6.9.3)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.4.0)(codemirror@6.0.2)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(styled-components@6.3.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
-    dependencies:
-      '@codemirror/autocomplete': 6.20.0
-      '@codemirror/commands': 6.10.2
-      '@codemirror/lang-javascript': 6.2.4
-      '@codemirror/language': 6.12.1
-      '@codemirror/search': 6.6.0
-      '@codemirror/state': 6.5.4
-      '@codemirror/view': 6.39.12
-      '@juggle/resize-observer': 3.4.0
-      '@lezer/highlight': 1.2.3
-      '@rexxars/react-json-inspector': 9.0.1(react@18.3.1)
-      '@rexxars/react-split-pane': 1.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@sanity/color': 3.0.6
-      '@sanity/icons': 3.7.4(react@18.3.1)
-      '@sanity/ui': 2.16.22(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(styled-components@6.3.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
-      '@sanity/uuid': 3.0.2
-      '@uiw/react-codemirror': 4.25.4(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.0)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.3)(@codemirror/search@6.6.0)(@codemirror/state@6.5.4)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.39.12)(codemirror@6.0.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      is-hotkey-esm: 1.0.0
-      json-2-csv: 5.5.10
-      json5: 2.2.3
-      lodash: 4.17.23
-      quick-lru: 5.1.1
-      react: 18.3.1
-      react-compiler-runtime: 19.1.0-rc.2(react@18.3.1)
-      react-fast-compare: 3.2.2
-      react-rx: 4.2.2(react@18.3.1)(rxjs@7.8.2)
-      rxjs: 7.8.2
-      styled-components: 6.3.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      use-effect-event: 2.0.3(react@18.3.1)
-    transitivePeerDependencies:
-      - '@babel/runtime'
-      - '@codemirror/lint'
-      - '@codemirror/theme-one-dark'
-      - '@emotion/is-prop-valid'
-      - codemirror
-      - react-dom
-      - react-is
 
   '@sanity/vision@3.99.0(@babel/runtime@7.28.6)(@codemirror/lint@6.9.3)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.4.0)(codemirror@6.0.2)(react-dom@18.3.1(react@18.3.1))(react-is@19.2.4)(react@18.3.1)(styled-components@6.3.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
     dependencies:
@@ -14327,7 +14311,7 @@ snapshots:
     optionalDependencies:
       '@sanity/types': 3.99.0(@types/react@18.3.28)(debug@4.4.3)
 
-  '@sanity/visual-editing@5.2.1(@emotion/is-prop-valid@1.4.0)(@sanity/client@7.14.1)(@sanity/types@3.99.0(@types/react@18.3.28))(next@14.2.35(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(styled-components@6.3.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)':
+  '@sanity/visual-editing@5.2.1(@emotion/is-prop-valid@1.4.0)(@sanity/client@7.14.1)(@sanity/types@3.99.0(@types/react@18.3.28))(next@14.2.35(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react-is@19.2.4)(react@18.3.1)(styled-components@6.3.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)':
     dependencies:
       '@sanity/comlink': 4.0.1
       '@sanity/icons': 3.7.4(react@18.3.1)
@@ -14335,7 +14319,7 @@ snapshots:
       '@sanity/mutate': 0.16.1(xstate@5.26.0)
       '@sanity/presentation-comlink': 2.0.1(@sanity/client@7.14.1)(@sanity/types@3.99.0(@types/react@18.3.28))
       '@sanity/preview-url-secret': 4.0.3(@sanity/client@7.14.1)
-      '@sanity/ui': 3.1.11(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(styled-components@6.3.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      '@sanity/ui': 3.1.11(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react-is@19.2.4)(react@18.3.1)(styled-components@6.3.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@sanity/visual-editing-csm': 3.0.5(@sanity/client@7.14.1)(@sanity/types@3.99.0(@types/react@18.3.28))(typescript@5.9.3)
       '@vercel/stega': 1.0.0
       react: 18.3.1
@@ -18314,11 +18298,6 @@ snapshots:
 
   isobject@3.0.1: {}
 
-  isolated-vm@6.1.2:
-    dependencies:
-      node-gyp-build: 4.8.4
-    optional: true
-
   isomorphic-dompurify@2.36.0(@noble/hashes@1.8.0):
     dependencies:
       dompurify: 3.3.1
@@ -19612,14 +19591,14 @@ snapshots:
       react: 18.3.1
       use-intl: 3.26.5(react@18.3.1)
 
-  next-sanity@12.1.0(@emotion/is-prop-valid@1.4.0)(@sanity/client@7.14.1)(@sanity/types@3.99.0(@types/react@18.3.28))(next@14.2.35(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(sanity@3.99.0(@emotion/is-prop-valid@1.4.0)(@noble/hashes@1.8.0)(@types/node@22.19.9)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(bufferutil@4.1.0)(immer@10.2.0)(jiti@2.6.1)(react-dom@18.3.1(react@18.3.1))(react-native@0.83.1(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1)(styled-components@6.3.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(yaml@2.8.2))(styled-components@6.3.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3):
+  next-sanity@12.1.0(@emotion/is-prop-valid@1.4.0)(@sanity/client@7.14.1)(@sanity/types@3.99.0(@types/react@18.3.28))(next@14.2.35(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react-is@19.2.4)(react@18.3.1)(sanity@3.99.0(@emotion/is-prop-valid@1.4.0)(@noble/hashes@1.8.0)(@types/node@22.19.9)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(bufferutil@4.1.0)(immer@10.2.0)(jiti@2.6.1)(react-dom@18.3.1(react@18.3.1))(react-native@0.83.1(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1)(styled-components@6.3.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(yaml@2.8.2))(styled-components@6.3.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3):
     dependencies:
       '@portabletext/react': 6.0.2(react@18.3.1)
       '@sanity/client': 7.14.1(debug@4.4.3)
       '@sanity/comlink': 4.0.1
       '@sanity/presentation-comlink': 2.0.1(@sanity/client@7.14.1)(@sanity/types@3.99.0(@types/react@18.3.28))
       '@sanity/preview-url-secret': 4.0.3(@sanity/client@7.14.1)
-      '@sanity/visual-editing': 5.2.1(@emotion/is-prop-valid@1.4.0)(@sanity/client@7.14.1)(@sanity/types@3.99.0(@types/react@18.3.28))(next@14.2.35(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(styled-components@6.3.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)
+      '@sanity/visual-editing': 5.2.1(@emotion/is-prop-valid@1.4.0)(@sanity/client@7.14.1)(@sanity/types@3.99.0(@types/react@18.3.28))(next@14.2.35(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react-is@19.2.4)(react@18.3.1)(styled-components@6.3.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)
       '@sanity/webhook': 4.0.4
       dequal: 2.0.3
       groq: 5.8.1
@@ -20249,6 +20228,10 @@ snapshots:
 
   quick-lru@5.1.1: {}
 
+  quickjs-emscripten-core@0.32.0:
+    dependencies:
+      '@jitl/quickjs-ffi-types': 0.32.0
+
   raf@3.4.1:
     dependencies:
       performance-now: 2.1.0
@@ -20806,7 +20789,7 @@ snapshots:
       '@sanity/migrate': 3.99.0(@types/react@18.3.28)
       '@sanity/mutator': 3.99.0(@types/react@18.3.28)
       '@sanity/presentation-comlink': 1.0.33(@sanity/client@7.14.1)(@sanity/types@3.99.0(@types/react@18.3.28)(debug@4.4.3))
-      '@sanity/preview-url-secret': 2.1.16(@sanity/client@7.14.1(debug@4.4.3))(@sanity/icons@3.7.4(react@18.3.1))(sanity@3.99.0(@emotion/is-prop-valid@1.4.0)(@noble/hashes@1.8.0)(@types/node@22.19.9)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(bufferutil@4.1.0)(immer@10.2.0)(jiti@2.6.1)(react-dom@18.3.1(react@18.3.1))(react-native@0.83.1(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1)(styled-components@6.3.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(yaml@2.8.2))
+      '@sanity/preview-url-secret': 2.1.16(@sanity/client@7.14.1)(@sanity/icons@3.7.4(react@18.3.1))(sanity@3.99.0(@emotion/is-prop-valid@1.4.0)(@noble/hashes@1.8.0)(@types/node@22.19.9)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(bufferutil@4.1.0)(immer@10.2.0)(jiti@2.6.1)(react-dom@18.3.1(react@18.3.1))(react-native@0.83.1(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1)(styled-components@6.3.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(yaml@2.8.2))
       '@sanity/schema': 3.99.0(@types/react@18.3.28)(debug@4.4.3)
       '@sanity/sdk': 0.0.0-alpha.25(@types/react@18.3.28)(debug@4.4.3)(immer@10.2.0)(react@18.3.1)(use-sync-external-store@1.6.0(react@18.3.1))
       '@sanity/telemetry': 0.8.1(react@18.3.1)


### PR DESCRIPTION
## Summary

Fixes `POST /api/lessons/complete` returning **503** on every **JavaScript/TypeScript** challenge on Vercel.

## Root cause

The server-side JS grader (`lib/challenge/executor.ts`, #195) ran learner code in **`isolated-vm`**, a native C++ Node addon that doesn't load on Vercel serverless. There it degraded closed → `executor_unavailable` → 503, so JS challenges were un-submittable in production. (Rust was unaffected — it grades over HTTP via the Rust Playground.)

## Fix

Swap the sandbox to **QuickJS compiled to WebAssembly** (`quickjs-emscripten`). WASM loads in any Node/serverless runtime, so grading works on Vercel like the Rust path does.

Security model preserved:
- separate JS engine — no host realm, globals, `process`/`require`, fs, or network
- hard memory cap + interrupt-based CPU timeout + host wall-clock guard for quiescent hangs
- **fresh runtime + context per test**, so a submission can't poison `Function`/prototypes/`JSON` to force a later (hidden) test to pass
- degrade-closed retained: if the WASM can't instantiate → `available: false` → deny

`runJsSubmission` / `isExecutorAvailable` keep the same contract, so `validate.ts` and the routes are unchanged. Removes the `isolated-vm` optional dependency.

## Bundling note

The single-file QuickJS variant embeds the WASM in JS (no separate `.wasm` to trace). It's kept in `serverComponentsExternalPackages` so webpack doesn't re-emit it — its embedded WASM uses octal escapes in a template literal that Node's loader rejects once re-emitted. Left external, Node loads the package's own valid file and Next's file-tracing still bundles it.

## Verification

- All executor security tests now **run in every environment** (previously skipped when the native addon was absent) and pass: forged-pass blocked, `Function`/`Object`/`Array`/`JSON` poisoning blocked, CPU-runaway + never-settling-promise killed, host escapes (`process`/`require`) denied — 19/19.
- `next build` **compiles and collects page data** for the challenge routes (was the failure point).
- tsc clean, eslint clean.

Closes #251
