### PR TITLE
chore(gamification): remove the Speed Runner achievement

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -415,9 +415,9 @@ NEXT_PUBLIC_APP_URL=http://localhost:3000
 **Level formula**: `Level = floor(sqrt(totalXP / 100))`
 **Server-side cap**: max 100 XP per lesson completion, max 2000 XP per generic award
 
-### Achievements (15 total)
+### Achievements (14 total)
 
-- **Progress**: First Steps, Course Completer, Speed Runner
+- **Progress**: First Steps, Course Completer
 - **Streaks**: Week Warrior (7d), Monthly Master (30d), Consistency King (100d)
 - **Skills**: Rust Rookie, Anchor Expert, Full Stack Solana
 - **Community**: Helper, First Comment, Top Contributor

--- a/apps/web/src/lib/gamification/achievements.ts
+++ b/apps/web/src/lib/gamification/achievements.ts
@@ -22,7 +22,6 @@ export interface UserState {
   hasCompletedRustLesson: boolean;
   hasCompletedAnchorCourse: boolean;
   hasCompletedAllTracks: boolean;
-  courseCompletionTimeHours: number | null;
   allTestsPassedFirstTry: boolean;
   userNumber: number;
   totalThreads: number;
@@ -39,8 +38,6 @@ export interface UserState {
 const UNLOCK_CHECKS: Record<string, (state: UserState) => boolean> = {
   "achievement-first-steps": (s) => s.completedLessons >= 1,
   "achievement-course-completer": (s) => s.completedCourses >= 1,
-  "achievement-speed-runner": (s) =>
-    s.courseCompletionTimeHours !== null && s.courseCompletionTimeHours < 24,
   "achievement-week-warrior": (s) => s.currentStreak >= 7,
   "achievement-monthly-master": (s) => s.currentStreak >= 30,
   "achievement-consistency-king": (s) => s.currentStreak >= 100,
@@ -128,7 +125,6 @@ export async function checkCommunityAchievements(
     hasCompletedRustLesson: false,
     hasCompletedAnchorCourse: false,
     hasCompletedAllTracks: false,
-    courseCompletionTimeHours: null,
     allTestsPassedFirstTry: false,
     userNumber: 999,
     totalThreads: 0,

--- a/apps/web/src/lib/helius/event-handlers.ts
+++ b/apps/web/src/lib/helius/event-handlers.ts
@@ -756,7 +756,6 @@ async function checkAndAwardAchievements(
         hasCompletedAllTracks: SOLANA_DEV_PATH_COURSES.every((id) =>
           completedCourseIds.has(id)
         ),
-        courseCompletionTimeHours: null,
         allTestsPassedFirstTry: false,
         userNumber: userNumber ?? 999,
         totalThreads: 0,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -685,7 +685,6 @@ Achievement metadata (name, description, icon, category) lives in **Sanity CMS**
 | ------------------- | ------------------------------ |
 | `first-steps`       | 1+ lesson completed            |
 | `course-completer`  | 1+ course completed            |
-| `speed-runner`      | Course completed in < 24 hours |
 | `week-warrior`      | 7-day streak                   |
 | `monthly-master`    | 30-day streak                  |
 | `consistency-king`  | 100-day streak                 |

--- a/docs/CUSTOMIZATION.md
+++ b/docs/CUSTOMIZATION.md
@@ -474,7 +474,7 @@ interface UserState {
 }
 ```
 
-**Deferred signals**: Three fields (`hasCompletedAllTracks`, `courseCompletionTimeHours`, `allTestsPassedFirstTry`) require cross-course tracking infrastructure that is not yet implemented. Achievements depending on these signals (`full-stack-solana`, `speed-runner`, `perfect-score`) are currently unearnable.
+**Deferred signals**: Two fields (`hasCompletedAllTracks`, `allTestsPassedFirstTry`) require cross-course tracking infrastructure that is not yet implemented. Achievements depending on these signals (`full-stack-solana`, `perfect-score`) are currently unearnable.
 
 Achievement IDs in `UNLOCK_CHECKS` must match the Sanity `_id` minus the `achievement-` prefix. For example, Sanity document `achievement-first-steps` maps to key `"first-steps"`.
 
@@ -484,13 +484,12 @@ Use the admin panel to deploy the achievement on-chain. This creates an Achievem
 
 #### Current Achievement Catalog
 
-The 15 built-in achievements and their unlock conditions:
+The 14 built-in achievements and their unlock conditions:
 
 | ID                  | Condition                                      |
 | ------------------- | ---------------------------------------------- |
 | `first-steps`       | Complete 1 lesson                              |
 | `course-completer`  | Complete 1 course                              |
-| `speed-runner`      | Complete a course in under 24 hours (deferred) |
 | `week-warrior`      | 7-day streak                                   |
 | `monthly-master`    | 30-day streak                                  |
 | `consistency-king`  | 100-day streak                                 |

--- a/sanity/seed/achievements.json
+++ b/sanity/seed/achievements.json
@@ -26,19 +26,6 @@
     "metadataUri": "https://superteam-academy.vercel.app/api/achievements/metadata?id=achievement-course-completer"
   },
   {
-    "_id": "achievement-speed-runner",
-    "_type": "achievement",
-    "name": "Speed Runner",
-    "description": "Complete a course in under 24 hours",
-    "icon": "zap",
-    "glyph": "\u00bb",
-    "solTier": false,
-    "category": "progress",
-    "xpReward": 150,
-    "maxSupply": 0,
-    "metadataUri": "https://superteam-academy.vercel.app/api/achievements/metadata?id=achievement-speed-runner"
-  },
-  {
     "_id": "achievement-week-warrior",
     "_type": "achievement",
     "name": "Week Warrior",


### PR DESCRIPTION
## Summary

Removes the **Speed Runner** achievement ("Complete a course in under 24 hours").

## Why

We don't want to reward rushing through courses — learning is better done at one's own pace, and a speed reward pushes the opposite behaviour. The achievement also relied on a `courseCompletionTimeHours` signal that was never implemented (documented as "deferred"), so it was unearnable anyway.

## Changes

- `achievements.ts` — remove the `achievement-speed-runner` unlock check and the now-dead `courseCompletionTimeHours` `UserState` field (only that check read it)
- `event-handlers.ts` — remove the `courseCompletionTimeHours` field it passed into the state
- `sanity/seed/achievements.json` — remove the `achievement-speed-runner` document
- `docs/ARCHITECTURE.md`, `docs/CUSTOMIZATION.md`, `CLAUDE.md` — drop the row/mentions; update the built-in count 15 → 14

Any already-deployed on-chain `AchievementType` PDA is harmless residue (absent from Sanity, so never checked or surfaced) and is left as-is.

## Verification

- No `speed-runner` / `courseCompletionTimeHours` references remain in code or seed
- `tsc` clean, eslint clean, seed JSON valid

Closes #254
