### PR TITLE
fix(certificates): surface the real cause of a failed credential mint

### DIFF
--- a/apps/web/src/app/api/certificates/mint/route.ts
+++ b/apps/web/src/app/api/certificates/mint/route.ts
@@ -5,7 +5,11 @@ import { PublicKey } from "@solana/web3.js";
 import { createClient } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { getCourseById } from "@/lib/sanity/queries";
-import { issueCredential, getConnection } from "@/lib/solana/academy-program";
+import {
+  issueCredential,
+  getConnection,
+  describeProgramError,
+} from "@/lib/solana/academy-program";
 import { fetchEnrollment, fetchCourse } from "@/lib/solana/academy-reads";
 import { getProgramId } from "@/lib/solana/pda";
 import { uploadCertificateMetadata } from "@/lib/solana/arweave";
@@ -204,13 +208,22 @@ export async function POST(request: NextRequest) {
     } catch (mintErr) {
       // Clean up orphaned metadata row
       await adminClient.from("nft_metadata").delete().eq("id", metadataRow.id);
+      // Surface the real cause: resolve Anchor program codes (e.g.
+      // MintingPaused, backend-signer constraint) and detect infra failures
+      // (unfunded payer, missing signer) instead of a single opaque message.
+      const reason = describeProgramError(mintErr);
       logError({
         errorId: ERROR_IDS.CERTIFICATE_INSERT_FAILED,
         error: mintErr instanceof Error ? mintErr : new Error(String(mintErr)),
-        context: { handler: "certificates/mint", userId: user.id, courseId },
+        context: {
+          handler: "certificates/mint",
+          userId: user.id,
+          courseId,
+          reason,
+        },
       });
       return NextResponse.json(
-        { error: "On-chain credential minting failed" },
+        { error: "On-chain credential minting failed", reason },
         { status: 500 }
       );
     }

--- a/apps/web/src/components/certificates/course-completion-mint.tsx
+++ b/apps/web/src/components/certificates/course-completion-mint.tsx
@@ -92,14 +92,15 @@ export function CourseCompletionMint({
         body: JSON.stringify({ courseId }),
       });
       if (!res.ok) {
-        const data = (await res.json()) as { error?: string };
+        const data = (await res.json()) as { error?: string; reason?: string };
         if (res.status === 409) {
           setState({ status: "already_minted" });
           return;
         }
+        const base = data.error ?? "Minting failed";
         setState({
           status: "mint_error",
-          message: data.error ?? "Minting failed",
+          message: data.reason ? `${base}: ${data.reason}` : base,
         });
         return;
       }

--- a/apps/web/src/lib/solana/academy-program.ts
+++ b/apps/web/src/lib/solana/academy-program.ts
@@ -7,7 +7,7 @@ import {
   PublicKey,
   TransactionInstruction,
 } from "@solana/web3.js";
-import { BN } from "@coral-xyz/anchor";
+import { AnchorError, BN } from "@coral-xyz/anchor";
 import {
   getAssociatedTokenAddressSync,
   createAssociatedTokenAccountIdempotentInstruction,
@@ -27,6 +27,7 @@ import {
   findMinterRolePDA,
   getProgramId,
 } from "./pda";
+import { extractCustomErrorCode, resolveIdlError } from "./parse-program-error";
 import { serverEnv } from "@/lib/env.server";
 
 export { getProgramId } from "./pda";
@@ -331,6 +332,45 @@ export async function issueCredential(
     .rpc();
 
   return { signature: sig, mintAddress: credentialAsset.publicKey };
+}
+
+/**
+ * Turn a thrown backend-signed transaction error into a concise, safe,
+ * human-readable reason. Resolves Anchor custom program codes against the IDL
+ * (e.g. `MintingPaused`, backend-signer constraint) and detects the common
+ * infra failures that otherwise look identical (unfunded payer, missing signer,
+ * expired blockhash). Falls back to the raw message. Safe to surface to the
+ * caller — it exposes program/operational state, never user data.
+ */
+export function describeProgramError(err: unknown): string {
+  // Anchor decodes its own program errors into AnchorError.
+  if (err instanceof AnchorError) {
+    const { errorCode, errorMessage } = err.error;
+    return `${errorCode.code} (${errorCode.number}): ${errorMessage}`;
+  }
+
+  const message = err instanceof Error ? err.message : String(err);
+  const logs = (err as { logs?: unknown })?.logs;
+  const logLines = Array.isArray(logs) ? (logs as string[]) : [];
+
+  // A raw custom-error code in the tx logs -> resolve against the IDL.
+  const code = extractCustomErrorCode(logLines);
+  if (code !== null) {
+    const resolved = resolveIdlError(code, IDL as unknown as Idl);
+    if (resolved) return `${resolved.name} (${resolved.code}): ${resolved.msg}`;
+  }
+
+  const haystack = [message, ...logLines].join("\n");
+  if (/insufficient lamports|insufficient funds|Attempt to debit/i.test(haystack)) {
+    return "Backend signer wallet has insufficient SOL to pay for the mint";
+  }
+  if (/BACKEND_SIGNER_SECRET/.test(message)) {
+    return "BACKEND_SIGNER_SECRET is not configured on the server";
+  }
+  if (/blockhash not found|block height exceeded/i.test(haystack)) {
+    return "Transaction expired (blockhash) — please retry";
+  }
+  return message.slice(0, 300);
 }
 
 export async function awardAchievement(


### PR DESCRIPTION
## Summary

`POST /api/certificates/mint` returned a single opaque **"On-chain credential minting failed"** (500) for every failure of the on-chain `issueCredential()` call — the real error was only in server logs, so the actual blocker was undiagnosable.

## Root cause

The mint route's `catch` discarded the thrown error and returned a fixed message. All of these collapse into the same response:

- **`MintingPaused`** — the on-chain kill-switch (`config.paused`) is engaged
- **Backend-signer mismatch** — `BACKEND_SIGNER_SECRET` ≠ `Config.backend_signer`
- **`BACKEND_SIGNER_SECRET` unset** — `getBackendSigner()` throws
- **Unfunded payer** — backend signer has no SOL for the Metaplex Core asset rent
- **Collection authority mismatch** — the course `trackCollection` update authority isn't the program `Config` PDA

## Fix

`describeProgramError()` (new, in `academy-program.ts` — it has the IDL):
- If it's an `AnchorError`, format `code (number): message`
- Else resolve a custom program code from the tx logs against the IDL (via the existing `parse-program-error.ts` helpers)
- Else detect common infra failures (`insufficient lamports`, missing `BACKEND_SIGNER_SECRET`, expired blockhash)
- Else fall back to the raw message (capped)

The mint route now returns a concise `reason` alongside the generic error and logs the parsed detail; `course-completion-mint.tsx` shows it to the user.

## Notes

- Diagnostics-first: some causes (paused, unfunded, collection mismatch) are config/infra and get resolved outside the code — but they were invisible before. Now the blocker is obvious in the response and logs.
- No behavioural change to a successful mint. `reason` exposes program/operational state only, never user data.
- `tsc` + lint pass (one pre-existing import-order warning, untouched).

Closes #256
