### PR TITLE
fix(certificates): mint into the on-chain course collection (fix CollectionMismatch)

### DIFF
--- a/apps/web/src/app/api/certificates/mint/route.ts
+++ b/apps/web/src/app/api/certificates/mint/route.ts
@@ -101,41 +101,50 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Get course data from Sanity
+    // Get course data from Sanity (for the display name only)
     const sanityCourse = await getCourseById(courseId);
     if (!sanityCourse) {
       return NextResponse.json({ error: "Course not found" }, { status: 404 });
     }
-
-    const trackCollectionAddress = sanityCourse.trackCollectionAddress as
-      | string
-      | undefined;
-    if (!trackCollectionAddress) {
-      return NextResponse.json(
-        {
-          error:
-            "Course is missing trackCollectionAddress — ask an admin to sync the course first",
-        },
-        { status: 400 }
-      );
-    }
-
-    const trackCollectionPubkey = new PublicKey(trackCollectionAddress);
     const courseName = sanityCourse.title ?? courseId;
 
     // Truncate credential name to 32 UTF-8 bytes (on-chain limit)
     const credentialName = capCredentialName(courseName);
 
-    // Fetch on-chain course for XP calculation
+    // Fetch the on-chain course — the SOURCE OF TRUTH for both XP and the
+    // credential collection. The program enforces
+    // `track_collection == course.collection` (CollectionMismatch), so the mint
+    // MUST use the on-chain collection, never Sanity's trackCollectionAddress
+    // (which can drift out of sync and is what caused CollectionMismatch here).
     const onChainCourse = await fetchCourse(
       courseId,
       connection,
       getProgramId()
     );
-    const totalXp = onChainCourse
-      ? Number(onChainCourse.xp_per_lesson) *
-        (Number(onChainCourse.lesson_count) || 1)
-      : 0;
+    if (!onChainCourse) {
+      return NextResponse.json(
+        {
+          error:
+            "Course is not deployed on-chain — ask an admin to sync the course first",
+        },
+        { status: 400 }
+      );
+    }
+
+    const trackCollectionPubkey = new PublicKey(onChainCourse.collection);
+    if (trackCollectionPubkey.equals(PublicKey.default)) {
+      return NextResponse.json(
+        {
+          error:
+            "Course has no on-chain credential collection — ask an admin to sync the course first",
+        },
+        { status: 400 }
+      );
+    }
+
+    const totalXp =
+      Number(onChainCourse.xp_per_lesson) *
+      (Number(onChainCourse.lesson_count) || 1);
 
     // Build metadata
     const metadataJson = {

--- a/apps/web/src/lib/helius/event-handlers.ts
+++ b/apps/web/src/lib/helius/event-handlers.ts
@@ -502,20 +502,9 @@ async function tryIssueCredential(
     if (!enrollment) return;
     if (enrollment.credential_asset) return;
 
-    // Fetch course data from Sanity for metadata
+    // Fetch course data from Sanity for the display name
     const sanityCourse = await getCourseById(courseId);
     if (!sanityCourse) return;
-
-    const trackCollectionAddress = sanityCourse.trackCollectionAddress as
-      | string
-      | undefined;
-    if (!trackCollectionAddress) {
-      throw new Error(
-        `Course "${courseId}" has no trackCollectionAddress in Sanity — re-sync the course from the admin console`
-      );
-    }
-
-    const trackCollectionPubkey = new PublicKey(trackCollectionAddress);
     const courseName = sanityCourse.title ?? courseId;
 
     // Truncate credential name to 32 UTF-8 bytes (on-chain limit)
@@ -525,16 +514,30 @@ async function tryIssueCredential(
       credentialName = credentialName.slice(0, -1);
     }
 
-    // Fetch on-chain course for XP calculation
+    // Fetch the on-chain course — the SOURCE OF TRUTH for both XP and the
+    // credential collection. The program enforces
+    // `track_collection == course.collection` (CollectionMismatch), so use the
+    // on-chain collection, never Sanity's trackCollectionAddress (which can
+    // drift out of sync and is what causes CollectionMismatch).
     const onChainCourse = await fetchCourse(
       courseId,
       connection,
       getProgramId()
     );
-    const totalXp = onChainCourse
-      ? Number(onChainCourse.xp_per_lesson) *
-        (Number(onChainCourse.lesson_count) || 1)
-      : 0;
+    if (!onChainCourse) {
+      throw new Error(
+        `Course "${courseId}" is not deployed on-chain — re-sync the course from the admin console`
+      );
+    }
+    const trackCollectionPubkey = new PublicKey(onChainCourse.collection);
+    if (trackCollectionPubkey.equals(PublicKey.default)) {
+      throw new Error(
+        `Course "${courseId}" has no on-chain credential collection — re-sync the course from the admin console`
+      );
+    }
+    const totalXp =
+      Number(onChainCourse.xp_per_lesson) *
+      (Number(onChainCourse.lesson_count) || 1);
 
     // Fetch user profile for metadata
     const supabase = createAdminClient();


### PR DESCRIPTION
## Summary

Fixes the certificate mint failing with **`CollectionMismatch (6016)`** — "Collection does not match the course's credential collection." (Surfaced by #257's diagnostics.)

## Root cause

The on-chain `issue_credential` instruction constrains the passed collection:

```rust
constraint = track_collection.key() == course.collection @ AcademyError::CollectionMismatch
```

i.e. it must equal the collection stored on the **on-chain Course account**. But both mint paths passed **Sanity's `trackCollectionAddress`**, which had drifted out of sync with the on-chain `course.collection` — so the constraint always failed.

## Fix

Use the on-chain `course.collection` as the source of truth (it's already fetched via `fetchCourse` in both paths for the XP calc), and drop the Sanity `trackCollectionAddress` dependency entirely. This makes the passed collection match the program's check by construction. Guards added for a course that isn't deployed on-chain or has no collection set.

Fixed in **both** places that issue credentials:
- `api/certificates/mint` — the manual/fallback mint
- `helius/event-handlers.ts` `tryIssueCredential` — the automatic webhook mint. It had the identical bug, which is *why* the automatic path failed and pushed users onto the manual fallback that then failed the same way.

## Verification

- `tsc` clean, eslint clean
- No behavioural change to a course whose Sanity + on-chain collections already agree; for drifted courses the mint now targets the correct (on-chain) collection

Closes #256

## Note

Related #257 already merged (the diagnostics that surfaced this exact error). This is the actual fix for the underlying `CollectionMismatch`.
