### PR TITLE
fix(sanity): give lesson test cases a stable id (fix duplicate React keys)

### DIFF
--- a/apps/web/src/lib/sanity/__tests__/queries-answer-leak.test.ts
+++ b/apps/web/src/lib/sanity/__tests__/queries-answer-leak.test.ts
@@ -54,9 +54,10 @@ describe("P0-C4: client lesson queries do not leak answers", () => {
     // Tests are filtered to exclude hidden ones at the source.
     expect(query).toContain('"tests": tests[hidden != true]');
     // The projected test shape lists only client-safe fields — `hidden` is not
-    // among the projected keys.
+    // among the projected keys. `id` is projected as coalesce(id, _key) so each
+    // test carries a stable, unique key (Sanity items key on `_key`).
     expect(query).toMatch(
-      /"tests": tests\[hidden != true\]\{ id, description, input, expectedOutput \}/
+      /"tests": tests\[hidden != true\]\{ "id": coalesce\(id, _key\), description, input, expectedOutput \}/
     );
     // Raw `tests,` (unfiltered, includes hidden) must not be projected.
     expect(query).not.toMatch(/\btests,/);

--- a/apps/web/src/lib/sanity/queries.ts
+++ b/apps/web/src/lib/sanity/queries.ts
@@ -47,7 +47,7 @@ const moduleWithLessonsFields = `
     videoUrl,
     content,
     code,
-    "tests": tests[hidden != true]{ id, description, input, expectedOutput },
+    "tests": tests[hidden != true]{ "id": coalesce(id, _key), description, input, expectedOutput },
     hints,
     order
   } | order(order asc)
@@ -112,7 +112,7 @@ export async function getLessonBySlug(
         videoUrl,
         content,
         code,
-        "tests": tests[hidden != true]{ id, description, input, expectedOutput },
+        "tests": tests[hidden != true]{ "id": coalesce(id, _key), description, input, expectedOutput },
         hints,
         order
       }
@@ -147,7 +147,7 @@ const answerKeyProjection = `{
   type,
   language,
   buildType,
-  "tests": tests[]{ id, description, input, expectedOutput, hidden },
+  "tests": tests[]{ "id": coalesce(id, _key), description, input, expectedOutput, hidden },
   solution
 }`;
 


### PR DESCRIPTION
## Summary

Fixes the React **"Encountered two children with the same key, `null`"** warning on the lesson challenge page (#248).

## Root cause

`lesson-client.tsx` renders `key={tc.id}` for each visible test case, but the GROQ projections selected a bare `id` field — which Sanity test-case objects don't have (they key on `_key`). So `tc.id` was `null` for every row, collapsing them all to `key={null}` and producing unstable list rendering.

The `id` field was also typed `string` while being `null` at runtime — a type/data mismatch.

## Fix

Project `"id": coalesce(id, _key)` in the test-case projections, so each test case carries a **stable, unique** id (Sanity guarantees `_key` on array items; `coalesce` still prefers an explicit `id` if one is ever authored).

Applied to all three test projections in `queries.ts`:
- `moduleWithLessonsFields` (getCourseBySlug / getCourseById)
- `getLessonBySlug` — the query that feeds the lesson page in the bug report
- `answerKeyProjection` (server-side) — so ids are consistent everywhere; the executor keys `ServerTestResult` by test id too

No change needed in `lesson-client.tsx` — `key={tc.id}` is now correct at the source (the fix addresses the root, not the symptom).

## Verification

- `tsc` clean, eslint clean
- Confirmed the lesson page uses `getLessonBySlug` (the fixed projection), so the reported data path is covered
- Each Sanity test case has a unique `_key`, so keys are now unique → no duplicate-key warning

Closes #248
