### PR TITLE
feat(challenge): server-side grader for buildable Anchor challenges (#253 part 2)

### DIFF
--- a/apps/web/src/app/api/lessons/complete/route.ts
+++ b/apps/web/src/app/api/lessons/complete/route.ts
@@ -119,22 +119,20 @@ export async function POST(request: NextRequest) {
           }
           break;
         case "executor_unavailable":
-          // Degrade closed: never grant completion we could not verify.
+          // Degrade closed: never grant completion we could not verify. Also the
+          // buildable path when the build server is unreachable OR not configured
+          // (prod, pre-#193) — a buildable submission stays un-gradeable and is
+          // denied here, exactly as before this grader existed.
           return NextResponse.json(
             { error: "Challenge validation is temporarily unavailable" },
             { status: 503 }
           );
         case "non_js_challenge":
-          // FAIL CLOSED. Only `buildType: "buildable"` challenges reach here now
-          // (plain Rust is graded server-side via the Rust Playground and
-          // resolves to `validated`). Buildable challenges must be compiled +
-          // graded by the Anchor build server, and that handshake is NOT wired
-          // up yet — so the server cannot prove correctness and MUST NOT submit
-          // the on-chain completeLesson. A bare fall-through would grant a
-          // completion (and credential eligibility) for any unverified
-          // buildable submission. Deny exactly like executor_unavailable.
-          // TODO(#195 follow-up): wire the build-server validation handshake,
-          // then gate this branch on its passing verdict.
+          // FAIL CLOSED. Unreachable for the known challenge types now that JS
+          // (isolate), plain Rust (Playground), and buildable (build server) all
+          // resolve to `validated`/`executor_unavailable`. Retained so any future
+          // unrecognised type is denied rather than granted an unverified
+          // completion (and credential eligibility) via a bare fall-through.
           return NextResponse.json(
             {
               error:

--- a/apps/web/src/lib/challenge/__tests__/buildable-executor.test.ts
+++ b/apps/web/src/lib/challenge/__tests__/buildable-executor.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { AdminTestCase } from "@superteam-lms/types";
+
+// The grader reads BUILD_SERVER_URL / BUILD_SERVER_API_KEY at module load, so
+// each test re-imports the module after setting the env it needs (vitest
+// isolates the module registry per resetModules()).
+const URL = "https://build.example.test";
+const KEY = "test-api-key";
+
+const tests: AdminTestCase[] = [
+  {
+    id: "test-1",
+    description: "Program compiles",
+    input: "",
+    expectedOutput: "true",
+  },
+  {
+    id: "test-2",
+    description: "hidden content check",
+    input: "",
+    expectedOutput: "true",
+    hidden: true,
+  },
+];
+
+const CODE = 'use anchor_lang::prelude::*;\ndeclare_id!("Fg6");\n';
+
+/** Stub the build server. `respond` gets the parsed request body. */
+function mockBuildServer(
+  respond: (body: {
+    files: [string, string][];
+  }) => { ok?: boolean; success?: boolean; stderr?: string } | Promise<never>
+) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (_url: string, init: { body: string }) => {
+      const body = JSON.parse(init.body) as { files: [string, string][] };
+      const r = respond(body);
+      if (r instanceof Promise) return r;
+      return {
+        ok: r.ok ?? true,
+        json: async () => ({
+          success: r.success ?? false,
+          stderr: r.stderr ?? "",
+          uuid: "uuid-1",
+        }),
+      } as unknown as Response;
+    })
+  );
+}
+
+async function loadGrader() {
+  vi.resetModules();
+  return import("../buildable-executor");
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+  delete process.env.BUILD_SERVER_URL;
+  delete process.env.BUILD_SERVER_API_KEY;
+});
+
+describe("runBuildableSubmission — build server configured", () => {
+  beforeEach(() => {
+    process.env.BUILD_SERVER_URL = URL;
+    process.env.BUILD_SERVER_API_KEY = KEY;
+  });
+
+  it("passes ALL tests when the program compiles (success: true)", async () => {
+    mockBuildServer(() => ({ success: true }));
+    const { runBuildableSubmission } = await loadGrader();
+    const r = await runBuildableSubmission(CODE, tests);
+    expect(r.available).toBe(true);
+    expect(r).toMatchObject({ passed: true });
+    if (r.available) {
+      expect(r.results.every((t) => t.passed)).toBe(true);
+      expect(r.results[1]?.hidden).toBe(true);
+    }
+  });
+
+  it("fails ALL tests on a genuine compile error (success: false)", async () => {
+    mockBuildServer(() => ({
+      success: false,
+      stderr: "error[E0425]: cannot find value `x` in this scope",
+    }));
+    const { runBuildableSubmission } = await loadGrader();
+    const r = await runBuildableSubmission(CODE, tests);
+    expect(r).toMatchObject({ available: true, passed: false });
+    if (r.available) {
+      expect(r.results[0]?.passed).toBe(false);
+      expect(r.results[0]?.detail).toContain("error");
+    }
+  });
+
+  it("sends /src/lib.rs plus a cache-busting nonce file, with the API key", async () => {
+    const spy = vi.fn(
+      async (
+        _url: string,
+        init: { body: string; headers: Record<string, string> }
+      ) => {
+        const body = JSON.parse(init.body) as { files: [string, string][] };
+        expect(_url).toBe(`${URL}/build`);
+        expect(init.headers["X-API-Key"]).toBe(KEY);
+        const paths = body.files.map((f) => f[0]);
+        expect(paths).toContain("/src/lib.rs");
+        expect(
+          paths.some((p) => p.endsWith(".rs") && p !== "/src/lib.rs")
+        ).toBe(true);
+        return {
+          ok: true,
+          json: async () => ({ success: true, stderr: "", uuid: "u" }),
+        } as unknown as Response;
+      }
+    );
+    vi.stubGlobal("fetch", spy);
+    const { runBuildableSubmission } = await loadGrader();
+    await runBuildableSubmission(CODE, tests);
+    expect(spy).toHaveBeenCalledOnce();
+  });
+
+  it("degrades closed when the build server is unreachable", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new Error("ECONNREFUSED");
+      })
+    );
+    const { runBuildableSubmission } = await loadGrader();
+    const r = await runBuildableSubmission(CODE, tests);
+    expect(r).toEqual({ available: false, reason: "executor_unavailable" });
+  });
+
+  it("degrades closed on a non-2xx build-server response", async () => {
+    mockBuildServer(() => ({ ok: false }));
+    const { runBuildableSubmission } = await loadGrader();
+    const r = await runBuildableSubmission(CODE, tests);
+    expect(r).toEqual({ available: false, reason: "executor_unavailable" });
+  });
+
+  it("rejects an oversized submission without calling the build server", async () => {
+    const spy = vi.fn();
+    vi.stubGlobal("fetch", spy);
+    const { runBuildableSubmission } = await loadGrader();
+    const big = "// x\n".repeat(30_000); // > 100KB
+    const r = await runBuildableSubmission(big, tests);
+    expect(r).toMatchObject({ available: true, passed: false });
+    expect(spy).not.toHaveBeenCalled();
+  });
+});
+
+describe("runBuildableSubmission — build server NOT configured", () => {
+  it("fails closed (never calls out) when env is unset", async () => {
+    // env intentionally unset (afterEach cleared it)
+    const spy = vi.fn();
+    vi.stubGlobal("fetch", spy);
+    const { runBuildableSubmission, isBuildServerConfigured } =
+      await loadGrader();
+    expect(isBuildServerConfigured()).toBe(false);
+    const r = await runBuildableSubmission(CODE, tests);
+    expect(r).toEqual({ available: false, reason: "executor_unavailable" });
+    expect(spy).not.toHaveBeenCalled();
+  });
+});
+
+describe("validateAgainstAnswerKey — buildable routing", () => {
+  const buildableKey = {
+    _id: "l1",
+    type: "challenge" as const,
+    language: "rust" as const,
+    buildType: "buildable" as const,
+    tests,
+    solution: CODE,
+  };
+
+  it("grades a compiling buildable challenge to validated/passed", async () => {
+    process.env.BUILD_SERVER_URL = URL;
+    process.env.BUILD_SERVER_API_KEY = KEY;
+    mockBuildServer(() => ({ success: true }));
+    vi.resetModules();
+    const { validateAgainstAnswerKey } = await import("../validate");
+    const v = await validateAgainstAnswerKey(buildableKey, CODE);
+    expect(v).toMatchObject({ kind: "validated", passed: true });
+  });
+
+  it("maps a build-server outage to executor_unavailable (deny completion)", async () => {
+    process.env.BUILD_SERVER_URL = URL;
+    process.env.BUILD_SERVER_API_KEY = KEY;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new Error("down");
+      })
+    );
+    vi.resetModules();
+    const { validateAgainstAnswerKey } = await import("../validate");
+    const v = await validateAgainstAnswerKey(buildableKey, CODE);
+    expect(v.kind).toBe("executor_unavailable");
+  });
+
+  it("fails closed (executor_unavailable) when the build server is unset", async () => {
+    // env unset → grader reports unavailable → validate maps to
+    // executor_unavailable (completion route denies with 503). This is what
+    // keeps prod unchanged.
+    const spy = vi.fn();
+    vi.stubGlobal("fetch", spy);
+    vi.resetModules();
+    const { validateAgainstAnswerKey } = await import("../validate");
+    const v = await validateAgainstAnswerKey(buildableKey, CODE);
+    expect(v.kind).toBe("executor_unavailable");
+    expect(spy).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/challenge/__tests__/executor.test.ts
+++ b/apps/web/src/lib/challenge/__tests__/executor.test.ts
@@ -252,15 +252,17 @@ describe("validateAgainstAnswerKey (classification, no executor)", () => {
     expect(verdict.kind).toBe("not_a_challenge");
   });
 
-  // Plain `language: "rust"` challenges are now graded by the Rust executor
-  // (see rust-executor.test.ts). Only `buildType: "buildable"` still fails
-  // closed here — its build-server grading handshake isn't wired up.
-  it("classifies buildable challenges as non_js_challenge", async () => {
+  // Plain `language: "rust"` challenges are graded by the Rust executor (see
+  // rust-executor.test.ts); `buildType: "buildable"` by the build server (see
+  // buildable-executor.test.ts). With no build server configured in this test
+  // env, buildable fails closed to executor_unavailable — completion denied,
+  // never a granted pass. (This is the pre-#193 prod posture too.)
+  it("fails a buildable challenge closed when the build server is unconfigured", async () => {
     const buildable = await validateAgainstAnswerKey(
       answerKey({ buildType: "buildable" }),
       "// program"
     );
-    expect(buildable.kind).toBe("non_js_challenge");
+    expect(buildable.kind).toBe("executor_unavailable");
   });
 });
 

--- a/apps/web/src/lib/challenge/__tests__/rust-executor.test.ts
+++ b/apps/web/src/lib/challenge/__tests__/rust-executor.test.ts
@@ -159,7 +159,11 @@ describe("validateAgainstAnswerKey — Rust routing", () => {
     expect(v.kind).toBe("executor_unavailable");
   });
 
-  it("still fails a buildable challenge closed as non_js_challenge", async () => {
+  it("routes a buildable challenge to the build server, NOT the Playground", async () => {
+    // With no build server configured (env unset here), the buildable grader
+    // fails closed to executor_unavailable — never the Rust Playground, and
+    // never a granted completion. (Grading against a live build server is
+    // covered in buildable-executor.test.ts.)
     const spy = vi.fn();
     vi.stubGlobal("fetch", spy);
     const buildableKey: ChallengeAnswerKey = {
@@ -167,7 +171,7 @@ describe("validateAgainstAnswerKey — Rust routing", () => {
       buildType: "buildable",
     };
     const v = await validateAgainstAnswerKey(buildableKey, CODE);
-    expect(v.kind).toBe("non_js_challenge");
+    expect(v.kind).toBe("executor_unavailable");
     expect(spy).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/lib/challenge/buildable-executor.ts
+++ b/apps/web/src/lib/challenge/buildable-executor.ts
@@ -1,0 +1,209 @@
+/**
+ * Authoritative server-side grader for **buildable** challenge submissions —
+ * the `buildType: "buildable"` lessons that ship a full on-chain Anchor program
+ * (the "Your First Build" / Counter / "Deploy to Devnet" track).
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * `/api/lessons/complete` must independently prove a submission passes before it
+ * records an on-chain completion (which awards XP + credential eligibility).
+ * JS/TS challenges are proven by the QuickJS isolate (`executor.ts`); plain Rust
+ * snippets by the Rust Playground (`rust-executor.ts`). Buildable challenges are
+ * proven HERE: the submission is compiled with `cargo-build-sbf` by the Anchor
+ * build server (`apps/build-server`), and the verdict is derived from whether it
+ * compiled. This mirrors those graders' relationship to their browser runners —
+ * the browser `runBuildChallenge` (in `challenge-runner.tsx`) is a non-
+ * authoritative UX pre-check; the server is the source of truth.
+ *
+ * GRADING RUBRIC (compilation success)
+ * ------------------------------------
+ * Every buildable lesson's tests are compilation checks. Test 0 is always
+ * "Program compiles successfully"; any further tests are prose content-checks
+ * ("Code contains a greet function", …) that the browser runner ALSO grades as
+ * plain compile-success (it never regexes the description). We honour the same
+ * contract server-side: a submission passes iff the build server reports the
+ * program compiled. The build server's own `build.rs` still defers IDL parsing
+ * ("no anchor-syn"), so `success: bool` is the only authoritative signal — and a
+ * clean SBF compile is the realistic, non-forgeable v1 bar for these lessons.
+ * (If a future lesson encodes a checkable expected result, extend here.)
+ *
+ * SECURITY — this path grants on-chain XP, so it must resist a hostile
+ * submission forging a pass:
+ *
+ *   - FAIL-CLOSED ON CONFIG. If the build server is not configured
+ *     (`BUILD_SERVER_URL` / `BUILD_SERVER_API_KEY` unset), the grader reports
+ *     `available: false` and grades NOTHING — callers deny completion. This is
+ *     what keeps PROD (where the build server is not yet deployed) unchanged: a
+ *     buildable submission still 503s rather than being granted unverified.
+ *   - FAIL-CLOSED ON OUTAGE. A build-server timeout, network error, non-2xx, or
+ *     malformed body all resolve to `available: false` (deny), never a pass. Only
+ *     an explicit `success: true` from the build server is a pass; an explicit
+ *     `success: false` (genuine compile error) is `available: true` + all tests
+ *     failed (a bad submission, not an outage).
+ *   - SIZE-CAPPED. The raw submission is rejected above `MAX_BUILDABLE_BYTES`
+ *     before any network call.
+ *
+ * ⚠️ OPERATIONAL SECURITY — DO NOT set `BUILD_SERVER_URL` in production until the
+ * build server is network-isolated (issue #193, VPC deny-egress). Grading an
+ * untrusted `anchor build` runs the submission's `build.rs` / proc-macros as
+ * arbitrary code on the build host; egress isolation is what contains that. The
+ * SBF target sandboxes the *compiled* program, NOT the build itself. Until #193
+ * lands, leave it unset — this grader then fails closed and blocks nothing.
+ */
+
+import type { AdminTestCase } from "@superteam-lms/types";
+import type { ServerTestResult, SubmissionRunResult } from "./executor";
+
+const BUILD_SERVER_URL = process.env.BUILD_SERVER_URL;
+const BUILD_SERVER_API_KEY = process.env.BUILD_SERVER_API_KEY;
+
+/**
+ * Upper bound on the RAW submission we are willing to compile. Matches the
+ * build server's own per-file limit (100KB); the isolate/Playground graders cap
+ * lower because they wrap the code in a harness, which we do not.
+ */
+const MAX_BUILDABLE_BYTES = 100 * 1024;
+
+/**
+ * Wall-clock budget for the build round-trip. The build server's own build
+ * timeout is 120s; we wait slightly longer so a genuinely slow compile surfaces
+ * its real verdict instead of being cut off client-side as an outage.
+ */
+const UPSTREAM_TIMEOUT_MS = 130_000;
+
+/** Shape the build server's `/build` returns (see apps/build-server build.rs). */
+interface BuildServerResponse {
+  success: boolean;
+  stderr: string;
+  uuid: string | null;
+  binary_b64?: string;
+}
+
+const ANSI_REGEX = /\x1b\[[0-9;]*m/g;
+const stripAnsi = (s: string): string => s.replace(ANSI_REGEX, "");
+
+/** Whether the build server is configured (and therefore grading can run). */
+export function isBuildServerConfigured(): boolean {
+  return Boolean(BUILD_SERVER_URL && BUILD_SERVER_API_KEY);
+}
+
+/**
+ * The build server only accepts source paths matching `^/src/<name>.rs$`, so a
+ * buildable submission is always compiled as the crate's `src/lib.rs`. It also
+ * pins `declare_id!` at runtime, but for a *compile-only* grade the placeholder
+ * id compiles fine, so we leave the source byte-identical (no rewrite needed).
+ *
+ * A per-request nonce file busts the build server's content-addressable cache so
+ * one learner's PASS/FAIL is never served from another submission's cached
+ * entry — the grade always reflects THIS exact source.
+ */
+function toBuildFiles(code: string, nonce: string): [string, string][] {
+  return [
+    ["/src/lib.rs", code],
+    ["/src/_grade_nonce.rs", `// ${nonce}`],
+  ];
+}
+
+/** Fail every test with the same reason (bad submission, not a build outage). */
+function allFailed(
+  tests: AdminTestCase[],
+  detail: string
+): SubmissionRunResult {
+  return {
+    available: true,
+    passed: false,
+    results: tests.map((t) => ({
+      id: t.id,
+      hidden: t.hidden === true,
+      passed: false,
+      detail,
+    })),
+  };
+}
+
+/** Pass every test (the program compiled — the rubric for buildable lessons). */
+function allPassed(tests: AdminTestCase[]): SubmissionRunResult {
+  return {
+    available: true,
+    passed: true,
+    results: tests.map((t) => ({
+      id: t.id,
+      hidden: t.hidden === true,
+      passed: true,
+      detail: "compiled",
+    })),
+  };
+}
+
+/**
+ * Grade a buildable submission by compiling it via the build server.
+ *
+ * Contract mirrors {@link runJsSubmission} / {@link runRustSubmission}:
+ *   - `{ available: false }` → the grader could not run (build server unset or
+ *     unreachable); callers MUST deny completion.
+ *   - `{ available: true, passed }` → the build server rendered a verdict;
+ *     `passed` is true iff the program compiled (all tests pass together).
+ */
+export async function runBuildableSubmission(
+  code: string,
+  tests: AdminTestCase[]
+): Promise<SubmissionRunResult> {
+  // Fail closed when the build server is not configured. This is the guard that
+  // leaves prod (build server not deployed) unchanged — a buildable submission
+  // stays un-gradeable → completion denied, never granted.
+  if (!BUILD_SERVER_URL || !BUILD_SERVER_API_KEY) {
+    return { available: false, reason: "executor_unavailable" };
+  }
+
+  if (Buffer.byteLength(code, "utf8") > MAX_BUILDABLE_BYTES) {
+    return allFailed(tests, "Submission too large");
+  }
+
+  const nonce = crypto.randomUUID();
+  const files = toBuildFiles(code, nonce);
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), UPSTREAM_TIMEOUT_MS);
+
+  let data: BuildServerResponse;
+  try {
+    const res = await fetch(`${BUILD_SERVER_URL}/build`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-API-Key": BUILD_SERVER_API_KEY,
+      },
+      body: JSON.stringify({ files, uuid: null, flags: {} }),
+      signal: controller.signal,
+    });
+    if (!res.ok) {
+      // Build server reachable but erroring (4xx/5xx/429) — cannot render a
+      // trustworthy verdict, so degrade closed.
+      return { available: false, reason: "executor_unavailable" };
+    }
+    data = (await res.json()) as BuildServerResponse;
+  } catch {
+    // Network failure / timeout / abort — degrade closed.
+    return { available: false, reason: "executor_unavailable" };
+  } finally {
+    clearTimeout(timer);
+  }
+
+  if (data.success === true) {
+    return allPassed(tests);
+  }
+
+  // Explicit compile failure: a bad submission, not an outage. Surface the first
+  // real compiler error line as a short, non-sensitive diagnostic (no answer
+  // key). Prefer a diagnostic line (`error[E1234]:` / `error:`) over incidental
+  // matches like a crate named "…-error" in cargo's "Compiling …" progress.
+  const lines = stripAnsi(data.stderr ?? "").split("\n");
+  const firstError =
+    lines.find((l) => /^\s*error(\[|:)/.test(l)) ??
+    lines.find((l) => l.includes("error")) ??
+    "Program did not compile";
+  return allFailed(tests, firstError.trim().slice(0, 200));
+}
+
+/** Result of running a single test case — re-exported for callers/tests. */
+export type { ServerTestResult };

--- a/apps/web/src/lib/challenge/validate.ts
+++ b/apps/web/src/lib/challenge/validate.ts
@@ -15,6 +15,7 @@ import {
   type ServerTestResult,
 } from "@/lib/challenge/executor";
 import { runRustSubmission } from "@/lib/challenge/rust-executor";
+import { runBuildableSubmission } from "@/lib/challenge/buildable-executor";
 
 export type ChallengeVerdict =
   | {
@@ -27,12 +28,13 @@ export type ChallengeVerdict =
     }
   | {
       /**
-       * Lesson is a challenge whose correctness cannot yet be established
-       * server-side: `buildType: "buildable"` challenges are compiled by the
-       * Anchor build server, and that grading handshake is not wired up. The
-       * completion gate must deny these (fail closed). Plain `language: "rust"`
-       * challenges are NOT here — they are graded by the Rust executor and
-       * resolve to `validated`.
+       * Lesson is a challenge no server-side grader can currently judge — a
+       * true dead-end that the completion gate must deny (fail closed). With the
+       * buildable grader wired up this is now unreachable for the known
+       * challenge types (JS → isolate, `language: "rust"` → Rust executor,
+       * `buildType: "buildable"` → build server), but it is retained so any
+       * FUTURE unrecognised type also degrades closed instead of falling
+       * through to a granted completion.
        */
       kind: "non_js_challenge";
       language: string | null;
@@ -94,6 +96,14 @@ function isRustGradableChallenge(key: ChallengeAnswerKey): boolean {
 }
 
 /**
+ * A buildable challenge (`buildType: "buildable"`) — a full on-chain Anchor
+ * program graded by compiling it via the build server (`buildable-executor.ts`).
+ */
+function isBuildableChallenge(key: ChallengeAnswerKey): boolean {
+  return key.type === "challenge" && key.buildType === "buildable";
+}
+
+/**
  * Validate a submission against the answer key. Pure logic — no auth, no HTTP.
  */
 export async function validateAgainstAnswerKey(
@@ -127,8 +137,30 @@ export async function validateAgainstAnswerKey(
     };
   }
 
-  // Remaining non-JS challenges (buildType: "buildable") have no server-side
-  // grader yet — fail closed.
+  // Buildable challenges: graded authoritatively by compiling the submission on
+  // the Anchor build server. Pass == the program compiles (see
+  // buildable-executor.ts for the rubric). A build-server outage — or the build
+  // server simply not being configured (prod, pre-#193) — degrades closed to
+  // executor_unavailable so completion is denied, never granted unverified.
+  if (isBuildableChallenge(key)) {
+    const run = await runBuildableSubmission(submittedCode, key.tests ?? []);
+    if (!run.available) {
+      return {
+        kind: "executor_unavailable",
+        hiddenTestCount: hidden,
+        visibleTestCount: visible,
+      };
+    }
+    return {
+      kind: "validated",
+      passed: run.passed,
+      hiddenTestCount: hidden,
+      visibleTestCount: visible,
+      results: run.results,
+    };
+  }
+
+  // Any remaining challenge type has no server-side grader — fail closed.
   if (!isJsExecutableChallenge(key)) {
     return {
       kind: "non_js_challenge",


### PR DESCRIPTION
Resolves **part 2** of #253 (the server-side grader). Part 1 (deploy the build server to Cloud Run + set `BUILD_SERVER_URL`/`BUILD_SERVER_API_KEY`) is infra and remains separate.

## What this does

Wires the 8 `buildType: "buildable"` challenges into the server-authoritative completion gate. Before this, `validate.ts` classified them as `non_js_challenge` and `/api/lessons/complete` fail-closed with a 503 ("Server-side validation for this challenge type is not yet available"), so the 8 buildable lessons (Your First Build, Add an Instruction, Define a Counter Account, Wire Up Initialize, Build the Increment, Complete Counter Program, Deploy to Devnet, Deploy Your Program to Devnet) could never be completed for XP.

New `apps/web/src/lib/challenge/buildable-executor.ts` mirrors the existing graders (`executor.ts` for JS/QuickJS, `rust-executor.ts` for Rust/Playground): it POSTs the submission to the Anchor build server (`BUILD_SERVER_URL` + `X-API-Key`, as `/src/lib.rs` + a cache-busting nonce file) and derives the verdict from the build result. `validate.ts` routes buildable challenges to it.

## Grading rubric: compilation success

Every buildable lesson's tests are compilation checks — test 0 is always "Program compiles successfully", and any further tests are prose content-checks the **browser runner already grades as plain compile-success** (it never regexes the description). The build server's `build.rs` defers IDL parsing ("no anchor-syn"), so `success: bool` is the only authoritative signal it exposes. So: **a submission passes iff the program compiles cleanly** — the realistic, non-forgeable v1 bar #253 calls for. (Extension point documented if a future lesson encodes a checkable expected result.)

## Security — fail-closed preserved

- **Build server unset → 503, never a pass.** If `BUILD_SERVER_URL`/`BUILD_SERVER_API_KEY` are not set, the grader reports `available: false` → `validate.ts` returns `executor_unavailable` → the completion route 503s. **This keeps production unchanged** (the build server isn't deployed there yet).
- ⚠️ **`BUILD_SERVER_URL` must only be set in prod AFTER the build server is network-isolated (#193, VPC deny-egress)** — grading an untrusted `anchor build` runs untrusted `build.rs`/proc-macros on the build host; the SBF target only sandboxes the *compiled* program. This is called out in a code comment on the grader.
- Build-server outage / non-2xx / timeout → `executor_unavailable` (deny), never an unverified pass.
- Submission size-capped (100KB) before any network call.
- Only an explicit `success: true` is a pass; `success: false` is a genuine compile failure (all tests failed), kept distinct from an outage.

## Testing — end-to-end against a locally-run build server

Ran `apps/build-server` locally (`ACADEMY_API_KEY` set) and pointed the grader at it:

- **Correct solution** (the real "Complete Counter Program" Anchor program — PDA seeds, account init, custom `#[error_code]`) → build server `success: true`, produced a 233KB `.so` → grader `available:true, passed:true`.
- **Broken submission** (undeclared symbol) → build server `success: false` (`error[E0425]`, no binary) → grader `available:true, passed:false` (deny), surfacing the real error line as the diagnostic.
- **`BUILD_SERVER_URL` unset** → grader `available:false` with no network call → completion denied (503). Fail-closed confirmed.

Plus a new `buildable-executor.test.ts` (10 tests) covering pass/fail, degrade-closed on outage, fail-closed when unset, request shape, and size cap. Updated the two sibling tests that asserted the old `non_js_challenge` classification (buildable now degrades to `executor_unavailable` when unconfigured — still denies completion).

`pnpm --filter @superteam-lms/web typecheck` and eslint both clean; all 40 challenge-lib tests pass.

> Local-test caveat: on macOS the build server's `cp --reflink=auto` (GNU-only) in `setup_build_dir` fails, so I removed the pre-built `programs/target/` to force a full (BSD-`cp`-safe) build. Not a code issue — Cloud Run runs Ubuntu where `--reflink` is supported.