### PR TITLE
fix(landing): show real platform stats (0 courses/builders/creds bug)

### DIFF
--- a/apps/web/src/app/[locale]/(marketing)/page.tsx
+++ b/apps/web/src/app/[locale]/(marketing)/page.tsx
@@ -4,7 +4,13 @@ import {
   getAllLearningPaths,
   getDeployedAchievements,
 } from "@/lib/sanity/queries";
-import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+
+// The landing shows live platform stats (courses, enrolled builders, credentials,
+// XP). Without revalidation it renders fully static and freezes at build time —
+// which is why "COURSES LIVE" showed 0 whenever the build-time Sanity fetch lagged
+// and never refreshed. 5-minute ISR keeps the numbers current without per-request cost.
+export const revalidate = 300;
 
 export default async function LandingPage() {
   const [courses, learningPaths, achievements] = await Promise.all([
@@ -18,7 +24,11 @@ export default async function LandingPage() {
   let enrolledBuilders = 0;
   let credentialsIssued = 0;
   try {
-    const supabase = await createClient();
+    // Service-role (server-only) so this public landing can read aggregate counts.
+    // The anon client hits RLS ("own-row only" on profiles/certificates), so every
+    // count returned 0 — why the live page showed 0 builders/credentials despite real
+    // data. These are non-sensitive totals; the service key never reaches the client.
+    const supabase = createAdminClient();
     const [xpResult, enrollResult, certResult] = await Promise.all([
       supabase.from("public_user_xp").select("total_xp"),
       supabase.from("profiles").select("id", { count: "exact", head: true }),


### PR DESCRIPTION
Found via a live browser QA pass of **solarium.courses**: the landing's "on-chain stats" bar shows **0 COURSES LIVE / 0 BUILDERS ENROLLED / 0 CREDENTIALS ISSUED** despite real data (only XP = 208 rendered) — the platform looks dead to visitors.

## Root causes
1. **Fully static** landing (no `revalidate`) → the Sanity-sourced `courses.length` froze at build time. `/courses` shows the same courses fine, so this was a stale/failed build-time fetch that never refreshed.
2. **Anon Supabase client** counting `profiles`/`certificates` → RLS is "own-row only" on those tables, so an unauthenticated (public landing) count returns **0**. XP worked only because it reads the public `public_user_xp` view.

## Fix
- `export const revalidate = 300` — 5-min ISR so the stats stay current instead of frozen.
- `createAdminClient()` (service-role, **server-only** — the key never reaches the client) for the count queries, bypassing RLS. Non-sensitive aggregate totals.

Verification: I'll confirm the real numbers render on the deployed landing after merge (live browser check).