### PR TITLE
feat(teacher): course ownership + authoring status + teacher role (#263)

### DIFF
--- a/apps/web/src/lib/sanity/queries.ts
+++ b/apps/web/src/lib/sanity/queries.ts
@@ -4,6 +4,14 @@ import type { Course, Lesson, LearningPath } from "./types";
 
 // --- GROQ Queries ---
 
+// Authoring-workflow gate for PUBLIC/catalog queries (issue #263). A course is
+// only publicly visible once an admin has approved it. LENIENT on purpose:
+// legacy course docs predate the `authoringStatus` field, so `!defined(...)`
+// admits them — a bare `== "approved"` would hide the entire live catalog until
+// the backfill runs. Combine with the existing on-chain "synced" gate. This is
+// applied ONLY to public queries; admin/Studio queries must keep seeing drafts.
+const publicAuthoringGate = `(authoringStatus == "approved" || !defined(authoringStatus))`;
+
 const courseFields = `
   _id,
   title,
@@ -57,7 +65,7 @@ const moduleWithLessonsFields = `
 
 export async function getAllCourses(): Promise<Course[]> {
   return sanityFetch<Course[]>(
-    `*[_type == "course" && onChainStatus.status == "synced"] | order(title asc) {
+    `*[_type == "course" && onChainStatus.status == "synced" && ${publicAuthoringGate}] | order(title asc) {
       ${courseFields},
       "modules": modules[]->{
         _id,
@@ -78,7 +86,7 @@ export async function getAllCourses(): Promise<Course[]> {
 
 export async function getCourseBySlug(slug: string): Promise<Course | null> {
   return sanityFetch<Course | null>(
-    `*[_type == "course" && slug.current == $slug && onChainStatus.status == "synced"][0] {
+    `*[_type == "course" && slug.current == $slug && onChainStatus.status == "synced" && ${publicAuthoringGate}][0] {
       ${courseFields},
       "modules": modules[]->{
         ${moduleWithLessonsFields}
@@ -98,7 +106,7 @@ export async function getLessonBySlug(
   // re-projects each to drop the `hidden` flag itself. Hidden-test/solution
   // checking lives server-side in /api/lessons/validate-challenge.
   return sanityFetch<Lesson | null>(
-    `*[_type == "course" && slug.current == $courseSlug && onChainStatus.status == "synced"][0] {
+    `*[_type == "course" && slug.current == $courseSlug && onChainStatus.status == "synced" && ${publicAuthoringGate}][0] {
       "allLessons": modules[]->lessons[]->{
         _id,
         title,
@@ -158,7 +166,7 @@ export async function getChallengeAnswerKey(
   // revalidate=0: always read fresh, never via the public Sanity CDN, so the
   // answer key is not cached on any edge.
   return sanityFetch<ChallengeAnswerKey | null>(
-    `*[_type == "course" && slug.current == $courseSlug && onChainStatus.status == "synced"][0] {
+    `*[_type == "course" && slug.current == $courseSlug && onChainStatus.status == "synced" && ${publicAuthoringGate}][0] {
       "allLessons": modules[]->lessons[]->${answerKeyProjection}
     }.allLessons[slug == $lessonSlug][0]`,
     { courseSlug, lessonSlug },
@@ -176,7 +184,7 @@ export async function getChallengeAnswerKeyById(
   lessonId: string
 ): Promise<ChallengeAnswerKey | null> {
   return sanityFetch<ChallengeAnswerKey | null>(
-    `*[_type == "course" && _id == $courseId && onChainStatus.status == "synced"][0] {
+    `*[_type == "course" && _id == $courseId && onChainStatus.status == "synced" && ${publicAuthoringGate}][0] {
       "allLessons": modules[]->lessons[]->${answerKeyProjection}
     }.allLessons[_id == $lessonId][0]`,
     { courseId, lessonId },
@@ -194,7 +202,7 @@ export async function getAllLearningPaths(): Promise<LearningPath[]> {
       tag,
       order,
       difficulty,
-      "courses": *[_type == "course" && _id in ^.courses[]._ref && onChainStatus.status == "synced"] {
+      "courses": *[_type == "course" && _id in ^.courses[]._ref && onChainStatus.status == "synced" && ${publicAuthoringGate}] {
         ${courseFields},
         "modules": modules[]->{
           _id,
@@ -239,7 +247,7 @@ export async function getCourseIdBySlug(
   slug: string
 ): Promise<{ _id: string; xpPerLesson: number } | null> {
   return sanityFetch<{ _id: string; xpPerLesson: number } | null>(
-    `*[_type == "course" && slug.current == $slug && onChainStatus.status == "synced"][0] {
+    `*[_type == "course" && slug.current == $slug && onChainStatus.status == "synced" && ${publicAuthoringGate}][0] {
       _id,
       "xpPerLesson": coalesce(xpPerLesson, 0)
     }`,
@@ -254,7 +262,7 @@ export async function getCourseLessons(
   courseSlug: string
 ): Promise<Pick<Lesson, "_id" | "title" | "slug" | "type">[]> {
   return sanityFetch<Pick<Lesson, "_id" | "title" | "slug" | "type">[]>(
-    `*[_type == "course" && slug.current == $courseSlug && onChainStatus.status == "synced"][0] {
+    `*[_type == "course" && slug.current == $courseSlug && onChainStatus.status == "synced" && ${publicAuthoringGate}][0] {
       "lessons": modules[]->lessons[]-> {
         _id,
         title,
@@ -286,7 +294,7 @@ export interface CourseSummary {
 export async function getCoursesByIds(ids: string[]): Promise<CourseSummary[]> {
   if (ids.length === 0) return [];
   return sanityFetch<CourseSummary[]>(
-    `*[_type == "course" && _id in $ids && onChainStatus.status == "synced"] {
+    `*[_type == "course" && _id in $ids && onChainStatus.status == "synced" && ${publicAuthoringGate}] {
       _id,
       title,
       "slug": slug.current,
@@ -347,7 +355,7 @@ export async function getRecommendedCourses(
   excludeIds: string[]
 ): Promise<RecommendedCourse[]> {
   return sanityFetch<RecommendedCourse[]>(
-    `*[_type == "course" && !(_id in $excludeIds) && onChainStatus.status == "synced"] | order(title asc) {
+    `*[_type == "course" && !(_id in $excludeIds) && onChainStatus.status == "synced" && ${publicAuthoringGate}] | order(title asc) {
       _id,
       title,
       "slug": slug.current,
@@ -377,7 +385,7 @@ export async function getAllCourseTags(): Promise<
   return sanityFetch<
     { _id: string; title: string; tags: string[]; totalLessons: number }[]
   >(
-    `*[_type == "course" && onChainStatus.status == "synced" && defined(tags)] {
+    `*[_type == "course" && onChainStatus.status == "synced" && ${publicAuthoringGate} && defined(tags)] {
       _id,
       title,
       tags,
@@ -394,7 +402,7 @@ export async function getAllCourseLessonCounts(): Promise<
   { _id: string; totalLessons: number }[]
 > {
   return sanityFetch<{ _id: string; totalLessons: number }[]>(
-    `*[_type == "course" && onChainStatus.status == "synced"] {
+    `*[_type == "course" && onChainStatus.status == "synced" && ${publicAuthoringGate}] {
       _id,
       "totalLessons": count(modules[]->lessons[])
     }`

--- a/apps/web/src/lib/sanity/types.ts
+++ b/apps/web/src/lib/sanity/types.ts
@@ -1,5 +1,9 @@
+// `Course` re-exported here carries the optional `author?: string` and
+// `authoringStatus?: "draft" | "pending_review" | "approved"` fields added for
+// teacher-authored courses (issue #263); `AuthoringStatus` is the status union.
 export type {
   Course,
+  AuthoringStatus,
   Module,
   Lesson,
   Instructor,

--- a/apps/web/src/lib/supabase/types.ts
+++ b/apps/web/src/lib/supabase/types.ts
@@ -404,6 +404,7 @@ export type Database = {
           id: string;
           is_public: boolean | null;
           name_rerolls_used: number | null;
+          role: "learner" | "teacher" | "admin";
           social_links: Json | null;
           username: string;
           wallet_address: string | null;
@@ -418,6 +419,7 @@ export type Database = {
           id: string;
           is_public?: boolean | null;
           name_rerolls_used?: number | null;
+          role?: "learner" | "teacher" | "admin";
           social_links?: Json | null;
           username: string;
           wallet_address?: string | null;
@@ -432,6 +434,7 @@ export type Database = {
           id?: string;
           is_public?: boolean | null;
           name_rerolls_used?: number | null;
+          role?: "learner" | "teacher" | "admin";
           social_links?: Json | null;
           username?: string;
           wallet_address?: string | null;

--- a/packages/types/src/course.ts
+++ b/packages/types/src/course.ts
@@ -96,6 +96,8 @@ export interface Module {
   order: number;
 }
 
+export type AuthoringStatus = "draft" | "pending_review" | "approved";
+
 export interface Course {
   _id: string;
   title: string;
@@ -111,6 +113,10 @@ export interface Course {
   trackCollectionAddress?: string | null;
   trackId?: number;
   trackLevel?: number;
+  /** Supabase user id of the owning teacher (issue #263). Managed by the app. */
+  author?: string;
+  /** Authoring workflow state (issue #263). Legacy docs may omit this. */
+  authoringStatus?: AuthoringStatus;
 }
 
 export interface LearningPath {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -22,10 +22,11 @@ export type {
   Lesson,
   Module,
   Course,
+  AuthoringStatus,
   LearningPath,
 } from "./course";
 
-export type { UserProfile, Achievement, Certificate } from "./user";
+export type { UserProfile, UserRole, Achievement, Certificate } from "./user";
 
 export type {
   XPMintInfo,

--- a/packages/types/src/user.ts
+++ b/packages/types/src/user.ts
@@ -1,3 +1,5 @@
+export type UserRole = "learner" | "teacher" | "admin";
+
 export interface UserProfile {
   id: string;
   walletAddress: string | null;
@@ -12,6 +14,8 @@ export interface UserProfile {
   };
   isPublic: boolean;
   nameRerollsUsed: number;
+  /** Coarse account role (issue #263). Defaults to "learner"; set by admin only. */
+  role?: UserRole;
   createdAt: Date;
 }
 

--- a/sanity/schemas/course.ts
+++ b/sanity/schemas/course.ts
@@ -128,6 +128,33 @@ export const course = defineType({
         "Number of student completions required before creator reward is paid. 0 = never.",
     }),
     defineField({
+      name: "author",
+      title: "Author (Teacher User ID)",
+      type: "string",
+      readOnly: true,
+      hidden: ({ currentUser }) =>
+        !currentUser?.roles?.some((r) => r.name === "administrator"),
+      description:
+        "Supabase user id of the owning teacher. Managed by the app; do not edit manually.",
+    }),
+    defineField({
+      name: "authoringStatus",
+      title: "Authoring Status",
+      type: "string",
+      initialValue: "draft",
+      hidden: ({ currentUser }) =>
+        !currentUser?.roles?.some((r) => r.name === "administrator"),
+      description:
+        "Authoring workflow state. New courses start as draft; an admin approves before it goes public.",
+      options: {
+        list: [
+          { title: "Draft", value: "draft" },
+          { title: "Pending Review", value: "pending_review" },
+          { title: "Approved", value: "approved" },
+        ],
+      },
+    }),
+    defineField({
       name: "onChainStatus",
       title: "On-Chain Status",
       type: "object",

--- a/sanity/seed/backfill-authoring-status.mjs
+++ b/sanity/seed/backfill-authoring-status.mjs
@@ -1,0 +1,114 @@
+/**
+ * Sanity Backfill — course.authoringStatus (issue #263)
+ *
+ * Sets authoringStatus = "approved" on every existing course document that does
+ * not yet have the field. Legacy courses predate the teacher-authoring workflow
+ * and must stay publicly visible, so they are backfilled to "approved".
+ *
+ * RUN MANUALLY, POST-DEPLOY, with a write token. This is NOT run automatically
+ * and does NOT need to run before shipping: the public GROQ catalog filter is
+ * lenient — `(authoringStatus == "approved" || !defined(authoringStatus))` — so
+ * legacy docs remain visible even while their field is still undefined. This
+ * script simply normalizes the data so every course carries an explicit status.
+ *
+ * Usage:
+ *   SANITY_API_WRITE_TOKEN=<token> node sanity/seed/backfill-authoring-status.mjs
+ *
+ * Requires env vars (from apps/web/.env.local or the process environment):
+ *   NEXT_PUBLIC_SANITY_PROJECT_ID
+ *   NEXT_PUBLIC_SANITY_DATASET   (default: production)
+ *   SANITY_API_WRITE_TOKEN       (a token with write access; NEVER hardcode it)
+ */
+import { createClient } from "@sanity/client";
+import { readFileSync, existsSync } from "fs";
+import { resolve, dirname } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const rootDir = resolve(__dirname, "../..");
+
+// Load env vars from apps/web/.env.local, falling back to process.env so the
+// script also works in CI / one-off shells that export the vars directly.
+function loadEnv() {
+  const vars = { ...process.env };
+  const envPath = resolve(rootDir, "apps/web/.env.local");
+  if (existsSync(envPath)) {
+    const envContent = readFileSync(envPath, "utf-8");
+    for (const line of envContent.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith("#")) continue;
+      const eqIndex = trimmed.indexOf("=");
+      if (eqIndex === -1) continue;
+      const key = trimmed.slice(0, eqIndex);
+      const value = trimmed.slice(eqIndex + 1);
+      // Do not let a blank .env.local line clobber a real process.env value.
+      if (value !== "") vars[key] = value;
+    }
+  }
+  return vars;
+}
+
+const env = loadEnv();
+const projectId = env.NEXT_PUBLIC_SANITY_PROJECT_ID;
+const dataset = env.NEXT_PUBLIC_SANITY_DATASET || "production";
+const token = env.SANITY_API_WRITE_TOKEN;
+
+if (!projectId || projectId === "placeholder") {
+  console.error("NEXT_PUBLIC_SANITY_PROJECT_ID is not set or is 'placeholder'.");
+  process.exit(1);
+}
+if (!token) {
+  console.error(
+    "SANITY_API_WRITE_TOKEN is not set. Provide a write token via env; do not hardcode it."
+  );
+  process.exit(1);
+}
+
+const client = createClient({
+  projectId,
+  dataset,
+  token,
+  apiVersion: "2024-01-01",
+  useCdn: false,
+});
+
+async function backfill() {
+  console.log(
+    `Backfilling course.authoringStatus in project "${projectId}", dataset "${dataset}"...`
+  );
+
+  // Every course (incl. drafts) still missing the field.
+  const ids = await client.fetch(
+    `*[_type == "course" && !defined(authoringStatus)]._id`
+  );
+
+  if (!ids.length) {
+    console.log("No courses need backfilling — all already have authoringStatus.");
+    return;
+  }
+
+  console.log(`Found ${ids.length} course(s) without authoringStatus. Patching...`);
+
+  let patched = 0;
+  // Chain patches in a single transaction so the backfill is atomic.
+  let tx = client.transaction();
+  for (const id of ids) {
+    // setIfMissing is defensive: never overwrite a status set in the meantime.
+    tx = tx.patch(id, (p) => p.setIfMissing({ authoringStatus: "approved" }));
+  }
+
+  try {
+    await tx.commit({ visibility: "async" });
+    patched = ids.length;
+  } catch (err) {
+    console.error(`Failed to commit backfill transaction: ${err.message}`);
+    process.exit(1);
+  }
+
+  console.log(`Done. Patched ${patched} course document(s) -> authoringStatus = "approved".`);
+}
+
+backfill().catch((err) => {
+  console.error("Fatal error:", err);
+  process.exit(1);
+});

--- a/supabase/migrations/20260703130652_add_profiles_role_and_lock_role_writes.sql
+++ b/supabase/migrations/20260703130652_add_profiles_role_and_lock_role_writes.sql
@@ -1,0 +1,115 @@
+-- ============================================
+-- Teacher role: add profiles.role + lock role writes to service_role
+-- (issue #263 — foundation for teacher-authored courses)
+-- ============================================
+-- Adds a coarse role to profiles ('learner' | 'teacher' | 'admin') so the app
+-- can gate teacher authoring + admin approval flows. Existing rows default to
+-- 'learner'.
+--
+-- CRITICAL SECURITY — privilege-escalation lockdown.
+-- profiles carries self-service RLS policies so a user can edit their OWN row:
+--   FOR INSERT WITH CHECK (auth.uid() = id)
+--   FOR UPDATE USING      (auth.uid() = id)
+-- Those policies do NOT constrain WHICH columns are written. Without the guard
+-- below, any authenticated user could escalate themselves by writing
+-- role = 'teacher' / 'admin' straight to their own row via a PostgREST
+-- INSERT/UPDATE (RLS would happily allow it — it only checks the row id).
+--
+-- Fix: a BEFORE INSERT OR UPDATE trigger makes `role` writable ONLY by
+-- service_role. All legitimate role changes go through the admin API (#264),
+-- which uses the service-role key via createAdminClient() and so is detected as
+-- privileged and passes through untouched.
+--   * UPDATE: a non-privileged caller changing role -> RAISE EXCEPTION.
+--   * INSERT: a non-privileged caller is silently coerced back to 'learner'
+--     (so ordinary profile creation on signup still succeeds — the signup path
+--     never sets role, and even a crafted role is quietly downgraded rather
+--     than erroring the whole insert).
+--
+-- service_role detection is deliberately belt-and-suspenders: PostgREST runs
+-- requests under the `authenticated`/`anon` role and stashes the JWT claims in
+-- `request.jwt.claims`, while a direct service-role connection runs as
+-- `current_user = 'service_role'`. We treat the caller as privileged when
+-- EITHER signal says service_role, so the check holds whether the write comes
+-- via PostgREST with a service-role JWT or a direct service-role DB session.
+--
+-- The trigger function is SECURITY INVOKER: it must observe the CALLER's role,
+-- not the definer's. (A SECURITY DEFINER function would see the owner's role and
+-- defeat the check.)
+--
+-- Idempotent: CREATE OR REPLACE FUNCTION + DROP TRIGGER IF EXISTS / CREATE.
+
+-- (a) role column. IF NOT EXISTS keeps re-runs safe; the DEFAULT backfills
+-- every existing row to 'learner'.
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS role TEXT NOT NULL DEFAULT 'learner';
+
+-- Constrain the allowed values. Guarded add: PG15 has no
+-- ADD CONSTRAINT IF NOT EXISTS for CHECKs.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'chk_profiles_role'
+      AND conrelid = 'public.profiles'::regclass
+  ) THEN
+    ALTER TABLE public.profiles
+      ADD CONSTRAINT chk_profiles_role
+      CHECK (role IN ('learner', 'teacher', 'admin'));
+  END IF;
+END $$;
+
+-- (b) role-write lockdown trigger. SECURITY INVOKER so current_user reflects the
+-- actual caller (service_role bypasses RLS but still runs the trigger).
+CREATE OR REPLACE FUNCTION public.enforce_profile_role_write()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+DECLARE
+  jwt_role TEXT;
+  is_privileged BOOLEAN;
+BEGIN
+  -- Effective DB role (direct service-role connection) OR the PostgREST JWT
+  -- claims role (service-role key routed through PostgREST). Either implies
+  -- privileged. current_setting(..., true) returns NULL (not an error) when the
+  -- GUC is unset, e.g. a direct psql session with no JWT context; NULLIF guards
+  -- against an empty-string GUC (''::jsonb would raise). COALESCE keeps the
+  -- result a strict boolean so the IF below never sees NULL.
+  jwt_role := NULLIF(current_setting('request.jwt.claims', true), '')::jsonb ->> 'role';
+  is_privileged := COALESCE(current_user = 'service_role' OR jwt_role = 'service_role', false);
+
+  IF is_privileged THEN
+    RETURN NEW;
+  END IF;
+
+  IF TG_OP = 'UPDATE' THEN
+    -- Non-privileged caller may not change role at all. IS DISTINCT FROM is
+    -- NULL-safe and lets no-op updates (role unchanged) through.
+    IF NEW.role IS DISTINCT FROM OLD.role THEN
+      RAISE EXCEPTION
+        'permission denied: role may only be changed by service_role'
+        USING ERRCODE = 'insufficient_privilege';
+    END IF;
+  ELSIF TG_OP = 'INSERT' THEN
+    -- Non-privileged caller may only ever create a 'learner'. Silently coerce
+    -- anything else so ordinary signup (which never sets role) still succeeds
+    -- and a crafted escalating insert is downgraded rather than rejected.
+    IF NEW.role IS DISTINCT FROM 'learner' THEN
+      NEW.role := 'learner';
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_enforce_profile_role_write ON public.profiles;
+CREATE TRIGGER trg_enforce_profile_role_write
+  BEFORE INSERT OR UPDATE ON public.profiles
+  FOR EACH ROW
+  EXECUTE FUNCTION public.enforce_profile_role_write();
+
+-- Trigger functions run in trigger context (no EXECUTE needed), so this helper
+-- must never be callable via PostgREST RPC. Revoke the default PUBLIC grant.
+REVOKE EXECUTE ON FUNCTION public.enforce_profile_role_write() FROM PUBLIC, anon, authenticated;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -21,6 +21,11 @@ CREATE TABLE profiles (
   is_public BOOLEAN DEFAULT true,
   name_rerolls_used INTEGER DEFAULT 0,
   wallet_xp_synced_at TIMESTAMPTZ,
+  -- Coarse account role. Writable ONLY by service_role (enforced by the
+  -- enforce_profile_role_write() trigger below) to block self-escalation via
+  -- the self-service profiles RLS policies. See migration
+  -- 20260703130652_add_profiles_role_and_lock_role_writes.sql.
+  role TEXT NOT NULL DEFAULT 'learner',
   created_at TIMESTAMPTZ DEFAULT NOW()
 );
 
@@ -128,6 +133,8 @@ ALTER TABLE profiles
   ADD CONSTRAINT chk_profiles_name_rerolls_non_negative CHECK (name_rerolls_used >= 0);
 ALTER TABLE profiles
   ADD CONSTRAINT chk_profiles_name_rerolls_max CHECK (name_rerolls_used <= 3);
+ALTER TABLE profiles
+  ADD CONSTRAINT chk_profiles_role CHECK (role IN ('learner', 'teacher', 'admin'));
 
 ALTER TABLE user_xp
   ADD CONSTRAINT chk_user_xp_total_xp_non_negative CHECK (total_xp >= 0);
@@ -480,6 +487,57 @@ $$;
 CREATE OR REPLACE TRIGGER on_auth_user_created
   AFTER INSERT ON auth.users
   FOR EACH ROW EXECUTE FUNCTION handle_new_user();
+
+-- ─────────────────────────────────────────────
+-- 5a. LOCK profiles.role WRITES TO service_role
+-- ─────────────────────────────────────────────
+-- The self-service profiles RLS policies (auth.uid() = id for INSERT/UPDATE) do
+-- not constrain WHICH columns are written, so without this a user could escalate
+-- by writing role='teacher'/'admin' to their own row. This BEFORE trigger makes
+-- role writable only by service_role: non-privileged UPDATEs that change role
+-- error; non-privileged INSERTs are coerced back to 'learner'. SECURITY INVOKER
+-- so current_user reflects the actual caller. See migration
+-- 20260703130652_add_profiles_role_and_lock_role_writes.sql.
+CREATE OR REPLACE FUNCTION public.enforce_profile_role_write()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+DECLARE
+  jwt_role TEXT;
+  is_privileged BOOLEAN;
+BEGIN
+  jwt_role := NULLIF(current_setting('request.jwt.claims', true), '')::jsonb ->> 'role';
+  is_privileged := COALESCE(current_user = 'service_role' OR jwt_role = 'service_role', false);
+
+  IF is_privileged THEN
+    RETURN NEW;
+  END IF;
+
+  IF TG_OP = 'UPDATE' THEN
+    IF NEW.role IS DISTINCT FROM OLD.role THEN
+      RAISE EXCEPTION
+        'permission denied: role may only be changed by service_role'
+        USING ERRCODE = 'insufficient_privilege';
+    END IF;
+  ELSIF TG_OP = 'INSERT' THEN
+    IF NEW.role IS DISTINCT FROM 'learner' THEN
+      NEW.role := 'learner';
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_enforce_profile_role_write ON public.profiles;
+CREATE TRIGGER trg_enforce_profile_role_write
+  BEFORE INSERT OR UPDATE ON public.profiles
+  FOR EACH ROW
+  EXECUTE FUNCTION public.enforce_profile_role_write();
+
+REVOKE EXECUTE ON FUNCTION public.enforce_profile_role_write() FROM PUBLIC, anon, authenticated;
 
 -- ─────────────────────────────────────────────
 -- 5b. LEADERBOARD RPC


### PR DESCRIPTION
## Summary

Foundation for the **teacher-authored courses** epic (#263). Introduces the platform's own notion of course ownership, an authoring draft/review workflow, and a coarse `role` on `profiles` — none of which existed before (Sanity per-doc ACLs are Enterprise-only, so ownership + workflow live in the app).

This is a **data-model-only** change. No teacher UI, no admin approval UI (those are later issues in the epic, e.g. #264).

### What changed

**1. Sanity `course` schema** (`sanity/schemas/course.ts`)
- `author` (string) — Supabase user id of the owning teacher, distinct from the display `instructor` reference. Admin-only + `readOnly` in Studio (mirrors the `onChainStatus` visibility pattern).
- `authoringStatus` (string enum `draft` | `pending_review` | `approved`, `initialValue: "draft"`) — admin-visible but **not** readOnly, so an admin can approve via Studio as a fallback.

**2. Supabase migration** (`supabase/migrations/20260703130652_add_profiles_role_and_lock_role_writes.sql`) — also mirrored into `supabase/schema.sql`
- Adds `profiles.role TEXT NOT NULL DEFAULT 'learner'` + CHECK `role IN ('learner','teacher','admin')`. Existing rows backfill to `learner` via the default.
- **Role-write lockdown trigger** — see the security section below.

**3. Public GROQ catalog queries** (`apps/web/src/lib/sanity/queries.ts`)
- Added an authoring gate to every public/catalog query — see the catalog-safety section below.

**4. TypeScript types**
- `packages/types/src/course.ts` — optional `author?: string`, `authoringStatus?: AuthoringStatus` on `Course`; new `AuthoringStatus` union.
- `packages/types/src/user.ts` — optional `role?: UserRole` on `UserProfile`; new `UserRole` union.
- `packages/types/src/index.ts` — re-export `AuthoringStatus`, `UserRole`.
- `apps/web/src/lib/sanity/types.ts` — re-export `AuthoringStatus` (Course already carries the new fields via the package re-export).
- `apps/web/src/lib/supabase/types.ts` — `role` added to the `profiles` Row (required) + Insert/Update (optional), matching the generated-types style.

**5. Backfill script** (`sanity/seed/backfill-authoring-status.mjs`)
- Node ESM script (mirrors `import.mjs`) that patches every `*[_type == "course" && !defined(authoringStatus)]` to `authoringStatus = "approved"`. Reads the write token from `SANITY_API_WRITE_TOKEN` (never hardcoded). Prints the patched count. **Not run** — run manually post-deploy.

---

### (a) Role-write lockdown trigger — WHY

`profiles` has self-service RLS: `FOR INSERT WITH CHECK (auth.uid() = id)` and `FOR UPDATE USING (auth.uid() = id)`. Those policies only check the **row id**, not **which columns** are written. So without a guard, any authenticated user could escalate themselves by writing `role = 'teacher'` / `'admin'` to their own row via a direct PostgREST INSERT/UPDATE — RLS would allow it.

Fix: a `BEFORE INSERT OR UPDATE` trigger (`enforce_profile_role_write()`) makes `role` writable **only by service_role**:
- **UPDATE** by a non-privileged caller that changes `role` → `RAISE EXCEPTION`.
- **INSERT** by a non-privileged caller with `role != 'learner'` → silently coerced to `'learner'` (so ordinary signup, which never sets role, still succeeds; a crafted escalating insert is downgraded, not errored).

**service_role detection is belt-and-suspenders** — treated as privileged when `current_user = 'service_role'` **OR** the `request.jwt.claims` role is `service_role`. PostgREST runs browser requests under `authenticated`/`anon` with claims in `request.jwt.claims`; a direct service-role connection runs as `current_user = 'service_role'`. Either signal ⇒ privileged. `NULLIF(..., '')` + `COALESCE(..., false)` keep the check from erroring/NULL-ing when the claims GUC is unset or empty.

The function is **SECURITY INVOKER** (must observe the caller's role, not the definer's).

**Verified against the admin API (#264):** `createAdminClient()` uses `SUPABASE_SERVICE_ROLE_KEY`, whose JWT `role` claim is `service_role`. Through PostgREST this sets both `current_user = 'service_role'` and the claims role, so admin role writes are detected as privileged and pass through untouched. The lockdown only blocks the browser (`authenticated`/`anon`) path — exactly the escalation vector.

**Confirmed no client path writes `role`:** grepped every `.from("profiles").update/upsert/insert` across `apps/web/src` — writes touch only `avatar_url`, `username`, `name_rerolls_used`, `is_public`, `wallet_address`, `google_id`, `github_id`, `wallet_xp_synced_at`. Never `role`.

### (b) Lenient GROQ filter — WHY (avoid catalog wipe before backfill)

Existing Sanity course docs do **not** have `authoringStatus` yet. A bare `authoringStatus == "approved"` would hide **every current course** from production the moment this ships. So the gate is lenient and also admits legacy docs:

```
(authoringStatus == "approved" || !defined(authoringStatus))
```

Applied to all 12 public course queries that already gate on `onChainStatus.status == "synced"` (see below). Legacy (undefined) docs stay visible; once the backfill runs they carry an explicit `"approved"`. The catalog is safe **before and after** the backfill.

### (c) Migration + backfill NOT applied

Neither the migration nor the backfill script has been run against any database. Both are deploy-time steps:
1. Apply the migration to Supabase.
2. Run `SANITY_API_WRITE_TOKEN=<token> node sanity/seed/backfill-authoring-status.mjs` to normalize existing courses to `approved`.

---

### GROQ queries gated (12 public)

`getAllCourses`, `getCourseBySlug`, `getLessonBySlug`, `getChallengeAnswerKey`, `getChallengeAnswerKeyById`, `getAllLearningPaths` (nested courses), `getCourseIdBySlug`, `getCourseLessons`, `getCoursesByIds`, `getRecommendedCourses`, `getAllCourseTags`, `getAllCourseLessonCounts`.

### GROQ queries deliberately NOT gated

- `getAllCoursesAdmin` (`*[_type == "course"]`, admin sync table) — must see drafts.
- `getCourseById` (`*[_type == "course" && _id == $id]`, no `synced` gate) — server-only; called exclusively by `/api/certificates/mint`, `/api/lessons/complete`, `lib/solana/onchain-queue.ts`, and Helius resolvers/handlers to resolve course metadata by exact `_id` for on-chain operations. Not a public catalog path; must resolve regardless of authoring status.

### Verification

- `pnpm --filter @superteam-lms/web typecheck` → **pass** (0 errors). *(Note: an unrelated pre-existing gap — `quickjs-emscripten-core` / `@jitl/...` not installed — surfaced first; resolved with `pnpm install`. Not caused by this change.)*
- `pnpm --filter @superteam-lms/web lint` → **pass** (exit 0; only pre-existing `import/order` warnings in files this PR doesn't touch).
- `pnpm --filter @superteam-lms/web build` → **pass** (exit 0).

Closes #263
