### PR TITLE
feat(teacher-courses): data model — course ownership, authoring status, role

### DIFF
--- a/apps/web/src/lib/sanity/queries.ts
+++ b/apps/web/src/lib/sanity/queries.ts
@@ -57,7 +57,7 @@ const moduleWithLessonsFields = `
 
 export async function getAllCourses(): Promise<Course[]> {
   return sanityFetch<Course[]>(
-    `*[_type == "course" && onChainStatus.status == "synced"] | order(title asc) {
+    `*[_type == "course" && onChainStatus.status == "synced" && (authoringStatus == "approved" || !defined(authoringStatus))] | order(title asc) {
       ${courseFields},
       "modules": modules[]->{
         _id,
@@ -78,7 +78,7 @@ export async function getAllCourses(): Promise<Course[]> {
 
 export async function getCourseBySlug(slug: string): Promise<Course | null> {
   return sanityFetch<Course | null>(
-    `*[_type == "course" && slug.current == $slug && onChainStatus.status == "synced"][0] {
+    `*[_type == "course" && slug.current == $slug && onChainStatus.status == "synced" && (authoringStatus == "approved" || !defined(authoringStatus))][0] {
       ${courseFields},
       "modules": modules[]->{
         ${moduleWithLessonsFields}
@@ -98,7 +98,7 @@ export async function getLessonBySlug(
   // re-projects each to drop the `hidden` flag itself. Hidden-test/solution
   // checking lives server-side in /api/lessons/validate-challenge.
   return sanityFetch<Lesson | null>(
-    `*[_type == "course" && slug.current == $courseSlug && onChainStatus.status == "synced"][0] {
+    `*[_type == "course" && slug.current == $courseSlug && onChainStatus.status == "synced" && (authoringStatus == "approved" || !defined(authoringStatus))][0] {
       "allLessons": modules[]->lessons[]->{
         _id,
         title,
@@ -158,7 +158,7 @@ export async function getChallengeAnswerKey(
   // revalidate=0: always read fresh, never via the public Sanity CDN, so the
   // answer key is not cached on any edge.
   return sanityFetch<ChallengeAnswerKey | null>(
-    `*[_type == "course" && slug.current == $courseSlug && onChainStatus.status == "synced"][0] {
+    `*[_type == "course" && slug.current == $courseSlug && onChainStatus.status == "synced" && (authoringStatus == "approved" || !defined(authoringStatus))][0] {
       "allLessons": modules[]->lessons[]->${answerKeyProjection}
     }.allLessons[slug == $lessonSlug][0]`,
     { courseSlug, lessonSlug },
@@ -176,7 +176,7 @@ export async function getChallengeAnswerKeyById(
   lessonId: string
 ): Promise<ChallengeAnswerKey | null> {
   return sanityFetch<ChallengeAnswerKey | null>(
-    `*[_type == "course" && _id == $courseId && onChainStatus.status == "synced"][0] {
+    `*[_type == "course" && _id == $courseId && onChainStatus.status == "synced" && (authoringStatus == "approved" || !defined(authoringStatus))][0] {
       "allLessons": modules[]->lessons[]->${answerKeyProjection}
     }.allLessons[_id == $lessonId][0]`,
     { courseId, lessonId },
@@ -194,7 +194,7 @@ export async function getAllLearningPaths(): Promise<LearningPath[]> {
       tag,
       order,
       difficulty,
-      "courses": *[_type == "course" && _id in ^.courses[]._ref && onChainStatus.status == "synced"] {
+      "courses": *[_type == "course" && _id in ^.courses[]._ref && onChainStatus.status == "synced" && (authoringStatus == "approved" || !defined(authoringStatus))] {
         ${courseFields},
         "modules": modules[]->{
           _id,
@@ -239,7 +239,7 @@ export async function getCourseIdBySlug(
   slug: string
 ): Promise<{ _id: string; xpPerLesson: number } | null> {
   return sanityFetch<{ _id: string; xpPerLesson: number } | null>(
-    `*[_type == "course" && slug.current == $slug && onChainStatus.status == "synced"][0] {
+    `*[_type == "course" && slug.current == $slug && onChainStatus.status == "synced" && (authoringStatus == "approved" || !defined(authoringStatus))][0] {
       _id,
       "xpPerLesson": coalesce(xpPerLesson, 0)
     }`,
@@ -254,7 +254,7 @@ export async function getCourseLessons(
   courseSlug: string
 ): Promise<Pick<Lesson, "_id" | "title" | "slug" | "type">[]> {
   return sanityFetch<Pick<Lesson, "_id" | "title" | "slug" | "type">[]>(
-    `*[_type == "course" && slug.current == $courseSlug && onChainStatus.status == "synced"][0] {
+    `*[_type == "course" && slug.current == $courseSlug && onChainStatus.status == "synced" && (authoringStatus == "approved" || !defined(authoringStatus))][0] {
       "lessons": modules[]->lessons[]-> {
         _id,
         title,
@@ -286,7 +286,7 @@ export interface CourseSummary {
 export async function getCoursesByIds(ids: string[]): Promise<CourseSummary[]> {
   if (ids.length === 0) return [];
   return sanityFetch<CourseSummary[]>(
-    `*[_type == "course" && _id in $ids && onChainStatus.status == "synced"] {
+    `*[_type == "course" && _id in $ids && onChainStatus.status == "synced" && (authoringStatus == "approved" || !defined(authoringStatus))] {
       _id,
       title,
       "slug": slug.current,
@@ -347,7 +347,7 @@ export async function getRecommendedCourses(
   excludeIds: string[]
 ): Promise<RecommendedCourse[]> {
   return sanityFetch<RecommendedCourse[]>(
-    `*[_type == "course" && !(_id in $excludeIds) && onChainStatus.status == "synced"] | order(title asc) {
+    `*[_type == "course" && !(_id in $excludeIds) && onChainStatus.status == "synced" && (authoringStatus == "approved" || !defined(authoringStatus))] | order(title asc) {
       _id,
       title,
       "slug": slug.current,
@@ -377,7 +377,7 @@ export async function getAllCourseTags(): Promise<
   return sanityFetch<
     { _id: string; title: string; tags: string[]; totalLessons: number }[]
   >(
-    `*[_type == "course" && onChainStatus.status == "synced" && defined(tags)] {
+    `*[_type == "course" && onChainStatus.status == "synced" && (authoringStatus == "approved" || !defined(authoringStatus)) && defined(tags)] {
       _id,
       title,
       tags,
@@ -394,7 +394,7 @@ export async function getAllCourseLessonCounts(): Promise<
   { _id: string; totalLessons: number }[]
 > {
   return sanityFetch<{ _id: string; totalLessons: number }[]>(
-    `*[_type == "course" && onChainStatus.status == "synced"] {
+    `*[_type == "course" && onChainStatus.status == "synced" && (authoringStatus == "approved" || !defined(authoringStatus))] {
       _id,
       "totalLessons": count(modules[]->lessons[])
     }`

--- a/apps/web/src/lib/supabase/types.ts
+++ b/apps/web/src/lib/supabase/types.ts
@@ -404,6 +404,7 @@ export type Database = {
           id: string;
           is_public: boolean | null;
           name_rerolls_used: number | null;
+          role: string;
           social_links: Json | null;
           username: string;
           wallet_address: string | null;
@@ -418,6 +419,7 @@ export type Database = {
           id: string;
           is_public?: boolean | null;
           name_rerolls_used?: number | null;
+          role?: string;
           social_links?: Json | null;
           username: string;
           wallet_address?: string | null;
@@ -432,6 +434,7 @@ export type Database = {
           id?: string;
           is_public?: boolean | null;
           name_rerolls_used?: number | null;
+          role?: string;
           social_links?: Json | null;
           username?: string;
           wallet_address?: string | null;

--- a/sanity/schemas/course.ts
+++ b/sanity/schemas/course.ts
@@ -157,6 +157,32 @@ export const course = defineType({
         }),
       ],
     }),
+    defineField({
+      name: "author",
+      title: "Author (owner)",
+      type: "string",
+      readOnly: true,
+      hidden: ({ currentUser }) =>
+        !currentUser?.roles?.some((r) => r.name === "administrator"),
+      description:
+        "Supabase user id of the teacher who owns this course. Set by the app; do not edit manually.",
+    }),
+    defineField({
+      name: "authoringStatus",
+      title: "Authoring Status",
+      type: "string",
+      initialValue: "approved",
+      options: {
+        list: [
+          { title: "Draft", value: "draft" },
+          { title: "Pending review", value: "pending_review" },
+          { title: "Approved", value: "approved" },
+        ],
+        layout: "radio",
+      },
+      description:
+        "Authoring workflow state, separate from on-chain sync. Only 'approved' courses appear in the public catalog. Teacher-authored courses start as 'draft'; an admin approves them.",
+    }),
   ],
   preview: {
     select: {

--- a/supabase/migrations/20260703120000_add_profile_role.sql
+++ b/supabase/migrations/20260703120000_add_profile_role.sql
@@ -1,0 +1,39 @@
+-- Migration: add_profile_role
+-- Adds a role to profiles for teacher-authored courses (mediated authoring).
+--   learner (default) | teacher | admin
+-- Granted/revoked from the admin panel via an ADMIN_SECRET-gated route (which
+-- uses the service_role key); read server-side to gate /teach/* and the teacher
+-- course API.
+--
+-- SECURITY: the existing RLS UPDATE policy ("Users can update their own
+-- profile") is USING (auth.uid() = id) with NO column restriction, so an
+-- authenticated user could otherwise `UPDATE profiles SET role='admin'` on their
+-- own row. A BEFORE UPDATE trigger pins `role` to its previous value for any
+-- caller that is not the service_role, so only the admin API can change it.
+-- Attempts by users are silently ignored (no error, no escalation).
+
+ALTER TABLE profiles
+  ADD COLUMN IF NOT EXISTS role TEXT NOT NULL DEFAULT 'learner'
+  CHECK (role IN ('learner', 'teacher', 'admin'));
+
+CREATE OR REPLACE FUNCTION public.enforce_profile_role_immutable()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SET search_path = ''
+AS $$
+BEGIN
+  -- Only the service_role (admin API) may change `role`; keep the old value for
+  -- everyone else.
+  IF NEW.role IS DISTINCT FROM OLD.role
+     AND coalesce(auth.role(), '') <> 'service_role' THEN
+    NEW.role := OLD.role;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS enforce_profile_role_immutable ON profiles;
+CREATE TRIGGER enforce_profile_role_immutable
+  BEFORE UPDATE ON profiles
+  FOR EACH ROW
+  EXECUTE FUNCTION public.enforce_profile_role_immutable();

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -21,6 +21,9 @@ CREATE TABLE profiles (
   is_public BOOLEAN DEFAULT true,
   name_rerolls_used INTEGER DEFAULT 0,
   wallet_xp_synced_at TIMESTAMPTZ,
+  -- Platform role. Granted/revoked only by the admin API (service_role); pinned
+  -- against self-escalation by the enforce_profile_role_immutable trigger below.
+  role TEXT NOT NULL DEFAULT 'learner' CHECK (role IN ('learner', 'teacher', 'admin')),
   created_at TIMESTAMPTZ DEFAULT NOW()
 );
 
@@ -204,6 +207,29 @@ CREATE POLICY "Users can insert their own profile"
 
 CREATE POLICY "Users can update their own profile"
   ON profiles FOR UPDATE USING (auth.uid() = id);
+
+-- The UPDATE policy above has no column restriction, so pin `role` against
+-- self-escalation: only the service_role (admin API) may change it; any other
+-- caller's change is silently reverted to the old value.
+CREATE OR REPLACE FUNCTION public.enforce_profile_role_immutable()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SET search_path = ''
+AS $$
+BEGIN
+  IF NEW.role IS DISTINCT FROM OLD.role
+     AND coalesce(auth.role(), '') <> 'service_role' THEN
+    NEW.role := OLD.role;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS enforce_profile_role_immutable ON profiles;
+CREATE TRIGGER enforce_profile_role_immutable
+  BEFORE UPDATE ON profiles
+  FOR EACH ROW
+  EXECUTE FUNCTION public.enforce_profile_role_immutable();
 
 -- enrollments
 CREATE POLICY "Users can view their own enrollments"


### PR DESCRIPTION
## Summary

First PR of the **teacher-authored courses** epic (#269): the data foundation the API/UI/review issues build on. No user-facing behaviour changes yet.

## What & why

Teachers won't get Sanity logins (per-document access is Enterprise-only, and the Content Lake isn't self-hostable), so authoring is mediated through the app. That needs the platform's own notions of *who owns a course* and *is it still a draft*, plus a *user role* — none of which existed.

- **`course` schema** — add `author` (owning teacher's Supabase user id; distinct from the display `instructor`) and `authoringStatus` (`draft` | `pending_review` | `approved`), separate from the on-chain `onChainStatus`. Studio-authored (admin) courses default to `approved`.
- **`profiles.role`** — `learner` | `teacher` | `admin` (default `learner`), added via migration + `schema.sql` + generated types.
- **Catalog gate** — public course queries now require `authoringStatus == "approved" || !defined(authoringStatus)`. The `|| !defined` keeps existing courses visible with **no backfill needed**; and since drafts are never synced on-chain, this is defense-in-depth over the existing `onChainStatus == "synced"` gate.

## Security — role self-escalation guard

The profiles UPDATE policy is `USING (auth.uid() = id)` with **no column restriction**, so a user could otherwise `UPDATE profiles SET role='admin'` on their own row. Added a `enforce_profile_role_immutable` BEFORE UPDATE trigger that pins `role` for any caller that isn't the `service_role` — only the admin API (which uses the service_role key) can change it. Attempts by users are silently reverted (no error, no escalation).

## Verification

- `tsc` clean, eslint clean
- Sanity query tests pass, including the P0-C4 answer-leak test (the change is a filter clause; projections are untouched)
- Backward-compatible: existing courses (no `authoringStatus`) remain public

Closes #263 · part of #269
