### PR TITLE
feat(teacher): admin teacher-role grant + /teach access gate (#264)

### DIFF
--- a/apps/web/src/app/[locale]/(platform)/teach/layout.tsx
+++ b/apps/web/src/app/[locale]/(platform)/teach/layout.tsx
@@ -1,0 +1,50 @@
+import { redirect } from "next/navigation";
+import { locales, defaultLocale, type Locale } from "@/lib/i18n/config";
+import { createClient } from "@/lib/supabase/server";
+
+interface TeachLayoutProps {
+  children: React.ReactNode;
+  params: { locale: string };
+}
+
+/**
+ * Server-side access gate for the teacher authoring area (`/teach/*`).
+ *
+ * This layout — NOT client-side hiding — is the security boundary:
+ *   - Unauthenticated users are redirected to the landing page (the middleware
+ *     also fail-closes `/teach`, but we re-check here as defense in depth).
+ *   - Authenticated users whose `role` is not `teacher` or `admin` are
+ *     redirected to their dashboard.
+ * The role is read from the caller's OWN `profiles` row via the user-session
+ * client, which RLS permits (own-row SELECT). No role write happens here.
+ */
+export default async function TeachLayout({
+  children,
+  params: { locale },
+}: TeachLayoutProps) {
+  const activeLocale: Locale = locales.includes(locale as Locale)
+    ? (locale as Locale)
+    : defaultLocale;
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect(`/${activeLocale}`);
+  }
+
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("role")
+    .eq("id", user.id)
+    .maybeSingle();
+
+  const role = profile?.role;
+  if (role !== "teacher" && role !== "admin") {
+    redirect(`/${activeLocale}/dashboard`);
+  }
+
+  return <>{children}</>;
+}

--- a/apps/web/src/app/[locale]/(platform)/teach/page.tsx
+++ b/apps/web/src/app/[locale]/(platform)/teach/page.tsx
@@ -1,0 +1,26 @@
+import { getTranslations } from "next-intl/server";
+
+export default async function TeachPage() {
+  const t = await getTranslations("teacher.area");
+
+  return (
+    <section aria-labelledby="teach-heading" className="mx-auto max-w-3xl">
+      <h1
+        id="teach-heading"
+        className="font-display text-2xl font-bold text-[var(--text)]"
+      >
+        {t("title")}
+      </h1>
+      <p className="mt-2 text-sm text-[var(--text-3)]">{t("subtitle")}</p>
+
+      <div className="mt-8 rounded-lg border border-[var(--border)] bg-[var(--card)] p-6 shadow-card">
+        <h2 className="font-display text-lg font-bold text-[var(--text)]">
+          {t("comingSoonTitle")}
+        </h2>
+        <p className="mt-2 text-sm text-[var(--text-2)]">
+          {t("comingSoonBody")}
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/app/api/admin/teachers/route.ts
+++ b/apps/web/src/app/api/admin/teachers/route.ts
@@ -1,0 +1,101 @@
+import "server-only";
+
+import { NextRequest, NextResponse } from "next/server";
+import {
+  requireAdminAuth,
+  adminUnauthorizedResponse,
+  AdminAuthError,
+} from "@/lib/admin/auth";
+import { createAdminClient } from "@/lib/supabase/admin";
+
+// Only these two roles are grantable through this endpoint. `admin` is
+// deliberately excluded — it is NOT grantable here and must never be settable
+// by this route (see the strict action enum + explicit role map below).
+const ROLE_BY_ACTION = {
+  grant: "teacher",
+  revoke: "learner",
+} as const;
+
+type Action = keyof typeof ROLE_BY_ACTION;
+
+const MAX_USERNAME_LENGTH = 64;
+
+function isAction(value: unknown): value is Action {
+  return value === "grant" || value === "revoke";
+}
+
+/**
+ * POST /api/admin/teachers — grant or revoke the `teacher` role for a user,
+ * looked up by username. Admin-only (signed `admin_session` cookie).
+ *
+ * The role write goes through the service-role client (`createAdminClient`),
+ * which the `enforce_profile_role_write` DB trigger recognizes as privileged;
+ * a normal user-session client cannot mutate `role`. This endpoint can only
+ * ever set `teacher` (grant) or `learner` (revoke) — never `admin`.
+ */
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  try {
+    requireAdminAuth(req);
+  } catch (e) {
+    if (e instanceof AdminAuthError) return adminUnauthorizedResponse();
+    throw e;
+  }
+
+  let username: string;
+  let action: Action;
+  try {
+    const body = (await req.json()) as {
+      username?: unknown;
+      action?: unknown;
+    };
+
+    if (
+      typeof body.username !== "string" ||
+      body.username.trim().length === 0 ||
+      body.username.trim().length > MAX_USERNAME_LENGTH
+    ) {
+      return NextResponse.json(
+        { error: "username is required" },
+        { status: 400 }
+      );
+    }
+    if (!isAction(body.action)) {
+      return NextResponse.json(
+        { error: "action must be 'grant' or 'revoke'" },
+        { status: 400 }
+      );
+    }
+
+    username = body.username.trim();
+    action = body.action;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const role = ROLE_BY_ACTION[action];
+  const supabase = createAdminClient();
+
+  const { data: profile, error: lookupError } = await supabase
+    .from("profiles")
+    .select("id")
+    .eq("username", username)
+    .maybeSingle();
+
+  if (lookupError) {
+    return NextResponse.json({ error: "Lookup failed" }, { status: 500 });
+  }
+  if (!profile) {
+    return NextResponse.json({ error: "User not found" }, { status: 404 });
+  }
+
+  const { error: updateError } = await supabase
+    .from("profiles")
+    .update({ role })
+    .eq("id", profile.id);
+
+  if (updateError) {
+    return NextResponse.json({ error: "Update failed" }, { status: 500 });
+  }
+
+  return NextResponse.json({ username, role });
+}

--- a/apps/web/src/components/layout/header.tsx
+++ b/apps/web/src/components/layout/header.tsx
@@ -5,7 +5,13 @@ import Image from "next/image";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useTranslations, useLocale } from "next-intl";
-import { House, Book, Trophy, ChatCircle } from "@phosphor-icons/react";
+import {
+  House,
+  Book,
+  Trophy,
+  ChatCircle,
+  Chalkboard,
+} from "@phosphor-icons/react";
 import { cn } from "@/lib/utils";
 import { useAuth } from "@/lib/auth/auth-provider";
 import { ThemeToggle } from "@/components/layout/theme-toggle";
@@ -168,6 +174,12 @@ export function Header() {
   }, [fetchXp, animateXpTo]);
 
   const isLoggedIn = !!user && !!profile;
+  // Teacher authoring entry is UX-only; the real gate is the server-side
+  // /teach layout. Show it only to teacher/admin roles.
+  const canTeach = profile?.role === "teacher" || profile?.role === "admin";
+  const loggedInNavItems = canTeach
+    ? [...navItems, { key: "teach", icon: Chalkboard, href: "/teach" }]
+    : navItems;
   const { xpInCurrentLevel, xpRequiredForNext } = xpToNextLevel(displayedXp);
   const xpRemaining = xpRequiredForNext - xpInCurrentLevel;
 
@@ -215,7 +227,7 @@ export function Header() {
               className="nav-bar absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2"
               aria-label={tA11y("platformNavigation")}
             >
-              {navItems.map((item) => {
+              {loggedInNavItems.map((item) => {
                 const fullHref = `/${locale}${item.href}`;
                 const isActive = pathname.startsWith(fullHref);
                 const Icon = item.icon;

--- a/apps/web/src/lib/auth/auth-provider.tsx
+++ b/apps/web/src/lib/auth/auth-provider.tsx
@@ -13,10 +13,13 @@ import {
 import type { User } from "@supabase/supabase-js";
 import { createClient } from "@/lib/supabase/client";
 
+export type UserRole = "learner" | "teacher" | "admin";
+
 export interface UserProfile {
   username: string;
   avatar_url: string | null;
   wallet_address: string | null;
+  role: UserRole;
 }
 
 interface AuthContextValue {
@@ -29,7 +32,7 @@ interface AuthContextValue {
 
 const AuthContext = createContext<AuthContextValue | null>(null);
 
-const PROFILE_COLUMNS = "username, avatar_url, wallet_address";
+const PROFILE_COLUMNS = "username, avatar_url, wallet_address, role";
 
 // Single state object — ensures ONE render per state transition.
 // Three separate useState calls would cause three render cycles,

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -29,8 +29,17 @@
     "all": "All",
     "viewOnSolanaExplorer": "View on Solana Explorer: {address}"
   },
+  "teacher": {
+    "area": {
+      "title": "Teacher Area",
+      "subtitle": "Create and manage your courses.",
+      "comingSoonTitle": "Authoring coming soon",
+      "comingSoonBody": "Course authoring tools are on the way — you'll be able to draft courses, add lessons, and submit them for review right here."
+    }
+  },
   "nav": {
     "home": "Home",
+    "teach": "Teach",
     "courses": "Courses",
     "dashboard": "Dashboard",
     "leaderboard": "Leaderboard",

--- a/apps/web/src/messages/es.json
+++ b/apps/web/src/messages/es.json
@@ -29,8 +29,17 @@
     "all": "Todos",
     "viewOnSolanaExplorer": "Ver en Solana Explorer: {address}"
   },
+  "teacher": {
+    "area": {
+      "title": "Área del Profesor",
+      "subtitle": "Crea y gestiona tus cursos.",
+      "comingSoonTitle": "Creación próximamente",
+      "comingSoonBody": "Las herramientas de creación de cursos están en camino: podrás crear borradores de cursos, añadir lecciones y enviarlos para revisión aquí."
+    }
+  },
   "nav": {
     "home": "Inicio",
+    "teach": "Enseñar",
     "courses": "Cursos",
     "dashboard": "Panel",
     "leaderboard": "Clasificación",

--- a/apps/web/src/messages/pt-BR.json
+++ b/apps/web/src/messages/pt-BR.json
@@ -29,8 +29,17 @@
     "all": "Todos",
     "viewOnSolanaExplorer": "Ver no Solana Explorer: {address}"
   },
+  "teacher": {
+    "area": {
+      "title": "Área do Professor",
+      "subtitle": "Crie e gerencie seus cursos.",
+      "comingSoonTitle": "Criação em breve",
+      "comingSoonBody": "As ferramentas de criação de cursos estão a caminho — você poderá rascunhar cursos, adicionar lições e enviá-los para revisão aqui."
+    }
+  },
   "nav": {
     "home": "Início",
+    "teach": "Ensinar",
     "courses": "Cursos",
     "dashboard": "Painel",
     "leaderboard": "Ranking",

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -78,7 +78,7 @@ function isAdminRoute(pathname: string): boolean {
 function isProtectedRoute(pathname: string): boolean {
   // Only routes that require authentication (personal data)
   // Public routes (/courses, /leaderboard, /certificates/[id]) are NOT listed here
-  const protectedPaths = ["/dashboard", "/settings"];
+  const protectedPaths = ["/dashboard", "/settings", "/teach"];
 
   // Strip locale prefix to check the remaining path
   for (const locale of locales) {


### PR DESCRIPTION
## What

Teacher-role invitation + authoring-area access gate — the second unit of the teacher-authored-courses epic. Builds on #263 (merged; `profiles.role` + the `enforce_profile_role_write` trigger are live).

## Changes

- **`POST /api/admin/teachers`** — admin (ADMIN_SECRET / signed `admin_session` cookie) grants/revokes the `teacher` role by username. Role write goes through the **service-role** client (`createAdminClient`), which the #263 trigger recognizes as privileged; a normal user-session client cannot mutate `role`.
- **`/[locale]/(platform)/teach/` server-side guard** (`layout.tsx`) — reads the caller's **own** `profiles.role` via the user-session client (RLS-permitted own-row SELECT) and `redirect()`s anyone who isn't `teacher`/`admin`. Unauthenticated → landing. Plus `/teach` added to middleware `protectedPaths` (defense in depth). A minimal `page.tsx` placeholder stands in for the authoring UI (later issues).
- **Teacher-only "Teach" nav entry** — `role` is now exposed on `UserProfile` via `auth-provider` (`PROFILE_COLUMNS` includes it); the header shows a `Chalkboard` link only to `teacher`/`admin`. UX-only — the real gate is the server layout.
- **i18n** — `teacher.area.*` + `nav.teach` added to `en`, `pt-BR`, `es` (identical structure).

## Security invariants

- `/teach/*` is gated **server-side** (layout + middleware) — not reachable by disabling JS or hitting the route directly.
- The grant endpoint is **admin-only** and can set **only** `teacher` (grant) or `learner` (revoke) — **never `admin`** (strict action enum + explicit role map).
- Role writes go **only** through the service-role client; the #263 DB trigger blocks any user-session `role` write.
- Generic error messages; no secrets logged.

## Verified locally

- `tsc --noEmit` clean; ESLint clean (only pre-existing `import/order` warnings in untouched files).
- All 3 message files parse and carry `teacher.area.{title,subtitle,comingSoonTitle,comingSoonBody}` + `nav.teach`.

Closes #264. Part of the teacher-authored-courses epic (#269).
