### PR TITLE
feat(teacher-courses): teacher role invitation (/admin) + /teach access gate

### DIFF
--- a/apps/web/src/app/[locale]/(platform)/teach/layout.tsx
+++ b/apps/web/src/app/[locale]/(platform)/teach/layout.tsx
@@ -1,0 +1,29 @@
+import { redirect } from "next/navigation";
+import { getSessionUserAndRole, canAuthorCourses } from "@/lib/auth/roles";
+
+// The access gate reads the request's auth cookies, so this segment must render
+// per-request (never statically prerendered, which would evaluate the gate with
+// no user at build time).
+export const dynamic = "force-dynamic";
+
+/**
+ * Access gate for the teacher authoring area. Unauthenticated → landing;
+ * authenticated non-teachers (learners) → dashboard. Only teachers and admins
+ * may proceed. Enforced again in the teacher API routes (never trust the layout
+ * alone).
+ */
+export default async function TeachLayout({
+  children,
+  params,
+}: {
+  children: React.ReactNode;
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  const session = await getSessionUserAndRole();
+
+  if (!session) redirect(`/${locale}`);
+  if (!canAuthorCourses(session.role)) redirect(`/${locale}/dashboard`);
+
+  return <>{children}</>;
+}

--- a/apps/web/src/app/[locale]/(platform)/teach/page.tsx
+++ b/apps/web/src/app/[locale]/(platform)/teach/page.tsx
@@ -1,0 +1,20 @@
+import { getTranslations } from "next-intl/server";
+
+// Gated by the teacher-role check in layout.tsx (reads auth cookies) — render
+// per-request, never as static HTML.
+export const dynamic = "force-dynamic";
+
+export default async function TeachPage() {
+  const t = await getTranslations("teach");
+
+  return (
+    <div className="mx-auto max-w-4xl px-4 py-8">
+      <h1 className="text-2xl font-bold text-text">{t("title")}</h1>
+      <p className="mt-2 text-text-2">{t("subtitle")}</p>
+
+      <div className="mt-6 rounded-lg border border-border bg-card p-6 text-sm text-text-3 shadow-card">
+        {t("comingSoon")}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/[locale]/admin/admin-client.tsx
+++ b/apps/web/src/app/[locale]/admin/admin-client.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback } from "react";
 import { CourseSyncTable } from "@/components/admin/course-sync-table";
 import { AchievementSyncTable } from "@/components/admin/achievement-sync-table";
 import { DataResyncPanel } from "@/components/admin/data-resync-panel";
+import { TeacherRolesPanel } from "@/components/admin/teacher-roles-panel";
 
 interface DiffEntry {
   field: string;
@@ -185,6 +186,16 @@ export function AdminClient() {
         </h2>
         <div className="rounded-lg border border-border bg-card p-4 shadow-card">
           <DataResyncPanel />
+        </div>
+      </section>
+
+      {/* Teacher Roles */}
+      <section>
+        <h2 className="mb-4 font-display text-lg font-bold text-text">
+          Teacher Roles
+        </h2>
+        <div className="rounded-lg border border-border bg-card p-4 shadow-card">
+          <TeacherRolesPanel />
         </div>
       </section>
     </div>

--- a/apps/web/src/app/api/admin/teachers/route.ts
+++ b/apps/web/src/app/api/admin/teachers/route.ts
@@ -1,0 +1,106 @@
+import "server-only";
+
+import { NextRequest, NextResponse } from "next/server";
+import {
+  requireAdminAuth,
+  adminUnauthorizedResponse,
+  AdminAuthError,
+} from "@/lib/admin/auth";
+import { createAdminClient } from "@/lib/supabase/admin";
+
+/**
+ * Admin-only teacher role management (grant/revoke), from the admin panel.
+ * Authorized by the HMAC `admin_session` cookie (`requireAdminAuth`) — the same
+ * gate as the rest of `/api/admin/*`. Writes go through the service_role client,
+ * which is the only caller the `enforce_profile_role_write` trigger lets change
+ * `profiles.role`.
+ */
+
+function guard(req: NextRequest): NextResponse | null {
+  try {
+    requireAdminAuth(req);
+    return null;
+  } catch (e) {
+    if (e instanceof AdminAuthError) return adminUnauthorizedResponse();
+    throw e;
+  }
+}
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const denied = guard(req);
+  if (denied) return denied;
+
+  const admin = createAdminClient();
+  const { data, error } = await admin
+    .from("profiles")
+    .select("id, username, role")
+    .eq("role", "teacher")
+    .order("username");
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+  return NextResponse.json({ teachers: data ?? [] });
+}
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  const denied = guard(req);
+  if (denied) return denied;
+
+  let username: string;
+  let action: "grant" | "revoke";
+  try {
+    const body = (await req.json()) as { username?: unknown; action?: unknown };
+    if (typeof body.username !== "string" || !body.username.trim()) {
+      return NextResponse.json(
+        { error: "username is required" },
+        { status: 400 }
+      );
+    }
+    if (body.action !== "grant" && body.action !== "revoke") {
+      return NextResponse.json(
+        { error: "action must be 'grant' or 'revoke'" },
+        { status: 400 }
+      );
+    }
+    username = body.username.trim();
+    action = body.action;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const admin = createAdminClient();
+  const { data: target, error: findErr } = await admin
+    .from("profiles")
+    .select("id, username, role")
+    .eq("username", username)
+    .maybeSingle();
+
+  if (findErr) {
+    return NextResponse.json({ error: findErr.message }, { status: 500 });
+  }
+  if (!target) {
+    return NextResponse.json(
+      { error: `No user found with username "${username}"` },
+      { status: 404 }
+    );
+  }
+  // This endpoint only toggles teacher/learner; it must never touch admins.
+  if (target.role === "admin") {
+    return NextResponse.json(
+      { error: "Refusing to change an admin account's role" },
+      { status: 409 }
+    );
+  }
+
+  const newRole = action === "grant" ? "teacher" : "learner";
+  const { error: updErr } = await admin
+    .from("profiles")
+    .update({ role: newRole })
+    .eq("id", target.id);
+
+  if (updErr) {
+    return NextResponse.json({ error: updErr.message }, { status: 500 });
+  }
+  return NextResponse.json({ username: target.username, role: newRole });
+}

--- a/apps/web/src/components/admin/teacher-roles-panel.tsx
+++ b/apps/web/src/components/admin/teacher-roles-panel.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+
+interface TeacherRow {
+  id: string;
+  username: string;
+  role: string;
+}
+
+export function TeacherRolesPanel() {
+  const [username, setUsername] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+  const [teachers, setTeachers] = useState<TeacherRow[]>([]);
+
+  const loadTeachers = useCallback(async () => {
+    try {
+      const res = await fetch("/api/admin/teachers");
+      if (!res.ok) return;
+      const body = (await res.json()) as { teachers?: TeacherRow[] };
+      setTeachers(body.teachers ?? []);
+    } catch {
+      // Non-critical: the list is a convenience view.
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadTeachers();
+  }, [loadTeachers]);
+
+  async function submit(action: "grant" | "revoke") {
+    const trimmed = username.trim();
+    if (!trimmed) return;
+
+    setLoading(true);
+    setError(null);
+    setNotice(null);
+
+    try {
+      const res = await fetch("/api/admin/teachers", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ username: trimmed, action }),
+      });
+      const body = (await res.json().catch(() => ({}))) as {
+        error?: string;
+        username?: string;
+        role?: string;
+      };
+      if (!res.ok) {
+        setError(body.error ?? `Request failed (${res.status})`);
+        return;
+      }
+      setNotice(
+        action === "grant"
+          ? `Granted teacher to @${body.username}`
+          : `Revoked teacher from @${body.username}`
+      );
+      setUsername("");
+      await loadTeachers();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Network error");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-text-3">
+        Grant or revoke the <span className="font-medium">teacher</span> role by
+        username. Teachers can author their own courses under{" "}
+        <span className="font-mono">/teach</span>; publishing on-chain still
+        requires admin review. Admin accounts cannot be changed here.
+      </p>
+
+      <div className="flex flex-wrap items-center gap-2">
+        <input
+          type="text"
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+          placeholder="username"
+          className="min-w-48 flex-1 rounded-md border border-border bg-[var(--input)] px-3 py-2 text-sm text-text"
+          aria-label="Username"
+        />
+        <button
+          type="button"
+          onClick={() => submit("grant")}
+          disabled={loading || !username.trim()}
+          className="rounded-md border border-success bg-success-light px-3 py-2 text-sm font-medium text-success disabled:opacity-50"
+        >
+          Grant teacher
+        </button>
+        <button
+          type="button"
+          onClick={() => submit("revoke")}
+          disabled={loading || !username.trim()}
+          className="rounded-md border border-border px-3 py-2 text-sm font-medium text-text disabled:opacity-50"
+        >
+          Revoke
+        </button>
+      </div>
+
+      {error && (
+        <div className="rounded-md border border-danger bg-danger-light p-3 text-sm text-danger">
+          {error}
+        </div>
+      )}
+      {notice && (
+        <div className="rounded-md border border-success bg-success-light p-3 text-sm text-success">
+          {notice}
+        </div>
+      )}
+
+      <div>
+        <h4 className="mb-2 text-xs font-semibold uppercase text-text-3">
+          Current teachers ({teachers.length})
+        </h4>
+        {teachers.length === 0 ? (
+          <p className="text-sm text-text-3">No teachers yet.</p>
+        ) : (
+          <ul className="space-y-1">
+            {teachers.map((t) => (
+              <li
+                key={t.id}
+                className="flex items-center justify-between rounded-md border border-border bg-card px-3 py-2 text-sm"
+              >
+                <span className="font-mono text-text">@{t.username}</span>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setUsername(t.username);
+                    void submit("revoke");
+                  }}
+                  disabled={loading}
+                  className="text-xs text-danger underline hover:no-underline disabled:opacity-50"
+                >
+                  Revoke
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/layout/header.tsx
+++ b/apps/web/src/components/layout/header.tsx
@@ -5,7 +5,13 @@ import Image from "next/image";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useTranslations, useLocale } from "next-intl";
-import { House, Book, Trophy, ChatCircle } from "@phosphor-icons/react";
+import {
+  House,
+  Book,
+  Trophy,
+  ChatCircle,
+  Chalkboard,
+} from "@phosphor-icons/react";
 import { cn } from "@/lib/utils";
 import { useAuth } from "@/lib/auth/auth-provider";
 import { ThemeToggle } from "@/components/layout/theme-toggle";
@@ -31,12 +37,19 @@ const publicNavItems = [
   { key: "leaderboard", icon: Trophy, href: "/leaderboard" },
 ] as const;
 
+// Shown only to teachers/admins (course authors).
+const teachNavItem = { key: "teach", icon: Chalkboard, href: "/teach" } as const;
+
 export function Header() {
   const t = useTranslations("nav");
   const tA11y = useTranslations("a11y");
   const locale = useLocale();
   const pathname = usePathname();
   const { user, profile, isLoading: authLoading } = useAuth();
+
+  // Teachers/admins get an extra "Teach" nav entry into the authoring area.
+  const canAuthor = profile?.role === "teacher" || profile?.role === "admin";
+  const authedNavItems = canAuthor ? [...navItems, teachNavItem] : navItems;
 
   // XP state
   const [displayedXp, setDisplayedXp] = useState(0);
@@ -215,7 +228,7 @@ export function Header() {
               className="nav-bar absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2"
               aria-label={tA11y("platformNavigation")}
             >
-              {navItems.map((item) => {
+              {authedNavItems.map((item) => {
                 const fullHref = `/${locale}${item.href}`;
                 const isActive = pathname.startsWith(fullHref);
                 const Icon = item.icon;

--- a/apps/web/src/lib/auth/auth-provider.tsx
+++ b/apps/web/src/lib/auth/auth-provider.tsx
@@ -17,6 +17,7 @@ export interface UserProfile {
   username: string;
   avatar_url: string | null;
   wallet_address: string | null;
+  role: string | null;
 }
 
 interface AuthContextValue {
@@ -29,7 +30,7 @@ interface AuthContextValue {
 
 const AuthContext = createContext<AuthContextValue | null>(null);
 
-const PROFILE_COLUMNS = "username, avatar_url, wallet_address";
+const PROFILE_COLUMNS = "username, avatar_url, wallet_address, role";
 
 // Single state object — ensures ONE render per state transition.
 // Three separate useState calls would cause three render cycles,

--- a/apps/web/src/lib/auth/roles.ts
+++ b/apps/web/src/lib/auth/roles.ts
@@ -1,0 +1,42 @@
+import "server-only";
+import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+
+export type UserRole = "learner" | "teacher" | "admin";
+
+/** Teachers and admins may author courses; learners may not. */
+export function canAuthorCourses(role: UserRole): boolean {
+  return role === "teacher" || role === "admin";
+}
+
+/**
+ * Read a user's platform role. Uses the service_role client so it works
+ * regardless of RLS; defaults to `learner` when the row/column is absent.
+ * SERVER-ONLY.
+ */
+export async function getUserRole(userId: string): Promise<UserRole> {
+  const admin = createAdminClient();
+  const { data } = await admin
+    .from("profiles")
+    .select("role")
+    .eq("id", userId)
+    .single();
+  const role = data?.role;
+  return role === "teacher" || role === "admin" ? role : "learner";
+}
+
+/**
+ * The authenticated user id + role for the current request, or `null` when the
+ * request is unauthenticated. Used to gate the teacher authoring area.
+ */
+export async function getSessionUserAndRole(): Promise<{
+  userId: string;
+  role: UserRole;
+} | null> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return null;
+  return { userId: user.id, role: await getUserRole(user.id) };
+}

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -35,12 +35,18 @@
     "dashboard": "Dashboard",
     "leaderboard": "Leaderboard",
     "community": "Community",
+    "teach": "Teach",
     "profile": "Profile",
     "settings": "Settings",
     "certificates": "Certificates",
     "lowSolBalance": "Low SOL balance.",
     "getDevnetSol": "Get devnet SOL ->",
     "dismissBanner": "Dismiss"
+  },
+  "teach": {
+    "title": "Teach",
+    "subtitle": "Create and manage your own courses.",
+    "comingSoon": "Course authoring is coming soon. You'll be able to draft courses here and submit them for review."
   },
   "auth": {
     "authFailed": "Wallet authentication failed. Please try again or use a different sign-in method.",

--- a/apps/web/src/messages/es.json
+++ b/apps/web/src/messages/es.json
@@ -35,12 +35,18 @@
     "dashboard": "Panel",
     "leaderboard": "Clasificación",
     "community": "Comunidad",
+    "teach": "Enseñar",
     "profile": "Perfil",
     "settings": "Configuración",
     "certificates": "Certificados",
     "lowSolBalance": "Saldo SOL bajo.",
     "getDevnetSol": "Obtener SOL devnet ->",
     "dismissBanner": "Cerrar"
+  },
+  "teach": {
+    "title": "Enseñar",
+    "subtitle": "Crea y gestiona tus propios cursos.",
+    "comingSoon": "La creación de cursos llegará pronto. Podrás crear borradores de cursos aquí y enviarlos para revisión."
   },
   "auth": {
     "authFailed": "La autenticación de la billetera falló. Inténtalo de nuevo o usa otro método de inicio de sesión.",

--- a/apps/web/src/messages/pt-BR.json
+++ b/apps/web/src/messages/pt-BR.json
@@ -35,12 +35,18 @@
     "dashboard": "Painel",
     "leaderboard": "Ranking",
     "community": "Comunidade",
+    "teach": "Ensinar",
     "profile": "Perfil",
     "settings": "Configurações",
     "certificates": "Certificados",
     "lowSolBalance": "Saldo SOL baixo.",
     "getDevnetSol": "Obter SOL devnet ->",
     "dismissBanner": "Fechar"
+  },
+  "teach": {
+    "title": "Ensinar",
+    "subtitle": "Crie e gerencie seus próprios cursos.",
+    "comingSoon": "A criação de cursos chegará em breve. Você poderá rascunhar cursos aqui e enviá-los para revisão."
   },
   "auth": {
     "authFailed": "A autenticação da carteira falhou. Tente novamente ou use outro método de login.",

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -78,7 +78,9 @@ function isAdminRoute(pathname: string): boolean {
 function isProtectedRoute(pathname: string): boolean {
   // Only routes that require authentication (personal data)
   // Public routes (/courses, /leaderboard, /certificates/[id]) are NOT listed here
-  const protectedPaths = ["/dashboard", "/settings"];
+  // /teach also enforces a teacher-role check in its layout; middleware just
+  // ensures the visitor is authenticated (redirect to landing otherwise).
+  const protectedPaths = ["/dashboard", "/settings", "/teach"];
 
   // Strip locale prefix to check the remaining path
   for (const locale of locales) {


### PR DESCRIPTION
## Summary

Second PR of the **teacher-authored courses** epic (#269), building on the merged #263 data model. Admins grant/revoke the teacher role from the existing **/admin** panel; teachers get gated access to the `/teach` authoring area.

## What & why

Teachers author through the app (not Sanity), so we need an admin-controlled way to promote a user and a real access boundary.

- **`/api/admin/teachers`** — `GET` (list teachers), `POST` (grant/revoke by username). Behind the same `admin_session`/`ADMIN_SECRET` gate as the rest of `/api/admin/*`. Writes use the `service_role` client — the only caller the #263 `enforce_profile_role_write` trigger permits to change `profiles.role`. Refuses to modify admin accounts.
- **Admin panel** — a "Teacher Roles" section (`TeacherRolesPanel`) to grant/revoke and view current teachers, wired into `admin-client.tsx`.
- **`lib/auth/roles.ts`** — `getUserRole` / `getSessionUserAndRole` / `canAuthorCourses` (server-only). The shared role helpers the teacher course API (#265) will reuse.
- **`/teach` gate** — a layout that redirects unauthenticated → landing, learners → dashboard, and admits teachers/admins; `force-dynamic` so it evaluates per request. Plus a minimal landing page. `/teach` also added to the middleware protected paths (auth at the edge; role check in the layout).
- **Entry point** — `auth-provider` now selects `role`; the header shows a "Teach" nav item to teachers/admins. i18n keys added to en/pt-BR/es.

## Security

- `role` is only ever changed via the admin API (service_role); the #263 trigger blocks any other caller, so this can't be self-granted.
- The `/teach` gate is enforced server-side (layout + middleware); the nav item is cosmetic. The teacher **write** API (#265) re-checks the role — never trusts the UI.
- The grant endpoint won't touch `admin` accounts.

## Verification

- `tsc` clean, eslint clean
- `next build` passes; `/teach` renders per-request (same `●`+dynamic pattern as `/dashboard`, `/settings`); `/api/admin/teachers` present
- i18n key parity across en/pt-BR/es confirmed

Closes #264 · part of #269
