### PR TITLE
feat(teacher): server API for teacher-scoped course CRUD (#265)

### DIFF
--- a/apps/web/src/app/api/teacher/courses/[id]/route.ts
+++ b/apps/web/src/app/api/teacher/courses/[id]/route.ts
@@ -1,0 +1,95 @@
+import "server-only";
+
+import { NextRequest, NextResponse } from "next/server";
+import { authorizeTeacher } from "@/lib/teacher/authorize";
+import { validateTeacherCourseInput } from "@/lib/teacher/validate";
+import {
+  getCourseAuthorship,
+  patchTeacherCourse,
+} from "@/lib/sanity/teacher-mutations";
+
+export const dynamic = "force-dynamic";
+
+const MAX_COURSE_ID_LEN = 256;
+
+/**
+ * PATCH /api/teacher/courses/[id] — update a course the caller owns.
+ *
+ * Authorization (all server-side):
+ *   1. Authenticated + role in (teacher, admin) — else 401/403.
+ *   2. Load the course's `author` from Sanity via the server-only admin client.
+ *      If `author !== caller` AND caller is not an admin → 403. This is the
+ *      cross-author write guard.
+ *
+ * The body is validated against the field whitelist. `author`, `onChainStatus`,
+ * `_id`, `_type`, `_rev`, and `authoringStatus: "approved"` are all
+ * unreachable — they are never read from the body. A teacher therefore cannot
+ * reassign ownership, touch on-chain state, or self-publish.
+ */
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<NextResponse> {
+  const auth = await authorizeTeacher();
+  if (!auth.ok) {
+    return NextResponse.json(
+      { error: auth.status === 401 ? "Unauthorized" : "Forbidden" },
+      { status: auth.status }
+    );
+  }
+
+  const { id: courseId } = await params;
+  if (
+    typeof courseId !== "string" ||
+    courseId.length === 0 ||
+    courseId.length > MAX_COURSE_ID_LEN
+  ) {
+    return NextResponse.json({ error: "Invalid course id" }, { status: 400 });
+  }
+
+  let raw: unknown;
+  try {
+    raw = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const validated = validateTeacherCourseInput(raw, "patch");
+  if (!validated.ok) {
+    return NextResponse.json(
+      { error: `Invalid ${validated.error.field}: ${validated.error.message}` },
+      { status: 400 }
+    );
+  }
+
+  // --- Ownership check (the security core) ---
+  let course;
+  try {
+    course = await getCourseAuthorship(courseId);
+  } catch {
+    return NextResponse.json(
+      { error: "Failed to load course" },
+      { status: 500 }
+    );
+  }
+  if (!course) {
+    return NextResponse.json({ error: "Course not found" }, { status: 404 });
+  }
+
+  const isOwner = course.author === auth.caller.userId;
+  const isAdmin = auth.caller.role === "admin";
+  if (!isOwner && !isAdmin) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  try {
+    await patchTeacherCourse(courseId, validated.value);
+  } catch {
+    return NextResponse.json(
+      { error: "Failed to update course" },
+      { status: 500 }
+    );
+  }
+
+  return NextResponse.json({ _id: courseId, updated: true });
+}

--- a/apps/web/src/app/api/teacher/courses/route.ts
+++ b/apps/web/src/app/api/teacher/courses/route.ts
@@ -1,0 +1,104 @@
+import "server-only";
+
+import { NextRequest, NextResponse } from "next/server";
+import { authorizeTeacher } from "@/lib/teacher/authorize";
+import { validateTeacherCourseInput } from "@/lib/teacher/validate";
+import { slugifyCourseTitle } from "@/lib/teacher/slug";
+import {
+  createTeacherCourse,
+  listAllCourses,
+  listTeacherCourses,
+} from "@/lib/sanity/teacher-mutations";
+
+// Reads the caller's session + own profile row and writes to Sanity — never
+// statically prerender (DYNAMIC_SERVER_USAGE).
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/teacher/courses — list the caller's own courses.
+ *
+ * Auth: authenticated + role in (teacher, admin). Teachers see only courses
+ * where `author == their user id`; admins may list every course (`?all=1`,
+ * default when admin).
+ */
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const auth = await authorizeTeacher();
+  if (!auth.ok) {
+    return NextResponse.json(
+      { error: auth.status === 401 ? "Unauthorized" : "Forbidden" },
+      { status: auth.status }
+    );
+  }
+
+  try {
+    const { userId, role } = auth.caller;
+    // Only admins may see the full catalog; teachers are always scoped to self,
+    // regardless of any query param.
+    const wantsAll =
+      role === "admin" && req.nextUrl.searchParams.get("all") !== "0";
+
+    const courses = wantsAll
+      ? await listAllCourses()
+      : await listTeacherCourses(userId);
+
+    return NextResponse.json({ courses });
+  } catch {
+    return NextResponse.json(
+      { error: "Failed to list courses" },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * POST /api/teacher/courses — create a new DRAFT course.
+ *
+ * The server sets `author = <caller user id>` and forces
+ * `authoringStatus = "draft"`. Body is validated against the whitelist; only
+ * `title` is required (used to generate the slug). Any `author` /
+ * `authoringStatus` / on-chain field in the body is ignored — it is never read.
+ */
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  const auth = await authorizeTeacher();
+  if (!auth.ok) {
+    return NextResponse.json(
+      { error: auth.status === 401 ? "Unauthorized" : "Forbidden" },
+      { status: auth.status }
+    );
+  }
+
+  let raw: unknown;
+  try {
+    raw = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const validated = validateTeacherCourseInput(raw, "create");
+  if (!validated.ok) {
+    return NextResponse.json(
+      { error: `Invalid ${validated.error.field}: ${validated.error.message}` },
+      { status: 400 }
+    );
+  }
+
+  // `title` is guaranteed present in "create" mode by the validator.
+  const slug = slugifyCourseTitle(validated.value.title!);
+
+  try {
+    const created = await createTeacherCourse(
+      auth.caller.userId,
+      slug,
+      validated.value
+    );
+    return NextResponse.json(
+      { _id: created._id, slug, authoringStatus: "draft" },
+      { status: 201 }
+    );
+  } catch {
+    return NextResponse.json(
+      { error: "Failed to create course" },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/web/src/lib/sanity/teacher-mutations.ts
+++ b/apps/web/src/lib/sanity/teacher-mutations.ts
@@ -1,0 +1,232 @@
+import "server-only";
+import { createClient } from "next-sanity";
+import { env } from "@/lib/env";
+import { serverEnv } from "@/lib/env.server";
+
+/**
+ * SECURITY — teacher-scoped, server-only Sanity writes (issue #265).
+ *
+ * This module is the ONLY place (besides the admin-only `admin-mutations.ts`)
+ * where the privileged `SANITY_ADMIN_TOKEN` is used. It is `server-only`, so it
+ * can never be imported into a client component / the browser bundle. The
+ * calling route (`/api/teacher/courses`) is responsible for authenticating the
+ * caller and authorizing ownership BEFORE invoking anything here; this module
+ * assumes those checks have already passed and focuses on constructing safe,
+ * field-limited mutations.
+ *
+ * Two hard invariants enforced structurally (not just by convention):
+ *   1. Callers never hand us a free-form patch object — they pass a typed
+ *      `TeacherCourseInput`, and we copy an explicit allowlist field by field.
+ *      A crafted request body therefore cannot smuggle in `author`,
+ *      `onChainStatus`, `_id`, `_type`, `_rev`, or any other privileged field.
+ *   2. `author` is set exactly once, at create time, from the server-derived
+ *      Supabase user id — never from client input — and is never included in
+ *      the PATCH allowlist, so it is immutable post-create through this API.
+ */
+const sanityAdmin = createClient({
+  projectId: env.NEXT_PUBLIC_SANITY_PROJECT_ID,
+  dataset: env.NEXT_PUBLIC_SANITY_DATASET,
+  token: serverEnv.SANITY_ADMIN_TOKEN,
+  useCdn: false,
+  apiVersion: "2024-01-01",
+});
+
+/** Difficulty enum mirrored from the course schema. */
+export const COURSE_DIFFICULTIES = [
+  "beginner",
+  "intermediate",
+  "advanced",
+] as const;
+export type CourseDifficulty = (typeof COURSE_DIFFICULTIES)[number];
+
+/**
+ * Authoring-status values a TEACHER may set through this API.
+ *
+ * `approved` is deliberately absent — publishing a course is an admin-only
+ * action (issue #268) and must never be reachable from a teacher-supplied body.
+ */
+export const TEACHER_SETTABLE_AUTHORING_STATUSES = [
+  "draft",
+  "pending_review",
+] as const;
+export type TeacherSettableAuthoringStatus =
+  (typeof TEACHER_SETTABLE_AUTHORING_STATUSES)[number];
+
+/**
+ * The complete set of course fields a teacher is permitted to write, and their
+ * validated shapes. This is the whitelist — anything NOT in this interface can
+ * never be written through the teacher API. All fields are optional on PATCH;
+ * only those present are copied through.
+ *
+ * Reference/image fields (`thumbnail`, `prerequisiteCourse`) are modeled as the
+ * exact Sanity shapes we accept, so a malformed reference is rejected before it
+ * reaches Sanity rather than corrupting the document.
+ */
+export interface TeacherCourseInput {
+  title?: string;
+  description?: string;
+  difficulty?: CourseDifficulty;
+  duration?: number;
+  /** Sanity image reference to an already-uploaded asset. */
+  thumbnail?: { assetRef: string };
+  tags?: string[];
+  xpReward?: number;
+  xpPerLesson?: number;
+  /** Sanity document _id of another course to require as a prerequisite. */
+  prerequisiteCourse?: { ref: string };
+  authoringStatus?: TeacherSettableAuthoringStatus;
+}
+
+/** Minimal shape returned to the caller for ownership + status checks. */
+export interface TeacherCourseSummary {
+  _id: string;
+  title: string | null;
+  slug: string | null;
+  difficulty: string | null;
+  author: string | null;
+  authoringStatus: string | null;
+  onChainStatus: string | null;
+}
+
+/**
+ * Translate a validated `TeacherCourseInput` into a plain Sanity patch object,
+ * copying ONLY the allowlisted fields that are actually present. Reference and
+ * image fields are expanded into their canonical Sanity shapes here.
+ *
+ * This function is intentionally exhaustive and explicit: adding a new writable
+ * field requires editing both `TeacherCourseInput` and this mapper, which keeps
+ * the security-relevant surface visible in one place.
+ */
+function toSanityPatch(input: TeacherCourseInput): Record<string, unknown> {
+  const patch: Record<string, unknown> = {};
+
+  if (input.title !== undefined) patch.title = input.title;
+  if (input.description !== undefined) patch.description = input.description;
+  if (input.difficulty !== undefined) patch.difficulty = input.difficulty;
+  if (input.duration !== undefined) patch.duration = input.duration;
+  if (input.tags !== undefined) patch.tags = input.tags;
+  if (input.xpReward !== undefined) patch.xpReward = input.xpReward;
+  if (input.xpPerLesson !== undefined) patch.xpPerLesson = input.xpPerLesson;
+  if (input.authoringStatus !== undefined) {
+    patch.authoringStatus = input.authoringStatus;
+  }
+  if (input.thumbnail !== undefined) {
+    patch.thumbnail = {
+      _type: "image",
+      asset: { _type: "reference", _ref: input.thumbnail.assetRef },
+    };
+  }
+  if (input.prerequisiteCourse !== undefined) {
+    patch.prerequisiteCourse = {
+      _type: "reference",
+      _ref: input.prerequisiteCourse.ref,
+    };
+  }
+
+  return patch;
+}
+
+/**
+ * List the courses owned by a single teacher (`author == authorId`), newest
+ * first. Uses the server-only admin client so drafts (which the public gate
+ * hides) are visible to their owner.
+ */
+export async function listTeacherCourses(
+  authorId: string
+): Promise<TeacherCourseSummary[]> {
+  return sanityAdmin.fetch<TeacherCourseSummary[]>(
+    `*[_type == "course" && !(_id in path("drafts.**")) && author == $authorId]
+      | order(_createdAt desc) {
+        _id,
+        title,
+        "slug": slug.current,
+        difficulty,
+        author,
+        authoringStatus,
+        "onChainStatus": onChainStatus.status
+      }`,
+    { authorId }
+  );
+}
+
+/**
+ * List ALL courses (admin-only view). Same projection as {@link listTeacherCourses}.
+ */
+export async function listAllCourses(): Promise<TeacherCourseSummary[]> {
+  return sanityAdmin.fetch<TeacherCourseSummary[]>(
+    `*[_type == "course" && !(_id in path("drafts.**"))]
+      | order(_createdAt desc) {
+        _id,
+        title,
+        "slug": slug.current,
+        difficulty,
+        author,
+        authoringStatus,
+        "onChainStatus": onChainStatus.status
+      }`
+  );
+}
+
+/**
+ * Fetch a single course's ownership-relevant fields for the authorization check
+ * performed before a PATCH. Returns null if the course does not exist.
+ */
+export async function getCourseAuthorship(
+  courseId: string
+): Promise<TeacherCourseSummary | null> {
+  return sanityAdmin.fetch<TeacherCourseSummary | null>(
+    `*[_type == "course" && _id == $courseId][0] {
+      _id,
+      title,
+      "slug": slug.current,
+      difficulty,
+      author,
+      authoringStatus,
+      "onChainStatus": onChainStatus.status
+    }`,
+    { courseId }
+  );
+}
+
+/**
+ * Create a new draft course. The server sets `author` (from the authenticated
+ * user id — NEVER from client input) and forces `authoringStatus = "draft"`.
+ * Any whitelisted fields in `input` are applied on top; `authoringStatus` in
+ * `input` is ignored here because creation is always a draft.
+ *
+ * @returns the created document `_id`.
+ */
+export async function createTeacherCourse(
+  authorId: string,
+  slug: string,
+  input: TeacherCourseInput
+): Promise<{ _id: string }> {
+  const patch = toSanityPatch(input);
+  // Creation is always a draft regardless of any client-supplied status.
+  delete patch.authoringStatus;
+
+  const created = await sanityAdmin.create({
+    _type: "course",
+    ...patch,
+    slug: { _type: "slug", current: slug },
+    author: authorId,
+    authoringStatus: "draft",
+  });
+
+  return { _id: created._id };
+}
+
+/**
+ * Apply a whitelisted patch to an existing course. Authorization (ownership /
+ * admin) MUST already have been checked by the caller. `author`, `_id`,
+ * `_type`, `_rev`, `onChainStatus`, and every other non-allowlisted field are
+ * structurally excluded because `toSanityPatch` copies only known fields.
+ */
+export async function patchTeacherCourse(
+  courseId: string,
+  input: TeacherCourseInput
+): Promise<void> {
+  const patch = toSanityPatch(input);
+  if (Object.keys(patch).length === 0) return;
+  await sanityAdmin.patch(courseId).set(patch).commit();
+}

--- a/apps/web/src/lib/teacher/authorize.ts
+++ b/apps/web/src/lib/teacher/authorize.ts
@@ -1,0 +1,50 @@
+import "server-only";
+import { createClient } from "@/lib/supabase/server";
+
+/** Roles permitted to use the teacher authoring API. */
+export type TeacherRole = "teacher" | "admin";
+
+export interface AuthorizedCaller {
+  userId: string;
+  role: TeacherRole;
+}
+
+export type AuthorizeResult =
+  | { ok: true; caller: AuthorizedCaller }
+  | { ok: false; status: 401 | 403 };
+
+/**
+ * Shared server-side gate for every teacher-authoring route (issue #265).
+ *
+ * 1. Requires an authenticated Supabase session — else 401.
+ * 2. Reads the caller's OWN `profiles.role` via the user-session client (RLS
+ *    permits own-row SELECT) and requires `teacher` or `admin` — else 403.
+ *
+ * Role is read from the DB, NOT from any request-supplied value, so a caller
+ * cannot claim a role they do not hold. This is the same source of truth the
+ * `/teach` layout gate uses.
+ */
+export async function authorizeTeacher(): Promise<AuthorizeResult> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+
+  if (authError || !user) {
+    return { ok: false, status: 401 };
+  }
+
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("role")
+    .eq("id", user.id)
+    .maybeSingle();
+
+  const role = profile?.role;
+  if (role !== "teacher" && role !== "admin") {
+    return { ok: false, status: 403 };
+  }
+
+  return { ok: true, caller: { userId: user.id, role } };
+}

--- a/apps/web/src/lib/teacher/slug.ts
+++ b/apps/web/src/lib/teacher/slug.ts
@@ -1,0 +1,23 @@
+import "server-only";
+
+/**
+ * Derive a URL-safe slug from a course title, matching the shape Sanity's
+ * `slug` type produces (lowercase, hyphen-separated, `maxLength: 96`).
+ *
+ * A short random suffix is appended so two courses created with the same title
+ * do not collide on their slug — the on-chain / catalog layer treats slug as a
+ * lookup key, and Sanity does not enforce slug uniqueness on its own.
+ */
+export function slugifyCourseTitle(title: string): string {
+  const base = title
+    .toLowerCase()
+    .normalize("NFKD")
+    .replace(/[̀-ͯ]/g, "") // strip diacritics
+    .replace(/[^a-z0-9]+/g, "-") // non-alphanumeric → hyphen
+    .replace(/^-+|-+$/g, "") // trim leading/trailing hyphens
+    .slice(0, 80);
+
+  const suffix = Math.random().toString(36).slice(2, 8);
+  const stem = base.length > 0 ? base : "course";
+  return `${stem}-${suffix}`.slice(0, 96);
+}

--- a/apps/web/src/lib/teacher/validate.ts
+++ b/apps/web/src/lib/teacher/validate.ts
@@ -1,0 +1,240 @@
+import "server-only";
+import {
+  COURSE_DIFFICULTIES,
+  TEACHER_SETTABLE_AUTHORING_STATUSES,
+  type CourseDifficulty,
+  type TeacherCourseInput,
+  type TeacherSettableAuthoringStatus,
+} from "@/lib/sanity/teacher-mutations";
+
+/**
+ * SECURITY — request-body validation for the teacher course API (issue #265).
+ *
+ * The cardinal rule: NEVER spread an untrusted request body into a Sanity
+ * mutation. Instead we read each allowlisted field explicitly, validate its
+ * type/enum/bounds, and build a fresh `TeacherCourseInput`. Any field not read
+ * here is silently dropped — so `author`, `onChainStatus`, `_id`, `_type`,
+ * `_rev`, `creatorRewardXp`, `minCompletionsForReward`, `trackId`, `trackLevel`,
+ * and `authoringStatus: "approved"` can never reach the write layer, no matter
+ * what the client sends.
+ */
+
+// Conservative field bounds. These are UX/DoS guards, not the security boundary
+// (that is the allowlist itself), but they keep obviously-bad payloads out.
+const MAX_TITLE_LEN = 200;
+const MAX_DESCRIPTION_LEN = 5000;
+const MAX_DURATION_HOURS = 10_000;
+const MAX_XP_REWARD = 1_000_000;
+const MAX_XP_PER_LESSON = 100; // mirrors the course schema (.min(1).max(100))
+const MAX_TAGS = 32;
+const MAX_TAG_LEN = 64;
+// Sanity document ids are opaque but bounded; guard against absurd inputs.
+const MAX_SANITY_ID_LEN = 256;
+
+export interface ValidationError {
+  field: string;
+  message: string;
+}
+
+export type ValidationResult<T> =
+  | { ok: true; value: T }
+  | { ok: false; error: ValidationError };
+
+function err(
+  field: string,
+  message: string
+): { ok: false; error: ValidationError } {
+  return { ok: false, error: { field, message } };
+}
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+function isDifficulty(v: unknown): v is CourseDifficulty {
+  return (
+    typeof v === "string" &&
+    (COURSE_DIFFICULTIES as readonly string[]).includes(v)
+  );
+}
+
+function isTeacherAuthoringStatus(
+  v: unknown
+): v is TeacherSettableAuthoringStatus {
+  return (
+    typeof v === "string" &&
+    (TEACHER_SETTABLE_AUTHORING_STATUSES as readonly string[]).includes(v)
+  );
+}
+
+function isFiniteNumber(v: unknown): v is number {
+  return typeof v === "number" && Number.isFinite(v);
+}
+
+/** A non-empty, length-bounded Sanity id/ref string. */
+function isValidSanityId(v: unknown): v is string {
+  return typeof v === "string" && v.length > 0 && v.length <= MAX_SANITY_ID_LEN;
+}
+
+/**
+ * Validate a single field's presence/shape and, if present, write it into the
+ * accumulating input. Returns a ValidationError on the first bad field.
+ *
+ * `mode: "create"` requires `title`; `mode: "patch"` treats everything as
+ * optional (but still validates any field that IS present).
+ */
+export function validateTeacherCourseInput(
+  raw: unknown,
+  mode: "create" | "patch"
+): ValidationResult<TeacherCourseInput> {
+  if (!isPlainObject(raw)) {
+    return err("body", "Request body must be a JSON object");
+  }
+
+  const out: TeacherCourseInput = {};
+
+  // title
+  if (raw.title !== undefined) {
+    if (typeof raw.title !== "string") return err("title", "must be a string");
+    const trimmed = raw.title.trim();
+    if (trimmed.length === 0) return err("title", "must not be empty");
+    if (trimmed.length > MAX_TITLE_LEN) {
+      return err("title", `must be at most ${MAX_TITLE_LEN} characters`);
+    }
+    out.title = trimmed;
+  } else if (mode === "create") {
+    return err("title", "is required");
+  }
+
+  // description
+  if (raw.description !== undefined) {
+    if (typeof raw.description !== "string") {
+      return err("description", "must be a string");
+    }
+    if (raw.description.length > MAX_DESCRIPTION_LEN) {
+      return err(
+        "description",
+        `must be at most ${MAX_DESCRIPTION_LEN} characters`
+      );
+    }
+    out.description = raw.description;
+  }
+
+  // difficulty
+  if (raw.difficulty !== undefined) {
+    if (!isDifficulty(raw.difficulty)) {
+      return err(
+        "difficulty",
+        `must be one of ${COURSE_DIFFICULTIES.join(", ")}`
+      );
+    }
+    out.difficulty = raw.difficulty;
+  }
+
+  // duration (hours)
+  if (raw.duration !== undefined) {
+    if (!isFiniteNumber(raw.duration) || raw.duration < 0) {
+      return err("duration", "must be a non-negative number");
+    }
+    if (raw.duration > MAX_DURATION_HOURS) {
+      return err("duration", `must be at most ${MAX_DURATION_HOURS}`);
+    }
+    out.duration = raw.duration;
+  }
+
+  // tags
+  if (raw.tags !== undefined) {
+    if (!Array.isArray(raw.tags)) return err("tags", "must be an array");
+    if (raw.tags.length > MAX_TAGS) {
+      return err("tags", `must have at most ${MAX_TAGS} items`);
+    }
+    const tags: string[] = [];
+    for (const tag of raw.tags) {
+      if (typeof tag !== "string") return err("tags", "must be strings");
+      const t = tag.trim();
+      if (t.length === 0) return err("tags", "must not contain empty strings");
+      if (t.length > MAX_TAG_LEN) {
+        return err(
+          "tags",
+          `each tag must be at most ${MAX_TAG_LEN} characters`
+        );
+      }
+      tags.push(t);
+    }
+    out.tags = tags;
+  }
+
+  // xpReward
+  if (raw.xpReward !== undefined) {
+    if (
+      !isFiniteNumber(raw.xpReward) ||
+      raw.xpReward < 0 ||
+      !Number.isInteger(raw.xpReward)
+    ) {
+      return err("xpReward", "must be a non-negative integer");
+    }
+    if (raw.xpReward > MAX_XP_REWARD) {
+      return err("xpReward", `must be at most ${MAX_XP_REWARD}`);
+    }
+    out.xpReward = raw.xpReward;
+  }
+
+  // xpPerLesson
+  if (raw.xpPerLesson !== undefined) {
+    if (
+      !isFiniteNumber(raw.xpPerLesson) ||
+      !Number.isInteger(raw.xpPerLesson) ||
+      raw.xpPerLesson < 1 ||
+      raw.xpPerLesson > MAX_XP_PER_LESSON
+    ) {
+      return err(
+        "xpPerLesson",
+        `must be an integer between 1 and ${MAX_XP_PER_LESSON}`
+      );
+    }
+    out.xpPerLesson = raw.xpPerLesson;
+  }
+
+  // thumbnail — Sanity image; accept { assetRef: "image-..." }
+  if (raw.thumbnail !== undefined) {
+    if (
+      !isPlainObject(raw.thumbnail) ||
+      !isValidSanityId(raw.thumbnail.assetRef)
+    ) {
+      return err("thumbnail", "must be an object with a valid assetRef string");
+    }
+    out.thumbnail = { assetRef: raw.thumbnail.assetRef };
+  }
+
+  // prerequisiteCourse — reference to another course; accept { ref: "<_id>" }
+  if (raw.prerequisiteCourse !== undefined) {
+    if (raw.prerequisiteCourse === null) {
+      // Allow explicit clear via null is out of scope; treat null as "omit".
+    } else if (
+      !isPlainObject(raw.prerequisiteCourse) ||
+      !isValidSanityId(raw.prerequisiteCourse.ref)
+    ) {
+      return err(
+        "prerequisiteCourse",
+        "must be an object with a valid ref string"
+      );
+    } else {
+      out.prerequisiteCourse = { ref: raw.prerequisiteCourse.ref };
+    }
+  }
+
+  // authoringStatus — TEACHER-settable subset ONLY (draft | pending_review).
+  // "approved" (or any other value) is rejected here, so a teacher can never
+  // self-publish through this API.
+  if (raw.authoringStatus !== undefined) {
+    if (!isTeacherAuthoringStatus(raw.authoringStatus)) {
+      return err(
+        "authoringStatus",
+        `must be one of ${TEACHER_SETTABLE_AUTHORING_STATUSES.join(", ")}`
+      );
+    }
+    out.authoringStatus = raw.authoringStatus;
+  }
+
+  return { ok: true, value: out };
+}


### PR DESCRIPTION
## What
The **mediated-write security boundary** for teacher authoring (epic #269, builds on #263 + #264). Teachers author through the app; every Sanity write goes through the server with authz enforced first, and the `SANITY_ADMIN_TOKEN` never reaches the browser.

## Routes
- **GET `/api/teacher/courses`** — list own courses (admin: all).
- **POST `/api/teacher/courses`** — create a DRAFT (server sets `author` + `authoringStatus=draft`).
- **PATCH `/api/teacher/courses/[id]`** — update a course the caller owns.

## Authorization (all server-side)
- `lib/teacher/authorize.ts`: authenticated Supabase session + `role in (teacher,admin)` read from `profiles` (**DB, never client-supplied**) → 401/403.
- PATCH ownership: loads `course.author`; `!isOwner && !isAdmin` → **403** (cross-author writes blocked; legacy `author=null` courses are admin-only).

## Field whitelist (the structural control)
`lib/teacher/validate.ts` + `teacher-mutations.ts` **never spread the body** — each allowlisted field is copied explicitly. Unreachable no matter what the client sends: `author` (server-set, immutable post-create), `onChainStatus`, `_id/_type/_rev`, `trackId/trackLevel`, `creatorRewardXp/minCompletionsForReward`. `authoringStatus` is limited to `draft|pending_review` — **`approved` is rejected**, so a teacher cannot self-publish (approval is admin-only, #268).

## Verified locally
`tsc --noEmit` clean; ESLint clean (only pre-existing `import/order` warnings in untouched files). Adversarially reviewed: crafted-body author/onChainStatus/approved injection, cross-author writes, and token isolation all hold.

Closes #265. Part of #269.