### PR TITLE
feat(teacher-courses): teacher-scoped course CRUD API (mediated writes + ownership)

### DIFF
--- a/apps/web/src/app/api/teacher/courses/[id]/route.ts
+++ b/apps/web/src/app/api/teacher/courses/[id]/route.ts
@@ -1,0 +1,78 @@
+import "server-only";
+
+import { NextRequest, NextResponse } from "next/server";
+import { requireCourseAuthor } from "@/lib/auth/roles";
+import {
+  getCourseOwnership,
+  patchCourseMeta,
+  setAuthoringStatus,
+  parseCourseMeta,
+} from "@/lib/sanity/teacher-mutations";
+
+/**
+ * Update a single teacher-owned course.
+ *   PATCH → whitelisted metadata and/or a status transition
+ *
+ * Ownership is enforced against the course's `author`: teachers may only touch
+ * their own courses; admins may touch any. Teachers can move the status to
+ * `draft` or `pending_review` (submit for review) — never `approved`, which is
+ * admin-only (the review flow, #268). `author`/`onChainStatus` are never
+ * writable here.
+ */
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<NextResponse> {
+  const authed = await requireCourseAuthor();
+  if (authed instanceof NextResponse) return authed;
+
+  const { id } = await params;
+  if (!id || typeof id !== "string") {
+    return NextResponse.json({ error: "Invalid course id" }, { status: 400 });
+  }
+
+  const ownership = await getCourseOwnership(id);
+  if (!ownership) {
+    return NextResponse.json({ error: "Course not found" }, { status: 404 });
+  }
+  if (authed.role !== "admin" && ownership.author !== authed.userId) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = (await req.json()) as Record<string, unknown>;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  // Optional status transition — teachers may only submit for review.
+  let nextStatus: "draft" | "pending_review" | undefined;
+  if (body.authoringStatus !== undefined) {
+    if (
+      body.authoringStatus !== "draft" &&
+      body.authoringStatus !== "pending_review"
+    ) {
+      return NextResponse.json(
+        { error: "authoringStatus may only be set to draft or pending_review" },
+        { status: 400 }
+      );
+    }
+    nextStatus = body.authoringStatus;
+  }
+
+  let meta;
+  try {
+    meta = parseCourseMeta(body);
+  } catch (e) {
+    return NextResponse.json(
+      { error: e instanceof Error ? e.message : "Invalid input" },
+      { status: 400 }
+    );
+  }
+
+  await patchCourseMeta(id, meta);
+  if (nextStatus) await setAuthoringStatus(id, nextStatus);
+
+  return NextResponse.json({ id, ...(nextStatus ? { authoringStatus: nextStatus } : {}) });
+}

--- a/apps/web/src/app/api/teacher/courses/route.ts
+++ b/apps/web/src/app/api/teacher/courses/route.ts
@@ -1,0 +1,44 @@
+import "server-only";
+
+import { NextRequest, NextResponse } from "next/server";
+import { requireCourseAuthor } from "@/lib/auth/roles";
+import {
+  listCoursesByAuthor,
+  createDraftCourse,
+  parseCourseMeta,
+} from "@/lib/sanity/teacher-mutations";
+
+/**
+ * Teacher-scoped course collection.
+ *   GET  → the caller's own courses
+ *   POST → create a new draft course owned by the caller
+ *
+ * The Sanity write token stays server-side; role is enforced here (and again on
+ * writes). New courses are always `author = caller`, `authoringStatus = draft`.
+ */
+
+export async function GET(): Promise<NextResponse> {
+  const authed = await requireCourseAuthor();
+  if (authed instanceof NextResponse) return authed;
+
+  const courses = await listCoursesByAuthor(authed.userId);
+  return NextResponse.json({ courses });
+}
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  const authed = await requireCourseAuthor();
+  if (authed instanceof NextResponse) return authed;
+
+  let meta;
+  try {
+    meta = parseCourseMeta(await req.json());
+  } catch (e) {
+    return NextResponse.json(
+      { error: e instanceof Error ? e.message : "Invalid input" },
+      { status: 400 }
+    );
+  }
+
+  const id = await createDraftCourse(authed.userId, meta);
+  return NextResponse.json({ id }, { status: 201 });
+}

--- a/apps/web/src/lib/auth/roles.ts
+++ b/apps/web/src/lib/auth/roles.ts
@@ -1,0 +1,57 @@
+import "server-only";
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+
+export type UserRole = "learner" | "teacher" | "admin";
+
+/** Teachers and admins may author courses; learners may not. */
+export function canAuthorCourses(role: UserRole): boolean {
+  return role === "teacher" || role === "admin";
+}
+
+/**
+ * The authenticated user id + role for the current request, or `null` when
+ * unauthenticated. Role is read from the caller's OWN `profiles` row via the
+ * user-session client (RLS permits own-row SELECT); it is never writable here.
+ * SERVER-ONLY.
+ */
+export async function getSessionUserAndRole(): Promise<{
+  userId: string;
+  role: UserRole;
+} | null> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return null;
+
+  const { data } = await supabase
+    .from("profiles")
+    .select("role")
+    .eq("id", user.id)
+    .maybeSingle();
+
+  const role = data?.role;
+  return {
+    userId: user.id,
+    role: role === "teacher" || role === "admin" ? role : "learner",
+  };
+}
+
+/**
+ * Guard for teacher API routes: returns the authenticated author `{ userId,
+ * role }`, or a ready-to-return NextResponse (401 unauthenticated, 403
+ * non-author). Callers do `if (authed instanceof NextResponse) return authed;`.
+ */
+export async function requireCourseAuthor(): Promise<
+  { userId: string; role: UserRole } | NextResponse
+> {
+  const session = await getSessionUserAndRole();
+  if (!session) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  if (!canAuthorCourses(session.role)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  return session;
+}

--- a/apps/web/src/lib/sanity/teacher-mutations.ts
+++ b/apps/web/src/lib/sanity/teacher-mutations.ts
@@ -1,0 +1,173 @@
+import "server-only";
+import { createClient } from "next-sanity";
+import { env } from "@/lib/env";
+import { serverEnv } from "@/lib/env.server";
+
+/**
+ * Server-only Sanity write client for teacher-authored courses. Uses the
+ * write-enabled SANITY_ADMIN_TOKEN, which NEVER reaches the browser — all
+ * teacher writes are mediated through the /api/teacher/* routes, which enforce
+ * role + ownership before calling into here.
+ */
+const sanityWrite = createClient({
+  projectId: env.NEXT_PUBLIC_SANITY_PROJECT_ID,
+  dataset: env.NEXT_PUBLIC_SANITY_DATASET,
+  token: serverEnv.SANITY_ADMIN_TOKEN,
+  useCdn: false,
+  apiVersion: "2024-01-01",
+});
+
+export type AuthoringStatus = "draft" | "pending_review" | "approved";
+
+/** Whitelisted, teacher-writable course metadata. */
+export interface TeacherCourseMeta {
+  title?: string;
+  description?: string;
+  difficulty?: "beginner" | "intermediate" | "advanced";
+  duration?: number;
+  tags?: string[];
+  xpReward?: number;
+  xpPerLesson?: number;
+}
+
+export interface TeacherCourseSummary {
+  _id: string;
+  title: string | null;
+  slug: string | null;
+  authoringStatus: AuthoringStatus | null;
+  onChainStatus: string | null;
+}
+
+function slugify(input: string): string {
+  const base =
+    input
+      .toLowerCase()
+      .trim()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "")
+      .slice(0, 80) || "course";
+  return `${base}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+/**
+ * Validate + whitelist an untrusted request body into TeacherCourseMeta.
+ * Throws on any bad field. Only these fields are ever writable by a teacher —
+ * `author`, `authoringStatus`, `onChainStatus` are set by the server, never the
+ * client.
+ */
+export function parseCourseMeta(body: unknown): TeacherCourseMeta {
+  if (typeof body !== "object" || body === null) {
+    throw new Error("Invalid body");
+  }
+  const b = body as Record<string, unknown>;
+  const meta: TeacherCourseMeta = {};
+
+  if (b.title !== undefined) {
+    if (typeof b.title !== "string" || !b.title.trim() || b.title.length > 200)
+      throw new Error("Invalid title");
+    meta.title = b.title.trim();
+  }
+  if (b.description !== undefined) {
+    if (typeof b.description !== "string" || b.description.length > 5000)
+      throw new Error("Invalid description");
+    meta.description = b.description;
+  }
+  if (b.difficulty !== undefined) {
+    if (
+      b.difficulty !== "beginner" &&
+      b.difficulty !== "intermediate" &&
+      b.difficulty !== "advanced"
+    )
+      throw new Error("Invalid difficulty");
+    meta.difficulty = b.difficulty;
+  }
+  if (b.duration !== undefined) {
+    if (typeof b.duration !== "number" || b.duration < 0 || b.duration > 1000)
+      throw new Error("Invalid duration");
+    meta.duration = b.duration;
+  }
+  if (b.tags !== undefined) {
+    if (
+      !Array.isArray(b.tags) ||
+      b.tags.length > 20 ||
+      b.tags.some((t) => typeof t !== "string" || t.length > 40)
+    )
+      throw new Error("Invalid tags");
+    meta.tags = b.tags as string[];
+  }
+  if (b.xpReward !== undefined) {
+    if (typeof b.xpReward !== "number" || b.xpReward < 0 || b.xpReward > 100000)
+      throw new Error("Invalid xpReward");
+    meta.xpReward = b.xpReward;
+  }
+  if (b.xpPerLesson !== undefined) {
+    if (
+      typeof b.xpPerLesson !== "number" ||
+      b.xpPerLesson < 1 ||
+      b.xpPerLesson > 100
+    )
+      throw new Error("Invalid xpPerLesson");
+    meta.xpPerLesson = b.xpPerLesson;
+  }
+  return meta;
+}
+
+/** Courses owned by a given teacher (their Supabase user id in `author`). */
+export async function listCoursesByAuthor(
+  author: string
+): Promise<TeacherCourseSummary[]> {
+  return sanityWrite.fetch<TeacherCourseSummary[]>(
+    `*[_type == "course" && author == $author] | order(_updatedAt desc) {
+      _id, title, "slug": slug.current, authoringStatus,
+      "onChainStatus": onChainStatus.status
+    }`,
+    { author }
+  );
+}
+
+/** Ownership + status for a single course, or null when it doesn't exist. */
+export async function getCourseOwnership(
+  id: string
+): Promise<{ author: string | null; authoringStatus: AuthoringStatus | null } | null> {
+  return sanityWrite.fetch(
+    `*[_type == "course" && _id == $id][0]{ author, authoringStatus }`,
+    { id }
+  );
+}
+
+/** Create a draft course owned by `author`. Returns the new document id. */
+export async function createDraftCourse(
+  author: string,
+  meta: TeacherCourseMeta
+): Promise<string> {
+  const title = meta.title ?? "Untitled course";
+  const doc = await sanityWrite.create({
+    _type: "course",
+    ...meta,
+    title,
+    slug: { _type: "slug", current: slugify(title) },
+    author,
+    authoringStatus: "draft",
+  });
+  return doc._id;
+}
+
+/** Patch whitelisted metadata fields on an existing course. */
+export async function patchCourseMeta(
+  id: string,
+  meta: TeacherCourseMeta
+): Promise<void> {
+  if (Object.keys(meta).length === 0) return;
+  await sanityWrite.patch(id).set(meta).commit();
+}
+
+/**
+ * Set the authoring status. Teachers may only reach `draft` or `pending_review`
+ * (submit for review); `approved` is admin-only and lives in the review flow.
+ */
+export async function setAuthoringStatus(
+  id: string,
+  status: "draft" | "pending_review"
+): Promise<void> {
+  await sanityWrite.patch(id).set({ authoringStatus: status }).commit();
+}


### PR DESCRIPTION
## Summary

Third PR of the **teacher-authored courses** epic (#269), on top of the merged #263 (data model) and #264 (role + `/teach` gate). This is the **real security boundary**: teachers author only their own courses, and the Sanity write token never touches the browser.

## What

- **`lib/auth/roles.ts`** — `getSessionUserAndRole`, `canAuthorCourses`, and `requireCourseAuthor` (a 401/403 guard for API routes). #264 inlined role reading in the layout; this makes it a shared server-side helper the API (and #266/#268) reuse.
- **`lib/sanity/teacher-mutations.ts`** — server-only Sanity write client (`SANITY_ADMIN_TOKEN`) with `parseCourseMeta` (strict field whitelist), `listCoursesByAuthor`, `getCourseOwnership`, `createDraftCourse`, `patchCourseMeta`, `setAuthoringStatus`.
- **`GET/POST /api/teacher/courses`** — list the caller's own courses / create a draft (`author = caller`, `authoringStatus = draft`).
- **`PATCH /api/teacher/courses/[id]`** — update an owned course.

## Security

- **Ownership** enforced against `course.author`: a teacher may only read/write their own courses (cross-author → 403); admins may edit any.
- **Token stays server-side** — the browser never sees `SANITY_ADMIN_TOKEN`; every write goes through these role- and ownership-checked routes.
- **Field whitelist** — only `title`, `description`, `difficulty`, `duration`, `tags`, `xpReward`, `xpPerLesson` are writable. `author`, `onChainStatus`, and `authoringStatus` beyond `pending_review` are never client-settable.
- **Status ceiling** — teachers can move status only to `draft` or `pending_review` (submit for review); `approved` is admin-only (the review flow, #268).

## Verification

- `tsc` clean, eslint clean
- `next build` passes; both routes register as dynamic (`ƒ /api/teacher/courses`, `ƒ /api/teacher/courses/[id]`)

Closes #265 · part of #269
