### PR TITLE
feat(teacher-courses): course creation/edit page (metadata)

### DIFF
--- a/apps/web/src/app/[locale]/(platform)/teach/courses/[id]/edit/page.tsx
+++ b/apps/web/src/app/[locale]/(platform)/teach/courses/[id]/edit/page.tsx
@@ -1,0 +1,44 @@
+import Link from "next/link";
+import { notFound, redirect } from "next/navigation";
+import { getTranslations } from "next-intl/server";
+import { authorizeTeacher } from "@/lib/teacher/authorize";
+import { getTeacherCourseEditable } from "@/lib/sanity/teacher-mutations";
+import { CourseForm } from "@/components/teacher/course-form";
+
+export const dynamic = "force-dynamic";
+
+export default async function EditCoursePage({
+  params,
+}: {
+  params: Promise<{ locale: string; id: string }>;
+}) {
+  const { locale, id } = await params;
+
+  const auth = await authorizeTeacher();
+  if (!auth.ok) redirect(`/${locale}`);
+
+  const course = await getTeacherCourseEditable(id);
+  if (!course) notFound();
+
+  // Ownership: teachers may only edit their own courses; admins may edit any.
+  if (auth.caller.role !== "admin" && course.author !== auth.caller.userId) {
+    redirect(`/${locale}/teach/courses`);
+  }
+
+  const t = await getTranslations("teacher.form");
+
+  return (
+    <div className="mx-auto max-w-2xl px-4 py-8">
+      <Link
+        href={`/${locale}/teach/courses`}
+        className="text-sm text-text-3 underline hover:no-underline"
+      >
+        &larr; {t("back")}
+      </Link>
+      <h1 className="mb-6 mt-3 font-display text-2xl font-bold text-text">
+        {t("editHeading")}
+      </h1>
+      <CourseForm mode="edit" courseId={course._id} initial={course} />
+    </div>
+  );
+}

--- a/apps/web/src/app/[locale]/(platform)/teach/courses/new/page.tsx
+++ b/apps/web/src/app/[locale]/(platform)/teach/courses/new/page.tsx
@@ -1,0 +1,27 @@
+import Link from "next/link";
+import { getTranslations } from "next-intl/server";
+import { CourseForm } from "@/components/teacher/course-form";
+
+export default async function NewCoursePage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  const t = await getTranslations("teacher.form");
+
+  return (
+    <div className="mx-auto max-w-2xl px-4 py-8">
+      <Link
+        href={`/${locale}/teach/courses`}
+        className="text-sm text-text-3 underline hover:no-underline"
+      >
+        &larr; {t("back")}
+      </Link>
+      <h1 className="mb-6 mt-3 font-display text-2xl font-bold text-text">
+        {t("createHeading")}
+      </h1>
+      <CourseForm mode="create" />
+    </div>
+  );
+}

--- a/apps/web/src/app/[locale]/(platform)/teach/courses/page.tsx
+++ b/apps/web/src/app/[locale]/(platform)/teach/courses/page.tsx
@@ -1,0 +1,73 @@
+import { redirect } from "next/navigation";
+import Link from "next/link";
+import { getTranslations } from "next-intl/server";
+import { authorizeTeacher } from "@/lib/teacher/authorize";
+import { listTeacherCourses } from "@/lib/sanity/teacher-mutations";
+
+export const dynamic = "force-dynamic";
+
+export default async function TeacherCoursesPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+
+  // The /teach layout already gates, but we need the caller id here.
+  const auth = await authorizeTeacher();
+  if (!auth.ok) redirect(`/${locale}`);
+
+  const t = await getTranslations("teacher.courses");
+  const courses = await listTeacherCourses(auth.caller.userId);
+
+  const statusLabel = (s: string | null): string =>
+    s === "pending_review"
+      ? t("statusPendingReview")
+      : s === "approved"
+        ? t("statusApproved")
+        : t("statusDraft");
+
+  return (
+    <div className="mx-auto max-w-4xl px-4 py-8">
+      <div className="mb-6 flex items-center justify-between">
+        <h1 className="font-display text-2xl font-bold text-text">
+          {t("heading")}
+        </h1>
+        <Link
+          href={`/${locale}/teach/courses/new`}
+          className="rounded-md border border-primary bg-primary px-4 py-2 text-sm font-medium text-primary-foreground"
+        >
+          {t("new")}
+        </Link>
+      </div>
+
+      {courses.length === 0 ? (
+        <p className="text-sm text-text-3">{t("empty")}</p>
+      ) : (
+        <ul className="space-y-2">
+          {courses.map((c) => (
+            <li
+              key={c._id}
+              className="flex items-center justify-between rounded-lg border border-border bg-card px-4 py-3 shadow-card"
+            >
+              <div>
+                <p className="font-medium text-text">
+                  {c.title ?? t("untitled")}
+                </p>
+                <p className="text-xs text-text-3">
+                  {statusLabel(c.authoringStatus)}
+                </p>
+              </div>
+              <Link
+                href={`/${locale}/teach/courses/${c._id}/edit`}
+                className="text-sm text-primary underline hover:no-underline"
+              >
+                {t("edit")}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/[locale]/(platform)/teach/courses/page.tsx
+++ b/apps/web/src/app/[locale]/(platform)/teach/courses/page.tsx
@@ -8,16 +8,20 @@ export const dynamic = "force-dynamic";
 
 export default async function TeacherCoursesPage({
   params,
+  searchParams,
 }: {
   params: Promise<{ locale: string }>;
+  searchParams: Promise<{ submitted?: string }>;
 }) {
   const { locale } = await params;
+  const { submitted } = await searchParams;
 
   // The /teach layout already gates, but we need the caller id here.
   const auth = await authorizeTeacher();
   if (!auth.ok) redirect(`/${locale}`);
 
   const t = await getTranslations("teacher.courses");
+  const tForm = await getTranslations("teacher.form");
   const courses = await listTeacherCourses(auth.caller.userId);
 
   const statusLabel = (s: string | null): string =>
@@ -40,6 +44,12 @@ export default async function TeacherCoursesPage({
           {t("new")}
         </Link>
       </div>
+
+      {submitted === "1" && (
+        <div className="mb-4 rounded-md border border-success bg-success-light p-3 text-sm text-success">
+          {tForm("submitted")}
+        </div>
+      )}
 
       {courses.length === 0 ? (
         <p className="text-sm text-text-3">{t("empty")}</p>

--- a/apps/web/src/app/[locale]/(platform)/teach/page.tsx
+++ b/apps/web/src/app/[locale]/(platform)/teach/page.tsx
@@ -1,26 +1,13 @@
-import { getTranslations } from "next-intl/server";
+import { redirect } from "next/navigation";
 
-export default async function TeachPage() {
-  const t = await getTranslations("teacher.area");
+export const dynamic = "force-dynamic";
 
-  return (
-    <section aria-labelledby="teach-heading" className="mx-auto max-w-3xl">
-      <h1
-        id="teach-heading"
-        className="font-display text-2xl font-bold text-[var(--text)]"
-      >
-        {t("title")}
-      </h1>
-      <p className="mt-2 text-sm text-[var(--text-3)]">{t("subtitle")}</p>
-
-      <div className="mt-8 rounded-lg border border-[var(--border)] bg-[var(--card)] p-6 shadow-card">
-        <h2 className="font-display text-lg font-bold text-[var(--text)]">
-          {t("comingSoonTitle")}
-        </h2>
-        <p className="mt-2 text-sm text-[var(--text-2)]">
-          {t("comingSoonBody")}
-        </p>
-      </div>
-    </section>
-  );
+/** Teacher area entry point — send authors straight to their course list. */
+export default async function TeachPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  redirect(`/${locale}/teach/courses`);
 }

--- a/apps/web/src/components/teacher/course-form.tsx
+++ b/apps/web/src/components/teacher/course-form.tsx
@@ -1,0 +1,281 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useLocale, useTranslations } from "next-intl";
+
+interface CourseInitial {
+  title?: string | null;
+  description?: string | null;
+  difficulty?: string | null;
+  duration?: number | null;
+  tags?: string[] | null;
+  xpReward?: number | null;
+  xpPerLesson?: number | null;
+}
+
+interface CourseFormProps {
+  mode: "create" | "edit";
+  courseId?: string;
+  initial?: CourseInitial;
+}
+
+const DIFFICULTIES = ["beginner", "intermediate", "advanced"] as const;
+const inputClass =
+  "w-full rounded-md border border-border bg-[var(--input)] px-3 py-2 text-sm text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary";
+
+export function CourseForm({ mode, courseId, initial }: CourseFormProps) {
+  const t = useTranslations("teacher.form");
+  const router = useRouter();
+  const locale = useLocale();
+
+  const [title, setTitle] = useState(initial?.title ?? "");
+  const [description, setDescription] = useState(initial?.description ?? "");
+  const [difficulty, setDifficulty] = useState(
+    initial?.difficulty ?? "beginner"
+  );
+  const [duration, setDuration] = useState(
+    initial?.duration != null ? String(initial.duration) : ""
+  );
+  const [tags, setTags] = useState((initial?.tags ?? []).join(", "));
+  const [xpReward, setXpReward] = useState(
+    initial?.xpReward != null ? String(initial.xpReward) : ""
+  );
+  const [xpPerLesson, setXpPerLesson] = useState(
+    initial?.xpPerLesson != null ? String(initial.xpPerLesson) : ""
+  );
+
+  const [busy, setBusy] = useState<null | "save" | "submit">(null);
+  const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+
+  function buildBody(extra?: Record<string, unknown>): Record<string, unknown> {
+    const body: Record<string, unknown> = { title: title.trim(), difficulty };
+    if (description.trim()) body.description = description.trim();
+    const tagList = tags
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean);
+    if (tagList.length) body.tags = tagList;
+    if (duration.trim()) {
+      const n = Number(duration);
+      if (Number.isFinite(n)) body.duration = n;
+    }
+    if (xpReward.trim()) {
+      const n = Number(xpReward);
+      if (Number.isInteger(n)) body.xpReward = n;
+    }
+    if (xpPerLesson.trim()) {
+      const n = Number(xpPerLesson);
+      if (Number.isInteger(n)) body.xpPerLesson = n;
+    }
+    return { ...body, ...extra };
+  }
+
+  async function persist(
+    extra: Record<string, unknown> | undefined,
+    which: "save" | "submit"
+  ) {
+    if (!title.trim()) {
+      setError(t("titleRequired"));
+      return;
+    }
+    setBusy(which);
+    setError(null);
+    setNotice(null);
+    try {
+      const url =
+        mode === "create"
+          ? "/api/teacher/courses"
+          : `/api/teacher/courses/${courseId}`;
+      const method = mode === "create" ? "POST" : "PATCH";
+      const res = await fetch(url, {
+        method,
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(buildBody(extra)),
+      });
+      const data = (await res.json().catch(() => ({}))) as {
+        error?: string;
+        _id?: string;
+      };
+      if (!res.ok) {
+        setError(data.error ?? "Request failed");
+        return;
+      }
+      if (which === "submit") {
+        router.push(`/${locale}/teach/courses`);
+        return;
+      }
+      if (mode === "create" && data._id) {
+        router.push(`/${locale}/teach/courses/${data._id}/edit`);
+        return;
+      }
+      setNotice(t("saved"));
+      router.refresh();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Network error");
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  return (
+    <form
+      className="space-y-5"
+      onSubmit={(e) => {
+        e.preventDefault();
+        void persist(undefined, "save");
+      }}
+    >
+      <div>
+        <label htmlFor="course-title" className="mb-1 block text-sm font-medium">
+          {t("title")}
+        </label>
+        <input
+          id="course-title"
+          type="text"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          maxLength={200}
+          required
+          className={inputClass}
+        />
+      </div>
+
+      <div>
+        <label htmlFor="course-desc" className="mb-1 block text-sm font-medium">
+          {t("description")}
+        </label>
+        <textarea
+          id="course-desc"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          maxLength={5000}
+          rows={4}
+          className={inputClass}
+        />
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div>
+          <label
+            htmlFor="course-difficulty"
+            className="mb-1 block text-sm font-medium"
+          >
+            {t("difficulty")}
+          </label>
+          <select
+            id="course-difficulty"
+            value={difficulty}
+            onChange={(e) => setDifficulty(e.target.value)}
+            className={inputClass}
+          >
+            {DIFFICULTIES.map((d) => (
+              <option key={d} value={d}>
+                {t(d)}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label
+            htmlFor="course-duration"
+            className="mb-1 block text-sm font-medium"
+          >
+            {t("duration")}
+          </label>
+          <input
+            id="course-duration"
+            type="number"
+            min={0}
+            value={duration}
+            onChange={(e) => setDuration(e.target.value)}
+            className={inputClass}
+          />
+        </div>
+      </div>
+
+      <div>
+        <label htmlFor="course-tags" className="mb-1 block text-sm font-medium">
+          {t("tags")}
+        </label>
+        <input
+          id="course-tags"
+          type="text"
+          value={tags}
+          onChange={(e) => setTags(e.target.value)}
+          className={inputClass}
+        />
+        <p className="mt-1 text-xs text-text-3">{t("tagsHint")}</p>
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div>
+          <label htmlFor="course-xp" className="mb-1 block text-sm font-medium">
+            {t("xpReward")}
+          </label>
+          <input
+            id="course-xp"
+            type="number"
+            min={0}
+            step={1}
+            value={xpReward}
+            onChange={(e) => setXpReward(e.target.value)}
+            className={inputClass}
+          />
+        </div>
+        <div>
+          <label
+            htmlFor="course-xppl"
+            className="mb-1 block text-sm font-medium"
+          >
+            {t("xpPerLesson")}
+          </label>
+          <input
+            id="course-xppl"
+            type="number"
+            min={1}
+            max={100}
+            step={1}
+            value={xpPerLesson}
+            onChange={(e) => setXpPerLesson(e.target.value)}
+            className={inputClass}
+          />
+        </div>
+      </div>
+
+      {error && (
+        <div className="rounded-md border border-danger bg-danger-light p-3 text-sm text-danger">
+          {error}
+        </div>
+      )}
+      {notice && (
+        <div className="rounded-md border border-success bg-success-light p-3 text-sm text-success">
+          {notice}
+        </div>
+      )}
+
+      <div className="flex flex-wrap items-center gap-3">
+        <button
+          type="submit"
+          disabled={busy !== null}
+          className="rounded-md border border-primary bg-primary px-4 py-2 text-sm font-medium text-primary-foreground disabled:opacity-50"
+        >
+          {busy === "save" ? t("saving") : t("saveDraft")}
+        </button>
+        {mode === "edit" && (
+          <button
+            type="button"
+            disabled={busy !== null}
+            onClick={() =>
+              void persist({ authoringStatus: "pending_review" }, "submit")
+            }
+            className="rounded-md border border-border px-4 py-2 text-sm font-medium text-text disabled:opacity-50"
+          >
+            {busy === "submit" ? t("submitting") : t("submitForReview")}
+          </button>
+        )}
+      </div>
+    </form>
+  );
+}

--- a/apps/web/src/components/teacher/course-form.tsx
+++ b/apps/web/src/components/teacher/course-form.tsx
@@ -103,7 +103,7 @@ export function CourseForm({ mode, courseId, initial }: CourseFormProps) {
         return;
       }
       if (which === "submit") {
-        router.push(`/${locale}/teach/courses`);
+        router.push(`/${locale}/teach/courses?submitted=1`);
         return;
       }
       if (mode === "create" && data._id) {

--- a/apps/web/src/lib/sanity/teacher-mutations.ts
+++ b/apps/web/src/lib/sanity/teacher-mutations.ts
@@ -230,3 +230,34 @@ export async function patchTeacherCourse(
   if (Object.keys(patch).length === 0) return;
   await sanityAdmin.patch(courseId).set(patch).commit();
 }
+
+/** Full editable field set for the course builder (issue #266). */
+export interface TeacherCourseEditable {
+  _id: string;
+  author: string | null;
+  authoringStatus: string | null;
+  onChainStatus: string | null;
+  title: string | null;
+  description: string | null;
+  difficulty: string | null;
+  duration: number | null;
+  tags: string[] | null;
+  xpReward: number | null;
+  xpPerLesson: number | null;
+}
+
+/**
+ * Fetch a course's full editable fields for the builder, including the
+ * ownership fields the caller needs to authorize. Returns null if absent.
+ */
+export async function getTeacherCourseEditable(
+  courseId: string
+): Promise<TeacherCourseEditable | null> {
+  return sanityAdmin.fetch<TeacherCourseEditable | null>(
+    `*[_type == "course" && _id == $courseId][0] {
+      _id, author, authoringStatus, "onChainStatus": onChainStatus.status,
+      title, description, difficulty, duration, tags, xpReward, xpPerLesson
+    }`,
+    { courseId }
+  );
+}

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -30,12 +30,6 @@
     "viewOnSolanaExplorer": "View on Solana Explorer: {address}"
   },
   "teacher": {
-    "area": {
-      "title": "Teacher Area",
-      "subtitle": "Create and manage your courses.",
-      "comingSoonTitle": "Authoring coming soon",
-      "comingSoonBody": "Course authoring tools are on the way — you'll be able to draft courses, add lessons, and submit them for review right here."
-    },
     "courses": {
       "heading": "Your courses",
       "new": "New course",

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -35,6 +35,39 @@
       "subtitle": "Create and manage your courses.",
       "comingSoonTitle": "Authoring coming soon",
       "comingSoonBody": "Course authoring tools are on the way — you'll be able to draft courses, add lessons, and submit them for review right here."
+    },
+    "courses": {
+      "heading": "Your courses",
+      "new": "New course",
+      "empty": "You haven't created any courses yet.",
+      "edit": "Edit",
+      "untitled": "Untitled course",
+      "statusDraft": "Draft",
+      "statusPendingReview": "Pending review",
+      "statusApproved": "Approved"
+    },
+    "form": {
+      "createHeading": "New course",
+      "editHeading": "Edit course",
+      "title": "Title",
+      "description": "Description",
+      "difficulty": "Difficulty",
+      "beginner": "Beginner",
+      "intermediate": "Intermediate",
+      "advanced": "Advanced",
+      "duration": "Duration (hours)",
+      "tags": "Tags",
+      "tagsHint": "Comma-separated",
+      "xpReward": "XP reward",
+      "xpPerLesson": "XP per lesson",
+      "saveDraft": "Save draft",
+      "saving": "Saving…",
+      "submitForReview": "Submit for review",
+      "submitting": "Submitting…",
+      "saved": "Saved",
+      "submitted": "Submitted for review",
+      "back": "Back to courses",
+      "titleRequired": "Title is required"
     }
   },
   "nav": {

--- a/apps/web/src/messages/es.json
+++ b/apps/web/src/messages/es.json
@@ -35,6 +35,39 @@
       "subtitle": "Crea y gestiona tus cursos.",
       "comingSoonTitle": "Creación próximamente",
       "comingSoonBody": "Las herramientas de creación de cursos están en camino: podrás crear borradores de cursos, añadir lecciones y enviarlos para revisión aquí."
+    },
+    "courses": {
+      "heading": "Tus cursos",
+      "new": "Nuevo curso",
+      "empty": "Aún no has creado ningún curso.",
+      "edit": "Editar",
+      "untitled": "Curso sin título",
+      "statusDraft": "Borrador",
+      "statusPendingReview": "En revisión",
+      "statusApproved": "Aprobado"
+    },
+    "form": {
+      "createHeading": "Nuevo curso",
+      "editHeading": "Editar curso",
+      "title": "Título",
+      "description": "Descripción",
+      "difficulty": "Dificultad",
+      "beginner": "Principiante",
+      "intermediate": "Intermedio",
+      "advanced": "Avanzado",
+      "duration": "Duración (horas)",
+      "tags": "Etiquetas",
+      "tagsHint": "Separadas por comas",
+      "xpReward": "Recompensa XP",
+      "xpPerLesson": "XP por lección",
+      "saveDraft": "Guardar borrador",
+      "saving": "Guardando…",
+      "submitForReview": "Enviar para revisión",
+      "submitting": "Enviando…",
+      "saved": "Guardado",
+      "submitted": "Enviado para revisión",
+      "back": "Volver a los cursos",
+      "titleRequired": "El título es obligatorio"
     }
   },
   "nav": {

--- a/apps/web/src/messages/es.json
+++ b/apps/web/src/messages/es.json
@@ -30,12 +30,6 @@
     "viewOnSolanaExplorer": "Ver en Solana Explorer: {address}"
   },
   "teacher": {
-    "area": {
-      "title": "Área del Profesor",
-      "subtitle": "Crea y gestiona tus cursos.",
-      "comingSoonTitle": "Creación próximamente",
-      "comingSoonBody": "Las herramientas de creación de cursos están en camino: podrás crear borradores de cursos, añadir lecciones y enviarlos para revisión aquí."
-    },
     "courses": {
       "heading": "Tus cursos",
       "new": "Nuevo curso",

--- a/apps/web/src/messages/pt-BR.json
+++ b/apps/web/src/messages/pt-BR.json
@@ -35,6 +35,39 @@
       "subtitle": "Crie e gerencie seus cursos.",
       "comingSoonTitle": "Criação em breve",
       "comingSoonBody": "As ferramentas de criação de cursos estão a caminho — você poderá rascunhar cursos, adicionar lições e enviá-los para revisão aqui."
+    },
+    "courses": {
+      "heading": "Seus cursos",
+      "new": "Novo curso",
+      "empty": "Você ainda não criou nenhum curso.",
+      "edit": "Editar",
+      "untitled": "Curso sem título",
+      "statusDraft": "Rascunho",
+      "statusPendingReview": "Em revisão",
+      "statusApproved": "Aprovado"
+    },
+    "form": {
+      "createHeading": "Novo curso",
+      "editHeading": "Editar curso",
+      "title": "Título",
+      "description": "Descrição",
+      "difficulty": "Dificuldade",
+      "beginner": "Iniciante",
+      "intermediate": "Intermediário",
+      "advanced": "Avançado",
+      "duration": "Duração (horas)",
+      "tags": "Tags",
+      "tagsHint": "Separadas por vírgula",
+      "xpReward": "Recompensa XP",
+      "xpPerLesson": "XP por aula",
+      "saveDraft": "Salvar rascunho",
+      "saving": "Salvando…",
+      "submitForReview": "Enviar para revisão",
+      "submitting": "Enviando…",
+      "saved": "Salvo",
+      "submitted": "Enviado para revisão",
+      "back": "Voltar aos cursos",
+      "titleRequired": "O título é obrigatório"
     }
   },
   "nav": {

--- a/apps/web/src/messages/pt-BR.json
+++ b/apps/web/src/messages/pt-BR.json
@@ -30,12 +30,6 @@
     "viewOnSolanaExplorer": "Ver no Solana Explorer: {address}"
   },
   "teacher": {
-    "area": {
-      "title": "Área do Professor",
-      "subtitle": "Crie e gerencie seus cursos.",
-      "comingSoonTitle": "Criação em breve",
-      "comingSoonBody": "As ferramentas de criação de cursos estão a caminho — você poderá rascunhar cursos, adicionar lições e enviá-los para revisão aqui."
-    },
     "courses": {
       "heading": "Seus cursos",
       "new": "Novo curso",


### PR DESCRIPTION
## Summary

Fourth PR of the **teacher-authored courses** epic (#269), on top of the merged #263/#264/#265. The teacher-facing **course builder (metadata)**, wired to the #265 API — the Sanity write token never touches the browser.

## What

- **`/teach/courses`** — the caller's own courses with authoring-status labels and a "New course" action. Server component; lists via the #265 mutation using the `authorizeTeacher` caller id.
- **`/teach/courses/new`** and **`/teach/courses/[id]/edit`** — a shared `CourseForm` that `POST`/`PATCH`es `/api/teacher/courses`. Create → redirect to the edit page; **"Submit for review"** `PATCH`es `authoringStatus = pending_review` (edit only — teachers can't self-approve, enforced by #265).
- **Ownership re-checked server-side** on the edit page (teacher owns it, or admin) in addition to the API.
- **`getTeacherCourseEditable`** added to `teacher-mutations.ts` — a full editable-field read for the edit form (his summary projection didn't include description/tags/etc.).
- **`/teach` now redirects to `/teach/courses`** so the "Teach" nav lands on the builder.
- **i18n** — `teacher.courses` + `teacher.form` across en/pt-BR/es (key parity verified).

## Fields

Scalar metadata + tags: title, description, difficulty, duration, tags, xpReward, xpPerLesson. **Thumbnail image upload is intentionally out of scope** — tracked in **#278** (needs a mediated asset-upload endpoint).

## Built on his merged work

#263/#264/#265 were implemented + merged by the maintainer; this consumes his API contract (`GET/POST /api/teacher/courses`, `PATCH /api/teacher/courses/[id]`) and reuses `authorizeTeacher`. The only change to his files is one additive export (`getTeacherCourseEditable`).

## Verification

- `tsc` clean, eslint clean, i18n key parity across the 3 locales
- `next build` passes; `/teach/courses` (+ new/edit) render per-request under the `/teach` gate

Closes #266 · part of #269
