### PR TITLE
feat(teacher): admin review + approval gate + on-chain sync (#268)

### DIFF
--- a/apps/web/src/app/[locale]/admin/admin-client.tsx
+++ b/apps/web/src/app/[locale]/admin/admin-client.tsx
@@ -2,6 +2,10 @@
 
 import { useState, useEffect, useCallback } from "react";
 import { CourseSyncTable } from "@/components/admin/course-sync-table";
+import {
+  CourseReviewQueue,
+  type PendingReviewCourse,
+} from "@/components/admin/course-review-queue";
 import { AchievementSyncTable } from "@/components/admin/achievement-sync-table";
 import { DataResyncPanel } from "@/components/admin/data-resync-panel";
 
@@ -53,6 +57,7 @@ interface AdminStatus {
   };
   courses: CourseStatus[];
   achievements: AchievementStatus[];
+  pendingReviews: PendingReviewCourse[];
 }
 
 export function AdminClient() {
@@ -108,6 +113,7 @@ export function AdminClient() {
   if (!status) return null;
 
   const { program, courses, achievements } = status;
+  const pendingReviews = status.pendingReviews ?? [];
 
   return (
     <div className="space-y-8">
@@ -135,6 +141,32 @@ export function AdminClient() {
           )}
         </div>
       </div>
+
+      {/* Review Queue — teacher-submitted courses awaiting admin approval */}
+      <section>
+        <div className="mb-4 flex items-center justify-between">
+          <h2 className="font-display text-lg font-bold text-text">
+            Review Queue
+            {pendingReviews.length > 0 && (
+              <span className="ml-2 rounded-full bg-primary px-2 py-0.5 text-xs font-bold text-white">
+                {pendingReviews.length}
+              </span>
+            )}
+          </h2>
+          <button
+            onClick={() => void fetchStatus()}
+            className="rounded-md border border-border bg-card px-3 py-1 text-xs text-text-2 shadow-push-sm transition-all hover:bg-subtle active:translate-y-[2px] active:shadow-push-active"
+          >
+            Refresh
+          </button>
+        </div>
+        <div className="rounded-lg border border-border bg-card p-4 shadow-card">
+          <CourseReviewQueue
+            courses={pendingReviews}
+            onRefresh={() => void fetchStatus()}
+          />
+        </div>
+      </section>
 
       {/* Courses */}
       <section>

--- a/apps/web/src/app/api/admin/courses/review/route.ts
+++ b/apps/web/src/app/api/admin/courses/review/route.ts
@@ -1,0 +1,103 @@
+import "server-only";
+
+import { NextRequest, NextResponse } from "next/server";
+import {
+  requireAdminAuth,
+  adminUnauthorizedResponse,
+  AdminAuthError,
+} from "@/lib/admin/auth";
+import { approveCourse, rejectCourse } from "@/lib/sanity/admin-mutations";
+
+// Auth/cookie-gated + Sanity write — never statically prerender.
+export const dynamic = "force-dynamic";
+
+// Upper bound on rejection feedback. Keeps the note human-sized and prevents a
+// malformed/oversized body from being persisted onto the course document.
+const MAX_FEEDBACK_LENGTH = 2000;
+
+/**
+ * Admin-only review action for teacher-submitted courses (issue #268).
+ *
+ * This endpoint sets the authoring status ONLY:
+ *   - approve → authoringStatus = "approved" (clears reviewFeedback)
+ *   - reject  → authoringStatus = "draft" + stores reviewFeedback
+ *
+ * The on-chain course-sync is intentionally NOT triggered here — the admin UI
+ * calls the existing `/api/admin/courses/sync` after a successful approve, so
+ * the complex sync flow lives in exactly one place. The status this endpoint
+ * can write is fixed by the server (approved | draft); arbitrary states can
+ * never be set from client input.
+ */
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  try {
+    requireAdminAuth(req);
+  } catch (e) {
+    if (e instanceof AdminAuthError) return adminUnauthorizedResponse();
+    throw e;
+  }
+
+  let courseId: string;
+  let action: "approve" | "reject";
+  let feedback: string | undefined;
+
+  try {
+    const body = (await req.json()) as {
+      courseId?: unknown;
+      action?: unknown;
+      feedback?: unknown;
+    };
+
+    if (typeof body.courseId !== "string" || body.courseId.trim() === "") {
+      return NextResponse.json(
+        { error: "courseId is required" },
+        { status: 400 }
+      );
+    }
+    courseId = body.courseId;
+
+    if (body.action !== "approve" && body.action !== "reject") {
+      return NextResponse.json(
+        { error: 'action must be "approve" or "reject"' },
+        { status: 400 }
+      );
+    }
+    action = body.action;
+
+    if (action === "reject") {
+      if (typeof body.feedback !== "string" || body.feedback.trim() === "") {
+        return NextResponse.json(
+          { error: "feedback is required when rejecting" },
+          { status: 400 }
+        );
+      }
+      if (body.feedback.length > MAX_FEEDBACK_LENGTH) {
+        return NextResponse.json(
+          {
+            error: `feedback exceeds ${MAX_FEEDBACK_LENGTH} characters`,
+          },
+          { status: 400 }
+        );
+      }
+      feedback = body.feedback;
+    }
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  try {
+    if (action === "approve") {
+      await approveCourse(courseId);
+      return NextResponse.json({ status: "approved" });
+    }
+
+    await rejectCourse(courseId, feedback!);
+    return NextResponse.json({ status: "draft" });
+  } catch (e) {
+    // Generic message only — never leak Sanity internals / stack traces.
+    console.error("[admin/courses/review] mutation failed:", e);
+    return NextResponse.json(
+      { error: "Failed to update course status" },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/web/src/app/api/admin/status/route.ts
+++ b/apps/web/src/app/api/admin/status/route.ts
@@ -11,6 +11,7 @@ import {
 import {
   getAllCoursesAdmin,
   getAllAchievementsAdmin,
+  getPendingReviewCourses,
 } from "@/lib/sanity/queries";
 import {
   findCoursePDA,
@@ -40,11 +41,13 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
 
   const connection = new Connection(serverEnv.SOLANA_RPC_URL, "confirmed");
 
-  const [courses, achievements, authorityCheck] = await Promise.all([
-    getAllCoursesAdmin(),
-    getAllAchievementsAdmin(),
-    verifyAuthorityMatchesConfig(),
-  ]);
+  const [courses, achievements, pendingReviews, authorityCheck] =
+    await Promise.all([
+      getAllCoursesAdmin(),
+      getAllAchievementsAdmin(),
+      getPendingReviewCourses(),
+      verifyAuthorityMatchesConfig(),
+    ]);
 
   const courseStatuses = await Promise.all(
     courses.map(async (course) => {
@@ -177,5 +180,6 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
     },
     courses: courseStatuses,
     achievements: achievementStatuses,
+    pendingReviews,
   });
 }

--- a/apps/web/src/components/admin/course-review-queue.tsx
+++ b/apps/web/src/components/admin/course-review-queue.tsx
@@ -1,0 +1,223 @@
+"use client";
+
+import { useState } from "react";
+
+/** One course awaiting admin review (mirrors the API `pendingReviews` shape). */
+export interface PendingReviewCourse {
+  _id: string;
+  title: string;
+  slug: string | null;
+  difficulty: string | null;
+  author: string | null;
+  authoringStatus: string;
+}
+
+interface CourseReviewQueueProps {
+  courses: PendingReviewCourse[];
+  onRefresh: () => void;
+}
+
+/** Per-row result surfaced after an approve (incl. the chained on-chain sync). */
+interface RowResult {
+  kind: "success" | "error";
+  message: string;
+}
+
+interface ReviewResponse {
+  status?: string;
+  error?: string;
+}
+
+interface SyncResponse {
+  action?: "created" | "updated" | "noop";
+  message?: string;
+  warning?: string;
+  error?: string;
+}
+
+export function CourseReviewQueue({
+  courses,
+  onRefresh,
+}: CourseReviewQueueProps) {
+  const [busy, setBusy] = useState<string | null>(null);
+  const [results, setResults] = useState<Record<string, RowResult>>({});
+
+  function setRowResult(courseId: string, result: RowResult) {
+    setResults((prev) => ({ ...prev, [courseId]: result }));
+  }
+
+  // Approve → set status approved, THEN run the existing on-chain sync so the
+  // course deploys + becomes public. The sync is the same endpoint the sync
+  // table uses; we do NOT reimplement it here.
+  async function handleApprove(courseId: string) {
+    setBusy(courseId);
+    setResults((prev) => {
+      const next = { ...prev };
+      delete next[courseId];
+      return next;
+    });
+    try {
+      const reviewRes = await fetch("/api/admin/courses/review", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ courseId, action: "approve" }),
+      });
+      if (!reviewRes.ok) {
+        const data = (await reviewRes.json()) as ReviewResponse;
+        setRowResult(courseId, {
+          kind: "error",
+          message: data.error ?? "Approval failed",
+        });
+        return;
+      }
+
+      // Status is now "approved"; deploy on-chain via the existing sync flow.
+      const syncRes = await fetch("/api/admin/courses/sync", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ courseId }),
+      });
+      const syncData = (await syncRes.json()) as SyncResponse;
+      if (!syncRes.ok) {
+        setRowResult(courseId, {
+          kind: "error",
+          message: `Approved, but on-chain sync failed: ${
+            syncData.error ?? "unknown error"
+          }. Re-sync from the Courses table.`,
+        });
+        return;
+      }
+
+      const actionLabel =
+        syncData.action === "created"
+          ? "deployed on-chain"
+          : syncData.action === "updated"
+            ? "updated on-chain"
+            : "already synced";
+      setRowResult(courseId, {
+        kind: "success",
+        message: syncData.warning
+          ? `Approved and ${actionLabel}. Warning: ${syncData.warning}`
+          : `Approved and ${actionLabel}.`,
+      });
+    } catch (e) {
+      setRowResult(courseId, {
+        kind: "error",
+        message: e instanceof Error ? e.message : "Approval failed",
+      });
+    } finally {
+      setBusy(null);
+      // Refresh so the approved course leaves the queue.
+      onRefresh();
+    }
+  }
+
+  // Reject → prompt for feedback, then return the course to draft with the note.
+  async function handleReject(courseId: string) {
+    const feedback = prompt(
+      "Rejection feedback for the teacher (required):"
+    )?.trim();
+    if (!feedback) return;
+
+    setBusy(courseId);
+    setResults((prev) => {
+      const next = { ...prev };
+      delete next[courseId];
+      return next;
+    });
+    try {
+      const res = await fetch("/api/admin/courses/review", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ courseId, action: "reject", feedback }),
+      });
+      if (!res.ok) {
+        const data = (await res.json()) as ReviewResponse;
+        setRowResult(courseId, {
+          kind: "error",
+          message: data.error ?? "Rejection failed",
+        });
+        return;
+      }
+      setRowResult(courseId, {
+        kind: "success",
+        message: "Rejected — returned to draft with feedback.",
+      });
+    } catch (e) {
+      setRowResult(courseId, {
+        kind: "error",
+        message: e instanceof Error ? e.message : "Rejection failed",
+      });
+    } finally {
+      setBusy(null);
+      onRefresh();
+    }
+  }
+
+  if (courses.length === 0) {
+    return <p className="text-sm text-text-3">No courses awaiting review.</p>;
+  }
+
+  return (
+    <table className="w-full text-sm">
+      <thead>
+        <tr className="border-b border-border text-left text-xs uppercase tracking-wider text-text-3">
+          <th className="pb-2 pr-4 font-medium">Course</th>
+          <th className="pb-2 pr-4 font-medium">Difficulty</th>
+          <th className="pb-2 font-medium">Action</th>
+        </tr>
+      </thead>
+      <tbody className="divide-y divide-border">
+        {courses.map((course) => {
+          const isBusy = busy === course._id;
+          const result = results[course._id];
+          return (
+            <tr key={course._id} className="transition-colors hover:bg-subtle">
+              <td className="py-3 pr-4">
+                <div className="font-medium text-text">{course.title}</div>
+                {course.slug && (
+                  <div className="mt-0.5 font-mono text-xs text-text-3">
+                    {course.slug}
+                  </div>
+                )}
+                {course.author && (
+                  <div className="mt-0.5 font-mono text-[10px] text-text-3">
+                    author: {course.author}
+                  </div>
+                )}
+                {result && (
+                  <div
+                    className={`mt-1 text-xs ${
+                      result.kind === "error" ? "text-danger" : "text-success"
+                    }`}
+                  >
+                    {result.message}
+                  </div>
+                )}
+              </td>
+              <td className="py-3 pr-4 capitalize text-text">
+                {course.difficulty ?? "—"}
+              </td>
+              <td className="py-3">
+                <button
+                  onClick={() => void handleApprove(course._id)}
+                  disabled={isBusy}
+                  className="rounded-md bg-primary px-3 py-1 font-display text-xs font-bold text-white shadow-push transition-all duration-100 hover:bg-primary-hover active:translate-y-[3px] active:shadow-push-active disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  {isBusy ? "..." : "Approve"}
+                </button>
+                <button
+                  onClick={() => void handleReject(course._id)}
+                  disabled={isBusy}
+                  className="ml-2 rounded-md border border-border px-3 py-1 font-display text-xs font-bold text-text-2 shadow-push-sm transition-all hover:border-danger hover:bg-danger-light hover:text-danger active:translate-y-[2px] active:shadow-push-active disabled:opacity-50"
+                >
+                  {isBusy ? "..." : "Reject"}
+                </button>
+              </td>
+            </tr>
+          );
+        })}
+      </tbody>
+    </table>
+  );
+}

--- a/apps/web/src/lib/sanity/admin-mutations.ts
+++ b/apps/web/src/lib/sanity/admin-mutations.ts
@@ -40,6 +40,37 @@ export async function writeCourseTrackCollection(
     .commit();
 }
 
+/**
+ * Approve a teacher-submitted course (issue #268). Admin-only — the calling
+ * route (`/api/admin/courses/review`) MUST have passed `requireAdminAuth`
+ * first. Sets `authoringStatus = "approved"` and clears any prior
+ * `reviewFeedback`. Does NOT run the on-chain sync; the admin UI triggers the
+ * existing `/api/admin/courses/sync` separately so the complex sync stays in
+ * one place.
+ */
+export async function approveCourse(sanityId: string): Promise<void> {
+  await sanityAdmin
+    .patch(sanityId)
+    .set({ authoringStatus: "approved", reviewFeedback: null })
+    .commit();
+}
+
+/**
+ * Reject a teacher-submitted course (issue #268). Admin-only. Returns the
+ * course to `draft` and stores `feedback` in `reviewFeedback` so the teacher
+ * can see why it was rejected. Feedback length bounding is the caller's
+ * responsibility (enforced in the review route).
+ */
+export async function rejectCourse(
+  sanityId: string,
+  feedback: string
+): Promise<void> {
+  await sanityAdmin
+    .patch(sanityId)
+    .set({ authoringStatus: "draft", reviewFeedback: feedback })
+    .commit();
+}
+
 export async function writeAchievementOnChainStatus(
   sanityId: string,
   achievementPda: string,

--- a/apps/web/src/lib/sanity/queries.ts
+++ b/apps/web/src/lib/sanity/queries.ts
@@ -638,6 +638,42 @@ export async function getAllCoursesAdmin(): Promise<AdminCourse[]> {
 }
 
 /**
+ * A course awaiting admin review (issue #268). Minimal metadata for the admin
+ * review queue — the admin approves (→ on-chain sync) or rejects (→ draft +
+ * feedback) from this list.
+ */
+export interface PendingReviewCourse {
+  _id: string;
+  title: string;
+  slug: string | null;
+  difficulty: string | null;
+  author: string | null;
+  authoringStatus: string;
+}
+
+/**
+ * Fetch courses with `authoringStatus == "pending_review"` for the admin review
+ * queue. Excludes Sanity drafts. Server-side only (admin panel); reads fresh
+ * (revalidate=0) so a just-submitted course appears without CDN lag.
+ */
+export async function getPendingReviewCourses(): Promise<
+  PendingReviewCourse[]
+> {
+  return sanityFetch<PendingReviewCourse[]>(
+    `*[_type == "course" && authoringStatus == "pending_review" && !(_id in path("drafts.**"))] | order(title asc) {
+      _id,
+      title,
+      "slug": slug.current,
+      difficulty,
+      author,
+      authoringStatus
+    }`,
+    undefined,
+    0
+  );
+}
+
+/**
  * Fetch all achievements with on-chain sync fields for the admin dashboard.
  */
 export async function getAllAchievementsAdmin(): Promise<AdminAchievement[]> {

--- a/apps/web/src/lib/sanity/types.ts
+++ b/apps/web/src/lib/sanity/types.ts
@@ -1,6 +1,7 @@
 // `Course` re-exported here carries the optional `author?: string` and
 // `authoringStatus?: "draft" | "pending_review" | "approved"` fields added for
-// teacher-authored courses (issue #263); `AuthoringStatus` is the status union.
+// teacher-authored courses (issue #263), plus `reviewFeedback?: string` (issue
+// #268, admin feedback on rejection); `AuthoringStatus` is the status union.
 export type {
   Course,
   AuthoringStatus,

--- a/packages/types/src/course.ts
+++ b/packages/types/src/course.ts
@@ -117,6 +117,11 @@ export interface Course {
   author?: string;
   /** Authoring workflow state (issue #263). Legacy docs may omit this. */
   authoringStatus?: AuthoringStatus;
+  /**
+   * Admin feedback shown to the teacher when a course is rejected (issue #268).
+   * Admin-managed; cleared on approval.
+   */
+  reviewFeedback?: string;
 }
 
 export interface LearningPath {

--- a/sanity/schemas/course.ts
+++ b/sanity/schemas/course.ts
@@ -155,6 +155,17 @@ export const course = defineType({
       },
     }),
     defineField({
+      name: "reviewFeedback",
+      title: "Review Feedback",
+      type: "text",
+      rows: 3,
+      readOnly: true,
+      hidden: ({ currentUser }) =>
+        !currentUser?.roles?.some((r) => r.name === "administrator"),
+      description:
+        "Admin feedback shown to the teacher when a course is rejected.",
+    }),
+    defineField({
       name: "onChainStatus",
       title: "On-Chain Status",
       type: "object",


### PR DESCRIPTION
## Summary

Admin side of teacher-authored courses (issue #268). A teacher submits a draft for review via the existing #265 API (draft → `pending_review`); this PR gives admins a **review queue** in the existing admin panel to **Approve** (→ publish + deploy on-chain) or **Reject with feedback** (→ back to draft).

Because courses mint soulbound credentials, **approval and on-chain sync stay strictly admin-only**. No teacher-facing `/teach` UI is touched (that's #266/#267).

## Flow

**Approve** (admin panel button):
1. `POST /api/admin/courses/review { courseId, action: "approve" }` → sets `authoringStatus = "approved"`, clears `reviewFeedback`.
2. On success, the UI then calls the **existing** `POST /api/admin/courses/sync { courseId }` to deploy the Course PDA + Metaplex credential collection and make the course public. Its result (`created` / `updated` / `noop` + any `warning`) is surfaced per-row.

**Reject** (admin panel button):
- Prompts for feedback → `POST /api/admin/courses/review { courseId, action: "reject", feedback }` → sets `authoringStatus = "draft"` and stores `reviewFeedback` (visible to the teacher later).

The review endpoint **sets status only** — it never calls the on-chain sync. The complex sync flow stays in exactly one place (`/api/admin/courses/sync`), reused as-is (not reimplemented or refactored).

## Changes

- **Schema**: `reviewFeedback` (`text`) added to `sanity/schemas/course.ts` (admin-managed, admin-only visibility). Mirrored into the shared `Course` type (`packages/types/src/course.ts`) as optional `reviewFeedback?`.
- **Admin mutations** (`lib/sanity/admin-mutations.ts`, `server-only`, `SANITY_ADMIN_TOKEN`): `approveCourse(id)` → `{ authoringStatus: "approved", reviewFeedback: null }`; `rejectCourse(id, feedback)` → `{ authoringStatus: "draft", reviewFeedback: feedback }`.
- **Admin API** `POST /api/admin/courses/review`: `requireAdminAuth` first; strict body validation (non-empty `courseId`; `action` enum `approve|reject`; `feedback` required + length-bounded to 2000 chars for reject). Returns `{ status }` (`approved` | `draft`). Generic errors, no stack traces.
- **Admin query** `getPendingReviewCourses()` (`lib/sanity/queries.ts`): `pending_review` courses, drafts excluded, fresh read.
- **Admin status route** now also returns `pendingReviews` (single fetch feeds the panel, matching existing pattern).
- **Admin UI**: new `CourseReviewQueue` component (mirrors `course-sync-table.tsx`; per-row loading/error/success). Wired into `admin-client.tsx` as a "Review Queue" section with a pending-count badge. Matches the panel's existing hardcoded-string style (the admin panel does not use next-intl).

## Security invariants

- Approve/reject are **admin-only** (`requireAdminAuth` + same-origin CSRF check via the shared admin auth); no new auth surface — reached only through the existing `ADMIN_SECRET` panel.
- The endpoint can set **only** `approved` (approve) or `draft` (reject) — server-fixed, never an arbitrary state from client input.
- `reviewFeedback` is length-bounded (2000 chars); nothing sensitive logged.
- **No `/teach` files touched** — this stays entirely on the admin/backend/schema side. No overlap with #266/#267.

## Verify

- `pnpm --filter @superteam-lms/web typecheck` — zero errors
- `lint` — zero new errors/warnings (touched files clean)
- `build` — succeeds; `/api/admin/courses/review` registered as a dynamic route

Closes #268