### PR TITLE
feat(teacher): wire creator rewards to the instructor's linked wallet (#281)

### DIFF
--- a/apps/web/src/app/api/admin/courses/sync/route.ts
+++ b/apps/web/src/app/api/admin/courses/sync/route.ts
@@ -27,6 +27,13 @@ import {
   writeCourseOnChainStatus,
   writeCourseTrackCollection,
 } from "@/lib/sanity/admin-mutations";
+import { createAdminClient } from "@/lib/supabase/admin";
+
+// Default creator reward for TEACHER-authored courses (those with a real author
+// wallet) when the fields are unset. Platform/admin courses stay at 0. Starting
+// values — tunable per course by an admin (see #281).
+const DEFAULT_CREATOR_REWARD_XP = 500;
+const DEFAULT_MIN_COMPLETIONS_FOR_REWARD = 5;
 
 export async function POST(req: NextRequest): Promise<NextResponse> {
   try {
@@ -105,6 +112,30 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
       prerequisitePda = prereqPda.toBase58();
     }
 
+    // Resolve the on-chain creator: the course author's linked wallet, so the
+    // creator reward (finalize_course) pays the real instructor. Falls back to
+    // the platform authority (deployCoursePda default) when there's no author or
+    // no linked wallet.
+    let creatorWallet: string | undefined;
+    if (course.author) {
+      const supabaseAdmin = createAdminClient();
+      const { data: authorProfile } = await supabaseAdmin
+        .from("profiles")
+        .select("wallet_address")
+        .eq("id", course.author)
+        .maybeSingle();
+      creatorWallet = authorProfile?.wallet_address ?? undefined;
+    }
+    // Teacher-authored courses (real creator wallet) earn a default reward when
+    // unset; platform courses stay at 0. An explicit 0 is preserved.
+    const hasCreatorWallet = Boolean(creatorWallet);
+    const creatorRewardXp =
+      course.creatorRewardXp ??
+      (hasCreatorWallet ? DEFAULT_CREATOR_REWARD_XP : 0);
+    const minCompletionsForReward =
+      course.minCompletionsForReward ??
+      (hasCreatorWallet ? DEFAULT_MIN_COMPLETIONS_FOR_REWARD : 0);
+
     const result = await deployCoursePda({
       courseId,
       lessonCount: course.lessonCount,
@@ -113,8 +144,9 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
       trackId: course.trackId ?? 0,
       trackLevel: course.trackLevel ?? 0,
       prerequisitePda,
-      creatorRewardXp: course.creatorRewardXp ?? 0,
-      minCompletionsForReward: course.minCompletionsForReward ?? 0,
+      creatorWallet,
+      creatorRewardXp,
+      minCompletionsForReward,
     });
 
     if (!result.success) {

--- a/apps/web/src/lib/sanity/queries.ts
+++ b/apps/web/src/lib/sanity/queries.ts
@@ -576,6 +576,7 @@ export interface AdminCourse {
   title: string;
   slug: string;
   difficulty: string;
+  author: string | null;
   xpPerLesson: number | null;
   trackId: number | null;
   trackLevel: number | null;
@@ -628,6 +629,7 @@ export async function getAllCoursesAdmin(): Promise<AdminCourse[]> {
       },
       creatorRewardXp,
       minCompletionsForReward,
+      author,
       "lessonCount": count(modules[]->lessons[]),
       "trackCollectionAddress": onChainStatus.trackCollectionAddress,
       onChainStatus

--- a/apps/web/src/lib/solana/admin-signer.ts
+++ b/apps/web/src/lib/solana/admin-signer.ts
@@ -117,6 +117,12 @@ export interface CreateCourseAdminParams {
   prerequisitePda?: string;
   creatorRewardXp: number;
   minCompletionsForReward: number;
+  /**
+   * Instructor's linked Solana wallet (base58). When set + parseable it becomes
+   * the on-chain `course.creator` (creator-reward recipient); otherwise the
+   * platform authority is used.
+   */
+  creatorWallet?: string;
 }
 
 export interface UpdateCourseAdminParams {
@@ -234,9 +240,23 @@ export async function deployCoursePda(
         ? new PublicKey(params.prerequisitePda)
         : null;
 
+    // Creator = the instructor's linked wallet when supplied + valid, so the
+    // on-chain creator reward (finalize_course) pays the real teacher. Falls back
+    // to the platform authority for admin/platform courses or an unparseable wallet.
+    let creator = _authority.publicKey;
+    if (params.creatorWallet) {
+      try {
+        creator = new PublicKey(params.creatorWallet);
+      } catch {
+        console.warn(
+          `[admin-signer] deployCoursePda(${params.courseId}): invalid creatorWallet "${params.creatorWallet}" — using platform authority as creator.`
+        );
+      }
+    }
+
     const onChainParams: CreateCourseOnChainParams = {
       courseId: params.courseId,
-      creator: _authority.publicKey,
+      creator,
       contentTxId: Array(32).fill(0) as number[],
       lessonCount: params.lessonCount,
       difficulty: params.difficulty,


### PR DESCRIPTION
## What
Instructors earn 0 XP from their courses today because `deployCoursePda` hardcodes `course.creator = platform authority` (so `finalize_course` pays the platform), and `creatorRewardXp` defaults to 0. This wires the on-chain creator to the **real teacher**.

## Changes
- **`deployCoursePda`** (`admin-signer.ts`): new optional `creatorWallet` param → becomes `course.creator` when parseable; falls back to the platform authority otherwise (admin/platform courses, or an unparseable wallet — logged).
- **`/api/admin/courses/sync`**: looks up the course author's `profiles.wallet_address` (service-role) and passes it as the creator. Teacher-authored courses (real wallet) get a default `creatorRewardXp` (500) + `minCompletionsForReward` (5) when unset; platform courses stay 0; an explicit 0 is preserved.
- **`getAllCoursesAdmin`**: now projects `author`.

## Why the finalize side needs no change
`finalizeCourse` already reads `course.creator` dynamically and creates the creator's XP ATA idempotently, then `finalize_course` mints `creator_reward_xp` to it once `total_completions >= min_completions_for_reward`. So setting the creator correctly at create time is sufficient — the real teacher's XP account gets paid.

## Notes / scope
- On-chain `creator` is **immutable post-create**, so this applies to **newly-created** on-chain courses (all teacher-authored courses go through approve→sync). Existing courses keep `creator = platform`.
- The 500/5 defaults are **starting values to tune** with David (economics).
- Not browser-testable (needs an admin sync of a teacher course + a learner completing on devnet); verified via typecheck + lint + review. The finalize path is unchanged.

Closes #281. Part of #269.