### PR TITLE
feat(admin): teacher-role grant/revoke UI in the admin panel

### DIFF
--- a/apps/web/src/app/[locale]/admin/admin-client.tsx
+++ b/apps/web/src/app/[locale]/admin/admin-client.tsx
@@ -8,6 +8,7 @@ import {
 } from "@/components/admin/course-review-queue";
 import { AchievementSyncTable } from "@/components/admin/achievement-sync-table";
 import { DataResyncPanel } from "@/components/admin/data-resync-panel";
+import { TeacherRolesPanel } from "@/components/admin/teacher-roles-panel";
 
 interface DiffEntry {
   field: string;
@@ -217,6 +218,16 @@ export function AdminClient() {
         </h2>
         <div className="rounded-lg border border-border bg-card p-4 shadow-card">
           <DataResyncPanel />
+        </div>
+      </section>
+
+      {/* Teacher Roles */}
+      <section>
+        <h2 className="mb-4 font-display text-lg font-bold text-text">
+          Teacher Roles
+        </h2>
+        <div className="rounded-lg border border-border bg-card p-4 shadow-card">
+          <TeacherRolesPanel />
         </div>
       </section>
     </div>

--- a/apps/web/src/app/api/admin/teachers/route.ts
+++ b/apps/web/src/app/api/admin/teachers/route.ts
@@ -25,6 +25,31 @@ function isAction(value: unknown): value is Action {
 }
 
 /**
+ * GET /api/admin/teachers — list current teachers (for the admin panel).
+ * Admin-only (signed `admin_session` cookie).
+ */
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  try {
+    requireAdminAuth(req);
+  } catch (e) {
+    if (e instanceof AdminAuthError) return adminUnauthorizedResponse();
+    throw e;
+  }
+
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("profiles")
+    .select("id, username, role")
+    .eq("role", "teacher")
+    .order("username");
+
+  if (error) {
+    return NextResponse.json({ error: "Lookup failed" }, { status: 500 });
+  }
+  return NextResponse.json({ teachers: data ?? [] });
+}
+
+/**
  * POST /api/admin/teachers — grant or revoke the `teacher` role for a user,
  * looked up by username. Admin-only (signed `admin_session` cookie).
  *
@@ -77,7 +102,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
 
   const { data: profile, error: lookupError } = await supabase
     .from("profiles")
-    .select("id")
+    .select("id, role")
     .eq("username", username)
     .maybeSingle();
 
@@ -86,6 +111,13 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   }
   if (!profile) {
     return NextResponse.json({ error: "User not found" }, { status: 404 });
+  }
+  // This endpoint only toggles teacher <-> learner; never touch admin accounts.
+  if (profile.role === "admin") {
+    return NextResponse.json(
+      { error: "Refusing to change an admin account's role" },
+      { status: 409 }
+    );
   }
 
   const { error: updateError } = await supabase

--- a/apps/web/src/components/admin/teacher-roles-panel.tsx
+++ b/apps/web/src/components/admin/teacher-roles-panel.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+
+interface TeacherRow {
+  id: string;
+  username: string;
+  role: string;
+}
+
+export function TeacherRolesPanel() {
+  const [username, setUsername] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+  const [teachers, setTeachers] = useState<TeacherRow[]>([]);
+
+  const loadTeachers = useCallback(async () => {
+    try {
+      const res = await fetch("/api/admin/teachers");
+      if (!res.ok) return;
+      const body = (await res.json()) as { teachers?: TeacherRow[] };
+      setTeachers(body.teachers ?? []);
+    } catch {
+      // Non-critical: the list is a convenience view.
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadTeachers();
+  }, [loadTeachers]);
+
+  async function submit(action: "grant" | "revoke", name?: string) {
+    const trimmed = (name ?? username).trim();
+    if (!trimmed) return;
+
+    setLoading(true);
+    setError(null);
+    setNotice(null);
+    try {
+      const res = await fetch("/api/admin/teachers", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ username: trimmed, action }),
+      });
+      const body = (await res.json().catch(() => ({}))) as {
+        error?: string;
+        username?: string;
+      };
+      if (!res.ok) {
+        setError(body.error ?? `Request failed (${res.status})`);
+        return;
+      }
+      setNotice(
+        action === "grant"
+          ? `Granted teacher to @${body.username}`
+          : `Revoked teacher from @${body.username}`
+      );
+      if (!name) setUsername("");
+      await loadTeachers();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Network error");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-text-3">
+        Grant or revoke the <span className="font-medium">teacher</span> role by
+        username. Teachers can author their own courses under{" "}
+        <span className="font-mono">/teach</span>; publishing on-chain still
+        requires admin review. Admin accounts cannot be changed here.
+      </p>
+
+      <div className="flex flex-wrap items-center gap-2">
+        <input
+          type="text"
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+          placeholder="username"
+          className="min-w-48 flex-1 rounded-md border border-border bg-[var(--input)] px-3 py-2 text-sm text-text"
+          aria-label="Username"
+        />
+        <button
+          type="button"
+          onClick={() => void submit("grant")}
+          disabled={loading || !username.trim()}
+          className="rounded-md border border-success bg-success-light px-3 py-2 text-sm font-medium text-success disabled:opacity-50"
+        >
+          Grant teacher
+        </button>
+        <button
+          type="button"
+          onClick={() => void submit("revoke")}
+          disabled={loading || !username.trim()}
+          className="rounded-md border border-border px-3 py-2 text-sm font-medium text-text disabled:opacity-50"
+        >
+          Revoke
+        </button>
+      </div>
+
+      {error && (
+        <div className="rounded-md border border-danger bg-danger-light p-3 text-sm text-danger">
+          {error}
+        </div>
+      )}
+      {notice && (
+        <div className="rounded-md border border-success bg-success-light p-3 text-sm text-success">
+          {notice}
+        </div>
+      )}
+
+      <div>
+        <h4 className="mb-2 text-xs font-semibold uppercase text-text-3">
+          Current teachers ({teachers.length})
+        </h4>
+        {teachers.length === 0 ? (
+          <p className="text-sm text-text-3">No teachers yet.</p>
+        ) : (
+          <ul className="space-y-1">
+            {teachers.map((t) => (
+              <li
+                key={t.id}
+                className="flex items-center justify-between rounded-md border border-border bg-card px-3 py-2 text-sm"
+              >
+                <span className="font-mono text-text">@{t.username}</span>
+                <button
+                  type="button"
+                  onClick={() => void submit("revoke", t.username)}
+                  disabled={loading}
+                  className="text-xs text-danger underline hover:no-underline disabled:opacity-50"
+                >
+                  Revoke
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Adds a **"Teacher Roles"** section to the admin dashboard so an admin can grant/revoke the teacher role from the UI — no more manual DevTools/`curl` call to `POST /api/admin/teachers`.

## What

- **`TeacherRolesPanel`** — username input + Grant / Revoke, and a list of current teachers (each with an inline revoke). Matches the existing admin-panel component style (`admin_session` cookie, hardcoded English like the other admin panels).
- **`GET /api/admin/teachers`** (admin-gated) — lists current teachers so the panel can render them. The existing `POST` (grant/revoke by username) is unchanged in behaviour.
- **Hardened `POST`** — refuse to change an **admin** account's role. The endpoint only ever toggles teacher ↔ learner, but previously would have demoted an admin if their username was passed in; now it 409s. (My earlier issue text claimed this was already enforced — it wasn't, so this makes it true.)

## Verification

- `tsc` clean, eslint clean, `next build` passes (`ƒ /api/admin/teachers`)

## Notes

Requirement 2 from the same request ("add a Teach option in the nav for teachers → /teach") is **already shipped** (nav entry from #273, `/teach` redirect from #266), so there's no work there. The teacher course-stats work is split into #285 (enrolled/completions) and #286 (richer analytics).

Closes #284
