### PR TITLE
fix: readiness-audit quick wins (migration drift, soft-delete RLS, admin brute-force, CODEOWNERS)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,14 @@
+# Code owners — a PR touching a matched path auto-requests review from these
+# owners. With branch protection's "Require review from Code Owners" enabled,
+# this gates merges (readiness gate G7). Add teammates/teams as the team grows.
+
+# Default owner for everything
+*                             @thomgabriel
+
+# Highest-risk surfaces — always review
+/onchain-academy/             @thomgabriel
+/supabase/                    @thomgabriel
+/apps/web/src/lib/solana/     @thomgabriel
+/apps/web/src/middleware.ts   @thomgabriel
+/apps/web/src/lib/csp.ts      @thomgabriel
+/.github/                     @thomgabriel

--- a/apps/web/src/app/api/admin/auth/route.ts
+++ b/apps/web/src/app/api/admin/auth/route.ts
@@ -2,9 +2,28 @@ import "server-only";
 
 import crypto from "crypto";
 import { NextRequest, NextResponse } from "next/server";
+import { isRateLimited } from "@/lib/rate-limit";
 
 export async function POST(req: NextRequest): Promise<NextResponse> {
   try {
+    // Brute-force protection: throttle admin-login attempts per client IP. The
+    // admin secret gates authority-signed on-chain writes, so cap guessing.
+    const ip =
+      req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+      req.headers.get("x-real-ip") ||
+      "unknown";
+    if (
+      await isRateLimited("admin-auth", ip, {
+        maxTokens: 10,
+        refillIntervalMs: 60_000,
+      })
+    ) {
+      return NextResponse.json(
+        { error: "Too many attempts. Try again shortly." },
+        { status: 429 }
+      );
+    }
+
     const body = (await req.json()) as { password?: unknown };
     const { password } = body;
 

--- a/supabase/migrations/20260703150000_reconcile_award_xp_caps.sql
+++ b/supabase/migrations/20260703150000_reconcile_award_xp_caps.sql
@@ -1,0 +1,125 @@
+-- Reconcile award_xp XP caps into the migration chain (readiness audit).
+--
+-- The 2000/award + 5000/day caps live in schema.sql (and the current prod DB)
+-- but were never captured as a migration, so a fresh DB built from the chain
+-- would ship award_xp WITHOUT the caps — silently reopening the XP-integrity
+-- ceiling (G1). This redefines award_xp verbatim from schema.sql so the repo
+-- migration chain reproduces prod. CREATE OR REPLACE keeps existing GRANTs.
+
+CREATE OR REPLACE FUNCTION award_xp(
+  p_user_id UUID,
+  p_amount INTEGER,
+  p_reason TEXT,
+  p_idempotency_key TEXT DEFAULT NULL,
+  p_tx_signature TEXT DEFAULT NULL
+) RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_last_activity DATE;
+  v_current_streak INTEGER;
+  v_longest_streak INTEGER;
+  v_new_streak INTEGER;
+  v_new_longest INTEGER;
+  v_daily_total INTEGER;
+  -- Hard per-award ceiling. Matches the documented "max 2000 XP per award"
+  -- (the largest legitimate single award is a course-completion bonus).
+  c_max_award_xp CONSTANT INTEGER := 2000;
+  -- Per-user daily ceiling across the learning XP path (lessons, challenges,
+  -- bonuses, achievements). Generous enough for normal multi-course days,
+  -- low enough to cap a forged-"passed" farming loop.
+  c_max_daily_award_xp CONSTANT INTEGER := 5000;
+BEGIN
+  -- Reject non-positive awards outright (defensive — callers pass positives).
+  IF p_amount IS NULL OR p_amount <= 0 THEN
+    RETURN;
+  END IF;
+
+  -- Clamp any single award to the hard ceiling.
+  IF p_amount > c_max_award_xp THEN
+    p_amount := c_max_award_xp;
+  END IF;
+
+  -- Serialize concurrent awards for the same user so the read-then-insert daily
+  -- cap below is atomic: without this lock, two parallel awards can both read a
+  -- sub-cap total and both insert, blowing past the daily ceiling.
+  PERFORM pg_advisory_xact_lock(hashtext('award_xp:' || p_user_id::text)::bigint);
+
+  -- Enforce the per-user daily ceiling. Sum today's learning-path awards
+  -- (excluding community XP, which is capped separately) and clamp the credit
+  -- so the daily total can never exceed the ceiling. The window boundary is
+  -- pinned to UTC midnight so it is independent of the DB session timezone.
+  SELECT COALESCE(SUM(amount), 0) INTO v_daily_total
+  FROM public.xp_transactions
+  WHERE user_id = p_user_id
+    AND created_at >= date_trunc('day', now() AT TIME ZONE 'UTC') AT TIME ZONE 'UTC'
+    AND reason NOT LIKE 'community:%';
+
+  IF v_daily_total >= c_max_daily_award_xp THEN
+    RETURN;
+  END IF;
+
+  IF v_daily_total + p_amount > c_max_daily_award_xp THEN
+    p_amount := c_max_daily_award_xp - v_daily_total;
+  END IF;
+
+  IF p_amount <= 0 THEN
+    RETURN;
+  END IF;
+
+  IF p_idempotency_key IS NOT NULL THEN
+    INSERT INTO public.xp_transactions (user_id, amount, reason, idempotency_key, tx_signature)
+    VALUES (p_user_id, p_amount, p_reason, p_idempotency_key, p_tx_signature)
+    ON CONFLICT (user_id, idempotency_key) WHERE idempotency_key IS NOT NULL DO NOTHING;
+
+    -- If nothing was inserted (duplicate), skip the XP update too
+    IF NOT FOUND THEN
+      RETURN;
+    END IF;
+  ELSE
+    INSERT INTO public.xp_transactions (user_id, amount, reason, tx_signature)
+    VALUES (p_user_id, p_amount, p_reason, p_tx_signature);
+  END IF;
+
+  -- Get current streak state before updating
+  SELECT last_activity_date, current_streak, longest_streak
+  INTO v_last_activity, v_current_streak, v_longest_streak
+  FROM public.user_xp
+  WHERE user_id = p_user_id;
+
+  -- Calculate new streak
+  IF v_last_activity IS NULL THEN
+    -- First activity ever
+    v_new_streak := 1;
+  ELSIF v_last_activity = CURRENT_DATE THEN
+    -- Already active today, keep current streak
+    v_new_streak := COALESCE(v_current_streak, 1);
+  ELSIF v_last_activity = CURRENT_DATE - INTERVAL '1 day' THEN
+    -- Active yesterday, increment streak
+    v_new_streak := COALESCE(v_current_streak, 0) + 1;
+  ELSE
+    -- Gap > 1 day, reset streak
+    v_new_streak := 1;
+  END IF;
+
+  v_new_longest := GREATEST(COALESCE(v_longest_streak, 0), v_new_streak);
+
+  INSERT INTO public.user_xp (user_id, total_xp, level, last_activity_date, current_streak, longest_streak)
+  VALUES (
+    p_user_id,
+    p_amount,
+    floor(sqrt(p_amount / 100.0))::int,
+    CURRENT_DATE,
+    v_new_streak,
+    v_new_longest
+  )
+  ON CONFLICT (user_id) DO UPDATE SET
+    total_xp = user_xp.total_xp + p_amount,
+    level = floor(sqrt((user_xp.total_xp + p_amount) / 100.0))::int,
+    last_activity_date = CURRENT_DATE,
+    current_streak = v_new_streak,
+    longest_streak = v_new_longest;
+END;
+$$;

--- a/supabase/migrations/20260703150100_scope_soft_deleted_forum_visibility.sql
+++ b/supabase/migrations/20260703150100_scope_soft_deleted_forum_visibility.sql
@@ -1,0 +1,15 @@
+-- Scope soft-deleted forum content out of the public SELECT (readiness audit).
+--
+-- The threads/answers "Anyone can view" policies were USING(true), so a
+-- soft-deleted row (deleted_at set by soft_delete_thread / soft_delete_answer)
+-- stayed publicly readable. Scope the public read to deleted_at IS NULL.
+-- Moderation/admin paths use the service-role client, which bypasses RLS, so
+-- they still see deleted content for review.
+
+DROP POLICY IF EXISTS "Anyone can view threads" ON threads;
+CREATE POLICY "Anyone can view threads"
+  ON threads FOR SELECT USING (deleted_at IS NULL);
+
+DROP POLICY IF EXISTS "Anyone can view answers" ON answers;
+CREATE POLICY "Anyone can view answers"
+  ON answers FOR SELECT USING (deleted_at IS NULL);

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -1556,7 +1556,7 @@ CREATE POLICY "Anyone can view categories"
   ON forum_categories FOR SELECT USING (true);
 
 CREATE POLICY "Anyone can view threads"
-  ON threads FOR SELECT USING (true);
+  ON threads FOR SELECT USING (deleted_at IS NULL);
 
 CREATE POLICY "Authenticated users can create threads"
   ON threads FOR INSERT
@@ -1586,7 +1586,7 @@ REVOKE UPDATE ON threads FROM anon;
 -- No DELETE policy needed. Soft delete is handled via soft_delete_thread() SECURITY DEFINER function.
 
 CREATE POLICY "Anyone can view answers"
-  ON answers FOR SELECT USING (true);
+  ON answers FOR SELECT USING (deleted_at IS NULL);
 
 CREATE POLICY "Authenticated users can create answers"
   ON answers FOR INSERT


### PR DESCRIPTION
Four low-risk fixes from the **2026-07-03 mainnet-readiness code audit**.

| # | Finding | Fix |
|---|---------|-----|
| 🆕 G1 | **XP-cap migration drift** — 2000/award + 5000/day caps in schema.sql + prod but **no migration**; a fresh DB would ship `award_xp` uncapped | New migration redefines `award_xp` **verbatim** from schema.sql (extracted, not retyped) — repo now reproduces prod |
| §4 | **Soft-deleted forum content publicly readable** — threads/answers SELECT was `USING(true)` | Scope to `deleted_at IS NULL` (migration + schema.sql); service-role moderation still sees them |
| §1.4 / G5 | **Admin-login brute-force** — `/api/admin/auth` unthrottled | Per-IP rate limit (10/min) via the durable `check_rate_limit` limiter |
| G7 | **No CODEOWNERS** | `.github/CODEOWNERS` so branch protection can require code-owner review |

### Apply notes
- `award_xp` migration = **no-op on current prod** (caps already there); it exists so a fresh mainnet DB reproduces them.
- The **soft-delete** migration needs applying to prod to take effect (deleted content stays readable until then). The admin rate-limit + CODEOWNERS take effect on merge/deploy.

### Deferred (not a quick win)
**Deploy-route IDOR** (`/api/deploy/[uuid]`) — the build `uuid` is client-chosen with **no user link** anywhere (cache stores no owner; `deploy/save` doesn't record it), so it's a capability-URL. A correct fix needs a durable `uuid → owner` mapping (table + wiring, applied before the route queries it) — tracked separately.

Verified: `tsc --noEmit` clean, ESLint clean.