### PR TITLE
fix(gamification): seed the 4 community achievements so they're earnable

### DIFF
--- a/sanity/seed/achievements.json
+++ b/sanity/seed/achievements.json
@@ -141,5 +141,57 @@
     "xpReward": 100,
     "maxSupply": 0,
     "metadataUri": "https://superteam-academy.vercel.app/api/achievements/metadata?id=achievement-perfect-score"
+  },
+  {
+    "_id": "achievement-first-comment",
+    "_type": "achievement",
+    "name": "First Comment",
+    "description": "Post your first thread or answer in the community",
+    "icon": "message-circle",
+    "glyph": "“”",
+    "solTier": false,
+    "category": "community",
+    "xpReward": 50,
+    "maxSupply": 0,
+    "metadataUri": "https://superteam-academy.vercel.app/api/achievements/metadata?id=achievement-first-comment"
+  },
+  {
+    "_id": "achievement-curious-mind",
+    "_type": "achievement",
+    "name": "Curious Mind",
+    "description": "Start 10 discussions in the community",
+    "icon": "help-circle",
+    "glyph": "?",
+    "solTier": false,
+    "category": "community",
+    "xpReward": 100,
+    "maxSupply": 0,
+    "metadataUri": "https://superteam-academy.vercel.app/api/achievements/metadata?id=achievement-curious-mind"
+  },
+  {
+    "_id": "achievement-helper",
+    "_type": "achievement",
+    "name": "Helper",
+    "description": "Have 5 of your community answers accepted",
+    "icon": "hand-helping",
+    "glyph": "✓",
+    "solTier": false,
+    "category": "community",
+    "xpReward": 150,
+    "maxSupply": 0,
+    "metadataUri": "https://superteam-academy.vercel.app/api/achievements/metadata?id=achievement-helper"
+  },
+  {
+    "_id": "achievement-top-contributor",
+    "_type": "achievement",
+    "name": "Top Contributor",
+    "description": "Earn 500 community XP by helping others",
+    "icon": "award",
+    "glyph": "★",
+    "solTier": true,
+    "category": "community",
+    "xpReward": 250,
+    "maxSupply": 0,
+    "metadataUri": "https://superteam-academy.vercel.app/api/achievements/metadata?id=achievement-top-contributor"
   }
 ]


### PR DESCRIPTION
From the readiness audit (§7, dead-achievements). `first-comment`, `curious-mind`, `helper`, and `top-contributor` have unlock logic in `achievements.ts` (UNLOCK_CHECKS) but were **never seeded in Sanity** — so they could never be granted. Adds the 4 seed docs (category `community`, `_id` matching UNLOCK_CHECKS keys).

- Seed count 11 → **15** (matches the 15 code-defined achievements).
- They become grantable once deployed on-chain via the existing admin achievement sync.

**Not touched here (flagged):** `perfect-score` is seeded but un-earnable — `allTestsPassedFirstTry` is hardcoded `false` (needs per-lesson first-try attempt tracking). That's a build-or-hide product decision, not a mechanical fix.