### PR TITLE
fix(dashboard): bound the unbounded activity-feed query (readiness §8)

### DIFF
--- a/apps/web/src/app/[locale]/(platform)/dashboard/page.tsx
+++ b/apps/web/src/app/[locale]/(platform)/dashboard/page.tsx
@@ -180,12 +180,16 @@ function useDashboardData(
           .select("id", { count: "exact", head: true })
           .eq("user_id", authUserId);
 
-        // Fetch all XP transactions for the activity feed
+        // Fetch recent XP transactions for the activity feed + recent-course
+        // resolution. Bounded: the feed shows a handful of recent items and this
+        // set only drives recent-activity lookups — an unbounded fetch grew with
+        // every lesson a user ever completed.
         const { data: transactions } = await supabase
           .from("xp_transactions")
           .select("amount, reason, created_at, tx_signature")
           .eq("user_id", authUserId)
-          .order("created_at", { ascending: false });
+          .order("created_at", { ascending: false })
+          .limit(100);
 
         // Fetch activity dates for streak heatmap (last 270 days)
         const oneYearAgo = new Date();


### PR DESCRIPTION
Readiness audit §8-HIGH. The dashboard fetched **all** of a user's `xp_transactions` with no `.limit()` — growing forever — to render a short activity feed + resolve recently-referenced courses. Add `.limit(100)`.

- The adjacent streak-heatmap query is already date-bounded (270d).
- Total XP comes from `user_xp`, and the two loops over `transactions` only parse reasons for the feed + recent-course IDs — so bounding to recent rows changes no displayed counts.
- (Optional follow-up: a composite `(user_id, created_at desc)` index — that's a gated DB migration, deferred.)