### PR TITLE
fix(seo): real course title + OG image in metadata (readiness §4)

### DIFF
--- a/apps/web/src/app/[locale]/(platform)/courses/[slug]/layout.tsx
+++ b/apps/web/src/app/[locale]/(platform)/courses/[slug]/layout.tsx
@@ -1,18 +1,45 @@
 import type { Metadata } from "next";
+import { getCourseBySlug } from "@/lib/sanity/queries";
 
-export function generateMetadata({
+export async function generateMetadata({
   params,
 }: {
   params: { slug: string };
-}): Metadata {
-  const title = params.slug
-    .split("-")
-    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-    .join(" ");
+}): Promise<Metadata> {
+  const course = await getCourseBySlug(params.slug);
+
+  // Course not found / not yet public — fall back to a slug-derived title.
+  if (!course) {
+    const fallback = params.slug
+      .split("-")
+      .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+      .join(" ");
+    return {
+      title: fallback,
+      description: `Learn ${fallback} on Superteam Academy — the Solana developer education platform.`,
+    };
+  }
+
+  const description =
+    course.description ??
+    `Learn ${course.title} on Superteam Academy — the Solana developer education platform.`;
+  const images = course.thumbnail ? [{ url: course.thumbnail }] : undefined;
 
   return {
-    title,
-    description: `Learn ${title} on Superteam LMS — the Solana developer education platform.`,
+    title: course.title,
+    description,
+    openGraph: {
+      title: course.title,
+      description,
+      type: "website",
+      images,
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: course.title,
+      description,
+      images: course.thumbnail ? [course.thumbnail] : undefined,
+    },
   };
 }
 


### PR DESCRIPTION
Readiness audit §4/SEO. Course `generateMetadata` fabricated the title from the slug (tabs + social share cards showed the wrong name) with **no OG image**. Now fetches the course (`getCourseBySlug`, ISR-cached) and uses the real **title + description + thumbnail** as the OG/Twitter image; falls back to a slug-derived title when a course isn't public. Also corrects stale 'Superteam LMS' → 'Superteam Academy'.