### PR TITLE
feat(teacher-courses): per-course overview — enrolled & completion counts

### DIFF
--- a/apps/web/src/app/[locale]/(platform)/teach/courses/[id]/page.tsx
+++ b/apps/web/src/app/[locale]/(platform)/teach/courses/[id]/page.tsx
@@ -1,0 +1,81 @@
+import Link from "next/link";
+import { notFound, redirect } from "next/navigation";
+import { getTranslations } from "next-intl/server";
+import { authorizeTeacher } from "@/lib/teacher/authorize";
+import { getTeacherCourseEditable } from "@/lib/sanity/teacher-mutations";
+import { getCourseStats } from "@/lib/teacher/stats";
+
+export const dynamic = "force-dynamic";
+
+function statusKey(s: string | null): "statusDraft" | "statusPendingReview" | "statusApproved" {
+  return s === "pending_review"
+    ? "statusPendingReview"
+    : s === "approved"
+      ? "statusApproved"
+      : "statusDraft";
+}
+
+export default async function CourseOverviewPage({
+  params,
+}: {
+  params: Promise<{ locale: string; id: string }>;
+}) {
+  const { locale, id } = await params;
+
+  const auth = await authorizeTeacher();
+  if (!auth.ok) redirect(`/${locale}`);
+
+  const course = await getTeacherCourseEditable(id);
+  if (!course) notFound();
+  if (auth.caller.role !== "admin" && course.author !== auth.caller.userId) {
+    redirect(`/${locale}/teach/courses`);
+  }
+
+  const stats = await getCourseStats(id);
+  const t = await getTranslations("teacher.overview");
+  const tc = await getTranslations("teacher.courses");
+
+  const cards = [
+    { label: t("enrolled"), value: stats.enrolledCount },
+    { label: t("completions"), value: stats.completionCount },
+    { label: t("certificates"), value: stats.certificateCount },
+  ];
+
+  return (
+    <div className="mx-auto max-w-4xl px-4 py-8">
+      <Link
+        href={`/${locale}/teach/courses`}
+        className="text-sm text-text-3 underline hover:no-underline"
+      >
+        &larr; {t("back")}
+      </Link>
+
+      <div className="mb-6 mt-3 flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h1 className="font-display text-2xl font-bold text-text">
+            {course.title ?? tc("untitled")}
+          </h1>
+          <p className="text-xs text-text-3">{tc(statusKey(course.authoringStatus))}</p>
+        </div>
+        <Link
+          href={`/${locale}/teach/courses/${id}/edit`}
+          className="rounded-md border border-primary bg-primary px-4 py-2 text-sm font-medium text-primary-foreground"
+        >
+          {t("edit")}
+        </Link>
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-3">
+        {cards.map((c) => (
+          <div
+            key={c.label}
+            className="rounded-lg border border-border bg-card p-5 shadow-card"
+          >
+            <p className="text-3xl font-bold text-text">{c.value}</p>
+            <p className="mt-1 text-sm text-text-3">{c.label}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/[locale]/(platform)/teach/courses/page.tsx
+++ b/apps/web/src/app/[locale]/(platform)/teach/courses/page.tsx
@@ -69,10 +69,10 @@ export default async function TeacherCoursesPage({
                 </p>
               </div>
               <Link
-                href={`/${locale}/teach/courses/${c._id}/edit`}
+                href={`/${locale}/teach/courses/${c._id}`}
                 className="text-sm text-primary underline hover:no-underline"
               >
-                {t("edit")}
+                {t("manage")}
               </Link>
             </li>
           ))}

--- a/apps/web/src/app/api/teacher/courses/[id]/stats/route.ts
+++ b/apps/web/src/app/api/teacher/courses/[id]/stats/route.ts
@@ -1,0 +1,39 @@
+import "server-only";
+
+import { NextRequest, NextResponse } from "next/server";
+import { authorizeTeacher } from "@/lib/teacher/authorize";
+import { getCourseAuthorship } from "@/lib/sanity/teacher-mutations";
+import { getCourseStats } from "@/lib/teacher/stats";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/teacher/courses/[id]/stats — headline stats for a course the caller
+ * owns (enrolled / completions / certificates). Ownership is checked against
+ * the course's `author` (teacher owns it, or admin); the aggregation runs
+ * server-side against Supabase.
+ */
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<NextResponse> {
+  const auth = await authorizeTeacher();
+  if (!auth.ok) {
+    return NextResponse.json(
+      { error: auth.status === 401 ? "Unauthorized" : "Forbidden" },
+      { status: auth.status }
+    );
+  }
+
+  const { id } = await params;
+  const course = await getCourseAuthorship(id);
+  if (!course) {
+    return NextResponse.json({ error: "Course not found" }, { status: 404 });
+  }
+  if (auth.caller.role !== "admin" && course.author !== auth.caller.userId) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const stats = await getCourseStats(id);
+  return NextResponse.json(stats);
+}

--- a/apps/web/src/lib/teacher/stats.ts
+++ b/apps/web/src/lib/teacher/stats.ts
@@ -1,0 +1,43 @@
+import "server-only";
+import { createAdminClient } from "@/lib/supabase/admin";
+
+export interface CourseStats {
+  /** Learners enrolled in the course. */
+  enrolledCount: number;
+  /** Enrollments the learner has finished (course finalized on-chain). */
+  completionCount: number;
+  /** Credential NFTs minted for the course. */
+  certificateCount: number;
+}
+
+/**
+ * Aggregate a course's headline stats from Supabase. SERVER-ONLY; the caller
+ * (teacher API / overview page) must verify course ownership first. Uses the
+ * service-role client with head+count queries (no rows transferred).
+ * `course_id` is the Sanity course _id, as used across enrollments/certificates.
+ */
+export async function getCourseStats(courseId: string): Promise<CourseStats> {
+  const admin = createAdminClient();
+
+  const [enrolled, completed, certs] = await Promise.all([
+    admin
+      .from("enrollments")
+      .select("id", { count: "exact", head: true })
+      .eq("course_id", courseId),
+    admin
+      .from("enrollments")
+      .select("id", { count: "exact", head: true })
+      .eq("course_id", courseId)
+      .not("completed_at", "is", null),
+    admin
+      .from("certificates")
+      .select("id", { count: "exact", head: true })
+      .eq("course_id", courseId),
+  ]);
+
+  return {
+    enrolledCount: enrolled.count ?? 0,
+    completionCount: completed.count ?? 0,
+    certificateCount: certs.count ?? 0,
+  };
+}

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -38,7 +38,15 @@
       "untitled": "Untitled course",
       "statusDraft": "Draft",
       "statusPendingReview": "Pending review",
-      "statusApproved": "Approved"
+      "statusApproved": "Approved",
+      "manage": "Manage"
+    },
+    "overview": {
+      "enrolled": "Enrolled",
+      "completions": "Completions",
+      "certificates": "Certificates",
+      "edit": "Edit course",
+      "back": "Back to courses"
     },
     "form": {
       "createHeading": "New course",

--- a/apps/web/src/messages/es.json
+++ b/apps/web/src/messages/es.json
@@ -38,7 +38,15 @@
       "untitled": "Curso sin título",
       "statusDraft": "Borrador",
       "statusPendingReview": "En revisión",
-      "statusApproved": "Aprobado"
+      "statusApproved": "Aprobado",
+      "manage": "Gestionar"
+    },
+    "overview": {
+      "enrolled": "Inscritos",
+      "completions": "Finalizaciones",
+      "certificates": "Certificados",
+      "edit": "Editar curso",
+      "back": "Volver a los cursos"
     },
     "form": {
       "createHeading": "Nuevo curso",

--- a/apps/web/src/messages/pt-BR.json
+++ b/apps/web/src/messages/pt-BR.json
@@ -38,7 +38,15 @@
       "untitled": "Curso sem título",
       "statusDraft": "Rascunho",
       "statusPendingReview": "Em revisão",
-      "statusApproved": "Aprovado"
+      "statusApproved": "Aprovado",
+      "manage": "Gerenciar"
+    },
+    "overview": {
+      "enrolled": "Inscritos",
+      "completions": "Conclusões",
+      "certificates": "Certificados",
+      "edit": "Editar curso",
+      "back": "Voltar aos cursos"
     },
     "form": {
       "createHeading": "Novo curso",

--- a/supabase/migrations/20260704120000_add_certificates_course_id_index.sql
+++ b/supabase/migrations/20260704120000_add_certificates_course_id_index.sql
@@ -1,0 +1,7 @@
+-- Migration: add_certificates_course_id_index
+-- The teacher per-course overview (#285) counts certificates by course_id via a
+-- head+count query. `certificates` was only indexed on user_id, so that query
+-- would sequential-scan as certificate volume grows. Mirror the existing
+-- idx_enrollments_course_id and add the missing index.
+CREATE INDEX IF NOT EXISTS idx_certificates_course_id
+  ON certificates (course_id);

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -180,6 +180,8 @@ CREATE UNIQUE INDEX idx_xp_transactions_idempotency
   WHERE idempotency_key IS NOT NULL;
 CREATE INDEX idx_user_achievements_user_id ON user_achievements(user_id);
 CREATE INDEX idx_certificates_user_id ON certificates(user_id);
+-- Per-course certificate counts (teacher overview, #285) filter by course_id.
+CREATE INDEX idx_certificates_course_id ON certificates(course_id);
 -- One mint tx == one certificate row. Partial so NULL-signature rows
 -- (off-chain / resync) stay allowed while real mint signatures can't collide.
 CREATE UNIQUE INDEX idx_certificates_tx_signature_unique


### PR DESCRIPTION
## Summary

Second PR of the teacher course-analytics work. Gives teachers a **per-course overview** with the headline numbers — enrolled learners, completions, certificates.

## What

- **`lib/teacher/stats.ts`** — `getCourseStats` aggregates from Supabase with head+count queries (no rows transferred): `enrolledCount`, `completionCount` (enrollments with `completed_at` set), `certificateCount`. `course_id` is the Sanity course _id, as used across the DB.
- **`GET /api/teacher/courses/[id]/stats`** — ownership-checked (course `author`, or admin); returns the stats. Server-side only; no direct client DB access.
- **`/teach/courses/[id]`** (new overview page) — course title + authoring status, three stat cards, and an **Edit** button into the builder.
- The course list now links each row to the overview (**"Manage"**); the overview links on to the edit/builder page (so: list → overview → edit).
- `teacher.overview` + `teacher.courses.manage` i18n across en/pt-BR/es.

## Acceptance criteria

- [x] Teacher sees enrolled + completion counts for their OWN courses (cross-author → 403 / redirect)
- [x] Counts aggregated server-side from Supabase, mediated (token/service-role never in the browser)
- [x] `tsc` + lint + build clean; i18n parity

## Notes

Builds on the merged #263–#268 + #284. Richer analytics (completion funnel, XP, recent activity) is the follow-up #286.

Closes #285
