### PR TITLE
chore(readiness): staging guide + read-path load test (G8)

### DIFF
--- a/.env.staging.example
+++ b/.env.staging.example
@@ -1,0 +1,73 @@
+# =============================================================================
+# Superteam Academy — STAGING environment (example)
+# =============================================================================
+# Copy to `.env.staging` (gitignored) or paste into the Vercel *Preview*
+# environment for your staging deploy, then fill in staging-scoped values.
+#
+# RULES:
+#   - Never commit real values. This file ships blank placeholders only.
+#   - Point every NEXT_PUBLIC_* at DEVNET + the STAGING Supabase/Sanity project.
+#     Staging must NOT share a database, mint, or program with production.
+#   - Keep all server-only secrets (no NEXT_PUBLIC_ prefix) staging-scoped.
+#   - See docs/STAGING.md for the full setup, and docs/DEPLOYMENT.md for the
+#     authoritative variable reference.
+# =============================================================================
+
+# --- Required: Supabase (staging project or branch) --------------------------
+NEXT_PUBLIC_SUPABASE_URL=
+NEXT_PUBLIC_SUPABASE_ANON_KEY=
+# Server-only — never exposed to the browser.
+SUPABASE_SERVICE_ROLE_KEY=
+
+# --- Required: Sanity (staging dataset recommended) --------------------------
+NEXT_PUBLIC_SANITY_PROJECT_ID=
+NEXT_PUBLIC_SANITY_DATASET=production
+
+# --- Required: Solana (DEVNET for staging) -----------------------------------
+NEXT_PUBLIC_SOLANA_RPC_URL=https://api.devnet.solana.com
+NEXT_PUBLIC_SOLANA_NETWORK=devnet
+# Program ID of the devnet-deployed program (see docs/DEPLOY-PROGRAM.md).
+NEXT_PUBLIC_PROGRAM_ID=
+# XP mint pubkey from the initialize step.
+NEXT_PUBLIC_XP_MINT_ADDRESS=
+
+# --- Required: App URL -------------------------------------------------------
+# Your staging Vercel URL (e.g. https://academy-staging.vercel.app).
+NEXT_PUBLIC_APP_URL=
+
+# --- Required: Build server (Cloud Run) --------------------------------------
+BUILD_SERVER_URL=
+BUILD_SERVER_API_KEY=
+
+# --- Required: Helius (devnet) -----------------------------------------------
+HELIUS_API_KEY=
+# Shared secret for /api/webhooks/helius signature verification.
+HELIUS_WEBHOOK_SECRET=
+
+# --- Required: On-chain authority keypairs (staging/devnet, base58) ----------
+# Config PDA authority — admin panel on-chain deployments.
+PROGRAM_AUTHORITY_SECRET=
+# Backend signer registered in Config.backend_signer — signs lesson completions.
+BACKEND_SIGNER_SECRET=
+# XP mint authority — wallet link/unlink XP transfers.
+XP_MINT_AUTHORITY_SECRET=
+
+# --- Required: Admin & CMS write ---------------------------------------------
+# Admin panel password (min 32 chars) — gates /{locale}/admin.
+ADMIN_SECRET=
+# Sanity write token — updates onChainStatus after on-chain deployment.
+SANITY_ADMIN_TOKEN=
+
+# --- Optional: Rust playground proxy -----------------------------------------
+RUST_PLAYGROUND_URL=
+
+# --- Optional: Permanent credential storage (Irys/Arweave) -------------------
+# Solana keypair (JSON array of 64 bytes) funded with SOL. Unset -> mint falls
+# back to /api/certificates/metadata. Not required for devnet staging.
+ARWEAVE_UPLOADER_SECRET=
+
+# --- Optional: Analytics (leave blank on staging to avoid polluting prod data)
+NEXT_PUBLIC_GA4_MEASUREMENT_ID=
+NEXT_PUBLIC_POSTHOG_KEY=
+NEXT_PUBLIC_POSTHOG_HOST=https://app.posthog.com
+NEXT_PUBLIC_SENTRY_DSN=

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ Thumbs.db
 .env.*
 .env*.local
 !.env.example
+!.env.staging.example
 
 # IDE / Editor
 .idea/

--- a/docs/STAGING.md
+++ b/docs/STAGING.md
@@ -1,0 +1,170 @@
+# Staging Environment Guide
+
+Readiness item **G8**. How to stand up a staging environment for Superteam
+Academy that mirrors production topology (Vercel + Supabase + Sanity + Helius +
+Cloud Run) without touching prod data, and how to run the read-path load test
+against it.
+
+Staging exists to rehearse deploys and run load tests **safely**. The golden
+rule: **staging must never share a database, XP mint, program, or webhook with
+production.** Everything points at **devnet** and a **separate Supabase**
+project/branch.
+
+- Full deploy reference: [`docs/DEPLOYMENT.md`](./DEPLOYMENT.md)
+- Env-var placeholders: [`.env.staging.example`](../.env.staging.example)
+- Load test: [`scripts/load/README.md`](../scripts/load/README.md)
+
+---
+
+## Topology at a glance
+
+| Layer            | Production                         | Staging                                              |
+| ---------------- | ---------------------------------- | ---------------------------------------------------- |
+| Frontend         | Vercel Production deploy (`main`)  | Vercel **Preview** env (staging branch or PR)        |
+| Database         | Supabase prod project              | Supabase **branch** _or_ a separate staging project  |
+| CMS              | Sanity `production` dataset        | Same project; `production` (or a `staging` dataset)  |
+| Chain            | mainnet-beta / devnet              | **devnet** always                                    |
+| RPC + webhooks   | Helius (prod webhook)              | Helius (separate **devnet** webhook → staging URL)   |
+| Build server     | Cloud Run (shared)                 | Same Cloud Run service (stateless) or a staging one  |
+
+---
+
+## 1. Supabase: branch or separate project
+
+Two options — pick based on how isolated you need staging to be.
+
+### Option A — Supabase branch (fast, ephemeral)
+
+If the project is on a plan with [database branching](https://supabase.com/docs/guides/deployment/branching),
+create a branch off the prod project. It clones the schema and gives you a
+separate connection string, keys, and data namespace — ideal for short-lived
+staging.
+
+- Create the branch from the Supabase dashboard (Branches) or CLI.
+- Grab the branch's Project URL + anon + service-role keys for the env vars in
+  §4.
+
+### Option B — Separate staging project (durable)
+
+For a long-lived staging environment, create a **new** Supabase project
+(`superteam-academy-staging`) and apply the same migrations:
+
+```bash
+# From supabase/ — apply the full schema to the staging project
+supabase link --project-ref <STAGING_PROJECT_REF>
+supabase db push        # or run supabase/schema.sql against the staging DB
+```
+
+Then, exactly as in [`docs/DEPLOYMENT.md`](./DEPLOYMENT.md) §Supabase Setup:
+
+- **Verify RLS is enabled** on all tables (staging is still exposed to the
+  internet — do not relax RLS).
+- Add the staging Vercel URL to **Auth → Redirect URLs**.
+- Enable the Google OAuth provider if you're testing sign-in (use a staging
+  OAuth client, not the prod one).
+
+> Do **not** copy production user data into staging. Seed with test content
+> (`sanity/seed/`) and test accounts only.
+
+---
+
+## 2. Sanity: dataset
+
+The simplest path is to reuse the existing Sanity project and its `production`
+dataset (content is not user data). If you want editorial isolation, create a
+`staging` dataset and set `NEXT_PUBLIC_SANITY_DATASET=staging`. Add the staging
+Vercel URL to **Sanity → API → CORS origins** either way.
+
+---
+
+## 3. Solana + Helius: devnet only
+
+Staging always runs against **devnet**:
+
+- `NEXT_PUBLIC_SOLANA_NETWORK=devnet`
+- `NEXT_PUBLIC_SOLANA_RPC_URL=https://api.devnet.solana.com` (or your Helius
+  devnet RPC URL)
+- `NEXT_PUBLIC_PROGRAM_ID` + `NEXT_PUBLIC_XP_MINT_ADDRESS` = the **devnet**
+  program and mint (see [`docs/DEPLOY-PROGRAM.md`](./DEPLOY-PROGRAM.md)).
+
+Create a **separate Helius webhook** for staging pointed at
+`https://<staging-url>/api/webhooks/helius`, with its own
+`HELIUS_WEBHOOK_SECRET`. Never repoint the production webhook at staging — that
+would leak prod on-chain events into the staging DB (and vice versa).
+
+---
+
+## 4. Vercel: preview/staging deployment
+
+Staging rides on Vercel's **Preview** environment.
+
+1. **Push a staging branch** (or open a PR). Vercel auto-builds a Preview
+   deployment for every branch/PR — that URL is your staging site. For a stable
+   URL, keep a long-lived `staging` branch and use its Preview URL, or assign a
+   custom domain (e.g. `academy-staging.example.com`) to it.
+2. **Set Preview env vars**: Vercel → Project → Settings → Environment
+   Variables, scope = **Preview**. Fill in every variable from
+   [`.env.staging.example`](../.env.staging.example) with staging-scoped values:
+   - `NEXT_PUBLIC_*` → devnet + the **staging** Supabase/Sanity project.
+   - Server secrets (`SUPABASE_SERVICE_ROLE_KEY`, `*_AUTHORITY_SECRET`,
+     `BACKEND_SIGNER_SECRET`, `XP_MINT_AUTHORITY_SECRET`, `ADMIN_SECRET`,
+     `HELIUS_*`, `BUILD_SERVER_*`, `SANITY_ADMIN_TOKEN`) → staging values,
+     **Preview-scoped so they never bleed into Production**.
+   - `NEXT_PUBLIC_APP_URL` → the staging URL (drives sitemap + OG tags).
+   - Leave analytics keys blank on staging to avoid polluting prod dashboards.
+
+See the annotated variable list in [`docs/DEPLOYMENT.md`](./DEPLOYMENT.md)
+§Environment Variables for what each one does and whether it's public.
+
+---
+
+## 5. Build server (Cloud Run)
+
+The Anchor build server is stateless and auth-gated by `BUILD_SERVER_API_KEY`,
+so staging can point `BUILD_SERVER_URL` at the **same** Cloud Run service as
+prod. If you'd rather isolate build load, deploy a second Cloud Run service per
+[`docs/DEPLOYMENT.md`](./DEPLOYMENT.md) §Build Server and use its URL + key.
+
+---
+
+## 6. Smoke-check staging
+
+Before load-testing, confirm the deploy is healthy:
+
+```bash
+STAGING=https://academy-staging.example.com
+
+curl -sS -o /dev/null -w "%{http_code}\n" "$STAGING/en"                    # landing -> 200
+curl -sS -o /dev/null -w "%{http_code}\n" "$STAGING/en/courses"            # catalog -> 200
+curl -sS -o /dev/null -w "%{http_code}\n" "$STAGING/api/leaderboard?timeframe=weekly"  # 200
+curl -sS -o /dev/null -w "%{http_code}\n" "$STAGING/sitemap.xml"           # 200
+```
+
+---
+
+## 7. Run the load test against staging
+
+Once staging is green, run the read-path k6 test against it. It exercises
+**public GET paths only** — no writes, no auth, no mint/chain calls.
+
+```bash
+BASE_URL=https://academy-staging.example.com k6 run scripts/load/load-test.js
+```
+
+Full instructions, install steps, and threshold meanings:
+[`scripts/load/README.md`](../scripts/load/README.md).
+
+> [!CAUTION]
+> Run the load test against **staging or localhost only — never production.**
+> The script guards against the known prod hosts, but the responsibility to
+> point it at the right target is yours.
+
+---
+
+## Teardown
+
+- **Supabase branch**: delete the branch when done (Option A).
+- **Vercel Preview**: preview deploys are disposable; delete the staging branch
+  or leave it — no Production impact.
+- **Helius**: delete the staging devnet webhook so it stops consuming events.
+- **Cloud Run**: nothing to tear down if you reused the prod service.

--- a/scripts/load/README.md
+++ b/scripts/load/README.md
@@ -1,0 +1,119 @@
+# Read-path load test (k6)
+
+Readiness item **G8**. A [k6](https://k6.io) script that exercises Superteam
+Academy's **public, read-only** paths under a ramping load, so you can gauge
+latency and error rates before a launch push.
+
+> [!CAUTION]
+> **NEVER run this against production.** The script defaults to
+> `http://localhost:3000` and refuses to target the known prod hosts
+> (`solarium.courses`, `superteam-academy-web.vercel.app`). Point it at
+> **localhost** or a dedicated **staging** deploy only. Load-testing prod can
+> trip rate limits, skew analytics, exhaust Supabase/Helius quotas, and page
+> on-call.
+
+## What it hits (all GET, no auth, no writes)
+
+| Tag               | Path                          | Notes                                   |
+| ----------------- | ----------------------------- | --------------------------------------- |
+| `landing`         | `/{locale}`                   | Marketing landing page                  |
+| `courses_list`    | `/{locale}/courses`           | Course catalog                          |
+| `course_detail`   | `/{locale}/courses/{slug}`    | One course (slug auto-discovered)       |
+| `leaderboard_api` | `/api/leaderboard?timeframe=weekly` | XP rankings API (public GET)      |
+| `community`       | `/{locale}/community`         | Forum home                              |
+| `sitemap`         | `/sitemap.xml`                | Dynamic sitemap                         |
+
+The course slug is discovered at runtime from `/sitemap.xml` in the k6 `setup()`
+stage, so the test always hits a real course. If discovery fails and no
+`COURSE_SLUG` is set, the course-detail request is skipped rather than 404ing.
+
+The script makes **only** `GET` requests. It never authenticates, posts, mints
+XP, touches the chain, or mutates data. Do not add non-GET requests to it.
+
+## Install k6
+
+k6 is a standalone Go binary — no Node dependency.
+
+```bash
+# macOS
+brew install k6
+
+# Debian / Ubuntu
+sudo gpg -k
+sudo gpg --no-default-keyring --keyring /usr/share/keyrings/k6-archive-keyring.gpg \
+  --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C5AD17C747E3415A3642D57D77C6C491D6AC1D69
+echo "deb [signed-by=/usr/share/keyrings/k6-archive-keyring.gpg] https://dl.k6.io/deb stable main" \
+  | sudo tee /etc/apt/sources.list.d/k6.list
+sudo apt-get update && sudo apt-get install k6
+
+# Windows
+winget install k6 --source winget
+
+# Docker (no install)
+docker run --rm -i grafana/k6 run - < scripts/load/load-test.js
+```
+
+Other options: <https://grafana.com/docs/k6/latest/set-up/install-k6/>.
+
+## Run it
+
+### Against a local dev server (default target)
+
+```bash
+cd apps/web && pnpm dev          # in one terminal — starts http://localhost:3000
+k6 run scripts/load/load-test.js # in another — no BASE_URL needed
+```
+
+### Against a staging deploy
+
+`BASE_URL` is **required** to target anything other than localhost. No trailing
+slash.
+
+```bash
+BASE_URL=https://academy-staging.example.com k6 run scripts/load/load-test.js
+```
+
+### Optional overrides
+
+| Env var       | Default                 | Purpose                                             |
+| ------------- | ----------------------- | --------------------------------------------------- |
+| `BASE_URL`    | `http://localhost:3000` | Target origin. Required for non-localhost.          |
+| `LOCALE`      | `en`                    | Locale prefix (`en`, `pt-BR`, `es`).                |
+| `COURSE_SLUG` | _(auto from sitemap)_   | Force a specific course slug.                       |
+| `ALLOW_PROD`  | _(unset)_               | Escape hatch for the prod-host guard. Avoid.        |
+
+## Load profile & thresholds
+
+**Profile** (`options.stages`): ramp 0 → 50 VUs over 30s, hold at 50 VUs for
+1m, ramp down to 0 over 30s. Adjust `stages` to model your expected traffic.
+
+**Thresholds** (`options.thresholds`) — the run **fails** (non-zero exit) if any
+are breached, so it's CI-friendly:
+
+| Threshold                                  | Meaning                                            |
+| ------------------------------------------ | -------------------------------------------------- |
+| `http_req_duration: p(95)<800`             | 95% of all requests finish in under 800ms.         |
+| `http_req_failed: rate<0.02`               | Fewer than 2% of requests fail.                    |
+| `http_req_duration{name:landing}<800`      | Per-endpoint p95 budgets (each tag has its own).   |
+| `…{name:courses_list}<1000`                | Catalog page.                                      |
+| `…{name:course_detail}<1200`               | Course page (heavier — CMS content).               |
+| `…{name:leaderboard_api}<600`              | Leaderboard API.                                   |
+| `…{name:community}<1000`                   | Forum home.                                        |
+| `…{name:sitemap}<800`                      | Sitemap.                                           |
+
+Each request is `tags`-named, so the end-of-run summary breaks latency down per
+endpoint. Tune the numbers to your infra; these are sane starting budgets for a
+Vercel + Supabase read path, not hard SLAs.
+
+## Interpreting results
+
+- `http_req_duration` — response time. Watch `p(95)` / `p(99)`, not `avg`.
+- `http_req_failed` — error rate. Should stay well under the 2% budget.
+- `checks` — per-request status assertions (2xx/3xx). Any failures point at a
+  broken route or an overloaded backend.
+- A red `✗` next to a threshold in the summary = that budget was breached.
+
+## Related
+
+- Standing up the staging target this runs against: [`docs/STAGING.md`](../../docs/STAGING.md)
+- Env vars for a staging deploy: [`.env.staging.example`](../../.env.staging.example)

--- a/scripts/load/load-test.js
+++ b/scripts/load/load-test.js
@@ -1,0 +1,156 @@
+/**
+ * Superteam Academy — read-path load test (k6)
+ * Readiness item G8.
+ *
+ * ============================================================================
+ *  SAFETY — READ THIS BEFORE RUNNING
+ * ============================================================================
+ *  - This script ONLY issues GET requests against PUBLIC, read-only paths.
+ *    It never writes, authenticates, mints XP, touches the chain, or mutates
+ *    any data. Do not add non-GET requests to this file.
+ *  - It defaults to http://localhost:3000. To target another environment you
+ *    MUST set BASE_URL explicitly.
+ *  - NEVER point this at production. Load-testing prod can trip rate limits,
+ *    skew analytics, exhaust Supabase/Helius quotas, and page on-call.
+ *    Run it against localhost or a dedicated STAGING deploy only.
+ * ============================================================================
+ *
+ * Usage:
+ *   # Local dev server (default target)
+ *   k6 run scripts/load/load-test.js
+ *
+ *   # Staging (explicit URL required; no trailing slash)
+ *   BASE_URL=https://academy-staging.example.com k6 run scripts/load/load-test.js
+ *
+ *   # Optional overrides
+ *   LOCALE=pt-BR COURSE_SLUG=intro-to-solana BASE_URL=... k6 run scripts/load/load-test.js
+ *
+ * See scripts/load/README.md for install + interpretation notes.
+ */
+
+import http from "k6/http";
+import { check, group, sleep } from "k6";
+
+// --- Config (env-driven, safe defaults) -------------------------------------
+
+const BASE_URL = (__ENV.BASE_URL || "http://localhost:3000").replace(/\/+$/, "");
+const LOCALE = __ENV.LOCALE || "en";
+// Fallback course slug used only if setup() can't discover one from the sitemap.
+const FALLBACK_COURSE_SLUG = __ENV.COURSE_SLUG || "";
+
+// Fail fast if someone fat-fingers a prod-looking host without meaning to.
+// This is a guard rail, not a security control — override with ALLOW_PROD=1
+// if you genuinely intend to target one of these (you almost never do).
+const PROD_HOST_PATTERNS = [
+  /(^|\.)solarium\.courses$/i,
+  /superteam-academy-web\.vercel\.app$/i,
+];
+if (__ENV.ALLOW_PROD !== "1") {
+  let host = "";
+  try {
+    // k6 has no URL global; extract host cheaply.
+    host = BASE_URL.replace(/^https?:\/\//i, "").split("/")[0].split(":")[0];
+  } catch (_e) {
+    host = "";
+  }
+  for (const re of PROD_HOST_PATTERNS) {
+    if (re.test(host)) {
+      throw new Error(
+        `Refusing to run against what looks like production (${host}). ` +
+          `This load test is for localhost or staging only. ` +
+          `If you REALLY mean it, set ALLOW_PROD=1 — but you almost certainly do not.`
+      );
+    }
+  }
+}
+
+// --- Test options -----------------------------------------------------------
+
+export const options = {
+  // Ramping virtual users: warm up, hold, cool down.
+  stages: [
+    { duration: "30s", target: 50 }, // ramp 0 -> 50 VUs
+    { duration: "1m", target: 50 }, // hold at 50 VUs
+    { duration: "30s", target: 0 }, // ramp down to 0
+  ],
+  thresholds: {
+    // 95th-percentile latency budget across all requests.
+    http_req_duration: ["p(95)<800"],
+    // Overall error budget: fewer than 2% failed requests.
+    http_req_failed: ["rate<0.02"],
+    // Per-endpoint latency budgets (tagged via the `name` below).
+    "http_req_duration{name:landing}": ["p(95)<800"],
+    "http_req_duration{name:courses_list}": ["p(95)<1000"],
+    "http_req_duration{name:course_detail}": ["p(95)<1200"],
+    "http_req_duration{name:leaderboard_api}": ["p(95)<600"],
+    "http_req_duration{name:community}": ["p(95)<1000"],
+    "http_req_duration{name:sitemap}": ["p(95)<800"],
+  },
+};
+
+// --- Setup: discover a real course slug from the public sitemap -------------
+
+export function setup() {
+  let courseSlug = FALLBACK_COURSE_SLUG;
+
+  const res = http.get(`${BASE_URL}/sitemap.xml`, {
+    tags: { name: "sitemap_setup" },
+  });
+
+  if (res.status === 200 && typeof res.body === "string") {
+    // Sitemap entries look like: .../<locale>/courses/<slug>
+    const re = new RegExp(`/${LOCALE}/courses/([^<\\s/]+)`);
+    const match = re.exec(res.body);
+    if (match && match[1]) {
+      courseSlug = match[1];
+    }
+  }
+
+  return { courseSlug };
+}
+
+// --- GET helper (read-only) -------------------------------------------------
+
+function getPath(path, name) {
+  const res = http.get(`${BASE_URL}${path}`, { tags: { name } });
+  check(res, {
+    [`${name}: status is 2xx/3xx`]: (r) => r.status >= 200 && r.status < 400,
+  });
+  return res;
+}
+
+// --- Main VU flow (public reads only) ---------------------------------------
+
+export default function (data) {
+  group("landing", () => {
+    getPath(`/${LOCALE}`, "landing");
+  });
+  sleep(1);
+
+  group("courses list", () => {
+    getPath(`/${LOCALE}/courses`, "courses_list");
+  });
+  sleep(1);
+
+  group("course detail", () => {
+    if (data && data.courseSlug) {
+      getPath(`/${LOCALE}/courses/${data.courseSlug}`, "course_detail");
+    }
+  });
+  sleep(1);
+
+  group("leaderboard api", () => {
+    getPath(`/api/leaderboard?timeframe=weekly`, "leaderboard_api");
+  });
+  sleep(1);
+
+  group("community", () => {
+    getPath(`/${LOCALE}/community`, "community");
+  });
+  sleep(1);
+
+  group("sitemap", () => {
+    getPath(`/sitemap.xml`, "sitemap");
+  });
+  sleep(1);
+}


### PR DESCRIPTION
Readiness item **G8**: a read-path load-test script + a staging-environment setup guide.

## What's here

- **`scripts/load/load-test.js`** — a [k6](https://k6.io) load test that hits **public, read-only** paths only:
  `/en` (landing), `/en/courses` (catalog), `/en/courses/{slug}` (one course — slug auto-discovered from `/sitemap.xml` in `setup()`), `/api/leaderboard?timeframe=weekly` (public GET), `/en/community`, and `/sitemap.xml`.
  - **Read-only**: every request is `http.get`. No writes, auth, mint, chain, or webhook calls — verified there are zero non-GET requests.
  - **localhost-default**: `BASE_URL` reads from `__ENV.BASE_URL` and defaults to `http://localhost:3000`. Targeting anything else requires an explicit `BASE_URL`.
  - Ramping-VU profile (`stages`: 0→50 over 30s, hold 50 for 1m, ramp down) + `thresholds` (`http_req_duration p(95)<800`, `http_req_failed rate<0.02`, plus per-endpoint p95 budgets). Each request is `tags`-named for a readable per-endpoint summary.
  - Belt-and-suspenders guard: refuses to run against the known prod hosts (`solarium.courses`, `superteam-academy-web.vercel.app`) unless `ALLOW_PROD=1`.
- **`scripts/load/README.md`** — install k6, run against localhost (`k6 run …`) or staging (`BASE_URL=… k6 run …`), what each threshold means, and a bold **never target production** warning.
- **`docs/STAGING.md`** — concise guide to standing up staging on the real stack (Vercel Preview + Supabase branch/separate project + Sanity dataset + Helius **devnet** webhook + Cloud Run), which env vars to set (`NEXT_PUBLIC_*` → devnet + staging DB, server secrets Preview-scoped), a smoke check, and how to run the load test against it.
- **`.env.staging.example`** — blank placeholders mirroring the required + optional env vars from `docs/DEPLOYMENT.md` / `CLAUDE.md`. No real values. Added a `!.env.staging.example` negation to `.gitignore` (matching the existing `!.env.example` convention) so it's tracked.

## Safety

- The load test only exercises **GET / public** paths — it can never mint XP, hit the chain, or mutate data.
- It defaults to **localhost** and requires an explicit `BASE_URL` for anything else. **Never point it at production** — documented prominently in both the script header and the README.
- No secrets or real env values are committed.

## Verification

- `node --check scripts/load/load-test.js` → passes (catches JS syntax errors without k6 installed).
- Grepped the script: only `http.get` calls, no `method:` overrides, no POST/PUT/PATCH/DELETE.
- k6 is not installed in this environment, so nothing was executed — and per the safety rules, `k6 run` was **not** invoked against anything.

Do not merge — opening for review.
