### PR TITLE
fix(onchain): assert recipient ATA mint + bound per-mint XP (readiness §3)

### DIFF
--- a/apps/web/src/lib/solana/idl/superteam_academy.json
+++ b/apps/web/src/lib/solana/idl/superteam_academy.json
@@ -1428,6 +1428,16 @@
       "code": 6031,
       "name": "MintingPaused",
       "msg": "Minting is paused"
+    },
+    {
+      "code": 6032,
+      "name": "WrongXpMint",
+      "msg": "Recipient token account mint does not match Config.xp_mint"
+    },
+    {
+      "code": 6033,
+      "name": "XpAmountExceedsMax",
+      "msg": "XP amount exceeds the per-mint ceiling"
     }
   ],
   "types": [

--- a/onchain-academy/programs/onchain-academy/src/errors.rs
+++ b/onchain-academy/programs/onchain-academy/src/errors.rs
@@ -66,4 +66,8 @@ pub enum AcademyError {
     InvalidCourseAccount,
     #[msg("Minting is paused")]
     MintingPaused,
+    #[msg("Recipient token account mint does not match Config.xp_mint")]
+    WrongXpMint,
+    #[msg("XP amount exceeds the per-mint ceiling")]
+    XpAmountExceedsMax,
 }

--- a/onchain-academy/programs/onchain-academy/src/instructions/award_achievement.rs
+++ b/onchain-academy/programs/onchain-academy/src/instructions/award_achievement.rs
@@ -10,7 +10,7 @@ use mpl_core::{
 use crate::errors::AcademyError;
 use crate::events::AchievementAwarded;
 use crate::state::{AchievementReceipt, AchievementType, Config, MinterRole};
-use crate::utils::mint_xp;
+use crate::utils::{mint_xp, require_xp_mint, MAX_XP_PER_MINT};
 
 pub fn handler(ctx: Context<AwardAchievement>) -> Result<()> {
     require!(!ctx.accounts.config.paused, AcademyError::MintingPaused);
@@ -33,6 +33,10 @@ pub fn handler(ctx: Context<AwardAchievement>) -> Result<()> {
     // must gate it too — otherwise a capped minter could be drained via
     // achievements. Only relevant when xp_reward > 0 (else total stays put).
     let new_total_xp_minted = if achievement.xp_reward > 0 {
+        require!(
+            achievement.xp_reward as u64 <= MAX_XP_PER_MINT,
+            AcademyError::XpAmountExceedsMax
+        );
         let new_total = role
             .total_xp_minted
             .checked_add(achievement.xp_reward as u64)
@@ -92,6 +96,7 @@ pub fn handler(ctx: Context<AwardAchievement>) -> Result<()> {
 
     // Mint XP if xp_reward > 0
     if achievement.xp_reward > 0 {
+        require_xp_mint(&ctx.accounts.recipient_token_account, &config.xp_mint)?;
         mint_xp(
             &ctx.accounts.xp_mint.to_account_info(),
             &ctx.accounts.recipient_token_account.to_account_info(),

--- a/onchain-academy/programs/onchain-academy/src/instructions/complete_lesson.rs
+++ b/onchain-academy/programs/onchain-academy/src/instructions/complete_lesson.rs
@@ -27,6 +27,13 @@ pub fn handler(ctx: Context<CompleteLesson>, lesson_index: u8) -> Result<()> {
     );
     enrollment.lesson_flags[word_index] |= mask;
 
+    require!(
+        course.xp_per_lesson as u64 <= utils::MAX_XP_PER_MINT,
+        AcademyError::XpAmountExceedsMax
+    );
+
+    utils::require_xp_mint(&ctx.accounts.learner_token_account, &config.xp_mint)?;
+
     let config_seeds: &[&[u8]] = &[b"config", &[config.bump]];
 
     utils::mint_xp(

--- a/onchain-academy/programs/onchain-academy/src/instructions/finalize_course.rs
+++ b/onchain-academy/programs/onchain-academy/src/instructions/finalize_course.rs
@@ -62,6 +62,10 @@ pub fn handler(ctx: Context<FinalizeCourse>) -> Result<()> {
     if course.total_completions >= course.min_completions_for_reward as u32
         && course.creator_reward_xp > 0
     {
+        require!(
+            course.creator_reward_xp as u64 <= utils::MAX_XP_PER_MINT,
+            AcademyError::XpAmountExceedsMax
+        );
         utils::require_xp_mint(&ctx.accounts.creator_token_account, &config.xp_mint)?;
         utils::mint_xp(
             &ctx.accounts.xp_mint.to_account_info(),

--- a/onchain-academy/programs/onchain-academy/src/instructions/finalize_course.rs
+++ b/onchain-academy/programs/onchain-academy/src/instructions/finalize_course.rs
@@ -40,7 +40,13 @@ pub fn handler(ctx: Context<FinalizeCourse>) -> Result<()> {
         .ok_or(AcademyError::Overflow)?;
     let bonus_xp = total_lesson_xp / 2;
 
+    require!(
+        bonus_xp <= utils::MAX_XP_PER_MINT,
+        AcademyError::XpAmountExceedsMax
+    );
+
     if bonus_xp > 0 {
+        utils::require_xp_mint(&ctx.accounts.learner_token_account, &config.xp_mint)?;
         utils::mint_xp(
             &ctx.accounts.xp_mint.to_account_info(),
             &ctx.accounts.learner_token_account.to_account_info(),
@@ -56,6 +62,7 @@ pub fn handler(ctx: Context<FinalizeCourse>) -> Result<()> {
     if course.total_completions >= course.min_completions_for_reward as u32
         && course.creator_reward_xp > 0
     {
+        utils::require_xp_mint(&ctx.accounts.creator_token_account, &config.xp_mint)?;
         utils::mint_xp(
             &ctx.accounts.xp_mint.to_account_info(),
             &ctx.accounts.creator_token_account.to_account_info(),

--- a/onchain-academy/programs/onchain-academy/src/instructions/reward_xp.rs
+++ b/onchain-academy/programs/onchain-academy/src/instructions/reward_xp.rs
@@ -3,7 +3,7 @@ use anchor_lang::prelude::*;
 use crate::errors::AcademyError;
 use crate::events::XpRewarded;
 use crate::state::{Config, MinterRole};
-use crate::utils::mint_xp;
+use crate::utils::{mint_xp, require_xp_mint};
 
 pub fn handler(ctx: Context<RewardXp>, amount: u64, memo: String) -> Result<()> {
     require!(!ctx.accounts.config.paused, AcademyError::MintingPaused);
@@ -34,6 +34,8 @@ pub fn handler(ctx: Context<RewardXp>, amount: u64, memo: String) -> Result<()> 
 
     let config = &ctx.accounts.config;
     let config_seeds: &[&[u8]] = &[b"config", &[config.bump]];
+
+    require_xp_mint(&ctx.accounts.recipient_token_account, &config.xp_mint)?;
 
     mint_xp(
         &ctx.accounts.xp_mint.to_account_info(),

--- a/onchain-academy/programs/onchain-academy/src/utils.rs
+++ b/onchain-academy/programs/onchain-academy/src/utils.rs
@@ -1,6 +1,37 @@
 use anchor_lang::prelude::*;
 use anchor_lang::solana_program::program::invoke_signed;
 
+use crate::errors::AcademyError;
+
+/// Hard ceiling on the XP minted in a single instruction.
+///
+/// Deliberately generous versus the largest legitimate single mint (a
+/// course-completion bonus): a max-difficulty course with `xp_per_lesson = 50`
+/// and a full 50-lesson roster yields a `2500 * 0.5 = 1250` bonus, and creator
+/// rewards / achievement grants sit well below that. This is a tunable backstop,
+/// not a business rule — its job is to cap the blast radius of a bug or a leaked
+/// `backend_signer` to a bounded per-call amount. It matches the 5000 XP daily
+/// ceiling enforced in SQL, so the two limits stay in lockstep.
+pub const MAX_XP_PER_MINT: u64 = 5000;
+
+/// Asserts that `token_account` is a Token-2022 account whose base mint equals
+/// `expected_mint` (i.e. `Config.xp_mint`).
+///
+/// The `#[account(mut)]` + program-owner constraints on the recipient ATAs only
+/// prove the account is *some* Token-2022 account; without this the backend
+/// could point a mint instruction at an ATA of an unrelated Token-2022 mint. The
+/// `mint_to` CPI would still fail there (mint/account mismatch), but asserting up
+/// front turns that into a precise, named error instead of an opaque CPI failure.
+pub fn require_xp_mint(token_account: &AccountInfo, expected_mint: &Pubkey) -> Result<()> {
+    let data = token_account.try_borrow_data()?;
+    let state =
+        spl_token_2022::extension::StateWithExtensions::<spl_token_2022::state::Account>::unpack(
+            &data,
+        )?;
+    require_keys_eq!(state.base.mint, *expected_mint, AcademyError::WrongXpMint);
+    Ok(())
+}
+
 /// Mints XP tokens via Token-2022 CPI. The authority (Config PDA) signs
 /// using the provided seeds.
 pub fn mint_xp<'info>(

--- a/onchain-academy/tests/rust/Cargo.lock
+++ b/onchain-academy/tests/rust/Cargo.lock
@@ -1315,6 +1315,7 @@ dependencies = [
  "onchain-academy",
  "solana-program",
  "solana-sdk",
+ "spl-token-2022",
 ]
 
 [[package]]

--- a/onchain-academy/tests/rust/Cargo.toml
+++ b/onchain-academy/tests/rust/Cargo.toml
@@ -11,6 +11,9 @@ anchor-lang = "0.31.1"
 solana-sdk = "=2.0.25"
 solana-program = "=2.0.25"
 borsh = "0.10"
+# Already in the tree via `onchain-academy`; used here to pack real Token-2022
+# account fixtures for the require_xp_mint assertions.
+spl-token-2022 = { version = "5", features = ["no-entrypoint"] }
 
 [lib]
 name = "onchain_academy_tests"

--- a/onchain-academy/tests/rust/src/lib.rs
+++ b/onchain-academy/tests/rust/src/lib.rs
@@ -1,11 +1,13 @@
 #[cfg(test)]
 pub mod helpers;
 #[cfg(test)]
+mod test_achievement;
+#[cfg(test)]
+mod test_close_course;
+#[cfg(test)]
 mod test_completion;
 #[cfg(test)]
 mod test_course;
-#[cfg(test)]
-mod test_close_course;
 #[cfg(test)]
 mod test_enrollment;
 #[cfg(test)]
@@ -13,8 +15,8 @@ mod test_initialize;
 #[cfg(test)]
 mod test_kill_switch;
 #[cfg(test)]
-mod test_utils;
+mod test_mint_hardening;
 #[cfg(test)]
 mod test_minter_role;
 #[cfg(test)]
-mod test_achievement;
+mod test_utils;

--- a/onchain-academy/tests/rust/src/test_mint_hardening.rs
+++ b/onchain-academy/tests/rust/src/test_mint_hardening.rs
@@ -1,0 +1,156 @@
+//! Tests for the on-chain XP-mint hardening (launch-readiness §3).
+//!
+//! Two independent guards were added to every XP-minting path
+//! (`complete_lesson`, `finalize_course`, `reward_xp`, `award_achievement`):
+//!
+//! 1. `utils::require_xp_mint(ata, &config.xp_mint)` — unpacks the recipient
+//!    Token-2022 account and asserts its base mint equals `Config.xp_mint`,
+//!    raising `WrongXpMint` otherwise. Without it, a recipient ATA of an
+//!    unrelated Token-2022 mint would pass the program-owner constraint.
+//! 2. `require!(amount <= MAX_XP_PER_MINT, XpAmountExceedsMax)` — a tunable
+//!    per-call ceiling that bounds the blast radius of a bug or a leaked
+//!    `backend_signer`.
+//!
+//! These exercise the real `require_xp_mint` against packed Token-2022 account
+//! bytes, mirror the ceiling gate, and pin the new error codes — matching the
+//! rest of this test crate, which validates handler logic without a runtime.
+
+use onchain_academy::errors::AcademyError;
+use onchain_academy::utils::{require_xp_mint, MAX_XP_PER_MINT};
+use solana_program::account_info::AccountInfo;
+use solana_program::program_pack::Pack;
+use solana_sdk::pubkey::Pubkey;
+use spl_token_2022::state::{Account as Token2022Account, AccountState};
+
+/// Pack an initialized Token-2022 account (base state, no extensions) holding
+/// the given mint — exactly the byte layout `require_xp_mint` unpacks.
+fn pack_token_account(mint: Pubkey, owner: Pubkey) -> Vec<u8> {
+    let account = Token2022Account {
+        mint,
+        owner,
+        amount: 0,
+        state: AccountState::Initialized,
+        ..Default::default()
+    };
+    let mut data = vec![0u8; Token2022Account::LEN];
+    Token2022Account::pack(account, &mut data).expect("pack token account");
+    data
+}
+
+/// Build an owned `AccountInfo` over a packed Token-2022 account so the real
+/// `require_xp_mint` can be invoked directly (not a logic mirror).
+fn call_require_xp_mint(account_mint: Pubkey, expected_mint: &Pubkey) -> anchor_lang::Result<()> {
+    let key = Pubkey::new_unique();
+    let owner = spl_token_2022::id();
+    let ata_owner = Pubkey::new_unique();
+    let mut lamports: u64 = 1_000_000;
+    let mut data = pack_token_account(account_mint, ata_owner);
+
+    let account_info = AccountInfo::new(
+        &key,
+        false,
+        true,
+        &mut lamports,
+        &mut data,
+        &owner,
+        false,
+        0,
+    );
+
+    require_xp_mint(&account_info, expected_mint)
+}
+
+// --- require_xp_mint: mint-matching guard ---
+
+#[test]
+fn require_xp_mint_accepts_matching_mint() {
+    let xp_mint = Pubkey::new_unique();
+    assert!(call_require_xp_mint(xp_mint, &xp_mint).is_ok());
+}
+
+#[test]
+fn require_xp_mint_rejects_wrong_mint() {
+    let xp_mint = Pubkey::new_unique();
+    let other_mint = Pubkey::new_unique();
+    assert_ne!(xp_mint, other_mint);
+
+    let err = call_require_xp_mint(other_mint, &xp_mint)
+        .expect_err("an ATA of a different mint must be rejected");
+
+    // The error must be exactly WrongXpMint (6032), not some opaque unpack
+    // failure. `require_keys_eq!` decorates the AnchorError with a source
+    // location and the mismatched pubkeys, so match on the code, not the string.
+    match err {
+        anchor_lang::error::Error::AnchorError(ae) => {
+            assert_eq!(
+                ae.error_code_number,
+                AcademyError::WrongXpMint as u32 + 6000
+            );
+            assert_eq!(ae.error_code_number, 6032);
+        }
+        other => panic!("expected AnchorError(WrongXpMint), got {other:?}"),
+    }
+}
+
+// --- MAX_XP_PER_MINT: per-call ceiling gate ---
+
+/// The exact gate applied before minting in complete_lesson (xp_per_lesson),
+/// finalize_course (bonus), and award_achievement (xp_reward):
+/// `require!(amount <= MAX_XP_PER_MINT, XpAmountExceedsMax)`.
+fn amount_within_ceiling(amount: u64) -> bool {
+    amount <= MAX_XP_PER_MINT
+}
+
+#[test]
+fn max_xp_per_mint_is_5000() {
+    // Pinned to the SQL daily ceiling so the two limits stay in lockstep.
+    assert_eq!(MAX_XP_PER_MINT, 5000);
+}
+
+#[test]
+fn ceiling_gate_boundaries() {
+    // Below the ceiling: allowed.
+    assert!(amount_within_ceiling(0));
+    assert!(amount_within_ceiling(4999));
+    // Exactly at the ceiling: allowed (<=).
+    assert!(amount_within_ceiling(MAX_XP_PER_MINT));
+    // One over: rejected.
+    assert!(!amount_within_ceiling(MAX_XP_PER_MINT + 1));
+    assert!(!amount_within_ceiling(u64::MAX));
+}
+
+/// The largest legitimate single mint is the finalize_course completion bonus:
+/// `(xp_per_lesson * lesson_count) / 2`. Even a max-difficulty course
+/// (xp_per_lesson = 50) with a 50-lesson roster stays under the ceiling, so the
+/// backstop never trips on honest traffic.
+#[test]
+fn largest_legitimate_bonus_is_within_ceiling() {
+    let xp_per_lesson: u64 = 50;
+    let lesson_count: u64 = 50;
+    let bonus = (xp_per_lesson * lesson_count) / 2;
+    assert_eq!(bonus, 1250);
+    assert!(amount_within_ceiling(bonus));
+}
+
+// --- Error codes: append-only, prior codes never shift ---
+
+/// The two new variants were appended at the END of `AcademyError`, so every
+/// prior code — critically `MintingPaused` at 6031 — stays put. Anchor numbers
+/// variants from 6000 in declaration order. Pin the absolute codes so a future
+/// reorder fails CI instantly.
+#[test]
+fn new_error_codes_are_appended_after_minting_paused() {
+    let minting_paused = 6000 + AcademyError::MintingPaused as u32;
+    let wrong_xp_mint = 6000 + AcademyError::WrongXpMint as u32;
+    let xp_amount_exceeds_max = 6000 + AcademyError::XpAmountExceedsMax as u32;
+
+    // MintingPaused is unchanged.
+    assert_eq!(minting_paused, 6031);
+    // The two new variants follow it, in order.
+    assert_eq!(wrong_xp_mint, 6032);
+    assert_eq!(xp_amount_exceeds_max, 6033);
+
+    // Strictly monotonic append — no code reuse or reordering.
+    assert!(wrong_xp_mint > minting_paused);
+    assert!(xp_amount_exceeds_max > wrong_xp_mint);
+}


### PR DESCRIPTION
**⚠️ DRAFT — recovered from an agent that died on a process restart before building. NOT yet build/test-verified; do not merge until CI + local `anchor build`/`cargo test` are green and I've adversarially reviewed the mint assertion.**

## What
Hardens all XP-mint paths (readiness §3):
- `require_xp_mint(ata, &config.xp_mint)` — asserts each recipient ATA's mint == Config.xp_mint (unpacks the Token-2022 account). New error `WrongXpMint`.
- `MAX_XP_PER_MINT = 5000` ceiling on complete_lesson / finalize_course / award_achievement. New error `XpAmountExceedsMax`.
- Both errors appended AFTER `MintingPaused` so existing codes don't shift.

## Status
Implementation recovered from worktree. Still TODO before ready: `cargo fmt`/clippy, `cargo test`, `anchor build` (IDL regen), `program_autofixer`, and a devnet redeploy for it to take effect. Verifying now.