### PR TITLE
feat(teacher-courses): richer course analytics (funnel, XP, recent activity)

### DIFF
--- a/apps/web/src/app/[locale]/(platform)/teach/courses/[id]/page.tsx
+++ b/apps/web/src/app/[locale]/(platform)/teach/courses/[id]/page.tsx
@@ -3,7 +3,9 @@ import { notFound, redirect } from "next/navigation";
 import { getTranslations } from "next-intl/server";
 import { authorizeTeacher } from "@/lib/teacher/authorize";
 import { getTeacherCourseEditable } from "@/lib/sanity/teacher-mutations";
+import { getCourseLessonList } from "@/lib/sanity/teacher-structure";
 import { getCourseStats } from "@/lib/teacher/stats";
+import { getCourseAnalytics } from "@/lib/teacher/analytics";
 
 export const dynamic = "force-dynamic";
 
@@ -32,6 +34,15 @@ export default async function CourseOverviewPage({
   }
 
   const stats = await getCourseStats(id);
+  const lessons = await getCourseLessonList(id);
+  const analytics = await getCourseAnalytics(
+    id,
+    lessons,
+    course.xpPerLesson ?? 0,
+    stats.enrolledCount,
+    stats.completionCount
+  );
+
   const t = await getTranslations("teacher.overview");
   const tc = await getTranslations("teacher.courses");
 
@@ -40,6 +51,7 @@ export default async function CourseOverviewPage({
     { label: t("completions"), value: stats.completionCount },
     { label: t("certificates"), value: stats.certificateCount },
   ];
+  const maxFunnel = Math.max(1, ...analytics.funnel.map((f) => f.completedBy));
 
   return (
     <div className="mx-auto max-w-4xl px-4 py-8">
@@ -76,6 +88,60 @@ export default async function CourseOverviewPage({
           </div>
         ))}
       </div>
+
+      {/* Secondary metrics */}
+      <div className="mt-4 grid gap-4 sm:grid-cols-3">
+        {[
+          {
+            label: t("completionRate"),
+            value: `${Math.round(analytics.completionRate * 100)}%`,
+          },
+          { label: t("xpAwarded"), value: analytics.xpAwarded },
+          {
+            label: t("recentActivity", { days: analytics.recentWindowDays }),
+            value: `+${analytics.recentEnrollments} / +${analytics.recentCompletions}`,
+          },
+        ].map((c) => (
+          <div
+            key={c.label}
+            className="rounded-lg border border-border bg-card p-4 text-sm shadow-card"
+          >
+            <p className="text-lg font-bold text-text">{c.value}</p>
+            <p className="mt-1 text-text-3">{c.label}</p>
+          </div>
+        ))}
+      </div>
+
+      {/* Per-lesson completion funnel */}
+      <section className="mt-8">
+        <h2 className="mb-3 font-display text-lg font-bold text-text">
+          {t("lessonFunnel")}
+        </h2>
+        {analytics.funnel.length === 0 ? (
+          <p className="text-sm text-text-3">{t("noLessons")}</p>
+        ) : (
+          <ol className="space-y-2">
+            {analytics.funnel.map((f, i) => (
+              <li key={f.lessonId} className="text-sm">
+                <div className="mb-1 flex items-center justify-between gap-3">
+                  <span className="truncate text-text">
+                    {i + 1}. {f.title || t("untitledLesson")}
+                  </span>
+                  <span className="shrink-0 text-text-3">{f.completedBy}</span>
+                </div>
+                <div className="h-1.5 w-full rounded bg-[var(--input)]">
+                  <div
+                    className="h-1.5 rounded bg-primary"
+                    style={{
+                      width: `${Math.round((f.completedBy / maxFunnel) * 100)}%`,
+                    }}
+                  />
+                </div>
+              </li>
+            ))}
+          </ol>
+        )}
+      </section>
     </div>
   );
 }

--- a/apps/web/src/lib/sanity/teacher-structure.ts
+++ b/apps/web/src/lib/sanity/teacher-structure.ts
@@ -75,6 +75,21 @@ export async function getCourseStructure(
   return result?.modules ?? [];
 }
 
+/** Ordered (module → lesson) list of a course's lessons — id + title only. */
+export async function getCourseLessonList(
+  courseId: string
+): Promise<{ _id: string; title: string | null }[]> {
+  const result = await sanityAdmin.fetch<{
+    modules: { lessons: { _id: string; title: string | null }[] | null }[] | null;
+  } | null>(
+    `*[_type == "course" && _id == $courseId][0]{
+      "modules": modules[]->{ "lessons": lessons[]->{ _id, title } }
+    }`,
+    { courseId }
+  );
+  return (result?.modules ?? []).flatMap((m) => m.lessons ?? []);
+}
+
 /** Flat id sets of the course's current modules + lessons (for the diff). */
 async function getCurrentTreeIds(courseId: string): Promise<CurrentTree> {
   const result = await sanityAdmin.fetch<{

--- a/apps/web/src/lib/supabase/types.ts
+++ b/apps/web/src/lib/supabase/types.ts
@@ -879,6 +879,10 @@ export type Database = {
       };
     };
     Functions: {
+      course_lesson_completion_counts: {
+        Args: { p_course_id: string };
+        Returns: { lesson_id: string; completed_by: number }[];
+      };
       award_community_xp: {
         Args: {
           p_amount: number;

--- a/apps/web/src/lib/teacher/analytics.ts
+++ b/apps/web/src/lib/teacher/analytics.ts
@@ -41,7 +41,7 @@ export async function getCourseAnalytics(
   const admin = createAdminClient();
   const cutoff = new Date(Date.now() - RECENT_DAYS * 86_400_000).toISOString();
 
-  const [recentEnr, recentComp, progress] = await Promise.all([
+  const [recentEnr, recentComp, counts] = await Promise.all([
     admin
       .from("enrollments")
       .select("id", { count: "exact", head: true })
@@ -52,17 +52,17 @@ export async function getCourseAnalytics(
       .select("id", { count: "exact", head: true })
       .eq("course_id", courseId)
       .gte("completed_at", cutoff),
-    admin
-      .from("user_progress")
-      .select("lesson_id")
-      .eq("course_id", courseId)
-      .eq("completed", true),
+    // Aggregate per-lesson completions IN Postgres (one row per lesson) — a raw
+    // row fetch would be silently capped at max_rows (1000) and under-report the
+    // funnel + XP for busy courses. See course_lesson_completion_counts.
+    admin.rpc("course_lesson_completion_counts", { p_course_id: courseId }),
   ]);
 
-  const rows = (progress.data ?? []) as { lesson_id: string }[];
   const perLesson = new Map<string, number>();
-  for (const r of rows) {
-    perLesson.set(r.lesson_id, (perLesson.get(r.lesson_id) ?? 0) + 1);
+  let totalCompletedLessons = 0;
+  for (const row of counts.data ?? []) {
+    perLesson.set(row.lesson_id, row.completed_by);
+    totalCompletedLessons += row.completed_by;
   }
 
   const funnel: LessonFunnelRow[] = orderedLessons.map((l) => ({
@@ -75,7 +75,7 @@ export async function getCourseAnalytics(
     completionRate: enrolledCount > 0 ? completionCount / enrolledCount : 0,
     recentEnrollments: recentEnr.count ?? 0,
     recentCompletions: recentComp.count ?? 0,
-    xpAwarded: rows.length * (xpPerLesson || 0),
+    xpAwarded: totalCompletedLessons * (xpPerLesson || 0),
     funnel,
     recentWindowDays: RECENT_DAYS,
   };

--- a/apps/web/src/lib/teacher/analytics.ts
+++ b/apps/web/src/lib/teacher/analytics.ts
@@ -1,0 +1,82 @@
+import "server-only";
+import { createAdminClient } from "@/lib/supabase/admin";
+
+const RECENT_DAYS = 7;
+
+export interface LessonFunnelRow {
+  lessonId: string;
+  title: string;
+  /** Distinct learners who have completed this lesson. */
+  completedBy: number;
+}
+
+export interface CourseAnalytics {
+  /** completions / enrolled, 0..1 (0 when no enrollments). */
+  completionRate: number;
+  recentEnrollments: number;
+  recentCompletions: number;
+  /** Estimated XP handed out: completed lessons × the course's per-lesson XP. */
+  xpAwarded: number;
+  /** Per-lesson completion in course order — the drop-off funnel. */
+  funnel: LessonFunnelRow[];
+  recentWindowDays: number;
+}
+
+/**
+ * Richer per-course analytics for the teacher overview (#286). SERVER-ONLY; the
+ * caller must verify course ownership first.
+ *
+ * `completionRate` uses the SAME course-completion signal as the headline
+ * `completionCount` (enrollments with `completed_at` set) so the two views never
+ * disagree; the `funnel` is a separate per-lesson drill-down from
+ * `user_progress` and is not re-defining "completed the course".
+ */
+export async function getCourseAnalytics(
+  courseId: string,
+  orderedLessons: { _id: string; title: string | null }[],
+  xpPerLesson: number,
+  enrolledCount: number,
+  completionCount: number
+): Promise<CourseAnalytics> {
+  const admin = createAdminClient();
+  const cutoff = new Date(Date.now() - RECENT_DAYS * 86_400_000).toISOString();
+
+  const [recentEnr, recentComp, progress] = await Promise.all([
+    admin
+      .from("enrollments")
+      .select("id", { count: "exact", head: true })
+      .eq("course_id", courseId)
+      .gte("enrolled_at", cutoff),
+    admin
+      .from("enrollments")
+      .select("id", { count: "exact", head: true })
+      .eq("course_id", courseId)
+      .gte("completed_at", cutoff),
+    admin
+      .from("user_progress")
+      .select("lesson_id")
+      .eq("course_id", courseId)
+      .eq("completed", true),
+  ]);
+
+  const rows = (progress.data ?? []) as { lesson_id: string }[];
+  const perLesson = new Map<string, number>();
+  for (const r of rows) {
+    perLesson.set(r.lesson_id, (perLesson.get(r.lesson_id) ?? 0) + 1);
+  }
+
+  const funnel: LessonFunnelRow[] = orderedLessons.map((l) => ({
+    lessonId: l._id,
+    title: l.title ?? "",
+    completedBy: perLesson.get(l._id) ?? 0,
+  }));
+
+  return {
+    completionRate: enrolledCount > 0 ? completionCount / enrolledCount : 0,
+    recentEnrollments: recentEnr.count ?? 0,
+    recentCompletions: recentComp.count ?? 0,
+    xpAwarded: rows.length * (xpPerLesson || 0),
+    funnel,
+    recentWindowDays: RECENT_DAYS,
+  };
+}

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -46,7 +46,13 @@
       "completions": "Completions",
       "certificates": "Certificates",
       "edit": "Edit course",
-      "back": "Back to courses"
+      "back": "Back to courses",
+      "completionRate": "Completion rate",
+      "xpAwarded": "XP awarded",
+      "recentActivity": "New in {days}d (enroll/complete)",
+      "lessonFunnel": "Lesson completion",
+      "noLessons": "No lessons yet.",
+      "untitledLesson": "Untitled lesson"
     },
     "form": {
       "createHeading": "New course",

--- a/apps/web/src/messages/es.json
+++ b/apps/web/src/messages/es.json
@@ -46,7 +46,13 @@
       "completions": "Finalizaciones",
       "certificates": "Certificados",
       "edit": "Editar curso",
-      "back": "Volver a los cursos"
+      "back": "Volver a los cursos",
+      "completionRate": "Tasa de finalización",
+      "xpAwarded": "XP otorgado",
+      "recentActivity": "Nuevos en {days}d (inscr./final.)",
+      "lessonFunnel": "Finalización por lección",
+      "noLessons": "Aún no hay lecciones.",
+      "untitledLesson": "Lección sin título"
     },
     "form": {
       "createHeading": "Nuevo curso",

--- a/apps/web/src/messages/pt-BR.json
+++ b/apps/web/src/messages/pt-BR.json
@@ -46,7 +46,13 @@
       "completions": "Conclusões",
       "certificates": "Certificados",
       "edit": "Editar curso",
-      "back": "Voltar aos cursos"
+      "back": "Voltar aos cursos",
+      "completionRate": "Taxa de conclusão",
+      "xpAwarded": "XP concedido",
+      "recentActivity": "Novos em {days}d (inscr./concl.)",
+      "lessonFunnel": "Conclusão por aula",
+      "noLessons": "Nenhuma aula ainda.",
+      "untitledLesson": "Aula sem título"
     },
     "form": {
       "createHeading": "Novo curso",

--- a/supabase/migrations/20260705120000_course_lesson_completion_counts.sql
+++ b/supabase/migrations/20260705120000_course_lesson_completion_counts.sql
@@ -1,0 +1,30 @@
+-- Migration: course_lesson_completion_counts
+-- The teacher analytics funnel (#286) needs per-lesson completion counts. The
+-- app previously SELECTed raw completed `user_progress` rows and counted them in
+-- JS — which PostgREST silently truncates at max_rows (1000), under-reporting
+-- the funnel bars AND xpAwarded for busy courses (e.g. 150 learners × 10
+-- lessons > 1000 rows). Aggregate in Postgres instead: this returns ONE row per
+-- lesson (far under the cap), counted by the database, so the count is exact.
+--
+-- SECURITY DEFINER so it aggregates across all learners regardless of RLS; it
+-- returns only non-sensitive counts (lesson_id + a count), never learner rows.
+-- Ownership of the course is verified by the caller (teacher analytics path)
+-- before invoking this via the service-role client; EXECUTE is granted to
+-- service_role only, mirroring the other SECURITY DEFINER functions.
+CREATE OR REPLACE FUNCTION public.course_lesson_completion_counts(p_course_id TEXT)
+RETURNS TABLE (lesson_id TEXT, completed_by BIGINT)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+  SELECT up.lesson_id, COUNT(*)::bigint
+  FROM public.user_progress up
+  WHERE up.course_id = p_course_id AND up.completed = true
+  GROUP BY up.lesson_id;
+$$;
+
+REVOKE ALL ON FUNCTION public.course_lesson_completion_counts(TEXT)
+  FROM public, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.course_lesson_completion_counts(TEXT)
+  TO service_role;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -1730,3 +1730,23 @@ $$;
 
 REVOKE ALL ON FUNCTION check_rate_limit(TEXT, INT, INT) FROM PUBLIC, anon, authenticated;
 GRANT EXECUTE ON FUNCTION check_rate_limit(TEXT, INT, INT) TO service_role;
+
+-- Per-lesson completion counts for the teacher analytics funnel (#286).
+-- Aggregated in Postgres so it returns one row per lesson (not raw progress
+-- rows, which PostgREST caps at max_rows=1000 and would silently truncate).
+-- SECURITY DEFINER: aggregates across all learners, returns only counts.
+CREATE OR REPLACE FUNCTION course_lesson_completion_counts(p_course_id TEXT)
+RETURNS TABLE (lesson_id TEXT, completed_by BIGINT)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+  SELECT up.lesson_id, COUNT(*)::bigint
+  FROM public.user_progress up
+  WHERE up.course_id = p_course_id AND up.completed = true
+  GROUP BY up.lesson_id;
+$$;
+
+REVOKE ALL ON FUNCTION course_lesson_completion_counts(TEXT) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION course_lesson_completion_counts(TEXT) TO service_role;


### PR DESCRIPTION
## Summary

Extends the per-course overview (#285) with **drop-off + engagement** signals for course creators.

## What

- **`lib/teacher/analytics.ts`** — `getCourseAnalytics`: completion rate, recent (7-day) enrollments/completions, estimated **XP awarded** (completed lessons × the course's `xpPerLesson`), and a **per-lesson completion funnel** aggregated from `user_progress`. Server-only; ownership checked by the caller.
- **`teacher-structure.ts`** — `getCourseLessonList`: ordered (module → lesson) `id`+`title` for the funnel's labels and order.
- **Overview page** — three secondary metric cards (completion rate, XP awarded, recent activity) plus a per-lesson **funnel** with bars so the teacher can see where learners drop off.
- `teacher.overview` i18n across en/pt-BR/es.

## Completion semantics (per review note on #285)

Consistent by construction: `completionRate` uses the **same** course-completion signal as the headline `completionCount` (enrollments with `completed_at` set). The funnel is a **separate per-lesson drill-down** from `user_progress` and does **not** redefine "completed the course" — so the two views can't disagree on the course-level number.

## Acceptance criteria

- [x] Completion rate + a per-lesson drop-off signal for the teacher's own course
- [x] XP, certificates (from #285), and recent-activity surfaced on the overview
- [x] Ownership enforced (via the overview page's existing author/admin check); `tsc` + lint + build clean; i18n parity

## Notes

Uses the `idx_certificates_course_id` index added in #295, and reuses the ownership-gated overview page from #285. This closes out the three-issue teacher-analytics set (#284 admin UI, #285 overview, #286 analytics).

Closes #286
