### PR TITLE
fix(challenge): polyfill TextDecoder/TextEncoder in the QuickJS grader sandbox

### DIFF
--- a/apps/web/src/lib/challenge/__tests__/executor.test.ts
+++ b/apps/web/src/lib/challenge/__tests__/executor.test.ts
@@ -35,6 +35,38 @@ const PASSES_VISIBLE_ONLY =
 const WRONG = "function add(a, b) { return a * b; }";
 const EMPTY = "";
 
+// Regression: byte-parsing challenges decode strings with TextDecoder — a WHATWG
+// Web API the browser worker has but QuickJS does NOT. Without the sandbox
+// polyfill this correct submission threw "TextDecoder is not defined" and 403'd
+// server-side while passing in the browser (parse-data-challenge). Uses the
+// "data" fixture: Uint8Array([1, 5,0,0,0, 6,0,0,0, "SolDev"]) => version 1,
+// level 5 (u32 LE), username "SolDev".
+const PARSE_DATA_TEXTDECODER = `function parseAccountData(data) {
+  const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
+  const version = view.getUint8(0);
+  const level = view.getUint32(1, true);
+  const len = view.getUint32(5, true);
+  const username = new TextDecoder().decode(data.slice(9, 9 + len));
+  return { version, level, username };
+}`;
+const parseDataTests: AdminTestCase[] = [
+  {
+    id: "shape",
+    description: "returns the expected object shape",
+    input: "data",
+    expectedOutput:
+      "typeof result === 'object' && 'version' in result && 'level' in result && 'username' in result",
+  },
+  {
+    id: "values",
+    description: "parses correct values (hidden)",
+    input: "data",
+    expectedOutput:
+      "result.version === 1 && result.level === 5 && result.username === 'SolDev'",
+    hidden: true,
+  },
+];
+
 // These tests exercise the REAL QuickJS executor (no mocks). They prove the
 // server is authoritative: correctness is judged by running the submission
 // against the server-held tests, so a forged client "passed" cannot produce a
@@ -55,6 +87,16 @@ describe.skipIf(!EXECUTOR_AVAILABLE)(
       expect(run.results.every((r) => r.passed)).toBe(true);
       // hidden test was actually executed
       expect(run.results.find((r) => r.id === "hidden-1")?.passed).toBe(true);
+    });
+
+    it("runs Web-API code (TextDecoder/DataView): a byte-parsing submission grades server-side", async () => {
+      const run = await runJsSubmission(PARSE_DATA_TEXTDECODER, parseDataTests);
+      expect(run.available).toBe(true);
+      if (!run.available) return;
+      // Without the TextDecoder polyfill this threw "TextDecoder is not defined"
+      // in QuickJS -> every test failed -> an un-completable challenge.
+      expect(run.passed).toBe(true);
+      expect(run.results.find((r) => r.id === "values")?.passed).toBe(true);
     });
 
     it("rejects a WRONG submission", async () => {

--- a/apps/web/src/lib/challenge/executor.ts
+++ b/apps/web/src/lib/challenge/executor.ts
@@ -162,6 +162,58 @@ var __Function__ = Function;
 var __jsonStringify__ = JSON.stringify;
 var __jsonParse__ = JSON.parse;
 
+/* Web-API polyfills QuickJS lacks. TextEncoder/TextDecoder are WHATWG APIs, not
+ * core ECMAScript — the browser worker has them, this engine does not. Solana
+ * byte-parsing challenges (e.g. decoding a username out of account data) use
+ * them routinely, so without these a CORRECT submission throws server-side
+ * ("TextDecoder is not defined") while passing in the browser -> an
+ * un-completable challenge. Pure-JS UTF-8, defined before any user code runs. */
+if (typeof globalThis.TextEncoder === "undefined") {
+  globalThis.TextEncoder = function TextEncoder() {};
+  globalThis.TextEncoder.prototype.encode = function (input) {
+    var str = String(input === undefined ? "" : input);
+    var bytes = [];
+    for (var i = 0; i < str.length; i++) {
+      var c = str.charCodeAt(i);
+      if (c < 0x80) {
+        bytes.push(c);
+      } else if (c < 0x800) {
+        bytes.push(0xc0 | (c >> 6), 0x80 | (c & 0x3f));
+      } else if (c >= 0xd800 && c <= 0xdbff && i + 1 < str.length) {
+        var lo = str.charCodeAt(++i);
+        var cp = 0x10000 + ((c & 0x3ff) << 10) + (lo & 0x3ff);
+        bytes.push(0xf0 | (cp >> 18), 0x80 | ((cp >> 12) & 0x3f), 0x80 | ((cp >> 6) & 0x3f), 0x80 | (cp & 0x3f));
+      } else {
+        bytes.push(0xe0 | (c >> 12), 0x80 | ((c >> 6) & 0x3f), 0x80 | (c & 0x3f));
+      }
+    }
+    return new Uint8Array(bytes);
+  };
+}
+if (typeof globalThis.TextDecoder === "undefined") {
+  globalThis.TextDecoder = function TextDecoder() {};
+  globalThis.TextDecoder.prototype.decode = function (input) {
+    if (input === undefined || input === null) return "";
+    var bytes = input instanceof Uint8Array ? input : new Uint8Array(input.buffer ? input.buffer : input);
+    var out = "";
+    for (var i = 0; i < bytes.length; ) {
+      var c = bytes[i++];
+      if (c < 0x80) {
+        out += String.fromCharCode(c);
+      } else if (c < 0xe0) {
+        out += String.fromCharCode(((c & 0x1f) << 6) | (bytes[i++] & 0x3f));
+      } else if (c < 0xf0) {
+        out += String.fromCharCode(((c & 0x0f) << 12) | ((bytes[i++] & 0x3f) << 6) | (bytes[i++] & 0x3f));
+      } else {
+        var cp2 = ((c & 0x07) << 18) | ((bytes[i++] & 0x3f) << 12) | ((bytes[i++] & 0x3f) << 6) | (bytes[i++] & 0x3f);
+        cp2 -= 0x10000;
+        out += String.fromCharCode(0xd800 + (cp2 >> 10), 0xdc00 + (cp2 & 0x3ff));
+      }
+    }
+    return out;
+  };
+}
+
 var BASE58_ALPHABET = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
 function toBase58(bytes) {
   var result = "";


### PR DESCRIPTION
## The bug (real platform bug, not learner code)

`parse-data-challenge` (and any byte-parsing challenge) decodes strings with **`new TextDecoder()`** — a WHATWG **Web API, not core ECMAScript**.

- The **browser** runs submissions in a Web Worker, which **has** `TextDecoder` → sample tests pass ✅
- The **server** grades in **QuickJS** (`quickjs-emscripten`), which **lacks** `TextDecoder` → a *correct* submission throws `"TextDecoder is not defined"` → every test fails → **`/api/lessons/complete` 403**

Net: the challenge was **un-completable by anyone**, and the 403 looked like "your code is wrong." Rust challenges use the Rust Playground (full runtime), so they were unaffected — matching the report ("JS fails, Rust works").

### Proof (real QuickJS engine)
```
before: TextDecoder → undefined ;  reference solution → THREW: 'TextDecoder' is not defined
after : TextDecoder → function  ;  reference solution → {version:1, level:5, username:"SolDev"} ; hidden test → true
```

## Fix
Inject a **pure-JS UTF-8 `TextEncoder`/`TextDecoder`** into `ISOLATE_RUNTIME_SOURCE` before any user code runs (no host FFI — keeps sandbox isolation). Also fixes the `expectedSeeds` fixture, which used `TextEncoder`.

## Test
Added a regression test that grades a `TextDecoder`/`DataView` byte-parsing submission (visible shape + hidden value tests) through the real `runJsSubmission`. Full suite: **20/20 pass**. `tsc` + `eslint` clean.

Frontend-only; no schema/server-route changes.