### PR TITLE
fix(onchain): audit remediation — reward_xp cap, authority rotation, recipient-owner binding, revoke_minter guard

### DIFF
--- a/apps/web/src/lib/solana/idl/superteam_academy.json
+++ b/apps/web/src/lib/solana/idl/superteam_academy.json
@@ -9,7 +9,16 @@
   "instructions": [
     {
       "name": "award_achievement",
-      "discriminator": [75, 47, 156, 253, 124, 231, 84, 12],
+      "discriminator": [
+        75,
+        47,
+        156,
+        253,
+        124,
+        231,
+        84,
+        12
+      ],
       "accounts": [
         {
           "name": "config",
@@ -17,7 +26,14 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [99, 111, 110, 102, 105, 103]
+                "value": [
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
               }
             ]
           }
@@ -29,7 +45,19 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [97, 99, 104, 105, 101, 118, 101, 109, 101, 110, 116]
+                "value": [
+                  97,
+                  99,
+                  104,
+                  105,
+                  101,
+                  118,
+                  101,
+                  109,
+                  101,
+                  110,
+                  116
+                ]
               },
               {
                 "kind": "account",
@@ -47,8 +75,25 @@
               {
                 "kind": "const",
                 "value": [
-                  97, 99, 104, 105, 101, 118, 101, 109, 101, 110, 116, 95, 114,
-                  101, 99, 101, 105, 112, 116
+                  97,
+                  99,
+                  104,
+                  105,
+                  101,
+                  118,
+                  101,
+                  109,
+                  101,
+                  110,
+                  116,
+                  95,
+                  114,
+                  101,
+                  99,
+                  101,
+                  105,
+                  112,
+                  116
                 ]
               },
               {
@@ -70,7 +115,14 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [109, 105, 110, 116, 101, 114]
+                "value": [
+                  109,
+                  105,
+                  110,
+                  116,
+                  101,
+                  114
+                ]
               },
               {
                 "kind": "account",
@@ -81,7 +133,9 @@
         },
         {
           "name": "asset",
-          "docs": ["New achievement NFT keypair"],
+          "docs": [
+            "New achievement NFT keypair"
+          ],
           "writable": true,
           "signer": true
         },
@@ -94,6 +148,10 @@
         },
         {
           "name": "recipient_token_account",
+          "docs": [
+            "its base mint (== Config.xp_mint) and token-account owner (== recipient)",
+            "are asserted in the handler via `require_xp_recipient` before minting."
+          ],
           "writable": true
         },
         {
@@ -136,7 +194,16 @@
     },
     {
       "name": "close_course",
-      "discriminator": [157, 252, 239, 166, 213, 174, 160, 34],
+      "discriminator": [
+        157,
+        252,
+        239,
+        166,
+        213,
+        174,
+        160,
+        34
+      ],
       "accounts": [
         {
           "name": "config",
@@ -144,7 +211,14 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [99, 111, 110, 102, 105, 103]
+                "value": [
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
               }
             ]
           }
@@ -162,7 +236,14 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [99, 111, 117, 114, 115, 101]
+                "value": [
+                  99,
+                  111,
+                  117,
+                  114,
+                  115,
+                  101
+                ]
               },
               {
                 "kind": "arg",
@@ -174,7 +255,9 @@
         {
           "name": "authority",
           "signer": true,
-          "relations": ["config"]
+          "relations": [
+            "config"
+          ]
         }
       ],
       "args": [
@@ -186,7 +269,16 @@
     },
     {
       "name": "close_enrollment",
-      "discriminator": [236, 137, 133, 253, 91, 138, 217, 91],
+      "discriminator": [
+        236,
+        137,
+        133,
+        253,
+        91,
+        138,
+        217,
+        91
+      ],
       "accounts": [
         {
           "name": "course",
@@ -194,7 +286,14 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [99, 111, 117, 114, 115, 101]
+                "value": [
+                  99,
+                  111,
+                  117,
+                  114,
+                  115,
+                  101
+                ]
               },
               {
                 "kind": "account",
@@ -211,7 +310,18 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [101, 110, 114, 111, 108, 108, 109, 101, 110, 116]
+                "value": [
+                  101,
+                  110,
+                  114,
+                  111,
+                  108,
+                  108,
+                  109,
+                  101,
+                  110,
+                  116
+                ]
               },
               {
                 "kind": "account",
@@ -235,7 +345,16 @@
     },
     {
       "name": "complete_lesson",
-      "discriminator": [77, 217, 53, 132, 204, 150, 169, 58],
+      "discriminator": [
+        77,
+        217,
+        53,
+        132,
+        204,
+        150,
+        169,
+        58
+      ],
       "accounts": [
         {
           "name": "config",
@@ -243,7 +362,14 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [99, 111, 110, 102, 105, 103]
+                "value": [
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
               }
             ]
           }
@@ -254,7 +380,14 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [99, 111, 117, 114, 115, 101]
+                "value": [
+                  99,
+                  111,
+                  117,
+                  114,
+                  115,
+                  101
+                ]
               },
               {
                 "kind": "account",
@@ -271,7 +404,18 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [101, 110, 114, 111, 108, 108, 109, 101, 110, 116]
+                "value": [
+                  101,
+                  110,
+                  114,
+                  111,
+                  108,
+                  108,
+                  109,
+                  101,
+                  110,
+                  116
+                ]
               },
               {
                 "kind": "account",
@@ -290,6 +434,10 @@
         },
         {
           "name": "learner_token_account",
+          "docs": [
+            "base mint (== Config.xp_mint) and token-account owner (== learner) are",
+            "asserted in the handler via `require_xp_recipient` before minting."
+          ],
           "writable": true
         },
         {
@@ -314,7 +462,16 @@
     },
     {
       "name": "create_achievement_type",
-      "discriminator": [231, 38, 39, 228, 103, 4, 229, 19],
+      "discriminator": [
+        231,
+        38,
+        39,
+        228,
+        103,
+        4,
+        229,
+        19
+      ],
       "accounts": [
         {
           "name": "config",
@@ -322,7 +479,14 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [99, 111, 110, 102, 105, 103]
+                "value": [
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
               }
             ]
           }
@@ -334,7 +498,19 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [97, 99, 104, 105, 101, 118, 101, 109, 101, 110, 116]
+                "value": [
+                  97,
+                  99,
+                  104,
+                  105,
+                  101,
+                  118,
+                  101,
+                  109,
+                  101,
+                  110,
+                  116
+                ]
               },
               {
                 "kind": "arg",
@@ -345,7 +521,9 @@
         },
         {
           "name": "collection",
-          "docs": ["New Metaplex Core collection keypair"],
+          "docs": [
+            "New Metaplex Core collection keypair"
+          ],
           "writable": true,
           "signer": true
         },
@@ -380,7 +558,16 @@
     },
     {
       "name": "create_course",
-      "discriminator": [120, 121, 154, 164, 107, 180, 167, 241],
+      "discriminator": [
+        120,
+        121,
+        154,
+        164,
+        107,
+        180,
+        167,
+        241
+      ],
       "accounts": [
         {
           "name": "course",
@@ -389,7 +576,14 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [99, 111, 117, 114, 115, 101]
+                "value": [
+                  99,
+                  111,
+                  117,
+                  114,
+                  115,
+                  101
+                ]
               },
               {
                 "kind": "arg",
@@ -404,7 +598,14 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [99, 111, 110, 102, 105, 103]
+                "value": [
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
               }
             ]
           }
@@ -413,7 +614,9 @@
           "name": "authority",
           "writable": true,
           "signer": true,
-          "relations": ["config"]
+          "relations": [
+            "config"
+          ]
         },
         {
           "name": "system_program",
@@ -433,7 +636,16 @@
     },
     {
       "name": "deactivate_achievement_type",
-      "discriminator": [185, 21, 222, 243, 192, 118, 71, 191],
+      "discriminator": [
+        185,
+        21,
+        222,
+        243,
+        192,
+        118,
+        71,
+        191
+      ],
       "accounts": [
         {
           "name": "config",
@@ -441,7 +653,14 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [99, 111, 110, 102, 105, 103]
+                "value": [
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
               }
             ]
           }
@@ -453,7 +672,19 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [97, 99, 104, 105, 101, 118, 101, 109, 101, 110, 116]
+                "value": [
+                  97,
+                  99,
+                  104,
+                  105,
+                  101,
+                  118,
+                  101,
+                  109,
+                  101,
+                  110,
+                  116
+                ]
               },
               {
                 "kind": "account",
@@ -472,7 +703,16 @@
     },
     {
       "name": "enroll",
-      "discriminator": [58, 12, 36, 3, 142, 28, 1, 43],
+      "discriminator": [
+        58,
+        12,
+        36,
+        3,
+        142,
+        28,
+        1,
+        43
+      ],
       "accounts": [
         {
           "name": "course",
@@ -481,7 +721,14 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [99, 111, 117, 114, 115, 101]
+                "value": [
+                  99,
+                  111,
+                  117,
+                  114,
+                  115,
+                  101
+                ]
               },
               {
                 "kind": "arg",
@@ -497,7 +744,18 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [101, 110, 114, 111, 108, 108, 109, 101, 110, 116]
+                "value": [
+                  101,
+                  110,
+                  114,
+                  111,
+                  108,
+                  108,
+                  109,
+                  101,
+                  110,
+                  116
+                ]
               },
               {
                 "kind": "arg",
@@ -529,7 +787,16 @@
     },
     {
       "name": "finalize_course",
-      "discriminator": [68, 189, 122, 239, 39, 121, 16, 218],
+      "discriminator": [
+        68,
+        189,
+        122,
+        239,
+        39,
+        121,
+        16,
+        218
+      ],
       "accounts": [
         {
           "name": "config",
@@ -537,7 +804,14 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [99, 111, 110, 102, 105, 103]
+                "value": [
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
               }
             ]
           }
@@ -549,7 +823,14 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [99, 111, 117, 114, 115, 101]
+                "value": [
+                  99,
+                  111,
+                  117,
+                  114,
+                  115,
+                  101
+                ]
               },
               {
                 "kind": "account",
@@ -566,7 +847,18 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [101, 110, 114, 111, 108, 108, 109, 101, 110, 116]
+                "value": [
+                  101,
+                  110,
+                  114,
+                  111,
+                  108,
+                  108,
+                  109,
+                  101,
+                  110,
+                  116
+                ]
               },
               {
                 "kind": "account",
@@ -585,10 +877,18 @@
         },
         {
           "name": "learner_token_account",
+          "docs": [
+            "its base mint (== Config.xp_mint) and token-account owner (== learner) are",
+            "asserted in the handler via `require_xp_recipient` before minting."
+          ],
           "writable": true
         },
         {
           "name": "creator_token_account",
+          "docs": [
+            "its base mint (== Config.xp_mint) and token-account owner (== creator) are",
+            "asserted in the handler via `require_xp_recipient` before minting."
+          ],
           "writable": true
         },
         {
@@ -611,7 +911,16 @@
     },
     {
       "name": "initialize",
-      "discriminator": [175, 175, 109, 31, 13, 152, 155, 237],
+      "discriminator": [
+        175,
+        175,
+        109,
+        31,
+        13,
+        152,
+        155,
+        237
+      ],
       "accounts": [
         {
           "name": "config",
@@ -620,7 +929,14 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [99, 111, 110, 102, 105, 103]
+                "value": [
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
               }
             ]
           }
@@ -649,7 +965,14 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [109, 105, 110, 116, 101, 114]
+                "value": [
+                  109,
+                  105,
+                  110,
+                  116,
+                  101,
+                  114
+                ]
               },
               {
                 "kind": "account",
@@ -671,7 +994,16 @@
     },
     {
       "name": "issue_credential",
-      "discriminator": [255, 193, 171, 224, 68, 171, 194, 87],
+      "discriminator": [
+        255,
+        193,
+        171,
+        224,
+        68,
+        171,
+        194,
+        87
+      ],
       "accounts": [
         {
           "name": "config",
@@ -679,7 +1011,14 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [99, 111, 110, 102, 105, 103]
+                "value": [
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
               }
             ]
           }
@@ -690,7 +1029,14 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [99, 111, 117, 114, 115, 101]
+                "value": [
+                  99,
+                  111,
+                  117,
+                  114,
+                  115,
+                  101
+                ]
               },
               {
                 "kind": "account",
@@ -707,7 +1053,18 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [101, 110, 114, 111, 108, 108, 109, 101, 110, 116]
+                "value": [
+                  101,
+                  110,
+                  114,
+                  111,
+                  108,
+                  108,
+                  109,
+                  101,
+                  110,
+                  116
+                ]
               },
               {
                 "kind": "account",
@@ -775,7 +1132,16 @@
     },
     {
       "name": "register_minter",
-      "discriminator": [58, 224, 74, 142, 170, 95, 116, 191],
+      "discriminator": [
+        58,
+        224,
+        74,
+        142,
+        170,
+        95,
+        116,
+        191
+      ],
       "accounts": [
         {
           "name": "config",
@@ -783,7 +1149,14 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [99, 111, 110, 102, 105, 103]
+                "value": [
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
               }
             ]
           }
@@ -795,7 +1168,14 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [109, 105, 110, 116, 101, 114]
+                "value": [
+                  109,
+                  105,
+                  110,
+                  116,
+                  101,
+                  114
+                ]
               },
               {
                 "kind": "arg",
@@ -832,7 +1212,16 @@
     },
     {
       "name": "revoke_minter",
-      "discriminator": [33, 91, 131, 167, 62, 37, 38, 105],
+      "discriminator": [
+        33,
+        91,
+        131,
+        167,
+        62,
+        37,
+        38,
+        105
+      ],
       "accounts": [
         {
           "name": "config",
@@ -840,7 +1229,14 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [99, 111, 110, 102, 105, 103]
+                "value": [
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
               }
             ]
           }
@@ -852,7 +1248,14 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [109, 105, 110, 116, 101, 114]
+                "value": [
+                  109,
+                  105,
+                  110,
+                  116,
+                  101,
+                  114
+                ]
               },
               {
                 "kind": "account",
@@ -872,7 +1275,16 @@
     },
     {
       "name": "reward_xp",
-      "discriminator": [144, 187, 117, 238, 89, 118, 224, 145],
+      "discriminator": [
+        144,
+        187,
+        117,
+        238,
+        89,
+        118,
+        224,
+        145
+      ],
       "accounts": [
         {
           "name": "config",
@@ -880,7 +1292,14 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [99, 111, 110, 102, 105, 103]
+                "value": [
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
               }
             ]
           }
@@ -892,7 +1311,14 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [109, 105, 110, 116, 101, 114]
+                "value": [
+                  109,
+                  105,
+                  110,
+                  116,
+                  101,
+                  114
+                ]
               },
               {
                 "kind": "account",
@@ -903,12 +1329,24 @@
         },
         {
           "name": "xp_mint",
-          "docs": ["Token-2022 XP mint"],
+          "docs": [
+            "Token-2022 XP mint"
+          ],
           "writable": true
         },
         {
           "name": "recipient_token_account",
-          "docs": ["Recipient's Token-2022 ATA for XP"],
+          "docs": [
+            "Recipient's Token-2022 ATA for XP.",
+            "",
+            "reward_xp is address-based by design: the minter passes the destination",
+            "ATA directly and there is no on-chain recipient-identity account to bind",
+            "its owner against (unlike complete_lesson/finalize_course/award_achievement,",
+            "which each own a learner/creator/recipient key). The mint is still pinned",
+            "via `require_xp_mint` (== Config.xp_mint) and the amount is bounded by",
+            "MAX_XP_PER_MINT + the per-minter cap, so the account cannot be an ATA of an",
+            "unrelated mint and the per-call blast radius is bounded."
+          ],
           "writable": true
         },
         {
@@ -937,7 +1375,16 @@
     },
     {
       "name": "update_config",
-      "discriminator": [29, 158, 252, 191, 10, 83, 219, 99],
+      "discriminator": [
+        29,
+        158,
+        252,
+        191,
+        10,
+        83,
+        219,
+        99
+      ],
       "accounts": [
         {
           "name": "config",
@@ -946,7 +1393,14 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [99, 111, 110, 102, 105, 103]
+                "value": [
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
               }
             ]
           }
@@ -954,7 +1408,9 @@
         {
           "name": "authority",
           "signer": true,
-          "relations": ["config"]
+          "relations": [
+            "config"
+          ]
         }
       ],
       "args": [
@@ -970,7 +1426,16 @@
     },
     {
       "name": "update_course",
-      "discriminator": [81, 217, 18, 192, 129, 233, 129, 231],
+      "discriminator": [
+        81,
+        217,
+        18,
+        192,
+        129,
+        233,
+        129,
+        231
+      ],
       "accounts": [
         {
           "name": "config",
@@ -978,7 +1443,14 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [99, 111, 110, 102, 105, 103]
+                "value": [
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
               }
             ]
           }
@@ -990,7 +1462,14 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [99, 111, 117, 114, 115, 101]
+                "value": [
+                  99,
+                  111,
+                  117,
+                  114,
+                  115,
+                  101
+                ]
               },
               {
                 "kind": "account",
@@ -1003,7 +1482,9 @@
         {
           "name": "authority",
           "signer": true,
-          "relations": ["config"]
+          "relations": [
+            "config"
+          ]
         }
       ],
       "args": [
@@ -1019,7 +1500,16 @@
     },
     {
       "name": "update_minter",
-      "discriminator": [164, 129, 164, 88, 75, 29, 91, 38],
+      "discriminator": [
+        164,
+        129,
+        164,
+        88,
+        75,
+        29,
+        91,
+        38
+      ],
       "accounts": [
         {
           "name": "config",
@@ -1027,7 +1517,14 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [99, 111, 110, 102, 105, 103]
+                "value": [
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
               }
             ]
           }
@@ -1039,7 +1536,14 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [109, 105, 110, 116, 101, 114]
+                "value": [
+                  109,
+                  105,
+                  110,
+                  116,
+                  101,
+                  114
+                ]
               },
               {
                 "kind": "account",
@@ -1067,7 +1571,16 @@
     },
     {
       "name": "upgrade_credential",
-      "discriminator": [2, 121, 77, 255, 103, 187, 252, 169],
+      "discriminator": [
+        2,
+        121,
+        77,
+        255,
+        103,
+        187,
+        252,
+        169
+      ],
       "accounts": [
         {
           "name": "config",
@@ -1075,7 +1588,14 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [99, 111, 110, 102, 105, 103]
+                "value": [
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
               }
             ]
           }
@@ -1086,7 +1606,14 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [99, 111, 117, 114, 115, 101]
+                "value": [
+                  99,
+                  111,
+                  117,
+                  114,
+                  115,
+                  101
+                ]
               },
               {
                 "kind": "account",
@@ -1102,7 +1629,18 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [101, 110, 114, 111, 108, 108, 109, 101, 110, 116]
+                "value": [
+                  101,
+                  110,
+                  114,
+                  111,
+                  108,
+                  108,
+                  109,
+                  101,
+                  110,
+                  116
+                ]
               },
               {
                 "kind": "account",
@@ -1171,101 +1709,317 @@
   "accounts": [
     {
       "name": "AchievementReceipt",
-      "discriminator": [149, 5, 79, 178, 116, 231, 43, 248]
+      "discriminator": [
+        149,
+        5,
+        79,
+        178,
+        116,
+        231,
+        43,
+        248
+      ]
     },
     {
       "name": "AchievementType",
-      "discriminator": [13, 187, 114, 66, 217, 154, 85, 137]
+      "discriminator": [
+        13,
+        187,
+        114,
+        66,
+        217,
+        154,
+        85,
+        137
+      ]
     },
     {
       "name": "Config",
-      "discriminator": [155, 12, 170, 224, 30, 250, 204, 130]
+      "discriminator": [
+        155,
+        12,
+        170,
+        224,
+        30,
+        250,
+        204,
+        130
+      ]
     },
     {
       "name": "Course",
-      "discriminator": [206, 6, 78, 228, 163, 138, 241, 106]
+      "discriminator": [
+        206,
+        6,
+        78,
+        228,
+        163,
+        138,
+        241,
+        106
+      ]
     },
     {
       "name": "Enrollment",
-      "discriminator": [249, 210, 64, 145, 197, 241, 57, 51]
+      "discriminator": [
+        249,
+        210,
+        64,
+        145,
+        197,
+        241,
+        57,
+        51
+      ]
     },
     {
       "name": "MinterRole",
-      "discriminator": [21, 246, 6, 133, 142, 211, 33, 193]
+      "discriminator": [
+        21,
+        246,
+        6,
+        133,
+        142,
+        211,
+        33,
+        193
+      ]
     }
   ],
   "events": [
     {
       "name": "AchievementAwarded",
-      "discriminator": [127, 212, 93, 231, 175, 0, 69, 150]
+      "discriminator": [
+        127,
+        212,
+        93,
+        231,
+        175,
+        0,
+        69,
+        150
+      ]
     },
     {
       "name": "AchievementTypeCreated",
-      "discriminator": [189, 36, 173, 243, 25, 232, 198, 153]
+      "discriminator": [
+        189,
+        36,
+        173,
+        243,
+        25,
+        232,
+        198,
+        153
+      ]
     },
     {
       "name": "AchievementTypeDeactivated",
-      "discriminator": [133, 12, 218, 127, 151, 28, 1, 222]
+      "discriminator": [
+        133,
+        12,
+        218,
+        127,
+        151,
+        28,
+        1,
+        222
+      ]
     },
     {
       "name": "ConfigUpdated",
-      "discriminator": [40, 241, 230, 122, 11, 19, 198, 194]
+      "discriminator": [
+        40,
+        241,
+        230,
+        122,
+        11,
+        19,
+        198,
+        194
+      ]
     },
     {
       "name": "CourseClosed",
-      "discriminator": [35, 195, 37, 254, 25, 107, 100, 12]
+      "discriminator": [
+        35,
+        195,
+        37,
+        254,
+        25,
+        107,
+        100,
+        12
+      ]
     },
     {
       "name": "CourseCreated",
-      "discriminator": [205, 144, 55, 47, 150, 170, 123, 214]
+      "discriminator": [
+        205,
+        144,
+        55,
+        47,
+        150,
+        170,
+        123,
+        214
+      ]
     },
     {
       "name": "CourseFinalized",
-      "discriminator": [18, 195, 195, 25, 165, 189, 194, 56]
+      "discriminator": [
+        18,
+        195,
+        195,
+        25,
+        165,
+        189,
+        194,
+        56
+      ]
     },
     {
       "name": "CourseUpdated",
-      "discriminator": [124, 141, 110, 224, 149, 124, 26, 141]
+      "discriminator": [
+        124,
+        141,
+        110,
+        224,
+        149,
+        124,
+        26,
+        141
+      ]
     },
     {
       "name": "CredentialIssued",
-      "discriminator": [194, 216, 28, 159, 89, 29, 72, 177]
+      "discriminator": [
+        194,
+        216,
+        28,
+        159,
+        89,
+        29,
+        72,
+        177
+      ]
     },
     {
       "name": "CredentialUpgraded",
-      "discriminator": [198, 142, 252, 191, 210, 200, 253, 133]
+      "discriminator": [
+        198,
+        142,
+        252,
+        191,
+        210,
+        200,
+        253,
+        133
+      ]
     },
     {
       "name": "Enrolled",
-      "discriminator": [129, 156, 102, 214, 94, 196, 220, 127]
+      "discriminator": [
+        129,
+        156,
+        102,
+        214,
+        94,
+        196,
+        220,
+        127
+      ]
     },
     {
       "name": "EnrollmentClosed",
-      "discriminator": [197, 4, 145, 238, 217, 4, 175, 77]
+      "discriminator": [
+        197,
+        4,
+        145,
+        238,
+        217,
+        4,
+        175,
+        77
+      ]
     },
     {
       "name": "LessonCompleted",
-      "discriminator": [248, 174, 148, 235, 186, 49, 11, 163]
+      "discriminator": [
+        248,
+        174,
+        148,
+        235,
+        186,
+        49,
+        11,
+        163
+      ]
     },
     {
       "name": "MinterRegistered",
-      "discriminator": [104, 203, 87, 105, 23, 33, 231, 1]
+      "discriminator": [
+        104,
+        203,
+        87,
+        105,
+        23,
+        33,
+        231,
+        1
+      ]
     },
     {
       "name": "MinterRevoked",
-      "discriminator": [138, 76, 227, 247, 141, 92, 77, 127]
+      "discriminator": [
+        138,
+        76,
+        227,
+        247,
+        141,
+        92,
+        77,
+        127
+      ]
     },
     {
       "name": "MinterUpdated",
-      "discriminator": [8, 124, 66, 45, 176, 53, 49, 153]
+      "discriminator": [
+        8,
+        124,
+        66,
+        45,
+        176,
+        53,
+        49,
+        153
+      ]
     },
     {
       "name": "MintingPauseSet",
-      "discriminator": [232, 11, 219, 8, 116, 65, 178, 74]
+      "discriminator": [
+        232,
+        11,
+        219,
+        8,
+        116,
+        65,
+        178,
+        74
+      ]
     },
     {
       "name": "XpRewarded",
-      "discriminator": [140, 182, 232, 144, 16, 155, 237, 182]
+      "discriminator": [
+        140,
+        182,
+        232,
+        144,
+        16,
+        155,
+        237,
+        182
+      ]
     }
   ],
   "errors": [
@@ -1480,7 +2234,9 @@
         "fields": [
           {
             "name": "asset",
-            "docs": ["Metaplex Core NFT address"],
+            "docs": [
+              "Metaplex Core NFT address"
+            ],
             "type": "pubkey"
           },
           {
@@ -1509,12 +2265,16 @@
           },
           {
             "name": "metadata_uri",
-            "docs": ["Default metadata URI for minted NFTs"],
+            "docs": [
+              "Default metadata URI for minted NFTs"
+            ],
             "type": "string"
           },
           {
             "name": "collection",
-            "docs": ["Metaplex Core collection for this achievement"],
+            "docs": [
+              "Metaplex Core collection for this achievement"
+            ],
             "type": "pubkey"
           },
           {
@@ -1523,7 +2283,9 @@
           },
           {
             "name": "max_supply",
-            "docs": ["0 = unlimited supply"],
+            "docs": [
+              "0 = unlimited supply"
+            ],
             "type": "u32"
           },
           {
@@ -1532,7 +2294,9 @@
           },
           {
             "name": "xp_reward",
-            "docs": ["XP awarded alongside the NFT (0 = no XP)"],
+            "docs": [
+              "XP awarded alongside the NFT (0 = no XP)"
+            ],
             "type": "u32"
           },
           {
@@ -1546,7 +2310,10 @@
           {
             "name": "_reserved",
             "type": {
-              "array": ["u8", 8]
+              "array": [
+                "u8",
+                8
+              ]
             }
           },
           {
@@ -1611,17 +2378,23 @@
         "fields": [
           {
             "name": "authority",
-            "docs": ["Platform multisig (Squads)"],
+            "docs": [
+              "Platform multisig (Squads)"
+            ],
             "type": "pubkey"
           },
           {
             "name": "backend_signer",
-            "docs": ["Rotatable backend signer for completions"],
+            "docs": [
+              "Rotatable backend signer for completions"
+            ],
             "type": "pubkey"
           },
           {
             "name": "xp_mint",
-            "docs": ["Token-2022 mint for XP"],
+            "docs": [
+              "Token-2022 mint for XP"
+            ],
             "type": "pubkey"
           },
           {
@@ -1636,14 +2409,21 @@
           },
           {
             "name": "_reserved",
-            "docs": ["Reserved for future use"],
+            "docs": [
+              "Reserved for future use"
+            ],
             "type": {
-              "array": ["u8", 7]
+              "array": [
+                "u8",
+                7
+              ]
             }
           },
           {
             "name": "bump",
-            "docs": ["PDA bump"],
+            "docs": [
+              "PDA bump"
+            ],
             "type": "u8"
           }
         ]
@@ -1684,7 +2464,10 @@
           {
             "name": "content_tx_id",
             "type": {
-              "array": ["u8", 32]
+              "array": [
+                "u8",
+                32
+              ]
             }
           },
           {
@@ -1756,7 +2539,10 @@
           {
             "name": "_reserved",
             "type": {
-              "array": ["u8", 8]
+              "array": [
+                "u8",
+                8
+              ]
             }
           },
           {
@@ -1926,7 +2712,10 @@
           {
             "name": "content_tx_id",
             "type": {
-              "array": ["u8", 32]
+              "array": [
+                "u8",
+                32
+              ]
             }
           },
           {
@@ -2063,17 +2852,23 @@
         "fields": [
           {
             "name": "course",
-            "docs": ["The Course PDA this enrollment belongs to"],
+            "docs": [
+              "The Course PDA this enrollment belongs to"
+            ],
             "type": "pubkey"
           },
           {
             "name": "enrolled_at",
-            "docs": ["When learner enrolled"],
+            "docs": [
+              "When learner enrolled"
+            ],
             "type": "i64"
           },
           {
             "name": "completed_at",
-            "docs": ["When course was completed (None if in progress)"],
+            "docs": [
+              "When course was completed (None if in progress)"
+            ],
             "type": {
               "option": "i64"
             }
@@ -2085,7 +2880,10 @@
               "lesson_count is u8 (max 255), so all valid indices fit within this bitmap."
             ],
             "type": {
-              "array": ["u64", 4]
+              "array": [
+                "u64",
+                4
+              ]
             }
           },
           {
@@ -2100,15 +2898,30 @@
           {
             "name": "_reserved",
             "docs": [
-              "Reserved for future use (4 bytes — differs from 8 on other accounts; cannot resize without migration)"
+              "Forward-compat padding (4 bytes — differs from the 8 reserved on other",
+              "accounts). A future field is carved from this in place, the same way",
+              "`Config.paused` and `MinterRole.max_total_xp` were: replace some of these",
+              "bytes with a real field declared immediately before `bump` so the field's",
+              "Borsh offset is unchanged, and shrink `_reserved` by the field's width so",
+              "`SIZE` stays constant. Because Borsh lays fields out in declaration order",
+              "and these bytes are already zero on every existing account, legacy",
+              "enrollments deserialize the new field as all-zeros (`0` / `false` /",
+              "`None`) — pick a type whose zero value preserves prior behavior. Widening",
+              "past these 4 bytes (or reordering fields) changes the layout/account size",
+              "and is a migration (realloc + backfill), not an in-place change."
             ],
             "type": {
-              "array": ["u8", 4]
+              "array": [
+                "u8",
+                4
+              ]
             }
           },
           {
             "name": "bump",
-            "docs": ["PDA bump"],
+            "docs": [
+              "PDA bump"
+            ],
             "type": "u8"
           }
         ]
@@ -2225,7 +3038,9 @@
         "fields": [
           {
             "name": "minter",
-            "docs": ["Wallet or program PDA authorized to mint XP"],
+            "docs": [
+              "Wallet or program PDA authorized to mint XP"
+            ],
             "type": "pubkey"
           },
           {
@@ -2237,12 +3052,16 @@
           },
           {
             "name": "max_xp_per_call",
-            "docs": ["Per-call XP cap. 0 = unlimited."],
+            "docs": [
+              "Per-call XP cap. 0 = unlimited."
+            ],
             "type": "u64"
           },
           {
             "name": "total_xp_minted",
-            "docs": ["Lifetime XP minted through this role"],
+            "docs": [
+              "Lifetime XP minted through this role"
+            ],
             "type": "u64"
           },
           {
@@ -2329,7 +3148,9 @@
           },
           {
             "name": "max_total_xp",
-            "docs": ["Cumulative XP ceiling for this role. 0 = unlimited."],
+            "docs": [
+              "Cumulative XP ceiling for this role. 0 = unlimited."
+            ],
             "type": "u64"
           }
         ]
@@ -2355,6 +3176,19 @@
             "type": {
               "option": "bool"
             }
+          },
+          {
+            "name": "new_authority",
+            "docs": [
+              "Rotate the platform authority (governance handover). `Some(a)` sets",
+              "`Config.authority = a`, `None` leaves it unchanged. The struct's",
+              "`has_one = authority` gate means the CURRENT authority co-signs the",
+              "rotation, so this cannot be used to seize control — only to hand it off",
+              "(e.g. to a Squads multisig) without a program upgrade."
+            ],
+            "type": {
+              "option": "pubkey"
+            }
           }
         ]
       }
@@ -2368,7 +3202,10 @@
             "name": "new_content_tx_id",
             "type": {
               "option": {
-                "array": ["u8", 32]
+                "array": [
+                  "u8",
+                  32
+                ]
               }
             }
           },
@@ -2415,7 +3252,9 @@
         "fields": [
           {
             "name": "max_xp_per_call",
-            "docs": ["New per-call XP cap. 0 = unlimited."],
+            "docs": [
+              "New per-call XP cap. 0 = unlimited."
+            ],
             "type": "u64"
           },
           {

--- a/onchain-academy/programs/onchain-academy/src/instructions/award_achievement.rs
+++ b/onchain-academy/programs/onchain-academy/src/instructions/award_achievement.rs
@@ -10,7 +10,7 @@ use mpl_core::{
 use crate::errors::AcademyError;
 use crate::events::AchievementAwarded;
 use crate::state::{AchievementReceipt, AchievementType, Config, MinterRole};
-use crate::utils::{mint_xp, require_xp_mint, MAX_XP_PER_MINT};
+use crate::utils::{mint_xp, require_xp_recipient, MAX_XP_PER_MINT};
 
 pub fn handler(ctx: Context<AwardAchievement>) -> Result<()> {
     require!(!ctx.accounts.config.paused, AcademyError::MintingPaused);
@@ -94,9 +94,16 @@ pub fn handler(ctx: Context<AwardAchievement>) -> Result<()> {
         ])
         .invoke_signed(signer_seeds)?;
 
-    // Mint XP if xp_reward > 0
+    // Mint XP if xp_reward > 0. Bind the recipient ATA to the achievement
+    // recipient: mint == Config.xp_mint AND owner == recipient (the same key that
+    // owns the minted NFT and seeds the achievement_receipt PDA), so the XP can
+    // only land in the recipient's own account.
     if achievement.xp_reward > 0 {
-        require_xp_mint(&ctx.accounts.recipient_token_account, &config.xp_mint)?;
+        require_xp_recipient(
+            &ctx.accounts.recipient_token_account,
+            &config.xp_mint,
+            &ctx.accounts.recipient.key(),
+        )?;
         mint_xp(
             &ctx.accounts.xp_mint.to_account_info(),
             &ctx.accounts.recipient_token_account.to_account_info(),
@@ -184,7 +191,9 @@ pub struct AwardAchievement<'info> {
     /// CHECK: Recipient of the achievement NFT.
     pub recipient: AccountInfo<'info>,
 
-    /// CHECK: Recipient's Token-2022 ATA. Only used if xp_reward > 0. Validated by CPI.
+    /// CHECK: Recipient's Token-2022 ATA. Only used if xp_reward > 0. When used,
+    /// its base mint (== Config.xp_mint) and token-account owner (== recipient)
+    /// are asserted in the handler via `require_xp_recipient` before minting.
     #[account(mut)]
     pub recipient_token_account: AccountInfo<'info>,
 

--- a/onchain-academy/programs/onchain-academy/src/instructions/complete_lesson.rs
+++ b/onchain-academy/programs/onchain-academy/src/instructions/complete_lesson.rs
@@ -32,7 +32,13 @@ pub fn handler(ctx: Context<CompleteLesson>, lesson_index: u8) -> Result<()> {
         AcademyError::XpAmountExceedsMax
     );
 
-    utils::require_xp_mint(&ctx.accounts.learner_token_account, &config.xp_mint)?;
+    // Bind the recipient ATA to the learner: mint == Config.xp_mint AND owner ==
+    // learner, so the XP can only land in the learner's own account.
+    utils::require_xp_recipient(
+        &ctx.accounts.learner_token_account,
+        &config.xp_mint,
+        &ctx.accounts.learner.key(),
+    )?;
 
     let config_seeds: &[&[u8]] = &[b"config", &[config.bump]];
 
@@ -81,7 +87,9 @@ pub struct CompleteLesson<'info> {
     /// CHECK: Tied to enrollment PDA via seeds constraint.
     pub learner: AccountInfo<'info>,
 
-    /// CHECK: Token-2022 ATA for learner's XP. Validated by Token-2022 CPI + program owner check.
+    /// CHECK: Token-2022 ATA for learner's XP. Program-owner checked here; its
+    /// base mint (== Config.xp_mint) and token-account owner (== learner) are
+    /// asserted in the handler via `require_xp_recipient` before minting.
     #[account(
         mut,
         constraint = learner_token_account.owner == &spl_token_2022::id() @ AcademyError::Unauthorized,

--- a/onchain-academy/programs/onchain-academy/src/instructions/finalize_course.rs
+++ b/onchain-academy/programs/onchain-academy/src/instructions/finalize_course.rs
@@ -46,7 +46,13 @@ pub fn handler(ctx: Context<FinalizeCourse>) -> Result<()> {
     );
 
     if bonus_xp > 0 {
-        utils::require_xp_mint(&ctx.accounts.learner_token_account, &config.xp_mint)?;
+        // Bind the bonus ATA to the learner (mint == Config.xp_mint, owner ==
+        // learner) so the bonus can only land in the learner's own account.
+        utils::require_xp_recipient(
+            &ctx.accounts.learner_token_account,
+            &config.xp_mint,
+            &ctx.accounts.learner.key(),
+        )?;
         utils::mint_xp(
             &ctx.accounts.xp_mint.to_account_info(),
             &ctx.accounts.learner_token_account.to_account_info(),
@@ -66,7 +72,14 @@ pub fn handler(ctx: Context<FinalizeCourse>) -> Result<()> {
             course.creator_reward_xp as u64 <= utils::MAX_XP_PER_MINT,
             AcademyError::XpAmountExceedsMax
         );
-        utils::require_xp_mint(&ctx.accounts.creator_token_account, &config.xp_mint)?;
+        // Bind the creator-reward ATA to the creator (mint == Config.xp_mint,
+        // owner == creator) so the reward can only land in the creator's own
+        // account. `creator` is itself pinned to course.creator on the struct.
+        utils::require_xp_recipient(
+            &ctx.accounts.creator_token_account,
+            &config.xp_mint,
+            &ctx.accounts.creator.key(),
+        )?;
         utils::mint_xp(
             &ctx.accounts.xp_mint.to_account_info(),
             &ctx.accounts.creator_token_account.to_account_info(),
@@ -119,14 +132,18 @@ pub struct FinalizeCourse<'info> {
     /// CHECK: Tied to enrollment PDA via seeds constraint.
     pub learner: AccountInfo<'info>,
 
-    /// CHECK: Token-2022 ATA for learner's XP. Validated by Token-2022 CPI + owner derivation.
+    /// CHECK: Token-2022 ATA for learner's XP bonus. Program-owner checked here;
+    /// its base mint (== Config.xp_mint) and token-account owner (== learner) are
+    /// asserted in the handler via `require_xp_recipient` before minting.
     #[account(
         mut,
         constraint = learner_token_account.owner == &spl_token_2022::id() @ AcademyError::Unauthorized,
     )]
     pub learner_token_account: AccountInfo<'info>,
 
-    /// CHECK: Token-2022 ATA for creator's XP. Validated by Token-2022 CPI + owner derivation.
+    /// CHECK: Token-2022 ATA for creator's XP reward. Program-owner checked here;
+    /// its base mint (== Config.xp_mint) and token-account owner (== creator) are
+    /// asserted in the handler via `require_xp_recipient` before minting.
     #[account(
         mut,
         constraint = creator_token_account.owner == &spl_token_2022::id() @ AcademyError::Unauthorized,

--- a/onchain-academy/programs/onchain-academy/src/instructions/revoke_minter.rs
+++ b/onchain-academy/programs/onchain-academy/src/instructions/revoke_minter.rs
@@ -7,6 +7,16 @@ use crate::state::{Config, MinterRole};
 pub fn handler(ctx: Context<RevokeMinter>) -> Result<()> {
     let role = &ctx.accounts.minter_role;
 
+    // Do not let revoke_minter brick the backend's own minting role: closing the
+    // role whose minter == Config.backend_signer would leave the live backend
+    // authorized as signer but unable to mint (its MinterRole PDA gone), silently
+    // breaking completions. Operators must rotate backend_signer via update_config
+    // first — which deactivates the old role — then revoke it.
+    require!(
+        role.minter != ctx.accounts.config.backend_signer,
+        AcademyError::Unauthorized
+    );
+
     emit!(MinterRevoked {
         minter: role.minter,
         total_xp_minted: role.total_xp_minted,

--- a/onchain-academy/programs/onchain-academy/src/instructions/reward_xp.rs
+++ b/onchain-academy/programs/onchain-academy/src/instructions/reward_xp.rs
@@ -3,7 +3,7 @@ use anchor_lang::prelude::*;
 use crate::errors::AcademyError;
 use crate::events::XpRewarded;
 use crate::state::{Config, MinterRole};
-use crate::utils::{mint_xp, require_xp_mint};
+use crate::utils::{mint_xp, require_xp_mint, MAX_XP_PER_MINT};
 
 pub fn handler(ctx: Context<RewardXp>, amount: u64, memo: String) -> Result<()> {
     require!(!ctx.accounts.config.paused, AcademyError::MintingPaused);
@@ -12,6 +12,11 @@ pub fn handler(ctx: Context<RewardXp>, amount: u64, memo: String) -> Result<()> 
 
     require!(role.is_active, AcademyError::MinterNotActive);
     require!(amount > 0, AcademyError::InvalidAmount);
+    // Absolute per-call ceiling: this is the only general-purpose XP-mint path,
+    // so an unbounded (or over-generously capped) minter role would otherwise let
+    // a leaked backend_signer mint an arbitrary amount in one call. Bounds the
+    // blast radius; the per-minter cap below still applies on top.
+    require!(amount <= MAX_XP_PER_MINT, AcademyError::XpAmountExceedsMax);
 
     if role.max_xp_per_call > 0 {
         require!(
@@ -84,8 +89,16 @@ pub struct RewardXp<'info> {
     )]
     pub xp_mint: AccountInfo<'info>,
 
-    /// Recipient's Token-2022 ATA for XP
-    /// CHECK: Validated by Token-2022 CPI.
+    /// Recipient's Token-2022 ATA for XP.
+    ///
+    /// reward_xp is address-based by design: the minter passes the destination
+    /// ATA directly and there is no on-chain recipient-identity account to bind
+    /// its owner against (unlike complete_lesson/finalize_course/award_achievement,
+    /// which each own a learner/creator/recipient key). The mint is still pinned
+    /// via `require_xp_mint` (== Config.xp_mint) and the amount is bounded by
+    /// MAX_XP_PER_MINT + the per-minter cap, so the account cannot be an ATA of an
+    /// unrelated mint and the per-call blast radius is bounded.
+    /// CHECK: Validated by require_xp_mint + Token-2022 CPI.
     #[account(mut)]
     pub recipient_token_account: AccountInfo<'info>,
 

--- a/onchain-academy/programs/onchain-academy/src/instructions/update_config.rs
+++ b/onchain-academy/programs/onchain-academy/src/instructions/update_config.rs
@@ -10,6 +10,16 @@ pub struct UpdateConfigParams {
     /// Minting kill-switch toggle. `Some(true)` pauses all minting,
     /// `Some(false)` resumes, `None` leaves it unchanged.
     pub paused: Option<bool>,
+    /// Rotate the platform authority (governance handover). `Some(a)` sets
+    /// `Config.authority = a`, `None` leaves it unchanged. The struct's
+    /// `has_one = authority` gate means the CURRENT authority co-signs the
+    /// rotation, so this cannot be used to seize control — only to hand it off
+    /// (e.g. to a Squads multisig) without a program upgrade.
+    // TODO: two-step nominate/accept (store a pending_authority; require the
+    // nominee to sign an accept_authority ix) to guard against handoff to a
+    // mistyped / uncontrolled key. One-step is sufficient for the initial
+    // EOA -> multisig handover this fix unblocks.
+    pub new_authority: Option<Pubkey>,
 }
 
 pub fn handler<'info>(
@@ -48,6 +58,20 @@ pub fn handler<'info>(
         config.paused = paused;
         emit!(MintingPauseSet {
             paused,
+            timestamp: Clock::get()?.unix_timestamp,
+        });
+    }
+
+    if let Some(new_authority) = params.new_authority {
+        // Reject the zero pubkey — an unrecoverable handoff that would brick
+        // governance. The current authority already co-signs (has_one).
+        require!(
+            new_authority != Pubkey::default(),
+            AcademyError::Unauthorized
+        );
+        config.authority = new_authority;
+        emit!(ConfigUpdated {
+            field: "authority".to_string(),
             timestamp: Clock::get()?.unix_timestamp,
         });
     }

--- a/onchain-academy/programs/onchain-academy/src/utils.rs
+++ b/onchain-academy/programs/onchain-academy/src/utils.rs
@@ -32,6 +32,36 @@ pub fn require_xp_mint(token_account: &AccountInfo, expected_mint: &Pubkey) -> R
     Ok(())
 }
 
+/// Asserts that `token_account` is a Token-2022 account whose base mint equals
+/// `expected_mint` (== `Config.xp_mint`) AND whose token-account authority
+/// equals `expected_owner`.
+///
+/// The mint check alone (see `require_xp_mint`) does not bind *whose* account
+/// receives the XP: a leaked/buggy backend could pass any wallet's XP ATA and
+/// mint to it while the emitted event names a different learner/creator/recipient.
+/// Binding the owner closes that gap — XP can only ever land in the intended
+/// identity's own account. Used on every recipient-identity-bearing mint path
+/// (complete_lesson, finalize_course, award_achievement); the address-based
+/// reward_xp path has no on-chain recipient identity and keeps `require_xp_mint`.
+pub fn require_xp_recipient(
+    token_account: &AccountInfo,
+    expected_mint: &Pubkey,
+    expected_owner: &Pubkey,
+) -> Result<()> {
+    let data = token_account.try_borrow_data()?;
+    let state =
+        spl_token_2022::extension::StateWithExtensions::<spl_token_2022::state::Account>::unpack(
+            &data,
+        )?;
+    require_keys_eq!(state.base.mint, *expected_mint, AcademyError::WrongXpMint);
+    require_keys_eq!(
+        state.base.owner,
+        *expected_owner,
+        AcademyError::Unauthorized
+    );
+    Ok(())
+}
+
 /// Mints XP tokens via Token-2022 CPI. The authority (Config PDA) signs
 /// using the provided seeds.
 pub fn mint_xp<'info>(

--- a/onchain-academy/tests/onchain-academy.ts
+++ b/onchain-academy/tests/onchain-academy.ts
@@ -183,6 +183,7 @@ describe("onchain-academy", () => {
         .updateConfig({
           newBackendSigner: newSigner.publicKey,
           paused: null,
+          newAuthority: null,
         })
         .accountsPartial({
           config: configPda,
@@ -200,6 +201,7 @@ describe("onchain-academy", () => {
         .updateConfig({
           newBackendSigner: authority.publicKey,
           paused: null,
+          newAuthority: null,
         })
         .accountsPartial({
           config: configPda,
@@ -220,6 +222,7 @@ describe("onchain-academy", () => {
         .updateConfig({
           newBackendSigner: null,
           paused: null,
+          newAuthority: null,
         })
         .accountsPartial({
           config: configPda,
@@ -246,6 +249,7 @@ describe("onchain-academy", () => {
           .updateConfig({
             newBackendSigner: imposter.publicKey,
             paused: null,
+            newAuthority: null,
           })
           .accountsPartial({
             config: configPda,
@@ -281,6 +285,7 @@ describe("onchain-academy", () => {
           .updateConfig({
             newBackendSigner: null,
             paused: true,
+            newAuthority: null,
           })
           .accountsPartial({
             config: configPda,
@@ -308,6 +313,7 @@ describe("onchain-academy", () => {
         .updateConfig({
           newBackendSigner: null,
           paused: true,
+          newAuthority: null,
         })
         .accountsPartial({
           config: configPda,
@@ -323,6 +329,7 @@ describe("onchain-academy", () => {
         .updateConfig({
           newBackendSigner: null,
           paused: false,
+          newAuthority: null,
         })
         .accountsPartial({
           config: configPda,
@@ -4486,6 +4493,7 @@ describe("onchain-academy", () => {
         .updateConfig({
           newBackendSigner: newSigner.publicKey,
           paused: null,
+          newAuthority: null,
         })
         .accountsPartial({
           config: configPda,
@@ -4517,6 +4525,7 @@ describe("onchain-academy", () => {
         .updateConfig({
           newBackendSigner: authority.publicKey,
           paused: null,
+          newAuthority: null,
         })
         .accountsPartial({
           config: configPda,
@@ -5494,14 +5503,14 @@ describe("onchain-academy", () => {
 
     const pause = async (): Promise<void> => {
       await program.methods
-        .updateConfig({ newBackendSigner: null, paused: true })
+        .updateConfig({ newBackendSigner: null, paused: true, newAuthority: null })
         .accountsPartial({ config: configPda, authority: authority.publicKey })
         .rpc();
     };
 
     const resume = async (): Promise<void> => {
       await program.methods
-        .updateConfig({ newBackendSigner: null, paused: false })
+        .updateConfig({ newBackendSigner: null, paused: false, newAuthority: null })
         .accountsPartial({ config: configPda, authority: authority.publicKey })
         .rpc();
     };

--- a/onchain-academy/tests/rust/src/lib.rs
+++ b/onchain-academy/tests/rust/src/lib.rs
@@ -3,6 +3,8 @@ pub mod helpers;
 #[cfg(test)]
 mod test_achievement;
 #[cfg(test)]
+mod test_audit_hardening;
+#[cfg(test)]
 mod test_close_course;
 #[cfg(test)]
 mod test_completion;

--- a/onchain-academy/tests/rust/src/test_achievement.rs
+++ b/onchain-academy/tests/rust/src/test_achievement.rs
@@ -1,10 +1,10 @@
 use crate::helpers::*;
 use anchor_lang::{AnchorDeserialize, AnchorSerialize};
-use solana_sdk::pubkey::Pubkey;
 use onchain_academy::state::{
     AchievementReceipt, AchievementType, MAX_ACHIEVEMENT_ID_LEN, MAX_ACHIEVEMENT_NAME_LEN,
     MAX_ACHIEVEMENT_URI_LEN,
 };
+use solana_sdk::pubkey::Pubkey;
 
 // --- AchievementType ---
 
@@ -160,28 +160,18 @@ fn achievement_type_reserved_bytes_are_zeroed() {
 #[test]
 fn achievement_type_pda_is_deterministic() {
     let achievement_id = "early-adopter";
-    let (pda1, bump1) = Pubkey::find_program_address(
-        &[b"achievement", achievement_id.as_bytes()],
-        &PROGRAM_ID,
-    );
-    let (pda2, bump2) = Pubkey::find_program_address(
-        &[b"achievement", achievement_id.as_bytes()],
-        &PROGRAM_ID,
-    );
+    let (pda1, bump1) =
+        Pubkey::find_program_address(&[b"achievement", achievement_id.as_bytes()], &PROGRAM_ID);
+    let (pda2, bump2) =
+        Pubkey::find_program_address(&[b"achievement", achievement_id.as_bytes()], &PROGRAM_ID);
     assert_eq!(pda1, pda2);
     assert_eq!(bump1, bump2);
 }
 
 #[test]
 fn different_achievement_ids_yield_different_pdas() {
-    let (pda_a, _) = Pubkey::find_program_address(
-        &[b"achievement", b"badge-a"],
-        &PROGRAM_ID,
-    );
-    let (pda_b, _) = Pubkey::find_program_address(
-        &[b"achievement", b"badge-b"],
-        &PROGRAM_ID,
-    );
+    let (pda_a, _) = Pubkey::find_program_address(&[b"achievement", b"badge-a"], &PROGRAM_ID);
+    let (pda_b, _) = Pubkey::find_program_address(&[b"achievement", b"badge-b"], &PROGRAM_ID);
     assert_ne!(pda_a, pda_b);
 }
 

--- a/onchain-academy/tests/rust/src/test_audit_hardening.rs
+++ b/onchain-academy/tests/rust/src/test_audit_hardening.rs
@@ -1,0 +1,283 @@
+//! Tests for the security-audit remediation (audit hardening).
+//!
+//! Four fixes, one file:
+//!
+//! 1. `reward_xp` per-call ceiling — the only general-purpose XP-mint path now
+//!    gates `amount <= MAX_XP_PER_MINT` (XpAmountExceedsMax), on top of the
+//!    per-minter cap.
+//! 2. `update_config` authority rotation — `UpdateConfigParams.new_authority:
+//!    Option<Pubkey>` rotates `Config.authority` (co-signed by the current
+//!    authority via `has_one`); the zero pubkey is rejected (Unauthorized).
+//! 3. `revoke_minter` backend guard — the role whose `minter ==
+//!    Config.backend_signer` cannot be closed (Unauthorized), so operators can't
+//!    brick the live backend's minting role.
+//! 4. recipient-owner binding — `require_xp_recipient` asserts the recipient ATA
+//!    is the XP mint AND is owned by the intended learner/creator/recipient, so
+//!    XP can only land in that identity's own account.
+//!
+//! These exercise the real `require_xp_recipient` against packed Token-2022
+//! bytes, mirror the handler guards, and pin the error codes — matching the rest
+//! of this test crate, which validates handler logic without a runtime.
+
+use anchor_lang::{AnchorDeserialize, AnchorSerialize};
+use onchain_academy::errors::AcademyError;
+use onchain_academy::instructions::UpdateConfigParams;
+use onchain_academy::utils::{require_xp_recipient, MAX_XP_PER_MINT};
+use solana_program::account_info::AccountInfo;
+use solana_program::program_pack::Pack;
+use solana_sdk::pubkey::Pubkey;
+use spl_token_2022::state::{Account as Token2022Account, AccountState};
+
+// --- Fix 1: reward_xp absolute per-call ceiling ---
+
+/// The gate added to reward_xp after `amount > 0`:
+/// `require!(amount <= MAX_XP_PER_MINT, XpAmountExceedsMax)`. reward_xp is the
+/// only general-purpose mint path, so an over-generously-capped (or unlimited)
+/// minter role must still not mint more than the ceiling in one call.
+fn reward_xp_amount_allowed(amount: u64) -> bool {
+    amount > 0 && amount <= MAX_XP_PER_MINT
+}
+
+#[test]
+fn reward_xp_rejects_amount_over_ceiling() {
+    // At/under the ceiling: allowed.
+    assert!(reward_xp_amount_allowed(1));
+    assert!(reward_xp_amount_allowed(MAX_XP_PER_MINT));
+    // One over: rejected — this is the new XpAmountExceedsMax path.
+    assert!(!reward_xp_amount_allowed(MAX_XP_PER_MINT + 1));
+    assert!(!reward_xp_amount_allowed(u64::MAX));
+    // Zero still rejected by the pre-existing InvalidAmount gate.
+    assert!(!reward_xp_amount_allowed(0));
+}
+
+/// The ceiling is enforced BEFORE and independently of the per-minter cap: even
+/// an unlimited role (max_xp_per_call == 0, max_total_xp == 0) is bounded to
+/// MAX_XP_PER_MINT per call. Mirrors the ordering in the handler.
+#[test]
+fn reward_xp_ceiling_binds_even_an_unlimited_role() {
+    let max_xp_per_call: u64 = 0; // unlimited per-call
+    let over = MAX_XP_PER_MINT + 1;
+
+    // The per-minter per-call gate would allow it (0 == unlimited)...
+    let per_minter_allows = max_xp_per_call == 0 || over <= max_xp_per_call;
+    assert!(per_minter_allows);
+    // ...but the absolute ceiling rejects it first.
+    assert!(!reward_xp_amount_allowed(over));
+}
+
+// --- Fix 2: update_config authority rotation ---
+
+/// Mirror of the rotation branch in the handler:
+/// `if let Some(a) = params.new_authority { require!(a != default); config.authority = a }`.
+/// Returns the resulting authority, or an error code for the rejected zero key.
+fn apply_authority_rotation(
+    current_authority: Pubkey,
+    new_authority: Option<Pubkey>,
+) -> Result<Pubkey, u32> {
+    match new_authority {
+        Some(a) if a == Pubkey::default() => Err(6000 + AcademyError::Unauthorized as u32),
+        Some(a) => Ok(a),
+        None => Ok(current_authority),
+    }
+}
+
+#[test]
+fn authority_rotation_succeeds_for_a_real_key() {
+    let current = Pubkey::new_unique();
+    let multisig = Pubkey::new_unique();
+    assert_ne!(current, multisig);
+
+    // The current authority co-signs (has_one, enforced by the accounts struct);
+    // the handler swaps in the new key.
+    let result = apply_authority_rotation(current, Some(multisig));
+    assert_eq!(result, Ok(multisig));
+}
+
+#[test]
+fn authority_rotation_rejects_the_zero_pubkey() {
+    let current = Pubkey::new_unique();
+
+    // Some(default) is an unrecoverable handoff that would brick governance.
+    let result = apply_authority_rotation(current, Some(Pubkey::default()));
+    assert_eq!(result, Err(6000 + AcademyError::Unauthorized as u32));
+    assert_eq!(result, Err(6000)); // Unauthorized is index 0.
+}
+
+#[test]
+fn authority_rotation_none_leaves_authority_unchanged() {
+    let current = Pubkey::new_unique();
+    assert_eq!(apply_authority_rotation(current, None), Ok(current));
+}
+
+/// `UpdateConfigParams` now carries `new_authority: Option<Pubkey>` appended
+/// after `paused`. Round-trip the meaningful shapes so the wire format (and thus
+/// the generated IDL arg) is pinned — including a rotate-only call.
+#[test]
+fn update_config_params_new_authority_serialization_roundtrip() {
+    // Rotate authority only.
+    let rotate = UpdateConfigParams {
+        new_backend_signer: None,
+        paused: None,
+        new_authority: Some(Pubkey::new_unique()),
+    };
+    let mut buf = Vec::new();
+    rotate.serialize(&mut buf).unwrap();
+    let decoded = UpdateConfigParams::deserialize(&mut buf.as_slice()).unwrap();
+    assert_eq!(decoded.new_backend_signer, None);
+    assert_eq!(decoded.paused, None);
+    assert_eq!(decoded.new_authority, rotate.new_authority);
+
+    // All three fields set together.
+    let all = UpdateConfigParams {
+        new_backend_signer: Some(Pubkey::new_unique()),
+        paused: Some(true),
+        new_authority: Some(Pubkey::new_unique()),
+    };
+    let mut buf = Vec::new();
+    all.serialize(&mut buf).unwrap();
+    let decoded = UpdateConfigParams::deserialize(&mut buf.as_slice()).unwrap();
+    assert_eq!(decoded.new_backend_signer, all.new_backend_signer);
+    assert_eq!(decoded.paused, Some(true));
+    assert_eq!(decoded.new_authority, all.new_authority);
+}
+
+// --- Fix 3: revoke_minter cannot brick the backend's own role ---
+
+/// The guard added to revoke_minter:
+/// `require!(role.minter != config.backend_signer, Unauthorized)`. Closing the
+/// role whose minter is the live backend_signer would leave the backend
+/// authorized as signer but unable to mint (its MinterRole PDA gone).
+fn revoke_minter_allowed(role_minter: &Pubkey, backend_signer: &Pubkey) -> bool {
+    role_minter != backend_signer
+}
+
+#[test]
+fn revoke_minter_rejects_the_backends_own_role() {
+    let backend_signer = Pubkey::new_unique();
+
+    // Revoking the backend's own role is rejected — operators must rotate
+    // backend_signer via update_config first (which deactivates the old role).
+    assert!(!revoke_minter_allowed(&backend_signer, &backend_signer));
+}
+
+#[test]
+fn revoke_minter_allows_any_other_role() {
+    let backend_signer = Pubkey::new_unique();
+    let other_minter = Pubkey::new_unique();
+    assert_ne!(backend_signer, other_minter);
+
+    // A non-backend minter role closes normally.
+    assert!(revoke_minter_allowed(&other_minter, &backend_signer));
+}
+
+// --- Fix 4: recipient-owner binding (require_xp_recipient) ---
+
+/// Pack an initialized Token-2022 account (base state, no extensions) with the
+/// given mint + owner — exactly the byte layout `require_xp_recipient` unpacks.
+fn pack_token_account(mint: Pubkey, owner: Pubkey) -> Vec<u8> {
+    let account = Token2022Account {
+        mint,
+        owner,
+        amount: 0,
+        state: AccountState::Initialized,
+        ..Default::default()
+    };
+    let mut data = vec![0u8; Token2022Account::LEN];
+    Token2022Account::pack(account, &mut data).expect("pack token account");
+    data
+}
+
+/// Invoke the real `require_xp_recipient` over an owned `AccountInfo` wrapping a
+/// packed Token-2022 account (not a logic mirror).
+fn call_require_xp_recipient(
+    account_mint: Pubkey,
+    account_owner: Pubkey,
+    expected_mint: &Pubkey,
+    expected_owner: &Pubkey,
+) -> anchor_lang::Result<()> {
+    let key = Pubkey::new_unique();
+    let program_owner = spl_token_2022::id();
+    let mut lamports: u64 = 1_000_000;
+    let mut data = pack_token_account(account_mint, account_owner);
+
+    let account_info = AccountInfo::new(
+        &key,
+        false,
+        true,
+        &mut lamports,
+        &mut data,
+        &program_owner,
+        false,
+        0,
+    );
+
+    require_xp_recipient(&account_info, expected_mint, expected_owner)
+}
+
+#[test]
+fn require_xp_recipient_accepts_matching_mint_and_owner() {
+    let xp_mint = Pubkey::new_unique();
+    let learner = Pubkey::new_unique();
+    assert!(call_require_xp_recipient(xp_mint, learner, &xp_mint, &learner).is_ok());
+}
+
+#[test]
+fn require_xp_recipient_rejects_wrong_owner() {
+    let xp_mint = Pubkey::new_unique();
+    let learner = Pubkey::new_unique();
+    let attacker = Pubkey::new_unique();
+    assert_ne!(learner, attacker);
+
+    // Right mint, wrong owner: an ATA belonging to someone other than the
+    // intended recipient must be rejected with Unauthorized (6000).
+    let err = call_require_xp_recipient(xp_mint, attacker, &xp_mint, &learner)
+        .expect_err("an ATA owned by a different wallet must be rejected");
+
+    match err {
+        anchor_lang::error::Error::AnchorError(ae) => {
+            assert_eq!(
+                ae.error_code_number,
+                AcademyError::Unauthorized as u32 + 6000
+            );
+            assert_eq!(ae.error_code_number, 6000);
+        }
+        other => panic!("expected AnchorError(Unauthorized), got {other:?}"),
+    }
+}
+
+#[test]
+fn require_xp_recipient_rejects_wrong_mint() {
+    let xp_mint = Pubkey::new_unique();
+    let other_mint = Pubkey::new_unique();
+    let learner = Pubkey::new_unique();
+    assert_ne!(xp_mint, other_mint);
+
+    // Wrong mint (even with the right owner) is rejected with WrongXpMint (6032),
+    // checked before the owner assertion — mirrors require_xp_mint's ordering.
+    let err = call_require_xp_recipient(other_mint, learner, &xp_mint, &learner)
+        .expect_err("an ATA of a different mint must be rejected");
+
+    match err {
+        anchor_lang::error::Error::AnchorError(ae) => {
+            assert_eq!(
+                ae.error_code_number,
+                AcademyError::WrongXpMint as u32 + 6000
+            );
+            assert_eq!(ae.error_code_number, 6032);
+        }
+        other => panic!("expected AnchorError(WrongXpMint), got {other:?}"),
+    }
+}
+
+// --- Error codes: prior codes never shift (append-only invariant) ---
+
+/// The audit fixes add NO new error variants: they reuse Unauthorized (6000),
+/// WrongXpMint (6032), and XpAmountExceedsMax (6033). Pin the three critical
+/// codes so a future error-list reorder fails CI instantly.
+#[test]
+fn audit_fixes_reuse_existing_codes_without_shifting_them() {
+    assert_eq!(6000 + AcademyError::Unauthorized as u32, 6000);
+    assert_eq!(6000 + AcademyError::MintingPaused as u32, 6031);
+    assert_eq!(6000 + AcademyError::WrongXpMint as u32, 6032);
+    assert_eq!(6000 + AcademyError::XpAmountExceedsMax as u32, 6033);
+}

--- a/onchain-academy/tests/rust/src/test_course.rs
+++ b/onchain-academy/tests/rust/src/test_course.rs
@@ -1,7 +1,7 @@
 use crate::helpers::*;
 use anchor_lang::{AnchorDeserialize, AnchorSerialize};
-use solana_sdk::pubkey::Pubkey;
 use onchain_academy::state::{Course, MAX_COURSE_ID_LEN};
+use solana_sdk::pubkey::Pubkey;
 
 #[test]
 fn course_size_constant_is_correct() {

--- a/onchain-academy/tests/rust/src/test_enrollment.rs
+++ b/onchain-academy/tests/rust/src/test_enrollment.rs
@@ -1,7 +1,7 @@
 use crate::helpers::*;
 use anchor_lang::{AnchorDeserialize, AnchorSerialize};
-use solana_sdk::pubkey::Pubkey;
 use onchain_academy::state::Enrollment;
+use solana_sdk::pubkey::Pubkey;
 
 #[test]
 fn enrollment_size_constant_is_correct() {

--- a/onchain-academy/tests/rust/src/test_initialize.rs
+++ b/onchain-academy/tests/rust/src/test_initialize.rs
@@ -1,7 +1,7 @@
 use crate::helpers::*;
 use anchor_lang::{AnchorDeserialize, AnchorSerialize};
-use solana_sdk::pubkey::Pubkey;
 use onchain_academy::state::Config;
+use solana_sdk::pubkey::Pubkey;
 
 #[test]
 fn config_size_constant_is_correct() {

--- a/onchain-academy/tests/rust/src/test_kill_switch.rs
+++ b/onchain-academy/tests/rust/src/test_kill_switch.rs
@@ -147,7 +147,10 @@ fn non_authority_cannot_toggle_pause() {
     let attacker = Pubkey::new_unique();
 
     // The real authority is allowed.
-    assert!(update_config_authorized(&config.authority, &config.authority));
+    assert!(update_config_authorized(
+        &config.authority,
+        &config.authority
+    ));
     // A different signer is not — this is the Unauthorized path.
     assert!(!update_config_authorized(&config.authority, &attacker));
     assert_ne!(config.authority, attacker);
@@ -182,6 +185,7 @@ fn update_config_params_serialization_roundtrip() {
     let params = UpdateConfigParams {
         new_backend_signer: Some(Pubkey::new_unique()),
         paused: Some(true),
+        new_authority: None,
     };
     let mut buf = Vec::new();
     params.serialize(&mut buf).unwrap();
@@ -193,6 +197,7 @@ fn update_config_params_serialization_roundtrip() {
     let pause_only = UpdateConfigParams {
         new_backend_signer: None,
         paused: Some(false),
+        new_authority: None,
     };
     let mut buf = Vec::new();
     pause_only.serialize(&mut buf).unwrap();
@@ -200,16 +205,18 @@ fn update_config_params_serialization_roundtrip() {
     assert_eq!(decoded.new_backend_signer, None);
     assert_eq!(decoded.paused, Some(false));
 
-    // Neither field set: a no-op update (both None).
+    // Neither field set: a no-op update (all None).
     let noop = UpdateConfigParams {
         new_backend_signer: None,
         paused: None,
+        new_authority: None,
     };
     let mut buf = Vec::new();
     noop.serialize(&mut buf).unwrap();
     let decoded = UpdateConfigParams::deserialize(&mut buf.as_slice()).unwrap();
     assert_eq!(decoded.new_backend_signer, None);
     assert_eq!(decoded.paused, None);
+    assert_eq!(decoded.new_authority, None);
 }
 
 /// `MintingPauseSet { paused, timestamp }` is emitted whenever the toggle runs.


### PR DESCRIPTION
## Summary

Implements 4 security-audit remediation fixes on the on-chain program. All changes are minimal and append-only where required. **Needs a devnet redeploy to take effect** (this PR only lands source + regenerated IDL).

## Fixes

### 1. (HIGH) `reward_xp` absolute per-call ceiling
`instructions/reward_xp.rs:15-20` — after `require!(amount > 0)`, added `require!(amount <= MAX_XP_PER_MINT, XpAmountExceedsMax)`. `reward_xp` is the only general-purpose XP-mint path with no absolute ceiling; the per-minter cap still applies on top. Bounds the leaked-`backend_signer` blast radius on this path.

### 2. (CRITICAL keystone) Authority rotation in `update_config`
`instructions/update_config.rs:21 (param), :65-76 (handler)` — added `new_authority: Option<Pubkey>` to `UpdateConfigParams`. When `Some(a)`: rejects `Pubkey::default()` (`Unauthorized`), sets `config.authority = a`, emits `ConfigUpdated { field: "authority" }`. The struct's existing `has_one = authority` means the **current** authority co-signs the rotation, so this can only hand governance off (e.g. to a Squads multisig), never seize it. One-step; a `// TODO: two-step nominate/accept` note is left inline. Unblocks EOA → multisig handover without a program upgrade.

### 3. (MEDIUM) `revoke_minter` can't brick the backend's own role
`instructions/revoke_minter.rs:11-15` — added `require!(minter_role.minter != config.backend_signer, Unauthorized)`. `Config` was already in the accounts struct. Closing the role whose `minter == backend_signer` would leave the backend authorized as signer but unable to mint. Operators must rotate `backend_signer` via `update_config` first (which already deactivates the old role), then revoke it.

### 4. (HIGH) Bind each XP recipient ATA to its intended owner
Recipient token accounts were validated for the right **mint** but not the right **owner** — a leaked/buggy backend could mint XP to any wallet while the event named someone else. New `utils::require_xp_recipient(acct, expected_mint, expected_owner)` asserts base mint == `Config.xp_mint` (`WrongXpMint`) **and** token-account owner == the intended identity (`Unauthorized`), called before each mint:

| Instruction | Account (name + order preserved) | Bound owner | File:line |
|---|---|---|---|
| `complete_lesson` | `learner_token_account` | `learner` | `complete_lesson.rs:28-32` |
| `finalize_course` | `learner_token_account` | `learner` | `finalize_course.rs:41-45` |
| `finalize_course` | `creator_token_account` | `creator` (itself pinned to `course.creator`) | `finalize_course.rs:64-68` |
| `award_achievement` | `recipient_token_account` | `recipient` (owns the NFT + seeds the receipt PDA) | `award_achievement.rs:52-56` |

`reward_xp` is **address-based by design** — the minter passes the destination ATA directly and there is no on-chain recipient-identity account to bind against. Left unchanged (documented inline); the amount cap (Fix 1) + `require_xp_mint` cover it.

**Approach note:** the spec suggested switching these to `InterfaceAccount<TokenAccount>` via `anchor-spl`. `anchor-spl 0.31.1` forces `spl-token-2022 v6` → `solana-zk-sdk 2.1.0` → `solana-program =2.1.0`, which **conflicts** with this workspace's pinned tree (`spl-token-2022 v5.0.2` / `solana-program 2.0.25`, matched by the test crate's `=2.0.25`). Adding it would not resolve. The helper-based check is the minimal, dependency-free equivalent: it preserves every account field's **name, order, and `AccountInfo` type** (so frontend instruction-building and the IDL's `accounts`/`instructions` are byte-identical), reuses the established `require_xp_mint` unpack pattern already in `utils.rs`, and enforces the exact same property (owner + mint). The mint check is retained in all cases.

## Error codes — no shift (invariant held)
No new error variant was added; the fixes reuse `Unauthorized` (6000), `WrongXpMint` (6032), `XpAmountExceedsMax` (6033).

- `MintingPaused` = **6031** ✅ unchanged
- `WrongXpMint` = **6032** ✅ unchanged
- `XpAmountExceedsMax` = **6033** ✅ unchanged

Total error count still 34. Pinned by `test_audit_hardening::audit_fixes_reuse_existing_codes_without_shifting_them`.

## IDL
Regenerated via `anchor build` and copied to `apps/web/src/lib/solana/idl/superteam_academy.json`. Semantic diff vs the prior IDL (docs-stripped): **`instructions`, `accounts`, `events`, `errors`, `metadata`, `address` all byte-identical**; the only structural change is `UpdateConfigParams` gaining the `new_authority` (`option: pubkey`) field. (The line-level diff is larger because regeneration also resynced pre-existing stale doc comments on `Enrollment._reserved` — behavior-neutral.)

## Tests
New `onchain-academy/tests/rust/src/test_audit_hardening.rs` (12 tests): authority rotation succeeds for a real key + rejects the zero pubkey + `None` is a no-op; `reward_xp` rejects `amount > MAX_XP_PER_MINT` (and the ceiling binds even an unlimited role); `revoke_minter` rejects the backend's own role; `require_xp_recipient` accepts matching mint+owner and rejects wrong-owner (`Unauthorized`/6000) and wrong-mint (`WrongXpMint`/6032); `UpdateConfigParams` round-trips with `new_authority`; error codes pinned. Existing `test_kill_switch.rs` + the TypeScript suite were updated to pass `new_authority: null` / `newAuthority: null` on all `UpdateConfigParams` / `.updateConfig(...)` call sites.

## Verification
- `cargo fmt` ✅
- `cargo clippy -- -W clippy::all` ✅ clean on the program crate; my changes add **zero** new warnings on the test crate (8 pre-existing warnings remain in `test_completion.rs` / `test_utils.rs`, untouched)
- `cargo test --manifest-path onchain-academy/tests/rust/Cargo.toml` ✅ **116 passed / 0 failed** (12 new)
- `anchor build` ✅ compiles + regenerates IDL
- `program_autofixer` (solana-mcp-server) ✅ run on all 7 changed program files, **0 issues / 0 suggestions**, loop clean

## Follow-ups (report, not fixed here — out of scope)
- **Frontend `new_authority` wiring:** `update_config` is **not** currently invoked anywhere in `apps/web/src` (grep for `updateConfig` / `newAuthority` / `UpdateConfigParams` = 0 hits outside the IDL). Adding the optional param is backward compatible — no frontend change is required to keep existing behavior. Wire it only if/when a UI/script surface for governance handover is desired.
- **Creator-reward economics (deferred decision):** `finalize_course` still mints the creator reward on **every** qualifying finalization past the completion threshold (no per-creator cap beyond `MAX_XP_PER_MINT` per call, no one-time gate). This PR only binds *who* receives it (owner == `course.creator`); whether the reward should be rate-limited / one-shot / capped cumulatively is an economics decision left open.

## Deployment
Source + IDL only. **This needs a devnet redeploy to take effect** — do NOT merge without the redeploy plan. Not merging or deploying in this PR.
