### PR TITLE
fix(teacher-courses): surface the real cause of a failed course write

### DIFF
--- a/apps/web/src/app/api/teacher/courses/[id]/route.ts
+++ b/apps/web/src/app/api/teacher/courses/[id]/route.ts
@@ -3,6 +3,7 @@ import "server-only";
 import { NextRequest, NextResponse } from "next/server";
 import { authorizeTeacher } from "@/lib/teacher/authorize";
 import { validateTeacherCourseInput } from "@/lib/teacher/validate";
+import { reportTeacherWriteError } from "@/lib/teacher/errors";
 import {
   getCourseAuthorship,
   patchTeacherCourse,
@@ -66,9 +67,13 @@ export async function PATCH(
   let course;
   try {
     course = await getCourseAuthorship(courseId);
-  } catch {
+  } catch (err) {
+    const reason = reportTeacherWriteError("teacher-course-load", err, {
+      route: "/api/teacher/courses/[id]",
+      courseId,
+    });
     return NextResponse.json(
-      { error: "Failed to load course" },
+      { error: "Failed to load course", reason },
       { status: 500 }
     );
   }
@@ -84,9 +89,14 @@ export async function PATCH(
 
   try {
     await patchTeacherCourse(courseId, validated.value);
-  } catch {
+  } catch (err) {
+    const reason = reportTeacherWriteError("teacher-course-update", err, {
+      route: "/api/teacher/courses/[id]",
+      courseId,
+      userId: auth.caller.userId,
+    });
     return NextResponse.json(
-      { error: "Failed to update course" },
+      { error: "Failed to update course", reason },
       { status: 500 }
     );
   }

--- a/apps/web/src/app/api/teacher/courses/[id]/structure/route.ts
+++ b/apps/web/src/app/api/teacher/courses/[id]/structure/route.ts
@@ -8,6 +8,7 @@ import {
   applyCourseStructure,
 } from "@/lib/sanity/teacher-structure";
 import { validateStructure } from "@/lib/teacher/validate-structure";
+import { reportTeacherWriteError } from "@/lib/teacher/errors";
 
 export const dynamic = "force-dynamic";
 
@@ -96,9 +97,13 @@ export async function PUT(
 
   try {
     await applyCourseStructure(id, validated.value);
-  } catch {
+  } catch (err) {
+    const reason = reportTeacherWriteError("teacher-course-structure", err, {
+      route: "/api/teacher/courses/[id]/structure",
+      courseId: id,
+    });
     return NextResponse.json(
-      { error: "Failed to save course structure" },
+      { error: "Failed to save course structure", reason },
       { status: 500 }
     );
   }

--- a/apps/web/src/app/api/teacher/courses/route.ts
+++ b/apps/web/src/app/api/teacher/courses/route.ts
@@ -4,6 +4,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { authorizeTeacher } from "@/lib/teacher/authorize";
 import { validateTeacherCourseInput } from "@/lib/teacher/validate";
 import { slugifyCourseTitle } from "@/lib/teacher/slug";
+import { reportTeacherWriteError } from "@/lib/teacher/errors";
 import {
   createTeacherCourse,
   listAllCourses,
@@ -95,9 +96,13 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
       { _id: created._id, slug, authoringStatus: "draft" },
       { status: 201 }
     );
-  } catch {
+  } catch (err) {
+    const reason = reportTeacherWriteError("teacher-course-create", err, {
+      route: "/api/teacher/courses",
+      userId: auth.caller.userId,
+    });
     return NextResponse.json(
-      { error: "Failed to create course" },
+      { error: "Failed to create course", reason },
       { status: 500 }
     );
   }

--- a/apps/web/src/components/teacher/course-form.tsx
+++ b/apps/web/src/components/teacher/course-form.tsx
@@ -96,10 +96,12 @@ export function CourseForm({ mode, courseId, initial }: CourseFormProps) {
       });
       const data = (await res.json().catch(() => ({}))) as {
         error?: string;
+        reason?: string;
         _id?: string;
       };
       if (!res.ok) {
-        setError(data.error ?? "Request failed");
+        const base = data.error ?? "Request failed";
+        setError(data.reason ? `${base}: ${data.reason}` : base);
         return;
       }
       if (which === "submit") {

--- a/apps/web/src/components/teacher/course-structure-editor.tsx
+++ b/apps/web/src/components/teacher/course-structure-editor.tsx
@@ -224,9 +224,13 @@ export function CourseStructureEditor({ courseId }: { courseId: string }) {
           body: JSON.stringify(payload),
         }
       );
-      const data = (await res.json().catch(() => ({}))) as { error?: string };
+      const data = (await res.json().catch(() => ({}))) as {
+        error?: string;
+        reason?: string;
+      };
       if (!res.ok) {
-        setError(data.error ?? "Save failed");
+        const base = data.error ?? "Save failed";
+        setError(data.reason ? `${base}: ${data.reason}` : base);
         return;
       }
       setNotice(t("saved"));

--- a/apps/web/src/lib/teacher/errors.ts
+++ b/apps/web/src/lib/teacher/errors.ts
@@ -1,0 +1,37 @@
+import "server-only";
+import { logError } from "@/lib/logging";
+
+/**
+ * A concise, safe reason for a failed teacher Sanity write. The common cause is
+ * a missing/read-only SANITY_ADMIN_TOKEN, so map permission-shaped errors to an
+ * actionable hint; otherwise fall back to the (capped) error message. Reasons
+ * describe server/operational state, never user data — safe to return.
+ */
+export function describeTeacherWriteError(err: unknown): string {
+  const msg = err instanceof Error ? err.message : String(err);
+  if (
+    /unauthorized|permission|not allowed|insufficient|forbidden|token|session/i.test(
+      msg
+    )
+  ) {
+    return "Sanity write was rejected — verify SANITY_ADMIN_TOKEN is set and write-enabled on the server";
+  }
+  return msg.slice(0, 300);
+}
+
+/**
+ * Log a teacher-write failure (so it's visible in server logs) and return the
+ * reason to include in the 500 response body.
+ */
+export function reportTeacherWriteError(
+  errorId: string,
+  err: unknown,
+  context: Record<string, unknown>
+): string {
+  logError({
+    errorId,
+    error: err instanceof Error ? err : new Error(String(err)),
+    context,
+  });
+  return describeTeacherWriteError(err);
+}


### PR DESCRIPTION
## Summary

Saving a course draft returned an opaque **500** with no detail. The teacher-write routes caught errors with a bare `catch {}` — no logging, no reason — so the real Sanity failure wasn't even in the server logs. This makes it diagnosable (same approach as the certificate-mint fix).

## What

- **`lib/teacher/errors.ts`** — `reportTeacherWriteError`: logs the real error server-side and returns a concise, safe `reason`. Permission-shaped errors map to an actionable hint (**"verify SANITY_ADMIN_TOKEN is set and write-enabled"**); otherwise the capped error message.
- Wired into all three teacher-write catches: `POST /api/teacher/courses`, `PATCH /api/teacher/courses/[id]`, `PUT /api/teacher/courses/[id]/structure`.
- The **course form** and **structure editor** now display the `reason` alongside the generic error.

## Most likely underlying cause

`SANITY_ADMIN_TOKEN` is optional in `env.server.ts`. Course authoring is the first **app-driven Sanity write**; if the token is unset or read-only on the deployment, `sanityAdmin.create(...)` throws a permission error → the old blind catch turned it into this opaque 500. After this PR, the response + logs will say so explicitly.

## Verification

- `tsc` clean, eslint clean, `next build` passes
- No behavioural change to a successful write; reasons expose operational state only, never user data

Closes #308
