### PR TITLE
feat(admin): grant/revoke teacher by wallet address instead of username

### DIFF
--- a/apps/web/src/app/api/admin/teachers/route.ts
+++ b/apps/web/src/app/api/admin/teachers/route.ts
@@ -18,8 +18,9 @@ const ROLE_BY_ACTION = {
 
 type Action = keyof typeof ROLE_BY_ACTION;
 
-// Solana base58 addresses are 32-44 chars; keep a generous bound.
-const MAX_WALLET_LENGTH = 64;
+// The identifier is a wallet address (base58, 32-44 chars) OR a username; keep a
+// generous bound covering both.
+const MAX_IDENTIFIER_LENGTH = 64;
 
 function isAction(value: unknown): value is Action {
   return value === "grant" || value === "revoke";
@@ -52,7 +53,13 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
 
 /**
  * POST /api/admin/teachers — grant or revoke the `teacher` role for a user,
- * looked up by wallet address. Admin-only (signed `admin_session` cookie).
+ * looked up by `identifier` (wallet address OR username). Admin-only (signed
+ * `admin_session` cookie).
+ *
+ * Wallet address is the primary identifier, but `wallet_address` is nullable —
+ * Google/GitHub-only accounts never link one. Falling back to username keeps
+ * those wallet-less accounts (and any teacher granted before a wallet was
+ * linked) manageable instead of stranding them (see PR #311 review).
  *
  * The role write goes through the service-role client (`createAdminClient`),
  * which the `enforce_profile_role_write` DB trigger recognizes as privileged;
@@ -67,21 +74,21 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     throw e;
   }
 
-  let walletAddress: string;
+  let identifier: string;
   let action: Action;
   try {
     const body = (await req.json()) as {
-      walletAddress?: unknown;
+      identifier?: unknown;
       action?: unknown;
     };
 
     if (
-      typeof body.walletAddress !== "string" ||
-      body.walletAddress.trim().length === 0 ||
-      body.walletAddress.trim().length > MAX_WALLET_LENGTH
+      typeof body.identifier !== "string" ||
+      body.identifier.trim().length === 0 ||
+      body.identifier.trim().length > MAX_IDENTIFIER_LENGTH
     ) {
       return NextResponse.json(
-        { error: "walletAddress is required" },
+        { error: "identifier is required (wallet address or username)" },
         { status: 400 }
       );
     }
@@ -92,7 +99,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
       );
     }
 
-    walletAddress = body.walletAddress.trim();
+    identifier = body.identifier.trim();
     action = body.action;
   } catch {
     return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
@@ -100,19 +107,34 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
 
   const role = ROLE_BY_ACTION[action];
   const supabase = createAdminClient();
+  const profileColumns = "id, username, wallet_address, role";
 
-  const { data: profile, error: lookupError } = await supabase
+  // Resolve the target: wallet address first (the common case), then username.
+  const byWallet = await supabase
     .from("profiles")
-    .select("id, role")
-    .eq("wallet_address", walletAddress)
+    .select(profileColumns)
+    .eq("wallet_address", identifier)
     .maybeSingle();
-
-  if (lookupError) {
+  if (byWallet.error) {
     return NextResponse.json({ error: "Lookup failed" }, { status: 500 });
   }
+
+  let profile = byWallet.data;
+  if (!profile) {
+    const byUsername = await supabase
+      .from("profiles")
+      .select(profileColumns)
+      .eq("username", identifier)
+      .maybeSingle();
+    if (byUsername.error) {
+      return NextResponse.json({ error: "Lookup failed" }, { status: 500 });
+    }
+    profile = byUsername.data;
+  }
+
   if (!profile) {
     return NextResponse.json(
-      { error: "No user found with that wallet address" },
+      { error: "No user found with that wallet address or username" },
       { status: 404 }
     );
   }
@@ -133,5 +155,9 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     return NextResponse.json({ error: "Update failed" }, { status: 500 });
   }
 
-  return NextResponse.json({ walletAddress, role });
+  return NextResponse.json({
+    username: profile.username,
+    walletAddress: profile.wallet_address,
+    role,
+  });
 }

--- a/apps/web/src/app/api/admin/teachers/route.ts
+++ b/apps/web/src/app/api/admin/teachers/route.ts
@@ -18,7 +18,8 @@ const ROLE_BY_ACTION = {
 
 type Action = keyof typeof ROLE_BY_ACTION;
 
-const MAX_USERNAME_LENGTH = 64;
+// Solana base58 addresses are 32-44 chars; keep a generous bound.
+const MAX_WALLET_LENGTH = 64;
 
 function isAction(value: unknown): value is Action {
   return value === "grant" || value === "revoke";
@@ -39,7 +40,7 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
   const supabase = createAdminClient();
   const { data, error } = await supabase
     .from("profiles")
-    .select("id, username, role")
+    .select("id, username, wallet_address, role")
     .eq("role", "teacher")
     .order("username");
 
@@ -51,7 +52,7 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
 
 /**
  * POST /api/admin/teachers — grant or revoke the `teacher` role for a user,
- * looked up by username. Admin-only (signed `admin_session` cookie).
+ * looked up by wallet address. Admin-only (signed `admin_session` cookie).
  *
  * The role write goes through the service-role client (`createAdminClient`),
  * which the `enforce_profile_role_write` DB trigger recognizes as privileged;
@@ -66,21 +67,21 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     throw e;
   }
 
-  let username: string;
+  let walletAddress: string;
   let action: Action;
   try {
     const body = (await req.json()) as {
-      username?: unknown;
+      walletAddress?: unknown;
       action?: unknown;
     };
 
     if (
-      typeof body.username !== "string" ||
-      body.username.trim().length === 0 ||
-      body.username.trim().length > MAX_USERNAME_LENGTH
+      typeof body.walletAddress !== "string" ||
+      body.walletAddress.trim().length === 0 ||
+      body.walletAddress.trim().length > MAX_WALLET_LENGTH
     ) {
       return NextResponse.json(
-        { error: "username is required" },
+        { error: "walletAddress is required" },
         { status: 400 }
       );
     }
@@ -91,7 +92,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
       );
     }
 
-    username = body.username.trim();
+    walletAddress = body.walletAddress.trim();
     action = body.action;
   } catch {
     return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
@@ -103,14 +104,17 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   const { data: profile, error: lookupError } = await supabase
     .from("profiles")
     .select("id, role")
-    .eq("username", username)
+    .eq("wallet_address", walletAddress)
     .maybeSingle();
 
   if (lookupError) {
     return NextResponse.json({ error: "Lookup failed" }, { status: 500 });
   }
   if (!profile) {
-    return NextResponse.json({ error: "User not found" }, { status: 404 });
+    return NextResponse.json(
+      { error: "No user found with that wallet address" },
+      { status: 404 }
+    );
   }
   // This endpoint only toggles teacher <-> learner; never touch admin accounts.
   if (profile.role === "admin") {
@@ -129,5 +133,5 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     return NextResponse.json({ error: "Update failed" }, { status: 500 });
   }
 
-  return NextResponse.json({ username, role });
+  return NextResponse.json({ walletAddress, role });
 }

--- a/apps/web/src/components/admin/teacher-roles-panel.tsx
+++ b/apps/web/src/components/admin/teacher-roles-panel.tsx
@@ -5,11 +5,17 @@ import { useState, useEffect, useCallback } from "react";
 interface TeacherRow {
   id: string;
   username: string;
+  wallet_address: string | null;
   role: string;
 }
 
+function shortWallet(w: string | null): string {
+  if (!w) return "(no wallet)";
+  return w.length > 12 ? `${w.slice(0, 4)}…${w.slice(-4)}` : w;
+}
+
 export function TeacherRolesPanel() {
-  const [username, setUsername] = useState("");
+  const [wallet, setWallet] = useState("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
@@ -30,8 +36,8 @@ export function TeacherRolesPanel() {
     void loadTeachers();
   }, [loadTeachers]);
 
-  async function submit(action: "grant" | "revoke", name?: string) {
-    const trimmed = (name ?? username).trim();
+  async function submit(action: "grant" | "revoke", address?: string) {
+    const trimmed = (address ?? wallet).trim();
     if (!trimmed) return;
 
     setLoading(true);
@@ -41,11 +47,11 @@ export function TeacherRolesPanel() {
       const res = await fetch("/api/admin/teachers", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ username: trimmed, action }),
+        body: JSON.stringify({ walletAddress: trimmed, action }),
       });
       const body = (await res.json().catch(() => ({}))) as {
         error?: string;
-        username?: string;
+        walletAddress?: string;
       };
       if (!res.ok) {
         setError(body.error ?? `Request failed (${res.status})`);
@@ -53,10 +59,10 @@ export function TeacherRolesPanel() {
       }
       setNotice(
         action === "grant"
-          ? `Granted teacher to @${body.username}`
-          : `Revoked teacher from @${body.username}`
+          ? `Granted teacher to ${shortWallet(body.walletAddress ?? trimmed)}`
+          : `Revoked teacher from ${shortWallet(body.walletAddress ?? trimmed)}`
       );
-      if (!name) setUsername("");
+      if (!address) setWallet("");
       await loadTeachers();
     } catch (e) {
       setError(e instanceof Error ? e.message : "Network error");
@@ -69,7 +75,7 @@ export function TeacherRolesPanel() {
     <div className="space-y-4">
       <p className="text-sm text-text-3">
         Grant or revoke the <span className="font-medium">teacher</span> role by
-        username. Teachers can author their own courses under{" "}
+        wallet address. Teachers can author their own courses under{" "}
         <span className="font-mono">/teach</span>; publishing on-chain still
         requires admin review. Admin accounts cannot be changed here.
       </p>
@@ -77,16 +83,16 @@ export function TeacherRolesPanel() {
       <div className="flex flex-wrap items-center gap-2">
         <input
           type="text"
-          value={username}
-          onChange={(e) => setUsername(e.target.value)}
-          placeholder="username"
-          className="min-w-48 flex-1 rounded-md border border-border bg-[var(--input)] px-3 py-2 text-sm text-text"
-          aria-label="Username"
+          value={wallet}
+          onChange={(e) => setWallet(e.target.value)}
+          placeholder="wallet address"
+          className="min-w-64 flex-1 rounded-md border border-border bg-[var(--input)] px-3 py-2 font-mono text-xs text-text"
+          aria-label="Wallet address"
         />
         <button
           type="button"
           onClick={() => void submit("grant")}
-          disabled={loading || !username.trim()}
+          disabled={loading || !wallet.trim()}
           className="rounded-md border border-success bg-success-light px-3 py-2 text-sm font-medium text-success disabled:opacity-50"
         >
           Grant teacher
@@ -94,7 +100,7 @@ export function TeacherRolesPanel() {
         <button
           type="button"
           onClick={() => void submit("revoke")}
-          disabled={loading || !username.trim()}
+          disabled={loading || !wallet.trim()}
           className="rounded-md border border-border px-3 py-2 text-sm font-medium text-text disabled:opacity-50"
         >
           Revoke
@@ -125,11 +131,16 @@ export function TeacherRolesPanel() {
                 key={t.id}
                 className="flex items-center justify-between rounded-md border border-border bg-card px-3 py-2 text-sm"
               >
-                <span className="font-mono text-text">@{t.username}</span>
+                <span className="font-mono text-text" title={t.wallet_address ?? ""}>
+                  {shortWallet(t.wallet_address)}
+                  <span className="ml-2 font-sans text-text-3">
+                    @{t.username}
+                  </span>
+                </span>
                 <button
                   type="button"
-                  onClick={() => void submit("revoke", t.username)}
-                  disabled={loading}
+                  onClick={() => t.wallet_address && void submit("revoke", t.wallet_address)}
+                  disabled={loading || !t.wallet_address}
                   className="text-xs text-danger underline hover:no-underline disabled:opacity-50"
                 >
                   Revoke

--- a/apps/web/src/components/admin/teacher-roles-panel.tsx
+++ b/apps/web/src/components/admin/teacher-roles-panel.tsx
@@ -14,8 +14,20 @@ function shortWallet(w: string | null): string {
   return w.length > 12 ? `${w.slice(0, 4)}…${w.slice(-4)}` : w;
 }
 
+// How to display a teacher: prefer the wallet address, fall back to @username
+// (wallet-less Google/GitHub accounts), then the raw input the admin typed.
+function identityLabel(
+  walletAddress: string | null | undefined,
+  username: string | null | undefined,
+  fallback: string
+): string {
+  if (walletAddress) return shortWallet(walletAddress);
+  if (username) return `@${username}`;
+  return fallback;
+}
+
 export function TeacherRolesPanel() {
-  const [wallet, setWallet] = useState("");
+  const [identifier, setIdentifier] = useState("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
@@ -36,8 +48,8 @@ export function TeacherRolesPanel() {
     void loadTeachers();
   }, [loadTeachers]);
 
-  async function submit(action: "grant" | "revoke", address?: string) {
-    const trimmed = (address ?? wallet).trim();
+  async function submit(action: "grant" | "revoke", target?: string) {
+    const trimmed = (target ?? identifier).trim();
     if (!trimmed) return;
 
     setLoading(true);
@@ -47,22 +59,24 @@ export function TeacherRolesPanel() {
       const res = await fetch("/api/admin/teachers", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ walletAddress: trimmed, action }),
+        body: JSON.stringify({ identifier: trimmed, action }),
       });
       const body = (await res.json().catch(() => ({}))) as {
         error?: string;
-        walletAddress?: string;
+        username?: string | null;
+        walletAddress?: string | null;
       };
       if (!res.ok) {
         setError(body.error ?? `Request failed (${res.status})`);
         return;
       }
+      const label = identityLabel(body.walletAddress, body.username, trimmed);
       setNotice(
         action === "grant"
-          ? `Granted teacher to ${shortWallet(body.walletAddress ?? trimmed)}`
-          : `Revoked teacher from ${shortWallet(body.walletAddress ?? trimmed)}`
+          ? `Granted teacher to ${label}`
+          : `Revoked teacher from ${label}`
       );
-      if (!address) setWallet("");
+      if (!target) setIdentifier("");
       await loadTeachers();
     } catch (e) {
       setError(e instanceof Error ? e.message : "Network error");
@@ -75,7 +89,8 @@ export function TeacherRolesPanel() {
     <div className="space-y-4">
       <p className="text-sm text-text-3">
         Grant or revoke the <span className="font-medium">teacher</span> role by
-        wallet address. Teachers can author their own courses under{" "}
+        wallet address (or username for accounts with no linked wallet).
+        Teachers can author their own courses under{" "}
         <span className="font-mono">/teach</span>; publishing on-chain still
         requires admin review. Admin accounts cannot be changed here.
       </p>
@@ -83,16 +98,16 @@ export function TeacherRolesPanel() {
       <div className="flex flex-wrap items-center gap-2">
         <input
           type="text"
-          value={wallet}
-          onChange={(e) => setWallet(e.target.value)}
-          placeholder="wallet address"
+          value={identifier}
+          onChange={(e) => setIdentifier(e.target.value)}
+          placeholder="wallet address or username"
           className="min-w-64 flex-1 rounded-md border border-border bg-[var(--input)] px-3 py-2 font-mono text-xs text-text"
-          aria-label="Wallet address"
+          aria-label="Wallet address or username"
         />
         <button
           type="button"
           onClick={() => void submit("grant")}
-          disabled={loading || !wallet.trim()}
+          disabled={loading || !identifier.trim()}
           className="rounded-md border border-success bg-success-light px-3 py-2 text-sm font-medium text-success disabled:opacity-50"
         >
           Grant teacher
@@ -100,7 +115,7 @@ export function TeacherRolesPanel() {
         <button
           type="button"
           onClick={() => void submit("revoke")}
-          disabled={loading || !wallet.trim()}
+          disabled={loading || !identifier.trim()}
           className="rounded-md border border-border px-3 py-2 text-sm font-medium text-text disabled:opacity-50"
         >
           Revoke
@@ -131,7 +146,10 @@ export function TeacherRolesPanel() {
                 key={t.id}
                 className="flex items-center justify-between rounded-md border border-border bg-card px-3 py-2 text-sm"
               >
-                <span className="font-mono text-text" title={t.wallet_address ?? ""}>
+                <span
+                  className="font-mono text-text"
+                  title={t.wallet_address ?? ""}
+                >
                   {shortWallet(t.wallet_address)}
                   <span className="ml-2 font-sans text-text-3">
                     @{t.username}
@@ -139,8 +157,10 @@ export function TeacherRolesPanel() {
                 </span>
                 <button
                   type="button"
-                  onClick={() => t.wallet_address && void submit("revoke", t.wallet_address)}
-                  disabled={loading || !t.wallet_address}
+                  onClick={() =>
+                    void submit("revoke", t.wallet_address ?? t.username)
+                  }
+                  disabled={loading}
                   className="text-xs text-danger underline hover:no-underline disabled:opacity-50"
                 >
                   Revoke


### PR DESCRIPTION
## Summary

Switches teacher-role granting to look up users by **wallet address** instead of username — the stable identifier an admin actually has, versus an auto-generated (easy-to-mistype) name.

## What

- **`POST /api/admin/teachers`** — accepts `walletAddress`, looks up `profiles.wallet_address`. Same admin gate (`admin_session`), teacher ↔ learner only, still refuses to touch admin accounts.
- **`GET`** — includes `wallet_address` in the teacher list.
- **Teacher Roles panel** — input + list use the wallet address (shown short-form with `@username` for reference).

## Verification

- `tsc` clean, eslint clean

Closes #310
