### PR TITLE
fix(onchain): bound creator-reward drip to a completion window (#306)

### DIFF
--- a/onchain-academy/programs/onchain-academy/src/instructions/finalize_course.rs
+++ b/onchain-academy/programs/onchain-academy/src/instructions/finalize_course.rs
@@ -63,9 +63,20 @@ pub fn handler(ctx: Context<FinalizeCourse>) -> Result<()> {
         )?;
     }
 
-    // Mint creator reward if threshold met
+    // Mint creator reward, but only for a bounded WINDOW of completions past the
+    // popularity threshold — [min_completions, min_completions + WINDOW). The
+    // per-completion drip was otherwise unbounded and Sybil-farmable once a
+    // course crossed its threshold. This reuses the existing `total_completions`
+    // counter (no new per-course state, no migration): live courses are bounded
+    // on their next finalize automatically. Total creator XP per course is thus
+    // capped at WINDOW * creator_reward_xp.
+    const CREATOR_REWARD_WINDOW: u32 = 100;
+    let reward_end =
+        (course.min_completions_for_reward as u32).saturating_add(CREATOR_REWARD_WINDOW);
+
     let mut creator_xp: u32 = 0;
     if course.total_completions >= course.min_completions_for_reward as u32
+        && course.total_completions < reward_end
         && course.creator_reward_xp > 0
     {
         require!(

--- a/onchain-academy/tests/rust/src/test_audit_hardening.rs
+++ b/onchain-academy/tests/rust/src/test_audit_hardening.rs
@@ -334,3 +334,40 @@ fn audit_fixes_reuse_existing_codes_without_shifting_them() {
     assert_eq!(6000 + AcademyError::WrongXpMint as u32, 6032);
     assert_eq!(6000 + AcademyError::XpAmountExceedsMax as u32, 6033);
 }
+
+// --- Fix 5: creator-reward window (bound the per-completion drip) ---
+
+const CREATOR_REWARD_WINDOW: u32 = 100;
+
+/// Mirrors the finalize_course gate: the creator reward is paid only for
+/// completions in [min_completions, min_completions + WINDOW) — bounding the
+/// per-completion drip by reusing the existing total_completions counter, so
+/// aggregate creator XP can't run away (Sybil-farmable) once popular.
+fn creator_reward_paid(total_completions: u32, min_completions: u32, reward_xp: u32) -> bool {
+    let reward_end = min_completions.saturating_add(CREATOR_REWARD_WINDOW);
+    reward_xp > 0 && total_completions >= min_completions && total_completions < reward_end
+}
+
+#[test]
+fn creator_reward_only_within_the_window() {
+    let min = 10u32;
+    assert!(!creator_reward_paid(9, min, 750)); // below threshold: nothing
+    assert!(creator_reward_paid(10, min, 750)); // first qualifying completion
+    assert!(creator_reward_paid(109, min, 750)); // last in-window (min + WINDOW - 1)
+    assert!(!creator_reward_paid(110, min, 750)); // window closed — drip stops
+    assert!(!creator_reward_paid(10_000, min, 750)); // ...stays closed forever
+    assert!(!creator_reward_paid(50, min, 0)); // reward_xp == 0 never pays
+}
+
+#[test]
+fn creator_reward_total_is_capped_regardless_of_completions() {
+    // No matter how many (potentially Sybil) completions occur, the creator is
+    // paid at most WINDOW times => WINDOW * creator_reward_xp total.
+    let min = 10u32;
+    let reward_xp: u64 = 750;
+    let payouts = (min..)
+        .take_while(|&c| creator_reward_paid(c, min, reward_xp as u32))
+        .count() as u64;
+    assert_eq!(payouts, CREATOR_REWARD_WINDOW as u64);
+    assert_eq!(payouts * reward_xp, 75_000);
+}


### PR DESCRIPTION
Closes #306 (audit MEDIUM — Sybil-farmable creator rewards).

## Problem
Once a course crosses `min_completions_for_reward`, **every** subsequent `finalize_course` minted `creator_reward_xp` to the creator, forever — unbounded aggregate creator XP, farmable via fake enrollments.

## Fix (the simple, idiomatic way)
Bound the drip to a **window of completions** past the threshold — `[min, min + 100)` — using the **existing** `total_completions` counter:
```rust
const CREATOR_REWARD_WINDOW: u32 = 100;
let reward_end = (min_completions as u32).saturating_add(CREATOR_REWARD_WINDOW);
if total_completions >= min && total_completions < reward_end && creator_reward_xp > 0 { /* mint */ }
```
Total creator XP per course is now capped at **`100 * creator_reward_xp`** (e.g. 75,000 for a 750-XP course).

**Why a window, not a MinterRole-style counter+cap:** the program already counts completions, so a second counter + a per-course cap field carved from reserved bytes + Sanity/sync plumbing + a re-sync migration would all be redundant. The window reuses existing state → **no new fields, no migration** → the 6 live courses are bounded automatically on their next finalize.

## Verify
- 122 rust tests pass (2 new: window boundaries + "total capped regardless of completions"; the existing below-threshold test still green)
- `cargo fmt` + `clippy` clean · `program_autofixer` clean
- No IDL/struct/instruction change → frontend untouched. **Needs a devnet redeploy to take effect.**