### PR TITLE
fix(admin): hide deactivated courses from the public catalog

### DIFF
--- a/apps/web/src/app/api/admin/courses/deactivate/route.ts
+++ b/apps/web/src/app/api/admin/courses/deactivate/route.ts
@@ -1,5 +1,6 @@
 import "server-only";
 
+import { revalidateTag } from "next/cache";
 import { NextRequest, NextResponse } from "next/server";
 import {
   requireAdminAuth,
@@ -7,6 +8,8 @@ import {
   AdminAuthError,
 } from "@/lib/admin/auth";
 import { deactivateCoursePda } from "@/lib/solana/admin-signer";
+import { writeCourseActive } from "@/lib/sanity/admin-mutations";
+import { COURSES_CACHE_TAG } from "@/lib/sanity/queries";
 
 export async function POST(req: NextRequest): Promise<NextResponse> {
   try {
@@ -38,5 +41,21 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     );
   }
 
-  return NextResponse.json({ txSignature: result.signature });
+  // Mirror the on-chain flag into Sanity + purge the catalog cache so the course
+  // disappears from /courses immediately. If this write fails the course stays
+  // visible despite being deactivated on-chain, so surface a warning.
+  let warning: string | undefined;
+  try {
+    await writeCourseActive(courseId, false);
+    revalidateTag(COURSES_CACHE_TAG);
+  } catch (err) {
+    console.error("[admin/courses/deactivate] Sanity write-back failed:", err);
+    warning =
+      "Deactivated on-chain, but the catalog flag didn't update — the course may still show until re-synced.";
+  }
+
+  return NextResponse.json({
+    txSignature: result.signature,
+    ...(warning ? { warning } : {}),
+  });
 }

--- a/apps/web/src/app/api/admin/courses/reactivate/route.ts
+++ b/apps/web/src/app/api/admin/courses/reactivate/route.ts
@@ -1,5 +1,6 @@
 import "server-only";
 
+import { revalidateTag } from "next/cache";
 import { NextRequest, NextResponse } from "next/server";
 import {
   requireAdminAuth,
@@ -7,6 +8,8 @@ import {
   AdminAuthError,
 } from "@/lib/admin/auth";
 import { updateCoursePda } from "@/lib/solana/admin-signer";
+import { writeCourseActive } from "@/lib/sanity/admin-mutations";
+import { COURSES_CACHE_TAG } from "@/lib/sanity/queries";
 
 export async function POST(req: NextRequest): Promise<NextResponse> {
   try {
@@ -38,5 +41,20 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     );
   }
 
-  return NextResponse.json({ txSignature: result.signature });
+  // Mirror the on-chain flag into Sanity + purge the catalog cache so the course
+  // reappears on /courses immediately.
+  let warning: string | undefined;
+  try {
+    await writeCourseActive(courseId, true);
+    revalidateTag(COURSES_CACHE_TAG);
+  } catch (err) {
+    console.error("[admin/courses/reactivate] Sanity write-back failed:", err);
+    warning =
+      "Reactivated on-chain, but the catalog flag didn't update — the course may stay hidden until re-synced.";
+  }
+
+  return NextResponse.json({
+    txSignature: result.signature,
+    ...(warning ? { warning } : {}),
+  });
 }

--- a/apps/web/src/lib/sanity/admin-mutations.ts
+++ b/apps/web/src/lib/sanity/admin-mutations.ts
@@ -28,6 +28,22 @@ export async function writeCourseOnChainStatus(
     .commit();
 }
 
+/**
+ * Mirror a course's on-chain `is_active` flag into Sanity so the public catalog
+ * can hide a deactivated course (issue #321). The catalog gate reads
+ * `onChainStatus.isActive`; the on-chain tx alone doesn't affect Sanity, so the
+ * deactivate/reactivate routes call this after the tx succeeds.
+ */
+export async function writeCourseActive(
+  sanityId: string,
+  isActive: boolean
+): Promise<void> {
+  await sanityAdmin
+    .patch(sanityId)
+    .set({ "onChainStatus.isActive": isActive })
+    .commit();
+}
+
 export async function writeCourseTrackCollection(
   sanityId: string,
   trackCollectionAddress: string

--- a/apps/web/src/lib/sanity/queries.ts
+++ b/apps/web/src/lib/sanity/queries.ts
@@ -196,12 +196,17 @@ export async function getChallengeAnswerKey(
   courseSlug: string,
   lessonSlug: string
 ): Promise<ChallengeAnswerKey | null> {
-  // revalidate=0: always read fresh, never via the public Sanity CDN, so the
-  // answer key is not cached on any edge. catalogFetch (not sanityFetch) only to
-  // keep the "every gated query uses catalogFetch" invariant — the tag is inert
-  // on an uncached read.
-  return catalogFetch<ChallengeAnswerKey | null>(
-    `*[_type == "course" && slug.current == $courseSlug && onChainStatus.status == "synced" && ${activeGate} && ${publicAuthoringGate}][0] {
+  // SECURITY: intentionally UNGATED (no synced/active/authoring filter), unlike
+  // the public catalog queries. This is the server-authoritative answer key for
+  // challenge grading — the completion/validation gates treat a `null` result as
+  // "not a challenge lesson" and skip test execution. If visibility state
+  // (deactivation, un-approval, un-sync) could suppress the answer key, a
+  // challenge lesson would silently fall through the gate and grant unvalidated
+  // completions. Grading must be independent of catalog visibility, so we filter
+  // by identity only (like `getCourseById`). Server-only, never sent to clients.
+  // revalidate=0: always fresh, never via the public Sanity CDN.
+  return sanityFetch<ChallengeAnswerKey | null>(
+    `*[_type == "course" && slug.current == $courseSlug][0] {
       "allLessons": modules[]->lessons[]->${answerKeyProjection}
     }.allLessons[slug == $lessonSlug][0]`,
     { courseSlug, lessonSlug },
@@ -218,8 +223,12 @@ export async function getChallengeAnswerKeyById(
   courseId: string,
   lessonId: string
 ): Promise<ChallengeAnswerKey | null> {
-  return catalogFetch<ChallengeAnswerKey | null>(
-    `*[_type == "course" && _id == $courseId && onChainStatus.status == "synced" && ${activeGate} && ${publicAuthoringGate}][0] {
+  // SECURITY: UNGATED by design — see getChallengeAnswerKey. This backs the
+  // server-authoritative gate in /api/lessons/complete, where `null` means "not
+  // a challenge lesson" and skips validation. A visibility gate here would let a
+  // deactivated/unapproved course's challenge lesson skip grading and mint XP.
+  return sanityFetch<ChallengeAnswerKey | null>(
+    `*[_type == "course" && _id == $courseId][0] {
       "allLessons": modules[]->lessons[]->${answerKeyProjection}
     }.allLessons[_id == $lessonId][0]`,
     { courseId, lessonId },

--- a/apps/web/src/lib/sanity/queries.ts
+++ b/apps/web/src/lib/sanity/queries.ts
@@ -13,6 +13,14 @@ import type { Course, Lesson, LearningPath } from "./types";
 // applied ONLY to public queries; admin/Studio queries must keep seeing drafts.
 const publicAuthoringGate = `(authoringStatus == "approved" || !defined(authoringStatus))`;
 
+// A course drops out of EVERY public surface the moment an admin deactivates it
+// (issue #321). The deactivate/reactivate routes mirror the on-chain is_active
+// flag into `onChainStatus.isActive`; legacy course docs predate the field, so
+// `coalesce(..., true)` keeps them visible. Combined into the shared synced gate
+// so catalog, detail, lesson, and dashboard reads all hide inactive courses
+// consistently (same reasoning as the #313 tag rollout).
+const activeGate = `coalesce(onChainStatus.isActive, true)`;
+
 // Shared Next.js cache tag for the public course catalog. Public catalog reads
 // are tagged with this so an admin action that changes what the catalog should
 // show (course sync) can purge them on demand via `revalidateTag(COURSES_CACHE_TAG)`
@@ -90,7 +98,7 @@ const moduleWithLessonsFields = `
 
 export async function getAllCourses(): Promise<Course[]> {
   return catalogFetch<Course[]>(
-    `*[_type == "course" && onChainStatus.status == "synced" && ${publicAuthoringGate}] | order(title asc) {
+    `*[_type == "course" && onChainStatus.status == "synced" && ${activeGate} && ${publicAuthoringGate}] | order(title asc) {
       ${courseFields},
       "modules": modules[]->{
         _id,
@@ -111,7 +119,7 @@ export async function getAllCourses(): Promise<Course[]> {
 
 export async function getCourseBySlug(slug: string): Promise<Course | null> {
   return catalogFetch<Course | null>(
-    `*[_type == "course" && slug.current == $slug && onChainStatus.status == "synced" && ${publicAuthoringGate}][0] {
+    `*[_type == "course" && slug.current == $slug && onChainStatus.status == "synced" && ${activeGate} && ${publicAuthoringGate}][0] {
       ${courseFields},
       "modules": modules[]->{
         ${moduleWithLessonsFields}
@@ -131,7 +139,7 @@ export async function getLessonBySlug(
   // re-projects each to drop the `hidden` flag itself. Hidden-test/solution
   // checking lives server-side in /api/lessons/validate-challenge.
   return catalogFetch<Lesson | null>(
-    `*[_type == "course" && slug.current == $courseSlug && onChainStatus.status == "synced" && ${publicAuthoringGate}][0] {
+    `*[_type == "course" && slug.current == $courseSlug && onChainStatus.status == "synced" && ${activeGate} && ${publicAuthoringGate}][0] {
       "allLessons": modules[]->lessons[]->{
         _id,
         title,
@@ -193,7 +201,7 @@ export async function getChallengeAnswerKey(
   // keep the "every gated query uses catalogFetch" invariant — the tag is inert
   // on an uncached read.
   return catalogFetch<ChallengeAnswerKey | null>(
-    `*[_type == "course" && slug.current == $courseSlug && onChainStatus.status == "synced" && ${publicAuthoringGate}][0] {
+    `*[_type == "course" && slug.current == $courseSlug && onChainStatus.status == "synced" && ${activeGate} && ${publicAuthoringGate}][0] {
       "allLessons": modules[]->lessons[]->${answerKeyProjection}
     }.allLessons[slug == $lessonSlug][0]`,
     { courseSlug, lessonSlug },
@@ -211,7 +219,7 @@ export async function getChallengeAnswerKeyById(
   lessonId: string
 ): Promise<ChallengeAnswerKey | null> {
   return catalogFetch<ChallengeAnswerKey | null>(
-    `*[_type == "course" && _id == $courseId && onChainStatus.status == "synced" && ${publicAuthoringGate}][0] {
+    `*[_type == "course" && _id == $courseId && onChainStatus.status == "synced" && ${activeGate} && ${publicAuthoringGate}][0] {
       "allLessons": modules[]->lessons[]->${answerKeyProjection}
     }.allLessons[_id == $lessonId][0]`,
     { courseId, lessonId },
@@ -229,7 +237,7 @@ export async function getAllLearningPaths(): Promise<LearningPath[]> {
       tag,
       order,
       difficulty,
-      "courses": *[_type == "course" && _id in ^.courses[]._ref && onChainStatus.status == "synced" && ${publicAuthoringGate}] {
+      "courses": *[_type == "course" && _id in ^.courses[]._ref && onChainStatus.status == "synced" && ${activeGate} && ${publicAuthoringGate}] {
         ${courseFields},
         "modules": modules[]->{
           _id,
@@ -274,7 +282,7 @@ export async function getCourseIdBySlug(
   slug: string
 ): Promise<{ _id: string; xpPerLesson: number } | null> {
   return catalogFetch<{ _id: string; xpPerLesson: number } | null>(
-    `*[_type == "course" && slug.current == $slug && onChainStatus.status == "synced" && ${publicAuthoringGate}][0] {
+    `*[_type == "course" && slug.current == $slug && onChainStatus.status == "synced" && ${activeGate} && ${publicAuthoringGate}][0] {
       _id,
       "xpPerLesson": coalesce(xpPerLesson, 0)
     }`,
@@ -289,7 +297,7 @@ export async function getCourseLessons(
   courseSlug: string
 ): Promise<Pick<Lesson, "_id" | "title" | "slug" | "type">[]> {
   return catalogFetch<Pick<Lesson, "_id" | "title" | "slug" | "type">[]>(
-    `*[_type == "course" && slug.current == $courseSlug && onChainStatus.status == "synced" && ${publicAuthoringGate}][0] {
+    `*[_type == "course" && slug.current == $courseSlug && onChainStatus.status == "synced" && ${activeGate} && ${publicAuthoringGate}][0] {
       "lessons": modules[]->lessons[]-> {
         _id,
         title,
@@ -321,7 +329,7 @@ export interface CourseSummary {
 export async function getCoursesByIds(ids: string[]): Promise<CourseSummary[]> {
   if (ids.length === 0) return [];
   return catalogFetch<CourseSummary[]>(
-    `*[_type == "course" && _id in $ids && onChainStatus.status == "synced" && ${publicAuthoringGate}] {
+    `*[_type == "course" && _id in $ids && onChainStatus.status == "synced" && ${activeGate} && ${publicAuthoringGate}] {
       _id,
       title,
       "slug": slug.current,
@@ -382,7 +390,7 @@ export async function getRecommendedCourses(
   excludeIds: string[]
 ): Promise<RecommendedCourse[]> {
   return catalogFetch<RecommendedCourse[]>(
-    `*[_type == "course" && !(_id in $excludeIds) && onChainStatus.status == "synced" && ${publicAuthoringGate}] | order(title asc) {
+    `*[_type == "course" && !(_id in $excludeIds) && onChainStatus.status == "synced" && ${activeGate} && ${publicAuthoringGate}] | order(title asc) {
       _id,
       title,
       "slug": slug.current,
@@ -412,7 +420,7 @@ export async function getAllCourseTags(): Promise<
   return catalogFetch<
     { _id: string; title: string; tags: string[]; totalLessons: number }[]
   >(
-    `*[_type == "course" && onChainStatus.status == "synced" && ${publicAuthoringGate} && defined(tags)] {
+    `*[_type == "course" && onChainStatus.status == "synced" && ${activeGate} && ${publicAuthoringGate} && defined(tags)] {
       _id,
       title,
       tags,
@@ -429,7 +437,7 @@ export async function getAllCourseLessonCounts(): Promise<
   { _id: string; totalLessons: number }[]
 > {
   return catalogFetch<{ _id: string; totalLessons: number }[]>(
-    `*[_type == "course" && onChainStatus.status == "synced" && ${publicAuthoringGate}] {
+    `*[_type == "course" && onChainStatus.status == "synced" && ${activeGate} && ${publicAuthoringGate}] {
       _id,
       "totalLessons": count(modules[]->lessons[])
     }`

--- a/sanity/schemas/course.ts
+++ b/sanity/schemas/course.ts
@@ -175,6 +175,13 @@ export const course = defineType({
       description: "Managed by the admin dashboard. Do not edit manually.",
       fields: [
         defineField({ name: "status", title: "Status", type: "string" }),
+        defineField({
+          name: "isActive",
+          title: "Active",
+          type: "boolean",
+          description:
+            "Mirrors the on-chain is_active flag. Set false on deactivate to hide the course from the public catalog. Legacy courses without this field are treated as active.",
+        }),
         defineField({ name: "coursePda", title: "Course PDA", type: "string" }),
         defineField({
           name: "trackCollectionAddress",


### PR DESCRIPTION
## Bug
Deactivating a course from `/admin` didn't remove it from the public catalog — it kept showing on `/courses`.

## Root cause
`POST /api/admin/courses/deactivate` → `deactivateCoursePda` only flips the **on-chain** `Course.is_active` flag. It wrote nothing back to Sanity and didn't revalidate the catalog cache, and the public catalog gate keyed solely on `onChainStatus.status == "synced" && publicAuthoringGate` — never on `is_active`. So the course stayed visible.

## Fix
- **Mirror the flag into Sanity**: new `writeCourseActive(sanityId, isActive)` sets `onChainStatus.isActive`; the deactivate/reactivate routes call it after the on-chain tx and `revalidateTag(COURSES_CACHE_TAG)` (the tag from #313) so the catalog updates immediately.
- **Gate the reads**: new `activeGate = coalesce(onChainStatus.isActive, true)` folded into the shared synced/approved gate across all 12 public course queries — so detail pages, lessons, and dashboard reads hide inactive courses too, not just `/courses`. `coalesce(..., true)` keeps legacy docs (no field) visible.
- **Schema**: added `onChainStatus.isActive` (boolean) to the course schema.
- Admin queries (`getAllCoursesAdmin`) stay **ungated**, so deactivated courses remain visible and reactivatable in `/admin`.
- If the Sanity write fails, the route returns a `warning` (the on-chain tx already succeeded).

## Verification
- `tsc --noEmit` ✓, eslint ✓

Closes #321
