### PR TITLE
fix(onchain): make course lesson_count increase-only mutable (#314)

### DIFF
--- a/apps/web/src/app/api/admin/courses/sync/route.ts
+++ b/apps/web/src/app/api/admin/courses/sync/route.ts
@@ -318,6 +318,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     newXpPerLesson?: number;
     newCreatorRewardXp?: number;
     newMinCompletionsForReward?: number;
+    newLessonCount?: number;
   } = { courseId };
   const updatedFields: string[] = [];
 
@@ -332,6 +333,23 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   if (course.minCompletionsForReward !== null) {
     updateParams.newMinCompletionsForReward = course.minCompletionsForReward;
     updatedFields.push("newMinCompletionsForReward");
+  }
+
+  // Grow the on-chain lesson count when a teacher has appended lessons to an
+  // already-deployed course. Increase-only: without this, a new lesson's index
+  // is >= course.lesson_count and complete_lesson reverts (LessonOutOfBounds,
+  // surfaced as a 409 in /api/lessons/complete). fetchCourse uses the raw-IDL
+  // BorshCoder → snake_case `lesson_count`. The program rejects any decrease
+  // (LessonCountDecrease), so we only send the field when Sanity is strictly
+  // higher; equal/lower is left untouched.
+  const onChainLessonCount = onChainCourse?.lesson_count as number | undefined;
+  if (
+    typeof course.lessonCount === "number" &&
+    typeof onChainLessonCount === "number" &&
+    course.lessonCount > onChainLessonCount
+  ) {
+    updateParams.newLessonCount = course.lessonCount;
+    updatedFields.push("newLessonCount");
   }
 
   if (updatedFields.length === 0) {

--- a/apps/web/src/app/api/lessons/complete/route.ts
+++ b/apps/web/src/app/api/lessons/complete/route.ts
@@ -173,13 +173,12 @@ export async function POST(request: NextRequest) {
     const walletPubkey = new PublicKey(profile.wallet_address);
     const connection = getConnection();
 
-    // Verify on-chain enrollment exists
-    const onChainEnrollment = await fetchEnrollment(
-      courseId,
-      walletPubkey,
-      connection,
-      getProgramId()
-    );
+    // Verify on-chain enrollment exists. The course fetch (for the lesson-count
+    // guard below) is independent, so run both RPC reads in parallel.
+    const [onChainEnrollment, onChainCourse] = await Promise.all([
+      fetchEnrollment(courseId, walletPubkey, connection, getProgramId()),
+      fetchCourse(courseId, connection, getProgramId()),
+    ]);
 
     if (!onChainEnrollment) {
       return NextResponse.json(
@@ -199,11 +198,6 @@ export async function POST(request: NextRequest) {
     // raised by an admin re-sync (update_course.new_lesson_count). Detect it here
     // and return a clear 409 instead of letting the on-chain TX throw a generic
     // 500. fetchCourse uses the raw-IDL BorshCoder → snake_case `lesson_count`.
-    const onChainCourse = await fetchCourse(
-      courseId,
-      connection,
-      getProgramId()
-    );
     const onChainLessonCount = onChainCourse?.lesson_count as
       | number
       | undefined;

--- a/apps/web/src/app/api/lessons/complete/route.ts
+++ b/apps/web/src/app/api/lessons/complete/route.ts
@@ -15,7 +15,7 @@ import {
   getConnection,
   getProgramId,
 } from "@/lib/solana/academy-program";
-import { fetchEnrollment } from "@/lib/solana/academy-reads";
+import { fetchEnrollment, fetchCourse } from "@/lib/solana/academy-reads";
 import { isLessonComplete } from "@/lib/solana/bitmap";
 import { findLessonIndex } from "@/lib/courses/lesson-index";
 
@@ -192,6 +192,33 @@ export async function POST(request: NextRequest) {
 
     // Derive lesson index from Sanity content order
     const lessonIndex = await deriveLessonIndex(courseId, lessonId);
+
+    // Guard: the on-chain complete_lesson reverts when lessonIndex >=
+    // course.lesson_count. That happens when a teacher appended lessons to an
+    // already-deployed course but the Course PDA's lesson_count has not yet been
+    // raised by an admin re-sync (update_course.new_lesson_count). Detect it here
+    // and return a clear 409 instead of letting the on-chain TX throw a generic
+    // 500. fetchCourse uses the raw-IDL BorshCoder → snake_case `lesson_count`.
+    const onChainCourse = await fetchCourse(
+      courseId,
+      connection,
+      getProgramId()
+    );
+    const onChainLessonCount = onChainCourse?.lesson_count as
+      | number
+      | undefined;
+    if (
+      typeof onChainLessonCount === "number" &&
+      lessonIndex >= onChainLessonCount
+    ) {
+      return NextResponse.json(
+        {
+          error:
+            "This course was recently extended and is pending an admin re-sync — try again shortly.",
+        },
+        { status: 409 }
+      );
+    }
 
     // Idempotency: skip on-chain TX if lesson already completed in bitmap
     const alreadyOnChain = isLessonComplete(

--- a/apps/web/src/lib/admin/sync-diff.ts
+++ b/apps/web/src/lib/admin/sync-diff.ts
@@ -168,10 +168,11 @@ export function isDraftId(sanityId: string): boolean {
  * Compare a Sanity course document against an on-chain Course PDA.
  *
  * Updateable fields (fixable with `updateCourse`):
- *   xpPerLesson, creatorRewardXp, minCompletionsForReward
+ *   xpPerLesson, creatorRewardXp, minCompletionsForReward, and an INCREASE in
+ *   lessonCount (increase-only via update_course.new_lesson_count)
  *
  * Immutable fields (require PDA recreation if different):
- *   lessonCount, difficulty, trackId, trackLevel, prerequisite
+ *   difficulty, trackId, trackLevel, prerequisite, and a DECREASE in lessonCount
  *
  * Note: `prerequisite` is compared using raw Sanity _id vs on-chain base58
  * pubkey. The caller is responsible for PDA resolution — this function only
@@ -254,11 +255,16 @@ export function diffCourse(
   // --- Immutable fields ---
 
   if (sanityCourse.lessonCount !== onChainCourse.lessonCount) {
+    // lesson_count is increase-only updateable: a re-sync raises the on-chain
+    // count when a teacher appends lessons (update_course.new_lesson_count).
+    // A DECREASE (Sanity has fewer lessons than on-chain) is rejected by the
+    // program (LessonCountDecrease) and stays an immutable mismatch — applying
+    // it would strand completion flags, so it needs PDA recreation.
     differences.push({
       field: "lessonCount",
       sanityValue: sanityCourse.lessonCount,
       onChainValue: onChainCourse.lessonCount,
-      updateable: false,
+      updateable: sanityCourse.lessonCount > onChainCourse.lessonCount,
     });
   }
 

--- a/apps/web/src/lib/solana/admin-signer.ts
+++ b/apps/web/src/lib/solana/admin-signer.ts
@@ -76,6 +76,7 @@ interface UpdateCourseOnChainParams {
   newCreatorRewardXp: number | null;
   newMinCompletionsForReward: number | null;
   newCollection: PublicKey | null;
+  newLessonCount: number | null;
 }
 
 interface CreateAchievementTypeOnChainParams {
@@ -133,6 +134,12 @@ export interface UpdateCourseAdminParams {
   newMinCompletionsForReward?: number;
   /** Base58 address of the Metaplex Core credential collection to set/backfill. */
   newCollection?: string;
+  /**
+   * Raise the on-chain lesson count (increase-only) after a teacher appends
+   * lessons to an already-deployed course. The program rejects any value below
+   * the current count (LessonCountDecrease).
+   */
+  newLessonCount?: number;
 }
 
 export interface CreateAchievementAdminParams {
@@ -323,6 +330,7 @@ export async function updateCoursePda(
         params.newCollection != null
           ? new PublicKey(params.newCollection)
           : null,
+      newLessonCount: params.newLessonCount ?? null,
     };
 
     const methods = _program.methods as unknown as AdminMethods;

--- a/apps/web/src/lib/solana/idl/superteam_academy.json
+++ b/apps/web/src/lib/solana/idl/superteam_academy.json
@@ -9,16 +9,7 @@
   "instructions": [
     {
       "name": "award_achievement",
-      "discriminator": [
-        75,
-        47,
-        156,
-        253,
-        124,
-        231,
-        84,
-        12
-      ],
+      "discriminator": [75, 47, 156, 253, 124, 231, 84, 12],
       "accounts": [
         {
           "name": "config",
@@ -26,14 +17,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  99,
-                  111,
-                  110,
-                  102,
-                  105,
-                  103
-                ]
+                "value": [99, 111, 110, 102, 105, 103]
               }
             ]
           }
@@ -45,19 +29,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  97,
-                  99,
-                  104,
-                  105,
-                  101,
-                  118,
-                  101,
-                  109,
-                  101,
-                  110,
-                  116
-                ]
+                "value": [97, 99, 104, 105, 101, 118, 101, 109, 101, 110, 116]
               },
               {
                 "kind": "account",
@@ -75,25 +47,8 @@
               {
                 "kind": "const",
                 "value": [
-                  97,
-                  99,
-                  104,
-                  105,
-                  101,
-                  118,
-                  101,
-                  109,
-                  101,
-                  110,
-                  116,
-                  95,
-                  114,
-                  101,
-                  99,
-                  101,
-                  105,
-                  112,
-                  116
+                  97, 99, 104, 105, 101, 118, 101, 109, 101, 110, 116, 95, 114,
+                  101, 99, 101, 105, 112, 116
                 ]
               },
               {
@@ -115,14 +70,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  109,
-                  105,
-                  110,
-                  116,
-                  101,
-                  114
-                ]
+                "value": [109, 105, 110, 116, 101, 114]
               },
               {
                 "kind": "account",
@@ -133,9 +81,7 @@
         },
         {
           "name": "asset",
-          "docs": [
-            "New achievement NFT keypair"
-          ],
+          "docs": ["New achievement NFT keypair"],
           "writable": true,
           "signer": true
         },
@@ -194,16 +140,7 @@
     },
     {
       "name": "close_course",
-      "discriminator": [
-        157,
-        252,
-        239,
-        166,
-        213,
-        174,
-        160,
-        34
-      ],
+      "discriminator": [157, 252, 239, 166, 213, 174, 160, 34],
       "accounts": [
         {
           "name": "config",
@@ -211,14 +148,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  99,
-                  111,
-                  110,
-                  102,
-                  105,
-                  103
-                ]
+                "value": [99, 111, 110, 102, 105, 103]
               }
             ]
           }
@@ -236,14 +166,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  99,
-                  111,
-                  117,
-                  114,
-                  115,
-                  101
-                ]
+                "value": [99, 111, 117, 114, 115, 101]
               },
               {
                 "kind": "arg",
@@ -255,9 +178,7 @@
         {
           "name": "authority",
           "signer": true,
-          "relations": [
-            "config"
-          ]
+          "relations": ["config"]
         }
       ],
       "args": [
@@ -269,16 +190,7 @@
     },
     {
       "name": "close_enrollment",
-      "discriminator": [
-        236,
-        137,
-        133,
-        253,
-        91,
-        138,
-        217,
-        91
-      ],
+      "discriminator": [236, 137, 133, 253, 91, 138, 217, 91],
       "accounts": [
         {
           "name": "course",
@@ -286,14 +198,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  99,
-                  111,
-                  117,
-                  114,
-                  115,
-                  101
-                ]
+                "value": [99, 111, 117, 114, 115, 101]
               },
               {
                 "kind": "account",
@@ -310,18 +215,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  101,
-                  110,
-                  114,
-                  111,
-                  108,
-                  108,
-                  109,
-                  101,
-                  110,
-                  116
-                ]
+                "value": [101, 110, 114, 111, 108, 108, 109, 101, 110, 116]
               },
               {
                 "kind": "account",
@@ -345,16 +239,7 @@
     },
     {
       "name": "complete_lesson",
-      "discriminator": [
-        77,
-        217,
-        53,
-        132,
-        204,
-        150,
-        169,
-        58
-      ],
+      "discriminator": [77, 217, 53, 132, 204, 150, 169, 58],
       "accounts": [
         {
           "name": "config",
@@ -362,14 +247,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  99,
-                  111,
-                  110,
-                  102,
-                  105,
-                  103
-                ]
+                "value": [99, 111, 110, 102, 105, 103]
               }
             ]
           }
@@ -380,14 +258,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  99,
-                  111,
-                  117,
-                  114,
-                  115,
-                  101
-                ]
+                "value": [99, 111, 117, 114, 115, 101]
               },
               {
                 "kind": "account",
@@ -404,18 +275,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  101,
-                  110,
-                  114,
-                  111,
-                  108,
-                  108,
-                  109,
-                  101,
-                  110,
-                  116
-                ]
+                "value": [101, 110, 114, 111, 108, 108, 109, 101, 110, 116]
               },
               {
                 "kind": "account",
@@ -462,16 +322,7 @@
     },
     {
       "name": "create_achievement_type",
-      "discriminator": [
-        231,
-        38,
-        39,
-        228,
-        103,
-        4,
-        229,
-        19
-      ],
+      "discriminator": [231, 38, 39, 228, 103, 4, 229, 19],
       "accounts": [
         {
           "name": "config",
@@ -479,14 +330,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  99,
-                  111,
-                  110,
-                  102,
-                  105,
-                  103
-                ]
+                "value": [99, 111, 110, 102, 105, 103]
               }
             ]
           }
@@ -498,19 +342,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  97,
-                  99,
-                  104,
-                  105,
-                  101,
-                  118,
-                  101,
-                  109,
-                  101,
-                  110,
-                  116
-                ]
+                "value": [97, 99, 104, 105, 101, 118, 101, 109, 101, 110, 116]
               },
               {
                 "kind": "arg",
@@ -521,9 +353,7 @@
         },
         {
           "name": "collection",
-          "docs": [
-            "New Metaplex Core collection keypair"
-          ],
+          "docs": ["New Metaplex Core collection keypair"],
           "writable": true,
           "signer": true
         },
@@ -558,16 +388,7 @@
     },
     {
       "name": "create_course",
-      "discriminator": [
-        120,
-        121,
-        154,
-        164,
-        107,
-        180,
-        167,
-        241
-      ],
+      "discriminator": [120, 121, 154, 164, 107, 180, 167, 241],
       "accounts": [
         {
           "name": "course",
@@ -576,14 +397,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  99,
-                  111,
-                  117,
-                  114,
-                  115,
-                  101
-                ]
+                "value": [99, 111, 117, 114, 115, 101]
               },
               {
                 "kind": "arg",
@@ -598,14 +412,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  99,
-                  111,
-                  110,
-                  102,
-                  105,
-                  103
-                ]
+                "value": [99, 111, 110, 102, 105, 103]
               }
             ]
           }
@@ -614,9 +421,7 @@
           "name": "authority",
           "writable": true,
           "signer": true,
-          "relations": [
-            "config"
-          ]
+          "relations": ["config"]
         },
         {
           "name": "system_program",
@@ -636,16 +441,7 @@
     },
     {
       "name": "deactivate_achievement_type",
-      "discriminator": [
-        185,
-        21,
-        222,
-        243,
-        192,
-        118,
-        71,
-        191
-      ],
+      "discriminator": [185, 21, 222, 243, 192, 118, 71, 191],
       "accounts": [
         {
           "name": "config",
@@ -653,14 +449,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  99,
-                  111,
-                  110,
-                  102,
-                  105,
-                  103
-                ]
+                "value": [99, 111, 110, 102, 105, 103]
               }
             ]
           }
@@ -672,19 +461,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  97,
-                  99,
-                  104,
-                  105,
-                  101,
-                  118,
-                  101,
-                  109,
-                  101,
-                  110,
-                  116
-                ]
+                "value": [97, 99, 104, 105, 101, 118, 101, 109, 101, 110, 116]
               },
               {
                 "kind": "account",
@@ -703,16 +480,7 @@
     },
     {
       "name": "enroll",
-      "discriminator": [
-        58,
-        12,
-        36,
-        3,
-        142,
-        28,
-        1,
-        43
-      ],
+      "discriminator": [58, 12, 36, 3, 142, 28, 1, 43],
       "accounts": [
         {
           "name": "course",
@@ -721,14 +489,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  99,
-                  111,
-                  117,
-                  114,
-                  115,
-                  101
-                ]
+                "value": [99, 111, 117, 114, 115, 101]
               },
               {
                 "kind": "arg",
@@ -744,18 +505,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  101,
-                  110,
-                  114,
-                  111,
-                  108,
-                  108,
-                  109,
-                  101,
-                  110,
-                  116
-                ]
+                "value": [101, 110, 114, 111, 108, 108, 109, 101, 110, 116]
               },
               {
                 "kind": "arg",
@@ -787,16 +537,7 @@
     },
     {
       "name": "finalize_course",
-      "discriminator": [
-        68,
-        189,
-        122,
-        239,
-        39,
-        121,
-        16,
-        218
-      ],
+      "discriminator": [68, 189, 122, 239, 39, 121, 16, 218],
       "accounts": [
         {
           "name": "config",
@@ -804,14 +545,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  99,
-                  111,
-                  110,
-                  102,
-                  105,
-                  103
-                ]
+                "value": [99, 111, 110, 102, 105, 103]
               }
             ]
           }
@@ -823,14 +557,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  99,
-                  111,
-                  117,
-                  114,
-                  115,
-                  101
-                ]
+                "value": [99, 111, 117, 114, 115, 101]
               },
               {
                 "kind": "account",
@@ -847,18 +574,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  101,
-                  110,
-                  114,
-                  111,
-                  108,
-                  108,
-                  109,
-                  101,
-                  110,
-                  116
-                ]
+                "value": [101, 110, 114, 111, 108, 108, 109, 101, 110, 116]
               },
               {
                 "kind": "account",
@@ -911,16 +627,7 @@
     },
     {
       "name": "initialize",
-      "discriminator": [
-        175,
-        175,
-        109,
-        31,
-        13,
-        152,
-        155,
-        237
-      ],
+      "discriminator": [175, 175, 109, 31, 13, 152, 155, 237],
       "accounts": [
         {
           "name": "config",
@@ -929,14 +636,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  99,
-                  111,
-                  110,
-                  102,
-                  105,
-                  103
-                ]
+                "value": [99, 111, 110, 102, 105, 103]
               }
             ]
           }
@@ -965,14 +665,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  109,
-                  105,
-                  110,
-                  116,
-                  101,
-                  114
-                ]
+                "value": [109, 105, 110, 116, 101, 114]
               },
               {
                 "kind": "account",
@@ -994,16 +687,7 @@
     },
     {
       "name": "issue_credential",
-      "discriminator": [
-        255,
-        193,
-        171,
-        224,
-        68,
-        171,
-        194,
-        87
-      ],
+      "discriminator": [255, 193, 171, 224, 68, 171, 194, 87],
       "accounts": [
         {
           "name": "config",
@@ -1011,14 +695,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  99,
-                  111,
-                  110,
-                  102,
-                  105,
-                  103
-                ]
+                "value": [99, 111, 110, 102, 105, 103]
               }
             ]
           }
@@ -1029,14 +706,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  99,
-                  111,
-                  117,
-                  114,
-                  115,
-                  101
-                ]
+                "value": [99, 111, 117, 114, 115, 101]
               },
               {
                 "kind": "account",
@@ -1053,18 +723,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  101,
-                  110,
-                  114,
-                  111,
-                  108,
-                  108,
-                  109,
-                  101,
-                  110,
-                  116
-                ]
+                "value": [101, 110, 114, 111, 108, 108, 109, 101, 110, 116]
               },
               {
                 "kind": "account",
@@ -1132,16 +791,7 @@
     },
     {
       "name": "register_minter",
-      "discriminator": [
-        58,
-        224,
-        74,
-        142,
-        170,
-        95,
-        116,
-        191
-      ],
+      "discriminator": [58, 224, 74, 142, 170, 95, 116, 191],
       "accounts": [
         {
           "name": "config",
@@ -1149,14 +799,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  99,
-                  111,
-                  110,
-                  102,
-                  105,
-                  103
-                ]
+                "value": [99, 111, 110, 102, 105, 103]
               }
             ]
           }
@@ -1168,14 +811,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  109,
-                  105,
-                  110,
-                  116,
-                  101,
-                  114
-                ]
+                "value": [109, 105, 110, 116, 101, 114]
               },
               {
                 "kind": "arg",
@@ -1212,16 +848,7 @@
     },
     {
       "name": "revoke_minter",
-      "discriminator": [
-        33,
-        91,
-        131,
-        167,
-        62,
-        37,
-        38,
-        105
-      ],
+      "discriminator": [33, 91, 131, 167, 62, 37, 38, 105],
       "accounts": [
         {
           "name": "config",
@@ -1229,14 +856,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  99,
-                  111,
-                  110,
-                  102,
-                  105,
-                  103
-                ]
+                "value": [99, 111, 110, 102, 105, 103]
               }
             ]
           }
@@ -1248,14 +868,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  109,
-                  105,
-                  110,
-                  116,
-                  101,
-                  114
-                ]
+                "value": [109, 105, 110, 116, 101, 114]
               },
               {
                 "kind": "account",
@@ -1275,16 +888,7 @@
     },
     {
       "name": "reward_xp",
-      "discriminator": [
-        144,
-        187,
-        117,
-        238,
-        89,
-        118,
-        224,
-        145
-      ],
+      "discriminator": [144, 187, 117, 238, 89, 118, 224, 145],
       "accounts": [
         {
           "name": "config",
@@ -1292,14 +896,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  99,
-                  111,
-                  110,
-                  102,
-                  105,
-                  103
-                ]
+                "value": [99, 111, 110, 102, 105, 103]
               }
             ]
           }
@@ -1311,14 +908,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  109,
-                  105,
-                  110,
-                  116,
-                  101,
-                  114
-                ]
+                "value": [109, 105, 110, 116, 101, 114]
               },
               {
                 "kind": "account",
@@ -1329,9 +919,7 @@
         },
         {
           "name": "xp_mint",
-          "docs": [
-            "Token-2022 XP mint"
-          ],
+          "docs": ["Token-2022 XP mint"],
           "writable": true
         },
         {
@@ -1375,16 +963,7 @@
     },
     {
       "name": "update_config",
-      "discriminator": [
-        29,
-        158,
-        252,
-        191,
-        10,
-        83,
-        219,
-        99
-      ],
+      "discriminator": [29, 158, 252, 191, 10, 83, 219, 99],
       "accounts": [
         {
           "name": "config",
@@ -1393,14 +972,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  99,
-                  111,
-                  110,
-                  102,
-                  105,
-                  103
-                ]
+                "value": [99, 111, 110, 102, 105, 103]
               }
             ]
           }
@@ -1408,9 +980,7 @@
         {
           "name": "authority",
           "signer": true,
-          "relations": [
-            "config"
-          ]
+          "relations": ["config"]
         }
       ],
       "args": [
@@ -1426,16 +996,7 @@
     },
     {
       "name": "update_course",
-      "discriminator": [
-        81,
-        217,
-        18,
-        192,
-        129,
-        233,
-        129,
-        231
-      ],
+      "discriminator": [81, 217, 18, 192, 129, 233, 129, 231],
       "accounts": [
         {
           "name": "config",
@@ -1443,14 +1004,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  99,
-                  111,
-                  110,
-                  102,
-                  105,
-                  103
-                ]
+                "value": [99, 111, 110, 102, 105, 103]
               }
             ]
           }
@@ -1462,14 +1016,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  99,
-                  111,
-                  117,
-                  114,
-                  115,
-                  101
-                ]
+                "value": [99, 111, 117, 114, 115, 101]
               },
               {
                 "kind": "account",
@@ -1482,9 +1029,7 @@
         {
           "name": "authority",
           "signer": true,
-          "relations": [
-            "config"
-          ]
+          "relations": ["config"]
         }
       ],
       "args": [
@@ -1500,16 +1045,7 @@
     },
     {
       "name": "update_minter",
-      "discriminator": [
-        164,
-        129,
-        164,
-        88,
-        75,
-        29,
-        91,
-        38
-      ],
+      "discriminator": [164, 129, 164, 88, 75, 29, 91, 38],
       "accounts": [
         {
           "name": "config",
@@ -1517,14 +1053,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  99,
-                  111,
-                  110,
-                  102,
-                  105,
-                  103
-                ]
+                "value": [99, 111, 110, 102, 105, 103]
               }
             ]
           }
@@ -1536,14 +1065,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  109,
-                  105,
-                  110,
-                  116,
-                  101,
-                  114
-                ]
+                "value": [109, 105, 110, 116, 101, 114]
               },
               {
                 "kind": "account",
@@ -1571,16 +1093,7 @@
     },
     {
       "name": "upgrade_credential",
-      "discriminator": [
-        2,
-        121,
-        77,
-        255,
-        103,
-        187,
-        252,
-        169
-      ],
+      "discriminator": [2, 121, 77, 255, 103, 187, 252, 169],
       "accounts": [
         {
           "name": "config",
@@ -1588,14 +1101,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  99,
-                  111,
-                  110,
-                  102,
-                  105,
-                  103
-                ]
+                "value": [99, 111, 110, 102, 105, 103]
               }
             ]
           }
@@ -1606,14 +1112,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  99,
-                  111,
-                  117,
-                  114,
-                  115,
-                  101
-                ]
+                "value": [99, 111, 117, 114, 115, 101]
               },
               {
                 "kind": "account",
@@ -1629,18 +1128,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  101,
-                  110,
-                  114,
-                  111,
-                  108,
-                  108,
-                  109,
-                  101,
-                  110,
-                  116
-                ]
+                "value": [101, 110, 114, 111, 108, 108, 109, 101, 110, 116]
               },
               {
                 "kind": "account",
@@ -1709,317 +1197,101 @@
   "accounts": [
     {
       "name": "AchievementReceipt",
-      "discriminator": [
-        149,
-        5,
-        79,
-        178,
-        116,
-        231,
-        43,
-        248
-      ]
+      "discriminator": [149, 5, 79, 178, 116, 231, 43, 248]
     },
     {
       "name": "AchievementType",
-      "discriminator": [
-        13,
-        187,
-        114,
-        66,
-        217,
-        154,
-        85,
-        137
-      ]
+      "discriminator": [13, 187, 114, 66, 217, 154, 85, 137]
     },
     {
       "name": "Config",
-      "discriminator": [
-        155,
-        12,
-        170,
-        224,
-        30,
-        250,
-        204,
-        130
-      ]
+      "discriminator": [155, 12, 170, 224, 30, 250, 204, 130]
     },
     {
       "name": "Course",
-      "discriminator": [
-        206,
-        6,
-        78,
-        228,
-        163,
-        138,
-        241,
-        106
-      ]
+      "discriminator": [206, 6, 78, 228, 163, 138, 241, 106]
     },
     {
       "name": "Enrollment",
-      "discriminator": [
-        249,
-        210,
-        64,
-        145,
-        197,
-        241,
-        57,
-        51
-      ]
+      "discriminator": [249, 210, 64, 145, 197, 241, 57, 51]
     },
     {
       "name": "MinterRole",
-      "discriminator": [
-        21,
-        246,
-        6,
-        133,
-        142,
-        211,
-        33,
-        193
-      ]
+      "discriminator": [21, 246, 6, 133, 142, 211, 33, 193]
     }
   ],
   "events": [
     {
       "name": "AchievementAwarded",
-      "discriminator": [
-        127,
-        212,
-        93,
-        231,
-        175,
-        0,
-        69,
-        150
-      ]
+      "discriminator": [127, 212, 93, 231, 175, 0, 69, 150]
     },
     {
       "name": "AchievementTypeCreated",
-      "discriminator": [
-        189,
-        36,
-        173,
-        243,
-        25,
-        232,
-        198,
-        153
-      ]
+      "discriminator": [189, 36, 173, 243, 25, 232, 198, 153]
     },
     {
       "name": "AchievementTypeDeactivated",
-      "discriminator": [
-        133,
-        12,
-        218,
-        127,
-        151,
-        28,
-        1,
-        222
-      ]
+      "discriminator": [133, 12, 218, 127, 151, 28, 1, 222]
     },
     {
       "name": "ConfigUpdated",
-      "discriminator": [
-        40,
-        241,
-        230,
-        122,
-        11,
-        19,
-        198,
-        194
-      ]
+      "discriminator": [40, 241, 230, 122, 11, 19, 198, 194]
     },
     {
       "name": "CourseClosed",
-      "discriminator": [
-        35,
-        195,
-        37,
-        254,
-        25,
-        107,
-        100,
-        12
-      ]
+      "discriminator": [35, 195, 37, 254, 25, 107, 100, 12]
     },
     {
       "name": "CourseCreated",
-      "discriminator": [
-        205,
-        144,
-        55,
-        47,
-        150,
-        170,
-        123,
-        214
-      ]
+      "discriminator": [205, 144, 55, 47, 150, 170, 123, 214]
     },
     {
       "name": "CourseFinalized",
-      "discriminator": [
-        18,
-        195,
-        195,
-        25,
-        165,
-        189,
-        194,
-        56
-      ]
+      "discriminator": [18, 195, 195, 25, 165, 189, 194, 56]
     },
     {
       "name": "CourseUpdated",
-      "discriminator": [
-        124,
-        141,
-        110,
-        224,
-        149,
-        124,
-        26,
-        141
-      ]
+      "discriminator": [124, 141, 110, 224, 149, 124, 26, 141]
     },
     {
       "name": "CredentialIssued",
-      "discriminator": [
-        194,
-        216,
-        28,
-        159,
-        89,
-        29,
-        72,
-        177
-      ]
+      "discriminator": [194, 216, 28, 159, 89, 29, 72, 177]
     },
     {
       "name": "CredentialUpgraded",
-      "discriminator": [
-        198,
-        142,
-        252,
-        191,
-        210,
-        200,
-        253,
-        133
-      ]
+      "discriminator": [198, 142, 252, 191, 210, 200, 253, 133]
     },
     {
       "name": "Enrolled",
-      "discriminator": [
-        129,
-        156,
-        102,
-        214,
-        94,
-        196,
-        220,
-        127
-      ]
+      "discriminator": [129, 156, 102, 214, 94, 196, 220, 127]
     },
     {
       "name": "EnrollmentClosed",
-      "discriminator": [
-        197,
-        4,
-        145,
-        238,
-        217,
-        4,
-        175,
-        77
-      ]
+      "discriminator": [197, 4, 145, 238, 217, 4, 175, 77]
     },
     {
       "name": "LessonCompleted",
-      "discriminator": [
-        248,
-        174,
-        148,
-        235,
-        186,
-        49,
-        11,
-        163
-      ]
+      "discriminator": [248, 174, 148, 235, 186, 49, 11, 163]
     },
     {
       "name": "MinterRegistered",
-      "discriminator": [
-        104,
-        203,
-        87,
-        105,
-        23,
-        33,
-        231,
-        1
-      ]
+      "discriminator": [104, 203, 87, 105, 23, 33, 231, 1]
     },
     {
       "name": "MinterRevoked",
-      "discriminator": [
-        138,
-        76,
-        227,
-        247,
-        141,
-        92,
-        77,
-        127
-      ]
+      "discriminator": [138, 76, 227, 247, 141, 92, 77, 127]
     },
     {
       "name": "MinterUpdated",
-      "discriminator": [
-        8,
-        124,
-        66,
-        45,
-        176,
-        53,
-        49,
-        153
-      ]
+      "discriminator": [8, 124, 66, 45, 176, 53, 49, 153]
     },
     {
       "name": "MintingPauseSet",
-      "discriminator": [
-        232,
-        11,
-        219,
-        8,
-        116,
-        65,
-        178,
-        74
-      ]
+      "discriminator": [232, 11, 219, 8, 116, 65, 178, 74]
     },
     {
       "name": "XpRewarded",
-      "discriminator": [
-        140,
-        182,
-        232,
-        144,
-        16,
-        155,
-        237,
-        182
-      ]
+      "discriminator": [140, 182, 232, 144, 16, 155, 237, 182]
     }
   ],
   "errors": [
@@ -2192,6 +1464,11 @@
       "code": 6033,
       "name": "XpAmountExceedsMax",
       "msg": "XP amount exceeds the per-mint ceiling"
+    },
+    {
+      "code": 6034,
+      "name": "LessonCountDecrease",
+      "msg": "Lesson count can only be increased, never decreased"
     }
   ],
   "types": [
@@ -2234,9 +1511,7 @@
         "fields": [
           {
             "name": "asset",
-            "docs": [
-              "Metaplex Core NFT address"
-            ],
+            "docs": ["Metaplex Core NFT address"],
             "type": "pubkey"
           },
           {
@@ -2265,16 +1540,12 @@
           },
           {
             "name": "metadata_uri",
-            "docs": [
-              "Default metadata URI for minted NFTs"
-            ],
+            "docs": ["Default metadata URI for minted NFTs"],
             "type": "string"
           },
           {
             "name": "collection",
-            "docs": [
-              "Metaplex Core collection for this achievement"
-            ],
+            "docs": ["Metaplex Core collection for this achievement"],
             "type": "pubkey"
           },
           {
@@ -2283,9 +1554,7 @@
           },
           {
             "name": "max_supply",
-            "docs": [
-              "0 = unlimited supply"
-            ],
+            "docs": ["0 = unlimited supply"],
             "type": "u32"
           },
           {
@@ -2294,9 +1563,7 @@
           },
           {
             "name": "xp_reward",
-            "docs": [
-              "XP awarded alongside the NFT (0 = no XP)"
-            ],
+            "docs": ["XP awarded alongside the NFT (0 = no XP)"],
             "type": "u32"
           },
           {
@@ -2310,10 +1577,7 @@
           {
             "name": "_reserved",
             "type": {
-              "array": [
-                "u8",
-                8
-              ]
+              "array": ["u8", 8]
             }
           },
           {
@@ -2378,23 +1642,17 @@
         "fields": [
           {
             "name": "authority",
-            "docs": [
-              "Platform multisig (Squads)"
-            ],
+            "docs": ["Platform multisig (Squads)"],
             "type": "pubkey"
           },
           {
             "name": "backend_signer",
-            "docs": [
-              "Rotatable backend signer for completions"
-            ],
+            "docs": ["Rotatable backend signer for completions"],
             "type": "pubkey"
           },
           {
             "name": "xp_mint",
-            "docs": [
-              "Token-2022 mint for XP"
-            ],
+            "docs": ["Token-2022 mint for XP"],
             "type": "pubkey"
           },
           {
@@ -2409,21 +1667,14 @@
           },
           {
             "name": "_reserved",
-            "docs": [
-              "Reserved for future use"
-            ],
+            "docs": ["Reserved for future use"],
             "type": {
-              "array": [
-                "u8",
-                7
-              ]
+              "array": ["u8", 7]
             }
           },
           {
             "name": "bump",
-            "docs": [
-              "PDA bump"
-            ],
+            "docs": ["PDA bump"],
             "type": "u8"
           }
         ]
@@ -2464,10 +1715,7 @@
           {
             "name": "content_tx_id",
             "type": {
-              "array": [
-                "u8",
-                32
-              ]
+              "array": ["u8", 32]
             }
           },
           {
@@ -2539,10 +1787,7 @@
           {
             "name": "_reserved",
             "type": {
-              "array": [
-                "u8",
-                8
-              ]
+              "array": ["u8", 8]
             }
           },
           {
@@ -2712,10 +1957,7 @@
           {
             "name": "content_tx_id",
             "type": {
-              "array": [
-                "u8",
-                32
-              ]
+              "array": ["u8", 32]
             }
           },
           {
@@ -2852,23 +2094,17 @@
         "fields": [
           {
             "name": "course",
-            "docs": [
-              "The Course PDA this enrollment belongs to"
-            ],
+            "docs": ["The Course PDA this enrollment belongs to"],
             "type": "pubkey"
           },
           {
             "name": "enrolled_at",
-            "docs": [
-              "When learner enrolled"
-            ],
+            "docs": ["When learner enrolled"],
             "type": "i64"
           },
           {
             "name": "completed_at",
-            "docs": [
-              "When course was completed (None if in progress)"
-            ],
+            "docs": ["When course was completed (None if in progress)"],
             "type": {
               "option": "i64"
             }
@@ -2880,10 +2116,7 @@
               "lesson_count is u8 (max 255), so all valid indices fit within this bitmap."
             ],
             "type": {
-              "array": [
-                "u64",
-                4
-              ]
+              "array": ["u64", 4]
             }
           },
           {
@@ -2911,17 +2144,12 @@
               "and is a migration (realloc + backfill), not an in-place change."
             ],
             "type": {
-              "array": [
-                "u8",
-                4
-              ]
+              "array": ["u8", 4]
             }
           },
           {
             "name": "bump",
-            "docs": [
-              "PDA bump"
-            ],
+            "docs": ["PDA bump"],
             "type": "u8"
           }
         ]
@@ -3038,9 +2266,7 @@
         "fields": [
           {
             "name": "minter",
-            "docs": [
-              "Wallet or program PDA authorized to mint XP"
-            ],
+            "docs": ["Wallet or program PDA authorized to mint XP"],
             "type": "pubkey"
           },
           {
@@ -3052,16 +2278,12 @@
           },
           {
             "name": "max_xp_per_call",
-            "docs": [
-              "Per-call XP cap. 0 = unlimited."
-            ],
+            "docs": ["Per-call XP cap. 0 = unlimited."],
             "type": "u64"
           },
           {
             "name": "total_xp_minted",
-            "docs": [
-              "Lifetime XP minted through this role"
-            ],
+            "docs": ["Lifetime XP minted through this role"],
             "type": "u64"
           },
           {
@@ -3148,9 +2370,7 @@
           },
           {
             "name": "max_total_xp",
-            "docs": [
-              "Cumulative XP ceiling for this role. 0 = unlimited."
-            ],
+            "docs": ["Cumulative XP ceiling for this role. 0 = unlimited."],
             "type": "u64"
           }
         ]
@@ -3202,10 +2422,7 @@
             "name": "new_content_tx_id",
             "type": {
               "option": {
-                "array": [
-                  "u8",
-                  32
-                ]
+                "array": ["u8", 32]
               }
             }
           },
@@ -3241,6 +2458,19 @@
             "type": {
               "option": "pubkey"
             }
+          },
+          {
+            "name": "new_lesson_count",
+            "docs": [
+              "Grow the course's lesson count (increase-only) when a teacher appends",
+              "lessons to an already-deployed course. Shrinking is rejected — it would",
+              "strand completed-lesson flags and shift bitmap indices. The enrollment",
+              "bitmap is `[u64; 4]` (256 bits), so any valid `u8` count fits without an",
+              "account resize."
+            ],
+            "type": {
+              "option": "u8"
+            }
           }
         ]
       }
@@ -3252,9 +2482,7 @@
         "fields": [
           {
             "name": "max_xp_per_call",
-            "docs": [
-              "New per-call XP cap. 0 = unlimited."
-            ],
+            "docs": ["New per-call XP cap. 0 = unlimited."],
             "type": "u64"
           },
           {

--- a/onchain-academy/programs/onchain-academy/src/errors.rs
+++ b/onchain-academy/programs/onchain-academy/src/errors.rs
@@ -70,4 +70,6 @@ pub enum AcademyError {
     WrongXpMint,
     #[msg("XP amount exceeds the per-mint ceiling")]
     XpAmountExceedsMax,
+    #[msg("Lesson count can only be increased, never decreased")]
+    LessonCountDecrease,
 }

--- a/onchain-academy/programs/onchain-academy/src/instructions/update_course.rs
+++ b/onchain-academy/programs/onchain-academy/src/instructions/update_course.rs
@@ -13,6 +13,12 @@ pub struct UpdateCourseParams {
     pub new_min_completions_for_reward: Option<u16>,
     /// Set/backfill the Metaplex Core credential collection for this course.
     pub new_collection: Option<Pubkey>,
+    /// Grow the course's lesson count (increase-only) when a teacher appends
+    /// lessons to an already-deployed course. Shrinking is rejected — it would
+    /// strand completed-lesson flags and shift bitmap indices. The enrollment
+    /// bitmap is `[u64; 4]` (256 bits), so any valid `u8` count fits without an
+    /// account resize.
+    pub new_lesson_count: Option<u8>,
 }
 
 pub fn handler(ctx: Context<UpdateCourse>, params: UpdateCourseParams) -> Result<()> {
@@ -42,6 +48,17 @@ pub fn handler(ctx: Context<UpdateCourse>, params: UpdateCourseParams) -> Result
 
     if let Some(min_completions) = params.new_min_completions_for_reward {
         course.min_completions_for_reward = min_completions;
+    }
+
+    if let Some(new_lesson_count) = params.new_lesson_count {
+        // Increase-only: raising the count lets a re-sync pick up appended
+        // lessons; equal is a no-op. A lower value would strand completed flags
+        // and shift indices, so reject it.
+        require!(
+            new_lesson_count >= course.lesson_count,
+            AcademyError::LessonCountDecrease
+        );
+        course.lesson_count = new_lesson_count;
     }
 
     if let Some(collection) = params.new_collection {

--- a/onchain-academy/tests/onchain-academy.ts
+++ b/onchain-academy/tests/onchain-academy.ts
@@ -681,6 +681,7 @@ describe("onchain-academy", () => {
           newCreatorRewardXp: null,
           newMinCompletionsForReward: null,
           newCollection: null,
+          newLessonCount: null,
         })
         .accountsPartial({
           course: coursePda,
@@ -703,6 +704,7 @@ describe("onchain-academy", () => {
           newCreatorRewardXp: null,
           newMinCompletionsForReward: null,
           newCollection: null,
+          newLessonCount: null,
         })
         .accountsPartial({
           course: coursePda,
@@ -723,6 +725,7 @@ describe("onchain-academy", () => {
           newCreatorRewardXp: null,
           newMinCompletionsForReward: null,
           newCollection: null,
+          newLessonCount: null,
         })
         .accountsPartial({
           course: coursePda,
@@ -751,6 +754,7 @@ describe("onchain-academy", () => {
           newCreatorRewardXp: 50,
           newMinCompletionsForReward: 5,
           newCollection: null,
+          newLessonCount: null,
         })
         .accountsPartial({
           course: diffPda,
@@ -810,6 +814,7 @@ describe("onchain-academy", () => {
           newCreatorRewardXp: null,
           newMinCompletionsForReward: null,
           newCollection: firstCollection,
+          newLessonCount: null,
         })
         .accountsPartial({
           course: guardPda,
@@ -831,6 +836,7 @@ describe("onchain-academy", () => {
             newCreatorRewardXp: null,
             newMinCompletionsForReward: null,
             newCollection: secondCollection,
+            newLessonCount: null,
           })
           .accountsPartial({
             course: guardPda,
@@ -856,6 +862,7 @@ describe("onchain-academy", () => {
           newCreatorRewardXp: null,
           newMinCompletionsForReward: null,
           newCollection: firstCollection,
+          newLessonCount: null,
         })
         .accountsPartial({
           course: guardPda,
@@ -885,6 +892,7 @@ describe("onchain-academy", () => {
             newCreatorRewardXp: null,
             newMinCompletionsForReward: null,
             newCollection: null,
+            newLessonCount: null,
           })
           .accountsPartial({
             course: coursePda,
@@ -901,6 +909,79 @@ describe("onchain-academy", () => {
           expect(err.toString()).to.contain("Error");
         }
       }
+    });
+
+    it("lesson_count is increase-only (grow ok, equal no-op, shrink rejected)", async () => {
+      const growId = "lesson-count-grow";
+      const [growPda] = PublicKey.findProgramAddressSync(
+        [Buffer.from("course"), Buffer.from(growId)],
+        program.programId
+      );
+
+      await program.methods
+        .createCourse({
+          courseId: growId,
+          creator: creator.publicKey,
+          contentTxId: contentTxId,
+          lessonCount: 2,
+          difficulty: 1,
+          xpPerLesson: 10,
+          trackId: 1,
+          trackLevel: 1,
+          prerequisite: null,
+          creatorRewardXp: 0,
+          minCompletionsForReward: 0,
+          collection: null,
+        })
+        .accountsPartial({
+          course: growPda,
+          config: configPda,
+          authority: authority.publicKey,
+          systemProgram: SystemProgram.programId,
+        })
+        .rpc();
+
+      const bump = (newLessonCount: number) =>
+        program.methods
+          .updateCourse({
+            newContentTxId: null,
+            newIsActive: null,
+            newXpPerLesson: null,
+            newCreatorRewardXp: null,
+            newMinCompletionsForReward: null,
+            newCollection: null,
+            newLessonCount,
+          })
+          .accountsPartial({
+            course: growPda,
+            config: configPda,
+            authority: authority.publicKey,
+          })
+          .rpc();
+
+      // Increase 2 -> 4: allowed.
+      await bump(4);
+      let course = await program.account.course.fetch(growPda);
+      expect(course.lessonCount).to.equal(4);
+
+      // Equal (4 -> 4): no-op, allowed.
+      await bump(4);
+      course = await program.account.course.fetch(growPda);
+      expect(course.lessonCount).to.equal(4);
+
+      // Decrease 4 -> 3: rejected, count unchanged.
+      try {
+        await bump(3);
+        expect.fail("Should have thrown");
+      } catch (err) {
+        if (err instanceof AnchorError) {
+          expect(err.error.errorCode.code).to.equal("LessonCountDecrease");
+        } else {
+          expect(err.toString()).to.contain("Error");
+        }
+      }
+      course = await program.account.course.fetch(growPda);
+      expect(course.lessonCount).to.equal(4);
     });
   });
 
@@ -990,6 +1071,7 @@ describe("onchain-academy", () => {
           newCreatorRewardXp: null,
           newMinCompletionsForReward: null,
           newCollection: null,
+          newLessonCount: null,
         })
         .accountsPartial({
           course: coursePda,
@@ -1043,6 +1125,7 @@ describe("onchain-academy", () => {
           newCreatorRewardXp: null,
           newMinCompletionsForReward: null,
           newCollection: null,
+          newLessonCount: null,
         })
         .accountsPartial({
           course: coursePda,
@@ -5503,14 +5586,22 @@ describe("onchain-academy", () => {
 
     const pause = async (): Promise<void> => {
       await program.methods
-        .updateConfig({ newBackendSigner: null, paused: true, newAuthority: null })
+        .updateConfig({
+          newBackendSigner: null,
+          paused: true,
+          newAuthority: null,
+        })
         .accountsPartial({ config: configPda, authority: authority.publicKey })
         .rpc();
     };
 
     const resume = async (): Promise<void> => {
       await program.methods
-        .updateConfig({ newBackendSigner: null, paused: false, newAuthority: null })
+        .updateConfig({
+          newBackendSigner: null,
+          paused: false,
+          newAuthority: null,
+        })
         .accountsPartial({ config: configPda, authority: authority.publicKey })
         .rpc();
     };

--- a/onchain-academy/tests/rust/src/lib.rs
+++ b/onchain-academy/tests/rust/src/lib.rs
@@ -17,6 +17,8 @@ mod test_initialize;
 #[cfg(test)]
 mod test_kill_switch;
 #[cfg(test)]
+mod test_lesson_count;
+#[cfg(test)]
 mod test_mint_hardening;
 #[cfg(test)]
 mod test_minter_role;

--- a/onchain-academy/tests/rust/src/test_lesson_count.rs
+++ b/onchain-academy/tests/rust/src/test_lesson_count.rs
@@ -1,0 +1,120 @@
+//! Tests for the increase-only `lesson_count` mutation (#314).
+//!
+//! `update_course` gains `UpdateCourseParams.new_lesson_count: Option<u8>` so a
+//! teacher who appends lessons to an already-deployed course can raise the
+//! on-chain `course.lesson_count`; without it a newly-added lesson's index is
+//! `>= course.lesson_count` and `complete_lesson` reverts with
+//! `LessonOutOfBounds`.
+//!
+//! Invariant: the count is INCREASE-ONLY. Raising it succeeds, an equal value is
+//! a no-op that is accepted, and any value below the current count is rejected
+//! with the new `LessonCountDecrease` error (shrinking would strand already-set
+//! completion flags and shift bitmap indices). No account resize is needed — the
+//! enrollment bitmap is `[u64; 4]` = 256 bits and `lesson_count` is a `u8`
+//! (max 255), so the `Course` layout is unchanged.
+//!
+//! These mirror the handler guard directly (matching the rest of this test
+//! crate, which validates handler logic without a runtime) and round-trip the
+//! wire format so the generated IDL arg is pinned.
+
+use anchor_lang::{AnchorDeserialize, AnchorSerialize};
+use onchain_academy::errors::AcademyError;
+use onchain_academy::instructions::UpdateCourseParams;
+
+/// Mirror of the increase-only branch in the handler:
+/// `if let Some(n) = params.new_lesson_count { require!(n >= course.lesson_count, LessonCountDecrease); course.lesson_count = n }`.
+/// Returns the resulting lesson_count, or the error code for a rejected shrink.
+fn apply_lesson_count_update(current: u8, new_lesson_count: Option<u8>) -> Result<u8, u32> {
+    match new_lesson_count {
+        Some(n) if n < current => Err(6000 + AcademyError::LessonCountDecrease as u32),
+        Some(n) => Ok(n),
+        None => Ok(current),
+    }
+}
+
+#[test]
+fn lesson_count_can_be_increased() {
+    // A teacher appends lessons: 5 -> 8 lands, matching the new bitmap positions.
+    assert_eq!(apply_lesson_count_update(5, Some(8)), Ok(8));
+    // Growth all the way to the u8 ceiling still fits the [u64; 4] bitmap.
+    assert_eq!(apply_lesson_count_update(1, Some(255)), Ok(255));
+}
+
+#[test]
+fn lesson_count_equal_is_an_accepted_noop() {
+    // Re-syncing with an unchanged count is not an error — it simply re-sets the
+    // same value (idempotent), so a redundant admin re-sync never reverts.
+    assert_eq!(apply_lesson_count_update(10, Some(10)), Ok(10));
+}
+
+#[test]
+fn lesson_count_decrease_is_rejected() {
+    // Any value below the current count is rejected with LessonCountDecrease:
+    // shrinking would strand completion flags for the removed tail lessons and
+    // shift indices for the survivors.
+    let err = apply_lesson_count_update(10, Some(9))
+        .expect_err("shrinking lesson_count must be rejected");
+    assert_eq!(err, 6000 + AcademyError::LessonCountDecrease as u32);
+
+    // Dropping to zero is likewise rejected.
+    assert_eq!(
+        apply_lesson_count_update(10, Some(0)),
+        Err(6000 + AcademyError::LessonCountDecrease as u32)
+    );
+}
+
+#[test]
+fn lesson_count_none_leaves_it_unchanged() {
+    // Omitting the field (the common re-sync case where the count is unchanged)
+    // leaves lesson_count as-is.
+    assert_eq!(apply_lesson_count_update(7, None), Ok(7));
+}
+
+/// `UpdateCourseParams` now carries `new_lesson_count: Option<u8>` appended after
+/// `new_collection`. Round-trip the meaningful shapes so the wire format (and
+/// thus the generated IDL arg) is pinned — including a grow-only call and the
+/// all-None (nothing-to-do) shape.
+#[test]
+fn update_course_params_new_lesson_count_serialization_roundtrip() {
+    // Grow lesson_count only.
+    let grow = UpdateCourseParams {
+        new_content_tx_id: None,
+        new_is_active: None,
+        new_xp_per_lesson: None,
+        new_creator_reward_xp: None,
+        new_min_completions_for_reward: None,
+        new_collection: None,
+        new_lesson_count: Some(12),
+    };
+    let mut buf = Vec::new();
+    grow.serialize(&mut buf).unwrap();
+    let decoded = UpdateCourseParams::deserialize(&mut buf.as_slice()).unwrap();
+    assert_eq!(decoded.new_lesson_count, Some(12));
+    assert_eq!(decoded.new_xp_per_lesson, None);
+    assert_eq!(decoded.new_collection, None);
+
+    // All-None: nothing to change (the field is a strict addition, so the empty
+    // update still round-trips).
+    let noop = UpdateCourseParams {
+        new_content_tx_id: None,
+        new_is_active: None,
+        new_xp_per_lesson: None,
+        new_creator_reward_xp: None,
+        new_min_completions_for_reward: None,
+        new_collection: None,
+        new_lesson_count: None,
+    };
+    let mut buf = Vec::new();
+    noop.serialize(&mut buf).unwrap();
+    let decoded = UpdateCourseParams::deserialize(&mut buf.as_slice()).unwrap();
+    assert_eq!(decoded.new_lesson_count, None);
+}
+
+/// The new variant is APPENDED at the end of `AcademyError`, so every prior
+/// discriminant keeps its number (the live devnet program must not renumber).
+/// Pin the tail: XpAmountExceedsMax stays 6033, LessonCountDecrease is 6034.
+#[test]
+fn lesson_count_decrease_is_appended_without_shifting_prior_codes() {
+    assert_eq!(6000 + AcademyError::XpAmountExceedsMax as u32, 6033);
+    assert_eq!(6000 + AcademyError::LessonCountDecrease as u32, 6034);
+}


### PR DESCRIPTION
Closes #314

## The bug
When a teacher adds lessons to a course a learner has **already completed** (credential issued), the learner cannot complete the new lessons: `POST /api/lessons/complete` returned **500**.

**Root cause:** `Course.lesson_count` (`u8`) was set once at `create_course` and was immutable — `UpdateCourseParams` had no field to change it. A newly-added lesson's derived index is `>= course.lesson_count`, so `complete_lesson` reverts (`require!(lesson_index < course.lesson_count, LessonOutOfBounds)`), `onChainCompleteLesson` throws, and the route catch-all returned a generic 500.

**Not a migration:** the enrollment bitmap is `[u64; 4]` = 256 bits and `lesson_count` is a `u8` (max 255), so growing the count needs no account resize/backfill. The `Course` struct + `Course::SIZE` (224) are **unchanged** — only an existing field becomes mutable via a new instruction param.

## The fix (3 parts)

### 1. On-chain — `update_course.rs` + `errors.rs`
- Added `new_lesson_count: Option<u8>` to `UpdateCourseParams`, handled with the same `Option` pattern as the other fields.
- **Increase-only:** `require!(new >= course.lesson_count, LessonCountDecrease)`. Raising the count is applied; an equal value is an accepted no-op; a lower value is rejected (shrinking would strand completed-lesson flags and shift bitmap indices).
- New error variant `LessonCountDecrease` **appended at the end** of `errors.rs` → code **6034**; every prior discriminant keeps its number (`XpAmountExceedsMax` stays 6033), matching the live devnet program.
- IDL regenerated via `anchor build` and copied to `apps/web/src/lib/solana/idl/superteam_academy.json` (purely additive: the new `new_lesson_count` arg + the new error; program address unchanged).

### 2. Admin sync route — `apps/web/src/app/api/admin/courses/sync/route.ts`
- When the Sanity course's `lessonCount > onChainCourse.lesson_count`, the `update_course` call now includes `newLessonCount` so a re-sync raises the on-chain count. Only sent when strictly higher (the program rejects decreases). Wired through `admin-signer.ts` `updateCoursePda` / `UpdateCourseOnChainParams` (camelCase `newLessonCount`, mapped to the IDL param).
- `lib/admin/sync-diff.ts`: `diffCourse` now marks a lesson-count **increase** as `updateable` (so the admin Sync button proceeds instead of showing a blocking immutable-mismatch); a **decrease** stays an immutable mismatch. Doc comment updated to match.

### 3. `/api/lessons/complete` — defense-in-depth pre-check
- Before the on-chain `complete_lesson`, the derived `lessonIndex` is checked against the on-chain `course.lesson_count` (raw-IDL read → snake_case `lesson_count`). If out of bounds it returns a clear **409** ("This course was recently extended and is pending an admin re-sync — try again shortly.") instead of a 500. Real error even before the re-sync lands.

## Scope
- **In scope:** new-lesson completion now works and awards per-lesson XP via the **existing** `complete_lesson` mint. XP logic untouched.
- **Out of scope (deliberate deferral):** re-opening `finalize_course` / re-issuing / upgrading the already-issued credential. `finalize_course` ran once; the learner keeps their credential and simply earns XP for the new lessons. Suggested follow-up issue: *"Optionally re-issue/upgrade a course credential after a teacher extends an already-finalized course."*
- **Re-finalize safety:** verified `/api/lessons/complete` does **not** auto-finalize — it calls only `onChainCompleteLesson` (program `complete_lesson`, which never finalizes). Completing newly-added lessons on an already-finalized course is safe; no guard needed.

## Verification (actual results)
| Check | Result |
|-------|--------|
| `cargo test` (Rust unit, `tests/rust`) | ✅ **128 passed, 0 failed** (6 new in `test_lesson_count.rs`) |
| `anchor build` | ✅ exit 0; IDL contains `new_lesson_count` (option u8) + `LessonCountDecrease` (6034) |
| `cargo fmt --check` (program + tests) | ✅ clean |
| `cargo clippy -- -W clippy::all` (program) | ✅ clean (0 warnings) |
| `cargo clippy` (test crate) | ✅ 0 warnings in new file (8 pre-existing warnings in `test_completion.rs`/`test_utils.rs`, untouched) |
| `pnpm typecheck` (`apps/web`) | ✅ pass (tsc --noEmit, zero `any`) |
| `anchor test` (TS integration) | ⚠️ **not run** — requires the gitignored provider wallet `wallets/signer.json`, absent in this environment. Covered by the Rust unit tests (increase-only invariant + wire-format round-trip + append-only error codes). |

### New Rust tests (`onchain-academy/tests/rust/src/test_lesson_count.rs`)
- `lesson_count_can_be_increased` — raising the count updates it (incl. up to the `u8` ceiling).
- `lesson_count_equal_is_an_accepted_noop` — equal value accepted (idempotent re-sync).
- `lesson_count_decrease_is_rejected` — value `< lesson_count` → `LessonCountDecrease`.
- `lesson_count_none_leaves_it_unchanged` — `None` leaves it as-is.
- `update_course_params_new_lesson_count_serialization_roundtrip` — pins the IDL wire format.
- `lesson_count_decrease_is_appended_without_shifting_prior_codes` — `XpAmountExceedsMax`=6033, `LessonCountDecrease`=6034.

## Deploy note
No deploy in this PR. Applying the fix on devnet/mainnet requires a **program redeploy** (new instruction param) — a separate human-gated step.