### PR TITLE
fix(csp): allow YouTube/Vimeo embeds in frame-src for lesson videos

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -57,8 +57,10 @@ const cspDirectives = [
     "https://*.posthog.com https://*.sentry.io https://*.ingest.sentry.io",
   ].join(" "),
 
-  // Frames: Sanity Studio is a same-origin embed; Google OAuth may use frames.
-  "frame-src 'self' https://accounts.google.com",
+  // Frames: Sanity Studio is a same-origin embed; Google OAuth may use frames;
+  // lesson videos embed the YouTube and Vimeo players. Keep in sync with the
+  // per-request CSP in src/lib/csp.ts.
+  "frame-src 'self' https://accounts.google.com https://www.youtube.com https://player.vimeo.com",
 
   // Workers: code sandbox + Monaco spawn workers from blob: URLs; Monaco also
   // loads its language workers (ts/json/css/html) directly from the jsdelivr CDN.

--- a/apps/web/src/lib/csp.ts
+++ b/apps/web/src/lib/csp.ts
@@ -131,8 +131,11 @@ export function buildCsp(nonce: string): string {
       "https://*.posthog.com https://*.sentry.io https://*.ingest.sentry.io",
     ].join(" "),
 
-    // Frames: Sanity Studio is a same-origin embed; Google OAuth may use frames.
-    "frame-src 'self' https://accounts.google.com",
+    // Frames: Sanity Studio is a same-origin embed; Google OAuth may use frames;
+    // lesson videos embed the YouTube and Vimeo players (see getEmbedUrl in the
+    // lesson client). Without these origins the iframe is blocked ("This content
+    // is blocked").
+    "frame-src 'self' https://accounts.google.com https://www.youtube.com https://player.vimeo.com",
 
     // Workers: code sandbox + Monaco spawn workers from blob: URLs; Monaco also
     // loads its language workers (ts/json/css/html) directly from jsdelivr.


### PR DESCRIPTION
## Bug
Lesson videos showed **"This content is blocked. Contact the site owner to fix the issue."** instead of playing.

## Root cause
The lesson embeds YouTube (`https://www.youtube.com/embed/…`) and Vimeo (`https://player.vimeo.com/video/…`) players in an `<iframe>`, but the CSP `frame-src` only allowed `'self' https://accounts.google.com` — so the browser blocked the iframe.

## Fix
Add the two embed player origins to `frame-src` in both places the CSP is defined:
- `apps/web/src/lib/csp.ts` (authoritative per-request CSP)
- `apps/web/next.config.mjs` (static fallback)

`frame-src 'self' https://accounts.google.com https://www.youtube.com https://player.vimeo.com`

Kept minimal — only the two player origins the lesson embeds actually use (`getEmbedUrl` normalizes `youtu.be`→`www.youtube.com/embed` and `vimeo.com`→`player.vimeo.com`).

## Verification
- Origins match `getEmbedUrl` output exactly; `tsc` + eslint clean.

Closes #324
