### PR TITLE
fix(admin): reflect deactivated courses in admin table + dashboard

### DIFF
--- a/apps/web/src/app/[locale]/(platform)/dashboard/page.tsx
+++ b/apps/web/src/app/[locale]/(platform)/dashboard/page.tsx
@@ -323,19 +323,25 @@ function useDashboardData(
         // Build a lookup map: course _id -> Sanity data
         const courseMap = new Map(courseSummaries.map((c) => [c._id, c]));
 
-        const currentCourses: CurrentCourse[] = enrolledIds.map((id) => {
-          const sanity = courseMap.get(id);
-          return {
-            courseId: id,
-            title: sanity?.title ?? id,
-            slug: sanity?.slug ?? id,
-            completedLessons: completedPerCourse.get(id) ?? 0,
-            totalLessons: sanity?.totalLessons ?? 0,
-            difficulty: sanity?.difficulty ?? "beginner",
-            learningPath: sanity?.learningPath ?? null,
-            thumbnail: sanity?.thumbnail ?? null,
-          };
-        });
+        // Only surface enrolled courses that still resolve from Sanity. A
+        // deactivated (or unpublished) course is filtered out by getCoursesByIds
+        // (activeGate), so without this its "Continue learning" card would still
+        // render from the Supabase enrollment row with a raw-id title.
+        const currentCourses: CurrentCourse[] = enrolledIds
+          .filter((id) => courseMap.has(id))
+          .map((id) => {
+            const sanity = courseMap.get(id);
+            return {
+              courseId: id,
+              title: sanity?.title ?? id,
+              slug: sanity?.slug ?? id,
+              completedLessons: completedPerCourse.get(id) ?? 0,
+              totalLessons: sanity?.totalLessons ?? 0,
+              difficulty: sanity?.difficulty ?? "beginner",
+              learningPath: sanity?.learningPath ?? null,
+              thumbnail: sanity?.thumbnail ?? null,
+            };
+          });
 
         // Build multi-source activity feed. Each source uses a different timestamp
         // column name; normalise all to `time` before merging and sorting.

--- a/apps/web/src/app/[locale]/admin/admin-client.tsx
+++ b/apps/web/src/app/[locale]/admin/admin-client.tsx
@@ -33,6 +33,9 @@ interface CourseStatus {
     | "missing_fields";
   coursePda: string | null;
   differences: DiffEntry[];
+  // Authoritative on-chain is_active. Absent for not-yet-deployed/draft courses
+  // (treated as active). false → deactivated (hidden from the public catalog).
+  isActive?: boolean;
 }
 
 interface AchievementStatus {

--- a/apps/web/src/app/api/admin/status/route.ts
+++ b/apps/web/src/app/api/admin/status/route.ts
@@ -18,6 +18,7 @@ import {
   findAchievementTypePDA,
   getProgramId,
 } from "@/lib/solana/pda";
+import { fetchCourse } from "@/lib/solana/academy-reads";
 import {
   verifyAuthorityMatchesConfig,
   isAdminSignerReady,
@@ -105,6 +106,23 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
       const sanityStatus = course.onChainStatus?.status ?? "synced";
       const status = knownPda === pdaAddress ? sanityStatus : "out_of_sync";
 
+      // Authoritative on-chain is_active (the Sanity mirror can lag if a
+      // deactivate write-back failed), so the admin table reflects the real
+      // deactivated state and offers Reactivate. Default true if undecodable.
+      let isActive = true;
+      try {
+        const decoded = (await fetchCourse(
+          course._id,
+          connection,
+          getProgramId()
+        )) as { is_active?: boolean } | null;
+        if (decoded && typeof decoded.is_active === "boolean") {
+          isActive = decoded.is_active;
+        }
+      } catch {
+        // Stale/undecodable account — leave isActive at its default.
+      }
+
       return {
         sanityId: course._id,
         slug: course.slug,
@@ -116,6 +134,7 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
         onChainStatus: status,
         coursePda: pdaAddress,
         differences: [],
+        isActive,
       };
     })
   );

--- a/apps/web/src/app/api/admin/status/route.ts
+++ b/apps/web/src/app/api/admin/status/route.ts
@@ -18,7 +18,7 @@ import {
   findAchievementTypePDA,
   getProgramId,
 } from "@/lib/solana/pda";
-import { fetchCourse } from "@/lib/solana/academy-reads";
+import { decodeCourse } from "@/lib/solana/academy-reads";
 import {
   verifyAuthorityMatchesConfig,
   isAdminSignerReady,
@@ -108,15 +108,14 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
 
       // Authoritative on-chain is_active (the Sanity mirror can lag if a
       // deactivate write-back failed), so the admin table reflects the real
-      // deactivated state and offers Reactivate. Default true if undecodable.
+      // deactivated state and offers Reactivate. Decoded from the accountInfo
+      // already fetched above — no extra RPC. Default true if undecodable.
       let isActive = true;
       try {
-        const decoded = (await fetchCourse(
-          course._id,
-          connection,
-          getProgramId()
-        )) as { is_active?: boolean } | null;
-        if (decoded && typeof decoded.is_active === "boolean") {
+        const decoded = decodeCourse(accountInfo.data) as {
+          is_active?: boolean;
+        };
+        if (typeof decoded.is_active === "boolean") {
           isActive = decoded.is_active;
         }
       } catch {

--- a/apps/web/src/components/admin/course-sync-table.tsx
+++ b/apps/web/src/components/admin/course-sync-table.tsx
@@ -28,6 +28,7 @@ interface CourseStatus {
     | "missing_fields";
   coursePda: string | null;
   differences: DiffEntry[];
+  isActive?: boolean;
 }
 
 interface CourseSyncTableProps {
@@ -80,6 +81,28 @@ export function CourseSyncTable({ courses, onRefresh }: CourseSyncTableProps) {
       if (!res.ok) {
         const data = (await res.json()) as { error?: string };
         setError(data.error ?? "Deactivation failed");
+      } else {
+        onRefresh();
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed");
+    } finally {
+      setSyncing(null);
+    }
+  }
+
+  async function handleReactivate(courseId: string) {
+    setSyncing(courseId);
+    setError(null);
+    try {
+      const res = await fetch("/api/admin/courses/reactivate", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ courseId }),
+      });
+      if (!res.ok) {
+        const data = (await res.json()) as { error?: string };
+        setError(data.error ?? "Reactivation failed");
       } else {
         onRefresh();
       }
@@ -214,7 +237,15 @@ export function CourseSyncTable({ courses, onRefresh }: CourseSyncTableProps) {
                   {course.sanityXpPerLesson ?? "—"}
                 </td>
                 <td className="py-3 pr-4">
-                  <StatusBadge status={course.onChainStatus} />
+                  <div className="flex flex-wrap items-center gap-1.5">
+                    <StatusBadge status={course.onChainStatus} />
+                    {course.onChainStatus === "synced" &&
+                      course.isActive === false && (
+                        <span className="inline-flex items-center rounded border border-danger bg-danger-light px-2 py-0.5 text-xs font-medium text-danger">
+                          Deactivated
+                        </span>
+                      )}
+                  </div>
                 </td>
                 <td className="py-3">
                   {canSync && (
@@ -226,15 +257,24 @@ export function CourseSyncTable({ courses, onRefresh }: CourseSyncTableProps) {
                       {isSyncing ? "..." : actionLabel}
                     </button>
                   )}
-                  {course.onChainStatus === "synced" && (
-                    <button
-                      onClick={() => void handleDeactivate(course.sanityId)}
-                      disabled={isSyncing}
-                      className="ml-2 rounded-md border border-border px-3 py-1 font-display text-xs font-bold text-text-2 shadow-push-sm transition-all hover:border-danger hover:bg-danger-light hover:text-danger active:translate-y-[2px] active:shadow-push-active disabled:opacity-50"
-                    >
-                      {isSyncing ? "..." : "Deactivate"}
-                    </button>
-                  )}
+                  {course.onChainStatus === "synced" &&
+                    (course.isActive === false ? (
+                      <button
+                        onClick={() => void handleReactivate(course.sanityId)}
+                        disabled={isSyncing}
+                        className="ml-2 rounded-md border border-success px-3 py-1 font-display text-xs font-bold text-success shadow-push-sm transition-all hover:bg-success-light active:translate-y-[2px] active:shadow-push-active disabled:opacity-50"
+                      >
+                        {isSyncing ? "..." : "Reactivate"}
+                      </button>
+                    ) : (
+                      <button
+                        onClick={() => void handleDeactivate(course.sanityId)}
+                        disabled={isSyncing}
+                        className="ml-2 rounded-md border border-border px-3 py-1 font-display text-xs font-bold text-text-2 shadow-push-sm transition-all hover:border-danger hover:bg-danger-light hover:text-danger active:translate-y-[2px] active:shadow-push-active disabled:opacity-50"
+                      >
+                        {isSyncing ? "..." : "Deactivate"}
+                      </button>
+                    ))}
                 </td>
               </tr>
             );

--- a/apps/web/src/lib/solana/academy-reads.ts
+++ b/apps/web/src/lib/solana/academy-reads.ts
@@ -58,6 +58,16 @@ export async function fetchCourse(
   return coder.accounts.decode("Course", accountInfo.data);
 }
 
+/**
+ * Decode a Course account from raw account data (BorshCoder → snake_case fields).
+ * Lets a caller that has already fetched the account (e.g. via getAccountInfo)
+ * read Course fields without a second RPC round-trip. Throws on a stale/
+ * size-mismatched layout — callers that just want a field should try/catch.
+ */
+export function decodeCourse(data: Buffer) {
+  return coder.accounts.decode("Course", data);
+}
+
 export async function fetchAchievementType(
   achievementId: string,
   connection: Connection,


### PR DESCRIPTION
## Follow-up to #321 / #325
After deactivating a course, two surfaces still showed it. Root causes were separate from the catalog gate:

### 1) Admin table showed it as active
`/api/admin/status` and the admin table keyed only on `onChainStatus.status` (`"synced"`) — never on `is_active`. So a deactivated course still rendered as Synced with a Deactivate button, and there was no way to reactivate from the UI.

- `/api/admin/status` now returns the **authoritative on-chain `is_active`** per synced course (decoded via `fetchCourse`; defaults to active if the account is undecodable — same graceful handling as the sync route).
- The admin table shows a **"Deactivated"** badge and swaps Deactivate → **Reactivate** (calling the existing `/api/admin/courses/reactivate`) when `isActive === false`.

### 2) Dashboard still showed it
The "Continue learning" cards are built from Supabase `enrolledIds` and rendered with fallback data (`sanity?.title ?? id`). `getCoursesByIds`'s `activeGate` (from #325) only stripped the Sanity metadata — the card still rendered from the enrollment row. Now `currentCourses` is filtered to ids that still resolve from Sanity, so a deactivated (or unpublished) course drops off.

## Notes
- Admin reads on-chain `is_active` directly, so it's correct even if the Sanity mirror write lagged/failed.
- Consistent with the "deactivated = hidden everywhere" intent: lesson pages are already gated (`getLessonBySlug`), so an enrolled learner couldn't open lessons of a deactivated course anyway.

## Verification
- `tsc --noEmit` ✓, eslint ✓

Refs #321
