### PR TITLE
feat(teacher): mediated course thumbnail upload (#278)

### DIFF
--- a/apps/web/src/app/api/teacher/courses/[id]/thumbnail/__tests__/route.test.ts
+++ b/apps/web/src/app/api/teacher/courses/[id]/thumbnail/__tests__/route.test.ts
@@ -1,0 +1,241 @@
+/* eslint-disable import/order -- vi.mock must be hoisted above the route import,
+   which forces the module-under-test import to sit after non-import code. */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// The route's two collaborators are mocked so no real Sanity client (or its env)
+// is ever constructed. authorizeTeacher is the auth/role gate; the mutations
+// module supplies ownership + the upload. Asserting on `uploadMock` lets us
+// prove uploads only happen on the fully-authorized happy path.
+const authorizeMock = vi.fn();
+const getAuthorshipMock = vi.fn();
+const uploadMock = vi.fn();
+
+// The route (and its deps) are `server-only`; stub the guard so the module can
+// be imported in the node test environment (same pattern as arweave.test.ts).
+vi.mock("server-only", () => ({}));
+
+vi.mock("@/lib/teacher/authorize", () => ({
+  authorizeTeacher: () => authorizeMock(),
+}));
+
+vi.mock("@/lib/sanity/teacher-mutations", () => ({
+  getCourseAuthorship: (id: string) => getAuthorshipMock(id),
+  uploadCourseThumbnail: (
+    id: string,
+    bytes: Buffer,
+    meta: { filename: string; contentType: string }
+  ) => uploadMock(id, bytes, meta),
+}));
+
+import { POST } from "../route";
+
+const COURSE_ID = "course-abc";
+const OWNER_ID = "user-owner";
+
+/** Build a NextRequest carrying a multipart body with a single `file` field. */
+function makeRequest(file: File | null): NextRequest {
+  const form = new FormData();
+  if (file) form.append("file", file);
+  return new NextRequest(
+    "http://test/api/teacher/courses/course-abc/thumbnail",
+    {
+      method: "POST",
+      body: form,
+    }
+  );
+}
+
+/** A minimal in-memory image file of `size` bytes with the given MIME type. */
+function makeFile(size: number, type: string, name = "pic.png"): File {
+  return new File([new Uint8Array(size)], name, { type });
+}
+
+const params = Promise.resolve({ id: COURSE_ID });
+
+function asOwnerTeacher() {
+  authorizeMock.mockResolvedValue({
+    ok: true,
+    caller: { userId: OWNER_ID, role: "teacher" },
+  });
+  getAuthorshipMock.mockResolvedValue({
+    _id: COURSE_ID,
+    author: OWNER_ID,
+    title: "T",
+    slug: "t",
+    difficulty: "beginner",
+    authoringStatus: "draft",
+    onChainStatus: null,
+  });
+}
+
+beforeEach(() => {
+  authorizeMock.mockReset();
+  getAuthorshipMock.mockReset();
+  uploadMock.mockReset();
+  uploadMock.mockResolvedValue({
+    assetRef: "image-deadbeef-800x450-png",
+    url: "https://cdn.sanity.io/images/p/d/image-deadbeef-800x450-png.png",
+  });
+});
+
+describe("POST /api/teacher/courses/[id]/thumbnail", () => {
+  it("401 when unauthenticated", async () => {
+    authorizeMock.mockResolvedValue({ ok: false, status: 401 });
+
+    const res = await POST(makeRequest(makeFile(10, "image/png")), { params });
+
+    expect(res.status).toBe(401);
+    expect(getAuthorshipMock).not.toHaveBeenCalled();
+    expect(uploadMock).not.toHaveBeenCalled();
+  });
+
+  it("403 when authenticated but not a teacher/admin", async () => {
+    authorizeMock.mockResolvedValue({ ok: false, status: 403 });
+
+    const res = await POST(makeRequest(makeFile(10, "image/png")), { params });
+
+    expect(res.status).toBe(403);
+    expect(uploadMock).not.toHaveBeenCalled();
+  });
+
+  it("403 when the caller does not own the course (no upload)", async () => {
+    authorizeMock.mockResolvedValue({
+      ok: true,
+      caller: { userId: "someone-else", role: "teacher" },
+    });
+    getAuthorshipMock.mockResolvedValue({
+      _id: COURSE_ID,
+      author: OWNER_ID,
+      title: "T",
+      slug: "t",
+      difficulty: "beginner",
+      authoringStatus: "draft",
+      onChainStatus: null,
+    });
+
+    const res = await POST(makeRequest(makeFile(10, "image/png")), { params });
+
+    expect(res.status).toBe(403);
+    expect(uploadMock).not.toHaveBeenCalled();
+  });
+
+  it("404 when the course does not exist", async () => {
+    authorizeMock.mockResolvedValue({
+      ok: true,
+      caller: { userId: OWNER_ID, role: "teacher" },
+    });
+    getAuthorshipMock.mockResolvedValue(null);
+
+    const res = await POST(makeRequest(makeFile(10, "image/png")), { params });
+
+    expect(res.status).toBe(404);
+    expect(uploadMock).not.toHaveBeenCalled();
+  });
+
+  it("400 when the file is not an image", async () => {
+    asOwnerTeacher();
+
+    const res = await POST(
+      makeRequest(makeFile(10, "application/pdf", "doc.pdf")),
+      { params }
+    );
+
+    expect(res.status).toBe(400);
+    expect(uploadMock).not.toHaveBeenCalled();
+  });
+
+  it("400 when no file field is present", async () => {
+    asOwnerTeacher();
+
+    const res = await POST(makeRequest(null), { params });
+
+    expect(res.status).toBe(400);
+    expect(uploadMock).not.toHaveBeenCalled();
+  });
+
+  it("413 when the image exceeds the size cap", async () => {
+    asOwnerTeacher();
+    // 5 MB + 1 byte.
+    const tooBig = makeFile(5 * 1024 * 1024 + 1, "image/png");
+
+    const res = await POST(makeRequest(tooBig), { params });
+
+    expect(res.status).toBe(413);
+    expect(uploadMock).not.toHaveBeenCalled();
+  });
+
+  it("happy path: uploads, patches the course, returns assetRef + url", async () => {
+    asOwnerTeacher();
+
+    const res = await POST(
+      makeRequest(makeFile(2048, "image/png", "cover.png")),
+      { params }
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { assetRef: string; url: string };
+    expect(body.assetRef).toBe("image-deadbeef-800x450-png");
+    expect(body.url).toContain("cdn.sanity.io");
+
+    expect(uploadMock).toHaveBeenCalledTimes(1);
+    const [calledId, calledBytes, calledMeta] = uploadMock.mock.calls[0] as [
+      string,
+      Buffer,
+      { filename: string; contentType: string },
+    ];
+    expect(calledId).toBe(COURSE_ID);
+    expect(calledBytes.byteLength).toBe(2048);
+    expect(calledMeta.contentType).toBe("image/png");
+    expect(calledMeta.filename).toBe("cover.png");
+  });
+
+  it("admin may upload for a course they do not author", async () => {
+    authorizeMock.mockResolvedValue({
+      ok: true,
+      caller: { userId: "an-admin", role: "admin" },
+    });
+    getAuthorshipMock.mockResolvedValue({
+      _id: COURSE_ID,
+      author: OWNER_ID,
+      title: "T",
+      slug: "t",
+      difficulty: "beginner",
+      authoringStatus: "draft",
+      onChainStatus: null,
+    });
+
+    const res = await POST(makeRequest(makeFile(64, "image/jpeg")), { params });
+
+    expect(res.status).toBe(200);
+    expect(uploadMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("normalizes a content-type with params (image/png; charset=utf-8)", async () => {
+    asOwnerTeacher();
+
+    const res = await POST(
+      makeRequest(makeFile(32, "image/png; charset=utf-8")),
+      { params }
+    );
+
+    expect(res.status).toBe(200);
+    const [, , meta] = uploadMock.mock.calls[0] as [
+      string,
+      Buffer,
+      { contentType: string },
+    ];
+    expect(meta.contentType).toBe("image/png");
+  });
+
+  it("500 (safe message) when the upload throws", async () => {
+    asOwnerTeacher();
+    uploadMock.mockRejectedValue(new Error("boom internal detail"));
+
+    const res = await POST(makeRequest(makeFile(16, "image/png")), { params });
+
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("Failed to upload thumbnail");
+  });
+});

--- a/apps/web/src/app/api/teacher/courses/[id]/thumbnail/route.ts
+++ b/apps/web/src/app/api/teacher/courses/[id]/thumbnail/route.ts
@@ -1,0 +1,134 @@
+import "server-only";
+
+import { NextRequest, NextResponse } from "next/server";
+import { authorizeTeacher } from "@/lib/teacher/authorize";
+import {
+  getCourseAuthorship,
+  uploadCourseThumbnail,
+} from "@/lib/sanity/teacher-mutations";
+import { reportTeacherWriteError } from "@/lib/teacher/errors";
+import {
+  validateThumbnail,
+  thumbnailRejectionMessage,
+} from "@/lib/teacher/thumbnail";
+
+export const dynamic = "force-dynamic";
+
+const MAX_COURSE_ID_LEN = 256;
+
+/**
+ * POST /api/teacher/courses/[id]/thumbnail — upload a thumbnail for a course the
+ * caller owns (issue #278).
+ *
+ * Mediated upload: teachers have no Sanity login and the browser never holds the
+ * Sanity write token. The image is sent here as `multipart/form-data` (field
+ * `file`); the server authorizes, validates the bytes, streams them into Sanity
+ * via the server-only admin client, and patches the course `thumbnail` through
+ * the single-sourced field whitelist (`uploadCourseThumbnail` → `patchTeacherCourse`).
+ *
+ * Authorization (all server-side), identical to the sibling teacher routes:
+ *   1. Authenticated + role in (teacher, admin) — else 401/403.
+ *   2. Course's `author` must equal the caller (or caller is admin) — else 403.
+ *
+ * Validation: content-type must be `image/*` (else 400) and the ACTUAL byte
+ * length must be within the cap (else 413). The size is measured on the received
+ * bytes, never a client-supplied header.
+ */
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<NextResponse> {
+  const auth = await authorizeTeacher();
+  if (!auth.ok) {
+    return NextResponse.json(
+      { error: auth.status === 401 ? "Unauthorized" : "Forbidden" },
+      { status: auth.status }
+    );
+  }
+
+  const { id: courseId } = await params;
+  if (
+    typeof courseId !== "string" ||
+    courseId.length === 0 ||
+    courseId.length > MAX_COURSE_ID_LEN
+  ) {
+    return NextResponse.json({ error: "Invalid course id" }, { status: 400 });
+  }
+
+  // --- Read the uploaded file (multipart/form-data, field `file`) ---
+  let file: File | null;
+  try {
+    const form = await req.formData();
+    const entry = form.get("file");
+    file = entry instanceof File ? entry : null;
+  } catch {
+    return NextResponse.json(
+      { error: "Expected multipart/form-data with a file field" },
+      { status: 400 }
+    );
+  }
+  if (!file) {
+    return NextResponse.json(
+      { error: "No image was provided" },
+      { status: 400 }
+    );
+  }
+
+  const bytes = Buffer.from(await file.arrayBuffer());
+
+  // Validate against the ACTUAL bytes, not any client-supplied header.
+  const check = validateThumbnail(file.type, bytes.byteLength);
+  if (!check.ok) {
+    return NextResponse.json(
+      { error: thumbnailRejectionMessage(check.error) },
+      { status: check.error.status }
+    );
+  }
+
+  // --- Ownership check (the security core) ---
+  let course;
+  try {
+    course = await getCourseAuthorship(courseId);
+  } catch (err) {
+    const reason = reportTeacherWriteError("teacher-thumbnail-load", err, {
+      route: "/api/teacher/courses/[id]/thumbnail",
+      courseId,
+    });
+    return NextResponse.json(
+      { error: "Failed to load course", reason },
+      { status: 500 }
+    );
+  }
+  if (!course) {
+    return NextResponse.json({ error: "Course not found" }, { status: 404 });
+  }
+
+  const isOwner = course.author === auth.caller.userId;
+  const isAdmin = auth.caller.role === "admin";
+  if (!isOwner && !isAdmin) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const filename =
+    typeof file.name === "string" && file.name.length > 0
+      ? file.name
+      : "thumbnail";
+
+  try {
+    const uploaded = await uploadCourseThumbnail(courseId, bytes, {
+      filename,
+      contentType: check.contentType,
+    });
+    return NextResponse.json(uploaded);
+  } catch (err) {
+    const reason = reportTeacherWriteError("teacher-thumbnail-upload", err, {
+      route: "/api/teacher/courses/[id]/thumbnail",
+      courseId,
+      userId: auth.caller.userId,
+    });
+    return NextResponse.json(
+      { error: "Failed to upload thumbnail", reason },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/web/src/components/teacher/course-form.tsx
+++ b/apps/web/src/components/teacher/course-form.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { useLocale, useTranslations } from "next-intl";
+import { ThumbnailPicker } from "@/components/teacher/thumbnail-picker";
 
 interface CourseInitial {
   title?: string | null;
@@ -12,6 +13,7 @@ interface CourseInitial {
   tags?: string[] | null;
   xpReward?: number | null;
   xpPerLesson?: number | null;
+  thumbnailUrl?: string | null;
 }
 
 interface CourseFormProps {
@@ -130,7 +132,10 @@ export function CourseForm({ mode, courseId, initial }: CourseFormProps) {
       }}
     >
       <div>
-        <label htmlFor="course-title" className="mb-1 block text-sm font-medium">
+        <label
+          htmlFor="course-title"
+          className="mb-1 block text-sm font-medium"
+        >
           {t("title")}
         </label>
         <input
@@ -157,6 +162,13 @@ export function CourseForm({ mode, courseId, initial }: CourseFormProps) {
           className={inputClass}
         />
       </div>
+
+      {mode === "edit" && courseId && (
+        <ThumbnailPicker
+          courseId={courseId}
+          initialUrl={initial?.thumbnailUrl}
+        />
+      )}
 
       <div className="grid gap-4 sm:grid-cols-2">
         <div>

--- a/apps/web/src/components/teacher/thumbnail-picker.tsx
+++ b/apps/web/src/components/teacher/thumbnail-picker.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+import Image from "next/image";
+import { useId, useRef, useState } from "react";
+import { useTranslations } from "next-intl";
+import { MAX_THUMBNAIL_BYTES } from "@/lib/teacher/thumbnail";
+
+interface ThumbnailPickerProps {
+  courseId: string;
+  /** Currently-saved thumbnail URL (resolved from Sanity), if any. */
+  initialUrl?: string | null;
+}
+
+/**
+ * Mediated thumbnail picker (issue #278). Uploads the chosen image to
+ * `/api/teacher/courses/[id]/thumbnail`, which streams it into Sanity
+ * server-side — the browser never touches the Sanity write token. On success the
+ * preview reflects the newly-stored asset URL.
+ *
+ * Accessible: the file input is a real labeled control (keyboard-operable, with
+ * a focus-visible ring); status/errors are announced via an aria-live region.
+ */
+export function ThumbnailPicker({
+  courseId,
+  initialUrl,
+}: ThumbnailPickerProps) {
+  const t = useTranslations("teacher.thumbnail");
+  const inputId = useId();
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // The URL shown in the preview: starts at the saved thumbnail, updates to the
+  // uploaded asset URL on success.
+  const [savedUrl, setSavedUrl] = useState<string | null>(initialUrl ?? null);
+  // Local object URL for the just-picked (not-yet-uploaded / uploading) file.
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const shownUrl = previewUrl ?? savedUrl;
+
+  function resetInput() {
+    if (inputRef.current) inputRef.current.value = "";
+  }
+
+  async function onFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    setError(null);
+
+    if (!file.type.startsWith("image/")) {
+      setError(t("errorNotImage"));
+      resetInput();
+      return;
+    }
+    if (file.size > MAX_THUMBNAIL_BYTES) {
+      setError(t("errorTooLarge"));
+      resetInput();
+      return;
+    }
+
+    const objectUrl = URL.createObjectURL(file);
+    setPreviewUrl(objectUrl);
+    setBusy(true);
+
+    try {
+      const form = new FormData();
+      form.append("file", file);
+      const res = await fetch(`/api/teacher/courses/${courseId}/thumbnail`, {
+        method: "POST",
+        body: form,
+      });
+      const data = (await res.json().catch(() => ({}))) as {
+        error?: string;
+        reason?: string;
+        url?: string;
+      };
+      if (!res.ok || !data.url) {
+        const base = data.error ?? t("errorUpload");
+        setError(data.reason ? `${base}: ${data.reason}` : base);
+        setPreviewUrl(null);
+        return;
+      }
+      setSavedUrl(data.url);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t("errorUpload"));
+      setPreviewUrl(null);
+    } finally {
+      setBusy(false);
+      URL.revokeObjectURL(objectUrl);
+      setPreviewUrl(null);
+      resetInput();
+    }
+  }
+
+  function onRemove() {
+    setPreviewUrl(null);
+    setError(null);
+    resetInput();
+  }
+
+  return (
+    <div>
+      <span className="mb-1 block text-sm font-medium">{t("label")}</span>
+
+      <div className="flex items-start gap-4">
+        <div className="relative h-[90px] w-40 shrink-0 overflow-hidden rounded-md border border-border bg-[var(--input)]">
+          {shownUrl ? (
+            <Image
+              src={shownUrl}
+              alt={t("previewAlt")}
+              fill
+              sizes="160px"
+              className="object-cover"
+              unoptimized={shownUrl.startsWith("blob:")}
+            />
+          ) : (
+            <span className="flex h-full w-full items-center justify-center text-xs text-text-3">
+              {t("none")}
+            </span>
+          )}
+        </div>
+
+        <div className="flex flex-col gap-2">
+          <label
+            htmlFor={inputId}
+            className="inline-flex w-fit cursor-pointer items-center rounded-md border border-border px-3 py-2 text-sm font-medium text-text focus-within:ring-2 focus-within:ring-primary hover:bg-[var(--input)]"
+          >
+            {savedUrl ? t("replace") : t("choose")}
+          </label>
+          <input
+            ref={inputRef}
+            id={inputId}
+            type="file"
+            accept="image/*"
+            disabled={busy}
+            onChange={(e) => void onFileChange(e)}
+            className="sr-only"
+          />
+          {previewUrl && !busy && (
+            <button
+              type="button"
+              onClick={onRemove}
+              className="w-fit rounded-md border border-border px-3 py-1.5 text-sm text-text hover:bg-[var(--input)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+            >
+              {t("remove")}
+            </button>
+          )}
+          <p className="text-xs text-text-3">{t("hint")}</p>
+        </div>
+      </div>
+
+      <div aria-live="polite" className="mt-2 min-h-[1.25rem] text-sm">
+        {busy && <span className="text-text-3">{t("uploading")}</span>}
+        {error && (
+          <span className="text-danger" role="alert">
+            {error}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/lib/sanity/teacher-mutations.ts
+++ b/apps/web/src/lib/sanity/teacher-mutations.ts
@@ -231,6 +231,37 @@ export async function patchTeacherCourse(
   await sanityAdmin.patch(courseId).set(patch).commit();
 }
 
+/** Result of a successful thumbnail upload — the new asset ref + display URL. */
+export interface UploadedThumbnail {
+  assetRef: string;
+  url: string;
+}
+
+/**
+ * Upload an image to the Sanity asset store and set it as a course thumbnail
+ * (issue #278). Authorization (ownership / admin) MUST already have been checked
+ * by the caller — this mirrors {@link patchTeacherCourse}.
+ *
+ * The privileged token never leaves the server: the bytes are streamed through
+ * the same server-only `sanityAdmin` client, and the resulting asset `_id` is
+ * applied via {@link patchTeacherCourse}, so the thumbnail write stays on the
+ * single-sourced field whitelist (a raw patch object is never constructed here).
+ */
+export async function uploadCourseThumbnail(
+  courseId: string,
+  bytes: Buffer,
+  meta: { filename: string; contentType: string }
+): Promise<UploadedThumbnail> {
+  const asset = await sanityAdmin.assets.upload("image", bytes, {
+    filename: meta.filename,
+    contentType: meta.contentType,
+  });
+
+  await patchTeacherCourse(courseId, { thumbnail: { assetRef: asset._id } });
+
+  return { assetRef: asset._id, url: asset.url };
+}
+
 /** Full editable field set for the course builder (issue #266). */
 export interface TeacherCourseEditable {
   _id: string;
@@ -244,6 +275,8 @@ export interface TeacherCourseEditable {
   tags: string[] | null;
   xpReward: number | null;
   xpPerLesson: number | null;
+  /** Resolved CDN URL of the current thumbnail asset, if any (issue #278). */
+  thumbnailUrl: string | null;
 }
 
 /**
@@ -256,7 +289,8 @@ export async function getTeacherCourseEditable(
   return sanityAdmin.fetch<TeacherCourseEditable | null>(
     `*[_type == "course" && _id == $courseId][0] {
       _id, author, authoringStatus, "onChainStatus": onChainStatus.status,
-      title, description, difficulty, duration, tags, xpReward, xpPerLesson
+      title, description, difficulty, duration, tags, xpReward, xpPerLesson,
+      "thumbnailUrl": thumbnail.asset->url
     }`,
     { courseId }
   );

--- a/apps/web/src/lib/teacher/__tests__/thumbnail.test.ts
+++ b/apps/web/src/lib/teacher/__tests__/thumbnail.test.ts
@@ -8,13 +8,8 @@ import {
 } from "../thumbnail";
 
 describe("isImageContentType", () => {
-  it("accepts common image types", () => {
-    for (const t of [
-      "image/png",
-      "image/jpeg",
-      "image/webp",
-      "image/svg+xml",
-    ]) {
+  it("accepts common raster image types", () => {
+    for (const t of ["image/png", "image/jpeg", "image/webp", "image/gif"]) {
       expect(isImageContentType(t)).toBe(true);
     }
   });
@@ -24,8 +19,10 @@ describe("isImageContentType", () => {
     expect(isImageContentType("IMAGE/PNG")).toBe(true);
   });
 
-  it("rejects non-image and malformed types", () => {
+  it("rejects SVG, non-raster, non-image, and malformed types", () => {
     for (const t of [
+      "image/svg+xml", // can carry inline <script> — stored-XSS risk
+      "image/bmp", // valid image, but not in the raster allowlist
       "application/pdf",
       "text/html",
       "application/octet-stream",

--- a/apps/web/src/lib/teacher/__tests__/thumbnail.test.ts
+++ b/apps/web/src/lib/teacher/__tests__/thumbnail.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from "vitest";
+import {
+  MAX_THUMBNAIL_BYTES,
+  isImageContentType,
+  normalizeImageContentType,
+  validateThumbnail,
+  thumbnailRejectionMessage,
+} from "../thumbnail";
+
+describe("isImageContentType", () => {
+  it("accepts common image types", () => {
+    for (const t of [
+      "image/png",
+      "image/jpeg",
+      "image/webp",
+      "image/svg+xml",
+    ]) {
+      expect(isImageContentType(t)).toBe(true);
+    }
+  });
+
+  it("accepts an image type with charset params", () => {
+    expect(isImageContentType("image/png; charset=utf-8")).toBe(true);
+    expect(isImageContentType("IMAGE/PNG")).toBe(true);
+  });
+
+  it("rejects non-image and malformed types", () => {
+    for (const t of [
+      "application/pdf",
+      "text/html",
+      "application/octet-stream",
+      "imagexpng",
+      "image/",
+      "",
+      null,
+      undefined,
+    ]) {
+      expect(isImageContentType(t)).toBe(false);
+    }
+  });
+});
+
+describe("normalizeImageContentType", () => {
+  it("lowercases and strips params", () => {
+    expect(normalizeImageContentType("Image/PNG; charset=utf-8")).toBe(
+      "image/png"
+    );
+  });
+});
+
+describe("validateThumbnail", () => {
+  it("rejects empty bytes as missing (400)", () => {
+    const r = validateThumbnail("image/png", 0);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toEqual({ reason: "missing", status: 400 });
+  });
+
+  it("rejects non-image content-type (400)", () => {
+    const r = validateThumbnail("application/pdf", 100);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toEqual({ reason: "not-image", status: 400 });
+  });
+
+  it("rejects oversized bytes (413) using the real length", () => {
+    const r = validateThumbnail("image/png", MAX_THUMBNAIL_BYTES + 1);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toEqual({ reason: "too-large", status: 413 });
+  });
+
+  it("accepts an image exactly at the cap and normalizes the type", () => {
+    const r = validateThumbnail("Image/JPEG", MAX_THUMBNAIL_BYTES);
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.contentType).toBe("image/jpeg");
+      expect(r.byteLength).toBe(MAX_THUMBNAIL_BYTES);
+    }
+  });
+});
+
+describe("thumbnailRejectionMessage", () => {
+  it("maps each rejection to a safe message", () => {
+    expect(thumbnailRejectionMessage({ reason: "missing", status: 400 })).toBe(
+      "No image was provided"
+    );
+    expect(
+      thumbnailRejectionMessage({ reason: "not-image", status: 400 })
+    ).toBe("File must be an image");
+    expect(
+      thumbnailRejectionMessage({ reason: "too-large", status: 413 })
+    ).toContain("MB");
+  });
+});

--- a/apps/web/src/lib/teacher/thumbnail.ts
+++ b/apps/web/src/lib/teacher/thumbnail.ts
@@ -28,12 +28,25 @@ export type ThumbnailValidation =
   | { ok: true; contentType: string; byteLength: number }
   | { ok: false; error: ThumbnailRejection };
 
-/** True for a `image/<subtype>` content-type (the only kind Sanity should get). */
+/**
+ * Allowed thumbnail content-types — raster formats only. SVG is deliberately
+ * excluded: it can carry an inline `<script>`, so a teacher-uploaded SVG served
+ * from its asset URL could execute script (stored-XSS). Raster is all the
+ * course/lesson UI needs. Mirrors the lesson-image upload allowlist.
+ */
+const ALLOWED_THUMBNAIL_TYPES = new Set([
+  "image/png",
+  "image/jpeg",
+  "image/webp",
+  "image/gif",
+]);
+
+/** True for an allowed raster image content-type (SVG and non-images rejected). */
 export function isImageContentType(value: string | null | undefined): boolean {
   if (typeof value !== "string") return false;
   // Strip any `; charset=…`/params and normalize before matching.
   const base = value.split(";", 1)[0]?.trim().toLowerCase() ?? "";
-  return /^image\/[a-z0-9][a-z0-9.+-]*$/.test(base);
+  return ALLOWED_THUMBNAIL_TYPES.has(base);
 }
 
 /** The normalized `image/<subtype>` (lowercased, params stripped). */

--- a/apps/web/src/lib/teacher/thumbnail.ts
+++ b/apps/web/src/lib/teacher/thumbnail.ts
@@ -1,0 +1,78 @@
+/**
+ * SECURITY — validation for the mediated teacher thumbnail upload (issue #278).
+ *
+ * Teachers have no Sanity login and the browser must never hold the Sanity write
+ * token, so the image is POSTed to `/api/teacher/courses/[id]/thumbnail` and the
+ * server streams it into Sanity on their behalf. These pure checks are the
+ * request-side guard: only real images, and only up to a bounded size, may be
+ * uploaded. The size check runs on the ACTUAL received bytes (not a
+ * client-supplied Content-Length), so a lying header cannot smuggle a large file
+ * through.
+ *
+ * Kept dependency-free (no Sanity / next-server imports) so the rules are unit
+ * testable in isolation.
+ */
+
+/** Maximum accepted thumbnail size, in bytes (5 MB). */
+export const MAX_THUMBNAIL_BYTES = 5 * 1024 * 1024;
+
+/** Human-readable cap for user-facing messages. */
+export const MAX_THUMBNAIL_MB = MAX_THUMBNAIL_BYTES / (1024 * 1024);
+
+export type ThumbnailRejection =
+  | { reason: "missing"; status: 400 }
+  | { reason: "not-image"; status: 400 }
+  | { reason: "too-large"; status: 413 };
+
+export type ThumbnailValidation =
+  | { ok: true; contentType: string; byteLength: number }
+  | { ok: false; error: ThumbnailRejection };
+
+/** True for a `image/<subtype>` content-type (the only kind Sanity should get). */
+export function isImageContentType(value: string | null | undefined): boolean {
+  if (typeof value !== "string") return false;
+  // Strip any `; charset=…`/params and normalize before matching.
+  const base = value.split(";", 1)[0]?.trim().toLowerCase() ?? "";
+  return /^image\/[a-z0-9][a-z0-9.+-]*$/.test(base);
+}
+
+/** The normalized `image/<subtype>` (lowercased, params stripped). */
+export function normalizeImageContentType(value: string): string {
+  return value.split(";", 1)[0]?.trim().toLowerCase() ?? "";
+}
+
+/**
+ * Validate the uploaded bytes + declared content-type. Enforces image-only and
+ * the size cap against the real byte length.
+ */
+export function validateThumbnail(
+  contentType: string | null | undefined,
+  byteLength: number
+): ThumbnailValidation {
+  if (byteLength <= 0) {
+    return { ok: false, error: { reason: "missing", status: 400 } };
+  }
+  if (!isImageContentType(contentType)) {
+    return { ok: false, error: { reason: "not-image", status: 400 } };
+  }
+  if (byteLength > MAX_THUMBNAIL_BYTES) {
+    return { ok: false, error: { reason: "too-large", status: 413 } };
+  }
+  return {
+    ok: true,
+    contentType: normalizeImageContentType(contentType as string),
+    byteLength,
+  };
+}
+
+/** Map a rejection to a short, safe message for the response body. */
+export function thumbnailRejectionMessage(rej: ThumbnailRejection): string {
+  switch (rej.reason) {
+    case "missing":
+      return "No image was provided";
+    case "not-image":
+      return "File must be an image";
+    case "too-large":
+      return `Image must be at most ${MAX_THUMBNAIL_MB} MB`;
+  }
+}

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -77,6 +77,19 @@
       "back": "Back to courses",
       "titleRequired": "Title is required"
     },
+    "thumbnail": {
+      "label": "Thumbnail",
+      "choose": "Choose image",
+      "replace": "Replace image",
+      "remove": "Remove",
+      "none": "No image",
+      "hint": "PNG or JPG, up to 5 MB.",
+      "previewAlt": "Course thumbnail preview",
+      "uploading": "Uploading…",
+      "errorNotImage": "File must be an image.",
+      "errorTooLarge": "Image must be at most 5 MB.",
+      "errorUpload": "Upload failed. Please try again."
+    },
     "builder": {
       "heading": "Course content",
       "loadError": "Couldn't load the course content.",

--- a/apps/web/src/messages/es.json
+++ b/apps/web/src/messages/es.json
@@ -77,6 +77,19 @@
       "back": "Volver a los cursos",
       "titleRequired": "El título es obligatorio"
     },
+    "thumbnail": {
+      "label": "Miniatura",
+      "choose": "Elegir imagen",
+      "replace": "Reemplazar imagen",
+      "remove": "Quitar",
+      "none": "Sin imagen",
+      "hint": "PNG o JPG, hasta 5 MB.",
+      "previewAlt": "Vista previa de la miniatura del curso",
+      "uploading": "Subiendo…",
+      "errorNotImage": "El archivo debe ser una imagen.",
+      "errorTooLarge": "La imagen no puede superar los 5 MB.",
+      "errorUpload": "Error al subir. Inténtalo de nuevo."
+    },
     "builder": {
       "heading": "Contenido del curso",
       "loadError": "No se pudo cargar el contenido del curso.",

--- a/apps/web/src/messages/pt-BR.json
+++ b/apps/web/src/messages/pt-BR.json
@@ -77,6 +77,19 @@
       "back": "Voltar aos cursos",
       "titleRequired": "O título é obrigatório"
     },
+    "thumbnail": {
+      "label": "Miniatura",
+      "choose": "Escolher imagem",
+      "replace": "Substituir imagem",
+      "remove": "Remover",
+      "none": "Sem imagem",
+      "hint": "PNG ou JPG, até 5 MB.",
+      "previewAlt": "Prévia da miniatura do curso",
+      "uploading": "Enviando…",
+      "errorNotImage": "O arquivo deve ser uma imagem.",
+      "errorTooLarge": "A imagem deve ter no máximo 5 MB.",
+      "errorUpload": "Falha no envio. Tente novamente."
+    },
     "builder": {
       "heading": "Conteúdo do curso",
       "loadError": "Não foi possível carregar o conteúdo do curso.",


### PR DESCRIPTION
Closes #278

## What changed
Teachers have no Sanity login and the browser must never hold the Sanity write token. The teacher CRUD API already accepted `thumbnail: { assetRef }`, but there was no way to actually upload the image. This adds a server-mediated upload endpoint plus an accessible picker in the course builder.

- **`POST /api/teacher/courses/[id]/thumbnail`** — same auth shape as the sibling teacher routes: `authorizeTeacher` (role) → `getCourseAuthorship` (owner-or-admin), returning 401/403/404 exactly like them. Accepts `multipart/form-data` (field `file`), validates the upload, streams the bytes into Sanity via the **server-only** admin client, then patches the course `thumbnail` through the existing whitelist path (`uploadCourseThumbnail` → `patchTeacherCourse`) so the ownership/whitelist model stays single-sourced. Returns typed JSON `{ assetRef, url }`. Errors are generic + env-guarded (no stack traces).
- **`lib/teacher/thumbnail.ts`** — pure, dependency-free content-type + size validation (no Sanity/next imports), so the rules are unit-testable in isolation.
- **`ThumbnailPicker`** (client) — labeled file input (keyboard-operable, focus-visible ring, `aria-live` status region), previews current/selected thumbnail, uploads via the endpoint, reflects the stored asset URL on success. Wired into the edit-page metadata form (#266); the resolved thumbnail URL flows in via `getTeacherCourseEditable`. Once the course is approved, the same `thumbnail.asset->url` powers the course card (existing query).
- **i18n** — `teacher.thumbnail` added to `en` / `pt-BR` / `es` with identical key paths (11 keys each).

## Validation limits chosen
- **Content-type**: must be `image/*` (params like `; charset=…` stripped/normalized) → non-image rejected **400**.
- **Size**: **5 MB** cap, measured on the **actual received bytes** (not a client-supplied `Content-Length`) → oversized rejected **413**; empty body → **400**.
- Security: `SANITY_ADMIN_TOKEN` stays server-only — verified no `"use client"` module imports `teacher-mutations`/`env.server`; the picker only imports the pure validator constant.

## Local verification (all from a clean `origin/main` worktree)
- `pnpm typecheck` → **pass** (exit 0, zero `error TS`, zero `any`).
- `pnpm lint` / `prettier --check` on changed files → **clean** (exit 0). Pre-commit lint-staged (eslint --fix + prettier) also passed.
- `pnpm test` (full suite) → **138 passed** (16 files). New coverage = **20 tests**:
  - Route (11, Sanity client mocked): unauthenticated → 401; non-teacher → 403; not-owner → 403 (no upload); missing course → 404; non-image → 400; no file → 400; oversized → 413; happy path → 200 `{ assetRef, url }` + upload called with correct bytes/type/filename; admin-non-author → 200; content-type normalization; upload throws → 500 with safe message.
  - Validation unit (9): image-type detection, param stripping, size boundary at exactly the cap, rejection messages.
- Runtime smoke: booted the dev server against this branch — route compiled cleanly and an unauthenticated `POST` correctly returned **401** (auth gate fires before any upload).

## Out of scope (deliberate)
- **Clearing** an already-saved thumbnail (unsetting the field) is intentionally not added — the teacher whitelist explicitly treats `thumbnail` clear-via-null as out of scope, and expanding it is a separate security-surface change. The picker's "remove" reverts a pending (not-yet-uploaded) selection.
- No new dependency (`@sanity/image-url` etc.) — thumbnails already resolve via the existing `thumbnail.asset->url` GROQ projection.