### PR TITLE
fix(onchain): sync update_course IDL to deployed program (fixes reactivate/deactivate error 102)

### DIFF
--- a/apps/web/src/lib/solana/admin-signer.ts
+++ b/apps/web/src/lib/solana/admin-signer.ts
@@ -76,6 +76,10 @@ interface UpdateCourseOnChainParams {
   newCreatorRewardXp: number | null;
   newMinCompletionsForReward: number | null;
   newCollection: PublicKey | null;
+  // 7th field — the deployed program's UpdateCourseParams includes it, so it
+  // MUST be serialized (even as null) or every update_course call fails to
+  // deserialize (AnchorError 102). Grows lesson_count when a course is extended.
+  newLessonCount: number | null;
 }
 
 interface CreateAchievementTypeOnChainParams {
@@ -133,6 +137,9 @@ export interface UpdateCourseAdminParams {
   newMinCompletionsForReward?: number;
   /** Base58 address of the Metaplex Core credential collection to set/backfill. */
   newCollection?: string;
+  /** New on-chain lesson_count (increase-only) — grows the completion bitmap
+   * bound when a course is extended after deploy. See #314. */
+  newLessonCount?: number;
 }
 
 export interface CreateAchievementAdminParams {
@@ -323,6 +330,7 @@ export async function updateCoursePda(
         params.newCollection != null
           ? new PublicKey(params.newCollection)
           : null,
+      newLessonCount: params.newLessonCount ?? null,
     };
 
     const methods = _program.methods as unknown as AdminMethods;

--- a/apps/web/src/lib/solana/idl/superteam_academy.json
+++ b/apps/web/src/lib/solana/idl/superteam_academy.json
@@ -1464,6 +1464,11 @@
       "code": 6033,
       "name": "XpAmountExceedsMax",
       "msg": "XP amount exceeds the per-mint ceiling"
+    },
+    {
+      "code": 6034,
+      "name": "LessonCountCannotDecrease",
+      "msg": "Lesson count can only increase"
     }
   ],
   "types": [

--- a/apps/web/src/lib/solana/idl/superteam_academy.json
+++ b/apps/web/src/lib/solana/idl/superteam_academy.json
@@ -9,16 +9,7 @@
   "instructions": [
     {
       "name": "award_achievement",
-      "discriminator": [
-        75,
-        47,
-        156,
-        253,
-        124,
-        231,
-        84,
-        12
-      ],
+      "discriminator": [75, 47, 156, 253, 124, 231, 84, 12],
       "accounts": [
         {
           "name": "config",
@@ -26,14 +17,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  99,
-                  111,
-                  110,
-                  102,
-                  105,
-                  103
-                ]
+                "value": [99, 111, 110, 102, 105, 103]
               }
             ]
           }
@@ -45,19 +29,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  97,
-                  99,
-                  104,
-                  105,
-                  101,
-                  118,
-                  101,
-                  109,
-                  101,
-                  110,
-                  116
-                ]
+                "value": [97, 99, 104, 105, 101, 118, 101, 109, 101, 110, 116]
               },
               {
                 "kind": "account",
@@ -75,25 +47,8 @@
               {
                 "kind": "const",
                 "value": [
-                  97,
-                  99,
-                  104,
-                  105,
-                  101,
-                  118,
-                  101,
-                  109,
-                  101,
-                  110,
-                  116,
-                  95,
-                  114,
-                  101,
-                  99,
-                  101,
-                  105,
-                  112,
-                  116
+                  97, 99, 104, 105, 101, 118, 101, 109, 101, 110, 116, 95, 114,
+                  101, 99, 101, 105, 112, 116
                 ]
               },
               {
@@ -115,14 +70,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  109,
-                  105,
-                  110,
-                  116,
-                  101,
-                  114
-                ]
+                "value": [109, 105, 110, 116, 101, 114]
               },
               {
                 "kind": "account",
@@ -133,9 +81,7 @@
         },
         {
           "name": "asset",
-          "docs": [
-            "New achievement NFT keypair"
-          ],
+          "docs": ["New achievement NFT keypair"],
           "writable": true,
           "signer": true
         },
@@ -194,16 +140,7 @@
     },
     {
       "name": "close_course",
-      "discriminator": [
-        157,
-        252,
-        239,
-        166,
-        213,
-        174,
-        160,
-        34
-      ],
+      "discriminator": [157, 252, 239, 166, 213, 174, 160, 34],
       "accounts": [
         {
           "name": "config",
@@ -211,14 +148,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  99,
-                  111,
-                  110,
-                  102,
-                  105,
-                  103
-                ]
+                "value": [99, 111, 110, 102, 105, 103]
               }
             ]
           }
@@ -236,14 +166,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  99,
-                  111,
-                  117,
-                  114,
-                  115,
-                  101
-                ]
+                "value": [99, 111, 117, 114, 115, 101]
               },
               {
                 "kind": "arg",
@@ -255,9 +178,7 @@
         {
           "name": "authority",
           "signer": true,
-          "relations": [
-            "config"
-          ]
+          "relations": ["config"]
         }
       ],
       "args": [
@@ -269,16 +190,7 @@
     },
     {
       "name": "close_enrollment",
-      "discriminator": [
-        236,
-        137,
-        133,
-        253,
-        91,
-        138,
-        217,
-        91
-      ],
+      "discriminator": [236, 137, 133, 253, 91, 138, 217, 91],
       "accounts": [
         {
           "name": "course",
@@ -286,14 +198,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  99,
-                  111,
-                  117,
-                  114,
-                  115,
-                  101
-                ]
+                "value": [99, 111, 117, 114, 115, 101]
               },
               {
                 "kind": "account",
@@ -310,18 +215,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  101,
-                  110,
-                  114,
-                  111,
-                  108,
-                  108,
-                  109,
-                  101,
-                  110,
-                  116
-                ]
+                "value": [101, 110, 114, 111, 108, 108, 109, 101, 110, 116]
               },
               {
                 "kind": "account",
@@ -345,16 +239,7 @@
     },
     {
       "name": "complete_lesson",
-      "discriminator": [
-        77,
-        217,
-        53,
-        132,
-        204,
-        150,
-        169,
-        58
-      ],
+      "discriminator": [77, 217, 53, 132, 204, 150, 169, 58],
       "accounts": [
         {
           "name": "config",
@@ -362,14 +247,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  99,
-                  111,
-                  110,
-                  102,
-                  105,
-                  103
-                ]
+                "value": [99, 111, 110, 102, 105, 103]
               }
             ]
           }
@@ -380,14 +258,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  99,
-                  111,
-                  117,
-                  114,
-                  115,
-                  101
-                ]
+                "value": [99, 111, 117, 114, 115, 101]
               },
               {
                 "kind": "account",
@@ -404,18 +275,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  101,
-                  110,
-                  114,
-                  111,
-                  108,
-                  108,
-                  109,
-                  101,
-                  110,
-                  116
-                ]
+                "value": [101, 110, 114, 111, 108, 108, 109, 101, 110, 116]
               },
               {
                 "kind": "account",
@@ -462,16 +322,7 @@
     },
     {
       "name": "create_achievement_type",
-      "discriminator": [
-        231,
-        38,
-        39,
-        228,
-        103,
-        4,
-        229,
-        19
-      ],
+      "discriminator": [231, 38, 39, 228, 103, 4, 229, 19],
       "accounts": [
         {
           "name": "config",
@@ -479,14 +330,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  99,
-                  111,
-                  110,
-                  102,
-                  105,
-                  103
-                ]
+                "value": [99, 111, 110, 102, 105, 103]
               }
             ]
           }
@@ -498,19 +342,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  97,
-                  99,
-                  104,
-                  105,
-                  101,
-                  118,
-                  101,
-                  109,
-                  101,
-                  110,
-                  116
-                ]
+                "value": [97, 99, 104, 105, 101, 118, 101, 109, 101, 110, 116]
               },
               {
                 "kind": "arg",
@@ -521,9 +353,7 @@
         },
         {
           "name": "collection",
-          "docs": [
-            "New Metaplex Core collection keypair"
-          ],
+          "docs": ["New Metaplex Core collection keypair"],
           "writable": true,
           "signer": true
         },
@@ -558,16 +388,7 @@
     },
     {
       "name": "create_course",
-      "discriminator": [
-        120,
-        121,
-        154,
-        164,
-        107,
-        180,
-        167,
-        241
-      ],
+      "discriminator": [120, 121, 154, 164, 107, 180, 167, 241],
       "accounts": [
         {
           "name": "course",
@@ -576,14 +397,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  99,
-                  111,
-                  117,
-                  114,
-                  115,
-                  101
-                ]
+                "value": [99, 111, 117, 114, 115, 101]
               },
               {
                 "kind": "arg",
@@ -598,14 +412,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  99,
-                  111,
-                  110,
-                  102,
-                  105,
-                  103
-                ]
+                "value": [99, 111, 110, 102, 105, 103]
               }
             ]
           }
@@ -614,9 +421,7 @@
           "name": "authority",
           "writable": true,
           "signer": true,
-          "relations": [
-            "config"
-          ]
+          "relations": ["config"]
         },
         {
           "name": "system_program",
@@ -636,16 +441,7 @@
     },
     {
       "name": "deactivate_achievement_type",
-      "discriminator": [
-        185,
-        21,
-        222,
-        243,
-        192,
-        118,
-        71,
-        191
-      ],
+      "discriminator": [185, 21, 222, 243, 192, 118, 71, 191],
       "accounts": [
         {
           "name": "config",
@@ -653,14 +449,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  99,
-                  111,
-                  110,
-                  102,
-                  105,
-                  103
-                ]
+                "value": [99, 111, 110, 102, 105, 103]
               }
             ]
           }
@@ -672,19 +461,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  97,
-                  99,
-                  104,
-                  105,
-                  101,
-                  118,
-                  101,
-                  109,
-                  101,
-                  110,
-                  116
-                ]
+                "value": [97, 99, 104, 105, 101, 118, 101, 109, 101, 110, 116]
               },
               {
                 "kind": "account",
@@ -703,16 +480,7 @@
     },
     {
       "name": "enroll",
-      "discriminator": [
-        58,
-        12,
-        36,
-        3,
-        142,
-        28,
-        1,
-        43
-      ],
+      "discriminator": [58, 12, 36, 3, 142, 28, 1, 43],
       "accounts": [
         {
           "name": "course",
@@ -721,14 +489,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  99,
-                  111,
-                  117,
-                  114,
-                  115,
-                  101
-                ]
+                "value": [99, 111, 117, 114, 115, 101]
               },
               {
                 "kind": "arg",
@@ -744,18 +505,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  101,
-                  110,
-                  114,
-                  111,
-                  108,
-                  108,
-                  109,
-                  101,
-                  110,
-                  116
-                ]
+                "value": [101, 110, 114, 111, 108, 108, 109, 101, 110, 116]
               },
               {
                 "kind": "arg",
@@ -787,16 +537,7 @@
     },
     {
       "name": "finalize_course",
-      "discriminator": [
-        68,
-        189,
-        122,
-        239,
-        39,
-        121,
-        16,
-        218
-      ],
+      "discriminator": [68, 189, 122, 239, 39, 121, 16, 218],
       "accounts": [
         {
           "name": "config",
@@ -804,14 +545,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  99,
-                  111,
-                  110,
-                  102,
-                  105,
-                  103
-                ]
+                "value": [99, 111, 110, 102, 105, 103]
               }
             ]
           }
@@ -823,14 +557,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  99,
-                  111,
-                  117,
-                  114,
-                  115,
-                  101
-                ]
+                "value": [99, 111, 117, 114, 115, 101]
               },
               {
                 "kind": "account",
@@ -847,18 +574,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  101,
-                  110,
-                  114,
-                  111,
-                  108,
-                  108,
-                  109,
-                  101,
-                  110,
-                  116
-                ]
+                "value": [101, 110, 114, 111, 108, 108, 109, 101, 110, 116]
               },
               {
                 "kind": "account",
@@ -911,16 +627,7 @@
     },
     {
       "name": "initialize",
-      "discriminator": [
-        175,
-        175,
-        109,
-        31,
-        13,
-        152,
-        155,
-        237
-      ],
+      "discriminator": [175, 175, 109, 31, 13, 152, 155, 237],
       "accounts": [
         {
           "name": "config",
@@ -929,14 +636,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  99,
-                  111,
-                  110,
-                  102,
-                  105,
-                  103
-                ]
+                "value": [99, 111, 110, 102, 105, 103]
               }
             ]
           }
@@ -965,14 +665,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  109,
-                  105,
-                  110,
-                  116,
-                  101,
-                  114
-                ]
+                "value": [109, 105, 110, 116, 101, 114]
               },
               {
                 "kind": "account",
@@ -994,16 +687,7 @@
     },
     {
       "name": "issue_credential",
-      "discriminator": [
-        255,
-        193,
-        171,
-        224,
-        68,
-        171,
-        194,
-        87
-      ],
+      "discriminator": [255, 193, 171, 224, 68, 171, 194, 87],
       "accounts": [
         {
           "name": "config",
@@ -1011,14 +695,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  99,
-                  111,
-                  110,
-                  102,
-                  105,
-                  103
-                ]
+                "value": [99, 111, 110, 102, 105, 103]
               }
             ]
           }
@@ -1029,14 +706,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  99,
-                  111,
-                  117,
-                  114,
-                  115,
-                  101
-                ]
+                "value": [99, 111, 117, 114, 115, 101]
               },
               {
                 "kind": "account",
@@ -1053,18 +723,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  101,
-                  110,
-                  114,
-                  111,
-                  108,
-                  108,
-                  109,
-                  101,
-                  110,
-                  116
-                ]
+                "value": [101, 110, 114, 111, 108, 108, 109, 101, 110, 116]
               },
               {
                 "kind": "account",
@@ -1132,16 +791,7 @@
     },
     {
       "name": "register_minter",
-      "discriminator": [
-        58,
-        224,
-        74,
-        142,
-        170,
-        95,
-        116,
-        191
-      ],
+      "discriminator": [58, 224, 74, 142, 170, 95, 116, 191],
       "accounts": [
         {
           "name": "config",
@@ -1149,14 +799,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  99,
-                  111,
-                  110,
-                  102,
-                  105,
-                  103
-                ]
+                "value": [99, 111, 110, 102, 105, 103]
               }
             ]
           }
@@ -1168,14 +811,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  109,
-                  105,
-                  110,
-                  116,
-                  101,
-                  114
-                ]
+                "value": [109, 105, 110, 116, 101, 114]
               },
               {
                 "kind": "arg",
@@ -1212,16 +848,7 @@
     },
     {
       "name": "revoke_minter",
-      "discriminator": [
-        33,
-        91,
-        131,
-        167,
-        62,
-        37,
-        38,
-        105
-      ],
+      "discriminator": [33, 91, 131, 167, 62, 37, 38, 105],
       "accounts": [
         {
           "name": "config",
@@ -1229,14 +856,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  99,
-                  111,
-                  110,
-                  102,
-                  105,
-                  103
-                ]
+                "value": [99, 111, 110, 102, 105, 103]
               }
             ]
           }
@@ -1248,14 +868,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  109,
-                  105,
-                  110,
-                  116,
-                  101,
-                  114
-                ]
+                "value": [109, 105, 110, 116, 101, 114]
               },
               {
                 "kind": "account",
@@ -1275,16 +888,7 @@
     },
     {
       "name": "reward_xp",
-      "discriminator": [
-        144,
-        187,
-        117,
-        238,
-        89,
-        118,
-        224,
-        145
-      ],
+      "discriminator": [144, 187, 117, 238, 89, 118, 224, 145],
       "accounts": [
         {
           "name": "config",
@@ -1292,14 +896,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  99,
-                  111,
-                  110,
-                  102,
-                  105,
-                  103
-                ]
+                "value": [99, 111, 110, 102, 105, 103]
               }
             ]
           }
@@ -1311,14 +908,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  109,
-                  105,
-                  110,
-                  116,
-                  101,
-                  114
-                ]
+                "value": [109, 105, 110, 116, 101, 114]
               },
               {
                 "kind": "account",
@@ -1329,9 +919,7 @@
         },
         {
           "name": "xp_mint",
-          "docs": [
-            "Token-2022 XP mint"
-          ],
+          "docs": ["Token-2022 XP mint"],
           "writable": true
         },
         {
@@ -1375,16 +963,7 @@
     },
     {
       "name": "update_config",
-      "discriminator": [
-        29,
-        158,
-        252,
-        191,
-        10,
-        83,
-        219,
-        99
-      ],
+      "discriminator": [29, 158, 252, 191, 10, 83, 219, 99],
       "accounts": [
         {
           "name": "config",
@@ -1393,14 +972,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  99,
-                  111,
-                  110,
-                  102,
-                  105,
-                  103
-                ]
+                "value": [99, 111, 110, 102, 105, 103]
               }
             ]
           }
@@ -1408,9 +980,7 @@
         {
           "name": "authority",
           "signer": true,
-          "relations": [
-            "config"
-          ]
+          "relations": ["config"]
         }
       ],
       "args": [
@@ -1426,16 +996,7 @@
     },
     {
       "name": "update_course",
-      "discriminator": [
-        81,
-        217,
-        18,
-        192,
-        129,
-        233,
-        129,
-        231
-      ],
+      "discriminator": [81, 217, 18, 192, 129, 233, 129, 231],
       "accounts": [
         {
           "name": "config",
@@ -1443,14 +1004,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  99,
-                  111,
-                  110,
-                  102,
-                  105,
-                  103
-                ]
+                "value": [99, 111, 110, 102, 105, 103]
               }
             ]
           }
@@ -1462,14 +1016,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  99,
-                  111,
-                  117,
-                  114,
-                  115,
-                  101
-                ]
+                "value": [99, 111, 117, 114, 115, 101]
               },
               {
                 "kind": "account",
@@ -1482,9 +1029,7 @@
         {
           "name": "authority",
           "signer": true,
-          "relations": [
-            "config"
-          ]
+          "relations": ["config"]
         }
       ],
       "args": [
@@ -1500,16 +1045,7 @@
     },
     {
       "name": "update_minter",
-      "discriminator": [
-        164,
-        129,
-        164,
-        88,
-        75,
-        29,
-        91,
-        38
-      ],
+      "discriminator": [164, 129, 164, 88, 75, 29, 91, 38],
       "accounts": [
         {
           "name": "config",
@@ -1517,14 +1053,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  99,
-                  111,
-                  110,
-                  102,
-                  105,
-                  103
-                ]
+                "value": [99, 111, 110, 102, 105, 103]
               }
             ]
           }
@@ -1536,14 +1065,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  109,
-                  105,
-                  110,
-                  116,
-                  101,
-                  114
-                ]
+                "value": [109, 105, 110, 116, 101, 114]
               },
               {
                 "kind": "account",
@@ -1571,16 +1093,7 @@
     },
     {
       "name": "upgrade_credential",
-      "discriminator": [
-        2,
-        121,
-        77,
-        255,
-        103,
-        187,
-        252,
-        169
-      ],
+      "discriminator": [2, 121, 77, 255, 103, 187, 252, 169],
       "accounts": [
         {
           "name": "config",
@@ -1588,14 +1101,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  99,
-                  111,
-                  110,
-                  102,
-                  105,
-                  103
-                ]
+                "value": [99, 111, 110, 102, 105, 103]
               }
             ]
           }
@@ -1606,14 +1112,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  99,
-                  111,
-                  117,
-                  114,
-                  115,
-                  101
-                ]
+                "value": [99, 111, 117, 114, 115, 101]
               },
               {
                 "kind": "account",
@@ -1629,18 +1128,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  101,
-                  110,
-                  114,
-                  111,
-                  108,
-                  108,
-                  109,
-                  101,
-                  110,
-                  116
-                ]
+                "value": [101, 110, 114, 111, 108, 108, 109, 101, 110, 116]
               },
               {
                 "kind": "account",
@@ -1709,317 +1197,101 @@
   "accounts": [
     {
       "name": "AchievementReceipt",
-      "discriminator": [
-        149,
-        5,
-        79,
-        178,
-        116,
-        231,
-        43,
-        248
-      ]
+      "discriminator": [149, 5, 79, 178, 116, 231, 43, 248]
     },
     {
       "name": "AchievementType",
-      "discriminator": [
-        13,
-        187,
-        114,
-        66,
-        217,
-        154,
-        85,
-        137
-      ]
+      "discriminator": [13, 187, 114, 66, 217, 154, 85, 137]
     },
     {
       "name": "Config",
-      "discriminator": [
-        155,
-        12,
-        170,
-        224,
-        30,
-        250,
-        204,
-        130
-      ]
+      "discriminator": [155, 12, 170, 224, 30, 250, 204, 130]
     },
     {
       "name": "Course",
-      "discriminator": [
-        206,
-        6,
-        78,
-        228,
-        163,
-        138,
-        241,
-        106
-      ]
+      "discriminator": [206, 6, 78, 228, 163, 138, 241, 106]
     },
     {
       "name": "Enrollment",
-      "discriminator": [
-        249,
-        210,
-        64,
-        145,
-        197,
-        241,
-        57,
-        51
-      ]
+      "discriminator": [249, 210, 64, 145, 197, 241, 57, 51]
     },
     {
       "name": "MinterRole",
-      "discriminator": [
-        21,
-        246,
-        6,
-        133,
-        142,
-        211,
-        33,
-        193
-      ]
+      "discriminator": [21, 246, 6, 133, 142, 211, 33, 193]
     }
   ],
   "events": [
     {
       "name": "AchievementAwarded",
-      "discriminator": [
-        127,
-        212,
-        93,
-        231,
-        175,
-        0,
-        69,
-        150
-      ]
+      "discriminator": [127, 212, 93, 231, 175, 0, 69, 150]
     },
     {
       "name": "AchievementTypeCreated",
-      "discriminator": [
-        189,
-        36,
-        173,
-        243,
-        25,
-        232,
-        198,
-        153
-      ]
+      "discriminator": [189, 36, 173, 243, 25, 232, 198, 153]
     },
     {
       "name": "AchievementTypeDeactivated",
-      "discriminator": [
-        133,
-        12,
-        218,
-        127,
-        151,
-        28,
-        1,
-        222
-      ]
+      "discriminator": [133, 12, 218, 127, 151, 28, 1, 222]
     },
     {
       "name": "ConfigUpdated",
-      "discriminator": [
-        40,
-        241,
-        230,
-        122,
-        11,
-        19,
-        198,
-        194
-      ]
+      "discriminator": [40, 241, 230, 122, 11, 19, 198, 194]
     },
     {
       "name": "CourseClosed",
-      "discriminator": [
-        35,
-        195,
-        37,
-        254,
-        25,
-        107,
-        100,
-        12
-      ]
+      "discriminator": [35, 195, 37, 254, 25, 107, 100, 12]
     },
     {
       "name": "CourseCreated",
-      "discriminator": [
-        205,
-        144,
-        55,
-        47,
-        150,
-        170,
-        123,
-        214
-      ]
+      "discriminator": [205, 144, 55, 47, 150, 170, 123, 214]
     },
     {
       "name": "CourseFinalized",
-      "discriminator": [
-        18,
-        195,
-        195,
-        25,
-        165,
-        189,
-        194,
-        56
-      ]
+      "discriminator": [18, 195, 195, 25, 165, 189, 194, 56]
     },
     {
       "name": "CourseUpdated",
-      "discriminator": [
-        124,
-        141,
-        110,
-        224,
-        149,
-        124,
-        26,
-        141
-      ]
+      "discriminator": [124, 141, 110, 224, 149, 124, 26, 141]
     },
     {
       "name": "CredentialIssued",
-      "discriminator": [
-        194,
-        216,
-        28,
-        159,
-        89,
-        29,
-        72,
-        177
-      ]
+      "discriminator": [194, 216, 28, 159, 89, 29, 72, 177]
     },
     {
       "name": "CredentialUpgraded",
-      "discriminator": [
-        198,
-        142,
-        252,
-        191,
-        210,
-        200,
-        253,
-        133
-      ]
+      "discriminator": [198, 142, 252, 191, 210, 200, 253, 133]
     },
     {
       "name": "Enrolled",
-      "discriminator": [
-        129,
-        156,
-        102,
-        214,
-        94,
-        196,
-        220,
-        127
-      ]
+      "discriminator": [129, 156, 102, 214, 94, 196, 220, 127]
     },
     {
       "name": "EnrollmentClosed",
-      "discriminator": [
-        197,
-        4,
-        145,
-        238,
-        217,
-        4,
-        175,
-        77
-      ]
+      "discriminator": [197, 4, 145, 238, 217, 4, 175, 77]
     },
     {
       "name": "LessonCompleted",
-      "discriminator": [
-        248,
-        174,
-        148,
-        235,
-        186,
-        49,
-        11,
-        163
-      ]
+      "discriminator": [248, 174, 148, 235, 186, 49, 11, 163]
     },
     {
       "name": "MinterRegistered",
-      "discriminator": [
-        104,
-        203,
-        87,
-        105,
-        23,
-        33,
-        231,
-        1
-      ]
+      "discriminator": [104, 203, 87, 105, 23, 33, 231, 1]
     },
     {
       "name": "MinterRevoked",
-      "discriminator": [
-        138,
-        76,
-        227,
-        247,
-        141,
-        92,
-        77,
-        127
-      ]
+      "discriminator": [138, 76, 227, 247, 141, 92, 77, 127]
     },
     {
       "name": "MinterUpdated",
-      "discriminator": [
-        8,
-        124,
-        66,
-        45,
-        176,
-        53,
-        49,
-        153
-      ]
+      "discriminator": [8, 124, 66, 45, 176, 53, 49, 153]
     },
     {
       "name": "MintingPauseSet",
-      "discriminator": [
-        232,
-        11,
-        219,
-        8,
-        116,
-        65,
-        178,
-        74
-      ]
+      "discriminator": [232, 11, 219, 8, 116, 65, 178, 74]
     },
     {
       "name": "XpRewarded",
-      "discriminator": [
-        140,
-        182,
-        232,
-        144,
-        16,
-        155,
-        237,
-        182
-      ]
+      "discriminator": [140, 182, 232, 144, 16, 155, 237, 182]
     }
   ],
   "errors": [
@@ -2234,9 +1506,7 @@
         "fields": [
           {
             "name": "asset",
-            "docs": [
-              "Metaplex Core NFT address"
-            ],
+            "docs": ["Metaplex Core NFT address"],
             "type": "pubkey"
           },
           {
@@ -2265,16 +1535,12 @@
           },
           {
             "name": "metadata_uri",
-            "docs": [
-              "Default metadata URI for minted NFTs"
-            ],
+            "docs": ["Default metadata URI for minted NFTs"],
             "type": "string"
           },
           {
             "name": "collection",
-            "docs": [
-              "Metaplex Core collection for this achievement"
-            ],
+            "docs": ["Metaplex Core collection for this achievement"],
             "type": "pubkey"
           },
           {
@@ -2283,9 +1549,7 @@
           },
           {
             "name": "max_supply",
-            "docs": [
-              "0 = unlimited supply"
-            ],
+            "docs": ["0 = unlimited supply"],
             "type": "u32"
           },
           {
@@ -2294,9 +1558,7 @@
           },
           {
             "name": "xp_reward",
-            "docs": [
-              "XP awarded alongside the NFT (0 = no XP)"
-            ],
+            "docs": ["XP awarded alongside the NFT (0 = no XP)"],
             "type": "u32"
           },
           {
@@ -2310,10 +1572,7 @@
           {
             "name": "_reserved",
             "type": {
-              "array": [
-                "u8",
-                8
-              ]
+              "array": ["u8", 8]
             }
           },
           {
@@ -2378,23 +1637,17 @@
         "fields": [
           {
             "name": "authority",
-            "docs": [
-              "Platform multisig (Squads)"
-            ],
+            "docs": ["Platform multisig (Squads)"],
             "type": "pubkey"
           },
           {
             "name": "backend_signer",
-            "docs": [
-              "Rotatable backend signer for completions"
-            ],
+            "docs": ["Rotatable backend signer for completions"],
             "type": "pubkey"
           },
           {
             "name": "xp_mint",
-            "docs": [
-              "Token-2022 mint for XP"
-            ],
+            "docs": ["Token-2022 mint for XP"],
             "type": "pubkey"
           },
           {
@@ -2409,21 +1662,14 @@
           },
           {
             "name": "_reserved",
-            "docs": [
-              "Reserved for future use"
-            ],
+            "docs": ["Reserved for future use"],
             "type": {
-              "array": [
-                "u8",
-                7
-              ]
+              "array": ["u8", 7]
             }
           },
           {
             "name": "bump",
-            "docs": [
-              "PDA bump"
-            ],
+            "docs": ["PDA bump"],
             "type": "u8"
           }
         ]
@@ -2464,10 +1710,7 @@
           {
             "name": "content_tx_id",
             "type": {
-              "array": [
-                "u8",
-                32
-              ]
+              "array": ["u8", 32]
             }
           },
           {
@@ -2539,10 +1782,7 @@
           {
             "name": "_reserved",
             "type": {
-              "array": [
-                "u8",
-                8
-              ]
+              "array": ["u8", 8]
             }
           },
           {
@@ -2712,10 +1952,7 @@
           {
             "name": "content_tx_id",
             "type": {
-              "array": [
-                "u8",
-                32
-              ]
+              "array": ["u8", 32]
             }
           },
           {
@@ -2852,23 +2089,17 @@
         "fields": [
           {
             "name": "course",
-            "docs": [
-              "The Course PDA this enrollment belongs to"
-            ],
+            "docs": ["The Course PDA this enrollment belongs to"],
             "type": "pubkey"
           },
           {
             "name": "enrolled_at",
-            "docs": [
-              "When learner enrolled"
-            ],
+            "docs": ["When learner enrolled"],
             "type": "i64"
           },
           {
             "name": "completed_at",
-            "docs": [
-              "When course was completed (None if in progress)"
-            ],
+            "docs": ["When course was completed (None if in progress)"],
             "type": {
               "option": "i64"
             }
@@ -2880,10 +2111,7 @@
               "lesson_count is u8 (max 255), so all valid indices fit within this bitmap."
             ],
             "type": {
-              "array": [
-                "u64",
-                4
-              ]
+              "array": ["u64", 4]
             }
           },
           {
@@ -2911,17 +2139,12 @@
               "and is a migration (realloc + backfill), not an in-place change."
             ],
             "type": {
-              "array": [
-                "u8",
-                4
-              ]
+              "array": ["u8", 4]
             }
           },
           {
             "name": "bump",
-            "docs": [
-              "PDA bump"
-            ],
+            "docs": ["PDA bump"],
             "type": "u8"
           }
         ]
@@ -3038,9 +2261,7 @@
         "fields": [
           {
             "name": "minter",
-            "docs": [
-              "Wallet or program PDA authorized to mint XP"
-            ],
+            "docs": ["Wallet or program PDA authorized to mint XP"],
             "type": "pubkey"
           },
           {
@@ -3052,16 +2273,12 @@
           },
           {
             "name": "max_xp_per_call",
-            "docs": [
-              "Per-call XP cap. 0 = unlimited."
-            ],
+            "docs": ["Per-call XP cap. 0 = unlimited."],
             "type": "u64"
           },
           {
             "name": "total_xp_minted",
-            "docs": [
-              "Lifetime XP minted through this role"
-            ],
+            "docs": ["Lifetime XP minted through this role"],
             "type": "u64"
           },
           {
@@ -3148,9 +2365,7 @@
           },
           {
             "name": "max_total_xp",
-            "docs": [
-              "Cumulative XP ceiling for this role. 0 = unlimited."
-            ],
+            "docs": ["Cumulative XP ceiling for this role. 0 = unlimited."],
             "type": "u64"
           }
         ]
@@ -3202,10 +2417,7 @@
             "name": "new_content_tx_id",
             "type": {
               "option": {
-                "array": [
-                  "u8",
-                  32
-                ]
+                "array": ["u8", 32]
               }
             }
           },
@@ -3241,6 +2453,15 @@
             "type": {
               "option": "pubkey"
             }
+          },
+          {
+            "name": "new_lesson_count",
+            "docs": [
+              "Grow lesson_count when a course is extended after deploy (increase-only)."
+            ],
+            "type": {
+              "option": "u8"
+            }
           }
         ]
       }
@@ -3252,9 +2473,7 @@
         "fields": [
           {
             "name": "max_xp_per_call",
-            "docs": [
-              "New per-call XP cap. 0 = unlimited."
-            ],
+            "docs": ["New per-call XP cap. 0 = unlimited."],
             "type": "u64"
           },
           {

--- a/onchain-academy/programs/onchain-academy/src/errors.rs
+++ b/onchain-academy/programs/onchain-academy/src/errors.rs
@@ -70,4 +70,6 @@ pub enum AcademyError {
     WrongXpMint,
     #[msg("XP amount exceeds the per-mint ceiling")]
     XpAmountExceedsMax,
+    #[msg("Lesson count can only increase")]
+    LessonCountCannotDecrease,
 }

--- a/onchain-academy/programs/onchain-academy/src/instructions/update_course.rs
+++ b/onchain-academy/programs/onchain-academy/src/instructions/update_course.rs
@@ -13,6 +13,11 @@ pub struct UpdateCourseParams {
     pub new_min_completions_for_reward: Option<u16>,
     /// Set/backfill the Metaplex Core credential collection for this course.
     pub new_collection: Option<Pubkey>,
+    /// Grow the lesson count when a course is extended after deploy (e.g. a
+    /// teacher adds lessons). Increase-only: `lesson_count` seeds the enrollment
+    /// completion bitmap position and gates `complete_lesson`, so shrinking it
+    /// would strand already-completed high-index lessons.
+    pub new_lesson_count: Option<u8>,
 }
 
 pub fn handler(ctx: Context<UpdateCourse>, params: UpdateCourseParams) -> Result<()> {
@@ -53,6 +58,14 @@ pub fn handler(ctx: Context<UpdateCourse>, params: UpdateCourseParams) -> Result
             AcademyError::CollectionMismatch
         );
         course.collection = collection;
+    }
+
+    if let Some(new_lesson_count) = params.new_lesson_count {
+        require!(
+            new_lesson_count >= course.lesson_count,
+            AcademyError::LessonCountCannotDecrease
+        );
+        course.lesson_count = new_lesson_count;
     }
 
     course.updated_at = now;


### PR DESCRIPTION
## Bug
Reactivating (and deactivating) a course failed with `AnchorError … InstructionDidNotDeserialize. Error Number: 102`. In fact **every** `update_course` call from the app was broken (course-sync field updates, collection backfill, activate/deactivate).

## Root cause — repo IDL is behind the deployed program
The deployed devnet program (`7NeJ…SgwE8V`) has a **7th field** in `UpdateCourseParams` — `new_lesson_count: Option<u8>` (the #314 lesson-count fix, deployed on-chain). The repo IDL/source only had **6 fields**, so the client serialized 15 bytes while the program expected 16 → deserialization rejected.

The earlier successful deactivate happened **before** that program upgrade, which is why the course showed `is_active=false` on-chain yet reactivate now fails.

### Confirmed by on-chain simulation
- Decoding on-chain Course accounts: all 224 bytes, one course already `is_active=false`.
- Simulating `update_course` against devnet:
  - **6-field** (repo IDL) → `Custom: 102` InstructionDidNotDeserialize
  - **7-field** (`new_lesson_count=null`) → **success**, emits `CourseUpdated`

## Fix — sync the repo to the deployed program
- **IDL** (`superteam_academy.json`): add `new_lesson_count` as the 7th `UpdateCourseParams` field (`option u8`), matching the deployed layout.
- **Client** (`admin-signer.ts`): serialize `newLessonCount` (null default) so instructions are 16 bytes again, and expose `newLessonCount` on the admin params for a future course-extension sync.
- **Program source** (`update_course.rs` + `errors.rs`): re-apply the field + increase-only guard so `anchor build` regenerates a matching 7-field IDL. **Without this, the next build would regenerate a 6-field IDL and silently re-break the app.**

Re-verified: with the committed repo IDL, the reactivate instruction now deserializes and the program returns success.

## Note for the team
This reconciles the repo with a program upgrade that was deployed to devnet but never committed (the #314 change). The source here re-implements that field with sensible increase-only semantics — please confirm it matches the exact source Thom deployed (field position/type match is what the serialization needs, and that's verified). This also means #314's client-side wiring (push `newLessonCount` on re-sync when a course is extended) can now be completed on top of this.
