### PR TITLE
fix(teacher): import image-by-URL server-side into Sanity (was CSP-blocked)

### DIFF
--- a/apps/web/src/app/api/teacher/upload-image/route.ts
+++ b/apps/web/src/app/api/teacher/upload-image/route.ts
@@ -4,6 +4,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { authorizeTeacher } from "@/lib/teacher/authorize";
 import { isRateLimited } from "@/lib/rate-limit";
 import { uploadTeacherImage } from "@/lib/sanity/teacher-mutations";
+import { fetchRemoteImage, RemoteImageError } from "@/lib/teacher/remote-image";
 
 // Reads the caller's session + streams a file upload — never statically
 // prerender (DYNAMIC_SERVER_USAGE).
@@ -19,13 +20,24 @@ const ALLOWED_TYPES = new Set([
   "image/gif",
 ]);
 
+interface Resolved {
+  buffer: Buffer;
+  filename: string;
+  contentType: string;
+}
+
 /**
- * POST /api/teacher/upload-image — upload a lesson-content image to Sanity and
- * return its CDN URL for insertion as Markdown. Multipart form field: `file`.
+ * POST /api/teacher/upload-image — add a lesson-content image to Sanity and
+ * return its CDN URL for Markdown insertion. Two request shapes:
+ *   - multipart/form-data with a `file` field (upload from computer)
+ *   - application/json `{ "url": "https://…" }` (import by URL)
+ *
+ * Both paths store the image in Sanity so the resulting `cdn.sanity.io` URL is
+ * allowlisted by the lesson renderer's CSP (a raw foreign URL would be blocked)
+ * and no longer depends on the source host staying up.
  *
  * Auth: authenticated + role in (teacher, admin). Rate-limited per user. The
- * privileged Sanity write happens server-side (`uploadTeacherImage`); the client
- * never sees the admin token.
+ * privileged Sanity write happens server-side; the client never sees the token.
  */
 export async function POST(req: NextRequest): Promise<NextResponse> {
   const auth = await authorizeTeacher();
@@ -48,10 +60,39 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     );
   }
 
+  const contentType = req.headers.get("content-type") ?? "";
+  const resolved = contentType.includes("application/json")
+    ? await resolveFromUrl(req)
+    : await resolveFromFile(req);
+
+  if ("error" in resolved) {
+    return NextResponse.json(
+      { error: resolved.error },
+      { status: resolved.status }
+    );
+  }
+
+  try {
+    const { url } = await uploadTeacherImage(
+      resolved.buffer,
+      resolved.filename,
+      resolved.contentType
+    );
+    return NextResponse.json({ url });
+  } catch (err) {
+    console.error("[teacher/upload-image] Sanity upload failed:", err);
+    return NextResponse.json({ error: "Upload failed" }, { status: 500 });
+  }
+}
+
+/** Multipart `file` upload from the user's computer. */
+async function resolveFromFile(
+  req: NextRequest
+): Promise<Resolved | { error: string; status: number }> {
   // Reject oversized bodies before buffering them into memory.
   const declaredLength = Number(req.headers.get("content-length") ?? "0");
   if (Number.isFinite(declaredLength) && declaredLength > MAX_BYTES + 4096) {
-    return NextResponse.json({ error: "Image exceeds 4 MB" }, { status: 413 });
+    return { error: "Image exceeds 4 MB", status: 413 };
   }
 
   let file: File | null = null;
@@ -60,39 +101,66 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     const f = form.get("file");
     if (f instanceof File) file = f;
   } catch {
-    return NextResponse.json({ error: "Invalid form data" }, { status: 400 });
+    return { error: "Invalid form data", status: 400 };
   }
 
-  if (!file) {
-    return NextResponse.json({ error: "No file provided" }, { status: 400 });
-  }
+  if (!file) return { error: "No file provided", status: 400 };
   if (!ALLOWED_TYPES.has(file.type)) {
-    return NextResponse.json(
-      { error: "Unsupported image type (PNG, JPEG, WebP, or GIF only)" },
-      { status: 415 }
-    );
+    return {
+      error: "Unsupported image type (PNG, JPEG, WebP, or GIF only)",
+      status: 415,
+    };
   }
-  if (file.size > MAX_BYTES) {
-    return NextResponse.json({ error: "Image exceeds 4 MB" }, { status: 413 });
+  if (file.size > MAX_BYTES)
+    return { error: "Image exceeds 4 MB", status: 413 };
+
+  const buffer = Buffer.from(await file.arrayBuffer());
+  // Re-check the real byte length (the declared Content-Length can lie).
+  if (buffer.byteLength > MAX_BYTES) {
+    return { error: "Image exceeds 4 MB", status: 413 };
   }
+  return { buffer, filename: file.name || "image", contentType: file.type };
+}
+
+/** Import by URL — fetched server-side (SSRF-guarded) and pinned into Sanity. */
+async function resolveFromUrl(
+  req: NextRequest
+): Promise<Resolved | { error: string; status: number }> {
+  let rawUrl = "";
+  try {
+    const body = (await req.json()) as { url?: unknown };
+    if (typeof body.url === "string") rawUrl = body.url.trim();
+  } catch {
+    return { error: "Invalid JSON body", status: 400 };
+  }
+  if (!rawUrl) return { error: "Image URL is required", status: 400 };
 
   try {
-    const buffer = Buffer.from(await file.arrayBuffer());
-    // Re-check the real byte length (the declared Content-Length can lie).
-    if (buffer.byteLength > MAX_BYTES) {
-      return NextResponse.json(
-        { error: "Image exceeds 4 MB" },
-        { status: 413 }
-      );
-    }
-    const { url } = await uploadTeacherImage(
-      buffer,
-      file.name || "image",
-      file.type
-    );
-    return NextResponse.json({ url });
+    const img = await fetchRemoteImage(rawUrl, {
+      maxBytes: MAX_BYTES,
+      allowedTypes: ALLOWED_TYPES,
+    });
+    return {
+      buffer: img.buffer,
+      filename: img.filename,
+      contentType: img.contentType,
+    };
   } catch (err) {
-    console.error("[teacher/upload-image] upload failed:", err);
-    return NextResponse.json({ error: "Upload failed" }, { status: 500 });
+    if (err instanceof RemoteImageError) {
+      const messages: Record<string, string> = {
+        invalid_url: "Enter a valid image URL",
+        not_https: "The image URL must start with https://",
+        blocked_host: "That image host isn't allowed",
+        bad_type: "The URL must point to a PNG, JPEG, WebP, or GIF image",
+        too_large: "Image exceeds 4 MB",
+        fetch_failed: "Couldn't fetch that image URL",
+      };
+      return {
+        error: messages[err.reason] ?? "Couldn't fetch that image URL",
+        status: 400,
+      };
+    }
+    console.error("[teacher/upload-image] URL import failed:", err);
+    return { error: "Couldn't fetch that image URL", status: 400 };
   }
 }

--- a/apps/web/src/components/teacher/markdown-field.tsx
+++ b/apps/web/src/components/teacher/markdown-field.tsx
@@ -106,14 +106,38 @@ export function MarkdownField({
     }
   }
 
-  function handleUrlInsert() {
+  async function handleUrlInsert() {
     const url = urlValue.trim();
-    if (!/^https?:\/\/\S+$/i.test(url)) {
+    if (!/^https:\/\/\S+$/i.test(url)) {
       setImgError(t("imageUrlInvalid"));
       return;
     }
-    insertAtCaret(`![](${url})`);
-    closeMenu();
+    setUploading(true);
+    setImgError(null);
+    try {
+      // Import server-side (fetch + pin to Sanity) so the resulting
+      // cdn.sanity.io URL renders under the lesson CSP — a raw foreign URL
+      // would be blocked.
+      const res = await fetch("/api/teacher/upload-image", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ url }),
+      });
+      const data = (await res.json().catch(() => ({}))) as {
+        url?: string;
+        error?: string;
+      };
+      if (!res.ok || !data.url) {
+        setImgError(data.error ?? t("imageUploadError"));
+        return;
+      }
+      insertAtCaret(`![](${data.url})`);
+      closeMenu();
+    } catch {
+      setImgError(t("imageUploadError"));
+    } finally {
+      setUploading(false);
+    }
   }
 
   return (
@@ -200,7 +224,7 @@ export function MarkdownField({
                   <button
                     type="button"
                     disabled={uploading || !urlValue.trim()}
-                    onClick={handleUrlInsert}
+                    onClick={() => void handleUrlInsert()}
                     className="rounded-md border border-border px-2.5 py-1.5 text-xs font-medium text-text disabled:opacity-50"
                   >
                     {t("insert")}

--- a/apps/web/src/lib/teacher/remote-image.ts
+++ b/apps/web/src/lib/teacher/remote-image.ts
@@ -1,0 +1,164 @@
+import "server-only";
+import dns from "node:dns/promises";
+import net from "node:net";
+
+/**
+ * Fetch a remote image by URL, safely, so "add image by URL" can pin it into
+ * Sanity (→ cdn.sanity.io) rather than embedding a foreign URL the lesson
+ * renderer's CSP would block. Guards against SSRF: https-only, no embedded
+ * credentials, and the host must resolve to a PUBLIC address (private/loopback/
+ * link-local ranges are rejected, and redirects are refused so a 3xx can't
+ * bounce to an internal host). Size is capped by streaming, not trust in
+ * Content-Length.
+ */
+
+export type RemoteImageReason =
+  | "invalid_url"
+  | "not_https"
+  | "blocked_host"
+  | "bad_type"
+  | "too_large"
+  | "fetch_failed";
+
+export class RemoteImageError extends Error {
+  constructor(public reason: RemoteImageReason) {
+    super(reason);
+    this.name = "RemoteImageError";
+  }
+}
+
+function isPrivateIPv4(ip: string): boolean {
+  const parts = ip.split(".").map((n) => Number(n));
+  if (
+    parts.length !== 4 ||
+    parts.some((n) => !Number.isInteger(n) || n < 0 || n > 255)
+  ) {
+    return true; // malformed → treat as unsafe
+  }
+  const [a, b] = parts as [number, number, number, number];
+  return (
+    a === 0 ||
+    a === 10 ||
+    a === 127 ||
+    (a === 169 && b === 254) || // link-local
+    (a === 172 && b >= 16 && b <= 31) ||
+    (a === 192 && b === 168) ||
+    (a === 100 && b >= 64 && b <= 127) // CGNAT 100.64/10
+  );
+}
+
+function isPrivateIPv6(ip: string): boolean {
+  const s = ip.toLowerCase();
+  if (s === "::1" || s === "::") return true;
+  if (/^f[cd]/.test(s)) return true; // ULA fc00::/7
+  if (/^fe[89ab]/.test(s)) return true; // link-local fe80::/10
+  const mapped = s.match(/::ffff:(\d+\.\d+\.\d+\.\d+)$/);
+  if (mapped && mapped[1]) return isPrivateIPv4(mapped[1]);
+  return false;
+}
+
+function isPrivateIp(ip: string): boolean {
+  const kind = net.isIP(ip);
+  if (kind === 4) return isPrivateIPv4(ip);
+  if (kind === 6) return isPrivateIPv6(ip);
+  return true; // not a recognizable IP → unsafe
+}
+
+async function assertPublicHttpsUrl(raw: string): Promise<URL> {
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    throw new RemoteImageError("invalid_url");
+  }
+  if (url.protocol !== "https:") throw new RemoteImageError("not_https");
+  if (url.username || url.password) throw new RemoteImageError("invalid_url");
+
+  const host = url.hostname;
+  if (net.isIP(host)) {
+    if (isPrivateIp(host)) throw new RemoteImageError("blocked_host");
+    return url;
+  }
+  let resolved: { address: string }[];
+  try {
+    resolved = await dns.lookup(host, { all: true });
+  } catch {
+    throw new RemoteImageError("blocked_host");
+  }
+  if (resolved.length === 0 || resolved.some((r) => isPrivateIp(r.address))) {
+    throw new RemoteImageError("blocked_host");
+  }
+  return url;
+}
+
+export interface FetchedImage {
+  buffer: Buffer;
+  contentType: string;
+  filename: string;
+}
+
+export async function fetchRemoteImage(
+  raw: string,
+  opts: {
+    maxBytes: number;
+    allowedTypes: ReadonlySet<string>;
+    timeoutMs?: number;
+  }
+): Promise<FetchedImage> {
+  const url = await assertPublicHttpsUrl(raw);
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), opts.timeoutMs ?? 10_000);
+
+  try {
+    const res = await fetch(url, {
+      // Refuse redirects — a 3xx could bounce to an internal host and bypass the
+      // pre-flight DNS check.
+      redirect: "error",
+      signal: controller.signal,
+      headers: { accept: "image/*" },
+    });
+    if (!res.ok) throw new RemoteImageError("fetch_failed");
+
+    const contentType = (
+      (res.headers.get("content-type") ?? "").split(";")[0] ?? ""
+    )
+      .trim()
+      .toLowerCase();
+    if (!opts.allowedTypes.has(contentType)) {
+      throw new RemoteImageError("bad_type");
+    }
+    const declared = Number(res.headers.get("content-length") ?? "0");
+    if (Number.isFinite(declared) && declared > opts.maxBytes) {
+      throw new RemoteImageError("too_large");
+    }
+
+    // Stream with a hard cap — don't trust Content-Length for the real size.
+    const reader = res.body?.getReader();
+    if (!reader) throw new RemoteImageError("fetch_failed");
+    const chunks: Uint8Array[] = [];
+    let total = 0;
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (value) {
+        total += value.byteLength;
+        if (total > opts.maxBytes) {
+          await reader.cancel();
+          throw new RemoteImageError("too_large");
+        }
+        chunks.push(value);
+      }
+    }
+    if (total === 0) throw new RemoteImageError("fetch_failed");
+
+    const buffer = Buffer.concat(chunks.map((c) => Buffer.from(c)));
+    const filename = url.pathname.split("/").pop() || "image";
+    return { buffer, contentType, filename };
+  } catch (err) {
+    if (err instanceof RemoteImageError) throw err;
+    // Abort/timeout/network/redirect-refused all collapse to a generic failure.
+    throw new RemoteImageError("fetch_failed");
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/apps/web/src/lib/teacher/remote-image.ts
+++ b/apps/web/src/lib/teacher/remote-image.ts
@@ -1,15 +1,27 @@
 import "server-only";
 import dns from "node:dns/promises";
 import net from "node:net";
+import https from "node:https";
+import type { IncomingMessage } from "node:http";
 
 /**
  * Fetch a remote image by URL, safely, so "add image by URL" can pin it into
  * Sanity (→ cdn.sanity.io) rather than embedding a foreign URL the lesson
- * renderer's CSP would block. Guards against SSRF: https-only, no embedded
- * credentials, and the host must resolve to a PUBLIC address (private/loopback/
- * link-local ranges are rejected, and redirects are refused so a 3xx can't
- * bounce to an internal host). Size is capped by streaming, not trust in
- * Content-Length.
+ * renderer's CSP would block.
+ *
+ * SSRF hardening:
+ *  - https-only, no embedded credentials.
+ *  - The hostname is resolved once and every resolved address must be PUBLIC
+ *    (private/loopback/link-local/CGNAT rejected).
+ *  - The connection is then made DIRECTLY to that validated IP (not by hostname),
+ *    with SNI + Host set to the original hostname. This closes the DNS-rebinding
+ *    TOCTOU hole: a plain `fetch(url)` would re-resolve the hostname when opening
+ *    the socket, so an attacker controlling the domain's DNS could return a
+ *    public IP to the pre-flight check and a private one to the real request.
+ *    Pinning the IP means the socket only ever goes to the address we validated.
+ *  - Redirects are NOT followed (a 3xx could point at an internal host).
+ *  - Size is capped by streaming, not by trusting Content-Length; idle sockets
+ *    time out.
  */
 
 export type RemoteImageReason =
@@ -64,7 +76,13 @@ function isPrivateIp(ip: string): boolean {
   return true; // not a recognizable IP → unsafe
 }
 
-async function assertPublicHttpsUrl(raw: string): Promise<URL> {
+/**
+ * Validate the URL and resolve it to a single PUBLIC IP to connect to. Returns
+ * both the parsed URL (for SNI/Host/path) and the pinned address.
+ */
+async function resolvePublicTarget(
+  raw: string
+): Promise<{ url: URL; ip: string }> {
   let url: URL;
   try {
     url = new URL(raw);
@@ -77,18 +95,20 @@ async function assertPublicHttpsUrl(raw: string): Promise<URL> {
   const host = url.hostname;
   if (net.isIP(host)) {
     if (isPrivateIp(host)) throw new RemoteImageError("blocked_host");
-    return url;
+    return { url, ip: host };
   }
+
   let resolved: { address: string }[];
   try {
     resolved = await dns.lookup(host, { all: true });
   } catch {
     throw new RemoteImageError("blocked_host");
   }
-  if (resolved.length === 0 || resolved.some((r) => isPrivateIp(r.address))) {
+  const first = resolved[0];
+  if (!first || resolved.some((r) => isPrivateIp(r.address))) {
     throw new RemoteImageError("blocked_host");
   }
-  return url;
+  return { url, ip: first.address };
 }
 
 export interface FetchedImage {
@@ -105,60 +125,87 @@ export async function fetchRemoteImage(
     timeoutMs?: number;
   }
 ): Promise<FetchedImage> {
-  const url = await assertPublicHttpsUrl(raw);
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), opts.timeoutMs ?? 10_000);
+  const { url, ip } = await resolvePublicTarget(raw);
+  const timeoutMs = opts.timeoutMs ?? 10_000;
+
+  // Connect straight to the validated IP; keep the real hostname for TLS SNI +
+  // certificate verification and the HTTP Host header. No hostname re-resolution
+  // happens, so DNS rebinding cannot swing the socket to a private address.
+  const res = await new Promise<IncomingMessage>((resolve, reject) => {
+    const request = https.request(
+      {
+        host: ip,
+        servername: url.hostname,
+        port: url.port ? Number(url.port) : 443,
+        path: `${url.pathname}${url.search}`,
+        method: "GET",
+        headers: { host: url.host, accept: "image/*" },
+        rejectUnauthorized: true,
+      },
+      resolve
+    );
+    request.setTimeout(timeoutMs, () => {
+      request.destroy(new RemoteImageError("fetch_failed"));
+    });
+    request.on("error", (err) =>
+      reject(
+        err instanceof RemoteImageError
+          ? err
+          : new RemoteImageError("fetch_failed")
+      )
+    );
+    request.end();
+  });
 
   try {
-    const res = await fetch(url, {
-      // Refuse redirects — a 3xx could bounce to an internal host and bypass the
-      // pre-flight DNS check.
-      redirect: "error",
-      signal: controller.signal,
-      headers: { accept: "image/*" },
-    });
-    if (!res.ok) throw new RemoteImageError("fetch_failed");
-
+    const status = res.statusCode ?? 0;
+    // 3xx is refused, not followed — it could redirect to an internal host.
+    if (status < 200 || status >= 300) {
+      res.destroy();
+      throw new RemoteImageError("fetch_failed");
+    }
     const contentType = (
-      (res.headers.get("content-type") ?? "").split(";")[0] ?? ""
+      (res.headers["content-type"] ?? "").split(";")[0] ?? ""
     )
       .trim()
       .toLowerCase();
     if (!opts.allowedTypes.has(contentType)) {
+      res.destroy();
       throw new RemoteImageError("bad_type");
     }
-    const declared = Number(res.headers.get("content-length") ?? "0");
+    const declared = Number(res.headers["content-length"] ?? "0");
     if (Number.isFinite(declared) && declared > opts.maxBytes) {
+      res.destroy();
       throw new RemoteImageError("too_large");
     }
 
-    // Stream with a hard cap — don't trust Content-Length for the real size.
-    const reader = res.body?.getReader();
-    if (!reader) throw new RemoteImageError("fetch_failed");
-    const chunks: Uint8Array[] = [];
-    let total = 0;
-    for (;;) {
-      const { done, value } = await reader.read();
-      if (done) break;
-      if (value) {
-        total += value.byteLength;
+    const buffer = await new Promise<Buffer>((resolve, reject) => {
+      const chunks: Buffer[] = [];
+      let total = 0;
+      res.on("data", (chunk: Buffer) => {
+        total += chunk.byteLength;
         if (total > opts.maxBytes) {
-          await reader.cancel();
-          throw new RemoteImageError("too_large");
+          res.destroy();
+          reject(new RemoteImageError("too_large"));
+          return;
         }
-        chunks.push(value);
-      }
-    }
-    if (total === 0) throw new RemoteImageError("fetch_failed");
+        chunks.push(chunk);
+      });
+      res.on("end", () => resolve(Buffer.concat(chunks)));
+      res.on("error", (err) =>
+        reject(
+          err instanceof RemoteImageError
+            ? err
+            : new RemoteImageError("fetch_failed")
+        )
+      );
+    });
 
-    const buffer = Buffer.concat(chunks.map((c) => Buffer.from(c)));
+    if (buffer.byteLength === 0) throw new RemoteImageError("fetch_failed");
     const filename = url.pathname.split("/").pop() || "image";
     return { buffer, contentType, filename };
   } catch (err) {
     if (err instanceof RemoteImageError) throw err;
-    // Abort/timeout/network/redirect-refused all collapse to a generic failure.
     throw new RemoteImageError("fetch_failed");
-  } finally {
-    clearTimeout(timer);
   }
 }

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -98,7 +98,7 @@
       "imageUrl": "Paste image URL",
       "insert": "Insert",
       "uploading": "Uploading…",
-      "imageHint": "Uploaded images are hosted on the site. Pasted URLs must be from an allowed host to display.",
+      "imageHint": "Images are hosted on the site (a pasted URL is imported too), so they always display.",
       "imageUploadError": "Image upload failed",
       "imageUrlInvalid": "Enter a valid image URL",
       "videoUrl": "Video URL",

--- a/apps/web/src/messages/es.json
+++ b/apps/web/src/messages/es.json
@@ -98,7 +98,7 @@
       "imageUrl": "Pegar URL de imagen",
       "insert": "Insertar",
       "uploading": "Subiendo…",
-      "imageHint": "Las imágenes subidas se alojan en el sitio. Las URLs pegadas deben ser de un host permitido para mostrarse.",
+      "imageHint": "Las imágenes se alojan en el sitio (una URL pegada también se importa), así que siempre se muestran.",
       "imageUploadError": "Error al subir la imagen",
       "imageUrlInvalid": "Introduce una URL de imagen válida",
       "videoUrl": "URL del vídeo",

--- a/apps/web/src/messages/pt-BR.json
+++ b/apps/web/src/messages/pt-BR.json
@@ -98,7 +98,7 @@
       "imageUrl": "Colar URL da imagem",
       "insert": "Inserir",
       "uploading": "Enviando…",
-      "imageHint": "Imagens enviadas ficam hospedadas no site. URLs coladas precisam vir de um host permitido para aparecer.",
+      "imageHint": "As imagens ficam hospedadas no site (uma URL colada também é importada), então sempre aparecem.",
       "imageUploadError": "Falha ao enviar a imagem",
       "imageUrlInvalid": "Informe uma URL de imagem válida",
       "videoUrl": "URL do vídeo",


### PR DESCRIPTION
## Problem
Follow-up to #335 (merged). Adding a lesson image **by URL** didn't work: the URL path inserted a raw `![](foreign-url)`, and the lesson's tight `img-src` CSP blocks non-allowlisted hosts, so the image never rendered.

## Fix
The URL is now sent to `POST /api/teacher/upload-image` (JSON body), **fetched server-side and pinned into Sanity** — the returned `cdn.sanity.io` URL renders under the existing CSP and no longer depends on the source host staying up. Same outcome as an upload.

## Security — SSRF-guarded fetch (`lib/teacher/remote-image.ts`)
- **https-only**, no embedded credentials
- Host must resolve to a **public** address — private/loopback/link-local/CGNAT ranges (IPv4 + IPv6, incl. IPv4-mapped) are rejected via a pre-flight DNS lookup
- **Redirects refused** (`redirect: "error"`) so a 3xx can't bounce to an internal host
- Body **streamed with a hard 4 MB cap** (doesn't trust Content-Length); 10s timeout
- Same type allowlist as the file path (PNG/JPEG/WebP/GIF; **no SVG**)

Route still teacher-auth'd + per-user rate-limited. Updated the popover hint (en/pt-BR/es) to reflect that pasted URLs are imported too.

## Verification
- `tsc --noEmit` ✓, eslint ✓, locale key parity ✓

## Deploy note
The URL-import path needs outbound egress from the serverless function (default on Vercel) plus the `SANITY_ADMIN_TOKEN` write access the upload already relies on.
