### PR TITLE
feat(admin): grant/revoke teacher by wallet address only

### DIFF
--- a/apps/web/src/app/api/admin/teachers/route.ts
+++ b/apps/web/src/app/api/admin/teachers/route.ts
@@ -18,9 +18,8 @@ const ROLE_BY_ACTION = {
 
 type Action = keyof typeof ROLE_BY_ACTION;
 
-// The identifier is a wallet address (base58, 32-44 chars) OR a username; keep a
-// generous bound covering both.
-const MAX_IDENTIFIER_LENGTH = 64;
+// Solana base58 addresses are 32-44 chars; keep a generous bound.
+const MAX_WALLET_LENGTH = 64;
 
 function isAction(value: unknown): value is Action {
   return value === "grant" || value === "revoke";
@@ -53,13 +52,13 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
 
 /**
  * POST /api/admin/teachers — grant or revoke the `teacher` role for a user,
- * looked up by `identifier` (wallet address OR username). Admin-only (signed
- * `admin_session` cookie).
+ * looked up strictly by wallet address. Admin-only (signed `admin_session`
+ * cookie).
  *
- * Wallet address is the primary identifier, but `wallet_address` is nullable —
- * Google/GitHub-only accounts never link one. Falling back to username keeps
- * those wallet-less accounts (and any teacher granted before a wallet was
- * linked) manageable instead of stranding them (see PR #311 review).
+ * Wallet address is the only identifier accepted (issue #320): teacher features
+ * are on-chain (creator rewards pay a linked wallet), so a teacher must have a
+ * wallet anyway. Google/GitHub-only accounts with no `wallet_address` can't be
+ * targeted here — they need a wallet linked first.
  *
  * The role write goes through the service-role client (`createAdminClient`),
  * which the `enforce_profile_role_write` DB trigger recognizes as privileged;
@@ -74,21 +73,21 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     throw e;
   }
 
-  let identifier: string;
+  let walletAddress: string;
   let action: Action;
   try {
     const body = (await req.json()) as {
-      identifier?: unknown;
+      walletAddress?: unknown;
       action?: unknown;
     };
 
     if (
-      typeof body.identifier !== "string" ||
-      body.identifier.trim().length === 0 ||
-      body.identifier.trim().length > MAX_IDENTIFIER_LENGTH
+      typeof body.walletAddress !== "string" ||
+      body.walletAddress.trim().length === 0 ||
+      body.walletAddress.trim().length > MAX_WALLET_LENGTH
     ) {
       return NextResponse.json(
-        { error: "identifier is required (wallet address or username)" },
+        { error: "walletAddress is required" },
         { status: 400 }
       );
     }
@@ -99,7 +98,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
       );
     }
 
-    identifier = body.identifier.trim();
+    walletAddress = body.walletAddress.trim();
     action = body.action;
   } catch {
     return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
@@ -107,34 +106,19 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
 
   const role = ROLE_BY_ACTION[action];
   const supabase = createAdminClient();
-  const profileColumns = "id, username, wallet_address, role";
 
-  // Resolve the target: wallet address first (the common case), then username.
-  const byWallet = await supabase
+  const { data: profile, error: lookupError } = await supabase
     .from("profiles")
-    .select(profileColumns)
-    .eq("wallet_address", identifier)
+    .select("id, username, wallet_address, role")
+    .eq("wallet_address", walletAddress)
     .maybeSingle();
-  if (byWallet.error) {
+
+  if (lookupError) {
     return NextResponse.json({ error: "Lookup failed" }, { status: 500 });
   }
-
-  let profile = byWallet.data;
-  if (!profile) {
-    const byUsername = await supabase
-      .from("profiles")
-      .select(profileColumns)
-      .eq("username", identifier)
-      .maybeSingle();
-    if (byUsername.error) {
-      return NextResponse.json({ error: "Lookup failed" }, { status: 500 });
-    }
-    profile = byUsername.data;
-  }
-
   if (!profile) {
     return NextResponse.json(
-      { error: "No user found with that wallet address or username" },
+      { error: "No user found with that wallet address" },
       { status: 404 }
     );
   }

--- a/apps/web/src/components/admin/teacher-roles-panel.tsx
+++ b/apps/web/src/components/admin/teacher-roles-panel.tsx
@@ -14,20 +14,8 @@ function shortWallet(w: string | null): string {
   return w.length > 12 ? `${w.slice(0, 4)}…${w.slice(-4)}` : w;
 }
 
-// How to display a teacher: prefer the wallet address, fall back to @username
-// (wallet-less Google/GitHub accounts), then the raw input the admin typed.
-function identityLabel(
-  walletAddress: string | null | undefined,
-  username: string | null | undefined,
-  fallback: string
-): string {
-  if (walletAddress) return shortWallet(walletAddress);
-  if (username) return `@${username}`;
-  return fallback;
-}
-
 export function TeacherRolesPanel() {
-  const [identifier, setIdentifier] = useState("");
+  const [wallet, setWallet] = useState("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
@@ -48,8 +36,8 @@ export function TeacherRolesPanel() {
     void loadTeachers();
   }, [loadTeachers]);
 
-  async function submit(action: "grant" | "revoke", target?: string) {
-    const trimmed = (target ?? identifier).trim();
+  async function submit(action: "grant" | "revoke", address?: string) {
+    const trimmed = (address ?? wallet).trim();
     if (!trimmed) return;
 
     setLoading(true);
@@ -59,24 +47,23 @@ export function TeacherRolesPanel() {
       const res = await fetch("/api/admin/teachers", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ identifier: trimmed, action }),
+        body: JSON.stringify({ walletAddress: trimmed, action }),
       });
       const body = (await res.json().catch(() => ({}))) as {
         error?: string;
-        username?: string | null;
         walletAddress?: string | null;
       };
       if (!res.ok) {
         setError(body.error ?? `Request failed (${res.status})`);
         return;
       }
-      const label = identityLabel(body.walletAddress, body.username, trimmed);
+      const label = shortWallet(body.walletAddress ?? trimmed);
       setNotice(
         action === "grant"
           ? `Granted teacher to ${label}`
           : `Revoked teacher from ${label}`
       );
-      if (!target) setIdentifier("");
+      if (!address) setWallet("");
       await loadTeachers();
     } catch (e) {
       setError(e instanceof Error ? e.message : "Network error");
@@ -89,25 +76,25 @@ export function TeacherRolesPanel() {
     <div className="space-y-4">
       <p className="text-sm text-text-3">
         Grant or revoke the <span className="font-medium">teacher</span> role by
-        wallet address (or username for accounts with no linked wallet).
-        Teachers can author their own courses under{" "}
+        wallet address. Teachers can author their own courses under{" "}
         <span className="font-mono">/teach</span>; publishing on-chain still
-        requires admin review. Admin accounts cannot be changed here.
+        requires admin review. Admin accounts cannot be changed here. A user
+        must have a linked wallet to be granted the teacher role.
       </p>
 
       <div className="flex flex-wrap items-center gap-2">
         <input
           type="text"
-          value={identifier}
-          onChange={(e) => setIdentifier(e.target.value)}
-          placeholder="wallet address or username"
+          value={wallet}
+          onChange={(e) => setWallet(e.target.value)}
+          placeholder="wallet address"
           className="min-w-64 flex-1 rounded-md border border-border bg-[var(--input)] px-3 py-2 font-mono text-xs text-text"
-          aria-label="Wallet address or username"
+          aria-label="Wallet address"
         />
         <button
           type="button"
           onClick={() => void submit("grant")}
-          disabled={loading || !identifier.trim()}
+          disabled={loading || !wallet.trim()}
           className="rounded-md border border-success bg-success-light px-3 py-2 text-sm font-medium text-success disabled:opacity-50"
         >
           Grant teacher
@@ -115,7 +102,7 @@ export function TeacherRolesPanel() {
         <button
           type="button"
           onClick={() => void submit("revoke")}
-          disabled={loading || !identifier.trim()}
+          disabled={loading || !wallet.trim()}
           className="rounded-md border border-border px-3 py-2 text-sm font-medium text-text disabled:opacity-50"
         >
           Revoke
@@ -158,9 +145,10 @@ export function TeacherRolesPanel() {
                 <button
                   type="button"
                   onClick={() =>
-                    void submit("revoke", t.wallet_address ?? t.username)
+                    t.wallet_address && void submit("revoke", t.wallet_address)
                   }
-                  disabled={loading}
+                  disabled={loading || !t.wallet_address}
+                  title={t.wallet_address ? undefined : "No linked wallet"}
                   className="text-xs text-danger underline hover:no-underline disabled:opacity-50"
                 >
                   Revoke


### PR DESCRIPTION
## What
Teacher-role grant/revoke now identifies users **only by wallet address** — the username fallback (added in #311) is removed.

- `POST /api/admin/teachers` accepts only `walletAddress` and looks up strictly by `profiles.wallet_address`; 404 reads "No user found with that wallet address".
- Panel input is wallet-only; the per-row Revoke uses the wallet address and is disabled (with a "No linked wallet" title) for any wallet-less row.
- Same admin gate + teacher↔learner-only + admin-account protection as before.

## Rationale / tradeoff
Teacher features are on-chain (creator rewards pay the instructor's linked wallet), so a teacher must have a wallet anyway. Accounts with no `wallet_address` (Google/GitHub-only) can't be targeted here — they must link a wallet first. Any pre-existing wallet-less teacher row can't be revoked via the panel (its Revoke is disabled); such a row would need a wallet linked, or removal via the DB.

## Verification
- `tsc --noEmit` ✓, eslint ✓

Closes #320
