### PR TITLE
feat(admin): assign courses to learning paths from the admin panel

### DIFF
--- a/apps/web/src/app/[locale]/admin/admin-client.tsx
+++ b/apps/web/src/app/[locale]/admin/admin-client.tsx
@@ -9,6 +9,7 @@ import {
 import { AchievementSyncTable } from "@/components/admin/achievement-sync-table";
 import { DataResyncPanel } from "@/components/admin/data-resync-panel";
 import { TeacherRolesPanel } from "@/components/admin/teacher-roles-panel";
+import { LearningPathsPanel } from "@/components/admin/learning-paths-panel";
 
 interface DiffEntry {
   field: string;
@@ -231,6 +232,16 @@ export function AdminClient() {
         </h2>
         <div className="rounded-lg border border-border bg-card p-4 shadow-card">
           <TeacherRolesPanel />
+        </div>
+      </section>
+
+      {/* Learning Paths */}
+      <section>
+        <h2 className="mb-4 font-display text-lg font-bold text-text">
+          Learning Paths
+        </h2>
+        <div className="rounded-lg border border-border bg-card p-4 shadow-card">
+          <LearningPathsPanel />
         </div>
       </section>
     </div>

--- a/apps/web/src/app/api/admin/learning-paths/route.ts
+++ b/apps/web/src/app/api/admin/learning-paths/route.ts
@@ -1,0 +1,103 @@
+import "server-only";
+
+import { revalidateTag } from "next/cache";
+import { NextRequest, NextResponse } from "next/server";
+import {
+  requireAdminAuth,
+  adminUnauthorizedResponse,
+  AdminAuthError,
+} from "@/lib/admin/auth";
+import {
+  getLearningPathsForAdmin,
+  getCoursesForPathPicker,
+  COURSES_CACHE_TAG,
+} from "@/lib/sanity/queries";
+import { setLearningPathCourses } from "@/lib/sanity/admin-mutations";
+
+// Reads the admin cookie + writes to Sanity — never statically prerender.
+export const dynamic = "force-dynamic";
+
+function guard(req: NextRequest): NextResponse | null {
+  try {
+    requireAdminAuth(req);
+    return null;
+  } catch (e) {
+    if (e instanceof AdminAuthError) return adminUnauthorizedResponse();
+    throw e;
+  }
+}
+
+/** GET — learning paths (+ current course ids) and the assignable course list. */
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const denied = guard(req);
+  if (denied) return denied;
+  const [paths, courses] = await Promise.all([
+    getLearningPathsForAdmin(),
+    getCoursesForPathPicker(),
+  ]);
+  return NextResponse.json({ paths, courses });
+}
+
+/** PUT { pathId, courseIds } — set a path's full course membership. */
+export async function PUT(req: NextRequest): Promise<NextResponse> {
+  const denied = guard(req);
+  if (denied) return denied;
+
+  let pathId: string;
+  let courseIds: string[];
+  try {
+    const body = (await req.json()) as {
+      pathId?: unknown;
+      courseIds?: unknown;
+    };
+    if (typeof body.pathId !== "string" || body.pathId.length === 0) {
+      return NextResponse.json(
+        { error: "pathId is required" },
+        { status: 400 }
+      );
+    }
+    if (
+      !Array.isArray(body.courseIds) ||
+      body.courseIds.some((id) => typeof id !== "string")
+    ) {
+      return NextResponse.json(
+        { error: "courseIds must be an array of strings" },
+        { status: 400 }
+      );
+    }
+    pathId = body.pathId;
+    // De-dupe, drop empties, and reject Sanity drafts.
+    courseIds = Array.from(
+      new Set((body.courseIds as string[]).map((id) => id.trim()))
+    ).filter((id) => id.length > 0 && !id.startsWith("drafts."));
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  // Validate the pathId is actually a learning path (not an arbitrary doc id).
+  const paths = await getLearningPathsForAdmin();
+  if (!paths.some((p) => p._id === pathId)) {
+    return NextResponse.json(
+      { error: "Learning path not found" },
+      { status: 404 }
+    );
+  }
+  // Validate every course id exists in the assignable set.
+  const validIds = new Set((await getCoursesForPathPicker()).map((c) => c._id));
+  if (courseIds.some((id) => !validIds.has(id))) {
+    return NextResponse.json(
+      { error: "One or more courses are not assignable" },
+      { status: 400 }
+    );
+  }
+
+  try {
+    await setLearningPathCourses(pathId, courseIds);
+    // Learning-path sections render on /courses (catalog); purge that cache.
+    revalidateTag(COURSES_CACHE_TAG);
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    console.error("[admin/learning-paths] update failed:", err);
+    return NextResponse.json({ error: "Failed to save" }, { status: 500 });
+  }
+}

--- a/apps/web/src/components/admin/learning-paths-panel.tsx
+++ b/apps/web/src/components/admin/learning-paths-panel.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+
+interface AdminPath {
+  _id: string;
+  title: string;
+  courseIds: string[];
+}
+interface PickerCourse {
+  _id: string;
+  title: string;
+  slug: string | null;
+}
+
+export function LearningPathsPanel() {
+  const [paths, setPaths] = useState<AdminPath[]>([]);
+  const [courses, setCourses] = useState<PickerCourse[]>([]);
+  // Per-path working selection (course id set), edited before Save.
+  const [selection, setSelection] = useState<Record<string, Set<string>>>({});
+  const [savingId, setSavingId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    try {
+      const res = await fetch("/api/admin/learning-paths");
+      if (!res.ok) return;
+      const body = (await res.json()) as {
+        paths?: AdminPath[];
+        courses?: PickerCourse[];
+      };
+      const nextPaths = body.paths ?? [];
+      setPaths(nextPaths);
+      setCourses(body.courses ?? []);
+      setSelection(
+        Object.fromEntries(nextPaths.map((p) => [p._id, new Set(p.courseIds)]))
+      );
+    } catch {
+      // Non-critical convenience view.
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  function toggle(pathId: string, courseId: string) {
+    setSelection((prev) => {
+      const current = new Set(prev[pathId] ?? []);
+      if (current.has(courseId)) current.delete(courseId);
+      else current.add(courseId);
+      return { ...prev, [pathId]: current };
+    });
+  }
+
+  async function save(pathId: string) {
+    setSavingId(pathId);
+    setError(null);
+    setNotice(null);
+    try {
+      const courseIds = Array.from(selection[pathId] ?? []);
+      const res = await fetch("/api/admin/learning-paths", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ pathId, courseIds }),
+      });
+      const body = (await res.json().catch(() => ({}))) as { error?: string };
+      if (!res.ok) {
+        setError(body.error ?? `Request failed (${res.status})`);
+        return;
+      }
+      setNotice("Saved");
+      await load();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Network error");
+    } finally {
+      setSavingId(null);
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-text-3">
+        Assign courses to learning paths. Changes take effect on the courses
+        page after saving.
+      </p>
+
+      {error && (
+        <div className="rounded-md border border-danger bg-danger-light p-3 text-sm text-danger">
+          {error}
+        </div>
+      )}
+      {notice && (
+        <div className="rounded-md border border-success bg-success-light p-3 text-sm text-success">
+          {notice}
+        </div>
+      )}
+
+      {paths.length === 0 ? (
+        <p className="text-sm text-text-3">No learning paths yet.</p>
+      ) : (
+        <div className="space-y-4">
+          {paths.map((path) => {
+            const selected = selection[path._id] ?? new Set<string>();
+            return (
+              <div
+                key={path._id}
+                className="rounded-lg border border-border bg-card p-4"
+              >
+                <div className="mb-2 flex items-center justify-between">
+                  <h4 className="font-display text-sm font-bold text-text">
+                    {path.title}{" "}
+                    <span className="font-sans text-xs font-normal text-text-3">
+                      ({selected.size})
+                    </span>
+                  </h4>
+                  <button
+                    type="button"
+                    onClick={() => void save(path._id)}
+                    disabled={savingId === path._id}
+                    className="rounded-md border border-primary bg-primary px-3 py-1 text-xs font-medium text-primary-foreground disabled:opacity-50"
+                  >
+                    {savingId === path._id ? "Saving…" : "Save"}
+                  </button>
+                </div>
+                {courses.length === 0 ? (
+                  <p className="text-xs text-text-3">No courses available.</p>
+                ) : (
+                  <ul className="grid gap-1 sm:grid-cols-2">
+                    {courses.map((course) => (
+                      <li key={course._id}>
+                        <label className="flex items-center gap-2 text-sm text-text">
+                          <input
+                            type="checkbox"
+                            checked={selected.has(course._id)}
+                            onChange={() => toggle(path._id, course._id)}
+                          />
+                          {course.title}
+                        </label>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/lib/sanity/admin-mutations.ts
+++ b/apps/web/src/lib/sanity/admin-mutations.ts
@@ -11,6 +11,24 @@ const sanityAdmin = createClient({
   apiVersion: "2024-01-01",
 });
 
+/**
+ * Set the full course membership of a learning path (issue #323). Admin-only —
+ * the calling route must have passed `requireAdminAuth`. `courseIds` should be
+ * de-duplicated by the caller; each becomes a keyed Sanity reference (order
+ * preserved). Passing an empty array clears the path.
+ */
+export async function setLearningPathCourses(
+  pathId: string,
+  courseIds: string[]
+): Promise<void> {
+  const courses = courseIds.map((ref) => ({
+    _type: "reference",
+    _ref: ref,
+    _key: ref,
+  }));
+  await sanityAdmin.patch(pathId).set({ courses }).commit();
+}
+
 export async function writeCourseOnChainStatus(
   sanityId: string,
   status: string,

--- a/apps/web/src/lib/sanity/queries.ts
+++ b/apps/web/src/lib/sanity/queries.ts
@@ -683,6 +683,49 @@ export async function getAllCoursesAdmin(): Promise<AdminCourse[]> {
   );
 }
 
+export interface AdminLearningPath {
+  _id: string;
+  title: string;
+  courseIds: string[];
+}
+
+/**
+ * Learning paths + their current course membership, for the admin panel
+ * (issue #323). Read fresh (revalidate=0) so edits reflect immediately.
+ */
+export async function getLearningPathsForAdmin(): Promise<AdminLearningPath[]> {
+  return sanityFetch<AdminLearningPath[]>(
+    `*[_type == "learningPath"] | order(coalesce(order, 999) asc, title asc) {
+      _id,
+      title,
+      "courseIds": coalesce(courses[]._ref, [])
+    }`,
+    undefined,
+    0
+  );
+}
+
+export interface PathPickerCourse {
+  _id: string;
+  title: string;
+  slug: string | null;
+}
+
+/**
+ * Non-draft courses the admin can assign to a learning path (issue #323).
+ */
+export async function getCoursesForPathPicker(): Promise<PathPickerCourse[]> {
+  return sanityFetch<PathPickerCourse[]>(
+    `*[_type == "course" && !(_id in path("drafts.**"))] | order(title asc) {
+      _id,
+      title,
+      "slug": slug.current
+    }`,
+    undefined,
+    0
+  );
+}
+
 /**
  * A course awaiting admin review (issue #268). Minimal metadata for the admin
  * review queue — the admin approves (→ on-chain sync) or rejects (→ draft +


### PR DESCRIPTION
## What
Admins can now assign courses to **learning paths** from `/admin` — previously only editable in Sanity Studio.

## Pieces
- **Read**: `getLearningPathsForAdmin()` (each path + its current `courseIds`) and `getCoursesForPathPicker()` (non-draft courses), both fresh (revalidate=0).
- **Write**: `setLearningPathCourses(pathId, courseIds)` sets the path's `courses` to keyed Sanity references (order preserved, empty clears).
- **Route**: `/api/admin/learning-paths` — `GET` (paths + assignable courses), `PUT { pathId, courseIds }`. Admin-cookie auth; validates the `pathId` is a real learning path and every course id is assignable; de-dupes and rejects Sanity drafts; **`revalidateTag(COURSES_CACHE_TAG)`** so the `/courses` learning-path sections update.
- **UI**: `LearningPathsPanel` — each path shows a checklist of courses with a per-path Save.

## Behavior notes
- Save writes the **full membership** (set semantics), so it's idempotent and order/dupe-safe.
- Course choices exclude Sanity drafts; a not-yet-synced course can still be assigned (it just won't render publicly until it's synced/approved/active — the catalog gate handles that).

## Verification
- `tsc --noEmit` ✓, eslint ✓

Closes #323
