### PR TITLE
feat(community): admin moderation queue + flag notifications

### DIFF
--- a/apps/web/src/app/[locale]/admin/admin-client.tsx
+++ b/apps/web/src/app/[locale]/admin/admin-client.tsx
@@ -11,6 +11,7 @@ import { DataResyncPanel } from "@/components/admin/data-resync-panel";
 import { TeacherRolesPanel } from "@/components/admin/teacher-roles-panel";
 import { LearningPathsPanel } from "@/components/admin/learning-paths-panel";
 import { CourseTagsPanel } from "@/components/admin/course-tags-panel";
+import { FlagsPanel } from "@/components/admin/flags-panel";
 
 interface DiffEntry {
   field: string;
@@ -70,6 +71,7 @@ export function AdminClient() {
   const [status, setStatus] = useState<AdminStatus | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [flagCount, setFlagCount] = useState(0);
 
   const fetchStatus = useCallback(async () => {
     setLoading(true);
@@ -171,6 +173,21 @@ export function AdminClient() {
             courses={pendingReviews}
             onRefresh={() => void fetchStatus()}
           />
+        </div>
+      </section>
+
+      {/* Moderation — community flags awaiting review */}
+      <section>
+        <h2 className="mb-4 font-display text-lg font-bold text-text">
+          Moderation
+          {flagCount > 0 && (
+            <span className="ml-2 rounded-full bg-danger px-2 py-0.5 text-xs font-bold text-white">
+              {flagCount}
+            </span>
+          )}
+        </h2>
+        <div className="rounded-lg border border-border bg-card p-4 shadow-card">
+          <FlagsPanel onCountChange={setFlagCount} />
         </div>
       </section>
 

--- a/apps/web/src/app/api/admin/flags/route.ts
+++ b/apps/web/src/app/api/admin/flags/route.ts
@@ -1,0 +1,182 @@
+import "server-only";
+
+import { NextRequest, NextResponse } from "next/server";
+import {
+  requireAdminAuth,
+  adminUnauthorizedResponse,
+  AdminAuthError,
+} from "@/lib/admin/auth";
+import { createAdminClient } from "@/lib/supabase/admin";
+
+// Reads the admin cookie + service-role DB — never statically prerender.
+export const dynamic = "force-dynamic";
+
+function guard(req: NextRequest): NextResponse | null {
+  try {
+    requireAdminAuth(req);
+    return null;
+  } catch (e) {
+    if (e instanceof AdminAuthError) return adminUnauthorizedResponse();
+    throw e;
+  }
+}
+
+export interface ModerationFlag {
+  id: string;
+  reason: string;
+  details: string | null;
+  createdAt: string;
+  reporter: string | null;
+  targetType: "thread" | "answer";
+  preview: string;
+  url: string | null;
+}
+
+/**
+ * GET /api/admin/flags — pending community flags for the moderation queue, each
+ * resolved to a target preview + link. Service-role read (the `flags` table is
+ * not readable by normal users). Assembled in-app from small `.in()` fetches
+ * rather than PostgREST embedding to keep the FK-hint surface simple.
+ */
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const denied = guard(req);
+  if (denied) return denied;
+
+  const admin = createAdminClient();
+  const { data: flags, error } = await admin
+    .from("flags")
+    .select(
+      "id, reason, details, created_at, reporter_id, thread_id, answer_id"
+    )
+    .eq("status", "pending")
+    .order("created_at", { ascending: false })
+    .limit(200);
+
+  if (error) {
+    return NextResponse.json({ error: "Lookup failed" }, { status: 500 });
+  }
+  const rows = flags ?? [];
+
+  const answerIds = rows
+    .map((f) => f.answer_id)
+    .filter((id): id is string => !!id);
+  const answers = answerIds.length
+    ? ((
+        await admin
+          .from("answers")
+          .select("id, body, thread_id")
+          .in("id", answerIds)
+      ).data ?? [])
+    : [];
+  const answerMap = new Map(answers.map((a) => [a.id, a]));
+
+  const threadIds = Array.from(
+    new Set([
+      ...rows.map((f) => f.thread_id).filter((id): id is string => !!id),
+      ...answers.map((a) => a.thread_id),
+    ])
+  );
+  const threads = threadIds.length
+    ? ((
+        await admin
+          .from("threads")
+          .select("id, title, slug, category_id")
+          .in("id", threadIds)
+      ).data ?? [])
+    : [];
+  const threadMap = new Map(threads.map((t) => [t.id, t]));
+
+  const categoryIds = Array.from(
+    new Set(
+      threads.map((t) => t.category_id).filter((id): id is string => !!id)
+    )
+  );
+  const categories = categoryIds.length
+    ? ((
+        await admin
+          .from("forum_categories")
+          .select("id, slug")
+          .in("id", categoryIds)
+      ).data ?? [])
+    : [];
+  const categorySlug = new Map(categories.map((c) => [c.id, c.slug]));
+
+  const reporterIds = Array.from(new Set(rows.map((f) => f.reporter_id)));
+  const reporters = reporterIds.length
+    ? ((
+        await admin
+          .from("profiles")
+          .select("id, username")
+          .in("id", reporterIds)
+      ).data ?? [])
+    : [];
+  const reporterName = new Map(reporters.map((r) => [r.id, r.username]));
+
+  const result: ModerationFlag[] = rows.map((f) => {
+    const isThread = !!f.thread_id;
+    const answer = f.answer_id ? answerMap.get(f.answer_id) : undefined;
+    const threadId = isThread ? f.thread_id : (answer?.thread_id ?? null);
+    const thread = threadId ? threadMap.get(threadId) : undefined;
+    const preview = isThread ? (thread?.title ?? "") : (answer?.body ?? "");
+    const slug = thread?.category_id
+      ? categorySlug.get(thread.category_id)
+      : undefined;
+    const url = thread && slug ? `/community/${slug}/${thread.slug}` : null;
+    return {
+      id: f.id,
+      reason: f.reason,
+      details: f.details,
+      createdAt: f.created_at,
+      reporter: reporterName.get(f.reporter_id) ?? null,
+      targetType: isThread ? "thread" : "answer",
+      preview: preview.slice(0, 200),
+      url,
+    };
+  });
+
+  return NextResponse.json({ flags: result });
+}
+
+/** POST { flagId, action: "resolve" | "dismiss" } — action a pending flag. */
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  const denied = guard(req);
+  if (denied) return denied;
+
+  let flagId: string;
+  let action: "resolve" | "dismiss";
+  try {
+    const body = (await req.json()) as { flagId?: unknown; action?: unknown };
+    if (typeof body.flagId !== "string" || body.flagId.length === 0) {
+      return NextResponse.json(
+        { error: "flagId is required" },
+        { status: 400 }
+      );
+    }
+    if (body.action !== "resolve" && body.action !== "dismiss") {
+      return NextResponse.json(
+        { error: "action must be 'resolve' or 'dismiss'" },
+        { status: 400 }
+      );
+    }
+    flagId = body.flagId;
+    action = body.action;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const admin = createAdminClient();
+  // resolved_by is left null: the admin_session cookie is not a Supabase user,
+  // so there's no profile id to attribute. status + resolved_at are enough.
+  const { error } = await admin
+    .from("flags")
+    .update({
+      status: action === "resolve" ? "resolved" : "dismissed",
+      resolved_at: new Date().toISOString(),
+    })
+    .eq("id", flagId);
+
+  if (error) {
+    return NextResponse.json({ error: "Update failed" }, { status: 500 });
+  }
+  return NextResponse.json({ success: true });
+}

--- a/apps/web/src/app/api/community/flags/route.ts
+++ b/apps/web/src/app/api/community/flags/route.ts
@@ -1,7 +1,9 @@
 // apps/web/src/app/api/community/flags/route.ts
 import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
 import { isRateLimited } from "@/lib/rate-limit";
+import { notifyModeration } from "@/lib/community/moderation-notify";
 
 export async function POST(request: NextRequest) {
   try {
@@ -55,6 +57,26 @@ export async function POST(request: NextRequest) {
         { error: "Failed to submit flag" },
         { status: 500 }
       );
+    }
+
+    // Notify admins on the FIRST flag for this target (one ping per item, not
+    // per report). Count via the service-role client so RLS doesn't limit it to
+    // the reporter's own rows. Non-blocking: never fail the flag on this.
+    try {
+      const admin = createAdminClient();
+      const column = threadId ? "thread_id" : "answer_id";
+      const targetId = threadId || answerId;
+      const { count } = await admin
+        .from("flags")
+        .select("id", { count: "exact", head: true })
+        .eq(column, targetId);
+      if (count === 1) {
+        void notifyModeration(
+          `🚩 New "${reason}" flag on a community ${threadId ? "thread" : "answer"}. Review it in /admin.`
+        );
+      }
+    } catch {
+      // Notification is best-effort; the flag is already recorded.
     }
 
     return NextResponse.json({ success: true }, { status: 201 });

--- a/apps/web/src/components/admin/flags-panel.tsx
+++ b/apps/web/src/components/admin/flags-panel.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+
+interface ModerationFlag {
+  id: string;
+  reason: string;
+  details: string | null;
+  createdAt: string;
+  reporter: string | null;
+  targetType: "thread" | "answer";
+  preview: string;
+  url: string | null;
+}
+
+export function FlagsPanel({
+  onCountChange,
+}: {
+  onCountChange?: (count: number) => void;
+}) {
+  const [flags, setFlags] = useState<ModerationFlag[]>([]);
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    try {
+      const res = await fetch("/api/admin/flags");
+      if (!res.ok) return;
+      const body = (await res.json()) as { flags?: ModerationFlag[] };
+      setFlags(body.flags ?? []);
+    } catch {
+      // Non-critical convenience view.
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  // Keep the parent's badge count in sync with the list (incl. optimistic drops).
+  useEffect(() => {
+    onCountChange?.(flags.length);
+  }, [flags, onCountChange]);
+
+  async function act(flagId: string, action: "resolve" | "dismiss") {
+    setBusyId(flagId);
+    setError(null);
+    try {
+      const res = await fetch("/api/admin/flags", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ flagId, action }),
+      });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as { error?: string };
+        setError(body.error ?? `Request failed (${res.status})`);
+        return;
+      }
+      // Optimistically drop the actioned flag.
+      setFlags((prev) => prev.filter((f) => f.id !== flagId));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Network error");
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-text-3">
+        Community posts reported by users. Resolve once you&apos;ve actioned the
+        content, or dismiss if the report isn&apos;t valid.
+      </p>
+
+      {error && (
+        <div className="rounded-md border border-danger bg-danger-light p-3 text-sm text-danger">
+          {error}
+        </div>
+      )}
+
+      {flags.length === 0 ? (
+        <p className="text-sm text-text-3">No pending flags.</p>
+      ) : (
+        <ul className="space-y-2">
+          {flags.map((flag) => (
+            <li
+              key={flag.id}
+              className="rounded-md border border-border bg-card p-3 text-sm"
+            >
+              <div className="mb-1 flex flex-wrap items-center gap-2">
+                <span className="rounded-full border border-danger bg-danger-light px-2 py-0.5 text-xs font-medium text-danger">
+                  {flag.reason}
+                </span>
+                <span className="text-xs text-text-3">
+                  {flag.targetType} · reported by @{flag.reporter ?? "unknown"}{" "}
+                  · {new Date(flag.createdAt).toLocaleString()}
+                </span>
+              </div>
+              <p className="text-text">
+                {flag.preview || <span className="italic text-text-3">—</span>}
+              </p>
+              {flag.details && (
+                <p className="mt-1 text-xs text-text-2">“{flag.details}”</p>
+              )}
+              <div className="mt-2 flex items-center gap-3">
+                {flag.url && (
+                  <a
+                    href={flag.url}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="text-xs text-primary underline hover:no-underline"
+                  >
+                    View
+                  </a>
+                )}
+                <button
+                  type="button"
+                  onClick={() => void act(flag.id, "resolve")}
+                  disabled={busyId === flag.id}
+                  className="rounded-md border border-success bg-success-light px-2.5 py-1 text-xs font-medium text-success disabled:opacity-50"
+                >
+                  Resolve
+                </button>
+                <button
+                  type="button"
+                  onClick={() => void act(flag.id, "dismiss")}
+                  disabled={busyId === flag.id}
+                  className="rounded-md border border-border px-2.5 py-1 text-xs font-medium text-text-2 disabled:opacity-50"
+                >
+                  Dismiss
+                </button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/lib/community/moderation-notify.ts
+++ b/apps/web/src/lib/community/moderation-notify.ts
@@ -1,0 +1,25 @@
+import "server-only";
+import { serverEnv } from "@/lib/env.server";
+
+/**
+ * Fire-and-forget ping to the optional moderation webhook (`MODERATION_WEBHOOK_URL`).
+ * Sends both `text` (Slack incoming webhooks) and `content` (Discord) so either
+ * platform renders the message. Never throws — a failed/absent webhook must not
+ * affect the flag request that triggered it.
+ */
+export async function notifyModeration(message: string): Promise<void> {
+  const url = serverEnv.MODERATION_WEBHOOK_URL;
+  if (!url) return;
+  try {
+    await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ text: message, content: message }),
+    });
+  } catch (err) {
+    console.warn(
+      "[moderation] webhook failed:",
+      err instanceof Error ? err.message : err
+    );
+  }
+}

--- a/apps/web/src/lib/env.server.ts
+++ b/apps/web/src/lib/env.server.ts
@@ -46,6 +46,10 @@ const serverEnvSchema = z.object({
   // Anchor build-server proxy.
   BUILD_SERVER_URL: optUrl,
   BUILD_SERVER_API_KEY: optStr,
+  // Optional: Slack/Discord-compatible incoming webhook. When set, the first
+  // flag on a community post pings it so admins know to check the moderation
+  // queue. Unset → no notification (the queue is still available in /admin).
+  MODERATION_WEBHOOK_URL: optUrl,
 });
 
 const parsed = serverEnvSchema.safeParse({
@@ -59,6 +63,7 @@ const parsed = serverEnvSchema.safeParse({
   PROGRAM_AUTHORITY_SECRET: process.env.PROGRAM_AUTHORITY_SECRET,
   BUILD_SERVER_URL: process.env.BUILD_SERVER_URL,
   BUILD_SERVER_API_KEY: process.env.BUILD_SERVER_API_KEY,
+  MODERATION_WEBHOOK_URL: process.env.MODERATION_WEBHOOK_URL,
 });
 
 if (!parsed.success) {


### PR DESCRIPTION
## Problem
When a user flagged a community post (spam/etc.), it was just stored in `flags` with `status = 'pending'` — no admin was notified and there was no in-app way to see or action pending flags.

## What this adds
### Admin moderation queue
- **`GET /api/admin/flags`** — pending flags, each resolved to a **target preview** (thread title / answer snippet), **reason**, **details**, **reporter**, and a **link** to the thread. Service-role read (the `flags` table isn't user-readable); assembled from small `.in()` fetches rather than fragile PostgREST embedding.
- **`POST /api/admin/flags` `{ flagId, action }`** — resolve/dismiss: sets `status` + `resolved_at`. (`resolved_by` is left null — the `admin_session` cookie isn't a Supabase user, so there's no profile id to attribute.)
- **`FlagsPanel`** in `/admin` — View / Resolve / Dismiss per flag, plus a **Moderation** section with a **pending-count badge** (matches the Review Queue pattern).

### Notification (optional)
- On the **first** flag for a given target (one ping per item, not per report — counted via the service-role client so RLS doesn't skew it), pings an optional **`MODERATION_WEBHOOK_URL`**. Slack- and Discord-compatible (`{ text, content }`), fire-and-forget, and a **no-op when unset** (the queue still works without it).
- I went with a webhook rather than email because there's no email provider configured in the app; a Slack/Discord incoming webhook needs only the URL.

## Notes / scope
- Resolve/dismiss action only updates the flag's status — it doesn't auto-delete the content. Admins use the existing thread/answer soft-delete via the linked post. Auto-moderation could be a follow-up.
- Flat list (one row per flag) rather than grouped-by-target; the first-flag-only notification keeps admin noise down.

## Verification
- `tsc --noEmit` ✓, eslint ✓

Closes #339
