### PR TITLE
chore(build-server): scale-to-zero Cloud Run config for cost (#253)

### DIFF
--- a/apps/build-server/deploy/cloudbuild.yaml
+++ b/apps/build-server/deploy/cloudbuild.yaml
@@ -45,10 +45,16 @@ steps:
       - '300'
       - '--concurrency'
       - '2'
+      # COST: scale to zero — buildable compiles are sporadic, so bill CPU+memory
+      # only while a build runs (idle ~$0 vs ~$300-400/mo for a warm 4vCPU/8GiB
+      # instance). --cpu-boost softens the ~10-30s cold start on the first build
+      # after idle. Keep 4vCPU/8GiB: the build target/ lives in tmpfs (RAM), so
+      # trimming memory risks OOM. Never add --no-cpu-throttling (bills CPU 24/7).
       - '--min-instances'
-      - '1'
+      - '0'
       - '--max-instances'
-      - '3'
+      - '2'
+      - '--cpu-boost'
       # Egress hardening (P1-8): route ALL outbound traffic through a locked-down
       # VPC so untrusted user-code compilation cannot reach the network. This must
       # be paired with a VPC firewall rule that DENIES egress for the network tag

--- a/apps/build-server/deploy/deploy.sh
+++ b/apps/build-server/deploy/deploy.sh
@@ -24,6 +24,14 @@ echo "==> Deploying to Cloud Run"
 # X-API-Key, not GCP IAM. To gate ingress at the platform edge instead, swap
 # --no-invoker-iam-check for --no-allow-unauthenticated and have the caller mint a
 # Google ID token (see deploy/HARDENING.md).
+# COST: buildable-challenge compiles are sporadic, so the service scales to zero
+# (--min-instances 0) and bills CPU+memory ONLY while a build runs — idle cost is
+# ~$0 instead of ~$300-400/mo for a warm 4vCPU/8GiB instance. Trade-off: a ~10-30s
+# cold start on the first build after an idle period; --cpu-boost gives full CPU
+# during startup to soften it. Do NOT add --no-cpu-throttling (it bills CPU 24/7
+# and undoes the savings). 4vCPU/8GiB is kept: a build copies the pre-built
+# target/ into tmpfs (/tmp, RAM-backed) then runs cargo-build-sbf, so trimming
+# memory risks OOM for a fraction-of-a-cent saving now that you only pay per build.
 gcloud run deploy "${SERVICE_NAME}" \
   --image "${IMAGE}" \
   --region "${REGION}" \
@@ -32,8 +40,9 @@ gcloud run deploy "${SERVICE_NAME}" \
   --memory 8Gi \
   --timeout 300 \
   --concurrency 2 \
-  --min-instances 1 \
-  --max-instances 3 \
+  --min-instances 0 \
+  --max-instances 2 \
+  --cpu-boost \
   --set-env-vars "ACADEMY_API_KEY=${ACADEMY_API_KEY},ALLOWED_ORIGIN=${ALLOWED_ORIGIN:-https://solarium.courses},MAX_CONCURRENT_BUILDS=2,BUILD_TIMEOUT_SECS=300,CACHE_TTL_SECS=1800,LOG_FORMAT=json,RUST_LOG=info" \
   --no-invoker-iam-check
 


### PR DESCRIPTION
## What
Codifies a **cost-optimized** Cloud Run config for the buildable-challenge build server (#253), so the cheap setup is what ships on the next deploy.

## Change
Both `deploy.sh` and `cloudbuild.yaml`:
- `--min-instances 1 → 0` — **scale to zero**. Bills CPU+memory only while a build runs.
- `--max-instances 3 → 2` — tighter cost ceiling (2 × concurrency 2 = 4 parallel builds).
- `+ --cpu-boost` — full CPU during container startup to soften the cold start.
- Unchanged: `4 vCPU / 8 GiB`, `concurrency 2`, `timeout 300`, env vars, VPC egress lockdown, and all other hardening.

## Why
Buildable compiles are sporadic (occasional learner submissions), so a warm 4vCPU/8GiB instance running 24/7 (`min-instances 1`) costs **~$300–400/mo to sit idle**. Scale-to-zero drops idle cost to **~$0**; at low volume the whole service is **a few $/mo**.

| | min=1 (before) | min=0 (this PR) |
| --- | --- | --- |
| Idle | ~$300–400/mo | ~$0 |
| ~2,000 builds/mo | ~$300–400 + builds | ~$5–10 total |
| Trade-off | instant | ~10–30s cold start on first build after idle |

Cold starts are fine here — the app already degrades gracefully, and compiles aren't latency-critical.

## Deliberately kept
- **4 vCPU / 8 GiB** — a build copies the pre-built `target/` into tmpfs (`/tmp`, RAM-backed) then runs `cargo-build-sbf`; trimming memory risks OOM for a fraction-of-a-cent saving now that you only pay per build.
- **Region** left at `southamerica-east1` (default) — `us-central1` is ~25–30% cheaper, but the Artifact Registry repo + VPC are region-scoped, so a region move isn't worth ~$2/mo on an already-tiny bill. Easy to change via the script's `REGION` arg if desired.

## Still needs a human (can't run from CI/here)
Deploying requires GCP credentials — see the runbook in the PR discussion. Refs #253 (the issue is tagged `blocked:needs-human` for exactly this).
