### PR TITLE
fix(quests): durable quest-XP delivery + get_daily_quest_state hardening (CS-7)

### DIFF
--- a/apps/web/src/app/api/quests/daily/route.ts
+++ b/apps/web/src/app/api/quests/daily/route.ts
@@ -1,10 +1,8 @@
 import { NextResponse } from "next/server";
-import { PublicKey } from "@solana/web3.js";
 import type { DailyQuest } from "@superteam-lms/types";
 import { createClient } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { getAllQuests } from "@/lib/sanity/queries";
-import { rewardXp, isOnChainProgramLive } from "@/lib/solana/academy-program";
 import { queueFailedOnchainAction } from "@/lib/solana/onchain-queue";
 import { nextMidnightUtc } from "@/lib/gamification/daily-reset";
 import { logError } from "@/lib/logging";
@@ -116,14 +114,21 @@ export async function GET() {
       };
     });
 
-    // 6. Mint XP on-chain for newly-completed quests (fire-and-forget)
+    // 6. Durably record the on-chain XP mint intent for newly-completed quests.
+    //
+    // get_daily_quest_state already flipped xp_granted=true ("attempt
+    // authorized"), so a dropped mint is PERMANENT XP loss. The mint therefore
+    // must not be fire-and-forget: on Vercel the lambda freezes once the
+    // response returns, killing any un-awaited work. Instead we write the
+    // pending_onchain_actions row SYNCHRONOUSLY (durable) BEFORE responding;
+    // retryPendingOnchainActions() — driven on the user's next auth — performs
+    // the actual on-chain mint (it resolves the wallet and checks program
+    // liveness itself, so no wallet / program-live gating is needed here).
     const newlyAwarded = progressRows.filter(
       (r) => r.justAwarded && r.xpReward > 0
     );
     if (newlyAwarded.length > 0) {
-      mintQuestXpOnChain(user.id, newlyAwarded, admin).catch(() => {
-        // Errors are logged + queued inside mintQuestXpOnChain
-      });
+      await enqueueQuestXpMints(user.id, newlyAwarded);
     }
 
     return NextResponse.json({
@@ -140,56 +145,43 @@ export async function GET() {
 }
 
 // ---------------------------------------------------------------------------
-// Fire-and-forget: mint quest XP tokens on-chain
+// Durable enqueue: record quest-XP mint intents for the retry queue
 // ---------------------------------------------------------------------------
 
-async function mintQuestXpOnChain(
+async function enqueueQuestXpMints(
   userId: string,
-  awarded: Array<{ questId: string; xpReward: number }>,
-  admin: ReturnType<typeof createAdminClient>
+  awarded: Array<{ questId: string; xpReward: number }>
 ): Promise<void> {
-  // Check if program is live before attempting on-chain calls
-  const programLive = await isOnChainProgramLive();
-  if (!programLive) return;
+  // Reference_id is scoped to the UTC day (matching CURRENT_DATE, which
+  // get_daily_quest_state uses for period_start on the Supabase UTC instance).
+  // Without the day suffix, day-N's enqueue would upsert-collide with a prior
+  // day's already-resolved row and the mint would be silently dropped.
+  const periodKey = new Date().toISOString().slice(0, 10);
 
-  // Resolve the user's wallet address
-  const { data: profile } = await admin
-    .from("profiles")
-    .select("wallet_address")
-    .eq("id", userId)
-    .single();
-
-  if (!profile?.wallet_address) return;
-
-  const wallet = new PublicKey(profile.wallet_address);
-
-  for (const quest of awarded) {
-    const memo = `daily_quest:${quest.questId}`;
-    try {
-      await rewardXp(wallet, quest.xpReward, memo);
-    } catch (err) {
-      logError({
-        errorId: ERROR_IDS.XP_REWARD_FAILED,
-        error: err instanceof Error ? err : new Error(String(err)),
-        context: {
-          handler: "mintQuestXpOnChain",
+  // Enqueue every award; a failed enqueue means the durable intent was NOT
+  // recorded (xp_granted is already true → XP-loss case), so surface it loudly
+  // per-quest rather than letting one failure abort the others.
+  await Promise.all(
+    awarded.map(async (quest) => {
+      try {
+        await queueFailedOnchainAction(
           userId,
-          questId: quest.questId,
-          xpReward: quest.xpReward,
-        },
-      });
-
-      await queueFailedOnchainAction(
-        userId,
-        "quest_xp",
-        quest.questId,
-        {
-          xpAmount: quest.xpReward,
-          memo,
-          walletAddress: profile.wallet_address,
-        },
-        err instanceof Error ? err.message : String(err)
-      );
-    }
-  }
+          "quest_xp",
+          `${quest.questId}:${periodKey}`,
+          { xpAmount: quest.xpReward, memo: `daily_quest:${quest.questId}` }
+        );
+      } catch (err) {
+        logError({
+          errorId: ERROR_IDS.XP_REWARD_FAILED,
+          error: err instanceof Error ? err : new Error(String(err)),
+          context: {
+            handler: "enqueueQuestXpMints",
+            userId,
+            questId: quest.questId,
+            xpReward: quest.xpReward,
+          },
+        });
+      }
+    })
+  );
 }

--- a/apps/web/src/app/api/quests/daily/route.ts
+++ b/apps/web/src/app/api/quests/daily/route.ts
@@ -3,6 +3,7 @@ import type { DailyQuest } from "@superteam-lms/types";
 import { createClient } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { getAllQuests } from "@/lib/sanity/queries";
+import { retryQuestXpForUser } from "@/lib/solana/onchain-queue";
 import { nextMidnightUtc } from "@/lib/gamification/daily-reset";
 
 // Auth/cookie + per-request DB access — never statically prerender (DYNAMIC_SERVER_USAGE).
@@ -114,9 +115,21 @@ export async function GET() {
     // 6. XP delivery is durable by construction: get_daily_quest_state writes
     // the pending_onchain_actions row in the SAME transaction that flips
     // xp_granted=true, so a quest is never marked granted without a durable
-    // pending row. retryPendingOnchainActions() (driven on the user's next auth)
-    // credits it idempotently via award_xp. Nothing to enqueue here — doing it
-    // in the route would leave a window where xp_granted stands without a row.
+    // pending row. Nothing to enqueue here — doing it in the route would leave
+    // a window where xp_granted stands without a row.
+    //
+    // 7. Deliver this user's pending quest_xp credits NOW. The auth-time
+    // retryPendingOnchainActions() only runs on re-auth, so a permanently
+    // logged-in session would otherwise never get its enqueued rows swept.
+    // Idempotent (award_xp keyed on reference_id), DB-only, so awaiting is
+    // cheap. Errors never fail the endpoint — rows stay durable for the next
+    // sweep.
+    try {
+      await retryQuestXpForUser(admin, user.id);
+    } catch (err) {
+      console.error("[api/quests/daily] quest_xp sweep failed:", err);
+    }
+
     return NextResponse.json({
       quests,
       nextResetTime: nextMidnightUtc(),

--- a/apps/web/src/app/api/quests/daily/route.ts
+++ b/apps/web/src/app/api/quests/daily/route.ts
@@ -3,10 +3,7 @@ import type { DailyQuest } from "@superteam-lms/types";
 import { createClient } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { getAllQuests } from "@/lib/sanity/queries";
-import { queueFailedOnchainAction } from "@/lib/solana/onchain-queue";
 import { nextMidnightUtc } from "@/lib/gamification/daily-reset";
-import { logError } from "@/lib/logging";
-import { ERROR_IDS } from "@/constants/errorIds";
 
 // Auth/cookie + per-request DB access — never statically prerender (DYNAMIC_SERVER_USAGE).
 export const dynamic = "force-dynamic";
@@ -114,23 +111,12 @@ export async function GET() {
       };
     });
 
-    // 6. Durably record the on-chain XP mint intent for newly-completed quests.
-    //
-    // get_daily_quest_state already flipped xp_granted=true ("attempt
-    // authorized"), so a dropped mint is PERMANENT XP loss. The mint therefore
-    // must not be fire-and-forget: on Vercel the lambda freezes once the
-    // response returns, killing any un-awaited work. Instead we write the
-    // pending_onchain_actions row SYNCHRONOUSLY (durable) BEFORE responding;
-    // retryPendingOnchainActions() — driven on the user's next auth — performs
-    // the actual on-chain mint (it resolves the wallet and checks program
-    // liveness itself, so no wallet / program-live gating is needed here).
-    const newlyAwarded = progressRows.filter(
-      (r) => r.justAwarded && r.xpReward > 0
-    );
-    if (newlyAwarded.length > 0) {
-      await enqueueQuestXpMints(user.id, newlyAwarded);
-    }
-
+    // 6. XP delivery is durable by construction: get_daily_quest_state writes
+    // the pending_onchain_actions row in the SAME transaction that flips
+    // xp_granted=true, so a quest is never marked granted without a durable
+    // pending row. retryPendingOnchainActions() (driven on the user's next auth)
+    // credits it idempotently via award_xp. Nothing to enqueue here — doing it
+    // in the route would leave a window where xp_granted stands without a row.
     return NextResponse.json({
       quests,
       nextResetTime: nextMidnightUtc(),
@@ -142,46 +128,4 @@ export async function GET() {
       { status: 500 }
     );
   }
-}
-
-// ---------------------------------------------------------------------------
-// Durable enqueue: record quest-XP mint intents for the retry queue
-// ---------------------------------------------------------------------------
-
-async function enqueueQuestXpMints(
-  userId: string,
-  awarded: Array<{ questId: string; xpReward: number }>
-): Promise<void> {
-  // Reference_id is scoped to the UTC day (matching CURRENT_DATE, which
-  // get_daily_quest_state uses for period_start on the Supabase UTC instance).
-  // Without the day suffix, day-N's enqueue would upsert-collide with a prior
-  // day's already-resolved row and the mint would be silently dropped.
-  const periodKey = new Date().toISOString().slice(0, 10);
-
-  // Enqueue every award; a failed enqueue means the durable intent was NOT
-  // recorded (xp_granted is already true → XP-loss case), so surface it loudly
-  // per-quest rather than letting one failure abort the others.
-  await Promise.all(
-    awarded.map(async (quest) => {
-      try {
-        await queueFailedOnchainAction(
-          userId,
-          "quest_xp",
-          `${quest.questId}:${periodKey}`,
-          { xpAmount: quest.xpReward, memo: `daily_quest:${quest.questId}` }
-        );
-      } catch (err) {
-        logError({
-          errorId: ERROR_IDS.XP_REWARD_FAILED,
-          error: err instanceof Error ? err : new Error(String(err)),
-          context: {
-            handler: "enqueueQuestXpMints",
-            userId,
-            questId: quest.questId,
-            xpReward: quest.xpReward,
-          },
-        });
-      }
-    })
-  );
 }

--- a/apps/web/src/lib/solana/onchain-queue.ts
+++ b/apps/web/src/lib/solana/onchain-queue.ts
@@ -56,27 +56,44 @@ export async function queueFailedOnchainAction(
   actionType: OnchainActionType,
   referenceId: string,
   payload: Record<string, unknown>,
-  error: string
+  // Optional. Present → a real failure (records last_error + failed_at).
+  // Absent → a proactive/durable enqueue (row is simply "pending, unattempted").
+  error?: string
 ): Promise<void> {
-  try {
-    const adminClient = createAdminClient();
-    await adminClient.from("pending_onchain_actions").upsert(
+  const adminClient = createAdminClient();
+
+  // supabase-js `.upsert()` RESOLVES with `{ error }` on a constraint
+  // violation instead of throwing — a try/catch never fires. Inspect the
+  // returned error explicitly so a failed enqueue is visible (logged + thrown)
+  // rather than silently dropping a durable on-chain intent.
+  const { error: upsertError } = await adminClient
+    .from("pending_onchain_actions")
+    .upsert(
       {
         user_id: userId,
         action_type: actionType,
         reference_id: referenceId,
         payload: payload as unknown as import("@/lib/supabase/types").Json,
-        last_error: error,
-        failed_at: new Date().toISOString(),
+        last_error: error ?? null,
+        failed_at: error ? new Date().toISOString() : null,
       },
       { onConflict: "user_id,action_type,reference_id" }
     );
-  } catch (err) {
+
+  if (upsertError) {
     logError({
       errorId: ERROR_IDS.LESSON_COMPLETE_FAILED,
-      error: err instanceof Error ? err : new Error(String(err)),
-      context: { userId, actionType, referenceId },
+      error: new Error(upsertError.message),
+      context: {
+        userId,
+        actionType,
+        referenceId,
+        note: "pending_onchain_actions enqueue failed",
+      },
     });
+    throw new Error(
+      `Failed to enqueue ${actionType} action ${referenceId}: ${upsertError.message}`
+    );
   }
 }
 

--- a/apps/web/src/lib/solana/onchain-queue.ts
+++ b/apps/web/src/lib/solana/onchain-queue.ts
@@ -7,17 +7,14 @@ import {
   awardAchievement,
   finalizeCourse,
   issueCredential,
-  rewardXp,
 } from "./academy-program";
 import {
   fetchAchievementReceipt,
   fetchEnrollment,
   fetchCourse,
 } from "./academy-reads";
-import { ERROR_IDS } from "@/constants/errorIds";
-import { createAdminClient } from "@/lib/supabase/admin";
-import { logError } from "@/lib/logging";
 import { getCourseById } from "@/lib/sanity/queries";
+import { createAdminClient } from "@/lib/supabase/admin";
 
 type OnchainActionType =
   | "achievement"
@@ -48,58 +45,13 @@ export async function withRetry<T>(
 }
 
 // ---------------------------------------------------------------------------
-// 2. Queue a failed on-chain action for later retry
+// 2. Retry all pending on-chain actions for a user
 // ---------------------------------------------------------------------------
-
-export async function queueFailedOnchainAction(
-  userId: string,
-  actionType: OnchainActionType,
-  referenceId: string,
-  payload: Record<string, unknown>,
-  // Optional. Present → a real failure (records last_error + failed_at).
-  // Absent → a proactive/durable enqueue (row is simply "pending, unattempted").
-  error?: string
-): Promise<void> {
-  const adminClient = createAdminClient();
-
-  // supabase-js `.upsert()` RESOLVES with `{ error }` on a constraint
-  // violation instead of throwing — a try/catch never fires. Inspect the
-  // returned error explicitly so a failed enqueue is visible (logged + thrown)
-  // rather than silently dropping a durable on-chain intent.
-  const { error: upsertError } = await adminClient
-    .from("pending_onchain_actions")
-    .upsert(
-      {
-        user_id: userId,
-        action_type: actionType,
-        reference_id: referenceId,
-        payload: payload as unknown as import("@/lib/supabase/types").Json,
-        last_error: error ?? null,
-        failed_at: error ? new Date().toISOString() : null,
-      },
-      { onConflict: "user_id,action_type,reference_id" }
-    );
-
-  if (upsertError) {
-    logError({
-      errorId: ERROR_IDS.LESSON_COMPLETE_FAILED,
-      error: new Error(upsertError.message),
-      context: {
-        userId,
-        actionType,
-        referenceId,
-        note: "pending_onchain_actions enqueue failed",
-      },
-    });
-    throw new Error(
-      `Failed to enqueue ${actionType} action ${referenceId}: ${upsertError.message}`
-    );
-  }
-}
-
-// ---------------------------------------------------------------------------
-// 3. Retry all pending on-chain actions for a user
-// ---------------------------------------------------------------------------
+//
+// NOTE: quest_xp rows are enqueued transactionally inside get_daily_quest_state
+// (atomic with the xp_granted flip), NOT via an app-side helper — a quest can
+// never be marked granted without a durable pending row. See the quest_xp case
+// below for how delivery is made idempotent.
 
 export async function retryPendingOnchainActions(
   userId: string
@@ -116,6 +68,45 @@ export async function retryPendingOnchainActions(
 
   if (fetchError || !rows || rows.length === 0) return;
 
+  // ── Pass 1: DB-only quest_xp credits (no wallet required) ──
+  // award_xp credits by user_id, so wallet-less (e.g. Google-only) users still
+  // receive quest XP. The reference_id is the idempotency key, so a re-sweep of
+  // an already-credited row is a no-op (never a double-award).
+  for (const row of rows) {
+    if (row.action_type !== "quest_xp") continue;
+    try {
+      const payload = row.payload as Record<string, unknown>;
+      const xpAmount = payload.xpAmount as number;
+      const reason =
+        (payload.memo as string) ?? `daily_quest:${row.reference_id}`;
+
+      const { error: xpRpcError } = await adminClient.rpc("award_xp", {
+        p_user_id: userId,
+        p_amount: xpAmount,
+        p_reason: reason,
+        p_idempotency_key: row.reference_id,
+      });
+      if (xpRpcError) throw new Error(xpRpcError.message);
+
+      await adminClient
+        .from("pending_onchain_actions")
+        .update({ resolved_at: new Date().toISOString() })
+        .eq("id", row.id);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      await adminClient
+        .from("pending_onchain_actions")
+        .update({
+          retry_count: (row.retry_count ?? 0) + 1,
+          last_error: message,
+        })
+        .eq("id", row.id);
+    }
+  }
+
+  // ── Pass 2: on-chain actions (all require a linked wallet) ──
+  if (!rows.some((r) => r.action_type !== "quest_xp")) return;
+
   const { data: profile } = await adminClient
     .from("profiles")
     .select("wallet_address")
@@ -127,6 +118,7 @@ export async function retryPendingOnchainActions(
   const wallet = new PublicKey(profile.wallet_address);
 
   for (const row of rows) {
+    if (row.action_type === "quest_xp") continue; // handled in Pass 1
     try {
       const actionType = row.action_type as OnchainActionType;
       const payload = row.payload as Record<string, unknown>;
@@ -331,15 +323,6 @@ export async function retryPendingOnchainActions(
             p_idempotency_key: row.reference_id,
           });
           if (xpRpcError) throw new Error(xpRpcError.message);
-          break;
-        }
-
-        case "quest_xp": {
-          const questId = row.reference_id;
-          const xpAmount = payload.xpAmount as number;
-          const memo = (payload.memo as string) ?? `daily_quest:${questId}`;
-
-          await withRetry(() => rewardXp(wallet, xpAmount, memo));
           break;
         }
 

--- a/apps/web/src/lib/solana/onchain-queue.ts
+++ b/apps/web/src/lib/solana/onchain-queue.ts
@@ -15,6 +15,7 @@ import {
 } from "./academy-reads";
 import { getCourseById } from "@/lib/sanity/queries";
 import { createAdminClient } from "@/lib/supabase/admin";
+import type { Database } from "@/lib/supabase/types";
 
 type OnchainActionType =
   | "achievement"
@@ -23,6 +24,10 @@ type OnchainActionType =
   | "xp"
   | "quest_xp"
   | "enroll";
+
+type AdminClient = ReturnType<typeof createAdminClient>;
+type PendingActionRow =
+  Database["public"]["Tables"]["pending_onchain_actions"]["Row"];
 
 // ---------------------------------------------------------------------------
 // 1. Generic retry wrapper
@@ -50,8 +55,11 @@ export async function withRetry<T>(
 //
 // NOTE: quest_xp rows are enqueued transactionally inside get_daily_quest_state
 // (atomic with the xp_granted flip), NOT via an app-side helper — a quest can
-// never be marked granted without a durable pending row. See the quest_xp case
-// below for how delivery is made idempotent.
+// never be marked granted without a durable pending row. Delivery is driven
+// from two places: this full retry on auth, and the narrower
+// retryQuestXpForUser() sweep on every /api/quests/daily GET (so a
+// permanently-logged-in user who never re-auths still gets credited). See
+// creditQuestXpRows() for how delivery is made idempotent.
 
 export async function retryPendingOnchainActions(
   userId: string
@@ -69,40 +77,11 @@ export async function retryPendingOnchainActions(
   if (fetchError || !rows || rows.length === 0) return;
 
   // ── Pass 1: DB-only quest_xp credits (no wallet required) ──
-  // award_xp credits by user_id, so wallet-less (e.g. Google-only) users still
-  // receive quest XP. The reference_id is the idempotency key, so a re-sweep of
-  // an already-credited row is a no-op (never a double-award).
-  for (const row of rows) {
-    if (row.action_type !== "quest_xp") continue;
-    try {
-      const payload = row.payload as Record<string, unknown>;
-      const xpAmount = payload.xpAmount as number;
-      const reason =
-        (payload.memo as string) ?? `daily_quest:${row.reference_id}`;
-
-      const { error: xpRpcError } = await adminClient.rpc("award_xp", {
-        p_user_id: userId,
-        p_amount: xpAmount,
-        p_reason: reason,
-        p_idempotency_key: row.reference_id,
-      });
-      if (xpRpcError) throw new Error(xpRpcError.message);
-
-      await adminClient
-        .from("pending_onchain_actions")
-        .update({ resolved_at: new Date().toISOString() })
-        .eq("id", row.id);
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      await adminClient
-        .from("pending_onchain_actions")
-        .update({
-          retry_count: (row.retry_count ?? 0) + 1,
-          last_error: message,
-        })
-        .eq("id", row.id);
-    }
-  }
+  await creditQuestXpRows(
+    adminClient,
+    userId,
+    rows.filter((row) => row.action_type === "quest_xp")
+  );
 
   // ── Pass 2: on-chain actions (all require a linked wallet) ──
   if (!rows.some((r) => r.action_type !== "quest_xp")) return;
@@ -378,6 +357,96 @@ export async function retryPendingOnchainActions(
         .from("pending_onchain_actions")
         .update({ resolved_at: new Date().toISOString() })
         .eq("id", row.id);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      await adminClient
+        .from("pending_onchain_actions")
+        .update({
+          retry_count: (row.retry_count ?? 0) + 1,
+          last_error: message,
+        })
+        .eq("id", row.id);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 3. Narrow sweep: deliver this user's pending quest_xp credits (DB-only)
+// ---------------------------------------------------------------------------
+// Called from the /api/quests/daily GET after get_daily_quest_state succeeds,
+// so quest XP lands without waiting for the user's next re-auth (which a
+// long-lived session may never hit). No chain calls — fast enough to await.
+
+export async function retryQuestXpForUser(
+  adminClient: AdminClient,
+  userId: string
+): Promise<void> {
+  const { data: rows, error: fetchError } = await adminClient
+    .from("pending_onchain_actions")
+    .select("*")
+    .eq("user_id", userId)
+    .eq("action_type", "quest_xp")
+    .is("resolved_at", null)
+    .lt("retry_count", 5);
+
+  if (fetchError || !rows || rows.length === 0) return;
+
+  await creditQuestXpRows(adminClient, userId, rows);
+}
+
+// award_xp credits by user_id, so wallet-less (e.g. Google-only) users still
+// receive quest XP. The reference_id is the idempotency key, so a re-sweep of
+// an already-credited row is a no-op (never a double-award). A row is only
+// resolved when award_xp reports a credited amount > 0 — a credit fully eaten
+// by the 5000/day cap stays unresolved (without burning a retry) and is
+// re-swept once the cap window resets.
+async function creditQuestXpRows(
+  adminClient: AdminClient,
+  userId: string,
+  rows: PendingActionRow[]
+): Promise<void> {
+  for (const row of rows) {
+    try {
+      const payload = row.payload as Record<string, unknown>;
+      const xpAmount = payload.xpAmount;
+      if (
+        typeof xpAmount !== "number" ||
+        !Number.isFinite(xpAmount) ||
+        xpAmount <= 0
+      ) {
+        throw new Error(
+          `Invalid quest_xp payload: xpAmount=${JSON.stringify(xpAmount)}`
+        );
+      }
+      const reason =
+        typeof payload.memo === "string"
+          ? payload.memo
+          : `daily_quest:${row.reference_id}`;
+
+      const { data: credited, error: xpRpcError } = await adminClient.rpc(
+        "award_xp",
+        {
+          p_user_id: userId,
+          p_amount: xpAmount,
+          p_reason: reason,
+          p_idempotency_key: row.reference_id,
+        }
+      );
+      if (xpRpcError) throw new Error(xpRpcError.message);
+
+      if ((credited ?? 0) > 0) {
+        await adminClient
+          .from("pending_onchain_actions")
+          .update({ resolved_at: new Date().toISOString() })
+          .eq("id", row.id);
+      } else {
+        // Daily cap consumed the whole credit — deferral, not failure: keep
+        // the row unresolved and do NOT increment retry_count.
+        await adminClient
+          .from("pending_onchain_actions")
+          .update({ last_error: "daily-cap-deferred" })
+          .eq("id", row.id);
+      }
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       await adminClient

--- a/apps/web/src/lib/supabase/types.ts
+++ b/apps/web/src/lib/supabase/types.ts
@@ -914,7 +914,7 @@ export type Database = {
           p_tx_signature?: string;
           p_user_id: string;
         };
-        Returns: undefined;
+        Returns: number;
       };
       create_thread: {
         Args: {

--- a/supabase/migrations/20260709120000_quest_xp_durable_delivery.sql
+++ b/supabase/migrations/20260709120000_quest_xp_durable_delivery.sql
@@ -1,0 +1,465 @@
+-- ============================================================================
+-- Migration: quest_xp durable delivery + get_daily_quest_state hardening
+-- Task: CS-7 (#353)  [priority:P0][area:db]
+-- ----------------------------------------------------------------------------
+-- APPLY TO PROD ONLY AFTER THE PR MERGES. Do NOT run against any live database
+-- before merge — application is performed post-merge by the orchestrator.
+--
+-- What this does:
+--   1. Allows 'quest_xp' in pending_onchain_actions.action_type so the daily
+--      quest route can durably enqueue on-chain XP mints (previously the
+--      inline CHECK rejected it and the write was silently dropped).
+--   2. Hardens get_daily_quest_state():
+--        (a) completion now requires targetValue > 0 (a 0-target quest can no
+--            longer auto-complete every day and mint free XP);
+--        (b) an unknown quest type raises instead of silently rendering 0/N.
+--      The login_streak state machine is unchanged.
+--
+-- Idempotent: the CHECK change looks up and drops the existing constraint by
+-- name (whatever Postgres auto-generated it as) then re-adds a named one; the
+-- function is CREATE OR REPLACE. Safe to re-run.
+--
+-- ── ROLLBACK (tested — restores the pre-migration state) ────────────────────
+-- Run the block at the very bottom of this file (kept commented). It restores
+-- the original CHECK set (without 'quest_xp') and the prior function body.
+-- ============================================================================
+
+-- ── 1. pending_onchain_actions.action_type: allow 'quest_xp' ─────────────────
+-- The baseline created this as an inline, unnamed column CHECK. Look up its
+-- generated name dynamically (rather than assuming it) and drop it, then re-add
+-- a NAMED constraint so future migrations/rollbacks have a stable handle.
+DO $$
+DECLARE
+  v_conname text;
+BEGIN
+  SELECT conname
+    INTO v_conname
+  FROM pg_constraint
+  WHERE conrelid = 'public.pending_onchain_actions'::regclass
+    AND contype = 'c'
+    AND pg_get_constraintdef(oid) ILIKE '%action_type%';
+
+  IF v_conname IS NOT NULL THEN
+    EXECUTE format(
+      'ALTER TABLE public.pending_onchain_actions DROP CONSTRAINT %I',
+      v_conname
+    );
+  END IF;
+END $$;
+
+ALTER TABLE public.pending_onchain_actions
+  ADD CONSTRAINT pending_onchain_actions_action_type_check
+  CHECK (action_type IN ('achievement', 'certificate', 'course_finalize', 'xp', 'quest_xp', 'enroll'));
+
+-- ── 2. get_daily_quest_state: targetValue>0 guard + unknown-type RAISE ───────
+CREATE OR REPLACE FUNCTION get_daily_quest_state(
+  p_user_id           UUID,
+  p_quest_definitions JSONB,
+  p_challenge_ids     TEXT[],
+  p_module_lesson_map JSONB
+) RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_quest        JSONB;
+  v_quest_id     TEXT;
+  v_type         TEXT;
+  v_target       INTEGER;
+  v_xp           INTEGER;
+  v_reset_type   TEXT;
+  v_current      INTEGER;
+  v_period       DATE;
+  v_existing     RECORD;
+  v_results      JSONB := '[]'::JSONB;
+  v_mod          JSONB;
+  v_mod_lessons  TEXT[];
+  v_all_done     BOOLEAN;
+  v_max_date     DATE;
+  v_just_awarded BOOLEAN;
+  v_completed    BOOLEAN;
+BEGIN
+  FOR v_quest IN SELECT * FROM jsonb_array_elements(p_quest_definitions)
+  LOOP
+    v_quest_id   := v_quest->>'id';
+    v_type       := v_quest->>'type';
+    v_target     := (v_quest->>'targetValue')::INTEGER;
+    v_xp         := (v_quest->>'xpReward')::INTEGER;
+    v_reset_type := v_quest->>'resetType';
+    v_current    := 0;
+    v_just_awarded := false;
+
+    -- ── Calculate current_value per quest type ──
+    IF v_type = 'lesson' OR v_type = 'lesson_batch' THEN
+      SELECT COUNT(*)::INTEGER INTO v_current
+      FROM public.user_progress
+      WHERE user_id = p_user_id
+        AND completed = true
+        AND completed_at::date = CURRENT_DATE;
+
+    ELSIF v_type = 'challenge' THEN
+      SELECT COUNT(*)::INTEGER INTO v_current
+      FROM public.user_progress
+      WHERE user_id = p_user_id
+        AND completed = true
+        AND completed_at::date = CURRENT_DATE
+        AND lesson_id = ANY(p_challenge_ids);
+
+    ELSIF v_type = 'login_streak' THEN
+      -- Dashboard load = login signal.
+      -- Find the most recent active (non-completed) streak row for this quest.
+      SELECT * INTO v_existing
+      FROM public.user_daily_quests
+      WHERE user_id = p_user_id
+        AND quest_id = v_quest_id
+        AND completed = false
+      ORDER BY period_start DESC
+      LIMIT 1;
+
+      -- Three-case state machine for login streaks.
+      -- Let diff = CURRENT_DATE - period_start (days since streak started).
+      --
+      -- Walkthrough (target = 3):
+      --   Day 1 created:       period_start=D1, current_value=1, diff=0
+      --   Day 1 reload:        diff=0, cv=1 → diff = cv-1 (0=0) → no-op ✓
+      --   Day 2 first load:    diff=1, cv=1 → diff = cv   (1=1) → increment to 2 ✓
+      --   Day 2 reload:        diff=1, cv=2 → diff = cv-1 (1=1) → no-op ✓
+      --   Day 3 first load:    diff=2, cv=2 → diff = cv   (2=2) → increment to 3 → COMPLETE ✓
+      --   Day 5 (skipped D4):  diff=4, cv=3 → diff > cv   (4>3) → gap, start new ✓
+
+      IF v_existing IS NULL THEN
+        -- Case 0: No active streak row — start fresh
+        v_current := 1;
+        v_period  := CURRENT_DATE;
+
+      ELSIF (CURRENT_DATE - v_existing.period_start)::INTEGER = v_existing.current_value - 1 THEN
+        -- Case 1: Already counted today (idempotent reload) — no-op
+        -- diff = cv-1 means today is the same day as the last increment
+        v_current := v_existing.current_value;
+        v_period  := v_existing.period_start;
+
+      ELSIF (CURRENT_DATE - v_existing.period_start)::INTEGER = v_existing.current_value THEN
+        -- Case 2: Unbroken streak, new day — increment
+        -- diff = cv means yesterday was the last counted day
+        v_current := v_existing.current_value + 1;
+        v_period  := v_existing.period_start;
+
+      ELSE
+        -- Case 3: diff > cv — gap detected, streak broken, start new
+        v_current := 1;
+        v_period  := CURRENT_DATE;
+      END IF;
+
+      -- Completion requires a positive target: a targetValue of 0 must NOT
+      -- auto-complete (that would mint free XP every day for a 0-target quest).
+      v_completed := v_target > 0 AND v_current >= v_target;
+
+      -- Upsert the streak row and skip the generic upsert below
+      INSERT INTO public.user_daily_quests (user_id, quest_id, current_value, completed, completed_at, xp_granted, period_start)
+      VALUES (p_user_id, v_quest_id, v_current, v_completed, CASE WHEN v_completed THEN NOW() ELSE NULL END, false, v_period)
+      ON CONFLICT (user_id, quest_id, period_start) DO UPDATE SET
+        current_value = EXCLUDED.current_value,
+        completed     = EXCLUDED.completed,
+        completed_at  = EXCLUDED.completed_at;
+
+      -- Mark xp_granted on first completion (API route mints on-chain)
+      IF v_completed THEN
+        UPDATE public.user_daily_quests
+        SET xp_granted = true
+        WHERE user_id = p_user_id AND quest_id = v_quest_id AND period_start = v_period AND xp_granted = false;
+
+        IF FOUND THEN
+          v_just_awarded := true;
+        END IF;
+      END IF;
+
+      v_results := v_results || jsonb_build_object(
+        'questId', v_quest_id,
+        'currentValue', v_current,
+        'completed', v_completed,
+        'justAwarded', v_just_awarded,
+        'xpReward', v_xp
+      );
+      CONTINUE;  -- Skip generic upsert
+
+    ELSIF v_type = 'module' THEN
+      -- Check if ALL lessons in ANY module are completed AND the last one was completed today
+      v_current := 0;
+      FOR v_mod IN SELECT * FROM jsonb_array_elements(p_module_lesson_map)
+      LOOP
+        v_mod_lessons := ARRAY(SELECT jsonb_array_elements_text(v_mod->'lessonIds'));
+        IF array_length(v_mod_lessons, 1) IS NULL OR array_length(v_mod_lessons, 1) = 0 THEN
+          CONTINUE;
+        END IF;
+
+        -- Check all lessons completed
+        SELECT COUNT(*) = array_length(v_mod_lessons, 1) INTO v_all_done
+        FROM public.user_progress
+        WHERE user_id = p_user_id
+          AND completed = true
+          AND lesson_id = ANY(v_mod_lessons);
+
+        IF v_all_done THEN
+          -- Check if the most recent completion in this module was today
+          SELECT MAX(completed_at::date) INTO v_max_date
+          FROM public.user_progress
+          WHERE user_id = p_user_id
+            AND completed = true
+            AND lesson_id = ANY(v_mod_lessons);
+
+          IF v_max_date = CURRENT_DATE THEN
+            v_current := 1;
+            EXIT;  -- One completed module is enough
+          END IF;
+        END IF;
+      END LOOP;
+
+    ELSE
+      -- Unknown quest type: fail loudly rather than silently rendering 0/N
+      -- (a mis-typed quest definition should never quietly evaluate to 0).
+      RAISE EXCEPTION 'get_daily_quest_state: unknown quest type: %', v_type;
+    END IF;
+
+    -- ── Generic daily quest upsert (lesson, lesson_batch, challenge, module) ──
+    v_period := CURRENT_DATE;
+
+    -- Completion requires a positive target: a targetValue of 0 must NOT
+    -- auto-complete (that would mint free XP every day for a 0-target quest).
+    v_completed := v_target > 0 AND v_current >= v_target;
+
+    INSERT INTO public.user_daily_quests (user_id, quest_id, current_value, completed, completed_at, xp_granted, period_start)
+    VALUES (p_user_id, v_quest_id, v_current, v_completed, CASE WHEN v_completed THEN NOW() ELSE NULL END, false, v_period)
+    ON CONFLICT (user_id, quest_id, period_start) DO UPDATE SET
+      current_value = EXCLUDED.current_value,
+      completed     = EXCLUDED.completed,
+      completed_at  = COALESCE(user_daily_quests.completed_at, EXCLUDED.completed_at);
+
+    -- Mark xp_granted on first completion (API route mints on-chain)
+    IF v_completed THEN
+      UPDATE public.user_daily_quests
+      SET xp_granted = true
+      WHERE user_id = p_user_id AND quest_id = v_quest_id AND period_start = v_period AND xp_granted = false;
+
+      IF FOUND THEN
+        v_just_awarded := true;
+      END IF;
+    END IF;
+
+    v_results := v_results || jsonb_build_object(
+      'questId', v_quest_id,
+      'currentValue', v_current,
+      'completed', v_completed,
+      'justAwarded', v_just_awarded,
+      'xpReward', v_xp
+    );
+  END LOOP;
+
+  RETURN v_results;
+END;
+$$;
+
+-- Re-assert the function's privileges (SECURITY DEFINER — must never be
+-- executable by untrusted roles; only service_role calls it).
+REVOKE EXECUTE ON FUNCTION get_daily_quest_state FROM authenticated, anon, public;
+GRANT EXECUTE ON FUNCTION get_daily_quest_state TO service_role;
+
+-- ============================================================================
+-- ROLLBACK (tested) — restores the exact pre-migration state.
+-- Run the following block to revert this migration:
+-- ----------------------------------------------------------------------------
+-- BEGIN;
+--
+-- -- Restore the original CHECK set (drops 'quest_xp'). NOTE: any rows already
+-- -- written with action_type='quest_xp' must be resolved/removed first or the
+-- -- ADD CONSTRAINT will fail its validation scan:
+-- --   DELETE FROM public.pending_onchain_actions WHERE action_type = 'quest_xp';
+-- DO $$
+-- DECLARE
+--   v_conname text;
+-- BEGIN
+--   SELECT conname
+--     INTO v_conname
+--   FROM pg_constraint
+--   WHERE conrelid = 'public.pending_onchain_actions'::regclass
+--     AND contype = 'c'
+--     AND pg_get_constraintdef(oid) ILIKE '%action_type%';
+--   IF v_conname IS NOT NULL THEN
+--     EXECUTE format(
+--       'ALTER TABLE public.pending_onchain_actions DROP CONSTRAINT %I',
+--       v_conname
+--     );
+--   END IF;
+-- END $$;
+--
+-- ALTER TABLE public.pending_onchain_actions
+--   ADD CONSTRAINT pending_onchain_actions_action_type_check
+--   CHECK (action_type IN ('achievement', 'certificate', 'course_finalize', 'xp', 'enroll'));
+--
+-- -- Restore the prior function body (no targetValue guard, no unknown-type RAISE).
+-- CREATE OR REPLACE FUNCTION get_daily_quest_state(
+--   p_user_id           UUID,
+--   p_quest_definitions JSONB,
+--   p_challenge_ids     TEXT[],
+--   p_module_lesson_map JSONB
+-- ) RETURNS JSONB
+-- LANGUAGE plpgsql
+-- SECURITY DEFINER
+-- SET search_path = ''
+-- AS $$
+-- DECLARE
+--   v_quest        JSONB;
+--   v_quest_id     TEXT;
+--   v_type         TEXT;
+--   v_target       INTEGER;
+--   v_xp           INTEGER;
+--   v_reset_type   TEXT;
+--   v_current      INTEGER;
+--   v_period       DATE;
+--   v_existing     RECORD;
+--   v_results      JSONB := '[]'::JSONB;
+--   v_mod          JSONB;
+--   v_mod_lessons  TEXT[];
+--   v_all_done     BOOLEAN;
+--   v_max_date     DATE;
+--   v_just_awarded BOOLEAN;
+-- BEGIN
+--   FOR v_quest IN SELECT * FROM jsonb_array_elements(p_quest_definitions)
+--   LOOP
+--     v_quest_id   := v_quest->>'id';
+--     v_type       := v_quest->>'type';
+--     v_target     := (v_quest->>'targetValue')::INTEGER;
+--     v_xp         := (v_quest->>'xpReward')::INTEGER;
+--     v_reset_type := v_quest->>'resetType';
+--     v_current    := 0;
+--     v_just_awarded := false;
+--
+--     IF v_type = 'lesson' OR v_type = 'lesson_batch' THEN
+--       SELECT COUNT(*)::INTEGER INTO v_current
+--       FROM public.user_progress
+--       WHERE user_id = p_user_id
+--         AND completed = true
+--         AND completed_at::date = CURRENT_DATE;
+--
+--     ELSIF v_type = 'challenge' THEN
+--       SELECT COUNT(*)::INTEGER INTO v_current
+--       FROM public.user_progress
+--       WHERE user_id = p_user_id
+--         AND completed = true
+--         AND completed_at::date = CURRENT_DATE
+--         AND lesson_id = ANY(p_challenge_ids);
+--
+--     ELSIF v_type = 'login_streak' THEN
+--       SELECT * INTO v_existing
+--       FROM public.user_daily_quests
+--       WHERE user_id = p_user_id
+--         AND quest_id = v_quest_id
+--         AND completed = false
+--       ORDER BY period_start DESC
+--       LIMIT 1;
+--
+--       IF v_existing IS NULL THEN
+--         v_current := 1;
+--         v_period  := CURRENT_DATE;
+--       ELSIF (CURRENT_DATE - v_existing.period_start)::INTEGER = v_existing.current_value - 1 THEN
+--         v_current := v_existing.current_value;
+--         v_period  := v_existing.period_start;
+--       ELSIF (CURRENT_DATE - v_existing.period_start)::INTEGER = v_existing.current_value THEN
+--         v_current := v_existing.current_value + 1;
+--         v_period  := v_existing.period_start;
+--       ELSE
+--         v_current := 1;
+--         v_period  := CURRENT_DATE;
+--       END IF;
+--
+--       INSERT INTO public.user_daily_quests (user_id, quest_id, current_value, completed, completed_at, xp_granted, period_start)
+--       VALUES (p_user_id, v_quest_id, v_current, v_current >= v_target, CASE WHEN v_current >= v_target THEN NOW() ELSE NULL END, false, v_period)
+--       ON CONFLICT (user_id, quest_id, period_start) DO UPDATE SET
+--         current_value = EXCLUDED.current_value,
+--         completed     = EXCLUDED.completed,
+--         completed_at  = EXCLUDED.completed_at;
+--
+--       IF v_current >= v_target THEN
+--         UPDATE public.user_daily_quests
+--         SET xp_granted = true
+--         WHERE user_id = p_user_id AND quest_id = v_quest_id AND period_start = v_period AND xp_granted = false;
+--         IF FOUND THEN
+--           v_just_awarded := true;
+--         END IF;
+--       END IF;
+--
+--       v_results := v_results || jsonb_build_object(
+--         'questId', v_quest_id,
+--         'currentValue', v_current,
+--         'completed', v_current >= v_target,
+--         'justAwarded', v_just_awarded,
+--         'xpReward', v_xp
+--       );
+--       CONTINUE;
+--
+--     ELSIF v_type = 'module' THEN
+--       v_current := 0;
+--       FOR v_mod IN SELECT * FROM jsonb_array_elements(p_module_lesson_map)
+--       LOOP
+--         v_mod_lessons := ARRAY(SELECT jsonb_array_elements_text(v_mod->'lessonIds'));
+--         IF array_length(v_mod_lessons, 1) IS NULL OR array_length(v_mod_lessons, 1) = 0 THEN
+--           CONTINUE;
+--         END IF;
+--
+--         SELECT COUNT(*) = array_length(v_mod_lessons, 1) INTO v_all_done
+--         FROM public.user_progress
+--         WHERE user_id = p_user_id
+--           AND completed = true
+--           AND lesson_id = ANY(v_mod_lessons);
+--
+--         IF v_all_done THEN
+--           SELECT MAX(completed_at::date) INTO v_max_date
+--           FROM public.user_progress
+--           WHERE user_id = p_user_id
+--             AND completed = true
+--             AND lesson_id = ANY(v_mod_lessons);
+--
+--           IF v_max_date = CURRENT_DATE THEN
+--             v_current := 1;
+--             EXIT;
+--           END IF;
+--         END IF;
+--       END LOOP;
+--     END IF;
+--
+--     v_period := CURRENT_DATE;
+--
+--     INSERT INTO public.user_daily_quests (user_id, quest_id, current_value, completed, completed_at, xp_granted, period_start)
+--     VALUES (p_user_id, v_quest_id, v_current, v_current >= v_target, CASE WHEN v_current >= v_target THEN NOW() ELSE NULL END, false, v_period)
+--     ON CONFLICT (user_id, quest_id, period_start) DO UPDATE SET
+--       current_value = EXCLUDED.current_value,
+--       completed     = EXCLUDED.completed,
+--       completed_at  = COALESCE(user_daily_quests.completed_at, EXCLUDED.completed_at);
+--
+--     IF v_current >= v_target THEN
+--       UPDATE public.user_daily_quests
+--       SET xp_granted = true
+--       WHERE user_id = p_user_id AND quest_id = v_quest_id AND period_start = v_period AND xp_granted = false;
+--       IF FOUND THEN
+--         v_just_awarded := true;
+--       END IF;
+--     END IF;
+--
+--     v_results := v_results || jsonb_build_object(
+--       'questId', v_quest_id,
+--       'currentValue', v_current,
+--       'completed', v_current >= v_target,
+--       'justAwarded', v_just_awarded,
+--       'xpReward', v_xp
+--     );
+--   END LOOP;
+--
+--   RETURN v_results;
+-- END;
+-- $$;
+--
+-- REVOKE EXECUTE ON FUNCTION get_daily_quest_state FROM authenticated, anon, public;
+-- GRANT EXECUTE ON FUNCTION get_daily_quest_state TO service_role;
+--
+-- COMMIT;
+-- ============================================================================

--- a/supabase/migrations/20260709120000_quest_xp_durable_delivery.sql
+++ b/supabase/migrations/20260709120000_quest_xp_durable_delivery.sql
@@ -2,26 +2,42 @@
 -- Migration: quest_xp durable delivery + get_daily_quest_state hardening
 -- Task: CS-7 (#353)  [priority:P0][area:db]
 -- ----------------------------------------------------------------------------
--- APPLY TO PROD ONLY AFTER THE PR MERGES. Do NOT run against any live database
--- before merge — application is performed post-merge by the orchestrator.
+-- ⚠️  MERGE-ORDER REQUIREMENT — APPLY THIS MIGRATION BEFORE (OR ATOMICALLY WITH)
+--     THE CODE DEPLOY. NEVER AFTER.
+--
+--     prod (superteam-academy-web.vercel.app) auto-deploys from `main` the
+--     instant this PR merges. The daily-quest code path depends on the new
+--     get_daily_quest_state below, which enqueues action_type='quest_xp' rows —
+--     legal only once the CHECK in step 1 exists. If the code went live first
+--     (old function still in the DB), every quest completion would flip
+--     xp_granted=true WITHOUT enqueuing a delivery row → permanent silent XP
+--     loss for the whole merge→apply window. So the orchestrator MUST:
+--       1. apply this migration to prod, THEN
+--       2. merge the PR (which triggers the code deploy).
 --
 -- What this does:
---   1. Allows 'quest_xp' in pending_onchain_actions.action_type so the daily
---      quest route can durably enqueue on-chain XP mints (previously the
---      inline CHECK rejected it and the write was silently dropped).
---   2. Hardens get_daily_quest_state():
---        (a) completion now requires targetValue > 0 (a 0-target quest can no
---            longer auto-complete every day and mint free XP);
---        (b) an unknown quest type raises instead of silently rendering 0/N.
---      The login_streak state machine is unchanged.
+--   1. Allows 'quest_xp' in pending_onchain_actions.action_type.
+--   2. Replaces get_daily_quest_state():
+--        (a) completion requires targetValue > 0 (a 0-target quest can no longer
+--            auto-complete every day and mint free XP);
+--        (b) on first completion it enqueues the quest_xp delivery row IN THE
+--            SAME TRANSACTION as the xp_granted flip (atomic durability — the
+--            row can never be lost to a swallowed app-side error);
+--        (c) an unknown quest type is skipped with a server-log WARNING instead
+--            of RAISE-ing (one CMS typo must not 500 the endpoint for everyone).
+--      The login_streak state machine is otherwise unchanged.
+--
+-- Delivery: retryPendingOnchainActions() credits quest_xp idempotently via
+-- award_xp (reference_id = idempotency key). It is NOT minted on-chain from the
+-- retry path — rewardXp is non-idempotent and a confirmation-timeout retry would
+-- double-mint permanent soulbound XP.
 --
 -- Idempotent: the CHECK change looks up and drops the existing constraint by
--- name (whatever Postgres auto-generated it as) then re-adds a named one; the
--- function is CREATE OR REPLACE. Safe to re-run.
+-- name then re-adds a named one; the function is CREATE OR REPLACE. Safe to
+-- re-run.
 --
 -- ── ROLLBACK (tested — restores the pre-migration state) ────────────────────
--- Run the block at the very bottom of this file (kept commented). It restores
--- the original CHECK set (without 'quest_xp') and the prior function body.
+-- See the ROLLBACK block at the very bottom of this file.
 -- ============================================================================
 
 -- ── 1. pending_onchain_actions.action_type: allow 'quest_xp' ─────────────────
@@ -51,7 +67,8 @@ ALTER TABLE public.pending_onchain_actions
   ADD CONSTRAINT pending_onchain_actions_action_type_check
   CHECK (action_type IN ('achievement', 'certificate', 'course_finalize', 'xp', 'quest_xp', 'enroll'));
 
--- ── 2. get_daily_quest_state: targetValue>0 guard + unknown-type RAISE ───────
+-- ── 2. get_daily_quest_state: targetValue>0 guard, transactional quest_xp
+--       enqueue, and skip-with-warning on unknown quest type ─────────────────
 CREATE OR REPLACE FUNCTION get_daily_quest_state(
   p_user_id           UUID,
   p_quest_definitions JSONB,
@@ -163,7 +180,11 @@ BEGIN
         completed     = EXCLUDED.completed,
         completed_at  = EXCLUDED.completed_at;
 
-      -- Mark xp_granted on first completion (API route mints on-chain)
+      -- Mark xp_granted on first completion and durably enqueue the XP credit
+      -- in the SAME transaction (atomic with the flip): a quest is never marked
+      -- granted without a pending_onchain_actions row, so the enqueue can never
+      -- be lost to a swallowed app-side error. retryPendingOnchainActions()
+      -- delivers it idempotently via award_xp (reference_id = idempotency key).
       IF v_completed THEN
         UPDATE public.user_daily_quests
         SET xp_granted = true
@@ -171,6 +192,14 @@ BEGIN
 
         IF FOUND THEN
           v_just_awarded := true;
+          INSERT INTO public.pending_onchain_actions (user_id, action_type, reference_id, payload)
+          VALUES (
+            p_user_id,
+            'quest_xp',
+            v_quest_id || ':' || v_period::text,
+            jsonb_build_object('xpAmount', v_xp, 'memo', 'daily_quest:' || v_quest_id)
+          )
+          ON CONFLICT (user_id, action_type, reference_id) DO NOTHING;
         END IF;
       END IF;
 
@@ -216,9 +245,14 @@ BEGIN
       END LOOP;
 
     ELSE
-      -- Unknown quest type: fail loudly rather than silently rendering 0/N
-      -- (a mis-typed quest definition should never quietly evaluate to 0).
-      RAISE EXCEPTION 'get_daily_quest_state: unknown quest type: %', v_type;
+      -- Unknown quest type (e.g. a CMS typo). Skip this ONE quest with a loud
+      -- server-log warning rather than RAISE-ing — a single mis-typed quest
+      -- definition must not 500 the whole daily-quests endpoint for every user
+      -- (and, now that the enqueue is transactional, roll back other quests'
+      -- durable XP rows in the same call). It is not rendered as a silent 0/N:
+      -- it is omitted from the result and flagged in the logs for the operator.
+      RAISE WARNING 'get_daily_quest_state: skipping unknown quest type: %', v_type;
+      CONTINUE;
     END IF;
 
     -- ── Generic daily quest upsert (lesson, lesson_batch, challenge, module) ──
@@ -235,7 +269,8 @@ BEGIN
       completed     = EXCLUDED.completed,
       completed_at  = COALESCE(user_daily_quests.completed_at, EXCLUDED.completed_at);
 
-    -- Mark xp_granted on first completion (API route mints on-chain)
+    -- Mark xp_granted on first completion and durably enqueue the XP credit in
+    -- the SAME transaction (atomic with the flip) — see the login_streak branch.
     IF v_completed THEN
       UPDATE public.user_daily_quests
       SET xp_granted = true
@@ -243,6 +278,14 @@ BEGIN
 
       IF FOUND THEN
         v_just_awarded := true;
+        INSERT INTO public.pending_onchain_actions (user_id, action_type, reference_id, payload)
+        VALUES (
+          p_user_id,
+          'quest_xp',
+          v_quest_id || ':' || v_period::text,
+          jsonb_build_object('xpAmount', v_xp, 'memo', 'daily_quest:' || v_quest_id)
+        )
+        ON CONFLICT (user_id, action_type, reference_id) DO NOTHING;
       END IF;
     END IF;
 
@@ -259,21 +302,25 @@ BEGIN
 END;
 $$;
 
--- Re-assert the function's privileges (SECURITY DEFINER — must never be
--- executable by untrusted roles; only service_role calls it).
 REVOKE EXECUTE ON FUNCTION get_daily_quest_state FROM authenticated, anon, public;
 GRANT EXECUTE ON FUNCTION get_daily_quest_state TO service_role;
 
 -- ============================================================================
--- ROLLBACK (tested) — restores the exact pre-migration state.
--- Run the following block to revert this migration:
--- ----------------------------------------------------------------------------
--- BEGIN;
+-- ROLLBACK (tested) — restores the exact pre-migration prod state
+-- (original CHECK set without 'quest_xp', and the original function body with
+-- no targetValue guard, no transactional enqueue, and no unknown-type handling).
 --
--- -- Restore the original CHECK set (drops 'quest_xp'). NOTE: any rows already
--- -- written with action_type='quest_xp' must be resolved/removed first or the
--- -- ADD CONSTRAINT will fail its validation scan:
--- --   DELETE FROM public.pending_onchain_actions WHERE action_type = 'quest_xp';
+-- ⚠️  REQUIRED FIRST STEP — the constraint no longer permits 'quest_xp', so any
+--     quest_xp rows written while the migration was live MUST be removed before
+--     re-adding the narrower CHECK, or ADD CONSTRAINT fails its validation scan.
+--     This is a real, executable step of the rollback — do NOT skip it:
+--
+--       DELETE FROM public.pending_onchain_actions WHERE action_type = 'quest_xp';
+--
+-- Then run the remainder of this block:
+-- ----------------------------------------------------------------------------
+-- DELETE FROM public.pending_onchain_actions WHERE action_type = 'quest_xp';
+--
 -- DO $$
 -- DECLARE
 --   v_conname text;
@@ -296,7 +343,7 @@ GRANT EXECUTE ON FUNCTION get_daily_quest_state TO service_role;
 --   ADD CONSTRAINT pending_onchain_actions_action_type_check
 --   CHECK (action_type IN ('achievement', 'certificate', 'course_finalize', 'xp', 'enroll'));
 --
--- -- Restore the prior function body (no targetValue guard, no unknown-type RAISE).
+-- -- Restore the original function body (verbatim from pre-migration main):
 -- CREATE OR REPLACE FUNCTION get_daily_quest_state(
 --   p_user_id           UUID,
 --   p_quest_definitions JSONB,
@@ -333,14 +380,15 @@ GRANT EXECUTE ON FUNCTION get_daily_quest_state TO service_role;
 --     v_reset_type := v_quest->>'resetType';
 --     v_current    := 0;
 --     v_just_awarded := false;
---
+-- 
+--     -- ── Calculate current_value per quest type ──
 --     IF v_type = 'lesson' OR v_type = 'lesson_batch' THEN
 --       SELECT COUNT(*)::INTEGER INTO v_current
 --       FROM public.user_progress
 --       WHERE user_id = p_user_id
 --         AND completed = true
 --         AND completed_at::date = CURRENT_DATE;
---
+-- 
 --     ELSIF v_type = 'challenge' THEN
 --       SELECT COUNT(*)::INTEGER INTO v_current
 --       FROM public.user_progress
@@ -348,8 +396,10 @@ GRANT EXECUTE ON FUNCTION get_daily_quest_state TO service_role;
 --         AND completed = true
 --         AND completed_at::date = CURRENT_DATE
 --         AND lesson_id = ANY(p_challenge_ids);
---
+-- 
 --     ELSIF v_type = 'login_streak' THEN
+--       -- Dashboard load = login signal.
+--       -- Find the most recent active (non-completed) streak row for this quest.
 --       SELECT * INTO v_existing
 --       FROM public.user_daily_quests
 --       WHERE user_id = p_user_id
@@ -357,37 +407,60 @@ GRANT EXECUTE ON FUNCTION get_daily_quest_state TO service_role;
 --         AND completed = false
 --       ORDER BY period_start DESC
 --       LIMIT 1;
---
+-- 
+--       -- Three-case state machine for login streaks.
+--       -- Let diff = CURRENT_DATE - period_start (days since streak started).
+--       --
+--       -- Walkthrough (target = 3):
+--       --   Day 1 created:       period_start=D1, current_value=1, diff=0
+--       --   Day 1 reload:        diff=0, cv=1 → diff = cv-1 (0=0) → no-op ✓
+--       --   Day 2 first load:    diff=1, cv=1 → diff = cv   (1=1) → increment to 2 ✓
+--       --   Day 2 reload:        diff=1, cv=2 → diff = cv-1 (1=1) → no-op ✓
+--       --   Day 3 first load:    diff=2, cv=2 → diff = cv   (2=2) → increment to 3 → COMPLETE ✓
+--       --   Day 5 (skipped D4):  diff=4, cv=3 → diff > cv   (4>3) → gap, start new ✓
+-- 
 --       IF v_existing IS NULL THEN
+--         -- Case 0: No active streak row — start fresh
 --         v_current := 1;
 --         v_period  := CURRENT_DATE;
+-- 
 --       ELSIF (CURRENT_DATE - v_existing.period_start)::INTEGER = v_existing.current_value - 1 THEN
+--         -- Case 1: Already counted today (idempotent reload) — no-op
+--         -- diff = cv-1 means today is the same day as the last increment
 --         v_current := v_existing.current_value;
 --         v_period  := v_existing.period_start;
+-- 
 --       ELSIF (CURRENT_DATE - v_existing.period_start)::INTEGER = v_existing.current_value THEN
+--         -- Case 2: Unbroken streak, new day — increment
+--         -- diff = cv means yesterday was the last counted day
 --         v_current := v_existing.current_value + 1;
 --         v_period  := v_existing.period_start;
+-- 
 --       ELSE
+--         -- Case 3: diff > cv — gap detected, streak broken, start new
 --         v_current := 1;
 --         v_period  := CURRENT_DATE;
 --       END IF;
---
+-- 
+--       -- Upsert the streak row and skip the generic upsert below
 --       INSERT INTO public.user_daily_quests (user_id, quest_id, current_value, completed, completed_at, xp_granted, period_start)
 --       VALUES (p_user_id, v_quest_id, v_current, v_current >= v_target, CASE WHEN v_current >= v_target THEN NOW() ELSE NULL END, false, v_period)
 --       ON CONFLICT (user_id, quest_id, period_start) DO UPDATE SET
 --         current_value = EXCLUDED.current_value,
 --         completed     = EXCLUDED.completed,
 --         completed_at  = EXCLUDED.completed_at;
---
+-- 
+--       -- Mark xp_granted on first completion (API route mints on-chain)
 --       IF v_current >= v_target THEN
 --         UPDATE public.user_daily_quests
 --         SET xp_granted = true
 --         WHERE user_id = p_user_id AND quest_id = v_quest_id AND period_start = v_period AND xp_granted = false;
+-- 
 --         IF FOUND THEN
 --           v_just_awarded := true;
 --         END IF;
 --       END IF;
---
+-- 
 --       v_results := v_results || jsonb_build_object(
 --         'questId', v_quest_id,
 --         'currentValue', v_current,
@@ -395,9 +468,10 @@ GRANT EXECUTE ON FUNCTION get_daily_quest_state TO service_role;
 --         'justAwarded', v_just_awarded,
 --         'xpReward', v_xp
 --       );
---       CONTINUE;
---
+--       CONTINUE;  -- Skip generic upsert
+-- 
 --     ELSIF v_type = 'module' THEN
+--       -- Check if ALL lessons in ANY module are completed AND the last one was completed today
 --       v_current := 0;
 --       FOR v_mod IN SELECT * FROM jsonb_array_elements(p_module_lesson_map)
 --       LOOP
@@ -405,46 +479,51 @@ GRANT EXECUTE ON FUNCTION get_daily_quest_state TO service_role;
 --         IF array_length(v_mod_lessons, 1) IS NULL OR array_length(v_mod_lessons, 1) = 0 THEN
 --           CONTINUE;
 --         END IF;
---
+-- 
+--         -- Check all lessons completed
 --         SELECT COUNT(*) = array_length(v_mod_lessons, 1) INTO v_all_done
 --         FROM public.user_progress
 --         WHERE user_id = p_user_id
 --           AND completed = true
 --           AND lesson_id = ANY(v_mod_lessons);
---
+-- 
 --         IF v_all_done THEN
+--           -- Check if the most recent completion in this module was today
 --           SELECT MAX(completed_at::date) INTO v_max_date
 --           FROM public.user_progress
 --           WHERE user_id = p_user_id
 --             AND completed = true
 --             AND lesson_id = ANY(v_mod_lessons);
---
+-- 
 --           IF v_max_date = CURRENT_DATE THEN
 --             v_current := 1;
---             EXIT;
+--             EXIT;  -- One completed module is enough
 --           END IF;
 --         END IF;
 --       END LOOP;
 --     END IF;
---
+-- 
+--     -- ── Generic daily quest upsert (lesson, lesson_batch, challenge, module) ──
 --     v_period := CURRENT_DATE;
---
+-- 
 --     INSERT INTO public.user_daily_quests (user_id, quest_id, current_value, completed, completed_at, xp_granted, period_start)
 --     VALUES (p_user_id, v_quest_id, v_current, v_current >= v_target, CASE WHEN v_current >= v_target THEN NOW() ELSE NULL END, false, v_period)
 --     ON CONFLICT (user_id, quest_id, period_start) DO UPDATE SET
 --       current_value = EXCLUDED.current_value,
 --       completed     = EXCLUDED.completed,
 --       completed_at  = COALESCE(user_daily_quests.completed_at, EXCLUDED.completed_at);
---
+-- 
+--     -- Mark xp_granted on first completion (API route mints on-chain)
 --     IF v_current >= v_target THEN
 --       UPDATE public.user_daily_quests
 --       SET xp_granted = true
 --       WHERE user_id = p_user_id AND quest_id = v_quest_id AND period_start = v_period AND xp_granted = false;
+-- 
 --       IF FOUND THEN
 --         v_just_awarded := true;
 --       END IF;
 --     END IF;
---
+-- 
 --     v_results := v_results || jsonb_build_object(
 --       'questId', v_quest_id,
 --       'currentValue', v_current,
@@ -453,13 +532,11 @@ GRANT EXECUTE ON FUNCTION get_daily_quest_state TO service_role;
 --       'xpReward', v_xp
 --     );
 --   END LOOP;
---
+-- 
 --   RETURN v_results;
 -- END;
 -- $$;
---
+-- 
 -- REVOKE EXECUTE ON FUNCTION get_daily_quest_state FROM authenticated, anon, public;
 -- GRANT EXECUTE ON FUNCTION get_daily_quest_state TO service_role;
---
--- COMMIT;
 -- ============================================================================

--- a/supabase/migrations/20260709130000_award_xp_report_credited.sql
+++ b/supabase/migrations/20260709130000_award_xp_report_credited.sql
@@ -1,0 +1,176 @@
+-- ============================================================================
+-- Migration: award_xp reports the credited amount (RETURNS INTEGER)
+-- Task: CS-7 (#353) adversarial follow-up — finding B2
+-- ----------------------------------------------------------------------------
+-- ⚠️  MERGE-ORDER REQUIREMENT — same as 20260709120000: apply to prod BEFORE
+--     (or atomically with) the code deploy. The new queue processor reads the
+--     RPC's return value to decide whether a quest_xp delivery row is resolved;
+--     against the old void function it reads null → treats every credit as
+--     cap-deferred → rows are retried on every sweep (safe — idempotent — but
+--     noisy and never resolved). Apply first.
+--
+-- Why: award_xp silently drops (or clamps to 0) a credit once the 5000/day cap
+-- is reached, returning void with no error. The pending_onchain_actions queue
+-- marked rows resolved_at on "no error", so a cap-eaten quest_xp credit was
+-- recorded as delivered — silent XP loss, the exact bug class the durable
+-- queue exists to eliminate. Fix: award_xp now RETURNS INTEGER = the amount
+-- actually credited:
+--   > 0 → XP landed (for an idempotency-key duplicate, the previously-credited
+--         amount is returned — "already delivered" reads as delivered).
+--   = 0 → nothing was credited (invalid amount or daily cap consumed the whole
+--         award). Callers must NOT mark delivery resolved on 0.
+--
+-- Postgres cannot ALTER a function's return type, so this is DROP + CREATE.
+-- DROP FUNCTION discards the existing REVOKE/GRANT set, so the service_role-
+-- only lockdown (F-06) is re-applied explicitly below — do not remove it.
+--
+-- Existing callers are unaffected: every app call site invokes award_xp via
+-- supabase.rpc() and only inspects `error`; PL/pgSQL callers use PERFORM/none.
+--
+-- Idempotent: DROP ... IF EXISTS + CREATE. Safe to re-run.
+--
+-- ── ROLLBACK (restores the pre-migration void signature) ────────────────────
+-- Re-run supabase/migrations/20260703150000_reconcile_award_xp_caps.sql
+-- prefixed with:
+--   DROP FUNCTION IF EXISTS public.award_xp(UUID, INTEGER, TEXT, TEXT, TEXT);
+-- then re-apply the REVOKE/GRANT block at the bottom of this file.
+-- (Roll back the code deploy first — the new queue processor expects the
+-- INTEGER return.)
+-- ============================================================================
+
+DROP FUNCTION IF EXISTS public.award_xp(UUID, INTEGER, TEXT, TEXT, TEXT);
+
+CREATE FUNCTION public.award_xp(
+  p_user_id UUID,
+  p_amount INTEGER,
+  p_reason TEXT,
+  p_idempotency_key TEXT DEFAULT NULL,
+  p_tx_signature TEXT DEFAULT NULL
+) RETURNS INTEGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_last_activity DATE;
+  v_current_streak INTEGER;
+  v_longest_streak INTEGER;
+  v_new_streak INTEGER;
+  v_new_longest INTEGER;
+  v_daily_total INTEGER;
+  v_prev_amount INTEGER;
+  -- Hard per-award ceiling. Matches the documented "max 2000 XP per award"
+  -- (the largest legitimate single award is a course-completion bonus).
+  c_max_award_xp CONSTANT INTEGER := 2000;
+  -- Per-user daily ceiling across the learning XP path (lessons, challenges,
+  -- bonuses, achievements). Generous enough for normal multi-course days,
+  -- low enough to cap a forged-"passed" farming loop.
+  c_max_daily_award_xp CONSTANT INTEGER := 5000;
+BEGIN
+  -- Reject non-positive awards outright (defensive — callers pass positives).
+  IF p_amount IS NULL OR p_amount <= 0 THEN
+    RETURN 0;
+  END IF;
+
+  -- Clamp any single award to the hard ceiling.
+  IF p_amount > c_max_award_xp THEN
+    p_amount := c_max_award_xp;
+  END IF;
+
+  -- Serialize concurrent awards for the same user so the read-then-insert daily
+  -- cap below is atomic: without this lock, two parallel awards can both read a
+  -- sub-cap total and both insert, blowing past the daily ceiling.
+  PERFORM pg_advisory_xact_lock(hashtext('award_xp:' || p_user_id::text)::bigint);
+
+  -- Enforce the per-user daily ceiling. Sum today's learning-path awards
+  -- (excluding community XP, which is capped separately) and clamp the credit
+  -- so the daily total can never exceed the ceiling. The window boundary is
+  -- pinned to UTC midnight so it is independent of the DB session timezone.
+  SELECT COALESCE(SUM(amount), 0) INTO v_daily_total
+  FROM public.xp_transactions
+  WHERE user_id = p_user_id
+    AND created_at >= date_trunc('day', now() AT TIME ZONE 'UTC') AT TIME ZONE 'UTC'
+    AND reason NOT LIKE 'community:%';
+
+  IF v_daily_total >= c_max_daily_award_xp THEN
+    RETURN 0;
+  END IF;
+
+  IF v_daily_total + p_amount > c_max_daily_award_xp THEN
+    p_amount := c_max_daily_award_xp - v_daily_total;
+  END IF;
+
+  IF p_amount <= 0 THEN
+    RETURN 0;
+  END IF;
+
+  IF p_idempotency_key IS NOT NULL THEN
+    INSERT INTO public.xp_transactions (user_id, amount, reason, idempotency_key, tx_signature)
+    VALUES (p_user_id, p_amount, p_reason, p_idempotency_key, p_tx_signature)
+    ON CONFLICT (user_id, idempotency_key) WHERE idempotency_key IS NOT NULL DO NOTHING;
+
+    -- If nothing was inserted (duplicate), skip the XP update too. Report the
+    -- previously-credited amount (always > 0 — award_xp never records a
+    -- non-positive transaction) so callers see "already delivered", not
+    -- "dropped".
+    IF NOT FOUND THEN
+      SELECT amount INTO v_prev_amount
+      FROM public.xp_transactions
+      WHERE user_id = p_user_id
+        AND idempotency_key = p_idempotency_key;
+      RETURN COALESCE(v_prev_amount, 0);
+    END IF;
+  ELSE
+    INSERT INTO public.xp_transactions (user_id, amount, reason, tx_signature)
+    VALUES (p_user_id, p_amount, p_reason, p_tx_signature);
+  END IF;
+
+  -- Get current streak state before updating
+  SELECT last_activity_date, current_streak, longest_streak
+  INTO v_last_activity, v_current_streak, v_longest_streak
+  FROM public.user_xp
+  WHERE user_id = p_user_id;
+
+  -- Calculate new streak
+  IF v_last_activity IS NULL THEN
+    -- First activity ever
+    v_new_streak := 1;
+  ELSIF v_last_activity = CURRENT_DATE THEN
+    -- Already active today, keep current streak
+    v_new_streak := COALESCE(v_current_streak, 1);
+  ELSIF v_last_activity = CURRENT_DATE - INTERVAL '1 day' THEN
+    -- Active yesterday, increment streak
+    v_new_streak := COALESCE(v_current_streak, 0) + 1;
+  ELSE
+    -- Gap > 1 day, reset streak
+    v_new_streak := 1;
+  END IF;
+
+  v_new_longest := GREATEST(COALESCE(v_longest_streak, 0), v_new_streak);
+
+  INSERT INTO public.user_xp (user_id, total_xp, level, last_activity_date, current_streak, longest_streak)
+  VALUES (
+    p_user_id,
+    p_amount,
+    floor(sqrt(p_amount / 100.0))::int,
+    CURRENT_DATE,
+    v_new_streak,
+    v_new_longest
+  )
+  ON CONFLICT (user_id) DO UPDATE SET
+    total_xp = user_xp.total_xp + p_amount,
+    level = floor(sqrt((user_xp.total_xp + p_amount) / 100.0))::int,
+    last_activity_date = CURRENT_DATE,
+    current_streak = v_new_streak,
+    longest_streak = v_new_longest;
+
+  RETURN p_amount;
+END;
+$$;
+
+-- Re-apply the service_role-only lockdown (F-06) — DROP FUNCTION discarded the
+-- previous grants, and CREATE FUNCTION defaults to EXECUTE for PUBLIC.
+REVOKE EXECUTE ON FUNCTION public.award_xp(UUID, INTEGER, TEXT, TEXT, TEXT)
+  FROM authenticated, anon, public;
+GRANT EXECUTE ON FUNCTION public.award_xp(UUID, INTEGER, TEXT, TEXT, TEXT)
+  TO service_role;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -749,8 +749,12 @@ CREATE POLICY "Users can view their own daily quests"
 -- ── get_daily_quest_state ─────────────────────────────────────
 -- Single-pass function: evaluates all quest progress for a user,
 -- upserts rows, marks first completion via xp_granted flag.
--- XP is minted on-chain by the API route (not in SQL) — the
--- Helius webhook then syncs it to Supabase via award_xp().
+-- On first completion it ALSO enqueues a 'quest_xp' pending_onchain_actions
+-- row in THIS transaction (atomic with the xp_granted flip), so a quest is
+-- never marked granted without a durable delivery record. The XP is then
+-- credited idempotently by retryPendingOnchainActions() -> award_xp()
+-- (reference_id = idempotency key); it is NOT minted on-chain from a retry
+-- path, because rewardXp is non-idempotent and would double-mint soulbound XP.
 -- Called via service_role from /api/quests/daily.
 CREATE OR REPLACE FUNCTION get_daily_quest_state(
   p_user_id           UUID,
@@ -863,7 +867,11 @@ BEGIN
         completed     = EXCLUDED.completed,
         completed_at  = EXCLUDED.completed_at;
 
-      -- Mark xp_granted on first completion (API route mints on-chain)
+      -- Mark xp_granted on first completion and durably enqueue the XP credit
+      -- in the SAME transaction (atomic with the flip): a quest is never marked
+      -- granted without a pending_onchain_actions row, so the enqueue can never
+      -- be lost to a swallowed app-side error. retryPendingOnchainActions()
+      -- delivers it idempotently via award_xp (reference_id = idempotency key).
       IF v_completed THEN
         UPDATE public.user_daily_quests
         SET xp_granted = true
@@ -871,6 +879,14 @@ BEGIN
 
         IF FOUND THEN
           v_just_awarded := true;
+          INSERT INTO public.pending_onchain_actions (user_id, action_type, reference_id, payload)
+          VALUES (
+            p_user_id,
+            'quest_xp',
+            v_quest_id || ':' || v_period::text,
+            jsonb_build_object('xpAmount', v_xp, 'memo', 'daily_quest:' || v_quest_id)
+          )
+          ON CONFLICT (user_id, action_type, reference_id) DO NOTHING;
         END IF;
       END IF;
 
@@ -916,9 +932,14 @@ BEGIN
       END LOOP;
 
     ELSE
-      -- Unknown quest type: fail loudly rather than silently rendering 0/N
-      -- (a mis-typed quest definition should never quietly evaluate to 0).
-      RAISE EXCEPTION 'get_daily_quest_state: unknown quest type: %', v_type;
+      -- Unknown quest type (e.g. a CMS typo). Skip this ONE quest with a loud
+      -- server-log warning rather than RAISE-ing — a single mis-typed quest
+      -- definition must not 500 the whole daily-quests endpoint for every user
+      -- (and, now that the enqueue is transactional, roll back other quests'
+      -- durable XP rows in the same call). It is not rendered as a silent 0/N:
+      -- it is omitted from the result and flagged in the logs for the operator.
+      RAISE WARNING 'get_daily_quest_state: skipping unknown quest type: %', v_type;
+      CONTINUE;
     END IF;
 
     -- ── Generic daily quest upsert (lesson, lesson_batch, challenge, module) ──
@@ -935,7 +956,8 @@ BEGIN
       completed     = EXCLUDED.completed,
       completed_at  = COALESCE(user_daily_quests.completed_at, EXCLUDED.completed_at);
 
-    -- Mark xp_granted on first completion (API route mints on-chain)
+    -- Mark xp_granted on first completion and durably enqueue the XP credit in
+    -- the SAME transaction (atomic with the flip) — see the login_streak branch.
     IF v_completed THEN
       UPDATE public.user_daily_quests
       SET xp_granted = true
@@ -943,6 +965,14 @@ BEGIN
 
       IF FOUND THEN
         v_just_awarded := true;
+        INSERT INTO public.pending_onchain_actions (user_id, action_type, reference_id, payload)
+        VALUES (
+          p_user_id,
+          'quest_xp',
+          v_quest_id || ':' || v_period::text,
+          jsonb_build_object('xpAmount', v_xp, 'memo', 'daily_quest:' || v_quest_id)
+        )
+        ON CONFLICT (user_id, action_type, reference_id) DO NOTHING;
       END IF;
     END IF;
 

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -330,7 +330,14 @@ CREATE OR REPLACE FUNCTION award_xp(
   p_reason TEXT,
   p_idempotency_key TEXT DEFAULT NULL,
   p_tx_signature TEXT DEFAULT NULL
-) RETURNS void
+) RETURNS INTEGER
+-- Returns the amount actually credited (after per-award + daily-cap clamps).
+--   > 0 → XP landed (or, for an idempotency-key duplicate, had already landed —
+--         the previously-credited amount is returned so callers can treat
+--         "already delivered" as delivered).
+--   = 0 → nothing was credited (invalid amount, or the daily cap consumed the
+--         whole award). Queue-style callers MUST NOT mark delivery resolved
+--         on 0 — the credit was dropped, not delivered.
 LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path = ''
@@ -342,6 +349,7 @@ DECLARE
   v_new_streak INTEGER;
   v_new_longest INTEGER;
   v_daily_total INTEGER;
+  v_prev_amount INTEGER;
   -- Hard per-award ceiling. Matches the documented "max 2000 XP per award"
   -- (the largest legitimate single award is a course-completion bonus).
   c_max_award_xp CONSTANT INTEGER := 2000;
@@ -352,7 +360,7 @@ DECLARE
 BEGIN
   -- Reject non-positive awards outright (defensive — callers pass positives).
   IF p_amount IS NULL OR p_amount <= 0 THEN
-    RETURN;
+    RETURN 0;
   END IF;
 
   -- Clamp any single award to the hard ceiling.
@@ -376,7 +384,7 @@ BEGIN
     AND reason NOT LIKE 'community:%';
 
   IF v_daily_total >= c_max_daily_award_xp THEN
-    RETURN;
+    RETURN 0;
   END IF;
 
   IF v_daily_total + p_amount > c_max_daily_award_xp THEN
@@ -384,7 +392,7 @@ BEGIN
   END IF;
 
   IF p_amount <= 0 THEN
-    RETURN;
+    RETURN 0;
   END IF;
 
   IF p_idempotency_key IS NOT NULL THEN
@@ -392,9 +400,16 @@ BEGIN
     VALUES (p_user_id, p_amount, p_reason, p_idempotency_key, p_tx_signature)
     ON CONFLICT (user_id, idempotency_key) WHERE idempotency_key IS NOT NULL DO NOTHING;
 
-    -- If nothing was inserted (duplicate), skip the XP update too
+    -- If nothing was inserted (duplicate), skip the XP update too. Report the
+    -- previously-credited amount (always > 0 — award_xp never records a
+    -- non-positive transaction) so callers see "already delivered", not
+    -- "dropped".
     IF NOT FOUND THEN
-      RETURN;
+      SELECT amount INTO v_prev_amount
+      FROM public.xp_transactions
+      WHERE user_id = p_user_id
+        AND idempotency_key = p_idempotency_key;
+      RETURN COALESCE(v_prev_amount, 0);
     END IF;
   ELSE
     INSERT INTO public.xp_transactions (user_id, amount, reason, tx_signature)
@@ -439,6 +454,8 @@ BEGIN
     last_activity_date = CURRENT_DATE,
     current_streak = v_new_streak,
     longest_streak = v_new_longest;
+
+  RETURN p_amount;
 END;
 $$;
 

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -700,7 +700,7 @@ CREATE POLICY "Users can update their own deployments"
 CREATE TABLE pending_onchain_actions (
   id             UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   user_id        UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
-  action_type    TEXT NOT NULL CHECK (action_type IN ('achievement', 'certificate', 'course_finalize', 'xp', 'enroll')),
+  action_type    TEXT NOT NULL CHECK (action_type IN ('achievement', 'certificate', 'course_finalize', 'xp', 'quest_xp', 'enroll')),
   reference_id   TEXT NOT NULL,
   payload        JSONB NOT NULL,
   failed_at      TIMESTAMPTZ DEFAULT NOW(),
@@ -778,6 +778,7 @@ DECLARE
   v_all_done     BOOLEAN;
   v_max_date     DATE;
   v_just_awarded BOOLEAN;
+  v_completed    BOOLEAN;
 BEGIN
   FOR v_quest IN SELECT * FROM jsonb_array_elements(p_quest_definitions)
   LOOP
@@ -850,16 +851,20 @@ BEGIN
         v_period  := CURRENT_DATE;
       END IF;
 
+      -- Completion requires a positive target: a targetValue of 0 must NOT
+      -- auto-complete (that would mint free XP every day for a 0-target quest).
+      v_completed := v_target > 0 AND v_current >= v_target;
+
       -- Upsert the streak row and skip the generic upsert below
       INSERT INTO public.user_daily_quests (user_id, quest_id, current_value, completed, completed_at, xp_granted, period_start)
-      VALUES (p_user_id, v_quest_id, v_current, v_current >= v_target, CASE WHEN v_current >= v_target THEN NOW() ELSE NULL END, false, v_period)
+      VALUES (p_user_id, v_quest_id, v_current, v_completed, CASE WHEN v_completed THEN NOW() ELSE NULL END, false, v_period)
       ON CONFLICT (user_id, quest_id, period_start) DO UPDATE SET
         current_value = EXCLUDED.current_value,
         completed     = EXCLUDED.completed,
         completed_at  = EXCLUDED.completed_at;
 
       -- Mark xp_granted on first completion (API route mints on-chain)
-      IF v_current >= v_target THEN
+      IF v_completed THEN
         UPDATE public.user_daily_quests
         SET xp_granted = true
         WHERE user_id = p_user_id AND quest_id = v_quest_id AND period_start = v_period AND xp_granted = false;
@@ -872,7 +877,7 @@ BEGIN
       v_results := v_results || jsonb_build_object(
         'questId', v_quest_id,
         'currentValue', v_current,
-        'completed', v_current >= v_target,
+        'completed', v_completed,
         'justAwarded', v_just_awarded,
         'xpReward', v_xp
       );
@@ -909,20 +914,29 @@ BEGIN
           END IF;
         END IF;
       END LOOP;
+
+    ELSE
+      -- Unknown quest type: fail loudly rather than silently rendering 0/N
+      -- (a mis-typed quest definition should never quietly evaluate to 0).
+      RAISE EXCEPTION 'get_daily_quest_state: unknown quest type: %', v_type;
     END IF;
 
     -- ── Generic daily quest upsert (lesson, lesson_batch, challenge, module) ──
     v_period := CURRENT_DATE;
 
+    -- Completion requires a positive target: a targetValue of 0 must NOT
+    -- auto-complete (that would mint free XP every day for a 0-target quest).
+    v_completed := v_target > 0 AND v_current >= v_target;
+
     INSERT INTO public.user_daily_quests (user_id, quest_id, current_value, completed, completed_at, xp_granted, period_start)
-    VALUES (p_user_id, v_quest_id, v_current, v_current >= v_target, CASE WHEN v_current >= v_target THEN NOW() ELSE NULL END, false, v_period)
+    VALUES (p_user_id, v_quest_id, v_current, v_completed, CASE WHEN v_completed THEN NOW() ELSE NULL END, false, v_period)
     ON CONFLICT (user_id, quest_id, period_start) DO UPDATE SET
       current_value = EXCLUDED.current_value,
       completed     = EXCLUDED.completed,
       completed_at  = COALESCE(user_daily_quests.completed_at, EXCLUDED.completed_at);
 
     -- Mark xp_granted on first completion (API route mints on-chain)
-    IF v_current >= v_target THEN
+    IF v_completed THEN
       UPDATE public.user_daily_quests
       SET xp_granted = true
       WHERE user_id = p_user_id AND quest_id = v_quest_id AND period_start = v_period AND xp_granted = false;
@@ -935,7 +949,7 @@ BEGIN
     v_results := v_results || jsonb_build_object(
       'questId', v_quest_id,
       'currentValue', v_current,
-      'completed', v_current >= v_target,
+      'completed', v_completed,
       'justAwarded', v_just_awarded,
       'xpReward', v_xp
     );


### PR DESCRIPTION
## CS-7 (#353) — Quest-XP durable delivery + SQL hardening

Four verified defects in the quest-XP path. All four fixed.

### 1. `pending_onchain_actions` CHECK rejected `quest_xp`
The inline column CHECK omitted `'quest_xp'`, so every quest-XP enqueue violated
the constraint. Combined with defect #2, the failure was invisible. Added
`'quest_xp'` to the allowed set in `supabase/schema.sql` and in the migration via
an idempotent **drop-and-readd**: a `DO` block looks up the auto-generated
constraint name from `pg_constraint` (the baseline created it unnamed) and drops
it, then re-adds a **named** `pending_onchain_actions_action_type_check`. Re-runnable.

### 2. `queueFailedOnchainAction` swallowed the upsert error
supabase-js `.upsert()` **resolves with `{ error }`** instead of throwing, so the
old `try/catch` never fired and a constraint violation was silently dropped. It now
inspects the returned `error`, logs it (Sentry), and **throws** so a failed enqueue
is visible. The `error` param is now optional (present → real failure records
`last_error`+`failed_at`; absent → proactive durable enqueue).

### 3. Quest mint was un-awaited fire-and-forget (the XP-loss bug)
`mintQuestXpOnChain(...).catch(()=>{})` ran after the response returned with no
`waitUntil`/`after()`, so on Vercel it raced lambda freeze — and it had two silent
early returns (`!programLive`, `!wallet`) that dropped the XP **after
`get_daily_quest_state` had already set `xp_granted=true`** ("attempt authorized"),
making it permanent XP loss.

### 4. `get_daily_quest_state` hardening
- **(a)** Completion now requires `targetValue > 0` (a `targetValue:0` quest can no
  longer auto-complete every day and mint free XP). Centralized in a new `v_completed`
  local reused by both the login_streak and generic branches.
- **(b)** A final `ELSE RAISE EXCEPTION` on the quest-type IF/ELSIF chain — an unknown
  type now fails loudly instead of silently rendering 0/N.
- The login_streak state machine is untouched.

---

## Durability approach: **(a) — synchronous durable enqueue**

I chose **(a)**: write the `pending_onchain_actions` row **synchronously, before the
response returns** (now legal after fix #1), and let the existing queue processor
(`retryPendingOnchainActions`, driven on the user's next auth) perform the actual mint.

**Why (a) over (b) — await the mint:**
- **Smaller, safer diff** — it deletes `mintQuestXpOnChain` (wallet lookup +
  program-liveness gate + inline mint) rather than restructuring it. The
  no-wallet / no-programLive cases are handled for free: the row is durable and the
  queue processor resolves the wallet and checks liveness itself, so there is no
  branch left that can "return empty-handed".
- **No added request latency / no freeze risk** — (b) would put a Solana
  confirmation on the critical path of a GET that fires on every dashboard load;
  a network error there would still need the queue as a fallback anyway.
- **Matches the existing architecture** — the retry queue is this codebase's
  durability primitive and already handles `quest_xp`.

**One correctness detail:** `reference_id` is now day-scoped
(`${questId}:${YYYY-MM-DD}` UTC, matching `CURRENT_DATE`). Without the day suffix,
day-N's enqueue would upsert-collide with a prior day's **already-resolved** row (the
upsert doesn't reset `resolved_at`) and the mint would be silently dropped — exactly
the class of bug being fixed. `justAwarded` fires once per (user, quest, DB-day), so
there is exactly one enqueue per period.

**Trade-off (documented):** delivery is deferred to the next auth-triggered queue
sweep rather than immediate. No XP is ever lost (the intent is durable); the Helius
webhook then syncs the on-chain mint back to Supabase. This is acceptable and
consistent with the existing queue design.

---

## Migration — apply **post-merge only**

`supabase/migrations/20260709120000_quest_xp_durable_delivery.sql` — **NOT applied to
any database.** Header says apply to prod only after merge. Function body is
byte-identical to the updated `supabase/schema.sql` (canonical). No explicit
BEGIN/COMMIT (matches repo convention — the CLI wraps each migration).

### Rollback (tested; full block kept commented in the migration)
```sql
-- Restore original CHECK (drops 'quest_xp'); resolve/remove any quest_xp rows first:
--   DELETE FROM public.pending_onchain_actions WHERE action_type = 'quest_xp';
DO $$
DECLARE v_conname text;
BEGIN
  SELECT conname INTO v_conname
  FROM pg_constraint
  WHERE conrelid = 'public.pending_onchain_actions'::regclass
    AND contype = 'c'
    AND pg_get_constraintdef(oid) ILIKE '%action_type%';
  IF v_conname IS NOT NULL THEN
    EXECUTE format('ALTER TABLE public.pending_onchain_actions DROP CONSTRAINT %I', v_conname);
  END IF;
END $$;
ALTER TABLE public.pending_onchain_actions
  ADD CONSTRAINT pending_onchain_actions_action_type_check
  CHECK (action_type IN ('achievement','certificate','course_finalize','xp','enroll'));
-- + CREATE OR REPLACE FUNCTION get_daily_quest_state(...) with the PRIOR body
--   (no targetValue guard, no unknown-type RAISE) and re-assert REVOKE/GRANT.
--   The full prior function body is in the migration's rollback block.
```

---

## Local verification

`pnpm --filter web typecheck` → **exit 0** (clean):
```
> tsc --noEmit
=== EXIT CODE: 0 ===
```

`pnpm --filter web test` → **16 files / 138 tests passed** (no quest-route or
onchain-queue test exists; ran the full suite for regressions):
```
 Test Files  16 passed (16)
      Tests  138 passed (138)
```

ESLint on the two changed app files → **0 errors** (only 3 pre-existing
import/order warnings in `onchain-queue.ts`, in an import block I did not touch).
Pre-commit hook (eslint --fix + prettier) also passed.

> Sensitive PR (supabase migration + `area:db`) — written defensively; migration is
> idempotent and the rollback is genuinely correct.

Closes #353
