### PR TITLE
docs: fix 3 live doc landmines (CS backlog)

### DIFF
--- a/docs/CMS_GUIDE.md
+++ b/docs/CMS_GUIDE.md
@@ -221,7 +221,7 @@ Achievements follow a similar pattern:
 3. Admin panel writes back via `writeAchievementOnChainStatus(sanityId, achievementPda, collectionAddress)` -- sets status to `"synced"`
 4. The achievement becomes mintable. The GROQ query `getDeployedAchievements()` filters to `defined(onChainStatus.achievementPda)`
 
-Unlock logic is defined in `apps/web/src/lib/gamification/achievements.ts` in the `UNLOCK_CHECKS` map. Achievement IDs in this map must match Sanity `_id` values minus the `"achievement-"` prefix.
+Unlock logic is defined in `apps/web/src/lib/gamification/achievements.ts` in the `UNLOCK_CHECKS` map. Achievement IDs in this map must be the **full** Sanity `_id`, including the `achievement-` prefix — e.g. the key for `achievement-first-steps` is `"achievement-first-steps"`, not `"first-steps"`. The lookup is `UNLOCK_CHECKS[def.id]` where `def.id` is the raw Sanity `_id`; stripping the prefix derives the wrong PDA and fails silently in the on-chain queue.
 
 ## Creating a New Course
 

--- a/docs/CUSTOMIZATION.md
+++ b/docs/CUSTOMIZATION.md
@@ -476,7 +476,7 @@ interface UserState {
 
 **Deferred signals**: Two fields (`hasCompletedAllTracks`, `allTestsPassedFirstTry`) require cross-course tracking infrastructure that is not yet implemented. Achievements depending on these signals (`full-stack-solana`, `perfect-score`) are currently unearnable.
 
-Achievement IDs in `UNLOCK_CHECKS` must match the Sanity `_id` minus the `achievement-` prefix. For example, Sanity document `achievement-first-steps` maps to key `"first-steps"`.
+Achievement IDs in `UNLOCK_CHECKS` must be the **full** Sanity `_id`, including the `achievement-` prefix. For example, Sanity document `achievement-first-steps` maps to key `"achievement-first-steps"` (NOT `"first-steps"`). Stripping the prefix derives the wrong PDA and the award fails silently.
 
 #### 3. Deploy On-Chain
 

--- a/docs/SECRET-ROTATION.md
+++ b/docs/SECRET-ROTATION.md
@@ -12,6 +12,12 @@ secrets** — production data and credentials are **not isolated** from developm
 Before mainnet, every prod secret must be **freshly minted, isolated from dev, and
 stored outside the repo**.
 
+> **Correction (2026-07-09):** the canonical production deploy is
+> **superteam-academy-web.vercel.app** (Vercel `stbr-true`), which auto-deploys from
+> `main` and uses Supabase `obqlljsagzslxarwphxv`. References to `solarium.courses` /
+> `credit-markets-team/lms` in this document are a parallel red herring, not prod — the
+> rotation decisions below still apply, but to the `stbr-true` deploy.
+
 ## Decisions (D-2) — RATIFIED 2026-07-03
 
 1. **Isolate prod from dev — a NEW dedicated production Supabase project.** Stand
@@ -44,7 +50,7 @@ stored outside the repo**.
 | `HELIUS_WEBHOOK_SECRET`     | Verifies Helius webhook signatures               | Forge on-chain events → fake enroll / XP / credential grants | Rotate in Helius webhook config **and** env together                   |
 | `BUILD_SERVER_API_KEY`      | Authenticates `/build` calls to the build server | Submit arbitrary Anchor builds to the compile sandbox        | Rotate on the build server + env                                       |
 | `SANITY_ADMIN_TOKEN`        | Sanity **write** token (course content)          | Modify / delete any course, lesson, answer key               | sanity.io/manage → revoke, issue new write token                       |
-| `SANITY_API_TOKEN`          | Sanity read/API token                            | Read content (incl. hidden test answer keys)                 | sanity.io/manage → rotate                                              |
+| `SANITY_API_TOKEN`          | Sanity read/API token                            | Read/write via the API (NOT required to read course content — the production dataset is public)                 | sanity.io/manage → rotate                                              |
 | `GEMINI_API_KEY`            | AI tutor / challenge suggest                     | Quota abuse, cost                                            | Google AI Studio → rotate                                              |
 
 ### Semi-sensitive (client-exposed, but abuse/quota risk)


### PR DESCRIPTION
SAFE docs-only. Fixes the three landmines in spec §16.4, each verified against `main`:

1. **`CMS_GUIDE.md:224` + `CUSTOMIZATION.md:479`** told readers to strip the `achievement-` prefix from UNLOCK_CHECKS keys. **Wrong** — the actual map keys carry the full prefix (`"achievement-first-steps"`) and the lookup is `UNLOCK_CHECKS[def.id]` with the raw Sanity `_id`. Following the old instruction reproduces the getDeployedAchievements() wrong-PDA silent failure. Corrected to state the full `_id`.
2. **`SECRET-ROTATION.md:47`** claimed SANITY_API_TOKEN guards 'hidden test answer keys' — the dataset is public, no token needed to read content. Corrected.
3. **`SECRET-ROTATION.md` prod host** — added a non-destructive correction note (canonical prod = superteam-academy-web.vercel.app / stbr-true, not solarium.courses) rather than rewriting the ratified D-2 decision text.

Follow-up flagged for CS-6: the `achievements.ts` docstring repeats the same misleading 'minus the prefix' claim and should be fixed when that file is rewritten.

Closes #354