### PR TITLE
ci: run all workspace vitest suites (content-schema, content-lint) in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,15 +66,19 @@ jobs:
 
       - name: Unit tests
         # P1-1 landed: the frontend suite is green and is now a hard gate.
-        # Env defaults below mirror apps/web/vitest.setup.ts so the suite also
-        # runs without prod secrets (see P1-1 / P0-C2).
+        # `pnpm -r test` runs the `test` script of EVERY workspace package that
+        # defines one — @superteam-lms/web, content-schema, and content-lint —
+        # so all vitest suites gate CI. The old web-only `--filter` silently
+        # skipped content-schema (93 tests) and content-lint (32) (fixes #374).
+        # Env defaults below mirror apps/web/vitest.setup.ts so the web suite
+        # also runs without prod secrets (see P1-1 / P0-C2).
         env:
           NEXT_PUBLIC_PROGRAM_ID: 7NeJaSRyb4Wxay3Tcd9bdpD7T3GWYUQSFyrhG8SgwE8V
           NEXT_PUBLIC_SOLANA_NETWORK: devnet
           NEXT_PUBLIC_SOLANA_RPC_URL: https://api.devnet.solana.com
           NEXT_PUBLIC_SUPABASE_URL: https://example.supabase.co
           NEXT_PUBLIC_SUPABASE_ANON_KEY: test-anon-key
-        run: pnpm --filter @superteam-lms/web test
+        run: pnpm -r test
 
   # ── On-chain program: fmt, clippy, Rust unit tests ──────────────────────────
   onchain-rust:


### PR DESCRIPTION
## The gap (#374)

The `frontend` job's **Unit tests** step hardcoded:

```yaml
run: pnpm --filter @superteam-lms/web test
```

That filter runs **only** `@superteam-lms/web`. Every other workspace package that defines a `test` script was silently skipped by CI, so those suites could regress with a fully green pipeline.

A full-workspace scan (`git ls-tree -r` over every `package.json`) shows exactly **three** packages define a `test` script, all `vitest run`:

| Package | `test` | Ran in CI before? |
| --- | --- | --- |
| `@superteam-lms/web` | `vitest run` | ✅ yes |
| `@superteam-lms/content-schema` | `vitest run` | ❌ **no** (93 tests — the CS-1 source-of-truth Zod schema) |
| `@superteam-lms/content-lint` | `vitest run` | ❌ **no** (32 tests) |

`onchain-academy` and `sanity` have **no** `test` script, and the root `package.json`/`turbo.json` define no `test` task — so there was no existing recursive/turbo pattern, and there is no `anchor test` wired to a package `test` script that `-r` could accidentally trigger.

> Note: CS-2's `.github/workflows/validate-content.yml` is a `workflow_call` reusable workflow that runs the content-lint **CLI** against content repos — it does **not** run content-schema's or content-lint's vitest unit suites on push/PR. The gap was real.

## The fix

One-line change to the unit-test step:

```diff
-        run: pnpm --filter @superteam-lms/web test
+        run: pnpm -r test
```

`pnpm -r test` runs the `test` script of **every** workspace package that has one. Because only web + content-schema + content-lint define it, this is the minimal complete fix for the whole class — not just #374 — and is future-proof: any new package with a `test` script is auto-covered. The web-specific env defaults are kept intact (web still reads them; the two content packages ignore them).

## Packages that now run in CI that didn't before

- `@superteam-lms/content-schema` — **93 tests** (13 files)
- `@superteam-lms/content-lint` — **32 tests** (12 files)

## Local verification (real output)

`pnpm -r test` (with the same env defaults the CI step sets):

```
packages/content-schema  Test Files  13 passed (13)   Tests  93 passed (93)
packages/content-lint    Test Files  12 passed (12)   Tests  32 passed (32)
apps/web                 Test Files  24 passed (24)   Tests 210 passed (210)
EXIT CODE: 0
```

Negative control — the issue's "Done when" (a deliberately broken content-schema test fails the pipeline). Injected a failing test into content-schema and re-ran `pnpm -r test`:

```
packages/content-schema  Test Files  1 failed | 13 passed (14)
ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  @superteam-lms/content-schema test: `vitest run`
EXIT CODE: 1
```

The probe was removed; the only change in this PR is `.github/workflows/ci.yml`.

## Scope / safety

- Touches `.github/workflows/ci.yml` only; no other jobs changed.
- No new secrets, no `pull_request_target`, no permission/privilege change — stays a plain `push` / `pull_request` unit-test step.
- CI-time impact is negligible: content-schema ~0.5s, content-lint ~4.5s (its git merge-base gate tests dominate).
- YAML validated (PyYAML parse: valid).

Closes #374