### PR TITLE
fix(content-schema): per-block-type produces constraints (CS-1 amendment d9409f2)

### DIFF
--- a/packages/content-schema/src/__tests__/code.test.ts
+++ b/packages/content-schema/src/__tests__/code.test.ts
@@ -71,4 +71,22 @@ describe("CodeBlock", () => {
     const r = CodeBlock.safeParse({ ...valid, language: "rust" });
     expect(r.success).toBe(false); // .ts files declared as rust
   });
+
+  it("rejects produces on a non-deployable code block", () => {
+    const r = CodeBlock.safeParse({ ...valid, produces: "deployed-program" });
+    expect(r.success).toBe(false); // a standard TS exercise deploys nothing
+  });
+
+  it("rejects a code block producing a capability it cannot create", () => {
+    const r = CodeBlock.safeParse({
+      ...valid,
+      language: "rust",
+      starter: "s.rs",
+      solution: "x.rs",
+      buildType: "buildable",
+      deployable: true,
+      produces: "funded-wallet",
+    });
+    expect(r.success).toBe(false);
+  });
 });

--- a/packages/content-schema/src/__tests__/widgets.test.ts
+++ b/packages/content-schema/src/__tests__/widgets.test.ts
@@ -95,3 +95,33 @@ describe("DeployedProgramCardBlock", () => {
     expect(b.consumes).toEqual(["deployed-program"]);
   });
 });
+
+describe("per-type produces constraints (gate 13a, local half)", () => {
+  it("rejects wallet-funding producing anything but funded-wallet", () => {
+    expect(
+      WalletFundingBlock.safeParse({
+        type: "wallet-funding",
+        key: "f",
+        produces: "deployed-program",
+      }).success
+    ).toBe(false);
+  });
+
+  it("rejects produces on pure consumers", () => {
+    expect(
+      ProgramExplorerBlock.safeParse({
+        type: "program-explorer",
+        key: "e",
+        idl: "program.idl.json",
+        produces: "funded-wallet",
+      }).success
+    ).toBe(false);
+    expect(
+      DeployedProgramCardBlock.safeParse({
+        type: "deployed-program-card",
+        key: "c",
+        produces: "deployed-program",
+      }).success
+    ).toBe(false);
+  });
+});

--- a/packages/content-schema/src/blocks/code.ts
+++ b/packages/content-schema/src/blocks/code.ts
@@ -50,6 +50,22 @@ export const CodeBlock = z
   .refine((b) => b.solution.endsWith(EXT[b.language]), {
     message: "solution extension must match language",
     path: ["solution"],
+  })
+  // Gate 13a's local half (PR #350 review): a capability may only be produced by
+  // a block type that can actually create it. A code block can only ever produce
+  // `deployed-program`, and only when it is deployable — otherwise a stray
+  // `produces:` satisfies the CI ordering check with a producer that produces
+  // nothing.
+  .refine(
+    (b) => b.produces === undefined || b.produces === "deployed-program",
+    {
+      message: "a code block may only produce 'deployed-program'",
+      path: ["produces"],
+    }
+  )
+  .refine((b) => b.produces !== "deployed-program" || b.deployable, {
+    message: "only a deployable code block may produce 'deployed-program'",
+    path: ["produces"],
   });
 
 export type CodeBlockT = z.infer<typeof CodeBlock>;

--- a/packages/content-schema/src/blocks/widgets.ts
+++ b/packages/content-schema/src/blocks/widgets.ts
@@ -11,6 +11,8 @@ import { blockBase, relativePath } from "./base";
 export const WalletFundingBlock = z.object({
   type: z.literal("wallet-funding"),
   ...blockBase,
+  /** Gate 13a local half: funding a wallet can only ever produce `funded-wallet`. */
+  produces: z.literal("funded-wallet").optional(),
   /** SOL. Hardcoded to 2 in wallet-funding-card.tsx today. */
   amount: z.number().positive().max(5).default(2),
   network: z.literal("devnet").default("devnet"),
@@ -19,6 +21,8 @@ export const WalletFundingBlock = z.object({
 export const ProgramExplorerBlock = z.object({
   type: z.literal("program-explorer"),
   ...blockBase,
+  /** A pure consumer — it can never produce a capability. */
+  produces: z.never().optional(),
   /**
    * A real file, not a textarea. CI asserts it parses, has a non-empty
    * `instructions` array, and that `metadata.name` matches the keypair-storage
@@ -30,6 +34,8 @@ export const ProgramExplorerBlock = z.object({
 export const DeployedProgramCardBlock = z.object({
   type: z.literal("deployed-program-card"),
   ...blockBase,
+  /** A pure consumer — it can never produce a capability. */
+  produces: z.never().optional(),
 });
 
 export type WalletFundingBlockT = z.infer<typeof WalletFundingBlock>;


### PR DESCRIPTION
## The gap

PR #364 (CS-1, content-schema package) was built from the **pre-amendment** Plan 1. Amendment commit `d9409f2` (Plan 1, Tasks 4 & 6) added per-block-type `produces` capability constraints that #364 never picked up. Today every block inherits `produces: CapabilityKey.optional()` from `blocks/base.ts`, so any block type can declare it can produce **any** capability — a stray `produces:` would satisfy the CI slot-ordering check (spec §4.9) with a "producer" that in reality produces nothing.

This PR ports the amendment's refines/overrides verbatim.

## Constraints added (exactly as amendment `d9409f2` specifies)

- **`code` block** (`blocks/code.ts`) — two new `.refine()`s: may only produce `deployed-program`, and only when `deployable` is `true`; otherwise it produces nothing.
- **`wallet-funding` widget** (`blocks/widgets.ts`) — `produces: z.literal("funded-wallet").optional()` (overrides the base `produces` after the `...blockBase` spread).
- **`program-explorer` & `deployed-program-card` widgets** — pure CONSUMERS: `produces: z.never().optional()` (they can never produce a capability).

## Tests (4 new, per Tasks 4 & 6)

`src/__tests__/code.test.ts` (8 → 10):
- rejects `produces` on a non-deployable code block
- rejects a `deployable:true` code block producing `funded-wallet` (a capability it cannot create)

`src/__tests__/widgets.test.ts` (8 → 10):
- rejects `wallet-funding` producing anything but `funded-wallet`
- rejects `produces` on the pure consumers (`program-explorer`, `deployed-program-card`)

**fail → pass demonstrated**: with the two source files reverted but the tests kept, exactly these 4 tests fail (`4 failed | 16 passed`); with the source change they pass.

## Verification

- `pnpm --filter @superteam-lms/content-schema test` → **97 passed** (was 93). Per-file counts now match the plan's post-amendment numbers: `code.test.ts` = 10, `widgets.test.ts` = 10.
- `pnpm --filter @superteam-lms/content-schema typecheck` → exit 0.
- Root `pnpm typecheck` → exit 0 (8/8 tasks). Additive only: the block `type` discriminant, existing field names, and everything CS-6/#384's `BLOCK_REGISTRY` `satisfies Record<BlockType, BlockMeta>` consumes are unchanged (the registry keys on the `type` discriminant, which this PR does not touch).

Strict TS, zero `any`.

Closes #373