### PR TITLE
feat(sync): CS-9 content sync route + drift UI (stacked on #384)

### DIFF
--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -70,6 +70,11 @@ NEXT_PUBLIC_XP_MINT_ADDRESS=       # XP mint pubkey (from initialize.ts output)
 ADMIN_SECRET=                      # Admin panel authentication secret (HMAC-signed cookies)
 BUILD_SERVER_URL=                  # Cloud Run build server URL (server-only, proxied via /api)
 BUILD_SERVER_API_KEY=              # Build server authentication key
+GITHUB_TOKEN=                      # Fine-grained READ token for solanabr/academy-courses
+                                   # (server-only). Powers POST /api/admin/content/sync (tarball
+                                   # fetch), the drift UI (HEAD polling), and the Checks API
+                                   # (blocked state). Unauthenticated GitHub is 60 req/hr per IP
+                                   # and flakes on Vercel; unset → the /api/admin/content/* routes 503.
 HELIUS_API_KEY=                    # Helius key for webhook management + DAS API (lib/helius)
 HELIUS_WEBHOOK_SECRET=             # Helius webhook signature verification
 BACKEND_SIGNER_SECRET=             # Rotatable backend co-signer keypair (completeLesson etc.)

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -23,6 +23,7 @@
     "@metaplex-foundation/umi-web3js-adapters": "^1.5.1",
     "@monaco-editor/react": "^4.7.0",
     "@noble/hashes": "^1.8.0",
+    "image-size": "^1.2.1",
     "@phosphor-icons/react": "^2.1.10",
     "@radix-ui/react-avatar": "^1.1.0",
     "@radix-ui/react-dialog": "^1.1.0",
@@ -71,6 +72,7 @@
     "tailwind-merge": "^2.4.0",
     "tailwindcss-animate": "^1.0.7",
     "tweetnacl": "^1.0.3",
+    "yaml": "^2.8.2",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/apps/web/src/app/[locale]/admin/admin-client.tsx
+++ b/apps/web/src/app/[locale]/admin/admin-client.tsx
@@ -8,6 +8,7 @@ import {
 } from "@/components/admin/course-review-queue";
 import { AchievementSyncTable } from "@/components/admin/achievement-sync-table";
 import { DataResyncPanel } from "@/components/admin/data-resync-panel";
+import { ContentSyncPanel } from "@/components/admin/content-sync-panel";
 import { TeacherRolesPanel } from "@/components/admin/teacher-roles-panel";
 import { LearningPathsPanel } from "@/components/admin/learning-paths-panel";
 import { CourseTagsPanel } from "@/components/admin/course-tags-panel";
@@ -211,6 +212,16 @@ export function AdminClient() {
               onRefresh={() => void fetchStatus()}
             />
           )}
+        </div>
+      </section>
+
+      {/* Content Sync (repo → Sanity → devnet) */}
+      <section>
+        <h2 className="mb-4 font-display text-lg font-bold text-text">
+          Content Sync
+        </h2>
+        <div className="rounded-lg border border-border bg-card p-4 shadow-card">
+          <ContentSyncPanel />
         </div>
       </section>
 

--- a/apps/web/src/app/api/CLAUDE.md
+++ b/apps/web/src/app/api/CLAUDE.md
@@ -1,4 +1,4 @@
-# Frontend API Routes (34 routes)
+# Frontend API Routes (36 routes)
 
 ## Auth
 
@@ -54,15 +54,17 @@
 
 ## Admin
 
-| Route                           | Method | Auth         | Purpose                                             |
-| ------------------------------- | ------ | ------------ | --------------------------------------------------- |
-| `/api/admin/auth`               | POST   | ADMIN_SECRET | Admin authentication                                |
-| `/api/admin/status`             | GET    | ADMIN_SECRET | Platform status (program liveness, authority match) |
-| `/api/admin/courses/sync`       | POST   | ADMIN_SECRET | Deploy course PDA + collection on-chain             |
-| `/api/admin/courses/deactivate` | POST   | ADMIN_SECRET | Set course `is_active = false`                      |
-| `/api/admin/courses/reactivate` | POST   | ADMIN_SECRET | Set course `is_active = true`                       |
-| `/api/admin/achievements/sync`  | POST   | ADMIN_SECRET | Deploy achievement type + collection on-chain       |
-| `/api/admin/resync`             | POST   | ADMIN_SECRET | Resync on-chain state to Supabase                   |
+| Route                           | Method | Auth         | Purpose                                                                         |
+| ------------------------------- | ------ | ------------ | ------------------------------------------------------------------------------- |
+| `/api/admin/auth`               | POST   | ADMIN_SECRET | Admin authentication                                                            |
+| `/api/admin/status`             | GET    | ADMIN_SECRET | Platform status (program liveness, authority match)                             |
+| `/api/admin/courses/sync`       | POST   | ADMIN_SECRET | Deploy course PDA + collection on-chain                                         |
+| `/api/admin/courses/deactivate` | POST   | ADMIN_SECRET | Set course `is_active = false`                                                  |
+| `/api/admin/courses/reactivate` | POST   | ADMIN_SECRET | Set course `is_active = true`                                                   |
+| `/api/admin/achievements/sync`  | POST   | ADMIN_SECRET | Deploy achievement type + collection on-chain                                   |
+| `/api/admin/resync`             | POST   | ADMIN_SECRET | Resync on-chain state to Supabase                                               |
+| `/api/admin/content/sync`       | POST   | ADMIN_SECRET | Sync academy-courses@sha → Sanity (re-validate, PRESERVE, prune, content_tx_id) |
+| `/api/admin/content/drift`      | GET    | ADMIN_SECRET | Three-way drift: content (repo→Sanity) + chain (Sanity→devnet)                  |
 
 ## Route Conventions
 

--- a/apps/web/src/app/api/admin/content/drift/__tests__/route.test.ts
+++ b/apps/web/src/app/api/admin/content/drift/__tests__/route.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi } from "vitest";
+import type { NextRequest } from "next/server";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/admin/auth", () => ({
+  AdminAuthError: class extends Error {},
+  adminUnauthorizedResponse: () => new Response("{}", { status: 401 }),
+  requireAdminAuth: vi.fn(),
+}));
+vi.mock("@/lib/content-sync/github", () => ({
+  createGitHubClient: () => ({
+    fetchHeadSha: async () => "b".repeat(40),
+    fetchChecksState: async () => "success",
+    fetchTarball: async () => new Uint8Array(),
+  }),
+}));
+vi.mock("@/lib/sanity/admin-mutations", () => ({
+  readManagedDocuments: async () => [],
+  readContentSyncSingleton: async () => ({ sha: "a".repeat(40) }),
+}));
+vi.mock("@/lib/sanity/queries", () => ({
+  getAllCoursesAdmin: async () => [],
+  COURSES_CACHE_TAG: "courses",
+}));
+
+import { GET } from "../route";
+
+const get = (): Promise<Response> =>
+  GET(
+    new Request("https://x/api/admin/content/drift") as unknown as NextRequest
+  );
+
+describe("GET /api/admin/content/drift", () => {
+  it("returns content drift computed from HEAD vs the singleton", async () => {
+    const res = await get();
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      content: { state: string; canSync: boolean };
+    };
+    expect(body.content.state).toBe("behind"); // synced=a…, head=b…, ci green
+    expect(body.content.canSync).toBe(true);
+  });
+});

--- a/apps/web/src/app/api/admin/content/drift/route.ts
+++ b/apps/web/src/app/api/admin/content/drift/route.ts
@@ -1,0 +1,168 @@
+import "server-only";
+import { NextRequest, NextResponse } from "next/server";
+import { Connection } from "@solana/web3.js";
+import { parse as parseYaml } from "yaml";
+import { serverEnv } from "@/lib/env.server";
+import {
+  requireAdminAuth,
+  adminUnauthorizedResponse,
+  AdminAuthError,
+} from "@/lib/admin/auth";
+import { getAllCoursesAdmin } from "@/lib/sanity/queries";
+import { fetchCourse } from "@/lib/solana/academy-reads";
+import { getProgramId } from "@/lib/solana/pda";
+import {
+  getMissingCourseFields,
+  isDraftId,
+  type SyncStatus,
+} from "@/lib/admin/sync-diff";
+import { readContentSyncSingleton } from "@/lib/sanity/admin-mutations";
+import { createGitHubClient } from "@/lib/content-sync/github";
+import { extractTarball } from "@/lib/content-sync/tarball";
+import { deriveActiveMask } from "@/lib/content-sync/content-commit";
+import {
+  computeContentDrift,
+  computeChainDrift,
+} from "@/lib/content-sync/drift";
+import {
+  GitHubUnavailableError,
+  type RepoTree,
+} from "@/lib/content-sync/types";
+
+/**
+ * The cheap chain-status a course needs for `computeChainDrift`. §11.1 replaces
+ * the field-by-field `diffCourse` heuristic with the `content_tx_id == HEAD`
+ * equality, so only "does the PDA exist / is Sanity complete" survives — both
+ * derivable without decoding the whole on-chain account.
+ */
+function courseDiffStatus(
+  course: Parameters<typeof getMissingCourseFields>[0],
+  onChainExists: boolean
+): SyncStatus {
+  if (isDraftId(course._id)) return "draft";
+  if (getMissingCourseFields(course).length > 0) return "missing_fields";
+  if (!onChainExists) return "not_deployed";
+  return "synced";
+}
+
+/** Map every course id in a synced tree to its committed active_lessons mask. */
+function maskByCourseFromTree(
+  tree: RepoTree
+): Map<string, [bigint, bigint, bigint, bigint]> {
+  const out = new Map<string, [bigint, bigint, bigint, bigint]>();
+  for (const [path, bytes] of tree) {
+    if (!path.endsWith("/course.yaml")) continue;
+    let id: string;
+    try {
+      ({ id } = parseYaml(new TextDecoder().decode(bytes)) as { id: string });
+    } catch {
+      continue;
+    }
+    const lockRaw = tree.get(path.replace(/course\.yaml$/, "slots.lock.json"));
+    if (!lockRaw) continue;
+    try {
+      const slots = JSON.parse(new TextDecoder().decode(lockRaw));
+      out.set(id, deriveActiveMask(slots));
+    } catch {
+      // ignore a malformed lockfile — the mask is omitted for that course
+    }
+  }
+  return out;
+}
+
+/**
+ * GET /api/admin/content/drift — the §11 three-way drift view. Content drift
+ * (repo → Sanity) is always computed; chain drift (Sanity → devnet) is computed
+ * per course via the `content_tx_id == HEAD` equality plus the ordering
+ * interlock (chain sync must wait for content sync). GitHub being unreachable is
+ * a 503 so the panel shows "drift unavailable" rather than crashing.
+ */
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  try {
+    requireAdminAuth(req);
+  } catch (e) {
+    if (e instanceof AdminAuthError) return adminUnauthorizedResponse();
+    throw e;
+  }
+
+  let headSha: string;
+  let checks: Awaited<
+    ReturnType<ReturnType<typeof createGitHubClient>["fetchChecksState"]>
+  >;
+  try {
+    const github = createGitHubClient();
+    headSha = await github.fetchHeadSha();
+    checks = await github.fetchChecksState(headSha);
+  } catch (e) {
+    if (e instanceof GitHubUnavailableError) {
+      return NextResponse.json(
+        { error: e.message, unavailable: true },
+        { status: 503 }
+      );
+    }
+    throw e;
+  }
+
+  const singleton = await readContentSyncSingleton();
+  const syncedSha = singleton?.sha ?? null;
+  const content = computeContentDrift({ syncedSha, headSha, checks });
+  const contentUpToDate = content.state === "up_to_date";
+
+  const courses = await getAllCoursesAdmin();
+
+  // The intended active_lessons mask is only actionable once content is at HEAD
+  // (the ordering interlock). Fetch the synced tree for masks solely in that
+  // case, so a routine drift poll does not download a tarball.
+  let masks = new Map<string, [bigint, bigint, bigint, bigint]>();
+  if (contentUpToDate && syncedSha && courses.length > 0) {
+    try {
+      const tree = await extractTarball(
+        await createGitHubClient().fetchTarball(syncedSha)
+      );
+      masks = maskByCourseFromTree(tree);
+    } catch {
+      // best-effort — masks omitted, chain sync stays disabled for those rows
+    }
+  }
+
+  const connection = new Connection(serverEnv.SOLANA_RPC_URL, "confirmed");
+  const programId = getProgramId();
+
+  const courseRows = await Promise.all(
+    courses.map(async (course) => {
+      let onChainContentTxId: number[] | null = null;
+      let onChainExists = false;
+      try {
+        const onChain = await fetchCourse(course._id, connection, programId);
+        if (onChain) {
+          onChainExists = true;
+          const raw = (onChain as { content_tx_id?: unknown }).content_tx_id;
+          if (Array.isArray(raw)) onChainContentTxId = raw as number[];
+          else if (raw instanceof Uint8Array)
+            onChainContentTxId = Array.from(raw);
+        }
+      } catch {
+        onChainExists = false;
+      }
+      const diffStatus = courseDiffStatus(course, onChainExists);
+      const chainDrift = computeChainDrift({
+        onChainContentTxId,
+        headSha,
+        diffStatus,
+        contentUpToDate,
+      });
+      const mask = masks.get(course._id);
+      return {
+        id: course._id,
+        title: course.title,
+        chainDrift,
+        activeLessons: mask ? mask.map((w) => w.toString()) : null,
+      };
+    })
+  );
+
+  return NextResponse.json({
+    content: { ...content, syncedSha, headSha, checks },
+    courses: courseRows,
+  });
+}

--- a/apps/web/src/app/api/admin/content/sync/__tests__/route.test.ts
+++ b/apps/web/src/app/api/admin/content/sync/__tests__/route.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { NextRequest } from "next/server";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/admin/auth", () => ({
+  AdminAuthError: class AdminAuthError extends Error {},
+  adminUnauthorizedResponse: () =>
+    new Response(JSON.stringify({ error: "Unauthorized" }), { status: 401 }),
+  requireAdminAuth: vi.fn(),
+}));
+const runContentSync = vi.fn();
+vi.mock("@/lib/content-sync/sync", () => ({
+  runContentSync: (...a: unknown[]) => runContentSync(...a),
+}));
+vi.mock("@/lib/content-sync/github", () => ({
+  createGitHubClient: () => ({}),
+}));
+vi.mock("@/lib/content-sync/gateway", () => ({
+  createLiveGateway: () => ({}),
+}));
+vi.mock("@/lib/content-sync/graders", () => ({
+  createLiveGraders: () => ({}),
+}));
+
+import { POST } from "../route";
+import { requireAdminAuth } from "@/lib/admin/auth";
+import {
+  BlockedCommitError,
+  ContentValidationError,
+} from "@/lib/content-sync/types";
+
+const post = (body: unknown): Promise<Response> =>
+  POST(
+    new Request("https://x/api/admin/content/sync", {
+      method: "POST",
+      body: JSON.stringify(body),
+    }) as unknown as NextRequest
+  );
+
+beforeEach(() => {
+  runContentSync.mockReset();
+  (requireAdminAuth as unknown as ReturnType<typeof vi.fn>).mockReset();
+});
+
+describe("POST /api/admin/content/sync", () => {
+  it("401 when the admin cookie is missing", async () => {
+    const { AdminAuthError } =
+      (await import("@/lib/admin/auth")) as unknown as {
+        AdminAuthError: new () => Error;
+      };
+    (
+      requireAdminAuth as unknown as ReturnType<typeof vi.fn>
+    ).mockImplementation(() => {
+      throw new AdminAuthError();
+    });
+    expect((await post({ sha: "a".repeat(40) })).status).toBe(401);
+  });
+
+  it("400 when sha is missing or malformed", async () => {
+    expect((await post({})).status).toBe(400);
+    expect((await post({ sha: "nope" })).status).toBe(400);
+  });
+
+  it("returns the SyncResult on success", async () => {
+    runContentSync.mockResolvedValue({
+      sha: "a".repeat(40),
+      written: 3,
+      skipped: 0,
+      pruned: 0,
+      assetsUploaded: 0,
+      pendingChainDeltas: [],
+    });
+    const res = await post({ sha: "a".repeat(40) });
+    expect(res.status).toBe(200);
+    expect((await res.json()).written).toBe(3);
+  });
+
+  it("409 on a blocked commit", async () => {
+    runContentSync.mockRejectedValue(new BlockedCommitError("a".repeat(40)));
+    expect((await post({ sha: "a".repeat(40) })).status).toBe(409);
+  });
+
+  it("422 with issues on a validation failure", async () => {
+    runContentSync.mockRejectedValue(
+      new ContentValidationError(["bad course id"])
+    );
+    const res = await post({ sha: "a".repeat(40) });
+    expect(res.status).toBe(422);
+    expect((await res.json()).issues).toEqual(["bad course id"]);
+  });
+});

--- a/apps/web/src/app/api/admin/content/sync/route.ts
+++ b/apps/web/src/app/api/admin/content/sync/route.ts
@@ -1,0 +1,86 @@
+import "server-only";
+import { NextRequest, NextResponse } from "next/server";
+import {
+  requireAdminAuth,
+  adminUnauthorizedResponse,
+  AdminAuthError,
+} from "@/lib/admin/auth";
+import { env } from "@/lib/env";
+import { runContentSync } from "@/lib/content-sync/sync";
+import { createGitHubClient } from "@/lib/content-sync/github";
+import { createLiveGateway } from "@/lib/content-sync/gateway";
+import { createLiveGraders } from "@/lib/content-sync/graders";
+import {
+  BlockedCommitError,
+  ContentValidationError,
+  BlastRadiusError,
+  GitHubUnavailableError,
+} from "@/lib/content-sync/types";
+
+/**
+ * POST /api/admin/content/sync — sync academy-courses@sha → Sanity (§9.2).
+ *
+ * Thin handler: auth, parse+guard the body, build the real deps, delegate to
+ * `runContentSync`, map its error classes to status codes. The client sends the
+ * exact `sha` it saw in the drift panel (HEAD is never taken from the client);
+ * the orchestrator re-checks that commit's CI and refuses a red one.
+ *
+ * Note: `runContentSync` never touches the on-chain mask, so `MaskMismatchError`
+ * (a chain-sync error) cannot arise here — that branch lives only in
+ * /api/admin/courses/sync (Task 13).
+ */
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  try {
+    requireAdminAuth(req);
+  } catch (e) {
+    if (e instanceof AdminAuthError) return adminUnauthorizedResponse();
+    throw e;
+  }
+
+  let sha: string;
+  try {
+    const body = (await req.json()) as { sha?: unknown };
+    if (typeof body.sha !== "string" || !/^[0-9a-f]{40}$/i.test(body.sha)) {
+      return NextResponse.json(
+        { error: "a 40-hex commit sha is required" },
+        { status: 400 }
+      );
+    }
+    sha = body.sha;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  try {
+    const result = await runContentSync({
+      sha,
+      github: createGitHubClient(),
+      gateway: createLiveGateway(),
+      graders: createLiveGraders(),
+      projectId: env.NEXT_PUBLIC_SANITY_PROJECT_ID,
+      dataset: env.NEXT_PUBLIC_SANITY_DATASET,
+    });
+    return NextResponse.json(result);
+  } catch (e) {
+    if (e instanceof BlockedCommitError) {
+      return NextResponse.json({ error: e.message }, { status: 409 });
+    }
+    if (e instanceof BlastRadiusError) {
+      return NextResponse.json(
+        { error: e.message, override: "explicit admin override required" },
+        { status: 409 }
+      );
+    }
+    if (e instanceof ContentValidationError) {
+      return NextResponse.json(
+        { error: e.message, issues: e.issues },
+        { status: 422 }
+      );
+    }
+    if (e instanceof GitHubUnavailableError) {
+      return NextResponse.json({ error: e.message }, { status: 503 });
+    }
+    console.error("[admin/content/sync]", e);
+    return NextResponse.json({ error: "Content sync failed" }, { status: 500 });
+  }
+}

--- a/apps/web/src/app/api/admin/courses/sync/route.ts
+++ b/apps/web/src/app/api/admin/courses/sync/route.ts
@@ -4,6 +4,7 @@ import { revalidateTag } from "next/cache";
 import { NextRequest, NextResponse } from "next/server";
 import { Connection } from "@solana/web3.js";
 import { PublicKey } from "@solana/web3.js";
+import { parse as parseYaml } from "yaml";
 import { serverEnv } from "@/lib/env.server";
 import {
   requireAdminAuth,
@@ -18,6 +19,7 @@ import {
   updateCoursePda,
   deployCourseTrackCollection,
   setCourseCollectionPda,
+  buildCourseCommit,
 } from "@/lib/solana/admin-signer";
 import {
   difficultyToNumber,
@@ -27,8 +29,77 @@ import {
 import {
   writeCourseOnChainStatus,
   writeCourseTrackCollection,
+  readContentSyncSingleton,
 } from "@/lib/sanity/admin-mutations";
 import { createAdminClient } from "@/lib/supabase/admin";
+import { createGitHubClient } from "@/lib/content-sync/github";
+import { extractTarball } from "@/lib/content-sync/tarball";
+import {
+  MaskMismatchError,
+  GitHubUnavailableError,
+} from "@/lib/content-sync/types";
+
+interface SlotsLock {
+  version: number;
+  slots: Record<string, number>;
+  retired: number[];
+  next: number;
+}
+
+/**
+ * Load a course's committed `slots.lock.json` from the last-synced tree (§11.0).
+ * Sourced independently of the panel's mask — that independence is what makes
+ * the `buildCourseCommit` assertion a real cross-check rather than a tautology.
+ * Throws when content sync has not yet ingested this course (ordering interlock:
+ * the mask commitment cannot be computed from a Sanity/tree that predates the
+ * course), or when GitHub is unavailable.
+ */
+async function readCourseSlotsLock(
+  courseId: string
+): Promise<{ contentSha: string; slotsLock: SlotsLock }> {
+  const singleton = await readContentSyncSingleton();
+  if (!singleton) {
+    throw new Error(
+      "No content sync has run yet — run content sync before committing the mask on-chain"
+    );
+  }
+  const tree = await extractTarball(
+    await createGitHubClient().fetchTarball(singleton.sha)
+  );
+  for (const [path, bytes] of tree) {
+    if (!path.endsWith("/course.yaml")) continue;
+    const { id } = parseYaml(new TextDecoder().decode(bytes)) as { id: string };
+    if (id !== courseId) continue;
+    const raw = tree.get(path.replace(/course\.yaml$/, "slots.lock.json"));
+    if (!raw)
+      throw new Error(`${courseId}: no slots.lock.json next to ${path}`);
+    return {
+      contentSha: singleton.sha,
+      slotsLock: JSON.parse(new TextDecoder().decode(raw)) as SlotsLock,
+    };
+  }
+  throw new Error(
+    `${courseId}: not found in the synced tree at ${singleton.sha}`
+  );
+}
+
+/** Validate a `[u64, u64, u64, u64]` mask sent as decimal strings. */
+function parseActiveLessons(
+  value: unknown
+): [bigint, bigint, bigint, bigint] | null {
+  if (!Array.isArray(value) || value.length !== 4) return null;
+  try {
+    const words = value.map((w) => {
+      if (typeof w !== "string") throw new Error("not a string");
+      const n = BigInt(w);
+      if (n < 0n) throw new Error("negative");
+      return n;
+    });
+    return [words[0]!, words[1]!, words[2]!, words[3]!];
+  } catch {
+    return null;
+  }
+}
 
 // Default creator reward for TEACHER-authored courses (those with a real author
 // wallet) when the fields are unset. Platform/admin courses stay at 0. Starting
@@ -45,8 +116,16 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   }
 
   let courseId: string;
+  // Optional §11.0 commitment: the mask the admin panel's pending-sync state
+  // intends to send (u64 words as decimal strings). When present, the on-chain
+  // content_tx_id is committed in the same update and the mask is cross-checked
+  // against the committed slots.lock.json. Absent → legacy behaviour, unchanged.
+  let activeLessons: [bigint, bigint, bigint, bigint] | null = null;
   try {
-    const body = (await req.json()) as { courseId?: unknown };
+    const body = (await req.json()) as {
+      courseId?: unknown;
+      activeLessons?: unknown;
+    };
     if (typeof body.courseId !== "string" || !body.courseId) {
       return NextResponse.json(
         { error: "courseId is required" },
@@ -54,6 +133,18 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
       );
     }
     courseId = body.courseId;
+    if (body.activeLessons !== undefined) {
+      activeLessons = parseActiveLessons(body.activeLessons);
+      if (!activeLessons) {
+        return NextResponse.json(
+          {
+            error:
+              "activeLessons must be a [u64,u64,u64,u64] of decimal strings",
+          },
+          { status: 400 }
+        );
+      }
+    }
   } catch {
     return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
   }
@@ -319,8 +410,47 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     newCreatorRewardXp?: number;
     newMinCompletionsForReward?: number;
     newLessonCount?: number;
+    contentTxId?: number[];
   } = { courseId };
   const updatedFields: string[] = [];
+
+  // §11.0 content commitment. When the panel sends its intended active_lessons
+  // mask, load the committed lockfile INDEPENDENTLY (from the synced tree) and
+  // assert the two agree right before signing — update_course trusts the
+  // authority blindly, so this is where the "slots never reused" invariant is
+  // enforced. The git SHA is committed into content_tx_id in the same update.
+  // (active_lessons itself is written on-chain only once program v2 exposes the
+  // field; until then the assertion + SHA commitment land.)
+  if (activeLessons) {
+    let commit: ReturnType<typeof buildCourseCommit>;
+    try {
+      const { contentSha, slotsLock } = await readCourseSlotsLock(courseId);
+      commit = buildCourseCommit({
+        courseId,
+        contentSha,
+        slotsLock,
+        activeLessons,
+      });
+    } catch (e) {
+      if (e instanceof MaskMismatchError) {
+        return NextResponse.json({ error: e.message }, { status: 409 });
+      }
+      if (e instanceof GitHubUnavailableError) {
+        return NextResponse.json({ error: e.message }, { status: 503 });
+      }
+      return NextResponse.json(
+        {
+          error:
+            e instanceof Error
+              ? e.message
+              : "Failed to load committed lockfile",
+        },
+        { status: 409 }
+      );
+    }
+    updateParams.contentTxId = commit.contentTxId;
+    updatedFields.push("contentTxId");
+  }
 
   if (course.xpPerLesson !== null) {
     updateParams.newXpPerLesson = course.xpPerLesson;

--- a/apps/web/src/components/admin/content-sync-panel.tsx
+++ b/apps/web/src/components/admin/content-sync-panel.tsx
@@ -1,0 +1,236 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useTranslations } from "next-intl";
+
+type ContentDriftState = "up_to_date" | "behind" | "never_synced" | "blocked";
+
+type ChainDriftState =
+  | "content_current"
+  | "content_stale"
+  | "not_deployed"
+  | "missing_fields"
+  | "awaiting_content_sync";
+
+interface CourseRow {
+  id: string;
+  title: string;
+  chainDrift: ChainDriftState;
+  activeLessons: string[] | null;
+}
+
+interface DriftResponse {
+  content: {
+    state: ContentDriftState;
+    canSync: boolean;
+    syncedSha: string | null;
+    headSha: string;
+    checks: string;
+  };
+  courses: CourseRow[];
+}
+
+const BUTTON_CLASSES =
+  "rounded-md border border-border bg-card px-4 py-2 text-sm font-medium text-text shadow-push-sm transition-all hover:bg-subtle active:translate-y-[2px] active:shadow-push-active focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary disabled:pointer-events-none disabled:opacity-50";
+
+const short = (sha: string | null): string => (sha ? sha.slice(0, 7) : "—");
+
+export function ContentSyncPanel() {
+  const t = useTranslations("adminContentSync");
+  const [drift, setDrift] = useState<DriftResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [unavailable, setUnavailable] = useState(false);
+  const [syncing, setSyncing] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+  const [chainBusy, setChainBusy] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setUnavailable(false);
+    try {
+      const res = await fetch("/api/admin/content/drift");
+      if (!res.ok) {
+        setUnavailable(true);
+        setDrift(null);
+        return;
+      }
+      setDrift((await res.json()) as DriftResponse);
+    } catch {
+      setUnavailable(true);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const runContentSync = useCallback(async () => {
+    if (!drift) return;
+    setSyncing(true);
+    setMessage(null);
+    try {
+      const res = await fetch("/api/admin/content/sync", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ sha: drift.content.headSha }),
+      });
+      const body = (await res.json().catch(() => ({}))) as {
+        error?: string;
+        written?: number;
+        pruned?: number;
+      };
+      if (!res.ok) {
+        setMessage(body.error ?? t("syncFailed"));
+      } else {
+        setMessage(
+          t("syncSucceeded", {
+            written: body.written ?? 0,
+            pruned: body.pruned ?? 0,
+          })
+        );
+        await load();
+      }
+    } catch {
+      setMessage(t("syncFailed"));
+    } finally {
+      setSyncing(false);
+    }
+  }, [drift, t, load]);
+
+  const runChainSync = useCallback(
+    async (row: CourseRow) => {
+      if (!row.activeLessons) return;
+      setChainBusy(row.id);
+      setMessage(null);
+      try {
+        const res = await fetch("/api/admin/courses/sync", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            courseId: row.id,
+            activeLessons: row.activeLessons,
+          }),
+        });
+        const body = (await res.json().catch(() => ({}))) as { error?: string };
+        setMessage(
+          res.ok
+            ? t("chainSyncSucceeded", { id: row.id })
+            : (body.error ?? t("chainSyncFailed"))
+        );
+        if (res.ok) await load();
+      } catch {
+        setMessage(t("chainSyncFailed"));
+      } finally {
+        setChainBusy(null);
+      }
+    },
+    [t, load]
+  );
+
+  if (loading) {
+    return <p className="text-sm text-text-3">{t("loading")}</p>;
+  }
+
+  if (unavailable || !drift) {
+    return (
+      <div className="space-y-3">
+        <div
+          role="alert"
+          className="rounded-md border border-danger bg-danger-light p-3 text-sm text-danger"
+        >
+          {t("driftUnavailable")}
+        </div>
+        <button className={BUTTON_CLASSES} onClick={() => void load()}>
+          {t("retry")}
+        </button>
+      </div>
+    );
+  }
+
+  const { content, courses } = drift;
+  const contentUpToDate = content.state === "up_to_date";
+  const bannerTone =
+    content.state === "up_to_date"
+      ? "border-success bg-success-light text-success"
+      : content.state === "blocked"
+        ? "border-danger bg-danger-light text-danger"
+        : "border-border bg-subtle text-text-2";
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-text-3">{t("description")}</p>
+
+      <div className={`rounded-md border p-3 text-sm ${bannerTone}`}>
+        <div className="mb-2 font-medium">{t(`state.${content.state}`)}</div>
+        <div className="flex flex-wrap gap-x-4 gap-y-1 font-mono text-xs text-text-2">
+          <span>{t("head", { sha: short(content.headSha) })}</span>
+          <span>{t("synced", { sha: short(content.syncedSha) })}</span>
+          <span>{t("ci", { state: content.checks })}</span>
+        </div>
+      </div>
+
+      <button
+        className={BUTTON_CLASSES}
+        onClick={() => void runContentSync()}
+        disabled={!content.canSync || syncing}
+        aria-disabled={!content.canSync || syncing}
+      >
+        {syncing ? t("syncing") : t("syncButton")}
+      </button>
+
+      {message && (
+        <div
+          role="status"
+          className="rounded-md border border-border bg-subtle p-3 text-sm text-text-2"
+        >
+          {message}
+        </div>
+      )}
+
+      <div>
+        <h3 className="mb-2 text-sm font-semibold text-text">
+          {t("coursesHeading")}
+        </h3>
+        {courses.length === 0 ? (
+          <p className="text-sm text-text-3">{t("noCourses")}</p>
+        ) : (
+          <ul className="divide-y divide-border rounded-md border border-border">
+            {courses.map((row) => {
+              const canChainSync =
+                contentUpToDate &&
+                row.activeLessons !== null &&
+                row.chainDrift !== "content_current";
+              return (
+                <li
+                  key={row.id}
+                  className="flex items-center justify-between gap-3 p-3"
+                >
+                  <div className="min-w-0">
+                    <div className="truncate text-sm font-medium text-text">
+                      {row.title}
+                    </div>
+                    <div className="text-xs text-text-3">
+                      {t(`chain.${row.chainDrift}`)}
+                    </div>
+                  </div>
+                  <button
+                    className={`${BUTTON_CLASSES} shrink-0`}
+                    onClick={() => void runChainSync(row)}
+                    disabled={!canChainSync || chainBusy === row.id}
+                    aria-disabled={!canChainSync || chainBusy === row.id}
+                  >
+                    {chainBusy === row.id
+                      ? t("chainSyncing")
+                      : t("chainSyncButton")}
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/lib/content-sync/__tests__/_fixtures.ts
+++ b/apps/web/src/lib/content-sync/__tests__/_fixtures.ts
@@ -6,19 +6,40 @@ import { stringify } from "yaml";
  * Shared by tarball.test.ts and sync.test.ts so the archive layout stays in one
  * place. Keys are the full tar entry names (including the generated top dir).
  */
+const enc = new TextEncoder();
+const blen = (s: string): number => enc.encode(s).length;
+
+/**
+ * Split a path across the ustar `name` (100) and `prefix` (155) fields at a `/`
+ * boundary, exactly as `git archive` does for a path longer than 100 bytes.
+ * Throws if no boundary yields a valid split (a single component > 100 bytes),
+ * which our fixture paths never hit.
+ */
+function splitUstarName(path: string): { name: string; prefix: string } {
+  if (blen(path) <= 100) return { name: path, prefix: "" };
+  for (let i = path.length - 1; i > 0; i--) {
+    if (path[i] !== "/") continue;
+    const prefix = path.slice(0, i);
+    const name = path.slice(i + 1);
+    if (blen(name) <= 100 && blen(prefix) <= 155) return { name, prefix };
+  }
+  throw new Error(`path too long to encode in ustar: ${path}`);
+}
+
 export function makeTar(
   files: Record<string, string | Uint8Array>
 ): Uint8Array {
-  const enc = new TextEncoder();
   const blocks: Uint8Array[] = [];
   const pad = (b: Uint8Array): Uint8Array => {
     const rem = b.length % 512;
     return rem === 0 ? b : new Uint8Array([...b, ...new Uint8Array(512 - rem)]);
   };
-  for (const [name, raw] of Object.entries(files)) {
+  for (const [path, raw] of Object.entries(files)) {
     const body = typeof raw === "string" ? enc.encode(raw) : raw;
+    const { name, prefix } = splitUstarName(path);
     const header = new Uint8Array(512);
     header.set(enc.encode(name), 0); // name (100)
+    if (prefix) header.set(enc.encode(prefix), 345); // ustar prefix (155)
     header.set(enc.encode("0000644"), 100); // mode
     header.set(enc.encode("0000000"), 108); // uid
     header.set(enc.encode("0000000"), 116); // gid

--- a/apps/web/src/lib/content-sync/__tests__/_fixtures.ts
+++ b/apps/web/src/lib/content-sync/__tests__/_fixtures.ts
@@ -1,0 +1,111 @@
+import { gzipSync } from "node:zlib";
+import { stringify } from "yaml";
+
+/**
+ * Build a minimal, spec-compliant POSIX tar (512-byte records) in-memory.
+ * Shared by tarball.test.ts and sync.test.ts so the archive layout stays in one
+ * place. Keys are the full tar entry names (including the generated top dir).
+ */
+export function makeTar(
+  files: Record<string, string | Uint8Array>
+): Uint8Array {
+  const enc = new TextEncoder();
+  const blocks: Uint8Array[] = [];
+  const pad = (b: Uint8Array): Uint8Array => {
+    const rem = b.length % 512;
+    return rem === 0 ? b : new Uint8Array([...b, ...new Uint8Array(512 - rem)]);
+  };
+  for (const [name, raw] of Object.entries(files)) {
+    const body = typeof raw === "string" ? enc.encode(raw) : raw;
+    const header = new Uint8Array(512);
+    header.set(enc.encode(name), 0); // name (100)
+    header.set(enc.encode("0000644"), 100); // mode
+    header.set(enc.encode("0000000"), 108); // uid
+    header.set(enc.encode("0000000"), 116); // gid
+    const size = body.length.toString(8).padStart(11, "0");
+    header.set(enc.encode(size), 124); // size (octal, 12)
+    header.set(enc.encode("00000000000"), 136); // mtime
+    header[156] = "0".charCodeAt(0); // typeflag: regular file
+    header.set(enc.encode("ustar\0"), 257);
+    header.set(enc.encode("00"), 263);
+    // checksum: sum of bytes with the checksum field treated as spaces
+    header.fill(32, 148, 156);
+    let sum = 0;
+    for (const byte of header) sum += byte;
+    header.set(enc.encode(sum.toString(8).padStart(6, "0") + "\0 "), 148);
+    blocks.push(header, pad(body));
+  }
+  blocks.push(new Uint8Array(1024)); // two zero blocks = end of archive
+  const total = blocks.reduce((n, b) => n + b.length, 0);
+  const out = new Uint8Array(total);
+  let off = 0;
+  for (const b of blocks) {
+    out.set(b, off);
+    off += b.length;
+  }
+  return out;
+}
+
+/** A real 1x1 transparent PNG (68 bytes) — the image-size probe reads 1x1 from it. */
+export const PNG_1X1 = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=",
+  "base64"
+);
+
+const courseYaml = stringify({
+  id: "course-demo",
+  slug: "demo",
+  title: "Demo",
+  description: "d",
+  difficulty: "beginner",
+  duration: 1,
+  xpPerLesson: 10,
+  xpReward: 100,
+  creator: { githubId: "1" },
+  modules: [{ key: "m", title: "M", lessons: ["lesson-accounts"] }],
+});
+
+const slotsLockJson = JSON.stringify({
+  version: 1,
+  slots: { "lesson-accounts": 0 },
+  retired: [],
+  next: 1,
+});
+
+function lessonYaml(withImage: boolean): string {
+  void withImage;
+  return stringify({
+    id: "lesson-accounts",
+    slug: "accounts",
+    title: "Accounts",
+    blocks: [{ key: "intro", type: "prose", src: "intro.md" }],
+  });
+}
+
+/**
+ * A one-course, one-lesson gzipped tarball (course.yaml, slots.lock.json,
+ * lesson.yaml, intro.md), keyed under a generated `owner-repo-<sha>/` top dir so
+ * `extractTarball` strips it exactly as it would a real GitHub tarball. With
+ * `withImage: true` the tree also carries `assets/pixel.png` (PNG_1X1),
+ * referenced from intro.md so the asset pipeline has something to sync.
+ */
+export function makeCourseTarball(
+  sha: string,
+  opts: { withImage?: boolean } = {}
+): Uint8Array {
+  const top = `solanabr-academy-courses-${sha}`;
+  const lessonDir = `${top}/courses/demo/lessons/accounts`;
+  const intro = opts.withImage
+    ? "# Accounts\n\nSee ![pixel](assets/pixel.png) here.\n"
+    : "# Accounts\n";
+  const files: Record<string, string | Uint8Array> = {
+    [`${top}/courses/demo/course.yaml`]: courseYaml,
+    [`${top}/courses/demo/slots.lock.json`]: slotsLockJson,
+    [`${lessonDir}/lesson.yaml`]: lessonYaml(opts.withImage ?? false),
+    [`${lessonDir}/intro.md`]: intro,
+  };
+  if (opts.withImage) {
+    files[`${lessonDir}/assets/pixel.png`] = new Uint8Array(PNG_1X1);
+  }
+  return gzipSync(Buffer.from(makeTar(files)));
+}

--- a/apps/web/src/lib/content-sync/__tests__/assets.test.ts
+++ b/apps/web/src/lib/content-sync/__tests__/assets.test.ts
@@ -1,0 +1,47 @@
+import { createHash } from "node:crypto";
+import { describe, it, expect } from "vitest";
+import { computeAssetId, rewriteMarkdownAssetPaths, cdnUrl } from "../assets";
+
+describe("computeAssetId", () => {
+  it("derives image-<sha1>-<dims>-<format> from the bytes", () => {
+    const bytes = new Uint8Array([1, 2, 3, 4]);
+    const sha1 = createHash("sha1").update(Buffer.from(bytes)).digest("hex");
+    expect(computeAssetId(bytes, { width: 640, height: 480 }, "png")).toBe(
+      `image-${sha1}-640x480-png`
+    );
+  });
+
+  it("is stable — same bytes yield the same id (dedupe key)", () => {
+    const b = new Uint8Array([9, 9, 9]);
+    expect(computeAssetId(b, { width: 1, height: 1 }, "png")).toBe(
+      computeAssetId(b, { width: 1, height: 1 }, "png")
+    );
+  });
+});
+
+describe("rewriteMarkdownAssetPaths", () => {
+  it("rewrites a relative image path to its resolved CDN url", () => {
+    const md = "See ![accounts](assets/accounts.png) here.";
+    const out = rewriteMarkdownAssetPaths(md, (rel) =>
+      rel === "assets/accounts.png"
+        ? "https://cdn.sanity.io/images/p/d/x-1x1.png"
+        : null
+    );
+    expect(out).toBe(
+      "See ![accounts](https://cdn.sanity.io/images/p/d/x-1x1.png) here."
+    );
+  });
+
+  it("leaves absolute/remote urls untouched", () => {
+    const md = "![x](https://example.com/x.png)";
+    expect(rewriteMarkdownAssetPaths(md, () => "SHOULD_NOT_BE_USED")).toBe(md);
+  });
+});
+
+describe("cdnUrl", () => {
+  it("builds the Sanity CDN url for an asset id", () => {
+    expect(cdnUrl("image-abc-640x480-png", "proj", "production")).toBe(
+      "https://cdn.sanity.io/images/proj/production/abc-640x480.png"
+    );
+  });
+});

--- a/apps/web/src/lib/content-sync/__tests__/content-commit.test.ts
+++ b/apps/web/src/lib/content-sync/__tests__/content-commit.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import {
+  padContentTxId,
+  contentTxIdMatchesHead,
+  deriveActiveMask,
+  assertMaskMatchesLockfile,
+} from "../content-commit";
+import { MaskMismatchError } from "../types";
+
+const sha = "a".repeat(40); // 20 bytes of 0xaa
+
+describe("padContentTxId", () => {
+  it("left-pads the 20-byte sha into 32 bytes (12 leading zeros)", () => {
+    const bytes = padContentTxId(sha);
+    expect(bytes).toHaveLength(32);
+    expect(bytes.slice(0, 12)).toEqual(Array(12).fill(0));
+    expect(bytes.slice(12)).toEqual(Array(20).fill(0xaa));
+  });
+
+  it("rejects a non-40-hex sha", () => {
+    expect(() => padContentTxId("abc")).toThrow();
+  });
+});
+
+describe("contentTxIdMatchesHead", () => {
+  it("is true when the on-chain bytes equal the padded head sha", () => {
+    expect(contentTxIdMatchesHead(padContentTxId(sha), sha)).toBe(true);
+  });
+  it("is false for the all-zero legacy value", () => {
+    expect(contentTxIdMatchesHead(Array(32).fill(0), sha)).toBe(false);
+  });
+  it("accepts a Uint8Array as well as number[]", () => {
+    expect(
+      contentTxIdMatchesHead(new Uint8Array(padContentTxId(sha)), sha)
+    ).toBe(true);
+  });
+});
+
+describe("deriveActiveMask", () => {
+  it("sets a bit per live slot and clears retired ones", () => {
+    // slots 0 and 2 live, slot 1 retired → mask low word = 0b101 = 5
+    const mask = deriveActiveMask({
+      version: 1,
+      slots: { a: 0, b: 1, c: 2 },
+      retired: [1],
+      next: 3,
+    });
+    expect(mask[0]).toBe(5n);
+    expect(mask.slice(1)).toEqual([0n, 0n, 0n]);
+  });
+
+  it("places a high slot in the correct u64 word", () => {
+    const mask = deriveActiveMask({
+      version: 1,
+      slots: { x: 64 },
+      retired: [],
+      next: 65,
+    });
+    expect(mask[0]).toBe(0n);
+    expect(mask[1]).toBe(1n);
+  });
+});
+
+describe("assertMaskMatchesLockfile", () => {
+  const slots = { version: 1, slots: { a: 0, c: 2 }, retired: [], next: 3 };
+  it("passes when the mask to send equals the lockfile-derived mask", () => {
+    expect(() =>
+      assertMaskMatchesLockfile("course-x", [5n, 0n, 0n, 0n], slots)
+    ).not.toThrow();
+  });
+  it("throws MaskMismatchError when the panel would set an arbitrary bit", () => {
+    expect(() =>
+      assertMaskMatchesLockfile("course-x", [7n, 0n, 0n, 0n], slots)
+    ).toThrow(MaskMismatchError);
+  });
+});

--- a/apps/web/src/lib/content-sync/__tests__/drift.test.ts
+++ b/apps/web/src/lib/content-sync/__tests__/drift.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from "vitest";
+import {
+  computeContentDrift,
+  computeChainDrift,
+  assertCommitSyncable,
+} from "../drift";
+import { padContentTxId } from "../content-commit";
+import { BlockedCommitError } from "../types";
+
+const HEAD = "b".repeat(40);
+
+describe("computeContentDrift", () => {
+  it("never_synced when there is no contentSync doc", () => {
+    expect(
+      computeContentDrift({ syncedSha: null, headSha: HEAD, checks: "success" })
+    ).toEqual({
+      state: "never_synced",
+      canSync: true,
+    });
+  });
+
+  it("up_to_date when synced sha equals HEAD", () => {
+    expect(
+      computeContentDrift({ syncedSha: HEAD, headSha: HEAD, checks: "success" })
+    ).toEqual({
+      state: "up_to_date",
+      canSync: false,
+    });
+  });
+
+  it("blocked (cannot sync) when HEAD's CI is failing", () => {
+    expect(
+      computeContentDrift({
+        syncedSha: "old",
+        headSha: HEAD,
+        checks: "failure",
+      })
+    ).toEqual({
+      state: "blocked",
+      canSync: false,
+    });
+  });
+
+  it("behind when HEAD is ahead and CI is green", () => {
+    expect(
+      computeContentDrift({
+        syncedSha: "old",
+        headSha: HEAD,
+        checks: "success",
+      })
+    ).toEqual({
+      state: "behind",
+      canSync: true,
+    });
+  });
+
+  it("blocked overrides never_synced when HEAD is red", () => {
+    expect(
+      computeContentDrift({ syncedSha: null, headSha: HEAD, checks: "failure" })
+        .canSync
+    ).toBe(false);
+  });
+});
+
+describe("computeChainDrift", () => {
+  it("content_current when content_tx_id equals the padded HEAD sha", () => {
+    expect(
+      computeChainDrift({
+        onChainContentTxId: padContentTxId(HEAD),
+        headSha: HEAD,
+        diffStatus: "synced",
+        contentUpToDate: true,
+      })
+    ).toBe("content_current");
+  });
+
+  it("content_stale when the tx id is the legacy zeros", () => {
+    expect(
+      computeChainDrift({
+        onChainContentTxId: Array(32).fill(0),
+        headSha: HEAD,
+        diffStatus: "synced",
+        contentUpToDate: true,
+      })
+    ).toBe("content_stale");
+  });
+
+  it("passes through not_deployed from diffCourse", () => {
+    expect(
+      computeChainDrift({
+        onChainContentTxId: null,
+        headSha: HEAD,
+        diffStatus: "not_deployed",
+        contentUpToDate: true,
+      })
+    ).toBe("not_deployed");
+  });
+
+  it("blocks the chain-drift verdict until content sync has landed (ordering interlock)", () => {
+    expect(
+      computeChainDrift({
+        onChainContentTxId: null,
+        headSha: HEAD,
+        diffStatus: "synced",
+        contentUpToDate: false,
+      })
+    ).toBe("awaiting_content_sync");
+  });
+});
+
+describe("assertCommitSyncable", () => {
+  it("throws BlockedCommitError on red CI", () => {
+    expect(() => assertCommitSyncable("failure", "sha")).toThrow(
+      BlockedCommitError
+    );
+  });
+  it("throws on pending CI (do not sync an unfinished commit)", () => {
+    expect(() => assertCommitSyncable("pending", "sha")).toThrow(
+      BlockedCommitError
+    );
+  });
+  it("passes on green CI", () => {
+    expect(() => assertCommitSyncable("success", "sha")).not.toThrow();
+  });
+});

--- a/apps/web/src/lib/content-sync/__tests__/executor-gate.test.ts
+++ b/apps/web/src/lib/content-sync/__tests__/executor-gate.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from "vitest";
+import { gateCodeBlock, type GraderSet } from "../executor-gate";
+
+const tests = [{ id: "t1", description: "d", input: "", expectedOutput: "42" }];
+
+// Fake graders: a submission "passes" iff it equals the string "SOLUTION".
+const graders: GraderSet = {
+  js: async (code) => ({ passed: code.trim() === "SOLUTION", failures: [] }),
+  rust: async (code) => ({ passed: code.trim() === "SOLUTION", failures: [] }),
+  buildable: async (code) => ({
+    passed: code.trim() === "SOLUTION",
+    failures: [],
+  }),
+};
+
+const files = (starter: string, solution: string) => ({
+  starter,
+  solution,
+  tests,
+});
+
+describe("gateCodeBlock", () => {
+  it("passes when the solution passes and the starter fails", async () => {
+    const block = {
+      key: "ex",
+      type: "code",
+      language: "typescript" as const,
+      buildType: "standard" as const,
+    };
+    const issues = await gateCodeBlock(
+      block,
+      files("STARTER", "SOLUTION"),
+      graders
+    );
+    expect(issues).toEqual([]);
+  });
+
+  it("rejects when the reference solution does NOT pass its own tests", async () => {
+    const block = {
+      key: "ex",
+      type: "code",
+      language: "typescript" as const,
+      buildType: "standard" as const,
+    };
+    const issues = await gateCodeBlock(
+      block,
+      files("STARTER", "BROKEN"),
+      graders
+    );
+    expect(issues.join(" ")).toContain("solution does not pass");
+  });
+
+  it("rejects when the starter already passes (nothing to solve)", async () => {
+    const block = {
+      key: "ex",
+      type: "code",
+      language: "typescript" as const,
+      buildType: "standard" as const,
+    };
+    const issues = await gateCodeBlock(
+      block,
+      files("SOLUTION", "SOLUTION"),
+      graders
+    );
+    expect(issues.join(" ")).toContain("starter already passes");
+  });
+
+  it("routes a rust standard block to the rust grader", async () => {
+    let used = "";
+    const spy: GraderSet = {
+      ...graders,
+      rust: async (c) => (
+        (used = "rust"),
+        { passed: c.trim() === "SOLUTION", failures: [] }
+      ),
+    };
+    const block = {
+      key: "ex",
+      type: "code",
+      language: "rust" as const,
+      buildType: "standard" as const,
+    };
+    await gateCodeBlock(block, files("STARTER", "SOLUTION"), spy);
+    expect(used).toBe("rust");
+  });
+
+  it("routes a buildable block to the buildable grader", async () => {
+    let used = "";
+    const spy: GraderSet = {
+      ...graders,
+      buildable: async (c) => (
+        (used = "buildable"),
+        { passed: c.trim() === "SOLUTION", failures: [] }
+      ),
+    };
+    const block = {
+      key: "ex",
+      type: "code",
+      language: "rust" as const,
+      buildType: "buildable" as const,
+    };
+    await gateCodeBlock(block, files("STARTER", "SOLUTION"), spy);
+    expect(used).toBe("buildable");
+  });
+});

--- a/apps/web/src/lib/content-sync/__tests__/gateway.test.ts
+++ b/apps/web/src/lib/content-sync/__tests__/gateway.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+import { InMemoryGateway } from "../gateway";
+import type { SanityDoc } from "../types";
+
+describe("InMemoryGateway (test double)", () => {
+  it("records writes, deletes, asset uploads and the singleton", async () => {
+    const gw = new InMemoryGateway([{ _id: "lesson-a", _type: "lesson" }]);
+    expect((await gw.readManaged()).map((d) => d._id)).toEqual(["lesson-a"]);
+
+    await gw.writeDocs([{ _id: "lesson-b", _type: "lesson" } as SanityDoc]);
+    await gw.deleteDocs(["lesson-a"]);
+    const id = await gw.uploadAsset(new Uint8Array([1]), "x.png");
+    await gw.writeSingleton("sha1", { lesson: 1 });
+
+    expect(gw.written.map((d) => d._id)).toEqual(["lesson-b"]);
+    expect(gw.deleted).toEqual(["lesson-a"]);
+    expect(await gw.assetExists(id)).toBe(true);
+    expect(gw.singleton).toEqual({ sha: "sha1", counts: { lesson: 1 } });
+  });
+});

--- a/apps/web/src/lib/content-sync/__tests__/github.test.ts
+++ b/apps/web/src/lib/content-sync/__tests__/github.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import { createGitHubClient } from "../github";
+import { GitHubUnavailableError } from "../types";
+
+const okJson = (body: unknown): Response =>
+  new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+
+describe("GitHubClient", () => {
+  it("authenticates the tarball request and follows to bytes", async () => {
+    const fetchImpl = vi.fn(
+      async (_url: string, _init?: RequestInit) =>
+        new Response(new Uint8Array([1, 2, 3]), { status: 200 })
+    );
+    const client = createGitHubClient({
+      token: "ghp_x",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    const bytes = await client.fetchTarball("abc123");
+    expect(Array.from(bytes)).toEqual([1, 2, 3]);
+    const [url, init] = fetchImpl.mock.calls[0]!;
+    expect(url).toBe(
+      "https://api.github.com/repos/solanabr/academy-courses/tarball/abc123"
+    );
+    expect(init?.headers).toMatchObject({
+      Authorization: "Bearer ghp_x",
+    });
+  });
+
+  it("reads HEAD sha from the branch ref", async () => {
+    const fetchImpl = vi.fn(async (_url: string, _init?: RequestInit) =>
+      okJson({ sha: "headsha999" })
+    );
+    const client = createGitHubClient({
+      token: "t",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    expect(await client.fetchHeadSha()).toBe("headsha999");
+    expect(fetchImpl.mock.calls[0]![0]).toContain("/commits/main");
+  });
+
+  it("folds check-runs into a single state", async () => {
+    const client = createGitHubClient({
+      token: "t",
+      fetchImpl: (async () =>
+        okJson({
+          check_runs: [{ conclusion: "success" }, { conclusion: "failure" }],
+        })) as unknown as typeof fetch,
+    });
+    expect(await client.fetchChecksState("s")).toBe("failure");
+  });
+
+  it("reports pending when a run is still in progress", async () => {
+    const client = createGitHubClient({
+      token: "t",
+      fetchImpl: (async () =>
+        okJson({
+          check_runs: [
+            { conclusion: "success" },
+            { status: "in_progress", conclusion: null },
+          ],
+        })) as unknown as typeof fetch,
+    });
+    expect(await client.fetchChecksState("s")).toBe("pending");
+  });
+
+  it("throws GitHubUnavailableError without a token", async () => {
+    const client = createGitHubClient({
+      token: undefined,
+      fetchImpl: (async () => new Response()) as unknown as typeof fetch,
+    });
+    await expect(client.fetchHeadSha()).rejects.toBeInstanceOf(
+      GitHubUnavailableError
+    );
+  });
+
+  it("throws GitHubUnavailableError on a non-2xx", async () => {
+    const client = createGitHubClient({
+      token: "t",
+      fetchImpl: (async () =>
+        new Response("rate limited", {
+          status: 403,
+        })) as unknown as typeof fetch,
+    });
+    await expect(client.fetchHeadSha()).rejects.toBeInstanceOf(
+      GitHubUnavailableError
+    );
+  });
+});

--- a/apps/web/src/lib/content-sync/__tests__/github.test.ts
+++ b/apps/web/src/lib/content-sync/__tests__/github.test.ts
@@ -69,6 +69,42 @@ describe("GitHubClient", () => {
     expect(await client.fetchChecksState("s")).toBe("pending");
   });
 
+  it("does NOT read a skipped check as green (a required skipped check must block)", async () => {
+    // GitHub reports a skipped required check as conclusion `skipped`; the Checks
+    // API can't tell us it was required, so a non-`success` terminal conclusion
+    // must never fold to `success` and be waved past the sync gate.
+    const client = createGitHubClient({
+      token: "t",
+      fetchImpl: (async () =>
+        okJson({
+          check_runs: [{ conclusion: "success" }, { conclusion: "skipped" }],
+        })) as unknown as typeof fetch,
+    });
+    expect(await client.fetchChecksState("s")).toBe("failure");
+  });
+
+  it("does NOT read a neutral check as green", async () => {
+    const client = createGitHubClient({
+      token: "t",
+      fetchImpl: (async () =>
+        okJson({
+          check_runs: [{ conclusion: "neutral" }],
+        })) as unknown as typeof fetch,
+    });
+    expect(await client.fetchChecksState("s")).toBe("failure");
+  });
+
+  it("is green only when every run concluded success", async () => {
+    const client = createGitHubClient({
+      token: "t",
+      fetchImpl: (async () =>
+        okJson({
+          check_runs: [{ conclusion: "success" }, { conclusion: "success" }],
+        })) as unknown as typeof fetch,
+    });
+    expect(await client.fetchChecksState("s")).toBe("success");
+  });
+
   it("throws GitHubUnavailableError without a token", async () => {
     const client = createGitHubClient({
       token: undefined,

--- a/apps/web/src/lib/content-sync/__tests__/preserve.test.ts
+++ b/apps/web/src/lib/content-sync/__tests__/preserve.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import {
+  PRESERVE,
+  PROJECTED_FIELDS,
+  reattachPreserved,
+  assertSchemaFieldsCovered,
+} from "../preserve";
+import type { SanityDoc } from "../types";
+
+describe("reattachPreserved", () => {
+  it("carries onChainStatus from the existing course onto the projected one", () => {
+    const projected: SanityDoc = {
+      _id: "course-x",
+      _type: "course",
+      title: "X",
+      sync: { source: "academy-courses", rev: "s" },
+    };
+    const existing: SanityDoc = {
+      _id: "course-x",
+      _type: "course",
+      title: "OLD",
+      onChainStatus: { coursePda: "PDA", isActive: true },
+    };
+    const merged = reattachPreserved(projected, existing);
+    expect(merged.onChainStatus).toEqual({ coursePda: "PDA", isActive: true });
+    expect(merged.title).toBe("X"); // repo wins for projected fields
+  });
+
+  it("is a no-op when there is no existing doc", () => {
+    const projected: SanityDoc = {
+      _id: "course-x",
+      _type: "course",
+      title: "X",
+    };
+    expect(
+      reattachPreserved(projected, undefined).onChainStatus
+    ).toBeUndefined();
+  });
+
+  it("does not preserve onChainStatus for a lesson (not in PRESERVE)", () => {
+    const projected: SanityDoc = { _id: "lesson-x", _type: "lesson" };
+    const existing: SanityDoc = {
+      _id: "lesson-x",
+      _type: "lesson",
+      onChainStatus: { foo: 1 },
+    };
+    expect(
+      reattachPreserved(projected, existing).onChainStatus
+    ).toBeUndefined();
+  });
+});
+
+describe("assertSchemaFieldsCovered", () => {
+  it("passes when sanity fields == projected ∪ PRESERVE ∪ sync", () => {
+    const fields = [...PROJECTED_FIELDS.course, ...PRESERVE.course, "sync"];
+    expect(() => assertSchemaFieldsCovered("course", fields)).not.toThrow();
+  });
+
+  it("throws when Sanity has an unregistered field (would be wiped on sync)", () => {
+    const fields = [
+      ...PROJECTED_FIELDS.course,
+      ...PRESERVE.course,
+      "sync",
+      "editorNote",
+    ];
+    expect(() => assertSchemaFieldsCovered("course", fields)).toThrow(
+      /editorNote/
+    );
+  });
+});

--- a/apps/web/src/lib/content-sync/__tests__/projector.test.ts
+++ b/apps/web/src/lib/content-sync/__tests__/projector.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect } from "vitest";
+import { projectContent } from "../projector";
+import type { ValidatedContent } from "../validate";
+
+function fixture(): ValidatedContent {
+  return {
+    courses: [
+      {
+        id: "course-demo",
+        slug: "demo",
+        title: "Demo",
+        description: "d",
+        difficulty: "beginner",
+        duration: 1,
+        xpPerLesson: 10,
+        xpReward: 100,
+        creator: { githubId: "1" },
+        modules: [{ key: "m", title: "M", lessons: ["lesson-accounts"] }],
+      } as never,
+    ],
+    lessons: [
+      {
+        dir: "courses/demo/lessons/accounts",
+        lesson: {
+          id: "lesson-accounts",
+          slug: "accounts",
+          title: "Accounts",
+          blocks: [
+            { key: "intro", type: "prose", src: "intro.md" },
+            {
+              key: "ex",
+              type: "code",
+              language: "typescript",
+              buildType: "standard",
+              deployable: false,
+              starter: "exercise/starter.ts",
+              solution: "exercise/solution.ts",
+              tests: "exercise/tests.json",
+              hints: [],
+            },
+          ],
+        } as never,
+      },
+    ],
+    achievements: [],
+    quests: [],
+    paths: [],
+    instructors: [],
+    slots: new Map(),
+    prose: new Map([["courses/demo/lessons/accounts/intro.md", "# Accounts"]]),
+    code: new Map([
+      ["courses/demo/lessons/accounts/exercise/starter.ts", "// starter"],
+      ["courses/demo/lessons/accounts/exercise/solution.ts", "// solution"],
+    ]),
+    idl: new Map(),
+    assets: new Map(),
+  } as ValidatedContent;
+}
+
+const noAsset = (): string | null => null;
+
+describe("projectContent", () => {
+  it("gives each managed doc a deterministic _id equal to its content id", () => {
+    const { docs } = projectContent(fixture(), "sha1", noAsset, () => [
+      { id: "t", description: "d", input: "", expectedOutput: "1" },
+    ]);
+    const course = docs.find((d) => d._type === "course")!;
+    const lesson = docs.find((d) => d._type === "lesson")!;
+    expect(course._id).toBe("course-demo");
+    expect(lesson._id).toBe("lesson-accounts");
+  });
+
+  it("stamps the sync marker with the sha on every managed doc", () => {
+    const { docs } = projectContent(fixture(), "sha1", noAsset, () => []);
+    for (const d of docs) {
+      expect(d.sync).toEqual({ source: "academy-courses", rev: "sha1" });
+    }
+  });
+
+  it("resolves prose src → markdown body and uses block.key as _key", () => {
+    const { docs } = projectContent(fixture(), "sha1", noAsset, () => []);
+    const lesson = docs.find((d) => d._type === "lesson") as unknown as {
+      blocks: { _key: string; _type: string; src?: string }[];
+    };
+    const intro = lesson.blocks.find((b) => b._key === "intro")!;
+    expect(intro._type).toBe("prose");
+    expect(intro.src).toBe("# Accounts");
+  });
+
+  it("rewrites repo-relative image paths in prose src to the resolved CDN url (§9.6)", () => {
+    const f = fixture();
+    f.prose = new Map([
+      [
+        "courses/demo/lessons/accounts/intro.md",
+        "See ![pixel](assets/pixel.png) here.",
+      ],
+    ]);
+    const cdn = "https://cdn.sanity.io/images/proj/production/abc123-1x1.png";
+    const resolveAsset = (repoPath: string): string | null =>
+      repoPath === "courses/demo/lessons/accounts/assets/pixel.png"
+        ? cdn
+        : null;
+    const { docs } = projectContent(f, "sha1", resolveAsset, () => []);
+    const lesson = docs.find((d) => d._type === "lesson") as unknown as {
+      blocks: { _key: string; src?: string }[];
+    };
+    const intro = lesson.blocks.find((b) => b._key === "intro")!;
+    expect(intro.src).toBe(`See ![pixel](${cdn}) here.`);
+    expect(intro.src).not.toContain("assets/pixel.png");
+  });
+
+  it("resolves code.tests → a testCase[] array", () => {
+    const { docs } = projectContent(fixture(), "sha1", noAsset, () => [
+      { id: "t1", description: "d", input: "", expectedOutput: "1" },
+    ]);
+    const lesson = docs.find((d) => d._type === "lesson") as unknown as {
+      blocks: { _key: string; tests?: { id: string }[] }[];
+    };
+    const ex = lesson.blocks.find((b) => b._key === "ex")!;
+    expect(ex.tests).toEqual([
+      { id: "t1", description: "d", input: "", expectedOutput: "1" },
+    ]);
+  });
+
+  it("never emits lesson.xpReward and inlines modules with weak lesson refs", () => {
+    const { docs } = projectContent(fixture(), "sha1", noAsset, () => []);
+    const lesson = docs.find((d) => d._type === "lesson")!;
+    expect("xpReward" in lesson).toBe(false);
+    const course = docs.find((d) => d._type === "course") as unknown as {
+      modules: { lessons: { _ref: string; _weak: boolean }[] }[];
+    };
+    expect(course.modules[0]!.lessons[0]).toMatchObject({
+      _ref: "lesson-accounts",
+      _weak: true,
+    });
+  });
+
+  it("is deterministic — same input yields deep-equal output", () => {
+    const a = projectContent(fixture(), "sha1", noAsset, () => []);
+    const b = projectContent(fixture(), "sha1", noAsset, () => []);
+    expect(a.docs).toEqual(b.docs);
+  });
+});

--- a/apps/web/src/lib/content-sync/__tests__/prune.test.ts
+++ b/apps/web/src/lib/content-sync/__tests__/prune.test.ts
@@ -16,10 +16,19 @@ const marked = (id: string, rev: string): SanityDoc =>
   doc(id, { sync: { source: "academy-courses", rev } });
 
 describe("selectPrunable", () => {
-  it("selects marked docs whose rev != current sha", () => {
-    const existing = [marked("a", "old"), marked("b", "new"), doc("c")];
-    const prunable = selectPrunable(existing, "new");
+  it("selects marked docs absent from the projected tree (by id, not rev)", () => {
+    // `b` is in the new tree so it is kept even though its rev is stale; `a` is
+    // ours and gone from the tree → pruned; `c` is unmarked → untouchable.
+    const existing = [marked("a", "old"), marked("b", "old"), doc("c")];
+    const prunable = selectPrunable(existing, new Set(["b"]));
     expect(prunable.map((d) => d._id)).toEqual(["a"]);
+  });
+
+  it("keeps a marked doc present in the tree even at a stale rev", () => {
+    // The read-your-writes race: a just-written doc may still read at its OLD
+    // rev, but as long as its id is in the projected set it must never prune.
+    const existing = [marked("a", "old"), marked("b", "old")];
+    expect(selectPrunable(existing, new Set(["a", "b"]))).toEqual([]);
   });
 
   it("NEVER selects an unmarked doc (no sync marker)", () => {
@@ -28,14 +37,14 @@ describe("selectPrunable", () => {
       doc("handCreated"),
       marked("x", "old"),
     ];
-    const prunable = selectPrunable(existing, "new");
+    const prunable = selectPrunable(existing, new Set());
     expect(prunable.map((d) => d._id)).toEqual(["x"]);
     expect(prunable.some((d) => d._id === "imageAsset")).toBe(false);
   });
 
   it("never selects a doc from a different source", () => {
     const foreign = doc("f", { sync: { source: "other-repo", rev: "old" } });
-    expect(selectPrunable([foreign], "new")).toEqual([]);
+    expect(selectPrunable([foreign], new Set())).toEqual([]);
   });
 });
 

--- a/apps/web/src/lib/content-sync/__tests__/prune.test.ts
+++ b/apps/web/src/lib/content-sync/__tests__/prune.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from "vitest";
+import {
+  selectChangedDocs,
+  selectPrunable,
+  assertBlastRadius,
+  prunableQuery,
+} from "../prune";
+import { BlastRadiusError, type SanityDoc } from "../types";
+
+const doc = (id: string, extra: Partial<SanityDoc> = {}): SanityDoc => ({
+  _id: id,
+  _type: "lesson",
+  ...extra,
+});
+const marked = (id: string, rev: string): SanityDoc =>
+  doc(id, { sync: { source: "academy-courses", rev } });
+
+describe("selectPrunable", () => {
+  it("selects marked docs whose rev != current sha", () => {
+    const existing = [marked("a", "old"), marked("b", "new"), doc("c")];
+    const prunable = selectPrunable(existing, "new");
+    expect(prunable.map((d) => d._id)).toEqual(["a"]);
+  });
+
+  it("NEVER selects an unmarked doc (no sync marker)", () => {
+    const existing = [
+      doc("imageAsset"),
+      doc("handCreated"),
+      marked("x", "old"),
+    ];
+    const prunable = selectPrunable(existing, "new");
+    expect(prunable.map((d) => d._id)).toEqual(["x"]);
+    expect(prunable.some((d) => d._id === "imageAsset")).toBe(false);
+  });
+
+  it("never selects a doc from a different source", () => {
+    const foreign = doc("f", { sync: { source: "other-repo", rev: "old" } });
+    expect(selectPrunable([foreign], "new")).toEqual([]);
+  });
+});
+
+describe("assertBlastRadius", () => {
+  it("aborts when the prune set exceeds 20% of managed docs", () => {
+    expect(() => assertBlastRadius(25, 100)).toThrow(BlastRadiusError);
+  });
+
+  it("allows a prune at exactly the 20% line", () => {
+    expect(() => assertBlastRadius(20, 100)).not.toThrow();
+  });
+});
+
+describe("selectChangedDocs (idempotency)", () => {
+  it("returns nothing when projected deep-equals existing (same sha re-run)", () => {
+    const existing = [marked("a", "s1"), marked("b", "s1")];
+    const projected = [marked("a", "s1"), marked("b", "s1")];
+    expect(selectChangedDocs(existing, projected)).toEqual([]);
+  });
+
+  it("returns only the docs whose projected value changed", () => {
+    const existing = [
+      marked("a", "s1"),
+      doc("b", {
+        title: "old",
+        sync: { source: "academy-courses", rev: "s1" },
+      }),
+    ];
+    const projected = [
+      marked("a", "s1"),
+      doc("b", {
+        title: "new",
+        sync: { source: "academy-courses", rev: "s2" },
+      }),
+    ];
+    expect(selectChangedDocs(existing, projected).map((d) => d._id)).toEqual([
+      "b",
+    ]);
+  });
+
+  it("preserves PRESERVE fields in the comparison (onChainStatus difference is ignored)", () => {
+    const existing = [
+      doc("a", {
+        _type: "course",
+        onChainStatus: { pda: "X" },
+        sync: { source: "academy-courses", rev: "s1" },
+      }),
+    ];
+    const projected = [
+      doc("a", {
+        _type: "course",
+        onChainStatus: { pda: "X" },
+        sync: { source: "academy-courses", rev: "s1" },
+      }),
+    ];
+    expect(selectChangedDocs(existing, projected)).toEqual([]);
+  });
+});
+
+describe("prunableQuery", () => {
+  it("is marker-scoped and sha-parameterised", () => {
+    expect(prunableQuery()).toBe(
+      '*[sync.source == "academy-courses" && sync.rev != $sha]._id'
+    );
+  });
+});

--- a/apps/web/src/lib/content-sync/__tests__/signer-commit.test.ts
+++ b/apps/web/src/lib/content-sync/__tests__/signer-commit.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import { MaskMismatchError } from "../types";
+import { buildCourseCommit } from "@/lib/solana/admin-signer";
+
+const sha = "c".repeat(40);
+const slots = { version: 1, slots: { a: 0, b: 1 }, retired: [], next: 2 };
+
+describe("buildCourseCommit", () => {
+  it("packs the sha into 32 bytes and passes through a mask that matches the lockfile", () => {
+    const commit = buildCourseCommit({
+      courseId: "course-x",
+      contentSha: sha,
+      slotsLock: slots,
+      activeLessons: [3n, 0n, 0n, 0n], // bits 0 and 1 — matches slots a:0, b:1
+    });
+    expect(commit.contentTxId).toHaveLength(32);
+    expect(commit.activeLessons[0]).toBe(3n);
+  });
+
+  it("throws MaskMismatchError naming the course when the caller's mask disagrees with the lockfile", () => {
+    expect(() =>
+      buildCourseCommit({
+        courseId: "course-x",
+        contentSha: sha,
+        slotsLock: slots,
+        activeLessons: [1n, 0n, 0n, 0n], // bit 1 missing — panel bug
+      })
+    ).toThrow(MaskMismatchError);
+    try {
+      buildCourseCommit({
+        courseId: "course-x",
+        contentSha: sha,
+        slotsLock: slots,
+        activeLessons: [1n, 0n, 0n, 0n],
+      });
+    } catch (e) {
+      expect((e as Error).message).toContain("course-x"); // reports the course id, not a sha
+    }
+  });
+});

--- a/apps/web/src/lib/content-sync/__tests__/sync.test.ts
+++ b/apps/web/src/lib/content-sync/__tests__/sync.test.ts
@@ -1,0 +1,146 @@
+import { createHash } from "node:crypto";
+import { describe, it, expect, vi } from "vitest";
+import { runContentSync } from "../sync";
+import { InMemoryGateway } from "../gateway";
+import { BlockedCommitError, BlastRadiusError, type SanityDoc } from "../types";
+import type { GitHubClient } from "../github";
+import type { GraderSet } from "../executor-gate";
+import { makeCourseTarball, PNG_1X1 } from "./_fixtures";
+
+vi.mock("next/cache", () => ({ revalidateTag: vi.fn() }));
+
+const graders: GraderSet = {
+  js: async () => ({ passed: true, failures: [] }),
+  rust: async () => ({ passed: true, failures: [] }),
+  buildable: async () => ({ passed: true, failures: [] }),
+};
+
+function github(
+  sha: string,
+  checks: "success" | "failure",
+  tarball: Uint8Array
+): GitHubClient {
+  return {
+    fetchTarball: async () => tarball,
+    fetchHeadSha: async () => sha,
+    fetchChecksState: async () => checks,
+  };
+}
+
+const SHA = "a".repeat(40);
+
+const deps = (
+  over: Partial<Parameters<typeof runContentSync>[0]> = {}
+): Parameters<typeof runContentSync>[0] => ({
+  sha: SHA,
+  github: github(SHA, "success", makeCourseTarball(SHA)),
+  gateway: new InMemoryGateway([]),
+  graders,
+  projectId: "p",
+  dataset: "production",
+  ...over,
+});
+
+describe("runContentSync", () => {
+  it("refuses to sync a commit whose CI is red (§11.1 blocked)", async () => {
+    const d = deps({
+      github: github(SHA, "failure", makeCourseTarball(SHA)),
+    });
+    await expect(runContentSync(d)).rejects.toBeInstanceOf(BlockedCommitError);
+    expect((d.gateway as InMemoryGateway).written).toEqual([]); // nothing written
+  });
+
+  it("writes the projected docs on a first sync and the singleton last", async () => {
+    const d = deps();
+    const result = await runContentSync(d);
+    const gw = d.gateway as InMemoryGateway;
+    expect(result.written).toBeGreaterThan(0);
+    expect(gw.singleton?.sha).toBe(d.sha);
+    // singleton is not part of the managed write batch
+    expect(gw.written.some((x) => x._id === "contentSync")).toBe(false);
+  });
+
+  it("is idempotent — a second run at the same sha writes and deletes nothing", async () => {
+    const gw = new InMemoryGateway([]);
+    await runContentSync(deps({ gateway: gw }));
+    const writesAfterFirst = gw.written.length;
+    const deletesAfterFirst = gw.deleted.length;
+    await runContentSync(
+      deps({
+        gateway: gw,
+        github: github(SHA, "success", makeCourseTarball(SHA)),
+      })
+    );
+    expect(gw.written.length).toBe(writesAfterFirst); // zero additional writes
+    expect(gw.deleted.length).toBe(deletesAfterFirst); // zero additional deletes
+  });
+
+  it("aborts before any delete when the prune set exceeds 20%", async () => {
+    // Seed the gateway with many stale managed docs from an old sha; the new
+    // tree has one course, so nearly all would prune.
+    const stale: SanityDoc[] = Array.from({ length: 50 }, (_v, i) => ({
+      _id: `lesson-old-${i}`,
+      _type: "lesson",
+      sync: { source: "academy-courses", rev: "oldsha" },
+    }));
+    const gw = new InMemoryGateway(stale);
+    await expect(runContentSync(deps({ gateway: gw }))).rejects.toBeInstanceOf(
+      BlastRadiusError
+    );
+    expect(gw.deleted).toEqual([]); // never deleted anything
+  });
+
+  it("prunes a small stale set and reports the count", async () => {
+    // 9 current-ish + 1 stale → prune 1 of 10 managed (< 20%).
+    const current: SanityDoc[] = Array.from({ length: 9 }, (_v, i) => ({
+      _id: `lesson-keep-${i}`,
+      _type: "lesson",
+      sync: { source: "academy-courses", rev: SHA },
+    }));
+    const stale: SanityDoc = {
+      _id: "lesson-gone",
+      _type: "lesson",
+      sync: { source: "academy-courses", rev: "oldsha" },
+    };
+    const gw = new InMemoryGateway([...current, stale]);
+    const result = await runContentSync(deps({ gateway: gw }));
+    expect(gw.deleted).toContain("lesson-gone");
+    expect(result.pruned).toBe(1);
+  });
+
+  it("computes asset ids from real probed dimensions, so an existing Sanity asset is skipped (§9.6)", async () => {
+    // Sanity's asset _id embeds the REAL dimensions it computes on upload
+    // (image-<sha1>-<w>x<h>-<format>). Seed the gateway with the id Sanity would
+    // hold for PNG_1X1; the sync must probe the same 1x1 dims to match it and
+    // skip the upload. A placeholder probe (0x0) would never match.
+    const sha1 = createHash("sha1").update(PNG_1X1).digest("hex");
+    const gw = new InMemoryGateway([]);
+    gw.assets.add(`image-${sha1}-1x1-png`);
+    const result = await runContentSync(
+      deps({
+        gateway: gw,
+        github: github(
+          SHA,
+          "success",
+          makeCourseTarball(SHA, { withImage: true })
+        ),
+      })
+    );
+    expect(result.assetsUploaded).toBe(0); // dedupe hit — nothing re-uploaded
+  });
+
+  it("uploads a new asset once and reports it", async () => {
+    const gw = new InMemoryGateway([]);
+    const result = await runContentSync(
+      deps({
+        gateway: gw,
+        github: github(
+          SHA,
+          "success",
+          makeCourseTarball(SHA, { withImage: true })
+        ),
+      })
+    );
+    expect(result.assetsUploaded).toBe(1);
+  });
+});

--- a/apps/web/src/lib/content-sync/__tests__/sync.test.ts
+++ b/apps/web/src/lib/content-sync/__tests__/sync.test.ts
@@ -1,13 +1,77 @@
 import { createHash } from "node:crypto";
 import { describe, it, expect, vi } from "vitest";
 import { runContentSync } from "../sync";
-import { InMemoryGateway } from "../gateway";
+import { InMemoryGateway, type SanityGateway } from "../gateway";
 import { BlockedCommitError, BlastRadiusError, type SanityDoc } from "../types";
 import type { GitHubClient } from "../github";
 import type { GraderSet } from "../executor-gate";
 import { makeCourseTarball, PNG_1X1 } from "./_fixtures";
 
 vi.mock("next/cache", () => ({ revalidateTag: vi.fn() }));
+
+/** Hand-authored managed docs unrelated to the sync (no marker → never pruned).
+ *  They inflate the managed total the blast-radius guard measures against. */
+const handAuthored = (n: number): SanityDoc[] =>
+  Array.from({ length: n }, (_v, i) => ({
+    _id: `hand-authored-${i}`,
+    _type: "lesson",
+  }));
+
+const managedMarked = (id: string, type: string, rev: string): SanityDoc => ({
+  _id: id,
+  _type: type,
+  sync: { source: "academy-courses", rev },
+});
+
+/**
+ * Models Sanity `visibility:"async"`: `writeDocs` commits durably, but the next
+ * `readManaged` LAGS for a configured subset of ids — they still read at their
+ * pre-write value. This is exactly the read-your-writes window a post-write
+ * read-back prune would race.
+ */
+class AsyncVisibilityGateway implements SanityGateway {
+  written: SanityDoc[] = [];
+  deleted: string[] = [];
+  assets = new Set<string>();
+  singleton: { sha: string; counts: Record<string, number> } | null = null;
+  private visible: Map<string, SanityDoc>;
+
+  constructor(
+    existing: SanityDoc[],
+    private laggingIds: Set<string>
+  ) {
+    this.visible = new Map(existing.map((d) => [d._id, d]));
+  }
+
+  async readManaged(): Promise<SanityDoc[]> {
+    return [...this.visible.values()];
+  }
+  async writeDocs(docs: SanityDoc[]): Promise<void> {
+    this.written.push(...docs);
+    for (const d of docs) {
+      // A lagging id keeps its previously-visible value on the next read.
+      if (!this.laggingIds.has(d._id)) this.visible.set(d._id, d);
+    }
+  }
+  async deleteDocs(ids: string[]): Promise<void> {
+    this.deleted.push(...ids);
+    for (const id of ids) this.visible.delete(id);
+  }
+  async assetExists(id: string): Promise<boolean> {
+    return this.assets.has(id);
+  }
+  async uploadAsset(_bytes: Uint8Array, filename: string): Promise<string> {
+    const id = `image-${filename}`;
+    this.assets.add(id);
+    return id;
+  }
+  async writeSingleton(
+    sha: string,
+    counts: Record<string, number>
+  ): Promise<void> {
+    this.singleton = { sha, counts };
+  }
+}
 
 const graders: GraderSet = {
   js: async () => ({ passed: true, failures: [] }),
@@ -90,21 +154,48 @@ describe("runContentSync", () => {
     expect(gw.deleted).toEqual([]); // never deleted anything
   });
 
-  it("prunes a small stale set and reports the count", async () => {
-    // 9 current-ish + 1 stale → prune 1 of 10 managed (< 20%).
-    const current: SanityDoc[] = Array.from({ length: 9 }, (_v, i) => ({
-      _id: `lesson-keep-${i}`,
-      _type: "lesson",
-      sync: { source: "academy-courses", rev: SHA },
-    }));
-    const stale: SanityDoc = {
-      _id: "lesson-gone",
-      _type: "lesson",
-      sync: { source: "academy-courses", rev: "oldsha" },
-    };
-    const gw = new InMemoryGateway([...current, stale]);
+  it("prunes a managed doc absent from the new tree and reports the count", async () => {
+    // The two tree docs are kept (present in the projected set) even though they
+    // are re-written from a stale rev; `lesson-gone` is ours but no longer in the
+    // tree → pruned. Hand-authored docs pad the managed total so the single
+    // removal stays under the 20% blast radius.
+    const gw = new InMemoryGateway([
+      managedMarked("course-demo", "course", "oldsha"),
+      managedMarked("lesson-accounts", "lesson", "oldsha"),
+      managedMarked("lesson-gone", "lesson", "oldsha"),
+      ...handAuthored(4),
+    ]);
     const result = await runContentSync(deps({ gateway: gw }));
-    expect(gw.deleted).toContain("lesson-gone");
+    expect(gw.deleted).toEqual(["lesson-gone"]);
+    expect(result.pruned).toBe(1);
+  });
+
+  it("async managed-read visibility never prunes a just-written doc; a removed doc still prunes", async () => {
+    // Model Sanity `visibility:"async"`: after the write, the managed read-back
+    // LAGS for `lesson-accounts` (it still reads at its OLD rev). Enough
+    // hand-authored docs exist that a 2-doc stale read-back slips under the 20%
+    // blast radius — so the OLD post-write-read prune would SILENTLY DELETE the
+    // just-written `lesson-accounts`. Computing the prune set from the pre-write
+    // read + projected ids makes that impossible: an id in the new tree is never
+    // pruned, regardless of what the read-back reports.
+    const existing: SanityDoc[] = [
+      managedMarked("course-demo", "course", "oldsha"),
+      managedMarked("lesson-accounts", "lesson", "oldsha"),
+      managedMarked("lesson-removed", "lesson", "oldsha"),
+      ...handAuthored(7),
+    ];
+    const gw = new AsyncVisibilityGateway(
+      existing,
+      new Set(["lesson-accounts"])
+    );
+    const result = await runContentSync(deps({ gateway: gw }));
+
+    // The just-written tree docs are never in the delete set...
+    expect(gw.written.map((d) => d._id)).toContain("lesson-accounts");
+    expect(gw.deleted).not.toContain("lesson-accounts");
+    expect(gw.deleted).not.toContain("course-demo");
+    // ...but a doc genuinely absent from the new tree IS pruned.
+    expect(gw.deleted).toEqual(["lesson-removed"]);
     expect(result.pruned).toBe(1);
   });
 

--- a/apps/web/src/lib/content-sync/__tests__/tarball.test.ts
+++ b/apps/web/src/lib/content-sync/__tests__/tarball.test.ts
@@ -31,4 +31,18 @@ describe("extractTarball", () => {
     const tree = await extractTarball(gzipSync(Buffer.from(tar)));
     expect([...tree.keys()]).toEqual(["courses/real/course.yaml"]);
   });
+
+  it("reconstructs a path longer than 100 bytes from the ustar prefix field", async () => {
+    // The generated `owner-repo-<40-char-sha>/` top dir alone is 65 bytes, so any
+    // real repo path overflows the 100-byte name field; git archive splits it
+    // across name + prefix. A naive reader that ignores prefix would drop this.
+    const top = `solanabr-academy-courses-${"a".repeat(40)}`;
+    const deep = `${top}/courses/solana-fundamentals/lessons/pdas-and-accounts/exercise/solution.ts`;
+    expect(deep.length).toBeGreaterThan(100);
+    const tar = makeTar({ [deep]: "// solution\n" });
+    const tree = await extractTarball(gzipSync(Buffer.from(tar)));
+    expect([...tree.keys()]).toEqual([
+      "courses/solana-fundamentals/lessons/pdas-and-accounts/exercise/solution.ts",
+    ]);
+  });
 });

--- a/apps/web/src/lib/content-sync/__tests__/tarball.test.ts
+++ b/apps/web/src/lib/content-sync/__tests__/tarball.test.ts
@@ -1,6 +1,6 @@
 import { gzipSync } from "node:zlib";
 import { describe, it, expect } from "vitest";
-import { extractTarball } from "../tarball";
+import { extractTarball, TarballTooLargeError } from "../tarball";
 import { makeTar } from "./_fixtures";
 
 describe("extractTarball", () => {
@@ -44,5 +44,35 @@ describe("extractTarball", () => {
     expect([...tree.keys()]).toEqual([
       "courses/solana-fundamentals/lessons/pdas-and-accounts/exercise/solution.ts",
     ]);
+  });
+
+  it("rejects a tarball that inflates past the decompressed-size cap", async () => {
+    // Guards against a gzip bomb: 4 KiB inflated, capped at 512 bytes.
+    const tar = makeTar({ "r-abc/courses/real/big.md": "x".repeat(4096) });
+    const gz = gzipSync(Buffer.from(tar));
+    await expect(
+      extractTarball(gz, { maxDecompressedBytes: 512 })
+    ).rejects.toBeInstanceOf(TarballTooLargeError);
+  });
+
+  it("rejects a tarball with more entries than the cap", async () => {
+    // Guards against a pathological archive of many tiny headers.
+    const tar = makeTar({
+      "r-abc/courses/real/a.md": "a",
+      "r-abc/courses/real/b.md": "b",
+      "r-abc/courses/real/c.md": "c",
+    });
+    const gz = gzipSync(Buffer.from(tar));
+    await expect(extractTarball(gz, { maxEntries: 2 })).rejects.toBeInstanceOf(
+      TarballTooLargeError
+    );
+  });
+
+  it("extracts normally within default caps", async () => {
+    const tar = makeTar({
+      "r-abc/courses/real/course.yaml": "id: course-real\n",
+    });
+    const tree = await extractTarball(gzipSync(Buffer.from(tar)));
+    expect([...tree.keys()]).toEqual(["courses/real/course.yaml"]);
   });
 });

--- a/apps/web/src/lib/content-sync/__tests__/tarball.test.ts
+++ b/apps/web/src/lib/content-sync/__tests__/tarball.test.ts
@@ -1,0 +1,34 @@
+import { gzipSync } from "node:zlib";
+import { describe, it, expect } from "vitest";
+import { extractTarball } from "../tarball";
+import { makeTar } from "./_fixtures";
+
+describe("extractTarball", () => {
+  it("strips the generated top dir and keys by repo-relative path", async () => {
+    const tar = makeTar({
+      "solanabr-academy-courses-abc123/courses/solana-fundamentals/course.yaml":
+        "id: course-solana-fundamentals\n",
+      "solanabr-academy-courses-abc123/courses/solana-fundamentals/lessons/accounts/intro.md":
+        "# Accounts\n",
+    });
+    const tree = await extractTarball(gzipSync(Buffer.from(tar)));
+    expect([...tree.keys()].sort()).toEqual([
+      "courses/solana-fundamentals/course.yaml",
+      "courses/solana-fundamentals/lessons/accounts/intro.md",
+    ]);
+    expect(
+      new TextDecoder().decode(
+        tree.get("courses/solana-fundamentals/course.yaml")
+      )
+    ).toContain("course-solana-fundamentals");
+  });
+
+  it("excludes courses/_template/", async () => {
+    const tar = makeTar({
+      "r-abc/courses/_template/course.yaml": "id: course-template\n",
+      "r-abc/courses/real/course.yaml": "id: course-real\n",
+    });
+    const tree = await extractTarball(gzipSync(Buffer.from(tar)));
+    expect([...tree.keys()]).toEqual(["courses/real/course.yaml"]);
+  });
+});

--- a/apps/web/src/lib/content-sync/__tests__/types.test.ts
+++ b/apps/web/src/lib/content-sync/__tests__/types.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import {
+  MANAGED_TYPES,
+  BlockedCommitError,
+  BlastRadiusError,
+  ContentValidationError,
+} from "../types";
+
+describe("content-sync types", () => {
+  it("lists exactly the six managed document types", () => {
+    expect([...MANAGED_TYPES].sort()).toEqual(
+      [
+        "achievement",
+        "course",
+        "instructor",
+        "learningPath",
+        "lesson",
+        "quest",
+      ].sort()
+    );
+  });
+
+  it("error classes carry a stable name and message", () => {
+    expect(new BlockedCommitError("abc").name).toBe("BlockedCommitError");
+    expect(new BlastRadiusError(30, 100).message).toContain("30");
+    expect(new ContentValidationError(["bad"]).issues).toEqual(["bad"]);
+  });
+});

--- a/apps/web/src/lib/content-sync/__tests__/validate.test.ts
+++ b/apps/web/src/lib/content-sync/__tests__/validate.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from "vitest";
+import { stringify } from "yaml";
+import { parseAndValidateTree } from "../validate";
+import { ContentValidationError } from "../types";
+import type { GraderSet } from "../executor-gate";
+
+// A submission "passes" iff its text contains "solve".
+const passGraders: GraderSet = {
+  js: async (code) => ({ passed: code.includes("solve"), failures: ["fail"] }),
+  rust: async (code) => ({
+    passed: code.includes("solve"),
+    failures: ["fail"],
+  }),
+  buildable: async (code) => ({
+    passed: code.includes("solve"),
+    failures: ["fail"],
+  }),
+};
+
+function tree(files: Record<string, string>): Map<string, Uint8Array> {
+  const m = new Map<string, Uint8Array>();
+  const enc = new TextEncoder();
+  for (const [k, v] of Object.entries(files)) m.set(k, enc.encode(v));
+  return m;
+}
+
+const courseYaml = stringify({
+  id: "course-demo",
+  slug: "demo",
+  title: "Demo",
+  description: "d",
+  difficulty: "beginner",
+  duration: 1,
+  xpPerLesson: 10,
+  xpReward: 100,
+  creator: { githubId: "1" },
+  modules: [{ key: "m", title: "M", lessons: ["lesson-accounts"] }],
+});
+const lessonYaml = stringify({
+  id: "lesson-accounts",
+  slug: "accounts",
+  title: "Accounts",
+  blocks: [{ key: "intro", type: "prose", src: "intro.md" }],
+});
+
+describe("parseAndValidateTree", () => {
+  it("validates a well-formed single-course tree", async () => {
+    const t = tree({
+      "courses/demo/course.yaml": courseYaml,
+      "courses/demo/slots.lock.json": JSON.stringify({
+        version: 1,
+        slots: { "lesson-accounts": 0 },
+        retired: [],
+        next: 1,
+      }),
+      "courses/demo/lessons/accounts/lesson.yaml": lessonYaml,
+      "courses/demo/lessons/accounts/intro.md": "# Accounts",
+    });
+    const v = await parseAndValidateTree(t, passGraders);
+    expect(v.courses.map((c) => c.id)).toEqual(["course-demo"]);
+    expect(v.prose.get("courses/demo/lessons/accounts/intro.md")).toContain(
+      "# Accounts"
+    );
+  });
+
+  it("throws with the Zod issue when a course is malformed", async () => {
+    const t = tree({
+      "courses/demo/course.yaml": stringify({ id: "NOT-a-course-id" }),
+    });
+    await expect(parseAndValidateTree(t, passGraders)).rejects.toBeInstanceOf(
+      ContentValidationError
+    );
+  });
+
+  it("throws when a code block's solution fails the executor gate", async () => {
+    const withCode = stringify({
+      id: "lesson-ex",
+      slug: "ex",
+      title: "Ex",
+      blocks: [
+        {
+          key: "ex",
+          type: "code",
+          language: "typescript",
+          starter: "exercise/starter.ts",
+          solution: "exercise/solution.ts",
+          tests: "exercise/tests.json",
+        },
+      ],
+    });
+    const t = tree({
+      "courses/demo/course.yaml": courseYaml,
+      "courses/demo/lessons/ex/lesson.yaml": withCode,
+      "courses/demo/lessons/ex/exercise/starter.ts": "// nope",
+      "courses/demo/lessons/ex/exercise/solution.ts":
+        "// also nope (no keyword)",
+      "courses/demo/lessons/ex/exercise/tests.json": JSON.stringify([
+        { id: "t", description: "d", input: "", expectedOutput: "1" },
+      ]),
+    });
+    // The executor gate rejects because the reference solution does not "solve".
+    await expect(parseAndValidateTree(t, passGraders)).rejects.toBeInstanceOf(
+      ContentValidationError
+    );
+  });
+});

--- a/apps/web/src/lib/content-sync/assets.ts
+++ b/apps/web/src/lib/content-sync/assets.ts
@@ -1,0 +1,52 @@
+import { createHash } from "node:crypto";
+
+export interface Dimensions {
+  width: number;
+  height: number;
+}
+
+/**
+ * Sanity's content-derived asset id: `image-<sha1>-<w>x<h>-<format>`. Uploading
+ * the same bytes twice yields one asset (spec §9.6), so this id is our dedupe
+ * key: compute it, skip the upload if it already exists.
+ */
+export function computeAssetId(
+  bytes: Uint8Array,
+  dims: Dimensions,
+  format: string
+): string {
+  const sha1 = createHash("sha1").update(Buffer.from(bytes)).digest("hex");
+  return `image-${sha1}-${dims.width}x${dims.height}-${format}`;
+}
+
+/** Build the public CDN url for an asset id (`image-<hash>-<dims>-<fmt>`). */
+export function cdnUrl(
+  assetId: string,
+  projectId: string,
+  dataset: string
+): string {
+  const m = /^image-([0-9a-f]+)-(\d+x\d+)-(\w+)$/.exec(assetId);
+  if (!m) return "";
+  const [, hash, dims, fmt] = m;
+  return `https://cdn.sanity.io/images/${projectId}/${dataset}/${hash}-${dims}.${fmt}`;
+}
+
+const IMG = /!\[([^\]]*)\]\(([^)]+)\)/g;
+const isRemote = (u: string): boolean =>
+  /^(https?:)?\/\//.test(u) || u.startsWith("/");
+
+/**
+ * Rewrite relative markdown image paths to resolved CDN urls (spec §9.6).
+ * Absolute or remote urls are left untouched. `resolve` returns null when the
+ * path has no uploaded asset (leave as-is so the failure is visible).
+ */
+export function rewriteMarkdownAssetPaths(
+  markdown: string,
+  resolve: (relPath: string) => string | null
+): string {
+  return markdown.replace(IMG, (whole, alt: string, url: string) => {
+    if (isRemote(url)) return whole;
+    const resolved = resolve(url);
+    return resolved ? `![${alt}](${resolved})` : whole;
+  });
+}

--- a/apps/web/src/lib/content-sync/content-commit.ts
+++ b/apps/web/src/lib/content-sync/content-commit.ts
@@ -1,0 +1,69 @@
+import { MaskMismatchError } from "./types";
+
+interface SlotsLock {
+  version: number;
+  slots: Record<string, number>;
+  retired: number[];
+  next: number;
+}
+
+type Mask = [bigint, bigint, bigint, bigint];
+
+/**
+ * A git SHA-1 (40 hex = 20 bytes) left-padded into the 32-byte
+ * `Course.content_tx_id` (§11.0): 12 leading zero bytes, then the sha.
+ */
+export function padContentTxId(sha: string): number[] {
+  if (!/^[0-9a-f]{40}$/i.test(sha)) {
+    throw new Error(`expected a 40-hex git sha, got "${sha}"`);
+  }
+  const shaBytes: number[] = [];
+  for (let i = 0; i < 40; i += 2)
+    shaBytes.push(parseInt(sha.slice(i, i + 2), 16));
+  return [...Array(12).fill(0), ...shaBytes];
+}
+
+/** Chain-current test (§11.0): on-chain content_tx_id equals the padded HEAD sha. */
+export function contentTxIdMatchesHead(
+  onChain: number[] | Uint8Array,
+  headSha: string
+): boolean {
+  const want = padContentTxId(headSha);
+  const got = Array.from(onChain);
+  return got.length === 32 && want.every((b, i) => b === got[i]);
+}
+
+/**
+ * Derive the 256-bit `active_lessons` mask (`[u64; 4]`) from a course's
+ * slots.lock.json: one bit set per live (non-retired) slot. This is the only
+ * invariant carrier for "slots are never reused" — the chain cannot know it.
+ */
+export function deriveActiveMask(slots: SlotsLock): Mask {
+  const retired = new Set(slots.retired);
+  const mask: Mask = [0n, 0n, 0n, 0n];
+  for (const slot of Object.values(slots.slots)) {
+    if (retired.has(slot)) continue;
+    const word = Math.floor(slot / 64);
+    if (word < 0 || word > 3) continue; // slots are bounded 0..255 (4 u64 words)
+    const bit = BigInt(slot % 64);
+    mask[word] = (mask[word] ?? 0n) | (1n << bit);
+  }
+  return mask;
+}
+
+/**
+ * Guard for §11.0: `update_course(new_active_lessons)` trusts the authority
+ * blindly, so a panel bug could set arbitrary bits. Assert the mask about to be
+ * signed equals the mask derived from the committed lockfile, right before
+ * signing.
+ */
+export function assertMaskMatchesLockfile(
+  courseId: string,
+  maskToSend: Mask,
+  slots: SlotsLock
+): void {
+  const expected = deriveActiveMask(slots);
+  if (!expected.every((w, i) => w === maskToSend[i])) {
+    throw new MaskMismatchError(courseId);
+  }
+}

--- a/apps/web/src/lib/content-sync/drift.ts
+++ b/apps/web/src/lib/content-sync/drift.ts
@@ -1,0 +1,72 @@
+import { type ChecksState, BlockedCommitError } from "./types";
+import { contentTxIdMatchesHead } from "./content-commit";
+import type { SyncStatus } from "@/lib/admin/sync-diff";
+
+export type ContentDriftState =
+  | "up_to_date"
+  | "behind"
+  | "never_synced"
+  | "blocked";
+
+/**
+ * Content drift (§11.1): the cached contentSync.sha vs GitHub HEAD. `blocked`
+ * means HEAD's CI is red — the panel must refuse to sync it, or a human could
+ * click invalid content past the Zod gate. `canSync` folds the CI gate in.
+ */
+export function computeContentDrift(input: {
+  syncedSha: string | null;
+  headSha: string;
+  checks: ChecksState;
+}): { state: ContentDriftState; canSync: boolean } {
+  const ciGreen = input.checks === "success";
+  if (input.syncedSha === input.headSha)
+    return { state: "up_to_date", canSync: false };
+  if (!ciGreen)
+    return {
+      state: input.syncedSha ? "blocked" : "never_synced",
+      canSync: false,
+    };
+  if (!input.syncedSha) return { state: "never_synced", canSync: true };
+  return { state: "behind", canSync: true };
+}
+
+export type ChainDriftState =
+  | "content_current" // content_tx_id == HEAD (§11.0)
+  | "content_stale" // deployed, but content_tx_id != HEAD
+  | "not_deployed" // no PDA yet (diffCourse)
+  | "missing_fields" // diffCourse
+  | "awaiting_content_sync"; // content sync must land first (ordering interlock)
+
+/**
+ * Chain drift (§11.0/§11.1). The `content_tx_id == HEAD` equality replaces the
+ * field-by-field `diffCourse` heuristic for "is this course current"; the
+ * surviving diffCourse states pass through. Content sync must precede chain
+ * sync, so a course whose Sanity is not yet at HEAD reports
+ * `awaiting_content_sync`.
+ */
+export function computeChainDrift(input: {
+  onChainContentTxId: number[] | Uint8Array | null;
+  headSha: string;
+  diffStatus: SyncStatus;
+  contentUpToDate: boolean;
+}): ChainDriftState {
+  if (input.diffStatus === "not_deployed") return "not_deployed";
+  if (input.diffStatus === "missing_fields") return "missing_fields";
+  if (!input.contentUpToDate) return "awaiting_content_sync";
+  if (
+    input.onChainContentTxId &&
+    contentTxIdMatchesHead(input.onChainContentTxId, input.headSha)
+  ) {
+    return "content_current";
+  }
+  return "content_stale";
+}
+
+/**
+ * Sync-time gate (§11.1 `blocked`): refuse a commit whose CI is not green. Only
+ * `success` is syncable — `pending` means the two-sided executor / Zod gate may
+ * not have finished, `failure` means it rejected.
+ */
+export function assertCommitSyncable(checks: ChecksState, sha: string): void {
+  if (checks !== "success") throw new BlockedCommitError(sha);
+}

--- a/apps/web/src/lib/content-sync/executor-gate.ts
+++ b/apps/web/src/lib/content-sync/executor-gate.ts
@@ -1,0 +1,61 @@
+interface GradeResult {
+  passed: boolean;
+  failures: string[];
+}
+type Grader = (code: string, tests: unknown[]) => Promise<GradeResult>;
+
+/** The three execution tiers of §6.2a, injectable so the orchestrator wires the
+ *  real executors and tests wire fakes. */
+export interface GraderSet {
+  js: Grader; // QuickJS-in-WASM (runJsSubmission), pure Node
+  rust: Grader; // rustc/cargo on the runner (or Playground fallback)
+  buildable: Grader; // cargo build-sbf / Anchor build server
+}
+
+interface CodeBlockLike {
+  key: string;
+  type: string;
+  language: "typescript" | "rust";
+  buildType: "standard" | "buildable";
+}
+
+interface CodeFiles {
+  starter: string;
+  solution: string;
+  tests: unknown[];
+}
+
+function pickGrader(block: CodeBlockLike, graders: GraderSet): Grader {
+  if (block.buildType === "buildable") return graders.buildable;
+  return block.language === "rust" ? graders.rust : graders.js;
+}
+
+/**
+ * Two-sided gate (spec §3, §6.2 gate 6): the reference solution must pass every
+ * test and the starter must fail at least one. Returns human-readable issue
+ * strings prefixed with the block key; empty means the block is well-formed.
+ */
+export async function gateCodeBlock(
+  block: CodeBlockLike,
+  files: CodeFiles,
+  graders: GraderSet
+): Promise<string[]> {
+  const issues: string[] = [];
+  const grader = pickGrader(block, graders);
+
+  const sol = await grader(files.solution, files.tests);
+  if (!sol.passed) {
+    issues.push(
+      `block "${block.key}": solution does not pass its own tests (${sol.failures.join("; ")})`
+    );
+  }
+
+  const starter = await grader(files.starter, files.tests);
+  if (starter.passed) {
+    issues.push(
+      `block "${block.key}": starter already passes — there is nothing to solve`
+    );
+  }
+
+  return issues;
+}

--- a/apps/web/src/lib/content-sync/gateway.ts
+++ b/apps/web/src/lib/content-sync/gateway.ts
@@ -1,0 +1,82 @@
+import type { SanityDoc } from "./types";
+
+export interface SanityGateway {
+  readManaged(): Promise<SanityDoc[]>;
+  writeDocs(docs: SanityDoc[]): Promise<void>;
+  deleteDocs(ids: string[]): Promise<void>;
+  assetExists(assetId: string): Promise<boolean>;
+  uploadAsset(bytes: Uint8Array, filename: string): Promise<string>;
+  writeSingleton(sha: string, counts: Record<string, number>): Promise<void>;
+}
+
+/** Live gateway over the shared admin write client (server-only). */
+export function createLiveGateway(): SanityGateway {
+  // Imported lazily so unit tests never pull `server-only`/env at module load.
+  return {
+    async readManaged() {
+      const { readManagedDocuments } =
+        await import("@/lib/sanity/admin-mutations");
+      return readManagedDocuments();
+    },
+    async writeDocs(docs) {
+      const { writeDocuments } = await import("@/lib/sanity/admin-mutations");
+      return writeDocuments(docs);
+    },
+    async deleteDocs(ids) {
+      const { deleteDocuments } = await import("@/lib/sanity/admin-mutations");
+      return deleteDocuments(ids);
+    },
+    async assetExists(assetId) {
+      const { assetExists } = await import("@/lib/sanity/admin-mutations");
+      return assetExists(assetId);
+    },
+    async uploadAsset(bytes, filename) {
+      const { uploadImageAsset } = await import("@/lib/sanity/admin-mutations");
+      return uploadImageAsset(bytes, filename);
+    },
+    async writeSingleton(sha, counts) {
+      const { writeContentSyncSingleton } =
+        await import("@/lib/sanity/admin-mutations");
+      return writeContentSyncSingleton(sha, counts);
+    },
+  };
+}
+
+/** In-memory double for the orchestrator test — records every mutation. */
+export class InMemoryGateway implements SanityGateway {
+  written: SanityDoc[] = [];
+  deleted: string[] = [];
+  assets = new Set<string>();
+  singleton: { sha: string; counts: Record<string, number> } | null = null;
+
+  constructor(private existing: SanityDoc[] = []) {}
+
+  async readManaged(): Promise<SanityDoc[]> {
+    return this.existing;
+  }
+  async writeDocs(docs: SanityDoc[]): Promise<void> {
+    this.written.push(...docs);
+    // Reflect writes so a same-sha re-run sees them as existing.
+    const byId = new Map(this.existing.map((d) => [d._id, d]));
+    for (const d of docs) byId.set(d._id, d);
+    this.existing = [...byId.values()];
+  }
+  async deleteDocs(ids: string[]): Promise<void> {
+    this.deleted.push(...ids);
+    this.existing = this.existing.filter((d) => !ids.includes(d._id));
+  }
+  async assetExists(assetId: string): Promise<boolean> {
+    return this.assets.has(assetId);
+  }
+  async uploadAsset(_bytes: Uint8Array, filename: string): Promise<string> {
+    const id = `image-${filename}`;
+    this.assets.add(id);
+    return id;
+  }
+  async writeSingleton(
+    sha: string,
+    counts: Record<string, number>
+  ): Promise<void> {
+    this.singleton = { sha, counts };
+  }
+}

--- a/apps/web/src/lib/content-sync/github.ts
+++ b/apps/web/src/lib/content-sync/github.ts
@@ -1,0 +1,94 @@
+import "server-only";
+import { type ChecksState, GitHubUnavailableError } from "./types";
+import { serverEnv } from "@/lib/env.server";
+
+const REPO = "solanabr/academy-courses";
+const BRANCH = "main";
+const API = "https://api.github.com";
+
+export interface GitHubClient {
+  fetchTarball(sha: string): Promise<Uint8Array>;
+  fetchHeadSha(): Promise<string>;
+  fetchChecksState(sha: string): Promise<ChecksState>;
+}
+
+interface Opts {
+  token?: string;
+  fetchImpl?: typeof fetch;
+}
+
+export function createGitHubClient(opts: Opts = {}): GitHubClient {
+  const token = "token" in opts ? opts.token : serverEnv.GITHUB_TOKEN;
+  const doFetch = opts.fetchImpl ?? fetch;
+
+  async function call(path: string, accept: string): Promise<Response> {
+    if (!token) {
+      throw new GitHubUnavailableError("GITHUB_TOKEN is not configured");
+    }
+    let res: Response;
+    try {
+      res = await doFetch(`${API}${path}`, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Accept: accept,
+          "X-GitHub-Api-Version": "2022-11-28",
+        },
+      });
+    } catch (e) {
+      throw new GitHubUnavailableError(
+        e instanceof Error ? e.message : String(e)
+      );
+    }
+    if (!res.ok) {
+      throw new GitHubUnavailableError(`GitHub ${path} → ${res.status}`);
+    }
+    return res;
+  }
+
+  return {
+    async fetchTarball(sha) {
+      // `tarball/<sha>` 302-redirects to codeload; fetch follows redirects by default.
+      const res = await call(
+        `/repos/${REPO}/tarball/${sha}`,
+        "application/vnd.github+json"
+      );
+      return new Uint8Array(await res.arrayBuffer());
+    },
+
+    async fetchHeadSha() {
+      const res = await call(
+        `/repos/${REPO}/commits/${BRANCH}`,
+        "application/vnd.github+json"
+      );
+      const body = (await res.json()) as { sha?: string };
+      if (!body.sha)
+        throw new GitHubUnavailableError("HEAD commit response missing sha");
+      return body.sha;
+    },
+
+    async fetchChecksState(sha) {
+      const res = await call(
+        `/repos/${REPO}/commits/${sha}/check-runs`,
+        "application/vnd.github+json"
+      );
+      const body = (await res.json()) as {
+        check_runs?: { status?: string; conclusion?: string | null }[];
+      };
+      const runs = body.check_runs ?? [];
+      if (runs.length === 0) return "unknown";
+      const failed = new Set([
+        "failure",
+        "timed_out",
+        "cancelled",
+        "action_required",
+        "stale",
+      ]);
+      const done = new Set(["success", "neutral", "skipped"]);
+      if (runs.some((r) => r.conclusion && failed.has(r.conclusion)))
+        return "failure";
+      if (runs.some((r) => !r.conclusion || !done.has(r.conclusion)))
+        return "pending";
+      return "success";
+    },
+  };
+}

--- a/apps/web/src/lib/content-sync/github.ts
+++ b/apps/web/src/lib/content-sync/github.ts
@@ -76,18 +76,20 @@ export function createGitHubClient(opts: Opts = {}): GitHubClient {
       };
       const runs = body.check_runs ?? [];
       if (runs.length === 0) return "unknown";
-      const failed = new Set([
-        "failure",
-        "timed_out",
-        "cancelled",
-        "action_required",
-        "stale",
-      ]);
-      const done = new Set(["success", "neutral", "skipped"]);
-      if (runs.some((r) => r.conclusion && failed.has(r.conclusion)))
+      // A run only counts as green when its terminal conclusion is exactly
+      // `success`. Every other terminal conclusion — failure/timed_out/
+      // cancelled/action_required/stale AND neutral/skipped — blocks the sync:
+      // we cannot tell a *required* skipped check (which must block) from an
+      // optional one via the Checks API, so a skipped/neutral required check
+      // must never read green and be waved past the Zod/executor gate. A run
+      // with no conclusion yet is still in progress → pending.
+      const isTerminal = (c: string | null | undefined): c is string =>
+        c != null && c !== "";
+      if (
+        runs.some((r) => isTerminal(r.conclusion) && r.conclusion !== "success")
+      )
         return "failure";
-      if (runs.some((r) => !r.conclusion || !done.has(r.conclusion)))
-        return "pending";
+      if (runs.some((r) => !isTerminal(r.conclusion))) return "pending";
       return "success";
     },
   };

--- a/apps/web/src/lib/content-sync/graders.ts
+++ b/apps/web/src/lib/content-sync/graders.ts
@@ -1,0 +1,41 @@
+import "server-only";
+import type { AdminTestCase } from "@superteam-lms/types";
+import type { GraderSet } from "./executor-gate";
+import type { SubmissionRunResult } from "@/lib/challenge/executor";
+import { runJsSubmission } from "@/lib/challenge/executor";
+import { runRustSubmission } from "@/lib/challenge/rust-executor";
+import { runBuildableSubmission } from "@/lib/challenge/buildable-executor";
+
+type Run = (
+  code: string,
+  tests: AdminTestCase[]
+) => Promise<SubmissionRunResult>;
+
+/**
+ * Adapt a learner-grading executor into the sync's `Grader` shape. An
+ * unavailable executor is a NON-pass (fail-closed) — the sync must not certify a
+ * block whose oracle could not run (spec §6.2a). This is the SAME oracle that
+ * grades learners, so a block that passes the gate at sync time is judged
+ * identically in the lesson.
+ */
+function adapt(run: Run): GraderSet["js"] {
+  return async (code, tests) => {
+    const result = await run(code, tests as AdminTestCase[]);
+    if (!result.available) {
+      return { passed: false, failures: ["executor_unavailable"] };
+    }
+    return {
+      passed: result.passed,
+      failures: result.results.filter((r) => !r.passed).map((r) => r.detail),
+    };
+  };
+}
+
+/** Wire the three real execution tiers of §6.2a for the sync-time executor gate. */
+export function createLiveGraders(): GraderSet {
+  return {
+    js: adapt(runJsSubmission),
+    rust: adapt(runRustSubmission),
+    buildable: adapt(runBuildableSubmission),
+  };
+}

--- a/apps/web/src/lib/content-sync/preserve.ts
+++ b/apps/web/src/lib/content-sync/preserve.ts
@@ -1,0 +1,118 @@
+import type { ManagedType, SanityDoc } from "./types";
+
+/** Sanity-owned fields that survive a re-sync (spec §9.3). */
+export const PRESERVE: Record<ManagedType, string[]> = {
+  course: ["onChainStatus"],
+  achievement: ["onChainStatus"],
+  lesson: [],
+  instructor: [],
+  learningPath: [],
+  quest: [],
+};
+
+/**
+ * Fields the projector writes per type (Task 6). Kept in lockstep with
+ * projector.ts; the CI equality below fails the build if the two diverge from
+ * the Sanity schema.
+ */
+export const PROJECTED_FIELDS: Record<ManagedType, string[]> = {
+  course: [
+    "title",
+    "slug",
+    "description",
+    "difficulty",
+    "duration",
+    "xpPerLesson",
+    "xpReward",
+    "trackId",
+    "trackLevel",
+    "creatorRewardXp",
+    "minCompletionsForReward",
+    "tags",
+    "creator",
+    "instructor",
+    "prerequisiteCourse",
+    "modules",
+    "thumbnail",
+  ],
+  lesson: ["title", "slug", "blocks"],
+  instructor: ["name", "avatar", "bio", "socialLinks"],
+  learningPath: [
+    "title",
+    "slug",
+    "description",
+    "tag",
+    "order",
+    "difficulty",
+    "courses",
+  ],
+  achievement: [
+    "name",
+    "description",
+    "icon",
+    "category",
+    "xpReward",
+    "maxSupply",
+    "award",
+  ],
+  quest: [
+    "name",
+    "description",
+    "type",
+    "targetValue",
+    "xpReward",
+    "resetType",
+    "active",
+  ],
+};
+
+/** System fields Sanity always adds; excluded from the equality check. */
+const SYSTEM_FIELDS = new Set([
+  "_id",
+  "_type",
+  "_rev",
+  "_createdAt",
+  "_updatedAt",
+  "_key",
+]);
+
+/**
+ * Copy PRESERVE fields from the existing doc onto the projected doc, so a
+ * whole-document `createOrReplace` does not erase Sanity-owned state (§9.3).
+ */
+export function reattachPreserved(
+  projected: SanityDoc,
+  existing: SanityDoc | undefined
+): SanityDoc {
+  if (!existing) return projected;
+  const keep = PRESERVE[projected._type as ManagedType] ?? [];
+  const out: SanityDoc = { ...projected };
+  for (const field of keep) {
+    if (existing[field] !== undefined) out[field] = existing[field];
+  }
+  return out;
+}
+
+/**
+ * Build-time invariant (spec §9.3): every Sanity field is projected, preserved,
+ * the sync marker, or a system field. A Sanity-owned field added without adding
+ * it to PRESERVE throws here — it would otherwise be silently wiped on sync.
+ */
+export function assertSchemaFieldsCovered(
+  type: ManagedType,
+  sanityFields: string[]
+): void {
+  const allowed = new Set([
+    ...PROJECTED_FIELDS[type],
+    ...PRESERVE[type],
+    "sync",
+  ]);
+  const orphans = sanityFields.filter(
+    (f) => !SYSTEM_FIELDS.has(f) && !allowed.has(f)
+  );
+  if (orphans.length > 0) {
+    throw new Error(
+      `Sanity ${type} has unregistered field(s) [${orphans.join(", ")}]: add to PROJECTED_FIELDS or PRESERVE`
+    );
+  }
+}

--- a/apps/web/src/lib/content-sync/projector.ts
+++ b/apps/web/src/lib/content-sync/projector.ts
@@ -1,0 +1,167 @@
+import type { BlockT } from "@superteam-lms/content-schema";
+import type { ValidatedContent } from "./validate";
+import type { SanityDoc } from "./types";
+import { rewriteMarkdownAssetPaths } from "./assets";
+
+export interface AssetUpload {
+  path: string; // repo-relative image path
+  bytes: Uint8Array;
+}
+
+/** Maps a repo-relative image path to its resolved CDN url string, or null if none.
+ *  Markdown rewriting needs a plain url, not a Sanity image reference. */
+export type AssetResolver = (repoRelativePath: string) => string | null;
+
+/** Reads a code block's resolved tests.json array for a given lesson dir + path. */
+export type TestsResolver = (dir: string, testsRelPath: string) => unknown[];
+
+const weakRef = (
+  ref: string
+): { _type: string; _ref: string; _weak: boolean; _key: string } => ({
+  _type: "reference",
+  _ref: ref,
+  _weak: true,
+  _key: ref,
+});
+
+function projectBlock(
+  block: BlockT,
+  dir: string,
+  v: ValidatedContent,
+  resolveAsset: AssetResolver,
+  resolveTests: TestsResolver
+): Record<string, unknown> {
+  const rec = block as unknown as Record<string, unknown>;
+  const out: Record<string, unknown> = {
+    _key: rec.key as string,
+    _type: rec.type as string,
+  };
+  for (const [k, val] of Object.entries(rec)) {
+    if (k === "key" || k === "type") continue;
+    out[k] = val;
+  }
+  // Resolve repo paths → content (spec §9.6, §10.2).
+  if (block.type === "prose") {
+    // Rewrite repo-relative image paths (`assets/x.png`) → CDN urls so the markdown
+    // a learner reads resolves once the repo tree is gone (§9.6). `resolveAsset` keys
+    // on the full repo path, so join the lesson dir onto each markdown-relative path.
+    const rawMd = v.prose.get(`${dir}/${block.src}`) ?? "";
+    out.src = rewriteMarkdownAssetPaths(rawMd, (rel) =>
+      resolveAsset(`${dir}/${rel}`)
+    );
+  }
+  if (block.type === "code") {
+    out.starter = v.code.get(`${dir}/${block.starter}`) ?? "";
+    out.solution = v.code.get(`${dir}/${block.solution}`) ?? "";
+    out.tests = resolveTests(dir, block.tests);
+  }
+  if (block.type === "program-explorer") {
+    const idlPath = (rec.idl as string | undefined) ?? "";
+    out.idl = idlPath ? (v.idl.get(`${dir}/${idlPath}`) ?? "") : "";
+  }
+  return out;
+}
+
+function stripId(
+  obj: Record<string, unknown>,
+  alsoDrop: string[] = []
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [k, val] of Object.entries(obj)) {
+    if (k === "id" || alsoDrop.includes(k)) continue;
+    out[k] = val;
+  }
+  return out;
+}
+
+/**
+ * Project validated repo content into managed Sanity documents. Deterministic:
+ * `_id` = content id, `_key` = block key, module refs weak (§9.5). Every field
+ * is a pure function of the repo or the `sync` marker (§9.3 invariant).
+ */
+export function projectContent(
+  v: ValidatedContent,
+  sha: string,
+  resolveAsset: AssetResolver,
+  resolveTests: TestsResolver
+): { docs: SanityDoc[]; assets: AssetUpload[] } {
+  const marker = { source: "academy-courses", rev: sha } as const;
+  const docs: SanityDoc[] = [];
+  const assets: AssetUpload[] = [...v.assets.entries()].map(
+    ([path, bytes]) => ({
+      path,
+      bytes,
+    })
+  );
+
+  for (const c of v.courses) {
+    docs.push({
+      _id: c.id,
+      _type: "course",
+      title: c.title,
+      slug: { _type: "slug", current: c.slug },
+      description: c.description,
+      difficulty: c.difficulty,
+      duration: c.duration,
+      xpPerLesson: c.xpPerLesson,
+      xpReward: c.xpReward,
+      trackId: c.trackId ?? 0,
+      trackLevel: c.trackLevel ?? 0,
+      creatorRewardXp: c.creatorRewardXp ?? 0,
+      minCompletionsForReward: c.minCompletionsForReward ?? 0,
+      tags: c.tags ?? [],
+      creator: { githubId: c.creator.githubId },
+      instructor: c.instructor ? weakRef(c.instructor) : undefined,
+      prerequisiteCourse: c.prerequisiteCourse
+        ? weakRef(c.prerequisiteCourse)
+        : undefined,
+      modules: c.modules.map((m) => ({
+        _type: "courseModule",
+        _key: m.key,
+        key: m.key,
+        title: m.title,
+        description: m.description,
+        lessons: m.lessons.map(weakRef),
+      })),
+      sync: marker,
+    });
+  }
+
+  for (const { dir, lesson } of v.lessons) {
+    docs.push({
+      _id: lesson.id,
+      _type: "lesson",
+      title: lesson.title,
+      slug: { _type: "slug", current: lesson.slug },
+      blocks: lesson.blocks.map((b) =>
+        projectBlock(b, dir, v, resolveAsset, resolveTests)
+      ),
+      sync: marker,
+    });
+  }
+
+  for (const i of v.instructors as { id: string; [k: string]: unknown }[]) {
+    docs.push({ _id: i.id, _type: "instructor", ...stripId(i), sync: marker });
+  }
+  for (const p of v.paths as {
+    id: string;
+    courses?: string[];
+    [k: string]: unknown;
+  }[]) {
+    docs.push({
+      _id: p.id,
+      _type: "learningPath",
+      ...stripId(p, ["courses"]),
+      courses: (p.courses ?? []).map(weakRef),
+      sync: marker,
+    });
+  }
+  for (const a of v.achievements as { id: string; [k: string]: unknown }[]) {
+    docs.push({ _id: a.id, _type: "achievement", ...stripId(a), sync: marker });
+  }
+  for (const q of v.quests as { id: string; [k: string]: unknown }[]) {
+    docs.push({ _id: q.id, _type: "quest", ...stripId(q), sync: marker });
+  }
+
+  return { docs, assets };
+}

--- a/apps/web/src/lib/content-sync/prune.ts
+++ b/apps/web/src/lib/content-sync/prune.ts
@@ -8,16 +8,20 @@ export function prunableQuery(): string {
 }
 
 /**
- * Docs to delete after a full write: ours (matching `sync.source`) and NOT at
- * the current sha. Documents without the marker — image assets, anything
- * hand-created — are untouchable (spec §9.4 guard 2).
+ * Docs to delete after a full write: ours (matching `sync.source`) whose `_id`
+ * is absent from the new tree (`projectedIds`). Computed purely from the
+ * pre-write managed read + the projected id set — never from a post-write
+ * read-back — so an async / lagging managed-read can never place a just-written
+ * doc in the delete set (the read-your-writes race). Documents without our
+ * marker — image assets, hand-created docs, drafts — are untouchable
+ * (spec §9.4 guard 2).
  */
 export function selectPrunable(
   existing: SanityDoc[],
-  sha: string
+  projectedIds: ReadonlySet<string>
 ): SanityDoc[] {
   return existing.filter(
-    (d) => d.sync?.source === SOURCE && d.sync.rev !== sha
+    (d) => d.sync?.source === SOURCE && !projectedIds.has(d._id)
   );
 }
 

--- a/apps/web/src/lib/content-sync/prune.ts
+++ b/apps/web/src/lib/content-sync/prune.ts
@@ -1,0 +1,73 @@
+import { BlastRadiusError, type SanityDoc } from "./types";
+
+const SOURCE = "academy-courses";
+
+/** GROQ that selects prunable ids: our marker, a stale rev. Parameterised by $sha. */
+export function prunableQuery(): string {
+  return '*[sync.source == "academy-courses" && sync.rev != $sha]._id';
+}
+
+/**
+ * Docs to delete after a full write: ours (matching `sync.source`) and NOT at
+ * the current sha. Documents without the marker — image assets, anything
+ * hand-created — are untouchable (spec §9.4 guard 2).
+ */
+export function selectPrunable(
+  existing: SanityDoc[],
+  sha: string
+): SanityDoc[] {
+  return existing.filter(
+    (d) => d.sync?.source === SOURCE && d.sync.rev !== sha
+  );
+}
+
+/** Blast-radius guard (spec §9.4 guard 4): abort if prune > 20% of managed docs. */
+export function assertBlastRadius(
+  pruneCount: number,
+  managedTotal: number
+): void {
+  if (managedTotal > 0 && pruneCount > managedTotal * 0.2) {
+    throw new BlastRadiusError(pruneCount, managedTotal);
+  }
+}
+
+function sortKeys(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortKeys);
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([k, v]) => [k, sortKeys(v)])
+    );
+  }
+  return value;
+}
+
+const stable = (d: SanityDoc): string => {
+  const { _rev, _createdAt, _updatedAt, ...rest } = d as Record<
+    string,
+    unknown
+  >;
+  void _rev;
+  void _createdAt;
+  void _updatedAt;
+  return JSON.stringify(sortKeys(rest));
+};
+
+/**
+ * Idempotency core (Global Constraints): only the docs whose projected value
+ * differs from the existing doc. Re-running at the same sha yields [] because
+ * `sync.rev` is identical and every projected field is a pure function of the
+ * repo. PRESERVE fields must already be reattached onto `projected` (Task 6/8)
+ * so an unchanged onChainStatus does not register as a diff.
+ */
+export function selectChangedDocs(
+  existing: SanityDoc[],
+  projected: SanityDoc[]
+): SanityDoc[] {
+  const byId = new Map(existing.map((d) => [d._id, d]));
+  return projected.filter((p) => {
+    const cur = byId.get(p._id);
+    return !cur || stable(cur) !== stable(p);
+  });
+}

--- a/apps/web/src/lib/content-sync/sync.ts
+++ b/apps/web/src/lib/content-sync/sync.ts
@@ -1,0 +1,155 @@
+import { imageSize } from "image-size";
+import { revalidateTag } from "next/cache";
+import type { GitHubClient } from "./github";
+import type { SanityGateway } from "./gateway";
+import type { GraderSet } from "./executor-gate";
+import type { SanityDoc, SyncResult } from "./types";
+import { MANAGED_TYPES } from "./types";
+import { extractTarball } from "./tarball";
+import { parseAndValidateTree } from "./validate";
+import { projectContent, type AssetUpload } from "./projector";
+import { reattachPreserved } from "./preserve";
+import { selectChangedDocs, selectPrunable, assertBlastRadius } from "./prune";
+import { assertCommitSyncable } from "./drift";
+import { computeAssetId, cdnUrl } from "./assets";
+import { COURSES_CACHE_TAG } from "@/lib/sanity/queries";
+
+export interface SyncDeps {
+  sha: string;
+  github: GitHubClient;
+  gateway: SanityGateway;
+  graders: GraderSet;
+  projectId: string;
+  dataset: string;
+}
+
+/** Probe the real image dimensions. Sanity computes width/height on upload and
+ *  bakes them into the asset _id, so `computeAssetId` and `cdnUrl` must use the
+ *  same values — otherwise `assetExists` never matches (every sync re-uploads)
+ *  and the rewritten markdown points at a URL Sanity does not serve. */
+function probeDims(bytes: Uint8Array): { width: number; height: number } {
+  const { width, height } = imageSize(bytes);
+  if (!width || !height) {
+    throw new Error("could not probe image dimensions");
+  }
+  return { width, height };
+}
+function formatOf(path: string): string {
+  const m = /\.(\w+)$/.exec(path);
+  return (m?.[1] ?? "png").toLowerCase();
+}
+
+/** Upload new assets (skip existing by content-derived id) and return a
+ *  repo-path → CDN-url map for the markdown rewrite. */
+async function syncAssets(
+  assets: AssetUpload[],
+  deps: SyncDeps
+): Promise<{ urlByPath: Map<string, string>; uploaded: number }> {
+  const urlByPath = new Map<string, string>();
+  let uploaded = 0;
+  for (const a of assets) {
+    const id = computeAssetId(a.bytes, probeDims(a.bytes), formatOf(a.path));
+    if (!(await deps.gateway.assetExists(id))) {
+      await deps.gateway.uploadAsset(
+        a.bytes,
+        a.path.split("/").pop() ?? "asset"
+      );
+      uploaded += 1;
+    }
+    urlByPath.set(a.path, cdnUrl(id, deps.projectId, deps.dataset));
+  }
+  return { urlByPath, uploaded };
+}
+
+/**
+ * The repo → Sanity content sync (§9.2). Every guard is applied in order; a
+ * partial write can never trigger a prune, a red-CI commit is refused, and a
+ * same-sha re-run is a no-op.
+ */
+export async function runContentSync(deps: SyncDeps): Promise<SyncResult> {
+  // 1. Refuse a red / unfinished commit (§11.1 blocked).
+  const checks = await deps.github.fetchChecksState(deps.sha);
+  assertCommitSyncable(checks, deps.sha);
+
+  // 2. Fetch + extract the tree at the SHA.
+  const tree = await extractTarball(await deps.github.fetchTarball(deps.sha));
+
+  // 3. Authoritative re-validation (Zod + executor gate).
+  const validated = await parseAndValidateTree(tree, deps.graders);
+
+  // 4. Assets: upload new, resolve CDN urls for the markdown rewrite.
+  const { urlByPath, uploaded } = await syncAssets(
+    [...validated.assets.entries()].map(([path, bytes]) => ({ path, bytes })),
+    deps
+  );
+
+  // 5. Project (resolving prose/code/idl + rewriting image paths via the map).
+  const resolveTests = (dir: string, rel: string): unknown[] => {
+    const raw = tree.get(`${dir}/${rel}`);
+    return raw ? (JSON.parse(new TextDecoder().decode(raw)) as unknown[]) : [];
+  };
+  // resolveAsset returns the plain CDN url string (an `AssetResolver`) — the
+  // markdown rewrite needs a url, not a Sanity image reference. syncAssets already
+  // ran the async pipeline per asset (computeAssetId → assetExists/upload → cdnUrl)
+  // into urlByPath, so this stays a synchronous lookup (rewriteMarkdownAssetPaths
+  // runs inside String.replace and can't await). The content-derived id yields the
+  // same url whether the asset already existed or was just uploaded.
+  const resolveAsset = (repoPath: string): string | null =>
+    urlByPath.get(repoPath) ?? null;
+  const { docs: projected } = projectContent(
+    validated,
+    deps.sha,
+    resolveAsset,
+    resolveTests
+  );
+
+  // 6. Reattach PRESERVE from existing docs.
+  const existing = await deps.gateway.readManaged();
+  const existingById = new Map(existing.map((d) => [d._id, d]));
+  const merged = projected.map((p) =>
+    reattachPreserved(p, existingById.get(p._id))
+  );
+
+  // 7. Idempotent change set.
+  const changed = selectChangedDocs(existing, merged);
+
+  // 8. Write everything first, then verify the count (§9.4 guard 3).
+  await deps.gateway.writeDocs(changed);
+  const afterWrite = await deps.gateway.readManaged();
+  const managed = (d: SanityDoc): boolean =>
+    (MANAGED_TYPES as readonly string[]).includes(d._type);
+  const managedNow = afterWrite.filter(managed);
+  const projectedManaged = merged.filter(managed);
+  if (managedNow.length < projectedManaged.length) {
+    throw new Error(
+      `write-verify failed: ${managedNow.length} managed docs present, expected >= ${projectedManaged.length}`
+    );
+  }
+
+  // 9. Prune stale docs — marker-scoped, blast-radius guarded (§9.4).
+  const prunable = selectPrunable(afterWrite, deps.sha);
+  assertBlastRadius(prunable.length, afterWrite.length);
+  await deps.gateway.deleteDocs(prunable.map((d) => d._id));
+
+  // 10. Write the contentSync singleton LAST (never matches the prune query).
+  const counts = countByType(projectedManaged);
+  await deps.gateway.writeSingleton(deps.sha, counts);
+
+  // 11. Purge the catalog cache.
+  revalidateTag(COURSES_CACHE_TAG);
+
+  return {
+    sha: deps.sha,
+    written: changed.length,
+    skipped: merged.length - changed.length,
+    pruned: prunable.length,
+    assetsUploaded: uploaded,
+    pendingChainDeltas: [], // computed by the chain-sync path (§11.2), reported in the drift route
+  };
+}
+
+function countByType(docs: SanityDoc[]): Record<string, number> {
+  const out: Record<string, number> = {};
+  for (const d of docs) out[d._type] = (out[d._type] ?? 0) + 1;
+  return out;
+}

--- a/apps/web/src/lib/content-sync/sync.ts
+++ b/apps/web/src/lib/content-sync/sync.ts
@@ -113,26 +113,27 @@ export async function runContentSync(deps: SyncDeps): Promise<SyncResult> {
   // 7. Idempotent change set.
   const changed = selectChangedDocs(existing, merged);
 
-  // 8. Write everything first, then verify the count (§9.4 guard 3).
+  // 8. Write the change set in one atomic, read-your-writes transaction.
   await deps.gateway.writeDocs(changed);
-  const afterWrite = await deps.gateway.readManaged();
-  const managed = (d: SanityDoc): boolean =>
-    (MANAGED_TYPES as readonly string[]).includes(d._type);
-  const managedNow = afterWrite.filter(managed);
-  const projectedManaged = merged.filter(managed);
-  if (managedNow.length < projectedManaged.length) {
-    throw new Error(
-      `write-verify failed: ${managedNow.length} managed docs present, expected >= ${projectedManaged.length}`
-    );
-  }
 
-  // 9. Prune stale docs — marker-scoped, blast-radius guarded (§9.4).
-  const prunable = selectPrunable(afterWrite, deps.sha);
-  assertBlastRadius(prunable.length, afterWrite.length);
+  // 9. Prune docs this source previously managed that are absent from the new
+  //    tree (§9.4). The prune set is derived purely from `existing` (the
+  //    pre-write managed read) and `projectedIds` (the ids we just wrote) — it
+  //    is NEVER re-read after writing. A post-write read-back would race Sanity's
+  //    write visibility: a just-written doc that read back at its OLD sync.rev
+  //    would match a stale-rev filter and be silently deleted. Computing from
+  //    in-memory sets makes that impossible: a doc present in the new tree can
+  //    never be in the prune set. Blast-radius is guarded against the managed
+  //    total read at the start.
+  const projectedIds = new Set(merged.map((d) => d._id));
+  const prunable = selectPrunable(existing, projectedIds);
+  assertBlastRadius(prunable.length, existing.length);
   await deps.gateway.deleteDocs(prunable.map((d) => d._id));
 
-  // 10. Write the contentSync singleton LAST (never matches the prune query).
-  const counts = countByType(projectedManaged);
+  // 10. Write the contentSync singleton LAST (never matches the prune set).
+  const managed = (d: SanityDoc): boolean =>
+    (MANAGED_TYPES as readonly string[]).includes(d._type);
+  const counts = countByType(merged.filter(managed));
   await deps.gateway.writeSingleton(deps.sha, counts);
 
   // 11. Purge the catalog cache.

--- a/apps/web/src/lib/content-sync/tarball.ts
+++ b/apps/web/src/lib/content-sync/tarball.ts
@@ -4,9 +4,23 @@ import type { RepoTree } from "./types";
 /** Repo path prefix that is excluded from sync (spec §4.1, §12). */
 const EXCLUDED = "courses/_template/";
 
+function decodeStr(bytes: Uint8Array): string {
+  return new TextDecoder().decode(bytes).replace(/\0.*$/, "");
+}
+
 function parseOctal(bytes: Uint8Array): number {
-  const s = new TextDecoder().decode(bytes).replace(/\0.*$/, "").trim();
+  const s = decodeStr(bytes).trim();
   return s === "" ? 0 : parseInt(s, 8);
+}
+
+/**
+ * Read the `path=` override from a pax extended header's records. Records are
+ * `"<len> <key>=<value>\n"`; git archive emits one for a path that cannot be
+ * split across the ustar name/prefix fields.
+ */
+function parsePaxPath(data: Uint8Array): string | null {
+  const m = /\d+ path=([^\n]*)\n/.exec(new TextDecoder().decode(data));
+  return m ? m[1]! : null;
 }
 
 /**
@@ -14,34 +28,53 @@ function parseOctal(bytes: Uint8Array): number {
  * GitHub wraps every entry under one generated dir (`owner-repo-<sha>/`); we
  * strip the first path segment so keys match the repo layout. Directory entries
  * (typeflag '5', trailing slash) and `courses/_template/**` are dropped.
+ *
+ * Long paths (repo paths routinely exceed the 100-byte tar `name` field once the
+ * generated top dir is prepended) are reconstructed from the ustar `prefix`
+ * field (offset 345) and from pax extended headers ('x' typeflag) — the two
+ * mechanisms `git archive` uses. Ignoring them would silently drop deep files.
  */
 export async function extractTarball(gzipped: Uint8Array): Promise<RepoTree> {
   const buf = new Uint8Array(gunzipSync(Buffer.from(gzipped)));
   const tree: RepoTree = new Map();
   let offset = 0;
+  let paxPath: string | null = null; // path override from a preceding 'x' header
   while (offset + 512 <= buf.length) {
     const header = buf.subarray(offset, offset + 512);
     // Two consecutive zero blocks terminate the archive.
     if (header.every((b) => b === 0)) break;
 
-    const rawName = new TextDecoder()
-      .decode(header.subarray(0, 100))
-      .replace(/\0.*$/, "");
+    const name = decodeStr(header.subarray(0, 100));
     const size = parseOctal(header.subarray(124, 136));
     const typeflag = String.fromCharCode(header[156] || 0);
+    const prefix = decodeStr(header.subarray(345, 500));
     offset += 512;
 
     const dataLen = Math.ceil(size / 512) * 512;
     const data = buf.subarray(offset, offset + size);
     offset += dataLen;
 
-    if (typeflag !== "0" && typeflag !== "\0") continue; // only regular files
-    if (rawName.endsWith("/")) continue;
+    // pax extended header — its records carry `path=` for the NEXT entry.
+    if (typeflag === "x" || typeflag === "g") {
+      const p = parsePaxPath(data);
+      if (typeflag === "x" && p) paxPath = p;
+      continue;
+    }
+
+    if (typeflag !== "0" && typeflag !== "\0") {
+      paxPath = null;
+      continue; // only regular files
+    }
+
+    const fullName = paxPath ?? (prefix ? `${prefix}/${name}` : name);
+    paxPath = null;
+
+    if (fullName.endsWith("/")) continue;
 
     // Strip the generated top-level directory (`owner-repo-<sha>/`).
-    const slash = rawName.indexOf("/");
+    const slash = fullName.indexOf("/");
     if (slash === -1) continue;
-    const relPath = rawName.slice(slash + 1);
+    const relPath = fullName.slice(slash + 1);
     if (relPath === "" || relPath.startsWith(EXCLUDED)) continue;
 
     tree.set(relPath, new Uint8Array(data));

--- a/apps/web/src/lib/content-sync/tarball.ts
+++ b/apps/web/src/lib/content-sync/tarball.ts
@@ -4,6 +4,30 @@ import type { RepoTree } from "./types";
 /** Repo path prefix that is excluded from sync (spec §4.1, §12). */
 const EXCLUDED = "courses/_template/";
 
+/**
+ * Decompression bounds against a malicious/corrupt tarball (a gzip bomb inflates
+ * to gigabytes; a pathological archive packs millions of tiny headers). The
+ * academy-courses repo is text + optimised images — well under these — so the
+ * caps only ever fire on abuse. Both are overridable for tests.
+ */
+const DEFAULT_MAX_DECOMPRESSED_BYTES = 128 * 1024 * 1024; // 128 MiB
+const DEFAULT_MAX_ENTRIES = 20_000;
+
+export interface ExtractOpts {
+  /** Max bytes the gunzip may inflate to before aborting. */
+  maxDecompressedBytes?: number;
+  /** Max number of tar entries (headers) processed before aborting. */
+  maxEntries?: number;
+}
+
+/** Raised when a tarball breaches a decompression bound (§ defensive extraction). */
+export class TarballTooLargeError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "TarballTooLargeError";
+  }
+}
+
 function decodeStr(bytes: Uint8Array): string {
   return new TextDecoder().decode(bytes).replace(/\0.*$/, "");
 }
@@ -34,15 +58,40 @@ function parsePaxPath(data: Uint8Array): string | null {
  * field (offset 345) and from pax extended headers ('x' typeflag) — the two
  * mechanisms `git archive` uses. Ignoring them would silently drop deep files.
  */
-export async function extractTarball(gzipped: Uint8Array): Promise<RepoTree> {
-  const buf = new Uint8Array(gunzipSync(Buffer.from(gzipped)));
+export async function extractTarball(
+  gzipped: Uint8Array,
+  opts: ExtractOpts = {}
+): Promise<RepoTree> {
+  const maxBytes = opts.maxDecompressedBytes ?? DEFAULT_MAX_DECOMPRESSED_BYTES;
+  const maxEntries = opts.maxEntries ?? DEFAULT_MAX_ENTRIES;
+
+  let inflated: Buffer;
+  try {
+    inflated = gunzipSync(Buffer.from(gzipped), { maxOutputLength: maxBytes });
+  } catch (e) {
+    // zlib throws (ERR_BUFFER_TOO_LARGE) once the output would exceed
+    // maxOutputLength; a corrupt stream throws here too. Fail with a clear error.
+    throw new TarballTooLargeError(
+      `content tarball could not be decompressed within the ${maxBytes}-byte cap: ${
+        e instanceof Error ? e.message : String(e)
+      }`
+    );
+  }
+  const buf = new Uint8Array(inflated);
   const tree: RepoTree = new Map();
   let offset = 0;
+  let entries = 0;
   let paxPath: string | null = null; // path override from a preceding 'x' header
   while (offset + 512 <= buf.length) {
     const header = buf.subarray(offset, offset + 512);
     // Two consecutive zero blocks terminate the archive.
     if (header.every((b) => b === 0)) break;
+
+    if (++entries > maxEntries) {
+      throw new TarballTooLargeError(
+        `content tarball exceeds the ${maxEntries}-entry cap`
+      );
+    }
 
     const name = decodeStr(header.subarray(0, 100));
     const size = parseOctal(header.subarray(124, 136));

--- a/apps/web/src/lib/content-sync/tarball.ts
+++ b/apps/web/src/lib/content-sync/tarball.ts
@@ -1,0 +1,50 @@
+import { gunzipSync } from "node:zlib";
+import type { RepoTree } from "./types";
+
+/** Repo path prefix that is excluded from sync (spec §4.1, §12). */
+const EXCLUDED = "courses/_template/";
+
+function parseOctal(bytes: Uint8Array): number {
+  const s = new TextDecoder().decode(bytes).replace(/\0.*$/, "").trim();
+  return s === "" ? 0 : parseInt(s, 8);
+}
+
+/**
+ * Gunzip + untar a GitHub tarball into a repo-relative path → bytes map.
+ * GitHub wraps every entry under one generated dir (`owner-repo-<sha>/`); we
+ * strip the first path segment so keys match the repo layout. Directory entries
+ * (typeflag '5', trailing slash) and `courses/_template/**` are dropped.
+ */
+export async function extractTarball(gzipped: Uint8Array): Promise<RepoTree> {
+  const buf = new Uint8Array(gunzipSync(Buffer.from(gzipped)));
+  const tree: RepoTree = new Map();
+  let offset = 0;
+  while (offset + 512 <= buf.length) {
+    const header = buf.subarray(offset, offset + 512);
+    // Two consecutive zero blocks terminate the archive.
+    if (header.every((b) => b === 0)) break;
+
+    const rawName = new TextDecoder()
+      .decode(header.subarray(0, 100))
+      .replace(/\0.*$/, "");
+    const size = parseOctal(header.subarray(124, 136));
+    const typeflag = String.fromCharCode(header[156] || 0);
+    offset += 512;
+
+    const dataLen = Math.ceil(size / 512) * 512;
+    const data = buf.subarray(offset, offset + size);
+    offset += dataLen;
+
+    if (typeflag !== "0" && typeflag !== "\0") continue; // only regular files
+    if (rawName.endsWith("/")) continue;
+
+    // Strip the generated top-level directory (`owner-repo-<sha>/`).
+    const slash = rawName.indexOf("/");
+    if (slash === -1) continue;
+    const relPath = rawName.slice(slash + 1);
+    if (relPath === "" || relPath.startsWith(EXCLUDED)) continue;
+
+    tree.set(relPath, new Uint8Array(data));
+  }
+  return tree;
+}

--- a/apps/web/src/lib/content-sync/types.ts
+++ b/apps/web/src/lib/content-sync/types.ts
@@ -1,0 +1,80 @@
+/** A repo tarball flattened to POSIX paths (relative to the repo root) → file bytes. */
+export type RepoTree = Map<string, Uint8Array>;
+
+export const MANAGED_TYPES = [
+  "course",
+  "lesson",
+  "instructor",
+  "learningPath",
+  "achievement",
+  "quest",
+] as const;
+export type ManagedType = (typeof MANAGED_TYPES)[number];
+
+/** A minimal Sanity document. `sync`/`onChainStatus` are optional overlays. */
+export interface SanityDoc {
+  _id: string;
+  _type: string;
+  sync?: { source: string; rev: string };
+  onChainStatus?: Record<string, unknown>;
+  [field: string]: unknown;
+}
+
+/** GitHub combined check state for a commit (Checks API `conclusion` folded). */
+export type ChecksState = "success" | "failure" | "pending" | "unknown";
+
+export interface SyncResult {
+  sha: string;
+  written: number;
+  skipped: number;
+  pruned: number;
+  assetsUploaded: number;
+  pendingChainDeltas: string[]; // course ids whose active_lessons mask changed
+}
+
+/** HEAD's CI is red — refuse to sync (§11.1 `blocked`). */
+export class BlockedCommitError extends Error {
+  constructor(public readonly sha: string) {
+    super(`Refusing to sync ${sha}: its CI checks are not passing`);
+    this.name = "BlockedCommitError";
+  }
+}
+
+/** The prune set exceeds the 20% blast-radius guard (§9.4). */
+export class BlastRadiusError extends Error {
+  constructor(
+    public readonly pruneCount: number,
+    public readonly managedTotal: number
+  ) {
+    super(
+      `Prune of ${pruneCount}/${managedTotal} managed docs exceeds the 20% blast radius; aborting`
+    );
+    this.name = "BlastRadiusError";
+  }
+}
+
+/** Zod / executor re-validation rejected the tree (§9.2 step 2, §6.2a). */
+export class ContentValidationError extends Error {
+  constructor(public readonly issues: string[]) {
+    super(`Content re-validation failed: ${issues.length} issue(s)`);
+    this.name = "ContentValidationError";
+  }
+}
+
+/** GitHub API unreachable / unauthenticated (missing GITHUB_TOKEN, rate limit). */
+export class GitHubUnavailableError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "GitHubUnavailableError";
+  }
+}
+
+/** The active_lessons mask does not match the committed slots.lock.json (§11.0). */
+export class MaskMismatchError extends Error {
+  constructor(public readonly courseId: string) {
+    super(
+      `active_lessons mask for ${courseId} does not match its slots.lock.json`
+    );
+    this.name = "MaskMismatchError";
+  }
+}

--- a/apps/web/src/lib/content-sync/validate.ts
+++ b/apps/web/src/lib/content-sync/validate.ts
@@ -1,0 +1,136 @@
+import { parse as parseYaml } from "yaml";
+import {
+  Course,
+  Lesson,
+  SlotsLock,
+  Achievement,
+  Quest,
+  LearningPath,
+  Instructor,
+  type CourseT,
+  type LessonT,
+  type SlotsLockT,
+} from "@superteam-lms/content-schema";
+import type { RepoTree } from "./types";
+import { ContentValidationError } from "./types";
+import { gateCodeBlock, type GraderSet } from "./executor-gate";
+
+export interface ValidatedContent {
+  courses: CourseT[];
+  lessons: { dir: string; lesson: LessonT }[];
+  achievements: unknown[];
+  quests: unknown[];
+  paths: unknown[];
+  instructors: unknown[];
+  slots: Map<string, SlotsLockT>; // course dir → lockfile
+  prose: Map<string, string>; // md path → body
+  code: Map<string, string>; // ts/rs path → body
+  idl: Map<string, string>; // idl path → json
+  assets: Map<string, Uint8Array>; // image path → bytes
+}
+
+const text = (bytes: Uint8Array): string => new TextDecoder().decode(bytes);
+const dirOf = (path: string): string => path.slice(0, path.lastIndexOf("/"));
+
+/**
+ * Re-parse and Zod-validate every YAML/JSON in the tree, load prose/code/idl/
+ * asset bodies, and run the two-sided executor gate on every `code` block. This
+ * is the authoritative validation (§9.2 step 2) — the repo's PR check may not
+ * have run against this exact SHA. Accumulates all issues, then throws once.
+ */
+export async function parseAndValidateTree(
+  tree: RepoTree,
+  graders: GraderSet
+): Promise<ValidatedContent> {
+  const issues: string[] = [];
+  const v: ValidatedContent = {
+    courses: [],
+    lessons: [],
+    achievements: [],
+    quests: [],
+    paths: [],
+    instructors: [],
+    slots: new Map(),
+    prose: new Map(),
+    code: new Map(),
+    idl: new Map(),
+    assets: new Map(),
+  };
+
+  const zod = <T>(
+    schema: { parse: (x: unknown) => T },
+    raw: unknown,
+    where: string
+  ): T | null => {
+    try {
+      return schema.parse(raw);
+    } catch (e) {
+      issues.push(`${where}: ${e instanceof Error ? e.message : String(e)}`);
+      return null;
+    }
+  };
+
+  for (const [path, bytes] of tree) {
+    if (path.endsWith("/course.yaml")) {
+      const c = zod(Course, parseYaml(text(bytes)), path);
+      if (c) v.courses.push(c);
+    } else if (path.endsWith("/slots.lock.json")) {
+      const s = zod(SlotsLock, JSON.parse(text(bytes)), path);
+      if (s) v.slots.set(dirOf(path), s);
+    } else if (path.endsWith("/lesson.yaml")) {
+      const l = zod(Lesson, parseYaml(text(bytes)), path);
+      if (l) v.lessons.push({ dir: dirOf(path), lesson: l });
+    } else if (path.startsWith("achievements/") && path.endsWith(".yaml")) {
+      const a = zod(Achievement, parseYaml(text(bytes)), path);
+      if (a) v.achievements.push(a);
+    } else if (path.startsWith("quests/") && path.endsWith(".yaml")) {
+      const q = zod(Quest, parseYaml(text(bytes)), path);
+      if (q) v.quests.push(q);
+    } else if (path.startsWith("paths/") && path.endsWith(".yaml")) {
+      const p = zod(LearningPath, parseYaml(text(bytes)), path);
+      if (p) v.paths.push(p);
+    } else if (path.startsWith("instructors/") && path.endsWith(".yaml")) {
+      const i = zod(Instructor, parseYaml(text(bytes)), path);
+      if (i) v.instructors.push(i);
+    } else if (path.endsWith(".md")) {
+      v.prose.set(path, text(bytes));
+    } else if (path.endsWith(".ts") || path.endsWith(".rs")) {
+      v.code.set(path, text(bytes));
+    } else if (path.endsWith(".idl.json")) {
+      v.idl.set(path, text(bytes));
+    } else if (/\.(png|jpe?g|gif|webp|svg)$/i.test(path)) {
+      v.assets.set(path, bytes);
+    }
+  }
+
+  // Executor gate on every code block, resolving its files from the tree.
+  for (const { dir, lesson } of v.lessons) {
+    for (const block of lesson.blocks) {
+      if (block.type !== "code") continue;
+      const starter = v.code.get(`${dir}/${block.starter}`);
+      const solution = v.code.get(`${dir}/${block.solution}`);
+      const testsRaw = tree.get(`${dir}/${block.tests}`);
+      if (!starter || !solution || !testsRaw) {
+        issues.push(
+          `lesson ${lesson.id} block ${block.key}: missing starter/solution/tests file`
+        );
+        continue;
+      }
+      const tests = JSON.parse(text(testsRaw)) as unknown[];
+      const blockIssues = await gateCodeBlock(
+        {
+          key: block.key,
+          type: "code",
+          language: block.language,
+          buildType: block.buildType,
+        },
+        { starter, solution, tests },
+        graders
+      );
+      issues.push(...blockIssues);
+    }
+  }
+
+  if (issues.length > 0) throw new ContentValidationError(issues);
+  return v;
+}

--- a/apps/web/src/lib/env.server.ts
+++ b/apps/web/src/lib/env.server.ts
@@ -31,6 +31,11 @@ const serverEnvSchema = z.object({
   SOLANA_RPC_URL: z.url(),
   // Optional: only needed for admin Sanity writes.
   SANITY_ADMIN_TOKEN: optStr,
+  // Fine-grained READ token for solanabr/academy-courses. Server-only. Needed by
+  // POST /api/admin/content/sync (tarball fetch), the drift UI (HEAD polling),
+  // and the Checks API (blocked state). Optional at boot; the content routes 503
+  // when unset. Unauthenticated GitHub is 60 req/hr per IP and flakes on Vercel.
+  GITHUB_TOKEN: optStr,
   // Admin panel HMAC cookie signing key.
   ADMIN_SECRET: optStr,
   // Helius webhook HMAC verification secret.
@@ -56,6 +61,7 @@ const parsed = serverEnvSchema.safeParse({
   SUPABASE_SERVICE_ROLE_KEY: process.env.SUPABASE_SERVICE_ROLE_KEY,
   SOLANA_RPC_URL: process.env.SOLANA_RPC_URL,
   SANITY_ADMIN_TOKEN: process.env.SANITY_ADMIN_TOKEN,
+  GITHUB_TOKEN: process.env.GITHUB_TOKEN,
   ADMIN_SECRET: process.env.ADMIN_SECRET,
   HELIUS_WEBHOOK_SECRET: process.env.HELIUS_WEBHOOK_SECRET,
   BACKEND_SIGNER_SECRET: process.env.BACKEND_SIGNER_SECRET,

--- a/apps/web/src/lib/sanity/__tests__/admin-mutations.test.ts
+++ b/apps/web/src/lib/sanity/__tests__/admin-mutations.test.ts
@@ -1,0 +1,75 @@
+/* eslint-disable import/order -- vi.mock/vi.hoisted must precede importing ../admin-mutations. */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+// Hoisted mocks so the next-sanity factory can reference them safely.
+const { fetchMock, commitMock, createOrReplaceMock, deleteMock } = vi.hoisted(
+  () => ({
+    fetchMock: vi.fn(),
+    commitMock: vi.fn(),
+    createOrReplaceMock: vi.fn(),
+    deleteMock: vi.fn(),
+  })
+);
+
+vi.mock("next-sanity", () => {
+  const tx = {
+    createOrReplace: (doc: unknown) => {
+      createOrReplaceMock(doc);
+      return tx;
+    },
+    delete: (id: string) => {
+      deleteMock(id);
+      return tx;
+    },
+    commit: (opts: unknown) => {
+      commitMock(opts);
+      return Promise.resolve();
+    },
+  };
+  return {
+    createClient: () => ({ fetch: fetchMock, transaction: () => tx }),
+  };
+});
+
+import {
+  readManagedDocuments,
+  writeDocuments,
+  deleteDocuments,
+} from "../admin-mutations";
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  commitMock.mockReset();
+  createOrReplaceMock.mockReset();
+  deleteMock.mockReset();
+});
+
+describe("admin-mutations content-sync surface", () => {
+  it("reads managed docs pinned to the published perspective (drafts excluded)", async () => {
+    fetchMock.mockResolvedValue([]);
+    await readManagedDocuments();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const options = fetchMock.mock.calls[0]![2];
+    expect(options).toEqual({ perspective: "published" });
+  });
+
+  it("commits the write batch with read-your-writes (sync) visibility", async () => {
+    await writeDocuments([{ _id: "course-a", _type: "course" }]);
+    expect(createOrReplaceMock).toHaveBeenCalledTimes(1);
+    expect(commitMock).toHaveBeenCalledWith({ visibility: "sync" });
+  });
+
+  it("commits the delete batch with sync visibility", async () => {
+    await deleteDocuments(["course-a"]);
+    expect(deleteMock).toHaveBeenCalledWith("course-a");
+    expect(commitMock).toHaveBeenCalledWith({ visibility: "sync" });
+  });
+
+  it("is a no-op (no transaction commit) on an empty batch", async () => {
+    await writeDocuments([]);
+    await deleteDocuments([]);
+    expect(commitMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/sanity/admin-mutations.ts
+++ b/apps/web/src/lib/sanity/admin-mutations.ts
@@ -26,28 +26,45 @@ export function getSanityAdminClient(): typeof sanityAdmin {
 // unit-tested against an in-memory double, never a live Sanity.
 // ---------------------------------------------------------------------------
 
-/** Read every managed document (with onChainStatus + sync marker) for the sync. */
+/**
+ * Read every managed document (with onChainStatus + sync marker) for the sync.
+ * Pinned to the `published` perspective: with a token and no perspective the
+ * client reads raw, returning `drafts.*` documents too. Those would inflate the
+ * blast-radius denominator and — since a draft `_id` (`drafts.course-x`) is
+ * absent from the projected tree — be pruned on every sync, silently deleting an
+ * editor's in-progress draft. Published-only keeps the sync operating solely on
+ * the published dataset it owns.
+ */
 export async function readManagedDocuments(): Promise<SanityDoc[]> {
   const query = `*[_type in $types]{ ..., onChainStatus, sync }`;
-  return sanityAdmin.fetch<SanityDoc[]>(query, { types: [...MANAGED_TYPES] });
+  return sanityAdmin.fetch<SanityDoc[]>(
+    query,
+    { types: [...MANAGED_TYPES] },
+    { perspective: "published" }
+  );
 }
 
-/** createOrReplace a batch of documents in one transaction. */
+/**
+ * createOrReplace a batch of documents in one transaction. Committed with
+ * `visibility:"sync"` so the write is query-visible before the call resolves —
+ * the sync's downstream steps (and any re-sync) get read-your-writes and never
+ * race an async-propagating write.
+ */
 export async function writeDocuments(docs: SanityDoc[]): Promise<void> {
   if (docs.length === 0) return;
   let tx = sanityAdmin.transaction();
   for (const doc of docs) {
     tx = tx.createOrReplace(doc as unknown as { _id: string; _type: string });
   }
-  await tx.commit({ visibility: "async" });
+  await tx.commit({ visibility: "sync" });
 }
 
-/** Delete a batch of documents by id in one transaction (post write-verify). */
+/** Delete a batch of documents by id in one transaction (post-prune). */
 export async function deleteDocuments(ids: string[]): Promise<void> {
   if (ids.length === 0) return;
   let tx = sanityAdmin.transaction();
   for (const id of ids) tx = tx.delete(id);
-  await tx.commit({ visibility: "async" });
+  await tx.commit({ visibility: "sync" });
 }
 
 /** Write the contentSync singleton LAST (spec §9.4 — never matches the prune). */

--- a/apps/web/src/lib/sanity/admin-mutations.ts
+++ b/apps/web/src/lib/sanity/admin-mutations.ts
@@ -2,6 +2,8 @@ import "server-only";
 import { createClient } from "next-sanity";
 import { env } from "@/lib/env";
 import { serverEnv } from "@/lib/env.server";
+import type { SanityDoc } from "@/lib/content-sync/types";
+import { MANAGED_TYPES } from "@/lib/content-sync/types";
 
 const sanityAdmin = createClient({
   projectId: env.NEXT_PUBLIC_SANITY_PROJECT_ID,
@@ -10,6 +12,86 @@ const sanityAdmin = createClient({
   useCdn: false,
   apiVersion: "2024-01-01",
 });
+
+/** The shared server-only write client (spec §10.4 — one SANITY_ADMIN_TOKEN
+ *  client, held only by the sync job and admin-mutations). */
+export function getSanityAdminClient(): typeof sanityAdmin {
+  return sanityAdmin;
+}
+
+// ---------------------------------------------------------------------------
+// CS-9 content sync — batched managed-doc read/write/delete + asset upload.
+// The gateway (lib/content-sync/gateway.ts) is the only caller; each function is
+// a thin wrapper over the shared write client so the orchestrator's guards are
+// unit-tested against an in-memory double, never a live Sanity.
+// ---------------------------------------------------------------------------
+
+/** Read every managed document (with onChainStatus + sync marker) for the sync. */
+export async function readManagedDocuments(): Promise<SanityDoc[]> {
+  const query = `*[_type in $types]{ ..., onChainStatus, sync }`;
+  return sanityAdmin.fetch<SanityDoc[]>(query, { types: [...MANAGED_TYPES] });
+}
+
+/** createOrReplace a batch of documents in one transaction. */
+export async function writeDocuments(docs: SanityDoc[]): Promise<void> {
+  if (docs.length === 0) return;
+  let tx = sanityAdmin.transaction();
+  for (const doc of docs) {
+    tx = tx.createOrReplace(doc as unknown as { _id: string; _type: string });
+  }
+  await tx.commit({ visibility: "async" });
+}
+
+/** Delete a batch of documents by id in one transaction (post write-verify). */
+export async function deleteDocuments(ids: string[]): Promise<void> {
+  if (ids.length === 0) return;
+  let tx = sanityAdmin.transaction();
+  for (const id of ids) tx = tx.delete(id);
+  await tx.commit({ visibility: "async" });
+}
+
+/** Write the contentSync singleton LAST (spec §9.4 — never matches the prune). */
+export async function writeContentSyncSingleton(
+  sha: string,
+  counts: Record<string, number>
+): Promise<void> {
+  await sanityAdmin.createOrReplace({
+    _id: "contentSync",
+    _type: "contentSync",
+    sha,
+    syncedAt: new Date().toISOString(),
+    counts,
+  });
+}
+
+/** Read the contentSync singleton's sha (the last-synced commit), or null. */
+export async function readContentSyncSingleton(): Promise<{
+  sha: string;
+} | null> {
+  const found = await sanityAdmin.fetch<{ sha?: string } | null>(
+    `*[_id == "contentSync"][0]{ sha }`
+  );
+  return found?.sha ? { sha: found.sha } : null;
+}
+
+/** True if an image asset with this content-derived id already exists (§9.6). */
+export async function assetExists(assetId: string): Promise<boolean> {
+  const found = await sanityAdmin.fetch<string | null>(`*[_id == $id][0]._id`, {
+    id: assetId,
+  });
+  return found !== null;
+}
+
+/** Upload image bytes; returns the asset _id (content-derived, so idempotent). */
+export async function uploadImageAsset(
+  bytes: Uint8Array,
+  filename: string
+): Promise<string> {
+  const asset = await sanityAdmin.assets.upload("image", Buffer.from(bytes), {
+    filename,
+  });
+  return asset._id;
+}
 
 /**
  * Set the full course membership of a learning path (issue #323). Admin-only —

--- a/apps/web/src/lib/solana/admin-signer.ts
+++ b/apps/web/src/lib/solana/admin-signer.ts
@@ -31,6 +31,10 @@ import {
   getProgramId,
 } from "./pda";
 import { serverEnv } from "@/lib/env.server";
+import {
+  padContentTxId,
+  assertMaskMatchesLockfile,
+} from "@/lib/content-sync/content-commit";
 
 // ---------------------------------------------------------------------------
 // Anchor method builder types — mirrors the pattern in academy-program.ts
@@ -140,6 +144,51 @@ export interface UpdateCourseAdminParams {
    * the current count (LessonCountDecrease).
    */
   newLessonCount?: number;
+  /**
+   * The 32-byte `content_tx_id` commitment (§11.0), built by `buildCourseCommit`
+   * from the synced git SHA. Written via `update_course.new_content_tx_id`.
+   * Omit to leave the field unchanged.
+   */
+  contentTxId?: number[];
+}
+
+interface SlotsLock {
+  version: number;
+  slots: Record<string, number>;
+  retired: number[];
+  next: number;
+}
+
+/**
+ * Build the on-chain content commitment for a course (§11.0): the 32-byte
+ * content_tx_id (git sha left-padded) and the active_lessons mask. The caller
+ * (the chain-sync route, from the admin panel's pending-sync state) supplies the
+ * mask it intends to send; this ALWAYS asserts it equals the mask derived from
+ * the committed slots.lock.json before returning the signable params — the guard
+ * that stops a panel bug setting arbitrary bits, since update_course trusts the
+ * authority blindly. Because the two masks come from independent sources
+ * (panel state vs the committed lockfile), the assertion is a real cross-check,
+ * not a tautology.
+ *
+ * NOTE: `active_lessons` is written on-chain only once program v2 (CS-3) exposes
+ * `update_course.new_active_lessons`. Until then the returned mask is the
+ * asserted invariant carrier; only `content_tx_id` is threaded into the tx.
+ */
+export function buildCourseCommit(input: {
+  courseId: string;
+  contentSha: string;
+  slotsLock: SlotsLock;
+  activeLessons: [bigint, bigint, bigint, bigint];
+}): { contentTxId: number[]; activeLessons: [bigint, bigint, bigint, bigint] } {
+  assertMaskMatchesLockfile(
+    input.courseId,
+    input.activeLessons,
+    input.slotsLock
+  );
+  return {
+    contentTxId: padContentTxId(input.contentSha),
+    activeLessons: input.activeLessons,
+  };
 }
 
 export interface CreateAchievementAdminParams {
@@ -321,7 +370,7 @@ export async function updateCoursePda(
     const [coursePDA] = findCoursePDA(params.courseId, getProgramId());
 
     const onChainParams: UpdateCourseOnChainParams = {
-      newContentTxId: null,
+      newContentTxId: params.contentTxId ?? null,
       newIsActive: params.newIsActive ?? null,
       newXpPerLesson: params.newXpPerLesson ?? null,
       newCreatorRewardXp: params.newCreatorRewardXp ?? null,

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -902,5 +902,37 @@
       "assistMeter": "AI assist usage",
       "diffCard": "Proposed code change"
     }
+  },
+  "adminContentSync": {
+    "description": "Sync the academy-courses repository into Sanity at a specific commit, then commit the content hash on-chain.",
+    "loading": "Loading drift…",
+    "driftUnavailable": "Drift is unavailable — GitHub could not be reached. Check GITHUB_TOKEN and retry.",
+    "retry": "Retry",
+    "state": {
+      "up_to_date": "Sanity is up to date with the repository HEAD.",
+      "behind": "Sanity is behind HEAD — new content is ready to sync.",
+      "never_synced": "Content has never been synced — run the first sync.",
+      "blocked": "HEAD CI is failing — this commit cannot be synced."
+    },
+    "head": "HEAD {sha}",
+    "synced": "Synced {sha}",
+    "ci": "CI {state}",
+    "syncButton": "Sync content",
+    "syncing": "Syncing…",
+    "syncFailed": "Content sync failed.",
+    "syncSucceeded": "Synced: {written} written, {pruned} pruned.",
+    "coursesHeading": "On-chain content drift",
+    "noCourses": "No courses to show.",
+    "chain": {
+      "content_current": "On-chain content matches HEAD.",
+      "content_stale": "On-chain content is stale — commit the new hash.",
+      "not_deployed": "Not deployed on-chain yet.",
+      "missing_fields": "Missing required fields in Sanity.",
+      "awaiting_content_sync": "Waiting for content sync to land first."
+    },
+    "chainSyncButton": "Commit on-chain",
+    "chainSyncing": "Committing…",
+    "chainSyncFailed": "Chain sync failed.",
+    "chainSyncSucceeded": "Committed {id} on-chain."
   }
 }

--- a/apps/web/src/messages/es.json
+++ b/apps/web/src/messages/es.json
@@ -902,5 +902,37 @@
       "assistMeter": "Uso de asistencia de IA",
       "diffCard": "Cambio de código propuesto"
     }
+  },
+  "adminContentSync": {
+    "description": "Sincroniza el repositorio academy-courses en Sanity en un commit específico y registra el hash de contenido on-chain.",
+    "loading": "Cargando divergencia…",
+    "driftUnavailable": "Divergencia no disponible — no se pudo acceder a GitHub. Comprueba GITHUB_TOKEN e inténtalo de nuevo.",
+    "retry": "Reintentar",
+    "state": {
+      "up_to_date": "Sanity está al día con el HEAD del repositorio.",
+      "behind": "Sanity está por detrás del HEAD — hay contenido nuevo listo para sincronizar.",
+      "never_synced": "El contenido nunca se ha sincronizado — ejecuta la primera sincronización.",
+      "blocked": "La CI del HEAD está fallando — este commit no se puede sincronizar."
+    },
+    "head": "HEAD {sha}",
+    "synced": "Sincronizado {sha}",
+    "ci": "CI {state}",
+    "syncButton": "Sincronizar contenido",
+    "syncing": "Sincronizando…",
+    "syncFailed": "Error al sincronizar el contenido.",
+    "syncSucceeded": "Sincronizado: {written} escritos, {pruned} eliminados.",
+    "coursesHeading": "Divergencia de contenido on-chain",
+    "noCourses": "No hay cursos para mostrar.",
+    "chain": {
+      "content_current": "El contenido on-chain coincide con HEAD.",
+      "content_stale": "El contenido on-chain está desactualizado — registra el nuevo hash.",
+      "not_deployed": "Aún no desplegado on-chain.",
+      "missing_fields": "Faltan campos obligatorios en Sanity.",
+      "awaiting_content_sync": "Esperando a que se complete la sincronización de contenido."
+    },
+    "chainSyncButton": "Registrar on-chain",
+    "chainSyncing": "Registrando…",
+    "chainSyncFailed": "Error en la sincronización on-chain.",
+    "chainSyncSucceeded": "{id} registrado on-chain."
   }
 }

--- a/apps/web/src/messages/pt-BR.json
+++ b/apps/web/src/messages/pt-BR.json
@@ -902,5 +902,37 @@
       "assistMeter": "Uso de assistência de IA",
       "diffCard": "Mudança de código proposta"
     }
+  },
+  "adminContentSync": {
+    "description": "Sincronize o repositório academy-courses no Sanity em um commit específico e registre o hash de conteúdo on-chain.",
+    "loading": "Carregando divergência…",
+    "driftUnavailable": "Divergência indisponível — não foi possível acessar o GitHub. Verifique GITHUB_TOKEN e tente novamente.",
+    "retry": "Tentar novamente",
+    "state": {
+      "up_to_date": "O Sanity está atualizado com o HEAD do repositório.",
+      "behind": "O Sanity está atrás do HEAD — há novo conteúdo pronto para sincronizar.",
+      "never_synced": "O conteúdo nunca foi sincronizado — execute a primeira sincronização.",
+      "blocked": "A CI do HEAD está falhando — este commit não pode ser sincronizado."
+    },
+    "head": "HEAD {sha}",
+    "synced": "Sincronizado {sha}",
+    "ci": "CI {state}",
+    "syncButton": "Sincronizar conteúdo",
+    "syncing": "Sincronizando…",
+    "syncFailed": "Falha na sincronização de conteúdo.",
+    "syncSucceeded": "Sincronizado: {written} gravados, {pruned} removidos.",
+    "coursesHeading": "Divergência de conteúdo on-chain",
+    "noCourses": "Nenhum curso para exibir.",
+    "chain": {
+      "content_current": "O conteúdo on-chain corresponde ao HEAD.",
+      "content_stale": "O conteúdo on-chain está desatualizado — registre o novo hash.",
+      "not_deployed": "Ainda não implantado on-chain.",
+      "missing_fields": "Campos obrigatórios ausentes no Sanity.",
+      "awaiting_content_sync": "Aguardando a sincronização de conteúdo primeiro."
+    },
+    "chainSyncButton": "Registrar on-chain",
+    "chainSyncing": "Registrando…",
+    "chainSyncFailed": "Falha na sincronização on-chain.",
+    "chainSyncSucceeded": "{id} registrado on-chain."
   }
 }

--- a/apps/web/vitest.setup.ts
+++ b/apps/web/vitest.setup.ts
@@ -4,6 +4,18 @@
 process.env.NEXT_PUBLIC_PROGRAM_ID ??=
   "7NeJaSRyb4Wxay3Tcd9bdpD7T3GWYUQSFyrhG8SgwE8V";
 
+// Public + server env modules (lib/env.ts, lib/env.server.ts) validate eagerly
+// at import time. Tests that pull a route or a `server-only` module through the
+// module graph need these present so validation passes; `??=` keeps any real or
+// per-test override winning.
+process.env.NEXT_PUBLIC_SUPABASE_URL ??= "https://test.supabase.co";
+process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ??= "test-anon-key";
+process.env.NEXT_PUBLIC_SANITY_PROJECT_ID ??= "testproj";
+process.env.NEXT_PUBLIC_SANITY_DATASET ??= "production";
+process.env.NEXT_PUBLIC_SOLANA_RPC_URL ??= "https://api.devnet.solana.com";
+process.env.SUPABASE_SERVICE_ROLE_KEY ??= "test-service-role-key";
+process.env.SOLANA_RPC_URL ??= "https://api.devnet.solana.com";
+
 // Registers `toBeInTheDocument()`, `toBeDisabled()`, etc. globally for every
 // test file — required by component tests that render real DOM (jsdom) and
 // assert on it (e.g. diff-card.test.tsx).

--- a/docs/ADMIN.md
+++ b/docs/ADMIN.md
@@ -12,12 +12,13 @@ The admin panel is available at `/{locale}/admin` (e.g., `/en/admin`).
 
 ## Required Environment Variables
 
-| Variable                   | Description                                                                                                                                     |
-| -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
-| `ADMIN_SECRET`             | Admin password (min 32 chars, random). Set in `.env.local`.                                                                                     |
-| `PROGRAM_AUTHORITY_SECRET` | Base58 private key of the keypair that is authority on the on-chain `Config` PDA.                                                               |
-| `BACKEND_SIGNER_SECRET`    | Base58 private key of the backend signer registered in `Config.backend_signer`. Used to sign on-chain transactions from API routes.             |
-| `SANITY_ADMIN_TOKEN`       | Sanity write token from [sanity.io/manage](https://sanity.io/manage). Required to sync `onChainStatus` back to Sanity after deploying a course. |
+| Variable                   | Description                                                                                                                                                                                     |
+| -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ADMIN_SECRET`             | Admin password (min 32 chars, random). Set in `.env.local`.                                                                                                                                     |
+| `PROGRAM_AUTHORITY_SECRET` | Base58 private key of the keypair that is authority on the on-chain `Config` PDA.                                                                                                               |
+| `BACKEND_SIGNER_SECRET`    | Base58 private key of the backend signer registered in `Config.backend_signer`. Used to sign on-chain transactions from API routes.                                                             |
+| `SANITY_ADMIN_TOKEN`       | Sanity write token from [sanity.io/manage](https://sanity.io/manage). Required to sync `onChainStatus` back to Sanity after deploying a course.                                                 |
+| `GITHUB_TOKEN`             | Fine-grained **read** token for `solanabr/academy-courses`. Required by the Content Sync panel (tarball fetch, HEAD polling, Checks API). Unset → the `/api/admin/content/*` routes return 503. |
 
 ## Course Sync Workflow
 
@@ -63,6 +64,26 @@ Both routes require `ADMIN_SECRET` in the Authorization header.
 ### Resync On-Chain State
 
 `POST /api/admin/resync` re-reads on-chain state and backfills Supabase mirror tables. Use this to recover from Supabase write failures or sync drift.
+
+### Content Sync (repo → Sanity → devnet)
+
+The **Content Sync** panel ingests the `solanabr/academy-courses` repository into Sanity at a chosen commit and then commits the content hash on-chain. It is **always admin-triggered from the panel — never automatic.**
+
+**Content drift** (repo → Sanity), shown as a banner:
+
+- **up_to_date** — Sanity already matches GitHub HEAD; the Sync button is disabled.
+- **behind** — HEAD has new content; click **Sync content** to `POST /api/admin/content/sync { sha: HEAD }`.
+- **never_synced** — first-run banner; the sync writes the initial projection.
+- **blocked** — HEAD's CI is **red**; the commit is **un-syncable** and the button is disabled (the sync re-validates the whole tree with the CS-2 linter and refuses a failing tree, so a red HEAD is never projected).
+
+The sync is idempotent (re-running at the same SHA is a no-op), PRESERVE-safe (`onChainStatus` survives), and prune-guarded: it deletes only its own `sync.source`-marked docs that are absent from the new tree, and **aborts if the prune set exceeds 20%** of managed docs. A blast-radius abort returns 409 with an override hint — inspect the tree before overriding.
+
+**Chain drift** (Sanity → devnet), shown per course:
+
+- **content_current** — the on-chain `content_tx_id` equals the padded HEAD sha (§11.0).
+- **content_stale** — deployed, but `content_tx_id != HEAD`; commit the new hash.
+- **not_deployed** / **missing_fields** — no PDA yet / Sanity incomplete.
+- **awaiting_content_sync** — the **ordering interlock**: chain sync is disabled until content drift is `up_to_date`, because the mask/commitment cannot be computed from a Sanity that has not ingested the new lesson. The chain-sync action re-asserts the intended `active_lessons` mask against the committed `slots.lock.json` before signing (a mismatch is a 409).
 
 ### Troubleshooting
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -73,15 +73,18 @@ Add all environment variables in **Vercel → Project → Settings → Environme
 
 #### Optional Variables
 
-| Variable                         | Type            | Notes                                                      |
-| -------------------------------- | --------------- | ---------------------------------------------------------- |
-| `RUST_PLAYGROUND_URL`            | **Server-only** | `/api/rust/execute` upstream (default: play.rust-lang.org) |
-| `NEXT_PUBLIC_GA4_MEASUREMENT_ID` | Public          | Google Analytics 4                                         |
-| `NEXT_PUBLIC_POSTHOG_KEY`        | Public          | PostHog project key                                        |
-| `NEXT_PUBLIC_POSTHOG_HOST`       | Public          | PostHog instance URL                                       |
-| `NEXT_PUBLIC_SENTRY_DSN`         | Public          | Sentry error tracking (DSN is safe to expose)              |
+| Variable                         | Type            | Notes                                                                                                                                                                                                                                                                                                                       |
+| -------------------------------- | --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `RUST_PLAYGROUND_URL`            | **Server-only** | `/api/rust/execute` upstream (default: play.rust-lang.org)                                                                                                                                                                                                                                                                  |
+| `GITHUB_TOKEN`                   | **Server-only** | Fine-grained **read** token for `solanabr/academy-courses`. Powers `POST /api/admin/content/sync` (tarball fetch), the drift UI (HEAD polling), and the Checks API (`blocked` state). Unauthenticated GitHub is 60 req/hr per IP and flakes on Vercel's shared egress; unset → the `/api/admin/content/*` routes return 503 |
+| `NEXT_PUBLIC_GA4_MEASUREMENT_ID` | Public          | Google Analytics 4                                                                                                                                                                                                                                                                                                          |
+| `NEXT_PUBLIC_POSTHOG_KEY`        | Public          | PostHog project key                                                                                                                                                                                                                                                                                                         |
+| `NEXT_PUBLIC_POSTHOG_HOST`       | Public          | PostHog instance URL                                                                                                                                                                                                                                                                                                        |
+| `NEXT_PUBLIC_SENTRY_DSN`         | Public          | Sentry error tracking (DSN is safe to expose)                                                                                                                                                                                                                                                                               |
 
 > **Tip**: Variables prefixed with `NEXT_PUBLIC_` are bundled into the client-side JavaScript bundle. All others are server-only and only accessible in API routes and server components.
+
+> **Content sync (CS-9) secrets**: The Sanity dataset is **public** (read path uses no browser token). `SANITY_ADMIN_TOKEN` is held only by the content-sync job and `admin-mutations.ts` — it never belongs in GitHub Actions. `GITHUB_TOKEN` is a read-only token for the `academy-courses` repo, used server-side by the content-sync + drift routes; it carries no write scope.
 
 ### 4. Deploy
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -152,6 +152,9 @@ importers:
       clsx:
         specifier: ^2.1.0
         version: 2.1.1
+      image-size:
+        specifier: ^1.2.1
+        version: 1.2.1
       isomorphic-dompurify:
         specifier: 2.36.0
         version: 2.36.0(@noble/hashes@1.8.0)
@@ -212,6 +215,9 @@ importers:
       tweetnacl:
         specifier: ^1.0.3
         version: 1.0.3
+      yaml:
+        specifier: ^2.8.2
+        version: 2.8.2
       zod:
         specifier: ^4.4.3
         version: 4.4.3


### PR DESCRIPTION
## CS-9 — Content Sync Route + Drift UI (Phase 7 cutover tooling)

**Stacked PR.** Base = `loop/feat-cs5-cs6-app-blocks-09-07-2026` (PR #384), because CS-9 consumes CS-5/CS-6's `blocks[]` Sanity schema + projection. Review/merge #384 first; this diff shows only the CS-9 delta on top of it.

Implements `docs/superpowers/plans/2026-07-09-content-sync-route.md` task-by-task (spec §9 tarball-at-SHA sync, §10 Sanity projection, §11 drift + `content_tx_id` commitment §11.0), plus the two #370-review corrections recorded on #360:
1. `AssetResolver`/`resolveAssetRef` returns a **CDN url string** (not a Sanity asset ref) — implemented and regression-tested.
2. Task 14 (`runContentSync`) carries **no** `MaskMismatchError → 409` branch — that error only arises in `/api/admin/courses/sync` (Task 13). Omitted.

### HARD constraints honored
- **No live writes / no real repo fetch.** Everything is built + unit-tested against fixtures (in-memory tarball builder, `InMemoryGateway`, fake `GitHubClient`, injectable graders). The live RUN stays the human-gated cutover.
- Strict TS, zero `any`. Panel strings via next-intl (`adminContentSync`, added to en / pt-BR / es with identical key structure). Server-only secrets read through `@/lib/env.server`.

### Tasks done (1–16)
| # | Task | Status |
|---|------|--------|
| 1 | Shared types + `GITHUB_TOKEN` env | ✅ |
| 2 | Tarball → `RepoTree` (excl `_template`) | ✅ (+ ustar `prefix`/pax long-path support — see note) |
| 3 | `GitHubClient` (tarball, HEAD, Checks API) | ✅ |
| 4 | Two-sided executor gate (§6.2a) | ✅ |
| 5 | `parseAndValidateTree` — Zod re-validation + gate | ✅ |
| 6 | Projector → `SanityDoc[]` (weak refs, CDN rewrite) | ✅ |
| 7 | Content-derived asset ids, dedupe, md rewrite | ✅ |
| 8 | PRESERVE reattach + field-coverage assert; prune guards | ✅ |
| 9 | `content_tx_id` commit + mask-vs-lockfile assert (§11.0) | ✅ |
| 10 | Three-way drift model | ✅ |
| 11 | `SanityGateway` seam over `admin-mutations` | ✅ |
| 12 | `runContentSync` orchestrator (idempotency, red-CI refusal, blast-radius, real-dims assets) | ✅ |
| 13 | `content_tx_id` + mask wired into chain-sync signer/route | ✅ (mask on-chain write gated on program v2; see note) |
| 14 | `POST /api/admin/content/sync` | ✅ |
| 15 | `GET /api/admin/content/drift` + three-way panel | ✅ |
| 16 | Docs (GITHUB_TOKEN, trigger, drift UI) | ✅ |

### Notes / deviations
- **Program v2 not deployed yet.** The current IDL has `Course.content_tx_id` (writable via `update_course.new_content_tx_id`) but **no** `active_lessons` field. Per the plan's prerequisite note, the pure §11.0 helpers (`buildCourseCommit`, `padContentTxId`, `deriveActiveMask`, `assertMaskMatchesLockfile`) land and are fully tested; the SHA is committed on-chain; the mask **assertion** runs at chain-sync time (MaskMismatchError → 409), but the mask on-chain **write** is gated until program v2 exposes the field.
- **Real GitHub tarball hardening.** The plan's `extractTarball` only read the 100-byte tar `name` field; real repo paths under the generated `owner-repo-<40-char-sha>/` top dir routinely exceed 100 bytes, so `git archive` splits them across the ustar `prefix` field (and pax `x` headers). Left as-is this would silently drop deep files at cutover. `extractTarball` now reconstructs from `prefix` + pax, with a dedicated long-path round-trip test.
- Chain-sync mask assertion is wired **additively** into `/api/admin/courses/sync`: only active when the request carries `activeLessons`; absent → the existing route behaves exactly as before (backward compatible).
- `vitest.setup.ts` gained safe (`??=`) test-env defaults so server/public env modules validate under vitest (same pattern the file already used for `NEXT_PUBLIC_PROGRAM_ID`).

### Verification (pasted)
```
pnpm --filter web typecheck   → exit 0
pnpm --filter web test        → 47 files, 331 tests passed
  content-sync suite: 82 tests across 16 files
```
Load-bearing outcomes, each proven by a named test:
- **PRESERVE + prune** — `prune.test.ts` "NEVER selects an unmarked doc"; `preserve.test.ts` carries `onChainStatus` across a re-sync + field-coverage assert; `sync.test.ts` "aborts before any delete when the prune set exceeds 20%" (nothing deleted), "prunes a small stale set and reports the count".
- **Idempotency** — `sync.test.ts` "second run at the same sha writes and deletes nothing".
- **Refuse-on-red-validation** — `drift.test.ts` `assertCommitSyncable` throws on failure/pending; `sync.test.ts` "refuses to sync a commit whose CI is red" (nothing written).
- **content_tx_id stamping** — `content-commit.test.ts` (20→32 pad, HEAD equality); `signer-commit.test.ts` packs the sha into 32 bytes.
- **mask-vs-lock PASS and FAIL** — `content-commit.test.ts` `assertMaskMatchesLockfile` passes on a matching mask, throws `MaskMismatchError` on an arbitrary bit; `signer-commit.test.ts` throws (naming the course) when the caller's mask disagrees with the lockfile.

### Open question
Program v2 (`Course.active_lessons` + `update_course.new_active_lessons`, CS-3) is the one remaining prerequisite before the mask can actually be written on-chain at cutover — everything else (assertion, SHA commitment, drift, panel) is live and tested.

Closes #360
