### PR TITLE
feat(sync): point content sync at solanabr/courses-academy

### DIFF
--- a/apps/web/src/app/api/admin/content/sync/route.ts
+++ b/apps/web/src/app/api/admin/content/sync/route.ts
@@ -18,7 +18,7 @@ import {
 } from "@/lib/content-sync/types";
 
 /**
- * POST /api/admin/content/sync — sync academy-courses@sha → Sanity (§9.2).
+ * POST /api/admin/content/sync — sync courses-academy@sha → Sanity (§9.2).
  *
  * Thin handler: auth, parse+guard the body, build the real deps, delegate to
  * `runContentSync`, map its error classes to status codes. The client sends the

--- a/apps/web/src/lib/content-sync/__tests__/_fixtures.ts
+++ b/apps/web/src/lib/content-sync/__tests__/_fixtures.ts
@@ -114,7 +114,7 @@ export function makeCourseTarball(
   sha: string,
   opts: { withImage?: boolean } = {}
 ): Uint8Array {
-  const top = `solanabr-academy-courses-${sha}`;
+  const top = `solanabr-courses-academy-${sha}`;
   const lessonDir = `${top}/courses/demo/lessons/accounts`;
   const intro = opts.withImage
     ? "# Accounts\n\nSee ![pixel](assets/pixel.png) here.\n"

--- a/apps/web/src/lib/content-sync/__tests__/github.test.ts
+++ b/apps/web/src/lib/content-sync/__tests__/github.test.ts
@@ -25,7 +25,7 @@ describe("GitHubClient", () => {
     expect(Array.from(bytes)).toEqual([1, 2, 3]);
     const [url, init] = fetchImpl.mock.calls[0]!;
     expect(url).toBe(
-      "https://api.github.com/repos/solanabr/academy-courses/tarball/abc123"
+      "https://api.github.com/repos/solanabr/courses-academy/tarball/abc123"
     );
     expect(init?.headers).toMatchObject({
       Authorization: "Bearer ghp_x",

--- a/apps/web/src/lib/content-sync/__tests__/preserve.test.ts
+++ b/apps/web/src/lib/content-sync/__tests__/preserve.test.ts
@@ -13,7 +13,7 @@ describe("reattachPreserved", () => {
       _id: "course-x",
       _type: "course",
       title: "X",
-      sync: { source: "academy-courses", rev: "s" },
+      sync: { source: "courses-academy", rev: "s" },
     };
     const existing: SanityDoc = {
       _id: "course-x",

--- a/apps/web/src/lib/content-sync/__tests__/projector.test.ts
+++ b/apps/web/src/lib/content-sync/__tests__/projector.test.ts
@@ -73,7 +73,7 @@ describe("projectContent", () => {
   it("stamps the sync marker with the sha on every managed doc", () => {
     const { docs } = projectContent(fixture(), "sha1", noAsset, () => []);
     for (const d of docs) {
-      expect(d.sync).toEqual({ source: "academy-courses", rev: "sha1" });
+      expect(d.sync).toEqual({ source: "courses-academy", rev: "sha1" });
     }
   });
 

--- a/apps/web/src/lib/content-sync/__tests__/prune.test.ts
+++ b/apps/web/src/lib/content-sync/__tests__/prune.test.ts
@@ -13,7 +13,7 @@ const doc = (id: string, extra: Partial<SanityDoc> = {}): SanityDoc => ({
   ...extra,
 });
 const marked = (id: string, rev: string): SanityDoc =>
-  doc(id, { sync: { source: "academy-courses", rev } });
+  doc(id, { sync: { source: "courses-academy", rev } });
 
 describe("selectPrunable", () => {
   it("selects marked docs absent from the projected tree (by id, not rev)", () => {
@@ -70,14 +70,14 @@ describe("selectChangedDocs (idempotency)", () => {
       marked("a", "s1"),
       doc("b", {
         title: "old",
-        sync: { source: "academy-courses", rev: "s1" },
+        sync: { source: "courses-academy", rev: "s1" },
       }),
     ];
     const projected = [
       marked("a", "s1"),
       doc("b", {
         title: "new",
-        sync: { source: "academy-courses", rev: "s2" },
+        sync: { source: "courses-academy", rev: "s2" },
       }),
     ];
     expect(selectChangedDocs(existing, projected).map((d) => d._id)).toEqual([
@@ -90,14 +90,14 @@ describe("selectChangedDocs (idempotency)", () => {
       doc("a", {
         _type: "course",
         onChainStatus: { pda: "X" },
-        sync: { source: "academy-courses", rev: "s1" },
+        sync: { source: "courses-academy", rev: "s1" },
       }),
     ];
     const projected = [
       doc("a", {
         _type: "course",
         onChainStatus: { pda: "X" },
-        sync: { source: "academy-courses", rev: "s1" },
+        sync: { source: "courses-academy", rev: "s1" },
       }),
     ];
     expect(selectChangedDocs(existing, projected)).toEqual([]);
@@ -107,7 +107,7 @@ describe("selectChangedDocs (idempotency)", () => {
 describe("prunableQuery", () => {
   it("is marker-scoped and sha-parameterised", () => {
     expect(prunableQuery()).toBe(
-      '*[sync.source == "academy-courses" && sync.rev != $sha]._id'
+      '*[sync.source == "courses-academy" && sync.rev != $sha]._id'
     );
   });
 });

--- a/apps/web/src/lib/content-sync/__tests__/sync.test.ts
+++ b/apps/web/src/lib/content-sync/__tests__/sync.test.ts
@@ -20,7 +20,7 @@ const handAuthored = (n: number): SanityDoc[] =>
 const managedMarked = (id: string, type: string, rev: string): SanityDoc => ({
   _id: id,
   _type: type,
-  sync: { source: "academy-courses", rev },
+  sync: { source: "courses-academy", rev },
 });
 
 /**
@@ -145,7 +145,7 @@ describe("runContentSync", () => {
     const stale: SanityDoc[] = Array.from({ length: 50 }, (_v, i) => ({
       _id: `lesson-old-${i}`,
       _type: "lesson",
-      sync: { source: "academy-courses", rev: "oldsha" },
+      sync: { source: "courses-academy", rev: "oldsha" },
     }));
     const gw = new InMemoryGateway(stale);
     await expect(runContentSync(deps({ gateway: gw }))).rejects.toBeInstanceOf(

--- a/apps/web/src/lib/content-sync/__tests__/tarball.test.ts
+++ b/apps/web/src/lib/content-sync/__tests__/tarball.test.ts
@@ -6,9 +6,9 @@ import { makeTar } from "./_fixtures";
 describe("extractTarball", () => {
   it("strips the generated top dir and keys by repo-relative path", async () => {
     const tar = makeTar({
-      "solanabr-academy-courses-abc123/courses/solana-fundamentals/course.yaml":
+      "solanabr-courses-academy-abc123/courses/solana-fundamentals/course.yaml":
         "id: course-solana-fundamentals\n",
-      "solanabr-academy-courses-abc123/courses/solana-fundamentals/lessons/accounts/intro.md":
+      "solanabr-courses-academy-abc123/courses/solana-fundamentals/lessons/accounts/intro.md":
         "# Accounts\n",
     });
     const tree = await extractTarball(gzipSync(Buffer.from(tar)));
@@ -36,7 +36,7 @@ describe("extractTarball", () => {
     // The generated `owner-repo-<40-char-sha>/` top dir alone is 65 bytes, so any
     // real repo path overflows the 100-byte name field; git archive splits it
     // across name + prefix. A naive reader that ignores prefix would drop this.
-    const top = `solanabr-academy-courses-${"a".repeat(40)}`;
+    const top = `solanabr-courses-academy-${"a".repeat(40)}`;
     const deep = `${top}/courses/solana-fundamentals/lessons/pdas-and-accounts/exercise/solution.ts`;
     expect(deep.length).toBeGreaterThan(100);
     const tar = makeTar({ [deep]: "// solution\n" });

--- a/apps/web/src/lib/content-sync/github.ts
+++ b/apps/web/src/lib/content-sync/github.ts
@@ -2,7 +2,7 @@ import "server-only";
 import { type ChecksState, GitHubUnavailableError } from "./types";
 import { serverEnv } from "@/lib/env.server";
 
-const REPO = "solanabr/academy-courses";
+const REPO = "solanabr/courses-academy";
 const BRANCH = "main";
 const API = "https://api.github.com";
 

--- a/apps/web/src/lib/content-sync/projector.ts
+++ b/apps/web/src/lib/content-sync/projector.ts
@@ -2,6 +2,7 @@ import type { BlockT } from "@superteam-lms/content-schema";
 import type { ValidatedContent } from "./validate";
 import type { SanityDoc } from "./types";
 import { rewriteMarkdownAssetPaths } from "./assets";
+import { SOURCE } from "./prune";
 
 export interface AssetUpload {
   path: string; // repo-relative image path
@@ -85,7 +86,7 @@ export function projectContent(
   resolveAsset: AssetResolver,
   resolveTests: TestsResolver
 ): { docs: SanityDoc[]; assets: AssetUpload[] } {
-  const marker = { source: "academy-courses", rev: sha } as const;
+  const marker = { source: SOURCE, rev: sha } as const;
   const docs: SanityDoc[] = [];
   const assets: AssetUpload[] = [...v.assets.entries()].map(
     ([path, bytes]) => ({

--- a/apps/web/src/lib/content-sync/prune.ts
+++ b/apps/web/src/lib/content-sync/prune.ts
@@ -1,10 +1,10 @@
 import { BlastRadiusError, type SanityDoc } from "./types";
 
-const SOURCE = "academy-courses";
+export const SOURCE = "courses-academy";
 
 /** GROQ that selects prunable ids: our marker, a stale rev. Parameterised by $sha. */
 export function prunableQuery(): string {
-  return '*[sync.source == "academy-courses" && sync.rev != $sha]._id';
+  return `*[sync.source == "${SOURCE}" && sync.rev != $sha]._id`;
 }
 
 /**

--- a/apps/web/src/lib/content-sync/tarball.ts
+++ b/apps/web/src/lib/content-sync/tarball.ts
@@ -7,7 +7,7 @@ const EXCLUDED = "courses/_template/";
 /**
  * Decompression bounds against a malicious/corrupt tarball (a gzip bomb inflates
  * to gigabytes; a pathological archive packs millions of tiny headers). The
- * academy-courses repo is text + optimised images — well under these — so the
+ * courses-academy repo is text + optimised images — well under these — so the
  * caps only ever fire on abuse. Both are overridable for tests.
  */
 const DEFAULT_MAX_DECOMPRESSED_BYTES = 128 * 1024 * 1024; // 128 MiB

--- a/apps/web/src/lib/env.server.ts
+++ b/apps/web/src/lib/env.server.ts
@@ -31,7 +31,7 @@ const serverEnvSchema = z.object({
   SOLANA_RPC_URL: z.url(),
   // Optional: only needed for admin Sanity writes.
   SANITY_ADMIN_TOKEN: optStr,
-  // Fine-grained READ token for solanabr/academy-courses. Server-only. Needed by
+  // Fine-grained READ token for solanabr/courses-academy. Server-only. Needed by
   // POST /api/admin/content/sync (tarball fetch), the drift UI (HEAD polling),
   // and the Checks API (blocked state). Optional at boot; the content routes 503
   // when unset. Unauthenticated GitHub is 60 req/hr per IP and flakes on Vercel.


### PR DESCRIPTION
The content source-of-truth repo is **solanabr/courses-academy** (the owner has write there; the earlier `academy-courses` was read-only, blocking the push).

- `content-sync/github.ts`: `REPO` → `solanabr/courses-academy` (tarball/commit/checks fetch).
- `content-sync/prune.ts`: `SOURCE` is now an **exported const** (`"courses-academy"`) and `prunableQuery()` uses it — `projector.ts` imports the same const for the written `sync.source` marker, so writes and the prune query can never drift.
- `tarball.ts` strips the tarball top-dir dynamically (name-agnostic) — only its comment changed.
- Updated all fixtures/tests/comments (`solanabr-academy-courses-<sha>` → `solanabr-courses-academy-<sha>`).

typecheck clean; 351 content-sync + web tests green. Must merge before running the CS-9 sync so it fetches from the right repo. Refs #360.