### PR TITLE
fix(content-schema): regenerate lesson.schema.json + assert JSON/Zod parity

### DIFF
--- a/packages/content-schema/schema/lesson.schema.json
+++ b/packages/content-schema/schema/lesson.schema.json
@@ -329,10 +329,7 @@
               },
               "produces": {
                 "type": "string",
-                "enum": [
-                  "funded-wallet",
-                  "deployed-program"
-                ]
+                "const": "funded-wallet"
               },
               "consumes": {
                 "minItems": 1,
@@ -374,11 +371,7 @@
                 "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
               },
               "produces": {
-                "type": "string",
-                "enum": [
-                  "funded-wallet",
-                  "deployed-program"
-                ]
+                "not": {}
               },
               "consumes": {
                 "minItems": 1,
@@ -413,11 +406,7 @@
                 "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
               },
               "produces": {
-                "type": "string",
-                "enum": [
-                  "funded-wallet",
-                  "deployed-program"
-                ]
+                "not": {}
               },
               "consumes": {
                 "minItems": 1,

--- a/packages/content-schema/src/__tests__/json-schema.test.ts
+++ b/packages/content-schema/src/__tests__/json-schema.test.ts
@@ -1,6 +1,16 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
 import { describe, it, expect } from "vitest";
 import { z } from "zod";
 import { SCHEMA_TARGETS } from "../../scripts/generate-json-schema";
+
+/** `schema/` as written by `pnpm schema:generate`. */
+const SCHEMA_DIR = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "../../schema"
+);
 
 describe("JSON Schema generation", () => {
   it("covers every authored file type", () => {
@@ -35,4 +45,26 @@ describe("JSON Schema generation", () => {
     expect(json).toContain('"prose"');
     expect(json).toContain('"deployed-program-card"');
   });
+
+  // The committed `schema/*.json` are copied verbatim into the content repo,
+  // where editors and `validate-content.yml` enforce them. If they drift from
+  // the Zod source, a contributor's PR goes green there and then fails the Zod
+  // gate at sync time. This caught #386's `produces` amendment, which amended
+  // the Zod blocks without regenerating `lesson.schema.json`.
+  it.each(Object.keys(SCHEMA_TARGETS))(
+    "schema/%s.schema.json is byte-identical to the generated schema",
+    (name) => {
+      const target = SCHEMA_TARGETS[name as keyof typeof SCHEMA_TARGETS];
+      const generated =
+        JSON.stringify(z.toJSONSchema(target, { io: "input" }), null, 2) + "\n";
+      const committed = readFileSync(
+        join(SCHEMA_DIR, `${name}.schema.json`),
+        "utf8"
+      );
+      expect(
+        committed,
+        `schema/${name}.schema.json is stale — run \`pnpm --filter @superteam-lms/content-schema schema:generate\` and commit the result`
+      ).toBe(generated);
+    }
+  );
 });


### PR DESCRIPTION
## What

`packages/content-schema/schema/lesson.schema.json` has been **stale since #386**.

| | last touched by |
|---|---|
| `schema/lesson.schema.json` | `0bedf5d` — CS-1 (#364) |
| `src/blocks/` (the Zod source) | `ae5aa4f` — per-block-type `produces` constraints (#386) |

#386 amended the Zod blocks but never regenerated the JSON schema. Regenerating yields:

```
wallet-funding         produces: enum[funded-wallet, deployed-program] -> const "funded-wallet"
program-explorer       produces: enum[...]                             -> never  (not: {})
deployed-program-card  produces: enum[...]                             -> never  (not: {})
```

(`widgets.ts:15` is `z.literal("funded-wallet").optional()`; `:25` and `:38` are `z.never().optional()`.)

## Why it matters

These files are copied **verbatim** into `solanabr/courses-academy`, where editors (`.vscode` `yaml.schemas`) and `validate-content.yml` enforce them. With the stale schema a contributor can declare `produces: deployed-program` on a `wallet-funding` block, get a green PR, and then fail the Zod gate at sync time. Repo CI and the real gate disagreed.

## Why CI never caught it

`json-schema.test.ts` asserted only the **key names** of `SCHEMA_TARGETS` and that each generated schema has a `$schema`. It never read the committed files.

## The fix

- Regenerate `lesson.schema.json` (the other 7 were already current).
- Add a byte-parity test over **every** committed schema. Its failure message names the regen command.

## Verification

- Falsified: restoring the stale `lesson.schema.json` makes exactly **1** test fail with `schema/lesson.schema.json is stale — run \`pnpm --filter @superteam-lms/content-schema schema:generate\``; regenerating returns **105/105 green**.
- `pnpm --filter @superteam-lms/content-schema typecheck` — exit 0.
- `pnpm --filter @superteam-lms/content-lint test` — 32/32 green (unaffected).

Refs #359