### PR TITLE
fix(content-sync): defer rust/buildable at sync, matching CI gate 6

### DIFF
--- a/apps/web/src/lib/content-sync/__tests__/validate.test.ts
+++ b/apps/web/src/lib/content-sync/__tests__/validate.test.ts
@@ -149,4 +149,32 @@ describe("parseAndValidateTree", () => {
       expect(v.lessons.map((l) => l.lesson.id)).toContain("lesson-ex");
     }
   );
+
+  it("still requires the files of a DEFERRED (rust) block to exist", async () => {
+    const withCode = stringify({
+      id: "lesson-ex",
+      slug: "ex",
+      title: "Ex",
+      blocks: [
+        {
+          key: "ex",
+          type: "code",
+          language: "rust",
+          starter: "exercise/starter.rs",
+          solution: "exercise/solution.rs",
+          tests: "exercise/tests.json",
+        },
+      ],
+    });
+    const t = tree({
+      "courses/demo/course.yaml": courseYaml,
+      "courses/demo/lessons/ex/lesson.yaml": withCode,
+      // solution.rs + tests.json deliberately absent — deferral skips GRADING,
+      // not the file-existence check.
+      "courses/demo/lessons/ex/exercise/starter.rs": "// stub",
+    });
+    await expect(parseAndValidateTree(t, passGraders)).rejects.toBeInstanceOf(
+      ContentValidationError
+    );
+  });
 });

--- a/apps/web/src/lib/content-sync/__tests__/validate.test.ts
+++ b/apps/web/src/lib/content-sync/__tests__/validate.test.ts
@@ -102,4 +102,51 @@ describe("parseAndValidateTree", () => {
       ContentValidationError
     );
   });
+
+  // Parity with content-lint gate 6 (gate6-executor.ts): rust and buildable
+  // blocks are DEFERRED at sync time, not graded. A buildable scaffold that
+  // compiles would "pass" the starter-must-fail check (the grader grades on
+  // compilation), and the build server is off in prod — so grading them here
+  // rejected content that CI accepts. The sync now grades exactly what CI grades.
+  it.each([
+    { language: "rust", buildType: "standard" },
+    { language: "rust", buildType: "buildable" },
+  ])(
+    "defers a $language/$buildType block even when its starter would pass",
+    async ({ language, buildType }) => {
+      const withCode = stringify({
+        id: "lesson-ex",
+        slug: "ex",
+        title: "Ex",
+        blocks: [
+          {
+            key: "ex",
+            type: "code",
+            language,
+            buildType,
+            deployable: buildType === "buildable",
+            starter: "exercise/starter.rs",
+            solution: "exercise/solution.rs",
+            tests: "exercise/tests.json",
+            ...(buildType === "buildable"
+              ? { produces: "deployed-program" }
+              : {}),
+          },
+        ],
+      });
+      const t = tree({
+        "courses/demo/course.yaml": courseYaml,
+        "courses/demo/lessons/ex/lesson.yaml": withCode,
+        // Both "solve" → both would PASS → starter-already-passes would throw
+        // if this block were graded. Deferral means it is not.
+        "courses/demo/lessons/ex/exercise/starter.rs": "// solve",
+        "courses/demo/lessons/ex/exercise/solution.rs": "// solve",
+        "courses/demo/lessons/ex/exercise/tests.json": JSON.stringify([
+          { id: "t", description: "d", input: "", expectedOutput: "1" },
+        ]),
+      });
+      const v = await parseAndValidateTree(t, passGraders);
+      expect(v.lessons.map((l) => l.lesson.id)).toContain("lesson-ex");
+    }
+  );
 });

--- a/apps/web/src/lib/content-sync/validate.ts
+++ b/apps/web/src/lib/content-sync/validate.ts
@@ -103,18 +103,17 @@ export async function parseAndValidateTree(
     }
   }
 
-  // Executor gate on TS-standard code blocks only, in lockstep with content-lint
-  // gate 6 (gate6-executor.ts): rust and buildable blocks are DEFERRED. Grading
-  // them here rejected content that CI accepts — the build server is off in prod,
-  // and the two-sided "starter must fail" rule is incoherent for compile-graded
-  // buildable blocks (a `todo!()` scaffold compiles, so its starter "passes").
-  // Runtime grading is unchanged and stays fail-closed per block.
+  // Every code block must have its files present — checked for ALL languages so a
+  // broken lesson can't publish silently. The two-sided EXECUTOR gate then runs on
+  // TS-standard blocks only, in lockstep with content-lint gate 6
+  // (gate6-executor.ts): rust and buildable are DEFERRED. Grading them here
+  // rejected content that CI accepts — the build server is off in prod, and the
+  // "starter must fail" rule is incoherent for compile-graded buildable blocks (a
+  // `todo!()` scaffold compiles, so its starter "passes"). Runtime grading is
+  // unchanged and stays fail-closed per block.
   for (const { dir, lesson } of v.lessons) {
     for (const block of lesson.blocks) {
       if (block.type !== "code") continue;
-      if (block.language !== "typescript" || block.buildType === "buildable") {
-        continue; // deferred to runtime grading, exactly as CI gate 6 defers it
-      }
       const starter = v.code.get(`${dir}/${block.starter}`);
       const solution = v.code.get(`${dir}/${block.solution}`);
       const testsRaw = tree.get(`${dir}/${block.tests}`);
@@ -123,6 +122,9 @@ export async function parseAndValidateTree(
           `lesson ${lesson.id} block ${block.key}: missing starter/solution/tests file`
         );
         continue;
+      }
+      if (block.language !== "typescript" || block.buildType === "buildable") {
+        continue; // grading deferred to runtime, exactly as CI gate 6 defers it
       }
       const tests = JSON.parse(text(testsRaw)) as unknown[];
       const blockIssues = await gateCodeBlock(

--- a/apps/web/src/lib/content-sync/validate.ts
+++ b/apps/web/src/lib/content-sync/validate.ts
@@ -103,10 +103,18 @@ export async function parseAndValidateTree(
     }
   }
 
-  // Executor gate on every code block, resolving its files from the tree.
+  // Executor gate on TS-standard code blocks only, in lockstep with content-lint
+  // gate 6 (gate6-executor.ts): rust and buildable blocks are DEFERRED. Grading
+  // them here rejected content that CI accepts — the build server is off in prod,
+  // and the two-sided "starter must fail" rule is incoherent for compile-graded
+  // buildable blocks (a `todo!()` scaffold compiles, so its starter "passes").
+  // Runtime grading is unchanged and stays fail-closed per block.
   for (const { dir, lesson } of v.lessons) {
     for (const block of lesson.blocks) {
       if (block.type !== "code") continue;
+      if (block.language !== "typescript" || block.buildType === "buildable") {
+        continue; // deferred to runtime grading, exactly as CI gate 6 defers it
+      }
       const starter = v.code.get(`${dir}/${block.starter}`);
       const solution = v.code.get(`${dir}/${block.solution}`);
       const testsRaw = tree.get(`${dir}/${block.tests}`);


### PR DESCRIPTION
> ⚠️ **SENSITIVE** — content-sync validation (the trust boundary for what reaches prod Sanity). Adversarially reviewed; please sign off before merge.

## The bug (found while running the CS-9 sync)

The prod sync returned **HTTP 422** with 8 issues — 6× *"starter already passes"* and 2× *"solution … executor_unavailable"* — on content that content-lint passed with **0 errors** in CI. This is why prod has never been synced to `blocks[]`.

## Root cause

The two gates have different scope:
- **content-lint gate 6** (`gate6-executor.ts:117`) grades only `typescript && !buildable`; rust/buildable are a deferred **notice**.
- **content-sync** (`validate.ts:108`) graded **every** code block.

So the sync enforced exactly what CI defers. And the enforcement is *incoherent* for buildable: the buildable grader grades on **compilation**, and a good scaffold starter (`todo!()`) compiles — so it "passes" the two-sided *starter-must-fail* check → the 6 "starter already passes". The other 2 are the build server being **deliberately off in prod** → "executor_unavailable". All 8 failures were buildable; the rust `todo!()` starters correctly fail, and the 16 TS-standard blocks all passed.

No content fix makes a compiling scaffold fail a compile check. The gates simply must agree.

## The fix

content-sync now grades exactly what CI grades — **TS-standard only**; rust and buildable are deferred to runtime grading, which is unchanged and stays **fail-closed per block** (a learner can't complete a rust/buildable challenge until its executor is available). 6 lines in `validate.ts`, mirroring `gate6Check`.

## Tradeoff (approved by the owner)

The sync no longer verifies rust/buildable reference solutions — but **CI never did either**, and runtime grading is unchanged. This also stops every future rust/buildable teacher PR from hitting the same wall.

## Verification

- New parity tests: a rust/standard and a rust/buildable block whose starter *would* pass are now **deferred** (no throw); a TS block with a bad solution **still throws**. Confirmed failing before the fix, passing after.
- content-sync suite 86/86; full web suite **353/353**; `tsc` clean; prettier clean.
- Matches the real prod failure: deferring rust/buildable leaves only the 16 TS-standard blocks, which had **0 failures** in that run — so this fully unblocks the sync.

Refs #359