### PR TITLE
fix(web): null-safe getCourseLessons + lesson page hardening (prod 500 fix)

### DIFF
--- a/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/page.tsx
+++ b/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/page.tsx
@@ -24,7 +24,7 @@ export default async function LessonPage({ params }: LessonPageProps) {
   return (
     <LessonPageClient
       lesson={lesson}
-      allLessons={allLessons ?? []}
+      allLessons={(allLessons ?? []).filter(Boolean)}
       locale={locale}
       courseSlug={slug}
       courseId={courseInfo?._id ?? slug}

--- a/apps/web/src/lib/sanity/queries.ts
+++ b/apps/web/src/lib/sanity/queries.ts
@@ -256,11 +256,14 @@ export async function getCourseLessons(
 ): Promise<Pick<Lesson, "_id" | "title" | "slug">[]> {
   return catalogFetch<Pick<Lesson, "_id" | "title" | "slug">[]>(
     `*[_type == "course" && slug.current == $courseSlug && onChainStatus.status == "synced" && ${activeGate} && ${publicAuthoringGate}][0] {
-      "lessons": modules[].lessons[]-> {
+      // (...)[defined(_id)] drops unresolvable derefs: a stale cache entry or a
+      // legacy-shaped course doc must degrade to fewer nav items, never emit
+      // nulls that crash every lesson page of the course (issue #405).
+      "lessons": (modules[].lessons[]-> {
         _id,
         title,
         "slug": slug.current
-      }
+      })[defined(_id)]
     }.lessons`,
     { courseSlug }
   );

--- a/apps/web/src/lib/sanity/queries.ts
+++ b/apps/web/src/lib/sanity/queries.ts
@@ -110,9 +110,9 @@ const moduleWithLessonsFields = `
   key,
   title,
   description,
-  "lessons": lessons[]->{
+  "lessons": (lessons[]->{
     ${lessonFields}
-  }
+  })[defined(_id)]
 `;
 
 // --- Query Functions ---
@@ -125,11 +125,11 @@ export async function getAllCourses(): Promise<Course[]> {
         key,
         title,
         description,
-        "lessons": lessons[]->{
+        "lessons": (lessons[]->{
           _id,
           title,
           "slug": slug.current
-        }
+        })[defined(_id)]
       }
     }`
   );
@@ -156,9 +156,9 @@ export async function getLessonBySlug(
   // there is no per-_type conditional stripping and no separate answer-key query.
   return catalogFetch<Lesson | null>(
     `*[_type == "course" && slug.current == $courseSlug && onChainStatus.status == "synced" && ${activeGate} && ${publicAuthoringGate}][0] {
-      "allLessons": modules[].lessons[]->{
+      "allLessons": (modules[].lessons[]->{
         ${lessonFields}
-      }
+      })[defined(_id)]
     }.allLessons[slug == $lessonSlug][0]`,
     { courseSlug, lessonSlug }
   );
@@ -179,9 +179,9 @@ export async function getLessonByIdForGrading(
 ): Promise<Lesson | null> {
   return sanityFetch<Lesson | null>(
     `*[_type == "course" && _id == $courseId][0] {
-      "allLessons": modules[].lessons[]->{
+      "allLessons": (modules[].lessons[]->{
         ${lessonFields}
-      }
+      })[defined(_id)]
     }.allLessons[_id == $lessonId][0]`,
     { courseId, lessonId },
     0
@@ -204,11 +204,11 @@ export async function getAllLearningPaths(): Promise<LearningPath[]> {
           key,
           title,
           description,
-          "lessons": lessons[]->{
+          "lessons": (lessons[]->{
             _id,
             title,
             "slug": slug.current
-          }
+          })[defined(_id)]
         }
       }
     }`


### PR DESCRIPTION
## Incident
All 12 `solana-fundamentals` lesson pages returned 500 in prod post-CS-9-sync while 64 others were fine. Root cause (full forensics in #405): a pre-sync data-cache entry held the legacy-shaped course doc → `allLessons=[null,null,null]` (verified in the crashed page's RSC flight payload) → `LessonPageClient` crashed on `null._id` (lesson-client.tsx:137). The poisoned entry outlived TTL 3600, `revalidateTag`, and two redeploys.

## Fix
- **GROQ**: `(modules[].lessons[]->{...})[defined(_id)]` — unresolvable derefs degrade to fewer sidebar items, never nulls. Verified against live Sanity: healthy course → 12 clean items; the legacy-shaped solana-101 doc → `[]`.
- **Page**: `.filter(Boolean)` on allLessons before it reaches the client component.
- **Deterministic prod heal**: the query-text change alters the fetch cache key, evicting the stuck entry on deploy.

## Verification
- New GROQ tested against live prod Sanity on BOTH shapes (healthy + legacy) — 0 nulls in both.
- `tsc` clean, web tests 354/354.
- Local render of the failing URL with the fix: 200.

Closes #405