### PR TITLE
docs(specs): SP1 — retire teacher-authoring era (design)

### DIFF
--- a/docs/superpowers/plans/2026-07-10-sp1-retire-teacher-authoring.md
+++ b/docs/superpowers/plans/2026-07-10-sp1-retire-teacher-authoring.md
@@ -1,0 +1,191 @@
+# SP1 — Retire Teacher-Authoring Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Delete every UI-authoring-era surface (teacher CRUD, role machinery, 4 obsolete admin panels) and replace /teach with a read-only wallet-keyed analytics viewer.
+
+**Architecture:** Two staged PRs. PR-1 "cut the writers" removes all write paths (admin panels, teacher API routes, teacher libs) and ships the human-gated role-drop migration + orphan purge script. PR-2 "replace the reader" deletes the /teach CRUD pages and adds one read-only viewer whose identity key is `instructor.wallet` (SIWS wallet ↔ Sanity `instructor->wallet`).
+
+**Tech Stack:** Next.js 14 App Router, next-intl, Sanity GROQ, Supabase SSR, vitest.
+
+**Spec:** `docs/superpowers/specs/2026-07-10-sp1-retire-teacher-authoring-design.md` — read it first; its "Owner decisions" bind this plan.
+
+## Global Constraints
+
+- TypeScript strict, **zero `any`**; all strings via next-intl with **en/pt-BR/es parity** (`apps/web/src/messages/{en,pt-BR,es}.json`).
+- PR-1 is **SENSITIVE** (carries a `supabase/migrations/**` file): both review gates + independent adversarial review + owner sign-off. **Merging PR-1 must NOT apply the migration** — application is a separate human-gated step.
+- The purge script defaults to **dry-run**; `--live` required to mutate; it must refuse to delete any doc carrying `sync.source`.
+- Tests: `pnpm --filter @superteam-lms/web test` (354 passing baseline) and `pnpm --filter @superteam-lms/web typecheck`. Node: `export PATH="/Users/thomgabriel/.nvm/versions/node/v22.17.1/bin:$PATH"`.
+- Branches: `loop/sp1-pr1-cut-writers-<DD-MM-YYYY>` and `loop/sp1-pr2-teach-viewer-<DD-MM-YYYY>`. Conventional commits.
+- **Plan deviation from spec (intentional):** `lib/teacher/authorize.ts` and `lib/teacher/stats.ts` are deleted/kept per PR-2, NOT PR-1 — the surviving stats route imports them until its PR-2 rewire. The spec listed authorize.ts under PR-1; that would break the interim build.
+
+---
+
+## PR-1 — "Cut the writers"
+
+### Task 1: Remove the 4 obsolete panels from the admin page
+
+**Files:**
+- Modify: `apps/web/src/app/[locale]/admin/admin-client.tsx` (remove imports + JSX for the 4 panels)
+- Delete: `apps/web/src/components/admin/course-review-queue.tsx`, `course-tags-panel.tsx`, `learning-paths-panel.tsx`, `teacher-roles-panel.tsx`
+- Delete tests colocated with those components (`grep -rl "course-review-queue\|course-tags-panel\|learning-paths-panel\|teacher-roles-panel" apps/web/src --include="*.test.*"`)
+
+**Steps:**
+- [ ] In `admin-client.tsx`, delete the import lines and JSX usages of `CourseReviewQueue`, `CourseTagsPanel`, `LearningPathsPanel`, `TeacherRolesPanel` (exact component names per the file's imports — read it first).
+- [ ] `git rm` the four component files and their test files.
+- [ ] Remove now-unused i18n keys: in each of the 3 message files, delete the sub-objects under whichever namespaces those four panels used (find with `grep -o "t(\"[^\"]*\"" <component>` BEFORE deleting the files; the shared `teacher` namespace keys used only by these panels go too; keys shared with surviving code stay). Run the parity check test if one exists; otherwise verify with `python3 -c "import json;a=json.load(open('apps/web/src/messages/en.json'));b=json.load(open('apps/web/src/messages/pt-BR.json'));c=json.load(open('apps/web/src/messages/es.json'));import sys;sys.exit(0 if a.keys()==b.keys()==c.keys() else 1)"` (deep parity is enforced by existing i18n tests).
+- [ ] Run: `pnpm --filter @superteam-lms/web typecheck && pnpm --filter @superteam-lms/web test` — expect green (test count drops by the deleted suites).
+- [ ] Commit: `refactor(admin): remove review-queue/tags/learning-paths/teacher-roles panels (git-sourced now)`
+
+### Task 2: Delete the manual-management + teacher CRUD API routes
+
+**Files:**
+- Delete directories: `apps/web/src/app/api/admin/tags/`, `apps/web/src/app/api/admin/learning-paths/`, `apps/web/src/app/api/admin/teachers/`, `apps/web/src/app/api/admin/courses/review/`
+- Delete: `apps/web/src/app/api/teacher/courses/route.ts`, `apps/web/src/app/api/teacher/courses/[id]/route.ts`, `[id]/structure/route.ts`, `[id]/thumbnail/route.ts` (+ its `__tests__/route.test.ts`), `apps/web/src/app/api/teacher/upload-image/`
+- **KEEP**: `apps/web/src/app/api/teacher/courses/[id]/stats/route.ts` (rewired in PR-2), `lib/teacher/authorize.ts`, `lib/teacher/stats.ts`
+- Delete: `apps/web/src/lib/sanity/teacher-mutations.ts`, `apps/web/src/lib/sanity/teacher-structure.ts`, `apps/web/src/lib/teacher/validate.ts`
+
+**Steps:**
+- [ ] Before deleting, verify importers: `grep -rln "teacher-mutations\|teacher-structure\|teacher/validate" apps/web/src --include="*.ts*"` — every hit must be a file this task deletes or a /teach page PR-2 deletes. If a /teach page imports them, the page keeps building until PR-2 — so ONLY proceed if hits are the API routes; otherwise defer the lib deletion to PR-2 and note it in the PR body.
+- [ ] `git rm -r` the listed routes/libs. Delete their test files.
+- [ ] `pnpm --filter @superteam-lms/web typecheck && pnpm --filter @superteam-lms/web test` — green. If a /teach CRUD page fails typecheck due to a deleted lib, defer that lib to PR-2 (see step 1) rather than stubbing.
+- [ ] Commit: `refactor(api): delete teacher CRUD + manual tags/paths/teachers/review routes`
+
+### Task 3: Role-drop migration file (application human-gated)
+
+**Files:**
+- Create: `supabase/migrations/20260710T00_drop_teacher_role.sql`
+
+**Steps:**
+- [ ] Verify the trigger's function name on the live DB (dbd5cdaf MCP, project `obqlljsagzslxarwphxv`): `SELECT tgfoid::regproc AS fn FROM pg_trigger WHERE tgname='trg_enforce_profile_role_write';` — substitute the result below if it differs.
+- [ ] Write the migration:
+```sql
+-- SP1: the teacher-role concept is retired; instructor identity = on-curve
+-- instructor.wallet in courses-academy (spec 2026-07-10-sp1). Admin panel auth
+-- is the HMAC admin_session cookie and never used profiles.role.
+DROP TRIGGER IF EXISTS trg_enforce_profile_role_write ON public.profiles;
+DROP FUNCTION IF EXISTS public.enforce_profile_role_write();
+ALTER TABLE public.profiles DROP COLUMN IF EXISTS role;
+```
+- [ ] Search for role-referencing policies before finalizing: `SELECT polname, polrelid::regclass FROM pg_policy WHERE pg_get_expr(polqual, polrelid) ILIKE '%role%';` — if any reference `profiles.role`, add `DROP POLICY`/`CREATE POLICY` lines reproducing the policy without the role clause, and paste the before/after into the PR body.
+- [ ] Do NOT apply. PR body must carry: "MIGRATION FILE ONLY — application is a separate human-gated step pending Supabase stability verification."
+- [ ] Commit: `feat(db): migration to drop profiles.role + escalation-lock trigger (application gated)`
+
+### Task 4: Orphan purge script (dry-run default)
+
+**Files:**
+- Create: `scripts/purge-legacy-sanity-docs.ts`
+
+**Steps:**
+- [ ] Write the script:
+```ts
+/**
+ * One-time purge of legacy (pre-content-standard) Sanity docs.
+ * DRY-RUN by default; pass --live to mutate. Refuses to touch any doc
+ * carrying sync.source (those are owned by the content sync).
+ * Env: SANITY_ADMIN_TOKEN (write), NEXT_PUBLIC_SANITY_PROJECT_ID, NEXT_PUBLIC_SANITY_DATASET.
+ * Run: npx tsx scripts/purge-legacy-sanity-docs.ts [--live]
+ */
+import { createClient } from "@sanity/client";
+
+const LEGACY_COURSE_IDS = ["aD45H1NEbb1bqELwloGCqI", "ops2aYkxIM6NMo1gE18U1o"];
+
+async function main(): Promise<void> {
+  const live = process.argv.includes("--live");
+  const client = createClient({
+    projectId: process.env.NEXT_PUBLIC_SANITY_PROJECT_ID ?? "",
+    dataset: process.env.NEXT_PUBLIC_SANITY_DATASET ?? "production",
+    apiVersion: "2024-01-01",
+    token: process.env.SANITY_ADMIN_TOKEN,
+    useCdn: false,
+  });
+  // Legacy courses, their lessons (UUID ids, never sync-marked), and ALL
+  // module documents (type deleted from the schema in CS-5).
+  const targets = await client.fetch<{ _id: string; _type: string }[]>(
+    `*[(_id in $courses)
+       || (_type == "module")
+       || (_type == "lesson" && !defined(sync.source) && !defined(blocks))]
+       { _id, _type, "sync": sync.source }`,
+    { courses: LEGACY_COURSE_IDS }
+  );
+  const guarded = targets.filter(
+    (d) => (d as { sync?: string }).sync !== undefined
+  );
+  if (guarded.length > 0) {
+    throw new Error(
+      `refusing: ${guarded.length} target(s) carry sync.source: ${guarded.map((d) => d._id).join(", ")}`
+    );
+  }
+  for (const d of targets) console.log(`${live ? "DELETE" : "would delete"} ${d._type} ${d._id}`);
+  if (!live) {
+    console.log(`dry-run: ${targets.length} docs. Re-run with --live to execute.`);
+    return;
+  }
+  const tx = targets.reduce((t, d) => t.delete(d._id), client.transaction());
+  await tx.commit();
+  console.log(`deleted ${targets.length} docs`);
+}
+main().catch((e) => { console.error(e); process.exit(1); });
+```
+- [ ] Dry-run against prod (read needs no token): expect exactly the 2 legacy courses + 3 UUID lessons + N module docs, zero sync-marked entries.
+- [ ] Commit: `feat(scripts): one-time legacy Sanity doc purge (dry-run default)`
+- [ ] Open PR-1 with `Refs #359` + the spec link; flag SENSITIVE in the body; go through both gates + adversarial review + owner sign-off.
+
+---
+
+## PR-2 — "Replace the reader" (branch from main AFTER PR-1 merges)
+
+### Task 5: Delete the /teach CRUD pages
+
+**Files:**
+- Delete: `apps/web/src/app/[locale]/(platform)/teach/courses/` (entire tree: `page.tsx`, `new/page.tsx`, `[id]/page.tsx`, `[id]/edit/page.tsx`, client components)
+- Keep for rewrite: `apps/web/src/app/[locale]/(platform)/teach/page.tsx`
+- Delete any lib deferred from Task 2 (see its PR body).
+
+**Steps:**
+- [ ] `git rm -r` the tree; delete colocated tests; `typecheck` — the remaining `teach/page.tsx` may now have dead imports; strip it to a placeholder that Task 6 replaces.
+- [ ] Commit: `refactor(teach): delete CRUD authoring pages`
+
+### Task 6: Read-only wallet-keyed viewer
+
+**Files:**
+- Rewrite: `apps/web/src/app/[locale]/(platform)/teach/page.tsx` (server component)
+- Create: `apps/web/src/app/[locale]/(platform)/teach/instructor-courses.tsx` (client, stats expansion)
+- Add query to `apps/web/src/lib/sanity/queries.ts`
+- i18n: replace the `teacher` namespace in all 3 message files with viewer keys (`teach.title`, `teach.signInPrompt`, `teach.emptyState`, `teach.courseCard.*`, `teach.stats.*`)
+
+**Interfaces:**
+- Produces: `getInstructorCourses(wallet: string): Promise<{ _id: string; title: string; slug: string }[]>` in queries.ts — GROQ:
+```groq
+*[_type == "course" && instructor->wallet == $wallet && onChainStatus.status == "synced"]{ _id, title, "slug": slug.current }
+```
+(unfiltered by active/authoring gates on purpose — an instructor sees their deactivated courses too; note this in a comment.)
+- Consumes: caller wallet from the Supabase SSR session — follow the exact pattern used by `apps/web/src/app/api/teacher/courses/[id]/stats/route.ts` (via `lib/teacher/authorize.ts`) to resolve the session profile's `wallet_address`; reuse `getCourseStats(courseId)` from `lib/teacher/stats.ts` for the per-course payload.
+
+**Steps:**
+- [ ] Write failing tests first (`apps/web/src/lib/sanity/__tests__/instructor-courses.test.ts`): `getInstructorCourses` builds the exact GROQ above (mock `sanityFetch`, assert query text + params like sibling query tests do).
+- [ ] Implement query; page: no session → `teach.signInPrompt`; wallet matches nothing → `teach.emptyState`; else course cards with expandable stats via a small client component fetching the stats route.
+- [ ] i18n keys in en, pt-BR, es (translate properly, not machine-echo).
+- [ ] `typecheck + test` green. Commit: `feat(teach): read-only wallet-keyed instructor viewer`
+
+### Task 7: Rewire stats-route auth to wallet-match, delete authorize.ts
+
+**Files:**
+- Modify: `apps/web/src/app/api/teacher/courses/[id]/stats/route.ts`
+- Delete: `apps/web/src/lib/teacher/authorize.ts` (fold what stats needs inline or into `lib/teacher/stats.ts`)
+- Test: colocated route test
+
+**Steps:**
+- [ ] Failing tests: session wallet == `instructor->wallet` of the course → 200; different wallet → 403; no session → 401; course without instructor → 403 (no fallback).
+- [ ] Replace the `auth.caller.role !== "admin" && course.author !== auth.caller.userId` block: resolve session profile wallet (Supabase SSR), fetch `*[_type=="course" && _id==$id][0]{ "wallet": instructor->wallet }` (revalidate 0), compare. Delete `getCourseAuthorship` if now unused. NO admin override (owner decision #1), NO platform-authority fallback.
+- [ ] `typecheck + test` green. Commit: `refactor(api): stats auth = instructor wallet match; drop role/author machinery`
+- [ ] Open PR-2 (`Refs #359`, SAFE lane), both gates, merge.
+
+---
+
+## Post-merge (human-gated, NOT part of any PR)
+
+- [ ] Migration application via dbd5cdaf MCP **only after** owner confirms Supabase stability; then `get_advisors` both types + verify with `SELECT column_name FROM information_schema.columns WHERE table_name='profiles' AND column_name='role';` → empty.
+- [ ] Purge script `--live` run after owner eyeballs the dry-run list; verify: `count(*[_type=="module"]) == 0`, both legacy course ids gone, lesson count == 76.
+- [ ] E2E: owner wallet `B7o8NfV81HzjuZFWQTTx3Xdvh77Dqoajwib3kWEnvzJF` signs into /teach → all 6 courses appear with stats.
+- [ ] Close #263/#264/#265 with pointers to the spec; verify #398 closed.

--- a/docs/superpowers/plans/2026-07-10-sp1-retire-teacher-authoring.md
+++ b/docs/superpowers/plans/2026-07-10-sp1-retire-teacher-authoring.md
@@ -2,89 +2,117 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Delete every UI-authoring-era surface (teacher CRUD, role machinery, 4 obsolete admin panels) and replace /teach with a read-only wallet-keyed analytics viewer.
+**Rev 2 — post tri-audit.** Three independent auditors (ground-truth, alignment, security) invalidated rev 1 on: the purge guard (GROQ null vs undefined), unaccounted `profiles.role` consumers (auth-provider — app-wide logout on migration), a PR-1 delete/keep contradiction (teacher-mutations), the missed `teach/layout.tsx` role gate, and the spoofable wallet auth (#408). All fixed below.
 
-**Architecture:** Two staged PRs. PR-1 "cut the writers" removes all write paths (admin panels, teacher API routes, teacher libs) and ships the human-gated role-drop migration + orphan purge script. PR-2 "replace the reader" deletes the /teach CRUD pages and adds one read-only viewer whose identity key is `instructor.wallet` (SIWS wallet ↔ Sanity `instructor->wallet`).
+**Goal:** Delete every UI-authoring-era surface and replace /teach with a read-only wallet-keyed analytics viewer, closing #408 in the same migration.
+
+**Architecture:** PR-1 "cut the writers" (admin panels + API routes + validate.ts + gated migration + purge script). PR-2 "replace the reader" (/teach viewer, stats rewire, header/auth-provider role removal, teacher libs deletion, dead-code sweep). Migration applies only after PR-2 deploys.
 
 **Tech Stack:** Next.js 14 App Router, next-intl, Sanity GROQ, Supabase SSR, vitest.
 
-**Spec:** `docs/superpowers/specs/2026-07-10-sp1-retire-teacher-authoring-design.md` — read it first; its "Owner decisions" bind this plan.
+**Spec:** `docs/superpowers/specs/2026-07-10-sp1-retire-teacher-authoring-design.md` (rev 2) — its Owner decisions + Security decision bind this plan.
 
 ## Global Constraints
 
-- TypeScript strict, **zero `any`**; all strings via next-intl with **en/pt-BR/es parity** (`apps/web/src/messages/{en,pt-BR,es}.json`).
-- PR-1 is **SENSITIVE** (carries a `supabase/migrations/**` file): both review gates + independent adversarial review + owner sign-off. **Merging PR-1 must NOT apply the migration** — application is a separate human-gated step.
-- The purge script defaults to **dry-run**; `--live` required to mutate; it must refuse to delete any doc carrying `sync.source`.
-- Tests: `pnpm --filter @superteam-lms/web test` (354 passing baseline) and `pnpm --filter @superteam-lms/web typecheck`. Node: `export PATH="/Users/thomgabriel/.nvm/versions/node/v22.17.1/bin:$PATH"`.
-- Branches: `loop/sp1-pr1-cut-writers-<DD-MM-YYYY>` and `loop/sp1-pr2-teach-viewer-<DD-MM-YYYY>`. Conventional commits.
-- **Plan deviation from spec (intentional):** `lib/teacher/authorize.ts` and `lib/teacher/stats.ts` are deleted/kept per PR-2, NOT PR-1 — the surviving stats route imports them until its PR-2 rewire. The spec listed authorize.ts under PR-1; that would break the interim build.
+- TypeScript strict, **zero `any`**; all NEW strings via next-intl, en/pt-BR/es parity (`apps/web/src/messages/`). The 4 admin panels have no i18n (hardcoded English) — nothing to prune in PR-1; the `teacher.*` namespace is pruned in PR-2 ONLY.
+- PR-1 is **SENSITIVE** (migration file): both gates + independent adversarial review + owner sign-off. **Merge ≠ apply.** Application gate: **PR-2 deployed to prod + Supabase stability confirmed** (auth-provider still selects `role` until PR-2 — applying earlier logs out the whole app).
+- Purge script: dry-run default, token REQUIRED in both modes, `perspective: "raw"` pinned, `--live --expect N` count assertion, refuses `sync.source != null` docs.
+- Tests: `pnpm --filter @superteam-lms/web test` (354 baseline) + `typecheck`. Node: `export PATH="/Users/thomgabriel/.nvm/versions/node/v22.17.1/bin:$PATH"`.
+- Branches `loop/sp1-pr1-cut-writers-<DD-MM-YYYY>`, `loop/sp1-pr2-teach-viewer-<DD-MM-YYYY>`; conventional commits.
 
 ---
 
 ## PR-1 — "Cut the writers"
 
-### Task 1: Remove the 4 obsolete panels from the admin page
+### Task 1: Remove the 4 obsolete panels + their residue
 
 **Files:**
-- Modify: `apps/web/src/app/[locale]/admin/admin-client.tsx` (remove imports + JSX for the 4 panels)
-- Delete: `apps/web/src/components/admin/course-review-queue.tsx`, `course-tags-panel.tsx`, `learning-paths-panel.tsx`, `teacher-roles-panel.tsx`
-- Delete tests colocated with those components (`grep -rl "course-review-queue\|course-tags-panel\|learning-paths-panel\|teacher-roles-panel" apps/web/src --include="*.test.*"`)
+- Modify: `apps/web/src/app/[locale]/admin/admin-client.tsx`
+- Modify: `apps/web/src/app/api/admin/status/route.ts` (drop `pendingReviews`)
+- Delete: `apps/web/src/components/admin/course-review-queue.tsx`, `course-tags-panel.tsx`, `learning-paths-panel.tsx`, `teacher-roles-panel.tsx` (no colocated tests exist — verified)
+- Modify: `apps/web/src/lib/sanity/queries.ts` (delete `getPendingReviewCourses`) and `apps/web/src/lib/sanity/admin-mutations.ts` (delete `approveCourse`, `rejectCourse` + their tests — their only caller is the deleted review route/queue)
 
 **Steps:**
-- [ ] In `admin-client.tsx`, delete the import lines and JSX usages of `CourseReviewQueue`, `CourseTagsPanel`, `LearningPathsPanel`, `TeacherRolesPanel` (exact component names per the file's imports — read it first).
-- [ ] `git rm` the four component files and their test files.
-- [ ] Remove now-unused i18n keys: in each of the 3 message files, delete the sub-objects under whichever namespaces those four panels used (find with `grep -o "t(\"[^\"]*\"" <component>` BEFORE deleting the files; the shared `teacher` namespace keys used only by these panels go too; keys shared with surviving code stay). Run the parity check test if one exists; otherwise verify with `python3 -c "import json;a=json.load(open('apps/web/src/messages/en.json'));b=json.load(open('apps/web/src/messages/pt-BR.json'));c=json.load(open('apps/web/src/messages/es.json'));import sys;sys.exit(0 if a.keys()==b.keys()==c.keys() else 1)"` (deep parity is enforced by existing i18n tests).
-- [ ] Run: `pnpm --filter @superteam-lms/web typecheck && pnpm --filter @superteam-lms/web test` — expect green (test count drops by the deleted suites).
-- [ ] Commit: `refactor(admin): remove review-queue/tags/learning-paths/teacher-roles panels (git-sourced now)`
+- [ ] In `admin-client.tsx` remove: imports + JSX of `CourseReviewQueue`, `CourseTagsPanel`, `LearningPathsPanel`, `TeacherRolesPanel` (imports at lines 6-14); the `PendingReviewCourse` type import (line 7); `AdminStatus.pendingReviews` (line 68); `const pendingReviews = status.pendingReviews ?? []` (line 125); the "Review Queue" section header/refresh chrome (lines 154-178). Line numbers are rev-time — re-locate by symbol.
+- [ ] In `api/admin/status/route.ts` remove the `pendingReviews` field and its `getPendingReviewCourses` call (lines 14, 45-49, 201 rev-time). Delete `getPendingReviewCourses` from queries.ts and `approveCourse`/`rejectCourse` from admin-mutations.ts + their test blocks.
+- [ ] `git rm` the 4 component files.
+- [ ] `pnpm --filter @superteam-lms/web typecheck && pnpm --filter @superteam-lms/web test` → green.
+- [ ] Commit: `refactor(admin): remove review-queue/tags/learning-paths/teacher-roles panels + dead pendingReviews stat`
 
-### Task 2: Delete the manual-management + teacher CRUD API routes
+### Task 2: Delete manual-management + teacher CRUD API routes
 
 **Files:**
-- Delete directories: `apps/web/src/app/api/admin/tags/`, `apps/web/src/app/api/admin/learning-paths/`, `apps/web/src/app/api/admin/teachers/`, `apps/web/src/app/api/admin/courses/review/`
-- Delete: `apps/web/src/app/api/teacher/courses/route.ts`, `apps/web/src/app/api/teacher/courses/[id]/route.ts`, `[id]/structure/route.ts`, `[id]/thumbnail/route.ts` (+ its `__tests__/route.test.ts`), `apps/web/src/app/api/teacher/upload-image/`
-- **KEEP**: `apps/web/src/app/api/teacher/courses/[id]/stats/route.ts` (rewired in PR-2), `lib/teacher/authorize.ts`, `lib/teacher/stats.ts`
-- Delete: `apps/web/src/lib/sanity/teacher-mutations.ts`, `apps/web/src/lib/sanity/teacher-structure.ts`, `apps/web/src/lib/teacher/validate.ts`
+- Delete dirs: `apps/web/src/app/api/admin/tags/`, `api/admin/learning-paths/`, `api/admin/teachers/`, `api/admin/courses/review/`
+- Delete: `api/teacher/courses/route.ts`, `api/teacher/courses/[id]/route.ts`, `[id]/structure/route.ts`, `[id]/thumbnail/route.ts` + `thumbnail/__tests__/route.test.ts`, `api/teacher/upload-image/`
+- Delete: `apps/web/src/lib/teacher/validate.ts` (importers = exactly the 3 routes above — verified)
+- **KEEP until PR-2**: `api/teacher/courses/[id]/stats/route.ts`, `lib/teacher/authorize.ts`, `lib/teacher/stats.ts`, `lib/sanity/teacher-mutations.ts`, `lib/sanity/teacher-structure.ts` (stats route imports `getCourseAuthorship` from teacher-mutations at line 5; /teach pages import both libs)
 
 **Steps:**
-- [ ] Before deleting, verify importers: `grep -rln "teacher-mutations\|teacher-structure\|teacher/validate" apps/web/src --include="*.ts*"` — every hit must be a file this task deletes or a /teach page PR-2 deletes. If a /teach page imports them, the page keeps building until PR-2 — so ONLY proceed if hits are the API routes; otherwise defer the lib deletion to PR-2 and note it in the PR body.
-- [ ] `git rm -r` the listed routes/libs. Delete their test files.
-- [ ] `pnpm --filter @superteam-lms/web typecheck && pnpm --filter @superteam-lms/web test` — green. If a /teach CRUD page fails typecheck due to a deleted lib, defer that lib to PR-2 (see step 1) rather than stubbing.
-- [ ] Commit: `refactor(api): delete teacher CRUD + manual tags/paths/teachers/review routes`
+- [ ] `git rm -r` the listed routes + validate.ts; delete their test files.
+- [ ] Re-verify keeps: `grep -rln "teacher-mutations\|teacher-structure" apps/web/src --include="*.ts*"` → hits must be only the stats route + /teach pages (all die in PR-2).
+- [ ] `typecheck + test` → green. Commit: `refactor(api): delete teacher CRUD + manual tags/paths/teachers/review routes`
 
-### Task 3: Role-drop migration file (application human-gated)
+### Task 3: Migration — drop role machinery, add wallet_address write-lock (#408)
 
 **Files:**
-- Create: `supabase/migrations/20260710T00_drop_teacher_role.sql`
+- Create: `supabase/migrations/20260710120000_drop_teacher_role.sql`
 
 **Steps:**
-- [ ] Verify the trigger's function name on the live DB (dbd5cdaf MCP, project `obqlljsagzslxarwphxv`): `SELECT tgfoid::regproc AS fn FROM pg_trigger WHERE tgname='trg_enforce_profile_role_write';` — substitute the result below if it differs.
-- [ ] Write the migration:
+- [ ] Write:
 ```sql
--- SP1: the teacher-role concept is retired; instructor identity = on-curve
--- instructor.wallet in courses-academy (spec 2026-07-10-sp1). Admin panel auth
--- is the HMAC admin_session cookie and never used profiles.role.
+-- SP1: retire the teacher-role concept (instructor identity = on-curve
+-- instructor.wallet in courses-academy) AND close #408 by locking
+-- profiles.wallet_address writes to service_role — the same self-escalation
+-- class the role trigger closed, on the column that now carries identity.
+-- IRREVERSIBLE BY DESIGN: role values are destroyed (concept retired).
+-- Live-verified 2026-07-10: zero RLS policies reference profiles.role.
+
 DROP TRIGGER IF EXISTS trg_enforce_profile_role_write ON public.profiles;
 DROP FUNCTION IF EXISTS public.enforce_profile_role_write();
 ALTER TABLE public.profiles DROP COLUMN IF EXISTS role;
-```
-- [ ] Search for role-referencing policies before finalizing: `SELECT polname, polrelid::regclass FROM pg_policy WHERE pg_get_expr(polqual, polrelid) ILIKE '%role%';` — if any reference `profiles.role`, add `DROP POLICY`/`CREATE POLICY` lines reproducing the policy without the role clause, and paste the before/after into the PR body.
-- [ ] Do NOT apply. PR body must carry: "MIGRATION FILE ONLY — application is a separate human-gated step pending Supabase stability verification."
-- [ ] Commit: `feat(db): migration to drop profiles.role + escalation-lock trigger (application gated)`
 
-### Task 4: Orphan purge script (dry-run default)
+-- #408: wallet_address may only be set by service_role (SIWS link routes).
+CREATE OR REPLACE FUNCTION public.enforce_profile_wallet_write()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF NEW.wallet_address IS DISTINCT FROM OLD.wallet_address
+     AND current_setting('request.jwt.claims', true)::jsonb->>'role' IS DISTINCT FROM 'service_role'
+  THEN
+    RAISE EXCEPTION 'wallet_address may only be changed via the wallet-link flow';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_enforce_profile_wallet_write ON public.profiles;
+CREATE TRIGGER trg_enforce_profile_wallet_write
+  BEFORE UPDATE ON public.profiles
+  FOR EACH ROW EXECUTE FUNCTION public.enforce_profile_wallet_write();
+```
+- [ ] Mirror-check the guard style against the OLD role trigger (`supabase/migrations/20260703130652*`, function `enforce_profile_role_write`) — if it detects service_role differently (e.g. `auth.role()` or `current_user`), use ITS mechanism verbatim so behavior is proven, and note the substitution in the PR body.
+- [ ] PR body must include: "MIGRATION FILE ONLY — apply after PR-2 deploys + Supabase stability confirmed" + the pre-apply snapshot query `SELECT id, role FROM public.profiles WHERE role IS DISTINCT FROM 'learner';`
+- [ ] Commit: `feat(db): drop teacher role machinery; lock wallet_address writes to service_role (Closes #408 on apply)`
+
+### Task 4: Orphan purge script (dry-run default, audit-hardened)
 
 **Files:**
 - Create: `scripts/purge-legacy-sanity-docs.ts`
 
 **Steps:**
-- [ ] Write the script:
+- [ ] Write:
 ```ts
 /**
- * One-time purge of legacy (pre-content-standard) Sanity docs.
- * DRY-RUN by default; pass --live to mutate. Refuses to touch any doc
- * carrying sync.source (those are owned by the content sync).
- * Env: SANITY_ADMIN_TOKEN (write), NEXT_PUBLIC_SANITY_PROJECT_ID, NEXT_PUBLIC_SANITY_DATASET.
- * Run: npx tsx scripts/purge-legacy-sanity-docs.ts [--live]
+ * One-time purge of legacy (pre-content-standard) Sanity docs + manual-era
+ * courseTag / unsynced learningPath docs. DRY-RUN by default; --live to
+ * mutate, and --live REQUIRES --expect N where N is the dry-run count.
+ * SANITY_ADMIN_TOKEN is required in BOTH modes (raw perspective must see
+ * drafts identically in dry-run and live — a tokenless dry-run would show
+ * a different doc set than the tokened live run).
+ * Run: npx tsx scripts/purge-legacy-sanity-docs.ts [--live --expect N]
  */
 import { createClient } from "@sanity/client";
 
@@ -92,25 +120,35 @@ const LEGACY_COURSE_IDS = ["aD45H1NEbb1bqELwloGCqI", "ops2aYkxIM6NMo1gE18U1o"];
 
 async function main(): Promise<void> {
   const live = process.argv.includes("--live");
+  const expectIdx = process.argv.indexOf("--expect");
+  const expected = expectIdx === -1 ? null : Number(process.argv[expectIdx + 1]);
+  if (live && (expected === null || Number.isNaN(expected))) {
+    throw new Error("--live requires --expect N (the dry-run count)");
+  }
+  const token = process.env.SANITY_ADMIN_TOKEN;
+  if (!token) throw new Error("SANITY_ADMIN_TOKEN is required (both modes)");
   const client = createClient({
-    projectId: process.env.NEXT_PUBLIC_SANITY_PROJECT_ID ?? "",
+    projectId: process.env.NEXT_PUBLIC_SANITY_PROJECT_ID ?? "4e3i2wwc",
     dataset: process.env.NEXT_PUBLIC_SANITY_DATASET ?? "production",
     apiVersion: "2024-01-01",
-    token: process.env.SANITY_ADMIN_TOKEN,
+    token,
     useCdn: false,
+    perspective: "raw",
   });
-  // Legacy courses, their lessons (UUID ids, never sync-marked), and ALL
-  // module documents (type deleted from the schema in CS-5).
-  const targets = await client.fetch<{ _id: string; _type: string }[]>(
-    `*[(_id in $courses)
-       || (_type == "module")
-       || (_type == "lesson" && !defined(sync.source) && !defined(blocks))]
+  const targets = await client.fetch<{ _id: string; _type: string; sync: string | null }[]>(
+    `*[((_id in $courses || _id in $draftCourses)
+       || _type == "module"
+       || _type == "courseTag"
+       || (_type == "learningPath" && !defined(sync.source))
+       || (_type == "lesson" && !defined(sync.source) && !defined(blocks)))]
        { _id, _type, "sync": sync.source }`,
-    { courses: LEGACY_COURSE_IDS }
+    {
+      courses: LEGACY_COURSE_IDS,
+      draftCourses: LEGACY_COURSE_IDS.map((id) => `drafts.${id}`),
+    }
   );
-  const guarded = targets.filter(
-    (d) => (d as { sync?: string }).sync !== undefined
-  );
+  // Belt + suspenders: GROQ returns null (not undefined) for absent fields.
+  const guarded = targets.filter((d) => d.sync != null);
   if (guarded.length > 0) {
     throw new Error(
       `refusing: ${guarded.length} target(s) carry sync.source: ${guarded.map((d) => d._id).join(", ")}`
@@ -118,8 +156,11 @@ async function main(): Promise<void> {
   }
   for (const d of targets) console.log(`${live ? "DELETE" : "would delete"} ${d._type} ${d._id}`);
   if (!live) {
-    console.log(`dry-run: ${targets.length} docs. Re-run with --live to execute.`);
+    console.log(`dry-run: ${targets.length} docs. Re-run with --live --expect ${targets.length} to execute.`);
     return;
+  }
+  if (targets.length !== expected) {
+    throw new Error(`aborting: target count ${targets.length} != --expect ${expected} (dataset changed since dry-run)`);
   }
   const tx = targets.reduce((t, d) => t.delete(d._id), client.transaction());
   await tx.commit();
@@ -127,65 +168,70 @@ async function main(): Promise<void> {
 }
 main().catch((e) => { console.error(e); process.exit(1); });
 ```
-- [ ] Dry-run against prod (read needs no token): expect exactly the 2 legacy courses + 3 UUID lessons + N module docs, zero sync-marked entries.
-- [ ] Commit: `feat(scripts): one-time legacy Sanity doc purge (dry-run default)`
-- [ ] Open PR-1 with `Refs #359` + the spec link; flag SENSITIVE in the body; go through both gates + adversarial review + owner sign-off.
+- [ ] Tokened dry-run against prod: expect the verified 25 legacy docs (2 courses + 3 UUID lessons + 20 modules) plus any courseTag / unsynced-learningPath docs; ZERO sync-marked entries; count printed.
+- [ ] Commit: `feat(scripts): legacy Sanity purge (raw perspective, count-asserted live mode)`
+- [ ] Open PR-1: `Refs #359 #408`, spec link, SENSITIVE flag → both gates + adversarial review + owner sign-off.
 
 ---
 
 ## PR-2 — "Replace the reader" (branch from main AFTER PR-1 merges)
 
-### Task 5: Delete the /teach CRUD pages
+### Task 5: Delete CRUD pages, teacher components, and the role-gate layout
 
 **Files:**
-- Delete: `apps/web/src/app/[locale]/(platform)/teach/courses/` (entire tree: `page.tsx`, `new/page.tsx`, `[id]/page.tsx`, `[id]/edit/page.tsx`, client components)
-- Keep for rewrite: `apps/web/src/app/[locale]/(platform)/teach/page.tsx`
-- Delete any lib deferred from Task 2 (see its PR body).
+- Delete: `apps/web/src/app/[locale]/(platform)/teach/courses/` (entire tree), **`teach/layout.tsx`** (role gate — would redirect everyone off the new viewer post-migration), `apps/web/src/components/teacher/` (course-form, course-structure-editor, markdown-field, thumbnail-picker — outside the teach tree, stranded otherwise)
+- Strip `teach/page.tsx` to a minimal placeholder Task 6 replaces.
 
 **Steps:**
-- [ ] `git rm -r` the tree; delete colocated tests; `typecheck` — the remaining `teach/page.tsx` may now have dead imports; strip it to a placeholder that Task 6 replaces.
-- [ ] Commit: `refactor(teach): delete CRUD authoring pages`
+- [ ] `git rm -r` the three targets + colocated tests; placeholder page; `typecheck` green (fix dead imports).
+- [ ] Commit: `refactor(teach): delete CRUD pages, teacher components, role-gate layout`
 
-### Task 6: Read-only wallet-keyed viewer
+### Task 6: Read-only wallet-keyed viewer + header/auth-provider role removal
 
 **Files:**
-- Rewrite: `apps/web/src/app/[locale]/(platform)/teach/page.tsx` (server component)
-- Create: `apps/web/src/app/[locale]/(platform)/teach/instructor-courses.tsx` (client, stats expansion)
-- Add query to `apps/web/src/lib/sanity/queries.ts`
-- i18n: replace the `teacher` namespace in all 3 message files with viewer keys (`teach.title`, `teach.signInPrompt`, `teach.emptyState`, `teach.courseCard.*`, `teach.stats.*`)
+- Rewrite: `teach/page.tsx` (server) + create `teach/instructor-courses.tsx` (client stats expansion)
+- Add to `lib/sanity/queries.ts`: `getInstructorCourses`, `isInstructorWallet`
+- Modify: `components/layout/header.tsx` (`canTeach` → instructor-wallet check), `lib/auth/auth-provider.tsx` (drop `role` from `PROFILE_COLUMNS` line 35)
+- i18n: replace `teacher.*` namespace with `teach.*` viewer keys in en/pt-BR/es; create `apps/web/src/messages/__tests__/parity.test.ts`
+- Tests: `lib/sanity/__tests__/instructor-courses.test.ts`, viewer state tests
 
-**Interfaces:**
-- Produces: `getInstructorCourses(wallet: string): Promise<{ _id: string; title: string; slug: string }[]>` in queries.ts — GROQ:
-```groq
-*[_type == "course" && instructor->wallet == $wallet && onChainStatus.status == "synced"]{ _id, title, "slug": slug.current }
+**Interfaces (produced):**
+```ts
+// queries.ts — unfiltered by active/authoring gates on purpose: instructors see their deactivated courses too.
+export async function getInstructorCourses(wallet: string): Promise<{ _id: string; title: string; slug: string }[]> // GROQ: *[_type=="course" && instructor->wallet == $wallet && onChainStatus.status=="synced"]{_id,title,"slug":slug.current}
+export async function isInstructorWallet(wallet: string): Promise<boolean> // GROQ: count(*[_type=="instructor" && wallet == $wallet]) > 0, catalogFetch (1h cache fine)
 ```
-(unfiltered by active/authoring gates on purpose — an instructor sees their deactivated courses too; note this in a comment.)
-- Consumes: caller wallet from the Supabase SSR session — follow the exact pattern used by `apps/web/src/app/api/teacher/courses/[id]/stats/route.ts` (via `lib/teacher/authorize.ts`) to resolve the session profile's `wallet_address`; reuse `getCourseStats(courseId)` from `lib/teacher/stats.ts` for the per-course payload.
+**Consumes:** session profile `wallet_address` resolved the same way `authorizeTeacher()` does today (Supabase SSR own-profile read — copy that mechanism, minus role); `getCourseStats(courseId)` from `lib/teacher/stats.ts` unchanged.
 
 **Steps:**
-- [ ] Write failing tests first (`apps/web/src/lib/sanity/__tests__/instructor-courses.test.ts`): `getInstructorCourses` builds the exact GROQ above (mock `sanityFetch`, assert query text + params like sibling query tests do).
-- [ ] Implement query; page: no session → `teach.signInPrompt`; wallet matches nothing → `teach.emptyState`; else course cards with expandable stats via a small client component fetching the stats route.
-- [ ] i18n keys in en, pt-BR, es (translate properly, not machine-echo).
-- [ ] `typecheck + test` green. Commit: `feat(teach): read-only wallet-keyed instructor viewer`
+- [ ] Failing tests first: query-builder tests for both new functions (mock `sanityFetch`, assert query text + params, matching sibling test style); viewer renders courses list when `getInstructorCourses` returns items and the empty state (`teach.emptyState`) when `[]`.
+- [ ] Deep i18n parity test: recursively compare key structures of the 3 message files (fails on missing nested keys) — this is NEW; no parity test exists today.
+- [ ] Implement query functions, page (two states only — middleware already redirects unauthenticated users), client stats expansion, header `canTeach` via `isInstructorWallet(profile.wallet_address)`, PROFILE_COLUMNS without `role`.
+- [ ] All new strings in en + properly translated pt-BR/es.
+- [ ] `typecheck + test` green. Commit: `feat(teach): wallet-keyed read-only viewer; header/auth off role`
 
-### Task 7: Rewire stats-route auth to wallet-match, delete authorize.ts
+### Task 7: Stats-route wallet auth + teacher libs deletion + dead-code sweep
 
 **Files:**
-- Modify: `apps/web/src/app/api/teacher/courses/[id]/stats/route.ts`
-- Delete: `apps/web/src/lib/teacher/authorize.ts` (fold what stats needs inline or into `lib/teacher/stats.ts`)
-- Test: colocated route test
+- Modify: `api/teacher/courses/[id]/stats/route.ts`
+- Delete: `lib/teacher/authorize.ts`, `lib/sanity/teacher-mutations.ts`, `lib/sanity/teacher-structure.ts`
+- Sweep: `getManagedCourseTags` (queries.ts), `createCourseTag`/`deleteCourseTag`/`setLearningPathCourses` (admin-mutations.ts) + tests, `packages/types/src/user.ts` `UserRole` + `UserProfile.role`, `packages/types/src/course.ts` `author` + teacher-feedback fields, `lib/supabase/types.ts` role entries (hand-edit; regen post-migration)
+- Test: colocated stats route test
 
 **Steps:**
-- [ ] Failing tests: session wallet == `instructor->wallet` of the course → 200; different wallet → 403; no session → 401; course without instructor → 403 (no fallback).
-- [ ] Replace the `auth.caller.role !== "admin" && course.author !== auth.caller.userId` block: resolve session profile wallet (Supabase SSR), fetch `*[_type=="course" && _id==$id][0]{ "wallet": instructor->wallet }` (revalidate 0), compare. Delete `getCourseAuthorship` if now unused. NO admin override (owner decision #1), NO platform-authority fallback.
-- [ ] `typecheck + test` green. Commit: `refactor(api): stats auth = instructor wallet match; drop role/author machinery`
-- [ ] Open PR-2 (`Refs #359`, SAFE lane), both gates, merge.
+- [ ] Failing tests: matching wallet → 200; different wallet → 403; no session → 401; course without instructor → 403 (NO fallback, no admin override — owner decision 1).
+- [ ] Rewire: session wallet (same mechanism as Task 6) vs `sanityFetch('*[_type=="course" && _id==$id][0]{"wallet": instructor->wallet}', {id}, 0)`. Delete the role/author block and `getCourseAuthorship`.
+- [ ] Run the sweep; verify each symbol has zero remaining importers before deleting (`grep -rn <symbol> apps/web/src packages/`).
+- [ ] `typecheck + test` green across web AND `pnpm --filter @superteam-lms/types build` if types package builds separately.
+- [ ] Commit: `refactor(api): stats auth = instructor wallet; delete teacher libs + dead types`
+- [ ] Open PR-2 (`Refs #359`, SAFE lane) → both gates → merge.
 
 ---
 
 ## Post-merge (human-gated, NOT part of any PR)
 
-- [ ] Migration application via dbd5cdaf MCP **only after** owner confirms Supabase stability; then `get_advisors` both types + verify with `SELECT column_name FROM information_schema.columns WHERE table_name='profiles' AND column_name='role';` → empty.
-- [ ] Purge script `--live` run after owner eyeballs the dry-run list; verify: `count(*[_type=="module"]) == 0`, both legacy course ids gone, lesson count == 76.
-- [ ] E2E: owner wallet `B7o8NfV81HzjuZFWQTTx3Xdvh77Dqoajwib3kWEnvzJF` signs into /teach → all 6 courses appear with stats.
-- [ ] Close #263/#264/#265 with pointers to the spec; verify #398 closed.
+- [ ] **Order matters:** PR-2 deployed to prod FIRST (removes every `role` read), THEN migration application via dbd5cdaf MCP after owner confirms Supabase stability → `get_advisors` (both types) → verify: role column gone; `trg_enforce_profile_wallet_write` present; **link-wallet flow still works** (SIWS route is service-role); a non-service-role `wallet_address` UPDATE is rejected.
+- [ ] Purge: tokened dry-run → owner eyeballs list → `--live --expect N` → verify counts RELATIVE to pre-purge (modules → 0, legacy course ids gone, lesson delta == the UUID-lesson count from the dry-run list; no hardcoded absolutes).
+- [ ] Regenerate `lib/supabase/types.ts` + `supabase/schema.sql` snapshot against the post-migration DB; commit as a docs/chore PR.
+- [ ] E2E: owner wallet `B7o8NfV81HzjuZFWQTTx3Xdvh77Dqoajwib3kWEnvzJF` → header shows Teach → all 6 courses + stats; non-instructor wallet → no Teach item, /teach shows empty state.
+- [ ] Issues: close #398 (fixed by #399 — verified); post spec pointers on the closed #263/#264/#265; #408 closes with the migration application.

--- a/docs/superpowers/specs/2026-07-10-sp1-retire-teacher-authoring-design.md
+++ b/docs/superpowers/specs/2026-07-10-sp1-retire-teacher-authoring-design.md
@@ -1,8 +1,8 @@
 # SP1 — Retire the Teacher-Authoring Era (Design)
 
-**Date:** 2026-07-10
-**Status:** Approved by owner (in-session)
-**Epic context:** First of three sub-projects (SP1 retire teacher-authoring → SP2 remove Sanity → SP3 admin panel v2) following the content-standard epic (#359). Git (`solanabr/courses-academy`) is the source of truth for all course content, tags, learning paths, instructors, and achievements; instructor identity is the on-curve `instructor.wallet` (#399).
+**Date:** 2026-07-10 (rev 2 — post tri-audit)
+**Status:** Approved by owner (in-session); revised after a 3-agent audit (ground-truth / alignment / security). Audit deltas are marked **[AUDIT]**.
+**Epic context:** First of three sub-projects (SP1 retire teacher-authoring → SP2 remove Sanity → SP3 admin panel v2) following the content-standard epic (#359). Git (`solanabr/courses-academy`) is the source of truth for all course content, tags, learning paths, instructors, and achievements; instructor identity is the on-curve `instructor.wallet` (#399). **[AUDIT] Epic gate: #387 (Pinocchio) must be decided before SP2's spec freezes** — recorded here as the epic's sequencing note.
 
 ## Goal
 
@@ -12,69 +12,57 @@ Delete every UI-authoring-era surface whose job moved to git PRs, and reduce `/t
 
 1. **Admin analytics access**: deleted with the role override. Admin-facing analytics is an SP3 screen. No interim hack.
 2. **Viewer scope**: reuse the existing stats route data as-is (per-course enrollments/completions). No new analytics work in SP1.
-3. **Orphan purge**: one-time scripted deletion of legacy non-sync-marked Sanity docs (Solana 101 `aD45H1NEbb1bqELwloGCqI`, `xcvxcv` `ops2aYkxIM6NMo1gE18U1o`, their 3 UUID lessons, old `module` documents). On-chain accounts untouched (CS-4's job).
-4. **Approach**: two staged PRs + one script (Approach B). No feature flags.
-5. **What is NOT touched**: content-sync panel, course-sync-table, achievement-sync-table, flags-panel (moderation), data-resync, sync-diff, status, mismatch-warning — all admin sync/moderation capability survives SP1 unchanged and gets its UX rebuild in SP3.
+3. **Orphan purge**: one-time scripted deletion of legacy non-sync-marked Sanity docs. **[AUDIT]** Verified live: exactly 25 docs (2 legacy courses `aD45H1NEbb1bqELwloGCqI`/`ops2aYkxIM6NMo1gE18U1o`, their 3 UUID lessons, 20 `module` docs) — plus manual-era `courseTag` docs and any `learningPath` without `sync.source` (the deleted panels wrote them; the sync never writes `courseTag`). On-chain accounts untouched (CS-4's job).
+4. **Approach**: two staged PRs + one script. No feature flags.
+5. **What is NOT touched**: content-sync panel, course-sync-table, achievement-sync-table, flags-panel (moderation), data-resync, sync-diff, status, mismatch-warning — all admin sync/moderation capability survives SP1 unchanged and gets its UX rebuild in SP3. **[AUDIT]** One trim: the status route's dead `pendingReviews` stat goes with the review queue.
+6. **[AUDIT] Teach nav visibility**: the header "Teach" item shows only when the signed-in wallet matches an `instructor->wallet` (one cached query) — git-keyed replacement for the old role gate.
 
-## Judgment calls (documented, not user-gated)
+## Security decision **[AUDIT — from #408]**
 
-- `publicAuthoringGate` / `authoringStatus` GROQ gates stay untouched — SP2 deletes them with Sanity wholesale; touching 8 queries now is churn with zero user-visible change. (Live data: 0 pending-review courses, 0 drafts — the gates are inert.)
-- `profiles.role` is consumed ONLY by the teacher routes being deleted (verified by grep; admin panel auth is the separate HMAC `admin_session` cookie). Safe to drop with the surface.
+`profiles.wallet_address` is self-writable via the open own-row UPDATE policy, which would make wallet-match auth spoofable (and already lets an attacker capture Helius XP events today — filed as **#408, P0**). The SP1 migration therefore **replaces** the role write-lock with a `wallet_address` write-lock of identical shape: only `service_role` (the SIWS link routes) may change it. One migration, one concept swapped.
+
+## Corrected findings of record **[AUDIT]**
+
+- `profiles.role` is NOT consumed only by deleted surfaces (rev-1 claim was false). Live consumers: `lib/auth/auth-provider.tsx:35` (`PROFILE_COLUMNS` — selected on **every session**; dropping the column without fixing this logs out the entire app), `components/layout/header.tsx:179` (`canTeach`), `app/[locale]/(platform)/teach/layout.tsx:38-47` (role gate that would brick the new viewer), `lib/supabase/types.ts` (generated types), `supabase/schema.sql` (canonical snapshot). All are now explicit plan tasks; **migration application is additionally gated on PR-2 being deployed**.
+- The 4 admin panels contain **zero i18n** (hardcoded English) — there are no keys to prune in PR-1. The `teacher.*` namespace belongs to the /teach pages and is pruned only in PR-2.
+- There is **no existing i18n parity test**; PR-2 adds a deep-parity test as part of the viewer work.
+- No sign-in-prompt state: `/teach` stays in the middleware `protectedPaths` (unauthenticated → landing redirect, existing behavior). The viewer needs only the two authenticated states (courses list / empty state).
 
 ## PR-1 — "Cut the writers"
 
-**Delete (components, out of `/admin` page + files):**
-- `components/admin/course-review-queue.tsx` (submissions are now PRs on courses-academy: CODEOWNERS + validate-content CI are the review queue)
-- `components/admin/course-tags-panel.tsx` (tags come from `course.yaml`)
-- `components/admin/learning-paths-panel.tsx` (paths come from `paths/*.yaml`)
-- `components/admin/teacher-roles-panel.tsx` (role concept deleted)
-
-**Delete (API routes):**
-- `api/admin/tags`, `api/admin/learning-paths`, `api/admin/teachers`, `api/admin/courses/review`
-- `api/teacher/courses` (CRUD + `[id]` + `[id]/structure` + `[id]/thumbnail`), `api/teacher/upload-image`
-
-**Delete (libs):**
-- `lib/sanity/teacher-mutations.ts`, `lib/sanity/teacher-structure.ts` (verify no other importers), `lib/teacher/authorize.ts`
-
-**Migration (file in PR, application HUMAN-GATED):**
-- Drop `profiles.role` column, the `trg_enforce_profile_role_write` trigger on `profiles` (verified against the live DB) + its function, and any role-referencing policies.
-- Applied via the dbd5cdaf Supabase MCP only after the David-Supabase migration situation is verified stable (rollback to `obqlljsagzslxarwphxv` confirmed + advisors clean). Merge of PR-1 does NOT imply application.
-
-**Ships in PR-1:** `scripts/purge-legacy-sanity-docs.ts` — dry-run by default (`--live` to execute), deletes the enumerated orphan docs + any `_type == "module"` documents; prints exactly what it will delete and refuses if a doc carries `sync.source`.
+- Remove the 4 obsolete panels (`course-review-queue`, `course-tags-panel`, `learning-paths-panel`, `teacher-roles-panel`) from `admin-client.tsx` **including their orphaned residue** (the `PendingReviewCourse` import, `AdminStatus.pendingReviews`, the Review Queue section chrome) and the `pendingReviews` computation + `getPendingReviewCourses` in the status route/queries.
+- Delete API routes: `admin/tags`, `admin/learning-paths`, `admin/teachers`, `admin/courses/review`, `teacher/courses` CRUD + `structure` + `thumbnail` + `upload-image`.
+- Delete `lib/teacher/validate.ts` (importers verified: only the routes above). **`lib/sanity/teacher-mutations.ts` and `teacher-structure.ts` are PR-2 deletions** — the surviving stats route and /teach pages import them.
+- Migration `supabase/migrations/20260710120000_drop_teacher_role.sql` (14-digit convention): drop `trg_enforce_profile_role_write` + `public.enforce_profile_role_write()` + `profiles.role` (live-verified: zero role-referencing policies), **and create the `wallet_address` write-lock trigger** (#408). Irreversible by design (comment says so); pre-apply snapshot of non-learner roles goes in the PR body. **Application human-gated on: PR-2 deployed + Supabase stability confirmed.**
+- Purge script `scripts/purge-legacy-sanity-docs.ts`, dry-run default. **[AUDIT fixes]**: guard uses `!= null` (GROQ returns `null`, never `undefined` — the rev-1 guard refused everything); client pins `perspective: "raw"` in BOTH modes with the token required even for dry-run (tokenless dry-run vs tokened live see different draft sets); deletes `drafts.<id>` counterparts; adds `courseTag` + unsynced-`learningPath` clauses; `--live` asserts its target count equals the dry-run count passed via `--expect N`.
 
 ## PR-2 — "Replace the reader"
 
-**Delete:** the 5 `/teach` pages (`teach/page`, `teach/courses`, `teach/courses/new`, `teach/courses/[id]`, `teach/courses/[id]/edit`) and their client components.
-
-**Add:** one read-only `/[locale]/(platform)/teach/page.tsx`:
-- Server component. SIWS session wallet → GROQ `*[_type == "instructor" && wallet == $wallet]` → courses via `course.instructor->wallet` match.
-- Renders course cards with per-course expandable stats (existing stats payload). No separate detail pages.
-- States: no wallet session → sign-in prompt; wallet matches no instructor → empty state ("no courses assigned to this wallet — instructors are defined in courses-academy").
-- All strings next-intl, en/pt-BR/es parity.
-
-**Rewire:** the stats route's auth from `role`/`course.author` to wallet-match (`course.instructor->wallet == caller wallet`). Non-matching wallet → 403. The dead `course.author` dependency goes with it.
+- Delete the `/teach/courses/` tree **and `components/teacher/`** (course-form, course-structure-editor, markdown-field, thumbnail-picker — they live outside the tree and would be stranded), **and `teach/layout.tsx`** (its role gate would brick the viewer; the platform layout provides chrome).
+- New read-only `/teach` page: SIWS session wallet → `getInstructorCourses(wallet)` (live-verified: returns exactly the 6 courses for the owner wallet) → course cards with expandable stats. Two states: courses / empty. i18n en/pt-BR/es + **new deep-parity test** (recursive key-structure comparison across the 3 files).
+- Stats route rewire: session wallet vs `instructor->wallet` (revalidate 0), 401 no session / 403 mismatch / no fallback. Then delete `authorize.ts`, `teacher-mutations.ts`, `teacher-structure.ts`, `getCourseAuthorship`.
+- Header: `canTeach` = cached instructor-wallet lookup (decision 6). `PROFILE_COLUMNS` drops `role`.
+- Dead-code sweep: `getManagedCourseTags`, admin-mutations orphans (`createCourseTag`, `deleteCourseTag`, `setLearningPathCourses`, `approveCourse`, `rejectCourse`) + tests, `packages/types` `UserRole`/`UserProfile.role`/course `author`+teacher-feedback fields, `lib/supabase/types.ts` role entries (hand-edit the generated file; regen against the post-migration DB later).
 
 ## Sequencing & gates
 
-1. PR-1 → both review gates → merge (SAFE lane unless migration content triggers SENSITIVE — the migration FILE makes it `supabase/**`-adjacent, so treat PR-1 as SENSITIVE: adversarial review + owner sign-off).
-2. PR-2 → both gates → merge (SAFE lane).
-3. Migration application: separate human-gated step, only after Supabase stability is verified.
-4. Purge script: dry-run → owner eyeballs the list → `--live` run → verify with a Sanity count query.
-
-Between PR-1 and PR-2 the old /teach pages render but cannot write — acceptable interim on a mock-content platform.
+1. PR-1 (SENSITIVE — migration file): both gates + independent adversarial review + owner sign-off. Merge ≠ apply.
+2. PR-2 (SAFE): both gates. Deletes every remaining `role` read.
+3. **Migration application** (human-gated): only after PR-2 is deployed to prod AND Supabase stability is confirmed (rollback to `obqlljsagzslxarwphxv` verified + advisors clean). Verify link-wallet flow still works post-trigger (SIWS routes are service-role — live-verified all 11 profiles carry wallet_address).
+4. Purge: tokened dry-run → owner eyeballs the list (expect the 25 legacy docs + any courseTag/stray-path docs) → `--live --expect N` → verify counts relative to pre-purge (no hardcoded absolutes).
 
 ## Testing & verification
 
-- Suites minus deleted surfaces stay green; `tsc` clean; i18n keys for deleted screens pruned from all 3 locale files (parity check).
-- New tests: viewer wallet-match query, both empty states, stats-route wallet auth (matching wallet 200, non-matching 403, no session 401).
-- End-to-end: viewer rendered against live data with the owner wallet `B7o8NfV81HzjuZFWQTTx3Xdvh77Dqoajwib3kWEnvzJF` (owns all 4 mock instructors — every course should appear).
+- Suites minus deleted surfaces green; `tsc` clean; new tests: viewer query, both viewer states, stats auth (200/403/401), i18n deep parity.
+- E2E after everything: owner wallet `B7o8NfV81HzjuZFWQTTx3Xdvh77Dqoajwib3kWEnvzJF` signs in → header shows Teach → all 6 courses with stats; a non-instructor wallet → no Teach item; direct /teach → empty state.
 
 ## Explicitly out of scope
 
-- Admin panel restructure/nav (SP3). Sanity removal, `authoringStatus` gate cleanup, onChainStatus relocation (SP2). CS-4 devnet cutover and #400/#401/#402 (tracked separately; #400 resolves in SP3). Any mainnet action.
+Admin panel restructure/nav (SP3). Sanity removal, `authoringStatus` gate cleanup, onChainStatus relocation (SP2). CS-4 and #400/#401/#402 (#400 → SP3; #401/#402 → pre-CS-4). Any mainnet action. Helius-side hardening beyond the #408 trigger (the trigger closes the write path; event-handler defense-in-depth can ride SP2/SP3).
 
-## Issue remapping
+## Issue remapping **[AUDIT-corrected]**
 
-- #263/#264/#265 (teacher-courses epic): superseded by SP1 — close with pointers to this spec on PR-2 merge.
-- #398 (creator attribution): already resolved by #399; verify closed.
-- #400 → SP3. #401/#402 → pre-CS-4 checklist. #404/#405/#406: independent, already handled.
+- #263/#264/#265: already CLOSED — post spec pointers on PR-2 merge, no state change.
+- #398: fixed by #399 (verified in code) — close it now.
+- #408 (NEW, P0): wallet_address write-lock — fixed by this migration.
+- #400 → SP3. #401/#402 → pre-CS-4 checklist.

--- a/docs/superpowers/specs/2026-07-10-sp1-retire-teacher-authoring-design.md
+++ b/docs/superpowers/specs/2026-07-10-sp1-retire-teacher-authoring-design.md
@@ -1,0 +1,80 @@
+# SP1 — Retire the Teacher-Authoring Era (Design)
+
+**Date:** 2026-07-10
+**Status:** Approved by owner (in-session)
+**Epic context:** First of three sub-projects (SP1 retire teacher-authoring → SP2 remove Sanity → SP3 admin panel v2) following the content-standard epic (#359). Git (`solanabr/courses-academy`) is the source of truth for all course content, tags, learning paths, instructors, and achievements; instructor identity is the on-curve `instructor.wallet` (#399).
+
+## Goal
+
+Delete every UI-authoring-era surface whose job moved to git PRs, and reduce `/teach` to a read-only, wallet-keyed analytics viewer. After SP1, nothing writes course structure outside the git→Sanity sync, and the "teacher role" concept no longer exists — an instructor IS a wallet declared in content.
+
+## Owner decisions (locked)
+
+1. **Admin analytics access**: deleted with the role override. Admin-facing analytics is an SP3 screen. No interim hack.
+2. **Viewer scope**: reuse the existing stats route data as-is (per-course enrollments/completions). No new analytics work in SP1.
+3. **Orphan purge**: one-time scripted deletion of legacy non-sync-marked Sanity docs (Solana 101 `aD45H1NEbb1bqELwloGCqI`, `xcvxcv` `ops2aYkxIM6NMo1gE18U1o`, their 3 UUID lessons, old `module` documents). On-chain accounts untouched (CS-4's job).
+4. **Approach**: two staged PRs + one script (Approach B). No feature flags.
+5. **What is NOT touched**: content-sync panel, course-sync-table, achievement-sync-table, flags-panel (moderation), data-resync, sync-diff, status, mismatch-warning — all admin sync/moderation capability survives SP1 unchanged and gets its UX rebuild in SP3.
+
+## Judgment calls (documented, not user-gated)
+
+- `publicAuthoringGate` / `authoringStatus` GROQ gates stay untouched — SP2 deletes them with Sanity wholesale; touching 8 queries now is churn with zero user-visible change. (Live data: 0 pending-review courses, 0 drafts — the gates are inert.)
+- `profiles.role` is consumed ONLY by the teacher routes being deleted (verified by grep; admin panel auth is the separate HMAC `admin_session` cookie). Safe to drop with the surface.
+
+## PR-1 — "Cut the writers"
+
+**Delete (components, out of `/admin` page + files):**
+- `components/admin/course-review-queue.tsx` (submissions are now PRs on courses-academy: CODEOWNERS + validate-content CI are the review queue)
+- `components/admin/course-tags-panel.tsx` (tags come from `course.yaml`)
+- `components/admin/learning-paths-panel.tsx` (paths come from `paths/*.yaml`)
+- `components/admin/teacher-roles-panel.tsx` (role concept deleted)
+
+**Delete (API routes):**
+- `api/admin/tags`, `api/admin/learning-paths`, `api/admin/teachers`, `api/admin/courses/review`
+- `api/teacher/courses` (CRUD + `[id]` + `[id]/structure` + `[id]/thumbnail`), `api/teacher/upload-image`
+
+**Delete (libs):**
+- `lib/sanity/teacher-mutations.ts`, `lib/sanity/teacher-structure.ts` (verify no other importers), `lib/teacher/authorize.ts`
+
+**Migration (file in PR, application HUMAN-GATED):**
+- Drop `profiles.role` column, the `trg_enforce_profile_role_write` trigger on `profiles` (verified against the live DB) + its function, and any role-referencing policies.
+- Applied via the dbd5cdaf Supabase MCP only after the David-Supabase migration situation is verified stable (rollback to `obqlljsagzslxarwphxv` confirmed + advisors clean). Merge of PR-1 does NOT imply application.
+
+**Ships in PR-1:** `scripts/purge-legacy-sanity-docs.ts` — dry-run by default (`--live` to execute), deletes the enumerated orphan docs + any `_type == "module"` documents; prints exactly what it will delete and refuses if a doc carries `sync.source`.
+
+## PR-2 — "Replace the reader"
+
+**Delete:** the 5 `/teach` pages (`teach/page`, `teach/courses`, `teach/courses/new`, `teach/courses/[id]`, `teach/courses/[id]/edit`) and their client components.
+
+**Add:** one read-only `/[locale]/(platform)/teach/page.tsx`:
+- Server component. SIWS session wallet → GROQ `*[_type == "instructor" && wallet == $wallet]` → courses via `course.instructor->wallet` match.
+- Renders course cards with per-course expandable stats (existing stats payload). No separate detail pages.
+- States: no wallet session → sign-in prompt; wallet matches no instructor → empty state ("no courses assigned to this wallet — instructors are defined in courses-academy").
+- All strings next-intl, en/pt-BR/es parity.
+
+**Rewire:** the stats route's auth from `role`/`course.author` to wallet-match (`course.instructor->wallet == caller wallet`). Non-matching wallet → 403. The dead `course.author` dependency goes with it.
+
+## Sequencing & gates
+
+1. PR-1 → both review gates → merge (SAFE lane unless migration content triggers SENSITIVE — the migration FILE makes it `supabase/**`-adjacent, so treat PR-1 as SENSITIVE: adversarial review + owner sign-off).
+2. PR-2 → both gates → merge (SAFE lane).
+3. Migration application: separate human-gated step, only after Supabase stability is verified.
+4. Purge script: dry-run → owner eyeballs the list → `--live` run → verify with a Sanity count query.
+
+Between PR-1 and PR-2 the old /teach pages render but cannot write — acceptable interim on a mock-content platform.
+
+## Testing & verification
+
+- Suites minus deleted surfaces stay green; `tsc` clean; i18n keys for deleted screens pruned from all 3 locale files (parity check).
+- New tests: viewer wallet-match query, both empty states, stats-route wallet auth (matching wallet 200, non-matching 403, no session 401).
+- End-to-end: viewer rendered against live data with the owner wallet `B7o8NfV81HzjuZFWQTTx3Xdvh77Dqoajwib3kWEnvzJF` (owns all 4 mock instructors — every course should appear).
+
+## Explicitly out of scope
+
+- Admin panel restructure/nav (SP3). Sanity removal, `authoringStatus` gate cleanup, onChainStatus relocation (SP2). CS-4 devnet cutover and #400/#401/#402 (tracked separately; #400 resolves in SP3). Any mainnet action.
+
+## Issue remapping
+
+- #263/#264/#265 (teacher-courses epic): superseded by SP1 — close with pointers to this spec on PR-2 merge.
+- #398 (creator attribution): already resolved by #399; verify closed.
+- #400 → SP3. #401/#402 → pre-CS-4 checklist. #404/#405/#406: independent, already handled.


### PR DESCRIPTION
Approved-in-session design for SP1 of the post-content-standard epic (SP1 retire teacher-authoring → SP2 remove Sanity → SP3 admin panel v2).

Two staged PRs + one purge script; profiles.role drop migration written-but-human-gated; /teach becomes a read-only wallet-keyed analytics viewer; 4 obsolete admin panels deleted (all sync/moderation panels untouched — SP3 rebuilds their UX). Trigger name verified against live DB.

Docs-only. Refs #359