### PR TITLE
fix(csp): allow GitHub avatar host (GitHub-OAuth users had no picture)

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -39,7 +39,7 @@ const cspDirectives = [
   // Studio media library, GA4 measurement pixel (doubleclick). data:/blob:
   // cover inline SVGs, canvas-confetti, and wallet QR codes. Supabase stays a
   // wildcard here (Studio/API fallback); the app's middleware CSP pins it.
-  "img-src 'self' data: blob: https://cdn.sanity.io https://media.sanity.io https://lh3.googleusercontent.com https://arweave.net https://*.arweave.net https://*.supabase.co https://stats.g.doubleclick.net",
+  "img-src 'self' data: blob: https://cdn.sanity.io https://media.sanity.io https://lh3.googleusercontent.com https://avatars.githubusercontent.com https://arweave.net https://*.arweave.net https://*.supabase.co https://stats.g.doubleclick.net",
 
   // Network: Supabase (REST + realtime wss), Sanity (CDN/API + listen wss),
   // Solana/Helius RPC, Google OAuth/identity, and analytics (GA4, PostHog,
@@ -132,6 +132,7 @@ const nextConfig = {
     remotePatterns: [
       { protocol: "https", hostname: "cdn.sanity.io" },
       { protocol: "https", hostname: "lh3.googleusercontent.com" },
+      { protocol: "https", hostname: "avatars.githubusercontent.com" },
       { protocol: "https", hostname: "arweave.net" },
       { protocol: "https", hostname: "*.supabase.co" },
     ],

--- a/apps/web/src/lib/csp.ts
+++ b/apps/web/src/lib/csp.ts
@@ -118,7 +118,7 @@ export function buildCsp(nonce: string): string {
     [
       "img-src 'self' data: blob:",
       "https://cdn.sanity.io https://media.sanity.io",
-      "https://lh3.googleusercontent.com",
+      "https://lh3.googleusercontent.com https://avatars.githubusercontent.com",
       "https://arweave.net https://*.arweave.net",
       supabase.http,
       "https://stats.g.doubleclick.net",


### PR DESCRIPTION
## Bug
Logging in with **GitHub** shows **no profile picture** (Google login shows one). GitHub-and-Google with the same email are linked into one Supabase account, and when the avatar becomes the GitHub URL (`https://avatars.githubusercontent.com/...`) the browser blocks it.

## Cause
`img-src` (and `next/image` `remotePatterns`) allowed **`lh3.googleusercontent.com`** (Google) but **not `avatars.githubusercontent.com`** (GitHub) — so the GitHub avatar is CSP-blocked / rejected by the image optimizer.

## Fix
Add `https://avatars.githubusercontent.com` to:
- `img-src` in `lib/csp.ts` (the enforcing CSP) and the `next.config.mjs` static fallback
- `images.remotePatterns` in `next.config.mjs`

## Note (not a bug)
The **shared username** across Google/GitHub is Supabase's automatic email-based identity linking — one person, one account. Intended behavior.

## Verification
- eslint ✓; grep-confirmed the host is in both `img-src` and `remotePatterns`.
