### PR TITLE
docs: fix CLAUDE.md + docs drift after content-standard epic and SP1

### DIFF
--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -35,13 +35,9 @@ The middleware (`src/middleware.ts`) chains two concerns:
 **Level formula**: `Level = floor(sqrt(totalXP / 100))`
 **Server-side cap**: max 100 XP per lesson completion, max 2000 XP per generic award
 
-### Achievements (14 total)
+### Achievements
 
-- **Progress**: First Steps, Course Completer
-- **Streaks**: Week Warrior (7d), Monthly Master (30d), Consistency King (100d)
-- **Skills**: Rust Rookie, Anchor Expert, Full Stack Solana
-- **Community**: Helper, First Comment, Top Contributor
-- **Special**: Early Adopter, Bug Hunter, Perfect Score
+The curated set (currently 10) lives in `solanabr/courses-academy` under `achievements/` — git is the source of truth; do not enumerate them here. Unlock logic maps full Sanity `_id`s in `UNLOCK_CHECKS` (`lib/achievements.ts`).
 
 ## Environment Variables
 
@@ -70,11 +66,12 @@ NEXT_PUBLIC_XP_MINT_ADDRESS=       # XP mint pubkey (from initialize.ts output)
 ADMIN_SECRET=                      # Admin panel authentication secret (HMAC-signed cookies)
 BUILD_SERVER_URL=                  # Cloud Run build server URL (server-only, proxied via /api)
 BUILD_SERVER_API_KEY=              # Build server authentication key
-GITHUB_TOKEN=                      # Fine-grained READ token for solanabr/academy-courses
-                                   # (server-only). Powers POST /api/admin/content/sync (tarball
-                                   # fetch), the drift UI (HEAD polling), and the Checks API
-                                   # (blocked state). Unauthenticated GitHub is 60 req/hr per IP
-                                   # and flakes on Vercel; unset → the /api/admin/content/* routes 503.
+GITHUB_TOKEN=                      # Fine-grained READ token for solanabr/courses-academy (public repo,
+                                   # but the token is still required — unauthenticated GitHub is
+                                   # 60 req/hr per IP and flakes on Vercel). Server-only. Powers
+                                   # POST /api/admin/content/sync (tarball fetch), the drift UI
+                                   # (HEAD polling), and the Checks API (blocked state);
+                                   # unset → the /api/admin/content/* routes 503.
 HELIUS_API_KEY=                    # Helius key for webhook management + DAS API (lib/helius)
 HELIUS_WEBHOOK_SECRET=             # Helius webhook signature verification
 BACKEND_SIGNER_SECRET=             # Rotatable backend co-signer keypair (completeLesson etc.)

--- a/apps/web/src/app/api/CLAUDE.md
+++ b/apps/web/src/app/api/CLAUDE.md
@@ -63,7 +63,7 @@
 | `/api/admin/courses/reactivate` | POST   | ADMIN_SECRET | Set course `is_active = true`                                                   |
 | `/api/admin/achievements/sync`  | POST   | ADMIN_SECRET | Deploy achievement type + collection on-chain                                   |
 | `/api/admin/resync`             | POST   | ADMIN_SECRET | Resync on-chain state to Supabase                                               |
-| `/api/admin/content/sync`       | POST   | ADMIN_SECRET | Sync academy-courses@sha → Sanity (re-validate, PRESERVE, prune, content_tx_id) |
+| `/api/admin/content/sync`       | POST   | ADMIN_SECRET | Sync courses-academy@sha → Sanity (re-validate, PRESERVE, prune, content_tx_id) |
 | `/api/admin/content/drift`      | GET    | ADMIN_SECRET | Three-way drift: content (repo→Sanity) + chain (Sanity→devnet)                  |
 
 ## Route Conventions

--- a/docs/ADMIN.md
+++ b/docs/ADMIN.md
@@ -18,7 +18,7 @@ The admin panel is available at `/{locale}/admin` (e.g., `/en/admin`).
 | `PROGRAM_AUTHORITY_SECRET` | Base58 private key of the keypair that is authority on the on-chain `Config` PDA.                                                                                                               |
 | `BACKEND_SIGNER_SECRET`    | Base58 private key of the backend signer registered in `Config.backend_signer`. Used to sign on-chain transactions from API routes.                                                             |
 | `SANITY_ADMIN_TOKEN`       | Sanity write token from [sanity.io/manage](https://sanity.io/manage). Required to sync `onChainStatus` back to Sanity after deploying a course.                                                 |
-| `GITHUB_TOKEN`             | Fine-grained **read** token for `solanabr/academy-courses`. Required by the Content Sync panel (tarball fetch, HEAD polling, Checks API). Unset → the `/api/admin/content/*` routes return 503. |
+| `GITHUB_TOKEN`             | Fine-grained **read** token for `solanabr/courses-academy`. Required by the Content Sync panel (tarball fetch, HEAD polling, Checks API). Unset → the `/api/admin/content/*` routes return 503. |
 
 ## Course Sync Workflow
 
@@ -67,7 +67,7 @@ Both routes require `ADMIN_SECRET` in the Authorization header.
 
 ### Content Sync (repo → Sanity → devnet)
 
-The **Content Sync** panel ingests the `solanabr/academy-courses` repository into Sanity at a chosen commit and then commits the content hash on-chain. It is **always admin-triggered from the panel — never automatic.**
+The **Content Sync** panel ingests the `solanabr/courses-academy` repository into Sanity at a chosen commit and then commits the content hash on-chain. It is **always admin-triggered from the panel — never automatic.**
 
 **Content drift** (repo → Sanity), shown as a banner:
 

--- a/docs/CMS_GUIDE.md
+++ b/docs/CMS_GUIDE.md
@@ -2,7 +2,7 @@
 
 # CMS Guide
 
-Guide for managing course content in Sanity CMS for Superteam Academy (`solarium.courses`), a Solana developer education platform.
+Guide for managing course content in Sanity CMS for Superteam Academy (`superteam-academy-web.vercel.app`), a Solana developer education platform.
 
 ## Overview
 
@@ -228,12 +228,14 @@ Unlock logic is defined in `apps/web/src/lib/gamification/achievements.ts` in th
 ### Step-by-Step
 
 1. **Create the Instructor** (if not already existing):
+
    - Go to the "Instructor" section in Studio
    - Click "Create new"
    - Fill in: name (required), avatar, bio, social links (twitter, github)
    - Publish
 
 2. **Create the Lessons**:
+
    - Go to the "Lesson" section
    - For each lesson, create a new document:
      - Set the title and let the slug auto-generate
@@ -246,6 +248,7 @@ Unlock logic is defined in `apps/web/src/lib/gamification/achievements.ts` in th
    - Publish each lesson
 
 3. **Create the Modules**:
+
    - Go to the "Module" section
    - Create a module for each logical section of the course
    - Add lesson references in the correct order
@@ -253,6 +256,7 @@ Unlock logic is defined in `apps/web/src/lib/gamification/achievements.ts` in th
    - Publish
 
 4. **Create the Course**:
+
    - Go to the "Course" section
    - Fill in: title (required), slug (auto-generated), description, difficulty (required), duration (required)
    - Upload a thumbnail image (recommended 16:9 aspect ratio)
@@ -266,6 +270,7 @@ Unlock logic is defined in `apps/web/src/lib/gamification/achievements.ts` in th
    - Publish
 
 5. **Deploy on-chain** (see [Publishing Workflow](#publishing-workflow)):
+
    - Go to the admin panel
    - Deploy the course and create its track collection
    - The course becomes visible to students once sync completes
@@ -434,11 +439,11 @@ The script:
 
 ### Environment-Specific Datasets
 
-| Environment | Dataset                                    | Purpose                         |
-| ----------- | ------------------------------------------ | ------------------------------- |
-| Development | `production` (or `development` if created) | Local development and testing   |
-| Staging     | `production`                               | Preview deployments on Vercel   |
-| Production  | `production`                               | Live site at `solarium.courses` |
+| Environment | Dataset                                    | Purpose                                         |
+| ----------- | ------------------------------------------ | ----------------------------------------------- |
+| Development | `production` (or `development` if created) | Local development and testing                   |
+| Staging     | `production`                               | Preview deployments on Vercel                   |
+| Production  | `production`                               | Live site at `superteam-academy-web.vercel.app` |
 
 You can create a separate `development` dataset in Sanity for testing content changes without affecting production. Update the `NEXT_PUBLIC_SANITY_DATASET` and `SANITY_STUDIO_DATASET` environment variables accordingly.
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -58,7 +58,7 @@ Add all environment variables in **Vercel → Project → Settings → Environme
 | `NEXT_PUBLIC_SANITY_DATASET`    | Public          | Usually `production`                                                                                                  |
 | `NEXT_PUBLIC_SOLANA_RPC_URL`    | Public          | `https://api.devnet.solana.com`                                                                                       |
 | `NEXT_PUBLIC_SOLANA_NETWORK`    | Public          | `devnet`                                                                                                              |
-| `NEXT_PUBLIC_APP_URL`           | Public          | Your Vercel URL (e.g., `https://solarium.courses`)                                                                    |
+| `NEXT_PUBLIC_APP_URL`           | Public          | Your Vercel URL (e.g., `https://superteam-academy-web.vercel.app`)                                                    |
 | `NEXT_PUBLIC_PROGRAM_ID`        | Public          | Program ID from `anchor deploy` (see [DEPLOY-PROGRAM.md](./DEPLOY-PROGRAM.md))                                        |
 | `NEXT_PUBLIC_XP_MINT_ADDRESS`   | Public          | XP mint pubkey from `initialize.ts` output                                                                            |
 | `BUILD_SERVER_URL`              | **Server-only** | Cloud Run service URL (e.g., `https://academy-build-server-HASH.a.run.app`)                                           |
@@ -73,18 +73,18 @@ Add all environment variables in **Vercel → Project → Settings → Environme
 
 #### Optional Variables
 
-| Variable                         | Type            | Notes                                                                                                                                                                                                                                                                                                                       |
-| -------------------------------- | --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `RUST_PLAYGROUND_URL`            | **Server-only** | `/api/rust/execute` upstream (default: play.rust-lang.org)                                                                                                                                                                                                                                                                  |
-| `GITHUB_TOKEN`                   | **Server-only** | Fine-grained **read** token for `solanabr/academy-courses`. Powers `POST /api/admin/content/sync` (tarball fetch), the drift UI (HEAD polling), and the Checks API (`blocked` state). Unauthenticated GitHub is 60 req/hr per IP and flakes on Vercel's shared egress; unset → the `/api/admin/content/*` routes return 503 |
-| `NEXT_PUBLIC_GA4_MEASUREMENT_ID` | Public          | Google Analytics 4                                                                                                                                                                                                                                                                                                          |
-| `NEXT_PUBLIC_POSTHOG_KEY`        | Public          | PostHog project key                                                                                                                                                                                                                                                                                                         |
-| `NEXT_PUBLIC_POSTHOG_HOST`       | Public          | PostHog instance URL                                                                                                                                                                                                                                                                                                        |
-| `NEXT_PUBLIC_SENTRY_DSN`         | Public          | Sentry error tracking (DSN is safe to expose)                                                                                                                                                                                                                                                                               |
+| Variable                         | Type            | Notes                                                                                                                                                                                                                                                                                                                                                                                             |
+| -------------------------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `RUST_PLAYGROUND_URL`            | **Server-only** | `/api/rust/execute` upstream (default: play.rust-lang.org)                                                                                                                                                                                                                                                                                                                                        |
+| `GITHUB_TOKEN`                   | **Server-only** | Fine-grained **read** token for `solanabr/courses-academy` (the repo is public, but the token is still required for rate limits). Powers `POST /api/admin/content/sync` (tarball fetch), the drift UI (HEAD polling), and the Checks API (`blocked` state). Unauthenticated GitHub is 60 req/hr per IP and flakes on Vercel's shared egress; unset → the `/api/admin/content/*` routes return 503 |
+| `NEXT_PUBLIC_GA4_MEASUREMENT_ID` | Public          | Google Analytics 4                                                                                                                                                                                                                                                                                                                                                                                |
+| `NEXT_PUBLIC_POSTHOG_KEY`        | Public          | PostHog project key                                                                                                                                                                                                                                                                                                                                                                               |
+| `NEXT_PUBLIC_POSTHOG_HOST`       | Public          | PostHog instance URL                                                                                                                                                                                                                                                                                                                                                                              |
+| `NEXT_PUBLIC_SENTRY_DSN`         | Public          | Sentry error tracking (DSN is safe to expose)                                                                                                                                                                                                                                                                                                                                                     |
 
 > **Tip**: Variables prefixed with `NEXT_PUBLIC_` are bundled into the client-side JavaScript bundle. All others are server-only and only accessible in API routes and server components.
 
-> **Content sync (CS-9) secrets**: The Sanity dataset is **public** (read path uses no browser token). `SANITY_ADMIN_TOKEN` is held only by the content-sync job and `admin-mutations.ts` — it never belongs in GitHub Actions. `GITHUB_TOKEN` is a read-only token for the `academy-courses` repo, used server-side by the content-sync + drift routes; it carries no write scope.
+> **Content sync (CS-9) secrets**: The Sanity dataset is **public** (read path uses no browser token). `SANITY_ADMIN_TOKEN` is held only by the content-sync job and `admin-mutations.ts` — it never belongs in GitHub Actions. `GITHUB_TOKEN` is a read-only token for the `courses-academy` repo, used server-side by the content-sync + drift routes; it carries no write scope.
 
 ### 4. Deploy
 
@@ -142,8 +142,8 @@ The schema includes:
 ### 2. Auth Redirect URLs
 
 1. Go to **Authentication** → **URL Configuration**
-2. Set **Site URL** to your production URL: `https://solarium.courses`
-3. Add to **Redirect URLs**: `https://solarium.courses/api/auth/callback`
+2. Set **Site URL** to your production URL: `https://superteam-academy-web.vercel.app`
+3. Add to **Redirect URLs**: `https://superteam-academy-web.vercel.app/api/auth/callback`
 
 ### 3. Enable Google OAuth Provider
 
@@ -187,7 +187,7 @@ Supabase automatically creates daily backups on paid plans. On the free tier:
 ### 2. CORS Origins
 
 1. Navigate to **API** → **CORS Origins**
-2. Add your production domain: `https://solarium.courses`
+2. Add your production domain: `https://superteam-academy-web.vercel.app`
 3. Check **Allow credentials**
 4. Also add `http://localhost:3000` for local development
 
@@ -321,7 +321,7 @@ openssl rand -hex 32
 
 ```bash
 export ACADEMY_API_KEY=<your-generated-api-key>
-export ALLOWED_ORIGIN=https://solarium.courses
+export ALLOWED_ORIGIN=https://superteam-academy-web.vercel.app
 
 cd apps/build-server/deploy
 ./deploy.sh <PROJECT_ID> [REGION] [TAG]
@@ -440,14 +440,14 @@ Sign up at [sentry.io](https://sentry.io).
 ### 1. Add Domain in Vercel
 
 1. Go to **Vercel → Project → Settings → Domains**
-2. Add your custom domain (e.g., `solarium.courses`)
+2. Add your custom domain (e.g., `academy.example.com`)
 3. Follow Vercel's DNS instructions (add CNAME or A records)
 
 ### 2. Update Environment Variables
 
-| Variable              | New Value                  |
-| --------------------- | -------------------------- |
-| `NEXT_PUBLIC_APP_URL` | `https://solarium.courses` |
+| Variable              | New Value                     |
+| --------------------- | ----------------------------- |
+| `NEXT_PUBLIC_APP_URL` | `https://academy.example.com` |
 
 ### 3. Update External Services
 


### PR DESCRIPTION
## Summary

Docs-only cleanup of drift left behind by the content-standard epic (#359) and SP1, folding in the stale-prod-host landmine from #371.

- **apps/web/CLAUDE.md** — the "Achievements (14 total)" enumeration (Perfect Score, Helper, First Comment, Top Contributor, …) is gone; the section now points at `solanabr/courses-academy/achievements` as the source of truth (currently 10, curated in git) instead of hardcoding a list that will drift again.
- **Repo rename** `solanabr/academy-courses` → `solanabr/courses-academy` in all living docs: apps/web/CLAUDE.md (`GITHUB_TOKEN`), apps/web/src/app/api/CLAUDE.md (content-sync route table), docs/ADMIN.md, docs/DEPLOYMENT.md. Noted the repo is now public but the read token is still required (unauthenticated GitHub = 60 req/hr per IP, flakes on Vercel).
- **#371 landmine** — `solarium.courses` no longer asserted as prod anywhere: docs/CMS_GUIDE.md (2×) and docs/DEPLOYMENT.md (6×) now use `superteam-academy-web.vercel.app`; the generic custom-domain walkthrough uses a neutral `academy.example.com`. Remaining `solarium` hits in docs/ are only SECRET-ROTATION.md's existing correction note and historical spec text — exactly #371's done-when.
- **Audited clean** — root CLAUDE.md and docs/ARCHITECTURE.md contain no teacher-role or stale-repo references (SP1 already scrubbed them); no changes needed there. Historical specs/plans under `docs/superpowers/` intentionally untouched.

Refs #359
Closes #371

## Verification

`grep -rn -i 'solarium|academy-courses'` over the living docs (CLAUDE.md files, ADMIN, DEPLOYMENT, CMS_GUIDE, ARCHITECTURE) returns zero hits. Prettier 3 applied to all touched files.