### PR TITLE
feat(content-schema): optional course thumbnail path (SP2 prereq)

### DIFF
--- a/packages/content-schema/schema/course.schema.json
+++ b/packages/content-schema/schema/course.schema.json
@@ -75,6 +75,10 @@
       "type": "string",
       "pattern": "^instructor-[a-z0-9]+(?:-[a-z0-9]+)*$"
     },
+    "thumbnail": {
+      "type": "string",
+      "minLength": 1
+    },
     "prerequisiteCourse": {
       "type": "string",
       "pattern": "^course-[a-z0-9]+(?:-[a-z0-9]+)*$"

--- a/packages/content-schema/src/__tests__/course.test.ts
+++ b/packages/content-schema/src/__tests__/course.test.ts
@@ -19,6 +19,14 @@ describe("Course", () => {
     expect(Course.parse(base).modules[0]!.key).toBe("basics");
   });
 
+  it("accepts an optional thumbnail path and rejects an empty one", () => {
+    expect(
+      Course.parse({ ...base, thumbnail: "assets/thumbnail.png" }).thumbnail
+    ).toBe("assets/thumbnail.png");
+    expect(Course.parse(base).thumbnail).toBeUndefined();
+    expect(Course.safeParse({ ...base, thumbnail: "" }).success).toBe(false);
+  });
+
   it("enforces the on-chain xpPerLesson range", () => {
     expect(Course.safeParse({ ...base, xpPerLesson: 0 }).success).toBe(false);
     expect(Course.safeParse({ ...base, xpPerLesson: 101 }).success).toBe(false);

--- a/packages/content-schema/src/course.ts
+++ b/packages/content-schema/src/course.ts
@@ -41,6 +41,13 @@ export const Course = z
      * creator and is rejected by the sync (no platform-authority fallback).
      */
     instructor: InstructorId.optional(),
+    /**
+     * Repo-relative path to the course's catalogue thumbnail (e.g.
+     * `assets/thumbnail.png`), resolved against the course folder. Optional in
+     * the schema; the compiler verifies the file exists when set (SP2 — images
+     * are git-sourced, no external image host).
+     */
+    thumbnail: z.string().min(1).optional(),
     prerequisiteCourse: CourseId.optional(),
     modules: z.array(CourseModule).min(1),
   })


### PR DESCRIPTION
First slice of SP2 (spec: #415, rev 2 decision 2 — images live in courses-academy git).

Adds `thumbnail: z.string().min(1).optional()` to `Course` — a repo-relative path (e.g. `assets/thumbnail.png`) resolved against the course folder. The SP2-A compiler will verify the file exists; the schema stays permissive (optional) so existing content validates unchanged.

- Regenerated `course.schema.json` (byte-parity test enforces it)
- Test: accepts a path, stays optional, rejects empty string
- Behavior-neutral for the app: nothing reads `thumbnail` from the repo yet (Sanity thumbnails still serve until SP2-B/C)

Unblocks the courses-academy content PR that commits the 6 Studio-authored thumbnails + updates its vendored `schema/course.schema.json` (its CI validates against this repo's main, so this merges first).