### PR TITLE
docs(plans): SP2-B onchain-status flip + SP3-A admin nav shell

### DIFF
--- a/docs/superpowers/plans/2026-07-11-sp2b-onchain-status-flip.md
+++ b/docs/superpowers/plans/2026-07-11-sp2b-onchain-status-flip.md
@@ -1,0 +1,119 @@
+# SP2-B — Relocate onChainStatus + Flip the Reads (Implementation Plan)
+
+**Date:** 2026-07-11 · **Spec:** `docs/superpowers/specs/2026-07-10-sp2-remove-sanity-design.md` (rev 2.1), SP2-B section
+**Lane:** SENSITIVE (Supabase migration + one-cut read/write flip; main auto-deploys)
+**Prereqs:** SP2-A merged (compiler, committed bundle at `src/content/generated/`, `lib/content/store.ts` + `build-store.ts` + `types.ts`, `content.lock`, CI freshness/parity anchors).
+**Rollback property to preserve:** Sanity's `onChainStatus` is frozen but left intact until SP2-C — a straight revert of this PR must fully restore the old world. Keep the flip mechanical and reversible.
+
+## Ambiguities resolved (read before executing)
+
+1. **Instructor avatar source.** Spec decision 2: avatars come from `profiles.avatar_url` keyed by `instructor.wallet`; the bundle carries no avatar. Live content has zero instructor avatars (measured), so the observable production value is already null. **Controller-reviewed resolution: project `avatar: null` in SP2-B.** Do NOT wire a `profiles` read here — the anon cookieless client can't read other users' profiles under own-row RLS, and exposing avatars-by-wallet publicly is an RLS design decision that must not ride inside a SENSITIVE flip PR. Wiring real profile avatars is a follow-up issue (needs a deliberate public exposure surface, e.g. a view).
+2. **Where the flipped query fns live.** 33 files import `@/lib/sanity/queries`; `COURSES_CACHE_TAG` has 5 importers. **Resolution:** re-implement the fns in `lib/content/queries.ts` (server-only, over the bundle store + Supabase seam) and turn `lib/sanity/queries.ts` into a thin **re-export barrel** (`export * from "@/lib/content/queries"` plus `COURSES_CACHE_TAG`). Zero import-site churn in the sensitive PR; SP2-C repoints imports and deletes the barrel. Revert stays clean.
+3. **Return-type contract.** Each query fn PRESERVES its exact current return type (`Course`, `Lesson`, `LearningPath`, `CourseSummary`, `RecommendedCourse`, `DeployedAchievement`, `AdminCourse`, `QuestData`, … from `@/lib/sanity/types`). The GROQ projection (slug→string flatten, `thumbnail.asset->url`, `instructor->` deref, `modules[].lessons[]->` deref, `blocks[]` shape, `award{...}`) moves verbatim into TS projector functions. No consumer changes shape.
+4. **`authoringStatus` is dead.** All live courses are `approved`; the clause is dropped (not defaulted). Gate becomes exactly `synced && coalesce(isActive, true)`, sourced from Supabase.
+5. **Client split (controller-reviewed):** public/gated reads use the anon cookieless client against the **public view**; admin + reward-path reads that need the full row (e.g. `track_collection_address`) use `createAdminClient()` (service_role) in server-only routes — the public view stays minimal.
+
+## Data-plane split this PR lands
+- **Content** → the committed bundle (`lib/content/store.ts` maps).
+- **On-chain status** → new Supabase `onchain_deployments` table (keyed by content id `course-*` / `achievement-*`), read via a cached map, written by the 4 writer sites.
+- **slots.lock + synced-SHA** → the bundle (`slotsByCourseId`, `meta.json.sha` / `content.lock`), retiring the runtime GitHub tarball fetch and the `contentSync` singleton.
+
+## Consumer inventory (shape preserved for every one)
+
+| Fn | Return type | Gate today | Flip |
+|---|---|---|---|
+| `getAllCourses` | `Course[]` | synced+active+auth | bundle + status map, gated |
+| `getCourseBySlug` | `Course \| null` | synced+active+auth | bundle + status map, gated |
+| `getLessonBySlug` | `Lesson \| null` | synced+active+auth | bundle (server-only; carries `solution`/`tests`) + status map, gated |
+| `getLessonByIdForGrading` | `Lesson \| null` | ungated, revalidate 0 | bundle only, uncached |
+| `getAllLearningPaths` | `LearningPath[]` | nested course gate | bundle paths + course status map, gated |
+| `getCourseById` | `Course \| null` (+`trackCollectionAddress`) | ungated | bundle + deployment-by-id (admin client), uncached (reward path) |
+| `getCourseIdBySlug` | `{_id,xpPerLesson}\|null` | synced+active+auth | bundle + status map, gated |
+| `getCourseLessons` | `Pick<Lesson,…>[]` | synced+active+auth | bundle + status map, gated |
+| `getCoursesByIds` | `CourseSummary[]` | synced+active+auth | bundle + status map, gated |
+| `getLessonsByIds` | `LessonSummary[]` | ungated | bundle only |
+| `getRecommendedCourses` | `RecommendedCourse[]` | synced+active+auth | bundle + status map, gated |
+| `getAllCourseTags` | `{…}[]` | synced+active+auth | bundle + status map, gated |
+| `getAllCourseLessonCounts` | `{…}[]` | synced+active+auth | bundle + status map, gated |
+| `getDeployedAchievements` | `DeployedAchievement[]` | `defined(achievementPda)` | bundle + deployment join (has PDA) |
+| `getAllAchievements` | `DeployedAchievement[]` | all | bundle only |
+| `getAllQuests` | `QuestData` | `active==true`, code-block lessons, module→lesson map | bundle only |
+| `getAllCoursesAdmin` | `AdminCourse[]` | admin, revalidate 0 | bundle + full deployment row (admin client), uncached |
+| `getLearningPathsForAdmin` | `AdminLearningPath[]` | admin, revalidate 0 | bundle only, uncached |
+| `getAllAchievementsAdmin` | `AdminAchievement[]` | admin, revalidate 0 | bundle + deployment row (admin client), uncached |
+| `getInstructorCourses` | `InstructorCourseSummary[]` | synced only, by wallet | bundle + deployment status |
+| `isInstructorWallet` | `boolean` | instructor-by-wallet | bundle only |
+| inline `teacher/courses/[id]/stats` | `{wallet}` | `instructor->wallet` | bundle instructor deref |
+
+**Reward/grading consumers this PR must not break** (all resolve via the fns above): `app/api/certificates/mint/route.ts`, `lib/helius/event-handlers.ts`, `lib/solana/onchain-queue.ts`, `app/api/lessons/complete/route.ts`, `app/api/admin/resync/route.ts`.
+
+**Writer sites (4)** — flip to Supabase-only, keep `revalidateTag("courses")`: `admin/courses/sync` (`writeCourseOnChainStatus` + `writeCourseTrackCollection`), `admin/achievements/sync` (`writeAchievementOnChainStatus`), `admin/courses/{deactivate,reactivate}` (`writeCourseActive`), `lib/solana/admin-signer.ts` (`writeCourseTrackCollection`).
+
+**Runtime tarball / singleton retirement:** `admin/courses/sync/route.ts::readCourseSlotsLock` and `admin/content/drift/route.ts` derive `slots.lock` from `slotsByCourseId` and the synced SHA from `content.lock` / `meta.json` — no request-time GitHub fetch, no `readContentSyncSingleton`.
+
+---
+
+## Tasks
+
+### Task 1 — Migration: `onchain_deployments` table + public view (HUMAN-GATED, applied before merge)
+**File:** `supabase/migrations/<ts>_onchain_deployments.sql`
+- Table `onchain_deployments`, PK `content_id TEXT` (`course-*` / `achievement-*` — distinct from `deployed_programs`, which is per-learner practice deploys). Columns mirror the frozen `onChainStatus` union: `status`, `course_pda`, `tx_signature`, `collection_address`, `track_collection_address`, `achievement_pda`, `is_active BOOLEAN`, `last_synced TIMESTAMPTZ`, plus `kind TEXT CHECK (kind IN ('course','achievement'))` and `updated_at`. Index on `kind`.
+- `ENABLE ROW LEVEL SECURITY`; no public policies — writes service_role only (house pattern).
+- **Public view** `public_onchain_deployments` exposing only what the gate + public reads need (`content_id`, `kind`, `status`, `is_active`, `achievement_pda`); `REVOKE ALL FROM PUBLIC, anon, authenticated; GRANT SELECT TO anon, authenticated;` (study `public_user_xp`).
+- Header doc block in the style of `20260703130652_add_profiles_role_and_lock_role_writes.sql`.
+
+**Gate:** applied to David's Supabase under the SP1 triple gate BEFORE the code PR merges. Advisors clean.
+**Verify:** table+view exist; anon SELECT on view works; authenticated INSERT rejected; advisors clean.
+
+### Task 2 — One-time backfill from Sanity + parity assertion (HUMAN-GATED, before merge)
+**File:** `scripts/backfill-onchain-deployments.ts` (standalone tsx; not shipped in the app).
+- Read every managed doc's `onChainStatus` from prod Sanity, **including `isActive` and `trackCollectionAddress`**; upsert one row per synced course + per achievement with a PDA.
+- **Parity assertion (fail-closed):** row count == synced Sanity docs; field-by-field equality per `content_id`; divergence → non-zero exit.
+
+**Verify:** dry-run first; real run's parity output (counts + zero field diffs) captured in the PR description. 6 live courses + all synced achievements have rows.
+
+### Task 3 — Supabase deployment read seam (cookieless client + cached map + by-id)
+**File:** `apps/web/src/lib/content/deployments.ts` (`import "server-only"`).
+- **Cookieless** anon client (NOT `lib/supabase/server.ts` — `cookies()` would force catalog/lesson pages dynamic) against the public view.
+- `getActiveDeployments()` → one query → one `ReadonlyMap<content_id, DeploymentStatus>`, wrapped in `unstable_cache` tagged `"courses"` / 3600s. Outage: serve cached; cold-cache + outage fails closed (hidden > leaked).
+- `getDeploymentById(contentId)` → uncached, **admin client** (service_role), full row incl. `track_collection_address` — for reward paths + admin reads (server-only routes).
+- `isSynced(dep)` = `dep?.status === "synced" && (dep.is_active ?? true)` — the entire gate, one place.
+
+**TDD:** `isSynced` truth table; map-shaping against a stubbed client. No live Supabase in unit tests.
+**Verify:** `next build` — catalog + lesson routes stay static/ISR (no `cookies()` in the trace).
+
+### Task 4 — Content projectors: raw bundle doc → GROQ-projected shape
+**File:** `apps/web/src/lib/content/project.ts` (`import "server-only"`; pure fns over store maps).
+- One projector per output type, field-exact: `projectCourse` (slug flatten, thumbnail path, instructor deref → `{name, avatar: null, bio, socialLinks}`, modules with lesson derefs + drop-nulls), `projectLesson` (full `blocks[]` projection), `projectCourseSummary`, `projectRecommended`, `projectAchievement` (reuse `parseAward` verbatim), `projectQuestData`.
+- GROQ `(...)[defined(_id)]` → explicit `.filter()` after deref (#405 hardening). **Never count via flattened traversals** — `totalLessons` = per-course sum of `modules[].lessons.length` (memory: GROQ flatten null-counting).
+
+**TDD:** golden tests — bundle fixtures through each projector deep-equal a snapshot of the current GROQ output (captured from live `queries.ts` against prod BEFORE the flip). Cover: multi-module course, module-less course, code-block lesson (solution/tests), achievement with/without award, quest set. This is the correctness anchor of the PR.
+
+### Task 5 — Flip the query fns
+**File:** `apps/web/src/lib/content/queries.ts` (new, server-only); `lib/sanity/queries.ts` becomes the re-export barrel (keeps `COURSES_CACHE_TAG`).
+- Gated fns: filter store courses through `isSynced(map.get(course._id))`, then project; `order(title asc)` → `.sort()`.
+- Ungated/grading/reward fns per the inventory table (uncached where revalidate 0 today; `getCourseById` + admin fns via `getDeploymentById`).
+
+**TDD:** per-fn tests over fixture store + stubbed deployment map: gated fn hides not-synced/inactive and admits synced+active; grading fn resolves a lesson in a deactivated course; `getCourseById` returns `trackCollectionAddress` from the stub.
+**Verify:** typecheck green — return types unchanged means the 33 importers compile untouched.
+
+### Task 6 — Flip the 4 writer sites + retire tarball/singleton in deploy+drift
+**Files:** the 4 writer routes/modules + `admin-mutations.ts` writer fns + `courses/sync/route.ts` + `content/drift/route.ts` + the teacher-stats inline query.
+- Writer fns keep their signatures; bodies become service_role upserts into `onchain_deployments` (`createAdminClient()`); keep `revalidateTag("courses")` semantics (deactivate/reactivate must purge).
+- `readCourseSlotsLock` + drift: bundle `slotsByCourseId` + `content.lock`/`meta.json` SHA; delete the runtime tarball fetch.
+- Teacher stats route: resolve `instructor.wallet` via store (`coursesById` → `instructorsById`); 401/403 semantics identical.
+
+**TDD:** update existing route tests — assert Supabase upserts (not Sanity patches), bundle-derived slots, tag purge still fires.
+
+### Task 7 — E2E verification (devnet + render parity) — the SENSITIVE evidence pack
+- Render parity: pre-flip GROQ vs post-flip projector output for all 6 courses + 76 lessons, byte-identical.
+- Gate: synthetic non-synced row hidden everywhere; `is_active=false` disappears within one tag purge.
+- Reward path on devnet: backfilled course resolves through certificates/mint + an achievement award; `getCourseById` returns `track_collection_address`; mint succeeds.
+- `next build`: catalog + lesson routes still static/ISR. Public view exposes only the whitelisted columns.
+- All captured in the PR description.
+
+## Ordering & gates
+1 → 2 human-gated (DB applied + parity-verified BEFORE the code PR merges; triple gate). 3 → 7 sequential code. **Full independent adversarial re-exploit review before the PR opens** (memory: single claude[bot] gate insufficient for trust-boundary flips). Revert-clean: Sanity `onChainStatus` frozen intact until SP2-C.
+
+## Out of scope (SP2-C/D)
+Deleting `lib/sanity/*` / `lib/content-sync/*` / Studio; repointing the 33 imports off the barrel; `@sanity/*` deps; `next.config.mjs` cdn/CSP/`/studio` cleanup; env removal; golden snapshots replacing the parity anchor; CMS_GUIDE deletion; profile-avatar wiring (follow-up issue); #387/CS-4.

--- a/docs/superpowers/plans/2026-07-11-sp3a-admin-nav-shell.md
+++ b/docs/superpowers/plans/2026-07-11-sp3a-admin-nav-shell.md
@@ -1,0 +1,59 @@
+# SP3-A — Admin Nav Shell + Route Split (Implementation Plan)
+
+**Date:** 2026-07-11 · **Spec:** `docs/superpowers/specs/2026-07-10-sp3-admin-panel-v2-design.md` (rev 2), SP3-A
+**Lane:** SAFE (frontend-only, no migrations, no trust-boundary change, auth unchanged). **Independent of SP2** (moves existing panels; doesn't touch the data model).
+
+## Ambiguities resolved (read before executing)
+
+1. **`/admin` root behavior after the split (controller-corrected).** Today `app/[locale]/admin/page.tsx` renders `AdminLoginForm` unauthenticated and the stacked `AdminClient` authenticated. The middleware redirects unauthenticated `/admin/*` sub-routes to `/admin` (`middleware.ts:163-178`) — so an unconditional `redirect()` in the root page would LOOP for unauthenticated users (`/admin` → `/admin/status` → middleware → `/admin` → …). **Resolution:** the root `page.tsx` checks the session itself: valid `admin_session` → `redirect(/{locale}/admin/status)`; invalid → render `<AdminLoginForm/>` (exactly as today). The new `layout.tsx` renders the console chrome + `<AdminNav/>` only when the session is valid, and plain `{children}` otherwise (so the login form isn't wrapped in a nav). No middleware change.
+2. **Status data fetch split.** `AdminClient` fetches `/api/admin/status` once and fans out. **Resolution:** each screen's client component fetches what it needs from the UNCHANGED `/api/admin/status` (deploy: `courses`+`achievements`; status: `program`+counts). Do NOT split the API in SP3-A; small refetch duplication is acceptable and behavior-preserving.
+3. **i18n scope.** The admin console has zero next-intl today (hardcoded English). **Resolution:** add an `admin` namespace for the NEW nav/screen chrome only (nav labels, screen titles, console header) in en/pt-BR/es. Pre-existing hardcoded strings inside moved panels stay as-is (behavior-preserving). The SP1 deep-parity test enforces structural parity of the new keys.
+
+## Screen map (grounded in the real files)
+
+| Route | Renders (moved as-is) | Source today |
+|---|---|---|
+| `/admin/publish` | `ContentSyncPanel` (+ its `sync-diff-view`) | `components/admin/content-sync-panel.tsx` |
+| `/admin/deploy` | `CourseSyncTable` + `AchievementSyncTable` (+ `immutable-mismatch-warning` inside them) | `components/admin/{course,achievement}-sync-table.tsx` |
+| `/admin/moderation` | `FlagsPanel` | `components/admin/flags-panel.tsx` |
+| `/admin/status` | **the inline program-status bar** (spec rev-2 mandate — must not be dropped) + `DataResyncPanel` + deploy counts | inline in `admin-client.tsx` + `components/admin/data-resync-panel.tsx` |
+
+**SP2-C/D deletability constraint:** `/admin/publish` renders `<ContentSyncPanel/>` as-is, no new coupling — SP2-C/D deletes it by removing one file + one nav entry.
+
+## Tasks
+
+### Task 1 — Layout + nav shell + root-page session split + i18n scaffold
+**Files:**
+- `app/[locale]/admin/layout.tsx` (new) — server component; `isValidAdminSession(cookies().get("admin_session"))`: valid → console chrome (`max-w-6xl` shell + i18n'd "Admin Console" header) + `<AdminNav/>` + `{children}`; invalid → plain `{children}` (login form renders unwrapped).
+- `app/[locale]/admin/admin-nav.tsx` (new) — client component; persistent left rail (desktop) / top tabs (mobile) with 4 links, `aria-current` via `usePathname`, keyboard-navigable, focus-visible rings (house a11y rules). Labels from the `admin` namespace.
+- `app/[locale]/admin/page.tsx` — session check: valid → `redirect(/{locale}/admin/status)`; invalid → `<AdminLoginForm/>` (today's path preserved; NO unconditional redirect — see ambiguity 1).
+- `messages/{en,pt-BR,es}.json` — `admin` namespace: `console.title`, `console.subtitle`, `nav.{publish,deploy,moderation,status}`, screen titles. Identical structure across locales.
+
+**TDD:** `admin-nav` test (4 links, active marking from mocked pathname, labels resolve); parity test covers the new keys.
+**Verify:** unauth `/admin` → login form, no nav, no redirect loop (curl -L bounded); auth `/admin` → `/admin/status`; nav on every sub-route; `next build` clean.
+
+### Task 2 — Publish + Moderation screens (straight moves)
+**Files:** `app/[locale]/admin/publish/page.tsx` (renders `<ContentSyncPanel/>`, no new coupling), `app/[locale]/admin/moderation/page.tsx` (renders `<FlagsPanel/>`; the flag-count badge's `onCountChange` lift moves into a thin client wrapper local to this screen).
+
+**TDD:** render smoke only (panels carry their own tests).
+**Verify:** click-through — publish shows content-sync + drift UI exactly as before; moderation actions work.
+
+### Task 3 — Deploy + Status screens (table wiring + status-bar relocation) + delete `admin-client.tsx`
+**Files:** `app/[locale]/admin/deploy/{page,deploy-client}.tsx` (fetch `/api/admin/status`, render both sync tables with the same `onRefresh` wiring), `app/[locale]/admin/status/{page,status-client}.tsx` (fetch `/api/admin/status`, render the relocated program-status bar — moved verbatim — + `<DataResyncPanel/>` + counts). Delete `admin-client.tsx` once relocated.
+
+**TDD:** both clients — mock `/api/admin/status`; tables/status bar render; refresh refetches; authority-mismatch banner shows on `authorityMatch.matches === false`.
+**Verify:** deploy actions (sync/deactivate) identical; status shows program bar + banner; resync works; counts match.
+
+### Task 4 — i18n parity + full e2e capability check
+- Parity test green with the new namespace across en/pt-BR/es.
+- E2E click-through proving NO capability lost vs the stacked page: sync a course, deploy an achievement, act on a flag, run a resync, read program status.
+- Regression: unauthenticated GET of each `/admin/*` sub-route redirects to `/admin` (middleware, no code change).
+
+**Verify:** captured click-through = the SP3-A evidence (spec: "every surviving admin capability reachable via nav; no capability lost").
+
+## Notes
+- SAFE-lane; per-task review + whole-branch review. If any task incidentally touches deploy write logic it becomes SENSITIVE — it should not here.
+- Merge-order note: SP3-A moves panels; SP2-C/D later deletes the content-sync panel at its new location. If SP2-C lands first, rebase this branch and drop `/admin/publish` to a placeholder pointing at the SP3-B publish screen.
+
+## Out of scope (SP3-B/C/D)
+Publish pin-bump flow (SP3-B, needs SP2). Deploy-screen v2 (change-preview, #400 UI, #402) — SP3-C. Moderation/status polish — SP3-D. No API-route changes.


### PR DESCRIPTION
Implementation plans for the next two parallel streams, drafted by an opus planner grounded in the real code and controller-reviewed with two corrections:

- **SP2-B** (SENSITIVE — onchain_deployments migration + backfill + one-cut read/write flip): re-export-barrel strategy keeps import churn at zero; avatar projects `null` (no anon profiles read inside the sensitive PR); admin/reward reads via `createAdminClient` so the public view stays minimal; migration+backfill human-gated before merge (triple gate).
- **SP3-A** (SAFE, SP2-independent — admin nav shell + route split): root page keeps its own session check (an unconditional redirect would loop with the middleware guard); program-status bar explicitly relocated to /admin/status per spec rev-2.

SP3-A implementation starts in parallel; SP2-B waits for SP2-A merge + owner gates.