### PR TITLE
fix(web): pt-BR admin root guard — match mixed-case locales (#418)

### DIFF
--- a/apps/web/src/lib/admin/__tests__/routes.test.ts
+++ b/apps/web/src/lib/admin/__tests__/routes.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import { isAdminRoute, isAdminRootPath } from "@/lib/admin/routes";
+
+const locales = ["en", "es", "pt-BR"] as const;
+
+describe("isAdminRootPath", () => {
+  // Regression for #418: the previous inline regex `^\/[a-z-]+\/admin\/?$`
+  // failed to match the uppercase segment in `pt-BR`, so `/pt-BR/admin` was
+  // treated as a sub-route and redirected to itself in an infinite loop.
+  for (const locale of locales) {
+    it(`matches the admin root for ${locale} (no trailing slash)`, () => {
+      expect(isAdminRootPath(`/${locale}/admin`)).toBe(true);
+    });
+
+    it(`matches the admin root for ${locale} (trailing slash)`, () => {
+      expect(isAdminRootPath(`/${locale}/admin/`)).toBe(true);
+    });
+
+    it(`does not match an admin sub-route for ${locale}`, () => {
+      expect(isAdminRootPath(`/${locale}/admin/content`)).toBe(false);
+    });
+
+    it(`does not match a non-admin route for ${locale}`, () => {
+      expect(isAdminRootPath(`/${locale}/dashboard`)).toBe(false);
+    });
+  }
+
+  it("does not match an unknown locale", () => {
+    expect(isAdminRootPath("/fr/admin")).toBe(false);
+  });
+});
+
+describe("isAdminRoute", () => {
+  for (const locale of locales) {
+    it(`matches the admin root for ${locale}`, () => {
+      expect(isAdminRoute(`/${locale}/admin`)).toBe(true);
+    });
+
+    it(`matches an admin sub-route for ${locale}`, () => {
+      expect(isAdminRoute(`/${locale}/admin/content`)).toBe(true);
+    });
+
+    it(`does not match a non-admin route for ${locale}`, () => {
+      expect(isAdminRoute(`/${locale}/courses`)).toBe(false);
+    });
+  }
+
+  it("does not match an unknown locale", () => {
+    expect(isAdminRoute("/fr/admin")).toBe(false);
+  });
+});

--- a/apps/web/src/lib/admin/routes.ts
+++ b/apps/web/src/lib/admin/routes.ts
@@ -1,0 +1,31 @@
+import { locales } from "@/lib/i18n/config";
+
+// Pure, framework-free route classifiers for the admin guard in middleware.
+// Both derive locale matching from the `locales` constant so mixed-case locales
+// (e.g. `pt-BR`) are handled correctly — a locale-agnostic `[a-z-]+` regex would
+// miss the uppercase segment and misclassify `/pt-BR/admin` as a sub-route,
+// causing an infinite redirect loop back to itself (#418).
+
+/** True for the admin section root or any admin sub-route, e.g. `/en/admin`, `/pt-BR/admin/content`. */
+export function isAdminRoute(pathname: string): boolean {
+  for (const locale of locales) {
+    const prefix = `/${locale}`;
+    if (pathname.startsWith(prefix)) {
+      const rest = pathname.slice(prefix.length);
+      return rest === "/admin" || rest.startsWith("/admin/");
+    }
+  }
+  return false;
+}
+
+/** True only for the admin login root, e.g. `/en/admin` or `/pt-BR/admin/` (trailing slash allowed). */
+export function isAdminRootPath(pathname: string): boolean {
+  for (const locale of locales) {
+    const prefix = `/${locale}`;
+    if (pathname.startsWith(prefix)) {
+      const rest = pathname.slice(prefix.length);
+      return rest === "/admin" || rest === "/admin/";
+    }
+  }
+  return false;
+}

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -3,6 +3,7 @@ import { createServerClient } from "@supabase/ssr";
 import createIntlMiddleware from "next-intl/middleware";
 import { env } from "@/lib/env";
 import { locales, defaultLocale } from "@/lib/i18n/config";
+import { isAdminRoute, isAdminRootPath } from "@/lib/admin/routes";
 import { ADMIN_SESSION_MAX_AGE_MS } from "@/lib/admin/session-format";
 import { buildCsp, generateNonce } from "@/lib/csp";
 
@@ -63,17 +64,6 @@ const intlMiddleware = createIntlMiddleware({
   defaultLocale,
   localePrefix: "always",
 });
-
-function isAdminRoute(pathname: string): boolean {
-  for (const locale of locales) {
-    const prefix = `/${locale}`;
-    if (pathname.startsWith(prefix)) {
-      const rest = pathname.slice(prefix.length);
-      return rest === "/admin" || rest.startsWith("/admin/");
-    }
-  }
-  return false;
-}
 
 function isProtectedRoute(pathname: string): boolean {
   // Only routes that require authentication (personal data)
@@ -162,7 +152,7 @@ export async function middleware(request: NextRequest) {
   // so sub-routes that need protection redirect back to /admin.
   if (isAdminRoute(request.nextUrl.pathname)) {
     const adminSession = request.cookies.get("admin_session");
-    const isAdminRoot = /^\/[a-z-]+\/admin\/?$/.test(request.nextUrl.pathname);
+    const isAdminRoot = isAdminRootPath(request.nextUrl.pathname);
     if (!(await isValidAdminSession(adminSession?.value))) {
       if (!isAdminRoot) {
         const locale =


### PR DESCRIPTION
Fixes #418 — unauthenticated `/pt-BR/admin` infinite-redirect-loops because the inline `isAdminRoot` regex `^\/[a-z-]+\/admin\/?$` excludes uppercase locale segments.

**Fix:** extracted the admin route classifiers into a pure, testable `lib/admin/routes.ts` — `isAdminRoute` moved **verbatim** (reviewer diffed it: only the `export` keyword differs) and the new `isAdminRootPath` derives locale matching from the `locales` constant, same approach `isAdminRoute` already used. 23 unit tests: all locales × root/trailing-slash/sub-route/non-admin + unknown-locale, including the negative security cases.

**Security review (Fable, guard-equivalence walk):** the guarded set is IDENTICAL before/after; within it exactly ONE path changes classification — `/pt-BR/admin` from self-redirecting sub-route to login-form root. No protected sub-route is reclassified; hostile shapes (trailing slashes, dot-segments, %2F, double-slash prefixes) walk identically; unknown locales were already unreachable in the guard (isAdminRoute gate, unchanged). `routes.ts` is Edge-safe (only imports the `as const` locales config).

**Deferred (noted by review):** the predicates early-return on the first locale-prefix match — safe with today's set, but a prefix-colliding locale (e.g. adding `pt` alongside `pt-BR`) would re-open this bug class; future-proof with a boundary check when locales next change.