### PR TITLE
SP3-B: admin publish screen — content-pin drift card + prefilled publish-PR flow

### DIFF
--- a/apps/web/src/app/[locale]/admin/__tests__/publish-page.test.tsx
+++ b/apps/web/src/app/[locale]/admin/__tests__/publish-page.test.tsx
@@ -4,10 +4,13 @@ import { render, screen } from "@testing-library/react";
 import AdminPublishPage from "../publish/page";
 import messages from "@/messages/en.json";
 
-// Render smoke only — ContentSyncPanel carries its own tests and fetches on
-// mount, so it is stubbed out here.
+// Render smoke only — ContentSyncPanel and the SP3-B PublishPinClient carry
+// their own tests and fetch on mount, so both are stubbed out here.
 vi.mock("@/components/admin/content-sync-panel", () => ({
   ContentSyncPanel: () => <div data-testid="content-sync-panel" />,
+}));
+vi.mock("../publish/publish-pin-client", () => ({
+  PublishPinClient: () => <div data-testid="publish-pin-client" />,
 }));
 
 vi.mock("next-intl/server", () => ({
@@ -27,6 +30,7 @@ describe("AdminPublishPage (smoke)", () => {
     expect(
       screen.getByRole("heading", { name: messages.admin.screens.publish })
     ).toBeInTheDocument();
+    expect(screen.getByTestId("publish-pin-client")).toBeInTheDocument();
     expect(screen.getByTestId("content-sync-panel")).toBeInTheDocument();
   });
 });

--- a/apps/web/src/app/[locale]/admin/__tests__/publish-pin-client.test.tsx
+++ b/apps/web/src/app/[locale]/admin/__tests__/publish-pin-client.test.tsx
@@ -1,0 +1,158 @@
+// @vitest-environment jsdom
+import type { ReactElement } from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import { PublishPinClient } from "../publish/publish-pin-client";
+import messages from "@/messages/en.json";
+
+interface PinResponse {
+  pin: { sha: string; counts: Record<string, number>; compiledAt?: string };
+  head: { sha: string; checks: string };
+  verdict: {
+    state: string;
+    commitsBehind: number | null;
+    headChecks: string;
+    warnRedHead: boolean;
+  };
+  repos: { content: string; app: string };
+}
+
+const PIN = "401c7df1035061337dd209ea8a8c7272d3223cbc";
+const HEAD = "b".repeat(40);
+
+const upToDate: PinResponse = {
+  pin: { sha: PIN, counts: { courses: 6, lessons: 76 } },
+  head: { sha: PIN, checks: "success" },
+  verdict: {
+    state: "up_to_date",
+    commitsBehind: 0,
+    headChecks: "success",
+    warnRedHead: false,
+  },
+  repos: {
+    content: "solanabr/courses-academy",
+    app: "solanabr/superteam-academy",
+  },
+};
+
+const drifted: PinResponse = {
+  pin: { sha: PIN, counts: { courses: 6, lessons: 76 } },
+  head: { sha: HEAD, checks: "success" },
+  verdict: {
+    state: "behind",
+    commitsBehind: 3,
+    headChecks: "success",
+    warnRedHead: false,
+  },
+  repos: {
+    content: "solanabr/courses-academy",
+    app: "solanabr/superteam-academy",
+  },
+};
+
+const driftedRedHead: PinResponse = {
+  ...drifted,
+  head: { sha: HEAD, checks: "failure" },
+  verdict: { ...drifted.verdict, headChecks: "failure", warnRedHead: true },
+};
+
+function renderWithIntl(ui: ReactElement) {
+  return render(
+    <NextIntlClientProvider locale="en" messages={messages}>
+      {ui}
+    </NextIntlClientProvider>
+  );
+}
+
+function mockFetch(body: PinResponse, ok = true): void {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue({
+      ok,
+      json: async () => body,
+    })
+  );
+}
+
+describe("PublishPinClient", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("shows 'up to date' and hides the prepare-PR section when the pin matches HEAD", async () => {
+    mockFetch(upToDate);
+    renderWithIntl(<PublishPinClient />);
+    await waitFor(() =>
+      expect(
+        screen.getByText(messages.admin.publishPin.upToDate)
+      ).toBeInTheDocument()
+    );
+    expect(
+      screen.queryByText(messages.admin.publishPin.prepare.title)
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders the drift count, one-line diff and prepare-PR link when drifted", async () => {
+    mockFetch(drifted);
+    renderWithIntl(<PublishPinClient />);
+    await waitFor(() =>
+      expect(
+        screen.getByText(messages.admin.publishPin.prepare.title)
+      ).toBeInTheDocument()
+    );
+    expect(screen.getByText("3 commits behind HEAD")).toBeInTheDocument();
+    // The one-line lock diff is shown verbatim.
+    expect(screen.getByText(/"sha": "401c7df/)).toBeInTheDocument();
+    const prLink = screen.getByRole("link", {
+      name: messages.admin.publishPin.preparePrLink,
+    });
+    expect(prLink).toHaveAttribute(
+      "href",
+      expect.stringContaining("solanabr/superteam-academy/compare/main")
+    );
+  });
+
+  it("warns loudly when HEAD's CI is red", async () => {
+    mockFetch(driftedRedHead);
+    renderWithIntl(<PublishPinClient />);
+    await waitFor(() =>
+      expect(
+        screen.getByText(messages.admin.publishPin.prepare.redHeadWarning)
+      ).toBeInTheDocument()
+    );
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+  });
+
+  it("copies the compile command to the clipboard", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal("navigator", { clipboard: { writeText } });
+    mockFetch(drifted);
+    renderWithIntl(<PublishPinClient />);
+    await waitFor(() =>
+      expect(
+        screen.getByText(messages.admin.publishPin.copyCommand)
+      ).toBeInTheDocument()
+    );
+    fireEvent.click(screen.getByText(messages.admin.publishPin.copyCommand));
+    await waitFor(() =>
+      expect(writeText).toHaveBeenCalledWith(
+        "pnpm --filter web compile-content"
+      )
+    );
+  });
+
+  it("shows the unavailable banner on a non-ok response", async () => {
+    mockFetch(upToDate, false);
+    renderWithIntl(<PublishPinClient />);
+    await waitFor(() =>
+      expect(
+        screen.getByText(messages.admin.publishPin.unavailable)
+      ).toBeInTheDocument()
+    );
+  });
+});

--- a/apps/web/src/app/[locale]/admin/publish/page.tsx
+++ b/apps/web/src/app/[locale]/admin/publish/page.tsx
@@ -1,19 +1,22 @@
 import { getTranslations } from "next-intl/server";
+import { PublishPinClient } from "./publish-pin-client";
 import { ContentSyncPanel } from "@/components/admin/content-sync-panel";
 
 /**
- * `/admin/publish` — the content-sync surface, moved as-is from the stacked
- * admin page (SP3-A Task 2). Intentionally zero new coupling: SP2-C/D retires
- * this screen by deleting this file plus its nav entry.
+ * `/admin/publish` — the content-publishing surface. SP3-B adds the "Content
+ * pin" card (content.lock SHA vs courses-academy HEAD + a prefilled human PR
+ * link) ABOVE the SP3-A content-sync panel. The panel is left untouched: SP2-C/D
+ * retires it by deleting this file plus its nav entry, so no new coupling.
  */
 export default async function AdminPublishPage() {
   const t = await getTranslations("admin");
 
   return (
-    <section>
-      <h2 className="mb-4 font-display text-lg font-bold text-text">
+    <section className="space-y-4">
+      <h2 className="font-display text-lg font-bold text-text">
         {t("screens.publish")}
       </h2>
+      <PublishPinClient />
       <div className="rounded-lg border border-border bg-card p-4 shadow-card">
         <ContentSyncPanel />
       </div>

--- a/apps/web/src/app/[locale]/admin/publish/publish-pin-client.tsx
+++ b/apps/web/src/app/[locale]/admin/publish/publish-pin-client.tsx
@@ -1,0 +1,299 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useTranslations } from "next-intl";
+import type { ChecksState } from "@/lib/content-sync/types";
+import {
+  computePublishVerdict,
+  shortSha,
+  contentTreeUrl,
+  contentCommitUrl,
+  contentCompareUrl,
+  suggestBranchName,
+  buildLockDiff,
+  buildPrTitle,
+  buildPrBody,
+  buildPublishPrUrl,
+  COMPILE_COMMAND,
+  LOCK_PATH,
+} from "@/lib/content-sync/publish-pin";
+
+interface PinResponse {
+  pin: { sha: string; counts: Record<string, number>; compiledAt?: string };
+  head: { sha: string; checks: ChecksState };
+  verdict: ReturnType<typeof computePublishVerdict>;
+  repos: { content: string; app: string };
+}
+
+const LINK_CLASSES =
+  "font-mono text-primary underline-offset-2 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded-sm";
+
+const BUTTON_CLASSES =
+  "rounded-md border border-border bg-card px-3 py-1.5 text-xs font-medium text-text shadow-push-sm transition-all hover:bg-subtle active:translate-y-[1px] active:shadow-push-active focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary disabled:pointer-events-none disabled:opacity-50";
+
+function ChecksBadge({ checks }: { checks: ChecksState }): React.ReactElement {
+  const t = useTranslations("admin.publishPin");
+  const tone: Record<ChecksState, string> = {
+    success: "border-success bg-success-light text-success",
+    failure: "border-danger bg-danger-light text-danger",
+    pending: "border-streak bg-streak-light text-streak",
+    unknown: "border-border bg-subtle text-text-3",
+  };
+  return (
+    <span
+      className={`inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-medium ${tone[checks]}`}
+    >
+      {t(`checks.${checks}`)}
+    </span>
+  );
+}
+
+function CopyButton({
+  text,
+  label,
+}: {
+  text: string;
+  label: string;
+}): React.ReactElement {
+  const t = useTranslations("admin.publishPin");
+  const [copied, setCopied] = useState(false);
+  const copy = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // Clipboard unavailable (insecure context / denied) — text stays visible
+      // and manually selectable, so no error surface is needed.
+    }
+  }, [text]);
+  return (
+    <button
+      type="button"
+      onClick={() => void copy()}
+      className={BUTTON_CLASSES}
+    >
+      {copied ? t("copied") : label}
+    </button>
+  );
+}
+
+/**
+ * SP3-B "Content pin" card. Shows the pinned courses-academy SHA (from the
+ * committed bundle) vs repo HEAD, HEAD's CI state, a drift verdict, and — when
+ * drifted — the exact one-line `content.lock` diff, the local rebuild command,
+ * and a prefilled PR link. The bump is a one-line HUMAN PR: this card performs
+ * no repo write and holds no write token (spec rev-2, locked).
+ */
+export function PublishPinClient(): React.ReactElement {
+  const t = useTranslations("admin.publishPin");
+  const [data, setData] = useState<PinResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [unavailable, setUnavailable] = useState(false);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setUnavailable(false);
+    try {
+      const res = await fetch("/api/admin/publish/pin");
+      if (!res.ok) {
+        setUnavailable(true);
+        setData(null);
+        return;
+      }
+      setData((await res.json()) as PinResponse);
+    } catch {
+      setUnavailable(true);
+      setData(null);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  return (
+    <div className="rounded-lg border border-border bg-card p-4 shadow-card">
+      <div className="mb-3 flex items-center justify-between gap-4">
+        <h3 className="font-display text-base font-bold text-text">
+          {t("title")}
+        </h3>
+        <button
+          type="button"
+          onClick={() => void load()}
+          disabled={loading}
+          className={BUTTON_CLASSES}
+        >
+          {t("refresh")}
+        </button>
+      </div>
+      <p className="mb-4 text-sm text-text-3">{t("description")}</p>
+
+      {loading ? (
+        <p className="py-6 text-center text-sm text-text-3">{t("loading")}</p>
+      ) : unavailable || !data ? (
+        <div className="rounded-md border border-streak bg-streak-light p-3 text-sm text-streak">
+          {t("unavailable")}
+        </div>
+      ) : (
+        <PinBody data={data} />
+      )}
+    </div>
+  );
+}
+
+function PinBody({ data }: { data: PinResponse }): React.ReactElement {
+  const t = useTranslations("admin.publishPin");
+  const { pin, head, verdict } = data;
+  const drifted = verdict.state === "behind";
+
+  return (
+    <div className="space-y-4">
+      <dl className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        <div>
+          <dt className="text-xs uppercase tracking-wide text-text-3">
+            {t("pinnedSha")}
+          </dt>
+          <dd className="mt-1">
+            <a
+              href={contentTreeUrl(pin.sha)}
+              target="_blank"
+              rel="noreferrer"
+              className={LINK_CLASSES}
+            >
+              {shortSha(pin.sha)}
+            </a>
+          </dd>
+        </div>
+        <div>
+          <dt className="text-xs uppercase tracking-wide text-text-3">
+            {t("headSha")}
+          </dt>
+          <dd className="mt-1 flex items-center gap-2">
+            <a
+              href={contentCommitUrl(head.sha)}
+              target="_blank"
+              rel="noreferrer"
+              className={LINK_CLASSES}
+            >
+              {shortSha(head.sha)}
+            </a>
+            <ChecksBadge checks={head.checks} />
+          </dd>
+        </div>
+      </dl>
+
+      <div>
+        <dt className="text-xs uppercase tracking-wide text-text-3">
+          {t("drift")}
+        </dt>
+        <dd className="mt-1 text-sm font-medium text-text">
+          {verdict.state === "up_to_date"
+            ? t("upToDate")
+            : verdict.commitsBehind == null
+              ? t("behindUnknown")
+              : t("behind", { count: verdict.commitsBehind })}
+        </dd>
+      </div>
+
+      <p className="text-xs text-text-3">
+        {t("counts", {
+          courses: pin.counts.courses ?? 0,
+          lessons: pin.counts.lessons ?? 0,
+        })}
+      </p>
+
+      {drifted && <PreparePr data={data} />}
+    </div>
+  );
+}
+
+function PreparePr({ data }: { data: PinResponse }): React.ReactElement {
+  const t = useTranslations("admin.publishPin");
+  const { pin, head, verdict } = data;
+  const diff = buildLockDiff(pin.sha, head.sha);
+  const title = buildPrTitle(head.sha);
+  const body = buildPrBody({
+    pinnedSha: pin.sha,
+    headSha: head.sha,
+    commitsBehind: verdict.commitsBehind,
+  });
+  const branch = suggestBranchName(head.sha);
+  const prUrl = buildPublishPrUrl({ pinnedSha: pin.sha, headSha: head.sha });
+
+  return (
+    <section className="space-y-4 rounded-md border border-border bg-bg p-4">
+      <h4 className="font-display text-sm font-bold text-text">
+        {t("prepare.title")}
+      </h4>
+
+      {verdict.warnRedHead && (
+        <div
+          role="alert"
+          className="rounded-md border border-danger bg-danger-light p-3 text-sm text-danger"
+        >
+          {t("prepare.redHeadWarning")}
+        </div>
+      )}
+
+      <div className="space-y-1">
+        <p className="text-xs font-medium uppercase tracking-wide text-text-3">
+          {t("prepare.step1")}
+        </p>
+        <pre className="overflow-x-auto rounded-md border border-border bg-card p-3 text-xs">
+          <code className="font-mono text-text">{diff}</code>
+        </pre>
+      </div>
+
+      <div className="space-y-1">
+        <p className="text-xs font-medium uppercase tracking-wide text-text-3">
+          {t("prepare.step2")}
+        </p>
+        <div className="flex flex-wrap items-center gap-2">
+          <code className="rounded-md border border-border bg-card px-2 py-1 font-mono text-xs text-text">
+            {COMPILE_COMMAND}
+          </code>
+          <CopyButton text={COMPILE_COMMAND} label={t("copyCommand")} />
+        </div>
+        <p className="text-xs text-text-3">
+          {t("prepare.step2Hint", { path: LOCK_PATH })}
+        </p>
+      </div>
+
+      <div className="space-y-2">
+        <p className="text-xs font-medium uppercase tracking-wide text-text-3">
+          {t("prepare.step3")}
+        </p>
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="text-xs text-text-3">{t("prepare.branch")}</span>
+          <code className="rounded-md border border-border bg-card px-2 py-1 font-mono text-xs text-text">
+            {branch}
+          </code>
+          <CopyButton text={branch} label={t("copyBranch")} />
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <CopyButton text={title} label={t("copyTitle")} />
+          <CopyButton text={body} label={t("copyBody")} />
+          <a
+            href={contentCompareUrl(pin.sha, head.sha)}
+            target="_blank"
+            rel="noreferrer"
+            className={`${BUTTON_CLASSES} inline-flex items-center`}
+          >
+            {t("viewCompare")}
+          </a>
+          <a
+            href={prUrl}
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex items-center rounded-md border border-primary bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground shadow-push-sm transition-all hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary active:translate-y-[1px]"
+          >
+            {t("preparePrLink")}
+          </a>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/app/[locale]/admin/publish/publish-pin-client.tsx
+++ b/apps/web/src/app/[locale]/admin/publish/publish-pin-client.tsx
@@ -183,20 +183,19 @@ function PinBody({ data }: { data: PinResponse }): React.ReactElement {
             <ChecksBadge checks={head.checks} />
           </dd>
         </div>
+        <div className="sm:col-span-2">
+          <dt className="text-xs uppercase tracking-wide text-text-3">
+            {t("drift")}
+          </dt>
+          <dd className="mt-1 text-sm font-medium text-text">
+            {verdict.state === "up_to_date"
+              ? t("upToDate")
+              : verdict.commitsBehind == null
+                ? t("behindUnknown")
+                : t("behind", { count: verdict.commitsBehind })}
+          </dd>
+        </div>
       </dl>
-
-      <div>
-        <dt className="text-xs uppercase tracking-wide text-text-3">
-          {t("drift")}
-        </dt>
-        <dd className="mt-1 text-sm font-medium text-text">
-          {verdict.state === "up_to_date"
-            ? t("upToDate")
-            : verdict.commitsBehind == null
-              ? t("behindUnknown")
-              : t("behind", { count: verdict.commitsBehind })}
-        </dd>
-      </div>
 
       <p className="text-xs text-text-3">
         {t("counts", {

--- a/apps/web/src/app/api/admin/publish/pin/__tests__/route.test.ts
+++ b/apps/web/src/app/api/admin/publish/pin/__tests__/route.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi } from "vitest";
+import type { NextRequest } from "next/server";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/admin/auth", () => ({
+  AdminAuthError: class extends Error {},
+  adminUnauthorizedResponse: () => new Response("{}", { status: 401 }),
+  requireAdminAuth: vi.fn(),
+}));
+
+const fetchHeadSha = vi.fn();
+const fetchChecksState = vi.fn();
+const fetchAheadBy = vi.fn();
+vi.mock("@/lib/content-sync/github", () => ({
+  createGitHubClient: () => ({ fetchHeadSha, fetchChecksState, fetchAheadBy }),
+}));
+
+// The committed bundle's meta — pin the sha the route reads.
+vi.mock("@/lib/content/meta", () => ({
+  contentMeta: {
+    sha: "a".repeat(40),
+    counts: { courses: 6, lessons: 76 },
+    compiledAt: "2026-07-10T18:10:15Z",
+  },
+}));
+
+import { GET } from "../route";
+
+const get = (): Promise<Response> =>
+  GET(new Request("https://x/api/admin/publish/pin") as unknown as NextRequest);
+
+describe("GET /api/admin/publish/pin", () => {
+  it("reports up_to_date when the pin equals HEAD", async () => {
+    fetchHeadSha.mockResolvedValue("a".repeat(40));
+    fetchChecksState.mockResolvedValue("success");
+    const res = await get();
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      verdict: { state: string; commitsBehind: number };
+      pin: { counts: Record<string, number> };
+    };
+    expect(body.verdict.state).toBe("up_to_date");
+    expect(body.pin.counts.courses).toBe(6);
+    expect(fetchAheadBy).not.toHaveBeenCalled();
+  });
+
+  it("reports behind with the compare ahead_by when drifted", async () => {
+    fetchHeadSha.mockResolvedValue("b".repeat(40));
+    fetchChecksState.mockResolvedValue("success");
+    fetchAheadBy.mockResolvedValue(4);
+    const res = await get();
+    const body = (await res.json()) as {
+      verdict: { state: string; commitsBehind: number; warnRedHead: boolean };
+    };
+    expect(body.verdict.state).toBe("behind");
+    expect(body.verdict.commitsBehind).toBe(4);
+    expect(body.verdict.warnRedHead).toBe(false);
+  });
+
+  it("warns and null-counts when compare fails on a red HEAD", async () => {
+    fetchHeadSha.mockResolvedValue("c".repeat(40));
+    fetchChecksState.mockResolvedValue("failure");
+    fetchAheadBy.mockRejectedValue(new Error("compare boom"));
+    const res = await get();
+    const body = (await res.json()) as {
+      verdict: { commitsBehind: number | null; warnRedHead: boolean };
+    };
+    expect(body.verdict.commitsBehind).toBeNull();
+    expect(body.verdict.warnRedHead).toBe(true);
+  });
+
+  it("503s when GitHub is unreachable", async () => {
+    const { GitHubUnavailableError } = await import("@/lib/content-sync/types");
+    fetchHeadSha.mockRejectedValue(new GitHubUnavailableError("no token"));
+    const res = await get();
+    expect(res.status).toBe(503);
+    const body = (await res.json()) as { unavailable: boolean };
+    expect(body.unavailable).toBe(true);
+  });
+});

--- a/apps/web/src/app/api/admin/publish/pin/route.ts
+++ b/apps/web/src/app/api/admin/publish/pin/route.ts
@@ -1,0 +1,87 @@
+import "server-only";
+import { NextRequest, NextResponse } from "next/server";
+import {
+  requireAdminAuth,
+  adminUnauthorizedResponse,
+  AdminAuthError,
+} from "@/lib/admin/auth";
+import { createGitHubClient } from "@/lib/content-sync/github";
+import {
+  GitHubUnavailableError,
+  type ChecksState,
+} from "@/lib/content-sync/types";
+import {
+  computePublishVerdict,
+  CONTENT_REPO,
+  APP_REPO,
+} from "@/lib/content-sync/publish-pin";
+import { contentMeta } from "@/lib/content/meta";
+
+/**
+ * GET /api/admin/publish/pin — the SP3-B "Content pin" data source.
+ *
+ * Returns the pinned SHA + counts (from the committed bundle's `meta.json`,
+ * which the compiler writes from `content.lock`), courses-academy HEAD + its CI
+ * checks, and a drift verdict. This route holds NO GitHub write token and never
+ * writes the repo — the pin bump is a one-line human PR (spec rev-2, locked).
+ * GitHub unreachable is a 503 so the card shows "drift unavailable" instead of
+ * crashing, mirroring `/api/admin/content/drift`.
+ */
+export const dynamic = "force-dynamic";
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  try {
+    requireAdminAuth(req);
+  } catch (e) {
+    if (e instanceof AdminAuthError) return adminUnauthorizedResponse();
+    throw e;
+  }
+
+  const pinnedSha = contentMeta.sha;
+
+  let headSha: string;
+  let headChecks: ChecksState;
+  let aheadBy: number | null = null;
+  try {
+    const github = createGitHubClient();
+    headSha = await github.fetchHeadSha();
+    headChecks = await github.fetchChecksState(headSha);
+    // One extra compare call to surface "N commits behind"; best-effort so a
+    // compare hiccup degrades to an unknown count rather than a 503.
+    if (headSha !== pinnedSha) {
+      try {
+        aheadBy = await github.fetchAheadBy(pinnedSha, headSha);
+      } catch {
+        aheadBy = null;
+      }
+    } else {
+      aheadBy = 0;
+    }
+  } catch (e) {
+    if (e instanceof GitHubUnavailableError) {
+      return NextResponse.json(
+        { error: e.message, unavailable: true },
+        { status: 503 }
+      );
+    }
+    throw e;
+  }
+
+  const verdict = computePublishVerdict({
+    pinnedSha,
+    headSha,
+    aheadBy,
+    headChecks,
+  });
+
+  return NextResponse.json({
+    pin: {
+      sha: pinnedSha,
+      counts: contentMeta.counts,
+      compiledAt: contentMeta.compiledAt,
+    },
+    head: { sha: headSha, checks: headChecks },
+    verdict,
+    repos: { content: CONTENT_REPO, app: APP_REPO },
+  });
+}

--- a/apps/web/src/lib/content-sync/__tests__/publish-pin.test.ts
+++ b/apps/web/src/lib/content-sync/__tests__/publish-pin.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect } from "vitest";
+import {
+  computePublishVerdict,
+  shortSha,
+  contentTreeUrl,
+  contentCompareUrl,
+  suggestBranchName,
+  buildLockDiff,
+  buildPrTitle,
+  buildPrBody,
+  buildPublishPrUrl,
+  CONTENT_REPO,
+  APP_REPO,
+  LOCK_PATH,
+} from "../publish-pin";
+
+const PIN = "401c7df1035061337dd209ea8a8c7272d3223cbc";
+const HEAD = "b".repeat(40);
+
+describe("computePublishVerdict", () => {
+  it("is up_to_date when the pin equals HEAD", () => {
+    const v = computePublishVerdict({
+      pinnedSha: PIN,
+      headSha: PIN,
+      aheadBy: 0,
+      headChecks: "success",
+    });
+    expect(v.state).toBe("up_to_date");
+    expect(v.commitsBehind).toBe(0);
+    expect(v.warnRedHead).toBe(false);
+  });
+
+  it("is behind with the compare ahead_by when drifted and CI green", () => {
+    const v = computePublishVerdict({
+      pinnedSha: PIN,
+      headSha: HEAD,
+      aheadBy: 3,
+      headChecks: "success",
+    });
+    expect(v.state).toBe("behind");
+    expect(v.commitsBehind).toBe(3);
+    expect(v.warnRedHead).toBe(false);
+  });
+
+  it("warns when drifted and HEAD CI is failing", () => {
+    const v = computePublishVerdict({
+      pinnedSha: PIN,
+      headSha: HEAD,
+      aheadBy: 1,
+      headChecks: "failure",
+    });
+    expect(v.warnRedHead).toBe(true);
+  });
+
+  it("warns when drifted and HEAD CI is still pending", () => {
+    const v = computePublishVerdict({
+      pinnedSha: PIN,
+      headSha: HEAD,
+      aheadBy: 1,
+      headChecks: "pending",
+    });
+    expect(v.warnRedHead).toBe(true);
+  });
+
+  it("carries a null commit count when the compare call was skipped", () => {
+    const v = computePublishVerdict({
+      pinnedSha: PIN,
+      headSha: HEAD,
+      aheadBy: null,
+      headChecks: "success",
+    });
+    expect(v.state).toBe("behind");
+    expect(v.commitsBehind).toBeNull();
+  });
+});
+
+describe("shortSha", () => {
+  it("truncates to 7 chars", () => {
+    expect(shortSha(PIN)).toBe("401c7df");
+  });
+  it("returns an em-dash for null/undefined", () => {
+    expect(shortSha(null)).toBe("—");
+    expect(shortSha(undefined)).toBe("—");
+  });
+});
+
+describe("links", () => {
+  it("builds a content-repo tree URL at the sha", () => {
+    expect(contentTreeUrl(PIN)).toBe(
+      `https://github.com/${CONTENT_REPO}/tree/${PIN}`
+    );
+  });
+
+  it("builds a content-repo compare URL pin...HEAD", () => {
+    expect(contentCompareUrl(PIN, HEAD)).toBe(
+      `https://github.com/${CONTENT_REPO}/compare/${PIN}...${HEAD}`
+    );
+  });
+
+  it("suggests a branch name from the short HEAD sha", () => {
+    expect(suggestBranchName(HEAD)).toBe("chore/content-pin-bbbbbbb");
+  });
+
+  it("builds a prefilled app-repo PR link with encoded title/body", () => {
+    const url = buildPublishPrUrl({ pinnedSha: PIN, headSha: HEAD });
+    expect(url.startsWith(`https://github.com/${APP_REPO}/compare/main?`)).toBe(
+      true
+    );
+    const params = new URLSearchParams(url.split("?")[1]);
+    expect(params.get("quick_pull")).toBe("1");
+    expect(params.get("title")).toContain("bump content.lock");
+    expect(params.get("body")).toContain(LOCK_PATH);
+  });
+});
+
+describe("buildLockDiff", () => {
+  it("emits the one-line sha change against the lock path", () => {
+    const diff = buildLockDiff(PIN, HEAD);
+    expect(diff).toContain(`--- a/${LOCK_PATH}`);
+    expect(diff).toContain(`-  "sha": "${PIN}"`);
+    expect(diff).toContain(`+  "sha": "${HEAD}"`);
+  });
+});
+
+describe("PR text", () => {
+  it("titles the PR with the short HEAD sha", () => {
+    expect(buildPrTitle(HEAD)).toContain("bbbbbbb");
+  });
+
+  it("includes the compile command and commit count in the body", () => {
+    const body = buildPrBody({
+      pinnedSha: PIN,
+      headSha: HEAD,
+      commitsBehind: 4,
+    });
+    expect(body).toContain("pnpm --filter web compile-content");
+    expect(body).toContain("4 commit(s)");
+  });
+
+  it("omits the commit-count sentence when unknown", () => {
+    const body = buildPrBody({
+      pinnedSha: PIN,
+      headSha: HEAD,
+      commitsBehind: null,
+    });
+    expect(body).not.toContain("commit(s)");
+  });
+});

--- a/apps/web/src/lib/content-sync/__tests__/sync.test.ts
+++ b/apps/web/src/lib/content-sync/__tests__/sync.test.ts
@@ -88,6 +88,7 @@ function github(
     fetchTarball: async () => tarball,
     fetchHeadSha: async () => sha,
     fetchChecksState: async () => checks,
+    fetchAheadBy: async () => 0,
   };
 }
 

--- a/apps/web/src/lib/content-sync/github.ts
+++ b/apps/web/src/lib/content-sync/github.ts
@@ -10,6 +10,8 @@ export interface GitHubClient {
   fetchTarball(sha: string): Promise<Uint8Array>;
   fetchHeadSha(): Promise<string>;
   fetchChecksState(sha: string): Promise<ChecksState>;
+  /** Commits `head` is ahead of `base` (compare API `ahead_by`). */
+  fetchAheadBy(base: string, head: string): Promise<number>;
 }
 
 interface Opts {
@@ -91,6 +93,17 @@ export function createGitHubClient(opts: Opts = {}): GitHubClient {
         return "failure";
       if (runs.some((r) => !isTerminal(r.conclusion))) return "pending";
       return "success";
+    },
+
+    async fetchAheadBy(base, head) {
+      const res = await call(
+        `/repos/${REPO}/compare/${base}...${head}`,
+        "application/vnd.github+json"
+      );
+      const body = (await res.json()) as { ahead_by?: number };
+      if (typeof body.ahead_by !== "number")
+        throw new GitHubUnavailableError("compare response missing ahead_by");
+      return body.ahead_by;
     },
   };
 }

--- a/apps/web/src/lib/content-sync/publish-pin.ts
+++ b/apps/web/src/lib/content-sync/publish-pin.ts
@@ -1,0 +1,143 @@
+import type { ChecksState } from "./types";
+
+/**
+ * SP3-B publish-pin: the pure drift/verdict + PR-link helpers behind the
+ * `/admin/publish` "Content pin" card. The pin bump is a ONE-LINE HUMAN PR —
+ * these helpers only describe the drift and build the exact diff + a prefilled
+ * PR link. Nothing here performs (or enables) a server-side repo write; the
+ * admin route that consumes them holds no write token (spec rev-2, locked).
+ */
+
+/** The content source repo `apps/web/content.lock` pins (a courses commit). */
+export const CONTENT_REPO = "solanabr/courses-academy";
+/** The app repo the one-line `content.lock` bump PR is opened against. */
+export const APP_REPO = "solanabr/superteam-academy";
+/** Repo-relative path of the pin file the bump edits. */
+export const LOCK_PATH = "apps/web/content.lock";
+
+export type PublishVerdictState = "up_to_date" | "behind" | "unknown";
+
+export interface PublishVerdict {
+  state: PublishVerdictState;
+  /** Commits HEAD is ahead of the pin (compare `ahead_by`); null if unknown. */
+  commitsBehind: number | null;
+  /** HEAD's combined CI state — bumping to a red HEAD is warned against. */
+  headChecks: ChecksState;
+  /** True when drifted AND HEAD's CI is not green: warn before bumping. */
+  warnRedHead: boolean;
+}
+
+/**
+ * The drift verdict: pin == HEAD is up-to-date; otherwise "N commits behind"
+ * (from the compare `ahead_by`, or null when that call was skipped/failed).
+ * A drifted HEAD whose CI is not `success` sets `warnRedHead` — the UI must
+ * discourage bumping to unverified content.
+ */
+export function computePublishVerdict(input: {
+  pinnedSha: string;
+  headSha: string;
+  aheadBy: number | null;
+  headChecks: ChecksState;
+}): PublishVerdict {
+  if (input.pinnedSha === input.headSha) {
+    return {
+      state: "up_to_date",
+      commitsBehind: 0,
+      headChecks: input.headChecks,
+      warnRedHead: false,
+    };
+  }
+  return {
+    state: "behind",
+    commitsBehind: input.aheadBy,
+    headChecks: input.headChecks,
+    warnRedHead: input.headChecks !== "success",
+  };
+}
+
+/** Short 7-char SHA for display, or an em-dash when absent. */
+export function shortSha(sha: string | null | undefined): string {
+  return sha ? sha.slice(0, 7) : "—";
+}
+
+/** Link to the content repo tree browsed at a specific commit. */
+export function contentTreeUrl(sha: string): string {
+  return `https://github.com/${CONTENT_REPO}/tree/${sha}`;
+}
+
+/** Link to a single content-repo commit. */
+export function contentCommitUrl(sha: string): string {
+  return `https://github.com/${CONTENT_REPO}/commit/${sha}`;
+}
+
+/** Compare view of the commits a bump would pull in (pin → HEAD). */
+export function contentCompareUrl(pinnedSha: string, headSha: string): string {
+  return `https://github.com/${CONTENT_REPO}/compare/${pinnedSha}...${headSha}`;
+}
+
+/** Suggested branch name for the bump PR, e.g. `chore/content-pin-a1b2c3d`. */
+export function suggestBranchName(headSha: string): string {
+  return `chore/content-pin-${shortSha(headSha)}`;
+}
+
+/** The exact one-line `content.lock` edit the human PR makes (old → new sha). */
+export function buildLockDiff(oldSha: string, newSha: string): string {
+  return [
+    `--- a/${LOCK_PATH}`,
+    `+++ b/${LOCK_PATH}`,
+    `-  "sha": "${oldSha}"`,
+    `+  "sha": "${newSha}"`,
+  ].join("\n");
+}
+
+/** The local command that rebuilds the committed bundle from the new pin. */
+export const COMPILE_COMMAND = "pnpm --filter web compile-content";
+
+/** Copyable PR title for the bump. */
+export function buildPrTitle(headSha: string): string {
+  return `chore(content): bump content.lock to ${shortSha(headSha)}`;
+}
+
+/** Copyable PR body: what changed, the pin transition, and the rebuild step. */
+export function buildPrBody(input: {
+  pinnedSha: string;
+  headSha: string;
+  commitsBehind: number | null;
+}): string {
+  const behind =
+    input.commitsBehind == null
+      ? ""
+      : `\n\nPulls in ${input.commitsBehind} commit(s) from ${CONTENT_REPO}.`;
+  return (
+    `Bump \`${LOCK_PATH}\` pin from \`${shortSha(input.pinnedSha)}\` to ` +
+    `\`${shortSha(input.headSha)}\` and regenerate the committed content ` +
+    `bundle.${behind}\n\n` +
+    `Steps:\n` +
+    `1. Edit \`${LOCK_PATH}\`: set \`"sha"\` to \`${input.headSha}\`.\n` +
+    `2. Run \`${COMPILE_COMMAND}\`.\n` +
+    `3. Commit both \`${LOCK_PATH}\` and \`apps/web/src/content/generated/\`.\n\n` +
+    `Compare: ${contentCompareUrl(input.pinnedSha, input.headSha)}`
+  );
+}
+
+/**
+ * Prefilled "new PR" link on the APP repo compare page. GitHub prefills the
+ * PR form's title/body from the query params; the contributor selects their
+ * pushed branch there. This link performs NO write — it only opens the form.
+ */
+export function buildPublishPrUrl(input: {
+  pinnedSha: string;
+  headSha: string;
+}): string {
+  const params = new URLSearchParams({
+    quick_pull: "1",
+    expand: "1",
+    title: buildPrTitle(input.headSha),
+    body: buildPrBody({
+      pinnedSha: input.pinnedSha,
+      headSha: input.headSha,
+      commitsBehind: null,
+    }),
+  });
+  return `https://github.com/${APP_REPO}/compare/main?${params.toString()}`;
+}

--- a/apps/web/src/lib/content/meta.ts
+++ b/apps/web/src/lib/content/meta.ts
@@ -1,0 +1,20 @@
+import "server-only";
+import meta from "@/content/generated/meta.json";
+
+/**
+ * The committed content bundle's `meta.json`, surfaced through `lib/content`
+ * (the only place the ESLint rule permits importing `content/generated/*`).
+ * `meta.json` carries no secrets — just the pinned SHA the compiler read from
+ * `content.lock` plus per-type counts — but it is routed here so the generated
+ * dir keeps a single import seam. `server-only` matches the rest of the store.
+ */
+export interface ContentMeta {
+  /** The courses-academy commit `content.lock` pins (mirrored by the compiler). */
+  sha: string;
+  /** Per-type document counts in the bundle (courses, lessons, …). */
+  counts: Record<string, number>;
+  /** ISO timestamp the bundle was compiled, when recorded. */
+  compiledAt?: string;
+}
+
+export const contentMeta: ContentMeta = meta;

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -850,6 +850,42 @@
       "deploy": "On-Chain Deploy",
       "moderation": "Community Moderation",
       "status": "Program Status"
+    },
+    "publishPin": {
+      "title": "Content pin",
+      "description": "The committed content bundle is pinned to a courses-academy commit in content.lock. Publishing new content is a one-line human PR that bumps the pin and rebuilds the bundle — no server-side write happens here.",
+      "refresh": "Refresh",
+      "loading": "Checking the content pin…",
+      "unavailable": "Drift unavailable — GitHub could not be reached. Try again shortly.",
+      "pinnedSha": "Pinned commit",
+      "headSha": "Repo HEAD",
+      "drift": "Drift",
+      "upToDate": "Up to date — the pin matches courses-academy HEAD.",
+      "behind": "{count, plural, one {# commit behind HEAD} other {# commits behind HEAD}}",
+      "behindUnknown": "Behind HEAD (commit count unavailable).",
+      "counts": "Bundle: {courses} courses, {lessons} lessons.",
+      "checks": {
+        "success": "CI passing",
+        "failure": "CI failing",
+        "pending": "CI pending",
+        "unknown": "CI unknown"
+      },
+      "copied": "Copied",
+      "copyCommand": "Copy command",
+      "copyBranch": "Copy branch",
+      "copyTitle": "Copy title",
+      "copyBody": "Copy body",
+      "viewCompare": "View commits",
+      "preparePrLink": "Open publish PR",
+      "prepare": {
+        "title": "Prepare publish PR",
+        "redHeadWarning": "HEAD's CI is not green. Do not bump the pin to unverified content — wait for CI to pass.",
+        "step1": "1. Apply this one-line change to content.lock",
+        "step2": "2. Rebuild the committed bundle locally",
+        "step2Hint": "Run this after editing {path}, then commit both the lock and the regenerated bundle.",
+        "step3": "3. Push a branch and open the PR",
+        "branch": "Suggested branch:"
+      }
     }
   }
 }

--- a/apps/web/src/messages/es.json
+++ b/apps/web/src/messages/es.json
@@ -850,6 +850,42 @@
       "deploy": "Despliegue on-chain",
       "moderation": "Moderación de la comunidad",
       "status": "Estado del programa"
+    },
+    "publishPin": {
+      "title": "Fijación de contenido",
+      "description": "El paquete de contenido versionado está fijado a un commit de courses-academy en content.lock. Publicar contenido nuevo es un PR humano de una línea que actualiza la fijación y reconstruye el paquete — aquí no ocurre ninguna escritura en el servidor.",
+      "refresh": "Actualizar",
+      "loading": "Comprobando la fijación de contenido…",
+      "unavailable": "Desfase no disponible — no se pudo contactar con GitHub. Inténtalo de nuevo en un momento.",
+      "pinnedSha": "Commit fijado",
+      "headSha": "HEAD del repositorio",
+      "drift": "Desfase",
+      "upToDate": "Al día — la fijación coincide con el HEAD de courses-academy.",
+      "behind": "{count, plural, one {# commit por detrás del HEAD} other {# commits por detrás del HEAD}}",
+      "behindUnknown": "Por detrás del HEAD (recuento de commits no disponible).",
+      "counts": "Paquete: {courses} cursos, {lessons} lecciones.",
+      "checks": {
+        "success": "CI en verde",
+        "failure": "CI en fallo",
+        "pending": "CI pendiente",
+        "unknown": "CI desconocida"
+      },
+      "copied": "Copiado",
+      "copyCommand": "Copiar comando",
+      "copyBranch": "Copiar rama",
+      "copyTitle": "Copiar título",
+      "copyBody": "Copiar descripción",
+      "viewCompare": "Ver commits",
+      "preparePrLink": "Abrir PR de publicación",
+      "prepare": {
+        "title": "Preparar PR de publicación",
+        "redHeadWarning": "La CI del HEAD no está en verde. No actualices la fijación a contenido no verificado — espera a que la CI pase.",
+        "step1": "1. Aplica este cambio de una línea a content.lock",
+        "step2": "2. Reconstruye el paquete versionado localmente",
+        "step2Hint": "Ejecuta esto tras editar {path}, luego confirma tanto el lock como el paquete regenerado.",
+        "step3": "3. Sube una rama y abre el PR",
+        "branch": "Rama sugerida:"
+      }
     }
   }
 }

--- a/apps/web/src/messages/pt-BR.json
+++ b/apps/web/src/messages/pt-BR.json
@@ -850,6 +850,42 @@
       "deploy": "Implantação on-chain",
       "moderation": "Moderação da comunidade",
       "status": "Status do programa"
+    },
+    "publishPin": {
+      "title": "Pin de conteúdo",
+      "description": "O pacote de conteúdo versionado está fixado em um commit do courses-academy no content.lock. Publicar novo conteúdo é um PR humano de uma linha que atualiza o pin e reconstrói o pacote — nenhuma escrita no servidor acontece aqui.",
+      "refresh": "Atualizar",
+      "loading": "Verificando o pin de conteúdo…",
+      "unavailable": "Divergência indisponível — não foi possível acessar o GitHub. Tente novamente em instantes.",
+      "pinnedSha": "Commit fixado",
+      "headSha": "HEAD do repositório",
+      "drift": "Divergência",
+      "upToDate": "Atualizado — o pin corresponde ao HEAD do courses-academy.",
+      "behind": "{count, plural, one {# commit atrás do HEAD} other {# commits atrás do HEAD}}",
+      "behindUnknown": "Atrás do HEAD (contagem de commits indisponível).",
+      "counts": "Pacote: {courses} cursos, {lessons} aulas.",
+      "checks": {
+        "success": "CI aprovada",
+        "failure": "CI falhando",
+        "pending": "CI pendente",
+        "unknown": "CI desconhecida"
+      },
+      "copied": "Copiado",
+      "copyCommand": "Copiar comando",
+      "copyBranch": "Copiar branch",
+      "copyTitle": "Copiar título",
+      "copyBody": "Copiar descrição",
+      "viewCompare": "Ver commits",
+      "preparePrLink": "Abrir PR de publicação",
+      "prepare": {
+        "title": "Preparar PR de publicação",
+        "redHeadWarning": "A CI do HEAD não está verde. Não atualize o pin para conteúdo não verificado — aguarde a CI passar.",
+        "step1": "1. Aplique esta alteração de uma linha ao content.lock",
+        "step2": "2. Reconstrua o pacote versionado localmente",
+        "step2Hint": "Execute isto após editar {path}, então faça o commit do lock e do pacote regenerado.",
+        "step3": "3. Envie uma branch e abra o PR",
+        "branch": "Branch sugerida:"
+      }
     }
   }
 }


### PR DESCRIPTION
SP3-B per the SP3 spec's locked publish mechanism (rev 2). **SAFE lane: GET-only, read-only token, zero server-side repo writes.**

## What
A "Content pin" card on /admin/publish (above the existing ContentSyncPanel — untouched, still one-file-deletable by SP2-C/D): pinned courses-academy SHA (linked), HEAD SHA + CI checks badge, drift verdict ("N commits behind"), bundle counts. When drifted: the exact one-line content.lock diff, the compile command, suggested branch, copyable PR title/body, and a prefilled "Open publish PR" link. A red/pending HEAD raises a role="alert" warning against publishing.

The pin bump stays a **one-line human PR** — the screen makes that flow one click + one paste; it holds no write token (spec-rejected).

## Evidence
Fable review: SPEC ✅ / approved — write-path trace confirmed GET-only end-to-end; server-only boundary intact; i18n en/pt-BR/es with correct ICU plurals; a11y (focus-visible, role=alert, valid dl markup after the review fix). `next build` clean with both new routes in the manifest. Suite 423 passing.

## Planning note surfaced by review (recorded in the SP2-C plan inputs)
lib/content-sync's blanket deletion at SP2-C must CARVE OUT the surviving publish-flow modules: github.ts (read client), publish-pin.ts, ChecksState/GitHubUnavailableError — relocate, don't delete.