### PR TITLE
SP3-D: admin polish — shared status hook, refresh affordance, nav flag badge, i18n sweep

### DIFF
--- a/.superpowers/sdd/sp3d-report.md
+++ b/.superpowers/sdd/sp3d-report.md
@@ -1,0 +1,56 @@
+# SP3-D — Moderation + Status screens polish
+
+Branch `feat/sp3d-admin-polish-11-07-2026` (off origin/main @ 3a90ac7). Committed, not pushed.
+Isolated worktree; `pnpm install` was needed (worktree had no node_modules).
+
+## Result
+
+- `pnpm --filter web test` → **60 files / 430 tests passed**
+- `tsc --noEmit` → clean
+- `next lint` → **0 errors** (only pre-existing import/order warnings in untouched files)
+- Prettier + Husky lint-staged ran clean on each commit.
+
+## Commits (3)
+
+1. `065a691` i18n(admin): externalize moved-panel strings with pt-BR/es
+2. `3c07a16` refactor(admin): shared useAdminStatus hook + status Refresh; drop deploy-counts testid
+3. `4e05445` feat(admin): pending-flags count badge on the Moderation nav link
+
+## The 5 items
+
+1. **Shared hook** — `app/[locale]/admin/use-admin-status.ts` (`useAdminStatus()` →
+   `{ status, loading, error, refetch }`). Both deploy-client and status-client consume it;
+   the duplicated fetch/loading/error/refetch block is gone. Own test file.
+2. **Status Refresh** — added a Refresh button to the program-status bar wired to `refetch`,
+   mirroring the deploy screen's existing button idiom. Test added.
+3. **Nav flag badge** — small count badge on the Moderation nav link (`admin-nav.tsx`).
+   Async, non-blocking; hidden on error/zero. Tests added (badge shows, zero-hidden, error-safe).
+4. **i18n sweep** — new `admin` namespace groups (`states`, `programBar`, `deployScreen`,
+   `resync`, `flags`) with real pt-BR/es. Touched: status-client, deploy-client,
+   data-resync-panel, flags-panel. Deep-parity test stays green.
+5. **Removed** `data-testid="deploy-counts"` from status-client; status test now queries
+   counts by their i18n'd labels (label span → nextElementSibling).
+
+## Badge data-source decision
+
+Reused the existing **`GET /api/admin/flags`** (the list route already behind
+`requireAdminAuth`) and took `flags.length`. No count-only endpoint exists, and the contract
+said not to add a route unless nothing usable exists — so no new route. The payload is capped
+at 200 rows; the count is exact up to that cap, which is more than enough for an at-a-glance badge.
+
+## Scope boundary / concerns
+
+- **i18n scope**: translated exactly the enumerated set (program-status bar, Data Resync panel,
+  deploy headings + empty states, shared loading/error/refresh, flags-panel chrome). I did **not**
+  translate `course-sync-table` / `achievement-sync-table` internals — they are not in the
+  enumerated list, are large, and `course-sync-table` pulls in the doomed `sync-diff-view`
+  (SP2-C). Left `content-sync-panel` + `sync-diff-view` hardcoded per instructions. Flag if the
+  intent was to sweep the sync tables too.
+- **Minor behavior nuance**: the hook now surfaces failures as a kind (`"fetch"` | `"network"`)
+  so each screen can localize the copy; the previous code showed the raw `Error.message` for the
+  network case. En text for both states is byte-identical to the old hardcoded strings, so all
+  existing string assertions still pass.
+- Did not touch the publish screen (PR #422 owns it); a trivial messages.json rebase may occur.
+
+> Note: written to the worktree copy of `.superpowers/sdd/sp3d-report.md` — this agent is
+> sandboxed to the worktree and cannot write the shared-checkout path directly.

--- a/apps/web/src/app/[locale]/admin/__tests__/admin-nav.test.tsx
+++ b/apps/web/src/app/[locale]/admin/__tests__/admin-nav.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import type { ReactElement } from "react";
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
 import { NextIntlClientProvider } from "next-intl";
 import { AdminNav } from "../admin-nav";
 import messages from "@/messages/en.json";
@@ -24,9 +24,25 @@ function renderWithIntl(ui: ReactElement) {
 
 const nav = messages.admin.nav;
 
+/** Stub the badge's `GET /api/admin/flags` with a given pending-flag count. */
+function mockFlags(count: number) {
+  const flags = Array.from({ length: count }, (_, i) => ({ id: `f${i}` }));
+  const fetchMock = vi
+    .fn()
+    .mockResolvedValue({ ok: true, json: async () => ({ flags }) } as Response);
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
 beforeEach(() => {
   usePathnameMock.mockReset();
   usePathnameMock.mockReturnValue("/en/admin/status");
+  mockFlags(0);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
 });
 
 describe("AdminNav", () => {
@@ -82,5 +98,42 @@ describe("AdminNav", () => {
       "aria-current",
       "page"
     );
+  });
+
+  it("shows a pending-flag badge on Moderation once the count fetch resolves", async () => {
+    mockFlags(4);
+    renderWithIntl(<AdminNav />);
+
+    await waitFor(() => {
+      const link = screen.getByRole("link", { name: /Moderation/ });
+      expect(link).toHaveTextContent("4");
+    });
+    // The badge is scoped to Moderation, not other sections.
+    expect(
+      screen.getByRole("link", { name: nav.deploy })
+    ).not.toHaveTextContent("4");
+  });
+
+  it("renders no badge when there are zero pending flags", async () => {
+    mockFlags(0);
+    renderWithIntl(<AdminNav />);
+
+    // Give the async fetch a chance to resolve, then assert nothing appeared.
+    await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+    expect(
+      screen.getByRole("link", { name: nav.moderation })
+    ).toBeInTheDocument();
+  });
+
+  it("hides the badge (and never throws) when the count fetch fails", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("offline")));
+    renderWithIntl(<AdminNav />);
+
+    await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+    // Nav still renders its four links; the badge simply never shows.
+    expect(screen.getAllByRole("link")).toHaveLength(4);
+    expect(
+      screen.getByRole("link", { name: nav.moderation })
+    ).toBeInTheDocument();
   });
 });

--- a/apps/web/src/app/[locale]/admin/__tests__/admin-nav.test.tsx
+++ b/apps/web/src/app/[locale]/admin/__tests__/admin-nav.test.tsx
@@ -108,6 +108,8 @@ describe("AdminNav", () => {
       const link = screen.getByRole("link", { name: /Moderation/ });
       expect(link).toHaveTextContent("4");
     });
+    // The badge carries a pluralized, i18n'd accessible name.
+    expect(screen.getByLabelText("4 pending flags")).toHaveTextContent("4");
     // The badge is scoped to Moderation, not other sections.
     expect(
       screen.getByRole("link", { name: nav.deploy })

--- a/apps/web/src/app/[locale]/admin/__tests__/deploy-client.test.tsx
+++ b/apps/web/src/app/[locale]/admin/__tests__/deploy-client.test.tsx
@@ -1,8 +1,19 @@
 // @vitest-environment jsdom
+import type { ReactElement } from "react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
 import type { AdminStatus } from "../admin-status-types";
 import { DeployClient } from "../deploy/deploy-client";
+import messages from "@/messages/en.json";
+
+function renderWithIntl(ui: ReactElement) {
+  return render(
+    <NextIntlClientProvider locale="en" messages={messages}>
+      {ui}
+    </NextIntlClientProvider>
+  );
+}
 
 // The sync tables carry their own tests and fire on-chain sync requests, so
 // they are stubbed; the stubs surface the props wiring under test.
@@ -72,7 +83,7 @@ afterEach(() => {
 describe("DeployClient", () => {
   it("fetches /api/admin/status and renders both sync tables", async () => {
     const fetchMock = mockStatusFetch();
-    render(<DeployClient />);
+    renderWithIntl(<DeployClient />);
 
     expect(screen.getByText("Loading on-chain status...")).toBeInTheDocument();
 
@@ -85,7 +96,7 @@ describe("DeployClient", () => {
 
   it("shows the empty-state copy when there are no courses/achievements", async () => {
     mockStatusFetch({ ...status, courses: [], achievements: [] });
-    render(<DeployClient />);
+    renderWithIntl(<DeployClient />);
 
     await waitFor(() => {
       expect(
@@ -99,7 +110,7 @@ describe("DeployClient", () => {
 
   it("refetches on the Refresh button and on the table's onRefresh", async () => {
     const fetchMock = mockStatusFetch();
-    render(<DeployClient />);
+    renderWithIntl(<DeployClient />);
 
     await waitFor(() => {
       expect(screen.getByTestId("course-sync-table")).toBeInTheDocument();
@@ -123,7 +134,7 @@ describe("DeployClient", () => {
       .mockResolvedValue({ ok: true, json: async () => status } as Response);
     vi.stubGlobal("fetch", fetchMock);
 
-    render(<DeployClient />);
+    renderWithIntl(<DeployClient />);
     await waitFor(() => {
       expect(screen.getByText("Failed to fetch status")).toBeInTheDocument();
     });

--- a/apps/web/src/app/[locale]/admin/__tests__/status-client.test.tsx
+++ b/apps/web/src/app/[locale]/admin/__tests__/status-client.test.tsx
@@ -138,13 +138,28 @@ describe("StatusClient", () => {
     await waitFor(() => {
       expect(screen.getByTestId("data-resync-panel")).toBeInTheDocument();
     });
-    const counts = screen.getByTestId("deploy-counts");
-    expect(counts).toHaveTextContent(
-      new RegExp(`${messages.admin.counts.courses}:\\s*2`)
+    // No test-id on prod markup: locate the counts by their i18n'd labels.
+    const coursesLabel = screen.getByText(`${messages.admin.counts.courses}:`);
+    expect(coursesLabel.nextElementSibling).toHaveTextContent("2");
+    const achievementsLabel = screen.getByText(
+      `${messages.admin.counts.achievements}:`
     );
-    expect(counts).toHaveTextContent(
-      new RegExp(`${messages.admin.counts.achievements}:\\s*1`)
+    expect(achievementsLabel.nextElementSibling).toHaveTextContent("1");
+  });
+
+  it("refetches on the program-bar Refresh button", async () => {
+    const fetchMock = mockStatusFetch();
+    renderWithIntl(<StatusClient />);
+
+    await waitFor(() => {
+      expect(screen.getByText("devnet")).toBeInTheDocument();
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: messages.admin.states.refresh })
     );
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
   });
 
   it("shows the error state and refetches on Retry", async () => {

--- a/apps/web/src/app/[locale]/admin/__tests__/use-admin-status.test.tsx
+++ b/apps/web/src/app/[locale]/admin/__tests__/use-admin-status.test.tsx
@@ -1,0 +1,77 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, waitFor, act } from "@testing-library/react";
+import type { AdminStatus } from "../admin-status-types";
+import { useAdminStatus } from "../use-admin-status";
+
+const status: AdminStatus = {
+  program: {
+    deployed: true,
+    programId: "AcademyProgram1111111111111111111111111111",
+    configPda: "Config11111111111111111111111111111111111",
+    minterRegistered: true,
+    authorityMatch: { matches: true },
+  },
+  courses: [],
+  achievements: [],
+};
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", vi.fn());
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("useAdminStatus", () => {
+  it("fetches /api/admin/status on mount and exposes the payload", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue({ ok: true, json: async () => status } as Response);
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result } = renderHook(() => useAdminStatus());
+    expect(result.current.loading).toBe(true);
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.status).toEqual(status);
+    expect(result.current.error).toBeNull();
+    expect(fetchMock).toHaveBeenCalledWith("/api/admin/status");
+  });
+
+  it("surfaces a 'fetch' error kind on a non-ok response", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ ok: false } as Response)
+    );
+
+    const { result } = renderHook(() => useAdminStatus());
+    await waitFor(() => expect(result.current.error).toBe("fetch"));
+    expect(result.current.status).toBeNull();
+  });
+
+  it("surfaces a 'network' error kind when fetch throws", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("boom")));
+
+    const { result } = renderHook(() => useAdminStatus());
+    await waitFor(() => expect(result.current.error).toBe("network"));
+  });
+
+  it("refetches and clears a prior error", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: false } as Response)
+      .mockResolvedValue({ ok: true, json: async () => status } as Response);
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result } = renderHook(() => useAdminStatus());
+    await waitFor(() => expect(result.current.error).toBe("fetch"));
+
+    act(() => result.current.refetch());
+    await waitFor(() => expect(result.current.status).toEqual(status));
+    expect(result.current.error).toBeNull();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/web/src/app/[locale]/admin/__tests__/use-admin-status.test.tsx
+++ b/apps/web/src/app/[locale]/admin/__tests__/use-admin-status.test.tsx
@@ -74,4 +74,19 @@ describe("useAdminStatus", () => {
     expect(result.current.error).toBeNull();
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
+
+  it("returns a referentially stable refetch across re-renders", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValue({ ok: true, json: async () => status } as Response)
+    );
+
+    const { result, rerender } = renderHook(() => useAdminStatus());
+    const first = result.current.refetch;
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    rerender();
+    expect(result.current.refetch).toBe(first);
+  });
 });

--- a/apps/web/src/app/[locale]/admin/admin-nav.tsx
+++ b/apps/web/src/app/[locale]/admin/admin-nav.tsx
@@ -1,11 +1,42 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useTranslations, useLocale } from "next-intl";
 import { cn } from "@/lib/utils";
 
 const SECTIONS = ["publish", "deploy", "moderation", "status"] as const;
+
+/**
+ * Best-effort pending-flags count for the "Moderation" nav badge. Reuses the
+ * existing `GET /api/admin/flags` list route (no count-only sibling exists);
+ * `.length` of the returned rows is the pending count. Purely additive to nav
+ * render — it never throws into the tree, and a failed/zero fetch leaves the
+ * badge hidden.
+ */
+function usePendingFlagCount(): number {
+  const [count, setCount] = useState(0);
+
+  useEffect(() => {
+    let active = true;
+    void (async () => {
+      try {
+        const res = await fetch("/api/admin/flags");
+        if (!res.ok) return;
+        const body = (await res.json()) as { flags?: unknown[] };
+        if (active) setCount(body.flags?.length ?? 0);
+      } catch {
+        // Non-critical at-a-glance count; leave the badge hidden on error.
+      }
+    })();
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  return count;
+}
 
 /**
  * Persistent admin console navigation: a left rail on desktop, horizontal
@@ -18,6 +49,7 @@ export function AdminNav() {
   const t = useTranslations("admin");
   const locale = useLocale();
   const pathname = usePathname();
+  const pendingFlags = usePendingFlagCount();
 
   return (
     <nav aria-label={t("console.navLabel")} className="shrink-0 md:w-48">
@@ -25,6 +57,7 @@ export function AdminNav() {
         {SECTIONS.map((section) => {
           const href = `/${locale}/admin/${section}`;
           const isActive = pathname === href || pathname.startsWith(`${href}/`);
+          const showBadge = section === "moderation" && pendingFlags > 0;
 
           return (
             <li key={section}>
@@ -32,14 +65,19 @@ export function AdminNav() {
                 href={href}
                 aria-current={isActive ? "page" : undefined}
                 className={cn(
-                  "block whitespace-nowrap rounded-[var(--r-md)] px-3 py-2 text-sm font-semibold no-underline transition-colors duration-150",
+                  "flex items-center justify-between gap-2 whitespace-nowrap rounded-[var(--r-md)] px-3 py-2 text-sm font-semibold no-underline transition-colors duration-150",
                   "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg)]",
                   isActive
                     ? "bg-[var(--primary-dim)] text-[var(--primary)]"
                     : "text-[var(--text-3)] hover:bg-[var(--card)] hover:text-[var(--text-2)]"
                 )}
               >
-                {t(`nav.${section}`)}
+                <span>{t(`nav.${section}`)}</span>
+                {showBadge && (
+                  <span className="inline-flex min-w-[1.25rem] items-center justify-center rounded-full bg-danger px-1.5 py-0.5 text-xs font-bold leading-none text-white">
+                    {pendingFlags}
+                  </span>
+                )}
               </Link>
             </li>
           );

--- a/apps/web/src/app/[locale]/admin/admin-nav.tsx
+++ b/apps/web/src/app/[locale]/admin/admin-nav.tsx
@@ -74,7 +74,10 @@ export function AdminNav() {
               >
                 <span>{t(`nav.${section}`)}</span>
                 {showBadge && (
-                  <span className="inline-flex min-w-[1.25rem] items-center justify-center rounded-full bg-danger px-1.5 py-0.5 text-xs font-bold leading-none text-white">
+                  <span
+                    aria-label={t("nav.pendingFlags", { count: pendingFlags })}
+                    className="inline-flex min-w-[1.25rem] items-center justify-center rounded-full bg-danger px-1.5 py-0.5 text-xs font-bold leading-none text-white"
+                  >
                     {pendingFlags}
                   </span>
                 )}

--- a/apps/web/src/app/[locale]/admin/deploy/deploy-client.tsx
+++ b/apps/web/src/app/[locale]/admin/deploy/deploy-client.tsx
@@ -1,48 +1,24 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
-import type { AdminStatus } from "../admin-status-types";
+import { useTranslations } from "next-intl";
+import { useAdminStatus } from "../use-admin-status";
 import { CourseSyncTable } from "@/components/admin/course-sync-table";
 import { AchievementSyncTable } from "@/components/admin/achievement-sync-table";
 
 /**
  * `/admin/deploy` client: the Courses + Achievements sync tables relocated
- * verbatim from the deleted stacked `admin-client.tsx` (SP3-A Task 3), with
- * the same `/api/admin/status` fetch, loading/error/refetch semantics, and
- * `onRefresh` wiring.
+ * from the deleted stacked `admin-client.tsx` (SP3-A Task 3). The
+ * `/api/admin/status` fetch + loading/error/refetch now live in the shared
+ * `useAdminStatus` hook (SP3-D), which the status screen consumes too.
  */
 export function DeployClient() {
-  const [status, setStatus] = useState<AdminStatus | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-
-  const fetchStatus = useCallback(async () => {
-    setLoading(true);
-    setError(null);
-    try {
-      // Authorized via the httpOnly admin_session cookie (sent automatically).
-      const res = await fetch("/api/admin/status");
-      if (!res.ok) {
-        setError("Failed to fetch status");
-        return;
-      }
-      const data = (await res.json()) as AdminStatus;
-      setStatus(data);
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "Network error");
-    } finally {
-      setLoading(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    void fetchStatus();
-  }, [fetchStatus]);
+  const t = useTranslations("admin");
+  const { status, loading, error, refetch } = useAdminStatus();
 
   if (loading) {
     return (
       <div className="flex items-center justify-center py-20">
-        <div className="text-sm text-text-3">Loading on-chain status...</div>
+        <div className="text-sm text-text-3">{t("states.loading")}</div>
       </div>
     );
   }
@@ -50,12 +26,9 @@ export function DeployClient() {
   if (error) {
     return (
       <div className="rounded-md border border-danger bg-danger-light p-4 text-sm text-danger">
-        {error}
-        <button
-          onClick={() => void fetchStatus()}
-          className="ml-3 underline hover:no-underline"
-        >
-          Retry
+        {t(error === "network" ? "states.networkError" : "states.fetchError")}
+        <button onClick={refetch} className="ml-3 underline hover:no-underline">
+          {t("states.retry")}
         </button>
       </div>
     );
@@ -70,22 +43,21 @@ export function DeployClient() {
       {/* Courses */}
       <section>
         <div className="mb-4 flex items-center justify-between">
-          <h3 className="font-display text-lg font-bold text-text">Courses</h3>
+          <h3 className="font-display text-lg font-bold text-text">
+            {t("deployScreen.coursesHeading")}
+          </h3>
           <button
-            onClick={() => void fetchStatus()}
+            onClick={refetch}
             className="rounded-md border border-border bg-card px-3 py-1 text-xs text-text-2 shadow-push-sm transition-all hover:bg-subtle active:translate-y-[2px] active:shadow-push-active"
           >
-            Refresh
+            {t("states.refresh")}
           </button>
         </div>
         <div className="rounded-lg border border-border bg-card p-4 shadow-card">
           {courses.length === 0 ? (
-            <p className="text-sm text-text-3">No courses found in Sanity.</p>
+            <p className="text-sm text-text-3">{t("deployScreen.noCourses")}</p>
           ) : (
-            <CourseSyncTable
-              courses={courses}
-              onRefresh={() => void fetchStatus()}
-            />
+            <CourseSyncTable courses={courses} onRefresh={refetch} />
           )}
         </div>
       </section>
@@ -93,17 +65,17 @@ export function DeployClient() {
       {/* Achievements */}
       <section>
         <h3 className="mb-4 font-display text-lg font-bold text-text">
-          Achievements
+          {t("deployScreen.achievementsHeading")}
         </h3>
         <div className="rounded-lg border border-border bg-card p-4 shadow-card">
           {achievements.length === 0 ? (
             <p className="text-sm text-text-3">
-              No achievements found in Sanity.
+              {t("deployScreen.noAchievements")}
             </p>
           ) : (
             <AchievementSyncTable
               achievements={achievements}
-              onRefresh={() => void fetchStatus()}
+              onRefresh={refetch}
             />
           )}
         </div>

--- a/apps/web/src/app/[locale]/admin/status/status-client.tsx
+++ b/apps/web/src/app/[locale]/admin/status/status-client.tsx
@@ -1,49 +1,25 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
 import { useTranslations } from "next-intl";
-import type { AdminStatus } from "../admin-status-types";
+import { useAdminStatus } from "../use-admin-status";
 import { DataResyncPanel } from "@/components/admin/data-resync-panel";
 
 /**
  * `/admin/status` client (SP3-A Task 3): the inline program-status bar
- * relocated VERBATIM from the deleted stacked `admin-client.tsx` (spec rev-2
- * mandate), plus `<DataResyncPanel/>` and the deploy counts. Same
- * `/api/admin/status` fetch and loading/error/refetch semantics.
+ * relocated from the deleted stacked `admin-client.tsx`, plus the deploy
+ * counts and `<DataResyncPanel/>`. The `/api/admin/status` fetch +
+ * loading/error/refetch now live in the shared `useAdminStatus` hook (SP3-D);
+ * the manual Refresh button restores the affordance the bar lost in the
+ * route split, wired to the hook's `refetch`.
  */
 export function StatusClient() {
   const t = useTranslations("admin");
-  const [status, setStatus] = useState<AdminStatus | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-
-  const fetchStatus = useCallback(async () => {
-    setLoading(true);
-    setError(null);
-    try {
-      // Authorized via the httpOnly admin_session cookie (sent automatically).
-      const res = await fetch("/api/admin/status");
-      if (!res.ok) {
-        setError("Failed to fetch status");
-        return;
-      }
-      const data = (await res.json()) as AdminStatus;
-      setStatus(data);
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "Network error");
-    } finally {
-      setLoading(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    void fetchStatus();
-  }, [fetchStatus]);
+  const { status, loading, error, refetch } = useAdminStatus();
 
   if (loading) {
     return (
       <div className="flex items-center justify-center py-20">
-        <div className="text-sm text-text-3">Loading on-chain status...</div>
+        <div className="text-sm text-text-3">{t("states.loading")}</div>
       </div>
     );
   }
@@ -51,12 +27,9 @@ export function StatusClient() {
   if (error) {
     return (
       <div className="rounded-md border border-danger bg-danger-light p-4 text-sm text-danger">
-        {error}
-        <button
-          onClick={() => void fetchStatus()}
-          className="ml-3 underline hover:no-underline"
-        >
-          Retry
+        {t(error === "network" ? "states.networkError" : "states.fetchError")}
+        <button onClick={refetch} className="ml-3 underline hover:no-underline">
+          {t("states.retry")}
         </button>
       </div>
     );
@@ -71,33 +44,38 @@ export function StatusClient() {
       {/* Program status bar */}
       <div className="rounded-lg border border-border bg-card p-4 text-sm shadow-card">
         <div className="flex flex-wrap items-center gap-3">
-          <span className="text-text-3">Network:</span>
+          <span className="text-text-3">{t("programBar.network")}:</span>
           <span className="text-text">devnet</span>
           <span className="text-border">|</span>
-          <span className="text-text-3">Program:</span>
+          <span className="text-text-3">{t("programBar.program")}:</span>
           <span className="font-mono text-xs text-text">
             {program.programId.slice(0, 8)}...{program.programId.slice(-4)}
           </span>
           <span className="text-border">|</span>
-          <span className="text-text-3">Config:</span>
+          <span className="text-text-3">{t("programBar.config")}:</span>
           {program.deployed ? (
-            <span className="text-success">Found</span>
+            <span className="text-success">{t("programBar.found")}</span>
           ) : (
-            <span className="text-danger">Not initialized</span>
+            <span className="text-danger">
+              {t("programBar.notInitialized")}
+            </span>
           )}
           {!program.authorityMatch.matches && (
             <span className="ml-2 text-xs text-accent">
-              Authority mismatch — check PROGRAM_AUTHORITY_SECRET
+              {t("programBar.authorityMismatch")}
             </span>
           )}
+          <button
+            onClick={refetch}
+            className="ml-auto rounded-md border border-border bg-card px-3 py-1 text-xs text-text-2 shadow-push-sm transition-all hover:bg-subtle active:translate-y-[2px] active:shadow-push-active"
+          >
+            {t("states.refresh")}
+          </button>
         </div>
       </div>
 
       {/* Deploy counts */}
-      <div
-        data-testid="deploy-counts"
-        className="flex flex-wrap items-center gap-3 rounded-lg border border-border bg-card p-4 text-sm shadow-card"
-      >
+      <div className="flex flex-wrap items-center gap-3 rounded-lg border border-border bg-card p-4 text-sm shadow-card">
         <span className="text-text-3">{t("counts.courses")}:</span>
         <span className="text-text">{courses.length}</span>
         <span className="text-border">|</span>
@@ -108,7 +86,7 @@ export function StatusClient() {
       {/* Data Resync */}
       <section>
         <h3 className="mb-4 font-display text-lg font-bold text-text">
-          Data Resync
+          {t("resync.heading")}
         </h3>
         <div className="rounded-lg border border-border bg-card p-4 shadow-card">
           <DataResyncPanel />

--- a/apps/web/src/app/[locale]/admin/use-admin-status.ts
+++ b/apps/web/src/app/[locale]/admin/use-admin-status.ts
@@ -1,0 +1,54 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import type { AdminStatus } from "./admin-status-types";
+
+/** Which failure the last fetch hit — mapped to a translated string by the UI. */
+export type AdminStatusError = "fetch" | "network";
+
+export interface UseAdminStatus {
+  status: AdminStatus | null;
+  loading: boolean;
+  /** Non-null while the last fetch failed; cleared on the next attempt. */
+  error: AdminStatusError | null;
+  /** Re-runs the fetch, resetting loading/error. */
+  refetch: () => void;
+}
+
+/**
+ * Shared data layer for the `/admin/deploy` and `/admin/status` screens: a
+ * single `GET /api/admin/status` fetch (authorized via the httpOnly
+ * `admin_session` cookie) with loading/error state and a `refetch`. Extracted
+ * from the two clients, which held byte-identical copies of this block before
+ * the SP3-A route split. Behavior is unchanged (same states, same refetch);
+ * the failure is surfaced as a kind so each screen can localize the copy.
+ */
+export function useAdminStatus(): UseAdminStatus {
+  const [status, setStatus] = useState<AdminStatus | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<AdminStatusError | null>(null);
+
+  const refetch = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/admin/status");
+      if (!res.ok) {
+        setError("fetch");
+        return;
+      }
+      const data = (await res.json()) as AdminStatus;
+      setStatus(data);
+    } catch {
+      setError("network");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refetch();
+  }, [refetch]);
+
+  return { status, loading, error, refetch: () => void refetch() };
+}

--- a/apps/web/src/app/[locale]/admin/use-admin-status.ts
+++ b/apps/web/src/app/[locale]/admin/use-admin-status.ts
@@ -28,27 +28,29 @@ export function useAdminStatus(): UseAdminStatus {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<AdminStatusError | null>(null);
 
-  const refetch = useCallback(async () => {
+  const refetch = useCallback((): void => {
     setLoading(true);
     setError(null);
-    try {
-      const res = await fetch("/api/admin/status");
-      if (!res.ok) {
-        setError("fetch");
-        return;
+    void (async () => {
+      try {
+        const res = await fetch("/api/admin/status");
+        if (!res.ok) {
+          setError("fetch");
+          return;
+        }
+        const data = (await res.json()) as AdminStatus;
+        setStatus(data);
+      } catch {
+        setError("network");
+      } finally {
+        setLoading(false);
       }
-      const data = (await res.json()) as AdminStatus;
-      setStatus(data);
-    } catch {
-      setError("network");
-    } finally {
-      setLoading(false);
-    }
+    })();
   }, []);
 
   useEffect(() => {
-    void refetch();
+    refetch();
   }, [refetch]);
 
-  return { status, loading, error, refetch: () => void refetch() };
+  return { status, loading, error, refetch };
 }

--- a/apps/web/src/components/admin/data-resync-panel.tsx
+++ b/apps/web/src/components/admin/data-resync-panel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { useTranslations } from "next-intl";
 
 interface ResyncResult {
   synced: boolean;
@@ -14,6 +15,7 @@ interface ResyncResult {
 }
 
 export function DataResyncPanel() {
+  const t = useTranslations("admin.resync");
   const [walletAddress, setWalletAddress] = useState("");
   const [loading, setLoading] = useState(false);
   const [result, setResult] = useState<ResyncResult | null>(null);
@@ -52,20 +54,14 @@ export function DataResyncPanel() {
 
   return (
     <div className="space-y-4">
-      <p className="text-sm text-text-3">
-        Rebuild a user&apos;s Supabase data from on-chain state: XP balance
-        (Token-2022 ATA), enrollments &amp; lesson progress (Enrollment PDAs +
-        bitmap), achievements (AchievementReceipt PDAs) &amp; certificates
-        (Enrollment credential_asset). Use after webhook failures or for
-        migration.
-      </p>
+      <p className="text-sm text-text-3">{t("description")}</p>
 
       <div className="flex gap-2">
         <input
           type="text"
           value={walletAddress}
           onChange={(e) => setWalletAddress(e.target.value)}
-          placeholder="Wallet address (base58)"
+          placeholder={t("walletPlaceholder")}
           className="flex-1 rounded-md border border-border bg-subtle px-3 py-2 text-sm text-text placeholder:text-text-3 focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
         />
         <button
@@ -73,7 +69,7 @@ export function DataResyncPanel() {
           disabled={loading || !walletAddress.trim()}
           className="rounded-md border border-border bg-card px-4 py-2 text-sm font-medium text-text shadow-push-sm transition-all hover:bg-subtle active:translate-y-[2px] active:shadow-push-active disabled:pointer-events-none disabled:opacity-50"
         >
-          {loading ? "Syncing..." : "Resync"}
+          {loading ? t("syncing") : t("resync")}
         </button>
       </div>
 
@@ -86,44 +82,44 @@ export function DataResyncPanel() {
       {result && (
         <div className="rounded-md border border-success bg-success-light p-3 text-sm">
           <div className="mb-1 font-medium text-success">
-            Resync complete for{" "}
+            {t("completeFor")}{" "}
             <span className="font-mono text-xs">
               {result.wallet.slice(0, 4)}...{result.wallet.slice(-4)}
             </span>
           </div>
           <div className="flex flex-wrap gap-x-4 gap-y-1 text-text-2">
             <span>
-              XP:{" "}
+              {t("xp")}:{" "}
               <span className="font-display font-bold text-text">
                 {result.xp.toLocaleString()}
               </span>
             </span>
             <span>
-              Enrollments:{" "}
+              {t("enrollments")}:{" "}
               <span className="font-display font-bold text-text">
                 {result.enrollments}
               </span>
             </span>
             <span>
-              Lessons:{" "}
+              {t("lessons")}:{" "}
               <span className="font-display font-bold text-text">
                 {result.lessonsCompleted}
               </span>
             </span>
             <span>
-              Courses completed:{" "}
+              {t("coursesCompleted")}:{" "}
               <span className="font-display font-bold text-text">
                 {result.coursesCompleted}
               </span>
             </span>
             <span>
-              Achievements:{" "}
+              {t("achievements")}:{" "}
               <span className="font-display font-bold text-text">
                 {result.achievements}
               </span>
             </span>
             <span>
-              Certificates:{" "}
+              {t("certificates")}:{" "}
               <span className="font-display font-bold text-text">
                 {result.certificates}
               </span>

--- a/apps/web/src/components/admin/flags-panel.tsx
+++ b/apps/web/src/components/admin/flags-panel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
+import { useTranslations } from "next-intl";
 
 interface ModerationFlag {
   id: string;
@@ -18,6 +19,7 @@ export function FlagsPanel({
 }: {
   onCountChange?: (count: number) => void;
 }) {
+  const t = useTranslations("admin.flags");
   const [flags, setFlags] = useState<ModerationFlag[]>([]);
   const [busyId, setBusyId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -67,10 +69,7 @@ export function FlagsPanel({
 
   return (
     <div className="space-y-4">
-      <p className="text-sm text-text-3">
-        Community posts reported by users. Resolve once you&apos;ve actioned the
-        content, or dismiss if the report isn&apos;t valid.
-      </p>
+      <p className="text-sm text-text-3">{t("description")}</p>
 
       {error && (
         <div className="rounded-md border border-danger bg-danger-light p-3 text-sm text-danger">
@@ -79,7 +78,7 @@ export function FlagsPanel({
       )}
 
       {flags.length === 0 ? (
-        <p className="text-sm text-text-3">No pending flags.</p>
+        <p className="text-sm text-text-3">{t("noPending")}</p>
       ) : (
         <ul className="space-y-2">
           {flags.map((flag) => (
@@ -92,7 +91,13 @@ export function FlagsPanel({
                   {flag.reason}
                 </span>
                 <span className="text-xs text-text-3">
-                  {flag.targetType} · reported by @{flag.reporter ?? "unknown"}{" "}
+                  {flag.targetType === "thread"
+                    ? t("targetThread")
+                    : t("targetAnswer")}{" "}
+                  ·{" "}
+                  {t("reportedBy", {
+                    reporter: flag.reporter ?? t("unknownReporter"),
+                  })}{" "}
                   · {new Date(flag.createdAt).toLocaleString()}
                 </span>
               </div>
@@ -110,7 +115,7 @@ export function FlagsPanel({
                     rel="noreferrer"
                     className="text-xs text-primary underline hover:no-underline"
                   >
-                    View
+                    {t("view")}
                   </a>
                 )}
                 <button
@@ -119,7 +124,7 @@ export function FlagsPanel({
                   disabled={busyId === flag.id}
                   className="rounded-md border border-success bg-success-light px-2.5 py-1 text-xs font-medium text-success disabled:opacity-50"
                 >
-                  Resolve
+                  {t("resolve")}
                 </button>
                 <button
                   type="button"
@@ -127,7 +132,7 @@ export function FlagsPanel({
                   disabled={busyId === flag.id}
                   className="rounded-md border border-border px-2.5 py-1 text-xs font-medium text-text-2 disabled:opacity-50"
                 >
-                  Dismiss
+                  {t("dismiss")}
                 </button>
               </div>
             </li>

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -839,6 +839,7 @@
       "publish": "Publish",
       "deploy": "Deploy",
       "moderation": "Moderation",
+      "pendingFlags": "{count, plural, one {# pending flag} other {# pending flags}}",
       "status": "Status"
     },
     "counts": {

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -886,6 +886,52 @@
         "step3": "3. Push a branch and open the PR",
         "branch": "Suggested branch:"
       }
+    },
+    "states": {
+      "loading": "Loading on-chain status...",
+      "fetchError": "Failed to fetch status",
+      "networkError": "Network error",
+      "retry": "Retry",
+      "refresh": "Refresh"
+    },
+    "programBar": {
+      "network": "Network",
+      "program": "Program",
+      "config": "Config",
+      "found": "Found",
+      "notInitialized": "Not initialized",
+      "authorityMismatch": "Authority mismatch — check PROGRAM_AUTHORITY_SECRET"
+    },
+    "deployScreen": {
+      "coursesHeading": "Courses",
+      "achievementsHeading": "Achievements",
+      "noCourses": "No courses found in Sanity.",
+      "noAchievements": "No achievements found in Sanity."
+    },
+    "resync": {
+      "heading": "Data Resync",
+      "description": "Rebuild a user's Supabase data from on-chain state: XP balance (Token-2022 ATA), enrollments & lesson progress (Enrollment PDAs + bitmap), achievements (AchievementReceipt PDAs) & certificates (Enrollment credential_asset). Use after webhook failures or for migration.",
+      "walletPlaceholder": "Wallet address (base58)",
+      "resync": "Resync",
+      "syncing": "Syncing...",
+      "completeFor": "Resync complete for",
+      "xp": "XP",
+      "enrollments": "Enrollments",
+      "lessons": "Lessons",
+      "coursesCompleted": "Courses completed",
+      "achievements": "Achievements",
+      "certificates": "Certificates"
+    },
+    "flags": {
+      "description": "Community posts reported by users. Resolve once you've actioned the content, or dismiss if the report isn't valid.",
+      "noPending": "No pending flags.",
+      "reportedBy": "reported by @{reporter}",
+      "unknownReporter": "unknown",
+      "targetThread": "thread",
+      "targetAnswer": "answer",
+      "view": "View",
+      "resolve": "Resolve",
+      "dismiss": "Dismiss"
     }
   }
 }

--- a/apps/web/src/messages/es.json
+++ b/apps/web/src/messages/es.json
@@ -839,6 +839,7 @@
       "publish": "Publicar",
       "deploy": "Desplegar",
       "moderation": "Moderación",
+      "pendingFlags": "{count, plural, one {# reporte pendiente} other {# reportes pendientes}}",
       "status": "Estado"
     },
     "counts": {

--- a/apps/web/src/messages/es.json
+++ b/apps/web/src/messages/es.json
@@ -886,6 +886,52 @@
         "step3": "3. Sube una rama y abre el PR",
         "branch": "Rama sugerida:"
       }
+    },
+    "states": {
+      "loading": "Cargando estado on-chain...",
+      "fetchError": "Error al obtener el estado",
+      "networkError": "Error de red",
+      "retry": "Reintentar",
+      "refresh": "Actualizar"
+    },
+    "programBar": {
+      "network": "Red",
+      "program": "Programa",
+      "config": "Config",
+      "found": "Encontrada",
+      "notInitialized": "No inicializada",
+      "authorityMismatch": "Discrepancia de autoridad — verifica PROGRAM_AUTHORITY_SECRET"
+    },
+    "deployScreen": {
+      "coursesHeading": "Cursos",
+      "achievementsHeading": "Logros",
+      "noCourses": "No se encontraron cursos en Sanity.",
+      "noAchievements": "No se encontraron logros en Sanity."
+    },
+    "resync": {
+      "heading": "Resincronización de datos",
+      "description": "Reconstruye los datos del usuario en Supabase a partir del estado on-chain: saldo de XP (ATA Token-2022), inscripciones y progreso de lecciones (PDAs de Enrollment + bitmap), logros (PDAs de AchievementReceipt) y certificados (credential_asset de Enrollment). Úsalo tras fallos de webhook o para migraciones.",
+      "walletPlaceholder": "Dirección de la billetera (base58)",
+      "resync": "Resincronizar",
+      "syncing": "Sincronizando...",
+      "completeFor": "Resincronización completa para",
+      "xp": "XP",
+      "enrollments": "Inscripciones",
+      "lessons": "Lecciones",
+      "coursesCompleted": "Cursos completados",
+      "achievements": "Logros",
+      "certificates": "Certificados"
+    },
+    "flags": {
+      "description": "Publicaciones de la comunidad reportadas por usuarios. Resuelve una vez que hayas actuado sobre el contenido, o descarta si el reporte no es válido.",
+      "noPending": "No hay reportes pendientes.",
+      "reportedBy": "reportado por @{reporter}",
+      "unknownReporter": "desconocido",
+      "targetThread": "hilo",
+      "targetAnswer": "respuesta",
+      "view": "Ver",
+      "resolve": "Resolver",
+      "dismiss": "Descartar"
     }
   }
 }

--- a/apps/web/src/messages/pt-BR.json
+++ b/apps/web/src/messages/pt-BR.json
@@ -886,6 +886,52 @@
         "step3": "3. Envie uma branch e abra o PR",
         "branch": "Branch sugerida:"
       }
+    },
+    "states": {
+      "loading": "Carregando status on-chain...",
+      "fetchError": "Falha ao buscar o status",
+      "networkError": "Erro de rede",
+      "retry": "Tentar novamente",
+      "refresh": "Atualizar"
+    },
+    "programBar": {
+      "network": "Rede",
+      "program": "Programa",
+      "config": "Config",
+      "found": "Encontrada",
+      "notInitialized": "Não inicializada",
+      "authorityMismatch": "Divergência de autoridade — verifique PROGRAM_AUTHORITY_SECRET"
+    },
+    "deployScreen": {
+      "coursesHeading": "Cursos",
+      "achievementsHeading": "Conquistas",
+      "noCourses": "Nenhum curso encontrado no Sanity.",
+      "noAchievements": "Nenhuma conquista encontrada no Sanity."
+    },
+    "resync": {
+      "heading": "Ressincronização de dados",
+      "description": "Reconstrua os dados do usuário no Supabase a partir do estado on-chain: saldo de XP (ATA Token-2022), matrículas e progresso das lições (PDAs de Enrollment + bitmap), conquistas (PDAs de AchievementReceipt) e certificados (credential_asset da Enrollment). Use após falhas de webhook ou para migração.",
+      "walletPlaceholder": "Endereço da carteira (base58)",
+      "resync": "Ressincronizar",
+      "syncing": "Sincronizando...",
+      "completeFor": "Ressincronização concluída para",
+      "xp": "XP",
+      "enrollments": "Matrículas",
+      "lessons": "Lições",
+      "coursesCompleted": "Cursos concluídos",
+      "achievements": "Conquistas",
+      "certificates": "Certificados"
+    },
+    "flags": {
+      "description": "Publicações da comunidade denunciadas por usuários. Resolva depois de tratar o conteúdo ou descarte se a denúncia não for válida.",
+      "noPending": "Nenhuma denúncia pendente.",
+      "reportedBy": "denunciado por @{reporter}",
+      "unknownReporter": "desconhecido",
+      "targetThread": "tópico",
+      "targetAnswer": "resposta",
+      "view": "Ver",
+      "resolve": "Resolver",
+      "dismiss": "Descartar"
     }
   }
 }

--- a/apps/web/src/messages/pt-BR.json
+++ b/apps/web/src/messages/pt-BR.json
@@ -839,6 +839,7 @@
       "publish": "Publicar",
       "deploy": "Implantar",
       "moderation": "Moderação",
+      "pendingFlags": "{count, plural, one {# denúncia pendente} other {# denúncias pendentes}}",
       "status": "Status"
     },
     "counts": {


### PR DESCRIPTION
SP3-D polish batch — the five reviewed-and-accepted backlog items from the SP3-A/B reviews. **SAFE lane, frontend-only.**

1. Shared `useAdminStatus()` hook — deduplicates the verbatim fetch/loading/error/Retry block from the deploy + status screens (behavior-identical; the one delta — error surfaced as a localizable kind instead of raw `Error.message` — was review-adjudicated as strictly better).
2. Status-screen manual Refresh — restores the operator affordance lost in the route split (watching for "Config: Found" after init).
3. Pending-flags count badge on the Moderation nav link — async, non-blocking, hidden on error/zero, i18n'd aria-label, reuses the existing authed flags route.
4. i18n sweep of the moved panels' hardcoded strings with real pt-BR/es (SP2-C-doomed components deliberately excluded — they die/rebuild in SP2-C/SP3-C).
5. `data-testid` removed from prod markup.

Review: Fable, SPEC ✅ 5/5 + both scoping adjudications accepted; two post-review one-liners folded in (stable refetch identity, badge aria-label). Suite 455 passing at the rebased HEAD, parity green, tsc/lint clean.

**Known follow-up (backlog, deliberately excluded):** flags-panel/data-resync action-error paths still show hardcoded/raw error text — same kind-mapping treatment applies; small sweep alongside SP3-C.