### PR TITLE
fix(solana): creator denylist + platform-authority refusal in deployCoursePda (#402)

### DIFF
--- a/apps/web/src/lib/solana/__tests__/admin-signer.test.ts
+++ b/apps/web/src/lib/solana/__tests__/admin-signer.test.ts
@@ -1,0 +1,91 @@
+/* eslint-disable import/order -- vi.mock('server-only') must be hoisted above
+   the admin-signer import so the module graph loads under vitest. */
+import { describe, it, expect, vi } from "vitest";
+import { Keypair, PublicKey } from "@solana/web3.js";
+
+// admin-signer is a `server-only` module; neutralize the guard so the pure
+// creator-validation helper can be imported under the node test runner.
+vi.mock("server-only", () => ({}));
+
+import { CREATOR_DENYLIST, assertCreatorAllowed } from "../admin-signer";
+
+const AUTHORITY = Keypair.generate().publicKey;
+const NORMAL = Keypair.generate().publicKey;
+const COURSE = "course-abc";
+
+describe("CREATOR_DENYLIST", () => {
+  it("every entry is a real, on-curve address (not dead code the off-curve check already stops)", () => {
+    for (const { address } of CREATOR_DENYLIST) {
+      const pk = new PublicKey(address);
+      expect(PublicKey.isOnCurve(pk.toBytes())).toBe(true);
+    }
+  });
+
+  it("includes the four required well-knowns", () => {
+    const addrs = CREATOR_DENYLIST.map((e) => e.address);
+    expect(addrs).toContain("11111111111111111111111111111111"); // System
+    expect(addrs).toContain("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"); // Token
+    expect(addrs).toContain("TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"); // Token-2022
+    expect(addrs).toContain("ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"); // ATA
+  });
+});
+
+describe("assertCreatorAllowed", () => {
+  it("passes a normal wallet", () => {
+    expect(() =>
+      assertCreatorAllowed(NORMAL, AUTHORITY, COURSE, false)
+    ).not.toThrow();
+  });
+
+  it.each(CREATOR_DENYLIST)(
+    "refuses denylisted $label and names the pubkey",
+    ({ address, label }) => {
+      const creator = new PublicKey(address);
+      let thrown: Error | undefined;
+      try {
+        assertCreatorAllowed(creator, AUTHORITY, COURSE, false);
+      } catch (e) {
+        thrown = e as Error;
+      }
+      expect(thrown).toBeInstanceOf(Error);
+      expect(thrown?.message).toContain(address);
+      expect(thrown?.message).toContain(label);
+      expect(thrown?.message).toContain(COURSE);
+    }
+  );
+
+  it.each(CREATOR_DENYLIST)(
+    "allows denylisted $label when allowUnusualCreator is set",
+    ({ address }) => {
+      const creator = new PublicKey(address);
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      expect(() =>
+        assertCreatorAllowed(creator, AUTHORITY, COURSE, true)
+      ).not.toThrow();
+      expect(warn).toHaveBeenCalled();
+      warn.mockRestore();
+    }
+  );
+
+  it("refuses creator == platform authority and names the pubkey", () => {
+    let thrown: Error | undefined;
+    try {
+      assertCreatorAllowed(AUTHORITY, AUTHORITY, COURSE, false);
+    } catch (e) {
+      thrown = e as Error;
+    }
+    expect(thrown).toBeInstanceOf(Error);
+    expect(thrown?.message).toContain(AUTHORITY.toBase58());
+    expect(thrown?.message.toLowerCase()).toContain("authority");
+    expect(thrown?.message).toContain(COURSE);
+  });
+
+  it("allows creator == authority when allowUnusualCreator is set", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    expect(() =>
+      assertCreatorAllowed(AUTHORITY, AUTHORITY, COURSE, true)
+    ).not.toThrow();
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+});

--- a/apps/web/src/lib/solana/admin-signer.ts
+++ b/apps/web/src/lib/solana/admin-signer.ts
@@ -128,6 +128,14 @@ export interface CreateCourseAdminParams {
    * or off-curve value throws; there is no platform-authority fallback.
    */
   creatorWallet?: string;
+  /**
+   * Escape hatch for the deliberate case where `creatorWallet` is a denylisted
+   * well-known address or equals the platform authority (see
+   * {@link assertCreatorAllowed}). Default false → those cases hard-throw. When
+   * true, the guard logs loudly and proceeds. No caller sets this today; it
+   * exists for a future admin-UI "I know what I'm doing" override.
+   */
+  allowUnusualCreator?: boolean;
 }
 
 export interface UpdateCourseAdminParams {
@@ -268,6 +276,113 @@ export function isAdminSignerReady(): boolean {
   return ready;
 }
 
+// ---------------------------------------------------------------------------
+// Creator-wallet guard
+// ---------------------------------------------------------------------------
+
+/**
+ * Well-known program / sysvar addresses that are structurally valid Ed25519
+ * points (so they PASS the upstream `isOnCurve` check in `deployCoursePda`) yet
+ * are never a legitimate creator-reward recipient. Setting one of these as a
+ * course `creator` would mint the creator reward to an address no human
+ * controls — an irreversible mis-mint.
+ *
+ * Every entry here was verified ON-CURVE with `PublicKey.isOnCurve`. Off-curve
+ * well-knowns are deliberately EXCLUDED — the upstream off-curve check already
+ * rejects them, so listing them would be dead code. Confirmed off-curve and
+ * omitted for exactly that reason: Compute Budget, Vote, BPFLoaderUpgradeable,
+ * Ed25519 SigVerify, Secp256k1, and the Incinerator.
+ */
+export const CREATOR_DENYLIST: ReadonlyArray<{
+  address: string;
+  label: string;
+}> = [
+  // System program === the all-zero default Pubkey. The single most likely
+  // accidental value (an uninitialized / empty field decodes to this). On-curve.
+  { address: "11111111111111111111111111111111", label: "System program" },
+  // SPL Token program. On-curve.
+  {
+    address: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+    label: "SPL Token program",
+  },
+  // SPL Token-2022 program. On-curve.
+  {
+    address: "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb",
+    label: "SPL Token-2022 program",
+  },
+  // Associated Token Account program. On-curve.
+  {
+    address: "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL",
+    label: "Associated Token Account program",
+  },
+  // SPL Memo program. On-curve.
+  {
+    address: "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr",
+    label: "SPL Memo program",
+  },
+  // Stake program. On-curve.
+  {
+    address: "Stake11111111111111111111111111111111111111",
+    label: "Stake program",
+  },
+  // Rent sysvar. On-curve.
+  {
+    address: "SysvarRent111111111111111111111111111111111",
+    label: "Rent sysvar",
+  },
+  // Clock sysvar. On-curve.
+  {
+    address: "SysvarC1ock11111111111111111111111111111111",
+    label: "Clock sysvar",
+  },
+];
+
+/**
+ * Defense-in-depth guard for the on-chain course `creator`, run AFTER the
+ * caller has parsed `creatorWallet` and confirmed it is on-curve. Refuses two
+ * on-curve-but-wrong cases that the off-curve check cannot catch:
+ *
+ *  1. `creator` is a {@link CREATOR_DENYLIST} well-known (a program/sysvar).
+ *  2. `creator` equals the platform authority — the authority signs and pays
+ *     for the deploy; it must not also be the creator-reward recipient.
+ *
+ * Throws a clear, pubkey-naming error (surfaced in the admin deploy UI) unless
+ * `allowUnusualCreator` is set, in which case it logs loudly and returns.
+ */
+export function assertCreatorAllowed(
+  creator: PublicKey,
+  authority: PublicKey,
+  courseId: string,
+  allowUnusualCreator: boolean
+): void {
+  const creator58 = creator.toBase58();
+
+  const denied = CREATOR_DENYLIST.find((e) => e.address === creator58);
+  if (denied) {
+    if (allowUnusualCreator) {
+      console.warn(
+        `[admin-signer] deployCoursePda(${courseId}): OVERRIDE — creatorWallet ${creator58} is a denylisted well-known (${denied.label}); proceeding because allowUnusualCreator=true`
+      );
+    } else {
+      throw new Error(
+        `deployCoursePda(${courseId}): creatorWallet ${creator58} is a denylisted well-known address (${denied.label}) and cannot receive creator rewards. Pass allowUnusualCreator to override.`
+      );
+    }
+  }
+
+  if (creator.equals(authority)) {
+    if (allowUnusualCreator) {
+      console.warn(
+        `[admin-signer] deployCoursePda(${courseId}): OVERRIDE — creatorWallet ${creator58} equals the platform authority; proceeding because allowUnusualCreator=true`
+      );
+    } else {
+      throw new Error(
+        `deployCoursePda(${courseId}): creatorWallet ${creator58} equals the platform authority, which must not be the creator-reward recipient. Pass allowUnusualCreator to override.`
+      );
+    }
+  }
+}
+
 /**
  * Deploy a new Course PDA on-chain.
  *
@@ -320,6 +435,15 @@ export async function deployCoursePda(
         `deployCoursePda(${params.courseId}): creatorWallet "${params.creatorWallet}" is off-curve`
       );
     }
+    // On-curve but still wrong: reject denylisted well-knowns and the platform
+    // authority itself (both would mis-mint the creator reward). Opt-out via
+    // params.allowUnusualCreator for the deliberate case.
+    assertCreatorAllowed(
+      creator,
+      _authority.publicKey,
+      params.courseId,
+      params.allowUnusualCreator ?? false
+    );
 
     const onChainParams: CreateCourseOnChainParams = {
       courseId: params.courseId,


### PR DESCRIPTION
Closes #402. **SENSITIVE (on-chain deploy signer) — holding for owner merge.**

Adds an exported `CREATOR_DENYLIST` + pure `assertCreatorAllowed()` guard in `deployCoursePda`, AFTER the existing on-curve check and BEFORE any transaction construction: refuses on-curve-but-nonsense creators (System/all-zero default, Token, Token-2022, ATA, Memo, Stake, Rent+Clock sysvars — **each independently re-verified on-curve during review**; off-curve well-knowns deliberately excluded as dead code) and `creator == platform authority`. `allowUnusualCreator` escape hatch (default false, unreachable from HTTP — verified by grep, no route plumbs it) logs loudly instead of refusing.

21 RED-first unit tests incl. an anti-dead-code on-curve assertion over the whole list; errors name the pubkey + failed check + courseId. Fable security review: approved — refusal ordering walked, authority reference confirmed (`PROGRAM_AUTHORITY_SECRET` keypair, not backend signer), surgical +215/-0.

**Devnet negative-path demo** (deploy with creator=System → refused; normal wallet → succeeds) deferred to post-merge evidence per the SP3-C plan — the guard is pure client-side refusal, unit coverage is the substrate.

Note for SP3-C (recorded): when the UI plumbs the override, split or label WHICH condition is overridden — one flag silencing two hazards invites rubber-stamping.