### PR TITLE
fix(admin): localize panel action-error paths (SP3-D follow-up)

### DIFF
--- a/.superpowers/sdd/sp3d-errorpaths-report.md
+++ b/.superpowers/sdd/sp3d-errorpaths-report.md
@@ -1,0 +1,89 @@
+# SP3-D follow-up — admin action-error path i18n
+
+**Branch:** `fix/admin-error-path-i18n-11-07-2026` (off `origin/main` @ `8a59ba6`)
+
+## What changed
+
+The SP3-D review's Minor: the admin panels' ACTION-ERROR paths still set raw
+`e.message` / `"Network error"` / `"Request failed (N)"` strings as displayed
+error state. Applied the same kind-mapping treatment SP3-D's `useAdminStatus`
+uses — errors become localized kinds surfaced via the panel's next-intl
+namespace; the raw message stays in `console.error` for devtools.
+
+### `components/admin/flags-panel.tsx`
+
+- `error` state: `string | null` → `ActionError | null` (`"fetch" | "network"`).
+- Non-ok action response → `console.error(raw)` + `setError("fetch")` (was
+  `setError(body.error ?? "Request failed (N)")`).
+- `catch` → `console.error(e)` + `setError("network")` (was `setError(e.message)`).
+- Render maps the kind: `t(error === "network" ? "errorNetwork" : "errorFetch")`.
+
+### `components/admin/data-resync-panel.tsx`
+
+- Identical treatment (same kind union, same console-log + kind mapping,
+  same render mapping under `admin.resync`).
+
+### i18n keys (en / pt-BR / es)
+
+Added two keys to each panel's existing namespace, real translations in all
+three locales:
+
+- `admin.resync.errorFetch`, `admin.resync.errorNetwork`
+- `admin.flags.errorFetch`, `admin.flags.errorNetwork`
+
+Reused the two-kind vocabulary from `useAdminStatus`; did NOT reuse
+`admin.states.fetchError` ("Failed to fetch status") because that copy is
+status-screen specific and wrong for a flag-resolve / resync action.
+
+## Tests
+
+- **New:** `components/admin/__tests__/flags-panel.test.tsx` (2),
+  `components/admin/__tests__/data-resync-panel.test.tsx` (2). Both panels
+  previously had NO dedicated test (their parents stub them with
+  "carries its own tests" comments). Each asserts: non-ok → localized
+  `errorFetch` shown AND the raw server message stays out of the DOM AND
+  `console.error` was called; throw → localized `errorNetwork` shown, raw
+  message not in DOM. This is the changed-behavior assertion (localized string,
+  not raw message).
+- No existing assertions changed — no prior test asserted the raw error text
+  (the panels were stubbed in `moderation-client.test.tsx` /
+  `status-client.test.tsx`).
+- Deep-parity guard (`src/messages/__tests__/parity.test.ts`, 4 tests): green.
+- Full `pnpm --filter web test`: **65 files, 459 tests, all pass**.
+- `tsc --noEmit`: clean. `next lint` on changed files: no warnings/errors.
+
+## Sweep inventory
+
+Grepped every `components/admin/*.tsx` for `catch` / `.message` /
+`"Network error"` / `setError`.
+
+**Touched (in scope — already-i18n'd panels whose action-error path was missed):**
+
+- `flags-panel.tsx`
+- `data-resync-panel.tsx`
+
+**Deliberately excluded:**
+
+- `content-sync-panel.tsx`, `sync-diff-view.tsx` — SP2-C-doomed (delete-Sanity,
+  `2026-07-11-sp2c-delete-sanity.md`). Explicitly named as untouchable by the task.
+- `course-sync-table.tsx`, `achievement-sync-table.tsx` — display raw `e.message`
+  and are NOT in the SP2-C deletion set (they deploy Course/Achievement PDAs via
+  `/api/admin/{courses,achievements}/sync`, which survive; live in the SP3-C
+  deploy screen). **Excluded anyway** for two reasons: (1) they are NOT i18n'd at
+  all — every string is hardcoded English ("Deploy", "Syncing...", "Sync All",
+  table headers, "Missing:") — so localizing only the error line would be
+  incoherent; (2) they are owned by the **open, not-yet-implemented** SP3-C
+  deploy-screen-v2 plan, whose Tasks 2/3/5 rewrite these tables and add their
+  en/pt-BR/es keys wholesale. Touching their error paths now would collide with
+  that pending rewrite. Same spirit as the SP2-C carve-out: leave migration-owned
+  surfaces to their owning workstream.
+
+## Concerns
+
+- The kind-mapping intentionally drops the server-provided `body.error` string
+  from the UI (now console-only), matching `useAdminStatus`. If an admin needs
+  the specific server reason, it is in devtools, not on screen. This is the
+  documented SP3-D pattern, applied consistently.
+- `course-sync-table` / `achievement-sync-table` remain fully-hardcoded English
+  including their error paths; that is left to SP3-C by design (noted above), not
+  an oversight.

--- a/apps/web/src/components/admin/__tests__/data-resync-panel.test.tsx
+++ b/apps/web/src/components/admin/__tests__/data-resync-panel.test.tsx
@@ -1,0 +1,70 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import { DataResyncPanel } from "../data-resync-panel";
+import messages from "@/messages/en.json";
+
+function renderPanel() {
+  return render(
+    <NextIntlClientProvider locale="en" messages={messages}>
+      <DataResyncPanel />
+    </NextIntlClientProvider>
+  );
+}
+
+function typeWalletAndResync() {
+  fireEvent.change(
+    screen.getByPlaceholderText(messages.admin.resync.walletPlaceholder),
+    { target: { value: "SomeWallet1111111111111111111111111111111" } }
+  );
+  fireEvent.click(screen.getByText(messages.admin.resync.resync));
+}
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", vi.fn());
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("DataResyncPanel action-error paths", () => {
+  it("shows the localized fetch-error string (not the raw server message) on a non-ok response", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 400,
+        json: async () => ({ error: "boom: bad wallet" }),
+      })
+    );
+
+    renderPanel();
+    typeWalletAndResync();
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(messages.admin.resync.errorFetch)
+      ).toBeInTheDocument()
+    );
+    expect(screen.queryByText(/boom: bad wallet/)).not.toBeInTheDocument();
+    expect(console.error).toHaveBeenCalled();
+  });
+
+  it("shows the localized network-error string when the fetch throws", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("offline")));
+
+    renderPanel();
+    typeWalletAndResync();
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(messages.admin.resync.errorNetwork)
+      ).toBeInTheDocument()
+    );
+    expect(screen.queryByText(/offline/)).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/admin/__tests__/flags-panel.test.tsx
+++ b/apps/web/src/components/admin/__tests__/flags-panel.test.tsx
@@ -1,0 +1,97 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import { FlagsPanel } from "../flags-panel";
+import messages from "@/messages/en.json";
+
+const flag = {
+  id: "flag-1",
+  reason: "spam",
+  details: null,
+  createdAt: "2026-07-01T00:00:00.000Z",
+  reporter: "alice",
+  targetType: "thread" as const,
+  preview: "reported post",
+  url: null,
+};
+
+function renderPanel() {
+  return render(
+    <NextIntlClientProvider locale="en" messages={messages}>
+      <FlagsPanel />
+    </NextIntlClientProvider>
+  );
+}
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", vi.fn());
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("FlagsPanel action-error paths", () => {
+  it("shows the localized fetch-error string (not the raw server message) on a non-ok action", async () => {
+    const fetchMock = vi
+      .fn()
+      // initial load (GET)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ flags: [flag] }),
+      })
+      // resolve action (POST) — server sends a raw error we must not surface
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        json: async () => ({ error: "boom: internal DB error" }),
+      });
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderPanel();
+    await waitFor(() =>
+      expect(screen.getByText(messages.admin.flags.resolve)).toBeInTheDocument()
+    );
+
+    fireEvent.click(screen.getByText(messages.admin.flags.resolve));
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(messages.admin.flags.errorFetch)
+      ).toBeInTheDocument()
+    );
+    // The raw server message stays out of the DOM (console-only for devtools).
+    expect(
+      screen.queryByText(/boom: internal DB error/)
+    ).not.toBeInTheDocument();
+    expect(console.error).toHaveBeenCalled();
+  });
+
+  it("shows the localized network-error string when the action fetch throws", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ flags: [flag] }),
+      })
+      .mockRejectedValueOnce(new Error("offline"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderPanel();
+    await waitFor(() =>
+      expect(screen.getByText(messages.admin.flags.dismiss)).toBeInTheDocument()
+    );
+
+    fireEvent.click(screen.getByText(messages.admin.flags.dismiss));
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(messages.admin.flags.errorNetwork)
+      ).toBeInTheDocument()
+    );
+    expect(screen.queryByText(/offline/)).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/admin/data-resync-panel.tsx
+++ b/apps/web/src/components/admin/data-resync-panel.tsx
@@ -14,12 +14,15 @@ interface ResyncResult {
   certificates: number;
 }
 
+/** Which failure the last resync hit — mapped to a translated string by the UI. */
+type ActionError = "fetch" | "network";
+
 export function DataResyncPanel() {
   const t = useTranslations("admin.resync");
   const [walletAddress, setWalletAddress] = useState("");
   const [loading, setLoading] = useState(false);
   const [result, setResult] = useState<ResyncResult | null>(null);
-  const [error, setError] = useState<string | null>(null);
+  const [error, setError] = useState<ActionError | null>(null);
 
   async function handleResync() {
     const trimmed = walletAddress.trim();
@@ -38,15 +41,18 @@ export function DataResyncPanel() {
 
       if (!res.ok) {
         const body = await res.json().catch(() => ({}));
-        setError(
+        console.error(
+          "Admin resync failed:",
           (body as { error?: string }).error ?? `Request failed (${res.status})`
         );
+        setError("fetch");
         return;
       }
 
       setResult((await res.json()) as ResyncResult);
     } catch (e) {
-      setError(e instanceof Error ? e.message : "Network error");
+      console.error("Admin resync failed:", e);
+      setError("network");
     } finally {
       setLoading(false);
     }
@@ -75,7 +81,7 @@ export function DataResyncPanel() {
 
       {error && (
         <div className="rounded-md border border-danger bg-danger-light p-3 text-sm text-danger">
-          {error}
+          {t(error === "network" ? "errorNetwork" : "errorFetch")}
         </div>
       )}
 

--- a/apps/web/src/components/admin/flags-panel.tsx
+++ b/apps/web/src/components/admin/flags-panel.tsx
@@ -14,6 +14,9 @@ interface ModerationFlag {
   url: string | null;
 }
 
+/** Which failure the last action hit — mapped to a translated string by the UI. */
+type ActionError = "fetch" | "network";
+
 export function FlagsPanel({
   onCountChange,
 }: {
@@ -22,7 +25,7 @@ export function FlagsPanel({
   const t = useTranslations("admin.flags");
   const [flags, setFlags] = useState<ModerationFlag[]>([]);
   const [busyId, setBusyId] = useState<string | null>(null);
-  const [error, setError] = useState<string | null>(null);
+  const [error, setError] = useState<ActionError | null>(null);
 
   const load = useCallback(async () => {
     try {
@@ -55,13 +58,18 @@ export function FlagsPanel({
       });
       if (!res.ok) {
         const body = (await res.json().catch(() => ({}))) as { error?: string };
-        setError(body.error ?? `Request failed (${res.status})`);
+        console.error(
+          "Admin flag action failed:",
+          body.error ?? `Request failed (${res.status})`
+        );
+        setError("fetch");
         return;
       }
       // Optimistically drop the actioned flag.
       setFlags((prev) => prev.filter((f) => f.id !== flagId));
     } catch (e) {
-      setError(e instanceof Error ? e.message : "Network error");
+      console.error("Admin flag action failed:", e);
+      setError("network");
     } finally {
       setBusyId(null);
     }
@@ -73,7 +81,7 @@ export function FlagsPanel({
 
       {error && (
         <div className="rounded-md border border-danger bg-danger-light p-3 text-sm text-danger">
-          {error}
+          {t(error === "network" ? "errorNetwork" : "errorFetch")}
         </div>
       )}
 

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -921,7 +921,9 @@
       "lessons": "Lessons",
       "coursesCompleted": "Courses completed",
       "achievements": "Achievements",
-      "certificates": "Certificates"
+      "certificates": "Certificates",
+      "errorFetch": "Resync failed. Please try again.",
+      "errorNetwork": "Network error. Please try again."
     },
     "flags": {
       "description": "Community posts reported by users. Resolve once you've actioned the content, or dismiss if the report isn't valid.",
@@ -932,7 +934,9 @@
       "targetAnswer": "answer",
       "view": "View",
       "resolve": "Resolve",
-      "dismiss": "Dismiss"
+      "dismiss": "Dismiss",
+      "errorFetch": "Failed to update the flag. Please try again.",
+      "errorNetwork": "Network error. Please try again."
     }
   }
 }

--- a/apps/web/src/messages/es.json
+++ b/apps/web/src/messages/es.json
@@ -921,7 +921,9 @@
       "lessons": "Lecciones",
       "coursesCompleted": "Cursos completados",
       "achievements": "Logros",
-      "certificates": "Certificados"
+      "certificates": "Certificados",
+      "errorFetch": "Error en la resincronización. Inténtalo de nuevo.",
+      "errorNetwork": "Error de red. Inténtalo de nuevo."
     },
     "flags": {
       "description": "Publicaciones de la comunidad reportadas por usuarios. Resuelve una vez que hayas actuado sobre el contenido, o descarta si el reporte no es válido.",
@@ -932,7 +934,9 @@
       "targetAnswer": "respuesta",
       "view": "Ver",
       "resolve": "Resolver",
-      "dismiss": "Descartar"
+      "dismiss": "Descartar",
+      "errorFetch": "No se pudo actualizar el reporte. Inténtalo de nuevo.",
+      "errorNetwork": "Error de red. Inténtalo de nuevo."
     }
   }
 }

--- a/apps/web/src/messages/pt-BR.json
+++ b/apps/web/src/messages/pt-BR.json
@@ -921,7 +921,9 @@
       "lessons": "Lições",
       "coursesCompleted": "Cursos concluídos",
       "achievements": "Conquistas",
-      "certificates": "Certificados"
+      "certificates": "Certificados",
+      "errorFetch": "Falha na ressincronização. Tente novamente.",
+      "errorNetwork": "Erro de rede. Tente novamente."
     },
     "flags": {
       "description": "Publicações da comunidade denunciadas por usuários. Resolva depois de tratar o conteúdo ou descarte se a denúncia não for válida.",
@@ -932,7 +934,9 @@
       "targetAnswer": "resposta",
       "view": "Ver",
       "resolve": "Resolver",
-      "dismiss": "Descartar"
+      "dismiss": "Descartar",
+      "errorFetch": "Falha ao atualizar a denúncia. Tente novamente.",
+      "errorNetwork": "Erro de rede. Tente novamente."
     }
   }
 }


### PR DESCRIPTION
The deferred SP3-D follow-up: flags-panel + data-resync-panel action-error paths adopt the useAdminStatus kind-mapping — raw server/exception text goes console-only, the UI renders localized error kinds (`admin.flags.error*` / `admin.resync.error*`, real en/pt-BR/es). Includes the panels' first dedicated tests (localized string shown, raw text asserted ABSENT from DOM, console.error fired).

Deliberately excluded (review-adjudicated): content-sync-panel/sync-diff-view (SP2-C deletes them) and the sync tables (fully un-i18n'd; SP3-C rewrites them wholesale — one localized line in an English table = churn for no benefit).

Fable review: SPEC ✅ / approved, no findings. SAFE lane.