### PR TITLE
docs: post-Sanity architecture rewrite + exhaustively re-derived secret/route inventories

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Superteam Academy is an open-source learning management system built on Solana. 
 - XP rewards for lesson completions (10-100 XP based on difficulty)
 - Level progression: `Level = floor(sqrt(totalXP / 100))`
 - Daily streaks tracking consecutive learning days
-- 15 achievements across 5 categories (Progress, Streaks, Skills, Community, Special)
+- Achievements across 5 categories (Progress, Streaks, Skills, Community, Special), with unlock rules declared in content
 - Celebration popups for level-ups, achievements, and certificate minting
 
 **Community Forum**
@@ -80,7 +80,7 @@ Superteam Academy is an open-source learning management system built on Solana. 
 | Layer            | Technology                                                            |
 | ---------------- | --------------------------------------------------------------------- |
 | Frontend         | Next.js 14 (App Router), React 18, Tailwind CSS, shadcn/ui + Radix UI |
-| CMS              | Sanity v3 (GROQ queries)                                              |
+| Content          | Committed bundle compiled from the `courses-academy` git repo         |
 | Database / Auth  | Supabase (Postgres, RLS, Auth)                                        |
 | On-Chain Program | Solana, Anchor 0.31+ (Rust)                                           |
 | XP Tokens        | Token-2022 (NonTransferable + PermanentDelegate)                      |
@@ -107,7 +107,6 @@ Superteam Academy is an open-source learning management system built on Solana. 
 - [Node.js](https://nodejs.org) >= 18
 - [pnpm](https://pnpm.io) >= 9
 - A [Supabase](https://supabase.com) account (free tier works)
-- A [Sanity](https://sanity.io) account (free tier works)
 - A Solana wallet ([Phantom](https://phantom.app) recommended)
 
 For on-chain program development, you also need:
@@ -129,7 +128,7 @@ cp .env.example apps/web/.env.local
 # Replace every placeholder with a real value — .env.example holds illustrative
 # defaults, not working credentials. Minimum to boot (see Environment Variables):
 # NEXT_PUBLIC_SUPABASE_URL, NEXT_PUBLIC_SUPABASE_ANON_KEY, SUPABASE_SERVICE_ROLE_KEY,
-# NEXT_PUBLIC_SANITY_PROJECT_ID, NEXT_PUBLIC_SANITY_DATASET.
+# NEXT_PUBLIC_SOLANA_RPC_URL, SOLANA_RPC_URL.
 
 # 3. Set up the database (migrations are the source of truth)
 # Create a Supabase project, install the Supabase CLI, then link and push:
@@ -137,8 +136,11 @@ cp .env.example apps/web/.env.local
 #   supabase db push        # applies supabase/migrations/ in order
 # supabase/schema.sql is a generated snapshot for reference — do not run it directly.
 
-# 4. Import seed content into Sanity
-cd sanity && SANITY_API_TOKEN=<your-token> node seed/import.mjs && cd ..
+# 4. Content — nothing to import.
+# Course content is a COMMITTED bundle (apps/web/src/content/generated/), compiled
+# from solanabr/courses-academy at the SHA pinned in apps/web/content.lock.
+# It is already in the repo. To recompile it after a pin bump:
+#   pnpm --filter web compile-content
 
 # 5. Start the dev server
 pnpm dev
@@ -146,7 +148,12 @@ pnpm dev
 
 Open [http://localhost:3000](http://localhost:3000).
 
-**Minimum variables for basic dev** (no on-chain features): `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY`, `NEXT_PUBLIC_SANITY_PROJECT_ID`, `NEXT_PUBLIC_SANITY_DATASET`.
+**Minimum variables for basic dev** (no on-chain features): `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY`, `NEXT_PUBLIC_SOLANA_RPC_URL`, `SOLANA_RPC_URL`.
+
+> **Courses won't appear until they're deployed on-chain.** Visibility is gated on
+> the Supabase `onchain_deployments` table (`status = "synced"` and active), which
+> starts empty on a fresh project. Deploy courses from `/en/admin/deploy` — see
+> [docs/ADMIN.md](docs/ADMIN.md).
 
 **Full on-chain features** require: `NEXT_PUBLIC_PROGRAM_ID`, `NEXT_PUBLIC_XP_MINT_ADDRESS`, `PROGRAM_AUTHORITY_SECRET`, `BACKEND_SIGNER_SECRET`. See [Program Deployment](docs/DEPLOY-PROGRAM.md) for the deploy and initialize workflow.
 
@@ -173,7 +180,10 @@ superteam-academy/
 │   │   │   │   └── admin/        # Admin panel
 │   │   │   └── api/              # API routes (auth, lessons, achievements, etc.)
 │   │   ├── src/components/     #   UI components (auth, editor, gamification, layout)
-│   │   ├── src/lib/            #   Utilities (supabase, sanity, solana, analytics)
+│   │   ├── src/lib/            #   Utilities (supabase, content, github, solana, analytics)
+│   │   ├── src/content/generated/  # COMMITTED content bundle (do not hand-edit)
+│   │   ├── content.lock        #   The courses-academy commit the bundle is pinned to
+│   │   ├── scripts/            #   compile-content.ts (repo → committed bundle)
 │   │   └── src/messages/       #   i18n translation files (en, pt-BR, es)
 │   └── build-server/           # Rust/Axum build server (GCP Cloud Run)
 ├── onchain-academy/            # Anchor workspace (Solana program)
@@ -181,14 +191,19 @@ superteam-academy/
 │   └── tests/                  #   Integration + unit tests
 ├── packages/
 │   ├── types/                  # Shared TypeScript interfaces
+│   ├── content-schema/         # Zod schemas for the content standard
+│   ├── content-lint/           # Content linter (runs in courses-academy CI)
+│   ├── challenge-executor/     # Sandboxed challenge runner (QuickJS)
 │   ├── deploy/                 # Browser-based Solana program deployment library
 │   └── config/                 # Shared ESLint, TS, Tailwind configs
-├── sanity/                     # Sanity Studio + schemas + seed data
 ├── supabase/                   # Database schema + migrations
 ├── scripts/                    # Helper scripts (init-program, update-program-id)
 ├── wallets/                    # Keypairs (gitignored)
 └── docs/                       # Documentation
 ```
+
+Course **content** lives in a separate repo:
+[`solanabr/courses-academy`](https://github.com/solanabr/courses-academy).
 
 ## Environment Variables
 
@@ -202,32 +217,31 @@ Copy `.env.example` to `apps/web/.env.local` and fill in values.
 | `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Client | Public anon key (safe for browser)                                  |
 | `SUPABASE_SERVICE_ROLE_KEY`     | Server | Service role key for admin operations. **Never expose to browser.** |
 
-### Sanity CMS (Required)
+### Content
 
-| Variable                        | Scope  | Description                                                  |
-| ------------------------------- | ------ | ------------------------------------------------------------ |
-| `NEXT_PUBLIC_SANITY_PROJECT_ID` | Client | Project ID from [sanity.io/manage](https://sanity.io/manage) |
-| `NEXT_PUBLIC_SANITY_DATASET`    | Client | Dataset name (usually `production`)                          |
-| `SANITY_API_TOKEN`              | Server | Editor token for seed import script only                     |
+**No variables required.** Course content is a committed bundle — there is no CMS
+and no content-write credential. `GITHUB_TOKEN` (below) is optional, read-only, and
+only used to poll the content repo's HEAD/CI state for the admin Publish screen.
 
 ### Solana (Required for on-chain features)
 
-| Variable                      | Scope  | Description                                             |
-| ----------------------------- | ------ | ------------------------------------------------------- |
-| `NEXT_PUBLIC_SOLANA_RPC_URL`  | Client | RPC endpoint (default: `https://api.devnet.solana.com`) |
-| `NEXT_PUBLIC_SOLANA_NETWORK`  | Client | Network name (`devnet`)                                 |
-| `NEXT_PUBLIC_PROGRAM_ID`      | Client | Program ID from `anchor deploy`                         |
-| `NEXT_PUBLIC_XP_MINT_ADDRESS` | Client | XP mint pubkey from `initialize` output                 |
+| Variable                      | Scope  | Description                                                                                       |
+| ----------------------------- | ------ | ------------------------------------------------------------------------------------------------- |
+| `NEXT_PUBLIC_SOLANA_RPC_URL`  | Client | Browser RPC endpoint. Must carry **no** privileged key (default: `https://api.devnet.solana.com`) |
+| `SOLANA_RPC_URL`              | Server | Server RPC endpoint — **this** is the one that may carry the Helius key. Required at boot.        |
+| `NEXT_PUBLIC_SOLANA_NETWORK`  | Client | Network name (`devnet`)                                                                           |
+| `NEXT_PUBLIC_PROGRAM_ID`      | Client | Program ID from `anchor deploy`                                                                   |
+| `NEXT_PUBLIC_XP_MINT_ADDRESS` | Client | XP mint pubkey from `initialize` output                                                           |
 
-### Admin / Signing (Required for admin panel and on-chain operations)
+### Admin / Signing (Required for the admin console and on-chain operations)
 
-| Variable                   | Scope  | Description                                                                                      |
-| -------------------------- | ------ | ------------------------------------------------------------------------------------------------ |
-| `PROGRAM_AUTHORITY_SECRET` | Server | JSON array of authority keypair bytes (64 elements). The keypair that signed `initialize`.       |
-| `BACKEND_SIGNER_SECRET`    | Server | JSON array of backend signer keypair bytes. On devnet, same as `PROGRAM_AUTHORITY_SECRET`.       |
-| `XP_MINT_AUTHORITY_SECRET` | Server | JSON array of XP mint authority keypair bytes. Signs XP token mints; omit to disable XP minting. |
-| `ADMIN_SECRET`             | Server | Admin panel password (min 32 chars, random string)                                               |
-| `SANITY_ADMIN_TOKEN`       | Server | Write-enabled Sanity API token for course sync in admin panel                                    |
+| Variable                   | Scope  | Description                                                                                                                                |
+| -------------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `PROGRAM_AUTHORITY_SECRET` | Server | JSON array of authority keypair bytes (64 elements). The keypair that signed `initialize`.                                                 |
+| `BACKEND_SIGNER_SECRET`    | Server | JSON array of backend signer keypair bytes. On devnet, same as `PROGRAM_AUTHORITY_SECRET`.                                                 |
+| `XP_MINT_AUTHORITY_SECRET` | Server | JSON array of XP mint authority keypair bytes. Signs XP token mints; omit to disable XP minting.                                           |
+| `ADMIN_SECRET`             | Server | Admin console secret (min 32 chars, random) — also the HMAC key signing the `admin_session` cookie                                         |
+| `GITHUB_TOKEN`             | Server | Fine-grained **read** token for `solanabr/courses-academy`. Powers the admin Publish screen. Unset → those routes 503. **No write scope.** |
 
 ### Build Server (Optional -- for code compilation features)
 
@@ -239,9 +253,19 @@ Copy `.env.example` to `apps/web/.env.local` and fill in values.
 
 ### AI Lesson Assistant (Optional)
 
-| Variable         | Scope  | Description                                                    |
-| ---------------- | ------ | -------------------------------------------------------------- |
-| `GEMINI_API_KEY` | Server | Google Gemini API key for the in-lesson AI chat/suggest routes |
+| Variable                 | Scope  | Description                                                                             |
+| ------------------------ | ------ | --------------------------------------------------------------------------------------- |
+| `GEMINI_API_KEY`         | Server | Google Gemini API key for the in-lesson AI assistant (`/api/ai/*`). Omit to disable it. |
+| `AI_PARTNER_SEAL_SECRET` | Server | Key sealing the comprehension-check token. Falls back to `SUPABASE_SERVICE_ROLE_KEY`.   |
+
+### Credentials & Moderation (Optional)
+
+| Variable                  | Scope  | Description                                                                                                          |
+| ------------------------- | ------ | -------------------------------------------------------------------------------------------------------------------- |
+| `ARWEAVE_UPLOADER_SECRET` | Server | Solana keypair funding Irys uploads that pin credential metadata to Arweave. Unset → falls back to the metadata API. |
+| `MODERATION_WEBHOOK_URL`  | Server | Slack/Discord-compatible webhook pinged on the first flag of a post.                                                 |
+| `HELIUS_API_KEY`          | Server | Helius DAS API + webhook management                                                                                  |
+| `HELIUS_WEBHOOK_SECRET`   | Server | Verifies Helius webhook signatures                                                                                   |
 
 ### Analytics (Optional -- platform works without these)
 
@@ -260,9 +284,9 @@ Copy `.env.example` to `apps/web/.env.local` and fill in values.
 
 ## Deployment
 
-Superteam Academy deploys as a Vercel-hosted Next.js app backed by Supabase (Postgres + Auth), Sanity CMS, and a Solana on-chain program.
+Superteam Academy deploys as a Vercel-hosted Next.js app backed by Supabase (Postgres + Auth) and a Solana on-chain program. Content ships inside the build — there is no CMS to deploy.
 
-- **[Production Deployment Guide](docs/DEPLOYMENT.md)** -- Full instructions for Vercel, Supabase, Sanity, Google OAuth, GCP Cloud Run (build server), analytics, custom domains, and post-deployment checklist.
+- **[Production Deployment Guide](docs/DEPLOYMENT.md)** -- Full instructions for Vercel, Supabase, the content bundle, Google OAuth, GCP Cloud Run (build server), analytics, custom domains, and post-deployment checklist.
 - **[Program Deployment Guide](docs/DEPLOY-PROGRAM.md)** -- On-chain program build, deploy, and initialize workflow (keypair generation, Anchor build, devnet deploy, XP mint creation).
 
 ## On-Chain Program
@@ -273,44 +297,45 @@ Superteam Academy deploys as a Vercel-hosted Next.js app backed by Supabase (Pos
 
 The program manages the full learning lifecycle on-chain:
 
-- **16 instructions**: initialize, create/update/close course, enroll, complete lesson, finalize course, issue/upgrade credential, create achievement type, unlock achievement, register/revoke minter, update config, unenroll, and more
-- **6 PDA account types**: Config, Course, Enrollment, MinterRole, AchievementType, AchievementRecord
+- **18 instructions**: initialize, update config, create/update/close course, enroll, complete lesson, finalize course, close enrollment, issue/upgrade credential, register/update/revoke minter, reward XP, create/deactivate achievement type, award achievement
+- **6 PDA account types**: Config, Course, Enrollment, MinterRole, AchievementType, AchievementReceipt
 - **XP minting**: Token-2022 soulbound tokens minted on lesson completion
 - **Credential issuance**: Metaplex Core NFTs minted on course completion
 
 For deployment instructions, see [docs/DEPLOY-PROGRAM.md](docs/DEPLOY-PROGRAM.md).
 For system architecture, see [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
 
-## Admin Panel
+## Admin Console
 
 **URL**: `/{locale}/admin` (e.g., `/en/admin`)
-**Auth**: Enter the `ADMIN_SECRET` environment variable value
+**Auth**: Enter the `ADMIN_SECRET` value — this mints an HMAC-signed `admin_session` cookie
 
-The admin panel bridges Sanity CMS content with the on-chain program:
+Four screens:
 
-- **Deploy courses**: Creates the course on-chain, creates a Metaplex Core collection for the track, and syncs `onChainStatus` back to Sanity
-- **Deploy achievements**: Creates achievement types on-chain with their Metaplex Core collections
-- **View sync status**: See which courses and achievements are deployed on-chain
+- **Publish** (`/admin/publish`): shows the pinned content SHA vs `courses-academy` HEAD and hands you a prefilled PR link. Publishing is a **pull request** that bumps `content.lock` + commits the regenerated bundle — the console holds no write token and cannot mutate content.
+- **Deploy** (`/admin/deploy`): deploy courses and achievements on-chain (Course PDA + Metaplex Core collection), and deactivate/reactivate courses. Recorded in the Supabase `onchain_deployments` table, which **is** the learner-visibility gate.
+- **Moderation** (`/admin/moderation`): the pending community-flag queue.
+- **Status** (`/admin/status`): program liveness, authority match, deploy counts, and on-chain → Supabase resync.
 
 For details, see [docs/ADMIN.md](docs/ADMIN.md).
 
 ## Documentation
 
-| Document                                     | Description                                           |
-| -------------------------------------------- | ----------------------------------------------------- |
-| [Architecture](docs/ARCHITECTURE.md)         | System design, account maps, data flows, CU budgets   |
-| [CMS Guide](docs/CMS_GUIDE.md)               | Sanity schema, GROQ patterns, content workflow        |
-| [Customization](docs/CUSTOMIZATION.md)       | Theming, i18n, gamification, and extending            |
-| [Admin Guide](docs/ADMIN.md)                 | Admin panel usage and course/achievement deployment   |
-| [Program Deployment](docs/DEPLOY-PROGRAM.md) | On-chain program build, deploy, and initialize        |
-| [Developer Reference](CLAUDE.md)             | Full codebase conventions, security model, API routes |
+| Document                                     | Description                                               |
+| -------------------------------------------- | --------------------------------------------------------- |
+| [Architecture](docs/ARCHITECTURE.md)         | System design, account maps, data flows, content pipeline |
+| [Customization](docs/CUSTOMIZATION.md)       | Theming, i18n, gamification, and extending                |
+| [Admin Guide](docs/ADMIN.md)                 | The 4-screen console: publish, deploy, moderate, status   |
+| [Deployment](docs/DEPLOYMENT.md)             | Vercel, Supabase, content bundle, build server            |
+| [Program Deployment](docs/DEPLOY-PROGRAM.md) | On-chain program build, deploy, and initialize            |
+| [Developer Reference](CLAUDE.md)             | Full codebase conventions, security model, API routes     |
 
 ## Known Limitations / Roadmap
 
-The on-chain program is feature-complete with 16 instructions covering the full learning lifecycle. The following items are scoped for future iterations:
+The on-chain program is feature-complete with 18 instructions covering the full learning lifecycle. The following items are scoped for future iterations:
 
 - **Track collection enforcement**: `track_collection` is validated server-side during credential issuance but is not yet enforced on-chain as an account constraint (future program upgrade).
-- **Cross-course achievements**: Three achievement types (Anchor Expert, Full Stack Solana, Rust Rookie) have partial frontend logic but lack proper cross-course tracking infrastructure. `full-stack-solana` is hardcoded to `false`; `anchor-expert` and `rust-rookie` use lesson ID pattern matching instead of course-level completion checks.
+- **`perfect-score` achievement**: dropped, not deferred. Block results are transient by design, so there is no durable "passed on first try" signal to key it on.
 - **Build server**: Compilation features (`buildable` Rust challenges + program deployment) require a separately deployed Rust/Axum build server on GCP Cloud Run. See the [Deployment](#deployment) section for setup details.
 
 ## Code Quality

--- a/docs/ADMIN.md
+++ b/docs/ADMIN.md
@@ -1,99 +1,254 @@
-> Last synced: 2026-03-02
+> Last synced: 2026-07-12
 
-# Admin Panel Guide
+# Admin Console Guide
 
-The Superteam Academy admin panel provides tools for syncing Sanity CMS content to the on-chain program.
+The admin console is a four-screen panel for operating the platform: publishing
+content, deploying it on-chain, moderating the community forum, and checking
+platform status.
 
-## Accessing the Admin Panel
+It is **not** a CMS. Course content is authored in the
+[`solanabr/courses-academy`](https://github.com/solanabr/courses-academy) git
+repo and ships to the app as a **committed, compiled bundle**. The console holds
+**no content-write token** and cannot mutate content — publishing is a pull
+request. See [Publishing content](#1-publish--pin-the-content-bundle).
 
-The admin panel is available at `/{locale}/admin` (e.g., `/en/admin`).
+## Accessing the console
 
-**Authentication**: The panel is protected by a shared secret. On the login page, enter the value of `ADMIN_SECRET` from your environment variables.
+The console lives at `/{locale}/admin` (e.g. `/en/admin`).
 
-## Required Environment Variables
+**Authentication**: `/admin` renders a login form. Enter the value of
+`ADMIN_SECRET`. On success the server sets an **HMAC-signed `admin_session`
+cookie**, and `/admin` redirects to `/admin/status` (the default screen).
 
-| Variable                   | Description                                                                                                                                                                                     |
-| -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `ADMIN_SECRET`             | Admin password (min 32 chars, random). Set in `.env.local`.                                                                                                                                     |
-| `PROGRAM_AUTHORITY_SECRET` | Base58 private key of the keypair that is authority on the on-chain `Config` PDA.                                                                                                               |
-| `BACKEND_SIGNER_SECRET`    | Base58 private key of the backend signer registered in `Config.backend_signer`. Used to sign on-chain transactions from API routes.                                                             |
-| `SANITY_ADMIN_TOKEN`       | Sanity write token from [sanity.io/manage](https://sanity.io/manage). Required to sync `onChainStatus` back to Sanity after deploying a course.                                                 |
-| `GITHUB_TOKEN`             | Fine-grained **read** token for `solanabr/courses-academy`. Required by the Content Sync panel (tarball fetch, HEAD polling, Checks API). Unset → the `/api/admin/content/*` routes return 503. |
+- The middleware bounces unauthenticated `/admin/*` sub-routes back to `/admin`.
+- Every `/api/admin/*` route authorizes on that **signed cookie plus a
+  same-origin check** (`requireAdminAuth`, `lib/admin/auth.ts`). There is no
+  `Authorization: Bearer <ADMIN_SECRET>` header path — the secret is only ever
+  submitted once, at login, and is never read in a page component (so it cannot
+  leak into a client payload).
 
-## Course Sync Workflow
+## Required environment variables
 
-### Overview
+| Variable                    | Required for                                                                                                                                                                                           |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `ADMIN_SECRET`              | Console login + the HMAC key that signs `admin_session`. Min 32 random chars. Unset → the console cannot be logged into and admin routes 401.                                                          |
+| `PROGRAM_AUTHORITY_SECRET`  | The `Config.authority` keypair. Signs `create_course`, `update_course`, `create_achievement_type` from the **Deploy** screen.                                                                          |
+| `BACKEND_SIGNER_SECRET`     | The keypair registered in `Config.backend_signer`. Signs lesson/credential instructions from the learner-facing API routes.                                                                            |
+| `SOLANA_RPC_URL`            | Server-only RPC (may carry the Helius key). Required at boot — every admin screen reads chain state through it.                                                                                        |
+| `SUPABASE_SERVICE_ROLE_KEY` | Service-role writes to `onchain_deployments` (deploy status) and reads of the moderation queue.                                                                                                        |
+| `GITHUB_TOKEN`              | Fine-grained **read** token for `solanabr/courses-academy`. Powers the Publish screen's HEAD polling + CI-checks lookup. Unset → Publish shows "drift unavailable" (503); everything else still works. |
 
-Course content lives in Sanity CMS. On-chain course state lives in the Solana program. The admin panel bridges these two.
+`GITHUB_TOKEN` is read-only by design. **No admin route holds a GitHub write
+token** — nothing in the app can push a commit or open a PR on your behalf.
 
-A course must be in `onChainStatus.status == "synced"` before it appears to learners.
+---
 
-### Steps to deploy a new course
+## The four screens
 
-1. **Create the course in Sanity Studio** (`/studio`) with all modules, lessons, and metadata.
-2. **Open the admin panel** at `/en/admin`.
-3. **Select "Deploy Course"** and choose the course from the Sanity course list.
-4. The admin panel will:
-   - Call `create_course` on-chain (via `PROGRAM_AUTHORITY_SECRET`)
-   - Create a Metaplex Core collection for the course track (via `deployCourseTrackCollection`)
-   - Update `onChainStatus` in Sanity to `{ status: "synced", ... }` (via `SANITY_ADMIN_TOKEN`)
-5. The course is now visible in the learner-facing platform.
+| Screen         | Route               | What it does                                                                 |
+| -------------- | ------------------- | ---------------------------------------------------------------------------- |
+| **Publish**    | `/admin/publish`    | Shows the pinned content SHA vs `courses-academy` HEAD; links a prefilled PR |
+| **Deploy**     | `/admin/deploy`     | Per-course / per-achievement on-chain state + deploy, deactivate, reactivate |
+| **Moderation** | `/admin/moderation` | The pending community-flag queue (resolve / dismiss)                         |
+| **Status**     | `/admin/status`     | Program liveness, authority match, deploy counts, on-chain → Supabase resync |
 
-### Steps to deploy achievements
+The nav rail is persistent (left rail on desktop, tabs on mobile). The
+**Moderation** tab carries a badge with the pending-flag count.
 
-1. Open the admin panel at `/en/admin`.
-2. Select "Deploy Achievement".
-3. The admin panel calls `create_achievement_type` on-chain and creates the Metaplex Core collection.
+---
 
-### Course Deactivation / Reactivation
+## 1. Publish — pin the content bundle
 
-Courses can be toggled on/off without deleting the on-chain PDA:
+### How content actually ships
 
-- **Deactivate**: `POST /api/admin/courses/deactivate` — sets the on-chain Course PDA `is_active = false`
-- **Reactivate**: `POST /api/admin/courses/reactivate` — sets `is_active = true`
+```
+solanabr/courses-academy  (git = source of truth: course.yaml, lesson.yaml, achievements/, …)
+        │
+        │  pinned to ONE commit by apps/web/content.lock
+        ▼
+apps/web/scripts/compile-content.ts   (fetch tarball @ SHA → Zod-validate → project → emit)
+        │
+        ▼
+apps/web/src/content/generated/*.json   (COMMITTED bundle)
+apps/web/public/content-assets/*        (COMMITTED assets)
+        │
+        ▼
+the running app reads the bundle at build time — no runtime CMS fetch
+```
 
-Both routes require `ADMIN_SECRET` in the Authorization header.
+Publishing new content is therefore **a pull request against this repo**, not a
+button. The Publish screen exists to tell you _whether_ a bump is needed and to
+hand you the exact diff.
 
-### Platform Status Check
+### The "Content pin" card
 
-`GET /api/admin/status` returns:
+`GET /api/admin/publish/pin` returns the pinned SHA (read from the committed
+bundle's `meta.json`, which the compiler writes from `content.lock`), the
+`courses-academy` HEAD SHA, HEAD's combined CI state, and a drift verdict:
 
-- Whether the on-chain program is live (Config PDA exists)
-- Whether the local `PROGRAM_AUTHORITY_SECRET` matches the on-chain `Config.authority`
+| Verdict      | Meaning                                                                 |
+| ------------ | ----------------------------------------------------------------------- |
+| `up_to_date` | Pin == HEAD. Nothing to publish.                                        |
+| `behind`     | HEAD has moved. The card shows **N commits behind** and a compare link. |
+| `unknown`    | GitHub unreachable (503) — the card degrades to "drift unavailable".    |
 
-### Resync On-Chain State
+When drifted **and HEAD's CI is not green**, the card raises `warnRedHead` and
+discourages the bump. Bumping to a red HEAD is possible but is a bad idea: the
+`courses-academy` CI gate (the content linter + executor gate) is what certifies
+that a tree is publishable, and `compile-content` does **not** re-run the
+executor gate.
 
-`POST /api/admin/resync` re-reads on-chain state and backfills Supabase mirror tables. Use this to recover from Supabase write failures or sync drift.
+### Bumping the pin (the actual workflow)
 
-### Content Sync (repo → Sanity → devnet)
+1. Open `/admin/publish` and confirm the verdict is `behind` with a green HEAD.
+2. Create a branch (the card suggests `chore/content-pin-<short-sha>`).
+3. Edit `apps/web/content.lock` — set `"sha"` to the new HEAD.
+4. Regenerate the bundle:
+   ```bash
+   pnpm --filter web compile-content
+   ```
+5. Commit **both** `apps/web/content.lock` **and** the regenerated
+   `apps/web/src/content/generated/` (and `apps/web/public/content-assets/` if
+   assets changed).
+6. Push and open the PR — the card's button opens GitHub's PR form with the
+   title and body prefilled. **The button performs no write**; it just opens the
+   form.
+7. Merge. Vercel redeploys from `main` with the new bundle.
 
-The **Content Sync** panel ingests the `solanabr/courses-academy` repository into Sanity at a chosen commit and then commits the content hash on-chain. It is **always admin-triggered from the panel — never automatic.**
+### Why CI catches a bad bump
 
-**Content drift** (repo → Sanity), shown as a banner:
+`compile-content` output is a **pure function of the locked SHA** — sorted keys,
+no wall-clock timestamps, assets left as repo-relative paths. CI recompiles the
+bundle and fails if the result differs by a single byte from what is committed
+(the "Content bundle freshness" step in `.github/workflows/ci.yml`). That catches
+both a stale bundle after a lock bump _and_ a hand-edit of the generated files.
 
-- **up_to_date** — Sanity already matches GitHub HEAD; the Sync button is disabled.
-- **behind** — HEAD has new content; click **Sync content** to `POST /api/admin/content/sync { sha: HEAD }`.
-- **never_synced** — first-run banner; the sync writes the initial projection.
-- **blocked** — HEAD's CI is **red**; the commit is **un-syncable** and the button is disabled (the sync re-validates the whole tree with the CS-2 linter and refuses a failing tree, so a red HEAD is never projected).
+> Never hand-edit `apps/web/src/content/generated/*`. An ESLint rule also bans
+> importing it anywhere outside `src/lib/content/`.
 
-The sync is idempotent (re-running at the same SHA is a no-op), PRESERVE-safe (`onChainStatus` survives), and prune-guarded: it deletes only its own `sync.source`-marked docs that are absent from the new tree, and **aborts if the prune set exceeds 20%** of managed docs. A blast-radius abort returns 409 with an override hint — inspect the tree before overriding.
+---
 
-**Chain drift** (Sanity → devnet), shown per course:
+## 2. Deploy — put content on-chain
 
-- **content_current** — the on-chain `content_tx_id` equals the padded HEAD sha (§11.0).
-- **content_stale** — deployed, but `content_tx_id != HEAD`; commit the new hash.
-- **not_deployed** / **missing_fields** — no PDA yet / Sanity incomplete.
-- **awaiting_content_sync** — the **ordering interlock**: chain sync is disabled until content drift is `up_to_date`, because the mask/commitment cannot be computed from a Sanity that has not ingested the new lesson. The chain-sync action re-asserts the intended `active_lessons` mask against the committed `slots.lock.json` before signing (a mismatch is a 409).
+A course is **invisible to learners** until it is deployed. The visibility gate
+is a Supabase row, not a content field:
 
-### Troubleshooting
+```
+visible  ⇔  onchain_deployments.status == "synced"  AND  coalesce(is_active, true)
+```
 
-- **"Unauthorized"**: Check that `ADMIN_SECRET` is set and matches the value used at login.
-- **"Transaction failed"**: Verify `PROGRAM_AUTHORITY_SECRET` is the correct authority keypair and has SOL for fees.
-- **"Sanity update failed"**: Verify `SANITY_ADMIN_TOKEN` has write access to the dataset.
-- **Course not appearing to learners**: Check `onChainStatus.status` in Sanity Studio — it must be `"synced"`.
+That gate lives in exactly one function — `isSynced()` in
+`lib/content/deployments.ts` — and is applied to every public read. Content that
+has no deployment row is **hidden** (fail-closed).
 
-## Security Notes
+### Course table
 
-- `ADMIN_SECRET` should be at least 32 random characters. Never commit it to version control.
-- `PROGRAM_AUTHORITY_SECRET` and `BACKEND_SIGNER_SECRET` must never be exposed to the browser — all admin API routes use `import "server-only"`.
-- The admin panel is for internal use only. Do not expose it publicly without additional authentication.
+Each row joins the bundle's course doc to its `onchain_deployments` row and to
+live chain state, and shows one of:
+
+| State            | Meaning                                                          |
+| ---------------- | ---------------------------------------------------------------- |
+| `missing_fields` | The content doc lacks a field the on-chain `create_course` needs |
+| `not_deployed`   | No Course PDA on chain yet                                       |
+| `synced`         | PDA exists and matches the recorded `course_pda`                 |
+| `out_of_sync`    | A PDA exists but differs from the recorded one                   |
+
+Actions:
+
+- **Deploy** — `POST /api/admin/courses/sync`. Signs `create_course` with
+  `PROGRAM_AUTHORITY_SECRET`, creates the course's Metaplex Core track
+  collection, then upserts `onchain_deployments` (status `synced`, `course_pda`,
+  `tx_signature`, `track_collection_address`) and purges the `courses` cache tag
+  so the catalog picks the course up.
+- **Deactivate** — `POST /api/admin/courses/deactivate`. Sets the on-chain
+  Course `is_active = false` and mirrors it to `onchain_deployments.is_active`,
+  which hides the course from learners without deleting the PDA.
+- **Reactivate** — `POST /api/admin/courses/reactivate`. The inverse.
+
+The `is_active` column is deliberately **tri-state**: `NULL` means "no explicit
+flag" and the gate coalesces it to `true`. Deactivation is opt-in.
+
+The table shows the **authoritative on-chain `is_active`** (decoded from the
+account it already fetched), not the Supabase mirror — so a failed write-back
+still surfaces the real deactivated state and offers Reactivate.
+
+### Achievement table
+
+Same shape. **Deploy** (`POST /api/admin/achievements/sync`) signs
+`create_achievement_type` and creates the achievement's Metaplex Core collection,
+then records `achievement_pda` + `collection_address` in `onchain_deployments`.
+
+> **ID convention**: the content `_id` (`course-*`, `achievement-*`) is used
+> **verbatim** as the on-chain PDA seed. Never strip the prefix anywhere —
+> stripping it derives a different PDA and the award/deploy silently targets a
+> non-existent account.
+
+---
+
+## 3. Moderation — the flag queue
+
+`/admin/moderation` lists **pending** community flags (`GET /api/admin/flags`),
+each resolved to a preview of the flagged thread/answer and a link to it.
+
+`POST /api/admin/flags { flagId, action }` takes one of:
+
+- `resolve` — the flag was valid; the content is actioned.
+- `dismiss` — the flag was not valid.
+
+Both transition the flag out of `pending`, which drops it from the queue and
+decrements the nav badge.
+
+If `MODERATION_WEBHOOK_URL` is set, the **first** flag on a post pings that
+Slack/Discord-compatible webhook so admins know to check the queue. Unset → no
+notification; the queue still fills normally.
+
+---
+
+## 4. Status — platform health
+
+`GET /api/admin/status` drives this screen (and the Deploy screen — they share
+the `useAdminStatus` hook, so it is one fetch).
+
+**Program status bar**
+
+- Whether the on-chain program is live (the Config PDA resolves).
+- Whether the local `PROGRAM_AUTHORITY_SECRET` matches the on-chain
+  `Config.authority` (`verifyAuthorityMatchesConfig`). A mismatch here is why a
+  deploy will fail with a constraint error.
+- Whether the admin signer loaded at all (`isAdminSignerReady`).
+
+**Deploy counts** — how many courses/achievements are in each state.
+
+**Data resync** — `POST /api/admin/resync` re-reads on-chain state (enrollment
+bitmaps, Token-2022 XP balances, achievement receipts) and backfills the Supabase
+mirror tables. Use it after a Supabase mirror write failed behind a successful
+on-chain transaction. On-chain is the source of truth; the mirror is rebuildable.
+
+---
+
+## Troubleshooting
+
+| Symptom                                       | Check                                                                                                                                    |
+| --------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| **"Unauthorized" / 401 on every admin route** | `ADMIN_SECRET` unset, or the `admin_session` cookie expired — log in again. Cross-origin requests are rejected by design.                |
+| **Publish card says "drift unavailable"**     | `GITHUB_TOKEN` unset or GitHub unreachable. The route 503s rather than crashing. Unauthenticated GitHub is 60 req/hr per IP.             |
+| **Course not visible to learners**            | Its `onchain_deployments` row must be `status = "synced"` and `is_active` not `false`. Deploy it from `/admin/deploy`.                   |
+| **New lesson not showing up**                 | The bundle is pinned. Bump `content.lock` and recompile — merging content to `courses-academy` alone changes nothing in the app.         |
+| **"Transaction failed" on Deploy**            | Verify `PROGRAM_AUTHORITY_SECRET` is the real `Config.authority` (the Status screen's authority match tells you) and is funded with SOL. |
+| **CI fails with "Content bundle is stale"**   | You bumped `content.lock` without recompiling, or hand-edited the generated bundle. Run `pnpm --filter web compile-content` and commit.  |
+
+---
+
+## Security notes
+
+- `ADMIN_SECRET` must be at least 32 random characters and is never committed. It
+  is the HMAC key for the session cookie — rotating it invalidates all sessions.
+- `PROGRAM_AUTHORITY_SECRET` and `BACKEND_SIGNER_SECRET` must never reach the
+  browser. Every admin route and signer module is `import "server-only"`.
+- The `onchain_deployments` base table has **RLS on with no policies** —
+  service_role only. Public reads go through the `public_onchain_deployments`
+  view, which exposes only `content_id, kind, status, is_active,
+achievement_pda`. Raw pubkeys, signatures, and `track_collection_address` are
+  never in the public surface.
+- The console is for internal use. Do not expose it publicly without additional
+  authentication in front of it.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -717,15 +717,17 @@ User action → API route → Supabase (RLS/service_role)
                        ↘ on-chain reward_xp (for thread/answer/accept XP)
 ```
 
-### API Routes (7)
+### API Routes (9)
 
 | Route                                | Method | Auth     | Rate Limit | Purpose                                                                                            |
 | ------------------------------------ | ------ | -------- | ---------- | -------------------------------------------------------------------------------------------------- |
 | `/api/community/threads`             | GET    | None     | —          | List threads with cursor pagination, category/course/lesson filters                                |
 | `/api/community/threads`             | POST   | Required | 10/hr      | Create thread (5 XP, awards via `award_xp()`)                                                      |
 | `/api/community/threads/[id]`        | GET    | None     | —          | Thread detail with answers, increments view count                                                  |
+| `/api/community/threads/[id]/delete` | POST   | Required | —          | Soft-delete own thread (author only)                                                               |
 | `/api/community/answers`             | POST   | Required | 30/hr      | Post answer to thread (10 XP)                                                                      |
 | `/api/community/answers/[id]/accept` | POST   | Required | —          | Accept answer (thread author only, 25 XP to answerer). Re-accept revokes previous XP.              |
+| `/api/community/answers/[id]/delete` | POST   | Required | —          | Soft-delete own answer (author only)                                                               |
 | `/api/community/votes`               | POST   | Required | 60/hr      | Three-state vote (+1/0/-1). Self-vote prevented by DB trigger.                                     |
 | `/api/community/flags`               | POST   | Required | 20/hr      | Flag content for moderation. Dedup index prevents duplicate flags. Self-flag prevented by trigger. |
 | `/api/community/search`              | GET    | None     | —          | Full-text search (tsvector on title + body)                                                        |
@@ -882,8 +884,17 @@ GamificationOverlays
 
 ## 9. API Routes
 
-All routes are in `apps/web/src/app/api/`. The authoritative, always-current list
-lives in `apps/web/src/app/api/CLAUDE.md`.
+All routes are in `apps/web/src/app/api/`. **44 routes** as of the last sync.
+
+> **How to re-derive this list** (do this rather than trusting the table):
+>
+> ```bash
+> find apps/web/src/app/api -name route.ts \
+>   | sed 's|apps/web/src/app/api/||; s|/route.ts||' | sort
+> ```
+>
+> A route exists iff it has a `route.ts`. Anything in this table with no
+> corresponding file is a doc bug — `/api/deploy/[uuid]` was exactly that.
 
 "Admin" auth below means the same-origin + signed-`admin_session`-cookie check
 (`requireAdminAuth`), **not** a bearer token.
@@ -905,28 +916,28 @@ client-side route for a full lesson read.
 
 ### Auth / core / community
 
-| Route                             | Method   | Auth                  | Purpose                                                                            |
-| --------------------------------- | -------- | --------------------- | ---------------------------------------------------------------------------------- |
-| `/api/auth/nonce`                 | GET      | None                  | Generate SIWS nonce (stored in `siws_nonces` table)                                |
-| `/api/auth/wallet`                | POST     | None                  | SIWS authentication (nonce + Ed25519 verification)                                 |
-| `/api/auth/callback`              | GET      | None                  | Google/GitHub OAuth callback (code exchange)                                       |
-| `/api/auth/link-wallet`           | POST     | Required              | Link wallet to existing account                                                    |
-| `/api/auth/unlink`                | POST     | Required              | Unlink auth method (wallet/Google/GitHub)                                          |
-| `/api/account/delete`             | POST     | Required              | Account deletion                                                                   |
-| `/api/lessons/complete`           | POST     | Required              | Mark lesson complete, award XP, auto-finalize, auto-credential, check achievements |
-| `/api/lessons/validate-challenge` | POST     | Required              | Server-side challenge validation (UX pass/fail)                                    |
-| `/api/leaderboard`                | GET      | None                  | XP rankings (alltime/weekly/monthly)                                               |
-| `/api/certificates/metadata`      | GET      | None                  | Serve NFT metadata JSON by UUID                                                    |
-| `/api/certificates/mint`          | POST     | Required              | Manual credential mint with retry queue                                            |
-| `/api/build-program`              | POST     | Required              | Proxy Anchor build to build server                                                 |
-| `/api/deploy/save`                | POST     | Required              | Save deployed program record                                                       |
-| `/api/deploy/[uuid]`              | GET      | Required              | Download compiled .so binary                                                       |
-| `/api/rust/execute`               | POST     | Required              | Proxy basic Rust execution to Rust Playground                                      |
-| `/api/quests/daily`               | GET/POST | Required              | Get daily quest state / award quest XP (on-chain minting via `reward_xp`)          |
-| `/api/ai/partner`                 | POST     | Required              | AI lesson assistant (Gemini); rate-limited + input-capped                          |
-| `/api/ai/partner/verify`          | POST     | Required              | Verify the sealed comprehension-check token                                        |
-| `/api/community/*`                | Varies   | Varies                | Threads, answers, votes, flags, search (see §7)                                    |
-| `/api/webhooks/helius`            | POST     | HELIUS_WEBHOOK_SECRET | Process on-chain events (XP, achievements)                                         |
+| Route                             | Method   | Auth                  | Purpose                                                                                                                                                                             |
+| --------------------------------- | -------- | --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `/api/auth/nonce`                 | GET      | None                  | Generate SIWS nonce (stored in `siws_nonces` table)                                                                                                                                 |
+| `/api/auth/wallet`                | POST     | None                  | SIWS authentication (nonce + Ed25519 verification)                                                                                                                                  |
+| `/api/auth/callback`              | GET      | None                  | Google/GitHub OAuth callback (code exchange)                                                                                                                                        |
+| `/api/auth/link-wallet`           | POST     | Required              | Link wallet to existing account                                                                                                                                                     |
+| `/api/auth/unlink`                | POST     | Required              | Unlink auth method (wallet/Google/GitHub)                                                                                                                                           |
+| `/api/account/delete`             | POST     | Required              | Account deletion                                                                                                                                                                    |
+| `/api/lessons/complete`           | POST     | Required              | Mark lesson complete, award XP, auto-finalize, auto-credential, check achievements                                                                                                  |
+| `/api/lessons/validate-challenge` | POST     | Required              | Server-side challenge validation (UX pass/fail)                                                                                                                                     |
+| `/api/leaderboard`                | GET      | None                  | XP rankings (alltime/weekly/monthly)                                                                                                                                                |
+| `/api/certificates/metadata`      | GET      | None                  | Serve NFT metadata JSON by UUID                                                                                                                                                     |
+| `/api/certificates/mint`          | POST     | Required              | Manual credential mint with retry queue                                                                                                                                             |
+| `/api/build-program`              | POST     | Required              | Proxy Anchor build to build server                                                                                                                                                  |
+| `/api/deploy/save`                | POST     | Required              | Save deployed program record. **The only route under `/api/deploy`** — the compiled `.so` comes back inline (base64) from `/api/build-program`, not from a separate download route. |
+| `/api/rust/execute`               | POST     | Required              | Proxy basic Rust execution to Rust Playground                                                                                                                                       |
+| `/api/quests/daily`               | GET/POST | Required              | Get daily quest state / award quest XP (on-chain minting via `reward_xp`)                                                                                                           |
+| `/api/ai/partner`                 | POST     | Required              | AI lesson assistant (Gemini); rate-limited + input-capped                                                                                                                           |
+| `/api/ai/partner/verify`          | POST     | Required              | Verify the sealed comprehension-check token                                                                                                                                         |
+| `/api/teacher/courses/[id]/stats` | GET      | Required              | Read-only per-course stats for the instructor (`/teach`) viewer                                                                                                                     |
+| `/api/community/*`                | Varies   | Varies                | 9 routes: threads (+delete), answers (+accept, +delete), votes, flags, search — see §7                                                                                              |
+| `/api/webhooks/helius`            | POST     | HELIUS_WEBHOOK_SECRET | Process on-chain events (XP, achievements)                                                                                                                                          |
 
 ### Admin
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,8 +1,12 @@
-> Last synced: 2026-03-02
+> Last synced: 2026-07-12
 
 # Superteam Academy -- Architecture Reference
 
 System architecture, component structure, data flow, and service interfaces for Superteam Academy -- a Solana-native educational LMS.
+
+**There is no CMS.** Course content is authored in a git repo, compiled ahead of
+time, and **committed** to this repo as a typed bundle. Nothing fetches content at
+runtime. See [§3 Data Flow](#3-data-flow).
 
 ---
 
@@ -22,42 +26,61 @@ System architecture, component structure, data flow, and service interfaces for 
 │                                                                      │
 │  Server Components ── API Routes ── Middleware (auth + i18n)         │
 │                                                                      │
+│  ┌────────────────────────────────────────────────────────────────┐  │
+│  │  COMMITTED CONTENT BUNDLE  (src/content/generated/*.json)      │  │
+│  │  compiled from solanabr/courses-academy @ content.lock sha     │  │
+│  │  statically imported — no runtime content fetch, no CMS        │  │
+│  └────────────────────────────────────────────────────────────────┘  │
+│                                                                      │
 │  Holds: BACKEND_SIGNER_SECRET · PROGRAM_AUTHORITY_SECRET             │
-│         SUPABASE_SERVICE_ROLE_KEY · SANITY_ADMIN_TOKEN               │
-└──┬───────────┬──────────────┬──────────────┬─────────────────────────┘
-   │           │              │              │
-   ▼           ▼              ▼              ▼
-┌──────┐  ┌────────┐  ┌───────────┐  ┌──────────────────────────────┐
-│Sanity│  │Supabase│  │  Solana   │  │  Build Server (Rust/Axum)    │
-│(CMS) │  │(DB +   │  │ (Devnet) │  │  on GCP Cloud Run            │
-│      │  │ Auth)  │  │          │  │  cargo-build-sbf --offline   │
-└──────┘  └────────┘  │ Token-2022│  └──────────────────────────────┘
-                      │ Metaplex  │
-                      │   Core    │
-                      └───────────┘
+│         SUPABASE_SERVICE_ROLE_KEY · GITHUB_TOKEN (READ-ONLY)         │
+└──────────────┬──────────────┬──────────────┬─────────────────────────┘
+               │              │              │
+               ▼              ▼              ▼
+        ┌────────────┐  ┌───────────┐  ┌──────────────────────────────┐
+        │  Supabase  │  │  Solana   │  │  Build Server (Rust/Axum)    │
+        │  (DB+Auth) │  │ (Devnet)  │  │  on GCP Cloud Run            │
+        │            │  │           │  │  cargo-build-sbf --offline   │
+        │ user data  │  │ Token-2022│  └──────────────────────────────┘
+        │ +on-chain  │  │ Metaplex  │
+        │  status    │  │   Core    │
+        └────────────┘  └───────────┘
+```
+
+Build-time only (not a runtime dependency):
+
+```
+solanabr/courses-academy ──► compile-content.ts ──► committed bundle
+      (git = source of truth)      (pinned by apps/web/content.lock)
 ```
 
 ### Monorepo Layout
 
-| Directory            | Purpose                                                                                  |
-| -------------------- | ---------------------------------------------------------------------------------------- |
-| `apps/web/`          | Next.js 14 application (pages, API routes, components, services)                         |
-| `apps/build-server/` | Rust/Axum Solana program compiler on GCP Cloud Run                                       |
-| `onchain-academy/`   | Anchor workspace (program source, IDL, tests)                                            |
-| `packages/types/`    | Shared TypeScript interfaces (`Course`, `UserProfile`, `Progress`)                       |
-| `packages/config/`   | Shared ESLint, TypeScript, Tailwind configs                                              |
-| `sanity/`            | Sanity Studio schemas (`course`, `module`, `lesson`, `achievement`, `quest`) + seed data |
-| `supabase/`          | Complete Postgres schema (19 tables, indexes, RLS, functions, views)                     |
+| Directory                      | Purpose                                                                                 |
+| ------------------------------ | --------------------------------------------------------------------------------------- |
+| `apps/web/`                    | Next.js 14 application (pages, API routes, components, services)                        |
+| `apps/build-server/`           | Rust/Axum Solana program compiler on GCP Cloud Run                                      |
+| `onchain-academy/`             | Anchor workspace (program source, IDL, tests)                                           |
+| `packages/types/`              | Shared TypeScript interfaces (`Course`, `Lesson`, `LessonBlock`, …)                     |
+| `packages/content-schema/`     | Zod schemas for the content standard (course, lesson, blocks, achievement, quest, path) |
+| `packages/content-lint/`       | The content linter — runs in `courses-academy` CI, gating what is publishable           |
+| `packages/challenge-executor/` | Challenge runner (QuickJS sandbox) shared by the app and the linter's executor gate     |
+| `packages/deploy/`             | Browser-based Solana program deployment library                                         |
+| `packages/config/`             | Shared ESLint, TypeScript, Tailwind configs                                             |
+| `supabase/`                    | Postgres schema + migrations (21 tables, indexes, RLS, functions, views)                |
+
+Content itself lives **outside** this repo, in
+[`solanabr/courses-academy`](https://github.com/solanabr/courses-academy).
 
 ### Deployment Model
 
-| Service          | Host                       | Notes                                    |
-| ---------------- | -------------------------- | ---------------------------------------- |
-| Web app          | Vercel                     | Edge middleware, automatic deploys       |
-| Database + Auth  | Supabase (hosted Postgres) | RLS, SECURITY DEFINER functions          |
-| CMS              | Sanity (hosted)            | GROQ queries via CDN                     |
-| On-chain program | Solana devnet              | Anchor 0.31+, Token-2022, Metaplex Core  |
-| Build server     | GCP Cloud Run              | Docker, no IAM gateway, `X-API-Key` auth |
+| Service          | Host                       | Notes                                                                 |
+| ---------------- | -------------------------- | --------------------------------------------------------------------- |
+| Web app          | Vercel                     | Edge middleware, automatic deploys from `main`                        |
+| Database + Auth  | Supabase (hosted Postgres) | RLS, SECURITY DEFINER functions. Prod project: `pywhtmidcrptomrabbrw` |
+| Content          | **Committed to this repo** | Compiled bundle; no hosted service, no runtime credential             |
+| On-chain program | Solana devnet              | Anchor 0.31+, Token-2022, Metaplex Core                               |
+| Build server     | GCP Cloud Run              | Docker, no IAM gateway, `X-API-Key` auth                              |
 
 ---
 
@@ -86,8 +109,16 @@ RootLayout (app/layout.tsx)
        │    │    └── [id]/        ← Public: individual certificate
        │    └── settings/         ← Auth-gated: account settings
        │
-       └── admin/                 ← Admin dashboard (admin_session cookie required)
+       └── admin/                 ← Admin console (signed admin_session cookie required)
+            ├── publish/          ← Content pin: bundle SHA vs courses-academy HEAD
+            ├── deploy/           ← Course + achievement on-chain deploy tables
+            ├── moderation/       ← Pending community-flag queue
+            └── status/           ← Default screen: program health + data resync
 ```
+
+`/admin` itself renders the login form when unauthenticated and redirects to
+`/admin/status` when authenticated. A persistent nav rail (rendered by the admin
+`layout.tsx`) links the four screens.
 
 ### Component Groups
 
@@ -100,7 +131,7 @@ RootLayout (app/layout.tsx)
 | `gamification/` | XpPopup, LevelUpOverlay, LevelBadge, StreakDisplay, SkillRadar, AchievementCard, AchievementGrid, AchievementPopup, CertificatePopup, GamificationOverlays                                                       | XP animations, achievement celebrations, streak display    |
 | `certificates/` | CertificateCard, CertificateGrid, CourseCompletionMint                                                                                                                                                           | NFT credential display and minting UI                      |
 | `deploy/`       | DeployPanel, WalletFundingCard, GenericProgramExplorer                                                                                                                                                           | Student program deployment panel                           |
-| `admin/`        | CourseSyncTable, AchievementSyncTable, StatusBadge, SyncDiffView, ImmutableMismatchWarning                                                                                                                       | Admin CMS-to-chain sync UI                                 |
+| `admin/`        | CourseSyncTable, AchievementSyncTable, DataResyncPanel, FlagsPanel, StatusBadge, SyncDiffView                                                                                                                    | Admin console: content-to-chain deploy, resync, moderation |
 | `auth/`         | AuthModal, WalletAuthHandler, UserMenu                                                                                                                                                                           | Wallet + OAuth authentication                              |
 | `layout/`       | Header, Footer, Sidebar, LanguageSwitcher, ThemeProvider, ThemeToggle                                                                                                                                            | Page chrome, navigation, theming                           |
 | `landing/`      | TerminalTypewriter                                                                                                                                                                                               | Landing page animation                                     |
@@ -120,46 +151,99 @@ RootLayout (app/layout.tsx)
 
 ### Four Data Sources
 
-| Source                | Data                                                                | Access Pattern                                                        |
-| --------------------- | ------------------------------------------------------------------- | --------------------------------------------------------------------- |
-| **Sanity CMS**        | Course content (titles, modules, lessons, challenges, achievements) | Read-only via GROQ queries in server components                       |
-| **Supabase Postgres** | User data (profiles, progress, XP, achievements, certificates)      | Client reads via anon key + RLS; writes via API routes + service_role |
-| **Solana Blockchain** | Token-2022 XP balances, Enrollment PDAs, Credential NFTs            | On-chain writes via backend signer; reads via RPC                     |
-| **Build Server**      | Compiled Solana programs (.so binaries)                             | POST source to `/build`, GET binary from `/deploy/{uuid}`             |
+| Source                       | Data                                                                                            | Access Pattern                                                            |
+| ---------------------------- | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| **Committed content bundle** | Course content (courses, lessons, blocks, achievements, quests, paths)                          | Statically imported at build time by `lib/content/store.ts` (server-only) |
+| **Supabase Postgres**        | User data (profiles, progress, XP, achievements, certificates) **+ on-chain deployment status** | Client reads via anon key + RLS; writes via API routes + service_role     |
+| **Solana Blockchain**        | Token-2022 XP balances, Enrollment PDAs, Credential NFTs                                        | On-chain writes via backend signer; reads via RPC                         |
+| **Build Server**             | Compiled Solana programs (.so binaries)                                                         | POST source to `/build`, GET binary from `/deploy/{uuid}`                 |
 
-### Content Flow (Sanity to Pages)
+### Content Flow (git to pages)
+
+Content is **compiled ahead of time and committed**. Nothing fetches it at
+request time.
 
 ```
-Sanity CMS (content authoring)
-       │
-       ▼ GROQ queries via CDN
-       │
-Next.js Server Components ──► Rendered HTML
+solanabr/courses-academy         ← git repo: course.yaml, lesson.yaml,
+        │                          achievements/, quests/, paths/, instructors/
+        │  pinned to ONE commit by apps/web/content.lock
+        ▼
+apps/web/scripts/compile-content.ts
+        │  fetch tarball @ locked SHA → Zod-validate every doc (fail-closed)
+        │  → project → emit deterministic JSON (sorted keys, no timestamps)
+        ▼
+apps/web/src/content/generated/*.json   ← COMMITTED, prettier-ignored
+apps/web/public/content-assets/*        ← COMMITTED
+        │
+        ▼ static import (server-only)
+lib/content/store.ts  ──►  lib/content/queries.ts  ──►  Server Components
 ```
 
-Courses are only visible to students when their Sanity document has `onChainStatus.status == "synced"`. This filter is applied in every public-facing GROQ query (`getAllCourses`, `getCourseBySlug`, `getLessonBySlug`, etc.). Unpublished or undeployed courses are invisible to the platform but visible in the admin dashboard.
+Properties this buys:
 
-Key queries in `lib/sanity/queries.ts`:
+- **Determinism** — output is a pure function of the locked SHA. CI recompiles and
+  fails on any byte of drift, catching a stale bundle after a lock bump _and_ a
+  hand-edit of the generated files.
+- **No runtime dependency** — a content-repo outage cannot affect the site.
+- **No content-write credential exists.** The app cannot mutate content under any
+  credential. Publishing is a PR that bumps `content.lock` + commits the
+  regenerated bundle. `GITHUB_TOKEN` is **read-only** and only polls HEAD/CI state
+  for the admin Publish screen.
 
-| Function                                  | Returns                                                                        |
-| ----------------------------------------- | ------------------------------------------------------------------------------ |
-| `getAllCourses()`                         | All synced courses with modules and lesson summaries                           |
-| `getCourseBySlug(slug)`                   | Single course with full module/lesson content                                  |
-| `getLessonBySlug(courseSlug, lessonSlug)` | Single lesson with code, tests, hints, solution                                |
-| `getCourseById(id)`                       | Course by Sanity `_id` (used in API routes), includes `trackCollectionAddress` |
-| `getAllCourseLessonCounts()`              | `{ _id, totalLessons }[]` for course-completion detection                      |
-| `getAllAchievements()`                    | All achievement definitions (for unlock checking)                              |
-| `getDeployedAchievements()`               | Achievements with on-chain PDAs only                                           |
-| `getAllCoursesAdmin()`                    | All courses including drafts and `onChainStatus` fields                        |
-| `getAllAchievementsAdmin()`               | All achievements with `onChainStatus` fields                                   |
+`lib/content/store.ts` is `server-only` **by necessity**: the bundle contains quiz
+answer keys, code solutions, and hidden tests. The `server-only` marker makes a
+client value-import a build error. Client components read the safe subset through
+the public `/api/content/*` routes (via `lib/content/client-queries.ts`, whose fn
+signatures are identical to the server ones).
 
-Sanity admin mutations (`lib/sanity/admin-mutations.ts`):
+### The visibility gate
 
-| Function                                                                     | Purpose                                     |
-| ---------------------------------------------------------------------------- | ------------------------------------------- |
-| `writeCourseOnChainStatus(sanityId, status, coursePda, txSignature)`         | Mark course as synced after on-chain deploy |
-| `writeCourseTrackCollection(sanityId, trackCollectionAddress)`               | Store credential collection address         |
-| `writeAchievementOnChainStatus(sanityId, achievementPda, collectionAddress)` | Mark achievement as synced                  |
+A course is visible to learners **iff its Supabase deployment row says so**:
+
+```
+visible  ⇔  onchain_deployments.status == "synced"  AND  coalesce(is_active, true)
+```
+
+This is the post-SP2 replacement for the old CMS `onChainStatus` field. It lives in
+**exactly one function** — `isSynced()` in `lib/content/deployments.ts` — and is
+applied to every public read. Content with **no** deployment row is **hidden**
+(fail-closed: hidden > leaked). `is_active` is tri-state; `NULL` coalesces to
+`true`, so deactivation is opt-in.
+
+Two read paths into `onchain_deployments`:
+
+| Function                 | Client                                                                                                                    | Used by                                                             |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| `getActiveDeployments()` | Cookieless **anon** client over the `public_onchain_deployments` view, wrapped in `unstable_cache` (tag `courses`, 3600s) | Public catalog + lesson reads. Cookieless so pages stay static/ISR. |
+| `getDeploymentById(id)`  | **service_role** client, uncached, full row                                                                               | Reward paths + admin reads that need `track_collection_address`     |
+
+Key queries in `lib/content/queries.ts` (server-only):
+
+| Function                                  | Returns                                                                  |
+| ----------------------------------------- | ------------------------------------------------------------------------ |
+| `getAllCourses()`                         | All synced+active courses with lesson summaries                          |
+| `getCourseBySlug(slug)`                   | Single course with full lesson content                                   |
+| `getLessonBySlug(courseSlug, lessonSlug)` | Single lesson with its ordered `blocks[]` (code, tests, hints, solution) |
+| `getCourseById(id)`                       | Course by content `_id` (used in API routes)                             |
+| `getAllCourseLessonCounts()`              | `{ _id, totalLessons }[]` for course-completion detection                |
+| `getAllAchievements()`                    | All achievement definitions (for unlock checking)                        |
+| `getDeployedAchievements()`               | Achievements with on-chain PDAs only                                     |
+| `getAllCoursesAdmin()`                    | All courses joined with their full Supabase deployment row               |
+| `getAllAchievementsAdmin()`               | All achievements joined with their full Supabase deployment row          |
+
+Deployment writes (`lib/content/deployment-writes.ts`, service_role only) — these
+kept their original signatures across the CMS removal, so their four call sites
+(`courses/sync`, `achievements/sync`, `courses/{deactivate,reactivate}`) were
+untouched:
+
+| Function                                                               | Purpose                                                    |
+| ---------------------------------------------------------------------- | ---------------------------------------------------------- |
+| `writeCourseOnChainStatus(id, status, coursePda, txSignature)`         | Upsert the course row as `synced` after an on-chain deploy |
+| `writeCourseTrackCollection(id, trackCollectionAddress)`               | Store the credential collection address                    |
+| `writeAchievementOnChainStatus(id, achievementPda, collectionAddress)` | Upsert the achievement row as `synced`                     |
+
+Each upsert is keyed on the `content_id` PK and sets **only the columns that writer
+owns** (`ON CONFLICT DO UPDATE` merge semantics), preserving the rest of the row.
 
 ### Auth Flow
 
@@ -257,29 +341,62 @@ Client: POST /api/lessons/complete { lessonId, courseId }
 2. Learner wallet signs the transaction
 3. On-chain: Enrollment PDA created (lesson_flags = 0, completed_at = None)
 4. If course has prerequisite: verified via remaining accounts
-5. Supabase: enrollment row mirrored via /api/enrollment/sync
+5. Supabase: enrollment row mirrored by the client via the enrollments table
 ```
 
 ### Admin Deployment Flow
 
 ```
-Admin Dashboard → POST /api/admin/courses/sync
+/admin/deploy → POST /api/admin/courses/sync
   │
-  ├── Verify ADMIN_SECRET (Bearer token in Authorization header)
+  ├── requireAdminAuth() — same-origin check + HMAC-signed `admin_session` cookie
   ├── deployCoursePda() via admin-signer.ts → createCourse instruction
   ├── deployCourseTrackCollection() → Metaplex Core collection (UMI)
-  ├── writeCourseOnChainStatus() → Sanity marks course as "synced"
-  └── writeCourseTrackCollection() → Sanity stores collection address
+  ├── writeCourseOnChainStatus()   → Supabase `onchain_deployments` row = "synced"
+  ├── writeCourseTrackCollection() → Supabase stores the collection address
+  └── revalidateTag("courses")     → purge the cached deployment map so the
+                                      catalog picks the new course up
 
 Similarly for achievements:
   POST /api/admin/achievements/sync
   ├── deployAchievementType() → createAchievementType + collection
-  └── writeAchievementOnChainStatus() → Sanity marks as "synced"
+  └── writeAchievementOnChainStatus() → Supabase row = "synced"
 ```
+
+**Admin auth is a signed cookie, not a bearer token.** `requireAdminAuth()`
+(`lib/admin/auth.ts`) requires a same-origin request **and** a valid HMAC-signed
+`admin_session` cookie, minted by `POST /api/admin/auth` when the operator enters
+`ADMIN_SECRET` at the login form. No admin route accepts
+`Authorization: Bearer <ADMIN_SECRET>`.
 
 ---
 
 ## 4. Service Interfaces
+
+### `lib/content/*` -- The Content Read Layer
+
+All server-only. Composes three seams: the committed bundle (content), Supabase
+(on-chain status), and projectors (shape).
+
+| Module                 | Purpose                                                                                                                                                                        |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `store.ts`             | Statically imports the generated JSON into id/slug-keyed maps. **The `server-only` marker here is load-bearing** — the bundle holds quiz answers, solutions, and hidden tests. |
+| `queries.ts`           | The query API (`getAllCourses`, `getCourseBySlug`, `getLessonBySlug`, …). Owns `COURSES_CACHE_TAG`.                                                                            |
+| `deployments.ts`       | The on-chain status read seam. `getActiveDeployments()` (cached anon view read), `getDeploymentById()` (service_role full row), and `isSynced()` — the entire visibility gate. |
+| `deployment-writes.ts` | The four service_role upserts into `onchain_deployments`.                                                                                                                      |
+| `project.ts`           | Projectors that map raw bundle docs to the app's `Course` / `Lesson` / … types.                                                                                                |
+| `meta.ts`              | `contentMeta` + `SYNCED_SHA` — the pinned SHA, a **build-time constant** (the bundle _is_ the synced content).                                                                 |
+| `client-queries.ts`    | Browser-side fetch wrappers over `/api/content/*`. Same fn names/signatures as the server ones, so swapping a component over is an import-line change.                         |
+| `compile/*`            | The compiler internals (tarball extract, validate, project, assets, prune), shared with `scripts/compile-content.ts`.                                                          |
+
+### `lib/github/*` -- Read-Only GitHub Seam
+
+| Module              | Purpose                                                                                                                                           |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `github.ts`         | The GitHub client: `fetchHeadSha`, `fetchChecksState`, `fetchAheadBy`. **Read scope only.**                                                       |
+| `publish-pin.ts`    | Pure drift/verdict + PR-link helpers for `/admin/publish`. Builds the one-line `content.lock` diff and a prefilled PR URL. **Performs no write.** |
+| `drift.ts`          | `computeContentDrift` / `computeChainDrift`.                                                                                                      |
+| `content-commit.ts` | `deriveActiveMask` — the `active_lessons` bitmask derived from a course's `slots.lock.json`.                                                      |
 
 ### `academy-program.ts` -- Backend-Signed Instructions
 
@@ -374,9 +491,11 @@ Used for wallet link/unlink flow, not for lesson completion (which uses on-chain
 
 ## 5. On-Chain Integration Points
 
-### Program Instructions (16 total)
+### Program Instructions (18 total)
 
 The Solana program (`onchain-academy`) is built with Anchor 0.31+. Instruction names in Rust are snake_case; Anchor's `Program` constructor converts them to camelCase for TypeScript.
+
+Source of truth: `onchain-academy/programs/onchain-academy/src/instructions/`.
 
 | Instruction (Rust)            | TypeScript Builder (`academy-program.ts`)           | Signer            |
 | ----------------------------- | --------------------------------------------------- | ----------------- |
@@ -384,6 +503,7 @@ The Solana program (`onchain-academy`) is built with Anchor 0.31+. Instruction n
 | `update_config`               | -- (admin CLI)                                      | Authority         |
 | `create_course`               | `deployCoursePda()` in `admin-signer.ts`            | Authority         |
 | `update_course`               | `updateCoursePda()` in `admin-signer.ts`            | Authority         |
+| `close_course`                | -- (admin CLI)                                      | Authority         |
 | `enroll`                      | Client-side via `instructions.ts`                   | Learner wallet    |
 | `complete_lesson`             | `completeLesson()` in `academy-program.ts`          | Backend signer    |
 | `finalize_course`             | `finalizeCourse()` in `academy-program.ts`          | Backend signer    |
@@ -391,6 +511,7 @@ The Solana program (`onchain-academy`) is built with Anchor 0.31+. Instruction n
 | `issue_credential`            | `issueCredential()` in `academy-program.ts`         | Backend signer    |
 | `upgrade_credential`          | -- (not yet used in API routes)                     | Backend signer    |
 | `register_minter`             | -- (admin CLI)                                      | Authority         |
+| `update_minter`               | -- (admin CLI)                                      | Authority         |
 | `revoke_minter`               | -- (admin CLI)                                      | Authority         |
 | `reward_xp`                   | `rewardXp()` in `academy-program.ts` (daily quests) | Registered minter |
 | `create_achievement_type`     | `deployAchievementType()` in `admin-signer.ts`      | Authority         |
@@ -536,7 +657,17 @@ Community data (categories, threads, answers, votes) has public SELECT policies.
 
 ### Admin Auth
 
-Admin routes use a separate `ADMIN_SECRET` environment variable. The admin page renders a login form; successful authentication sets an `admin_session` cookie. Sub-routes under `/admin/` redirect to the admin login page if the cookie is absent.
+Admin auth is separate from Supabase auth. `/admin` renders a login form; entering
+`ADMIN_SECRET` mints an **HMAC-signed `admin_session` cookie** (`POST /api/admin/auth`).
+`ADMIN_SECRET` is both the login secret and the HMAC signing key — rotating it
+invalidates every session.
+
+- Middleware redirects `/admin/*` sub-routes back to `/admin` when the cookie is
+  absent or expired.
+- Every `/api/admin/*` route calls `requireAdminAuth()`, which enforces a
+  **same-origin check plus the signed cookie**. There is no bearer-token path.
+- `ADMIN_SECRET` is never read in a page component, so it cannot be serialized into
+  a client payload.
 
 ### Middleware
 
@@ -557,9 +688,10 @@ The middleware (`src/middleware.ts`) chains two concerns in order:
 - `/leaderboard`, `/certificates`, `/certificates/[id]`
 - `/profile/[username]` (viewing other users)
 
-**Admin routes**: Checked against `admin_session` cookie, separate from Supabase auth.
+**Admin routes**: Checked against the signed `admin_session` cookie, separate from Supabase auth.
 
-The middleware matcher excludes API routes, `_next`, `_vercel`, `/studio`, and static assets.
+The middleware matcher excludes API routes, `_next`, `_vercel`, and static assets
+(`matcher: ["/((?!api|_next|_vercel|.*\\..*).*)"]`).
 
 ---
 
@@ -679,27 +811,52 @@ Handled entirely in the `award_xp()` SQL function:
 
 ### Achievements
 
-Achievement metadata (name, description, icon, category) lives in **Sanity CMS**. Unlock logic lives in `lib/gamification/achievements.ts` as `UNLOCK_CHECKS`:
+**Unlock logic is content, not TypeScript.** Each achievement doc in
+`courses-academy` carries a declarative `award` rule (a Zod discriminated union,
+`packages/content-schema/src/achievement.ts`). The app holds one predicate per
+award _kind_ — not per achievement — in `PREDICATES`
+(`lib/gamification/achievements.ts`):
 
-| Achievement ID      | Condition                      |
-| ------------------- | ------------------------------ |
-| `first-steps`       | 1+ lesson completed            |
-| `course-completer`  | 1+ course completed            |
-| `week-warrior`      | 7-day streak                   |
-| `monthly-master`    | 30-day streak                  |
-| `consistency-king`  | 100-day streak                 |
-| `rust-rookie`       | Completed a Rust lesson        |
-| `anchor-expert`     | Completed an Anchor course     |
-| `full-stack-solana` | Completed all tracks           |
-| `early-adopter`     | Among first 100 users          |
-| `perfect-score`     | All tests passed first try     |
+```ts
+export const PREDICATES = { ... } satisfies Record<AwardKind, Predicate>;
+```
 
-Achievements without an `UNLOCK_CHECKS` entry (e.g., `bug-hunter`, `helper`) are admin-granted manually.
+The `satisfies` makes a missing kind a **compile error**, and no course or path id
+is hardcoded anywhere — every target is named by content.
+
+The eight award kinds:
+
+| `award.kind`                  | Unlocks when                                              |
+| ----------------------------- | --------------------------------------------------------- |
+| `lessons-completed`           | `completedLessons >= gte`                                 |
+| `lessons-completed-in-course` | completed lessons in `course` >= `gte`                    |
+| `course-completed`            | `course` is fully completed                               |
+| `path-completed`              | every course in learning path `path` is completed         |
+| `streak`                      | `currentStreak >= days`                                   |
+| `user-number`                 | `userNumber <= lte` (early-adopter style)                 |
+| `community-stat`              | a community stat (threads/answers/accepted) >= `gte`      |
+| `manual`                      | never auto-fires — admin-granted only (e.g. `bug-hunter`) |
+
+`checkNewAchievements(deployed, state, alreadyUnlocked)` evaluates the rule on each
+not-yet-unlocked achievement against one fully-populated `UserState` (lessons,
+courses, paths, streak, user number, community stats) built in a single pass by
+`buildUserState()`.
+
+The bundle currently carries **10** achievements. Their conditions are defined in
+the content repo, not here — do not enumerate them in this doc.
+
+> `perfect-score` was **dropped**: block results are transient by design, so there
+> is no durable "passed on first try" signal to key it on.
 
 The check runs after every lesson completion. New achievements are:
 
-1. Recorded in Supabase via `unlock_achievement()` SECURITY DEFINER function
+1. Recorded in Supabase via the `unlock_achievement()` SECURITY DEFINER function
 2. Minted on-chain as Metaplex Core NFTs via `awardAchievement()` (non-fatal)
+
+> **ID convention**: the achievement's full content `_id` (e.g.
+> `achievement-first-steps`) is used **verbatim** as the on-chain PDA seed. Never
+> strip the `achievement-` prefix — doing so derives the wrong PDA and the award
+> fails silently.
 
 ### Celebration Popups (Event Bus Pattern)
 
@@ -725,62 +882,114 @@ GamificationOverlays
 
 ## 9. API Routes
 
-All routes are in `apps/web/src/app/api/`.
+All routes are in `apps/web/src/app/api/`. The authoritative, always-current list
+lives in `apps/web/src/app/api/CLAUDE.md`.
 
-| Route                                | Method   | Auth                  | Purpose                                                                            |
-| ------------------------------------ | -------- | --------------------- | ---------------------------------------------------------------------------------- |
-| `/api/auth/nonce`                    | GET      | None                  | Generate SIWS nonce (stored in `siws_nonces` table)                                |
-| `/api/auth/wallet`                   | POST     | None                  | SIWS authentication (nonce + Ed25519 verification)                                 |
-| `/api/auth/callback`                 | GET      | None                  | Google/GitHub OAuth callback (code exchange)                                       |
-| `/api/auth/link-wallet`              | POST     | Required              | Link wallet to existing account                                                    |
-| `/api/auth/unlink`                   | POST     | Required              | Unlink auth method (wallet/Google/GitHub)                                          |
-| `/api/lessons/complete`              | POST     | Required              | Mark lesson complete, award XP, auto-finalize, auto-credential, check achievements |
-| `/api/leaderboard`                   | GET      | None                  | XP rankings (alltime/weekly/monthly)                                               |
-| `/api/certificates/metadata`         | GET      | None                  | Serve NFT metadata JSON by UUID                                                    |
-| `/api/certificates/mint`             | POST     | Required              | Manual credential mint with retry queue                                            |
-| `/api/build-program`                 | POST     | Required              | Proxy Anchor build to build server                                                 |
-| `/api/deploy/save`                   | POST     | Required              | Save deployed program record                                                       |
-| `/api/deploy/[uuid]`                 | GET      | Required              | Download compiled .so binary                                                       |
-| `/api/rust/execute`                  | POST     | Required              | Proxy basic Rust execution to Rust Playground                                      |
-| `/api/quests/daily`                  | GET/POST | Required              | Get daily quest state / award quest XP (on-chain minting via `reward_xp`)          |
-| `/api/community/threads`             | GET/POST | Varies                | List threads (cursor pagination) / create thread                                   |
-| `/api/community/threads/[id]`        | GET      | None                  | Thread detail with answers                                                         |
-| `/api/community/answers`             | POST     | Required              | Post answer to a thread                                                            |
-| `/api/community/answers/[id]/accept` | POST     | Required              | Accept an answer (thread author only)                                              |
-| `/api/community/votes`               | POST     | Required              | Upvote/downvote thread or answer                                                   |
-| `/api/community/flags`               | POST     | Required              | Flag content for moderation                                                        |
-| `/api/community/search`              | GET      | None                  | Full-text search across threads                                                    |
-| `/api/webhooks/helius`               | POST     | HELIUS_WEBHOOK_SECRET | Process on-chain events (XP, achievements)                                         |
-| `/api/admin/auth`                    | POST     | ADMIN_SECRET          | Admin authentication                                                               |
-| `/api/admin/status`                  | GET      | ADMIN_SECRET          | Platform status (program liveness, authority match)                                |
-| `/api/admin/courses/sync`            | POST     | ADMIN_SECRET          | Deploy course PDA + collection on-chain                                            |
-| `/api/admin/courses/deactivate`      | POST     | ADMIN_SECRET          | Set course `is_active = false`                                                     |
-| `/api/admin/courses/reactivate`      | POST     | ADMIN_SECRET          | Set course `is_active = true`                                                      |
-| `/api/admin/achievements/sync`       | POST     | ADMIN_SECRET          | Deploy achievement type + collection on-chain                                      |
-| `/api/admin/resync`                  | POST     | ADMIN_SECRET          | Resync on-chain state to Supabase                                                  |
+"Admin" auth below means the same-origin + signed-`admin_session`-cookie check
+(`requireAdminAuth`), **not** a bearer token.
+
+### Content (public, serve the bundle to client components)
+
+These exist because `lib/content/*` is `server-only` (the bundle holds answer keys
+and solutions). They expose only summary-safe shapes — there is deliberately **no**
+client-side route for a full lesson read.
+
+| Route                            | Method | Auth | Purpose                                          |
+| -------------------------------- | ------ | ---- | ------------------------------------------------ |
+| `/api/content/courses`           | GET    | None | Course summaries by id                           |
+| `/api/content/lessons-summary`   | GET    | None | Lesson summaries by id                           |
+| `/api/content/recommended`       | GET    | None | Recommended courses (excluding given ids)        |
+| `/api/content/tags`              | GET    | None | Course tags (cached, revalidated hourly)         |
+| `/api/content/achievements`      | GET    | None | Achievement catalog (cached, revalidated hourly) |
+| `/api/content/instructor-wallet` | GET    | None | Is this wallet an instructor?                    |
+
+### Auth / core / community
+
+| Route                             | Method   | Auth                  | Purpose                                                                            |
+| --------------------------------- | -------- | --------------------- | ---------------------------------------------------------------------------------- |
+| `/api/auth/nonce`                 | GET      | None                  | Generate SIWS nonce (stored in `siws_nonces` table)                                |
+| `/api/auth/wallet`                | POST     | None                  | SIWS authentication (nonce + Ed25519 verification)                                 |
+| `/api/auth/callback`              | GET      | None                  | Google/GitHub OAuth callback (code exchange)                                       |
+| `/api/auth/link-wallet`           | POST     | Required              | Link wallet to existing account                                                    |
+| `/api/auth/unlink`                | POST     | Required              | Unlink auth method (wallet/Google/GitHub)                                          |
+| `/api/account/delete`             | POST     | Required              | Account deletion                                                                   |
+| `/api/lessons/complete`           | POST     | Required              | Mark lesson complete, award XP, auto-finalize, auto-credential, check achievements |
+| `/api/lessons/validate-challenge` | POST     | Required              | Server-side challenge validation (UX pass/fail)                                    |
+| `/api/leaderboard`                | GET      | None                  | XP rankings (alltime/weekly/monthly)                                               |
+| `/api/certificates/metadata`      | GET      | None                  | Serve NFT metadata JSON by UUID                                                    |
+| `/api/certificates/mint`          | POST     | Required              | Manual credential mint with retry queue                                            |
+| `/api/build-program`              | POST     | Required              | Proxy Anchor build to build server                                                 |
+| `/api/deploy/save`                | POST     | Required              | Save deployed program record                                                       |
+| `/api/deploy/[uuid]`              | GET      | Required              | Download compiled .so binary                                                       |
+| `/api/rust/execute`               | POST     | Required              | Proxy basic Rust execution to Rust Playground                                      |
+| `/api/quests/daily`               | GET/POST | Required              | Get daily quest state / award quest XP (on-chain minting via `reward_xp`)          |
+| `/api/ai/partner`                 | POST     | Required              | AI lesson assistant (Gemini); rate-limited + input-capped                          |
+| `/api/ai/partner/verify`          | POST     | Required              | Verify the sealed comprehension-check token                                        |
+| `/api/community/*`                | Varies   | Varies                | Threads, answers, votes, flags, search (see §7)                                    |
+| `/api/webhooks/helius`            | POST     | HELIUS_WEBHOOK_SECRET | Process on-chain events (XP, achievements)                                         |
+
+### Admin
+
+| Route                           | Method   | Auth  | Purpose                                                                     |
+| ------------------------------- | -------- | ----- | --------------------------------------------------------------------------- |
+| `/api/admin/auth`               | POST     | None  | Exchange `ADMIN_SECRET` for the signed `admin_session` cookie               |
+| `/api/admin/status`             | GET      | Admin | Program liveness, authority match, per-item deploy state (drives 2 screens) |
+| `/api/admin/publish/pin`        | GET      | Admin | Pinned bundle SHA vs `courses-academy` HEAD + CI checks + drift verdict     |
+| `/api/admin/content/drift`      | GET      | Admin | Bundle SHA vs HEAD, plus per-course chain drift (`content_tx_id == HEAD`)   |
+| `/api/admin/courses/sync`       | POST     | Admin | Deploy course PDA + track collection on-chain, record it in Supabase        |
+| `/api/admin/courses/deactivate` | POST     | Admin | Set course `is_active = false` (hides it from learners)                     |
+| `/api/admin/courses/reactivate` | POST     | Admin | Set course `is_active = true`                                               |
+| `/api/admin/achievements/sync`  | POST     | Admin | Deploy achievement type + collection on-chain                               |
+| `/api/admin/flags`              | GET/POST | Admin | Pending moderation queue / resolve+dismiss a flag                           |
+| `/api/admin/resync`             | POST     | Admin | Re-read on-chain state and backfill the Supabase mirror                     |
+
+No admin route holds a content- or repo-write credential. `GITHUB_TOKEN` is
+read-only; the publish flow's output is a **prefilled PR link**, not a write.
 
 ---
 
 ## 10. Database Schema
 
-### Tables (17)
+### Tables (21)
 
-#### Core Tables (10)
+#### Core Tables (11)
 
-| Table               | Purpose                     | Key Columns                                                        |
-| ------------------- | --------------------------- | ------------------------------------------------------------------ |
-| `profiles`          | User identity               | `id` (FK auth.users), `wallet_address`, `username`, `is_public`    |
-| `enrollments`       | Course enrollment records   | `user_id`, `course_id`, `completed_at`, `tx_signature`             |
-| `user_progress`     | Per-lesson completion       | `user_id`, `lesson_id`, `completed`, `lesson_index`                |
-| `user_xp`           | XP totals and streaks       | `user_id`, `total_xp`, `level`, `current_streak`, `longest_streak` |
-| `xp_transactions`   | XP award history            | `user_id`, `amount`, `reason`, `tx_signature`                      |
-| `user_achievements` | Achievement unlock records  | `user_id`, `achievement_id`, `asset_address`                       |
-| `certificates`      | Credential NFT records      | `user_id`, `course_id`, `mint_address`, `credential_type`          |
-| `nft_metadata`      | Full Metaplex metadata JSON | `id`, `data` (JSONB)                                               |
-| `siws_nonces`       | Nonce replay protection     | `nonce`, `status`, `ip_address`, TTL-based cleanup                 |
-| `deployed_programs` | Student program deployments | `user_id`, `program_id`, `network`                                 |
+| Table                 | Purpose                                  | Key Columns                                                        |
+| --------------------- | ---------------------------------------- | ------------------------------------------------------------------ |
+| `profiles`            | User identity                            | `id` (FK auth.users), `wallet_address`, `username`, `is_public`    |
+| `enrollments`         | Course enrollment records                | `user_id`, `course_id`, `completed_at`, `tx_signature`             |
+| `user_progress`       | Per-lesson completion                    | `user_id`, `lesson_id`, `completed`, `lesson_index`                |
+| `user_xp`             | XP totals and streaks                    | `user_id`, `total_xp`, `level`, `current_streak`, `longest_streak` |
+| `xp_transactions`     | XP award history                         | `user_id`, `amount`, `reason`, `tx_signature`                      |
+| `user_achievements`   | Achievement unlock records               | `user_id`, `achievement_id`, `asset_address`                       |
+| `certificates`        | Credential NFT records                   | `user_id`, `course_id`, `mint_address`, `credential_type`          |
+| `nft_metadata`        | Full Metaplex metadata JSON              | `id`, `data` (JSONB)                                               |
+| `siws_nonces`         | Nonce replay protection                  | `nonce`, `status`, `ip_address`, TTL-based cleanup                 |
+| `deployed_programs`   | **Learner** practice program deployments | `user_id`, `program_id`, `network`                                 |
+| `onchain_deployments` | **Platform** content → chain state       | `content_id` (PK), `kind`, `status`, `course_pda`, `is_active`, …  |
 
-#### Community Tables (5)
+#### `onchain_deployments` — the visibility gate
+
+The post-SP2 home of what used to be a CMS `onChainStatus` field. One row per synced
+course (`course-*`) or achievement (`achievement-*`), keyed by the content `_id`
+**used verbatim as the on-chain PDA seed**.
+
+It is deliberately **not** `deployed_programs`: that table is per-learner practice
+deploys (UUID pk, `user_id` FK, own-row RLS). This one is per-content platform
+state (TEXT pk, no user). They never mix.
+
+Security follows the house `public_user_xp` pattern — RLS is row-level, not
+column-level, so the minimal public surface is a **view**:
+
+- Base table: **RLS enabled, zero policies** → service_role only (which bypasses
+  RLS). All four writer sites use `createAdminClient()`.
+- `public_onchain_deployments` view: `SELECT` granted to `anon` + `authenticated`,
+  exposing **only** `content_id, kind, status, is_active, achievement_pda`.
+- **Invariant**: never add a raw pubkey, tx signature, or
+  `track_collection_address` to that view — those are reward-path reads served via
+  service_role only.
+
+#### Community Tables (6)
 
 | Table              | Purpose                  | Key Columns                                                                   |
 | ------------------ | ------------------------ | ----------------------------------------------------------------------------- |
@@ -788,20 +997,25 @@ All routes are in `apps/web/src/app/api/`.
 | `threads`          | Discussion threads       | `author_id`, `category_id`, `title`, `body`, `course_id`, `lesson_id`, `tags` |
 | `answers`          | Thread replies           | `thread_id`, `author_id`, `body`, `is_accepted`                               |
 | `votes`            | Upvotes/downvotes        | `user_id`, `thread_id` or `answer_id`, `value` (+1/-1)                        |
-| `flags`            | Content moderation flags | `user_id`, `thread_id` or `answer_id`, `reason`                               |
+| `flags`            | Content moderation flags | `reporter_id`, `thread_id` or `answer_id`, `reason`, `status`                 |
+| `thread_views`     | Per-user view dedup      | `user_id`, `thread_id`                                                        |
 
-#### Queue / Quest Tables (2)
+#### Queue / Quest / Infra Tables (4)
 
 | Table                     | Purpose                             | Key Columns                                                         |
 | ------------------------- | ----------------------------------- | ------------------------------------------------------------------- |
 | `pending_onchain_actions` | On-chain retry queue for failed TXs | `user_id`, `action_type`, `payload`, `attempts`, `status`           |
 | `user_daily_quests`       | Daily quest completion tracking     | `user_id`, `quest_id`, `current_value`, `completed`, `period_start` |
+| `challenge_assists`       | Per-user AI-assist budget           | `user_id`, `lesson_id`, assist counters                             |
+| `rate_limits`             | Cross-instance API rate limiter     | key, window, count                                                  |
 
-#### Views
+#### Views (3)
 
-| View              | Purpose                                                                 |
-| ----------------- | ----------------------------------------------------------------------- |
-| `community_stats` | Aggregated thread/answer/accepted counts per user (for profile display) |
+| View                         | Purpose                                                                      |
+| ---------------------------- | ---------------------------------------------------------------------------- |
+| `community_stats`            | Aggregated thread/answer/accepted counts per user (for profile display)      |
+| `public_user_xp`             | Non-sensitive `user_id`/`total_xp`/`level` for public profiles + leaderboard |
+| `public_onchain_deployments` | The 5-column public read surface of `onchain_deployments` (see above)        |
 
 ### Auto-Provisioning
 
@@ -869,9 +1083,27 @@ On-chain state (Token-2022 XP, enrollment bitmap, Metaplex Core credentials) is 
 
 The backend server holds a rotatable keypair (`BACKEND_SIGNER_SECRET`, stored in Config PDA). Lesson completion, course finalization, and credential issuance are all backend-signed to prevent gaming. Enrollment and enrollment closure are learner-signed (personal commitment, no anti-cheat concern).
 
-### Sanity Content Gate
+### Content as a Committed Artifact (no CMS)
 
-Courses become visible to students only when `onChainStatus.status == "synced"` in Sanity. This ensures courses are deployed on-chain before students can access them. The admin dashboard shows all courses regardless of status.
+Course content is authored in git (`solanabr/courses-academy`), compiled by
+`compile-content.ts` at a SHA pinned in `apps/web/content.lock`, and **committed**
+to this repo as typed JSON. The app never fetches content at runtime.
+
+Why: content changes become reviewable diffs with CI gates; the read path has zero
+network hops and cannot be broken by a third-party outage; and — because no
+server-side content-write token exists anywhere in the app — there is no runtime
+path by which content can be mutated. Publishing is a pull request. The cost is
+that publishing requires a deploy, which is the intended trade.
+
+### Content Gate (Supabase, not content)
+
+Courses become visible to learners only when their `onchain_deployments` row is
+`status == "synced"` **and** `coalesce(is_active, true)`. This keeps courses hidden
+until they are actually deployed on-chain, and lets an admin hide one again without
+destroying the PDA. Content with no row at all is hidden (fail-closed).
+
+The gate is one function — `isSynced()` in `lib/content/deployments.ts`. The admin
+console shows all content regardless of status.
 
 ### Browser-Side Code Execution
 
@@ -883,4 +1115,4 @@ Solana brand colors (#9945FF, #14F195) contrast best against dark backgrounds. D
 
 ---
 
-_Last updated: 2026-03-02_
+_Last updated: 2026-07-12_

--- a/docs/CUSTOMIZATION.md
+++ b/docs/CUSTOMIZATION.md
@@ -428,78 +428,97 @@ To switch to mainnet, update the environment variable and set `NEXT_PUBLIC_SOLAN
 
 3. Call the XP award from the appropriate API route. XP is awarded server-side via the Supabase `award_xp()` function (SECURITY DEFINER, called with service_role key from API routes).
 
-**Server-side XP cap**: The on-chain `xpPerLesson` field has a max of 100 (enforced in the Sanity schema: `rule.min(1).max(100)`). The Supabase `award_xp()` function itself has no cap -- the API route controls the amount.
+**Server-side XP cap**: `xpReward` is capped by the content schema (`MAX_XP_PER_MINT`, `packages/content-schema/src/constants.ts`), and the API routes cap awards independently (max 100 XP per lesson completion, max 2000 per generic award). The Supabase `award_xp()` function does enforce a daily community-XP cap but does not cap the per-call amount — the API route controls it.
 
 ### Adding New Achievements
 
-Adding a new achievement requires changes in three places: Sanity (metadata), TypeScript (unlock logic), and on-chain (deployment via admin panel).
+**Unlock logic is content, not TypeScript.** Since the content-standard cutover,
+each achievement carries a declarative `award` rule, and the app holds one
+predicate **per award kind** — not per achievement. Adding a normal achievement
+therefore requires **no app code change at all**.
 
-#### 1. Create the Achievement in Sanity
+#### 1. Add the achievement doc (in `solanabr/courses-academy`)
 
-Create a new Achievement document in Sanity Studio with:
+Create `achievements/<slug>.yaml`:
 
-- **name** (required): Display name (e.g., "Decathlon")
-- **description**: What the learner did to earn it (e.g., "Complete 10 courses")
-- **icon**: Icon identifier (e.g., `trophy`)
-- **category** (required): One of `progress`, `streaks`, `skills`, `community`, `special`
-- **xpReward** (required): XP awarded on unlock (default: 50)
-- **maxSupply**: Maximum awards (0 = unlimited)
-
-Use the `_id` convention: `achievement-{slug}` (e.g., `achievement-ten-courses`).
-
-#### 2. Add Unlock Logic
-
-Add the check condition to the `UNLOCK_CHECKS` map in `apps/web/src/lib/gamification/achievements.ts`:
-
-```typescript
-const UNLOCK_CHECKS: Record<string, (state: UserState) => boolean> = {
-  // ...existing checks...
-  "ten-courses": (s) => s.completedCourses >= 10,
-};
+```yaml
+id: achievement-ten-courses
+name: Decathlon
+description: Complete 10 courses
+icon: trophy
+glyph: "10"
+category: progress # progress | streaks | skills | community | special
+xpReward: 50
+maxSupply: 0 # 0 = unlimited
+award:
+  kind: lessons-completed
+  gte: 10
 ```
 
-The function receives a `UserState` object with these fields:
+The `id` convention is `achievement-{slug}` and it is validated by
+`packages/content-schema/src/achievement.ts` (Zod). `award` is **required** — an
+achievement with no award rule can never be earned.
+
+Available `award.kind` values:
+
+| `kind`                        | Params          | Unlocks when                                    |
+| ----------------------------- | --------------- | ----------------------------------------------- |
+| `lessons-completed`           | `gte`           | total completed lessons >= `gte`                |
+| `lessons-completed-in-course` | `course`, `gte` | completed lessons in that course >= `gte`       |
+| `course-completed`            | `course`        | that course is fully completed                  |
+| `path-completed`              | `path`          | every course in that learning path is completed |
+| `streak`                      | `days`          | current streak >= `days`                        |
+| `user-number`                 | `lte`           | signup order <= `lte` (early-adopter style)     |
+| `community-stat`              | `stat`, `gte`   | that community stat >= `gte`                    |
+| `manual`                      | —               | never auto-fires; admin-granted only            |
+
+No course or path id is hardcoded in the app — `course` and `path` name real
+content docs and are validated by the linter.
+
+#### 2. Publish it
+
+Merge in `courses-academy`, then bump `apps/web/content.lock` and recompile the
+bundle (see [ADMIN.md](./ADMIN.md)). The achievement now exists in the app.
+
+#### 3. Deploy on-chain
+
+From `/admin/deploy`, deploy the achievement. This creates the AchievementType PDA
+and its Metaplex Core collection, and records `achievement_pda` +
+`collection_address` in the Supabase `onchain_deployments` table.
+
+> **ID convention**: the full content `_id` (e.g. `achievement-first-steps`) is the
+> on-chain PDA seed, used **verbatim**. Never strip the `achievement-` prefix —
+> stripping it derives a different PDA and the award fails silently.
+
+#### When you DO need app code
+
+Only when you need a genuinely new **kind** of condition. Then:
+
+1. Add the variant to the `Award` discriminated union in
+   `packages/content-schema/src/achievement.ts` (and to `AWARD_KINDS`).
+2. Add the matching predicate to `PREDICATES` in
+   `apps/web/src/lib/gamification/achievements.ts`. It is declared
+   `satisfies Record<AwardKind, Predicate>`, so a missing kind is a **compile
+   error** — you cannot forget this step.
+3. If the predicate needs a new signal, add the field to `UserState` and populate
+   it in `buildUserState()`.
+
+The current `UserState`:
 
 ```typescript
 interface UserState {
-  completedLessons: number; // Total lessons completed across all courses
-  completedCourses: number; // Number of fully completed courses
-  currentStreak: number; // Current consecutive-day streak
-  hasCompletedRustLesson: boolean;
-  hasCompletedAnchorCourse: boolean;
-  hasCompletedAllTracks: boolean; // Deferred (always false currently)
-  courseCompletionTimeHours: number | null; // Deferred (always null currently)
-  allTestsPassedFirstTry: boolean; // Deferred (always false currently)
-  userNumber: number; // User's signup order (1 = first user)
+  completedLessons: number;
+  completedLessonsByCourse: Record<string, number>; // courseId → count
+  completedCourseIds: ReadonlySet<string>;
+  completedPathIds: ReadonlySet<string>;
+  currentStreak: number;
+  userNumber: number; // signup order (1 = first user)
+  community: Record<CommunityStat, number>;
 }
 ```
 
-**Deferred signals**: Two fields (`hasCompletedAllTracks`, `allTestsPassedFirstTry`) require cross-course tracking infrastructure that is not yet implemented. Achievements depending on these signals (`full-stack-solana`, `perfect-score`) are currently unearnable.
-
-Achievement IDs in `UNLOCK_CHECKS` must be the **full** Sanity `_id`, including the `achievement-` prefix. For example, Sanity document `achievement-first-steps` maps to key `"achievement-first-steps"` (NOT `"first-steps"`). Stripping the prefix derives the wrong PDA and the award fails silently.
-
-#### 3. Deploy On-Chain
-
-Use the admin panel to deploy the achievement on-chain. This creates an AchievementType PDA and a Metaplex Core collection. The admin panel writes back `achievementPda` and `collectionAddress` to Sanity, setting the status to `"synced"`.
-
-#### Current Achievement Catalog
-
-The 14 built-in achievements and their unlock conditions:
-
-| ID                  | Condition                                      |
-| ------------------- | ---------------------------------------------- |
-| `first-steps`       | Complete 1 lesson                              |
-| `course-completer`  | Complete 1 course                              |
-| `week-warrior`      | 7-day streak                                   |
-| `monthly-master`    | 30-day streak                                  |
-| `consistency-king`  | 100-day streak                                 |
-| `rust-rookie`       | Complete a Rust lesson                         |
-| `anchor-expert`     | Complete an Anchor course                      |
-| `full-stack-solana` | Complete all tracks (deferred)                 |
-| `early-adopter`     | Be among the first 100 users                   |
-| `perfect-score`     | Pass all tests on first try (deferred)         |
-
-Achievements without a `UNLOCK_CHECKS` entry (e.g., `bug-hunter`, `helper`, `first-comment`, `top-contributor`) are admin-granted and not automatically checked.
+> `perfect-score` was **dropped**, not deferred: block results are transient by
+> design, so there is no durable "passed on first try" signal to key it on.
 
 ### Adding New Streak Milestones
 
@@ -514,7 +533,9 @@ export const STREAK_MILESTONES = [
 ] as const;
 ```
 
-Then add a corresponding achievement definition in Sanity and an `UNLOCK_CHECKS` entry for the new milestone.
+Then add a matching achievement doc in `courses-academy` with
+`award: { kind: streak, days: 365 }`. No predicate change is needed — `streak` is
+already a supported kind.
 
 ### Streak Logic
 
@@ -585,83 +606,69 @@ Gamification popups use a custom event bus pattern. Components dispatch browser 
 2. Add the component to `GamificationOverlays`
 3. Call the dispatch function from the relevant API response handler or client action
 
-## Creating New Course Types
+## Adding a New Lesson Block Type
 
-The current lesson types are `content` and `challenge`, defined as a discriminated union in `packages/types/src/course.ts`. To add a new type:
+A lesson is **not** typed `content` vs `challenge` any more. A lesson is an ordered
+`blocks[]` array — a page builder. Adding a new capability means adding a new
+**block type**, not a new lesson type.
 
-### 1. Update the Sanity Schema
+The current block types (`packages/content-schema/src/blocks/`):
 
-In `sanity/schemas/lesson.ts`, add the new type to the options list:
+| `type`                  | Graded  | Required | Purpose                                   |
+| ----------------------- | ------- | -------- | ----------------------------------------- |
+| `prose`                 | no      | no       | Markdown body                             |
+| `video`                 | no      | no       | Embedded video                            |
+| `code`                  | **yes** | **yes**  | Monaco challenge (starter/solution/tests) |
+| `quiz`                  | **yes** | **yes**  | Multiple-choice questions                 |
+| `openEnded`             | no      | **yes**  | Free-text reflection prompt               |
+| `wallet-funding`        | no      | no       | Devnet airdrop widget                     |
+| `program-explorer`      | no      | no       | IDL-driven program explorer               |
+| `deployed-program-card` | no      | no       | Shows the learner's deployed program      |
 
-```typescript
-defineField({
-  name: "type",
-  title: "Lesson Type",
-  type: "string",
-  options: {
-    list: [
-      { title: "Content", value: "content" },
-      { title: "Challenge", value: "challenge" },
-      { title: "Quiz", value: "quiz" },  // new
-    ],
-    layout: "radio",
-  },
-}),
-```
+### 1. Define the schema
 
-### 2. Add Type-Specific Fields
+Add the Zod schema in `packages/content-schema/src/blocks/<name>.ts` and register
+it in the `Block` discriminated union in `blocks/index.ts`.
 
-Add fields that are conditionally shown based on the new type:
+### 2. Register it
 
-```typescript
-defineField({
-  name: "questions",
-  title: "Quiz Questions",
-  type: "array",
-  hidden: ({ parent }) => parent?.type !== "quiz",
-  of: [
-    {
-      type: "object",
-      fields: [
-        defineField({ name: "question", type: "string" }),
-        defineField({ name: "options", type: "array", of: [{ type: "string" }] }),
-        defineField({ name: "correctIndex", type: "number" }),
-      ],
-    },
-  ],
-}),
-```
-
-### 3. Update TypeScript Types
-
-In `packages/types/src/course.ts`, add a new variant to the discriminated union. The existing types use a `LessonBase` interface with `ContentLesson` and `ChallengeLesson` extending it:
+Add an entry to `BLOCK_REGISTRY` in the same file:
 
 ```typescript
-export interface QuizLesson extends LessonBase {
-  type: "quiz";
-  content: string;
-  questions: QuizQuestion[];
-}
-
-export interface QuizQuestion {
-  question: string;
-  options: string[];
-  correctIndex: number;
-}
-
-export type Lesson = ContentLesson | ChallengeLesson | QuizLesson;
+export const BLOCK_REGISTRY = {
+  // ...existing...
+  myBlock: { graded: false, required: true },
+} satisfies Record<BlockType, BlockMeta>;
 ```
 
-### 4. Create the UI Component
+`satisfies Record<BlockType, BlockMeta>` makes an unregistered block type a
+**compile error**. This is the fail-closed seam: the lesson-completion gate
+dispatches on this registry, and a block type with no registered grader is
+**DENIED** — an unknown type can never silently pass a lesson.
 
-Build a component to render the new lesson type in `apps/web/src/components/course/` or `apps/web/src/components/editor/`.
+- `graded: true` → the block returns pass/fail, and failing it blocks lesson completion.
+- `required: true` → the learner must interact with it before the lesson can complete.
 
-### 5. Update the Lesson Page
+### 3. Add the projected type
 
-In the lesson page component, add rendering logic for the new type:
+Add the matching variant to the `LessonBlock` union in
+`packages/types/src/course.ts` (discriminated on `_type`), and project it in
+`apps/web/src/lib/content/project.ts`.
 
-```typescript
-if (lesson.type === "quiz") {
-  return <QuizInterface lesson={lesson} />;
-}
-```
+### 4. Create the renderer
+
+Add the component and register it in the lesson page's block renderer registry —
+which keys on the same `_type` string as the schema and `BLOCK_REGISTRY`.
+
+### 5. Grade it (if `graded: true`)
+
+Add the grader to the grader map. All three maps — renderer, grader, and
+`BLOCK_REGISTRY` — key on the same discriminant, so a missing one is caught at
+compile time or fails closed at runtime.
+
+### 6. Lint + publish
+
+The content linter (`packages/content-lint`) validates every block in
+`courses-academy` CI. Once your block ships in a released version of the schema,
+content authors can use it; the change reaches the app via a `content.lock` bump
+(see [ADMIN.md](./ADMIN.md)).

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,8 +1,12 @@
-> Last synced: 2026-03-02
+> Last synced: 2026-07-12
 
 # Deployment Guide
 
-Production deployment guide for Superteam Academy on Vercel + Supabase + Sanity + GCP.
+Production deployment guide for Superteam Academy on Vercel + Supabase + GCP.
+
+There is **no CMS to deploy**. Course content ships as a committed bundle
+compiled from the `solanabr/courses-academy` git repo — see
+[Content Bundle](#content-bundle).
 
 ---
 
@@ -10,7 +14,7 @@ Production deployment guide for Superteam Academy on Vercel + Supabase + Sanity 
 
 1. [Vercel Deployment (Web App)](#vercel-deployment)
 2. [Supabase Setup](#supabase-setup)
-3. [Sanity CMS Setup](#sanity-cms-setup)
+3. [Content Bundle](#content-bundle)
 4. [Google OAuth Setup](#google-oauth-setup)
 5. [Solana Devnet Setup (XP Mint)](#solana-devnet-setup)
 6. [Build Server (GCP Cloud Run)](#build-server-gcp-cloud-run)
@@ -49,42 +53,51 @@ Add all environment variables in **Vercel → Project → Settings → Environme
 
 #### Required Variables
 
-| Variable                        | Type            | Notes                                                                                                                 |
-| ------------------------------- | --------------- | --------------------------------------------------------------------------------------------------------------------- |
-| `NEXT_PUBLIC_SUPABASE_URL`      | Public          | Bundled into client JS                                                                                                |
-| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Public          | Bundled into client JS                                                                                                |
-| `SUPABASE_SERVICE_ROLE_KEY`     | **Server-only** | Never exposed to browser                                                                                              |
-| `NEXT_PUBLIC_SANITY_PROJECT_ID` | Public          | Bundled into client JS                                                                                                |
-| `NEXT_PUBLIC_SANITY_DATASET`    | Public          | Usually `production`                                                                                                  |
-| `NEXT_PUBLIC_SOLANA_RPC_URL`    | Public          | `https://api.devnet.solana.com`                                                                                       |
-| `NEXT_PUBLIC_SOLANA_NETWORK`    | Public          | `devnet`                                                                                                              |
-| `NEXT_PUBLIC_APP_URL`           | Public          | Your Vercel URL (e.g., `https://superteam-academy-web.vercel.app`)                                                    |
-| `NEXT_PUBLIC_PROGRAM_ID`        | Public          | Program ID from `anchor deploy` (see [DEPLOY-PROGRAM.md](./DEPLOY-PROGRAM.md))                                        |
-| `NEXT_PUBLIC_XP_MINT_ADDRESS`   | Public          | XP mint pubkey from `initialize.ts` output                                                                            |
-| `BUILD_SERVER_URL`              | **Server-only** | Cloud Run service URL (e.g., `https://academy-build-server-HASH.a.run.app`)                                           |
-| `BUILD_SERVER_API_KEY`          | **Server-only** | Same value as `ACADEMY_API_KEY` on Cloud Run                                                                          |
-| `HELIUS_API_KEY`                | **Server-only** | Helius key for webhook management + DAS API (`lib/helius`)                                                            |
-| `PROGRAM_AUTHORITY_SECRET`      | **Server-only** | Base58 private key of the Config PDA authority — required for admin panel on-chain deployments                        |
-| `BACKEND_SIGNER_SECRET`         | **Server-only** | Base58 private key of the backend signer registered in `Config.backend_signer` — signs lesson completion transactions |
-| `ADMIN_SECRET`                  | **Server-only** | Admin panel password (min 32 chars). Required to access `/{locale}/admin`                                             |
-| `SANITY_ADMIN_TOKEN`            | **Server-only** | Sanity write token — required to update `onChainStatus` in Sanity after on-chain deployment                           |
-| `HELIUS_WEBHOOK_SECRET`         | **Server-only** | Shared secret for Helius webhook signature verification (`/api/webhooks/helius`)                                      |
-| `XP_MINT_AUTHORITY_SECRET`      | **Server-only** | Base58 private key of the XP mint authority — required for wallet link/unlink XP transfers                            |
+Validated eagerly at boot (`lib/env.ts` for public, `lib/env.server.ts` for
+server-only, both wired through `instrumentation.ts`). A missing **required** var
+fails the boot loudly rather than degrading silently.
+
+| Variable                        | Type            | Notes                                                                                                                                                                                                                                                            |
+| ------------------------------- | --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `NEXT_PUBLIC_SUPABASE_URL`      | Public          | Bundled into client JS                                                                                                                                                                                                                                           |
+| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Public          | Bundled into client JS                                                                                                                                                                                                                                           |
+| `SUPABASE_SERVICE_ROLE_KEY`     | **Server-only** | Never exposed to browser                                                                                                                                                                                                                                         |
+| `NEXT_PUBLIC_SOLANA_RPC_URL`    | Public          | Browser RPC. Must carry **no** privileged key (e.g. `https://api.devnet.solana.com`)                                                                                                                                                                             |
+| `SOLANA_RPC_URL`                | **Server-only** | Server RPC — **this** is the one that may carry the Helius key. Required at boot so a misconfig fails loudly instead of falling back to public devnet                                                                                                            |
+| `NEXT_PUBLIC_SOLANA_NETWORK`    | Public          | `devnet`                                                                                                                                                                                                                                                         |
+| `NEXT_PUBLIC_APP_URL`           | Public          | Your Vercel URL (e.g., `https://superteam-academy-web.vercel.app`)                                                                                                                                                                                               |
+| `NEXT_PUBLIC_PROGRAM_ID`        | Public          | Program ID from `anchor deploy` (see [DEPLOY-PROGRAM.md](./DEPLOY-PROGRAM.md))                                                                                                                                                                                   |
+| `NEXT_PUBLIC_XP_MINT_ADDRESS`   | Public          | XP mint pubkey from the `initialize` output                                                                                                                                                                                                                      |
+| `BUILD_SERVER_URL`              | **Server-only** | Cloud Run service URL (e.g., `https://academy-build-server-HASH.a.run.app`)                                                                                                                                                                                      |
+| `BUILD_SERVER_API_KEY`          | **Server-only** | Same value as `ACADEMY_API_KEY` on Cloud Run                                                                                                                                                                                                                     |
+| `HELIUS_API_KEY`                | **Server-only** | Helius key for webhook management + DAS API (`lib/helius`)                                                                                                                                                                                                       |
+| `PROGRAM_AUTHORITY_SECRET`      | **Server-only** | The `Config.authority` keypair (JSON array of 64 bytes) — required for admin on-chain deployments                                                                                                                                                                |
+| `BACKEND_SIGNER_SECRET`         | **Server-only** | The keypair registered in `Config.backend_signer` — signs lesson completion / finalize / credential transactions                                                                                                                                                 |
+| `ADMIN_SECRET`                  | **Server-only** | Admin console password **and** the HMAC key signing the `admin_session` cookie (min 32 chars). Required to access `/{locale}/admin`                                                                                                                              |
+| `HELIUS_WEBHOOK_SECRET`         | **Server-only** | Shared secret for Helius webhook signature verification (`/api/webhooks/helius`)                                                                                                                                                                                 |
+| `XP_MINT_AUTHORITY_SECRET`      | **Server-only** | XP mint authority keypair — required for the wallet link/unlink XP transfers                                                                                                                                                                                     |
+| `GITHUB_TOKEN`                  | **Server-only** | Fine-grained **read** token for `solanabr/courses-academy`. Powers the admin **Publish** screen (HEAD polling + CI checks). Optional at boot, but the admin content routes 503 without it. **Read scope only — no route in the app holds a GitHub write token.** |
 
 #### Optional Variables
 
-| Variable                         | Type            | Notes                                                                                                                                                                                                                                                                                                                                                                                             |
-| -------------------------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `RUST_PLAYGROUND_URL`            | **Server-only** | `/api/rust/execute` upstream (default: play.rust-lang.org)                                                                                                                                                                                                                                                                                                                                        |
-| `GITHUB_TOKEN`                   | **Server-only** | Fine-grained **read** token for `solanabr/courses-academy` (the repo is public, but the token is still required for rate limits). Powers `POST /api/admin/content/sync` (tarball fetch), the drift UI (HEAD polling), and the Checks API (`blocked` state). Unauthenticated GitHub is 60 req/hr per IP and flakes on Vercel's shared egress; unset → the `/api/admin/content/*` routes return 503 |
-| `NEXT_PUBLIC_GA4_MEASUREMENT_ID` | Public          | Google Analytics 4                                                                                                                                                                                                                                                                                                                                                                                |
-| `NEXT_PUBLIC_POSTHOG_KEY`        | Public          | PostHog project key                                                                                                                                                                                                                                                                                                                                                                               |
-| `NEXT_PUBLIC_POSTHOG_HOST`       | Public          | PostHog instance URL                                                                                                                                                                                                                                                                                                                                                                              |
-| `NEXT_PUBLIC_SENTRY_DSN`         | Public          | Sentry error tracking (DSN is safe to expose)                                                                                                                                                                                                                                                                                                                                                     |
+| Variable                         | Type            | Notes                                                                                                                                                                                                                                                                |
+| -------------------------------- | --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `GEMINI_API_KEY`                 | **Server-only** | Gemini key for the AI lesson assistant (`/api/ai/*`). Omit to disable the assistant.                                                                                                                                                                                 |
+| `AI_PARTNER_SEAL_SECRET`         | **Server-only** | Dedicated key for sealing the comprehension-check token. If unset, derived from `SUPABASE_SERVICE_ROLE_KEY`.                                                                                                                                                         |
+| `ARWEAVE_UPLOADER_SECRET`        | **Server-only** | Funds Irys uploads that pin credential metadata to Arweave at mint. A **Solana** keypair (JSON array of 64 bytes), not an Arweave JWK. Unset → mint falls back to `/api/certificates/metadata`. Required (funded on mainnet-beta) for permanent mainnet credentials. |
+| `MODERATION_WEBHOOK_URL`         | **Server-only** | Slack/Discord-compatible incoming webhook. When set, the first flag on a community post pings it. Unset → no notification (the `/admin/moderation` queue still fills).                                                                                               |
+| `RUST_PLAYGROUND_URL`            | **Server-only** | `/api/rust/execute` upstream (default: play.rust-lang.org)                                                                                                                                                                                                           |
+| `NEXT_PUBLIC_GA4_MEASUREMENT_ID` | Public          | Google Analytics 4                                                                                                                                                                                                                                                   |
+| `NEXT_PUBLIC_POSTHOG_KEY`        | Public          | PostHog project key                                                                                                                                                                                                                                                  |
+| `NEXT_PUBLIC_POSTHOG_HOST`       | Public          | PostHog instance URL                                                                                                                                                                                                                                                 |
+| `NEXT_PUBLIC_SENTRY_DSN`         | Public          | Sentry error tracking (DSN is safe to expose)                                                                                                                                                                                                                        |
 
 > **Tip**: Variables prefixed with `NEXT_PUBLIC_` are bundled into the client-side JavaScript bundle. All others are server-only and only accessible in API routes and server components.
 
-> **Content sync (CS-9) secrets**: The Sanity dataset is **public** (read path uses no browser token). `SANITY_ADMIN_TOKEN` is held only by the content-sync job and `admin-mutations.ts` — it never belongs in GitHub Actions. `GITHUB_TOKEN` is a read-only token for the `courses-academy` repo, used server-side by the content-sync + drift routes; it carries no write scope.
+> **No content-write secret exists.** The app cannot mutate course content at
+> runtime under any credential. Content is a committed bundle; publishing is a
+> pull request (see [Content Bundle](#content-bundle)). `GITHUB_TOKEN` is
+> read-only and is used solely to poll `courses-academy` HEAD and its CI state.
 
 ### 4. Deploy
 
@@ -102,6 +115,9 @@ Subsequent pushes to `main` trigger automatic deployments. Pull requests get pre
 
 ### 1. Create Project & Apply Migrations
 
+> **Production project**: `pywhtmidcrptomrabbrw`. The previously used project is
+> **retired** — do not point a new deploy at it.
+
 1. Create a new project at [supabase.com/dashboard](https://supabase.com/dashboard)
 2. Install the [Supabase CLI](https://supabase.com/docs/guides/cli) and link the project:
    ```bash
@@ -111,33 +127,46 @@ Subsequent pushes to `main` trigger automatic deployments. Pull requests get pre
    ```bash
    supabase db push
    ```
-   This runs every file in `supabase/migrations/` in order, creating all 19 tables, RLS policies, indexes, SECURITY DEFINER functions, and views.
+   This runs every file in `supabase/migrations/` in order, creating all 21 tables, RLS policies, indexes, SECURITY DEFINER functions, and views.
 
 > **Migrations are the source of truth.** `supabase/schema.sql` is a generated snapshot (via `supabase db dump`) kept for reference and diffing — do **not** run or hand-edit it. Ship schema changes as new migrations: `supabase migration new <name>`, then `supabase db push`.
 
 The schema includes:
 
-| Table                     | Purpose                         |
-| ------------------------- | ------------------------------- |
-| `profiles`                | User profiles (wallet, email)   |
-| `enrollments`             | Course enrollments              |
-| `user_progress`           | Lesson completion tracking      |
-| `user_xp`                 | Total XP per user               |
-| `xp_transactions`         | XP change log                   |
-| `user_achievements`       | Unlocked achievements           |
-| `certificates`            | NFT certificate records         |
-| `siws_nonces`             | SIWS replay protection          |
-| `nft_metadata`            | NFT metadata storage            |
-| `deployed_programs`       | Student program deployments     |
-| `pending_onchain_actions` | On-chain retry queue            |
-| `user_daily_quests`       | Daily quest progress tracking   |
-| `forum_categories`        | Community forum sections        |
-| `threads`                 | Community discussion threads    |
-| `answers`                 | Thread replies                  |
-| `votes`                   | Upvotes/downvotes               |
-| `flags`                   | Content moderation flags        |
-| `thread_views`            | Per-user thread view dedup      |
-| `rate_limits`             | Cross-instance API rate limiter |
+| Table                     | Purpose                                                          |
+| ------------------------- | ---------------------------------------------------------------- |
+| `profiles`                | User profiles (wallet, email)                                    |
+| `enrollments`             | Course enrollments                                               |
+| `user_progress`           | Lesson completion tracking                                       |
+| `user_xp`                 | Total XP per user                                                |
+| `xp_transactions`         | XP change log                                                    |
+| `user_achievements`       | Unlocked achievements                                            |
+| `certificates`            | NFT certificate records                                          |
+| `siws_nonces`             | SIWS replay protection                                           |
+| `nft_metadata`            | NFT metadata storage                                             |
+| `deployed_programs`       | **Learner** practice program deployments                         |
+| `onchain_deployments`     | **Platform** content → chain state (the learner-visibility gate) |
+| `pending_onchain_actions` | On-chain retry queue                                             |
+| `user_daily_quests`       | Daily quest progress tracking                                    |
+| `challenge_assists`       | Per-user AI-assist budget for challenges                         |
+| `forum_categories`        | Community forum sections                                         |
+| `threads`                 | Community discussion threads                                     |
+| `answers`                 | Thread replies                                                   |
+| `votes`                   | Upvotes/downvotes                                                |
+| `flags`                   | Content moderation flags                                         |
+| `thread_views`            | Per-user thread view dedup                                       |
+| `rate_limits`             | Cross-instance API rate limiter                                  |
+
+Plus three views: `community_stats`, `public_user_xp`, and
+`public_onchain_deployments`.
+
+> **`onchain_deployments` is load-bearing for content visibility.** It is the
+> post-SP2 home of the on-chain sync status that gates which courses learners can
+> see (`status == "synced" AND coalesce(is_active, true)`). A fresh project starts
+> with zero rows, so **no courses are visible until you deploy them from
+> `/admin/deploy`** — see [ADMIN.md](./ADMIN.md). The base table is service_role
+> only (RLS on, no policies); anon/authenticated read the narrow
+> `public_onchain_deployments` view.
 
 ### 2. Auth Redirect URLs
 
@@ -175,45 +204,80 @@ Supabase automatically creates daily backups on paid plans. On the free tier:
 
 ---
 
-## Sanity CMS Setup
+## Content Bundle
 
-### 1. Create Project
+**There is nothing to provision here.** Course content is not fetched at runtime
+from any hosted service — it is compiled ahead of time and **committed to this
+repo**, so a deploy is entirely self-contained.
 
-1. Go to [sanity.io/manage](https://sanity.io/manage)
-2. Create a new project
-3. Note the **Project ID** → `NEXT_PUBLIC_SANITY_PROJECT_ID`
-4. Use dataset `production` → `NEXT_PUBLIC_SANITY_DATASET`
+### How it works
 
-### 2. CORS Origins
-
-1. Navigate to **API** → **CORS Origins**
-2. Add your production domain: `https://superteam-academy-web.vercel.app`
-3. Check **Allow credentials**
-4. Also add `http://localhost:3000` for local development
-
-### 3. API Token (for Seed Import Only)
-
-1. Go to **API** → **Tokens**
-2. Create a token with **Editor** permissions
-3. Set as `SANITY_API_TOKEN` (only needed for the seed script, not the running app)
-
-### 4. Import Seed Data
-
-```bash
-cd sanity
-SANITY_API_TOKEN=<your-token> node seed/import.mjs
+```
+solanabr/courses-academy   ← git repo, the single source of truth for content
+        │
+        │  pinned to ONE commit by apps/web/content.lock
+        ▼
+apps/web/scripts/compile-content.ts
+        │   fetch tarball @ locked SHA → Zod-validate every doc (fail-closed)
+        │   → project → emit deterministic JSON
+        ▼
+apps/web/src/content/generated/*.json   ← COMMITTED
+apps/web/public/content-assets/*        ← COMMITTED
 ```
 
-This populates courses, modules, lessons, and instructor data.
+`apps/web/content.lock` is the pin:
 
-### 5. Deploy Sanity Studio (Optional)
+```json
+{
+  "repo": "solanabr/courses-academy",
+  "sha": "<40-char commit sha>"
+}
+```
 
-The Sanity Studio in `sanity/` can be deployed separately for content editing:
+At build time the app statically imports the generated JSON (`lib/content/store.ts`,
+`server-only`). Vercel needs **no** content credentials, and a content-repo
+outage cannot take the site down.
+
+### Regenerating the bundle
 
 ```bash
-cd sanity
-npx sanity deploy
+pnpm --filter web compile-content     # from the repo root
 ```
+
+`GITHUB_TOKEN` is optional here — it only raises the GitHub rate limit when
+fetching the tarball.
+
+### CI enforces freshness
+
+The compiler's output is a **pure function of the locked SHA** (sorted keys, no
+wall-clock timestamps, assets kept as repo-relative paths). The
+`Content bundle freshness` step in `.github/workflows/ci.yml` recompiles the
+bundle and fails if the result differs by a single byte from what is committed.
+
+This catches both failure modes:
+
+- a `content.lock` bump without a recompile (stale bundle), and
+- a hand-edit of `src/content/generated/*`.
+
+> Never hand-edit the generated bundle. An ESLint rule also bans importing it
+> outside `src/lib/content/`.
+
+### Publishing new content
+
+Publishing is a **pull request**, not a deploy step and not a button:
+
+1. Merge the content change into `solanabr/courses-academy` (its own CI gates it).
+2. In this repo: bump `"sha"` in `apps/web/content.lock`.
+3. Run `pnpm --filter web compile-content`.
+4. Commit `content.lock` **and** the regenerated bundle together.
+5. Merge → Vercel redeploys with the new content.
+
+The `/admin/publish` screen shows the pin-vs-HEAD drift and hands you a prefilled
+PR link. It holds **no write token** and performs no repo write. See
+[ADMIN.md](./ADMIN.md).
+
+> New courses are still **invisible to learners** until they are deployed on-chain
+> from `/admin/deploy` — compiling the bundle is necessary but not sufficient.
 
 ---
 
@@ -455,7 +519,6 @@ When changing domains, update all of these:
 
 - **Supabase**: Update **Site URL** and **Redirect URLs** in Authentication settings
 - **Google OAuth**: Add new domain to authorized redirect URIs in [Google Cloud Console](https://console.cloud.google.com/apis/credentials)
-- **Sanity**: Add new domain to CORS origins
 - **Build Server**: Update `ALLOWED_ORIGIN` env var in Cloud Run
 
 ---
@@ -465,7 +528,8 @@ When changing domains, update all of these:
 After deploying, verify:
 
 - [ ] Landing page loads without errors
-- [ ] Courses display correctly (fetched from Sanity)
+- [ ] Courses display correctly (served from the committed bundle; a course only
+      appears once its `onchain_deployments` row is `synced` + active)
 - [ ] Wallet connect works (Phantom, Solflare, Backpack)
 - [ ] Google OAuth works (if configured)
 - [ ] Completing a lesson awards XP
@@ -488,10 +552,15 @@ After deploying, verify:
 - Dynamic pages (course detail, lessons) are server-rendered on demand
 - The middleware handles locale detection and auth checks at the edge
 
-### Sanity
+### Content
 
-- GROQ queries use CDN caching by default
-- Image assets are served through Sanity's image CDN with automatic optimization
+- The content bundle is statically imported at build time — **zero** network hops
+  and zero cache misses on the read path
+- Course assets are served from `public/content-assets/` by Vercel's CDN
+- The only per-request content dependency is the on-chain deployment status map
+  (Supabase), which is wrapped in `unstable_cache` (tag `courses`, 3600s) with a
+  cookieless anon client so catalog and lesson routes stay static/ISR. An admin
+  course sync purges the tag via `revalidateTag`.
 
 ### Next.js
 
@@ -536,7 +605,6 @@ gcloud run services update-traffic academy-build-server \
 | ------------- | ------------------------------------------- | ------------------------- |
 | Vercel        | 100GB bandwidth, 100 deploys/day            | High traffic              |
 | Supabase      | 500MB database, 50K auth users, 2GB storage | >500MB data or >50K users |
-| Sanity        | 100K API requests/month, 10GB bandwidth     | High content volume       |
 | Solana Devnet | Free, rate-limited                          | Moving to mainnet         |
 | Cloud Run     | 2M requests/month, 360K vCPU-sec free       | High build volume         |
 | Artifact Reg. | 500MB storage free                          | Many image versions       |

--- a/docs/SECRET-ROTATION.md
+++ b/docs/SECRET-ROTATION.md
@@ -45,22 +45,54 @@ stored outside the repo**.
 
 ## Secret inventory & rotation
 
+> **How this inventory was derived** — re-run this before trusting it. An omission
+> here is a secret nobody rotates, so the list is derived from the code, not from
+> the previous version of this doc:
+>
+> 1. `apps/web/src/lib/env.ts` — the validated **public** schema (4 vars).
+> 2. `apps/web/src/lib/env.server.ts` — the validated **server** schema (11 vars).
+> 3. `apps/web/next.config.mjs` — build-time reads the schemas don't cover
+>    (`SENTRY_ORG`, `SENTRY_PROJECT`, `SENTRY_AUTH_TOKEN`).
+> 4. `turbo.json` `env` — build-cache keys (catches build-time vars).
+> 5. `.env.example` — the documented surface.
+> 6. Backstop, catches anything the above miss:
+>    ```bash
+>    grep -rhoE "process\.env\.[A-Z_0-9]+" apps/web/src apps/web/next.config.mjs \
+>      | sed 's/.*process\.env\.//' | sort -u
+>    ```
+>
+> Vars 3 and 6 are the ones that bite: a var read directly via `process.env` is
+> **not** in either Zod schema, so schema-only derivation silently misses it. That
+> is how `SENTRY_AUTH_TOKEN` was missed once already.
+>
+> **Union as of 2026-07-12: 30 real variables.** Anything in an env store that is
+> not below is **dead** — delete it, don't rotate it.
+
 ### Critical — server-only (rotate before mainnet; leak = high blast radius)
 
-| Secret                      | Purpose                                          | Blast radius if leaked                                                    | How to rotate                                                          |
-| --------------------------- | ------------------------------------------------ | ------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
-| `SUPABASE_SERVICE_ROLE_KEY` | Bypasses RLS; all privileged DB writes           | Full DB read/write; forge any user's XP/progress/certs                    | New prod project (pref.) or Supabase → rotate `service_role` JWT       |
-| `BACKEND_SIGNER_SECRET`     | Keypair signing on-chain mint / credential ix    | Mint arbitrary XP + credentials to any wallet                             | New keypair → `update_config` sets `Config.backend_signer` (**#118**)  |
-| `PROGRAM_AUTHORITY_SECRET`  | Program upgrade + config authority               | Upgrade program, rewrite config, seize authority powers                   | Move to **Squads multisig** at mainnet (**#144**); retire the hot JSON |
-| `ADMIN_SECRET`              | HMAC-signs the `admin_session` cookie            | Admin panel: course/achievement sync, resync, deactivate                  | Generate new 32-byte random → update env; invalidates live sessions    |
-| `HELIUS_WEBHOOK_SECRET`     | Verifies Helius webhook signatures               | Forge on-chain events → fake enroll / XP / credential grants              | Rotate in Helius webhook config **and** env together                   |
-| `BUILD_SERVER_API_KEY`      | Authenticates `/build` calls to the build server | Submit arbitrary Anchor builds to the compile sandbox                     | Rotate on the build server + env                                       |
-| `XP_MINT_AUTHORITY_SECRET`  | XP mint authority (wallet link/unlink XP moves)  | Mint/burn XP tokens directly                                              | New keypair; must match the mint's authority on-chain                  |
-| `HELIUS_API_KEY`            | Helius DAS API + webhook management (server)     | Quota abuse, cost; read of on-chain indexes                               | Helius dashboard → rotate                                              |
-| `ARWEAVE_UPLOADER_SECRET`   | Funds Irys uploads pinning credential metadata   | Drains the funded upload wallet                                           | New Solana keypair; re-fund; old one keeps only residual balance       |
-| `AI_PARTNER_SEAL_SECRET`    | Seals the comprehension-check token              | Forge comprehension-check passes                                          | New random value (falls back to `SUPABASE_SERVICE_ROLE_KEY` if unset)  |
-| `GEMINI_API_KEY`            | AI tutor / challenge suggest                     | Quota abuse, cost                                                         | Google AI Studio → rotate                                              |
-| `GITHUB_TOKEN`              | **Read-only** poll of `courses-academy` HEAD/CI  | **Low** — read-only, and the repo is public. Worst case: rate-limit abuse | GitHub → revoke, issue a new fine-grained read token                   |
+| Secret                       | Purpose                                                        | Blast radius if leaked                                                                                                                              | How to rotate                                                                          |
+| ---------------------------- | -------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| `SUPABASE_SERVICE_ROLE_KEY`  | Bypasses RLS; all privileged DB writes                         | Full DB read/write; forge any user's XP/progress/certs                                                                                              | New prod project (pref.) or Supabase → rotate `service_role` JWT                       |
+| `BACKEND_SIGNER_SECRET`      | Keypair signing on-chain mint / credential ix                  | Mint arbitrary XP + credentials to any wallet                                                                                                       | New keypair → `update_config` sets `Config.backend_signer` (**#118**)                  |
+| `PROGRAM_AUTHORITY_SECRET`   | Program upgrade + config authority                             | Upgrade program, rewrite config, seize authority powers                                                                                             | Move to **Squads multisig** at mainnet (**#144**); retire the hot JSON                 |
+| `XP_MINT_AUTHORITY_SECRET`   | XP mint authority (wallet link/unlink XP moves)                | Mint/burn XP tokens directly                                                                                                                        | New keypair; must match the mint's authority on-chain                                  |
+| `ARWEAVE_UPLOADER_SECRET`    | Funds Irys uploads pinning credential metadata                 | Drains the funded upload wallet                                                                                                                     | New Solana keypair; re-fund; old one keeps only residual balance                       |
+| `ADMIN_SECRET`               | HMAC-signs the `admin_session` cookie                          | Admin console: deploy/deactivate content, resync, moderate                                                                                          | Generate new 32-byte random → update env; invalidates live sessions                    |
+| `HELIUS_WEBHOOK_SECRET`      | Verifies Helius webhook signatures                             | Forge on-chain events → fake enroll / XP / credential grants                                                                                        | Rotate in Helius webhook config **and** env together                                   |
+| `HELIUS_API_KEY`             | Helius DAS API + webhook management (server)                   | Quota abuse, cost; read of on-chain indexes                                                                                                         | Helius dashboard → rotate                                                              |
+| **`SOLANA_RPC_URL`**         | **Server** RPC endpoint — **embeds the Helius key in prod**    | Same as `HELIUS_API_KEY`: the key is _in the URL_. Quota abuse + cost.                                                                              | **Rotate WITH `HELIUS_API_KEY` — they are one secret in two places.**                  |
+| `BUILD_SERVER_API_KEY`       | Authenticates `/build` calls to the build server               | Submit arbitrary Anchor builds to the compile sandbox                                                                                               | Rotate on the build server + env                                                       |
+| `GEMINI_API_KEY`             | AI lesson assistant (`/api/ai/*`)                              | Quota abuse, cost                                                                                                                                   | Google AI Studio → rotate                                                              |
+| `AI_PARTNER_SEAL_SECRET`     | Seals the comprehension-check token                            | Forge comprehension-check passes                                                                                                                    | New random value (falls back to `SUPABASE_SERVICE_ROLE_KEY` if unset)                  |
+| **`MODERATION_WEBHOOK_URL`** | Slack/Discord incoming webhook — first flag on a post pings it | **The URL _is_ the credential.** Anyone holding it can post arbitrary messages into the admin channel (phishing/social-engineering the moderators). | Delete the incoming webhook in Slack/Discord → create a new one → update env           |
+| **`SENTRY_AUTH_TOKEN`**      | Build-time source-map upload (`next.config.mjs:171`)           | Write to the Sentry org: upload/alter releases + source maps, read project data                                                                     | Sentry → revoke the token, issue a new one. **CI/Vercel only** — not needed at runtime |
+| `GITHUB_TOKEN`               | **Read-only** poll of `courses-academy` HEAD/CI                | **Low** — read-only, and the repo is public. Worst case: rate-limit abuse                                                                           | GitHub → revoke, issue a new fine-grained read token                                   |
+
+> **`SOLANA_RPC_URL` is secret-bearing, not config.** `env.server.ts` says it plainly:
+> "this is the one that may carry a privileged Helius API key". Treating it as
+> config is how a Helius key leaks into a screenshot. Its **public** sibling
+> `NEXT_PUBLIC_SOLANA_RPC_URL` must carry **no** key — it is inlined into the
+> browser bundle.
 
 > **There is no content-write secret.** The app cannot mutate course content at
 > runtime under any credential — content is a committed bundle and publishing is a
@@ -69,18 +101,32 @@ stored outside the repo**.
 
 ### Semi-sensitive (client-exposed, but abuse/quota risk)
 
-| Secret                          | Purpose                 | Note                                                                                                   |
-| ------------------------------- | ----------------------- | ------------------------------------------------------------------------------------------------------ |
-| `NEXT_PUBLIC_SOLANA_RPC_URL`    | Browser RPC endpoint    | Must carry **no** privileged key. The Helius-keyed endpoint belongs in `SOLANA_RPC_URL` (server-only). |
-| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Browser Supabase client | RLS-gated (not a secret), but changes with the new prod project                                        |
-| `NEXT_PUBLIC_SENTRY_DSN`        | Error reporting         | Safe to expose; rotate only on abuse                                                                   |
+| Secret                          | Purpose                 | Note                                                                                                                         |
+| ------------------------------- | ----------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `NEXT_PUBLIC_SOLANA_RPC_URL`    | Browser RPC endpoint    | **Must carry no privileged key** — it is inlined into the client bundle. The Helius-keyed endpoint goes in `SOLANA_RPC_URL`. |
+| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Browser Supabase client | RLS-gated (not a secret), but changes with the new prod project                                                              |
+| `NEXT_PUBLIC_SENTRY_DSN`        | Error reporting         | Safe to expose by design; rotate only on abuse                                                                               |
 
 ### Config — not secret (change only when the underlying resource changes)
 
 `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_PROGRAM_ID`, `NEXT_PUBLIC_XP_MINT_ADDRESS`,
-`NEXT_PUBLIC_SOLANA_RPC_URL` / `SOLANA_RPC_URL`, `NEXT_PUBLIC_SOLANA_NETWORK`,
-`NEXT_PUBLIC_APP_URL`, `NEXT_PUBLIC_GA4_MEASUREMENT_ID`,
-`NEXT_PUBLIC_POSTHOG_KEY` / `_HOST`.
+`NEXT_PUBLIC_SOLANA_NETWORK`, `NEXT_PUBLIC_APP_URL`, `NEXT_PUBLIC_GA4_MEASUREMENT_ID`,
+`NEXT_PUBLIC_POSTHOG_KEY`, `NEXT_PUBLIC_POSTHOG_HOST`, `BUILD_SERVER_URL`,
+`RUST_PLAYGROUND_URL`, `SENTRY_ORG`, `SENTRY_PROJECT`.
+
+(Every name is written out in full — no `_HOST`-style shorthand — so the
+grep-the-doc-against-the-code check above actually works.)
+
+Google OAuth has **no** app-side env var — the client ID/secret live in the Supabase
+dashboard (Authentication → Providers → Google).
+
+### Known drift in the env surface (not secrets — clean these up)
+
+| Var                                                                                                     | Where                            | Status                                                                                                              |
+| ------------------------------------------------------------------------------------------------------- | -------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `NEXT_PUBLIC_SANITY_PROJECT_ID`, `NEXT_PUBLIC_SANITY_DATASET`, `SANITY_API_TOKEN`, `SANITY_ADMIN_TOKEN` | `turbo.json` `env` (lines 12-15) | **DEAD.** Read nowhere in the codebase. Delete from `turbo.json` and from every env store.                          |
+| `NEXT_PUBLIC_HELIUS_API_KEY`                                                                            | `turbo.json` `env`               | **PHANTOM.** Declared as a build-cache key but read nowhere. Helius is server-side only (`HELIUS_API_KEY`). Delete. |
+| `GITHUB_TOKEN`, `MODERATION_WEBHOOK_URL`                                                                | absent from `.env.example`       | **UNDOCUMENTED.** Both are live in `env.server.ts`. Add them to `.env.example`.                                     |
 
 Google OAuth has **no** app-side env var — the client ID/secret live in the Supabase
 dashboard (Authentication → Providers → Google).
@@ -108,8 +154,12 @@ dashboard (Authentication → Providers → Google).
 ## Definition of done
 
 - [x] New dedicated prod Supabase live (`pywhtmidcrptomrabbrw`); `service_role` isolated from dev.
-- [ ] Helius, Gemini, `GITHUB_TOKEN`, `ADMIN_SECRET`, `BUILD_SERVER_API_KEY` all freshly minted for prod.
-- [ ] Any dead `SANITY_*` vars deleted from every env store (Vercel prod + preview, local).
+- [ ] Helius (`HELIUS_API_KEY` **+ `SOLANA_RPC_URL` together**), Gemini, `GITHUB_TOKEN`, `ADMIN_SECRET`, `BUILD_SERVER_API_KEY`, `SENTRY_AUTH_TOKEN`, `MODERATION_WEBHOOK_URL` all freshly minted for prod.
+- [ ] `AI_PARTNER_SEAL_SECRET` set explicitly in prod (not derived from `SUPABASE_SERVICE_ROLE_KEY`, so rotating the DB key doesn't silently invalidate live check tokens).
+- [ ] `ARWEAVE_UPLOADER_SECRET` is a dedicated, funded keypair — never reused as a signer.
+- [ ] Dead `SANITY_*` + phantom `NEXT_PUBLIC_HELIUS_API_KEY` deleted from `turbo.json` and every env store (Vercel prod + preview, local).
+- [ ] `GITHUB_TOKEN` + `MODERATION_WEBHOOK_URL` added to `.env.example`.
+- [ ] `NEXT_PUBLIC_SOLANA_RPC_URL` verified to carry **no** API key (it ships in the browser bundle).
 - [ ] `backend_signer` rotated to a distinct hot key at mainnet init (**#118**).
 - [ ] Program / mint authority under Squads multisig (**#144**).
 - [ ] All prod secrets live only in the Vercel/Cloud Run encrypted env; on-chain keypairs in multisig/HW; repo clean.

--- a/docs/SECRET-ROTATION.md
+++ b/docs/SECRET-ROTATION.md
@@ -14,9 +14,14 @@ stored outside the repo**.
 
 > **Correction (2026-07-09):** the canonical production deploy is
 > **superteam-academy-web.vercel.app** (Vercel `stbr-true`), which auto-deploys from
-> `main` and uses Supabase `obqlljsagzslxarwphxv`. References to `solarium.courses` /
-> `credit-markets-team/lms` in this document are a parallel red herring, not prod — the
-> rotation decisions below still apply, but to the `stbr-true` deploy.
+> `main`. References to `solarium.courses` / `credit-markets-team/lms` in this
+> document are a parallel red herring, not prod — the rotation decisions below still
+> apply, but to the `stbr-true` deploy.
+>
+> **Update (2026-07-12):** the dedicated production Supabase project (D-2 item 1) is
+> **live: `pywhtmidcrptomrabbrw`**. The previously shared project
+> (`obqlljsagzslxarwphxv`) is **retired as a prod source** — do not point anything
+> new at it. The remaining D-2 work is credential minting + on-chain custody.
 
 ## Decisions (D-2) — RATIFIED 2026-07-03
 
@@ -24,9 +29,10 @@ stored outside the repo**.
    up a fresh prod Supabase project with its own `URL` / `anon` / `service_role`,
    apply the schema + all migrations, migrate/seed the data, and cut prod
    (solarium.courses) over to it. Retire the shared dev project as a prod source.
-2. **Mint ALL prod credentials fresh** — new Helius API key + webhook secret, new
-   Sanity tokens, new Gemini key, new `ADMIN_SECRET` / `BUILD_SERVER_API_KEY`, and
-   new Supabase keys (from the new project). **No dev value is ever reused in prod.**
+2. **Mint ALL prod credentials fresh** — new Helius API key + webhook secret, a new
+   Gemini key, a new `GITHUB_TOKEN` (read-only), new `ADMIN_SECRET` /
+   `BUILD_SERVER_API_KEY`, and new Supabase keys (from the new project). **No dev
+   value is ever reused in prod.**
 3. **Custody — the platform env store is the source of truth for app secrets.**
    Prod secrets live only in the **Vercel / Cloud Run encrypted env** (no separate
    password-manager vault). Because there is no offline master, treat an env wipe
@@ -41,37 +47,47 @@ stored outside the repo**.
 
 ### Critical — server-only (rotate before mainnet; leak = high blast radius)
 
-| Secret                      | Purpose                                          | Blast radius if leaked                                       | How to rotate                                                          |
-| --------------------------- | ------------------------------------------------ | ------------------------------------------------------------ | ---------------------------------------------------------------------- |
-| `SUPABASE_SERVICE_ROLE_KEY` | Bypasses RLS; all privileged DB writes           | Full DB read/write; forge any user's XP/progress/certs       | New prod project (pref.) or Supabase → rotate `service_role` JWT       |
-| `BACKEND_SIGNER_SECRET`     | Keypair signing on-chain mint / credential ix    | Mint arbitrary XP + credentials to any wallet                | New keypair → `update_config` sets `Config.backend_signer` (**#118**)  |
-| `PROGRAM_AUTHORITY_SECRET`  | Program upgrade + config authority               | Upgrade program, rewrite config, seize authority powers      | Move to **Squads multisig** at mainnet (**#144**); retire the hot JSON |
-| `ADMIN_SECRET`              | HMAC-signs the `admin_session` cookie            | Admin panel: course/achievement sync, resync, deactivate     | Generate new 32-byte random → update env; invalidates live sessions    |
-| `HELIUS_WEBHOOK_SECRET`     | Verifies Helius webhook signatures               | Forge on-chain events → fake enroll / XP / credential grants | Rotate in Helius webhook config **and** env together                   |
-| `BUILD_SERVER_API_KEY`      | Authenticates `/build` calls to the build server | Submit arbitrary Anchor builds to the compile sandbox        | Rotate on the build server + env                                       |
-| `SANITY_ADMIN_TOKEN`        | Sanity **write** token (course content)          | Modify / delete any course, lesson, answer key               | sanity.io/manage → revoke, issue new write token                       |
-| `SANITY_API_TOKEN`          | Sanity read/API token                            | Read/write via the API (NOT required to read course content — the production dataset is public)                 | sanity.io/manage → rotate                                              |
-| `GEMINI_API_KEY`            | AI tutor / challenge suggest                     | Quota abuse, cost                                            | Google AI Studio → rotate                                              |
+| Secret                      | Purpose                                          | Blast radius if leaked                                                    | How to rotate                                                          |
+| --------------------------- | ------------------------------------------------ | ------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| `SUPABASE_SERVICE_ROLE_KEY` | Bypasses RLS; all privileged DB writes           | Full DB read/write; forge any user's XP/progress/certs                    | New prod project (pref.) or Supabase → rotate `service_role` JWT       |
+| `BACKEND_SIGNER_SECRET`     | Keypair signing on-chain mint / credential ix    | Mint arbitrary XP + credentials to any wallet                             | New keypair → `update_config` sets `Config.backend_signer` (**#118**)  |
+| `PROGRAM_AUTHORITY_SECRET`  | Program upgrade + config authority               | Upgrade program, rewrite config, seize authority powers                   | Move to **Squads multisig** at mainnet (**#144**); retire the hot JSON |
+| `ADMIN_SECRET`              | HMAC-signs the `admin_session` cookie            | Admin panel: course/achievement sync, resync, deactivate                  | Generate new 32-byte random → update env; invalidates live sessions    |
+| `HELIUS_WEBHOOK_SECRET`     | Verifies Helius webhook signatures               | Forge on-chain events → fake enroll / XP / credential grants              | Rotate in Helius webhook config **and** env together                   |
+| `BUILD_SERVER_API_KEY`      | Authenticates `/build` calls to the build server | Submit arbitrary Anchor builds to the compile sandbox                     | Rotate on the build server + env                                       |
+| `XP_MINT_AUTHORITY_SECRET`  | XP mint authority (wallet link/unlink XP moves)  | Mint/burn XP tokens directly                                              | New keypair; must match the mint's authority on-chain                  |
+| `HELIUS_API_KEY`            | Helius DAS API + webhook management (server)     | Quota abuse, cost; read of on-chain indexes                               | Helius dashboard → rotate                                              |
+| `ARWEAVE_UPLOADER_SECRET`   | Funds Irys uploads pinning credential metadata   | Drains the funded upload wallet                                           | New Solana keypair; re-fund; old one keeps only residual balance       |
+| `AI_PARTNER_SEAL_SECRET`    | Seals the comprehension-check token              | Forge comprehension-check passes                                          | New random value (falls back to `SUPABASE_SERVICE_ROLE_KEY` if unset)  |
+| `GEMINI_API_KEY`            | AI tutor / challenge suggest                     | Quota abuse, cost                                                         | Google AI Studio → rotate                                              |
+| `GITHUB_TOKEN`              | **Read-only** poll of `courses-academy` HEAD/CI  | **Low** — read-only, and the repo is public. Worst case: rate-limit abuse | GitHub → revoke, issue a new fine-grained read token                   |
+
+> **There is no content-write secret.** The app cannot mutate course content at
+> runtime under any credential — content is a committed bundle and publishing is a
+> pull request. Any `SANITY_*` variable found in an env store is **dead** and should
+> be **deleted**, not rotated.
 
 ### Semi-sensitive (client-exposed, but abuse/quota risk)
 
-| Secret                          | Purpose                 | Note                                                                                              |
-| ------------------------------- | ----------------------- | ------------------------------------------------------------------------------------------------- |
-| `NEXT_PUBLIC_HELIUS_API_KEY`    | Client-side Helius RPC  | Public by design but quota-abusable; prefer a server proxy + a low-limit key, and rotate for prod |
-| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Browser Supabase client | RLS-gated (not a secret), but changes with the new prod project                                   |
-| `SENTRY_DSN`                    | Error reporting         | Safe to expose; rotate only on abuse                                                              |
+| Secret                          | Purpose                 | Note                                                                                                   |
+| ------------------------------- | ----------------------- | ------------------------------------------------------------------------------------------------------ |
+| `NEXT_PUBLIC_SOLANA_RPC_URL`    | Browser RPC endpoint    | Must carry **no** privileged key. The Helius-keyed endpoint belongs in `SOLANA_RPC_URL` (server-only). |
+| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Browser Supabase client | RLS-gated (not a secret), but changes with the new prod project                                        |
+| `NEXT_PUBLIC_SENTRY_DSN`        | Error reporting         | Safe to expose; rotate only on abuse                                                                   |
 
 ### Config — not secret (change only when the underlying resource changes)
 
-`NEXT_PUBLIC_BACKEND_SIGNER` (pubkey; changes when `BACKEND_SIGNER_SECRET` rotates),
 `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_PROGRAM_ID`, `NEXT_PUBLIC_XP_MINT_ADDRESS`,
 `NEXT_PUBLIC_SOLANA_RPC_URL` / `SOLANA_RPC_URL`, `NEXT_PUBLIC_SOLANA_NETWORK`,
-`NEXT_PUBLIC_SANITY_PROJECT_ID` / `_DATASET`, `NEXT_PUBLIC_GOOGLE_CLIENT_ID`,
-`NEXT_PUBLIC_GA4_MEASUREMENT_ID`, `NEXT_PUBLIC_POSTHOG_KEY` / `_HOST`.
+`NEXT_PUBLIC_APP_URL`, `NEXT_PUBLIC_GA4_MEASUREMENT_ID`,
+`NEXT_PUBLIC_POSTHOG_KEY` / `_HOST`.
+
+Google OAuth has **no** app-side env var — the client ID/secret live in the Supabase
+dashboard (Authentication → Providers → Google).
 
 ## Rotation procedure (order matters — avoid downtime)
 
-1. **Provision** the new prod resource (Supabase project / Helius key / Sanity token).
+1. **Provision** the new prod resource (Supabase project / Helius key / Gemini key).
 2. **Stage** the new value in the platform env store (Vercel prod scope) _without_
    removing the old one where a dual-read window helps (e.g. deploy, verify, then revoke).
 3. **Rotate on-chain last:** `backend_signer` via `update_config` (the app keeps
@@ -91,8 +107,9 @@ stored outside the repo**.
 
 ## Definition of done
 
-- [ ] New dedicated prod Supabase live; `service_role` isolated from dev.
-- [ ] Helius, Sanity, Gemini, `ADMIN_SECRET`, `BUILD_SERVER_API_KEY` all freshly minted for prod.
+- [x] New dedicated prod Supabase live (`pywhtmidcrptomrabbrw`); `service_role` isolated from dev.
+- [ ] Helius, Gemini, `GITHUB_TOKEN`, `ADMIN_SECRET`, `BUILD_SERVER_API_KEY` all freshly minted for prod.
+- [ ] Any dead `SANITY_*` vars deleted from every env store (Vercel prod + preview, local).
 - [ ] `backend_signer` rotated to a distinct hot key at mainnet init (**#118**).
 - [ ] Program / mint authority under Squads multisig (**#144**).
 - [ ] All prod secrets live only in the Vercel/Cloud Run encrypted env; on-chain keypairs in multisig/HW; repo clean.

--- a/docs/STAGING.md
+++ b/docs/STAGING.md
@@ -1,7 +1,7 @@
 # Staging Environment Guide
 
 Readiness item **G8**. How to stand up a staging environment for Superteam
-Academy that mirrors production topology (Vercel + Supabase + Sanity + Helius +
+Academy that mirrors production topology (Vercel + Supabase + Helius +
 Cloud Run) without touching prod data, and how to run the read-path load test
 against it.
 
@@ -18,14 +18,14 @@ project/branch.
 
 ## Topology at a glance
 
-| Layer            | Production                         | Staging                                              |
-| ---------------- | ---------------------------------- | ---------------------------------------------------- |
-| Frontend         | Vercel Production deploy (`main`)  | Vercel **Preview** env (staging branch or PR)        |
-| Database         | Supabase prod project              | Supabase **branch** _or_ a separate staging project  |
-| CMS              | Sanity `production` dataset        | Same project; `production` (or a `staging` dataset)  |
-| Chain            | mainnet-beta / devnet              | **devnet** always                                    |
-| RPC + webhooks   | Helius (prod webhook)              | Helius (separate **devnet** webhook → staging URL)   |
-| Build server     | Cloud Run (shared)                 | Same Cloud Run service (stateless) or a staging one  |
+| Layer          | Production                                  | Staging                                             |
+| -------------- | ------------------------------------------- | --------------------------------------------------- |
+| Frontend       | Vercel Production deploy (`main`)           | Vercel **Preview** env (staging branch or PR)       |
+| Database       | Supabase prod (`pywhtmidcrptomrabbrw`)      | Supabase **branch** _or_ a separate staging project |
+| Content        | Committed bundle (whatever the branch pins) | **Identical** — the bundle ships with the code      |
+| Chain          | mainnet-beta / devnet                       | **devnet** always                                   |
+| RPC + webhooks | Helius (prod webhook)                       | Helius (separate **devnet** webhook → staging URL)  |
+| Build server   | Cloud Run (shared)                          | Same Cloud Run service (stateless) or a staging one |
 
 ---
 
@@ -63,17 +63,24 @@ Then, exactly as in [`docs/DEPLOYMENT.md`](./DEPLOYMENT.md) §Supabase Setup:
 - Enable the Google OAuth provider if you're testing sign-in (use a staging
   OAuth client, not the prod one).
 
-> Do **not** copy production user data into staging. Seed with test content
-> (`sanity/seed/`) and test accounts only.
+> Do **not** copy production user data into staging. Use test accounts only.
+
+> **Content visibility on a fresh staging DB**: `onchain_deployments` starts empty,
+> and that table **is** the learner-visibility gate. No courses will be visible
+> until you deploy them from `/admin/deploy` against the staging DB + devnet
+> program. This is expected, not a bug.
 
 ---
 
-## 2. Sanity: dataset
+## 2. Content: nothing to provision
 
-The simplest path is to reuse the existing Sanity project and its `production`
-dataset (content is not user data). If you want editorial isolation, create a
-`staging` dataset and set `NEXT_PUBLIC_SANITY_DATASET=staging`. Add the staging
-Vercel URL to **Sanity → API → CORS origins** either way.
+Content is a **committed bundle** compiled from `solanabr/courses-academy` and
+pinned by `apps/web/content.lock`. It ships with the code, so staging serves
+exactly the content the deployed branch pins — there is no separate content
+service, dataset, CORS origin, or token to configure.
+
+To stage a content change, bump `content.lock` + recompile the bundle on the
+staging branch (see [`docs/ADMIN.md`](./ADMIN.md)); the Preview deploy picks it up.
 
 ---
 
@@ -105,11 +112,11 @@ Staging rides on Vercel's **Preview** environment.
 2. **Set Preview env vars**: Vercel → Project → Settings → Environment
    Variables, scope = **Preview**. Fill in every variable from
    [`.env.staging.example`](../.env.staging.example) with staging-scoped values:
-   - `NEXT_PUBLIC_*` → devnet + the **staging** Supabase/Sanity project.
-   - Server secrets (`SUPABASE_SERVICE_ROLE_KEY`, `*_AUTHORITY_SECRET`,
-     `BACKEND_SIGNER_SECRET`, `XP_MINT_AUTHORITY_SECRET`, `ADMIN_SECRET`,
-     `HELIUS_*`, `BUILD_SERVER_*`, `SANITY_ADMIN_TOKEN`) → staging values,
-     **Preview-scoped so they never bleed into Production**.
+   - `NEXT_PUBLIC_*` → devnet + the **staging** Supabase project.
+   - Server secrets (`SUPABASE_SERVICE_ROLE_KEY`, `SOLANA_RPC_URL`,
+     `*_AUTHORITY_SECRET`, `BACKEND_SIGNER_SECRET`, `XP_MINT_AUTHORITY_SECRET`,
+     `ADMIN_SECRET`, `HELIUS_*`, `BUILD_SERVER_*`, `GITHUB_TOKEN`) → staging
+     values, **Preview-scoped so they never bleed into Production**.
    - `NEXT_PUBLIC_APP_URL` → the staging URL (drives sitemap + OG tags).
    - Leave analytics keys blank on staging to avoid polluting prod dashboards.
 


### PR DESCRIPTION
Rewrites `docs/` for the post-Sanity architecture (content compiles from git into a committed bundle; on-chain status lives in Supabase; the admin console is 4 screens).

## The docs were lying about the code

Beyond Sanity rot, the sweep found docs that would actively burn someone — each verified against the code by an independent fact-check:

- **`ADMIN.md` told readers to authenticate with `Authorization: Bearer $ADMIN_SECRET`.** There is no bearer path; it is a same-origin check + HMAC-signed `admin_session` cookie. Following the doc always 401s.
- **`SECRET-ROTATION.md`'s inventory was wrong in both directions** — it invented 4 secrets that do not exist (including a *client-exposed* `NEXT_PUBLIC_HELIUS_API_KEY` that has never existed anywhere) and **omitted live ones**, including `XP_MINT_AUTHORITY_SECRET`, `MODERATION_WEBHOOK_URL`, and `SENTRY_AUTH_TOKEN`. A rotation runbook that misses a live credential leaves it unrotated.
- **`ARCHITECTURE.md` documented two phantom routes** (`/api/enrollment/sync`, `/api/deploy/[uuid]`) and omitted 3 real ones; counts were stale (16→**18** instructions, 17/19→**21** tables, 1→**3** views).
- **`CUSTOMIZATION.md`'s "add a lesson type" section was un-followable** — it described a `content`/`challenge` union; lessons are an ordered `blocks[]` discriminated union.
- `UNLOCK_CHECKS` / `lib/achievements.ts` **do not exist** (unlock is declarative: `PREDICATES satisfies Record<AwardKind, Predicate>`). Fixed in `apps/web/CLAUDE.md` separately (#445).

## Root cause of the first miss (worth keeping)

The first pass derived the env inventory from the two Zod schemas — which structurally **cannot see** vars read directly via `process.env`. That is exactly how `SENTRY_AUTH_TOKEN` escaped. Both inventories are now derived from the filesystem, verified programmatically (**env 30/30, routes 44/44, zero phantoms**), and the doc **states its derivation method inline** so the next person can re-check it.

## Verification

Independent fact-check against the code: 8/9 original claims verified clean; the 3 gaps it found (`MODERATION_WEBHOOK_URL`, `SENTRY_AUTH_TOKEN`, `SOLANA_RPC_URL` misclassified as non-secret when it carries the Helius key) are fixed here and re-verified.

Code-side drift found along the way is fixed in #443 (dead `turbo.json` cache keys + the phantom; `.env.example` omissions). Docs-only here.