### PR TITLE
feat(admin): close+recreate a course on-chain — SERVER PATH ONLY (no UI, deliberately)

### DIFF
--- a/apps/web/src/app/api/admin/courses/recreate/__tests__/route.test.ts
+++ b/apps/web/src/app/api/admin/courses/recreate/__tests__/route.test.ts
@@ -1,0 +1,196 @@
+/* eslint-disable import/order -- vi.mock('server-only') must be hoisted above
+   the route import so the `server-only` graph loads under vitest. */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { NextRequest } from "next/server";
+
+vi.mock("server-only", () => ({}));
+
+// `vi.mock` factories are hoisted above the module body, so anything they close
+// over must come from `vi.hoisted`.
+const h = vi.hoisted(() => ({
+  AdminAuthError: class AdminAuthError extends Error {},
+  state: { authThrows: false },
+  recreateCourse: vi.fn(),
+}));
+
+vi.mock("@/lib/admin/auth", () => ({
+  // Must be the SAME class object the route's `instanceof` check sees.
+  AdminAuthError: h.AdminAuthError,
+  adminUnauthorizedResponse: () =>
+    new Response(JSON.stringify({ error: "Unauthorized" }), { status: 401 }),
+  requireAdminAuth: vi.fn(() => {
+    if (h.state.authThrows) throw new h.AdminAuthError();
+  }),
+}));
+
+vi.mock("@/lib/content/queries", () => ({
+  getAllCoursesAdmin: async () => [],
+  COURSES_CACHE_TAG: "courses",
+}));
+
+vi.mock("next/cache", () => ({ revalidateTag: vi.fn() }));
+
+// Keep the REAL RecreateCourseError class (the route branches on `instanceof`);
+// stub only the orchestrator so no on-chain call can happen from a route test.
+vi.mock("@/lib/admin/recreate-course", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/lib/admin/recreate-course")>();
+  return { ...actual, recreateCourse: h.recreateCourse };
+});
+
+import { RecreateCourseError } from "@/lib/admin/recreate-course";
+
+const recreateCourse = h.recreateCourse;
+const COURSE_ID = "course-solana-101";
+
+const post = async (body: unknown): Promise<Response> => {
+  const { POST } = await import("../route");
+  return POST(
+    new Request("https://app.test/api/admin/courses/recreate", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    }) as unknown as NextRequest
+  );
+};
+
+beforeEach(() => {
+  h.state.authThrows = false;
+  recreateCourse.mockReset();
+  recreateCourse.mockResolvedValue({
+    action: "recreated",
+    coursePda: "PDA111",
+    closeSignature: "close-sig",
+    createSignature: "create-sig",
+    createAttempts: 1,
+    lostCounters: { totalCompletions: 42, totalEnrollments: 100 },
+    warnings: [],
+  });
+});
+
+describe("POST /api/admin/courses/recreate — auth", () => {
+  it("401s when the admin session is missing, without touching the chain", async () => {
+    h.state.authThrows = true;
+    const res = await post({ courseId: COURSE_ID, confirm: COURSE_ID });
+    expect(res.status).toBe(401);
+    expect(recreateCourse).not.toHaveBeenCalled();
+  });
+});
+
+describe("POST /api/admin/courses/recreate — the confirmation gate", () => {
+  it("400s when `confirm` does NOT match courseId, with no on-chain call", async () => {
+    const res = await post({ courseId: COURSE_ID, confirm: "course-other" });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toMatch(/does not match courseId/i);
+    // The point of the gate: a stray/CSRF-ish call cannot nuke a course.
+    expect(recreateCourse).not.toHaveBeenCalled();
+  });
+
+  it("400s when `confirm` is absent entirely", async () => {
+    const res = await post({ courseId: COURSE_ID });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toMatch(/confirm is required/i);
+    expect(recreateCourse).not.toHaveBeenCalled();
+  });
+
+  it("400s when courseId is absent", async () => {
+    const res = await post({ confirm: COURSE_ID });
+    expect(res.status).toBe(400);
+    expect(recreateCourse).not.toHaveBeenCalled();
+  });
+
+  it("400s on an invalid JSON body", async () => {
+    const { POST } = await import("../route");
+    const res = await POST(
+      new Request("https://app.test/api/admin/courses/recreate", {
+        method: "POST",
+        body: "{not json",
+      }) as unknown as NextRequest
+    );
+    expect(res.status).toBe(400);
+    expect(recreateCourse).not.toHaveBeenCalled();
+  });
+
+  it("proceeds only when confirm === courseId", async () => {
+    const res = await post({ courseId: COURSE_ID, confirm: COURSE_ID });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      action: string;
+      lostCounters: { totalCompletions: number };
+    };
+    expect(body.action).toBe("recreated");
+    // The destroyed counters reach the caller so the UI can warn about the
+    // re-opened creator-reward window.
+    expect(body.lostCounters.totalCompletions).toBe(42);
+    expect(recreateCourse).toHaveBeenCalledWith(COURSE_ID, false);
+  });
+
+  it("threads allowUnusualCreator through", async () => {
+    await post({
+      courseId: COURSE_ID,
+      confirm: COURSE_ID,
+      allowUnusualCreator: true,
+    });
+    expect(recreateCourse).toHaveBeenCalledWith(COURSE_ID, true);
+  });
+});
+
+describe("POST /api/admin/courses/recreate — error mapping", () => {
+  it("maps a pre-flight refusal to 400 and reports the course as intact", async () => {
+    recreateCourse.mockRejectedValue(
+      new RecreateCourseError(
+        'Course "x" has no creator wallet',
+        "preflight",
+        true
+      )
+    );
+    const res = await post({ courseId: COURSE_ID, confirm: COURSE_ID });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as {
+      phase: string;
+      courseIntact: boolean;
+      error: string;
+    };
+    expect(body.phase).toBe("preflight");
+    expect(body.courseIntact).toBe(true);
+  });
+
+  it("maps a post-close create failure to 500, courseIntact:false, with the recovery message", async () => {
+    recreateCourse.mockRejectedValue(
+      new RecreateCourseError(
+        'Course "x" was closed but could NOT be recreated after 4 attempts. The course is currently NOT deployed on-chain; use Deploy to recreate it.',
+        "create",
+        false
+      )
+    );
+    const res = await post({ courseId: COURSE_ID, confirm: COURSE_ID });
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as {
+      phase: string;
+      courseIntact: boolean;
+      error: string;
+    };
+    expect(body.phase).toBe("create");
+    // The operator must be told the course is DOWN and exactly how to fix it.
+    expect(body.courseIntact).toBe(false);
+    expect(body.error).toMatch(
+      /currently NOT deployed on-chain; use Deploy to recreate it/i
+    );
+  });
+
+  it("maps a failed close to 500 but reports the course as intact", async () => {
+    recreateCourse.mockRejectedValue(
+      new RecreateCourseError(
+        "Failed to close: Unauthorized. The course is UNCHANGED and still deployed.",
+        "close",
+        true
+      )
+    );
+    const res = await post({ courseId: COURSE_ID, confirm: COURSE_ID });
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { courseIntact: boolean };
+    expect(body.courseIntact).toBe(true);
+  });
+});

--- a/apps/web/src/app/api/admin/courses/recreate/route.ts
+++ b/apps/web/src/app/api/admin/courses/recreate/route.ts
@@ -1,0 +1,112 @@
+import "server-only";
+
+import { revalidateTag } from "next/cache";
+import { NextRequest, NextResponse } from "next/server";
+import {
+  requireAdminAuth,
+  adminUnauthorizedResponse,
+  AdminAuthError,
+} from "@/lib/admin/auth";
+import { COURSES_CACHE_TAG } from "@/lib/content/queries";
+import {
+  recreateCourse,
+  RecreateCourseError,
+} from "@/lib/admin/recreate-course";
+
+/**
+ * POST /api/admin/courses/recreate — DESTRUCTIVE. Closes a course's on-chain PDA
+ * and recreates it, to rewrite the create-only fields (`creator`, `difficulty`,
+ * `trackId`, `trackLevel`, `prerequisite`) that `update_course` cannot touch.
+ * See `lib/admin/recreate-course.ts` for the full rationale and the non-atomicity
+ * window this is built around.
+ *
+ * Guards, in order:
+ *   1. `requireAdminAuth` — the signed `admin_session` cookie AND the same-origin
+ *      (CSRF) check that it applies to every state-changing method.
+ *   2. An explicit `confirm` field that must EQUAL the target `courseId`. A
+ *      CSRF-ish or fat-fingered call that merely reaches this route cannot
+ *      destroy a course without naming it exactly. Checked before any on-chain
+ *      call is made.
+ *
+ * No UI wires this yet — the confirmation button lands with the /admin/courses
+ * screen in a follow-up.
+ */
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  try {
+    requireAdminAuth(req);
+  } catch (e) {
+    if (e instanceof AdminAuthError) return adminUnauthorizedResponse();
+    throw e;
+  }
+
+  let courseId: string;
+  let confirm: string;
+  let allowUnusualCreator = false;
+  try {
+    const body = (await req.json()) as {
+      courseId?: unknown;
+      confirm?: unknown;
+      allowUnusualCreator?: unknown;
+    };
+    if (typeof body.courseId !== "string" || !body.courseId) {
+      return NextResponse.json(
+        { error: "courseId is required" },
+        { status: 400 }
+      );
+    }
+    if (typeof body.confirm !== "string" || !body.confirm) {
+      return NextResponse.json(
+        {
+          error:
+            "confirm is required and must equal the courseId — this operation destroys an on-chain account",
+        },
+        { status: 400 }
+      );
+    }
+    courseId = body.courseId;
+    confirm = body.confirm;
+    allowUnusualCreator = body.allowUnusualCreator === true;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  // The confirmation gate. Nothing on-chain has been touched at this point.
+  if (confirm !== courseId) {
+    return NextResponse.json(
+      {
+        error: `confirm "${confirm}" does not match courseId "${courseId}" — refusing to close the course`,
+      },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const result = await recreateCourse(courseId, allowUnusualCreator);
+    // The course was closed and recreated — purge the catalog cache so the new
+    // PDA / status is served immediately rather than after the 1h ISR window.
+    revalidateTag(COURSES_CACHE_TAG);
+    return NextResponse.json(result);
+  } catch (e) {
+    if (e instanceof RecreateCourseError) {
+      // A pre-flight refusal is a bad request: the params were invalid and NOTHING
+      // was touched. A close/create failure is a server-side failure — and when
+      // `courseIntact` is false the course is DOWN, so the caller must not treat
+      // this as a routine error. The message carries the recovery instruction.
+      const status = e.phase === "preflight" ? 400 : 500;
+      if (!e.courseIntact) {
+        console.error(
+          `[admin/courses/recreate] ${courseId}: COURSE IS DOWN — ${e.message}`
+        );
+        // The PDA is gone, so the catalog/admin reads must re-derive from chain.
+        revalidateTag(COURSES_CACHE_TAG);
+      }
+      return NextResponse.json(
+        { error: e.message, phase: e.phase, courseIntact: e.courseIntact },
+        { status }
+      );
+    }
+    const message = e instanceof Error ? e.message : String(e);
+    console.error(`[admin/courses/recreate] ${courseId}: ${message}`);
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/apps/web/src/lib/admin/__tests__/recreate-course.test.ts
+++ b/apps/web/src/lib/admin/__tests__/recreate-course.test.ts
@@ -1,0 +1,465 @@
+/* eslint-disable import/order -- vi.mock('server-only') must be hoisted above
+   the module imports so the `server-only` graph loads under vitest. */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { Keypair, PublicKey } from "@solana/web3.js";
+
+vi.mock("server-only", () => ({}));
+
+// ---------------------------------------------------------------------------
+// Call-ORDER log. The safety property of this feature is an ordering one:
+// pre-flight must fully validate BEFORE `close_course` destroys the account. So
+// every on-chain / DB effect appends to this log and the tests assert the exact
+// sequence, not just that the calls happened.
+// ---------------------------------------------------------------------------
+let calls: string[] = [];
+
+const AUTHORITY = Keypair.generate().publicKey;
+const INSTRUCTOR = Keypair.generate().publicKey.toBase58();
+const COLLECTION = Keypair.generate().publicKey.toBase58();
+const COURSE_ID = "course-solana-101";
+
+// Mutable mock state, reset per test.
+let authority: PublicKey | null = AUTHORITY;
+let courses: unknown[] = [];
+let accounts: Map<string, object | null> = new Map();
+let onChainCourse: Record<string, unknown> | null = null;
+let closeResult = { success: true, signature: "close-sig" };
+let createResults: Array<{
+  success: boolean;
+  signature?: string;
+  error?: string;
+}> = [];
+let bindResult = { success: true, signature: "bind-sig" };
+let updateResult = { success: true, signature: "update-sig" };
+let dbThrows = false;
+
+// The REAL #427 guard (assertCreatorAllowed + CREATOR_DENYLIST) is kept via
+// importOriginal — mocking it would test the mock, not the guard. Only the
+// tx-sending functions are stubbed.
+vi.mock("@/lib/solana/admin-signer", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/lib/solana/admin-signer")>();
+  return {
+    ...actual,
+    getAuthorityPublicKey: () => authority,
+    closeCoursePda: vi.fn(async () => {
+      calls.push("close");
+      return closeResult;
+    }),
+    deployCoursePda: vi.fn(async () => {
+      calls.push("create");
+      return createResults.shift() ?? { success: false, error: "no result" };
+    }),
+    setCourseCollectionPda: vi.fn(async () => {
+      calls.push("bind");
+      return bindResult;
+    }),
+    updateCoursePda: vi.fn(async () => {
+      calls.push("deactivate");
+      return updateResult;
+    }),
+  };
+});
+
+vi.mock("@/lib/content/queries", () => ({
+  getAllCoursesAdmin: async () => courses,
+  COURSES_CACHE_TAG: "courses",
+}));
+
+vi.mock("@/lib/solana/academy-reads", () => ({
+  fetchCourse: async () => onChainCourse,
+}));
+
+vi.mock("@/lib/content/deployment-writes", () => ({
+  writeCourseOnChainStatus: vi.fn(async (_id: string, status: string) => {
+    calls.push(`db:${status}`);
+    if (dbThrows) throw new Error("supabase down");
+  }),
+}));
+
+vi.mock("@solana/web3.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@solana/web3.js")>();
+  return {
+    ...actual,
+    Connection: class {
+      async getAccountInfo(pk: PublicKey) {
+        return accounts.get(pk.toBase58()) ?? null;
+      }
+    },
+  };
+});
+
+import { recreateCourse, RecreateCourseError } from "../recreate-course";
+import { findCoursePDA, getProgramId } from "@/lib/solana/pda";
+import { closeCoursePda, deployCoursePda } from "@/lib/solana/admin-signer";
+
+const coursePda = (id: string) =>
+  findCoursePDA(id, getProgramId())[0].toBase58();
+
+/**
+ * Capture a rejection as a typed error. The retry backoff runs under fake timers,
+ * so the rejection must be attached BEFORE `runAllTimersAsync()` drives the
+ * sleeps — awaiting the promise directly would deadlock.
+ */
+function captureError(p: Promise<unknown>): Promise<RecreateCourseError> {
+  return p.then(
+    () => {
+      throw new Error("expected the recreate to reject, but it resolved");
+    },
+    (e: unknown) => e as RecreateCourseError
+  );
+}
+
+/** A fully-valid course in the content bundle. */
+function validCourse(overrides: Record<string, unknown> = {}) {
+  return {
+    _id: COURSE_ID,
+    title: "Solana 101",
+    slug: "solana-101",
+    difficulty: "beginner",
+    creatorWallet: INSTRUCTOR,
+    xpPerLesson: 10,
+    trackId: 1,
+    trackLevel: 1,
+    prerequisiteCourse: null,
+    creatorRewardXp: 500,
+    minCompletionsForReward: 10,
+    lessonCount: 5,
+    trackCollectionAddress: COLLECTION,
+    onChainStatus: null,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  calls = [];
+  authority = AUTHORITY;
+  courses = [validCourse()];
+  // The course exists on-chain (so there IS something to recreate).
+  accounts = new Map([[coursePda(COURSE_ID), { lamports: 1 } as object]]);
+  onChainCourse = {
+    total_completions: 42,
+    total_enrollments: 100,
+    is_active: true,
+    collection: COLLECTION,
+  };
+  closeResult = { success: true, signature: "close-sig" };
+  createResults = [{ success: true, signature: "create-sig" }];
+  bindResult = { success: true, signature: "bind-sig" };
+  updateResult = { success: true, signature: "update-sig" };
+  dbThrows = false;
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+// ---------------------------------------------------------------------------
+// PRE-FLIGHT: must refuse WITHOUT ever calling close. This is the whole safety
+// property — it must be impossible to close a course and only then discover the
+// create params were bad.
+// ---------------------------------------------------------------------------
+describe("preflight refuses before ever closing the course", () => {
+  const expectRefusedIntact = async (expectedMessage: RegExp) => {
+    let thrown: RecreateCourseError | undefined;
+    try {
+      await recreateCourse(COURSE_ID);
+    } catch (e) {
+      thrown = e as RecreateCourseError;
+    }
+    expect(thrown).toBeInstanceOf(RecreateCourseError);
+    expect(thrown!.phase).toBe("preflight");
+    // The course was never touched.
+    expect(thrown!.courseIntact).toBe(true);
+    expect(thrown!.message).toMatch(expectedMessage);
+    // THE assertion: close_course was never sent, and nothing else was either.
+    expect(closeCoursePda).not.toHaveBeenCalled();
+    expect(deployCoursePda).not.toHaveBeenCalled();
+    expect(calls).toEqual([]);
+  };
+
+  // A missing / malformed creatorWallet is caught by the shared
+  // `getMissingCourseFields` gate (which checks presence AND base58 shape), so it
+  // refuses one step earlier than the orchestrator's own parse check. Either way
+  // the contract that matters holds: refused, and close_course was never sent.
+  // The orchestrator's `!creatorWallet` / `new PublicKey()` checks remain as
+  // defense-in-depth backstops.
+  it("refuses a course with NO creator wallet", async () => {
+    courses = [validCourse({ creatorWallet: null })];
+    await expectRefusedIntact(/missing required fields.*creatorWallet/i);
+  });
+
+  it("refuses an unparseable creator wallet", async () => {
+    courses = [validCourse({ creatorWallet: "not-a-real-pubkey!!!" })];
+    await expectRefusedIntact(/missing required fields.*creatorWallet/i);
+  });
+
+  // An off-curve PDA is valid base58 and passes the shape gate above — only the
+  // orchestrator's on-curve check stops it.
+  it("refuses an OFF-CURVE creator wallet (a PDA cannot own the reward ATA)", async () => {
+    const [offCurve] = PublicKey.findProgramAddressSync(
+      [Buffer.from("nope")],
+      getProgramId()
+    );
+    expect(PublicKey.isOnCurve(offCurve.toBytes())).toBe(false);
+    courses = [validCourse({ creatorWallet: offCurve.toBase58() })];
+    await expectRefusedIntact(/off-curve/i);
+  });
+
+  // The #427 guard, running for real (not a mock) inside pre-flight.
+  it("refuses a DENYLISTED creator (#427 guard) — the System program", async () => {
+    courses = [
+      validCourse({ creatorWallet: "11111111111111111111111111111111" }),
+    ];
+    await expectRefusedIntact(
+      /denylisted well-known address \(System program\)/i
+    );
+  });
+
+  it("refuses a DENYLISTED creator (#427 guard) — the Token-2022 program", async () => {
+    courses = [
+      validCourse({
+        creatorWallet: "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb",
+      }),
+    ];
+    await expectRefusedIntact(/denylisted well-known address/i);
+  });
+
+  // This is issue #440 itself: the live courses have creator == platform authority.
+  it("refuses creator == platform authority (#427 guard / the #440 bug)", async () => {
+    courses = [validCourse({ creatorWallet: AUTHORITY.toBase58() })];
+    await expectRefusedIntact(/equals the platform authority/i);
+  });
+
+  it("refuses when the course is missing required fields", async () => {
+    courses = [validCourse({ xpPerLesson: 0, lessonCount: 0 })];
+    await expectRefusedIntact(/missing required fields/i);
+  });
+
+  it("refuses a course absent from the content bundle", async () => {
+    courses = [];
+    await expectRefusedIntact(/not found in the content bundle/i);
+  });
+
+  it("refuses a draft id", async () => {
+    let thrown: RecreateCourseError | undefined;
+    try {
+      await recreateCourse("drafts.course-x");
+    } catch (e) {
+      thrown = e as RecreateCourseError;
+    }
+    expect(thrown!.phase).toBe("preflight");
+    expect(closeCoursePda).not.toHaveBeenCalled();
+  });
+
+  it("refuses when the admin signer is not configured", async () => {
+    authority = null;
+    await expectRefusedIntact(/Admin signer not configured/i);
+  });
+
+  it("refuses when the course is NOT deployed (nothing to recreate)", async () => {
+    accounts = new Map();
+    await expectRefusedIntact(/not deployed on-chain.*nothing to recreate/is);
+  });
+
+  it("refuses when the prerequisite course is not yet deployed", async () => {
+    courses = [
+      validCourse({
+        prerequisiteCourse: {
+          _id: "course-intro",
+          slug: "intro",
+          title: "Intro",
+        },
+      }),
+    ];
+    // Target exists on-chain; the prerequisite does not.
+    await expectRefusedIntact(/Prerequisite course "Intro" is not deployed/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// HAPPY PATH
+// ---------------------------------------------------------------------------
+describe("close → create happy path", () => {
+  it("closes, recreates, re-binds the collection, and persists a synced row IN THAT ORDER", async () => {
+    const result = await recreateCourse(COURSE_ID);
+
+    // The ordering IS the safety property: close strictly before create, and the
+    // DB row written only after the create landed.
+    expect(calls).toEqual(["close", "create", "bind", "db:synced"]);
+
+    expect(result.action).toBe("recreated");
+    expect(result.coursePda).toBe(coursePda(COURSE_ID));
+    expect(result.closeSignature).toBe("close-sig");
+    expect(result.createSignature).toBe("create-sig");
+    expect(result.createAttempts).toBe(1);
+  });
+
+  it("passes the content bundle's creator + create-only fields to create_course", async () => {
+    await recreateCourse(COURSE_ID);
+    expect(deployCoursePda).toHaveBeenCalledWith(
+      expect.objectContaining({
+        courseId: COURSE_ID,
+        creatorWallet: INSTRUCTOR,
+        difficulty: 1,
+        trackId: 1,
+        trackLevel: 1,
+        lessonCount: 5,
+        creatorRewardXp: 500,
+        minCompletionsForReward: 10,
+      })
+    );
+  });
+
+  it("REPORTS the counters the recreate destroys (they cannot be restored)", async () => {
+    const result = await recreateCourse(COURSE_ID);
+    expect(result.lostCounters).toEqual({
+      totalCompletions: 42,
+      totalEnrollments: 100,
+    });
+    // The reset re-opens finalize_course's bounded creator-reward window — the
+    // one anti-Sybil cap on creator XP. It must be surfaced, never silent.
+    expect(result.warnings.join(" ")).toMatch(
+      /total_completions was reset from 42 to 0.*RE-OPENS the bounded creator-reward window/is
+    );
+  });
+
+  it("re-binds the EXISTING collection rather than minting a new one", async () => {
+    await recreateCourse(COURSE_ID);
+    const { setCourseCollectionPda } =
+      await import("@/lib/solana/admin-signer");
+    expect(setCourseCollectionPda).toHaveBeenCalledWith(COURSE_ID, COLLECTION);
+  });
+
+  it("re-deactivates a course that was deactivated before the recreate", async () => {
+    // create_course forces is_active = true, which would silently un-hide it.
+    onChainCourse = { ...onChainCourse!, is_active: false };
+    const result = await recreateCourse(COURSE_ID);
+    expect(calls).toEqual([
+      "close",
+      "create",
+      "bind",
+      "deactivate",
+      "db:synced",
+    ]);
+    expect(result.warnings.join(" ")).not.toMatch(/currently LIVE/);
+  });
+
+  it("warns (but does not fail) when the collection re-bind fails", async () => {
+    bindResult = { success: false, error: "blockhash expired" } as never;
+    const result = await recreateCourse(COURSE_ID);
+    expect(result.action).toBe("recreated");
+    expect(result.warnings.join(" ")).toMatch(/Collection re-bind failed/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// THE DANGEROUS PATH: create fails AFTER the close landed.
+// ---------------------------------------------------------------------------
+describe("create fails after close — the course is DOWN", () => {
+  it("retries the create, then fails LOUD with an honest DB row and the recovery message", async () => {
+    vi.useFakeTimers();
+    createResults = [
+      { success: false, error: "blockhash not found" },
+      { success: false, error: "blockhash not found" },
+      { success: false, error: "node is behind" },
+      { success: false, error: "node is behind" },
+    ];
+
+    const promise = recreateCourse(COURSE_ID);
+    const captured = captureError(promise);
+    await vi.runAllTimersAsync();
+    const thrown = await captured;
+
+    expect(thrown).toBeInstanceOf(RecreateCourseError);
+    expect(thrown.phase).toBe("create");
+
+    // THE flag the caller must branch on: the course is NOT intact.
+    expect(thrown.courseIntact).toBe(false);
+
+    // It retried hard (4 attempts), then persisted the truth. Note the DB row is
+    // written AFTER the last failed create — and is `not_deployed`, never a stale
+    // `synced` claiming the course is fine.
+    expect(calls).toEqual([
+      "close",
+      "create",
+      "create",
+      "create",
+      "create",
+      "db:not_deployed",
+    ]);
+
+    // The error names the exact recovery path (the existing Deploy button works,
+    // because status is derived from the ABSENCE of the on-chain account).
+    expect(thrown.message).toMatch(
+      /currently NOT deployed on-chain; use Deploy to recreate it/i
+    );
+    // ...and states that learner progress survived, which is the whole premise.
+    expect(thrown.message).toMatch(
+      /Enrollments, learner progress and already-minted XP are intact/i
+    );
+    // ...and surfaces the close signature so the operator can audit the chain.
+    expect(thrown.message).toMatch(/close-sig/);
+    // ...and does not swallow the underlying cause.
+    expect(thrown.message).toMatch(/node is behind/);
+  });
+
+  it("succeeds on a later attempt without failing the operation", async () => {
+    vi.useFakeTimers();
+    createResults = [
+      { success: false, error: "blockhash not found" },
+      { success: true, signature: "create-sig-2" },
+    ];
+
+    const promise = recreateCourse(COURSE_ID);
+    const captured = promise.then((r) => r);
+    await vi.runAllTimersAsync();
+    const result = await captured;
+
+    expect(result.createAttempts).toBe(2);
+    expect(result.createSignature).toBe("create-sig-2");
+    expect(calls).toEqual(["close", "create", "create", "bind", "db:synced"]);
+  });
+
+  it("still throws the loud error when persisting not_deployed ALSO fails", async () => {
+    vi.useFakeTimers();
+    createResults = Array.from({ length: 4 }, () => ({
+      success: false,
+      error: "rpc down",
+    }));
+    dbThrows = true;
+
+    const promise = recreateCourse(COURSE_ID);
+    const captured = captureError(promise);
+    await vi.runAllTimersAsync();
+    const thrown = await captured;
+
+    // A failed DB write must NOT mask the fact that the course is down.
+    expect(thrown).toBeInstanceOf(RecreateCourseError);
+    expect(thrown.courseIntact).toBe(false);
+    expect(thrown.message).toMatch(/use Deploy to recreate it/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CLOSE fails: the course is still there, untouched.
+// ---------------------------------------------------------------------------
+describe("close fails", () => {
+  it("reports the course as INTACT and never attempts the create", async () => {
+    closeResult = { success: false, error: "Unauthorized" } as never;
+
+    let thrown: RecreateCourseError | undefined;
+    try {
+      await recreateCourse(COURSE_ID);
+    } catch (e) {
+      thrown = e as RecreateCourseError;
+    }
+
+    expect(thrown!.phase).toBe("close");
+    expect(thrown!.courseIntact).toBe(true);
+    expect(thrown!.message).toMatch(/UNCHANGED and still deployed/i);
+    expect(deployCoursePda).not.toHaveBeenCalled();
+    expect(calls).toEqual(["close"]);
+  });
+});

--- a/apps/web/src/lib/admin/recreate-course.ts
+++ b/apps/web/src/lib/admin/recreate-course.ts
@@ -1,0 +1,468 @@
+import "server-only";
+
+import { Connection, PublicKey } from "@solana/web3.js";
+import {
+  difficultyToNumber,
+  getMissingCourseFields,
+  isDraftId,
+} from "./sync-diff";
+import { serverEnv } from "@/lib/env.server";
+import { getAllCoursesAdmin } from "@/lib/content/queries";
+import { fetchCourse } from "@/lib/solana/academy-reads";
+import { findCoursePDA, getProgramId } from "@/lib/solana/pda";
+import {
+  assertCreatorAllowed,
+  closeCoursePda,
+  deployCoursePda,
+  getAuthorityPublicKey,
+  setCourseCollectionPda,
+  updateCoursePda,
+  type CreateCourseAdminParams,
+} from "@/lib/solana/admin-signer";
+import { writeCourseOnChainStatus } from "@/lib/content/deployment-writes";
+
+/**
+ * Close + recreate a Course PDA (issue #440).
+ *
+ * WHY THIS EXISTS. `Course.creator`, `difficulty`, `track_id`, `track_level` and
+ * `prerequisite` are written once by `create_course` and `UpdateCourseParams`
+ * has no field for any of them — they are CREATE-ONLY. When the content bundle
+ * disagrees with the chain on one of these, deploying would write the mutable
+ * fields and leave the immutable divergence in place forever, so the deploy
+ * screen blocks. Closing and recreating the PDA is the only real fix. Concretely:
+ * every live devnet course was deployed pre-#399 with `creator == platform
+ * authority`, so creator rewards route to a wallet no instructor controls.
+ *
+ * THE LOAD-BEARING CONSTRAINT. close + create CANNOT be atomic. A 0-lamport
+ * closed account is not garbage-collected until the transaction ends, so an
+ * `init` in the same tx fails — `create_course` must run in a LATER tx. There is
+ * therefore a WINDOW in which the Course PDA does not exist, and during it
+ * `enroll` / `complete_lesson` have no course account to read and revert. Every
+ * design choice below exists to bound that window:
+ *
+ *   1. PRE-FLIGHT EVERYTHING (`preflightRecreate`). The full create params are
+ *      resolved AND validated — including the #427 `assertCreatorAllowed`
+ *      denylist guard and the on-curve/parse checks — BEFORE the close is sent.
+ *      It must be impossible to close a course and only then discover the create
+ *      params were bad. This ordering IS the safety property; it is asserted
+ *      directly in the unit tests.
+ *   2. RETRY THE CREATE HARD. {@link CREATE_ATTEMPTS} attempts, each a fresh
+ *      `.rpc()` (Anchor fetches a new blockhash per call, so a retry is never a
+ *      resend of an expired tx).
+ *   3. FAIL LOUD, LEAVE IT RECOVERABLE. If the create still fails we do NOT
+ *      swallow it: the deployment row is written honestly as `not_deployed`
+ *      (never left as a stale `synced` claiming the course is fine) and the
+ *      thrown error names the exact recovery. Natural recovery already exists —
+ *      both the admin status route and the drift route derive `not_deployed`
+ *      from the ABSENCE of the on-chain account, so a course whose PDA is gone
+ *      shows a "Deploy" button that runs the ordinary create path.
+ *
+ * WHAT SURVIVES A RECREATE. Enrollment PDAs are seeded
+ * `["enrollment", course_id, learner]`, are never passed to `close_course`, and
+ * are physically untouched. Their stored `enrollment.course` is the Course PDA,
+ * derived from `course_id` alone — so recreating under the SAME course_id
+ * reproduces the IDENTICAL address and the `enrollment.course == course.key()`
+ * constraint in `complete_lesson` / `finalize_course` still holds. Learner
+ * lesson_flags, completed_at and already-minted XP all survive.
+ *
+ * WHAT DOES NOT. `create_course` hard-resets `total_completions` and
+ * `total_enrollments` to 0 and NO instruction can write them back. That reset
+ * re-opens the bounded creator-reward window in `finalize_course`
+ * (`total_completions >= min_completions_for_reward &&
+ * total_completions < min_completions_for_reward + 100`), which is the only
+ * anti-Sybil cap on creator XP — a course that already drained its window can
+ * pay the creator reward up to 100 more times as completions re-accumulate.
+ * We cannot prevent this on-chain, so we surface it: the pre-flight reads both
+ * counters off the live account and they are returned in
+ * {@link RecreateCourseResult.lostCounters} for the operator (and the follow-up
+ * confirmation UI) to see. `is_active` and `collection` are also reset, but
+ * those we CAN restore, and do — see {@link restoreAfterCreate}.
+ */
+
+/** Create attempts after the close has landed. */
+const CREATE_ATTEMPTS = 4;
+
+/** Backoff between create attempts (ms). */
+const CREATE_RETRY_DELAY_MS = 1_000;
+
+/** The phase a failure happened in — decides whether the course is still intact. */
+export type RecreatePhase = "preflight" | "close" | "create";
+
+/**
+ * A recreate failure.
+ *
+ * `courseIntact` is the field callers must branch on:
+ *   - `true`  → nothing was destroyed. Either the pre-flight refused (no on-chain
+ *     call was made at all) or the close itself failed, in which case the old
+ *     Course PDA is still there, unchanged. Safe to retry, safe to ignore.
+ *   - `false` → THE COURSE IS DOWN. The close landed and the create did not, so
+ *     the Course PDA does not exist. Enrollments and learner XP are intact, but
+ *     `enroll` / `complete_lesson` revert until the PDA is recreated.
+ *     {@link Error.message} carries the recovery instruction.
+ */
+export class RecreateCourseError extends Error {
+  constructor(
+    message: string,
+    readonly phase: RecreatePhase,
+    readonly courseIntact: boolean
+  ) {
+    super(message);
+    this.name = "RecreateCourseError";
+  }
+}
+
+/** On-chain course state captured BEFORE the close, so we can restore/report it. */
+interface PreCloseSnapshot {
+  /** Reset to 0 by create_course; unrecoverable. Re-opens the creator-reward window. */
+  totalCompletions: number;
+  /** Reset to 0 by create_course; unrecoverable. Never recovers (enroll uses `init`). */
+  totalEnrollments: number;
+  /** Reset to `true` by create_course; we restore it. */
+  isActive: boolean;
+  /** Reset to default by create_course; we re-BIND the existing one (never mint a new one). */
+  collection: string | null;
+}
+
+export interface RecreateCourseResult {
+  action: "recreated";
+  coursePda: string;
+  closeSignature: string;
+  createSignature: string;
+  /** How many create attempts it took (1 = landed first try). */
+  createAttempts: number;
+  /**
+   * On-chain counters destroyed by the recreate. NOT restorable — reported so the
+   * operator knows the creator-reward window has been re-opened.
+   */
+  lostCounters: { totalCompletions: number; totalEnrollments: number };
+  /** Non-fatal post-create problems (collection re-bind, is_active restore). */
+  warnings: string[];
+}
+
+/** Everything the create needs, fully resolved and validated. */
+export interface RecreatePlan {
+  courseId: string;
+  coursePda: PublicKey;
+  createParams: CreateCourseAdminParams;
+  snapshot: PreCloseSnapshot;
+}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+/**
+ * Normalize the raw-IDL BorshCoder's `collection` (snake_case fields; the pubkey
+ * comes back as base58 or raw bytes) to a base58 string, or `null` when it is
+ * unset (`Pubkey::default()` — the all-zero key).
+ */
+function normalizeCollection(raw: unknown): string | null {
+  if (raw == null) return null;
+  let base58: string;
+  try {
+    base58 =
+      typeof raw === "string"
+        ? raw
+        : new PublicKey(raw as Uint8Array).toBase58();
+  } catch {
+    return null;
+  }
+  return base58 === PublicKey.default.toBase58() ? null : base58;
+}
+
+/**
+ * PHASE 1 — resolve and validate EVERY create param against the content bundle
+ * and the live chain. Purely read-only: this function performs NO on-chain
+ * writes and MUST be called (and must succeed) before the close is sent.
+ *
+ * Throws {@link RecreateCourseError} with `phase: "preflight"`, `courseIntact:
+ * true` on any problem — a refusal here means the course was never touched.
+ */
+export async function preflightRecreate(
+  courseId: string,
+  connection: Connection,
+  allowUnusualCreator = false
+): Promise<RecreatePlan> {
+  const refuse = (message: string): never => {
+    throw new RecreateCourseError(message, "preflight", true);
+  };
+
+  if (isDraftId(courseId)) {
+    refuse("Cannot recreate a draft document");
+  }
+
+  // The signer must be loaded BEFORE we close anything — otherwise the create
+  // could not possibly succeed. Also gives us the authority for the #427 guard.
+  const authority = getAuthorityPublicKey();
+  if (!authority) {
+    refuse("Admin signer not configured (PROGRAM_AUTHORITY_SECRET missing)");
+  }
+
+  const courses = await getAllCoursesAdmin();
+  const course = courses.find((c) => c._id === courseId);
+  if (!course) {
+    refuse(`Course "${courseId}" not found in the content bundle`);
+  }
+
+  const missingFields = getMissingCourseFields(course!);
+  if (missingFields.length > 0) {
+    refuse(
+      `Course "${courseId}" is missing required fields: ${missingFields.join(", ")}`
+    );
+  }
+
+  // Creator: the entire reason this operation exists. Required, parseable and
+  // on-curve (Course.creator must own the reward ATA, so a PDA is invalid), and
+  // then run the #427 denylist guard — which also rejects creator == authority,
+  // i.e. exactly the bug (#440) we are here to fix. Doing this in PRE-FLIGHT is
+  // the point: deployCoursePda runs the same guard, but by the time it would
+  // fire the old PDA is already gone.
+  const creatorWallet = course!.creatorWallet ?? undefined;
+  if (!creatorWallet) {
+    refuse(
+      `Course "${courseId}" has no creator wallet — set course.instructor to an instructor with a wallet`
+    );
+  }
+  let creator: PublicKey;
+  try {
+    creator = new PublicKey(creatorWallet!);
+  } catch {
+    refuse(
+      `Instructor wallet "${creatorWallet}" is not a valid Solana address`
+    );
+  }
+  if (!PublicKey.isOnCurve(creator!.toBytes())) {
+    refuse(`Instructor wallet "${creatorWallet}" is off-curve`);
+  }
+  try {
+    assertCreatorAllowed(creator!, authority!, courseId, allowUnusualCreator);
+  } catch (e) {
+    refuse(e instanceof Error ? e.message : String(e));
+  }
+
+  // Prerequisite must already be on-chain, or the recreated course would carry a
+  // dangling prerequisite pubkey that `enroll` can never satisfy.
+  let prerequisitePda: string | undefined;
+  if (course!.prerequisiteCourse) {
+    const [prereqPda] = findCoursePDA(
+      course!.prerequisiteCourse._id,
+      getProgramId()
+    );
+    const prereqInfo = await connection.getAccountInfo(prereqPda);
+    if (!prereqInfo) {
+      refuse(
+        `Prerequisite course "${course!.prerequisiteCourse.title}" is not deployed on-chain`
+      );
+    }
+    prerequisitePda = prereqPda.toBase58();
+  }
+
+  // The course must currently EXIST on-chain — there is nothing to recreate
+  // otherwise, and closing a non-existent account is not a no-op we want to
+  // paper over. If it is already gone, the ordinary Deploy path is the right tool.
+  const [coursePda] = findCoursePDA(courseId, getProgramId());
+  const accountInfo = await connection.getAccountInfo(coursePda);
+  if (!accountInfo) {
+    refuse(
+      `Course "${courseId}" is not deployed on-chain — there is nothing to recreate. Use Deploy instead.`
+    );
+  }
+
+  // Snapshot the live account so we can restore is_active/collection after the
+  // create and report the counters the recreate will destroy. A stale/undecodable
+  // account is fine to close (close_course takes an UncheckedAccount and only
+  // checks the discriminator) — we just cannot snapshot it, so we degrade to
+  // defaults rather than refuse.
+  let snapshot: PreCloseSnapshot = {
+    totalCompletions: 0,
+    totalEnrollments: 0,
+    isActive: true,
+    collection: null,
+  };
+  try {
+    const onChain = await fetchCourse(courseId, connection, getProgramId());
+    if (onChain) {
+      snapshot = {
+        totalCompletions: Number(onChain.total_completions ?? 0),
+        totalEnrollments: Number(onChain.total_enrollments ?? 0),
+        isActive: onChain.is_active !== false,
+        collection: normalizeCollection(onChain.collection),
+      };
+    }
+  } catch {
+    // Undecodable (stale layout). Fall back to the content bundle's collection so
+    // we can still re-bind it, and leave the counters at 0 — they are already lost.
+    snapshot.collection = course!.trackCollectionAddress ?? null;
+  }
+  snapshot.collection ??= course!.trackCollectionAddress ?? null;
+
+  return {
+    courseId,
+    coursePda,
+    snapshot,
+    createParams: {
+      courseId,
+      lessonCount: course!.lessonCount,
+      difficulty: difficultyToNumber(course!.difficulty),
+      xpPerLesson: course!.xpPerLesson ?? 10,
+      trackId: course!.trackId ?? 0,
+      trackLevel: course!.trackLevel ?? 0,
+      prerequisitePda,
+      creatorWallet: creatorWallet!,
+      creatorRewardXp: course!.creatorRewardXp ?? 0,
+      minCompletionsForReward: course!.minCompletionsForReward ?? 0,
+      allowUnusualCreator,
+    },
+  };
+}
+
+/**
+ * PHASE 4 — best-effort restore of the two resettable fields, AFTER the create
+ * landed. Never throws: the course is already up and correct on the fields that
+ * matter, and both of these self-heal on the next ordinary sync (which re-binds
+ * an unbound collection). Problems come back as warnings.
+ */
+async function restoreAfterCreate(plan: RecreatePlan): Promise<string[]> {
+  const warnings: string[] = [];
+
+  // Re-BIND the collection that already exists. Never create a new one: credentials
+  // already minted point at the old collection address and would be orphaned.
+  if (plan.snapshot.collection) {
+    const bind = await setCourseCollectionPda(
+      plan.courseId,
+      plan.snapshot.collection
+    );
+    if (!bind.success) {
+      warnings.push(
+        `Collection re-bind failed: ${bind.error ?? "unknown error"}. Credential issuance reverts with CollectionMismatch until you re-sync.`
+      );
+    }
+  }
+
+  // create_course forces is_active = true, which would silently un-hide a course
+  // an admin had deliberately deactivated.
+  if (!plan.snapshot.isActive) {
+    const deactivate = await updateCoursePda({
+      courseId: plan.courseId,
+      newIsActive: false,
+    });
+    if (!deactivate.success) {
+      warnings.push(
+        `Course was deactivated before the recreate but could not be re-deactivated: ${deactivate.error ?? "unknown error"}. It is currently LIVE — re-deactivate it.`
+      );
+    }
+  }
+
+  return warnings;
+}
+
+/**
+ * Close and recreate a course's on-chain PDA. See the module docstring.
+ *
+ * @throws {RecreateCourseError} Always check `courseIntact` — `false` means the
+ * Course PDA is currently GONE and the course is broken until it is redeployed.
+ */
+export async function recreateCourse(
+  courseId: string,
+  allowUnusualCreator = false
+): Promise<RecreateCourseResult> {
+  const connection = new Connection(serverEnv.SOLANA_RPC_URL, "confirmed");
+
+  // 1. PRE-FLIGHT. Nothing below this line runs unless every create param is
+  //    resolved and valid. Throws with courseIntact: true.
+  const plan = await preflightRecreate(
+    courseId,
+    connection,
+    allowUnusualCreator
+  );
+
+  // 2. CLOSE. From here the course is DOWN until the create lands.
+  const closed = await closeCoursePda(courseId);
+  if (!closed.success) {
+    // The close never landed, so the old PDA is still there, untouched.
+    throw new RecreateCourseError(
+      `Failed to close course "${courseId}": ${closed.error ?? "unknown error"}. The course is UNCHANGED and still deployed — nothing was destroyed.`,
+      "close",
+      true
+    );
+  }
+
+  // 3. CREATE, hard. Each deployCoursePda call is a fresh `.rpc()`, and Anchor
+  //    fetches a new blockhash per call — so a retry is a genuinely new tx, not a
+  //    resend of an expired one.
+  let createSignature: string | undefined;
+  let createAttempts = 0;
+  let lastError = "unknown error";
+
+  for (let attempt = 1; attempt <= CREATE_ATTEMPTS; attempt++) {
+    createAttempts = attempt;
+    const created = await deployCoursePda(plan.createParams);
+    if (created.success && created.signature) {
+      createSignature = created.signature;
+      break;
+    }
+    lastError = created.error ?? "unknown error";
+    console.error(
+      `[recreate-course] ${courseId}: create attempt ${attempt}/${CREATE_ATTEMPTS} failed: ${lastError}`
+    );
+    if (attempt < CREATE_ATTEMPTS) await sleep(CREATE_RETRY_DELAY_MS);
+  }
+
+  if (!createSignature) {
+    // LOUD FAILURE. The close landed, every create attempt failed: the Course PDA
+    // is gone. Persist that HONESTLY — leaving a stale `synced` row would have the
+    // admin panel claim the course is fine while every enroll/complete_lesson
+    // reverts. `not_deployed` is exactly what the status + drift routes already
+    // derive from a missing account, so the panel will offer the Deploy button
+    // that recreates it.
+    try {
+      await writeCourseOnChainStatus(
+        courseId,
+        "not_deployed",
+        plan.coursePda.toBase58(),
+        closed.signature!
+      );
+    } catch (dbErr) {
+      console.error(
+        `[recreate-course] ${courseId}: FAILED to persist not_deployed status:`,
+        dbErr
+      );
+    }
+    throw new RecreateCourseError(
+      `Course "${courseId}" was closed but could NOT be recreated after ${CREATE_ATTEMPTS} attempts (last error: ${lastError}). ` +
+        `The course is currently NOT deployed on-chain; use Deploy to recreate it. ` +
+        `Enrollments, learner progress and already-minted XP are intact, but enroll/complete_lesson will fail until the Course PDA exists again. ` +
+        `Close signature: ${closed.signature}`,
+      "create",
+      false
+    );
+  }
+
+  // 4. RESTORE the fields create_course reset. Non-fatal.
+  const warnings = await restoreAfterCreate(plan);
+
+  if (plan.snapshot.totalCompletions > 0) {
+    warnings.push(
+      `total_completions was reset from ${plan.snapshot.totalCompletions} to 0 and cannot be restored. This RE-OPENS the bounded creator-reward window in finalize_course — the new creator can earn the reward for up to 100 further completions.`
+    );
+  }
+
+  // 5. PERSIST, exactly as the deploy path does.
+  await writeCourseOnChainStatus(
+    courseId,
+    "synced",
+    plan.coursePda.toBase58(),
+    createSignature
+  );
+
+  return {
+    action: "recreated",
+    coursePda: plan.coursePda.toBase58(),
+    closeSignature: closed.signature!,
+    createSignature,
+    createAttempts,
+    lostCounters: {
+      totalCompletions: plan.snapshot.totalCompletions,
+      totalEnrollments: plan.snapshot.totalEnrollments,
+    },
+    warnings,
+  };
+}

--- a/apps/web/src/lib/solana/admin-signer.ts
+++ b/apps/web/src/lib/solana/admin-signer.ts
@@ -49,6 +49,7 @@ interface MethodBuilder {
 interface AdminMethods {
   createCourse(params: CreateCourseOnChainParams): MethodBuilder;
   updateCourse(params: UpdateCourseOnChainParams): MethodBuilder;
+  closeCourse(courseId: string): MethodBuilder;
   createAchievementType(
     params: CreateAchievementTypeOnChainParams
   ): MethodBuilder;
@@ -274,6 +275,21 @@ function initialize(): { ready: boolean } {
 export function isAdminSignerReady(): boolean {
   const { ready } = initialize();
   return ready;
+}
+
+/**
+ * The loaded platform-authority pubkey, or `null` when the signer is not
+ * configured.
+ *
+ * Exposed so a caller can run {@link assertCreatorAllowed} — which needs the
+ * authority to reject `creator == authority` — during a PRE-FLIGHT phase,
+ * BEFORE it takes any destructive on-chain action. `deployCoursePda` runs the
+ * same guard internally as a backstop, but that is far too late for the
+ * recreate flow: by then the old Course PDA is already closed.
+ */
+export function getAuthorityPublicKey(): PublicKey | null {
+  const { ready } = initialize();
+  return ready && _authority ? _authority.publicKey : null;
 }
 
 // ---------------------------------------------------------------------------
@@ -534,6 +550,70 @@ export async function updateCoursePda(
     console.error(
       `[admin-signer] updateCoursePda(${params.courseId}): ${message}`
     );
+    return { success: false, error: message };
+  }
+}
+
+/**
+ * DESTRUCTIVE. Close a Course PDA: drains its lamports to the authority, zeroes
+ * its data and hands the address back to the System Program.
+ *
+ * The ONLY caller is the recreate orchestrator (`lib/admin/recreate-course.ts`),
+ * which exists to rewrite the create-only fields (`creator`, `difficulty`,
+ * `trackId`, `trackLevel`, `prerequisite`) that `update_course` cannot touch.
+ * Do not call this on its own: `create_course` CANNOT run in the same
+ * transaction (a 0-lamport account is not garbage-collected until the tx ends,
+ * so the `init` fails), so between this call and a successful `deployCoursePda`
+ * the Course PDA DOES NOT EXIST and `enroll` / `complete_lesson` have no account
+ * to read. See the orchestrator for the pre-flight + retry that bound that window.
+ *
+ * What survives (verified against the program, not just its doc comment):
+ *   - Enrollment PDAs are seeded `["enrollment", course_id, learner]` and are
+ *     never passed to `close_course` — they are physically untouched. Their
+ *     stored `enrollment.course` is the Course PDA, which is derived from
+ *     `course_id` alone, so recreating under the SAME course_id reproduces the
+ *     IDENTICAL address and the `enrollment.course == course.key()` constraint
+ *     in `complete_lesson` / `finalize_course` still holds. Learner lesson_flags,
+ *     completed_at and already-minted XP all survive.
+ *
+ * What does NOT survive (`create_course` hard-resets these — no instruction can
+ * restore them):
+ *   - `total_completions` / `total_enrollments` → 0. This RE-OPENS the bounded
+ *     creator-reward window in `finalize_course`, which is the only anti-Sybil
+ *     cap on creator XP. The orchestrator reads and reports both counters.
+ *   - `is_active` → true, `collection` → default, `content_tx_id` → zeroes.
+ *     The orchestrator restores the first two; a re-sync restores the third.
+ */
+export async function closeCoursePda(
+  courseId: string
+): Promise<AdminSignerResult> {
+  const { ready } = initialize();
+  if (!ready || !_program || !_authority) {
+    return {
+      success: false,
+      error: "Admin signer not configured (PROGRAM_AUTHORITY_SECRET missing)",
+    };
+  }
+
+  try {
+    const [configPDA] = findConfigPDA(getProgramId());
+    const [coursePDA] = findCoursePDA(courseId, getProgramId());
+
+    const methods = _program.methods as unknown as AdminMethods;
+
+    const signature = await methods
+      .closeCourse(courseId)
+      .accountsPartial({
+        config: configPDA,
+        course: coursePDA,
+        authority: _authority.publicKey,
+      })
+      .rpc();
+
+    return { success: true, signature };
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(`[admin-signer] closeCoursePda(${courseId}): ${message}`);
     return { success: false, error: message };
   }
 }


### PR DESCRIPTION
**Stacked on #430.** 🔴 **SENSITIVE — this destroys an on-chain account.** Deliberately ships **no UI**: the route exists but nothing can reach it. See the gate at the bottom.

## Why
`creator`, `difficulty`, `trackId`, `trackLevel`, `prerequisite` are create-only — `UpdateCourseParams` cannot write them. When the bundle disagrees, the deploy screen blocks, and the *only* real fix is close + recreate. All 6 live devnet courses have `creator == platform authority` (#440), so creator rewards route to the wrong wallet.

## The load-bearing constraint
**Close and create cannot be atomic.** A closed 0-lamport account is not garbage-collected until the tx ends, so `init` in the same tx fails — which is why the program comment says create happens *"in a later tx"*. There is a window where the Course PDA does not exist, and `enroll` / `complete_lesson` revert during it. If the create fails, the course stays down until retried.

So the orchestrator: **pre-flights everything before it closes anything** (resolves + validates all create params, including running the real #427 creator guard), retries the create hard, and on failure writes an honest `not_deployed` row and returns the exact recovery instruction. **Recovery is natural** — `not_deployed` is derived from the *absence of the account*, not the DB, so the ordinary Deploy button recreates it.

## 🔴 What this work uncovered — read before you ever wire a button

**#450 — a recreate re-opens the anti-Sybil creator-reward window.** `create_course` resets `total_completions = 0`; `finalize_course` gates the creator reward on `[min_completions, min_completions + 100)`; **nothing can write the counter back**. The program says plainly why the window exists: *"unbounded and Sybil-farmable"*. So a course that already paid its full cap can pay **100 more** — and it bites precisely in the #440 case, handing a freshly-installed creator a refreshed reward window. The orchestrator snapshots the counters (`lostCounters`) and warns, but **cannot restore them on-chain**.

**Two silent resets found and fixed:** `create_course` also resets `is_active → true` (would un-hide a deactivated course) and `collection → default` (would break credential issuance with `CollectionMismatch` and orphan minted credentials). The orchestrator **re-binds the existing collection** rather than minting a new one.

**#449 facet:** post-v2, a recreate rebuilds the course **dense** via `Course::dense_mask(lesson_count)` — **re-activating retired lesson slots**.

## Enrollments-survive verdict: TRUE (with the reason the comment omits)
`CloseCourse` touches only `config`/`course`/`authority` — enrollment PDAs are physically untouched. The bit nobody states: `complete_lesson`/`finalize_course` constrain `enrollment.course == course.key()`, and the Course PDA derives from `course_id` **alone** — so recreating at the same id reproduces the identical address and the constraint still passes. Had the seeds included anything mutable, this feature would be silently broken.

## Tests: 32 new, suite 577/577 green
Every effect appends to a **call-order log**, so the tests assert the exact sequence — *the ordering is the safety property*. Happy path: `[close, create, bind, db:synced]`. Post-close create failure: `[close, create×4, db:not_deployed]` with `courseIntact:false`. **Eleven pre-flight refusals each assert `closeCoursePda` was NEVER called** — including against the real #427 denylist (via `importOriginal`, not a mock). Route: 401 on missing auth, 400 on `confirm` mismatch, both with zero on-chain calls. **No cluster was ever contacted.**

## ⛔ Gate — do not merge a button on top of this until #450 is answered
The UI must **force** the operator to re-close the reward window (`creator_reward_xp = 0`, or raise `min_completions_for_reward` — both `update_course`-writable), not surface a warning people learn to click past. On devnet the hazard is ~zero; on mainnet it is a live exploit vector.

Also outstanding for mainnet: this ships **before** the Squads custody handoff, so `PROGRAM_AUTHORITY_SECRET` compromise now means *"delete any course"*, not just *"update fields"*.