### PR TITLE
fix(lesson): restore wide editor-dominant layout for challenge lessons

### DIFF
--- a/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/blocks/code-block.tsx
+++ b/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/blocks/code-block.tsx
@@ -23,30 +23,39 @@ export function CodeBlock({ block, ctx }: BlockRenderProps) {
   const b = block as CodeBlockData;
   const t = useTranslations("lesson");
 
+  const hasTests = !!(b.tests && b.tests.length > 0);
+  // The rail carries the lesson instructions (threaded from lesson-client) above
+  // the test cases, so the description sits beside the editor instead of stacked
+  // full-width on top of it.
   const taskSlot =
-    b.tests && b.tests.length > 0 ? (
-      <div className="space-y-3 p-4 sm:p-5">
-        <h4 className="text-xs font-semibold uppercase text-text-3">
-          {t("testCases")}
-        </h4>
-        <div className="space-y-1.5">
-          {b.tests.map((tc) => (
-            <div
-              key={tc.id}
-              className="rounded-md border border-border p-2 text-xs [background:var(--input)]"
-            >
-              <span className="font-medium">{tc.description}</span>
-              <div className="mt-1 flex gap-4 font-mono text-text-3">
-                <span>
-                  {t("input")}: <code>{tc.input}</code>
-                </span>
-                <span>
-                  {t("expected")}: <code>{tc.expectedOutput}</code>
-                </span>
-              </div>
+    ctx.instructionsSlot || hasTests ? (
+      <div className="space-y-5 p-4 sm:p-5">
+        {ctx.instructionsSlot}
+        {hasTests && (
+          <div className="space-y-3">
+            <h4 className="text-xs font-semibold uppercase text-text-3">
+              {t("testCases")}
+            </h4>
+            <div className="space-y-1.5">
+              {b.tests!.map((tc) => (
+                <div
+                  key={tc.id}
+                  className="rounded-md border border-border p-2 text-xs [background:var(--input)]"
+                >
+                  <span className="font-medium">{tc.description}</span>
+                  <div className="mt-1 flex gap-4 font-mono text-text-3">
+                    <span>
+                      {t("input")}: <code>{tc.input}</code>
+                    </span>
+                    <span>
+                      {t("expected")}: <code>{tc.expectedOutput}</code>
+                    </span>
+                  </div>
+                </div>
+              ))}
             </div>
-          ))}
-        </div>
+          </div>
+        )}
       </div>
     ) : undefined;
 

--- a/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/blocks/types.ts
+++ b/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/blocks/types.ts
@@ -1,4 +1,4 @@
-import type { JSX } from "react";
+import type { JSX, ReactNode } from "react";
 import type { Lesson, LessonBlock } from "@superteam-lms/types";
 
 /**
@@ -24,6 +24,13 @@ export interface BlockContext {
   programKeypairSecret: number[] | null;
   /** Clear the current build (deploy panel `onBuildExpired`). */
   resetBuild: () => void;
+  /**
+   * Challenge lessons only: the non-code "instructions" blocks (prose, etc.),
+   * pre-rendered by `lesson-client` and threaded into the code block so the
+   * description renders inside the IDE's side rail alongside the test cases,
+   * rather than stacked full-width above a squeezed editor.
+   */
+  instructionsSlot?: ReactNode;
 }
 
 export interface BlockRenderProps {

--- a/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/lesson-client.tsx
+++ b/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/lesson-client.tsx
@@ -266,8 +266,28 @@ export function LessonPageClient({
     ]
   );
 
+  // Challenge lessons get a wide, editor-dominant layout: the non-code blocks
+  // (the description/instructions) render inside the IDE's side rail next to the
+  // test cases, and only the code block(s) occupy the main area — restoring the
+  // dedicated coding-challenge experience the unified block renderer flattened.
+  const instructionBlocks = lesson.blocks.filter((b) => b._type !== "code");
+  const codeBlocks = lesson.blocks.filter((b) => b._type === "code");
+  const instructionsSlot = hasCodeBlock ? (
+    <div className="space-y-6">
+      {instructionBlocks.map((block) => {
+        const Renderer = RENDERERS[block._type];
+        return <Renderer key={block.key} block={block} ctx={ctx} />;
+      })}
+    </div>
+  ) : null;
+  const codeCtx: BlockContext = { ...ctx, instructionsSlot };
+
   return (
-    <div className="mx-auto max-w-3xl space-y-6">
+    <div
+      className={`mx-auto space-y-6 ${
+        hasCodeBlock ? "max-w-[1600px] px-1 sm:px-2" : "max-w-3xl"
+      }`}
+    >
       {/* Lesson top bar */}
       <div className="flex flex-wrap items-center gap-2 border-b border-border pb-4 sm:gap-3">
         <Link
@@ -298,13 +318,23 @@ export function LessonPageClient({
         </div>
       </div>
 
-      {/* Blocks */}
-      <div className="space-y-6">
-        {lesson.blocks.map((block) => {
-          const Renderer = RENDERERS[block._type];
-          return <Renderer key={block.key} block={block} ctx={ctx} />;
-        })}
-      </div>
+      {/* Blocks — challenges render only the code block(s) here (the wide IDE);
+          the instructions ride in the IDE rail via ctx.instructionsSlot. */}
+      {hasCodeBlock ? (
+        <div className="space-y-4">
+          {codeBlocks.map((block) => {
+            const Renderer = RENDERERS[block._type];
+            return <Renderer key={block.key} block={block} ctx={codeCtx} />;
+          })}
+        </div>
+      ) : (
+        <div className="space-y-6">
+          {lesson.blocks.map((block) => {
+            const Renderer = RENDERERS[block._type];
+            return <Renderer key={block.key} block={block} ctx={ctx} />;
+          })}
+        </div>
+      )}
 
       {/* Completion + navigation */}
       <div className="space-y-2">


### PR DESCRIPTION
## The regression
The CS-5 blocks[] migration (#384) put **every** lesson through one `max-w-3xl` (768px) reading column. Challenge lessons — which have a full-screen IDE (#346: resizable editor | test-cases + AI rail) — got crushed into 768px, and their description was split into a **full-width prose block stacked above** the editor. Result: duplicated title, tiny Monaco, text in the wrong place.

## The fix (3 files, layout only)
- `blocks/types.ts` — `BlockContext` can carry an optional `instructionsSlot`.
- `lesson-client.tsx` — challenge lessons (any `code` block) render in a wide `max-w-[1600px]` container; only the code block renders in the main area; the non-code blocks are pre-rendered and threaded into the IDE rail.
- `blocks/code-block.tsx` — renders `ctx.instructionsSlot` in the rail **above** the test cases.
- Reading lessons (prose/quiz/video) unchanged — still the centered column.

## Verify
Open the Vercel preview → any challenge lesson (e.g. anchor-framework → anchor-accounts-challenge): big editor, description beside the tests in the rail, no duplicate title. typecheck clean.

SAFE-lane, frontend-only.