### PR TITLE
fix(ai): drop unsupported Gemini schema keywords causing AI 502 (#463)

### DIFF
--- a/apps/web/src/app/api/ai/partner/route.ts
+++ b/apps/web/src/app/api/ai/partner/route.ts
@@ -285,8 +285,11 @@ export async function POST(request: NextRequest) {
       // here) but Gemini never ran — refund so a failed call doesn't burn
       // one of the user's 4 paid assists.
       await refundAssist(user.id, lesson._id);
+      // Surface the upstream status (not Gemini's raw body) so a config-side
+      // failure (403 API-not-enabled / key-restricted, 404 model, 429 quota)
+      // is diagnosable from the Network tab, not just the server logs.
       return NextResponse.json(
-        { error: "AI service unavailable" },
+        { error: "AI service unavailable", upstreamStatus: response.status },
         { status: 502 }
       );
     }

--- a/apps/web/src/lib/ai/partner-prompt.ts
+++ b/apps/web/src/lib/ai/partner-prompt.ts
@@ -137,8 +137,9 @@ export const GEMINI_RESPONSE_SCHEMA = {
         },
         correctIndex: {
           type: "integer",
-          minimum: 0,
-          maximum: 2,
+          // NOTE: no `minimum`/`maximum` — Gemini's structured-output schema
+          // dialect rejects those numeric-constraint keywords with a 400. The
+          // 0–2 range is enforced at runtime in `validatePartnerResponse`.
           description: "Index (0-2) of the single correct option.",
         },
         explanation: {


### PR DESCRIPTION
## Fixes #463 — AI assistant returns 502

## Cause
`/api/ai/partner` wraps **any** non-2xx Gemini response into a generic `502`. The most likely trigger is the request `responseSchema`, which set **`minimum`/`maximum` on `correctIndex`** — numeric-constraint keywords that Gemini's structured-output schema dialect rejects with `400 INVALID_ARGUMENT`.

## Fix
- **Remove `minimum`/`maximum`** from the Gemini `responseSchema`. They're redundant: `validatePartnerResponse` already enforces `correctIndex ∈ {0,1,2}` and exactly 3 options at runtime, so output validity is unchanged.
- **Surface `upstreamStatus`** in the 502 body (just the HTTP status, not Gemini's raw text) so a *config-side* failure is diagnosable from the Network tab:
  - `403` → Generative Language API not enabled on the key's project, or the key is IP/referrer-restricted
  - `404` → model/region unavailable for the key
  - `429` → free-tier quota/rate limit

## Verification
- eslint ✓ on both files; `tsc` doesn't flag them (unrelated workspace module errors pre-exist locally). Runtime validation unchanged, so malformed AI payloads are still rejected.

## After deploy
Retry the assistant. If it **still 502s**, the Network-tab response now shows `upstreamStatus` — paste it (or the `Gemini partner API error:` log line) and it's a config/quota fix, not code.
