### PR TITLE
fix(ai): raise AI partner output token caps (propose/ask 502)

### DIFF
--- a/apps/web/src/lib/ai/__tests__/partner-prompt.test.ts
+++ b/apps/web/src/lib/ai/__tests__/partner-prompt.test.ts
@@ -58,8 +58,12 @@ describe("partner-prompt", () => {
     expect(buildStaticPrefix(ctx)).not.toContain("let x = 1;");
   });
 
-  it("token caps are tight per intent", () => {
-    expect(maxTokensFor("hint")).toBeLessThanOrEqual(160);
-    expect(maxTokensFor("propose")).toBeLessThanOrEqual(500);
+  it("token caps grow with intent and stay within the model ceiling", () => {
+    // Ordered by how much output each intent needs — hint (a sentence) <
+    // ask (a full answer) < propose (the entire updated file + a 3-option
+    // check) — and every cap fits Flash-Lite's 8192-token output ceiling.
+    expect(maxTokensFor("hint")).toBeLessThan(maxTokensFor("ask"));
+    expect(maxTokensFor("ask")).toBeLessThan(maxTokensFor("propose"));
+    expect(maxTokensFor("propose")).toBeLessThanOrEqual(8192);
   });
 });

--- a/apps/web/src/lib/ai/partner-prompt.ts
+++ b/apps/web/src/lib/ai/partner-prompt.ts
@@ -84,13 +84,17 @@ export function buildDynamicSuffix(req: PartnerRequest): string {
   return sections.join("\n\n");
 }
 
+// Per-intent output token cap. These must comfortably fit the JSON payload the
+// model produces for that intent — if the response hits the cap mid-generation,
+// the JSON is truncated and JSON.parse fails (surfacing as a 502). `hint` is a
+// short sentence, but `ask` returns a full answer and `propose` returns the
+// ENTIRE updated file plus a 3-option check, so those need real headroom.
 const MAX_TOKENS: Record<PartnerAction, number> = {
-  hint: 160,
-  ask: 240,
-  propose: 500,
+  hint: 256,
+  ask: 1536,
+  propose: 4096,
 };
 
-/** Tight, per-intent output token cap — not a flat 1024. */
 export function maxTokensFor(action: PartnerAction): number {
   return MAX_TOKENS[action];
 }


### PR DESCRIPTION
## Follow-up to #464 — the actual fix for the propose/ask 502

#464 merged the schema cleanup + `upstreamStatus` surfacing, but testing showed the real cause: **`hint` works, `propose` and `ask` 502.**

## Cause
The per-intent `maxOutputTokens` were too low:

| action | old cap | result |
| --- | --- | --- |
| `hint` | 160 | short sentence → fits → **works** |
| `ask` | 240 | full answer → overflows → truncated JSON → **502** |
| `propose` | 500 | *entire updated file* + 3-option check → way over → **502** |

When Gemini hits the cap mid-generation it truncates the JSON, so `JSON.parse` throws and the route returns its "invalid response" 502. `hint`'s short output fit in 160 — which is exactly why only it worked.

## Fix
Raise the caps to **hint 256 / ask 1536 / propose 4096** (Flash-Lite max output is 8192, so ample headroom).

## Verification
- eslint ✓. Runtime validation unchanged.
- After deploy: **propose fix** and **ask a question** return full responses.

Refs #463.
