### PR TITLE
fix(ai): use gemini-2.5-flash (flash-lite is 404 for new keys)

### DIFF
--- a/apps/web/src/app/api/ai/partner/route.ts
+++ b/apps/web/src/app/api/ai/partner/route.ts
@@ -27,8 +27,11 @@ const MAX_MESSAGE_CHARS = 4_000;
 const MAX_SLUG_CHARS = 256;
 const MAX_TEST_SUMMARY_CHARS = 2_000;
 
+// gemini-2.5-flash-lite is no longer available to new API keys (404
+// "no longer available to new users"). Use the GA flagship flash model, which
+// is available to new keys and supports structured output (responseSchema).
 const GEMINI_URL =
-  "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-lite:generateContent";
+  "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent";
 
 const VALID_ACTIONS: readonly PartnerAction[] = ["hint", "propose", "ask"];
 


### PR DESCRIPTION
## Root cause (from the Vercel log)
```
Gemini partner API error: 404
"This model models/gemini-2.5-flash-lite is no longer available to new users.
 Please update your code to use a newer model…"
```
The route hardcoded **`gemini-2.5-flash-lite`**, which Google has **gated to existing users only**. Since the new Superteam key is a *new* key, every `propose`/`ask` call 404s → the route's generic 502. (`hint` never hit this — it serves 2 authored hints client-side, which is why it "worked".)

## Fix
Switch the model to **`gemini-2.5-flash`** (GA flagship flash) — available to new keys and supports structured output (`responseSchema`), which this route requires.

## Relationship to #465
- **This PR** = the actual unblock (the model was returning 404).
- **#465** = raises `maxOutputTokens` so responses don't truncate *once the model responds*.
Both should land for a fully working assistant.

## Verification
- eslint ✓. After deploy, `propose`/`ask` return real AI responses.
- To confirm a model is callable on a given key: `curl "https://generativelanguage.googleapis.com/v1beta/models?key=<KEY>"` lists available models.

Fixes the 502 in #463.
