### PR TITLE
feat(program): WS-1 Phase 0 — v-next program (drop min_completions, flat uncapped creator reward)

### DIFF
--- a/onchain-academy/programs/onchain-academy/src/instructions/create_course.rs
+++ b/onchain-academy/programs/onchain-academy/src/instructions/create_course.rs
@@ -16,7 +16,6 @@ pub struct CreateCourseParams {
     pub track_level: u8,
     pub prerequisite: Option<Pubkey>,
     pub creator_reward_xp: u32,
-    pub min_completions_for_reward: u16,
     /// Metaplex Core collection for credential NFTs. `None` defers to a later
     /// `update_course` (the per-course collection is created after the PDA).
     pub collection: Option<Pubkey>,
@@ -50,7 +49,6 @@ pub fn handler(ctx: Context<CreateCourse>, params: CreateCourseParams) -> Result
     course.track_level = params.track_level;
     course.prerequisite = params.prerequisite;
     course.creator_reward_xp = params.creator_reward_xp;
-    course.min_completions_for_reward = params.min_completions_for_reward;
     course.total_completions = 0;
     course.total_enrollments = 0;
     course.is_active = true;

--- a/onchain-academy/programs/onchain-academy/src/instructions/finalize_course.rs
+++ b/onchain-academy/programs/onchain-academy/src/instructions/finalize_course.rs
@@ -73,22 +73,8 @@ pub fn handler(ctx: Context<FinalizeCourse>) -> Result<()> {
         )?;
     }
 
-    // Mint creator reward, but only for a bounded WINDOW of completions past the
-    // popularity threshold — [min_completions, min_completions + WINDOW). The
-    // per-completion drip was otherwise unbounded and Sybil-farmable once a
-    // course crossed its threshold. This reuses the existing `total_completions`
-    // counter (no new per-course state, no migration): live courses are bounded
-    // on their next finalize automatically. Total creator XP per course is thus
-    // capped at WINDOW * creator_reward_xp.
-    const CREATOR_REWARD_WINDOW: u32 = 100;
-    let reward_end =
-        (course.min_completions_for_reward as u32).saturating_add(CREATOR_REWARD_WINDOW);
-
     let mut creator_xp: u32 = 0;
-    if course.total_completions >= course.min_completions_for_reward as u32
-        && course.total_completions < reward_end
-        && course.creator_reward_xp > 0
-    {
+    if course.creator_reward_xp > 0 {
         require!(
             course.creator_reward_xp as u64 <= utils::MAX_XP_PER_MINT,
             AcademyError::XpAmountExceedsMax

--- a/onchain-academy/programs/onchain-academy/src/instructions/update_course.rs
+++ b/onchain-academy/programs/onchain-academy/src/instructions/update_course.rs
@@ -10,7 +10,6 @@ pub struct UpdateCourseParams {
     pub new_is_active: Option<bool>,
     pub new_xp_per_lesson: Option<u32>,
     pub new_creator_reward_xp: Option<u32>,
-    pub new_min_completions_for_reward: Option<u16>,
     /// Set/backfill the Metaplex Core credential collection for this course.
     pub new_collection: Option<Pubkey>,
     /// Replace the 256-bit live-lesson mask. Add, remove, reorder and replace
@@ -45,10 +44,6 @@ pub fn handler(ctx: Context<UpdateCourse>, params: UpdateCourseParams) -> Result
 
     if let Some(creator_reward_xp) = params.new_creator_reward_xp {
         course.creator_reward_xp = creator_reward_xp;
-    }
-
-    if let Some(min_completions) = params.new_min_completions_for_reward {
-        course.min_completions_for_reward = min_completions;
     }
 
     if let Some(active_lessons) = params.new_active_lessons {

--- a/onchain-academy/programs/onchain-academy/src/state/course.rs
+++ b/onchain-academy/programs/onchain-academy/src/state/course.rs
@@ -20,8 +20,8 @@ pub struct Course {
     pub track_id: u16,
     pub track_level: u8,
     pub prerequisite: Option<Pubkey>,
+    /// Flat XP to the creator per completion; intentionally uncapped on chain.
     pub creator_reward_xp: u32,
-    pub min_completions_for_reward: u16,
     pub total_completions: u32,
     pub total_enrollments: u32,
     pub is_active: bool,
@@ -35,12 +35,9 @@ pub struct Course {
 }
 
 impl Course {
-    // SIZE grew 224 -> 255 in v2 (CS-3): `lesson_count` (u8, -1) was deleted and
-    // `active_lessons: [u64; 4]` (+32) added; `_reserved: [u8; 8]` is preserved
-    // (the "reserved bytes on every account" convention is kept, not consumed).
-    // Old 224-byte Course accounts no longer deserialize, so EVERY instruction
-    // that resolves `course: Account<Course>` fails until the account is recreated
-    // via close_course + create_course. That recreation is CS-4's execution.
+    // SIZE = 253. The client decoder dispatches on account length, so this must
+    // not drift to 255 (the never-deployed v2 layout) — do not grow _reserved to
+    // reclaim the 2 bytes freed by dropping min_completions_for_reward.
     // 8 (discriminator)
     // + (4 + 32) (course_id)
     // + 32 (creator)
@@ -53,7 +50,6 @@ impl Course {
     // + 1 (track_level)
     // + (1 + 32) (prerequisite)
     // + 4 (creator_reward_xp)
-    // + 2 (min_completions_for_reward)
     // + 4 (total_completions)
     // + 4 (total_enrollments)
     // + 1 (is_active)
@@ -74,7 +70,6 @@ impl Course {
         + 1
         + (1 + 32)
         + 4
-        + 2
         + 4
         + 4
         + 1
@@ -82,7 +77,7 @@ impl Course {
         + 8
         + 32
         + 8
-        + 1; // 255
+        + 1; // 253
 
     /// True if `slot` is a live lesson slot (its bit is set in `active_lessons`).
     /// `slot: u8` spans 0..=255, so every value maps to a valid word/bit of the

--- a/onchain-academy/programs/onchain-academy/src/state/course.rs
+++ b/onchain-academy/programs/onchain-academy/src/state/course.rs
@@ -20,7 +20,8 @@ pub struct Course {
     pub track_id: u16,
     pub track_level: u8,
     pub prerequisite: Option<Pubkey>,
-    /// Flat XP to the creator per completion; intentionally uncapped on chain.
+    /// XP minted to the creator on every completion; no completion-count
+    /// threshold or window (still bounded per mint by MAX_XP_PER_MINT).
     pub creator_reward_xp: u32,
     pub total_completions: u32,
     pub total_enrollments: u32,

--- a/onchain-academy/scripts/create-mock-course.ts
+++ b/onchain-academy/scripts/create-mock-course.ts
@@ -34,7 +34,7 @@ async function main() {
       trackLevel: 1,
       prerequisite: null,
       creatorRewardXp: 50,
-      minCompletionsForReward: 10,
+      collection: null,
     })
     .accountsStrict({
       config: configPda,

--- a/onchain-academy/scripts/fetch-course.ts
+++ b/onchain-academy/scripts/fetch-course.ts
@@ -1,6 +1,7 @@
 import * as anchor from "@coral-xyz/anchor";
 import { Program } from "@coral-xyz/anchor";
 import { OnchainAcademy } from "../target/types/onchain_academy";
+import { BN } from "@coral-xyz/anchor";
 import { PublicKey } from "@solana/web3.js";
 
 const provider = anchor.AnchorProvider.env();
@@ -14,6 +15,16 @@ const [coursePda] = PublicKey.findProgramAddressSync(
   program.programId
 );
 
+// CS-3: `active_lessons` ([u64; 4] / BN[4] in the camelCase IDL) replaced the
+// v1 `lesson_count: u8`. Popcount it client-side for display — there is no
+// on-chain helper exposed to the client.
+function liveLessonCount(activeLessons: BN[]): number {
+  return activeLessons.reduce(
+    (sum, word) => sum + word.toString(2).split("1").length - 1,
+    0
+  );
+}
+
 async function main() {
   const course = await program.account.course.fetch(coursePda);
 
@@ -21,7 +32,10 @@ async function main() {
   console.log("PDA:                     ", coursePda.toBase58());
   console.log("Creator:                 ", course.creator.toBase58());
   console.log("Version:                 ", course.version);
-  console.log("Lesson Count:            ", course.lessonCount);
+  console.log(
+    "Live Lessons:            ",
+    liveLessonCount(course.activeLessons)
+  );
   console.log("Difficulty:              ", course.difficulty);
   console.log("XP per Lesson:           ", course.xpPerLesson);
   console.log("Track ID:                ", course.trackId);
@@ -31,7 +45,6 @@ async function main() {
     course.prerequisite?.toBase58() || "none"
   );
   console.log("Creator Reward XP:       ", course.creatorRewardXp);
-  console.log("Min Completions (reward):", course.minCompletionsForReward);
   console.log("Total Completions:       ", course.totalCompletions);
   console.log("Total Enrollments:       ", course.totalEnrollments);
   console.log("Active:                  ", course.isActive);

--- a/onchain-academy/tests/cu-measurement.ts
+++ b/onchain-academy/tests/cu-measurement.ts
@@ -254,7 +254,6 @@ describe("CU measurement (#121)", () => {
           trackLevel: 1,
           prerequisite: null,
           creatorRewardXp: 50,
-          minCompletionsForReward: 1,
           collection: null,
         })
         .accountsPartial({
@@ -274,7 +273,6 @@ describe("CU measurement (#121)", () => {
           newIsActive: null,
           newXpPerLesson: null,
           newCreatorRewardXp: null,
-          newMinCompletionsForReward: null,
           newCollection: null,
         })
         .accountsPartial({
@@ -433,7 +431,6 @@ describe("CU measurement (#121)", () => {
           trackLevel: 1,
           prerequisite: null,
           creatorRewardXp: 0,
-          minCompletionsForReward: 0,
           collection: null,
         })
         .accountsPartial({
@@ -570,7 +567,6 @@ describe("CU measurement (#121)", () => {
           trackLevel: 1,
           prerequisite: null,
           creatorRewardXp: 0,
-          minCompletionsForReward: 0,
           collection: credCollection.publicKey,
         })
         .accountsPartial({

--- a/onchain-academy/tests/onchain-academy.ts
+++ b/onchain-academy/tests/onchain-academy.ts
@@ -63,7 +63,6 @@ describe("onchain-academy", () => {
   // Completion bonus is now 50% of total lesson XP = (XP_PER_LESSON * LESSON_COUNT) / 2
   const EXPECTED_BONUS_XP = Math.floor((XP_PER_LESSON * LESSON_COUNT) / 2);
   const CREATOR_REWARD_XP = 50;
-  const MIN_COMPLETIONS_FOR_REWARD = 1;
 
   const contentTxId = new Array(32).fill(1);
 
@@ -391,7 +390,6 @@ describe("onchain-academy", () => {
           trackLevel: 1,
           prerequisite: null,
           creatorRewardXp: CREATOR_REWARD_XP,
-          minCompletionsForReward: MIN_COMPLETIONS_FOR_REWARD,
           collection: null,
         })
         .accountsPartial({
@@ -414,9 +412,6 @@ describe("onchain-academy", () => {
       expect(course.trackLevel).to.equal(1);
       expect(course.prerequisite).to.be.null;
       expect(course.creatorRewardXp).to.equal(CREATOR_REWARD_XP);
-      expect(course.minCompletionsForReward).to.equal(
-        MIN_COMPLETIONS_FOR_REWARD
-      );
       expect(course.totalCompletions).to.equal(0);
       expect(course.totalEnrollments).to.equal(0);
       expect(course.isActive).to.equal(true);
@@ -444,7 +439,6 @@ describe("onchain-academy", () => {
             trackLevel: 1,
             prerequisite: null,
             creatorRewardXp: 0,
-            minCompletionsForReward: 0,
             collection: null,
           })
           .accountsPartial({
@@ -485,7 +479,6 @@ describe("onchain-academy", () => {
             trackLevel: 1,
             prerequisite: null,
             creatorRewardXp: 0,
-            minCompletionsForReward: 0,
             collection: null,
           })
           .accountsPartial({
@@ -526,7 +519,6 @@ describe("onchain-academy", () => {
             trackLevel: 1,
             prerequisite: null,
             creatorRewardXp: 0,
-            minCompletionsForReward: 0,
             collection: null,
           })
           .accountsPartial({
@@ -566,7 +558,6 @@ describe("onchain-academy", () => {
             trackLevel: 1,
             prerequisite: null,
             creatorRewardXp: 0,
-            minCompletionsForReward: 0,
             collection: null,
           })
           .accountsPartial({
@@ -606,7 +597,6 @@ describe("onchain-academy", () => {
             trackLevel: 1,
             prerequisite: null,
             creatorRewardXp: 0,
-            minCompletionsForReward: 0,
             collection: null,
           })
           .accountsPartial({
@@ -645,7 +635,6 @@ describe("onchain-academy", () => {
           trackLevel: 1,
           prerequisite: null,
           creatorRewardXp: 0,
-          minCompletionsForReward: 0,
           collection: null,
         })
         .accountsPartial({
@@ -681,7 +670,6 @@ describe("onchain-academy", () => {
             trackLevel: difficulty,
             prerequisite: null,
             creatorRewardXp: 0,
-            minCompletionsForReward: 0,
             collection: null,
           })
           .accountsPartial({
@@ -711,7 +699,6 @@ describe("onchain-academy", () => {
           newIsActive: null,
           newXpPerLesson: null,
           newCreatorRewardXp: null,
-          newMinCompletionsForReward: null,
           newCollection: null,
           newActiveLessons: null,
         })
@@ -734,7 +721,6 @@ describe("onchain-academy", () => {
           newIsActive: false,
           newXpPerLesson: null,
           newCreatorRewardXp: null,
-          newMinCompletionsForReward: null,
           newCollection: null,
           newActiveLessons: null,
         })
@@ -755,7 +741,6 @@ describe("onchain-academy", () => {
           newIsActive: true,
           newXpPerLesson: null,
           newCreatorRewardXp: null,
-          newMinCompletionsForReward: null,
           newCollection: null,
           newActiveLessons: null,
         })
@@ -784,7 +769,6 @@ describe("onchain-academy", () => {
           newIsActive: null,
           newXpPerLesson: 200,
           newCreatorRewardXp: 50,
-          newMinCompletionsForReward: 5,
           newCollection: null,
           newActiveLessons: null,
         })
@@ -798,7 +782,6 @@ describe("onchain-academy", () => {
       const course = await program.account.course.fetch(diffPda);
       expect(course.xpPerLesson).to.equal(200);
       expect(course.creatorRewardXp).to.equal(50);
-      expect(course.minCompletionsForReward).to.equal(5);
       expect(Array.from(course.contentTxId)).to.deep.equal(newContent);
       expect(course.version).to.equal(2);
     });
@@ -823,7 +806,6 @@ describe("onchain-academy", () => {
           trackLevel: 1,
           prerequisite: null,
           creatorRewardXp: 0,
-          minCompletionsForReward: 0,
           collection: null,
         })
         .accountsPartial({
@@ -844,7 +826,6 @@ describe("onchain-academy", () => {
           newIsActive: null,
           newXpPerLesson: null,
           newCreatorRewardXp: null,
-          newMinCompletionsForReward: null,
           newCollection: firstCollection,
           newActiveLessons: null,
         })
@@ -866,7 +847,6 @@ describe("onchain-academy", () => {
             newIsActive: null,
             newXpPerLesson: null,
             newCreatorRewardXp: null,
-            newMinCompletionsForReward: null,
             newCollection: secondCollection,
             newActiveLessons: null,
           })
@@ -892,7 +872,6 @@ describe("onchain-academy", () => {
           newIsActive: null,
           newXpPerLesson: null,
           newCreatorRewardXp: null,
-          newMinCompletionsForReward: null,
           newCollection: firstCollection,
           newActiveLessons: null,
         })
@@ -922,7 +901,6 @@ describe("onchain-academy", () => {
             newIsActive: false,
             newXpPerLesson: null,
             newCreatorRewardXp: null,
-            newMinCompletionsForReward: null,
             newCollection: null,
             newActiveLessons: null,
           })
@@ -966,7 +944,6 @@ describe("onchain-academy", () => {
           trackLevel: 1,
           prerequisite: null,
           creatorRewardXp: 0,
-          minCompletionsForReward: 0,
           collection: null,
         })
         .accountsPartial({
@@ -988,7 +965,6 @@ describe("onchain-academy", () => {
             newIsActive: null,
             newXpPerLesson: null,
             newCreatorRewardXp: null,
-            newMinCompletionsForReward: null,
             newCollection: null,
             newActiveLessons: mask,
           })
@@ -1108,7 +1084,6 @@ describe("onchain-academy", () => {
           newIsActive: false,
           newXpPerLesson: null,
           newCreatorRewardXp: null,
-          newMinCompletionsForReward: null,
           newCollection: null,
           newActiveLessons: null,
         })
@@ -1162,7 +1137,6 @@ describe("onchain-academy", () => {
           newIsActive: true,
           newXpPerLesson: null,
           newCreatorRewardXp: null,
-          newMinCompletionsForReward: null,
           newCollection: null,
           newActiveLessons: null,
         })
@@ -1377,7 +1351,8 @@ describe("onchain-academy", () => {
         XP_PER_LESSON * LESSON_COUNT + EXPECTED_BONUS_XP
       );
 
-      // Creator XP: 50 (reward met since totalCompletions=1 >= minCompletionsForReward=1)
+      // Creator XP: 50 (creator reward is flat/unconditional whenever
+      // creator_reward_xp > 0 — WS-1: no threshold, no window).
       const creatorAta = await getAccount(
         provider.connection,
         creatorTokenAccount,
@@ -1433,7 +1408,6 @@ describe("onchain-academy", () => {
           trackLevel: 1,
           prerequisite: null,
           creatorRewardXp: 10,
-          minCompletionsForReward: 1,
           collection: null,
         })
         .accountsPartial({
@@ -1558,7 +1532,6 @@ describe("onchain-academy", () => {
           trackLevel: 1,
           prerequisite: null,
           creatorRewardXp: 0,
-          minCompletionsForReward: 0,
           collection: null,
         })
         .accountsPartial({
@@ -1818,7 +1791,6 @@ describe("onchain-academy", () => {
           trackLevel: 1,
           prerequisite: null,
           creatorRewardXp: 0,
-          minCompletionsForReward: 0,
           collection: null,
         })
         .accountsPartial({
@@ -1907,9 +1879,9 @@ describe("onchain-academy", () => {
   });
 
   // ===========================================================================
-  // 11. Finalize without creator reward (below threshold)
+  // 11. Creator reward is flat and unconditional (WS-1: threshold/window removed)
   // ===========================================================================
-  describe("11. Creator reward threshold", () => {
+  describe("11. Creator reward (flat, no threshold)", () => {
     const threshId = "threshold-test";
     let threshCoursePda: PublicKey;
     const threshLearner = Keypair.generate();
@@ -1932,7 +1904,9 @@ describe("onchain-academy", () => {
         program.programId
       );
 
-      // Course with min_completions_for_reward = 10 (high threshold)
+      // WS-1: there is no min_completions_for_reward field anymore — the
+      // creator reward now pays on every completion whenever creator_reward_xp
+      // > 0, starting with the very first one.
       await program.methods
         .createCourse({
           courseId: threshId,
@@ -1945,7 +1919,6 @@ describe("onchain-academy", () => {
           trackLevel: 1,
           prerequisite: null,
           creatorRewardXp: 100,
-          minCompletionsForReward: 10,
           collection: null,
         })
         .accountsPartial({
@@ -2031,7 +2004,7 @@ describe("onchain-academy", () => {
       await provider.connection.confirmTransaction(clSig, "confirmed");
     });
 
-    it("creator gets no reward when below threshold", async () => {
+    it("creator gets the reward on the very first completion (no threshold)", async () => {
       const sig = await program.methods
         .finalizeCourse()
         .accountsPartial({
@@ -2062,14 +2035,16 @@ describe("onchain-academy", () => {
       );
       expect(Number(learnerAta.amount)).to.equal(50 + 25);
 
-      // Creator gets 0 (totalCompletions=1 < minCompletionsForReward=10)
+      // Creator gets 100 (== creator_reward_xp): WS-1 pays on every completion,
+      // no threshold to cross — the old "below threshold => 0" case no longer
+      // exists in the program.
       const creatorAta = await getAccount(
         provider.connection,
         threshCreatorTokenAccount,
         "confirmed",
         TOKEN_2022_PROGRAM_ID
       );
-      expect(Number(creatorAta.amount)).to.equal(0);
+      expect(Number(creatorAta.amount)).to.equal(100);
     });
   });
 
@@ -2107,7 +2082,6 @@ describe("onchain-academy", () => {
           trackLevel: 2,
           prerequisite: coursePda, // requires solana-101
           creatorRewardXp: 0,
-          minCompletionsForReward: 0,
           collection: null,
         })
         .accountsPartial({
@@ -2378,7 +2352,6 @@ describe("onchain-academy", () => {
           trackLevel: 1,
           prerequisite: null,
           creatorRewardXp: 0,
-          minCompletionsForReward: 0,
           collection: collectionAddress,
         })
         .accountsPartial({
@@ -2967,7 +2940,6 @@ describe("onchain-academy", () => {
           trackLevel: 1,
           prerequisite: null,
           creatorRewardXp: 0,
-          minCompletionsForReward: 0,
           collection: null,
         })
         .accountsPartial({
@@ -3124,7 +3096,6 @@ describe("onchain-academy", () => {
           trackLevel: 1,
           prerequisite: null,
           creatorRewardXp: 0,
-          minCompletionsForReward: 0,
           collection: null,
         })
         .accountsPartial({
@@ -3251,7 +3222,6 @@ describe("onchain-academy", () => {
           trackLevel: 1,
           prerequisite: null,
           creatorRewardXp: 10,
-          minCompletionsForReward: 1,
           collection: null,
         })
         .accountsPartial({
@@ -3317,7 +3287,7 @@ describe("onchain-academy", () => {
         .rpc();
       await provider.connection.confirmTransaction(clSig, "confirmed");
 
-      // Finalize: creator gets reward since minCompletionsForReward=1
+      // Finalize: creator gets the flat per-completion reward (WS-1: no threshold)
       // Need a dedicated creator ATA for this course's creator (reuse existing)
       const fsig = await program.methods
         .finalizeCourse()
@@ -4303,7 +4273,6 @@ describe("onchain-academy", () => {
           trackLevel: 1,
           prerequisite: null,
           creatorRewardXp: 0,
-          minCompletionsForReward: 0,
           collection: null,
         })
         .accountsPartial({
@@ -4442,7 +4411,6 @@ describe("onchain-academy", () => {
           trackLevel: 1,
           prerequisite: null,
           creatorRewardXp: 0,
-          minCompletionsForReward: 0,
           collection: null,
         })
         .accountsPartial({
@@ -5053,7 +5021,6 @@ describe("onchain-academy", () => {
           trackLevel: 1,
           prerequisite: null,
           creatorRewardXp: 0,
-          minCompletionsForReward: 0,
           collection: null,
         })
         .accountsPartial({
@@ -5219,7 +5186,6 @@ describe("onchain-academy", () => {
           trackLevel: 2,
           prerequisite: null,
           creatorRewardXp: 0,
-          minCompletionsForReward: 0,
           collection: null,
         })
         .accountsPartial({
@@ -5422,7 +5388,6 @@ describe("onchain-academy", () => {
           trackLevel: 1,
           prerequisite: null,
           creatorRewardXp: 0,
-          minCompletionsForReward: 0,
           collection: ksCollection,
         })
         .accountsPartial({
@@ -5908,7 +5873,6 @@ describe("onchain-academy", () => {
           newIsActive: null,
           newXpPerLesson: null,
           newCreatorRewardXp: null,
-          newMinCompletionsForReward: null,
           newCollection: null,
           newActiveLessons: slotsToMask([0, 2]),
         })
@@ -5933,7 +5897,6 @@ describe("onchain-academy", () => {
           trackLevel: 1,
           prerequisite: null,
           creatorRewardXp: 0,
-          minCompletionsForReward: 0,
           collection: null,
         })
         .accountsPartial({
@@ -6031,7 +5994,6 @@ describe("onchain-academy", () => {
           trackLevel: 1,
           prerequisite: null,
           creatorRewardXp: 0,
-          minCompletionsForReward: 0,
           collection: null,
         })
         .accountsPartial({
@@ -6096,7 +6058,8 @@ describe("onchain-academy", () => {
           .rpc();
       }
 
-      const enrollment = await program.account.enrollment.fetch(rejectEnrollPda);
+      const enrollment =
+        await program.account.enrollment.fetch(rejectEnrollPda);
       // Slots 0 and 2 set: 0b101 = 5.
       expect(enrollment.lessonFlags[0].toNumber() & 0x7).to.equal(0b101);
     });

--- a/onchain-academy/tests/rust/src/test_active_lessons.rs
+++ b/onchain-academy/tests/rust/src/test_active_lessons.rs
@@ -51,7 +51,6 @@ fn update_course_params_new_active_lessons_roundtrip() {
         new_is_active: None,
         new_xp_per_lesson: None,
         new_creator_reward_xp: None,
-        new_min_completions_for_reward: None,
         new_collection: None,
         new_active_lessons: Some(target),
     };
@@ -68,7 +67,6 @@ fn update_course_params_new_active_lessons_roundtrip() {
         new_is_active: None,
         new_xp_per_lesson: None,
         new_creator_reward_xp: None,
-        new_min_completions_for_reward: None,
         new_collection: None,
         new_active_lessons: None,
     };

--- a/onchain-academy/tests/rust/src/test_audit_hardening.rs
+++ b/onchain-academy/tests/rust/src/test_audit_hardening.rs
@@ -334,17 +334,3 @@ fn audit_fixes_reuse_existing_codes_without_shifting_them() {
     assert_eq!(6000 + AcademyError::WrongXpMint as u32, 6032);
     assert_eq!(6000 + AcademyError::XpAmountExceedsMax as u32, 6033);
 }
-
-// --- WS-1: creator reward is flat and unbounded (window removed) ---
-
-// Mirrors the finalize_course gate post-WS-1: pay iff reward_xp > 0. These pin
-// the new gate so a reintroduced cap fails CI instead of landing silently.
-fn creator_reward_paid(reward_xp: u32) -> bool {
-    reward_xp > 0
-}
-
-#[test]
-fn creator_reward_paid_on_every_completion_when_set() {
-    assert!(creator_reward_paid(30));
-    assert!(!creator_reward_paid(0));
-}

--- a/onchain-academy/tests/rust/src/test_audit_hardening.rs
+++ b/onchain-academy/tests/rust/src/test_audit_hardening.rs
@@ -335,39 +335,16 @@ fn audit_fixes_reuse_existing_codes_without_shifting_them() {
     assert_eq!(6000 + AcademyError::XpAmountExceedsMax as u32, 6033);
 }
 
-// --- Fix 5: creator-reward window (bound the per-completion drip) ---
+// --- WS-1: creator reward is flat and unbounded (window removed) ---
 
-const CREATOR_REWARD_WINDOW: u32 = 100;
-
-/// Mirrors the finalize_course gate: the creator reward is paid only for
-/// completions in [min_completions, min_completions + WINDOW) — bounding the
-/// per-completion drip by reusing the existing total_completions counter, so
-/// aggregate creator XP can't run away (Sybil-farmable) once popular.
-fn creator_reward_paid(total_completions: u32, min_completions: u32, reward_xp: u32) -> bool {
-    let reward_end = min_completions.saturating_add(CREATOR_REWARD_WINDOW);
-    reward_xp > 0 && total_completions >= min_completions && total_completions < reward_end
+// Mirrors the finalize_course gate post-WS-1: pay iff reward_xp > 0. These pin
+// the new gate so a reintroduced cap fails CI instead of landing silently.
+fn creator_reward_paid(reward_xp: u32) -> bool {
+    reward_xp > 0
 }
 
 #[test]
-fn creator_reward_only_within_the_window() {
-    let min = 10u32;
-    assert!(!creator_reward_paid(9, min, 750)); // below threshold: nothing
-    assert!(creator_reward_paid(10, min, 750)); // first qualifying completion
-    assert!(creator_reward_paid(109, min, 750)); // last in-window (min + WINDOW - 1)
-    assert!(!creator_reward_paid(110, min, 750)); // window closed — drip stops
-    assert!(!creator_reward_paid(10_000, min, 750)); // ...stays closed forever
-    assert!(!creator_reward_paid(50, min, 0)); // reward_xp == 0 never pays
-}
-
-#[test]
-fn creator_reward_total_is_capped_regardless_of_completions() {
-    // No matter how many (potentially Sybil) completions occur, the creator is
-    // paid at most WINDOW times => WINDOW * creator_reward_xp total.
-    let min = 10u32;
-    let reward_xp: u64 = 750;
-    let payouts = (min..)
-        .take_while(|&c| creator_reward_paid(c, min, reward_xp as u32))
-        .count() as u64;
-    assert_eq!(payouts, CREATOR_REWARD_WINDOW as u64);
-    assert_eq!(payouts * reward_xp, 75_000);
+fn creator_reward_paid_on_every_completion_when_set() {
+    assert!(creator_reward_paid(30));
+    assert!(!creator_reward_paid(0));
 }

--- a/onchain-academy/tests/rust/src/test_completion.rs
+++ b/onchain-academy/tests/rust/src/test_completion.rs
@@ -124,8 +124,6 @@ fn completion_bonus_xp_is_50_percent_of_total() {
     let xp_per_lesson: u32 = 100;
     let live_lesson_count: u8 = 5;
     let creator_reward_xp: u32 = 50;
-    let min_completions_for_reward: u16 = 3;
-    let total_completions: u32 = 3;
 
     let total_lesson_xp = (xp_per_lesson as u64) * (live_lesson_count as u64);
     assert_eq!(total_lesson_xp, 500);
@@ -133,13 +131,12 @@ fn completion_bonus_xp_is_50_percent_of_total() {
     let bonus_xp = total_lesson_xp / 2;
     assert_eq!(bonus_xp, 250);
 
-    // Creator reward is minted if threshold met
-    assert!(total_completions >= min_completions_for_reward as u32);
     let total_xp_to_learner = total_lesson_xp + bonus_xp;
     assert_eq!(total_xp_to_learner, 750);
 
-    // Creator gets their reward
-    assert_eq!(creator_reward_xp, 50);
+    // Creator reward is now unconditional on completion (WS-1: no threshold, no
+    // window) whenever creator_reward_xp > 0.
+    assert!(creator_reward_xp > 0);
 }
 
 #[test]
@@ -153,15 +150,14 @@ fn completion_bonus_zero_when_xp_per_lesson_is_one() {
 }
 
 #[test]
-fn creator_reward_below_threshold_means_no_mint() {
-    let min_completions_for_reward: u16 = 5;
-    let total_completions: u32 = 4; // below threshold
-    let creator_reward_xp: u32 = 100;
+fn creator_reward_gate_is_reward_xp_only() {
+    // WS-1: the `total_completions >= min_completions` threshold and the window
+    // are gone. finalize_course now mints the creator reward iff reward_xp > 0,
+    // on the first completion and every one after.
+    let mint = |reward_xp: u32| reward_xp > 0;
 
-    // finalize_course: `if total_completions >= min_completions && creator_reward_xp > 0`
-    let should_mint =
-        total_completions >= min_completions_for_reward as u32 && creator_reward_xp > 0;
-    assert!(!should_mint);
+    assert!(mint(100)); // first completion pays — no threshold to cross
+    assert!(!mint(0)); // reward_xp == 0 is the only thing that suppresses it
 }
 
 #[test]

--- a/onchain-academy/tests/rust/src/test_completion.rs
+++ b/onchain-academy/tests/rust/src/test_completion.rs
@@ -123,7 +123,6 @@ fn completion_bonus_xp_is_50_percent_of_total() {
     // finalize_course: bonus = (xp_per_lesson * live_lesson_count) / 2
     let xp_per_lesson: u32 = 100;
     let live_lesson_count: u8 = 5;
-    let creator_reward_xp: u32 = 50;
 
     let total_lesson_xp = (xp_per_lesson as u64) * (live_lesson_count as u64);
     assert_eq!(total_lesson_xp, 500);
@@ -133,10 +132,6 @@ fn completion_bonus_xp_is_50_percent_of_total() {
 
     let total_xp_to_learner = total_lesson_xp + bonus_xp;
     assert_eq!(total_xp_to_learner, 750);
-
-    // Creator reward is now unconditional on completion (WS-1: no threshold, no
-    // window) whenever creator_reward_xp > 0.
-    assert!(creator_reward_xp > 0);
 }
 
 #[test]
@@ -147,17 +142,6 @@ fn completion_bonus_zero_when_xp_per_lesson_is_one() {
     let total_lesson_xp = (xp_per_lesson as u64) * (live_lesson_count as u64);
     let bonus_xp = total_lesson_xp / 2;
     assert_eq!(bonus_xp, 0);
-}
-
-#[test]
-fn creator_reward_gate_is_reward_xp_only() {
-    // WS-1: the `total_completions >= min_completions` threshold and the window
-    // are gone. finalize_course now mints the creator reward iff reward_xp > 0,
-    // on the first completion and every one after.
-    let mint = |reward_xp: u32| reward_xp > 0;
-
-    assert!(mint(100)); // first completion pays — no threshold to cross
-    assert!(!mint(0)); // reward_xp == 0 is the only thing that suppresses it
 }
 
 #[test]

--- a/onchain-academy/tests/rust/src/test_course.rs
+++ b/onchain-academy/tests/rust/src/test_course.rs
@@ -5,7 +5,7 @@ use solana_sdk::pubkey::Pubkey;
 
 #[test]
 fn course_size_constant_is_correct() {
-    // v-next (WS-1): v2's 255 - 2 (deleted min_completions_for_reward u16) = 253.
+    // 253 = prior 255 - 2 (deleted min_completions_for_reward u16).
     // 8 (discriminator) + (4 + 32) (course_id) + 32 (creator) + 32 (content_tx_id)
     // + 2 (version) + 32 (active_lessons: [u64; 4]) + 1 (difficulty) + 4 (xp_per_lesson)
     // + 2 (track_id) + 1 (track_level) + (1 + 32) (prerequisite Option<Pubkey>)

--- a/onchain-academy/tests/rust/src/test_course.rs
+++ b/onchain-academy/tests/rust/src/test_course.rs
@@ -5,14 +5,16 @@ use solana_sdk::pubkey::Pubkey;
 
 #[test]
 fn course_size_constant_is_correct() {
-    // v2 (CS-3): 224 - 1 (deleted lesson_count u8) + 32 (active_lessons [u64;4]) = 255.
+    // v-next (WS-1): v2's 255 - 2 (deleted min_completions_for_reward u16) = 253.
     // 8 (discriminator) + (4 + 32) (course_id) + 32 (creator) + 32 (content_tx_id)
     // + 2 (version) + 32 (active_lessons: [u64; 4]) + 1 (difficulty) + 4 (xp_per_lesson)
     // + 2 (track_id) + 1 (track_level) + (1 + 32) (prerequisite Option<Pubkey>)
-    // + 4 (creator_reward_xp) + 2 (min_completions_for_reward) + 4 (total_completions)
+    // + 4 (creator_reward_xp) + 4 (total_completions)
     // + 4 (total_enrollments) + 1 (is_active) + 8 (created_at) + 8 (updated_at)
     // + 32 (collection) + 8 (_reserved) + 1 (bump)
-    assert_eq!(Course::SIZE, 255);
+    // 253 must NOT drift back to 255 — the client decoder dispatches on length,
+    // and 255 is the never-deployed v2 layout.
+    assert_eq!(Course::SIZE, 253);
 }
 
 #[test]
@@ -35,7 +37,6 @@ fn course_with_mask(active_lessons: [u64; 4]) -> Course {
         track_level: 0,
         prerequisite: None,
         creator_reward_xp: 0,
-        min_completions_for_reward: 0,
         total_completions: 0,
         total_enrollments: 0,
         is_active: true,
@@ -111,7 +112,6 @@ fn course_serialization_roundtrip() {
         track_level: 2,
         prerequisite: None,
         creator_reward_xp: 50,
-        min_completions_for_reward: 10,
         total_completions: 7,
         total_enrollments: 25,
         is_active: true,
@@ -139,7 +139,6 @@ fn course_serialization_roundtrip() {
     assert_eq!(deserialized.track_level, 2);
     assert_eq!(deserialized.prerequisite, None);
     assert_eq!(deserialized.creator_reward_xp, 50);
-    assert_eq!(deserialized.min_completions_for_reward, 10);
     assert_eq!(deserialized.total_completions, 7);
     assert_eq!(deserialized.total_enrollments, 25);
     assert!(deserialized.is_active);
@@ -165,7 +164,6 @@ fn course_with_prerequisite_roundtrip() {
         track_level: 2,
         prerequisite: Some(prereq),
         creator_reward_xp: 20,
-        min_completions_for_reward: 5,
         total_completions: 0,
         total_enrollments: 0,
         is_active: true,
@@ -198,7 +196,6 @@ fn course_collection_roundtrip() {
         track_level: 1,
         prerequisite: None,
         creator_reward_xp: 0,
-        min_completions_for_reward: 0,
         total_completions: 0,
         total_enrollments: 0,
         is_active: true,
@@ -274,7 +271,6 @@ fn course_serialized_size_with_max_id_and_all_options() {
         track_level: 0,
         prerequisite: Some(Pubkey::new_unique()),
         creator_reward_xp: 0,
-        min_completions_for_reward: 0,
         total_completions: 0,
         total_enrollments: 0,
         is_active: true,
@@ -306,7 +302,6 @@ fn course_serialized_size_shorter_id_fits_within_allocation() {
         track_level: 0,
         prerequisite: None,
         creator_reward_xp: 0,
-        min_completions_for_reward: 0,
         total_completions: 0,
         total_enrollments: 0,
         is_active: true,

--- a/onchain-academy/trident-tests/fuzz_0/test_fuzz.rs
+++ b/onchain-academy/trident-tests/fuzz_0/test_fuzz.rs
@@ -265,10 +265,9 @@ impl FuzzTest {
         let enrollment = self.derive_enrollment(&learner);
         let learner_token_account = self.derive_ata(&learner, &xp_mint);
 
-        // How many lessons does this course actually have? CS-3/WS-1: the account
-        // no longer stores a raw lesson_count — derive it as the popcount of the
-        // active_lessons mask. `start` never retires a slot, so the course stays
-        // dense and this popcount equals the fuzzed lesson_count used at creation.
+        // The account stores no raw lesson_count — derive it as the popcount of
+        // the active_lessons mask. `start` never retires a slot, so the course
+        // stays dense and this popcount equals the lesson_count used at creation.
         let lesson_count: u32 = match self
             .trident
             .get_account_with_type::<CourseAccount>(&course, 8)

--- a/onchain-academy/trident-tests/fuzz_0/test_fuzz.rs
+++ b/onchain-academy/trident-tests/fuzz_0/test_fuzz.rs
@@ -115,7 +115,6 @@ impl FuzzTest {
         let difficulty: u8 = self.trident.random_from_range(1..=3u8);
         let xp_per_lesson: u32 = self.trident.random_from_range(0..=5_000u32);
         let creator_reward_xp: u32 = self.trident.random_from_range(0..=10_000u32);
-        let min_completions_for_reward: u16 = self.trident.random_from_range(1..=3u16);
 
         let course = self.fuzz_accounts.course.insert(
             &mut self.trident,
@@ -136,7 +135,6 @@ impl FuzzTest {
             track_level: self.trident.random_from_range(0..=u8::MAX),
             prerequisite: None,
             creator_reward_xp,
-            min_completions_for_reward,
             collection: None,
         };
 
@@ -267,18 +265,21 @@ impl FuzzTest {
         let enrollment = self.derive_enrollment(&learner);
         let learner_token_account = self.derive_ata(&learner, &xp_mint);
 
-        // How many lessons does this course actually have?
-        let lesson_count = match self
+        // How many lessons does this course actually have? CS-3/WS-1: the account
+        // no longer stores a raw lesson_count — derive it as the popcount of the
+        // active_lessons mask. `start` never retires a slot, so the course stays
+        // dense and this popcount equals the fuzzed lesson_count used at creation.
+        let lesson_count: u32 = match self
             .trident
             .get_account_with_type::<CourseAccount>(&course, 8)
         {
-            Some(c) => c.lesson_count,
+            Some(c) => c.active_lessons.iter().map(|w| w.count_ones()).sum(),
             None => return,
         };
 
         // Mark all lessons (ignore per-call results: already-complete / not-enrolled
         // are valid rejections; we just want to reach a finalizable state).
-        for idx in 0..lesson_count {
+        for idx in 0..(lesson_count as u8) {
             let _ = self.trident.process_transaction(
                 &[complete_lesson_ix(
                     &CompleteLessonAccounts {
@@ -324,7 +325,7 @@ impl FuzzTest {
                 );
                 let completed: u32 = enr.lesson_flags.iter().map(|w| w.count_ones()).sum();
                 assert_eq!(
-                    completed, lesson_count as u32,
+                    completed, lesson_count,
                     "finalize succeeded with {} lessons completed, expected {}",
                     completed, lesson_count
                 );

--- a/onchain-academy/trident-tests/fuzz_0/types.rs
+++ b/onchain-academy/trident-tests/fuzz_0/types.rs
@@ -74,7 +74,6 @@ pub struct CreateCourseParams {
     pub track_level: u8,
     pub prerequisite: Option<Pubkey>,
     pub creator_reward_xp: u32,
-    pub min_completions_for_reward: u16,
     pub collection: Option<Pubkey>,
 }
 
@@ -195,20 +194,22 @@ pub struct EnrollmentAccount {
 }
 
 /// Borsh body of the `Course` account (after the 8-byte discriminator).
+///
+/// `active_lessons` (CS-3) replaced the v1 `lesson_count: u8` — a 256-bit mask
+/// ([u64; 4]) of live lesson slots, mirroring `Enrollment.lesson_flags`.
 #[derive(BorshDeserialize, Debug, Clone)]
 pub struct CourseAccount {
     pub course_id: String,
     pub creator: Pubkey,
     pub content_tx_id: [u8; 32],
     pub version: u16,
-    pub lesson_count: u8,
+    pub active_lessons: [u64; 4],
     pub difficulty: u8,
     pub xp_per_lesson: u32,
     pub track_id: u16,
     pub track_level: u8,
     pub prerequisite: Option<Pubkey>,
     pub creator_reward_xp: u32,
-    pub min_completions_for_reward: u16,
     pub total_completions: u32,
     pub total_enrollments: u32,
     pub is_active: bool,


### PR DESCRIPTION
**Phase 0 of WS-1** (spec: `docs/superpowers/specs/2026-07-13-program-vnext-design.md`, merged #462). Program source + fixtures + IDL regen. **No client changes** — the client-side IDL cutover and the length-aware decoder are Phase 1.

## What changed
- `min_completions_for_reward` (u16) removed from **all three layout surfaces**: `Course`, `CreateCourseParams`, `UpdateCourseParams`.
- `finalize_course`: the `CREATOR_REWARD_WINDOW` const and both threshold clauses are gone. The reward is now `if course.creator_reward_xp > 0 { mint }` — flat, every completion.
- `Course::SIZE` **255 → 253**. `_reserved` is **not** padded back to 255 — that would collide with the never-deployed v2 layout and break the client's length-based decoder dispatch.

## DoD (gate-verifiable)
- [x] Field gone from the 3 layout surfaces + the finalize window (const + both clauses).
- [x] `Course::SIZE == 253`; `_reserved` unchanged at `[u8; 8]`.
- [x] IDL regenerates clean from this source (`anchor build`; confirmed no `min_completions_for_reward` in the `Course` account). The committed **client** IDL is deliberately untouched — Phase 1.
- [x] CI-breakers ride along: `test_course.rs` SIZE assert flipped 255→253; the **Trident fuzz mirror** (`fuzz_0/types.rs`) regenerated — it hand-copied the layout and was *already stale* (still had `lesson_count:u8` from before CS-3's `active_lessons` migration), so it was fuzzing a struct that no longer exists.
- [x] Behavior tests that asserted the old threshold/window rewritten to the flat rule (a course that paid the creator 0 below-threshold now pays on the first completion).
- [x] 130 Rust tests pass; `cargo check` + `anchor build` clean; `grep` for the field shows only comments.

## Notes for the gate
- Two pre-existing script bugs were fixed opportunistically (both blocked `tsc`): `fetch-course.ts` printed a `lessonCount` field dead since CS-3; `create-mock-course.ts` was missing `collection`.
- The uncapped creator reward is the owner-accepted risk from the epic; the compensating control (completion-route rate limit) already shipped in #460.

Built via SDD (implementer subagent for the fixture sweep + IDL regen; controller reviewed the diff). Requesting the full adversarial pass on the complete diff, same discipline as #460.