### PR TITLE
feat(web): WS-1 Phase 1 — length-aware Course decoder + consumer migration (H1, S6)

### DIFF
--- a/apps/web/src/app/api/admin/courses/sync/route.ts
+++ b/apps/web/src/app/api/admin/courses/sync/route.ts
@@ -445,11 +445,11 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   // Grow the on-chain lesson count when a teacher has appended lessons to an
   // already-deployed course. Increase-only: without this, a new lesson's index
   // is >= course.lesson_count and complete_lesson reverts (LessonOutOfBounds,
-  // surfaced as a 409 in /api/lessons/complete). fetchCourse uses the raw-IDL
-  // BorshCoder → snake_case `lesson_count`. The program rejects any decrease
+  // surfaced as a 409 in /api/lessons/complete). fetchCourse returns the
+  // normalised `liveLessonCount`. The program rejects any decrease
   // (LessonCountDecrease), so we only send the field when Sanity is strictly
   // higher; equal/lower is left untouched.
-  const onChainLessonCount = onChainCourse?.lesson_count as number | undefined;
+  const onChainLessonCount = onChainCourse?.liveLessonCount;
   if (
     typeof course.lessonCount === "number" &&
     typeof onChainLessonCount === "number" &&

--- a/apps/web/src/app/api/admin/courses/sync/route.ts
+++ b/apps/web/src/app/api/admin/courses/sync/route.ts
@@ -449,6 +449,9 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   // normalised `liveLessonCount`. The program rejects any decrease
   // (LessonCountDecrease), so we only send the field when Sanity is strictly
   // higher; equal/lower is left untouched.
+  // Count-based and only correct while masks are dense (today). Once a
+  // sparse-mask course can exist, this must become a per-slot bit test
+  // against `activeLessons` instead of a count comparison.
   const onChainLessonCount = onChainCourse?.liveLessonCount;
   if (
     typeof course.lessonCount === "number" &&

--- a/apps/web/src/app/api/admin/status/__tests__/route.test.ts
+++ b/apps/web/src/app/api/admin/status/__tests__/route.test.ts
@@ -84,7 +84,7 @@ vi.mock("@/lib/content/meta", () => ({ SYNCED_SHA: "a".repeat(40) }));
 const matchingRaw = {
   creator: { toBase58: () => INSTRUCTOR_WALLET },
   content_tx_id: MATCHING_TX_ID,
-  lesson_count: 3,
+  liveLessonCount: 3,
   difficulty: 1,
   xp_per_lesson: 50,
   track_id: 0,

--- a/apps/web/src/app/api/admin/status/__tests__/route.test.ts
+++ b/apps/web/src/app/api/admin/status/__tests__/route.test.ts
@@ -91,8 +91,10 @@ const matchingRaw = {
   track_level: 0,
   prerequisite: null,
   creator_reward_xp: 0,
-  min_completions_for_reward: 0,
+  total_completions: 0,
+  total_enrollments: 0,
   is_active: true,
+  version: 1,
 };
 const rawByMarker: Record<string, unknown> = {
   A: matchingRaw,

--- a/apps/web/src/app/api/admin/status/route.ts
+++ b/apps/web/src/app/api/admin/status/route.ts
@@ -76,7 +76,7 @@ async function computeRepoContentDrift(): Promise<CourseContentDrift> {
 interface RawCourse {
   creator?: { toBase58(): string };
   content_tx_id?: number[] | Uint8Array;
-  lesson_count?: number;
+  liveLessonCount: number;
   difficulty?: number;
   xp_per_lesson?: number;
   track_id?: number;
@@ -95,7 +95,7 @@ function toOnChainCourse(courseId: string, raw: RawCourse): OnChainCourse {
   return {
     courseId,
     creator: raw.creator?.toBase58() ?? "",
-    lessonCount: raw.lesson_count ?? 0,
+    lessonCount: raw.liveLessonCount,
     difficulty: raw.difficulty ?? 1,
     xpPerLesson: raw.xp_per_lesson ?? 0,
     trackId: raw.track_id ?? 0,

--- a/apps/web/src/app/api/admin/status/route.ts
+++ b/apps/web/src/app/api/admin/status/route.ts
@@ -17,7 +17,7 @@ import {
   findAchievementTypePDA,
   getProgramId,
 } from "@/lib/solana/pda";
-import { decodeCourse } from "@/lib/solana/academy-reads";
+import { decodeCourse, type DecodedCourse } from "@/lib/solana/academy-reads";
 import {
   verifyAuthorityMatchesConfig,
   isAdminSignerReady,
@@ -69,44 +69,27 @@ async function computeRepoContentDrift(): Promise<CourseContentDrift> {
 }
 
 /**
- * The raw BorshCoder decode of a Course account (snake_case — `decodeCourse`
- * bypasses Anchor's camelCase IDL conversion). Pubkeys decode to objects with
- * `toBase58()`; `prerequisite` is `option<pubkey>` → object or null.
+ * Map the normalised `DecodedCourse` (snake_case — `decodeCourse` bypasses
+ * Anchor's camelCase IDL conversion) to the diff engine's `OnChainCourse`.
+ * Takes `DecodedCourse` directly (no shadow interface, no cast) so that a
+ * field dropped from `DecodedCourse` fails `tsc`, not silently reads as
+ * `undefined`.
  */
-interface RawCourse {
-  creator?: { toBase58(): string };
-  content_tx_id?: number[] | Uint8Array;
-  liveLessonCount: number;
-  difficulty?: number;
-  xp_per_lesson?: number;
-  track_id?: number;
-  track_level?: number;
-  prerequisite?: { toBase58(): string } | null;
-  creator_reward_xp?: number;
-  min_completions_for_reward?: number;
-  total_completions?: number;
-  total_enrollments?: number;
-  is_active?: boolean;
-  version?: number;
-}
-
-/** Map the raw snake_case decode to the diff engine's `OnChainCourse`. */
-function toOnChainCourse(courseId: string, raw: RawCourse): OnChainCourse {
+function toOnChainCourse(courseId: string, raw: DecodedCourse): OnChainCourse {
   return {
     courseId,
-    creator: raw.creator?.toBase58() ?? "",
+    creator: raw.creator.toBase58(),
     lessonCount: raw.liveLessonCount,
-    difficulty: raw.difficulty ?? 1,
-    xpPerLesson: raw.xp_per_lesson ?? 0,
-    trackId: raw.track_id ?? 0,
-    trackLevel: raw.track_level ?? 0,
+    difficulty: raw.difficulty,
+    xpPerLesson: raw.xp_per_lesson,
+    trackId: raw.track_id,
+    trackLevel: raw.track_level,
     prerequisite: raw.prerequisite ? raw.prerequisite.toBase58() : null,
-    creatorRewardXp: raw.creator_reward_xp ?? 0,
-    minCompletionsForReward: raw.min_completions_for_reward ?? 0,
-    totalCompletions: raw.total_completions ?? 0,
-    totalEnrollments: raw.total_enrollments ?? 0,
-    isActive: raw.is_active ?? true,
-    version: raw.version ?? 0,
+    creatorRewardXp: raw.creator_reward_xp,
+    totalCompletions: raw.total_completions,
+    totalEnrollments: raw.total_enrollments,
+    isActive: raw.is_active,
+    version: raw.version,
   };
 }
 
@@ -199,10 +182,8 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
       let differences: DiffEntry[] = [];
       let chainDrift: ChainDriftState | null = null;
       try {
-        const raw = decodeCourse(accountInfo.data) as RawCourse;
-        if (typeof raw.is_active === "boolean") {
-          isActive = raw.is_active;
-        }
+        const raw = decodeCourse(accountInfo.data);
+        isActive = raw.is_active;
         // Resolve the bundle prerequisite to its Course PDA so the diff is
         // pubkey-to-pubkey (sync derivation, no RPC).
         const prerequisitePda = course.prerequisiteCourse
@@ -222,7 +203,7 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
         // headSha here is the bundle pin, not GitHub HEAD): content_stale means
         // deploying now would update this course's on-chain content commitment.
         chainDrift = computeChainDrift({
-          onChainContentTxId: raw.content_tx_id ?? null,
+          onChainContentTxId: raw.content_tx_id,
           headSha: SYNCED_SHA,
           diffStatus: diff.status,
           contentUpToDate: true,

--- a/apps/web/src/app/api/certificates/mint/route.ts
+++ b/apps/web/src/app/api/certificates/mint/route.ts
@@ -177,8 +177,7 @@ export async function POST(request: NextRequest) {
     }
 
     const totalXp =
-      Number(onChainCourse.xp_per_lesson) *
-      (Number(onChainCourse.lesson_count) || 1);
+      Number(onChainCourse.xp_per_lesson) * onChainCourse.liveLessonCount;
 
     // Build metadata
     const metadataJson = {

--- a/apps/web/src/app/api/lessons/complete/route.ts
+++ b/apps/web/src/app/api/lessons/complete/route.ts
@@ -255,6 +255,9 @@ export async function POST(request: NextRequest) {
     // raised by an admin re-sync (update_course.new_lesson_count). Detect it here
     // and return a clear 409 instead of letting the on-chain TX throw a generic
     // 500. fetchCourse returns the normalised `liveLessonCount`.
+    // Count-based and only correct while masks are dense (today). Once a
+    // sparse-mask course can exist, this must become a per-slot bit test
+    // against `activeLessons` instead of a count comparison.
     const onChainLessonCount = onChainCourse?.liveLessonCount;
     if (
       typeof onChainLessonCount === "number" &&

--- a/apps/web/src/app/api/lessons/complete/route.ts
+++ b/apps/web/src/app/api/lessons/complete/route.ts
@@ -254,10 +254,8 @@ export async function POST(request: NextRequest) {
     // already-deployed course but the Course PDA's lesson_count has not yet been
     // raised by an admin re-sync (update_course.new_lesson_count). Detect it here
     // and return a clear 409 instead of letting the on-chain TX throw a generic
-    // 500. fetchCourse uses the raw-IDL BorshCoder → snake_case `lesson_count`.
-    const onChainLessonCount = onChainCourse?.lesson_count as
-      | number
-      | undefined;
+    // 500. fetchCourse returns the normalised `liveLessonCount`.
+    const onChainLessonCount = onChainCourse?.liveLessonCount;
     if (
       typeof onChainLessonCount === "number" &&
       lessonIndex >= onChainLessonCount

--- a/apps/web/src/lib/admin/__tests__/sync-diff.test.ts
+++ b/apps/web/src/lib/admin/__tests__/sync-diff.test.ts
@@ -41,7 +41,6 @@ function onChain(overrides: Partial<OnChainCourse> = {}): OnChainCourse {
     trackLevel: 0,
     prerequisite: null,
     creatorRewardXp: 0,
-    minCompletionsForReward: 0,
     totalCompletions: 0,
     totalEnrollments: 0,
     isActive: true,

--- a/apps/web/src/lib/admin/sync-diff.ts
+++ b/apps/web/src/lib/admin/sync-diff.ts
@@ -21,7 +21,6 @@ export interface OnChainCourse {
   trackLevel: number;
   prerequisite: string | null; // base58 pubkey or null
   creatorRewardXp: number;
-  minCompletionsForReward: number;
   totalCompletions: number;
   totalEnrollments: number;
   isActive: boolean;
@@ -187,8 +186,8 @@ export function isDraftId(id: string): boolean {
  * Compare a bundle course document against an on-chain Course PDA.
  *
  * Updateable fields (fixable with `updateCourse`):
- *   xpPerLesson, creatorRewardXp, minCompletionsForReward, and an INCREASE in
- *   lessonCount (increase-only via update_course.new_lesson_count)
+ *   xpPerLesson, creatorRewardXp, and an INCREASE in lessonCount (increase-only
+ *   via update_course.new_lesson_count)
  *
  * Immutable fields (require PDA recreation if different):
  *   creator (#400 — the XP-reward recipient, set once at create_course),
@@ -263,16 +262,6 @@ export function diffCourse(
       field: "creatorRewardXp",
       contentValue: contentCreatorRewardXp,
       onChainValue: onChainCourse.creatorRewardXp,
-      updateable: true,
-    });
-  }
-
-  const contentMinCompletions = course.minCompletionsForReward ?? 0;
-  if (contentMinCompletions !== onChainCourse.minCompletionsForReward) {
-    differences.push({
-      field: "minCompletionsForReward",
-      contentValue: contentMinCompletions,
-      onChainValue: onChainCourse.minCompletionsForReward,
       updateable: true,
     });
   }

--- a/apps/web/src/lib/helius/event-handlers.ts
+++ b/apps/web/src/lib/helius/event-handlers.ts
@@ -16,7 +16,7 @@ import {
 import { fetchEnrollment, fetchCourse } from "@/lib/solana/academy-reads";
 import { getProgramId } from "@/lib/solana/pda";
 import { uploadCertificateMetadata } from "@/lib/solana/arweave";
-import { isAllLessonsComplete } from "@/lib/solana/bitmap";
+import { isCourseComplete } from "@/lib/solana/bitmap";
 import {
   checkNewAchievements,
   buildUserState,
@@ -447,10 +447,9 @@ async function tryFinalizeCourse(
     const course = await fetchCourse(courseId, connection, getProgramId());
     if (!course) return;
 
-    const lessonCount = Number(course.lesson_count);
     const lessonFlags = enrollment.lesson_flags as (bigint | number)[];
 
-    if (!isAllLessonsComplete(lessonFlags, lessonCount)) return;
+    if (!isCourseComplete(lessonFlags, course.activeLessons)) return;
 
     await onChainFinalizeCourse(courseId, learnerPk);
   } catch (err) {
@@ -524,8 +523,7 @@ async function tryIssueCredential(
       );
     }
     const totalXp =
-      Number(onChainCourse.xp_per_lesson) *
-      (Number(onChainCourse.lesson_count) || 1);
+      Number(onChainCourse.xp_per_lesson) * onChainCourse.liveLessonCount;
 
     // Fetch user profile for metadata
     const supabase = createAdminClient();

--- a/apps/web/src/lib/helius/resolvers.ts
+++ b/apps/web/src/lib/helius/resolvers.ts
@@ -1,12 +1,8 @@
 import "server-only";
 
 import { Connection, PublicKey } from "@solana/web3.js";
-import { BorshCoder, Idl } from "@coral-xyz/anchor";
 import { createAdminClient } from "@/lib/supabase/admin";
-import IDL from "@/lib/solana/idl/superteam_academy.json";
-
-// Double cast: JSON import lacks Anchor's Idl type shape at compile time
-const coder = new BorshCoder(IDL as unknown as Idl);
+import { decodeCourse } from "@/lib/solana/academy-reads";
 
 /**
  * Resolve a wallet address to a Supabase user_id.
@@ -66,9 +62,8 @@ export async function resolveCourseId(
       return null;
     }
 
-    const decoded = coder.accounts.decode("Course", accountInfo.data);
-    // Anchor 0.31+ IDL preserves snake_case field names
-    const courseId = (decoded.course_id ?? decoded.courseId) as string;
+    const decoded = decodeCourse(accountInfo.data);
+    const courseId = decoded.course_id;
     coursePdaCache.set(coursePda, courseId);
     return courseId;
   } catch (err) {

--- a/apps/web/src/lib/solana/__tests__/academy-reads.test.ts
+++ b/apps/web/src/lib/solana/__tests__/academy-reads.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect } from "vitest";
+import { PublicKey } from "@solana/web3.js";
+import type { Idl } from "@coral-xyz/anchor";
+import { BorshCoder } from "@coral-xyz/anchor";
+import BN from "bn.js";
+import V1_IDL from "../idl/superteam_academy.json";
+import VNEXT_IDL from "../idl/superteam_academy_vnext.json";
+import {
+  decodeCourse,
+  COURSE_SIZE_V1,
+  COURSE_SIZE_VNEXT,
+} from "../academy-reads";
+
+// Independent coders built straight from the committed IDL files — mirrors
+// how academy-reads.ts builds coderV1/coderVNext internally, but kept
+// separate here so the test constructs its own synthetic account bytes
+// rather than reaching into the module's private coders.
+const coderV1 = new BorshCoder(V1_IDL as unknown as Idl);
+const coderVNext = new BorshCoder(VNEXT_IDL as unknown as Idl);
+
+/**
+ * `.accounts.encode()` returns discriminator + serialized fields only — it is
+ * NOT padded to the account's allocated `space`. A real on-chain account's
+ * `data` is always the full allocated size (zero-padded), so the length
+ * dispatch in decodeCourse needs fixtures padded out to the real size.
+ */
+function padToSize(buf: Buffer, size: number): Buffer {
+  if (buf.length > size) {
+    throw new Error(
+      `encoded buffer (${buf.length}b) exceeds target size ${size}b`
+    );
+  }
+  const out = Buffer.alloc(size);
+  buf.copy(out);
+  return out;
+}
+
+const CREATOR = PublicKey.unique();
+const COLLECTION = PublicKey.unique();
+const CONTENT_TX_ID = Array(32).fill(7);
+const RESERVED = Array(8).fill(0);
+
+interface V1Fixture {
+  course_id: string;
+  creator: PublicKey;
+  content_tx_id: number[];
+  version: number;
+  lesson_count: number;
+  difficulty: number;
+  xp_per_lesson: number;
+  track_id: number;
+  track_level: number;
+  prerequisite: PublicKey | null;
+  creator_reward_xp: number;
+  min_completions_for_reward: number;
+  total_completions: number;
+  total_enrollments: number;
+  is_active: boolean;
+  created_at: BN;
+  updated_at: BN;
+  collection: PublicKey;
+  _reserved: number[];
+  bump: number;
+}
+
+function makeV1Fixture(overrides: Partial<V1Fixture> = {}): V1Fixture {
+  return {
+    course_id: "solana-101",
+    creator: CREATOR,
+    content_tx_id: CONTENT_TX_ID,
+    version: 1,
+    lesson_count: 12,
+    difficulty: 1,
+    xp_per_lesson: 25,
+    track_id: 0,
+    track_level: 1,
+    prerequisite: null,
+    creator_reward_xp: 100,
+    min_completions_for_reward: 0,
+    total_completions: 5,
+    total_enrollments: 10,
+    is_active: true,
+    created_at: new BN(1_700_000_000),
+    updated_at: new BN(1_700_000_100),
+    collection: COLLECTION,
+    _reserved: RESERVED,
+    bump: 254,
+    ...overrides,
+  };
+}
+
+interface VNextFixture {
+  course_id: string;
+  creator: PublicKey;
+  content_tx_id: number[];
+  version: number;
+  active_lessons: BN[];
+  difficulty: number;
+  xp_per_lesson: number;
+  track_id: number;
+  track_level: number;
+  prerequisite: PublicKey | null;
+  creator_reward_xp: number;
+  total_completions: number;
+  total_enrollments: number;
+  is_active: boolean;
+  created_at: BN;
+  updated_at: BN;
+  collection: PublicKey;
+  _reserved: number[];
+  bump: number;
+}
+
+function makeVNextFixture(overrides: Partial<VNextFixture> = {}): VNextFixture {
+  return {
+    course_id: "solana-201",
+    creator: CREATOR,
+    content_tx_id: CONTENT_TX_ID,
+    version: 1,
+    active_lessons: [new BN(0), new BN(0), new BN(0), new BN(0)],
+    difficulty: 2,
+    xp_per_lesson: 30,
+    track_id: 1,
+    track_level: 2,
+    prerequisite: null,
+    creator_reward_xp: 150,
+    total_completions: 3,
+    total_enrollments: 7,
+    is_active: true,
+    created_at: new BN(1_700_000_200),
+    updated_at: new BN(1_700_000_300),
+    collection: COLLECTION,
+    _reserved: RESERVED,
+    bump: 253,
+    ...overrides,
+  };
+}
+
+async function encodeV1(fixture: V1Fixture): Promise<Buffer> {
+  const raw = await coderV1.accounts.encode("Course", fixture);
+  return padToSize(raw, COURSE_SIZE_V1);
+}
+
+async function encodeVNext(fixture: VNextFixture): Promise<Buffer> {
+  const raw = await coderVNext.accounts.encode("Course", fixture);
+  return padToSize(raw, COURSE_SIZE_VNEXT);
+}
+
+describe("decodeCourse — v1 (224 bytes)", () => {
+  it("dense mask: liveLessonCount matches lesson_count, popcount === 12, bits 0..11 set", async () => {
+    const data = await encodeV1(makeV1Fixture({ lesson_count: 12 }));
+    const course = decodeCourse(data);
+
+    expect(course.liveLessonCount).toBe(12);
+    expect(course.activeLessons).toHaveLength(4);
+    expect(course.activeLessons[0]).toBe(0xfffn);
+    expect(course.activeLessons[1]).toBe(0n);
+    expect(course.activeLessons[2]).toBe(0n);
+    expect(course.activeLessons[3]).toBe(0n);
+
+    const popcount = course.activeLessons.reduce(
+      (sum, word) => sum + word.toString(2).split("1").length - 1,
+      0
+    );
+    expect(popcount).toBe(12);
+  });
+
+  it("behaviour-neutrality: liveLessonCount equals the encoded lesson_count", async () => {
+    for (const lessonCount of [0, 1, 5, 64, 65, 200]) {
+      const data = await encodeV1(makeV1Fixture({ lesson_count: lessonCount }));
+      const course = decodeCourse(data);
+      expect(course.liveLessonCount).toBe(lessonCount);
+    }
+  });
+
+  it("does not expose lesson_count or min_completions_for_reward", async () => {
+    const data = await encodeV1(makeV1Fixture());
+    const course = decodeCourse(data);
+    expect("lesson_count" in course).toBe(false);
+    expect("min_completions_for_reward" in course).toBe(false);
+    expect("active_lessons" in course).toBe(false);
+  });
+});
+
+describe("decodeCourse — v-next (253 bytes)", () => {
+  it("sparse mask: preserves the exact mask and popcount, including a retired slot (bit 3 gap)", async () => {
+    // Bits {0,1,2,4} set, bit 3 deliberately absent (a retired slot) — proves
+    // the mask is carried through as-is rather than re-derived from a count.
+    const sparseMask = (1n << 0n) | (1n << 1n) | (1n << 2n) | (1n << 4n);
+    const data = await encodeVNext(
+      makeVNextFixture({
+        active_lessons: [
+          new BN(sparseMask.toString()),
+          new BN(0),
+          new BN(0),
+          new BN(0),
+        ],
+      })
+    );
+    const course = decodeCourse(data);
+
+    expect(course.activeLessons).toEqual([sparseMask, 0n, 0n, 0n]);
+    expect(course.liveLessonCount).toBe(4);
+  });
+
+  it("does not expose active_lessons", async () => {
+    const data = await encodeVNext(makeVNextFixture());
+    const course = decodeCourse(data);
+    expect("active_lessons" in course).toBe(false);
+    expect("lesson_count" in course).toBe(false);
+  });
+});
+
+describe("decodeCourse — unknown length", () => {
+  it("throws on a 255-byte buffer (never-deployed v2), naming the length", async () => {
+    const data = Buffer.alloc(255);
+    expect(() => decodeCourse(data)).toThrow(/255/);
+  });
+
+  it("throws on an arbitrary short buffer, naming the length", () => {
+    const data = Buffer.alloc(100);
+    expect(() => decodeCourse(data)).toThrow(/100/);
+  });
+});
+
+describe("decodeCourse — shared fields round-trip identically through both branches", () => {
+  it("xp_per_lesson and creator survive the v1 branch", async () => {
+    const data = await encodeV1(
+      makeV1Fixture({ xp_per_lesson: 42, creator: CREATOR })
+    );
+    const course = decodeCourse(data);
+    expect(course.xp_per_lesson).toBe(42);
+    expect(course.creator.equals(CREATOR)).toBe(true);
+  });
+
+  it("xp_per_lesson and creator survive the v-next branch", async () => {
+    const data = await encodeVNext(
+      makeVNextFixture({ xp_per_lesson: 42, creator: CREATOR })
+    );
+    const course = decodeCourse(data);
+    expect(course.xp_per_lesson).toBe(42);
+    expect(course.creator.equals(CREATOR)).toBe(true);
+  });
+});

--- a/apps/web/src/lib/solana/__tests__/bitmap.test.ts
+++ b/apps/web/src/lib/solana/__tests__/bitmap.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import BN from "bn.js";
-import { decodeLessonBitmap, isAllLessonsComplete } from "../bitmap";
+import { decodeLessonBitmap, isCourseComplete } from "../bitmap";
 
 describe("decodeLessonBitmap", () => {
   it("empty bitmap returns all false", () => {
@@ -39,36 +39,96 @@ describe("decodeLessonBitmap", () => {
   });
 });
 
-describe("isAllLessonsComplete", () => {
-  it("false when not all complete", () => {
+// Mirrors the on-chain `finalize_course` gate:
+//   enrollment.lesson_flags.iter().zip(course.active_lessons.iter())
+//       .all(|(flags, active)| flags & active == *active)
+// A SUBSET test over the live-lesson mask, NOT a dense-prefix check — the
+// sparse-mask cases are the whole point (a retired lesson slot must not block
+// completion, and must not be required to be unset either).
+describe("isCourseComplete", () => {
+  it("dense mask, all live bits set -> complete", () => {
+    // active = lessons 0,1,2 (0b111); learner has exactly those bits set.
     expect(
-      isAllLessonsComplete([new BN(3), new BN(0), new BN(0), new BN(0)], 3)
-    ).toBe(false);
-  });
-
-  it("true when all complete", () => {
-    expect(
-      isAllLessonsComplete([new BN(7), new BN(0), new BN(0), new BN(0)], 3)
+      isCourseComplete(
+        [new BN(0b111), new BN(0), new BN(0), new BN(0)],
+        [0b111n, 0n, 0n, 0n]
+      )
     ).toBe(true);
   });
 
-  it("single lesson course", () => {
+  it("dense mask, one live bit missing -> incomplete", () => {
+    // active = lessons 0,1,2 (0b111); learner is missing lesson 2 (0b011).
     expect(
-      isAllLessonsComplete([new BN(1), new BN(0), new BN(0), new BN(0)], 1)
-    ).toBe(true);
-  });
-
-  it("returns false for lessonCount 0", () => {
-    expect(
-      isAllLessonsComplete(
-        [new BN(0xffffffff), new BN(0), new BN(0), new BN(0)],
-        0
+      isCourseComplete(
+        [new BN(0b011), new BN(0), new BN(0), new BN(0)],
+        [0b111n, 0n, 0n, 0n]
       )
     ).toBe(false);
   });
 
-  it("returns false when lessonFlags too short", () => {
-    expect(isAllLessonsComplete([new BN(0xff)], 65)).toBe(false);
+  // Sparse mask: active = {0,1,2,4}, slot 3 retired (0b10111 = 23).
+  const sparseActive: bigint[] = [0b10111n, 0n, 0n, 0n];
+
+  it("sparse mask: learner holds exactly the live slots -> complete", () => {
+    // flags = {0,1,2,4} = 0b10111
+    expect(
+      isCourseComplete(
+        [new BN(0b10111), new BN(0), new BN(0), new BN(0)],
+        sparseActive
+      )
+    ).toBe(true);
+  });
+
+  it("sparse mask: learner missing a live slot -> incomplete", () => {
+    // flags = {0,1,2} = 0b00111, missing live slot 4
+    expect(
+      isCourseComplete(
+        [new BN(0b00111), new BN(0), new BN(0), new BN(0)],
+        sparseActive
+      )
+    ).toBe(false);
+  });
+
+  it("sparse mask: learner also holds a retired-slot bit -> still complete", () => {
+    // flags = {0,1,2,3,4} = 0b11111, includes retired slot 3 — the AND against
+    // `active` ignores the stray bit, so this must still read as complete.
+    expect(
+      isCourseComplete(
+        [new BN(0b11111), new BN(0), new BN(0), new BN(0)],
+        sparseActive
+      )
+    ).toBe(true);
+  });
+
+  it("empty/zero flags with a non-empty mask -> incomplete", () => {
+    expect(
+      isCourseComplete(
+        [new BN(0), new BN(0), new BN(0), new BN(0)],
+        [0b111n, 0n, 0n, 0n]
+      )
+    ).toBe(false);
+  });
+
+  it("empty mask -> complete (vacuous)", () => {
+    expect(
+      isCourseComplete(
+        [new BN(0), new BN(0), new BN(0), new BN(0)],
+        [0n, 0n, 0n, 0n]
+      )
+    ).toBe(true);
+  });
+
+  it("treats a missing/short lessonFlags word as 0", () => {
+    // Only one word of flags supplied, but the mask spans word index 1 too.
+    expect(isCourseComplete([new BN(0)], [0n, 0b1n, 0n, 0n])).toBe(false);
+    expect(isCourseComplete([new BN(0)], [0n, 0n, 0n, 0n])).toBe(true);
+  });
+
+  it("handles bigint and number flag inputs", () => {
+    expect(isCourseComplete([0b111n, 0n, 0n, 0n], [0b111n, 0n, 0n, 0n])).toBe(
+      true
+    );
+    expect(isCourseComplete([0b111, 0, 0, 0], [0b111n, 0n, 0n, 0n])).toBe(true);
   });
 });
 
@@ -83,25 +143,11 @@ describe("decodeLessonBitmap edge cases", () => {
 // A non-finite lessonCount is not hypothetical: callers derive it from a chain
 // read (`Number(course.lesson_count)`), so a Course layout the coder cannot see
 // — e.g. any client/program version skew (#449) — yields NaN. Every guard in
-// these functions is a comparison, and every comparison against NaN is false,
-// so NaN used to sail straight through. These pin the fail-CLOSED behaviour.
+// decodeLessonBitmap is a comparison, and every comparison against NaN is
+// false, so NaN used to sail straight through. This pins the fail-CLOSED
+// behaviour (isCourseComplete has no count parameter, so it needs no such guard).
 describe("non-finite lessonCount fails closed", () => {
   const noneComplete = [new BN(0), new BN(0), new BN(0), new BN(0)];
-
-  it.each([
-    ["NaN", NaN],
-    ["Infinity", Infinity],
-    ["-Infinity", -Infinity],
-  ])(
-    "isAllLessonsComplete returns false for %s (not true via loop fall-through)",
-    (_label, count) => {
-      expect(isAllLessonsComplete(noneComplete, count)).toBe(false);
-    }
-  );
-
-  it("isAllLessonsComplete returns false for a negative count", () => {
-    expect(isAllLessonsComplete(noneComplete, -1)).toBe(false);
-  });
 
   it.each([
     ["NaN", NaN],

--- a/apps/web/src/lib/solana/academy-reads.ts
+++ b/apps/web/src/lib/solana/academy-reads.ts
@@ -1,6 +1,7 @@
 import { Connection, PublicKey } from "@solana/web3.js";
 import type { Idl } from "@coral-xyz/anchor";
 import { BorshCoder } from "@coral-xyz/anchor";
+import type BN from "bn.js";
 import {
   getAssociatedTokenAddressSync,
   getAccount,
@@ -8,6 +9,7 @@ import {
   ASSOCIATED_TOKEN_PROGRAM_ID,
 } from "@solana/spl-token";
 import IDL from "./idl/superteam_academy.json";
+import VNEXT_IDL from "./idl/superteam_academy_vnext.json";
 import {
   findConfigPDA,
   findCoursePDA,
@@ -17,7 +19,241 @@ import {
   getProgramId,
 } from "./pda";
 
+// Config, Enrollment, AchievementType, AchievementReceipt layouts are
+// unchanged across program versions — only `Course` has multiple on-chain
+// byte layouts (see coderV1/coderVNext below), so everything except Course
+// keeps using this single v1 coder.
 const coder = new BorshCoder(IDL as unknown as Idl);
+
+// -----------------------------------------------------------------------------
+// Course: length-dispatched, normalising decode
+// -----------------------------------------------------------------------------
+//
+// The on-chain `Course` account has had multiple byte layouts. Anchor's account
+// discriminator is derived from the struct name alone, so it is IDENTICAL
+// across every layout — and `Course.version` is a content-revision counter,
+// not a schema version. The only reliable signal for which layout an account
+// holds is the account's raw byte length (`data.length`), which always equals
+// the account's allocated `space` (== `Course::SIZE`, zero-padded), regardless
+// of how short the variable-length `course_id` string inside it is.
+//
+//   224 bytes = v1     — `lesson_count: u8` + `min_completions_for_reward: u16`,
+//                        no `active_lessons`. This is the layout in
+//                        `superteam_academy.json` (coderV1) and is what's live
+//                        on devnet today.
+//   253 bytes = v-next — `active_lessons: [u64; 4]`, no `lesson_count` / no
+//                        `min_completions_for_reward`. This is the layout in
+//                        `superteam_academy_vnext.json` (coderVNext).
+//
+// Any other length (e.g. 255, the never-deployed v2) is an unknown layout and
+// must never be silently decoded — decodeCourseBuffer throws.
+const coderV1 = coder;
+const coderVNext = new BorshCoder(VNEXT_IDL as unknown as Idl);
+
+export const COURSE_SIZE_V1 = 224;
+export const COURSE_SIZE_VNEXT = 253;
+
+/** Raw (snake_case) BorshCoder decode of a 224-byte v1 Course account. */
+interface RawCourseV1 {
+  course_id: string;
+  creator: PublicKey;
+  content_tx_id: number[];
+  version: number;
+  lesson_count: number;
+  difficulty: number;
+  xp_per_lesson: number;
+  track_id: number;
+  track_level: number;
+  prerequisite: PublicKey | null;
+  creator_reward_xp: number;
+  min_completions_for_reward: number;
+  total_completions: number;
+  total_enrollments: number;
+  is_active: boolean;
+  created_at: BN;
+  updated_at: BN;
+  collection: PublicKey;
+  _reserved: number[];
+  bump: number;
+}
+
+/** Raw (snake_case) BorshCoder decode of a 253-byte v-next Course account. */
+interface RawCourseVNext {
+  course_id: string;
+  creator: PublicKey;
+  content_tx_id: number[];
+  version: number;
+  active_lessons: BN[];
+  difficulty: number;
+  xp_per_lesson: number;
+  track_id: number;
+  track_level: number;
+  prerequisite: PublicKey | null;
+  creator_reward_xp: number;
+  total_completions: number;
+  total_enrollments: number;
+  is_active: boolean;
+  created_at: BN;
+  updated_at: BN;
+  collection: PublicKey;
+  _reserved: number[];
+  bump: number;
+}
+
+/**
+ * Normalised Course shape returned by `fetchCourse`/`decodeCourse`, regardless
+ * of which on-chain layout (v1 or v-next) the account was actually decoded
+ * from. All pre-existing snake_case fields are unchanged; `activeLessons` and
+ * `liveLessonCount` replace the version-specific `lesson_count` /
+ * `active_lessons` / `min_completions_for_reward` fields so callers stop
+ * asking version-specific questions.
+ */
+export interface DecodedCourse {
+  course_id: string;
+  creator: PublicKey;
+  content_tx_id: number[];
+  version: number;
+  difficulty: number;
+  xp_per_lesson: number;
+  track_id: number;
+  track_level: number;
+  prerequisite: PublicKey | null;
+  creator_reward_xp: number;
+  total_completions: number;
+  total_enrollments: number;
+  is_active: boolean;
+  created_at: BN;
+  updated_at: BN;
+  collection: PublicKey;
+  _reserved: number[];
+  bump: number;
+  /** 256-bit live-lesson mask (4 u64 words), always populated, both versions. */
+  activeLessons: bigint[];
+  /** popcount(activeLessons); for v1 this equals the old `lesson_count`. */
+  liveLessonCount: number;
+  // NOTE: `lesson_count` is intentionally NOT part of this type or the
+  // decoded object — every consumer that still reads `.lesson_count` off a
+  // decoded Course (pre-existing #449 drift; tracked for Tasks 1b/1c/1d) is
+  // left alone per this task's brief. TypeScript would otherwise refuse to
+  // compile that dead-field access now that Course has a real type instead of
+  // `any`, so it's declared here as a type-only, always-`undefined` compat
+  // shim — it is never assigned, so it never appears on the actual decoded
+  // object (`"lesson_count" in course` is false).
+  lesson_count?: undefined;
+}
+
+/** Popcount of a single 64-bit word via Brian Kernighan's algorithm. */
+function popcountWord(word: bigint): number {
+  let count = 0;
+  let w = word;
+  while (w !== 0n) {
+    w &= w - 1n;
+    count++;
+  }
+  return count;
+}
+
+function popcountMask(mask: bigint[]): number {
+  return mask.reduce((sum, word) => sum + popcountWord(word), 0);
+}
+
+/**
+ * Dense mask for a v1 course's `lesson_count` lessons: bits `0..lessonCount-1`
+ * set across the four 64-bit words. Mirrors the on-chain `Course::dense_mask`
+ * (onchain-academy/programs/onchain-academy/src/state/course.rs). Exact
+ * because v1 courses are always dense — no v1 course ever retired a lesson
+ * slot (that capability only exists post-migration, via `active_lessons`).
+ */
+function denseMask(lessonCount: number): bigint[] {
+  const mask: [bigint, bigint, bigint, bigint] = [0n, 0n, 0n, 0n];
+  for (let i = 0; i < lessonCount; i++) {
+    // lessonCount is u8 (<= 255), so i < 255 and word is always 0..3 — a
+    // statically-known-valid tuple index, not an unchecked array access.
+    const word = Math.floor(i / 64) as 0 | 1 | 2 | 3;
+    const bit = BigInt(i % 64);
+    mask[word] |= 1n << bit;
+  }
+  return mask;
+}
+
+function normalizeCourseV1(raw: RawCourseV1): DecodedCourse {
+  const activeLessons = denseMask(raw.lesson_count);
+  return {
+    course_id: raw.course_id,
+    creator: raw.creator,
+    content_tx_id: raw.content_tx_id,
+    version: raw.version,
+    difficulty: raw.difficulty,
+    xp_per_lesson: raw.xp_per_lesson,
+    track_id: raw.track_id,
+    track_level: raw.track_level,
+    prerequisite: raw.prerequisite,
+    creator_reward_xp: raw.creator_reward_xp,
+    total_completions: raw.total_completions,
+    total_enrollments: raw.total_enrollments,
+    is_active: raw.is_active,
+    created_at: raw.created_at,
+    updated_at: raw.updated_at,
+    collection: raw.collection,
+    _reserved: raw._reserved,
+    bump: raw.bump,
+    activeLessons,
+    // Behaviour-neutrality: read `lesson_count` directly rather than
+    // popcount-ing the mask we just synthesised from it. They ARE equal for a
+    // dense mask (every v1 course is dense), but this way every existing
+    // caller of the old `lesson_count` keeps getting the *exact* same number
+    // unconditionally — not contingent on `denseMask` being bug-free.
+    liveLessonCount: raw.lesson_count,
+  };
+}
+
+function normalizeCourseVNext(raw: RawCourseVNext): DecodedCourse {
+  const activeLessons = raw.active_lessons.map((word) =>
+    BigInt(word.toString())
+  );
+  return {
+    course_id: raw.course_id,
+    creator: raw.creator,
+    content_tx_id: raw.content_tx_id,
+    version: raw.version,
+    difficulty: raw.difficulty,
+    xp_per_lesson: raw.xp_per_lesson,
+    track_id: raw.track_id,
+    track_level: raw.track_level,
+    prerequisite: raw.prerequisite,
+    creator_reward_xp: raw.creator_reward_xp,
+    total_completions: raw.total_completions,
+    total_enrollments: raw.total_enrollments,
+    is_active: raw.is_active,
+    created_at: raw.created_at,
+    updated_at: raw.updated_at,
+    collection: raw.collection,
+    _reserved: raw._reserved,
+    bump: raw.bump,
+    activeLessons,
+    liveLessonCount: popcountMask(activeLessons),
+  };
+}
+
+/**
+ * Length-dispatched, normalising Course decode — the ONLY place that should
+ * ever call `coderV1`/`coderVNext .accounts.decode("Course", ...)` directly.
+ * Both `fetchCourse` and `decodeCourse` route through this.
+ */
+function decodeCourseBuffer(data: Buffer): DecodedCourse {
+  if (data.length === COURSE_SIZE_V1) {
+    const raw = coderV1.accounts.decode<RawCourseV1>("Course", data);
+    return normalizeCourseV1(raw);
+  }
+  if (data.length === COURSE_SIZE_VNEXT) {
+    const raw = coderVNext.accounts.decode<RawCourseVNext>("Course", data);
+    return normalizeCourseVNext(raw);
+  }
+  throw new Error(
+    `decodeCourse: unexpected Course account length ${data.length} bytes ` +
+      `(expected ${COURSE_SIZE_V1} [v1] or ${COURSE_SIZE_VNEXT} [v-next])`
+  );
+}
 
 /** Decoded AchievementReceipt PDA (raw BorshCoder returns snake_case). */
 export interface AchievementReceiptDecoded {
@@ -51,21 +287,23 @@ export async function fetchCourse(
   courseId: string,
   connection: Connection,
   programId: PublicKey = getProgramId()
-) {
+): Promise<DecodedCourse | null> {
   const [pda] = findCoursePDA(courseId, programId);
   const accountInfo = await connection.getAccountInfo(pda);
   if (!accountInfo) return null;
-  return coder.accounts.decode("Course", accountInfo.data);
+  return decodeCourseBuffer(accountInfo.data);
 }
 
 /**
- * Decode a Course account from raw account data (BorshCoder → snake_case fields).
+ * Decode a Course account from raw account data (BorshCoder → snake_case
+ * fields, normalised across the v1/v-next layouts — see `DecodedCourse`).
  * Lets a caller that has already fetched the account (e.g. via getAccountInfo)
- * read Course fields without a second RPC round-trip. Throws on a stale/
- * size-mismatched layout — callers that just want a field should try/catch.
+ * read Course fields without a second RPC round-trip. Throws on an account
+ * whose length doesn't match a known layout — callers that just want a field
+ * should try/catch.
  */
-export function decodeCourse(data: Buffer) {
-  return coder.accounts.decode("Course", data);
+export function decodeCourse(data: Buffer): DecodedCourse {
+  return decodeCourseBuffer(data);
 }
 
 export async function fetchAchievementType(

--- a/apps/web/src/lib/solana/academy-reads.ts
+++ b/apps/web/src/lib/solana/academy-reads.ts
@@ -131,15 +131,6 @@ export interface DecodedCourse {
   activeLessons: bigint[];
   /** popcount(activeLessons); for v1 this equals the old `lesson_count`. */
   liveLessonCount: number;
-  // NOTE: `lesson_count` is intentionally NOT part of this type or the
-  // decoded object — every consumer that still reads `.lesson_count` off a
-  // decoded Course (pre-existing #449 drift; tracked for Tasks 1b/1c/1d) is
-  // left alone per this task's brief. TypeScript would otherwise refuse to
-  // compile that dead-field access now that Course has a real type instead of
-  // `any`, so it's declared here as a type-only, always-`undefined` compat
-  // shim — it is never assigned, so it never appears on the actual decoded
-  // object (`"lesson_count" in course` is false).
-  lesson_count?: undefined;
 }
 
 /** Popcount of a single 64-bit word via Brian Kernighan's algorithm. */

--- a/apps/web/src/lib/solana/bitmap.ts
+++ b/apps/web/src/lib/solana/bitmap.ts
@@ -8,8 +8,9 @@ export function decodeLessonBitmap(
 ): boolean[] {
   // Throw rather than silently returning [] — a NaN count would otherwise skip
   // the words check (`x < NaN` is false) and skip the loop (`i < NaN` is false),
-  // decoding every enrollment as "no lessons complete". Same NaN-from-a-chain-read
-  // hazard guarded in isAllLessonsComplete; here the honest answer is an error.
+  // decoding every enrollment as "no lessons complete". The honest answer here
+  // is an error (this is a count-derived read; the mask-based completion check
+  // in isCourseComplete has no count and needs no such guard).
   if (!Number.isFinite(lessonCount) || lessonCount < 0) {
     throw new Error(`decodeLessonBitmap: invalid lessonCount=${lessonCount}`);
   }
@@ -41,25 +42,23 @@ export function isLessonComplete(
   return (word & (1n << BigInt(bitIndex))) !== 0n;
 }
 
-export function isAllLessonsComplete(
+// Mirrors the on-chain `finalize_course` gate exactly:
+//   enrollment.lesson_flags.iter().zip(course.active_lessons.iter())
+//       .all(|(flags, active)| flags & active == *active)
+// This is a SUBSET test over the live-lesson mask, not a dense-prefix check —
+// a retired (non-live) lesson slot never blocks completion, and a learner who
+// finished every live slot is complete even if a retired slot's bit is unset
+// (or, symmetrically, set — the AND against `active` ignores stray bits in
+// retired slots either way).
+export function isCourseComplete(
   lessonFlags: BitValue[],
-  lessonCount: number
+  activeLessons: bigint[]
 ): boolean {
-  // Fail CLOSED on a non-finite count. Callers derive this from a chain read
-  // (`Number(course.lesson_count)`), so a field the coder cannot see yields NaN
-  // — and NaN sails through every guard below: `NaN === 0` is false, `x < NaN`
-  // is false, and `i < NaN` is false on the first iteration, so the loop never
-  // runs and the function falls through to `return true`. "Nobody has completed
-  // anything" would then read as "everybody has completed everything".
-  if (!Number.isFinite(lessonCount) || lessonCount <= 0) return false;
-  const wordsNeeded = Math.ceil(lessonCount / 64);
-  if (lessonFlags.length < wordsNeeded) return false;
-  for (let i = 0; i < lessonCount; i++) {
-    const wordIndex = Math.floor(i / 64);
-    const bitIndex = i % 64;
-    const flagWord = lessonFlags[wordIndex] as BitValue;
-    const word = BigInt(flagWord.toString());
-    if ((word & (1n << BigInt(bitIndex))) === 0n) return false;
+  for (let i = 0; i < activeLessons.length; i++) {
+    const active = activeLessons[i] ?? 0n;
+    const flagWord = lessonFlags[i];
+    const flags = flagWord === undefined ? 0n : BigInt(flagWord.toString());
+    if ((flags & active) !== active) return false;
   }
   return true;
 }

--- a/apps/web/src/lib/solana/idl/superteam_academy_vnext.json
+++ b/apps/web/src/lib/solana/idl/superteam_academy_vnext.json
@@ -1,0 +1,2532 @@
+{
+  "address": "7NeJaSRyb4Wxay3Tcd9bdpD7T3GWYUQSFyrhG8SgwE8V",
+  "metadata": {
+    "name": "onchain_academy",
+    "version": "0.1.0",
+    "spec": "0.1.0",
+    "description": "Superteam Academy on-chain program — courses, XP, credentials, achievements"
+  },
+  "instructions": [
+    {
+      "name": "award_achievement",
+      "discriminator": [75, 47, 156, 253, 124, 231, 84, 12],
+      "accounts": [
+        {
+          "name": "config",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [99, 111, 110, 102, 105, 103]
+              }
+            ]
+          }
+        },
+        {
+          "name": "achievement_type",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [97, 99, 104, 105, 101, 118, 101, 109, 101, 110, 116]
+              },
+              {
+                "kind": "account",
+                "path": "achievement_type.achievement_id",
+                "account": "AchievementType"
+              }
+            ]
+          }
+        },
+        {
+          "name": "achievement_receipt",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  97, 99, 104, 105, 101, 118, 101, 109, 101, 110, 116, 95, 114,
+                  101, 99, 101, 105, 112, 116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "achievement_type.achievement_id",
+                "account": "AchievementType"
+              },
+              {
+                "kind": "account",
+                "path": "recipient"
+              }
+            ]
+          }
+        },
+        {
+          "name": "minter_role",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [109, 105, 110, 116, 101, 114]
+              },
+              {
+                "kind": "account",
+                "path": "minter"
+              }
+            ]
+          }
+        },
+        {
+          "name": "asset",
+          "docs": ["New achievement NFT keypair"],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "collection",
+          "writable": true
+        },
+        {
+          "name": "recipient"
+        },
+        {
+          "name": "recipient_token_account",
+          "docs": [
+            "its base mint (== Config.xp_mint) and token-account owner (== recipient)",
+            "are asserted in the handler via `require_xp_recipient` before minting."
+          ],
+          "writable": true
+        },
+        {
+          "name": "xp_mint",
+          "writable": true
+        },
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "minter",
+          "signer": true
+        },
+        {
+          "name": "backend_signer",
+          "docs": [
+            "Rotatable backend signer that authorizes the award. Eligibility is",
+            "proven off-chain (achievement criteria have no on-chain qualifying",
+            "receipt to validate against), so this co-signature is the authorization",
+            "boundary: an active minter alone cannot mint arbitrary achievements."
+          ],
+          "signer": true
+        },
+        {
+          "name": "mpl_core_program",
+          "address": "CoREENxT6tW1HoK8ypY1SxRMZTcVPm7R94rH4PZNhX7d"
+        },
+        {
+          "name": "token_program",
+          "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "close_course",
+      "discriminator": [157, 252, 239, 166, 213, 174, 160, 34],
+      "accounts": [
+        {
+          "name": "config",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [99, 111, 110, 102, 105, 103]
+              }
+            ]
+          }
+        },
+        {
+          "name": "course",
+          "docs": [
+            "for `course_id`) and `owner = crate::ID` (program-owned). Loaded as",
+            "`UncheckedAccount` rather than `Account<Course>` so a stale, size-mismatched",
+            "(pre-resize, 192-byte) account can still be closed. The handler also",
+            "verifies the `Course` discriminator before draining/freeing it."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [99, 111, 117, 114, 115, 101]
+              },
+              {
+                "kind": "arg",
+                "path": "course_id"
+              }
+            ]
+          }
+        },
+        {
+          "name": "authority",
+          "signer": true,
+          "relations": ["config"]
+        }
+      ],
+      "args": [
+        {
+          "name": "course_id",
+          "type": "string"
+        }
+      ]
+    },
+    {
+      "name": "close_enrollment",
+      "discriminator": [236, 137, 133, 253, 91, 138, 217, 91],
+      "accounts": [
+        {
+          "name": "course",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [99, 111, 117, 114, 115, 101]
+              },
+              {
+                "kind": "account",
+                "path": "course.course_id",
+                "account": "Course"
+              }
+            ]
+          }
+        },
+        {
+          "name": "enrollment",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [101, 110, 114, 111, 108, 108, 109, 101, 110, 116]
+              },
+              {
+                "kind": "account",
+                "path": "course.course_id",
+                "account": "Course"
+              },
+              {
+                "kind": "account",
+                "path": "learner"
+              }
+            ]
+          }
+        },
+        {
+          "name": "learner",
+          "writable": true,
+          "signer": true
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "complete_lesson",
+      "discriminator": [77, 217, 53, 132, 204, 150, 169, 58],
+      "accounts": [
+        {
+          "name": "config",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [99, 111, 110, 102, 105, 103]
+              }
+            ]
+          }
+        },
+        {
+          "name": "course",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [99, 111, 117, 114, 115, 101]
+              },
+              {
+                "kind": "account",
+                "path": "course.course_id",
+                "account": "Course"
+              }
+            ]
+          }
+        },
+        {
+          "name": "enrollment",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [101, 110, 114, 111, 108, 108, 109, 101, 110, 116]
+              },
+              {
+                "kind": "account",
+                "path": "course.course_id",
+                "account": "Course"
+              },
+              {
+                "kind": "account",
+                "path": "learner"
+              }
+            ]
+          }
+        },
+        {
+          "name": "learner"
+        },
+        {
+          "name": "learner_token_account",
+          "docs": [
+            "base mint (== Config.xp_mint) and token-account owner (== learner) are",
+            "asserted in the handler via `require_xp_recipient` before minting."
+          ],
+          "writable": true
+        },
+        {
+          "name": "xp_mint",
+          "writable": true
+        },
+        {
+          "name": "backend_signer",
+          "signer": true
+        },
+        {
+          "name": "token_program",
+          "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+        }
+      ],
+      "args": [
+        {
+          "name": "lesson_index",
+          "type": "u8"
+        }
+      ]
+    },
+    {
+      "name": "create_achievement_type",
+      "discriminator": [231, 38, 39, 228, 103, 4, 229, 19],
+      "accounts": [
+        {
+          "name": "config",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [99, 111, 110, 102, 105, 103]
+              }
+            ]
+          }
+        },
+        {
+          "name": "achievement_type",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [97, 99, 104, 105, 101, 118, 101, 109, 101, 110, 116]
+              },
+              {
+                "kind": "arg",
+                "path": "params.achievement_id"
+              }
+            ]
+          }
+        },
+        {
+          "name": "collection",
+          "docs": ["New Metaplex Core collection keypair"],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "authority",
+          "signer": true
+        },
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "mpl_core_program",
+          "address": "CoREENxT6tW1HoK8ypY1SxRMZTcVPm7R94rH4PZNhX7d"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "CreateAchievementTypeParams"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "create_course",
+      "discriminator": [120, 121, 154, 164, 107, 180, 167, 241],
+      "accounts": [
+        {
+          "name": "course",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [99, 111, 117, 114, 115, 101]
+              },
+              {
+                "kind": "arg",
+                "path": "params.course_id"
+              }
+            ]
+          }
+        },
+        {
+          "name": "config",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [99, 111, 110, 102, 105, 103]
+              }
+            ]
+          }
+        },
+        {
+          "name": "authority",
+          "writable": true,
+          "signer": true,
+          "relations": ["config"]
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "CreateCourseParams"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "deactivate_achievement_type",
+      "discriminator": [185, 21, 222, 243, 192, 118, 71, 191],
+      "accounts": [
+        {
+          "name": "config",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [99, 111, 110, 102, 105, 103]
+              }
+            ]
+          }
+        },
+        {
+          "name": "achievement_type",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [97, 99, 104, 105, 101, 118, 101, 109, 101, 110, 116]
+              },
+              {
+                "kind": "account",
+                "path": "achievement_type.achievement_id",
+                "account": "AchievementType"
+              }
+            ]
+          }
+        },
+        {
+          "name": "authority",
+          "signer": true
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "enroll",
+      "discriminator": [58, 12, 36, 3, 142, 28, 1, 43],
+      "accounts": [
+        {
+          "name": "course",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [99, 111, 117, 114, 115, 101]
+              },
+              {
+                "kind": "arg",
+                "path": "course_id"
+              }
+            ]
+          }
+        },
+        {
+          "name": "enrollment",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [101, 110, 114, 111, 108, 108, 109, 101, 110, 116]
+              },
+              {
+                "kind": "arg",
+                "path": "course_id"
+              },
+              {
+                "kind": "account",
+                "path": "learner"
+              }
+            ]
+          }
+        },
+        {
+          "name": "learner",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "course_id",
+          "type": "string"
+        }
+      ]
+    },
+    {
+      "name": "finalize_course",
+      "discriminator": [68, 189, 122, 239, 39, 121, 16, 218],
+      "accounts": [
+        {
+          "name": "config",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [99, 111, 110, 102, 105, 103]
+              }
+            ]
+          }
+        },
+        {
+          "name": "course",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [99, 111, 117, 114, 115, 101]
+              },
+              {
+                "kind": "account",
+                "path": "course.course_id",
+                "account": "Course"
+              }
+            ]
+          }
+        },
+        {
+          "name": "enrollment",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [101, 110, 114, 111, 108, 108, 109, 101, 110, 116]
+              },
+              {
+                "kind": "account",
+                "path": "course.course_id",
+                "account": "Course"
+              },
+              {
+                "kind": "account",
+                "path": "learner"
+              }
+            ]
+          }
+        },
+        {
+          "name": "learner"
+        },
+        {
+          "name": "learner_token_account",
+          "docs": [
+            "its base mint (== Config.xp_mint) and token-account owner (== learner) are",
+            "asserted in the handler via `require_xp_recipient` before minting."
+          ],
+          "writable": true
+        },
+        {
+          "name": "creator_token_account",
+          "docs": [
+            "its base mint (== Config.xp_mint) and token-account owner (== creator) are",
+            "asserted in the handler via `require_xp_recipient` before minting."
+          ],
+          "writable": true
+        },
+        {
+          "name": "creator"
+        },
+        {
+          "name": "xp_mint",
+          "writable": true
+        },
+        {
+          "name": "backend_signer",
+          "signer": true
+        },
+        {
+          "name": "token_program",
+          "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "initialize",
+      "discriminator": [175, 175, 109, 31, 13, 152, 155, 237],
+      "accounts": [
+        {
+          "name": "config",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [99, 111, 110, 102, 105, 103]
+              }
+            ]
+          }
+        },
+        {
+          "name": "xp_mint",
+          "docs": [
+            "Passed as a signer (new keypair) so create_account can assign ownership",
+            "to the Token-2022 program."
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "authority",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "backend_minter_role",
+          "docs": [
+            "Auto-registered MinterRole for the backend signer (defaults to authority)"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [109, 105, 110, 116, 101, 114]
+              },
+              {
+                "kind": "account",
+                "path": "authority"
+              }
+            ]
+          }
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "token_program",
+          "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "issue_credential",
+      "discriminator": [255, 193, 171, 224, 68, 171, 194, 87],
+      "accounts": [
+        {
+          "name": "config",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [99, 111, 110, 102, 105, 103]
+              }
+            ]
+          }
+        },
+        {
+          "name": "course",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [99, 111, 117, 114, 115, 101]
+              },
+              {
+                "kind": "account",
+                "path": "course.course_id",
+                "account": "Course"
+              }
+            ]
+          }
+        },
+        {
+          "name": "enrollment",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [101, 110, 114, 111, 108, 108, 109, 101, 110, 116]
+              },
+              {
+                "kind": "account",
+                "path": "course.course_id",
+                "account": "Course"
+              },
+              {
+                "kind": "account",
+                "path": "learner"
+              }
+            ]
+          }
+        },
+        {
+          "name": "learner"
+        },
+        {
+          "name": "credential_asset",
+          "docs": [
+            "New credential NFT asset keypair — must sign the transaction."
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "track_collection",
+          "writable": true
+        },
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "backend_signer",
+          "signer": true
+        },
+        {
+          "name": "mpl_core_program",
+          "address": "CoREENxT6tW1HoK8ypY1SxRMZTcVPm7R94rH4PZNhX7d"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "credential_name",
+          "type": "string"
+        },
+        {
+          "name": "metadata_uri",
+          "type": "string"
+        },
+        {
+          "name": "courses_completed",
+          "type": "u32"
+        },
+        {
+          "name": "total_xp",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "register_minter",
+      "discriminator": [58, 224, 74, 142, 170, 95, 116, 191],
+      "accounts": [
+        {
+          "name": "config",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [99, 111, 110, 102, 105, 103]
+              }
+            ]
+          }
+        },
+        {
+          "name": "minter_role",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [109, 105, 110, 116, 101, 114]
+              },
+              {
+                "kind": "arg",
+                "path": "params.minter"
+              }
+            ]
+          }
+        },
+        {
+          "name": "authority",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "RegisterMinterParams"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "revoke_minter",
+      "discriminator": [33, 91, 131, 167, 62, 37, 38, 105],
+      "accounts": [
+        {
+          "name": "config",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [99, 111, 110, 102, 105, 103]
+              }
+            ]
+          }
+        },
+        {
+          "name": "minter_role",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [109, 105, 110, 116, 101, 114]
+              },
+              {
+                "kind": "account",
+                "path": "minter_role.minter",
+                "account": "MinterRole"
+              }
+            ]
+          }
+        },
+        {
+          "name": "authority",
+          "writable": true,
+          "signer": true
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "reward_xp",
+      "discriminator": [144, 187, 117, 238, 89, 118, 224, 145],
+      "accounts": [
+        {
+          "name": "config",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [99, 111, 110, 102, 105, 103]
+              }
+            ]
+          }
+        },
+        {
+          "name": "minter_role",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [109, 105, 110, 116, 101, 114]
+              },
+              {
+                "kind": "account",
+                "path": "minter"
+              }
+            ]
+          }
+        },
+        {
+          "name": "xp_mint",
+          "docs": ["Token-2022 XP mint"],
+          "writable": true
+        },
+        {
+          "name": "recipient_token_account",
+          "docs": [
+            "Recipient's Token-2022 ATA for XP.",
+            "",
+            "reward_xp is address-based by design: the minter passes the destination",
+            "ATA directly and there is no on-chain recipient-identity account to bind",
+            "its owner against (unlike complete_lesson/finalize_course/award_achievement,",
+            "which each own a learner/creator/recipient key). The mint is still pinned",
+            "via `require_xp_mint` (== Config.xp_mint) and the amount is bounded by",
+            "MAX_XP_PER_MINT + the per-minter cap, so the account cannot be an ATA of an",
+            "unrelated mint and the per-call blast radius is bounded."
+          ],
+          "writable": true
+        },
+        {
+          "name": "minter",
+          "signer": true
+        },
+        {
+          "name": "backend_signer",
+          "signer": true
+        },
+        {
+          "name": "token_program",
+          "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+        }
+      ],
+      "args": [
+        {
+          "name": "amount",
+          "type": "u64"
+        },
+        {
+          "name": "memo",
+          "type": "string"
+        }
+      ]
+    },
+    {
+      "name": "update_config",
+      "discriminator": [29, 158, 252, 191, 10, 83, 219, 99],
+      "accounts": [
+        {
+          "name": "config",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [99, 111, 110, 102, 105, 103]
+              }
+            ]
+          }
+        },
+        {
+          "name": "authority",
+          "signer": true,
+          "relations": ["config"]
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "UpdateConfigParams"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "update_course",
+      "discriminator": [81, 217, 18, 192, 129, 233, 129, 231],
+      "accounts": [
+        {
+          "name": "config",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [99, 111, 110, 102, 105, 103]
+              }
+            ]
+          }
+        },
+        {
+          "name": "course",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [99, 111, 117, 114, 115, 101]
+              },
+              {
+                "kind": "account",
+                "path": "course.course_id",
+                "account": "Course"
+              }
+            ]
+          }
+        },
+        {
+          "name": "authority",
+          "signer": true,
+          "relations": ["config"]
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "UpdateCourseParams"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "update_minter",
+      "discriminator": [164, 129, 164, 88, 75, 29, 91, 38],
+      "accounts": [
+        {
+          "name": "config",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [99, 111, 110, 102, 105, 103]
+              }
+            ]
+          }
+        },
+        {
+          "name": "minter_role",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [109, 105, 110, 116, 101, 114]
+              },
+              {
+                "kind": "account",
+                "path": "minter_role.minter",
+                "account": "MinterRole"
+              }
+            ]
+          }
+        },
+        {
+          "name": "authority",
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "UpdateMinterParams"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "upgrade_credential",
+      "discriminator": [2, 121, 77, 255, 103, 187, 252, 169],
+      "accounts": [
+        {
+          "name": "config",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [99, 111, 110, 102, 105, 103]
+              }
+            ]
+          }
+        },
+        {
+          "name": "course",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [99, 111, 117, 114, 115, 101]
+              },
+              {
+                "kind": "account",
+                "path": "course.course_id",
+                "account": "Course"
+              }
+            ]
+          }
+        },
+        {
+          "name": "enrollment",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [101, 110, 114, 111, 108, 108, 109, 101, 110, 116]
+              },
+              {
+                "kind": "account",
+                "path": "course.course_id",
+                "account": "Course"
+              },
+              {
+                "kind": "account",
+                "path": "learner"
+              }
+            ]
+          }
+        },
+        {
+          "name": "learner"
+        },
+        {
+          "name": "credential_asset",
+          "docs": [
+            "Existing credential NFT asset — not a signer, validated against enrollment record."
+          ],
+          "writable": true
+        },
+        {
+          "name": "track_collection",
+          "writable": true
+        },
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "backend_signer",
+          "signer": true
+        },
+        {
+          "name": "mpl_core_program",
+          "address": "CoREENxT6tW1HoK8ypY1SxRMZTcVPm7R94rH4PZNhX7d"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "credential_name",
+          "type": "string"
+        },
+        {
+          "name": "metadata_uri",
+          "type": "string"
+        },
+        {
+          "name": "courses_completed",
+          "type": "u32"
+        },
+        {
+          "name": "total_xp",
+          "type": "u64"
+        }
+      ]
+    }
+  ],
+  "accounts": [
+    {
+      "name": "AchievementReceipt",
+      "discriminator": [149, 5, 79, 178, 116, 231, 43, 248]
+    },
+    {
+      "name": "AchievementType",
+      "discriminator": [13, 187, 114, 66, 217, 154, 85, 137]
+    },
+    {
+      "name": "Config",
+      "discriminator": [155, 12, 170, 224, 30, 250, 204, 130]
+    },
+    {
+      "name": "Course",
+      "discriminator": [206, 6, 78, 228, 163, 138, 241, 106]
+    },
+    {
+      "name": "Enrollment",
+      "discriminator": [249, 210, 64, 145, 197, 241, 57, 51]
+    },
+    {
+      "name": "MinterRole",
+      "discriminator": [21, 246, 6, 133, 142, 211, 33, 193]
+    }
+  ],
+  "events": [
+    {
+      "name": "AchievementAwarded",
+      "discriminator": [127, 212, 93, 231, 175, 0, 69, 150]
+    },
+    {
+      "name": "AchievementTypeCreated",
+      "discriminator": [189, 36, 173, 243, 25, 232, 198, 153]
+    },
+    {
+      "name": "AchievementTypeDeactivated",
+      "discriminator": [133, 12, 218, 127, 151, 28, 1, 222]
+    },
+    {
+      "name": "ConfigUpdated",
+      "discriminator": [40, 241, 230, 122, 11, 19, 198, 194]
+    },
+    {
+      "name": "CourseClosed",
+      "discriminator": [35, 195, 37, 254, 25, 107, 100, 12]
+    },
+    {
+      "name": "CourseCreated",
+      "discriminator": [205, 144, 55, 47, 150, 170, 123, 214]
+    },
+    {
+      "name": "CourseFinalized",
+      "discriminator": [18, 195, 195, 25, 165, 189, 194, 56]
+    },
+    {
+      "name": "CourseUpdated",
+      "discriminator": [124, 141, 110, 224, 149, 124, 26, 141]
+    },
+    {
+      "name": "CredentialIssued",
+      "discriminator": [194, 216, 28, 159, 89, 29, 72, 177]
+    },
+    {
+      "name": "CredentialUpgraded",
+      "discriminator": [198, 142, 252, 191, 210, 200, 253, 133]
+    },
+    {
+      "name": "Enrolled",
+      "discriminator": [129, 156, 102, 214, 94, 196, 220, 127]
+    },
+    {
+      "name": "EnrollmentClosed",
+      "discriminator": [197, 4, 145, 238, 217, 4, 175, 77]
+    },
+    {
+      "name": "LessonCompleted",
+      "discriminator": [248, 174, 148, 235, 186, 49, 11, 163]
+    },
+    {
+      "name": "MinterRegistered",
+      "discriminator": [104, 203, 87, 105, 23, 33, 231, 1]
+    },
+    {
+      "name": "MinterRevoked",
+      "discriminator": [138, 76, 227, 247, 141, 92, 77, 127]
+    },
+    {
+      "name": "MinterUpdated",
+      "discriminator": [8, 124, 66, 45, 176, 53, 49, 153]
+    },
+    {
+      "name": "MintingPauseSet",
+      "discriminator": [232, 11, 219, 8, 116, 65, 178, 74]
+    },
+    {
+      "name": "XpRewarded",
+      "discriminator": [140, 182, 232, 144, 16, 155, 237, 182]
+    }
+  ],
+  "errors": [
+    {
+      "code": 6000,
+      "name": "Unauthorized",
+      "msg": "Unauthorized signer"
+    },
+    {
+      "code": 6001,
+      "name": "CourseNotActive",
+      "msg": "Course not active"
+    },
+    {
+      "code": 6002,
+      "name": "LessonOutOfBounds",
+      "msg": "Lesson index out of bounds"
+    },
+    {
+      "code": 6003,
+      "name": "LessonAlreadyCompleted",
+      "msg": "Lesson already completed"
+    },
+    {
+      "code": 6004,
+      "name": "CourseNotCompleted",
+      "msg": "Not all lessons completed"
+    },
+    {
+      "code": 6005,
+      "name": "CourseAlreadyFinalized",
+      "msg": "Course already finalized"
+    },
+    {
+      "code": 6006,
+      "name": "CourseNotFinalized",
+      "msg": "Course not finalized"
+    },
+    {
+      "code": 6007,
+      "name": "PrerequisiteNotMet",
+      "msg": "Prerequisite not met"
+    },
+    {
+      "code": 6008,
+      "name": "UnenrollCooldown",
+      "msg": "Close cooldown not met (24h)"
+    },
+    {
+      "code": 6009,
+      "name": "EnrollmentCourseMismatch",
+      "msg": "Enrollment/course mismatch"
+    },
+    {
+      "code": 6010,
+      "name": "Overflow",
+      "msg": "Arithmetic overflow"
+    },
+    {
+      "code": 6011,
+      "name": "CourseIdEmpty",
+      "msg": "Course ID is empty"
+    },
+    {
+      "code": 6012,
+      "name": "CourseIdTooLong",
+      "msg": "Course ID exceeds max length"
+    },
+    {
+      "code": 6013,
+      "name": "InvalidLessonCount",
+      "msg": "Lesson count must be at least 1"
+    },
+    {
+      "code": 6014,
+      "name": "InvalidDifficulty",
+      "msg": "Difficulty must be 1, 2, or 3"
+    },
+    {
+      "code": 6015,
+      "name": "CredentialAssetMismatch",
+      "msg": "Credential asset does not match enrollment record"
+    },
+    {
+      "code": 6016,
+      "name": "CollectionMismatch",
+      "msg": "Collection does not match the course's credential collection"
+    },
+    {
+      "code": 6017,
+      "name": "CredentialAlreadyIssued",
+      "msg": "Credential already issued for this enrollment"
+    },
+    {
+      "code": 6018,
+      "name": "MinterNotActive",
+      "msg": "Minter role is not active"
+    },
+    {
+      "code": 6019,
+      "name": "MinterAmountExceeded",
+      "msg": "Amount exceeds minter's per-call limit"
+    },
+    {
+      "code": 6020,
+      "name": "MinterCapExceeded",
+      "msg": "Cumulative minted XP would exceed minter's total cap"
+    },
+    {
+      "code": 6021,
+      "name": "LabelTooLong",
+      "msg": "Minter label exceeds max length"
+    },
+    {
+      "code": 6022,
+      "name": "AchievementNotActive",
+      "msg": "Achievement type is not active"
+    },
+    {
+      "code": 6023,
+      "name": "AchievementSupplyExhausted",
+      "msg": "Achievement max supply reached"
+    },
+    {
+      "code": 6024,
+      "name": "AchievementIdTooLong",
+      "msg": "Achievement ID exceeds max length"
+    },
+    {
+      "code": 6025,
+      "name": "AchievementNameTooLong",
+      "msg": "Achievement name exceeds max length"
+    },
+    {
+      "code": 6026,
+      "name": "AchievementUriTooLong",
+      "msg": "Achievement URI exceeds max length"
+    },
+    {
+      "code": 6027,
+      "name": "InvalidAmount",
+      "msg": "Amount must be greater than zero"
+    },
+    {
+      "code": 6028,
+      "name": "InvalidXpReward",
+      "msg": "XP reward must be greater than zero"
+    },
+    {
+      "code": 6029,
+      "name": "EnrollmentFinalized",
+      "msg": "Finalized or credentialed enrollment cannot be closed"
+    },
+    {
+      "code": 6030,
+      "name": "InvalidCourseAccount",
+      "msg": "Account is not a valid Course PDA"
+    },
+    {
+      "code": 6031,
+      "name": "MintingPaused",
+      "msg": "Minting is paused"
+    },
+    {
+      "code": 6032,
+      "name": "WrongXpMint",
+      "msg": "Recipient token account mint does not match Config.xp_mint"
+    },
+    {
+      "code": 6033,
+      "name": "XpAmountExceedsMax",
+      "msg": "XP amount exceeds the per-mint ceiling"
+    },
+    {
+      "code": 6034,
+      "name": "LessonCountDecrease",
+      "msg": "Lesson count can only be increased, never decreased"
+    }
+  ],
+  "types": [
+    {
+      "name": "AchievementAwarded",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "achievement_id",
+            "type": "string"
+          },
+          {
+            "name": "recipient",
+            "type": "pubkey"
+          },
+          {
+            "name": "asset",
+            "type": "pubkey"
+          },
+          {
+            "name": "xp_reward",
+            "type": "u32"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "AchievementReceipt",
+      "docs": [
+        "Thin PDA for on-chain double-award prevention.",
+        "Seeds: [\"achievement_receipt\", achievement_id.as_bytes(), recipient.key()]"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "asset",
+            "docs": ["Metaplex Core NFT address"],
+            "type": "pubkey"
+          },
+          {
+            "name": "awarded_at",
+            "type": "i64"
+          },
+          {
+            "name": "bump",
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "AchievementType",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "achievement_id",
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "type": "string"
+          },
+          {
+            "name": "metadata_uri",
+            "docs": ["Default metadata URI for minted NFTs"],
+            "type": "string"
+          },
+          {
+            "name": "collection",
+            "docs": ["Metaplex Core collection for this achievement"],
+            "type": "pubkey"
+          },
+          {
+            "name": "creator",
+            "type": "pubkey"
+          },
+          {
+            "name": "max_supply",
+            "docs": ["0 = unlimited supply"],
+            "type": "u32"
+          },
+          {
+            "name": "current_supply",
+            "type": "u32"
+          },
+          {
+            "name": "xp_reward",
+            "docs": ["XP awarded alongside the NFT (0 = no XP)"],
+            "type": "u32"
+          },
+          {
+            "name": "is_active",
+            "type": "bool"
+          },
+          {
+            "name": "created_at",
+            "type": "i64"
+          },
+          {
+            "name": "_reserved",
+            "type": {
+              "array": ["u8", 8]
+            }
+          },
+          {
+            "name": "bump",
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "AchievementTypeCreated",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "achievement_id",
+            "type": "string"
+          },
+          {
+            "name": "collection",
+            "type": "pubkey"
+          },
+          {
+            "name": "creator",
+            "type": "pubkey"
+          },
+          {
+            "name": "max_supply",
+            "type": "u32"
+          },
+          {
+            "name": "xp_reward",
+            "type": "u32"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "AchievementTypeDeactivated",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "achievement_id",
+            "type": "string"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Config",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "authority",
+            "docs": ["Platform multisig (Squads)"],
+            "type": "pubkey"
+          },
+          {
+            "name": "backend_signer",
+            "docs": ["Rotatable backend signer for completions"],
+            "type": "pubkey"
+          },
+          {
+            "name": "xp_mint",
+            "docs": ["Token-2022 mint for XP"],
+            "type": "pubkey"
+          },
+          {
+            "name": "paused",
+            "docs": [
+              "Global minting kill-switch. When true, every XP-minting / credential",
+              "instruction is blocked: complete_lesson, finalize_course, reward_xp,",
+              "award_achievement, and issue_credential. Occupies the first former",
+              "`_reserved` byte; legacy accounts (reserved zeroed) deserialize as `false`."
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "_reserved",
+            "docs": ["Reserved for future use"],
+            "type": {
+              "array": ["u8", 7]
+            }
+          },
+          {
+            "name": "bump",
+            "docs": ["PDA bump"],
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ConfigUpdated",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "field",
+            "type": "string"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Course",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "course_id",
+            "type": "string"
+          },
+          {
+            "name": "creator",
+            "docs": [
+              "XP recipient for creator rewards (not an authority — all admin goes through Config)"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "content_tx_id",
+            "type": {
+              "array": ["u8", 32]
+            }
+          },
+          {
+            "name": "version",
+            "type": "u16"
+          },
+          {
+            "name": "active_lessons",
+            "docs": [
+              "256-bit mask of live lesson slots, mirroring `Enrollment.lesson_flags`.",
+              "Bit `i` set ⇒ slot `i` is a live lesson. Replaces the v1 `lesson_count`",
+              "(u8): the live-lesson count is `live_lesson_count()` (popcount) and",
+              "completion is `lesson_flags & active_lessons == active_lessons`, so",
+              "retiring a slot (clearing its bit) never strands a completed learner."
+            ],
+            "type": {
+              "array": ["u64", 4]
+            }
+          },
+          {
+            "name": "difficulty",
+            "type": "u8"
+          },
+          {
+            "name": "xp_per_lesson",
+            "type": "u32"
+          },
+          {
+            "name": "track_id",
+            "type": "u16"
+          },
+          {
+            "name": "track_level",
+            "type": "u8"
+          },
+          {
+            "name": "prerequisite",
+            "type": {
+              "option": "pubkey"
+            }
+          },
+          {
+            "name": "creator_reward_xp",
+            "docs": [
+              "XP minted to the creator on every completion; no completion-count",
+              "threshold or window (still bounded per mint by MAX_XP_PER_MINT)."
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "total_completions",
+            "type": "u32"
+          },
+          {
+            "name": "total_enrollments",
+            "type": "u32"
+          },
+          {
+            "name": "is_active",
+            "type": "bool"
+          },
+          {
+            "name": "created_at",
+            "type": "i64"
+          },
+          {
+            "name": "updated_at",
+            "type": "i64"
+          },
+          {
+            "name": "collection",
+            "docs": [
+              "Metaplex Core collection this course's credentials are minted into.",
+              "`Pubkey::default()` until set via `create_course`/`update_course`."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "_reserved",
+            "type": {
+              "array": ["u8", 8]
+            }
+          },
+          {
+            "name": "bump",
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "CourseClosed",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "course",
+            "type": "pubkey"
+          },
+          {
+            "name": "course_id",
+            "type": "string"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "CourseCreated",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "course",
+            "type": "pubkey"
+          },
+          {
+            "name": "course_id",
+            "type": "string"
+          },
+          {
+            "name": "creator",
+            "type": "pubkey"
+          },
+          {
+            "name": "track_id",
+            "type": "u16"
+          },
+          {
+            "name": "track_level",
+            "type": "u8"
+          },
+          {
+            "name": "collection",
+            "type": "pubkey"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "CourseFinalized",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "learner",
+            "type": "pubkey"
+          },
+          {
+            "name": "course",
+            "type": "pubkey"
+          },
+          {
+            "name": "total_xp",
+            "type": "u32"
+          },
+          {
+            "name": "bonus_xp",
+            "type": "u64"
+          },
+          {
+            "name": "creator",
+            "type": "pubkey"
+          },
+          {
+            "name": "creator_xp",
+            "type": "u32"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "CourseUpdated",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "course",
+            "type": "pubkey"
+          },
+          {
+            "name": "version",
+            "type": "u16"
+          },
+          {
+            "name": "collection",
+            "type": "pubkey"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "CreateAchievementTypeParams",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "achievement_id",
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "type": "string"
+          },
+          {
+            "name": "metadata_uri",
+            "type": "string"
+          },
+          {
+            "name": "max_supply",
+            "type": "u32"
+          },
+          {
+            "name": "xp_reward",
+            "type": "u32"
+          }
+        ]
+      }
+    },
+    {
+      "name": "CreateCourseParams",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "course_id",
+            "type": "string"
+          },
+          {
+            "name": "creator",
+            "type": "pubkey"
+          },
+          {
+            "name": "content_tx_id",
+            "type": {
+              "array": ["u8", 32]
+            }
+          },
+          {
+            "name": "lesson_count",
+            "type": "u8"
+          },
+          {
+            "name": "difficulty",
+            "type": "u8"
+          },
+          {
+            "name": "xp_per_lesson",
+            "type": "u32"
+          },
+          {
+            "name": "track_id",
+            "type": "u16"
+          },
+          {
+            "name": "track_level",
+            "type": "u8"
+          },
+          {
+            "name": "prerequisite",
+            "type": {
+              "option": "pubkey"
+            }
+          },
+          {
+            "name": "creator_reward_xp",
+            "type": "u32"
+          },
+          {
+            "name": "collection",
+            "docs": [
+              "Metaplex Core collection for credential NFTs. `None` defers to a later",
+              "`update_course` (the per-course collection is created after the PDA)."
+            ],
+            "type": {
+              "option": "pubkey"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "CredentialIssued",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "learner",
+            "type": "pubkey"
+          },
+          {
+            "name": "track_id",
+            "type": "u16"
+          },
+          {
+            "name": "credential_asset",
+            "type": "pubkey"
+          },
+          {
+            "name": "current_level",
+            "type": "u8"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "CredentialUpgraded",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "learner",
+            "type": "pubkey"
+          },
+          {
+            "name": "track_id",
+            "type": "u16"
+          },
+          {
+            "name": "credential_asset",
+            "type": "pubkey"
+          },
+          {
+            "name": "current_level",
+            "type": "u8"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Enrolled",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "learner",
+            "type": "pubkey"
+          },
+          {
+            "name": "course",
+            "type": "pubkey"
+          },
+          {
+            "name": "course_version",
+            "type": "u16"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Enrollment",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "course",
+            "docs": ["The Course PDA this enrollment belongs to"],
+            "type": "pubkey"
+          },
+          {
+            "name": "enrolled_at",
+            "docs": ["When learner enrolled"],
+            "type": "i64"
+          },
+          {
+            "name": "completed_at",
+            "docs": ["When course was completed (None if in progress)"],
+            "type": {
+              "option": "i64"
+            }
+          },
+          {
+            "name": "lesson_flags",
+            "docs": [
+              "Lesson completion bitmap: 4 × u64 = 256 bits, mirroring",
+              "`Course.active_lessons`. Completion is `lesson_flags & active_lessons ==",
+              "active_lessons`, so every valid slot (0..=255) fits within this bitmap."
+            ],
+            "type": {
+              "array": ["u64", 4]
+            }
+          },
+          {
+            "name": "credential_asset",
+            "docs": [
+              "Credential NFT address for this track (set by issue_credential)"
+            ],
+            "type": {
+              "option": "pubkey"
+            }
+          },
+          {
+            "name": "_reserved",
+            "docs": [
+              "Forward-compat padding (4 bytes — differs from the 8 reserved on other",
+              "accounts). A future field is carved from this in place, the same way",
+              "`Config.paused` and `MinterRole.max_total_xp` were: replace some of these",
+              "bytes with a real field declared immediately before `bump` so the field's",
+              "Borsh offset is unchanged, and shrink `_reserved` by the field's width so",
+              "`SIZE` stays constant. Because Borsh lays fields out in declaration order",
+              "and these bytes are already zero on every existing account, legacy",
+              "enrollments deserialize the new field as all-zeros (`0` / `false` /",
+              "`None`) — pick a type whose zero value preserves prior behavior. Widening",
+              "past these 4 bytes (or reordering fields) changes the layout/account size",
+              "and is a migration (realloc + backfill), not an in-place change."
+            ],
+            "type": {
+              "array": ["u8", 4]
+            }
+          },
+          {
+            "name": "bump",
+            "docs": ["PDA bump"],
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EnrollmentClosed",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "learner",
+            "type": "pubkey"
+          },
+          {
+            "name": "course",
+            "type": "pubkey"
+          },
+          {
+            "name": "completed",
+            "type": "bool"
+          },
+          {
+            "name": "rent_reclaimed",
+            "type": "u64"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LessonCompleted",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "learner",
+            "type": "pubkey"
+          },
+          {
+            "name": "course",
+            "type": "pubkey"
+          },
+          {
+            "name": "lesson_index",
+            "type": "u8"
+          },
+          {
+            "name": "xp_earned",
+            "type": "u32"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "MinterRegistered",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "minter",
+            "type": "pubkey"
+          },
+          {
+            "name": "label",
+            "type": "string"
+          },
+          {
+            "name": "max_xp_per_call",
+            "type": "u64"
+          },
+          {
+            "name": "max_total_xp",
+            "type": "u64"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "MinterRevoked",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "minter",
+            "type": "pubkey"
+          },
+          {
+            "name": "total_xp_minted",
+            "type": "u64"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "MinterRole",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "minter",
+            "docs": ["Wallet or program PDA authorized to mint XP"],
+            "type": "pubkey"
+          },
+          {
+            "name": "label",
+            "docs": [
+              "Human-readable label (\"streak-program\", \"irl-events\", etc.)"
+            ],
+            "type": "string"
+          },
+          {
+            "name": "max_xp_per_call",
+            "docs": ["Per-call XP cap. 0 = unlimited."],
+            "type": "u64"
+          },
+          {
+            "name": "total_xp_minted",
+            "docs": ["Lifetime XP minted through this role"],
+            "type": "u64"
+          },
+          {
+            "name": "is_active",
+            "type": "bool"
+          },
+          {
+            "name": "created_at",
+            "type": "i64"
+          },
+          {
+            "name": "max_total_xp",
+            "docs": [
+              "Cumulative XP ceiling for this role. 0 = unlimited.",
+              "Occupies the 8 bytes formerly reserved, so the account size is",
+              "unchanged and pre-existing roles deserialize with this field = 0",
+              "(unlimited), preserving prior behavior until an admin sets a cap."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "bump",
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "MinterUpdated",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "minter",
+            "type": "pubkey"
+          },
+          {
+            "name": "max_xp_per_call",
+            "type": "u64"
+          },
+          {
+            "name": "max_total_xp",
+            "type": "u64"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "MintingPauseSet",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "paused",
+            "type": "bool"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "RegisterMinterParams",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "minter",
+            "type": "pubkey"
+          },
+          {
+            "name": "label",
+            "type": "string"
+          },
+          {
+            "name": "max_xp_per_call",
+            "type": "u64"
+          },
+          {
+            "name": "max_total_xp",
+            "docs": ["Cumulative XP ceiling for this role. 0 = unlimited."],
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "UpdateConfigParams",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "new_backend_signer",
+            "type": {
+              "option": "pubkey"
+            }
+          },
+          {
+            "name": "paused",
+            "docs": [
+              "Minting kill-switch toggle. `Some(true)` pauses all minting,",
+              "`Some(false)` resumes, `None` leaves it unchanged."
+            ],
+            "type": {
+              "option": "bool"
+            }
+          },
+          {
+            "name": "new_authority",
+            "docs": [
+              "Rotate the platform authority (governance handover). `Some(a)` sets",
+              "`Config.authority = a`, `None` leaves it unchanged. The struct's",
+              "`has_one = authority` gate means the CURRENT authority co-signs the",
+              "rotation, so this cannot be used to seize control — only to hand it off",
+              "(e.g. to a Squads multisig) without a program upgrade."
+            ],
+            "type": {
+              "option": "pubkey"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "UpdateCourseParams",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "new_content_tx_id",
+            "type": {
+              "option": {
+                "array": ["u8", 32]
+              }
+            }
+          },
+          {
+            "name": "new_is_active",
+            "type": {
+              "option": "bool"
+            }
+          },
+          {
+            "name": "new_xp_per_lesson",
+            "type": {
+              "option": "u32"
+            }
+          },
+          {
+            "name": "new_creator_reward_xp",
+            "type": {
+              "option": "u32"
+            }
+          },
+          {
+            "name": "new_collection",
+            "docs": [
+              "Set/backfill the Metaplex Core credential collection for this course."
+            ],
+            "type": {
+              "option": "pubkey"
+            }
+          },
+          {
+            "name": "new_active_lessons",
+            "docs": [
+              "Replace the 256-bit live-lesson mask. Add, remove, reorder and replace",
+              "lessons all reduce to writing a new mask: retiring a slot clears its bit,",
+              "adding one sets a fresh bit. The chain cannot know slots are never reused",
+              "— the repo's `slots.lock.json` is the only invariant carrier — so this is",
+              "trusted blindly here; the sync route asserts the mask matches the lockfile",
+              "right before signing (spec §11.0). Replaces v1's `new_lesson_count`."
+            ],
+            "type": {
+              "option": {
+                "array": ["u64", 4]
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "UpdateMinterParams",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "max_xp_per_call",
+            "docs": ["New per-call XP cap. 0 = unlimited."],
+            "type": "u64"
+          },
+          {
+            "name": "max_total_xp",
+            "docs": [
+              "New cumulative XP ceiling. 0 = unlimited. Setting this at or below the",
+              "role's existing total_xp_minted freezes the role from further minting,",
+              "which is a valid way to retire a minter without closing its PDA."
+            ],
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "XpRewarded",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "minter",
+            "type": "pubkey"
+          },
+          {
+            "name": "recipient",
+            "type": "pubkey"
+          },
+          {
+            "name": "amount",
+            "type": "u64"
+          },
+          {
+            "name": "memo",
+            "type": "string"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/apps/web/src/lib/solana/onchain-queue.ts
+++ b/apps/web/src/lib/solana/onchain-queue.ts
@@ -178,7 +178,7 @@ export async function retryPendingOnchainActions(
           );
           const totalXp = onChainCourse
             ? Number(onChainCourse.xp_per_lesson) *
-              (Number(onChainCourse.lesson_count) || 1)
+              onChainCourse.liveLessonCount
             : 0;
 
           const { count: existingCerts } = await adminClient


### PR DESCRIPTION
**Phase 1 of WS-1**, stacked on Phase 0 (#469) — base is the Phase-0 branch, so this diff is Phase 1 only. Merge #469 first, then this.

The client half of the migration: make Course reads survive the program's byte-layout change **before** any deploy, so the client/program version skew (#449) can never silently misdecode.

## What's here
- **Length-aware normalising decoder** (`academy-reads.ts`): `fetchCourse`/`decodeCourse` dispatch on account length — **224 → v1**, **253 → v-next**, anything else **throws** (an unknown layout must never decode). Both return one shape: `activeLessons` (the 256-bit mask; synthesised dense from `lesson_count` on v1) + `liveLessonCount` (its popcount; read straight from `lesson_count` on v1 so it's bit-identical to today). New `superteam_academy_vnext.json` IDL committed for the v-next coder; the v1 IDL stays for the write path.
- **H1 — the finalize trigger now mirrors the chain.** `event-handlers.ts` gated completion with a dense-PREFIX check (`isAllLessonsComplete`), which diverges from `finalize_course`'s SUBSET test (`flags & active == active`) the instant a slot is retired — stranding a finished learner or firing a doomed, fee-burning finalize. It now calls `isCourseComplete(lessonFlags, course.activeLessons)`, bit-identical to the program. `isAllLessonsComplete` is **removed** (it had exactly one caller — the bug). Sparse-mask tests cover both failure directions.
- **Six count-consumers** → `liveLessonCount`, dropping the dead `|| 1` / `?? 0` fallbacks.
- **S6** — `resolvers.ts` decoded Course with its own fixed coder outside `academy-reads`; now routed through `decodeCourse` (fails loud into its existing catch instead of silently misreading a `course_id`).
- The transitional `lesson_count?: undefined` shim is gone — a future `.lesson_count` access is a compile error again.

## Behaviour-neutral on the live chain
Every account on devnet is 224 bytes today → the v1 branch → `liveLessonCount === old lesson_count`. No consumer changes what it computes until the program actually deploys v-next. This PR is safe to merge and deploy the *frontend* ahead of the program.

## DoD
- [x] 224/253 dispatch; unknown length throws. New vnext IDL committed.
- [x] **6** count-consumers read `liveLessonCount`; no `|| 1` / `?? 0` on a chain-read count remains.
- [x] Finalize trigger reads `activeLessons` + subset test; `isAllLessonsComplete` (prefix) removed, not merely unused. **(H1)**
- [x] A test proves correctness against a **sparse** mask (finished-every-live-slot finalizes; missing-a-live-slot does not; a stray retired-slot bit is ignored).
- [x] S6 `resolvers.ts` on the length-aware path.
- [x] tsc clean; 597 tests pass.

Built via SDD: decoder (Task 1a) reviewed + committed first, then the finalize-trigger / count-consumers / S6 fanned out to three concurrent implementers on disjoint files; controller integrated (shim removal + full typecheck/suite). Requesting the full adversarial pass, same as #469.