### PR TITLE
fix(ai): use gemini-2.0-flash (2.5 flash family gated for new keys)

### DIFF
--- a/apps/web/src/app/api/ai/partner/route.ts
+++ b/apps/web/src/app/api/ai/partner/route.ts
@@ -27,11 +27,12 @@ const MAX_MESSAGE_CHARS = 4_000;
 const MAX_SLUG_CHARS = 256;
 const MAX_TEST_SUMMARY_CHARS = 2_000;
 
-// gemini-2.5-flash-lite is no longer available to new API keys (404
-// "no longer available to new users"). Use the GA flagship flash model, which
-// is available to new keys and supports structured output (responseSchema).
+// The entire gemini-2.5 flash family (flash + flash-lite) is gated to existing
+// users — a new API key gets 404 "no longer available to new users". gemini-2.0-flash
+// IS available to new keys (verified: it returns 429 RESOURCE_EXHAUSTED, not 404)
+// and supports structured output (responseSchema).
 const GEMINI_URL =
-  "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent";
+  "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent";
 
 const VALID_ACTIONS: readonly PartnerAction[] = ["hint", "propose", "ask"];
 


### PR DESCRIPTION
## Follow-up to #468 — gemini-2.5-flash is *also* gated for new keys

After #468 shipped `gemini-2.5-flash`, it returned the **same 404**: *"models/gemini-2.5-flash is no longer available to new users."* Google has gated the **entire 2.5 flash family** (flash + flash-lite) for new API keys.

## Verified fix
Probing the new key directly, **`gemini-2.0-flash` returns `429 RESOURCE_EXHAUSTED`, not `404`** — i.e. it's **available to the key** (the 429 was just the free-tier rate limit tripped by today's testing). Switch the route to `gemini-2.0-flash`:
- available to new keys ✅
- free-tier ✅
- structured output (`responseSchema`) ✅

## After deploy
`propose`/`ask` will call `gemini-2.0-flash`. If you briefly see a **429** it's the free-tier per-minute limit (resets in ~seconds); the app's 4-assist-per-lesson cap keeps normal usage well under it. A persistent 429 with `…PerDay…FreeTier` means the daily free quota is spent — resets at midnight PT, or enable billing (flash is cheap) to remove the caps.

Together with #465 (token caps), this makes the assistant fully functional. Refs #463.
