### PR TITLE
fix(db): revoke public EXECUTE on handle_new_user (#377) [SENSITIVE — migration applied to prod]

### DIFF
--- a/supabase/migrations/20260714120000_revoke_execute_handle_new_user.sql
+++ b/supabase/migrations/20260714120000_revoke_execute_handle_new_user.sql
@@ -1,0 +1,20 @@
+-- #377: handle_new_user is a SECURITY DEFINER trigger function (fires on
+-- auth.users INSERT to seed public.profiles + public.user_xp). Postgres grants
+-- EXECUTE to PUBLIC by default on function creation, exposing it directly at
+-- /rest/v1/rpc/handle_new_user to anon + authenticated. A trigger function must
+-- never be client-callable — revoke it.
+--
+-- Trigger execution is unaffected: a trigger runs its function regardless of the
+-- invoking role's EXECUTE privilege; EXECUTE only gates direct RPC calls.
+-- postgres (owner) + service_role retain EXECUTE.
+--
+-- Verified against prod (pywhtmidcrptomrabbrw): before, proacl held the PUBLIC
+-- grant (=X/postgres) and anon/authenticated could execute; after, the ACL is
+-- {postgres=X/postgres,service_role=X/postgres} and anon/authenticated/public
+-- cannot.
+--
+-- Scope note: the security advisor also flags get_leaderboard, which is
+-- intentionally public (leaderboard API) and is deliberately NOT revoked here.
+-- The originating issue also named rls_auto_enable, which does NOT exist on this
+-- database (confirmed via pg_proc introspection) — no action for it.
+REVOKE EXECUTE ON FUNCTION public.handle_new_user() FROM anon, authenticated, PUBLIC;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -503,6 +503,13 @@ BEGIN
 END;
 $$;
 
+-- handle_new_user is a trigger function; it must never be callable directly via
+-- PostgREST (#377). Postgres grants EXECUTE to PUBLIC by default on function
+-- creation, which exposes it at /rest/v1/rpc/handle_new_user — revoke that. The
+-- trigger below still fires (triggers run their function regardless of the
+-- caller's EXECUTE grant); only direct RPC calls are blocked.
+REVOKE EXECUTE ON FUNCTION handle_new_user() FROM anon, authenticated, PUBLIC;
+
 CREATE OR REPLACE TRIGGER on_auth_user_created
   AFTER INSERT ON auth.users
   FOR EACH ROW EXECUTE FUNCTION handle_new_user();


### PR DESCRIPTION
**WS-3 · SENSITIVE (DB).** Migration-before-code: **already applied to prod (`pywhtmidcrptomrabbrw`) and verified** before this PR, per the WS-3 handoff.

## What
`handle_new_user` is a SECURITY DEFINER trigger function (seeds `profiles` + `user_xp` on signup). Postgres grants EXECUTE to PUBLIC by default on function creation, so it was directly callable at `/rest/v1/rpc/handle_new_user` by `anon` + `authenticated`. A trigger function must never be client-callable.

## Applied + verified on prod (before this PR)
- Before: `proacl` held the PUBLIC grant; `anon`/`authenticated` EXECUTE = true.
- After the `REVOKE`: ACL is `{postgres=X/postgres,service_role=X/postgres}`; `anon`/`authenticated`/`public` EXECUTE = **false**; `service_role` retained.
- The signup trigger still fires — trigger functions run regardless of the caller's EXECUTE grant; only direct RPC is blocked.

## This PR (the code half)
- The migration file (matches what was applied to prod, for repo tracking — avoids the untracked-drift class).
- **The same REVOKE added to `schema.sql`** — the default PUBLIC grant returns on any from-scratch rebuild, so without this a fresh apply would silently re-expose it.

## Scope corrected by live introspection
- The issue also named `rls_auto_enable` — it **does not exist** on this database (verified via `pg_proc`). No action.
- `get_leaderboard` is flagged by the advisor too but is **intentionally public** (leaderboard API) — deliberately left executable, per the issue.

**Done when:** REVOKE applied, advisor no longer lists `handle_new_user`. Direct privilege check confirms it; the advisor cache refreshes on its own cycle.

SENSITIVE → requesting the full adversarial pass (esp: does the REVOKE break the signup trigger? — it doesn't, and that's the thing to verify).