### PR TITLE
chore(ws3): delete dead diffAchievement (#435) + genericize Supabase refs in docs (#392)

### DIFF
--- a/apps/web/src/lib/admin/sync-diff.ts
+++ b/apps/web/src/lib/admin/sync-diff.ts
@@ -27,18 +27,6 @@ export interface OnChainCourse {
   version: number;
 }
 
-export interface OnChainAchievement {
-  achievementId: string;
-  name: string;
-  metadataUri: string;
-  collection: string; // base58
-  creator: string; // base58
-  maxSupply: number;
-  currentSupply: number;
-  xpReward: number;
-  isActive: boolean;
-}
-
 // ---------------------------------------------------------------------------
 // Diff types
 // ---------------------------------------------------------------------------
@@ -340,100 +328,6 @@ export function diffCourse(
       field: "prerequisite",
       contentValue: contentPrerequisite,
       onChainValue: onChainCourse.prerequisite,
-      updateable: false,
-    });
-  }
-
-  const hasImmutableMismatch = differences.some((d) => !d.updateable);
-
-  return {
-    status: differences.length === 0 ? "synced" : "out_of_sync",
-    missingFields: [],
-    differences,
-    hasImmutableMismatch,
-  };
-}
-
-// ---------------------------------------------------------------------------
-// Achievement diff
-// ---------------------------------------------------------------------------
-
-/**
- * Compare a bundle achievement document against an on-chain AchievementType PDA.
- *
- * There is no `updateAchievementType` instruction in the program, so ALL
- * diffed fields are marked `updateable: false`. Any mismatch requires PDA
- * recreation (deregister + re-register).
- *
- * @param achievement - From getAllAchievementsAdmin()
- * @param onChainAchievement - Deserialized on-chain account, or null if not deployed
- * @returns SyncDiff describing the current state
- */
-export function diffAchievement(
-  achievement: AdminAchievement,
-  onChainAchievement: OnChainAchievement | null
-): SyncDiff {
-  // 1. Draft check
-  if (isDraftId(achievement._id)) {
-    return {
-      status: "draft",
-      missingFields: [],
-      differences: [],
-      hasImmutableMismatch: false,
-    };
-  }
-
-  // 2. Required field check
-  const missingFields = getMissingAchievementFields(achievement);
-  if (missingFields.length > 0) {
-    return {
-      status: "missing_fields",
-      missingFields,
-      differences: [],
-      hasImmutableMismatch: false,
-    };
-  }
-
-  // 3. Not yet deployed
-  if (onChainAchievement === null) {
-    return {
-      status: "not_deployed",
-      missingFields: [],
-      differences: [],
-      hasImmutableMismatch: false,
-    };
-  }
-
-  // 4. Compute field-level differences
-  // All fields are immutable — no updateAchievementType instruction exists.
-  const differences: DiffEntry[] = [];
-
-  if (achievement.name !== onChainAchievement.name) {
-    differences.push({
-      field: "name",
-      contentValue: achievement.name,
-      onChainValue: onChainAchievement.name,
-      updateable: false,
-    });
-  }
-
-  const contentXpReward = achievement.xpReward ?? 0;
-  if (contentXpReward !== onChainAchievement.xpReward) {
-    differences.push({
-      field: "xpReward",
-      contentValue: contentXpReward,
-      onChainValue: onChainAchievement.xpReward,
-      updateable: false,
-    });
-  }
-
-  // maxSupply: 0 = unlimited supply on-chain
-  const contentMaxSupply = achievement.maxSupply ?? 0;
-  if (contentMaxSupply !== onChainAchievement.maxSupply) {
-    differences.push({
-      field: "maxSupply",
-      contentValue: contentMaxSupply,
-      onChainValue: onChainAchievement.maxSupply,
       updateable: false,
     });
   }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -74,13 +74,13 @@ Content itself lives **outside** this repo, in
 
 ### Deployment Model
 
-| Service          | Host                       | Notes                                                                 |
-| ---------------- | -------------------------- | --------------------------------------------------------------------- |
-| Web app          | Vercel                     | Edge middleware, automatic deploys from `main`                        |
-| Database + Auth  | Supabase (hosted Postgres) | RLS, SECURITY DEFINER functions. Prod project: `pywhtmidcrptomrabbrw` |
-| Content          | **Committed to this repo** | Compiled bundle; no hosted service, no runtime credential             |
-| On-chain program | Solana devnet              | Anchor 0.31+, Token-2022, Metaplex Core                               |
-| Build server     | GCP Cloud Run              | Docker, no IAM gateway, `X-API-Key` auth                              |
+| Service          | Host                       | Notes                                                          |
+| ---------------- | -------------------------- | -------------------------------------------------------------- |
+| Web app          | Vercel                     | Edge middleware, automatic deploys from `main`                 |
+| Database + Auth  | Supabase (hosted Postgres) | RLS, SECURITY DEFINER functions. Prod project: `<project-ref>` |
+| Content          | **Committed to this repo** | Compiled bundle; no hosted service, no runtime credential      |
+| On-chain program | Solana devnet              | Anchor 0.31+, Token-2022, Metaplex Core                        |
+| Build server     | GCP Cloud Run              | Docker, no IAM gateway, `X-API-Key` auth                       |
 
 ---
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -115,8 +115,8 @@ Subsequent pushes to `main` trigger automatic deployments. Pull requests get pre
 
 ### 1. Create Project & Apply Migrations
 
-> **Production project**: `pywhtmidcrptomrabbrw`. The previously used project is
-> **retired** — do not point a new deploy at it.
+> **Production project**: refers to the current production Supabase project. The
+> previously used project is **retired** — do not point a new deploy at it.
 
 1. Create a new project at [supabase.com/dashboard](https://supabase.com/dashboard)
 2. Install the [Supabase CLI](https://supabase.com/docs/guides/cli) and link the project:

--- a/docs/SECRET-ROTATION.md
+++ b/docs/SECRET-ROTATION.md
@@ -19,9 +19,9 @@ stored outside the repo**.
 > apply, but to the `stbr-true` deploy.
 >
 > **Update (2026-07-12):** the dedicated production Supabase project (D-2 item 1) is
-> **live: `pywhtmidcrptomrabbrw`**. The previously shared project
-> (`obqlljsagzslxarwphxv`) is **retired as a prod source** — do not point anything
-> new at it. The remaining D-2 work is credential minting + on-chain custody.
+> **live** (project ref `<project-ref>`). The previously shared project is
+> **retired as a prod source** — do not point anything new at it. The remaining D-2
+> work is credential minting + on-chain custody.
 
 ## Decisions (D-2) — RATIFIED 2026-07-03
 
@@ -153,7 +153,7 @@ dashboard (Authentication → Providers → Google).
 
 ## Definition of done
 
-- [x] New dedicated prod Supabase live (`pywhtmidcrptomrabbrw`); `service_role` isolated from dev.
+- [x] New dedicated prod Supabase live (`<project-ref>`); `service_role` isolated from dev.
 - [ ] Helius (`HELIUS_API_KEY` **+ `SOLANA_RPC_URL` together**), Gemini, `GITHUB_TOKEN`, `ADMIN_SECRET`, `BUILD_SERVER_API_KEY`, `SENTRY_AUTH_TOKEN`, `MODERATION_WEBHOOK_URL` all freshly minted for prod.
 - [ ] `AI_PARTNER_SEAL_SECRET` set explicitly in prod (not derived from `SUPABASE_SERVICE_ROLE_KEY`, so rotating the DB key doesn't silently invalidate live check tokens).
 - [ ] `ARWEAVE_UPLOADER_SECRET` is a dedicated, funded keypair — never reused as a signer.

--- a/docs/STAGING.md
+++ b/docs/STAGING.md
@@ -21,7 +21,7 @@ project/branch.
 | Layer          | Production                                  | Staging                                             |
 | -------------- | ------------------------------------------- | --------------------------------------------------- |
 | Frontend       | Vercel Production deploy (`main`)           | Vercel **Preview** env (staging branch or PR)       |
-| Database       | Supabase prod (`pywhtmidcrptomrabbrw`)      | Supabase **branch** _or_ a separate staging project |
+| Database       | Supabase prod (`<project-ref>`)             | Supabase **branch** _or_ a separate staging project |
 | Content        | Committed bundle (whatever the branch pins) | **Identical** — the bundle ships with the code      |
 | Chain          | mainnet-beta / devnet                       | **devnet** always                                   |
 | RPC + webhooks | Helius (prod webhook)                       | Helius (separate **devnet** webhook → staging URL)  |


### PR DESCRIPTION
**WS-3 · SAFE.** Two small cleanups.

## #435 — delete dead `diffAchievement`
`lib/admin/sync-diff.ts` exported `diffAchievement` with zero callers (the status route never computes achievement drift). Deleted the function + the `OnChainAchievement` interface it alone referenced (−106 lines). Verified nothing else in `apps/web/src` referenced either. `getMissingAchievementFields` (live — used by the achievements/sync + status routes) and `diffCourse` are untouched.

## #392 — genericize the live Supabase project ref
Replaced the literal prod/retired project refs with `<project-ref>` in the 4 canonical operational docs (`ARCHITECTURE.md`, `SECRET-ROTATION.md`, `STAGING.md`, `DEPLOYMENT.md`), preserving the prod-vs-retired meaning in words. `docs/superpowers/plans/*` and `specs/*` left untouched — those are historical point-in-time records; genericizing them would falsify history.

tsc clean, `src/lib/admin` tests pass (28), no lockfile/dep changes.