### PR TITLE
fix(web): route server secrets through serverEnv (#327)

### DIFF
--- a/apps/web/src/app/api/admin/auth/route.ts
+++ b/apps/web/src/app/api/admin/auth/route.ts
@@ -3,6 +3,7 @@ import "server-only";
 import crypto from "crypto";
 import { NextRequest, NextResponse } from "next/server";
 import { isRateLimited, getClientIp } from "@/lib/rate-limit";
+import { serverEnv } from "@/lib/env.server";
 
 export async function POST(req: NextRequest): Promise<NextResponse> {
   try {
@@ -27,7 +28,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     const body = (await req.json()) as { password?: unknown };
     const { password } = body;
 
-    const adminSecret = process.env.ADMIN_SECRET;
+    const adminSecret = serverEnv.ADMIN_SECRET;
     if (!adminSecret) {
       return NextResponse.json({ error: "Invalid password" }, { status: 401 });
     }

--- a/apps/web/src/app/api/ai/partner/route.ts
+++ b/apps/web/src/app/api/ai/partner/route.ts
@@ -17,8 +17,9 @@ import type {
   HintResponse,
   AnswerResponse,
 } from "@/lib/ai/partner-types";
+import { serverEnv } from "@/lib/env.server";
 
-const GEMINI_API_KEY = process.env.GEMINI_API_KEY;
+const GEMINI_API_KEY = serverEnv.GEMINI_API_KEY;
 
 // Input caps for the AI Partner route.
 const MAX_BODY_CHARS = 50_000;

--- a/apps/web/src/app/api/auth/link-wallet/route.ts
+++ b/apps/web/src/app/api/auth/link-wallet/route.ts
@@ -6,6 +6,7 @@ import { createAdminClient } from "@/lib/supabase/admin";
 import { mintXpToWallet } from "@/lib/solana/xp-mint";
 import { logError } from "@/lib/logging";
 import { ERROR_IDS } from "@/constants/errorIds";
+import { serverEnv } from "@/lib/env.server";
 import type { Database } from "@/lib/supabase/types";
 
 interface LinkWalletRequest {
@@ -20,7 +21,7 @@ export async function POST(request: NextRequest) {
     if (
       !process.env.NEXT_PUBLIC_SUPABASE_URL ||
       !process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ||
-      !process.env.SUPABASE_SERVICE_ROLE_KEY
+      !serverEnv.SUPABASE_SERVICE_ROLE_KEY
     ) {
       console.error("Missing required Supabase environment variables");
       return NextResponse.json(

--- a/apps/web/src/app/api/auth/nonce/route.ts
+++ b/apps/web/src/app/api/auth/nonce/route.ts
@@ -4,6 +4,7 @@ import { createAdminClient } from "@/lib/supabase/admin";
 import { getClientIp } from "@/lib/rate-limit";
 import { logError } from "@/lib/logging";
 import { ERROR_IDS } from "@/constants/errorIds";
+import { serverEnv } from "@/lib/env.server";
 
 const NONCE_TTL_MS = 5 * 60 * 1000; // 5 minutes
 const MAX_PENDING_PER_IP = 10;
@@ -15,7 +16,7 @@ export async function GET(request: NextRequest) {
   try {
     if (
       !process.env.NEXT_PUBLIC_SUPABASE_URL ||
-      !process.env.SUPABASE_SERVICE_ROLE_KEY
+      !serverEnv.SUPABASE_SERVICE_ROLE_KEY
     ) {
       return NextResponse.json(
         { error: "Server configuration error" },

--- a/apps/web/src/app/api/auth/unlink/route.ts
+++ b/apps/web/src/app/api/auth/unlink/route.ts
@@ -3,6 +3,7 @@ import { createClient } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { logError } from "@/lib/logging";
 import { ERROR_IDS } from "@/constants/errorIds";
+import { serverEnv } from "@/lib/env.server";
 
 type UnlinkProvider = "wallet" | "google" | "github";
 
@@ -15,7 +16,7 @@ export async function POST(request: NextRequest) {
     // Env var guards
     if (
       !process.env.NEXT_PUBLIC_SUPABASE_URL ||
-      !process.env.SUPABASE_SERVICE_ROLE_KEY
+      !serverEnv.SUPABASE_SERVICE_ROLE_KEY
     ) {
       console.error(
         "[auth/unlink] Missing required Supabase environment variables"

--- a/apps/web/src/app/api/auth/wallet/route.ts
+++ b/apps/web/src/app/api/auth/wallet/route.ts
@@ -7,6 +7,7 @@ import { generateWalletName } from "@/lib/utils/generate-wallet-name";
 import { logError } from "@/lib/logging";
 import { ERROR_IDS } from "@/constants/errorIds";
 import { retryPendingOnchainActions } from "@/lib/solana/onchain-queue";
+import { serverEnv } from "@/lib/env.server";
 import type { Database } from "@/lib/supabase/types";
 
 interface WalletAuthRequest {
@@ -24,7 +25,7 @@ export async function POST(request: NextRequest) {
     // Env var guards
     if (
       !process.env.NEXT_PUBLIC_SUPABASE_URL ||
-      !process.env.SUPABASE_SERVICE_ROLE_KEY ||
+      !serverEnv.SUPABASE_SERVICE_ROLE_KEY ||
       !process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
     ) {
       console.error("Missing required Supabase environment variables");
@@ -58,7 +59,7 @@ export async function POST(request: NextRequest) {
     // Admin client for user management (no cookies needed)
     const supabaseAdmin = createClient<Database>(
       process.env.NEXT_PUBLIC_SUPABASE_URL,
-      process.env.SUPABASE_SERVICE_ROLE_KEY,
+      serverEnv.SUPABASE_SERVICE_ROLE_KEY,
       { auth: { autoRefreshToken: false, persistSession: false } }
     );
 

--- a/apps/web/src/app/api/build-program/route.ts
+++ b/apps/web/src/app/api/build-program/route.ts
@@ -3,6 +3,7 @@ import { createClient } from "@/lib/supabase/server";
 import { logError } from "@/lib/logging";
 import { ERROR_IDS } from "@/constants/errorIds";
 import { isRateLimited } from "@/lib/rate-limit";
+import { serverEnv } from "@/lib/env.server";
 
 // Rate limit: 5 builds/min per user (shared cross-instance store — see P1-7).
 const MAX_TOKENS = 5;
@@ -34,8 +35,8 @@ interface BuildProgramResponse {
 
 // --- Config ------------------------------------------------------------------
 
-const BUILD_SERVER_URL = process.env.BUILD_SERVER_URL;
-const BUILD_SERVER_API_KEY = process.env.BUILD_SERVER_API_KEY;
+const BUILD_SERVER_URL = serverEnv.BUILD_SERVER_URL;
+const BUILD_SERVER_API_KEY = serverEnv.BUILD_SERVER_API_KEY;
 const UPSTREAM_TIMEOUT_MS = 130_000; // slightly above the 120s build timeout
 const MAX_TOTAL_SIZE = 500 * 1024; // 500KB, matches build server limit
 

--- a/apps/web/src/app/api/community/answers/[id]/accept/route.ts
+++ b/apps/web/src/app/api/community/answers/[id]/accept/route.ts
@@ -3,6 +3,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { checkCommunityAchievements } from "@/lib/gamification/achievements";
+import { serverEnv } from "@/lib/env.server";
 
 export async function POST(
   request: NextRequest,
@@ -11,7 +12,7 @@ export async function POST(
   try {
     if (
       !process.env.NEXT_PUBLIC_SUPABASE_URL ||
-      !process.env.SUPABASE_SERVICE_ROLE_KEY
+      !serverEnv.SUPABASE_SERVICE_ROLE_KEY
     ) {
       return NextResponse.json(
         { error: "Server configuration error" },

--- a/apps/web/src/app/api/community/answers/[id]/delete/route.ts
+++ b/apps/web/src/app/api/community/answers/[id]/delete/route.ts
@@ -3,6 +3,7 @@ import { createClient } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { isRateLimited } from "@/lib/rate-limit";
 import { logError } from "@/lib/logging";
+import { serverEnv } from "@/lib/env.server";
 
 export async function POST(
   request: NextRequest,
@@ -11,7 +12,7 @@ export async function POST(
   try {
     if (
       !process.env.NEXT_PUBLIC_SUPABASE_URL ||
-      !process.env.SUPABASE_SERVICE_ROLE_KEY
+      !serverEnv.SUPABASE_SERVICE_ROLE_KEY
     ) {
       return NextResponse.json(
         { error: "Server configuration error" },

--- a/apps/web/src/app/api/community/answers/route.ts
+++ b/apps/web/src/app/api/community/answers/route.ts
@@ -4,12 +4,13 @@ import { createClient } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { checkCommunityAchievements } from "@/lib/gamification/achievements";
 import { isRateLimited } from "@/lib/rate-limit";
+import { serverEnv } from "@/lib/env.server";
 
 export async function POST(request: NextRequest) {
   try {
     if (
       !process.env.NEXT_PUBLIC_SUPABASE_URL ||
-      !process.env.SUPABASE_SERVICE_ROLE_KEY
+      !serverEnv.SUPABASE_SERVICE_ROLE_KEY
     ) {
       return NextResponse.json(
         { error: "Server configuration error" },

--- a/apps/web/src/app/api/community/threads/[id]/delete/route.ts
+++ b/apps/web/src/app/api/community/threads/[id]/delete/route.ts
@@ -3,6 +3,7 @@ import { createClient } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { isRateLimited } from "@/lib/rate-limit";
 import { logError } from "@/lib/logging";
+import { serverEnv } from "@/lib/env.server";
 
 export async function POST(
   request: NextRequest,
@@ -11,7 +12,7 @@ export async function POST(
   try {
     if (
       !process.env.NEXT_PUBLIC_SUPABASE_URL ||
-      !process.env.SUPABASE_SERVICE_ROLE_KEY
+      !serverEnv.SUPABASE_SERVICE_ROLE_KEY
     ) {
       return NextResponse.json(
         { error: "Server configuration error" },

--- a/apps/web/src/app/api/community/threads/[id]/route.ts
+++ b/apps/web/src/app/api/community/threads/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { logError } from "@/lib/logging";
+import { serverEnv } from "@/lib/env.server";
 
 // Auth/cookie + per-request DB access — never statically prerender (DYNAMIC_SERVER_USAGE).
 export const dynamic = "force-dynamic";
@@ -98,7 +99,7 @@ export async function GET(
     // Increment view count (fire-and-forget via admin client)
     if (
       process.env.NEXT_PUBLIC_SUPABASE_URL &&
-      process.env.SUPABASE_SERVICE_ROLE_KEY
+      serverEnv.SUPABASE_SERVICE_ROLE_KEY
     ) {
       const admin = createAdminClient();
       admin

--- a/apps/web/src/app/api/community/threads/route.ts
+++ b/apps/web/src/app/api/community/threads/route.ts
@@ -4,6 +4,7 @@ import { createClient } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { checkCommunityAchievements } from "@/lib/gamification/achievements";
 import { isRateLimited } from "@/lib/rate-limit";
+import { serverEnv } from "@/lib/env.server";
 
 // Auth/cookie + per-request DB access — never statically prerender (DYNAMIC_SERVER_USAGE).
 export const dynamic = "force-dynamic";
@@ -179,7 +180,7 @@ export async function POST(request: NextRequest) {
   try {
     if (
       !process.env.NEXT_PUBLIC_SUPABASE_URL ||
-      !process.env.SUPABASE_SERVICE_ROLE_KEY
+      !serverEnv.SUPABASE_SERVICE_ROLE_KEY
     ) {
       return NextResponse.json(
         { error: "Server configuration error" },

--- a/apps/web/src/app/api/community/votes/route.ts
+++ b/apps/web/src/app/api/community/votes/route.ts
@@ -3,12 +3,13 @@ import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { isRateLimited } from "@/lib/rate-limit";
+import { serverEnv } from "@/lib/env.server";
 
 export async function POST(request: NextRequest) {
   try {
     if (
       !process.env.NEXT_PUBLIC_SUPABASE_URL ||
-      !process.env.SUPABASE_SERVICE_ROLE_KEY
+      !serverEnv.SUPABASE_SERVICE_ROLE_KEY
     ) {
       return NextResponse.json(
         { error: "Server configuration error" },

--- a/apps/web/src/app/api/lessons/complete/route.ts
+++ b/apps/web/src/app/api/lessons/complete/route.ts
@@ -18,6 +18,7 @@ import {
 import { fetchEnrollment, fetchCourse } from "@/lib/solana/academy-reads";
 import { isLessonComplete } from "@/lib/solana/bitmap";
 import { findLessonIndex } from "@/lib/courses/lesson-index";
+import { serverEnv } from "@/lib/env.server";
 
 interface LessonCompleteRequest {
   lessonId: string;
@@ -54,7 +55,7 @@ export async function POST(request: NextRequest) {
   try {
     if (
       !process.env.NEXT_PUBLIC_SUPABASE_URL ||
-      !process.env.SUPABASE_SERVICE_ROLE_KEY
+      !serverEnv.SUPABASE_SERVICE_ROLE_KEY
     ) {
       return NextResponse.json(
         { error: "Server configuration error" },

--- a/apps/web/src/app/api/quests/daily/route.ts
+++ b/apps/web/src/app/api/quests/daily/route.ts
@@ -5,6 +5,7 @@ import { createAdminClient } from "@/lib/supabase/admin";
 import { getAllQuests } from "@/lib/content/queries";
 import { retryQuestXpForUser } from "@/lib/solana/onchain-queue";
 import { nextMidnightUtc } from "@/lib/gamification/daily-reset";
+import { serverEnv } from "@/lib/env.server";
 
 // Auth/cookie + per-request DB access — never statically prerender (DYNAMIC_SERVER_USAGE).
 export const dynamic = "force-dynamic";
@@ -13,7 +14,7 @@ export async function GET() {
   try {
     if (
       !process.env.NEXT_PUBLIC_SUPABASE_URL ||
-      !process.env.SUPABASE_SERVICE_ROLE_KEY
+      !serverEnv.SUPABASE_SERVICE_ROLE_KEY
     ) {
       return NextResponse.json(
         { error: "Server configuration error" },

--- a/apps/web/src/app/api/webhooks/helius/route.ts
+++ b/apps/web/src/app/api/webhooks/helius/route.ts
@@ -23,8 +23,9 @@ import type {
   AchievementAwardedEvent,
   XpRewardedEvent,
 } from "@/lib/helius/types";
+import { serverEnv } from "@/lib/env.server";
 
-const WEBHOOK_SECRET = process.env.HELIUS_WEBHOOK_SECRET;
+const WEBHOOK_SECRET = serverEnv.HELIUS_WEBHOOK_SECRET;
 const MAX_BODY_SIZE = 1 * 1024 * 1024; // 1 MB
 
 function verifyBearerToken(header: string | null, secret: string): boolean {

--- a/apps/web/src/lib/admin/auth.ts
+++ b/apps/web/src/lib/admin/auth.ts
@@ -2,6 +2,7 @@ import "server-only";
 import crypto from "crypto";
 import { NextResponse } from "next/server";
 import { ADMIN_SESSION_MAX_AGE_MS } from "./session-format";
+import { serverEnv } from "@/lib/env.server";
 
 export class AdminAuthError extends Error {
   constructor() {
@@ -109,7 +110,7 @@ export function adminUnauthorizedResponse(): NextResponse {
 
 export function isValidAdminSession(cookieValue: string | undefined): boolean {
   if (!cookieValue) return false;
-  const secret = process.env.ADMIN_SECRET;
+  const secret = serverEnv.ADMIN_SECRET;
   if (!secret) return false;
 
   const dotIndex = cookieValue.indexOf(".");

--- a/apps/web/src/lib/ai/__tests__/attestation-seal.test.ts
+++ b/apps/web/src/lib/ai/__tests__/attestation-seal.test.ts
@@ -1,6 +1,23 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 vi.mock("server-only", () => ({}));
+// check-seal.ts derives its HMAC key from serverEnv, not raw process.env.
+// serverEnv.SUPABASE_SERVICE_ROLE_KEY is REQUIRED (non-optional) in the real
+// schema, so deleting it and letting the real env.server.ts re-parse would
+// crash the module import instead of exercising check-seal's own graceful
+// fallback/throw logic (see the "THROWS when no seal secret" test below).
+// Getters keep this mock live against each test's direct process.env mutation
+// without that crash.
+vi.mock("@/lib/env.server", () => ({
+  serverEnv: {
+    get AI_PARTNER_SEAL_SECRET() {
+      return process.env.AI_PARTNER_SEAL_SECRET;
+    },
+    get SUPABASE_SERVICE_ROLE_KEY() {
+      return process.env.SUPABASE_SERVICE_ROLE_KEY;
+    },
+  },
+}));
 
 const ORIG_SEAL = process.env.AI_PARTNER_SEAL_SECRET;
 const ORIG_SRK = process.env.SUPABASE_SERVICE_ROLE_KEY;

--- a/apps/web/src/lib/ai/__tests__/check-seal.test.ts
+++ b/apps/web/src/lib/ai/__tests__/check-seal.test.ts
@@ -1,6 +1,22 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 vi.mock("server-only", () => ({}));
+// check-seal.ts derives its HMAC key from serverEnv, not raw process.env.
+// serverEnv.SUPABASE_SERVICE_ROLE_KEY is REQUIRED (non-optional) in the real
+// schema, so deleting it and letting the real env.server.ts re-parse would
+// crash the module import instead of exercising check-seal's own graceful
+// fallback/throw logic. Getters keep this mock live against each test's
+// direct process.env mutation without that crash.
+vi.mock("@/lib/env.server", () => ({
+  serverEnv: {
+    get AI_PARTNER_SEAL_SECRET() {
+      return process.env.AI_PARTNER_SEAL_SECRET;
+    },
+    get SUPABASE_SERVICE_ROLE_KEY() {
+      return process.env.SUPABASE_SERVICE_ROLE_KEY;
+    },
+  },
+}));
 
 const ORIGINAL_SEAL_SECRET = process.env.AI_PARTNER_SEAL_SECRET;
 const ORIGINAL_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;

--- a/apps/web/src/lib/ai/check-seal.ts
+++ b/apps/web/src/lib/ai/check-seal.ts
@@ -1,6 +1,7 @@
 import "server-only";
 import crypto from "crypto";
 import type { SealedCheck, Attestation } from "./partner-types";
+import { serverEnv } from "@/lib/env.server";
 
 // Seals opaque, authenticated + encrypted tokens so answer/attestation state is
 // never readable or forgeable client-side. Stateless by design (no DB row, no
@@ -19,7 +20,7 @@ const AUTH_TAG_LENGTH = 16;
 
 function deriveKey(label: string): Buffer {
   const base =
-    process.env.AI_PARTNER_SEAL_SECRET || process.env.SUPABASE_SERVICE_ROLE_KEY;
+    serverEnv.AI_PARTNER_SEAL_SECRET || serverEnv.SUPABASE_SERVICE_ROLE_KEY;
   if (!base) {
     // Enforce the invariant rather than assume it: an all-unset chain must never
     // HMAC the empty string — that would be a publicly-computable, forgeable key,

--- a/apps/web/src/lib/challenge/buildable-executor.ts
+++ b/apps/web/src/lib/challenge/buildable-executor.ts
@@ -53,9 +53,10 @@
 
 import type { AdminTestCase } from "@superteam-lms/types";
 import type { ServerTestResult, SubmissionRunResult } from "./executor";
+import { serverEnv } from "@/lib/env.server";
 
-const BUILD_SERVER_URL = process.env.BUILD_SERVER_URL;
-const BUILD_SERVER_API_KEY = process.env.BUILD_SERVER_API_KEY;
+const BUILD_SERVER_URL = serverEnv.BUILD_SERVER_URL;
+const BUILD_SERVER_API_KEY = serverEnv.BUILD_SERVER_API_KEY;
 
 /**
  * Upper bound on the RAW submission we are willing to compile. Matches the

--- a/apps/web/src/lib/env.server.ts
+++ b/apps/web/src/lib/env.server.ts
@@ -53,6 +53,18 @@ const serverEnvSchema = z.object({
   // flag on a community post pings it so admins know to check the moderation
   // queue. Unset → no notification (the queue is still available in /admin).
   MODERATION_WEBHOOK_URL: optUrl,
+  // Gemini key for /api/ai/* (omit to disable the AI lesson assistant).
+  GEMINI_API_KEY: optStr,
+  // Funds Irys uploads that pin credential metadata to Arweave at mint
+  // (lib/solana/arweave.ts). Unset → mint falls back to the app-served
+  // metadata URL.
+  ARWEAVE_UPLOADER_SECRET: optStr,
+  // Helius key for webhook management + DAS API (lib/helius).
+  HELIUS_API_KEY: optStr,
+  // Optional dedicated key for sealing the AI Partner's comprehension-check /
+  // attestation tokens (lib/ai/check-seal.ts). Falls back to
+  // SUPABASE_SERVICE_ROLE_KEY when unset.
+  AI_PARTNER_SEAL_SECRET: optStr,
 });
 
 const parsed = serverEnvSchema.safeParse({
@@ -67,6 +79,10 @@ const parsed = serverEnvSchema.safeParse({
   BUILD_SERVER_URL: process.env.BUILD_SERVER_URL,
   BUILD_SERVER_API_KEY: process.env.BUILD_SERVER_API_KEY,
   MODERATION_WEBHOOK_URL: process.env.MODERATION_WEBHOOK_URL,
+  GEMINI_API_KEY: process.env.GEMINI_API_KEY,
+  ARWEAVE_UPLOADER_SECRET: process.env.ARWEAVE_UPLOADER_SECRET,
+  HELIUS_API_KEY: process.env.HELIUS_API_KEY,
+  AI_PARTNER_SEAL_SECRET: process.env.AI_PARTNER_SEAL_SECRET,
 });
 
 if (!parsed.success) {

--- a/apps/web/src/lib/helius/webhook-config.ts
+++ b/apps/web/src/lib/helius/webhook-config.ts
@@ -1,8 +1,9 @@
 import "server-only";
+import { serverEnv } from "@/lib/env.server";
 
-const HELIUS_API_KEY = process.env.HELIUS_API_KEY;
+const HELIUS_API_KEY = serverEnv.HELIUS_API_KEY;
 const PROGRAM_ID = process.env.NEXT_PUBLIC_PROGRAM_ID;
-const WEBHOOK_SECRET = process.env.HELIUS_WEBHOOK_SECRET;
+const WEBHOOK_SECRET = serverEnv.HELIUS_WEBHOOK_SECRET;
 const NETWORK = process.env.NEXT_PUBLIC_SOLANA_NETWORK ?? "devnet";
 
 interface HeliusWebhookResponse {

--- a/apps/web/src/lib/solana/__tests__/arweave.test.ts
+++ b/apps/web/src/lib/solana/__tests__/arweave.test.ts
@@ -7,8 +7,16 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 // the validated server env. Stub all three so the unit under test is just the
 // secret parsing + graceful-fallback logic — no network, no env boot.
 vi.mock("server-only", () => ({}));
+// `serverEnv.ARWEAVE_UPLOADER_SECRET` is read live via a getter (not a frozen
+// property) so each test's direct `process.env.ARWEAVE_UPLOADER_SECRET`
+// mutation below is reflected — this file never calls `resetModules()`.
 vi.mock("@/lib/env.server", () => ({
-  serverEnv: { SOLANA_RPC_URL: "https://api.devnet.solana.com" },
+  serverEnv: {
+    SOLANA_RPC_URL: "https://api.devnet.solana.com",
+    get ARWEAVE_UPLOADER_SECRET() {
+      return process.env.ARWEAVE_UPLOADER_SECRET;
+    },
+  },
 }));
 // If a test ever reaches the uploader, fail loudly: the fallback paths must
 // return BEFORE constructing UMI / hitting Irys.

--- a/apps/web/src/lib/solana/__tests__/xp-mint.test.ts
+++ b/apps/web/src/lib/solana/__tests__/xp-mint.test.ts
@@ -10,8 +10,16 @@ const h = vi.hoisted(() => ({
 }));
 
 vi.mock("server-only", () => ({}));
+// `serverEnv.XP_MINT_AUTHORITY_SECRET` is read live via a getter (not a frozen
+// property) so `loadXpMint`'s per-test `process.env` mutation + `resetModules()`
+// is reflected regardless of whether vitest re-invokes this factory on reimport.
 vi.mock("@/lib/env.server", () => ({
-  serverEnv: { SOLANA_RPC_URL: "https://rpc.test" },
+  serverEnv: {
+    SOLANA_RPC_URL: "https://rpc.test",
+    get XP_MINT_AUTHORITY_SECRET() {
+      return process.env.XP_MINT_AUTHORITY_SECRET;
+    },
+  },
 }));
 vi.mock("@solana/web3.js", () => ({
   // Classes so `new Connection(...)` / `new PublicKey(...)` are constructable

--- a/apps/web/src/lib/solana/admin-signer.ts
+++ b/apps/web/src/lib/solana/admin-signer.ts
@@ -232,7 +232,7 @@ function initialize(): { ready: boolean } {
 
   _connection = new Connection(serverEnv.SOLANA_RPC_URL, "confirmed");
 
-  const authoritySecret = process.env.PROGRAM_AUTHORITY_SECRET;
+  const authoritySecret = serverEnv.PROGRAM_AUTHORITY_SECRET;
   if (!authoritySecret) {
     console.warn(
       "[admin-signer] PROGRAM_AUTHORITY_SECRET not set. Admin on-chain operations disabled."

--- a/apps/web/src/lib/solana/arweave.ts
+++ b/apps/web/src/lib/solana/arweave.ts
@@ -57,7 +57,7 @@ const IRYS_DEVNET_NODE = "https://devnet.irys.xyz";
  *     mint AND orphan the already-inserted `nft_metadata` row.
  */
 function getUploaderKeypair(): Keypair | null {
-  const secret = process.env.ARWEAVE_UPLOADER_SECRET;
+  const secret = serverEnv.ARWEAVE_UPLOADER_SECRET;
   if (!secret) return null;
 
   try {
@@ -102,7 +102,7 @@ export async function uploadCertificateMetadata(
   // not deduplicate this warning — it is cheap and useful on each invocation.)
   const keypair = getUploaderKeypair();
   if (!keypair) {
-    if (!process.env.ARWEAVE_UPLOADER_SECRET) {
+    if (!serverEnv.ARWEAVE_UPLOADER_SECRET) {
       console.warn(
         "[arweave] ARWEAVE_UPLOADER_SECRET not set — credential metadata will " +
           "be served from the app (/api/certificates/metadata) instead of " +

--- a/apps/web/src/lib/solana/xp-mint.ts
+++ b/apps/web/src/lib/solana/xp-mint.ts
@@ -50,7 +50,7 @@ function initialize(): { ready: boolean } {
   }
   _xpMint = new PublicKey(mintAddress);
 
-  const authoritySecret = process.env.XP_MINT_AUTHORITY_SECRET;
+  const authoritySecret = serverEnv.XP_MINT_AUTHORITY_SECRET;
   if (!authoritySecret) {
     console.warn(
       "[xp-mint] XP_MINT_AUTHORITY_SECRET not set. On-chain XP minting disabled."


### PR DESCRIPTION
**WS-3 · SAFE.** Env hygiene — mechanical, no behavior change intended.

## What
`lib/env.server.ts` validates all server secrets at boot (zod, `"" → undefined` normalization, `server-only` guard) and exports `serverEnv`, but ~26 call sites read `process.env.<SECRET>` directly — losing the empty-string→undefined normalization (a blank Vercel placeholder reads as "set") and re-implementing ad-hoc guards. Routed them through `serverEnv`.

- **Added to the `serverEnv` schema** (were read raw with zero validation): `GEMINI_API_KEY`, `ARWEAVE_UPLOADER_SECRET`, `HELIUS_API_KEY`, `AI_PARTNER_SEAL_SECRET`.
- **Routed** `SUPABASE_SERVICE_ROLE_KEY` (12 routes), `ADMIN_SECRET`, `BUILD_SERVER_URL`/`_API_KEY`, `HELIUS_WEBHOOK_SECRET`, `XP_MINT_AUTHORITY_SECRET`, `PROGRAM_AUTHORITY_SECRET`, and the AI/Arweave secrets — 17 routes + 8 libs.
- `check-seal.ts`'s `AI_PARTNER_SEAL_SECRET || SUPABASE_SERVICE_ROLE_KEY` fallback is preserved verbatim, just via `serverEnv`.

## Deliberately left raw (with reason)
- `RUST_PLAYGROUND_URL` — a config URL with a public default, not a secret, not in the issue's list.
- `NODE_ENV` — standard Next runtime var, not a `serverEnv`-managed secret.
- `NEXT_PUBLIC_*` — public/browser vars, different accessor (out of scope).

## Test note
Four seal/mint test files switched their `serverEnv` mocks to getter-based so per-test `process.env` mutation still flows through — notably `attestation-seal.test.ts` deletes `SUPABASE_SERVICE_ROLE_KEY` to exercise the module's graceful "no seal secret" throw; the getter mock preserves that intent instead of turning it into an import-time crash.

tsc clean, 597 tests pass. Remaining `process.env` hits are only the 6 documented leftovers.