### PR TITLE
security(db): stop anon reading profiles.google_id/github_id (#486) [SENSITIVE — applied+verified on prod]

### DIFF
--- a/supabase/migrations/20260714140000_restrict_anon_profiles_select.sql
+++ b/supabase/migrations/20260714140000_restrict_anon_profiles_select.sql
@@ -1,0 +1,24 @@
+-- #486: anon could read google_id / github_id (OAuth subject IDs) of any public
+-- profile directly from profiles. The "public profiles viewable by everyone" RLS
+-- policy grants row visibility of public rows, and anon holds Supabase's default
+-- whole-table SELECT (every column). RLS gates rows, not columns.
+--
+-- A column-level REVOKE is a NO-OP against a table-level grant (a table grant
+-- can't be carved by column — verified: the first attempt left google_id still
+-- readable). The correct fix is to drop the table-level SELECT and re-grant
+-- SELECT on only the non-sensitive columns.
+--
+-- Withholds from anon: google_id, github_id, deleted_at, deletion_requested_at.
+-- Keeps every column the public profile page / landing count read. Only SELECT
+-- is touched; anon's RLS-gated write privileges are unchanged. authenticated is
+-- untouched (needs own-row google_id for settings) — the authenticated path is a
+-- separate view-routing follow-up.
+--
+-- Applied + verified on prod (pywhtmidcrptomrabbrw): anon SELECT on
+-- google_id/github_id/deleted_at/deletion_requested_at = false; the 10 granted
+-- columns = true; authenticated google_id = true (unchanged).
+REVOKE SELECT ON public.profiles FROM anon;
+GRANT SELECT (
+  id, wallet_address, username, bio, avatar_url, social_links,
+  is_public, name_rerolls_used, wallet_xp_synced_at, created_at
+) ON public.profiles TO anon;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -214,6 +214,22 @@ CREATE POLICY "Users can insert their own profile"
 CREATE POLICY "Users can update their own profile"
   ON profiles FOR UPDATE USING (auth.uid() = id);
 
+-- Column-restrict the anon SELECT (#486). The "public profiles" policy above
+-- grants ROW visibility of public rows, and Supabase's default grant gives anon
+-- whole-table SELECT (every column) — so anon could read google_id/github_id
+-- (OAuth subject IDs) of any public profile. RLS gates rows, not columns; and a
+-- column-level REVOKE cannot carve a subset out of a table-level grant, so drop
+-- the table SELECT and re-grant only the non-sensitive columns. Withholds
+-- google_id, github_id, deleted_at, deletion_requested_at from anon.
+-- (authenticated keeps whole-table SELECT — it needs own-row google_id for
+-- settings; the authenticated-reads-others-public-rows residual is tracked as a
+-- view-routing follow-up.)
+REVOKE SELECT ON profiles FROM anon;
+GRANT SELECT (
+  id, wallet_address, username, bio, avatar_url, social_links,
+  is_public, name_rerolls_used, wallet_xp_synced_at, created_at
+) ON profiles TO anon;
+
 -- enrollments
 CREATE POLICY "Users can view their own enrollments"
   ON enrollments FOR SELECT USING (auth.uid() = user_id);


### PR DESCRIPTION
**#486 · SENSITIVE (DB).** Migration-before-code: **applied to prod (`pywhtmidcrptomrabbrw`) and verified** before this PR.

## The leak
anon held Supabase's default whole-table SELECT on `profiles`, and the `"Public profiles are viewable by everyone"` RLS policy grants row visibility of public rows. RLS gates rows, not columns — so anon could `GET /rest/v1/profiles?is_public=eq.true&select=google_id,github_id` and read OAuth **subject IDs** of any public profile. (NULL today only because seed users haven't linked OAuth.)

## The fix + a Postgres gotcha worth flagging
A column-level `REVOKE SELECT (google_id,…)` is a **no-op** against a table-level grant — the table grant can't be carved by column. Confirmed live: after the column REVOKE, anon still read `google_id`. Correct fix: **drop the table-level SELECT and re-grant SELECT on only the non-sensitive columns.**

Withheld from anon: `google_id`, `github_id`, `deleted_at`, `deletion_requested_at`. Kept: `id, wallet_address, username, bio, avatar_url, social_links, is_public, name_rerolls_used, wallet_xp_synced_at, created_at`.

## Verified on prod (before this PR)
- `has_column_privilege('anon', …, 'google_id'/'github_id'/'deleted_at'/'deletion_requested_at')` → **false** (all four).
- The 10 granted columns → **true** (public profile page + landing count unaffected).
- `authenticated` `google_id` → **true**, unchanged (settings needs own-row).
- Grep confirms **no client read selects a revoked column** — the only `google_id` reader is the settings/account tab, which runs authenticated on its own row.

Mirrored in `schema.sql` so a fresh rebuild reproduces the restriction (otherwise Supabase's default re-grants all columns).

## Scope — closes anon, names the residual
This closes the **zero-auth** (anon) exposure. A logged-in user can *still* read another public profile's `google_id` via the same row policy + wide `authenticated` grants. Fully closing that requires dropping the public-row RLS policy and routing all public reads through `public_profiles` (#485) — a bigger app migration, because `authenticated` legitimately needs own-row `google_id`, so a blanket column REVOKE would break settings. Recommend as the thorough follow-up.

Closes #486.