### PR TITLE
fix(auth): reject wallet re-auth for deleted accounts before the wallet_address write (#489)

### DIFF
--- a/apps/web/src/app/api/auth/wallet/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/wallet/__tests__/route.test.ts
@@ -1,0 +1,177 @@
+/* eslint-disable import/order -- vi.mock calls must precede importing the route. */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("server-only", () => ({}));
+
+const {
+  verifySIWSRequest,
+  getUserById,
+  createUser,
+  generateLink,
+  verifyOtp,
+  signOut,
+  selectExistingProfile,
+  selectLinkedWallet,
+  selectUsername,
+  updateWalletAddress,
+  updateUsername,
+  isAccountDeleted,
+  retryPendingOnchainActions,
+  generateWalletName,
+} = vi.hoisted(() => ({
+  verifySIWSRequest: vi.fn(),
+  getUserById: vi.fn(),
+  createUser: vi.fn(),
+  generateLink: vi.fn(),
+  verifyOtp: vi.fn(),
+  signOut: vi.fn().mockResolvedValue({ error: null }),
+  selectExistingProfile:
+    vi.fn<() => Promise<{ data: unknown; error: unknown }>>(),
+  selectLinkedWallet: vi.fn<() => Promise<{ data: unknown; error: unknown }>>(),
+  selectUsername: vi.fn<() => Promise<{ data: unknown; error: unknown }>>(),
+  updateWalletAddress: vi.fn().mockResolvedValue({ error: null }),
+  updateUsername: vi.fn().mockResolvedValue({ error: null }),
+  isAccountDeleted: vi.fn<(userId: string) => Promise<boolean>>(),
+  retryPendingOnchainActions: vi.fn().mockResolvedValue(undefined),
+  generateWalletName: vi.fn().mockReturnValue("StakedFalcon"),
+}));
+
+vi.mock("@/lib/solana/verify-siws", () => ({ verifySIWSRequest }));
+
+// Admin (service-role) client — used for user management + all `profiles`
+// reads/writes. Branches on the `select`ed fields / `update`d patch since the
+// route makes several distinct `.from("profiles")` calls.
+vi.mock("@supabase/supabase-js", () => ({
+  createClient: () => ({
+    from: (table: string) => {
+      if (table !== "profiles") throw new Error(`unexpected table ${table}`);
+      return {
+        select: (fields: string) => ({
+          eq: () => {
+            if (fields === "id") return { maybeSingle: selectExistingProfile };
+            if (fields === "wallet_address")
+              return { single: selectLinkedWallet };
+            if (fields === "username") return { single: selectUsername };
+            throw new Error(`unexpected select fields "${fields}"`);
+          },
+        }),
+        update: (patch: Record<string, unknown>) => ({
+          eq: () => {
+            if ("wallet_address" in patch) return updateWalletAddress(patch);
+            if ("username" in patch) return updateUsername(patch);
+            throw new Error("unexpected update patch");
+          },
+        }),
+      };
+    },
+    auth: {
+      admin: { getUserById, createUser, generateLink },
+    },
+  }),
+}));
+
+// Anon (cookie-bound) client — used only for verifyOtp() (session creation)
+// and, for #489, signOut() when the resolved account turns out to be deleted.
+vi.mock("@supabase/ssr", () => ({
+  createServerClient: () => ({
+    auth: { verifyOtp, signOut },
+  }),
+}));
+
+vi.mock("next/headers", () => ({
+  cookies: async () => ({
+    getAll: () => [],
+    set: () => {},
+  }),
+}));
+
+vi.mock("@/lib/utils/generate-wallet-name", () => ({ generateWalletName }));
+vi.mock("@/lib/logging", () => ({ logError: vi.fn() }));
+vi.mock("@/lib/solana/onchain-queue", () => ({ retryPendingOnchainActions }));
+
+// #489 — the route delegates the tombstone check to the shared helper (added
+// in #488/#461); mocked directly so this test doesn't have to re-mock the
+// admin Supabase client just to exercise `profiles.deleted_at`.
+vi.mock("@/lib/auth/account-status", () => ({ isAccountDeleted }));
+
+import { POST } from "../route";
+
+function walletRequest(): NextRequest {
+  return new NextRequest("https://app.test/api/auth/wallet", {
+    method: "POST",
+    headers: { host: "app.test", "content-type": "application/json" },
+    body: JSON.stringify({
+      message: "app.test wants you to sign in...",
+      signature: [1, 2, 3],
+      publicKey: "WalletPubkey11111111111111111111111111111",
+    }),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  verifySIWSRequest.mockResolvedValue({ success: true });
+  // No existing profile keyed by wallet_address — true for a genuinely new
+  // wallet AND for a deleted account re-authenticating (#410 nulls
+  // wallet_address on deletion, so this lookup can never find the tombstoned
+  // row by wallet address).
+  selectExistingProfile.mockResolvedValue({ data: null, error: null });
+  createUser.mockResolvedValue({ error: null });
+  generateLink.mockResolvedValue({
+    data: { properties: { hashed_token: "tok_123" } },
+    error: null,
+  });
+  verifyOtp.mockResolvedValue({
+    data: { session: { user: { id: "user-1" } } },
+    error: null,
+  });
+  isAccountDeleted.mockResolvedValue(false);
+  selectLinkedWallet.mockResolvedValue({
+    data: { wallet_address: null },
+    error: null,
+  });
+  selectUsername.mockResolvedValue({
+    data: { username: "user_abc123" },
+    error: null,
+  });
+});
+
+describe("POST /api/auth/wallet — #489 refuse wallet_address write for deleted accounts", () => {
+  it("lets a normal (non-deleted) wallet login proceed exactly as before", async () => {
+    const res = await POST(walletRequest());
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ success: true });
+
+    expect(updateWalletAddress).toHaveBeenCalledWith({
+      wallet_address: "WalletPubkey11111111111111111111111111111",
+    });
+    expect(signOut).not.toHaveBeenCalled();
+    expect(retryPendingOnchainActions).toHaveBeenCalledWith("user-1");
+  });
+
+  it("refuses a tombstoned account: no wallet_address write, signs out, 403 + accountDeleted", async () => {
+    isAccountDeleted.mockResolvedValue(true);
+
+    const res = await POST(walletRequest());
+
+    expect(res.status).toBe(403);
+    await expect(res.json()).resolves.toEqual({ error: "accountDeleted" });
+
+    // The write this bug was about must never happen for a deleted account.
+    expect(updateWalletAddress).not.toHaveBeenCalled();
+    // Refused before any other profile read/write past the deletion check.
+    expect(selectLinkedWallet).not.toHaveBeenCalled();
+    expect(selectUsername).not.toHaveBeenCalled();
+    expect(updateUsername).not.toHaveBeenCalled();
+
+    expect(signOut).toHaveBeenCalledTimes(1);
+    expect(retryPendingOnchainActions).not.toHaveBeenCalled();
+  });
+
+  it("checks deletion status for the resolved (post-verifyOtp) user id", async () => {
+    await POST(walletRequest());
+    expect(isAccountDeleted).toHaveBeenCalledWith("user-1");
+  });
+});

--- a/apps/web/src/app/api/auth/wallet/route.ts
+++ b/apps/web/src/app/api/auth/wallet/route.ts
@@ -8,6 +8,7 @@ import { logError } from "@/lib/logging";
 import { ERROR_IDS } from "@/constants/errorIds";
 import { retryPendingOnchainActions } from "@/lib/solana/onchain-queue";
 import { serverEnv } from "@/lib/env.server";
+import { isAccountDeleted } from "@/lib/auth/account-status";
 import type { Database } from "@/lib/supabase/types";
 
 interface WalletAuthRequest {
@@ -158,6 +159,25 @@ export async function POST(request: NextRequest) {
     }
 
     const userId = sessionData.session.user.id;
+
+    // #489 — refuse a soft-deleted (tombstoned) account. Must run BEFORE the
+    // wallet_address write below, or a deleted user re-authenticating with
+    // the SAME wallet re-writes wallet_address onto the tombstoned row,
+    // partially reversing the #410 anonymization (which nulled it on
+    // deletion). This is the earliest point userId is authoritatively known
+    // for every resolution path above: wallet_address is nulled on deletion,
+    // so the existingProfile lookup by wallet_address never matches a
+    // deleted account — the deleted-reauth path always falls through to
+    // magic-link + verifyOtp, which is what resolves userId here.
+    //
+    // Sign out via the SAME cookie-bound client used for verifyOtp() above,
+    // so the clearing Set-Cookie headers overwrite the session cookies
+    // verifyOtp() just queued onto cookieStore — the browser never ends up
+    // holding a usable session for a deleted account.
+    if (await isAccountDeleted(userId)) {
+      await supabaseAnon.auth.signOut();
+      return NextResponse.json({ error: "accountDeleted" }, { status: 403 });
+    }
 
     // Wallet links are permanent — reject if a different wallet is already linked.
     // Same wallet re-authenticating (e.g. after session expiry) is allowed.

--- a/apps/web/src/components/auth/wallet-auth-handler.tsx
+++ b/apps/web/src/components/auth/wallet-auth-handler.tsx
@@ -111,9 +111,16 @@ export function WalletAuthHandler() {
 
       if (!response.ok) {
         let errorMsg = t("authFailed");
+        // #489 — a deleted account is refused with a stable key ("accountDeleted",
+        // matching the auth.accountDeleted message #461 already added) rather
+        // than a raw server string, and can't be fixed by retrying.
+        let canRetry = true;
         try {
           const body = (await response.json()) as { error?: string };
-          if (body.error) {
+          if (body.error === "accountDeleted") {
+            errorMsg = t("accountDeleted");
+            canRetry = false;
+          } else if (body.error) {
             errorMsg = body.error;
           }
         } catch {
@@ -123,7 +130,7 @@ export function WalletAuthHandler() {
         setOverlayState({
           status: "error",
           message: errorMsg,
-          canRetry: true,
+          canRetry,
         });
         isAuthenticating.current = false;
         return;


### PR DESCRIPTION
**#489 · SAFE (auth).** Stacked on #488 (reuses its `isAccountDeleted` helper) — merge #488 first, then retarget this to main.

## The bug
`/api/auth/wallet` unconditionally UPSERTs `profiles.wallet_address` during SIWS auth — before #461's middleware backstop rejects a deleted account on the next request. So a deleted user re-authenticating via wallet had their `wallet_address` re-written onto the tombstoned row, partially reversing #410's anonymization (the write persists after signout).

## Fix
`isAccountDeleted(userId)` is checked right after `verifyOtp()` resolves the session — the earliest point `userId` is authoritatively known, and **before the only `profiles.wallet_address` write** (the `.update(...).eq("id", userId)` later in the route; the earlier `createUser` writes auth-user *metadata*, not the profiles row). On a deleted account: `signOut()` + `403 {error:"accountDeleted"}`, and the wallet write never runs. `wallet-auth-handler.tsx` maps that response to the existing `auth.accountDeleted` message (reused from #461, not duplicated) and disables retry.

## Verify
- Normal wallet login unchanged (200, `wallet_address` written) — explicitly tested.
- Deleted account: 403, `wallet_address` update never called, no downstream reads/writes, `signOut` once, queue-retry not called.
- New route test harness (route had none): 3 cases. tsc clean, 613 tests.

Closes #489.