### PR TITLE
feat(certificates): stamp course version into credential metadata at mint (WS-2 §2)

### DIFF
--- a/apps/web/src/app/api/certificates/mint/route.ts
+++ b/apps/web/src/app/api/certificates/mint/route.ts
@@ -196,6 +196,10 @@ export async function POST(request: NextRequest) {
           value: profile.username ?? profile.wallet_address,
         },
         { trait_type: "Platform", value: "Superteam Academy" },
+        // Course.version rewinds to 1 on a close+recreate (WS-2). Stamping the
+        // live on-chain version at mint time lets a credential's provenance
+        // survive a later recreate of the same course_id.
+        { trait_type: "Course Version", value: onChainCourse.version },
       ],
       properties: { category: "certificate", creators: [] },
       external_url: `${process.env.NEXT_PUBLIC_APP_URL ?? ""}/certificates`,


### PR DESCRIPTION
**WS-2 · SAFE.** Independent of the recreate flow; buildable now.

`Course.version` rewinds to 1 when a course is closed+recreated (WS-2). So a credential should record which version it was minted against, or its provenance is ambiguous after a later recreate. Adds one attribute to the credential metadata at mint:

```ts
{ trait_type: "Course Version", value: onChainCourse.version }
```

Uses the **live on-chain** `onChainCourse.version` (the `DecodedCourse.version` captured at mint), following the metadata's existing `{trait_type, value}` convention. Nothing else in the mint flow, the Arweave pin, or the DB store changes — the same object flows through unchanged. No existing test asserted the metadata shape.

tsc clean, 640 tests.