### PR TITLE
fix(ai): use gemini-3.5-flash + disable thinking (2.0-flash retired)

### DIFF
--- a/apps/web/src/app/api/ai/partner/route.ts
+++ b/apps/web/src/app/api/ai/partner/route.ts
@@ -28,12 +28,15 @@ const MAX_MESSAGE_CHARS = 4_000;
 const MAX_SLUG_CHARS = 256;
 const MAX_TEST_SUMMARY_CHARS = 2_000;
 
-// The entire gemini-2.5 flash family (flash + flash-lite) is gated to existing
-// users — a new API key gets 404 "no longer available to new users". gemini-2.0-flash
-// IS available to new keys (verified: it returns 429 RESOURCE_EXHAUSTED, not 404)
-// and supports structured output (responseSchema).
+// Model history: gemini-2.5-flash(-lite) are gated for new keys (404 "not
+// available to new users") and gemini-2.0-flash is now fully retired (404 "no
+// longer available"). gemini-3.5-flash is available and supports structured
+// output. NOTE it's a *thinking* model — thinking tokens draw from the
+// maxOutputTokens budget — so thinking is disabled in generationConfig
+// (thinkingBudget: 0) to keep the whole budget for the response (esp. `propose`,
+// which returns the entire updated file).
 const GEMINI_URL =
-  "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent";
+  "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.5-flash:generateContent";
 
 const VALID_ACTIONS: readonly PartnerAction[] = ["hint", "propose", "ask"];
 
@@ -277,6 +280,10 @@ export async function POST(request: NextRequest) {
         generationConfig: {
           temperature: 0.3,
           maxOutputTokens: maxTokensFor(action),
+          // gemini-3.5-flash is a thinking model and thinking tokens share the
+          // maxOutputTokens budget; disable it so the full budget goes to the
+          // structured response (and to cut latency/cost).
+          thinkingConfig: { thinkingBudget: 0 },
           responseMimeType: "application/json",
           responseSchema: GEMINI_RESPONSE_SCHEMA,
         },


### PR DESCRIPTION
gemini-2.0-flash is now fully retired (`404 'no longer available'`); the 2.5 family was already gated for new keys. **gemini-3.5-flash** is available on the funded key and supports structured output.

It's a *thinking* model (`thoughtsTokenCount: 189` even for 'hi'), and thinking tokens draw from `maxOutputTokens` — which would starve/truncate `propose` (returns the whole file). So this sets `thinkingConfig.thinkingBudget: 0` to keep the full budget for the response, plus lower latency/cost.

Verified `gemini-3.5-flash` returns real answers on the key. Refs #463 (with #465 token caps already merged).