### PR TITLE
fix(ai): raise partner token caps + log finishReason (non-JSON 502)

### DIFF
--- a/apps/web/src/app/api/ai/partner/route.ts
+++ b/apps/web/src/app/api/ai/partner/route.ts
@@ -312,8 +312,12 @@ export async function POST(request: NextRequest) {
       data?.usageMetadata?.cachedContentTokenCount ?? 0
     );
 
+    const finishReason = data?.candidates?.[0]?.finishReason;
     const rawText = data?.candidates?.[0]?.content?.parts?.[0]?.text ?? "";
     if (!rawText) {
+      // finishReason === "MAX_TOKENS" here means the budget was spent before any
+      // visible output (raise maxTokensFor(action)); log it so it's diagnosable.
+      console.error("[ai/partner] empty output", { action, finishReason });
       await refundAssist(user.id, lesson._id);
       return NextResponse.json(
         { error: "AI could not generate a response" },
@@ -325,7 +329,13 @@ export async function POST(request: NextRequest) {
     try {
       parsed = JSON.parse(rawText);
     } catch {
-      console.error("Gemini partner API returned non-JSON output");
+      // Usually a truncated payload (finishReason "MAX_TOKENS"): the JSON is cut
+      // off mid-string. Log the reason + a snippet so the cap can be tuned.
+      console.error("[ai/partner] non-JSON output", {
+        action,
+        finishReason,
+        snippet: rawText.slice(0, 200),
+      });
       await refundAssist(user.id, lesson._id);
       return NextResponse.json(
         { error: "AI returned an invalid response" },

--- a/apps/web/src/lib/ai/partner-prompt.ts
+++ b/apps/web/src/lib/ai/partner-prompt.ts
@@ -90,9 +90,9 @@ export function buildDynamicSuffix(req: PartnerRequest): string {
 // short sentence, but `ask` returns a full answer and `propose` returns the
 // ENTIRE updated file plus a 3-option check, so those need real headroom.
 const MAX_TOKENS: Record<PartnerAction, number> = {
-  hint: 256,
-  ask: 1536,
-  propose: 4096,
+  hint: 512,
+  ask: 4096,
+  propose: 8192,
 };
 
 export function maxTokensFor(action: PartnerAction): number {


### PR DESCRIPTION
## Follow-up to #500 — raise token caps + add diagnostics

#500 (merged) switched the AI partner to `gemini-3.5-flash` with `thinkingBudget: 0`. Testing showed `hint`/`ask`/`propose` still 502 with **"AI returned an invalid response" (non-JSON)** — while a small verification curl with the *exact same config* returned valid JSON (`finishReason: STOP`, no thinking tokens). The difference is the app's **large real prompt** (full lesson + tests + reference solution + learner code) producing longer outputs that hit the old caps mid-generation → truncated JSON → parse failure.

## Changes
1. **Raise `maxOutputTokens`** — `hint 256→512`, `ask 1536→4096`, `propose 4096→8192` (3.5-flash supports far larger output; thinking is off so the full budget is the response). Keeps the test invariant `hint < ask < propose <= 8192`.
2. **Diagnostic logging** — the non-JSON / empty-output 502 branches now log `action`, `finishReason` (`MAX_TOKENS` = truncation), and a 200-char snippet, so any remaining failure is a one-line read in Vercel logs instead of guesswork.

## Verification
- eslint ✓, test invariant ✓. The verified-good config (from a direct curl) is unchanged; this only lifts the output ceiling + adds logging.

Refs #463.
