### PR TITLE
fix(ai): per-action responseSchema (propose has no text field)

### DIFF
--- a/apps/web/src/app/api/ai/partner/route.ts
+++ b/apps/web/src/app/api/ai/partner/route.ts
@@ -9,7 +9,7 @@ import {
   buildStaticPrefix,
   buildDynamicSuffix,
   maxTokensFor,
-  GEMINI_RESPONSE_SCHEMA,
+  responseSchemaFor,
 } from "@/lib/ai/partner-prompt";
 import type {
   PartnerAction,
@@ -69,10 +69,10 @@ type ValidatedResponse =
 
 /**
  * Runtime validation of the Gemini structured output against the expected
- * shape per `type`. `GEMINI_RESPONSE_SCHEMA` can't hard-require fields
- * conditional on `type` (Gemini's schema dialect has no such constraint), so
- * this is the actual enforcement point — a malformed or incomplete payload is
- * rejected here rather than trusted and forwarded. The "propose" branch keeps
+ * shape per `type`. The per-action `responseSchemaFor` already constrains the
+ * fields at the model, but this remains the authoritative enforcement point —
+ * a malformed or truncated payload is rejected here rather than trusted and
+ * forwarded. The "propose" branch keeps
  * `correctIndex`/`explanation` internally (see `ValidatedProposeResponse`) —
  * the caller is responsible for sealing them before responding to the client.
  */
@@ -285,7 +285,7 @@ export async function POST(request: NextRequest) {
           // structured response (and to cut latency/cost).
           thinkingConfig: { thinkingBudget: 0 },
           responseMimeType: "application/json",
-          responseSchema: GEMINI_RESPONSE_SCHEMA,
+          responseSchema: responseSchemaFor(action),
         },
       }),
     });

--- a/apps/web/src/lib/ai/partner-prompt.ts
+++ b/apps/web/src/lib/ai/partner-prompt.ts
@@ -105,54 +105,67 @@ export function maxTokensFor(action: PartnerAction): number {
  * Paired with `responseMimeType: "application/json"` in the generation
  * config at the call site.
  */
-export const GEMINI_RESPONSE_SCHEMA = {
+const CHECK_SCHEMA = {
+  type: "object",
+  description: "Comprehension check for the 'propose' variant.",
+  properties: {
+    question: { type: "string" },
+    options: {
+      type: "array",
+      items: { type: "string" },
+      minItems: 3,
+      maxItems: 3,
+      description: "Exactly 3 answer options.",
+    },
+    correctIndex: {
+      type: "integer",
+      // NOTE: no `minimum`/`maximum` — Gemini's structured-output schema dialect
+      // rejects those with a 400. The 0–2 range is enforced at runtime in
+      // `validatePartnerResponse`.
+      description: "Index (0-2) of the single correct option.",
+    },
+    explanation: { type: "string" },
+  },
+  required: ["question", "options", "correctIndex", "explanation"],
+} as const;
+
+// Schema for the `hint` and `answer` variants — a single `text` body.
+const TEXT_RESPONSE_SCHEMA = {
   type: "object",
   properties: {
-    type: {
-      type: "string",
-      enum: ["hint", "answer", "propose"],
-    },
-    text: {
-      type: "string",
-      description:
-        "Response body for the 'hint' or 'answer' variants ONLY. Omit entirely for 'propose' (which uses rationale/proposedCode/check).",
-    },
+    type: { type: "string", enum: ["hint", "answer"] },
+    text: { type: "string", description: "The hint or answer body." },
+  },
+  required: ["type", "text"],
+} as const;
+
+// Schema for the `propose` variant. Deliberately has NO `text` field, so the
+// model physically cannot emit a prose narrative that burns the output budget
+// and truncates before producing proposedCode/check (the failure a shared
+// schema + prompt instructions could not prevent). All four fields required.
+const PROPOSE_RESPONSE_SCHEMA = {
+  type: "object",
+  properties: {
+    type: { type: "string", enum: ["propose"] },
     rationale: {
       type: "string",
-      description: "One-line rationale for the 'propose' variant.",
+      description: "ONE short sentence — the only prose in a propose response.",
     },
     proposedCode: {
       type: "string",
-      description:
-        "Full updated file contents for the 'propose' variant (client computes the diff).",
+      description: "Full updated file contents (client computes the diff).",
     },
-    check: {
-      type: "object",
-      description: "Comprehension check, required for the 'propose' variant.",
-      properties: {
-        question: {
-          type: "string",
-        },
-        options: {
-          type: "array",
-          items: { type: "string" },
-          minItems: 3,
-          maxItems: 3,
-          description: "Exactly 3 answer options.",
-        },
-        correctIndex: {
-          type: "integer",
-          // NOTE: no `minimum`/`maximum` — Gemini's structured-output schema
-          // dialect rejects those numeric-constraint keywords with a 400. The
-          // 0–2 range is enforced at runtime in `validatePartnerResponse`.
-          description: "Index (0-2) of the single correct option.",
-        },
-        explanation: {
-          type: "string",
-        },
-      },
-      required: ["question", "options", "correctIndex", "explanation"],
-    },
+    check: CHECK_SCHEMA,
   },
-  required: ["type"],
+  required: ["type", "rationale", "proposedCode", "check"],
 } as const;
+
+/**
+ * The Gemini `responseSchema` for a given action. `propose` gets a schema with
+ * no `text` field (forcing the structured fields and preventing a runaway
+ * narrative); `hint`/`ask` get the text-body schema. Paired with
+ * `responseMimeType: "application/json"` at the call site.
+ */
+export function responseSchemaFor(action: PartnerAction) {
+  return action === "propose" ? PROPOSE_RESPONSE_SCHEMA : TEXT_RESPONSE_SCHEMA;
+}


### PR DESCRIPTION
## Root cause (finally, structural)
The new logging showed `propose` hitting `MAX_TOKENS` with a runaway prose **`text`** field — even after #504's prompt rule forbade it. Prompt instructions aren't a reliable guardrail; `gemini-3.5-flash` kept writing `text` and truncating **before** `proposedCode`/`check`.

## Fix
Send a **per-action `responseSchema`** instead of one shared schema:
- **`propose`** → schema with **no `text` field** at all; `required: [type, rationale, proposedCode, check]`. The model *physically cannot* emit a narrative → the whole budget goes to the real fields.
- **`hint`/`ask`** → the `{ type, text }` schema (they legitimately use `text`).

`validatePartnerResponse` is unchanged (still the authoritative runtime check).

## Verification
- eslint ✓; no remaining `GEMINI_RESPONSE_SCHEMA` refs.
- After deploy, `propose` returns `proposedCode`/`check` and parses cleanly — no more `text`-field truncation.

Refs #463.
