### PR TITLE
fix(build): stop gamification barrel leaking server-only into client bundle

### DIFF
--- a/apps/web/src/lib/gamification/index.ts
+++ b/apps/web/src/lib/gamification/index.ts
@@ -20,7 +20,13 @@ export {
   generateWeekCalendar,
 } from "./streaks";
 
-export { checkNewAchievements } from "./achievements";
+// NOTE: `checkNewAchievements` is intentionally NOT re-exported here. It lives in
+// the server-only `./achievements` module (`import "server-only"`), and a value
+// re-export would pull that module — and thus `server-only` — into any client
+// component that imports anything from this barrel (e.g. `completedLessonsToRadar`
+// in profile pages), failing the build. Server callers import it directly from
+// `@/lib/gamification/achievements`. The type-only re-export below is erased at
+// compile time, so it carries no runtime dependency and is safe.
 export type { AchievementDefinition } from "./achievements";
 
 export { completedLessonsToRadar } from "./skill-radar";


### PR DESCRIPTION
## Problem

`next build` fails on `main` (and every branch cut from it):

```
./src/lib/gamification/achievements.ts
Error: You're importing a component that needs server-only.
Import trace:
  ./src/lib/gamification/achievements.ts
  ./src/lib/gamification/index.ts
  ./src/app/[locale]/(platform)/profile/page.tsx
```

`achievements.ts` is `import "server-only"` (it uses `createAdminClient`). The gamification **barrel** (`index.ts`) re-exported a *value* from it — `export { checkNewAchievements } from "./achievements"` — which gives the barrel a runtime dependency on the server-only module. `profile/page.tsx` is a **client** component (`"use client"`) that imports `completedLessonsToRadar` from the barrel, so `server-only` got pulled into the client bundle and the build failed.

This slipped into `main` unnoticed because Vercel builds were disabled for cost, so no build gate caught it.

## Fix

Drop the value re-export from the barrel. No caller used it via the barrel — both server callers import it **directly**:
- `src/lib/helius/event-handlers.ts` → `@/lib/gamification/achievements`
- `src/lib/gamification/__tests__/predicates.test.ts` → `../achievements`

The type-only `export type { AchievementDefinition }` stays: types are erased at compile time and carry no runtime dependency, so `dashboard-identity-panel.tsx` / `achievement-grid.tsx` (which import the type from the barrel) are unaffected.

## Verification
- `grep` confirms no remaining barrel import of `checkNewAchievements`.
- eslint clean on the changed file.
