### PR TITLE
feat(admin): creator wallet in first-deploy change-preview (#433)

### DIFF
--- a/apps/web/src/app/[locale]/admin/admin-status-types.ts
+++ b/apps/web/src/app/[locale]/admin/admin-status-types.ts
@@ -47,6 +47,17 @@ export interface CourseStatus {
   // Authoritative on-chain is_active. Absent for not-yet-deployed/draft courses
   // (treated as active). false → deactivated (hidden from the public catalog).
   isActive?: boolean;
+  // The resolved `course.creator` wallet (#433, #478) — the SAME value the
+  // deploy path (`/api/admin/courses/sync`) uses as `Course.creator`. On a
+  // first deploy this is the wallet the course will be PERMANENTLY attributed
+  // to (`Course.creator` is set once at `create_course` and is immutable), so
+  // the change-preview surfaces it before the operator confirms. Optional
+  // (like `isActive`) so existing fixtures/tests unrelated to #433 don't need
+  // updating; every branch of `/api/admin/status` sets it. null only when the
+  // content bundle has no creator wallet set (blocks deploy earlier via
+  // `missingFields`, so in practice this is non-null by the time a course
+  // reaches `not_deployed`).
+  creatorWallet?: string | null;
 }
 
 export interface AchievementStatus {

--- a/apps/web/src/app/api/admin/status/route.ts
+++ b/apps/web/src/app/api/admin/status/route.ts
@@ -127,6 +127,7 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
           onChainStatus: "draft" as const,
           coursePda: null,
           differences: [],
+          creatorWallet: course.creatorWallet,
         };
       }
 
@@ -145,6 +146,7 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
           onChainStatus: "missing_fields" as const,
           coursePda: null,
           differences: [],
+          creatorWallet: course.creatorWallet,
         };
       }
 
@@ -165,6 +167,7 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
           onChainStatus: "not_deployed" as const,
           coursePda: null,
           differences: [],
+          creatorWallet: course.creatorWallet,
         };
       }
 
@@ -247,6 +250,7 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
         coursePda: pdaAddress,
         differences,
         isActive,
+        creatorWallet: course.creatorWallet,
       };
     })
   );

--- a/apps/web/src/components/admin/__tests__/deploy-change-preview.test.tsx
+++ b/apps/web/src/components/admin/__tests__/deploy-change-preview.test.tsx
@@ -29,6 +29,7 @@ function course(overrides: Partial<CourseStatus> = {}): CourseStatus {
     differences: [],
     contentDrift: "up_to_date",
     chainDrift: "content_current",
+    creatorWallet: "CreatorWa11et" + "1".repeat(31),
     ...overrides,
   };
 }
@@ -117,6 +118,34 @@ describe("DeployChangePreview", () => {
       screen.getByText(/deploying will create its on-chain account/)
     ).toBeTruthy();
     expect(screen.getByRole("button", { name: "Deploy" })).toBeTruthy();
+  });
+
+  it("#433: a first deploy shows the resolved creator wallet, labeled immutable", () => {
+    const wallet = "CreatorWa11et" + "1".repeat(31);
+    const c = course({
+      onChainStatus: "not_deployed",
+      coursePda: null,
+      chainDrift: "not_deployed",
+      creatorWallet: wallet,
+    });
+    renderWithIntl(
+      <DeployChangePreview course={c} onConfirm={vi.fn()} onCancel={vi.fn()} />
+    );
+    expect(screen.getByText(/permanently attributed to/)).toBeTruthy();
+    expect(screen.getByText(wallet)).toBeTruthy();
+    expect(screen.getByText(/cannot be changed after deploy/)).toBeTruthy();
+  });
+
+  it("#433: a redeploy/update (already on chain) does not show the creator wallet line", () => {
+    // Same creatorWallet as the first-deploy fixture, but onChainStatus is
+    // already "synced" — the creator is on chain and any mismatch there is
+    // handled by ImmutableMismatchWarning, not this block.
+    const c = course({ creatorWallet: "CreatorWa11et" + "1".repeat(31) });
+    renderWithIntl(
+      <DeployChangePreview course={c} onConfirm={vi.fn()} onCancel={vi.fn()} />
+    );
+    expect(screen.queryByText(/permanently attributed to/)).toBeNull();
+    expect(screen.queryByText(/cannot be changed after deploy/)).toBeNull();
   });
 
   it("surfaces per-course chain drift honestly: informational, NOT a promise this deploy fixes it", () => {

--- a/apps/web/src/components/admin/deploy-change-preview.tsx
+++ b/apps/web/src/components/admin/deploy-change-preview.tsx
@@ -25,6 +25,14 @@ interface DeployChangePreviewProps {
  * flow on the drift screen). Confirming here would not move the commitment —
  * the route would answer "Already synced" and the badge would stay stale — so
  * the copy must not promise otherwise.
+ *
+ * #433: on a FIRST deploy, `course.creatorWallet` is surfaced prominently —
+ * the SAME value `/api/admin/courses/sync` resolves as `Course.creator` (no
+ * independent re-derivation here). `Course.creator` is set once at
+ * `create_course` and can never change, so this is the operator's only chance
+ * to catch a wrong wallet before it's permanent. Redeploys/updates never show
+ * it — the creator is already on chain and a mismatch there is handled by
+ * `ImmutableMismatchWarning` instead.
  */
 export function DeployChangePreview({
   course,
@@ -96,6 +104,18 @@ export function DeployChangePreview({
 
         {firstDeploy && (
           <p className="mt-3 text-sm text-text-2">{t("firstDeploy")}</p>
+        )}
+
+        {firstDeploy && course.creatorWallet && (
+          <div className="mt-3 rounded-md border border-accent bg-accent-bg p-2.5 text-xs">
+            <p className="font-medium text-text">{t("creatorWalletLabel")}</p>
+            <p className="mt-1 break-all font-mono text-text-2">
+              {course.creatorWallet}
+            </p>
+            <p className="mt-1 font-semibold text-accent-dark dark:text-accent">
+              {t("creatorWalletImmutable")}
+            </p>
+          </div>
         )}
 
         {updateableDiffs.length > 0 && (

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -958,6 +958,8 @@
       "preview": {
         "title": "Review deploy — {title}",
         "firstDeploy": "This course is not on chain yet — deploying will create its on-chain account.",
+        "creatorWalletLabel": "Creator wallet — this course will be permanently attributed to:",
+        "creatorWalletImmutable": "Set once — cannot be changed after deploy.",
         "willWrite": "This transaction will write:",
         "contentStale": "For information: this course's on-chain content commitment (content_tx_id) is behind the committed bundle. This deploy will NOT change it — it only writes the course fields listed above. The commitment is updated by the content-commit step on the Content Drift screen.",
         "noChanges": "No changes detected. Redeploy anyway?",

--- a/apps/web/src/messages/es.json
+++ b/apps/web/src/messages/es.json
@@ -958,6 +958,8 @@
       "preview": {
         "title": "Revisar despliegue — {title}",
         "firstDeploy": "Este curso aún no está on-chain — el despliegue creará su cuenta on-chain.",
+        "creatorWalletLabel": "Wallet del creador — este curso quedará atribuido permanentemente a:",
+        "creatorWalletImmutable": "Se establece una sola vez — no se puede cambiar después del despliegue.",
         "willWrite": "Esta transacción escribirá:",
         "contentStale": "Informativo: el compromiso de contenido on-chain de este curso (content_tx_id) está detrás del paquete commiteado. Este despliegue NO lo cambiará — solo escribe los campos del curso listados arriba. El compromiso se actualiza mediante el paso de content-commit en la pantalla de Divergencia de Contenido.",
         "noChanges": "No se detectaron cambios. ¿Volver a desplegar de todos modos?",

--- a/apps/web/src/messages/pt-BR.json
+++ b/apps/web/src/messages/pt-BR.json
@@ -958,6 +958,8 @@
       "preview": {
         "title": "Revisar implantação — {title}",
         "firstDeploy": "Este curso ainda não está on-chain — a implantação criará a conta on-chain dele.",
+        "creatorWalletLabel": "Carteira do criador — este curso será atribuído permanentemente a:",
+        "creatorWalletImmutable": "Definida uma única vez — não pode ser alterada após a implantação.",
         "willWrite": "Esta transação irá gravar:",
         "contentStale": "Informativo: o compromisso de conteúdo on-chain deste curso (content_tx_id) está atrás do pacote commitado. Esta implantação NÃO o alterará — ela grava apenas os campos do curso listados acima. O compromisso é atualizado pela etapa de content-commit na tela de Divergência de Conteúdo.",
         "noChanges": "Nenhuma mudança detectada. Reimplantar mesmo assim?",


### PR DESCRIPTION
## Summary

- On a **first deploy** (no on-chain `Course` account yet), the admin deploy change-preview now surfaces the resolved **creator wallet**, labeled clearly as immutable — "set once — cannot be changed after deploy." `Course.creator` is written once at `create_course` and can never be updated, so this is the operator's only chance to catch a wrong wallet before it's permanent.
- The wallet is the **same value** already resolved by `getAllCoursesAdmin` / `AdminCourse.creatorWallet` (issue #478) and consumed by `/api/admin/courses/sync` as `Course.creator` — no independent re-derivation. It's threaded through `/api/admin/status` into `CourseStatus.creatorWallet` (new optional field, following the existing `isActive?` convention) and rendered by `DeployChangePreview` only when `firstDeploy` is true.
- Redeploys/updates (course already on chain) never show this block — a creator mismatch there is already handled by the existing `ImmutableMismatchWarning`.
- All new UI strings added to `en.json`, `es.json`, `pt-BR.json` under `admin.deployScreen.preview`.

Closes #433.

**SAFE-lane, single-surface change** (admin change-preview component + status route + i18n). Merge is held until the WS-2 recreate dry-run is green.

## Test plan

- [x] `pnpm exec vitest run src/components/admin/__tests__/deploy-change-preview.test.tsx` — 12/12 passed (added: first-deploy shows creator wallet; redeploy/update does not show a duplicate creator line)
- [x] `pnpm exec vitest run` (full suite) — 758/758 passed
- [x] `pnpm exec tsc --noEmit` — clean, zero errors