### PR TITLE
feat(admin): WS-2 recreate UI — preflight + non-dismissible confirm over the recreate server path [SENSITIVE]

### DIFF
--- a/apps/web/src/app/api/admin/courses/recreate/preflight/__tests__/route.test.ts
+++ b/apps/web/src/app/api/admin/courses/recreate/preflight/__tests__/route.test.ts
@@ -1,0 +1,118 @@
+/* eslint-disable import/order -- vi.mock('server-only') must be hoisted above
+   the route import so the `server-only` graph loads under vitest. */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { NextRequest } from "next/server";
+
+vi.mock("server-only", () => ({}));
+
+const h = vi.hoisted(() => ({
+  AdminAuthError: class AdminAuthError extends Error {},
+  state: { authThrows: false },
+  buildRecreatePreflight: vi.fn(),
+}));
+
+vi.mock("@/lib/admin/auth", () => ({
+  AdminAuthError: h.AdminAuthError,
+  adminUnauthorizedResponse: () =>
+    new Response(JSON.stringify({ error: "Unauthorized" }), { status: 401 }),
+  requireAdminAuth: vi.fn(() => {
+    if (h.state.authThrows) throw new h.AdminAuthError();
+  }),
+}));
+
+// The route delegates the read-only work to the helper; stub it so no on-chain
+// read happens in a route test.
+vi.mock("@/lib/admin/recreate-preflight", () => ({
+  buildRecreatePreflight: h.buildRecreatePreflight,
+}));
+
+const buildRecreatePreflight = h.buildRecreatePreflight;
+const COURSE_ID = "course-solana-101";
+
+const OK_DTO = {
+  canRecreate: true as const,
+  courseId: COURSE_ID,
+  coursePda: "PDA111",
+  creatorOnChain: "AUTH1111",
+  creatorResolved: "CREATOR111",
+  liveLessonCount: 3,
+  unusualCreator: false,
+  immutableDiffs: [
+    { field: "creator", onChainValue: "AUTH1111", contentValue: "CREATOR111" },
+  ],
+  lostCounters: { totalCompletions: 42, totalEnrollments: 100 },
+};
+
+const get = async (query: string): Promise<Response> => {
+  const { GET } = await import("../route");
+  return GET(
+    new Request(
+      `https://app.test/api/admin/courses/recreate/preflight${query}`
+    ) as unknown as NextRequest
+  );
+};
+
+beforeEach(() => {
+  h.state.authThrows = false;
+  buildRecreatePreflight.mockReset();
+  buildRecreatePreflight.mockResolvedValue(OK_DTO);
+});
+
+describe("GET /api/admin/courses/recreate/preflight — auth", () => {
+  it("401s when the admin session is missing, without doing any preflight work", async () => {
+    h.state.authThrows = true;
+    const res = await get(`?courseId=${COURSE_ID}`);
+    expect(res.status).toBe(401);
+    expect(buildRecreatePreflight).not.toHaveBeenCalled();
+  });
+});
+
+describe("GET /api/admin/courses/recreate/preflight — validation", () => {
+  it("400s when courseId is absent", async () => {
+    const res = await get("");
+    expect(res.status).toBe(400);
+    expect(buildRecreatePreflight).not.toHaveBeenCalled();
+  });
+});
+
+describe("GET /api/admin/courses/recreate/preflight — success DTO", () => {
+  it("returns 200 with the full recreate DTO shape", async () => {
+    const res = await get(`?courseId=${COURSE_ID}`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as typeof OK_DTO;
+    expect(body.canRecreate).toBe(true);
+    expect(body.coursePda).toBe("PDA111");
+    expect(body.creatorResolved).toBe("CREATOR111");
+    expect(body.liveLessonCount).toBe(3);
+    expect(body.unusualCreator).toBe(false);
+    expect(body.immutableDiffs[0]?.field).toBe("creator");
+    expect(body.lostCounters.totalCompletions).toBe(42);
+    expect(buildRecreatePreflight).toHaveBeenCalledWith(COURSE_ID);
+  });
+});
+
+describe("GET /api/admin/courses/recreate/preflight — a refusal is data, not a 500", () => {
+  it("passes { canRecreate: false, reason } straight through at 200", async () => {
+    buildRecreatePreflight.mockResolvedValue({
+      canRecreate: false,
+      reason:
+        'Course "x" has no creator wallet — set course.instructor to an instructor with a wallet',
+    });
+    const res = await get(`?courseId=${COURSE_ID}`);
+    // A refused preflight is expected UI data, never a server error.
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { canRecreate: boolean; reason: string };
+    expect(body.canRecreate).toBe(false);
+    expect(body.reason).toMatch(/no creator wallet/i);
+  });
+});
+
+describe("GET /api/admin/courses/recreate/preflight — unexpected failure", () => {
+  it("500s only when the helper itself throws (RPC/DB), not on a refusal", async () => {
+    buildRecreatePreflight.mockRejectedValue(new Error("RPC down"));
+    const res = await get(`?courseId=${COURSE_ID}`);
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toMatch(/RPC down/);
+  });
+});

--- a/apps/web/src/app/api/admin/courses/recreate/preflight/__tests__/route.test.ts
+++ b/apps/web/src/app/api/admin/courses/recreate/preflight/__tests__/route.test.ts
@@ -107,6 +107,41 @@ describe("GET /api/admin/courses/recreate/preflight — a refusal is data, not a
   });
 });
 
+describe("GET /api/admin/courses/recreate/preflight — reason is scrubbed of secrets", () => {
+  it("redacts an api-keyed RPC URL and secret env identifiers from a refusal reason", async () => {
+    buildRecreatePreflight.mockResolvedValue({
+      canRecreate: false,
+      reason:
+        "boom at https://rpc.example/?api-key=SECRET and PROGRAM_AUTHORITY_SECRET missing",
+    });
+    const res = await get(`?courseId=${COURSE_ID}`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { canRecreate: boolean; reason: string };
+    expect(body.canRecreate).toBe(false);
+    // The whole URL (with the leaked key) and the env identifiers are gone.
+    expect(body.reason).not.toMatch(/rpc\.example/);
+    expect(body.reason).not.toMatch(/api-key/);
+    expect(body.reason).not.toMatch(/SECRET/);
+    expect(body.reason).not.toMatch(/PROGRAM_AUTHORITY_SECRET/);
+    expect(body.reason).toContain("[redacted-url]");
+    expect(body.reason).toContain("[redacted-env]");
+  });
+
+  it("scrubs a leaked RPC URL from an unexpected-failure (500) error message", async () => {
+    buildRecreatePreflight.mockRejectedValue(
+      new Error(
+        "getGenesisHash failed at https://mainnet.helius/?api-key=abc123"
+      )
+    );
+    const res = await get(`?courseId=${COURSE_ID}`);
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).not.toMatch(/helius/);
+    expect(body.error).not.toMatch(/abc123/);
+    expect(body.error).toContain("[redacted-url]");
+  });
+});
+
 describe("GET /api/admin/courses/recreate/preflight — unexpected failure", () => {
   it("500s only when the helper itself throws (RPC/DB), not on a refusal", async () => {
     buildRecreatePreflight.mockRejectedValue(new Error("RPC down"));

--- a/apps/web/src/app/api/admin/courses/recreate/preflight/route.ts
+++ b/apps/web/src/app/api/admin/courses/recreate/preflight/route.ts
@@ -9,6 +9,24 @@ import {
 import { buildRecreatePreflight } from "@/lib/admin/recreate-preflight";
 
 /**
+ * Scrub secret-bearing substrings out of a `reason`/error string before it is
+ * returned to the browser (reasons are rendered verbatim and can flow into
+ * client telemetry). Pure. Redacts, in order:
+ *   1. any `https?://…` URL (an api-keyed RPC URL leaks the whole key),
+ *   2. any leftover `?api-key=…` / `&api-key=…` query param not inside a URL,
+ *   3. the known secret env identifiers `SOLANA_RPC_URL` / `PROGRAM_AUTHORITY_SECRET`.
+ * Scoped to this NEW preflight GET route; the already-merged execute route
+ * (`recreate/route.ts`) is a pre-existing follow-up, deliberately untouched.
+ */
+function sanitizeReason(reason: string): string {
+  return reason
+    .replace(/https?:\/\/\S+/gi, "[redacted-url]")
+    .replace(/[?&]api-key=[^\s&]*/gi, "[redacted-api-key]")
+    .replace(/SOLANA_RPC_URL/g, "[redacted-env]")
+    .replace(/PROGRAM_AUTHORITY_SECRET/g, "[redacted-env]");
+}
+
+/**
  * GET /api/admin/courses/recreate/preflight?courseId=<id> — READ-ONLY.
  *
  * The non-destructive companion to the POST execute route: it resolves and
@@ -20,8 +38,19 @@ import { buildRecreatePreflight } from "@/lib/admin/recreate-preflight";
  *
  * A pre-flight REFUSAL is expected data for the UI, not an error: it comes back
  * as `{ canRecreate: false, reason }` with a 200. Only an unexpected failure
- * (RPC/DB) is a 500. Admin-gated with the same cookie + same-origin (CSRF)
- * check the POST route uses.
+ * (RPC/DB) is a 500.
+ *
+ * Auth: this GET relies on the HMAC-signed `admin_session` cookie
+ * (`requireAdminAuth`). The cookie is `SameSite=Strict`, so a cross-site GET
+ * carries no cookie and is rejected with 401 — that, not an origin check, is the
+ * boundary here. `isSameOriginRequest` returns true for a GET (no CSRF-mutation
+ * surface), so the POST route's same-origin assertion is a no-op for GET and is
+ * deliberately not applied; this handler is read-only regardless.
+ *
+ * Any `reason`/error string is scrubbed with {@link sanitizeReason} before it
+ * leaves the server: refusal reasons from `preflightRecreate` can embed the
+ * (api-keyed) RPC URL or secret env identifiers, which must not reach the client
+ * or its telemetry.
  */
 export async function GET(req: NextRequest): Promise<NextResponse> {
   try {
@@ -41,12 +70,22 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
 
   try {
     const data = await buildRecreatePreflight(courseId);
+    // A refusal's `reason` is rendered verbatim client-side — scrub any secret
+    // (api-keyed RPC URL, env identifiers) before it leaves the server.
+    if (!data.canRecreate) {
+      return NextResponse.json({
+        ...data,
+        reason: sanitizeReason(data.reason),
+      });
+    }
     return NextResponse.json(data);
   } catch (e) {
     const message = e instanceof Error ? e.message : String(e);
-    console.error(
-      `[admin/courses/recreate/preflight] ${courseId}: ${message}`
+    // Log the raw message server-side; return only the sanitized form.
+    console.error(`[admin/courses/recreate/preflight] ${courseId}: ${message}`);
+    return NextResponse.json(
+      { error: sanitizeReason(message) },
+      { status: 500 }
     );
-    return NextResponse.json({ error: message }, { status: 500 });
   }
 }

--- a/apps/web/src/app/api/admin/courses/recreate/preflight/route.ts
+++ b/apps/web/src/app/api/admin/courses/recreate/preflight/route.ts
@@ -1,0 +1,52 @@
+import "server-only";
+
+import { NextRequest, NextResponse } from "next/server";
+import {
+  requireAdminAuth,
+  adminUnauthorizedResponse,
+  AdminAuthError,
+} from "@/lib/admin/auth";
+import { buildRecreatePreflight } from "@/lib/admin/recreate-preflight";
+
+/**
+ * GET /api/admin/courses/recreate/preflight?courseId=<id> — READ-ONLY.
+ *
+ * The non-destructive companion to the POST execute route: it resolves and
+ * validates every create param (via {@link buildRecreatePreflight} →
+ * `preflightRecreate`) and returns what the WS-2 confirm UI needs — the
+ * immutable field diffs old→new, the resolved creator wallet, the live on-chain
+ * lesson_count the recreate will default to (H3), the F4 "unusual creator" flag,
+ * and the counters the recreate will reset. It performs NO on-chain write.
+ *
+ * A pre-flight REFUSAL is expected data for the UI, not an error: it comes back
+ * as `{ canRecreate: false, reason }` with a 200. Only an unexpected failure
+ * (RPC/DB) is a 500. Admin-gated with the same cookie + same-origin (CSRF)
+ * check the POST route uses.
+ */
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  try {
+    requireAdminAuth(req);
+  } catch (e) {
+    if (e instanceof AdminAuthError) return adminUnauthorizedResponse();
+    throw e;
+  }
+
+  const courseId = new URL(req.url).searchParams.get("courseId");
+  if (!courseId) {
+    return NextResponse.json(
+      { error: "courseId is required" },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const data = await buildRecreatePreflight(courseId);
+    return NextResponse.json(data);
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    console.error(
+      `[admin/courses/recreate/preflight] ${courseId}: ${message}`
+    );
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/apps/web/src/app/api/admin/courses/recreate/preflight/route.ts
+++ b/apps/web/src/app/api/admin/courses/recreate/preflight/route.ts
@@ -7,24 +7,7 @@ import {
   AdminAuthError,
 } from "@/lib/admin/auth";
 import { buildRecreatePreflight } from "@/lib/admin/recreate-preflight";
-
-/**
- * Scrub secret-bearing substrings out of a `reason`/error string before it is
- * returned to the browser (reasons are rendered verbatim and can flow into
- * client telemetry). Pure. Redacts, in order:
- *   1. any `https?://…` URL (an api-keyed RPC URL leaks the whole key),
- *   2. any leftover `?api-key=…` / `&api-key=…` query param not inside a URL,
- *   3. the known secret env identifiers `SOLANA_RPC_URL` / `PROGRAM_AUTHORITY_SECRET`.
- * Scoped to this NEW preflight GET route; the already-merged execute route
- * (`recreate/route.ts`) is a pre-existing follow-up, deliberately untouched.
- */
-function sanitizeReason(reason: string): string {
-  return reason
-    .replace(/https?:\/\/\S+/gi, "[redacted-url]")
-    .replace(/[?&]api-key=[^\s&]*/gi, "[redacted-api-key]")
-    .replace(/SOLANA_RPC_URL/g, "[redacted-env]")
-    .replace(/PROGRAM_AUTHORITY_SECRET/g, "[redacted-env]");
-}
+import { sanitizeReason } from "@/lib/admin/sanitize-reason";
 
 /**
  * GET /api/admin/courses/recreate/preflight?courseId=<id> — READ-ONLY.

--- a/apps/web/src/components/admin/__tests__/recreate-course-flow.test.tsx
+++ b/apps/web/src/components/admin/__tests__/recreate-course-flow.test.tsx
@@ -1,0 +1,198 @@
+// @vitest-environment jsdom
+import type { ReactElement } from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import { RecreateCourseFlow } from "../recreate-course-flow";
+import type { DiffEntry } from "@/lib/admin/sync-diff";
+import messages from "@/messages/en.json";
+
+const COURSE_ID = "course-solana-101";
+
+const IMMUTABLE_DIFFS: DiffEntry[] = [
+  {
+    field: "creator",
+    contentValue: "CREATOR111",
+    onChainValue: "AUTH1111",
+    updateable: false,
+  },
+];
+
+function preflightDto(unusualCreator: boolean) {
+  return {
+    canRecreate: true as const,
+    courseId: COURSE_ID,
+    coursePda: "PDA111",
+    creatorOnChain: "AUTH1111",
+    creatorResolved: "CREATOR111",
+    liveLessonCount: 3,
+    unusualCreator,
+    immutableDiffs: [
+      { field: "creator", onChainValue: "AUTH1111", contentValue: "CREATOR111" },
+    ],
+    lostCounters: { totalCompletions: 42, totalEnrollments: 100 },
+  };
+}
+
+const EXECUTE_RESULT = {
+  action: "recreated",
+  coursePda: "PDA111",
+  closeSignature: "close-sig",
+  createSignature: "create-sig",
+  createAttempts: 1,
+  lostCounters: { totalCompletions: 42, totalEnrollments: 100 },
+  warnings: [],
+};
+
+function renderWithIntl(ui: ReactElement) {
+  return render(
+    <NextIntlClientProvider locale="en" messages={messages}>
+      {ui}
+    </NextIntlClientProvider>
+  );
+}
+
+/** Mock fetch: GET → preflight DTO, POST → execute result. */
+function mockFetch(unusualCreator: boolean) {
+  const fetchMock = vi.fn(
+    (_url: string, init?: { method?: string; body?: string }) => {
+      const body =
+        !init || !init.method || init.method === "GET"
+          ? preflightDto(unusualCreator)
+          : EXECUTE_RESULT;
+      return Promise.resolve(
+        new Response(JSON.stringify(body), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        })
+      );
+    }
+  );
+  global.fetch = fetchMock as unknown as typeof fetch;
+  return fetchMock;
+}
+
+async function openModal(unusualCreator: boolean) {
+  const onRecreated = vi.fn();
+  const fetchMock = mockFetch(unusualCreator);
+  renderWithIntl(
+    <RecreateCourseFlow
+      courseId={COURSE_ID}
+      courseTitle="Solana 101"
+      immutableDiffs={IMMUTABLE_DIFFS}
+      onRecreated={onRecreated}
+    />
+  );
+  fireEvent.click(screen.getByRole("button", { name: /Recreate course…/ }));
+  await screen.findByRole("dialog");
+  return { fetchMock, onRecreated };
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+afterEach(() => {
+  // @ts-expect-error — reset the global fetch stub between tests.
+  delete global.fetch;
+});
+
+describe("RecreateCourseFlow — confirm gating (b)", () => {
+  it("keeps Confirm disabled until the exact courseId is typed", async () => {
+    await openModal(false);
+
+    const confirm = () =>
+      screen.getByRole("button", { name: "Recreate course" });
+    expect(confirm()).toBeDisabled();
+
+    const input = screen.getByRole("textbox");
+    // A near-miss must NOT enable it.
+    fireEvent.change(input, { target: { value: "course-solana-10" } });
+    expect(confirm()).toBeDisabled();
+
+    // The exact id enables it.
+    fireEvent.change(input, { target: { value: COURSE_ID } });
+    expect(confirm()).not.toBeDisabled();
+  });
+
+  it("does not dismiss on a backdrop click (only explicit Cancel/Confirm)", async () => {
+    await openModal(false);
+    // The overlay is a presentation node wrapping the dialog; clicking it must
+    // not close the modal.
+    const dialog = screen.getByRole("dialog");
+    fireEvent.click(dialog.parentElement as HTMLElement);
+    expect(screen.getByRole("dialog")).toBeTruthy();
+  });
+});
+
+describe("RecreateCourseFlow — F4 unusual-creator acknowledgement (c)", () => {
+  it("sends allowUnusualCreator + acknowledgeUnusualCreator ONLY after the second ack, and requires it to confirm", async () => {
+    const { fetchMock } = await openModal(true);
+
+    const confirm = () =>
+      screen.getByRole("button", { name: "Recreate course" });
+    const input = screen.getByRole("textbox");
+
+    // Typing the id is necessary but NOT sufficient for an unusual creator.
+    fireEvent.change(input, { target: { value: COURSE_ID } });
+    expect(confirm()).toBeDisabled();
+
+    // The second, separate acknowledgement unlocks it.
+    fireEvent.click(screen.getByRole("checkbox"));
+    expect(confirm()).not.toBeDisabled();
+
+    fireEvent.click(confirm());
+
+    await waitFor(() => {
+      const post = fetchMock.mock.calls.find(
+        (c) => c[1] && (c[1] as { method?: string }).method === "POST"
+      );
+      expect(post).toBeTruthy();
+    });
+
+    const post = fetchMock.mock.calls.find(
+      (c) => c[1] && (c[1] as { method?: string }).method === "POST"
+    )!;
+    const sent = JSON.parse((post[1] as { body: string }).body) as {
+      courseId: string;
+      confirm: string;
+      allowUnusualCreator?: boolean;
+      acknowledgeUnusualCreator?: string;
+    };
+    expect(sent.courseId).toBe(COURSE_ID);
+    expect(sent.confirm).toBe(COURSE_ID);
+    expect(sent.allowUnusualCreator).toBe(true);
+    expect(sent.acknowledgeUnusualCreator).toBe(COURSE_ID);
+  });
+
+  it("a normal recreate sends NEITHER F4 field", async () => {
+    const { fetchMock } = await openModal(false);
+
+    // No unusual-creator section, so no checkbox is rendered.
+    expect(screen.queryByRole("checkbox")).toBeNull();
+
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: COURSE_ID },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Recreate course" }));
+
+    await waitFor(() => {
+      const post = fetchMock.mock.calls.find(
+        (c) => c[1] && (c[1] as { method?: string }).method === "POST"
+      );
+      expect(post).toBeTruthy();
+    });
+
+    const post = fetchMock.mock.calls.find(
+      (c) => c[1] && (c[1] as { method?: string }).method === "POST"
+    )!;
+    const sent = JSON.parse((post[1] as { body: string }).body) as Record<
+      string,
+      unknown
+    >;
+    expect(sent.courseId).toBe(COURSE_ID);
+    expect(sent.confirm).toBe(COURSE_ID);
+    expect("allowUnusualCreator" in sent).toBe(false);
+    expect("acknowledgeUnusualCreator" in sent).toBe(false);
+  });
+});

--- a/apps/web/src/components/admin/__tests__/recreate-course-flow.test.tsx
+++ b/apps/web/src/components/admin/__tests__/recreate-course-flow.test.tsx
@@ -95,6 +95,20 @@ function mockFetchCustomPost(post: () => Promise<Response>) {
   return fetchMock;
 }
 
+/** GET → the supplied responder (used to simulate a preflight load failure). */
+function mockFetchCustomGet(get: () => Promise<Response>) {
+  const fetchMock = vi.fn(
+    (_url: string, init?: { method?: string; body?: string }) => {
+      if (!init || !init.method || init.method === "GET") {
+        return get();
+      }
+      throw new Error("unexpected POST in a load-error test");
+    }
+  );
+  global.fetch = fetchMock as unknown as typeof fetch;
+  return fetchMock;
+}
+
 /** Render, open the modal, type the id, and click Confirm with a POST responder. */
 async function executeWith(post: () => Promise<Response>) {
   const onRecreated = vi.fn();
@@ -272,5 +286,75 @@ describe("RecreateCourseFlow — FIX 2 honest execute-failure recovery", () => {
 
     await screen.findByText(DOWN);
     expect(screen.queryByText(INDETERMINATE)).toBeNull();
+  });
+});
+
+describe("RecreateCourseFlow — FIX A: execute error is scrubbed before render (#509 gate)", () => {
+  it("redacts an api-keyed Helius RPC URL embedded in the execute route's error before rendering it", async () => {
+    await executeWith(() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            error:
+              "closeCoursePda failed at https://rpc.helius.xyz/?api-key=SECRET123",
+          }),
+          { status: 500, headers: { "content-type": "application/json" } }
+        )
+      )
+    );
+
+    await screen.findByText(/closeCoursePda failed at/);
+    // The secret and the raw URL must never reach the DOM.
+    expect(screen.queryByText(/SECRET123/)).toBeNull();
+    expect(screen.queryByText(/rpc\.helius\.xyz/)).toBeNull();
+    expect(screen.getByText(/\[redacted-url\]/)).toBeTruthy();
+  });
+});
+
+describe("RecreateCourseFlow — FIX B: swallowed preflight load error now renders (#509 gate)", () => {
+  it("renders the load-error message when the preflight fetch rejects (network failure)", async () => {
+    const onRecreated = vi.fn();
+    mockFetchCustomGet(() => Promise.reject(new Error("Failed to fetch")));
+    renderWithIntl(
+      <RecreateCourseFlow
+        courseId={COURSE_ID}
+        courseTitle="Solana 101"
+        immutableDiffs={IMMUTABLE_DIFFS}
+        onRecreated={onRecreated}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Recreate course…/ }));
+
+    // Previously the guard `phase !== "error"` made this unreachable — the
+    // admin clicked Recreate and saw nothing. It must render now.
+    await screen.findByText("Failed to fetch");
+    // No dialog should have opened — this is the load-error path, not confirm.
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("renders the load-error message when the preflight response is a non-refusal error (e.g. 500)", async () => {
+    const onRecreated = vi.fn();
+    mockFetchCustomGet(() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ error: "preflight blew up" }), {
+          status: 500,
+          headers: { "content-type": "application/json" },
+        })
+      )
+    );
+    renderWithIntl(
+      <RecreateCourseFlow
+        courseId={COURSE_ID}
+        courseTitle="Solana 101"
+        immutableDiffs={IMMUTABLE_DIFFS}
+        onRecreated={onRecreated}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Recreate course…/ }));
+
+    await screen.findByText("preflight blew up");
+    expect(screen.queryByRole("dialog")).toBeNull();
   });
 });

--- a/apps/web/src/components/admin/__tests__/recreate-course-flow.test.tsx
+++ b/apps/web/src/components/admin/__tests__/recreate-course-flow.test.tsx
@@ -28,7 +28,11 @@ function preflightDto(unusualCreator: boolean) {
     liveLessonCount: 3,
     unusualCreator,
     immutableDiffs: [
-      { field: "creator", onChainValue: "AUTH1111", contentValue: "CREATOR111" },
+      {
+        field: "creator",
+        onChainValue: "AUTH1111",
+        contentValue: "CREATOR111",
+      },
     ],
     lostCounters: { totalCompletions: 42, totalEnrollments: 100 },
   };
@@ -70,6 +74,46 @@ function mockFetch(unusualCreator: boolean) {
   );
   global.fetch = fetchMock as unknown as typeof fetch;
   return fetchMock;
+}
+
+/** GET → preflight DTO (normal creator); POST → the supplied responder. */
+function mockFetchCustomPost(post: () => Promise<Response>) {
+  const fetchMock = vi.fn(
+    (_url: string, init?: { method?: string; body?: string }) => {
+      if (!init || !init.method || init.method === "GET") {
+        return Promise.resolve(
+          new Response(JSON.stringify(preflightDto(false)), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          })
+        );
+      }
+      return post();
+    }
+  );
+  global.fetch = fetchMock as unknown as typeof fetch;
+  return fetchMock;
+}
+
+/** Render, open the modal, type the id, and click Confirm with a POST responder. */
+async function executeWith(post: () => Promise<Response>) {
+  const onRecreated = vi.fn();
+  const fetchMock = mockFetchCustomPost(post);
+  renderWithIntl(
+    <RecreateCourseFlow
+      courseId={COURSE_ID}
+      courseTitle="Solana 101"
+      immutableDiffs={IMMUTABLE_DIFFS}
+      onRecreated={onRecreated}
+    />
+  );
+  fireEvent.click(screen.getByRole("button", { name: /Recreate course…/ }));
+  await screen.findByRole("dialog");
+  fireEvent.change(screen.getByRole("textbox"), {
+    target: { value: COURSE_ID },
+  });
+  fireEvent.click(screen.getByRole("button", { name: "Recreate course" }));
+  return { fetchMock, onRecreated };
 }
 
 async function openModal(unusualCreator: boolean) {
@@ -194,5 +238,39 @@ describe("RecreateCourseFlow — F4 unusual-creator acknowledgement (c)", () => 
     expect(sent.confirm).toBe(COURSE_ID);
     expect("allowUnusualCreator" in sent).toBe(false);
     expect("acknowledgeUnusualCreator" in sent).toBe(false);
+  });
+});
+
+describe("RecreateCourseFlow — FIX 2 honest execute-failure recovery", () => {
+  const INDETERMINATE =
+    messages.admin.deployScreen.recreate.execError.indeterminateRecovery;
+  const DOWN = messages.admin.deployScreen.recreate.execError.downRecovery;
+
+  it("shows the 'refresh and check' message and NOT the Deploy banner on a network/indeterminate reject (no courseIntact)", async () => {
+    await executeWith(() => Promise.reject(new Error("Failed to fetch")));
+
+    // The indeterminate banner appears; the definitive "use Deploy" banner does not.
+    await screen.findByText(INDETERMINATE);
+    expect(screen.queryByText(DOWN)).toBeNull();
+    // The raw network error is still surfaced.
+    expect(screen.getByText("Failed to fetch")).toBeTruthy();
+  });
+
+  it("still shows the Deploy banner (and not the indeterminate one) when the server reports courseIntact:false", async () => {
+    await executeWith(() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            error: "close landed, create did not",
+            phase: "create",
+            courseIntact: false,
+          }),
+          { status: 500, headers: { "content-type": "application/json" } }
+        )
+      )
+    );
+
+    await screen.findByText(DOWN);
+    expect(screen.queryByText(INDETERMINATE)).toBeNull();
   });
 });

--- a/apps/web/src/components/admin/course-sync-table.tsx
+++ b/apps/web/src/components/admin/course-sync-table.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { useTranslations } from "next-intl";
 import { StatusBadge, ContentDriftBadge } from "./status-badge";
 import { SyncDiffView } from "./sync-diff-view";
-import { ImmutableMismatchWarning } from "./immutable-mismatch-warning";
+import { RecreateCourseFlow } from "./recreate-course-flow";
 import { DeployChangePreview } from "./deploy-change-preview";
 import type { CourseStatus } from "@/app/[locale]/admin/admin-status-types";
 
@@ -219,9 +219,11 @@ export function CourseSyncTable({ courses, onRefresh }: CourseSyncTableProps) {
                     />
                   )}
                   {hasImmutableMismatch && (
-                    <ImmutableMismatchWarning
-                      immutableDiffs={immutableDiffs}
+                    <RecreateCourseFlow
+                      courseId={course.contentId}
                       courseTitle={course.title}
+                      immutableDiffs={immutableDiffs}
+                      onRecreated={onRefresh}
                     />
                   )}
                 </td>

--- a/apps/web/src/components/admin/recreate-course-flow.tsx
+++ b/apps/web/src/components/admin/recreate-course-flow.tsx
@@ -8,6 +8,7 @@ import type {
   RecreatePreflightRefusal,
 } from "@/lib/admin/recreate-preflight";
 import type { RecreateCourseResult } from "@/lib/admin/recreate-course";
+import { sanitizeReason } from "@/lib/admin/sanitize-reason";
 
 interface RecreateCourseFlowProps {
   courseId: string;
@@ -164,7 +165,7 @@ export function RecreateCourseFlow({
         <p className="mb-2 font-semibold text-danger">
           {t("execError.heading")}
         </p>
-        <p className="text-xs text-danger">{execError.error}</p>
+        <p className="text-xs text-danger">{sanitizeReason(execError.error)}</p>
         {execError.courseIntact === false && (
           <p className="mt-2 rounded border border-danger bg-card p-2 text-xs font-medium text-danger">
             {t("execError.downRecovery")}
@@ -209,7 +210,7 @@ export function RecreateCourseFlow({
       </ul>
       <p className="mt-2 text-xs text-text-3">{t("cardIntro")}</p>
 
-      {loadError && phase !== "error" && (
+      {loadError && phase === "error" && (
         <p className="mt-2 text-xs text-danger">{loadError}</p>
       )}
 

--- a/apps/web/src/components/admin/recreate-course-flow.tsx
+++ b/apps/web/src/components/admin/recreate-course-flow.tsx
@@ -1,0 +1,450 @@
+"use client";
+
+import { useEffect, useId, useRef, useState } from "react";
+import { useTranslations } from "next-intl";
+import type { DiffEntry } from "@/lib/admin/sync-diff";
+import type { RecreatePreflightData } from "@/lib/admin/recreate-preflight";
+import type { RecreateCourseResult } from "@/lib/admin/recreate-course";
+
+interface RecreateCourseFlowProps {
+  courseId: string;
+  courseTitle: string;
+  /** Row-level immutable diffs (from the status payload) for the at-a-glance card. */
+  immutableDiffs: DiffEntry[];
+  /** Called after a successful recreate so the parent can refetch the status. */
+  onRecreated: () => void;
+}
+
+type Phase = "idle" | "loading" | "confirm" | "executing" | "done" | "error";
+
+/** Shape of the execute route's failure body (405/400/500). */
+interface ExecuteError {
+  error: string;
+  phase?: string;
+  courseIntact?: boolean;
+}
+
+/**
+ * WS-2 — the actionable replacement for the immutable-mismatch dead-end. Shows
+ * the immutable diffs, then drives the platform's single most destructive
+ * on-chain operation (`close_course` → `create_course`) behind a read-only
+ * preflight and a non-dismissible, type-to-confirm modal.
+ */
+export function RecreateCourseFlow({
+  courseId,
+  courseTitle,
+  immutableDiffs,
+  onRecreated,
+}: RecreateCourseFlowProps) {
+  const t = useTranslations("admin.deployScreen.recreate");
+  const [phase, setPhase] = useState<Phase>("idle");
+  const [preflight, setPreflight] = useState<RecreatePreflightData | null>(null);
+  const [refusal, setRefusal] = useState<string | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [result, setResult] = useState<RecreateCourseResult | null>(null);
+  const [execError, setExecError] = useState<ExecuteError | null>(null);
+
+  const hasCreatorMismatch = immutableDiffs.some((d) => d.field === "creator");
+
+  async function openPreflight(): Promise<void> {
+    setPhase("loading");
+    setRefusal(null);
+    setLoadError(null);
+    try {
+      const res = await fetch(
+        `/api/admin/courses/recreate/preflight?courseId=${encodeURIComponent(courseId)}`
+      );
+      if (!res.ok) {
+        const data = (await res.json().catch(() => ({}))) as { error?: string };
+        setLoadError(data.error ?? t("loadErrorHeading"));
+        setPhase("error");
+        return;
+      }
+      const data = (await res.json()) as
+        | RecreatePreflightData
+        | { canRecreate: false; reason: string };
+      if (!data.canRecreate) {
+        setRefusal(data.reason);
+        setPhase("idle");
+        return;
+      }
+      setPreflight(data);
+      setPhase("confirm");
+    } catch (e) {
+      setLoadError(e instanceof Error ? e.message : t("loadErrorHeading"));
+      setPhase("error");
+    }
+  }
+
+  async function execute(allowUnusual: boolean): Promise<void> {
+    setPhase("executing");
+    setExecError(null);
+    const body: Record<string, unknown> = { courseId, confirm: courseId };
+    if (allowUnusual) {
+      body.allowUnusualCreator = true;
+      body.acknowledgeUnusualCreator = courseId;
+    }
+    try {
+      const res = await fetch("/api/admin/courses/recreate", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      const data = (await res.json()) as RecreateCourseResult | ExecuteError;
+      if (!res.ok) {
+        setExecError(data as ExecuteError);
+        setPhase("error");
+        return;
+      }
+      setResult(data as RecreateCourseResult);
+      setPhase("done");
+    } catch (e) {
+      setExecError({ error: e instanceof Error ? e.message : String(e) });
+      setPhase("error");
+    }
+  }
+
+  // ----- Success summary -----
+  if (phase === "done" && result) {
+    return (
+      <div className="mt-3 rounded-md border border-success bg-success-light p-3 text-sm">
+        <p className="mb-2 font-semibold text-success">{t("result.heading")}</p>
+        <dl className="space-y-1 font-mono text-xs text-text-2">
+          <SummaryRow label={t("result.coursePda")} value={result.coursePda} />
+          <SummaryRow
+            label={t("result.closeSignature")}
+            value={result.closeSignature}
+          />
+          <SummaryRow
+            label={t("result.createSignature")}
+            value={result.createSignature}
+          />
+          <SummaryRow
+            label={t("result.attempts")}
+            value={String(result.createAttempts)}
+          />
+        </dl>
+        <p className="mt-2 text-xs text-text-3">
+          {t("result.lostCounters", {
+            completions: result.lostCounters.totalCompletions,
+            enrollments: result.lostCounters.totalEnrollments,
+          })}
+        </p>
+        {result.warnings.length > 0 && (
+          <div className="mt-2">
+            <p className="text-xs font-semibold text-streak">
+              {t("result.warningsHeading")}
+            </p>
+            <ul className="mt-1 list-disc space-y-0.5 pl-4 text-xs text-streak">
+              {result.warnings.map((w) => (
+                <li key={w}>{w}</li>
+              ))}
+            </ul>
+          </div>
+        )}
+        <button
+          onClick={onRecreated}
+          className="mt-3 rounded-md bg-primary px-3 py-1 font-display text-xs font-bold text-white shadow-push transition-all duration-100 hover:bg-primary-hover focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary active:translate-y-[3px] active:shadow-push-active"
+        >
+          {t("result.refresh")}
+        </button>
+      </div>
+    );
+  }
+
+  // ----- Execute failure (course may be DOWN) -----
+  if (phase === "error" && execError) {
+    return (
+      <div className="mt-3 rounded-md border border-danger bg-danger-light p-3 text-sm">
+        <p className="mb-2 font-semibold text-danger">
+          {t("execError.heading")}
+        </p>
+        <p className="text-xs text-danger">{execError.error}</p>
+        {execError.courseIntact === false && (
+          <p className="mt-2 rounded border border-danger bg-card p-2 text-xs font-medium text-danger">
+            {t("execError.downRecovery")}
+          </p>
+        )}
+        <button
+          onClick={() => {
+            setExecError(null);
+            setPhase("idle");
+          }}
+          className="mt-3 rounded-md border border-border bg-card px-3 py-1 text-xs font-medium text-text shadow-push-sm transition-all hover:bg-subtle focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary active:translate-y-[2px] active:shadow-push-active"
+        >
+          {t("execError.close")}
+        </button>
+      </div>
+    );
+  }
+
+  // ----- The at-a-glance card + confirm modal -----
+  return (
+    <div className="mt-3 rounded-md border border-danger bg-danger-light p-3 text-sm">
+      <p className="mb-2 font-semibold text-danger">{t("cardHeading")}</p>
+      {hasCreatorMismatch && (
+        <p className="mb-2 rounded border border-danger bg-card p-2 text-xs font-semibold text-danger">
+          {t("creatorEmphasis")}
+        </p>
+      )}
+      <ul className="space-y-1 font-mono text-xs text-danger">
+        {immutableDiffs.map((d) => (
+          <li key={d.field}>
+            <span className="text-text-3">{d.field}:</span> {t("onChainLabel")}{" "}
+            <span className="text-danger">{String(d.onChainValue)}</span> →{" "}
+            {t("bundleLabel")}{" "}
+            <span className="text-accent">{String(d.contentValue)}</span>
+          </li>
+        ))}
+      </ul>
+      <p className="mt-2 text-xs text-text-3">{t("cardIntro")}</p>
+
+      {loadError && phase !== "error" && (
+        <p className="mt-2 text-xs text-danger">{loadError}</p>
+      )}
+
+      {refusal && (
+        <div className="mt-2 rounded border border-streak bg-streak-light p-2 text-xs text-streak">
+          <p className="font-semibold">{t("refusedHeading")}</p>
+          <p className="mt-1">{refusal}</p>
+        </div>
+      )}
+
+      <button
+        onClick={() => void openPreflight()}
+        disabled={phase === "loading"}
+        className="mt-3 rounded-md border border-danger bg-card px-3 py-1 font-display text-xs font-bold text-danger shadow-push-sm transition-all hover:bg-danger hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-danger active:translate-y-[2px] active:shadow-push-active disabled:pointer-events-none disabled:opacity-50"
+      >
+        {phase === "loading" ? t("loading") : t("reviewButton")}
+      </button>
+
+      {phase === "confirm" && preflight && (
+        <RecreateConfirmModal
+          preflight={preflight}
+          courseTitle={courseTitle}
+          busy={false}
+          onCancel={() => {
+            setPreflight(null);
+            setPhase("idle");
+          }}
+          onConfirm={(allowUnusual) => void execute(allowUnusual)}
+        />
+      )}
+      {phase === "executing" && preflight && (
+        <RecreateConfirmModal
+          preflight={preflight}
+          courseTitle={courseTitle}
+          busy
+          onCancel={() => undefined}
+          onConfirm={() => undefined}
+        />
+      )}
+    </div>
+  );
+}
+
+function SummaryRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex gap-2">
+      <dt className="shrink-0 text-text-3">{label}:</dt>
+      <dd className="break-all text-text-2">{value}</dd>
+    </div>
+  );
+}
+
+interface RecreateConfirmModalProps {
+  preflight: RecreatePreflightData;
+  courseTitle: string;
+  busy: boolean;
+  onCancel: () => void;
+  onConfirm: (allowUnusual: boolean) => void;
+}
+
+/**
+ * Non-dismissible confirm modal. Deliberately NOT dismiss-by-habit: the
+ * backdrop does not close it (no click-outside), only an explicit Cancel/Esc or
+ * Confirm resolves it. Confirm is gated on typing the exact courseId, and — for
+ * an F4 unusual creator — a SECOND explicit acknowledgement checkbox. Only when
+ * that ack is checked does the execute POST carry `allowUnusualCreator` +
+ * `acknowledgeUnusualCreator`.
+ */
+function RecreateConfirmModal({
+  preflight,
+  courseTitle,
+  busy,
+  onCancel,
+  onConfirm,
+}: RecreateConfirmModalProps) {
+  const t = useTranslations("admin.deployScreen.recreate.modal");
+  const [typed, setTyped] = useState("");
+  const [ackUnusual, setAckUnusual] = useState(false);
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const titleId = useId();
+  const { courseId } = preflight;
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  const affirmed = typed.trim() === courseId;
+  const ackSatisfied = !preflight.unusualCreator || ackUnusual;
+  const allowUnusual = preflight.unusualCreator && ackUnusual;
+  const confirmEnabled = affirmed && ackSatisfied && !busy;
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLDivElement>): void {
+    if (e.key === "Escape") {
+      if (!busy) onCancel();
+      return;
+    }
+    if (e.key !== "Tab") return;
+    const focusables = dialogRef.current?.querySelectorAll<HTMLElement>(
+      'button:not([disabled]), input:not([disabled]), [href], select, textarea, [tabindex]:not([tabindex="-1"])'
+    );
+    if (!focusables || focusables.length === 0) return;
+    const first = focusables[0]!;
+    const last = focusables[focusables.length - 1]!;
+    if (e.shiftKey && document.activeElement === first) {
+      e.preventDefault();
+      last.focus();
+    } else if (!e.shiftKey && document.activeElement === last) {
+      e.preventDefault();
+      first.focus();
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+      role="presentation"
+      onKeyDown={handleKeyDown}
+    >
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        className="max-h-[90vh] w-full max-w-lg overflow-y-auto rounded-lg border border-danger bg-card p-5 shadow-card"
+      >
+        <h4
+          id={titleId}
+          className="font-display text-base font-bold text-danger"
+        >
+          {t("title", { title: courseTitle })}
+        </h4>
+        <p className="mt-2 text-sm text-text-2">{t("intro")}</p>
+
+        {/* Creator old→new, prominent (immutable). */}
+        <div className="mt-3 rounded-md border border-danger bg-danger-light p-2.5">
+          <p className="text-xs font-semibold uppercase tracking-wider text-danger">
+            {t("creatorLabel")}
+          </p>
+          <p className="mt-1 break-all font-mono text-xs text-text-2">
+            <span className="text-danger">
+              {preflight.creatorOnChain ?? "—"}
+            </span>{" "}
+            → <span className="text-accent">{preflight.creatorResolved}</span>
+          </p>
+        </div>
+
+        {preflight.immutableDiffs.length > 0 && (
+          <div className="mt-3">
+            <p className="text-xs font-medium text-text">
+              {t("immutableHeading")}
+            </p>
+            <ul className="mt-1 space-y-1 font-mono text-xs text-text-2">
+              {preflight.immutableDiffs.map((d) => (
+                <li key={d.field}>
+                  <span className="text-text-3">{d.field}:</span>{" "}
+                  <span className="text-danger">{d.onChainValue}</span> →{" "}
+                  <span className="text-accent">{d.contentValue}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        <p className="mt-3 text-xs text-text-3">
+          {t("lessonCountLabel", { count: preflight.liveLessonCount })}
+        </p>
+
+        {/* Reset vs preserved (fixed summary). */}
+        <div className="mt-3 rounded-md border border-border bg-subtle p-2.5 text-xs">
+          <p className="font-semibold text-text">{t("resetHeading")}</p>
+          <p className="mt-1 text-text-2">
+            {t("resetCounters", {
+              completions: preflight.lostCounters.totalCompletions,
+              enrollments: preflight.lostCounters.totalEnrollments,
+            })}
+          </p>
+          <p className="mt-2 font-semibold text-text">{t("preserveHeading")}</p>
+          <p className="mt-1 text-text-2">{t("preserveList")}</p>
+        </div>
+
+        {/* Brief-downtime warning. */}
+        <p className="mt-3 rounded-md border border-streak bg-streak-light p-2.5 text-xs text-streak">
+          {t("downtimeWarning")}
+        </p>
+
+        {/* F4 — second, separate acknowledgement for an unusual creator. */}
+        {preflight.unusualCreator && (
+          <div className="mt-3 rounded-md border border-danger bg-danger-light p-2.5">
+            <p className="text-xs font-semibold text-danger">
+              {t("unusualHeading")}
+            </p>
+            <p className="mt-1 text-xs text-text-2">{t("unusualDescription")}</p>
+            <label className="mt-2 flex items-start gap-2 text-xs text-danger">
+              <input
+                type="checkbox"
+                checked={ackUnusual}
+                onChange={(e) => setAckUnusual(e.target.checked)}
+                disabled={busy}
+                className="mt-0.5 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-danger"
+              />
+              <span>{t("unusualAck")}</span>
+            </label>
+          </div>
+        )}
+
+        {/* Type-to-confirm. */}
+        <div className="mt-4">
+          <label
+            htmlFor={`${titleId}-confirm`}
+            className="text-xs font-medium text-text"
+          >
+            {t("confirmLabel")}
+          </label>
+          <input
+            id={`${titleId}-confirm`}
+            ref={inputRef}
+            type="text"
+            value={typed}
+            onChange={(e) => setTyped(e.target.value)}
+            disabled={busy}
+            autoComplete="off"
+            spellCheck={false}
+            placeholder={t("confirmPlaceholder", { courseId })}
+            className="mt-1 w-full rounded-md border border-border bg-card px-3 py-1.5 font-mono text-xs text-text focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+          />
+        </div>
+
+        <div className="mt-5 flex justify-end gap-2">
+          <button
+            onClick={onCancel}
+            disabled={busy}
+            className="rounded-md border border-border bg-card px-4 py-1.5 text-xs font-medium text-text shadow-push-sm transition-all hover:bg-subtle focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary active:translate-y-[2px] active:shadow-push-active disabled:opacity-50"
+          >
+            {t("cancel")}
+          </button>
+          <button
+            onClick={() => onConfirm(allowUnusual)}
+            disabled={!confirmEnabled}
+            className="rounded-md bg-danger px-4 py-1.5 font-display text-xs font-bold text-white shadow-push transition-all duration-100 hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-danger active:translate-y-[3px] active:shadow-push-active disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {busy ? t("executing") : t("confirm")}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/admin/recreate-course-flow.tsx
+++ b/apps/web/src/components/admin/recreate-course-flow.tsx
@@ -3,7 +3,10 @@
 import { useEffect, useId, useRef, useState } from "react";
 import { useTranslations } from "next-intl";
 import type { DiffEntry } from "@/lib/admin/sync-diff";
-import type { RecreatePreflightData } from "@/lib/admin/recreate-preflight";
+import type {
+  RecreatePreflightData,
+  RecreatePreflightRefusal,
+} from "@/lib/admin/recreate-preflight";
 import type { RecreateCourseResult } from "@/lib/admin/recreate-course";
 
 interface RecreateCourseFlowProps {
@@ -38,8 +41,10 @@ export function RecreateCourseFlow({
 }: RecreateCourseFlowProps) {
   const t = useTranslations("admin.deployScreen.recreate");
   const [phase, setPhase] = useState<Phase>("idle");
-  const [preflight, setPreflight] = useState<RecreatePreflightData | null>(null);
-  const [refusal, setRefusal] = useState<string | null>(null);
+  const [preflight, setPreflight] = useState<RecreatePreflightData | null>(
+    null
+  );
+  const [refusal, setRefusal] = useState<RecreatePreflightRefusal | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [result, setResult] = useState<RecreateCourseResult | null>(null);
   const [execError, setExecError] = useState<ExecuteError | null>(null);
@@ -62,9 +67,9 @@ export function RecreateCourseFlow({
       }
       const data = (await res.json()) as
         | RecreatePreflightData
-        | { canRecreate: false; reason: string };
+        | RecreatePreflightRefusal;
       if (!data.canRecreate) {
-        setRefusal(data.reason);
+        setRefusal(data);
         setPhase("idle");
         return;
       }
@@ -165,6 +170,11 @@ export function RecreateCourseFlow({
             {t("execError.downRecovery")}
           </p>
         )}
+        {execError.courseIntact === undefined && (
+          <p className="mt-2 rounded border border-danger bg-card p-2 text-xs font-medium text-danger">
+            {t("execError.indeterminateRecovery")}
+          </p>
+        )}
         <button
           onClick={() => {
             setExecError(null);
@@ -206,7 +216,13 @@ export function RecreateCourseFlow({
       {refusal && (
         <div className="mt-2 rounded border border-streak bg-streak-light p-2 text-xs text-streak">
           <p className="font-semibold">{t("refusedHeading")}</p>
-          <p className="mt-1">{refusal}</p>
+          <p className="mt-1">
+            {refusal.reasonCode === "noImmutableDiff"
+              ? t("refusalReason.noImmutableDiff")
+              : refusal.reasonCode === "unconfirmed"
+                ? t("refusalReason.unconfirmed")
+                : refusal.reason}
+          </p>
         </div>
       )}
 
@@ -392,7 +408,9 @@ function RecreateConfirmModal({
             <p className="text-xs font-semibold text-danger">
               {t("unusualHeading")}
             </p>
-            <p className="mt-1 text-xs text-text-2">{t("unusualDescription")}</p>
+            <p className="mt-1 text-xs text-text-2">
+              {t("unusualDescription")}
+            </p>
             <label className="mt-2 flex items-start gap-2 text-xs text-danger">
               <input
                 type="checkbox"

--- a/apps/web/src/lib/admin/__tests__/recreate-preflight.test.ts
+++ b/apps/web/src/lib/admin/__tests__/recreate-preflight.test.ts
@@ -1,0 +1,184 @@
+/* eslint-disable import/order -- vi.mock('server-only') must be hoisted above
+   the module import so the `server-only` graph loads under vitest. */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const h = vi.hoisted(() => ({
+  preflightRecreate: vi.fn(),
+  getAllCoursesAdmin: vi.fn(),
+  fetchCourse: vi.fn(),
+  diffCourse: vi.fn(),
+}));
+
+vi.mock("@/lib/env.server", () => ({
+  serverEnv: { SOLANA_RPC_URL: "https://api.devnet.solana.com" },
+}));
+
+// Keep the REAL RecreateCourseError (the helper branches on `instanceof`); stub
+// only preflightRecreate so no on-chain read happens.
+vi.mock("@/lib/admin/recreate-course", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/lib/admin/recreate-course")>();
+  return { ...actual, preflightRecreate: h.preflightRecreate };
+});
+
+vi.mock("@/lib/content/queries", () => ({
+  getAllCoursesAdmin: h.getAllCoursesAdmin,
+}));
+
+vi.mock("@/lib/solana/academy-reads", () => ({
+  fetchCourse: h.fetchCourse,
+}));
+
+vi.mock("@/lib/solana/pda", () => ({
+  getProgramId: () => "ProgRam1111111111111111111111111111111111111",
+}));
+
+vi.mock("@/lib/admin/sync-diff", () => ({
+  diffCourse: h.diffCourse,
+}));
+
+import { RecreateCourseError } from "@/lib/admin/recreate-course";
+import { buildRecreatePreflight } from "@/lib/admin/recreate-preflight";
+
+const COURSE_ID = "course-solana-101";
+
+function plan(overrides: Record<string, unknown> = {}) {
+  return {
+    courseId: COURSE_ID,
+    coursePda: { toBase58: () => "PDA111" },
+    snapshot: {
+      totalCompletions: 42,
+      totalEnrollments: 100,
+      isActive: true,
+      collection: null,
+    },
+    createParams: {
+      courseId: COURSE_ID,
+      lessonCount: 3,
+      creatorWallet: "CREATOR111",
+      prerequisitePda: undefined,
+    },
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  h.preflightRecreate.mockReset();
+  h.getAllCoursesAdmin.mockReset();
+  h.fetchCourse.mockReset();
+  h.diffCourse.mockReset();
+  h.getAllCoursesAdmin.mockResolvedValue([{ _id: COURSE_ID }]);
+  h.fetchCourse.mockResolvedValue({ creator: { toBase58: () => "AUTH1111" } });
+  h.diffCourse.mockReturnValue({
+    differences: [
+      {
+        field: "creator",
+        onChainValue: "AUTH1111",
+        contentValue: "CREATOR111",
+        updateable: false,
+      },
+      // lesson_count is PRESERVED by the recreate (H3) — must be filtered out.
+      {
+        field: "lessonCount",
+        onChainValue: 3,
+        contentValue: 2,
+        updateable: false,
+      },
+      // an updateable diff must never appear as an immutable one.
+      {
+        field: "xpPerLesson",
+        onChainValue: 10,
+        contentValue: 25,
+        updateable: true,
+      },
+    ],
+  });
+});
+
+describe("buildRecreatePreflight — normal creator", () => {
+  it("resolves on the first preflight (allow=false) and reports unusualCreator=false", async () => {
+    h.preflightRecreate.mockResolvedValueOnce(plan());
+    const res = await buildRecreatePreflight(COURSE_ID);
+    expect(res.canRecreate).toBe(true);
+    if (!res.canRecreate) throw new Error("unreachable");
+    expect(res.unusualCreator).toBe(false);
+    expect(res.coursePda).toBe("PDA111");
+    expect(res.creatorResolved).toBe("CREATOR111");
+    expect(res.creatorOnChain).toBe("AUTH1111");
+    expect(res.liveLessonCount).toBe(3);
+    expect(res.lostCounters).toEqual({
+      totalCompletions: 42,
+      totalEnrollments: 100,
+    });
+    // preflight runs exactly ONCE in the common case (no override needed).
+    expect(h.preflightRecreate).toHaveBeenCalledTimes(1);
+    expect(h.preflightRecreate.mock.calls[0]?.[2]).toBe(false);
+  });
+
+  it("filters lessonCount and updateable fields out of immutableDiffs", async () => {
+    h.preflightRecreate.mockResolvedValueOnce(plan());
+    const res = await buildRecreatePreflight(COURSE_ID);
+    if (!res.canRecreate) throw new Error("unreachable");
+    expect(res.immutableDiffs.map((d) => d.field)).toEqual(["creator"]);
+  });
+});
+
+describe("buildRecreatePreflight — F4 unusual creator", () => {
+  it("flags unusualCreator when only preflight(allow=true) accepts", async () => {
+    h.preflightRecreate
+      .mockRejectedValueOnce(
+        new RecreateCourseError(
+          "creatorWallet equals the platform authority",
+          "preflight",
+          true
+        )
+      )
+      .mockResolvedValueOnce(plan());
+    const res = await buildRecreatePreflight(COURSE_ID);
+    expect(res.canRecreate).toBe(true);
+    if (!res.canRecreate) throw new Error("unreachable");
+    expect(res.unusualCreator).toBe(true);
+    // Derived behaviourally: false refused, true accepted → needs the override.
+    expect(h.preflightRecreate).toHaveBeenCalledTimes(2);
+    expect(h.preflightRecreate.mock.calls[0]?.[2]).toBe(false);
+    expect(h.preflightRecreate.mock.calls[1]?.[2]).toBe(true);
+  });
+});
+
+describe("buildRecreatePreflight — genuine refusal", () => {
+  it("returns { canRecreate: false, reason } when even allow=true refuses, using the allow=true message", async () => {
+    h.preflightRecreate
+      .mockRejectedValueOnce(
+        new RecreateCourseError("creator guard", "preflight", true)
+      )
+      .mockRejectedValueOnce(
+        new RecreateCourseError(
+          "Prerequisite course is not deployed on-chain",
+          "preflight",
+          true
+        )
+      );
+    const res = await buildRecreatePreflight(COURSE_ID);
+    expect(res.canRecreate).toBe(false);
+    if (res.canRecreate) throw new Error("unreachable");
+    // The terminal reason is the one that persists under the maximal override,
+    // not the (hidden) creator-guard message.
+    expect(res.reason).toMatch(/Prerequisite course is not deployed/i);
+  });
+
+  it("returns { canRecreate: false } for an ordinary (non-creator) refusal", async () => {
+    // Both calls refuse identically (e.g. mainnet / missing fields).
+    const err = new RecreateCourseError(
+      'Recreate is unavailable on network "mainnet"',
+      "preflight",
+      true
+    );
+    h.preflightRecreate.mockRejectedValue(err);
+    const res = await buildRecreatePreflight(COURSE_ID);
+    expect(res.canRecreate).toBe(false);
+    if (res.canRecreate) throw new Error("unreachable");
+    expect(res.reason).toMatch(/mainnet/i);
+  });
+});

--- a/apps/web/src/lib/admin/__tests__/recreate-preflight.test.ts
+++ b/apps/web/src/lib/admin/__tests__/recreate-preflight.test.ts
@@ -147,6 +147,80 @@ describe("buildRecreatePreflight — F4 unusual creator", () => {
   });
 });
 
+describe("buildRecreatePreflight — FIX 1 no-op / unconfirmed gate", () => {
+  it("refuses with the 'fixes nothing' reason + code when no immutable field differs and the creator matches", async () => {
+    h.preflightRecreate.mockResolvedValueOnce(plan());
+    // On-chain creator equals the resolved (bundle) creator → no creator diff.
+    h.fetchCourse.mockResolvedValue({
+      creator: { toBase58: () => "CREATOR111" },
+    });
+    // Only an UPDATEABLE diff remains — must not count as "something to fix".
+    h.diffCourse.mockReturnValue({
+      differences: [
+        {
+          field: "xpPerLesson",
+          onChainValue: 10,
+          contentValue: 25,
+          updateable: true,
+        },
+      ],
+    });
+    const res = await buildRecreatePreflight(COURSE_ID);
+    expect(res.canRecreate).toBe(false);
+    if (res.canRecreate) throw new Error("unreachable");
+    expect(res.reasonCode).toBe("noImmutableDiff");
+    expect(res.reason).toMatch(/fix nothing/i);
+  });
+
+  it("refuses with the 'could not read' reason + code when the on-chain account is unavailable/undecodable", async () => {
+    h.preflightRecreate.mockResolvedValueOnce(plan());
+    // fetchCourse returns null → creatorOnChain stays null, immutableDiffs empty
+    // for LACK OF DATA (diffCourse is never reached).
+    h.fetchCourse.mockResolvedValue(null);
+    const res = await buildRecreatePreflight(COURSE_ID);
+    expect(res.canRecreate).toBe(false);
+    if (res.canRecreate) throw new Error("unreachable");
+    expect(res.reasonCode).toBe("unconfirmed");
+    expect(res.reason).toMatch(/could not read the on-chain account/i);
+    // diffCourse must NOT run when there is no on-chain account to diff against.
+    expect(h.diffCourse).not.toHaveBeenCalled();
+  });
+});
+
+describe("buildRecreatePreflight — FIX 1 over-refusal guard (a real mismatch still allows)", () => {
+  it("allows when the creator genuinely differs on-chain vs bundle", async () => {
+    // Default beforeEach: on-chain AUTH1111 vs resolved CREATOR111 + a creator
+    // immutable diff — a REAL mismatch that must NOT be over-refused.
+    h.preflightRecreate.mockResolvedValueOnce(plan());
+    const res = await buildRecreatePreflight(COURSE_ID);
+    expect(res.canRecreate).toBe(true);
+    if (!res.canRecreate) throw new Error("unreachable");
+    expect(res.immutableDiffs.map((d) => d.field)).toContain("creator");
+  });
+
+  it("allows when the creator matches but a non-creator immutable field (difficulty) differs", async () => {
+    h.preflightRecreate.mockResolvedValueOnce(plan());
+    // Creator matches → refusal must NOT hook onto creator-equality alone.
+    h.fetchCourse.mockResolvedValue({
+      creator: { toBase58: () => "CREATOR111" },
+    });
+    h.diffCourse.mockReturnValue({
+      differences: [
+        {
+          field: "difficulty",
+          onChainValue: "beginner",
+          contentValue: "advanced",
+          updateable: false,
+        },
+      ],
+    });
+    const res = await buildRecreatePreflight(COURSE_ID);
+    expect(res.canRecreate).toBe(true);
+    if (!res.canRecreate) throw new Error("unreachable");
+    expect(res.immutableDiffs.map((d) => d.field)).toEqual(["difficulty"]);
+  });
+});
+
 describe("buildRecreatePreflight — genuine refusal", () => {
   it("returns { canRecreate: false, reason } when even allow=true refuses, using the allow=true message", async () => {
     h.preflightRecreate

--- a/apps/web/src/lib/admin/__tests__/sanitize-reason.test.ts
+++ b/apps/web/src/lib/admin/__tests__/sanitize-reason.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { sanitizeReason } from "../sanitize-reason";
+
+describe("sanitizeReason", () => {
+  it("redacts an api-keyed RPC URL", () => {
+    const out = sanitizeReason(
+      "boom at https://rpc.example/?api-key=SECRET and more"
+    );
+    expect(out).not.toMatch(/rpc\.example/);
+    expect(out).not.toMatch(/SECRET/);
+    expect(out).toContain("[redacted-url]");
+  });
+
+  it("redacts a leftover api-key query param not inside a URL match", () => {
+    const out = sanitizeReason("params: ?api-key=abc123 leaked");
+    expect(out).not.toMatch(/abc123/);
+    expect(out).toContain("[redacted-api-key]");
+  });
+
+  it("redacts the SOLANA_RPC_URL env identifier", () => {
+    const out = sanitizeReason("missing env SOLANA_RPC_URL at boot");
+    expect(out).not.toMatch(/SOLANA_RPC_URL/);
+    expect(out).toContain("[redacted-env]");
+  });
+
+  it("redacts the PROGRAM_AUTHORITY_SECRET env identifier", () => {
+    const out = sanitizeReason("missing env PROGRAM_AUTHORITY_SECRET at boot");
+    expect(out).not.toMatch(/PROGRAM_AUTHORITY_SECRET/);
+    expect(out).toContain("[redacted-env]");
+  });
+
+  it("leaves an ordinary message untouched", () => {
+    expect(sanitizeReason("Failed to fetch")).toBe("Failed to fetch");
+  });
+});

--- a/apps/web/src/lib/admin/recreate-preflight.ts
+++ b/apps/web/src/lib/admin/recreate-preflight.ts
@@ -59,10 +59,21 @@ export interface RecreatePreflightData {
   lostCounters: { totalCompletions: number; totalEnrollments: number };
 }
 
+/**
+ * Stable, locale-agnostic discriminator for the two refusals THIS helper adds
+ * (the "no immutable field differs" / "could not confirm a mismatch" gate). The
+ * client maps these to translated copy; the English {@link
+ * RecreatePreflightRefusal.reason} stays as the server-side/telemetry fallback.
+ * Absent for pass-through `preflightRecreate` reasons (already free English).
+ */
+export type RecreatePreflightRefusalCode = "noImmutableDiff" | "unconfirmed";
+
 /** The recreate is refused — a dead-end, but now with a reason. */
 export interface RecreatePreflightRefusal {
   canRecreate: false;
   reason: string;
+  /** Present only for the no-op / unconfirmed gate so the client can i18n it. */
+  reasonCode?: RecreatePreflightRefusalCode;
 }
 
 export type RecreatePreflightResponse =
@@ -166,7 +177,52 @@ export async function buildRecreatePreflight(
   // `createParams.creatorWallet` is typed optional, but `preflightRecreate`
   // validates it (required, parseable, on-curve) and refuses otherwise before
   // ever returning a plan — so by here it is a resolved base58 string.
-  const creatorResolved = plan.createParams.creatorWallet ?? creatorOnChain ?? "";
+  const creatorResolved =
+    plan.createParams.creatorWallet ?? creatorOnChain ?? "";
+
+  // ---- POSITIVE requirement: a recreate must actually fix an immutable field.
+  // `preflightRecreate` only proves the create PARAMS are valid — it never
+  // asserts the on-chain account is genuinely wrong. Without this gate a stale
+  // tab or a second sequential recreate would close+recreate an already-correct
+  // course, irreversibly zeroing completion/enrollment counters and causing
+  // downtime while fixing nothing. So allow ONLY on positive evidence of a real
+  // immutable mismatch:
+  //   - `immutableDiffs` is non-empty (the pure diff engine — which already
+  //     excludes updateable fields and the H3-preserved lessonCount — found a
+  //     create-only field that differs, creator included), OR
+  //   - the creator provably differs from chain (both sides read and unequal).
+  // A confirmed creator difference ALSO shows up in `immutableDiffs`, but the
+  // creator check is kept independent so a diff-engine hiccup can't mask it.
+  const creatorDiffers =
+    creatorOnChain !== null &&
+    creatorResolved !== "" &&
+    creatorOnChain !== creatorResolved;
+  const hasRealImmutableDiff = immutableDiffs.length > 0 || creatorDiffers;
+
+  if (!hasRealImmutableDiff) {
+    // Distinguish "confirmed no-op" from "couldn't confirm". When the on-chain
+    // account could not be read/decoded (`creatorOnChain` is null → the diff
+    // engine also had no data, so `immutableDiffs` is empty for LACK OF DATA,
+    // not lack of difference), refuse on unconfirmed state rather than assert a
+    // no-op. Otherwise chain and bundle agree on every immutable field.
+    if (creatorOnChain === null) {
+      return {
+        canRecreate: false,
+        reasonCode: "unconfirmed",
+        reason:
+          "Could not read the on-chain account to confirm an immutable mismatch — " +
+          "refresh the status screen and retry; refusing to recreate on unconfirmed state.",
+      };
+    }
+    return {
+      canRecreate: false,
+      reasonCode: "noImmutableDiff",
+      reason:
+        "No immutable field differs between the content bundle and the on-chain account — " +
+        "a recreate would fix nothing and would irreversibly reset completion/enrollment " +
+        "counters and cause downtime.",
+    };
+  }
 
   return {
     canRecreate: true,

--- a/apps/web/src/lib/admin/recreate-preflight.ts
+++ b/apps/web/src/lib/admin/recreate-preflight.ts
@@ -1,0 +1,185 @@
+import "server-only";
+
+import { Connection } from "@solana/web3.js";
+import { serverEnv } from "@/lib/env.server";
+import { getAllCoursesAdmin } from "@/lib/content/queries";
+import { fetchCourse, type DecodedCourse } from "@/lib/solana/academy-reads";
+import { getProgramId } from "@/lib/solana/pda";
+import { diffCourse, type OnChainCourse } from "@/lib/admin/sync-diff";
+import {
+  preflightRecreate,
+  RecreateCourseError,
+  type RecreatePlan,
+} from "@/lib/admin/recreate-course";
+
+/**
+ * READ-ONLY preflight DTO for the WS-2 recreate UI. Everything here is a pure
+ * read: it calls {@link preflightRecreate} (which performs no on-chain writes),
+ * the cached content-bundle query, one `fetchCourse` read and the pure
+ * {@link diffCourse} engine — and NEVER `recreateCourse`/`closeCoursePda`. The
+ * destructive close+create lives exclusively behind the POST route.
+ */
+
+/** One immutable field the recreate will set, old (on-chain) → new (bundle). */
+export interface RecreatePreflightDiff {
+  field: string;
+  /** Current on-chain value (base58 for pubkeys). */
+  onChainValue: string;
+  /** Value the recreate will write from the content bundle. */
+  contentValue: string;
+}
+
+/** The recreate is possible — everything the confirm UI needs to show. */
+export interface RecreatePreflightData {
+  canRecreate: true;
+  courseId: string;
+  /** The Course PDA (unchanged by a recreate — same seeds). base58. */
+  coursePda: string;
+  /** Current on-chain `Course.creator` (base58), or null if it could not be read. */
+  creatorOnChain: string | null;
+  /** Resolved NEW creator wallet the recreate will set (base58, on-curve-validated). */
+  creatorResolved: string;
+  /**
+   * H3 — the live on-chain lesson_count the recreate defaults to. The recreate
+   * NEVER widens this (a wider mask would un-complete mid-course learners), so
+   * it is reported separately and is not one of {@link immutableDiffs}.
+   */
+  liveLessonCount: number;
+  /**
+   * F4 — true iff the resolved creator is "unusual": on the #427 denylist or
+   * equal to the platform authority, i.e. the recreate needs
+   * `allowUnusualCreator` to proceed. Derived purely from whether
+   * `preflightRecreate` accepts the creator without the override (see
+   * {@link buildRecreatePreflight}).
+   */
+  unusualCreator: boolean;
+  /** Immutable fields (creator/difficulty/trackId/trackLevel/prerequisite) that differ. */
+  immutableDiffs: RecreatePreflightDiff[];
+  /** Counters `create_course` resets to 0 — unrecoverable, reported for visibility. */
+  lostCounters: { totalCompletions: number; totalEnrollments: number };
+}
+
+/** The recreate is refused — a dead-end, but now with a reason. */
+export interface RecreatePreflightRefusal {
+  canRecreate: false;
+  reason: string;
+}
+
+export type RecreatePreflightResponse =
+  | RecreatePreflightData
+  | RecreatePreflightRefusal;
+
+/**
+ * Map the normalised, snake_case `DecodedCourse` to the diff engine's
+ * `OnChainCourse`. Display-only — mirrors the same mapping the status route
+ * uses so the recreate confirm shows exactly the fields the deploy screen does.
+ */
+function toOnChainCourse(courseId: string, raw: DecodedCourse): OnChainCourse {
+  return {
+    courseId,
+    creator: raw.creator.toBase58(),
+    lessonCount: raw.liveLessonCount,
+    difficulty: raw.difficulty,
+    xpPerLesson: raw.xp_per_lesson,
+    trackId: raw.track_id,
+    trackLevel: raw.track_level,
+    prerequisite: raw.prerequisite ? raw.prerequisite.toBase58() : null,
+    creatorRewardXp: raw.creator_reward_xp,
+    totalCompletions: raw.total_completions,
+    totalEnrollments: raw.total_enrollments,
+    isActive: raw.is_active,
+    version: raw.version,
+  };
+}
+
+/**
+ * Build the read-only recreate preflight DTO for a course.
+ *
+ * F4 flag derivation — the "unusual creator" flag is derived PURELY from
+ * `preflightRecreate`'s own accept/refuse behaviour, never by re-running the
+ * #427 denylist guard here (that would duplicate the contract). The flag is
+ * exactly "would the recreate NEED `allowUnusualCreator` to proceed":
+ *   - preflight(allow=false) accepts             → creator is normal.
+ *   - preflight(false) refuses, preflight(true)  → the ONLY blocker was the
+ *     accepts                                       creator guard → unusual.
+ *   - both refuse                                → a genuine dead-end; surface
+ *     the allow=true message, i.e. the reason that persists even under the
+ *     maximal override (never the creator-guard message, which would hide the
+ *     real remaining blocker).
+ *
+ * The common case for this fix (a normal instructor wallet replacing an
+ * on-chain `creator == authority`) accepts on the first call, so preflight runs
+ * only once; the second call happens only on the rare unusual-creator path.
+ */
+export async function buildRecreatePreflight(
+  courseId: string
+): Promise<RecreatePreflightResponse> {
+  const connection = new Connection(serverEnv.SOLANA_RPC_URL, "confirmed");
+
+  let plan: RecreatePlan;
+  let unusualCreator = false;
+  try {
+    plan = await preflightRecreate(courseId, connection, false);
+  } catch (first) {
+    if (!(first instanceof RecreateCourseError)) throw first;
+    // preflight(false) refused. Was the creator guard the SOLE reason?
+    try {
+      plan = await preflightRecreate(courseId, connection, true);
+      unusualCreator = true;
+    } catch (second) {
+      if (!(second instanceof RecreateCourseError)) throw second;
+      return { canRecreate: false, reason: second.message };
+    }
+  }
+
+  // The gate passed — assemble the display DTO. The immutable diffs + the old
+  // creator come from the same pure diff engine the deploy screen uses, so the
+  // confirm modal shows exactly the create-only fields `update_course` cannot
+  // fix. Best-effort: the gate is already authoritative, so a read hiccup here
+  // degrades to "no diffs shown" rather than a refusal (the client also carries
+  // its own row-level diffs for the at-a-glance card).
+  const [courses, onChain] = await Promise.all([
+    getAllCoursesAdmin(),
+    fetchCourse(courseId, connection, getProgramId()),
+  ]);
+  const course = courses.find((c) => c._id === courseId);
+  let creatorOnChain: string | null = null;
+  let immutableDiffs: RecreatePreflightDiff[] = [];
+  if (onChain && course) {
+    creatorOnChain = onChain.creator.toBase58();
+    const diff = diffCourse(
+      course,
+      toOnChainCourse(courseId, onChain),
+      plan.createParams.prerequisitePda ?? null
+    );
+    immutableDiffs = diff.differences
+      // lesson_count is PRESERVED by the recreate (H3) and reported separately
+      // as liveLessonCount — never shown here as an applied old→new change.
+      .filter((d) => !d.updateable && d.field !== "lessonCount")
+      .map((d) => ({
+        field: d.field,
+        onChainValue: String(d.onChainValue),
+        contentValue: String(d.contentValue),
+      }));
+  }
+
+  // `createParams.creatorWallet` is typed optional, but `preflightRecreate`
+  // validates it (required, parseable, on-curve) and refuses otherwise before
+  // ever returning a plan — so by here it is a resolved base58 string.
+  const creatorResolved = plan.createParams.creatorWallet ?? creatorOnChain ?? "";
+
+  return {
+    canRecreate: true,
+    courseId: plan.courseId,
+    coursePda: plan.coursePda.toBase58(),
+    creatorOnChain,
+    creatorResolved,
+    liveLessonCount: plan.createParams.lessonCount,
+    unusualCreator,
+    immutableDiffs,
+    lostCounters: {
+      totalCompletions: plan.snapshot.totalCompletions,
+      totalEnrollments: plan.snapshot.totalEnrollments,
+    },
+  };
+}

--- a/apps/web/src/lib/admin/sanitize-reason.ts
+++ b/apps/web/src/lib/admin/sanitize-reason.ts
@@ -1,0 +1,21 @@
+/**
+ * Scrub secret-bearing substrings out of a `reason`/error string before it is
+ * returned to the browser (reasons are rendered verbatim and can flow into
+ * client telemetry). Pure. Redacts, in order:
+ *   1. any `https?://…` URL (an api-keyed RPC URL leaks the whole key),
+ *   2. any leftover `?api-key=…` / `&api-key=…` query param not inside a URL,
+ *   3. the known secret env identifiers `SOLANA_RPC_URL` / `PROGRAM_AUTHORITY_SECRET`.
+ *
+ * Shared by the recreate preflight GET route (server-side scrub before the
+ * response leaves the server) and the recreate-course client flow (belt-and-
+ * suspenders scrub of the execute route's error string right before render —
+ * see `recreate-course-flow.tsx`). No `server-only` and no imports: this must
+ * be safely importable from both a route handler and a client component.
+ */
+export function sanitizeReason(reason: string): string {
+  return reason
+    .replace(/https?:\/\/\S+/gi, "[redacted-url]")
+    .replace(/[?&]api-key=[^\s&]*/gi, "[redacted-api-key]")
+    .replace(/SOLANA_RPC_URL/g, "[redacted-env]")
+    .replace(/PROGRAM_AUTHORITY_SECRET/g, "[redacted-env]");
+}

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -973,6 +973,52 @@
         "onChainLabel": "on-chain",
         "bundleLabel": "bundle",
         "remediation": "\"{title}\" has immutable on-chain fields that differ from the content bundle; update_course cannot apply them. Options: 1. Fix the value in the courses-academy repo and publish a new bundle PR, or 2. Deactivate this course and deploy a new version."
+      },
+      "recreate": {
+        "cardHeading": "Immutable mismatch — recreate required",
+        "cardIntro": "These fields are set once at deploy and update_course cannot change them. The only fix is to close and recreate the on-chain course.",
+        "creatorEmphasis": "Creator mismatch: Course.creator is the immutable XP-reward recipient. Until the course is recreated, every creator reward pays the wrong wallet.",
+        "onChainLabel": "on-chain",
+        "bundleLabel": "bundle",
+        "reviewButton": "Recreate course…",
+        "loading": "Checking…",
+        "refusedHeading": "Recreate unavailable",
+        "loadErrorHeading": "Could not check the recreate preflight",
+        "modal": {
+          "title": "Recreate “{title}”",
+          "intro": "This closes the on-chain course account and creates it again to rewrite the immutable fields below. It is the platform's most destructive on-chain operation.",
+          "creatorLabel": "Creator (immutable)",
+          "immutableHeading": "Immutable fields this recreate will set",
+          "lessonCountLabel": "On-chain lesson count is preserved exactly ({count}). New lessons are added afterwards via the ordinary sync.",
+          "resetHeading": "What resets",
+          "resetCounters": "Completion and enrollment counters reset to 0 (completions {completions}, enrollments {enrollments}). This is unrecoverable.",
+          "preserveHeading": "What is preserved",
+          "preserveList": "Enrollments, learner progress, and earned certificates are all preserved.",
+          "downtimeWarning": "Brief downtime: close and create are NOT atomic — there is a seconds-long window where the course PDA is absent and enroll/complete will fail.",
+          "unusualHeading": "Unusual creator",
+          "unusualDescription": "The resolved creator is on the denylist or equals the platform authority — normally refused by the #427 guard.",
+          "unusualAck": "I understand this creator is on the denylist / equals the platform authority.",
+          "confirmLabel": "Type the course id to confirm",
+          "confirmPlaceholder": "{courseId}",
+          "cancel": "Cancel",
+          "confirm": "Recreate course",
+          "executing": "Recreating…"
+        },
+        "result": {
+          "heading": "Course recreated",
+          "coursePda": "Course PDA",
+          "closeSignature": "Close signature",
+          "createSignature": "Create signature",
+          "attempts": "Create attempts",
+          "lostCounters": "Counters reset — completions {completions}, enrollments {enrollments}.",
+          "warningsHeading": "Warnings",
+          "refresh": "Refresh"
+        },
+        "execError": {
+          "heading": "Recreate failed",
+          "downRecovery": "A course with no PDA reads as not_deployed — use the normal Deploy button to recreate it.",
+          "close": "Close"
+        }
       }
     },
     "statusBadge": {

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -984,6 +984,10 @@
         "loading": "Checking…",
         "refusedHeading": "Recreate unavailable",
         "loadErrorHeading": "Could not check the recreate preflight",
+        "refusalReason": {
+          "noImmutableDiff": "No immutable field differs between the content bundle and the on-chain account — a recreate would fix nothing and would irreversibly reset completion/enrollment counters and cause downtime.",
+          "unconfirmed": "Could not read the on-chain account to confirm an immutable mismatch — refresh the status screen and retry; refusing to recreate on unconfirmed state."
+        },
         "modal": {
           "title": "Recreate “{title}”",
           "intro": "This closes the on-chain course account and creates it again to rewrite the immutable fields below. It is the platform's most destructive on-chain operation.",
@@ -1017,6 +1021,7 @@
         "execError": {
           "heading": "Recreate failed",
           "downRecovery": "A course with no PDA reads as not_deployed — use the normal Deploy button to recreate it.",
+          "indeterminateRecovery": "The recreate failed before a result was confirmed — the course may be intact or mid-recreate. Do NOT retry blindly. Refresh the admin status screen to check whether the course PDA exists before acting.",
           "close": "Close"
         }
       }

--- a/apps/web/src/messages/es.json
+++ b/apps/web/src/messages/es.json
@@ -973,6 +973,52 @@
         "onChainLabel": "on-chain",
         "bundleLabel": "paquete",
         "remediation": "\"{title}\" tiene campos on-chain inmutables que difieren del paquete de contenido; update_course no puede aplicarlos. Opciones: 1. Corrige el valor en el repositorio courses-academy y publica un nuevo PR de paquete, o 2. Desactiva este curso y despliega una nueva versión."
+      },
+      "recreate": {
+        "cardHeading": "Discrepancia inmutable — se requiere recrear",
+        "cardIntro": "Estos campos se fijan una sola vez al desplegar y update_course no puede cambiarlos. La única solución es cerrar y recrear el curso on-chain.",
+        "creatorEmphasis": "Discrepancia de creador: Course.creator es el destinatario inmutable de la recompensa de XP. Hasta que se recree el curso, cada recompensa de creador se paga a la wallet equivocada.",
+        "onChainLabel": "on-chain",
+        "bundleLabel": "bundle",
+        "reviewButton": "Recrear curso…",
+        "loading": "Comprobando…",
+        "refusedHeading": "Recrear no disponible",
+        "loadErrorHeading": "No se pudo comprobar la verificación previa de recreación",
+        "modal": {
+          "title": "Recrear «{title}»",
+          "intro": "Esto cierra la cuenta on-chain del curso y la vuelve a crear para reescribir los campos inmutables de abajo. Es la operación on-chain más destructiva de la plataforma.",
+          "creatorLabel": "Creador (inmutable)",
+          "immutableHeading": "Campos inmutables que esta recreación establecerá",
+          "lessonCountLabel": "El número de lecciones on-chain se conserva exactamente ({count}). Las nuevas lecciones se añaden después mediante la sincronización habitual.",
+          "resetHeading": "Qué se reinicia",
+          "resetCounters": "Los contadores de finalizaciones e inscripciones se reinician a 0 (finalizaciones {completions}, inscripciones {enrollments}). Esto es irrecuperable.",
+          "preserveHeading": "Qué se conserva",
+          "preserveList": "Las inscripciones, el progreso de los estudiantes y los certificados obtenidos se conservan todos.",
+          "downtimeWarning": "Breve interrupción: cerrar y crear NO son atómicos — hay una ventana de varios segundos en la que el PDA del curso no existe y enroll/complete fallarán.",
+          "unusualHeading": "Creador inusual",
+          "unusualDescription": "El creador resuelto está en la lista de bloqueo o es igual a la autoridad de la plataforma — normalmente rechazado por la protección #427.",
+          "unusualAck": "Entiendo que este creador está en la lista de bloqueo / es igual a la autoridad de la plataforma.",
+          "confirmLabel": "Escribe el id del curso para confirmar",
+          "confirmPlaceholder": "{courseId}",
+          "cancel": "Cancelar",
+          "confirm": "Recrear curso",
+          "executing": "Recreando…"
+        },
+        "result": {
+          "heading": "Curso recreado",
+          "coursePda": "PDA del curso",
+          "closeSignature": "Firma de cierre",
+          "createSignature": "Firma de creación",
+          "attempts": "Intentos de creación",
+          "lostCounters": "Contadores reiniciados — finalizaciones {completions}, inscripciones {enrollments}.",
+          "warningsHeading": "Advertencias",
+          "refresh": "Actualizar"
+        },
+        "execError": {
+          "heading": "La recreación falló",
+          "downRecovery": "Un curso sin PDA aparece como not_deployed — usa el botón normal de Desplegar para recrearlo.",
+          "close": "Cerrar"
+        }
       }
     },
     "statusBadge": {

--- a/apps/web/src/messages/es.json
+++ b/apps/web/src/messages/es.json
@@ -984,6 +984,10 @@
         "loading": "Comprobando…",
         "refusedHeading": "Recrear no disponible",
         "loadErrorHeading": "No se pudo comprobar la verificación previa de recreación",
+        "refusalReason": {
+          "noImmutableDiff": "Ningún campo inmutable difiere entre el paquete de contenido y la cuenta on-chain — recrear no arreglaría nada y reiniciaría de forma irreversible los contadores de finalización/inscripción y causaría tiempo de inactividad.",
+          "unconfirmed": "No se pudo leer la cuenta on-chain para confirmar una discrepancia inmutable — actualiza la pantalla de estado y reinténtalo; se rechaza recrear sobre un estado no confirmado."
+        },
         "modal": {
           "title": "Recrear «{title}»",
           "intro": "Esto cierra la cuenta on-chain del curso y la vuelve a crear para reescribir los campos inmutables de abajo. Es la operación on-chain más destructiva de la plataforma.",
@@ -1017,6 +1021,7 @@
         "execError": {
           "heading": "La recreación falló",
           "downRecovery": "Un curso sin PDA aparece como not_deployed — usa el botón normal de Desplegar para recrearlo.",
+          "indeterminateRecovery": "La recreación falló antes de confirmar un resultado — el curso puede estar intacto o a medio recrear. NO reintentes a ciegas. Actualiza la pantalla de estado de administración para comprobar si el PDA del curso existe antes de actuar.",
           "close": "Cerrar"
         }
       }

--- a/apps/web/src/messages/pt-BR.json
+++ b/apps/web/src/messages/pt-BR.json
@@ -984,6 +984,10 @@
         "loading": "Verificando…",
         "refusedHeading": "Recriação indisponível",
         "loadErrorHeading": "Não foi possível verificar a pré-verificação de recriação",
+        "refusalReason": {
+          "noImmutableDiff": "Nenhum campo imutável difere entre o pacote de conteúdo e a conta on-chain — recriar não corrigiria nada e zeraria de forma irreversível os contadores de conclusão/matrícula e causaria indisponibilidade.",
+          "unconfirmed": "Não foi possível ler a conta on-chain para confirmar uma divergência imutável — atualize a tela de status e tente novamente; recusando recriar sobre um estado não confirmado."
+        },
         "modal": {
           "title": "Recriar “{title}”",
           "intro": "Isto fecha a conta on-chain do curso e a cria novamente para reescrever os campos imutáveis abaixo. É a operação on-chain mais destrutiva da plataforma.",
@@ -1017,6 +1021,7 @@
         "execError": {
           "heading": "A recriação falhou",
           "downRecovery": "Um curso sem PDA aparece como not_deployed — use o botão normal de Deploy para recriá-lo.",
+          "indeterminateRecovery": "A recriação falhou antes de um resultado ser confirmado — o curso pode estar intacto ou no meio da recriação. NÃO tente novamente às cegas. Atualize a tela de status do admin para verificar se o PDA do curso existe antes de agir.",
           "close": "Fechar"
         }
       }

--- a/apps/web/src/messages/pt-BR.json
+++ b/apps/web/src/messages/pt-BR.json
@@ -973,6 +973,52 @@
         "onChainLabel": "on-chain",
         "bundleLabel": "pacote",
         "remediation": "\"{title}\" tem campos on-chain imutáveis que diferem do pacote de conteúdo; update_course não pode aplicá-los. Opções: 1. Corrija o valor no repositório courses-academy e publique um novo PR de pacote, ou 2. Desative este curso e implante uma nova versão."
+      },
+      "recreate": {
+        "cardHeading": "Divergência imutável — recriação necessária",
+        "cardIntro": "Estes campos são definidos uma única vez no deploy e update_course não pode alterá-los. A única correção é fechar e recriar o curso on-chain.",
+        "creatorEmphasis": "Divergência de criador: Course.creator é o destinatário imutável da recompensa de XP. Até o curso ser recriado, cada recompensa de criador é paga à carteira errada.",
+        "onChainLabel": "on-chain",
+        "bundleLabel": "bundle",
+        "reviewButton": "Recriar curso…",
+        "loading": "Verificando…",
+        "refusedHeading": "Recriação indisponível",
+        "loadErrorHeading": "Não foi possível verificar a pré-verificação de recriação",
+        "modal": {
+          "title": "Recriar “{title}”",
+          "intro": "Isto fecha a conta on-chain do curso e a cria novamente para reescrever os campos imutáveis abaixo. É a operação on-chain mais destrutiva da plataforma.",
+          "creatorLabel": "Criador (imutável)",
+          "immutableHeading": "Campos imutáveis que esta recriação irá definir",
+          "lessonCountLabel": "A contagem de lições on-chain é preservada exatamente ({count}). Novas lições são adicionadas depois pela sincronização normal.",
+          "resetHeading": "O que é zerado",
+          "resetCounters": "Os contadores de conclusões e inscrições são zerados (conclusões {completions}, inscrições {enrollments}). Isto é irrecuperável.",
+          "preserveHeading": "O que é preservado",
+          "preserveList": "As inscrições, o progresso dos alunos e os certificados conquistados são todos preservados.",
+          "downtimeWarning": "Breve indisponibilidade: fechar e criar NÃO são atômicos — há uma janela de alguns segundos em que o PDA do curso não existe e enroll/complete irão falhar.",
+          "unusualHeading": "Criador incomum",
+          "unusualDescription": "O criador resolvido está na lista de bloqueio ou é igual à autoridade da plataforma — normalmente recusado pela proteção #427.",
+          "unusualAck": "Entendo que este criador está na lista de bloqueio / é igual à autoridade da plataforma.",
+          "confirmLabel": "Digite o id do curso para confirmar",
+          "confirmPlaceholder": "{courseId}",
+          "cancel": "Cancelar",
+          "confirm": "Recriar curso",
+          "executing": "Recriando…"
+        },
+        "result": {
+          "heading": "Curso recriado",
+          "coursePda": "PDA do curso",
+          "closeSignature": "Assinatura de fechamento",
+          "createSignature": "Assinatura de criação",
+          "attempts": "Tentativas de criação",
+          "lostCounters": "Contadores zerados — conclusões {completions}, inscrições {enrollments}.",
+          "warningsHeading": "Avisos",
+          "refresh": "Atualizar"
+        },
+        "execError": {
+          "heading": "A recriação falhou",
+          "downRecovery": "Um curso sem PDA aparece como not_deployed — use o botão normal de Deploy para recriá-lo.",
+          "close": "Fechar"
+        }
       }
     },
     "statusBadge": {


### PR DESCRIPTION
## What
The UI half of WS-2 (plan: `docs/superpowers/specs/2026-07-14-ws2-recreate-ui-plan.md`, step 3 + step 6 i18n). Replaces the dead-end "cannot auto-fix" immutable-mismatch card on `/admin/courses` with an actionable, authority-gated **Recreate** flow — a **thin front over the merged #502 server path** (`recreate-course.ts` + `/api/admin/courses/recreate`). This is the mechanism that reconciles the 6 devnet courses after B4 activates the creator-wallet content (the `creator` mismatch that trips this UI *is* the #440 fix).

## Pieces
- **NEW `GET /api/admin/courses/recreate/preflight`** — read-only, admin-gated. Runs `preflightRecreate`, catches its refusal-throw into `{ canRecreate:false, reason }` at 200 (a refusal is UI data, not a 500). The route the plan assumed on #453 didn't exist (that route is execute-only) — this fills it.
- **Preflight card** — immutable field(s) old→new, creator old→new (prominent — immutable), the live on-chain `lesson_count` (H3), and the reset-vs-preserved summary (**counters reset to 0; enrollments, learner progress, AND certificates preserved**).
- **Non-dismissible confirm modal** — no backdrop/silent dismissal; type-the-courseId to enable Confirm; brief-downtime warning (close+create are not atomic). **F4:** an "unusual creator" (denylist / equals platform authority) requires a SECOND explicit acknowledgment, which alone maps to `allowUnusualCreator:true` + `acknowledgeUnusualCreator:courseId`. A normal recreate sends neither.
- **i18n** en/es/pt-BR (folded in — a standalone i18n PR would ship dead keys).

## Review discipline
**SENSITIVE.** Independent adversarial pass run before this PR opened → **no CRITICAL/HIGH** (the destructive authority is the server route, which independently re-enforces admin-auth, `confirm===courseId`, the F4 double-field, mainnet/genesis refusal, the #427 creator guard, H3, and maintenance-gate mutual exclusion). Findings, all fixed in `caeb14e`:
- **MEDIUM** — recreate was never re-gated on "an immutable mismatch still exists," so a stale tab / sequential double-recreate could close+recreate an already-correct course (irreversible counter reset + downtime for nothing). Fixed: preflight now returns `canRecreate:false` unless a real immutable diff is present (`noImmutableDiff`), or `unconfirmed` when the chain read is unavailable. Guarded against over-refusal — a genuine mismatch (incl. creator-only) still allows.
- **LOW** — indeterminate/network execute failure now shows an honest "refresh & check" recovery message instead of hiding the down-course hint.
- **LOW** — refusal/error `reason` strings scrubbed (`sanitizeReason`) so an api-keyed RPC URL / secret env names can't leak into client telemetry.
- **LOW** — corrected an inaccurate CSRF claim in the GET docstring.

## Merge gate
Hold until: (1) the gate's independent re-pass, (2) **owner sign-off** (destructive path), and (3) the **§7 live-devnet dry-run is green**. Do not merge before the dry-run.

## Noted pre-existing follow-up
The already-merged execute route (`recreate/route.ts`) still returns `preflightRecreate`/error reasons verbatim and can leak the same secret-bearing substrings — out of scope here (didn't re-touch merged SENSITIVE code); recommend routing it through the same `sanitizeReason` in a follow-up.

## Tests
22/22 new (preflight helper incl. both over-refusal guards, preflight route incl. redaction, client flow incl. F4 body + confirm-gating + the three failure states); 147/147 broader admin suite; tsc clean.