### PR TITLE
feat(challenge): LeetCode-style split — text left, editor right, AI reveals on scroll

### DIFF
--- a/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/blocks/code-block.tsx
+++ b/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/blocks/code-block.tsx
@@ -61,7 +61,7 @@ export function CodeBlock({ block, ctx }: BlockRenderProps) {
 
   return (
     <div className="overflow-hidden rounded-[var(--r-lg)] border-[2.5px] border-border shadow-card">
-      <div className="flex w-full flex-col overflow-hidden lg:h-[calc(100vh-220px)]">
+      <div className="flex w-full flex-col overflow-hidden lg:h-[calc(100vh-150px)]">
         <ChallengeInterface
           lessonId={ctx.lesson._id}
           courseSlug={ctx.courseSlug}

--- a/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/lesson-client.tsx
+++ b/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/lesson-client.tsx
@@ -294,8 +294,13 @@ export function LessonPageClient({
         hasCodeBlock ? "max-w-[1600px] px-1 sm:px-2" : "max-w-3xl"
       }`}
     >
-      {/* Lesson top bar */}
-      <div className="flex flex-wrap items-center gap-2 border-b border-border pb-4 sm:gap-3">
+      {/* Lesson top bar — full-bleed on challenges so its bottom border and
+          content line up with the edge-to-edge editor split below. */}
+      <div
+        className={`flex flex-wrap items-center gap-2 border-b border-border pb-4 sm:gap-3 ${
+          hasCodeBlock ? "mx-[calc(50%_-_50vw)] w-screen px-3 sm:px-4" : ""
+        }`}
+      >
         <Link
           href={`/${locale}/courses/${courseSlug}`}
           className="inline-flex items-center gap-1.5 font-display text-sm font-semibold text-text-3 transition-colors hover:text-text"
@@ -325,9 +330,12 @@ export function LessonPageClient({
       </div>
 
       {/* Blocks — challenges render only the code block(s) here (the wide IDE);
-          the instructions ride in the IDE rail via ctx.instructionsSlot. */}
+          the instructions ride in the IDE rail via ctx.instructionsSlot. The
+          split is full-bleed (w-screen + calc margin) so it escapes the platform
+          `container` max-width and spans the viewport edge-to-edge, LeetCode
+          style. `px` leaves a small gutter from the screen edges. */}
       {hasCodeBlock ? (
-        <div className="space-y-4">
+        <div className="mx-[calc(50%_-_50vw)] w-screen space-y-4 px-3 sm:px-4">
           {codeBlocks.map((block) => {
             const Renderer = RENDERERS[block._type];
             return <Renderer key={block.key} block={block} ctx={codeCtx} />;

--- a/apps/web/src/components/editor/challenge-interface.tsx
+++ b/apps/web/src/components/editor/challenge-interface.tsx
@@ -14,8 +14,8 @@ import type {
   CodeEditorHandle,
   ExecutionResult,
 } from "./types";
-import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 
 const LESSON_COMPLETE_EVENT = "superteam:lesson-complete";
 
@@ -90,20 +90,38 @@ export function ChallengeInterface({
     }
     prevIsAlreadyCompleted.current = isAlreadyCompleted ?? false;
   }, [isAlreadyCompleted]);
+
   const [panelHeight, setPanelHeight] = useState(120);
-  const [taskHeight, setTaskHeight] = useState(320);
-  // null = default 50/50 (both columns flex-1); a number = user dragged to that
-  // pixel width. Starting null keeps the split half-and-half on any screen.
-  const [railWidth, setRailWidth] = useState<number | null>(null);
-  const resizeRef = useRef<{
-    startY: number;
-    startHeight: number;
-    target: "output" | "task";
-  } | null>(null);
-  const railResizeRef = useRef<{ startX: number; startWidth: number } | null>(
+  // null = default 50/50 (both columns flex-1); a number = the user dragged the
+  // text column to that pixel width. Starting null keeps the split even.
+  const [leftWidth, setLeftWidth] = useState<number | null>(null);
+  const resizeRef = useRef<{ startY: number; startHeight: number } | null>(
     null
   );
-  const railRef = useRef<HTMLDivElement>(null);
+  const splitResizeRef = useRef<{ startX: number; startWidth: number } | null>(
+    null
+  );
+  const leftColRef = useRef<HTMLDivElement>(null);
+  const sentinelRef = useRef<HTMLDivElement>(null);
+
+  // The AI Partner sits at the bottom of the left reading column and stays
+  // hidden until the learner scrolls to the end of the description — then it
+  // slides in. `root: null` watches the viewport, so this works whether the
+  // column scrolls internally (lg+) or the page scrolls (below lg). Once
+  // revealed it stays revealed.
+  const [aiRevealed, setAiRevealed] = useState(false);
+  useEffect(() => {
+    const el = sentinelRef.current;
+    if (!el || aiRevealed) return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) setAiRevealed(true);
+      },
+      { root: null, rootMargin: "0px 0px -32px 0px", threshold: 0 }
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [aiRevealed]);
 
   const handleCodeChange = useCallback((newCode: string) => {
     setCode(newCode);
@@ -185,31 +203,21 @@ export function ChallengeInterface({
       window.removeEventListener("superteam:lesson-complete-error", handler);
   }, [lessonId]);
 
+  // Vertical drag for the editor/output split — the resizer sits above the
+  // output panel, so dragging up makes the output taller.
   const handleResizeStart = useCallback(
-    (target: "output" | "task") => (e: React.MouseEvent) => {
+    (e: React.MouseEvent) => {
       e.preventDefault();
-      const startHeight = target === "task" ? taskHeight : panelHeight;
-      resizeRef.current = { startY: e.clientY, startHeight, target };
+      resizeRef.current = { startY: e.clientY, startHeight: panelHeight };
 
       const handleMouseMove = (moveEvent: MouseEvent) => {
         if (!resizeRef.current) return;
-        // Task: drag down = taller (resizer sits below the panel).
-        // Output: drag up = taller (resizer sits above the panel).
-        const delta =
-          resizeRef.current.target === "output"
-            ? resizeRef.current.startY - moveEvent.clientY
-            : moveEvent.clientY - resizeRef.current.startY;
-        const [min, max] =
-          resizeRef.current.target === "task" ? [140, 600] : [88, 500];
+        const delta = resizeRef.current.startY - moveEvent.clientY;
         const newHeight = Math.max(
-          min,
-          Math.min(max, resizeRef.current.startHeight + delta)
+          88,
+          Math.min(500, resizeRef.current.startHeight + delta)
         );
-        if (resizeRef.current.target === "task") {
-          setTaskHeight(newHeight);
-        } else {
-          setPanelHeight(newHeight);
-        }
+        setPanelHeight(newHeight);
       };
 
       const handleMouseUp = () => {
@@ -221,34 +229,32 @@ export function ChallengeInterface({
       document.addEventListener("mousemove", handleMouseMove);
       document.addEventListener("mouseup", handleMouseUp);
     },
-    [panelHeight, taskHeight]
+    [panelHeight]
   );
 
-  // Horizontal (X-axis) drag for the workspace/rail split — the rail is on the
-  // right, so dragging the handle left widens it. Mirrors the vertical
-  // resizers' pattern, just on clientX/width instead of clientY/height.
-  const handleRailResizeStart = useCallback(
+  // Horizontal (X-axis) drag for the text/editor split. The text column is on
+  // the left and the handle sits on its right edge, so dragging right widens
+  // the text. Clamp the max against the container so the editor keeps ≥360px.
+  const handleSplitResizeStart = useCallback(
     (e: React.MouseEvent) => {
       e.preventDefault();
-      // From the flex default (railWidth null) measure the rail's live width;
-      // clamp the max against the container so the editor keeps ≥360px.
-      const startWidth = railWidth ?? railRef.current?.clientWidth ?? 460;
-      const container = railRef.current?.parentElement;
+      const startWidth = leftWidth ?? leftColRef.current?.clientWidth ?? 460;
+      const container = leftColRef.current?.parentElement;
       const maxW = container ? Math.max(360, container.clientWidth - 360) : 900;
-      railResizeRef.current = { startX: e.clientX, startWidth };
+      splitResizeRef.current = { startX: e.clientX, startWidth };
 
       const handleMouseMove = (moveEvent: MouseEvent) => {
-        if (!railResizeRef.current) return;
-        const delta = railResizeRef.current.startX - moveEvent.clientX;
+        if (!splitResizeRef.current) return;
+        const delta = moveEvent.clientX - splitResizeRef.current.startX;
         const next = Math.max(
           320,
-          Math.min(maxW, railResizeRef.current.startWidth + delta)
+          Math.min(maxW, splitResizeRef.current.startWidth + delta)
         );
-        setRailWidth(next);
+        setLeftWidth(next);
       };
 
       const handleMouseUp = () => {
-        railResizeRef.current = null;
+        splitResizeRef.current = null;
         document.removeEventListener("mousemove", handleMouseMove);
         document.removeEventListener("mouseup", handleMouseUp);
       };
@@ -256,7 +262,7 @@ export function ChallengeInterface({
       document.addEventListener("mousemove", handleMouseMove);
       document.addEventListener("mouseup", handleMouseUp);
     },
-    [railWidth]
+    [leftWidth]
   );
 
   return (
@@ -266,10 +272,69 @@ export function ChallengeInterface({
         className
       )}
     >
-      {/* LEFT workspace: toolbar + editor + output. 50/50 with the rail by
-          default (both sides use lg:flex-1); below lg, `contents` flattens
-          this into the root flex-col so its children order alongside the
-          rail's. */}
+      {/* LEFT: lesson text — full height, scrollable as one column. The AI
+          Partner lives at the very bottom and stays hidden until the learner
+          scrolls to the end of the description, then slides in (LeetCode-style
+          reading pane). Below lg, `contents` flattens this so the text
+          (order-1) and AI (order-4) bracket the editor/output (order-2/3). */}
+      <div
+        ref={leftColRef}
+        className={cn(
+          "contents lg:flex lg:min-w-0 lg:flex-col lg:overflow-auto",
+          leftWidth === null ? "lg:flex-1" : "lg:shrink-0"
+        )}
+        style={leftWidth !== null ? { width: leftWidth } : undefined}
+      >
+        {/* Instructions + test cases */}
+        <div className="order-1 lg:order-none lg:shrink-0">{taskSlot}</div>
+
+        {/* Reveal sentinel — entering the viewport unhides the AI Partner. */}
+        <div
+          ref={sentinelRef}
+          aria-hidden="true"
+          className="order-1 h-px w-full shrink-0 lg:order-none"
+        />
+
+        {/* AI Partner — collapsed until the sentinel is reached, then slides in. */}
+        <div
+          aria-hidden={!aiRevealed}
+          className={cn(
+            "order-4 px-3 transition-all duration-500 ease-out motion-reduce:transition-none lg:order-none lg:shrink-0",
+            aiRevealed
+              ? "max-h-[760px] translate-y-0 pb-4 pt-2 opacity-100"
+              : "pointer-events-none max-h-0 translate-y-3 overflow-hidden opacity-0"
+          )}
+        >
+          <div className="h-[600px]">
+            <AiPartnerPane
+              lessonSlug={lessonSlug}
+              courseSlug={courseSlug}
+              hints={hints}
+              getCode={() => code}
+              getTestSummary={() => summarize(challengeState.executionResult)}
+              onApply={(proposed) => setCode(proposed)}
+              disabled={isComplete}
+              className="h-full rounded-none border-0"
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* Text/editor split resizer — lg+ only; drag right to widen the text. */}
+      <div
+        className="group hidden w-1.5 shrink-0 cursor-col-resize border-x border-border transition-colors [background:var(--resizer-bg)] hover:[background:var(--primary-dim)] lg:relative lg:block"
+        onMouseDown={handleSplitResizeStart}
+        role="separator"
+        aria-orientation="vertical"
+        aria-label={tA11y("resizeRailPanel")}
+        tabIndex={0}
+      >
+        <div className="absolute left-1/2 top-1/2 h-8 w-0.5 -translate-x-1/2 -translate-y-1/2 rounded-full transition-colors [background:var(--resizer-handle)] group-hover:[background:var(--primary)]" />
+      </div>
+
+      {/* RIGHT: code editor + output — full height. Below lg, `contents`
+          flattens this so the editor (order-2) and output (order-3) slot
+          between the text (order-1) and the AI Partner (order-4). */}
       <div className="contents lg:flex lg:min-w-0 lg:flex-1 lg:flex-col lg:overflow-hidden">
         <div className="order-2 flex min-h-0 flex-col overflow-hidden lg:order-none lg:flex-1">
           {/* Toolbar */}
@@ -400,11 +465,11 @@ export function ChallengeInterface({
           </div>
         </div>
 
-        {/* Editor/output resizer — unchanged mechanism, hidden below lg since
-            the panels stack in natural flow there instead. */}
+        {/* Editor/output resizer — lg+ only; below lg the panels stack in
+            natural flow instead. */}
         <div
           className="lg:group hidden h-1.5 shrink-0 cursor-row-resize border-y border-border transition-colors [background:var(--resizer-bg)] hover:[background:var(--primary-dim)] lg:relative lg:block"
-          onMouseDown={handleResizeStart("output")}
+          onMouseDown={handleResizeStart}
           role="separator"
           aria-orientation="horizontal"
           aria-label={tA11y("resizeOutputPanel")}
@@ -422,65 +487,6 @@ export function ChallengeInterface({
             executionResult={challengeState.executionResult}
             isRunning={challengeState.status === "running"}
             onClear={handleClearOutput}
-            className="h-full rounded-none border-0"
-          />
-        </div>
-      </div>
-
-      {/* Workspace/rail horizontal resizer — lg+ only; drag to rebalance the
-          editor against the task/AI rail. */}
-      <div
-        className="group hidden w-1.5 shrink-0 cursor-col-resize border-x border-border transition-colors [background:var(--resizer-bg)] hover:[background:var(--primary-dim)] lg:relative lg:block"
-        onMouseDown={handleRailResizeStart}
-        role="separator"
-        aria-orientation="vertical"
-        aria-label={tA11y("resizeRailPanel")}
-        tabIndex={0}
-      >
-        <div className="absolute left-1/2 top-1/2 h-8 w-0.5 -translate-x-1/2 -translate-y-1/2 rounded-full transition-colors [background:var(--resizer-handle)] group-hover:[background:var(--primary)]" />
-      </div>
-
-      {/* RIGHT rail: task brief on top, AI Partner below, resizable split.
-          Width is drag-adjustable (railWidth); below lg, `contents` flattens
-          this into the root flex-col so task/AI take their `order` slots. */}
-      <div
-        ref={railRef}
-        className={cn(
-          "contents lg:flex lg:min-w-0 lg:flex-col lg:overflow-hidden",
-          railWidth === null ? "lg:flex-1" : "lg:shrink-0"
-        )}
-        style={railWidth !== null ? { width: railWidth } : undefined}
-      >
-        {/* Task brief */}
-        <div
-          className="order-1 overflow-auto max-lg:!h-auto lg:order-none lg:shrink-0"
-          style={{ height: taskHeight }}
-        >
-          {taskSlot}
-        </div>
-
-        {/* Task/AI resizer — same drag mechanic as the editor/output one. */}
-        <div
-          className="lg:group hidden h-1.5 shrink-0 cursor-row-resize border-y border-border transition-colors [background:var(--resizer-bg)] hover:[background:var(--primary-dim)] lg:relative lg:block"
-          onMouseDown={handleResizeStart("task")}
-          role="separator"
-          aria-orientation="horizontal"
-          aria-label={tA11y("resizeTaskPanel")}
-          tabIndex={0}
-        >
-          <div className="absolute left-1/2 top-1/2 h-0.5 w-8 -translate-x-1/2 -translate-y-1/2 rounded-full transition-colors [background:var(--resizer-handle)] group-hover:[background:var(--primary)]" />
-        </div>
-
-        {/* AI Partner */}
-        <div className="order-4 lg:order-none lg:min-h-0 lg:flex-1">
-          <AiPartnerPane
-            lessonSlug={lessonSlug}
-            courseSlug={courseSlug}
-            hints={hints}
-            getCode={() => code}
-            getTestSummary={() => summarize(challengeState.executionResult)}
-            onApply={(proposed) => setCode(proposed)}
-            disabled={isComplete}
             className="h-full rounded-none border-0"
           />
         </div>

--- a/apps/web/src/components/editor/challenge-interface.tsx
+++ b/apps/web/src/components/editor/challenge-interface.tsx
@@ -295,28 +295,34 @@ export function ChallengeInterface({
           className="order-1 h-px w-full shrink-0 lg:order-none"
         />
 
-        {/* AI Partner — collapsed until the sentinel is reached, then slides in. */}
+        {/* AI Partner — collapsed until the sentinel is reached, then slides in.
+            The pane is NOT mounted while collapsed: a CSS-only hide (max-h-0 /
+            overflow-hidden) would keep its inputs and buttons in the tab order,
+            letting a keyboard user land on invisible controls (WCAG 4.1.2). The
+            transition still runs because it lives on this always-mounted
+            wrapper — the pane simply mounts as the envelope grows. */}
         <div
-          aria-hidden={!aiRevealed}
           className={cn(
             "order-4 px-3 transition-all duration-500 ease-out motion-reduce:transition-none lg:order-none lg:shrink-0",
             aiRevealed
               ? "max-h-[760px] translate-y-0 pb-4 pt-2 opacity-100"
-              : "pointer-events-none max-h-0 translate-y-3 overflow-hidden opacity-0"
+              : "max-h-0 translate-y-3 overflow-hidden opacity-0"
           )}
         >
-          <div className="h-[600px]">
-            <AiPartnerPane
-              lessonSlug={lessonSlug}
-              courseSlug={courseSlug}
-              hints={hints}
-              getCode={() => code}
-              getTestSummary={() => summarize(challengeState.executionResult)}
-              onApply={(proposed) => setCode(proposed)}
-              disabled={isComplete}
-              className="h-full rounded-none border-0"
-            />
-          </div>
+          {aiRevealed && (
+            <div className="h-[600px]">
+              <AiPartnerPane
+                lessonSlug={lessonSlug}
+                courseSlug={courseSlug}
+                hints={hints}
+                getCode={() => code}
+                getTestSummary={() => summarize(challengeState.executionResult)}
+                onApply={(proposed) => setCode(proposed)}
+                disabled={isComplete}
+                className="h-full rounded-none border-0"
+              />
+            </div>
+          )}
         </div>
       </div>
 


### PR DESCRIPTION
## What

Reworks the challenge workspace into a **LeetCode-style two-column split**.

**Before:** code editor on the left; instructions + AI Partner stacked in a right rail.

**After:**
- **Left** — the lesson **text** (instructions + test cases) as one full-height, independently scrollable reading column.
- **Right** — the **code editor** + output panel, full height.
- **AI Partner** now sits at the **bottom of the left reading column** and stays collapsed until the learner **scrolls to the end of the description**, then slides in.

## How

- Swapped the two panels so text renders left / editor right; the drag divider now rebalances the text↔editor split (drag right widens the text). The editor↔output vertical resizer is unchanged.
- Reveal-on-scroll: an `IntersectionObserver` watches a 1px sentinel at the end of the text. `root: null` (viewport) so it works for both the column's internal scroll (lg+) and page scroll (below lg). Reveals **once** and stays revealed; `motion-reduce` disables the transition.
- Mobile stack order preserved via the existing `contents` + `order` pattern: **text (1) → editor (2) → output (3) → AI (4)**.

## Notes / test
- eslint + tsc clean.
- Please eyeball on the Vercel preview: desktop split + resize, scroll the left text to trigger the AI reveal, and the mobile stack. The AI pane is a fixed-height widget (600px) at the column bottom.
