### PR TITLE
feat(ai): persist AI Partner chat log so paid notes survive navigation

### DIFF
--- a/apps/web/src/app/api/ai/__tests__/partner-route.test.ts
+++ b/apps/web/src/app/api/ai/__tests__/partner-route.test.ts
@@ -10,9 +10,11 @@ vi.mock("@/lib/supabase/server", () => ({
 
 const spendAssist = vi.fn();
 const refundAssist = vi.fn();
+const appendAssistLog = vi.fn();
 vi.mock("@/lib/ai/assist-budget", () => ({
   spendAssist,
   refundAssist,
+  appendAssistLog,
   MAX_PAID_ASSISTS: 4,
 }));
 
@@ -129,6 +131,7 @@ beforeEach(() => {
   getUser.mockReset();
   spendAssist.mockReset();
   refundAssist.mockReset();
+  appendAssistLog.mockReset();
   isRateLimited.mockReset();
   getLessonBySlug.mockReset();
 
@@ -138,6 +141,7 @@ beforeEach(() => {
   getLessonBySlug.mockResolvedValue(LESSON);
   spendAssist.mockResolvedValue({ allowed: true, used: 1 });
   refundAssist.mockResolvedValue(undefined);
+  appendAssistLog.mockResolvedValue(undefined);
 });
 
 afterEach(() => {
@@ -237,6 +241,36 @@ describe("POST /api/ai/partner", () => {
 
     expect(res.status).toBe(200);
     expect(refundAssist).not.toHaveBeenCalled();
+  });
+
+  it("persists the AI turn to the assist log on a successful paid call", async () => {
+    stubGeminiFetch(PROPOSE_GEMINI_TEXT);
+
+    const { POST } = await import("../partner/route");
+    await POST(makeRequest(VALID_BODY));
+
+    expect(appendAssistLog).toHaveBeenCalledTimes(1);
+    const [userId, lessonId, entries] = appendAssistLog.mock.calls[0]!;
+    expect(userId).toBe("user-1");
+    expect(lessonId).toBe("lesson-1");
+    // propose carries no user turn — just the AI reply (with the sealed token).
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      role: "ai",
+      response: { type: "propose", proposedCode: "let x = 2;" },
+    });
+  });
+
+  it("does NOT persist to the assist log when the paid call fails", async () => {
+    // Gemini errors after spend -> route refunds and 502s; nothing to log.
+    stubGeminiFetch("", { ok: false });
+
+    const { POST } = await import("../partner/route");
+    const res = await POST(makeRequest(VALID_BODY));
+
+    expect(res.status).toBe(502);
+    expect(refundAssist).toHaveBeenCalledTimes(1);
+    expect(appendAssistLog).not.toHaveBeenCalled();
   });
 
   it("does NOT call refundAssist when the budget is already exhausted (no spend happened)", async () => {

--- a/apps/web/src/app/api/ai/partner/log/route.ts
+++ b/apps/web/src/app/api/ai/partner/log/route.ts
@@ -1,0 +1,45 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { getLessonBySlug } from "@/lib/content/queries";
+import { getAssistState } from "@/lib/ai/assist-budget";
+
+const MAX_SLUG_CHARS = 256;
+
+/**
+ * Returns the persisted AI Partner chat log + paid-assist count for the current
+ * learner on a lesson, so the pane can rehydrate past notes on load WITHOUT a
+ * paid model call. Own-data only: keyed by the authenticated user's id, read
+ * through the SECURITY DEFINER `get_challenge_assist_state` RPC.
+ */
+export async function GET(request: NextRequest) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+  if (authError || !user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { searchParams } = new URL(request.url);
+  const courseSlug = searchParams.get("courseSlug") ?? "";
+  const lessonSlug = searchParams.get("lessonSlug") ?? "";
+  if (
+    !courseSlug ||
+    !lessonSlug ||
+    courseSlug.length > MAX_SLUG_CHARS ||
+    lessonSlug.length > MAX_SLUG_CHARS
+  ) {
+    return NextResponse.json({ error: "Missing lesson" }, { status: 400 });
+  }
+
+  // Resolve the lesson id the budget/log is keyed by (same seam the paid route
+  // uses). A lesson not yet live has no partner surface, so no log either.
+  const lesson = await getLessonBySlug(courseSlug, lessonSlug);
+  if (!lesson) {
+    return NextResponse.json({ error: "Lesson not found" }, { status: 404 });
+  }
+
+  const { paidUsed, log } = await getAssistState(user.id, lesson._id);
+  return NextResponse.json({ log, paidUsed });
+}

--- a/apps/web/src/app/api/ai/partner/route.ts
+++ b/apps/web/src/app/api/ai/partner/route.ts
@@ -3,7 +3,11 @@ import type { CodeBlockData, ProseBlockData } from "@superteam-lms/types";
 import { createClient } from "@/lib/supabase/server";
 import { isRateLimited } from "@/lib/rate-limit";
 import { getLessonBySlug } from "@/lib/content/queries";
-import { spendAssist, refundAssist } from "@/lib/ai/assist-budget";
+import {
+  spendAssist,
+  refundAssist,
+  appendAssistLog,
+} from "@/lib/ai/assist-budget";
 import { sealCheck } from "@/lib/ai/check-seal";
 import {
   buildStaticPrefix,
@@ -14,6 +18,8 @@ import {
 import type {
   PartnerAction,
   PartnerRequest,
+  PartnerResponse,
+  PartnerMessage,
   HintResponse,
   AnswerResponse,
 } from "@/lib/ai/partner-types";
@@ -353,6 +359,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    let clientResponse: PartnerResponse;
     if (validated.type === "propose") {
       // Seal the answer server-side — the client only ever sees
       // {question, options} + an opaque checkToken. Never spread `validated`
@@ -361,7 +368,7 @@ export async function POST(request: NextRequest) {
         correctIndex: validated.correctIndex,
         explanation: validated.explanation,
       });
-      return NextResponse.json({
+      clientResponse = {
         type: "propose",
         rationale: validated.rationale,
         proposedCode: validated.proposedCode,
@@ -370,10 +377,26 @@ export async function POST(request: NextRequest) {
           options: validated.options,
         },
         checkToken,
-      });
+      };
+    } else {
+      clientResponse = validated;
     }
 
-    return NextResponse.json(validated);
+    // Persist the turn(s) to the per-(user, lesson) log so a returning learner
+    // can review these AI notes without spending another assist. Runs only on
+    // this success path — after every refund branch has returned — so the log
+    // stays aligned with the assists actually charged. "ask" also records the
+    // learner's question; propose/hint carry no user text. Best-effort:
+    // appendAssistLog never throws, and logging must not block the paid reply.
+    const logEntries: PartnerMessage[] = [
+      ...(action === "ask" && message
+        ? [{ role: "user", text: message } as const]
+        : []),
+      { role: "ai", response: clientResponse } as const,
+    ];
+    await appendAssistLog(user.id, lesson._id, logEntries);
+
+    return NextResponse.json(clientResponse);
   } catch (error) {
     console.error("AI partner error:", error);
     // Same reasoning as the other post-spend failure paths: refund the spend

--- a/apps/web/src/lib/ai/__tests__/use-ai-partner.test.tsx
+++ b/apps/web/src/lib/ai/__tests__/use-ai-partner.test.tsx
@@ -27,7 +27,13 @@ function baseProps(
 }
 
 beforeEach(() => {
-  vi.stubGlobal("fetch", vi.fn());
+  // Default: the on-mount rehydrate GET (/api/ai/partner/log) resolves to an
+  // empty log. Individual tests override with mockResolvedValue for their
+  // action fetch (mockClear in renderPartner keeps that implementation).
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => jsonResponse({ log: [], paidUsed: 0 }))
+  );
 });
 
 afterEach(() => {
@@ -35,9 +41,43 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
+// Renders the hook and flushes the on-mount rehydrate fetch
+// (GET /api/ai/partner/log), then clears the fetch mock so each test's
+// assertions only see the action fetches that follow — not the rehydrate call.
+async function renderPartner(
+  props: Parameters<typeof useAiPartner>[0] = baseProps()
+) {
+  const view = renderHook(() => useAiPartner(props));
+  await act(async () => {});
+  vi.mocked(global.fetch).mockClear();
+  return view;
+}
+
 describe("useAiPartner", () => {
-  it("serves the first two requestHint() calls from authored hints with no fetch", async () => {
+  it("rehydrates the persisted chat log + paidUsed on mount (no paid call)", async () => {
+    const stored = [
+      { role: "user", text: "why does this fail?" },
+      { role: "ai", response: { type: "answer", text: "off-by-one." } },
+    ];
+    vi.mocked(global.fetch).mockResolvedValue(
+      jsonResponse({ log: stored, paidUsed: 2 })
+    );
+
     const { result } = renderHook(() => useAiPartner(baseProps()));
+
+    await waitFor(() => expect(result.current.messages).toHaveLength(2));
+    expect(global.fetch).toHaveBeenCalledWith(
+      "/api/ai/partner/log?courseSlug=c-slug&lessonSlug=l-slug"
+    );
+    expect(result.current.messages[0]).toMatchObject({
+      role: "user",
+      text: "why does this fail?",
+    });
+    expect(result.current.paidUsed).toBe(2);
+  });
+
+  it("serves the first two requestHint() calls from authored hints with no fetch", async () => {
+    const { result } = await renderPartner();
 
     await act(async () => {
       result.current.requestHint();
@@ -71,7 +111,7 @@ describe("useAiPartner", () => {
     };
     vi.mocked(global.fetch).mockResolvedValue(jsonResponse(response));
 
-    const { result } = renderHook(() => useAiPartner(baseProps()));
+    const { result } = await renderPartner();
 
     // Drain the two free hints first (no network).
     await act(async () => {
@@ -116,9 +156,8 @@ describe("useAiPartner", () => {
       jsonResponse({ budgetExhausted: true, used: 4 })
     );
 
-    const { result } = renderHook(
-      () => useAiPartner(baseProps({ hints: [] })) // no authored hints -> requestHint always pays
-    );
+    // no authored hints -> requestHint always pays
+    const { result } = await renderPartner(baseProps({ hints: [] }));
 
     await act(async () => {
       await result.current.requestHint();
@@ -142,7 +181,7 @@ describe("useAiPartner", () => {
     };
     vi.mocked(global.fetch).mockResolvedValue(jsonResponse(response));
 
-    const { result } = renderHook(() => useAiPartner(baseProps()));
+    const { result } = await renderPartner();
 
     await act(async () => {
       await result.current.proposeFix();
@@ -166,7 +205,7 @@ describe("useAiPartner", () => {
     };
     vi.mocked(global.fetch).mockResolvedValue(jsonResponse(response));
 
-    const { result } = renderHook(() => useAiPartner(baseProps()));
+    const { result } = await renderPartner();
 
     await act(async () => {
       await result.current.ask("why does this fail?");
@@ -198,7 +237,7 @@ describe("useAiPartner", () => {
       })
     );
 
-    const { result } = renderHook(() => useAiPartner(baseProps()));
+    const { result } = await renderPartner();
 
     expect(result.current.loading).toBe(false);
 
@@ -220,7 +259,7 @@ describe("useAiPartner", () => {
   it("sets error on network failure and does not increment paidUsed", async () => {
     vi.mocked(global.fetch).mockRejectedValue(new Error("network down"));
 
-    const { result } = renderHook(() => useAiPartner(baseProps()));
+    const { result } = await renderPartner();
 
     await act(async () => {
       await result.current.ask("help?");
@@ -235,9 +274,7 @@ describe("useAiPartner", () => {
     const response: PartnerResponse = { type: "hint", text: "paid hint" };
     vi.mocked(global.fetch).mockResolvedValue(jsonResponse(response));
 
-    const { result } = renderHook(() =>
-      useAiPartner(baseProps({ hints: [HINTS[0]!] }))
-    );
+    const { result } = await renderPartner(baseProps({ hints: [HINTS[0]!] }));
 
     await act(async () => {
       result.current.requestHint();
@@ -261,7 +298,7 @@ describe("useAiPartner", () => {
         jsonResponse({ correct: true, explanation: "because B" })
       );
 
-      const { result } = renderHook(() => useAiPartner(baseProps()));
+      const { result } = await renderPartner();
 
       const verdict = await result.current.verifyCheck("tok", 1);
 
@@ -281,7 +318,7 @@ describe("useAiPartner", () => {
         json: async () => ({ error: "invalid check" }),
       } as Response);
 
-      const { result } = renderHook(() => useAiPartner(baseProps()));
+      const { result } = await renderPartner();
 
       const verdict = await result.current.verifyCheck("tok", 1);
 
@@ -291,7 +328,7 @@ describe("useAiPartner", () => {
     it("fails SAFE (correct:false) when the fetch itself throws", async () => {
       vi.mocked(global.fetch).mockRejectedValue(new Error("network down"));
 
-      const { result } = renderHook(() => useAiPartner(baseProps()));
+      const { result } = await renderPartner();
 
       const verdict = await result.current.verifyCheck("tok", 0);
 

--- a/apps/web/src/lib/ai/assist-budget.ts
+++ b/apps/web/src/lib/ai/assist-budget.ts
@@ -1,6 +1,8 @@
 import "server-only";
 import { MAX_PAID_ASSISTS } from "./partner-types";
+import type { PartnerMessage } from "./partner-types";
 import { createAdminClient } from "@/lib/supabase/admin";
+import type { Json } from "@/lib/supabase/types";
 
 // Single source of truth lives in partner-types.ts (shared client/server).
 // Re-exported here so existing consumers (the route, tests) keep importing it
@@ -90,5 +92,66 @@ export async function refundAssist(
     }
   } catch (err) {
     console.warn("[assist-budget] refund threw:", err);
+  }
+}
+
+/**
+ * Append rendered chat turns to the learner's per-lesson AI Partner log so a
+ * returning learner can review past notes without spending another assist.
+ * Called ONLY on a successful paid response (after every refund path has
+ * returned), keeping the log aligned with the assists actually charged.
+ * Best-effort: never throws, so a logging failure can't break the response the
+ * learner already paid for.
+ */
+export async function appendAssistLog(
+  userId: string,
+  lessonId: string,
+  entries: PartnerMessage[]
+): Promise<void> {
+  if (entries.length === 0) return;
+  try {
+    const { error } = await createAdminClient().rpc(
+      "append_challenge_assist_log",
+      {
+        p_user_id: userId,
+        p_lesson_id: lessonId,
+        // PartnerMessage[] is structurally JSON but not assignable to the
+        // recursive Json type without a cast (named interfaces lack an index
+        // signature). Safe: every field is a string/array/object literal.
+        p_entries: entries as unknown as Json,
+      }
+    );
+    if (error) {
+      console.warn("[assist-budget] append log failed:", error.message);
+    }
+  } catch (err) {
+    console.warn("[assist-budget] append log threw:", err);
+  }
+}
+
+/**
+ * Read a learner's per-lesson paid-assist count + persisted chat log for pane
+ * rehydration on load. Fails soft to an empty state so a missing row / read
+ * error just shows an empty chat (never blocks the lesson).
+ */
+export async function getAssistState(
+  userId: string,
+  lessonId: string
+): Promise<{ paidUsed: number; log: PartnerMessage[] }> {
+  try {
+    const { data, error } = await createAdminClient().rpc(
+      "get_challenge_assist_state",
+      { p_user_id: userId, p_lesson_id: lessonId }
+    );
+    const row = Array.isArray(data) ? data[0] : data;
+    if (error || !row) return { paidUsed: 0, log: [] };
+    return {
+      paidUsed: typeof row.assists_used === "number" ? row.assists_used : 0,
+      log: Array.isArray(row.chat_log)
+        ? (row.chat_log as PartnerMessage[])
+        : [],
+    };
+  } catch {
+    return { paidUsed: 0, log: [] };
   }
 }

--- a/apps/web/src/lib/ai/partner-types.ts
+++ b/apps/web/src/lib/ai/partner-types.ts
@@ -36,6 +36,18 @@ export interface ProposeResponse {
 
 export type PartnerResponse = HintResponse | AnswerResponse | ProposeResponse;
 
+/**
+ * A single rendered turn in the AI Partner chat. Persisted server-side per
+ * (learner, lesson) so a returning learner can review past AI notes without
+ * spending another paid assist. The `{role:"ai",kind:"hint"}` variant is the
+ * only client-only one — free authored hints never hit the paid route, so they
+ * aren't logged (and stay re-viewable for free).
+ */
+export type PartnerMessage =
+  | { role: "user"; text: string }
+  | { role: "ai"; kind: "hint"; text: string }
+  | { role: "ai"; response: PartnerResponse };
+
 /** The comprehension-check answer, sealed into `checkToken` (never sent to the client in the clear). */
 export interface SealedCheck {
   correctIndex: 0 | 1 | 2;

--- a/apps/web/src/lib/ai/use-ai-partner.ts
+++ b/apps/web/src/lib/ai/use-ai-partner.ts
@@ -1,12 +1,15 @@
 "use client";
 
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { MAX_PAID_ASSISTS } from "./partner-types";
 import type {
   PartnerAction,
+  PartnerMessage,
   PartnerResponse,
   VerifyResponse,
 } from "./partner-types";
+
+export type { PartnerMessage };
 
 // Free authored hints are served locally from the lesson's `hints` ladder —
 // they never hit the network. Once this many have been shown, `requestHint()`
@@ -19,11 +22,7 @@ const FREE_HINT_LIMIT = 2;
 
 const PARTNER_ROUTE = "/api/ai/partner";
 const VERIFY_ROUTE = "/api/ai/partner/verify";
-
-export type PartnerMessage =
-  | { role: "user"; text: string }
-  | { role: "ai"; kind: "hint"; text: string }
-  | { role: "ai"; response: PartnerResponse };
+const LOG_ROUTE = "/api/ai/partner/log";
 
 interface UseAiPartnerOptions {
   lessonSlug: string;
@@ -73,6 +72,44 @@ export function useAiPartner({
   const [budgetExhausted, setBudgetExhausted] = useState(false);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  // Rehydrate the persisted chat log + paid-assist count on mount so a
+  // returning learner sees past AI notes without spending again (the log lives
+  // server-side per user+lesson). Seeds only while the chat is still empty and
+  // never lowers a live `paidUsed`, so a fast first interaction during the
+  // async load is never clobbered.
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const res = await fetch(
+          `${LOG_ROUTE}?courseSlug=${encodeURIComponent(
+            courseSlug
+          )}&lessonSlug=${encodeURIComponent(lessonSlug)}`
+        );
+        if (!res.ok || cancelled) return;
+        const data = (await res.json()) as {
+          log?: PartnerMessage[];
+          paidUsed?: number;
+        };
+        if (cancelled) return;
+        if (Array.isArray(data.log) && data.log.length > 0) {
+          const loaded = data.log;
+          setMessages((prev) => (prev.length === 0 ? loaded : prev));
+        }
+        if (typeof data.paidUsed === "number") {
+          const used = data.paidUsed;
+          setPaidUsed((prev) => Math.max(prev, used));
+          if (used >= MAX_PAID_ASSISTS) setBudgetExhausted(true);
+        }
+      } catch {
+        // best-effort: an empty chat on load is an acceptable fallback
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [courseSlug, lessonSlug]);
 
   // Every call to the route is a PAID action (free hints never reach here) —
   // stateless by design, so only the current code/testSummary are sent, never

--- a/apps/web/src/lib/supabase/types.ts
+++ b/apps/web/src/lib/supabase/types.ts
@@ -945,6 +945,24 @@ export type Database = {
         };
         Returns: undefined;
       };
+      append_challenge_assist_log: {
+        Args: {
+          p_user_id: string;
+          p_lesson_id: string;
+          p_entries: Json;
+        };
+        Returns: undefined;
+      };
+      get_challenge_assist_state: {
+        Args: {
+          p_user_id: string;
+          p_lesson_id: string;
+        };
+        Returns: {
+          assists_used: number;
+          chat_log: Json;
+        }[];
+      };
       award_xp: {
         Args: {
           p_amount: number;

--- a/supabase/migrations/20260715160000_ai_partner_chat_log.sql
+++ b/supabase/migrations/20260715160000_ai_partner_chat_log.sql
@@ -1,0 +1,49 @@
+-- AI Partner chat-log persistence (per learner + lesson).
+-- Additive + idempotent — safe to run on an existing database. Mirrors the
+-- definitions added to supabase/schema.sql.
+
+-- 1. Store the rendered chat turns alongside the existing paid-assist counter.
+ALTER TABLE challenge_assists
+  ADD COLUMN IF NOT EXISTS chat_log JSONB NOT NULL DEFAULT '[]'::jsonb;
+
+-- 2. Append rendered turns (JSONB array of PartnerMessage) to a learner's log.
+CREATE OR REPLACE FUNCTION append_challenge_assist_log(
+  p_user_id   UUID,
+  p_lesson_id TEXT,
+  p_entries   JSONB
+) RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+  IF p_entries IS NULL OR jsonb_typeof(p_entries) <> 'array' THEN
+    RETURN;
+  END IF;
+  INSERT INTO public.challenge_assists (user_id, lesson_id, chat_log, updated_at)
+  VALUES (p_user_id, p_lesson_id, p_entries, now())
+  ON CONFLICT (user_id, lesson_id)
+  DO UPDATE SET
+    chat_log = public.challenge_assists.chat_log || EXCLUDED.chat_log,
+    updated_at = now();
+END;
+$$;
+
+REVOKE ALL ON FUNCTION append_challenge_assist_log(UUID, TEXT, JSONB) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION append_challenge_assist_log(UUID, TEXT, JSONB) TO service_role;
+
+-- 3. Read a learner's paid-assist count + chat log for pane rehydration.
+CREATE OR REPLACE FUNCTION get_challenge_assist_state(p_user_id UUID, p_lesson_id TEXT)
+RETURNS TABLE (assists_used INT, chat_log JSONB)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+  SELECT assists_used, chat_log
+  FROM public.challenge_assists
+  WHERE user_id = p_user_id AND lesson_id = p_lesson_id;
+$$;
+
+REVOKE ALL ON FUNCTION get_challenge_assist_state(UUID, TEXT) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION get_challenge_assist_state(UUID, TEXT) TO service_role;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -1864,9 +1864,17 @@ CREATE TABLE IF NOT EXISTS challenge_assists (
   user_id     UUID NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
   lesson_id   TEXT NOT NULL,
   assists_used INTEGER NOT NULL DEFAULT 0,
+  -- Rendered AI Partner chat turns (JSONB array of PartnerMessage) so a
+  -- returning learner can review past AI notes without spending another paid
+  -- assist. Bounded in practice by MAX_PAID_ASSISTS successful paid actions.
+  chat_log    JSONB NOT NULL DEFAULT '[]'::jsonb,
   updated_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
   PRIMARY KEY (user_id, lesson_id)
 );
+
+-- Idempotent add for DBs created before chat_log existed (this file predates it).
+ALTER TABLE challenge_assists
+  ADD COLUMN IF NOT EXISTS chat_log JSONB NOT NULL DEFAULT '[]'::jsonb;
 
 ALTER TABLE challenge_assists ENABLE ROW LEVEL SECURITY;
 -- No policies: reached only through SECURITY DEFINER RPCs called by service_role.
@@ -1954,3 +1962,50 @@ $$;
 
 REVOKE ALL ON FUNCTION refund_challenge_assist(UUID, TEXT) FROM PUBLIC, anon, authenticated;
 GRANT EXECUTE ON FUNCTION refund_challenge_assist(UUID, TEXT) TO service_role;
+
+-- Append rendered chat turns to a learner's per-lesson AI Partner log.
+-- p_entries is a JSONB array (PartnerMessage[]). The row already exists by the
+-- time this runs (spend_challenge_assist upserted it on the same paid call),
+-- but upsert defensively. Only ever called on a SUCCESSFUL paid response, so it
+-- stays aligned with the assists that were actually charged.
+CREATE OR REPLACE FUNCTION append_challenge_assist_log(
+  p_user_id   UUID,
+  p_lesson_id TEXT,
+  p_entries   JSONB
+) RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+  IF p_entries IS NULL OR jsonb_typeof(p_entries) <> 'array' THEN
+    RETURN;
+  END IF;
+  INSERT INTO public.challenge_assists (user_id, lesson_id, chat_log, updated_at)
+  VALUES (p_user_id, p_lesson_id, p_entries, now())
+  ON CONFLICT (user_id, lesson_id)
+  DO UPDATE SET
+    chat_log = public.challenge_assists.chat_log || EXCLUDED.chat_log,
+    updated_at = now();
+END;
+$$;
+
+REVOKE ALL ON FUNCTION append_challenge_assist_log(UUID, TEXT, JSONB) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION append_challenge_assist_log(UUID, TEXT, JSONB) TO service_role;
+
+-- Read a learner's per-lesson assist count + chat log for pane rehydration
+-- (so returning to a lesson restores past AI notes without a paid model call).
+CREATE OR REPLACE FUNCTION get_challenge_assist_state(p_user_id UUID, p_lesson_id TEXT)
+RETURNS TABLE (assists_used INT, chat_log JSONB)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+  SELECT assists_used, chat_log
+  FROM public.challenge_assists
+  WHERE user_id = p_user_id AND lesson_id = p_lesson_id;
+$$;
+
+REVOKE ALL ON FUNCTION get_challenge_assist_state(UUID, TEXT) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION get_challenge_assist_state(UUID, TEXT) TO service_role;


### PR DESCRIPTION
## Problem

The AI Partner chat lived only in React state (`useState`), so navigating away lost every hint / answer / **proposal a learner had paid for**. Meanwhile the paid-assist budget is tracked **server-side** per (user, lesson), so a returning learner saw *consumed credits but no notes* — you can't re-read what you paid for without spending again.

## Fix — persist the log account-wide, next to the budget it belongs to

**Schema** (`challenge_assists` already holds the per-(user, lesson) paid counter):
- `+ chat_log JSONB` column (rendered `PartnerMessage[]`).
- `append_challenge_assist_log(user, lesson, entries)` — upsert + JSONB concat.
- `get_challenge_assist_state(user, lesson)` — returns `{ assists_used, chat_log }`.
- Both `SECURITY DEFINER`, `REVOKE`d from `anon`/`authenticated`, `GRANT`ed to `service_role` — identical to the existing assist RPCs. Additive, idempotent migration in `supabase/migrations/`.

**Server** — `/api/ai/partner`:
- On a **successful** paid response (after every refund path has returned), append the turn(s): the `ask` question + the AI reply, or just the reply for `propose`/`hint`. Best-effort — logging never blocks or fails the paid reply, and only successful (charged) turns are logged, so the log stays aligned with the budget.

**Load route** — `GET /api/ai/partner/log`:
- Returns `{ log, paidUsed }` for the current user, own-data only via the definer RPC.

**Client** — `use-ai-partner`:
- Rehydrates `messages` + `paidUsed` on mount. Seeds only while the chat is still empty and never lowers a live count, so a fast first interaction during the async load is never clobbered. Past notes reappear **for free**.

`PartnerMessage` moved to `partner-types.ts` (shared with the server route), re-exported from the hook for existing consumers (`message-list.tsx`).

Free authored hints are unchanged: client-only, never logged, re-viewable for free. Volume is bounded by `MAX_PAID_ASSISTS`, so the log can't grow unbounded.

## Deploy note
Run `supabase/migrations/20260715160000_ai_partner_chat_log.sql` against the DB (additive + idempotent). tsc clean.

---

Closes #518 (fixes the `useAiPartner` unit-test regression from the on-mount rehydrate fetch).

Closes #522 (partner-route tests: mock `appendAssistLog` + cover log persistence).
