### PR TITLE
feat(admin): WS-A UI lighten + formatting + recreate-copy fix (#512)

### DIFF
--- a/apps/web/src/app/[locale]/admin/__tests__/courses-page.test.tsx
+++ b/apps/web/src/app/[locale]/admin/__tests__/courses-page.test.tsx
@@ -1,9 +1,9 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import { NextIntlClientProvider } from "next-intl";
-import messages from "@/messages/en.json";
 import AdminCoursesPage from "../courses/page";
+import messages from "@/messages/en.json";
 
 /**
  * `/admin/courses` — the merged Publish + Deploy screen. Both moved components
@@ -91,9 +91,12 @@ describe("AdminCoursesPage", () => {
   it("legends every deploy state the rows can show", async () => {
     await renderPage();
 
+    // The legend is a default-collapsed disclosure (WS-A) — its heading is the
+    // toggle; expand it to reveal the state reference.
     expect(
       screen.getByRole("heading", { name: legend.title })
     ).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: legend.title }));
 
     // On-chain states (StatusBadge) — badge label paired with its meaning.
     for (const state of [
@@ -122,6 +125,7 @@ describe("AdminCoursesPage", () => {
 
   it("legends the drifted state as a publish fix, not a redeploy", async () => {
     await renderPage();
+    fireEvent.click(screen.getByRole("button", { name: legend.title }));
     expect(legend.drifted).toMatch(/publish PR/i);
     expect(screen.getByText(legend.drifted)).toBeInTheDocument();
   });

--- a/apps/web/src/app/[locale]/admin/__tests__/deploy-legend.test.tsx
+++ b/apps/web/src/app/[locale]/admin/__tests__/deploy-legend.test.tsx
@@ -1,0 +1,43 @@
+// @vitest-environment jsdom
+import type { ReactElement } from "react";
+import { describe, it, expect } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import { DeployLegend } from "../courses/deploy-legend";
+import messages from "@/messages/en.json";
+
+function renderWithIntl(ui: ReactElement) {
+  return render(
+    <NextIntlClientProvider locale="en" messages={messages}>
+      {ui}
+    </NextIntlClientProvider>
+  );
+}
+
+const legend = messages.admin.coursesScreen.legend;
+
+describe("DeployLegend disclosure", () => {
+  it("renders collapsed by default: title trigger shown, body hidden", () => {
+    renderWithIntl(<DeployLegend />);
+    const trigger = screen.getByRole("button", { name: legend.title });
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+    // The reference body (headings, per-state copy) is not mounted while collapsed.
+    expect(screen.queryByText(legend.onChainHeading)).not.toBeInTheDocument();
+    expect(screen.queryByText(legend.description)).not.toBeInTheDocument();
+  });
+
+  it("reveals the legend body and flips aria-expanded on toggle", () => {
+    renderWithIntl(<DeployLegend />);
+    const trigger = screen.getByRole("button", { name: legend.title });
+
+    fireEvent.click(trigger);
+    expect(trigger).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByText(legend.onChainHeading)).toBeInTheDocument();
+    expect(screen.getByText(legend.driftHeading)).toBeInTheDocument();
+    expect(screen.getByText(legend.immutableTitle)).toBeInTheDocument();
+
+    fireEvent.click(trigger);
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByText(legend.onChainHeading)).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/[locale]/admin/__tests__/publish-pin-client.test.tsx
+++ b/apps/web/src/app/[locale]/admin/__tests__/publish-pin-client.test.tsx
@@ -97,16 +97,21 @@ describe("PublishPinClient", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("renders the drift count, one-line diff and prepare-PR link when drifted", async () => {
+  it("keeps the prepare-PR steps behind a default-collapsed disclosure and reveals the one-line diff + PR link on expand", async () => {
     mockFetch(drifted);
     renderWithIntl(<PublishPinClient />);
-    await waitFor(() =>
-      expect(
-        screen.getByText(messages.admin.publishPin.prepare.title)
-      ).toBeInTheDocument()
-    );
+    const trigger = await screen.findByRole("button", {
+      name: messages.admin.publishPin.prepare.title,
+    });
+    // The drift count is always visible; the manual 3-step block is not.
     expect(screen.getByText("3 commits behind HEAD")).toBeInTheDocument();
-    // The one-line lock diff is shown verbatim.
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByText(/"sha": "401c7df/)).not.toBeInTheDocument();
+
+    fireEvent.click(trigger);
+
+    expect(trigger).toHaveAttribute("aria-expanded", "true");
+    // The one-line lock diff is shown verbatim once expanded.
     expect(screen.getByText(/"sha": "401c7df/)).toBeInTheDocument();
     const prLink = screen.getByRole("link", {
       name: messages.admin.publishPin.preparePrLink,
@@ -117,27 +122,28 @@ describe("PublishPinClient", () => {
     );
   });
 
-  it("warns loudly when HEAD's CI is red", async () => {
+  it("warns loudly when HEAD's CI is red, inside the expanded prepare-PR block", async () => {
     mockFetch(driftedRedHead);
     renderWithIntl(<PublishPinClient />);
-    await waitFor(() =>
-      expect(
-        screen.getByText(messages.admin.publishPin.prepare.redHeadWarning)
-      ).toBeInTheDocument()
-    );
+    const trigger = await screen.findByRole("button", {
+      name: messages.admin.publishPin.prepare.title,
+    });
+    fireEvent.click(trigger);
+    expect(
+      screen.getByText(messages.admin.publishPin.prepare.redHeadWarning)
+    ).toBeInTheDocument();
     expect(screen.getByRole("alert")).toBeInTheDocument();
   });
 
-  it("copies the compile command to the clipboard", async () => {
+  it("copies the compile command to the clipboard once the disclosure is expanded", async () => {
     const writeText = vi.fn().mockResolvedValue(undefined);
     vi.stubGlobal("navigator", { clipboard: { writeText } });
     mockFetch(drifted);
     renderWithIntl(<PublishPinClient />);
-    await waitFor(() =>
-      expect(
-        screen.getByText(messages.admin.publishPin.copyCommand)
-      ).toBeInTheDocument()
-    );
+    const trigger = await screen.findByRole("button", {
+      name: messages.admin.publishPin.prepare.title,
+    });
+    fireEvent.click(trigger);
     fireEvent.click(screen.getByText(messages.admin.publishPin.copyCommand));
     await waitFor(() =>
       expect(writeText).toHaveBeenCalledWith(

--- a/apps/web/src/app/[locale]/admin/courses/deploy-client.tsx
+++ b/apps/web/src/app/[locale]/admin/courses/deploy-client.tsx
@@ -4,6 +4,7 @@ import { useTranslations } from "next-intl";
 import { useAdminStatus } from "../use-admin-status";
 import { CourseSyncTable } from "@/components/admin/course-sync-table";
 import { AchievementSyncTable } from "@/components/admin/achievement-sync-table";
+import { AdminCard } from "@/components/admin/admin-card";
 
 /**
  * The deploy half of `/admin/courses` (step 2): the Courses + Achievements
@@ -24,8 +25,13 @@ export function DeployClient() {
   }
 
   if (error) {
+    // A failed status fetch is transient/recoverable — neutral `streak`, not the
+    // blocking `danger` red.
     return (
-      <div className="rounded-md border border-danger bg-danger-light p-4 text-sm text-danger">
+      <div
+        role="alert"
+        className="rounded-md border border-streak bg-streak-light p-4 text-sm text-streak"
+      >
         {t(error === "network" ? "states.networkError" : "states.fetchError")}
         <button onClick={refetch} className="ml-3 underline hover:no-underline">
           {t("states.retry")}
@@ -53,13 +59,13 @@ export function DeployClient() {
             {t("states.refresh")}
           </button>
         </div>
-        <div className="rounded-lg border border-border bg-card p-4 shadow-card">
+        <AdminCard>
           {courses.length === 0 ? (
             <p className="text-sm text-text-3">{t("deployScreen.noCourses")}</p>
           ) : (
             <CourseSyncTable courses={courses} onRefresh={refetch} />
           )}
-        </div>
+        </AdminCard>
       </section>
 
       {/* Achievements */}
@@ -67,7 +73,7 @@ export function DeployClient() {
         <h3 className="mb-4 font-display text-lg font-bold text-text">
           {t("deployScreen.achievementsHeading")}
         </h3>
-        <div className="rounded-lg border border-border bg-card p-4 shadow-card">
+        <AdminCard>
           {achievements.length === 0 ? (
             <p className="text-sm text-text-3">
               {t("deployScreen.noAchievements")}
@@ -78,7 +84,7 @@ export function DeployClient() {
               onRefresh={refetch}
             />
           )}
-        </div>
+        </AdminCard>
       </section>
     </div>
   );

--- a/apps/web/src/app/[locale]/admin/courses/deploy-legend.tsx
+++ b/apps/web/src/app/[locale]/admin/courses/deploy-legend.tsx
@@ -5,6 +5,8 @@ import {
   StatusBadge,
   ContentDriftBadge,
 } from "@/components/admin/status-badge";
+import { AdminCard } from "@/components/admin/admin-card";
+import { AdminDisclosure } from "@/components/admin/admin-disclosure";
 import type { CourseContentDrift } from "@/lib/github/drift";
 
 /**
@@ -38,63 +40,68 @@ export function DeployLegend() {
   const t = useTranslations("admin.coursesScreen.legend");
 
   return (
-    <section
-      aria-labelledby="deploy-legend-heading"
-      className="rounded-lg border border-border bg-card p-4 shadow-card"
-    >
-      <h3
-        id="deploy-legend-heading"
-        className="font-display text-base font-bold text-text"
+    <AdminCard as="section">
+      <AdminDisclosure
+        headingLevel={3}
+        summary={
+          <span className="font-display text-base font-bold text-text">
+            {t("title")}
+          </span>
+        }
       >
-        {t("title")}
-      </h3>
-      <p className="mt-1 text-sm text-text-3">{t("description")}</p>
+        <p className="mt-1 text-sm text-text-3">{t("description")}</p>
 
-      <div className="mt-4 grid grid-cols-1 gap-6 md:grid-cols-2">
-        <div>
-          <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-text-3">
-            {t("onChainHeading")}
-          </p>
-          <dl className="space-y-2">
-            {ON_CHAIN_STATES.map((status) => (
-              <div key={status} className="flex flex-wrap items-baseline gap-2">
-                <dt className="shrink-0">
-                  <StatusBadge status={status} />
-                </dt>
-                <dd className="min-w-0 flex-1 text-sm text-text-3">
-                  {t(status)}
-                </dd>
-              </div>
-            ))}
-          </dl>
-        </div>
-
-        <div>
-          <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-text-3">
-            {t("driftHeading")}
-          </p>
-          <dl className="space-y-2">
-            {DRIFT_STATES.map(({ key, contentDrift }) => (
-              <div key={key} className="flex flex-wrap items-baseline gap-2">
-                <dt className="shrink-0">
-                  <ContentDriftBadge
-                    onChainStatus="synced"
-                    contentDrift={contentDrift}
-                  />
-                </dt>
-                <dd className="min-w-0 flex-1 text-sm text-text-3">{t(key)}</dd>
-              </div>
-            ))}
-          </dl>
-
-          <div className="mt-4 rounded-md border border-danger bg-danger-light p-3">
-            <p className="text-sm font-semibold text-danger">
-              {t("immutableTitle")}
+        <div className="mt-4 grid grid-cols-1 gap-6 md:grid-cols-2">
+          <div>
+            <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-text-3">
+              {t("onChainHeading")}
             </p>
-            <p className="mt-1 text-sm text-text-2">{t("immutableBody")}</p>
+            <dl className="space-y-2">
+              {ON_CHAIN_STATES.map((status) => (
+                <div
+                  key={status}
+                  className="flex flex-wrap items-baseline gap-2"
+                >
+                  <dt className="shrink-0">
+                    <StatusBadge status={status} />
+                  </dt>
+                  <dd className="min-w-0 flex-1 text-sm text-text-3">
+                    {t(status)}
+                  </dd>
+                </div>
+              ))}
+            </dl>
+          </div>
+
+          <div>
+            <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-text-3">
+              {t("driftHeading")}
+            </p>
+            <dl className="space-y-2">
+              {DRIFT_STATES.map(({ key, contentDrift }) => (
+                <div key={key} className="flex flex-wrap items-baseline gap-2">
+                  <dt className="shrink-0">
+                    <ContentDriftBadge
+                      onChainStatus="synced"
+                      contentDrift={contentDrift}
+                    />
+                  </dt>
+                  <dd className="min-w-0 flex-1 text-sm text-text-3">
+                    {t(key)}
+                  </dd>
+                </div>
+              ))}
+            </dl>
+
+            <div className="mt-4 rounded-md border border-danger bg-danger-light p-3">
+              <p className="text-sm font-semibold text-danger">
+                {t("immutableTitle")}
+              </p>
+              <p className="mt-1 text-sm text-text-2">{t("immutableBody")}</p>
+            </div>
           </div>
         </div>
-      </div>
-    </section>
+      </AdminDisclosure>
+    </AdminCard>
   );
 }

--- a/apps/web/src/app/[locale]/admin/courses/page.tsx
+++ b/apps/web/src/app/[locale]/admin/courses/page.tsx
@@ -2,6 +2,7 @@ import { getTranslations } from "next-intl/server";
 import { PublishPinClient } from "./publish-pin-client";
 import { DeployClient } from "./deploy-client";
 import { DeployLegend } from "./deploy-legend";
+import { AdminCard } from "@/components/admin/admin-card";
 
 /**
  * `/admin/courses` — the merged content screen. It composes the two surfaces
@@ -32,7 +33,7 @@ export default async function AdminCoursesPage() {
           {t("screens.courses")}
         </h2>
 
-        <div className="space-y-4 rounded-lg border border-border bg-card p-4 shadow-card">
+        <AdminCard className="space-y-4">
           <p className="text-sm text-text-2">{t("coursesScreen.intro.lede")}</p>
           <ol className="space-y-3">
             {(["step1", "step2"] as const).map((step) => (
@@ -49,7 +50,7 @@ export default async function AdminCoursesPage() {
           <p className="rounded-md border border-primary bg-primary-bg p-3 text-sm text-text-2">
             {t("coursesScreen.intro.contentOnlyNote")}
           </p>
-        </div>
+        </AdminCard>
       </section>
 
       <section

--- a/apps/web/src/app/[locale]/admin/courses/publish-pin-client.tsx
+++ b/apps/web/src/app/[locale]/admin/courses/publish-pin-client.tsx
@@ -2,6 +2,12 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { useTranslations } from "next-intl";
+import { AdminCard } from "@/components/admin/admin-card";
+import {
+  AdminBadge,
+  type AdminBadgeTone,
+} from "@/components/admin/admin-badge";
+import { AdminDisclosure } from "@/components/admin/admin-disclosure";
 import type { ChecksState } from "@/lib/github/types";
 import {
   computePublishVerdict,
@@ -33,18 +39,16 @@ const BUTTON_CLASSES =
 
 function ChecksBadge({ checks }: { checks: ChecksState }): React.ReactElement {
   const t = useTranslations("admin.publishPin");
-  const tone: Record<ChecksState, string> = {
-    success: "border-success bg-success-light text-success",
-    failure: "border-danger bg-danger-light text-danger",
-    pending: "border-streak bg-streak-light text-streak",
-    unknown: "border-border bg-subtle text-text-3",
+  const tone: Record<ChecksState, AdminBadgeTone> = {
+    success: "success",
+    failure: "danger",
+    pending: "warning",
+    unknown: "neutral",
   };
   return (
-    <span
-      className={`inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-medium ${tone[checks]}`}
-    >
+    <AdminBadge tone={tone[checks]} shape="pill">
       {t(`checks.${checks}`)}
-    </span>
+    </AdminBadge>
   );
 }
 
@@ -117,7 +121,7 @@ export function PublishPinClient(): React.ReactElement {
   }, [load]);
 
   return (
-    <div className="rounded-lg border border-border bg-card p-4 shadow-card">
+    <AdminCard>
       <div className="mb-3 flex items-center justify-between gap-4">
         <h3 className="font-display text-base font-bold text-text">
           {t("title")}
@@ -142,7 +146,7 @@ export function PublishPinClient(): React.ReactElement {
       ) : (
         <PinBody data={data} />
       )}
-    </div>
+    </AdminCard>
   );
 }
 
@@ -225,76 +229,82 @@ function PreparePr({ data }: { data: PinResponse }): React.ReactElement {
   const prUrl = buildPublishPrUrl({ pinnedSha: pin.sha, headSha: head.sha });
 
   return (
-    <section className="space-y-4 rounded-md border border-border bg-bg p-4">
-      <h4 className="font-display text-sm font-bold text-text">
-        {t("prepare.title")}
-      </h4>
-
-      {verdict.warnRedHead && (
-        <div
-          role="alert"
-          className="rounded-md border border-danger bg-danger-light p-3 text-sm text-danger"
-        >
-          {t("prepare.redHeadWarning")}
-        </div>
-      )}
-
-      <div className="space-y-1">
-        <p className="text-xs font-medium uppercase tracking-wide text-text-3">
-          {t("prepare.step1")}
-        </p>
-        <pre className="overflow-x-auto rounded-md border border-border bg-card p-3 text-xs">
-          <code className="font-mono text-text">{diff}</code>
-        </pre>
-      </div>
-
-      <div className="space-y-1">
-        <p className="text-xs font-medium uppercase tracking-wide text-text-3">
-          {t("prepare.step2")}
-        </p>
-        <div className="flex flex-wrap items-center gap-2">
-          <code className="rounded-md border border-border bg-card px-2 py-1 font-mono text-xs text-text">
-            {COMPILE_COMMAND}
-          </code>
-          <CopyButton text={COMPILE_COMMAND} label={t("copyCommand")} />
-        </div>
-        <p className="text-xs text-text-3">
-          {t("prepare.step2Hint", { path: LOCK_PATH })}
-        </p>
-      </div>
-
-      <div className="space-y-2">
-        <p className="text-xs font-medium uppercase tracking-wide text-text-3">
-          {t("prepare.step3")}
-        </p>
-        <div className="flex flex-wrap items-center gap-2">
-          <span className="text-xs text-text-3">{t("prepare.branch")}</span>
-          <code className="rounded-md border border-border bg-card px-2 py-1 font-mono text-xs text-text">
-            {branch}
-          </code>
-          <CopyButton text={branch} label={t("copyBranch")} />
-        </div>
-        <div className="flex flex-wrap gap-2">
-          <CopyButton text={title} label={t("copyTitle")} />
-          <CopyButton text={body} label={t("copyBody")} />
-          <a
-            href={contentCompareUrl(pin.sha, head.sha)}
-            target="_blank"
-            rel="noreferrer"
-            className={`${BUTTON_CLASSES} inline-flex items-center`}
+    <div className="border-t border-border pt-4">
+      <AdminDisclosure
+        headingLevel={4}
+        summary={
+          <span className="font-display text-sm font-bold text-text">
+            {t("prepare.title")}
+          </span>
+        }
+        contentClassName="mt-3 space-y-4"
+      >
+        {verdict.warnRedHead && (
+          <div
+            role="alert"
+            className="rounded-md border border-danger bg-danger-light p-3 text-sm text-danger"
           >
-            {t("viewCompare")}
-          </a>
-          <a
-            href={prUrl}
-            target="_blank"
-            rel="noreferrer"
-            className="inline-flex items-center rounded-md border border-primary bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground shadow-push-sm transition-all hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary active:translate-y-[1px]"
-          >
-            {t("preparePrLink")}
-          </a>
+            {t("prepare.redHeadWarning")}
+          </div>
+        )}
+
+        <div className="space-y-1">
+          <p className="text-xs font-medium uppercase tracking-wide text-text-3">
+            {t("prepare.step1")}
+          </p>
+          <pre className="overflow-x-auto rounded-md border border-border bg-card p-3 text-xs">
+            <code className="font-mono text-text">{diff}</code>
+          </pre>
         </div>
-      </div>
-    </section>
+
+        <div className="space-y-1">
+          <p className="text-xs font-medium uppercase tracking-wide text-text-3">
+            {t("prepare.step2")}
+          </p>
+          <div className="flex flex-wrap items-center gap-2">
+            <code className="rounded-md border border-border bg-card px-2 py-1 font-mono text-xs text-text">
+              {COMPILE_COMMAND}
+            </code>
+            <CopyButton text={COMPILE_COMMAND} label={t("copyCommand")} />
+          </div>
+          <p className="text-xs text-text-3">
+            {t("prepare.step2Hint", { path: LOCK_PATH })}
+          </p>
+        </div>
+
+        <div className="space-y-2">
+          <p className="text-xs font-medium uppercase tracking-wide text-text-3">
+            {t("prepare.step3")}
+          </p>
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="text-xs text-text-3">{t("prepare.branch")}</span>
+            <code className="rounded-md border border-border bg-card px-2 py-1 font-mono text-xs text-text">
+              {branch}
+            </code>
+            <CopyButton text={branch} label={t("copyBranch")} />
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <CopyButton text={title} label={t("copyTitle")} />
+            <CopyButton text={body} label={t("copyBody")} />
+            <a
+              href={contentCompareUrl(pin.sha, head.sha)}
+              target="_blank"
+              rel="noreferrer"
+              className={`${BUTTON_CLASSES} inline-flex items-center`}
+            >
+              {t("viewCompare")}
+            </a>
+            <a
+              href={prUrl}
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex items-center rounded-md border border-primary bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground shadow-push-sm transition-all hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary active:translate-y-[1px]"
+            >
+              {t("preparePrLink")}
+            </a>
+          </div>
+        </div>
+      </AdminDisclosure>
+    </div>
   );
 }

--- a/apps/web/src/components/admin/__tests__/admin-disclosure.test.tsx
+++ b/apps/web/src/components/admin/__tests__/admin-disclosure.test.tsx
@@ -1,0 +1,49 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { AdminDisclosure } from "../admin-disclosure";
+
+describe("AdminDisclosure", () => {
+  it("is collapsed by default: children unmounted, aria-expanded false", () => {
+    render(
+      <AdminDisclosure summary="More">
+        <p>revealed body</p>
+      </AdminDisclosure>
+    );
+    const trigger = screen.getByRole("button", { name: "More" });
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByText("revealed body")).not.toBeInTheDocument();
+  });
+
+  it("toggles aria-expanded and reveals/hides the children on click", () => {
+    render(
+      <AdminDisclosure summary="More">
+        <p>revealed body</p>
+      </AdminDisclosure>
+    );
+    const trigger = screen.getByRole("button", { name: "More" });
+
+    fireEvent.click(trigger);
+    expect(trigger).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByText("revealed body")).toBeInTheDocument();
+    // The trigger controls the revealed region.
+    expect(trigger).toHaveAttribute("aria-controls");
+
+    fireEvent.click(trigger);
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByText("revealed body")).not.toBeInTheDocument();
+  });
+
+  it("honours defaultOpen and wraps the trigger in the requested heading level", () => {
+    render(
+      <AdminDisclosure summary="Legend" defaultOpen headingLevel={3}>
+        <p>revealed body</p>
+      </AdminDisclosure>
+    );
+    const trigger = screen.getByRole("button", { name: "Legend" });
+    expect(trigger).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByText("revealed body")).toBeInTheDocument();
+    // ARIA accordion pattern: <h3><button>…</button></h3>.
+    expect(screen.getByRole("heading", { level: 3 })).toContainElement(trigger);
+  });
+});

--- a/apps/web/src/components/admin/__tests__/course-sync-table.test.tsx
+++ b/apps/web/src/components/admin/__tests__/course-sync-table.test.tsx
@@ -218,3 +218,65 @@ describe("CourseSyncTable — Task 5 polish", () => {
     );
   });
 });
+
+describe("CourseSyncTable — WS-A alignment + mismatch disclosure", () => {
+  const mismatchCourse: CourseStatus = {
+    ...syncedCourse,
+    contentId: "course-defi",
+    slug: "defi",
+    title: "DeFi",
+    onChainStatus: "out_of_sync",
+    differences: [
+      {
+        field: "creator",
+        contentValue: "CREATOR111",
+        onChainValue: "AUTH1111",
+        updateable: false,
+      },
+    ],
+    chainDrift: "content_stale",
+  };
+
+  it("gives every body cell align-top so a tall row keeps its siblings' eyeline", () => {
+    const { container } = renderWithIntl(
+      <CourseSyncTable courses={[syncedCourse]} onRefresh={vi.fn()} />
+    );
+    const cells = container.querySelectorAll("tbody td");
+    expect(cells.length).toBe(5);
+    cells.forEach((td) => expect(td.className).toContain("align-top"));
+  });
+
+  it("collapses the immutable mismatch to a one-line danger pill, hiding the recreate card by default", () => {
+    vi.stubGlobal("fetch", vi.fn());
+    renderWithIntl(
+      <CourseSyncTable courses={[mismatchCourse]} onRefresh={vi.fn()} />
+    );
+
+    const pill = screen.getByRole("button", {
+      name: "Immutable mismatch — 1 field",
+    });
+    expect(pill).toHaveAttribute("aria-expanded", "false");
+    // The full RecreateCourseFlow card (its review button) is not mounted yet.
+    expect(
+      screen.queryByRole("button", { name: /Recreate course…/ })
+    ).not.toBeInTheDocument();
+  });
+
+  it("expands the same recreate card behind the disclosure on click", () => {
+    vi.stubGlobal("fetch", vi.fn());
+    renderWithIntl(
+      <CourseSyncTable courses={[mismatchCourse]} onRefresh={vi.fn()} />
+    );
+
+    const pill = screen.getByRole("button", {
+      name: "Immutable mismatch — 1 field",
+    });
+    fireEvent.click(pill);
+
+    expect(pill).toHaveAttribute("aria-expanded", "true");
+    // The unchanged RecreateCourseFlow at-a-glance card is now revealed.
+    expect(
+      screen.getByRole("button", { name: /Recreate course…/ })
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/admin/__tests__/recreate-course-flow.test.tsx
+++ b/apps/web/src/components/admin/__tests__/recreate-course-flow.test.tsx
@@ -358,3 +358,22 @@ describe("RecreateCourseFlow — FIX B: swallowed preflight load error now rende
     expect(screen.queryByRole("dialog")).toBeNull();
   });
 });
+
+describe("RecreateConfirmModal — WS-D copy: on-chain counters vs untouched DB", () => {
+  const modal = messages.admin.deployScreen.recreate.modal;
+
+  it("renders the approved, non-contradictory reset/preserve copy in the modal", async () => {
+    await openModal(false);
+
+    // The two adjacent lines no longer contradict: one scopes the reset to the
+    // on-chain counters, the other says the DB learner records are untouched.
+    expect(screen.getByText(modal.resetCounters)).toBeInTheDocument();
+    expect(screen.getByText(modal.preserveList)).toBeInTheDocument();
+
+    // The reset line is explicitly on-chain; the preserve line is explicitly DB.
+    expect(modal.resetCounters).toMatch(/on-chain counters/i);
+    expect(modal.preserveList).toMatch(/database/i);
+    // The retired copy — "all preserved" against a bare "counters reset" — is gone.
+    expect(screen.queryByText(/are all preserved/i)).toBeNull();
+  });
+});

--- a/apps/web/src/components/admin/admin-badge.tsx
+++ b/apps/web/src/components/admin/admin-badge.tsx
@@ -1,0 +1,59 @@
+import type { HTMLAttributes } from "react";
+import { cn } from "@/lib/utils";
+
+/**
+ * Semantic badge tones, on-token (`tailwind.config.ts`). Deliberately narrow so
+ * "which red?" has one answer per meaning:
+ *  - `danger`  — blocking / destructive (immutable mismatch, CI failing)
+ *  - `warning` — transient / attention (content drift, CI pending, fetch retry)
+ *  - `success` — healthy / passing
+ *  - `info`    — informational (undecodable, in-progress checks)
+ *  - `accent`  — a distinct non-red drift call-out (out-of-sync)
+ *  - `neutral` — inert (draft, unknown)
+ */
+const BADGE_TONES = {
+  success: "border-success bg-success-light text-success",
+  danger: "border-danger bg-danger-light text-danger",
+  warning: "border-streak bg-streak-light text-streak",
+  info: "border-primary bg-primary-bg text-primary-dark dark:text-primary",
+  accent: "border-accent bg-accent-bg text-accent-dark dark:text-accent",
+  neutral: "border-border bg-subtle text-text-3",
+} as const;
+
+export type AdminBadgeTone = keyof typeof BADGE_TONES;
+
+interface AdminBadgeProps extends HTMLAttributes<HTMLSpanElement> {
+  /** Semantic color. Omit and pass `className` when a bespoke palette is needed. */
+  tone?: AdminBadgeTone;
+  /** `square` (default) for status chips, `pill` for CI-state chips. */
+  shape?: "square" | "pill";
+}
+
+/**
+ * The shared badge chrome — `inline-flex items-center border px-2 py-0.5 text-xs
+ * font-medium` — plus an optional semantic `tone`. Consumers with a one-off
+ * palette (the multi-state on-chain `StatusBadge`) pass `className`; consumers
+ * with a semantic meaning pass `tone`. WS-C/WS-B reuse this for their read-only
+ * state chips.
+ */
+export function AdminBadge({
+  tone,
+  shape = "square",
+  className,
+  children,
+  ...rest
+}: AdminBadgeProps) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center border px-2 py-0.5 text-xs font-medium",
+        shape === "pill" ? "rounded-full" : "rounded",
+        tone && BADGE_TONES[tone],
+        className
+      )}
+      {...rest}
+    >
+      {children}
+    </span>
+  );
+}

--- a/apps/web/src/components/admin/admin-button.tsx
+++ b/apps/web/src/components/admin/admin-button.tsx
@@ -1,0 +1,46 @@
+import { forwardRef, type ButtonHTMLAttributes } from "react";
+import { cn } from "@/lib/utils";
+
+export type AdminButtonVariant = "primary" | "neutral" | "danger" | "success";
+
+interface AdminButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: AdminButtonVariant;
+}
+
+/**
+ * One admin button, one size. Every variant keeps the platform's tactile
+ * `shadow-push` press convention (`active:translate-y` + `active:shadow-push-active`)
+ * and a focus-visible ring. Action columns pair exactly two: a `primary` and a
+ * `neutral` outline — no mixed paddings.
+ */
+const BASE =
+  "inline-flex items-center justify-center rounded-md px-3 py-1 font-display text-xs font-bold transition-all duration-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 disabled:pointer-events-none disabled:opacity-50";
+
+const VARIANTS: Record<AdminButtonVariant, string> = {
+  primary:
+    "bg-primary text-white shadow-push hover:bg-primary-hover focus-visible:outline-primary active:translate-y-[3px] active:shadow-push-active",
+  neutral:
+    "border border-border bg-card text-text-2 shadow-push-sm hover:bg-subtle focus-visible:outline-primary active:translate-y-[2px] active:shadow-push-active",
+  danger:
+    "bg-danger text-white shadow-push hover:opacity-90 focus-visible:outline-danger active:translate-y-[3px] active:shadow-push-active",
+  success:
+    "border border-success bg-card text-success shadow-push-sm hover:bg-success-light focus-visible:outline-success active:translate-y-[2px] active:shadow-push-active",
+};
+
+export const AdminButton = forwardRef<HTMLButtonElement, AdminButtonProps>(
+  function AdminButton(
+    { variant = "neutral", type = "button", className, children, ...rest },
+    ref
+  ) {
+    return (
+      <button
+        ref={ref}
+        type={type}
+        className={cn(BASE, VARIANTS[variant], className)}
+        {...rest}
+      >
+        {children}
+      </button>
+    );
+  }
+);

--- a/apps/web/src/components/admin/admin-card.tsx
+++ b/apps/web/src/components/admin/admin-card.tsx
@@ -1,0 +1,36 @@
+import type { HTMLAttributes } from "react";
+import { cn } from "@/lib/utils";
+
+interface AdminCardProps extends HTMLAttributes<HTMLElement> {
+  /** Render as a landmark `section` (with an `aria-labelledby`) or a plain `div`. */
+  as?: "div" | "section";
+}
+
+/**
+ * The one admin surface chrome — `rounded-lg border border-border bg-card p-4
+ * shadow-card`. Extracted so every top-level admin card (WS-A/B/C) reads from a
+ * single source of truth instead of re-typing the class string, and so the
+ * "flatten nested cards to dividers" rule has one place to enforce: a full
+ * bordered card is an `AdminCard`; anything nested inside one should be a
+ * divider, not another `AdminCard`.
+ *
+ * Layout classes (spacing, grid, width) merge over the chrome via `className`.
+ */
+export function AdminCard({
+  as: Tag = "div",
+  className,
+  children,
+  ...rest
+}: AdminCardProps) {
+  return (
+    <Tag
+      className={cn(
+        "rounded-lg border border-border bg-card p-4 shadow-card",
+        className
+      )}
+      {...rest}
+    >
+      {children}
+    </Tag>
+  );
+}

--- a/apps/web/src/components/admin/admin-disclosure.tsx
+++ b/apps/web/src/components/admin/admin-disclosure.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { useId, useState, type ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+interface AdminDisclosureProps {
+  /**
+   * The always-visible trigger content (a heading, a label, or a self-contained
+   * pill). Rendered inside the toggle button, so it must be phrasing content —
+   * no nested interactive or block elements.
+   */
+  summary: ReactNode;
+  /** Revealed content — only mounted while open. */
+  children: ReactNode;
+  /** Collapsed by default; opt into open with `defaultOpen`. */
+  defaultOpen?: boolean;
+  /** Extra classes on the trigger button (e.g. a danger-pill treatment). */
+  triggerClassName?: string;
+  /** Extra classes on the revealed region wrapper. */
+  contentClassName?: string;
+  /** Hide the leading chevron when the summary carries its own affordance. */
+  hideChevron?: boolean;
+  /**
+   * Wrap the trigger in a heading tag so the document outline is preserved
+   * (the ARIA accordion pattern: `<h3><button aria-expanded>…</button></h3>`).
+   */
+  headingLevel?: 2 | 3 | 4 | 5 | 6;
+}
+
+/**
+ * Controlled disclosure with a real `aria-expanded` + `aria-controls` toggle.
+ * Keyboard-operable (it is a `<button>`) and collapsed by default. The shared
+ * admin primitive for "tuck this behind a click": the legend, the publish-PR
+ * fallback, and the immutable-mismatch card all reveal through this.
+ */
+export function AdminDisclosure({
+  summary,
+  children,
+  defaultOpen = false,
+  triggerClassName,
+  contentClassName,
+  hideChevron = false,
+  headingLevel,
+}: AdminDisclosureProps) {
+  const [open, setOpen] = useState(defaultOpen);
+  const regionId = useId();
+
+  const trigger = (
+    <button
+      type="button"
+      aria-expanded={open}
+      aria-controls={regionId}
+      onClick={() => setOpen((v) => !v)}
+      className={cn(
+        "flex items-center gap-2 rounded-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary",
+        triggerClassName
+      )}
+    >
+      {!hideChevron && (
+        <span aria-hidden className="text-xs text-text-3">
+          {open ? "▼" : "▶"}
+        </span>
+      )}
+      {summary}
+    </button>
+  );
+
+  const Heading = headingLevel
+    ? (`h${headingLevel}` as "h2" | "h3" | "h4" | "h5" | "h6")
+    : null;
+
+  return (
+    <div>
+      {Heading ? <Heading className="m-0">{trigger}</Heading> : trigger}
+      {open && (
+        <div id={regionId} className={contentClassName}>
+          {children}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/admin/admin-table-shell.tsx
+++ b/apps/web/src/components/admin/admin-table-shell.tsx
@@ -1,0 +1,70 @@
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+export interface AdminTableColumn {
+  /** Stable React key + column identity. */
+  key: string;
+  /** Header content (already localized by the caller). */
+  label: ReactNode;
+  align?: "left" | "center" | "right";
+  /** Extra `<th>` classes — column width, right-padding, etc. */
+  headClassName?: string;
+  /** Visually hide the header label (still read by assistive tech). */
+  srOnly?: boolean;
+}
+
+interface AdminTableShellProps {
+  columns: AdminTableColumn[];
+  /** `<tr>` rows. Give every `<td>` `align-top` so a tall row never drags its
+   *  siblings' cells to vertical-center. */
+  children: ReactNode;
+  className?: string;
+}
+
+const ALIGN: Record<NonNullable<AdminTableColumn["align"]>, string> = {
+  left: "text-left",
+  center: "text-center",
+  right: "text-right",
+};
+
+/**
+ * Shared admin table chrome: a horizontally-scrollable wrapper (wide rows scroll
+ * inside their own box instead of pushing the page), the uppercase header row,
+ * and a `divide-y` body. Rows are the caller's responsibility — the shell only
+ * owns the frame so WS-A's courses table and WS-C's read-only tables render as
+ * one system.
+ */
+export function AdminTableShell({
+  columns,
+  children,
+  className,
+}: AdminTableShellProps) {
+  return (
+    <div className="overflow-x-auto">
+      <table className={cn("w-full text-sm", className)}>
+        <thead>
+          <tr className="border-b border-border text-left text-xs uppercase tracking-wider text-text-3">
+            {columns.map((col) => (
+              <th
+                key={col.key}
+                scope="col"
+                className={cn(
+                  "pb-2 align-bottom font-medium",
+                  ALIGN[col.align ?? "left"],
+                  col.headClassName
+                )}
+              >
+                {col.srOnly ? (
+                  <span className="sr-only">{col.label}</span>
+                ) : (
+                  col.label
+                )}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-border">{children}</tbody>
+      </table>
+    </div>
+  );
+}

--- a/apps/web/src/components/admin/course-sync-table.tsx
+++ b/apps/web/src/components/admin/course-sync-table.tsx
@@ -6,6 +6,10 @@ import { StatusBadge, ContentDriftBadge } from "./status-badge";
 import { SyncDiffView } from "./sync-diff-view";
 import { RecreateCourseFlow } from "./recreate-course-flow";
 import { DeployChangePreview } from "./deploy-change-preview";
+import { AdminTableShell } from "./admin-table-shell";
+import { AdminButton } from "./admin-button";
+import { AdminBadge } from "./admin-badge";
+import { AdminDisclosure } from "./admin-disclosure";
 import type { CourseStatus } from "@/app/[locale]/admin/admin-status-types";
 
 interface CourseSyncTableProps {
@@ -155,137 +159,178 @@ export function CourseSyncTable({ courses, onRefresh }: CourseSyncTableProps) {
 
   return (
     <div>
+      {/* Transient action errors get the neutral `streak` treatment, not
+          `danger` — `danger` is reserved for the blocking immutable mismatch and
+          the destructive recreate. */}
       {error && (
-        <div className="mb-3 rounded-md border border-danger bg-danger-light p-3 text-sm text-danger">
+        <div
+          role="alert"
+          className="mb-3 rounded-md border border-streak bg-streak-light p-3 text-sm text-streak"
+        >
           {error}
         </div>
       )}
       {syncableCount > 0 && (
         <div className="mb-3 flex justify-end">
-          <button
+          <AdminButton
+            variant="neutral"
             onClick={() => void handleSyncAll()}
             disabled={syncingAll}
-            className="rounded-md border border-border bg-card px-4 py-1.5 text-xs font-medium text-text shadow-push-sm transition-all hover:bg-subtle active:translate-y-[2px] active:shadow-push-active disabled:pointer-events-none disabled:opacity-50"
           >
-            {syncingAll ? "Syncing..." : `Sync All (${syncableCount})`}
-          </button>
+            {syncingAll
+              ? t("actions.syncAllBusy")
+              : t("actions.syncAll", { count: syncableCount })}
+          </AdminButton>
         </div>
       )}
-      <table className="w-full text-sm">
-        <thead>
-          <tr className="border-b border-border text-left text-xs uppercase tracking-wider text-text-3">
-            <th className="pb-2 pr-4 font-medium">Course</th>
-            <th className="pb-2 pr-4 text-center font-medium">Lessons</th>
-            <th className="pb-2 pr-4 text-center font-medium">XP/Lesson</th>
-            <th className="pb-2 pr-4 font-medium">Status</th>
-            <th className="pb-2 font-medium">Action</th>
-          </tr>
-        </thead>
-        <tbody className="divide-y divide-border">
-          {courses.map((course) => {
-            const isSyncing = syncing === course.contentId;
-            const immutableDiffs = course.differences.filter(
-              (d) => !d.updateable
-            );
-            const hasImmutableMismatch = immutableDiffs.length > 0;
-            const canSync =
-              !course.isDraft &&
-              course.missingFields.length === 0 &&
-              !hasImmutableMismatch;
-            const actionLabel =
-              course.onChainStatus === "not_deployed" ? "Deploy" : "Sync";
+      <AdminTableShell
+        columns={[
+          { key: "course", label: t("table.course"), headClassName: "pr-4" },
+          {
+            key: "lessons",
+            label: t("table.lessons"),
+            align: "center",
+            headClassName: "pr-4",
+          },
+          {
+            key: "xpPerLesson",
+            label: t("table.xpPerLesson"),
+            align: "center",
+            headClassName: "pr-4",
+          },
+          { key: "status", label: t("table.status"), headClassName: "pr-4" },
+          {
+            key: "action",
+            label: t("table.action"),
+            align: "right",
+            headClassName: "w-44",
+          },
+        ]}
+      >
+        {courses.map((course) => {
+          const isSyncing = syncing === course.contentId;
+          const immutableDiffs = course.differences.filter(
+            (d) => !d.updateable
+          );
+          const hasImmutableMismatch = immutableDiffs.length > 0;
+          const canSync =
+            !course.isDraft &&
+            course.missingFields.length === 0 &&
+            !hasImmutableMismatch;
+          const actionLabel =
+            course.onChainStatus === "not_deployed"
+              ? t("actions.deploy")
+              : t("actions.sync");
 
-            return (
-              <tr
-                key={course.contentId}
-                className="transition-colors hover:bg-subtle"
-              >
-                <td className="py-3 pr-4">
-                  <div className="font-medium text-text">{course.title}</div>
-                  <div className="mt-0.5 font-mono text-xs text-text-3">
-                    {course.slug}
+          return (
+            <tr
+              key={course.contentId}
+              className="transition-colors hover:bg-subtle"
+            >
+              {/* align-top keeps every cell's eyeline steady when a tall
+                  mismatch/diff row expands the Course cell. */}
+              <td className="py-3 pr-4 align-top">
+                <div className="font-medium text-text">{course.title}</div>
+                <div className="mt-0.5 font-mono text-xs text-text-3">
+                  {course.slug}
+                </div>
+                {course.missingFields.length > 0 && (
+                  <div className="mt-1 text-xs text-streak">
+                    {t("missingFields", {
+                      fields: course.missingFields.join(", "),
+                    })}
                   </div>
-                  {course.missingFields.length > 0 && (
-                    <div className="mt-1 text-xs text-streak">
-                      {t("missingFields", {
-                        fields: course.missingFields.join(", "),
-                      })}
-                    </div>
-                  )}
-                  {course.differences.length > 0 && (
-                    <SyncDiffView
-                      differences={course.differences}
-                      title={course.title}
-                    />
-                  )}
-                  {hasImmutableMismatch && (
+                )}
+                {course.differences.length > 0 && (
+                  <SyncDiffView
+                    differences={course.differences}
+                    title={course.title}
+                  />
+                )}
+                {hasImmutableMismatch && (
+                  // Collapse the row-exploding recreate card to a one-line danger
+                  // pill; the disclosure reveals the SAME `RecreateCourseFlow`
+                  // card unchanged (its preflight/execute/refusal logic is
+                  // frozen — this is pure presentation).
+                  <AdminDisclosure
+                    triggerClassName="mt-2 rounded-full border border-danger bg-danger-light px-2.5 py-1 text-xs font-semibold text-danger"
+                    summary={t("recreate.summaryPill", {
+                      count: immutableDiffs.length,
+                    })}
+                  >
                     <RecreateCourseFlow
                       courseId={course.contentId}
                       courseTitle={course.title}
                       immutableDiffs={immutableDiffs}
                       onRecreated={onRefresh}
                     />
-                  )}
-                </td>
-                <td className="py-3 pr-4 text-center text-text">
-                  {course.lessonCount === 0 ? (
-                    <span className="text-streak">—</span>
-                  ) : (
-                    course.lessonCount
-                  )}
-                </td>
-                <td className="py-3 pr-4 text-center text-text">
-                  {course.contentXpPerLesson ?? "—"}
-                </td>
-                <td className="py-3 pr-4">
-                  <div className="flex flex-wrap items-center gap-1.5">
-                    <StatusBadge status={course.onChainStatus} />
-                    <ContentDriftBadge
-                      onChainStatus={course.onChainStatus}
-                      contentDrift={course.contentDrift}
-                    />
-                    {course.onChainStatus === "synced" &&
-                      course.isActive === false && (
-                        <span className="inline-flex items-center rounded border border-danger bg-danger-light px-2 py-0.5 text-xs font-medium text-danger">
-                          Deactivated
-                        </span>
-                      )}
-                  </div>
-                </td>
-                <td className="py-3">
+                  </AdminDisclosure>
+                )}
+              </td>
+              <td className="py-3 pr-4 text-center align-top text-text">
+                {course.lessonCount === 0 ? (
+                  <span className="text-streak">—</span>
+                ) : (
+                  course.lessonCount
+                )}
+              </td>
+              <td className="py-3 pr-4 text-center align-top text-text">
+                {course.contentXpPerLesson ?? "—"}
+              </td>
+              <td className="py-3 pr-4 align-top">
+                {/* min-w reserves the badge column so wrapping there never
+                    ripples the Course/Action columns' widths. */}
+                <div className="flex min-w-[7.5rem] flex-wrap items-center gap-1.5">
+                  <StatusBadge status={course.onChainStatus} />
+                  <ContentDriftBadge
+                    onChainStatus={course.onChainStatus}
+                    contentDrift={course.contentDrift}
+                  />
+                  {course.onChainStatus === "synced" &&
+                    course.isActive === false && (
+                      <AdminBadge tone="danger">{t("deactivated")}</AdminBadge>
+                    )}
+                </div>
+              </td>
+              <td className="py-3 text-right align-top">
+                <div className="flex justify-end gap-2">
                   {canSync && (
-                    <button
+                    <AdminButton
+                      variant="primary"
                       onClick={() => setPreviewCourse(course)}
                       disabled={isSyncing}
-                      className="rounded-md bg-primary px-3 py-1 font-display text-xs font-bold text-white shadow-push transition-all duration-100 hover:bg-primary-hover active:translate-y-[3px] active:shadow-push-active disabled:cursor-not-allowed disabled:opacity-50"
                     >
-                      {isSyncing ? "..." : actionLabel}
-                    </button>
+                      {isSyncing ? t("actions.working") : actionLabel}
+                    </AdminButton>
                   )}
                   {course.onChainStatus === "synced" &&
                     (course.isActive === false ? (
-                      <button
+                      <AdminButton
+                        variant="neutral"
                         onClick={() => void handleReactivate(course.contentId)}
                         disabled={isSyncing}
-                        className="ml-2 rounded-md border border-success px-3 py-1 font-display text-xs font-bold text-success shadow-push-sm transition-all hover:bg-success-light active:translate-y-[2px] active:shadow-push-active disabled:opacity-50"
                       >
-                        {isSyncing ? "..." : "Reactivate"}
-                      </button>
+                        {isSyncing
+                          ? t("actions.working")
+                          : t("actions.reactivate")}
+                      </AdminButton>
                     ) : (
-                      <button
+                      <AdminButton
+                        variant="neutral"
                         onClick={() => void handleDeactivate(course.contentId)}
                         disabled={isSyncing}
-                        className="ml-2 rounded-md border border-border px-3 py-1 font-display text-xs font-bold text-text-2 shadow-push-sm transition-all hover:border-danger hover:bg-danger-light hover:text-danger active:translate-y-[2px] active:shadow-push-active disabled:opacity-50"
                       >
-                        {isSyncing ? "..." : "Deactivate"}
-                      </button>
+                        {isSyncing
+                          ? t("actions.working")
+                          : t("actions.deactivate")}
+                      </AdminButton>
                     ))}
-                </td>
-              </tr>
-            );
-          })}
-        </tbody>
-      </table>
+                </div>
+              </td>
+            </tr>
+          );
+        })}
+      </AdminTableShell>
       {previewCourse && (
         <DeployChangePreview
           course={previewCourse}

--- a/apps/web/src/components/admin/status-badge.tsx
+++ b/apps/web/src/components/admin/status-badge.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useTranslations } from "next-intl";
+import { AdminBadge, type AdminBadgeTone } from "./admin-badge";
 import type { CourseContentDrift } from "@/lib/github/drift";
 
 type SyncStatus =
@@ -22,6 +23,9 @@ interface StatusBadgeProps {
 
 export function StatusBadge({ status }: StatusBadgeProps) {
   const t = useTranslations("admin.statusBadge");
+  // The on-chain badge carries a bespoke seven-state palette (two of them —
+  // `synced`, `db_unavailable` — sit outside the shared semantic tones), so it
+  // borrows only `AdminBadge`'s chrome and supplies its own colors.
   const className: Record<SyncStatus, string> = {
     synced: "bg-success-bg border-success text-success",
     out_of_sync: "bg-accent-bg border-accent text-accent-dark dark:text-accent",
@@ -32,13 +36,7 @@ export function StatusBadge({ status }: StatusBadgeProps) {
     db_unavailable: "bg-subtle border-solana-purple text-solana-purple",
   };
 
-  return (
-    <span
-      className={`inline-flex items-center rounded border px-2 py-0.5 text-xs font-medium ${className[status]}`}
-    >
-      {t(status)}
-    </span>
-  );
+  return <AdminBadge className={className[status]}>{t(status)}</AdminBadge>;
 }
 
 /**
@@ -82,18 +80,18 @@ export function ContentDriftBadge({
   const state = contentDriftBadgeState(onChainStatus, contentDrift);
   if (state === "none") return null;
 
-  const className: Record<Exclude<typeof state, "none">, string> = {
-    drifted: "bg-streak-light border-streak text-streak",
-    blocked: "bg-danger-light border-danger text-danger",
-    unknown: "bg-subtle border-border text-text-3",
+  // Content drift maps cleanly onto the shared semantic tones: a red-CI upstream
+  // commit is `danger` (blocking), a behind pin is `warning` (attention), an
+  // unreachable GitHub is `neutral`.
+  const tone: Record<Exclude<typeof state, "none">, AdminBadgeTone> = {
+    drifted: "warning",
+    blocked: "danger",
+    unknown: "neutral",
   };
 
   return (
-    <span
-      title={t(`${state}Hint`)}
-      className={`inline-flex items-center rounded border px-2 py-0.5 text-xs font-medium ${className[state]}`}
-    >
+    <AdminBadge tone={tone[state]} title={t(`${state}Hint`)}>
       {t(state)}
-    </span>
+    </AdminBadge>
   );
 }

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -938,6 +938,23 @@
       "noCourses": "No courses in the content bundle.",
       "noAchievements": "No achievements in the content bundle.",
       "missingFields": "Missing: {fields}",
+      "table": {
+        "course": "Course",
+        "lessons": "Lessons",
+        "xpPerLesson": "XP/Lesson",
+        "status": "Status",
+        "action": "Action"
+      },
+      "actions": {
+        "deploy": "Deploy",
+        "sync": "Sync",
+        "reactivate": "Reactivate",
+        "deactivate": "Deactivate",
+        "working": "…",
+        "syncAll": "Sync All ({count})",
+        "syncAllBusy": "Syncing…"
+      },
+      "deactivated": "Deactivated",
       "syncAllConfirm": "{count, plural, one {Sync # course} other {Sync # courses}} — {changes, plural, one {# field change} other {# field changes}}. Continue?",
       "deactivateConfirm": "Deactivate this course? Students cannot enroll until reactivated.",
       "errors": {
@@ -977,6 +994,7 @@
         "remediation": "\"{title}\" has immutable on-chain fields that differ from the content bundle; update_course cannot apply them. Options: 1. Fix the value in the courses-academy repo and publish a new bundle PR, or 2. Deactivate this course and deploy a new version."
       },
       "recreate": {
+        "summaryPill": "Immutable mismatch — {count, plural, one {# field} other {# fields}}",
         "cardHeading": "Immutable mismatch — recreate required",
         "cardIntro": "These fields are set once at deploy and update_course cannot change them. The only fix is to close and recreate the on-chain course.",
         "creatorEmphasis": "Creator mismatch: Course.creator is the immutable XP-reward recipient. Until the course is recreated, every creator reward pays the wrong wallet.",
@@ -987,7 +1005,7 @@
         "refusedHeading": "Recreate unavailable",
         "loadErrorHeading": "Could not check the recreate preflight",
         "refusalReason": {
-          "noImmutableDiff": "No immutable field differs between the content bundle and the on-chain account — a recreate would fix nothing and would irreversibly reset completion/enrollment counters and cause downtime.",
+          "noImmutableDiff": "No immutable field differs between the content bundle and the on-chain account — a recreate would fix nothing and would irreversibly reset the on-chain completion/enrollment counters and cause downtime.",
           "unconfirmed": "Could not read the on-chain account to confirm an immutable mismatch — refresh the status screen and retry; refusing to recreate on unconfirmed state."
         },
         "modal": {
@@ -997,9 +1015,9 @@
           "immutableHeading": "Immutable fields this recreate will set",
           "lessonCountLabel": "On-chain lesson count is preserved exactly ({count}). New lessons are added afterwards via the ordinary sync.",
           "resetHeading": "What resets",
-          "resetCounters": "Completion and enrollment counters reset to 0 (completions {completions}, enrollments {enrollments}). This is unrecoverable.",
+          "resetCounters": "On-chain counters (total completions/enrollments shown on the course) reset to 0 — unrecoverable.",
           "preserveHeading": "What is preserved",
-          "preserveList": "Enrollments, learner progress, and earned certificates are all preserved.",
+          "preserveList": "Learner records in the database — enrollments, lesson progress, certificates — are untouched.",
           "downtimeWarning": "Brief downtime: close and create are NOT atomic — there is a seconds-long window where the course PDA is absent and enroll/complete will fail.",
           "unusualHeading": "Unusual creator",
           "unusualDescription": "The resolved creator is on the denylist or equals the platform authority — normally refused by the #427 guard.",
@@ -1016,7 +1034,7 @@
           "closeSignature": "Close signature",
           "createSignature": "Create signature",
           "attempts": "Create attempts",
-          "lostCounters": "Counters reset — completions {completions}, enrollments {enrollments}.",
+          "lostCounters": "On-chain counters reset — completions {completions}, enrollments {enrollments}.",
           "warningsHeading": "Warnings",
           "refresh": "Refresh"
         },

--- a/apps/web/src/messages/es.json
+++ b/apps/web/src/messages/es.json
@@ -938,6 +938,23 @@
       "noCourses": "No hay cursos en el paquete de contenido.",
       "noAchievements": "No hay logros en el paquete de contenido.",
       "missingFields": "Faltan: {fields}",
+      "table": {
+        "course": "Curso",
+        "lessons": "Lecciones",
+        "xpPerLesson": "XP/Lección",
+        "status": "Estado",
+        "action": "Acción"
+      },
+      "actions": {
+        "deploy": "Desplegar",
+        "sync": "Sincronizar",
+        "reactivate": "Reactivar",
+        "deactivate": "Desactivar",
+        "working": "…",
+        "syncAll": "Sincronizar todo ({count})",
+        "syncAllBusy": "Sincronizando…"
+      },
+      "deactivated": "Desactivado",
       "syncAllConfirm": "{count, plural, one {Sincronizar # curso} other {Sincronizar # cursos}} — {changes, plural, one {# cambio de campo} other {# cambios de campo}}. ¿Continuar?",
       "deactivateConfirm": "¿Desactivar este curso? Los estudiantes no podrán inscribirse hasta que se reactive.",
       "errors": {
@@ -977,6 +994,7 @@
         "remediation": "\"{title}\" tiene campos on-chain inmutables que difieren del paquete de contenido; update_course no puede aplicarlos. Opciones: 1. Corrige el valor en el repositorio courses-academy y publica un nuevo PR de paquete, o 2. Desactiva este curso y despliega una nueva versión."
       },
       "recreate": {
+        "summaryPill": "Discrepancia inmutable — {count, plural, one {# campo} other {# campos}}",
         "cardHeading": "Discrepancia inmutable — se requiere recrear",
         "cardIntro": "Estos campos se fijan una sola vez al desplegar y update_course no puede cambiarlos. La única solución es cerrar y recrear el curso on-chain.",
         "creatorEmphasis": "Discrepancia de creador: Course.creator es el destinatario inmutable de la recompensa de XP. Hasta que se recree el curso, cada recompensa de creador se paga a la wallet equivocada.",
@@ -987,7 +1005,7 @@
         "refusedHeading": "Recrear no disponible",
         "loadErrorHeading": "No se pudo comprobar la verificación previa de recreación",
         "refusalReason": {
-          "noImmutableDiff": "Ningún campo inmutable difiere entre el paquete de contenido y la cuenta on-chain — recrear no arreglaría nada y reiniciaría de forma irreversible los contadores de finalización/inscripción y causaría tiempo de inactividad.",
+          "noImmutableDiff": "Ningún campo inmutable difiere entre el paquete de contenido y la cuenta on-chain — recrear no arreglaría nada y reiniciaría de forma irreversible los contadores on-chain de finalización/inscripción y causaría tiempo de inactividad.",
           "unconfirmed": "No se pudo leer la cuenta on-chain para confirmar una discrepancia inmutable — actualiza la pantalla de estado y reinténtalo; se rechaza recrear sobre un estado no confirmado."
         },
         "modal": {
@@ -997,9 +1015,9 @@
           "immutableHeading": "Campos inmutables que esta recreación establecerá",
           "lessonCountLabel": "El número de lecciones on-chain se conserva exactamente ({count}). Las nuevas lecciones se añaden después mediante la sincronización habitual.",
           "resetHeading": "Qué se reinicia",
-          "resetCounters": "Los contadores de finalizaciones e inscripciones se reinician a 0 (finalizaciones {completions}, inscripciones {enrollments}). Esto es irrecuperable.",
+          "resetCounters": "Los contadores on-chain (finalizaciones/inscripciones totales que se muestran en el curso) se reinician a 0 — irrecuperable.",
           "preserveHeading": "Qué se conserva",
-          "preserveList": "Las inscripciones, el progreso de los estudiantes y los certificados obtenidos se conservan todos.",
+          "preserveList": "Los registros de los estudiantes en la base de datos — inscripciones, progreso de las lecciones, certificados — permanecen intactos.",
           "downtimeWarning": "Breve interrupción: cerrar y crear NO son atómicos — hay una ventana de varios segundos en la que el PDA del curso no existe y enroll/complete fallarán.",
           "unusualHeading": "Creador inusual",
           "unusualDescription": "El creador resuelto está en la lista de bloqueo o es igual a la autoridad de la plataforma — normalmente rechazado por la protección #427.",
@@ -1016,7 +1034,7 @@
           "closeSignature": "Firma de cierre",
           "createSignature": "Firma de creación",
           "attempts": "Intentos de creación",
-          "lostCounters": "Contadores reiniciados — finalizaciones {completions}, inscripciones {enrollments}.",
+          "lostCounters": "Contadores on-chain reiniciados — finalizaciones {completions}, inscripciones {enrollments}.",
           "warningsHeading": "Advertencias",
           "refresh": "Actualizar"
         },

--- a/apps/web/src/messages/pt-BR.json
+++ b/apps/web/src/messages/pt-BR.json
@@ -938,6 +938,23 @@
       "noCourses": "Nenhum curso no pacote de conteúdo.",
       "noAchievements": "Nenhuma conquista no pacote de conteúdo.",
       "missingFields": "Faltando: {fields}",
+      "table": {
+        "course": "Curso",
+        "lessons": "Lições",
+        "xpPerLesson": "XP/Lição",
+        "status": "Status",
+        "action": "Ação"
+      },
+      "actions": {
+        "deploy": "Implantar",
+        "sync": "Sincronizar",
+        "reactivate": "Reativar",
+        "deactivate": "Desativar",
+        "working": "…",
+        "syncAll": "Sincronizar tudo ({count})",
+        "syncAllBusy": "Sincronizando…"
+      },
+      "deactivated": "Desativado",
       "syncAllConfirm": "{count, plural, one {Sincronizar # curso} other {Sincronizar # cursos}} — {changes, plural, one {# mudança de campo} other {# mudanças de campo}}. Continuar?",
       "deactivateConfirm": "Desativar este curso? Os alunos não poderão se matricular até ele ser reativado.",
       "errors": {
@@ -977,6 +994,7 @@
         "remediation": "\"{title}\" tem campos on-chain imutáveis que diferem do pacote de conteúdo; update_course não pode aplicá-los. Opções: 1. Corrija o valor no repositório courses-academy e publique um novo PR de pacote, ou 2. Desative este curso e implante uma nova versão."
       },
       "recreate": {
+        "summaryPill": "Divergência imutável — {count, plural, one {# campo} other {# campos}}",
         "cardHeading": "Divergência imutável — recriação necessária",
         "cardIntro": "Estes campos são definidos uma única vez no deploy e update_course não pode alterá-los. A única correção é fechar e recriar o curso on-chain.",
         "creatorEmphasis": "Divergência de criador: Course.creator é o destinatário imutável da recompensa de XP. Até o curso ser recriado, cada recompensa de criador é paga à carteira errada.",
@@ -987,7 +1005,7 @@
         "refusedHeading": "Recriação indisponível",
         "loadErrorHeading": "Não foi possível verificar a pré-verificação de recriação",
         "refusalReason": {
-          "noImmutableDiff": "Nenhum campo imutável difere entre o pacote de conteúdo e a conta on-chain — recriar não corrigiria nada e zeraria de forma irreversível os contadores de conclusão/matrícula e causaria indisponibilidade.",
+          "noImmutableDiff": "Nenhum campo imutável difere entre o pacote de conteúdo e a conta on-chain — recriar não corrigiria nada e zeraria de forma irreversível os contadores on-chain de conclusão/inscrição e causaria indisponibilidade.",
           "unconfirmed": "Não foi possível ler a conta on-chain para confirmar uma divergência imutável — atualize a tela de status e tente novamente; recusando recriar sobre um estado não confirmado."
         },
         "modal": {
@@ -997,9 +1015,9 @@
           "immutableHeading": "Campos imutáveis que esta recriação irá definir",
           "lessonCountLabel": "A contagem de lições on-chain é preservada exatamente ({count}). Novas lições são adicionadas depois pela sincronização normal.",
           "resetHeading": "O que é zerado",
-          "resetCounters": "Os contadores de conclusões e inscrições são zerados (conclusões {completions}, inscrições {enrollments}). Isto é irrecuperável.",
+          "resetCounters": "Os contadores on-chain (total de conclusões/inscrições exibido no curso) são zerados — irrecuperável.",
           "preserveHeading": "O que é preservado",
-          "preserveList": "As inscrições, o progresso dos alunos e os certificados conquistados são todos preservados.",
+          "preserveList": "Os registros dos alunos no banco de dados — inscrições, progresso das lições, certificados — permanecem intactos.",
           "downtimeWarning": "Breve indisponibilidade: fechar e criar NÃO são atômicos — há uma janela de alguns segundos em que o PDA do curso não existe e enroll/complete irão falhar.",
           "unusualHeading": "Criador incomum",
           "unusualDescription": "O criador resolvido está na lista de bloqueio ou é igual à autoridade da plataforma — normalmente recusado pela proteção #427.",
@@ -1016,7 +1034,7 @@
           "closeSignature": "Assinatura de fechamento",
           "createSignature": "Assinatura de criação",
           "attempts": "Tentativas de criação",
-          "lostCounters": "Contadores zerados — conclusões {completions}, inscrições {enrollments}.",
+          "lostCounters": "Contadores on-chain zerados — conclusões {completions}, inscrições {enrollments}.",
           "warningsHeading": "Avisos",
           "refresh": "Atualizar"
         },


### PR DESCRIPTION
**SAFE-lane** — first lane of the admin-panel revamp (#512). Establishes the shared admin primitives WS-C and WS-B consume.

Closes #512
Closes #448

## What changed (WS-A items 1–6)
1. **Courses table alignment** — `align-top` on every body cell (a tall mismatch/diff row no longer drags its siblings' Status/Action cells to vertical-center); a `min-w` wrapper on Status stops badge-wrap ripple; Action is now a fixed-width, right-aligned `flex justify-end gap-2` column with one button size and one primary + one neutral-outline variant.
2. **Mismatch card collapse** — the row-exploding immutable-mismatch card is now a one-line danger pill (`Immutable mismatch — N field(s)`) behind a disclosure that reveals the **same** `RecreateCourseFlow` card, unchanged. Pure presentation: an external disclosure wrapper in `course-sync-table.tsx`.
3. **Legend** — `deploy-legend.tsx` is wrapped in a default-collapsed disclosure (`aria-expanded` toggle, heading-wrapped trigger).
4. **Publish-PR card** — the manual 3-step block in `publish-pin-client.tsx` is behind a default-collapsed disclosure (becomes WS-B's fallback later); its bordered sub-card flattened to a divider.
5. **Flatten + de-overload color** — nested bordered sub-cards reduced to dividers; full bordered cards only via the shared card chrome / modals. The "three reds" are split: `danger` reserved for blocking/destructive (immutable mismatch, destructive recreate), transient fetch/action errors moved to a neutral `streak` treatment.
6. **WS-D copy fix** — the two contradictory recreate-modal strings replaced with the approved copy (on-chain counters reset to 0 vs DB learner records untouched); `result.lostCounters` + `refusalReason.noImmutableDiff` aligned to the same on-chain-vs-DB framing. en / es / pt-BR, identical key sets.

Also folds in **#448**: remaining hardcoded English strings in the courses table (headers, action labels, Deactivated, Sync-All) externalized to i18n ×3.

## Extracted shared primitives (`components/admin/`, for WS-C/WS-B)
- **`AdminCard`** — the admin surface chrome (`rounded-lg border border-border bg-card p-4 shadow-card`); `as="section"` + className merge.
- **`AdminTableShell`** — scrollable table frame (header row + `divide-y` body) driven by a `columns` array.
- **`AdminBadge`** — badge chrome + semantic `tone` (danger/warning/success/info/accent/neutral) + `shape`. `StatusBadge`/`ContentDriftBadge`/`ChecksBadge` refactored onto it.
- **`AdminDisclosure`** — controlled `aria-expanded`/`aria-controls` disclosure, collapsed by default, optional heading wrapper (ARIA accordion pattern).
- **`AdminButton`** — one size, variants (primary/neutral/danger/success), each preserving the tactile `shadow-push` press convention + focus-visible ring.

## Freeze respected
Zero changes to `recreate-course-flow.tsx` preflight/execute/refusal logic, `recreate-course.ts`, or the recreate/preflight routes (verified byte-identical vs `origin/main`). Item 2 is a presentation-only disclosure wrapper; WS-D is copy-only.

## Verification
- `tsc --noEmit`: clean
- `next lint` (source): clean
- `vitest run`: **797 passed**. New/updated coverage: table `align-top`; mismatch disclosure (collapsed by default, expands to the recreate card); legend + publish-PR disclosures (default collapsed, `aria-expanded` toggles); `AdminDisclosure` primitive; WS-D copy (the two keys render the new non-contradictory text). Recreate POST never exercised (mocks only).