### PR TITLE
feat(admin): WS-C content tab — Quests/Achievements/Paths (#513)

### DIFF
--- a/apps/web/src/app/[locale]/admin/__tests__/admin-nav.test.tsx
+++ b/apps/web/src/app/[locale]/admin/__tests__/admin-nav.test.tsx
@@ -46,10 +46,10 @@ afterEach(() => {
 });
 
 describe("AdminNav", () => {
-  it("renders exactly the three section links pointing at locale-prefixed routes", () => {
+  it("renders exactly the four section links pointing at locale-prefixed routes", () => {
     renderWithIntl(<AdminNav />);
     const links = screen.getAllByRole("link");
-    expect(links).toHaveLength(3);
+    expect(links).toHaveLength(4);
 
     expect(screen.getByRole("link", { name: nav.courses })).toHaveAttribute(
       "href",
@@ -62,6 +62,10 @@ describe("AdminNav", () => {
     expect(screen.getByRole("link", { name: nav.status })).toHaveAttribute(
       "href",
       "/en/admin/status"
+    );
+    expect(screen.getByRole("link", { name: nav.content })).toHaveAttribute(
+      "href",
+      "/en/admin/content"
     );
   });
 
@@ -89,7 +93,7 @@ describe("AdminNav", () => {
       "aria-current",
       "page"
     );
-    for (const label of [nav.moderation, nav.status]) {
+    for (const label of [nav.moderation, nav.status, nav.content]) {
       expect(screen.getByRole("link", { name: label })).not.toHaveAttribute(
         "aria-current"
       );
@@ -137,8 +141,8 @@ describe("AdminNav", () => {
     renderWithIntl(<AdminNav />);
 
     await waitFor(() => expect(global.fetch).toHaveBeenCalled());
-    // Nav still renders its three links; the badge simply never shows.
-    expect(screen.getAllByRole("link")).toHaveLength(3);
+    // Nav still renders its four links; the badge simply never shows.
+    expect(screen.getAllByRole("link")).toHaveLength(4);
     expect(
       screen.getByRole("link", { name: nav.moderation })
     ).toBeInTheDocument();

--- a/apps/web/src/app/[locale]/admin/__tests__/deploy-client.test.tsx
+++ b/apps/web/src/app/[locale]/admin/__tests__/deploy-client.test.tsx
@@ -15,17 +15,16 @@ function renderWithIntl(ui: ReactElement) {
   );
 }
 
-// The sync tables carry their own tests and fire on-chain sync requests, so
-// they are stubbed; the stubs surface the props wiring under test.
+// The sync table carries its own tests and fires on-chain sync requests, so
+// it is stubbed; the stub surfaces the props wiring under test. The
+// Achievements sync table used to render as a second section here (#513
+// WS-C relocated it into `admin/content/achievements-subview.tsx`).
 vi.mock("@/components/admin/course-sync-table", () => ({
   CourseSyncTable: ({ onRefresh }: { onRefresh: () => void }) => (
     <button data-testid="course-sync-table" onClick={onRefresh}>
       course-table
     </button>
   ),
-}));
-vi.mock("@/components/admin/achievement-sync-table", () => ({
-  AchievementSyncTable: () => <div data-testid="achievement-sync-table" />,
 }));
 
 const status: AdminStatus = {
@@ -52,6 +51,8 @@ const status: AdminStatus = {
       chainDrift: "content_current",
     },
   ],
+  // DeployClient no longer renders achievements (#513 WS-C moved that table to
+  // the Content tab) — this array only needs to satisfy `AdminStatus`'s shape.
   achievements: [
     {
       contentId: "achievement-first-steps",
@@ -60,6 +61,7 @@ const status: AdminStatus = {
       onChainStatus: "synced",
       achievementPda: "Pda222",
       collectionAddress: "Coll111",
+      award: null,
     },
   ],
 };
@@ -83,7 +85,7 @@ afterEach(() => {
 });
 
 describe("DeployClient", () => {
-  it("fetches /api/admin/status and renders both sync tables", async () => {
+  it("fetches /api/admin/status and renders the course sync table", async () => {
     const fetchMock = mockStatusFetch();
     renderWithIntl(<DeployClient />);
 
@@ -92,12 +94,11 @@ describe("DeployClient", () => {
     await waitFor(() => {
       expect(screen.getByTestId("course-sync-table")).toBeInTheDocument();
     });
-    expect(screen.getByTestId("achievement-sync-table")).toBeInTheDocument();
     expect(fetchMock).toHaveBeenCalledWith("/api/admin/status");
   });
 
-  it("shows the empty-state copy when there are no courses/achievements", async () => {
-    mockStatusFetch({ ...status, courses: [], achievements: [] });
+  it("shows the empty-state copy when there are no courses", async () => {
+    mockStatusFetch({ ...status, courses: [] });
     renderWithIntl(<DeployClient />);
 
     await waitFor(() => {
@@ -105,9 +106,6 @@ describe("DeployClient", () => {
         screen.getByText("No courses in the content bundle.")
       ).toBeInTheDocument();
     });
-    expect(
-      screen.getByText("No achievements in the content bundle.")
-    ).toBeInTheDocument();
   });
 
   it("refetches on the Refresh button and on the table's onRefresh", async () => {

--- a/apps/web/src/app/[locale]/admin/__tests__/status-client.test.tsx
+++ b/apps/web/src/app/[locale]/admin/__tests__/status-client.test.tsx
@@ -59,6 +59,7 @@ const status: AdminStatus = {
       onChainStatus: "synced",
       achievementPda: "Pda222",
       collectionAddress: "Coll111",
+      award: null,
     },
   ],
 };

--- a/apps/web/src/app/[locale]/admin/admin-nav.tsx
+++ b/apps/web/src/app/[locale]/admin/admin-nav.tsx
@@ -7,8 +7,10 @@ import { useTranslations, useLocale } from "next-intl";
 import { cn } from "@/lib/utils";
 
 // "Courses" is the merged Publish + Deploy screen (the two used to be separate
-// entries, which hid the fact that they are two steps of one flow).
-const SECTIONS = ["courses", "moderation", "status"] as const;
+// entries, which hid the fact that they are two steps of one flow). "Content"
+// (#513 WS-C) is the read-only Quests/Achievements/Paths tab — appended, not
+// inserted, so it doesn't reshuffle the existing three.
+const SECTIONS = ["courses", "moderation", "status", "content"] as const;
 
 /**
  * Best-effort pending-flags count for the "Moderation" nav badge. Reuses the

--- a/apps/web/src/app/[locale]/admin/admin-status-types.ts
+++ b/apps/web/src/app/[locale]/admin/admin-status-types.ts
@@ -5,6 +5,7 @@
  * they need from the same endpoint (plan ambiguity 2: no API split).
  */
 
+import type { AwardT } from "@superteam-lms/content-schema";
 import type { DiffEntry } from "@/lib/admin/sync-diff";
 import type { ChainDriftState, CourseContentDrift } from "@/lib/github/drift";
 
@@ -74,6 +75,13 @@ export interface AchievementStatus {
     | "db_unavailable";
   achievementPda: string | null;
   collectionAddress: string | null;
+  /**
+   * The achievement's declarative unlock rule (#513 WS-C), passed through
+   * unmodified from {@link AdminAchievement.award} so the relocated Content
+   * tab can optionally show `award.course`/`award.path`. `null` for a
+   * pre-sync/legacy doc.
+   */
+  award: AwardT | null;
 }
 
 export interface AdminStatus {

--- a/apps/web/src/app/[locale]/admin/content/__tests__/achievements-subview.test.tsx
+++ b/apps/web/src/app/[locale]/admin/content/__tests__/achievements-subview.test.tsx
@@ -1,0 +1,121 @@
+// @vitest-environment jsdom
+import type { ReactElement } from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import type { AdminStatus } from "../../admin-status-types";
+import { AchievementsSubview } from "../achievements-subview";
+import messages from "@/messages/en.json";
+
+function renderWithIntl(ui: ReactElement) {
+  return render(
+    <NextIntlClientProvider locale="en" messages={messages}>
+      {ui}
+    </NextIntlClientProvider>
+  );
+}
+
+const status: AdminStatus = {
+  program: {
+    deployed: true,
+    programId: "AcademyProgram1111111111111111111111111111",
+    configPda: "Config11111111111111111111111111111111111",
+    minterRegistered: true,
+    authorityMatch: { matches: true },
+  },
+  courses: [
+    {
+      contentId: "course-rust",
+      slug: "rust",
+      title: "Rust Fundamentals",
+      isDraft: false,
+      lessonCount: 3,
+      contentXpPerLesson: 50,
+      missingFields: [],
+      onChainStatus: "synced",
+      coursePda: "Pda111",
+      differences: [],
+      contentDrift: "up_to_date",
+      chainDrift: "content_current",
+    },
+  ],
+  achievements: [
+    {
+      contentId: "achievement-first-steps",
+      name: "First Steps",
+      missingFields: [],
+      onChainStatus: "synced",
+      achievementPda: "Pda222",
+      collectionAddress: "Coll111",
+      award: { kind: "course-completed", course: "course-rust" },
+    },
+  ],
+};
+
+function mockStatusFetch(body: AdminStatus = status) {
+  const fetchMock = vi.fn().mockResolvedValue({
+    ok: true,
+    json: async () => body,
+  } as Response);
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", vi.fn());
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("AchievementsSubview", () => {
+  it("fetches /api/admin/status and renders the achievement table", async () => {
+    mockStatusFetch();
+    renderWithIntl(<AchievementsSubview pathTitleById={{}} />);
+
+    expect(screen.getByText("Loading on-chain status...")).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByText("First Steps")).toBeInTheDocument();
+    });
+  });
+
+  it("resolves award.course against the courses in the SAME status response (no extra request)", async () => {
+    const fetchMock = mockStatusFetch();
+    renderWithIntl(<AchievementsSubview pathTitleById={{}} />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Unlocks with course: Rust Fundamentals")
+      ).toBeInTheDocument();
+    });
+    // One status fetch, no second request for course titles.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows the empty-state copy when there are no achievements", async () => {
+    mockStatusFetch({ ...status, achievements: [] });
+    renderWithIntl(<AchievementsSubview pathTitleById={{}} />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("No achievements in the content bundle.")
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("shows the error state with a working Retry", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: false } as Response)
+      .mockResolvedValue({ ok: true, json: async () => status } as Response);
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderWithIntl(<AchievementsSubview pathTitleById={{}} />);
+    await waitFor(() => {
+      expect(screen.getByText("Failed to fetch status")).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/src/app/[locale]/admin/content/__tests__/content-tabs.test.tsx
+++ b/apps/web/src/app/[locale]/admin/content/__tests__/content-tabs.test.tsx
@@ -1,0 +1,48 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import { ContentTabs } from "../content-tabs";
+import messages from "@/messages/en.json";
+
+function renderTabs() {
+  return render(
+    <NextIntlClientProvider locale="en" messages={messages}>
+      <ContentTabs
+        questsSlot={<div>quests-content</div>}
+        achievementsSlot={<div>achievements-content</div>}
+        pathsSlot={<div>paths-content</div>}
+      />
+    </NextIntlClientProvider>
+  );
+}
+
+describe("ContentTabs", () => {
+  it("renders the three sub-view tabs (Quests / Achievements / Paths)", () => {
+    renderTabs();
+    expect(screen.getByRole("tab", { name: "Quests" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("tab", { name: "Achievements" })
+    ).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Paths" })).toBeInTheDocument();
+  });
+
+  it("shows the Achievements sub-view by default", () => {
+    renderTabs();
+    expect(screen.getByText("achievements-content")).toBeInTheDocument();
+  });
+
+  it("switches to the Quests sub-view on click", () => {
+    renderTabs();
+    // Radix's TabsTrigger selects on `mousedown` (not `click`) — see
+    // @radix-ui/react-tabs's TabsTrigger implementation.
+    fireEvent.mouseDown(screen.getByRole("tab", { name: "Quests" }));
+    expect(screen.getByText("quests-content")).toBeInTheDocument();
+  });
+
+  it("switches to the Paths sub-view on click", () => {
+    renderTabs();
+    fireEvent.mouseDown(screen.getByRole("tab", { name: "Paths" }));
+    expect(screen.getByText("paths-content")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/[locale]/admin/content/__tests__/page.test.tsx
+++ b/apps/web/src/app/[locale]/admin/content/__tests__/page.test.tsx
@@ -1,0 +1,113 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import type {
+  QuestData,
+  AdminLearningPathWithRefs,
+} from "@/lib/content/queries";
+import messages from "@/messages/en.json";
+
+/**
+ * `/admin/content` (#513 WS-C) composition test — the sub-views carry their
+ * own tests (quests-table / paths-table / achievements-subview), so they're
+ * stubbed here; what's under test is that the page fetches the bundle data
+ * server-side and wires it into `ContentTabs` + the pin indicator.
+ */
+const questData: QuestData = {
+  quests: [],
+  challengeLessonIds: [],
+  moduleLessonMap: [],
+};
+const paths: AdminLearningPathWithRefs[] = [
+  {
+    _id: "path-main",
+    title: "Main Path",
+    courseIds: [],
+    resolvedCourses: [],
+    danglingCourseIds: [],
+  },
+];
+
+const getAllQuestsMock = vi.fn(async () => questData);
+const getLearningPathsForAdminWithRefsMock = vi.fn(async () => paths);
+
+vi.mock("@/lib/content/queries", () => ({
+  getAllQuests: () => getAllQuestsMock(),
+  getLearningPathsForAdminWithRefs: () =>
+    getLearningPathsForAdminWithRefsMock(),
+}));
+
+vi.mock("../content-tabs", () => ({
+  ContentTabs: ({
+    questsSlot,
+    achievementsSlot,
+    pathsSlot,
+  }: {
+    questsSlot: React.ReactNode;
+    achievementsSlot: React.ReactNode;
+    pathsSlot: React.ReactNode;
+  }) => (
+    <div>
+      <div data-testid="quests-slot">{questsSlot}</div>
+      <div data-testid="achievements-slot">{achievementsSlot}</div>
+      <div data-testid="paths-slot">{pathsSlot}</div>
+    </div>
+  ),
+}));
+vi.mock("../quests-table", () => ({
+  QuestsTable: () => <div data-testid="quests-table" />,
+}));
+vi.mock("../achievements-subview", () => ({
+  AchievementsSubview: ({
+    pathTitleById,
+  }: {
+    pathTitleById: Record<string, string>;
+  }) => (
+    <div data-testid="achievements-subview">
+      {JSON.stringify(pathTitleById)}
+    </div>
+  ),
+}));
+vi.mock("../paths-table", () => ({
+  PathsTable: () => <div data-testid="paths-table" />,
+}));
+vi.mock("../pin-status-badge", () => ({
+  PinStatusBadge: () => <div data-testid="pin-status-badge" />,
+}));
+
+vi.mock("next-intl/server", () => ({
+  getTranslations: async (namespace: string) => (key: string) => {
+    const path = `${namespace}.${key}`.split(".");
+    let node: unknown = messages;
+    for (const segment of path) {
+      node = (node as Record<string, unknown>)[segment];
+    }
+    return node as string;
+  },
+}));
+
+const { default: AdminContentPage } = await import("../page");
+
+describe("AdminContentPage", () => {
+  it("fetches quests + paths server-side and renders the heading, pin badge, and all three sub-views", async () => {
+    render(await AdminContentPage());
+
+    expect(getAllQuestsMock).toHaveBeenCalledTimes(1);
+    expect(getLearningPathsForAdminWithRefsMock).toHaveBeenCalledTimes(1);
+
+    expect(
+      screen.getByRole("heading", { name: messages.admin.screens.content })
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("pin-status-badge")).toBeInTheDocument();
+    expect(screen.getByTestId("quests-table")).toBeInTheDocument();
+    expect(screen.getByTestId("achievements-subview")).toBeInTheDocument();
+    expect(screen.getByTestId("paths-table")).toBeInTheDocument();
+  });
+
+  it("derives pathTitleById from the fetched paths and hands it to the Achievements sub-view", async () => {
+    render(await AdminContentPage());
+    expect(screen.getByTestId("achievements-subview")).toHaveTextContent(
+      JSON.stringify({ "path-main": "Main Path" })
+    );
+  });
+});

--- a/apps/web/src/app/[locale]/admin/content/__tests__/paths-table.test.tsx
+++ b/apps/web/src/app/[locale]/admin/content/__tests__/paths-table.test.tsx
@@ -1,0 +1,97 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { createTranslator } from "next-intl";
+import { PathsTable } from "../paths-table";
+import type { AdminLearningPathWithRefs } from "@/lib/content/queries";
+import messages from "@/messages/en.json";
+
+// Real ICU-aware translator (supports the `danglingCount` plural rule),
+// rather than a raw key lookup — `next-intl/server`'s `getTranslations` needs
+// a request context this test environment doesn't have.
+vi.mock("next-intl/server", () => ({
+  getTranslations: async (namespace: string) =>
+    createTranslator({ locale: "en", messages, namespace }),
+}));
+
+async function renderTable(paths: AdminLearningPathWithRefs[]) {
+  return render(await PathsTable({ paths }));
+}
+
+describe("PathsTable", () => {
+  it("renders the resolved course sequence for a healthy path", async () => {
+    await renderTable([
+      {
+        _id: "path-main",
+        title: "Main Path",
+        courseIds: ["course-a", "course-b"],
+        resolvedCourses: [
+          { _id: "course-a", title: "Course A", slug: "a" },
+          { _id: "course-b", title: "Course B", slug: "b" },
+        ],
+        danglingCourseIds: [],
+      },
+    ]);
+
+    expect(screen.getByText("Main Path")).toBeInTheDocument();
+    expect(screen.getByText("Course A")).toBeInTheDocument();
+    expect(screen.getByText("Course B")).toBeInTheDocument();
+    expect(screen.queryByText("missing")).not.toBeInTheDocument();
+  });
+
+  it("loudly flags a dangling course ref instead of dropping it", async () => {
+    await renderTable([
+      {
+        _id: "path-broken",
+        title: "Broken Path",
+        courseIds: ["course-a", "course-ghost"],
+        resolvedCourses: [{ _id: "course-a", title: "Course A", slug: "a" }],
+        danglingCourseIds: ["course-ghost"],
+      },
+    ]);
+
+    // The healthy ref still renders normally.
+    expect(screen.getByText("Course A")).toBeInTheDocument();
+    // The dangling ref is visible — the raw id, not silently dropped.
+    expect(screen.getByText("missing: course-ghost")).toBeInTheDocument();
+    // A visible count summarizes the breakage.
+    expect(screen.getByText("1 dangling course reference")).toBeInTheDocument();
+  });
+
+  it("pluralizes the dangling count for multiple broken refs", async () => {
+    await renderTable([
+      {
+        _id: "path-broken",
+        title: "Broken Path",
+        courseIds: ["ghost-1", "ghost-2"],
+        resolvedCourses: [],
+        danglingCourseIds: ["ghost-1", "ghost-2"],
+      },
+    ]);
+
+    expect(
+      screen.getByText("2 dangling course references")
+    ).toBeInTheDocument();
+  });
+
+  it("shows the no-courses copy for a path with no refs at all", async () => {
+    await renderTable([
+      {
+        _id: "path-empty",
+        title: "Empty Path",
+        courseIds: [],
+        resolvedCourses: [],
+        danglingCourseIds: [],
+      },
+    ]);
+
+    expect(screen.getByText("No courses in this path.")).toBeInTheDocument();
+  });
+
+  it("shows the bundle-empty copy when there are no paths", async () => {
+    await renderTable([]);
+    expect(
+      screen.getByText("No learning paths in the content bundle.")
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/[locale]/admin/content/__tests__/pin-status-badge.test.tsx
+++ b/apps/web/src/app/[locale]/admin/content/__tests__/pin-status-badge.test.tsx
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import { PinStatusBadge } from "../pin-status-badge";
+import messages from "@/messages/en.json";
+
+function renderBadge() {
+  return render(
+    <NextIntlClientProvider locale="en" messages={messages}>
+      <PinStatusBadge />
+    </NextIntlClientProvider>
+  );
+}
+
+function mockPinFetch(ok: boolean, body: unknown = {}) {
+  const fetchMock = vi
+    .fn()
+    .mockResolvedValue({ ok, json: async () => body } as Response);
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", vi.fn());
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("PinStatusBadge — reuses GET /api/admin/publish/pin, no new endpoint", () => {
+  it("shows 'Bundle pinned' when up to date", async () => {
+    const fetchMock = mockPinFetch(true, {
+      verdict: { state: "up_to_date", commitsBehind: 0 },
+    });
+    renderBadge();
+
+    await waitFor(() => {
+      expect(screen.getByText("Bundle pinned")).toBeInTheDocument();
+    });
+    expect(fetchMock).toHaveBeenCalledWith("/api/admin/publish/pin");
+  });
+
+  it("shows the commits-behind count when drifted", async () => {
+    mockPinFetch(true, {
+      verdict: { state: "behind", commitsBehind: 4 },
+    });
+    renderBadge();
+
+    await waitFor(() => {
+      expect(screen.getByText("4 commits behind")).toBeInTheDocument();
+    });
+  });
+
+  it("falls back to a generic drifted label when the commit count is unknown", async () => {
+    mockPinFetch(true, {
+      verdict: { state: "behind", commitsBehind: null },
+    });
+    renderBadge();
+
+    await waitFor(() => {
+      expect(screen.getByText("Bundle drifted")).toBeInTheDocument();
+    });
+  });
+
+  it("shows 'Pin status unavailable' when the route 503s", async () => {
+    mockPinFetch(false);
+    renderBadge();
+
+    await waitFor(() => {
+      expect(screen.getByText("Pin status unavailable")).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/src/app/[locale]/admin/content/__tests__/quests-table.test.tsx
+++ b/apps/web/src/app/[locale]/admin/content/__tests__/quests-table.test.tsx
@@ -1,0 +1,70 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { createTranslator } from "next-intl";
+import { QuestsTable } from "../quests-table";
+import type { SanityQuest } from "@/lib/content/queries";
+import messages from "@/messages/en.json";
+
+vi.mock("next-intl/server", () => ({
+  getTranslations: async (namespace: string) =>
+    createTranslator({ locale: "en", messages, namespace }),
+}));
+
+const quest: SanityQuest = {
+  id: "quest-three-lessons",
+  name: "Three Lessons",
+  description: "Complete 3 lessons today.",
+  type: "lesson_batch",
+  icon: "📚",
+  xpReward: 30,
+  targetValue: 3,
+  resetType: "daily",
+};
+
+describe("QuestsTable", () => {
+  it("renders each quest's reward config — read-only, no action column", async () => {
+    render(await QuestsTable({ quests: [quest] }));
+
+    expect(screen.getByText("Three Lessons")).toBeInTheDocument();
+    expect(screen.getByText("Lesson batch")).toBeInTheDocument();
+    expect(screen.getByText("30")).toBeInTheDocument();
+    expect(screen.getByText("3")).toBeInTheDocument();
+    expect(screen.getByText("Daily")).toBeInTheDocument();
+    expect(screen.getByText("📚")).toBeInTheDocument();
+    // Zero on-chain: no sync/deploy affordance anywhere in the table.
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+
+  it("translates every quest type and reset type", async () => {
+    const quests: SanityQuest[] = [
+      "lesson",
+      "lesson_batch",
+      "challenge",
+      "login_streak",
+      "module",
+    ].map((type, i) => ({
+      ...quest,
+      id: `quest-${i}`,
+      type: type as SanityQuest["type"],
+    }));
+    render(await QuestsTable({ quests }));
+
+    for (const label of [
+      "Lesson",
+      "Lesson batch",
+      "Challenge",
+      "Login streak",
+      "Module",
+    ]) {
+      expect(screen.getByText(label)).toBeInTheDocument();
+    }
+  });
+
+  it("shows the empty-bundle copy when there are no quests", async () => {
+    render(await QuestsTable({ quests: [] }));
+    expect(
+      screen.getByText("No quests in the content bundle.")
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/[locale]/admin/content/achievements-subview.tsx
+++ b/apps/web/src/app/[locale]/admin/content/achievements-subview.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { useAdminStatus } from "../use-admin-status";
+import { AchievementSyncTable } from "@/components/admin/achievement-sync-table";
+import { AdminCard } from "@/components/admin/admin-card";
+
+interface AchievementsSubviewProps {
+  /** `award.path` id → title, server-computed from `getLearningPathsForAdminWithRefs` (#513). */
+  pathTitleById: Record<string, string>;
+}
+
+/**
+ * The Achievements sub-view of the Content tab (#513 WS-C) — relocated from
+ * the Courses screen's second section (`courses/deploy-client.tsx`). Reuses
+ * `useAdminStatus()`, the SAME hook `DeployClient` uses, so the sync/sync-all
+ * behavior and the `/api/admin/achievements/sync` contract are unchanged; only
+ * where this renders moved. `courseTitleById` comes for free from the same
+ * response's `courses` array (no extra request) so the table can optionally
+ * resolve an achievement's `award.course` ref.
+ */
+export function AchievementsSubview({
+  pathTitleById,
+}: AchievementsSubviewProps) {
+  const t = useTranslations("admin");
+  const tAch = useTranslations("admin.contentScreen.achievements");
+  const { status, loading, error, refetch } = useAdminStatus();
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <div className="text-sm text-text-3">{t("states.loading")}</div>
+      </div>
+    );
+  }
+
+  if (error) {
+    // A failed status fetch is transient/recoverable — neutral `streak`, not
+    // the blocking `danger` red (same convention as DeployClient).
+    return (
+      <div
+        role="alert"
+        className="rounded-md border border-streak bg-streak-light p-4 text-sm text-streak"
+      >
+        {t(error === "network" ? "states.networkError" : "states.fetchError")}
+        <button onClick={refetch} className="ml-3 underline hover:no-underline">
+          {t("states.retry")}
+        </button>
+      </div>
+    );
+  }
+
+  if (!status) return null;
+
+  const { courses, achievements } = status;
+  const courseTitleById = Object.fromEntries(
+    courses.map((c) => [c.contentId, c.title])
+  );
+
+  return (
+    <section>
+      <div className="mb-4 flex items-center justify-between">
+        <h3 className="font-display text-lg font-bold text-text">
+          {tAch("heading")}
+        </h3>
+        <button
+          onClick={refetch}
+          className="rounded-md border border-border bg-card px-3 py-1 text-xs text-text-2 shadow-push-sm transition-all hover:bg-subtle active:translate-y-[2px] active:shadow-push-active"
+        >
+          {t("states.refresh")}
+        </button>
+      </div>
+      <AdminCard>
+        {achievements.length === 0 ? (
+          <p className="text-sm text-text-3">{tAch("empty")}</p>
+        ) : (
+          <AchievementSyncTable
+            achievements={achievements}
+            onRefresh={refetch}
+            courseTitleById={courseTitleById}
+            pathTitleById={pathTitleById}
+          />
+        )}
+      </AdminCard>
+    </section>
+  );
+}

--- a/apps/web/src/app/[locale]/admin/content/content-tabs.tsx
+++ b/apps/web/src/app/[locale]/admin/content/content-tabs.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { useTranslations } from "next-intl";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+
+interface ContentTabsProps {
+  questsSlot: ReactNode;
+  achievementsSlot: ReactNode;
+  pathsSlot: ReactNode;
+}
+
+/**
+ * Sub-view switch for the admin Content tab (#513 WS-C): Quests / Achievements
+ * / Paths share ONE "Content" nav entry rather than three top-level sections —
+ * none has Courses-scale write surface (plan decision). Built on the existing
+ * Radix-backed `Tabs` primitive (`components/ui/tabs.tsx`) instead of
+ * hand-rolled tab markup, so keyboard nav (arrow keys) and the full ARIA
+ * tablist/tab/tabpanel wiring come for free.
+ *
+ * Each sub-view is rendered by the server-component parent (`page.tsx`) —
+ * Quests/Paths are plain server components, Achievements is a client
+ * component that needs `useAdminStatus()` — and handed in as a slot; this
+ * component only arranges them into tabs.
+ */
+export function ContentTabs({
+  questsSlot,
+  achievementsSlot,
+  pathsSlot,
+}: ContentTabsProps) {
+  const t = useTranslations("admin.contentScreen.tabs");
+
+  return (
+    <Tabs defaultValue="achievements">
+      <TabsList>
+        <TabsTrigger value="quests">{t("quests")}</TabsTrigger>
+        <TabsTrigger value="achievements">{t("achievements")}</TabsTrigger>
+        <TabsTrigger value="paths">{t("paths")}</TabsTrigger>
+      </TabsList>
+      <TabsContent value="quests">{questsSlot}</TabsContent>
+      <TabsContent value="achievements">{achievementsSlot}</TabsContent>
+      <TabsContent value="paths">{pathsSlot}</TabsContent>
+    </Tabs>
+  );
+}

--- a/apps/web/src/app/[locale]/admin/content/page.tsx
+++ b/apps/web/src/app/[locale]/admin/content/page.tsx
@@ -1,0 +1,47 @@
+import { getTranslations } from "next-intl/server";
+import { ContentTabs } from "./content-tabs";
+import { AchievementsSubview } from "./achievements-subview";
+import { QuestsTable } from "./quests-table";
+import { PathsTable } from "./paths-table";
+import { PinStatusBadge } from "./pin-status-badge";
+import {
+  getAllQuests,
+  getLearningPathsForAdminWithRefs,
+} from "@/lib/content/queries";
+
+/**
+ * `/admin/content` (#513 WS-C) — one "Content" tab over three read-only bundle
+ * views (Quests, Achievements, Paths), plus the relocated achievement on-chain
+ * sync (the one write surface here — Quests and Paths are ZERO on-chain).
+ *
+ * Quests/Paths are fetched here, server-side, straight from the content
+ * bundle (`lib/content/queries.ts`) — no client round trip needed since
+ * they're static per-deploy content, not on-chain state. Achievements stays a
+ * client sub-view: it needs `useAdminStatus()` for on-chain sync status and
+ * the sync action, same as before the relocation.
+ */
+export default async function AdminContentPage() {
+  const t = await getTranslations("admin");
+  const [questData, paths] = await Promise.all([
+    getAllQuests(),
+    getLearningPathsForAdminWithRefs(),
+  ]);
+  const pathTitleById = Object.fromEntries(paths.map((p) => [p._id, p.title]));
+
+  return (
+    <section>
+      <div className="mb-4 flex items-center justify-between gap-4">
+        <h2 className="font-display text-lg font-bold text-text">
+          {t("screens.content")}
+        </h2>
+        <PinStatusBadge />
+      </div>
+      <p className="mb-6 text-sm text-text-3">{t("contentScreen.intro")}</p>
+      <ContentTabs
+        questsSlot={<QuestsTable quests={questData.quests} />}
+        achievementsSlot={<AchievementsSubview pathTitleById={pathTitleById} />}
+        pathsSlot={<PathsTable paths={paths} />}
+      />
+    </section>
+  );
+}

--- a/apps/web/src/app/[locale]/admin/content/paths-table.tsx
+++ b/apps/web/src/app/[locale]/admin/content/paths-table.tsx
@@ -1,0 +1,84 @@
+import { getTranslations } from "next-intl/server";
+import { AdminCard } from "@/components/admin/admin-card";
+import { AdminTableShell } from "@/components/admin/admin-table-shell";
+import { AdminBadge } from "@/components/admin/admin-badge";
+import type { AdminLearningPathWithRefs } from "@/lib/content/queries";
+
+interface PathsTableProps {
+  paths: AdminLearningPathWithRefs[];
+}
+
+/**
+ * Paths sub-view of the Content tab (#513 WS-C) — READ-ONLY, ZERO on-chain.
+ * Shows each path's resolved course sequence, and loudly flags any `courseId`
+ * ref that resolves to nothing instead of the silent drop `pathCourseRefIds`
+ * callers get elsewhere today — the net-new dangling-ref detection
+ * (`resolveRefs`, `getLearningPathsForAdminWithRefs`) exists specifically so
+ * this view never hides a broken ref.
+ */
+export async function PathsTable({ paths }: PathsTableProps) {
+  const t = await getTranslations("admin.contentScreen.paths");
+
+  return (
+    <section>
+      <h3 className="mb-4 font-display text-lg font-bold text-text">
+        {t("heading")}
+      </h3>
+      <AdminCard>
+        {paths.length === 0 ? (
+          <p className="text-sm text-text-3">{t("empty")}</p>
+        ) : (
+          <AdminTableShell
+            columns={[
+              { key: "path", label: t("table.path") },
+              { key: "courses", label: t("table.courses") },
+            ]}
+          >
+            {paths.map((path) => {
+              const hasNothing =
+                path.resolvedCourses.length === 0 &&
+                path.danglingCourseIds.length === 0;
+              return (
+                <tr
+                  key={path._id}
+                  className="transition-colors hover:bg-subtle"
+                >
+                  <td className="py-3 pr-4 align-top font-medium text-text">
+                    {path.title}
+                  </td>
+                  <td className="py-3 align-top">
+                    {hasNothing ? (
+                      <span className="text-sm text-text-3">
+                        {t("noCourses")}
+                      </span>
+                    ) : (
+                      <div className="flex flex-wrap gap-1.5">
+                        {path.resolvedCourses.map((course) => (
+                          <AdminBadge key={course._id} tone="neutral">
+                            {course.title}
+                          </AdminBadge>
+                        ))}
+                        {path.danglingCourseIds.map((id) => (
+                          <AdminBadge key={id} tone="danger" title={id}>
+                            {t("danglingBadge")}: {id}
+                          </AdminBadge>
+                        ))}
+                      </div>
+                    )}
+                    {path.danglingCourseIds.length > 0 && (
+                      <p className="mt-1 text-xs font-medium text-danger">
+                        {t("danglingCount", {
+                          count: path.danglingCourseIds.length,
+                        })}
+                      </p>
+                    )}
+                  </td>
+                </tr>
+              );
+            })}
+          </AdminTableShell>
+        )}
+      </AdminCard>
+    </section>
+  );
+}

--- a/apps/web/src/app/[locale]/admin/content/pin-status-badge.tsx
+++ b/apps/web/src/app/[locale]/admin/content/pin-status-badge.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useTranslations } from "next-intl";
+import { AdminBadge } from "@/components/admin/admin-badge";
+import type { PublishVerdict } from "@/lib/github/publish-pin";
+
+interface PinResponse {
+  verdict: PublishVerdict;
+}
+
+/**
+ * Shared "pinned / drifted" indicator for the admin Content tab (#513 WS-C).
+ * Inherits the SAME publish-pin verdict the Courses screen's
+ * `PublishPinClient` shows (one bundle SHA, true for every content type —
+ * quests/achievements/paths/courses all ship in the one committed bundle) via
+ * the EXISTING `GET /api/admin/publish/pin` route. No new endpoint — this is
+ * just a second, compact consumer of that one read.
+ */
+export function PinStatusBadge() {
+  const t = useTranslations("admin.contentScreen.pin");
+  const [verdict, setVerdict] = useState<PublishVerdict | null>(null);
+  const [unavailable, setUnavailable] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+    void (async () => {
+      try {
+        const res = await fetch("/api/admin/publish/pin");
+        if (!res.ok) {
+          if (active) setUnavailable(true);
+          return;
+        }
+        const data = (await res.json()) as PinResponse;
+        if (active) setVerdict(data.verdict);
+      } catch {
+        if (active) setUnavailable(true);
+      }
+    })();
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  if (unavailable) {
+    return <AdminBadge tone="neutral">{t("unavailable")}</AdminBadge>;
+  }
+  if (!verdict) return null;
+
+  if (verdict.state === "up_to_date") {
+    return <AdminBadge tone="success">{t("pinned")}</AdminBadge>;
+  }
+  if (verdict.state === "behind") {
+    return (
+      <AdminBadge tone="warning">
+        {verdict.commitsBehind == null
+          ? t("drifted")
+          : t("behind", { count: verdict.commitsBehind })}
+      </AdminBadge>
+    );
+  }
+  return <AdminBadge tone="neutral">{t("unknown")}</AdminBadge>;
+}

--- a/apps/web/src/app/[locale]/admin/content/quests-table.tsx
+++ b/apps/web/src/app/[locale]/admin/content/quests-table.tsx
@@ -1,0 +1,71 @@
+import { getTranslations } from "next-intl/server";
+import { AdminCard } from "@/components/admin/admin-card";
+import { AdminTableShell } from "@/components/admin/admin-table-shell";
+import type { SanityQuest } from "@/lib/content/queries";
+
+interface QuestsTableProps {
+  quests: SanityQuest[];
+}
+
+/**
+ * Quests sub-view of the Content tab (#513 WS-C) — READ-ONLY, ZERO on-chain.
+ * Quests have no sync/deploy action: they're pure content, evaluated against
+ * Supabase progress at request time (`/api/quests/daily`), so this is a plain
+ * reward-config table, not a mutation surface — do NOT invent a sync here.
+ */
+export async function QuestsTable({ quests }: QuestsTableProps) {
+  const t = await getTranslations("admin.contentScreen.quests");
+
+  return (
+    <section>
+      <h3 className="mb-1 font-display text-lg font-bold text-text">
+        {t("heading")}
+      </h3>
+      <p className="mb-4 text-sm text-text-3">{t("description")}</p>
+      <AdminCard>
+        {quests.length === 0 ? (
+          <p className="text-sm text-text-3">{t("empty")}</p>
+        ) : (
+          <AdminTableShell
+            columns={[
+              { key: "quest", label: t("table.quest") },
+              { key: "type", label: t("table.type") },
+              { key: "xpReward", label: t("table.xpReward"), align: "right" },
+              {
+                key: "targetValue",
+                label: t("table.targetValue"),
+                align: "right",
+              },
+              { key: "resetType", label: t("table.resetType") },
+              { key: "icon", label: t("table.icon"), align: "center" },
+            ]}
+          >
+            {quests.map((quest) => (
+              <tr key={quest.id} className="transition-colors hover:bg-subtle">
+                <td className="py-3 pr-4 align-top">
+                  <div className="font-medium text-text">{quest.name}</div>
+                  <div className="text-xs text-text-3">{quest.description}</div>
+                </td>
+                <td className="py-3 pr-4 align-top text-text-2">
+                  {t(`type.${quest.type}`)}
+                </td>
+                <td className="py-3 pr-4 text-right align-top font-mono text-text-2">
+                  {quest.xpReward}
+                </td>
+                <td className="py-3 pr-4 text-right align-top font-mono text-text-2">
+                  {quest.targetValue}
+                </td>
+                <td className="py-3 pr-4 align-top text-text-2">
+                  {t(`resetType.${quest.resetType}`)}
+                </td>
+                <td className="py-3 text-center align-top text-lg">
+                  {quest.icon || "—"}
+                </td>
+              </tr>
+            ))}
+          </AdminTableShell>
+        )}
+      </AdminCard>
+    </section>
+  );
+}

--- a/apps/web/src/app/[locale]/admin/courses/deploy-client.tsx
+++ b/apps/web/src/app/[locale]/admin/courses/deploy-client.tsx
@@ -3,14 +3,18 @@
 import { useTranslations } from "next-intl";
 import { useAdminStatus } from "../use-admin-status";
 import { CourseSyncTable } from "@/components/admin/course-sync-table";
-import { AchievementSyncTable } from "@/components/admin/achievement-sync-table";
 import { AdminCard } from "@/components/admin/admin-card";
 
 /**
- * The deploy half of `/admin/courses` (step 2): the Courses + Achievements
- * sync tables. Unchanged from the retired `/admin/deploy` screen apart from
- * this move — the `/api/admin/status` fetch + loading/error/refetch live in
- * the shared `useAdminStatus` hook (SP3-D), which the status screen uses too.
+ * The deploy half of `/admin/courses` (step 2): the Courses sync table.
+ * Unchanged from the retired `/admin/deploy` screen apart from this move — the
+ * `/api/admin/status` fetch + loading/error/refetch live in the shared
+ * `useAdminStatus` hook (SP3-D), which the status screen uses too.
+ *
+ * The Achievements sync table used to render as a second section here; #513
+ * WS-C relocated it into the new Content tab's Achievements sub-view
+ * (`admin/content/achievements-subview.tsx`), which reuses this same
+ * `useAdminStatus()` hook — same data, same sync behavior, different screen.
  */
 export function DeployClient() {
   const t = useTranslations("admin");
@@ -42,50 +46,28 @@ export function DeployClient() {
 
   if (!status) return null;
 
-  const { courses, achievements } = status;
+  const { courses } = status;
 
   return (
-    <div className="space-y-8">
-      {/* Courses */}
-      <section>
-        <div className="mb-4 flex items-center justify-between">
-          <h3 className="font-display text-lg font-bold text-text">
-            {t("deployScreen.coursesHeading")}
-          </h3>
-          <button
-            onClick={refetch}
-            className="rounded-md border border-border bg-card px-3 py-1 text-xs text-text-2 shadow-push-sm transition-all hover:bg-subtle active:translate-y-[2px] active:shadow-push-active"
-          >
-            {t("states.refresh")}
-          </button>
-        </div>
-        <AdminCard>
-          {courses.length === 0 ? (
-            <p className="text-sm text-text-3">{t("deployScreen.noCourses")}</p>
-          ) : (
-            <CourseSyncTable courses={courses} onRefresh={refetch} />
-          )}
-        </AdminCard>
-      </section>
-
-      {/* Achievements */}
-      <section>
-        <h3 className="mb-4 font-display text-lg font-bold text-text">
-          {t("deployScreen.achievementsHeading")}
+    <section>
+      <div className="mb-4 flex items-center justify-between">
+        <h3 className="font-display text-lg font-bold text-text">
+          {t("deployScreen.coursesHeading")}
         </h3>
-        <AdminCard>
-          {achievements.length === 0 ? (
-            <p className="text-sm text-text-3">
-              {t("deployScreen.noAchievements")}
-            </p>
-          ) : (
-            <AchievementSyncTable
-              achievements={achievements}
-              onRefresh={refetch}
-            />
-          )}
-        </AdminCard>
-      </section>
-    </div>
+        <button
+          onClick={refetch}
+          className="rounded-md border border-border bg-card px-3 py-1 text-xs text-text-2 shadow-push-sm transition-all hover:bg-subtle active:translate-y-[2px] active:shadow-push-active"
+        >
+          {t("states.refresh")}
+        </button>
+      </div>
+      <AdminCard>
+        {courses.length === 0 ? (
+          <p className="text-sm text-text-3">{t("deployScreen.noCourses")}</p>
+        ) : (
+          <CourseSyncTable courses={courses} onRefresh={refetch} />
+        )}
+      </AdminCard>
+    </section>
   );
 }

--- a/apps/web/src/app/api/admin/status/route.ts
+++ b/apps/web/src/app/api/admin/status/route.ts
@@ -265,6 +265,7 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
           onChainStatus: "draft" as const,
           achievementPda: null,
           collectionAddress: null,
+          award: ach.award ?? null,
         };
       }
 
@@ -277,6 +278,7 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
           onChainStatus: "missing_fields" as const,
           achievementPda: null,
           collectionAddress: null,
+          award: ach.award ?? null,
         };
       }
 
@@ -291,6 +293,7 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
           onChainStatus: "not_deployed" as const,
           achievementPda: null,
           collectionAddress: null,
+          award: ach.award ?? null,
         };
       }
 
@@ -306,6 +309,7 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
           : ("synced" as const),
         achievementPda: achPda.toBase58(),
         collectionAddress: ach.onChainStatus?.collectionAddress ?? null,
+        award: ach.award ?? null,
       };
     })
   );

--- a/apps/web/src/components/admin/__tests__/achievement-sync-table.test.tsx
+++ b/apps/web/src/components/admin/__tests__/achievement-sync-table.test.tsx
@@ -1,0 +1,184 @@
+// @vitest-environment jsdom
+import type { ReactElement } from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import { AchievementSyncTable } from "../achievement-sync-table";
+import messages from "@/messages/en.json";
+
+function renderWithIntl(ui: ReactElement) {
+  return render(
+    <NextIntlClientProvider locale="en" messages={messages}>
+      {ui}
+    </NextIntlClientProvider>
+  );
+}
+
+function mockFetch(ok: boolean, body: unknown = {}) {
+  const fetchMock = vi
+    .fn()
+    .mockResolvedValue({ ok, json: async () => body } as Response);
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", vi.fn());
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("AchievementSyncTable — relocation into the Content tab (#513) must not change sync behavior", () => {
+  it("POSTs the achievement id and calls onRefresh on a successful Deploy", async () => {
+    const fetchMock = mockFetch(true);
+    const onRefresh = vi.fn();
+    renderWithIntl(
+      <AchievementSyncTable
+        achievements={[
+          {
+            contentId: "achievement-first-steps",
+            name: "First Steps",
+            missingFields: [],
+            onChainStatus: "not_deployed",
+            achievementPda: null,
+            collectionAddress: null,
+          },
+        ]}
+        onRefresh={onRefresh}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Deploy" }));
+
+    await waitFor(() => expect(onRefresh).toHaveBeenCalledTimes(1));
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/admin/achievements/sync",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ achievementId: "achievement-first-steps" }),
+      })
+    );
+  });
+
+  it("shows a Sync All button that syncs every syncable achievement in sequence", async () => {
+    const fetchMock = mockFetch(true);
+    const onRefresh = vi.fn();
+    renderWithIntl(
+      <AchievementSyncTable
+        achievements={[
+          {
+            contentId: "achievement-a",
+            name: "Ach A",
+            missingFields: [],
+            onChainStatus: "not_deployed",
+            achievementPda: null,
+            collectionAddress: null,
+          },
+          {
+            contentId: "achievement-b",
+            name: "Ach B",
+            missingFields: [],
+            onChainStatus: "not_deployed",
+            achievementPda: null,
+            collectionAddress: null,
+          },
+        ]}
+        onRefresh={onRefresh}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Sync All (2)" }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      "/api/admin/achievements/sync",
+      expect.objectContaining({
+        body: JSON.stringify({ achievementId: "achievement-a" }),
+      })
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "/api/admin/achievements/sync",
+      expect.objectContaining({
+        body: JSON.stringify({ achievementId: "achievement-b" }),
+      })
+    );
+  });
+
+  it("surfaces a translated error and stops on sync failure", async () => {
+    mockFetch(false, { error: "boom" });
+    renderWithIntl(
+      <AchievementSyncTable
+        achievements={[
+          {
+            contentId: "achievement-first-steps",
+            name: "First Steps",
+            missingFields: [],
+            onChainStatus: "not_deployed",
+            achievementPda: null,
+            collectionAddress: null,
+          },
+        ]}
+        onRefresh={vi.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Deploy" }));
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent("boom");
+    });
+  });
+
+  it("resolves award.course to a title when courseTitleById has it", () => {
+    renderWithIntl(
+      <AchievementSyncTable
+        achievements={[
+          {
+            contentId: "achievement-first-steps",
+            name: "First Steps",
+            missingFields: [],
+            onChainStatus: "synced",
+            achievementPda: "Pda1",
+            collectionAddress: "Coll1",
+            award: { kind: "course-completed", course: "course-rust" },
+          },
+        ]}
+        onRefresh={vi.fn()}
+        courseTitleById={{ "course-rust": "Rust Fundamentals" }}
+      />
+    );
+
+    expect(
+      screen.getByText("Unlocks with course: Rust Fundamentals")
+    ).toBeInTheDocument();
+  });
+
+  it("loudly flags an award ref that resolves to nothing, instead of hiding it", () => {
+    renderWithIntl(
+      <AchievementSyncTable
+        achievements={[
+          {
+            contentId: "achievement-orphan",
+            name: "Orphan Achievement",
+            missingFields: [],
+            onChainStatus: "synced",
+            achievementPda: "Pda1",
+            collectionAddress: "Coll1",
+            award: { kind: "course-completed", course: "course-deleted" },
+          },
+        ]}
+        onRefresh={vi.fn()}
+        courseTitleById={{}}
+      />
+    );
+
+    expect(screen.getByText("missing")).toBeInTheDocument();
+    expect(
+      screen.getByText("Unresolved ref: course-deleted")
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/admin/achievement-sync-table.tsx
+++ b/apps/web/src/components/admin/achievement-sync-table.tsx
@@ -1,7 +1,12 @@
 "use client";
 
 import { useState } from "react";
+import { useTranslations } from "next-intl";
+import type { AwardT } from "@superteam-lms/content-schema";
 import { StatusBadge } from "./status-badge";
+import { AdminTableShell } from "./admin-table-shell";
+import { AdminButton } from "./admin-button";
+import { AdminBadge } from "./admin-badge";
 
 interface AchievementStatus {
   contentId: string;
@@ -17,17 +22,107 @@ interface AchievementStatus {
     | "db_unavailable";
   achievementPda: string | null;
   collectionAddress: string | null;
+  /**
+   * The declarative unlock rule (#513 WS-C) — when it targets a course or
+   * path, the row optionally surfaces which one below the achievement name.
+   * `null`/`undefined` for a pre-sync/legacy doc or an award kind with no ref
+   * (e.g. `streak`, `manual`).
+   */
+  award?: AwardT | null;
 }
 
 interface AchievementSyncTableProps {
   achievements: AchievementStatus[];
   onRefresh: () => void;
+  /** `award.course` id → title, for resolving the optional award-ref line. */
+  courseTitleById?: Record<string, string>;
+  /** `award.path` id → title, for resolving the optional award-ref line. */
+  pathTitleById?: Record<string, string>;
 }
 
+/** Award kinds that carry a course ref (issue #478's `AwardT` shape). */
+function awardCourseId(award: AwardT): string | null {
+  return award.kind === "course-completed" ||
+    award.kind === "lessons-completed-in-course"
+    ? award.course
+    : null;
+}
+
+function awardPathId(award: AwardT): string | null {
+  return award.kind === "path-completed" ? award.path : null;
+}
+
+/**
+ * Optional "unlocks with course X / path Y" line under an achievement's name
+ * (spec: "Optionally surface award.course/award.path"). Reuses the same
+ * loud-not-silent convention the Paths dangling-ref view established: a ref
+ * id with no matching title renders an `AdminBadge tone="danger"` instead of
+ * disappearing.
+ */
+function AwardRefLine({
+  award,
+  courseTitleById,
+  pathTitleById,
+}: {
+  award: AwardT | null | undefined;
+  courseTitleById: Record<string, string>;
+  pathTitleById: Record<string, string>;
+}) {
+  const t = useTranslations("admin.contentScreen.achievements");
+  if (!award) return null;
+
+  const courseId = awardCourseId(award);
+  if (courseId) {
+    const title = courseTitleById[courseId];
+    return title ? (
+      <div className="mt-1 text-xs text-text-3">
+        {t("awardCourse", { title })}
+      </div>
+    ) : (
+      <div className="mt-1 flex items-center gap-1.5">
+        <AdminBadge tone="danger">{t("awardMissingBadge")}</AdminBadge>
+        <span className="font-mono text-xs text-text-3">
+          {t("awardMissingRef", { id: courseId })}
+        </span>
+      </div>
+    );
+  }
+
+  const pathId = awardPathId(award);
+  if (pathId) {
+    const title = pathTitleById[pathId];
+    return title ? (
+      <div className="mt-1 text-xs text-text-3">
+        {t("awardPath", { title })}
+      </div>
+    ) : (
+      <div className="mt-1 flex items-center gap-1.5">
+        <AdminBadge tone="danger">{t("awardMissingBadge")}</AdminBadge>
+        <span className="font-mono text-xs text-text-3">
+          {t("awardMissingRef", { id: pathId })}
+        </span>
+      </div>
+    );
+  }
+
+  return null;
+}
+
+/**
+ * The achievement on-chain sync table — relocated (#513 WS-C) from the
+ * Courses screen into the admin Content tab's Achievements sub-view. The
+ * sync/sync-all behavior and the `/api/admin/achievements/sync` contract are
+ * UNCHANGED; only where this renders, and its chrome (AdminTableShell /
+ * AdminButton instead of hand-rolled markup, en/es/pt-BR strings instead of
+ * hardcoded English — #452) moved.
+ */
 export function AchievementSyncTable({
   achievements,
   onRefresh,
+  courseTitleById = {},
+  pathTitleById = {},
 }: AchievementSyncTableProps) {
+  const t = useTranslations("admin.contentScreen.achievements");
   const [syncing, setSyncing] = useState<string | null>(null);
   const [syncingAll, setSyncingAll] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -43,12 +138,12 @@ export function AchievementSyncTable({
       });
       if (!res.ok) {
         const data = (await res.json()) as { error?: string };
-        setError(data.error ?? "Sync failed");
+        setError(data.error ?? t("errors.sync"));
       } else {
         onRefresh();
       }
     } catch (e) {
-      setError(e instanceof Error ? e.message : "Sync failed");
+      setError(e instanceof Error ? e.message : t("errors.sync"));
     } finally {
       setSyncing(null);
     }
@@ -73,13 +168,15 @@ export function AchievementSyncTable({
         });
         if (!res.ok) {
           const data = (await res.json()) as { error?: string };
-          setError(data.error ?? `Sync failed for ${ach.name}`);
+          setError(data.error ?? t("errors.syncFor", { name: ach.name }));
           onRefresh();
           break;
         }
       } catch (e) {
         setError(
-          e instanceof Error ? e.message : `Sync failed for ${ach.name}`
+          e instanceof Error
+            ? e.message
+            : t("errors.syncFor", { name: ach.name })
         );
         onRefresh();
         break;
@@ -100,80 +197,89 @@ export function AchievementSyncTable({
   return (
     <div>
       {error && (
-        <div className="mb-3 rounded-md border border-danger bg-danger-light p-3 text-sm text-danger">
+        <div
+          role="alert"
+          className="mb-3 rounded-md border border-danger bg-danger-light p-3 text-sm text-danger"
+        >
           {error}
         </div>
       )}
       {syncableCount > 0 && (
         <div className="mb-3 flex justify-end">
-          <button
+          <AdminButton
+            variant="neutral"
             onClick={() => void handleSyncAll()}
             disabled={syncingAll}
-            className="rounded-md border border-border bg-card px-4 py-1.5 text-xs font-medium text-text shadow-push-sm transition-all hover:bg-subtle active:translate-y-[2px] active:shadow-push-active disabled:pointer-events-none disabled:opacity-50"
           >
-            {syncingAll ? "Syncing..." : `Sync All (${syncableCount})`}
-          </button>
+            {syncingAll
+              ? t("actions.syncAllBusy")
+              : t("actions.syncAll", { count: syncableCount })}
+          </AdminButton>
         </div>
       )}
-      <table className="w-full text-sm">
-        <thead>
-          <tr className="border-b border-border text-left text-xs uppercase tracking-wider text-text-3">
-            <th className="pb-2 pr-4 font-medium">Achievement</th>
-            <th className="pb-2 pr-4 font-medium">Status</th>
-            <th className="pb-2 pr-4 font-medium">Collection</th>
-            <th className="pb-2 font-medium">Action</th>
-          </tr>
-        </thead>
-        <tbody className="divide-y divide-border">
-          {achievements.map((ach) => {
-            const isSyncing = syncing === ach.contentId;
-            const canDeploy =
-              ach.onChainStatus === "not_deployed" &&
-              ach.missingFields.length === 0;
-            const needsCollectionRecovery =
-              ach.onChainStatus === "synced" && !ach.collectionAddress;
+      <AdminTableShell
+        columns={[
+          { key: "achievement", label: t("table.achievement") },
+          { key: "status", label: t("table.status") },
+          { key: "collection", label: t("table.collection") },
+          { key: "action", label: t("table.action"), align: "right" },
+        ]}
+      >
+        {achievements.map((ach) => {
+          const isSyncing = syncing === ach.contentId;
+          const canDeploy =
+            ach.onChainStatus === "not_deployed" &&
+            ach.missingFields.length === 0;
+          const needsCollectionRecovery =
+            ach.onChainStatus === "synced" && !ach.collectionAddress;
 
-            return (
-              <tr
-                key={ach.contentId}
-                className="transition-colors hover:bg-subtle"
-              >
-                <td className="py-3 pr-4">
-                  <div className="font-medium text-text">{ach.name}</div>
-                  {ach.missingFields.length > 0 && (
-                    <div className="mt-1 text-xs text-streak">
-                      Missing: {ach.missingFields.join(", ")}
-                    </div>
-                  )}
-                </td>
-                <td className="py-3 pr-4">
-                  <StatusBadge status={ach.onChainStatus} />
-                </td>
-                <td className="py-3 pr-4 font-mono text-xs text-text-3">
-                  {ach.collectionAddress
-                    ? `${ach.collectionAddress.slice(0, 8)}...${ach.collectionAddress.slice(-4)}`
-                    : "—"}
-                </td>
-                <td className="py-3">
-                  {(canDeploy || needsCollectionRecovery) && (
-                    <button
-                      onClick={() => void handleSync(ach.contentId)}
-                      disabled={isSyncing}
-                      className="rounded-md bg-primary px-3 py-1 font-display text-xs font-bold text-white shadow-push transition-all duration-100 hover:bg-primary-hover active:translate-y-[3px] active:shadow-push-active disabled:cursor-not-allowed disabled:opacity-50"
-                    >
-                      {isSyncing
-                        ? "..."
-                        : needsCollectionRecovery
-                          ? "Sync"
-                          : "Deploy"}
-                    </button>
-                  )}
-                </td>
-              </tr>
-            );
-          })}
-        </tbody>
-      </table>
+          return (
+            <tr
+              key={ach.contentId}
+              className="transition-colors hover:bg-subtle"
+            >
+              <td className="py-3 pr-4 align-top">
+                <div className="font-medium text-text">{ach.name}</div>
+                {ach.missingFields.length > 0 && (
+                  <div className="mt-1 text-xs text-streak">
+                    {t("missingFields", {
+                      fields: ach.missingFields.join(", "),
+                    })}
+                  </div>
+                )}
+                <AwardRefLine
+                  award={ach.award}
+                  courseTitleById={courseTitleById}
+                  pathTitleById={pathTitleById}
+                />
+              </td>
+              <td className="py-3 pr-4 align-top">
+                <StatusBadge status={ach.onChainStatus} />
+              </td>
+              <td className="py-3 pr-4 align-top font-mono text-xs text-text-3">
+                {ach.collectionAddress
+                  ? `${ach.collectionAddress.slice(0, 8)}...${ach.collectionAddress.slice(-4)}`
+                  : "—"}
+              </td>
+              <td className="py-3 text-right align-top">
+                {(canDeploy || needsCollectionRecovery) && (
+                  <AdminButton
+                    variant="primary"
+                    onClick={() => void handleSync(ach.contentId)}
+                    disabled={isSyncing}
+                  >
+                    {isSyncing
+                      ? t("actions.working")
+                      : needsCollectionRecovery
+                        ? t("actions.sync")
+                        : t("actions.deploy")}
+                  </AdminButton>
+                )}
+              </td>
+            </tr>
+          );
+        })}
+      </AdminTableShell>
     </div>
   );
 }

--- a/apps/web/src/lib/content/__tests__/resolve-refs.test.ts
+++ b/apps/web/src/lib/content/__tests__/resolve-refs.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import { resolveRefs } from "../resolve-refs";
+
+interface Doc {
+  _id: string;
+  title: string;
+}
+
+const byId = new Map<string, Doc>([
+  ["course-a", { _id: "course-a", title: "Course A" }],
+  ["course-b", { _id: "course-b", title: "Course B" }],
+]);
+
+describe("resolveRefs", () => {
+  it("resolves every id that matches the map", () => {
+    const { resolved, dangling } = resolveRefs(["course-a", "course-b"], byId);
+    expect(resolved).toEqual([
+      { _id: "course-a", title: "Course A" },
+      { _id: "course-b", title: "Course B" },
+    ]);
+    expect(dangling).toEqual([]);
+  });
+
+  it("flags an id with no match as dangling instead of silently dropping it", () => {
+    const { resolved, dangling } = resolveRefs(
+      ["course-a", "course-ghost"],
+      byId
+    );
+    expect(resolved).toEqual([{ _id: "course-a", title: "Course A" }]);
+    expect(dangling).toEqual(["course-ghost"]);
+  });
+
+  it("handles an all-dangling list without throwing", () => {
+    const { resolved, dangling } = resolveRefs(["nope", "also-nope"], byId);
+    expect(resolved).toEqual([]);
+    expect(dangling).toEqual(["nope", "also-nope"]);
+  });
+
+  it("returns empty arrays for an empty input", () => {
+    expect(resolveRefs([], byId)).toEqual({ resolved: [], dangling: [] });
+  });
+
+  it("preserves input order for both resolved and dangling ids", () => {
+    const { resolved, dangling } = resolveRefs(
+      ["course-b", "ghost-1", "course-a", "ghost-2"],
+      byId
+    );
+    expect(resolved.map((d) => d._id)).toEqual(["course-b", "course-a"]);
+    expect(dangling).toEqual(["ghost-1", "ghost-2"]);
+  });
+});

--- a/apps/web/src/lib/content/queries.ts
+++ b/apps/web/src/lib/content/queries.ts
@@ -11,6 +11,7 @@ import {
 } from "./deployments";
 import {
   countCourseLessons,
+  parseAward,
   projectAchievement,
   projectCourse,
   projectCourseSummary,
@@ -20,6 +21,7 @@ import {
   projectQuestData,
   projectRecommended,
 } from "./project";
+import { resolveRefs } from "./resolve-refs";
 import {
   achievementsById,
   coursesById,
@@ -505,6 +507,13 @@ export interface AdminAchievement {
   } | null;
   /** See {@link AdminCourse.deploymentReadFailed}. */
   deploymentReadFailed?: boolean;
+  /**
+   * The achievement's declarative unlock rule (#513 WS-C) — lets the admin
+   * Content tab optionally surface `award.course`/`award.path` next to the
+   * achievement, instead of only its own status. `null` for a pre-sync/legacy
+   * doc, same as {@link DeployedAchievement.award}.
+   */
+  award: AwardT | null;
 }
 
 /** Resolve a course's `prerequisiteCourse` ref to its `{_id, slug, title}` summary. */
@@ -598,6 +607,49 @@ export async function getLearningPathsForAdmin(): Promise<AdminLearningPath[]> {
   }));
 }
 
+export interface AdminLearningPathCourseRef {
+  _id: string;
+  title: string;
+  slug: string;
+}
+
+export interface AdminLearningPathWithRefs extends AdminLearningPath {
+  /** `courseIds` resolved to display info, in path order. */
+  resolvedCourses: AdminLearningPathCourseRef[];
+  /**
+   * `courseIds` entries that matched no course in the bundle (#513 WS-C). The
+   * plain `courseIds` array from {@link getLearningPathsForAdmin} already
+   * includes these — `pathCourseRefIds` only drops malformed ref *objects*,
+   * not refs that point at a nonexistent course — so without this the admin
+   * Paths view would render them as blanks instead of flagging the break.
+   */
+  danglingCourseIds: string[];
+}
+
+/**
+ * {@link getLearningPathsForAdmin}, with each path's course refs resolved
+ * against the bundle via {@link resolveRefs} instead of silently dropped. The
+ * admin Paths view (#513 WS-C) needs course titles to display, and needs to
+ * flag loudly — not drop — any ref a path carries that no longer resolves.
+ */
+export async function getLearningPathsForAdminWithRefs(): Promise<
+  AdminLearningPathWithRefs[]
+> {
+  const paths = await getLearningPathsForAdmin();
+  return paths.map((p) => {
+    const { resolved, dangling } = resolveRefs(p.courseIds, coursesById);
+    return {
+      ...p,
+      resolvedCourses: resolved.map((c) => ({
+        _id: c._id,
+        title: str(c.title) as string,
+        slug: c.slug.current,
+      })),
+      danglingCourseIds: dangling,
+    };
+  });
+}
+
 function toAdminAchievement(
   a: AchievementDoc,
   dep: OnchainDeploymentRow | null,
@@ -619,6 +671,7 @@ function toAdminAchievement(
         }
       : null,
     deploymentReadFailed,
+    award: parseAward(a.award),
   };
 }
 

--- a/apps/web/src/lib/content/resolve-refs.ts
+++ b/apps/web/src/lib/content/resolve-refs.ts
@@ -1,0 +1,38 @@
+/**
+ * Generic "resolve a ref id against a bundle map" helper (#513 WS-C).
+ *
+ * No such helper existed before this: `courseLessonDocs` and `pathCourseRefIds`
+ * (`./queries.ts`) each dereference weak refs by hand and SILENTLY DROP any id
+ * that doesn't resolve — fine for the public catalog (a dangling ref should
+ * never surface to learners), wrong for an admin content view, where a broken
+ * ref is exactly the kind of authoring mistake an operator needs to see.
+ *
+ * This is intentionally content-agnostic (no import of the bundle store) so it
+ * has zero server-only dependencies and is trivial to unit test: callers pass
+ * whichever `ReadonlyMap<string, TDoc>` they need resolved against (courses,
+ * lessons, paths, ...).
+ */
+
+export interface RefResolution<TDoc> {
+  /** Docs the ids resolved to, in input order. */
+  resolved: TDoc[];
+  /** Ids that matched nothing in `byId` — surface these loudly, never drop them. */
+  dangling: string[];
+}
+
+export function resolveRefs<TDoc>(
+  ids: readonly string[],
+  byId: ReadonlyMap<string, TDoc>
+): RefResolution<TDoc> {
+  const resolved: TDoc[] = [];
+  const dangling: string[] = [];
+  for (const id of ids) {
+    const doc = byId.get(id);
+    if (doc) {
+      resolved.push(doc);
+    } else {
+      dangling.push(id);
+    }
+  }
+  return { resolved, dangling };
+}

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -842,7 +842,8 @@
       "courses": "Courses",
       "moderation": "Moderation",
       "pendingFlags": "{count, plural, one {# pending flag} other {# pending flags}}",
-      "status": "Status"
+      "status": "Status",
+      "content": "Content"
     },
     "counts": {
       "courses": "Courses",
@@ -851,7 +852,8 @@
     "screens": {
       "courses": "Courses",
       "moderation": "Community Moderation",
-      "status": "Program Status"
+      "status": "Program Status",
+      "content": "Content"
     },
     "coursesScreen": {
       "intro": {
@@ -934,9 +936,7 @@
     },
     "deployScreen": {
       "coursesHeading": "Courses",
-      "achievementsHeading": "Achievements",
       "noCourses": "No courses in the content bundle.",
-      "noAchievements": "No achievements in the content bundle.",
       "missingFields": "Missing: {fields}",
       "table": {
         "course": "Course",
@@ -1044,6 +1044,82 @@
           "indeterminateRecovery": "The recreate failed before a result was confirmed — the course may be intact or mid-recreate. Do NOT retry blindly. Refresh the admin status screen to check whether the course PDA exists before acting.",
           "close": "Close"
         }
+      }
+    },
+    "contentScreen": {
+      "intro": "Read-only views over the content bundle: quests, achievements, and learning paths. Achievements is the one surface here with an on-chain sync action.",
+      "tabs": {
+        "quests": "Quests",
+        "achievements": "Achievements",
+        "paths": "Paths"
+      },
+      "pin": {
+        "pinned": "Bundle pinned",
+        "drifted": "Bundle drifted",
+        "unknown": "Drift unknown",
+        "unavailable": "Pin status unavailable",
+        "behind": "{count, plural, one {# commit behind} other {# commits behind}}"
+      },
+      "quests": {
+        "heading": "Quests",
+        "description": "Daily quest reward config from the content bundle. Read-only — quests have no on-chain component.",
+        "empty": "No quests in the content bundle.",
+        "table": {
+          "quest": "Quest",
+          "type": "Type",
+          "xpReward": "XP",
+          "targetValue": "Target",
+          "resetType": "Reset",
+          "icon": "Icon"
+        },
+        "type": {
+          "lesson": "Lesson",
+          "lesson_batch": "Lesson batch",
+          "challenge": "Challenge",
+          "login_streak": "Login streak",
+          "module": "Module"
+        },
+        "resetType": {
+          "daily": "Daily",
+          "multi_day": "Multi-day"
+        }
+      },
+      "achievements": {
+        "heading": "Achievements",
+        "empty": "No achievements in the content bundle.",
+        "table": {
+          "achievement": "Achievement",
+          "status": "Status",
+          "collection": "Collection",
+          "action": "Action"
+        },
+        "missingFields": "Missing: {fields}",
+        "actions": {
+          "deploy": "Deploy",
+          "sync": "Sync",
+          "working": "…",
+          "syncAll": "Sync All ({count})",
+          "syncAllBusy": "Syncing…"
+        },
+        "errors": {
+          "sync": "Sync failed",
+          "syncFor": "Sync failed for {name}"
+        },
+        "awardCourse": "Unlocks with course: {title}",
+        "awardPath": "Unlocks with path: {title}",
+        "awardMissingBadge": "missing",
+        "awardMissingRef": "Unresolved ref: {id}"
+      },
+      "paths": {
+        "heading": "Paths",
+        "empty": "No learning paths in the content bundle.",
+        "table": {
+          "path": "Path",
+          "courses": "Course sequence"
+        },
+        "noCourses": "No courses in this path.",
+        "danglingBadge": "missing",
+        "danglingCount": "{count, plural, one {# dangling course reference} other {# dangling course references}}"
       }
     },
     "statusBadge": {

--- a/apps/web/src/messages/es.json
+++ b/apps/web/src/messages/es.json
@@ -842,7 +842,8 @@
       "courses": "Cursos",
       "moderation": "Moderación",
       "pendingFlags": "{count, plural, one {# reporte pendiente} other {# reportes pendientes}}",
-      "status": "Estado"
+      "status": "Estado",
+      "content": "Contenido"
     },
     "counts": {
       "courses": "Cursos",
@@ -851,7 +852,8 @@
     "screens": {
       "courses": "Cursos",
       "moderation": "Moderación de la comunidad",
-      "status": "Estado del programa"
+      "status": "Estado del programa",
+      "content": "Contenido"
     },
     "coursesScreen": {
       "intro": {
@@ -934,9 +936,7 @@
     },
     "deployScreen": {
       "coursesHeading": "Cursos",
-      "achievementsHeading": "Logros",
       "noCourses": "No hay cursos en el paquete de contenido.",
-      "noAchievements": "No hay logros en el paquete de contenido.",
       "missingFields": "Faltan: {fields}",
       "table": {
         "course": "Curso",
@@ -1044,6 +1044,82 @@
           "indeterminateRecovery": "La recreación falló antes de confirmar un resultado — el curso puede estar intacto o a medio recrear. NO reintentes a ciegas. Actualiza la pantalla de estado de administración para comprobar si el PDA del curso existe antes de actuar.",
           "close": "Cerrar"
         }
+      }
+    },
+    "contentScreen": {
+      "intro": "Vistas de solo lectura sobre el paquete de contenido: misiones, logros y rutas de aprendizaje. Logros es la única superficie aquí con una acción de sincronización on-chain.",
+      "tabs": {
+        "quests": "Misiones",
+        "achievements": "Logros",
+        "paths": "Rutas"
+      },
+      "pin": {
+        "pinned": "Paquete fijado",
+        "drifted": "Paquete desactualizado",
+        "unknown": "Desfase desconocido",
+        "unavailable": "Estado de fijación no disponible",
+        "behind": "{count, plural, one {# commit por detrás} other {# commits por detrás}}"
+      },
+      "quests": {
+        "heading": "Misiones",
+        "description": "Configuración de recompensas de misiones diarias desde el paquete de contenido. Solo lectura — las misiones no tienen componente on-chain.",
+        "empty": "No hay misiones en el paquete de contenido.",
+        "table": {
+          "quest": "Misión",
+          "type": "Tipo",
+          "xpReward": "XP",
+          "targetValue": "Objetivo",
+          "resetType": "Reinicio",
+          "icon": "Icono"
+        },
+        "type": {
+          "lesson": "Lección",
+          "lesson_batch": "Lote de lecciones",
+          "challenge": "Desafío",
+          "login_streak": "Racha de inicio de sesión",
+          "module": "Módulo"
+        },
+        "resetType": {
+          "daily": "Diario",
+          "multi_day": "Multidía"
+        }
+      },
+      "achievements": {
+        "heading": "Logros",
+        "empty": "No hay logros en el paquete de contenido.",
+        "table": {
+          "achievement": "Logro",
+          "status": "Estado",
+          "collection": "Colección",
+          "action": "Acción"
+        },
+        "missingFields": "Faltan: {fields}",
+        "actions": {
+          "deploy": "Desplegar",
+          "sync": "Sincronizar",
+          "working": "…",
+          "syncAll": "Sincronizar todo ({count})",
+          "syncAllBusy": "Sincronizando…"
+        },
+        "errors": {
+          "sync": "Falló la sincronización",
+          "syncFor": "Falló la sincronización de {name}"
+        },
+        "awardCourse": "Se desbloquea con el curso: {title}",
+        "awardPath": "Se desbloquea con la ruta: {title}",
+        "awardMissingBadge": "falta",
+        "awardMissingRef": "Referencia no resuelta: {id}"
+      },
+      "paths": {
+        "heading": "Rutas",
+        "empty": "No hay rutas de aprendizaje en el paquete de contenido.",
+        "table": {
+          "path": "Ruta",
+          "courses": "Secuencia de cursos"
+        },
+        "noCourses": "Esta ruta no tiene cursos.",
+        "danglingBadge": "falta",
+        "danglingCount": "{count, plural, one {# referencia de curso rota} other {# referencias de curso rotas}}"
       }
     },
     "statusBadge": {

--- a/apps/web/src/messages/pt-BR.json
+++ b/apps/web/src/messages/pt-BR.json
@@ -842,7 +842,8 @@
       "courses": "Cursos",
       "moderation": "Moderação",
       "pendingFlags": "{count, plural, one {# denúncia pendente} other {# denúncias pendentes}}",
-      "status": "Status"
+      "status": "Status",
+      "content": "Conteúdo"
     },
     "counts": {
       "courses": "Cursos",
@@ -851,7 +852,8 @@
     "screens": {
       "courses": "Cursos",
       "moderation": "Moderação da comunidade",
-      "status": "Status do programa"
+      "status": "Status do programa",
+      "content": "Conteúdo"
     },
     "coursesScreen": {
       "intro": {
@@ -934,9 +936,7 @@
     },
     "deployScreen": {
       "coursesHeading": "Cursos",
-      "achievementsHeading": "Conquistas",
       "noCourses": "Nenhum curso no pacote de conteúdo.",
-      "noAchievements": "Nenhuma conquista no pacote de conteúdo.",
       "missingFields": "Faltando: {fields}",
       "table": {
         "course": "Curso",
@@ -1044,6 +1044,82 @@
           "indeterminateRecovery": "A recriação falhou antes de um resultado ser confirmado — o curso pode estar intacto ou no meio da recriação. NÃO tente novamente às cegas. Atualize a tela de status do admin para verificar se o PDA do curso existe antes de agir.",
           "close": "Fechar"
         }
+      }
+    },
+    "contentScreen": {
+      "intro": "Visões somente leitura sobre o pacote de conteúdo: missões, conquistas e trilhas de aprendizagem. Conquistas é a única superfície aqui com uma ação de sincronização on-chain.",
+      "tabs": {
+        "quests": "Missões",
+        "achievements": "Conquistas",
+        "paths": "Trilhas"
+      },
+      "pin": {
+        "pinned": "Pacote fixado",
+        "drifted": "Pacote desatualizado",
+        "unknown": "Divergência desconhecida",
+        "unavailable": "Status do pin indisponível",
+        "behind": "{count, plural, one {# commit atrás} other {# commits atrás}}"
+      },
+      "quests": {
+        "heading": "Missões",
+        "description": "Configuração de recompensas das missões diárias a partir do pacote de conteúdo. Somente leitura — missões não têm componente on-chain.",
+        "empty": "Nenhuma missão no pacote de conteúdo.",
+        "table": {
+          "quest": "Missão",
+          "type": "Tipo",
+          "xpReward": "XP",
+          "targetValue": "Meta",
+          "resetType": "Reinício",
+          "icon": "Ícone"
+        },
+        "type": {
+          "lesson": "Lição",
+          "lesson_batch": "Lote de lições",
+          "challenge": "Desafio",
+          "login_streak": "Sequência de login",
+          "module": "Módulo"
+        },
+        "resetType": {
+          "daily": "Diário",
+          "multi_day": "Multidias"
+        }
+      },
+      "achievements": {
+        "heading": "Conquistas",
+        "empty": "Nenhuma conquista no pacote de conteúdo.",
+        "table": {
+          "achievement": "Conquista",
+          "status": "Status",
+          "collection": "Coleção",
+          "action": "Ação"
+        },
+        "missingFields": "Faltando: {fields}",
+        "actions": {
+          "deploy": "Implantar",
+          "sync": "Sincronizar",
+          "working": "…",
+          "syncAll": "Sincronizar tudo ({count})",
+          "syncAllBusy": "Sincronizando…"
+        },
+        "errors": {
+          "sync": "Falha na sincronização",
+          "syncFor": "Falha na sincronização de {name}"
+        },
+        "awardCourse": "Desbloqueia com o curso: {title}",
+        "awardPath": "Desbloqueia com a trilha: {title}",
+        "awardMissingBadge": "faltando",
+        "awardMissingRef": "Referência não resolvida: {id}"
+      },
+      "paths": {
+        "heading": "Trilhas",
+        "empty": "Nenhuma trilha de aprendizagem no pacote de conteúdo.",
+        "table": {
+          "path": "Trilha",
+          "courses": "Sequência de cursos"
+        },
+        "noCourses": "Esta trilha não tem cursos.",
+        "danglingBadge": "faltando",
+        "danglingCount": "{count, plural, one {# referência de curso quebrada} other {# referências de curso quebradas}}"
       }
     },
     "statusBadge": {


### PR DESCRIPTION
## Summary

SAFE-lane. Builds on WS-A's primitives (#517, merged): `AdminCard`, `AdminTableShell`, `AdminBadge`, `AdminButton`, `AdminDisclosure`. Adds one new "Content" tab to the admin nav with three read-only sub-views over the committed content bundle — Quests, Achievements, Paths — switched via the existing Radix `Tabs` primitive.

- **Nav**: appended `"content"` to `admin-nav.tsx`'s `SECTIONS` + `admin.nav.content` / `admin.screens.content` i18n (en/es/pt-BR). New route: `apps/web/src/app/[locale]/admin/content/`.
- **Achievements sub-view**: extracted `components/admin/achievement-sync-table.tsx` out of `courses/deploy-client.tsx` (its 2nd section) into `admin/content/achievements-subview.tsx`. Reuses the same `useAdminStatus()` hook/response — no new fetch. The `/api/admin/achievements/sync` route and the sync/sync-all behavior are byte-for-byte unchanged; only where the table renders, its markup (now `AdminTableShell`/`AdminButton` instead of hand-rolled), and its strings (now i18n'd — folds in #452) changed. Optionally resolves `award.course`/`award.path` to a title (new additive `award` field threaded through `AdminAchievement` → `AchievementStatus` → `/api/admin/status`), and loudly flags ("missing" danger badge + raw id) when a ref doesn't resolve, instead of hiding it.
- **Quests sub-view** (read-only, zero on-chain): `getAllQuests()` → a table of `type` / `xpReward` / `targetValue` / `resetType` / `icon` per quest. No sync affordance — quests have no on-chain component.
- **Paths sub-view** (read-only, zero on-chain): `getLearningPathsForAdminWithRefs()` (new, additive — wraps the existing `getLearningPathsForAdmin()` unchanged) shows each path's resolved course sequence.
- **Dangling-ref detection (net-new)**: `lib/content/resolve-refs.ts` — a small generic `resolveRefs(ids, byId) → {resolved, dangling}` helper. No such helper existed; `courseLessonDocs`/`pathCourseRefIds` silently drop unresolvable refs today. The Paths view uses it to render resolved course chips normally and flag any dangling ref with an `AdminBadge tone="danger"` + a visible pluralized count — never silently dropped.
- **Pin/drift indicator**: a compact badge on the Content tab reusing the *existing* `GET /api/admin/publish/pin` verdict (same one bundle SHA `PublishPinClient` already shows) — no new endpoint.

## Test plan
- [x] `pnpm vitest run` — 96 files / 829 tests passing (32 new: nav update, `resolve-refs` unit tests, quests/paths/achievements-subview/content-tabs/pin-status-badge/page composition tests, and a dedicated `achievement-sync-table` test proving sync/sync-all + award-ref rendering survive the relocation)
- [x] `tsc --noEmit` — clean
- [x] `eslint` on every touched/created file — 0 errors, 0 warnings
- [x] i18n parity test (`src/messages/__tests__/parity.test.ts`) — en/es/pt-BR key sets match