### PR TITLE
feat(reset): read-only v-next reset verification harness (B4, #356)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
     "compile-content": "tsx scripts/compile-content.ts",
+    "reset-verify": "tsx scripts/reset-verify.ts",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/apps/web/scripts/reset-verify.ts
+++ b/apps/web/scripts/reset-verify.ts
@@ -1,0 +1,160 @@
+#!/usr/bin/env tsx
+/**
+ * reset-verify.ts — the second-observer CLI for the B4 read-only reset
+ * verification harness (#356).
+ *
+ * SAFE lane: this script only reads (`getProgramAccounts`) and diffs JSON —
+ * it never builds, signs, or sends a transaction, and never touches the
+ * close+recreate path (`src/lib/admin/recreate-course.ts`).
+ *
+ * Usage (run from apps/web):
+ *
+ *   pnpm tsx scripts/reset-verify.ts snapshot --out pre.json
+ *     [--rpc <url>] [--program <programId>]
+ *
+ *     Reads every Course + Enrollment account live under the program and
+ *     writes the structured snapshot as JSON to --out (or stdout if omitted).
+ *
+ *   pnpm tsx scripts/reset-verify.ts diff --pre pre.json --post post.json \
+ *     --expected expected.json [--out result.json]
+ *
+ *     Diffs two saved snapshots against the expected per-course post-recreate
+ *     values (see `ExpectedByCourseId` in reset-verify.ts) and prints/writes
+ *     the structured pass/fail result. Exits 1 if any invariant failed, so it
+ *     can gate a CI step or a human operator's "next course" decision.
+ *
+ *     `expected.json` shape: { "<courseId>": { "expectedSize": 253,
+ *     "expectedCreator": "<base58>", "expectedRewardXp": 30 }, ... }
+ *
+ * Env (no key required — read-only over any RPC):
+ *   --rpc / SOLANA_RPC_URL / NEXT_PUBLIC_SOLANA_RPC_URL, defaulting to the
+ *   public devnet RPC.
+ *   --program / NEXT_PUBLIC_PROGRAM_ID (required — no hardcoded program id).
+ */
+import * as fs from "node:fs";
+import { Connection, PublicKey } from "@solana/web3.js";
+import {
+  snapshotOnChainState,
+  verifyReset,
+  type ExpectedByCourseId,
+  type ResetSnapshot,
+} from "../src/lib/admin/reset-verify";
+
+const DEFAULT_DEVNET_RPC = "https://api.devnet.solana.com";
+
+interface ParsedArgs {
+  command: string;
+  flags: Record<string, string>;
+}
+
+function parseArgs(argv: string[]): ParsedArgs {
+  const [command, ...rest] = argv;
+  const flags: Record<string, string> = {};
+  for (let i = 0; i < rest.length; i++) {
+    const token = rest[i];
+    if (token?.startsWith("--")) {
+      const key = token.slice(2);
+      const value = rest[i + 1];
+      if (value === undefined || value.startsWith("--")) {
+        flags[key] = "true";
+      } else {
+        flags[key] = value;
+        i++;
+      }
+    }
+  }
+  return { command: command ?? "", flags };
+}
+
+function resolveRpcUrl(flags: Record<string, string>): string {
+  return (
+    flags.rpc ??
+    process.env.SOLANA_RPC_URL ??
+    process.env.NEXT_PUBLIC_SOLANA_RPC_URL ??
+    DEFAULT_DEVNET_RPC
+  );
+}
+
+function resolveProgramId(flags: Record<string, string>): PublicKey {
+  const raw = flags.program ?? process.env.NEXT_PUBLIC_PROGRAM_ID;
+  if (!raw) {
+    throw new Error(
+      "No program id given — pass --program <id> or set NEXT_PUBLIC_PROGRAM_ID"
+    );
+  }
+  return new PublicKey(raw);
+}
+
+function writeOutput(json: unknown, outPath: string | undefined): void {
+  const text = JSON.stringify(json, null, 2);
+  if (outPath) {
+    fs.writeFileSync(outPath, `${text}\n`, "utf8");
+    console.error(`Wrote ${outPath}`);
+  } else {
+    console.log(text);
+  }
+}
+
+function readJsonFile<T>(path: string): T {
+  return JSON.parse(fs.readFileSync(path, "utf8")) as T;
+}
+
+async function runSnapshot(flags: Record<string, string>): Promise<void> {
+  const rpcUrl = resolveRpcUrl(flags);
+  const programId = resolveProgramId(flags);
+  console.error(`Snapshotting program ${programId.toBase58()} via ${rpcUrl}…`);
+  const connection = new Connection(rpcUrl, "confirmed");
+  const snapshot = await snapshotOnChainState(connection, programId);
+  console.error(
+    `Courses: ${snapshot.courses.length} decoded, ${snapshot.undecodedCourses.length} undecoded. ` +
+      `Enrollments: ${snapshot.enrollments.length} decoded, ${snapshot.undecodedEnrollments.length} undecoded.`
+  );
+  writeOutput(snapshot, flags.out);
+}
+
+function runDiff(flags: Record<string, string>): void {
+  if (!flags.pre || !flags.post || !flags.expected) {
+    throw new Error(
+      "diff requires --pre <file> --post <file> --expected <file>"
+    );
+  }
+  const pre = readJsonFile<ResetSnapshot>(flags.pre);
+  const post = readJsonFile<ResetSnapshot>(flags.post);
+  const expected = readJsonFile<ExpectedByCourseId>(flags.expected);
+
+  const result = verifyReset(pre, post, expected);
+  writeOutput(result, flags.out);
+
+  if (!result.ok) {
+    console.error(
+      `\n${result.failures.length} invariant failure(s) — see "failures" above.`
+    );
+    process.exitCode = 1;
+  } else {
+    console.error("\nAll invariants passed.");
+  }
+}
+
+async function main(): Promise<void> {
+  const { command, flags } = parseArgs(process.argv.slice(2));
+  switch (command) {
+    case "snapshot":
+      await runSnapshot(flags);
+      break;
+    case "diff":
+      runDiff(flags);
+      break;
+    default:
+      console.error(
+        "Usage: tsx scripts/reset-verify.ts <snapshot|diff> [flags]\n" +
+          "  snapshot --out <file> [--rpc <url>] [--program <id>]\n" +
+          "  diff --pre <file> --post <file> --expected <file> [--out <file>]"
+      );
+      process.exitCode = 1;
+  }
+}
+
+main().catch((err) => {
+  console.error(err instanceof Error ? err.message : String(err));
+  process.exitCode = 1;
+});

--- a/apps/web/src/lib/admin/__tests__/reset-verify.test.ts
+++ b/apps/web/src/lib/admin/__tests__/reset-verify.test.ts
@@ -1,0 +1,540 @@
+import { describe, it, expect, vi } from "vitest";
+import { PublicKey } from "@solana/web3.js";
+import type { Idl } from "@coral-xyz/anchor";
+import { BorshCoder } from "@coral-xyz/anchor";
+import BN from "bn.js";
+import IDL from "../../solana/idl/superteam_academy.json";
+import VNEXT_IDL from "../../solana/idl/superteam_academy_vnext.json";
+import { COURSE_SIZE_V1, COURSE_SIZE_VNEXT } from "../../solana/academy-reads";
+import {
+  snapshotOnChainState,
+  verifyReset,
+  type CourseSnapshot,
+  type EnrollmentSnapshot,
+  type ExpectedByCourseId,
+  type ResetSnapshot,
+} from "../reset-verify";
+
+// -----------------------------------------------------------------------------
+// Shared fixture helpers
+// -----------------------------------------------------------------------------
+
+const CREATOR = "Creator11111111111111111111111111111111111";
+const OTHER_CREATOR = "Instructor111111111111111111111111111111111";
+const COURSE_PDA = "CoursePda111111111111111111111111111111111";
+const OTHER_COURSE_PDA = "OtherCoursePda11111111111111111111111111111";
+
+/**
+ * Reproduces the module's `maskToHex` format independently (64 hex chars,
+ * word[3] first) from a plain list of set-bit indices (0-255) — this is the
+ * documented contract of `activeLessonsOrCount` / `lessonFlags`, which any
+ * real caller (B3, the CLI's expected.json) has to construct the same way.
+ */
+function bitsToHex(bits: number[]): string {
+  const words: [bigint, bigint, bigint, bigint] = [0n, 0n, 0n, 0n];
+  for (const bit of bits) {
+    const wordIndex = Math.floor(bit / 64) as 0 | 1 | 2 | 3;
+    words[wordIndex] |= 1n << BigInt(bit % 64);
+  }
+  return [words[3], words[2], words[1], words[0]]
+    .map((w) => w.toString(16).padStart(16, "0"))
+    .join("");
+}
+
+function course(overrides: Partial<CourseSnapshot> = {}): CourseSnapshot {
+  return {
+    courseId: "course-rust",
+    coursePda: COURSE_PDA,
+    sizeBytes: COURSE_SIZE_VNEXT,
+    creator: CREATOR,
+    creatorRewardXp: 30,
+    liveLessonCount: 3,
+    activeLessonsOrCount: bitsToHex([0, 1, 2]),
+    contentTxId: "00".repeat(32),
+    ...overrides,
+  };
+}
+
+function enrollment(
+  overrides: Partial<EnrollmentSnapshot> = {}
+): EnrollmentSnapshot {
+  return {
+    address: "Enrollment1111111111111111111111111111111111",
+    course: COURSE_PDA,
+    lessonFlags: bitsToHex([0, 1]),
+    ...overrides,
+  };
+}
+
+function snapshot(overrides: Partial<ResetSnapshot> = {}): ResetSnapshot {
+  return {
+    courses: [],
+    enrollments: [],
+    undecodedCourses: [],
+    undecodedEnrollments: [],
+    ...overrides,
+  };
+}
+
+const EXPECTED: ExpectedByCourseId = {
+  "course-rust": {
+    expectedSize: COURSE_SIZE_VNEXT,
+    expectedCreator: CREATOR,
+    expectedRewardXp: 30,
+  },
+};
+
+// -----------------------------------------------------------------------------
+// verifyReset — the invariant/second-observer backbone
+// -----------------------------------------------------------------------------
+
+describe("verifyReset — (a) clean recreate", () => {
+  it("passes with no failures when every invariant holds", () => {
+    const pre = snapshot({
+      courses: [
+        course({
+          sizeBytes: COURSE_SIZE_V1,
+          creatorRewardXp: 750,
+          liveLessonCount: 3,
+          activeLessonsOrCount: bitsToHex([0, 1, 2]),
+        }),
+      ],
+      enrollments: [enrollment({ lessonFlags: bitsToHex([0, 1]) })],
+    });
+    const post = snapshot({
+      courses: [course()], // 253 bytes, creatorRewardXp 30, popcount 3
+      enrollments: [enrollment({ lessonFlags: bitsToHex([0, 1]) })],
+    });
+
+    const result = verifyReset(pre, post, EXPECTED);
+
+    expect(result.ok).toBe(true);
+    expect(result.failures).toEqual([]);
+    expect(result.perCourse).toEqual([
+      { courseId: "course-rust", ok: true, failures: [] },
+    ]);
+    expect(result.perEnrollment).toEqual([
+      { address: enrollment().address, ok: true, failures: [] },
+    ]);
+  });
+});
+
+describe("verifyReset — (b) H3 popcount: widened lesson count", () => {
+  it("flags a course whose post popcount exceeds the pre liveLessonCount", () => {
+    const pre = snapshot({
+      courses: [
+        course({
+          liveLessonCount: 3,
+          activeLessonsOrCount: bitsToHex([0, 1, 2]),
+        }),
+      ],
+    });
+    const post = snapshot({
+      // A 4th bit turned "live" that was never live pre-reset — popcount 4 > 3.
+      courses: [
+        course({
+          liveLessonCount: 4,
+          activeLessonsOrCount: bitsToHex([0, 1, 2, 3]),
+        }),
+      ],
+    });
+
+    const result = verifyReset(pre, post, EXPECTED);
+
+    expect(result.ok).toBe(false);
+    const courseResult = result.perCourse[0];
+    expect(courseResult?.ok).toBe(false);
+    expect(courseResult?.failures.some((f) => f.includes("[H3]"))).toBe(true);
+    expect(courseResult?.failures.some((f) => f.includes("widened"))).toBe(
+      true
+    );
+  });
+
+  it("flags a course whose post popcount is narrower than the pre liveLessonCount", () => {
+    const pre = snapshot({
+      courses: [
+        course({
+          liveLessonCount: 3,
+          activeLessonsOrCount: bitsToHex([0, 1, 2]),
+        }),
+      ],
+    });
+    const post = snapshot({
+      courses: [
+        course({ liveLessonCount: 2, activeLessonsOrCount: bitsToHex([0, 1]) }),
+      ],
+    });
+
+    const result = verifyReset(pre, post, EXPECTED);
+
+    expect(result.ok).toBe(false);
+    expect(
+      result.perCourse[0]?.failures.some((f) => f.includes("narrowed"))
+    ).toBe(true);
+  });
+});
+
+describe("verifyReset — (c) H3 superset: post mask drops a learner's completed bit", () => {
+  it("flags the course when the post mask no longer covers a pre enrollment's lesson_flags, even with matching popcount", () => {
+    const pre = snapshot({
+      courses: [
+        course({
+          liveLessonCount: 3,
+          activeLessonsOrCount: bitsToHex([0, 1, 2]),
+        }),
+      ],
+      enrollments: [
+        // Learner completed lesson 2 (bit 2) before the reset.
+        enrollment({ lessonFlags: bitsToHex([0, 1, 2]) }),
+      ],
+    });
+    const post = snapshot({
+      // Same popcount (3) as pre — H3a (popcount) alone would NOT catch this —
+      // but bit 2 was swapped for bit 4, so the mask no longer covers the
+      // learner's completed bit 2. Only the superset check catches it.
+      courses: [
+        course({
+          liveLessonCount: 3,
+          activeLessonsOrCount: bitsToHex([0, 1, 4]),
+        }),
+      ],
+      enrollments: [enrollment({ lessonFlags: bitsToHex([0, 1, 2]) })],
+    });
+
+    const result = verifyReset(pre, post, EXPECTED);
+
+    expect(result.ok).toBe(false);
+    const courseResult = result.perCourse[0];
+    expect(courseResult?.ok).toBe(false);
+    expect(
+      courseResult?.failures.some(
+        (f) => f.includes("[H3]") && f.includes(enrollment().address)
+      )
+    ).toBe(true);
+    // The enrollment itself is untouched (same address, same flags) — this is
+    // purely a course-level H3 violation, not an enrollment drift.
+    expect(result.perEnrollment[0]?.ok).toBe(true);
+  });
+
+  it("does not flag H3 when the post mask fully covers every learner's bits (a strict superset is fine)", () => {
+    const pre = snapshot({
+      courses: [
+        course({ liveLessonCount: 2, activeLessonsOrCount: bitsToHex([0, 1]) }),
+      ],
+      enrollments: [enrollment({ lessonFlags: bitsToHex([0, 1]) })],
+    });
+    // This scenario intentionally violates H3a (popcount 2 -> 2 must match —
+    // here we keep popcount equal to isolate the superset check as passing).
+    const post = snapshot({
+      courses: [
+        course({ liveLessonCount: 2, activeLessonsOrCount: bitsToHex([0, 1]) }),
+      ],
+      enrollments: [enrollment({ lessonFlags: bitsToHex([0, 1]) })],
+    });
+
+    const result = verifyReset(pre, post, EXPECTED);
+    expect(result.ok).toBe(true);
+  });
+});
+
+describe("verifyReset — (d) enrollment lessonFlags drift", () => {
+  it("flags an enrollment whose lessonFlags changed between pre and post", () => {
+    const pre = snapshot({
+      courses: [course()],
+      enrollments: [enrollment({ lessonFlags: bitsToHex([0, 1]) })],
+    });
+    const post = snapshot({
+      courses: [course()],
+      // Same address, DIFFERENT flags — must never happen (recreate never
+      // touches Enrollment PDAs), so this is flagged.
+      enrollments: [enrollment({ lessonFlags: bitsToHex([0, 1, 2]) })],
+    });
+
+    const result = verifyReset(pre, post, EXPECTED);
+
+    expect(result.ok).toBe(false);
+    const enrollmentResult = result.perEnrollment[0];
+    expect(enrollmentResult?.ok).toBe(false);
+    expect(
+      enrollmentResult?.failures.some((f) => f.includes("lessonFlags changed"))
+    ).toBe(true);
+  });
+
+  it("flags an enrollment whose course field changed", () => {
+    const pre = snapshot({
+      courses: [course()],
+      enrollments: [enrollment({ course: COURSE_PDA })],
+    });
+    const post = snapshot({
+      courses: [course()],
+      enrollments: [enrollment({ course: OTHER_COURSE_PDA })],
+    });
+
+    const result = verifyReset(pre, post, EXPECTED);
+
+    expect(result.ok).toBe(false);
+    expect(
+      result.perEnrollment[0]?.failures.some((f) =>
+        f.includes("course changed")
+      )
+    ).toBe(true);
+  });
+});
+
+describe("verifyReset — (e) missing enrollment", () => {
+  it("flags a pre enrollment absent from the post snapshot", () => {
+    const pre = snapshot({
+      courses: [course()],
+      enrollments: [enrollment()],
+    });
+    const post = snapshot({
+      courses: [course()],
+      enrollments: [], // dropped
+    });
+
+    const result = verifyReset(pre, post, EXPECTED);
+
+    expect(result.ok).toBe(false);
+    const enrollmentResult = result.perEnrollment[0];
+    expect(enrollmentResult?.ok).toBe(false);
+    expect(
+      enrollmentResult?.failures.some((f) => f.includes("missing from POST"))
+    ).toBe(true);
+  });
+
+  it("never flags a post-only enrollment with no pre counterpart (ordinary new signups)", () => {
+    const pre = snapshot({ courses: [course()], enrollments: [] });
+    const post = snapshot({
+      courses: [course()],
+      enrollments: [
+        enrollment({ address: "BrandNewEnrollment111111111111111111111111" }),
+      ],
+    });
+
+    const result = verifyReset(pre, post, EXPECTED);
+
+    expect(result.ok).toBe(true);
+    expect(result.perEnrollment).toEqual([]);
+  });
+});
+
+describe("verifyReset — (f) wrong creator / reward ≠ 30", () => {
+  it("flags a course whose post creator does not match the expected instructor wallet", () => {
+    const pre = snapshot({ courses: [course()] });
+    const post = snapshot({ courses: [course({ creator: OTHER_CREATOR })] });
+
+    const result = verifyReset(pre, post, EXPECTED);
+
+    expect(result.ok).toBe(false);
+    expect(
+      result.perCourse[0]?.failures.some((f) => f.includes("creator="))
+    ).toBe(true);
+  });
+
+  it("flags a course whose post creatorRewardXp is not 30", () => {
+    const pre = snapshot({ courses: [course()] });
+    const post = snapshot({ courses: [course({ creatorRewardXp: 750 })] });
+
+    const result = verifyReset(pre, post, EXPECTED);
+
+    expect(result.ok).toBe(false);
+    expect(
+      result.perCourse[0]?.failures.some((f) =>
+        f.includes("creatorRewardXp=750")
+      )
+    ).toBe(true);
+  });
+
+  it("flags a course whose post size is not the expected v-next size", () => {
+    const pre = snapshot({ courses: [course()] });
+    const post = snapshot({ courses: [course({ sizeBytes: COURSE_SIZE_V1 })] });
+
+    const result = verifyReset(pre, post, EXPECTED);
+
+    expect(result.ok).toBe(false);
+    expect(
+      result.perCourse[0]?.failures.some((f) => f.includes("sizeBytes="))
+    ).toBe(true);
+  });
+});
+
+describe("verifyReset — fail-closed on missing baseline data", () => {
+  it("flags a course present in `expected` but absent from the POST snapshot", () => {
+    const pre = snapshot({ courses: [course()] });
+    const post = snapshot({ courses: [] });
+
+    const result = verifyReset(pre, post, EXPECTED);
+
+    expect(result.ok).toBe(false);
+    expect(
+      result.perCourse[0]?.failures.some((f) => f.includes("missing from POST"))
+    ).toBe(true);
+  });
+
+  it("flags a course present in `expected` but absent from the PRE snapshot (no baseline to verify H3 against)", () => {
+    const pre = snapshot({ courses: [] });
+    const post = snapshot({ courses: [course()] });
+
+    const result = verifyReset(pre, post, EXPECTED);
+
+    expect(result.ok).toBe(false);
+    expect(
+      result.perCourse[0]?.failures.some((f) => f.includes("missing from PRE"))
+    ).toBe(true);
+  });
+});
+
+// -----------------------------------------------------------------------------
+// snapshotOnChainState — getProgramAccounts + decode plumbing
+// -----------------------------------------------------------------------------
+
+const coderV1 = new BorshCoder(IDL as unknown as Idl);
+const coderVNext = new BorshCoder(VNEXT_IDL as unknown as Idl);
+
+function padToSize(buf: Buffer, size: number): Buffer {
+  const out = Buffer.alloc(size);
+  buf.copy(out);
+  return out;
+}
+
+async function encodeV1Course(): Promise<Buffer> {
+  const raw = await coderV1.accounts.encode("Course", {
+    course_id: "course-v1",
+    creator: PublicKey.unique(),
+    content_tx_id: Array(32).fill(1),
+    version: 1,
+    lesson_count: 5,
+    difficulty: 1,
+    xp_per_lesson: 10,
+    track_id: 0,
+    track_level: 0,
+    prerequisite: null,
+    creator_reward_xp: 30,
+    min_completions_for_reward: 0,
+    total_completions: 0,
+    total_enrollments: 0,
+    is_active: true,
+    created_at: new BN(1),
+    updated_at: new BN(1),
+    collection: PublicKey.unique(),
+    _reserved: Array(8).fill(0),
+    bump: 255,
+  });
+  return padToSize(raw, COURSE_SIZE_V1);
+}
+
+async function encodeVNextCourse(): Promise<Buffer> {
+  const raw = await coderVNext.accounts.encode("Course", {
+    course_id: "course-vnext",
+    creator: PublicKey.unique(),
+    content_tx_id: Array(32).fill(2),
+    version: 1,
+    active_lessons: [new BN(0b111), new BN(0), new BN(0), new BN(0)],
+    difficulty: 1,
+    xp_per_lesson: 10,
+    track_id: 0,
+    track_level: 0,
+    prerequisite: null,
+    creator_reward_xp: 30,
+    total_completions: 0,
+    total_enrollments: 0,
+    is_active: true,
+    created_at: new BN(1),
+    updated_at: new BN(1),
+    collection: PublicKey.unique(),
+    _reserved: Array(8).fill(0),
+    bump: 254,
+  });
+  return padToSize(raw, COURSE_SIZE_VNEXT);
+}
+
+async function encodeEnrollment(courseKey: PublicKey): Promise<Buffer> {
+  const raw = await coderV1.accounts.encode("Enrollment", {
+    course: courseKey,
+    enrolled_at: new BN(1),
+    completed_at: null,
+    lesson_flags: [new BN(0b11), new BN(0), new BN(0), new BN(0)],
+    credential_asset: null,
+    _reserved: Array(4).fill(0),
+    bump: 255,
+  });
+  // Enrollment has no variable-length field, so it is already the exact size.
+  return raw;
+}
+
+describe("snapshotOnChainState", () => {
+  it("decodes both v1 and v-next Course accounts, plus Enrollment accounts, in one snapshot", async () => {
+    const v1Key = PublicKey.unique();
+    const vNextKey = PublicKey.unique();
+    const enrollmentKey = PublicKey.unique();
+
+    const v1Data = await encodeV1Course();
+    const vNextData = await encodeVNextCourse();
+    const enrollmentData = await encodeEnrollment(vNextKey);
+
+    const getProgramAccounts = vi
+      .fn()
+      .mockImplementationOnce(async () => [
+        { pubkey: v1Key, account: { data: v1Data } },
+        { pubkey: vNextKey, account: { data: vNextData } },
+      ])
+      .mockImplementationOnce(async () => [
+        { pubkey: enrollmentKey, account: { data: enrollmentData } },
+      ]);
+
+    const connection = {
+      getProgramAccounts,
+    } as unknown as import("@solana/web3.js").Connection;
+    const programId = PublicKey.unique();
+
+    const result = await snapshotOnChainState(connection, programId);
+
+    expect(result.courses).toHaveLength(2);
+    expect(result.undecodedCourses).toEqual([]);
+    const v1 = result.courses.find((c) => c.courseId === "course-v1");
+    const vNext = result.courses.find((c) => c.courseId === "course-vnext");
+    expect(v1?.sizeBytes).toBe(COURSE_SIZE_V1);
+    expect(v1?.liveLessonCount).toBe(5);
+    expect(vNext?.sizeBytes).toBe(COURSE_SIZE_VNEXT);
+    expect(vNext?.liveLessonCount).toBe(3);
+
+    expect(result.enrollments).toHaveLength(1);
+    expect(result.undecodedEnrollments).toEqual([]);
+    expect(result.enrollments[0]?.course).toBe(vNextKey.toBase58());
+    expect(result.enrollments[0]?.lessonFlags.endsWith("3")).toBe(true);
+
+    expect(getProgramAccounts).toHaveBeenCalledTimes(2);
+    expect(getProgramAccounts).toHaveBeenCalledWith(
+      programId,
+      expect.objectContaining({ filters: expect.any(Array) })
+    );
+  });
+
+  it("reports an account matching the discriminator but with an unrecognised length as undecoded, without dropping the rest of the snapshot", async () => {
+    const goodKey = PublicKey.unique();
+    const badKey = PublicKey.unique();
+    const goodData = await encodeV1Course();
+    const badData = Buffer.alloc(100); // matches nothing decodeCourse recognises
+
+    const getProgramAccounts = vi
+      .fn()
+      .mockImplementationOnce(async () => [
+        { pubkey: goodKey, account: { data: goodData } },
+        { pubkey: badKey, account: { data: badData } },
+      ])
+      .mockImplementationOnce(async () => []);
+
+    const connection = {
+      getProgramAccounts,
+    } as unknown as import("@solana/web3.js").Connection;
+
+    const result = await snapshotOnChainState(connection, PublicKey.unique());
+
+    expect(result.courses).toHaveLength(1);
+    expect(result.courses[0]?.courseId).toBe("course-v1");
+    expect(result.undecodedCourses).toHaveLength(1);
+    expect(result.undecodedCourses[0]?.address).toBe(badKey.toBase58());
+    expect(result.undecodedCourses[0]?.sizeBytes).toBe(100);
+    expect(result.undecodedCourses[0]?.error).toMatch(/100/);
+  });
+});

--- a/apps/web/src/lib/admin/reset-verify.ts
+++ b/apps/web/src/lib/admin/reset-verify.ts
@@ -1,0 +1,405 @@
+import { BorshCoder } from "@coral-xyz/anchor";
+import type { Idl } from "@coral-xyz/anchor";
+import type BN from "bn.js";
+import { Connection, PublicKey } from "@solana/web3.js";
+import IDL from "@/lib/solana/idl/superteam_academy.json";
+import { decodeCourse } from "@/lib/solana/academy-reads";
+import { getProgramId } from "@/lib/solana/pda";
+
+/**
+ * B4 — read-only v-next reset verification harness (#356).
+ *
+ * SAFE lane: every function here only calls `getProgramAccounts` /
+ * `getAccountInfo`-style reads and decodes bytes. Nothing in this module signs
+ * or sends a transaction. This is the safety net for the reset wave's most
+ * destructive lane (close+recreate, see `recreate-course.ts`) — it exists to
+ * catch a bad recreate BEFORE the operator moves on to the next course.
+ *
+ * Two pieces:
+ *   - {@link snapshotOnChainState} — a structural dump of every Course and
+ *     Enrollment account live under the program, taken once before the reset
+ *     wave (PRE) and once after (POST).
+ *   - {@link verifyReset} — a pure diff over a PRE snapshot, a POST snapshot,
+ *     and the expected per-course values, asserting the #356 invariants,
+ *     including H3 (see the docstring on {@link verifyReset}). NEVER throws on
+ *     a data mismatch — every violation is reported as a structured failure so
+ *     a caller (the admin route, or the CLI script) can display it, not crash
+ *     on it.
+ *
+ * The Course discriminator is identical across the v1 (224-byte) and v-next
+ * (253-byte) on-chain layouts (Anchor discriminators are derived from the
+ * struct name alone — see `academy-reads.ts`), so a single
+ * `getProgramAccounts` call with one memcmp filter returns BOTH pre-reset and
+ * post-reset accounts; each is then decoded with the length-dispatched
+ * `decodeCourse`, which normalises both layouts to the same shape (including
+ * `liveLessonCount` / `activeLessons`, the popcount and the dense mask this
+ * module's H3 check needs). The Enrollment layout is unchanged across
+ * versions, so it uses a single raw decode.
+ */
+
+// Enrollment/Course account-name discriminators only depend on the struct
+// name (`sha256("account:<Name>")[..8]`), not on the fields inside it, so the
+// v1 IDL's coder is sufficient to build memcmp filters that match BOTH the
+// v1 and v-next Course layouts (verified: both IDLs carry the identical
+// discriminator bytes for "Course", and Enrollment is unversioned).
+const coder = new BorshCoder(IDL as unknown as Idl);
+
+// -----------------------------------------------------------------------------
+// Bit-mask helpers — BigInt only. A `number &` truncates at 32 bits and would
+// silently corrupt any comparison over the 256-bit `active_lessons` /
+// `lesson_flags` masks (see apps/web/src/lib/solana/bitmap.ts, which this
+// mirrors for the same reason).
+// -----------------------------------------------------------------------------
+
+/**
+ * Encode a 4 x u64 mask (word[0] = bits 0-63 … word[3] = bits 192-255) as a
+ * stable 64-character hex string, most-significant word first, so two masks
+ * are byte-comparable as plain strings and JSON-serialisable for the CLI's
+ * saved-snapshot files.
+ */
+function maskToHex(mask: readonly bigint[]): string {
+  if (mask.length !== 4) {
+    throw new Error(
+      `maskToHex: expected a 4 x u64 mask, got ${mask.length} word(s)`
+    );
+  }
+  return [mask[3], mask[2], mask[1], mask[0]]
+    .map((word) => (word ?? 0n).toString(16).padStart(16, "0"))
+    .join("");
+}
+
+/** Parse a {@link maskToHex} string back into a single 256-bit BigInt. */
+function parseMaskHex(hex: string): bigint {
+  return BigInt(`0x${hex}`);
+}
+
+function bytesToHex(bytes: readonly number[]): string {
+  return Buffer.from(bytes).toString("hex");
+}
+
+// -----------------------------------------------------------------------------
+// Snapshot
+// -----------------------------------------------------------------------------
+
+export interface CourseSnapshot {
+  courseId: string;
+  /** The Course PDA address (base58). Unchanged by a recreate — same seeds. */
+  coursePda: string;
+  /** Raw account length — 224 (v1) or 253 (v-next); the length IS the version. */
+  sizeBytes: number;
+  creator: string;
+  creatorRewardXp: number;
+  /** v1: `lesson_count`. v-next: popcount(`active_lessons`). Always populated. */
+  liveLessonCount: number;
+  /**
+   * The 256-bit live-lesson mask, hex-encoded via {@link maskToHex}. For v1
+   * this is the dense mask synthesised from `lesson_count` (see
+   * `academy-reads.ts#denseMask`); for v-next it is the raw `active_lessons`.
+   * Both are directly comparable — this is what the H3 check operates on.
+   */
+  activeLessonsOrCount: string;
+  contentTxId: string;
+}
+
+export interface EnrollmentSnapshot {
+  /** The Enrollment PDA address (base58) — the identity key for this record. */
+  address: string;
+  /** The Course PDA this enrollment belongs to (base58). */
+  course: string;
+  /** The 4 x u64 `lesson_flags` bitmap, hex-encoded via {@link maskToHex}. */
+  lessonFlags: string;
+}
+
+/** An account matched by discriminator but which failed to decode. Reported, never dropped silently. */
+export interface UndecodedAccount {
+  address: string;
+  sizeBytes: number;
+  error: string;
+}
+
+export interface ResetSnapshot {
+  courses: CourseSnapshot[];
+  enrollments: EnrollmentSnapshot[];
+  undecodedCourses: UndecodedAccount[];
+  undecodedEnrollments: UndecodedAccount[];
+}
+
+interface RawEnrollment {
+  course: PublicKey;
+  enrolled_at: BN;
+  completed_at: BN | null;
+  lesson_flags: BN[];
+  credential_asset: PublicKey | null;
+  _reserved: number[];
+  bump: number;
+}
+
+function toCourseSnapshot(pubkey: PublicKey, data: Buffer): CourseSnapshot {
+  const decoded = decodeCourse(data);
+  return {
+    courseId: decoded.course_id,
+    coursePda: pubkey.toBase58(),
+    sizeBytes: data.length,
+    creator: decoded.creator.toBase58(),
+    creatorRewardXp: decoded.creator_reward_xp,
+    liveLessonCount: decoded.liveLessonCount,
+    activeLessonsOrCount: maskToHex(decoded.activeLessons),
+    contentTxId: bytesToHex(decoded.content_tx_id),
+  };
+}
+
+function toEnrollmentSnapshot(
+  pubkey: PublicKey,
+  data: Buffer
+): EnrollmentSnapshot {
+  const raw = coder.accounts.decode<RawEnrollment>("Enrollment", data);
+  const mask = raw.lesson_flags.map((word) => BigInt(word.toString()));
+  return {
+    address: pubkey.toBase58(),
+    course: raw.course.toBase58(),
+    lessonFlags: maskToHex(mask),
+  };
+}
+
+/**
+ * READ-ONLY structural snapshot of every Course and Enrollment account live
+ * under the program: `getProgramAccounts` + decode. No signing, no writes —
+ * safe to run against mainnet or devnet, before or after a reset.
+ */
+export async function snapshotOnChainState(
+  connection: Connection,
+  programId: PublicKey = getProgramId()
+): Promise<ResetSnapshot> {
+  const [courseAccounts, enrollmentAccounts] = await Promise.all([
+    connection.getProgramAccounts(programId, {
+      filters: [{ memcmp: coder.accounts.memcmp("Course") }],
+    }),
+    connection.getProgramAccounts(programId, {
+      filters: [{ memcmp: coder.accounts.memcmp("Enrollment") }],
+    }),
+  ]);
+
+  const courses: CourseSnapshot[] = [];
+  const undecodedCourses: UndecodedAccount[] = [];
+  for (const { pubkey, account } of courseAccounts) {
+    try {
+      courses.push(toCourseSnapshot(pubkey, account.data));
+    } catch (err) {
+      undecodedCourses.push({
+        address: pubkey.toBase58(),
+        sizeBytes: account.data.length,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  const enrollments: EnrollmentSnapshot[] = [];
+  const undecodedEnrollments: UndecodedAccount[] = [];
+  for (const { pubkey, account } of enrollmentAccounts) {
+    try {
+      enrollments.push(toEnrollmentSnapshot(pubkey, account.data));
+    } catch (err) {
+      undecodedEnrollments.push({
+        address: pubkey.toBase58(),
+        sizeBytes: account.data.length,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  return { courses, enrollments, undecodedCourses, undecodedEnrollments };
+}
+
+// -----------------------------------------------------------------------------
+// Invariant diff / assert
+// -----------------------------------------------------------------------------
+
+/** Expected post-recreate values for one course (the #356 targets). */
+export interface ExpectedCourseValues {
+  /** Expected v-next account size. Always 253 for a landed recreate. */
+  expectedSize: number;
+  /** Expected new `creator` (base58) — the instructor wallet, not the platform authority. */
+  expectedCreator: string;
+  /** Expected `creator_reward_xp` — 30 post-#356 (down from 750). */
+  expectedRewardXp: number;
+}
+
+export type ExpectedByCourseId = Record<string, ExpectedCourseValues>;
+
+export interface CourseCheckResult {
+  courseId: string;
+  ok: boolean;
+  failures: string[];
+}
+
+export interface EnrollmentCheckResult {
+  address: string;
+  ok: boolean;
+  failures: string[];
+}
+
+export interface ResetVerifyResult {
+  ok: boolean;
+  perCourse: CourseCheckResult[];
+  perEnrollment: EnrollmentCheckResult[];
+  failures: string[];
+}
+
+/**
+ * Verify the #356 reset invariants for a set of recreated courses. Pure
+ * function, never throws on a data mismatch — every violation is collected as
+ * a structured failure rather than an exception, so a caller can always
+ * inspect the full picture instead of stopping at the first problem.
+ *
+ * Checked per course in `expected` (keyed by `courseId`):
+ *   - the POST account is exactly `expectedSize` bytes (253 for a landed
+ *     v-next recreate),
+ *   - `creator == expectedCreator`,
+ *   - `creatorRewardXp == expectedRewardXp`,
+ *   - **H3 (safety-critical)**: `popcount(post.active_lessons) ==
+ *     pre.liveLessonCount` **AND** the POST dense mask is a SUPERSET of every
+ *     PRE enrollment's `lesson_flags` for that course — i.e. the recreate
+ *     never demands a bit a mid-course learner wasn't asked to set. Any
+ *     course where the post mask does not fully cover a pre enrollment's
+ *     `lesson_flags` is flagged, naming the specific enrollment.
+ *
+ * Checked per PRE enrollment (independent of `expected` — every enrollment
+ * that existed before the reset is checked, whether or not its course was
+ * recreated):
+ *   - it still exists in POST at the exact same address (a missing address is
+ *     flagged as "missing" — the Enrollment PDA is seeded from
+ *     `(course_id, learner)` and is never touched by a recreate, so there is
+ *     no legitimate reason for it to disappear or "move"),
+ *   - its `course` field and `lessonFlags` bytes are byte-identical to PRE.
+ *
+ * A PRE course or enrollment absent from the PRE snapshot itself, or a POST
+ * course absent from the POST snapshot, is ALSO a failure (fail-closed —
+ * "couldn't verify" is never treated as "assume it's fine").
+ *
+ * Deliberately NOT checked: POST-only enrollments with no PRE counterpart
+ * (new enrollments during/after the reset window are ordinary usage, not a
+ * corruption signal) and courses outside `expected` (out of scope for this run).
+ */
+export function verifyReset(
+  pre: ResetSnapshot,
+  post: ResetSnapshot,
+  expected: ExpectedByCourseId
+): ResetVerifyResult {
+  const preCoursesById = new Map(pre.courses.map((c) => [c.courseId, c]));
+  const postCoursesById = new Map(post.courses.map((c) => [c.courseId, c]));
+
+  const preEnrollmentsByCourse = new Map<string, EnrollmentSnapshot[]>();
+  for (const enrollment of pre.enrollments) {
+    const list = preEnrollmentsByCourse.get(enrollment.course) ?? [];
+    list.push(enrollment);
+    preEnrollmentsByCourse.set(enrollment.course, list);
+  }
+  const postEnrollmentsByAddress = new Map(
+    post.enrollments.map((e) => [e.address, e])
+  );
+
+  const perCourse: CourseCheckResult[] = [];
+  const failures: string[] = [];
+
+  for (const [courseId, exp] of Object.entries(expected)) {
+    const courseFailures: string[] = [];
+    const preCourse = preCoursesById.get(courseId);
+    const postCourse = postCoursesById.get(courseId);
+
+    if (!postCourse) {
+      courseFailures.push(
+        `course "${courseId}": missing from POST snapshot — the recreate did not land`
+      );
+    } else {
+      if (postCourse.sizeBytes !== exp.expectedSize) {
+        courseFailures.push(
+          `course "${courseId}": sizeBytes=${postCourse.sizeBytes}, expected ${exp.expectedSize}`
+        );
+      }
+      if (postCourse.creator !== exp.expectedCreator) {
+        courseFailures.push(
+          `course "${courseId}": creator=${postCourse.creator}, expected ${exp.expectedCreator}`
+        );
+      }
+      if (postCourse.creatorRewardXp !== exp.expectedRewardXp) {
+        courseFailures.push(
+          `course "${courseId}": creatorRewardXp=${postCourse.creatorRewardXp}, expected ${exp.expectedRewardXp}`
+        );
+      }
+    }
+
+    if (!preCourse) {
+      courseFailures.push(
+        `course "${courseId}": missing from PRE snapshot — cannot verify H3 against a baseline; refusing to assume it's fine`
+      );
+    } else if (postCourse) {
+      // H3a — popcount(post.active_lessons) === pre.liveLessonCount, exactly.
+      if (postCourse.liveLessonCount !== preCourse.liveLessonCount) {
+        const direction =
+          postCourse.liveLessonCount > preCourse.liveLessonCount
+            ? "widened"
+            : "narrowed";
+        courseFailures.push(
+          `course "${courseId}" [H3]: post liveLessonCount=${postCourse.liveLessonCount} != ` +
+            `pre liveLessonCount=${preCourse.liveLessonCount} (${direction} — a recreate must ` +
+            `preserve the on-chain lesson count exactly)`
+        );
+      }
+
+      // H3b — post dense mask ⊇ every PRE enrollment's lesson_flags for this course.
+      const postMask = parseMaskHex(postCourse.activeLessonsOrCount);
+      const learners = preEnrollmentsByCourse.get(preCourse.coursePda) ?? [];
+      for (const enrollment of learners) {
+        const learnerFlags = parseMaskHex(enrollment.lessonFlags);
+        const isSubset = (learnerFlags & postMask) === learnerFlags;
+        if (!isSubset) {
+          courseFailures.push(
+            `course "${courseId}" [H3]: post active_lessons (0x${postMask.toString(16)}) does not ` +
+              `cover enrollment ${enrollment.address}'s lesson_flags (0x${learnerFlags.toString(16)}) — ` +
+              `the recreate would demand a bit this mid-course learner was never asked to set`
+          );
+        }
+      }
+    }
+
+    perCourse.push({
+      courseId,
+      ok: courseFailures.length === 0,
+      failures: courseFailures,
+    });
+    failures.push(...courseFailures);
+  }
+
+  const perEnrollment: EnrollmentCheckResult[] = [];
+  for (const preEnrollment of pre.enrollments) {
+    const enrollmentFailures: string[] = [];
+    const postEnrollment = postEnrollmentsByAddress.get(preEnrollment.address);
+
+    if (!postEnrollment) {
+      enrollmentFailures.push(
+        `enrollment ${preEnrollment.address}: missing from POST snapshot (dropped or moved) — ` +
+          `Enrollment PDAs are never touched by a recreate, so this should be impossible`
+      );
+    } else {
+      if (postEnrollment.course !== preEnrollment.course) {
+        enrollmentFailures.push(
+          `enrollment ${preEnrollment.address}: course changed ${preEnrollment.course} -> ${postEnrollment.course}`
+        );
+      }
+      if (postEnrollment.lessonFlags !== preEnrollment.lessonFlags) {
+        enrollmentFailures.push(
+          `enrollment ${preEnrollment.address}: lessonFlags changed ${preEnrollment.lessonFlags} -> ${postEnrollment.lessonFlags}`
+        );
+      }
+    }
+
+    perEnrollment.push({
+      address: preEnrollment.address,
+      ok: enrollmentFailures.length === 0,
+      failures: enrollmentFailures,
+    });
+    failures.push(...enrollmentFailures);
+  }
+
+  return { ok: failures.length === 0, perCourse, perEnrollment, failures };
+}


### PR DESCRIPTION
## Summary

SAFE-lane, read-only tooling for the v-next devnet reset wave (#356) — the invariant/second-observer backbone that catches a bad recreate before the next course is touched. Nothing in this PR signs or writes a transaction.

- **Snapshot** (`apps/web/src/lib/admin/reset-verify.ts` — `snapshotOnChainState`): `getProgramAccounts` + decode every Course and Enrollment account under the program. Uses the existing length-aware `decodeCourse` (224 = v1, 253 = v-next) so it reads BOTH pre-reset and post-reset accounts with a single memcmp filter (Anchor discriminators are identical across the two Course layouts — verified against both IDLs). Decode failures are collected per-account (`undecodedCourses` / `undecodedEnrollments`) rather than throwing and losing the rest of the snapshot.
- **Invariant diff/assert** (`verifyReset`): pure function, given a PRE snapshot, a POST snapshot, and expected per-course values, asserts the #356 invariants and returns `{ ok, perCourse, perEnrollment, failures }`. Never throws on a data mismatch.
- **CLI** (`apps/web/scripts/reset-verify.ts`, `pnpm reset-verify`): `snapshot --out <file>` and `diff --pre --post --expected --out`, exits 1 on any invariant failure. No hardcoded RPC/program id/key — reads `--rpc`/`SOLANA_RPC_URL`/`NEXT_PUBLIC_SOLANA_RPC_URL` and `--program`/`NEXT_PUBLIC_PROGRAM_ID`.

### Invariants asserted (per course in `expected`)
- POST account is exactly `expectedSize` bytes (253), `creator == expectedCreator`, `creatorRewardXp == expectedRewardXp` (30).
- **H3 (safety-critical)**: `popcount(post.active_lessons) == pre.liveLessonCount`, **and** the POST dense mask is a superset of every PRE enrollment's `lesson_flags` for that course — flagging the specific enrollment address if the post mask doesn't fully cover a mid-course learner's completed bits.
- Fail-closed: a course missing from PRE or POST is itself a failure (never "assume it's fine").

### Invariants asserted (every PRE enrollment)
- Still exists in POST at the exact same address, with byte-identical `course` and `lessonFlags`. (POST-only enrollments with no PRE counterpart are NOT flagged — ordinary new signups during/after the reset window.)

## Test plan
- [x] `pnpm vitest run src/lib/admin/__tests__/reset-verify.test.ts` — 16/16 passing, including all six required fixtures: (a) clean recreate passes, (b) widened/narrowed popcount → H3 flagged, (c) superset violation (mask drops a learner's completed bit while popcount still matches) → H3 flagged, with the enrollment itself correctly reported unchanged, (d) enrollment `lessonFlags`/`course` drift → flagged, (e) missing enrollment → flagged (and the inverse: a POST-only new enrollment is correctly NOT flagged), (f) wrong creator / reward ≠ 30 / wrong size → flagged. Plus two `snapshotOnChainState` tests against real Anchor-encoded (`coder.accounts.encode`) v1 + v-next Course and Enrollment buffers, mocking `Connection.getProgramAccounts`, including one bad-length account routed to `undecodedCourses` without dropping the rest of the snapshot.
- [x] `pnpm typecheck` — clean.
- [x] `pnpm lint` — clean (no new warnings/errors on the added files).
- [x] `pnpm test` (full web suite) — 861/861 passing, no regressions.
- [x] Manual CLI smoke test of `reset-verify.ts diff` with hand-built pre/post/expected JSON fixtures — both a passing run (exit 0) and a failing run (wrong creator → exit 1, failure printed).