### PR TITLE
fix(admin): scrub recreate route error responses through sanitizeReason (#511)

### DIFF
--- a/apps/web/src/app/api/admin/courses/recreate/__tests__/route.test.ts
+++ b/apps/web/src/app/api/admin/courses/recreate/__tests__/route.test.ts
@@ -257,4 +257,32 @@ describe("POST /api/admin/courses/recreate — error mapping", () => {
     const body = (await res.json()) as { courseIntact: boolean };
     expect(body.courseIntact).toBe(true);
   });
+
+  it("scrubs a leaked api-keyed RPC URL from a RecreateCourseError response (#511)", async () => {
+    recreateCourse.mockRejectedValue(
+      new RecreateCourseError(
+        "Failed to close: connection to https://devnet.helius-rpc.com/?api-key=SECRET123 refused",
+        "close",
+        true
+      )
+    );
+    const res = await post({ courseId: COURSE_ID, confirm: COURSE_ID });
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).not.toContain("SECRET123");
+    expect(body.error).not.toContain("helius-rpc.com");
+    expect(body.error).toContain("[redacted-url]");
+  });
+
+  it("scrubs secrets from a generic (non-RecreateCourseError) 500 (#511)", async () => {
+    recreateCourse.mockRejectedValue(
+      new Error("SOLANA_RPC_URL misconfigured: https://x.rpc/?api-key=LEAK")
+    );
+    const res = await post({ courseId: COURSE_ID, confirm: COURSE_ID });
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).not.toContain("LEAK");
+    expect(body.error).not.toContain("SOLANA_RPC_URL");
+    expect(body.error).toContain("[redacted-env]");
+  });
 });

--- a/apps/web/src/app/api/admin/courses/recreate/route.ts
+++ b/apps/web/src/app/api/admin/courses/recreate/route.ts
@@ -12,6 +12,7 @@ import {
   recreateCourse,
   RecreateCourseError,
 } from "@/lib/admin/recreate-course";
+import { sanitizeReason } from "@/lib/admin/sanitize-reason";
 
 /**
  * POST /api/admin/courses/recreate — DESTRUCTIVE. Closes a course's on-chain PDA
@@ -136,13 +137,25 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
         // The PDA is gone, so the catalog/admin reads must re-derive from chain.
         revalidateTag(COURSES_CACHE_TAG);
       }
+      // Scrub before returning: e.message wraps closeCoursePda/deployCoursePda
+      // errors that can embed the api-keyed RPC URL (SOLANA_RPC_URL) or a secret
+      // env name. The response `reason` is rendered verbatim client-side and can
+      // flow into session-replay/telemetry, so redact at the source. Server logs
+      // above keep the full message for debugging.
       return NextResponse.json(
-        { error: e.message, phase: e.phase, courseIntact: e.courseIntact },
+        {
+          error: sanitizeReason(e.message),
+          phase: e.phase,
+          courseIntact: e.courseIntact,
+        },
         { status }
       );
     }
     const message = e instanceof Error ? e.message : String(e);
     console.error(`[admin/courses/recreate] ${courseId}: ${message}`);
-    return NextResponse.json({ error: message }, { status: 500 });
+    return NextResponse.json(
+      { error: sanitizeReason(message) },
+      { status: 500 }
+    );
   }
 }


### PR DESCRIPTION
Routes the recreate execute route's 400/500 `error`/`reason` responses through the existing `sanitizeReason` util, server-side at the source.

**Problem:** the route returned `recreateCourse` errors verbatim (`error: e.message`, `error: message`). Those wrap `closeCoursePda`/`deployCoursePda` failures that can embed the api-keyed Helius RPC URL (`SOLANA_RPC_URL`) or a secret env name — and the response `reason` is rendered client-side and can flow into session-replay/telemetry.

**Fix:** wrap both on-chain/exception error strings in `sanitizeReason(...)`. Destructive logic untouched; server logs keep the full message for debugging; static validation 400s are controlled strings and left as-is.

**Tests:** +2 cases — a leaked api-keyed RPC URL in a `RecreateCourseError`, and a secret env name in a generic 500, are both redacted. Full recreate suite: 17 passed.

Closes #511