### PR TITLE
fix(challenge): pass instructions rail only to the first code block (#457)

### DIFF
--- a/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/lesson-client.tsx
+++ b/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/lesson-client.tsx
@@ -336,9 +336,19 @@ export function LessonPageClient({
           style. `px` leaves a small gutter from the screen edges. */}
       {hasCodeBlock ? (
         <div className="mx-[calc(50%_-_50vw)] w-screen space-y-4 px-3 sm:px-4">
-          {codeBlocks.map((block) => {
+          {codeBlocks.map((block, i) => {
             const Renderer = RENDERERS[block._type];
-            return <Renderer key={block.key} block={block} ctx={codeCtx} />;
+            // Only the FIRST code block carries the instructions rail. A lesson
+            // with multiple code blocks would otherwise render the same
+            // instructionsSlot inside every editor (duplicated description +
+            // test cases). None ship today — this guards future content. (#457)
+            return (
+              <Renderer
+                key={block.key}
+                block={block}
+                ctx={i === 0 ? codeCtx : ctx}
+              />
+            );
           })}
         </div>
       ) : (


### PR DESCRIPTION
Latent-hardening from the #454 review (0 occurrences today).

**Problem:** the challenge layout gave every code block the same `codeCtx` (carrying `instructionsSlot`), so a lesson authored with **multiple code blocks** would render the description + test cases duplicated inside each editor.

**Fix:** only `codeBlocks[0]` gets the instructions rail; subsequent code blocks get the plain `ctx`. One-line guard in the `codeBlocks.map`.

No dedicated test: this is render-logic in a heavy client component (auth/supabase deps) with no existing render harness and zero current occurrences — the guard is self-evident. tsc + eslint clean.

(The second latent case in #457 — a code lesson also containing an interactive block — remains a content-authoring note, not a code change; those blocks live in their own prose-only lessons today.)

Closes #457