### PR TITLE
refactor(supabase): collapse hand-rolled onchain_deployments types onto generated Database (#438)

### DIFF
--- a/apps/web/src/lib/content/deployment-writes.ts
+++ b/apps/web/src/lib/content/deployment-writes.ts
@@ -3,10 +3,7 @@ import "server-only";
 import { createClient } from "@supabase/supabase-js";
 import { env } from "@/lib/env";
 import { serverEnv } from "@/lib/env.server";
-import type {
-  DeploymentStatus,
-  OnchainDeploymentRow,
-} from "@/lib/content/deployments";
+import type { Database } from "@/lib/supabase/types";
 
 /**
  * On-chain deployment WRITE seam (SP2-B Task 6).
@@ -47,48 +44,14 @@ type DeploymentUpsert = {
 };
 
 /**
- * supabase-js's `.upsert()`/`.select()` overloads require each relation's
- * `Row`/`Insert` to be assignable to `Record<string, unknown>`. An `interface`
- * (like the read seam's {@link OnchainDeploymentRow}) is NOT — interfaces carry
- * no implicit index signature — which collapses the `.upsert()` value type to
- * `never`. Re-mapping the interface through `{ [K in keyof T]: T[K] }` yields an
- * equivalent object-literal alias that IS index-signature compatible, keeping
- * the client fully typed with zero `any` while reusing the read seam's shapes.
+ * Service-role client typed for this seam (mirrors `lib/supabase/admin.ts`). The
+ * `onchain_deployments` relation now lives in the generated `Database` type, so
+ * the local schema augmentation and the `{ [K in keyof T]: T[K] }` index-
+ * signature workaround are gone — the generated Row is an object-literal type
+ * that `.upsert()`/`.select()` already accept (#438).
  */
-type WriteRow = { [K in keyof OnchainDeploymentRow]: OnchainDeploymentRow[K] };
-type WriteViewRow = { [K in keyof DeploymentStatus]: DeploymentStatus[K] };
-
-/**
- * Minimal Supabase schema for the write. The generated `Database` type does not
- * yet carry `onchain_deployments` (the SP2-B migration adds it; types regenerate
- * in a follow-up), so — like the read seam — we pin exactly the one relation
- * this module writes.
- */
-interface WriteSchema {
-  public: {
-    Tables: {
-      onchain_deployments: {
-        Row: WriteRow;
-        Insert: DeploymentUpsert;
-        Update: Partial<DeploymentUpsert>;
-        Relationships: [];
-      };
-    };
-    Views: {
-      public_onchain_deployments: {
-        Row: WriteViewRow;
-        Relationships: [];
-      };
-    };
-    Functions: Record<string, never>;
-    Enums: Record<string, never>;
-    CompositeTypes: Record<string, never>;
-  };
-}
-
-/** Service-role client typed for this seam (mirrors `lib/supabase/admin.ts`). */
 function createServiceClient() {
-  return createClient<WriteSchema>(
+  return createClient<Database>(
     env.NEXT_PUBLIC_SUPABASE_URL,
     serverEnv.SUPABASE_SERVICE_ROLE_KEY
   );

--- a/apps/web/src/lib/content/deployments.ts
+++ b/apps/web/src/lib/content/deployments.ts
@@ -7,6 +7,7 @@ import { serverEnv } from "@/lib/env.server";
 import { COURSES_CACHE_TAG } from "@/lib/content/queries";
 import { logError } from "@/lib/logging";
 import { ERROR_IDS } from "@/constants/errorIds";
+import type { Database } from "@/lib/supabase/types";
 
 /**
  * On-chain deployment read seam (SP2-B Task 3).
@@ -28,69 +29,23 @@ import { ERROR_IDS } from "@/constants/errorIds";
  * {@link isSynced} is the entire public-visibility gate, in one place.
  */
 
-/** The gate-relevant columns exposed by the `public_onchain_deployments` view. */
-export interface DeploymentStatus {
-  content_id: string;
-  kind: "course" | "achievement";
-  status: string | null;
-  is_active: boolean | null;
-  achievement_pda: string | null;
-}
-
-/** The full `onchain_deployments` row (service-role only). */
-export interface OnchainDeploymentRow {
-  content_id: string;
-  kind: "course" | "achievement";
-  status: string | null;
-  course_pda: string | null;
-  tx_signature: string | null;
-  collection_address: string | null;
-  track_collection_address: string | null;
-  achievement_pda: string | null;
-  is_active: boolean | null;
-  last_synced: string | null;
-  updated_at: string | null;
-  /**
-   * Per-course maintenance gate (WS-2 #453 rail 3). `true` while a close+recreate
-   * is in flight for this course — the Course PDA may be transiently absent.
-   * NOT NULL DEFAULT false on the table; see
-   * `20260714150000_course_maintenance_gate.sql`. Never exposed through
-   * `public_onchain_deployments` — it's an operational flag for server-side
-   * write paths ({@link isCourseInMaintenance}), not a public catalog signal.
-   */
-  in_maintenance: boolean;
-}
+/**
+ * The gate-relevant columns exposed by the `public_onchain_deployments` view,
+ * and the full `onchain_deployments` row (service-role only). Both derive from
+ * the generated `Database` types — the SP2-B migration's relations now live in
+ * `lib/supabase/types.ts`, so this seam no longer hand-rolls them (#438). The
+ * full row's `in_maintenance` is the per-course maintenance gate (WS-2 #453
+ * rail 3): `true` while a close+recreate is in flight (the Course PDA may be
+ * transiently absent). It is NOT exposed through the public view — an
+ * operational flag for server-side write paths ({@link isCourseInMaintenance}),
+ * not a public catalog signal.
+ */
+export type DeploymentStatus =
+  Database["public"]["Views"]["public_onchain_deployments"]["Row"];
+export type OnchainDeploymentRow =
+  Database["public"]["Tables"]["onchain_deployments"]["Row"];
 
 const VIEW_COLUMNS = "content_id, kind, status, is_active, achievement_pda";
-
-/**
- * Minimal Supabase schema for this seam. The generated `Database` type does not
- * yet carry `onchain_deployments` / `public_onchain_deployments` (the SP2-B
- * migration adds them; the generated types regenerate in a follow-up), so we
- * pin exactly the two relations this module touches. Keeps the client fully
- * typed with zero `any` and self-documents the expected columns.
- */
-interface DeploymentsSchema {
-  public: {
-    Tables: {
-      onchain_deployments: {
-        Row: OnchainDeploymentRow;
-        Insert: OnchainDeploymentRow;
-        Update: Partial<OnchainDeploymentRow>;
-        Relationships: [];
-      };
-    };
-    Views: {
-      public_onchain_deployments: {
-        Row: DeploymentStatus;
-        Relationships: [];
-      };
-    };
-    Functions: Record<string, never>;
-    Enums: Record<string, never>;
-    CompositeTypes: Record<string, never>;
-  };
-}
 
 /**
  * Cookieless anon client. NOT `lib/supabase/server.ts` — that reads `cookies()`,
@@ -98,7 +53,7 @@ interface DeploymentsSchema {
  * disabled: this is a pure read over a world-readable view.
  */
 function createCookielessClient() {
-  return createClient<DeploymentsSchema>(
+  return createClient<Database>(
     env.NEXT_PUBLIC_SUPABASE_URL,
     env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
     { auth: { persistSession: false, autoRefreshToken: false } }
@@ -106,12 +61,12 @@ function createCookielessClient() {
 }
 
 /**
- * Service-role client typed for this seam. Mirrors `lib/supabase/admin.ts` but
- * carries {@link DeploymentsSchema} so `onchain_deployments` is typed until the
- * generated `Database` regenerates with the SP2-B migration's relations.
+ * Service-role client typed for this seam. Mirrors `lib/supabase/admin.ts`; the
+ * `onchain_deployments` / `public_onchain_deployments` relations now live in the
+ * generated `Database` type (#438), so no local schema augmentation is needed.
  */
 function createServiceClient() {
-  return createClient<DeploymentsSchema>(
+  return createClient<Database>(
     env.NEXT_PUBLIC_SUPABASE_URL,
     serverEnv.SUPABASE_SERVICE_ROLE_KEY
   );

--- a/apps/web/src/lib/supabase/types.ts
+++ b/apps/web/src/lib/supabase/types.ts
@@ -14,6 +14,55 @@ export type Database = {
   };
   public: {
     Tables: {
+      onchain_deployments: {
+        Row: {
+          content_id: string;
+          kind: "course" | "achievement";
+          status: string | null;
+          course_pda: string | null;
+          tx_signature: string | null;
+          collection_address: string | null;
+          track_collection_address: string | null;
+          achievement_pda: string | null;
+          is_active: boolean | null;
+          last_synced: string | null;
+          updated_at: string | null;
+          // Per-course maintenance gate (WS-2 #453 rail 3): true while a
+          // close+recreate is in flight. NOT NULL DEFAULT false on the table
+          // (20260714150000_course_maintenance_gate.sql). Server-only — never
+          // exposed through the public_onchain_deployments view.
+          in_maintenance: boolean;
+        };
+        Insert: {
+          content_id: string;
+          kind: "course" | "achievement";
+          status?: string | null;
+          course_pda?: string | null;
+          tx_signature?: string | null;
+          collection_address?: string | null;
+          track_collection_address?: string | null;
+          achievement_pda?: string | null;
+          is_active?: boolean | null;
+          last_synced?: string | null;
+          updated_at?: string | null;
+          in_maintenance?: boolean;
+        };
+        Update: {
+          content_id?: string;
+          kind?: "course" | "achievement";
+          status?: string | null;
+          course_pda?: string | null;
+          tx_signature?: string | null;
+          collection_address?: string | null;
+          track_collection_address?: string | null;
+          achievement_pda?: string | null;
+          is_active?: boolean | null;
+          last_synced?: string | null;
+          updated_at?: string | null;
+          in_maintenance?: boolean;
+        };
+        Relationships: [];
+      };
       answers: {
         Row: {
           author_id: string;
@@ -862,6 +911,16 @@ export type Database = {
       };
     };
     Views: {
+      public_onchain_deployments: {
+        Row: {
+          content_id: string;
+          kind: "course" | "achievement";
+          status: string | null;
+          is_active: boolean | null;
+          achievement_pda: string | null;
+        };
+        Relationships: [];
+      };
       community_stats: {
         Row: {
           accepted_answers: number | null;


### PR DESCRIPTION
`onchain_deployments` / `public_onchain_deployments` were hand-rolled in two seams (read `deployments.ts`, write `deployment-writes.ts`) because the generated `Database` types predated the SP2-B table.

**Change:** add both relations to `lib/supabase/types.ts`, then collapse both seams onto them.
- `deployments.ts`: `OnchainDeploymentRow` / `DeploymentStatus` become aliases of `Database[...]` Row types; the local `DeploymentsSchema` augmentation is deleted; both clients use `createClient<Database>`.
- `deployment-writes.ts`: drops `WriteSchema` + the `WriteRow`/`WriteViewRow` `{ [K in keyof T]: T[K] }` index-signature workaround (the generated Row is an object-literal type `.upsert()`/`.select()` already accept) and uses `createClient<Database>`.

**No behavior change** — the Row shapes are byte-identical to the previous interfaces (incl. `in_maintenance` + nullable columns). Since the Supabase CLI is not wired here, the two relations were added to `types.ts` by hand from the migration + existing shapes; a future `supabase gen types` regen will simply reproduce them.

tsc clean; deployments + deployment-writes + queries suites green (56).

Note: the issue said 3 hand-rolled copies — it is actually **2** (`lib/supabase/admin.ts` does not reference the table).

Closes #438