### PR TITLE
chore: post-Sanity naming sweep — dead identifiers + factually-wrong strings (#442)

### DIFF
--- a/apps/web/src/app/[locale]/(platform)/certificates/[id]/page.tsx
+++ b/apps/web/src/app/[locale]/(platform)/certificates/[id]/page.tsx
@@ -47,7 +47,7 @@ function useCertificateData(certId: string) {
           .eq("id", cert.user_id)
           .single();
 
-        // Fetch learning path + difficulty from Sanity
+        // Fetch learning path + difficulty from the content bundle
         const courses = await getCoursesByIds([cert.course_id]);
         const course = courses[0];
         const parts: string[] = [];

--- a/apps/web/src/app/[locale]/(platform)/certificates/page.tsx
+++ b/apps/web/src/app/[locale]/(platform)/certificates/page.tsx
@@ -63,7 +63,7 @@ export default function CertificatesPage() {
           }));
           setCertificates(mapped);
 
-          // Fetch course data from Sanity for learning path + difficulty
+          // Fetch course data from the content bundle for learning path + difficulty
           const courseIds = [...new Set(mapped.map((c) => c.courseId))];
           const courses = await getCoursesByIds(courseIds);
           const sMap = new Map<string, string>();

--- a/apps/web/src/app/[locale]/(platform)/dashboard/page.tsx
+++ b/apps/web/src/app/[locale]/(platform)/dashboard/page.tsx
@@ -82,7 +82,7 @@ interface DashboardData {
   achievementsCount: number;
   /** Full Sanity _ids of achievements unlocked by this user */
   unlockedAchievementIds: string[];
-  /** All achievements from Sanity — single source of truth for catalog */
+  /** All achievements from the content bundle — single source of truth for catalog */
   achievementCatalog: DeployedAchievement[];
   quests: DailyQuest[];
   questsResetTime: string;
@@ -277,7 +277,7 @@ function useDashboardData(
           if (bonusMatch?.[1]) courseCompleteIdsFromTx.push(bonusMatch[1]);
         }
 
-        // Fetch lesson titles/slugs from Sanity
+        // Fetch lesson titles/slugs from the content bundle
         const uniqueLessonIds = [...new Set(lessonIdsFromTx)];
         const lessonSummaries =
           uniqueLessonIds.length > 0
@@ -291,7 +291,7 @@ function useDashboardData(
           lessonToCourse.set(row.lesson_id, row.course_id);
         }
 
-        // Resolve enrolled course titles and lesson counts from Sanity CMS
+        // Resolve enrolled course titles and lesson counts from the content bundle
         // Exclude courses that already have a minted certificate
         const allEnrolledIds = enrollments?.map((e) => e.course_id) ?? [];
         const enrolledIds = allEnrolledIds.filter(
@@ -325,23 +325,23 @@ function useDashboardData(
         // Build a lookup map: course _id -> Sanity data
         const courseMap = new Map(courseSummaries.map((c) => [c._id, c]));
 
-        // Only surface enrolled courses that still resolve from Sanity. A
+        // Only surface enrolled courses that still resolve from the content bundle. A
         // deactivated (or unpublished) course is filtered out by getCoursesByIds
         // (activeGate), so without this its "Continue learning" card would still
         // render from the Supabase enrollment row with a raw-id title.
         const currentCourses: CurrentCourse[] = enrolledIds
           .filter((id) => courseMap.has(id))
           .map((id) => {
-            const sanity = courseMap.get(id);
+            const courseInfo = courseMap.get(id);
             return {
               courseId: id,
-              title: sanity?.title ?? id,
-              slug: sanity?.slug ?? id,
+              title: courseInfo?.title ?? id,
+              slug: courseInfo?.slug ?? id,
               completedLessons: completedPerCourse.get(id) ?? 0,
-              totalLessons: sanity?.totalLessons ?? 0,
-              difficulty: sanity?.difficulty ?? "beginner",
-              learningPath: sanity?.learningPath ?? null,
-              thumbnail: sanity?.thumbnail ?? null,
+              totalLessons: courseInfo?.totalLessons ?? 0,
+              difficulty: courseInfo?.difficulty ?? "beginner",
+              learningPath: courseInfo?.learningPath ?? null,
+              thumbnail: courseInfo?.thumbnail ?? null,
             };
           });
 

--- a/apps/web/src/app/[locale]/(platform)/profile/[username]/page.tsx
+++ b/apps/web/src/app/[locale]/(platform)/profile/[username]/page.tsx
@@ -259,11 +259,11 @@ export default function PublicProfilePage() {
           const completedCount =
             courseProgressMap.get(enrollment.course_id) ?? 0;
           if (completedCount > 0) {
-            const sanity = courseMap.get(enrollment.course_id);
+            const courseInfo = courseMap.get(enrollment.course_id);
             completedCourseIds.add(enrollment.course_id);
             completedCourses.push({
-              title: sanity?.title ?? enrollment.course_id,
-              slug: sanity?.slug ?? enrollment.course_id,
+              title: courseInfo?.title ?? enrollment.course_id,
+              slug: courseInfo?.slug ?? enrollment.course_id,
               completedAt: new Date(
                 enrollment.enrolled_at ?? Date.now()
               ).toLocaleDateString(),

--- a/apps/web/src/app/[locale]/(platform)/profile/page.tsx
+++ b/apps/web/src/app/[locale]/(platform)/profile/page.tsx
@@ -169,7 +169,7 @@ function useProfileData(): ProfileData {
           .select("course_id, enrolled_at")
           .eq("user_id", user.id);
 
-        // Resolve enrolled course details from Sanity CMS
+        // Resolve enrolled course details from the content bundle
         const enrolledIds = (enrollmentRows ?? []).map((e) => e.course_id);
         const [courseSummaries, allLessonSkills, allAchievements] =
           await Promise.all([
@@ -206,18 +206,18 @@ function useProfileData(): ProfileData {
 
         const courseMap = new Map(courseSummaries.map((c) => [c._id, c]));
 
-        // Build completed courses list with real titles from Sanity
+        // Build completed courses list with real titles from the content bundle
         const completedCourses: CompletedCourse[] = [];
         const completedCourseIds = new Set<string>();
         for (const enrollment of enrollmentRows ?? []) {
           const completedCount =
             courseProgressMap.get(enrollment.course_id) ?? 0;
           if (completedCount > 0) {
-            const sanity = courseMap.get(enrollment.course_id);
+            const courseInfo = courseMap.get(enrollment.course_id);
             completedCourseIds.add(enrollment.course_id);
             completedCourses.push({
-              title: sanity?.title ?? enrollment.course_id,
-              slug: sanity?.slug ?? enrollment.course_id,
+              title: courseInfo?.title ?? enrollment.course_id,
+              slug: courseInfo?.slug ?? enrollment.course_id,
               completedAt: new Date(
                 enrollment.enrolled_at ?? Date.now()
               ).toLocaleDateString(),

--- a/apps/web/src/app/[locale]/admin/content/__tests__/quests-table.test.tsx
+++ b/apps/web/src/app/[locale]/admin/content/__tests__/quests-table.test.tsx
@@ -3,7 +3,7 @@ import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { createTranslator } from "next-intl";
 import { QuestsTable } from "../quests-table";
-import type { SanityQuest } from "@/lib/content/queries";
+import type { ContentQuest } from "@/lib/content/queries";
 import messages from "@/messages/en.json";
 
 vi.mock("next-intl/server", () => ({
@@ -11,7 +11,7 @@ vi.mock("next-intl/server", () => ({
     createTranslator({ locale: "en", messages, namespace }),
 }));
 
-const quest: SanityQuest = {
+const quest: ContentQuest = {
   id: "quest-three-lessons",
   name: "Three Lessons",
   description: "Complete 3 lessons today.",
@@ -37,7 +37,7 @@ describe("QuestsTable", () => {
   });
 
   it("translates every quest type and reset type", async () => {
-    const quests: SanityQuest[] = [
+    const quests: ContentQuest[] = [
       "lesson",
       "lesson_batch",
       "challenge",
@@ -46,7 +46,7 @@ describe("QuestsTable", () => {
     ].map((type, i) => ({
       ...quest,
       id: `quest-${i}`,
-      type: type as SanityQuest["type"],
+      type: type as ContentQuest["type"],
     }));
     render(await QuestsTable({ quests }));
 

--- a/apps/web/src/app/[locale]/admin/content/quests-table.tsx
+++ b/apps/web/src/app/[locale]/admin/content/quests-table.tsx
@@ -1,10 +1,10 @@
 import { getTranslations } from "next-intl/server";
 import { AdminCard } from "@/components/admin/admin-card";
 import { AdminTableShell } from "@/components/admin/admin-table-shell";
-import type { SanityQuest } from "@/lib/content/queries";
+import type { ContentQuest } from "@/lib/content/queries";
 
 interface QuestsTableProps {
-  quests: SanityQuest[];
+  quests: ContentQuest[];
 }
 
 /**

--- a/apps/web/src/app/api/admin/achievements/sync/route.ts
+++ b/apps/web/src/app/api/admin/achievements/sync/route.ts
@@ -68,7 +68,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   const ach = achievements.find((a) => a._id === achievementId);
   if (!ach) {
     return NextResponse.json(
-      { error: "Achievement not found in Sanity" },
+      { error: "Achievement not found in the content bundle" },
       { status: 404 }
     );
   }
@@ -162,7 +162,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
       revalidateTag(COURSES_CACHE_TAG);
     } catch (mutationErr) {
       console.error(
-        "[admin/achievements/sync] Sanity write-back failed:",
+        "[admin/achievements/sync] deployment write-back failed:",
         mutationErr
       );
     }

--- a/apps/web/src/app/api/admin/courses/deactivate/route.ts
+++ b/apps/web/src/app/api/admin/courses/deactivate/route.ts
@@ -58,7 +58,10 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     await writeCourseActive(courseId, false);
     revalidateTag(COURSES_CACHE_TAG);
   } catch (err) {
-    console.error("[admin/courses/deactivate] Sanity write-back failed:", err);
+    console.error(
+      "[admin/courses/deactivate] deployment write-back failed:",
+      err
+    );
     warning =
       "Deactivated on-chain, but the catalog flag didn't update — the course may still show until re-synced.";
   }

--- a/apps/web/src/app/api/admin/courses/reactivate/route.ts
+++ b/apps/web/src/app/api/admin/courses/reactivate/route.ts
@@ -56,7 +56,10 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     await writeCourseActive(courseId, true);
     revalidateTag(COURSES_CACHE_TAG);
   } catch (err) {
-    console.error("[admin/courses/reactivate] Sanity write-back failed:", err);
+    console.error(
+      "[admin/courses/reactivate] deployment write-back failed:",
+      err
+    );
     warning =
       "Reactivated on-chain, but the catalog flag didn't update — the course may stay hidden until re-synced.";
   }

--- a/apps/web/src/app/api/admin/courses/sync/route.ts
+++ b/apps/web/src/app/api/admin/courses/sync/route.ts
@@ -146,7 +146,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   const course = courses.find((c) => c._id === courseId);
   if (!course) {
     return NextResponse.json(
-      { error: "Course not found in Sanity" },
+      { error: "Course not found in the content bundle" },
       { status: 404 }
     );
   }
@@ -307,7 +307,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
       );
     } catch (mutationErr) {
       console.error(
-        "[admin/courses/sync] Sanity write-back failed:",
+        "[admin/courses/sync] deployment write-back failed:",
         mutationErr
       );
     }
@@ -486,7 +486,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
         );
       } catch (mutationErr) {
         console.error(
-          "[admin/courses/sync] Sanity PDA write-back failed:",
+          "[admin/courses/sync] deployment PDA write-back failed:",
           mutationErr
         );
       }
@@ -533,7 +533,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     );
   } catch (mutationErr) {
     console.error(
-      "[admin/courses/sync] Sanity write-back failed:",
+      "[admin/courses/sync] deployment write-back failed:",
       mutationErr
     );
   }

--- a/apps/web/src/app/api/certificates/mint/route.ts
+++ b/apps/web/src/app/api/certificates/mint/route.ts
@@ -159,7 +159,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Get course data from Sanity (for the display name only)
+    // Get course data from the content bundle (for the display name only)
     const sanityCourse = await getCourseById(courseId);
     if (!sanityCourse) {
       return NextResponse.json({ error: "Course not found" }, { status: 404 });

--- a/apps/web/src/app/api/lessons/complete/route.ts
+++ b/apps/web/src/app/api/lessons/complete/route.ts
@@ -35,7 +35,7 @@ interface LessonCompleteRequest {
 }
 
 /**
- * Derive the 0-based lesson index within a course from Sanity content order.
+ * Derive the 0-based lesson index within a course from content-bundle lesson order.
  * Modules and lessons are flattened in order; the index matches the on-chain bitmap position.
  */
 async function deriveLessonIndex(
@@ -273,7 +273,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Derive lesson index from Sanity content order
+    // Derive lesson index from content-bundle lesson order
     const lessonIndex = await deriveLessonIndex(courseId, lessonId);
 
     // Guard: the on-chain complete_lesson reverts when lessonIndex >=

--- a/apps/web/src/app/api/quests/daily/route.ts
+++ b/apps/web/src/app/api/quests/daily/route.ts
@@ -32,7 +32,7 @@ export async function GET() {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    // 1. Fetch quest definitions + auxiliary data from Sanity (single round trip)
+    // 1. Fetch quest definitions + auxiliary data from the content bundle (single round trip)
     const questData = await getAllQuests();
 
     if (questData.quests.length === 0) {

--- a/apps/web/src/components/deploy/generic-program-explorer.tsx
+++ b/apps/web/src/components/deploy/generic-program-explorer.tsx
@@ -35,7 +35,7 @@ import {
 // ---------------------------------------------------------------------------
 
 interface GenericProgramExplorerProps {
-  /** Raw IDL JSON string from Sanity */
+  /** Raw IDL JSON string from the content bundle */
   idlJson: string;
   courseSlug: string;
   courseId: string;

--- a/apps/web/src/components/gamification/achievement-grid.tsx
+++ b/apps/web/src/components/gamification/achievement-grid.tsx
@@ -22,7 +22,7 @@ import {
 
 interface AchievementGridProps {
   unlockedAchievements: Achievement[];
-  /** Deployed achievement definitions fetched from Sanity — only these are shown. */
+  /** Deployed achievement definitions fetched from the content bundle — only these are shown. */
   catalog: AchievementDefinition[];
   className?: string;
 }

--- a/apps/web/src/lib/content/deployment-writes.ts
+++ b/apps/web/src/lib/content/deployment-writes.ts
@@ -121,13 +121,13 @@ async function upsertDeployment(row: DeploymentUpsert): Promise<void> {
  * skipped by an earlier throw.
  */
 export async function writeCourseOnChainStatus(
-  sanityId: string,
+  contentId: string,
   status: string,
   coursePda: string,
   txSignature: string
 ): Promise<void> {
   await upsertDeployment({
-    content_id: sanityId,
+    content_id: contentId,
     kind: "course",
     status,
     course_pda: coursePda,
@@ -144,11 +144,11 @@ export async function writeCourseOnChainStatus(
  * deactivate/reactivate routes call this after the tx succeeds.
  */
 export async function writeCourseActive(
-  sanityId: string,
+  contentId: string,
   isActive: boolean
 ): Promise<void> {
   await upsertDeployment({
-    content_id: sanityId,
+    content_id: contentId,
     kind: "course",
     is_active: isActive,
   });
@@ -174,11 +174,11 @@ export async function writeCourseActive(
  * script) independent of the acquire/release protocol.
  */
 export async function writeCourseMaintenanceFlag(
-  sanityId: string,
+  contentId: string,
   inMaintenance: boolean
 ): Promise<void> {
   await upsertDeployment({
-    content_id: sanityId,
+    content_id: contentId,
     kind: "course",
     in_maintenance: inMaintenance,
   });
@@ -250,23 +250,23 @@ export async function acquireCourseMaintenanceGate(
 }
 
 export async function writeCourseTrackCollection(
-  sanityId: string,
+  contentId: string,
   trackCollectionAddress: string
 ): Promise<void> {
   await upsertDeployment({
-    content_id: sanityId,
+    content_id: contentId,
     kind: "course",
     track_collection_address: trackCollectionAddress,
   });
 }
 
 export async function writeAchievementOnChainStatus(
-  sanityId: string,
+  contentId: string,
   achievementPda: string,
   collectionAddress: string
 ): Promise<void> {
   await upsertDeployment({
-    content_id: sanityId,
+    content_id: contentId,
     kind: "achievement",
     status: "synced",
     achievement_pda: achievementPda,

--- a/apps/web/src/lib/content/project.ts
+++ b/apps/web/src/lib/content/project.ts
@@ -15,7 +15,7 @@ import type {
   DeployedAchievement,
   QuestData,
   RecommendedCourse,
-  SanityQuest,
+  ContentQuest,
 } from "@/lib/content/queries";
 
 /**
@@ -370,7 +370,7 @@ const DRAFT_PREFIX = "drafts.";
 
 /**
  * getAllQuests projection. `quests` = active, non-draft quest docs mapped to
- * {@link SanityQuest} (with the same `description`/`icon` defaults). `challengeLessonIds`
+ * {@link ContentQuest} (with the same `description`/`icon` defaults). `challengeLessonIds`
  * = lessons carrying ≥1 `code` block. `moduleLessonMap` = per-course modules
  * keyed `"<courseId>:<key>"`, lesson ids via ref deref, dropping module-less /
  * empty entries (matches the `.m[]` null-guard + `filter(Boolean)`).
@@ -380,17 +380,17 @@ export function projectQuestData(
   lessons: readonly LessonDoc[],
   courses: readonly CourseDoc[]
 ): QuestData {
-  const activeQuests: SanityQuest[] = quests
+  const activeQuests: ContentQuest[] = quests
     .filter((q) => q.active === true && !q._id.startsWith(DRAFT_PREFIX))
     .map((q) => ({
       id: q._id,
       name: optString(q.name) as string,
       description: optString(q.description) ?? "",
-      type: optString(q.type) as SanityQuest["type"],
+      type: optString(q.type) as ContentQuest["type"],
       icon: optString(q.icon) ?? "CircleDashed",
       xpReward: optNumber(q.xpReward) as number,
       targetValue: optNumber(q.targetValue) as number,
-      resetType: optString(q.resetType) as SanityQuest["resetType"],
+      resetType: optString(q.resetType) as ContentQuest["resetType"],
     }));
 
   const challengeLessonIds = lessons

--- a/apps/web/src/lib/content/queries.ts
+++ b/apps/web/src/lib/content/queries.ts
@@ -426,7 +426,7 @@ export async function getAllAchievements(): Promise<DeployedAchievement[]> {
 
 /* ── Daily Quests ──────────────────────────────────────────────── */
 
-export interface SanityQuest {
+export interface ContentQuest {
   id: string;
   name: string;
   description: string;
@@ -438,7 +438,7 @@ export interface SanityQuest {
 }
 
 export interface QuestData {
-  quests: SanityQuest[];
+  quests: ContentQuest[];
   challengeLessonIds: string[];
   moduleLessonMap: Array<{ id: string; lessonIds: string[] }>;
 }

--- a/apps/web/src/lib/helius/event-handlers.ts
+++ b/apps/web/src/lib/helius/event-handlers.ts
@@ -530,7 +530,7 @@ async function tryIssueCredential(
     if (!enrollment) return;
     if (enrollment.credential_asset) return;
 
-    // Fetch course data from Sanity for the display name
+    // Fetch course data from the content bundle for the display name
     const sanityCourse = await getCourseById(courseId);
     if (!sanityCourse) return;
     const courseName = sanityCourse.title ?? courseId;

--- a/apps/web/src/lib/helius/resolvers.ts
+++ b/apps/web/src/lib/helius/resolvers.ts
@@ -88,7 +88,7 @@ export async function resolveLessonId(
   try {
     const course = await getCourseById(courseId);
     if (!course) {
-      console.warn(`[resolver] No Sanity course found for ${courseId}`);
+      console.warn(`[resolver] No course found for ${courseId}`);
       return null;
     }
     const allLessons = (course.modules ?? []).flatMap(

--- a/apps/web/src/lib/services/hybrid-progress-service.ts
+++ b/apps/web/src/lib/services/hybrid-progress-service.ts
@@ -165,7 +165,7 @@ export class HybridProgressService implements LearningProgressService {
       userId,
       courseId,
       completedLessons,
-      totalLessons: 0, // Caller enriches from Sanity CMS
+      totalLessons: 0, // Caller enriches from the content bundle
       percentComplete: 0,
       lastAccessedAt: new Date(lastAccessed || new Date().toISOString()),
     };

--- a/apps/web/src/lib/solana/onchain-queue.ts
+++ b/apps/web/src/lib/solana/onchain-queue.ts
@@ -179,10 +179,12 @@ export async function retryPendingOnchainActions(
           // Already issued on-chain — just resolve the queue entry
           if (enrollment?.credential_asset) break;
 
-          // Derive all fields fresh from Sanity + on-chain (self-sufficient retry)
+          // Derive all fields fresh from the content bundle + on-chain (self-sufficient retry)
           const sanityCourse = await getCourseById(courseId);
           if (!sanityCourse) {
-            throw new Error(`Course "${courseId}" not found in Sanity`);
+            throw new Error(
+              `Course "${courseId}" not found in the content bundle`
+            );
           }
 
           const trackCollectionAddress = sanityCourse.trackCollectionAddress as


### PR DESCRIPTION
The Sanity pipeline is retired (content ships as a committed bundle; on-chain status writes go to Supabase `onchain_deployments`), but stale `Sanity` naming remained. This fixes the parts that are **dead names** or **now factually wrong**:

- **Live identifiers:** `sanityId`→`contentId` (deployment-writes params), `const sanity`→`courseInfo` (dashboard/profile pages), exported `SanityQuest`→`ContentQuest` (queries/project/quests-table + test).
- **User-visible errors:** \"X not found in Sanity\" → \"not found in the content bundle\".
- **Log prefixes:** \"… Sanity write-back failed\" → \"deployment write-back failed\" (writes target Supabase/on-chain now); same for the PDA variant.
- **Stale comments:** data fetched \"from Sanity\" → \"from the content bundle\".

**Deliberately left untouched** (not rot): the live `cdn.sanity.io` image CDN (still used), and the \"Sanity-shaped\" / `_id` architectural terminology + migration-history docstrings — those accurately describe the content bundle's document model (the projector emits Sanity-shaped docs by design). The issue's ~70-file grep over-counted these legitimate references.

No behavior change. No test asserted any changed string. tsc clean; **full suite green (931).**

Closes #442