### PR TITLE
chore(ai): gate per-call cachedContentTokenCount log behind AI_PARTNER_DEBUG (#535)

### DIFF
--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -39,7 +39,7 @@ The middleware (`src/middleware.ts`) chains two concerns:
 
 The curated set (currently 10) lives in `solanabr/courses-academy` under `achievements/` — git is the source of truth; do not enumerate them here.
 
-**Unlock logic is declarative, not a per-achievement map.** Each achievement doc carries an `award` rule (a discriminated union of `AwardKind`); `lib/gamification/achievements.ts` holds `PREDICATES satisfies Record<AwardKind, Predicate>` — one predicate per *kind*, so adding a kind without a predicate is a compile error, and no course/path id is ever hardcoded. Adding an achievement means adding a content doc, not code.
+**Unlock logic is declarative, not a per-achievement map.** Each achievement doc carries an `award` rule (a discriminated union of `AwardKind`); `lib/gamification/achievements.ts` holds `PREDICATES satisfies Record<AwardKind, Predicate>` — one predicate per _kind_, so adding a kind without a predicate is a compile error, and no course/path id is ever hardcoded. Adding an achievement means adding a content doc, not code.
 
 ## Environment Variables
 
@@ -76,6 +76,8 @@ GEMINI_API_KEY=                    # Gemini key for /api/ai/* (omit to disable t
 AI_PARTNER_SEAL_SECRET=            # Optional dedicated key for sealing the comprehension-check
                                     # token (lib/ai/check-seal.ts); if unset, derived from
                                     # SUPABASE_SERVICE_ROLE_KEY.
+AI_PARTNER_DEBUG=                  # Set to "1" to log per-call prompt-cache token counts
+                                    # from /api/ai/partner. Default off (quiet in production).
 
 # Optional — Rust playground proxy (server-only)
 RUST_PLAYGROUND_URL=               # /api/rust/execute upstream (default: play.rust-lang.org/execute)

--- a/apps/web/src/app/api/ai/partner/route.ts
+++ b/apps/web/src/app/api/ai/partner/route.ts
@@ -313,10 +313,17 @@ export async function POST(request: NextRequest) {
     }
 
     const data = await response.json();
-    console.log(
-      "[ai/partner] cachedContentTokenCount:",
-      data?.usageMetadata?.cachedContentTokenCount ?? 0
-    );
+    // Prompt-cache observability — useful for tuning the cache-shaped prefix, but
+    // this is the SUCCESS path of every paid call, so keep it opt-in (default
+    // off) rather than logging on every request in production. Set
+    // AI_PARTNER_DEBUG=1 to surface it. Failure-path diagnostics below stay
+    // unconditional — they only fire on an actual error.
+    if (process.env.AI_PARTNER_DEBUG === "1") {
+      console.log(
+        "[ai/partner] cachedContentTokenCount:",
+        data?.usageMetadata?.cachedContentTokenCount ?? 0
+      );
+    }
 
     const finishReason = data?.candidates?.[0]?.finishReason;
     const rawText = data?.candidates?.[0]?.content?.parts?.[0]?.text ?? "";


### PR DESCRIPTION
The prompt-cache token-count log fired on the **success path of every paid AI call** in production — useful for tuning the cache-shaped prefix, but unconditional log noise on a money path.

**Fix:** gate it behind `AI_PARTNER_DEBUG=1` (default off) so prod is quiet but the signal is available on demand. Failure-path `console.error` diagnostics are unchanged — they only fire on an actual error. Flag documented in `apps/web/CLAUDE.md`.

partner-route suite: 26 passed.

Closes #535