### PR TITLE
fix(idl): mark config writable in create_course (web vnext IDL)

### DIFF
--- a/apps/web/src/lib/solana/idl/superteam_academy_vnext.json
+++ b/apps/web/src/lib/solana/idl/superteam_academy_vnext.json
@@ -408,6 +408,7 @@
         },
         {
           "name": "config",
+          "writable": true,
           "pda": {
             "seeds": [
               {


### PR DESCRIPTION
## Problem

Deploying a course via `/admin` fails with `ConstraintMut` (2000):

```
Deploy action refused: AnchorError occurred. Error Code: ConstraintMut.
Error Number: 2000. Error Message: A mut constraint was violated.
```

## Root cause

`create_course` writes `Config.course_nonce` (the H-1 generation fix), so the
`config` account must be passed **writable**. The H-1 fix set `config.writable =
true` in `onchain-academy/idl/onchain_academy.json`, `onchain_academy.ts`, and
`apps/web/src/lib/solana/idl/superteam_academy.json` (v1 read-path coder) — but
missed `apps/web/src/lib/solana/idl/superteam_academy_vnext.json`, the IDL the
write path (`academy-program.ts`, `admin-signer.ts`) actually loads. The client
marked `config` read-only and the program rejected the write.

## Fix

Add `"writable": true` to `create_course`'s `config` account in the vnext IDL.
Verified account writability/signer flags now match the authoritative
`onchain-academy/idl/onchain_academy.json` for every instruction. Takes effect
on the next web redeploy (build-time IDL import).

Closes #539
