### PR TITLE
feat(admin): commit on-chain content hash from the sync table

### DIFF
--- a/apps/web/src/app/api/admin/courses/sync/route.ts
+++ b/apps/web/src/app/api/admin/courses/sync/route.ts
@@ -37,6 +37,7 @@ import {
 import { slotsByCourseId } from "@/lib/content/store";
 import { SYNCED_SHA } from "@/lib/content/meta";
 import { MaskMismatchError } from "@/lib/github/types";
+import { deriveActiveMask } from "@/lib/github/content-commit";
 
 /**
  * Load a course's committed `slots.lock.json` from the pinned content bundle
@@ -100,10 +101,17 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   // content_tx_id is committed in the same update and the mask is cross-checked
   // against the committed slots.lock.json. Absent → legacy behaviour, unchanged.
   let activeLessons: [bigint, bigint, bigint, bigint] | null = null;
+  // `commitContent: true` requests the same §11.0 commitment without the caller
+  // supplying a mask — the route derives it from the committed slots.lock.json
+  // itself (deriveActiveMask). This is the UI's "Commit content hash" action:
+  // the deleted drift screen used to send an explicit mask, but the lockfile is
+  // the source of truth, so deriving it here needs no browser-side mask logic.
+  let commitContent = false;
   try {
     const body = (await req.json()) as {
       courseId?: unknown;
       activeLessons?: unknown;
+      commitContent?: unknown;
     };
     if (typeof body.courseId !== "string" || !body.courseId) {
       return NextResponse.json(
@@ -112,6 +120,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
       );
     }
     courseId = body.courseId;
+    commitContent = body.commitContent === true;
     if (body.activeLessons !== undefined) {
       activeLessons = parseActiveLessons(body.activeLessons);
       if (!activeLessons) {
@@ -427,15 +436,19 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   // new_active_lessons AND the git SHA is committed into content_tx_id in the SAME
   // update (v-next exposes new_active_lessons; this replaces v1's count-based
   // new_lesson_count grow).
-  if (activeLessons) {
+  if (activeLessons || commitContent) {
     let commit: ReturnType<typeof buildCourseCommit>;
     try {
       const { contentSha, slotsLock } = readCourseSlotsLock(courseId);
+      // `commitContent` (no explicit mask) derives the mask from the lockfile;
+      // an explicit `activeLessons` is still cross-checked against it, so the
+      // "slots never reused" invariant holds on both paths.
+      const maskToSend = activeLessons ?? deriveActiveMask(slotsLock);
       commit = buildCourseCommit({
         courseId,
         contentSha,
         slotsLock,
-        activeLessons,
+        activeLessons: maskToSend,
       });
     } catch (e) {
       if (e instanceof MaskMismatchError) {

--- a/apps/web/src/components/admin/__tests__/course-sync-table.test.tsx
+++ b/apps/web/src/components/admin/__tests__/course-sync-table.test.tsx
@@ -81,6 +81,55 @@ describe("CourseSyncTable — deploy opens the change preview", () => {
   });
 });
 
+describe("CourseSyncTable — Commit content hash (§11.0)", () => {
+  const staleCourse: CourseStatus = {
+    ...syncedCourse,
+    contentId: "course-stale",
+    chainDrift: "content_stale",
+  };
+
+  it("hides Commit content hash for a content-current course", () => {
+    vi.stubGlobal("fetch", vi.fn());
+    renderWithIntl(
+      <CourseSyncTable courses={[syncedCourse]} onRefresh={vi.fn()} />
+    );
+    expect(
+      screen.queryByRole("button", { name: "Commit content hash" })
+    ).toBeNull();
+  });
+
+  it("shows Commit content hash for a stale course and posts commitContent (no preview)", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({}),
+    } as Response);
+    vi.stubGlobal("fetch", fetchMock);
+    const onRefresh = vi.fn();
+
+    renderWithIntl(
+      <CourseSyncTable courses={[staleCourse]} onRefresh={onRefresh} />
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Commit content hash" })
+    );
+    // Direct POST — no confirmation dialog for the content commitment.
+    expect(screen.queryByRole("dialog")).toBeNull();
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/admin/courses/sync",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          courseId: "course-stale",
+          commitContent: true,
+        }),
+      })
+    );
+    await waitFor(() => expect(onRefresh).toHaveBeenCalled());
+  });
+});
+
 describe("CourseSyncTable — Task 5 polish", () => {
   const driftedCourse: CourseStatus = {
     ...syncedCourse,

--- a/apps/web/src/components/admin/__tests__/deploy-change-preview.test.tsx
+++ b/apps/web/src/components/admin/__tests__/deploy-change-preview.test.tsx
@@ -164,7 +164,7 @@ describe("DeployChangePreview", () => {
     expect(screen.getByText(/This deploy will NOT change it/)).toBeTruthy();
     expect(
       screen.getByText(
-        /updated by the content-commit step on the Content Drift screen/
+        /Use the "Commit content hash" button on this course's row/
       )
     ).toBeTruthy();
 

--- a/apps/web/src/components/admin/course-sync-table.tsx
+++ b/apps/web/src/components/admin/course-sync-table.tsx
@@ -68,6 +68,32 @@ export function CourseSyncTable({ courses, onRefresh }: CourseSyncTableProps) {
     }
   }
 
+  // §11.0: write the on-chain content commitment (content_tx_id) so a
+  // `content_stale` course goes current. Posts `commitContent` alone — the route
+  // derives the active_lessons mask from the committed slots.lock.json. Separate
+  // from the field-sync/redeploy above, which never moves the commitment.
+  async function handleCommitContent(courseId: string) {
+    setSyncing(courseId);
+    setError(null);
+    try {
+      const res = await fetch("/api/admin/courses/sync", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ courseId, commitContent: true }),
+      });
+      if (!res.ok) {
+        const data = (await res.json()) as { error?: string };
+        actionError(data.error, "commitContent");
+      } else {
+        onRefresh();
+      }
+    } catch (e) {
+      actionError(e instanceof Error ? e.message : undefined, "commitContent");
+    } finally {
+      setSyncing(null);
+    }
+  }
+
   async function handleDeactivate(courseId: string) {
     if (!confirm(t("deactivateConfirm"))) return;
     setSyncing(courseId);
@@ -301,6 +327,21 @@ export function CourseSyncTable({ courses, onRefresh }: CourseSyncTableProps) {
                       disabled={isSyncing}
                     >
                       {isSyncing ? t("actions.working") : actionLabel}
+                    </AdminButton>
+                  )}
+                  {/* On-chain content commitment (content_tx_id) is written by a
+                      dedicated action, never by the field deploy/redeploy above
+                      (which posts `{ courseId }` alone). Shown only while the
+                      course is deployed-but-stale. */}
+                  {course.chainDrift === "content_stale" && (
+                    <AdminButton
+                      variant="neutral"
+                      onClick={() => void handleCommitContent(course.contentId)}
+                      disabled={isSyncing}
+                    >
+                      {isSyncing
+                        ? t("actions.working")
+                        : t("actions.commitContent")}
                     </AdminButton>
                   )}
                   {course.onChainStatus === "synced" &&

--- a/apps/web/src/components/admin/deploy-change-preview.tsx
+++ b/apps/web/src/components/admin/deploy-change-preview.tsx
@@ -21,10 +21,10 @@ interface DeployChangePreviewProps {
  *
  * `chainDrift: "content_stale"` is shown as an INFORMATIONAL note, never as a
  * pending change: this path posts `{ courseId }` alone, and the sync route only
- * writes `content_tx_id` when given an `activeLessons` mask (the content-commit
- * flow on the drift screen). Confirming here would not move the commitment —
- * the route would answer "Already synced" and the badge would stay stale — so
- * the copy must not promise otherwise.
+ * writes `content_tx_id` when given an `activeLessons` mask or `commitContent`
+ * (the dedicated "Commit content hash" action in the sync table). Confirming
+ * here would not move the commitment — the route would answer "Already synced"
+ * and the badge would stay stale — so the copy must not promise otherwise.
  *
  * #433: on a FIRST deploy, `course.creatorWallet` is surfaced prominently —
  * the SAME value `/api/admin/courses/sync` resolves as `Course.creator` (no
@@ -77,12 +77,13 @@ export function DeployChangePreview({
   const firstDeploy = course.onChainStatus === "not_deployed";
   const contentStale = course.chainDrift === "content_stale";
   // Content staleness is NOT a change this deploy makes: the sync route only
-  // writes `content_tx_id` when the caller supplies an `activeLessons` mask,
-  // and this path posts `{ courseId }` alone (the mask belongs to the
-  // content-commit flow on the drift screen). So a content-stale course with no
-  // field diffs really is "no changes" here — saying otherwise would promise a
-  // fix the confirm cannot deliver, and the route would answer "Already synced"
-  // while the badge stayed stale. The stale note below is informational only.
+  // writes `content_tx_id` when the caller supplies an `activeLessons` mask or
+  // the `commitContent` flag, and this path posts `{ courseId }` alone (the
+  // commitment belongs to the "Commit content hash" action in the sync table).
+  // So a content-stale course with no field diffs really is "no changes" here —
+  // saying otherwise would promise a fix the confirm cannot deliver, and the
+  // route would answer "Already synced" while the badge stayed stale. The stale
+  // note below is informational only.
   const noChanges = !firstDeploy && course.differences.length === 0;
 
   return (

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -952,7 +952,8 @@
         "deactivate": "Deactivate",
         "working": "…",
         "syncAll": "Sync All ({count})",
-        "syncAllBusy": "Syncing…"
+        "syncAllBusy": "Syncing…",
+        "commitContent": "Commit content hash"
       },
       "deactivated": "Deactivated",
       "syncAllConfirm": "{count, plural, one {Sync # course} other {Sync # courses}} — {changes, plural, one {# field change} other {# field changes}}. Continue?",
@@ -962,7 +963,8 @@
         "sync": "Sync failed",
         "deactivate": "Deactivation failed",
         "reactivate": "Reactivation failed",
-        "syncFor": "Sync failed for {title}"
+        "syncFor": "Sync failed for {title}",
+        "commitContent": "Content commit failed"
       },
       "contentDrift": {
         "drifted": "Content drift",
@@ -978,7 +980,7 @@
         "creatorWalletLabel": "Creator wallet — this course will be permanently attributed to:",
         "creatorWalletImmutable": "Set once — cannot be changed after deploy.",
         "willWrite": "This transaction will write:",
-        "contentStale": "For information: this course's on-chain content commitment (content_tx_id) is behind the committed bundle. This deploy will NOT change it — it only writes the course fields listed above. The commitment is updated by the content-commit step on the Content Drift screen.",
+        "contentStale": "For information: this course's on-chain content commitment (content_tx_id) is behind the committed bundle. This deploy will NOT change it — it only writes the course fields listed above. Use the \"Commit content hash\" button on this course's row to update the commitment.",
         "noChanges": "No changes detected. Redeploy anyway?",
         "blocked": "Deploy is blocked until the immutable mismatch is resolved.",
         "confirmDeploy": "Deploy",

--- a/apps/web/src/messages/es.json
+++ b/apps/web/src/messages/es.json
@@ -952,7 +952,8 @@
         "deactivate": "Desactivar",
         "working": "…",
         "syncAll": "Sincronizar todo ({count})",
-        "syncAllBusy": "Sincronizando…"
+        "syncAllBusy": "Sincronizando…",
+        "commitContent": "Confirmar hash de contenido"
       },
       "deactivated": "Desactivado",
       "syncAllConfirm": "{count, plural, one {Sincronizar # curso} other {Sincronizar # cursos}} — {changes, plural, one {# cambio de campo} other {# cambios de campo}}. ¿Continuar?",
@@ -962,7 +963,8 @@
         "sync": "Falló la sincronización",
         "deactivate": "Falló la desactivación",
         "reactivate": "Falló la reactivación",
-        "syncFor": "Falló la sincronización de {title}"
+        "syncFor": "Falló la sincronización de {title}",
+        "commitContent": "Falló el commit de contenido"
       },
       "contentDrift": {
         "drifted": "Contenido desactualizado",
@@ -978,7 +980,7 @@
         "creatorWalletLabel": "Wallet del creador — este curso quedará atribuido permanentemente a:",
         "creatorWalletImmutable": "Se establece una sola vez — no se puede cambiar después del despliegue.",
         "willWrite": "Esta transacción escribirá:",
-        "contentStale": "Informativo: el compromiso de contenido on-chain de este curso (content_tx_id) está detrás del paquete commiteado. Este despliegue NO lo cambiará — solo escribe los campos del curso listados arriba. El compromiso se actualiza mediante el paso de content-commit en la pantalla de Divergencia de Contenido.",
+        "contentStale": "Informativo: el compromiso de contenido on-chain de este curso (content_tx_id) está detrás del paquete commiteado. Este despliegue NO lo cambiará — solo escribe los campos del curso listados arriba. Usa el botón «Confirmar hash de contenido» en la fila de este curso para actualizar el compromiso.",
         "noChanges": "No se detectaron cambios. ¿Volver a desplegar de todos modos?",
         "blocked": "El despliegue está bloqueado hasta que se resuelva la divergencia inmutable.",
         "confirmDeploy": "Desplegar",

--- a/apps/web/src/messages/pt-BR.json
+++ b/apps/web/src/messages/pt-BR.json
@@ -952,7 +952,8 @@
         "deactivate": "Desativar",
         "working": "…",
         "syncAll": "Sincronizar tudo ({count})",
-        "syncAllBusy": "Sincronizando…"
+        "syncAllBusy": "Sincronizando…",
+        "commitContent": "Confirmar hash do conteúdo"
       },
       "deactivated": "Desativado",
       "syncAllConfirm": "{count, plural, one {Sincronizar # curso} other {Sincronizar # cursos}} — {changes, plural, one {# mudança de campo} other {# mudanças de campo}}. Continuar?",
@@ -962,7 +963,8 @@
         "sync": "Falha na sincronização",
         "deactivate": "Falha na desativação",
         "reactivate": "Falha na reativação",
-        "syncFor": "Falha na sincronização de {title}"
+        "syncFor": "Falha na sincronização de {title}",
+        "commitContent": "Falha no commit de conteúdo"
       },
       "contentDrift": {
         "drifted": "Conteúdo desatualizado",
@@ -978,7 +980,7 @@
         "creatorWalletLabel": "Carteira do criador — este curso será atribuído permanentemente a:",
         "creatorWalletImmutable": "Definida uma única vez — não pode ser alterada após a implantação.",
         "willWrite": "Esta transação irá gravar:",
-        "contentStale": "Informativo: o compromisso de conteúdo on-chain deste curso (content_tx_id) está atrás do pacote commitado. Esta implantação NÃO o alterará — ela grava apenas os campos do curso listados acima. O compromisso é atualizado pela etapa de content-commit na tela de Divergência de Conteúdo.",
+        "contentStale": "Informativo: o compromisso de conteúdo on-chain deste curso (content_tx_id) está atrás do pacote commitado. Esta implantação NÃO o alterará — ela grava apenas os campos do curso listados acima. Use o botão “Confirmar hash do conteúdo” na linha deste curso para atualizar o compromisso.",
         "noChanges": "Nenhuma mudança detectada. Reimplantar mesmo assim?",
         "blocked": "A implantação está bloqueada até que a divergência imutável seja resolvida.",
         "confirmDeploy": "Implantar",


### PR DESCRIPTION
## Problem

After deploying a course, its on-chain content commitment (`content_tx_id`)
stays behind the committed bundle → the row shows **content_stale** ("Out of
sync / Content drift"). The deploy preview points to a "Content Drift screen"
content-commit step that **was deleted in #444** ("never wired to a UI"). The
sync table only posts `{ courseId }`, which writes course fields but never
`content_tx_id`, so **redeploy loops without ever clearing the badge** — there
was no UI path sending the `activeLessons` mask the route needs.

## Fix

- **Route** (`POST /api/admin/courses/sync`): accept `commitContent: true` and
  derive the `active_lessons` mask from the committed `slots.lock.json`
  (`deriveActiveMask`) — no browser-side mask logic. The explicit-mask path is
  unchanged and still cross-checked, so the "slots never reused" invariant holds
  on both paths.
- **Sync table**: a **"Commit content hash"** action on `content_stale` rows
  posts `{ courseId, commitContent: true }` (direct POST, no preview dialog).
- **Copy**: deploy-preview note + the orphaned i18n string now point at the new
  button (en / es / pt-BR).

## Impact

`content_tx_id` is on-chain provenance only — nothing learner-facing reads it —
so this clears a drift badge, it is not a functional blocker.

## Tests

- `course-sync-table`: button hidden for content-current, shown for stale, POSTs
  `{ courseId, commitContent: true }`.
- `deploy-change-preview`: asserts the new copy; regression guard kept.
- i18n parity + web typecheck green.

Closes #541
