### PR TITLE
chore(content): bump content.lock to bccd92f

### DIFF
--- a/apps/web/content.lock
+++ b/apps/web/content.lock
@@ -1,4 +1,4 @@
 {
   "repo": "solanabr/courses-academy",
-  "sha": "15668d9d77d3cf8dfb6c68e85169b1e1ab8d923f"
+  "sha": "bccd92fc4ff90c30f014e452de744d702a0413d6"
 }

--- a/apps/web/src/content/generated/meta.json
+++ b/apps/web/src/content/generated/meta.json
@@ -1,5 +1,5 @@
 {
-  "compiledAt": "2026-07-16T13:39:44Z",
+  "compiledAt": "2026-07-16T13:45:02Z",
   "counts": {
     "achievements": 10,
     "courses": 6,
@@ -7,5 +7,5 @@
     "lessons": 76,
     "quests": 5
   },
-  "sha": "15668d9d77d3cf8dfb6c68e85169b1e1ab8d923f"
+  "sha": "bccd92fc4ff90c30f014e452de744d702a0413d6"
 }


### PR DESCRIPTION
Bump `apps/web/content.lock` pin from `15668d9` to `bccd92f` and regenerate the committed content bundle.

Steps:
1. Edit `apps/web/content.lock`: set `"sha"` to `bccd92fc4ff90c30f014e452de744d702a0413d6`.
2. Run `pnpm --filter web compile-content`.
3. Commit both `apps/web/content.lock` and `apps/web/src/content/generated/`.

Compare: https://github.com/solanabr/courses-academy/compare/15668d9d77d3cf8dfb6c68e85169b1e1ab8d923f...bccd92fc4ff90c30f014e452de744d702a0413d6