### PR TITLE
fix: close AI cost holes on /api/ai/partner (#590)

### DIFF
--- a/apps/web/src/app/api/ai/__tests__/partner-route.test.ts
+++ b/apps/web/src/app/api/ai/__tests__/partner-route.test.ts
@@ -404,6 +404,26 @@ describe("POST /api/ai/partner", () => {
     expect(refundAssist).toHaveBeenCalledWith("user-1", "lesson-1");
   });
 
+  it("refunds a PRE-billing throw during prompt building (billed still false)", async () => {
+    // The prompt-building block is inside the widened try. A throw there — here
+    // the visibleTests map blows up on a malformed code block (tests: null) —
+    // happens before any Gemini call, so it is pre-billing: the catch refunds it
+    // under `if (!billed)` and records no billed assist.
+    getLessonBySlug.mockResolvedValue({
+      ...LESSON,
+      blocks: [LESSON.blocks[0], { ...LESSON.blocks[1], tests: null }],
+    });
+    stubGeminiFetch(PROPOSE_GEMINI_TEXT); // never reached
+
+    const { POST } = await import("../partner/route");
+    const res = await POST(makeRequest(VALID_BODY));
+
+    expect(res.status).toBe(500);
+    expect(refundAssist).toHaveBeenCalledTimes(1);
+    expect(refundAssist).toHaveBeenCalledWith("user-1", "lesson-1");
+    expect(recordBilledAssist).not.toHaveBeenCalled();
+  });
+
   it("returns 429 when rate limited", async () => {
     isRateLimited.mockResolvedValue(true);
     stubGeminiFetch(PROPOSE_GEMINI_TEXT);
@@ -429,14 +449,19 @@ describe("POST /api/ai/partner", () => {
 
     expect(res.status).toBe(429);
     expect(spendAssist).not.toHaveBeenCalled();
-    // Both dimensions were consulted, and the per-IP key uses failClosed.
+    // Both dimensions were consulted, and BOTH opt into failClosed — a limiter
+    // outage must not wave either through unmetered on the platform-funded key.
     const namespaces = isRateLimited.mock.calls.map((c) => c[0]);
     expect(namespaces).toContain("ai:partner");
     expect(namespaces).toContain("ai:partner:ip");
+    const userCall = isRateLimited.mock.calls.find(
+      (c) => c[0] === "ai:partner"
+    )!;
     const ipCall = isRateLimited.mock.calls.find(
       (c) => c[0] === "ai:partner:ip"
     )!;
-    expect(ipCall[2]).toMatchObject({ failClosed: true });
+    expect(userCall[2]).toEqual(expect.objectContaining({ failClosed: true }));
+    expect(ipCall[2]).toEqual(expect.objectContaining({ failClosed: true }));
   });
 
   it("returns 400 on malformed JSON body", async () => {

--- a/apps/web/src/app/api/ai/__tests__/partner-route.test.ts
+++ b/apps/web/src/app/api/ai/__tests__/partner-route.test.ts
@@ -10,17 +10,21 @@ vi.mock("@/lib/supabase/server", () => ({
 
 const spendAssist = vi.fn();
 const refundAssist = vi.fn();
+const recordBilledAssist = vi.fn();
 const appendAssistLog = vi.fn();
 vi.mock("@/lib/ai/assist-budget", () => ({
   spendAssist,
   refundAssist,
+  recordBilledAssist,
   appendAssistLog,
   MAX_PAID_ASSISTS: 4,
 }));
 
 const isRateLimited = vi.fn();
+const getClientIp = vi.fn(() => "203.0.113.9");
 vi.mock("@/lib/rate-limit", () => ({
   isRateLimited,
+  getClientIp,
 }));
 
 const getLessonBySlug = vi.fn();
@@ -100,7 +104,11 @@ const PROPOSE_GEMINI_TEXT = JSON.stringify({
 
 function stubGeminiFetch(
   text: string,
-  opts: { ok?: boolean; cachedContentTokenCount?: number } = {}
+  opts: {
+    ok?: boolean;
+    cachedContentTokenCount?: number;
+    finishReason?: string;
+  } = {}
 ) {
   vi.stubGlobal(
     "fetch",
@@ -109,7 +117,12 @@ function stubGeminiFetch(
         ok: opts.ok ?? true,
         text: async () => "error",
         json: async () => ({
-          candidates: [{ content: { parts: [{ text }] } }],
+          candidates: [
+            {
+              finishReason: opts.finishReason,
+              content: { parts: [{ text }] },
+            },
+          ],
           usageMetadata: {
             cachedContentTokenCount: opts.cachedContentTokenCount ?? 0,
           },
@@ -131,6 +144,7 @@ beforeEach(() => {
   getUser.mockReset();
   spendAssist.mockReset();
   refundAssist.mockReset();
+  recordBilledAssist.mockReset();
   appendAssistLog.mockReset();
   isRateLimited.mockReset();
   getLessonBySlug.mockReset();
@@ -141,6 +155,7 @@ beforeEach(() => {
   getLessonBySlug.mockResolvedValue(LESSON);
   spendAssist.mockResolvedValue({ allowed: true, used: 1 });
   refundAssist.mockResolvedValue(undefined);
+  recordBilledAssist.mockResolvedValue(undefined);
   appendAssistLog.mockResolvedValue(undefined);
 });
 
@@ -243,6 +258,31 @@ describe("POST /api/ai/partner", () => {
     expect(refundAssist).not.toHaveBeenCalled();
   });
 
+  it("records a billed assist exactly once on a successful paid call", async () => {
+    stubGeminiFetch(PROPOSE_GEMINI_TEXT);
+
+    const { POST } = await import("../partner/route");
+    await POST(makeRequest(VALID_BODY));
+
+    expect(recordBilledAssist).toHaveBeenCalledTimes(1);
+    expect(recordBilledAssist).toHaveBeenCalledWith("user-1", "lesson-1");
+  });
+
+  it("does NOT refund a post-success throw (appendAssistLog throws) — billed", async () => {
+    // The outer catch wraps appendAssistLog; a throw AFTER Gemini has billed us
+    // must NOT refund (the AIE-10 line-411 correction). The spend is recorded
+    // and the assist stays charged even though logging blew up.
+    stubGeminiFetch(PROPOSE_GEMINI_TEXT);
+    appendAssistLog.mockRejectedValue(new Error("log store down"));
+
+    const { POST } = await import("../partner/route");
+    const res = await POST(makeRequest(VALID_BODY));
+
+    expect(res.status).toBe(500);
+    expect(refundAssist).not.toHaveBeenCalled();
+    expect(recordBilledAssist).toHaveBeenCalledTimes(1);
+  });
+
   it("persists the AI turn to the assist log on a successful paid call", async () => {
     stubGeminiFetch(PROPOSE_GEMINI_TEXT);
 
@@ -294,29 +334,48 @@ describe("POST /api/ai/partner", () => {
     expect(refundAssist).toHaveBeenCalledWith("user-1", "lesson-1");
   });
 
-  it("calls refundAssist when Gemini returns an empty candidate text (502)", async () => {
+  it("does NOT refund an empty candidate text — it was billed (502)", async () => {
+    // Gemini returned a 200 (billed) but no visible output. The tokens are
+    // spent, so the assist must NOT be handed back, and the spend is recorded.
     stubGeminiFetch("");
 
     const { POST } = await import("../partner/route");
     const res = await POST(makeRequest(VALID_BODY));
 
     expect(res.status).toBe(502);
-    expect(refundAssist).toHaveBeenCalledTimes(1);
-    expect(refundAssist).toHaveBeenCalledWith("user-1", "lesson-1");
+    expect(refundAssist).not.toHaveBeenCalled();
+    expect(recordBilledAssist).toHaveBeenCalledTimes(1);
+    expect(recordBilledAssist).toHaveBeenCalledWith("user-1", "lesson-1");
   });
 
-  it("calls refundAssist when Gemini returns non-JSON text (502)", async () => {
+  it("does NOT refund non-JSON text — it was billed (502)", async () => {
     stubGeminiFetch("not valid json {{{");
 
     const { POST } = await import("../partner/route");
     const res = await POST(makeRequest(VALID_BODY));
 
     expect(res.status).toBe(502);
-    expect(refundAssist).toHaveBeenCalledTimes(1);
-    expect(refundAssist).toHaveBeenCalledWith("user-1", "lesson-1");
+    expect(refundAssist).not.toHaveBeenCalled();
+    expect(recordBilledAssist).toHaveBeenCalledTimes(1);
   });
 
-  it("calls refundAssist when Gemini returns a malformed propose payload (502)", async () => {
+  it("does NOT refund a MAX_TOKENS-truncated payload — it was billed (502)", async () => {
+    // AIE-11: the attacker-triggerable path. A truncated envelope arrives with
+    // finishReason "MAX_TOKENS" and cut-off JSON; Gemini billed the full output
+    // budget, so refunding it is exactly the hole #590 closes.
+    stubGeminiFetch('{"type":"propose","rationale":"the JSON is cut off her', {
+      finishReason: "MAX_TOKENS",
+    });
+
+    const { POST } = await import("../partner/route");
+    const res = await POST(makeRequest(VALID_BODY));
+
+    expect(res.status).toBe(502);
+    expect(refundAssist).not.toHaveBeenCalled();
+    expect(recordBilledAssist).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT refund a malformed propose payload — it was billed (502)", async () => {
     stubGeminiFetch(
       JSON.stringify({ type: "propose", rationale: "only rationale" })
     );
@@ -325,8 +384,8 @@ describe("POST /api/ai/partner", () => {
     const res = await POST(makeRequest(VALID_BODY));
 
     expect(res.status).toBe(502);
-    expect(refundAssist).toHaveBeenCalledTimes(1);
-    expect(refundAssist).toHaveBeenCalledWith("user-1", "lesson-1");
+    expect(refundAssist).not.toHaveBeenCalled();
+    expect(recordBilledAssist).toHaveBeenCalledTimes(1);
   });
 
   it("calls refundAssist when an unexpected error is thrown after spend (500)", async () => {
@@ -354,6 +413,30 @@ describe("POST /api/ai/partner", () => {
 
     expect(res.status).toBe(429);
     expect(spendAssist).not.toHaveBeenCalled();
+  });
+
+  it("trips the per-IP ceiling independently of the per-user bucket (429)", async () => {
+    // Per-user passes, per-IP ("ai:partner:ip") trips — every fresh account is a
+    // fresh per-user bucket, so per-IP is the only dimension that bounds a Sybil
+    // actor. The IP ceiling alone must 429 before any spend.
+    isRateLimited.mockImplementation(async (namespace: string) => {
+      return namespace === "ai:partner:ip";
+    });
+    stubGeminiFetch(PROPOSE_GEMINI_TEXT);
+
+    const { POST } = await import("../partner/route");
+    const res = await POST(makeRequest(VALID_BODY));
+
+    expect(res.status).toBe(429);
+    expect(spendAssist).not.toHaveBeenCalled();
+    // Both dimensions were consulted, and the per-IP key uses failClosed.
+    const namespaces = isRateLimited.mock.calls.map((c) => c[0]);
+    expect(namespaces).toContain("ai:partner");
+    expect(namespaces).toContain("ai:partner:ip");
+    const ipCall = isRateLimited.mock.calls.find(
+      (c) => c[0] === "ai:partner:ip"
+    )!;
+    expect(ipCall[2]).toMatchObject({ failClosed: true });
   });
 
   it("returns 400 on malformed JSON body", async () => {

--- a/apps/web/src/app/api/ai/partner/route.ts
+++ b/apps/web/src/app/api/ai/partner/route.ts
@@ -271,46 +271,52 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ budgetExhausted: true, used: spend.used });
   }
 
-  // Post-D4 every test is public; feed them all to the prompt.
-  const visibleTests = codeBlock.tests.map((t) => ({
-    description: t.description,
-    input: t.input,
-    expectedOutput: t.expectedOutput,
-  }));
-
-  // Task brief = the lesson's prose blocks (resolved markdown), joined in order.
-  const task = lesson.blocks
-    .filter((b): b is ProseBlockData => b._type === "prose")
-    .map((b) => b.src)
-    .join("\n\n");
-
-  const prefix = buildStaticPrefix({
-    task,
-    visibleTests,
-    solution: codeBlock.solution,
-    tutorNotes: undefined,
-    language: codeBlock.language,
-  });
-  const suffix = buildDynamicSuffix({
-    lessonSlug,
-    courseSlug,
-    action,
-    message,
-    code,
-    testSummary,
-  });
-
   // Whether Gemini has BILLED us for this request. Flips true the instant the
-  // model returns a 200 — a non-200 or a network throw means it never ran. This
-  // gates the refund: we hand the assist back ONLY when we were not billed. A
-  // successful-but-useless generation (empty, non-JSON, or MAX_TOKENS
-  // truncation) is billed cost and is NOT refunded, closing the hole where
-  // reliably triggering truncation bought unlimited billed calls against a quota
-  // that never decremented (AIE-10/-11). The CAUSE — attacker-triggerable
+  // model returns a 2xx (`response.ok`) — a non-2xx or a network throw means it
+  // never ran. This gates the refund: we hand the assist back ONLY when we were
+  // not billed. A successful-but-useless generation (empty, non-JSON, or
+  // MAX_TOKENS truncation) is billed cost and is NOT refunded, closing the hole
+  // where reliably triggering truncation bought unlimited billed calls against a
+  // quota that never decremented (AIE-10/-11). The CAUSE — attacker-triggerable
   // truncation — is closed separately by spec item 3a (diff-propose +
   // MAX_CODE_CHARS trim), landing the same week.
   let billed = false;
   try {
+    // Prompt-building lives INSIDE the try on purpose: any throw here (a
+    // malformed block, a builder error) is PRE-billing — `billed` is still
+    // false — so the catch refunds it under `if (!billed)`. Nothing built here
+    // is referenced after the try, so widening the boundary changes no other
+    // semantics.
+
+    // Post-D4 every test is public; feed them all to the prompt.
+    const visibleTests = codeBlock.tests.map((t) => ({
+      description: t.description,
+      input: t.input,
+      expectedOutput: t.expectedOutput,
+    }));
+
+    // Task brief = the lesson's prose blocks (resolved markdown), joined in order.
+    const task = lesson.blocks
+      .filter((b): b is ProseBlockData => b._type === "prose")
+      .map((b) => b.src)
+      .join("\n\n");
+
+    const prefix = buildStaticPrefix({
+      task,
+      visibleTests,
+      solution: codeBlock.solution,
+      tutorNotes: undefined,
+      language: codeBlock.language,
+    });
+    const suffix = buildDynamicSuffix({
+      lessonSlug,
+      courseSlug,
+      action,
+      message,
+      code,
+      testSummary,
+    });
+
     const response = await fetch(`${GEMINI_URL}?key=${GEMINI_API_KEY}`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -350,9 +356,10 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Past this point Gemini has BILLED us (it returned a 200). Mark the request
-    // billed so no downstream failure path refunds it, and record the spend in
-    // the non-refundable billed-assists counter (best-effort, never throws).
+    // Past this point Gemini has BILLED us (`response.ok` — a 2xx). Mark the
+    // request billed so no downstream failure path refunds it, and record the
+    // spend in the non-refundable billed-assists counter (best-effort, never
+    // throws).
     billed = true;
     await recordBilledAssist(user.id, lesson._id);
 

--- a/apps/web/src/app/api/ai/partner/route.ts
+++ b/apps/web/src/app/api/ai/partner/route.ts
@@ -1,11 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
 import type { CodeBlockData, ProseBlockData } from "@superteam-lms/types";
 import { createClient } from "@/lib/supabase/server";
-import { isRateLimited } from "@/lib/rate-limit";
+import { isRateLimited, getClientIp } from "@/lib/rate-limit";
 import { getLessonBySlug } from "@/lib/content/queries";
 import {
   spendAssist,
   refundAssist,
+  recordBilledAssist,
   appendAssistLog,
 } from "@/lib/ai/assist-budget";
 import { sealCheck } from "@/lib/ai/check-seal";
@@ -207,12 +208,39 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  // Per-user rate limit (abuse mitigation only — fails open, NOT the cost
-  // ceiling; the fail-closed assist budget below is).
+  // Rate limit this route fail-CLOSED — it spends a platform-funded Gemini key,
+  // so a limiter-store outage must DENY, not wave traffic through unmetered (the
+  // rest of the app's limiters stay fail-open; only cost-critical callers opt
+  // in). Two dimensions, both required and both fail-closed:
+  //   • per-user bounds one account hammering the route;
+  //   • per-IP bounds an ACTOR — wallet sign-up is free, so per-user keys cannot
+  //     bound Sybils where every fresh account is a fresh bucket (the exact
+  //     reason /api/lessons/complete carries both).
   if (
     await isRateLimited("ai:partner", user.id, {
       maxTokens: 20,
       refillIntervalMs: 60_000,
+      failClosed: true,
+    })
+  ) {
+    return NextResponse.json(
+      { error: "Rate limit exceeded. Please wait before trying again." },
+      { status: 429, headers: { "Retry-After": "60" } }
+    );
+  }
+
+  // Per-IP ceiling, sized off the worst LEGITIMATE case, not a round number: a
+  // bootcamp cohort (~60) or a CGNAT'd BR mobile carrier behind one NAT, each
+  // learner holding MAX_PAID_ASSISTS paid assists per lesson. A fixed window is
+  // a cliff, not a throttle, so undershooting 429s a whole classroom at once;
+  // 600/min clears that with headroom while still bounding a Sybil actor's burn
+  // rate from a single address. The cost CEILING is the fail-closed assist
+  // budget below (+ #591's spend ledger), not this throttle.
+  if (
+    await isRateLimited("ai:partner:ip", getClientIp(request.headers), {
+      maxTokens: 600,
+      refillIntervalMs: 60_000,
+      failClosed: true,
     })
   ) {
     return NextResponse.json(
@@ -272,6 +300,16 @@ export async function POST(request: NextRequest) {
     testSummary,
   });
 
+  // Whether Gemini has BILLED us for this request. Flips true the instant the
+  // model returns a 200 — a non-200 or a network throw means it never ran. This
+  // gates the refund: we hand the assist back ONLY when we were not billed. A
+  // successful-but-useless generation (empty, non-JSON, or MAX_TOKENS
+  // truncation) is billed cost and is NOT refunded, closing the hole where
+  // reliably triggering truncation bought unlimited billed calls against a quota
+  // that never decremented (AIE-10/-11). The CAUSE — attacker-triggerable
+  // truncation — is closed separately by spec item 3a (diff-propose +
+  // MAX_CODE_CHARS trim), landing the same week.
+  let billed = false;
   try {
     const response = await fetch(`${GEMINI_URL}?key=${GEMINI_API_KEY}`, {
       method: "POST",
@@ -312,6 +350,12 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    // Past this point Gemini has BILLED us (it returned a 200). Mark the request
+    // billed so no downstream failure path refunds it, and record the spend in
+    // the non-refundable billed-assists counter (best-effort, never throws).
+    billed = true;
+    await recordBilledAssist(user.id, lesson._id);
+
     const data = await response.json();
     // Prompt-cache observability — useful for tuning the cache-shaped prefix, but
     // this is the SUCCESS path of every paid call, so keep it opt-in (default
@@ -328,10 +372,11 @@ export async function POST(request: NextRequest) {
     const finishReason = data?.candidates?.[0]?.finishReason;
     const rawText = data?.candidates?.[0]?.content?.parts?.[0]?.text ?? "";
     if (!rawText) {
-      // finishReason === "MAX_TOKENS" here means the budget was spent before any
-      // visible output (raise maxTokensFor(action)); log it so it's diagnosable.
+      // Billed but useless — usually finishReason "MAX_TOKENS" with the budget
+      // spent before any visible output. NOT refunded: Gemini billed the tokens.
+      // Log the reason so maxTokensFor(action) can be tuned; item 3a's
+      // diff-propose + smaller MAX_CODE_CHARS is what makes this hard to trigger.
       console.error("[ai/partner] empty output", { action, finishReason });
-      await refundAssist(user.id, lesson._id);
       return NextResponse.json(
         { error: "AI could not generate a response" },
         { status: 502 }
@@ -342,14 +387,14 @@ export async function POST(request: NextRequest) {
     try {
       parsed = JSON.parse(rawText);
     } catch {
-      // Usually a truncated payload (finishReason "MAX_TOKENS"): the JSON is cut
-      // off mid-string. Log the reason + a snippet so the cap can be tuned.
+      // Billed but unusable — a truncated payload (finishReason "MAX_TOKENS")
+      // cut off mid-string. NOT refunded: the tokens were billed. Log the reason
+      // + a snippet so the cap can be tuned.
       console.error("[ai/partner] non-JSON output", {
         action,
         finishReason,
         snippet: rawText.slice(0, 200),
       });
-      await refundAssist(user.id, lesson._id);
       return NextResponse.json(
         { error: "AI returned an invalid response" },
         { status: 502 }
@@ -358,8 +403,9 @@ export async function POST(request: NextRequest) {
 
     const validated = validatePartnerResponse(parsed);
     if (!validated) {
+      // Billed but structurally wrong (or truncated past the point the JSON
+      // still parsed). NOT refunded — the tokens were billed.
       console.error("Gemini partner API returned a malformed payload");
-      await refundAssist(user.id, lesson._id);
       return NextResponse.json(
         { error: "AI returned an invalid response" },
         { status: 502 }
@@ -406,9 +452,14 @@ export async function POST(request: NextRequest) {
     return NextResponse.json(clientResponse);
   } catch (error) {
     console.error("AI partner error:", error);
-    // Same reasoning as the other post-spend failure paths: refund the spend
-    // that already happened before this try block.
-    await refundAssist(user.id, lesson._id);
+    // Refund ONLY if Gemini never billed us — a throw before the 200 (network
+    // failure, DNS, TLS, abort). A throw AFTER `billed` (envelope parse, seal,
+    // or appendAssistLog) is post-billing and must NOT refund: this catch wraps
+    // appendAssistLog, so the old unconditional refund handed back a fully
+    // billed success (the AIE-10 line-411 correction).
+    if (!billed) {
+      await refundAssist(user.id, lesson._id);
+    }
     return NextResponse.json(
       { error: "Failed to get response" },
       { status: 500 }

--- a/apps/web/src/lib/__tests__/rate-limit.test.ts
+++ b/apps/web/src/lib/__tests__/rate-limit.test.ts
@@ -1,11 +1,23 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 
 vi.mock("server-only", () => ({}));
 vi.mock("@/lib/supabase/admin", () => ({ createAdminClient: vi.fn() }));
 
-import { getClientIp } from "@/lib/rate-limit";
+import { getClientIp, isRateLimited } from "@/lib/rate-limit";
+import { createAdminClient } from "@/lib/supabase/admin";
 
 const h = (headers: Record<string, string>) => new Headers(headers);
+
+// Wire createAdminClient().rpc("check_rate_limit", …) to a canned result: an
+// object resolves to { data, error }; an Error instance makes rpc throw.
+function stubRpc(result: { data?: unknown; error?: unknown } | Error) {
+  vi.mocked(createAdminClient).mockReturnValue({
+    rpc: vi.fn(async () => {
+      if (result instanceof Error) throw result;
+      return { data: result.data ?? null, error: result.error ?? null };
+    }),
+  } as unknown as ReturnType<typeof createAdminClient>);
+}
 
 describe("getClientIp — header trust order", () => {
   it("prefers x-vercel-forwarded-for, which the client cannot forge", () => {
@@ -117,5 +129,61 @@ describe("getClientIp — IPv6 collapses to a /64 bucket", () => {
     expect(getClientIp(h({ "x-real-ip": "203.0.113.8" }))).not.toBe(
       "203.0.113.7"
     );
+  });
+});
+
+// The default is fail-OPEN (a store blip must not hard-block traffic on a
+// non-auth throttle); cost-critical callers opt into fail-CLOSED. #590 turns the
+// AI route fail-closed so a limiter outage can't hand out unmetered generations
+// on the platform-funded Gemini key.
+describe("isRateLimited — fail-open default, fail-closed opt-in", () => {
+  const OPTS = { maxTokens: 20, refillIntervalMs: 60_000 };
+
+  beforeEach(() => {
+    vi.mocked(createAdminClient).mockReset();
+  });
+
+  it("returns the store verdict when the store is healthy (limited)", async () => {
+    stubRpc({ data: true });
+    expect(await isRateLimited("ns", "key", OPTS)).toBe(true);
+  });
+
+  it("returns the store verdict when the store is healthy (allowed)", async () => {
+    stubRpc({ data: false });
+    expect(await isRateLimited("ns", "key", OPTS)).toBe(false);
+  });
+
+  it("fails OPEN by default when the RPC returns an error", async () => {
+    stubRpc({ error: { message: "store down" } });
+    expect(await isRateLimited("ns", "key", OPTS)).toBe(false);
+  });
+
+  it("fails OPEN by default when the RPC throws", async () => {
+    stubRpc(new Error("connection refused"));
+    expect(await isRateLimited("ns", "key", OPTS)).toBe(false);
+  });
+
+  it("fails CLOSED (denies) on an RPC error when failClosed is set", async () => {
+    stubRpc({ error: { message: "store down" } });
+    expect(
+      await isRateLimited("ai:partner", "key", { ...OPTS, failClosed: true })
+    ).toBe(true);
+  });
+
+  it("fails CLOSED (denies) on an RPC throw when failClosed is set", async () => {
+    stubRpc(new Error("connection refused"));
+    expect(
+      await isRateLimited("ai:partner", "key", { ...OPTS, failClosed: true })
+    ).toBe(true);
+  });
+
+  it("a flagged and an unflagged caller diverge on the SAME store error", async () => {
+    stubRpc({ error: { message: "store down" } });
+    // Same failure, opposite verdicts — the flag is the only difference, so one
+    // route hardening cannot silently change another caller's semantics.
+    expect(await isRateLimited("other", "key", OPTS)).toBe(false);
+    expect(
+      await isRateLimited("ai:partner", "key", { ...OPTS, failClosed: true })
+    ).toBe(true);
   });
 });

--- a/apps/web/src/lib/ai/__tests__/assist-budget.test.ts
+++ b/apps/web/src/lib/ai/__tests__/assist-budget.test.ts
@@ -11,6 +11,7 @@ import {
   spendAssist,
   getAssistsUsed,
   refundAssist,
+  recordBilledAssist,
   MAX_PAID_ASSISTS,
 } from "../assist-budget";
 
@@ -80,6 +81,27 @@ describe("assist-budget", () => {
     it("swallows a thrown RPC without throwing", async () => {
       rpc.mockRejectedValueOnce(new Error("network"));
       await expect(refundAssist("u", "l")).resolves.toBeUndefined();
+    });
+  });
+
+  describe("recordBilledAssist", () => {
+    it("calls the billed-counter RPC with the right args", async () => {
+      rpc.mockResolvedValue({ data: null, error: null });
+      await recordBilledAssist("u", "l");
+      expect(rpc).toHaveBeenCalledWith("record_billed_assist", {
+        p_user_id: "u",
+        p_lesson_id: "l",
+      });
+    });
+
+    it("swallows an RPC error without throwing (best-effort audit write)", async () => {
+      rpc.mockResolvedValue({ data: null, error: { message: "db down" } });
+      await expect(recordBilledAssist("u", "l")).resolves.toBeUndefined();
+    });
+
+    it("swallows a thrown RPC without throwing", async () => {
+      rpc.mockRejectedValueOnce(new Error("network"));
+      await expect(recordBilledAssist("u", "l")).resolves.toBeUndefined();
     });
   });
 });

--- a/apps/web/src/lib/ai/assist-budget.ts
+++ b/apps/web/src/lib/ai/assist-budget.ts
@@ -96,6 +96,32 @@ export async function refundAssist(
 }
 
 /**
+ * Increment the NON-REFUNDABLE billed-assist counter for a (user, lesson): one
+ * bump per confirmed Gemini 200, regardless of whether the output was usable
+ * (empty / non-JSON / MAX_TOKENS-truncated all still cost us). Unlike
+ * `assists_used` — which the `!response.ok` refund path can hand back — this is
+ * the durable record of real spend against the platform-funded key, so it is
+ * never decremented. Best-effort: an audit-counter write must not break the
+ * paid reply the learner is owed, so this never throws.
+ */
+export async function recordBilledAssist(
+  userId: string,
+  lessonId: string
+): Promise<void> {
+  try {
+    const { error } = await createAdminClient().rpc("record_billed_assist", {
+      p_user_id: userId,
+      p_lesson_id: lessonId,
+    });
+    if (error) {
+      console.warn("[assist-budget] record billed failed:", error.message);
+    }
+  } catch (err) {
+    console.warn("[assist-budget] record billed threw:", err);
+  }
+}
+
+/**
  * Append rendered chat turns to the learner's per-lesson AI Partner log so a
  * returning learner can review past notes without spending another assist.
  * Called ONLY on a successful paid response (after every refund path has

--- a/apps/web/src/lib/rate-limit.ts
+++ b/apps/web/src/lib/rate-limit.ts
@@ -8,13 +8,21 @@ import { createAdminClient } from "@/lib/supabase/admin";
 // atomic `check_rate_limit` SECURITY DEFINER function, so limits hold across
 // all serverless instances (unlike the previous in-memory Map).
 //
-// Fails OPEN: if the store is unreachable we allow the request rather than
-// hard-blocking traffic on a transient DB issue (the limiter is abuse/cost
-// mitigation, not an auth gate). Failures are logged.
+// Fails OPEN by default: if the store is unreachable we allow the request
+// rather than hard-blocking traffic on a transient DB issue (the limiter is
+// abuse/cost mitigation, not an auth gate). Failures are logged. Cost-critical
+// callers pass `failClosed: true` to DENY instead — see RateLimiterOptions.
 
 interface RateLimiterOptions {
   maxTokens: number;
   refillIntervalMs: number;
+  // On a store error the limiter normally fails OPEN (allow) — it is abuse/cost
+  // mitigation, not an auth gate, and a transient DB blip shouldn't hard-block
+  // traffic. Cost-critical callers opt into failing CLOSED: a store error then
+  // DENIES rather than handing out an unmetered request against a
+  // platform-funded resource (the AI route on the shared Gemini key). Default:
+  // fail open, so every existing caller keeps its current behaviour.
+  failClosed?: boolean;
 }
 
 /**
@@ -104,19 +112,23 @@ export async function isRateLimited(
 
     if (error) {
       console.warn(
-        `[rate-limit] check_rate_limit failed for ${namespace}, allowing:`,
+        `[rate-limit] check_rate_limit failed for ${namespace}, ${
+          opts.failClosed ? "denying" : "allowing"
+        }:`,
         error.message
       );
-      return false;
+      return opts.failClosed === true;
     }
 
     return data === true;
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     console.warn(
-      `[rate-limit] limiter unavailable for ${namespace}, allowing:`,
+      `[rate-limit] limiter unavailable for ${namespace}, ${
+        opts.failClosed ? "denying" : "allowing"
+      }:`,
       message
     );
-    return false;
+    return opts.failClosed === true;
   }
 }

--- a/apps/web/src/lib/supabase/types.ts
+++ b/apps/web/src/lib/supabase/types.ts
@@ -1004,6 +1004,13 @@ export type Database = {
         };
         Returns: undefined;
       };
+      record_billed_assist: {
+        Args: {
+          p_user_id: string;
+          p_lesson_id: string;
+        };
+        Returns: undefined;
+      };
       append_challenge_assist_log: {
         Args: {
           p_user_id: string;

--- a/supabase/migrations/20260725120000_billed_assists_counter.sql
+++ b/supabase/migrations/20260725120000_billed_assists_counter.sql
@@ -1,0 +1,38 @@
+-- Migration: billed_assists_counter (#590 — AI cost holes)
+-- Records that a BILLED Gemini generation occurred, independent of the
+-- refundable per-(user, lesson) paid-assist quota. The route now refunds an
+-- assist ONLY when Gemini was not billed (!response.ok / a pre-200 network
+-- throw); a successful-but-useless generation (empty / non-JSON / MAX_TOKENS
+-- truncation) is billed cost and no longer refunds. `billed_assists` is the
+-- durable, never-decremented audit trail of that spend against the
+-- platform-funded key.
+--
+-- Additive + idempotent — safe to run on an existing database. Mirrors the
+-- definitions added to supabase/schema.sql. record_billed_assist follows the
+-- exact hardening pattern of the other challenge_assists RPCs: SECURITY
+-- DEFINER, search_path-pinned, RLS-on table with no policies, REVOKE from
+-- PUBLIC/anon/authenticated, GRANT to service_role only.
+
+-- 1. Non-refundable, monotonic count of billed generations for a (user, lesson).
+ALTER TABLE challenge_assists
+  ADD COLUMN IF NOT EXISTS billed_assists INTEGER NOT NULL DEFAULT 0;
+
+-- 2. Increment-by-one on each confirmed Gemini 200. Never decremented. The row
+--    already exists (spend_challenge_assist upserted it on the same paid call),
+--    but upsert defensively.
+CREATE OR REPLACE FUNCTION record_billed_assist(p_user_id UUID, p_lesson_id TEXT)
+RETURNS VOID
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+  INSERT INTO public.challenge_assists (user_id, lesson_id, billed_assists, updated_at)
+  VALUES (p_user_id, p_lesson_id, 1, now())
+  ON CONFLICT (user_id, lesson_id)
+  DO UPDATE SET
+    billed_assists = public.challenge_assists.billed_assists + 1,
+    updated_at = now();
+$$;
+
+REVOKE ALL ON FUNCTION record_billed_assist(UUID, TEXT) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION record_billed_assist(UUID, TEXT) TO service_role;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -1864,6 +1864,12 @@ CREATE TABLE IF NOT EXISTS challenge_assists (
   user_id     UUID NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
   lesson_id   TEXT NOT NULL,
   assists_used INTEGER NOT NULL DEFAULT 0,
+  -- Monotonic count of BILLED Gemini generations (one per confirmed 200),
+  -- incremented by record_billed_assist and NEVER decremented — the durable
+  -- record of real spend against the platform-funded key. Distinct from
+  -- assists_used, which the !response.ok refund path can hand back: a billed-but-
+  -- useless generation (empty / non-JSON / MAX_TOKENS) still counts here.
+  billed_assists INTEGER NOT NULL DEFAULT 0,
   -- Rendered AI Partner chat turns (JSONB array of PartnerMessage) so a
   -- returning learner can review past AI notes without spending another paid
   -- assist. Bounded in practice by MAX_PAID_ASSISTS successful paid actions.
@@ -1875,6 +1881,10 @@ CREATE TABLE IF NOT EXISTS challenge_assists (
 -- Idempotent add for DBs created before chat_log existed (this file predates it).
 ALTER TABLE challenge_assists
   ADD COLUMN IF NOT EXISTS chat_log JSONB NOT NULL DEFAULT '[]'::jsonb;
+
+-- Idempotent add for DBs created before the non-refundable billed counter.
+ALTER TABLE challenge_assists
+  ADD COLUMN IF NOT EXISTS billed_assists INTEGER NOT NULL DEFAULT 0;
 
 ALTER TABLE challenge_assists ENABLE ROW LEVEL SECURITY;
 -- No policies: reached only through SECURITY DEFINER RPCs called by service_role.
@@ -1962,6 +1972,30 @@ $$;
 
 REVOKE ALL ON FUNCTION refund_challenge_assist(UUID, TEXT) FROM PUBLIC, anon, authenticated;
 GRANT EXECUTE ON FUNCTION refund_challenge_assist(UUID, TEXT) TO service_role;
+
+-- Increment-by-one, never decremented. Records that a BILLED Gemini generation
+-- occurred for this (user, lesson) — called once per confirmed 200, regardless
+-- of whether the output was usable. This is the audit trail of real spend
+-- against the platform-funded key; unlike assists_used it is never refunded, so
+-- a truncated/empty/malformed-but-billed generation still counts. The row
+-- already exists by the time this runs (spend_challenge_assist upserted it on
+-- the same paid call), but upsert defensively.
+CREATE OR REPLACE FUNCTION record_billed_assist(p_user_id UUID, p_lesson_id TEXT)
+RETURNS VOID
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+  INSERT INTO public.challenge_assists (user_id, lesson_id, billed_assists, updated_at)
+  VALUES (p_user_id, p_lesson_id, 1, now())
+  ON CONFLICT (user_id, lesson_id)
+  DO UPDATE SET
+    billed_assists = public.challenge_assists.billed_assists + 1,
+    updated_at = now();
+$$;
+
+REVOKE ALL ON FUNCTION record_billed_assist(UUID, TEXT) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION record_billed_assist(UUID, TEXT) TO service_role;
 
 -- Append rendered chat turns to a learner's per-lesson AI Partner log.
 -- p_entries is a JSONB array (PartnerMessage[]). The row already exists by the


### PR DESCRIPTION
Closes #590

Three verified holes on `/api/ai/partner` compounded into an unbounded spend path on the platform-funded Gemini key. This is **live exposure**, not a launch feature. All three were re-confirmed in code (spec §2.5 AIE-10/-11/-12/-13, all CONFIRMED).

## The three holes and what closed each

**1. Refund-after-billing (AIE-10, incl. the line-411 correction).**
The route called `refundAssist()` on empty output, unparseable JSON, and MAX_TOKENS truncation — every one of those AFTER Gemini had already billed the tokens — and the outer `catch` (which wraps `appendAssistLog`) refunded even a throw that happened *after a fully-billed success*. A caller who reliably triggers truncation got unlimited billed generations against a quota that never decremented.
- Added a `billed` flag that flips `true` the instant Gemini returns a **2xx** (`response.ok`). Refund now fires **only when `!billed`** — a non-2xx (`!response.ok`) or a pre-response throw (DNS/TLS/abort, or a throw during prompt-building), i.e. the cases where the model never ran.
- The `try` was widened to cover prompt-building (`visibleTests` / `task` / `buildStaticPrefix` / `buildDynamicSuffix`) without moving `spendAssist` or touching any other semantics — nothing built there is used after the try. A throw in prompt-building is now pre-billing and correctly refunds under `if (!billed)`, closing a pre-existing (practically unreachable) spent-but-not-refunded window. Covered by a new test.
- Removed the refund from the empty / non-JSON / malformed branches (all post-billing).
- Narrowed the outer catch to `if (!billed) refund` so a post-success throw (envelope parse, seal, or `appendAssistLog`) no longer hands back a billed assist.

**2. Fail-open limiter (AIE-12).**
`lib/rate-limit.ts` returned `false` (= allow) from both its error branches, so a store outage made the AI route unmetered. Added an **opt-in `failClosed` flag** to `RateLimiterOptions`: a flagged caller returns `true` (deny) on a store error; the default is unchanged, so every other caller keeps failing open. Both `ai:partner` checks opt in.

**3. No per-IP bucket (AIE-12).**
The route keyed only on `user.id`, and wallet signup is free — so per-user buckets cannot bound an actor (every fresh account is a fresh bucket). Added an `ai:partner:ip` token bucket via `getClientIp`, mirroring `/api/lessons/complete`. Sized at 600/min: clears a NAT'd/CGNAT'd BR classroom (a fixed window is a cliff, not a throttle) while still bounding a Sybil actor's burn rate from one address.

## `billed_assists` counter — design choice

`assists_used` is **refundable** (the `!response.ok` path still gives it back), so it is not a faithful record of billing. Added a separate, non-refundable `billed_assists` counter, incremented once per confirmed 2xx **regardless of output quality** (empty / non-JSON / truncated-but-billed all still count) and never decremented — the durable audit trail of real spend against the shared key.

I deliberately did **not** bump the counter inside `spend_challenge_assist`: spend happens *before* the billing signal, and the `!response.ok` path is a genuine not-billed case, so counting at spend time would over-count. The counter is bumped from the route at the exact moment billing is confirmed, via a new `record_billed_assist` SECURITY DEFINER RPC that follows the existing hardening pattern verbatim (RLS-on table with no policies, `SET search_path = ''`, REVOKE from PUBLIC/anon/authenticated, GRANT to service_role only). Best-effort on the TS side — an audit write must not break the paid reply.

## Schema / migrations

- `supabase/schema.sql`: added the `billed_assists` column (+ idempotent `ALTER`) and the `record_billed_assist` function.
- New migration `supabase/migrations/20260725120000_billed_assists_counter.sql`, matching the additive + idempotent convention of its siblings.
- Generated `src/lib/supabase/types.ts`: added the `record_billed_assist` function signature (RPC names are type-constrained).
- **Nothing applied to any live database.** No `supabase db push`, no MCP apply. Shipping the SQL is this PR; applying it is the gate/owner's dry-run-first call.

## Fairness window (named, not hidden)

Removing the refund closes the hole but leaves its **cause** — AIE-11's attacker-triggerable truncation — open until **spec item 3a** (diff-propose + `MAX_CODE_CHARS` 20k→8k) lands. 3a is a separate follow-up shipping the **same week**, deliberately not in this PR. In the gap, an honest learner with a long file can be charged an assist for a truncated answer. Per the spec: **if 3a slips past a week, restore a NARROW refund keyed to `finishReason === "MAX_TOKENS"` only — never the broad catch.**

## Verification (run for real)

- `pnpm typecheck` (apps/web) → pass, no output.
- `pnpm test` (apps/web) → **102 files, 948 tests pass** (full suite, incl. the new/updated tests).
- `npx eslint` on all touched files → **0 errors** (1–2 pre-existing, non-blocking `import/order` warnings that match the repo's standard mock-then-import test layout; `next lint` does not fail on warnings).
- `npx prettier --check` on the 7 touched TS files → clean. SQL is outside prettier's glob (no SQL parser).

New/updated route tests: truncation (`finishReason: "MAX_TOKENS"`), empty, non-JSON, and malformed outputs **do not refund** but **do** record a billed assist; `!response.ok` **does** refund; a post-success throw (`appendAssistLog` rejects) **does not** refund; a **pre-billing throw during prompt-building does refund** (proves the widened `try`); the per-IP ceiling trips independently of per-user, and **both** `ai:partner` keys are asserted `failClosed: true`. Rate-limiter unit tests: a store error denies for a `failClosed` caller while an unflagged caller on the *same* error stays open. `assist-budget` unit tests cover `recordBilledAssist` (args + best-effort no-throw on error/throw).

## Out of scope (found, not fixed)

- **Spec item 3a** (diff-propose, `MAX_CODE_CHARS` 20k→8k) — separate follow-up, same week; it is what actually closes the truncation *cause*.
- **#591 spend ledger** — blocked on owner decision O-1; the real per-account cost ceiling.
- **Model/pricing routing (3b)** — blocked on two unverifiable curls.
- **`/api/lessons/reflect` + `lib/ai/reflection-reply.ts`** (PR #611, in flight) — not touched. Its rate-limit fail-open interaction is deliberately deferred to this flag landing. Follow-up after both merge: `ai:reflection` can now opt into `failClosed` the same way — left out here to avoid a cross-PR conflict.

