### PR TITLE
fix: bot-review follow-ups from merged #610/#611 (comment accuracy + a11y)

### DIFF
--- a/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/blocks/open-ended-block.tsx
+++ b/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/blocks/open-ended-block.tsx
@@ -83,7 +83,7 @@ export function OpenEndedBlock({ block, ctx }: BlockRenderProps) {
           variant={status === "done" ? "outline" : "pushSuccess"}
           size="sm"
           onClick={submit}
-          disabled={!canSubmit && status !== "error"}
+          disabled={!canSubmit}
           aria-disabled={!canSubmit}
         >
           {status === "submitting" ? (

--- a/apps/web/src/lib/challenge/buildable-executor.ts
+++ b/apps/web/src/lib/challenge/buildable-executor.ts
@@ -46,13 +46,15 @@
  * ⚠️ OPERATIONAL SECURITY — grading an untrusted `anchor build` runs the
  * submission's `build.rs` / proc-macros as arbitrary code on the build host; the
  * SBF target sandboxes the *compiled* program, NOT the build itself. Network
- * egress isolation is what contains that, and it is delivered: #193 attaches the
- * Cloud Run build server to a VPC whose firewall DENIES egress (one-time
- * `gcloud` steps in `apps/build-server/deploy/HARDENING.md`). Enabling this
- * grader in production is therefore an OPS action, not a code change: set
- * `BUILD_SERVER_URL` + `BUILD_SERVER_API_KEY` in the prod env, and only against a
- * build server actually deployed with the deny-egress VPC vars. While they are
- * unset the grader fails closed (buildable lessons 503) and blocks nothing.
+ * egress isolation is what contains that. The mechanism exists (#193: Cloud Run
+ * VPC + deny-egress firewall, `apps/build-server/deploy/HARDENING.md`) but it is
+ * OPT-IN at deploy time — `deploy/deploy.sh` only attaches the VPC when
+ * `VPC_NETWORK`/`VPC_SUBNET` are set, and WARNS-then-deploys unrestricted when
+ * they are not. Enabling this grader in production is therefore an OPS action
+ * with a verification step, not a code change: confirm the live build server
+ * was deployed WITH the deny-egress VPC vars, then set `BUILD_SERVER_URL` +
+ * `BUILD_SERVER_API_KEY` in the prod env. While they are unset the grader fails
+ * closed (buildable lessons 503) and blocks nothing.
  */
 
 import type { AdminTestCase } from "@superteam-lms/types";


### PR DESCRIPTION
Two non-blocking findings from the claude-review bot on PRs #610 and #611, which the gate merged before the fixes could land on their branches. Cherry-picked onto main:

1. **`buildable-executor.ts` comment overstated the egress-isolation guarantee** (bot finding on #610): it said deny-egress "is delivered", but `apps/build-server/deploy/deploy.sh` only attaches the VPC when `VPC_NETWORK`/`VPC_SUBNET` are set at deploy time — otherwise it warns and deploys unrestricted. The comment now states the mechanism is opt-in and adds the verification step to the ops instruction. Comment-only.
2. **`open-ended-block.tsx` `disabled`/`aria-disabled` mismatch** (bot finding on #611): after an error with empty/over-limit text, the real `disabled` attribute flipped false while `aria-disabled` stayed true — screen readers and sighted users saw different affordances. Both now derive from `!canSubmit`. (`submit()` already no-ops via the same guard, so behavior is unchanged for keyboard/mouse; the a11y announcement is now consistent.)

Housekeeping note for the owner: my pushes accidentally recreated the two merged PRs' branches (`fix/build-server-toolchain-bump-25-07-2026`, `feat/openended-attestation-route-25-07-2026`) — they're orphans now, safe to delete; the permission classifier wouldn't let this session delete them.
