### PR TITLE
fix: recover two review fixes stranded by a branch-lifecycle collision

### DIFF
--- a/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/blocks/open-ended-block.tsx
+++ b/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/blocks/open-ended-block.tsx
@@ -83,7 +83,7 @@ export function OpenEndedBlock({ block, ctx }: BlockRenderProps) {
           variant={status === "done" ? "outline" : "pushSuccess"}
           size="sm"
           onClick={submit}
-          disabled={!canSubmit && status !== "error"}
+          disabled={!canSubmit}
           aria-disabled={!canSubmit}
         >
           {status === "submitting" ? (

--- a/apps/web/src/lib/challenge/buildable-executor.ts
+++ b/apps/web/src/lib/challenge/buildable-executor.ts
@@ -46,13 +46,15 @@
  * ⚠️ OPERATIONAL SECURITY — grading an untrusted `anchor build` runs the
  * submission's `build.rs` / proc-macros as arbitrary code on the build host; the
  * SBF target sandboxes the *compiled* program, NOT the build itself. Network
- * egress isolation is what contains that, and it is delivered: #193 attaches the
- * Cloud Run build server to a VPC whose firewall DENIES egress (one-time
- * `gcloud` steps in `apps/build-server/deploy/HARDENING.md`). Enabling this
- * grader in production is therefore an OPS action, not a code change: set
- * `BUILD_SERVER_URL` + `BUILD_SERVER_API_KEY` in the prod env, and only against a
- * build server actually deployed with the deny-egress VPC vars. While they are
- * unset the grader fails closed (buildable lessons 503) and blocks nothing.
+ * egress isolation is what contains that. The mechanism exists (#193: Cloud Run
+ * VPC + deny-egress firewall, `apps/build-server/deploy/HARDENING.md`) but it is
+ * OPT-IN at deploy time — `deploy/deploy.sh` only attaches the VPC when
+ * `VPC_NETWORK`/`VPC_SUBNET` are set, and WARNS-then-deploys unrestricted when
+ * they are not. Enabling this grader in production is therefore an OPS action
+ * with a verification step, not a code change: confirm the live build server
+ * was deployed WITH the deny-egress VPC vars, then set `BUILD_SERVER_URL` +
+ * `BUILD_SERVER_API_KEY` in the prod env. While they are unset the grader fails
+ * closed (buildable lessons 503) and blocks nothing.
  */
 
 import type { AdminTestCase } from "@superteam-lms/types";

--- a/docs/HANDOFF-LOOP-2026-07-25.md
+++ b/docs/HANDOFF-LOOP-2026-07-25.md
@@ -49,11 +49,31 @@ Backlog: **issues #549–#608** are the plan. `#549–#589` are the launch-exper
 
 ## Gate protocol (this session)
 
-Drain `label:needs-gate`. For each PR: re-verify the load-bearing claims **against the code**, not the
-description; confirm the adversarial review actually happened and its findings landed; check nothing
-in the do-not-touch list moved; then merge, or bounce with specifics.
+Drain `label:needs-gate`. For each PR, in this order:
+
+1. **CI green.**
+2. **Read the `claude[bot]` review body** — not just that a comment exists. A green `claude-review`
+   check only means the action ran. Every non-blocking finding must be fixed or filed before merge;
+   one left neither is lost work.
+3. **Re-verify the load-bearing claims against the code**, not the description.
+4. **Confirm the adversarial review happened** and its findings landed.
+5. **Check nothing in the do-not-touch list moved.** Then merge, or bounce with specifics.
 
 Bounced PRs get `needs-gate` removed and a comment; the orchestrator picks them back up.
+
+### Branch lifecycle — the collision that already happened once
+
+The gate squash-merges with `--delete-branch`. **Once a PR is merged, its branch is closed for
+business.** Pushing further commits to it _recreates_ the branch with work attached to no open PR,
+where it is silently orphaned.
+
+- **Orchestrator:** after the gate merges, land follow-ups on a **new branch off `main`**, referencing
+  the issue. Never re-push to a merged branch.
+- **Gate:** before merging, check whether the orchestrator is still pushing; after merging, comment on
+  the issue so it knows the branch is closed.
+
+This cost two commits on 2026-07-26 (recovered in #618) — the deny-egress comment correction and the
+`aria-disabled` fix.
 
 ## Do not touch without the owner
 


### PR DESCRIPTION
**Coordination fix, not new work.** Both commits are cherry-picked verbatim from the orchestrator; they were pushed to branches that had already been deleted by the squash-merge of #610 and #611, so they were orphaned and would never have landed.

| Commit | Fix | Closes |
|---|---|---|
| `279bf7f` | `buildable-executor.ts` no longer claims the VPC deny-egress isolation "is delivered" — it is **opt-in** via `VPC_NETWORK`/`VPC_SUBNET` at deploy time, and `deploy.sh` warns and deploys with unrestricted egress when unset. That comment is what someone reads before flipping on `BUILD_SERVER_URL`. | #614 finding 1 |
| `1b612cf` | `open-ended-block.tsx:110` — `disabled` and `aria-disabled` now derive from the same expression, so a screen reader stops announcing "disabled" on a button a sighted user can click. | #616 finding 1 |

Both originate from the `claude[bot]` reviews on #610 and #611 (each of which concluded *no blocking findings*).

## The process bug worth fixing

I squash-merge with `--delete-branch`. The orchestrator was still improving those branches, so its pushes **recreated** them with commits that point at no open PR. Neither side was wrong — the handoff contract never said what happens to in-flight work on a branch the gate has already merged.

**Rule going forward:** once the gate merges a PR, that branch is closed for business. Follow-ups go on a new branch against `main`, referencing the issue. I'll add this to the handoff contract.