### PR TITLE
fix(auth): open AuthModal on anonymous enroll instead of silent no-op

### DIFF
--- a/apps/web/src/app/[locale]/(platform)/courses/[slug]/course-detail-client.tsx
+++ b/apps/web/src/app/[locale]/(platform)/courses/[slug]/course-detail-client.tsx
@@ -74,6 +74,7 @@ export function CourseDetailClient({
   const [completedLessons, setCompletedLessons] = useState<string[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [discussionModalOpen, setDiscussionModalOpen] = useState(false);
+  const [authModalOpen, setAuthModalOpen] = useState(false);
 
   const fetchEnrollmentAndProgress = useCallback(async () => {
     if (!userId) {
@@ -134,6 +135,10 @@ export function CourseDetailClient({
   const { isEnrolling, handleEnroll } = useOnChainEnroll({
     courseId: course._id,
     userId,
+    // Anonymous Enroll opens the auth modal instead of silently no-oping
+    // (#556). The signed-out CTA below already renders the AuthModal trigger,
+    // so this only fires if handleEnroll is reached some other way.
+    onRequireAuth: () => setAuthModalOpen(true),
     onSuccess: () => setIsEnrolled(true),
   });
 
@@ -280,6 +285,8 @@ export function CourseDetailClient({
             </>
           ) : !isLoading ? (
             <AuthModal
+              open={authModalOpen}
+              onOpenChange={setAuthModalOpen}
               trigger={
                 <Button
                   variant="push"

--- a/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/lesson-client.tsx
+++ b/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/lesson-client.tsx
@@ -84,6 +84,7 @@ export function LessonPageClient({
   const [isEnrolled, setIsEnrolled] = useState(false);
   const hasLinkedWallet = authProfile ? !!authProfile.wallet_address : null;
   const [isDiscussionOpen, setIsDiscussionOpen] = useState(false);
+  const [isAuthModalOpen, setIsAuthModalOpen] = useState(false);
   const [buildUuid, setBuildUuid] = useState<string | null>(null);
   const [programKeypairSecret, setProgramKeypairSecret] = useState<
     number[] | null
@@ -103,6 +104,9 @@ export function LessonPageClient({
   const { isEnrolling, handleEnroll, enrollError } = useOnChainEnroll({
     courseId,
     userId,
+    // Anonymous Enroll (e.g. the challenge "tests passed" overlay) opens the
+    // auth modal instead of silently no-oping (#556).
+    onRequireAuth: () => setIsAuthModalOpen(true),
     onSuccess: () => setIsEnrolled(true),
   });
 
@@ -495,6 +499,14 @@ export function LessonPageClient({
           </p>
         )}
       </div>
+
+      {/* Programmatic auth modal — opened when an anonymous visitor clicks an
+          Enroll CTA that lives outside this component (the ChallengeInterface
+          "tests passed" overlay calls ctx.onEnroll). No trigger: controlled
+          only (#556). */}
+      {!userId && (
+        <AuthModal open={isAuthModalOpen} onOpenChange={setIsAuthModalOpen} />
+      )}
 
       {/* Discussion */}
       <div className="border-t border-border pt-6">

--- a/apps/web/src/components/auth/__tests__/auth-modal.test.tsx
+++ b/apps/web/src/components/auth/__tests__/auth-modal.test.tsx
@@ -1,0 +1,88 @@
+// @vitest-environment jsdom
+import type { ReactElement } from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import { AuthModal } from "../auth-modal";
+import messages from "@/messages/en.json";
+
+vi.mock("@solana/wallet-adapter-react-ui", () => ({
+  useWalletModal: () => ({ setVisible: vi.fn() }),
+}));
+
+vi.mock("@/lib/supabase/client", () => ({
+  createClient: vi.fn(() => ({
+    auth: { signInWithOAuth: vi.fn().mockResolvedValue({ error: null }) },
+  })),
+}));
+
+vi.mock("@/lib/analytics", () => ({ trackEvent: vi.fn() }));
+
+function renderWithIntl(ui: ReactElement) {
+  return render(
+    <NextIntlClientProvider locale="en" messages={messages}>
+      {ui}
+    </NextIntlClientProvider>
+  );
+}
+
+const TITLE = messages.auth.signInTitle;
+const DEFAULT_TRIGGER = messages.common.signIn;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("AuthModal — controlled mode (#556)", () => {
+  it("opens programmatically via the open prop, without rendering a trigger button", () => {
+    renderWithIntl(<AuthModal open onOpenChange={() => {}} />);
+
+    expect(screen.getByText(TITLE)).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: DEFAULT_TRIGGER })
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders nothing while closed in controlled mode (no stray sign-in button)", () => {
+    renderWithIntl(<AuthModal open={false} onOpenChange={() => {}} />);
+
+    expect(screen.queryByText(TITLE)).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: DEFAULT_TRIGGER })
+    ).not.toBeInTheDocument();
+  });
+
+  it("reports close through onOpenChange", () => {
+    const onOpenChange = vi.fn();
+    renderWithIntl(<AuthModal open onOpenChange={onOpenChange} />);
+
+    fireEvent.keyDown(screen.getByText(TITLE), { key: "Escape" });
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("still supports a trigger alongside controlled state", () => {
+    const onOpenChange = vi.fn();
+    renderWithIntl(
+      <AuthModal
+        open={false}
+        onOpenChange={onOpenChange}
+        trigger={<button>Sign in to enroll</button>}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Sign in to enroll" }));
+    expect(onOpenChange).toHaveBeenCalledWith(true);
+  });
+});
+
+describe("AuthModal — uncontrolled mode (unchanged)", () => {
+  it("renders the default trigger and opens on click", () => {
+    renderWithIntl(<AuthModal />);
+
+    const trigger = screen.getByRole("button", { name: DEFAULT_TRIGGER });
+    expect(screen.queryByText(TITLE)).not.toBeInTheDocument();
+
+    fireEvent.click(trigger);
+    expect(screen.getByText(TITLE)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/auth/auth-modal.tsx
+++ b/apps/web/src/components/auth/auth-modal.tsx
@@ -20,12 +20,29 @@ import { trackEvent } from "@/lib/analytics";
 
 interface AuthModalProps {
   trigger?: React.ReactNode;
+  /**
+   * Controlled open state. Pass together with `onOpenChange` to drive the
+   * modal programmatically (e.g. an anonymous Enroll click, #556). When
+   * controlled and no `trigger` is given, no trigger button is rendered.
+   */
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
 }
 
-export function AuthModal({ trigger }: AuthModalProps) {
+export function AuthModal({
+  trigger,
+  open: controlledOpen,
+  onOpenChange,
+}: AuthModalProps) {
   const t = useTranslations("auth");
   const tCommon = useTranslations("common");
-  const [open, setOpen] = useState(false);
+  const [internalOpen, setInternalOpen] = useState(false);
+  const isControlled = controlledOpen !== undefined;
+  const open = isControlled ? controlledOpen : internalOpen;
+  const setOpen = (v: boolean) => {
+    if (!isControlled) setInternalOpen(v);
+    onOpenChange?.(v);
+  };
   const [loading, setLoading] = useState<"solana" | "google" | "github" | null>(
     null
   );
@@ -105,9 +122,11 @@ export function AuthModal({ trigger }: AuthModalProps) {
         }
       }}
     >
-      <DialogTrigger asChild>
-        {trigger ?? <Button variant="push">{tCommon("signIn")}</Button>}
-      </DialogTrigger>
+      {(trigger !== undefined || !isControlled) && (
+        <DialogTrigger asChild>
+          {trigger ?? <Button variant="push">{tCommon("signIn")}</Button>}
+        </DialogTrigger>
+      )}
       <DialogContent className="sm:max-w-sm">
         <DialogHeader>
           <DialogTitle className="text-center">{t("signInTitle")}</DialogTitle>

--- a/apps/web/src/hooks/__tests__/use-on-chain-enroll.test.tsx
+++ b/apps/web/src/hooks/__tests__/use-on-chain-enroll.test.tsx
@@ -1,0 +1,146 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { Keypair, type PublicKey } from "@solana/web3.js";
+import { useOnChainEnroll } from "../use-on-chain-enroll";
+
+// Mutable holders read lazily by the mock factories below, so each test can
+// shape the wallet state before rendering the hook.
+const wallet = vi.hoisted(() => ({
+  publicKey: null as unknown,
+  setVisible: vi.fn(),
+  sendTransaction: vi.fn(),
+  confirmTransaction: vi.fn(),
+}));
+
+vi.mock("@solana/wallet-adapter-react", () => ({
+  useConnection: () => ({
+    connection: { confirmTransaction: wallet.confirmTransaction },
+  }),
+  useWallet: () => ({
+    publicKey: wallet.publicKey,
+    sendTransaction: wallet.sendTransaction,
+  }),
+}));
+
+vi.mock("@solana/wallet-adapter-react-ui", () => ({
+  useWalletModal: () => ({ setVisible: wallet.setVisible }),
+}));
+
+vi.mock("@/lib/solana/instructions", () => ({
+  buildEnrollInstruction: vi.fn(() => ({
+    keys: [],
+    programId: { toBase58: () => "11111111111111111111111111111111" },
+    data: Buffer.alloc(0),
+  })),
+}));
+
+vi.mock("@/lib/solana/program-errors", () => ({
+  preflightTransaction: vi.fn(() => Promise.resolve()),
+  parseProgramError: vi.fn(() => ({ code: null, fallback: "Enroll failed" })),
+}));
+
+vi.mock("@/lib/analytics", () => ({ trackEvent: vi.fn() }));
+
+vi.mock("@/components/ui/toast-container", () => ({ dispatchToast: vi.fn() }));
+
+// The hook wraps the instruction in a real web3.js Transaction; sendTransaction
+// is mocked, so the Transaction never needs a blockhash or signatures.
+vi.mock("@solana/web3.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@solana/web3.js")>();
+  return {
+    ...actual,
+    Transaction: class {
+      add(): this {
+        return this;
+      }
+    },
+  };
+});
+
+const COURSE_ID = "solana-101";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  wallet.publicKey = null;
+});
+
+describe("useOnChainEnroll — anonymous visitor (#556)", () => {
+  it("calls onRequireAuth instead of silently returning when userId is null", async () => {
+    const onRequireAuth = vi.fn();
+    const onSuccess = vi.fn();
+
+    const { result } = renderHook(() =>
+      useOnChainEnroll({
+        courseId: COURSE_ID,
+        userId: null,
+        onRequireAuth,
+        onSuccess,
+      })
+    );
+
+    await act(async () => {
+      await result.current.handleEnroll();
+    });
+
+    expect(onRequireAuth).toHaveBeenCalledTimes(1);
+    // No wallet modal, no transaction, no success — just the auth prompt.
+    expect(wallet.setVisible).not.toHaveBeenCalled();
+    expect(wallet.sendTransaction).not.toHaveBeenCalled();
+    expect(onSuccess).not.toHaveBeenCalled();
+    expect(result.current.isEnrolling).toBe(false);
+    expect(result.current.enrollError).toBeNull();
+  });
+});
+
+describe("useOnChainEnroll — signed-in user (unchanged paths)", () => {
+  it("opens the wallet modal (not the auth modal) when signed in without a connected wallet", async () => {
+    const onRequireAuth = vi.fn();
+
+    const { result } = renderHook(() =>
+      useOnChainEnroll({
+        courseId: COURSE_ID,
+        userId: "user-1",
+        onRequireAuth,
+      })
+    );
+
+    await act(async () => {
+      await result.current.handleEnroll();
+    });
+
+    expect(wallet.setVisible).toHaveBeenCalledWith(true);
+    expect(onRequireAuth).not.toHaveBeenCalled();
+    expect(wallet.sendTransaction).not.toHaveBeenCalled();
+  });
+
+  it("sends the enroll transaction and reports success when signed in with a wallet", async () => {
+    const onRequireAuth = vi.fn();
+    const onSuccess = vi.fn();
+    wallet.publicKey = Keypair.generate().publicKey satisfies PublicKey;
+    wallet.sendTransaction.mockResolvedValue("mock-signature");
+    wallet.confirmTransaction.mockResolvedValue({ value: { err: null } });
+
+    const { result } = renderHook(() =>
+      useOnChainEnroll({
+        courseId: COURSE_ID,
+        userId: "user-1",
+        onRequireAuth,
+        onSuccess,
+      })
+    );
+
+    await act(async () => {
+      await result.current.handleEnroll();
+    });
+
+    expect(wallet.sendTransaction).toHaveBeenCalledTimes(1);
+    expect(wallet.confirmTransaction).toHaveBeenCalledWith(
+      "mock-signature",
+      "confirmed"
+    );
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+    expect(onRequireAuth).not.toHaveBeenCalled();
+    expect(result.current.enrollError).toBeNull();
+  });
+});

--- a/apps/web/src/hooks/use-on-chain-enroll.ts
+++ b/apps/web/src/hooks/use-on-chain-enroll.ts
@@ -33,6 +33,12 @@ function withTimeout<T>(
 interface UseOnChainEnrollOptions {
   courseId: string;
   userId: string | null;
+  /**
+   * Called instead of enrolling when there is no signed-in user — callers
+   * open the AuthModal here. Required so an anonymous Enroll click can never
+   * be a silent no-op (#556).
+   */
+  onRequireAuth: () => void;
   onSuccess?: () => void;
   onError?: (message: string) => void;
 }
@@ -46,6 +52,7 @@ interface UseOnChainEnrollResult {
 export function useOnChainEnroll({
   courseId,
   userId,
+  onRequireAuth,
   onSuccess,
   onError,
 }: UseOnChainEnrollOptions): UseOnChainEnrollResult {
@@ -56,7 +63,12 @@ export function useOnChainEnroll({
   const [enrollError, setEnrollError] = useState<string | null>(null);
 
   const handleEnroll = useCallback(async () => {
-    if (isEnrolling || !userId) return;
+    if (isEnrolling) return;
+
+    if (!userId) {
+      onRequireAuth();
+      return;
+    }
 
     if (!publicKey) {
       setWalletModalVisible(true);
@@ -116,6 +128,7 @@ export function useOnChainEnroll({
   }, [
     userId,
     courseId,
+    onRequireAuth,
     publicKey,
     sendTransaction,
     connection,


### PR DESCRIPTION
Closes #556 — task **LX-A4a** in `docs/superpowers/specs/2026-07-25-launch-experience-master-spec.md` §3/§6 (#8).

## Problem

`useOnChainEnroll.handleEnroll` returned silently when `userId` was null. The only anonymous-reachable enroll CTA is the **ChallengeInterface "tests passed — Enroll now" overlay** (`ctx.onEnroll` on lesson pages): an anonymous visitor who solved a challenge clicked Enroll and saw *nothing* happen. (The course-detail and non-code lesson CTAs already swap to an `AuthModal` trigger when signed out, so they were not reachable anonymously.)

## Fix (minimal, enroll-flow surface only)

- **`hooks/use-on-chain-enroll.ts`** — new **required** `onRequireAuth: () => void` option; called instead of the silent return when there is no signed-in user. Required (not optional) so no caller can reintroduce a silent path. Signed-in behavior is byte-for-byte unchanged (wallet-modal prompt, preflight, send, confirm, already-enrolled code-0 handling).
- **`components/auth/auth-modal.tsx`** — reuses the existing modal; adds optional controlled `open`/`onOpenChange`. When controlled without a `trigger`, no trigger button renders. Uncontrolled usage (header, landing, lesson/course CTAs) is unchanged.
- **`lesson-client.tsx`** — mounts a controlled, trigger-less `AuthModal` while anonymous and opens it from `onRequireAuth`.
- **`course-detail-client.tsx`** — the existing signed-out `AuthModal` becomes controlled (same trigger); `onRequireAuth` wired as defense in depth (its enroll button is unreachable while anonymous).

No new UI strings — the modal's copy is already externalized in all 3 locales, so no locale-file changes. Accessibility rides on the existing Radix Dialog (focus trap, ESC, aria).

## Post-auth resume behavior (per issue: "note what you did")

- **Wallet (SIWS) sign-in**: no page reload. The user lands back on the same lesson with the challenge overlay still up (`pendingSubmit` persists); clicking Enroll again now runs the real enroll, and the existing `pendingSubmit && isEnrolled` effect **auto-submits the passed solution** — a genuine resume.
- **OAuth (Google/GitHub)**: full-page redirect; `/api/auth/callback` has no `next` param from AuthModal and lands on `/en/dashboard`. This is pre-existing AuthModal behavior shared by every sign-in CTA; changing it is the LX-A4 "Later affordance + local progress banking" issue (spec §6 #19), not LX-A4a. Per the issue text, opening the modal satisfies LX-A4a.

## Verification

- `pnpm typecheck` (apps/web): clean
- `pnpm test` (apps/web): **106 files / 980 tests passed** (8 new: anonymous → `onRequireAuth` fired, no wallet modal / no tx / no silent return; signed-in no-wallet → wallet modal; signed-in with wallet → tx path + `onSuccess`; AuthModal controlled open/close/trigger + uncontrolled default unchanged)
- ESLint on touched files: 0 errors