### PR TITLE
fix(api): harden /api/deploy/save with on-chain program verification (#560)

### DIFF
--- a/apps/web/src/app/api/deploy/save/__tests__/route.test.ts
+++ b/apps/web/src/app/api/deploy/save/__tests__/route.test.ts
@@ -9,7 +9,17 @@ vi.mock("server-only", () => ({}));
 const { getUser, isRateLimited, getAccountInfo, profileSingle, upsert } =
   vi.hoisted(() => ({
     getUser: vi.fn<() => Promise<unknown>>(),
-    isRateLimited: vi.fn<() => Promise<boolean>>(),
+    isRateLimited: vi.fn<
+      (
+        namespace: string,
+        key: string,
+        opts: {
+          maxTokens: number;
+          refillIntervalMs: number;
+          failClosed?: boolean;
+        }
+      ) => Promise<boolean>
+    >(),
     getAccountInfo:
       vi.fn<
         (
@@ -344,6 +354,156 @@ describe("POST /api/deploy/save — on-chain verification (#560 / LX-E1)", () =>
     const res = await POST(req(validBody));
 
     expect(res.status).toBe(401);
+    expect(getAccountInfo).not.toHaveBeenCalled();
+    expect(upsert).not.toHaveBeenCalled();
+  });
+});
+
+describe("POST /api/deploy/save — adversarial account layouts", () => {
+  async function expectGenericReject(): Promise<void> {
+    const res = await POST(req(validBody));
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { error: string }).error).toBe(
+      "Program verification failed"
+    );
+    expect(upsert).not.toHaveBeenCalled();
+  }
+
+  it("rejects a program account with truncated data (< 36 bytes)", async () => {
+    setAccounts({
+      [programId.toBase58()]: account({ data: Buffer.alloc(10) }),
+    });
+
+    await expectGenericReject();
+    // Malformed program account never triggers the ProgramData read.
+    expect(getAccountInfo).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects a program account with the wrong state tag", async () => {
+    const data = programAccountData();
+    data.writeUInt32LE(1, 0); // tag 1 = Buffer, not Program
+
+    setAccounts({ [programId.toBase58()]: account({ data }) });
+
+    await expectGenericReject();
+    expect(getAccountInfo).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects a ProgramData account with a truncated header (< 45 bytes)", async () => {
+    setAccounts({
+      [programId.toBase58()]: account({ data: programAccountData() }),
+      [programDataAddress.toBase58()]: account({
+        executable: false,
+        data: programDataHeader(wallet).subarray(0, 20),
+      }),
+    });
+
+    await expectGenericReject();
+  });
+
+  it("rejects a ProgramData account with the wrong state tag", async () => {
+    const header = programDataHeader(wallet);
+    header.writeUInt32LE(2, 0); // tag 2 = Program, not ProgramData
+
+    setAccounts({
+      [programId.toBase58()]: account({ data: programAccountData() }),
+      [programDataAddress.toBase58()]: account({
+        executable: false,
+        data: header,
+      }),
+    });
+
+    await expectGenericReject();
+  });
+
+  it("rejects a ProgramData account owned by a non-loader program", async () => {
+    setAccounts({
+      [programId.toBase58()]: account({ data: programAccountData() }),
+      [programDataAddress.toBase58()]: account({
+        executable: false,
+        owner: OTHER_LOADER,
+        data: programDataHeader(wallet),
+      }),
+    });
+
+    await expectGenericReject();
+  });
+
+  it("rejects regex-passing base58 that fails PublicKey construction", async () => {
+    // 44 valid base58 chars, but decodes to 33 bytes — the regex passes and
+    // `new PublicKey()` throws. Must reject before rate limiting / RPC.
+    const res = await POST(req({ ...validBody, programId: "z".repeat(44) }));
+
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { error: string }).error).toBe(
+      "Invalid program ID format"
+    );
+    expect(isRateLimited).not.toHaveBeenCalled();
+    expect(getAccountInfo).not.toHaveBeenCalled();
+    expect(upsert).not.toHaveBeenCalled();
+  });
+});
+
+describe("POST /api/deploy/save — rate limiting", () => {
+  it("passes failClosed to both limiters (store error must deny, not allow)", async () => {
+    setHappyChain();
+
+    await POST(req(validBody));
+
+    expect(isRateLimited).toHaveBeenCalledWith(
+      "deploy:save",
+      "user-1",
+      expect.objectContaining({ failClosed: true })
+    );
+    expect(isRateLimited).toHaveBeenCalledWith(
+      "deploy:save:ip",
+      "203.0.113.7",
+      expect.objectContaining({ failClosed: true })
+    );
+  });
+
+  it("429s when only the per-user limit trips, without consulting the IP limiter", async () => {
+    setHappyChain();
+    isRateLimited.mockImplementation(async (namespace) => {
+      return namespace === "deploy:save";
+    });
+
+    const res = await POST(req(validBody));
+
+    expect(res.status).toBe(429);
+    expect(((await res.json()) as { error: string }).error).toMatch(
+      /try again later/i
+    );
+    expect(isRateLimited).toHaveBeenCalledTimes(1);
+    expect(getAccountInfo).not.toHaveBeenCalled();
+    expect(upsert).not.toHaveBeenCalled();
+  });
+
+  it("429s when only the per-IP limit trips, even for an unthrottled user", async () => {
+    setHappyChain();
+    isRateLimited.mockImplementation(async (namespace) => {
+      return namespace === "deploy:save:ip";
+    });
+
+    const res = await POST(req(validBody));
+
+    expect(res.status).toBe(429);
+    expect(((await res.json()) as { error: string }).error).toMatch(/network/i);
+    expect(isRateLimited).toHaveBeenCalledTimes(2);
+    expect(getAccountInfo).not.toHaveBeenCalled();
+    expect(upsert).not.toHaveBeenCalled();
+  });
+
+  it("429s (denies) when the limiter store errors in fail-closed mode", async () => {
+    setHappyChain();
+    // The real limiter returns `true` (deny) on a store error when
+    // failClosed is set — the route must translate that into a 429, never
+    // an unmetered RPC read.
+    isRateLimited.mockResolvedValue(true);
+
+    const res = await POST(req(validBody));
+
+    expect(res.status).toBe(429);
     expect(getAccountInfo).not.toHaveBeenCalled();
     expect(upsert).not.toHaveBeenCalled();
   });

--- a/apps/web/src/app/api/deploy/save/__tests__/route.test.ts
+++ b/apps/web/src/app/api/deploy/save/__tests__/route.test.ts
@@ -1,0 +1,350 @@
+/* eslint-disable import/order -- vi.mock('server-only') must be hoisted above
+   the route import so the `server-only` graph loads under vitest. */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { NextRequest } from "next/server";
+import { Keypair, PublicKey, type AccountInfo } from "@solana/web3.js";
+
+vi.mock("server-only", () => ({}));
+
+const { getUser, isRateLimited, getAccountInfo, profileSingle, upsert } =
+  vi.hoisted(() => ({
+    getUser: vi.fn<() => Promise<unknown>>(),
+    isRateLimited: vi.fn<() => Promise<boolean>>(),
+    getAccountInfo:
+      vi.fn<
+        (
+          pubkey: import("@solana/web3.js").PublicKey,
+          config?: unknown
+        ) => Promise<AccountInfo<Buffer> | null>
+      >(),
+    profileSingle:
+      vi.fn<() => Promise<{ data: { wallet_address: string } | null }>>(),
+    upsert: vi.fn<(row: unknown, opts: unknown) => Promise<{ error: null }>>(),
+  }));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: async () => ({
+    auth: { getUser },
+    from: () => ({ upsert }),
+  }),
+}));
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: () => ({
+    from: () => ({
+      select: () => ({ eq: () => ({ single: profileSingle }) }),
+    }),
+  }),
+}));
+vi.mock("@/lib/rate-limit", () => ({
+  isRateLimited,
+  getClientIp: () => "203.0.113.7",
+}));
+vi.mock("@/lib/solana/academy-program", () => ({
+  getConnection: () => ({ getAccountInfo }),
+}));
+
+import { POST } from "../route";
+
+// ---------------------------------------------------------------------------
+// BPF Upgradeable Loader fixtures
+// ---------------------------------------------------------------------------
+
+const LOADER = new PublicKey("BPFLoaderUpgradeab1e11111111111111111111111");
+const OTHER_LOADER = new PublicKey(
+  "BPFLoader2111111111111111111111111111111111"
+);
+
+const wallet = Keypair.generate().publicKey;
+const programId = Keypair.generate().publicKey;
+const [programDataAddress] = PublicKey.findProgramAddressSync(
+  [programId.toBuffer()],
+  LOADER
+);
+
+/** Program account data: tag 2 + programdata_address. */
+function programAccountData(pointer: PublicKey = programDataAddress): Buffer {
+  const buf = Buffer.alloc(36);
+  buf.writeUInt32LE(2, 0);
+  pointer.toBuffer().copy(buf, 4);
+  return buf;
+}
+
+/** ProgramData header: tag 3 + slot + Option<upgrade_authority>. */
+function programDataHeader(authority: PublicKey | null): Buffer {
+  const buf = Buffer.alloc(45);
+  buf.writeUInt32LE(3, 0);
+  buf.writeBigUInt64LE(123n, 4); // deploy slot — irrelevant to the check
+  if (authority) {
+    buf[12] = 1;
+    authority.toBuffer().copy(buf, 13);
+  }
+  return buf;
+}
+
+function account(
+  overrides: Partial<AccountInfo<Buffer>> = {}
+): AccountInfo<Buffer> {
+  return {
+    executable: true,
+    owner: LOADER,
+    lamports: 1_000_000,
+    data: Buffer.alloc(0),
+    rentEpoch: 0,
+    ...overrides,
+  };
+}
+
+/** Register on-chain accounts the mocked RPC should answer with. */
+function setAccounts(
+  entries: Record<string, AccountInfo<Buffer> | null>
+): void {
+  getAccountInfo.mockImplementation(async (pubkey: PublicKey) => {
+    const hit = entries[pubkey.toBase58()];
+    return hit ?? null;
+  });
+}
+
+function setHappyChain(authority: PublicKey = wallet): void {
+  setAccounts({
+    [programId.toBase58()]: account({ data: programAccountData() }),
+    [programDataAddress.toBase58()]: account({
+      executable: false,
+      data: programDataHeader(authority),
+    }),
+  });
+}
+
+function req(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/deploy/save", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "content-type": "application/json" },
+  });
+}
+
+const validBody = {
+  lessonId: "lesson-1",
+  courseId: "course-1",
+  programId: programId.toBase58(),
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getUser.mockResolvedValue({ data: { user: { id: "user-1" } }, error: null });
+  isRateLimited.mockResolvedValue(false);
+  profileSingle.mockResolvedValue({
+    data: { wallet_address: wallet.toBase58() },
+  });
+  upsert.mockResolvedValue({ error: null });
+  setAccounts({});
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("POST /api/deploy/save — on-chain verification (#560 / LX-E1)", () => {
+  it("saves when the program is executable and the upgrade authority is the linked wallet", async () => {
+    setHappyChain();
+
+    const res = await POST(req(validBody));
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ success: true });
+    expect(getAccountInfo).toHaveBeenCalledTimes(2);
+    expect(upsert).toHaveBeenCalledTimes(1);
+    expect(upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        user_id: "user-1",
+        course_id: "course-1",
+        lesson_id: "lesson-1",
+        program_id: programId.toBase58(),
+        network: "devnet",
+      }),
+      { onConflict: "user_id,course_id,lesson_id" }
+    );
+  });
+
+  it("rejects a non-executable account with the generic message", async () => {
+    setAccounts({
+      [programId.toBase58()]: account({
+        executable: false,
+        data: programAccountData(),
+      }),
+    });
+
+    const res = await POST(req(validBody));
+
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { error: string }).error).toBe(
+      "Program verification failed"
+    );
+    expect(upsert).not.toHaveBeenCalled();
+  });
+
+  it("rejects when the upgrade authority is not the linked wallet", async () => {
+    setHappyChain(Keypair.generate().publicKey);
+
+    const res = await POST(req(validBody));
+
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { error: string }).error).toBe(
+      "Program verification failed"
+    );
+    expect(upsert).not.toHaveBeenCalled();
+  });
+
+  it("rejects when the upgrade authority has been burned (None)", async () => {
+    setHappyChain();
+    setAccounts({
+      [programId.toBase58()]: account({ data: programAccountData() }),
+      [programDataAddress.toBase58()]: account({
+        executable: false,
+        data: programDataHeader(null),
+      }),
+    });
+
+    const res = await POST(req(validBody));
+
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { error: string }).error).toBe(
+      "Program verification failed"
+    );
+    expect(upsert).not.toHaveBeenCalled();
+  });
+
+  it("rejects an executable program owned by a non-upgradeable loader", async () => {
+    setAccounts({
+      [programId.toBase58()]: account({
+        owner: OTHER_LOADER,
+        data: programAccountData(),
+      }),
+    });
+
+    const res = await POST(req(validBody));
+
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { error: string }).error).toBe(
+      "Program verification failed"
+    );
+    expect(upsert).not.toHaveBeenCalled();
+  });
+
+  it("rejects a program whose ProgramData pointer is not the canonical PDA", async () => {
+    const decoy = Keypair.generate().publicKey;
+    setAccounts({
+      [programId.toBase58()]: account({ data: programAccountData(decoy) }),
+      [decoy.toBase58()]: account({
+        executable: false,
+        data: programDataHeader(wallet),
+      }),
+    });
+
+    const res = await POST(req(validBody));
+
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { error: string }).error).toBe(
+      "Program verification failed"
+    );
+    expect(upsert).not.toHaveBeenCalled();
+  });
+
+  it("rejects a missing account after one propagation-lag retry", async () => {
+    vi.useFakeTimers();
+    setAccounts({}); // nothing on chain
+
+    const pending = POST(req(validBody));
+    await vi.advanceTimersByTimeAsync(2_000);
+    const res = await pending;
+
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { error: string }).error).toBe(
+      "Program verification failed"
+    );
+    // Two verification attempts: initial read + one retry.
+    expect(getAccountInfo).toHaveBeenCalledTimes(2);
+    expect(upsert).not.toHaveBeenCalled();
+  });
+
+  it("saves when the account only appears on the retry (RPC propagation lag)", async () => {
+    vi.useFakeTimers();
+    let reads = 0;
+    getAccountInfo.mockImplementation(async (pubkey: PublicKey) => {
+      reads += 1;
+      if (reads === 1) return null; // first attempt: account not visible yet
+      if (pubkey.equals(programId)) {
+        return account({ data: programAccountData() });
+      }
+      if (pubkey.equals(programDataAddress)) {
+        return account({ executable: false, data: programDataHeader(wallet) });
+      }
+      return null;
+    });
+
+    const pending = POST(req(validBody));
+    await vi.advanceTimersByTimeAsync(2_000);
+    const res = await pending;
+
+    expect(res.status).toBe(200);
+    // Attempt 1: program read (miss). Attempt 2: program + ProgramData reads.
+    expect(getAccountInfo).toHaveBeenCalledTimes(3);
+    expect(upsert).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects when no wallet is linked, without touching the RPC", async () => {
+    profileSingle.mockResolvedValue({ data: null });
+
+    const res = await POST(req(validBody));
+
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { error: string }).error).toMatch(/wallet/i);
+    expect(getAccountInfo).not.toHaveBeenCalled();
+    expect(upsert).not.toHaveBeenCalled();
+  });
+
+  it("rejects malformed base58 before rate limiting or RPC reads", async () => {
+    const res = await POST(
+      req({ ...validBody, programId: "not-a-real-base58-key!!" })
+    );
+
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { error: string }).error).toBe(
+      "Invalid program ID format"
+    );
+    expect(isRateLimited).not.toHaveBeenCalled();
+    expect(getAccountInfo).not.toHaveBeenCalled();
+    expect(upsert).not.toHaveBeenCalled();
+  });
+
+  it("429s when rate limited, before any RPC read", async () => {
+    isRateLimited.mockResolvedValue(true);
+
+    const res = await POST(req(validBody));
+
+    expect(res.status).toBe(429);
+    expect(getAccountInfo).not.toHaveBeenCalled();
+    expect(upsert).not.toHaveBeenCalled();
+  });
+
+  it("503s (fail closed, retryable) when the RPC is unreachable", async () => {
+    getAccountInfo.mockRejectedValue(new Error("fetch failed"));
+
+    const res = await POST(req(validBody));
+
+    expect(res.status).toBe(503);
+    expect(((await res.json()) as { error: string }).error).toMatch(
+      /try again/i
+    );
+    expect(upsert).not.toHaveBeenCalled();
+  });
+
+  it("401s without a session", async () => {
+    getUser.mockResolvedValue({ data: { user: null }, error: null });
+
+    const res = await POST(req(validBody));
+
+    expect(res.status).toBe(401);
+    expect(getAccountInfo).not.toHaveBeenCalled();
+    expect(upsert).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/api/deploy/save/__tests__/route.test.ts
+++ b/apps/web/src/app/api/deploy/save/__tests__/route.test.ts
@@ -1,48 +1,67 @@
 /* eslint-disable import/order -- vi.mock('server-only') must be hoisted above
    the route import so the `server-only` graph loads under vitest. */
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { NextRequest } from "next/server";
 import { Keypair, PublicKey, type AccountInfo } from "@solana/web3.js";
 
 vi.mock("server-only", () => ({}));
 
-const { getUser, isRateLimited, getAccountInfo, profileSingle, upsert } =
-  vi.hoisted(() => ({
-    getUser: vi.fn<() => Promise<unknown>>(),
-    isRateLimited: vi.fn<
+const {
+  getUser,
+  isRateLimited,
+  getAccountInfo,
+  profileSingle,
+  upsert,
+  userClientFrom,
+} = vi.hoisted(() => ({
+  getUser: vi.fn<() => Promise<unknown>>(),
+  isRateLimited: vi.fn<
+    (
+      namespace: string,
+      key: string,
+      opts: {
+        maxTokens: number;
+        refillIntervalMs: number;
+        failClosed?: boolean;
+      }
+    ) => Promise<boolean>
+  >(),
+  getAccountInfo:
+    vi.fn<
       (
-        namespace: string,
-        key: string,
-        opts: {
-          maxTokens: number;
-          refillIntervalMs: number;
-          failClosed?: boolean;
-        }
-      ) => Promise<boolean>
+        pubkey: import("@solana/web3.js").PublicKey,
+        config?: unknown
+      ) => Promise<AccountInfo<Buffer> | null>
     >(),
-    getAccountInfo:
-      vi.fn<
-        (
-          pubkey: import("@solana/web3.js").PublicKey,
-          config?: unknown
-        ) => Promise<AccountInfo<Buffer> | null>
-      >(),
-    profileSingle:
-      vi.fn<() => Promise<{ data: { wallet_address: string } | null }>>(),
-    upsert: vi.fn<(row: unknown, opts: unknown) => Promise<{ error: null }>>(),
-  }));
+  profileSingle:
+    vi.fn<() => Promise<{ data: { wallet_address: string } | null }>>(),
+  upsert: vi.fn<(row: unknown, opts: unknown) => Promise<{ error: null }>>(),
+  // Spy so tests can prove POST never touches a table through the
+  // user-scoped client — deployed_programs is service_role-write-only
+  // (20260726120000_lockdown_deployed_programs_rls), so a user-client write
+  // would be an RLS-bypass regression AND would fail in production.
+  userClientFrom: vi.fn<(table: string) => never>(() => {
+    throw new Error(
+      "user-scoped client must not touch tables in POST /api/deploy/save"
+    );
+  }),
+}));
 
 vi.mock("@/lib/supabase/server", () => ({
   createClient: async () => ({
     auth: { getUser },
-    from: () => ({ upsert }),
+    from: userClientFrom,
   }),
 }));
 vi.mock("@/lib/supabase/admin", () => ({
   createAdminClient: () => ({
-    from: () => ({
-      select: () => ({ eq: () => ({ single: profileSingle }) }),
-    }),
+    from: (table: string) =>
+      table === "profiles"
+        ? { select: () => ({ eq: () => ({ single: profileSingle }) }) }
+        : { upsert },
   }),
 }));
 vi.mock("@/lib/rate-limit", () => ({
@@ -506,5 +525,65 @@ describe("POST /api/deploy/save — rate limiting", () => {
     expect(res.status).toBe(429);
     expect(getAccountInfo).not.toHaveBeenCalled();
     expect(upsert).not.toHaveBeenCalled();
+  });
+});
+
+describe("POST /api/deploy/save — service_role-only writes (RLS lockdown)", () => {
+  it("upserts through the admin (service_role) client, never the user-scoped client", async () => {
+    setHappyChain();
+
+    const res = await POST(req(validBody));
+
+    expect(res.status).toBe(200);
+    expect(upsert).toHaveBeenCalledTimes(1);
+    // deployed_programs has no client INSERT/UPDATE policies — a write
+    // through the user-scoped client would bypass on-chain verification in
+    // this suite and fail RLS in production.
+    expect(userClientFrom).not.toHaveBeenCalled();
+  });
+
+  // deployed_programs must be service_role-write-only: authenticated users
+  // could otherwise insert rows from devtools with anyone's program id,
+  // skipping the on-chain verification above entirely. RLS itself cannot be
+  // exercised in unit tests, so pin the SQL artifacts that enforce it.
+  const repoRoot = resolve(
+    dirname(fileURLToPath(import.meta.url)),
+    "../../../../../../../.."
+  );
+  const INSERT_POLICY = `"Users can insert their own deployments"`;
+  const UPDATE_POLICY = `"Users can update their own deployments"`;
+  const SELECT_POLICY = `"Users can view their own deployments"`;
+
+  it("migration drops the client INSERT and UPDATE policies on deployed_programs", () => {
+    const migration = readFileSync(
+      resolve(
+        repoRoot,
+        "supabase/migrations/20260726120000_lockdown_deployed_programs_rls.sql"
+      ),
+      "utf8"
+    );
+
+    expect(migration).toContain(
+      `DROP POLICY IF EXISTS ${INSERT_POLICY} ON deployed_programs;`
+    );
+    expect(migration).toContain(
+      `DROP POLICY IF EXISTS ${UPDATE_POLICY} ON deployed_programs;`
+    );
+    // Keep SELECT: the migration must not touch the read policy.
+    expect(migration).not.toContain(`DROP POLICY IF EXISTS ${SELECT_POLICY}`);
+  });
+
+  it("schema.sql end-state has no client INSERT/UPDATE policies on deployed_programs, keeps SELECT", () => {
+    const schema = readFileSync(
+      resolve(repoRoot, "supabase/schema.sql"),
+      "utf8"
+    );
+
+    expect(schema).not.toContain(`CREATE POLICY ${INSERT_POLICY}`);
+    expect(schema).not.toContain(`CREATE POLICY ${UPDATE_POLICY}`);
+    expect(schema).toContain(`CREATE POLICY ${SELECT_POLICY}`);
+    expect(schema).toContain(
+      "ALTER TABLE deployed_programs ENABLE ROW LEVEL SECURITY;"
+    );
   });
 });

--- a/apps/web/src/app/api/deploy/save/route.ts
+++ b/apps/web/src/app/api/deploy/save/route.ts
@@ -28,6 +28,11 @@ const VERIFICATION_FAILED = "Program verification failed";
 // the account can lag there for a moment. One short retry absorbs that window
 // (a rejected save is silently dropped client-side, which would later block
 // the capstone credential gate for a legitimate deploy).
+//
+// The retry makes the "missing" path ~1.5s slower than other rejections — a
+// timing oracle, but only over account EXISTENCE, which anyone can already
+// read for free from any public devnet RPC. Equalizing would add 1.5s to
+// every legitimate failure response for no secrecy gain, so we don't.
 const MISSING_ACCOUNT_RETRY_DELAY_MS = 1_500;
 
 export async function POST(request: NextRequest) {
@@ -167,8 +172,12 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: VERIFICATION_FAILED }, { status: 400 });
     }
 
-    // Upsert — if user re-deploys to the same lesson, update the program_id
-    const { error } = await supabase.from("deployed_programs").upsert(
+    // Upsert — if user re-deploys to the same lesson, update the program_id.
+    // Service-role client on purpose: deployed_programs has NO client
+    // INSERT/UPDATE policies (20260726120000_lockdown_deployed_programs_rls),
+    // so this verified route is the only write path — a direct devtools
+    // insert can't bypass the on-chain check above.
+    const { error } = await adminClient.from("deployed_programs").upsert(
       {
         user_id: user.id,
         course_id: body.courseId,

--- a/apps/web/src/app/api/deploy/save/route.ts
+++ b/apps/web/src/app/api/deploy/save/route.ts
@@ -1,4 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
+import { PublicKey } from "@solana/web3.js";
+import { isRateLimited, getClientIp } from "@/lib/rate-limit";
+import { getConnection } from "@/lib/solana/academy-program";
+import {
+  verifyProgramDeployment,
+  type DeployVerificationResult,
+} from "@/lib/solana/verify-program-deploy";
+import { createAdminClient } from "@/lib/supabase/admin";
 import { createClient } from "@/lib/supabase/server";
 
 interface SaveDeployRequest {
@@ -9,6 +17,18 @@ interface SaveDeployRequest {
 
 // Auth/cookie + per-request DB access — never statically prerender (DYNAMIC_SERVER_USAGE).
 export const dynamic = "force-dynamic";
+
+// One generic message for every on-chain rejection: distinguishing
+// missing/non-executable/wrong-authority would hand probers a free oracle
+// over arbitrary program ids (#560 / LX-E1).
+const VERIFICATION_FAILED = "Program verification failed";
+
+// The client POSTs immediately after its own RPC confirms the deploy tx, but
+// the server reads through a DIFFERENT RPC node — at "confirmed" commitment
+// the account can lag there for a moment. One short retry absorbs that window
+// (a rejected save is silently dropped client-side, which would later block
+// the capstone credential gate for a legitimate deploy).
+const MISSING_ACCOUNT_RETRY_DELAY_MS = 1_500;
 
 export async function POST(request: NextRequest) {
   try {
@@ -39,6 +59,107 @@ export async function POST(request: NextRequest) {
         { error: "Invalid program ID format" },
         { status: 400 }
       );
+    }
+
+    let programPubkey: PublicKey;
+    try {
+      programPubkey = new PublicKey(body.programId);
+    } catch {
+      return NextResponse.json(
+        { error: "Invalid program ID format" },
+        { status: 400 }
+      );
+    }
+
+    // Each save costs two RPC reads against the server RPC; a save is a rare
+    // event (once per deploy lesson, occasional redeploys), so a tight
+    // per-user cap plus a classroom-sized per-IP cap bounds the spend.
+    if (
+      await isRateLimited("deploy:save", user.id, {
+        maxTokens: 20,
+        refillIntervalMs: 3_600_000,
+      })
+    ) {
+      return NextResponse.json(
+        { error: "Too many save attempts. Please try again later." },
+        { status: 429, headers: { "Retry-After": "3600" } }
+      );
+    }
+    if (
+      await isRateLimited("deploy:save:ip", getClientIp(request.headers), {
+        maxTokens: 200,
+        refillIntervalMs: 3_600_000,
+      })
+    ) {
+      return NextResponse.json(
+        { error: "Too many save attempts from this network." },
+        { status: 429, headers: { "Retry-After": "3600" } }
+      );
+    }
+
+    // The wallet the deploy must be attributed to: the learner's LINKED
+    // wallet (profiles.wallet_address), not whatever the request claims. The
+    // deploy flow signs with the connected wallet, which becomes the
+    // program's upgrade authority — for a legitimate deploy these match.
+    const adminClient = createAdminClient();
+    const { data: profile } = await adminClient
+      .from("profiles")
+      .select("wallet_address")
+      .eq("id", user.id)
+      .single();
+
+    if (!profile?.wallet_address) {
+      return NextResponse.json(
+        {
+          error: "Wallet not connected. Link your wallet to save deployments.",
+        },
+        { status: 400 }
+      );
+    }
+
+    let walletPubkey: PublicKey;
+    try {
+      walletPubkey = new PublicKey(profile.wallet_address);
+    } catch {
+      return NextResponse.json({ error: VERIFICATION_FAILED }, { status: 400 });
+    }
+
+    // On-chain verification (#560 / LX-E1): the submitted id must be a live,
+    // executable upgradeable program whose upgrade authority is the linked
+    // wallet. Without this, any self-reported base58 counts as a deploy and
+    // the capstone credential gate (LX-E2) is farmable with someone else's
+    // public program id.
+    let verification: DeployVerificationResult;
+    try {
+      const connection = getConnection();
+      verification = await verifyProgramDeployment(
+        connection,
+        programPubkey,
+        walletPubkey
+      );
+      if (!verification.ok && verification.reason === "missing") {
+        await new Promise((resolve) =>
+          setTimeout(resolve, MISSING_ACCOUNT_RETRY_DELAY_MS)
+        );
+        verification = await verifyProgramDeployment(
+          connection,
+          programPubkey,
+          walletPubkey
+        );
+      }
+    } catch {
+      // RPC unreachable — fail closed, but as "try again", not as a rejection.
+      return NextResponse.json(
+        { error: "Verification temporarily unavailable. Please try again." },
+        { status: 503, headers: { "Retry-After": "30" } }
+      );
+    }
+
+    if (!verification.ok) {
+      console.warn(
+        `[deploy-save] rejected program ${body.programId} for user ${user.id}: ${verification.reason}`
+      );
+      return NextResponse.json({ error: VERIFICATION_FAILED }, { status: 400 });
     }
 
     // Upsert — if user re-deploys to the same lesson, update the program_id

--- a/apps/web/src/app/api/deploy/save/route.ts
+++ b/apps/web/src/app/api/deploy/save/route.ts
@@ -74,10 +74,14 @@ export async function POST(request: NextRequest) {
     // Each save costs two RPC reads against the server RPC; a save is a rare
     // event (once per deploy lesson, occasional redeploys), so a tight
     // per-user cap plus a classroom-sized per-IP cap bounds the spend.
+    // failClosed: this limiter meters platform-funded RPC reads, so a store
+    // error DENIES rather than handing out unmetered requests (same rationale
+    // as the AI routes). A save that hits the store blip retries cleanly.
     if (
       await isRateLimited("deploy:save", user.id, {
         maxTokens: 20,
         refillIntervalMs: 3_600_000,
+        failClosed: true,
       })
     ) {
       return NextResponse.json(
@@ -89,6 +93,7 @@ export async function POST(request: NextRequest) {
       await isRateLimited("deploy:save:ip", getClientIp(request.headers), {
         maxTokens: 200,
         refillIntervalMs: 3_600_000,
+        failClosed: true,
       })
     ) {
       return NextResponse.json(

--- a/apps/web/src/lib/solana/verify-program-deploy.ts
+++ b/apps/web/src/lib/solana/verify-program-deploy.ts
@@ -1,0 +1,119 @@
+import "server-only";
+import { Connection, PublicKey } from "@solana/web3.js";
+
+// On-chain verification that a claimed program id is a real BPF Upgradeable
+// Loader program whose upgrade authority is a specific wallet (#560 / LX-E1).
+//
+// BPF Upgradeable Loader account layout (bincode-serialized
+// `UpgradeableLoaderState`, enum tag = u32 LE):
+//
+//   Program account (36 bytes, `executable: true`):
+//     [0..4)   tag = 2 (Program)
+//     [4..36)  programdata_address: Pubkey
+//
+//   ProgramData account (45-byte header + program bytes):
+//     [0..4)   tag = 3 (ProgramData)
+//     [4..12)  slot: u64 LE (last deploy slot)
+//     [12]     Option<Pubkey> flag: 1 = Some, 0 = None (authority burned)
+//     [13..45) upgrade_authority_address: Pubkey (when flag = 1)
+
+export const BPF_LOADER_UPGRADEABLE_ID = new PublicKey(
+  "BPFLoaderUpgradeab1e11111111111111111111111"
+);
+
+const PROGRAM_STATE_TAG = 2;
+const PROGRAM_DATA_STATE_TAG = 3;
+const PROGRAM_ACCOUNT_LEN = 36;
+const PROGRAM_DATA_HEADER_LEN = 45;
+const AUTHORITY_OPTION_OFFSET = 12;
+const AUTHORITY_OFFSET = 13;
+
+export type DeployVerificationFailure =
+  | "missing" // program (or its ProgramData) account does not exist
+  | "not-executable" // account exists but is not an executable program
+  | "not-upgradeable" // executable but not owned by the upgradeable loader
+  | "malformed" // account data does not match the loader layout
+  | "authority-mismatch"; // upgrade authority absent (burned) or not the wallet
+
+export type DeployVerificationResult =
+  | { ok: true }
+  | { ok: false; reason: DeployVerificationFailure };
+
+/**
+ * Verify on-chain that `programId` is a live, executable BPF Upgradeable
+ * Loader program whose upgrade authority is `expectedAuthority`.
+ *
+ * Read-only: two `getAccountInfo` calls, no transactions. RPC/network errors
+ * propagate to the caller (which should fail closed) — only definitive
+ * on-chain answers produce an `{ ok: false }` result.
+ */
+export async function verifyProgramDeployment(
+  connection: Connection,
+  programId: PublicKey,
+  expectedAuthority: PublicKey
+): Promise<DeployVerificationResult> {
+  const programAccount = await connection.getAccountInfo(programId);
+  if (!programAccount) return { ok: false, reason: "missing" };
+  if (!programAccount.executable) {
+    return { ok: false, reason: "not-executable" };
+  }
+  if (!programAccount.owner.equals(BPF_LOADER_UPGRADEABLE_ID)) {
+    // Executable but owned by another loader (native/v2) — it has no
+    // ProgramData, so there is no upgrade authority to attribute it to.
+    return { ok: false, reason: "not-upgradeable" };
+  }
+
+  const data = programAccount.data;
+  if (
+    data.length < PROGRAM_ACCOUNT_LEN ||
+    data.readUInt32LE(0) !== PROGRAM_STATE_TAG
+  ) {
+    return { ok: false, reason: "malformed" };
+  }
+  const programDataAddress = new PublicKey(
+    data.subarray(4, PROGRAM_ACCOUNT_LEN)
+  );
+
+  // Loader invariant: the ProgramData account is the PDA of the program id.
+  // Cross-check the parsed pointer so a crafted account can't redirect the
+  // authority read.
+  const [canonicalProgramData] = PublicKey.findProgramAddressSync(
+    [programId.toBuffer()],
+    BPF_LOADER_UPGRADEABLE_ID
+  );
+  if (!programDataAddress.equals(canonicalProgramData)) {
+    return { ok: false, reason: "malformed" };
+  }
+
+  // dataSlice: the header is 45 bytes; without it the RPC would ship the
+  // entire program binary (hundreds of KB) just to read the authority.
+  const programDataAccount = await connection.getAccountInfo(
+    programDataAddress,
+    { dataSlice: { offset: 0, length: PROGRAM_DATA_HEADER_LEN } }
+  );
+  if (!programDataAccount) return { ok: false, reason: "missing" };
+  if (!programDataAccount.owner.equals(BPF_LOADER_UPGRADEABLE_ID)) {
+    return { ok: false, reason: "malformed" };
+  }
+
+  const header = programDataAccount.data;
+  if (
+    header.length < PROGRAM_DATA_HEADER_LEN ||
+    header.readUInt32LE(0) !== PROGRAM_DATA_STATE_TAG
+  ) {
+    return { ok: false, reason: "malformed" };
+  }
+  if (header[AUTHORITY_OPTION_OFFSET] !== 1) {
+    // Upgrade authority burned (None) — nobody can claim ownership.
+    return { ok: false, reason: "authority-mismatch" };
+  }
+
+  const authority = new PublicKey(
+    header.subarray(AUTHORITY_OFFSET, AUTHORITY_OFFSET + 32)
+  );
+  if (!authority.equals(expectedAuthority)) {
+    return { ok: false, reason: "authority-mismatch" };
+  }
+
+  return { ok: true };
+}

--- a/supabase/migrations/20260726120000_lockdown_deployed_programs_rls.sql
+++ b/supabase/migrations/20260726120000_lockdown_deployed_programs_rls.sql
@@ -1,0 +1,23 @@
+-- ============================================
+-- Lock down deployed_programs writes to service_role
+-- ============================================
+-- The authenticated INSERT/UPDATE policies let any signed-in user write
+-- deployment rows directly via the Supabase client (devtools), bypassing the
+-- on-chain verification in /api/deploy/save (#560 / LX-E1) entirely: a
+-- learner could claim ANYONE's public program id as their own deploy and
+-- farm the capstone credential gate (LX-E2). deployed_programs was the lone
+-- trusted table still client-writable — user_progress, enrollments, user_xp,
+-- and user_achievements are all service_role-write-only.
+--
+-- The only legitimate writer is /api/deploy/save, which now upserts through
+-- the service_role admin client (bypasses RLS) after verifying on-chain that
+-- the program is a live, executable upgradeable program whose upgrade
+-- authority is the learner's linked wallet. The SELECT policy ("Users can
+-- view their own deployments") is intentionally left in place — the GET
+-- handler and any client reads use it. Mirrors the pending_onchain_actions
+-- pattern (service_role-only writes, own-row SELECT) and the lockdowns in
+-- 20260624164418_restrict_user_progress_writes.sql /
+-- 20260624190000_lockdown_enrollments_rls.sql.
+
+DROP POLICY IF EXISTS "Users can insert their own deployments" ON deployed_programs;
+DROP POLICY IF EXISTS "Users can update their own deployments" ON deployed_programs;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -741,14 +741,14 @@ CREATE INDEX idx_deployed_programs_course_id ON deployed_programs(course_id);
 
 ALTER TABLE deployed_programs ENABLE ROW LEVEL SECURITY;
 
+-- NOTE: All writes to this table go through service_role (/api/deploy/save,
+-- after on-chain verification of the submitted program id — #560 / LX-E1).
+-- No INSERT/UPDATE RLS policies exist because authenticated/anon roles never
+-- write directly; a client-writable row would bypass the verification and let
+-- a learner claim anyone's public program as their own deploy
+-- (20260726120000_lockdown_deployed_programs_rls.sql).
 CREATE POLICY "Users can view their own deployments"
   ON deployed_programs FOR SELECT USING (auth.uid() = user_id);
-
-CREATE POLICY "Users can insert their own deployments"
-  ON deployed_programs FOR INSERT WITH CHECK (auth.uid() = user_id);
-
-CREATE POLICY "Users can update their own deployments"
-  ON deployed_programs FOR UPDATE USING (auth.uid() = user_id);
 
 -- ─────────────────────────────────────────────
 -- 8. PENDING ON-CHAIN ACTIONS (retry queue)


### PR DESCRIPTION
Closes #560 — LX-E1 in the launch-experience master spec (§3): the deploy-save route must stop counting a self-reported base58 as a deploy **before** the capstone credential gate (LX-E2) starts trusting its rows.

## What changed

`POST /api/deploy/save` now verifies the submitted program id on-chain (server RPC, `SOLANA_RPC_URL`, read-only) before upserting into `deployed_programs`:

1. **Program account** must exist, be `executable`, and be owned by the BPF Upgradeable Loader (`BPFLoaderUpgradeab1e…`).
2. Its data (36 bytes: `u32` tag `2` + `programdata_address`) is parsed and the pointer is **cross-checked against the canonical PDA** `findProgramAddress([program_id], loader)` so a crafted account can't redirect the authority read.
3. **ProgramData account** header (45 bytes: `u32` tag `3` + `u64` slot + `Option<Pubkey>`) is fetched with a `dataSlice` (never downloads the program binary) and the **upgrade authority must equal the learner's linked wallet** (`profiles.wallet_address`). A burned authority (`None`) rejects.

This matches the legit deploy flow exactly: `@superteam-lms/deploy` passes the connected wallet as the DeployWithMaxDataLen authority, so a real learner deploy verifies; someone pasting Serum's program id does not.

### Hardening details

- **No probing oracle**: every on-chain rejection (missing / non-executable / wrong loader / malformed / authority mismatch) returns the same generic `400 "Program verification failed"`; the reason is only logged server-side.
- **Fail closed on RPC outage**: `503` + `Retry-After` — unverifiable never becomes verified.
- **Rate-limited** per existing conventions (`isRateLimited`, fixed-window, Supabase-backed): 20/user/hr + 200/IP/hr — each save costs two RPC reads.
- **Propagation lag**: the client POSTs right after *its* RPC confirms the deploy; the server reads a *different* node. One 1.5s retry on the missing-account case absorbs that window (a silent client-side drop would otherwise poison the LX-E2 gate for a legit deploy).
- Base58 is now also validated via the `PublicKey` constructor (the old regex alone admits strings that don't decode to 32 bytes).
- `GET` handler and existing rows untouched (spec accept: "existing legit rows unaffected").

## Verification

- `pnpm typecheck` — clean
- `apps/web` vitest: **105 files / 985 tests passed** (13 new in `deploy/save/__tests__/route.test.ts`: happy path, non-executable, authority mismatch, burned authority, wrong loader, non-canonical ProgramData pointer, missing account (+retry), retry-then-visible, unlinked wallet, malformed base58, rate-limited, RPC-down 503, unauthenticated — all with a mocked RPC, no live network)
- Layout proven against live devnet (read-only) with the academy program `7NeJ…wE8V`: tag 2/36B program account, parsed pointer == canonical PDA, tag 3 header, option flag 1, authority parsed at [13..45).

## Out of scope (flagged)

- `deploy-panel.tsx` still swallows save failures silently (`.catch(() => {})`) and treats localStorage as primary — a legit deploy whose save 429s/503s never lands in `deployed_programs`, which LX-E2 will gate on. Worth a follow-up surface/retry.
