### PR TITLE
feat(gamification): celebration re-tiering — confetti only at deploy + credential mint (LX-B11)

### DIFF
--- a/apps/web/src/components/certificates/course-completion-mint.tsx
+++ b/apps/web/src/components/certificates/course-completion-mint.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { useTranslations, useLocale } from "next-intl";
 import Link from "next/link";
 import { GraduationCap, CheckCircle, Wallet } from "@phosphor-icons/react";
+import { celebrate } from "@/lib/gamification/celebration";
 import { createClient } from "@/lib/supabase/client";
 
 interface CourseCompletionMintProps {
@@ -105,6 +106,9 @@ export function CourseCompletionMint({
         return;
       }
       setState({ status: "already_minted" });
+      // Full celebration on a fresh mint (LX-B11) — celebrate() dedupes
+      // against the Realtime certificate-INSERT popup firing the same moment.
+      celebrate("credential-mint");
     } catch (e) {
       setState({
         status: "mint_error",

--- a/apps/web/src/components/deploy/deploy-panel.tsx
+++ b/apps/web/src/components/deploy/deploy-panel.tsx
@@ -11,8 +11,8 @@ import {
   type DeployResult,
   type DeployStep,
 } from "@superteam-lms/deploy";
-import confetti from "canvas-confetti";
 import { useTranslations } from "next-intl";
+import { celebrate } from "@/lib/gamification/celebration";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Progress } from "@/components/ui/progress";
@@ -308,8 +308,9 @@ export function DeployPanel({
         }
       }
 
-      // Fire confetti celebration
-      confetti({ particleCount: 150, spread: 80, origin: { y: 0.6 } });
+      // Medium celebration — a successful devnet deploy is one of the two
+      // confetti-worthy milestones (LX-B11); respects prefers-reduced-motion.
+      celebrate("deploy-success");
 
       // Notify challenge runner that deployment is complete (enables submit)
       window.dispatchEvent(new CustomEvent("superteam:deploy-complete"));

--- a/apps/web/src/components/editor/challenge-interface.tsx
+++ b/apps/web/src/components/editor/challenge-interface.tsx
@@ -177,7 +177,7 @@ export function ChallengeInterface({
     onComplete?.();
 
     // Emit custom event — lesson-client.tsx calls the API and sets
-    // isAlreadyCompleted=true when done, which triggers the overlay + confetti.
+    // isAlreadyCompleted=true when done, which triggers the completion overlay.
     // The submitted code travels with the event so the server can re-validate
     // it authoritatively (the browser test pass is UX-only).
     const event = new CustomEvent(LESSON_COMPLETE_EVENT, {

--- a/apps/web/src/components/editor/challenge-interface.tsx
+++ b/apps/web/src/components/editor/challenge-interface.tsx
@@ -1,9 +1,14 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import confetti from "canvas-confetti";
 import { useTranslations } from "next-intl";
-import { ArrowCounterClockwise, Trophy, X } from "@phosphor-icons/react";
+import {
+  ArrowCounterClockwise,
+  CheckCircle,
+  Lightbulb,
+  Trophy,
+  X,
+} from "@phosphor-icons/react";
 import { CodeEditor, resetEditorStorage } from "./code-editor";
 import { OutputPanel } from "./output-panel";
 import { ChallengeRunner } from "./challenge-runner";
@@ -16,6 +21,7 @@ import type {
 } from "./types";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import { shouldShowEncouragement } from "@/lib/gamification/celebration";
 
 const LESSON_COMPLETE_EVENT = "superteam:lesson-complete";
 
@@ -76,17 +82,22 @@ export function ChallengeInterface({
   const [isSaving, setIsSaving] = useState(false);
   const [serverError, setServerError] = useState<string | null>(null);
 
+  // Struggling-encouragement state (LX-B11 / F11, R10): count consecutive
+  // failed runs; a passing run resets the counter and the dismissal.
+  const [consecutiveFails, setConsecutiveFails] = useState(0);
+  const [encouragementDismissed, setEncouragementDismissed] = useState(false);
+
   const editorHandle = useRef<CodeEditorHandle>(null);
 
   // Sync when the async DB check resolves after mount.
   // Also fires when lesson-client sets isCompleted=true after API returns —
-  // this is when we show the overlay and trigger confetti.
+  // this is when we show the calm completion acknowledgment. No confetti here:
+  // celebration is reserved for deploy + credential-mint milestones (LX-B11).
   const prevIsAlreadyCompleted = useRef(isAlreadyCompleted ?? false);
   useEffect(() => {
     if (isAlreadyCompleted && !prevIsAlreadyCompleted.current) {
       setIsComplete(true);
       setIsSaving(false);
-      confetti({ particleCount: 100, spread: 70, origin: { y: 0.6 } });
     }
     prevIsAlreadyCompleted.current = isAlreadyCompleted ?? false;
   }, [isAlreadyCompleted]);
@@ -134,6 +145,12 @@ export function ChallengeInterface({
       status: result.success ? "success" : "error",
       executionResult: result,
     }));
+    if (result.success) {
+      setConsecutiveFails(0);
+      setEncouragementDismissed(false);
+    } else {
+      setConsecutiveFails((prev) => prev + 1);
+    }
   }, []);
 
   const handleClearOutput = useCallback(() => {
@@ -449,14 +466,14 @@ export function ChallengeInterface({
               </div>
             )}
 
-            {/* Success overlay */}
+            {/* Success overlay — calm checkmark acknowledgment (LX-B11) */}
             {isComplete && (
               <div className="pointer-events-none absolute inset-0 flex items-center justify-center backdrop-blur-sm [background:color-mix(in_srgb,var(--bg)_60%,transparent)]">
                 <div className="flex flex-col items-center gap-2 rounded-xl border-[2.5px] border-border bg-card p-6 shadow-card">
-                  <Trophy
+                  <CheckCircle
                     size={32}
                     weight="duotone"
-                    className="text-accent"
+                    className="text-success"
                     aria-hidden="true"
                   />
                   <p className="font-display text-lg font-black">
@@ -483,6 +500,37 @@ export function ChallengeInterface({
         >
           <div className="absolute left-1/2 top-1/2 h-0.5 w-8 -translate-x-1/2 -translate-y-1/2 rounded-full transition-colors [background:var(--resizer-handle)] group-hover:[background:var(--primary)]" />
         </div>
+
+        {/* Struggling encouragement — supportive, non-blocking nudge after
+            ≥3 consecutive failed runs (LX-B11 / F11, R10). */}
+        {shouldShowEncouragement(consecutiveFails) &&
+          !encouragementDismissed &&
+          !isComplete && (
+            <div
+              role="status"
+              className="order-3 flex shrink-0 items-center gap-2 border-t border-border bg-card px-3 py-2 lg:order-none"
+            >
+              <Lightbulb
+                size={18}
+                weight="duotone"
+                className="shrink-0 text-accent"
+                aria-hidden="true"
+              />
+              <p className="flex-1 text-xs text-text-3">
+                <span className="font-bold text-text">
+                  {t("encouragementTitle")}
+                </span>{" "}
+                {t("encouragementBody")}
+              </p>
+              <button
+                onClick={() => setEncouragementDismissed(true)}
+                className="shrink-0 text-text-3 transition-colors hover:text-text"
+                aria-label={tA11y("dismiss")}
+              >
+                <X size={14} weight="bold" aria-hidden="true" />
+              </button>
+            </div>
+          )}
 
         {/* Output panel */}
         <div

--- a/apps/web/src/components/gamification/certificate-popup.tsx
+++ b/apps/web/src/components/gamification/certificate-popup.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState, useCallback } from "react";
 import { useRouter, useParams } from "next/navigation";
 import { useTranslations } from "next-intl";
+import { celebrate } from "@/lib/gamification/celebration";
 import { cn } from "@/lib/utils";
 
 /**
@@ -38,6 +39,10 @@ export function CertificatePopup({ className }: { className?: string }) {
   const handleMinted = useCallback((e: Event) => {
     const detail = (e as CustomEvent<CertificateEvent>).detail;
     setEvents((prev) => [...prev, detail]);
+    // Full celebration — a credential mint is the rarest milestone (LX-B11).
+    // celebrate() dedupes against the manual-mint path and respects
+    // prefers-reduced-motion.
+    celebrate("credential-mint");
     setTimeout(() => {
       setEvents((prev) => prev.filter((ev) => ev.uid !== detail.uid));
     }, 7000);

--- a/apps/web/src/components/gamification/gamification-overlays.tsx
+++ b/apps/web/src/components/gamification/gamification-overlays.tsx
@@ -3,6 +3,7 @@
 import { useAuth } from "@/lib/auth/auth-provider";
 import { AchievementPopup } from "@/components/gamification/achievement-popup";
 import { CertificatePopup } from "@/components/gamification/certificate-popup";
+import { LevelUpPopup } from "@/components/gamification/level-up-popup";
 import { useGamificationEvents } from "@/hooks/use-gamification-events";
 import { ToastContainer } from "@/components/ui/toast-container";
 
@@ -20,6 +21,7 @@ export function GamificationOverlays() {
         /* Single stacking container for all bottom-right popups */
         <div className="pointer-events-none fixed bottom-4 right-3 z-50 flex flex-col items-end gap-2 sm:bottom-6 sm:right-6">
           <CertificatePopup className="pointer-events-auto" />
+          <LevelUpPopup className="pointer-events-auto" />
           <AchievementPopup className="pointer-events-auto" />
         </div>
       )}

--- a/apps/web/src/components/gamification/level-up-popup.tsx
+++ b/apps/web/src/components/gamification/level-up-popup.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import { useTranslations } from "next-intl";
+import { celebrate } from "@/lib/gamification/celebration";
+import { cn } from "@/lib/utils";
+
+/**
+ * Level-up popup — the "medium" celebration moment (LX-B11).
+ * Reuses the v9 .popup-grad pattern shared with achievement/certificate popups.
+ */
+
+interface LevelUpEvent {
+  level: number;
+  uid: number;
+}
+
+let counter = 0;
+
+export function dispatchLevelUp(level: number): void {
+  if (typeof window === "undefined") return;
+  counter++;
+  window.dispatchEvent(
+    new CustomEvent("superteam:level-up", {
+      detail: { level, uid: counter },
+    })
+  );
+}
+
+export function LevelUpPopup({ className }: { className?: string }) {
+  const t = useTranslations("gamification");
+
+  const [events, setEvents] = useState<LevelUpEvent[]>([]);
+
+  const handleLevelUp = useCallback((e: Event) => {
+    const detail = (e as CustomEvent<LevelUpEvent>).detail;
+    setEvents((prev) => [...prev, detail]);
+    celebrate("level-up");
+    setTimeout(() => {
+      setEvents((prev) => prev.filter((ev) => ev.uid !== detail.uid));
+    }, 7000);
+  }, []);
+
+  useEffect(() => {
+    window.addEventListener("superteam:level-up", handleLevelUp);
+    return () =>
+      window.removeEventListener("superteam:level-up", handleLevelUp);
+  }, [handleLevelUp]);
+
+  if (events.length === 0) return null;
+
+  return (
+    <div
+      className={cn("flex flex-col gap-2", className)}
+      aria-live="polite"
+      aria-label={t("levelUp")}
+    >
+      {events.map((ev) => (
+        /* v9 .popup-grad — Solana gradient border, pop-spring animation */
+        <div key={ev.uid} className="popup-grad achievement">
+          <div className="popup-grad-inner">
+            {/* v9 .popup-icon-ring — 44px circle, Solana gradient, 2.5px padding */}
+            <div className="popup-icon-ring">
+              <div className="popup-icon-inner" aria-hidden="true">
+                ↑
+              </div>
+            </div>
+            <div>
+              {/* v9 .popup-label — mono 10px uppercase primary */}
+              <div className="popup-label">{t("levelUp")}</div>
+              {/* v9 .popup-name — Nunito 800, 15px */}
+              <div className="popup-name">
+                {t("levelUpMessage", { level: ev.level })}
+              </div>
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/components/gamification/level-up-popup.tsx
+++ b/apps/web/src/components/gamification/level-up-popup.tsx
@@ -6,7 +6,12 @@ import { celebrate } from "@/lib/gamification/celebration";
 import { cn } from "@/lib/utils";
 
 /**
- * Level-up popup — the "medium" celebration moment (LX-B11).
+ * Level-up popup — the popup-only medium moment (LX-B11 acceptance line:
+ * "confetti fires only at deploy + credential mint; level-up gets a medium
+ * moment"). The animated pop-spring card IS the moment — the level-up tier
+ * resolves to "popup" in the celebration module, so celebrate("level-up")
+ * fires no confetti (early level-ups arrive every few lessons; confetti that
+ * frequent would recreate the routine-reward pattern PED-10 warns about).
  * Reuses the v9 .popup-grad pattern shared with achievement/certificate popups.
  */
 
@@ -35,6 +40,8 @@ export function LevelUpPopup({ className }: { className?: string }) {
   const handleLevelUp = useCallback((e: Event) => {
     const detail = (e as CustomEvent<LevelUpEvent>).detail;
     setEvents((prev) => [...prev, detail]);
+    // Routed through the tier module for uniformity; resolves to the "popup"
+    // tier, which is guaranteed confetti-free (asserted in celebration.test.ts).
     celebrate("level-up");
     setTimeout(() => {
       setEvents((prev) => prev.filter((ev) => ev.uid !== detail.uid));

--- a/apps/web/src/hooks/use-gamification-events.ts
+++ b/apps/web/src/hooks/use-gamification-events.ts
@@ -7,6 +7,7 @@ import {
   dispatchAchievementXp,
 } from "@/components/gamification/achievement-popup";
 import { dispatchCertificateMinted } from "@/components/gamification/certificate-popup";
+import { dispatchLevelUp } from "@/components/gamification/level-up-popup";
 
 let xpEventCounter = 0;
 
@@ -65,6 +66,12 @@ export function useGamificationEvents(userId: string | undefined) {
         },
         (payload) => {
           const newLevel = (payload.new as { level?: number }).level ?? 0;
+          const previousLevel = lastKnownLevelRef.current;
+          // Only celebrate a genuine increase — the ref starts null until the
+          // seed query resolves, so the first UPDATE can't false-trigger.
+          if (previousLevel !== null && newLevel > previousLevel) {
+            dispatchLevelUp(newLevel);
+          }
           lastKnownLevelRef.current = newLevel;
         }
       )

--- a/apps/web/src/lib/gamification/__tests__/celebration.test.ts
+++ b/apps/web/src/lib/gamification/__tests__/celebration.test.ts
@@ -1,0 +1,148 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import confetti from "canvas-confetti";
+import {
+  CELEBRATION_TIERS,
+  celebrationTierFor,
+  celebrate,
+  shouldShowEncouragement,
+  ENCOURAGEMENT_THRESHOLD,
+  isDuplicateFullCelebration,
+  FULL_TIER_DEDUPE_MS,
+  prefersReducedMotion,
+  resetCelebrationThrottleForTests,
+  type CelebrationEvent,
+} from "../celebration";
+
+vi.mock("canvas-confetti", () => ({ default: vi.fn() }));
+
+const confettiMock = vi.mocked(confetti);
+
+function stubMatchMedia(matches: boolean): void {
+  window.matchMedia = ((query: string) =>
+    ({
+      matches,
+      media: query,
+      onchange: null,
+      addListener: () => undefined,
+      removeListener: () => undefined,
+      addEventListener: () => undefined,
+      removeEventListener: () => undefined,
+      dispatchEvent: () => false,
+    }) as MediaQueryList) as typeof window.matchMedia;
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  confettiMock.mockClear();
+  resetCelebrationThrottleForTests();
+  stubMatchMedia(false);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("celebrationTierFor — the LX-B11 tier map", () => {
+  const expected: Record<CelebrationEvent, string> = {
+    "lesson-complete": "none",
+    "challenge-pass": "none",
+    "deploy-success": "medium",
+    "level-up": "medium",
+    "credential-mint": "full",
+  };
+
+  for (const [event, tier] of Object.entries(expected)) {
+    it(`${event} → ${tier}`, () => {
+      expect(celebrationTierFor(event as CelebrationEvent)).toBe(tier);
+    });
+  }
+
+  it("confetti-worthy tiers are exactly deploy, level-up, and credential mint", () => {
+    const celebrated = Object.entries(CELEBRATION_TIERS)
+      .filter(([, tier]) => tier !== "none")
+      .map(([event]) => event)
+      .sort();
+    expect(celebrated).toEqual([
+      "credential-mint",
+      "deploy-success",
+      "level-up",
+    ]);
+  });
+});
+
+describe("shouldShowEncouragement — struggling state after ≥3 consecutive fails", () => {
+  it("stays hidden below the threshold", () => {
+    expect(shouldShowEncouragement(0)).toBe(false);
+    expect(shouldShowEncouragement(1)).toBe(false);
+    expect(shouldShowEncouragement(2)).toBe(false);
+  });
+
+  it("appears at exactly 3 consecutive fails and beyond", () => {
+    expect(ENCOURAGEMENT_THRESHOLD).toBe(3);
+    expect(shouldShowEncouragement(3)).toBe(true);
+    expect(shouldShowEncouragement(4)).toBe(true);
+    expect(shouldShowEncouragement(10)).toBe(true);
+  });
+});
+
+describe("isDuplicateFullCelebration — mint double-fire dedupe", () => {
+  it("suppresses a repeat inside the window and allows one after it", () => {
+    expect(isDuplicateFullCelebration(1000, 1000)).toBe(true);
+    expect(
+      isDuplicateFullCelebration(1000 + FULL_TIER_DEDUPE_MS - 1, 1000)
+    ).toBe(true);
+    expect(isDuplicateFullCelebration(1000 + FULL_TIER_DEDUPE_MS, 1000)).toBe(
+      false
+    );
+  });
+});
+
+describe("celebrate — confetti firing per tier", () => {
+  it("never fires for lesson completion or challenge pass", () => {
+    celebrate("lesson-complete");
+    celebrate("challenge-pass");
+    expect(confettiMock).not.toHaveBeenCalled();
+  });
+
+  it("fires a single medium burst for deploy success and level-up", () => {
+    celebrate("deploy-success");
+    expect(confettiMock).toHaveBeenCalledTimes(1);
+    celebrate("level-up");
+    expect(confettiMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("fires the full multi-burst sequence for a credential mint", () => {
+    celebrate("credential-mint");
+    expect(confettiMock).toHaveBeenCalledTimes(1);
+    vi.advanceTimersByTime(500);
+    expect(confettiMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("collapses a duplicate credential-mint celebration inside the dedupe window", () => {
+    celebrate("credential-mint");
+    vi.advanceTimersByTime(500);
+    expect(confettiMock).toHaveBeenCalledTimes(3);
+
+    // Realtime INSERT + manual mint success land moments apart → one show only
+    celebrate("credential-mint");
+    vi.advanceTimersByTime(500);
+    expect(confettiMock).toHaveBeenCalledTimes(3);
+
+    // A later, genuinely separate mint celebrates again
+    vi.advanceTimersByTime(FULL_TIER_DEDUPE_MS);
+    celebrate("credential-mint");
+    vi.advanceTimersByTime(500);
+    expect(confettiMock).toHaveBeenCalledTimes(6);
+  });
+
+  it("respects prefers-reduced-motion for every tier", () => {
+    stubMatchMedia(true);
+    expect(prefersReducedMotion()).toBe(true);
+    celebrate("deploy-success");
+    celebrate("level-up");
+    celebrate("credential-mint");
+    vi.advanceTimersByTime(1000);
+    expect(confettiMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/gamification/__tests__/celebration.test.ts
+++ b/apps/web/src/lib/gamification/__tests__/celebration.test.ts
@@ -48,7 +48,7 @@ describe("celebrationTierFor — the LX-B11 tier map", () => {
     "lesson-complete": "none",
     "challenge-pass": "none",
     "deploy-success": "medium",
-    "level-up": "medium",
+    "level-up": "popup",
     "credential-mint": "full",
   };
 
@@ -58,16 +58,12 @@ describe("celebrationTierFor — the LX-B11 tier map", () => {
     });
   }
 
-  it("confetti-worthy tiers are exactly deploy, level-up, and credential mint", () => {
-    const celebrated = Object.entries(CELEBRATION_TIERS)
-      .filter(([, tier]) => tier !== "none")
+  it("confetti-worthy tiers are EXACTLY deploy + credential mint (LX-B11 accept line)", () => {
+    const confettiWorthy = Object.entries(CELEBRATION_TIERS)
+      .filter(([, tier]) => tier === "medium" || tier === "full")
       .map(([event]) => event)
       .sort();
-    expect(celebrated).toEqual([
-      "credential-mint",
-      "deploy-success",
-      "level-up",
-    ]);
+    expect(confettiWorthy).toEqual(["credential-mint", "deploy-success"]);
   });
 });
 
@@ -105,11 +101,15 @@ describe("celebrate — confetti firing per tier", () => {
     expect(confettiMock).not.toHaveBeenCalled();
   });
 
-  it("fires a single medium burst for deploy success and level-up", () => {
+  it("never fires for level-up — the popup itself is the medium moment", () => {
+    celebrate("level-up");
+    vi.advanceTimersByTime(1000);
+    expect(confettiMock).not.toHaveBeenCalled();
+  });
+
+  it("fires a single medium burst for deploy success", () => {
     celebrate("deploy-success");
     expect(confettiMock).toHaveBeenCalledTimes(1);
-    celebrate("level-up");
-    expect(confettiMock).toHaveBeenCalledTimes(2);
   });
 
   it("fires the full multi-burst sequence for a credential mint", () => {
@@ -140,7 +140,6 @@ describe("celebrate — confetti firing per tier", () => {
     stubMatchMedia(true);
     expect(prefersReducedMotion()).toBe(true);
     celebrate("deploy-success");
-    celebrate("level-up");
     celebrate("credential-mint");
     vi.advanceTimersByTime(1000);
     expect(confettiMock).not.toHaveBeenCalled();

--- a/apps/web/src/lib/gamification/celebration.ts
+++ b/apps/web/src/lib/gamification/celebration.ts
@@ -1,0 +1,124 @@
+import confetti from "canvas-confetti";
+
+/**
+ * Celebration re-tiering (LX-B11, PED-10 overjustification).
+ *
+ * Routine per-lesson rewards undermine intrinsic motivation, so confetti is
+ * reserved for RARE, meaningful milestones. Lesson/challenge completion gets a
+ * calm checkmark acknowledgment; a successful devnet deploy and a level-up get
+ * a medium moment; a credential mint gets the full-screen celebration.
+ *
+ * All visual celebration respects `prefers-reduced-motion`.
+ */
+
+export type CelebrationEvent =
+  | "lesson-complete"
+  | "challenge-pass"
+  | "deploy-success"
+  | "level-up"
+  | "credential-mint";
+
+export type CelebrationTier = "none" | "medium" | "full";
+
+export const CELEBRATION_TIERS: Record<CelebrationEvent, CelebrationTier> = {
+  "lesson-complete": "none",
+  "challenge-pass": "none",
+  "deploy-success": "medium",
+  "level-up": "medium",
+  "credential-mint": "full",
+} as const;
+
+export function celebrationTierFor(event: CelebrationEvent): CelebrationTier {
+  return CELEBRATION_TIERS[event];
+}
+
+/**
+ * Struggling-encouragement state (LX-B11 / F11, R10): a learner whose runs
+ * keep failing gets a supportive nudge after this many consecutive failed
+ * runs — never a punishment, never blocking.
+ */
+export const ENCOURAGEMENT_THRESHOLD = 3;
+
+export function shouldShowEncouragement(
+  consecutiveFailedRuns: number
+): boolean {
+  return consecutiveFailedRuns >= ENCOURAGEMENT_THRESHOLD;
+}
+
+export function prefersReducedMotion(): boolean {
+  if (typeof window === "undefined" || typeof window.matchMedia !== "function")
+    return false;
+  return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+}
+
+/**
+ * A credential mint can be observed twice within moments (manual mint success
+ * + the Supabase Realtime certificate INSERT funneling into the popup), so
+ * full-tier celebrations within this window are collapsed into one.
+ */
+export const FULL_TIER_DEDUPE_MS = 8000;
+
+export function isDuplicateFullCelebration(
+  now: number,
+  lastFiredAt: number
+): boolean {
+  return now - lastFiredAt < FULL_TIER_DEDUPE_MS;
+}
+
+let lastFullFiredAt = 0;
+
+/** Test-only: clears the full-tier dedupe window. */
+export function resetCelebrationThrottleForTests(): void {
+  lastFullFiredAt = 0;
+}
+
+/**
+ * Fire the visual celebration for an event according to its tier.
+ * `none` renders nothing — the calm acknowledgment lives in the calling UI.
+ */
+export function celebrate(event: CelebrationEvent): void {
+  const tier = celebrationTierFor(event);
+  if (tier === "none") return;
+  if (typeof window === "undefined") return;
+  if (prefersReducedMotion()) return;
+
+  if (tier === "medium") {
+    confetti({
+      particleCount: 150,
+      spread: 80,
+      origin: { y: 0.6 },
+      disableForReducedMotion: true,
+    });
+    return;
+  }
+
+  // full — credential mint: one center burst + two side bursts
+  const now = Date.now();
+  if (isDuplicateFullCelebration(now, lastFullFiredAt)) return;
+  lastFullFiredAt = now;
+
+  confetti({
+    particleCount: 200,
+    spread: 100,
+    origin: { y: 0.6 },
+    disableForReducedMotion: true,
+  });
+  setTimeout(() => {
+    confetti({
+      particleCount: 120,
+      angle: 60,
+      spread: 70,
+      origin: { x: 0, y: 0.7 },
+      disableForReducedMotion: true,
+    });
+  }, 250);
+  setTimeout(() => {
+    confetti({
+      particleCount: 120,
+      angle: 120,
+      spread: 70,
+      origin: { x: 1, y: 0.7 },
+      disableForReducedMotion: true,
+    });
+  }, 400);
+}

--- a/apps/web/src/lib/gamification/celebration.ts
+++ b/apps/web/src/lib/gamification/celebration.ts
@@ -3,10 +3,14 @@ import confetti from "canvas-confetti";
 /**
  * Celebration re-tiering (LX-B11, PED-10 overjustification).
  *
- * Routine per-lesson rewards undermine intrinsic motivation, so confetti is
- * reserved for RARE, meaningful milestones. Lesson/challenge completion gets a
- * calm checkmark acknowledgment; a successful devnet deploy and a level-up get
- * a medium moment; a credential mint gets the full-screen celebration.
+ * Routine per-lesson rewards undermine intrinsic motivation, so per the
+ * LX-B11 acceptance line, confetti fires ONLY at deploy + credential mint.
+ * Lesson/challenge completion gets a calm checkmark acknowledgment; a
+ * level-up gets a popup-only medium moment — with Level = floor(sqrt(XP/100))
+ * early level-ups arrive every few lessons, and confetti that frequent would
+ * recreate the routine-reward pattern this tiering exists to kill; a
+ * successful devnet deploy gets a single confetti burst; a credential mint
+ * gets the full-screen celebration.
  *
  * All visual celebration respects `prefers-reduced-motion`.
  */
@@ -18,13 +22,13 @@ export type CelebrationEvent =
   | "level-up"
   | "credential-mint";
 
-export type CelebrationTier = "none" | "medium" | "full";
+export type CelebrationTier = "none" | "popup" | "medium" | "full";
 
 export const CELEBRATION_TIERS: Record<CelebrationEvent, CelebrationTier> = {
   "lesson-complete": "none",
   "challenge-pass": "none",
   "deploy-success": "medium",
-  "level-up": "medium",
+  "level-up": "popup",
   "credential-mint": "full",
 } as const;
 
@@ -75,10 +79,13 @@ export function resetCelebrationThrottleForTests(): void {
 /**
  * Fire the visual celebration for an event according to its tier.
  * `none` renders nothing — the calm acknowledgment lives in the calling UI.
+ * `popup` also fires NO confetti — the animated popup rendered by the calling
+ * UI (e.g. LevelUpPopup's pop-spring card) IS the medium moment; only the
+ * `medium` and `full` tiers ever reach canvas-confetti.
  */
 export function celebrate(event: CelebrationEvent): void {
   const tier = celebrationTierFor(event);
-  if (tier === "none") return;
+  if (tier === "none" || tier === "popup") return;
   if (typeof window === "undefined") return;
   if (prefersReducedMotion()) return;
 

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -218,6 +218,8 @@
     "rustRateLimited": "Too many requests. Please wait a moment.",
     "rustCompileTimeout": "Compilation timed out. Try simplifying your code.",
     "enrollToSaveProgress": "Enroll in this course to save your progress and earn XP.",
+    "encouragementTitle": "Stuck? That's part of it.",
+    "encouragementBody": "Every failed run narrows things down. Peek at the hints or ask the AI partner for a nudge — you're closer than it feels.",
     "buildProgram": "Build",
     "buildingProgram": "Building Solana program...",
     "buildSuccess": "Program compiled successfully!",

--- a/apps/web/src/messages/es.json
+++ b/apps/web/src/messages/es.json
@@ -218,6 +218,8 @@
     "rustRateLimited": "Demasiadas solicitudes. Espera un momento.",
     "rustCompileTimeout": "La compilación expiró. Intenta simplificar tu código.",
     "enrollToSaveProgress": "Inscríbete en este curso para guardar tu progreso y ganar XP.",
+    "encouragementTitle": "¿Atascado? Es parte del proceso.",
+    "encouragementBody": "Cada ejecución fallida descarta posibilidades. Revisa las pistas o pídele una mano al compañero de IA — estás más cerca de lo que parece.",
     "buildProgram": "Compilar",
     "buildingProgram": "Compilando programa Solana...",
     "buildSuccess": "¡Programa compilado con éxito!",

--- a/apps/web/src/messages/pt-BR.json
+++ b/apps/web/src/messages/pt-BR.json
@@ -218,6 +218,8 @@
     "rustRateLimited": "Muitas requisições. Aguarde um momento.",
     "rustCompileTimeout": "Compilação expirou. Tente simplificar seu código.",
     "enrollToSaveProgress": "Inscreva-se neste curso para salvar seu progresso e ganhar XP.",
+    "encouragementTitle": "Travou? Faz parte.",
+    "encouragementBody": "Cada execução que falha elimina possibilidades. Dê uma olhada nas dicas ou peça uma força ao parceiro de IA — você está mais perto do que parece.",
     "buildProgram": "Compilar",
     "buildingProgram": "Compilando programa Solana...",
     "buildSuccess": "Programa compilado com sucesso!",


### PR DESCRIPTION
Closes #549

## What

Implements **LX-B11** (launch-experience master spec §3): celebration now marks rare, meaningful milestones instead of firing on every challenge pass (PED-10 overjustification — routine per-lesson rewards undermine intrinsic motivation).

Per the LX-B11 **acceptance line** — "confetti fires only at deploy + credential mint; level-up gets a medium moment" (ruled to beat the body's looser "add medium at level-up" phrasing) — the level-up moment is **popup-only**: with Level = floor(sqrt(XP/100)), early level-ups arrive every few lessons, and confetti that frequent would recreate the routine-reward pattern this issue exists to kill.

### Tier map (event → celebration)

| Event | Before | After |
|---|---|---|
| Challenge/lesson pass | confetti on EVERY pass (`challenge-interface.tsx:89`) | `none` — calm checkmark acknowledgment (CheckCircle overlay + XP line), **no confetti** |
| Devnet deploy success | confetti | `medium` — single confetti burst (kept, now reduced-motion-safe) |
| Level-up | nothing | `popup` — new `LevelUpPopup` (v9 `.popup-grad` pop-spring card) is the medium moment; **no confetti** — the tier resolves to `popup`, which `celebrate()` returns from before any canvas-confetti call, and a test asserts zero confetti calls for level-up |
| Credential mint | popup only | `full` — full-screen multi-burst confetti (Realtime certificate popup + manual mint path in `CourseCompletionMint`, deduped within an 8s window so the two paths can't double-fire) |
| ≥3 consecutive failed runs | nothing | **struggling-encouragement state** — supportive, dismissible, non-blocking banner above the output panel; resets on a passing run (F11/R10) |

### How

- All tier decisions + confetti firing centralized in `lib/gamification/celebration.ts` — pure `CELEBRATION_TIERS` map (`none | popup | medium | full`), `celebrationTierFor()`, `shouldShowEncouragement()` (threshold = 3), full-tier dedupe, and `celebrate(event)`. Only the `medium` and `full` tiers can ever reach canvas-confetti.
- **`prefers-reduced-motion` respected** at every tier (the two pre-existing confetti call sites had no guard) — both via an explicit `matchMedia` check and `disableForReducedMotion` on every confetti call.
- Level-up detection: the `user_xp` Realtime UPDATE handler in `use-gamification-events.ts` already tracked the level in a ref; it now dispatches `superteam:level-up` on a genuine increase (null-seeded ref prevents first-update false triggers). Uses the existing `gamification.levelUp` / `levelUpMessage` strings (already ×3 locales).
- New strings (`lesson.encouragementTitle` / `lesson.encouragementBody`) shipped in **en, pt-BR, es**; locale parity test passes.

## Verification

- `pnpm typecheck` — clean
- `pnpm test` (apps/web) — **105 files / 987 tests passed**, including `celebration.test.ts`: tier map (level-up → `popup`; confetti-worthy tiers asserted to be exactly `{deploy-success, credential-mint}`), level-up fires zero confetti calls, encouragement threshold boundaries, dedupe window, reduced-motion suppression — plus the locale parity test
- `grep -rn confetti apps/web/src` — canvas-confetti is now imported in exactly one module (`lib/gamification/celebration.ts`)

## Scope

Touches only celebration/confetti/popup surfaces + locales + tests. The deploy **save API route** is untouched (owned by a parallel task); only the deploy success UI moment changed.
