### PR TITLE
feat(dashboard): Continue card + fix hardcoded first-lesson CTA (LX-B2)

### DIFF
--- a/apps/web/src/app/[locale]/(platform)/courses/[slug]/course-detail-client.tsx
+++ b/apps/web/src/app/[locale]/(platform)/courses/[slug]/course-detail-client.tsx
@@ -18,6 +18,7 @@ import { CurriculumAccordion } from "@/components/course/curriculum-accordion";
 import { ProgressBar } from "@/components/course/progress-bar";
 import { InstructorCard } from "@/components/course/instructor-card";
 import { createClient } from "@/lib/supabase/client";
+import { findNextIncompleteLesson } from "@/lib/courses/continue-learning";
 import { AuthModal } from "@/components/auth/auth-modal";
 import { useAuth } from "@/lib/auth/auth-provider";
 import { useOnChainEnroll } from "@/hooks/use-on-chain-enroll";
@@ -140,6 +141,16 @@ export function CourseDetailClient({
   const completedCount = completedLessons.length;
   const isComplete = completedCount === totalLessons && totalLessons > 0;
 
+  // Next incomplete lesson in module→lesson order (LX-B2 — this used to be
+  // hardcoded to the first lesson regardless of progress). Fully complete
+  // courses fall back to the first lesson for review.
+  const orderedLessons = accordionModules.flatMap((m) => m.lessons);
+  const nextIncompleteLesson = findNextIncompleteLesson(
+    orderedLessons,
+    new Set(completedLessons)
+  );
+  const ctaLessonSlug = (nextIncompleteLesson ?? orderedLessons[0])?.slug ?? "";
+
   return (
     <div className="space-y-6">
       {/* Back to catalog */}
@@ -260,7 +271,7 @@ export function CourseDetailClient({
                 >
                   {isEnrolled ? (
                     <a
-                      href={`/${locale}/courses/${course.slug}/lessons/${modules[0]?.lessons?.[0]?.slug ?? ""}`}
+                      href={`/${locale}/courses/${course.slug}/lessons/${ctaLessonSlug}`}
                     >
                       {t("continueCourse")}
                     </a>

--- a/apps/web/src/app/[locale]/(platform)/dashboard/page.tsx
+++ b/apps/web/src/app/[locale]/(platform)/dashboard/page.tsx
@@ -39,6 +39,7 @@ import { dispatchToast } from "@/components/ui/toast-container";
 import { getProgressService } from "@/lib/services";
 import { calculateLevel } from "@/lib/gamification/xp";
 import {
+  getCourseLessonOrders,
   getCoursesByIds,
   getLessonsByIds,
   getRecommendedCourses,
@@ -48,6 +49,14 @@ import type {
   RecommendedCourse,
   DeployedAchievement,
 } from "@/lib/content/queries";
+import {
+  deriveContinueTarget,
+  type ContinueTarget,
+} from "@/lib/courses/continue-learning";
+import {
+  ContinueCard,
+  type ContinueCardTarget,
+} from "@/components/dashboard/continue-card";
 
 const SOLANA_CLUSTER = process.env.NEXT_PUBLIC_SOLANA_NETWORK ?? "devnet";
 function explorerTxUrl(sig: string): string {
@@ -87,6 +96,8 @@ interface DashboardData {
   quests: DailyQuest[];
   questsResetTime: string;
   currentCourses: CurrentCourse[];
+  /** Next-incomplete-lesson derivation for the hero Continue card (LX-B2). */
+  continueTarget: ContinueTarget | null;
   recommendedCourses: RecommendedCourse[];
   recentActivity: {
     type:
@@ -126,6 +137,7 @@ function useDashboardData(
     quests: [],
     questsResetTime: "",
     currentCourses: [],
+    continueTarget: null,
     recommendedCourses: [],
     recentActivity: [],
     username: "Builder",
@@ -221,7 +233,7 @@ function useDashboardData(
             .eq("user_id", authUserId),
           supabase
             .from("user_progress")
-            .select("course_id, lesson_id, completed")
+            .select("course_id, lesson_id, completed, completed_at")
             .eq("user_id", authUserId)
             .eq("completed", true),
           supabase
@@ -314,13 +326,16 @@ function useDashboardData(
         const excludeFromRecommended = [
           ...new Set([...allEnrolledIds, ...mintedCourseIds]),
         ];
-        const [courseSummaries, recommended, achievementCatalog] =
+        const [courseSummaries, recommended, achievementCatalog, lessonOrders] =
           await Promise.all([
             allCourseIdsToFetch.length > 0
               ? getCoursesByIds(allCourseIdsToFetch)
               : Promise.resolve([]),
             getRecommendedCourses(excludeFromRecommended),
             getAllAchievements(),
+            allEnrolledIds.length > 0
+              ? getCourseLessonOrders(allEnrolledIds)
+              : Promise.resolve([]),
           ]);
         // Build a lookup map: course _id -> Sanity data
         const courseMap = new Map(courseSummaries.map((c) => [c._id, c]));
@@ -344,6 +359,37 @@ function useDashboardData(
               thumbnail: courseInfo?.thumbnail ?? null,
             };
           });
+
+        // Derive the hero Continue card target: next incomplete lesson in the
+        // most recently active enrolled course (LX-B2). Minted (certified)
+        // courses still count as enrolled-and-finished for the all-complete
+        // state but are never a continue candidate.
+        const lessonOrderById = new Map(
+          lessonOrders.map((o) => [o._id, o.lessons])
+        );
+        const enrolledAtById = new Map(
+          (enrollments ?? []).map((e) => [e.course_id, e.enrolled_at])
+        );
+        const continueTarget = deriveContinueTarget(
+          allEnrolledIds
+            .filter((id) => courseMap.has(id))
+            .map((id) => {
+              const info = courseMap.get(id)!;
+              return {
+                courseId: id,
+                title: info.title,
+                slug: info.slug,
+                enrolledAt: enrolledAtById.get(id) ?? null,
+                certified: mintedCourseIds.has(id),
+                lessons: lessonOrderById.get(id) ?? [],
+              };
+            }),
+          (progressRows ?? []).map((row) => ({
+            courseId: row.course_id,
+            lessonId: row.lesson_id,
+            completedAt: row.completed_at,
+          }))
+        );
 
         // Build multi-source activity feed. Each source uses a different timestamp
         // column name; normalise all to `time` before merging and sorting.
@@ -549,6 +595,7 @@ function useDashboardData(
           quests: questsResult.quests ?? [],
           questsResetTime: questsResult.nextResetTime ?? "",
           currentCourses,
+          continueTarget,
           recommendedCourses: recommended,
           recentActivity,
           username: profile?.username ?? "Builder",
@@ -730,6 +777,30 @@ export default function DashboardPage() {
     [publicKey, sendTransaction, connection, setWalletModalVisible, t, tErrors]
   );
 
+  // Map the derived continue target onto the hero card's shape. All-complete
+  // learners are pointed at the next (recommended) course, or the catalog when
+  // nothing is left to recommend. No enrollments → no card (the Current
+  // Courses empty state keeps its catalog CTA).
+  const continueCardTarget: ContinueCardTarget | null = (() => {
+    const target = data.continueTarget;
+    if (!target) return null;
+    if (target.kind === "lesson") {
+      return {
+        kind: "lesson",
+        courseTitle: target.courseTitle,
+        courseSlug: target.courseSlug,
+        lessonTitle: target.lesson.title,
+        lessonSlug: target.lesson.slug,
+        completedLessons: target.completedLessons,
+        totalLessons: target.totalLessons,
+      };
+    }
+    const next = data.recommendedCourses[0];
+    return next
+      ? { kind: "nextCourse", courseTitle: next.title, courseSlug: next.slug }
+      : { kind: "catalog" };
+  })();
+
   const formatTimeAgo = (isoDate: string): string => {
     const diffMs = Date.now() - new Date(isoDate).getTime();
     const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
@@ -780,6 +851,11 @@ export default function DashboardPage() {
       <h1 className="font-display text-2xl font-black tracking-[-0.5px] sm:text-3xl">
         {t("title")}
       </h1>
+
+      {/* Hero Continue card — deep link to the next incomplete lesson (LX-B2) */}
+      {continueCardTarget && (
+        <ContinueCard target={continueCardTarget} locale={locale} />
+      )}
 
       {/* V9 Dashboard Identity Panel — Level+XP | Medals | Activity Grid */}
       <DashboardIdentityPanel

--- a/apps/web/src/app/api/content/__tests__/routes.test.ts
+++ b/apps/web/src/app/api/content/__tests__/routes.test.ts
@@ -6,6 +6,7 @@ vi.mock("server-only", () => ({}));
 
 const fns = vi.hoisted(() => ({
   getCoursesByIds: vi.fn(),
+  getCourseLessonOrders: vi.fn(),
   getLessonsByIds: vi.fn(),
   getRecommendedCourses: vi.fn(),
   getAllCourseTags: vi.fn(),
@@ -16,6 +17,7 @@ const fns = vi.hoisted(() => ({
 vi.mock("@/lib/content/queries", () => fns);
 
 import { GET as getCourses } from "../courses/route";
+import { GET as getCourseLessons } from "../course-lessons/route";
 import { GET as getLessons } from "../lessons-summary/route";
 import { GET as getRecommended } from "../recommended/route";
 import { GET as getTags } from "../tags/route";
@@ -73,6 +75,60 @@ describe("GET /api/content/courses", () => {
     const res = await getCourses(req("/api/content/courses?ids=course-a"));
     expect(res.status).toBe(500);
     expect(JSON.stringify(await res.json())).not.toContain("secret detail");
+  });
+});
+
+describe("GET /api/content/course-lessons", () => {
+  it("passes validated ids through and wraps the result", async () => {
+    fns.getCourseLessonOrders.mockResolvedValue([
+      {
+        _id: "course-a",
+        slug: "a",
+        lessons: [{ _id: "lesson-1", title: "One", slug: "one" }],
+      },
+    ]);
+    const res = await getCourseLessons(
+      req("/api/content/course-lessons?ids=course-a,course-b")
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      courses: [
+        {
+          _id: "course-a",
+          slug: "a",
+          lessons: [{ _id: "lesson-1", title: "One", slug: "one" }],
+        },
+      ],
+    });
+    expect(fns.getCourseLessonOrders).toHaveBeenCalledWith([
+      "course-a",
+      "course-b",
+    ]);
+  });
+
+  it("400s on missing or malformed ids", async () => {
+    expect(
+      (await getCourseLessons(req("/api/content/course-lessons"))).status
+    ).toBe(400);
+    expect(
+      (
+        await getCourseLessons(
+          req(
+            `/api/content/course-lessons?ids=${encodeURIComponent("bad id!")}`
+          )
+        )
+      ).status
+    ).toBe(400);
+    expect(fns.getCourseLessonOrders).not.toHaveBeenCalled();
+  });
+
+  it("500s with a generic message on failure", async () => {
+    fns.getCourseLessonOrders.mockRejectedValue(new Error("boom secret"));
+    const res = await getCourseLessons(
+      req("/api/content/course-lessons?ids=course-a")
+    );
+    expect(res.status).toBe(500);
+    expect(JSON.stringify(await res.json())).not.toContain("secret");
   });
 });
 

--- a/apps/web/src/app/api/content/course-lessons/route.ts
+++ b/apps/web/src/app/api/content/course-lessons/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from "next/server";
+import { parseIds } from "../params";
+import { getCourseLessonOrders } from "@/lib/content/queries";
+
+/**
+ * Ordered lesson summaries per course id — the client-side face of
+ * `getCourseLessonOrders` (dashboard Continue card, LX-B2). Gated server-side
+ * on synced+active; only the summary-safe `{_id,title,slug}` lesson shape
+ * crosses this boundary (no lesson content). Reading search params makes the
+ * route dynamic; the deployment map stays cached via `getActiveDeployments`.
+ */
+export async function GET(request: NextRequest) {
+  const ids = parseIds(request.nextUrl.searchParams.get("ids"), false);
+  if (ids instanceof NextResponse) return ids;
+  try {
+    const courses = await getCourseLessonOrders(ids);
+    return NextResponse.json({ courses });
+  } catch {
+    return NextResponse.json(
+      { error: "Failed to fetch course lessons" },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/web/src/components/dashboard/__tests__/continue-card.test.tsx
+++ b/apps/web/src/components/dashboard/__tests__/continue-card.test.tsx
@@ -1,0 +1,72 @@
+// @vitest-environment jsdom
+import type { ReactElement } from "react";
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import { ContinueCard } from "../continue-card";
+import messages from "@/messages/en.json";
+
+function renderWithIntl(ui: ReactElement) {
+  return render(
+    <NextIntlClientProvider locale="en" messages={messages}>
+      {ui}
+    </NextIntlClientProvider>
+  );
+}
+
+describe("ContinueCard — lesson target", () => {
+  const target = {
+    kind: "lesson" as const,
+    courseTitle: "Solana 101",
+    courseSlug: "solana-101",
+    lessonTitle: "What is a PDA?",
+    lessonSlug: "what-is-a-pda",
+    completedLessons: 3,
+    totalLessons: 8,
+  };
+
+  it("is a single focusable link deep-linking to the next incomplete lesson", () => {
+    renderWithIntl(<ContinueCard target={target} locale="en" />);
+    const link = screen.getByRole("link", {
+      name: "Continue Solana 101 — next lesson: What is a PDA?",
+    });
+    expect(link).toHaveAttribute(
+      "href",
+      "/en/courses/solana-101/lessons/what-is-a-pda"
+    );
+  });
+
+  it("shows course · lesson and the progress count", () => {
+    renderWithIntl(<ContinueCard target={target} locale="en" />);
+    expect(screen.getByText("Solana 101")).toBeInTheDocument();
+    expect(screen.getByText("What is a PDA?")).toBeInTheDocument();
+    expect(screen.getByText("3 of 8 lessons completed")).toBeInTheDocument();
+  });
+});
+
+describe("ContinueCard — all-complete targets", () => {
+  it("nextCourse variant links to the recommended course detail page", () => {
+    renderWithIntl(
+      <ContinueCard
+        target={{
+          kind: "nextCourse",
+          courseTitle: "Anchor Framework",
+          courseSlug: "anchor-framework",
+        }}
+        locale="en"
+      />
+    );
+    const link = screen.getByRole("link", {
+      name: "Start your next course: Anchor Framework",
+    });
+    expect(link).toHaveAttribute("href", "/en/courses/anchor-framework");
+    expect(screen.getByText("Anchor Framework")).toBeInTheDocument();
+    expect(screen.getByText("All caught up!")).toBeInTheDocument();
+  });
+
+  it("catalog variant links to the course catalog", () => {
+    renderWithIntl(<ContinueCard target={{ kind: "catalog" }} locale="en" />);
+    const link = screen.getByRole("link", { name: "Browse Courses" });
+    expect(link).toHaveAttribute("href", "/en/courses");
+  });
+});

--- a/apps/web/src/components/dashboard/continue-card.tsx
+++ b/apps/web/src/components/dashboard/continue-card.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import Link from "next/link";
+import { Play, ArrowRight, Confetti } from "@phosphor-icons/react";
+
+/**
+ * What the dashboard hero's Continue card points at (LX-B2, issue #551):
+ * the derived next-incomplete lesson, the next course when everything
+ * enrolled is finished, or the catalog when there is nothing left to suggest.
+ * `null` derivations (no enrollments) simply don't render the card — the
+ * existing empty states keep their catalog CTA.
+ */
+export type ContinueCardTarget =
+  | {
+      kind: "lesson";
+      courseTitle: string;
+      courseSlug: string;
+      lessonTitle: string;
+      lessonSlug: string;
+      completedLessons: number;
+      totalLessons: number;
+    }
+  | { kind: "nextCourse"; courseTitle: string; courseSlug: string }
+  | { kind: "catalog" };
+
+interface ContinueCardProps {
+  target: ContinueCardTarget;
+  locale: string;
+}
+
+/**
+ * Dashboard hero Continue card — one focusable deep link straight back into
+ * the learning loop, wrapped in the Solana brand gradient.
+ */
+export function ContinueCard({ target, locale }: ContinueCardProps) {
+  const t = useTranslations("dashboard");
+
+  const href =
+    target.kind === "lesson"
+      ? `/${locale}/courses/${target.courseSlug}/lessons/${target.lessonSlug}`
+      : target.kind === "nextCourse"
+        ? `/${locale}/courses/${target.courseSlug}`
+        : `/${locale}/courses`;
+
+  const ariaLabel =
+    target.kind === "lesson"
+      ? t("continueAria", {
+          course: target.courseTitle,
+          lesson: target.lessonTitle,
+        })
+      : target.kind === "nextCourse"
+        ? t("startNextCourseAria", { course: target.courseTitle })
+        : t("browseCourses");
+
+  return (
+    <Link
+      href={href}
+      aria-label={ariaLabel}
+      className="group block rounded-xl focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+    >
+      <div className="rounded-xl p-[2.5px] shadow-card [background:linear-gradient(135deg,#9945FF,#14F195)]">
+        <div className="relative flex items-center gap-4 overflow-hidden rounded-[10px] bg-card p-5 md:p-6">
+          {/* sheen sweep on hover */}
+          <div
+            className="pointer-events-none absolute inset-0 -translate-x-full bg-gradient-to-r from-transparent via-white/[0.06] to-transparent transition-transform duration-700 ease-out group-hover:translate-x-full"
+            aria-hidden="true"
+          />
+
+          <span
+            className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full text-white [background:linear-gradient(135deg,#9945FF,#14F195)]"
+            aria-hidden="true"
+          >
+            {target.kind === "lesson" ? (
+              <Play size={20} weight="fill" />
+            ) : (
+              <Confetti size={20} weight="fill" />
+            )}
+          </span>
+
+          <div className="min-w-0 flex-1">
+            <p className="font-mono text-[10px] font-bold uppercase tracking-[0.22em] text-primary">
+              {target.kind === "lesson"
+                ? t("continueLearning")
+                : t("allCaughtUp")}
+            </p>
+            {target.kind === "lesson" ? (
+              <p className="mt-1 truncate font-display text-base font-black tracking-[-0.25px] md:text-lg">
+                {target.courseTitle}
+                <span className="mx-2 text-text-3" aria-hidden="true">
+                  &middot;
+                </span>
+                <span className="text-text-2">{target.lessonTitle}</span>
+              </p>
+            ) : target.kind === "nextCourse" ? (
+              <p className="mt-1 truncate font-display text-base font-black tracking-[-0.25px] md:text-lg">
+                {t("startNextCourse")}
+                <span className="mx-2 text-text-3" aria-hidden="true">
+                  &middot;
+                </span>
+                <span className="text-text-2">{target.courseTitle}</span>
+              </p>
+            ) : (
+              <p className="mt-1 truncate font-display text-base font-black tracking-[-0.25px] md:text-lg">
+                {t("browseCourses")}
+              </p>
+            )}
+            {target.kind === "lesson" && (
+              <p className="mt-1 text-xs text-text-3">
+                {t("lessonsDone", {
+                  completed: target.completedLessons,
+                  total: target.totalLessons,
+                })}
+              </p>
+            )}
+            {target.kind !== "lesson" && (
+              <p className="mt-1 text-xs text-text-3">{t("allCaughtUpHint")}</p>
+            )}
+          </div>
+
+          <span
+            className="flex shrink-0 items-center gap-1.5 font-display text-sm font-extrabold text-primary transition-transform duration-200 group-hover:translate-x-0.5"
+            aria-hidden="true"
+          >
+            <span className="hidden sm:inline">
+              {target.kind === "lesson"
+                ? t("resumeLesson")
+                : target.kind === "nextCourse"
+                  ? t("startLearning")
+                  : t("browseCourses")}
+            </span>
+            <ArrowRight size={16} weight="bold" />
+          </span>
+        </div>
+      </div>
+    </Link>
+  );
+}

--- a/apps/web/src/lib/content/__tests__/client-queries.test.ts
+++ b/apps/web/src/lib/content/__tests__/client-queries.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
+  getCourseLessonOrders,
   getCoursesByIds,
   getLessonsByIds,
   getRecommendedCourses,
@@ -41,6 +42,23 @@ describe("client-queries — /api/content fetch wrappers", () => {
 
   it("getCoursesByIds([]) short-circuits without a request", async () => {
     expect(await getCoursesByIds([])).toEqual([]);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("getCourseLessonOrders hits course-lessons and unwraps", async () => {
+    fetchMock.mockResolvedValue(
+      ok({ courses: [{ _id: "course-a", slug: "a", lessons: [] }] })
+    );
+    expect(await getCourseLessonOrders(["course-a", "course-b"])).toEqual([
+      { _id: "course-a", slug: "a", lessons: [] },
+    ]);
+    expect(fetchMock).toHaveBeenCalledWith(
+      `/api/content/course-lessons?ids=${encodeURIComponent(
+        "course-a,course-b"
+      )}`
+    );
+    fetchMock.mockClear();
+    expect(await getCourseLessonOrders([])).toEqual([]);
     expect(fetchMock).not.toHaveBeenCalled();
   });
 

--- a/apps/web/src/lib/content/__tests__/queries.test.ts
+++ b/apps/web/src/lib/content/__tests__/queries.test.ts
@@ -299,6 +299,22 @@ describe("gated catalog fns — synced+active only, order(title asc)", () => {
     expect(res[0]?.learningPath).toBe("Main");
   });
 
+  it("getCourseLessonOrders returns bundle-ordered lesson summaries, gated on synced+active", async () => {
+    const res = await q.getCourseLessonOrders([
+      "course-zeta",
+      "course-off",
+      "course-pending",
+    ]);
+    expect(res).toEqual([
+      {
+        _id: "course-zeta",
+        slug: "zeta",
+        lessons: [{ _id: "lesson-live-1", title: "Live One", slug: "live-1" }],
+      },
+    ]);
+    expect(await q.getCourseLessonOrders([])).toEqual([]);
+  });
+
   it("getRecommendedCourses excludes ids + gates + sorts", async () => {
     const res = await q.getRecommendedCourses(["course-zeta"]);
     expect(res.map((c) => c._id)).toEqual(["course-alpha"]);

--- a/apps/web/src/lib/content/client-queries.ts
+++ b/apps/web/src/lib/content/client-queries.ts
@@ -1,4 +1,5 @@
 import type {
+  CourseLessonOrder,
   CourseSummary,
   DeployedAchievement,
   LessonSummary,
@@ -37,6 +38,16 @@ export async function getCoursesByIds(ids: string[]): Promise<CourseSummary[]> {
   if (ids.length === 0) return [];
   const data = await getJson<{ courses: CourseSummary[] }>(
     `/api/content/courses?ids=${idsParam(ids)}`
+  );
+  return data.courses;
+}
+
+export async function getCourseLessonOrders(
+  ids: string[]
+): Promise<CourseLessonOrder[]> {
+  if (ids.length === 0) return [];
+  const data = await getJson<{ courses: CourseLessonOrder[] }>(
+    `/api/content/course-lessons?ids=${idsParam(ids)}`
   );
   return data.courses;
 }

--- a/apps/web/src/lib/content/queries.ts
+++ b/apps/web/src/lib/content/queries.ts
@@ -298,6 +298,33 @@ export interface LessonSummary {
   slug: string;
 }
 
+/** A course's lessons in module→lesson display order (LX-B2 Continue card). */
+export interface CourseLessonOrder {
+  _id: string;
+  slug: string;
+  lessons: LessonSummary[];
+}
+
+/**
+ * Ordered lesson summaries for the given course ids, gated on synced+active
+ * like every public catalog read. Summary-safe shape only (no lesson content)
+ * — this feeds the dashboard's next-incomplete-lesson derivation.
+ */
+export async function getCourseLessonOrders(
+  ids: string[]
+): Promise<CourseLessonOrder[]> {
+  if (ids.length === 0) return [];
+  const idSet = new Set(ids);
+  const map = await getActiveDeployments();
+  return [...coursesById.values()]
+    .filter((c) => idSet.has(c._id) && isSynced(map.get(c._id)))
+    .map((c) => ({
+      _id: c._id,
+      slug: c.slug.current,
+      lessons: courseLessonDocs(c).map(projectLessonSummary),
+    }));
+}
+
 export async function getLessonsByIds(ids: string[]): Promise<LessonSummary[]> {
   if (ids.length === 0) return [];
   const idSet = new Set(ids);

--- a/apps/web/src/lib/courses/__tests__/continue-learning.test.ts
+++ b/apps/web/src/lib/courses/__tests__/continue-learning.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect } from "vitest";
+import {
+  deriveContinueTarget,
+  findNextIncompleteLesson,
+  type ContinueCourseInput,
+  type ProgressEntry,
+} from "../continue-learning";
+
+function lesson(id: string) {
+  return { _id: id, title: `Lesson ${id}`, slug: `slug-${id}` };
+}
+
+function course(
+  courseId: string,
+  lessonIds: string[],
+  overrides: Partial<ContinueCourseInput> = {}
+): ContinueCourseInput {
+  return {
+    courseId,
+    title: `Course ${courseId}`,
+    slug: `course-${courseId}`,
+    enrolledAt: null,
+    lessons: lessonIds.map(lesson),
+    ...overrides,
+  };
+}
+
+function done(
+  courseId: string,
+  lessonId: string,
+  completedAt: string | null = null
+): ProgressEntry {
+  return { courseId, lessonId, completedAt };
+}
+
+describe("findNextIncompleteLesson", () => {
+  const lessons = [lesson("l1"), lesson("l2"), lesson("l3")];
+
+  it("returns the first lesson when nothing is complete", () => {
+    expect(findNextIncompleteLesson(lessons, new Set())?._id).toBe("l1");
+  });
+
+  it("returns the first incomplete lesson in order, skipping completed holes", () => {
+    // l1 and l3 done out of order — the next gap in display order is l2.
+    expect(findNextIncompleteLesson(lessons, new Set(["l1", "l3"]))?._id).toBe(
+      "l2"
+    );
+  });
+
+  it("returns null when every lesson is complete", () => {
+    expect(
+      findNextIncompleteLesson(lessons, new Set(["l1", "l2", "l3"]))
+    ).toBeNull();
+  });
+
+  it("returns null for an empty lesson list", () => {
+    expect(findNextIncompleteLesson([], new Set())).toBeNull();
+  });
+});
+
+describe("deriveContinueTarget", () => {
+  it("returns null when there are no enrollments", () => {
+    expect(deriveContinueTarget([], [])).toBeNull();
+  });
+
+  it("mid-course: targets the next incomplete lesson with correct counts", () => {
+    const target = deriveContinueTarget(
+      [course("a", ["l1", "l2", "l3"])],
+      [done("a", "l1", "2026-07-01T10:00:00Z")]
+    );
+    expect(target).toEqual({
+      kind: "lesson",
+      courseId: "a",
+      courseTitle: "Course a",
+      courseSlug: "course-a",
+      lesson: lesson("l2"),
+      completedLessons: 1,
+      totalLessons: 3,
+    });
+  });
+
+  it("freshly enrolled course with zero progress targets its first lesson", () => {
+    const target = deriveContinueTarget(
+      [course("a", ["l1", "l2"], { enrolledAt: "2026-07-01T00:00:00Z" })],
+      []
+    );
+    expect(target).toMatchObject({ kind: "lesson", lesson: lesson("l1") });
+  });
+
+  it("all enrolled courses complete → allComplete", () => {
+    const target = deriveContinueTarget(
+      [course("a", ["l1", "l2"])],
+      [done("a", "l1"), done("a", "l2")]
+    );
+    expect(target).toEqual({ kind: "allComplete" });
+  });
+
+  it("multiple courses: picks the most recently active by last completion", () => {
+    const target = deriveContinueTarget(
+      [course("old", ["o1", "o2"]), course("new", ["n1", "n2"])],
+      [
+        done("old", "o1", "2026-07-01T10:00:00Z"),
+        done("new", "n1", "2026-07-20T10:00:00Z"),
+      ]
+    );
+    expect(target).toMatchObject({ kind: "lesson", courseId: "new" });
+    expect(target).toMatchObject({ lesson: lesson("n2") });
+  });
+
+  it("a fresh enrollment outranks older progress (enrolledAt counts as activity)", () => {
+    const target = deriveContinueTarget(
+      [
+        course("progressed", ["p1", "p2"]),
+        course("fresh", ["f1"], { enrolledAt: "2026-07-24T09:00:00Z" }),
+      ],
+      [done("progressed", "p1", "2026-07-10T10:00:00Z")]
+    );
+    expect(target).toMatchObject({ kind: "lesson", courseId: "fresh" });
+  });
+
+  it("skips a fully-complete most-recent course in favor of an unfinished one", () => {
+    const target = deriveContinueTarget(
+      [course("doneCourse", ["d1"]), course("open", ["x1", "x2"])],
+      [
+        done("doneCourse", "d1", "2026-07-22T10:00:00Z"),
+        done("open", "x1", "2026-07-02T10:00:00Z"),
+      ]
+    );
+    expect(target).toMatchObject({ kind: "lesson", courseId: "open" });
+  });
+
+  it("certified (minted) courses are never a continue target but count for allComplete", () => {
+    // Certified course has stale/no progress rows — still must not surface.
+    expect(
+      deriveContinueTarget([course("minted", ["m1"], { certified: true })], [])
+    ).toEqual({ kind: "allComplete" });
+
+    const target = deriveContinueTarget(
+      [
+        course("minted", ["m1"], {
+          certified: true,
+          enrolledAt: "2026-07-24T00:00:00Z",
+        }),
+        course("open", ["x1"]),
+      ],
+      []
+    );
+    expect(target).toMatchObject({ kind: "lesson", courseId: "open" });
+  });
+
+  it("ignores zero-lesson courses", () => {
+    const target = deriveContinueTarget(
+      [course("empty", [], { enrolledAt: "2026-07-24T00:00:00Z" })],
+      []
+    );
+    expect(target).toEqual({ kind: "allComplete" });
+  });
+
+  it("counts completion against bundle lessons, not raw progress rows", () => {
+    // A stale row for a removed lesson must not inflate the completed count.
+    const target = deriveContinueTarget(
+      [course("a", ["l1", "l2"])],
+      [done("a", "l1"), done("a", "removed-lesson")]
+    );
+    expect(target).toMatchObject({
+      kind: "lesson",
+      completedLessons: 1,
+      totalLessons: 2,
+      lesson: lesson("l2"),
+    });
+  });
+
+  it("tolerates malformed timestamps (treated as epoch 0)", () => {
+    const target = deriveContinueTarget(
+      [
+        course("a", ["a1"], { enrolledAt: "not-a-date" }),
+        course("b", ["b1"], { enrolledAt: "2026-07-01T00:00:00Z" }),
+      ],
+      []
+    );
+    expect(target).toMatchObject({ kind: "lesson", courseId: "b" });
+  });
+});

--- a/apps/web/src/lib/courses/continue-learning.ts
+++ b/apps/web/src/lib/courses/continue-learning.ts
@@ -1,0 +1,135 @@
+/**
+ * Next-incomplete-lesson derivation (LX-B2, issue #551). Pure — no I/O, no
+ * schema: everything is computed from data the app already has (enrollments,
+ * completed `user_progress` rows, and the content bundle's module→lesson
+ * display order).
+ */
+
+/** A lesson reference in content-bundle display order. */
+export interface OrderedLessonRef {
+  _id: string;
+  title: string;
+  slug: string;
+}
+
+/** One enrolled course, with its bundle-ordered lessons. */
+export interface ContinueCourseInput {
+  courseId: string;
+  title: string;
+  slug: string;
+  /** ISO timestamp of the enrollment row (`enrollments.enrolled_at`). */
+  enrolledAt: string | null;
+  /**
+   * True when the learner already minted this course's credential. Certified
+   * courses are never a continue target, but they still count as "enrolled and
+   * finished" for the all-complete state.
+   */
+  certified?: boolean;
+  /** Module→lesson display order from the content bundle. */
+  lessons: OrderedLessonRef[];
+}
+
+/** A completed `user_progress` row (the caller filters on `completed = true`). */
+export interface ProgressEntry {
+  courseId: string;
+  lessonId: string;
+  completedAt: string | null;
+}
+
+export type ContinueTarget =
+  | {
+      kind: "lesson";
+      courseId: string;
+      courseTitle: string;
+      courseSlug: string;
+      lesson: OrderedLessonRef;
+      completedLessons: number;
+      totalLessons: number;
+    }
+  /** Every enrolled course is fully complete — point at the next course. */
+  | { kind: "allComplete" };
+
+/**
+ * First lesson in bundle order whose `_id` is not in the completed set, or
+ * null when the course is fully complete. This is the single rule shared by
+ * the dashboard Continue card and the course-detail CTA.
+ */
+export function findNextIncompleteLesson<T extends { _id: string }>(
+  lessons: readonly T[],
+  completedLessonIds: ReadonlySet<string>
+): T | null {
+  return lessons.find((l) => !completedLessonIds.has(l._id)) ?? null;
+}
+
+function toEpoch(iso: string | null): number {
+  if (!iso) return 0;
+  const ts = Date.parse(iso);
+  return Number.isNaN(ts) ? 0 : ts;
+}
+
+/**
+ * Derive the learner's continue target:
+ *
+ * 1. Rank enrolled courses by last activity — the max of the course's latest
+ *    completed-lesson timestamp and its enrollment timestamp (so a freshly
+ *    enrolled course with zero progress still ranks by when it was joined).
+ * 2. In that order, pick the first non-certified course that still has an
+ *    incomplete lesson; the target is its first incomplete lesson in
+ *    content-bundle module→lesson order.
+ * 3. No such course but at least one enrollment → `allComplete`.
+ * 4. No enrollments at all → null (callers keep their existing empty state).
+ *
+ * Completed counts are measured against the bundle's lesson list, so stale
+ * progress rows for removed lessons never inflate the numbers.
+ */
+export function deriveContinueTarget(
+  courses: readonly ContinueCourseInput[],
+  progress: readonly ProgressEntry[]
+): ContinueTarget | null {
+  if (courses.length === 0) return null;
+
+  const completedByCourse = new Map<string, Set<string>>();
+  const lastCompletedByCourse = new Map<string, number>();
+  for (const row of progress) {
+    let set = completedByCourse.get(row.courseId);
+    if (!set) {
+      set = new Set();
+      completedByCourse.set(row.courseId, set);
+    }
+    set.add(row.lessonId);
+    const ts = toEpoch(row.completedAt);
+    if (ts > (lastCompletedByCourse.get(row.courseId) ?? 0)) {
+      lastCompletedByCourse.set(row.courseId, ts);
+    }
+  }
+
+  const lastActive = (course: ContinueCourseInput): number =>
+    Math.max(
+      toEpoch(course.enrolledAt),
+      lastCompletedByCourse.get(course.courseId) ?? 0
+    );
+
+  // Stable sort: ties keep input order.
+  const ranked = [...courses].sort((a, b) => lastActive(b) - lastActive(a));
+
+  const emptySet: ReadonlySet<string> = new Set();
+  for (const course of ranked) {
+    if (course.certified || course.lessons.length === 0) continue;
+    const completed = completedByCourse.get(course.courseId) ?? emptySet;
+    const lesson = findNextIncompleteLesson(course.lessons, completed);
+    if (lesson) {
+      return {
+        kind: "lesson",
+        courseId: course.courseId,
+        courseTitle: course.title,
+        courseSlug: course.slug,
+        lesson,
+        completedLessons: course.lessons.filter((l) => completed.has(l._id))
+          .length,
+        totalLessons: course.lessons.length,
+      };
+    }
+  }
+
+  return { kind: "allComplete" };
+}

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -231,8 +231,16 @@
     "dismissAllSuggestions": "Dismiss All"
   },
   "dashboard": {
+    "allCaughtUp": "All caught up!",
+    "allCaughtUpHint": "You've finished every lesson in your enrolled courses.",
     "browseCourses": "Browse Courses",
+    "continueAria": "Continue {course} — next lesson: {lesson}",
+    "continueLearning": "Continue learning",
     "currentCourses": "Current Courses",
+    "lessonsDone": "{completed} of {total} lessons completed",
+    "resumeLesson": "Resume lesson",
+    "startNextCourse": "Start your next course",
+    "startNextCourseAria": "Start your next course: {course}",
     "fetchError": "Could not load your dashboard",
     "fetchErrorDetail": "We had trouble loading your data. Your progress is safe — please try refreshing the page.",
     "noCourses": "You haven't enrolled in any courses yet",

--- a/apps/web/src/messages/es.json
+++ b/apps/web/src/messages/es.json
@@ -231,8 +231,16 @@
     "dismissAllSuggestions": "Descartar Todas"
   },
   "dashboard": {
+    "allCaughtUp": "¡Todo al día!",
+    "allCaughtUpHint": "Has completado todas las lecciones de tus cursos inscritos.",
     "browseCourses": "Explorar Cursos",
+    "continueAria": "Continuar {course} — siguiente lección: {lesson}",
+    "continueLearning": "Continúa aprendiendo",
     "currentCourses": "Cursos Actuales",
+    "lessonsDone": "{completed} de {total} lecciones completadas",
+    "resumeLesson": "Reanudar lección",
+    "startNextCourse": "Comienza tu próximo curso",
+    "startNextCourseAria": "Comenzar tu próximo curso: {course}",
     "fetchError": "No se pudo cargar tu panel",
     "fetchErrorDetail": "Tuvimos problemas al cargar tus datos. Tu progreso está seguro — intenta actualizar la página.",
     "noCourses": "Aún no te has inscrito en ningún curso",

--- a/apps/web/src/messages/pt-BR.json
+++ b/apps/web/src/messages/pt-BR.json
@@ -231,8 +231,16 @@
     "dismissAllSuggestions": "Dispensar Todas"
   },
   "dashboard": {
+    "allCaughtUp": "Tudo em dia!",
+    "allCaughtUpHint": "Você concluiu todas as aulas dos seus cursos matriculados.",
     "browseCourses": "Explorar Cursos",
+    "continueAria": "Continuar {course} — próxima aula: {lesson}",
+    "continueLearning": "Continue aprendendo",
     "currentCourses": "Cursos Atuais",
+    "lessonsDone": "{completed} de {total} aulas concluídas",
+    "resumeLesson": "Retomar aula",
+    "startNextCourse": "Comece seu próximo curso",
+    "startNextCourseAria": "Começar seu próximo curso: {course}",
     "fetchError": "Não foi possível carregar seu painel",
     "fetchErrorDetail": "Tivemos problemas ao carregar seus dados. Seu progresso está seguro — tente atualizar a página.",
     "noCourses": "Você ainda não se matriculou em nenhum curso",


### PR DESCRIPTION
Closes #551

Task **LX-B2** from `docs/superpowers/specs/2026-07-25-launch-experience-master-spec.md` §3 — derive the learner's next-incomplete lesson (NO schema change), surface a Continue card in the dashboard hero, and fix the course-detail CTA that was hardcoded to the first lesson.

## Derivation rule (pure, unit-tested)

`apps/web/src/lib/courses/continue-learning.ts`:

1. Rank enrolled courses by **last activity** = max(latest `user_progress.completed_at`, `enrollments.enrolled_at`).
2. In that order, pick the first non-certified course with an incomplete lesson; target = **first incomplete lesson in content-bundle module→lesson order** (completed `user_progress` rows subtracted).
3. All enrolled courses complete → `allComplete`; no enrollments → `null`.

Minted-credential courses are never a continue candidate but still count as enrolled-and-finished. Completed counts are measured against bundle lessons, so stale rows for removed lessons never inflate them.

## Dashboard hero

- Focusable Continue card (single link, composed `aria-label`, `focus-visible` outline) deep-linking straight to the next incomplete lesson: eyebrow + "Course · Lesson" + `x of y lessons completed`.
- **All complete** → card points at the first recommended course ("Start your next course · X"), or the catalog when nothing is left to recommend.
- **No enrollments** → no card; the existing empty-state catalog CTA is unchanged.
- Solana-gradient border matching the landing hero card language; additive slot only — no other dashboard widgets rearranged (LX-B1/LX-B13 land separately).

## Course detail CTA fix

`course-detail-client.tsx` — the enrolled CTA was `modules[0]?.lessons?.[0]?.slug` regardless of progress. It now uses the shared `findNextIncompleteLesson` over the same module→lesson order; fully-complete courses fall back to lesson 1 for review. Unenrolled behavior unchanged.

## Data plumbing

New gated public route `/api/content/course-lessons?ids=…` (`getCourseLessonOrders`, server + client wrapper) exposing ordered `{_id,title,slug}` lesson summaries per course — same synced+active gate and summary-safe shape as the sibling `/api/content/*` routes; no lesson content crosses the boundary.

## i18n / a11y

8 new `dashboard.*` keys ×3 locales (en / pt-BR / es); locale parity test passes.

## Verification

- `pnpm typecheck` (turbo, 6/6 packages) ✓
- `pnpm test` (apps/web): **106 files, 996 tests passed** ✓ — including new suites: derivation (14 tests), ContinueCard component, course-lessons route, query + client-wrapper coverage
- `next lint` + prettier on all touched files ✓