### PR TITLE
feat(credentials): Earn handoff card at post-mint moment (LX-E4)

### DIFF
--- a/apps/web/src/app/[locale]/(platform)/certificates/[id]/page.tsx
+++ b/apps/web/src/app/[locale]/(platform)/certificates/[id]/page.tsx
@@ -7,6 +7,7 @@ import { Copy, Check } from "@phosphor-icons/react";
 import type { Certificate } from "@superteam-lms/types";
 import { Button } from "@/components/ui/button";
 import { CertificateCard } from "@/components/certificates/certificate-card";
+import { EarnHandoffCard } from "@/components/certificates/earn-handoff-card";
 import { createClient } from "@/lib/supabase/client";
 import { getCoursesByIds } from "@/lib/content/client-queries";
 import { CERTIFICATE_STYLES as CS } from "@/lib/styles/styleClasses";
@@ -197,6 +198,11 @@ export default function CertificateViewPage() {
         <Button variant="outline" size="sm" onClick={handleCopyLink}>
           {t("copyLink")}
         </Button>
+      </div>
+
+      {/* Bridge from credential to paid work on Superteam Earn (LX-E4) */}
+      <div className="mt-6">
+        <EarnHandoffCard source="certificate_page" courseId={cert.courseId} />
       </div>
 
       {/* NFT Details card — copyable values */}

--- a/apps/web/src/components/certificates/__tests__/earn-handoff-card.test.tsx
+++ b/apps/web/src/components/certificates/__tests__/earn-handoff-card.test.tsx
@@ -48,6 +48,28 @@ describe("EarnHandoffCard — curated category links", () => {
     ).toBeInTheDocument();
     expect(screen.getAllByText("(opens in a new tab)")).toHaveLength(3);
   });
+
+  it("keeps heading ids unique when rendered multiple times on one page", () => {
+    // CourseCompletionMint renders once per enrolled course on the dashboard
+    renderWithIntl(
+      <>
+        <EarnHandoffCard source="mint_success" courseId="course-a" />
+        <EarnHandoffCard source="mint_success" courseId="course-b" />
+      </>
+    );
+    const headings = screen.getAllByRole("heading", {
+      name: "Turn your credential into paid work",
+    });
+    expect(headings).toHaveLength(2);
+    const ids = headings.map((h) => h.id);
+    expect(ids[0]).toBeTruthy();
+    expect(new Set(ids).size).toBe(2);
+    // Each region must reference its own heading
+    for (const region of screen.getAllByRole("region")) {
+      const labelledBy = region.getAttribute("aria-labelledby");
+      expect(region.querySelector(`[id="${labelledBy}"]`)).not.toBeNull();
+    }
+  });
 });
 
 describe("EarnHandoffCard — copy guardrails", () => {

--- a/apps/web/src/components/certificates/__tests__/earn-handoff-card.test.tsx
+++ b/apps/web/src/components/certificates/__tests__/earn-handoff-card.test.tsx
@@ -1,0 +1,94 @@
+// @vitest-environment jsdom
+import type { ReactElement } from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import { EarnHandoffCard } from "../earn-handoff-card";
+import messages from "@/messages/en.json";
+
+const { trackEvent } = vi.hoisted(() => ({ trackEvent: vi.fn() }));
+vi.mock("@/lib/analytics", () => ({ trackEvent }));
+
+function renderWithIntl(ui: ReactElement) {
+  return render(
+    <NextIntlClientProvider locale="en" messages={messages}>
+      {ui}
+    </NextIntlClientProvider>
+  );
+}
+
+beforeEach(() => {
+  trackEvent.mockClear();
+});
+
+describe("EarnHandoffCard — curated category links", () => {
+  it("links only to Superteam Earn category/section pages (zero bounty deep links)", () => {
+    renderWithIntl(<EarnHandoffCard source="mint_success" />);
+    const links = screen.getAllByRole("link");
+    expect(links.map((l) => l.getAttribute("href"))).toEqual([
+      "https://superteam.fun/earn/category/development/",
+      "https://superteam.fun/earn/category/content/",
+      "https://superteam.fun/earn/grants/",
+    ]);
+    for (const link of links) {
+      const href = link.getAttribute("href") ?? "";
+      // Accept criterion: bounty listings are ephemeral — never deep-link one
+      expect(href).not.toMatch(/\/listing|\/bounty|\/t\//);
+      expect(link).toHaveAttribute("target", "_blank");
+      expect(link).toHaveAttribute("rel", "noopener noreferrer");
+    }
+  });
+
+  it("is a labelled section with the new-tab hint on every link", () => {
+    renderWithIntl(<EarnHandoffCard source="certificate_page" />);
+    expect(
+      screen.getByRole("region", {
+        name: "Turn your credential into paid work",
+      })
+    ).toBeInTheDocument();
+    expect(screen.getAllByText("(opens in a new tab)")).toHaveLength(3);
+  });
+});
+
+describe("EarnHandoffCard — copy guardrails", () => {
+  it("makes the verified promise, never an employment claim", () => {
+    const { container } = renderWithIntl(
+      <EarnHandoffCard source="mint_success" />
+    );
+    expect(
+      screen.getByText(/first \$500–\$5,000 of paid Solana work/)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Brazil grants average \$5\.5k/)
+    ).toBeInTheDocument();
+    const text = container.textContent ?? "";
+    for (const banned of [/job/i, /career/i, /hire/i, /learn to earn/i]) {
+      expect(text).not.toMatch(banned);
+    }
+  });
+});
+
+describe("EarnHandoffCard — E8 instrumentation", () => {
+  it("fires earn_handoff_click with category, source, and courseId", () => {
+    renderWithIntl(
+      <EarnHandoffCard source="mint_success" courseId="solana-101" />
+    );
+    fireEvent.click(screen.getByRole("link", { name: /Development bounties/ }));
+    expect(trackEvent).toHaveBeenCalledTimes(1);
+    expect(trackEvent).toHaveBeenCalledWith("earn_handoff_click", {
+      category: "development",
+      source: "mint_success",
+      courseId: "solana-101",
+    });
+  });
+
+  it("omits courseId when unknown and records the surface", () => {
+    renderWithIntl(<EarnHandoffCard source="certificate_page" />);
+    fireEvent.click(screen.getByRole("link", { name: /Grants/ }));
+    expect(trackEvent).toHaveBeenCalledTimes(1);
+    expect(trackEvent).toHaveBeenCalledWith("earn_handoff_click", {
+      category: "grants",
+      source: "certificate_page",
+    });
+  });
+});

--- a/apps/web/src/components/certificates/course-completion-mint.tsx
+++ b/apps/web/src/components/certificates/course-completion-mint.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { useTranslations, useLocale } from "next-intl";
 import Link from "next/link";
 import { GraduationCap, CheckCircle, Wallet } from "@phosphor-icons/react";
+import { EarnHandoffCard } from "./earn-handoff-card";
 import { celebrate } from "@/lib/gamification/celebration";
 import { createClient } from "@/lib/supabase/client";
 
@@ -133,11 +134,15 @@ export function CourseCompletionMint({
 
   if (state.status === "already_minted") {
     return (
-      <div className="border-success/30 rounded-xl border bg-card px-5 py-4 shadow-[var(--shadow-card)]">
-        <div className="flex items-center justify-center gap-2 text-sm text-success">
-          <CheckCircle size={20} weight="duotone" aria-hidden="true" />
-          <span className="font-display font-bold">{t("mintSuccess")}</span>
+      <div className="flex flex-col gap-3">
+        <div className="border-success/30 rounded-xl border bg-card px-5 py-4 shadow-[var(--shadow-card)]">
+          <div className="flex items-center justify-center gap-2 text-sm text-success">
+            <CheckCircle size={20} weight="duotone" aria-hidden="true" />
+            <span className="font-display font-bold">{t("mintSuccess")}</span>
+          </div>
         </div>
+        {/* Post-mint bridge to paid work (LX-E4) — the KPI terminus */}
+        <EarnHandoffCard source="mint_success" courseId={courseId} />
       </div>
     );
   }

--- a/apps/web/src/components/certificates/earn-handoff-card.tsx
+++ b/apps/web/src/components/certificates/earn-handoff-card.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { ArrowUpRight, Coins } from "@phosphor-icons/react";
+import { trackEvent } from "@/lib/analytics";
+
+/**
+ * Earn handoff card — the bridge from a freshly minted credential to paid
+ * work on Superteam Earn (LX-E4).
+ *
+ * Curated CATEGORY links only: bounty listings are ephemeral, so this card
+ * must never deep-link a specific bounty. Fires the `earn_handoff_click`
+ * analytics event (metric E8) on every click-through, carrying the category,
+ * the surface it was clicked from, and the course id when known.
+ */
+
+const EARN_CATEGORIES = [
+  {
+    key: "development",
+    href: "https://superteam.fun/earn/category/development/",
+  },
+  { key: "content", href: "https://superteam.fun/earn/category/content/" },
+  { key: "grants", href: "https://superteam.fun/earn/grants/" },
+] as const;
+
+type EarnCategory = (typeof EARN_CATEGORIES)[number]["key"];
+
+interface EarnHandoffCardProps {
+  /** Surface the card is rendered on — recorded on the E8 event. */
+  source: "mint_success" | "certificate_page";
+  courseId?: string;
+}
+
+export function EarnHandoffCard({ source, courseId }: EarnHandoffCardProps) {
+  const t = useTranslations("earnHandoff");
+
+  function handleClick(category: EarnCategory): void {
+    trackEvent("earn_handoff_click", {
+      category,
+      source,
+      ...(courseId ? { courseId } : {}),
+    });
+  }
+
+  return (
+    <section
+      aria-labelledby="earn-handoff-title"
+      className="rounded-xl bg-cert-gradient p-[1.5px] shadow-[var(--shadow-card)]"
+    >
+      <div className="rounded-[11px] bg-card px-5 py-4">
+        <div className="flex items-center gap-2">
+          <Coins
+            size={20}
+            weight="duotone"
+            className="shrink-0 text-secondary"
+            aria-hidden="true"
+          />
+          <h2
+            id="earn-handoff-title"
+            className="font-display text-sm font-bold text-text"
+          >
+            {t("title")}
+          </h2>
+        </div>
+        <p className="mt-2 text-xs leading-relaxed text-text-2">
+          {t("description")}
+        </p>
+        <p className="mt-1.5 text-xs leading-relaxed text-text-3">
+          {t("grantNote")}
+        </p>
+        <ul className="mt-3 flex flex-wrap gap-2" aria-label={t("linksLabel")}>
+          {EARN_CATEGORIES.map(({ key, href }, index) => (
+            <li key={key}>
+              <a
+                href={href}
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={() => handleClick(key)}
+                className={
+                  index === 0
+                    ? "inline-flex items-center gap-1 rounded-md bg-primary px-3.5 py-1.5 font-display text-xs font-bold text-white shadow-push transition-all duration-100 hover:bg-primary-hover focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary active:translate-y-[3px] active:shadow-push-active"
+                    : "inline-flex items-center gap-1 rounded-md border border-border bg-bg px-3.5 py-1.5 font-display text-xs font-bold text-text transition-colors hover:border-primary hover:text-primary focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+                }
+              >
+                {t(key)}
+                <ArrowUpRight size={12} weight="bold" aria-hidden="true" />
+                <span className="sr-only">({t("opensInNewTab")})</span>
+              </a>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/certificates/earn-handoff-card.tsx
+++ b/apps/web/src/components/certificates/earn-handoff-card.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useId } from "react";
 import { useTranslations } from "next-intl";
 import { ArrowUpRight, Coins } from "@phosphor-icons/react";
 import { trackEvent } from "@/lib/analytics";
@@ -33,6 +34,9 @@ interface EarnHandoffCardProps {
 
 export function EarnHandoffCard({ source, courseId }: EarnHandoffCardProps) {
   const t = useTranslations("earnHandoff");
+  // Unique per instance — the card can render multiple times on one page
+  // (e.g. CourseCompletionMint is mapped per enrolled course on the dashboard)
+  const titleId = useId();
 
   function handleClick(category: EarnCategory): void {
     trackEvent("earn_handoff_click", {
@@ -44,7 +48,7 @@ export function EarnHandoffCard({ source, courseId }: EarnHandoffCardProps) {
 
   return (
     <section
-      aria-labelledby="earn-handoff-title"
+      aria-labelledby={titleId}
       className="rounded-xl bg-cert-gradient p-[1.5px] shadow-[var(--shadow-card)]"
     >
       <div className="rounded-[11px] bg-card px-5 py-4">
@@ -55,10 +59,7 @@ export function EarnHandoffCard({ source, courseId }: EarnHandoffCardProps) {
             className="shrink-0 text-secondary"
             aria-hidden="true"
           />
-          <h2
-            id="earn-handoff-title"
-            className="font-display text-sm font-bold text-text"
-          >
+          <h2 id={titleId} className="font-display text-sm font-bold text-text">
             {t("title")}
           </h2>
         </div>

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -349,6 +349,16 @@
     "insertFailed": "Failed to record certificate. Please try again.",
     "onChain": "On-chain"
   },
+  "earnHandoff": {
+    "title": "Turn your credential into paid work",
+    "description": "Superteam Earn is where Solana teams post paid bounties and projects — over $15M paid out to builders so far. Land your first $500–$5,000 of paid Solana work.",
+    "grantNote": "Building your own project? Brazil grants average $5.5k.",
+    "linksLabel": "Browse Superteam Earn",
+    "development": "Development bounties",
+    "content": "Content bounties",
+    "grants": "Grants",
+    "opensInNewTab": "opens in a new tab"
+  },
   "profile": {
     "editProfile": "Edit Profile",
     "skills": "Skills",

--- a/apps/web/src/messages/es.json
+++ b/apps/web/src/messages/es.json
@@ -349,6 +349,16 @@
     "insertFailed": "Error al registrar el certificado. Por favor, inténtelo de nuevo.",
     "onChain": "On-chain"
   },
+  "earnHandoff": {
+    "title": "Convierte tu credencial en trabajo pagado",
+    "description": "Superteam Earn es donde los equipos de Solana publican bounties y proyectos pagados — más de US$ 15 millones pagados a builders hasta hoy. Consigue tus primeros US$ 500–5.000 de trabajo pagado en Solana.",
+    "grantNote": "¿Construyes tu propio proyecto? Los grants de Brasil promedian US$ 5,5 mil.",
+    "linksLabel": "Explorar Superteam Earn",
+    "development": "Bounties de desarrollo",
+    "content": "Bounties de contenido",
+    "grants": "Grants",
+    "opensInNewTab": "se abre en una pestaña nueva"
+  },
   "profile": {
     "editProfile": "Editar Perfil",
     "skills": "Habilidades",

--- a/apps/web/src/messages/pt-BR.json
+++ b/apps/web/src/messages/pt-BR.json
@@ -349,6 +349,16 @@
     "insertFailed": "Falha ao registrar o certificado. Por favor, tente novamente.",
     "onChain": "On-chain"
   },
+  "earnHandoff": {
+    "title": "Transforme sua credencial em trabalho pago",
+    "description": "O Superteam Earn é onde as equipes da Solana publicam bounties e projetos pagos — mais de US$ 15 milhões já pagos a builders. Conquiste seus primeiros US$ 500–5.000 em trabalho pago na Solana.",
+    "grantNote": "Construindo um projeto próprio? Os grants do Brasil pagam em média US$ 5,5 mil.",
+    "linksLabel": "Explorar o Superteam Earn",
+    "development": "Bounties de desenvolvimento",
+    "content": "Bounties de conteúdo",
+    "grants": "Grants",
+    "opensInNewTab": "abre em uma nova aba"
+  },
   "profile": {
     "editProfile": "Editar Perfil",
     "skills": "Habilidades",


### PR DESCRIPTION
Closes #553

## What

The bridge across the post-credential cliff (PED-16): a Superteam Earn handoff card at both post-mint surfaces — the KPI terminus of the launch experience.

- **`course-completion-mint.tsx` success state** — card renders directly under the mint-success confirmation (`already_minted` state, so it also persists on revisit). Celebration logic from #549 untouched.
- **Certificate page** (`/certificates/[id]`) — card between the action buttons and the NFT details.

## Curated category links (zero bounty deep links)

Bounty listings are ephemeral, so the card links only to persistent Earn category/section pages (all verified live):

| Label | URL |
|---|---|
| Development bounties (primary CTA) | `https://superteam.fun/earn/category/development/` |
| Content bounties | `https://superteam.fun/earn/category/content/` |
| Grants | `https://superteam.fun/earn/grants/` |

## Copy (verified figures only, no employment framing)

- "Superteam Earn is where Solana teams post paid bounties and projects — over $15M paid out to builders so far. Land your first **$500–$5,000 of paid Solana work**." ($15.1M / avg $4,971 verified live 2026-07-25)
- Grant framing: "Brazil grants average **$5.5k**." (verified $5,519, rounded per spec)
- No "get a job", no "learn to earn", no unverified Brazil earnings totals — enforced by a test.

## E8 instrumentation

`earn_handoff_click` (name per LX-F1) via the existing `trackEvent` facade (GA4 + PostHog), fired on click-through:

```ts
trackEvent("earn_handoff_click", {
  category: "development" | "content" | "grants",
  source: "mint_success" | "certificate_page",
  courseId?: string,
});
```

## i18n + a11y

- Full `earnHandoff` namespace in en / pt-BR / es (locale parity test passes).
- Labelled `region` (`aria-labelledby`), labelled link list, focus-visible outlines, `rel="noopener noreferrer"`, sr-only "(opens in a new tab)" hints, icons `aria-hidden`.

## Tests

New `earn-handoff-card.test.tsx`: link curation (exact hrefs, no `/listing|/bounty` patterns), copy guardrails (promise present, employment words banned), E8 event shape with/without `courseId`.

## Verification

- `pnpm typecheck` — clean
- `vitest run` — **110 files / 1024 tests passed**
- `next lint` — exit 0, no warnings on changed files
- Prettier — clean