### PR TITLE
feat(credentials): LinkedIn Add-to-Profile + post-mint X share nudge (LX-E3)

### DIFF
--- a/apps/web/src/app/[locale]/(platform)/certificates/[id]/page.tsx
+++ b/apps/web/src/app/[locale]/(platform)/certificates/[id]/page.tsx
@@ -10,6 +10,12 @@ import { CertificateCard } from "@/components/certificates/certificate-card";
 import { EarnHandoffCard } from "@/components/certificates/earn-handoff-card";
 import { createClient } from "@/lib/supabase/client";
 import { getCoursesByIds } from "@/lib/content/client-queries";
+import {
+  CREDENTIAL_ISSUER_NAME,
+  buildLinkedInAddToProfileUrl,
+  buildXShareIntentUrl,
+  trackCredentialShareClick,
+} from "@/lib/credentials/share";
 import { CERTIFICATE_STYLES as CS } from "@/lib/styles/styleClasses";
 import { truncateAddress } from "@/lib/utils";
 
@@ -152,18 +158,27 @@ export default function CertificateViewPage() {
     ? `https://explorer.solana.com/address/${mintAddress}?cluster=${network}`
     : "";
 
-  function handleShareX() {
-    const pageUrl = window.location.href;
-    const text = encodeURIComponent(
-      `I just earned my "${cert.courseTitle}" certificate on @SuperteamBR Academy! 🎓\n\nVerify on-chain:`
-    );
-    const url = encodeURIComponent(pageUrl);
-    window.open(
-      `https://x.com/intent/tweet?text=${text}&url=${url}`,
-      "_blank",
-      "noopener,noreferrer"
-    );
-  }
+  // This page only renders content client-side (data arrives via useEffect),
+  // so window is available whenever `data` is set.
+  const pageUrl = typeof window !== "undefined" ? window.location.href : "";
+  const xShareUrl = pageUrl
+    ? buildXShareIntentUrl(
+        t("shareXText", { courseTitle: cert.courseTitle }),
+        pageUrl
+      )
+    : "";
+  // Profile-entry deep link (LX-E3) — NOT a social share; the share channel
+  // is X. All fields come from data already on this page.
+  const linkedInAddUrl = pageUrl
+    ? buildLinkedInAddToProfileUrl({
+        name: cert.courseTitle,
+        organizationName: CREDENTIAL_ISSUER_NAME,
+        issueYear: cert.mintedAt.getFullYear(),
+        issueMonth: cert.mintedAt.getMonth() + 1,
+        certUrl: pageUrl,
+        certId: mintAddress || undefined,
+      })
+    : "";
 
   async function handleCopyLink() {
     await navigator.clipboard.writeText(window.location.href);
@@ -192,9 +207,44 @@ export default function CertificateViewPage() {
             </a>
           </Button>
         )}
-        <Button variant="outline" size="sm" onClick={handleShareX}>
-          {t("share")}
-        </Button>
+        {linkedInAddUrl && (
+          <Button variant="outline" size="sm" asChild>
+            <a
+              href={linkedInAddUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={() =>
+                trackCredentialShareClick(
+                  "linkedin_add",
+                  "certificate_page",
+                  cert.courseId
+                )
+              }
+            >
+              {t("addToLinkedIn")}
+              <span className="sr-only">({t("opensInNewTab")})</span>
+            </a>
+          </Button>
+        )}
+        {xShareUrl && (
+          <Button variant="outline" size="sm" asChild>
+            <a
+              href={xShareUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={() =>
+                trackCredentialShareClick(
+                  "x",
+                  "certificate_page",
+                  cert.courseId
+                )
+              }
+            >
+              {t("share")}
+              <span className="sr-only">({t("opensInNewTab")})</span>
+            </a>
+          </Button>
+        )}
         <Button variant="outline" size="sm" onClick={handleCopyLink}>
           {t("copyLink")}
         </Button>

--- a/apps/web/src/components/certificates/__tests__/credential-share-nudge.test.tsx
+++ b/apps/web/src/components/certificates/__tests__/credential-share-nudge.test.tsx
@@ -1,0 +1,133 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import { CredentialShareNudge } from "../credential-share-nudge";
+import messages from "@/messages/en.json";
+
+const { trackEvent } = vi.hoisted(() => ({ trackEvent: vi.fn() }));
+vi.mock("@/lib/analytics", () => ({ trackEvent }));
+
+const MINT_ADDRESS = "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU";
+
+function renderNudge(overrides: { mintAddress?: string | null } = {}) {
+  const mintAddress =
+    "mintAddress" in overrides ? (overrides.mintAddress ?? null) : MINT_ADDRESS;
+  return render(
+    <NextIntlClientProvider locale="en" messages={messages}>
+      <CredentialShareNudge
+        source="mint_success"
+        courseId="solana-101"
+        courseTitle="Solana Fundamentals"
+        certificateId="cert-1"
+        mintAddress={mintAddress}
+        mintedAt={new Date(2026, 6, 25)}
+      />
+    </NextIntlClientProvider>
+  );
+}
+
+function getLink(name: RegExp): HTMLAnchorElement {
+  return screen.getByRole("link", { name }) as HTMLAnchorElement;
+}
+
+beforeEach(() => {
+  trackEvent.mockClear();
+});
+
+describe("CredentialShareNudge — LinkedIn Add-to-Profile deep link", () => {
+  it("prefills every documented field from data already on the page", () => {
+    renderNudge();
+    const url = new URL(getLink(/Add to your LinkedIn profile/).href);
+    expect(url.origin).toBe("https://www.linkedin.com");
+    expect(url.pathname).toBe("/profile/add");
+    expect(url.searchParams.get("startTask")).toBe("CERTIFICATION_NAME");
+    expect(url.searchParams.get("name")).toBe("Solana Fundamentals");
+    expect(url.searchParams.get("organizationName")).toBe("Superteam Academy");
+    expect(url.searchParams.get("issueYear")).toBe("2026");
+    expect(url.searchParams.get("issueMonth")).toBe("7");
+    expect(url.searchParams.get("certUrl")).toBe(
+      `${window.location.origin}/en/certificates/cert-1`
+    );
+    expect(url.searchParams.get("certId")).toBe(MINT_ADDRESS);
+  });
+
+  it("omits certId while the webhook mint is still settling", () => {
+    renderNudge({ mintAddress: null });
+    const url = new URL(getLink(/Add to your LinkedIn profile/).href);
+    expect(url.searchParams.has("certId")).toBe(false);
+  });
+});
+
+describe("CredentialShareNudge — X share (owner decision: X is the ONLY share channel)", () => {
+  it("shares via the X web intent pointing at the public certificate URL", () => {
+    renderNudge();
+    const url = new URL(getLink(/Share on X/).href);
+    expect(url.origin).toBe("https://x.com");
+    expect(url.pathname).toBe("/intent/tweet");
+    expect(url.searchParams.get("url")).toBe(
+      `${window.location.origin}/en/certificates/cert-1`
+    );
+    expect(url.searchParams.get("text")).toContain("Solana Fundamentals");
+  });
+
+  it("never renders a LinkedIn share-post URL", () => {
+    renderNudge();
+    for (const link of screen.getAllByRole("link")) {
+      const href = link.getAttribute("href") ?? "";
+      expect(href).not.toMatch(/linkedin\.com\/(shareArticle|sharing|share)/);
+    }
+  });
+});
+
+describe("CredentialShareNudge — a11y", () => {
+  it("is a labelled section whose links open in a new tab with sr-only hints", () => {
+    renderNudge();
+    expect(
+      screen.getByRole("region", { name: "Show off your credential" })
+    ).toBeInTheDocument();
+    const links = screen.getAllByRole("link");
+    expect(links).toHaveLength(2);
+    for (const link of links) {
+      expect(link).toHaveAttribute("target", "_blank");
+      expect(link).toHaveAttribute("rel", "noopener noreferrer");
+    }
+    expect(screen.getAllByText("(opens in a new tab)")).toHaveLength(2);
+  });
+});
+
+describe("CredentialShareNudge — copy guardrails (UIU-02 boundary)", () => {
+  it("uses action language only — no evidence overclaims or employment promises", () => {
+    const { container } = renderNudge();
+    const text = container.textContent ?? "";
+    for (const banned of [
+      /peer[- ]?reviewed/i,
+      /resume/i,
+      /employment/i,
+      /\bjob\b/i,
+      /career/i,
+      /hire/i,
+    ]) {
+      expect(text).not.toMatch(banned);
+    }
+  });
+});
+
+describe("CredentialShareNudge — instrumentation", () => {
+  it("fires credential_share_click with the channel, surface, and course", () => {
+    renderNudge();
+    fireEvent.click(getLink(/Add to your LinkedIn profile/));
+    expect(trackEvent).toHaveBeenCalledWith("credential_share_click", {
+      channel: "linkedin_add",
+      source: "mint_success",
+      courseId: "solana-101",
+    });
+    fireEvent.click(getLink(/Share on X/));
+    expect(trackEvent).toHaveBeenCalledWith("credential_share_click", {
+      channel: "x",
+      source: "mint_success",
+      courseId: "solana-101",
+    });
+    expect(trackEvent).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/web/src/components/certificates/course-completion-mint.tsx
+++ b/apps/web/src/components/certificates/course-completion-mint.tsx
@@ -5,6 +5,7 @@ import { useTranslations, useLocale } from "next-intl";
 import Link from "next/link";
 import { GraduationCap, CheckCircle, Wallet } from "@phosphor-icons/react";
 import { EarnHandoffCard } from "./earn-handoff-card";
+import { CredentialShareNudge } from "./credential-share-nudge";
 import { celebrate } from "@/lib/gamification/celebration";
 import { createClient } from "@/lib/supabase/client";
 
@@ -14,6 +15,14 @@ interface CourseCompletionMintProps {
   totalLessons: number;
 }
 
+/** Fields the post-mint share nudge needs from the certificates row. */
+interface MintedCertificate {
+  id: string;
+  mintAddress: string | null;
+  mintedAt: string | null;
+  courseTitle: string | null;
+}
+
 type CompletionState =
   | { status: "loading" }
   | { status: "incomplete"; completedCount: number }
@@ -21,7 +30,27 @@ type CompletionState =
   | { status: "no_wallet" }
   | { status: "minting" }
   | { status: "mint_error"; message: string }
-  | { status: "already_minted" };
+  | { status: "already_minted"; cert: MintedCertificate | null };
+
+async function fetchMintedCertificate(
+  supabase: ReturnType<typeof createClient>,
+  userId: string,
+  courseId: string
+): Promise<MintedCertificate | null> {
+  const { data } = await supabase
+    .from("certificates")
+    .select("id, mint_address, minted_at, course_title")
+    .eq("user_id", userId)
+    .eq("course_id", courseId)
+    .maybeSingle();
+  if (!data) return null;
+  return {
+    id: data.id,
+    mintAddress: data.mint_address,
+    mintedAt: data.minted_at,
+    courseTitle: data.course_title,
+  };
+}
 
 /**
  * Displays course completion status and credential mint state.
@@ -43,15 +72,14 @@ export function CourseCompletionMint({
     async function checkCompletion() {
       const supabase = createClient();
 
-      const { data: existingCert } = await supabase
-        .from("certificates")
-        .select("id")
-        .eq("user_id", userId)
-        .eq("course_id", courseId)
-        .maybeSingle();
+      const existingCert = await fetchMintedCertificate(
+        supabase,
+        userId,
+        courseId
+      );
 
       if (existingCert) {
-        setState({ status: "already_minted" });
+        setState({ status: "already_minted", cert: existingCert });
         return;
       }
 
@@ -96,7 +124,14 @@ export function CourseCompletionMint({
       if (!res.ok) {
         const data = (await res.json()) as { error?: string; reason?: string };
         if (res.status === 409) {
-          setState({ status: "already_minted" });
+          setState({
+            status: "already_minted",
+            cert: await fetchMintedCertificate(
+              createClient(),
+              userId,
+              courseId
+            ),
+          });
           return;
         }
         const base = data.error ?? "Minting failed";
@@ -106,10 +141,13 @@ export function CourseCompletionMint({
         });
         return;
       }
-      setState({ status: "already_minted" });
       // Full celebration on a fresh mint (LX-B11) — celebrate() dedupes
       // against the Realtime certificate-INSERT popup firing the same moment.
       celebrate("credential-mint");
+      setState({
+        status: "already_minted",
+        cert: await fetchMintedCertificate(createClient(), userId, courseId),
+      });
     } catch (e) {
       setState({
         status: "mint_error",
@@ -133,6 +171,7 @@ export function CourseCompletionMint({
   }
 
   if (state.status === "already_minted") {
+    const cert = state.cert;
     return (
       <div className="flex flex-col gap-3">
         <div className="border-success/30 rounded-xl border bg-card px-5 py-4 shadow-[var(--shadow-card)]">
@@ -143,6 +182,17 @@ export function CourseCompletionMint({
         </div>
         {/* Post-mint bridge to paid work (LX-E4) — the KPI terminus */}
         <EarnHandoffCard source="mint_success" courseId={courseId} />
+        {/* Secondary share nudge (LX-E3) — Earn card stays most prominent */}
+        {cert?.courseTitle && (
+          <CredentialShareNudge
+            source="mint_success"
+            courseId={courseId}
+            courseTitle={cert.courseTitle}
+            certificateId={cert.id}
+            mintAddress={cert.mintAddress}
+            mintedAt={new Date(cert.mintedAt ?? Date.now())}
+          />
+        )}
       </div>
     );
   }

--- a/apps/web/src/components/certificates/credential-share-nudge.tsx
+++ b/apps/web/src/components/certificates/credential-share-nudge.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { useId } from "react";
+import { useLocale, useTranslations } from "next-intl";
+import { LinkedinLogo, XLogo } from "@phosphor-icons/react";
+import {
+  CREDENTIAL_ISSUER_NAME,
+  buildLinkedInAddToProfileUrl,
+  buildXShareIntentUrl,
+  trackCredentialShareClick,
+} from "@/lib/credentials/share";
+import type { CredentialShareSource } from "@/lib/credentials/share";
+
+/**
+ * Post-mint share nudge (LX-E3). Secondary to the EarnHandoffCard — the
+ * Earn bridge stays the most prominent post-mint element (PED-16).
+ *
+ * Owner decision on #552: LinkedIn is Add-to-Profile ONLY (profile entry,
+ * the evidence-backed action); the social-share channel is X.
+ */
+
+interface CredentialShareNudgeProps {
+  source: CredentialShareSource;
+  courseId: string;
+  courseTitle: string;
+  /** certificates.id — keys the public /certificates/[id] URL. */
+  certificateId: string;
+  /** Credential NFT mint address; null while the webhook mint is settling. */
+  mintAddress: string | null;
+  mintedAt: Date;
+}
+
+const linkClass =
+  "inline-flex items-center gap-1.5 rounded-md border border-border bg-bg px-3.5 py-1.5 font-display text-xs font-bold text-text transition-colors hover:border-primary hover:text-primary focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary";
+
+export function CredentialShareNudge({
+  source,
+  courseId,
+  courseTitle,
+  certificateId,
+  mintAddress,
+  mintedAt,
+}: CredentialShareNudgeProps) {
+  const t = useTranslations("certificates");
+  const locale = useLocale();
+  // Unique per instance — the nudge can render once per course on the dashboard
+  const titleId = useId();
+
+  const origin =
+    typeof window !== "undefined"
+      ? window.location.origin
+      : (process.env.NEXT_PUBLIC_APP_URL ?? "");
+  const certUrl = `${origin}/${locale}/certificates/${certificateId}`;
+
+  const linkedInUrl = buildLinkedInAddToProfileUrl({
+    name: courseTitle,
+    organizationName: CREDENTIAL_ISSUER_NAME,
+    issueYear: mintedAt.getFullYear(),
+    issueMonth: mintedAt.getMonth() + 1,
+    certUrl,
+    certId: mintAddress ?? undefined,
+  });
+  const xShareUrl = buildXShareIntentUrl(
+    t("shareXText", { courseTitle }),
+    certUrl
+  );
+
+  return (
+    <section
+      aria-labelledby={titleId}
+      className="rounded-xl border border-border bg-card px-5 py-4 shadow-[var(--shadow-card)]"
+    >
+      <h2 id={titleId} className="font-display text-xs font-bold text-text">
+        {t("shareNudgeTitle")}
+      </h2>
+      <ul className="mt-2.5 flex flex-wrap gap-2">
+        <li>
+          <a
+            href={linkedInUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={() =>
+              trackCredentialShareClick("linkedin_add", source, courseId)
+            }
+            className={linkClass}
+          >
+            <LinkedinLogo size={14} weight="bold" aria-hidden="true" />
+            {t("addToLinkedIn")}
+            <span className="sr-only">({t("opensInNewTab")})</span>
+          </a>
+        </li>
+        <li>
+          <a
+            href={xShareUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={() => trackCredentialShareClick("x", source, courseId)}
+            className={linkClass}
+          >
+            <XLogo size={14} weight="bold" aria-hidden="true" />
+            {t("share")}
+            <span className="sr-only">({t("opensInNewTab")})</span>
+          </a>
+        </li>
+      </ul>
+    </section>
+  );
+}

--- a/apps/web/src/lib/credentials/__tests__/share.test.ts
+++ b/apps/web/src/lib/credentials/__tests__/share.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  CREDENTIAL_ISSUER_NAME,
+  buildLinkedInAddToProfileUrl,
+  buildXShareIntentUrl,
+  trackCredentialShareClick,
+} from "../share";
+
+const { trackEvent } = vi.hoisted(() => ({ trackEvent: vi.fn() }));
+vi.mock("@/lib/analytics", () => ({ trackEvent }));
+
+beforeEach(() => {
+  trackEvent.mockClear();
+});
+
+describe("buildLinkedInAddToProfileUrl", () => {
+  it("builds the documented Add-to-Profile deep link with every field prefilled", () => {
+    const href = buildLinkedInAddToProfileUrl({
+      name: "Solana Fundamentals",
+      organizationName: CREDENTIAL_ISSUER_NAME,
+      issueYear: 2026,
+      issueMonth: 7,
+      certUrl: "https://academy.example.com/en/certificates/cert-1",
+      certId: "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
+    });
+    const url = new URL(href);
+    expect(url.origin).toBe("https://www.linkedin.com");
+    expect(url.pathname).toBe("/profile/add");
+    expect(url.searchParams.get("startTask")).toBe("CERTIFICATION_NAME");
+    expect(url.searchParams.get("name")).toBe("Solana Fundamentals");
+    expect(url.searchParams.get("organizationName")).toBe("Superteam Academy");
+    expect(url.searchParams.get("issueYear")).toBe("2026");
+    expect(url.searchParams.get("issueMonth")).toBe("7");
+    expect(url.searchParams.get("certUrl")).toBe(
+      "https://academy.example.com/en/certificates/cert-1"
+    );
+    expect(url.searchParams.get("certId")).toBe(
+      "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU"
+    );
+    // organizationId and organizationName are mutually exclusive — we never
+    // send an organizationId, and credentials never expire.
+    expect(url.searchParams.has("organizationId")).toBe(false);
+    expect(url.searchParams.has("expirationYear")).toBe(false);
+    expect(url.searchParams.has("expirationMonth")).toBe(false);
+  });
+
+  it("omits certId while the mint address is not yet known", () => {
+    const href = buildLinkedInAddToProfileUrl({
+      name: "Solana Fundamentals",
+      organizationName: CREDENTIAL_ISSUER_NAME,
+      issueYear: 2026,
+      issueMonth: 1,
+      certUrl: "https://academy.example.com/en/certificates/cert-1",
+    });
+    expect(new URL(href).searchParams.has("certId")).toBe(false);
+  });
+});
+
+describe("buildXShareIntentUrl", () => {
+  it("builds the X web intent with text and url params", () => {
+    const href = buildXShareIntentUrl(
+      "I earned a certificate",
+      "https://academy.example.com/en/certificates/cert-1"
+    );
+    const url = new URL(href);
+    expect(url.origin).toBe("https://x.com");
+    expect(url.pathname).toBe("/intent/tweet");
+    expect(url.searchParams.get("text")).toBe("I earned a certificate");
+    expect(url.searchParams.get("url")).toBe(
+      "https://academy.example.com/en/certificates/cert-1"
+    );
+  });
+});
+
+describe("trackCredentialShareClick", () => {
+  it("fires credential_share_click with channel, source, and courseId", () => {
+    trackCredentialShareClick("linkedin_add", "certificate_page", "solana-101");
+    expect(trackEvent).toHaveBeenCalledWith("credential_share_click", {
+      channel: "linkedin_add",
+      source: "certificate_page",
+      courseId: "solana-101",
+    });
+  });
+
+  it("omits courseId when unknown", () => {
+    trackCredentialShareClick("x", "mint_success");
+    expect(trackEvent).toHaveBeenCalledWith("credential_share_click", {
+      channel: "x",
+      source: "mint_success",
+    });
+  });
+});

--- a/apps/web/src/lib/credentials/share.ts
+++ b/apps/web/src/lib/credentials/share.ts
@@ -1,0 +1,89 @@
+import { trackEvent } from "@/lib/analytics";
+
+/**
+ * Credential share helpers (LX-E3).
+ *
+ * Two distinct actions, per owner decision on #552:
+ * - LinkedIn is a PROFILE-ENTRY action only (Add-to-Profile deep link).
+ *   There is deliberately no LinkedIn share-post URL anywhere.
+ * - The social-share channel is X (existing intent URL, now localized).
+ */
+
+/**
+ * Issuer shown on the LinkedIn profile entry. Mirrors the `Platform`
+ * attribute stamped into the credential NFT metadata
+ * (app/api/certificates/mint/route.ts).
+ */
+export const CREDENTIAL_ISSUER_NAME = "Superteam Academy";
+
+export type CredentialShareChannel = "x" | "linkedin_add";
+export type CredentialShareSource = "certificate_page" | "mint_success";
+
+export interface LinkedInAddToProfileParams {
+  /** Certification name — the course title. */
+  name: string;
+  /**
+   * Free-text issuer name. LinkedIn's format accepts organizationId XOR
+   * organizationName; we use organizationName because the platform has no
+   * claimed LinkedIn Page id.
+   */
+  organizationName: string;
+  /** Issue year from minted_at. */
+  issueYear: number;
+  /** Issue month from minted_at, 1–12. */
+  issueMonth: number;
+  /** Public verification URL — the /certificates/[id] page. */
+  certUrl: string;
+  /** Credential id — the on-chain mint address (omitted while minting). */
+  certId?: string;
+}
+
+/**
+ * Builds the LinkedIn Add-to-Profile deep link for a certification.
+ *
+ * Format documented by LinkedIn's Add to Profile program
+ * (addtoprofile.linkedin.com / help article a528030):
+ *   /profile/add?startTask=CERTIFICATION_NAME&name=…&organizationName=…
+ *     &issueYear=…&issueMonth=…&certUrl=…&certId=…
+ * Expiration params are omitted — credentials do not expire.
+ */
+export function buildLinkedInAddToProfileUrl(
+  params: LinkedInAddToProfileParams
+): string {
+  const url = new URL("https://www.linkedin.com/profile/add");
+  url.searchParams.set("startTask", "CERTIFICATION_NAME");
+  url.searchParams.set("name", params.name);
+  url.searchParams.set("organizationName", params.organizationName);
+  url.searchParams.set("issueYear", String(params.issueYear));
+  url.searchParams.set("issueMonth", String(params.issueMonth));
+  url.searchParams.set("certUrl", params.certUrl);
+  if (params.certId) {
+    url.searchParams.set("certId", params.certId);
+  }
+  return url.toString();
+}
+
+/** Builds the X (Twitter) web-intent URL for sharing a certificate page. */
+export function buildXShareIntentUrl(text: string, shareUrl: string): string {
+  const url = new URL("https://x.com/intent/tweet");
+  url.searchParams.set("text", text);
+  url.searchParams.set("url", shareUrl);
+  return url.toString();
+}
+
+/**
+ * Fires the `credential_share_click` analytics event. Follows the
+ * `earn_handoff_click` (E8) convention: channel + surface + course id
+ * when known.
+ */
+export function trackCredentialShareClick(
+  channel: CredentialShareChannel,
+  source: CredentialShareSource,
+  courseId?: string
+): void {
+  trackEvent("credential_share_click", {
+    channel,
+    source,
+    ...(courseId ? { courseId } : {}),
+  });
+}

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -348,7 +348,11 @@
     "pageSubtitle": "Your earned NFT certificates on Solana",
     "linkWalletToMint": "Link a wallet in Settings to mint your certificate.",
     "insertFailed": "Failed to record certificate. Please try again.",
-    "onChain": "On-chain"
+    "onChain": "On-chain",
+    "shareXText": "I just earned my \"{courseTitle}\" certificate on @SuperteamBR Academy! 🎓\n\nVerify on-chain:",
+    "addToLinkedIn": "Add to your LinkedIn profile",
+    "shareNudgeTitle": "Show off your credential",
+    "opensInNewTab": "opens in a new tab"
   },
   "earnHandoff": {
     "title": "Turn your credential into paid work",

--- a/apps/web/src/messages/es.json
+++ b/apps/web/src/messages/es.json
@@ -348,7 +348,11 @@
     "pageSubtitle": "Tus certificados NFT ganados en Solana",
     "linkWalletToMint": "Vincula una billetera en Configuración para acuñar tu certificado.",
     "insertFailed": "Error al registrar el certificado. Por favor, inténtelo de nuevo.",
-    "onChain": "On-chain"
+    "onChain": "On-chain",
+    "shareXText": "¡Acabo de obtener mi certificado de \"{courseTitle}\" en @SuperteamBR Academy! 🎓\n\nVerifícalo on-chain:",
+    "addToLinkedIn": "Añadir a tu perfil de LinkedIn",
+    "shareNudgeTitle": "Muestra tu credencial",
+    "opensInNewTab": "se abre en una pestaña nueva"
   },
   "earnHandoff": {
     "title": "Convierte tu credencial en trabajo pagado",

--- a/apps/web/src/messages/pt-BR.json
+++ b/apps/web/src/messages/pt-BR.json
@@ -348,7 +348,11 @@
     "pageSubtitle": "Seus certificados NFT conquistados na Solana",
     "linkWalletToMint": "Vincule uma carteira em Configurações para cunhar seu certificado.",
     "insertFailed": "Falha ao registrar o certificado. Por favor, tente novamente.",
-    "onChain": "On-chain"
+    "onChain": "On-chain",
+    "shareXText": "Acabei de conquistar meu certificado de \"{courseTitle}\" na @SuperteamBR Academy! 🎓\n\nVerifique on-chain:",
+    "addToLinkedIn": "Adicionar ao seu perfil do LinkedIn",
+    "shareNudgeTitle": "Mostre sua credencial",
+    "opensInNewTab": "abre em uma nova aba"
   },
   "earnHandoff": {
     "title": "Transforme sua credencial em trabalho pago",


### PR DESCRIPTION
Closes #552

Task **LX-E3** (master spec §3, UIU-02): make the freshly minted credential portable — a LinkedIn **profile-entry** deep link plus a share **nudge** at the post-mint moment.

## What

### 1. LinkedIn Add-to-Profile deep link (profile entry — NOT a social share)
Built from data already on `/certificates/[id]`, per LinkedIn's documented Add-to-Profile URL format (`addtoprofile.linkedin.com` / help article a528030):

```
https://www.linkedin.com/profile/add?startTask=CERTIFICATION_NAME
  &name=<course title>
  &organizationName=Superteam Academy      ← issuer; organizationId XOR organizationName, we have no claimed LinkedIn Page id
  &issueYear=<minted_at year>&issueMonth=<minted_at month 1-12>
  &certUrl=<public /certificates/[id] URL>
  &certId=<credential NFT mint address>    ← omitted while the webhook mint is settling
```

Expiration params omitted — credentials do not expire. `CREDENTIAL_ISSUER_NAME` mirrors the `Platform` attribute stamped into the NFT metadata by the mint route.

**Owner decision honored:** the social-share channel is **X only**. There is no LinkedIn share-post URL anywhere (guarded by a test).

### 2. Share nudge at the post-mint moment
- `course-completion-mint.tsx` `already_minted` state now renders `CredentialShareNudge` **after** the `EarnHandoffCard` — the Earn bridge stays the most prominent element (PED-16). The certificates query was widened to `id, mint_address, minted_at, course_title` (same table, no new plumbing) so the nudge can build both links.
- `/certificates/[id]`: Add-to-Profile button beside the existing actions; the existing X share was converted from a `window.open` button to a real anchor, its previously hardcoded-English tweet text externalized to next-intl. The #625 Earn handoff card is untouched.

### 3. Analytics
`credential_share_click` — `{ channel: "x" | "linkedin_add", source: "certificate_page" | "mint_success", courseId }`, same shape/convention as `earn_handoff_click` (E8).

### Copy discipline (UIU-02 boundary)
Action language only ("Add to your LinkedIn profile", "Share on X"). No "peer-reviewed" claims, no resume-score claims, no employment promises — enforced by a copy-guardrail test.

### i18n & a11y
×3 locales (en / pt-BR / es, keyset parity verified). Labelled `section` with unique `useId` heading, real anchors (middle-click works), `focus-visible` rings, `rel="noopener noreferrer"`, sr-only "(opens in a new tab)" hints.

## Verification

- `pnpm typecheck` — clean
- `pnpm test` (apps/web) — **112 files / 1037 tests passed** (13 new: LinkedIn URL builder, X intent builder, event shape, certId-omission, a11y, copy guardrails, no-LinkedIn-share-URL guard)
- `pnpm lint` — exit 0 (only pre-existing import/order warnings in untouched files)

## Files

- `apps/web/src/lib/credentials/share.ts` (+ tests) — URL builders, issuer constant, `trackCredentialShareClick`
- `apps/web/src/components/certificates/credential-share-nudge.tsx` (+ tests)
- `apps/web/src/components/certificates/course-completion-mint.tsx`
- `apps/web/src/app/[locale]/(platform)/certificates/[id]/page.tsx`
- `apps/web/src/messages/{en,pt-BR,es}.json` — 4 new `certificates.*` keys