### PR TITLE
feat(db): xp_transactions.source typed column, derived from reason prefix (LX-B9a)

### DIFF
--- a/apps/web/src/lib/supabase/types.ts
+++ b/apps/web/src/lib/supabase/types.ts
@@ -871,6 +871,7 @@ export type Database = {
           id: string;
           idempotency_key: string | null;
           reason: string;
+          source: string;
           tx_signature: string | null;
           user_id: string | null;
         };
@@ -880,6 +881,7 @@ export type Database = {
           id?: string;
           idempotency_key?: string | null;
           reason: string;
+          source: string;
           tx_signature?: string | null;
           user_id?: string | null;
         };
@@ -889,6 +891,7 @@ export type Database = {
           id?: string;
           idempotency_key?: string | null;
           reason?: string;
+          source?: string;
           tx_signature?: string | null;
           user_id?: string | null;
         };

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -973,7 +973,7 @@ read-only; the publish flow's output is a **prefilled PR link**, not a write.
 | `enrollments`         | Course enrollment records                | `user_id`, `course_id`, `completed_at`, `tx_signature`             |
 | `user_progress`       | Per-lesson completion                    | `user_id`, `lesson_id`, `completed`, `lesson_index`                |
 | `user_xp`             | XP totals and streaks                    | `user_id`, `total_xp`, `level`, `current_streak`, `longest_streak` |
-| `xp_transactions`     | XP award history                         | `user_id`, `amount`, `reason`, `tx_signature`                      |
+| `xp_transactions`     | XP award history                         | `user_id`, `amount`, `reason`, `source`, `tx_signature`            |
 | `user_achievements`   | Achievement unlock records               | `user_id`, `achievement_id`, `asset_address`                       |
 | `certificates`        | Credential NFT records                   | `user_id`, `course_id`, `mint_address`, `credential_type`          |
 | `nft_metadata`        | Full Metaplex metadata JSON              | `id`, `data` (JSONB)                                               |

--- a/supabase/migrations/20260726120000_add_xp_transactions_source.sql
+++ b/supabase/migrations/20260726120000_add_xp_transactions_source.sql
@@ -6,10 +6,19 @@
 --      (mirrors the action_type / flags.reason CHECK-IN-list convention).
 --   2. Backfills existing rows by reason prefix (mapping below, derived from
 --      the actual writers), then sets NOT NULL — safe because the whole file
---      runs in one transaction and ALTER TABLE holds an exclusive lock, so no
---      concurrent insert can slip in a NULL between backfill and NOT NULL.
+--      runs in ONE transaction (explicit BEGIN/COMMIT below, so it holds for a
+--      manual psql apply too, not only under the Supabase CLI's per-file
+--      wrap) and ALTER TABLE holds an exclusive lock, so no concurrent insert
+--      from the still-live old award_xp can slip in a NULL between backfill
+--      and NOT NULL.
 --   3. Redefines award_xp / award_community_xp (the only two functions that
 --      INSERT into xp_transactions) to write `source` on every new row.
+--
+-- Idempotent (repo convention, cf. 20260703130652 / 20260624193000):
+-- ADD COLUMN IF NOT EXISTS; pg_constraint-guarded CHECK add (Postgres has no
+-- ADD CONSTRAINT IF NOT EXISTS for CHECKs); backfill scoped to source IS NULL;
+-- SET NOT NULL is a natural no-op when already set; CREATE OR REPLACE and
+-- REVOKE/GRANT re-run cleanly.
 --
 -- DESIGN — source is DERIVED from p_reason inside award_xp, not threaded as a
 -- new parameter through the ~6 TS call sites:
@@ -46,6 +55,11 @@
 -- "Completed challenge:" string is display-only, never written to the table).
 -- Values are derived from real call sites, not invented.
 
+-- Explicit transaction: under the Supabase CLI this nests inside the per-file
+-- wrap (inner BEGIN is a warning-level no-op); under a manual psql apply it is
+-- what makes backfill → NOT NULL → function swap atomic.
+BEGIN;
+
 -- ── 1. Shared reason→source derivation ───────────────────────
 -- Single source of truth for both the backfill below and every future
 -- award_xp insert. Pure and IMMUTABLE (no table access; search_path
@@ -76,28 +90,42 @@ REVOKE EXECUTE ON FUNCTION public.xp_source_for_reason(TEXT) FROM PUBLIC, anon, 
 
 -- ── 2. Column + backfill + constraints ───────────────────────
 
-ALTER TABLE public.xp_transactions ADD COLUMN source TEXT;
+ALTER TABLE public.xp_transactions ADD COLUMN IF NOT EXISTS source TEXT;
 
--- Backfill every existing row by reason prefix (mapping above).
+-- Backfill every unset row by reason prefix (mapping above). Scoped to
+-- source IS NULL so a re-run is a no-op.
 UPDATE public.xp_transactions
-SET source = public.xp_source_for_reason(reason);
+SET source = public.xp_source_for_reason(reason)
+WHERE source IS NULL;
 
 -- Safe: the backfill just populated every row (xp_source_for_reason never
 -- returns NULL — NULL/unknown reasons fall to 'platform'), and this file runs
--- in one transaction under the ADD COLUMN's exclusive lock.
+-- in one transaction under the ADD COLUMN's exclusive lock. Idempotent:
+-- SET NOT NULL is a no-op when the column is already NOT NULL.
 ALTER TABLE public.xp_transactions
   ALTER COLUMN source SET NOT NULL;
 
-ALTER TABLE public.xp_transactions
-  ADD CONSTRAINT chk_xp_transactions_source CHECK (source IN (
-    'lesson',
-    'course_completion',
-    'achievement',
-    'quest',
-    'creator_reward',
-    'community',
-    'platform'
-  ));
+-- Guarded add: Postgres has no ADD CONSTRAINT IF NOT EXISTS for CHECKs
+-- (mirrors chk_profiles_role in 20260703130652).
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'chk_xp_transactions_source'
+      AND conrelid = 'public.xp_transactions'::regclass
+  ) THEN
+    ALTER TABLE public.xp_transactions
+      ADD CONSTRAINT chk_xp_transactions_source CHECK (source IN (
+        'lesson',
+        'course_completion',
+        'achievement',
+        'quest',
+        'creator_reward',
+        'community',
+        'platform'
+      ));
+  END IF;
+END $$;
 
 -- ── 3. award_xp: write source on every insert ────────────────
 -- Verbatim from supabase/schema.sql (last redefined in
@@ -353,3 +381,5 @@ $$;
 -- Defensive re-assert (mirrors 20260630165536).
 REVOKE ALL ON FUNCTION award_community_xp(UUID, INTEGER, TEXT, TEXT) FROM public, anon, authenticated;
 GRANT EXECUTE ON FUNCTION award_community_xp(UUID, INTEGER, TEXT, TEXT) TO service_role;
+
+COMMIT;

--- a/supabase/migrations/20260726120000_add_xp_transactions_source.sql
+++ b/supabase/migrations/20260726120000_add_xp_transactions_source.sql
@@ -1,0 +1,355 @@
+-- Migration: xp_transactions.source typed column (LX-B9a, #557)
+--
+-- League scoring (LX-B9b) must filter XP by source — e.g. exclude creator and
+-- community XP — instead of parsing free-text reasons. This migration:
+--   1. Adds a CHECK-constrained TEXT column `source` to xp_transactions
+--      (mirrors the action_type / flags.reason CHECK-IN-list convention).
+--   2. Backfills existing rows by reason prefix (mapping below, derived from
+--      the actual writers), then sets NOT NULL — safe because the whole file
+--      runs in one transaction and ALTER TABLE holds an exclusive lock, so no
+--      concurrent insert can slip in a NULL between backfill and NOT NULL.
+--   3. Redefines award_xp / award_community_xp (the only two functions that
+--      INSERT into xp_transactions) to write `source` on every new row.
+--
+-- DESIGN — source is DERIVED from p_reason inside award_xp, not threaded as a
+-- new parameter through the ~6 TS call sites:
+--   * Reason prefixes are already load-bearing machine-readable convention in
+--     this schema: award_xp's daily cap counts `reason NOT LIKE 'community:%'`,
+--     award_community_xp's cap counts `LIKE 'community:%'`, the dashboard
+--     parses `Completed lesson:`, the realtime hook parses `daily_quest:`.
+--   * The backfill mapping and the go-forward mapping are the SAME function
+--     (xp_source_for_reason below) — one source of truth, so old and new rows
+--     can never disagree.
+--   * Durable pending_onchain_actions rows already carry reasons in their
+--     payloads and may be swept days after this migration applies; derivation
+--     keeps them correct with zero migration-before-code-deploy coordination
+--     (spec §"Migration serialization order": B9a must be trivial/standalone).
+-- award_community_xp hardcodes 'community' — the function IS the community
+-- path (all callers pass `community:%` reasons; its 50/day cap assumes it).
+--
+-- Backfill / derivation mapping (each prefix verified against its writer):
+--   reason prefix                 writer                                                        → source
+--   'community:%'                 award_community_xp — community routes (thread_created,
+--                                 answer_posted, answer_accepted, upvote_thread, upvote_answer) → community
+--   'daily_quest:%'               get_daily_quest_state enqueues quest_xp rows with
+--                                 memo 'daily_quest:<quest_id>'; swept via award_xp             → quest
+--   'Completed lesson:%'          handleLessonCompleted webhook + queued 'xp' action fallback   → lesson
+--   'Course completion bonus:%'   handleCourseFinalized bonus XP                                → course_completion
+--   'Completed course:%'          queued 'course_finalize' action fallback reason               → course_completion
+--   'Creator reward:%'            handleCourseFinalized creator XP                              → creator_reward
+--   'Achievement reward:%'        handleAchievementAwarded webhook + admin resync               → achievement
+--   anything else                 handleXpRewarded (on-chain reward_xp instruction — arbitrary
+--                                 authority-supplied memo, or the 'XP reward' fallback)         → platform
+--
+-- No 'challenge' or 'streak' value: no writer exists for either today
+-- (challenges complete as lessons via on-chain complete_lesson; the dashboard's
+-- "Completed challenge:" string is display-only, never written to the table).
+-- Values are derived from real call sites, not invented.
+
+-- ── 1. Shared reason→source derivation ───────────────────────
+-- Single source of truth for both the backfill below and every future
+-- award_xp insert. Pure and IMMUTABLE (no table access; search_path
+-- irrelevant). SECURITY INVOKER. Case order matters only for readability —
+-- the prefixes are mutually exclusive.
+CREATE OR REPLACE FUNCTION public.xp_source_for_reason(p_reason TEXT)
+RETURNS TEXT
+LANGUAGE sql
+IMMUTABLE
+AS $$
+  SELECT CASE
+    WHEN p_reason LIKE 'community:%'              THEN 'community'
+    WHEN p_reason LIKE 'daily_quest:%'            THEN 'quest'
+    WHEN p_reason LIKE 'Completed lesson:%'       THEN 'lesson'
+    WHEN p_reason LIKE 'Course completion bonus:%' THEN 'course_completion'
+    WHEN p_reason LIKE 'Completed course:%'       THEN 'course_completion'
+    WHEN p_reason LIKE 'Creator reward:%'         THEN 'creator_reward'
+    WHEN p_reason LIKE 'Achievement reward:%'     THEN 'achievement'
+    ELSE 'platform'
+  END
+$$;
+
+-- Not a client RPC — block PostgREST exposure (#377 convention). No
+-- service_role grant needed: it is only called from inside the SECURITY
+-- DEFINER award functions (which execute as the function owner) and from this
+-- migration's backfill.
+REVOKE EXECUTE ON FUNCTION public.xp_source_for_reason(TEXT) FROM PUBLIC, anon, authenticated;
+
+-- ── 2. Column + backfill + constraints ───────────────────────
+
+ALTER TABLE public.xp_transactions ADD COLUMN source TEXT;
+
+-- Backfill every existing row by reason prefix (mapping above).
+UPDATE public.xp_transactions
+SET source = public.xp_source_for_reason(reason);
+
+-- Safe: the backfill just populated every row (xp_source_for_reason never
+-- returns NULL — NULL/unknown reasons fall to 'platform'), and this file runs
+-- in one transaction under the ADD COLUMN's exclusive lock.
+ALTER TABLE public.xp_transactions
+  ALTER COLUMN source SET NOT NULL;
+
+ALTER TABLE public.xp_transactions
+  ADD CONSTRAINT chk_xp_transactions_source CHECK (source IN (
+    'lesson',
+    'course_completion',
+    'achievement',
+    'quest',
+    'creator_reward',
+    'community',
+    'platform'
+  ));
+
+-- ── 3. award_xp: write source on every insert ────────────────
+-- Verbatim from supabase/schema.sql (last redefined in
+-- 20260709130000_award_xp_report_credited.sql) + v_source. Same signature and
+-- return type, so CREATE OR REPLACE applies cleanly.
+CREATE OR REPLACE FUNCTION award_xp(
+  p_user_id UUID,
+  p_amount INTEGER,
+  p_reason TEXT,
+  p_idempotency_key TEXT DEFAULT NULL,
+  p_tx_signature TEXT DEFAULT NULL
+) RETURNS INTEGER
+-- Returns the amount actually credited (after per-award + daily-cap clamps).
+--   > 0 → XP landed (or, for an idempotency-key duplicate, had already landed —
+--         the previously-credited amount is returned so callers can treat
+--         "already delivered" as delivered).
+--   = 0 → nothing was credited (invalid amount, or the daily cap consumed the
+--         whole award). Queue-style callers MUST NOT mark delivery resolved
+--         on 0 — the credit was dropped, not delivered.
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_last_activity DATE;
+  v_current_streak INTEGER;
+  v_longest_streak INTEGER;
+  v_new_streak INTEGER;
+  v_new_longest INTEGER;
+  v_daily_total INTEGER;
+  v_prev_amount INTEGER;
+  -- Typed source derived from the reason prefix (LX-B9a) — see
+  -- xp_source_for_reason for the mapping and the derivation rationale.
+  v_source TEXT;
+  -- Hard per-award ceiling. Matches the documented "max 2000 XP per award"
+  -- (the largest legitimate single award is a course-completion bonus).
+  c_max_award_xp CONSTANT INTEGER := 2000;
+  -- Per-user daily ceiling across the learning XP path (lessons, challenges,
+  -- bonuses, achievements). Generous enough for normal multi-course days,
+  -- low enough to cap a forged-"passed" farming loop.
+  c_max_daily_award_xp CONSTANT INTEGER := 5000;
+BEGIN
+  -- Reject non-positive awards outright (defensive — callers pass positives).
+  IF p_amount IS NULL OR p_amount <= 0 THEN
+    RETURN 0;
+  END IF;
+
+  -- Clamp any single award to the hard ceiling.
+  IF p_amount > c_max_award_xp THEN
+    p_amount := c_max_award_xp;
+  END IF;
+
+  -- Serialize concurrent awards for the same user so the read-then-insert daily
+  -- cap below is atomic: without this lock, two parallel awards can both read a
+  -- sub-cap total and both insert, blowing past the daily ceiling.
+  PERFORM pg_advisory_xact_lock(hashtext('award_xp:' || p_user_id::text)::bigint);
+
+  -- Enforce the per-user daily ceiling. Sum today's learning-path awards
+  -- (excluding community XP, which is capped separately) and clamp the credit
+  -- so the daily total can never exceed the ceiling. The window boundary is
+  -- pinned to UTC midnight so it is independent of the DB session timezone.
+  SELECT COALESCE(SUM(amount), 0) INTO v_daily_total
+  FROM public.xp_transactions
+  WHERE user_id = p_user_id
+    AND created_at >= date_trunc('day', now() AT TIME ZONE 'UTC') AT TIME ZONE 'UTC'
+    AND reason NOT LIKE 'community:%';
+
+  IF v_daily_total >= c_max_daily_award_xp THEN
+    RETURN 0;
+  END IF;
+
+  IF v_daily_total + p_amount > c_max_daily_award_xp THEN
+    p_amount := c_max_daily_award_xp - v_daily_total;
+  END IF;
+
+  IF p_amount <= 0 THEN
+    RETURN 0;
+  END IF;
+
+  v_source := public.xp_source_for_reason(p_reason);
+
+  IF p_idempotency_key IS NOT NULL THEN
+    INSERT INTO public.xp_transactions (user_id, amount, reason, source, idempotency_key, tx_signature)
+    VALUES (p_user_id, p_amount, p_reason, v_source, p_idempotency_key, p_tx_signature)
+    ON CONFLICT (user_id, idempotency_key) WHERE idempotency_key IS NOT NULL DO NOTHING;
+
+    -- If nothing was inserted (duplicate), skip the XP update too. Report the
+    -- previously-credited amount (always > 0 — award_xp never records a
+    -- non-positive transaction) so callers see "already delivered", not
+    -- "dropped".
+    IF NOT FOUND THEN
+      SELECT amount INTO v_prev_amount
+      FROM public.xp_transactions
+      WHERE user_id = p_user_id
+        AND idempotency_key = p_idempotency_key;
+      RETURN COALESCE(v_prev_amount, 0);
+    END IF;
+  ELSE
+    INSERT INTO public.xp_transactions (user_id, amount, reason, source, tx_signature)
+    VALUES (p_user_id, p_amount, p_reason, v_source, p_tx_signature);
+  END IF;
+
+  -- Get current streak state before updating
+  SELECT last_activity_date, current_streak, longest_streak
+  INTO v_last_activity, v_current_streak, v_longest_streak
+  FROM public.user_xp
+  WHERE user_id = p_user_id;
+
+  -- Calculate new streak
+  IF v_last_activity IS NULL THEN
+    -- First activity ever
+    v_new_streak := 1;
+  ELSIF v_last_activity = CURRENT_DATE THEN
+    -- Already active today, keep current streak
+    v_new_streak := COALESCE(v_current_streak, 1);
+  ELSIF v_last_activity = CURRENT_DATE - INTERVAL '1 day' THEN
+    -- Active yesterday, increment streak
+    v_new_streak := COALESCE(v_current_streak, 0) + 1;
+  ELSE
+    -- Gap > 1 day, reset streak
+    v_new_streak := 1;
+  END IF;
+
+  v_new_longest := GREATEST(COALESCE(v_longest_streak, 0), v_new_streak);
+
+  INSERT INTO public.user_xp (user_id, total_xp, level, last_activity_date, current_streak, longest_streak)
+  VALUES (
+    p_user_id,
+    p_amount,
+    floor(sqrt(p_amount / 100.0))::int,
+    CURRENT_DATE,
+    v_new_streak,
+    v_new_longest
+  )
+  ON CONFLICT (user_id) DO UPDATE SET
+    total_xp = user_xp.total_xp + p_amount,
+    level = floor(sqrt((user_xp.total_xp + p_amount) / 100.0))::int,
+    last_activity_date = CURRENT_DATE,
+    current_streak = v_new_streak,
+    longest_streak = v_new_longest;
+
+  RETURN p_amount;
+END;
+$$;
+
+-- Re-apply the service_role-only lockdown (F-06) — defensive re-assert; CREATE
+-- OR REPLACE preserves grants, but every award_xp migration re-states them.
+REVOKE EXECUTE ON FUNCTION public.award_xp(UUID, INTEGER, TEXT, TEXT, TEXT)
+  FROM authenticated, anon, public;
+GRANT EXECUTE ON FUNCTION public.award_xp(UUID, INTEGER, TEXT, TEXT, TEXT)
+  TO service_role;
+
+-- ── 4. award_community_xp: write source='community' ──────────
+-- Verbatim from supabase/schema.sql (last redefined in
+-- 20260630165536_harden_award_community_xp.sql) + the source column.
+CREATE OR REPLACE FUNCTION award_community_xp(
+  p_user_id UUID,
+  p_amount INTEGER,
+  p_reason TEXT,
+  p_idempotency_key TEXT DEFAULT NULL
+) RETURNS BOOLEAN
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_daily_total INTEGER;
+  v_daily_vote_total INTEGER;
+  v_is_vote_xp BOOLEAN;
+BEGIN
+  IF p_amount <= 0 THEN RETURN FALSE; END IF;
+
+  -- Serialize concurrent community awards for the same user so the read-then-
+  -- insert daily cap below is atomic (mirrors the lock added to award_xp in
+  -- #179). A distinct key namespace avoids contending with award_xp's lock —
+  -- the two functions count disjoint xp_transactions rows (community:% vs NOT
+  -- community:%), so they need not serialize against each other.
+  PERFORM pg_advisory_xact_lock(hashtext('award_community_xp:' || p_user_id::text)::bigint);
+
+  SELECT COALESCE(SUM(amount), 0) INTO v_daily_total
+  FROM public.xp_transactions
+  WHERE user_id = p_user_id
+    AND reason LIKE 'community:%'
+    AND created_at >= date_trunc('day', now() AT TIME ZONE 'UTC') AT TIME ZONE 'UTC';
+
+  IF v_daily_total >= 50 THEN RETURN FALSE; END IF;
+
+  v_is_vote_xp := p_reason LIKE 'community:upvote%';
+  IF v_is_vote_xp THEN
+    SELECT COALESCE(SUM(amount), 0) INTO v_daily_vote_total
+    FROM public.xp_transactions
+    WHERE user_id = p_user_id
+      AND reason LIKE 'community:upvote%'
+      AND created_at >= date_trunc('day', now() AT TIME ZONE 'UTC') AT TIME ZONE 'UTC';
+
+    IF v_daily_vote_total >= 10 THEN RETURN FALSE; END IF;
+
+    IF v_daily_vote_total + p_amount > 10 THEN
+      p_amount := 10 - v_daily_vote_total;
+    END IF;
+    IF p_amount <= 0 THEN RETURN FALSE; END IF;
+  END IF;
+
+  IF v_daily_total + p_amount > 50 THEN
+    p_amount := 50 - v_daily_total;
+  END IF;
+  IF p_amount <= 0 THEN RETURN FALSE; END IF;
+
+  -- source is hardcoded: this function IS the community XP path (LX-B9a). All
+  -- callers pass 'community:%' reasons — the daily-cap accounting above
+  -- already depends on that convention.
+  IF p_idempotency_key IS NOT NULL THEN
+    INSERT INTO public.xp_transactions (user_id, amount, reason, source, idempotency_key)
+    VALUES (p_user_id, p_amount, p_reason, 'community', p_idempotency_key)
+    ON CONFLICT (user_id, idempotency_key) WHERE idempotency_key IS NOT NULL
+    DO NOTHING;
+
+    IF NOT FOUND THEN RETURN FALSE; END IF;
+  ELSE
+    INSERT INTO public.xp_transactions (user_id, amount, reason, source)
+    VALUES (p_user_id, p_amount, p_reason, 'community');
+  END IF;
+
+  INSERT INTO public.user_xp (id, user_id, total_xp, level, current_streak, longest_streak, last_activity_date)
+  VALUES (
+    gen_random_uuid(), p_user_id, p_amount,
+    floor(sqrt(p_amount / 100.0))::int,
+    1, 1, CURRENT_DATE
+  )
+  ON CONFLICT (user_id) DO UPDATE SET
+    total_xp = user_xp.total_xp + p_amount,
+    level = floor(sqrt((user_xp.total_xp + p_amount) / 100.0))::int,
+    last_activity_date = CURRENT_DATE,
+    current_streak = CASE
+      WHEN user_xp.last_activity_date IS NULL THEN 1
+      WHEN user_xp.last_activity_date = CURRENT_DATE THEN user_xp.current_streak
+      WHEN user_xp.last_activity_date = CURRENT_DATE - INTERVAL '1 day' THEN user_xp.current_streak + 1
+      ELSE 1
+    END,
+    longest_streak = GREATEST(
+      user_xp.longest_streak,
+      CASE
+        WHEN user_xp.last_activity_date = CURRENT_DATE - INTERVAL '1 day' THEN user_xp.current_streak + 1
+        WHEN user_xp.last_activity_date = CURRENT_DATE THEN user_xp.current_streak
+        ELSE 1
+      END
+    );
+
+  RETURN TRUE;
+END;
+$$;
+
+-- Defensive re-assert (mirrors 20260630165536).
+REVOKE ALL ON FUNCTION award_community_xp(UUID, INTEGER, TEXT, TEXT) FROM public, anon, authenticated;
+GRANT EXECUTE ON FUNCTION award_community_xp(UUID, INTEGER, TEXT, TEXT) TO service_role;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -69,7 +69,12 @@ CREATE TABLE xp_transactions (
   reason TEXT NOT NULL,
   created_at TIMESTAMPTZ DEFAULT NOW(),
   tx_signature TEXT,
-  idempotency_key TEXT
+  idempotency_key TEXT,
+  -- Typed award source (LX-B9a, #557) — league scoring filters by this instead
+  -- of parsing free-text reasons. Derived from the reason prefix inside
+  -- award_xp via xp_source_for_reason(); hardcoded 'community' inside
+  -- award_community_xp. CHECK constraint below (chk_xp_transactions_source).
+  source TEXT NOT NULL
 );
 
 CREATE TABLE user_achievements (
@@ -149,6 +154,16 @@ ALTER TABLE user_xp
 
 ALTER TABLE xp_transactions
   ADD CONSTRAINT chk_xp_transactions_amount_positive CHECK (amount > 0);
+ALTER TABLE xp_transactions
+  ADD CONSTRAINT chk_xp_transactions_source CHECK (source IN (
+    'lesson',
+    'course_completion',
+    'achievement',
+    'quest',
+    'creator_reward',
+    'community',
+    'platform'
+  ));
 
 -- A course can only be completed at or after it was enrolled. Closes the
 -- forged sub-24h enrolled->completed window that fakes Speed Runner. NULL
@@ -323,6 +338,40 @@ CREATE POLICY "Anyone can read nft metadata"
 -- 4. SECURE SERVER-SIDE FUNCTIONS
 -- ─────────────────────────────────────────────
 
+-- Reason→source derivation for xp_transactions.source (LX-B9a, #557).
+-- Single source of truth for the go-forward writes in award_xp AND the
+-- backfill in 20260726120000_add_xp_transactions_source.sql — old and new
+-- rows can never disagree. Source is DERIVED from the reason prefix (not a
+-- new award_xp parameter) because reason prefixes are already load-bearing
+-- machine-readable convention here: award_xp's daily cap counts
+-- `NOT LIKE 'community:%'`, award_community_xp's cap counts
+-- `LIKE 'community:%'`, and durable pending_onchain_actions payloads carry
+-- reasons that may be swept long after deploy. Each prefix below is verified
+-- against its writer; unknown reasons (on-chain reward_xp memos are arbitrary
+-- authority-supplied text) fall to 'platform'. No 'challenge'/'streak' values:
+-- no writer exists for either (challenges complete as lessons on-chain).
+CREATE OR REPLACE FUNCTION public.xp_source_for_reason(p_reason TEXT)
+RETURNS TEXT
+LANGUAGE sql
+IMMUTABLE
+AS $$
+  SELECT CASE
+    WHEN p_reason LIKE 'community:%'              THEN 'community'
+    WHEN p_reason LIKE 'daily_quest:%'            THEN 'quest'
+    WHEN p_reason LIKE 'Completed lesson:%'       THEN 'lesson'
+    WHEN p_reason LIKE 'Course completion bonus:%' THEN 'course_completion'
+    WHEN p_reason LIKE 'Completed course:%'       THEN 'course_completion'
+    WHEN p_reason LIKE 'Creator reward:%'         THEN 'creator_reward'
+    WHEN p_reason LIKE 'Achievement reward:%'     THEN 'achievement'
+    ELSE 'platform'
+  END
+$$;
+
+-- Not a client RPC — block PostgREST exposure (#377 convention). No
+-- service_role grant needed: only called from inside the SECURITY DEFINER
+-- award functions, which execute as the function owner.
+REVOKE EXECUTE ON FUNCTION public.xp_source_for_reason(TEXT) FROM PUBLIC, anon, authenticated;
+
 -- Award XP (called from API routes with service_role key only)
 -- Also handles streak tracking: increments current_streak if last activity was
 -- yesterday, resets to 1 if gap > 1 day, and updates longest_streak.
@@ -366,6 +415,9 @@ DECLARE
   v_new_longest INTEGER;
   v_daily_total INTEGER;
   v_prev_amount INTEGER;
+  -- Typed source derived from the reason prefix (LX-B9a) — see
+  -- xp_source_for_reason for the mapping and the derivation rationale.
+  v_source TEXT;
   -- Hard per-award ceiling. Matches the documented "max 2000 XP per award"
   -- (the largest legitimate single award is a course-completion bonus).
   c_max_award_xp CONSTANT INTEGER := 2000;
@@ -411,9 +463,11 @@ BEGIN
     RETURN 0;
   END IF;
 
+  v_source := public.xp_source_for_reason(p_reason);
+
   IF p_idempotency_key IS NOT NULL THEN
-    INSERT INTO public.xp_transactions (user_id, amount, reason, idempotency_key, tx_signature)
-    VALUES (p_user_id, p_amount, p_reason, p_idempotency_key, p_tx_signature)
+    INSERT INTO public.xp_transactions (user_id, amount, reason, source, idempotency_key, tx_signature)
+    VALUES (p_user_id, p_amount, p_reason, v_source, p_idempotency_key, p_tx_signature)
     ON CONFLICT (user_id, idempotency_key) WHERE idempotency_key IS NOT NULL DO NOTHING;
 
     -- If nothing was inserted (duplicate), skip the XP update too. Report the
@@ -428,8 +482,8 @@ BEGIN
       RETURN COALESCE(v_prev_amount, 0);
     END IF;
   ELSE
-    INSERT INTO public.xp_transactions (user_id, amount, reason, tx_signature)
-    VALUES (p_user_id, p_amount, p_reason, p_tx_signature);
+    INSERT INTO public.xp_transactions (user_id, amount, reason, source, tx_signature)
+    VALUES (p_user_id, p_amount, p_reason, v_source, p_tx_signature);
   END IF;
 
   -- Get current streak state before updating
@@ -1502,16 +1556,19 @@ BEGIN
   END IF;
   IF p_amount <= 0 THEN RETURN FALSE; END IF;
 
+  -- source is hardcoded: this function IS the community XP path (LX-B9a). All
+  -- callers pass 'community:%' reasons — the daily-cap accounting above
+  -- already depends on that convention.
   IF p_idempotency_key IS NOT NULL THEN
-    INSERT INTO public.xp_transactions (user_id, amount, reason, idempotency_key)
-    VALUES (p_user_id, p_amount, p_reason, p_idempotency_key)
+    INSERT INTO public.xp_transactions (user_id, amount, reason, source, idempotency_key)
+    VALUES (p_user_id, p_amount, p_reason, 'community', p_idempotency_key)
     ON CONFLICT (user_id, idempotency_key) WHERE idempotency_key IS NOT NULL
     DO NOTHING;
 
     IF NOT FOUND THEN RETURN FALSE; END IF;
   ELSE
-    INSERT INTO public.xp_transactions (user_id, amount, reason)
-    VALUES (p_user_id, p_amount, p_reason);
+    INSERT INTO public.xp_transactions (user_id, amount, reason, source)
+    VALUES (p_user_id, p_amount, p_reason, 'community');
   END IF;
 
   INSERT INTO public.user_xp (id, user_id, total_xp, level, current_streak, longest_streak, last_activity_date)


### PR DESCRIPTION
Closes #557 (LX-B9a, master spec §3).

Adds a CHECK-constrained `source` column to `xp_transactions` so future league scoring (LX-B9b) filters by a typed column — able to exclude creator/community XP — instead of parsing free-text reasons. **No league code in this PR.** SQL is **not applied anywhere**: it ships here for the gate/owner to apply dry-run-first.

## Call-site inventory (the spec's "6–7")

Every XP award write goes through exactly **two** SQL functions that INSERT into `xp_transactions` (`award_xp`, `award_community_xp`). Their callers:

**`award_xp` RPC — 6 call sites**
| # | Call site | Reason written | → source |
|---|-----------|----------------|----------|
| 1 | `lib/helius/event-handlers.ts:196` (handleLessonCompleted) | `Completed lesson: <lessonId \| index:N>` | `lesson` |
| 2 | `lib/helius/event-handlers.ts:263` (handleCourseFinalized bonus) | `Course completion bonus: <courseId>` | `course_completion` |
| 3 | `lib/helius/event-handlers.ts:289` (handleCourseFinalized creator) | `Creator reward: <courseId>` | `creator_reward` |
| 4 | `lib/helius/event-handlers.ts:368` (handleAchievementAwarded) | `Achievement reward: <achievementId>` | `achievement` |
| 5 | `lib/helius/event-handlers.ts:404` (handleXpRewarded) | arbitrary on-chain memo, or `XP reward`; historically incl. `daily_quest:<id>` | `platform` (or `quest` for daily_quest memos) |
| 6 | `lib/solana/onchain-queue.ts:554` (creditXpAndSettle — shared by the `xp`, `course_finalize`, and `quest_xp` queue rows) | payload reason, or fallbacks `Completed lesson: …` / `Completed course: <courseId>` / `daily_quest:<questId>` | `lesson` / `course_completion` / `quest` |
| +| `app/api/admin/resync/route.ts:257` (admin resync replay of #4) | `Achievement reward: <achievementId>` | `achievement` |

**`award_community_xp` RPC — 5 call sites, all `community:%` reasons → `community`**
`community/threads/route.ts:283` (`community:thread_created`) · `community/answers/route.ts:96` (`community:answer_posted`) · `community/answers/[id]/accept/route.ts:122` (`community:answer_accepted`) · `community/votes/route.ts:123` and `:158` (`community:upvote_thread` / `community:upvote_answer`).

(`revoke_community_xp` only DELETEs — no change needed. `get_daily_quest_state` never inserts XP directly; it enqueues `quest_xp` rows whose memo `daily_quest:<questId>` becomes the reason at sweep time.)

## Enum values + backfill mapping

`CHECK (source IN ('lesson','course_completion','achievement','quest','creator_reward','community','platform'))` — `chk_` naming per existing convention (`chk_profiles_role`, `pending_onchain_actions.action_type`).

Backfill = the same `xp_source_for_reason(reason)` used for go-forward writes:

| reason prefix | → source |
|---|---|
| `community:%` | `community` |
| `daily_quest:%` | `quest` |
| `Completed lesson:%` | `lesson` |
| `Course completion bonus:%` / `Completed course:%` | `course_completion` |
| `Creator reward:%` | `creator_reward` |
| `Achievement reward:%` | `achievement` |
| anything else (on-chain `reward_xp` memos are arbitrary authority text) | `platform` |

**Deliberately no `challenge` or `streak` value** — no writer exists for either (challenges complete as lessons via on-chain `complete_lesson`; the dashboard's `Completed challenge:` string is display-only rendering, never written to the table). Values derive from real call sites, not the spec's illustrative list.

## Design choice: derived in SQL, not a new parameter

`source` is derived from `p_reason` inside `award_xp` (one `IMMUTABLE` helper, `xp_source_for_reason`); `award_community_xp` hardcodes `'community'`. Rationale:

1. **Reason prefixes are already load-bearing machine-readable convention** in this schema: `award_xp`'s daily cap counts `reason NOT LIKE 'community:%'`, `award_community_xp`'s cap counts `LIKE 'community:%'`, the dashboard parses `Completed lesson:`, the realtime hook parses `daily_quest:`.
2. **Backfill and go-forward writes share the same function** — old and new rows can never disagree about the mapping.
3. **Zero deploy coordination**: durable `pending_onchain_actions` rows already in flight carry reasons in their payloads and may be swept days after the migration applies; a new required RPC arg would break every not-yet-redeployed caller during the migration-before-code-deploy window the spec mandates (§"Migration serialization order: B9a … trivial"). Derived, the TS diff is types-only.
4. Threading a param through 6 call sites adds 6 places to drift and doesn't remove the need for prefix derivation (the backfill needs it regardless).

Trade-off acknowledged: a future caller inventing a new reason format lands in `platform` silently. LX-B9b's accept criteria use an **inclusion** filter ("counts only learning-source XP"), so unknown → excluded, which fails safe.

## Migration mechanics (`supabase/migrations/20260726120000_add_xp_transactions_source.sql`)

Single transaction: helper fn (+ PostgREST-exposure REVOKE, #377 convention) → `ADD COLUMN` → backfill `UPDATE` → `SET NOT NULL` (safe under the ALTER's exclusive lock; helper never returns NULL) → `CHECK` constraint → redefine `award_xp` + `award_community_xp` verbatim from schema.sql + the `source` write, re-asserting the service_role-only REVOKE/GRANTs exactly as `20260709130000` / `20260630165536` do. `SECURITY DEFINER SET search_path = ''` preserved on both. Mirrored into `supabase/schema.sql`. **No RLS changes** (own-row SELECT stays), no index (LX-B9b's call), no touching the cap predicates (still reason-based, behavior-identical).

## Tests

No new RPC arg → no caller changes → the existing suites are the assertion that the TS contract is untouched: full `apps/web` suite **111 files / 1042 tests pass** unchanged, including `onchain-queue.test.ts`'s explicit `award_xp` argument assertions. Migration + schema.sql validated with the real Postgres grammar (libpg-query v16): both parse clean (12 / 240 statements). Not executed against any database per the issue's hard constraint — dry-run-first apply is the gate/owner's step.

## Verification

- `pnpm typecheck` — 6/6 tasks green
- `pnpm test` (apps/web) — 111 files, 1042 tests, all pass
- `pnpm lint` (apps/web) — exit 0 (2 pre-existing import-order warnings in untouched files)

## Out-of-scope findings

- `admin/resync/route.ts` sums community XP via `.like("reason", "community:%")` — could later switch to `source = 'community'` (behavior-identical today, left alone).
- The daily-cap predicates in both award functions still discriminate via reason prefix; migrating them to `source` would be a follow-up hardening, deliberately not done here to keep this PR behavior-identical.
- Dashboard's `Completed challenge:` regex (`dashboard/page.tsx:272`) parses a reason format nothing ever writes — dead parse path, untouched.
