### PR TITLE
feat(credentials): verify-page polish — course version, i18n, network label (LX-E5)

### DIFF
--- a/apps/web/src/app/[locale]/(platform)/certificates/[id]/__tests__/page.test.tsx
+++ b/apps/web/src/app/[locale]/(platform)/certificates/[id]/__tests__/page.test.tsx
@@ -1,0 +1,200 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import CertificateViewPage from "../page";
+import messages from "@/messages/en.json";
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ id: "cert-1" }),
+}));
+
+const { trackEvent } = vi.hoisted(() => ({ trackEvent: vi.fn() }));
+vi.mock("@/lib/analytics", () => ({ trackEvent }));
+
+const MINT_ADDRESS = "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU";
+const METADATA_URI = "https://gateway.irys.xyz/test-metadata";
+
+const db = vi.hoisted(() => ({
+  certRow: null as Record<string, unknown> | null,
+  profileRow: null as Record<string, unknown> | null,
+}));
+
+vi.mock("@/lib/supabase/client", () => ({
+  createClient: () => ({
+    from: (table: string) => ({
+      select: () => ({
+        eq: () => ({
+          single: async () => ({
+            data: table === "certificates" ? db.certRow : db.profileRow,
+          }),
+        }),
+      }),
+    }),
+  }),
+}));
+
+vi.mock("@/lib/content/client-queries", () => ({
+  getCoursesByIds: async () => [
+    {
+      _id: "solana-101",
+      learningPath: "Solana Development",
+      difficulty: "beginner",
+    },
+  ],
+}));
+
+function stubMetadataFetch(attributes: unknown[] | null): void {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () =>
+      attributes === null
+        ? ({ ok: false, json: async () => ({}) } as Response)
+        : ({
+            ok: true,
+            json: async () => ({ name: "Solana 101", attributes }),
+          } as Response)
+    )
+  );
+}
+
+function setCert(overrides: Record<string, unknown> = {}): void {
+  db.certRow = {
+    id: "cert-1",
+    user_id: "user-1",
+    course_id: "solana-101",
+    course_title: "Solana Fundamentals",
+    mint_address: MINT_ADDRESS,
+    metadata_uri: METADATA_URI,
+    minted_at: "2026-07-01T00:00:00.000Z",
+    ...overrides,
+  };
+  db.profileRow = { username: "gabi", wallet_address: "wallet-1" };
+}
+
+function renderPage() {
+  return render(
+    <NextIntlClientProvider locale="en" messages={messages}>
+      <CertificateViewPage />
+    </NextIntlClientProvider>
+  );
+}
+
+/** The NFT-details explorer button (not ProofPill, whose href omits the
+ *  cluster param on mainnet-beta). */
+function explorerLinks(): string[] {
+  return screen
+    .getAllByRole("link")
+    .map((link) => link.getAttribute("href") ?? "")
+    .filter((href) => href.startsWith("https://explorer.solana.com/address/"));
+}
+
+const ORIGINAL_NETWORK = process.env.NEXT_PUBLIC_SOLANA_NETWORK;
+
+beforeEach(() => {
+  trackEvent.mockClear();
+  delete process.env.NEXT_PUBLIC_SOLANA_NETWORK;
+  setCert();
+  stubMetadataFetch([{ trait_type: "Course Version", value: 3 }]);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  if (ORIGINAL_NETWORK === undefined) {
+    delete process.env.NEXT_PUBLIC_SOLANA_NETWORK;
+  } else {
+    process.env.NEXT_PUBLIC_SOLANA_NETWORK = ORIGINAL_NETWORK;
+  }
+});
+
+describe("certificate verify page — credential anatomy (F35)", () => {
+  it("shows issuer, unique credential ID, and course version, clearly labeled", async () => {
+    renderPage();
+
+    expect(await screen.findByText("Issuer")).toBeInTheDocument();
+    expect(screen.getByText("Superteam Academy")).toBeInTheDocument();
+
+    expect(screen.getByText("Credential ID")).toBeInTheDocument();
+    // Unique ID = truncated mint address (also shown on the card itself)
+    expect(screen.getAllByText(/7xKXtg\.\.\./).length).toBeGreaterThan(0);
+
+    expect(screen.getByText("Course Version")).toBeInTheDocument();
+    expect(screen.getByText("3")).toBeInTheDocument();
+  });
+
+  it("omits the course-version row for pre-#497 credentials (absent-safe)", async () => {
+    stubMetadataFetch([{ trait_type: "Course", value: "Solana 101" }]);
+    renderPage();
+
+    expect(await screen.findByText("Issuer")).toBeInTheDocument();
+    expect(screen.queryByText("Course Version")).not.toBeInTheDocument();
+  });
+
+  it("omits the course-version row when the metadata is unreachable", async () => {
+    stubMetadataFetch(null);
+    renderPage();
+
+    expect(await screen.findByText("Issuer")).toBeInTheDocument();
+    expect(screen.queryByText("Course Version")).not.toBeInTheDocument();
+  });
+});
+
+describe("certificate verify page — network label from env", () => {
+  it("defaults to Devnet when NEXT_PUBLIC_SOLANA_NETWORK is unset", async () => {
+    renderPage();
+
+    expect(await screen.findByText("Devnet")).toBeInTheDocument();
+    expect(
+      explorerLinks().some((href) => href.endsWith("?cluster=devnet"))
+    ).toBe(true);
+  });
+
+  it("labels Mainnet and targets the mainnet-beta explorer cluster", async () => {
+    process.env.NEXT_PUBLIC_SOLANA_NETWORK = "mainnet";
+    renderPage();
+
+    expect(await screen.findByText("Mainnet")).toBeInTheDocument();
+    expect(screen.queryByText("Devnet")).not.toBeInTheDocument();
+    expect(
+      explorerLinks().some((href) => href.endsWith("?cluster=mainnet-beta"))
+    ).toBe(true);
+    // Never the invalid bare "mainnet" cluster param
+    expect(
+      explorerLinks().some((href) => href.endsWith("?cluster=mainnet"))
+    ).toBe(false);
+  });
+});
+
+describe("certificate verify page — localized recipient fallback", () => {
+  it("renders the username when the profile has one", async () => {
+    renderPage();
+    expect(await screen.findByText("gabi")).toBeInTheDocument();
+  });
+
+  it("falls back to the message catalog when the username is missing", async () => {
+    db.profileRow = { username: null, wallet_address: "wallet-1" };
+    renderPage();
+
+    expect(
+      await screen.findByText(messages.certificates.recipientFallback)
+    ).toBeInTheDocument();
+  });
+
+  it("uses the active locale's catalog for the fallback (not hardcoded English)", async () => {
+    db.profileRow = { username: null, wallet_address: "wallet-1" };
+    const localized = {
+      ...messages,
+      certificates: {
+        ...messages.certificates,
+        recipientFallback: "Construtora",
+      },
+    };
+    render(
+      <NextIntlClientProvider locale="en" messages={localized}>
+        <CertificateViewPage />
+      </NextIntlClientProvider>
+    );
+
+    expect(await screen.findByText("Construtora")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/[locale]/(platform)/certificates/[id]/page.tsx
+++ b/apps/web/src/app/[locale]/(platform)/certificates/[id]/page.tsx
@@ -10,22 +10,26 @@ import { CertificateCard } from "@/components/certificates/certificate-card";
 import { EarnHandoffCard } from "@/components/certificates/earn-handoff-card";
 import { createClient } from "@/lib/supabase/client";
 import { getCoursesByIds } from "@/lib/content/client-queries";
+import { fetchCourseVersion } from "@/lib/credentials/metadata";
 import {
   CREDENTIAL_ISSUER_NAME,
   buildLinkedInAddToProfileUrl,
   buildXShareIntentUrl,
   trackCredentialShareClick,
 } from "@/lib/credentials/share";
+import { resolveSolanaNetwork } from "@/lib/solana/network";
 import { CERTIFICATE_STYLES as CS } from "@/lib/styles/styleClasses";
 import { truncateAddress } from "@/lib/utils";
 
 interface CertDetail {
   cert: Certificate;
-  recipientName: string;
+  /** Profile username; null when unset — the UI supplies a localized fallback. */
+  recipientName: string | null;
   subtitle: string;
   mintAddress: string;
   metadataUri: string;
-  network: string;
+  /** #497 Course Version stamp from the credential metadata; null pre-#497. */
+  courseVersion: number | null;
 }
 
 function useCertificateData(certId: string) {
@@ -66,6 +70,10 @@ function useCertificateData(certId: string) {
           );
         }
 
+        // Best-effort read of the #497 Course Version stamp from the
+        // credential metadata (its only off-chain home) — null pre-#497.
+        const courseVersion = await fetchCourseVersion(cert.metadata_uri ?? "");
+
         setData({
           cert: {
             id: cert.id,
@@ -76,11 +84,11 @@ function useCertificateData(certId: string) {
             metadataUri: cert.metadata_uri ?? "",
             mintedAt: new Date(cert.minted_at ?? Date.now()),
           },
-          recipientName: profile?.username ?? "Builder",
+          recipientName: profile?.username ?? null,
           subtitle: parts.join(" · "),
           mintAddress: cert.mint_address ?? "",
           metadataUri: cert.metadata_uri ?? "",
-          network: "devnet",
+          courseVersion,
         });
       } catch {
         setNotFound(true);
@@ -152,10 +160,11 @@ export default function CertificateViewPage() {
     );
   }
 
-  const { cert, recipientName, subtitle, mintAddress, metadataUri, network } =
-    data;
+  const { cert, subtitle, mintAddress, metadataUri, courseVersion } = data;
+  const recipientName = data.recipientName ?? t("recipientFallback");
+  const { cluster, label: networkLabel } = resolveSolanaNetwork();
   const explorerUrl = mintAddress
-    ? `https://explorer.solana.com/address/${mintAddress}?cluster=${network}`
+    ? `https://explorer.solana.com/address/${mintAddress}?cluster=${cluster}`
     : "";
 
   // This page only renders content client-side (data arrives via useEffect),
@@ -255,16 +264,27 @@ export default function CertificateViewPage() {
         <EarnHandoffCard source="certificate_page" courseId={cert.courseId} />
       </div>
 
-      {/* NFT Details card — copyable values */}
+      {/* NFT Details card — credential anatomy (F35): issuer, unique ID
+          (mint address), course version, each clearly labeled */}
       <div className={v.nftCard}>
         <div className={v.nftTitle}>{t("nftDetails")}</div>
         <div className={v.nftRow}>
-          <span className={v.nftLabel}>{t("mintAddress")}</span>
+          <span className={v.nftLabel}>{t("issuer")}</span>
+          <span className={v.nftValue}>{CREDENTIAL_ISSUER_NAME}</span>
+        </div>
+        <div className={v.nftRow}>
+          <span className={v.nftLabel}>{t("credentialId")}</span>
           <CopyableValue
             value={truncateAddress(mintAddress)}
             full={mintAddress}
           />
         </div>
+        {courseVersion !== null && (
+          <div className={v.nftRow}>
+            <span className={v.nftLabel}>{t("courseVersion")}</span>
+            <span className={v.nftValue}>{courseVersion}</span>
+          </div>
+        )}
         <div className={v.nftRow}>
           <span className={v.nftLabel}>{t("metadataUri")}</span>
           <CopyableValue
@@ -274,16 +294,14 @@ export default function CertificateViewPage() {
         </div>
         <div className={v.nftRow}>
           <span className={v.nftLabel}>{t("network")}</span>
-          <span className={v.nftValue}>
-            {network.charAt(0).toUpperCase() + network.slice(1)}
-          </span>
+          <span className={v.nftValue}>{networkLabel}</span>
         </div>
         <div className={v.nftRow}>
           <span className={v.nftLabel}>{t("standard")}</span>
-          <span className={v.nftValue}>Metaplex Core</span>
+          <span className={v.nftValue}>{t("standardValue")}</span>
         </div>
         <div className={v.nftRow}>
-          <span className={v.nftLabel}>{t("collection")}</span>
+          <span className={v.nftLabel}>{t("collectionLabel")}</span>
           <span className={v.nftValue}>{t("collection")}</span>
         </div>
       </div>

--- a/apps/web/src/components/certificates/certificate-card.tsx
+++ b/apps/web/src/components/certificates/certificate-card.tsx
@@ -2,6 +2,7 @@
 
 import { useTranslations } from "next-intl";
 import type { Certificate } from "@superteam-lms/types";
+import { resolveSolanaNetwork } from "@/lib/solana/network";
 import { CERTIFICATE_STYLES as CS, cx } from "@/lib/styles/styleClasses";
 import { truncateAddress } from "@/lib/utils";
 import { ProofPill } from "@/components/ui/proof-pill";
@@ -28,8 +29,7 @@ export function CertificateCard({
   const isCompact = variant === "compact";
   const wrapClass = isCompact ? CS.compact.wrap : CS.wrap;
 
-  const network = process.env.NEXT_PUBLIC_SOLANA_NETWORK ?? "devnet";
-  const cluster = network === "mainnet" ? "mainnet-beta" : network;
+  const { cluster, label: networkLabel } = resolveSolanaNetwork();
 
   return (
     <div className={cx(wrapClass, className)}>
@@ -91,7 +91,7 @@ export function CertificateCard({
               </div>
             )}
             <div className={CS.network}>
-              Solana {cluster.charAt(0).toUpperCase() + cluster.slice(1)}
+              {t("networkFooter", { network: networkLabel })}
             </div>
           </div>
         </div>

--- a/apps/web/src/lib/credentials/__tests__/metadata.test.ts
+++ b/apps/web/src/lib/credentials/__tests__/metadata.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { extractCourseVersion, fetchCourseVersion } from "../metadata";
+
+function metadataWithAttributes(attributes: unknown): unknown {
+  return { name: "Solana 101", attributes };
+}
+
+describe("extractCourseVersion — #497 Course Version stamp", () => {
+  it("extracts the stamped numeric version", () => {
+    const metadata = metadataWithAttributes([
+      { trait_type: "Course", value: "Solana 101" },
+      { trait_type: "Course Version", value: 3 },
+    ]);
+    expect(extractCourseVersion(metadata)).toBe(3);
+  });
+
+  it("tolerates a stringified number in externally pinned JSON", () => {
+    const metadata = metadataWithAttributes([
+      { trait_type: "Course Version", value: "2" },
+    ]);
+    expect(extractCourseVersion(metadata)).toBe(2);
+  });
+
+  it("is absent-safe for pre-#497 credentials (no attribute)", () => {
+    const metadata = metadataWithAttributes([
+      { trait_type: "Course", value: "Solana 101" },
+    ]);
+    expect(extractCourseVersion(metadata)).toBeNull();
+  });
+
+  it("returns null for malformed shapes rather than throwing", () => {
+    expect(extractCourseVersion(null)).toBeNull();
+    expect(extractCourseVersion("not-json-object")).toBeNull();
+    expect(extractCourseVersion({})).toBeNull();
+    expect(extractCourseVersion(metadataWithAttributes("nope"))).toBeNull();
+    expect(extractCourseVersion(metadataWithAttributes([null, 7]))).toBeNull();
+    expect(
+      extractCourseVersion(
+        metadataWithAttributes([{ trait_type: "Course Version", value: "v3" }])
+      )
+    ).toBeNull();
+    expect(
+      extractCourseVersion(
+        metadataWithAttributes([{ trait_type: "Course Version", value: NaN }])
+      )
+    ).toBeNull();
+  });
+});
+
+describe("fetchCourseVersion — best-effort metadata read", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function stubFetch(response: Partial<Response>) {
+    const mock = vi.fn(
+      async (_input: string, _init?: RequestInit) => response as Response
+    );
+    vi.stubGlobal("fetch", mock);
+    return mock;
+  }
+
+  it("resolves the version from the metadata URI", async () => {
+    const mock = stubFetch({
+      ok: true,
+      json: async () =>
+        metadataWithAttributes([{ trait_type: "Course Version", value: 1 }]),
+    });
+    await expect(
+      fetchCourseVersion("https://gateway.irys.xyz/abc")
+    ).resolves.toBe(1);
+    expect(mock).toHaveBeenCalledTimes(1);
+    expect(mock.mock.calls[0]?.[0]).toBe("https://gateway.irys.xyz/abc");
+  });
+
+  it("returns null without fetching when the URI is empty", async () => {
+    const mock = stubFetch({ ok: true, json: async () => ({}) });
+    await expect(fetchCourseVersion("")).resolves.toBeNull();
+    expect(mock).not.toHaveBeenCalled();
+  });
+
+  it("returns null on a non-ok response", async () => {
+    stubFetch({ ok: false, json: async () => ({}) });
+    await expect(fetchCourseVersion("https://x/404")).resolves.toBeNull();
+  });
+
+  it("returns null on network failure (e.g. CORS-blocked cross-origin)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new TypeError("Failed to fetch");
+      })
+    );
+    await expect(fetchCourseVersion("https://x/blocked")).resolves.toBeNull();
+  });
+
+  it("returns null on invalid JSON", async () => {
+    stubFetch({
+      ok: true,
+      json: async () => {
+        throw new SyntaxError("Unexpected token");
+      },
+    });
+    await expect(fetchCourseVersion("https://x/not-json")).resolves.toBeNull();
+  });
+});

--- a/apps/web/src/lib/credentials/metadata.ts
+++ b/apps/web/src/lib/credentials/metadata.ts
@@ -1,0 +1,75 @@
+/**
+ * Credential metadata helpers (LX-E5).
+ *
+ * #497 stamps the live on-chain `Course.version` into the credential NFT
+ * metadata at mint time as the "Course Version" attribute
+ * (app/api/certificates/mint/route.ts). It is NOT a `certificates` table
+ * column — the only place it lives off-chain is the metadata JSON (Arweave
+ * gateway URL or the app-served /api/certificates/metadata fallback), so the
+ * verify page reads it back from the credential's `metadata_uri`.
+ *
+ * Credentials minted before #497 have no such attribute; every reader here is
+ * absent-safe and resolves to `null` rather than throwing.
+ */
+
+const COURSE_VERSION_TRAIT = "Course Version";
+
+interface MetadataAttribute {
+  trait_type: string;
+  value: unknown;
+}
+
+function isMetadataAttribute(entry: unknown): entry is MetadataAttribute {
+  return (
+    typeof entry === "object" &&
+    entry !== null &&
+    "trait_type" in entry &&
+    typeof (entry as { trait_type: unknown }).trait_type === "string"
+  );
+}
+
+/**
+ * Extracts the stamped course version from credential metadata JSON.
+ * Returns `null` for pre-#497 credentials or malformed metadata.
+ */
+export function extractCourseVersion(metadata: unknown): number | null {
+  if (typeof metadata !== "object" || metadata === null) return null;
+  const { attributes } = metadata as { attributes?: unknown };
+  if (!Array.isArray(attributes)) return null;
+
+  const attribute = attributes
+    .filter(isMetadataAttribute)
+    .find((entry) => entry.trait_type === COURSE_VERSION_TRAIT);
+  if (!attribute) return null;
+
+  const { value } = attribute;
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  // Defensive: tolerate a stringified number in externally pinned JSON.
+  if (typeof value === "string" && /^\d+$/.test(value)) return Number(value);
+  return null;
+}
+
+/**
+ * Fetches the credential metadata JSON and extracts the course version.
+ * Best-effort by design: any network/CORS/parse failure yields `null` so the
+ * verify page simply omits the row (absent-safe for legacy credentials and
+ * unreachable gateways alike).
+ */
+export async function fetchCourseVersion(
+  metadataUri: string
+): Promise<number | null> {
+  if (!metadataUri) return null;
+  try {
+    // Bounded so a slow Arweave gateway can only delay the page, not hang it.
+    const signal =
+      typeof AbortSignal.timeout === "function"
+        ? AbortSignal.timeout(5_000)
+        : undefined;
+    const response = await fetch(metadataUri, { signal });
+    if (!response.ok) return null;
+    const metadata: unknown = await response.json();
+    return extractCourseVersion(metadata);
+  } catch {
+    return null;
+  }
+}

--- a/apps/web/src/lib/solana/__tests__/network.test.ts
+++ b/apps/web/src/lib/solana/__tests__/network.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeEach, afterAll } from "vitest";
+import { resolveSolanaNetwork } from "../network";
+
+const ORIGINAL = process.env.NEXT_PUBLIC_SOLANA_NETWORK;
+
+beforeEach(() => {
+  delete process.env.NEXT_PUBLIC_SOLANA_NETWORK;
+});
+
+afterAll(() => {
+  if (ORIGINAL === undefined) {
+    delete process.env.NEXT_PUBLIC_SOLANA_NETWORK;
+  } else {
+    process.env.NEXT_PUBLIC_SOLANA_NETWORK = ORIGINAL;
+  }
+});
+
+describe("resolveSolanaNetwork", () => {
+  it("defaults to devnet when the env var is unset", () => {
+    expect(resolveSolanaNetwork()).toEqual({
+      network: "devnet",
+      cluster: "devnet",
+      label: "Devnet",
+    });
+  });
+
+  it("reads NEXT_PUBLIC_SOLANA_NETWORK at call time", () => {
+    process.env.NEXT_PUBLIC_SOLANA_NETWORK = "devnet";
+    expect(resolveSolanaNetwork().label).toBe("Devnet");
+    process.env.NEXT_PUBLIC_SOLANA_NETWORK = "testnet";
+    expect(resolveSolanaNetwork().label).toBe("Testnet");
+  });
+
+  it('maps "mainnet" to the explorer cluster "mainnet-beta" with a clean label', () => {
+    process.env.NEXT_PUBLIC_SOLANA_NETWORK = "mainnet";
+    expect(resolveSolanaNetwork()).toEqual({
+      network: "mainnet",
+      cluster: "mainnet-beta",
+      label: "Mainnet",
+    });
+  });
+});

--- a/apps/web/src/lib/solana/network.ts
+++ b/apps/web/src/lib/solana/network.ts
@@ -1,0 +1,22 @@
+/**
+ * Solana network identity, resolved from `NEXT_PUBLIC_SOLANA_NETWORK`
+ * (devnet default — mirrors the inline convention used across pages).
+ */
+export interface SolanaNetworkInfo {
+  /** Raw env value, e.g. "devnet" | "mainnet". */
+  network: string;
+  /** Explorer `?cluster=` value — "mainnet" maps to "mainnet-beta". */
+  cluster: string;
+  /** Capitalized display label, e.g. "Devnet" | "Mainnet". */
+  label: string;
+}
+
+/** Read at call time (not module scope) so tests and previews can override. */
+export function resolveSolanaNetwork(): SolanaNetworkInfo {
+  const network = process.env.NEXT_PUBLIC_SOLANA_NETWORK ?? "devnet";
+  return {
+    network,
+    cluster: network === "mainnet" ? "mainnet-beta" : network,
+    label: network.charAt(0).toUpperCase() + network.slice(1),
+  };
+}

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -357,7 +357,14 @@
     "shareXText": "I just earned my \"{courseTitle}\" certificate on @SuperteamBR Academy! 🎓\n\nVerify on-chain:",
     "addToLinkedIn": "Add to your LinkedIn profile",
     "shareNudgeTitle": "Show off your credential",
-    "opensInNewTab": "opens in a new tab"
+    "opensInNewTab": "opens in a new tab",
+    "recipientFallback": "Builder",
+    "issuer": "Issuer",
+    "credentialId": "Credential ID",
+    "courseVersion": "Course Version",
+    "collectionLabel": "Collection",
+    "standardValue": "Metaplex Core",
+    "networkFooter": "Solana {network}"
   },
   "earnHandoff": {
     "title": "Turn your credential into paid work",

--- a/apps/web/src/messages/es.json
+++ b/apps/web/src/messages/es.json
@@ -357,7 +357,14 @@
     "shareXText": "¡Acabo de obtener mi certificado de \"{courseTitle}\" en @SuperteamBR Academy! 🎓\n\nVerifícalo on-chain:",
     "addToLinkedIn": "Añadir a tu perfil de LinkedIn",
     "shareNudgeTitle": "Muestra tu credencial",
-    "opensInNewTab": "se abre en una pestaña nueva"
+    "opensInNewTab": "se abre en una pestaña nueva",
+    "recipientFallback": "Builder",
+    "issuer": "Emisor",
+    "credentialId": "ID de la Credencial",
+    "courseVersion": "Versión del Curso",
+    "collectionLabel": "Colección",
+    "standardValue": "Metaplex Core",
+    "networkFooter": "Solana {network}"
   },
   "earnHandoff": {
     "title": "Convierte tu credencial en trabajo pagado",

--- a/apps/web/src/messages/pt-BR.json
+++ b/apps/web/src/messages/pt-BR.json
@@ -357,7 +357,14 @@
     "shareXText": "Acabei de conquistar meu certificado de \"{courseTitle}\" na @SuperteamBR Academy! 🎓\n\nVerifique on-chain:",
     "addToLinkedIn": "Adicionar ao seu perfil do LinkedIn",
     "shareNudgeTitle": "Mostre sua credencial",
-    "opensInNewTab": "abre em uma nova aba"
+    "opensInNewTab": "abre em uma nova aba",
+    "recipientFallback": "Builder",
+    "issuer": "Emissor",
+    "credentialId": "ID da Credencial",
+    "courseVersion": "Versão do Curso",
+    "collectionLabel": "Coleção",
+    "standardValue": "Metaplex Core",
+    "networkFooter": "Solana {network}"
   },
   "earnHandoff": {
     "title": "Transforme sua credencial em trabalho pago",


### PR DESCRIPTION
Closes #554

Task **LX-E5** (master spec §3). Composes with #629 (X-share text + Add-to-Profile already externalized on main — untouched here).

## What changed

### 1. Course version surfaced (the #497 stamp)
- **Where the stamp lives:** `/api/certificates/mint` writes `{ trait_type: "Course Version", value: onChainCourse.version }` into the credential **metadata JSON** (stored in `nft_metadata`, served by `/api/certificates/metadata`, and/or pinned to Arweave). It is **not** a `certificates` table column — the metadata is its only off-chain home.
- **How surfaced:** new `lib/credentials/metadata.ts` — `fetchCourseVersion(metadataUri)` fetches the cert's `metadata_uri` (timeout-bounded, best-effort) and `extractCourseVersion()` pulls the attribute. The verify page renders a labeled "Course Version" row **only when present** — absent-safe for pre-#497 credentials and unreachable gateways.

### 2. Network label from env
- `network: "devnet"` hardcode replaced by new `lib/solana/network.ts` → `resolveSolanaNetwork()` reading `NEXT_PUBLIC_SOLANA_NETWORK` (devnet default, matching the codebase convention).
- Explorer links now map `mainnet` → `?cluster=mainnet-beta` (the bare `?cluster=mainnet` the old code would have produced on mainnet is invalid).
- `CertificateCard` reuses the helper (was duplicating the env read inline) — its footer now shows "Solana Mainnet" instead of "Solana Mainnet-beta" on mainnet.

### 3. i18n sweep — literals found + fixed (×3 locales)
| Literal | Fix |
|---|---|
| `recipientName ?? "Builder"` | `certificates.recipientFallback` — data layer now returns `null`, UI resolves via catalog ("Builder" kept as the value in all 3 — it's the community-standard term in PT-BR/ES Superteam contexts, now locale-controllable) |
| `Metaplex Core` (standard row value) | `certificates.standardValue` |
| Collection row label reused the collection **name** key (`t("collection")` as both label and value) | new `certificates.collectionLabel` ("Collection"/"Coleção"/"Colección"); `collection` stays the name value |
| `Solana {cluster}` footer in `CertificateCard` | `certificates.networkFooter` |

The issuer row value uses the exported `CREDENTIAL_ISSUER_NAME` constant (not a message) deliberately: it must mirror the on-chain `Platform` metadata attribute and the LinkedIn `organizationName` byte-for-byte across locales.

### 4. Credential anatomy (F35)
NFT-details card now reads: **Issuer** → **Credential ID** (copyable mint address — the unique ID; the mint address also stays visible on the card itself under its "Mint Address" label) → **Course Version** (when stamped) → Metadata URI → Network → Standard → Collection. All labels via next-intl; copy affordances and sr-only/a11y behavior unchanged.

## Explicitly not done (per issue)
- **`/credential/[id]` redirect alias** — skipped; locale-aware redirect via the i18n routing layer isn't a one-liner and adds route-collision review surface for no launch value.
- **is_public privacy edge (owner decision D-7), note only:** confirmed the silent-404. `certificates` RLS grants public SELECT only when the owner's `profiles.is_public = true`; when it's false the anon query returns zero rows, the page's `.single()` errors, and the shared verify link renders generic "Certificate not found" — indistinguishable from a nonexistent cert. No code touched.

## Out-of-scope findings
- The `subtitle` (learning path · difficulty) is content-bundle English capitalized in code on both cert pages — content data, not UI copy; left alone.
- `certificates.mint`/`onChain` keys are untranslated across locales (pre-existing, off-surface).

## Verification
- `pnpm typecheck` — clean
- `pnpm test` — **117 files / 1082 tests passed** (20 new: metadata extract/fetch, network resolution, page anatomy/absent-safe/env-network/localized-fallback)
- `pnpm lint` — exit 0 (pre-existing import-order warnings only)
- Prettier clean on all changed files