### PR TITLE
feat(analytics): event pass — credential_minted, challenge lifecycle, funnel naming (LX-F1)

### DIFF
--- a/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/blocks/code-block.tsx
+++ b/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/blocks/code-block.tsx
@@ -64,6 +64,7 @@ export function CodeBlock({ block, ctx }: BlockRenderProps) {
       <div className="flex w-full flex-col overflow-hidden lg:h-[calc(100vh-150px)]">
         <ChallengeInterface
           lessonId={ctx.lesson._id}
+          courseId={ctx.courseId}
           courseSlug={ctx.courseSlug}
           lessonSlug={ctx.lesson.slug}
           taskSlot={taskSlot}

--- a/apps/web/src/components/certificates/__tests__/course-completion-mint.events.test.tsx
+++ b/apps/web/src/components/certificates/__tests__/course-completion-mint.events.test.tsx
@@ -1,0 +1,135 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import { CourseCompletionMint } from "../course-completion-mint";
+import {
+  resetAnalyticsEventDedupeForTests,
+  trackCredentialMinted,
+} from "@/lib/analytics/events";
+import messages from "@/messages/en.json";
+
+// Real events module between component and facade — asserts the wire format
+// AND the cross-path dedupe with the Realtime observation.
+const h = vi.hoisted(() => ({
+  trackEvent: vi.fn(),
+  celebrate: vi.fn(),
+  db: {
+    certificate: null as Record<string, unknown> | null,
+    progressCount: 0,
+    profile: {
+      wallet_address: "test-wallet",
+      username: "learner",
+    } as Record<string, unknown> | null,
+  },
+}));
+
+vi.mock("@/lib/analytics", () => ({ trackEvent: h.trackEvent }));
+vi.mock("@/lib/gamification/celebration", () => ({ celebrate: h.celebrate }));
+vi.mock("../earn-handoff-card", () => ({ EarnHandoffCard: () => null }));
+vi.mock("../credential-share-nudge", () => ({
+  CredentialShareNudge: () => null,
+}));
+
+vi.mock("@/lib/supabase/client", () => ({
+  createClient: () => ({
+    from: (table: string) => {
+      const query = {
+        select: () => query,
+        eq: () => query,
+        maybeSingle: () =>
+          Promise.resolve({
+            data: table === "certificates" ? h.db.certificate : null,
+          }),
+        single: () =>
+          Promise.resolve({
+            data: table === "profiles" ? h.db.profile : null,
+          }),
+        then: (
+          resolve: (value: { data: unknown[]; count: number }) => unknown
+        ) => resolve({ data: [], count: h.db.progressCount }),
+      };
+      return query;
+    },
+  }),
+}));
+
+function renderMint() {
+  return render(
+    <NextIntlClientProvider locale="en" messages={messages}>
+      <CourseCompletionMint
+        courseId="course-solana-101"
+        userId="user-1"
+        totalLessons={3}
+      />
+    </NextIntlClientProvider>
+  );
+}
+
+beforeEach(() => {
+  h.trackEvent.mockClear();
+  h.celebrate.mockClear();
+  h.db.certificate = null;
+  h.db.progressCount = 3;
+  resetAnalyticsEventDedupeForTests();
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => ({ ok: true, json: async () => ({}) }))
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("CourseCompletionMint — credential_minted (manual mint path)", () => {
+  it("fires credential_minted with courseId on manual mint success", async () => {
+    renderMint();
+    const mintButton = await screen.findByRole("button", {
+      name: "Mint Certificate",
+    });
+    expect(h.trackEvent).not.toHaveBeenCalled();
+
+    fireEvent.click(mintButton);
+
+    await waitFor(() =>
+      expect(h.trackEvent).toHaveBeenCalledWith("credential_minted", {
+        courseId: "course-solana-101",
+        source: "manual_mint",
+      })
+    );
+    expect(h.trackEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not double-fire when the Realtime INSERT observes the same mint", async () => {
+    renderMint();
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Mint Certificate" })
+    );
+    await waitFor(() => expect(h.trackEvent).toHaveBeenCalledTimes(1));
+
+    // The Supabase Realtime certificates-INSERT path lands moments later
+    // (use-gamification-events.ts) — same course, same mint.
+    trackCredentialMinted("course-solana-101", "realtime");
+
+    expect(h.trackEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fire when the mint API rejects", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: false,
+        status: 500,
+        json: async () => ({ error: "Minting failed" }),
+      }))
+    );
+    renderMint();
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Mint Certificate" })
+    );
+
+    await screen.findByText(/Minting failed/);
+    expect(h.trackEvent).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/certificates/course-completion-mint.tsx
+++ b/apps/web/src/components/certificates/course-completion-mint.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import { GraduationCap, CheckCircle, Wallet } from "@phosphor-icons/react";
 import { EarnHandoffCard } from "./earn-handoff-card";
 import { CredentialShareNudge } from "./credential-share-nudge";
+import { trackCredentialMinted } from "@/lib/analytics/events";
 import { celebrate } from "@/lib/gamification/celebration";
 import { createClient } from "@/lib/supabase/client";
 
@@ -141,6 +142,9 @@ export function CourseCompletionMint({
         });
         return;
       }
+      // credential_minted baseline (LX-F1) — trackCredentialMinted() dedupes
+      // against the Realtime certificate-INSERT observation of the same mint.
+      trackCredentialMinted(courseId, "manual_mint");
       // Full celebration on a fresh mint (LX-B11) — celebrate() dedupes
       // against the Realtime certificate-INSERT popup firing the same moment.
       celebrate("credential-mint");

--- a/apps/web/src/components/editor/__tests__/challenge-interface.events.test.tsx
+++ b/apps/web/src/components/editor/__tests__/challenge-interface.events.test.tsx
@@ -1,0 +1,193 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, beforeAll } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import { ChallengeInterface } from "../challenge-interface";
+import type { ChallengeRunnerProps, ExecutionResult } from "../types";
+import { resetAnalyticsEventDedupeForTests } from "@/lib/analytics/events";
+import messages from "@/messages/en.json";
+
+// The events module (REAL, with its dedupe) sits between the component and the
+// facade — mocking only the facade asserts the true wire format end-to-end.
+const h = vi.hoisted(() => ({
+  trackEvent: vi.fn(),
+  runnerProps: null as { onResult: (result: unknown) => void } | null,
+}));
+
+vi.mock("@/lib/analytics", () => ({ trackEvent: h.trackEvent }));
+
+vi.mock("../code-editor", async () => {
+  const React = await import("react");
+  return {
+    CodeEditor: React.forwardRef(function MockCodeEditor() {
+      return React.createElement("textarea", { "data-testid": "editor" });
+    }),
+    resetEditorStorage: vi.fn(),
+  };
+});
+
+vi.mock("../challenge-runner", async () => {
+  const React = await import("react");
+  return {
+    ChallengeRunner: (props: ChallengeRunnerProps) => {
+      h.runnerProps = {
+        onResult: props.onResult as (result: unknown) => void,
+      };
+      return React.createElement("div", { "data-testid": "runner" });
+    },
+  };
+});
+
+vi.mock("../ai-partner/ai-partner-pane", () => ({
+  AiPartnerPane: () => null,
+}));
+
+vi.mock("../output-panel", () => ({
+  OutputPanel: () => null,
+}));
+
+beforeAll(() => {
+  // jsdom has no IntersectionObserver (AI-partner reveal sentinel)
+  class MockIntersectionObserver {
+    observe(): void {}
+    unobserve(): void {}
+    disconnect(): void {}
+  }
+  Object.defineProperty(globalThis, "IntersectionObserver", {
+    writable: true,
+    configurable: true,
+    value: MockIntersectionObserver,
+  });
+});
+
+beforeEach(() => {
+  h.trackEvent.mockClear();
+  h.runnerProps = null;
+  resetAnalyticsEventDedupeForTests();
+});
+
+function renderChallenge(
+  overrides: Partial<Parameters<typeof ChallengeInterface>[0]> = {}
+) {
+  return render(
+    <NextIntlClientProvider locale="en" messages={messages}>
+      <ChallengeInterface
+        lessonId="lesson-1"
+        courseId="course-1"
+        courseSlug="solana-101"
+        lessonSlug="first-challenge"
+        initialCode="// starter"
+        language="typescript"
+        tests={[]}
+        hints={[]}
+        xpReward={50}
+        {...overrides}
+      />
+    </NextIntlClientProvider>
+  );
+}
+
+const failResult: ExecutionResult = {
+  success: false,
+  output: "",
+  testResults: [],
+};
+const passResult: ExecutionResult = {
+  success: true,
+  output: "",
+  testResults: [],
+};
+
+const expectedCtx = {
+  lessonId: "lesson-1",
+  challengeKind: "js",
+  courseId: "course-1",
+};
+
+describe("ChallengeInterface — challenge lifecycle events (LX-F1)", () => {
+  it("fires challenge_started once on the first editor keystroke, never on render", () => {
+    renderChallenge();
+    expect(h.trackEvent).not.toHaveBeenCalled();
+
+    fireEvent.keyDown(screen.getByTestId("editor"), { key: "a" });
+    fireEvent.keyDown(screen.getByTestId("editor"), { key: "b" });
+
+    expect(h.trackEvent).toHaveBeenCalledTimes(1);
+    expect(h.trackEvent).toHaveBeenCalledWith("challenge_started", expectedCtx);
+  });
+
+  it("covers run-first learners: first result fires started then run", () => {
+    renderChallenge();
+    act(() => h.runnerProps?.onResult(passResult));
+
+    const names = h.trackEvent.mock.calls.map((c) => c[0] as string);
+    expect(names).toEqual([
+      "challenge_started",
+      "challenge_run",
+      "challenge_solved",
+    ]);
+  });
+
+  it("fires challenge_run + challenge_failed per failing run with an escalating streak", () => {
+    renderChallenge();
+    fireEvent.keyDown(screen.getByTestId("editor"), { key: "a" });
+    act(() => h.runnerProps?.onResult(failResult));
+    act(() => h.runnerProps?.onResult(failResult));
+
+    expect(h.trackEvent).toHaveBeenCalledWith("challenge_run", expectedCtx);
+    expect(h.trackEvent).toHaveBeenCalledWith("challenge_failed", {
+      ...expectedCtx,
+      consecutiveFails: 1,
+    });
+    expect(h.trackEvent).toHaveBeenCalledWith("challenge_failed", {
+      ...expectedCtx,
+      consecutiveFails: 2,
+    });
+  });
+
+  it("fires challenge_solved on a passing run and resets the fail streak", () => {
+    renderChallenge();
+    act(() => h.runnerProps?.onResult(failResult));
+    act(() => h.runnerProps?.onResult(passResult));
+    act(() => h.runnerProps?.onResult(failResult));
+
+    expect(h.trackEvent).toHaveBeenCalledWith("challenge_solved", expectedCtx);
+    // Streak restarted at 1 after the solve, not 2
+    const failCalls = h.trackEvent.mock.calls.filter(
+      (c) => c[0] === "challenge_failed"
+    );
+    expect(failCalls.map((c) => c[1])).toEqual([
+      { ...expectedCtx, consecutiveFails: 1 },
+      { ...expectedCtx, consecutiveFails: 1 },
+    ]);
+  });
+
+  it("derives challengeKind buildable for rust build challenges", () => {
+    renderChallenge({ language: "rust", buildType: "buildable" });
+    act(() => h.runnerProps?.onResult(passResult));
+
+    expect(h.trackEvent).toHaveBeenCalledWith("challenge_run", {
+      lessonId: "lesson-1",
+      challengeKind: "buildable",
+      courseId: "course-1",
+    });
+  });
+
+  it("keeps payloads lean — no code content, no PII keys", () => {
+    renderChallenge();
+    fireEvent.keyDown(screen.getByTestId("editor"), { key: "a" });
+    act(() => h.runnerProps?.onResult(failResult));
+
+    const allowed = new Set([
+      "lessonId",
+      "courseId",
+      "challengeKind",
+      "consecutiveFails",
+    ]);
+    for (const [, payload] of h.trackEvent.mock.calls) {
+      for (const key of Object.keys(payload as Record<string, unknown>)) {
+        expect(allowed.has(key)).toBe(true);
+      }
+    }
+  });
+});

--- a/apps/web/src/components/editor/challenge-interface.tsx
+++ b/apps/web/src/components/editor/challenge-interface.tsx
@@ -19,6 +19,13 @@ import type {
   CodeEditorHandle,
   ExecutionResult,
 } from "./types";
+import {
+  challengeKindFor,
+  trackChallengeFailed,
+  trackChallengeRun,
+  trackChallengeSolved,
+  trackChallengeStarted,
+} from "@/lib/analytics/events";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { shouldShowEncouragement } from "@/lib/gamification/celebration";
@@ -47,6 +54,7 @@ function summarize(executionResult: ExecutionResult | null): string {
 
 export function ChallengeInterface({
   lessonId,
+  courseId,
   courseSlug,
   lessonSlug,
   taskSlot,
@@ -87,7 +95,30 @@ export function ChallengeInterface({
   const [consecutiveFails, setConsecutiveFails] = useState(0);
   const [encouragementDismissed, setEncouragementDismissed] = useState(false);
 
+  // Analytics (LX-F1): challenge lifecycle events compose alongside the
+  // existing state. The fail streak is mirrored in a ref because the state
+  // above updates functionally (no synchronous read at event time), and side
+  // effects inside state updaters would double-fire under StrictMode.
+  const challengeKind = challengeKindFor(language, buildType);
+  const failStreakRef = useRef(0);
+
   const editorHandle = useRef<CodeEditorHandle>(null);
+  const editorAreaRef = useRef<HTMLDivElement>(null);
+
+  // challenge_started = first genuine interaction, never a page view. A
+  // keystroke in the editor area is that signal for edit-first learners
+  // (CodeEditor's onChange also fires for the localStorage restore on mount,
+  // so it can't be used); run-first learners are covered in handleResult.
+  // trackChallengeStarted dedupes per lesson per session.
+  useEffect(() => {
+    const el = editorAreaRef.current;
+    if (!el) return;
+    const fireStarted = () =>
+      trackChallengeStarted({ lessonId, courseId, challengeKind });
+    el.addEventListener("keydown", fireStarted, { capture: true });
+    return () =>
+      el.removeEventListener("keydown", fireStarted, { capture: true });
+  }, [lessonId, courseId, challengeKind]);
 
   // Sync when the async DB check resolves after mount.
   // Also fires when lesson-client sets isCompleted=true after API returns —
@@ -139,19 +170,31 @@ export function ChallengeInterface({
     setServerError(null);
   }, []);
 
-  const handleResult = useCallback((result: ExecutionResult) => {
-    setChallengeState((prev) => ({
-      ...prev,
-      status: result.success ? "success" : "error",
-      executionResult: result,
-    }));
-    if (result.success) {
-      setConsecutiveFails(0);
-      setEncouragementDismissed(false);
-    } else {
-      setConsecutiveFails((prev) => prev + 1);
-    }
-  }, []);
+  const handleResult = useCallback(
+    (result: ExecutionResult) => {
+      setChallengeState((prev) => ({
+        ...prev,
+        status: result.success ? "success" : "error",
+        executionResult: result,
+      }));
+      // Lifecycle events (LX-F1): a run reaching a result IS an interaction,
+      // so run-first learners get their challenge_started here (deduped).
+      const ctx = { lessonId, courseId, challengeKind };
+      trackChallengeStarted(ctx);
+      trackChallengeRun(ctx);
+      if (result.success) {
+        failStreakRef.current = 0;
+        trackChallengeSolved(ctx);
+        setConsecutiveFails(0);
+        setEncouragementDismissed(false);
+      } else {
+        failStreakRef.current += 1;
+        trackChallengeFailed(ctx, failStreakRef.current);
+        setConsecutiveFails((prev) => prev + 1);
+      }
+    },
+    [lessonId, courseId, challengeKind]
+  );
 
   const handleClearOutput = useCallback(() => {
     setChallengeState((prev) => ({
@@ -397,7 +440,7 @@ export function ChallengeInterface({
           </div>
 
           {/* Editor */}
-          <div className="relative min-h-0 flex-1">
+          <div ref={editorAreaRef} className="relative min-h-0 flex-1">
             <CodeEditor
               ref={editorHandle}
               lessonId={lessonId}

--- a/apps/web/src/components/editor/types.ts
+++ b/apps/web/src/components/editor/types.ts
@@ -65,6 +65,8 @@ export interface ChallengeRunnerProps {
 
 export interface ChallengeInterfaceProps {
   lessonId: string;
+  /** Content id of the parent course — analytics only (challenge lifecycle events). */
+  courseId?: string;
   /** Sanity slug of the parent course — threaded to the AI Partner route. */
   courseSlug: string;
   /** Sanity slug of this lesson — threaded to the AI Partner route. */

--- a/apps/web/src/hooks/__tests__/use-gamification-events.test.tsx
+++ b/apps/web/src/hooks/__tests__/use-gamification-events.test.tsx
@@ -1,0 +1,115 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useGamificationEvents } from "../use-gamification-events";
+import {
+  resetAnalyticsEventDedupeForTests,
+  trackCredentialMinted,
+} from "@/lib/analytics/events";
+
+// Real events module between hook and facade — asserts the wire format AND
+// the cross-path dedupe with the manual-mint observation.
+const h = vi.hoisted(() => ({
+  trackEvent: vi.fn(),
+  dispatchCertificateMinted: vi.fn(),
+  handlers: new Map<string, (payload: unknown) => void>(),
+}));
+
+vi.mock("@/lib/analytics", () => ({ trackEvent: h.trackEvent }));
+
+vi.mock("@/components/gamification/achievement-popup", () => ({
+  dispatchAchievementUnlock: vi.fn(),
+  dispatchAchievementXp: vi.fn(),
+}));
+vi.mock("@/components/gamification/certificate-popup", () => ({
+  dispatchCertificateMinted: h.dispatchCertificateMinted,
+}));
+vi.mock("@/components/gamification/level-up-popup", () => ({
+  dispatchLevelUp: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase/client", () => ({
+  createClient: () => {
+    const channel = {
+      on: (
+        _type: string,
+        filter: { table: string; event: string },
+        callback: (payload: unknown) => void
+      ) => {
+        h.handlers.set(`${filter.table}:${filter.event}`, callback);
+        return channel;
+      },
+      subscribe: () => channel,
+    };
+    return {
+      from: () => ({
+        select: () => ({
+          eq: () => ({
+            maybeSingle: () => Promise.resolve({ data: null }),
+          }),
+        }),
+      }),
+      channel: () => channel,
+      removeChannel: vi.fn(),
+    };
+  },
+}));
+
+function certInsert(id: string, courseId: string): unknown {
+  return { new: { id, course_id: courseId, user_id: "user-1" } };
+}
+
+beforeEach(() => {
+  h.trackEvent.mockClear();
+  h.dispatchCertificateMinted.mockClear();
+  h.handlers.clear();
+  resetAnalyticsEventDedupeForTests();
+});
+
+describe("useGamificationEvents — credential_minted (Realtime INSERT path)", () => {
+  it("fires credential_minted with the row's course id on a certificates INSERT", () => {
+    renderHook(() => useGamificationEvents("user-1"));
+    const onCertInsert = h.handlers.get("certificates:INSERT");
+    expect(onCertInsert).toBeDefined();
+
+    act(() => onCertInsert?.(certInsert("cert-1", "course-solana-101")));
+
+    expect(h.trackEvent).toHaveBeenCalledTimes(1);
+    expect(h.trackEvent).toHaveBeenCalledWith("credential_minted", {
+      courseId: "course-solana-101",
+      source: "realtime",
+    });
+    expect(h.dispatchCertificateMinted).toHaveBeenCalledWith("cert-1");
+  });
+
+  it("ignores Realtime replays of the same row", () => {
+    renderHook(() => useGamificationEvents("user-1"));
+    const onCertInsert = h.handlers.get("certificates:INSERT");
+
+    act(() => onCertInsert?.(certInsert("cert-1", "course-solana-101")));
+    act(() => onCertInsert?.(certInsert("cert-1", "course-solana-101")));
+
+    expect(h.trackEvent).toHaveBeenCalledTimes(1);
+    expect(h.dispatchCertificateMinted).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not double-fire when the manual mint already observed this mint", () => {
+    renderHook(() => useGamificationEvents("user-1"));
+    const onCertInsert = h.handlers.get("certificates:INSERT");
+
+    // Manual-mint success (course-completion-mint.tsx) fired moments earlier.
+    trackCredentialMinted("course-solana-101", "manual_mint");
+    act(() => onCertInsert?.(certInsert("cert-1", "course-solana-101")));
+
+    const mintEvents = h.trackEvent.mock.calls.filter(
+      (call) => call[0] === "credential_minted"
+    );
+    expect(mintEvents).toHaveLength(1);
+    expect(mintEvents[0]?.[1]).toEqual({
+      courseId: "course-solana-101",
+      source: "manual_mint",
+    });
+    // The popup still shows — only the analytics event is deduped.
+    expect(h.dispatchCertificateMinted).toHaveBeenCalledWith("cert-1");
+  });
+});

--- a/apps/web/src/hooks/use-gamification-events.ts
+++ b/apps/web/src/hooks/use-gamification-events.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef } from "react";
+import { trackCredentialMinted } from "@/lib/analytics/events";
 import { createClient } from "@/lib/supabase/client";
 import {
   dispatchAchievementUnlock,
@@ -157,12 +158,18 @@ export function useGamificationEvents(userId: string | undefined) {
           filter: `user_id=eq.${userId}`,
         },
         (payload) => {
-          const row = payload.new as { id?: string };
+          const row = payload.new as { id?: string; course_id?: string };
           if (!row.id) return;
           if (seenIdsRef.current.has(row.id)) return;
           seenIdsRef.current.add(row.id);
           const certId = row.id;
           setTimeout(() => seenIdsRef.current.delete(certId), 15_000);
+          // credential_minted baseline (LX-F1) — the helper dedupes per
+          // course, so the manual-mint success firing moments earlier (or
+          // later) never double-counts the same mint.
+          if (row.course_id) {
+            trackCredentialMinted(row.course_id, "realtime");
+          }
           dispatchCertificateMinted(certId);
         }
       )

--- a/apps/web/src/lib/analytics/README.md
+++ b/apps/web/src/lib/analytics/README.md
@@ -1,0 +1,66 @@
+# Analytics event naming
+
+Canonical inventory of every product analytics event. All events flow through
+the `trackEvent(name, properties)` facade in `index.ts`, which fans out to GA4
+(`ga4.ts`) and PostHog (`posthog.ts`). Every provider degrades to a silent
+no-op when its `NEXT_PUBLIC_*` env vars are unset — **all analytics env vars
+are optional today**, so events only reach a backend once
+`NEXT_PUBLIC_GA4_MEASUREMENT_ID` / `NEXT_PUBLIC_POSTHOG_KEY` +
+`NEXT_PUBLIC_POSTHOG_HOST` are configured in the deployment.
+
+## Conventions
+
+- **Event names**: `snake_case`, verb in past tense for outcomes
+  (`lesson_completed`), noun_verb for interactions (`earn_handoff_click`).
+- **Payload properties**: `camelCase`, lean, closed-set strings and content
+  ids only.
+- **Zero PII**: never wallet addresses, emails, usernames, or user code
+  content in payloads. Identity is attached via `identifyUser()` (PostHog
+  identify + Sentry user), not via event properties. Transaction signatures
+  (public on-chain data) appear only in the two legacy on-chain events noted
+  below.
+- **Typed helpers**: events with dedupe or shared shapes have helpers in
+  `events.ts` — prefer those over raw `trackEvent` calls at new call sites.
+
+## Active events
+
+| Event                    | Payload                                                                                                         | Fires from                                                                                                                                                                                                        |
+| ------------------------ | --------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `$pageview`              | `{ $current_url }`                                                                                              | `trackPageView()` facade                                                                                                                                                                                          |
+| `auth_method_selected`   | `{ method: "solana" \| "github" \| "google" }`                                                                  | `components/auth/auth-modal.tsx`                                                                                                                                                                                  |
+| `enrollment_onchain`     | `{ courseId, signature }`                                                                                       | `hooks/use-on-chain-enroll.ts` after the enroll tx confirms (tx signature = public chain data)                                                                                                                    |
+| `unenrollment_onchain`   | `{ courseId, signature }`                                                                                       | `hooks/use-on-chain-unenroll.ts` after the unenroll tx confirms                                                                                                                                                   |
+| `lesson_completed`       | `{ lessonId, courseId, signature }`                                                                             | `lessons/[id]/lesson-client.tsx` on completion API success                                                                                                                                                        |
+| `earn_handoff_click`     | `{ category: "development" \| "content" \| "grants", source: "mint_success" \| "certificate_page", courseId? }` | `components/certificates/earn-handoff-card.tsx` (E8, #625)                                                                                                                                                        |
+| `credential_share_click` | `{ channel: "x" \| "linkedin_add", source: "mint_success" \| "certificate_page", courseId? }`                   | `lib/credentials/share.ts` → certificate share surfaces (#629)                                                                                                                                                    |
+| `credential_minted`      | `{ courseId, source: "manual_mint" \| "realtime" }`                                                             | `trackCredentialMinted()` — manual mint success (`course-completion-mint.tsx`) **and** the Realtime certificates INSERT (`use-gamification-events.ts`). Session-deduped per course so one mint = one event (#558) |
+| `challenge_started`      | `{ lessonId, challengeKind, courseId? }`                                                                        | `trackChallengeStarted()` — first genuine interaction with a challenge (first editor keystroke or first run, never a page view); session-deduped per lesson (#558)                                                |
+| `challenge_run`          | `{ lessonId, challengeKind, courseId? }`                                                                        | `trackChallengeRun()` — each execution, any outcome (#558)                                                                                                                                                        |
+| `challenge_failed`       | `{ lessonId, challengeKind, courseId?, consecutiveFails }`                                                      | `trackChallengeFailed()` — per failing run; `consecutiveFails` is the fail streak feeding the encouragement threshold + LX-C4 (#558)                                                                              |
+| `challenge_solved`       | `{ lessonId, challengeKind, courseId? }`                                                                        | `trackChallengeSolved()` — per passing run (#558)                                                                                                                                                                 |
+
+`challengeKind` is `"js" | "rust" | "buildable"` (`challengeKindFor()` in
+`events.ts`).
+
+Enrollment note: there is no separate `enroll_completed` event — the only
+enrollment success moment that exists today is the on-chain path, which
+`enrollment_onchain` already covers. If a wallet-less enrollment path ships,
+instrument it as `enroll_completed { courseId, method }`.
+
+## Reserved — onboarding funnel (E2/E7), do NOT fire yet
+
+The `/start` intake (#566) is **unbuilt**. These names are reserved so
+dashboards and the intake PR agree on shapes; nothing may emit them until the
+surface exists:
+
+| Event                       | Payload                                      | Purpose                                                                    |
+| --------------------------- | -------------------------------------------- | -------------------------------------------------------------------------- |
+| `onboarding_started`        | `{}`                                         | First interaction with `/start` screen 1 (not the page view)               |
+| `onboarding_step_completed` | `{ step: 1 \| 2 \| 3 \| 4, choice }`         | Per-screen funnel step (experience fork / goal / value chips / daily goal) |
+| `onboarding_goal_committed` | `{ dailyGoal }`                              | E2 implementation-intention substrate (daily-goal picker)                  |
+| `onboarding_route_accepted` | `{ accepted: boolean, recommendedCourseId }` | E7 segment-routing acceptance vs "Browse all" override                     |
+| `onboarding_completed`      | `{ experience, goal, dailyGoal }`            | Intake finished; values are the closed-set option ids, never free text     |
+
+## Planned (not reserved-blocked, just future)
+
+- `review_completed` — lands with LX-B5 (spaced-review loop).

--- a/apps/web/src/lib/analytics/__tests__/events.test.ts
+++ b/apps/web/src/lib/analytics/__tests__/events.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  challengeKindFor,
+  resetAnalyticsEventDedupeForTests,
+  trackChallengeFailed,
+  trackChallengeRun,
+  trackChallengeSolved,
+  trackChallengeStarted,
+  trackCredentialMinted,
+} from "../events";
+
+const { trackEvent } = vi.hoisted(() => ({ trackEvent: vi.fn() }));
+vi.mock("../index", () => ({ trackEvent }));
+
+const ctx = {
+  lessonId: "lesson-anchor-pda",
+  courseId: "course-solana-201",
+  challengeKind: "rust" as const,
+};
+
+beforeEach(() => {
+  trackEvent.mockClear();
+  resetAnalyticsEventDedupeForTests();
+});
+
+describe("challengeKindFor", () => {
+  it("maps language/buildType onto the closed challenge-kind set", () => {
+    expect(challengeKindFor("typescript")).toBe("js");
+    expect(challengeKindFor("typescript", "standard")).toBe("js");
+    expect(challengeKindFor("rust")).toBe("rust");
+    expect(challengeKindFor("rust", "standard")).toBe("rust");
+    expect(challengeKindFor("rust", "buildable")).toBe("buildable");
+  });
+});
+
+describe("challenge lifecycle events", () => {
+  it("challenge_run fires per execution with the exact lean payload", () => {
+    trackChallengeRun(ctx);
+    trackChallengeRun(ctx);
+    expect(trackEvent).toHaveBeenCalledTimes(2);
+    expect(trackEvent).toHaveBeenNthCalledWith(1, "challenge_run", {
+      lessonId: "lesson-anchor-pda",
+      challengeKind: "rust",
+      courseId: "course-solana-201",
+    });
+  });
+
+  it("challenge_failed carries the consecutive-fail streak", () => {
+    trackChallengeFailed(ctx, 1);
+    trackChallengeFailed(ctx, 2);
+    expect(trackEvent).toHaveBeenNthCalledWith(2, "challenge_failed", {
+      lessonId: "lesson-anchor-pda",
+      challengeKind: "rust",
+      courseId: "course-solana-201",
+      consecutiveFails: 2,
+    });
+  });
+
+  it("challenge_solved fires with the exact lean payload", () => {
+    trackChallengeSolved(ctx);
+    expect(trackEvent).toHaveBeenCalledWith("challenge_solved", {
+      lessonId: "lesson-anchor-pda",
+      challengeKind: "rust",
+      courseId: "course-solana-201",
+    });
+  });
+
+  it("omits courseId when the surface does not know it", () => {
+    trackChallengeRun({ lessonId: "l1", challengeKind: "js" });
+    expect(trackEvent).toHaveBeenCalledWith("challenge_run", {
+      lessonId: "l1",
+      challengeKind: "js",
+    });
+  });
+
+  it("challenge_started dedupes per lesson per session", () => {
+    trackChallengeStarted(ctx);
+    trackChallengeStarted(ctx);
+    trackChallengeStarted(ctx);
+    expect(trackEvent).toHaveBeenCalledTimes(1);
+    expect(trackEvent).toHaveBeenCalledWith("challenge_started", {
+      lessonId: "lesson-anchor-pda",
+      challengeKind: "rust",
+      courseId: "course-solana-201",
+    });
+
+    trackChallengeStarted({ ...ctx, lessonId: "another-lesson" });
+    expect(trackEvent).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("credential_minted dedupe (one mint = one event)", () => {
+  it("collapses the manual-mint and Realtime observations of the same mint", () => {
+    trackCredentialMinted("course-solana-201", "manual_mint");
+    trackCredentialMinted("course-solana-201", "realtime");
+    expect(trackEvent).toHaveBeenCalledTimes(1);
+    expect(trackEvent).toHaveBeenCalledWith("credential_minted", {
+      courseId: "course-solana-201",
+      source: "manual_mint",
+    });
+  });
+
+  it("collapses regardless of observation order", () => {
+    trackCredentialMinted("course-solana-201", "realtime");
+    trackCredentialMinted("course-solana-201", "manual_mint");
+    expect(trackEvent).toHaveBeenCalledTimes(1);
+    expect(trackEvent).toHaveBeenCalledWith("credential_minted", {
+      courseId: "course-solana-201",
+      source: "realtime",
+    });
+  });
+
+  it("still fires once per distinct course", () => {
+    trackCredentialMinted("course-a", "realtime");
+    trackCredentialMinted("course-b", "realtime");
+    expect(trackEvent).toHaveBeenCalledTimes(2);
+  });
+
+  it("test reset restores firing", () => {
+    trackCredentialMinted("course-a", "manual_mint");
+    resetAnalyticsEventDedupeForTests();
+    trackCredentialMinted("course-a", "manual_mint");
+    expect(trackEvent).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/web/src/lib/analytics/events.ts
+++ b/apps/web/src/lib/analytics/events.ts
@@ -1,0 +1,109 @@
+import { trackEvent } from "./index";
+
+/**
+ * Typed event helpers for the launch analytics pass (LX-F1, #558).
+ *
+ * Every helper funnels through the `trackEvent` facade (GA4 + PostHog) and
+ * keeps payloads lean: content ids and closed-set strings only — never code
+ * content, wallet addresses, or any other PII. Identity is handled by
+ * `identifyUser` (PostHog identify), not by event payloads.
+ *
+ * The full event inventory — existing, added here, and reserved — lives in
+ * README.md next to this file.
+ */
+
+export type ChallengeKind = "js" | "rust" | "buildable";
+
+/** Maps the editor's language/buildType pair onto the analytics challenge kind. */
+export function challengeKindFor(
+  language: string,
+  buildType?: string | null
+): ChallengeKind {
+  if (language === "rust") {
+    return buildType === "buildable" ? "buildable" : "rust";
+  }
+  return "js";
+}
+
+export interface ChallengeEventContext {
+  lessonId: string;
+  /** Content course id when the surface knows it; omitted from the payload otherwise. */
+  courseId?: string;
+  challengeKind: ChallengeKind;
+}
+
+function challengePayload(ctx: ChallengeEventContext): Record<string, unknown> {
+  return {
+    lessonId: ctx.lessonId,
+    challengeKind: ctx.challengeKind,
+    ...(ctx.courseId ? { courseId: ctx.courseId } : {}),
+  };
+}
+
+// Session-scoped dedupe state, mirroring the celebration full-tier dedupe
+// (lib/gamification/celebration.ts): module-level, reset only in tests.
+const startedLessons = new Set<string>();
+const mintedCourses = new Set<string>();
+
+/** Test-only: clears the session-scoped event dedupe state. */
+export function resetAnalyticsEventDedupeForTests(): void {
+  startedLessons.clear();
+  mintedCourses.clear();
+}
+
+/**
+ * `challenge_started` — first genuine interaction with a challenge (first
+ * keystroke in the editor or first run), never a page view. Deduped per
+ * lesson per session, so callers may invoke it from every candidate
+ * interaction without double-firing.
+ */
+export function trackChallengeStarted(ctx: ChallengeEventContext): void {
+  if (startedLessons.has(ctx.lessonId)) return;
+  startedLessons.add(ctx.lessonId);
+  trackEvent("challenge_started", challengePayload(ctx));
+}
+
+/** `challenge_run` — one event per execution (Run/Build click), any outcome. */
+export function trackChallengeRun(ctx: ChallengeEventContext): void {
+  trackEvent("challenge_run", challengePayload(ctx));
+}
+
+/**
+ * `challenge_failed` — a run whose tests (or build) did not pass.
+ * `consecutiveFails` is the running streak of failed runs — the substrate for
+ * the encouragement threshold (ENCOURAGEMENT_THRESHOLD) and the LX-C4
+ * stuck-nudge follow-up.
+ */
+export function trackChallengeFailed(
+  ctx: ChallengeEventContext,
+  consecutiveFails: number
+): void {
+  trackEvent("challenge_failed", {
+    ...challengePayload(ctx),
+    consecutiveFails,
+  });
+}
+
+/** `challenge_solved` — a run where every test (or the build) passed. */
+export function trackChallengeSolved(ctx: ChallengeEventContext): void {
+  trackEvent("challenge_solved", challengePayload(ctx));
+}
+
+export type CredentialMintObservationSource = "manual_mint" | "realtime";
+
+/**
+ * `credential_minted` — the post-mint-cliff baseline (LX-F1). One mint must
+ * produce exactly ONE event even though a mint can be observed twice within
+ * moments (the manual mint success in course-completion-mint.tsx and the
+ * Supabase Realtime certificates INSERT in use-gamification-events.ts), so
+ * this dedupes per course per session — mirroring how `celebrate()` collapses
+ * the same two observations into one full-tier celebration.
+ */
+export function trackCredentialMinted(
+  courseId: string,
+  source: CredentialMintObservationSource
+): void {
+  if (mintedCourses.has(courseId)) return;
+  mintedCourses.add(courseId);
+  trackEvent("credential_minted", { courseId, source });
+}

--- a/apps/web/src/lib/analytics/index.ts
+++ b/apps/web/src/lib/analytics/index.ts
@@ -14,6 +14,10 @@
  *   trackEvent("lesson_completed", { lessonId: "intro-1", xp: 50 });
  *   trackPageView("/en/courses/intro-to-solana");
  *   identifyUser("user-uuid", { walletAddress: "7xK..." });
+ *
+ * The canonical event inventory (names, payload shapes, reserved names) is
+ * documented in README.md next to this file; typed helpers with dedupe live
+ * in events.ts.
  */
 
 import { initGA4, trackGA4Event, trackGA4PageView } from "./ga4";


### PR DESCRIPTION
Closes #558 (LX-F1 — master spec §3). LX-F2/F3 dashboard config are follow-ups, not in scope here.

## What this adds

**`credential_minted`** — the post-mint-cliff baseline. Fires at BOTH observation paths of a mint:
- manual mint success (`components/certificates/course-completion-mint.tsx`)
- Supabase Realtime `certificates` INSERT (`hooks/use-gamification-events.ts`, which also covers webhook-driven automatic mints)

**Dedupe** (one mint = one event): `trackCredentialMinted()` in `lib/analytics/events.ts` keeps a session-scoped per-`courseId` set — mirroring how `celebrate()` collapses the same two observations into one full-tier celebration, but immune to Realtime latency beyond the 8s confetti window. Order-independent; the Realtime handler's existing 15s row-id replay dedupe stays as the first line. Payload: `{ courseId, source: "manual_mint" | "realtime" }`.

**Challenge lifecycle** — in `components/editor/challenge-interface.tsx` (composed alongside the celebration/encouragement logic, no behavior changes):
- `challenge_started` — first genuine interaction, never a page view: first keystroke in the editor area (native capture listener — `CodeEditor.onChange` can't be used because the localStorage restore fires it on mount) OR first run. Session-deduped per lesson.
- `challenge_run` — per execution, any outcome.
- `challenge_failed` — per failing run, with `consecutiveFails` streak (mirrored in a ref beside the existing state — the encouragement-threshold / LX-C4 substrate).
- `challenge_solved` — per passing run (resets the streak).
- Payloads: `{ lessonId, challengeKind: "js" | "rust" | "buildable", courseId? }` — `courseId` threaded as a new optional prop from the code block's ctx. No code content, no PII.

**Onboarding funnel (E2/E7)** — `/start` intake (#566) is unbuilt, so nothing fires: names + shapes are RESERVED in `lib/analytics/README.md` (`onboarding_started`, `onboarding_step_completed`, `onboarding_goal_committed` [E2], `onboarding_route_accepted` [E7], `onboarding_completed`) so dashboards and the intake PR agree. Checked the enrollment moment first: `enrollment_onchain` already covers the only enrollment success path that exists today — no `enroll_completed` added.

**Naming doc** — `apps/web/src/lib/analytics/README.md`: canonical inventory of every event (existing incl. `earn_handoff_click` #625 and `credential_share_click` #629, the five added here, reserved ones) with payload shapes and conventions; facade header now points at it.

## Tests (22 new)

- `lib/analytics/__tests__/events.test.ts` — facade called with exact name+shape; started dedupe; mint dedupe both orders + distinct courses; kind mapping.
- `components/editor/__tests__/challenge-interface.events.test.tsx` — no event on render; started once on first keystroke; run-first ordering (started → run → solved); streak escalation 1→2 and reset after solve; buildable kind; lean-payload key allowlist (PII guard).
- `components/certificates/__tests__/course-completion-mint.events.test.tsx` — manual mint success fires once with courseId; no double-fire when the Realtime observation lands; no event on API failure.
- `hooks/__tests__/use-gamification-events.test.tsx` — Realtime INSERT fires with the row's `course_id`; replay-deduped; suppressed when the manual path already observed the mint (popup still shows).

## Verification

- `pnpm typecheck` — pass (all 6 tasks)
- `pnpm test` (apps/web) — **118 files / 1084 tests pass**; root `test:scripts` 26 pass
- `pnpm lint` — exit 0; import/order warnings in the two touched components verified pre-existing at identical counts on main (net-neutral)

## OWNER checklist

- [ ] **Confirm `NEXT_PUBLIC_POSTHOG_KEY` / `NEXT_PUBLIC_POSTHOG_HOST` (and `NEXT_PUBLIC_GA4_MEASUREMENT_ID`) are set in the Vercel prod env — all analytics env vars are optional today, so every event in this PR silently no-ops without them.**
