### PR TITLE
ci: build the build-server Docker image + read-only /health smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,6 +221,65 @@ jobs:
       - name: Tests
         run: cargo test --manifest-path apps/build-server/Cargo.toml
 
+  # ── Build-server image: full Docker bake (#614) ─────────────────────────────
+  # Proves what fmt/clippy/test cannot: the host toolchain install, the Agave
+  # install, the `cargo-build-sbf --tools-version v1.54` pre-cache of the
+  # anchor template in programs/ (an independent crate no other job compiles),
+  # and the setuid-strip verification — all baked into the Dockerfile. Build
+  # only: no push, no registry, no credentials. The deep runtime check (POST a
+  # real submission to /build) stays an enable-time gate per #610; the smoke
+  # here just boots the image under the production runtime contract
+  # (read-only rootfs, tmpfs /tmp) and hits the public /health.
+  build-server-image:
+    name: Build server (docker build · smoke)
+    runs-on: ubuntu-latest
+    needs: changes
+    timeout-minutes: 30
+    if: >-
+      github.event.action != 'labeled' &&
+      (needs.changes.outputs.buildserver == 'true' || github.event_name == 'workflow_dispatch')
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      # Needed for the GHA layer cache below (the default docker driver cannot
+      # export type=gha).
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Build image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: apps/build-server
+          push: false
+          load: true # export into the local daemon for the smoke step
+          tags: academy-build-server:ci
+          # Default mode=min caches only final-image layers — which includes
+          # every expensive one (apt, rustup, Agave, platform-tools bake) while
+          # keeping the GHA cache footprint bounded. The stage-1 server build
+          # re-runs cold, but a src/ change would bust it anyway.
+          cache-from: type=gha,scope=build-server-image
+          cache-to: type=gha,scope=build-server-image
+
+      # Mirrors the enable-time gate command from #614/#610 minus the /build
+      # POST: boot with the hardened runtime flags and require /health to answer.
+      - name: Smoke test (read-only rootfs · /health)
+        run: |
+          docker run -d --name bs-smoke --read-only --tmpfs /tmp:exec \
+            -e BUILDS_DIR=/tmp/academy-builds -e ACADEMY_API_KEY=ci-smoke \
+            -p 8080:8080 academy-build-server:ci
+          ok=""
+          for _ in $(seq 1 30); do
+            if curl -sf http://127.0.0.1:8080/health; then ok=1; break; fi
+            sleep 1
+          done
+          echo
+          docker logs bs-smoke
+          docker rm -f bs-smoke >/dev/null
+          if [ -z "$ok" ]; then
+            echo "::error::/health did not respond within 30s under --read-only rootfs"
+            exit 1
+          fi
+
   # ── Dependency audit ────────────────────────────────────────────────────────
   # Non-blocking for now: the pinned Solana 2.0.x tree carries known transitive
   # advisories. Triage them, then flip continue-on-error to false to make this a


### PR DESCRIPTION
Closes #614

## What

Adds one job-level-gated CI job, `build-server-image` ("Build server (docker build · smoke)"), to `.github/workflows/ci.yml`. Nothing else in the workflow changes.

- **Full `docker build` of `apps/build-server/`** via `docker/build-push-action` — exercises everything the existing fmt/clippy/test job cannot: the host toolchain install, the Agave 3.0.14 install, the `cargo-build-sbf --tools-version v1.54` pre-cache of the anchor-1.1.2 template in `programs/`, and the Dockerfile's setuid-strip verification. A broken toolchain bump now fails CI instead of rotting silently (the #610 gap).
- **Build only** — `push: false`, no registry, no credentials, `permissions: contents: read` untouched.
- **Cached sensibly** — buildx GHA layer cache (`type=gha`, dedicated scope, default `mode=min` so only final-image layers are stored: that covers every expensive layer — apt, rustup, Agave, platform-tools bake — while bounding the cache footprint). Any change to `programs/` or the toolchain layers content-busts the bake layer, so the compile genuinely re-runs exactly when it must.
- **Bounded** — `timeout-minutes: 30` (expected ~15–25 min cold, much less warm).
- **Cheap runtime-contract smoke** (issue's third done-when box): boots the image with `--read-only --tmpfs /tmp:exec -e BUILDS_DIR=/tmp/academy-builds -e ACADEMY_API_KEY=…` — the exact flags of the enable-time gate — and requires the public `/health` to answer within 30 s, dumping container logs either way. The deep POST-a-real-submission `/build` verification **stays an enable-time gate** per #610's checklist, as the issue specifies.

## Conventions followed (SENSITIVE file)

- Same `needs: changes` + `github.event.action != 'labeled' && (needs.changes.outputs.buildserver == 'true' || workflow_dispatch)` gating as the sibling `build-server` job — skipped runs report "skipped", branch protection untouched (this job is not a required check).
- New third-party actions SHA-pinned with version comments, matching the repo's supply-chain convention: `docker/setup-buildx-action@bb05f3f5…` (v4.2.0, required because the default docker driver can't export `type=gha` cache) and `docker/build-push-action@53b7df96…` (v7.3.0).
- Zero changes to the Dockerfile, to any existing job, and no new secrets.

## Path-filter claim in #614 — verified, and it's not what the issue says

The issue claims the `changes` filter "doesn't cover `apps/build-server/programs/`". **False**: the `buildserver` filter is `apps/build-server/**`, and picomatch (the exact matcher `dorny/paths-filter` uses, `dot: true`) matches `apps/build-server/programs/Cargo.toml` and `programs/src/lib.rs` against it — verified programmatically. The real gap was one level up: the existing job *triggers* on `programs/` changes but never compiles that crate (it's an independent package, not part of the server cargo workspace — only the Docker bake builds it). This PR fixes the actual gap; the filter needs no change.

## Self-verification

The `buildserver` filter includes `.github/workflows/ci.yml`, so this PR itself sets `buildserver: true` and fires the new job — its run on this PR is the proof it triggers and that the image builds. (The GH runner can't be executed locally; `actionlint` passes clean and the YAML/job graph was validated.)