### PR TITLE
feat(courses): course-detail linear-path view — one active next node, every lesson stays openable (LX-B14)

### DIFF
--- a/apps/web/src/app/[locale]/(platform)/courses/[slug]/course-detail-client.tsx
+++ b/apps/web/src/app/[locale]/(platform)/courses/[slug]/course-detail-client.tsx
@@ -15,6 +15,7 @@ import { useConnection, useWallet } from "@solana/wallet-adapter-react";
 import type { Course } from "@superteam-lms/types";
 import { Button } from "@/components/ui/button";
 import { CurriculumAccordion } from "@/components/course/curriculum-accordion";
+import { CurriculumPath } from "@/components/course/curriculum-path";
 import { ProgressBar } from "@/components/course/progress-bar";
 import { InstructorCard } from "@/components/course/instructor-card";
 import { createClient } from "@/lib/supabase/client";
@@ -322,12 +323,25 @@ export function CourseDetailClient({
         <p className="text-sm text-text-3">
           {modules.length} {t("modules")} &middot; {totalLessons} {t("lessons")}
         </p>
-        <CurriculumAccordion
-          modules={accordionModules}
-          courseSlug={course.slug}
-          locale={locale}
-          completedLessons={completedLessons}
-        />
+        {isEnrolled ? (
+          // Linear-path progress map (LX-B14): one visually-active "next"
+          // node from the shared derivation; every lesson stays a plain
+          // link — presentation only, never a lock.
+          <CurriculumPath
+            modules={accordionModules}
+            courseSlug={course.slug}
+            locale={locale}
+            completedLessons={completedLessons}
+            activeLessonId={nextIncompleteLesson?._id ?? null}
+          />
+        ) : (
+          <CurriculumAccordion
+            modules={accordionModules}
+            courseSlug={course.slug}
+            locale={locale}
+            completedLessons={completedLessons}
+          />
+        )}
       </div>
 
       {/* Discussions */}

--- a/apps/web/src/components/course/__tests__/curriculum-path.test.tsx
+++ b/apps/web/src/components/course/__tests__/curriculum-path.test.tsx
@@ -1,0 +1,174 @@
+// @vitest-environment jsdom
+import type { ReactElement } from "react";
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import { CurriculumPath } from "../curriculum-path";
+import { findNextIncompleteLesson } from "@/lib/courses/continue-learning";
+import messages from "@/messages/en.json";
+
+const modules = [
+  {
+    id: "m1",
+    title: "Foundations",
+    lessons: [
+      { _id: "l1", title: "Intro", slug: "intro", isChallenge: false },
+      { _id: "l2", title: "Accounts", slug: "accounts", isChallenge: false },
+      {
+        _id: "l3",
+        title: "First program",
+        slug: "first-program",
+        isChallenge: true,
+      },
+    ],
+  },
+  {
+    id: "m2",
+    title: "Going deeper",
+    lessons: [
+      { _id: "l4", title: "PDAs", slug: "pdas", isChallenge: false },
+      { _id: "l5", title: "CPIs", slug: "cpis", isChallenge: true },
+    ],
+  },
+];
+
+const orderedLessons = modules.flatMap((m) => m.lessons);
+
+function renderPath(completedLessons: string[]) {
+  // Same derivation the course-detail page (and the dashboard Continue card)
+  // uses — the component itself never re-derives the next lesson.
+  const next = findNextIncompleteLesson(
+    orderedLessons,
+    new Set(completedLessons)
+  );
+  return renderWithIntl(
+    <CurriculumPath
+      modules={modules}
+      courseSlug="solana-101"
+      locale="en"
+      completedLessons={completedLessons}
+      activeLessonId={next?._id ?? null}
+    />
+  );
+}
+
+function renderWithIntl(ui: ReactElement) {
+  return render(
+    <NextIntlClientProvider locale="en" messages={messages}>
+      {ui}
+    </NextIntlClientProvider>
+  );
+}
+
+describe("CurriculumPath — active-node selection (shared derivation)", () => {
+  it("marks exactly one node as the active next step", () => {
+    renderPath(["l1", "l2"]);
+
+    const active = screen.getAllByRole("link", { current: "step" });
+    expect(active).toHaveLength(1);
+    expect(active[0]).toHaveAttribute(
+      "href",
+      "/en/courses/solana-101/lessons/first-program"
+    );
+    expect(screen.getAllByText("Up next")).toHaveLength(1);
+  });
+
+  it("follows findNextIncompleteLesson when the learner skips ahead: the active node is the first gap, not the furthest lesson", () => {
+    // l1 done, l3 done out of order — the first incomplete lesson is l2.
+    renderPath(["l1", "l3"]);
+
+    const active = screen.getAllByRole("link", { current: "step" });
+    expect(active).toHaveLength(1);
+    expect(active[0]).toHaveAttribute(
+      "href",
+      "/en/courses/solana-101/lessons/accounts"
+    );
+  });
+
+  it("with no progress, the first lesson is the active node", () => {
+    renderPath([]);
+
+    const active = screen.getAllByRole("link", { current: "step" });
+    expect(active).toHaveLength(1);
+    expect(active[0]).toHaveAttribute(
+      "href",
+      "/en/courses/solana-101/lessons/intro"
+    );
+  });
+
+  it("fully complete course: no active node, no Up-next badge", () => {
+    renderPath(["l1", "l2", "l3", "l4", "l5"]);
+
+    expect(
+      screen.queryByRole("link", { current: "step" })
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText("Up next")).not.toBeInTheDocument();
+  });
+});
+
+describe("CurriculumPath — every lesson stays openable (no locks)", () => {
+  it("renders every lesson as a plain link with its real href, whatever its state", () => {
+    renderPath(["l1", "l2"]);
+
+    const links = screen.getAllByRole("link");
+    expect(links).toHaveLength(orderedLessons.length);
+    for (const lesson of orderedLessons) {
+      const link = links.find(
+        (l) =>
+          l.getAttribute("href") ===
+          `/en/courses/solana-101/lessons/${lesson.slug}`
+      );
+      expect(link).toBeDefined();
+    }
+  });
+
+  it("no node is disabled, aria-disabled, unfocusable, or labeled locked", () => {
+    renderPath(["l1"]);
+
+    for (const link of screen.getAllByRole("link")) {
+      expect(link).not.toHaveAttribute("aria-disabled");
+      expect(link).not.toHaveAttribute("disabled");
+      expect(link).not.toHaveAttribute("tabindex", "-1");
+    }
+    expect(screen.queryByText(messages.courses.locked)).not.toBeInTheDocument();
+  });
+
+  it("future (not-yet-active) lessons are real links too — skipping is allowed by construction", () => {
+    // Active node is l1; l5 is deep in module 2 and still a first-class link.
+    renderPath([]);
+
+    const future = screen
+      .getAllByRole("link")
+      .find(
+        (l) => l.getAttribute("href") === "/en/courses/solana-101/lessons/cpis"
+      );
+    expect(future).toBeDefined();
+    expect(future).not.toHaveAttribute("aria-current");
+  });
+});
+
+describe("CurriculumPath — progress map", () => {
+  it("marks completed lessons for screen readers and shows per-module progress", () => {
+    renderPath(["l1", "l2", "l3"]);
+
+    // Completed nodes carry an sr-only "Completed" state.
+    expect(screen.getAllByText(messages.courses.completed)).toHaveLength(3);
+
+    // Per-module progress bars: module 1 fully complete, module 2 untouched.
+    const bars = screen.getAllByRole("progressbar");
+    expect(bars).toHaveLength(2);
+    expect(bars[0]).toHaveAttribute("aria-valuenow", "100");
+    expect(bars[1]).toHaveAttribute("aria-valuenow", "0");
+  });
+
+  it("renders modules and lessons with list semantics", () => {
+    renderPath([]);
+
+    const lists = screen.getAllByRole("list");
+    // 1 module list + 1 lesson list per module.
+    expect(lists).toHaveLength(1 + modules.length);
+    expect(screen.getAllByRole("listitem")).toHaveLength(
+      modules.length + orderedLessons.length
+    );
+  });
+});

--- a/apps/web/src/components/course/curriculum-path.tsx
+++ b/apps/web/src/components/course/curriculum-path.tsx
@@ -1,0 +1,187 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { CheckCircle, Play, Code, Article } from "@phosphor-icons/react";
+import { ProgressBar } from "./progress-bar";
+import { cn } from "@/lib/utils";
+
+interface PathLesson {
+  _id: string;
+  title: string;
+  slug: string;
+  /** Derived from block content: a lesson with a graded `code` block. */
+  isChallenge: boolean;
+}
+
+interface PathModule {
+  /** Stable id — the inline module `key` (namespaced by the caller if needed). */
+  id: string;
+  title: string;
+  lessons: PathLesson[];
+}
+
+interface CurriculumPathProps {
+  modules: PathModule[];
+  courseSlug: string;
+  locale: string;
+  completedLessons: string[];
+  /**
+   * `_id` of the single "next" node, derived by the caller with
+   * `findNextIncompleteLesson` (the same rule the dashboard Continue card
+   * uses — LX-B2). `null` means the course is fully complete: no active node.
+   */
+  activeLessonId: string | null;
+}
+
+/**
+ * Linear-path presentation of the curriculum (LX-B14): modules as a
+ * sequential progress map with exactly one visually-active "next" node.
+ *
+ * Presentation only — every lesson is a plain link regardless of state.
+ * Nothing here is locked, disabled, or gated (UIU-10/11: forced linearity
+ * has no learning-outcome evidence; the escape hatch is the design).
+ */
+export function CurriculumPath({
+  modules,
+  courseSlug,
+  locale,
+  completedLessons,
+  activeLessonId,
+}: CurriculumPathProps) {
+  const t = useTranslations("courses");
+  const tLesson = useTranslations("lesson");
+  const completedSet = new Set(completedLessons);
+
+  return (
+    <ol className="space-y-4">
+      {modules.map((mod, moduleIdx) => {
+        const completedInModule = mod.lessons.filter((l) =>
+          completedSet.has(l._id)
+        ).length;
+        const allComplete =
+          completedInModule === mod.lessons.length && mod.lessons.length > 0;
+
+        return (
+          <li
+            key={mod.id}
+            className={cn(
+              "overflow-hidden rounded-xl border-[2.5px] border-border bg-card shadow-card",
+              allComplete && "border-success/30"
+            )}
+          >
+            {/* Module header + per-module progress */}
+            <div className="border-b border-border p-4">
+              <div className="flex items-center justify-between gap-3">
+                <div className="min-w-0 flex-1">
+                  <p className="font-mono text-[10px] font-bold uppercase tracking-[0.22em] text-text-3">
+                    {t("moduleLabel", { number: moduleIdx + 1 })}
+                  </p>
+                  <h4 className="mt-0.5 truncate font-display font-black text-text">
+                    {mod.title}
+                  </h4>
+                </div>
+                <span className="shrink-0 font-display text-[13px] font-bold tabular-nums text-text-3">
+                  {completedInModule}/{mod.lessons.length} {t("lessons")}
+                </span>
+              </div>
+              <ProgressBar
+                value={completedInModule}
+                max={Math.max(mod.lessons.length, 1)}
+                variant={allComplete ? "success" : "primary"}
+                className="mt-3"
+              />
+            </div>
+
+            {/* Lesson nodes on the path */}
+            <ol className="p-2">
+              {mod.lessons.map((lesson, lessonIdx) => {
+                const isCompleted = completedSet.has(lesson._id);
+                const isActive = lesson._id === activeLessonId;
+
+                return (
+                  <li key={lesson._id} className="relative">
+                    {/* Connector rail between node markers (decorative) */}
+                    {lessonIdx > 0 && (
+                      <span
+                        aria-hidden="true"
+                        className="absolute left-[23px] top-0 h-1/2 w-0.5 bg-border"
+                      />
+                    )}
+                    {lessonIdx < mod.lessons.length - 1 && (
+                      <span
+                        aria-hidden="true"
+                        className="absolute bottom-0 left-[23px] h-1/2 w-0.5 bg-border"
+                      />
+                    )}
+
+                    {/* Every state renders the same plain link — nothing is
+                        locked or disabled; the map is presentation only. */}
+                    <a
+                      href={`/${locale}/courses/${courseSlug}/lessons/${lesson.slug}`}
+                      aria-current={isActive ? "step" : undefined}
+                      className={cn(
+                        "relative flex items-center gap-3 rounded-lg px-3 py-3 text-sm transition-colors hover:bg-subtle focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-primary",
+                        isActive &&
+                          "bg-primary-bg ring-2 ring-inset ring-primary",
+                        isCompleted && "text-text-3"
+                      )}
+                    >
+                      <span className="flex w-6 shrink-0 items-center justify-center">
+                        {isCompleted ? (
+                          <CheckCircle
+                            size={20}
+                            weight="fill"
+                            className="text-success"
+                          />
+                        ) : isActive ? (
+                          <span className="flex h-5 w-5 items-center justify-center rounded-full bg-primary text-primary-foreground">
+                            <Play size={11} weight="fill" />
+                          </span>
+                        ) : lesson.isChallenge ? (
+                          <Code
+                            size={20}
+                            weight="duotone"
+                            className="text-accent"
+                          />
+                        ) : (
+                          <Article
+                            size={20}
+                            weight="duotone"
+                            className="text-text-3"
+                          />
+                        )}
+                      </span>
+
+                      <span className="flex min-w-0 flex-1 items-center gap-2">
+                        <span className="text-text-3/60 font-mono text-xs tabular-nums">
+                          {lessonIdx + 1}.
+                        </span>
+                        <span className="truncate">
+                          {lesson.isChallenge && (
+                            <span className="font-display font-bold text-accent-dark dark:text-accent">
+                              {tLesson("challenge")}:{" "}
+                            </span>
+                          )}
+                          {lesson.title}
+                        </span>
+                        {isCompleted && (
+                          <span className="sr-only">{t("completed")}</span>
+                        )}
+                      </span>
+
+                      {isActive && (
+                        <span className="shrink-0 rounded-full bg-primary px-2.5 py-0.5 font-mono text-[10px] font-bold uppercase tracking-wider text-primary-foreground">
+                          {t("upNext")}
+                        </span>
+                      )}
+                    </a>
+                  </li>
+                );
+              })}
+            </ol>
+          </li>
+        );
+      })}
+    </ol>
+  );
+}

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -178,7 +178,9 @@
     "ofXp": "of {total} XP",
     "coursesCount": "{count} of {total} done",
     "discussions": "Course Discussions",
-    "startDiscussion": "Start a Discussion"
+    "startDiscussion": "Start a Discussion",
+    "moduleLabel": "Module {number}",
+    "upNext": "Up next"
   },
   "lesson": {
     "content": "Content",

--- a/apps/web/src/messages/es.json
+++ b/apps/web/src/messages/es.json
@@ -178,7 +178,9 @@
     "ofXp": "de {total} XP",
     "coursesCount": "{count} de {total} completados",
     "discussions": "Discusiones del Curso",
-    "startDiscussion": "Iniciar una Discusión"
+    "startDiscussion": "Iniciar una Discusión",
+    "moduleLabel": "Módulo {number}",
+    "upNext": "A continuación"
   },
   "lesson": {
     "content": "Contenido",

--- a/apps/web/src/messages/pt-BR.json
+++ b/apps/web/src/messages/pt-BR.json
@@ -178,7 +178,9 @@
     "ofXp": "de {total} XP",
     "coursesCount": "{count} de {total} concluídos",
     "discussions": "Discussões do Curso",
-    "startDiscussion": "Iniciar uma Discussão"
+    "startDiscussion": "Iniciar uma Discussão",
+    "moduleLabel": "Módulo {number}",
+    "upNext": "A seguir"
   },
   "lesson": {
     "content": "Conteúdo",


### PR DESCRIPTION
Closes #585

Task **LX-B14** (launch-experience master spec §3): course-detail page gains a linear-path presentation of the curriculum — a sequential progress map with **exactly one visually-active "next" node** — while keeping every lesson directly openable. The linear view is presentation, never a lock (UIU-10/11: forced linearity has no learning-outcome evidence; the escape hatch is the design).

## What changed

- **New `CurriculumPath` component** (`apps/web/src/components/course/curriculum-path.tsx`): modules as an ordered list with per-module progress (n/m + progress bar), lesson nodes on a connector rail. Node states: completed (check, sr-only "Completed"), active (`aria-current="step"`, ring highlight, "Up next" badge), upcoming (normal link styling — full text color, hover state, clearly perceivable as available; visually secondary only relative to the active node's highlight).
- **Course-detail wiring**: enrolled learners get the path view; **unenrolled visitors keep the existing accordion + CTA behavior unchanged** (per #623). The active node id is passed down from the page's existing `findNextIncompleteLesson` call.
- **Locales**: new `courses.moduleLabel` + `courses.upNext` keys in en / pt-BR / es.

## How the active node derives

Reuses `findNextIncompleteLesson` from `lib/courses/continue-learning.ts` (LX-B2, #623) — the exact rule the dashboard Continue card and the course-detail CTA already use: first lesson in content-bundle module→lesson order not in the completed set. **No new derivation logic**; the component receives `activeLessonId` and only compares ids. Fully complete course → `null` → no active node, all checked.

## Proof nothing is locked

- Every node in every state renders the **same plain `<a href>`** — there is no code path that renders a non-link, `aria-disabled`, `tabindex=-1`, or a lock icon, and no click handler that intercepts navigation.
- Tests assert it: all lessons render as links with real hrefs whatever the progress state; no `aria-disabled`/`disabled`/`tabindex=-1` on any node; the "locked" string never appears; a deep future lesson is a first-class link with no `aria-current`.
- Skip-ahead is exercised: completing l1+l3 out of order highlights l2 (the first gap) and produces no warning state.

## Accept criteria (LX-B14)

- [x] Exactly one primary next-lesson target per course page — the active node and the header Continue CTA point at the same derived lesson (single shared derivation, they cannot disagree)
- [x] All lessons remain clickable; skipping produces no warning or lockout
- [x] ×3 locales for new strings
- [x] A11y: list semantics, `aria-current="step"`, sr-only completed state, focus-visible outlines

## Tests

9 new component tests (`curriculum-path.test.tsx`) — active-node selection fed through the real `findNextIncompleteLesson` (derivation parity), all-clickable/no-locks assertions, per-module progress values, list semantics.

## Verification

- `pnpm typecheck` — 6/6 tasks pass
- `pnpm test` (apps/web) — **126 files / 1142 tests passed** (incl. 9 new)
- `pnpm lint` — no new warnings vs main (124 vs 125 pre-existing)
- Prettier clean

## Out of scope (untouched)

Dashboard (#563 in flight), lesson pages, quiz/AI surfaces, data flow, enrollment CTA logic. Per-module test-out entry point reserved for LX-A5 follow-on.