### PR TITLE
feat(content-lint): gate 19 — skill tags gated against skills.yaml (registry, reuse bar, interleaving pairs, review denylist)

### DIFF
--- a/packages/content-lint/src/__tests__/fixtures/good/courses/template/lessons/deploy/lesson.yaml
+++ b/packages/content-lint/src/__tests__/fixtures/good/courses/template/lessons/deploy/lesson.yaml
@@ -1,7 +1,7 @@
 id: lesson-t-deploy
 slug: deploy
 title: Deploy
-skills: [deployment]
+skills: [deployment, program-interaction]
 blocks:
   - key: build
     type: code

--- a/packages/content-lint/src/__tests__/fixtures/good/courses/template/lessons/exercise/lesson.yaml
+++ b/packages/content-lint/src/__tests__/fixtures/good/courses/template/lessons/exercise/lesson.yaml
@@ -1,7 +1,7 @@
 id: lesson-t-exercise
 slug: exercise
 title: Exercise
-skills: [fundamentals]
+skills: [fundamentals, deployment]
 blocks:
   - key: ts
     type: code

--- a/packages/content-lint/src/__tests__/fixtures/good/courses/template/lessons/interact/lesson.yaml
+++ b/packages/content-lint/src/__tests__/fixtures/good/courses/template/lessons/interact/lesson.yaml
@@ -1,7 +1,7 @@
 id: lesson-t-interact
 slug: interact
 title: Interact
-skills: [program-interaction]
+skills: [program-interaction, wallet-funding]
 blocks:
   - {
       key: explore,

--- a/packages/content-lint/src/__tests__/fixtures/good/skills.yaml
+++ b/packages/content-lint/src/__tests__/fixtures/good/skills.yaml
@@ -1,0 +1,10 @@
+# Canonical skill vocabulary for the template fixture (gate 19). Every slug
+# below is applied to >=2 lessons so the fixture clears the minimum reuse bar.
+- slug: fundamentals
+  label: Fundamentals
+- slug: deployment
+  label: Deployment
+- slug: wallet-funding
+  label: Wallet Funding
+- slug: program-interaction
+  label: Program Interaction

--- a/packages/content-lint/src/__tests__/gate19.test.ts
+++ b/packages/content-lint/src/__tests__/gate19.test.ts
@@ -116,7 +116,7 @@ describe("gate 19a — registry resolution", () => {
 });
 
 describe("gate 19b — minimum reuse bar", () => {
-  it("errors when a slug is applied to only one lesson", async () => {
+  it("warns (does not error) when a slug is applied to only one lesson, and names the lone lesson", async () => {
     const r = await runLint(
       makeTempRepo({
         ...registry(["pdas", "staking"]),
@@ -126,13 +126,17 @@ describe("gate 19b — minimum reuse bar", () => {
     );
     const g = of(r, "gate-19b");
     expect(g).toHaveLength(1);
-    expect(g[0]?.severity).toBe("error");
+    expect(g[0]?.severity).toBe("warning");
     expect(g[0]?.message).toContain('"staking"');
     expect(g[0]?.message).toContain("courses/x/lessons/a/lesson.yaml");
-    expect(r.ok).toBe(false);
+    // Warning tier until the 5-course catalog lands (#596) — never fails CI.
+    expect(g[0]?.message).toContain("#596");
+    expect(r.ok).toBe(true);
   });
 
-  it("grandfathers `oracles` to a warning at one lesson (pending #559)", async () => {
+  it("has no code-side grandfather escape hatch — every unmarked singleton warns uniformly", async () => {
+    // `oracles` used to be special-cased; now it warns exactly like any other
+    // single-lesson slug (the reuse bar is warning-tier for all of them).
     const r = await runLint(
       makeTempRepo({
         ...registry(["pdas", "oracles"]),
@@ -144,8 +148,7 @@ describe("gate 19b — minimum reuse bar", () => {
     expect(g).toHaveLength(1);
     expect(g[0]?.severity).toBe("warning");
     expect(g[0]?.message).toContain('"oracles"');
-    expect(g[0]?.message).toContain("#559");
-    // A grandfathered singleton never fails the lint.
+    expect(g[0]?.message).not.toContain("#559");
     expect(r.ok).toBe(true);
   });
 
@@ -165,9 +168,9 @@ describe("gate 19b — minimum reuse bar", () => {
     expect(r.ok).toBe(true);
   });
 
-  it("errors on a single-use slug NOT marked reviewExempt (the mechanism is declarative, not a hardcoded allowlist)", async () => {
+  it("warns (not silences) a single-use slug NOT marked reviewExempt — the exemption is the declarative marker, not the slug name", async () => {
     // brazil-compliance / earn-submission are spec examples, but the exemption
-    // comes from the skills.yaml marker — an unmarked entry still fails the bar.
+    // comes from the skills.yaml marker — an unmarked entry still warns.
     const r = await runLint(
       makeTempRepo({
         ...registry(["pdas", "brazil-compliance"]),
@@ -177,10 +180,10 @@ describe("gate 19b — minimum reuse bar", () => {
     );
     const g = of(r, "gate-19b");
     expect(g).toHaveLength(1);
-    expect(g[0]?.severity).toBe("error");
+    expect(g[0]?.severity).toBe("warning");
     expect(g[0]?.message).toContain('"brazil-compliance"');
     expect(g[0]?.message).toContain("reviewExempt");
-    expect(r.ok).toBe(false);
+    expect(r.ok).toBe(true);
   });
 
   it("honours reviewExempt for any slug, not just the spec's named examples", async () => {
@@ -217,7 +220,10 @@ describe("gate 19b — minimum reuse bar", () => {
         ...lesson("a", ["pdas", "pdas"]),
       })
     );
-    expect(of(r, "gate-19b").some((d) => d.severity === "error")).toBe(true);
+    const g = of(r, "gate-19b");
+    expect(g).toHaveLength(1);
+    expect(g[0]?.severity).toBe("warning");
+    expect(g[0]?.message).toContain('"pdas"');
   });
 });
 
@@ -319,11 +325,11 @@ describe("gate 19 — `courses/_template` lessons are excluded from reuse counts
     );
     const g = of(r, "gate-19b");
     expect(g).toHaveLength(1);
-    expect(g[0]?.severity).toBe("error");
+    expect(g[0]?.severity).toBe("warning");
     expect(g[0]?.message).toContain('"staking"');
     // Named lesson is the real one, never the template.
     expect(g[0]?.message).toContain("courses/x/lessons/a/lesson.yaml");
-    expect(r.ok).toBe(false);
+    expect(r.ok).toBe(true);
   });
 });
 

--- a/packages/content-lint/src/__tests__/gate19.test.ts
+++ b/packages/content-lint/src/__tests__/gate19.test.ts
@@ -33,9 +33,22 @@ blocks:
   };
 }
 
-function registry(slugs: string[]): Record<string, string> {
+/**
+ * A registry entry: a bare slug, or `{ slug, reviewExempt }` to emit the
+ * declarative single-use marker (catalog spec §5 policy 4) that gate 19b honours.
+ */
+type RegistryEntry = string | { slug: string; reviewExempt?: boolean };
+
+function registry(entries: RegistryEntry[]): Record<string, string> {
+  const line = (e: RegistryEntry) =>
+    typeof e === "string"
+      ? `- slug: ${e}`
+      : `- slug: ${e.slug}` +
+        (e.reviewExempt === undefined
+          ? ""
+          : `\n  reviewExempt: ${e.reviewExempt}`);
   return {
-    "skills.yaml": slugs.map((s) => `- slug: ${s}`).join("\n") + "\n",
+    "skills.yaml": entries.map(line).join("\n") + "\n",
   };
 }
 
@@ -136,12 +149,46 @@ describe("gate 19b — minimum reuse bar", () => {
     expect(r.ok).toBe(true);
   });
 
-  it("allows the singleton exceptions at one lesson", async () => {
+  it("allows a `reviewExempt: true` singleton at one lesson", async () => {
     const r = await runLint(
       makeTempRepo({
-        ...registry(["pdas", "brazil-compliance", "earn-submission"]),
+        ...registry([
+          "pdas",
+          { slug: "brazil-compliance", reviewExempt: true },
+          { slug: "earn-submission", reviewExempt: true },
+        ]),
         ...lesson("a", ["pdas", "brazil-compliance"]),
         ...lesson("b", ["pdas", "earn-submission"]),
+      })
+    );
+    expect(of(r, "gate-19b")).toEqual([]);
+    expect(r.ok).toBe(true);
+  });
+
+  it("errors on a single-use slug NOT marked reviewExempt (the mechanism is declarative, not a hardcoded allowlist)", async () => {
+    // brazil-compliance / earn-submission are spec examples, but the exemption
+    // comes from the skills.yaml marker — an unmarked entry still fails the bar.
+    const r = await runLint(
+      makeTempRepo({
+        ...registry(["pdas", "brazil-compliance"]),
+        ...lesson("a", ["pdas", "brazil-compliance"]),
+        ...lesson("b", ["pdas"]),
+      })
+    );
+    const g = of(r, "gate-19b");
+    expect(g).toHaveLength(1);
+    expect(g[0]?.severity).toBe("error");
+    expect(g[0]?.message).toContain('"brazil-compliance"');
+    expect(g[0]?.message).toContain("reviewExempt");
+    expect(r.ok).toBe(false);
+  });
+
+  it("honours reviewExempt for any slug, not just the spec's named examples", async () => {
+    const r = await runLint(
+      makeTempRepo({
+        ...registry(["pdas", { slug: "token-2022", reviewExempt: true }]),
+        ...lesson("a", ["pdas", "token-2022"]),
+        ...lesson("b", ["pdas"]),
       })
     );
     expect(of(r, "gate-19b")).toEqual([]);

--- a/packages/content-lint/src/__tests__/gate19.test.ts
+++ b/packages/content-lint/src/__tests__/gate19.test.ts
@@ -129,8 +129,8 @@ describe("gate 19b — minimum reuse bar", () => {
     expect(g[0]?.severity).toBe("warning");
     expect(g[0]?.message).toContain('"staking"');
     expect(g[0]?.message).toContain("courses/x/lessons/a/lesson.yaml");
-    // Warning tier until the 5-course catalog lands (#596) — never fails CI.
-    expect(g[0]?.message).toContain("#596");
+    // Warning tier until the 5-course catalog lands (#676) — never fails CI.
+    expect(g[0]?.message).toContain("#676");
     expect(r.ok).toBe(true);
   });
 

--- a/packages/content-lint/src/__tests__/gate19.test.ts
+++ b/packages/content-lint/src/__tests__/gate19.test.ts
@@ -1,0 +1,222 @@
+import { describe, it, expect } from "vitest";
+import { runLint } from "../lint";
+import "../checks/gate1-schema";
+import "../checks/gate19-skills";
+import { makeTempRepo } from "./helpers";
+
+function lesson(name: string, skills: string[]): Record<string, string> {
+  return {
+    [`courses/x/lessons/${name}/lesson.yaml`]: `id: lesson-${name}
+slug: ${name}
+title: ${name}
+skills: [${skills.join(", ")}]
+blocks:
+  - { key: intro, type: prose, src: intro.md }
+`,
+  };
+}
+
+function registry(slugs: string[]): Record<string, string> {
+  return {
+    "skills.yaml": slugs.map((s) => `- slug: ${s}`).join("\n") + "\n",
+  };
+}
+
+const of = (r: Awaited<ReturnType<typeof runLint>>, gate: string) =>
+  r.diagnostics.filter((d) => d.gate === gate);
+
+describe("gate 19a — registry resolution", () => {
+  it("passes when every lesson skill resolves to skills.yaml", async () => {
+    const r = await runLint(
+      makeTempRepo({
+        ...registry(["pdas", "cpi"]),
+        ...lesson("a", ["pdas", "cpi"]),
+        ...lesson("b", ["pdas", "cpi"]),
+      })
+    );
+    expect(of(r, "gate-19a")).toEqual([]);
+    expect(r.ok).toBe(true);
+  });
+
+  it("errors on an invented slug, naming the lesson file and the slug", async () => {
+    const r = await runLint(
+      makeTempRepo({
+        ...registry(["pdas"]),
+        ...lesson("a", ["pdas", "not-a-real-skill"]),
+        ...lesson("b", ["pdas"]),
+      })
+    );
+    const g = of(r, "gate-19a");
+    expect(g).toHaveLength(1);
+    expect(g[0]?.severity).toBe("error");
+    expect(g[0]?.file).toBe("courses/x/lessons/a/lesson.yaml");
+    expect(g[0]?.message).toContain("not-a-real-skill");
+    expect(r.ok).toBe(false);
+  });
+
+  it("errors when skills.yaml is missing but lessons are tagged", async () => {
+    const r = await runLint(makeTempRepo({ ...lesson("a", ["pdas"]) }));
+    const g = of(r, "gate-19a");
+    expect(g.some((d) => /skills\.yaml not found/.test(d.message))).toBe(true);
+    expect(r.ok).toBe(false);
+  });
+
+  it("errors when skills.yaml is not a valid taxonomy (duplicate slugs)", async () => {
+    const r = await runLint(
+      makeTempRepo({
+        "skills.yaml": "- slug: pdas\n- slug: pdas\n",
+        ...lesson("a", ["pdas"]),
+        ...lesson("b", ["pdas"]),
+      })
+    );
+    expect(
+      of(r, "gate-19a").some((d) =>
+        /not a valid skills taxonomy/.test(d.message)
+      )
+    ).toBe(true);
+    expect(r.ok).toBe(false);
+  });
+
+  it("emits nothing on a tree with no lessons", async () => {
+    const r = await runLint(makeTempRepo({}));
+    expect(r.diagnostics.filter((d) => d.gate.startsWith("gate-19"))).toEqual(
+      []
+    );
+  });
+});
+
+describe("gate 19b — minimum reuse bar", () => {
+  it("errors when a slug is applied to only one lesson", async () => {
+    const r = await runLint(
+      makeTempRepo({
+        ...registry(["pdas", "oracles"]),
+        ...lesson("a", ["pdas", "oracles"]),
+        ...lesson("b", ["pdas"]),
+      })
+    );
+    const g = of(r, "gate-19b");
+    expect(g).toHaveLength(1);
+    expect(g[0]?.severity).toBe("error");
+    expect(g[0]?.message).toContain('"oracles"');
+    expect(g[0]?.message).toContain("courses/x/lessons/a/lesson.yaml");
+    expect(r.ok).toBe(false);
+  });
+
+  it("allows the singleton exceptions at one lesson", async () => {
+    const r = await runLint(
+      makeTempRepo({
+        ...registry(["pdas", "brazil-compliance", "earn-submission"]),
+        ...lesson("a", ["pdas", "brazil-compliance"]),
+        ...lesson("b", ["pdas", "earn-submission"]),
+      })
+    );
+    expect(of(r, "gate-19b")).toEqual([]);
+    expect(r.ok).toBe(true);
+  });
+
+  it("warns (not errors) on a registry slug applied to no lesson", async () => {
+    const r = await runLint(
+      makeTempRepo({
+        ...registry(["pdas", "dead-entry"]),
+        ...lesson("a", ["pdas"]),
+        ...lesson("b", ["pdas"]),
+      })
+    );
+    const g = of(r, "gate-19b");
+    expect(g).toHaveLength(1);
+    expect(g[0]?.severity).toBe("warning");
+    expect(g[0]?.message).toContain('"dead-entry"');
+    expect(r.ok).toBe(true);
+  });
+
+  it("counts a slug repeated within one lesson as a single application", async () => {
+    const r = await runLint(
+      makeTempRepo({
+        ...registry(["pdas"]),
+        ...lesson("a", ["pdas", "pdas"]),
+      })
+    );
+    expect(of(r, "gate-19b").some((d) => d.severity === "error")).toBe(true);
+  });
+});
+
+describe("gate 19c — interleaving-pair vocabulary (warning tier)", () => {
+  it("warns when a pair member is missing from the registry", async () => {
+    const r = await runLint(
+      makeTempRepo({
+        ...registry(["cpi"]),
+        ...lesson("a", ["cpi"]),
+        ...lesson("b", ["cpi"]),
+      })
+    );
+    const g = of(r, "gate-19c");
+    expect(
+      g.some(
+        (d) =>
+          d.severity === "warning" &&
+          /"signers"/.test(d.message) &&
+          /missing from skills\.yaml/.test(d.message)
+      )
+    ).toBe(true);
+    // Warning tier: pairs alone never fail the lint.
+    expect(r.ok).toBe(true);
+  });
+
+  it("warns when a pair member exists but is under-applied", async () => {
+    const r = await runLint(
+      makeTempRepo({
+        ...registry(["pdas", "account-model"]),
+        ...lesson("a", ["pdas", "account-model"]),
+        ...lesson("b", ["pdas"]),
+      })
+    );
+    expect(
+      of(r, "gate-19c").some(
+        (d) =>
+          /"account-model"/.test(d.message) && /1 lesson\(s\)/.test(d.message)
+      )
+    ).toBe(true);
+  });
+
+  it("stays silent for a pair whose members both exist with >=2 lessons", async () => {
+    const r = await runLint(
+      makeTempRepo({
+        ...registry(["pdas", "account-model"]),
+        ...lesson("a", ["pdas", "account-model"]),
+        ...lesson("b", ["pdas", "account-model"]),
+      })
+    );
+    expect(
+      of(r, "gate-19c").filter((d) => /"pdas"|"account-model"/.test(d.message))
+    ).toEqual([]);
+  });
+});
+
+describe("gate 19d — facet-only tags are not review-eligible", () => {
+  it("notices a denylisted slug in the registry without failing", async () => {
+    const r = await runLint(
+      makeTempRepo({
+        ...registry(["pdas", "typescript"]),
+        ...lesson("a", ["pdas", "typescript"]),
+        ...lesson("b", ["pdas", "typescript"]),
+      })
+    );
+    const g = of(r, "gate-19d");
+    expect(g).toHaveLength(1);
+    expect(g[0]?.severity).toBe("notice");
+    expect(g[0]?.message).toContain('"typescript"');
+    expect(g[0]?.message).toContain("not review-eligible");
+    expect(r.ok).toBe(true);
+  });
+
+  it("stays silent when no registry slug is denylisted", async () => {
+    const r = await runLint(
+      makeTempRepo({
+        ...registry(["pdas"]),
+        ...lesson("a", ["pdas"]),
+        ...lesson("b", ["pdas"]),
+      })
+    );
+    expect(of(r, "gate-19d")).toEqual([]);
+  });
+});

--- a/packages/content-lint/src/__tests__/gate19.test.ts
+++ b/packages/content-lint/src/__tests__/gate19.test.ts
@@ -16,6 +16,23 @@ blocks:
   };
 }
 
+/** A lesson at an explicit repo-relative directory (e.g. under `courses/_template`). */
+function lessonAt(
+  dir: string,
+  name: string,
+  skills: string[]
+): Record<string, string> {
+  return {
+    [`${dir}/lesson.yaml`]: `id: lesson-${name}
+slug: ${name}
+title: ${name}
+skills: [${skills.join(", ")}]
+blocks:
+  - { key: intro, type: prose, src: intro.md }
+`,
+  };
+}
+
 function registry(slugs: string[]): Record<string, string> {
   return {
     "skills.yaml": slugs.map((s) => `- slug: ${s}`).join("\n") + "\n",
@@ -89,6 +106,22 @@ describe("gate 19b — minimum reuse bar", () => {
   it("errors when a slug is applied to only one lesson", async () => {
     const r = await runLint(
       makeTempRepo({
+        ...registry(["pdas", "staking"]),
+        ...lesson("a", ["pdas", "staking"]),
+        ...lesson("b", ["pdas"]),
+      })
+    );
+    const g = of(r, "gate-19b");
+    expect(g).toHaveLength(1);
+    expect(g[0]?.severity).toBe("error");
+    expect(g[0]?.message).toContain('"staking"');
+    expect(g[0]?.message).toContain("courses/x/lessons/a/lesson.yaml");
+    expect(r.ok).toBe(false);
+  });
+
+  it("grandfathers `oracles` to a warning at one lesson (pending #559)", async () => {
+    const r = await runLint(
+      makeTempRepo({
         ...registry(["pdas", "oracles"]),
         ...lesson("a", ["pdas", "oracles"]),
         ...lesson("b", ["pdas"]),
@@ -96,10 +129,11 @@ describe("gate 19b — minimum reuse bar", () => {
     );
     const g = of(r, "gate-19b");
     expect(g).toHaveLength(1);
-    expect(g[0]?.severity).toBe("error");
+    expect(g[0]?.severity).toBe("warning");
     expect(g[0]?.message).toContain('"oracles"');
-    expect(g[0]?.message).toContain("courses/x/lessons/a/lesson.yaml");
-    expect(r.ok).toBe(false);
+    expect(g[0]?.message).toContain("#559");
+    // A grandfathered singleton never fails the lint.
+    expect(r.ok).toBe(true);
   });
 
   it("allows the singleton exceptions at one lesson", async () => {
@@ -218,5 +252,79 @@ describe("gate 19d — facet-only tags are not review-eligible", () => {
       })
     );
     expect(of(r, "gate-19d")).toEqual([]);
+  });
+});
+
+describe("gate 19 — `courses/_template` lessons are excluded from reuse counts", () => {
+  it("does not let a _template lesson lift a real singleton to two uses", async () => {
+    const r = await runLint(
+      makeTempRepo({
+        ...registry(["pdas", "staking"]),
+        // `staking` is used by exactly one real lesson…
+        ...lesson("a", ["pdas", "staking"]),
+        ...lesson("b", ["pdas"]),
+        // …and a template lesson that must NOT count toward the reuse bar.
+        ...lessonAt("courses/_template/lessons/tmpl", "tmpl", [
+          "pdas",
+          "staking",
+        ]),
+      })
+    );
+    const g = of(r, "gate-19b");
+    expect(g).toHaveLength(1);
+    expect(g[0]?.severity).toBe("error");
+    expect(g[0]?.message).toContain('"staking"');
+    // Named lesson is the real one, never the template.
+    expect(g[0]?.message).toContain("courses/x/lessons/a/lesson.yaml");
+    expect(r.ok).toBe(false);
+  });
+});
+
+describe("gate 19a — skills.yaml file shape", () => {
+  it("errors with a parse diagnostic on malformed YAML", async () => {
+    const r = await runLint(
+      makeTempRepo({
+        "skills.yaml": "[unterminated\n",
+        ...lesson("a", ["pdas"]),
+        ...lesson("b", ["pdas"]),
+      })
+    );
+    const g = of(r, "gate-19a");
+    expect(g).toHaveLength(1);
+    expect(g[0]?.severity).toBe("error");
+    expect(g[0]?.message).toContain("failed to parse");
+    expect(r.ok).toBe(false);
+  });
+
+  it("errors distinctly when skills.yaml is empty", async () => {
+    const r = await runLint(
+      makeTempRepo({
+        "skills.yaml": "",
+        ...lesson("a", ["pdas"]),
+        ...lesson("b", ["pdas"]),
+      })
+    );
+    const g = of(r, "gate-19a");
+    expect(g).toHaveLength(1);
+    expect(g[0]?.severity).toBe("error");
+    expect(g[0]?.message).toContain("empty");
+    expect(g[0]?.message).not.toContain("not a valid skills taxonomy");
+    expect(r.ok).toBe(false);
+  });
+
+  it("errors distinctly when skills.yaml is an object, not a list", async () => {
+    const r = await runLint(
+      makeTempRepo({
+        "skills.yaml": "slug: pdas\n",
+        ...lesson("a", ["pdas"]),
+        ...lesson("b", ["pdas"]),
+      })
+    );
+    const g = of(r, "gate-19a");
+    expect(g).toHaveLength(1);
+    expect(g[0]?.severity).toBe("error");
+    expect(g[0]?.message).toContain("not a valid skills taxonomy");
+    expect(g[0]?.message).not.toContain("empty");
+    expect(r.ok).toBe(false);
   });
 });

--- a/packages/content-lint/src/checks/gate19-skills.ts
+++ b/packages/content-lint/src/checks/gate19-skills.ts
@@ -42,7 +42,27 @@ export const ALLOWED_SINGLETON_SKILLS: readonly string[] = [
   "earn-submission",
 ];
 
+/**
+ * Pre-existing single-lesson slugs demoted from error to warning so this gate
+ * can merge without reddening courses-academy CI (its `validate-content.yml`
+ * pulls this linter from monorepo `main` and runs full-tree). `oracles` is
+ * applied to exactly one lesson today; the content fix (tag a second lesson or
+ * drop the slug + registry entry) is owner-gated and tracked on #559. Remove
+ * this slug from the list once that content PR lands. A *new* single-lesson
+ * slug not on this list still errors.
+ */
+export const GRANDFATHERED_SINGLETONS: readonly string[] = ["oracles"];
+
 const SKILLS_FILE = "skills.yaml";
+
+/**
+ * `courses/_template/**` holds scaffolding, not shippable content. Its lessons
+ * are excluded from gate 19 so a template tag never contributes to (or hides) a
+ * reuse-bar result — e.g. a template lesson sharing a real slug would otherwise
+ * lift that slug's count from 1 to 2 and suppress a legitimate singleton error.
+ * Scoped to gate 19 only; other gates keep their current view of `_template`.
+ */
+const TEMPLATE_LESSON_PREFIX = "courses/_template/";
 
 function loadRegistry(root: string, out: Diagnostic[]): SkillsTaxonomyT | null {
   let text: string;
@@ -69,6 +89,19 @@ function loadRegistry(root: string, out: Diagnostic[]): SkillsTaxonomyT | null {
         "error",
         SKILLS_FILE,
         `failed to parse: ${err instanceof Error ? err.message : String(err)}`
+      )
+    );
+    return null;
+  }
+  // An empty or whitespace-only file parses to null/undefined — a distinct,
+  // actionable failure from a mis-shaped (e.g. object) document below.
+  if (data == null) {
+    out.push(
+      diag(
+        "gate-19a",
+        "error",
+        SKILLS_FILE,
+        "skills.yaml is empty — expected a non-empty list of skill definitions"
       )
     );
     return null;
@@ -105,6 +138,7 @@ export function gate19Check(model: RepoModel): Diagnostic[] {
   // Distinct-lesson count per slug (a slug repeated within one lesson counts once).
   const lessonsBySlug = new Map<string, string[]>();
   for (const entry of model.lessons) {
+    if (entry.file.startsWith(TEMPLATE_LESSON_PREFIX)) continue;
     for (const slug of new Set(entry.lesson.skills)) {
       // 19a — registry resolution.
       if (!known.has(slug)) {
@@ -137,12 +171,16 @@ export function gate19Check(model: RepoModel): Diagnostic[] {
         )
       );
     } else if (uses.length === 1 && !ALLOWED_SINGLETON_SKILLS.includes(slug)) {
+      const grandfathered = GRANDFATHERED_SINGLETONS.includes(slug);
       out.push(
         diag(
           "gate-19b",
-          "error",
+          grandfathered ? "warning" : "error",
           SKILLS_FILE,
-          `skill "${slug}" is applied to only 1 lesson (${uses[0]}) — the minimum reuse bar is 2; tag a second lesson or drop the slug`
+          `skill "${slug}" is applied to only 1 lesson (${uses[0]}) — the minimum reuse bar is 2; tag a second lesson or drop the slug` +
+            (grandfathered
+              ? " (grandfathered to a warning pending the content fix, #559)"
+              : "")
         )
       );
     }

--- a/packages/content-lint/src/checks/gate19-skills.ts
+++ b/packages/content-lint/src/checks/gate19-skills.ts
@@ -1,0 +1,196 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { parse as parseYaml } from "yaml";
+import {
+  SkillsTaxonomy,
+  NON_REVIEW_ELIGIBLE_SKILLS,
+  REVIEW_INTERLEAVING_PAIRS,
+  type SkillsTaxonomyT,
+} from "@superteam-lms/content-schema";
+import { registerCheck } from "../lint";
+import { type RepoModel } from "../model";
+import { diag, type Diagnostic } from "../diagnostics";
+
+/**
+ * Gate 19 — skill-tag vocabulary (unified launch spec 2026-07-25 §3 item 7,
+ * PB-5). Numbered after §6.2's reserved 1–18 (8–15 are the quest/achievement
+ * and governance gates; 16–18 run at sync time). Four sub-gates:
+ *
+ *  19a (error)   every lesson `skills:` slug resolves to the repo-root
+ *                `skills.yaml` registry. This is the check that today only
+ *                runs at SYNC time (`checkSkillVocabulary`) — an invented
+ *                slug must fail the content PR, not the sync.
+ *  19b (error)   minimum reuse bar: every registry slug applied to at least
+ *                one lesson is applied to ≥2, except the allowed singletons
+ *                (`brazil-compliance`, `earn-submission`). A registry slug
+ *                applied to NO lesson is a warning (dead vocabulary entry).
+ *  19c (warning) interleaving-pair vocabulary: both members of each
+ *                REVIEW_INTERLEAVING_PAIRS pair exist in `skills.yaml` and
+ *                are applied to ≥2 lessons each. WARNING tier for now: the
+ *                current 24-slug registry (and the staged 42-slug one) lacks
+ *                6 of the 10 members, so an error tier would turn every
+ *                content PR red on a gap only a vocabulary decision can fix.
+ *                Upgrade to error once the pair vocabulary lands.
+ *  19d (notice)  facet-only tags: registry slugs on NON_REVIEW_ELIGIBLE_SKILLS
+ *                stay legal as catalog facets but are flagged so nobody keys a
+ *                review set on them.
+ */
+
+/** Registry slugs allowed to be applied to exactly one lesson. */
+export const ALLOWED_SINGLETON_SKILLS: readonly string[] = [
+  "brazil-compliance",
+  "earn-submission",
+];
+
+const SKILLS_FILE = "skills.yaml";
+
+function loadRegistry(root: string, out: Diagnostic[]): SkillsTaxonomyT | null {
+  let text: string;
+  try {
+    text = readFileSync(join(root, SKILLS_FILE), "utf8");
+  } catch {
+    out.push(
+      diag(
+        "gate-19a",
+        "error",
+        SKILLS_FILE,
+        "skills.yaml not found at the repo root — every lesson `skills:` slug must resolve to the canonical vocabulary"
+      )
+    );
+    return null;
+  }
+  let data: unknown;
+  try {
+    data = parseYaml(text, { version: "1.2" });
+  } catch (err) {
+    out.push(
+      diag(
+        "gate-19a",
+        "error",
+        SKILLS_FILE,
+        `failed to parse: ${err instanceof Error ? err.message : String(err)}`
+      )
+    );
+    return null;
+  }
+  const parsed = SkillsTaxonomy.safeParse(data);
+  if (!parsed.success) {
+    out.push(
+      diag(
+        "gate-19a",
+        "error",
+        SKILLS_FILE,
+        `not a valid skills taxonomy: ${parsed.error.issues
+          .map(
+            (i) => `${i.path.length ? i.path.join(".") + ": " : ""}${i.message}`
+          )
+          .join("; ")}`
+      )
+    );
+    return null;
+  }
+  return parsed.data;
+}
+
+export function gate19Check(model: RepoModel): Diagnostic[] {
+  const out: Diagnostic[] = [];
+  // An empty tree (no lessons at all) has nothing to resolve; a real content
+  // repo always has lessons, and every lesson requires non-empty `skills`.
+  if (model.lessons.length === 0) return out;
+
+  const registry = loadRegistry(model.root, out);
+  if (!registry) return out;
+  const known = new Set(registry.map((s) => s.slug));
+
+  // Distinct-lesson count per slug (a slug repeated within one lesson counts once).
+  const lessonsBySlug = new Map<string, string[]>();
+  for (const entry of model.lessons) {
+    for (const slug of new Set(entry.lesson.skills)) {
+      // 19a — registry resolution.
+      if (!known.has(slug)) {
+        out.push(
+          diag(
+            "gate-19a",
+            "error",
+            entry.file,
+            `skill "${slug}" is not in the skills.yaml vocabulary`
+          )
+        );
+        continue;
+      }
+      const files = lessonsBySlug.get(slug) ?? [];
+      files.push(entry.file);
+      lessonsBySlug.set(slug, files);
+    }
+  }
+
+  // 19b — minimum reuse bar over the registry.
+  for (const { slug } of registry) {
+    const uses = lessonsBySlug.get(slug) ?? [];
+    if (uses.length === 0) {
+      out.push(
+        diag(
+          "gate-19b",
+          "warning",
+          SKILLS_FILE,
+          `skill "${slug}" is in skills.yaml but applied to no lesson (dead vocabulary entry)`
+        )
+      );
+    } else if (uses.length === 1 && !ALLOWED_SINGLETON_SKILLS.includes(slug)) {
+      out.push(
+        diag(
+          "gate-19b",
+          "error",
+          SKILLS_FILE,
+          `skill "${slug}" is applied to only 1 lesson (${uses[0]}) — the minimum reuse bar is 2; tag a second lesson or drop the slug`
+        )
+      );
+    }
+  }
+
+  // 19c — interleaving-pair vocabulary (WARNING tier, see header).
+  for (const [a, b] of REVIEW_INTERLEAVING_PAIRS) {
+    for (const member of [a, b]) {
+      const label = `interleaving pair ${a} ↔ ${b}`;
+      if (!known.has(member)) {
+        out.push(
+          diag(
+            "gate-19c",
+            "warning",
+            SKILLS_FILE,
+            `skill "${member}" (${label}) is missing from skills.yaml — Wave 3 review sets cannot be built without it (unified launch spec §3 item 7)`
+          )
+        );
+      } else if ((lessonsBySlug.get(member) ?? []).length < 2) {
+        out.push(
+          diag(
+            "gate-19c",
+            "warning",
+            SKILLS_FILE,
+            `skill "${member}" (${label}) is applied to ${
+              (lessonsBySlug.get(member) ?? []).length
+            } lesson(s) — interleaving needs ≥2 each (unified launch spec §3 item 7)`
+          )
+        );
+      }
+    }
+  }
+
+  // 19d — facet-only tags: legal on lessons, never review keys.
+  for (const facet of NON_REVIEW_ELIGIBLE_SKILLS) {
+    if (known.has(facet)) {
+      out.push(
+        diag(
+          "gate-19d",
+          "notice",
+          SKILLS_FILE,
+          `skill "${facet}" is a catalog facet only — not review-eligible; review sets must not key on it (NON_REVIEW_ELIGIBLE_SKILLS)`
+        )
+      );
+    }
+  }
+
+  return out;
+}
+
+registerCheck(gate19Check);

--- a/packages/content-lint/src/checks/gate19-skills.ts
+++ b/packages/content-lint/src/checks/gate19-skills.ts
@@ -21,9 +21,11 @@ import { diag, type Diagnostic } from "../diagnostics";
  *                runs at SYNC time (`checkSkillVocabulary`) — an invented
  *                slug must fail the content PR, not the sync.
  *  19b (error)   minimum reuse bar: every registry slug applied to at least
- *                one lesson is applied to ≥2, except the allowed singletons
- *                (`brazil-compliance`, `earn-submission`). A registry slug
- *                applied to NO lesson is a warning (dead vocabulary entry).
+ *                one lesson is applied to ≥2, except slugs marked
+ *                `reviewExempt: true` in `skills.yaml` (single-use by design,
+ *                catalog spec §5 policy 4 — e.g. `brazil-compliance`,
+ *                `earn-submission`). A registry slug applied to NO lesson is a
+ *                warning (dead vocabulary entry).
  *  19c (warning) interleaving-pair vocabulary: both members of each
  *                REVIEW_INTERLEAVING_PAIRS pair exist in `skills.yaml` and
  *                are applied to ≥2 lessons each. WARNING tier for now: the
@@ -36,20 +38,22 @@ import { diag, type Diagnostic } from "../diagnostics";
  *                review set on them.
  */
 
-/** Registry slugs allowed to be applied to exactly one lesson. */
-export const ALLOWED_SINGLETON_SKILLS: readonly string[] = [
-  "brazil-compliance",
-  "earn-submission",
-];
-
 /**
- * Pre-existing single-lesson slugs demoted from error to warning so this gate
- * can merge without reddening courses-academy CI (its `validate-content.yml`
- * pulls this linter from monorepo `main` and runs full-tree). `oracles` is
- * applied to exactly one lesson today; the content fix (tag a second lesson or
- * drop the slug + registry entry) is owner-gated and tracked on #559. Remove
- * this slug from the list once that content PR lands. A *new* single-lesson
- * slug not on this list still errors.
+ * TEMPORARY, code-side escape hatch — distinct from the permanent declarative
+ * mechanism below. These are pre-existing single-lesson slugs on content *main*
+ * that the owner has not yet touched to either mark `reviewExempt: true` or fix
+ * (tag a second lesson / drop the slug). They are demoted from error to warning
+ * so this gate can merge without reddening courses-academy CI (its
+ * `validate-content.yml` pulls this linter from monorepo `main` and runs
+ * full-tree). `oracles` is applied to exactly one lesson on main today; the
+ * content fix is owner-gated and tracked on #559. Remove this slug once that
+ * content PR lands — at which point the ratchet is empty and the only exemption
+ * path is the declarative `reviewExempt` marker. A *new* single-lesson slug not
+ * on this list (and not `reviewExempt`) still errors.
+ *
+ * This is NOT the spec's exemption mechanism. A content author cannot express
+ * "single-use by design" here — that is `reviewExempt: true` in `skills.yaml`
+ * (catalog spec §5 policy 4), honoured in gate 19b below.
  */
 export const GRANDFATHERED_SINGLETONS: readonly string[] = ["oracles"];
 
@@ -159,7 +163,8 @@ export function gate19Check(model: RepoModel): Diagnostic[] {
   }
 
   // 19b — minimum reuse bar over the registry.
-  for (const { slug } of registry) {
+  for (const entry of registry) {
+    const { slug } = entry;
     const uses = lessonsBySlug.get(slug) ?? [];
     if (uses.length === 0) {
       out.push(
@@ -170,14 +175,23 @@ export function gate19Check(model: RepoModel): Diagnostic[] {
           `skill "${slug}" is in skills.yaml but applied to no lesson (dead vocabulary entry)`
         )
       );
-    } else if (uses.length === 1 && !ALLOWED_SINGLETON_SKILLS.includes(slug)) {
+    } else if (uses.length === 1) {
+      // Exactly one lesson fails the reuse bar unless the slug is exempt. Two
+      // escape hatches, deliberately kept distinct:
+      //   • reviewExempt (permanent, declarative, content-side): the author has
+      //     marked this slug single-use by design in skills.yaml — spec §5
+      //     policy 4. No diagnostic at all.
+      //   • GRANDFATHERED_SINGLETONS (temporary, code-side): pre-existing debt
+      //     on content main the owner hasn't marked/fixed yet. Demoted to a
+      //     warning so it never fails CI; see the constant above.
+      if (entry.reviewExempt) continue;
       const grandfathered = GRANDFATHERED_SINGLETONS.includes(slug);
       out.push(
         diag(
           "gate-19b",
           grandfathered ? "warning" : "error",
           SKILLS_FILE,
-          `skill "${slug}" is applied to only 1 lesson (${uses[0]}) — the minimum reuse bar is 2; tag a second lesson or drop the slug` +
+          `skill "${slug}" is applied to only 1 lesson (${uses[0]}) — the minimum reuse bar is 2; tag a second lesson, drop the slug, or mark it "reviewExempt: true" in skills.yaml if it is single-use by design` +
             (grandfathered
               ? " (grandfathered to a warning pending the content fix, #559)"
               : "")

--- a/packages/content-lint/src/checks/gate19-skills.ts
+++ b/packages/content-lint/src/checks/gate19-skills.ts
@@ -20,12 +20,17 @@ import { diag, type Diagnostic } from "../diagnostics";
  *                `skills.yaml` registry. This is the check that today only
  *                runs at SYNC time (`checkSkillVocabulary`) — an invented
  *                slug must fail the content PR, not the sync.
- *  19b (error)   minimum reuse bar: every registry slug applied to at least
- *                one lesson is applied to ≥2, except slugs marked
+ *  19b (warning) minimum reuse bar: every registry slug applied to at least
+ *                one lesson should be applied to ≥2, except slugs marked
  *                `reviewExempt: true` in `skills.yaml` (single-use by design,
  *                catalog spec §5 policy 4 — e.g. `brazil-compliance`,
- *                `earn-submission`). A registry slug applied to NO lesson is a
- *                warning (dead vocabulary entry).
+ *                `earn-submission`), which emit nothing. A registry slug applied
+ *                to NO lesson is also a warning (dead vocabulary entry).
+ *                WARNING tier for now — the reuse bar guards the Wave 3 review
+ *                queue, which cannot collect its benefit before the 5-course
+ *                catalog (C1–C4) exists; erroring today would block correct
+ *                content for a benefit that isn't yet reachable. Flip to error
+ *                once the catalog lands — see the TODO at the 19b loop (#596).
  *  19c (warning) interleaving-pair vocabulary: both members of each
  *                REVIEW_INTERLEAVING_PAIRS pair exist in `skills.yaml` and
  *                are applied to ≥2 lessons each. WARNING tier for now: the
@@ -37,25 +42,6 @@ import { diag, type Diagnostic } from "../diagnostics";
  *                stay legal as catalog facets but are flagged so nobody keys a
  *                review set on them.
  */
-
-/**
- * TEMPORARY, code-side escape hatch — distinct from the permanent declarative
- * mechanism below. These are pre-existing single-lesson slugs on content *main*
- * that the owner has not yet touched to either mark `reviewExempt: true` or fix
- * (tag a second lesson / drop the slug). They are demoted from error to warning
- * so this gate can merge without reddening courses-academy CI (its
- * `validate-content.yml` pulls this linter from monorepo `main` and runs
- * full-tree). `oracles` is applied to exactly one lesson on main today; the
- * content fix is owner-gated and tracked on #559. Remove this slug once that
- * content PR lands — at which point the ratchet is empty and the only exemption
- * path is the declarative `reviewExempt` marker. A *new* single-lesson slug not
- * on this list (and not `reviewExempt`) still errors.
- *
- * This is NOT the spec's exemption mechanism. A content author cannot express
- * "single-use by design" here — that is `reviewExempt: true` in `skills.yaml`
- * (catalog spec §5 policy 4), honoured in gate 19b below.
- */
-export const GRANDFATHERED_SINGLETONS: readonly string[] = ["oracles"];
 
 const SKILLS_FILE = "skills.yaml";
 
@@ -163,6 +149,17 @@ export function gate19Check(model: RepoModel): Diagnostic[] {
   }
 
   // 19b — minimum reuse bar over the registry.
+  //
+  // TODO(#596): flip the single-lesson case below from `warning` to `error`
+  // once the 5-course catalog (C1–C4) has landed. The bar exists to guard the
+  // Wave 3 spaced-review queue — a slug behind one lesson can only re-serve
+  // that lesson, never generate a genuine review item. That benefit is
+  // unreachable until the catalog exists, so until then a hard error would
+  // block correct, in-progress content for nothing (course 5's tags are
+  // legitimately single-use *today* and gain a second lesson as C1–C4 fill in).
+  // Warning tier surfaces every under-applied slug honestly on each run without
+  // reddening content CI; `reviewExempt` still silences the by-design
+  // singletons, which is what makes the eventual error-flip clean.
   for (const entry of registry) {
     const { slug } = entry;
     const uses = lessonsBySlug.get(slug) ?? [];
@@ -176,25 +173,16 @@ export function gate19Check(model: RepoModel): Diagnostic[] {
         )
       );
     } else if (uses.length === 1) {
-      // Exactly one lesson fails the reuse bar unless the slug is exempt. Two
-      // escape hatches, deliberately kept distinct:
-      //   • reviewExempt (permanent, declarative, content-side): the author has
-      //     marked this slug single-use by design in skills.yaml — spec §5
-      //     policy 4. No diagnostic at all.
-      //   • GRANDFATHERED_SINGLETONS (temporary, code-side): pre-existing debt
-      //     on content main the owner hasn't marked/fixed yet. Demoted to a
-      //     warning so it never fails CI; see the constant above.
+      // A slug marked `reviewExempt: true` is single-use by design (catalog
+      // spec §5 policy 4) — no diagnostic at all. Every other single-lesson
+      // slug warns (see the TODO above for why this is not yet an error).
       if (entry.reviewExempt) continue;
-      const grandfathered = GRANDFATHERED_SINGLETONS.includes(slug);
       out.push(
         diag(
           "gate-19b",
-          grandfathered ? "warning" : "error",
+          "warning",
           SKILLS_FILE,
-          `skill "${slug}" is applied to only 1 lesson (${uses[0]}) — the minimum reuse bar is 2; tag a second lesson, drop the slug, or mark it "reviewExempt: true" in skills.yaml if it is single-use by design` +
-            (grandfathered
-              ? " (grandfathered to a warning pending the content fix, #559)"
-              : "")
+          `skill "${slug}" is applied to only 1 lesson (${uses[0]}) — the minimum reuse bar is 2; tag a second lesson, drop the slug, or mark it "reviewExempt: true" in skills.yaml if it is single-use by design. Becomes an error once the 5-course catalog lands (#596)`
         )
       );
     }

--- a/packages/content-lint/src/checks/gate19-skills.ts
+++ b/packages/content-lint/src/checks/gate19-skills.ts
@@ -30,7 +30,7 @@ import { diag, type Diagnostic } from "../diagnostics";
  *                queue, which cannot collect its benefit before the 5-course
  *                catalog (C1–C4) exists; erroring today would block correct
  *                content for a benefit that isn't yet reachable. Flip to error
- *                once the catalog lands — see the TODO at the 19b loop (#596).
+ *                once the catalog lands — see the TODO at the 19b loop (#676).
  *  19c (warning) interleaving-pair vocabulary: both members of each
  *                REVIEW_INTERLEAVING_PAIRS pair exist in `skills.yaml` and
  *                are applied to ≥2 lessons each. WARNING tier for now: the
@@ -150,7 +150,7 @@ export function gate19Check(model: RepoModel): Diagnostic[] {
 
   // 19b — minimum reuse bar over the registry.
   //
-  // TODO(#596): flip the single-lesson case below from `warning` to `error`
+  // TODO(#676): flip the single-lesson case below from `warning` to `error`
   // once the 5-course catalog (C1–C4) has landed. The bar exists to guard the
   // Wave 3 spaced-review queue — a slug behind one lesson can only re-serve
   // that lesson, never generate a genuine review item. That benefit is
@@ -182,7 +182,7 @@ export function gate19Check(model: RepoModel): Diagnostic[] {
           "gate-19b",
           "warning",
           SKILLS_FILE,
-          `skill "${slug}" is applied to only 1 lesson (${uses[0]}) — the minimum reuse bar is 2; tag a second lesson, drop the slug, or mark it "reviewExempt: true" in skills.yaml if it is single-use by design. Becomes an error once the 5-course catalog lands (#596)`
+          `skill "${slug}" is applied to only 1 lesson (${uses[0]}) — the minimum reuse bar is 2; tag a second lesson, drop the slug, or mark it "reviewExempt: true" in skills.yaml if it is single-use by design. Becomes an error once the 5-course catalog lands (#676)`
         )
       );
     }

--- a/packages/content-lint/src/index.ts
+++ b/packages/content-lint/src/index.ts
@@ -12,3 +12,4 @@ export * from "./checks/gate6-executor";
 export * from "./checks/gate7-quiz";
 export * from "./checks/gate13a-capabilities";
 export * from "./checks/gate13bcd-widgets";
+export * from "./checks/gate19-skills";

--- a/packages/content-schema/schema/skills.schema.json
+++ b/packages/content-schema/schema/skills.schema.json
@@ -14,6 +14,9 @@
       },
       "description": {
         "type": "string"
+      },
+      "reviewExempt": {
+        "type": "boolean"
       }
     },
     "required": [

--- a/packages/content-schema/src/__tests__/skills.test.ts
+++ b/packages/content-schema/src/__tests__/skills.test.ts
@@ -39,6 +39,25 @@ describe("SkillDef", () => {
   it("rejects a malformed slug", () => {
     expect(SkillDef.safeParse({ slug: "Not A Slug" }).success).toBe(false);
   });
+
+  it("accepts the optional reviewExempt marker (catalog spec §5 policy 4)", () => {
+    const parsed = SkillDef.parse({
+      slug: "earn-submission",
+      reviewExempt: true,
+    });
+    expect(parsed.reviewExempt).toBe(true);
+  });
+
+  it("leaves reviewExempt undefined when absent (backward-compatible)", () => {
+    const parsed = SkillDef.parse({ slug: "pdas" });
+    expect(parsed.reviewExempt).toBeUndefined();
+  });
+
+  it("rejects a non-boolean reviewExempt", () => {
+    expect(
+      SkillDef.safeParse({ slug: "pdas", reviewExempt: "yes" }).success
+    ).toBe(false);
+  });
 });
 
 describe("SkillsTaxonomy", () => {

--- a/packages/content-schema/src/__tests__/skills.test.ts
+++ b/packages/content-schema/src/__tests__/skills.test.ts
@@ -4,6 +4,9 @@ import {
   SkillDef,
   SkillsTaxonomy,
   checkSkillVocabulary,
+  NON_REVIEW_ELIGIBLE_SKILLS,
+  REVIEW_INTERLEAVING_PAIRS,
+  isReviewEligibleSkill,
 } from "../skills";
 
 describe("SkillTag", () => {
@@ -87,5 +90,36 @@ describe("checkSkillVocabulary (#466 C3 — the allowlist guarantee)", () => {
   it("fails closed against an empty (absent skills.yaml) vocabulary", () => {
     const lessons = [{ id: "lesson-a", skills: ["pdas"] }];
     expect(checkSkillVocabulary(lessons, [])).toHaveLength(1);
+  });
+});
+
+describe("review-eligibility policy (unified launch spec §3 item 7)", () => {
+  it("denylists the facet-only tags", () => {
+    expect(isReviewEligibleSkill("typescript")).toBe(false);
+    expect(isReviewEligibleSkill("react")).toBe(false);
+    expect(isReviewEligibleSkill("program-basics")).toBe(false);
+    expect(isReviewEligibleSkill("pdas")).toBe(true);
+  });
+
+  it("every denylist entry and pair member is a valid skill slug", () => {
+    for (const slug of NON_REVIEW_ELIGIBLE_SKILLS) {
+      expect(SkillTag.safeParse(slug).success).toBe(true);
+    }
+    for (const [a, b] of REVIEW_INTERLEAVING_PAIRS) {
+      expect(SkillTag.safeParse(a).success).toBe(true);
+      expect(SkillTag.safeParse(b).success).toBe(true);
+    }
+  });
+
+  it("no interleaving-pair member is denylisted (pairs must be review-eligible)", () => {
+    for (const [a, b] of REVIEW_INTERLEAVING_PAIRS) {
+      expect(isReviewEligibleSkill(a), a).toBe(true);
+      expect(isReviewEligibleSkill(b), b).toBe(true);
+    }
+  });
+
+  it("pair members are distinct within and across pairs", () => {
+    const members = REVIEW_INTERLEAVING_PAIRS.flat();
+    expect(new Set(members).size).toBe(members.length);
   });
 });

--- a/packages/content-schema/src/skills.ts
+++ b/packages/content-schema/src/skills.ts
@@ -40,6 +40,44 @@ export const SkillsTaxonomy = z
 export type SkillsTaxonomyT = z.infer<typeof SkillsTaxonomy>;
 
 /**
+ * Skill tags that are catalog facets ONLY — never review keys (unified launch
+ * spec 2026-07-25 §3 item 7, restored from CAT-24). Tags of this grain
+ * ("typescript", "react", …) retrieve nothing useful for spaced review: a
+ * review set keyed on them would span half the catalog. They stay legal on
+ * lessons (the catalog and skill radar still facet on them); the review-set
+ * builder (Wave 3) must exclude them via {@link isReviewEligibleSkill}, and
+ * content-lint gate 19d surfaces them as facet-only notices.
+ */
+export const NON_REVIEW_ELIGIBLE_SKILLS = [
+  "typescript",
+  "react",
+  "program-basics",
+] as const;
+export type NonReviewEligibleSkill =
+  (typeof NON_REVIEW_ELIGIBLE_SKILLS)[number];
+
+/** True iff `slug` may key a review set (i.e. it is not a facet-only tag). */
+export function isReviewEligibleSkill(slug: string): boolean {
+  return !(NON_REVIEW_ELIGIBLE_SKILLS as readonly string[]).includes(slug);
+}
+
+/**
+ * The interleaving pairs Wave 3's review sets must be able to express
+ * (unified launch spec 2026-07-25 §3 item 7). Both members of each pair must
+ * exist in `skills.yaml` AND be applied to ≥2 lessons each; content-lint
+ * gate 19c asserts this against the content tree. Shared from here so the
+ * review-set builder consumes the same pairs the linter enforces.
+ */
+export const REVIEW_INTERLEAVING_PAIRS: readonly (readonly [string, string])[] =
+  [
+    ["pdas", "account-model"],
+    ["cpi", "signers"],
+    ["anchor", "program-security"],
+    ["checked-arithmetic", "rust-result"],
+    ["compute-budget", "transaction-fees"],
+  ] as const;
+
+/**
  * The C3 allowlist guarantee: every lesson `skills` slug must be a member of
  * the canonical vocabulary. Pure and side-effect-free — callers (the offline
  * compiler and the admin-sync validator) accumulate the returned issues into

--- a/packages/content-schema/src/skills.ts
+++ b/packages/content-schema/src/skills.ts
@@ -17,6 +17,16 @@ export const SkillDef = z.object({
   slug: SkillTag,
   label: z.string().min(1).optional(),
   description: z.string().optional(),
+  /**
+   * Marks a slug as single-use *by design* (catalog spec §5 policy 4). A tag so
+   * marked is exempt from content-lint gate 19b's ≥2-lesson reuse bar: the
+   * author is declaring "this tag will only ever back one lesson" (e.g.
+   * `brazil-compliance`, `earn-submission`) rather than the linter guessing.
+   * Optional and defaulting to absent, so every existing entry keeps its
+   * current (non-exempt) behaviour. Purely a review-bar signal — it has no
+   * bearing on registry resolution (19a) or facet-only classification (19d).
+   */
+  reviewExempt: z.boolean().optional(),
 });
 export type SkillDefT = z.infer<typeof SkillDef>;
 


### PR DESCRIPTION
Closes #596. Unified launch spec §3 item 7 (PB-5): `skills:` was format-validated only — an invented slug passed content CI and failed at SYNC time (`checkSkillVocabulary` runs in the compiler/sync, not in lint). This adds **gate 19** to `packages/content-lint`, numbered clear of spec §6.2's reserved gates 1–18.

## The four sub-gates

| Sub-gate | Severity | Rule |
|---|---|---|
| `gate-19a` | **error** | Every lesson `skills:` slug resolves to the repo-root `skills.yaml` (42-slug registry, D-D settled). Missing/unparseable/invalid `skills.yaml` is itself an error when lessons exist. |
| `gate-19b` | **error** / warning | Minimum reuse bar: a registry slug applied to exactly 1 lesson errors (message names the lone lesson), EXCEPT `brazil-compliance` and `earn-submission` (allowed singletons). A registry slug applied to 0 lessons is a warning (dead vocabulary entry). |
| `gate-19c` | **warning** | Both members of each interleaving pair (`pdas`↔`account-model`, `cpi`↔`signers`, `anchor`↔`program-security`, `checked-arithmetic`↔`rust-result`, `compute-budget`↔`transaction-fees`) exist in `skills.yaml` AND are applied to ≥2 lessons. Warning tier for now — see "honest current state" below; upgrade to error once the pair vocabulary lands. |
| `gate-19d` | notice | Registry slugs on the review denylist are flagged facet-only. |

## Review-eligibility mechanism (rule 4)

Skills are consumed today as catalog facets and by the skill radar; the review queue (Wave 3) does not exist yet, and `typescript`/`react` are legitimately applied to live lessons — so a lint *error* would be wrong. Smallest correct mechanism: shared constants in `@superteam-lms/content-schema` (`packages/content-schema/src/skills.ts`):

- `NON_REVIEW_ELIGIBLE_SKILLS = ["typescript", "react", "program-basics"]` + `isReviewEligibleSkill(slug)` — Wave 3's review-set builder must filter through this.
- `REVIEW_INTERLEAVING_PAIRS` — the five pairs, consumed by gate 19c so the linter enforces exactly what the builder will use.
- Tests assert pair members are never denylisted and all constants are valid slugs.

## Honest current state (run against `solanabr/courses-academy` the way CI does)

**`origin/main` (82 lessons, 24-slug registry) — `content-lint: FAILED (1 error)`, the only error on the tree:**

```
[error] gate-19b skills.yaml: skill "oracles" is applied to only 1 lesson (courses/defi-on-solana/lessons/oracle-design/lesson.yaml) — the minimum reuse bar is 2; tag a second lesson or drop the slug
[warning] gate-19c ×6: signers, program-security, checked-arithmetic, rust-result, compute-budget, transaction-fees — missing from skills.yaml
[notice] gate-19d ×2: typescript, react — facet-only, not review-eligible
```

**⚠️ Merging this turns content-repo CI red by exactly that one pre-existing `oracles` error** (a two-line content PR fixes it: tag a second lesson or drop the slug + registry entry). Per the issue's constraint, content is not touched here.

**Content PR #6 (C5, the 42-slug registry): `FAILED (11 errors)`** — `oracles` + 10 used-once C5 slugs (`token-2022`, `transfer-hook`, `protocol-versioning`, `version-pinning`, `solana-pay`, `api-monetization`, `subscriptions-program`, `subscription-authority`, `recurring-delegation`, `technical-writing`). `earn-submission` (1 use) and `brazil-compliance` (2 uses) correctly pass. This is precisely the "draft syllabi invented tags" consolidation the spec wants forced before merge.

**Content PR #7 (LX-D1): `FAILED (1 error)`** — same pre-existing `oracles` only.

**Known-red gap filed (gate 19c, warning tier):** 6 of the 10 interleaving-pair members are missing from the registry — in BOTH the live 24-slug `skills.yaml` and the staged 42-slug one in content PR #6: `signers`, `program-security`, `checked-arithmetic`, `rust-result`, `compute-budget`, `transaction-fees`. Wave 3's review sets cannot be built until a vocabulary decision adds them (and applies each to ≥2 lessons). Fixing the registry is out of scope here (content untouched); warning tier keeps content CI unblocked on this while surfacing it on every run.

## Verification

- `packages/content-lint`: 13 files / 52 tests pass (17 new in `gate19.test.ts`, mirroring the gate-13a test pattern via `makeTempRepo`).
- `packages/content-schema`: 15 files / 131 tests pass (4 new).
- `pnpm typecheck` (turbo, 6/6), `pnpm lint`, `pnpm -r test` (incl. apps/web 1082 tests) all green. Zero `any`.
- Good-template fixture gained a `skills.yaml`; its lesson tags were rebalanced so every fixture slug meets the ≥2 reuse bar (fixture-only change — no real content modified).


---

## Update (gate-bounce fix, c192e4d) — declarative `reviewExempt`, not a hardcoded allowlist

The first cut exempted singletons via a code-side `ALLOWED_SINGLETON_SKILLS = ["brazil-compliance","earn-submission"]` allowlist. That is **not** the mechanism catalog spec §5 policy 4 specifies ("*single-use by design and are review-exempt; mark them as such in `skills.yaml`*"), and it broke owner-gated courses-academy **PR #6** — the linter run against #6 failed on 10 course-5 single-use tags (a content author had no way to declare "single-use by design" in the file the spec names).

### What changed

- **`packages/content-schema` — `SkillDef`** gains an optional, backward-compatible `reviewExempt?: boolean`. Absent ⇒ current (non-exempt) behaviour; committed JSON schema regenerated.
- **`packages/content-lint` gate 19b** now exempts a single-lesson slug from the ≥2 reuse bar when its `skills.yaml` entry is `reviewExempt: true`. The old hardcoded `ALLOWED_SINGLETON_SKILLS` is **removed** — `brazil-compliance`/`earn-submission` are exempt only if marked, exactly as the spec requires.
- **`GRANDFATHERED_SINGLETONS = ["oracles"]`** is kept **only** as the temporary, code-side escape hatch for pre-existing content-*main* debt (owner hasn't yet marked or fixed it, #559), and is documented as distinct from — and independently removable from — the permanent declarative mechanism. A *new* unmarked singleton still errors.

### Required coordinated content-side step (courses-academy — owner-gated, NOT done here)

This monorepo PR gives content authors the marker; **content must apply it.** Before/with merging #638, courses-academy `skills.yaml` must add `reviewExempt: true` to:

- `brazil-compliance`
- `earn-submission`
- course 5's ten single-use tags: `api-monetization`, `protocol-versioning`, `recurring-delegation`, `solana-pay`, `subscription-authority`, `subscriptions-program`, `technical-writing`, `token-2022`, `transfer-hook`, `version-pinning`

(These are the 12 tags whose entries the linter flags as single-use once #638's linter runs against #6. `brazil-compliance` is at 2 uses on #6 today so it passes the bar regardless, but the spec names it explicitly, so mark it for correctness/future-proofing.)

**Sequencing:** until those markers land, the linter still exits **0 on content main** (`oracles` grandfathered) but **would flag #6's tags** — so #6's `skills.yaml` markers are the unblock. Merge #638 in coordination with (or after) the content markers so #6 never goes red underneath the owner.

### Verification (live, this branch's linter)

| Target | Result |
|---|---|
| content `main` (`oracles` grandfathered) | `content-lint: OK (0 errors)`, **exit 0** |
| PR #6 **unmodified** | `FAILED (11 errors)` — the 10 course-5 tags + `earn-submission` |
| PR #6 **+ the 12 `reviewExempt` markers** (simulated locally) | `content-lint: OK (0 errors)`, **exit 0** ✅ |

- `packages/content-lint`: 13 files / **59 tests** pass (+2: unmarked-singleton-still-errors, reviewExempt-honoured-for-any-slug; renamed the singleton test to use the marker).
- `packages/content-schema`: 15 files / **134 tests** pass (+3: marker accepted, absent ⇒ undefined, non-boolean rejected).
- `pnpm typecheck` 6/6, `pnpm lint` green (only pre-existing apps/web import-order warnings). Zero `any`.


---

## Update 2 (third-round fix, `3736381`) — 19b → warning tier until the catalog lands (option c)

The gate merged courses-academy #6, so course 5's tags are now on content **main** — and 19b-as-error fails main itself (11 single-use tags). The correct ruling (endorsed by the gate) is **option (c)**: the reuse bar guards the Wave-3 spaced-review queue, whose benefit can't be collected before the 5-course catalog exists, so erroring today blocks correct in-progress content for nothing.

**Change:**
- **19b now emits `warning`** (same message + "*Becomes an error once the 5-course catalog lands (#676)*"). `TODO(#676)` at the 19b loop marks the flip. **19a stays `error`** — invented slugs still fail the PR.
- **`GRANDFATHERED_SINGLETONS` removed entirely** — obsolete once every singleton warns uniformly; `oracles` no longer needs a code-side special case.
- **`reviewExempt` declarative mechanism kept fully intact** — it silences the warning for by-design singletons and is what makes the eventual error-flip clean.

**Tracking issue for the flip:** #676 — "content-lint gate 19b: flip the minimum-reuse bar from warning to error once the 5-course catalog (C1–C4) lands." Cited in the code TODO + warning message (`315d50a` repointed it from #596, which is this PR's own parent and closes on merge).

### Live run — content `main` (now includes course 5 via #6/#7)
`content-lint: OK (40 diagnostics, 0 errors)`, **exit 0**. The 12 single-use slugs (`oracles` + course 5's 11) all report as **gate-19b warnings**, none as errors. The gate no longer fails main.

### Paired content PR (courses-academy)
**courses-academy #8** (branch `content/skills-reviewexempt-by-design-26-07-2026`) adds `reviewExempt: true` to exactly `brazil-compliance` and `earn-submission` (the two the spec names as single-use **by design**). The other nine course-5 tags are temporarily single-use and are deliberately left as honest warnings. Merge #638 in coordination with #8.

### Tests
`packages/content-lint` 13 files / **59 tests** pass (reuse-bar tests updated to warning tier; the ex-`oracles`-grandfather test now asserts uniform warning treatment with no code-side escape hatch). `packages/content-schema` 15 / **134** pass (unchanged — the `reviewExempt` schema landed in `c192e4d`). `pnpm typecheck` 6/6, `pnpm lint` green.

