### PR TITLE
feat(editor): Monaco a11y — platform-aware Tab-trap escape hint + F8 (LX-C5)

### DIFF
--- a/apps/web/src/components/editor/__tests__/code-editor.test.tsx
+++ b/apps/web/src/components/editor/__tests__/code-editor.test.tsx
@@ -1,0 +1,178 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, act, cleanup } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import type { EditorProps, Monaco, OnMount } from "@monaco-editor/react";
+import type { editor } from "monaco-editor";
+import { CodeEditor } from "../code-editor";
+import messages from "@/messages/en.json";
+
+const captured = vi.hoisted(() => ({
+  props: null as unknown,
+}));
+
+vi.mock("@monaco-editor/react", () => ({
+  __esModule: true,
+  default: (props: unknown) => {
+    captured.props = props;
+    return <div data-testid="monaco-editor" />;
+  },
+}));
+
+vi.mock("next-themes", () => ({
+  useTheme: () => ({ resolvedTheme: "dark" }),
+}));
+
+function editorProps(): EditorProps {
+  return captured.props as EditorProps;
+}
+
+/**
+ * Minimal stand-in for Monaco's IStandaloneCodeEditor covering exactly what
+ * CodeEditor.handleMount touches, plus manual focus/blur triggers.
+ */
+function makeFakeEditor() {
+  const focusCallbacks: Array<() => void> = [];
+  const blurCallbacks: Array<() => void> = [];
+  const domNode = document.createElement("div");
+  const textarea = document.createElement("textarea");
+  domNode.appendChild(textarea);
+
+  const fake = {
+    onDidFocusEditorWidget: (cb: () => void) => {
+      focusCallbacks.push(cb);
+      return { dispose: vi.fn() };
+    },
+    onDidBlurEditorWidget: (cb: () => void) => {
+      blurCallbacks.push(cb);
+      return { dispose: vi.fn() };
+    },
+    getDomNode: () => domNode,
+    setValue: vi.fn(),
+    getValue: () => "",
+  };
+
+  return {
+    instance: fake as unknown as editor.IStandaloneCodeEditor,
+    textarea,
+    focus: () => focusCallbacks.forEach((cb) => cb()),
+    blur: () => blurCallbacks.forEach((cb) => cb()),
+  };
+}
+
+function renderEditor() {
+  return render(
+    <NextIntlClientProvider locale="en" messages={messages}>
+      <CodeEditor
+        lessonId="lesson-test"
+        initialCode="const a = 1;"
+        language="typescript"
+      />
+    </NextIntlClientProvider>
+  );
+}
+
+function mountFakeEditor(): ReturnType<typeof makeFakeEditor> {
+  const fake = makeFakeEditor();
+  const onMount = editorProps().onMount as OnMount;
+  act(() => {
+    onMount(fake.instance, {} as unknown as Monaco);
+  });
+  return fake;
+}
+
+function setNavigatorPlatform(platform: string): void {
+  Object.defineProperty(window.navigator, "platform", {
+    value: platform,
+    configurable: true,
+  });
+}
+
+afterEach(() => {
+  cleanup();
+  // Remove any per-test platform override (restores jsdom's prototype getter).
+  Reflect.deleteProperty(window.navigator, "platform");
+});
+
+describe("CodeEditor a11y (LX-C5)", () => {
+  it("labels the editor region and associates the escape hint via aria-describedby", () => {
+    setNavigatorPlatform("Win32");
+    renderEditor();
+
+    const group = screen.getByRole("group", { name: "Code editor" });
+    const hintId = group.getAttribute("aria-describedby");
+    expect(hintId).toBeTruthy();
+
+    const hint = document.getElementById(hintId as string);
+    expect(hint).toBeInTheDocument();
+    expect(hint).toHaveTextContent(
+      "Press Ctrl+M to toggle whether Tab indents code or moves focus out of the editor. Press F8 or Shift+F8 to cycle through errors."
+    );
+  });
+
+  it("advertises the macOS chord (Ctrl+Shift+M) on Apple platforms", () => {
+    setNavigatorPlatform("MacIntel");
+    renderEditor();
+
+    const group = screen.getByRole("group", { name: "Code editor" });
+    const hint = document.getElementById(
+      group.getAttribute("aria-describedby") as string
+    );
+    expect(hint).toHaveTextContent(/Ctrl\+Shift\+M/);
+  });
+
+  it("passes the a11y editor options to Monaco", () => {
+    renderEditor();
+
+    const options = editorProps()
+      .options as editor.IStandaloneEditorConstructionOptions;
+    expect(options.accessibilitySupport).toBe("auto");
+    expect(options.ariaLabel).toBe("Code editor");
+  });
+
+  it("reveals the hint while the editor has focus and dims it on blur, without unmounting it", () => {
+    setNavigatorPlatform("Win32");
+    renderEditor();
+    const fake = mountFakeEditor();
+
+    const group = screen.getByRole("group", { name: "Code editor" });
+    const hint = document.getElementById(
+      group.getAttribute("aria-describedby") as string
+    ) as HTMLElement;
+
+    expect(hint).not.toHaveAttribute("data-focused");
+    expect(hint.className).toContain("opacity-0");
+
+    act(() => fake.focus());
+    expect(hint).toHaveAttribute("data-focused", "true");
+    expect(hint.className).toContain("opacity-100");
+
+    act(() => fake.blur());
+    expect(hint).not.toHaveAttribute("data-focused");
+    expect(hint.className).toContain("opacity-0");
+    // Still in the DOM (and the accessibility tree) when visually hidden.
+    expect(hint).toBeInTheDocument();
+  });
+
+  it("wires aria-describedby onto Monaco's focus-receiving textarea", () => {
+    renderEditor();
+    const fake = mountFakeEditor();
+
+    const group = screen.getByRole("group", { name: "Code editor" });
+    expect(fake.textarea.getAttribute("aria-describedby")).toBe(
+      group.getAttribute("aria-describedby")
+    );
+  });
+
+  it("introduces no focus stop of its own (no focusable content in the hint)", () => {
+    renderEditor();
+
+    const group = screen.getByRole("group", { name: "Code editor" });
+    const hint = document.getElementById(
+      group.getAttribute("aria-describedby") as string
+    ) as HTMLElement;
+
+    expect(hint).not.toHaveAttribute("tabindex");
+    expect(hint.querySelector("a, button, input, [tabindex]")).toBeNull();
+  });
+});

--- a/apps/web/src/components/editor/code-editor.tsx
+++ b/apps/web/src/components/editor/code-editor.tsx
@@ -4,11 +4,13 @@ import {
   forwardRef,
   useCallback,
   useEffect,
+  useId,
   useImperativeHandle,
   useRef,
+  useState,
 } from "react";
 import Editor, { type OnMount, type BeforeMount } from "@monaco-editor/react";
-import type { editor } from "monaco-editor";
+import type { editor, IDisposable } from "monaco-editor";
 import { useTheme } from "next-themes";
 import { useTranslations } from "next-intl";
 import { superteamDark, superteamLight, THEME_MAP } from "./themes";
@@ -18,6 +20,7 @@ import type {
   EditorLanguage,
 } from "./types";
 import { cn } from "@/lib/utils";
+import { tabFocusModeChord } from "@/lib/utils/keyboard";
 
 const AUTOSAVE_DELAY_MS = 1000;
 
@@ -68,6 +71,20 @@ export const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(
     const tA11y = useTranslations("a11y");
     const editorRef = useRef<editor.IStandaloneCodeEditor | null>(null);
 
+    // Tab-trap escape affordance (LX-C5 / WCAG 2.1.2). Monaco traps Tab by
+    // design; the built-in escape is `editor.action.toggleTabFocusMode`, bound
+    // to Ctrl+M (Windows/Linux) / Ctrl+Shift+M (macOS). The chord is resolved
+    // client-side after mount — during SSR/hydration there is no navigator, so
+    // rendering it eagerly would mismatch on Macs.
+    const hintId = useId();
+    const [escapeChord, setEscapeChord] = useState<string | null>(null);
+    const [isFocused, setIsFocused] = useState(false);
+    const focusListenersRef = useRef<IDisposable[]>([]);
+
+    useEffect(() => {
+      setEscapeChord(tabFocusModeChord());
+    }, []);
+
     useImperativeHandle(
       ref,
       () => ({
@@ -102,6 +119,21 @@ export const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(
       (editorInstance) => {
         editorRef.current = editorInstance;
 
+        // Show the Tab-trap escape hint while the editor owns the keyboard.
+        focusListenersRef.current.push(
+          editorInstance.onDidFocusEditorWidget(() => setIsFocused(true)),
+          editorInstance.onDidBlurEditorWidget(() => setIsFocused(false))
+        );
+
+        // Associate the hint with the element that actually receives focus.
+        // Monaco has no public describedby option (only `ariaLabel`), so this
+        // reaches for its hidden <textarea>; the group-level aria-describedby
+        // below remains the fallback if the internal structure ever changes.
+        editorInstance
+          .getDomNode()
+          ?.querySelector("textarea")
+          ?.setAttribute("aria-describedby", hintId);
+
         // Restore saved code from localStorage
         try {
           const saved = localStorage.getItem(getStorageKey(lessonId));
@@ -112,7 +144,7 @@ export const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(
           // localStorage may be unavailable
         }
       },
-      [lessonId]
+      [lessonId, hintId]
     );
 
     const handleChange = useCallback(
@@ -148,74 +180,110 @@ export const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(
       }
     }, [value]);
 
-    // Cleanup autosave timer on unmount
+    // Cleanup autosave timer + focus listeners on unmount
     useEffect(() => {
+      const focusListeners = focusListenersRef.current;
       return () => {
         if (autosaveTimerRef.current) {
           clearTimeout(autosaveTimerRef.current);
         }
+        focusListeners.forEach((listener) => listener.dispose());
+        focusListeners.length = 0;
       };
     }, []);
 
     return (
       <div
+        role="group"
         className={cn(
-          "relative h-full w-full overflow-hidden rounded-md border",
+          "relative flex h-full w-full flex-col overflow-hidden rounded-md border",
           className
         )}
         aria-label={tA11y("codeEditor")}
+        aria-describedby={hintId}
       >
-        <Editor
-          defaultValue={initialCode}
-          language={getMonacoLanguage(language)}
-          theme={themeName}
-          beforeMount={handleBeforeMount}
-          onMount={handleMount}
-          onChange={handleChange}
-          loading={<EditorSkeleton />}
-          options={{
-            readOnly,
-            minimap: { enabled: false },
-            fontSize: 14,
-            lineHeight: 22,
-            fontFamily:
-              "'JetBrains Mono', 'Fira Code', 'Cascadia Code', Menlo, monospace",
-            fontLigatures: true,
-            tabSize: 2,
-            insertSpaces: true,
-            wordWrap: "off",
-            scrollBeyondLastLine: false,
-            automaticLayout: true,
-            padding: { top: 16, bottom: 16 },
-            renderLineHighlight: "line",
-            cursorBlinking: "smooth",
-            cursorSmoothCaretAnimation: "on",
-            smoothScrolling: true,
-            bracketPairColorization: { enabled: true },
-            guides: {
-              bracketPairs: true,
-              indentation: true,
-            },
-            suggest: {
-              showKeywords: true,
-              showSnippets: true,
-            },
-            quickSuggestions: {
-              other: true,
-              comments: false,
-              strings: false,
-            },
-            scrollbar: {
-              verticalScrollbarSize: 8,
-              horizontalScrollbarSize: 8,
-            },
-            overviewRulerBorder: false,
-            hideCursorInOverviewRuler: true,
-            fixedOverflowWidgets: true,
-            contextmenu: true,
-            accessibilitySupport: "auto",
-          }}
-        />
+        <div className="relative min-h-0 flex-1">
+          <Editor
+            defaultValue={initialCode}
+            language={getMonacoLanguage(language)}
+            theme={themeName}
+            beforeMount={handleBeforeMount}
+            onMount={handleMount}
+            onChange={handleChange}
+            loading={<EditorSkeleton />}
+            options={{
+              readOnly,
+              // Names Monaco's focus target (its hidden <textarea>) for screen
+              // readers; the group label alone is not announced on focus.
+              ariaLabel: tA11y("codeEditor"),
+              minimap: { enabled: false },
+              fontSize: 14,
+              lineHeight: 22,
+              fontFamily:
+                "'JetBrains Mono', 'Fira Code', 'Cascadia Code', Menlo, monospace",
+              fontLigatures: true,
+              tabSize: 2,
+              insertSpaces: true,
+              wordWrap: "off",
+              scrollBeyondLastLine: false,
+              automaticLayout: true,
+              padding: { top: 16, bottom: 16 },
+              renderLineHighlight: "line",
+              cursorBlinking: "smooth",
+              cursorSmoothCaretAnimation: "on",
+              smoothScrolling: true,
+              bracketPairColorization: { enabled: true },
+              guides: {
+                bracketPairs: true,
+                indentation: true,
+              },
+              suggest: {
+                showKeywords: true,
+                showSnippets: true,
+              },
+              quickSuggestions: {
+                other: true,
+                comments: false,
+                strings: false,
+              },
+              scrollbar: {
+                verticalScrollbarSize: 8,
+                horizontalScrollbarSize: 8,
+              },
+              overviewRulerBorder: false,
+              hideCursorInOverviewRuler: true,
+              fixedOverflowWidgets: true,
+              contextmenu: true,
+              // "auto" defers to Monaco's screen-reader detection, which also
+              // scales accessibilityPageSize. Tab focus mode itself stays OFF by
+              // default (Tab indents while coding); the built-in
+              // `editor.action.toggleTabFocusMode` chord advertised by the hint
+              // below is the escape (WCAG 2.1.2), and F8 / Shift+F8 marker
+              // navigation works against the syntax-only diagnostics configured
+              // in beforeMount.
+              accessibilitySupport: "auto",
+            }}
+          />
+        </div>
+
+        {/* Tab-trap escape hint — reserved strip, so its appearance on focus
+            never shifts the layout. Plain text (no focusable content: it must
+            not add a keyboard stop of its own) that fades in while the editor
+            owns the keyboard. It stays in the accessibility tree at opacity-0,
+            keeping the aria-describedby associations valid at all times.
+            {escapeChord} is null until mount (SSR has no navigator). */}
+        <p
+          id={hintId}
+          data-focused={isFocused || undefined}
+          className={cn(
+            "min-h-7 shrink-0 border-t border-border bg-card px-3 py-1.5 text-xs text-text-3 transition-opacity motion-reduce:transition-none",
+            isFocused ? "opacity-100" : "opacity-0"
+          )}
+        >
+          {escapeChord
+            ? tA11y("editorKeyboardHint", { chord: escapeChord })
+            : " "}
+        </p>
       </div>
     );
   }

--- a/apps/web/src/lib/utils/__tests__/keyboard.test.ts
+++ b/apps/web/src/lib/utils/__tests__/keyboard.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi } from "vitest";
+import { isApplePlatform, tabFocusModeChord } from "../keyboard";
+
+function src(
+  platform: string,
+  userAgent = ""
+): {
+  platform: string;
+  userAgent: string;
+} {
+  return { platform, userAgent };
+}
+
+describe("isApplePlatform", () => {
+  it("detects macOS via navigator.platform", () => {
+    expect(isApplePlatform(src("MacIntel"))).toBe(true);
+    expect(isApplePlatform(src("MacPPC"))).toBe(true);
+  });
+
+  it("detects iOS devices (hardware-keyboard Safari users)", () => {
+    expect(isApplePlatform(src("iPhone"))).toBe(true);
+    expect(isApplePlatform(src("iPad"))).toBe(true);
+    expect(isApplePlatform(src("iPod"))).toBe(true);
+  });
+
+  it("is false on Windows and Linux", () => {
+    expect(isApplePlatform(src("Win32"))).toBe(false);
+    expect(isApplePlatform(src("Linux x86_64"))).toBe(false);
+  });
+
+  it("falls back to the user agent when platform is empty", () => {
+    expect(
+      isApplePlatform(
+        src("", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)")
+      )
+    ).toBe(true);
+    expect(
+      isApplePlatform(src("", "Mozilla/5.0 (Windows NT 10.0; Win64; x64)"))
+    ).toBe(false);
+  });
+
+  it("does not fall back to the user agent when platform is set", () => {
+    // A Windows platform with 'Mac' elsewhere in the UA must not read as Apple.
+    expect(
+      isApplePlatform(src("Win32", "Mozilla/5.0 (Macintosh; Intel Mac OS X)"))
+    ).toBe(false);
+  });
+
+  it("is false when no navigator global exists (SSR)", () => {
+    vi.stubGlobal("navigator", undefined);
+    try {
+      expect(isApplePlatform()).toBe(false);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+});
+
+describe("tabFocusModeChord", () => {
+  it("advertises Ctrl+Shift+M on Apple platforms", () => {
+    expect(tabFocusModeChord(src("MacIntel"))).toBe("Ctrl+Shift+M");
+    expect(tabFocusModeChord(src("iPad"))).toBe("Ctrl+Shift+M");
+  });
+
+  it("advertises Ctrl+M on Windows/Linux", () => {
+    expect(tabFocusModeChord(src("Win32"))).toBe("Ctrl+M");
+    expect(tabFocusModeChord(src("Linux x86_64"))).toBe("Ctrl+M");
+  });
+
+  it("always returns one of the two Monaco keybindings", () => {
+    expect(["Ctrl+M", "Ctrl+Shift+M"]).toContain(tabFocusModeChord());
+  });
+});

--- a/apps/web/src/lib/utils/keyboard.ts
+++ b/apps/web/src/lib/utils/keyboard.ts
@@ -1,0 +1,41 @@
+/**
+ * Platform-aware keyboard helpers for the Monaco editor a11y affordance
+ * (LX-C5 / #568, WCAG 2.1.2 "No Keyboard Trap").
+ *
+ * Monaco traps the Tab key by design (Tab indents). The built-in escape is
+ * "Toggle Tab Key Moves Focus", bound to Ctrl+M on Windows/Linux and
+ * Ctrl+Shift+M on macOS. A hardcoded "Ctrl+M" hint would leave macOS keyboard
+ * users trapped, so the advertised chord must be chosen per platform.
+ */
+
+const APPLE_PLATFORM_RE = /mac|iphone|ipad|ipod/i;
+
+/** The subset of `Navigator` the detection reads (injectable for tests). */
+export interface PlatformSource {
+  platform: string;
+  userAgent: string;
+}
+
+/**
+ * True on macOS / iOS. `navigator.platform` is deprecated but still the most
+ * reliable signal in every shipping engine; the user agent is the fallback for
+ * engines that return an empty platform. Returns false when no navigator
+ * exists (SSR), where the caller should defer until the client mounts.
+ */
+export function isApplePlatform(
+  source: PlatformSource | undefined = typeof navigator === "undefined"
+    ? undefined
+    : navigator
+): boolean {
+  if (!source) return false;
+  return APPLE_PLATFORM_RE.test(source.platform || source.userAgent);
+}
+
+/**
+ * The chord that toggles Monaco's "Tab moves focus" mode on this platform.
+ * Human-readable (fed into the translated affordance copy), matching the
+ * keybinding Monaco actually registers for `editor.action.toggleTabFocusMode`.
+ */
+export function tabFocusModeChord(source?: PlatformSource): string {
+  return isApplePlatform(source) ? "Ctrl+Shift+M" : "Ctrl+M";
+}

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -486,6 +486,7 @@
     "dismiss": "Dismiss",
     "close": "Close",
     "codeEditor": "Code editor",
+    "editorKeyboardHint": "Press {chord} to toggle whether Tab indents code or moves focus out of the editor. Press F8 or Shift+F8 to cycle through errors.",
     "clearOutput": "Clear output",
     "resizeOutputPanel": "Resize output panel",
     "resizeTaskPanel": "Resize task panel",

--- a/apps/web/src/messages/es.json
+++ b/apps/web/src/messages/es.json
@@ -486,6 +486,7 @@
     "dismiss": "Descartar",
     "close": "Cerrar",
     "codeEditor": "Editor de código",
+    "editorKeyboardHint": "Presiona {chord} para alternar si Tab indenta el código o mueve el foco fuera del editor. Presiona F8 o Shift+F8 para recorrer los errores.",
     "clearOutput": "Limpiar salida",
     "resizeOutputPanel": "Redimensionar panel de salida",
     "resizeTaskPanel": "Redimensionar panel de tarea",

--- a/apps/web/src/messages/pt-BR.json
+++ b/apps/web/src/messages/pt-BR.json
@@ -486,6 +486,7 @@
     "dismiss": "Dispensar",
     "close": "Fechar",
     "codeEditor": "Editor de código",
+    "editorKeyboardHint": "Pressione {chord} para alternar se Tab indenta o código ou move o foco para fora do editor. Pressione F8 ou Shift+F8 para percorrer os erros.",
     "clearOutput": "Limpar saída",
     "resizeOutputPanel": "Redimensionar painel de saída",
     "resizeTaskPanel": "Redimensionar painel de tarefa",


### PR DESCRIPTION
Closes #568

Task **LX-C5** (launch-experience master spec §3, UIU-20 CONFIRMED): Monaco traps the Tab key by design (WCAG 2.1.2 "No Keyboard Trap"). This PR surfaces the built-in escape with a **platform-aware** chord and correct ARIA wiring.

## What

- **`lib/utils/keyboard.ts`** — `isApplePlatform()` (`navigator.platform`, user-agent fallback, SSR-safe, injectable for tests) + `tabFocusModeChord()`: **Ctrl+M** on Windows/Linux, **Ctrl+Shift+M** on macOS. A hardcoded "Ctrl+M" would leave Mac keyboard users trapped — verified against the keybinding Monaco actually registers for `editor.action.toggleTabFocusMode` (primary `2091` = Ctrl+M, mac `1323` = Ctrl+Shift+M, confirmed in monaco-editor 0.55's shipped build).
- **`CodeEditor`** (`components/editor/code-editor.tsx`):
  - Wrapper is now a labelled `role="group"` (the bare `aria-label` on a div was invalid ARIA) with `aria-describedby` pointing at the hint.
  - Visible affordance: a reserved strip under the editor that fades in while the editor owns the keyboard (`onDidFocusEditorWidget` / `onDidBlurEditorWidget`) — no layout shift on focus, no focusable content (no new keyboard stop), stays in the accessibility tree while dimmed so the describedby association is always valid.
  - The hint is additionally wired onto Monaco's focus-receiving `<textarea>` via `aria-describedby` (Monaco has no public describedby option; the group-level association is the fallback).
  - Chord resolved after mount (SSR has no navigator → avoids hydration mismatch on Macs).
  - Monaco options: explicit `ariaLabel` on the editor input; `accessibilitySupport: "auto"` kept; tab focus mode itself stays **off** by default (Tab indents while coding — the chord is the escape). Monaco self-announces toggles ("Pressing Tab will now move focus…") via its live region, so NVDA gets state feedback natively.
- **F8** — copy surfaces F8 / Shift+F8 marker navigation, which works against the syntax-only diagnostics already configured in `beforeMount` (semantic validation stays off). `marker.next/prev` confirmed present in the shipped Monaco build.
- **i18n** — `a11y.editorKeyboardHint` with `{chord}` parameter, externalized in EN / PT-BR / ES (locale parity test green).

## Accept criteria (LX-C5)

- [x] Keyboard user can escape the editor — platform-correct chord advertised for `editor.action.toggleTabFocusMode`
- [x] Affordance visible on focus — fades in on `onDidFocusEditorWidget`, reserved strip (no layout shift)
- [x] F8 cycles diagnostics — surfaced in the affordance copy; marker navigation + syntax markers verified in build
- [x] ×3 locales

## Tests

15 new tests: platform detection matrix (mac/iOS/Win/Linux/UA-fallback/SSR) and component tests (group labelling, describedby association incl. Monaco textarea, per-platform chord rendering, focus/blur reveal without unmount, Monaco a11y options, no focus stop in the hint). Full suite: **127 files / 1148 tests passing**; `pnpm typecheck` and `pnpm lint` clean.

## Out of scope (noted)

- `monaco-field.tsx` (admin/teacher authoring editor) has the same Tab trap but is not a launch surface — not touched per LX-C5 scope.
- An NVDA pass on real hardware (NVDA 2017.3+ floor) still needs a human run; this PR ships the code-side prerequisites.