### PR TITLE
feat(courses): path-page presentation + per-segment guidance modality seam (LX-A7)

### DIFF
--- a/apps/web/src/app/[locale]/(platform)/courses/courses-client.tsx
+++ b/apps/web/src/app/[locale]/(platform)/courses/courses-client.tsx
@@ -5,10 +5,8 @@ import { useTranslations } from "next-intl";
 import { MagnifyingGlass, X } from "@phosphor-icons/react";
 import type { Course, LearningPath } from "@superteam-lms/types";
 import { CourseCard } from "@/components/course/course-card";
-import {
-  LearningPathSection,
-  type PathCourseProgress,
-} from "@/components/course/learning-path-section";
+import { type PathCourseProgress } from "@/components/course/learning-path-section";
+import { PathsView } from "@/components/course/paths-view";
 import { createClient } from "@/lib/supabase/client";
 
 type Difficulty = "beginner" | "intermediate" | "advanced";
@@ -322,21 +320,15 @@ export function CourseCatalogClient({
         </div>
       )}
 
-      {/* ════════ TAB 2: LEARNING PATHS ════════ */}
+      {/* ════════ TAB 2: LEARNING PATHS (LX-A7) ════════ */}
+      {/* `segment` is intentionally omitted until LX-A3 segment state lands
+          (#566) — PathsView defaults to the segment-1 presentation. */}
       {activeTab === "paths" && (
-        <div className="space-y-8">
-          {learningPaths.map((path, idx) => {
-            if ((path.courses?.length ?? 0) === 0) return null;
-            return (
-              <LearningPathSection
-                key={path._id}
-                learningPath={path}
-                progress={progress}
-                defaultOpen={idx === 0}
-              />
-            );
-          })}
-        </div>
+        <PathsView
+          learningPaths={learningPaths}
+          progress={progress}
+          onBrowseAll={() => setActiveTab("all")}
+        />
       )}
     </div>
   );

--- a/apps/web/src/components/course/__tests__/paths-view.test.tsx
+++ b/apps/web/src/components/course/__tests__/paths-view.test.tsx
@@ -1,0 +1,222 @@
+// @vitest-environment jsdom
+import type { ReactElement } from "react";
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent, within } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import type { Course, LearningPath } from "@superteam-lms/types";
+import type { PathCourseProgress } from "../learning-path-section";
+import { PathsView } from "../paths-view";
+import messages from "@/messages/en.json";
+
+function makeCourse(id: string, title: string): Course {
+  return {
+    _id: id,
+    title,
+    slug: id,
+    description: `${title} description`,
+    difficulty: "beginner",
+    duration: 4,
+    thumbnail: "/cover.png",
+    tags: [],
+    xpReward: 500,
+    modules: [
+      {
+        key: "m1",
+        title: "Module 1",
+        lessons: [
+          { _id: `${id}-l1`, title: "Lesson 1", slug: "l1", blocks: [] },
+          { _id: `${id}-l2`, title: "Lesson 2", slug: "l2", blocks: [] },
+        ],
+      },
+    ],
+  };
+}
+
+const courseA = makeCourse("course-a", "Course Alpha");
+const courseB = makeCourse("course-b", "Course Beta");
+const courseC = makeCourse("course-c", "Course Gamma");
+const courseD = makeCourse("course-d", "Course Delta");
+
+function makePath(
+  id: string,
+  title: string,
+  order: number,
+  courses: Course[]
+): LearningPath {
+  return {
+    _id: id,
+    title,
+    description: `${title} path`,
+    slug: id,
+    order,
+    courses,
+    difficulty: "beginner",
+  };
+}
+
+// An empty path listed FIRST proves the start card skips course-less paths
+// and targets the first course of the first path that has content.
+const emptyPath = makePath("path-empty", "Empty Path", 0, []);
+const mainPath = makePath("path-main", "Zero to Deployed", 1, [
+  courseA,
+  courseB,
+  courseC,
+]);
+const secondPath = makePath("path-second", "Second Path", 2, [courseD]);
+
+const ALL_PATHS = [emptyPath, mainPath, secondPath];
+
+function renderPaths(
+  props: Partial<Parameters<typeof PathsView>[0]> = {}
+): ReturnType<typeof render> {
+  const ui: ReactElement = (
+    <NextIntlClientProvider locale="en" messages={messages}>
+      <PathsView
+        learningPaths={ALL_PATHS}
+        progress={new Map<string, PathCourseProgress>()}
+        onBrowseAll={() => undefined}
+        {...props}
+      />
+    </NextIntlClientProvider>
+  );
+  return render(ui);
+}
+
+describe("PathsView — start-here card", () => {
+  it("renders exactly one start-here card, targeting the first course of the first non-empty path", () => {
+    renderPaths();
+
+    const badges = screen.getAllByText("Start here");
+    expect(badges).toHaveLength(1);
+
+    const card = screen.getByRole("region", { name: "Course Alpha" });
+    expect(
+      within(card).getByRole("heading", { name: "Course Alpha" })
+    ).toBeInTheDocument();
+    expect(
+      within(card).getByRole("link", { name: /Start Course/ })
+    ).toHaveAttribute("href", "/en/courses/course-a");
+  });
+
+  it("switches the CTA to Continue when the learner is mid-course", () => {
+    const progress = new Map<string, PathCourseProgress>([
+      [
+        "course-a",
+        {
+          courseId: "course-a",
+          completedLessons: 1,
+          totalLessons: 2,
+          isCompleted: false,
+          isEnrolled: true,
+        },
+      ],
+    ]);
+    renderPaths({ progress });
+
+    const card = screen.getByRole("region", { name: "Course Alpha" });
+    expect(
+      within(card).getByRole("link", { name: /Continue Learning/ })
+    ).toHaveAttribute("href", "/en/courses/course-a");
+  });
+});
+
+describe("PathsView — browse-all escape", () => {
+  it("is always present and hands control back to the catalog", () => {
+    const onBrowseAll = vi.fn();
+    renderPaths({ onBrowseAll });
+
+    const button = screen.getByRole("button", { name: /Browse all courses/ });
+    fireEvent.click(button);
+    expect(onBrowseAll).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("PathsView — per-segment guidance modality", () => {
+  it("defaults to the segment-1 presentation: sequenced steps stay clickable with a visible skip-ahead hint", () => {
+    renderPaths();
+
+    expect(
+      screen.getByText(/recommended order — skip ahead/)
+    ).toBeInTheDocument();
+    // Courses B and C follow an incomplete predecessor → skip-ahead hints;
+    // course D opens its own path (index 0) → no hint.
+    expect(screen.getAllByText("Skip ahead")).toHaveLength(2);
+    // Still links — nothing is hard-locked for segment 1.
+    expect(
+      screen.getByRole("link", { name: /Course Beta/ })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /Course Gamma/ })
+    ).toBeInTheDocument();
+  });
+
+  it("segment 3 (beginner) renders the fixed-path modality: later courses lock until the previous completes", () => {
+    renderPaths({ segment: 3 });
+
+    expect(screen.getByText(/Follow the path in order/)).toBeInTheDocument();
+    expect(screen.queryByText("Skip ahead")).not.toBeInTheDocument();
+    // Locked steps are not links.
+    expect(
+      screen.queryByRole("link", { name: /Course Beta/ })
+    ).not.toBeInTheDocument();
+    // The first course of each path stays reachable.
+    expect(
+      screen.getByRole("link", { name: /Course Delta/ })
+    ).toBeInTheDocument();
+  });
+
+  it("segment 3 unlocks the next course once the previous one completes", () => {
+    const progress = new Map<string, PathCourseProgress>([
+      [
+        "course-a",
+        {
+          courseId: "course-a",
+          completedLessons: 2,
+          totalLessons: 2,
+          isCompleted: true,
+          isEnrolled: true,
+        },
+      ],
+    ]);
+    renderPaths({ segment: 3, progress });
+
+    expect(
+      screen.getByRole("link", { name: /Course Beta/ })
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: /Course Gamma/ })
+    ).not.toBeInTheDocument();
+  });
+
+  it("segment 2 (web3 dev) renders open access: every course is a link, no locks, no skip hints", () => {
+    renderPaths({ segment: 2 });
+
+    expect(screen.getByText(/order is a recommendation/)).toBeInTheDocument();
+    expect(screen.queryByText("Skip ahead")).not.toBeInTheDocument();
+    for (const name of [
+      /Course Alpha/,
+      /Course Beta/,
+      /Course Gamma/,
+      /Course Delta/,
+    ]) {
+      expect(screen.getAllByRole("link", { name }).length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("PathsView — content-agnostic rendering", () => {
+  it("renders an empty state when the bundle provides no populated paths", () => {
+    renderPaths({ learningPaths: [emptyPath] });
+
+    expect(screen.getByText("No courses available")).toBeInTheDocument();
+    expect(screen.queryByText("Start here")).not.toBeInTheDocument();
+  });
+
+  it("renders every populated path as a sequenced section", () => {
+    renderPaths();
+
+    expect(screen.getByText("Zero to Deployed")).toBeInTheDocument();
+    expect(screen.getByText("Second Path")).toBeInTheDocument();
+    expect(screen.queryByText("Empty Path")).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/course/learning-path-section.tsx
+++ b/apps/web/src/components/course/learning-path-section.tsx
@@ -4,8 +4,14 @@ import { useState } from "react";
 import { useTranslations, useLocale } from "next-intl";
 import Link from "next/link";
 import Image from "next/image";
-import { CaretDown, Lock, CheckCircle } from "@phosphor-icons/react";
+import {
+  CaretDoubleRight,
+  CaretDown,
+  Lock,
+  CheckCircle,
+} from "@phosphor-icons/react";
 import type { LearningPath } from "@superteam-lms/types";
+import type { PathGuidanceModality } from "@/lib/courses/learner-segment";
 import { cn } from "@/lib/utils";
 
 export interface PathCourseProgress {
@@ -20,12 +26,19 @@ interface LearningPathSectionProps {
   learningPath: LearningPath;
   progress: Map<string, PathCourseProgress>;
   defaultOpen?: boolean;
+  /**
+   * Per-segment guidance modality (LX-A7). Only the framing changes — the
+   * sequence itself is identical across modalities. Defaults to the legacy
+   * locked sequence so existing call sites keep their behavior.
+   */
+  modality?: PathGuidanceModality;
 }
 
 export function LearningPathSection({
   learningPath,
   progress,
   defaultOpen = false,
+  modality = "fixed",
 }: LearningPathSectionProps) {
   const [isOpen, setIsOpen] = useState(defaultOpen);
   const t = useTranslations("courses");
@@ -62,8 +75,10 @@ export function LearningPathSection({
 
   const totalHours = courses.reduce((s, c) => s + c.duration, 0);
 
-  // Determine locked state: course N locked if course N-1 not completed
-  function isLocked(index: number): boolean {
+  // Sequential gate: course N is "ahead" if course N-1 is not completed.
+  // Only the `fixed` modality turns this into a hard lock; `guided-skip`
+  // surfaces it as a skip-ahead hint and `open` ignores it entirely.
+  function isAhead(index: number): boolean {
     if (index === 0) return false;
     const prevCourse = courses[index - 1];
     if (!prevCourse) return false;
@@ -134,7 +149,9 @@ export function LearningPathSection({
       <div className="path-timeline">
         {courses.map((course, idx) => {
           const p = progress.get(course._id);
-          const locked = isLocked(idx);
+          const ahead = isAhead(idx);
+          const locked = modality === "fixed" && ahead;
+          const skipAhead = modality === "guided-skip" && ahead;
           const isComplete = p?.isCompleted ?? false;
           const isActive = (p?.isEnrolled && !p?.isCompleted) ?? false;
           const percent =
@@ -181,6 +198,12 @@ export function LearningPathSection({
                   {isActive && (
                     <span className="path-step-badge active">
                       {completedLessons}/{lessonCount}
+                    </span>
+                  )}
+                  {skipAhead && (
+                    <span className="path-step-badge skip">
+                      <CaretDoubleRight size={11} weight="bold" />{" "}
+                      {t("skipAhead")}
                     </span>
                   )}
                   {locked && (

--- a/apps/web/src/components/course/paths-view.tsx
+++ b/apps/web/src/components/course/paths-view.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import { useMemo } from "react";
+import { useTranslations, useLocale } from "next-intl";
+import Link from "next/link";
+import Image from "next/image";
+import { ArrowRight, BookOpen } from "@phosphor-icons/react";
+import type { LearningPath } from "@superteam-lms/types";
+import {
+  DEFAULT_SEGMENT,
+  SEGMENT_PATH_MODALITY,
+  type LearnerSegment,
+  type PathGuidanceModality,
+} from "@/lib/courses/learner-segment";
+import { cn } from "@/lib/utils";
+import {
+  LearningPathSection,
+  type PathCourseProgress,
+} from "@/components/course/learning-path-section";
+
+interface PathsViewProps {
+  learningPaths: LearningPath[];
+  progress: Map<string, PathCourseProgress>;
+  /** Always-available escape back to the full catalog (S9: don't punish experts). */
+  onBrowseAll: () => void;
+  /**
+   * Learner segment from the /start intake (LX-A3, #566). Until segment state
+   * exists callers omit this and the view renders the segment-1 presentation
+   * (guided sequence with visible skip-ahead). When #566 lands, the page reads
+   * the stored segment and passes it here — no other change required.
+   */
+  segment?: LearnerSegment;
+}
+
+const GUIDANCE_KEY: Record<PathGuidanceModality, string> = {
+  fixed: "pathGuidanceFixed",
+  "guided-skip": "pathGuidanceGuided",
+  open: "pathGuidanceOpen",
+};
+
+/**
+ * Path-page presentation (LX-A7): a sequenced list per path with exactly one
+ * highlighted "start here" card and a secondary "Browse all courses" escape —
+ * NOT a catalog grid. Per-segment modality changes guidance copy/prominence
+ * only; the content and sequence are identical for every segment.
+ */
+export function PathsView({
+  learningPaths,
+  progress,
+  onBrowseAll,
+  segment = DEFAULT_SEGMENT,
+}: PathsViewProps) {
+  const t = useTranslations("courses");
+  const locale = useLocale();
+  const modality = SEGMENT_PATH_MODALITY[segment];
+
+  const nonEmptyPaths = useMemo(
+    () => learningPaths.filter((p) => (p.courses?.length ?? 0) > 0),
+    [learningPaths]
+  );
+
+  // One clear start (UIU-07): the first course of the first non-draft path by
+  // the bundle's ordering conventions (order asc, title asc; drafts never ship
+  // in the bundle). Content-agnostic — recomputes when paths change.
+  const startCourse = nonEmptyPaths[0]?.courses[0];
+  const startProgress = startCourse ? progress.get(startCourse._id) : undefined;
+  const startCtaLabel =
+    startProgress?.isEnrolled && !startProgress.isCompleted
+      ? t("continueCourse")
+      : t("startCourse");
+
+  if (nonEmptyPaths.length === 0 || !startCourse) {
+    return (
+      <div className="py-16 text-center">
+        <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-xl bg-subtle">
+          <BookOpen size={32} weight="duotone" className="text-text-3" />
+        </div>
+        <p className="font-semibold">{t("noCourses")}</p>
+        <p className="mt-1 text-sm text-text-3">{t("noCoursesDescription")}</p>
+      </div>
+    );
+  }
+
+  const startLessonCount =
+    startCourse.modules?.reduce(
+      (sum, m) => sum + (m.lessons?.length ?? 0),
+      0
+    ) ?? 0;
+
+  return (
+    <div className="space-y-6">
+      {/* Guidance line + browse-all escape */}
+      <div className="path-guidance-row">
+        <p className="path-guidance">{t(GUIDANCE_KEY[modality])}</p>
+        <button
+          type="button"
+          className={cn("path-browse-all", modality === "open" && "prominent")}
+          onClick={onBrowseAll}
+        >
+          {t("browseAllCourses")}
+          <ArrowRight size={13} weight="bold" aria-hidden="true" />
+        </button>
+      </div>
+
+      {/* The one highlighted start-here card */}
+      <section aria-labelledby="path-start-title" className="path-start-card">
+        <span className="path-start-badge">{t("startHere")}</span>
+        <div className="path-start-inner">
+          <div className="path-start-thumb" aria-hidden="true">
+            <Image
+              src={startCourse.thumbnail || "/cover.png"}
+              alt=""
+              width={224}
+              height={126}
+            />
+          </div>
+          <div className="path-start-content">
+            <h2 id="path-start-title" className="path-start-title">
+              {startCourse.title}
+            </h2>
+            <p className="path-start-desc">{startCourse.description}</p>
+            <div className="path-start-meta">
+              <span>
+                {startLessonCount} {t("lessons")}
+              </span>
+              <span aria-hidden="true">·</span>
+              <span>
+                {startCourse.duration} {t("hours")}
+              </span>
+              <span aria-hidden="true">·</span>
+              <span>{t(startCourse.difficulty)}</span>
+              <span className="path-start-meta-xp">
+                {"\u26A1"} {startCourse.xpReward}
+              </span>
+            </div>
+            <Link
+              href={`/${locale}/courses/${startCourse.slug}`}
+              className="path-start-cta"
+            >
+              {startCtaLabel}
+              <ArrowRight size={14} weight="bold" aria-hidden="true" />
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      {/* Sequenced path lists */}
+      <div className="space-y-8">
+        {nonEmptyPaths.map((path, idx) => (
+          <LearningPathSection
+            key={path._id}
+            learningPath={path}
+            progress={progress}
+            defaultOpen={idx === 0}
+            modality={modality}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/lib/courses/learner-segment.ts
+++ b/apps/web/src/lib/courses/learner-segment.ts
@@ -1,0 +1,45 @@
+/**
+ * Learner segments from the Design A /start intake (launch-experience master
+ * spec §3 — LX-A2/LX-A3):
+ *
+ *   1 — CORE web2 ("I build web apps (JS/TS)")
+ *   2 — web3 dev  ("I already ship web3 / smart contracts")
+ *   3 — beginner  ("I'm new to programming")
+ *
+ * This module is the SEAM for #566 (LX-A3 segment state). It deliberately
+ * contains no storage or routing — only the segment type and the per-segment
+ * path-page guidance modality (LX-A7). When #566 lands, the stored segment is
+ * read by the page and passed down; nothing here changes.
+ */
+
+export type LearnerSegment = 1 | 2 | 3;
+
+/**
+ * How the path page frames the same sequenced content (S9 expertise-reversal
+ * asymmetry — guidance copy/prominence varies, content never does):
+ *
+ * - `fixed`       — fixed-path emphasis: later courses render locked until the
+ *                   previous one completes (segment 3, high guidance).
+ * - `guided-skip` — same sequence, but every course stays reachable with a
+ *                   visible "skip ahead" hint (segment 1).
+ * - `open`        — open access: the order is presented as a recommendation
+ *                   only, no locks or skip hints (segment 2).
+ */
+export type PathGuidanceModality = "fixed" | "guided-skip" | "open";
+
+/**
+ * Default when no segment is stored (anonymous visitor, pre-#566): segment 1.
+ * Guidance is present (sequenced list + one start-here card) but skip-ahead is
+ * visible — S9 says default to guidance when uncertain without punishing
+ * experts.
+ */
+export const DEFAULT_SEGMENT: LearnerSegment = 1;
+
+export const SEGMENT_PATH_MODALITY: Record<
+  LearnerSegment,
+  PathGuidanceModality
+> = {
+  1: "guided-skip",
+  2: "open",
+  3: "fixed",
+};

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -180,7 +180,13 @@
     "discussions": "Course Discussions",
     "startDiscussion": "Start a Discussion",
     "moduleLabel": "Module {number}",
-    "upNext": "Up next"
+    "upNext": "Up next",
+    "startHere": "Start here",
+    "browseAllCourses": "Browse all courses",
+    "skipAhead": "Skip ahead",
+    "pathGuidanceFixed": "Follow the path in order \u2014 each course builds on the last.",
+    "pathGuidanceGuided": "Courses are in a recommended order \u2014 skip ahead whenever you're ready.",
+    "pathGuidanceOpen": "Jump into any course \u2014 the order is a recommendation, not a requirement."
   },
   "lesson": {
     "content": "Content",

--- a/apps/web/src/messages/es.json
+++ b/apps/web/src/messages/es.json
@@ -180,7 +180,13 @@
     "discussions": "Discusiones del Curso",
     "startDiscussion": "Iniciar una Discusión",
     "moduleLabel": "Módulo {number}",
-    "upNext": "A continuación"
+    "upNext": "A continuación",
+    "startHere": "Empieza aquí",
+    "browseAllCourses": "Ver todos los cursos",
+    "skipAhead": "Saltar adelante",
+    "pathGuidanceFixed": "Sigue la ruta en orden \u2014 cada curso se apoya en el anterior.",
+    "pathGuidanceGuided": "Los cursos siguen un orden recomendado \u2014 salta adelante cuando quieras.",
+    "pathGuidanceOpen": "Entra en cualquier curso \u2014 el orden es una recomendación, no un requisito."
   },
   "lesson": {
     "content": "Contenido",

--- a/apps/web/src/messages/pt-BR.json
+++ b/apps/web/src/messages/pt-BR.json
@@ -180,7 +180,13 @@
     "discussions": "Discussões do Curso",
     "startDiscussion": "Iniciar uma Discussão",
     "moduleLabel": "Módulo {number}",
-    "upNext": "A seguir"
+    "upNext": "A seguir",
+    "startHere": "Comece aqui",
+    "browseAllCourses": "Ver todos os cursos",
+    "skipAhead": "Pular adiante",
+    "pathGuidanceFixed": "Siga a trilha na ordem \u2014 cada curso se apoia no anterior.",
+    "pathGuidanceGuided": "Os cursos seguem uma ordem recomendada \u2014 pule adiante quando quiser.",
+    "pathGuidanceOpen": "Entre em qualquer curso \u2014 a ordem é uma recomendação, não uma exigência."
   },
   "lesson": {
     "content": "Conteúdo",

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -2523,6 +2523,180 @@ a.path-step-card:hover .path-step-thumb img {
   background: var(--primary);
 }
 
+/* ── Skip-ahead badge (LX-A7 guided-skip modality) ── */
+.path-step-badge.skip {
+  color: var(--text-3);
+  border-color: var(--border);
+  background: var(--subtle);
+}
+a.path-step-card:hover .path-step-badge.skip {
+  color: var(--text);
+  border-color: var(--border-hover);
+}
+
+/* ═══ PATHS VIEW — guidance row + start-here card (LX-A7) ═══ */
+.path-guidance-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+.path-guidance {
+  font-size: 13px;
+  color: var(--text-3);
+  margin: 0;
+}
+.path-browse-all {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  flex-shrink: 0;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-2, var(--text-3));
+  background: none;
+  border: none;
+  padding: 4px 2px;
+  cursor: pointer;
+  border-radius: 6px;
+  transition: color 0.15s ease;
+}
+.path-browse-all:hover {
+  color: var(--text);
+}
+.path-browse-all:focus-visible {
+  outline: 2px solid var(--primary);
+  outline-offset: 2px;
+}
+.path-browse-all.prominent {
+  color: var(--primary);
+  border: 2px solid color-mix(in srgb, var(--primary) 35%, transparent);
+  background: color-mix(in srgb, var(--primary) 8%, transparent);
+  padding: 6px 12px;
+  border-radius: var(--r-md);
+}
+.path-browse-all.prominent:hover {
+  color: var(--primary);
+  border-color: var(--primary);
+}
+
+/* One highlighted start card — gradient border, not a grid tile */
+.path-start-card {
+  position: relative;
+  border: 2.5px solid transparent;
+  border-radius: var(--r-lg);
+  background:
+    linear-gradient(var(--card), var(--card)) padding-box,
+    var(--sol-grad) border-box;
+  box-shadow: var(--shadow);
+  padding: 18px;
+}
+.path-start-badge {
+  position: absolute;
+  top: -11px;
+  left: 16px;
+  display: inline-flex;
+  align-items: center;
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #fff;
+  background: var(--sol-grad);
+  border-radius: 99px;
+  padding: 3px 10px;
+}
+.path-start-inner {
+  display: flex;
+  gap: 16px;
+  align-items: flex-start;
+}
+.path-start-thumb {
+  flex-shrink: 0;
+  width: 224px;
+  border-radius: var(--r-md);
+  overflow: hidden;
+  border: 2px solid var(--border);
+}
+.path-start-thumb img {
+  display: block;
+  width: 100%;
+  height: auto;
+  object-fit: cover;
+}
+.path-start-content {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.path-start-title {
+  font-family: var(--font-display, var(--font-d));
+  font-size: 18px;
+  font-weight: 800;
+  letter-spacing: -0.3px;
+  margin: 0;
+}
+.path-start-desc {
+  font-size: 13px;
+  color: var(--text-3);
+  margin: 0;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.path-start-meta {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+  color: var(--text-3);
+  flex-wrap: wrap;
+}
+.path-start-meta-xp {
+  color: var(--xp);
+  font-weight: 700;
+}
+.path-start-cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  align-self: flex-start;
+  margin-top: 4px;
+  font-size: 13px;
+  font-weight: 700;
+  color: #fff;
+  background: var(--primary);
+  border-radius: var(--r-md);
+  padding: 8px 16px;
+  text-decoration: none;
+  transition:
+    transform 0.15s ease,
+    filter 0.15s ease;
+}
+.path-start-cta:hover {
+  filter: brightness(1.08);
+  transform: translateY(-1px);
+}
+.path-start-cta:focus-visible {
+  outline: 2px solid var(--primary);
+  outline-offset: 2px;
+}
+@media (max-width: 640px) {
+  .path-start-inner {
+    flex-direction: column;
+  }
+  .path-start-thumb {
+    width: 100%;
+  }
+  .path-start-cta {
+    align-self: stretch;
+    justify-content: center;
+  }
+}
+
 /* ── Mobile responsive ── */
 @media (max-width: 640px) {
   .path-header {


### PR DESCRIPTION
Closes #586

Implements **LX-A7** (launch-experience master spec §3): the Learning Paths surface now renders as a **sequenced list with exactly one highlighted "start here" card** plus an always-available **Browse all courses** escape — not a catalog grid.

## What changed

- **`PathsView`** (`apps/web/src/components/course/paths-view.tsx`) — new composition for the Paths tab of `/courses`:
  - a per-modality guidance line,
  - ONE gradient-highlighted start-here card (UIU-07: one clear start for the beginner default). CTA switches to "Continue Learning" when the learner is mid-course,
  - the sequenced `LearningPathSection` lists (unchanged sequence/content),
  - a **Browse all courses** button that returns to the full catalog tab (S9: don't punish experts),
  - an empty state when the bundle provides no populated paths.
- **`LearningPathSection`** gains a `modality` prop; the previous hard-lock behavior is now the `fixed` modality (and remains the default for any other call site).
- **i18n ×3** (en / pt-BR / es): `startHere`, `browseAllCourses`, `skipAhead`, and the three guidance lines.
- **CSS**: `path-start-*`, `path-guidance*`, `path-browse-all`, `path-step-badge.skip` in `globals.css`, using existing tokens (`--sol-grad`, `--card`, `--r-lg`, `--xp`); dark-first with light-mode vars; mobile stacking at 640px.

## Segment seam (for #566 / LX-A3 — no rework needed)

Segment state does **not** exist yet, so nothing here reads storage or routes by segment. The seam is:

- `apps/web/src/lib/courses/learner-segment.ts` — exports `LearnerSegment` (`1 | 2 | 3` per Design A: 1 = CORE web2, 2 = web3 dev, 3 = beginner), `DEFAULT_SEGMENT = 1`, and `SEGMENT_PATH_MODALITY` (1 → `guided-skip`, 2 → `open`, 3 → `fixed`).
- `PathsView` accepts an optional `segment` prop, defaulting to the **segment-1 presentation** (guided sequence + visible skip-ahead — S9: default to guidance without punishing experts).
- When #566 lands, the page reads the stored segment and passes `segment={...}` to `PathsView`. That is the entire integration.

Per the expertise-reversal deferral, modality changes **guidance copy/prominence only** — the sequence and content are identical for every segment:

| Segment | Modality | Presentation |
|---|---|---|
| 3 (beginner) | `fixed` | later courses lock until the previous completes (legacy behavior) |
| 1 (CORE web2) — default | `guided-skip` | same sequence, every course clickable, visible "Skip ahead" badge |
| 2 (web3 dev) | `open` | no locks/hints, order framed as a recommendation, browse-all more prominent |

## Start-here target under current content

Content-agnostic: the card targets the **first course of the first non-empty path** by the bundle's existing ordering (`order` asc, `title` asc; drafts never ship in the bundle). Today that resolves against the legacy paths; when #559's Zero-to-Deployed path activates with the lowest `order`, the card retargets automatically — no code change.

## Verification

- `pnpm typecheck` — 6/6 tasks pass
- `pnpm --filter web test` — 126 files, **1142 tests pass** (includes 9 new `paths-view` tests: single start card, CTA switching, browse-all callback, all three modalities, fixed-mode unlock progression, empty/content-agnostic rendering)
- `content-lint` + `content-schema` suites pass (38 + 127)
- `pnpm lint` — exit 0 (no new warnings)

## A11y

Start card is a labelled `region` (`aria-labelledby` → course title); decorative icons/thumbnails `aria-hidden`; browse-all is a real button with `:focus-visible` ring; locked steps remain non-interactive divs; skip-ahead is a visible text badge, not color-only.

## Out of scope (untouched)

Course-detail (#585), dashboard (#563), enroll flow, content files, segment routing/state (#566).