### PR TITLE
feat(i18n): XP competence-framing copy audit (LX-B10)

### DIFF
--- a/apps/web/src/components/gamification/dashboard-identity-panel.tsx
+++ b/apps/web/src/components/gamification/dashboard-identity-panel.tsx
@@ -639,7 +639,8 @@ export function DashboardIdentityPanel({
                     <span className="dq-desc">{quest.description}</span>
                   </div>
                   <div className="dq-reward">
-                    <Lightning size={12} weight="fill" />+{quest.xpReward}
+                    <Lightning size={12} weight="fill" />+{quest.xpReward}{" "}
+                    {t("xp")}
                   </div>
                   {quest.completed ? (
                     <div className="dq-check">

--- a/apps/web/src/components/layout/header.tsx
+++ b/apps/web/src/components/layout/header.tsx
@@ -15,7 +15,7 @@ import { AuthModal } from "@/components/auth/auth-modal";
 import { UserMenu } from "@/components/auth/user-menu";
 import { LevelBadge } from "@/components/gamification/level-badge";
 import { xpToNextLevel, calculateLevel } from "@/lib/gamification/xp";
-import { useXpBalance } from "@/lib/solana/hooks";
+import { useXpTotal } from "@/lib/solana/hooks";
 import { createClient } from "@/lib/supabase/client";
 import { LowSolBanner } from "@/components/layout/low-sol-banner";
 
@@ -36,6 +36,7 @@ const publicNavItems = [
 export function Header() {
   const t = useTranslations("nav");
   const tA11y = useTranslations("a11y");
+  const tGam = useTranslations("gamification");
   const locale = useLocale();
   const pathname = usePathname();
   const { user, profile, isLoading: authLoading } = useAuth();
@@ -57,7 +58,7 @@ export function Header() {
   // continuing — a visible jump.
   const displayedXpRef = useRef(0);
 
-  const { balance: onChainXp } = useXpBalance();
+  const { total: onChainXp } = useXpTotal();
 
   // Teacher authoring entry is UX-only; the real gate is the server-side
   // /teach viewer. Replaces the old `profiles.role` check — the role-removal
@@ -291,7 +292,12 @@ export function Header() {
                   "group relative flex items-center gap-[8px] rounded-full border border-[var(--border)] bg-[var(--card)] py-[4px] pl-[4px] pr-[12px] transition-all duration-500",
                   glowing && "shadow-glow-xp"
                 )}
-                title={`${xpRemaining.toLocaleString()} XP to Level ${level + 1}`}
+                title={tGam("xpToNextLevel", {
+                  xp: xpRemaining.toLocaleString(),
+                  xpLabel: tGam("xp"),
+                  levelLabel: tGam("level"),
+                  level: level + 1,
+                })}
               >
                 <LevelBadge level={level} size="sm" />
 

--- a/apps/web/src/components/layout/header.tsx
+++ b/apps/web/src/components/layout/header.tsx
@@ -292,7 +292,7 @@ export function Header() {
                   "group relative flex items-center gap-[8px] rounded-full border border-[var(--border)] bg-[var(--card)] py-[4px] pl-[4px] pr-[12px] transition-all duration-500",
                   glowing && "shadow-glow-xp"
                 )}
-                title={tGam("xpToNextLevel", {
+                title={tGam("xpTooltip", {
                   xp: xpRemaining.toLocaleString(),
                   xpLabel: tGam("xp"),
                   levelLabel: tGam("level"),

--- a/apps/web/src/components/layout/sidebar.tsx
+++ b/apps/web/src/components/layout/sidebar.tsx
@@ -17,7 +17,7 @@ import { cn } from "@/lib/utils";
 import { createClient } from "@/lib/supabase/client";
 import { LevelBadge } from "@/components/gamification/level-badge";
 import { xpToNextLevel, calculateLevel } from "@/lib/gamification/xp";
-import { useXpBalance } from "@/lib/solana/hooks";
+import { useXpTotal } from "@/lib/solana/hooks";
 
 const sidebarItems = [
   { key: "dashboard", icon: House, href: "/dashboard" },
@@ -30,6 +30,7 @@ const sidebarItems = [
 export function Sidebar() {
   const t = useTranslations("nav");
   const tA11y = useTranslations("a11y");
+  const tGam = useTranslations("gamification");
   const locale = useLocale();
   const pathname = usePathname();
   const [collapsed, setCollapsed] = useState(true);
@@ -47,8 +48,8 @@ export function Sidebar() {
   const prevLevelRef = useRef(0);
   const rafRef = useRef<number>(0);
 
-  // On-chain XP balance as supplementary source
-  const { balance: onChainXp } = useXpBalance();
+  // On-chain XP total as supplementary source
+  const { total: onChainXp } = useXpTotal();
 
   const fetchXp = useCallback(async () => {
     const supabase = createClient();
@@ -231,8 +232,13 @@ export function Sidebar() {
               </span>
               <LevelBadge level={level} size="sm" />
             </div>
-            <div className="mb-[7px] font-mono text-[10px] text-[var(--text-3)]">
-              {xpRemaining.toLocaleString()} XP to Level {level + 1}
+            <div className="mb-[7px] font-mono text-[10px] tabular-nums text-[var(--text-3)]">
+              {tGam("xpToNextLevel", {
+                xp: xpRemaining.toLocaleString(),
+                xpLabel: tGam("xp"),
+                levelLabel: tGam("level"),
+                level: level + 1,
+              })}
             </div>
             <div
               className="sidebar-prog overflow-hidden rounded-full"

--- a/apps/web/src/components/layout/sidebar.tsx
+++ b/apps/web/src/components/layout/sidebar.tsx
@@ -233,7 +233,7 @@ export function Sidebar() {
               <LevelBadge level={level} size="sm" />
             </div>
             <div className="mb-[7px] font-mono text-[10px] tabular-nums text-[var(--text-3)]">
-              {tGam("xpToNextLevel", {
+              {tGam("xpTooltip", {
                 xp: xpRemaining.toLocaleString(),
                 xpLabel: tGam("xp"),
                 levelLabel: tGam("level"),

--- a/apps/web/src/lib/solana/hooks/index.ts
+++ b/apps/web/src/lib/solana/hooks/index.ts
@@ -1,1 +1,1 @@
-export { useXpBalance } from "./use-xp-balance";
+export { useXpTotal } from "./use-xp-total";

--- a/apps/web/src/lib/solana/hooks/use-xp-total.ts
+++ b/apps/web/src/lib/solana/hooks/use-xp-total.ts
@@ -6,23 +6,23 @@ import { PublicKey } from "@solana/web3.js";
 import { fetchConfig, fetchXpBalance } from "../academy-reads";
 import { getProgramId } from "../pda";
 
-interface UseXpBalanceResult {
-  balance: number;
+interface UseXpTotalResult {
+  total: number;
   isLoading: boolean;
   error: string | null;
   refetch: () => void;
 }
 
-export function useXpBalance(): UseXpBalanceResult {
+export function useXpTotal(): UseXpTotalResult {
   const { connection } = useConnection();
   const { publicKey } = useWallet();
-  const [balance, setBalance] = useState(0);
+  const [total, setTotal] = useState(0);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
   const fetchData = useCallback(async () => {
     if (!publicKey) {
-      setBalance(0);
+      setTotal(0);
       setIsLoading(false);
       return;
     }
@@ -33,7 +33,7 @@ export function useXpBalance(): UseXpBalanceResult {
     try {
       const config = await fetchConfig(connection, getProgramId());
       if (!config) {
-        setBalance(0);
+        setTotal(0);
         setIsLoading(false);
         return;
       }
@@ -43,15 +43,13 @@ export function useXpBalance(): UseXpBalanceResult {
         config.xp_mint as PublicKey,
         connection
       );
-      setBalance(result.balance);
+      setTotal(result.balance);
       if (result.error) {
         setError(result.error);
       }
     } catch (err) {
-      setError(
-        err instanceof Error ? err.message : "Failed to fetch XP balance"
-      );
-      setBalance(0);
+      setError(err instanceof Error ? err.message : "Failed to fetch XP total");
+      setTotal(0);
     } finally {
       setIsLoading(false);
     }
@@ -61,5 +59,5 @@ export function useXpBalance(): UseXpBalanceResult {
     fetchData();
   }, [fetchData]);
 
-  return { balance, isLoading, error, refetch: fetchData };
+  return { total, isLoading, error, refetch: fetchData };
 }

--- a/apps/web/src/messages/__tests__/no-duplicate-keys.test.ts
+++ b/apps/web/src/messages/__tests__/no-duplicate-keys.test.ts
@@ -1,0 +1,65 @@
+import { readFileSync } from "node:fs";
+import { describe, it, expect } from "vitest";
+
+/**
+ * Duplicate-key guard for the raw locale files. `parity.test.ts` imports the
+ * PARSED JSON, so a key defined twice in the same object is silently collapsed
+ * (last one wins) before that test ever sees it — a shadowed definition that
+ * changes copy at runtime yet leaves parity green. This scans the source TEXT
+ * and fails on any key repeated within the same object.
+ *
+ * Object-scoped by design: the same key name in different objects (e.g. many
+ * sections have a `title`) is legal; only a repeat inside one `{}` is a bug.
+ */
+function findDuplicateKeys(text: string): string[] {
+  const dupes: string[] = [];
+  const stack: Array<Set<string> | null> = []; // Set = object scope, null = array
+  let i = 0;
+  while (i < text.length) {
+    const c = text[i];
+    if (c === '"') {
+      let key = "";
+      i++; // consume opening quote
+      while (i < text.length && text[i] !== '"') {
+        if (text[i] === "\\") key += text[i++];
+        key += text[i++];
+      }
+      i++; // consume closing quote
+      let j = i;
+      while (j < text.length && /\s/.test(text[j]!)) j++;
+      if (text[j] === ":") {
+        const scope = stack[stack.length - 1];
+        if (scope instanceof Set) {
+          if (scope.has(key)) dupes.push(key);
+          else scope.add(key);
+        }
+      }
+      continue;
+    }
+    if (c === "{") stack.push(new Set());
+    else if (c === "[") stack.push(null);
+    else if (c === "}" || c === "]") stack.pop();
+    i++;
+  }
+  return dupes;
+}
+
+const LOCALES = ["en", "es", "pt-BR"] as const;
+
+describe("i18n locale files have no duplicate keys within any object", () => {
+  it("sanity: the scanner flags a known duplicate", () => {
+    expect(findDuplicateKeys('{"a":1,"b":{"x":1},"a":2}')).toEqual(["a"]);
+    expect(findDuplicateKeys('{"a":1,"b":{"a":2}}')).toEqual([]);
+    expect(findDuplicateKeys('{"a":"has:colon","a":"x"}')).toEqual(["a"]);
+  });
+
+  for (const locale of LOCALES) {
+    it(`${locale}.json defines each key at most once per object`, () => {
+      const text = readFileSync(
+        new URL(`../${locale}.json`, import.meta.url),
+        "utf8"
+      );
+      expect(findDuplicateKeys(text)).toEqual([]);
+    });
+  }
+});

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -330,7 +330,8 @@
     "viewOnExplorer": "View on Explorer",
     "onChain": "on-chain",
     "you": "You",
-    "xpRemaining": "<em>{xp} {xpLabel}</em> to {levelLabel} {level}"
+    "xpRemaining": "<em>{xp} {xpLabel}</em> to {levelLabel} {level}",
+    "xpToNextLevel": "{xp} {xpLabel} to {levelLabel} {level}"
   },
   "certificates": {
     "title": "Certificate of Completion",

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -318,7 +318,6 @@
     "category_skills": "Skills",
     "category_community": "Community",
     "category_special": "Special",
-    "xpToNextLevel": "{current} / {needed} XP to Level {level}",
     "noEntries": "No rankings yet. Complete lessons to earn XP and appear here.",
     "streakKeepGoing": "Learn today to keep it going!",
     "noAchievements": "Complete a lesson to earn your first achievement",
@@ -331,7 +330,7 @@
     "onChain": "on-chain",
     "you": "You",
     "xpRemaining": "<em>{xp} {xpLabel}</em> to {levelLabel} {level}",
-    "xpToNextLevel": "{xp} {xpLabel} to {levelLabel} {level}"
+    "xpTooltip": "{xp} {xpLabel} to {levelLabel} {level}"
   },
   "certificates": {
     "title": "Certificate of Completion",

--- a/apps/web/src/messages/es.json
+++ b/apps/web/src/messages/es.json
@@ -330,7 +330,8 @@
     "viewOnExplorer": "Ver en Explorer",
     "onChain": "on-chain",
     "you": "Tú",
-    "xpRemaining": "<em>{xp} {xpLabel}</em> para {levelLabel} {level}"
+    "xpRemaining": "<em>{xp} {xpLabel}</em> para {levelLabel} {level}",
+    "xpToNextLevel": "{xp} {xpLabel} para {levelLabel} {level}"
   },
   "certificates": {
     "title": "Certificado de Finalización",

--- a/apps/web/src/messages/es.json
+++ b/apps/web/src/messages/es.json
@@ -318,7 +318,6 @@
     "category_skills": "Habilidades",
     "category_community": "Comunidad",
     "category_special": "Especial",
-    "xpToNextLevel": "{current} / {needed} XP para Nivel {level}",
     "noEntries": "Sin ranking aún. Completa lecciones para ganar XP y aparecer aquí.",
     "streakKeepGoing": "¡Aprende hoy para mantener la racha!",
     "noAchievements": "Completa una lección para ganar tu primer logro",
@@ -331,7 +330,7 @@
     "onChain": "on-chain",
     "you": "Tú",
     "xpRemaining": "<em>{xp} {xpLabel}</em> para {levelLabel} {level}",
-    "xpToNextLevel": "{xp} {xpLabel} para {levelLabel} {level}"
+    "xpTooltip": "{xp} {xpLabel} para {levelLabel} {level}"
   },
   "certificates": {
     "title": "Certificado de Finalización",

--- a/apps/web/src/messages/pt-BR.json
+++ b/apps/web/src/messages/pt-BR.json
@@ -330,7 +330,8 @@
     "viewOnExplorer": "Ver no Explorer",
     "onChain": "on-chain",
     "you": "Você",
-    "xpRemaining": "<em>{xp} {xpLabel}</em> para {levelLabel} {level}"
+    "xpRemaining": "<em>{xp} {xpLabel}</em> para {levelLabel} {level}",
+    "xpToNextLevel": "{xp} {xpLabel} para {levelLabel} {level}"
   },
   "certificates": {
     "title": "Certificado de Conclusão",

--- a/apps/web/src/messages/pt-BR.json
+++ b/apps/web/src/messages/pt-BR.json
@@ -318,7 +318,6 @@
     "category_skills": "Habilidades",
     "category_community": "Comunidade",
     "category_special": "Especial",
-    "xpToNextLevel": "{current} / {needed} XP para o Nível {level}",
     "noEntries": "Nenhum ranking ainda. Complete aulas para ganhar XP e aparecer aqui.",
     "streakKeepGoing": "Aprenda hoje para manter a sequência!",
     "noAchievements": "Complete uma lição para ganhar sua primeira conquista",
@@ -331,7 +330,7 @@
     "onChain": "on-chain",
     "you": "Você",
     "xpRemaining": "<em>{xp} {xpLabel}</em> para {levelLabel} {level}",
-    "xpToNextLevel": "{xp} {xpLabel} para {levelLabel} {level}"
+    "xpTooltip": "{xp} {xpLabel} para {levelLabel} {level}"
   },
   "certificates": {
     "title": "Certificado de Conclusão",

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -424,6 +424,8 @@
     font-family: var(--font-display), "Nunito", sans-serif;
     font-weight: 900;
     letter-spacing: -0.5px;
+    /* F37: tabular numerals so level digits never reflow between values */
+    font-variant-numeric: tabular-nums;
     transition:
       transform 0.2s cubic-bezier(0.34, 1.56, 0.64, 1),
       box-shadow 0.2s;
@@ -3030,6 +3032,7 @@ a.path-step-card:hover .path-step-thumb img {
   font-weight: 900;
   font-size: 16px;
   color: var(--xp);
+  font-variant-numeric: tabular-nums; /* F37 */
 }
 .podium-card.gold .podium-xp {
   font-size: 18px;
@@ -3079,6 +3082,7 @@ a.path-step-card:hover .path-step-thumb img {
   text-align: center;
   color: var(--text-3);
   flex-shrink: 0;
+  font-variant-numeric: tabular-nums; /* F37 */
 }
 
 .lb-av {
@@ -3138,6 +3142,7 @@ a.path-step-card:hover .path-step-thumb img {
   color: var(--xp);
   text-align: right;
   min-width: 54px;
+  font-variant-numeric: tabular-nums; /* F37 */
 }
 
 /* ── Responsive: stack podium on small screens ── */
@@ -3645,6 +3650,7 @@ a.path-step-card:hover .path-step-thumb img {
   letter-spacing: -1.5px;
   line-height: 1;
   margin-bottom: 2px;
+  font-variant-numeric: tabular-nums; /* F37 */
 }
 @media (min-width: 640px) {
   .dash-xp-num {
@@ -3666,6 +3672,7 @@ a.path-step-card:hover .path-step-thumb img {
   font-size: 12px;
   color: var(--text-2);
   margin-bottom: 10px;
+  font-variant-numeric: tabular-nums; /* F37 */
 }
 .dash-xp-to em {
   color: var(--xp);
@@ -4303,6 +4310,7 @@ a.path-step-card:hover .path-step-thumb img {
   font-weight: 700;
   color: var(--xp);
   white-space: nowrap;
+  font-variant-numeric: tabular-nums; /* F37 */
 }
 .dq-check {
   color: var(--primary);
@@ -4314,6 +4322,7 @@ a.path-step-card:hover .path-step-thumb img {
   font-size: 10px;
   color: var(--text-3);
   white-space: nowrap;
+  font-variant-numeric: tabular-nums; /* F37 */
 }
 
 /* Heatmap tooltip — Radix-positioned, GitHub-style */
@@ -4924,6 +4933,7 @@ a.path-step-card:hover .path-step-title {
   background: var(--xp-dim);
   border: 1.5px solid rgba(245, 166, 35, 0.25);
   white-space: nowrap;
+  font-variant-numeric: tabular-nums; /* F37 */
 }
 .act-time {
   font-family: var(--font-mono, var(--font-m));


### PR DESCRIPTION
Closes #550 — task **LX-B10** (launch-experience master spec §3). Copy/presentation-only pass to make XP read as competence progress, never a balance/currency.

## Residuals found + fixed
| Surface | Before | After |
|---|---|---|
| Header XP tooltip | hardcoded EN `"{n} XP to Level {N}"` | `gamification.xpToNextLevel` key, ×3 locales |
| Sidebar XP panel | hardcoded EN `"{n} XP to Level {N}"` | same key, ×3 locales |
| Daily-quest reward chip | bare `+40` (ambiguous points/coins) | `+40 XP` (competence unit) |

Leaderboard podium + rows already pair every XP total with a `LevelBadge` (level context present) — no copy change needed there, only tabular numerals.

## Rename
`useXpBalance` → `useXpTotal`: hook fn, file (`use-xp-balance.ts` → `use-xp-total.ts`), `UseXpBalanceResult` → `UseXpTotalResult`, result field `balance` → `total`, internal state + fallback error string. Consumers (header, sidebar) updated (`{ total: onChainXp }`). No behavior change. The on-chain primitive `fetchXpBalance` (raw Token-2022 ATA read) is left as-is — genuine token-account balance, not learner copy, and out of the named scope.

## Tabular numerals (F37)
`font-variant-numeric: tabular-nums` added to all XP/level/rank figures: `.level-badge`, `.podium-xp`, `.lb-rank`, `.lb-xp`, `.dash-xp-num`, `.dash-xp-to`, `.dq-reward`, `.dq-progress-lbl`, `.act-xp`, plus the sidebar xp-to-next line (Tailwind `tabular-nums`). Header/sidebar big-number spans already had it.

## PT-BR +30% expansion audit (F38)
Method: char-length ratio (PT-BR/EN) of every string touched × inspection of each control's width constraints (fixed width / min-width / nowrap / wrap ability).
- Quest reward chip (`.dq-reward`, nowrap): added token is `"XP"` — locale-invariant, zero expansion.
- Sidebar xp-to-next line (mono 10px, ~196px panel, wraps): PT-BR `"para Nível"` vs EN `"to Level"` ≈ +3 chars (~+12%); fits, and can wrap. OK.
- Header tooltip: native `title` attribute — no width constraint.
- `.lb-xp` (`min-width:54px`): number + `"XP"` only, no copy change → no expansion.

## Verification
- `pnpm typecheck` — clean (twice: pre- and post-rebase)
- `pnpm test` — **129 files / 1162 tests pass**, incl. `messages/__tests__/parity.test.ts` locale parity
- `pnpm lint` — 0 errors (128 pre-existing import/order warnings, none in touched files)

No new i18n key contains "balance". Fences respected: no dashboard slot structure, paths-view, celebration, or analytics semantics touched.


---

## Review fix (commit 7fd29f5)

claude[bot] flagged a **blocking duplicate key**: my new `gamification.xpToNextLevel` collided with a pre-existing key of the same name in the same object (added in the initial scaffold commit `7bca44a`, shape `{current} / {needed} XP to Level {level}`). JSON keeps the last duplicate silently, so my definition shadowed the old one; the parity test parses the object, so it stayed green.

- **Renamed** my new key `xpToNextLevel` → `xpTooltip` (×3 locales); updated header.tsx + sidebar.tsx call sites.
- **Deleted the orphan** `xpToNextLevel` (`{current}/{needed}` shape) in all three locales. Confirmed genuinely dead: grepped zero translation call sites repo-wide (the only `xpToNextLevel` references in code are the unrelated JS helper `xpToNextLevel()` in `lib/gamification/xp.ts`), and no consumer passes `{current, needed}` params.
- **Added `no-duplicate-keys.test.ts`**: scans raw locale file TEXT (object-scoped, escape- and colon-aware) and fails on any key defined twice within one object — the guard the parity test structurally cannot provide (it operates on the already-parsed object).

Re-verified: typecheck clean; full suite **131 files / 1192 tests pass** (incl. parity + the new dupe-key guard); lint 0 errors.
