### PR TITLE
feat(onboarding): Later affordance + local progress banking (LX-A4b/c)

### DIFF
--- a/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/lesson-client.tsx
+++ b/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/lesson-client.tsx
@@ -19,6 +19,8 @@ import { completionErrorKey } from "@/lib/lessons/completion-error";
 import { createClient } from "@/lib/supabase/client";
 import { useAuth } from "@/lib/auth/auth-provider";
 import { useOnChainEnroll } from "@/hooks/use-on-chain-enroll";
+import { bankCompletion, removeBanked } from "@/lib/lessons/progress-bank";
+import { REPLAY_BANKED_EVENT } from "@/components/lessons/banked-progress-replay";
 import { ThreadList } from "@/components/community/thread-list";
 import { CreateThreadModal } from "@/components/community/create-thread-modal";
 
@@ -114,13 +116,41 @@ export function LessonPageClient({
     setProgramKeypairSecret(null);
   }, []);
 
+  // Bank the work done on THIS lesson so an anonymous learner never loses it at
+  // the sign-in wall (LX-A4c). Stores exactly the proofs the completion POST
+  // would carry; on sign-in they replay server-side (which re-grades them).
+  const bankCurrentLesson = useCallback(() => {
+    bankCompletion({
+      courseId,
+      courseSlug,
+      lessonId: lesson._id,
+      lessonSlug: lesson.slug,
+      lessonTitle: lesson.title,
+      proofs: { ...proofsRef.current },
+    });
+  }, [courseId, courseSlug, lesson._id, lesson.slug, lesson.title]);
+
+  // Claim moment: bank first, THEN open the sign-in prompt with its "Later"
+  // escape. Ordering matters — the modal's Later path relies on the work
+  // already being saved.
+  const openClaimAuth = useCallback(() => {
+    bankCurrentLesson();
+    setIsAuthModalOpen(true);
+  }, [bankCurrentLesson]);
+
   const { isEnrolling, handleEnroll, enrollError } = useOnChainEnroll({
     courseId,
     userId,
-    // Anonymous Enroll (e.g. the challenge "tests passed" overlay) opens the
-    // auth modal instead of silently no-oping (#556).
-    onRequireAuth: () => setIsAuthModalOpen(true),
-    onSuccess: () => setIsEnrolled(true),
+    // Anonymous Enroll (e.g. the challenge "tests passed" overlay) banks the
+    // learner's work and opens the auth modal instead of silently no-oping
+    // (#556) or dead-ending (LX-A4).
+    onRequireAuth: openClaimAuth,
+    onSuccess: () => {
+      setIsEnrolled(true);
+      // Now enrolled — invite the global replay to finish any banked lessons
+      // for this course (they 403'd on enrollment_missing before this point).
+      window.dispatchEvent(new CustomEvent(REPLAY_BANKED_EVENT));
+    },
   });
 
   const hasCodeBlock = lesson.blocks.some((b) => b._type === "code");
@@ -188,6 +218,9 @@ export function LessonPageClient({
       );
       setIsCompleting(false);
       setIsCompleted(true);
+      // Completed for real on the authed path — drop any banked copy so it can
+      // never re-replay (e.g. a stale entry the learner redid in-app).
+      removeBanked(courseId, lesson._id);
 
       if (!result.alreadyCompleted) {
         setEarnedXp(courseXpPerLesson);
@@ -257,6 +290,29 @@ export function LessonPageClient({
         handleChallengeComplete
       );
   }, [lesson, handleComplete]);
+
+  // An anonymous learner who passes a challenge submits BEFORE enrolling, so the
+  // passing code never rides `superteam:lesson-complete` (which drives an authed
+  // completion). Capture it here as the code block's proof so `bankCurrentLesson`
+  // banks a real submission, not an empty payload — the server re-grades it.
+  useEffect(() => {
+    const handleChallengeProof = (e: Event) => {
+      const detail = (
+        e as CustomEvent<{ lessonId: string; submittedCode?: string }>
+      ).detail;
+      if (detail.lessonId !== lesson._id) return;
+      const codeBlock = lesson.blocks.find((b) => b._type === "code");
+      if (codeBlock && typeof detail.submittedCode === "string") {
+        proofsRef.current[codeBlock.key] = { code: detail.submittedCode };
+      }
+    };
+    window.addEventListener("superteam:challenge-proof", handleChallengeProof);
+    return () =>
+      window.removeEventListener(
+        "superteam:challenge-proof",
+        handleChallengeProof
+      );
+  }, [lesson]);
 
   // Build-complete events (deployable code blocks / deployed-program card).
   useEffect(() => {
@@ -482,13 +538,17 @@ export function LessonPageClient({
                 </Button>
               )
             ) : (
-              <AuthModal
-                trigger={
-                  <Button variant="push" size="lg" className="gap-2">
-                    {t("signInToTrack")}
-                  </Button>
-                }
-              />
+              // Anonymous: banks the work done so far, then opens the sign-in
+              // prompt with its "Later" escape (LX-A4). The controlled modal is
+              // rendered once below.
+              <Button
+                variant="push"
+                size="lg"
+                className="gap-2"
+                onClick={openClaimAuth}
+              >
+                {t("signInToTrack")}
+              </Button>
             ))}
 
           {nextLesson ? (
@@ -535,12 +595,17 @@ export function LessonPageClient({
         )}
       </div>
 
-      {/* Programmatic auth modal — opened when an anonymous visitor clicks an
-          Enroll CTA that lives outside this component (the ChallengeInterface
-          "tests passed" overlay calls ctx.onEnroll). No trigger: controlled
-          only (#556). */}
+      {/* Programmatic auth modal — opened at the claim moment (the "tests
+          passed" enroll overlay, or the "Sign in to track" button). The work is
+          already banked before it opens, so it offers a "Later" escape framed as
+          "your progress is saved", never "discard" (LX-A4b). Controlled only
+          (#556). */}
       {!userId && (
-        <AuthModal open={isAuthModalOpen} onOpenChange={setIsAuthModalOpen} />
+        <AuthModal
+          open={isAuthModalOpen}
+          onOpenChange={setIsAuthModalOpen}
+          showLater
+        />
       )}
 
       {/* Discussion */}

--- a/apps/web/src/app/api/lessons/complete/__tests__/gate.test.ts
+++ b/apps/web/src/app/api/lessons/complete/__tests__/gate.test.ts
@@ -186,6 +186,44 @@ describe("volume gate (#459)", () => {
   });
 });
 
+// Replay-of-banked-proofs exemption (LX-A4c). A completion the learner earned
+// while anonymous, banked, and replays after signing in skips ONLY the per-user
+// token bucket — the per-IP key (the one that actually bounds a Sybil farm's
+// burn rate) still applies. Non-replay traffic is unchanged (covered above).
+describe("replay exemption (LX-A4c)", () => {
+  const lesson = { blocks: [{ _type: "code", key: "c1" }] };
+  const callReplay = (proofs: Record<string, unknown> = {}) =>
+    POST(
+      req({ lessonId: "lesson-1", courseId: "course-1", proofs, replay: true })
+    );
+
+  it("skips the per-user gate — a replay proceeds even when per-user is exhausted", async () => {
+    getLessonByIdForGrading.mockResolvedValue(lesson);
+    codeGrader.mockResolvedValue({ ok: false, status: 403 });
+    // Per-user is exhausted; a live completion would 429 here.
+    isRateLimited.mockImplementation(async (ns) => ns === "lessons:complete");
+
+    const res = await callReplay({ c1: { code: "wrong" } });
+
+    // Reached grading (403), NOT throttled — the per-user gate was never queried.
+    expect(res.status).toBe(403);
+    expect(isRateLimited).not.toHaveBeenCalledWith("lessons:complete");
+  });
+
+  it("still enforces the per-IP gate — the burn-rate bound is not loosened", async () => {
+    getLessonByIdForGrading.mockResolvedValue(lesson);
+    isRateLimited.mockImplementation(
+      async (ns) => ns === "lessons:complete:ip"
+    );
+
+    const res = await callReplay({ c1: { code: "correct" } });
+
+    expect(res.status).toBe(429);
+    expect(codeGrader).not.toHaveBeenCalled();
+    expect(isRateLimited).toHaveBeenCalledWith("lessons:complete:ip");
+  });
+});
+
 describe("maintenance gate (WS-2 #453 rail 3)", () => {
   const lesson = { blocks: [{ _type: "code", key: "c1" }] };
 

--- a/apps/web/src/app/api/lessons/complete/route.ts
+++ b/apps/web/src/app/api/lessons/complete/route.ts
@@ -33,6 +33,13 @@ interface LessonCompleteRequest {
    * attestation token. Block-level pass/fail is transient — never persisted.
    */
   proofs?: Record<string, unknown>;
+  /**
+   * Set only by the client's replay-on-signin pass (LX-A4c): completions the
+   * learner earned while ANONYMOUS, banked in localStorage, and now replayed
+   * once they have an account. It exempts this request from the per-USER volume
+   * gate below and NOTHING else — see the gate comment for why that is safe.
+   */
+  replay?: boolean;
 }
 
 /**
@@ -81,6 +88,12 @@ export async function POST(request: NextRequest) {
     const { lessonId, courseId } = body;
     const proofs: Record<string, unknown> =
       body.proofs && typeof body.proofs === "object" ? body.proofs : {};
+    // Replay-of-banked-proof marker (LX-A4c). A bare client boolean is enough
+    // BECAUSE it can only skip the per-user gate, which the analysis below shows
+    // is worthless against the only actor it could bound (a Sybil farmer). It
+    // never touches grading, enrollment, or the per-IP gate, so a caller who
+    // forges it gains nothing an honest replay wouldn't.
+    const isReplay = body.replay === true;
 
     if (!lessonId || !courseId) {
       return NextResponse.json(
@@ -132,11 +145,26 @@ export async function POST(request: NextRequest) {
     // cohort working through a 16-lesson course in one window is ~960 requests.
     // 1200 clears that; a fixed-window counter is a cliff, not a throttle, so
     // undershooting here 429s an entire classroom at once.
+    //
+    // ── Replay exemption (LX-A4c) ─────────────────────────────────────────
+    // A replay-of-banked-proofs request skips ONLY the per-user token bucket.
+    // A learner who worked through many lessons anonymously, then signs in, must
+    // be able to bank the whole batch in one burst — more than the 40/hr a fresh
+    // account carries — without their own honest history throttling them.
+    //
+    // This does NOT loosen the gate globally. By the argument above, the per-user
+    // key does nothing against the only actor worth stopping: a Sybil farmer
+    // mints a fresh SIWS account (hence a fresh per-user key) per replay, so the
+    // 40/hr bucket never bound them in the first place — the per-IP key is what
+    // bounds the burn rate, and replays stay fully subject to it (checked
+    // unconditionally below). So exempting replays costs zero Sybil resistance
+    // while unblocking the honest batch. Non-replay traffic is untouched.
     if (
-      await isRateLimited("lessons:complete", user.id, {
+      !isReplay &&
+      (await isRateLimited("lessons:complete", user.id, {
         maxTokens: 40,
         refillIntervalMs: 3_600_000,
-      })
+      }))
     ) {
       return NextResponse.json(
         { error: "Too many lesson completions. Please slow down." },

--- a/apps/web/src/components/auth/__tests__/auth-modal.test.tsx
+++ b/apps/web/src/components/auth/__tests__/auth-modal.test.tsx
@@ -86,3 +86,53 @@ describe("AuthModal — uncontrolled mode (unchanged)", () => {
     expect(screen.getByText(TITLE)).toBeInTheDocument();
   });
 });
+
+describe("AuthModal — Later affordance (LX-A4b)", () => {
+  it("shows the keep-progress framing, a Later button, and reassurance copy", () => {
+    renderWithIntl(<AuthModal open onOpenChange={() => {}} showLater />);
+
+    expect(screen.getByText(messages.auth.keepProgressTitle)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: messages.auth.later })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(messages.auth.progressSavedLocally)
+    ).toBeInTheDocument();
+  });
+
+  it("never uses discard/lose/delete language (F4) — progress is framed as kept", () => {
+    const claimCopy = [
+      messages.auth.keepProgressTitle,
+      messages.auth.keepProgressSubtitle,
+      messages.auth.later,
+      messages.auth.progressSavedLocally,
+    ]
+      .join(" ")
+      .toLowerCase();
+
+    for (const forbidden of ["discard", "lose", "lost", "delete", "erase"]) {
+      expect(claimCopy).not.toContain(forbidden);
+    }
+    expect(claimCopy).toContain("saved");
+  });
+
+  it("closes and calls onLater when Later is tapped", () => {
+    const onOpenChange = vi.fn();
+    const onLater = vi.fn();
+    renderWithIntl(
+      <AuthModal open onOpenChange={onOpenChange} showLater onLater={onLater} />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: messages.auth.later }));
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(onLater).toHaveBeenCalledTimes(1);
+  });
+
+  it("omits the Later affordance by default", () => {
+    renderWithIntl(<AuthModal open onOpenChange={() => {}} />);
+
+    expect(
+      screen.queryByRole("button", { name: messages.auth.later })
+    ).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/auth/auth-modal.tsx
+++ b/apps/web/src/components/auth/auth-modal.tsx
@@ -16,6 +16,7 @@ import { Button } from "@/components/ui/button";
 import { GoogleLogo } from "@/components/icons/google-logo";
 import { SolanaLogo } from "@/components/icons/solana-logo";
 import { createClient } from "@/lib/supabase/client";
+import { buildOAuthRedirect } from "@/lib/auth/oauth-redirect";
 import { trackEvent } from "@/lib/analytics";
 
 interface AuthModalProps {
@@ -62,14 +63,10 @@ export function AuthModal({
   // Return the learner to the page they signed in from (#619 review): the OAuth
   // callback otherwise always lands on /dashboard, stranding someone mid-lesson
   // — and, post-LX-A4, away from the replay that finishes their banked work. The
-  // callback re-sanitizes this against open-redirect, so a path is all we pass.
-  const oauthRedirectTo = () => {
-    const base = `${window.location.origin}/api/auth/callback`;
-    const next = window.location.pathname;
-    return next && next !== "/"
-      ? `${base}?next=${encodeURIComponent(next)}`
-      : base;
-  };
+  // path-shape guard lives in buildOAuthRedirect (unit-tested); the callback
+  // re-sanitizes server-side too.
+  const oauthRedirectTo = () =>
+    buildOAuthRedirect(window.location.origin, window.location.pathname);
 
   const handleConnectSolana = () => {
     setLoading("solana");

--- a/apps/web/src/components/auth/auth-modal.tsx
+++ b/apps/web/src/components/auth/auth-modal.tsx
@@ -27,12 +27,22 @@ interface AuthModalProps {
    */
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
+  /**
+   * Claim-moment mode (LX-A4b): the learner just did the work and is being asked
+   * to sign in to keep it. Shows the "keep your progress" framing plus a "Later"
+   * escape that dismisses without ever implying the work is lost — it stays
+   * banked locally (F4: never "discard progress").
+   */
+  showLater?: boolean;
+  onLater?: () => void;
 }
 
 export function AuthModal({
   trigger,
   open: controlledOpen,
   onOpenChange,
+  showLater = false,
+  onLater,
 }: AuthModalProps) {
   const t = useTranslations("auth");
   const tCommon = useTranslations("common");
@@ -48,6 +58,18 @@ export function AuthModal({
   );
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const { setVisible } = useWalletModal();
+
+  // Return the learner to the page they signed in from (#619 review): the OAuth
+  // callback otherwise always lands on /dashboard, stranding someone mid-lesson
+  // — and, post-LX-A4, away from the replay that finishes their banked work. The
+  // callback re-sanitizes this against open-redirect, so a path is all we pass.
+  const oauthRedirectTo = () => {
+    const base = `${window.location.origin}/api/auth/callback`;
+    const next = window.location.pathname;
+    return next && next !== "/"
+      ? `${base}?next=${encodeURIComponent(next)}`
+      : base;
+  };
 
   const handleConnectSolana = () => {
     setLoading("solana");
@@ -69,7 +91,7 @@ export function AuthModal({
       const { error } = await supabase.auth.signInWithOAuth({
         provider: "github",
         options: {
-          redirectTo: `${window.location.origin}/api/auth/callback`,
+          redirectTo: oauthRedirectTo(),
         },
       });
       if (error) {
@@ -95,7 +117,7 @@ export function AuthModal({
       const { error } = await supabase.auth.signInWithOAuth({
         provider: "google",
         options: {
-          redirectTo: `${window.location.origin}/api/auth/callback`,
+          redirectTo: oauthRedirectTo(),
         },
       });
       if (error) {
@@ -129,9 +151,11 @@ export function AuthModal({
       )}
       <DialogContent className="sm:max-w-sm">
         <DialogHeader>
-          <DialogTitle className="text-center">{t("signInTitle")}</DialogTitle>
+          <DialogTitle className="text-center">
+            {t(showLater ? "keepProgressTitle" : "signInTitle")}
+          </DialogTitle>
           <DialogDescription className="text-center">
-            {t("signInSubtitle")}
+            {t(showLater ? "keepProgressSubtitle" : "signInSubtitle")}
           </DialogDescription>
         </DialogHeader>
         <div className="mt-6 space-y-3">
@@ -190,6 +214,26 @@ export function AuthModal({
             <p className="text-center text-sm text-danger" role="alert">
               {errorMessage}
             </p>
+          )}
+
+          {showLater && (
+            <div className="space-y-3 pt-1">
+              <Button
+                variant="ghost"
+                className="h-10 w-full text-sm font-medium text-text-3"
+                onClick={() => {
+                  setOpen(false);
+                  onLater?.();
+                }}
+                disabled={loading !== null}
+              >
+                {t("later")}
+              </Button>
+              {/* Reassurance — the work is KEPT, never discarded (F4). */}
+              <p className="text-center text-xs text-text-3">
+                {t("progressSavedLocally")}
+              </p>
+            </div>
           )}
         </div>
       </DialogContent>

--- a/apps/web/src/components/editor/challenge-interface.tsx
+++ b/apps/web/src/components/editor/challenge-interface.tsx
@@ -31,6 +31,9 @@ import { cn } from "@/lib/utils";
 import { shouldShowEncouragement } from "@/lib/gamification/celebration";
 
 const LESSON_COMPLETE_EVENT = "superteam:lesson-complete";
+// Carries the passing code to lesson-client WITHOUT driving a completion, so an
+// anonymous learner's submission can be banked before they enroll (LX-A4c).
+const CHALLENGE_PROOF_EVENT = "superteam:challenge-proof";
 
 /**
  * Turns a run's test results into the compact summary string the AI Partner
@@ -235,12 +238,19 @@ export function ChallengeInterface({
 
   const handleSubmit = useCallback(() => {
     if (!isEnrolled) {
-      // Tests passed but not enrolled — prompt enrollment
+      // Tests passed but not enrolled — prompt enrollment. Stash the passing
+      // code first so it is banked if the learner is anonymous and chooses
+      // "Later" at the sign-in prompt (LX-A4c).
+      window.dispatchEvent(
+        new CustomEvent(CHALLENGE_PROOF_EVENT, {
+          detail: { lessonId, submittedCode: code },
+        })
+      );
       setPendingSubmit(true);
       return;
     }
     completeLesson();
-  }, [isEnrolled, completeLesson]);
+  }, [isEnrolled, completeLesson, lessonId, code]);
 
   // Auto-complete when user enrolls after passing all tests
   useEffect(() => {

--- a/apps/web/src/components/gamification/gamification-overlays.tsx
+++ b/apps/web/src/components/gamification/gamification-overlays.tsx
@@ -6,6 +6,7 @@ import { CertificatePopup } from "@/components/gamification/certificate-popup";
 import { LevelUpPopup } from "@/components/gamification/level-up-popup";
 import { useGamificationEvents } from "@/hooks/use-gamification-events";
 import { ToastContainer } from "@/components/ui/toast-container";
+import { BankedProgressReplay } from "@/components/lessons/banked-progress-replay";
 
 export function GamificationOverlays() {
   const { userId } = useAuth();
@@ -17,6 +18,8 @@ export function GamificationOverlays() {
     <>
       {/* Toast container always renders — works for auth and non-auth contexts */}
       <ToastContainer />
+      {/* Replays anonymously-banked completions once signed in (LX-A4c). */}
+      <BankedProgressReplay />
       {!userId ? null : (
         /* Single stacking container for all bottom-right popups */
         <div className="pointer-events-none fixed bottom-4 right-3 z-50 flex flex-col items-end gap-2 sm:bottom-6 sm:right-6">

--- a/apps/web/src/components/lessons/banked-progress-replay.tsx
+++ b/apps/web/src/components/lessons/banked-progress-replay.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useCallback, useEffect, useRef } from "react";
+import { useTranslations } from "next-intl";
+import { useAuth } from "@/lib/auth/auth-provider";
+import { dispatchToast } from "@/components/ui/toast-container";
+import {
+  replayBankedCompletions,
+  type ReplayStatus,
+} from "@/lib/lessons/replay-banked";
+import { hasBankedCompletions } from "@/lib/lessons/progress-bank";
+
+// Fired after an on-chain enrollment succeeds (lesson-client) so a learner who
+// signed in, then enrolled, immediately gets their banked work for that course
+// finished — without waiting for the next sign-in.
+export const REPLAY_BANKED_EVENT = "superteam:replay-banked";
+
+/**
+ * Replays anonymously-banked lesson completions once the learner is signed in
+ * (LX-A4c). Mounted globally (GamificationOverlays) so it runs regardless of
+ * which page the learner lands on after auth, and re-runs on enrollment.
+ *
+ * Every outcome is surfaced, never silently dropped:
+ *   - completed   → one success toast for the batch.
+ *   - needsEnroll → kept banked; a gentle nudge to enroll (retried post-enroll).
+ *   - needsRedo   → surfaced per lesson (the proof can't replay — redo in-app).
+ *   - retry       → kept banked silently; retried on the next sign-in/enroll.
+ */
+export function BankedProgressReplay() {
+  const { userId } = useAuth();
+  const t = useTranslations("lesson");
+  const running = useRef(false);
+
+  const run = useCallback(async () => {
+    if (running.current || !hasBankedCompletions()) return;
+    running.current = true;
+    try {
+      const outcomes = await replayBankedCompletions();
+
+      const count = (status: ReplayStatus) =>
+        outcomes.filter((o) => o.status === status).length;
+
+      const completed = count("completed");
+      if (completed > 0) {
+        dispatchToast(t("progressRestored", { count: completed }), "success");
+      }
+
+      const needsEnroll = count("needsEnroll");
+      if (needsEnroll > 0) {
+        dispatchToast(t("progressNeedsEnroll", { count: needsEnroll }), "info");
+      }
+
+      for (const o of outcomes) {
+        if (o.status === "needsRedo") {
+          dispatchToast(
+            t("progressNeedsRedo", { lesson: o.entry.lessonTitle }),
+            "warning"
+          );
+        }
+      }
+    } finally {
+      running.current = false;
+    }
+  }, [t]);
+
+  // Run when a user becomes available (initial load already signed in, or a
+  // fresh sign-in) and whenever an enrollment invites a retry.
+  useEffect(() => {
+    if (!userId) return;
+    void run();
+    const handler = () => void run();
+    window.addEventListener(REPLAY_BANKED_EVENT, handler);
+    return () => window.removeEventListener(REPLAY_BANKED_EVENT, handler);
+  }, [userId, run]);
+
+  return null;
+}

--- a/apps/web/src/lib/auth/__tests__/oauth-redirect.test.ts
+++ b/apps/web/src/lib/auth/__tests__/oauth-redirect.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import { buildOAuthRedirect, isSafeNextPath } from "../oauth-redirect";
+
+const ORIGIN = "https://academy.superteam.fun";
+const CALLBACK = `${ORIGIN}/api/auth/callback`;
+
+// Values `window.location.pathname` cannot legitimately produce but which the
+// guard must still refuse (defense in depth for the open-redirect surface).
+const HOSTILE_PATHS = [
+  "//evil.com", // protocol-relative
+  "//evil.com/path",
+  "/\\evil.com", // backslash host bypass
+  "/path\\to", // stray backslash
+  "https://evil.com", // absolute URL (no leading slash + scheme)
+  "javascript:alert(1)", // scheme injection
+  "/a:b", // any colon → drop (mirrors the callback sanitizer)
+  "/", // adds nothing over the callback default
+  "", // empty
+];
+
+describe("isSafeNextPath", () => {
+  it("accepts a normal same-origin lesson path", () => {
+    expect(isSafeNextPath("/en/courses/solana-101/lessons/intro")).toBe(true);
+  });
+
+  it("rejects protocol-relative, scheme, and backslash paths", () => {
+    for (const p of HOSTILE_PATHS) {
+      expect(isSafeNextPath(p)).toBe(false);
+    }
+  });
+});
+
+describe("buildOAuthRedirect", () => {
+  it("appends a `next` that round-trips a normal pathname", () => {
+    const path = "/pt-BR/courses/solana-101/lessons/intro";
+    const out = buildOAuthRedirect(ORIGIN, path);
+
+    const url = new URL(out);
+    expect(url.origin).toBe(ORIGIN); // same origin as the callback
+    expect(url.pathname).toBe("/api/auth/callback");
+    expect(url.searchParams.get("next")).toBe(path); // decodes back exactly
+  });
+
+  it("drops the `next` entirely for any unsafe pathname", () => {
+    for (const p of HOSTILE_PATHS) {
+      expect(buildOAuthRedirect(ORIGIN, p)).toBe(CALLBACK);
+    }
+  });
+
+  it("only ever emits a same-origin, path-shaped `next` (never //, a scheme, or a backslash)", () => {
+    const probes = [
+      "/en/dashboard",
+      ...HOSTILE_PATHS,
+      "/en/courses/x/lessons/y",
+    ];
+    for (const p of probes) {
+      const url = new URL(buildOAuthRedirect(ORIGIN, p));
+      // The callback target is always same-origin.
+      expect(url.origin).toBe(ORIGIN);
+      const next = url.searchParams.get("next");
+      if (next !== null) {
+        expect(next.startsWith("/")).toBe(true);
+        expect(next.startsWith("//")).toBe(false);
+        expect(next).not.toContain(":");
+        expect(next).not.toContain("\\");
+      }
+    }
+  });
+});

--- a/apps/web/src/lib/auth/oauth-redirect.ts
+++ b/apps/web/src/lib/auth/oauth-redirect.ts
@@ -1,0 +1,28 @@
+/**
+ * Build the OAuth callback URL, returning the learner to the page they signed in
+ * from via a `next` param (#619 — the branch otherwise always lands on
+ * /dashboard, stranding someone mid-lesson and away from their banked-progress
+ * replay).
+ *
+ * Client-side guard (defense in depth): the callback re-sanitizes `next` server
+ * side, but this never even emits an unsafe one. Only a same-origin, path-shaped
+ * value is attached — anything protocol-relative (`//host`), scheme-bearing
+ * (`javascript:`, and any `:`), or backslash-carrying is dropped, so the learner
+ * simply lands on the callback default rather than an attacker-chosen target.
+ */
+export function isSafeNextPath(path: string): boolean {
+  return (
+    path.length > 1 && // "/" alone adds nothing over the callback default
+    path.startsWith("/") &&
+    !path.startsWith("//") && // protocol-relative URL
+    !path.includes("\\") && // backslash host-relative bypass
+    !path.includes(":") // scheme injection (javascript:, data:, …)
+  );
+}
+
+export function buildOAuthRedirect(origin: string, pathname: string): string {
+  const callback = `${origin}/api/auth/callback`;
+  return isSafeNextPath(pathname)
+    ? `${callback}?next=${encodeURIComponent(pathname)}`
+    : callback;
+}

--- a/apps/web/src/lib/lessons/__tests__/progress-bank.test.ts
+++ b/apps/web/src/lib/lessons/__tests__/progress-bank.test.ts
@@ -1,0 +1,103 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import {
+  bankCompletion,
+  readBank,
+  removeBanked,
+  clearBank,
+  hasBankedCompletions,
+} from "../progress-bank";
+
+const base = {
+  courseId: "solana-101",
+  courseSlug: "solana-101",
+  lessonSlug: "intro",
+  lessonTitle: "Intro",
+  proofs: { c1: { code: "ok" } },
+};
+
+beforeEach(() => {
+  window.localStorage.clear();
+  vi.useRealTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("progress-bank round-trip", () => {
+  it("banks and reads back an entry with its proofs intact", () => {
+    bankCompletion({ ...base, lessonId: "lesson-1" });
+
+    const bank = readBank();
+    expect(bank).toHaveLength(1);
+    expect(bank[0]!.lessonId).toBe("lesson-1");
+    expect(bank[0]!.proofs).toEqual({ c1: { code: "ok" } });
+    expect(typeof bank[0]!.bankedAt).toBe("number");
+    expect(hasBankedCompletions()).toBe(true);
+  });
+
+  it("upserts by course+lesson rather than duplicating", () => {
+    bankCompletion({ ...base, lessonId: "lesson-1", proofs: { c1: 1 } });
+    bankCompletion({ ...base, lessonId: "lesson-1", proofs: { c1: 2 } });
+
+    const bank = readBank();
+    expect(bank).toHaveLength(1);
+    expect(bank[0]!.proofs).toEqual({ c1: 2 });
+  });
+
+  it("removes a single entry, leaving the rest", () => {
+    bankCompletion({ ...base, lessonId: "lesson-1" });
+    bankCompletion({ ...base, lessonId: "lesson-2" });
+
+    removeBanked("solana-101", "lesson-1");
+
+    const bank = readBank();
+    expect(bank.map((e) => e.lessonId)).toEqual(["lesson-2"]);
+  });
+
+  it("clears the whole bank", () => {
+    bankCompletion({ ...base, lessonId: "lesson-1" });
+    clearBank();
+    expect(readBank()).toHaveLength(0);
+    expect(hasBankedCompletions()).toBe(false);
+  });
+});
+
+describe("progress-bank resilience", () => {
+  it("returns [] for corrupt storage instead of throwing", () => {
+    window.localStorage.setItem("superteam:progress-bank:v1", "{not json");
+    expect(readBank()).toEqual([]);
+  });
+
+  it("drops entries whose shape is invalid", () => {
+    window.localStorage.setItem(
+      "superteam:progress-bank:v1",
+      JSON.stringify([{ courseId: "x" }, null, 42])
+    );
+    expect(readBank()).toEqual([]);
+  });
+
+  it("prunes entries older than the 30-day hygiene window", () => {
+    const stale = {
+      ...base,
+      lessonId: "old",
+      bankedAt: Date.now() - 31 * 24 * 60 * 60 * 1000,
+    };
+    window.localStorage.setItem(
+      "superteam:progress-bank:v1",
+      JSON.stringify([stale])
+    );
+    expect(readBank()).toEqual([]);
+  });
+
+  it("orders freshest first", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-26T10:00:00Z"));
+    bankCompletion({ ...base, lessonId: "first" });
+    vi.setSystemTime(new Date("2026-07-26T11:00:00Z"));
+    bankCompletion({ ...base, lessonId: "second" });
+
+    expect(readBank().map((e) => e.lessonId)).toEqual(["second", "first"]);
+  });
+});

--- a/apps/web/src/lib/lessons/__tests__/replay-banked.test.ts
+++ b/apps/web/src/lib/lessons/__tests__/replay-banked.test.ts
@@ -1,0 +1,143 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import { bankCompletion, readBank } from "../progress-bank";
+import { replayBankedCompletions } from "../replay-banked";
+
+const base = {
+  courseId: "solana-101",
+  courseSlug: "solana-101",
+  lessonSlug: "intro",
+  lessonTitle: "Intro",
+  proofs: { c1: { code: "ok" } },
+};
+
+function mockFetch(
+  handler: (body: unknown) => { status: number; json?: unknown }
+) {
+  return vi.fn(async (_url: string, init?: RequestInit) => {
+    const body = init?.body ? JSON.parse(init.body as string) : {};
+    const { status, json } = handler(body);
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      json: async () => json ?? {},
+    } as Response;
+  });
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("replayBankedCompletions", () => {
+  it("posts every banked entry with the replay marker set", async () => {
+    bankCompletion({ ...base, lessonId: "lesson-1" });
+    const fetchMock = mockFetch(() => ({
+      status: 200,
+      json: { success: true },
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await replayBankedCompletions();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const sent = JSON.parse(
+      (fetchMock.mock.calls[0]![1] as RequestInit).body as string
+    );
+    expect(sent).toMatchObject({
+      lessonId: "lesson-1",
+      courseId: "solana-101",
+      replay: true,
+      proofs: { c1: { code: "ok" } },
+    });
+  });
+
+  it("removes an entry the server accepts (completed)", async () => {
+    bankCompletion({ ...base, lessonId: "lesson-1" });
+    vi.stubGlobal(
+      "fetch",
+      mockFetch(() => ({ status: 200, json: { success: true } }))
+    );
+
+    const outcomes = await replayBankedCompletions();
+
+    expect(outcomes[0]!.status).toBe("completed");
+    expect(readBank()).toHaveLength(0);
+  });
+
+  it("keeps an entry that fails on missing enrollment (needsEnroll)", async () => {
+    bankCompletion({ ...base, lessonId: "lesson-1" });
+    vi.stubGlobal(
+      "fetch",
+      mockFetch(() => ({
+        status: 403,
+        json: { error: "no enrollment", reason: "enrollment_missing" },
+      }))
+    );
+
+    const outcomes = await replayBankedCompletions();
+
+    expect(outcomes[0]!.status).toBe("needsEnroll");
+    expect(readBank()).toHaveLength(1); // preserved for a post-enroll retry
+  });
+
+  it("drops an unrecoverable entry after surfacing it (needsRedo)", async () => {
+    // An expired/absent reflection seal replays as reflection_required — it can
+    // never pass, so it is surfaced then removed rather than nagged forever.
+    bankCompletion({ ...base, lessonId: "lesson-1" });
+    vi.stubGlobal(
+      "fetch",
+      mockFetch(() => ({
+        status: 403,
+        json: { error: "needs reflection", reason: "reflection_required" },
+      }))
+    );
+
+    const outcomes = await replayBankedCompletions();
+
+    expect(outcomes[0]!.status).toBe("needsRedo");
+    expect(outcomes[0]!.reason).toBe("reflection_required");
+    expect(readBank()).toHaveLength(0);
+  });
+
+  it("keeps an entry on a transient 429/5xx (retry)", async () => {
+    bankCompletion({ ...base, lessonId: "lesson-1" });
+    vi.stubGlobal(
+      "fetch",
+      mockFetch(() => ({ status: 429, json: { error: "slow down" } }))
+    );
+
+    const outcomes = await replayBankedCompletions();
+
+    expect(outcomes[0]!.status).toBe("retry");
+    expect(readBank()).toHaveLength(1);
+  });
+
+  it("captures a network error as retry and keeps walking the batch", async () => {
+    bankCompletion({ ...base, lessonId: "lesson-1" });
+    bankCompletion({ ...base, lessonId: "lesson-2" });
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("offline"))
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ success: true }),
+      } as Response);
+    vi.stubGlobal("fetch", fetchMock);
+
+    const outcomes = await replayBankedCompletions();
+
+    expect(outcomes).toHaveLength(2);
+    expect(outcomes.map((o) => o.status).sort()).toEqual([
+      "completed",
+      "retry",
+    ]);
+    // The failed one is preserved; the succeeded one is gone.
+    expect(readBank()).toHaveLength(1);
+  });
+});

--- a/apps/web/src/lib/lessons/progress-bank.ts
+++ b/apps/web/src/lib/lessons/progress-bank.ts
@@ -1,0 +1,123 @@
+/**
+ * Local bank of lesson completions earned while signed OUT (LX-A4c).
+ *
+ * An anonymous learner can do the graded work — pass a challenge, answer a quiz,
+ * read a prose/video lesson — but cannot POST `/api/lessons/complete` (it 401s).
+ * Rather than lose that work at the sign-in wall, we keep the exact `proofs`
+ * payload the completion POST would have carried in `localStorage`, framed as
+ * "saved on this device" (never discarded — F4). On sign-in it replays into the
+ * completion route, which re-grades every proof server-side (see replay-banked).
+ *
+ * What is stored is only what the client already computed for the live POST:
+ * challenge code, quiz selections, and — for reflection blocks — the sealed
+ * attestation token. Those seals are minted by `/api/lessons/reflect`, which
+ * itself requires auth AND binds the seal to the caller's `userId`, so an
+ * anonymous session never obtains one: reflection lessons simply won't carry a
+ * usable proof and will replay as incomplete. That is the honest outcome — the
+ * bank never forges a proof, and expiry is enforced server-side, not faked here.
+ */
+
+const STORAGE_KEY = "superteam:progress-bank:v1";
+
+// Storage hygiene only. Entries older than this are dropped on read so an
+// abandoned bank cannot grow without bound. It is deliberately unrelated to the
+// 24h attestation-seal TTL — a banked seal older than 24h is rejected by the
+// server regardless of whether the entry is still here; code/quiz proofs never
+// expire (the answers are static), so pruning is about storage, not validity.
+const MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000;
+
+// Bound the bank so a long anonymous session cannot fill the origin's storage
+// quota. Oldest entries are dropped first; a learner who completes more than
+// this many lessons before ever signing in is well past the intended flow.
+const MAX_ENTRIES = 100;
+
+export interface BankedCompletion {
+  courseId: string;
+  courseSlug: string;
+  lessonId: string;
+  lessonSlug: string;
+  lessonTitle: string;
+  /** Exactly the per-block proofs the live completion POST would carry. */
+  proofs: Record<string, unknown>;
+  /** Epoch ms when the work was banked — drives pruning and ordering. */
+  bankedAt: number;
+}
+
+function isBankedCompletion(value: unknown): value is BankedCompletion {
+  if (!value || typeof value !== "object") return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.courseId === "string" &&
+    typeof v.courseSlug === "string" &&
+    typeof v.lessonId === "string" &&
+    typeof v.lessonSlug === "string" &&
+    typeof v.lessonTitle === "string" &&
+    typeof v.bankedAt === "number" &&
+    Number.isFinite(v.bankedAt) &&
+    !!v.proofs &&
+    typeof v.proofs === "object"
+  );
+}
+
+function readRaw(): BankedCompletion[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(isBankedCompletion);
+  } catch {
+    // Corrupt/unavailable storage (private mode, quota, garbage) → treat as empty.
+    return [];
+  }
+}
+
+function writeRaw(entries: BankedCompletion[]): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(entries));
+  } catch {
+    // Best-effort: a storage write failure must never break the lesson flow.
+  }
+}
+
+/** Banked completions, freshest first, with stale entries pruned. */
+export function readBank(): BankedCompletion[] {
+  const cutoff = Date.now() - MAX_AGE_MS;
+  const live = readRaw()
+    .filter((e) => e.bankedAt >= cutoff)
+    .sort((a, b) => b.bankedAt - a.bankedAt);
+  return live.slice(0, MAX_ENTRIES);
+}
+
+export function hasBankedCompletions(): boolean {
+  return readBank().length > 0;
+}
+
+/**
+ * Save (or refresh) a lesson's proofs. Keyed by course+lesson so re-doing a
+ * lesson before signing in overwrites rather than duplicates.
+ */
+export function bankCompletion(
+  entry: Omit<BankedCompletion, "bankedAt">
+): void {
+  const others = readRaw().filter(
+    (e) => !(e.courseId === entry.courseId && e.lessonId === entry.lessonId)
+  );
+  const next = [...others, { ...entry, bankedAt: Date.now() }]
+    .sort((a, b) => b.bankedAt - a.bankedAt)
+    .slice(0, MAX_ENTRIES);
+  writeRaw(next);
+}
+
+export function removeBanked(courseId: string, lessonId: string): void {
+  const next = readRaw().filter(
+    (e) => !(e.courseId === courseId && e.lessonId === lessonId)
+  );
+  writeRaw(next);
+}
+
+export function clearBank(): void {
+  writeRaw([]);
+}

--- a/apps/web/src/lib/lessons/replay-banked.ts
+++ b/apps/web/src/lib/lessons/replay-banked.ts
@@ -1,0 +1,106 @@
+/**
+ * Replay-on-signin for banked anonymous completions (LX-A4c).
+ *
+ * Walks the local bank (progress-bank) and POSTs each entry to
+ * `/api/lessons/complete` with `replay: true`. The marker exempts the batch from
+ * the per-USER volume gate (#459) — a learner banking a whole anonymous session
+ * would otherwise throttle their own history — while the per-IP burn-rate gate
+ * still applies. The server re-grades every proof, so replay grants nothing a
+ * fresh live completion wouldn't: a forged or expired proof is rejected exactly
+ * the same way.
+ *
+ * Outcomes drive the bank and the UX honestly — no failure is silently dropped:
+ *   - completed  → the server accepted it → entry removed.
+ *   - needsEnroll→ 403 enrollment_missing / wallet not linked → entry KEPT, so a
+ *                  post-enroll retry finishes it (the learner still owns the work).
+ *   - retry      → 429 / 5xx / network → transient → entry KEPT for a later pass.
+ *   - needsRedo  → the banked proof is invalid or expired (wrong answer, failed
+ *                  suite, missing/stale reflection seal, unknown lesson) → it can
+ *                  never succeed on replay → surfaced, then removed. The learner
+ *                  redoes it in-lesson, where the normal completion path applies.
+ */
+
+import type { CompletionDenyReason } from "@/lib/lessons/completion-error";
+import { readBank, removeBanked, type BankedCompletion } from "./progress-bank";
+
+export type ReplayStatus = "completed" | "needsEnroll" | "retry" | "needsRedo";
+
+export interface ReplayOutcome {
+  entry: BankedCompletion;
+  status: ReplayStatus;
+  /** The route's 403 discriminator or the HTTP status, for surfacing/telemetry. */
+  reason?: CompletionDenyReason | string;
+}
+
+async function postCompletion(
+  entry: BankedCompletion
+): Promise<{ ok: boolean; status: number; reason?: string }> {
+  const res = await fetch("/api/lessons/complete", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      lessonId: entry.lessonId,
+      courseId: entry.courseId,
+      proofs: entry.proofs,
+      replay: true,
+    }),
+  });
+  if (res.ok) return { ok: true, status: res.status };
+  let reason: string | undefined;
+  try {
+    const body = (await res.json()) as { reason?: unknown };
+    if (typeof body.reason === "string") reason = body.reason;
+  } catch {
+    // Non-JSON error body — status alone classifies the outcome.
+  }
+  return { ok: false, status: res.status, reason };
+}
+
+function classify(status: number, reason?: string): ReplayStatus {
+  if (status === 429 || status >= 500) return "retry";
+  // enrollment_missing needs an on-chain enroll first; 400 covers "Wallet not
+  // connected" (link wallet, then it works). Both clear once the learner acts,
+  // so the entry is kept for a post-enroll retry.
+  if (status === 400 || reason === "enrollment_missing") return "needsEnroll";
+  // 403 quiz_failed / challenge_failed / reflection_required, 404, anything else
+  // → the proof itself won't pass on any retry.
+  return "needsRedo";
+}
+
+/**
+ * Replay the whole bank sequentially. Sequential (not parallel) so the per-IP
+ * gate and the backend keypair see the same ordered pressure a human would
+ * create, and so a mid-batch failure never races the ones after it. Never
+ * throws: a network error on one entry is captured as a `retry` outcome and the
+ * walk continues.
+ */
+export async function replayBankedCompletions(): Promise<ReplayOutcome[]> {
+  const entries = readBank();
+  const outcomes: ReplayOutcome[] = [];
+
+  for (const entry of entries) {
+    let status: ReplayStatus;
+    let reason: string | undefined;
+    try {
+      const res = await postCompletion(entry);
+      if (res.ok) {
+        status = "completed";
+      } else {
+        status = classify(res.status, res.reason);
+        reason = res.reason ?? String(res.status);
+      }
+    } catch {
+      status = "retry";
+      reason = "network";
+    }
+
+    if (status === "completed" || status === "needsRedo") {
+      // Both leave the bank: a success is done; a needsRedo can never replay, so
+      // holding it would re-fail (and re-nag) on every future sign-in.
+      removeBanked(entry.courseId, entry.lessonId);
+    }
+    outcomes.push({ entry, status, reason });
+  }
+
+  return outcomes;
+}

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -83,7 +83,11 @@
     "githubSignInFailed": "Could not start GitHub sign-in. Please try again.",
     "signingIn": "Signing in with your wallet...",
     "signingMessage": "Sign this message to verify your wallet ownership",
-    "walletConnected": "Wallet Connected"
+    "walletConnected": "Wallet Connected",
+    "keepProgressTitle": "Save your progress",
+    "keepProgressSubtitle": "Sign in to keep the work you just did. It's saved on this device until you do.",
+    "later": "Later",
+    "progressSavedLocally": "No rush — your progress stays saved on this device."
   },
   "landing": {
     "poweredBy": "Powered by",
@@ -243,7 +247,10 @@
     "askQuestion": "Ask a Question",
     "signInToAsk": "Sign in to ask a question",
     "dismissSuggestion": "Dismiss",
-    "dismissAllSuggestions": "Dismiss All"
+    "dismissAllSuggestions": "Dismiss All",
+    "progressRestored": "{count, plural, one {Restored # completed lesson} other {Restored # completed lessons}}",
+    "progressNeedsEnroll": "{count, plural, one {Enroll to save the lesson you completed} other {Enroll to save the # lessons you completed}}",
+    "progressNeedsRedo": "\"{lesson}\" needs to be finished — open it to complete."
   },
   "dashboard": {
     "allCaughtUp": "All caught up!",

--- a/apps/web/src/messages/es.json
+++ b/apps/web/src/messages/es.json
@@ -83,7 +83,11 @@
     "githubSignInFailed": "No se pudo iniciar sesión con GitHub. Inténtalo de nuevo.",
     "signingIn": "Iniciando sesión con tu billetera...",
     "signingMessage": "Firma este mensaje para verificar la propiedad de tu billetera",
-    "walletConnected": "Billetera Conectada"
+    "walletConnected": "Billetera Conectada",
+    "keepProgressTitle": "Guarda tu progreso",
+    "keepProgressSubtitle": "Inicia sesión para conservar lo que acabas de hacer. Se guarda en este dispositivo hasta entonces.",
+    "later": "Más tarde",
+    "progressSavedLocally": "Sin prisa: tu progreso permanece guardado en este dispositivo."
   },
   "landing": {
     "poweredBy": "Powered by",
@@ -243,7 +247,10 @@
     "askQuestion": "Hacer una Pregunta",
     "signInToAsk": "Inicia sesión para hacer una pregunta",
     "dismissSuggestion": "Descartar",
-    "dismissAllSuggestions": "Descartar Todas"
+    "dismissAllSuggestions": "Descartar Todas",
+    "progressRestored": "{count, plural, one {# lección completada restaurada} other {# lecciones completadas restauradas}}",
+    "progressNeedsEnroll": "{count, plural, one {Inscríbete para guardar la lección que completaste} other {Inscríbete para guardar las # lecciones que completaste}}",
+    "progressNeedsRedo": "\"{lesson}\" debe completarse: ábrela para finalizar."
   },
   "dashboard": {
     "allCaughtUp": "¡Todo al día!",

--- a/apps/web/src/messages/pt-BR.json
+++ b/apps/web/src/messages/pt-BR.json
@@ -83,7 +83,11 @@
     "githubSignInFailed": "Não foi possível iniciar o login com GitHub. Tente novamente.",
     "signingIn": "Entrando com sua carteira...",
     "signingMessage": "Assine esta mensagem para verificar a propriedade da sua carteira",
-    "walletConnected": "Carteira Conectada"
+    "walletConnected": "Carteira Conectada",
+    "keepProgressTitle": "Salve seu progresso",
+    "keepProgressSubtitle": "Entre para manter o que você acabou de fazer. Fica salvo neste dispositivo até lá.",
+    "later": "Depois",
+    "progressSavedLocally": "Sem pressa — seu progresso continua salvo neste dispositivo."
   },
   "landing": {
     "poweredBy": "Powered by",
@@ -243,7 +247,10 @@
     "askQuestion": "Fazer uma Pergunta",
     "signInToAsk": "Entre para fazer uma pergunta",
     "dismissSuggestion": "Dispensar",
-    "dismissAllSuggestions": "Dispensar Todas"
+    "dismissAllSuggestions": "Dispensar Todas",
+    "progressRestored": "{count, plural, one {# aula concluída restaurada} other {# aulas concluídas restauradas}}",
+    "progressNeedsEnroll": "{count, plural, one {Matricule-se para salvar a aula que você concluiu} other {Matricule-se para salvar as # aulas que você concluiu}}",
+    "progressNeedsRedo": "\"{lesson}\" precisa ser concluída — abra para finalizar."
   },
   "dashboard": {
     "allCaughtUp": "Tudo em dia!",


### PR DESCRIPTION
Closes #567 — **LX-A4 parts (b) + (c)**. Part (a) (anonymous-enroll AuthModal fix) already shipped in #556/#619; part (d) is owner decision D-2, out of scope.

## What this does
An anonymous learner who completes work no longer loses it at the sign-in wall. Their proofs are **banked locally**, framed as "saved on this device" (never "discard" — F4), and **replayed** into `/api/lessons/complete` once they sign in. The server stays authoritative — it re-grades every replayed proof.

## Banking design (`lib/lessons/progress-bank.ts`)
- **What's stored:** exactly the per-block `proofs` the live completion POST already carries (challenge code, quiz selections, reflection seal), keyed by course+lesson, plus `bankedAt`. Upsert (re-doing a lesson overwrites), capped at 100 entries, pruned at a 30-day storage-hygiene window. Corrupt/unavailable storage → treated as empty, never throws.
- **Expiry, handled honestly:** reflection attestation seals are minted only by `/api/lessons/reflect`, which **requires auth and binds the seal to the caller's `userId`** with a 24h TTL. So an anonymous session never obtains a usable seal — reflection lessons carry no valid proof and **replay as incomplete**, surfaced to the learner. The bank never forges or re-seals a proof; expiry is enforced server-side.

## Replay + the #459 cross-check constraint
- `replay-banked.ts` walks the bank sequentially, POSTing each with `replay: true`. Outcomes are **surfaced per lesson, never silently dropped**: `completed` → cleared; `needsEnroll` (403 enrollment_missing / wallet-not-linked) and `retry` (429/5xx/network) → **kept** for a post-enroll/next-signin retry; `needsRedo` (wrong answer / failed suite / stale-or-absent reflection seal / unknown lesson — can never replay) → surfaced, then cleared. `BankedProgressReplay` (mounted in `GamificationOverlays`) runs it on sign-in and re-fires after enrollment.
- **Replay marker (SENSITIVE — one route change, `route.ts`):** `replay: true` exempts the request from **only the per-user #459 gate**, and nothing else. Rationale, per the route's own #459 comment: the per-user bucket does *nothing* against the only actor worth stopping — a Sybil farmer mints a fresh SIWS account (fresh per-user key) per replay, so the per-IP key is what bounds burn rate. **The per-IP gate still applies to replays**, so nothing is loosened globally, and non-replay traffic is untouched. A forged `replay` flag therefore buys an attacker nothing an honest replay wouldn't already get, and the server still re-grades every proof. Composed cleanly on top of the #631 403-`reason` discriminators (rebased onto latest main).

## "Later" affordance (`auth-modal.tsx`, LX-A4b)
Claim-moment mode: keep-progress framing, a **"Later"** escape that dismisses without implying loss, and a "your progress stays saved on this device" reassurance line. A copy test asserts the claim copy contains no discard/lose/delete language and does say "saved".

## OAuth `next` (bonus, #619 review item)
The OAuth branch previously always landed on `/dashboard`, stranding a learner mid-lesson (and away from their replay). It now passes a `next` = current path through the existing callback, which already sanitizes against open-redirect. Small, self-contained — included rather than deferred.

## Scope / notes
- Anonymous users can't POST completion (401); banking is client-side pre-auth, replay is authed. A code learner submits *before* enrolling, so the passing code is captured via a new proof-capture event (no completion triggered) and banked.
- i18n ×3 (en / pt-BR / es); "Later" button is keyboard/focus-accessible; all strings externalized.

## Verification
- `pnpm --filter web typecheck` (tsc --noEmit): clean.
- `pnpm --filter web test` (vitest): **131 files / 1182 tests pass**, including new suites — bank round-trip, replay marker present, expiry/invalid-proof handling, per-user-gate exemption + per-IP still enforced, Later-copy no-discard.
- `next lint` + prettier: clean on touched files (pre-existing import-order warnings only, untouched lines).

Out-of-scope findings: none blocking. The husky pre-commit hook fails in a bare CI-less clone (root `eslint` ENOENT / prettier OOM); verified lint+format manually instead.