### PR TITLE
perf: enable optimizePackageImports for @phosphor-icons/react

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -118,6 +118,10 @@ const nextConfig = {
   // (validates env vars). Stable in Next 15; opt-in in Next 14.
   experimental: {
     instrumentationHook: true,
+    // Tree-shake the per-icon barrel so only the icons a client component
+    // actually imports land in its bundle (55+ named-import sites across the
+    // app). Named imports only — no namespace/dynamic imports of the package.
+    optimizePackageImports: ["@phosphor-icons/react"],
     // The server-side challenge executor (lib/challenge/executor.ts) runs learner
     // code in QuickJS-on-WASM. Keep these packages EXTERNAL so webpack does not
     // re-bundle the single-file variant — its WASM is embedded via octal escapes


### PR DESCRIPTION
Refs #534.

## Change
Adds `@phosphor-icons/react` to `experimental.optimizePackageImports` in `apps/web/next.config.mjs`, alongside the existing QuickJS `serverComponentsExternalPackages` block (untouched).

## Verification
- `pnpm typecheck` — green (6/6 packages)
- `pnpm test` (apps/web) — green (133 files, 1210 tests)
- `pnpm build` (apps/web) — **succeeds** with the flag (primary acceptance: this flag can break builds on some package structures; the build succeeding is the verification)
- Namespace/dynamic-import scan — **none**: all 63 import sites use named barrel imports (`import { Icon } from "@phosphor-icons/react"`), which is exactly what the optimizer handles

## Honest note on bundle size
The build succeeds, but **First Load JS is byte-identical** before vs. after on every icon-heavy route (dashboard 469 kB, `courses/[slug]/lessons/[id]` 570 kB, community 382 kB, profile 395 kB, home 304 kB).

Reason: `@phosphor-icons/react@2.1.10` already ships tree-shakeable ESM (`"module": "./dist/index.es.js"`, `"sideEffects": false`), so webpack's production tree-shaking already drops unused icons from the barrel. `optimizePackageImports` therefore adds **no production bundle-size win** here — its remaining value is faster dev-server compile / HMR (barrel rewritten to direct deep imports). The acceptance bullet "icon-heavy route First Load JS drops" did **not** materialize; the change is still low-risk perf hygiene and keeps future non-tree-shakeable icon usage optimized.

Change is a no-op for runtime behavior; safe to land or to close #534 as "already handled by tree-shaking" at the maintainer's discretion.