### PR TITLE
docs(env): enforce Helius browser/server key split in the env schema (Refs #467)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,14 +4,17 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=your-supabase-anon-key
 SUPABASE_SERVICE_ROLE_KEY=your-supabase-service-role-key   # PRIVATE — server-only
 
 # ── Solana ────────────────────────────────────────────────────────────────────
-# PUBLIC browser RPC endpoint — inlined into the client bundle. MUST NOT carry a
-# privileged Helius API key. Use a rate-limited public endpoint or a Helius
-# domain-restricted key safe for client exposure.
+# PUBLIC browser RPC endpoint — inlined into the client bundle, so its key (if
+# any) is visible in the browser. Use a keyless rate-limited public endpoint, or
+# a Helius key DOMAIN-RESTRICTED in the dashboard (Allowed Origins = the app's
+# domains only, e.g. https://www.stacademy.org + http://localhost:3000) so a
+# leaked copy can't be used off-domain. Must be a SEPARATE key from SOLANA_RPC_URL.
 NEXT_PUBLIC_SOLANA_RPC_URL=https://api.devnet.solana.com
 # SERVER-ONLY RPC endpoint — never sent to the browser (`server-only` enforced).
-# This is the one that may carry the privileged Helius API key. Required: a
+# Use a SEPARATE, UNRESTRICTED Helius key here: server calls send no browser
+# Origin, so an origin-restricted key would fail every request. Required: a
 # missing value fails loudly at boot instead of silently using public devnet.
-SOLANA_RPC_URL=https://devnet.helius-rpc.com/?api-key=YOUR_KEY
+SOLANA_RPC_URL=https://devnet.helius-rpc.com/?api-key=YOUR_UNRESTRICTED_KEY
 NEXT_PUBLIC_SOLANA_NETWORK=devnet
 
 # On-chain program (see docs/DEPLOY-PROGRAM.md for deployment guide)
@@ -19,7 +22,8 @@ NEXT_PUBLIC_PROGRAM_ID=                    # Program ID from anchor deploy
 NEXT_PUBLIC_XP_MINT_ADDRESS=               # XP mint pubkey (from initialize.ts output)
 
 # ── Helius ───────────────────────────────────────────────────────────────────
-# Server-only API key for webhook management + DAS API (same key as in RPC URL)
+# Server-only API key for webhook management + DAS API. The same unrestricted key
+# embedded in the server-only SOLANA_RPC_URL above — never the browser key.
 HELIUS_API_KEY=
 # Shared secret for Helius webhook Authorization header validation
 HELIUS_WEBHOOK_SECRET=

--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -50,8 +50,8 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=     # Public anon key (safe for browser)
 SUPABASE_SERVICE_ROLE_KEY=         # PRIVATE — server-only, for admin operations
 
 # Required — Solana
-NEXT_PUBLIC_SOLANA_RPC_URL=https://api.devnet.solana.com   # PUBLIC browser RPC — no privileged key
-SOLANA_RPC_URL=                    # SERVER-ONLY RPC (may carry the Helius key; required at boot)
+NEXT_PUBLIC_SOLANA_RPC_URL=https://api.devnet.solana.com   # PUBLIC browser RPC — keyless, or a Helius key DOMAIN-RESTRICTED to the app's origins
+SOLANA_RPC_URL=                    # SERVER-ONLY RPC — a SEPARATE, unrestricted Helius key (never NEXT_PUBLIC_); required at boot
 NEXT_PUBLIC_SOLANA_NETWORK=devnet
 NEXT_PUBLIC_PROGRAM_ID=            # Deployed program ID (used by webhook decoder + frontend)
 NEXT_PUBLIC_XP_MINT_ADDRESS=       # XP mint pubkey (from initialize.ts output)
@@ -65,7 +65,7 @@ GITHUB_TOKEN=                      # Fine-grained READ token for solanabr/course
                                    # 60 req/hr per IP and flakes on Vercel). Server-only. Powers
                                    # the publish-pin card (HEAD polling + ahead-by) and the
                                    # Checks API (blocked state); unset → those admin reads 503.
-HELIUS_API_KEY=                    # Helius key for webhook management + DAS API (lib/helius)
+HELIUS_API_KEY=                    # Helius key for webhook management + DAS API (lib/helius) — server-only, unrestricted, distinct from the browser key
 HELIUS_WEBHOOK_SECRET=             # Helius webhook signature verification
 BACKEND_SIGNER_SECRET=             # Rotatable backend co-signer keypair (completeLesson etc.)
 XP_MINT_AUTHORITY_SECRET=          # XP mint authority keypair (JSON array of 64 keypair bytes)

--- a/apps/web/src/lib/env.server.ts
+++ b/apps/web/src/lib/env.server.ts
@@ -28,6 +28,9 @@ const serverEnvSchema = z.object({
   // privileged Helius API key — it is never inlined into the client bundle
   // (`server-only` enforces that). Required so a misconfigured deployment
   // fails loudly here instead of silently falling back to public devnet.
+  // Use a SEPARATE, UNRESTRICTED Helius key here — distinct from the domain-
+  // restricted key behind NEXT_PUBLIC_SOLANA_RPC_URL. Server requests carry no
+  // browser Origin, so an origin-restricted key would 4xx on every call.
   SOLANA_RPC_URL: z.url(),
   // Fine-grained READ token for solanabr/courses-academy. Server-only. Needed by
   // the drift UI (HEAD polling) and the Checks API (blocked state). Optional at
@@ -59,7 +62,9 @@ const serverEnvSchema = z.object({
   // (lib/solana/arweave.ts). Unset → mint falls back to the app-served
   // metadata URL.
   ARWEAVE_UPLOADER_SECRET: optStr,
-  // Helius key for webhook management + DAS API (lib/helius).
+  // Helius key for webhook management + DAS API (lib/helius). Server-only and
+  // UNRESTRICTED — never NEXT_PUBLIC_, and not the same key as the domain-
+  // restricted one behind NEXT_PUBLIC_SOLANA_RPC_URL.
   HELIUS_API_KEY: optStr,
   // Optional dedicated key for sealing the AI Partner's comprehension-check /
   // attestation tokens (lib/ai/check-seal.ts). Falls back to

--- a/apps/web/src/lib/env.ts
+++ b/apps/web/src/lib/env.ts
@@ -37,9 +37,14 @@ const publicEnvSchema = z.object({
       { error: "must use https:// in production" }
     ),
   NEXT_PUBLIC_SUPABASE_ANON_KEY: z.string().min(1),
-  // Public, rate-limited browser RPC endpoint. MUST NOT carry a privileged
-  // Helius API key — it is inlined into the client bundle. The Helius-keyed
-  // endpoint lives server-side as SOLANA_RPC_URL in env.server.ts.
+  // Public browser RPC endpoint — inlined into the client bundle, so the key it
+  // carries (if any) is visible in the Network tab. Two ways to populate it
+  // safely: a keyless rate-limited public endpoint (e.g. api.devnet.solana.com),
+  // or a Helius key that is DOMAIN-RESTRICTED in the Helius dashboard (Allowed
+  // Origins = the app's domains only) so a copied key can't be abused off-domain.
+  // This key MUST be a *separate* key from the server's SOLANA_RPC_URL: that one
+  // is unrestricted, and server calls send no browser Origin — sharing one key
+  // and origin-restricting it would break every server-side RPC/DAS read.
   NEXT_PUBLIC_SOLANA_RPC_URL: z.url(),
   // Optional Sentry DSN (public/safe to expose). Unset disables Sentry.
   NEXT_PUBLIC_SENTRY_DSN: z.url().optional().or(z.literal("")),

--- a/docs/SECRET-ROTATION.md
+++ b/docs/SECRET-ROTATION.md
@@ -122,11 +122,11 @@ dashboard (Authentication → Providers → Google).
 
 ### Known drift in the env surface (not secrets — clean these up)
 
-| Var                                                                                                     | Where                            | Status                                                                                                              |
-| ------------------------------------------------------------------------------------------------------- | -------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
-| `NEXT_PUBLIC_SANITY_PROJECT_ID`, `NEXT_PUBLIC_SANITY_DATASET`, `SANITY_API_TOKEN`, `SANITY_ADMIN_TOKEN` | `turbo.json` `env` (lines 12-15) | **DEAD.** Read nowhere in the codebase. Delete from `turbo.json` and from every env store.                          |
-| `NEXT_PUBLIC_HELIUS_API_KEY`                                                                            | `turbo.json` `env`               | **PHANTOM.** Declared as a build-cache key but read nowhere. Helius is server-side only (`HELIUS_API_KEY`). Delete. |
-| `GITHUB_TOKEN`, `MODERATION_WEBHOOK_URL`                                                                | absent from `.env.example`       | **UNDOCUMENTED.** Both are live in `env.server.ts`. Add them to `.env.example`.                                     |
+| Var                                                                                                     | Where                            | Status                                                                                                                                                                                            |
+| ------------------------------------------------------------------------------------------------------- | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `NEXT_PUBLIC_SANITY_PROJECT_ID`, `NEXT_PUBLIC_SANITY_DATASET`, `SANITY_API_TOKEN`, `SANITY_ADMIN_TOKEN` | `turbo.json` `env` (lines 12-15) | **DEAD.** Read nowhere in the codebase. Delete from `turbo.json` and from every env store.                                                                                                        |
+| `NEXT_PUBLIC_HELIUS_API_KEY`                                                                            | (removed)                        | **RESOLVED (#467).** Was a phantom `turbo.json` build-cache key, read nowhere; now deleted. Helius is server-side only (`HELIUS_API_KEY`). Purge any leftover value from Vercel/local env stores. |
+| `GITHUB_TOKEN`, `MODERATION_WEBHOOK_URL`                                                                | absent from `.env.example`       | **UNDOCUMENTED.** Both are live in `env.server.ts`. Add them to `.env.example`.                                                                                                                   |
 
 Google OAuth has **no** app-side env var — the client ID/secret live in the Supabase
 dashboard (Authentication → Providers → Google).
@@ -157,9 +157,9 @@ dashboard (Authentication → Providers → Google).
 - [ ] Helius (`HELIUS_API_KEY` **+ `SOLANA_RPC_URL` together**), Gemini, `GITHUB_TOKEN`, `ADMIN_SECRET`, `BUILD_SERVER_API_KEY`, `SENTRY_AUTH_TOKEN`, `MODERATION_WEBHOOK_URL` all freshly minted for prod.
 - [ ] `AI_PARTNER_SEAL_SECRET` set explicitly in prod (not derived from `SUPABASE_SERVICE_ROLE_KEY`, so rotating the DB key doesn't silently invalidate live check tokens).
 - [ ] `ARWEAVE_UPLOADER_SECRET` is a dedicated, funded keypair — never reused as a signer.
-- [ ] Dead `SANITY_*` + phantom `NEXT_PUBLIC_HELIUS_API_KEY` deleted from `turbo.json` and every env store (Vercel prod + preview, local).
+- [ ] Dead `SANITY_*` deleted from `turbo.json` and every env store; phantom `NEXT_PUBLIC_HELIUS_API_KEY` already removed from `turbo.json` (#467) — purge any leftover value from Vercel prod + preview + local.
 - [ ] `GITHUB_TOKEN` + `MODERATION_WEBHOOK_URL` added to `.env.example`.
-- [ ] `NEXT_PUBLIC_SOLANA_RPC_URL` verified to carry **no** API key (it ships in the browser bundle).
+- [ ] `NEXT_PUBLIC_SOLANA_RPC_URL` carries either no API key or a **domain-restricted** Helius key (it ships in the browser bundle) — and is a **separate** key from the unrestricted `SOLANA_RPC_URL` (#467).
 - [ ] `backend_signer` rotated to a distinct hot key at mainnet init (**#118**).
 - [ ] Program / mint authority under Squads multisig (**#144**).
 - [ ] All prod secrets live only in the Vercel/Cloud Run encrypted env; on-chain keypairs in multisig/HW; repo clean.


### PR DESCRIPTION
Refs #467 (does **not** close it — the Helius-dashboard + Vercel half is an owner action, see checklist).

## What this is
The **code half** of #467. The Helius key in `NEXT_PUBLIC_SOLANA_RPC_URL` is inlined into the browser bundle and is currently **unrestricted**, so a copied key can be abused off-domain. The remediation is a key *split*: a domain-restricted (or keyless) browser key + a separate unrestricted server key. This PR makes the codebase state and enforce that split so the owner's dashboard restriction can't cause a server outage.

## Audit (every var → usage → verdict)
| Var | Usage sites | Verdict |
|---|---|---|
| `SOLANA_RPC_URL` (server) | `env.server.ts` (`server-only`), and every server Solana read: admin routes (status/resync/sync/recreate/achievements), `academy-program.ts`, `xp-mint.ts`, `arweave.ts`, `admin-signer.ts`, `recreate-*.ts` | ✅ Correct. All privileged/server reads already go through `serverEnv.SOLANA_RPC_URL`. |
| `HELIUS_API_KEY` (server) | `env.server.ts`, `lib/helius/webhook-config.ts` (webhook CRUD) | ✅ Correct. Server-only; never `NEXT_PUBLIC_`. |
| `NEXT_PUBLIC_SOLANA_RPC_URL` (browser) | `wallet-provider.tsx`, `landing-client.tsx`, `hybrid-progress-service.ts` (client XP read), `csp.ts` (pins `connect-src` to the browser endpoint — correct by design), `env.ts` schema | ✅ Only reached from client components + CSP. See below. |
| `NEXT_PUBLIC_HELIUS_API_KEY` | **none** — not in `env.ts`, not in `turbo.json` | ✅ Already removed. Was a phantom `turbo.json` cache key; the only surviving mention was a stale note in `SECRET-ROTATION.md`, now refreshed. |

**Server-on-browser-key paths: none found to fix.** `HybridProgressService` is constructed server-side (in `/api/leaderboard` and the leaderboard server page), but the *only* method that touches its `NEXT_PUBLIC` RPC `Connection` is `getXP`, which is called exclusively from `"use client"` files (`profile/page.tsx`, `use-dashboard-data.ts`). The server callers only invoke `getLeaderboard` / `getCredentials`, which are Supabase-only. `new Connection()` opens no socket at construction, so no server request ever rides the browser key today. The invariant already holds; this PR documents it so it stays that way.

> Note: the issue's premise that "DAS/leaderboard reads happen client-side with the public key" is now stale — the leaderboard reads via the Supabase `get_leaderboard` RPC, and credentials via the `certificates` table. No client-side Helius-keyed DAS call exists.

## Changes (docs/comments only — no runtime code)
- `env.ts` / `env.server.ts` — schema comments now state the split invariant: browser key must be **keyless or domain-restricted**; server key must be a **separate, unrestricted** key (server calls send no `Origin`, so an origin-restricted key would 4xx).
- `apps/web/CLAUDE.md`, `.env.example` — same guidance for operators; example server var renamed to `YOUR_UNRESTRICTED_KEY`.
- `docs/SECRET-ROTATION.md` — refreshed the now-resolved `NEXT_PUBLIC_HELIUS_API_KEY` phantom row + checklist; updated the browser-key checklist item to allow a domain-restricted key.

## Owner checklist (dashboard + Vercel — not code)
- [ ] In the Helius dashboard, restrict the **browser** key (behind `NEXT_PUBLIC_SOLANA_RPC_URL` / `NEXT_PUBLIC_HELIUS_API_KEY` if used) to **Allowed Origins = `https://www.stacademy.org` + `http://localhost:3000`**.
- [ ] Mint a **separate, unrestricted** Helius key for server use.
- [ ] Set it in Vercel (Production + Preview) as `SOLANA_RPC_URL` and `HELIUS_API_KEY`; update `.env.local`.
- [ ] Verify: `curl` the browser RPC URL from a disallowed `Origin` → rejected; app still loads balances / leaderboard / credentials.
- [ ] Purge any leftover `NEXT_PUBLIC_HELIUS_API_KEY` value from Vercel prod + preview + local env stores.

## Follow-up candidates (not in this PR)
- Make `HybridProgressService.connection` lazy so a browser-key `Connection` is never even constructed in server contexts (defense-in-depth against a future server-side `getXP` call). Low priority — no socket opens today.
- Optional `/api/rpc` + `/api/das` proxy so no Helius key reaches the browser at all (issue's "stronger" option); domain-restriction is the pragmatic default.

## Verification
- `pnpm typecheck` — clean
- `pnpm test` — 135 files, **1230 passed**
- `pnpm lint` — only pre-existing `import/order` warnings in untouched files; no errors
- `prettier --check` on changed files — clean