### PR TITLE
fix(courses): drop the per-module progress bar

### DIFF
--- a/apps/web/src/components/course/__tests__/curriculum-path.test.tsx
+++ b/apps/web/src/components/course/__tests__/curriculum-path.test.tsx
@@ -148,17 +148,23 @@ describe("CurriculumPath — every lesson stays openable (no locks)", () => {
 });
 
 describe("CurriculumPath — progress map", () => {
-  it("marks completed lessons for screen readers and shows per-module progress", () => {
+  it("marks completed lessons for screen readers and shows per-module progress as a count", () => {
     renderPath(["l1", "l2", "l3"]);
 
     // Completed nodes carry an sr-only "Completed" state.
     expect(screen.getAllByText(messages.courses.completed)).toHaveLength(3);
 
-    // Per-module progress bars: module 1 fully complete, module 2 untouched.
-    const bars = screen.getAllByRole("progressbar");
-    expect(bars).toHaveLength(2);
-    expect(bars[0]).toHaveAttribute("aria-valuenow", "100");
-    expect(bars[1]).toHaveAttribute("aria-valuenow", "0");
+    // Per-module progress is the x/y count in the module header — module 1 fully
+    // complete, module 2 untouched. There is deliberately NO per-module progress
+    // bar: the count plus the per-lesson node markers already carry that state,
+    // so a third indicator for the same fact was removed as noise.
+    expect(
+      screen.getByText(`3/3 ${messages.courses.lessons}`)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(`0/2 ${messages.courses.lessons}`)
+    ).toBeInTheDocument();
+    expect(screen.queryAllByRole("progressbar")).toHaveLength(0);
   });
 
   it("renders modules and lessons with list semantics", () => {

--- a/apps/web/src/components/course/curriculum-path.tsx
+++ b/apps/web/src/components/course/curriculum-path.tsx
@@ -2,7 +2,6 @@
 
 import { useTranslations } from "next-intl";
 import { CheckCircle, Play, Code, Article } from "@phosphor-icons/react";
-import { ProgressBar } from "./progress-bar";
 import { cn } from "@/lib/utils";
 
 interface PathLesson {
@@ -69,7 +68,10 @@ export function CurriculumPath({
               allComplete && "border-success/30"
             )}
           >
-            {/* Module header + per-module progress */}
+            {/* Module header. No per-module progress bar: the x/y count here and
+                the per-lesson node markers below already carry that state, and a
+                third indicator for the same fact read as noise. The course-level
+                bar stays — it's the one that isn't redundant. */}
             <div className="border-b border-border p-4">
               <div className="flex items-center justify-between gap-3">
                 <div className="min-w-0 flex-1">
@@ -80,16 +82,15 @@ export function CurriculumPath({
                     {mod.title}
                   </h4>
                 </div>
-                <span className="shrink-0 font-display text-[13px] font-bold tabular-nums text-text-3">
+                <span
+                  className={cn(
+                    "shrink-0 font-display text-[13px] font-bold tabular-nums",
+                    allComplete ? "text-success" : "text-text-3"
+                  )}
+                >
                   {completedInModule}/{mod.lessons.length} {t("lessons")}
                 </span>
               </div>
-              <ProgressBar
-                value={completedInModule}
-                max={Math.max(mod.lessons.length, 1)}
-                variant={allComplete ? "success" : "primary"}
-                className="mt-3"
-              />
             </div>
 
             {/* Lesson nodes on the path */}


### PR DESCRIPTION
Owner call — didn't like it on the module cards.

It was also redundant. The module header already shows `2/4 lessons` and every lesson below has a completed/active node marker, so the bar was a **third** indicator of the same fact.

**Kept:** the `x/y` count, now tinted `text-success` when the module is complete, so the "all done" signal the bar's success variant carried isn't lost. **The course-level progress bar is untouched** — that one isn't redundant.

Removed the now-unused `ProgressBar` import (the component is still used by `course-detail-client` and `lesson-client`).

**Test updated, not deleted.** `curriculum-path.test.tsx` asserted `getAllByRole("progressbar")` with `aria-valuenow` 100/0. It now asserts the counts render (`3/3`, `0/2`) *and* that zero `progressbar` roles remain — so the intent is pinned rather than silently losing coverage.

Verified: `tsc --noEmit` clean · `eslint` clean · **21/21** component tests. Browser-checked the course page shows no `progressbar` role (note `CurriculumPath` only mounts when `isEnrolled`, so the unit test is the authoritative check here).

Reverts the per-module bar added in #636 (LX-B14); the rest of that linear-path view stands.