### PR TITLE
docs(api): fix AI route drift + document billed-assist await (#616)

### DIFF
--- a/apps/web/src/app/api/CLAUDE.md
+++ b/apps/web/src/app/api/CLAUDE.md
@@ -31,10 +31,29 @@
 
 ## AI Lesson Assistant
 
-| Route             | Method | Auth     | Purpose                                                         |
-| ----------------- | ------ | -------- | --------------------------------------------------------------- |
-| `/api/ai/chat`    | POST   | Required | Lesson tutor chat (Gemini); rate-limited + input-capped         |
-| `/api/ai/suggest` | POST   | Required | Challenge code suggestion (Gemini); rate-limited + input-capped |
+| Route                    | Method | Auth     | Purpose                                                                                           |
+| ------------------------ | ------ | -------- | ------------------------------------------------------------------------------------------------- |
+| `/api/ai/partner`        | POST   | Required | AI Partner reply (Gemini); rate-limited **fail-closed** + input-capped; spends a paid assist      |
+| `/api/ai/partner/log`    | GET    | Required | Persisted chat log + remaining paid-assist budget for the current user/lesson                     |
+| `/api/ai/partner/verify` | POST   | Required | Grade a comprehension-check pick server-side (AES-GCM open + compare; no Gemini, no assist spent) |
+
+## Content (committed bundle → client)
+
+Public, read-only faces of the `server-only` content-bundle store (`lib/content/`).
+All gated server-side on synced+active deployments; only summary-safe shapes cross
+the boundary (never the full `Lesson` `blocks[]`, which carries solutions/tests).
+
+| Route                            | Method | Auth | Purpose                                                                       |
+| -------------------------------- | ------ | ---- | ----------------------------------------------------------------------------- |
+| `/api/content/courses`           | GET    | None | Course summaries by id (dashboard/profile/certificates)                       |
+| `/api/content/course-lessons`    | GET    | None | Ordered `{_id,title,slug}` lesson summaries per course (Continue card, LX-B2) |
+| `/api/content/lessons-summary`   | GET    | None | Lesson summaries by id — `{_id,title,slug}` only (recent-activity titles)     |
+| `/api/content/recommended`       | GET    | None | Recommended-course summaries (dashboard); optional `exclude`                  |
+| `/api/content/achievements`      | GET    | None | Achievement catalog (name/icon/award rule/xp); statically cached, hourly      |
+| `/api/content/tags`              | GET    | None | Course tags (profile skill radar); statically cached, hourly                  |
+| `/api/content/lesson-skills`     | GET    | None | Per-lesson skill tags (profile Skills radar, #466 C3); cached, hourly         |
+| `/api/content/is-instructor`     | GET    | None | Whether a wallet is a known instructor (header "Teach" nav gate)              |
+| `/api/content/instructor-wallet` | GET    | None | Wallet → public academy profile for display (#478 B4)                         |
 
 ## Community Forum
 
@@ -58,15 +77,20 @@
 
 ## Admin
 
-| Route                           | Method | Auth         | Purpose                                             |
-| ------------------------------- | ------ | ------------ | --------------------------------------------------- |
-| `/api/admin/auth`               | POST   | ADMIN_SECRET | Admin authentication                                |
-| `/api/admin/status`             | GET    | ADMIN_SECRET | Platform status (program liveness, authority match) |
-| `/api/admin/courses/sync`       | POST   | ADMIN_SECRET | Deploy course PDA + collection on-chain             |
-| `/api/admin/courses/deactivate` | POST   | ADMIN_SECRET | Set course `is_active = false`                      |
-| `/api/admin/courses/reactivate` | POST   | ADMIN_SECRET | Set course `is_active = true`                       |
-| `/api/admin/achievements/sync`  | POST   | ADMIN_SECRET | Deploy achievement type + collection on-chain       |
-| `/api/admin/resync`             | POST   | ADMIN_SECRET | Resync on-chain state to Supabase                   |
+| Route                                   | Method   | Auth         | Purpose                                                            |
+| --------------------------------------- | -------- | ------------ | ------------------------------------------------------------------ |
+| `/api/admin/auth`                       | POST     | ADMIN_SECRET | Admin authentication                                               |
+| `/api/admin/status`                     | GET      | ADMIN_SECRET | Platform status (program liveness, authority match)                |
+| `/api/admin/courses/sync`               | POST     | ADMIN_SECRET | Deploy course PDA + collection on-chain                            |
+| `/api/admin/courses/deactivate`         | POST     | ADMIN_SECRET | Set course `is_active = false`                                     |
+| `/api/admin/courses/reactivate`         | POST     | ADMIN_SECRET | Set course `is_active = true`                                      |
+| `/api/admin/courses/recreate`           | POST     | ADMIN_SECRET | **DESTRUCTIVE** — close + recreate course PDA (create-only fields) |
+| `/api/admin/courses/recreate/preflight` | GET      | ADMIN_SECRET | Read-only preflight validation for the recreate execute route      |
+| `/api/admin/achievements/sync`          | POST     | ADMIN_SECRET | Deploy achievement type + collection on-chain                      |
+| `/api/admin/resync`                     | POST     | ADMIN_SECRET | Resync on-chain state to Supabase                                  |
+| `/api/admin/flags`                      | GET      | ADMIN_SECRET | Pending community flags for the moderation queue                   |
+| `/api/admin/freeze`                     | GET/POST | ADMIN_SECRET | Read/set the global deploy-window freeze (reset wave B2)           |
+| `/api/admin/publish/pin`                | GET      | ADMIN_SECRET | Content pin: pinned bundle SHA + counts vs courses-academy HEAD    |
 
 Content drift (bundle SHA vs `courses-academy` HEAD) and chain drift are folded
 into `/api/admin/status`; the publish card reads `/api/admin/publish/pin`. There

--- a/apps/web/src/app/api/ai/partner/route.ts
+++ b/apps/web/src/app/api/ai/partner/route.ts
@@ -398,6 +398,11 @@ export async function POST(request: NextRequest) {
     // spend in the non-refundable billed-assists counter (best-effort, never
     // throws).
     billed = true;
+    // Deliberately awaited, not `void`ed: on Vercel serverless, work not settled
+    // before the response returns can be frozen/killed with the lambda, which
+    // would silently drop this billing record — the durable audit of spend. The
+    // one added RPC is on the paid path only (max 4/lesson). If latency ever
+    // matters here, use `after()`/`waitUntil` semantics, never a bare `void`.
     await recordBilledAssist(user.id, lesson._id);
 
     const data = await response.json();


### PR DESCRIPTION
Closes #616.

Clears the two remaining #616 cleanup items. Item 1 (the `open-ended-block.tsx` `disabled`/`aria-disabled` mismatch) already landed on `main` via the #618 recovery PR — verified here, both attributes now derive from `!canSubmit`; no change needed.

### Item 2 — billed-assist `await` on the hot path (comment, not a "fix")
Per the orchestrator note on the issue, `await recordBilledAssist(...)` in `api/ai/partner/route.ts` must **not** become a bare `void`: on Vercel serverless, work not settled before the response returns can be frozen/killed with the lambda, silently dropping the durable billing audit record. Added a code comment at the call site stating this (and pointing at `after()`/`waitUntil` as the correct shape if latency ever matters) so a future optimizer doesn't break it.

### Item 3 — `api/CLAUDE.md` route-table drift
- **AI section**: replaced the phantom `/api/ai/chat` + `/api/ai/suggest` rows with the real routes — `/api/ai/partner` (POST, paid reply, rate-limited fail-closed), `/api/ai/partner/log` (GET, chat log + remaining budget), `/api/ai/partner/verify` (POST, server-side comprehension grade).
- **Content section** (was entirely missing): added the 9 public bundle-face `GET` routes under `/api/content/*`, including `course-lessons`.
- **Admin section**: added recently-added routes missing from the existing table — `courses/recreate` (+ `preflight`), `flags`, `freeze`, `publish/pin`.

Method/auth/purpose for every added row were read from the route files.

### Verification
- `pnpm typecheck` — 6/6 packages pass
- `eslint` clean on the touched `route.ts`
- `prettier --check` clean on both files