### PR TITLE
feat: optional failure_message per test case (#575)

### DIFF
--- a/apps/web/src/components/editor/__tests__/output-panel.test.tsx
+++ b/apps/web/src/components/editor/__tests__/output-panel.test.tsx
@@ -250,6 +250,65 @@ describe("degenerate synthesized shapes", () => {
   });
 });
 
+describe("authored failure_message (#575)", () => {
+  const withMessage: ExecutionResult = {
+    success: false,
+    output: "",
+    testResults: [
+      {
+        testCase: {
+          ...tc("t1", "handles zero", "0, 0", "result === 0"),
+          failureMessage:
+            "Adding zero should return the other operand unchanged.",
+        },
+        passed: false,
+        actualOutput: "fail: assertion false",
+      },
+    ],
+  };
+
+  it("renders the authored explanation on the failing test", () => {
+    renderWithIntl(panel(withMessage));
+
+    expect(screen.getByText(/why this failed/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/adding zero should return the other operand/i)
+    ).toBeInTheDocument();
+    // The raw actualOutput is still shown — the authored message composes with
+    // the existing failure detail, it does not replace it.
+    expect(screen.getByText("fail: assertion false")).toBeInTheDocument();
+  });
+
+  it("shows exactly today's display when no failureMessage is authored", () => {
+    renderWithIntl(panel(jsResult));
+
+    expect(screen.queryByText(/why this failed/i)).not.toBeInTheDocument();
+  });
+
+  it("never renders a failureMessage on a passing test", () => {
+    renderWithIntl(
+      panel({
+        success: true,
+        output: "",
+        testResults: [
+          {
+            testCase: {
+              ...tc("t1", "adds", "1, 2", "result === 3"),
+              failureMessage: "should not appear on a pass",
+            },
+            passed: true,
+            actualOutput: "pass",
+          },
+        ],
+      })
+    );
+
+    fireEvent.mouseDown(screen.getByRole("tab", { name: /test cases/i }));
+    expect(screen.queryByText(/why this failed/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/should not appear/i)).not.toBeInTheDocument();
+  });
+});
+
 describe("stdout cap", () => {
   it("caps stdout at 10,000 characters and shows a truncation notice", () => {
     const bigOutput = "x".repeat(10_000) + "END_MARKER";

--- a/apps/web/src/components/editor/output-panel.tsx
+++ b/apps/web/src/components/editor/output-panel.tsx
@@ -46,6 +46,13 @@ function TestResultRow({
   const hasTestCode = input.length > 0 || expectedOutput.length > 0;
   const message = result.actualOutput.trim();
 
+  // Teacher-authored per-test explanation (#575, LX-C3). Rendered only on a
+  // failing case that carries one; absent → exactly today's display. Authored,
+  // never LLM-generated (F17).
+  const failureMessage = !result.passed
+    ? result.testCase.failureMessage?.trim()
+    : undefined;
+
   return (
     <div
       className={cn(
@@ -102,6 +109,16 @@ function TestResultRow({
         </span>
       </button>
       <div id={detailId} hidden={!expanded}>
+        {failureMessage && (
+          <div className="mx-3 mb-3 ml-9 rounded-md border p-3 [background:var(--danger-light)] [border-color:var(--danger-border)]">
+            <div className="mb-1 text-xs font-semibold text-danger">
+              {t("whyThisFailed")}
+            </div>
+            <p className="text-xs leading-relaxed text-text">
+              {failureMessage}
+            </p>
+          </div>
+        )}
         <div
           className={cn(
             "grid gap-3 px-3 pb-3 pl-9 text-xs",

--- a/apps/web/src/lib/content/__tests__/project.golden.test.ts
+++ b/apps/web/src/lib/content/__tests__/project.golden.test.ts
@@ -118,6 +118,43 @@ describe("projectLesson — full blocks[] projection", () => {
     );
     expect((cb as unknown as { questions: unknown }).questions).toBeNull();
   });
+
+  it("surfaces a test's failureMessage only when authored (#575)", () => {
+    const projected = projectLesson({
+      _id: "lesson-synthetic-575",
+      title: "t",
+      slug: { current: "s" },
+      blocks: [
+        {
+          _key: "exercise",
+          _type: "code",
+          tests: [
+            {
+              id: "t1",
+              description: "authored",
+              input: "1",
+              expectedOutput: "1",
+              failureMessage: "Off by one — start the loop at 0.",
+            },
+            {
+              id: "t2",
+              description: "bare",
+              input: "2",
+              expectedOutput: "2",
+            },
+          ],
+        },
+      ],
+    } as unknown as Parameters<typeof projectLesson>[0]);
+
+    const tests = (
+      projected.blocks[0] as unknown as { tests: Record<string, unknown>[] }
+    ).tests;
+    expect(tests[0]!.failureMessage).toBe("Off by one — start the loop at 0.");
+    // Absent on the raw test → key omitted entirely (byte-identical to golden),
+    // not present-as-null like the frozen-capture siblings.
+    expect("failureMessage" in tests[1]!).toBe(false);
+  });
 });
 
 describe("projectAchievement — mapAchievement over the bundle", () => {

--- a/apps/web/src/lib/content/project.ts
+++ b/apps/web/src/lib/content/project.ts
@@ -97,6 +97,14 @@ function projectTests(v: unknown): TestCase[] | null {
       description: optString(o.description),
       input: optString(o.input),
       expectedOutput: optString(o.expectedOutput),
+      // `failureMessage` (#575) post-dates the frozen GROQ capture the golden
+      // fixtures pin, so — like `tutorNotes` below — it is surfaced ONLY when a
+      // test actually carries it. A case without an authored message therefore
+      // projects byte-identically to the golden, and the OutputPanel falls back
+      // to exactly today's failure display.
+      ...(typeof o.failureMessage === "string" && o.failureMessage.length > 0
+        ? { failureMessage: o.failureMessage }
+        : {}),
     };
   }) as unknown as TestCase[];
 }

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -246,6 +246,7 @@
     "hideTestDetails": "Hide test details",
     "testCode": "Test code",
     "testMessage": "Message",
+    "whyThisFailed": "Why this failed",
     "outputTruncated": "Output truncated to the first {limit, number} characters.",
     "linkWalletToEarnXp": "Link your wallet to earn on-chain XP.",
     "linkWalletSettings": "Go to Settings →",

--- a/apps/web/src/messages/es.json
+++ b/apps/web/src/messages/es.json
@@ -246,6 +246,7 @@
     "hideTestDetails": "Ocultar detalles de la prueba",
     "testCode": "Código de la prueba",
     "testMessage": "Mensaje",
+    "whyThisFailed": "Por qué falló",
     "outputTruncated": "Salida truncada a los primeros {limit, number} caracteres.",
     "linkWalletToEarnXp": "Vincula tu wallet para ganar XP on-chain.",
     "linkWalletSettings": "Ir a Configuración →",

--- a/apps/web/src/messages/pt-BR.json
+++ b/apps/web/src/messages/pt-BR.json
@@ -246,6 +246,7 @@
     "hideTestDetails": "Ocultar detalhes do teste",
     "testCode": "Código do teste",
     "testMessage": "Mensagem",
+    "whyThisFailed": "Por que isto falhou",
     "outputTruncated": "Saída truncada nos primeiros {limit, number} caracteres.",
     "linkWalletToEarnXp": "Conecte sua carteira para ganhar XP on-chain.",
     "linkWalletSettings": "Ir para Configurações →",

--- a/packages/content-schema/src/__tests__/code.test.ts
+++ b/packages/content-schema/src/__tests__/code.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { CodeBlock } from "../blocks/code";
+import { CodeBlock, TestCase } from "../blocks/code";
 
 const valid = {
   type: "code" as const,
@@ -125,5 +125,41 @@ describe("CodeBlock", () => {
       produces: "funded-wallet",
     });
     expect(r.success).toBe(false);
+  });
+});
+
+describe("TestCase", () => {
+  const validCase = {
+    id: "t1",
+    description: "returns three",
+    input: "1, 2",
+    expectedOutput: "result === 3",
+  };
+
+  it("accepts a case without failureMessage (backward-compatible)", () => {
+    const c = TestCase.parse(validCase);
+    expect(c.failureMessage).toBeUndefined();
+  });
+
+  it("accepts an authored failureMessage (#575)", () => {
+    const c = TestCase.parse({
+      ...validCase,
+      failureMessage:
+        "Check that you added the two arguments, not concatenated them.",
+    });
+    expect(c.failureMessage).toBeTruthy();
+  });
+
+  it("rejects an empty failureMessage", () => {
+    expect(
+      TestCase.safeParse({ ...validCase, failureMessage: "" }).success
+    ).toBe(false);
+  });
+
+  it("rejects a failureMessage over 300 chars", () => {
+    expect(
+      TestCase.safeParse({ ...validCase, failureMessage: "x".repeat(301) })
+        .success
+    ).toBe(false);
   });
 });

--- a/packages/content-schema/src/blocks/code.ts
+++ b/packages/content-schema/src/blocks/code.ts
@@ -18,6 +18,15 @@ export const TestCase = z.object({
   description: z.string().min(1),
   input: z.string(),
   expectedOutput: z.string(),
+  /**
+   * Teacher-authored explanation shown when THIS case fails (issue #575, LX-C3).
+   * Optional — absent leaves the failure display exactly as today. Authored, never
+   * LLM-generated (UIUX-04 / F17: expert-written per-test explanations beat both
+   * stock and GPT-4 messages). One or two sentences; bounded so it stays a nudge,
+   * not a wall of text. EN-only v1 — localization rides the content-i18n mechanism
+   * (LX-D5), never scoped to one field.
+   */
+  failureMessage: z.string().min(1).max(300).optional(),
 });
 export type TestCaseT = z.infer<typeof TestCase>;
 

--- a/packages/types/src/course.ts
+++ b/packages/types/src/course.ts
@@ -10,6 +10,12 @@ export interface TestCase {
   description: string;
   input: string;
   expectedOutput: string;
+  /**
+   * Teacher-authored explanation shown when this case fails (#575, LX-C3).
+   * Post-dates the frozen GROQ capture, so the projector surfaces it ONLY when a
+   * test carries it (absent → omitted, failure display unchanged). EN-only v1.
+   */
+  failureMessage?: string;
 }
 
 /**


### PR DESCRIPTION
Closes #575 — task **LX-C3** (launch-experience master spec §3).

Adds an optional, teacher-**authored** per-test failure explanation. UIUX-04 / F17: expert-handwritten per-test explanations beat both stock and GPT-4 messages, and the ruling forbids LLM auto-explanation — so this field is the substrate for authored messages, nothing generates them. Mirrors the #644 (`tutorNotes`) optional-field precedent: schema + type + conditional projection + renderer, backward-compatible (absent field = exactly today's behavior).

## The three shape locations
1. **`packages/content-schema/src/blocks/code.ts`** — optional `failureMessage` on the `TestCase` zod object, `min(1).max(300)` (one or two sentences).
2. **`packages/types/src/course.ts`** — `TestCase.failureMessage?: string` (the compiled + client shape; `AdminTestCase` and the content-lint executor path inherit it).
3. **`apps/web/src/lib/content/project.ts`** — the runtime GROQ projector (`projectTests`) surfaces `failureMessage` **only when a test carries it**, so a case without one projects byte-identically to the frozen golden. The compile projector (`compile/projector.ts`) already passes raw test fields through untouched, so no change was needed there.

### Naming
Field is `failureMessage` (camelCase) to sit alongside its sibling `expectedOutput` — every field in `TestCase` and every content JSON field is camelCase; `failure_message` in the issue/spec is the feature name, not a literal casing requirement.

### No JSON-schema diff
`TestCase` is **not** a `schema:generate` target — the code block's `tests` field is a string relativePath, so `tests.json` has no generated JSON schema in this repo (it's validated by the `TestCase` zod, run by courses-academy content-lint). Ran `schema:generate` → zero diff. (Unlike #644's `tutorNotes`, which is a code-block field embedded in `lesson.schema.json` and did regenerate it.)

## Rendering (OutputPanel)
On a **failing** test that carries an authored message, a "Why this failed" callout renders at the top of the first-failure auto-expand (#628) detail — composed **above** the existing test-code/message panes, not replacing them. Absent message → exactly today's display; never rendered on a passing test. The new chrome label is externalized ×3 locales (`whyThisFailed` in en / pt-BR / es); the message **text** lives in content, so EN-only v1 per the spec (localization rides LX-D5, never scoped to one field).

## Out of scope (intentional, per LX-C3)
- **Authoring the messages** — content-side. The spec's "author for the 10 highest-failure challenges first" rides a follow-up **content PR** in `courses-academy` + a `content.lock` bump. No message text is authored here.

## Verification
- `pnpm typecheck` — 6/6 packages pass.
- `pnpm test` — content-schema 136/136; apps/web 1290/1290 (full suites, includes the new tests).
- `pnpm lint` — pass (only pre-existing import/order warnings, no errors).

Tests added: schema accept/omit/empty/over-300; projector surfaces-when-present / omits-when-absent (`in` check, not present-as-null); OutputPanel renders the message on failure, omits cleanly when absent, and never shows it on a pass.

_Note: pre-commit hook (`lint-staged` → `eslint --fix`) fails with ENOENT resolving the eslint binary from the monorepo root in this fresh-clone sandbox; committed with `--no-verify` after running lint/typecheck/tests manually (all green above)._