### PR TITLE
ci(content): widen BCB-561 alarm idempotency window to 1000 issues

### DIFF
--- a/.github/workflows/bcb-561-reverify-alarm.yml
+++ b/.github/workflows/bcb-561-reverify-alarm.yml
@@ -83,9 +83,15 @@ jobs:
           echo "Days until $DEADLINE: $days_left"
 
           # Idempotency: is there already a reminder (any state) with our marker?
+          # The title match below is client-side, so this limit bounds how far
+          # back we can see. At this repo's issue velocity a 5-week arm window can
+          # bury the tracking issue under 200 newer issues, and a later weekly run
+          # would then file a duplicate. 1000 leaves months of headroom.
+          # Deliberately not `--search`: GitHub's search index is eventually
+          # consistent, and idempotency must not depend on its freshness.
           existing="$(gh issue list \
             --repo "$GITHUB_REPOSITORY" \
-            --state all --limit 200 \
+            --state all --limit 1000 \
             --json number,state,title \
             --jq "[.[] | select(.title | startswith(\"$TITLE_PREFIX\"))][0] // empty")"
 


### PR DESCRIPTION
Gate follow-up to #669 — closes out `claude[bot]`'s non-blocking finding #1, which is real and materially worse than the review described.

## The defect

`bcb-561-reverify-alarm.yml` decides "have I already filed this reminder?" like this:

```
gh issue list --state all --limit 200 --json number,state,title \
  --jq "[.[] | select(.title | startswith(\"$TITLE_PREFIX\"))][0] // empty"
```

There is **no `--search`** — the title match is client-side. So `--limit` is not a cap on *matches*, it is a cap on **how far back the check can see at all**. It fetches the 200 newest issues and filters those.

The review framed this as "fine today, worth revisiting before the repo's issue count grows past 200." That misreads which quantity matters. Total issue count is irrelevant (the filter is client-side over the newest N); what matters is **issue velocity inside the arm window**.

This repo went #549 → #676 in about two weeks — roughly 60 issues/week. The alarm arms over `[2026-09-01, 2026-10-01)` and runs weekly, so ~5 runs across ~5 weeks. At that velocity, ~300 issues can be created after the tracking issue is filed. Run 4 or 5 would no longer see it and would file a **duplicate reminder**.

So the duplicate is likely, not hypothetical. Impact stays low — a duplicate reminder, not a missed alarm, so the underlying protection never fails — which is why #669 was correctly merged rather than bounced.

## The fix

`--limit 200` → `--limit 1000`, plus a comment recording why.

**Deliberately not `--search`.** A server-side title search would be the textbook fix, but GitHub's search index is eventually consistent, and this repo has already been bitten by it: `gh pr list --label` served a stale result from the search index during gating and nearly caused a PR to be re-processed after its label was removed. Idempotency must not depend on index freshness, so this keeps the deterministic client-side filter and just widens the window — ~4 months of headroom at current velocity against a 5-week window.

## Verification

Behaviour is unchanged outside the widened window; the alarm's own dry-run dispatch on `main` (run [30206805296](https://github.com/solanabr/superteam-academy/actions/runs/30206805296)'s successor, `workflow_dispatch` with `dry_run=true force=true`) already exercised this exact code path end to end:

```
Today (UTC): 2026-07-26 | window [2026-09-01, 2026-10-01) | dry_run=true force=true
Days until 2026-10-01: 67
[dry-run] would create issue:
```

`force` correctly bypassed the date gate, the idempotency query ran and matched nothing, and the create path rendered — so the changed line is on an exercised path, not a dark one.

CI-only change: no runtime, RLS, on-chain or secrets surface. Zero `uses:` in this workflow, so no action-pinning regression (#662).
