### PR TITLE
ci: run the frontend job for packages-only changes (tests were silently skipped)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,13 @@ jobs:
           filters: |
             frontend:
               - 'apps/web/**'
+              # The `Unit tests` step runs `pnpm -r test`, which covers
+              # content-schema and content-lint (that was the #374 fix). Without
+              # `packages/**` here the whole job is skipped for a packages-only
+              # PR, so those suites never run on precisely the changes they
+              # exist to guard — #638 shipped two new test files with zero CI
+              # coverage. Keep this in sync with what `pnpm -r` reaches.
+              - 'packages/**'
               - 'package.json'
               - 'pnpm-lock.yaml'
               - 'pnpm-workspace.yaml'


### PR DESCRIPTION
Found while gating #638. **Any PR that touches only `packages/**` runs zero tests in CI.**

## The hole

`ci.yml`'s `changes` job defines the `frontend` filter as:

```yaml
frontend:
  - 'apps/web/**'
  - 'package.json'
  - 'pnpm-lock.yaml'
  - 'pnpm-workspace.yaml'
  - 'tsconfig*.json'
  - '.github/workflows/ci.yml'
```

No filter in the file mentions `packages/**`. The `frontend` job is gated on `needs.changes.outputs.frontend == 'true'`, so a packages-only PR skips it — and with it Lint, Typecheck and Unit tests.

The irony is that the runner was already fixed for this. The `Unit tests` step says so in its own comment:

> `pnpm -r test` runs the `test` script of EVERY workspace package that defines one — @superteam-lms/web, content-schema, and content-lint — so all vitest suites gate CI. The old web-only `--filter` silently skipped content-schema (93 tests) and content-lint (32) (fixes #374).

So #374 fixed *which suites the runner reaches*, but the path filter still decides whether the runner is reached at all. For a packages-only PR the answer is no, which makes #374's fix inert for exactly the changes it was meant to cover.

## Observed impact

**#638** (`feat(content-lint): gate 19 …`) changed only `packages/content-lint/**` and `packages/content-schema/**`. Its full check list on head `315d50a7`:

```
Detect changes                        pass
Lighthouse (report-only)              pass
Vercel Preview Comments               pass
Frontend (lint · typecheck · test)    skipping     <-- the one that runs the tests
Build server / On-chain / Integration / Dependency audit / Verifiable build   skipping
```

It added `gate19.test.ts` and `skills.test.ts` and **neither ever executed in CI**. I ran them by hand while gating (193 tests pass: 59 content-lint + 134 content-schema), which is why #638 was still mergeable — but that was a manual step standing in for a gate, and the next packages-only PR won't get one.

Affects `content-lint`, `content-schema`, `types`, and `challenge-executor` equally.

## The fix

Add `packages/**` to the `frontend` filter, with a comment tying it to what `pnpm -r` reaches so the two don't drift apart again.

Verification is self-demonstrating: this PR touches only `.github/workflows/ci.yml`, which is already in the filter, so the frontend job runs here and you can see the suites execute. The real proof is the next packages-only PR — it will no longer come back with `Frontend … skipping`.
