### PR TITLE
content: activate launch catalog — zero-to-deployed + C5 + defi hold

### DIFF
--- a/apps/web/content.lock
+++ b/apps/web/content.lock
@@ -1,4 +1,4 @@
 {
   "repo": "solanabr/courses-academy",
-  "sha": "bccd92fc4ff90c30f014e452de744d702a0413d6"
+  "sha": "012cd03ddcaa1122283a742862d5c5b885a7a913"
 }

--- a/apps/web/src/content/generated/achievements.json
+++ b/apps/web/src/content/generated/achievements.json
@@ -105,7 +105,7 @@
     "_type": "achievement",
     "award": {
       "kind": "path-completed",
-      "path": "path-solana-core"
+      "path": "path-zero-to-deployed"
     },
     "category": "skills",
     "description": "Complete all courses in the Solana Developer Path",

--- a/apps/web/src/content/generated/courses.json
+++ b/apps/web/src/content/generated/courses.json
@@ -801,5 +801,129 @@
     "trackLevel": 1,
     "xpPerLesson": 10,
     "xpReward": 600
+  },
+  {
+    "_id": "course-stablecoin-payments",
+    "_type": "course",
+    "creator": "B7o8NfV81HzjuZFWQTTx3Xdvh77Dqoajwib3kWEnvzJF",
+    "creatorRewardXp": 30,
+    "description": "You have a deployed vault app that earns nothing. Put a price on it. Open a Subscription Authority and a Recurring Delegation so the app has a real paid tier, meter a route with an x402 v2 challenge, and give an autonomous agent a wallet that can say no — an on-chain spend cap instead of an unlimited keypair. TypeScript only, no Rust and no local toolchain. You finish by publishing a version-pinned deep dive and submitting one live Superteam Earn listing. Scope is what BCB Resolution 561 leaves open to Brazilian builders from 2026-10-01, domestic merchant acceptance, contractor payouts, subscriptions and agent budgets.",
+    "difficulty": "intermediate",
+    "duration": 10,
+    "minCompletionsForReward": 10,
+    "modules": [
+      {
+        "_key": "sap-paid-tier",
+        "_type": "courseModule",
+        "description": "Pick the rail your requirement actually needs, decide between Token and Token-2022 for the payment mint, then open a Subscription Authority and a Recurring Delegation on devnet. You end holding a delegation PDA and a settlement signature for a charge that correctly refuses to run a second time inside the same period.",
+        "key": "sap-paid-tier",
+        "lessons": [
+          {
+            "_key": "lesson-sap-payment-rails-decision-map",
+            "_ref": "lesson-sap-payment-rails-decision-map",
+            "_type": "reference",
+            "_weak": true
+          },
+          {
+            "_key": "lesson-sap-token-or-token-2022",
+            "_ref": "lesson-sap-token-or-token-2022",
+            "_type": "reference",
+            "_weak": true
+          },
+          {
+            "_key": "lesson-sap-subscription-authority-and-allowance",
+            "_ref": "lesson-sap-subscription-authority-and-allowance",
+            "_type": "reference",
+            "_weak": true
+          },
+          {
+            "_key": "lesson-sap-recurring-delegation-paid-tier",
+            "_ref": "lesson-sap-recurring-delegation-paid-tier",
+            "_type": "reference",
+            "_weak": true
+          }
+        ],
+        "title": "The Paid Tier"
+      },
+      {
+        "_key": "sap-metered-agentic",
+        "_type": "courseModule",
+        "description": "Price one route so it returns a real 402 challenge, read a challenge and pay it programmatically across both live protocol versions, then wire a call loop that spends only from a Fixed Delegation and halts cleanly when the allowance refuses the next payment.",
+        "key": "sap-metered-agentic",
+        "lessons": [
+          {
+            "_key": "lesson-sap-meter-an-endpoint-with-x402",
+            "_ref": "lesson-sap-meter-an-endpoint-with-x402",
+            "_type": "reference",
+            "_weak": true
+          },
+          {
+            "_key": "lesson-sap-pay-the-402-programmatically",
+            "_ref": "lesson-sap-pay-the-402-programmatically",
+            "_type": "reference",
+            "_weak": true
+          },
+          {
+            "_key": "lesson-sap-budgeted-agent-with-a-hard-cap",
+            "_ref": "lesson-sap-budgeted-agent-with-a-hard-cap",
+            "_type": "reference",
+            "_weak": true
+          }
+        ],
+        "title": "Metered & Agentic"
+      },
+      {
+        "_key": "sap-get-paid",
+        "_type": "courseModule",
+        "description": "Publish a technical deep dive in the shape Superteam chapters pay for — dated, version-pinned, reproducible — then submit one live Earn listing and name every layer of the artifact you built, from your first signed transaction to a metered endpoint an agent pays for.",
+        "key": "sap-get-paid",
+        "lessons": [
+          {
+            "_key": "lesson-sap-write-the-deep-dive",
+            "_ref": "lesson-sap-write-the-deep-dive",
+            "_type": "reference",
+            "_weak": true
+          },
+          {
+            "_key": "lesson-sap-submit-and-what-you-built",
+            "_ref": "lesson-sap-submit-and-what-you-built",
+            "_type": "reference",
+            "_weak": true
+          }
+        ],
+        "title": "Get Paid"
+      }
+    ],
+    "slug": {
+      "_type": "slug",
+      "current": "stablecoin-agentic-payments"
+    },
+    "tags": [
+      "agent-budgets",
+      "api-monetization",
+      "brazil-compliance",
+      "earn-submission",
+      "error-handling",
+      "fixed-delegation",
+      "payment-model-selection",
+      "pdas",
+      "protocol-versioning",
+      "recurring-delegation",
+      "solana-kit",
+      "solana-pay",
+      "spl-tokens",
+      "subscription-authority",
+      "subscriptions-program",
+      "technical-writing",
+      "token-2022",
+      "transfer-hook",
+      "version-pinning",
+      "x402-protocol"
+    ],
+    "title": "Getting Paid: Stablecoin & Agentic Payments",
+    "trackId": 1,
+    "trackLevel": 5,
+    "xpPerLesson": 25,
+    "xpReward": 750
   }
 ]

--- a/apps/web/src/content/generated/lessons.json
+++ b/apps/web/src/content/generated/lessons.json
@@ -794,7 +794,7 @@
       {
         "_key": "intro",
         "_type": "prose",
-        "src": "# What You've Built\n\nCongratulations! You've completed the full Solana developer lifecycle:\n\n## Your Journey\n\n1. **Write Code** — You wrote a counter program in Rust using the Anchor framework\n2. **Compile** — The Superteam Academy Build Server compiled it to a Solana program binary\n3. **Deploy** — You deployed it to Solana Devnet using the BPF Loader Upgradeable\n4. **Interact** — You called instructions and watched on-chain state change in real time\n\n## What You Learned\n\n### Anchor Framework\n- `#[program]` — defines your instruction handlers\n- `#[derive(Accounts)]` — specifies account constraints\n- `#[account]` — defines on-chain data structures\n- `#[error_code]` — custom errors enforced by the runtime\n\n### On-Chain Concepts\n- **Accounts** are Solana's storage primitive (not key-value pairs)\n- **Discriminators** identify account types (first 8 bytes)\n- **Rent** prevents spam (accounts must maintain minimum balance)\n- **Transactions** are batches of instructions signed by wallets\n\n### Deployment Protocol\n- Programs are uploaded in **~1000-byte chunks** via the BPF Loader\n- A **buffer account** holds the binary during upload\n- The **program account** is a pointer to the executable data\n- Upgradeable programs can be updated by the upgrade authority\n\n## What's Next?\n\n- **DeFi on Solana** — Build a token vault with PDAs and CPIs\n- **Anchor Framework Mastery** — Deep dive into testing, PDAs, and CPIs\n- **Install locally** — Set up Anchor CLI on your machine for faster iteration\n\nYour deployed program will continue to live on Devnet. You can interact with it anytime using the Solana CLI or any Anchor client.\n"
+        "src": "# What You've Built\n\nCongratulations! You've completed the full Solana developer lifecycle:\n\n## Your Journey\n\n1. **Write Code** — You wrote a counter program in Rust using the Anchor framework\n2. **Compile** — The Superteam Academy Build Server compiled it to a Solana program binary\n3. **Deploy** — You deployed it to Solana Devnet using the BPF Loader Upgradeable\n4. **Interact** — You called instructions and watched on-chain state change in real time\n\n## What You Learned\n\n### Anchor Framework\n- `#[program]` — defines your instruction handlers\n- `#[derive(Accounts)]` — specifies account constraints\n- `#[account]` — defines on-chain data structures\n- `#[error_code]` — custom errors enforced by the runtime\n\n### On-Chain Concepts\n- **Accounts** are Solana's storage primitive (not key-value pairs)\n- **Discriminators** identify account types (first 8 bytes)\n- **Rent** prevents spam (accounts must maintain minimum balance)\n- **Transactions** are batches of instructions signed by wallets\n\n### Deployment Protocol\n- Programs are uploaded in **~1000-byte chunks** via the BPF Loader\n- A **buffer account** holds the binary during upload\n- The **program account** is a pointer to the executable data\n- Upgradeable programs can be updated by the upgrade authority\n\n## Ship It: Your First Paid Solana Work\n\nYou now have something most applicants don't: a program you wrote, compiled, and deployed yourself, live on a public network. The next step isn't another course — it's putting that skill in front of teams that pay for it.\n\n**Superteam Earn** lists bounties and projects from real Solana teams, judged on submissions, not resumes. This is where deployed-a-program skills convert into your first $500–$5,000 of paid Solana work:\n\n1. **Browse open development work** — start with the [development bounties on Superteam Earn](https://superteam.fun/earn/category/development/). Look for small, scoped bounties with a defined deliverable: they are the fastest way to a first paid submission.\n2. **Write about what you built** — [content bounties](https://superteam.fun/earn/category/content/) pay for technical writing. A walkthrough of the counter program you just deployed — what confused you, and how you worked through it — is exactly the material sponsors ask for.\n3. **Have a bigger idea? Apply for a grant** — [Superteam grants](https://superteam.fun/earn/grants/) fund builders directly (avg $5.5k Brazil grants). A live Devnet program is the strongest artifact a first grant application can include.\n\nWhatever you submit, link your deployed program. It is live on a public network — anyone can verify it, and that proof is worth more than any certificate screenshot.\n\n## Keep Building\n\n- **Install locally** — Set up the Anchor CLI on your machine for faster iteration\n- **Solana Frontend Development** — Put a UI on your program: wallet integration, reading on-chain state, sending transactions from the browser\n\nYour deployed program will continue to live on Devnet. You can interact with it anytime using the Solana CLI or any Anchor client.\n"
       },
       {
         "_key": "deployed",
@@ -2077,6 +2077,2364 @@
       "current": "rust-program-challenge"
     },
     "title": "Challenge: Process Transfer Instruction"
+  },
+  {
+    "_id": "lesson-sap-budgeted-agent-with-a-hard-cap",
+    "_type": "lesson",
+    "blocks": [
+      {
+        "_key": "intro",
+        "_type": "prose",
+        "src": "# An Agent With a Wallet That Can Say No\n\n> **Version stamp — checked 2026-07-25.** `@solana/subscriptions` **0.4.0 exactly** (the `beta` tag is `0.4.0-rc.2`; this package is pre-1.0 and moving). `@solana/kit` **7.0.0**. `@x402/core`, `@x402/svm`, `@x402/fetch` **2.19.0**.\n\nHere is the scope fence, up front, so you know what this lesson is not.\n\n**No agent framework.** No SendAI Solana Agent Kit, no ElizaOS, no LangChain, no Vercel AI SDK. The \"agent\" in this lesson is a `for` loop. Every one of those frameworks will be a different set of names in eighteen months, and none of them solves the problem that actually matters here.\n\nThe problem that matters is this: **an autonomous process needs money, and giving a process money is giving it the ability to lose all of it.** The standard answer is to fund a hot keypair and hope. That is not a budget. That is a blast radius.\n\nYou already built the alternative. In lesson 3 you opened a **Fixed Delegation** — a program-enforced allowance with a capped total, drawn down by `transferFixed`. That is the agent's wallet. Not a keypair holding funds: an authorisation, on the user's account, that the program refuses to exceed.\n\nThe difference is where the limit lives. A limit in your code is a limit an attacker edits out. A limit in a program-owned account is a limit that survives your code being wrong, your key being stolen, and your loop running a hundred times more than you meant it to. That is why Allowances are documented as the budget primitive for agents, and it is the whole reason this course ends here rather than with a model integration.\n\n---\n\n## The loop\n\n```\nbudget = the Fixed Delegation from lesson 3   (remaining_amount, base units, u64)\n\nfor each task step, up to maxCalls:\n    if remaining < price:  HALT — budget exhausted\n    call the metered endpoint from lesson 5, through the wrapped fetch from lesson 6\n    settle the 402 by drawing `price` from the delegation with transferFixed\n    if the program refuses:  HALT — refused, record the code\n    remaining -= price\nreport: calls, spent, remaining, signatures, why it stopped\n```\n\nThree exits. Only one of them is success. **The exit conditions are the learning objective, not error handling bolted on at the end** — which is why today's exercise grades the decision logic and not the happy path.\n\n### Exit 1 — budget exhausted (you decide)\n\nBefore every call, compare `remaining` against the price. If you cannot afford it, stop. Do not build the transaction and let the chain tell you.\n\nA transaction that reaches execution and fails still pays a fee. Sending one you already know will be refused buys you nothing but a worse report: you learn \"the program refused\" when you could have known \"the budget ran out\" — different facts, different alerts, different fixes.\n\n### Exit 2 — refused (the program decides)\n\nA refusal from the delegation program is **terminal**. Do not retry it.\n\nBackoff exists for transient failures — congestion, an expired blockhash, a flaky RPC. A policy refusal is not transient. The allowance is state on-chain; waiting does not change it. Retrying asks the same program the same question and gets the same answer, one fee poorer, three times over.\n\nRecord the code the program returned, **verbatim**, and stop. Do not pattern-match on the string to decide whether to continue — your loop halts on any refusal, and the code is diagnostic output for a human, not a control-flow input. The one code worth recognising on sight is `AMOUNT_EXCEEDS_PERIOD_LIMIT` from lesson 4, and even that one is a halt: it means a recurring cap has not rolled over yet.\n\n### Exit 3 — completed\n\nThe task finished inside its budget. `halted: false`. This is the boring one, and it should be.\n\n---\n\n## Base units are u64\n\n`remaining_amount` and every price in this system is a `u64` count of base units. `Number.MAX_SAFE_INTEGER` is 2^53 − 1. A u64 goes to 2^64 − 1.\n\nConvert once with `BigInt(...)`, do the arithmetic in `BigInt`, return decimal strings. One of the scenarios in the exercise spends a u64-sized allowance to exactly zero — it comes out right in BigInt and comes out wrong, silently, in `Number`. Silently is the part that should worry you: there is no exception, just a balance that is off by a bit you will find in production.\n\n---\n\n## What the exercise grades\n\n`runAgentLoop(scenarioId)` gets an allowance, a price, a call budget and a list of settlement responses, and returns a report. The network round trips are captured; what you write is the spend / halt / report logic.\n\nTwo of the scenarios are traps, and both are traps that real loops fall into:\n\n- **`s-exhausted`** supplies five successful settlements for a task the allowance can only fund twice. A loop that settles first and checks the budget afterwards reports three calls and a negative balance.\n- **`s-refused`** puts a *successful* settlement immediately after the refusal. A loop that logs the refusal and continues will find it, count it, and report a spend that never happened.\n\nNeither trap produces an exception. Both produce a confident, wrong report. That is what makes them worth grading.\n\n---\n\n## Where this goes next\n\n`@x402/mcp` (2.19.0) puts the same payment loop behind the Model Context Protocol, so a tool an assistant calls can charge for itself and the assistant pays out of exactly this kind of capped allowance. Same primitive, one layer up. Worth an afternoon after this course.\n\n**A note on the bounty market, since you will be tempted.** Agent bounties on Superteam Earn are the worst odds on the platform — roughly $53 per competitor, with a median around 91 submissions. Payments listings and technical deep dives pay far better per unit of effort. What you learned here is the **budget primitive**, which is a component of things people actually pay for. Lesson 8 points you at the listings where that is true.\n\n## Milestone\n\nYou need three things from this module for lesson 8, so collect them now:\n\n1. **The URL of your metered endpoint** — the live one from lesson 5, running in your course-4 app.\n2. **The settlement signatures** your agent produced — at least one, from a real devnet draw against your Fixed Delegation.\n3. **The delegation address**, and the `remaining_amount` before and after.\n\nThat set is the proof. Anyone can describe an agent with a budget; you can show the transactions where one hit its cap and stopped.\n"
+      },
+      {
+        "_key": "exercise",
+        "_type": "code",
+        "buildType": "standard",
+        "deployable": false,
+        "hints": [
+          "Three ways out of the loop, and each one returns a different `reason`. Write all three before you write the happy path.",
+          "The budget check comes before the settlement, not after: if you cannot afford the call, you never attempt it and never consume a settlement.",
+          "Convert once with `BigInt(...)`, do the arithmetic in BigInt, and call `.toString()` on the way out.",
+          "`s-refused` has a successful settlement after the refusal. If your report counts three calls, your loop kept going."
+        ],
+        "language": "typescript",
+        "solution": "// ---------------------------------------------------------------------------\n// REFERENCE SOLUTION — the agent's call loop.\n//\n// Pinned 2026-07-25: @solana/subscriptions 0.4.0 (exactly), @solana/kit 7.0.0,\n// @x402/{core,svm,fetch} 2.19.0.\n//\n// In your own project each iteration is: call the metered endpoint through the\n// wrapped fetch from lesson 6, and settle the 402 with a `transferFixed` draw\n// against the Fixed Delegation you opened in lesson 3. Here the network round\n// trips are already captured — what you implement is the part that is actually\n// yours: the spend / halt / report decision logic.\n// ---------------------------------------------------------------------------\n\n/** One settlement attempt as the delegation program answered it. */\ninterface Settlement {\n  ok: boolean;\n  /** Present when ok. */\n  signature?: string;\n  /** Present when not ok. The program's error, verbatim. */\n  error?: { code: string };\n}\n\ninterface Scenario {\n  /** `remaining_amount` on the Fixed Delegation. Base units, decimal string. */\n  remainingBaseUnits: string;\n  /** What one call costs. Base units, decimal string. */\n  pricePerCall: string;\n  /** The agent's task: at most this many calls. */\n  maxCalls: number;\n  /** Settlement responses, consumed in order — one per call actually attempted. */\n  settlements: Settlement[];\n}\n\ninterface AgentReport {\n  /** Calls that completed AND settled. */\n  calls: number;\n  /** Total drawn from the delegation. Base units, decimal string. */\n  spent: string;\n  /** What is left on the delegation. Base units, decimal string. */\n  remaining: string;\n  /** Settlement signatures, in order, one per successful call. */\n  signatures: string[];\n  /** True when the loop stopped before finishing its task. */\n  halted: boolean;\n  reason: \"completed\" | \"budget-exhausted\" | \"refused\";\n  /** The program's error code when reason is \"refused\", otherwise null. */\n  errorCode: string | null;\n}\n\nconst SCENARIOS: Record<string, Scenario> = {\n  // Budget comfortably covers the task.\n  \"s-completed\": {\n    remainingBaseUnits: \"1000000\",\n    pricePerCall: \"10000\",\n    maxCalls: 3,\n    settlements: [\n      { ok: true, signature: \"sig-c1\" },\n      { ok: true, signature: \"sig-c2\" },\n      { ok: true, signature: \"sig-c3\" },\n    ],\n  },\n\n  // The task needs 5 calls. The allowance covers 2 and a half.\n  // Note that the fixtures would happily settle all five.\n  \"s-exhausted\": {\n    remainingBaseUnits: \"25000\",\n    pricePerCall: \"10000\",\n    maxCalls: 5,\n    settlements: [\n      { ok: true, signature: \"sig-e1\" },\n      { ok: true, signature: \"sig-e2\" },\n      { ok: true, signature: \"sig-e3\" },\n      { ok: true, signature: \"sig-e4\" },\n      { ok: true, signature: \"sig-e5\" },\n    ],\n  },\n\n  // The program refuses the third draw. The fourth response is a success —\n  // it is there to catch a loop that keeps going after a refusal.\n  \"s-refused\": {\n    remainingBaseUnits: \"1000000\",\n    pricePerCall: \"250000\",\n    maxCalls: 4,\n    settlements: [\n      { ok: true, signature: \"sig-r1\" },\n      { ok: true, signature: \"sig-r2\" },\n      { ok: false, error: { code: \"AmountExceedsTotalLimit\" } },\n      { ok: true, signature: \"sig-r4\" },\n    ],\n  },\n\n  // Nothing left at all.\n  \"s-broke\": {\n    remainingBaseUnits: \"0\",\n    pricePerCall: \"10000\",\n    maxCalls: 2,\n    settlements: [{ ok: true, signature: \"sig-b1\" }],\n  },\n\n  // A u64-sized allowance spent to exactly zero. Base units are u64; Number\n  // stops being exact above 2^53, so this one only comes out right if the\n  // arithmetic never becomes a Number.\n  \"s-precision\": {\n    remainingBaseUnits: \"18446744073709551615\",\n    pricePerCall: \"6148914691236517205\",\n    maxCalls: 3,\n    settlements: [\n      { ok: true, signature: \"sig-p1\" },\n      { ok: true, signature: \"sig-p2\" },\n      { ok: true, signature: \"sig-p3\" },\n    ],\n  },\n};\n\n/**\n * Run the agent's call loop against a scenario and report what happened.\n *\n * SPEC — the loop performs at most `maxCalls` calls, and before each one:\n *\n *   1. If `remaining` is less than `pricePerCall`, STOP. Do not attempt the\n *      call and do not consume a settlement. Report halted: true, reason\n *      \"budget-exhausted\", errorCode null. A transaction you already know the\n *      program will refuse still costs you a fee.\n *   2. Otherwise consume the next settlement, in order.\n *      - ok: count the call, add the price to `spent`, subtract it from\n *        `remaining`, append the signature, continue.\n *      - not ok: STOP IMMEDIATELY. Do not retry, do not skip it, do not touch\n *        `spent` or `remaining`. Report halted: true, reason \"refused\", and\n *        errorCode set to the program's code verbatim.\n *   3. If all `maxCalls` calls settle, report halted: false, reason\n *      \"completed\", errorCode null.\n *\n * ACCEPTANCE CRITERIA\n *   - `spent`, `remaining` and `pricePerCall` are base units. Do the arithmetic\n *     in BigInt and return decimal strings. A u64 allowance does not survive\n *     Number.\n *   - `signatures.length` always equals `calls`.\n *   - `errorCode` is non-null only when reason is \"refused\", and it is the code\n *     the program returned — never a string you invented.\n *   - The function returns a report in every case. It never throws.\n */\nfunction runAgentLoop(scenarioId: string): AgentReport {\n  const scenario = SCENARIOS[scenarioId];\n\n  const price = BigInt(scenario.pricePerCall);\n  let remaining = BigInt(scenario.remainingBaseUnits);\n  let spent = BigInt(0);\n  let calls = 0;\n  const signatures: string[] = [];\n\n  for (let i = 0; i < scenario.maxCalls; i++) {\n    // The cap is on-chain, so the loop checks it BEFORE spending a fee to be\n    // told what it could already work out for itself.\n    if (remaining < price) {\n      return {\n        calls,\n        spent: spent.toString(),\n        remaining: remaining.toString(),\n        signatures,\n        halted: true,\n        reason: \"budget-exhausted\",\n        errorCode: null,\n      };\n    }\n\n    const settlement = scenario.settlements[i];\n\n    // A refusal is terminal. Retrying it asks the same program the same\n    // question and gets the same answer, one fee poorer.\n    if (!settlement || !settlement.ok) {\n      const code =\n        settlement && settlement.error ? settlement.error.code : \"NoSettlementResponse\";\n      return {\n        calls,\n        spent: spent.toString(),\n        remaining: remaining.toString(),\n        signatures,\n        halted: true,\n        reason: \"refused\",\n        errorCode: code,\n      };\n    }\n\n    calls += 1;\n    spent += price;\n    remaining -= price;\n    signatures.push(settlement.signature as string);\n  }\n\n  return {\n    calls,\n    spent: spent.toString(),\n    remaining: remaining.toString(),\n    signatures,\n    halted: false,\n    reason: \"completed\",\n    errorCode: null,\n  };\n}\n",
+        "starter": "// ---------------------------------------------------------------------------\n// The agent's call loop. You write this one.\n//\n// Pinned 2026-07-25: @solana/subscriptions 0.4.0 (exactly), @solana/kit 7.0.0,\n// @x402/{core,svm,fetch} 2.19.0.\n//\n// In your own project each iteration is: call the metered endpoint through the\n// wrapped fetch from lesson 6, and settle the 402 with a `transferFixed` draw\n// against the Fixed Delegation you opened in lesson 3. Here the network round\n// trips are already captured — what you implement is the part that is actually\n// yours: the spend / halt / report decision logic.\n// ---------------------------------------------------------------------------\n\n/** One settlement attempt as the delegation program answered it. */\ninterface Settlement {\n  ok: boolean;\n  /** Present when ok. */\n  signature?: string;\n  /** Present when not ok. The program's error, verbatim. */\n  error?: { code: string };\n}\n\ninterface Scenario {\n  /** `remaining_amount` on the Fixed Delegation. Base units, decimal string. */\n  remainingBaseUnits: string;\n  /** What one call costs. Base units, decimal string. */\n  pricePerCall: string;\n  /** The agent's task: at most this many calls. */\n  maxCalls: number;\n  /** Settlement responses, consumed in order — one per call actually attempted. */\n  settlements: Settlement[];\n}\n\ninterface AgentReport {\n  /** Calls that completed AND settled. */\n  calls: number;\n  /** Total drawn from the delegation. Base units, decimal string. */\n  spent: string;\n  /** What is left on the delegation. Base units, decimal string. */\n  remaining: string;\n  /** Settlement signatures, in order, one per successful call. */\n  signatures: string[];\n  /** True when the loop stopped before finishing its task. */\n  halted: boolean;\n  reason: \"completed\" | \"budget-exhausted\" | \"refused\";\n  /** The program's error code when reason is \"refused\", otherwise null. */\n  errorCode: string | null;\n}\n\nconst SCENARIOS: Record<string, Scenario> = {\n  // Budget comfortably covers the task.\n  \"s-completed\": {\n    remainingBaseUnits: \"1000000\",\n    pricePerCall: \"10000\",\n    maxCalls: 3,\n    settlements: [\n      { ok: true, signature: \"sig-c1\" },\n      { ok: true, signature: \"sig-c2\" },\n      { ok: true, signature: \"sig-c3\" },\n    ],\n  },\n\n  // The task needs 5 calls. The allowance covers 2 and a half.\n  // Note that the fixtures would happily settle all five.\n  \"s-exhausted\": {\n    remainingBaseUnits: \"25000\",\n    pricePerCall: \"10000\",\n    maxCalls: 5,\n    settlements: [\n      { ok: true, signature: \"sig-e1\" },\n      { ok: true, signature: \"sig-e2\" },\n      { ok: true, signature: \"sig-e3\" },\n      { ok: true, signature: \"sig-e4\" },\n      { ok: true, signature: \"sig-e5\" },\n    ],\n  },\n\n  // The program refuses the third draw. The fourth response is a success —\n  // it is there to catch a loop that keeps going after a refusal.\n  \"s-refused\": {\n    remainingBaseUnits: \"1000000\",\n    pricePerCall: \"250000\",\n    maxCalls: 4,\n    settlements: [\n      { ok: true, signature: \"sig-r1\" },\n      { ok: true, signature: \"sig-r2\" },\n      { ok: false, error: { code: \"AmountExceedsTotalLimit\" } },\n      { ok: true, signature: \"sig-r4\" },\n    ],\n  },\n\n  // Nothing left at all.\n  \"s-broke\": {\n    remainingBaseUnits: \"0\",\n    pricePerCall: \"10000\",\n    maxCalls: 2,\n    settlements: [{ ok: true, signature: \"sig-b1\" }],\n  },\n\n  // A u64-sized allowance spent to exactly zero. Base units are u64; Number\n  // stops being exact above 2^53, so this one only comes out right if the\n  // arithmetic never becomes a Number.\n  \"s-precision\": {\n    remainingBaseUnits: \"18446744073709551615\",\n    pricePerCall: \"6148914691236517205\",\n    maxCalls: 3,\n    settlements: [\n      { ok: true, signature: \"sig-p1\" },\n      { ok: true, signature: \"sig-p2\" },\n      { ok: true, signature: \"sig-p3\" },\n    ],\n  },\n};\n\n/**\n * Run the agent's call loop against a scenario and report what happened.\n *\n * SPEC — the loop performs at most `maxCalls` calls, and before each one:\n *\n *   1. If `remaining` is less than `pricePerCall`, STOP. Do not attempt the\n *      call and do not consume a settlement. Report halted: true, reason\n *      \"budget-exhausted\", errorCode null. A transaction you already know the\n *      program will refuse still costs you a fee.\n *   2. Otherwise consume the next settlement, in order.\n *      - ok: count the call, add the price to `spent`, subtract it from\n *        `remaining`, append the signature, continue.\n *      - not ok: STOP IMMEDIATELY. Do not retry, do not skip it, do not touch\n *        `spent` or `remaining`. Report halted: true, reason \"refused\", and\n *        errorCode set to the program's code verbatim.\n *   3. If all `maxCalls` calls settle, report halted: false, reason\n *      \"completed\", errorCode null.\n *\n * ACCEPTANCE CRITERIA\n *   - `spent`, `remaining` and `pricePerCall` are base units. Do the arithmetic\n *     in BigInt and return decimal strings. A u64 allowance does not survive\n *     Number.\n *   - `signatures.length` always equals `calls`.\n *   - `errorCode` is non-null only when reason is \"refused\", and it is the code\n *     the program returned — never a string you invented.\n *   - The function returns a report in every case. It never throws.\n */\nfunction runAgentLoop(scenarioId: string): AgentReport {\n  const scenario = SCENARIOS[scenarioId];\n\n  // Your code here.\n\n  return {\n    calls: 0,\n    spent: \"0\",\n    remaining: scenario.remainingBaseUnits,\n    signatures: [],\n    halted: false,\n    reason: \"completed\",\n    errorCode: null,\n  };\n}\n",
+        "tests": [
+          {
+            "description": "Budget covers the task: every call settles and the loop reports completed",
+            "expectedOutput": "result.calls === 3 && result.spent === '30000' && result.remaining === '970000' && result.halted === false && result.reason === 'completed' && result.errorCode === null",
+            "id": "t1",
+            "input": "'s-completed'"
+          },
+          {
+            "description": "One signature per settled call, in order",
+            "expectedOutput": "result.signatures.length === result.calls && result.signatures[0] === 'sig-c1' && result.signatures[2] === 'sig-c3'",
+            "id": "t2",
+            "input": "'s-completed'"
+          },
+          {
+            "description": "Allowance runs out mid-task: the loop halts before attempting the call it cannot afford",
+            "expectedOutput": "result.calls === 2 && result.spent === '20000' && result.remaining === '5000' && result.halted === true && result.reason === 'budget-exhausted' && result.errorCode === null",
+            "id": "t3",
+            "input": "'s-exhausted'"
+          },
+          {
+            "description": "The program refuses a draw: the loop stops there, records the code, and does not consume the later successful settlement",
+            "expectedOutput": "result.calls === 2 && result.spent === '500000' && result.remaining === '500000' && result.halted === true && result.reason === 'refused' && result.errorCode === 'AmountExceedsTotalLimit' && result.signatures.length === 2",
+            "id": "t4",
+            "input": "'s-refused'"
+          },
+          {
+            "description": "An empty allowance halts on call zero without spending a fee",
+            "expectedOutput": "result.calls === 0 && result.spent === '0' && result.remaining === '0' && result.halted === true && result.reason === 'budget-exhausted' && result.signatures.length === 0",
+            "id": "t5",
+            "input": "'s-broke'"
+          },
+          {
+            "description": "A u64-sized allowance spent to exactly zero — the arithmetic never becomes a Number",
+            "expectedOutput": "result.spent === '18446744073709551615' && result.remaining === '0' && result.calls === 3 && result.reason === 'completed'",
+            "id": "t6",
+            "input": "'s-precision'"
+          }
+        ]
+      },
+      {
+        "_key": "check",
+        "_type": "quiz",
+        "questions": [
+          {
+            "explanation": "This is the whole argument for the lesson. Autonomy is safe when the limit is somewhere the agent cannot reach, and a program-enforced allowance is exactly that.",
+            "id": "q1",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "A loses up to 400. B loses at most the 40 still on the delegation — the cap is enforced by the program, so the stolen key cannot draw past it."
+              },
+              {
+                "correct": false,
+                "feedback": "A delegation is not account access. It authorises transfers up to a recorded amount, and the program refuses anything beyond it regardless of who is signing.",
+                "id": "b",
+                "label": "Both lose everything in the user's token account, since the delegation grants access to it."
+              },
+              {
+                "correct": false,
+                "feedback": "A Fixed Delegation is a capped TOTAL, not a per-transfer limit. Repeated draws consume the same pool and stop when it is empty.",
+                "id": "c",
+                "label": "B is worse, because the delegation can be drawn repeatedly."
+              },
+              {
+                "correct": false,
+                "feedback": "The cap lives in a program-owned account on-chain. A compromised client cannot raise it, ignore it, or patch it out.",
+                "id": "d",
+                "label": "The losses are identical; the cap is a client-side convenience."
+              }
+            ],
+            "prompt": "Two setups. (A) The agent holds a keypair with 400 USDC in its own token account. (B) The agent holds a keypair with no tokens, and a Fixed Delegation on the user's account capped at 40 USDC total. The agent's key leaks. Compare the losses."
+          },
+          {
+            "explanation": "Backoff is for transient failures: congestion, blockhash expiry, a flaky RPC. A policy refusal is terminal. Distinguishing the two is most of what \"error handling\" means in a payment loop.",
+            "id": "q2",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "Three more refusals and three more fees. The cap is state on-chain, not a transient failure — nothing about waiting changes the answer."
+              },
+              {
+                "correct": false,
+                "feedback": "Finalisation does not add funds to an allowance. The remaining amount is what it is.",
+                "id": "b",
+                "label": "One of the retries succeeds once the previous transaction finalises."
+              },
+              {
+                "correct": false,
+                "feedback": "A transaction that reaches execution and fails still pays its fee. Failing repeatedly on purpose is a way to spend money on nothing.",
+                "id": "c",
+                "label": "The retries are free because failed transactions are not charged."
+              },
+              {
+                "correct": false,
+                "feedback": "Nothing tops up automatically. Raising the cap is an action the USER signs — which is the point of the design.",
+                "id": "d",
+                "label": "The delegation auto-tops-up from the user's balance on the third attempt."
+              }
+            ],
+            "prompt": "Your loop draws from the delegation, the program refuses, and your `catch` block retries the same draw three times with backoff. Predict what happens."
+          },
+          {
+            "explanation": "Track `remaining_amount` locally and check it before you build the transaction. The on-chain cap is your last line of defence, not your first.",
+            "id": "q3",
+            "multiSelect": true,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "A transaction fee for a transaction you already knew would be refused"
+              },
+              {
+                "correct": true,
+                "id": "b",
+                "label": "A worse report — you learn \"the program refused\" instead of \"the budget is exhausted\", which are different operational facts"
+              },
+              {
+                "correct": false,
+                "feedback": "A failed transfer transfers nothing. The allowance is untouched — the cost is the fee and the lost clarity, not the balance.",
+                "id": "c",
+                "label": "The remaining 5,000 base units, which are consumed by the failed attempt"
+              },
+              {
+                "correct": false,
+                "feedback": "The cap protects the user's funds. It does not refund your fees, and it does not write your report for you.",
+                "id": "d",
+                "label": "Nothing, since the on-chain cap protects you either way"
+              }
+            ],
+            "prompt": "The allowance has 5,000 base units left and the next call costs 10,000. Your loop attempts it anyway and handles the failure. What did that choice cost you?"
+          },
+          {
+            "explanation": "Same three models you mapped in lesson 1, now with a concrete consequence: an agent budget is a Fixed Delegation when the limit is a lifetime total, and a Recurring Delegation when it is a rate.",
+            "id": "q4",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "(i) Fixed Delegation — a capped total. (ii) Recurring Delegation — a cap that resets per period."
+              },
+              {
+                "correct": false,
+                "feedback": "A recurring cap resets. There is no period long enough to make a resetting cap into a lifetime limit — you would just be extending the window.",
+                "id": "b",
+                "label": "Both are Recurring Delegations; you set the period to \"forever\" for (i)."
+              },
+              {
+                "correct": false,
+                "feedback": "That works only if someone remembers, and every re-creation needs the user's signature. The recurring model exists precisely so the user signs once.",
+                "id": "c",
+                "label": "Both are Fixed Delegations; for (ii) you re-create the delegation every month."
+              },
+              {
+                "correct": false,
+                "feedback": "A subscription plan is the merchant-published model, where approved pullers collect against terms the merchant set. Neither requirement here describes that.",
+                "id": "d",
+                "label": "(i) Subscription Plan, (ii) Fixed Delegation."
+              }
+            ],
+            "prompt": "Two requirements. (i) \"This agent may spend at most 50 USDC, ever.\" (ii) \"This agent may spend at most 50 USDC each month, indefinitely.\" Which delegation does each need?"
+          }
+        ]
+      }
+    ],
+    "skills": [
+      "agent-budgets",
+      "fixed-delegation",
+      "x402-protocol",
+      "error-handling"
+    ],
+    "slug": {
+      "_type": "slug",
+      "current": "budgeted-agent-with-a-hard-cap"
+    },
+    "title": "An Agent With a Wallet That Can Say No"
+  },
+  {
+    "_id": "lesson-sap-meter-an-endpoint-with-x402",
+    "_type": "lesson",
+    "blocks": [
+      {
+        "_key": "intro",
+        "_type": "prose",
+        "src": "# 402 Payment Required, For Real\n\n> **Version stamp — checked 2026-07-25.** `@x402/core`, `@x402/svm`, `@x402/express`, `@x402/fetch` at **2.19.0** (published 2026-07-17). `@solana/kit` at **7.0.0**. Everything below is written against those exact versions. If you are reading this more than a few months later, re-check the pins before you copy anything.\n\nIn module 1 you gave your vault app a paid tier: a Subscription Authority, a Recurring Delegation, one collected charge, and a second charge that correctly refused. That model prices a **relationship** — a subscriber, a period, a cap.\n\nThis lesson prices a **request**. One route, one price, one payment, no account, no relationship. That is what x402 is for: an HTTP status code that has been sitting unused in RFC 7231 since 1997, wired to a stablecoin transfer.\n\nThe flow has three moves and no new infrastructure:\n\n1. A client calls your route with no payment. You answer **402** with a machine-readable challenge describing what you will accept.\n2. The client builds a payment matching one of your accepted terms and calls again, carrying the payment in a header.\n3. You hand that payload to a **facilitator**, which verifies and settles it on-chain, and then you serve the response.\n\n---\n\n## The package split — read this before you install anything\n\nThis is the single worst staleness trap in this catalog, because search engines surface the wrong half and so does one of Solana's own templates.\n\n**Frozen. Do not install. Do not teach.**\n\n`x402` · `x402-express` · `x402-next` · `x402-fetch` · `x402-hono` — all **1.2.0**, published **2026-04-16**. These speak protocol **v1**. solana.com's own \"X402 Next.js\" scaffold still ships `x402-next`, so \"it came from an official template\" is not evidence of currency.\n\n**Current. Install these.**\n\n| Package | Version | What you use from it |\n| --- | --- | --- |\n| `@x402/core` | 2.19.0 | `x402ResourceServer`, `x402HTTPResourceServer`, `x402Client`, `HTTPFacilitatorClient`, `VerifyError`, `SettleError` |\n| `@x402/svm` | 2.19.0 | `ExactSvmScheme`, `ExactSvmSchemeV1`, `SOLANA_DEVNET_CAIP2`, `USDC_DEVNET_ADDRESS`, `TOKEN_PROGRAM_ADDRESS`, `TOKEN_2022_PROGRAM_ADDRESS` |\n| `@x402/express` | 2.19.0 | `paymentMiddleware` |\n| `@x402/fetch` | 2.19.0 | `wrapFetchWithPayment` (that is lesson 6) |\n\nThe unscoped packages are still published and still installable. Nothing stops you from typing the wrong one. Read the `@` before you press enter.\n\n`@x402/svm` peer-depends on `@solana/kit >=5.1.0`. That is the **same Kit you already have** from the client you published in course 4 — the metering layer is not a second SDK, it is a scheme plugin that borrows yours.\n\n---\n\n## The challenge envelope\n\nEverything the client needs is in the 402. Here is the worked example you will run in a moment, in full:\n\n```json\n{\n  \"x402Version\": 2,\n  \"error\": \"payment required\",\n  \"accepts\": [\n    {\n      \"scheme\": \"exact\",\n      \"network\": \"solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1\",\n      \"asset\": \"4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU\",\n      \"payTo\": \"<your devnet wallet>\",\n      \"maxAmountRequired\": \"10000\",\n      \"resource\": \"https://your-app.vercel.app/api/quote\",\n      \"description\": \"One FX quote\",\n      \"mimeType\": \"application/json\",\n      \"maxTimeoutSeconds\": 60\n    }\n  ]\n}\n```\n\nField by field, and each of these is a place people get it wrong:\n\n- **`x402Version`** — the wire version, `1` or `2`. Both are live in the world right now. You emit `2`.\n- **`scheme`** — `\"exact\"`. The client pays exactly `maxAmountRequired`, no more, no quoting, no conversion.\n- **`network`** — a CAIP-2 chain id: the namespace `solana:` plus the first 32 characters of the cluster's genesis hash. Devnet is `solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1`; mainnet is `solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp`. **Import `SOLANA_DEVNET_CAIP2` from `@x402/svm` rather than typing that literal into your server** — a one-character typo produces a challenge no client can match, and the failure looks like \"the client just never pays\".\n- **`asset`** — the mint address, on that network. Devnet USDC is `4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU` (`USDC_DEVNET_ADDRESS`). `network` and `asset` are a **pair**. A mint is an account on one cluster; the mainnet USDC mint does not exist on devnet.\n- **`payTo`** — the address that receives the tokens. This is the whole point of the exercise and it is the one value you are going to fill in.\n- **`maxAmountRequired`** — **base units, as a decimal string.** 0.01 USDC at 6 decimals is `\"10000\"`. Not `0.01`. Not the number `10000`. A string, because base-unit amounts are `u64` and JSON numbers stop being exact above 2^53 — and because the moment a float touches a payment field you have signed up for rounding bugs you will find in production, not in tests.\n- **`resource`** — the absolute URL being priced. It binds the payment to this route.\n- **`maxTimeoutSeconds`** — how long you will hold the door open between issuing the challenge and settling the payment.\n\n`accepts` is an **array** because it is a menu, not a demand. A real server offers several terms — devnet and mainnet, or several assets — and lets the client pick one it can satisfy. In lesson 6 you are on the other side of that menu, doing the picking.\n\n### Where the envelope travels\n\nIn the common case it is the JSON response body of the 402. But some servers return an **empty body** and put the whole base64-encoded envelope in a `PAYMENT-REQUIRED` response header — Vercel-hosted ones do this, because of how their edge layer handles bodies on error statuses. A correct server emits both. A correct client reads both. You will build the client-side fallback next lesson; today you emit both so you are never the reason a client fails.\n\nThat is why the exercise base64-encodes the envelope as well as returning it: `header` and `body` carry the same bytes.\n\n---\n\n## The facilitator\n\nYou do not run an RPC node, you do not hold a hot key for verification, and you do not submit transactions. A **facilitator** exposes three operations:\n\n- **`supported`** — which `(network, asset, scheme)` combinations it can service. Use it to build your `accepts[]` instead of guessing.\n- **`verify`** — is this payment payload well-formed, correctly signed, and does it satisfy the terms you advertised? Throws `VerifyError` when not.\n- **`settle`** — submit it and confirm it. Throws `SettleError` when not.\n\nWire one up with `HTTPFacilitatorClient` from `@x402/core` and hand it to `x402ResourceServer`. The illustrative shape, which you run in your own app rather than in the grader:\n\n```ts\nimport { x402ResourceServer, HTTPFacilitatorClient } from \"@x402/core\"; // 2.19.0\nimport { ExactSvmScheme, SOLANA_DEVNET_CAIP2, USDC_DEVNET_ADDRESS } from \"@x402/svm\"; // 2.19.0\nimport { paymentMiddleware } from \"@x402/express\"; // 2.19.0\n\nconst facilitator = new HTTPFacilitatorClient({ url: process.env.FACILITATOR_URL! });\n\nconst server = x402ResourceServer({\n  facilitator,\n  schemes: [ExactSvmScheme],\n});\n\napp.use(\n  paymentMiddleware(server, {\n    \"GET /api/quote\": {\n      network: SOLANA_DEVNET_CAIP2,\n      asset: USDC_DEVNET_ADDRESS,\n      payTo: process.env.MERCHANT_ADDRESS!,\n      maxAmountRequired: \"10000\",\n      description: \"One FX quote\",\n    },\n  })\n);\n```\n\nThe middleware is doing exactly what your exercise does by hand — building that `accepts[]` entry, returning 402 when no payment arrives, and calling `verify`/`settle` when one does. Write it once by hand so the middleware is never a black box.\n\n**On Kora:** you may run your own facilitator, and Kora is the Solana-native one. It requires cloning the repo and building it locally across several terminals. That is a local-toolchain detour this course does not take. Use a hosted or embedded facilitator on devnet; come back to self-hosting when you have revenue to protect.\n\n---\n\n## The exercise\n\nYou are handed a complete, annotated, working challenge builder. Read it top to bottom — it is the reference implementation, and it is short on purpose.\n\n**Change exactly one value: `PAY_TO`.** Put a real base58 devnet address there — the wallet you funded in course 1 is the right one, because in a moment you want to watch USDC land in it. Nothing else in the file needs to move.\n\nThe tests check the things that break real integrations: the amount is a decimal string of base units, the network and asset are the devnet pair, the encoded header is genuine base64 of the body, and `payTo` is an address rather than a placeholder.\n\n## Milestone\n\nTake the same envelope shape into your course-4 app, put it in front of one real route, and deploy it. **Keep the URL.** Lesson 6 pays it, lesson 7 has an agent pay it repeatedly out of a capped budget, and lesson 8 asks you for the link.\n"
+      },
+      {
+        "_key": "envelope",
+        "_type": "code",
+        "buildType": "standard",
+        "deployable": false,
+        "hints": [
+          "You change exactly one value in this file: PAY_TO. Everything else is already correct.",
+          "PAY_TO must be a base58 Solana address — the wallet that should receive the USDC, on devnet.",
+          "`maxAmountRequired` is a decimal string of base units, never a float: 0.01 USDC at 6 decimals is \"10000\"."
+        ],
+        "language": "typescript",
+        "solution": "// ---------------------------------------------------------------------------\n// REFERENCE SOLUTION — an x402 v2 challenge builder.\n//\n// Identical to the starter except for PAY_TO, which now holds a real base58\n// devnet address. Use YOUR OWN wallet — this one is an example merchant.\n//\n// Pinned 2026-07-25: @x402/core 2.19.0, @x402/svm 2.19.0, @solana/kit 7.0.0.\n// The grader has no module resolution, so the two constants below are written\n// out. In your own server you IMPORT them:\n//   import { SOLANA_DEVNET_CAIP2, USDC_DEVNET_ADDRESS } from \"@x402/svm\";\n// ---------------------------------------------------------------------------\n\n/** CAIP-2 chain id: \"solana:\" + the first 32 chars of the cluster genesis hash. */\nconst SOLANA_DEVNET_CAIP2 = \"solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1\";\n\n/** Circle's devnet USDC mint. 6 decimals. Paired with the network above. */\nconst USDC_DEVNET_ADDRESS = \"4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU\";\n\n// >>> THE ONE VALUE THAT CHANGED <<<\n// The wallet that receives the tokens. Use a real base58 devnet address.\nconst PAY_TO = \"B7o8NfV81HzjuZFWQTTx3Xdvh77Dqoajwib3kWEnvzJF\";\n\ninterface Route {\n  /** Absolute URL of the priced route. Binds the payment to this resource. */\n  resource: string;\n  /** Human-readable, shown by wallets and agent logs. */\n  description: string;\n  /** Base units, decimal string. 0.01 USDC at 6 decimals = \"10000\". */\n  priceBaseUnits: string;\n}\n\n/** Your price list. Two routes so the builder is driven by data, not by copy-paste. */\nconst ROUTES: Record<string, Route> = {\n  quote: {\n    resource: \"https://your-app.vercel.app/api/quote\",\n    description: \"One FX quote\",\n    priceBaseUnits: \"10000\",\n  },\n  digest: {\n    resource: \"https://your-app.vercel.app/api/digest\",\n    description: \"Daily market digest\",\n    priceBaseUnits: \"250000\",\n  },\n};\n\n/**\n * Build the full HTTP 402 response for a priced route.\n *\n * Returns the body (the challenge envelope), the headers, and the base64\n * encoding of the envelope — because some hosts strip bodies from error\n * responses, so a correct server emits the envelope BOTH ways.\n */\nfunction buildPaymentRequired(routeId: string) {\n  const route = ROUTES[routeId];\n  if (!route) throw new Error(\"unknown route: \" + routeId);\n\n  // The menu. One entry here; a real server offers several so the client can\n  // pick a (network, asset) pair it can actually satisfy.\n  const envelope = {\n    x402Version: 2,\n    error: \"payment required\",\n    accepts: [\n      {\n        // Pay the exact amount. No quoting, no conversion, no partial fills.\n        scheme: \"exact\",\n        // network and asset are a PAIR. A mint lives on one cluster.\n        network: SOLANA_DEVNET_CAIP2,\n        asset: USDC_DEVNET_ADDRESS,\n        payTo: PAY_TO,\n        // Decimal STRING of base units. Never a float, never a JSON number:\n        // u64 amounts stop being exact above 2^53.\n        maxAmountRequired: route.priceBaseUnits,\n        resource: route.resource,\n        description: route.description,\n        mimeType: \"application/json\",\n        // How long you will hold the door open between challenge and settlement.\n        maxTimeoutSeconds: 60,\n      },\n    ],\n  };\n\n  const encoded = utf8ToBase64(JSON.stringify(envelope));\n\n  return {\n    status: 402,\n    headers: {\n      \"content-type\": \"application/json\",\n      // Same bytes as the body. Clients behind edge layers that drop error\n      // bodies read the envelope from here instead.\n      \"payment-required\": encoded,\n    },\n    body: envelope,\n    encoded,\n  };\n}\n\n// --- plumbing -------------------------------------------------------------\n// In Node or a browser you would use Buffer.from(s).toString(\"base64\") or\n// btoa(). Neither exists in this sandbox, so here is base64 in twelve lines.\n\nconst B64_ALPHABET =\n  \"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/\";\n\nfunction utf8ToBase64(text: string): string {\n  const bytes = new TextEncoder().encode(text);\n  let out = \"\";\n  for (let i = 0; i < bytes.length; i += 3) {\n    const b0 = bytes[i];\n    const b1 = i + 1 < bytes.length ? bytes[i + 1] : -1;\n    const b2 = i + 2 < bytes.length ? bytes[i + 2] : -1;\n    out += B64_ALPHABET[b0 >> 2];\n    out += B64_ALPHABET[((b0 & 3) << 4) | (b1 < 0 ? 0 : b1 >> 4)];\n    out += b1 < 0 ? \"=\" : B64_ALPHABET[((b1 & 15) << 2) | (b2 < 0 ? 0 : b2 >> 6)];\n    out += b2 < 0 ? \"=\" : B64_ALPHABET[b2 & 63];\n  }\n  return out;\n}\n",
+        "starter": "// ---------------------------------------------------------------------------\n// WORKED EXAMPLE — an x402 v2 challenge builder.\n//\n// This file is complete and correct except for ONE value. Read it, then change\n// PAY_TO to your own devnet address. Nothing else needs to move.\n//\n// Pinned 2026-07-25: @x402/core 2.19.0, @x402/svm 2.19.0, @solana/kit 7.0.0.\n// The grader has no module resolution, so the two constants below are written\n// out. In your own server you IMPORT them:\n//   import { SOLANA_DEVNET_CAIP2, USDC_DEVNET_ADDRESS } from \"@x402/svm\";\n// ---------------------------------------------------------------------------\n\n/** CAIP-2 chain id: \"solana:\" + the first 32 chars of the cluster genesis hash. */\nconst SOLANA_DEVNET_CAIP2 = \"solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1\";\n\n/** Circle's devnet USDC mint. 6 decimals. Paired with the network above. */\nconst USDC_DEVNET_ADDRESS = \"4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU\";\n\n// >>> THE ONE VALUE YOU CHANGE <<<\n// The wallet that receives the tokens. Use a real base58 devnet address.\nconst PAY_TO = \"REPLACE_WITH_YOUR_DEVNET_WALLET\";\n\ninterface Route {\n  /** Absolute URL of the priced route. Binds the payment to this resource. */\n  resource: string;\n  /** Human-readable, shown by wallets and agent logs. */\n  description: string;\n  /** Base units, decimal string. 0.01 USDC at 6 decimals = \"10000\". */\n  priceBaseUnits: string;\n}\n\n/** Your price list. Two routes so the builder is driven by data, not by copy-paste. */\nconst ROUTES: Record<string, Route> = {\n  quote: {\n    resource: \"https://your-app.vercel.app/api/quote\",\n    description: \"One FX quote\",\n    priceBaseUnits: \"10000\",\n  },\n  digest: {\n    resource: \"https://your-app.vercel.app/api/digest\",\n    description: \"Daily market digest\",\n    priceBaseUnits: \"250000\",\n  },\n};\n\n/**\n * Build the full HTTP 402 response for a priced route.\n *\n * Returns the body (the challenge envelope), the headers, and the base64\n * encoding of the envelope — because some hosts strip bodies from error\n * responses, so a correct server emits the envelope BOTH ways.\n */\nfunction buildPaymentRequired(routeId: string) {\n  const route = ROUTES[routeId];\n  if (!route) throw new Error(\"unknown route: \" + routeId);\n\n  // The menu. One entry here; a real server offers several so the client can\n  // pick a (network, asset) pair it can actually satisfy.\n  const envelope = {\n    x402Version: 2,\n    error: \"payment required\",\n    accepts: [\n      {\n        // Pay the exact amount. No quoting, no conversion, no partial fills.\n        scheme: \"exact\",\n        // network and asset are a PAIR. A mint lives on one cluster.\n        network: SOLANA_DEVNET_CAIP2,\n        asset: USDC_DEVNET_ADDRESS,\n        payTo: PAY_TO,\n        // Decimal STRING of base units. Never a float, never a JSON number:\n        // u64 amounts stop being exact above 2^53.\n        maxAmountRequired: route.priceBaseUnits,\n        resource: route.resource,\n        description: route.description,\n        mimeType: \"application/json\",\n        // How long you will hold the door open between challenge and settlement.\n        maxTimeoutSeconds: 60,\n      },\n    ],\n  };\n\n  const encoded = utf8ToBase64(JSON.stringify(envelope));\n\n  return {\n    status: 402,\n    headers: {\n      \"content-type\": \"application/json\",\n      // Same bytes as the body. Clients behind edge layers that drop error\n      // bodies read the envelope from here instead.\n      \"payment-required\": encoded,\n    },\n    body: envelope,\n    encoded,\n  };\n}\n\n// --- plumbing -------------------------------------------------------------\n// In Node or a browser you would use Buffer.from(s).toString(\"base64\") or\n// btoa(). Neither exists in this sandbox, so here is base64 in twelve lines.\n\nconst B64_ALPHABET =\n  \"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/\";\n\nfunction utf8ToBase64(text: string): string {\n  const bytes = new TextEncoder().encode(text);\n  let out = \"\";\n  for (let i = 0; i < bytes.length; i += 3) {\n    const b0 = bytes[i];\n    const b1 = i + 1 < bytes.length ? bytes[i + 1] : -1;\n    const b2 = i + 2 < bytes.length ? bytes[i + 2] : -1;\n    out += B64_ALPHABET[b0 >> 2];\n    out += B64_ALPHABET[((b0 & 3) << 4) | (b1 < 0 ? 0 : b1 >> 4)];\n    out += b1 < 0 ? \"=\" : B64_ALPHABET[((b1 & 15) << 2) | (b2 < 0 ? 0 : b2 >> 6)];\n    out += b2 < 0 ? \"=\" : B64_ALPHABET[b2 & 63];\n  }\n  return out;\n}\n",
+        "tests": [
+          {
+            "description": "Returns a 402 whose body is a v2 envelope with a one-entry accepts menu",
+            "expectedOutput": "result.status === 402 && result.body.x402Version === 2 && Array.isArray(result.body.accepts) && result.body.accepts.length === 1",
+            "id": "t1",
+            "input": "'quote'"
+          },
+          {
+            "description": "The challenge is driven by the route table, not hardcoded",
+            "expectedOutput": "result.body.accepts[0].maxAmountRequired === '250000' && result.body.accepts[0].resource.indexOf('/api/digest') > -1 && result.body.accepts[0].description === 'Daily market digest'",
+            "id": "t2",
+            "input": "'digest'"
+          },
+          {
+            "description": "maxAmountRequired is a decimal string of base units, not a number or a float",
+            "expectedOutput": "typeof result.body.accepts[0].maxAmountRequired === 'string' && /^[0-9]+$/.test(result.body.accepts[0].maxAmountRequired) && result.body.accepts[0].maxAmountRequired === '10000'",
+            "id": "t3",
+            "input": "'quote'"
+          },
+          {
+            "description": "scheme, network and asset name the exact scheme and the devnet USDC pair",
+            "expectedOutput": "result.body.accepts[0].scheme === 'exact' && result.body.accepts[0].network === 'solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1' && result.body.accepts[0].asset === '4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU'",
+            "id": "t4",
+            "input": "'quote'"
+          },
+          {
+            "description": "payTo is a real base58 Solana address — change PAY_TO to your own devnet wallet",
+            "expectedOutput": "/^[1-9A-HJ-NP-Za-km-z]{32,44}$/.test(result.body.accepts[0].payTo)",
+            "id": "t5",
+            "input": "'quote'"
+          },
+          {
+            "description": "The envelope is also emitted base64-encoded in the payment-required header",
+            "expectedOutput": "typeof result.encoded === 'string' && result.encoded.slice(0, 4) === 'eyJ4' && result.headers['payment-required'] === result.encoded",
+            "id": "t6",
+            "input": "'digest'"
+          }
+        ]
+      },
+      {
+        "_key": "check",
+        "_type": "quiz",
+        "questions": [
+          {
+            "explanation": "The v1 line (`x402`, `x402-express`, `x402-next`, `x402-fetch`, `x402-hono`, all 1.2.0) is frozen. The current line is scoped: `@x402/core`, `@x402/svm`, `@x402/express`, `@x402/fetch`, `@x402/next`, `@x402/mcp`, all 2.19.0. Search engines still surface the frozen half.",
+            "id": "q1",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "You installed the frozen v1 line. The server emits a v1 challenge and reads the `X-PAYMENT` header; the v2 client sends `PAYMENT`. The two never agree."
+              },
+              {
+                "correct": false,
+                "feedback": "They are different packages. `x402-express` is frozen at 1.2.0 (2026-04-16) and speaks protocol v1. `@x402/express` is 2.19.0 (2026-07-17) and speaks v2.",
+                "id": "b",
+                "label": "The middleware works — `x402-express` and `@x402/express` are the same package under two names."
+              },
+              {
+                "correct": false,
+                "feedback": "npm does no such rewriting. The unscoped packages are still published and still installable — that is exactly why this trap keeps catching people.",
+                "id": "c",
+                "label": "npm resolves the scoped package automatically because the unscoped one is deprecated."
+              },
+              {
+                "correct": false,
+                "feedback": "The failure is a protocol mismatch, not a performance difference.",
+                "id": "d",
+                "label": "It works but is slower, because v1 does an extra round trip."
+              }
+            ],
+            "prompt": "You search for \"x402 express\" and the top result tells you to run `npm i x402-express`. You install it and wire `paymentMiddleware` into your route. A client running `@x402/fetch@2.19.0` calls the route. What happens?"
+          },
+          {
+            "explanation": "Base units as a decimal string, every time. The mint's decimals are a property of `asset`, not something you encode into the amount.",
+            "id": "q2",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "\"10000\""
+              },
+              {
+                "correct": false,
+                "feedback": "A float in a payment field is a bug waiting for a rounding error. The field is a string of base units.",
+                "id": "b",
+                "label": "0.01"
+              },
+              {
+                "correct": false,
+                "feedback": "Right magnitude, wrong type. Numbers above 2^53 lose precision in JSON, so the field is specified as a decimal string — use it as one even for small amounts.",
+                "id": "c",
+                "label": "10000"
+              },
+              {
+                "correct": false,
+                "feedback": "The field carries base units only. The asset is named separately in `asset`.",
+                "id": "d",
+                "label": "\"0.01 USDC\""
+              }
+            ],
+            "prompt": "Your route costs 0.01 USDC. USDC has 6 decimals. Which `accepts[0].maxAmountRequired` will a conforming client charge correctly?"
+          },
+          {
+            "explanation": "A facilitator exposes three operations — `supported`, `verify` and `settle`. It absorbs the RPC connection, the signature checks and the transaction submission, which is why an API provider can monetize a route without running any on-chain infrastructure.",
+            "id": "q3",
+            "multiSelect": true,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "Signature verification of the submitted payment payload"
+              },
+              {
+                "correct": true,
+                "id": "b",
+                "label": "Submitting and confirming the payment transaction on Solana"
+              },
+              {
+                "correct": false,
+                "feedback": "Pricing is yours. The facilitator has no idea what your route is worth.",
+                "id": "c",
+                "label": "Deciding the price of the route"
+              },
+              {
+                "correct": false,
+                "feedback": "The `accepts[]` array is your policy statement. The facilitator only tells you which combinations it can service, via `supported`.",
+                "id": "d",
+                "label": "Deciding which networks and assets you will accept"
+              }
+            ],
+            "prompt": "Your API server issues challenges and gates the route. Which of these does your server never have to run itself?"
+          },
+          {
+            "explanation": "`network` and `asset` are a pair, and a client filters on both. `SOLANA_DEVNET_CAIP2` + `USDC_DEVNET_ADDRESS` is one valid combination; the mainnet pair is another; mixing halves is not.",
+            "id": "q4",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "Verification fails — that is the mainnet USDC mint and the challenge named a devnet network and a devnet asset. Both fields have to match."
+              },
+              {
+                "correct": false,
+                "feedback": "A mint address is an account on one specific cluster. The mainnet USDC mint does not exist on devnet, and a token account for it cannot be created there.",
+                "id": "b",
+                "label": "It settles — USDC is USDC, the mint address is cosmetic."
+              },
+              {
+                "correct": false,
+                "feedback": "There is no bridging in the `exact` scheme. It settles a specified amount of a specified mint on a specified network, or it fails.",
+                "id": "c",
+                "label": "The facilitator bridges it automatically."
+              },
+              {
+                "correct": false,
+                "feedback": "Nothing in x402 converts or quotes. The amount is exact and the asset is fixed.",
+                "id": "d",
+                "label": "It settles at the mainnet price after conversion."
+              }
+            ],
+            "prompt": "A client reads your challenge, sees `network: \"solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1\"` and pays with the mint at `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`. Predict the outcome."
+          }
+        ]
+      }
+    ],
+    "skills": [
+      "x402-protocol",
+      "api-monetization",
+      "solana-kit"
+    ],
+    "slug": {
+      "_type": "slug",
+      "current": "meter-an-endpoint-with-x402"
+    },
+    "title": "402 Payment Required, For Real"
+  },
+  {
+    "_id": "lesson-sap-pay-the-402-programmatically",
+    "_type": "lesson",
+    "blocks": [
+      {
+        "_key": "intro",
+        "_type": "prose",
+        "src": "# Reading a Challenge and Paying It\n\n> **Version stamp — checked 2026-07-25.** `@x402/core`, `@x402/svm`, `@x402/fetch` at **2.19.0** (2026-07-17). `@solana/kit` at **7.0.0**. The frozen v1 line (`x402`, `x402-fetch`, 1.2.0, 2026-04-16) is still on npm and still installable — do not.\n\nLast lesson you were the server. Now you are the caller, and the caller has the harder job: the server publishes one shape and knows what it published. The client has to handle whatever it is handed.\n\nTwo things make that hard in practice, and both of them are in today's exercise:\n\n1. **The envelope is not always where the docs say it is.** Some servers return an empty body and put the whole base64 envelope in a response header.\n2. **Two protocol versions are live at the same time.** They use different header names and different envelope fields. Every tutorial that picks one and hardcodes it will rot; this lesson teaches you to read the version off the wire.\n\n---\n\n## The loop\n\n```\nfetch(url)                       → 402\nlocate the envelope              → body, or the PAYMENT-REQUIRED header\ndecode it                        → JSON (base64-decode first if it came from the header)\nread envelope.x402Version        → decides the retry header name\nselect one accepts[] entry       → filter on scheme + network + asset\nsign a payment for those terms\nfetch(url, { headers: { <name>: <payload> } })  → 200\n```\n\nIn production `wrapFetchWithPayment` from `@x402/fetch` does all of that:\n\n```ts\nimport { wrapFetchWithPayment } from \"@x402/fetch\"; // 2.19.0\nimport { x402Client } from \"@x402/core\"; // 2.19.0\nimport { ExactSvmScheme, ExactSvmSchemeV1 } from \"@x402/svm\"; // 2.19.0\n\nconst client = x402Client({\n  signer: agentSigner,             // your @solana/kit@7 signer\n  schemes: [ExactSvmScheme, ExactSvmSchemeV1],\n});\n\nconst paidFetch = wrapFetchWithPayment(fetch, client);\nconst res = await paidFetch(\"https://api.example.dev/quote\");\n```\n\nNote the `schemes` array. You register **both** — and this is the point of the lesson.\n\n---\n\n## The version seam\n\n`@x402/svm@2.19.0` exports `ExactSvmScheme` **and** `ExactSvmSchemeV1`. That is not legacy cruft kept around for types. It is there because **both wire versions are live right now**:\n\n| | v1 | v2 |\n| --- | --- | --- |\n| Emitted by | `x402`, `x402-express`, `x402-next`, `x402-fetch`, `x402-hono` @ 1.2.0 | `@x402/*` @ 2.19.0 |\n| Envelope field | `\"x402Version\": 1` | `\"x402Version\": 2` |\n| Payment request header | `X-PAYMENT` | `PAYMENT` |\n| Settlement response header | `X-PAYMENT-RESPONSE` | `PAYMENT-RESPONSE` |\n\nA client that registers only the v2 scheme fails silently against every server still on the frozen package line — and since solana.com's own Next.js x402 template ships `x402-next`, there are more of those than you expect.\n\n**Never assume the version. Read `x402Version` out of the envelope you were handed, then build the retry to match.** That single habit is the difference between a client that works for a year and one that works until the first server you did not test against.\n\n---\n\n## The menu\n\n`accepts[]` is a list of terms the server will take. It is ordered by the server's preference, which has nothing to do with your capability. In today's fixtures the **first** entry is always an EVM entry — that is deliberate, and it is the shape of the real bug:\n\n```ts\nconst terms = envelope.accepts[0];   // ← you are now trying to pay on Base\n```\n\nFilter instead, on all three of the fields that have to line up:\n\n```ts\nconst terms = envelope.accepts.find(\n  (entry) =>\n    entry.scheme === \"exact\" &&\n    entry.network === SOLANA_DEVNET_CAIP2 &&\n    entry.asset === USDC_DEVNET_ADDRESS\n);\n```\n\n`network` and `asset` are a pair. The `v2-header` fixture offers Solana **mainnet** USDC and Solana **devnet** USDC as separate entries, with the same scheme and the same price. Matching only on network, or only on asset, picks the wrong one.\n\nAnd \"no entry matches\" is a normal outcome, not an error. Servers that only accept EVM money exist. Report it and move on — your caller needs to know it was not paid, not receive an exception.\n\n---\n\n## The exercise\n\n`handle402(captureId)` receives one of four captured HTTP responses and returns a report saying what it found and what it would pay.\n\nInside the function there are **eight commented-out blocks**. Six of them are the ones you need, in the wrong order. **Two are wrong and must be deleted.** The block numbers are labels, not positions.\n\nHere is what the two wrong blocks get wrong. This is the whole reason they are in the file:\n\n- **One retries before decoding.** It calls `JSON.parse(res.body)` and takes `accepts[0]`, hardcoding version 2 and hardcoding \"the envelope is in the body\". It produces a plausible-looking result on exactly one of the four fixtures and is wrong on the rest — which is precisely how this bug survives review. Decoding is not a formality you can skip; it is where you learn which protocol you are speaking.\n- **One selects on the wrong chain namespace.** It filters for `eip155:` entries. Those are real, valid, payable terms — by somebody with an EVM wallet. The lesson is that \"found a match\" is not the same as \"found a match I can satisfy\".\n\nOrdering is not guesswork: every block after the first uses a local that an earlier block declares. Follow the dependency chain — `res` → `headerEnvelope`/`fromHeader` → `raw`/`envelope` → `paymentHeader`/`envelopeFrom` → `selected`.\n\nThe base64 decoder is given to you at the bottom of the file. It is not part of the puzzle; `atob()` and `Buffer` simply do not exist in the grader.\n\n## What this unlocks\n\nYou now have both halves: a route that charges, and a client that pays. Next lesson the caller stops being you and becomes a loop — and the interesting question stops being \"can it pay?\" and becomes \"what stops it?\"\n"
+      },
+      {
+        "_key": "exercise",
+        "_type": "code",
+        "buildType": "standard",
+        "deployable": false,
+        "hints": [
+          "Five things happen in order: detect, locate, decode, read the version, select. Only then do you retry.",
+          "Every block after the first uses a local that an earlier block declares. That dependency chain is the ordering.",
+          "One wrong block calls `JSON.parse(res.body)` before anything has checked whether the body is empty.",
+          "The other wrong block filters on `eip155:` — a namespace your Solana wallet cannot pay."
+        ],
+        "language": "typescript",
+        "solution": "// ---------------------------------------------------------------------------\n// REFERENCE SOLUTION — read a 402 challenge and decide how to pay it.\n//\n// Blocks 5, 2, 7, 1, 8, 4 in that order. Blocks 3 and 6 were the wrong ones:\n//   3 — retries before decoding: assumes v2, assumes the body, and takes\n//       accepts[0] sight unseen, which on every capture here is the EVM entry.\n//   6 — selects on the eip155 namespace: a chain you cannot pay from a Solana\n//       wallet.\n//\n// Pinned 2026-07-25: @x402/core 2.19.0, @x402/svm 2.19.0, @x402/fetch 2.19.0.\n// ---------------------------------------------------------------------------\n\nconst SOLANA_DEVNET_CAIP2 = \"solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1\";\nconst USDC_DEVNET_ADDRESS = \"4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU\";\n\ninterface Accept {\n  scheme: string;\n  network: string;\n  asset: string;\n  payTo: string;\n  maxAmountRequired: string;\n  resource: string;\n  description: string;\n  mimeType: string;\n  maxTimeoutSeconds: number;\n}\n\ninterface Report {\n  paid: boolean;\n  x402Version: number | null;\n  envelopeFrom: \"body\" | \"header\" | null;\n  paymentHeader: \"X-PAYMENT\" | \"PAYMENT\" | null;\n  selected: Accept | null;\n}\n\ninterface CapturedResponse {\n  status: number;\n  headers: Record<string, string>;\n  body: string;\n}\n\nconst CAPTURES: Record<string, CapturedResponse> = {\n  \"plain-200\": {\n    status: 200,\n    headers: { \"content-type\": \"application/json\" },\n    body: `{\"pair\":\"USDC/BRL\",\"rate\":\"5.41\"}`,\n  },\n\n  \"v1-body\": {\n    status: 402,\n    headers: { \"content-type\": \"application/json\" },\n    body: `{\"x402Version\":1,\"error\":\"X-PAYMENT header is required\",\"accepts\":[{\"scheme\":\"exact\",\"network\":\"eip155:8453\",\"asset\":\"0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913\",\"payTo\":\"0x1a2B3c4D5e6F708192a3B4c5D6e7F8091A2b3C4d\",\"maxAmountRequired\":\"50000\",\"resource\":\"https://api.example.dev/digest\",\"description\":\"Daily market digest\",\"mimeType\":\"application/json\",\"maxTimeoutSeconds\":60},{\"scheme\":\"exact\",\"network\":\"solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1\",\"asset\":\"4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU\",\"payTo\":\"B7o8NfV81HzjuZFWQTTx3Xdvh77Dqoajwib3kWEnvzJF\",\"maxAmountRequired\":\"10000\",\"resource\":\"https://api.example.dev/quote\",\"description\":\"One FX quote\",\"mimeType\":\"application/json\",\"maxTimeoutSeconds\":60}]}`,\n  },\n\n  \"v2-header\": {\n    status: 402,\n    headers: {\n      \"payment-required\":\n        \"eyJ4NDAyVmVyc2lvbiI6MiwiZXJyb3IiOiJwYXltZW50IHJlcXVpcmVkIiwiYWNjZXB0cyI6W3sic2NoZW1lIjoiZXhhY3QiLCJuZXR3b3JrIjoiZWlwMTU1Ojg0NTMiLCJhc3NldCI6IjB4ODMzNTg5ZkNENmVEYjZFMDhmNGM3QzMyRDRmNzFiNTRiZEEwMjkxMyIsInBheVRvIjoiMHgxYTJCM2M0RDVlNkY3MDgxOTJhM0I0YzVENmU3RjgwOTFBMmIzQzRkIiwibWF4QW1vdW50UmVxdWlyZWQiOiI1MDAwMCIsInJlc291cmNlIjoiaHR0cHM6Ly9hcGkuZXhhbXBsZS5kZXYvZGlnZXN0IiwiZGVzY3JpcHRpb24iOiJEYWlseSBtYXJrZXQgZGlnZXN0IiwibWltZVR5cGUiOiJhcHBsaWNhdGlvbi9qc29uIiwibWF4VGltZW91dFNlY29uZHMiOjYwfSx7InNjaGVtZSI6ImV4YWN0IiwibmV0d29yayI6InNvbGFuYTo1ZXlrdDRVc0Z2OFA4TkpkVFJFcFkxdnpxS3FaS3ZkcCIsImFzc2V0IjoiRVBqRldkZDVBdWZxU1NxZU0ycU4xeHp5YmFwQzhHNHdFR0drWnd5VER0MXYiLCJwYXlUbyI6IkI3bzhOZlY4MUh6anVaRldRVFR4M1hkdmg3N0Rxb2Fqd2liM2tXRW52ekpGIiwibWF4QW1vdW50UmVxdWlyZWQiOiI1MDAwMCIsInJlc291cmNlIjoiaHR0cHM6Ly9hcGkuZXhhbXBsZS5kZXYvZGlnZXN0IiwiZGVzY3JpcHRpb24iOiJEYWlseSBtYXJrZXQgZGlnZXN0IiwibWltZVR5cGUiOiJhcHBsaWNhdGlvbi9qc29uIiwibWF4VGltZW91dFNlY29uZHMiOjYwfSx7InNjaGVtZSI6ImV4YWN0IiwibmV0d29yayI6InNvbGFuYTpFdFdUUkFCWmFZcTZpTWZlWUtvdVJ1MTY2VlUyeHFhMSIsImFzc2V0IjoiNHpNTUM5c3J0NVJpNVgxNEdBZ1hoYUhpaTNHblBBRUVSWVBKZ1pKRG5jRFUiLCJwYXlUbyI6IkI3bzhOZlY4MUh6anVaRldRVFR4M1hkdmg3N0Rxb2Fqd2liM2tXRW52ekpGIiwibWF4QW1vdW50UmVxdWlyZWQiOiI1MDAwMCIsInJlc291cmNlIjoiaHR0cHM6Ly9hcGkuZXhhbXBsZS5kZXYvZGlnZXN0IiwiZGVzY3JpcHRpb24iOiJEYWlseSBtYXJrZXQgZGlnZXN0IiwibWltZVR5cGUiOiJhcHBsaWNhdGlvbi9qc29uIiwibWF4VGltZW91dFNlY29uZHMiOjYwfV19\",\n    },\n    body: \"\",\n  },\n\n  \"v2-evm-only\": {\n    status: 402,\n    headers: {\n      \"payment-required\":\n        \"eyJ4NDAyVmVyc2lvbiI6MiwiZXJyb3IiOiJwYXltZW50IHJlcXVpcmVkIiwiYWNjZXB0cyI6W3sic2NoZW1lIjoiZXhhY3QiLCJuZXR3b3JrIjoiZWlwMTU1Ojg0NTMiLCJhc3NldCI6IjB4ODMzNTg5ZkNENmVEYjZFMDhmNGM3QzMyRDRmNzFiNTRiZEEwMjkxMyIsInBheVRvIjoiMHgxYTJCM2M0RDVlNkY3MDgxOTJhM0I0YzVENmU3RjgwOTFBMmIzQzRkIiwibWF4QW1vdW50UmVxdWlyZWQiOiI1MDAwMCIsInJlc291cmNlIjoiaHR0cHM6Ly9hcGkuZXhhbXBsZS5kZXYvZGlnZXN0IiwiZGVzY3JpcHRpb24iOiJEYWlseSBtYXJrZXQgZGlnZXN0IiwibWltZVR5cGUiOiJhcHBsaWNhdGlvbi9qc29uIiwibWF4VGltZW91dFNlY29uZHMiOjYwfV19\",\n    },\n    body: \"\",\n  },\n};\n\nfunction handle402(captureId: string): Report {\n  const res = CAPTURES[captureId];\n\n  // ---- BLOCK 5 — detect -------------------------------------------------\n  // Nothing else runs unless the server actually asked for payment.\n  if (res.status !== 402) {\n    return { paid: false, x402Version: null, envelopeFrom: null, paymentHeader: null, selected: null };\n  }\n\n  // ---- BLOCK 2 — locate -------------------------------------------------\n  // The envelope is in the body, EXCEPT when the body is empty, in which case\n  // it is base64 in the payment-required header. Check both, always.\n  const headerEnvelope = res.headers[\"payment-required\"];\n  const fromHeader = res.body.length === 0 && typeof headerEnvelope === \"string\";\n\n  // ---- BLOCK 7 — decode -------------------------------------------------\n  const raw = fromHeader ? base64ToUtf8(headerEnvelope) : res.body;\n  const envelope = JSON.parse(raw);\n\n  // ---- BLOCK 1 — version ------------------------------------------------\n  // The envelope names its own wire version, and the version decides the\n  // request header the retry has to use.\n  const paymentHeader: \"X-PAYMENT\" | \"PAYMENT\" =\n    envelope.x402Version === 1 ? \"X-PAYMENT\" : \"PAYMENT\";\n  const envelopeFrom: \"header\" | \"body\" = fromHeader ? \"header\" : \"body\";\n\n  // ---- BLOCK 8 — select -------------------------------------------------\n  // accepts[] is a menu. Filter on scheme, network AND asset. Never index it.\n  const selected = envelope.accepts.find(\n    (entry: Accept) =>\n      entry.scheme === \"exact\" &&\n      entry.network === SOLANA_DEVNET_CAIP2 &&\n      entry.asset === USDC_DEVNET_ADDRESS\n  );\n  if (!selected) {\n    return { paid: false, x402Version: envelope.x402Version, envelopeFrom, paymentHeader, selected: null };\n  }\n\n  // ---- BLOCK 4 — retry --------------------------------------------------\n  // In the live client this is where you sign the payment for `selected` and\n  // re-issue the request carrying it in `paymentHeader`.\n  return { paid: true, x402Version: envelope.x402Version, envelopeFrom, paymentHeader, selected };\n}\n\n// --- plumbing -------------------------------------------------------------\n\nconst B64_ALPHABET =\n  \"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/\";\n\nfunction base64ToUtf8(encoded: string): string {\n  const bytes: number[] = [];\n  let buffer = 0;\n  let bits = 0;\n  for (let i = 0; i < encoded.length; i++) {\n    const value = B64_ALPHABET.indexOf(encoded[i]);\n    if (value < 0) continue;\n    buffer = (buffer << 6) | value;\n    bits += 6;\n    if (bits >= 8) {\n      bits -= 8;\n      bytes.push((buffer >> bits) & 0xff);\n    }\n  }\n  return new TextDecoder().decode(new Uint8Array(bytes));\n}\n",
+        "starter": "// ---------------------------------------------------------------------------\n// COMPLETION EXERCISE — read a 402 challenge and decide how to pay it.\n//\n// The eight blocks inside handle402() are the ones you need, PLUS TWO THAT ARE\n// WRONG. They are commented out and in the wrong order, and the BLOCK numbers\n// are labels, not positions. Uncomment the six that belong, put them in the\n// order the protocol requires, and delete the two that do not.\n//\n// The lesson text tells you what the two wrong blocks get wrong. It does not\n// tell you the order.\n//\n// Pinned 2026-07-25: @x402/core 2.19.0, @x402/svm 2.19.0, @x402/fetch 2.19.0.\n// The grader has no module resolution and no network, so the two constants\n// below are written out and the HTTP responses are captured fixtures. In your\n// own client you import the constants and let wrapFetchWithPayment do the\n// round trip.\n// ---------------------------------------------------------------------------\n\nconst SOLANA_DEVNET_CAIP2 = \"solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1\";\nconst USDC_DEVNET_ADDRESS = \"4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU\";\n\ninterface Accept {\n  scheme: string;\n  network: string;\n  asset: string;\n  payTo: string;\n  maxAmountRequired: string;\n  resource: string;\n  description: string;\n  mimeType: string;\n  maxTimeoutSeconds: number;\n}\n\ninterface Report {\n  /** True only when a payable Solana-devnet-USDC entry was found. */\n  paid: boolean;\n  /** The wire version the server spoke: 1, 2, or null when there was no challenge. */\n  x402Version: number | null;\n  /** Where the envelope actually was. */\n  envelopeFrom: \"body\" | \"header\" | null;\n  /** The request header the retry must use. v1 says X-PAYMENT; v2 says PAYMENT. */\n  paymentHeader: \"X-PAYMENT\" | \"PAYMENT\" | null;\n  /** The accepts[] entry you will pay, or null. */\n  selected: Accept | null;\n}\n\ninterface CapturedResponse {\n  status: number;\n  /** Header names arrive lowercased, the way fetch's Headers normalises them. */\n  headers: Record<string, string>;\n  /** Raw response body. Empty string means the server sent no body at all. */\n  body: string;\n}\n\n/** Four real-shaped responses captured off the wire. */\nconst CAPTURES: Record<string, CapturedResponse> = {\n  // Not metered. No payment needed.\n  \"plain-200\": {\n    status: 200,\n    headers: { \"content-type\": \"application/json\" },\n    body: `{\"pair\":\"USDC/BRL\",\"rate\":\"5.41\"}`,\n  },\n\n  // A v1 server. Envelope in the body. The EVM entry is listed first.\n  \"v1-body\": {\n    status: 402,\n    headers: { \"content-type\": \"application/json\" },\n    body: `{\"x402Version\":1,\"error\":\"X-PAYMENT header is required\",\"accepts\":[{\"scheme\":\"exact\",\"network\":\"eip155:8453\",\"asset\":\"0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913\",\"payTo\":\"0x1a2B3c4D5e6F708192a3B4c5D6e7F8091A2b3C4d\",\"maxAmountRequired\":\"50000\",\"resource\":\"https://api.example.dev/digest\",\"description\":\"Daily market digest\",\"mimeType\":\"application/json\",\"maxTimeoutSeconds\":60},{\"scheme\":\"exact\",\"network\":\"solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1\",\"asset\":\"4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU\",\"payTo\":\"B7o8NfV81HzjuZFWQTTx3Xdvh77Dqoajwib3kWEnvzJF\",\"maxAmountRequired\":\"10000\",\"resource\":\"https://api.example.dev/quote\",\"description\":\"One FX quote\",\"mimeType\":\"application/json\",\"maxTimeoutSeconds\":60}]}`,\n  },\n\n  // A v2 server behind an edge layer that drops bodies on error statuses.\n  // EMPTY BODY. The whole envelope is base64 in the payment-required header.\n  // Its menu offers EVM, Solana mainnet, and Solana devnet — in that order.\n  \"v2-header\": {\n    status: 402,\n    headers: {\n      \"payment-required\":\n        \"eyJ4NDAyVmVyc2lvbiI6MiwiZXJyb3IiOiJwYXltZW50IHJlcXVpcmVkIiwiYWNjZXB0cyI6W3sic2NoZW1lIjoiZXhhY3QiLCJuZXR3b3JrIjoiZWlwMTU1Ojg0NTMiLCJhc3NldCI6IjB4ODMzNTg5ZkNENmVEYjZFMDhmNGM3QzMyRDRmNzFiNTRiZEEwMjkxMyIsInBheVRvIjoiMHgxYTJCM2M0RDVlNkY3MDgxOTJhM0I0YzVENmU3RjgwOTFBMmIzQzRkIiwibWF4QW1vdW50UmVxdWlyZWQiOiI1MDAwMCIsInJlc291cmNlIjoiaHR0cHM6Ly9hcGkuZXhhbXBsZS5kZXYvZGlnZXN0IiwiZGVzY3JpcHRpb24iOiJEYWlseSBtYXJrZXQgZGlnZXN0IiwibWltZVR5cGUiOiJhcHBsaWNhdGlvbi9qc29uIiwibWF4VGltZW91dFNlY29uZHMiOjYwfSx7InNjaGVtZSI6ImV4YWN0IiwibmV0d29yayI6InNvbGFuYTo1ZXlrdDRVc0Z2OFA4TkpkVFJFcFkxdnpxS3FaS3ZkcCIsImFzc2V0IjoiRVBqRldkZDVBdWZxU1NxZU0ycU4xeHp5YmFwQzhHNHdFR0drWnd5VER0MXYiLCJwYXlUbyI6IkI3bzhOZlY4MUh6anVaRldRVFR4M1hkdmg3N0Rxb2Fqd2liM2tXRW52ekpGIiwibWF4QW1vdW50UmVxdWlyZWQiOiI1MDAwMCIsInJlc291cmNlIjoiaHR0cHM6Ly9hcGkuZXhhbXBsZS5kZXYvZGlnZXN0IiwiZGVzY3JpcHRpb24iOiJEYWlseSBtYXJrZXQgZGlnZXN0IiwibWltZVR5cGUiOiJhcHBsaWNhdGlvbi9qc29uIiwibWF4VGltZW91dFNlY29uZHMiOjYwfSx7InNjaGVtZSI6ImV4YWN0IiwibmV0d29yayI6InNvbGFuYTpFdFdUUkFCWmFZcTZpTWZlWUtvdVJ1MTY2VlUyeHFhMSIsImFzc2V0IjoiNHpNTUM5c3J0NVJpNVgxNEdBZ1hoYUhpaTNHblBBRUVSWVBKZ1pKRG5jRFUiLCJwYXlUbyI6IkI3bzhOZlY4MUh6anVaRldRVFR4M1hkdmg3N0Rxb2Fqd2liM2tXRW52ekpGIiwibWF4QW1vdW50UmVxdWlyZWQiOiI1MDAwMCIsInJlc291cmNlIjoiaHR0cHM6Ly9hcGkuZXhhbXBsZS5kZXYvZGlnZXN0IiwiZGVzY3JpcHRpb24iOiJEYWlseSBtYXJrZXQgZGlnZXN0IiwibWltZVR5cGUiOiJhcHBsaWNhdGlvbi9qc29uIiwibWF4VGltZW91dFNlY29uZHMiOjYwfV19\",\n    },\n    body: \"\",\n  },\n\n  // A v2 server that only takes EVM money. Nothing here is payable by you.\n  \"v2-evm-only\": {\n    status: 402,\n    headers: {\n      \"payment-required\":\n        \"eyJ4NDAyVmVyc2lvbiI6MiwiZXJyb3IiOiJwYXltZW50IHJlcXVpcmVkIiwiYWNjZXB0cyI6W3sic2NoZW1lIjoiZXhhY3QiLCJuZXR3b3JrIjoiZWlwMTU1Ojg0NTMiLCJhc3NldCI6IjB4ODMzNTg5ZkNENmVEYjZFMDhmNGM3QzMyRDRmNzFiNTRiZEEwMjkxMyIsInBheVRvIjoiMHgxYTJCM2M0RDVlNkY3MDgxOTJhM0I0YzVENmU3RjgwOTFBMmIzQzRkIiwibWF4QW1vdW50UmVxdWlyZWQiOiI1MDAwMCIsInJlc291cmNlIjoiaHR0cHM6Ly9hcGkuZXhhbXBsZS5kZXYvZGlnZXN0IiwiZGVzY3JpcHRpb24iOiJEYWlseSBtYXJrZXQgZGlnZXN0IiwibWltZVR5cGUiOiJhcHBsaWNhdGlvbi9qc29uIiwibWF4VGltZW91dFNlY29uZHMiOjYwfV19\",\n    },\n    body: \"\",\n  },\n};\n\n/**\n * Decide what to do with a captured HTTP response.\n *\n * Six of the eight blocks below belong here. Two do not. Order matters —\n * every block after the first depends on a local the ones before it declare.\n */\nfunction handle402(captureId: string): Report {\n  const res = CAPTURES[captureId];\n\n  // ---- BLOCK 8 ----------------------------------------------------------\n  // const selected = envelope.accepts.find(\n  //   (entry: Accept) =>\n  //     entry.scheme === \"exact\" &&\n  //     entry.network === SOLANA_DEVNET_CAIP2 &&\n  //     entry.asset === USDC_DEVNET_ADDRESS\n  // );\n  // if (!selected) {\n  //   return { paid: false, x402Version: envelope.x402Version, envelopeFrom, paymentHeader, selected: null };\n  // }\n\n  // ---- BLOCK 3 ----------------------------------------------------------\n  // return {\n  //   paid: true,\n  //   x402Version: 2,\n  //   envelopeFrom: \"body\",\n  //   paymentHeader: \"PAYMENT\",\n  //   selected: JSON.parse(res.body).accepts[0],\n  // };\n\n  // ---- BLOCK 5 ----------------------------------------------------------\n  // if (res.status !== 402) {\n  //   return { paid: false, x402Version: null, envelopeFrom: null, paymentHeader: null, selected: null };\n  // }\n\n  // ---- BLOCK 1 ----------------------------------------------------------\n  // const paymentHeader: \"X-PAYMENT\" | \"PAYMENT\" =\n  //   envelope.x402Version === 1 ? \"X-PAYMENT\" : \"PAYMENT\";\n  // const envelopeFrom: \"header\" | \"body\" = fromHeader ? \"header\" : \"body\";\n\n  // ---- BLOCK 7 ----------------------------------------------------------\n  // const raw = fromHeader ? base64ToUtf8(headerEnvelope) : res.body;\n  // const envelope = JSON.parse(raw);\n\n  // ---- BLOCK 6 ----------------------------------------------------------\n  // const selected = envelope.accepts.find(\n  //   (entry: Accept) => entry.network.indexOf(\"eip155:\") === 0\n  // );\n\n  // ---- BLOCK 2 ----------------------------------------------------------\n  // const headerEnvelope = res.headers[\"payment-required\"];\n  // const fromHeader = res.body.length === 0 && typeof headerEnvelope === \"string\";\n\n  // ---- BLOCK 4 ----------------------------------------------------------\n  // return { paid: true, x402Version: envelope.x402Version, envelopeFrom, paymentHeader, selected };\n}\n\n// --- plumbing -------------------------------------------------------------\n// atob() and Buffer do not exist in this sandbox. Given, not scrambled.\n\nconst B64_ALPHABET =\n  \"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/\";\n\nfunction base64ToUtf8(encoded: string): string {\n  const bytes: number[] = [];\n  let buffer = 0;\n  let bits = 0;\n  for (let i = 0; i < encoded.length; i++) {\n    const value = B64_ALPHABET.indexOf(encoded[i]);\n    if (value < 0) continue;\n    buffer = (buffer << 6) | value;\n    bits += 6;\n    if (bits >= 8) {\n      bits -= 8;\n      bytes.push((buffer >> bits) & 0xff);\n    }\n  }\n  return new TextDecoder().decode(new Uint8Array(bytes));\n}\n",
+        "tests": [
+          {
+            "description": "A 200 is not a challenge — nothing is decoded and nothing is paid",
+            "expectedOutput": "result.paid === false && result.x402Version === null && result.envelopeFrom === null && result.paymentHeader === null && result.selected === null",
+            "id": "t1",
+            "input": "'plain-200'"
+          },
+          {
+            "description": "v1 server: envelope read from the body, retry uses the X-PAYMENT header",
+            "expectedOutput": "result.paid === true && result.x402Version === 1 && result.envelopeFrom === 'body' && result.paymentHeader === 'X-PAYMENT'",
+            "id": "t2",
+            "input": "'v1-body'"
+          },
+          {
+            "description": "v1 server: the Solana devnet USDC entry is selected, not the EVM entry at accepts[0]",
+            "expectedOutput": "result.selected.network === 'solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1' && result.selected.asset === '4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU' && result.selected.maxAmountRequired === '10000'",
+            "id": "t3",
+            "input": "'v1-body'"
+          },
+          {
+            "description": "v2 server with an empty body: envelope read from the payment-required header, retry uses PAYMENT",
+            "expectedOutput": "result.paid === true && result.x402Version === 2 && result.envelopeFrom === 'header' && result.paymentHeader === 'PAYMENT'",
+            "id": "t4",
+            "input": "'v2-header'"
+          },
+          {
+            "description": "v2 server: devnet is picked over the mainnet entry that shares the same scheme",
+            "expectedOutput": "result.selected.network === 'solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1' && result.selected.asset === '4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU' && result.selected.maxAmountRequired === '50000'",
+            "id": "t5",
+            "input": "'v2-header'"
+          },
+          {
+            "description": "A challenge with no payable Solana entry is decoded and reported, not paid",
+            "expectedOutput": "result.paid === false && result.selected === null && result.x402Version === 2 && result.envelopeFrom === 'header' && result.paymentHeader === 'PAYMENT'",
+            "id": "t6",
+            "input": "'v2-evm-only'"
+          }
+        ]
+      },
+      {
+        "_key": "check",
+        "_type": "quiz",
+        "questions": [
+          {
+            "explanation": "A correct client reads both places. A correct server emits both places. You wrote the server half last lesson; this is the client half.",
+            "id": "q1",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "`JSON.parse(\"\")` throws. The envelope is base64 in the `PAYMENT-REQUIRED` response header — read the body, and fall back to the header when it is empty."
+              },
+              {
+                "correct": false,
+                "feedback": "It is legal and common. Edge layers in front of Vercel-hosted servers drop bodies on error statuses, so the envelope moves to a header. This is the single most frequent x402 integration failure.",
+                "id": "b",
+                "label": "The server is broken; the envelope is always in the body. Report a bug."
+              },
+              {
+                "correct": false,
+                "feedback": "Retrying a bare request gets you the same 402. Nothing about the response changes until you send a payment.",
+                "id": "c",
+                "label": "The 402 has no envelope, so retry the request until one arrives."
+              },
+              {
+                "correct": false,
+                "feedback": "`res.json()` on an empty body throws too. Changing the parser does not conjure a body that was never sent.",
+                "id": "d",
+                "label": "Use `res.json()` instead of `res.text()`; it handles the empty case."
+              }
+            ],
+            "prompt": "Your client calls a metered route. It gets back HTTP 402 with `content-length: 0` and an empty body. Your code does `JSON.parse(await res.text())`. Predict the failure and the fix."
+          },
+          {
+            "explanation": "This is the difference between a client that works for a year and one that works until the first server you did not test against. Read the version off the envelope; do not assume it.",
+            "id": "q2",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "Because v1 and v2 are both live on the wire right now. Servers on the frozen 1.2.0 packages still speak v1, with different header names and different envelope fields."
+              },
+              {
+                "correct": false,
+                "feedback": "It is there because you will meet v1 servers. Registering only the v2 scheme means silently failing against every server still on the frozen package line.",
+                "id": "b",
+                "label": "`ExactSvmSchemeV1` is deprecated dead code kept for the type definitions."
+              },
+              {
+                "correct": false,
+                "feedback": "The token program is a property of the mint named in `asset`, not of the scheme. The `V1` suffix is the protocol version.",
+                "id": "c",
+                "label": "One is for Token, the other for Token-2022."
+              },
+              {
+                "correct": false,
+                "feedback": "The network is a field in the challenge (`network`), not a separate scheme export.",
+                "id": "d",
+                "label": "One is for devnet, the other for mainnet."
+              }
+            ],
+            "prompt": "`@x402/svm@2.19.0` exports both `ExactSvmScheme` and `ExactSvmSchemeV1`. Why?"
+          },
+          {
+            "explanation": "`accepts[]` is a menu. Filter it on `scheme`, `network` and `asset`, and treat \"no match\" as a normal, reportable outcome — not a crash.",
+            "id": "q3",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "A client that tries to pay on Base. Ordering in `accepts[]` is the server's preference, not your capability — you have to filter on network and asset."
+              },
+              {
+                "correct": false,
+                "feedback": "Nothing in the protocol orders `accepts[]` by price, and nothing guarantees the first entry is even on a chain you can use.",
+                "id": "b",
+                "label": "A client that pays correctly, since servers list the cheapest option first."
+              },
+              {
+                "correct": false,
+                "feedback": "`accepts[0]` here is the EVM entry. Both Solana entries are further down the list, which is exactly why indexing is the bug.",
+                "id": "c",
+                "label": "A client that pays on Solana mainnet."
+              },
+              {
+                "correct": false,
+                "feedback": "Selection is the client's job. Nothing downstream will tell you that you picked terms you cannot satisfy — you will simply fail to produce a valid payment.",
+                "id": "d",
+                "label": "A client that fails safely, because the scheme validates the chain for you."
+              }
+            ],
+            "prompt": "A challenge's `accepts[]` is `[eip155:8453 USDC, solana-mainnet USDC, solana-devnet USDC]`. You hold devnet USDC. Your code does `const terms = envelope.accepts[0]`. What have you built?"
+          },
+          {
+            "explanation": "Header names are part of what changed between versions, which is why you read the version before you build the retry — not after.",
+            "id": "q4",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "`X-PAYMENT`"
+              },
+              {
+                "correct": false,
+                "feedback": "That is the v2 name. Sending it to a v1 server means the server sees no payment at all.",
+                "id": "b",
+                "label": "`PAYMENT`"
+              },
+              {
+                "correct": false,
+                "feedback": "That is a RESPONSE header — the fallback location for the challenge the server sends you. It never carries your payment.",
+                "id": "c",
+                "label": "`PAYMENT-REQUIRED`"
+              },
+              {
+                "correct": false,
+                "feedback": "x402 does not reuse the auth header. Payment is its own header.",
+                "id": "d",
+                "label": "`Authorization`"
+              }
+            ],
+            "prompt": "You decoded an envelope carrying `\"x402Version\": 1`. Which request header must your retry use to carry the payment?"
+          }
+        ]
+      }
+    ],
+    "skills": [
+      "x402-protocol",
+      "protocol-versioning",
+      "solana-kit"
+    ],
+    "slug": {
+      "_type": "slug",
+      "current": "pay-the-402-programmatically"
+    },
+    "title": "Reading a Challenge and Paying It"
+  },
+  {
+    "_id": "lesson-sap-payment-rails-decision-map",
+    "_type": "lesson",
+    "blocks": [
+      {
+        "_key": "intro",
+        "_type": "prose",
+        "src": "# Which Rail, and Is It Legal Where You Are\n\n> **Version stamp — checked 2026-07-25.** `@solana/kit@7.0.0` · `@solana/subscriptions@0.4.0` (exact) · `@x402/core`, `@x402/svm`, `@x402/express`, `@x402/fetch` all `2.19.0`. Subscriptions Delegation Program: `De1egAFMkMWZSN5rYXRj9CAdheBamobVNubTsi9avR44`. This course is TypeScript only — no Rust, no local toolchain.\n\nYou finished Course 4 with a deployed app and a published client. It earns nothing.\n\nNothing in it charges anybody. There is no subscription, no metered route, no allowance, no invoice. This module fixes exactly that, and the first decision is not a line of code — it is which payment rail your requirement actually needs, because picking the wrong one costs you a rewrite three lessons later.\n\nThere are three rails worth knowing on Solana today, and one legal boundary that decides whether a requirement is even buildable from Brazil.\n\n## Rail 1 — the Subscriptions Delegation Program\n\nProgram id `De1egAFMkMWZSN5rYXRj9CAdheBamobVNubTsi9avR44`. Audited, shared (you do not deploy it — you call it), live on mainnet since 2026-06-02. It exists because of a limitation in the SPL token model that you will hit the moment you try to build a paid tier by hand:\n\n**A token account can have exactly one approved delegate.**\n\nApprove your subscription contract as the delegate for the user's USDC account and you have burned the only slot. That user can now never hold an allowance for an agent, or a merchant agreement, or a second subscription, on the same mint. The Subscriptions program's answer is a program-controlled **Subscription Authority** PDA per `(user, mint)` pair: the user approves the authority once, and the authority then hands out as many independently-capped delegations as the user wants. One approval, many budgets. That is lesson 3.\n\nOn top of that authority the program offers three models:\n\n| Model                    | Cap behaviour                                              | Use it for                                            |\n| ------------------------ | ---------------------------------------------------------- | ----------------------------------------------------- |\n| **Fixed delegation**     | One capped **total**. Draws down and does not refill.      | An allowance. An agent's budget. A prepaid balance.   |\n| **Recurring delegation** | Cap **resets every period**. Unused periods do not stack.  | Payroll, contractor payouts, a monthly paid tier.     |\n| **Subscription plan**    | Merchant publishes terms; approved pullers collect.        | A published price list many customers subscribe to.   |\n\nYou build a fixed delegation in lesson 3 and a recurring delegation in lesson 4. The fixed delegation from lesson 3 is the same object that becomes your agent's spending cap in lesson 7 — it is not a throwaway exercise.\n\n## Rail 2 — Solana Pay\n\nA human, a QR code, one payment, done. Point-of-sale and checkout. It carries no cap, no schedule and no delegation, because there is nothing to authorise ahead of time: the payer is standing there approving the transfer.\n\n**You will not install it in this course, and that is a deliberate decision, not an omission.**\n\n`@solana/kit@7.0.0` shipped on 2026-06-30. Most of the payments ecosystem has not caught up yet, and the peer ranges are worth reading rather than guessing. Off the published manifests on 2026-07-25:\n\n| Package | Peer range on `@solana/kit` | Admits 7.0.0? |\n| --- | --- | --- |\n| `@x402/svm@2.19.0` | `>=5.1.0` | yes |\n| `@solana/subscriptions@0.4.0` | `^6.4.0` | no |\n| `@solana/pay@1.0.23` | `^6.9.0` | no |\n\nSo the honest position is not \"Solana Pay is broken and the others are fine\". Two of the three rails declare a kit-6 peer, and pinning `@solana/kit@7.0.0` means carrying a **documented peer-dependency override** for the Subscriptions half. We take that override because Subscriptions is load-bearing for this entire module — you cannot build a paid tier without it. We do not take a second one for a rail we only need as a *decision*, especially when `@solana/pay` also peers `@solana-program/token ^0.12.0` against `@x402/svm`'s `^0.9.0` — disjoint ranges, and peers are yours to satisfy.\n\nName the seam. Pin the versions. Write down which override you took and why. That habit is worth more than the rail.\n\nSolana Pay is on your decision map as an **answer**; it is not on your `package.json`.\n\nRead the current reference at `solana.com/docs/payments`. Do **not** use `solana.com/developers/payments` — at time of writing it still quotes USDC statistics dated 1/31/22 and a Shopify integration that has moved on.\n\n## Rail 3 — x402\n\nAn HTTP status code turned into a payment protocol. The client calls your route, the server answers `402 Payment Required` with a machine-readable challenge naming the network, the asset and the address to pay, the client pays and retries with a payment header, the server settles and serves the response. Stateless, per request, no account relationship at all.\n\nThat property is exactly what makes it the agent rail: an autonomous caller with no login and no card can discover a price and satisfy it inside one request cycle. Module 2 is x402 end to end.\n\n## The legal boundary — BCB Resolution 561\n\nIf you are building from Brazil, this is the constraint no English-language Solana course is going to tell you about.\n\n**Banco Central do Brasil Resolution 561** was published 2026-04-30 and takes effect **2026-10-01**. Its practical rule for our purposes:\n\n> A regulated eFX provider may **not** take reais, convert them to USDT / USDC / BTC, and settle the resulting obligation abroad on-chain.\n\nThat closes a specific pattern — using stablecoins as the cross-border settlement leg of a foreign-exchange operation — for regulated operators. It does **not** close crypto in Brazil. Individuals may still buy, sell, hold and transfer through authorised VASPs.\n\nWhat stays open, and what this whole course is scoped to:\n\n- **Domestic merchant acceptance** — a Brazilian business charging a Brazilian customer.\n- **Contractor payouts.**\n- **Subscriptions** — the paid tier you build in this module.\n- **Agent budgets** — the allowance you cap in module 2.\n\nEvery example in this course sits inside that box. If a requirement's settlement leg is a regulated cross-border FX conversion, the correct engineering answer is **not a rail** — it is \"this is out of scope for the entity as regulated,\" and you route it to compliance before you route it to a program id.\n\n**Which is why the compliance check runs first.** A decision function that reaches \"recurring delegation\" and only afterwards asks \"wait, is this allowed?\" has already told a product manager to build the wrong thing. Compliance is a gate, not a fallback branch.\n\n## The worked example\n\nBelow is the full decision map, annotated. Read it, then make exactly one change.\n\nThe function takes a requirement described by three facts and returns a rail name:\n\n| Parameter                 | Values                                                          |\n| ------------------------- | --------------------------------------------------------------- |\n| `cadence`                 | `one-off` · `per-request` · `periodic` · `capped-total`          |\n| `settlement`              | `domestic-br` · `cross-border-fx` · `n-a`                        |\n| `merchantPublishesTerms`  | `true` when the merchant publishes a plan customers subscribe to |\n\nand the rail names it can return:\n\n- `blocked-by-bcb-561` — the compliance stop\n- `solana-pay` — human, one-off, standing there\n- `x402` — priced per request\n- `subscription-plan` — published terms, approved pullers collect\n- `recurring-delegation` — cap resets per period\n- `fixed-delegation` — one capped total, drawn down\n- `unsupported` — a cadence the map does not model; fail loudly rather than guess\n\nThe starter is complete and correct except for one thing: **the compliance guard is at the bottom instead of the top.** Every requirement with `settlement === \"cross-border-fx\"` and a cadence the map understands will be answered with a rail before the guard is ever reached. Move the guard so it runs before any rail is chosen. That is the whole edit.\n"
+      },
+      {
+        "_key": "decision-map",
+        "_type": "code",
+        "buildType": "standard",
+        "deployable": false,
+        "hints": [
+          "The branches are all correct. Only their order is wrong.",
+          "A stop that runs after every rail has already returned never stops anything.",
+          "Move the `settlement === \"cross-border-fx\"` block above the `per-request` check."
+        ],
+        "language": "typescript",
+        "solution": "/**\n * The payment-rail decision map.\n *\n * The compliance gate runs FIRST. A requirement whose settlement leg is a\n * regulated cross-border FX conversion has no rail — it has a stop.\n */\nfunction chooseRail(\n  cadence: string,\n  settlement: string,\n  merchantPublishesTerms: boolean\n): string {\n  // BCB Resolution 561 (published 2026-04-30, effective 2026-10-01): a\n  // regulated eFX provider may not take reais, convert to USDT/USDC/BTC and\n  // settle abroad on-chain. Gate, not fallback.\n  if (settlement === \"cross-border-fx\") {\n    return \"blocked-by-bcb-561\";\n  }\n\n  // Priced per HTTP request, no account relationship, caller may be a machine.\n  // -> x402. Module 2 builds this end to end.\n  if (cadence === \"per-request\") {\n    return \"x402\";\n  }\n\n  // Charged again every period. If the merchant publishes terms that many\n  // customers subscribe to, that is a subscription plan; if you are charging\n  // your own users on your own schedule, it is a recurring delegation whose\n  // cap resets each period.\n  if (cadence === \"periodic\") {\n    return merchantPublishesTerms ? \"subscription-plan\" : \"recurring-delegation\";\n  }\n\n  // One capped total, drawn down over many pulls, no refill. An allowance.\n  // This is the agent budget in lesson 7.\n  if (cadence === \"capped-total\") {\n    return \"fixed-delegation\";\n  }\n\n  // A human approving a single transfer at a checkout. No cap and no schedule\n  // to authorise, because the payer is present. -> Solana Pay (as a decision;\n  // @solana/pay@1.0.23 peer-depends on @solana/kit ^6.9.0 and this course\n  // pins @solana/kit@7.0.0, so it is not installed here).\n  if (cadence === \"one-off\") {\n    return \"solana-pay\";\n  }\n\n  // A cadence the map does not model. Fail loudly instead of guessing a rail.\n  return \"unsupported\";\n}\n",
+        "starter": "/**\n * The payment-rail decision map.\n *\n * WORKED EXAMPLE — this code is complete and every branch below is correct.\n * There is exactly one thing wrong with it, and it is not a branch: it is the\n * ORDER. See the note at the bottom of the function.\n */\nfunction chooseRail(\n  cadence: string,\n  settlement: string,\n  merchantPublishesTerms: boolean\n): string {\n  // Priced per HTTP request, no account relationship, caller may be a machine.\n  // -> x402. Module 2 builds this end to end.\n  if (cadence === \"per-request\") {\n    return \"x402\";\n  }\n\n  // Charged again every period. If the merchant publishes terms that many\n  // customers subscribe to, that is a subscription plan; if you are charging\n  // your own users on your own schedule, it is a recurring delegation whose\n  // cap resets each period.\n  if (cadence === \"periodic\") {\n    return merchantPublishesTerms ? \"subscription-plan\" : \"recurring-delegation\";\n  }\n\n  // One capped total, drawn down over many pulls, no refill. An allowance.\n  // This is the agent budget in lesson 7.\n  if (cadence === \"capped-total\") {\n    return \"fixed-delegation\";\n  }\n\n  // A human approving a single transfer at a checkout. No cap and no schedule\n  // to authorise, because the payer is present. -> Solana Pay (as a decision;\n  // @solana/pay@1.0.23 peer-depends on @solana/kit ^6.9.0 and this course\n  // pins @solana/kit@7.0.0, so it is not installed here).\n  if (cadence === \"one-off\") {\n    return \"solana-pay\";\n  }\n\n  // ⚠️ THIS GUARD IS IN THE WRONG PLACE.\n  //\n  // BCB Resolution 561 (published 2026-04-30, effective 2026-10-01) closes the\n  // pattern where a regulated eFX provider takes reais, converts to a\n  // stablecoin and settles the obligation abroad on-chain. That is a stop, not\n  // a rail — and a stop that runs after the rails have already answered never\n  // stops anything.\n  //\n  // YOUR EDIT: move this block so it runs before any rail is chosen.\n  if (settlement === \"cross-border-fx\") {\n    return \"blocked-by-bcb-561\";\n  }\n\n  // A cadence the map does not model. Fail loudly instead of guessing a rail.\n  return \"unsupported\";\n}\n",
+        "tests": [
+          {
+            "description": "A human paying once at a checkout maps to Solana Pay",
+            "expectedOutput": "result === 'solana-pay'",
+            "id": "t1",
+            "input": "'one-off', 'domestic-br', false"
+          },
+          {
+            "description": "A price on a single HTTP request maps to x402",
+            "expectedOutput": "result === 'x402'",
+            "id": "t2",
+            "input": "'per-request', 'domestic-br', false"
+          },
+          {
+            "description": "Charging your own users on your own schedule is a recurring delegation",
+            "expectedOutput": "result === 'recurring-delegation'",
+            "id": "t3",
+            "input": "'periodic', 'domestic-br', false"
+          },
+          {
+            "description": "Published terms that customers subscribe to is a subscription plan",
+            "expectedOutput": "result === 'subscription-plan'",
+            "id": "t4",
+            "input": "'periodic', 'domestic-br', true"
+          },
+          {
+            "description": "One capped total drawn down over many pulls is a fixed delegation",
+            "expectedOutput": "result === 'fixed-delegation'",
+            "id": "t5",
+            "input": "'capped-total', 'domestic-br', false"
+          },
+          {
+            "description": "Cross-border FX settlement is stopped even when the cadence has a rail",
+            "expectedOutput": "result === 'blocked-by-bcb-561'",
+            "id": "t6",
+            "input": "'periodic', 'cross-border-fx', false"
+          },
+          {
+            "description": "The compliance gate outranks x402 too",
+            "expectedOutput": "result === 'blocked-by-bcb-561'",
+            "id": "t7",
+            "input": "'per-request', 'cross-border-fx', true"
+          },
+          {
+            "description": "An unmodelled cadence fails loudly instead of guessing",
+            "expectedOutput": "result === 'unsupported'",
+            "id": "t8",
+            "input": "'annual-invoice', 'domestic-br', false"
+          }
+        ]
+      },
+      {
+        "_key": "check",
+        "_type": "quiz",
+        "questions": [
+          {
+            "explanation": "BCB Resolution 561 (published 2026-04-30, effective 2026-10-01) closes reais → stablecoin → offshore settlement for regulated eFX providers. Domestic merchant acceptance, contractor payouts, subscriptions and agent budgets stay open, and individuals may still transact through authorised VASPs.",
+            "id": "q1",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "`blocked-by-bcb-561` — the settlement leg is a regulated cross-border FX conversion, so no rail applies"
+              },
+              {
+                "correct": false,
+                "feedback": "The cadence would fit, which is exactly the trap. The compliance gate runs before cadence is ever consulted, because the question \"is this allowed for this entity\" outranks \"which rail is convenient\".",
+                "id": "b",
+                "label": "`solana-pay` — it is a single transfer, so the one-off rail fits"
+              },
+              {
+                "correct": false,
+                "feedback": "Capping the amount does not change the nature of the operation. Resolution 561 closes the pattern, not a size of it.",
+                "id": "c",
+                "label": "`fixed-delegation` — cap the total the provider can convert and the exposure is bounded"
+              },
+              {
+                "correct": false,
+                "feedback": "`unsupported` means \"I do not model this cadence\". This case is modelled: it is stopped, and saying so precisely is the point.",
+                "id": "d",
+                "label": "`unsupported` — the map has no cadence for FX"
+              }
+            ],
+            "prompt": "A regulated Brazilian eFX provider wants to take reais from a client, convert them to USDC, and settle the client's obligation to a supplier abroad on-chain. It is 2026-11-01. What does your decision map return, and why?"
+          },
+          {
+            "id": "q2",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "x402 — the price travels in a 402 response and the caller satisfies it in the same request cycle"
+              },
+              {
+                "correct": false,
+                "feedback": "A delegation needs a prior on-chain relationship with each payer. These callers have none, which is the whole reason a stateless per-request challenge exists.",
+                "id": "b",
+                "label": "A recurring delegation, billed monthly for the calls made"
+              },
+              {
+                "correct": false,
+                "feedback": "That is the right answer for a published price list with an onboarding step. It is the wrong answer for an anonymous script that wants one response now.",
+                "id": "c",
+                "label": "A subscription plan the callers subscribe to"
+              },
+              {
+                "correct": false,
+                "feedback": "Solana Pay assumes a human is present to approve. Nobody is scanning a QR code inside a script's retry loop.",
+                "id": "d",
+                "label": "Solana Pay, generating a QR per call"
+              }
+            ],
+            "prompt": "Your API charges $0.002 per call. Callers are other people's scripts; they have no account with you and never will. Which rail?"
+          },
+          {
+            "id": "q3",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "50 USDC — the cap resets each period and skipped periods do not accumulate"
+              },
+              {
+                "correct": false,
+                "feedback": "This is the single most common wrong mental model of the recurring model, and lesson 4 grades you on it. Unused periods are lost, not banked.",
+                "id": "b",
+                "label": "150 USDC — three periods of unused cap are now available"
+              },
+              {
+                "correct": false,
+                "feedback": "Nothing is voided. The delegation stays live until it expires or is revoked; only the unused capacity is gone.",
+                "id": "c",
+                "label": "0 USDC — missing a period voids the delegation"
+              },
+              {
+                "correct": false,
+                "feedback": "No period carries. The cap is per period, full stop.",
+                "id": "d",
+                "label": "100 USDC — the two skipped periods carry, the current one does not"
+              }
+            ],
+            "prompt": "A recurring delegation is capped at 50 USDC per month. The merchant forgets to collect in March and April, then collects in May. How much can it pull in May?"
+          },
+          {
+            "explanation": "`@solana/subscriptions@0.4.0` declares the same shape of peer (`^6.4.0`), so this course carries one documented override for the rail it cannot do without, and declines a second for a rail it only needs as a decision. Naming the version seam is more useful than pretending one lockfile serves every rail.",
+            "id": "q4",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "A peer-dependency conflict — `@solana/pay` declares `@solana/kit ^6.9.0`, which does not admit a 7.x"
+              },
+              {
+                "correct": false,
+                "feedback": "A caret pins the major. `^6.9.0` means \">=6.9.0 <7.0.0\". This is the exact seam that keeps Solana Pay off this course's dependency tree.",
+                "id": "b",
+                "label": "It installs cleanly; `^6.9.0` covers everything from 6.9 upward including 7.0"
+              },
+              {
+                "correct": false,
+                "feedback": "npm has installed peers automatically and errored on unsatisfiable ones since v7. You get a resolution error unless you override it deliberately.",
+                "id": "c",
+                "label": "It installs cleanly because peer dependencies are advisory and never fail an install"
+              },
+              {
+                "correct": false,
+                "feedback": "A package manager will not rewrite your direct dependency to satisfy someone else's peer range. It reports the conflict.",
+                "id": "d",
+                "label": "`@solana/kit` is silently downgraded to 6.9.0 for the whole project"
+              }
+            ],
+            "prompt": "You add `@solana/pay@1.0.23` to a project that already pins `@solana/kit@7.0.0`. Predict what happens at install time."
+          }
+        ]
+      }
+    ],
+    "skills": [
+      "payment-model-selection",
+      "solana-pay",
+      "x402-protocol",
+      "brazil-compliance"
+    ],
+    "slug": {
+      "_type": "slug",
+      "current": "payment-rails-decision-map"
+    },
+    "title": "Which Rail, and Is It Legal Where You Are"
+  },
+  {
+    "_id": "lesson-sap-recurring-delegation-paid-tier",
+    "_type": "lesson",
+    "blocks": [
+      {
+        "_key": "intro",
+        "_type": "prose",
+        "src": "# Charge Every Month, Cap Every Month\n\n> **Version stamp — checked 2026-07-25.** `@solana/subscriptions@0.4.0` **exactly** · `@solana/kit@7.0.0`. Program: `De1egAFMkMWZSN5rYXRj9CAdheBamobVNubTsi9avR44`.\n\nThe fixed delegation you opened in lesson 3 is a budget: one total, drawn down, gone. A paid tier is a different shape. You want to charge 25 USDC this month, 25 USDC next month, and never more than 25 USDC in any month no matter how many times your billing job runs.\n\nThat is a **recurring delegation**, and its three semantics are the whole lesson.\n\n## Opening it\n\n```ts\nawait client.subscriptions.instructions\n  .createRecurringDelegation({\n    tokenMint,\n    delegatee: merchantAddress,\n    nonce: 1n,\n    amountPerPeriod: 25_000_000n,        // base units, as a bigint\n    periodLengthS: BigInt(30 * 24 * 3600),\n    startTs: 0n,                          // start when the transaction lands\n    expiryTs: BigInt(Math.floor(Date.now() / 1000) + 365 * 24 * 3600),\n  })\n  .sendTransaction();\n```\n\nSame authority, same `(user, tokenMint)` pair, different **nonce** — which is exactly the \"one approval, many budgets\" property doing its job. The lesson-3 fixed delegation is still open and untouched.\n\n`startTs: 0n` means \"the first period begins when this lands\". That convenience has a rule attached: **start-on-landing requires a non-zero `expiryTs`.** Pass both as zero and the program refuses with *\"start_ts of 0 (start on landing) requires a non-zero expiry\"* — an open-ended pull authorisation with no defined start is not something it will sign off on.\n\n## Collecting\n\n```ts\nawait client.subscriptions.instructions\n  .transferRecurring({\n    delegationPda,\n    delegator: userAddress,     // Address — the user is not here\n    delegatorAta: userAta,\n    receiverAta: merchantAta,\n    tokenMint,\n    tokenProgram,\n    amount: 25_000_000n,\n  })\n  .sendTransaction();\n```\n\n`transferRecurring` takes the identical input type as `transferFixed`. Same signing model, and it is worth saying again because it is the security point of this whole module:\n\n> **The user signs the setup and the revoke. The delegatee signs the transfers.**\n\n`delegator` is an `Address`; `delegatee` is a `TransactionSigner`. Your billing job holds the delegatee key. It cannot exceed the cap, it cannot extend the expiry, and it cannot stop the user revoking. Those three facts are what let you run it unattended.\n\n## The three semantics that must stick\n\n### 1. A second pull inside the same period fails\n\nCharge 25 USDC on the 3rd. Charge 1 more USDC on the 4th, same period. The program returns `AMOUNT_EXCEEDS_PERIOD_LIMIT` — *\"Transfer amount exceeds period limit\"*.\n\nThis is a feature, and it is the one your retry logic depends on. A billing job that crashes after the transfer landed but before it wrote its own record will retry. The retry is refused. The cap **is** your idempotency guard, as long as you read the error and treat it as \"already collected\" rather than \"temporary failure, back off and try again in five minutes\" for the rest of the month.\n\nNote the neighbouring error you will also meet: `PERIOD_NOT_ELAPSED` — *\"Period has not elapsed yet\"* — which is what you get when you try to collect for a period that has not started.\n\n### 2. The cap resets on period rollover\n\nOnce the clock crosses into the next period, the full `amountPerPeriod` is available again. Nothing is carried, nothing is prorated, and you do not call anything to make it happen. There is no \"renew\" instruction because there is nothing to renew.\n\n### 3. Skipped periods do not accumulate\n\nThis is the one that surprises people, and it is the one the exercise grades hardest.\n\nA merchant who forgets to collect in March and April does not get to collect 75 USDC in May. They get 25 USDC in May. **The unused capacity is gone.** The cap is a per-period ceiling, not an accruing balance.\n\nRead it from the user's side and it is obviously correct: they authorised \"up to 25 per month\", not \"up to 25 per month, banked indefinitely, redeemable in a lump sum by whoever holds the delegatee key\". The second thing would be a much larger authorisation wearing the first one's clothes.\n\nIf your business needs missed periods to be collectable, that is an invoice, and you build it in your own system. The delegation will not do it for you.\n\n## Revoking\n\n```ts\nawait client.subscriptions.instructions\n  .revokeDelegation({ delegationAccount: delegationPda })\n  .sendTransaction();\n```\n\nThe `authority` — the user — signs, and is filled from the configured signer. This **closes the PDA** and returns its rent. Pass `receiver` when somebody other than the user funded it.\n\nRevocation is permanent for that delegation. There is no pause. Re-establishing the arrangement means a new `createRecurringDelegation` with a new nonce, signed by the user, which means the user is present and consenting again. That is the correct trade.\n\n## The exercise — put the pieces in order\n\nThe starter contains the body of the period-accounting function, but scrambled: **three candidate lines for the available amount, of which one is right, and two return statements in the wrong order.** Only one candidate line is active.\n\nTwo decoys, both of which are real mistakes people ship:\n\n- **Decoy A — the cap that never resets.** `periodLimit - chargedInCurrentPeriod`, unconditionally. It ignores the rollover entirely, so the delegation works for exactly one period and then quietly refuses everything forever. This is the same class of error as revoking before collecting: an operation that looks correct in the happy path and destroys the arrangement on the second cycle.\n- **Decoy B — the accumulating cap.** `periodLimit * (currentPeriod - lastChargedPeriod + 1) - chargedInCurrentPeriod`. This one is worse, because it is *nearly* right: it agrees with the correct answer on every test where no period was skipped. It only diverges when a merchant comes back after missing a few — which is exactly the case where it lets them take money the user never authorised. This is the fixed-delegation model smuggled into a recurring PDA.\n\nThe ordering error matters too: if the success return runs before the over-cap guard, the guard is unreachable and every request is approved.\n\nAmounts here are plain integer base units so the arithmetic is legible. In your real client they are `bigint`, converted once, exactly as in lesson 3.\n\n## Milestone — write these down\n\nBefore you move to module 2, do this on devnet and keep the output:\n\n1. The **recurring delegation PDA** you created.\n2. The **settlement signature** of the charge that succeeded.\n3. The **error** you got when you collected a second time inside the same period.\n\nLesson 8 asks you to publish a deep dive with a reproducible run, and these three artifacts are the run. A screenshot of the second attempt failing with `AMOUNT_EXCEEDS_PERIOD_LIMIT` is worth more than a paragraph claiming it does.\n\n## Optional: where a revenue dashboard would come from\n\nThe program emits its state changes as Anchor-compatible **self-CPI inner instructions** through an event-authority PDA — `findEventAuthorityPda`, seed `\"event_authority\"` — and validates them on the way out with `INVALID_EVENT_AUTHORITY`, `INVALID_EVENT_TAG` and `INVALID_EVENT_DISCRIMINATOR`. An indexer that watches inner instructions for that authority sees every delegation created, every transfer settled and every revoke, per user, in order.\n\nThat is how you would build merchant revenue reporting. **Do not build it here.** It is a different course, and this one has an agent to fund.\n"
+      },
+      {
+        "_key": "collect",
+        "_type": "code",
+        "buildType": "standard",
+        "deployable": false,
+        "hints": [
+          "Nothing needs to be written. Pick the right `available` candidate and move the guard above the success return.",
+          "Candidate 2 passes every test where no period was skipped. That is what makes it a decoy rather than an obvious error — look at the case where `currentPeriod - lastChargedPeriod` is greater than 1.",
+          "A guard placed after an unconditional return never executes."
+        ],
+        "language": "typescript",
+        "solution": "/**\n * One collection attempt against a recurring delegation.\n *\n * The whole model is in the `available` expression: on a period rollover the\n * cap is the full period limit again (semantic 2), and it is the full period\n * limit no matter how many periods were skipped (semantic 3).\n */\nfunction collectRecurring(\n  periodLimitBaseUnits: number,\n  currentPeriod: number,\n  lastChargedPeriod: number,\n  chargedInCurrentPeriod: number,\n  requestBaseUnits: number\n): {\n  ok: boolean;\n  error: string;\n  charged: number;\n  remainingThisPeriod: number;\n} {\n  const available =\n    currentPeriod > lastChargedPeriod\n      ? periodLimitBaseUnits\n      : periodLimitBaseUnits - chargedInCurrentPeriod;\n\n  const overCap = requestBaseUnits > available;\n\n  // The guard runs first, or it does not run at all.\n  if (overCap) {\n    return {\n      ok: false,\n      error: \"AMOUNT_EXCEEDS_PERIOD_LIMIT\",\n      charged: 0,\n      remainingThisPeriod: available,\n    };\n  }\n\n  return {\n    ok: true,\n    error: \"\",\n    charged: requestBaseUnits,\n    remainingThisPeriod: available - requestBaseUnits,\n  };\n}\n",
+        "starter": "/**\n * One collection attempt against a recurring delegation.\n *\n * Every line you need is already below. Two of the three `available` candidates\n * are decoys, and the guard sits below the success return instead of above it.\n * Rearrange; do not rewrite.\n *\n * @param periodLimitBaseUnits   amountPerPeriod, in base units\n * @param currentPeriod          index of the period the clock is in now\n * @param lastChargedPeriod      index of the period of the last successful pull\n * @param chargedInCurrentPeriod already collected inside `currentPeriod`\n * @param requestBaseUnits       what this attempt is asking for\n */\nfunction collectRecurring(\n  periodLimitBaseUnits: number,\n  currentPeriod: number,\n  lastChargedPeriod: number,\n  chargedInCurrentPeriod: number,\n  requestBaseUnits: number\n): {\n  ok: boolean;\n  error: string;\n  charged: number;\n  remainingThisPeriod: number;\n} {\n  // --- candidate 1 ----------------------------------------------------------\n  // The cap that never resets: subtracts what was taken this period, but never\n  // notices that the clock moved on.\n  // const available = periodLimitBaseUnits - chargedInCurrentPeriod;\n\n  // --- candidate 2 (currently active) ---------------------------------------\n  // The accumulating cap: agrees with the truth whenever no period was skipped,\n  // and hands over several periods' worth the moment one was.\n  const available =\n    periodLimitBaseUnits * (currentPeriod - lastChargedPeriod + 1) -\n    chargedInCurrentPeriod;\n\n  // --- candidate 3 ----------------------------------------------------------\n  // const available =\n  //   currentPeriod > lastChargedPeriod\n  //     ? periodLimitBaseUnits\n  //     : periodLimitBaseUnits - chargedInCurrentPeriod;\n\n  const overCap = requestBaseUnits > available;\n\n  // --- the next two blocks are in the wrong order ---------------------------\n\n  return {\n    ok: true,\n    error: \"\",\n    charged: requestBaseUnits,\n    remainingThisPeriod: available - requestBaseUnits,\n  };\n\n  if (overCap) {\n    return {\n      ok: false,\n      error: \"AMOUNT_EXCEEDS_PERIOD_LIMIT\",\n      charged: 0,\n      remainingThisPeriod: available,\n    };\n  }\n}\n",
+        "tests": [
+          {
+            "description": "First pull of a fresh period takes the whole cap",
+            "expectedOutput": "result.ok === true && result.charged === 25000000 && result.remainingThisPeriod === 0",
+            "id": "t1",
+            "input": "25000000, 7, 6, 0, 25000000"
+          },
+          {
+            "description": "A second pull inside the same period is refused by name",
+            "expectedOutput": "result.ok === false && result.error === 'AMOUNT_EXCEEDS_PERIOD_LIMIT' && result.charged === 0",
+            "id": "t2",
+            "input": "25000000, 7, 7, 25000000, 1000000"
+          },
+          {
+            "description": "Two partial pulls inside one period are fine until the cap is reached",
+            "expectedOutput": "result.ok === true && result.remainingThisPeriod === 0",
+            "id": "t3",
+            "input": "25000000, 7, 7, 10000000, 15000000"
+          },
+          {
+            "description": "The cap resets on period rollover with nothing to call",
+            "expectedOutput": "result.ok === true && result.charged === 25000000 && result.remainingThisPeriod === 0",
+            "id": "t4",
+            "input": "25000000, 8, 7, 25000000, 25000000"
+          },
+          {
+            "description": "Five skipped periods do not accumulate — two periods' worth is still refused",
+            "expectedOutput": "result.ok === false && result.error === 'AMOUNT_EXCEEDS_PERIOD_LIMIT' && result.remainingThisPeriod === 25000000",
+            "id": "t5",
+            "input": "25000000, 12, 7, 0, 50000000"
+          },
+          {
+            "description": "After skipping, exactly one period's worth is still collectable",
+            "expectedOutput": "result.ok === true && result.charged === 25000000",
+            "id": "t6",
+            "input": "25000000, 12, 7, 0, 25000000"
+          },
+          {
+            "description": "One base unit over the cap is over the cap",
+            "expectedOutput": "result.ok === false && result.error === 'AMOUNT_EXCEEDS_PERIOD_LIMIT'",
+            "id": "t7",
+            "input": "25000000, 7, 7, 0, 25000001"
+          },
+          {
+            "description": "A refused attempt reports what is still available rather than zero",
+            "expectedOutput": "result.ok === false && result.remainingThisPeriod === 5000000 && result.charged === 0",
+            "id": "t8",
+            "input": "25000000, 7, 7, 20000000, 10000000"
+          }
+        ]
+      },
+      {
+        "_key": "check",
+        "_type": "quiz",
+        "questions": [
+          {
+            "id": "q1",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "`AMOUNT_EXCEEDS_PERIOD_LIMIT` — and the job should read that as \"already collected\", not as a transient failure to retry"
+              },
+              {
+                "correct": false,
+                "feedback": "The cap is per period, not per call. The second pull is exactly what it is designed to stop — which is why it doubles as your idempotency guard.",
+                "id": "b",
+                "label": "It succeeds and charges 50 USDC in total for the period"
+              },
+              {
+                "correct": false,
+                "feedback": "`PERIOD_NOT_ELAPSED` is for collecting against a period that has not started. Here the period has started and its cap is spent. Different error, different meaning.",
+                "id": "c",
+                "label": "`PERIOD_NOT_ELAPSED`, because the period has not rolled over yet"
+              },
+              {
+                "correct": false,
+                "feedback": "The program does not silently rewrite your amount. It refuses the instruction.",
+                "id": "d",
+                "label": "It succeeds with a zero-value transfer"
+              }
+            ],
+            "prompt": "A recurring delegation is capped at 25 USDC per period. Your billing job collects 25 USDC, then crashes before writing its own record. It restarts and retries the same charge, same period. Predict what the program does and what your job should conclude."
+          },
+          {
+            "explanation": "If your business needs missed periods to be collectable, that is an invoice, and you build it in your own system.",
+            "id": "q2",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "25 USDC — the cap is a per-period ceiling, and unused periods are gone"
+              },
+              {
+                "correct": false,
+                "feedback": "That would turn \"up to 25 per month\" into \"up to 25 per month, banked indefinitely and redeemable in a lump sum by whoever holds the delegatee key\". The user authorised the first thing.",
+                "id": "b",
+                "label": "75 USDC — three periods of authorised-but-uncollected capacity"
+              },
+              {
+                "correct": false,
+                "feedback": "No period carries. Not one, not two.",
+                "id": "c",
+                "label": "50 USDC — the two missed periods carry, the current one is charged separately"
+              },
+              {
+                "correct": false,
+                "feedback": "Nothing lapses. The delegation stays live until `expiryTs` or a revoke; only the unused capacity is lost.",
+                "id": "d",
+                "label": "0 USDC — missing a period puts the delegation into a lapsed state"
+              }
+            ],
+            "prompt": "A merchant with a 25 USDC/month recurring delegation forgets to collect in March and April, then runs the job in May. How much can it pull in May, and why?"
+          },
+          {
+            "id": "q3",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "The delegatee key — it can pull up to the cap each period, and nothing else"
+              },
+              {
+                "correct": false,
+                "feedback": "If the service needed the user's key, the delegation would be pointless. `delegator` is typed as an `Address` on the transfer precisely because it is not a signer there.",
+                "id": "b",
+                "label": "The delegator key — the user's key, held in escrow by the service"
+              },
+              {
+                "correct": false,
+                "feedback": "The instruction names exactly one signer. Setup and revoke take the user; transfers take the delegatee.",
+                "id": "c",
+                "label": "Either — the program accepts a signature from whichever of the two is present"
+              },
+              {
+                "correct": false,
+                "feedback": "The delegatee cannot change the terms. Extending means a new delegation with a new nonce, signed by the user — which means the user consents again.",
+                "id": "d",
+                "label": "The delegatee key, which can also extend `expiryTs` when the term runs out"
+              }
+            ],
+            "prompt": "Your unattended billing service holds one key. Which key must it be, and what can it do with it?"
+          },
+          {
+            "id": "q4",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "Refused — start-on-landing requires a non-zero expiry, so an open-ended pull authorisation with no defined start is rejected"
+              },
+              {
+                "correct": false,
+                "feedback": "\"Never expire\" combined with \"start whenever this happens to land\" is the least bounded authorisation the program could issue, so it is the one combination it refuses.",
+                "id": "b",
+                "label": "Accepted — both zeroes mean \"start now, never expire\", which is the common subscription case"
+              },
+              {
+                "correct": false,
+                "feedback": "The program does not invent terms on your behalf. It errors.",
+                "id": "c",
+                "label": "Accepted, with `expiryTs` defaulted to one year from the landing slot"
+              },
+              {
+                "correct": false,
+                "feedback": "`DELEGATION_NOT_STARTED` is real, and it is what you get from a `startTs` in the future. This case fails earlier, at creation.",
+                "id": "d",
+                "label": "Accepted, but every `transferRecurring` then fails with `DELEGATION_NOT_STARTED`"
+              }
+            ],
+            "prompt": "You call `createRecurringDelegation` with `startTs: 0n` and `expiryTs: 0n`. Predict the result."
+          },
+          {
+            "id": "q5",
+            "multiSelect": true,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "The delegation PDA is closed and its rent is returned"
+              },
+              {
+                "correct": true,
+                "id": "b",
+                "label": "Re-establishing the arrangement needs a new `createRecurringDelegation` with a new nonce, signed by the user"
+              },
+              {
+                "correct": false,
+                "feedback": "There is no pause on a delegation. `resumeSubscription` exists, but that is the subscription-plan model, not this one.",
+                "id": "c",
+                "label": "The delegation is paused and can be resumed by the delegatee later"
+              },
+              {
+                "correct": false,
+                "feedback": "Each delegation is its own PDA under the shared authority — that is the whole point. Revoking all of them at once is `closeSubscriptionAuthority`, and it is a separate, deliberate kill switch.",
+                "id": "d",
+                "label": "The user's other delegations on the same mint are also revoked"
+              }
+            ],
+            "prompt": "The user calls `revokeDelegation` on a live recurring delegation. Which of these are true afterwards?"
+          }
+        ]
+      }
+    ],
+    "skills": [
+      "recurring-delegation",
+      "error-handling",
+      "solana-kit"
+    ],
+    "slug": {
+      "_type": "slug",
+      "current": "recurring-delegation-paid-tier"
+    },
+    "title": "Charge Every Month, Cap Every Month"
+  },
+  {
+    "_id": "lesson-sap-submit-and-what-you-built",
+    "_type": "lesson",
+    "blocks": [
+      {
+        "_key": "recap",
+        "_type": "prose",
+        "src": "# Submit It — and What You Built\n\nOne artifact. Five courses. Name every layer of it.\n\n## The through-line\n\nNothing you built restarted. Each course added a layer to the same object.\n\n**Course 1 — you signed something.** Your own transaction, built and sent from your own key, confirmed on devnet, and an account inspector that reads state back off the chain rather than off a screenshot. The first time the chain answered you specifically.\n\n**Course 2 — the vault got a core.** Rust that models the vault's state and its rules, compiled green against the real toolchain on the build server. No local install, no version roulette.\n\n**Course 3 — your program went live.** Deposit and withdraw, hardened, deployed to devnet. You own a program id, and a credential NFT that says you do.\n\n**Course 4 — it became something other people can use.** A typed client generated from your own IDL, wrapped in an API you would actually import, published to npm with a semver policy you wrote down — and a deployed app at a public URL that installs that package from the registry and signs a real deposit through it.\n\n**Course 5 — it started earning.** A Subscription Authority and a Recurring Delegation gave the app a paid tier that charges once per period and correctly refuses to charge twice. An x402 route returns a real 402 challenge naming the network, the asset and the payTo address. An agent calls that route on a loop, pays for each call out of a Fixed Delegation, and halts cleanly when the allowance says no.\n\nSay the sentence out loud, because it is true and you will need it in a proposal:\n\n> You started as a web2 JavaScript developer, and you now own a monetized on-chain product.\n\nIf you entered here — at C5 lesson 1, on the reference app, because you wanted payments and not Anchor — the same sentence applies to the payments layer you built. The credential still requires your own artifact, not the reference one.\n\n## What is in scope, and what is not\n\nThe rails you learned are the ones open to you. From 2026-10-01, BCB Resolution 561 forbids a regulated eFX provider from taking reais, converting to a stablecoin, and settling the obligation abroad on-chain. That is a live constraint on a business model, not on you personally: individuals may still buy, sell, hold and transfer through authorized VASPs.\n\nWhat this course built sits entirely inside what the resolution leaves open: **domestic merchant acceptance, contractor payouts, subscriptions, and agent budgets.** Every one of those is a real product surface, and every one of them is something an Earn listing has asked for. When you write a proposal, name the use case in those terms — a reviewer in Brazil reads the difference immediately, and it is a signal that you understand the market and not just the SDK.\n\n## Pick a rail before you pick a package\n\nThe decision you now make without looking it up:\n\n- **Fixed delegation** — a capped total that never refills. An allowance. This is what an autonomous agent holds, because the on-chain cap is what makes the autonomy safe.\n- **Recurring delegation** — a cap that resets each period. Payroll, contractors, subscriptions. Skipped periods are lost.\n- **Subscription plan** — a merchant publishes terms and approved pullers collect against them.\n- **Solana Pay** — a human paying once, at a checkout. A decision, not an install: `@solana/pay@1.0.23` peer-depends on `@solana/kit ^6.9.0`, which does not admit the `@solana/kit@7.0.0` this course pins everywhere else.\n- **x402** — stateless per-request metering. No delegation, no relationship, one call.\n\nThat list is the most portable thing you learned. Packages will move; the shape of the requirement will not.\n\n## Submit one listing\n\nNow the part most people skip.\n\n**The calibration, honestly.** What this path realistically opens is **your first $500 to $5,000** of paid on-chain work. It is not a job offer, and anyone telling you a course makes you hireable as a Solana developer is selling something. The $5,000 frontend listing drew 731 submissions. The odds live somewhere else.\n\n**Where they live.** Two termini this course specifically unlocks:\n\n1. **Payments technical demos** — around $100 of reward per competitor, second only to Rust listings on that measure. You have a metered endpoint and a paid tier already running.\n2. **Educational modules** — $2,500–$3,000, typically closing near 10 submissions. Your deep dive from the last lesson is most of one.\n\n**How to read a listing, which is a skill in itself.** Competition is a function of **time-to-deadline**, not of category. The Zeroclaw listing sat at twelve submissions or fewer for most of its run and closed at 52 as the deadline approached. A submission count you read today tells you where that listing is in its life, not how contested it is. So: **never quote a single-day count as a competition rate.** Filter for **newly-opened development listings** and compare medians across listings that have actually closed.\n\n**Then submit.** One listing, this week, with a real artifact attached. Not a plan to submit. The bar is lower than it looks — most listings are decided among a handful of complete, reproducible submissions, and you now have the two things most submissions lack: something that runs, and a write-up that says which versions it ran against.\n\n## One more door\n\nTurbin3 runs cohort-based Solana builder programs, and its prerequisites are the kind of thing C1–C4 already satisfy: your own deployed program, a published client, a deployed app. If you want structure and a cohort after this, that is where to look. Bring the program id and the package URL.\n\nThat is the course. Submit the listing.\n"
+      },
+      {
+        "_key": "submit",
+        "_type": "openEnded",
+        "maxWords": 200,
+        "prompt": "Paste the URL of the Superteam Earn listing you submitted to, and the URL of what you submitted. Then, in three lines: which rail the work uses (fixed delegation, recurring delegation, subscription plan, Solana Pay or x402), which Brazilian use case it serves, and the one thing in your submission a reviewer can run themselves."
+      },
+      {
+        "_key": "check",
+        "_type": "quiz",
+        "questions": [
+          {
+            "explanation": "Rail selection is the portable skill. One-off human checkout is Solana Pay's exact shape — and note it stays a decision, not an install, because @solana/pay@1.0.23 peer-depends on @solana/kit ^6.9.0 and will not sit in a kit 7 lockfile.",
+            "id": "q1",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "Solana Pay — a human paying once at a checkout"
+              },
+              {
+                "correct": false,
+                "feedback": "A delegation is a standing approval between two known parties. A walk-in customer has no relationship to approve.",
+                "id": "b",
+                "label": "A recurring delegation, with a one-second period"
+              },
+              {
+                "correct": false,
+                "feedback": "x402 meters a machine calling an endpoint. There is no HTTP client here — there is a person with a phone.",
+                "id": "c",
+                "label": "An x402 challenge returned from the till's API"
+              },
+              {
+                "correct": false,
+                "feedback": "You would be asking the customer to set up an on-chain allowance before their first sip. The setup cost exceeds the payment.",
+                "id": "d",
+                "label": "A fixed delegation sized to the price of one coffee"
+              }
+            ],
+            "prompt": "A café in São Paulo wants a QR code on the counter so a customer can pay for one coffee in USDC from a phone wallet. No account, no relationship, no repeat. Which rail?"
+          },
+          {
+            "explanation": "Published 2026-04-30, effective 2026-10-01. In scope and legal for what you built: domestic merchant acceptance, contractor payouts, subscriptions, agent budgets.",
+            "id": "q2",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "A regulated eFX provider taking reais, converting to USDC, and settling the obligation abroad on-chain"
+              },
+              {
+                "correct": false,
+                "feedback": "Domestic merchant acceptance is explicitly in scope, and is one of the four surfaces this course targets.",
+                "id": "b",
+                "label": "A Brazilian merchant accepting USDC from a domestic customer"
+              },
+              {
+                "correct": false,
+                "feedback": "Individuals may still buy, sell, hold and transfer via authorized VASPs. The resolution constrains a provider's business model, not a person's wallet.",
+                "id": "c",
+                "label": "An individual buying and holding a stablecoin through an authorized VASP"
+              },
+              {
+                "correct": false,
+                "feedback": "Contractor payouts are in scope. That is one of the reasons the recurring delegation matters in this market.",
+                "id": "d",
+                "label": "Paying a Brazilian contractor in USDC on a recurring delegation"
+              }
+            ],
+            "prompt": "From 2026-10-01, which of these does BCB Resolution 561 put off-limits?"
+          },
+          {
+            "explanation": "Pick the extension you need, then check the rail. A TransferHook mint is the concrete case where a valid Token-2022 mint is refused.",
+            "id": "q3",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "Legacy Token by default; Token-2022 only when a named extension is required — then verify your rail accepts it, because the Subscriptions program rejects any mint with a configured TransferHook"
+              },
+              {
+                "correct": false,
+                "feedback": "Neither is being retired, and download volume is at parity (~1.27M/wk vs ~1.24M/wk). \"Newer\" is not a reason.",
+                "id": "b",
+                "label": "Token-2022 always, because it is the newer standard and legacy Token is being retired"
+              },
+              {
+                "correct": false,
+                "feedback": "That claim is stale — support is at parity now. The reason to prefer legacy is the absence of a requirement, not a compatibility gap.",
+                "id": "c",
+                "label": "Legacy Token always, because Token-2022 has limited DEX support"
+              },
+              {
+                "correct": false,
+                "feedback": "It supports both token programs, but it rejects a mint with a configured TransferHook. A Token-2022 mint is not automatically acceptable to your rail.",
+                "id": "d",
+                "label": "Either one — the Subscriptions program treats both token programs identically"
+              }
+            ],
+            "prompt": "You are choosing the payment mint for a subscription product. Which statement is the decision rule you learned?"
+          },
+          {
+            "explanation": "One authority per (user, mint), derived with findSubscriptionAuthorityPda, and you branch on .exists before initialising — running init twice is the classic error.",
+            "id": "q4",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "A token account can have only ONE approved delegate, so one wallet could never hold a subscription and an allowance and a merchant agreement on the same mint"
+              },
+              {
+                "correct": false,
+                "feedback": "Rent is not the reason. The authority exists to lift a hard one-delegate limit.",
+                "id": "b",
+                "label": "PDAs are cheaper to create than token accounts"
+              },
+              {
+                "correct": false,
+                "feedback": "A PDA has no private key — that is the point of deriving it rather than generating it. Nothing holds a keypair for the user.",
+                "id": "c",
+                "label": "It lets the program hold a keypair on the user's behalf"
+              },
+              {
+                "correct": false,
+                "feedback": "Unrelated. The authority is about delegate multiplicity, not about which token program owns the mint.",
+                "id": "d",
+                "label": "It is required in order to use Token-2022 mints"
+              }
+            ],
+            "prompt": "Why does the Subscriptions program put a program-controlled Subscription Authority between the user and every delegation, instead of approving each delegatee on the token account directly?"
+          },
+          {
+            "explanation": "Capped total = an allowance = the agent's budget. Cap resets per period = payroll, contractors, subscriptions.",
+            "id": "q5",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "Fixed caps a total that never refills; recurring caps an amount that resets every period"
+              },
+              {
+                "correct": false,
+                "feedback": "Reversed. \"Fixed\" names a fixed total, not a fixed schedule.",
+                "id": "b",
+                "label": "Fixed caps an amount per period; recurring caps a lifetime total"
+              },
+              {
+                "correct": false,
+                "feedback": "Neither model is tied to a token program. The distinction is whether the cap refills.",
+                "id": "c",
+                "label": "Fixed is for Token-2022 mints; recurring is for legacy Token mints"
+              },
+              {
+                "correct": false,
+                "feedback": "A fixed delegation never refills. That is exactly why it is the right budget for an autonomous agent.",
+                "id": "d",
+                "label": "Both refill; fixed refills daily and recurring refills on a period you choose"
+              }
+            ],
+            "prompt": "Fixed delegation versus recurring delegation. Which pair of statements is correct?"
+          },
+          {
+            "explanation": "Rollover resets the cap. It is what bounds the delegatee's draw to one period at a time, and it is the semantic most write-ups get wrong.",
+            "id": "q6",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "5 USDC — the cap is restored, not increased"
+              },
+              {
+                "correct": false,
+                "feedback": "Nothing accumulates. A merchant who forgets to collect loses that period's revenue permanently.",
+                "id": "b",
+                "label": "10 USDC — the skipped period carries forward"
+              },
+              {
+                "correct": false,
+                "feedback": "Skipping costs revenue, not the delegation. Only expiryTs ends it.",
+                "id": "c",
+                "label": "0 — a skipped period suspends the delegation until the user re-approves"
+              },
+              {
+                "correct": false,
+                "feedback": "Unspent headroom is discarded on rollover. The cap is set back to amountPerPeriod, never added to.",
+                "id": "d",
+                "label": "5 USDC, plus whatever was left unspent in the previous period"
+              }
+            ],
+            "prompt": "A recurring delegation is set to 5 USDC per period. The delegatee collects nothing for one full period. What is the allowance at the start of the next period?"
+          },
+          {
+            "explanation": "Handling this error correctly is the difference between a billing job that double-charges and one that does not. Treat it as \"already collected this period.\"",
+            "id": "q7",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "Fails with AMOUNT_EXCEEDS_PERIOD_LIMIT — no partial transfer occurs"
+              },
+              {
+                "correct": false,
+                "feedback": "There is no borrowing across periods. The cap is enforced per period, at the moment of the call.",
+                "id": "b",
+                "label": "Succeeds, and the excess is deducted from the next period"
+              },
+              {
+                "correct": false,
+                "feedback": "There is no partial fill. A pull for more than the remaining allowance is rejected outright — which is why a retry loop must treat this error as terminal for the period, not as transient.",
+                "id": "c",
+                "label": "Transfers whatever remains of the period allowance and reports a partial fill"
+              },
+              {
+                "correct": false,
+                "feedback": "Nothing deduplicates for you. Idempotency is your job; the cap is the backstop.",
+                "id": "d",
+                "label": "Succeeds — the program deduplicates identical charges automatically"
+              }
+            ],
+            "prompt": "Your billing job runs twice by accident inside the same period. What does the second transferRecurring call do?"
+          },
+          {
+            "explanation": "One approval, many collections, revocable at any time. That asymmetry is the security model of the whole module.",
+            "id": "q8",
+            "multiSelect": true,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "The user signs the setup — creating the authority and the delegation"
+              },
+              {
+                "correct": true,
+                "id": "b",
+                "label": "The delegatee signs each transfer"
+              },
+              {
+                "correct": true,
+                "id": "c",
+                "label": "The user signs the revoke, which closes the PDA and returns the rent to the signer or to the recorded receiver"
+              },
+              {
+                "correct": false,
+                "feedback": "That would reintroduce the per-charge signature the primitive exists to eliminate. The period cap is what bounds the delegatee, not a second signature.",
+                "id": "d",
+                "label": "The user must co-sign every transfer alongside the delegatee"
+              }
+            ],
+            "prompt": "Across the whole delegation lifecycle, who signs what?"
+          },
+          {
+            "explanation": "Metering is a protocol, not a checkout page. The envelope is what lets a client that has never seen your API pay for one call.",
+            "id": "q9",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "An accepts[] envelope naming the network, the asset and the payTo address — and the facilitator does verify, settle and supported, so the API provider never touches on-chain infrastructure"
+              },
+              {
+                "correct": false,
+                "feedback": "A bare address does not say which chain or which asset, and running settlement in your API server is exactly what the facilitator exists to remove.",
+                "id": "b",
+                "label": "A price in USD and a wallet address; the API server submits the transaction itself"
+              },
+              {
+                "correct": false,
+                "feedback": "The server states terms; the client constructs and signs the payment. It is a challenge, not a pre-built transaction.",
+                "id": "c",
+                "label": "A signed transaction for the client to submit unchanged"
+              },
+              {
+                "correct": false,
+                "feedback": "Then a generic client could never pay you. Self-description is the whole point of the envelope.",
+                "id": "d",
+                "label": "Only a price — the client is expected to already know the network and asset from your docs"
+              }
+            ],
+            "prompt": "A client hits your metered route with no payment. What does a valid x402 v2 challenge have to tell them, and who does the on-chain work?"
+          },
+          {
+            "explanation": "Reading which version a server speaks, rather than assuming, is what keeps an integration alive. It is also why the scoped 2.19.0 packages and the frozen unscoped 1.2.0 packages must never be mixed.",
+            "id": "q10",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "Both protocol versions are live on the wire, with different header names and different envelope fields, so a client has to detect which one a server speaks"
+              },
+              {
+                "correct": false,
+                "feedback": "They are not interchangeable. The header names and envelope fields differ, which is why you decide the version before you build the payment.",
+                "id": "b",
+                "label": "V1 is a deprecated alias kept for backwards source compatibility; it behaves identically"
+              },
+              {
+                "correct": false,
+                "feedback": "Network selection is SOLANA_DEVNET_CAIP2 and friends, an entirely separate axis from protocol version.",
+                "id": "c",
+                "label": "One is for devnet and one is for mainnet"
+              },
+              {
+                "correct": false,
+                "feedback": "Token program addresses are exported separately as TOKEN_PROGRAM_ADDRESS and TOKEN_2022_PROGRAM_ADDRESS. Not the same axis.",
+                "id": "d",
+                "label": "One is for legacy Token and one is for Token-2022"
+              }
+            ],
+            "prompt": "\"@x402/svm\" exports both ExactSvmScheme and ExactSvmSchemeV1. Why?"
+          },
+          {
+            "explanation": "Envelope in the body or envelope in the header — handle both, then filter accepts[] on network and asset before you build anything.",
+            "id": "q11",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "Read the base64 envelope out of the PAYMENT-REQUIRED response header — some hosts ship no body at all"
+              },
+              {
+                "correct": false,
+                "feedback": "Retrying without paying returns the same 402 forever. This is the number one x402 integration failure and it is a parsing bug, not a server bug.",
+                "id": "b",
+                "label": "Treat it as a malformed response and retry the bare request"
+              },
+              {
+                "correct": false,
+                "feedback": "Body placement and protocol version are independent. Decode the envelope first, then decide the version from its contents.",
+                "id": "c",
+                "label": "Fall back to the v1 scheme, since only v1 servers send empty bodies"
+              },
+              {
+                "correct": false,
+                "feedback": "Never pay against a value the server did not state in this response. That is how a client overpays or pays the wrong asset.",
+                "id": "d",
+                "label": "Pay a default amount to the address in your configuration"
+              }
+            ],
+            "prompt": "You fetch a metered URL and get a 402 with an empty response body. What is the correct next step?"
+          },
+          {
+            "explanation": "The exit condition is the learning objective. What makes agent autonomy safe is that the cap lives on-chain, where the agent cannot reach it.",
+            "id": "q12",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "Halt and report — the budget was a Fixed Delegation drawn down with transferFixed, and the program refusing the next payment is the exit condition"
+              },
+              {
+                "correct": false,
+                "feedback": "An agent that can raise its own cap has no cap. Refilling requires the user's signature by design.",
+                "id": "b",
+                "label": "Top the delegation up from the same signer and continue, since the agent is trusted"
+              },
+              {
+                "correct": false,
+                "feedback": "A raw keypair with unlimited funds is precisely what the on-chain cap replaces. That fallback deletes the safety property.",
+                "id": "c",
+                "label": "Fall back to a raw keypair the agent holds so the run can complete"
+              },
+              {
+                "correct": false,
+                "feedback": "A fixed delegation never refills. The retry loop would run forever.",
+                "id": "d",
+                "label": "Retry with exponential backoff until the allowance recovers"
+              }
+            ],
+            "prompt": "Your agent loop hits its spend limit mid-run. What should the correct implementation do, and what was the budget?"
+          },
+          {
+            "explanation": "Base units as bigint, everywhere in this stack, on @solana/kit 7.0.0. The type is a habit worth having.",
+            "id": "q13",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "5_000_000n — base units, as a bigint"
+              },
+              {
+                "correct": false,
+                "feedback": "Nothing converts. Passing 5 charges five millionths of a dollar, succeeds, and goes unnoticed for weeks.",
+                "id": "b",
+                "label": "5 — the client converts from display units for you"
+              },
+              {
+                "correct": false,
+                "feedback": "Amounts are integers in base units. A float cannot represent a token amount exactly and the API does not accept one.",
+                "id": "c",
+                "label": "5.0 — a float, since USDC has decimals"
+              },
+              {
+                "correct": false,
+                "feedback": "Right magnitude, wrong type. These APIs take bigint, in the same way Kit takes Address rather than a PublicKey object.",
+                "id": "d",
+                "label": "\"5000000\" — a decimal string"
+              }
+            ],
+            "prompt": "You are charging 5 USDC (6 decimals) through the Subscriptions client. Which amount argument is correct?"
+          },
+          {
+            "explanation": "Dated and pinned. Two paragraphs of work, and the reason your piece outlives every competing one.",
+            "id": "q14",
+            "multiSelect": true,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "A dated banner recording when you last ran the code"
+              },
+              {
+                "correct": true,
+                "id": "b",
+                "label": "Exact package versions copied out of the lockfile that actually resolved"
+              },
+              {
+                "correct": false,
+                "feedback": "A screenshot proves it worked once, for you. It does not let a reader reproduce anything.",
+                "id": "c",
+                "label": "A screenshot of a successful transaction in the explorer"
+              },
+              {
+                "correct": false,
+                "feedback": "On a pre-1.0 package a caret admits breaking minors. That is the opposite of reproducible.",
+                "id": "d",
+                "label": "A caret range on each dependency so readers get bug fixes automatically"
+              }
+            ],
+            "prompt": "Which two things must a deep dive on this material carry to stay verifiable a year from now?"
+          },
+          {
+            "explanation": "Filter for newly-opened development listings, and calibrate on closed ones. The realistic promise of this path is your first $500 to $5,000 of paid work.",
+            "id": "q15",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "Almost nothing — the count tracks time-to-deadline, so compare medians across listings that have already closed"
+              },
+              {
+                "correct": false,
+                "feedback": "The Zeroclaw listing sat at twelve or fewer for most of its run and closed at 52. A mid-run count is not a competition rate.",
+                "id": "b",
+                "label": "It is under-contested; submit immediately for good odds"
+              },
+              {
+                "correct": false,
+                "feedback": "Competition is a function of deadline proximity, not of category popularity.",
+                "id": "c",
+                "label": "The category is unpopular and probably low quality"
+              },
+              {
+                "correct": false,
+                "feedback": "They do not arrive at a steady rate. Submissions cluster hard against the deadline.",
+                "id": "d",
+                "label": "It will close near 12, since submissions arrive at a steady rate"
+              }
+            ],
+            "prompt": "A listing you are considering shows 12 submissions today. What can you conclude?"
+          },
+          {
+            "explanation": "Feature to signer to who-broadcasts. Getting this wrong produces a transaction that is signed and never sent, or sent twice.",
+            "id": "q16",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "createTransactionSendingSignerFromWalletAccount — the wallet broadcasts, and you never see the signed bytes"
+              },
+              {
+                "correct": false,
+                "feedback": "That is the signer for the \"solana:signTransaction\" feature, which hands you signed bytes to send yourself.",
+                "id": "b",
+                "label": "createTransactionSignerFromWalletAccount — your app broadcasts"
+              },
+              {
+                "correct": false,
+                "feedback": "Message signing does not produce a transaction, so nobody broadcasts anything.",
+                "id": "c",
+                "label": "createMessageSignerFromWalletAccount — the wallet broadcasts"
+              },
+              {
+                "correct": false,
+                "feedback": "It is not advisory — createSignerFromWalletAccount inspects the features at call time and throws when neither transaction feature exists.",
+                "id": "d",
+                "label": "Either transaction signer works; the feature list is advisory"
+              }
+            ],
+            "prompt": "Seeded from the previous course. A wallet account advertises \"solana:signAndSendTransaction\". Which signer do you build, and who broadcasts?"
+          },
+          {
+            "explanation": "The single most common first-publish failure, and the reason to pre-empt it rather than debug it in front of a bounty deadline.",
+            "id": "q17",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "The first publish of a scoped package needs --access public, otherwise it 402s as a private package"
+              },
+              {
+                "correct": false,
+                "feedback": "Trusted publishing via OIDC is the route taught — id-token write permission and a configured trusted publisher, no token. The token route is only the fallback.",
+                "id": "b",
+                "label": "NPM_TOKEN must be set as a repository secret"
+              },
+              {
+                "correct": false,
+                "feedback": "npm accepts any valid semver, including 0.x. Nothing about the first publish requires 1.0.0.",
+                "id": "c",
+                "label": "The package version must be 1.0.0 or higher"
+              },
+              {
+                "correct": false,
+                "feedback": "npm scopes and GitHub orgs are independent namespaces.",
+                "id": "d",
+                "label": "The scope must match your GitHub organisation name"
+              }
+            ],
+            "prompt": "Also seeded from the previous course. You are publishing the client package under a scope for the first time. What must be true, or the publish fails?"
+          }
+        ]
+      }
+    ],
+    "skills": [
+      "earn-submission",
+      "payment-model-selection",
+      "agent-budgets",
+      "brazil-compliance"
+    ],
+    "slug": {
+      "_type": "slug",
+      "current": "submit-and-what-you-built"
+    },
+    "title": "Submit It — and What You Built"
+  },
+  {
+    "_id": "lesson-sap-subscription-authority-and-allowance",
+    "_type": "lesson",
+    "blocks": [
+      {
+        "_key": "intro",
+        "_type": "prose",
+        "src": "# One Approval, Many Budgets\n\n> **Version stamp — checked 2026-07-25.** `@solana/subscriptions@0.4.0` **exactly** · `@solana/kit@7.0.0` · `@solana/kit-plugin-rpc@0.13.0` · `@solana/kit-plugin-signer` · `@solana-program/token` (pin the exact version you import). Program: `De1egAFMkMWZSN5rYXRj9CAdheBamobVNubTsi9avR44`.\n>\n> **Pin `0.4.0` exactly.** The `beta` dist-tag currently points at `0.4.0-rc.2`, which is an *older* build than the `latest` release. `@solana/subscriptions@beta` will therefore install you backwards. This package is pre-1.0 and moving — `0.1.0` shipped 2026-05-15 and `0.4.0` on 2026-07-13, four minors in two months. Pin the exact version and re-read the changelog before you bump.\n\n## Start with the constraint, not the API\n\nTry to build a paid tier by hand and you will reach for `approve` on the user's token account. It works. Then you build the second thing that needs to pull funds, and it does not.\n\n**An SPL token account holds exactly one approved delegate.** Not one per counterparty — one, total. Approve your subscription service and you have consumed it. That user can no longer hold an agent allowance, a merchant agreement, and your monthly charge at the same time on the same mint, because every new `approve` silently replaces the last one. The failure mode is not an error; it is somebody else's charge quietly ceasing to work.\n\nThe Subscriptions Delegation Program's answer is one level of indirection. The user approves **one** delegate: a program-controlled **SubscriptionAuthority** PDA, derived per `(user, tokenMint)` pair. That authority then issues as many independently-capped delegations as the user wants, each with its own delegatee, its own cap, its own expiry, and its own revoke.\n\nOne approval. Many budgets. That is the whole idea, and every step below is a consequence of it.\n\n## The client\n\n```ts\nimport { address, createClient } from \"@solana/kit\";\nimport { solanaDevnetRpc } from \"@solana/kit-plugin-rpc\";\nimport { signer } from \"@solana/kit-plugin-signer\";\nimport { subscriptionsProgram } from \"@solana/subscriptions\";\n\nconst client = createClient()\n  .use(signer(userSigner))\n  .use(solanaDevnetRpc({ rpcUrl: DEVNET_RPC_URL }))\n  .use(subscriptionsProgram());\n```\n\nThe plugin fills the configured signer and payer where it can, derives program PDAs for you, and can send transactions directly. Everything that follows hangs off `client.subscriptions`.\n\n## The six steps\n\n### 1. Derive the user's ATA\n\n```ts\nconst [userAta] = await findAssociatedTokenPda({ mint, owner: user, tokenProgram });\n```\n\n`[address, bump]` tuple — destructure it. `tokenProgram` is a seed (lesson 2), so pass the one that actually owns the mint.\n\n### 2. Derive the SubscriptionAuthority PDA\n\n```ts\nconst [subscriptionAuthority] = await findSubscriptionAuthorityPda({ tokenMint, user });\n```\n\nOne per `(user, tokenMint)`. Not per delegatee, not per product.\n\n### 3. Read it before you touch it\n\n```ts\nconst authority = await fetchMaybeSubscriptionAuthority(rpc, subscriptionAuthority);\nif (!authority.exists) {\n  // ...step 4\n}\n```\n\n**Branch on `.exists`.** This is the single most common error against this program: calling `initSubscriptionAuthority` unconditionally, so a returning user's second visit fails at step 4 and the whole flow dies before it reaches the delegation. `fetchMaybe*` is Kit's \"this may not be there\" fetch — it returns an object with an `exists` discriminant instead of throwing, and ignoring that discriminant is how you turn a normal state into a crash.\n\nThe plugin also exposes `client.subscriptions.queries.isSubscriptionAuthorityInitialized(user, tokenMint)` if all you need is the boolean.\n\n### 4. Initialise — only when it is not there\n\n```ts\nawait client.subscriptions.instructions\n  .initSubscriptionAuthority({ tokenMint, userAta, tokenProgram })\n  .sendTransaction();\n```\n\n`owner` and `payer` are filled from the configured signer, so the visible input is just the mint, the ATA and the token program. This is the transaction where the user's single delegate slot gets consumed — by the authority, once, on purpose.\n\n### 5. Open the Fixed Delegation\n\n```ts\nawait client.subscriptions.instructions\n  .createFixedDelegation({\n    tokenMint,\n    delegatee: agentAddress,\n    nonce: 0n,\n    amount: 25_000_000n,       // 25 USDC — BASE UNITS, as a bigint\n    expiryTs: BigInt(Math.floor(Date.now() / 1000) + 30 * 24 * 3600),\n  })\n  .sendTransaction();\n```\n\nFour things in that call will bite you:\n\n- **`amount` is base units, as a `bigint`.** `25` is twenty-five *millionths* of a USDC, not twenty-five USDC. There is no decimals conversion anywhere in this API. Do it once, in one function, and never inline it.\n- **`nonce` is what lets one delegator hold several delegations to the same delegatee.** It is part of the delegation PDA's seeds. Reuse a nonce with the same delegatee and you get `DELEGATION_ALREADY_EXISTS`; the account is already there.\n- **`expiryTs` is a hard stop with no grace period.** One second past it, transfers fail with `DELEGATION_EXPIRED`. Nothing renews, nothing warns, nothing degrades gracefully. If your product needs a renewal, your product builds the renewal.\n- **`payer` is optional, and it is how sponsorship works.** Pass a different signer and that account funds the rent instead of the user. The program stores who paid, and the teardown calls take an optional `receiver` to send it back to: on `revokeSubscriptionAuthority` the SDK documents `receiver` as *required when the authority's stored payer differs from `user`, and it must equal that stored payer*. Sponsorship is therefore a two-sided record — who paid on the way in decides who may be paid on the way out. Track it in your own database as well, because the failure surfaces months later.\n\nA fixed delegation is **one capped total that draws down and never refills**. Spend 25 USDC against a 25 USDC cap and it is finished — not \"finished for this month\". That is precisely the property that makes it a safe budget for something autonomous, which is why **this exact object becomes your agent's spending cap in lesson 7.** Do not think of it as an exercise.\n\n### 6. Pull from it\n\n```ts\nawait client.subscriptions.instructions\n  .transferFixed({\n    delegationPda,\n    delegator: userAddress,      // an Address — the user does NOT sign here\n    delegatorAta: userAta,\n    receiverAta: merchantAta,\n    tokenMint,\n    tokenProgram,\n    amount: 5_000_000n,\n  })\n  .sendTransaction();\n```\n\nLook at the types: `delegator` is an `Address`, `delegatee` is a `TransactionSigner`. **The user signs the setup and the revoke; the delegatee signs the transfers.** The user is not present when you charge them — that is the entire point of a delegation, and it is the security model of this module. Lesson 4 makes it a quiz question.\n\nOverrun the cap and you get `AMOUNT_EXCEEDS_LIMIT` — \"Transfer amount exceeds delegation limit\".\n\n## Your task\n\nWrite the planner. Given whether the authority already exists, a human-readable USDC amount, and whether a sponsor is paying, produce:\n\n- `steps` — the SDK operations in the order you would call them, using their exact names\n- `amountBaseUnits` — the amount converted to base units as a **`bigint`** (USDC has 6 decimals)\n- `payer` — `\"user\"` or `\"sponsor\"`\n\nThe starter has six numbered subgoals. The first two are filled in. Step 3 is always in the plan — you read the authority whether or not it exists, because that is how you found out.\n"
+      },
+      {
+        "_key": "plan",
+        "_type": "code",
+        "buildType": "standard",
+        "deployable": false,
+        "hints": [
+          "Subgoal 3 is unconditional. You read the authority in order to learn whether subgoal 4 is needed, so the read is in the plan either way.",
+          "Only subgoal 4 is conditional. Everything else runs on every path.",
+          "USDC has 6 decimals: multiply by 1_000_000 and round once, then wrap the integer in BigInt(). Do not build the bigint out of a float."
+        ],
+        "language": "typescript",
+        "solution": "/** USDC has 6 decimals. 1 USDC = 1_000_000 base units. */\nconst USDC_DECIMALS = 6;\n\n/**\n * Plan the calls that open a Fixed Delegation for one (user, mint) pair.\n */\nfunction planFixedDelegation(\n  authorityExists: boolean,\n  amountUsdc: number,\n  sponsored: boolean\n): { steps: string[]; amountBaseUnits: bigint; payer: string } {\n  const steps: string[] = [];\n\n  // 1. Derive the user's associated token account for the payment mint.\n  steps.push(\"findAssociatedTokenPda\");\n\n  // 2. Derive the SubscriptionAuthority PDA for this (user, tokenMint) pair.\n  steps.push(\"findSubscriptionAuthorityPda\");\n\n  // 3. Read the authority before touching it — always.\n  steps.push(\"fetchMaybeSubscriptionAuthority\");\n\n  // 4. Initialise it only when the read said it is not there.\n  if (!authorityExists) {\n    steps.push(\"initSubscriptionAuthority\");\n  }\n\n  // 5. Human amount -> base units, as a bigint, exactly once.\n  const amountBaseUnits = toBaseUnits(amountUsdc, USDC_DECIMALS);\n\n  // 6. Open the delegation, then draw the first payment down from its cap.\n  steps.push(\"createFixedDelegation\");\n  steps.push(\"transferFixed\");\n\n  return {\n    steps,\n    amountBaseUnits,\n    payer: sponsored ? \"sponsor\" : \"user\",\n  };\n}\n\n/**\n * Multiply in integer space and round once. Doing the arithmetic in bigint from\n * the start would be better still, but the input here is a JS number, so round\n * before the conversion rather than trusting float multiplication.\n */\nfunction toBaseUnits(amount: number, decimals: number): bigint {\n  let factor = 1;\n  for (let i = 0; i < decimals; i++) {\n    factor *= 10;\n  }\n  return BigInt(Math.round(amount * factor));\n}\n",
+        "starter": "/** USDC has 6 decimals. 1 USDC = 1_000_000 base units. */\nconst USDC_DECIMALS = 6;\n\n/**\n * Plan the calls that open a Fixed Delegation for one (user, mint) pair.\n *\n * @param authorityExists does the SubscriptionAuthority PDA already exist?\n * @param amountUsdc      the cap, in human USDC\n * @param sponsored       true when a sponsor signs as `payer` for the rent\n */\nfunction planFixedDelegation(\n  authorityExists: boolean,\n  amountUsdc: number,\n  sponsored: boolean\n): { steps: string[]; amountBaseUnits: bigint; payer: string } {\n  const steps: string[] = [];\n\n  // 1. Derive the user's associated token account for the payment mint.\n  //    findAssociatedTokenPda({ mint, owner, tokenProgram }) -> [address, bump]\n  steps.push(\"findAssociatedTokenPda\");\n\n  // 2. Derive the SubscriptionAuthority PDA for this (user, tokenMint) pair.\n  //    findSubscriptionAuthorityPda({ tokenMint, user }) -> [address, bump]\n  steps.push(\"findSubscriptionAuthorityPda\");\n\n  // 3. Read the authority before touching it. This step is ALWAYS in the plan —\n  //    reading is how you find out whether step 4 is needed.\n  //    fetchMaybeSubscriptionAuthority(rpc, pda) -> { exists, data }\n  // TODO\n\n  // 4. Initialise the authority ONLY when it does not exist yet. Calling\n  //    initSubscriptionAuthority unconditionally is the classic error here.\n  // TODO\n\n  // 5. Convert the human amount to base units as a bigint.\n  //    There is no decimals conversion anywhere in the SDK — this is it.\n  // TODO (and replace the 0n in the return below)\n\n  // 6. Open the delegation, then draw the first payment down from its cap.\n  //    createFixedDelegation, then transferFixed.\n  // TODO\n\n  return {\n    steps,\n    amountBaseUnits: 0n,\n    payer: sponsored ? \"sponsor\" : \"user\",\n  };\n}\n",
+        "tests": [
+          {
+            "description": "First-time user: all six steps, in order, including the init",
+            "expectedOutput": "result.steps.join('>') === 'findAssociatedTokenPda>findSubscriptionAuthorityPda>fetchMaybeSubscriptionAuthority>initSubscriptionAuthority>createFixedDelegation>transferFixed'",
+            "id": "t1",
+            "input": "false, 25, false"
+          },
+          {
+            "description": "Returning user: the init is skipped and nothing else moves",
+            "expectedOutput": "result.steps.join('>') === 'findAssociatedTokenPda>findSubscriptionAuthorityPda>fetchMaybeSubscriptionAuthority>createFixedDelegation>transferFixed'",
+            "id": "t2",
+            "input": "true, 25, false"
+          },
+          {
+            "description": "The authority is read even when it already exists",
+            "expectedOutput": "result.steps.indexOf('fetchMaybeSubscriptionAuthority') === 2 && result.steps.indexOf('initSubscriptionAuthority') === -1",
+            "id": "t3",
+            "input": "true, 10, false"
+          },
+          {
+            "description": "25 USDC is 25000000 base units, as a bigint",
+            "expectedOutput": "typeof result.amountBaseUnits === 'bigint' && result.amountBaseUnits === 25000000n",
+            "id": "t4",
+            "input": "false, 25, false"
+          },
+          {
+            "description": "Sub-unit amounts convert without losing the fraction",
+            "expectedOutput": "result.amountBaseUnits === 123456n",
+            "id": "t5",
+            "input": "true, 0.123456, false"
+          },
+          {
+            "description": "A sponsor paying the rent is recorded on the plan",
+            "expectedOutput": "result.payer === 'sponsor' && result.steps.indexOf('initSubscriptionAuthority') === 3",
+            "id": "t6",
+            "input": "false, 25, true"
+          },
+          {
+            "description": "The transfer is always last — you cannot pull from a delegation you have not opened",
+            "expectedOutput": "result.steps[result.steps.length - 1] === 'transferFixed' && result.steps.indexOf('createFixedDelegation') < result.steps.indexOf('transferFixed')",
+            "id": "t7",
+            "input": "false, 5, false"
+          }
+        ]
+      },
+      {
+        "_key": "check",
+        "_type": "quiz",
+        "questions": [
+          {
+            "id": "q1",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "The transaction fails on the init and the delegation is never created — the returning user is worse off than a new one"
+              },
+              {
+                "correct": false,
+                "feedback": "Nothing in this program is idempotent by convenience. Creating an account that exists is an error, which is why `fetchMaybe*` gives you an `exists` discriminant to branch on.",
+                "id": "b",
+                "label": "It is idempotent — the program sees the authority already exists and returns success"
+              },
+              {
+                "correct": false,
+                "feedback": "The PDA is derived from `(user, tokenMint)`. There is exactly one address; you cannot have two.",
+                "id": "c",
+                "label": "A second SubscriptionAuthority PDA is created, and the delegation attaches to the new one"
+              },
+              {
+                "correct": false,
+                "feedback": "Tearing down an authority and invalidating its delegations is what `closeSubscriptionAuthority` is for, and it is deliberate. `init` does not silently do it.",
+                "id": "d",
+                "label": "It succeeds and resets all of the user's existing delegations"
+              }
+            ],
+            "prompt": "You call `initSubscriptionAuthority` unconditionally, without reading the account first. A user who set this up last month comes back. Predict what happens."
+          },
+          {
+            "id": "q2",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "The cap is 25 base units — 0.000025 USDC — and the first real charge fails with `AMOUNT_EXCEEDS_LIMIT`"
+              },
+              {
+                "correct": false,
+                "feedback": "There is no decimals conversion anywhere in this API. Every amount is base units. That is why you write the conversion once, in one function.",
+                "id": "b",
+                "label": "The SDK reads the mint's decimals and scales 25 to 25000000"
+              },
+              {
+                "correct": false,
+                "feedback": "The only zero-related guard is `FIXED_DELEGATION_AMOUNT_ZERO`. 25 base units is a perfectly legal, perfectly useless cap.",
+                "id": "c",
+                "label": "It throws at call time, because 25 is below a minimum delegation amount"
+              },
+              {
+                "correct": false,
+                "feedback": "`amount` is the cap. The balance is a separate constraint that also has to hold.",
+                "id": "d",
+                "label": "Nothing — `amount` is a display hint and the real cap comes from the token account balance"
+              }
+            ],
+            "prompt": "You mean to cap a delegation at 25 USDC and pass `amount: 25n`. Predict the cost of the mistake."
+          },
+          {
+            "id": "q3",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "The transfer fails with `DELEGATION_EXPIRED`. There is no grace period, no warning and no auto-renewal."
+              },
+              {
+                "correct": false,
+                "feedback": "Expiry is checked on the transfer. It is a hard stop on the delegation, not a creation-time flag.",
+                "id": "b",
+                "label": "It succeeds — expiry only blocks *new* delegations, not pulls against existing ones"
+              },
+              {
+                "correct": false,
+                "feedback": "There is no grace window. If your product needs one, your product builds it.",
+                "id": "c",
+                "label": "It succeeds inside a short grace window and fails after it"
+              },
+              {
+                "correct": false,
+                "feedback": "Nothing renews. Renewal is a new `createFixedDelegation` with a new nonce, signed by the user.",
+                "id": "d",
+                "label": "The delegation auto-renews for another identical term"
+              }
+            ],
+            "prompt": "A fixed delegation's `expiryTs` passed 40 seconds ago. Your merchant service tries to collect. Predict the behaviour."
+          },
+          {
+            "id": "q4",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "The delegatee. The user signed once at setup and is not present when they are charged."
+              },
+              {
+                "correct": false,
+                "feedback": "If the user had to co-sign every pull, the delegation would be pointless. The cap, the expiry and the revoke are what protect them, not a signature per charge.",
+                "id": "b",
+                "label": "Both — the user co-signs every pull so they can always refuse"
+              },
+              {
+                "correct": false,
+                "feedback": "`delegator` is typed as a plain `Address` precisely because it is not a signer on this instruction. The types tell you.",
+                "id": "c",
+                "label": "The delegator, because it is their tokens moving"
+              },
+              {
+                "correct": false,
+                "feedback": "The authority is the SPL delegate and the program signs for it, but the transaction still needs an authorised human or service to sign — and that is the delegatee.",
+                "id": "d",
+                "label": "The SubscriptionAuthority PDA, via the program's own signature"
+              }
+            ],
+            "prompt": "Read the types. In `transferFixed`, `delegator` is an `Address` and `delegatee` is a `TransactionSigner`. Who must sign the charge?"
+          },
+          {
+            "explanation": "Sponsorship is a two-sided record: who paid on the way in decides who may be paid on the way out. Track it in your own database too, because the failure surfaces months later.",
+            "id": "q5",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "It fails — `receiver` is required when the stored payer differs from `user`, and it must equal that stored payer"
+              },
+              {
+                "correct": false,
+                "feedback": "The program records who funded the account exactly so it cannot silently redirect their rent. Sponsorship without that record would be a free withdrawal.",
+                "id": "b",
+                "label": "It succeeds and the rent goes to the user, who did not pay it"
+              },
+              {
+                "correct": false,
+                "feedback": "Lamports from a closed account go to a recipient account; the program will not destroy them.",
+                "id": "c",
+                "label": "It succeeds and the rent is burned"
+              },
+              {
+                "correct": false,
+                "feedback": "The sponsor's address is stored, but you still have to pass it as `receiver`. The call fails rather than guessing.",
+                "id": "d",
+                "label": "It succeeds and the rent is returned to the sponsor automatically, no argument needed"
+              }
+            ],
+            "prompt": "A sponsor signed as `payer`, so the sponsor funded the SubscriptionAuthority PDA's rent. Later the user calls `revokeSubscriptionAuthority` with no `receiver`. Predict the result."
+          }
+        ]
+      }
+    ],
+    "skills": [
+      "subscription-authority",
+      "fixed-delegation",
+      "solana-kit",
+      "pdas"
+    ],
+    "slug": {
+      "_type": "slug",
+      "current": "subscription-authority-and-allowance"
+    },
+    "title": "One Approval, Many Budgets"
+  },
+  {
+    "_id": "lesson-sap-token-or-token-2022",
+    "_type": "lesson",
+    "blocks": [
+      {
+        "_key": "intro",
+        "_type": "prose",
+        "src": "# Token or Token-2022: The Decision Rule\n\n> **Version stamp — checked 2026-07-25.** `@solana/kit@7.0.0` · `@solana/subscriptions@0.4.0` (exact) · `@x402/svm@2.19.0` · `@solana-program/token` latest `0.15.0`, `@solana-program/token-2022` latest `0.13.0`. Every dependency range quoted below was read off the published package manifests on that date.\n\nThis is a checkpoint, not new material. You are about to open a delegation against a specific mint, and the program will either take that mint or refuse it. Before you write the call, get the rule straight.\n\n## Two token programs, not two eras\n\n| | Program id |\n| --- | --- |\n| **Token** (the original) | `TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA` |\n| **Token-2022** (token extensions) | `TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb` |\n\nOlder material — including an earlier version of this very curriculum — frames these as \"the mature one\" and \"the new one with limited support\". That framing is dead. Weekly npm downloads for the two client libraries sit within a couple of percent of each other, DEX and wallet support is at parity, and Token-2022 has been carrying production stablecoin supply for years. Neither program is a legacy of the other. They are **two mints with different capability surfaces**, and you choose per mint.\n\nThe one thing you cannot do is choose late. A mint's owner program is fixed at creation and every downstream address depends on it.\n\n## Why the choice changes your addresses\n\nThe associated token account is a PDA whose seeds are `[owner, tokenProgram, mint]`. The token program id is **in the seeds**. So the same wallet holding the same nominal asset has a different ATA depending on which token program minted it.\n\n```ts\nimport { findAssociatedTokenPda } from \"@solana-program/token\";\n\nconst [ata] = await findAssociatedTokenPda({\n  mint,\n  owner,\n  tokenProgram, // Token or Token-2022 — this changes the resulting address\n});\n```\n\nTwo notes on that snippet, both of which are corrections to material you may have read here before:\n\n1. **`getAssociatedTokenAddress` from `@solana/spl-token` is not the current API.** The Kit-native derivation is `findAssociatedTokenPda`, it is synchronous-looking but returns a promise, and it returns a `[address, bump]` tuple — not a bare address. Destructure it.\n2. **`tokenProgram` is a required input, not an optional flourish.** Passing the wrong one silently derives a real, valid, empty account that will never receive the transfer you are expecting.\n\n### The version seam you will actually trip over\n\n`@solana-program/token` is at `0.15.0`. Under semver, a caret range on a `0.x` package pins the **minor**, not the major — `^0.9.0` means `>=0.9.0 <0.10.0`. Read off the published manifests on 2026-07-25:\n\n| Package | Range it declares on `@solana-program/token` |\n| --- | --- |\n| `@x402/svm@2.19.0` | `^0.9.0` |\n| `@solana/subscriptions@0.4.0` | `^0.13.0` |\n| `@solana/pay@1.0.23` | `^0.12.0` (a **peer**) |\n\nThose three ranges are pairwise disjoint. For `@x402/svm` and `@solana/subscriptions` this is harmless — they are ordinary dependencies, so your package manager installs a copy each and nobody argues. For `@solana/pay` it is a **peer** dependency, which is your problem to satisfy, and it is one of the reasons Solana Pay is a decision in this course rather than an install.\n\nPin `@solana-program/token` yourself, at whatever version your own code imports, and do not assume the one your dependency resolved is the one you got.\n\n## The rule\n\n> **Legacy Token by default. Token-2022 only when a named extension is required. Then verify your rail accepts it.**\n\nThree clauses, and the third is the one everybody skips.\n\nThere are around 28 Token-2022 extensions. This course is not going to tour them — Blueshift already owns that material and does it well. What matters here is that **your payment rail gets a veto**, and the Subscriptions Delegation Program uses it.\n\n## What the rail refuses\n\nRead the error constants shipped in `@solana/subscriptions@0.4.0` and a whole family jumps out:\n\n| Error constant (suffix) | Message |\n| --- | --- |\n| `MINT_HAS_CONFIDENTIAL_TRANSFER` | Mint has ConfidentialTransfer extension |\n| `MINT_HAS_MINT_CLOSE_AUTHORITY` | Mint has MintCloseAuthority extension |\n| `MINT_HAS_NON_TRANSFERABLE` | Mint has NonTransferable extension |\n| `MINT_HAS_PAUSABLE` | Mint has Pausable extension |\n| `MINT_HAS_PERMANENT_DELEGATE` | Mint has PermanentDelegate extension |\n| `MINT_HAS_TRANSFER_FEE` | Mint has TransferFee extension |\n| `MINT_HAS_TRANSFER_HOOK` | Mint has TransferHook extension |\n\nSeven extensions that can disqualify a mint from a delegation. Look at *why* each one is there and the list stops being arbitrary:\n\n- **NonTransferable** — a delegation is a promise that somebody else can move your tokens. A mint that forbids transfers cannot honour it.\n- **PermanentDelegate** — the mint authority already holds an irrevocable delegate over every account. A user-scoped, user-revocable allowance is a fiction on top of it.\n- **Pausable / MintCloseAuthority** — a third party can invalidate the arrangement out from under both parties.\n- **TransferFee** — the amount that lands is not the amount authorised, so a cap stops meaning what it says.\n- **ConfidentialTransfer** — the balances the program must check are encrypted.\n- **TransferHook** — an arbitrary program runs inside the transfer, so the extra accounts it needs must be discovered and appended before the instruction is built. The SDK ships `resolveTransferHookAccounts` for exactly that; hook support is therefore **path-dependent**, which is the strongest possible argument for the rule's third clause. Do not assume. Test on devnet against the rail you are actually going to use.\n\nThe two errors you will hit most in module 1 have nothing to do with extensions, and are worth memorising now: `AMOUNT_EXCEEDS_LIMIT` (\"Transfer amount exceeds delegation limit\") for a fixed delegation, and `AMOUNT_EXCEEDS_PERIOD_LIMIT` (\"Transfer amount exceeds period limit\") for a recurring one. Lesson 4 is built on the second.\n\n## The exercise\n\nWrite the decision rule as a function. It takes what a decoded mint tells you — which program owns it, which extensions are configured on it — plus the one extension your product actually needs, and it returns a verdict.\n\nCheck the disqualifying extensions in this fixed order, so the verdict is deterministic when a mint carries more than one:\n\n```\nconfidential-transfer, mint-close-authority, non-transferable,\npausable, permanent-delegate, transfer-fee, transfer-hook\n```\n\nVerdict codes:\n\n| Code | Meaning |\n| --- | --- |\n| `INVALID_TOKEN_PROGRAM` | Not owned by either token program. Not a payment mint. |\n| `MINT_HAS_*` | The rail refuses this mint. Names the first disqualifying extension in the order above. |\n| `design-error-extension-requires-token-2022` | You asked for an extension on a legacy Token mint. That is not a thing. |\n| `design-error-required-extension-missing` | Token-2022 mint, but the extension you need is not configured on it. |\n| `ok-legacy-token` | Correct default. |\n| `ok-token-2022-extension-required` | Token-2022, justified by a named extension the rail accepts. |\n| `ok-token-2022-not-justified` | The rail will take it, but you had no reason to leave legacy Token. |\n\nNote that the last one is `accepted: true`. The rail is not your code reviewer. A verdict of \"this works and you still chose wrong\" is exactly the kind of thing a decision rule should be able to say.\n"
+      },
+      {
+        "_key": "check",
+        "_type": "quiz",
+        "questions": [
+          {
+            "id": "q1",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "You get a valid, correctly-formed address that is simply the wrong account, and a transfer to it goes nowhere useful"
+              },
+              {
+                "correct": false,
+                "feedback": "PDA derivation is pure math over seeds. It never reads the mint account, so it cannot know the owner is wrong. That is exactly why the failure is silent.",
+                "id": "b",
+                "label": "The derivation throws, because the mint's owner is checked during derivation"
+              },
+              {
+                "correct": false,
+                "feedback": "It is in the seeds — `[owner, tokenProgram, mint]`. Change the token program and you change the address.",
+                "id": "c",
+                "label": "The token program id is not part of the ATA seeds, so you get the same address either way"
+              },
+              {
+                "correct": false,
+                "feedback": "It does both. It selects the program AND it is a seed, so it moves the address.",
+                "id": "d",
+                "label": "You get the right address; the tokenProgram argument only selects which instructions get built"
+              }
+            ],
+            "prompt": "You derive an ATA with `findAssociatedTokenPda({ mint, owner, tokenProgram })` and pass the legacy Token program id, but the mint was created under Token-2022. Predict what happens."
+          },
+          {
+            "id": "q2",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "Refused — `MINT_HAS_PERMANENT_DELEGATE`. A user-revocable allowance is meaningless when the mint authority already holds an irrevocable delegate."
+              },
+              {
+                "correct": false,
+                "feedback": "The rail vetoes on what the mint *carries*, not on what you intended to use. One disqualifying extension is enough.",
+                "id": "b",
+                "label": "Accepted — `interest-bearing` is not on the disqualifying list, and that is the extension you are relying on"
+              },
+              {
+                "correct": false,
+                "feedback": "There is no warning path. It is an error constant, and the instruction fails.",
+                "id": "c",
+                "label": "Accepted with a warning, since PermanentDelegate does not affect the transfer amount"
+              },
+              {
+                "correct": false,
+                "feedback": "Interest accrual is an exchange-rate mechanism, not a transfer fee. Different extension, different error.",
+                "id": "d",
+                "label": "Refused — `MINT_HAS_TRANSFER_FEE`, because interest accrual is charged as a fee"
+              }
+            ],
+            "prompt": "A mint is Token-2022 and carries both `permanent-delegate` and `interest-bearing`. Your product needs the interest-bearing behaviour. Predict the outcome of opening a delegation against it."
+          },
+          {
+            "id": "q3",
+            "multiSelect": true,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "Your product requires a named extension that the rail you are using accepts"
+              },
+              {
+                "correct": true,
+                "id": "b",
+                "label": "Your compliance requirement needs a transfer hook, and you have verified the specific rail resolves hook accounts on the path you use"
+              },
+              {
+                "correct": false,
+                "feedback": "\"Newer\" is not a requirement. The rule is legacy Token by default; Token-2022 buys you a capability and costs you a compatibility check.",
+                "id": "c",
+                "label": "It is the newer program, so new projects should default to it"
+              },
+              {
+                "correct": false,
+                "feedback": "Extensions are configured at mint creation. Choosing the program early does not let you add one later, so this buys nothing and costs the check.",
+                "id": "d",
+                "label": "You might want an extension later, so minting under Token-2022 keeps options open"
+              }
+            ],
+            "prompt": "Which of these are grounds for choosing Token-2022 for a payment mint under the rule taught here?"
+          },
+          {
+            "id": "q4",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "No — on a 0.x package a caret pins the minor, so `^0.9.0` means `>=0.9.0 <0.10.0`"
+              },
+              {
+                "correct": false,
+                "feedback": "That is the 1.x behaviour. Below 1.0.0 semver treats the minor as the breaking position, and npm's caret follows it.",
+                "id": "b",
+                "label": "Yes — a caret allows any release below the next major, and there is no 1.0.0 yet"
+              },
+              {
+                "correct": false,
+                "feedback": "A lockfile pins what was already resolved. It does not widen a range that never admitted 0.15.0.",
+                "id": "c",
+                "label": "Yes, but only if no lockfile is present"
+              },
+              {
+                "correct": false,
+                "feedback": "Patches still float. `^0.9.0` accepts `0.9.7`; it stops at `0.10.0`.",
+                "id": "d",
+                "label": "No — a caret on a 0.x package pins the patch, so only `0.9.0` itself resolves"
+              }
+            ],
+            "prompt": "Carried over from Course 4 — semver. `@x402/svm@2.19.0` depends on `@solana-program/token` at `^0.9.0`. The published latest is `0.15.0`. Does that range resolve to `0.15.0`?"
+          },
+          {
+            "id": "q5",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "A recurring delegation — \"Transfer amount exceeds period limit\""
+              },
+              {
+                "correct": false,
+                "feedback": "That is `AMOUNT_EXCEEDS_LIMIT`, the fixed-delegation error. The two are distinct constants with distinct messages, and telling them apart is how you know which cap you hit.",
+                "id": "b",
+                "label": "A fixed delegation — \"Transfer amount exceeds delegation limit\""
+              },
+              {
+                "correct": false,
+                "feedback": "There is no generic cap error. The program names the model in the constant.",
+                "id": "c",
+                "label": "Either one — it is the generic cap error for both models"
+              },
+              {
+                "correct": false,
+                "feedback": "Plan-related failures come back as `PLAN_*` constants (`PLAN_EXPIRED`, `PLAN_TERMS_MISMATCH`, and so on).",
+                "id": "d",
+                "label": "A subscription plan — the plan's billing terms were exceeded"
+              }
+            ],
+            "prompt": "Also from Course 4 — decoded program errors. Your delegation call fails and the client surfaces `SUBSCRIPTIONS_ERROR__AMOUNT_EXCEEDS_PERIOD_LIMIT`. What kind of delegation are you talking to, and what does the message say?"
+          }
+        ]
+      },
+      {
+        "_key": "classify",
+        "_type": "code",
+        "buildType": "standard",
+        "deployable": false,
+        "hints": [
+          "Order matters. Check the token program first, then the design errors that cannot be fixed at runtime, then the rail's veto.",
+          "Scan `DISQUALIFYING` in its declared order and return on the first hit — do not scan the mint's own extension list, or a mint carrying two will give you a different answer depending on how it was written.",
+          "`mintHasCode` is already written for you: it turns `transfer-hook` into `MINT_HAS_TRANSFER_HOOK`."
+        ],
+        "language": "typescript",
+        "solution": "/**\n * Decide whether a mint can back a delegation, and whether the token program\n * it was minted under was the right call.\n */\nfunction classifyPaymentMint(\n  ownerProgram: string,\n  extensions: string,\n  requiredExtension: string\n): { accepted: boolean; reason: string } {\n  // Checked in this order so a mint carrying several gets a stable verdict.\n  const DISQUALIFYING = [\n    \"confidential-transfer\",\n    \"mint-close-authority\",\n    \"non-transferable\",\n    \"pausable\",\n    \"permanent-delegate\",\n    \"transfer-fee\",\n    \"transfer-hook\",\n  ];\n  const configured = extensions === \"\" ? [] : extensions.split(\"|\");\n\n  // 1. Not a payment mint at all.\n  if (ownerProgram !== \"token\" && ownerProgram !== \"token-2022\") {\n    return { accepted: false, reason: \"INVALID_TOKEN_PROGRAM\" };\n  }\n\n  // 2. Extensions do not exist on legacy Token. Asking for one here is a\n  //    design error, not a runtime one — catch it before you mint.\n  if (ownerProgram === \"token\" && requiredExtension !== \"\") {\n    return {\n      accepted: false,\n      reason: \"design-error-extension-requires-token-2022\",\n    };\n  }\n\n  // 3. The rail's veto. First disqualifying extension wins, in the declared\n  //    order, so the verdict is deterministic.\n  for (const extension of DISQUALIFYING) {\n    if (configured.indexOf(extension) !== -1) {\n      return { accepted: false, reason: mintHasCode(extension) };\n    }\n  }\n\n  // 4. The default, and the right answer most of the time.\n  if (ownerProgram === \"token\") {\n    return { accepted: true, reason: \"ok-legacy-token\" };\n  }\n\n  // 5. Accepted, and still the wrong call: nothing justified leaving legacy.\n  if (requiredExtension === \"\") {\n    return { accepted: true, reason: \"ok-token-2022-not-justified\" };\n  }\n\n  // 6. Token-2022 for an extension the mint does not actually carry.\n  if (configured.indexOf(requiredExtension) === -1) {\n    return { accepted: false, reason: \"design-error-required-extension-missing\" };\n  }\n\n  // 7. Justified, configured, and the rail accepts it.\n  return { accepted: true, reason: \"ok-token-2022-extension-required\" };\n}\n\n/** \"transfer-hook\" -> \"MINT_HAS_TRANSFER_HOOK\" */\nfunction mintHasCode(extension: string): string {\n  return \"MINT_HAS_\" + extension.split(\"-\").join(\"_\").toUpperCase();\n}\n",
+        "starter": "/**\n * Decide whether a mint can back a delegation, and whether the token program\n * it was minted under was the right call.\n *\n * @param ownerProgram      \"token\" | \"token-2022\" | anything else\n * @param extensions        pipe-separated extension slugs configured on the\n *                          mint, e.g. \"transfer-fee|interest-bearing\".\n *                          Empty string means no extensions.\n * @param requiredExtension the one extension your product actually needs.\n *                          Empty string means none.\n */\nfunction classifyPaymentMint(\n  ownerProgram: string,\n  extensions: string,\n  requiredExtension: string\n): { accepted: boolean; reason: string } {\n  // Checked in this order so a mint carrying several gets a stable verdict.\n  const DISQUALIFYING = [\n    \"confidential-transfer\",\n    \"mint-close-authority\",\n    \"non-transferable\",\n    \"pausable\",\n    \"permanent-delegate\",\n    \"transfer-fee\",\n    \"transfer-hook\",\n  ];\n  const configured = extensions === \"\" ? [] : extensions.split(\"|\");\n\n  // TODO: implement the rule.\n  //\n  //   1. Neither token program owns it            -> INVALID_TOKEN_PROGRAM\n  //   2. Legacy Token but an extension is needed  -> design-error-extension-requires-token-2022\n  //   3. First disqualifying extension configured -> MINT_HAS_<UPPER_SNAKE>\n  //   4. Legacy Token, nothing needed             -> ok-legacy-token\n  //   5. Token-2022, nothing needed               -> ok-token-2022-not-justified\n  //   6. Token-2022, needed extension absent      -> design-error-required-extension-missing\n  //   7. Otherwise                                -> ok-token-2022-extension-required\n  void DISQUALIFYING;\n  void configured;\n  void ownerProgram;\n  void requiredExtension;\n\n  return { accepted: true, reason: \"ok-legacy-token\" };\n}\n\n/** \"transfer-hook\" -> \"MINT_HAS_TRANSFER_HOOK\" */\nfunction mintHasCode(extension: string): string {\n  return \"MINT_HAS_\" + extension.split(\"-\").join(\"_\").toUpperCase();\n}\n",
+        "tests": [
+          {
+            "description": "A plain legacy Token mint is the default and is accepted",
+            "expectedOutput": "result.accepted === true && result.reason === 'ok-legacy-token'",
+            "id": "t1",
+            "input": "'token', '', ''"
+          },
+          {
+            "description": "Token-2022 with nothing to justify it is accepted but flagged",
+            "expectedOutput": "result.accepted === true && result.reason === 'ok-token-2022-not-justified'",
+            "id": "t2",
+            "input": "'token-2022', '', ''"
+          },
+          {
+            "description": "A configured transfer hook is refused by name",
+            "expectedOutput": "result.accepted === false && result.reason === 'MINT_HAS_TRANSFER_HOOK'",
+            "id": "t3",
+            "input": "'token-2022', 'transfer-hook', 'transfer-hook'"
+          },
+          {
+            "description": "A named extension the rail accepts justifies Token-2022",
+            "expectedOutput": "result.accepted === true && result.reason === 'ok-token-2022-extension-required'",
+            "id": "t4",
+            "input": "'token-2022', 'interest-bearing|metadata-pointer', 'interest-bearing'"
+          },
+          {
+            "description": "A disqualifying extension refuses the mint even when another one was the reason for choosing Token-2022",
+            "expectedOutput": "result.accepted === false && result.reason === 'MINT_HAS_TRANSFER_FEE'",
+            "id": "t5",
+            "input": "'token-2022', 'transfer-fee|interest-bearing', 'interest-bearing'"
+          },
+          {
+            "description": "Asking for an extension on a legacy Token mint is a design error",
+            "expectedOutput": "result.accepted === false && result.reason === 'design-error-extension-requires-token-2022'",
+            "id": "t6",
+            "input": "'token', '', 'interest-bearing'"
+          },
+          {
+            "description": "A mint owned by neither token program is not a payment mint",
+            "expectedOutput": "result.accepted === false && result.reason === 'INVALID_TOKEN_PROGRAM'",
+            "id": "t7",
+            "input": "'mpl-core', '', ''"
+          },
+          {
+            "description": "With two disqualifying extensions the declared order decides the verdict",
+            "expectedOutput": "result.reason === 'MINT_HAS_PERMANENT_DELEGATE'",
+            "id": "t8",
+            "input": "'token-2022', 'transfer-hook|permanent-delegate', ''"
+          },
+          {
+            "description": "Token-2022 chosen for an extension the mint does not carry",
+            "expectedOutput": "result.accepted === false && result.reason === 'design-error-required-extension-missing'",
+            "id": "t9",
+            "input": "'token-2022', 'metadata-pointer', 'interest-bearing'"
+          }
+        ]
+      }
+    ],
+    "skills": [
+      "spl-tokens",
+      "token-2022",
+      "transfer-hook",
+      "solana-kit"
+    ],
+    "slug": {
+      "_type": "slug",
+      "current": "token-or-token-2022"
+    },
+    "title": "Token or Token-2022: The Decision Rule"
+  },
+  {
+    "_id": "lesson-sap-write-the-deep-dive",
+    "_type": "lesson",
+    "blocks": [
+      {
+        "_key": "shape",
+        "_type": "prose",
+        "src": "# Publish the Deep Dive\n\nYou have a paid tier, a metered endpoint and an agent with a spend cap. Nobody knows.\n\nThis lesson is not a writing-skills lesson. It is a lesson about a specific artifact that a specific buyer pays for, and about the two properties that decide whether it gets paid or ignored: **it is dated, and it is pinned.**\n\n## The market evidence, plainly and dated\n\nSuperteam Canada ran two listings on the Subscriptions & Allowances program, both closing 2026-06-23 — three weeks after the program hit mainnet on 2026-06-02:\n\n| Listing                                    | Reward       | Submissions at close |\n| ------------------------------------------ | ------------ | -------------------- |\n| Subscriptions & Allowances **code sample**  | $2,750 USDG  | 31                   |\n| Technical **deep dive** on the same primitive | $2,750 USDG | 44                   |\n\nEducational modules on Superteam Earn sit at **$2,500–$3,000** and routinely close at around **10 submissions**. Promotional content — threads, videos, \"explain this protocol\" posts — closes at **107 to 677**.\n\nThose are final counts on closed listings, not snapshots. That distinction matters and you will see it again in the next lesson: a submission count read on any single day tells you nothing, because the count is a function of how close the deadline is, not of how hard the work is.\n\nRead the table again. The write-up paid the same as the implementation, and the field with the lowest competition on the platform is the one where you explain something you actually built. **Writing about what you built is the best-odds path here.** You already did the expensive part.\n\n## Why the pins are the product\n\nEvery competitor's material on this primitive rotted the same way. It was written against a pre-1.0 package, the package moved, and the post never said which version it was written against. Six months later the code in the post does not run and there is no way to tell whether the reader's environment or the author's assumption is wrong.\n\n`@solana/subscriptions` is at `0.4.0`, published 2026-07-13. Its `beta` dist-tag points at `0.4.0-rc.2` — an *older* pre-release. `@x402/core`, `@x402/svm`, `@x402/express` and `@x402/fetch` are at `2.19.0`, published 2026-07-17, while the unscoped `x402`, `x402-express`, `x402-next` and `x402-fetch` packages are frozen at `1.2.0` from 2026-04-16 and speak an older protocol version. A reader who installs the wrong half of either split gets a failure that looks like their own bug.\n\nUndated, unpinned content is how that happens. A dated version banner and an exact pin block are two paragraphs of work, and they are the difference between an artifact with a shelf life and a screenshot.\n\n## The shape — worked exemplar, annotated\n\nWhat follows is the full skeleton of the piece, with the job of each section called out. Write your own version of this against your own artifact. The order is load-bearing: a reader who bounces off section 1 never reaches section 4, and a reviewer who cannot reproduce section 4 does not pay.\n\n---\n\n### `> Version banner` — first thing on the page, above the fold\n\n> Written against `@solana/subscriptions@0.4.0`, `@solana/kit@7.0.0`, `@x402/core@2.19.0`, Solana devnet. Program `De1egAFMkMWZSN5rYXRj9CAdheBamobVNubTsi9avR44`. **Checked 2026-07-25.**\n\n*Job:* tell the reader in one line whether this page is worth their next five minutes. It is the only section that costs you nothing and saves every future reader. It carries a **date you actually ran the code**, not the date you published.\n\n### 1. The problem, in one paragraph, from the user's side\n\n> A SaaS app wants to charge 5 USDC every month. A one-off transfer means the user signs every month and churns the first time they are busy. Handing the app a signed blank cheque means the app can drain the account. Neither is acceptable, and this is why the recurring delegation exists.\n\n*Job:* establish that there is a real decision here. Do not open with \"Solana is fast.\" Open with the thing that does not work.\n\n### 2. The minimal reference implementation\n\nMinimal means: no framework, no UI, no error handling beyond the one error that matters, and it runs top to bottom. Everything the reader does not need is a reason to stop reading.\n\n```ts\nimport { createClient, signer } from '@solana/kit';\nimport {\n  subscriptionsProgram,\n  findSubscriptionAuthorityPda,\n  fetchMaybeSubscriptionAuthority,\n  initSubscriptionAuthority,\n  createRecurringDelegation,\n  transferRecurring,\n} from '@solana/subscriptions';\n\nconst client = createClient()\n  .use(signer(userSigner))\n  .use(solanaDevnetRpc({ url: RPC_URL }))\n  .use(subscriptionsProgram());\n\n// One authority per (user, mint). Branch on .exists — init twice and it throws.\nconst [authority] = await findSubscriptionAuthorityPda({\n  user: userSigner.address,\n  tokenMint: USDC_DEVNET,\n});\nconst maybe = await fetchMaybeSubscriptionAuthority(client, authority);\nif (!maybe.exists) {\n  await initSubscriptionAuthority({ user: userSigner, tokenMint: USDC_DEVNET })\n    .sendTransaction(client);\n}\n\n// The paid tier: 5 USDC of headroom, refreshed every 30 days.\nawait createRecurringDelegation({\n  user: userSigner,\n  tokenMint: USDC_DEVNET,\n  delegatee: merchant.address,\n  amountPerPeriod: 5_000_000n,        // base units, bigint — 5 USDC at 6 decimals\n  periodSeconds: 2_592_000n,\n  expiryTs: EXPIRY,                    // hard stop, no grace period\n}).sendTransaction(client);\n\n// Collection. The MERCHANT signs this, not the user.\nawait transferRecurring({\n  delegatee: merchantSigner,\n  delegator: userSigner.address,\n  tokenMint: USDC_DEVNET,\n  amount: 5_000_000n,\n}).sendTransaction(merchantClient);\n```\n\n*Job:* be copy-pasteable. Amounts are base units as `bigint` — a reader who writes `5` instead of `5_000_000n` charges five millionths of a dollar and will not notice for a week, so annotate it inline rather than in a footnote.\n\n### 3. The semantics that bite — the section that earns the fee\n\nAnyone can paste an API sequence. What a reviewer is buying is the three behaviours that are not visible in the call signatures and that everyone gets wrong the first time. State each one as a claim, then show the observation that proves it.\n\n**(a) A second pull inside the same period fails.** Call `transferRecurring` twice before the period rolls over and the second call is rejected with `AMOUNT_EXCEEDS_PERIOD_LIMIT` (\"Transfer amount exceeds period limit\"). The cap is per period, not per call, and there is no partial-fill: a pull for more than the remaining period allowance fails outright rather than transferring what is left.\n\n**(b) The cap resets on rollover — it does not accumulate.** When the period rolls, the allowance is restored to `amountPerPeriod`. It is set back to the cap, not increased by it.\n\n**(c) Skipped periods are lost.** A merchant who forgets to collect in March cannot collect twice in April. Unclaimed headroom does not carry forward. This is a *user-protective* design — it bounds the delegatee's total draw to one period at a time — and it is the single most common wrong assumption about the primitive, which is exactly why it is worth writing down.\n\nAnd the security point underneath all three: **the delegatee signs transfers; the user signs setup and revoke.** The user approves once and never signs again; the merchant cannot exceed the cap; the user can `revokeDelegation` at any time, which closes the PDA and returns the rent to the signer — or to the recorded `receiver` if a sponsor funded the account.\n\n*Job:* this is the part a reader cannot get from the README, and it is the part that makes the piece worth $2,750 instead of a link.\n\n### 4. A runnable repro, with exact pins\n\n```jsonc\n// package.json — copied out of the lockfile, not typed from memory\n{\n  \"dependencies\": {\n    \"@solana/kit\": \"7.0.0\",\n    \"@solana/subscriptions\": \"0.4.0\",\n    \"@solana-program/token\": \"<the exact version your lockfile resolved>\"\n  }\n}\n```\n\n```bash\nnpm ci\nnode repro.mjs            # prints the settlement signature\nnode repro.mjs --again    # prints AMOUNT_EXCEEDS_PERIOD_LIMIT\n```\n\n*Job:* let a reviewer verify claim (a) in under two minutes without reading your prose. `0.4.0`, not `^0.4.0` — a caret on a pre-1.0 package admits every future minor, and pre-1.0 minors break. Copy the resolved versions out of your lockfile; the version you *meant* to install is not evidence.\n\n### 5. What you would not use this for\n\n> Fixed delegation caps a total and never refills — that is an allowance, and it is what an autonomous agent should hold. x402 meters a single stateless request and involves no delegation at all. If your requirement is a human paying once at a checkout, none of the three is the answer.\n\n*Job:* a piece that says what the primitive is *not* for reads as written by someone who used it. A piece that claims one rail solves everything reads as marketing.\n\n---\n\nThat is the whole shape: **banner → problem → minimal implementation → the semantics that bite → a runnable repro with exact pins → the boundary.** Five sections and a header line.\n\n## Two additions that cost nothing\n\n**Say what you actually ran into.** If a call failed and you spent an hour on it, that hour is the most valuable paragraph in the piece — it is the paragraph no documentation contains. The empty-402-body case from lesson 6, where the server ships no body and puts the base64 envelope in the `PAYMENT-REQUIRED` header, is exactly this kind of paragraph.\n\n**Do not build the indexer.** If you want a sixth section, note that the program emits six event types as Anchor-compatible self-CPI inner instructions under the tag `e445a52e51cb9a1d`, which is how you would build a revenue dashboard on top of this. One paragraph. Naming the mechanism is the value; implementing it is a different bounty.\n\n## Where to publish\n\nAnywhere with a stable URL you control the content of, and where the code blocks survive: your own site, a GitHub repo with the repro in it, or the listing's stated venue. The URL is what you submit in the next lesson, so it has to still resolve in six months.\n\nNow write it. The exemplar above is the scaffold — the artifact is yours.\n"
+      },
+      {
+        "_key": "publish",
+        "_type": "openEnded",
+        "maxWords": 250,
+        "prompt": "Paste the URL of your published deep dive, then paste its version banner line verbatim. Under it, name which of the three recurring-delegation semantics you demonstrated with a runnable repro, and say what the reader has to run to see it fail. If you have not published yet, paste your section-3 draft instead — the claims and the observation that proves each one."
+      },
+      {
+        "_key": "check",
+        "_type": "quiz",
+        "questions": [
+          {
+            "explanation": "Undated and unpinned is exactly how every competing write-up on this primitive rotted. The banner is one line and it is the cheapest thing on the page.",
+            "id": "q1",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "A version banner carrying the exact package versions and the date you last ran the code"
+              },
+              {
+                "correct": false,
+                "feedback": "That moves the diagnosis onto the reader, who cannot tell whether their environment or your assumption is wrong. The banner answers it before they start.",
+                "id": "b",
+                "label": "A note asking readers to open an issue if anything breaks"
+              },
+              {
+                "correct": false,
+                "feedback": "The latest version is the one thing the reader can already look up. What they cannot recover is which version you ran.",
+                "id": "c",
+                "label": "A link to the package's npm page so readers can see the latest version"
+              },
+              {
+                "correct": false,
+                "feedback": "Ages nothing and helps nobody. The reader who found a Subscriptions deep dive already knows.",
+                "id": "d",
+                "label": "A longer introduction explaining what stablecoins are"
+              }
+            ],
+            "prompt": "Your deep dive ships with a code block that runs today. Which single addition does the most to keep it verifiable a year from now?"
+          },
+          {
+            "explanation": "0.4.0 was published 2026-07-13 and the package is pre-1.0 and moving. Pin it exactly, and copy the value out of your lockfile rather than typing it from memory.",
+            "id": "q2",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "\"@solana/subscriptions\": \"0.4.0\""
+              },
+              {
+                "correct": false,
+                "feedback": "A caret on a pre-1.0 package admits every future minor, and pre-1.0 minors are allowed to break. That is the range your repro cannot survive.",
+                "id": "b",
+                "label": "\"@solana/subscriptions\": \"^0.4.0\""
+              },
+              {
+                "correct": false,
+                "feedback": "The beta dist-tag points at 0.4.0-rc.2, which is an OLDER pre-release than 0.4.0. A dist-tag is not a pin.",
+                "id": "c",
+                "label": "\"@solana/subscriptions\": \"beta\""
+              },
+              {
+                "correct": false,
+                "feedback": "\"latest\" resolves to whatever ships next. It records nothing about what you ran.",
+                "id": "d",
+                "label": "\"@solana/subscriptions\": \"latest\""
+              }
+            ],
+            "prompt": "You are writing the dependency block. Which entry pins \"@solana/subscriptions\" correctly for this course?"
+          },
+          {
+            "explanation": "Skipped periods are lost. That is user-protective by design, and it is the semantic worth writing down because it is invisible in the call signatures.",
+            "id": "q3",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "5 USDC — skipped periods do not accumulate"
+              },
+              {
+                "correct": false,
+                "feedback": "This is the most common wrong assumption about the primitive. The cap is SET BACK to amountPerPeriod on rollover, not increased by it, so the delegatee's draw is bounded to one period at a time.",
+                "id": "b",
+                "label": "15 USDC — the unclaimed allowance carries forward"
+              },
+              {
+                "correct": false,
+                "feedback": "Nothing accumulates. Rollover restores the cap; it never adds to it.",
+                "id": "c",
+                "label": "10 USDC — the two skipped periods accumulate but the current one does not"
+              },
+              {
+                "correct": false,
+                "feedback": "A missed period costs that period's revenue, not the delegation. Only expiryTs ends it, and that is a hard stop with no grace period.",
+                "id": "d",
+                "label": "Nothing — missing a period expires the delegation"
+              }
+            ],
+            "prompt": "A merchant holds a recurring delegation for 5 USDC per 30-day period and forgets to collect for two consecutive periods. On the first day of the third period, how much can they pull in one transfer?"
+          },
+          {
+            "explanation": "One approval, many collections, bounded by the period cap and revocable at any time. That asymmetry is the security story of the module and belongs in section 3 of your write-up.",
+            "id": "q4",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "The delegatee — the user signed only setup, and signs again only to revoke"
+              },
+              {
+                "correct": false,
+                "feedback": "If the user had to sign every month you would not need a delegation at all — that is the one-off transfer the primitive exists to replace.",
+                "id": "b",
+                "label": "The user, for every collection"
+              },
+              {
+                "correct": false,
+                "feedback": "Requiring the user on every pull reintroduces the churn. The cap, not a second signature, is what bounds the delegatee.",
+                "id": "c",
+                "label": "Both the user and the delegatee, as co-signers"
+              },
+              {
+                "correct": false,
+                "feedback": "A PDA has no private key. The authority is program-controlled precisely so no keypair exists to hand out.",
+                "id": "d",
+                "label": "The Subscription Authority PDA, via a keypair the program hands you"
+              }
+            ],
+            "prompt": "In your reference implementation, who must sign the transaction that actually collects a period's charge?"
+          },
+          {
+            "explanation": "Naming a live version split explicitly is what separates a piece that stays useful from one that rots the next time a reader searches.",
+            "id": "q5",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "\"@x402/core\", \"@x402/svm\", \"@x402/express\", \"@x402/fetch\" at 2.19.0"
+              },
+              {
+                "correct": false,
+                "feedback": "The unscoped line is frozen at 1.2.0 from 2026-04-16 and speaks the older protocol version. Search engines still surface it first, which is why the split has to be named in the write-up.",
+                "id": "b",
+                "label": "\"x402\", \"x402-express\", \"x402-fetch\" at 1.2.0"
+              },
+              {
+                "correct": false,
+                "feedback": "That template ships the frozen unscoped package. Being official does not make it current.",
+                "id": "c",
+                "label": "\"x402-next\", because the official Solana template uses it"
+              },
+              {
+                "correct": false,
+                "feedback": "They are different protocol versions on the wire, with different header names and different envelope fields. Mixing them is the failure your readers will report as your bug.",
+                "id": "d",
+                "label": "Either line — the scoped packages are just re-publishes under a namespace"
+              }
+            ],
+            "prompt": "Your deep dive includes the metered endpoint from module 2. A reader copies your install line. Which dependency set do you give them?"
+          },
+          {
+            "explanation": "You wrote that policy down as a package author. A deep dive that restates the version contract it holds itself to is one a reviewer trusts.",
+            "id": "q6",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "Patch"
+              },
+              {
+                "correct": false,
+                "feedback": "Minor is a NEW instruction — added surface a consumer can start using. Regenerating unchanged output adds no surface.",
+                "id": "b",
+                "label": "Minor"
+              },
+              {
+                "correct": false,
+                "feedback": "Major is a changed account layout, a removed field or a renamed export — something that breaks a consumer who upgrades.",
+                "id": "c",
+                "label": "Major"
+              },
+              {
+                "correct": false,
+                "feedback": "Regenerated output can still differ (formatting, generator version), and shipping it under a patch is exactly what patch is for.",
+                "id": "d",
+                "label": "No release at all is warranted"
+              }
+            ],
+            "prompt": "Seeded from the client you published in the previous course. You regenerate the typed client against an IDL that has not changed and republish. Under the semver policy you committed to, what is that release?"
+          },
+          {
+            "explanation": "If your repro is going to be run by strangers, size it. Fixing it is fillTransactionMessageProvisoryResourceLimits, then estimateResourceLimitsFactory, then estimateAndSetResourceLimitsFactory — the current trio, all three halves from the same line.",
+            "id": "q7",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "The requested limit — the 200,000 CU default per non-builtin instruction, not what the transaction consumed"
+              },
+              {
+                "correct": false,
+                "feedback": "This is the assumption that makes the bug invisible. The fee is charged on the REQUESTED limit, which is why an untuned transaction silently overpays.",
+                "id": "b",
+                "label": "The compute units actually consumed, measured after execution"
+              },
+              {
+                "correct": false,
+                "feedback": "True that no price means no priority fee, but the question is what the fee is computed against once you do set one, and that is the requested limit.",
+                "id": "c",
+                "label": "Nothing — priority fees only apply when you set a compute unit price"
+              },
+              {
+                "correct": false,
+                "feedback": "That is the ceiling on the total request, not the default charged per instruction.",
+                "id": "d",
+                "label": "The 1,400,000 CU per-transaction clamp"
+              }
+            ],
+            "prompt": "Also seeded from the previous course. Your repro sends a transaction with no compute-budget instruction. What does the reader pay a priority fee on?"
+          }
+        ]
+      }
+    ],
+    "skills": [
+      "technical-writing",
+      "version-pinning",
+      "subscriptions-program",
+      "x402-protocol"
+    ],
+    "slug": {
+      "_type": "slug",
+      "current": "write-the-deep-dive"
+    },
+    "title": "Publish the Deep Dive"
   },
   {
     "_id": "lesson-serialization",

--- a/apps/web/src/content/generated/meta.json
+++ b/apps/web/src/content/generated/meta.json
@@ -1,11 +1,11 @@
 {
-  "compiledAt": "2026-07-16T13:45:02Z",
+  "compiledAt": "2026-07-26T14:14:04Z",
   "counts": {
     "achievements": 10,
-    "courses": 6,
-    "learningPaths": 7,
-    "lessons": 76,
+    "courses": 7,
+    "learningPaths": 8,
+    "lessons": 85,
     "quests": 5
   },
-  "sha": "bccd92fc4ff90c30f014e452de744d702a0413d6"
+  "sha": "012cd03ddcaa1122283a742862d5c5b885a7a913"
 }

--- a/apps/web/src/content/generated/paths.json
+++ b/apps/web/src/content/generated/paths.json
@@ -14,17 +14,10 @@
   {
     "_id": "path-defi",
     "_type": "learningPath",
-    "courses": [
-      {
-        "_key": "course-defi-on-solana",
-        "_ref": "course-defi-on-solana",
-        "_type": "reference",
-        "_weak": true
-      }
-    ],
+    "courses": [],
     "description": "Specialize in decentralized finance on Solana. Understand AMMs, lending protocols, token mechanics, and create DeFi primitives.",
     "difficulty": "advanced",
-    "draft": false,
+    "draft": true,
     "order": 4,
     "slug": "defi",
     "tag": "DeFi",
@@ -64,23 +57,10 @@
   {
     "_id": "path-rust-programs",
     "_type": "learningPath",
-    "courses": [
-      {
-        "_key": "course-rust-for-solana",
-        "_ref": "course-rust-for-solana",
-        "_type": "reference",
-        "_weak": true
-      },
-      {
-        "_key": "course-anchor-framework",
-        "_ref": "course-anchor-framework",
-        "_type": "reference",
-        "_weak": true
-      }
-    ],
+    "courses": [],
     "description": "Master Rust for blockchain and the Anchor framework. Write, test, and deploy production-ready Solana programs.",
     "difficulty": "intermediate",
-    "draft": false,
+    "draft": true,
     "order": 2,
     "slug": "rust-programs",
     "tag": "Builder",
@@ -101,10 +81,34 @@
   {
     "_id": "path-solana-core",
     "_type": "learningPath",
+    "courses": [],
+    "description": "The complete path from zero to Solana developer. Start with the fundamentals, understand how the network works, and build your first on-chain program.",
+    "difficulty": "beginner",
+    "draft": true,
+    "order": 1,
+    "slug": "solana-core",
+    "tag": "Foundation",
+    "title": "Solana Core"
+  },
+  {
+    "_id": "path-zero-to-deployed",
+    "_type": "learningPath",
     "courses": [
       {
         "_key": "course-solana-fundamentals",
         "_ref": "course-solana-fundamentals",
+        "_type": "reference",
+        "_weak": true
+      },
+      {
+        "_key": "course-rust-for-solana",
+        "_ref": "course-rust-for-solana",
+        "_type": "reference",
+        "_weak": true
+      },
+      {
+        "_key": "course-anchor-framework",
+        "_ref": "course-anchor-framework",
         "_type": "reference",
         "_weak": true
       },
@@ -115,12 +119,12 @@
         "_weak": true
       }
     ],
-    "description": "The complete path from zero to Solana developer. Start with the fundamentals, understand how the network works, and build your first on-chain program.",
+    "description": "The complete path from zero to your first deployed Solana program. Learn how the network works, master Rust and Anchor, then write, build, and ship a real program to Devnet.",
     "difficulty": "beginner",
     "draft": false,
     "order": 1,
-    "slug": "solana-core",
+    "slug": "zero-to-deployed",
     "tag": "Foundation",
-    "title": "Solana Core"
+    "title": "Zero to Deployed"
   }
 ]

--- a/apps/web/src/content/generated/skills.json
+++ b/apps/web/src/content/generated/skills.json
@@ -94,5 +94,77 @@
   {
     "label": "TypeScript",
     "slug": "typescript"
+  },
+  {
+    "label": "Solana Kit",
+    "slug": "solana-kit"
+  },
+  {
+    "label": "Token-2022",
+    "slug": "token-2022"
+  },
+  {
+    "label": "Transfer Hook",
+    "slug": "transfer-hook"
+  },
+  {
+    "label": "Error Handling",
+    "slug": "error-handling"
+  },
+  {
+    "label": "Protocol Versioning",
+    "slug": "protocol-versioning"
+  },
+  {
+    "label": "Version Pinning",
+    "slug": "version-pinning"
+  },
+  {
+    "label": "Payment Model Selection",
+    "slug": "payment-model-selection"
+  },
+  {
+    "label": "Solana Pay",
+    "slug": "solana-pay"
+  },
+  {
+    "label": "x402 Protocol",
+    "slug": "x402-protocol"
+  },
+  {
+    "label": "API Monetization",
+    "slug": "api-monetization"
+  },
+  {
+    "label": "Subscriptions Program",
+    "slug": "subscriptions-program"
+  },
+  {
+    "label": "Subscription Authority",
+    "slug": "subscription-authority"
+  },
+  {
+    "label": "Fixed Delegation",
+    "slug": "fixed-delegation"
+  },
+  {
+    "label": "Recurring Delegation",
+    "slug": "recurring-delegation"
+  },
+  {
+    "label": "Agent Budgets",
+    "slug": "agent-budgets"
+  },
+  {
+    "label": "Technical Writing",
+    "slug": "technical-writing"
+  },
+  {
+    "label": "Brazil Compliance",
+    "slug": "brazil-compliance"
+  },
+  {
+    "label": "Earn Submission",
+    "slug": "earn-submission"
   }
 ]

--- a/apps/web/src/content/generated/slots.json
+++ b/apps/web/src/content/generated/slots.json
@@ -116,5 +116,21 @@
       "lesson-wallet-setup": 2
     },
     "version": 1
+  },
+  "course-stablecoin-payments": {
+    "next": 9,
+    "retired": [],
+    "slots": {
+      "lesson-sap-budgeted-agent-with-a-hard-cap": 6,
+      "lesson-sap-meter-an-endpoint-with-x402": 4,
+      "lesson-sap-pay-the-402-programmatically": 5,
+      "lesson-sap-payment-rails-decision-map": 0,
+      "lesson-sap-recurring-delegation-paid-tier": 3,
+      "lesson-sap-submit-and-what-you-built": 8,
+      "lesson-sap-subscription-authority-and-allowance": 2,
+      "lesson-sap-token-or-token-2022": 1,
+      "lesson-sap-write-the-deep-dive": 7
+    },
+    "version": 1
   }
 }

--- a/apps/web/src/lib/content/__tests__/fixtures/golden/achievements-raw.json
+++ b/apps/web/src/lib/content/__tests__/fixtures/golden/achievements-raw.json
@@ -122,7 +122,7 @@
         "gte": null,
         "kind": "path-completed",
         "lte": null,
-        "path": "path-solana-core",
+        "path": "path-zero-to-deployed",
         "stat": null
       },
       "category": "skills",

--- a/apps/web/src/lib/content/__tests__/fixtures/golden/courses.json
+++ b/apps/web/src/lib/content/__tests__/fixtures/golden/courses.json
@@ -639,5 +639,108 @@
     "trackId": 1,
     "trackLevel": 1,
     "xpReward": 600
+  },
+  {
+    "_id": "course-stablecoin-payments",
+    "title": "Getting Paid: Stablecoin & Agentic Payments",
+    "slug": "stablecoin-agentic-payments",
+    "description": "You have a deployed vault app that earns nothing. Put a price on it. Open a Subscription Authority and a Recurring Delegation so the app has a real paid tier, meter a route with an x402 v2 challenge, and give an autonomous agent a wallet that can say no — an on-chain spend cap instead of an unlimited keypair. TypeScript only, no Rust and no local toolchain. You finish by publishing a version-pinned deep dive and submitting one live Superteam Earn listing. Scope is what BCB Resolution 561 leaves open to Brazilian builders from 2026-10-01, domestic merchant acceptance, contractor payouts, subscriptions and agent budgets.",
+    "difficulty": "intermediate",
+    "duration": 10,
+    "thumbnail": null,
+    "creator": "B7o8NfV81HzjuZFWQTTx3Xdvh77Dqoajwib3kWEnvzJF",
+    "tags": [
+      "agent-budgets",
+      "api-monetization",
+      "brazil-compliance",
+      "earn-submission",
+      "error-handling",
+      "fixed-delegation",
+      "payment-model-selection",
+      "pdas",
+      "protocol-versioning",
+      "recurring-delegation",
+      "solana-kit",
+      "solana-pay",
+      "spl-tokens",
+      "subscription-authority",
+      "subscriptions-program",
+      "technical-writing",
+      "token-2022",
+      "transfer-hook",
+      "version-pinning",
+      "x402-protocol"
+    ],
+    "xpReward": 750,
+    "trackId": 1,
+    "trackLevel": 5,
+    "modules": [
+      {
+        "key": "sap-paid-tier",
+        "title": "The Paid Tier",
+        "description": "Pick the rail your requirement actually needs, decide between Token and Token-2022 for the payment mint, then open a Subscription Authority and a Recurring Delegation on devnet. You end holding a delegation PDA and a settlement signature for a charge that correctly refuses to run a second time inside the same period.",
+        "lessons": [
+          {
+            "_id": "lesson-sap-payment-rails-decision-map",
+            "title": "Which Rail, and Is It Legal Where You Are",
+            "slug": "payment-rails-decision-map"
+          },
+          {
+            "_id": "lesson-sap-token-or-token-2022",
+            "title": "Token or Token-2022: The Decision Rule",
+            "slug": "token-or-token-2022"
+          },
+          {
+            "_id": "lesson-sap-subscription-authority-and-allowance",
+            "title": "One Approval, Many Budgets",
+            "slug": "subscription-authority-and-allowance"
+          },
+          {
+            "_id": "lesson-sap-recurring-delegation-paid-tier",
+            "title": "Charge Every Month, Cap Every Month",
+            "slug": "recurring-delegation-paid-tier"
+          }
+        ]
+      },
+      {
+        "key": "sap-metered-agentic",
+        "title": "Metered & Agentic",
+        "description": "Price one route so it returns a real 402 challenge, read a challenge and pay it programmatically across both live protocol versions, then wire a call loop that spends only from a Fixed Delegation and halts cleanly when the allowance refuses the next payment.",
+        "lessons": [
+          {
+            "_id": "lesson-sap-meter-an-endpoint-with-x402",
+            "title": "402 Payment Required, For Real",
+            "slug": "meter-an-endpoint-with-x402"
+          },
+          {
+            "_id": "lesson-sap-pay-the-402-programmatically",
+            "title": "Reading a Challenge and Paying It",
+            "slug": "pay-the-402-programmatically"
+          },
+          {
+            "_id": "lesson-sap-budgeted-agent-with-a-hard-cap",
+            "title": "An Agent With a Wallet That Can Say No",
+            "slug": "budgeted-agent-with-a-hard-cap"
+          }
+        ]
+      },
+      {
+        "key": "sap-get-paid",
+        "title": "Get Paid",
+        "description": "Publish a technical deep dive in the shape Superteam chapters pay for — dated, version-pinned, reproducible — then submit one live Earn listing and name every layer of the artifact you built, from your first signed transaction to a metered endpoint an agent pays for.",
+        "lessons": [
+          {
+            "_id": "lesson-sap-write-the-deep-dive",
+            "title": "Publish the Deep Dive",
+            "slug": "write-the-deep-dive"
+          },
+          {
+            "_id": "lesson-sap-submit-and-what-you-built",
+            "title": "Submit It — and What You Built",
+            "slug": "submit-and-what-you-built"
+          }
+        ]
+      }
+    ]
   }
 ]

--- a/apps/web/src/lib/content/__tests__/fixtures/golden/lessons.json
+++ b/apps/web/src/lib/content/__tests__/fixtures/golden/lessons.json
@@ -1068,52 +1068,52 @@
   },
   {
     "_id": "lesson-bfsp-m4-capstone",
+    "title": "What You've Built",
+    "slug": "what-you-built",
     "blocks": [
       {
-        "_type": "prose",
-        "amount": null,
-        "buildType": null,
-        "consumes": null,
-        "deployable": null,
-        "hints": null,
-        "idl": null,
         "key": "intro",
-        "language": null,
-        "maxWords": null,
-        "network": null,
+        "_type": "prose",
         "produces": null,
-        "prompt": null,
-        "questions": null,
-        "solution": null,
-        "src": "# What You've Built\n\nCongratulations! You've completed the full Solana developer lifecycle:\n\n## Your Journey\n\n1. **Write Code** — You wrote a counter program in Rust using the Anchor framework\n2. **Compile** — The Superteam Academy Build Server compiled it to a Solana program binary\n3. **Deploy** — You deployed it to Solana Devnet using the BPF Loader Upgradeable\n4. **Interact** — You called instructions and watched on-chain state change in real time\n\n## What You Learned\n\n### Anchor Framework\n- `#[program]` — defines your instruction handlers\n- `#[derive(Accounts)]` — specifies account constraints\n- `#[account]` — defines on-chain data structures\n- `#[error_code]` — custom errors enforced by the runtime\n\n### On-Chain Concepts\n- **Accounts** are Solana's storage primitive (not key-value pairs)\n- **Discriminators** identify account types (first 8 bytes)\n- **Rent** prevents spam (accounts must maintain minimum balance)\n- **Transactions** are batches of instructions signed by wallets\n\n### Deployment Protocol\n- Programs are uploaded in **~1000-byte chunks** via the BPF Loader\n- A **buffer account** holds the binary during upload\n- The **program account** is a pointer to the executable data\n- Upgradeable programs can be updated by the upgrade authority\n\n## What's Next?\n\n- **DeFi on Solana** — Build a token vault with PDAs and CPIs\n- **Anchor Framework Mastery** — Deep dive into testing, PDAs, and CPIs\n- **Install locally** — Set up Anchor CLI on your machine for faster iteration\n\nYour deployed program will continue to live on Devnet. You can interact with it anytime using the Solana CLI or any Anchor client.\n",
+        "consumes": null,
+        "src": "# What You've Built\n\nCongratulations! You've completed the full Solana developer lifecycle:\n\n## Your Journey\n\n1. **Write Code** — You wrote a counter program in Rust using the Anchor framework\n2. **Compile** — The Superteam Academy Build Server compiled it to a Solana program binary\n3. **Deploy** — You deployed it to Solana Devnet using the BPF Loader Upgradeable\n4. **Interact** — You called instructions and watched on-chain state change in real time\n\n## What You Learned\n\n### Anchor Framework\n- `#[program]` — defines your instruction handlers\n- `#[derive(Accounts)]` — specifies account constraints\n- `#[account]` — defines on-chain data structures\n- `#[error_code]` — custom errors enforced by the runtime\n\n### On-Chain Concepts\n- **Accounts** are Solana's storage primitive (not key-value pairs)\n- **Discriminators** identify account types (first 8 bytes)\n- **Rent** prevents spam (accounts must maintain minimum balance)\n- **Transactions** are batches of instructions signed by wallets\n\n### Deployment Protocol\n- Programs are uploaded in **~1000-byte chunks** via the BPF Loader\n- A **buffer account** holds the binary during upload\n- The **program account** is a pointer to the executable data\n- Upgradeable programs can be updated by the upgrade authority\n\n## Ship It: Your First Paid Solana Work\n\nYou now have something most applicants don't: a program you wrote, compiled, and deployed yourself, live on a public network. The next step isn't another course — it's putting that skill in front of teams that pay for it.\n\n**Superteam Earn** lists bounties and projects from real Solana teams, judged on submissions, not resumes. This is where deployed-a-program skills convert into your first $500–$5,000 of paid Solana work:\n\n1. **Browse open development work** — start with the [development bounties on Superteam Earn](https://superteam.fun/earn/category/development/). Look for small, scoped bounties with a defined deliverable: they are the fastest way to a first paid submission.\n2. **Write about what you built** — [content bounties](https://superteam.fun/earn/category/content/) pay for technical writing. A walkthrough of the counter program you just deployed — what confused you, and how you worked through it — is exactly the material sponsors ask for.\n3. **Have a bigger idea? Apply for a grant** — [Superteam grants](https://superteam.fun/earn/grants/) fund builders directly (avg $5.5k Brazil grants). A live Devnet program is the strongest artifact a first grant application can include.\n\nWhatever you submit, link your deployed program. It is live on a public network — anyone can verify it, and that proof is worth more than any certificate screenshot.\n\n## Keep Building\n\n- **Install locally** — Set up the Anchor CLI on your machine for faster iteration\n- **Solana Frontend Development** — Put a UI on your program: wallet integration, reading on-chain state, sending transactions from the browser\n\nYour deployed program will continue to live on Devnet. You can interact with it anytime using the Solana CLI or any Anchor client.\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
         "starter": null,
+        "solution": null,
         "tests": null,
-        "url": null
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       },
       {
-        "_type": "deployed-program-card",
-        "amount": null,
-        "buildType": null,
-        "consumes": ["deployed-program"],
-        "deployable": null,
-        "hints": null,
-        "idl": null,
         "key": "deployed",
-        "language": null,
-        "maxWords": null,
-        "network": null,
+        "_type": "deployed-program-card",
         "produces": null,
-        "prompt": null,
-        "questions": null,
-        "solution": null,
+        "consumes": ["deployed-program"],
         "src": null,
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
         "starter": null,
+        "solution": null,
         "tests": null,
-        "url": null
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       }
-    ],
-    "slug": "what-you-built",
-    "title": "What You've Built"
+    ]
   },
   {
     "_id": "lesson-bfsp-m4-deploy",
@@ -3695,5 +3695,2741 @@
     ],
     "slug": "why-rust",
     "title": "Why Rust for Solana"
+  },
+  {
+    "_id": "lesson-sap-payment-rails-decision-map",
+    "title": "Which Rail, and Is It Legal Where You Are",
+    "slug": "payment-rails-decision-map",
+    "blocks": [
+      {
+        "key": "intro",
+        "_type": "prose",
+        "produces": null,
+        "consumes": null,
+        "src": "# Which Rail, and Is It Legal Where You Are\n\n> **Version stamp — checked 2026-07-25.** `@solana/kit@7.0.0` · `@solana/subscriptions@0.4.0` (exact) · `@x402/core`, `@x402/svm`, `@x402/express`, `@x402/fetch` all `2.19.0`. Subscriptions Delegation Program: `De1egAFMkMWZSN5rYXRj9CAdheBamobVNubTsi9avR44`. This course is TypeScript only — no Rust, no local toolchain.\n\nYou finished Course 4 with a deployed app and a published client. It earns nothing.\n\nNothing in it charges anybody. There is no subscription, no metered route, no allowance, no invoice. This module fixes exactly that, and the first decision is not a line of code — it is which payment rail your requirement actually needs, because picking the wrong one costs you a rewrite three lessons later.\n\nThere are three rails worth knowing on Solana today, and one legal boundary that decides whether a requirement is even buildable from Brazil.\n\n## Rail 1 — the Subscriptions Delegation Program\n\nProgram id `De1egAFMkMWZSN5rYXRj9CAdheBamobVNubTsi9avR44`. Audited, shared (you do not deploy it — you call it), live on mainnet since 2026-06-02. It exists because of a limitation in the SPL token model that you will hit the moment you try to build a paid tier by hand:\n\n**A token account can have exactly one approved delegate.**\n\nApprove your subscription contract as the delegate for the user's USDC account and you have burned the only slot. That user can now never hold an allowance for an agent, or a merchant agreement, or a second subscription, on the same mint. The Subscriptions program's answer is a program-controlled **Subscription Authority** PDA per `(user, mint)` pair: the user approves the authority once, and the authority then hands out as many independently-capped delegations as the user wants. One approval, many budgets. That is lesson 3.\n\nOn top of that authority the program offers three models:\n\n| Model                    | Cap behaviour                                              | Use it for                                            |\n| ------------------------ | ---------------------------------------------------------- | ----------------------------------------------------- |\n| **Fixed delegation**     | One capped **total**. Draws down and does not refill.      | An allowance. An agent's budget. A prepaid balance.   |\n| **Recurring delegation** | Cap **resets every period**. Unused periods do not stack.  | Payroll, contractor payouts, a monthly paid tier.     |\n| **Subscription plan**    | Merchant publishes terms; approved pullers collect.        | A published price list many customers subscribe to.   |\n\nYou build a fixed delegation in lesson 3 and a recurring delegation in lesson 4. The fixed delegation from lesson 3 is the same object that becomes your agent's spending cap in lesson 7 — it is not a throwaway exercise.\n\n## Rail 2 — Solana Pay\n\nA human, a QR code, one payment, done. Point-of-sale and checkout. It carries no cap, no schedule and no delegation, because there is nothing to authorise ahead of time: the payer is standing there approving the transfer.\n\n**You will not install it in this course, and that is a deliberate decision, not an omission.**\n\n`@solana/kit@7.0.0` shipped on 2026-06-30. Most of the payments ecosystem has not caught up yet, and the peer ranges are worth reading rather than guessing. Off the published manifests on 2026-07-25:\n\n| Package | Peer range on `@solana/kit` | Admits 7.0.0? |\n| --- | --- | --- |\n| `@x402/svm@2.19.0` | `>=5.1.0` | yes |\n| `@solana/subscriptions@0.4.0` | `^6.4.0` | no |\n| `@solana/pay@1.0.23` | `^6.9.0` | no |\n\nSo the honest position is not \"Solana Pay is broken and the others are fine\". Two of the three rails declare a kit-6 peer, and pinning `@solana/kit@7.0.0` means carrying a **documented peer-dependency override** for the Subscriptions half. We take that override because Subscriptions is load-bearing for this entire module — you cannot build a paid tier without it. We do not take a second one for a rail we only need as a *decision*, especially when `@solana/pay` also peers `@solana-program/token ^0.12.0` against `@x402/svm`'s `^0.9.0` — disjoint ranges, and peers are yours to satisfy.\n\nName the seam. Pin the versions. Write down which override you took and why. That habit is worth more than the rail.\n\nSolana Pay is on your decision map as an **answer**; it is not on your `package.json`.\n\nRead the current reference at `solana.com/docs/payments`. Do **not** use `solana.com/developers/payments` — at time of writing it still quotes USDC statistics dated 1/31/22 and a Shopify integration that has moved on.\n\n## Rail 3 — x402\n\nAn HTTP status code turned into a payment protocol. The client calls your route, the server answers `402 Payment Required` with a machine-readable challenge naming the network, the asset and the address to pay, the client pays and retries with a payment header, the server settles and serves the response. Stateless, per request, no account relationship at all.\n\nThat property is exactly what makes it the agent rail: an autonomous caller with no login and no card can discover a price and satisfy it inside one request cycle. Module 2 is x402 end to end.\n\n## The legal boundary — BCB Resolution 561\n\nIf you are building from Brazil, this is the constraint no English-language Solana course is going to tell you about.\n\n**Banco Central do Brasil Resolution 561** was published 2026-04-30 and takes effect **2026-10-01**. Its practical rule for our purposes:\n\n> A regulated eFX provider may **not** take reais, convert them to USDT / USDC / BTC, and settle the resulting obligation abroad on-chain.\n\nThat closes a specific pattern — using stablecoins as the cross-border settlement leg of a foreign-exchange operation — for regulated operators. It does **not** close crypto in Brazil. Individuals may still buy, sell, hold and transfer through authorised VASPs.\n\nWhat stays open, and what this whole course is scoped to:\n\n- **Domestic merchant acceptance** — a Brazilian business charging a Brazilian customer.\n- **Contractor payouts.**\n- **Subscriptions** — the paid tier you build in this module.\n- **Agent budgets** — the allowance you cap in module 2.\n\nEvery example in this course sits inside that box. If a requirement's settlement leg is a regulated cross-border FX conversion, the correct engineering answer is **not a rail** — it is \"this is out of scope for the entity as regulated,\" and you route it to compliance before you route it to a program id.\n\n**Which is why the compliance check runs first.** A decision function that reaches \"recurring delegation\" and only afterwards asks \"wait, is this allowed?\" has already told a product manager to build the wrong thing. Compliance is a gate, not a fallback branch.\n\n## The worked example\n\nBelow is the full decision map, annotated. Read it, then make exactly one change.\n\nThe function takes a requirement described by three facts and returns a rail name:\n\n| Parameter                 | Values                                                          |\n| ------------------------- | --------------------------------------------------------------- |\n| `cadence`                 | `one-off` · `per-request` · `periodic` · `capped-total`          |\n| `settlement`              | `domestic-br` · `cross-border-fx` · `n-a`                        |\n| `merchantPublishesTerms`  | `true` when the merchant publishes a plan customers subscribe to |\n\nand the rail names it can return:\n\n- `blocked-by-bcb-561` — the compliance stop\n- `solana-pay` — human, one-off, standing there\n- `x402` — priced per request\n- `subscription-plan` — published terms, approved pullers collect\n- `recurring-delegation` — cap resets per period\n- `fixed-delegation` — one capped total, drawn down\n- `unsupported` — a cadence the map does not model; fail loudly rather than guess\n\nThe starter is complete and correct except for one thing: **the compliance guard is at the bottom instead of the top.** Every requirement with `settlement === \"cross-border-fx\"` and a cadence the map understands will be answered with a rail before the guard is ever reached. Move the guard so it runs before any rail is chosen. That is the whole edit.\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "decision-map",
+        "_type": "code",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": "typescript",
+        "buildType": "standard",
+        "deployable": false,
+        "starter": "/**\n * The payment-rail decision map.\n *\n * WORKED EXAMPLE — this code is complete and every branch below is correct.\n * There is exactly one thing wrong with it, and it is not a branch: it is the\n * ORDER. See the note at the bottom of the function.\n */\nfunction chooseRail(\n  cadence: string,\n  settlement: string,\n  merchantPublishesTerms: boolean\n): string {\n  // Priced per HTTP request, no account relationship, caller may be a machine.\n  // -> x402. Module 2 builds this end to end.\n  if (cadence === \"per-request\") {\n    return \"x402\";\n  }\n\n  // Charged again every period. If the merchant publishes terms that many\n  // customers subscribe to, that is a subscription plan; if you are charging\n  // your own users on your own schedule, it is a recurring delegation whose\n  // cap resets each period.\n  if (cadence === \"periodic\") {\n    return merchantPublishesTerms ? \"subscription-plan\" : \"recurring-delegation\";\n  }\n\n  // One capped total, drawn down over many pulls, no refill. An allowance.\n  // This is the agent budget in lesson 7.\n  if (cadence === \"capped-total\") {\n    return \"fixed-delegation\";\n  }\n\n  // A human approving a single transfer at a checkout. No cap and no schedule\n  // to authorise, because the payer is present. -> Solana Pay (as a decision;\n  // @solana/pay@1.0.23 peer-depends on @solana/kit ^6.9.0 and this course\n  // pins @solana/kit@7.0.0, so it is not installed here).\n  if (cadence === \"one-off\") {\n    return \"solana-pay\";\n  }\n\n  // ⚠️ THIS GUARD IS IN THE WRONG PLACE.\n  //\n  // BCB Resolution 561 (published 2026-04-30, effective 2026-10-01) closes the\n  // pattern where a regulated eFX provider takes reais, converts to a\n  // stablecoin and settles the obligation abroad on-chain. That is a stop, not\n  // a rail — and a stop that runs after the rails have already answered never\n  // stops anything.\n  //\n  // YOUR EDIT: move this block so it runs before any rail is chosen.\n  if (settlement === \"cross-border-fx\") {\n    return \"blocked-by-bcb-561\";\n  }\n\n  // A cadence the map does not model. Fail loudly instead of guessing a rail.\n  return \"unsupported\";\n}\n",
+        "solution": "/**\n * The payment-rail decision map.\n *\n * The compliance gate runs FIRST. A requirement whose settlement leg is a\n * regulated cross-border FX conversion has no rail — it has a stop.\n */\nfunction chooseRail(\n  cadence: string,\n  settlement: string,\n  merchantPublishesTerms: boolean\n): string {\n  // BCB Resolution 561 (published 2026-04-30, effective 2026-10-01): a\n  // regulated eFX provider may not take reais, convert to USDT/USDC/BTC and\n  // settle abroad on-chain. Gate, not fallback.\n  if (settlement === \"cross-border-fx\") {\n    return \"blocked-by-bcb-561\";\n  }\n\n  // Priced per HTTP request, no account relationship, caller may be a machine.\n  // -> x402. Module 2 builds this end to end.\n  if (cadence === \"per-request\") {\n    return \"x402\";\n  }\n\n  // Charged again every period. If the merchant publishes terms that many\n  // customers subscribe to, that is a subscription plan; if you are charging\n  // your own users on your own schedule, it is a recurring delegation whose\n  // cap resets each period.\n  if (cadence === \"periodic\") {\n    return merchantPublishesTerms ? \"subscription-plan\" : \"recurring-delegation\";\n  }\n\n  // One capped total, drawn down over many pulls, no refill. An allowance.\n  // This is the agent budget in lesson 7.\n  if (cadence === \"capped-total\") {\n    return \"fixed-delegation\";\n  }\n\n  // A human approving a single transfer at a checkout. No cap and no schedule\n  // to authorise, because the payer is present. -> Solana Pay (as a decision;\n  // @solana/pay@1.0.23 peer-depends on @solana/kit ^6.9.0 and this course\n  // pins @solana/kit@7.0.0, so it is not installed here).\n  if (cadence === \"one-off\") {\n    return \"solana-pay\";\n  }\n\n  // A cadence the map does not model. Fail loudly instead of guessing a rail.\n  return \"unsupported\";\n}\n",
+        "tests": [
+          {
+            "id": "t1",
+            "description": "A human paying once at a checkout maps to Solana Pay",
+            "input": "'one-off', 'domestic-br', false",
+            "expectedOutput": "result === 'solana-pay'"
+          },
+          {
+            "id": "t2",
+            "description": "A price on a single HTTP request maps to x402",
+            "input": "'per-request', 'domestic-br', false",
+            "expectedOutput": "result === 'x402'"
+          },
+          {
+            "id": "t3",
+            "description": "Charging your own users on your own schedule is a recurring delegation",
+            "input": "'periodic', 'domestic-br', false",
+            "expectedOutput": "result === 'recurring-delegation'"
+          },
+          {
+            "id": "t4",
+            "description": "Published terms that customers subscribe to is a subscription plan",
+            "input": "'periodic', 'domestic-br', true",
+            "expectedOutput": "result === 'subscription-plan'"
+          },
+          {
+            "id": "t5",
+            "description": "One capped total drawn down over many pulls is a fixed delegation",
+            "input": "'capped-total', 'domestic-br', false",
+            "expectedOutput": "result === 'fixed-delegation'"
+          },
+          {
+            "id": "t6",
+            "description": "Cross-border FX settlement is stopped even when the cadence has a rail",
+            "input": "'periodic', 'cross-border-fx', false",
+            "expectedOutput": "result === 'blocked-by-bcb-561'"
+          },
+          {
+            "id": "t7",
+            "description": "The compliance gate outranks x402 too",
+            "input": "'per-request', 'cross-border-fx', true",
+            "expectedOutput": "result === 'blocked-by-bcb-561'"
+          },
+          {
+            "id": "t8",
+            "description": "An unmodelled cadence fails loudly instead of guessing",
+            "input": "'annual-invoice', 'domestic-br', false",
+            "expectedOutput": "result === 'unsupported'"
+          }
+        ],
+        "hints": [
+          "The branches are all correct. Only their order is wrong.",
+          "A stop that runs after every rail has already returned never stops anything.",
+          "Move the `settlement === \"cross-border-fx\"` block above the `per-request` check."
+        ],
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "check",
+        "_type": "quiz",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": [
+          {
+            "id": "q1",
+            "prompt": "A regulated Brazilian eFX provider wants to take reais from a client, convert them to USDC, and settle the client's obligation to a supplier abroad on-chain. It is 2026-11-01. What does your decision map return, and why?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "`blocked-by-bcb-561` — the settlement leg is a regulated cross-border FX conversion, so no rail applies",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "`solana-pay` — it is a single transfer, so the one-off rail fits",
+                "correct": false,
+                "feedback": "The cadence would fit, which is exactly the trap. The compliance gate runs before cadence is ever consulted, because the question \"is this allowed for this entity\" outranks \"which rail is convenient\"."
+              },
+              {
+                "id": "c",
+                "label": "`fixed-delegation` — cap the total the provider can convert and the exposure is bounded",
+                "correct": false,
+                "feedback": "Capping the amount does not change the nature of the operation. Resolution 561 closes the pattern, not a size of it."
+              },
+              {
+                "id": "d",
+                "label": "`unsupported` — the map has no cadence for FX",
+                "correct": false,
+                "feedback": "`unsupported` means \"I do not model this cadence\". This case is modelled: it is stopped, and saying so precisely is the point."
+              }
+            ],
+            "explanation": "BCB Resolution 561 (published 2026-04-30, effective 2026-10-01) closes reais → stablecoin → offshore settlement for regulated eFX providers. Domestic merchant acceptance, contractor payouts, subscriptions and agent budgets stay open, and individuals may still transact through authorised VASPs."
+          },
+          {
+            "id": "q2",
+            "prompt": "Your API charges $0.002 per call. Callers are other people's scripts; they have no account with you and never will. Which rail?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "x402 — the price travels in a 402 response and the caller satisfies it in the same request cycle",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "A recurring delegation, billed monthly for the calls made",
+                "correct": false,
+                "feedback": "A delegation needs a prior on-chain relationship with each payer. These callers have none, which is the whole reason a stateless per-request challenge exists."
+              },
+              {
+                "id": "c",
+                "label": "A subscription plan the callers subscribe to",
+                "correct": false,
+                "feedback": "That is the right answer for a published price list with an onboarding step. It is the wrong answer for an anonymous script that wants one response now."
+              },
+              {
+                "id": "d",
+                "label": "Solana Pay, generating a QR per call",
+                "correct": false,
+                "feedback": "Solana Pay assumes a human is present to approve. Nobody is scanning a QR code inside a script's retry loop."
+              }
+            ],
+            "explanation": null
+          },
+          {
+            "id": "q3",
+            "prompt": "A recurring delegation is capped at 50 USDC per month. The merchant forgets to collect in March and April, then collects in May. How much can it pull in May?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "50 USDC — the cap resets each period and skipped periods do not accumulate",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "150 USDC — three periods of unused cap are now available",
+                "correct": false,
+                "feedback": "This is the single most common wrong mental model of the recurring model, and lesson 4 grades you on it. Unused periods are lost, not banked."
+              },
+              {
+                "id": "c",
+                "label": "0 USDC — missing a period voids the delegation",
+                "correct": false,
+                "feedback": "Nothing is voided. The delegation stays live until it expires or is revoked; only the unused capacity is gone."
+              },
+              {
+                "id": "d",
+                "label": "100 USDC — the two skipped periods carry, the current one does not",
+                "correct": false,
+                "feedback": "No period carries. The cap is per period, full stop."
+              }
+            ],
+            "explanation": null
+          },
+          {
+            "id": "q4",
+            "prompt": "You add `@solana/pay@1.0.23` to a project that already pins `@solana/kit@7.0.0`. Predict what happens at install time.",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "A peer-dependency conflict — `@solana/pay` declares `@solana/kit ^6.9.0`, which does not admit a 7.x",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "It installs cleanly; `^6.9.0` covers everything from 6.9 upward including 7.0",
+                "correct": false,
+                "feedback": "A caret pins the major. `^6.9.0` means \">=6.9.0 <7.0.0\". This is the exact seam that keeps Solana Pay off this course's dependency tree."
+              },
+              {
+                "id": "c",
+                "label": "It installs cleanly because peer dependencies are advisory and never fail an install",
+                "correct": false,
+                "feedback": "npm has installed peers automatically and errored on unsatisfiable ones since v7. You get a resolution error unless you override it deliberately."
+              },
+              {
+                "id": "d",
+                "label": "`@solana/kit` is silently downgraded to 6.9.0 for the whole project",
+                "correct": false,
+                "feedback": "A package manager will not rewrite your direct dependency to satisfy someone else's peer range. It reports the conflict."
+              }
+            ],
+            "explanation": "`@solana/subscriptions@0.4.0` declares the same shape of peer (`^6.4.0`), so this course carries one documented override for the rail it cannot do without, and declines a second for a rail it only needs as a decision. Naming the version seam is more useful than pretending one lockfile serves every rail."
+          }
+        ],
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      }
+    ]
+  },
+  {
+    "_id": "lesson-sap-token-or-token-2022",
+    "title": "Token or Token-2022: The Decision Rule",
+    "slug": "token-or-token-2022",
+    "blocks": [
+      {
+        "key": "intro",
+        "_type": "prose",
+        "produces": null,
+        "consumes": null,
+        "src": "# Token or Token-2022: The Decision Rule\n\n> **Version stamp — checked 2026-07-25.** `@solana/kit@7.0.0` · `@solana/subscriptions@0.4.0` (exact) · `@x402/svm@2.19.0` · `@solana-program/token` latest `0.15.0`, `@solana-program/token-2022` latest `0.13.0`. Every dependency range quoted below was read off the published package manifests on that date.\n\nThis is a checkpoint, not new material. You are about to open a delegation against a specific mint, and the program will either take that mint or refuse it. Before you write the call, get the rule straight.\n\n## Two token programs, not two eras\n\n| | Program id |\n| --- | --- |\n| **Token** (the original) | `TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA` |\n| **Token-2022** (token extensions) | `TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb` |\n\nOlder material — including an earlier version of this very curriculum — frames these as \"the mature one\" and \"the new one with limited support\". That framing is dead. Weekly npm downloads for the two client libraries sit within a couple of percent of each other, DEX and wallet support is at parity, and Token-2022 has been carrying production stablecoin supply for years. Neither program is a legacy of the other. They are **two mints with different capability surfaces**, and you choose per mint.\n\nThe one thing you cannot do is choose late. A mint's owner program is fixed at creation and every downstream address depends on it.\n\n## Why the choice changes your addresses\n\nThe associated token account is a PDA whose seeds are `[owner, tokenProgram, mint]`. The token program id is **in the seeds**. So the same wallet holding the same nominal asset has a different ATA depending on which token program minted it.\n\n```ts\nimport { findAssociatedTokenPda } from \"@solana-program/token\";\n\nconst [ata] = await findAssociatedTokenPda({\n  mint,\n  owner,\n  tokenProgram, // Token or Token-2022 — this changes the resulting address\n});\n```\n\nTwo notes on that snippet, both of which are corrections to material you may have read here before:\n\n1. **`getAssociatedTokenAddress` from `@solana/spl-token` is not the current API.** The Kit-native derivation is `findAssociatedTokenPda`, it is synchronous-looking but returns a promise, and it returns a `[address, bump]` tuple — not a bare address. Destructure it.\n2. **`tokenProgram` is a required input, not an optional flourish.** Passing the wrong one silently derives a real, valid, empty account that will never receive the transfer you are expecting.\n\n### The version seam you will actually trip over\n\n`@solana-program/token` is at `0.15.0`. Under semver, a caret range on a `0.x` package pins the **minor**, not the major — `^0.9.0` means `>=0.9.0 <0.10.0`. Read off the published manifests on 2026-07-25:\n\n| Package | Range it declares on `@solana-program/token` |\n| --- | --- |\n| `@x402/svm@2.19.0` | `^0.9.0` |\n| `@solana/subscriptions@0.4.0` | `^0.13.0` |\n| `@solana/pay@1.0.23` | `^0.12.0` (a **peer**) |\n\nThose three ranges are pairwise disjoint. For `@x402/svm` and `@solana/subscriptions` this is harmless — they are ordinary dependencies, so your package manager installs a copy each and nobody argues. For `@solana/pay` it is a **peer** dependency, which is your problem to satisfy, and it is one of the reasons Solana Pay is a decision in this course rather than an install.\n\nPin `@solana-program/token` yourself, at whatever version your own code imports, and do not assume the one your dependency resolved is the one you got.\n\n## The rule\n\n> **Legacy Token by default. Token-2022 only when a named extension is required. Then verify your rail accepts it.**\n\nThree clauses, and the third is the one everybody skips.\n\nThere are around 28 Token-2022 extensions. This course is not going to tour them — Blueshift already owns that material and does it well. What matters here is that **your payment rail gets a veto**, and the Subscriptions Delegation Program uses it.\n\n## What the rail refuses\n\nRead the error constants shipped in `@solana/subscriptions@0.4.0` and a whole family jumps out:\n\n| Error constant (suffix) | Message |\n| --- | --- |\n| `MINT_HAS_CONFIDENTIAL_TRANSFER` | Mint has ConfidentialTransfer extension |\n| `MINT_HAS_MINT_CLOSE_AUTHORITY` | Mint has MintCloseAuthority extension |\n| `MINT_HAS_NON_TRANSFERABLE` | Mint has NonTransferable extension |\n| `MINT_HAS_PAUSABLE` | Mint has Pausable extension |\n| `MINT_HAS_PERMANENT_DELEGATE` | Mint has PermanentDelegate extension |\n| `MINT_HAS_TRANSFER_FEE` | Mint has TransferFee extension |\n| `MINT_HAS_TRANSFER_HOOK` | Mint has TransferHook extension |\n\nSeven extensions that can disqualify a mint from a delegation. Look at *why* each one is there and the list stops being arbitrary:\n\n- **NonTransferable** — a delegation is a promise that somebody else can move your tokens. A mint that forbids transfers cannot honour it.\n- **PermanentDelegate** — the mint authority already holds an irrevocable delegate over every account. A user-scoped, user-revocable allowance is a fiction on top of it.\n- **Pausable / MintCloseAuthority** — a third party can invalidate the arrangement out from under both parties.\n- **TransferFee** — the amount that lands is not the amount authorised, so a cap stops meaning what it says.\n- **ConfidentialTransfer** — the balances the program must check are encrypted.\n- **TransferHook** — an arbitrary program runs inside the transfer, so the extra accounts it needs must be discovered and appended before the instruction is built. The SDK ships `resolveTransferHookAccounts` for exactly that; hook support is therefore **path-dependent**, which is the strongest possible argument for the rule's third clause. Do not assume. Test on devnet against the rail you are actually going to use.\n\nThe two errors you will hit most in module 1 have nothing to do with extensions, and are worth memorising now: `AMOUNT_EXCEEDS_LIMIT` (\"Transfer amount exceeds delegation limit\") for a fixed delegation, and `AMOUNT_EXCEEDS_PERIOD_LIMIT` (\"Transfer amount exceeds period limit\") for a recurring one. Lesson 4 is built on the second.\n\n## The exercise\n\nWrite the decision rule as a function. It takes what a decoded mint tells you — which program owns it, which extensions are configured on it — plus the one extension your product actually needs, and it returns a verdict.\n\nCheck the disqualifying extensions in this fixed order, so the verdict is deterministic when a mint carries more than one:\n\n```\nconfidential-transfer, mint-close-authority, non-transferable,\npausable, permanent-delegate, transfer-fee, transfer-hook\n```\n\nVerdict codes:\n\n| Code | Meaning |\n| --- | --- |\n| `INVALID_TOKEN_PROGRAM` | Not owned by either token program. Not a payment mint. |\n| `MINT_HAS_*` | The rail refuses this mint. Names the first disqualifying extension in the order above. |\n| `design-error-extension-requires-token-2022` | You asked for an extension on a legacy Token mint. That is not a thing. |\n| `design-error-required-extension-missing` | Token-2022 mint, but the extension you need is not configured on it. |\n| `ok-legacy-token` | Correct default. |\n| `ok-token-2022-extension-required` | Token-2022, justified by a named extension the rail accepts. |\n| `ok-token-2022-not-justified` | The rail will take it, but you had no reason to leave legacy Token. |\n\nNote that the last one is `accepted: true`. The rail is not your code reviewer. A verdict of \"this works and you still chose wrong\" is exactly the kind of thing a decision rule should be able to say.\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "check",
+        "_type": "quiz",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": [
+          {
+            "id": "q1",
+            "prompt": "You derive an ATA with `findAssociatedTokenPda({ mint, owner, tokenProgram })` and pass the legacy Token program id, but the mint was created under Token-2022. Predict what happens.",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "You get a valid, correctly-formed address that is simply the wrong account, and a transfer to it goes nowhere useful",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "The derivation throws, because the mint's owner is checked during derivation",
+                "correct": false,
+                "feedback": "PDA derivation is pure math over seeds. It never reads the mint account, so it cannot know the owner is wrong. That is exactly why the failure is silent."
+              },
+              {
+                "id": "c",
+                "label": "The token program id is not part of the ATA seeds, so you get the same address either way",
+                "correct": false,
+                "feedback": "It is in the seeds — `[owner, tokenProgram, mint]`. Change the token program and you change the address."
+              },
+              {
+                "id": "d",
+                "label": "You get the right address; the tokenProgram argument only selects which instructions get built",
+                "correct": false,
+                "feedback": "It does both. It selects the program AND it is a seed, so it moves the address."
+              }
+            ],
+            "explanation": null
+          },
+          {
+            "id": "q2",
+            "prompt": "A mint is Token-2022 and carries both `permanent-delegate` and `interest-bearing`. Your product needs the interest-bearing behaviour. Predict the outcome of opening a delegation against it.",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "Refused — `MINT_HAS_PERMANENT_DELEGATE`. A user-revocable allowance is meaningless when the mint authority already holds an irrevocable delegate.",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "Accepted — `interest-bearing` is not on the disqualifying list, and that is the extension you are relying on",
+                "correct": false,
+                "feedback": "The rail vetoes on what the mint *carries*, not on what you intended to use. One disqualifying extension is enough."
+              },
+              {
+                "id": "c",
+                "label": "Accepted with a warning, since PermanentDelegate does not affect the transfer amount",
+                "correct": false,
+                "feedback": "There is no warning path. It is an error constant, and the instruction fails."
+              },
+              {
+                "id": "d",
+                "label": "Refused — `MINT_HAS_TRANSFER_FEE`, because interest accrual is charged as a fee",
+                "correct": false,
+                "feedback": "Interest accrual is an exchange-rate mechanism, not a transfer fee. Different extension, different error."
+              }
+            ],
+            "explanation": null
+          },
+          {
+            "id": "q3",
+            "prompt": "Which of these are grounds for choosing Token-2022 for a payment mint under the rule taught here?",
+            "multiSelect": true,
+            "options": [
+              {
+                "id": "a",
+                "label": "Your product requires a named extension that the rail you are using accepts",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "Your compliance requirement needs a transfer hook, and you have verified the specific rail resolves hook accounts on the path you use",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "c",
+                "label": "It is the newer program, so new projects should default to it",
+                "correct": false,
+                "feedback": "\"Newer\" is not a requirement. The rule is legacy Token by default; Token-2022 buys you a capability and costs you a compatibility check."
+              },
+              {
+                "id": "d",
+                "label": "You might want an extension later, so minting under Token-2022 keeps options open",
+                "correct": false,
+                "feedback": "Extensions are configured at mint creation. Choosing the program early does not let you add one later, so this buys nothing and costs the check."
+              }
+            ],
+            "explanation": null
+          },
+          {
+            "id": "q4",
+            "prompt": "Carried over from Course 4 — semver. `@x402/svm@2.19.0` depends on `@solana-program/token` at `^0.9.0`. The published latest is `0.15.0`. Does that range resolve to `0.15.0`?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "No — on a 0.x package a caret pins the minor, so `^0.9.0` means `>=0.9.0 <0.10.0`",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "Yes — a caret allows any release below the next major, and there is no 1.0.0 yet",
+                "correct": false,
+                "feedback": "That is the 1.x behaviour. Below 1.0.0 semver treats the minor as the breaking position, and npm's caret follows it."
+              },
+              {
+                "id": "c",
+                "label": "Yes, but only if no lockfile is present",
+                "correct": false,
+                "feedback": "A lockfile pins what was already resolved. It does not widen a range that never admitted 0.15.0."
+              },
+              {
+                "id": "d",
+                "label": "No — a caret on a 0.x package pins the patch, so only `0.9.0` itself resolves",
+                "correct": false,
+                "feedback": "Patches still float. `^0.9.0` accepts `0.9.7`; it stops at `0.10.0`."
+              }
+            ],
+            "explanation": null
+          },
+          {
+            "id": "q5",
+            "prompt": "Also from Course 4 — decoded program errors. Your delegation call fails and the client surfaces `SUBSCRIPTIONS_ERROR__AMOUNT_EXCEEDS_PERIOD_LIMIT`. What kind of delegation are you talking to, and what does the message say?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "A recurring delegation — \"Transfer amount exceeds period limit\"",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "A fixed delegation — \"Transfer amount exceeds delegation limit\"",
+                "correct": false,
+                "feedback": "That is `AMOUNT_EXCEEDS_LIMIT`, the fixed-delegation error. The two are distinct constants with distinct messages, and telling them apart is how you know which cap you hit."
+              },
+              {
+                "id": "c",
+                "label": "Either one — it is the generic cap error for both models",
+                "correct": false,
+                "feedback": "There is no generic cap error. The program names the model in the constant."
+              },
+              {
+                "id": "d",
+                "label": "A subscription plan — the plan's billing terms were exceeded",
+                "correct": false,
+                "feedback": "Plan-related failures come back as `PLAN_*` constants (`PLAN_EXPIRED`, `PLAN_TERMS_MISMATCH`, and so on)."
+              }
+            ],
+            "explanation": null
+          }
+        ],
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "classify",
+        "_type": "code",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": "typescript",
+        "buildType": "standard",
+        "deployable": false,
+        "starter": "/**\n * Decide whether a mint can back a delegation, and whether the token program\n * it was minted under was the right call.\n *\n * @param ownerProgram      \"token\" | \"token-2022\" | anything else\n * @param extensions        pipe-separated extension slugs configured on the\n *                          mint, e.g. \"transfer-fee|interest-bearing\".\n *                          Empty string means no extensions.\n * @param requiredExtension the one extension your product actually needs.\n *                          Empty string means none.\n */\nfunction classifyPaymentMint(\n  ownerProgram: string,\n  extensions: string,\n  requiredExtension: string\n): { accepted: boolean; reason: string } {\n  // Checked in this order so a mint carrying several gets a stable verdict.\n  const DISQUALIFYING = [\n    \"confidential-transfer\",\n    \"mint-close-authority\",\n    \"non-transferable\",\n    \"pausable\",\n    \"permanent-delegate\",\n    \"transfer-fee\",\n    \"transfer-hook\",\n  ];\n  const configured = extensions === \"\" ? [] : extensions.split(\"|\");\n\n  // TODO: implement the rule.\n  //\n  //   1. Neither token program owns it            -> INVALID_TOKEN_PROGRAM\n  //   2. Legacy Token but an extension is needed  -> design-error-extension-requires-token-2022\n  //   3. First disqualifying extension configured -> MINT_HAS_<UPPER_SNAKE>\n  //   4. Legacy Token, nothing needed             -> ok-legacy-token\n  //   5. Token-2022, nothing needed               -> ok-token-2022-not-justified\n  //   6. Token-2022, needed extension absent      -> design-error-required-extension-missing\n  //   7. Otherwise                                -> ok-token-2022-extension-required\n  void DISQUALIFYING;\n  void configured;\n  void ownerProgram;\n  void requiredExtension;\n\n  return { accepted: true, reason: \"ok-legacy-token\" };\n}\n\n/** \"transfer-hook\" -> \"MINT_HAS_TRANSFER_HOOK\" */\nfunction mintHasCode(extension: string): string {\n  return \"MINT_HAS_\" + extension.split(\"-\").join(\"_\").toUpperCase();\n}\n",
+        "solution": "/**\n * Decide whether a mint can back a delegation, and whether the token program\n * it was minted under was the right call.\n */\nfunction classifyPaymentMint(\n  ownerProgram: string,\n  extensions: string,\n  requiredExtension: string\n): { accepted: boolean; reason: string } {\n  // Checked in this order so a mint carrying several gets a stable verdict.\n  const DISQUALIFYING = [\n    \"confidential-transfer\",\n    \"mint-close-authority\",\n    \"non-transferable\",\n    \"pausable\",\n    \"permanent-delegate\",\n    \"transfer-fee\",\n    \"transfer-hook\",\n  ];\n  const configured = extensions === \"\" ? [] : extensions.split(\"|\");\n\n  // 1. Not a payment mint at all.\n  if (ownerProgram !== \"token\" && ownerProgram !== \"token-2022\") {\n    return { accepted: false, reason: \"INVALID_TOKEN_PROGRAM\" };\n  }\n\n  // 2. Extensions do not exist on legacy Token. Asking for one here is a\n  //    design error, not a runtime one — catch it before you mint.\n  if (ownerProgram === \"token\" && requiredExtension !== \"\") {\n    return {\n      accepted: false,\n      reason: \"design-error-extension-requires-token-2022\",\n    };\n  }\n\n  // 3. The rail's veto. First disqualifying extension wins, in the declared\n  //    order, so the verdict is deterministic.\n  for (const extension of DISQUALIFYING) {\n    if (configured.indexOf(extension) !== -1) {\n      return { accepted: false, reason: mintHasCode(extension) };\n    }\n  }\n\n  // 4. The default, and the right answer most of the time.\n  if (ownerProgram === \"token\") {\n    return { accepted: true, reason: \"ok-legacy-token\" };\n  }\n\n  // 5. Accepted, and still the wrong call: nothing justified leaving legacy.\n  if (requiredExtension === \"\") {\n    return { accepted: true, reason: \"ok-token-2022-not-justified\" };\n  }\n\n  // 6. Token-2022 for an extension the mint does not actually carry.\n  if (configured.indexOf(requiredExtension) === -1) {\n    return { accepted: false, reason: \"design-error-required-extension-missing\" };\n  }\n\n  // 7. Justified, configured, and the rail accepts it.\n  return { accepted: true, reason: \"ok-token-2022-extension-required\" };\n}\n\n/** \"transfer-hook\" -> \"MINT_HAS_TRANSFER_HOOK\" */\nfunction mintHasCode(extension: string): string {\n  return \"MINT_HAS_\" + extension.split(\"-\").join(\"_\").toUpperCase();\n}\n",
+        "tests": [
+          {
+            "id": "t1",
+            "description": "A plain legacy Token mint is the default and is accepted",
+            "input": "'token', '', ''",
+            "expectedOutput": "result.accepted === true && result.reason === 'ok-legacy-token'"
+          },
+          {
+            "id": "t2",
+            "description": "Token-2022 with nothing to justify it is accepted but flagged",
+            "input": "'token-2022', '', ''",
+            "expectedOutput": "result.accepted === true && result.reason === 'ok-token-2022-not-justified'"
+          },
+          {
+            "id": "t3",
+            "description": "A configured transfer hook is refused by name",
+            "input": "'token-2022', 'transfer-hook', 'transfer-hook'",
+            "expectedOutput": "result.accepted === false && result.reason === 'MINT_HAS_TRANSFER_HOOK'"
+          },
+          {
+            "id": "t4",
+            "description": "A named extension the rail accepts justifies Token-2022",
+            "input": "'token-2022', 'interest-bearing|metadata-pointer', 'interest-bearing'",
+            "expectedOutput": "result.accepted === true && result.reason === 'ok-token-2022-extension-required'"
+          },
+          {
+            "id": "t5",
+            "description": "A disqualifying extension refuses the mint even when another one was the reason for choosing Token-2022",
+            "input": "'token-2022', 'transfer-fee|interest-bearing', 'interest-bearing'",
+            "expectedOutput": "result.accepted === false && result.reason === 'MINT_HAS_TRANSFER_FEE'"
+          },
+          {
+            "id": "t6",
+            "description": "Asking for an extension on a legacy Token mint is a design error",
+            "input": "'token', '', 'interest-bearing'",
+            "expectedOutput": "result.accepted === false && result.reason === 'design-error-extension-requires-token-2022'"
+          },
+          {
+            "id": "t7",
+            "description": "A mint owned by neither token program is not a payment mint",
+            "input": "'mpl-core', '', ''",
+            "expectedOutput": "result.accepted === false && result.reason === 'INVALID_TOKEN_PROGRAM'"
+          },
+          {
+            "id": "t8",
+            "description": "With two disqualifying extensions the declared order decides the verdict",
+            "input": "'token-2022', 'transfer-hook|permanent-delegate', ''",
+            "expectedOutput": "result.reason === 'MINT_HAS_PERMANENT_DELEGATE'"
+          },
+          {
+            "id": "t9",
+            "description": "Token-2022 chosen for an extension the mint does not carry",
+            "input": "'token-2022', 'metadata-pointer', 'interest-bearing'",
+            "expectedOutput": "result.accepted === false && result.reason === 'design-error-required-extension-missing'"
+          }
+        ],
+        "hints": [
+          "Order matters. Check the token program first, then the design errors that cannot be fixed at runtime, then the rail's veto.",
+          "Scan `DISQUALIFYING` in its declared order and return on the first hit — do not scan the mint's own extension list, or a mint carrying two will give you a different answer depending on how it was written.",
+          "`mintHasCode` is already written for you: it turns `transfer-hook` into `MINT_HAS_TRANSFER_HOOK`."
+        ],
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      }
+    ]
+  },
+  {
+    "_id": "lesson-sap-subscription-authority-and-allowance",
+    "title": "One Approval, Many Budgets",
+    "slug": "subscription-authority-and-allowance",
+    "blocks": [
+      {
+        "key": "intro",
+        "_type": "prose",
+        "produces": null,
+        "consumes": null,
+        "src": "# One Approval, Many Budgets\n\n> **Version stamp — checked 2026-07-25.** `@solana/subscriptions@0.4.0` **exactly** · `@solana/kit@7.0.0` · `@solana/kit-plugin-rpc@0.13.0` · `@solana/kit-plugin-signer` · `@solana-program/token` (pin the exact version you import). Program: `De1egAFMkMWZSN5rYXRj9CAdheBamobVNubTsi9avR44`.\n>\n> **Pin `0.4.0` exactly.** The `beta` dist-tag currently points at `0.4.0-rc.2`, which is an *older* build than the `latest` release. `@solana/subscriptions@beta` will therefore install you backwards. This package is pre-1.0 and moving — `0.1.0` shipped 2026-05-15 and `0.4.0` on 2026-07-13, four minors in two months. Pin the exact version and re-read the changelog before you bump.\n\n## Start with the constraint, not the API\n\nTry to build a paid tier by hand and you will reach for `approve` on the user's token account. It works. Then you build the second thing that needs to pull funds, and it does not.\n\n**An SPL token account holds exactly one approved delegate.** Not one per counterparty — one, total. Approve your subscription service and you have consumed it. That user can no longer hold an agent allowance, a merchant agreement, and your monthly charge at the same time on the same mint, because every new `approve` silently replaces the last one. The failure mode is not an error; it is somebody else's charge quietly ceasing to work.\n\nThe Subscriptions Delegation Program's answer is one level of indirection. The user approves **one** delegate: a program-controlled **SubscriptionAuthority** PDA, derived per `(user, tokenMint)` pair. That authority then issues as many independently-capped delegations as the user wants, each with its own delegatee, its own cap, its own expiry, and its own revoke.\n\nOne approval. Many budgets. That is the whole idea, and every step below is a consequence of it.\n\n## The client\n\n```ts\nimport { address, createClient } from \"@solana/kit\";\nimport { solanaDevnetRpc } from \"@solana/kit-plugin-rpc\";\nimport { signer } from \"@solana/kit-plugin-signer\";\nimport { subscriptionsProgram } from \"@solana/subscriptions\";\n\nconst client = createClient()\n  .use(signer(userSigner))\n  .use(solanaDevnetRpc({ rpcUrl: DEVNET_RPC_URL }))\n  .use(subscriptionsProgram());\n```\n\nThe plugin fills the configured signer and payer where it can, derives program PDAs for you, and can send transactions directly. Everything that follows hangs off `client.subscriptions`.\n\n## The six steps\n\n### 1. Derive the user's ATA\n\n```ts\nconst [userAta] = await findAssociatedTokenPda({ mint, owner: user, tokenProgram });\n```\n\n`[address, bump]` tuple — destructure it. `tokenProgram` is a seed (lesson 2), so pass the one that actually owns the mint.\n\n### 2. Derive the SubscriptionAuthority PDA\n\n```ts\nconst [subscriptionAuthority] = await findSubscriptionAuthorityPda({ tokenMint, user });\n```\n\nOne per `(user, tokenMint)`. Not per delegatee, not per product.\n\n### 3. Read it before you touch it\n\n```ts\nconst authority = await fetchMaybeSubscriptionAuthority(rpc, subscriptionAuthority);\nif (!authority.exists) {\n  // ...step 4\n}\n```\n\n**Branch on `.exists`.** This is the single most common error against this program: calling `initSubscriptionAuthority` unconditionally, so a returning user's second visit fails at step 4 and the whole flow dies before it reaches the delegation. `fetchMaybe*` is Kit's \"this may not be there\" fetch — it returns an object with an `exists` discriminant instead of throwing, and ignoring that discriminant is how you turn a normal state into a crash.\n\nThe plugin also exposes `client.subscriptions.queries.isSubscriptionAuthorityInitialized(user, tokenMint)` if all you need is the boolean.\n\n### 4. Initialise — only when it is not there\n\n```ts\nawait client.subscriptions.instructions\n  .initSubscriptionAuthority({ tokenMint, userAta, tokenProgram })\n  .sendTransaction();\n```\n\n`owner` and `payer` are filled from the configured signer, so the visible input is just the mint, the ATA and the token program. This is the transaction where the user's single delegate slot gets consumed — by the authority, once, on purpose.\n\n### 5. Open the Fixed Delegation\n\n```ts\nawait client.subscriptions.instructions\n  .createFixedDelegation({\n    tokenMint,\n    delegatee: agentAddress,\n    nonce: 0n,\n    amount: 25_000_000n,       // 25 USDC — BASE UNITS, as a bigint\n    expiryTs: BigInt(Math.floor(Date.now() / 1000) + 30 * 24 * 3600),\n  })\n  .sendTransaction();\n```\n\nFour things in that call will bite you:\n\n- **`amount` is base units, as a `bigint`.** `25` is twenty-five *millionths* of a USDC, not twenty-five USDC. There is no decimals conversion anywhere in this API. Do it once, in one function, and never inline it.\n- **`nonce` is what lets one delegator hold several delegations to the same delegatee.** It is part of the delegation PDA's seeds. Reuse a nonce with the same delegatee and you get `DELEGATION_ALREADY_EXISTS`; the account is already there.\n- **`expiryTs` is a hard stop with no grace period.** One second past it, transfers fail with `DELEGATION_EXPIRED`. Nothing renews, nothing warns, nothing degrades gracefully. If your product needs a renewal, your product builds the renewal.\n- **`payer` is optional, and it is how sponsorship works.** Pass a different signer and that account funds the rent instead of the user. The program stores who paid, and the teardown calls take an optional `receiver` to send it back to: on `revokeSubscriptionAuthority` the SDK documents `receiver` as *required when the authority's stored payer differs from `user`, and it must equal that stored payer*. Sponsorship is therefore a two-sided record — who paid on the way in decides who may be paid on the way out. Track it in your own database as well, because the failure surfaces months later.\n\nA fixed delegation is **one capped total that draws down and never refills**. Spend 25 USDC against a 25 USDC cap and it is finished — not \"finished for this month\". That is precisely the property that makes it a safe budget for something autonomous, which is why **this exact object becomes your agent's spending cap in lesson 7.** Do not think of it as an exercise.\n\n### 6. Pull from it\n\n```ts\nawait client.subscriptions.instructions\n  .transferFixed({\n    delegationPda,\n    delegator: userAddress,      // an Address — the user does NOT sign here\n    delegatorAta: userAta,\n    receiverAta: merchantAta,\n    tokenMint,\n    tokenProgram,\n    amount: 5_000_000n,\n  })\n  .sendTransaction();\n```\n\nLook at the types: `delegator` is an `Address`, `delegatee` is a `TransactionSigner`. **The user signs the setup and the revoke; the delegatee signs the transfers.** The user is not present when you charge them — that is the entire point of a delegation, and it is the security model of this module. Lesson 4 makes it a quiz question.\n\nOverrun the cap and you get `AMOUNT_EXCEEDS_LIMIT` — \"Transfer amount exceeds delegation limit\".\n\n## Your task\n\nWrite the planner. Given whether the authority already exists, a human-readable USDC amount, and whether a sponsor is paying, produce:\n\n- `steps` — the SDK operations in the order you would call them, using their exact names\n- `amountBaseUnits` — the amount converted to base units as a **`bigint`** (USDC has 6 decimals)\n- `payer` — `\"user\"` or `\"sponsor\"`\n\nThe starter has six numbered subgoals. The first two are filled in. Step 3 is always in the plan — you read the authority whether or not it exists, because that is how you found out.\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "plan",
+        "_type": "code",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": "typescript",
+        "buildType": "standard",
+        "deployable": false,
+        "starter": "/** USDC has 6 decimals. 1 USDC = 1_000_000 base units. */\nconst USDC_DECIMALS = 6;\n\n/**\n * Plan the calls that open a Fixed Delegation for one (user, mint) pair.\n *\n * @param authorityExists does the SubscriptionAuthority PDA already exist?\n * @param amountUsdc      the cap, in human USDC\n * @param sponsored       true when a sponsor signs as `payer` for the rent\n */\nfunction planFixedDelegation(\n  authorityExists: boolean,\n  amountUsdc: number,\n  sponsored: boolean\n): { steps: string[]; amountBaseUnits: bigint; payer: string } {\n  const steps: string[] = [];\n\n  // 1. Derive the user's associated token account for the payment mint.\n  //    findAssociatedTokenPda({ mint, owner, tokenProgram }) -> [address, bump]\n  steps.push(\"findAssociatedTokenPda\");\n\n  // 2. Derive the SubscriptionAuthority PDA for this (user, tokenMint) pair.\n  //    findSubscriptionAuthorityPda({ tokenMint, user }) -> [address, bump]\n  steps.push(\"findSubscriptionAuthorityPda\");\n\n  // 3. Read the authority before touching it. This step is ALWAYS in the plan —\n  //    reading is how you find out whether step 4 is needed.\n  //    fetchMaybeSubscriptionAuthority(rpc, pda) -> { exists, data }\n  // TODO\n\n  // 4. Initialise the authority ONLY when it does not exist yet. Calling\n  //    initSubscriptionAuthority unconditionally is the classic error here.\n  // TODO\n\n  // 5. Convert the human amount to base units as a bigint.\n  //    There is no decimals conversion anywhere in the SDK — this is it.\n  // TODO (and replace the 0n in the return below)\n\n  // 6. Open the delegation, then draw the first payment down from its cap.\n  //    createFixedDelegation, then transferFixed.\n  // TODO\n\n  return {\n    steps,\n    amountBaseUnits: 0n,\n    payer: sponsored ? \"sponsor\" : \"user\",\n  };\n}\n",
+        "solution": "/** USDC has 6 decimals. 1 USDC = 1_000_000 base units. */\nconst USDC_DECIMALS = 6;\n\n/**\n * Plan the calls that open a Fixed Delegation for one (user, mint) pair.\n */\nfunction planFixedDelegation(\n  authorityExists: boolean,\n  amountUsdc: number,\n  sponsored: boolean\n): { steps: string[]; amountBaseUnits: bigint; payer: string } {\n  const steps: string[] = [];\n\n  // 1. Derive the user's associated token account for the payment mint.\n  steps.push(\"findAssociatedTokenPda\");\n\n  // 2. Derive the SubscriptionAuthority PDA for this (user, tokenMint) pair.\n  steps.push(\"findSubscriptionAuthorityPda\");\n\n  // 3. Read the authority before touching it — always.\n  steps.push(\"fetchMaybeSubscriptionAuthority\");\n\n  // 4. Initialise it only when the read said it is not there.\n  if (!authorityExists) {\n    steps.push(\"initSubscriptionAuthority\");\n  }\n\n  // 5. Human amount -> base units, as a bigint, exactly once.\n  const amountBaseUnits = toBaseUnits(amountUsdc, USDC_DECIMALS);\n\n  // 6. Open the delegation, then draw the first payment down from its cap.\n  steps.push(\"createFixedDelegation\");\n  steps.push(\"transferFixed\");\n\n  return {\n    steps,\n    amountBaseUnits,\n    payer: sponsored ? \"sponsor\" : \"user\",\n  };\n}\n\n/**\n * Multiply in integer space and round once. Doing the arithmetic in bigint from\n * the start would be better still, but the input here is a JS number, so round\n * before the conversion rather than trusting float multiplication.\n */\nfunction toBaseUnits(amount: number, decimals: number): bigint {\n  let factor = 1;\n  for (let i = 0; i < decimals; i++) {\n    factor *= 10;\n  }\n  return BigInt(Math.round(amount * factor));\n}\n",
+        "tests": [
+          {
+            "id": "t1",
+            "description": "First-time user: all six steps, in order, including the init",
+            "input": "false, 25, false",
+            "expectedOutput": "result.steps.join('>') === 'findAssociatedTokenPda>findSubscriptionAuthorityPda>fetchMaybeSubscriptionAuthority>initSubscriptionAuthority>createFixedDelegation>transferFixed'"
+          },
+          {
+            "id": "t2",
+            "description": "Returning user: the init is skipped and nothing else moves",
+            "input": "true, 25, false",
+            "expectedOutput": "result.steps.join('>') === 'findAssociatedTokenPda>findSubscriptionAuthorityPda>fetchMaybeSubscriptionAuthority>createFixedDelegation>transferFixed'"
+          },
+          {
+            "id": "t3",
+            "description": "The authority is read even when it already exists",
+            "input": "true, 10, false",
+            "expectedOutput": "result.steps.indexOf('fetchMaybeSubscriptionAuthority') === 2 && result.steps.indexOf('initSubscriptionAuthority') === -1"
+          },
+          {
+            "id": "t4",
+            "description": "25 USDC is 25000000 base units, as a bigint",
+            "input": "false, 25, false",
+            "expectedOutput": "typeof result.amountBaseUnits === 'bigint' && result.amountBaseUnits === 25000000n"
+          },
+          {
+            "id": "t5",
+            "description": "Sub-unit amounts convert without losing the fraction",
+            "input": "true, 0.123456, false",
+            "expectedOutput": "result.amountBaseUnits === 123456n"
+          },
+          {
+            "id": "t6",
+            "description": "A sponsor paying the rent is recorded on the plan",
+            "input": "false, 25, true",
+            "expectedOutput": "result.payer === 'sponsor' && result.steps.indexOf('initSubscriptionAuthority') === 3"
+          },
+          {
+            "id": "t7",
+            "description": "The transfer is always last — you cannot pull from a delegation you have not opened",
+            "input": "false, 5, false",
+            "expectedOutput": "result.steps[result.steps.length - 1] === 'transferFixed' && result.steps.indexOf('createFixedDelegation') < result.steps.indexOf('transferFixed')"
+          }
+        ],
+        "hints": [
+          "Subgoal 3 is unconditional. You read the authority in order to learn whether subgoal 4 is needed, so the read is in the plan either way.",
+          "Only subgoal 4 is conditional. Everything else runs on every path.",
+          "USDC has 6 decimals: multiply by 1_000_000 and round once, then wrap the integer in BigInt(). Do not build the bigint out of a float."
+        ],
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "check",
+        "_type": "quiz",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": [
+          {
+            "id": "q1",
+            "prompt": "You call `initSubscriptionAuthority` unconditionally, without reading the account first. A user who set this up last month comes back. Predict what happens.",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "The transaction fails on the init and the delegation is never created — the returning user is worse off than a new one",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "It is idempotent — the program sees the authority already exists and returns success",
+                "correct": false,
+                "feedback": "Nothing in this program is idempotent by convenience. Creating an account that exists is an error, which is why `fetchMaybe*` gives you an `exists` discriminant to branch on."
+              },
+              {
+                "id": "c",
+                "label": "A second SubscriptionAuthority PDA is created, and the delegation attaches to the new one",
+                "correct": false,
+                "feedback": "The PDA is derived from `(user, tokenMint)`. There is exactly one address; you cannot have two."
+              },
+              {
+                "id": "d",
+                "label": "It succeeds and resets all of the user's existing delegations",
+                "correct": false,
+                "feedback": "Tearing down an authority and invalidating its delegations is what `closeSubscriptionAuthority` is for, and it is deliberate. `init` does not silently do it."
+              }
+            ],
+            "explanation": null
+          },
+          {
+            "id": "q2",
+            "prompt": "You mean to cap a delegation at 25 USDC and pass `amount: 25n`. Predict the cost of the mistake.",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "The cap is 25 base units — 0.000025 USDC — and the first real charge fails with `AMOUNT_EXCEEDS_LIMIT`",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "The SDK reads the mint's decimals and scales 25 to 25000000",
+                "correct": false,
+                "feedback": "There is no decimals conversion anywhere in this API. Every amount is base units. That is why you write the conversion once, in one function."
+              },
+              {
+                "id": "c",
+                "label": "It throws at call time, because 25 is below a minimum delegation amount",
+                "correct": false,
+                "feedback": "The only zero-related guard is `FIXED_DELEGATION_AMOUNT_ZERO`. 25 base units is a perfectly legal, perfectly useless cap."
+              },
+              {
+                "id": "d",
+                "label": "Nothing — `amount` is a display hint and the real cap comes from the token account balance",
+                "correct": false,
+                "feedback": "`amount` is the cap. The balance is a separate constraint that also has to hold."
+              }
+            ],
+            "explanation": null
+          },
+          {
+            "id": "q3",
+            "prompt": "A fixed delegation's `expiryTs` passed 40 seconds ago. Your merchant service tries to collect. Predict the behaviour.",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "The transfer fails with `DELEGATION_EXPIRED`. There is no grace period, no warning and no auto-renewal.",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "It succeeds — expiry only blocks *new* delegations, not pulls against existing ones",
+                "correct": false,
+                "feedback": "Expiry is checked on the transfer. It is a hard stop on the delegation, not a creation-time flag."
+              },
+              {
+                "id": "c",
+                "label": "It succeeds inside a short grace window and fails after it",
+                "correct": false,
+                "feedback": "There is no grace window. If your product needs one, your product builds it."
+              },
+              {
+                "id": "d",
+                "label": "The delegation auto-renews for another identical term",
+                "correct": false,
+                "feedback": "Nothing renews. Renewal is a new `createFixedDelegation` with a new nonce, signed by the user."
+              }
+            ],
+            "explanation": null
+          },
+          {
+            "id": "q4",
+            "prompt": "Read the types. In `transferFixed`, `delegator` is an `Address` and `delegatee` is a `TransactionSigner`. Who must sign the charge?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "The delegatee. The user signed once at setup and is not present when they are charged.",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "Both — the user co-signs every pull so they can always refuse",
+                "correct": false,
+                "feedback": "If the user had to co-sign every pull, the delegation would be pointless. The cap, the expiry and the revoke are what protect them, not a signature per charge."
+              },
+              {
+                "id": "c",
+                "label": "The delegator, because it is their tokens moving",
+                "correct": false,
+                "feedback": "`delegator` is typed as a plain `Address` precisely because it is not a signer on this instruction. The types tell you."
+              },
+              {
+                "id": "d",
+                "label": "The SubscriptionAuthority PDA, via the program's own signature",
+                "correct": false,
+                "feedback": "The authority is the SPL delegate and the program signs for it, but the transaction still needs an authorised human or service to sign — and that is the delegatee."
+              }
+            ],
+            "explanation": null
+          },
+          {
+            "id": "q5",
+            "prompt": "A sponsor signed as `payer`, so the sponsor funded the SubscriptionAuthority PDA's rent. Later the user calls `revokeSubscriptionAuthority` with no `receiver`. Predict the result.",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "It fails — `receiver` is required when the stored payer differs from `user`, and it must equal that stored payer",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "It succeeds and the rent goes to the user, who did not pay it",
+                "correct": false,
+                "feedback": "The program records who funded the account exactly so it cannot silently redirect their rent. Sponsorship without that record would be a free withdrawal."
+              },
+              {
+                "id": "c",
+                "label": "It succeeds and the rent is burned",
+                "correct": false,
+                "feedback": "Lamports from a closed account go to a recipient account; the program will not destroy them."
+              },
+              {
+                "id": "d",
+                "label": "It succeeds and the rent is returned to the sponsor automatically, no argument needed",
+                "correct": false,
+                "feedback": "The sponsor's address is stored, but you still have to pass it as `receiver`. The call fails rather than guessing."
+              }
+            ],
+            "explanation": "Sponsorship is a two-sided record: who paid on the way in decides who may be paid on the way out. Track it in your own database too, because the failure surfaces months later."
+          }
+        ],
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      }
+    ]
+  },
+  {
+    "_id": "lesson-sap-recurring-delegation-paid-tier",
+    "title": "Charge Every Month, Cap Every Month",
+    "slug": "recurring-delegation-paid-tier",
+    "blocks": [
+      {
+        "key": "intro",
+        "_type": "prose",
+        "produces": null,
+        "consumes": null,
+        "src": "# Charge Every Month, Cap Every Month\n\n> **Version stamp — checked 2026-07-25.** `@solana/subscriptions@0.4.0` **exactly** · `@solana/kit@7.0.0`. Program: `De1egAFMkMWZSN5rYXRj9CAdheBamobVNubTsi9avR44`.\n\nThe fixed delegation you opened in lesson 3 is a budget: one total, drawn down, gone. A paid tier is a different shape. You want to charge 25 USDC this month, 25 USDC next month, and never more than 25 USDC in any month no matter how many times your billing job runs.\n\nThat is a **recurring delegation**, and its three semantics are the whole lesson.\n\n## Opening it\n\n```ts\nawait client.subscriptions.instructions\n  .createRecurringDelegation({\n    tokenMint,\n    delegatee: merchantAddress,\n    nonce: 1n,\n    amountPerPeriod: 25_000_000n,        // base units, as a bigint\n    periodLengthS: BigInt(30 * 24 * 3600),\n    startTs: 0n,                          // start when the transaction lands\n    expiryTs: BigInt(Math.floor(Date.now() / 1000) + 365 * 24 * 3600),\n  })\n  .sendTransaction();\n```\n\nSame authority, same `(user, tokenMint)` pair, different **nonce** — which is exactly the \"one approval, many budgets\" property doing its job. The lesson-3 fixed delegation is still open and untouched.\n\n`startTs: 0n` means \"the first period begins when this lands\". That convenience has a rule attached: **start-on-landing requires a non-zero `expiryTs`.** Pass both as zero and the program refuses with *\"start_ts of 0 (start on landing) requires a non-zero expiry\"* — an open-ended pull authorisation with no defined start is not something it will sign off on.\n\n## Collecting\n\n```ts\nawait client.subscriptions.instructions\n  .transferRecurring({\n    delegationPda,\n    delegator: userAddress,     // Address — the user is not here\n    delegatorAta: userAta,\n    receiverAta: merchantAta,\n    tokenMint,\n    tokenProgram,\n    amount: 25_000_000n,\n  })\n  .sendTransaction();\n```\n\n`transferRecurring` takes the identical input type as `transferFixed`. Same signing model, and it is worth saying again because it is the security point of this whole module:\n\n> **The user signs the setup and the revoke. The delegatee signs the transfers.**\n\n`delegator` is an `Address`; `delegatee` is a `TransactionSigner`. Your billing job holds the delegatee key. It cannot exceed the cap, it cannot extend the expiry, and it cannot stop the user revoking. Those three facts are what let you run it unattended.\n\n## The three semantics that must stick\n\n### 1. A second pull inside the same period fails\n\nCharge 25 USDC on the 3rd. Charge 1 more USDC on the 4th, same period. The program returns `AMOUNT_EXCEEDS_PERIOD_LIMIT` — *\"Transfer amount exceeds period limit\"*.\n\nThis is a feature, and it is the one your retry logic depends on. A billing job that crashes after the transfer landed but before it wrote its own record will retry. The retry is refused. The cap **is** your idempotency guard, as long as you read the error and treat it as \"already collected\" rather than \"temporary failure, back off and try again in five minutes\" for the rest of the month.\n\nNote the neighbouring error you will also meet: `PERIOD_NOT_ELAPSED` — *\"Period has not elapsed yet\"* — which is what you get when you try to collect for a period that has not started.\n\n### 2. The cap resets on period rollover\n\nOnce the clock crosses into the next period, the full `amountPerPeriod` is available again. Nothing is carried, nothing is prorated, and you do not call anything to make it happen. There is no \"renew\" instruction because there is nothing to renew.\n\n### 3. Skipped periods do not accumulate\n\nThis is the one that surprises people, and it is the one the exercise grades hardest.\n\nA merchant who forgets to collect in March and April does not get to collect 75 USDC in May. They get 25 USDC in May. **The unused capacity is gone.** The cap is a per-period ceiling, not an accruing balance.\n\nRead it from the user's side and it is obviously correct: they authorised \"up to 25 per month\", not \"up to 25 per month, banked indefinitely, redeemable in a lump sum by whoever holds the delegatee key\". The second thing would be a much larger authorisation wearing the first one's clothes.\n\nIf your business needs missed periods to be collectable, that is an invoice, and you build it in your own system. The delegation will not do it for you.\n\n## Revoking\n\n```ts\nawait client.subscriptions.instructions\n  .revokeDelegation({ delegationAccount: delegationPda })\n  .sendTransaction();\n```\n\nThe `authority` — the user — signs, and is filled from the configured signer. This **closes the PDA** and returns its rent. Pass `receiver` when somebody other than the user funded it.\n\nRevocation is permanent for that delegation. There is no pause. Re-establishing the arrangement means a new `createRecurringDelegation` with a new nonce, signed by the user, which means the user is present and consenting again. That is the correct trade.\n\n## The exercise — put the pieces in order\n\nThe starter contains the body of the period-accounting function, but scrambled: **three candidate lines for the available amount, of which one is right, and two return statements in the wrong order.** Only one candidate line is active.\n\nTwo decoys, both of which are real mistakes people ship:\n\n- **Decoy A — the cap that never resets.** `periodLimit - chargedInCurrentPeriod`, unconditionally. It ignores the rollover entirely, so the delegation works for exactly one period and then quietly refuses everything forever. This is the same class of error as revoking before collecting: an operation that looks correct in the happy path and destroys the arrangement on the second cycle.\n- **Decoy B — the accumulating cap.** `periodLimit * (currentPeriod - lastChargedPeriod + 1) - chargedInCurrentPeriod`. This one is worse, because it is *nearly* right: it agrees with the correct answer on every test where no period was skipped. It only diverges when a merchant comes back after missing a few — which is exactly the case where it lets them take money the user never authorised. This is the fixed-delegation model smuggled into a recurring PDA.\n\nThe ordering error matters too: if the success return runs before the over-cap guard, the guard is unreachable and every request is approved.\n\nAmounts here are plain integer base units so the arithmetic is legible. In your real client they are `bigint`, converted once, exactly as in lesson 3.\n\n## Milestone — write these down\n\nBefore you move to module 2, do this on devnet and keep the output:\n\n1. The **recurring delegation PDA** you created.\n2. The **settlement signature** of the charge that succeeded.\n3. The **error** you got when you collected a second time inside the same period.\n\nLesson 8 asks you to publish a deep dive with a reproducible run, and these three artifacts are the run. A screenshot of the second attempt failing with `AMOUNT_EXCEEDS_PERIOD_LIMIT` is worth more than a paragraph claiming it does.\n\n## Optional: where a revenue dashboard would come from\n\nThe program emits its state changes as Anchor-compatible **self-CPI inner instructions** through an event-authority PDA — `findEventAuthorityPda`, seed `\"event_authority\"` — and validates them on the way out with `INVALID_EVENT_AUTHORITY`, `INVALID_EVENT_TAG` and `INVALID_EVENT_DISCRIMINATOR`. An indexer that watches inner instructions for that authority sees every delegation created, every transfer settled and every revoke, per user, in order.\n\nThat is how you would build merchant revenue reporting. **Do not build it here.** It is a different course, and this one has an agent to fund.\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "collect",
+        "_type": "code",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": "typescript",
+        "buildType": "standard",
+        "deployable": false,
+        "starter": "/**\n * One collection attempt against a recurring delegation.\n *\n * Every line you need is already below. Two of the three `available` candidates\n * are decoys, and the guard sits below the success return instead of above it.\n * Rearrange; do not rewrite.\n *\n * @param periodLimitBaseUnits   amountPerPeriod, in base units\n * @param currentPeriod          index of the period the clock is in now\n * @param lastChargedPeriod      index of the period of the last successful pull\n * @param chargedInCurrentPeriod already collected inside `currentPeriod`\n * @param requestBaseUnits       what this attempt is asking for\n */\nfunction collectRecurring(\n  periodLimitBaseUnits: number,\n  currentPeriod: number,\n  lastChargedPeriod: number,\n  chargedInCurrentPeriod: number,\n  requestBaseUnits: number\n): {\n  ok: boolean;\n  error: string;\n  charged: number;\n  remainingThisPeriod: number;\n} {\n  // --- candidate 1 ----------------------------------------------------------\n  // The cap that never resets: subtracts what was taken this period, but never\n  // notices that the clock moved on.\n  // const available = periodLimitBaseUnits - chargedInCurrentPeriod;\n\n  // --- candidate 2 (currently active) ---------------------------------------\n  // The accumulating cap: agrees with the truth whenever no period was skipped,\n  // and hands over several periods' worth the moment one was.\n  const available =\n    periodLimitBaseUnits * (currentPeriod - lastChargedPeriod + 1) -\n    chargedInCurrentPeriod;\n\n  // --- candidate 3 ----------------------------------------------------------\n  // const available =\n  //   currentPeriod > lastChargedPeriod\n  //     ? periodLimitBaseUnits\n  //     : periodLimitBaseUnits - chargedInCurrentPeriod;\n\n  const overCap = requestBaseUnits > available;\n\n  // --- the next two blocks are in the wrong order ---------------------------\n\n  return {\n    ok: true,\n    error: \"\",\n    charged: requestBaseUnits,\n    remainingThisPeriod: available - requestBaseUnits,\n  };\n\n  if (overCap) {\n    return {\n      ok: false,\n      error: \"AMOUNT_EXCEEDS_PERIOD_LIMIT\",\n      charged: 0,\n      remainingThisPeriod: available,\n    };\n  }\n}\n",
+        "solution": "/**\n * One collection attempt against a recurring delegation.\n *\n * The whole model is in the `available` expression: on a period rollover the\n * cap is the full period limit again (semantic 2), and it is the full period\n * limit no matter how many periods were skipped (semantic 3).\n */\nfunction collectRecurring(\n  periodLimitBaseUnits: number,\n  currentPeriod: number,\n  lastChargedPeriod: number,\n  chargedInCurrentPeriod: number,\n  requestBaseUnits: number\n): {\n  ok: boolean;\n  error: string;\n  charged: number;\n  remainingThisPeriod: number;\n} {\n  const available =\n    currentPeriod > lastChargedPeriod\n      ? periodLimitBaseUnits\n      : periodLimitBaseUnits - chargedInCurrentPeriod;\n\n  const overCap = requestBaseUnits > available;\n\n  // The guard runs first, or it does not run at all.\n  if (overCap) {\n    return {\n      ok: false,\n      error: \"AMOUNT_EXCEEDS_PERIOD_LIMIT\",\n      charged: 0,\n      remainingThisPeriod: available,\n    };\n  }\n\n  return {\n    ok: true,\n    error: \"\",\n    charged: requestBaseUnits,\n    remainingThisPeriod: available - requestBaseUnits,\n  };\n}\n",
+        "tests": [
+          {
+            "id": "t1",
+            "description": "First pull of a fresh period takes the whole cap",
+            "input": "25000000, 7, 6, 0, 25000000",
+            "expectedOutput": "result.ok === true && result.charged === 25000000 && result.remainingThisPeriod === 0"
+          },
+          {
+            "id": "t2",
+            "description": "A second pull inside the same period is refused by name",
+            "input": "25000000, 7, 7, 25000000, 1000000",
+            "expectedOutput": "result.ok === false && result.error === 'AMOUNT_EXCEEDS_PERIOD_LIMIT' && result.charged === 0"
+          },
+          {
+            "id": "t3",
+            "description": "Two partial pulls inside one period are fine until the cap is reached",
+            "input": "25000000, 7, 7, 10000000, 15000000",
+            "expectedOutput": "result.ok === true && result.remainingThisPeriod === 0"
+          },
+          {
+            "id": "t4",
+            "description": "The cap resets on period rollover with nothing to call",
+            "input": "25000000, 8, 7, 25000000, 25000000",
+            "expectedOutput": "result.ok === true && result.charged === 25000000 && result.remainingThisPeriod === 0"
+          },
+          {
+            "id": "t5",
+            "description": "Five skipped periods do not accumulate — two periods' worth is still refused",
+            "input": "25000000, 12, 7, 0, 50000000",
+            "expectedOutput": "result.ok === false && result.error === 'AMOUNT_EXCEEDS_PERIOD_LIMIT' && result.remainingThisPeriod === 25000000"
+          },
+          {
+            "id": "t6",
+            "description": "After skipping, exactly one period's worth is still collectable",
+            "input": "25000000, 12, 7, 0, 25000000",
+            "expectedOutput": "result.ok === true && result.charged === 25000000"
+          },
+          {
+            "id": "t7",
+            "description": "One base unit over the cap is over the cap",
+            "input": "25000000, 7, 7, 0, 25000001",
+            "expectedOutput": "result.ok === false && result.error === 'AMOUNT_EXCEEDS_PERIOD_LIMIT'"
+          },
+          {
+            "id": "t8",
+            "description": "A refused attempt reports what is still available rather than zero",
+            "input": "25000000, 7, 7, 20000000, 10000000",
+            "expectedOutput": "result.ok === false && result.remainingThisPeriod === 5000000 && result.charged === 0"
+          }
+        ],
+        "hints": [
+          "Nothing needs to be written. Pick the right `available` candidate and move the guard above the success return.",
+          "Candidate 2 passes every test where no period was skipped. That is what makes it a decoy rather than an obvious error — look at the case where `currentPeriod - lastChargedPeriod` is greater than 1.",
+          "A guard placed after an unconditional return never executes."
+        ],
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "check",
+        "_type": "quiz",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": [
+          {
+            "id": "q1",
+            "prompt": "A recurring delegation is capped at 25 USDC per period. Your billing job collects 25 USDC, then crashes before writing its own record. It restarts and retries the same charge, same period. Predict what the program does and what your job should conclude.",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "`AMOUNT_EXCEEDS_PERIOD_LIMIT` — and the job should read that as \"already collected\", not as a transient failure to retry",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "It succeeds and charges 50 USDC in total for the period",
+                "correct": false,
+                "feedback": "The cap is per period, not per call. The second pull is exactly what it is designed to stop — which is why it doubles as your idempotency guard."
+              },
+              {
+                "id": "c",
+                "label": "`PERIOD_NOT_ELAPSED`, because the period has not rolled over yet",
+                "correct": false,
+                "feedback": "`PERIOD_NOT_ELAPSED` is for collecting against a period that has not started. Here the period has started and its cap is spent. Different error, different meaning."
+              },
+              {
+                "id": "d",
+                "label": "It succeeds with a zero-value transfer",
+                "correct": false,
+                "feedback": "The program does not silently rewrite your amount. It refuses the instruction."
+              }
+            ],
+            "explanation": null
+          },
+          {
+            "id": "q2",
+            "prompt": "A merchant with a 25 USDC/month recurring delegation forgets to collect in March and April, then runs the job in May. How much can it pull in May, and why?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "25 USDC — the cap is a per-period ceiling, and unused periods are gone",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "75 USDC — three periods of authorised-but-uncollected capacity",
+                "correct": false,
+                "feedback": "That would turn \"up to 25 per month\" into \"up to 25 per month, banked indefinitely and redeemable in a lump sum by whoever holds the delegatee key\". The user authorised the first thing."
+              },
+              {
+                "id": "c",
+                "label": "50 USDC — the two missed periods carry, the current one is charged separately",
+                "correct": false,
+                "feedback": "No period carries. Not one, not two."
+              },
+              {
+                "id": "d",
+                "label": "0 USDC — missing a period puts the delegation into a lapsed state",
+                "correct": false,
+                "feedback": "Nothing lapses. The delegation stays live until `expiryTs` or a revoke; only the unused capacity is lost."
+              }
+            ],
+            "explanation": "If your business needs missed periods to be collectable, that is an invoice, and you build it in your own system."
+          },
+          {
+            "id": "q3",
+            "prompt": "Your unattended billing service holds one key. Which key must it be, and what can it do with it?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "The delegatee key — it can pull up to the cap each period, and nothing else",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "The delegator key — the user's key, held in escrow by the service",
+                "correct": false,
+                "feedback": "If the service needed the user's key, the delegation would be pointless. `delegator` is typed as an `Address` on the transfer precisely because it is not a signer there."
+              },
+              {
+                "id": "c",
+                "label": "Either — the program accepts a signature from whichever of the two is present",
+                "correct": false,
+                "feedback": "The instruction names exactly one signer. Setup and revoke take the user; transfers take the delegatee."
+              },
+              {
+                "id": "d",
+                "label": "The delegatee key, which can also extend `expiryTs` when the term runs out",
+                "correct": false,
+                "feedback": "The delegatee cannot change the terms. Extending means a new delegation with a new nonce, signed by the user — which means the user consents again."
+              }
+            ],
+            "explanation": null
+          },
+          {
+            "id": "q4",
+            "prompt": "You call `createRecurringDelegation` with `startTs: 0n` and `expiryTs: 0n`. Predict the result.",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "Refused — start-on-landing requires a non-zero expiry, so an open-ended pull authorisation with no defined start is rejected",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "Accepted — both zeroes mean \"start now, never expire\", which is the common subscription case",
+                "correct": false,
+                "feedback": "\"Never expire\" combined with \"start whenever this happens to land\" is the least bounded authorisation the program could issue, so it is the one combination it refuses."
+              },
+              {
+                "id": "c",
+                "label": "Accepted, with `expiryTs` defaulted to one year from the landing slot",
+                "correct": false,
+                "feedback": "The program does not invent terms on your behalf. It errors."
+              },
+              {
+                "id": "d",
+                "label": "Accepted, but every `transferRecurring` then fails with `DELEGATION_NOT_STARTED`",
+                "correct": false,
+                "feedback": "`DELEGATION_NOT_STARTED` is real, and it is what you get from a `startTs` in the future. This case fails earlier, at creation."
+              }
+            ],
+            "explanation": null
+          },
+          {
+            "id": "q5",
+            "prompt": "The user calls `revokeDelegation` on a live recurring delegation. Which of these are true afterwards?",
+            "multiSelect": true,
+            "options": [
+              {
+                "id": "a",
+                "label": "The delegation PDA is closed and its rent is returned",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "Re-establishing the arrangement needs a new `createRecurringDelegation` with a new nonce, signed by the user",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "c",
+                "label": "The delegation is paused and can be resumed by the delegatee later",
+                "correct": false,
+                "feedback": "There is no pause on a delegation. `resumeSubscription` exists, but that is the subscription-plan model, not this one."
+              },
+              {
+                "id": "d",
+                "label": "The user's other delegations on the same mint are also revoked",
+                "correct": false,
+                "feedback": "Each delegation is its own PDA under the shared authority — that is the whole point. Revoking all of them at once is `closeSubscriptionAuthority`, and it is a separate, deliberate kill switch."
+              }
+            ],
+            "explanation": null
+          }
+        ],
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      }
+    ]
+  },
+  {
+    "_id": "lesson-sap-meter-an-endpoint-with-x402",
+    "title": "402 Payment Required, For Real",
+    "slug": "meter-an-endpoint-with-x402",
+    "blocks": [
+      {
+        "key": "intro",
+        "_type": "prose",
+        "produces": null,
+        "consumes": null,
+        "src": "# 402 Payment Required, For Real\n\n> **Version stamp — checked 2026-07-25.** `@x402/core`, `@x402/svm`, `@x402/express`, `@x402/fetch` at **2.19.0** (published 2026-07-17). `@solana/kit` at **7.0.0**. Everything below is written against those exact versions. If you are reading this more than a few months later, re-check the pins before you copy anything.\n\nIn module 1 you gave your vault app a paid tier: a Subscription Authority, a Recurring Delegation, one collected charge, and a second charge that correctly refused. That model prices a **relationship** — a subscriber, a period, a cap.\n\nThis lesson prices a **request**. One route, one price, one payment, no account, no relationship. That is what x402 is for: an HTTP status code that has been sitting unused in RFC 7231 since 1997, wired to a stablecoin transfer.\n\nThe flow has three moves and no new infrastructure:\n\n1. A client calls your route with no payment. You answer **402** with a machine-readable challenge describing what you will accept.\n2. The client builds a payment matching one of your accepted terms and calls again, carrying the payment in a header.\n3. You hand that payload to a **facilitator**, which verifies and settles it on-chain, and then you serve the response.\n\n---\n\n## The package split — read this before you install anything\n\nThis is the single worst staleness trap in this catalog, because search engines surface the wrong half and so does one of Solana's own templates.\n\n**Frozen. Do not install. Do not teach.**\n\n`x402` · `x402-express` · `x402-next` · `x402-fetch` · `x402-hono` — all **1.2.0**, published **2026-04-16**. These speak protocol **v1**. solana.com's own \"X402 Next.js\" scaffold still ships `x402-next`, so \"it came from an official template\" is not evidence of currency.\n\n**Current. Install these.**\n\n| Package | Version | What you use from it |\n| --- | --- | --- |\n| `@x402/core` | 2.19.0 | `x402ResourceServer`, `x402HTTPResourceServer`, `x402Client`, `HTTPFacilitatorClient`, `VerifyError`, `SettleError` |\n| `@x402/svm` | 2.19.0 | `ExactSvmScheme`, `ExactSvmSchemeV1`, `SOLANA_DEVNET_CAIP2`, `USDC_DEVNET_ADDRESS`, `TOKEN_PROGRAM_ADDRESS`, `TOKEN_2022_PROGRAM_ADDRESS` |\n| `@x402/express` | 2.19.0 | `paymentMiddleware` |\n| `@x402/fetch` | 2.19.0 | `wrapFetchWithPayment` (that is lesson 6) |\n\nThe unscoped packages are still published and still installable. Nothing stops you from typing the wrong one. Read the `@` before you press enter.\n\n`@x402/svm` peer-depends on `@solana/kit >=5.1.0`. That is the **same Kit you already have** from the client you published in course 4 — the metering layer is not a second SDK, it is a scheme plugin that borrows yours.\n\n---\n\n## The challenge envelope\n\nEverything the client needs is in the 402. Here is the worked example you will run in a moment, in full:\n\n```json\n{\n  \"x402Version\": 2,\n  \"error\": \"payment required\",\n  \"accepts\": [\n    {\n      \"scheme\": \"exact\",\n      \"network\": \"solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1\",\n      \"asset\": \"4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU\",\n      \"payTo\": \"<your devnet wallet>\",\n      \"maxAmountRequired\": \"10000\",\n      \"resource\": \"https://your-app.vercel.app/api/quote\",\n      \"description\": \"One FX quote\",\n      \"mimeType\": \"application/json\",\n      \"maxTimeoutSeconds\": 60\n    }\n  ]\n}\n```\n\nField by field, and each of these is a place people get it wrong:\n\n- **`x402Version`** — the wire version, `1` or `2`. Both are live in the world right now. You emit `2`.\n- **`scheme`** — `\"exact\"`. The client pays exactly `maxAmountRequired`, no more, no quoting, no conversion.\n- **`network`** — a CAIP-2 chain id: the namespace `solana:` plus the first 32 characters of the cluster's genesis hash. Devnet is `solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1`; mainnet is `solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp`. **Import `SOLANA_DEVNET_CAIP2` from `@x402/svm` rather than typing that literal into your server** — a one-character typo produces a challenge no client can match, and the failure looks like \"the client just never pays\".\n- **`asset`** — the mint address, on that network. Devnet USDC is `4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU` (`USDC_DEVNET_ADDRESS`). `network` and `asset` are a **pair**. A mint is an account on one cluster; the mainnet USDC mint does not exist on devnet.\n- **`payTo`** — the address that receives the tokens. This is the whole point of the exercise and it is the one value you are going to fill in.\n- **`maxAmountRequired`** — **base units, as a decimal string.** 0.01 USDC at 6 decimals is `\"10000\"`. Not `0.01`. Not the number `10000`. A string, because base-unit amounts are `u64` and JSON numbers stop being exact above 2^53 — and because the moment a float touches a payment field you have signed up for rounding bugs you will find in production, not in tests.\n- **`resource`** — the absolute URL being priced. It binds the payment to this route.\n- **`maxTimeoutSeconds`** — how long you will hold the door open between issuing the challenge and settling the payment.\n\n`accepts` is an **array** because it is a menu, not a demand. A real server offers several terms — devnet and mainnet, or several assets — and lets the client pick one it can satisfy. In lesson 6 you are on the other side of that menu, doing the picking.\n\n### Where the envelope travels\n\nIn the common case it is the JSON response body of the 402. But some servers return an **empty body** and put the whole base64-encoded envelope in a `PAYMENT-REQUIRED` response header — Vercel-hosted ones do this, because of how their edge layer handles bodies on error statuses. A correct server emits both. A correct client reads both. You will build the client-side fallback next lesson; today you emit both so you are never the reason a client fails.\n\nThat is why the exercise base64-encodes the envelope as well as returning it: `header` and `body` carry the same bytes.\n\n---\n\n## The facilitator\n\nYou do not run an RPC node, you do not hold a hot key for verification, and you do not submit transactions. A **facilitator** exposes three operations:\n\n- **`supported`** — which `(network, asset, scheme)` combinations it can service. Use it to build your `accepts[]` instead of guessing.\n- **`verify`** — is this payment payload well-formed, correctly signed, and does it satisfy the terms you advertised? Throws `VerifyError` when not.\n- **`settle`** — submit it and confirm it. Throws `SettleError` when not.\n\nWire one up with `HTTPFacilitatorClient` from `@x402/core` and hand it to `x402ResourceServer`. The illustrative shape, which you run in your own app rather than in the grader:\n\n```ts\nimport { x402ResourceServer, HTTPFacilitatorClient } from \"@x402/core\"; // 2.19.0\nimport { ExactSvmScheme, SOLANA_DEVNET_CAIP2, USDC_DEVNET_ADDRESS } from \"@x402/svm\"; // 2.19.0\nimport { paymentMiddleware } from \"@x402/express\"; // 2.19.0\n\nconst facilitator = new HTTPFacilitatorClient({ url: process.env.FACILITATOR_URL! });\n\nconst server = x402ResourceServer({\n  facilitator,\n  schemes: [ExactSvmScheme],\n});\n\napp.use(\n  paymentMiddleware(server, {\n    \"GET /api/quote\": {\n      network: SOLANA_DEVNET_CAIP2,\n      asset: USDC_DEVNET_ADDRESS,\n      payTo: process.env.MERCHANT_ADDRESS!,\n      maxAmountRequired: \"10000\",\n      description: \"One FX quote\",\n    },\n  })\n);\n```\n\nThe middleware is doing exactly what your exercise does by hand — building that `accepts[]` entry, returning 402 when no payment arrives, and calling `verify`/`settle` when one does. Write it once by hand so the middleware is never a black box.\n\n**On Kora:** you may run your own facilitator, and Kora is the Solana-native one. It requires cloning the repo and building it locally across several terminals. That is a local-toolchain detour this course does not take. Use a hosted or embedded facilitator on devnet; come back to self-hosting when you have revenue to protect.\n\n---\n\n## The exercise\n\nYou are handed a complete, annotated, working challenge builder. Read it top to bottom — it is the reference implementation, and it is short on purpose.\n\n**Change exactly one value: `PAY_TO`.** Put a real base58 devnet address there — the wallet you funded in course 1 is the right one, because in a moment you want to watch USDC land in it. Nothing else in the file needs to move.\n\nThe tests check the things that break real integrations: the amount is a decimal string of base units, the network and asset are the devnet pair, the encoded header is genuine base64 of the body, and `payTo` is an address rather than a placeholder.\n\n## Milestone\n\nTake the same envelope shape into your course-4 app, put it in front of one real route, and deploy it. **Keep the URL.** Lesson 6 pays it, lesson 7 has an agent pay it repeatedly out of a capped budget, and lesson 8 asks you for the link.\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "envelope",
+        "_type": "code",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": "typescript",
+        "buildType": "standard",
+        "deployable": false,
+        "starter": "// ---------------------------------------------------------------------------\n// WORKED EXAMPLE — an x402 v2 challenge builder.\n//\n// This file is complete and correct except for ONE value. Read it, then change\n// PAY_TO to your own devnet address. Nothing else needs to move.\n//\n// Pinned 2026-07-25: @x402/core 2.19.0, @x402/svm 2.19.0, @solana/kit 7.0.0.\n// The grader has no module resolution, so the two constants below are written\n// out. In your own server you IMPORT them:\n//   import { SOLANA_DEVNET_CAIP2, USDC_DEVNET_ADDRESS } from \"@x402/svm\";\n// ---------------------------------------------------------------------------\n\n/** CAIP-2 chain id: \"solana:\" + the first 32 chars of the cluster genesis hash. */\nconst SOLANA_DEVNET_CAIP2 = \"solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1\";\n\n/** Circle's devnet USDC mint. 6 decimals. Paired with the network above. */\nconst USDC_DEVNET_ADDRESS = \"4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU\";\n\n// >>> THE ONE VALUE YOU CHANGE <<<\n// The wallet that receives the tokens. Use a real base58 devnet address.\nconst PAY_TO = \"REPLACE_WITH_YOUR_DEVNET_WALLET\";\n\ninterface Route {\n  /** Absolute URL of the priced route. Binds the payment to this resource. */\n  resource: string;\n  /** Human-readable, shown by wallets and agent logs. */\n  description: string;\n  /** Base units, decimal string. 0.01 USDC at 6 decimals = \"10000\". */\n  priceBaseUnits: string;\n}\n\n/** Your price list. Two routes so the builder is driven by data, not by copy-paste. */\nconst ROUTES: Record<string, Route> = {\n  quote: {\n    resource: \"https://your-app.vercel.app/api/quote\",\n    description: \"One FX quote\",\n    priceBaseUnits: \"10000\",\n  },\n  digest: {\n    resource: \"https://your-app.vercel.app/api/digest\",\n    description: \"Daily market digest\",\n    priceBaseUnits: \"250000\",\n  },\n};\n\n/**\n * Build the full HTTP 402 response for a priced route.\n *\n * Returns the body (the challenge envelope), the headers, and the base64\n * encoding of the envelope — because some hosts strip bodies from error\n * responses, so a correct server emits the envelope BOTH ways.\n */\nfunction buildPaymentRequired(routeId: string) {\n  const route = ROUTES[routeId];\n  if (!route) throw new Error(\"unknown route: \" + routeId);\n\n  // The menu. One entry here; a real server offers several so the client can\n  // pick a (network, asset) pair it can actually satisfy.\n  const envelope = {\n    x402Version: 2,\n    error: \"payment required\",\n    accepts: [\n      {\n        // Pay the exact amount. No quoting, no conversion, no partial fills.\n        scheme: \"exact\",\n        // network and asset are a PAIR. A mint lives on one cluster.\n        network: SOLANA_DEVNET_CAIP2,\n        asset: USDC_DEVNET_ADDRESS,\n        payTo: PAY_TO,\n        // Decimal STRING of base units. Never a float, never a JSON number:\n        // u64 amounts stop being exact above 2^53.\n        maxAmountRequired: route.priceBaseUnits,\n        resource: route.resource,\n        description: route.description,\n        mimeType: \"application/json\",\n        // How long you will hold the door open between challenge and settlement.\n        maxTimeoutSeconds: 60,\n      },\n    ],\n  };\n\n  const encoded = utf8ToBase64(JSON.stringify(envelope));\n\n  return {\n    status: 402,\n    headers: {\n      \"content-type\": \"application/json\",\n      // Same bytes as the body. Clients behind edge layers that drop error\n      // bodies read the envelope from here instead.\n      \"payment-required\": encoded,\n    },\n    body: envelope,\n    encoded,\n  };\n}\n\n// --- plumbing -------------------------------------------------------------\n// In Node or a browser you would use Buffer.from(s).toString(\"base64\") or\n// btoa(). Neither exists in this sandbox, so here is base64 in twelve lines.\n\nconst B64_ALPHABET =\n  \"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/\";\n\nfunction utf8ToBase64(text: string): string {\n  const bytes = new TextEncoder().encode(text);\n  let out = \"\";\n  for (let i = 0; i < bytes.length; i += 3) {\n    const b0 = bytes[i];\n    const b1 = i + 1 < bytes.length ? bytes[i + 1] : -1;\n    const b2 = i + 2 < bytes.length ? bytes[i + 2] : -1;\n    out += B64_ALPHABET[b0 >> 2];\n    out += B64_ALPHABET[((b0 & 3) << 4) | (b1 < 0 ? 0 : b1 >> 4)];\n    out += b1 < 0 ? \"=\" : B64_ALPHABET[((b1 & 15) << 2) | (b2 < 0 ? 0 : b2 >> 6)];\n    out += b2 < 0 ? \"=\" : B64_ALPHABET[b2 & 63];\n  }\n  return out;\n}\n",
+        "solution": "// ---------------------------------------------------------------------------\n// REFERENCE SOLUTION — an x402 v2 challenge builder.\n//\n// Identical to the starter except for PAY_TO, which now holds a real base58\n// devnet address. Use YOUR OWN wallet — this one is an example merchant.\n//\n// Pinned 2026-07-25: @x402/core 2.19.0, @x402/svm 2.19.0, @solana/kit 7.0.0.\n// The grader has no module resolution, so the two constants below are written\n// out. In your own server you IMPORT them:\n//   import { SOLANA_DEVNET_CAIP2, USDC_DEVNET_ADDRESS } from \"@x402/svm\";\n// ---------------------------------------------------------------------------\n\n/** CAIP-2 chain id: \"solana:\" + the first 32 chars of the cluster genesis hash. */\nconst SOLANA_DEVNET_CAIP2 = \"solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1\";\n\n/** Circle's devnet USDC mint. 6 decimals. Paired with the network above. */\nconst USDC_DEVNET_ADDRESS = \"4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU\";\n\n// >>> THE ONE VALUE THAT CHANGED <<<\n// The wallet that receives the tokens. Use a real base58 devnet address.\nconst PAY_TO = \"B7o8NfV81HzjuZFWQTTx3Xdvh77Dqoajwib3kWEnvzJF\";\n\ninterface Route {\n  /** Absolute URL of the priced route. Binds the payment to this resource. */\n  resource: string;\n  /** Human-readable, shown by wallets and agent logs. */\n  description: string;\n  /** Base units, decimal string. 0.01 USDC at 6 decimals = \"10000\". */\n  priceBaseUnits: string;\n}\n\n/** Your price list. Two routes so the builder is driven by data, not by copy-paste. */\nconst ROUTES: Record<string, Route> = {\n  quote: {\n    resource: \"https://your-app.vercel.app/api/quote\",\n    description: \"One FX quote\",\n    priceBaseUnits: \"10000\",\n  },\n  digest: {\n    resource: \"https://your-app.vercel.app/api/digest\",\n    description: \"Daily market digest\",\n    priceBaseUnits: \"250000\",\n  },\n};\n\n/**\n * Build the full HTTP 402 response for a priced route.\n *\n * Returns the body (the challenge envelope), the headers, and the base64\n * encoding of the envelope — because some hosts strip bodies from error\n * responses, so a correct server emits the envelope BOTH ways.\n */\nfunction buildPaymentRequired(routeId: string) {\n  const route = ROUTES[routeId];\n  if (!route) throw new Error(\"unknown route: \" + routeId);\n\n  // The menu. One entry here; a real server offers several so the client can\n  // pick a (network, asset) pair it can actually satisfy.\n  const envelope = {\n    x402Version: 2,\n    error: \"payment required\",\n    accepts: [\n      {\n        // Pay the exact amount. No quoting, no conversion, no partial fills.\n        scheme: \"exact\",\n        // network and asset are a PAIR. A mint lives on one cluster.\n        network: SOLANA_DEVNET_CAIP2,\n        asset: USDC_DEVNET_ADDRESS,\n        payTo: PAY_TO,\n        // Decimal STRING of base units. Never a float, never a JSON number:\n        // u64 amounts stop being exact above 2^53.\n        maxAmountRequired: route.priceBaseUnits,\n        resource: route.resource,\n        description: route.description,\n        mimeType: \"application/json\",\n        // How long you will hold the door open between challenge and settlement.\n        maxTimeoutSeconds: 60,\n      },\n    ],\n  };\n\n  const encoded = utf8ToBase64(JSON.stringify(envelope));\n\n  return {\n    status: 402,\n    headers: {\n      \"content-type\": \"application/json\",\n      // Same bytes as the body. Clients behind edge layers that drop error\n      // bodies read the envelope from here instead.\n      \"payment-required\": encoded,\n    },\n    body: envelope,\n    encoded,\n  };\n}\n\n// --- plumbing -------------------------------------------------------------\n// In Node or a browser you would use Buffer.from(s).toString(\"base64\") or\n// btoa(). Neither exists in this sandbox, so here is base64 in twelve lines.\n\nconst B64_ALPHABET =\n  \"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/\";\n\nfunction utf8ToBase64(text: string): string {\n  const bytes = new TextEncoder().encode(text);\n  let out = \"\";\n  for (let i = 0; i < bytes.length; i += 3) {\n    const b0 = bytes[i];\n    const b1 = i + 1 < bytes.length ? bytes[i + 1] : -1;\n    const b2 = i + 2 < bytes.length ? bytes[i + 2] : -1;\n    out += B64_ALPHABET[b0 >> 2];\n    out += B64_ALPHABET[((b0 & 3) << 4) | (b1 < 0 ? 0 : b1 >> 4)];\n    out += b1 < 0 ? \"=\" : B64_ALPHABET[((b1 & 15) << 2) | (b2 < 0 ? 0 : b2 >> 6)];\n    out += b2 < 0 ? \"=\" : B64_ALPHABET[b2 & 63];\n  }\n  return out;\n}\n",
+        "tests": [
+          {
+            "id": "t1",
+            "description": "Returns a 402 whose body is a v2 envelope with a one-entry accepts menu",
+            "input": "'quote'",
+            "expectedOutput": "result.status === 402 && result.body.x402Version === 2 && Array.isArray(result.body.accepts) && result.body.accepts.length === 1"
+          },
+          {
+            "id": "t2",
+            "description": "The challenge is driven by the route table, not hardcoded",
+            "input": "'digest'",
+            "expectedOutput": "result.body.accepts[0].maxAmountRequired === '250000' && result.body.accepts[0].resource.indexOf('/api/digest') > -1 && result.body.accepts[0].description === 'Daily market digest'"
+          },
+          {
+            "id": "t3",
+            "description": "maxAmountRequired is a decimal string of base units, not a number or a float",
+            "input": "'quote'",
+            "expectedOutput": "typeof result.body.accepts[0].maxAmountRequired === 'string' && /^[0-9]+$/.test(result.body.accepts[0].maxAmountRequired) && result.body.accepts[0].maxAmountRequired === '10000'"
+          },
+          {
+            "id": "t4",
+            "description": "scheme, network and asset name the exact scheme and the devnet USDC pair",
+            "input": "'quote'",
+            "expectedOutput": "result.body.accepts[0].scheme === 'exact' && result.body.accepts[0].network === 'solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1' && result.body.accepts[0].asset === '4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU'"
+          },
+          {
+            "id": "t5",
+            "description": "payTo is a real base58 Solana address — change PAY_TO to your own devnet wallet",
+            "input": "'quote'",
+            "expectedOutput": "/^[1-9A-HJ-NP-Za-km-z]{32,44}$/.test(result.body.accepts[0].payTo)"
+          },
+          {
+            "id": "t6",
+            "description": "The envelope is also emitted base64-encoded in the payment-required header",
+            "input": "'digest'",
+            "expectedOutput": "typeof result.encoded === 'string' && result.encoded.slice(0, 4) === 'eyJ4' && result.headers['payment-required'] === result.encoded"
+          }
+        ],
+        "hints": [
+          "You change exactly one value in this file: PAY_TO. Everything else is already correct.",
+          "PAY_TO must be a base58 Solana address — the wallet that should receive the USDC, on devnet.",
+          "`maxAmountRequired` is a decimal string of base units, never a float: 0.01 USDC at 6 decimals is \"10000\"."
+        ],
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "check",
+        "_type": "quiz",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": [
+          {
+            "id": "q1",
+            "prompt": "You search for \"x402 express\" and the top result tells you to run `npm i x402-express`. You install it and wire `paymentMiddleware` into your route. A client running `@x402/fetch@2.19.0` calls the route. What happens?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "You installed the frozen v1 line. The server emits a v1 challenge and reads the `X-PAYMENT` header; the v2 client sends `PAYMENT`. The two never agree.",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "The middleware works — `x402-express` and `@x402/express` are the same package under two names.",
+                "correct": false,
+                "feedback": "They are different packages. `x402-express` is frozen at 1.2.0 (2026-04-16) and speaks protocol v1. `@x402/express` is 2.19.0 (2026-07-17) and speaks v2."
+              },
+              {
+                "id": "c",
+                "label": "npm resolves the scoped package automatically because the unscoped one is deprecated.",
+                "correct": false,
+                "feedback": "npm does no such rewriting. The unscoped packages are still published and still installable — that is exactly why this trap keeps catching people."
+              },
+              {
+                "id": "d",
+                "label": "It works but is slower, because v1 does an extra round trip.",
+                "correct": false,
+                "feedback": "The failure is a protocol mismatch, not a performance difference."
+              }
+            ],
+            "explanation": "The v1 line (`x402`, `x402-express`, `x402-next`, `x402-fetch`, `x402-hono`, all 1.2.0) is frozen. The current line is scoped: `@x402/core`, `@x402/svm`, `@x402/express`, `@x402/fetch`, `@x402/next`, `@x402/mcp`, all 2.19.0. Search engines still surface the frozen half."
+          },
+          {
+            "id": "q2",
+            "prompt": "Your route costs 0.01 USDC. USDC has 6 decimals. Which `accepts[0].maxAmountRequired` will a conforming client charge correctly?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "\"10000\"",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "0.01",
+                "correct": false,
+                "feedback": "A float in a payment field is a bug waiting for a rounding error. The field is a string of base units."
+              },
+              {
+                "id": "c",
+                "label": "10000",
+                "correct": false,
+                "feedback": "Right magnitude, wrong type. Numbers above 2^53 lose precision in JSON, so the field is specified as a decimal string — use it as one even for small amounts."
+              },
+              {
+                "id": "d",
+                "label": "\"0.01 USDC\"",
+                "correct": false,
+                "feedback": "The field carries base units only. The asset is named separately in `asset`."
+              }
+            ],
+            "explanation": "Base units as a decimal string, every time. The mint's decimals are a property of `asset`, not something you encode into the amount."
+          },
+          {
+            "id": "q3",
+            "prompt": "Your API server issues challenges and gates the route. Which of these does your server never have to run itself?",
+            "multiSelect": true,
+            "options": [
+              {
+                "id": "a",
+                "label": "Signature verification of the submitted payment payload",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "Submitting and confirming the payment transaction on Solana",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "c",
+                "label": "Deciding the price of the route",
+                "correct": false,
+                "feedback": "Pricing is yours. The facilitator has no idea what your route is worth."
+              },
+              {
+                "id": "d",
+                "label": "Deciding which networks and assets you will accept",
+                "correct": false,
+                "feedback": "The `accepts[]` array is your policy statement. The facilitator only tells you which combinations it can service, via `supported`."
+              }
+            ],
+            "explanation": "A facilitator exposes three operations — `supported`, `verify` and `settle`. It absorbs the RPC connection, the signature checks and the transaction submission, which is why an API provider can monetize a route without running any on-chain infrastructure."
+          },
+          {
+            "id": "q4",
+            "prompt": "A client reads your challenge, sees `network: \"solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1\"` and pays with the mint at `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`. Predict the outcome.",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "Verification fails — that is the mainnet USDC mint and the challenge named a devnet network and a devnet asset. Both fields have to match.",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "It settles — USDC is USDC, the mint address is cosmetic.",
+                "correct": false,
+                "feedback": "A mint address is an account on one specific cluster. The mainnet USDC mint does not exist on devnet, and a token account for it cannot be created there."
+              },
+              {
+                "id": "c",
+                "label": "The facilitator bridges it automatically.",
+                "correct": false,
+                "feedback": "There is no bridging in the `exact` scheme. It settles a specified amount of a specified mint on a specified network, or it fails."
+              },
+              {
+                "id": "d",
+                "label": "It settles at the mainnet price after conversion.",
+                "correct": false,
+                "feedback": "Nothing in x402 converts or quotes. The amount is exact and the asset is fixed."
+              }
+            ],
+            "explanation": "`network` and `asset` are a pair, and a client filters on both. `SOLANA_DEVNET_CAIP2` + `USDC_DEVNET_ADDRESS` is one valid combination; the mainnet pair is another; mixing halves is not."
+          }
+        ],
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      }
+    ]
+  },
+  {
+    "_id": "lesson-sap-pay-the-402-programmatically",
+    "title": "Reading a Challenge and Paying It",
+    "slug": "pay-the-402-programmatically",
+    "blocks": [
+      {
+        "key": "intro",
+        "_type": "prose",
+        "produces": null,
+        "consumes": null,
+        "src": "# Reading a Challenge and Paying It\n\n> **Version stamp — checked 2026-07-25.** `@x402/core`, `@x402/svm`, `@x402/fetch` at **2.19.0** (2026-07-17). `@solana/kit` at **7.0.0**. The frozen v1 line (`x402`, `x402-fetch`, 1.2.0, 2026-04-16) is still on npm and still installable — do not.\n\nLast lesson you were the server. Now you are the caller, and the caller has the harder job: the server publishes one shape and knows what it published. The client has to handle whatever it is handed.\n\nTwo things make that hard in practice, and both of them are in today's exercise:\n\n1. **The envelope is not always where the docs say it is.** Some servers return an empty body and put the whole base64 envelope in a response header.\n2. **Two protocol versions are live at the same time.** They use different header names and different envelope fields. Every tutorial that picks one and hardcodes it will rot; this lesson teaches you to read the version off the wire.\n\n---\n\n## The loop\n\n```\nfetch(url)                       → 402\nlocate the envelope              → body, or the PAYMENT-REQUIRED header\ndecode it                        → JSON (base64-decode first if it came from the header)\nread envelope.x402Version        → decides the retry header name\nselect one accepts[] entry       → filter on scheme + network + asset\nsign a payment for those terms\nfetch(url, { headers: { <name>: <payload> } })  → 200\n```\n\nIn production `wrapFetchWithPayment` from `@x402/fetch` does all of that:\n\n```ts\nimport { wrapFetchWithPayment } from \"@x402/fetch\"; // 2.19.0\nimport { x402Client } from \"@x402/core\"; // 2.19.0\nimport { ExactSvmScheme, ExactSvmSchemeV1 } from \"@x402/svm\"; // 2.19.0\n\nconst client = x402Client({\n  signer: agentSigner,             // your @solana/kit@7 signer\n  schemes: [ExactSvmScheme, ExactSvmSchemeV1],\n});\n\nconst paidFetch = wrapFetchWithPayment(fetch, client);\nconst res = await paidFetch(\"https://api.example.dev/quote\");\n```\n\nNote the `schemes` array. You register **both** — and this is the point of the lesson.\n\n---\n\n## The version seam\n\n`@x402/svm@2.19.0` exports `ExactSvmScheme` **and** `ExactSvmSchemeV1`. That is not legacy cruft kept around for types. It is there because **both wire versions are live right now**:\n\n| | v1 | v2 |\n| --- | --- | --- |\n| Emitted by | `x402`, `x402-express`, `x402-next`, `x402-fetch`, `x402-hono` @ 1.2.0 | `@x402/*` @ 2.19.0 |\n| Envelope field | `\"x402Version\": 1` | `\"x402Version\": 2` |\n| Payment request header | `X-PAYMENT` | `PAYMENT` |\n| Settlement response header | `X-PAYMENT-RESPONSE` | `PAYMENT-RESPONSE` |\n\nA client that registers only the v2 scheme fails silently against every server still on the frozen package line — and since solana.com's own Next.js x402 template ships `x402-next`, there are more of those than you expect.\n\n**Never assume the version. Read `x402Version` out of the envelope you were handed, then build the retry to match.** That single habit is the difference between a client that works for a year and one that works until the first server you did not test against.\n\n---\n\n## The menu\n\n`accepts[]` is a list of terms the server will take. It is ordered by the server's preference, which has nothing to do with your capability. In today's fixtures the **first** entry is always an EVM entry — that is deliberate, and it is the shape of the real bug:\n\n```ts\nconst terms = envelope.accepts[0];   // ← you are now trying to pay on Base\n```\n\nFilter instead, on all three of the fields that have to line up:\n\n```ts\nconst terms = envelope.accepts.find(\n  (entry) =>\n    entry.scheme === \"exact\" &&\n    entry.network === SOLANA_DEVNET_CAIP2 &&\n    entry.asset === USDC_DEVNET_ADDRESS\n);\n```\n\n`network` and `asset` are a pair. The `v2-header` fixture offers Solana **mainnet** USDC and Solana **devnet** USDC as separate entries, with the same scheme and the same price. Matching only on network, or only on asset, picks the wrong one.\n\nAnd \"no entry matches\" is a normal outcome, not an error. Servers that only accept EVM money exist. Report it and move on — your caller needs to know it was not paid, not receive an exception.\n\n---\n\n## The exercise\n\n`handle402(captureId)` receives one of four captured HTTP responses and returns a report saying what it found and what it would pay.\n\nInside the function there are **eight commented-out blocks**. Six of them are the ones you need, in the wrong order. **Two are wrong and must be deleted.** The block numbers are labels, not positions.\n\nHere is what the two wrong blocks get wrong. This is the whole reason they are in the file:\n\n- **One retries before decoding.** It calls `JSON.parse(res.body)` and takes `accepts[0]`, hardcoding version 2 and hardcoding \"the envelope is in the body\". It produces a plausible-looking result on exactly one of the four fixtures and is wrong on the rest — which is precisely how this bug survives review. Decoding is not a formality you can skip; it is where you learn which protocol you are speaking.\n- **One selects on the wrong chain namespace.** It filters for `eip155:` entries. Those are real, valid, payable terms — by somebody with an EVM wallet. The lesson is that \"found a match\" is not the same as \"found a match I can satisfy\".\n\nOrdering is not guesswork: every block after the first uses a local that an earlier block declares. Follow the dependency chain — `res` → `headerEnvelope`/`fromHeader` → `raw`/`envelope` → `paymentHeader`/`envelopeFrom` → `selected`.\n\nThe base64 decoder is given to you at the bottom of the file. It is not part of the puzzle; `atob()` and `Buffer` simply do not exist in the grader.\n\n## What this unlocks\n\nYou now have both halves: a route that charges, and a client that pays. Next lesson the caller stops being you and becomes a loop — and the interesting question stops being \"can it pay?\" and becomes \"what stops it?\"\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "exercise",
+        "_type": "code",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": "typescript",
+        "buildType": "standard",
+        "deployable": false,
+        "starter": "// ---------------------------------------------------------------------------\n// COMPLETION EXERCISE — read a 402 challenge and decide how to pay it.\n//\n// The eight blocks inside handle402() are the ones you need, PLUS TWO THAT ARE\n// WRONG. They are commented out and in the wrong order, and the BLOCK numbers\n// are labels, not positions. Uncomment the six that belong, put them in the\n// order the protocol requires, and delete the two that do not.\n//\n// The lesson text tells you what the two wrong blocks get wrong. It does not\n// tell you the order.\n//\n// Pinned 2026-07-25: @x402/core 2.19.0, @x402/svm 2.19.0, @x402/fetch 2.19.0.\n// The grader has no module resolution and no network, so the two constants\n// below are written out and the HTTP responses are captured fixtures. In your\n// own client you import the constants and let wrapFetchWithPayment do the\n// round trip.\n// ---------------------------------------------------------------------------\n\nconst SOLANA_DEVNET_CAIP2 = \"solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1\";\nconst USDC_DEVNET_ADDRESS = \"4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU\";\n\ninterface Accept {\n  scheme: string;\n  network: string;\n  asset: string;\n  payTo: string;\n  maxAmountRequired: string;\n  resource: string;\n  description: string;\n  mimeType: string;\n  maxTimeoutSeconds: number;\n}\n\ninterface Report {\n  /** True only when a payable Solana-devnet-USDC entry was found. */\n  paid: boolean;\n  /** The wire version the server spoke: 1, 2, or null when there was no challenge. */\n  x402Version: number | null;\n  /** Where the envelope actually was. */\n  envelopeFrom: \"body\" | \"header\" | null;\n  /** The request header the retry must use. v1 says X-PAYMENT; v2 says PAYMENT. */\n  paymentHeader: \"X-PAYMENT\" | \"PAYMENT\" | null;\n  /** The accepts[] entry you will pay, or null. */\n  selected: Accept | null;\n}\n\ninterface CapturedResponse {\n  status: number;\n  /** Header names arrive lowercased, the way fetch's Headers normalises them. */\n  headers: Record<string, string>;\n  /** Raw response body. Empty string means the server sent no body at all. */\n  body: string;\n}\n\n/** Four real-shaped responses captured off the wire. */\nconst CAPTURES: Record<string, CapturedResponse> = {\n  // Not metered. No payment needed.\n  \"plain-200\": {\n    status: 200,\n    headers: { \"content-type\": \"application/json\" },\n    body: `{\"pair\":\"USDC/BRL\",\"rate\":\"5.41\"}`,\n  },\n\n  // A v1 server. Envelope in the body. The EVM entry is listed first.\n  \"v1-body\": {\n    status: 402,\n    headers: { \"content-type\": \"application/json\" },\n    body: `{\"x402Version\":1,\"error\":\"X-PAYMENT header is required\",\"accepts\":[{\"scheme\":\"exact\",\"network\":\"eip155:8453\",\"asset\":\"0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913\",\"payTo\":\"0x1a2B3c4D5e6F708192a3B4c5D6e7F8091A2b3C4d\",\"maxAmountRequired\":\"50000\",\"resource\":\"https://api.example.dev/digest\",\"description\":\"Daily market digest\",\"mimeType\":\"application/json\",\"maxTimeoutSeconds\":60},{\"scheme\":\"exact\",\"network\":\"solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1\",\"asset\":\"4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU\",\"payTo\":\"B7o8NfV81HzjuZFWQTTx3Xdvh77Dqoajwib3kWEnvzJF\",\"maxAmountRequired\":\"10000\",\"resource\":\"https://api.example.dev/quote\",\"description\":\"One FX quote\",\"mimeType\":\"application/json\",\"maxTimeoutSeconds\":60}]}`,\n  },\n\n  // A v2 server behind an edge layer that drops bodies on error statuses.\n  // EMPTY BODY. The whole envelope is base64 in the payment-required header.\n  // Its menu offers EVM, Solana mainnet, and Solana devnet — in that order.\n  \"v2-header\": {\n    status: 402,\n    headers: {\n      \"payment-required\":\n        \"eyJ4NDAyVmVyc2lvbiI6MiwiZXJyb3IiOiJwYXltZW50IHJlcXVpcmVkIiwiYWNjZXB0cyI6W3sic2NoZW1lIjoiZXhhY3QiLCJuZXR3b3JrIjoiZWlwMTU1Ojg0NTMiLCJhc3NldCI6IjB4ODMzNTg5ZkNENmVEYjZFMDhmNGM3QzMyRDRmNzFiNTRiZEEwMjkxMyIsInBheVRvIjoiMHgxYTJCM2M0RDVlNkY3MDgxOTJhM0I0YzVENmU3RjgwOTFBMmIzQzRkIiwibWF4QW1vdW50UmVxdWlyZWQiOiI1MDAwMCIsInJlc291cmNlIjoiaHR0cHM6Ly9hcGkuZXhhbXBsZS5kZXYvZGlnZXN0IiwiZGVzY3JpcHRpb24iOiJEYWlseSBtYXJrZXQgZGlnZXN0IiwibWltZVR5cGUiOiJhcHBsaWNhdGlvbi9qc29uIiwibWF4VGltZW91dFNlY29uZHMiOjYwfSx7InNjaGVtZSI6ImV4YWN0IiwibmV0d29yayI6InNvbGFuYTo1ZXlrdDRVc0Z2OFA4TkpkVFJFcFkxdnpxS3FaS3ZkcCIsImFzc2V0IjoiRVBqRldkZDVBdWZxU1NxZU0ycU4xeHp5YmFwQzhHNHdFR0drWnd5VER0MXYiLCJwYXlUbyI6IkI3bzhOZlY4MUh6anVaRldRVFR4M1hkdmg3N0Rxb2Fqd2liM2tXRW52ekpGIiwibWF4QW1vdW50UmVxdWlyZWQiOiI1MDAwMCIsInJlc291cmNlIjoiaHR0cHM6Ly9hcGkuZXhhbXBsZS5kZXYvZGlnZXN0IiwiZGVzY3JpcHRpb24iOiJEYWlseSBtYXJrZXQgZGlnZXN0IiwibWltZVR5cGUiOiJhcHBsaWNhdGlvbi9qc29uIiwibWF4VGltZW91dFNlY29uZHMiOjYwfSx7InNjaGVtZSI6ImV4YWN0IiwibmV0d29yayI6InNvbGFuYTpFdFdUUkFCWmFZcTZpTWZlWUtvdVJ1MTY2VlUyeHFhMSIsImFzc2V0IjoiNHpNTUM5c3J0NVJpNVgxNEdBZ1hoYUhpaTNHblBBRUVSWVBKZ1pKRG5jRFUiLCJwYXlUbyI6IkI3bzhOZlY4MUh6anVaRldRVFR4M1hkdmg3N0Rxb2Fqd2liM2tXRW52ekpGIiwibWF4QW1vdW50UmVxdWlyZWQiOiI1MDAwMCIsInJlc291cmNlIjoiaHR0cHM6Ly9hcGkuZXhhbXBsZS5kZXYvZGlnZXN0IiwiZGVzY3JpcHRpb24iOiJEYWlseSBtYXJrZXQgZGlnZXN0IiwibWltZVR5cGUiOiJhcHBsaWNhdGlvbi9qc29uIiwibWF4VGltZW91dFNlY29uZHMiOjYwfV19\",\n    },\n    body: \"\",\n  },\n\n  // A v2 server that only takes EVM money. Nothing here is payable by you.\n  \"v2-evm-only\": {\n    status: 402,\n    headers: {\n      \"payment-required\":\n        \"eyJ4NDAyVmVyc2lvbiI6MiwiZXJyb3IiOiJwYXltZW50IHJlcXVpcmVkIiwiYWNjZXB0cyI6W3sic2NoZW1lIjoiZXhhY3QiLCJuZXR3b3JrIjoiZWlwMTU1Ojg0NTMiLCJhc3NldCI6IjB4ODMzNTg5ZkNENmVEYjZFMDhmNGM3QzMyRDRmNzFiNTRiZEEwMjkxMyIsInBheVRvIjoiMHgxYTJCM2M0RDVlNkY3MDgxOTJhM0I0YzVENmU3RjgwOTFBMmIzQzRkIiwibWF4QW1vdW50UmVxdWlyZWQiOiI1MDAwMCIsInJlc291cmNlIjoiaHR0cHM6Ly9hcGkuZXhhbXBsZS5kZXYvZGlnZXN0IiwiZGVzY3JpcHRpb24iOiJEYWlseSBtYXJrZXQgZGlnZXN0IiwibWltZVR5cGUiOiJhcHBsaWNhdGlvbi9qc29uIiwibWF4VGltZW91dFNlY29uZHMiOjYwfV19\",\n    },\n    body: \"\",\n  },\n};\n\n/**\n * Decide what to do with a captured HTTP response.\n *\n * Six of the eight blocks below belong here. Two do not. Order matters —\n * every block after the first depends on a local the ones before it declare.\n */\nfunction handle402(captureId: string): Report {\n  const res = CAPTURES[captureId];\n\n  // ---- BLOCK 8 ----------------------------------------------------------\n  // const selected = envelope.accepts.find(\n  //   (entry: Accept) =>\n  //     entry.scheme === \"exact\" &&\n  //     entry.network === SOLANA_DEVNET_CAIP2 &&\n  //     entry.asset === USDC_DEVNET_ADDRESS\n  // );\n  // if (!selected) {\n  //   return { paid: false, x402Version: envelope.x402Version, envelopeFrom, paymentHeader, selected: null };\n  // }\n\n  // ---- BLOCK 3 ----------------------------------------------------------\n  // return {\n  //   paid: true,\n  //   x402Version: 2,\n  //   envelopeFrom: \"body\",\n  //   paymentHeader: \"PAYMENT\",\n  //   selected: JSON.parse(res.body).accepts[0],\n  // };\n\n  // ---- BLOCK 5 ----------------------------------------------------------\n  // if (res.status !== 402) {\n  //   return { paid: false, x402Version: null, envelopeFrom: null, paymentHeader: null, selected: null };\n  // }\n\n  // ---- BLOCK 1 ----------------------------------------------------------\n  // const paymentHeader: \"X-PAYMENT\" | \"PAYMENT\" =\n  //   envelope.x402Version === 1 ? \"X-PAYMENT\" : \"PAYMENT\";\n  // const envelopeFrom: \"header\" | \"body\" = fromHeader ? \"header\" : \"body\";\n\n  // ---- BLOCK 7 ----------------------------------------------------------\n  // const raw = fromHeader ? base64ToUtf8(headerEnvelope) : res.body;\n  // const envelope = JSON.parse(raw);\n\n  // ---- BLOCK 6 ----------------------------------------------------------\n  // const selected = envelope.accepts.find(\n  //   (entry: Accept) => entry.network.indexOf(\"eip155:\") === 0\n  // );\n\n  // ---- BLOCK 2 ----------------------------------------------------------\n  // const headerEnvelope = res.headers[\"payment-required\"];\n  // const fromHeader = res.body.length === 0 && typeof headerEnvelope === \"string\";\n\n  // ---- BLOCK 4 ----------------------------------------------------------\n  // return { paid: true, x402Version: envelope.x402Version, envelopeFrom, paymentHeader, selected };\n}\n\n// --- plumbing -------------------------------------------------------------\n// atob() and Buffer do not exist in this sandbox. Given, not scrambled.\n\nconst B64_ALPHABET =\n  \"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/\";\n\nfunction base64ToUtf8(encoded: string): string {\n  const bytes: number[] = [];\n  let buffer = 0;\n  let bits = 0;\n  for (let i = 0; i < encoded.length; i++) {\n    const value = B64_ALPHABET.indexOf(encoded[i]);\n    if (value < 0) continue;\n    buffer = (buffer << 6) | value;\n    bits += 6;\n    if (bits >= 8) {\n      bits -= 8;\n      bytes.push((buffer >> bits) & 0xff);\n    }\n  }\n  return new TextDecoder().decode(new Uint8Array(bytes));\n}\n",
+        "solution": "// ---------------------------------------------------------------------------\n// REFERENCE SOLUTION — read a 402 challenge and decide how to pay it.\n//\n// Blocks 5, 2, 7, 1, 8, 4 in that order. Blocks 3 and 6 were the wrong ones:\n//   3 — retries before decoding: assumes v2, assumes the body, and takes\n//       accepts[0] sight unseen, which on every capture here is the EVM entry.\n//   6 — selects on the eip155 namespace: a chain you cannot pay from a Solana\n//       wallet.\n//\n// Pinned 2026-07-25: @x402/core 2.19.0, @x402/svm 2.19.0, @x402/fetch 2.19.0.\n// ---------------------------------------------------------------------------\n\nconst SOLANA_DEVNET_CAIP2 = \"solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1\";\nconst USDC_DEVNET_ADDRESS = \"4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU\";\n\ninterface Accept {\n  scheme: string;\n  network: string;\n  asset: string;\n  payTo: string;\n  maxAmountRequired: string;\n  resource: string;\n  description: string;\n  mimeType: string;\n  maxTimeoutSeconds: number;\n}\n\ninterface Report {\n  paid: boolean;\n  x402Version: number | null;\n  envelopeFrom: \"body\" | \"header\" | null;\n  paymentHeader: \"X-PAYMENT\" | \"PAYMENT\" | null;\n  selected: Accept | null;\n}\n\ninterface CapturedResponse {\n  status: number;\n  headers: Record<string, string>;\n  body: string;\n}\n\nconst CAPTURES: Record<string, CapturedResponse> = {\n  \"plain-200\": {\n    status: 200,\n    headers: { \"content-type\": \"application/json\" },\n    body: `{\"pair\":\"USDC/BRL\",\"rate\":\"5.41\"}`,\n  },\n\n  \"v1-body\": {\n    status: 402,\n    headers: { \"content-type\": \"application/json\" },\n    body: `{\"x402Version\":1,\"error\":\"X-PAYMENT header is required\",\"accepts\":[{\"scheme\":\"exact\",\"network\":\"eip155:8453\",\"asset\":\"0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913\",\"payTo\":\"0x1a2B3c4D5e6F708192a3B4c5D6e7F8091A2b3C4d\",\"maxAmountRequired\":\"50000\",\"resource\":\"https://api.example.dev/digest\",\"description\":\"Daily market digest\",\"mimeType\":\"application/json\",\"maxTimeoutSeconds\":60},{\"scheme\":\"exact\",\"network\":\"solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1\",\"asset\":\"4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU\",\"payTo\":\"B7o8NfV81HzjuZFWQTTx3Xdvh77Dqoajwib3kWEnvzJF\",\"maxAmountRequired\":\"10000\",\"resource\":\"https://api.example.dev/quote\",\"description\":\"One FX quote\",\"mimeType\":\"application/json\",\"maxTimeoutSeconds\":60}]}`,\n  },\n\n  \"v2-header\": {\n    status: 402,\n    headers: {\n      \"payment-required\":\n        \"eyJ4NDAyVmVyc2lvbiI6MiwiZXJyb3IiOiJwYXltZW50IHJlcXVpcmVkIiwiYWNjZXB0cyI6W3sic2NoZW1lIjoiZXhhY3QiLCJuZXR3b3JrIjoiZWlwMTU1Ojg0NTMiLCJhc3NldCI6IjB4ODMzNTg5ZkNENmVEYjZFMDhmNGM3QzMyRDRmNzFiNTRiZEEwMjkxMyIsInBheVRvIjoiMHgxYTJCM2M0RDVlNkY3MDgxOTJhM0I0YzVENmU3RjgwOTFBMmIzQzRkIiwibWF4QW1vdW50UmVxdWlyZWQiOiI1MDAwMCIsInJlc291cmNlIjoiaHR0cHM6Ly9hcGkuZXhhbXBsZS5kZXYvZGlnZXN0IiwiZGVzY3JpcHRpb24iOiJEYWlseSBtYXJrZXQgZGlnZXN0IiwibWltZVR5cGUiOiJhcHBsaWNhdGlvbi9qc29uIiwibWF4VGltZW91dFNlY29uZHMiOjYwfSx7InNjaGVtZSI6ImV4YWN0IiwibmV0d29yayI6InNvbGFuYTo1ZXlrdDRVc0Z2OFA4TkpkVFJFcFkxdnpxS3FaS3ZkcCIsImFzc2V0IjoiRVBqRldkZDVBdWZxU1NxZU0ycU4xeHp5YmFwQzhHNHdFR0drWnd5VER0MXYiLCJwYXlUbyI6IkI3bzhOZlY4MUh6anVaRldRVFR4M1hkdmg3N0Rxb2Fqd2liM2tXRW52ekpGIiwibWF4QW1vdW50UmVxdWlyZWQiOiI1MDAwMCIsInJlc291cmNlIjoiaHR0cHM6Ly9hcGkuZXhhbXBsZS5kZXYvZGlnZXN0IiwiZGVzY3JpcHRpb24iOiJEYWlseSBtYXJrZXQgZGlnZXN0IiwibWltZVR5cGUiOiJhcHBsaWNhdGlvbi9qc29uIiwibWF4VGltZW91dFNlY29uZHMiOjYwfSx7InNjaGVtZSI6ImV4YWN0IiwibmV0d29yayI6InNvbGFuYTpFdFdUUkFCWmFZcTZpTWZlWUtvdVJ1MTY2VlUyeHFhMSIsImFzc2V0IjoiNHpNTUM5c3J0NVJpNVgxNEdBZ1hoYUhpaTNHblBBRUVSWVBKZ1pKRG5jRFUiLCJwYXlUbyI6IkI3bzhOZlY4MUh6anVaRldRVFR4M1hkdmg3N0Rxb2Fqd2liM2tXRW52ekpGIiwibWF4QW1vdW50UmVxdWlyZWQiOiI1MDAwMCIsInJlc291cmNlIjoiaHR0cHM6Ly9hcGkuZXhhbXBsZS5kZXYvZGlnZXN0IiwiZGVzY3JpcHRpb24iOiJEYWlseSBtYXJrZXQgZGlnZXN0IiwibWltZVR5cGUiOiJhcHBsaWNhdGlvbi9qc29uIiwibWF4VGltZW91dFNlY29uZHMiOjYwfV19\",\n    },\n    body: \"\",\n  },\n\n  \"v2-evm-only\": {\n    status: 402,\n    headers: {\n      \"payment-required\":\n        \"eyJ4NDAyVmVyc2lvbiI6MiwiZXJyb3IiOiJwYXltZW50IHJlcXVpcmVkIiwiYWNjZXB0cyI6W3sic2NoZW1lIjoiZXhhY3QiLCJuZXR3b3JrIjoiZWlwMTU1Ojg0NTMiLCJhc3NldCI6IjB4ODMzNTg5ZkNENmVEYjZFMDhmNGM3QzMyRDRmNzFiNTRiZEEwMjkxMyIsInBheVRvIjoiMHgxYTJCM2M0RDVlNkY3MDgxOTJhM0I0YzVENmU3RjgwOTFBMmIzQzRkIiwibWF4QW1vdW50UmVxdWlyZWQiOiI1MDAwMCIsInJlc291cmNlIjoiaHR0cHM6Ly9hcGkuZXhhbXBsZS5kZXYvZGlnZXN0IiwiZGVzY3JpcHRpb24iOiJEYWlseSBtYXJrZXQgZGlnZXN0IiwibWltZVR5cGUiOiJhcHBsaWNhdGlvbi9qc29uIiwibWF4VGltZW91dFNlY29uZHMiOjYwfV19\",\n    },\n    body: \"\",\n  },\n};\n\nfunction handle402(captureId: string): Report {\n  const res = CAPTURES[captureId];\n\n  // ---- BLOCK 5 — detect -------------------------------------------------\n  // Nothing else runs unless the server actually asked for payment.\n  if (res.status !== 402) {\n    return { paid: false, x402Version: null, envelopeFrom: null, paymentHeader: null, selected: null };\n  }\n\n  // ---- BLOCK 2 — locate -------------------------------------------------\n  // The envelope is in the body, EXCEPT when the body is empty, in which case\n  // it is base64 in the payment-required header. Check both, always.\n  const headerEnvelope = res.headers[\"payment-required\"];\n  const fromHeader = res.body.length === 0 && typeof headerEnvelope === \"string\";\n\n  // ---- BLOCK 7 — decode -------------------------------------------------\n  const raw = fromHeader ? base64ToUtf8(headerEnvelope) : res.body;\n  const envelope = JSON.parse(raw);\n\n  // ---- BLOCK 1 — version ------------------------------------------------\n  // The envelope names its own wire version, and the version decides the\n  // request header the retry has to use.\n  const paymentHeader: \"X-PAYMENT\" | \"PAYMENT\" =\n    envelope.x402Version === 1 ? \"X-PAYMENT\" : \"PAYMENT\";\n  const envelopeFrom: \"header\" | \"body\" = fromHeader ? \"header\" : \"body\";\n\n  // ---- BLOCK 8 — select -------------------------------------------------\n  // accepts[] is a menu. Filter on scheme, network AND asset. Never index it.\n  const selected = envelope.accepts.find(\n    (entry: Accept) =>\n      entry.scheme === \"exact\" &&\n      entry.network === SOLANA_DEVNET_CAIP2 &&\n      entry.asset === USDC_DEVNET_ADDRESS\n  );\n  if (!selected) {\n    return { paid: false, x402Version: envelope.x402Version, envelopeFrom, paymentHeader, selected: null };\n  }\n\n  // ---- BLOCK 4 — retry --------------------------------------------------\n  // In the live client this is where you sign the payment for `selected` and\n  // re-issue the request carrying it in `paymentHeader`.\n  return { paid: true, x402Version: envelope.x402Version, envelopeFrom, paymentHeader, selected };\n}\n\n// --- plumbing -------------------------------------------------------------\n\nconst B64_ALPHABET =\n  \"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/\";\n\nfunction base64ToUtf8(encoded: string): string {\n  const bytes: number[] = [];\n  let buffer = 0;\n  let bits = 0;\n  for (let i = 0; i < encoded.length; i++) {\n    const value = B64_ALPHABET.indexOf(encoded[i]);\n    if (value < 0) continue;\n    buffer = (buffer << 6) | value;\n    bits += 6;\n    if (bits >= 8) {\n      bits -= 8;\n      bytes.push((buffer >> bits) & 0xff);\n    }\n  }\n  return new TextDecoder().decode(new Uint8Array(bytes));\n}\n",
+        "tests": [
+          {
+            "id": "t1",
+            "description": "A 200 is not a challenge — nothing is decoded and nothing is paid",
+            "input": "'plain-200'",
+            "expectedOutput": "result.paid === false && result.x402Version === null && result.envelopeFrom === null && result.paymentHeader === null && result.selected === null"
+          },
+          {
+            "id": "t2",
+            "description": "v1 server: envelope read from the body, retry uses the X-PAYMENT header",
+            "input": "'v1-body'",
+            "expectedOutput": "result.paid === true && result.x402Version === 1 && result.envelopeFrom === 'body' && result.paymentHeader === 'X-PAYMENT'"
+          },
+          {
+            "id": "t3",
+            "description": "v1 server: the Solana devnet USDC entry is selected, not the EVM entry at accepts[0]",
+            "input": "'v1-body'",
+            "expectedOutput": "result.selected.network === 'solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1' && result.selected.asset === '4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU' && result.selected.maxAmountRequired === '10000'"
+          },
+          {
+            "id": "t4",
+            "description": "v2 server with an empty body: envelope read from the payment-required header, retry uses PAYMENT",
+            "input": "'v2-header'",
+            "expectedOutput": "result.paid === true && result.x402Version === 2 && result.envelopeFrom === 'header' && result.paymentHeader === 'PAYMENT'"
+          },
+          {
+            "id": "t5",
+            "description": "v2 server: devnet is picked over the mainnet entry that shares the same scheme",
+            "input": "'v2-header'",
+            "expectedOutput": "result.selected.network === 'solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1' && result.selected.asset === '4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU' && result.selected.maxAmountRequired === '50000'"
+          },
+          {
+            "id": "t6",
+            "description": "A challenge with no payable Solana entry is decoded and reported, not paid",
+            "input": "'v2-evm-only'",
+            "expectedOutput": "result.paid === false && result.selected === null && result.x402Version === 2 && result.envelopeFrom === 'header' && result.paymentHeader === 'PAYMENT'"
+          }
+        ],
+        "hints": [
+          "Five things happen in order: detect, locate, decode, read the version, select. Only then do you retry.",
+          "Every block after the first uses a local that an earlier block declares. That dependency chain is the ordering.",
+          "One wrong block calls `JSON.parse(res.body)` before anything has checked whether the body is empty.",
+          "The other wrong block filters on `eip155:` — a namespace your Solana wallet cannot pay."
+        ],
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "check",
+        "_type": "quiz",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": [
+          {
+            "id": "q1",
+            "prompt": "Your client calls a metered route. It gets back HTTP 402 with `content-length: 0` and an empty body. Your code does `JSON.parse(await res.text())`. Predict the failure and the fix.",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "`JSON.parse(\"\")` throws. The envelope is base64 in the `PAYMENT-REQUIRED` response header — read the body, and fall back to the header when it is empty.",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "The server is broken; the envelope is always in the body. Report a bug.",
+                "correct": false,
+                "feedback": "It is legal and common. Edge layers in front of Vercel-hosted servers drop bodies on error statuses, so the envelope moves to a header. This is the single most frequent x402 integration failure."
+              },
+              {
+                "id": "c",
+                "label": "The 402 has no envelope, so retry the request until one arrives.",
+                "correct": false,
+                "feedback": "Retrying a bare request gets you the same 402. Nothing about the response changes until you send a payment."
+              },
+              {
+                "id": "d",
+                "label": "Use `res.json()` instead of `res.text()`; it handles the empty case.",
+                "correct": false,
+                "feedback": "`res.json()` on an empty body throws too. Changing the parser does not conjure a body that was never sent."
+              }
+            ],
+            "explanation": "A correct client reads both places. A correct server emits both places. You wrote the server half last lesson; this is the client half."
+          },
+          {
+            "id": "q2",
+            "prompt": "`@x402/svm@2.19.0` exports both `ExactSvmScheme` and `ExactSvmSchemeV1`. Why?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "Because v1 and v2 are both live on the wire right now. Servers on the frozen 1.2.0 packages still speak v1, with different header names and different envelope fields.",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "`ExactSvmSchemeV1` is deprecated dead code kept for the type definitions.",
+                "correct": false,
+                "feedback": "It is there because you will meet v1 servers. Registering only the v2 scheme means silently failing against every server still on the frozen package line."
+              },
+              {
+                "id": "c",
+                "label": "One is for Token, the other for Token-2022.",
+                "correct": false,
+                "feedback": "The token program is a property of the mint named in `asset`, not of the scheme. The `V1` suffix is the protocol version."
+              },
+              {
+                "id": "d",
+                "label": "One is for devnet, the other for mainnet.",
+                "correct": false,
+                "feedback": "The network is a field in the challenge (`network`), not a separate scheme export."
+              }
+            ],
+            "explanation": "This is the difference between a client that works for a year and one that works until the first server you did not test against. Read the version off the envelope; do not assume it."
+          },
+          {
+            "id": "q3",
+            "prompt": "A challenge's `accepts[]` is `[eip155:8453 USDC, solana-mainnet USDC, solana-devnet USDC]`. You hold devnet USDC. Your code does `const terms = envelope.accepts[0]`. What have you built?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "A client that tries to pay on Base. Ordering in `accepts[]` is the server's preference, not your capability — you have to filter on network and asset.",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "A client that pays correctly, since servers list the cheapest option first.",
+                "correct": false,
+                "feedback": "Nothing in the protocol orders `accepts[]` by price, and nothing guarantees the first entry is even on a chain you can use."
+              },
+              {
+                "id": "c",
+                "label": "A client that pays on Solana mainnet.",
+                "correct": false,
+                "feedback": "`accepts[0]` here is the EVM entry. Both Solana entries are further down the list, which is exactly why indexing is the bug."
+              },
+              {
+                "id": "d",
+                "label": "A client that fails safely, because the scheme validates the chain for you.",
+                "correct": false,
+                "feedback": "Selection is the client's job. Nothing downstream will tell you that you picked terms you cannot satisfy — you will simply fail to produce a valid payment."
+              }
+            ],
+            "explanation": "`accepts[]` is a menu. Filter it on `scheme`, `network` and `asset`, and treat \"no match\" as a normal, reportable outcome — not a crash."
+          },
+          {
+            "id": "q4",
+            "prompt": "You decoded an envelope carrying `\"x402Version\": 1`. Which request header must your retry use to carry the payment?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "`X-PAYMENT`",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "`PAYMENT`",
+                "correct": false,
+                "feedback": "That is the v2 name. Sending it to a v1 server means the server sees no payment at all."
+              },
+              {
+                "id": "c",
+                "label": "`PAYMENT-REQUIRED`",
+                "correct": false,
+                "feedback": "That is a RESPONSE header — the fallback location for the challenge the server sends you. It never carries your payment."
+              },
+              {
+                "id": "d",
+                "label": "`Authorization`",
+                "correct": false,
+                "feedback": "x402 does not reuse the auth header. Payment is its own header."
+              }
+            ],
+            "explanation": "Header names are part of what changed between versions, which is why you read the version before you build the retry — not after."
+          }
+        ],
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      }
+    ]
+  },
+  {
+    "_id": "lesson-sap-budgeted-agent-with-a-hard-cap",
+    "title": "An Agent With a Wallet That Can Say No",
+    "slug": "budgeted-agent-with-a-hard-cap",
+    "blocks": [
+      {
+        "key": "intro",
+        "_type": "prose",
+        "produces": null,
+        "consumes": null,
+        "src": "# An Agent With a Wallet That Can Say No\n\n> **Version stamp — checked 2026-07-25.** `@solana/subscriptions` **0.4.0 exactly** (the `beta` tag is `0.4.0-rc.2`; this package is pre-1.0 and moving). `@solana/kit` **7.0.0**. `@x402/core`, `@x402/svm`, `@x402/fetch` **2.19.0**.\n\nHere is the scope fence, up front, so you know what this lesson is not.\n\n**No agent framework.** No SendAI Solana Agent Kit, no ElizaOS, no LangChain, no Vercel AI SDK. The \"agent\" in this lesson is a `for` loop. Every one of those frameworks will be a different set of names in eighteen months, and none of them solves the problem that actually matters here.\n\nThe problem that matters is this: **an autonomous process needs money, and giving a process money is giving it the ability to lose all of it.** The standard answer is to fund a hot keypair and hope. That is not a budget. That is a blast radius.\n\nYou already built the alternative. In lesson 3 you opened a **Fixed Delegation** — a program-enforced allowance with a capped total, drawn down by `transferFixed`. That is the agent's wallet. Not a keypair holding funds: an authorisation, on the user's account, that the program refuses to exceed.\n\nThe difference is where the limit lives. A limit in your code is a limit an attacker edits out. A limit in a program-owned account is a limit that survives your code being wrong, your key being stolen, and your loop running a hundred times more than you meant it to. That is why Allowances are documented as the budget primitive for agents, and it is the whole reason this course ends here rather than with a model integration.\n\n---\n\n## The loop\n\n```\nbudget = the Fixed Delegation from lesson 3   (remaining_amount, base units, u64)\n\nfor each task step, up to maxCalls:\n    if remaining < price:  HALT — budget exhausted\n    call the metered endpoint from lesson 5, through the wrapped fetch from lesson 6\n    settle the 402 by drawing `price` from the delegation with transferFixed\n    if the program refuses:  HALT — refused, record the code\n    remaining -= price\nreport: calls, spent, remaining, signatures, why it stopped\n```\n\nThree exits. Only one of them is success. **The exit conditions are the learning objective, not error handling bolted on at the end** — which is why today's exercise grades the decision logic and not the happy path.\n\n### Exit 1 — budget exhausted (you decide)\n\nBefore every call, compare `remaining` against the price. If you cannot afford it, stop. Do not build the transaction and let the chain tell you.\n\nA transaction that reaches execution and fails still pays a fee. Sending one you already know will be refused buys you nothing but a worse report: you learn \"the program refused\" when you could have known \"the budget ran out\" — different facts, different alerts, different fixes.\n\n### Exit 2 — refused (the program decides)\n\nA refusal from the delegation program is **terminal**. Do not retry it.\n\nBackoff exists for transient failures — congestion, an expired blockhash, a flaky RPC. A policy refusal is not transient. The allowance is state on-chain; waiting does not change it. Retrying asks the same program the same question and gets the same answer, one fee poorer, three times over.\n\nRecord the code the program returned, **verbatim**, and stop. Do not pattern-match on the string to decide whether to continue — your loop halts on any refusal, and the code is diagnostic output for a human, not a control-flow input. The one code worth recognising on sight is `AMOUNT_EXCEEDS_PERIOD_LIMIT` from lesson 4, and even that one is a halt: it means a recurring cap has not rolled over yet.\n\n### Exit 3 — completed\n\nThe task finished inside its budget. `halted: false`. This is the boring one, and it should be.\n\n---\n\n## Base units are u64\n\n`remaining_amount` and every price in this system is a `u64` count of base units. `Number.MAX_SAFE_INTEGER` is 2^53 − 1. A u64 goes to 2^64 − 1.\n\nConvert once with `BigInt(...)`, do the arithmetic in `BigInt`, return decimal strings. One of the scenarios in the exercise spends a u64-sized allowance to exactly zero — it comes out right in BigInt and comes out wrong, silently, in `Number`. Silently is the part that should worry you: there is no exception, just a balance that is off by a bit you will find in production.\n\n---\n\n## What the exercise grades\n\n`runAgentLoop(scenarioId)` gets an allowance, a price, a call budget and a list of settlement responses, and returns a report. The network round trips are captured; what you write is the spend / halt / report logic.\n\nTwo of the scenarios are traps, and both are traps that real loops fall into:\n\n- **`s-exhausted`** supplies five successful settlements for a task the allowance can only fund twice. A loop that settles first and checks the budget afterwards reports three calls and a negative balance.\n- **`s-refused`** puts a *successful* settlement immediately after the refusal. A loop that logs the refusal and continues will find it, count it, and report a spend that never happened.\n\nNeither trap produces an exception. Both produce a confident, wrong report. That is what makes them worth grading.\n\n---\n\n## Where this goes next\n\n`@x402/mcp` (2.19.0) puts the same payment loop behind the Model Context Protocol, so a tool an assistant calls can charge for itself and the assistant pays out of exactly this kind of capped allowance. Same primitive, one layer up. Worth an afternoon after this course.\n\n**A note on the bounty market, since you will be tempted.** Agent bounties on Superteam Earn are the worst odds on the platform — roughly $53 per competitor, with a median around 91 submissions. Payments listings and technical deep dives pay far better per unit of effort. What you learned here is the **budget primitive**, which is a component of things people actually pay for. Lesson 8 points you at the listings where that is true.\n\n## Milestone\n\nYou need three things from this module for lesson 8, so collect them now:\n\n1. **The URL of your metered endpoint** — the live one from lesson 5, running in your course-4 app.\n2. **The settlement signatures** your agent produced — at least one, from a real devnet draw against your Fixed Delegation.\n3. **The delegation address**, and the `remaining_amount` before and after.\n\nThat set is the proof. Anyone can describe an agent with a budget; you can show the transactions where one hit its cap and stopped.\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "exercise",
+        "_type": "code",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": "typescript",
+        "buildType": "standard",
+        "deployable": false,
+        "starter": "// ---------------------------------------------------------------------------\n// The agent's call loop. You write this one.\n//\n// Pinned 2026-07-25: @solana/subscriptions 0.4.0 (exactly), @solana/kit 7.0.0,\n// @x402/{core,svm,fetch} 2.19.0.\n//\n// In your own project each iteration is: call the metered endpoint through the\n// wrapped fetch from lesson 6, and settle the 402 with a `transferFixed` draw\n// against the Fixed Delegation you opened in lesson 3. Here the network round\n// trips are already captured — what you implement is the part that is actually\n// yours: the spend / halt / report decision logic.\n// ---------------------------------------------------------------------------\n\n/** One settlement attempt as the delegation program answered it. */\ninterface Settlement {\n  ok: boolean;\n  /** Present when ok. */\n  signature?: string;\n  /** Present when not ok. The program's error, verbatim. */\n  error?: { code: string };\n}\n\ninterface Scenario {\n  /** `remaining_amount` on the Fixed Delegation. Base units, decimal string. */\n  remainingBaseUnits: string;\n  /** What one call costs. Base units, decimal string. */\n  pricePerCall: string;\n  /** The agent's task: at most this many calls. */\n  maxCalls: number;\n  /** Settlement responses, consumed in order — one per call actually attempted. */\n  settlements: Settlement[];\n}\n\ninterface AgentReport {\n  /** Calls that completed AND settled. */\n  calls: number;\n  /** Total drawn from the delegation. Base units, decimal string. */\n  spent: string;\n  /** What is left on the delegation. Base units, decimal string. */\n  remaining: string;\n  /** Settlement signatures, in order, one per successful call. */\n  signatures: string[];\n  /** True when the loop stopped before finishing its task. */\n  halted: boolean;\n  reason: \"completed\" | \"budget-exhausted\" | \"refused\";\n  /** The program's error code when reason is \"refused\", otherwise null. */\n  errorCode: string | null;\n}\n\nconst SCENARIOS: Record<string, Scenario> = {\n  // Budget comfortably covers the task.\n  \"s-completed\": {\n    remainingBaseUnits: \"1000000\",\n    pricePerCall: \"10000\",\n    maxCalls: 3,\n    settlements: [\n      { ok: true, signature: \"sig-c1\" },\n      { ok: true, signature: \"sig-c2\" },\n      { ok: true, signature: \"sig-c3\" },\n    ],\n  },\n\n  // The task needs 5 calls. The allowance covers 2 and a half.\n  // Note that the fixtures would happily settle all five.\n  \"s-exhausted\": {\n    remainingBaseUnits: \"25000\",\n    pricePerCall: \"10000\",\n    maxCalls: 5,\n    settlements: [\n      { ok: true, signature: \"sig-e1\" },\n      { ok: true, signature: \"sig-e2\" },\n      { ok: true, signature: \"sig-e3\" },\n      { ok: true, signature: \"sig-e4\" },\n      { ok: true, signature: \"sig-e5\" },\n    ],\n  },\n\n  // The program refuses the third draw. The fourth response is a success —\n  // it is there to catch a loop that keeps going after a refusal.\n  \"s-refused\": {\n    remainingBaseUnits: \"1000000\",\n    pricePerCall: \"250000\",\n    maxCalls: 4,\n    settlements: [\n      { ok: true, signature: \"sig-r1\" },\n      { ok: true, signature: \"sig-r2\" },\n      { ok: false, error: { code: \"AmountExceedsTotalLimit\" } },\n      { ok: true, signature: \"sig-r4\" },\n    ],\n  },\n\n  // Nothing left at all.\n  \"s-broke\": {\n    remainingBaseUnits: \"0\",\n    pricePerCall: \"10000\",\n    maxCalls: 2,\n    settlements: [{ ok: true, signature: \"sig-b1\" }],\n  },\n\n  // A u64-sized allowance spent to exactly zero. Base units are u64; Number\n  // stops being exact above 2^53, so this one only comes out right if the\n  // arithmetic never becomes a Number.\n  \"s-precision\": {\n    remainingBaseUnits: \"18446744073709551615\",\n    pricePerCall: \"6148914691236517205\",\n    maxCalls: 3,\n    settlements: [\n      { ok: true, signature: \"sig-p1\" },\n      { ok: true, signature: \"sig-p2\" },\n      { ok: true, signature: \"sig-p3\" },\n    ],\n  },\n};\n\n/**\n * Run the agent's call loop against a scenario and report what happened.\n *\n * SPEC — the loop performs at most `maxCalls` calls, and before each one:\n *\n *   1. If `remaining` is less than `pricePerCall`, STOP. Do not attempt the\n *      call and do not consume a settlement. Report halted: true, reason\n *      \"budget-exhausted\", errorCode null. A transaction you already know the\n *      program will refuse still costs you a fee.\n *   2. Otherwise consume the next settlement, in order.\n *      - ok: count the call, add the price to `spent`, subtract it from\n *        `remaining`, append the signature, continue.\n *      - not ok: STOP IMMEDIATELY. Do not retry, do not skip it, do not touch\n *        `spent` or `remaining`. Report halted: true, reason \"refused\", and\n *        errorCode set to the program's code verbatim.\n *   3. If all `maxCalls` calls settle, report halted: false, reason\n *      \"completed\", errorCode null.\n *\n * ACCEPTANCE CRITERIA\n *   - `spent`, `remaining` and `pricePerCall` are base units. Do the arithmetic\n *     in BigInt and return decimal strings. A u64 allowance does not survive\n *     Number.\n *   - `signatures.length` always equals `calls`.\n *   - `errorCode` is non-null only when reason is \"refused\", and it is the code\n *     the program returned — never a string you invented.\n *   - The function returns a report in every case. It never throws.\n */\nfunction runAgentLoop(scenarioId: string): AgentReport {\n  const scenario = SCENARIOS[scenarioId];\n\n  // Your code here.\n\n  return {\n    calls: 0,\n    spent: \"0\",\n    remaining: scenario.remainingBaseUnits,\n    signatures: [],\n    halted: false,\n    reason: \"completed\",\n    errorCode: null,\n  };\n}\n",
+        "solution": "// ---------------------------------------------------------------------------\n// REFERENCE SOLUTION — the agent's call loop.\n//\n// Pinned 2026-07-25: @solana/subscriptions 0.4.0 (exactly), @solana/kit 7.0.0,\n// @x402/{core,svm,fetch} 2.19.0.\n//\n// In your own project each iteration is: call the metered endpoint through the\n// wrapped fetch from lesson 6, and settle the 402 with a `transferFixed` draw\n// against the Fixed Delegation you opened in lesson 3. Here the network round\n// trips are already captured — what you implement is the part that is actually\n// yours: the spend / halt / report decision logic.\n// ---------------------------------------------------------------------------\n\n/** One settlement attempt as the delegation program answered it. */\ninterface Settlement {\n  ok: boolean;\n  /** Present when ok. */\n  signature?: string;\n  /** Present when not ok. The program's error, verbatim. */\n  error?: { code: string };\n}\n\ninterface Scenario {\n  /** `remaining_amount` on the Fixed Delegation. Base units, decimal string. */\n  remainingBaseUnits: string;\n  /** What one call costs. Base units, decimal string. */\n  pricePerCall: string;\n  /** The agent's task: at most this many calls. */\n  maxCalls: number;\n  /** Settlement responses, consumed in order — one per call actually attempted. */\n  settlements: Settlement[];\n}\n\ninterface AgentReport {\n  /** Calls that completed AND settled. */\n  calls: number;\n  /** Total drawn from the delegation. Base units, decimal string. */\n  spent: string;\n  /** What is left on the delegation. Base units, decimal string. */\n  remaining: string;\n  /** Settlement signatures, in order, one per successful call. */\n  signatures: string[];\n  /** True when the loop stopped before finishing its task. */\n  halted: boolean;\n  reason: \"completed\" | \"budget-exhausted\" | \"refused\";\n  /** The program's error code when reason is \"refused\", otherwise null. */\n  errorCode: string | null;\n}\n\nconst SCENARIOS: Record<string, Scenario> = {\n  // Budget comfortably covers the task.\n  \"s-completed\": {\n    remainingBaseUnits: \"1000000\",\n    pricePerCall: \"10000\",\n    maxCalls: 3,\n    settlements: [\n      { ok: true, signature: \"sig-c1\" },\n      { ok: true, signature: \"sig-c2\" },\n      { ok: true, signature: \"sig-c3\" },\n    ],\n  },\n\n  // The task needs 5 calls. The allowance covers 2 and a half.\n  // Note that the fixtures would happily settle all five.\n  \"s-exhausted\": {\n    remainingBaseUnits: \"25000\",\n    pricePerCall: \"10000\",\n    maxCalls: 5,\n    settlements: [\n      { ok: true, signature: \"sig-e1\" },\n      { ok: true, signature: \"sig-e2\" },\n      { ok: true, signature: \"sig-e3\" },\n      { ok: true, signature: \"sig-e4\" },\n      { ok: true, signature: \"sig-e5\" },\n    ],\n  },\n\n  // The program refuses the third draw. The fourth response is a success —\n  // it is there to catch a loop that keeps going after a refusal.\n  \"s-refused\": {\n    remainingBaseUnits: \"1000000\",\n    pricePerCall: \"250000\",\n    maxCalls: 4,\n    settlements: [\n      { ok: true, signature: \"sig-r1\" },\n      { ok: true, signature: \"sig-r2\" },\n      { ok: false, error: { code: \"AmountExceedsTotalLimit\" } },\n      { ok: true, signature: \"sig-r4\" },\n    ],\n  },\n\n  // Nothing left at all.\n  \"s-broke\": {\n    remainingBaseUnits: \"0\",\n    pricePerCall: \"10000\",\n    maxCalls: 2,\n    settlements: [{ ok: true, signature: \"sig-b1\" }],\n  },\n\n  // A u64-sized allowance spent to exactly zero. Base units are u64; Number\n  // stops being exact above 2^53, so this one only comes out right if the\n  // arithmetic never becomes a Number.\n  \"s-precision\": {\n    remainingBaseUnits: \"18446744073709551615\",\n    pricePerCall: \"6148914691236517205\",\n    maxCalls: 3,\n    settlements: [\n      { ok: true, signature: \"sig-p1\" },\n      { ok: true, signature: \"sig-p2\" },\n      { ok: true, signature: \"sig-p3\" },\n    ],\n  },\n};\n\n/**\n * Run the agent's call loop against a scenario and report what happened.\n *\n * SPEC — the loop performs at most `maxCalls` calls, and before each one:\n *\n *   1. If `remaining` is less than `pricePerCall`, STOP. Do not attempt the\n *      call and do not consume a settlement. Report halted: true, reason\n *      \"budget-exhausted\", errorCode null. A transaction you already know the\n *      program will refuse still costs you a fee.\n *   2. Otherwise consume the next settlement, in order.\n *      - ok: count the call, add the price to `spent`, subtract it from\n *        `remaining`, append the signature, continue.\n *      - not ok: STOP IMMEDIATELY. Do not retry, do not skip it, do not touch\n *        `spent` or `remaining`. Report halted: true, reason \"refused\", and\n *        errorCode set to the program's code verbatim.\n *   3. If all `maxCalls` calls settle, report halted: false, reason\n *      \"completed\", errorCode null.\n *\n * ACCEPTANCE CRITERIA\n *   - `spent`, `remaining` and `pricePerCall` are base units. Do the arithmetic\n *     in BigInt and return decimal strings. A u64 allowance does not survive\n *     Number.\n *   - `signatures.length` always equals `calls`.\n *   - `errorCode` is non-null only when reason is \"refused\", and it is the code\n *     the program returned — never a string you invented.\n *   - The function returns a report in every case. It never throws.\n */\nfunction runAgentLoop(scenarioId: string): AgentReport {\n  const scenario = SCENARIOS[scenarioId];\n\n  const price = BigInt(scenario.pricePerCall);\n  let remaining = BigInt(scenario.remainingBaseUnits);\n  let spent = BigInt(0);\n  let calls = 0;\n  const signatures: string[] = [];\n\n  for (let i = 0; i < scenario.maxCalls; i++) {\n    // The cap is on-chain, so the loop checks it BEFORE spending a fee to be\n    // told what it could already work out for itself.\n    if (remaining < price) {\n      return {\n        calls,\n        spent: spent.toString(),\n        remaining: remaining.toString(),\n        signatures,\n        halted: true,\n        reason: \"budget-exhausted\",\n        errorCode: null,\n      };\n    }\n\n    const settlement = scenario.settlements[i];\n\n    // A refusal is terminal. Retrying it asks the same program the same\n    // question and gets the same answer, one fee poorer.\n    if (!settlement || !settlement.ok) {\n      const code =\n        settlement && settlement.error ? settlement.error.code : \"NoSettlementResponse\";\n      return {\n        calls,\n        spent: spent.toString(),\n        remaining: remaining.toString(),\n        signatures,\n        halted: true,\n        reason: \"refused\",\n        errorCode: code,\n      };\n    }\n\n    calls += 1;\n    spent += price;\n    remaining -= price;\n    signatures.push(settlement.signature as string);\n  }\n\n  return {\n    calls,\n    spent: spent.toString(),\n    remaining: remaining.toString(),\n    signatures,\n    halted: false,\n    reason: \"completed\",\n    errorCode: null,\n  };\n}\n",
+        "tests": [
+          {
+            "id": "t1",
+            "description": "Budget covers the task: every call settles and the loop reports completed",
+            "input": "'s-completed'",
+            "expectedOutput": "result.calls === 3 && result.spent === '30000' && result.remaining === '970000' && result.halted === false && result.reason === 'completed' && result.errorCode === null"
+          },
+          {
+            "id": "t2",
+            "description": "One signature per settled call, in order",
+            "input": "'s-completed'",
+            "expectedOutput": "result.signatures.length === result.calls && result.signatures[0] === 'sig-c1' && result.signatures[2] === 'sig-c3'"
+          },
+          {
+            "id": "t3",
+            "description": "Allowance runs out mid-task: the loop halts before attempting the call it cannot afford",
+            "input": "'s-exhausted'",
+            "expectedOutput": "result.calls === 2 && result.spent === '20000' && result.remaining === '5000' && result.halted === true && result.reason === 'budget-exhausted' && result.errorCode === null"
+          },
+          {
+            "id": "t4",
+            "description": "The program refuses a draw: the loop stops there, records the code, and does not consume the later successful settlement",
+            "input": "'s-refused'",
+            "expectedOutput": "result.calls === 2 && result.spent === '500000' && result.remaining === '500000' && result.halted === true && result.reason === 'refused' && result.errorCode === 'AmountExceedsTotalLimit' && result.signatures.length === 2"
+          },
+          {
+            "id": "t5",
+            "description": "An empty allowance halts on call zero without spending a fee",
+            "input": "'s-broke'",
+            "expectedOutput": "result.calls === 0 && result.spent === '0' && result.remaining === '0' && result.halted === true && result.reason === 'budget-exhausted' && result.signatures.length === 0"
+          },
+          {
+            "id": "t6",
+            "description": "A u64-sized allowance spent to exactly zero — the arithmetic never becomes a Number",
+            "input": "'s-precision'",
+            "expectedOutput": "result.spent === '18446744073709551615' && result.remaining === '0' && result.calls === 3 && result.reason === 'completed'"
+          }
+        ],
+        "hints": [
+          "Three ways out of the loop, and each one returns a different `reason`. Write all three before you write the happy path.",
+          "The budget check comes before the settlement, not after: if you cannot afford the call, you never attempt it and never consume a settlement.",
+          "Convert once with `BigInt(...)`, do the arithmetic in BigInt, and call `.toString()` on the way out.",
+          "`s-refused` has a successful settlement after the refusal. If your report counts three calls, your loop kept going."
+        ],
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "check",
+        "_type": "quiz",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": [
+          {
+            "id": "q1",
+            "prompt": "Two setups. (A) The agent holds a keypair with 400 USDC in its own token account. (B) The agent holds a keypair with no tokens, and a Fixed Delegation on the user's account capped at 40 USDC total. The agent's key leaks. Compare the losses.",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "A loses up to 400. B loses at most the 40 still on the delegation — the cap is enforced by the program, so the stolen key cannot draw past it.",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "Both lose everything in the user's token account, since the delegation grants access to it.",
+                "correct": false,
+                "feedback": "A delegation is not account access. It authorises transfers up to a recorded amount, and the program refuses anything beyond it regardless of who is signing."
+              },
+              {
+                "id": "c",
+                "label": "B is worse, because the delegation can be drawn repeatedly.",
+                "correct": false,
+                "feedback": "A Fixed Delegation is a capped TOTAL, not a per-transfer limit. Repeated draws consume the same pool and stop when it is empty."
+              },
+              {
+                "id": "d",
+                "label": "The losses are identical; the cap is a client-side convenience.",
+                "correct": false,
+                "feedback": "The cap lives in a program-owned account on-chain. A compromised client cannot raise it, ignore it, or patch it out."
+              }
+            ],
+            "explanation": "This is the whole argument for the lesson. Autonomy is safe when the limit is somewhere the agent cannot reach, and a program-enforced allowance is exactly that."
+          },
+          {
+            "id": "q2",
+            "prompt": "Your loop draws from the delegation, the program refuses, and your `catch` block retries the same draw three times with backoff. Predict what happens.",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "Three more refusals and three more fees. The cap is state on-chain, not a transient failure — nothing about waiting changes the answer.",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "One of the retries succeeds once the previous transaction finalises.",
+                "correct": false,
+                "feedback": "Finalisation does not add funds to an allowance. The remaining amount is what it is."
+              },
+              {
+                "id": "c",
+                "label": "The retries are free because failed transactions are not charged.",
+                "correct": false,
+                "feedback": "A transaction that reaches execution and fails still pays its fee. Failing repeatedly on purpose is a way to spend money on nothing."
+              },
+              {
+                "id": "d",
+                "label": "The delegation auto-tops-up from the user's balance on the third attempt.",
+                "correct": false,
+                "feedback": "Nothing tops up automatically. Raising the cap is an action the USER signs — which is the point of the design."
+              }
+            ],
+            "explanation": "Backoff is for transient failures: congestion, blockhash expiry, a flaky RPC. A policy refusal is terminal. Distinguishing the two is most of what \"error handling\" means in a payment loop."
+          },
+          {
+            "id": "q3",
+            "prompt": "The allowance has 5,000 base units left and the next call costs 10,000. Your loop attempts it anyway and handles the failure. What did that choice cost you?",
+            "multiSelect": true,
+            "options": [
+              {
+                "id": "a",
+                "label": "A transaction fee for a transaction you already knew would be refused",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "A worse report — you learn \"the program refused\" instead of \"the budget is exhausted\", which are different operational facts",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "c",
+                "label": "The remaining 5,000 base units, which are consumed by the failed attempt",
+                "correct": false,
+                "feedback": "A failed transfer transfers nothing. The allowance is untouched — the cost is the fee and the lost clarity, not the balance."
+              },
+              {
+                "id": "d",
+                "label": "Nothing, since the on-chain cap protects you either way",
+                "correct": false,
+                "feedback": "The cap protects the user's funds. It does not refund your fees, and it does not write your report for you."
+              }
+            ],
+            "explanation": "Track `remaining_amount` locally and check it before you build the transaction. The on-chain cap is your last line of defence, not your first."
+          },
+          {
+            "id": "q4",
+            "prompt": "Two requirements. (i) \"This agent may spend at most 50 USDC, ever.\" (ii) \"This agent may spend at most 50 USDC each month, indefinitely.\" Which delegation does each need?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "(i) Fixed Delegation — a capped total. (ii) Recurring Delegation — a cap that resets per period.",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "Both are Recurring Delegations; you set the period to \"forever\" for (i).",
+                "correct": false,
+                "feedback": "A recurring cap resets. There is no period long enough to make a resetting cap into a lifetime limit — you would just be extending the window."
+              },
+              {
+                "id": "c",
+                "label": "Both are Fixed Delegations; for (ii) you re-create the delegation every month.",
+                "correct": false,
+                "feedback": "That works only if someone remembers, and every re-creation needs the user's signature. The recurring model exists precisely so the user signs once."
+              },
+              {
+                "id": "d",
+                "label": "(i) Subscription Plan, (ii) Fixed Delegation.",
+                "correct": false,
+                "feedback": "A subscription plan is the merchant-published model, where approved pullers collect against terms the merchant set. Neither requirement here describes that."
+              }
+            ],
+            "explanation": "Same three models you mapped in lesson 1, now with a concrete consequence: an agent budget is a Fixed Delegation when the limit is a lifetime total, and a Recurring Delegation when it is a rate."
+          }
+        ],
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      }
+    ]
+  },
+  {
+    "_id": "lesson-sap-write-the-deep-dive",
+    "title": "Publish the Deep Dive",
+    "slug": "write-the-deep-dive",
+    "blocks": [
+      {
+        "key": "shape",
+        "_type": "prose",
+        "produces": null,
+        "consumes": null,
+        "src": "# Publish the Deep Dive\n\nYou have a paid tier, a metered endpoint and an agent with a spend cap. Nobody knows.\n\nThis lesson is not a writing-skills lesson. It is a lesson about a specific artifact that a specific buyer pays for, and about the two properties that decide whether it gets paid or ignored: **it is dated, and it is pinned.**\n\n## The market evidence, plainly and dated\n\nSuperteam Canada ran two listings on the Subscriptions & Allowances program, both closing 2026-06-23 — three weeks after the program hit mainnet on 2026-06-02:\n\n| Listing                                    | Reward       | Submissions at close |\n| ------------------------------------------ | ------------ | -------------------- |\n| Subscriptions & Allowances **code sample**  | $2,750 USDG  | 31                   |\n| Technical **deep dive** on the same primitive | $2,750 USDG | 44                   |\n\nEducational modules on Superteam Earn sit at **$2,500–$3,000** and routinely close at around **10 submissions**. Promotional content — threads, videos, \"explain this protocol\" posts — closes at **107 to 677**.\n\nThose are final counts on closed listings, not snapshots. That distinction matters and you will see it again in the next lesson: a submission count read on any single day tells you nothing, because the count is a function of how close the deadline is, not of how hard the work is.\n\nRead the table again. The write-up paid the same as the implementation, and the field with the lowest competition on the platform is the one where you explain something you actually built. **Writing about what you built is the best-odds path here.** You already did the expensive part.\n\n## Why the pins are the product\n\nEvery competitor's material on this primitive rotted the same way. It was written against a pre-1.0 package, the package moved, and the post never said which version it was written against. Six months later the code in the post does not run and there is no way to tell whether the reader's environment or the author's assumption is wrong.\n\n`@solana/subscriptions` is at `0.4.0`, published 2026-07-13. Its `beta` dist-tag points at `0.4.0-rc.2` — an *older* pre-release. `@x402/core`, `@x402/svm`, `@x402/express` and `@x402/fetch` are at `2.19.0`, published 2026-07-17, while the unscoped `x402`, `x402-express`, `x402-next` and `x402-fetch` packages are frozen at `1.2.0` from 2026-04-16 and speak an older protocol version. A reader who installs the wrong half of either split gets a failure that looks like their own bug.\n\nUndated, unpinned content is how that happens. A dated version banner and an exact pin block are two paragraphs of work, and they are the difference between an artifact with a shelf life and a screenshot.\n\n## The shape — worked exemplar, annotated\n\nWhat follows is the full skeleton of the piece, with the job of each section called out. Write your own version of this against your own artifact. The order is load-bearing: a reader who bounces off section 1 never reaches section 4, and a reviewer who cannot reproduce section 4 does not pay.\n\n---\n\n### `> Version banner` — first thing on the page, above the fold\n\n> Written against `@solana/subscriptions@0.4.0`, `@solana/kit@7.0.0`, `@x402/core@2.19.0`, Solana devnet. Program `De1egAFMkMWZSN5rYXRj9CAdheBamobVNubTsi9avR44`. **Checked 2026-07-25.**\n\n*Job:* tell the reader in one line whether this page is worth their next five minutes. It is the only section that costs you nothing and saves every future reader. It carries a **date you actually ran the code**, not the date you published.\n\n### 1. The problem, in one paragraph, from the user's side\n\n> A SaaS app wants to charge 5 USDC every month. A one-off transfer means the user signs every month and churns the first time they are busy. Handing the app a signed blank cheque means the app can drain the account. Neither is acceptable, and this is why the recurring delegation exists.\n\n*Job:* establish that there is a real decision here. Do not open with \"Solana is fast.\" Open with the thing that does not work.\n\n### 2. The minimal reference implementation\n\nMinimal means: no framework, no UI, no error handling beyond the one error that matters, and it runs top to bottom. Everything the reader does not need is a reason to stop reading.\n\n```ts\nimport { createClient, signer } from '@solana/kit';\nimport {\n  subscriptionsProgram,\n  findSubscriptionAuthorityPda,\n  fetchMaybeSubscriptionAuthority,\n  initSubscriptionAuthority,\n  createRecurringDelegation,\n  transferRecurring,\n} from '@solana/subscriptions';\n\nconst client = createClient()\n  .use(signer(userSigner))\n  .use(solanaDevnetRpc({ url: RPC_URL }))\n  .use(subscriptionsProgram());\n\n// One authority per (user, mint). Branch on .exists — init twice and it throws.\nconst [authority] = await findSubscriptionAuthorityPda({\n  user: userSigner.address,\n  tokenMint: USDC_DEVNET,\n});\nconst maybe = await fetchMaybeSubscriptionAuthority(client, authority);\nif (!maybe.exists) {\n  await initSubscriptionAuthority({ user: userSigner, tokenMint: USDC_DEVNET })\n    .sendTransaction(client);\n}\n\n// The paid tier: 5 USDC of headroom, refreshed every 30 days.\nawait createRecurringDelegation({\n  user: userSigner,\n  tokenMint: USDC_DEVNET,\n  delegatee: merchant.address,\n  amountPerPeriod: 5_000_000n,        // base units, bigint — 5 USDC at 6 decimals\n  periodSeconds: 2_592_000n,\n  expiryTs: EXPIRY,                    // hard stop, no grace period\n}).sendTransaction(client);\n\n// Collection. The MERCHANT signs this, not the user.\nawait transferRecurring({\n  delegatee: merchantSigner,\n  delegator: userSigner.address,\n  tokenMint: USDC_DEVNET,\n  amount: 5_000_000n,\n}).sendTransaction(merchantClient);\n```\n\n*Job:* be copy-pasteable. Amounts are base units as `bigint` — a reader who writes `5` instead of `5_000_000n` charges five millionths of a dollar and will not notice for a week, so annotate it inline rather than in a footnote.\n\n### 3. The semantics that bite — the section that earns the fee\n\nAnyone can paste an API sequence. What a reviewer is buying is the three behaviours that are not visible in the call signatures and that everyone gets wrong the first time. State each one as a claim, then show the observation that proves it.\n\n**(a) A second pull inside the same period fails.** Call `transferRecurring` twice before the period rolls over and the second call is rejected with `AMOUNT_EXCEEDS_PERIOD_LIMIT` (\"Transfer amount exceeds period limit\"). The cap is per period, not per call, and there is no partial-fill: a pull for more than the remaining period allowance fails outright rather than transferring what is left.\n\n**(b) The cap resets on rollover — it does not accumulate.** When the period rolls, the allowance is restored to `amountPerPeriod`. It is set back to the cap, not increased by it.\n\n**(c) Skipped periods are lost.** A merchant who forgets to collect in March cannot collect twice in April. Unclaimed headroom does not carry forward. This is a *user-protective* design — it bounds the delegatee's total draw to one period at a time — and it is the single most common wrong assumption about the primitive, which is exactly why it is worth writing down.\n\nAnd the security point underneath all three: **the delegatee signs transfers; the user signs setup and revoke.** The user approves once and never signs again; the merchant cannot exceed the cap; the user can `revokeDelegation` at any time, which closes the PDA and returns the rent to the signer — or to the recorded `receiver` if a sponsor funded the account.\n\n*Job:* this is the part a reader cannot get from the README, and it is the part that makes the piece worth $2,750 instead of a link.\n\n### 4. A runnable repro, with exact pins\n\n```jsonc\n// package.json — copied out of the lockfile, not typed from memory\n{\n  \"dependencies\": {\n    \"@solana/kit\": \"7.0.0\",\n    \"@solana/subscriptions\": \"0.4.0\",\n    \"@solana-program/token\": \"<the exact version your lockfile resolved>\"\n  }\n}\n```\n\n```bash\nnpm ci\nnode repro.mjs            # prints the settlement signature\nnode repro.mjs --again    # prints AMOUNT_EXCEEDS_PERIOD_LIMIT\n```\n\n*Job:* let a reviewer verify claim (a) in under two minutes without reading your prose. `0.4.0`, not `^0.4.0` — a caret on a pre-1.0 package admits every future minor, and pre-1.0 minors break. Copy the resolved versions out of your lockfile; the version you *meant* to install is not evidence.\n\n### 5. What you would not use this for\n\n> Fixed delegation caps a total and never refills — that is an allowance, and it is what an autonomous agent should hold. x402 meters a single stateless request and involves no delegation at all. If your requirement is a human paying once at a checkout, none of the three is the answer.\n\n*Job:* a piece that says what the primitive is *not* for reads as written by someone who used it. A piece that claims one rail solves everything reads as marketing.\n\n---\n\nThat is the whole shape: **banner → problem → minimal implementation → the semantics that bite → a runnable repro with exact pins → the boundary.** Five sections and a header line.\n\n## Two additions that cost nothing\n\n**Say what you actually ran into.** If a call failed and you spent an hour on it, that hour is the most valuable paragraph in the piece — it is the paragraph no documentation contains. The empty-402-body case from lesson 6, where the server ships no body and puts the base64 envelope in the `PAYMENT-REQUIRED` header, is exactly this kind of paragraph.\n\n**Do not build the indexer.** If you want a sixth section, note that the program emits six event types as Anchor-compatible self-CPI inner instructions under the tag `e445a52e51cb9a1d`, which is how you would build a revenue dashboard on top of this. One paragraph. Naming the mechanism is the value; implementing it is a different bounty.\n\n## Where to publish\n\nAnywhere with a stable URL you control the content of, and where the code blocks survive: your own site, a GitHub repo with the repro in it, or the listing's stated venue. The URL is what you submit in the next lesson, so it has to still resolve in six months.\n\nNow write it. The exemplar above is the scaffold — the artifact is yours.\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "publish",
+        "_type": "openEnded",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": null,
+        "prompt": "Paste the URL of your published deep dive, then paste its version banner line verbatim. Under it, name which of the three recurring-delegation semantics you demonstrated with a runnable repro, and say what the reader has to run to see it fail. If you have not published yet, paste your section-3 draft instead — the claims and the observation that proves each one.",
+        "maxWords": 250,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "check",
+        "_type": "quiz",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": [
+          {
+            "id": "q1",
+            "prompt": "Your deep dive ships with a code block that runs today. Which single addition does the most to keep it verifiable a year from now?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "A version banner carrying the exact package versions and the date you last ran the code",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "A note asking readers to open an issue if anything breaks",
+                "correct": false,
+                "feedback": "That moves the diagnosis onto the reader, who cannot tell whether their environment or your assumption is wrong. The banner answers it before they start."
+              },
+              {
+                "id": "c",
+                "label": "A link to the package's npm page so readers can see the latest version",
+                "correct": false,
+                "feedback": "The latest version is the one thing the reader can already look up. What they cannot recover is which version you ran."
+              },
+              {
+                "id": "d",
+                "label": "A longer introduction explaining what stablecoins are",
+                "correct": false,
+                "feedback": "Ages nothing and helps nobody. The reader who found a Subscriptions deep dive already knows."
+              }
+            ],
+            "explanation": "Undated and unpinned is exactly how every competing write-up on this primitive rotted. The banner is one line and it is the cheapest thing on the page."
+          },
+          {
+            "id": "q2",
+            "prompt": "You are writing the dependency block. Which entry pins \"@solana/subscriptions\" correctly for this course?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "\"@solana/subscriptions\": \"0.4.0\"",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "\"@solana/subscriptions\": \"^0.4.0\"",
+                "correct": false,
+                "feedback": "A caret on a pre-1.0 package admits every future minor, and pre-1.0 minors are allowed to break. That is the range your repro cannot survive."
+              },
+              {
+                "id": "c",
+                "label": "\"@solana/subscriptions\": \"beta\"",
+                "correct": false,
+                "feedback": "The beta dist-tag points at 0.4.0-rc.2, which is an OLDER pre-release than 0.4.0. A dist-tag is not a pin."
+              },
+              {
+                "id": "d",
+                "label": "\"@solana/subscriptions\": \"latest\"",
+                "correct": false,
+                "feedback": "\"latest\" resolves to whatever ships next. It records nothing about what you ran."
+              }
+            ],
+            "explanation": "0.4.0 was published 2026-07-13 and the package is pre-1.0 and moving. Pin it exactly, and copy the value out of your lockfile rather than typing it from memory."
+          },
+          {
+            "id": "q3",
+            "prompt": "A merchant holds a recurring delegation for 5 USDC per 30-day period and forgets to collect for two consecutive periods. On the first day of the third period, how much can they pull in one transfer?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "5 USDC — skipped periods do not accumulate",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "15 USDC — the unclaimed allowance carries forward",
+                "correct": false,
+                "feedback": "This is the most common wrong assumption about the primitive. The cap is SET BACK to amountPerPeriod on rollover, not increased by it, so the delegatee's draw is bounded to one period at a time."
+              },
+              {
+                "id": "c",
+                "label": "10 USDC — the two skipped periods accumulate but the current one does not",
+                "correct": false,
+                "feedback": "Nothing accumulates. Rollover restores the cap; it never adds to it."
+              },
+              {
+                "id": "d",
+                "label": "Nothing — missing a period expires the delegation",
+                "correct": false,
+                "feedback": "A missed period costs that period's revenue, not the delegation. Only expiryTs ends it, and that is a hard stop with no grace period."
+              }
+            ],
+            "explanation": "Skipped periods are lost. That is user-protective by design, and it is the semantic worth writing down because it is invisible in the call signatures."
+          },
+          {
+            "id": "q4",
+            "prompt": "In your reference implementation, who must sign the transaction that actually collects a period's charge?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "The delegatee — the user signed only setup, and signs again only to revoke",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "The user, for every collection",
+                "correct": false,
+                "feedback": "If the user had to sign every month you would not need a delegation at all — that is the one-off transfer the primitive exists to replace."
+              },
+              {
+                "id": "c",
+                "label": "Both the user and the delegatee, as co-signers",
+                "correct": false,
+                "feedback": "Requiring the user on every pull reintroduces the churn. The cap, not a second signature, is what bounds the delegatee."
+              },
+              {
+                "id": "d",
+                "label": "The Subscription Authority PDA, via a keypair the program hands you",
+                "correct": false,
+                "feedback": "A PDA has no private key. The authority is program-controlled precisely so no keypair exists to hand out."
+              }
+            ],
+            "explanation": "One approval, many collections, bounded by the period cap and revocable at any time. That asymmetry is the security story of the module and belongs in section 3 of your write-up."
+          },
+          {
+            "id": "q5",
+            "prompt": "Your deep dive includes the metered endpoint from module 2. A reader copies your install line. Which dependency set do you give them?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "\"@x402/core\", \"@x402/svm\", \"@x402/express\", \"@x402/fetch\" at 2.19.0",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "\"x402\", \"x402-express\", \"x402-fetch\" at 1.2.0",
+                "correct": false,
+                "feedback": "The unscoped line is frozen at 1.2.0 from 2026-04-16 and speaks the older protocol version. Search engines still surface it first, which is why the split has to be named in the write-up."
+              },
+              {
+                "id": "c",
+                "label": "\"x402-next\", because the official Solana template uses it",
+                "correct": false,
+                "feedback": "That template ships the frozen unscoped package. Being official does not make it current."
+              },
+              {
+                "id": "d",
+                "label": "Either line — the scoped packages are just re-publishes under a namespace",
+                "correct": false,
+                "feedback": "They are different protocol versions on the wire, with different header names and different envelope fields. Mixing them is the failure your readers will report as your bug."
+              }
+            ],
+            "explanation": "Naming a live version split explicitly is what separates a piece that stays useful from one that rots the next time a reader searches."
+          },
+          {
+            "id": "q6",
+            "prompt": "Seeded from the client you published in the previous course. You regenerate the typed client against an IDL that has not changed and republish. Under the semver policy you committed to, what is that release?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "Patch",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "Minor",
+                "correct": false,
+                "feedback": "Minor is a NEW instruction — added surface a consumer can start using. Regenerating unchanged output adds no surface."
+              },
+              {
+                "id": "c",
+                "label": "Major",
+                "correct": false,
+                "feedback": "Major is a changed account layout, a removed field or a renamed export — something that breaks a consumer who upgrades."
+              },
+              {
+                "id": "d",
+                "label": "No release at all is warranted",
+                "correct": false,
+                "feedback": "Regenerated output can still differ (formatting, generator version), and shipping it under a patch is exactly what patch is for."
+              }
+            ],
+            "explanation": "You wrote that policy down as a package author. A deep dive that restates the version contract it holds itself to is one a reviewer trusts."
+          },
+          {
+            "id": "q7",
+            "prompt": "Also seeded from the previous course. Your repro sends a transaction with no compute-budget instruction. What does the reader pay a priority fee on?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "The requested limit — the 200,000 CU default per non-builtin instruction, not what the transaction consumed",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "The compute units actually consumed, measured after execution",
+                "correct": false,
+                "feedback": "This is the assumption that makes the bug invisible. The fee is charged on the REQUESTED limit, which is why an untuned transaction silently overpays."
+              },
+              {
+                "id": "c",
+                "label": "Nothing — priority fees only apply when you set a compute unit price",
+                "correct": false,
+                "feedback": "True that no price means no priority fee, but the question is what the fee is computed against once you do set one, and that is the requested limit."
+              },
+              {
+                "id": "d",
+                "label": "The 1,400,000 CU per-transaction clamp",
+                "correct": false,
+                "feedback": "That is the ceiling on the total request, not the default charged per instruction."
+              }
+            ],
+            "explanation": "If your repro is going to be run by strangers, size it. Fixing it is fillTransactionMessageProvisoryResourceLimits, then estimateResourceLimitsFactory, then estimateAndSetResourceLimitsFactory — the current trio, all three halves from the same line."
+          }
+        ],
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      }
+    ]
+  },
+  {
+    "_id": "lesson-sap-submit-and-what-you-built",
+    "title": "Submit It — and What You Built",
+    "slug": "submit-and-what-you-built",
+    "blocks": [
+      {
+        "key": "recap",
+        "_type": "prose",
+        "produces": null,
+        "consumes": null,
+        "src": "# Submit It — and What You Built\n\nOne artifact. Five courses. Name every layer of it.\n\n## The through-line\n\nNothing you built restarted. Each course added a layer to the same object.\n\n**Course 1 — you signed something.** Your own transaction, built and sent from your own key, confirmed on devnet, and an account inspector that reads state back off the chain rather than off a screenshot. The first time the chain answered you specifically.\n\n**Course 2 — the vault got a core.** Rust that models the vault's state and its rules, compiled green against the real toolchain on the build server. No local install, no version roulette.\n\n**Course 3 — your program went live.** Deposit and withdraw, hardened, deployed to devnet. You own a program id, and a credential NFT that says you do.\n\n**Course 4 — it became something other people can use.** A typed client generated from your own IDL, wrapped in an API you would actually import, published to npm with a semver policy you wrote down — and a deployed app at a public URL that installs that package from the registry and signs a real deposit through it.\n\n**Course 5 — it started earning.** A Subscription Authority and a Recurring Delegation gave the app a paid tier that charges once per period and correctly refuses to charge twice. An x402 route returns a real 402 challenge naming the network, the asset and the payTo address. An agent calls that route on a loop, pays for each call out of a Fixed Delegation, and halts cleanly when the allowance says no.\n\nSay the sentence out loud, because it is true and you will need it in a proposal:\n\n> You started as a web2 JavaScript developer, and you now own a monetized on-chain product.\n\nIf you entered here — at C5 lesson 1, on the reference app, because you wanted payments and not Anchor — the same sentence applies to the payments layer you built. The credential still requires your own artifact, not the reference one.\n\n## What is in scope, and what is not\n\nThe rails you learned are the ones open to you. From 2026-10-01, BCB Resolution 561 forbids a regulated eFX provider from taking reais, converting to a stablecoin, and settling the obligation abroad on-chain. That is a live constraint on a business model, not on you personally: individuals may still buy, sell, hold and transfer through authorized VASPs.\n\nWhat this course built sits entirely inside what the resolution leaves open: **domestic merchant acceptance, contractor payouts, subscriptions, and agent budgets.** Every one of those is a real product surface, and every one of them is something an Earn listing has asked for. When you write a proposal, name the use case in those terms — a reviewer in Brazil reads the difference immediately, and it is a signal that you understand the market and not just the SDK.\n\n## Pick a rail before you pick a package\n\nThe decision you now make without looking it up:\n\n- **Fixed delegation** — a capped total that never refills. An allowance. This is what an autonomous agent holds, because the on-chain cap is what makes the autonomy safe.\n- **Recurring delegation** — a cap that resets each period. Payroll, contractors, subscriptions. Skipped periods are lost.\n- **Subscription plan** — a merchant publishes terms and approved pullers collect against them.\n- **Solana Pay** — a human paying once, at a checkout. A decision, not an install: `@solana/pay@1.0.23` peer-depends on `@solana/kit ^6.9.0`, which does not admit the `@solana/kit@7.0.0` this course pins everywhere else.\n- **x402** — stateless per-request metering. No delegation, no relationship, one call.\n\nThat list is the most portable thing you learned. Packages will move; the shape of the requirement will not.\n\n## Submit one listing\n\nNow the part most people skip.\n\n**The calibration, honestly.** What this path realistically opens is **your first $500 to $5,000** of paid on-chain work. It is not a job offer, and anyone telling you a course makes you hireable as a Solana developer is selling something. The $5,000 frontend listing drew 731 submissions. The odds live somewhere else.\n\n**Where they live.** Two termini this course specifically unlocks:\n\n1. **Payments technical demos** — around $100 of reward per competitor, second only to Rust listings on that measure. You have a metered endpoint and a paid tier already running.\n2. **Educational modules** — $2,500–$3,000, typically closing near 10 submissions. Your deep dive from the last lesson is most of one.\n\n**How to read a listing, which is a skill in itself.** Competition is a function of **time-to-deadline**, not of category. The Zeroclaw listing sat at twelve submissions or fewer for most of its run and closed at 52 as the deadline approached. A submission count you read today tells you where that listing is in its life, not how contested it is. So: **never quote a single-day count as a competition rate.** Filter for **newly-opened development listings** and compare medians across listings that have actually closed.\n\n**Then submit.** One listing, this week, with a real artifact attached. Not a plan to submit. The bar is lower than it looks — most listings are decided among a handful of complete, reproducible submissions, and you now have the two things most submissions lack: something that runs, and a write-up that says which versions it ran against.\n\n## One more door\n\nTurbin3 runs cohort-based Solana builder programs, and its prerequisites are the kind of thing C1–C4 already satisfy: your own deployed program, a published client, a deployed app. If you want structure and a cohort after this, that is where to look. Bring the program id and the package URL.\n\nThat is the course. Submit the listing.\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "submit",
+        "_type": "openEnded",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": null,
+        "prompt": "Paste the URL of the Superteam Earn listing you submitted to, and the URL of what you submitted. Then, in three lines: which rail the work uses (fixed delegation, recurring delegation, subscription plan, Solana Pay or x402), which Brazilian use case it serves, and the one thing in your submission a reviewer can run themselves.",
+        "maxWords": 200,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "check",
+        "_type": "quiz",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": [
+          {
+            "id": "q1",
+            "prompt": "A café in São Paulo wants a QR code on the counter so a customer can pay for one coffee in USDC from a phone wallet. No account, no relationship, no repeat. Which rail?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "Solana Pay — a human paying once at a checkout",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "A recurring delegation, with a one-second period",
+                "correct": false,
+                "feedback": "A delegation is a standing approval between two known parties. A walk-in customer has no relationship to approve."
+              },
+              {
+                "id": "c",
+                "label": "An x402 challenge returned from the till's API",
+                "correct": false,
+                "feedback": "x402 meters a machine calling an endpoint. There is no HTTP client here — there is a person with a phone."
+              },
+              {
+                "id": "d",
+                "label": "A fixed delegation sized to the price of one coffee",
+                "correct": false,
+                "feedback": "You would be asking the customer to set up an on-chain allowance before their first sip. The setup cost exceeds the payment."
+              }
+            ],
+            "explanation": "Rail selection is the portable skill. One-off human checkout is Solana Pay's exact shape — and note it stays a decision, not an install, because @solana/pay@1.0.23 peer-depends on @solana/kit ^6.9.0 and will not sit in a kit 7 lockfile."
+          },
+          {
+            "id": "q2",
+            "prompt": "From 2026-10-01, which of these does BCB Resolution 561 put off-limits?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "A regulated eFX provider taking reais, converting to USDC, and settling the obligation abroad on-chain",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "A Brazilian merchant accepting USDC from a domestic customer",
+                "correct": false,
+                "feedback": "Domestic merchant acceptance is explicitly in scope, and is one of the four surfaces this course targets."
+              },
+              {
+                "id": "c",
+                "label": "An individual buying and holding a stablecoin through an authorized VASP",
+                "correct": false,
+                "feedback": "Individuals may still buy, sell, hold and transfer via authorized VASPs. The resolution constrains a provider's business model, not a person's wallet."
+              },
+              {
+                "id": "d",
+                "label": "Paying a Brazilian contractor in USDC on a recurring delegation",
+                "correct": false,
+                "feedback": "Contractor payouts are in scope. That is one of the reasons the recurring delegation matters in this market."
+              }
+            ],
+            "explanation": "Published 2026-04-30, effective 2026-10-01. In scope and legal for what you built: domestic merchant acceptance, contractor payouts, subscriptions, agent budgets."
+          },
+          {
+            "id": "q3",
+            "prompt": "You are choosing the payment mint for a subscription product. Which statement is the decision rule you learned?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "Legacy Token by default; Token-2022 only when a named extension is required — then verify your rail accepts it, because the Subscriptions program rejects any mint with a configured TransferHook",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "Token-2022 always, because it is the newer standard and legacy Token is being retired",
+                "correct": false,
+                "feedback": "Neither is being retired, and download volume is at parity (~1.27M/wk vs ~1.24M/wk). \"Newer\" is not a reason."
+              },
+              {
+                "id": "c",
+                "label": "Legacy Token always, because Token-2022 has limited DEX support",
+                "correct": false,
+                "feedback": "That claim is stale — support is at parity now. The reason to prefer legacy is the absence of a requirement, not a compatibility gap."
+              },
+              {
+                "id": "d",
+                "label": "Either one — the Subscriptions program treats both token programs identically",
+                "correct": false,
+                "feedback": "It supports both token programs, but it rejects a mint with a configured TransferHook. A Token-2022 mint is not automatically acceptable to your rail."
+              }
+            ],
+            "explanation": "Pick the extension you need, then check the rail. A TransferHook mint is the concrete case where a valid Token-2022 mint is refused."
+          },
+          {
+            "id": "q4",
+            "prompt": "Why does the Subscriptions program put a program-controlled Subscription Authority between the user and every delegation, instead of approving each delegatee on the token account directly?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "A token account can have only ONE approved delegate, so one wallet could never hold a subscription and an allowance and a merchant agreement on the same mint",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "PDAs are cheaper to create than token accounts",
+                "correct": false,
+                "feedback": "Rent is not the reason. The authority exists to lift a hard one-delegate limit."
+              },
+              {
+                "id": "c",
+                "label": "It lets the program hold a keypair on the user's behalf",
+                "correct": false,
+                "feedback": "A PDA has no private key — that is the point of deriving it rather than generating it. Nothing holds a keypair for the user."
+              },
+              {
+                "id": "d",
+                "label": "It is required in order to use Token-2022 mints",
+                "correct": false,
+                "feedback": "Unrelated. The authority is about delegate multiplicity, not about which token program owns the mint."
+              }
+            ],
+            "explanation": "One authority per (user, mint), derived with findSubscriptionAuthorityPda, and you branch on .exists before initialising — running init twice is the classic error."
+          },
+          {
+            "id": "q5",
+            "prompt": "Fixed delegation versus recurring delegation. Which pair of statements is correct?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "Fixed caps a total that never refills; recurring caps an amount that resets every period",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "Fixed caps an amount per period; recurring caps a lifetime total",
+                "correct": false,
+                "feedback": "Reversed. \"Fixed\" names a fixed total, not a fixed schedule."
+              },
+              {
+                "id": "c",
+                "label": "Fixed is for Token-2022 mints; recurring is for legacy Token mints",
+                "correct": false,
+                "feedback": "Neither model is tied to a token program. The distinction is whether the cap refills."
+              },
+              {
+                "id": "d",
+                "label": "Both refill; fixed refills daily and recurring refills on a period you choose",
+                "correct": false,
+                "feedback": "A fixed delegation never refills. That is exactly why it is the right budget for an autonomous agent."
+              }
+            ],
+            "explanation": "Capped total = an allowance = the agent's budget. Cap resets per period = payroll, contractors, subscriptions."
+          },
+          {
+            "id": "q6",
+            "prompt": "A recurring delegation is set to 5 USDC per period. The delegatee collects nothing for one full period. What is the allowance at the start of the next period?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "5 USDC — the cap is restored, not increased",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "10 USDC — the skipped period carries forward",
+                "correct": false,
+                "feedback": "Nothing accumulates. A merchant who forgets to collect loses that period's revenue permanently."
+              },
+              {
+                "id": "c",
+                "label": "0 — a skipped period suspends the delegation until the user re-approves",
+                "correct": false,
+                "feedback": "Skipping costs revenue, not the delegation. Only expiryTs ends it."
+              },
+              {
+                "id": "d",
+                "label": "5 USDC, plus whatever was left unspent in the previous period",
+                "correct": false,
+                "feedback": "Unspent headroom is discarded on rollover. The cap is set back to amountPerPeriod, never added to."
+              }
+            ],
+            "explanation": "Rollover resets the cap. It is what bounds the delegatee's draw to one period at a time, and it is the semantic most write-ups get wrong."
+          },
+          {
+            "id": "q7",
+            "prompt": "Your billing job runs twice by accident inside the same period. What does the second transferRecurring call do?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "Fails with AMOUNT_EXCEEDS_PERIOD_LIMIT — no partial transfer occurs",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "Succeeds, and the excess is deducted from the next period",
+                "correct": false,
+                "feedback": "There is no borrowing across periods. The cap is enforced per period, at the moment of the call."
+              },
+              {
+                "id": "c",
+                "label": "Transfers whatever remains of the period allowance and reports a partial fill",
+                "correct": false,
+                "feedback": "There is no partial fill. A pull for more than the remaining allowance is rejected outright — which is why a retry loop must treat this error as terminal for the period, not as transient."
+              },
+              {
+                "id": "d",
+                "label": "Succeeds — the program deduplicates identical charges automatically",
+                "correct": false,
+                "feedback": "Nothing deduplicates for you. Idempotency is your job; the cap is the backstop."
+              }
+            ],
+            "explanation": "Handling this error correctly is the difference between a billing job that double-charges and one that does not. Treat it as \"already collected this period.\""
+          },
+          {
+            "id": "q8",
+            "prompt": "Across the whole delegation lifecycle, who signs what?",
+            "multiSelect": true,
+            "options": [
+              {
+                "id": "a",
+                "label": "The user signs the setup — creating the authority and the delegation",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "The delegatee signs each transfer",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "c",
+                "label": "The user signs the revoke, which closes the PDA and returns the rent to the signer or to the recorded receiver",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "d",
+                "label": "The user must co-sign every transfer alongside the delegatee",
+                "correct": false,
+                "feedback": "That would reintroduce the per-charge signature the primitive exists to eliminate. The period cap is what bounds the delegatee, not a second signature."
+              }
+            ],
+            "explanation": "One approval, many collections, revocable at any time. That asymmetry is the security model of the whole module."
+          },
+          {
+            "id": "q9",
+            "prompt": "A client hits your metered route with no payment. What does a valid x402 v2 challenge have to tell them, and who does the on-chain work?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "An accepts[] envelope naming the network, the asset and the payTo address — and the facilitator does verify, settle and supported, so the API provider never touches on-chain infrastructure",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "A price in USD and a wallet address; the API server submits the transaction itself",
+                "correct": false,
+                "feedback": "A bare address does not say which chain or which asset, and running settlement in your API server is exactly what the facilitator exists to remove."
+              },
+              {
+                "id": "c",
+                "label": "A signed transaction for the client to submit unchanged",
+                "correct": false,
+                "feedback": "The server states terms; the client constructs and signs the payment. It is a challenge, not a pre-built transaction."
+              },
+              {
+                "id": "d",
+                "label": "Only a price — the client is expected to already know the network and asset from your docs",
+                "correct": false,
+                "feedback": "Then a generic client could never pay you. Self-description is the whole point of the envelope."
+              }
+            ],
+            "explanation": "Metering is a protocol, not a checkout page. The envelope is what lets a client that has never seen your API pay for one call."
+          },
+          {
+            "id": "q10",
+            "prompt": "\"@x402/svm\" exports both ExactSvmScheme and ExactSvmSchemeV1. Why?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "Both protocol versions are live on the wire, with different header names and different envelope fields, so a client has to detect which one a server speaks",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "V1 is a deprecated alias kept for backwards source compatibility; it behaves identically",
+                "correct": false,
+                "feedback": "They are not interchangeable. The header names and envelope fields differ, which is why you decide the version before you build the payment."
+              },
+              {
+                "id": "c",
+                "label": "One is for devnet and one is for mainnet",
+                "correct": false,
+                "feedback": "Network selection is SOLANA_DEVNET_CAIP2 and friends, an entirely separate axis from protocol version."
+              },
+              {
+                "id": "d",
+                "label": "One is for legacy Token and one is for Token-2022",
+                "correct": false,
+                "feedback": "Token program addresses are exported separately as TOKEN_PROGRAM_ADDRESS and TOKEN_2022_PROGRAM_ADDRESS. Not the same axis."
+              }
+            ],
+            "explanation": "Reading which version a server speaks, rather than assuming, is what keeps an integration alive. It is also why the scoped 2.19.0 packages and the frozen unscoped 1.2.0 packages must never be mixed."
+          },
+          {
+            "id": "q11",
+            "prompt": "You fetch a metered URL and get a 402 with an empty response body. What is the correct next step?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "Read the base64 envelope out of the PAYMENT-REQUIRED response header — some hosts ship no body at all",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "Treat it as a malformed response and retry the bare request",
+                "correct": false,
+                "feedback": "Retrying without paying returns the same 402 forever. This is the number one x402 integration failure and it is a parsing bug, not a server bug."
+              },
+              {
+                "id": "c",
+                "label": "Fall back to the v1 scheme, since only v1 servers send empty bodies",
+                "correct": false,
+                "feedback": "Body placement and protocol version are independent. Decode the envelope first, then decide the version from its contents."
+              },
+              {
+                "id": "d",
+                "label": "Pay a default amount to the address in your configuration",
+                "correct": false,
+                "feedback": "Never pay against a value the server did not state in this response. That is how a client overpays or pays the wrong asset."
+              }
+            ],
+            "explanation": "Envelope in the body or envelope in the header — handle both, then filter accepts[] on network and asset before you build anything."
+          },
+          {
+            "id": "q12",
+            "prompt": "Your agent loop hits its spend limit mid-run. What should the correct implementation do, and what was the budget?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "Halt and report — the budget was a Fixed Delegation drawn down with transferFixed, and the program refusing the next payment is the exit condition",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "Top the delegation up from the same signer and continue, since the agent is trusted",
+                "correct": false,
+                "feedback": "An agent that can raise its own cap has no cap. Refilling requires the user's signature by design."
+              },
+              {
+                "id": "c",
+                "label": "Fall back to a raw keypair the agent holds so the run can complete",
+                "correct": false,
+                "feedback": "A raw keypair with unlimited funds is precisely what the on-chain cap replaces. That fallback deletes the safety property."
+              },
+              {
+                "id": "d",
+                "label": "Retry with exponential backoff until the allowance recovers",
+                "correct": false,
+                "feedback": "A fixed delegation never refills. The retry loop would run forever."
+              }
+            ],
+            "explanation": "The exit condition is the learning objective. What makes agent autonomy safe is that the cap lives on-chain, where the agent cannot reach it."
+          },
+          {
+            "id": "q13",
+            "prompt": "You are charging 5 USDC (6 decimals) through the Subscriptions client. Which amount argument is correct?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "5_000_000n — base units, as a bigint",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "5 — the client converts from display units for you",
+                "correct": false,
+                "feedback": "Nothing converts. Passing 5 charges five millionths of a dollar, succeeds, and goes unnoticed for weeks."
+              },
+              {
+                "id": "c",
+                "label": "5.0 — a float, since USDC has decimals",
+                "correct": false,
+                "feedback": "Amounts are integers in base units. A float cannot represent a token amount exactly and the API does not accept one."
+              },
+              {
+                "id": "d",
+                "label": "\"5000000\" — a decimal string",
+                "correct": false,
+                "feedback": "Right magnitude, wrong type. These APIs take bigint, in the same way Kit takes Address rather than a PublicKey object."
+              }
+            ],
+            "explanation": "Base units as bigint, everywhere in this stack, on @solana/kit 7.0.0. The type is a habit worth having."
+          },
+          {
+            "id": "q14",
+            "prompt": "Which two things must a deep dive on this material carry to stay verifiable a year from now?",
+            "multiSelect": true,
+            "options": [
+              {
+                "id": "a",
+                "label": "A dated banner recording when you last ran the code",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "Exact package versions copied out of the lockfile that actually resolved",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "c",
+                "label": "A screenshot of a successful transaction in the explorer",
+                "correct": false,
+                "feedback": "A screenshot proves it worked once, for you. It does not let a reader reproduce anything."
+              },
+              {
+                "id": "d",
+                "label": "A caret range on each dependency so readers get bug fixes automatically",
+                "correct": false,
+                "feedback": "On a pre-1.0 package a caret admits breaking minors. That is the opposite of reproducible."
+              }
+            ],
+            "explanation": "Dated and pinned. Two paragraphs of work, and the reason your piece outlives every competing one."
+          },
+          {
+            "id": "q15",
+            "prompt": "A listing you are considering shows 12 submissions today. What can you conclude?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "Almost nothing — the count tracks time-to-deadline, so compare medians across listings that have already closed",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "It is under-contested; submit immediately for good odds",
+                "correct": false,
+                "feedback": "The Zeroclaw listing sat at twelve or fewer for most of its run and closed at 52. A mid-run count is not a competition rate."
+              },
+              {
+                "id": "c",
+                "label": "The category is unpopular and probably low quality",
+                "correct": false,
+                "feedback": "Competition is a function of deadline proximity, not of category popularity."
+              },
+              {
+                "id": "d",
+                "label": "It will close near 12, since submissions arrive at a steady rate",
+                "correct": false,
+                "feedback": "They do not arrive at a steady rate. Submissions cluster hard against the deadline."
+              }
+            ],
+            "explanation": "Filter for newly-opened development listings, and calibrate on closed ones. The realistic promise of this path is your first $500 to $5,000 of paid work."
+          },
+          {
+            "id": "q16",
+            "prompt": "Seeded from the previous course. A wallet account advertises \"solana:signAndSendTransaction\". Which signer do you build, and who broadcasts?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "createTransactionSendingSignerFromWalletAccount — the wallet broadcasts, and you never see the signed bytes",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "createTransactionSignerFromWalletAccount — your app broadcasts",
+                "correct": false,
+                "feedback": "That is the signer for the \"solana:signTransaction\" feature, which hands you signed bytes to send yourself."
+              },
+              {
+                "id": "c",
+                "label": "createMessageSignerFromWalletAccount — the wallet broadcasts",
+                "correct": false,
+                "feedback": "Message signing does not produce a transaction, so nobody broadcasts anything."
+              },
+              {
+                "id": "d",
+                "label": "Either transaction signer works; the feature list is advisory",
+                "correct": false,
+                "feedback": "It is not advisory — createSignerFromWalletAccount inspects the features at call time and throws when neither transaction feature exists."
+              }
+            ],
+            "explanation": "Feature to signer to who-broadcasts. Getting this wrong produces a transaction that is signed and never sent, or sent twice."
+          },
+          {
+            "id": "q17",
+            "prompt": "Also seeded from the previous course. You are publishing the client package under a scope for the first time. What must be true, or the publish fails?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "The first publish of a scoped package needs --access public, otherwise it 402s as a private package",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "NPM_TOKEN must be set as a repository secret",
+                "correct": false,
+                "feedback": "Trusted publishing via OIDC is the route taught — id-token write permission and a configured trusted publisher, no token. The token route is only the fallback."
+              },
+              {
+                "id": "c",
+                "label": "The package version must be 1.0.0 or higher",
+                "correct": false,
+                "feedback": "npm accepts any valid semver, including 0.x. Nothing about the first publish requires 1.0.0."
+              },
+              {
+                "id": "d",
+                "label": "The scope must match your GitHub organisation name",
+                "correct": false,
+                "feedback": "npm scopes and GitHub orgs are independent namespaces."
+              }
+            ],
+            "explanation": "The single most common first-publish failure, and the reason to pre-empt it rather than debug it in front of a bounty deadline."
+          }
+        ],
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      }
+    ]
   }
 ]

--- a/apps/web/src/lib/content/__tests__/fixtures/golden/quests-raw.json
+++ b/apps/web/src/lib/content/__tests__/fixtures/golden/quests-raw.json
@@ -32,7 +32,14 @@
     "lesson-testing-challenge",
     "lesson-token-math-challenge",
     "lesson-transfer-challenge",
-    "lesson-vault-challenge"
+    "lesson-vault-challenge",
+    "lesson-sap-payment-rails-decision-map",
+    "lesson-sap-token-or-token-2022",
+    "lesson-sap-subscription-authority-and-allowance",
+    "lesson-sap-recurring-delegation-paid-tier",
+    "lesson-sap-meter-an-endpoint-with-x402",
+    "lesson-sap-pay-the-402-programmatically",
+    "lesson-sap-budgeted-agent-with-a-hard-cap"
   ],
   "moduleLessonMap": [
     {
@@ -204,6 +211,30 @@
         "lesson-account-challenge",
         "lesson-programs-overview",
         "lesson-program-challenge"
+      ]
+    },
+    {
+      "_id": "course-stablecoin-payments:sap-paid-tier",
+      "lessonIds": [
+        "lesson-sap-payment-rails-decision-map",
+        "lesson-sap-token-or-token-2022",
+        "lesson-sap-subscription-authority-and-allowance",
+        "lesson-sap-recurring-delegation-paid-tier"
+      ]
+    },
+    {
+      "_id": "course-stablecoin-payments:sap-metered-agentic",
+      "lessonIds": [
+        "lesson-sap-meter-an-endpoint-with-x402",
+        "lesson-sap-pay-the-402-programmatically",
+        "lesson-sap-budgeted-agent-with-a-hard-cap"
+      ]
+    },
+    {
+      "_id": "course-stablecoin-payments:sap-get-paid",
+      "lessonIds": [
+        "lesson-sap-write-the-deep-dive",
+        "lesson-sap-submit-and-what-you-built"
       ]
     }
   ],

--- a/apps/web/src/lib/content/__tests__/project.golden.test.ts
+++ b/apps/web/src/lib/content/__tests__/project.golden.test.ts
@@ -30,8 +30,8 @@ vi.mock("server-only", () => ({}));
 // from prod Sanity (public dataset 4e3i2wwc/production). Each projector, fed the
 // committed bundle doc, must deep-equal the captured GROQ shape. Divergences
 // here mean the locked bundle SHA and prod Sanity have drifted (report, do not
-// fudge the fixture) — EXCEPT two documented content-wave deltas, hand-edited
-// into the fixtures because the golden capture predates them:
+// fudge the fixture) — EXCEPT the documented content-wave deltas below, hand-
+// edited into the fixtures because the golden capture predates them:
 //
 //  - `instructor` → `creator` (issue #478): the retired instructor deref no
 //    longer exists. RESOLVED by #399/B3 — every course now carries a real
@@ -41,6 +41,15 @@ vi.mock("server-only", () => ({}));
 //    content: it's the sorted, deduplicated union of the course's lessons'
 //    `skills`. The fixtures carry the DERIVED tags computed from each course's
 //    real lesson `skills`, not the original authored (now-retired) tag list.
+//  - launch-catalog activation (issue #559): the bump to courses-academy
+//    @012cd03d adds course 5 (`course-stablecoin-payments`, 9 lessons / 3
+//    modules) and retargets `achievement-full-stack-solana` from
+//    `path-solana-core` to `path-zero-to-deployed`, and course 4's capstone
+//    `lesson-bfsp-m4-capstone` swaps its held-DeFi "What's Next" pointer for
+//    the Superteam Earn terminus. This content never existed in the pre-flip
+//    Sanity capture, so for these docs the golden = the projected bundle (the
+//    committed bundle is the post-SP2 source of truth); every pre-existing
+//    doc still matches the original prod-Sanity capture unchanged.
 const deps = { lessonsById };
 
 function bundleCourse(id: string): CourseDoc {


### PR DESCRIPTION
Closes #559

Activates the launch catalog by bumping `apps/web/content.lock` to the merged head of `solanabr/courses-academy` and committing the regenerated bundle in the same change. Pins the two launch PRs merged into content `main`: **#6** (course 5 — Stablecoin & Agentic Payments) and **#7** (Zero-to-Deployed path + capstone Earn terminus + defi hold).

- **Pinned SHA:** `012cd03ddcaa1122283a742862d5c5b885a7a913` (was `bccd92fc`)
- Bundle counts: **7 courses, 8 learning paths, 85 lessons, 10 achievements, 5 quests**

## Reproducibility (what CI enforces)
Compiled with `pnpm --filter web compile-content`, then recompiled and `git diff --exit-code`'d the generated bundle + lock — **byte-identical, exit 0**. Output is a pure function of the locked SHA.

## Sanity check (jq over `src/content/generated/`)
- **`path-zero-to-deployed`** — `draft: false`, `order: 1`, 4 courses in order: `course-solana-fundamentals → course-rust-for-solana → course-anchor-framework → course-building-first-program`.
- **Held paths** — `path-defi`, `path-solana-core`, `path-rust-programs` all `draft: true` with `courses: []`.
- **Course 5** — `course-stablecoin-payments` ("Getting Paid: Stablecoin & Agentic Payments") present with **9 lessons** across 3 modules (The Paid Tier / Metered & Agentic / Get Paid). The Earn terminus is the openEnded block in `lesson-sap-submit-and-what-you-built` (prompt: paste your Superteam Earn listing URL).
- **Course-4 capstone** — `lesson-bfsp-m4-capstone` swaps its held-DeFi "What's Next" pointer for the Superteam Earn terminus (development / content / grants category links). **No defi pointer remains.**
- **Achievement retarget** — `achievement-full-stack-solana` award now `path-completed → path-zero-to-deployed` (was `path-solana-core`), riding in with #7.

## Tests fixed (and why)
`src/lib/content/__tests__/project.golden.test.ts` — a projection drift-guard whose fixtures are a pre-flip capture of prod Sanity. The activation intentionally introduces content that never existed in that capture, so 6 assertions (course/lesson counts, byte-identical capstone lesson, achievement path, challenge-lesson set, module map) legitimately failed on stale fixtures. Regenerated the affected golden fixtures **through the real projectors** (`projectCourse`/`projectLesson`) so the bundle is the post-SP2 source of truth for the new docs; every pre-existing doc still matches the original capture unchanged. Documented this as a third content-wave delta in the test header (alongside the existing #478/#466 deltas). Fixtures touched: `courses.json` (+C5), `lessons.json` (+9 C5 lessons, refreshed capstone), `achievements-raw.json` (path retarget), `quests-raw.json` (+7 C5 challenge lessons, +3 module-map entries). **Full suite: 1286 passed / 145 files. typecheck: clean. lint: clean (pre-existing import-order warnings only).**

## Known post-activation caveats (NOT acted on here)
- **C5 won't display until its on-chain course is created** via the admin gate (catalog filters on synced+active). That's the owner-gated devnet window (#606 / O-3), not this PR.
- **DeFi course-visibility leak** (#559's flagged risk): the defi *course* may still appear in All-Courses/search while its *path* is held (visibility filters on `isSynced` only). If the on-chain course is currently synced+active, the admin deactivate toggle is the owner's optional step (documented in content PR #7's body).
- **`full-stack-solana` achievement retarget** rode in with #7 — verified the bundle award now points at `path-zero-to-deployed`.
- **Not in this SHA:** the item-52 factual-error fixes (#666) and `reviewExempt` markers (in-flight content PR) are not yet merged into content `main`; they stage for the next lock bump.

## Notes
- Pre-commit prettier hook was killed on the 344KB `lessons.json` fixture (a local resource limit, not a formatting failure); fixtures were prettier-formatted manually and are canonical. CI's `format:check` is report-only (`continue-on-error`).
