### PR TITLE
ci: guard against non-SHA-pinned GitHub Actions

### DIFF
--- a/.github/workflows/action-pin-guard.yml
+++ b/.github/workflows/action-pin-guard.yml
@@ -1,0 +1,35 @@
+name: Action pin guard
+
+# #661 — reject any GitHub Action `uses:` that is not pinned to a 40-char commit
+# SHA, so the #635/#659 hardening cannot silently regress. Standalone (not a job
+# in ci.yml) to keep the diff off the sensitive ci.yml and its required checks.
+# Not a required check, so `on.paths` is safe here (unlike ci.yml — see its
+# header): it simply doesn't run when no workflow/guard file changed.
+
+on:
+  push:
+    branches: ["**"]
+    paths:
+      - ".github/workflows/**"
+      - "scripts/check-action-pins.sh"
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/**"
+      - "scripts/check-action-pins.sh"
+
+concurrency:
+  group: action-pin-guard-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  guard:
+    name: SHA-pin guard
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Assert every `uses:` is SHA-pinned
+        run: ./scripts/check-action-pins.sh

--- a/scripts/check-action-pins.sh
+++ b/scripts/check-action-pins.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# CI guard (#661, follows #635/#659): every third-party GitHub Action referenced
+# by a `uses:` in .github/workflows/*.yml MUST be pinned to a 40-char commit SHA,
+# never a mutable tag/branch (@v4, @main). A mutable tag lets an upstream
+# compromise or re-point silently change what runs in CI with our permissions.
+#
+# The whole repo is uniformly SHA-pinned today (checkout/cache included), so the
+# rule is simple and exceptionless: EVERY `uses:` needs a SHA. The only refs
+# that are legitimately not SHA-pinnable are excluded:
+#   - local reusable workflows:  uses: ./.github/workflows/foo.yml
+#   - Docker image refs:         uses: docker://alpine:3.20  (pin by @sha256 digest)
+#
+# Pure bash + grep — no third-party action or tool, so the guard can't itself
+# reintroduce an unpinned dependency. Runnable locally: scripts/check-action-pins.sh
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+workflow_dir="$repo_root/.github/workflows"
+sha_re='^[0-9a-fA-F]{40}$'
+violations=0
+
+shopt -s nullglob
+files=("$workflow_dir"/*.yml "$workflow_dir"/*.yaml)
+shopt -u nullglob
+
+if [ ${#files[@]} -eq 0 ]; then
+  echo "::error::No workflow files found under .github/workflows — check-action-pins.sh misconfigured."
+  exit 1
+fi
+
+for file in "${files[@]}"; do
+  rel="${file#"$repo_root"/}"
+  # `uses:` as a step/list key: optional leading "- ", then uses:. Skips comments
+  # and run-block prose (those don't start with an optional "- " + "uses:" key).
+  while IFS=: read -r lineno _; do
+    raw="$(sed -n "${lineno}p" "$file")"
+    # Strip up to and including "uses:", trailing "# comment", surrounding quotes/space.
+    value="${raw#*uses:}"
+    value="${value%%#*}"
+    value="$(echo "$value" | tr -d '\r' | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' -e 's/^["'\'']//' -e 's/["'\'']$//')"
+
+    # Excluded: local reusable workflows and docker image refs (not SHA-pinnable as a git ref).
+    case "$value" in
+      ./*|.\\*) continue ;;
+      docker://*) continue ;;
+    esac
+
+    ref="${value##*@}"
+    if [ "$ref" = "$value" ] || ! [[ "$ref" =~ $sha_re ]]; then
+      printf '::error file=%s,line=%s::Action is not SHA-pinned: `%s`. Pin to a 40-char commit SHA with a version comment, e.g. `uses: owner/repo@<40-hex-sha> # v1.2.3`.\n' \
+        "$rel" "$lineno" "$value"
+      violations=$((violations + 1))
+    fi
+  done < <(grep -nE '^[[:space:]]*(-[[:space:]]+)?uses:[[:space:]]*[^[:space:]]' "$file")
+done
+
+if [ "$violations" -gt 0 ]; then
+  echo "::error::$violations GitHub Action(s) are not pinned to a commit SHA. See #635 — mutable tags are forbidden."
+  exit 1
+fi
+
+echo "All GitHub Actions \`uses:\` refs are SHA-pinned across .github/workflows/. ✓"


### PR DESCRIPTION
Closes #661. Follow-up to #635 / #659 (which pinned all mutable-tag actions): adds the missing guard so a new unpinned \`uses:\` cannot slip back in.

## Rule
Every \`uses:\` in \`.github/workflows/*.yml\` must be pinned to a **40-char commit SHA**. The repo is uniformly SHA-pinned today (checkout/cache included), so the rule is exceptionless. Excluded (not SHA-pinnable as a git ref):
- local reusable workflows — \`uses: ./...\`
- Docker image refs — \`uses: docker://...\` (pin by \`@sha256\` digest instead)

## Implementation
- **\`scripts/check-action-pins.sh\`** — pure bash + grep, **no third-party action or tool** (so the guard can't itself reintroduce an unpinned dependency). Runnable locally. Fails with a GitHub \`::error file=…,line=…::\` annotation naming the offending file:line, the ref, and the fix.
- **\`.github/workflows/action-pin-guard.yml\`** — standalone workflow running the script on any \`.github/workflows/**\` or script change. Standalone (not a job in \`ci.yml\`) to keep the diff off the sensitive \`ci.yml\` and its required checks; being non-required, \`on.paths\` is safe here. Its own \`checkout\` is SHA-pinned, so the guard dogfoods itself.

## Proof (run both ways)
Current tree — **PASS**:
\`\`\`
All GitHub Actions \`uses:\` refs are SHA-pinned across .github/workflows/. ✓
exit=0
\`\`\`
Deliberately-broken fixture (\`actions/checkout@v4\`, \`some/action@main\`, plus an allowed \`./\` local, an allowed \`docker://\`, and a correctly-pinned action) — **FAIL**, flags only the two mutable tags:
\`\`\`
::error file=.github/workflows/evil.yml,line=7::Action is not SHA-pinned: \`actions/checkout@v4\`. Pin to a 40-char commit SHA with a version comment, e.g. \`uses: owner/repo@<40-hex-sha> # v1.2.3\`.
::error file=.github/workflows/evil.yml,line=8::Action is not SHA-pinned: \`some/action@main\`. ...
::error::2 GitHub Action(s) are not pinned to a commit SHA. See #635 — mutable tags are forbidden.
exit=1
\`\`\`

This PR touches \`.github/workflows/**\`, so the new guard job runs on it and passes — self-proving.

## Sensitivity
\`.github/workflows/**\` change: no new permissions or secrets (\`permissions: contents: read\`), no third-party actions in the guard itself, \`ci.yml\` untouched.