### PR TITLE
ci: make the SHA-pin guard registerable as a required check

### DIFF
--- a/.github/workflows/action-pin-guard.yml
+++ b/.github/workflows/action-pin-guard.yml
@@ -2,21 +2,21 @@ name: Action pin guard
 
 # #661 — reject any GitHub Action `uses:` that is not pinned to a 40-char commit
 # SHA, so the #635/#659 hardening cannot silently regress. Standalone (not a job
-# in ci.yml) to keep the diff off the sensitive ci.yml and its required checks.
-# Not a required check, so `on.paths` is safe here (unlike ci.yml — see its
-# header): it simply doesn't run when no workflow/guard file changed.
+# in ci.yml) to keep the diff off the sensitive ci.yml.
+#
+# NO `on.paths` FILTER, deliberately. This must be registerable as a required
+# check to actually satisfy #661 ("cannot slip back in") — a red ✗ that does not
+# block a merge is advisory, not a guard. And per ci.yml's header, a workflow
+# gated by workflow-level `on.paths` leaves a required check stuck "pending" and
+# blocks every merge that does not touch the filtered paths. The two properties
+# are mutually exclusive, so the filter goes. The job is ~4s of pure bash on
+# every PR, which is cheaper than the enforcement it buys.
 
 on:
   push:
     branches: ["**"]
-    paths:
-      - ".github/workflows/**"
-      - "scripts/check-action-pins.sh"
   pull_request:
     branches: [main]
-    paths:
-      - ".github/workflows/**"
-      - "scripts/check-action-pins.sh"
 
 concurrency:
   group: action-pin-guard-${{ github.workflow }}-${{ github.ref }}

--- a/scripts/check-action-pins.sh
+++ b/scripts/check-action-pins.sh
@@ -41,7 +41,7 @@ for file in "${files[@]}"; do
 
     # Excluded: local reusable workflows and docker image refs (not SHA-pinnable as a git ref).
     case "$value" in
-      ./*|.\\*) continue ;;
+      ./*) continue ;;
       docker://*) continue ;;
     esac
 


### PR DESCRIPTION
Follow-up to #680 (merged). **#661 asks that an unpinned action "cannot slip back in". #680 cannot deliver that as written**, and the blocker is structural, not an admin oversight.

## Why the guard is currently advisory only

Branch protection on `main` requires exactly two contexts:

```
Frontend (lint · typecheck · test)
On-chain (fmt · clippy · cargo test)
```

`SHA-pin guard` is not among them, so today it produces a visible red ✗ and nothing else — a PR reintroducing `@v4` merges cleanly.

## Why simply adding it to branch protection would break the repo

`action-pin-guard.yml` shipped with a workflow-level `on.paths` filter. `ci.yml`'s own header spells out the consequence:

> A job skipped this way reports a "skipped" conclusion, which branch protection treats as PASSING — so the required-check names stay intact with no branch-protection change. (Do NOT convert this to workflow-level `on.paths`: that leaves required checks stuck "pending" and blocks merges.)

Registering a path-filtered workflow as required means every PR touching neither `.github/workflows/**` nor `scripts/check-action-pins.sh` sits at *"Expected — waiting for status to be reported"* forever. That is **all normal PRs blocked indefinitely**.

So "path-filtered" and "enforceable" are mutually exclusive. #680 chose path-filtered and its header is internally consistent about that ("Not a required check, so `on.paths` is safe here"). This PR makes the other choice, because #661 asked for enforcement.

## Changes

1. **Drop both `paths:` filters** from `action-pin-guard.yml` so the job always runs and therefore always reports a conclusion — the precondition for it being a required check. The job is ~4 seconds of pure bash with `permissions: contents: read`; path-filtering it saved nothing and cost exactly the ability to enforce it. Header rewritten to record why the filter must stay off, so nobody helpfully re-adds it.
2. **Delete the dead exclusion pattern** at `check-action-pins.sh:44` — `case` had `./*|.\\*)`, whose second arm (literal `.` + `\`) matches no valid `uses:` value. Non-blocking nit from #680's review. Harmless either way (an exclusion can only be additive, never weaken the SHA test), removed for clarity.

## Verification

I re-ran the adversarial harness I used to gate #680 against the patched script — **12/12**, no behaviour change from dropping the dead pattern:

| Must pass (rc=0) | Must fail (rc=1) |
|---|---|
| 40-hex SHA + version comment | `@v4` mutable tag |
| `./` local reusable workflow | `@main` branch ref |
| `docker://alpine:3.20` | no ref at all |
| `# uses: …@v4` comment line | 7-hex short SHA |
| `uses:` inside `run: \|` prose | `"…@v4"` quoted tag |
| | `${{ env.PINNED }}` indirection |
| | `owner/repo/.github/workflows/x.yml@v1` |

SHA length boundary re-confirmed exact: 39 rejected, 40 accepted, 41 rejected. Workflow YAML parses; triggers remain `push` (all branches) + `pull_request` → `main`.

Self-demonstrating: this PR touches a workflow file, so `SHA-pin guard` runs here regardless of the filter change.

## One human step remains after this merges

Adding `SHA-pin guard` to the required-status-checks list for `main` needs repo-settings access — CI cannot grant itself enforcement, and I am deliberately not touching branch protection. Once this is merged the check reports on every PR, so registering it is safe and will not wedge unrelated PRs.

Until that click happens the guard stays advisory. Flagged to the owner.

Closes out #680's review finding. Related: #661, #635, #659, #681 (composite-action coverage, still open).
