### PR TITLE
docs: instructor credibility + track ladder pre-mainnet checklist (LX-D6)

### DIFF
--- a/.claude/skills/superteam-academy-dev/deployment.md
+++ b/.claude/skills/superteam-academy-dev/deployment.md
@@ -114,6 +114,11 @@ soteria -analyzeAll .
 
 ### Mainnet First Deploy
 
+> Before creating any course on mainnet, clear the **instructor credibility &
+> track ladder** items in the [Pre-Mainnet Checklist](#pre-mainnet-checklist) —
+> `creator` / `trackId` / `trackLevel` are immutable at creation with no mainnet
+> recreate escape.
+
 ```bash
 # 1. Ensure sufficient SOL (deployment costs ~2-5 SOL depending on program size)
 solana balance --url mainnet
@@ -513,6 +518,8 @@ anchor deploy --provider.cluster devnet --program-keypair wallets/program-keypai
 
 ## Pre-Mainnet Checklist
 
+### Program & deploy
+
 - [ ] All tests passing (unit + integration + fuzz 10+ min)
 - [ ] Security audit completed
 - [ ] Verifiable build (`anchor build --verifiable`)
@@ -522,6 +529,43 @@ anchor deploy --provider.cluster devnet --program-keypair wallets/program-keypai
 - [ ] Frontend Lighthouse: Performance 90+, Accessibility 95+, Best Practices 95+, SEO 90+
 - [ ] AI slop removed from branch
 - [ ] User explicit confirmation received
+
+### Instructor credibility & track ladder (course creation — IRREVERSIBLE at mainnet)
+
+`Course.creator`, `Course.track_id`, and `Course.track_level` are set once at
+`create_course` and have **no on-chain setter** — `update_course` cannot touch
+them. On devnet a wrong value is recoverable only via a full WS-2 recreate
+(new account, re-enroll). **On mainnet there is no recreate escape: every course
+must be created correctly the FIRST time.** All six devnet courses today carry
+`creator` = platform authority (created pre-#399) — do NOT copy that mistake to
+mainnet. Source of truth for all three fields is the course content doc
+(`creatorWallet` / `trackId` / `trackLevel` in `lib/content`), passed straight
+through the admin sync route to `create_course`; there is **no platform-authority
+fallback** — a missing or invalid creator wallet fails the deploy loudly.
+
+**Do this per course, before the first mainnet `create_course`:**
+
+- [ ] **Final instructor wallet confirmed with each instructor** — a wallet they
+      control (not a placeholder, not the platform authority). Devnet courses use
+      mock placeholder wallets; these MUST be replaced before mainnet.
+- [ ] Each course content doc's `creatorWallet` set to that confirmed wallet and
+      it is a valid on-curve address (the sync route rejects invalid/missing).
+- [ ] **Owner decision D-6 settled** — the credential track ladder
+      (`trackId` / `trackLevel` per course) is finalized against the launch spine
+      _before_ mainnet. Recreate-only afterward, one full recreate per course. See
+      the launch-experience master spec §"Owner Decisions" (D-6) and task LX-D6.
+- [ ] `trackId` / `trackLevel` in every course content doc match that finalized
+      ladder (no `undefined`/`0` defaults left where a real rung is intended).
+- [ ] **Credibility display verified against real data** — instructor identity is
+      surfaced ONLY via the `public_profiles` view, resolved from `course.creator`
+      by `resolvePublicProfileByWallet` (`api/content/instructor-wallet`). The
+      retired wallet→Instructor-content-doc path is gone (post-#478). Confirm each
+      confirmed creator wallet is linked to a public academy profile, so course
+      and certificate pages show a real instructor identity rather than the
+      truncated-wallet fallback.
+- [ ] courses-academy contributor docs (CLAUDE.md / CONTRIBUTING) describe the
+      real wallet→instructor flow — no reference to a nonexistent `instructors/`
+      directory (LX-D6 docs-drift fix; that fix lands in the separate content repo).
 
 ## Best Practices Summary
 

--- a/docs/DEPLOY-PROGRAM.md
+++ b/docs/DEPLOY-PROGRAM.md
@@ -234,6 +234,16 @@ Note on XP token metadata: The `initialize` instruction sets the `MetadataPointe
 npx ts-node scripts/create-mock-course.ts
 ```
 
+> **Mainnet caveat.** `create-mock-course.ts` uses a placeholder creator wallet
+> and default `trackId` / `trackLevel`. `Course.creator`, `track_id`, and
+> `track_level` are **immutable** after `create_course` (no `update_course`
+> setter; recoverable on devnet only via a full recreate, and NOT at all on
+> mainnet). Before any mainnet course creation, work the **instructor
+> credibility & track ladder** section of the Pre-Mainnet Checklist in the
+> `superteam-academy-dev` skill (`deployment.md`): real instructor wallets
+> confirmed per course, `trackId` / `trackLevel` finalized per owner decision
+> D-6, credibility display verified.
+
 ---
 
 ## 10. Create Track Collection (optional — credential flow only)


### PR DESCRIPTION
Closes #581.

## What LX-D6 flagged as drifted
The pre-mainnet checklist (`.claude/skills/superteam-academy-dev/deployment.md` → Pre-Mainnet Checklist, the canonical one SKILL.md points to) covered **only program deploy** — nothing about course creation. But `Course.creator`, `track_id`, and `track_level` are set once at `create_course` and have **no on-chain setter** (`update_course` can't touch them), so they are irreversible at mainnet with no recreate escape. The checklist gave zero guidance on getting them right the first time. That is the drift fixed here.

## What changed
- **`deployment.md` → Pre-Mainnet Checklist**: split into "Program & deploy" (unchanged items) + a new **"Instructor credibility & track ladder (IRREVERSIBLE at mainnet)"** subsection — actionable boxes:
  - final instructor wallet confirmed per course before the first mainnet `create_course` (devnet placeholders/`creator = platform authority` must be replaced);
  - each content doc's `creatorWallet` valid + set;
  - **owner decision D-6** settled (track ladder finalized against the launch spine) before mainnet;
  - `trackId`/`trackLevel` in content match that ladder;
  - **credibility display verified against real data** — instructor identity resolves ONLY via the `public_profiles` view from `course.creator` (`api/content/instructor-wallet` → `resolvePublicProfileByWallet`; the wallet→Instructor-content-doc path was retired post-#478), so each creator wallet must be linked to a public academy profile or the page shows a truncated-wallet fallback;
  - courses-academy contributor docs describe the real wallet→instructor flow (no nonexistent `instructors/` dir).
- **Cross-links** to the checklist from the two places mainnet course creation is documented: `DEPLOY-PROGRAM.md` §9 (placeholder-wallet caveat) and `deployment.md` → Mainnet First Deploy.

Facts are code-verified against `api/admin/courses/sync/route.ts` (immutable-creator comment, no-fallback loud failure), `lib/content/project.ts`/`queries.ts` (`creatorWallet`/`trackId`/`trackLevel` fields), and `api/content/instructor-wallet/route.ts` (public_profiles-only display path).

## Out of scope
- The actual `instructors/` dir drift lives in the **separate** `solanabr/courses-academy` repo (CLAUDE.md/CONTRIBUTING) — cannot be fixed from this monorepo PR; the checklist item flags it as the content-repo fix.
- Note: the spec labels the track-ladder owner decision **D-6**; the issue text called it "O-3". I used the spec's label (D-6) since that's what's verifiable in-repo.