### PR TITLE
feat(review): review_items spaced-repetition migration + seed (LX-B3)

### DIFF
--- a/apps/web/src/lib/supabase/__tests__/review-items-rls-guard.test.ts
+++ b/apps/web/src/lib/supabase/__tests__/review-items-rls-guard.test.ts
@@ -1,0 +1,146 @@
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, it, expect } from "vitest";
+
+// #569 (LX-B3): the review spine substrate. RLS cannot be exercised in unit
+// tests, so — as with the #493 profile guard — pin the security-critical SQL
+// invariants in both the migration and the schema.sql mirror:
+//   * review_items has RLS on, an own-row SELECT policy, and NO write policy
+//     (writes only via SECURITY DEFINER RPCs) — the challenge_assists pattern.
+//   * both write RPCs are SECURITY DEFINER, search_path-pinned, REVOKEd from
+//     clients, GRANTed only to service_role.
+//   * the 1/3/7/21 schedule lives as review_schedule ROWS, and the transition
+//     RPCs read intervals from it (never a hardcoded day count in the body).
+
+function findRepoRoot(): string {
+  let dir = dirname(fileURLToPath(import.meta.url));
+  while (!existsSync(resolve(dir, "supabase/schema.sql"))) {
+    const parent = dirname(dir);
+    if (parent === dir)
+      throw new Error("repo root (supabase/schema.sql) not found");
+    dir = parent;
+  }
+  return dir;
+}
+
+const repoRoot = findRepoRoot();
+const migration = readFileSync(
+  resolve(
+    repoRoot,
+    "supabase/migrations/20260726140000_review_items_spaced_repetition.sql"
+  ),
+  "utf8"
+);
+const schema = readFileSync(resolve(repoRoot, "supabase/schema.sql"), "utf8");
+
+const WRITE_RPCS: ReadonlyArray<[string, string]> = [
+  ["schedule_review_item", "(UUID, TEXT)"],
+  ["record_review_result", "(UUID, TEXT, BOOLEAN)"],
+];
+
+// The security invariants must hold in the migration (what gets applied) AND in
+// schema.sql (the snapshot new environments are built from) — a drift between
+// them is exactly the class of bug the #449 IDL memory warns about.
+for (const [label, sql] of [
+  ["migration", migration] as const,
+  ["schema.sql", schema] as const,
+]) {
+  describe(`#569 review spine — ${label}`, () => {
+    it("enables RLS on both review tables", () => {
+      expect(sql).toContain(
+        "ALTER TABLE review_items ENABLE ROW LEVEL SECURITY"
+      );
+      expect(sql).toContain(
+        "ALTER TABLE review_schedule ENABLE ROW LEVEL SECURITY"
+      );
+    });
+
+    it("gives review_items an own-row SELECT policy and NO write policy", () => {
+      expect(sql).toContain(
+        `ON review_items FOR SELECT USING (auth.uid() = user_id)`
+      );
+      // The only policy on review_items is the SELECT one. Any INSERT/UPDATE/
+      // DELETE policy would open a client write path around the RPCs.
+      expect(sql).not.toMatch(/ON review_items FOR (INSERT|UPDATE|DELETE|ALL)/);
+    });
+
+    it("item_key is the raw lesson id — no skill column (bundle resolves skills)", () => {
+      const start = sql.indexOf("CREATE TABLE IF NOT EXISTS review_items");
+      expect(start).toBeGreaterThan(-1);
+      // Column definitions only — strip `-- …` comments so the "no skill column"
+      // prose doesn't read as a skill column.
+      const table = sql
+        .slice(start, sql.indexOf(");", start))
+        .replace(/--[^\n]*/g, "");
+      expect(table).toContain("item_key");
+      expect(table).not.toMatch(/\bskill\b/i);
+    });
+
+    it("cascades review_items on profile deletion", () => {
+      expect(sql).toContain(
+        "user_id        UUID NOT NULL REFERENCES profiles(id) ON DELETE CASCADE"
+      );
+    });
+
+    it("stores the 1/3/7/21 schedule AS DATA rows", () => {
+      expect(sql).toContain("CREATE TABLE IF NOT EXISTS review_schedule");
+      for (const row of ["(1, 1)", "(2, 3)", "(3, 7)", "(4, 21)"]) {
+        expect(sql).toContain(row);
+      }
+    });
+
+    it("hardens every write RPC (SECURITY DEFINER, pinned path, service_role only)", () => {
+      for (const [fn, args] of WRITE_RPCS) {
+        const start = sql.indexOf(`CREATE OR REPLACE FUNCTION ${fn}(`);
+        expect(start, `${fn} defined`).toBeGreaterThan(-1);
+        const body = sql.slice(
+          start,
+          sql.indexOf("GRANT EXECUTE", start) + 200
+        );
+        expect(body).toContain("SECURITY DEFINER");
+        expect(body).toContain("SET search_path = ''");
+        expect(body).toContain(
+          `REVOKE ALL ON FUNCTION ${fn}${args} FROM PUBLIC, anon, authenticated`
+        );
+        expect(body).toContain(
+          `GRANT EXECUTE ON FUNCTION ${fn}${args} TO service_role`
+        );
+      }
+    });
+
+    it("computes intervals from the schedule, never a hardcoded day count", () => {
+      // The transition bodies must read interval_days from review_schedule.
+      expect(sql).toContain(
+        "SELECT interval_days INTO v_interval\n    FROM public.review_schedule"
+      );
+      // No literal review interval baked into a make_interval/now() expression.
+      expect(sql).not.toMatch(/make_interval\(days => (1|3|7|21)\b/);
+      expect(sql).not.toMatch(/now\(\) \+ interval '(1|3|7|21) day/);
+    });
+  });
+}
+
+describe("#569 review spine — migration-only guarantees", () => {
+  it("runs in one explicit transaction", () => {
+    expect(migration).toContain("BEGIN;");
+    expect(migration).toContain("COMMIT;");
+  });
+
+  it("seeds review items from completed lessons, idempotently", () => {
+    expect(migration).toContain("FROM user_progress up");
+    expect(migration).toContain("WHERE up.completed = true");
+    expect(migration).toContain("ON CONFLICT (user_id, item_key) DO NOTHING");
+  });
+
+  it("ships a rollback that drops exactly what it created", () => {
+    expect(migration).toContain(
+      "DROP FUNCTION IF EXISTS public.record_review_result(UUID, TEXT, BOOLEAN)"
+    );
+    expect(migration).toContain(
+      "DROP FUNCTION IF EXISTS public.schedule_review_item(UUID, TEXT)"
+    );
+    expect(migration).toContain("DROP TABLE IF EXISTS public.review_items");
+    expect(migration).toContain("DROP TABLE IF EXISTS public.review_schedule");
+  });
+});

--- a/apps/web/src/lib/supabase/__tests__/review-items-rls-guard.test.ts
+++ b/apps/web/src/lib/supabase/__tests__/review-items-rls-guard.test.ts
@@ -65,6 +65,15 @@ for (const [label, sql] of [
       expect(sql).not.toMatch(/ON review_items FOR (INSERT|UPDATE|DELETE|ALL)/);
     });
 
+    it("gives review_schedule a read-only policy — NO client write path", () => {
+      // Reference data: public read, but writes only via DDL / service_role.
+      // A write policy here would let a client rewrite everyone's spacing.
+      expect(sql).toContain(`ON review_schedule FOR SELECT USING (true)`);
+      expect(sql).not.toMatch(
+        /ON review_schedule FOR (INSERT|UPDATE|DELETE|ALL)/
+      );
+    });
+
     it("item_key is the raw lesson id — no skill column (bundle resolves skills)", () => {
       const start = sql.indexOf("CREATE TABLE IF NOT EXISTS review_items");
       expect(start).toBeGreaterThan(-1);
@@ -131,6 +140,21 @@ describe("#569 review spine — migration-only guarantees", () => {
     expect(migration).toContain("FROM user_progress up");
     expect(migration).toContain("WHERE up.completed = true");
     expect(migration).toContain("ON CONFLICT (user_id, item_key) DO NOTHING");
+  });
+
+  it("documents the seed's FK-safety argument", () => {
+    // The seed cannot abort on an orphan because user_progress.user_id is
+    // itself FK'd to profiles(id) — the reasoning must stay recorded next to
+    // the INSERT so a future edit doesn't drop the invariant unknowingly.
+    expect(migration).toMatch(/FK-safety:[\s\S]*user_progress\.user_id/);
+  });
+
+  it("advances the box atomically — no separate current-box read", () => {
+    // The transition must derive the new box from the row's own value inside a
+    // single UPDATE (LEAST(ri.box + 1, …)), never a standalone SELECT of box
+    // that a concurrent grade could double-read.
+    expect(migration).toContain("LEAST(ri.box + 1, v_max_box)");
+    expect(migration).not.toMatch(/v_new_box\s*:=\s*LEAST\(\s*\(SELECT/);
   });
 
   it("ships a rollback that drops exactly what it created", () => {

--- a/apps/web/src/lib/supabase/types.ts
+++ b/apps/web/src/lib/supabase/types.ts
@@ -912,6 +912,72 @@ export type Database = {
           },
         ];
       };
+      review_schedule: {
+        Row: {
+          box: number;
+          interval_days: number;
+        };
+        Insert: {
+          box: number;
+          interval_days: number;
+        };
+        Update: {
+          box?: number;
+          interval_days?: number;
+        };
+        Relationships: [];
+      };
+      review_items: {
+        Row: {
+          user_id: string;
+          item_key: string;
+          box: number;
+          due_at: string;
+          last_result: boolean | null;
+          last_reviewed_at: string | null;
+          lapses: number;
+          created_at: string;
+          updated_at: string;
+        };
+        Insert: {
+          user_id: string;
+          item_key: string;
+          box?: number;
+          due_at?: string;
+          last_result?: boolean | null;
+          last_reviewed_at?: string | null;
+          lapses?: number;
+          created_at?: string;
+          updated_at?: string;
+        };
+        Update: {
+          user_id?: string;
+          item_key?: string;
+          box?: number;
+          due_at?: string;
+          last_result?: boolean | null;
+          last_reviewed_at?: string | null;
+          lapses?: number;
+          created_at?: string;
+          updated_at?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "review_items_user_id_fkey";
+            columns: ["user_id"];
+            isOneToOne: false;
+            referencedRelation: "profiles";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "review_items_box_fkey";
+            columns: ["box"];
+            isOneToOne: false;
+            referencedRelation: "review_schedule";
+            referencedColumns: ["box"];
+          },
+        ];
+      };
     };
     Views: {
       public_onchain_deployments: {
@@ -1032,6 +1098,27 @@ export type Database = {
         Returns: {
           assists_used: number;
           chat_log: Json;
+        }[];
+      };
+      schedule_review_item: {
+        Args: {
+          p_user_id: string;
+          p_item_key: string;
+        };
+        Returns: {
+          box: number;
+          due_at: string;
+        }[];
+      };
+      record_review_result: {
+        Args: {
+          p_user_id: string;
+          p_item_key: string;
+          p_passed: boolean;
+        };
+        Returns: {
+          box: number;
+          due_at: string;
         }[];
       };
       award_xp: {

--- a/supabase/migrations/20260726140000_review_items_spaced_repetition.sql
+++ b/supabase/migrations/20260726140000_review_items_spaced_repetition.sql
@@ -1,0 +1,228 @@
+-- ============================================================================
+-- Migration: review_items — spaced-repetition substrate (LX-B3, #569)
+--
+-- The review spine (1/3 — this migration only) records, per learner and per
+-- lesson, WHEN that lesson's retrieval item is next due and which spacing box
+-- it sits in. The feed (#570 / LX-B4) and the /review page (#571 / LX-B5) build
+-- ON this substrate; neither is in scope here.
+--
+-- WRITE-SIDE HARDENING — copies the challenge_assists pattern EXACTLY:
+--   * RLS on; NO write policies. Every write goes through a SECURITY DEFINER
+--     RPC, search_path-pinned to '', REVOKEd from PUBLIC/anon/authenticated and
+--     GRANTed only to service_role. Clients never mutate the table directly.
+-- READ-SIDE — one addition over challenge_assists, prescribed by LX-B3:
+--   * own-row SELECT policy. Learners read their OWN review queue client-side
+--     (the /review page is a client surface), so authenticated may SELECT rows
+--     where user_id = auth.uid() and nothing else. anon gets no read.
+--
+-- SCHEDULE-AS-DATA (PED-04, unified spec §2.1) — the 1/3/7/21-day box expansion
+-- is CONVENTION, not evidence. It is stored as ROWS in review_schedule, never
+-- hardcoded as magic numbers in the transition RPCs, precisely so it can be
+-- re-tuned by a data change (a weekly-dominant spacing is the preferred
+-- direction if it is ever tuned) without touching any function body. A
+-- spaced-repetition scheduler that LEARNS intervals (per-item ML) is explicitly
+-- out of scope forever: HLR-style models buy ~0.54 AUC over fixed boxes
+-- (pedagogy note), not worth the complexity or the content-drift risk.
+--
+-- SKILLS RESOLVE FROM THE BUNDLE AT READ TIME — there is deliberately no skill
+-- column on review_items. The item_key is the RAW lesson _id (PDA-seed
+-- convention: never strip or transform ids); skill tags are looked up from the
+-- committed content bundle when the feed renders, so re-tagging content never
+-- leaves stale rows here.
+--
+-- Idempotent (repo convention): CREATE TABLE/INDEX IF NOT EXISTS, ON CONFLICT
+-- DO NOTHING seeds, CREATE OR REPLACE functions, DROP POLICY IF EXISTS before
+-- CREATE POLICY. Safe to re-apply. Explicit BEGIN/COMMIT so the whole file is
+-- one transaction even under a manual psql apply (not only the Supabase CLI's
+-- per-file wrap).
+--
+-- A tested ROLLBACK block is at the very bottom of this file.
+-- Mirrored into supabase/schema.sql (the full-schema snapshot).
+-- ============================================================================
+
+BEGIN;
+
+-- ── Schedule (reference data) ───────────────────────────────────────────────
+-- box → interval_days. Public-read reference data (mirrors forum_categories:
+-- non-sensitive global config, readable by everyone, writable only by DDL /
+-- service_role). The transition RPCs read interval_days from here; they never
+-- embed the day counts. The highest box row is the terminal box (advance caps
+-- there). Re-tuning spacing = UPDATE/INSERT rows, no function change.
+CREATE TABLE IF NOT EXISTS review_schedule (
+  box           SMALLINT PRIMARY KEY,
+  interval_days INTEGER  NOT NULL CHECK (interval_days > 0)
+);
+
+ALTER TABLE review_schedule ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Review schedule is viewable by everyone" ON review_schedule;
+CREATE POLICY "Review schedule is viewable by everyone"
+  ON review_schedule FOR SELECT USING (true);
+-- No write policy: seeded here, mutated only by service_role / future DDL.
+
+-- CONVENTION, NOT EVIDENCE (PED-04): 1 / 3 / 7 / 21 days. Encoded as data so a
+-- future tuning pass edits these rows, not a function body.
+INSERT INTO review_schedule (box, interval_days) VALUES
+  (1, 1),
+  (2, 3),
+  (3, 7),
+  (4, 21)
+ON CONFLICT (box) DO NOTHING;
+
+-- ── review_items ────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS review_items (
+  user_id        UUID NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+  -- Raw lesson _id. PDA-seed convention: NEVER strip/transform ids. Skill tags
+  -- resolve from the content bundle at read time — no skill column here.
+  item_key       TEXT NOT NULL,
+  -- Current spacing box; FK into review_schedule so a box always has an
+  -- interval. New items start at box 1.
+  box            SMALLINT NOT NULL DEFAULT 1 REFERENCES review_schedule(box),
+  -- When this item next surfaces in the review feed.
+  due_at         TIMESTAMPTZ NOT NULL DEFAULT now(),
+  -- Last graded review: true = cleared (box advanced), false = lapsed (reset to
+  -- box 1). NULL until first reviewed. last_result / lapse metadata per LX-B3.
+  last_result    BOOLEAN,
+  last_reviewed_at TIMESTAMPTZ,
+  -- Lapse metadata: how many times this item has been reset to box 1 after a
+  -- miss. Signal for the feed (chronically-lapsing items) — never feeds XP.
+  lapses         INTEGER NOT NULL DEFAULT 0,
+  created_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+  -- UNIQUE(user_id, item_key): one review row per learner per lesson.
+  PRIMARY KEY (user_id, item_key)
+);
+
+-- Feed's hot path: a learner's due items, soonest first.
+CREATE INDEX IF NOT EXISTS idx_review_items_user_due
+  ON review_items (user_id, due_at);
+
+ALTER TABLE review_items ENABLE ROW LEVEL SECURITY;
+
+-- Own-row SELECT only (LX-B3): learners read their own queue client-side.
+DROP POLICY IF EXISTS "Users can view their own review items" ON review_items;
+CREATE POLICY "Users can view their own review items"
+  ON review_items FOR SELECT USING (auth.uid() = user_id);
+-- No INSERT/UPDATE/DELETE policy: writes go through the SECURITY DEFINER RPCs.
+
+-- ── RPCs ────────────────────────────────────────────────────────────────────
+
+-- Enqueue a lesson's retrieval item at box 1 if the learner has none yet.
+-- Idempotent: an existing item is left untouched (DO NOTHING) so re-capturing a
+-- lesson never resets a learner's hard-won box progress. This is the entry
+-- point the failure-capture feed (LX-B4) and the seed below both use. due_at is
+-- computed from the box-1 interval in review_schedule — no hardcoded days.
+CREATE OR REPLACE FUNCTION schedule_review_item(
+  p_user_id  UUID,
+  p_item_key TEXT
+) RETURNS TABLE (box SMALLINT, due_at TIMESTAMPTZ)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_interval INT;
+BEGIN
+  SELECT interval_days INTO v_interval
+    FROM public.review_schedule WHERE box = 1;
+
+  INSERT INTO public.review_items (user_id, item_key, box, due_at)
+  VALUES (p_user_id, p_item_key, 1, now() + make_interval(days => v_interval))
+  ON CONFLICT (user_id, item_key) DO NOTHING;
+
+  RETURN QUERY
+    SELECT ri.box, ri.due_at
+    FROM public.review_items ri
+    WHERE ri.user_id = p_user_id AND ri.item_key = p_item_key;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION schedule_review_item(UUID, TEXT) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION schedule_review_item(UUID, TEXT) TO service_role;
+
+-- Record a graded review and advance/reset the box (LX-B5's transition, owned
+-- here as the substrate primitive):
+--   passed  → box := LEAST(box + 1, max box), due_at := now() + interval(new box)
+--   missed  → box := 1, lapses += 1, due_at := now() + interval(box 1)
+-- The terminal box is whatever the highest review_schedule row is — advance
+-- clamps there instead of walking off the end. No day counts in this body.
+-- No-op (returns nothing) if the item does not exist: the caller must have
+-- scheduled it first, and this must never silently resurrect a deleted row.
+CREATE OR REPLACE FUNCTION record_review_result(
+  p_user_id  UUID,
+  p_item_key TEXT,
+  p_passed   BOOLEAN
+) RETURNS TABLE (box SMALLINT, due_at TIMESTAMPTZ)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_max_box  SMALLINT;
+  v_new_box  SMALLINT;
+  v_interval INT;
+BEGIN
+  SELECT max(rs.box) INTO v_max_box FROM public.review_schedule rs;
+
+  IF p_passed THEN
+    v_new_box := LEAST(
+      (SELECT ri.box FROM public.review_items ri
+        WHERE ri.user_id = p_user_id AND ri.item_key = p_item_key) + 1,
+      v_max_box
+    );
+  ELSE
+    v_new_box := 1;
+  END IF;
+
+  SELECT interval_days INTO v_interval
+    FROM public.review_schedule WHERE box = v_new_box;
+
+  UPDATE public.review_items ri
+     SET box              = v_new_box,
+         due_at           = now() + make_interval(days => v_interval),
+         last_result      = p_passed,
+         last_reviewed_at = now(),
+         lapses           = ri.lapses + CASE WHEN p_passed THEN 0 ELSE 1 END,
+         updated_at       = now()
+   WHERE ri.user_id = p_user_id AND ri.item_key = p_item_key;
+
+  RETURN QUERY
+    SELECT ri.box, ri.due_at
+    FROM public.review_items ri
+    WHERE ri.user_id = p_user_id AND ri.item_key = p_item_key;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION record_review_result(UUID, TEXT, BOOLEAN) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION record_review_result(UUID, TEXT, BOOLEAN) TO service_role;
+
+-- ── Seed for existing learners (pure SQL, LX-B3 accept) ──────────────────────
+-- One box-1 review item per already-completed lesson. ON CONFLICT DO NOTHING so
+-- re-applying the migration, or a lesson already captured, is a no-op. due_at is
+-- the box-1 interval out from now(); per-session flood-shaping (a learner with
+-- many completions) is the feed's job (LX-B4/B5 cap items per session), not the
+-- substrate's.
+INSERT INTO review_items (user_id, item_key, box, due_at)
+SELECT up.user_id,
+       up.lesson_id,
+       1,
+       now() + make_interval(days => (SELECT interval_days FROM review_schedule WHERE box = 1))
+FROM user_progress up
+WHERE up.completed = true
+ON CONFLICT (user_id, item_key) DO NOTHING;
+
+COMMIT;
+
+-- ============================================================================
+-- ROLLBACK (tested) — restores the exact pre-migration state (no review spine).
+-- Everything this migration created is new (no table/function existed before),
+-- so the rollback is an unconditional drop of exactly those objects. Run as one
+-- transaction:
+-- ----------------------------------------------------------------------------
+-- BEGIN;
+-- DROP FUNCTION IF EXISTS public.record_review_result(UUID, TEXT, BOOLEAN);
+-- DROP FUNCTION IF EXISTS public.schedule_review_item(UUID, TEXT);
+-- DROP TABLE IF EXISTS public.review_items;      -- drops idx + own-row policy
+-- DROP TABLE IF EXISTS public.review_schedule;   -- drops the read policy
+-- COMMIT;
+-- ============================================================================

--- a/supabase/migrations/20260726140000_review_items_spaced_repetition.sql
+++ b/supabase/migrations/20260726140000_review_items_spaced_repetition.sql
@@ -146,8 +146,9 @@ GRANT EXECUTE ON FUNCTION schedule_review_item(UUID, TEXT) TO service_role;
 --   missed  → box := 1, lapses += 1, due_at := now() + interval(box 1)
 -- The terminal box is whatever the highest review_schedule row is — advance
 -- clamps there instead of walking off the end. No day counts in this body.
--- No-op (returns nothing) if the item does not exist: the caller must have
--- scheduled it first, and this must never silently resurrect a deleted row.
+-- No-op (returns nothing) if the item does not exist: an early guard bails
+-- before any transition is computed — the caller must schedule first, and a
+-- deleted row is never silently resurrected.
 CREATE OR REPLACE FUNCTION record_review_result(
   p_user_id  UUID,
   p_item_key TEXT,
@@ -158,33 +159,32 @@ SECURITY DEFINER
 SET search_path = ''
 AS $$
 DECLARE
-  v_max_box  SMALLINT;
-  v_new_box  SMALLINT;
-  v_interval INT;
+  v_max_box SMALLINT;
 BEGIN
-  SELECT max(rs.box) INTO v_max_box FROM public.review_schedule rs;
-
-  IF p_passed THEN
-    v_new_box := LEAST(
-      (SELECT ri.box FROM public.review_items ri
-        WHERE ri.user_id = p_user_id AND ri.item_key = p_item_key) + 1,
-      v_max_box
-    );
-  ELSE
-    v_new_box := 1;
+  -- Early guard: nothing to grade if the learner has no such item.
+  IF NOT EXISTS (
+    SELECT 1 FROM public.review_items ri
+    WHERE ri.user_id = p_user_id AND ri.item_key = p_item_key
+  ) THEN
+    RETURN;
   END IF;
 
-  SELECT interval_days INTO v_interval
-    FROM public.review_schedule WHERE box = v_new_box;
+  SELECT max(rs.box) INTO v_max_box FROM public.review_schedule rs;
 
+  -- Atomic read-modify-write: the new box is derived from the row's OWN box
+  -- inside the UPDATE (no separate SELECT of the current box), so two
+  -- concurrent grades cannot double-read a stale value. review_schedule is
+  -- joined for the new box's interval in the same statement — no day counts.
   UPDATE public.review_items ri
-     SET box              = v_new_box,
-         due_at           = now() + make_interval(days => v_interval),
+     SET box              = CASE WHEN p_passed THEN LEAST(ri.box + 1, v_max_box) ELSE 1 END,
+         due_at           = now() + make_interval(days => sched.interval_days),
          last_result      = p_passed,
          last_reviewed_at = now(),
          lapses           = ri.lapses + CASE WHEN p_passed THEN 0 ELSE 1 END,
          updated_at       = now()
-   WHERE ri.user_id = p_user_id AND ri.item_key = p_item_key;
+    FROM public.review_schedule sched
+   WHERE ri.user_id = p_user_id AND ri.item_key = p_item_key
+     AND sched.box = CASE WHEN p_passed THEN LEAST(ri.box + 1, v_max_box) ELSE 1 END;
 
   RETURN QUERY
     SELECT ri.box, ri.due_at
@@ -202,6 +202,10 @@ GRANT EXECUTE ON FUNCTION record_review_result(UUID, TEXT, BOOLEAN) TO service_r
 -- the box-1 interval out from now(); per-session flood-shaping (a learner with
 -- many completions) is the feed's job (LX-B4/B5 cap items per session), not the
 -- substrate's.
+-- FK-safety: the source user_progress.user_id is itself FK'd to profiles(id)
+-- (same ON DELETE CASCADE target as review_items.user_id), so every seeded
+-- user_id is guaranteed to satisfy review_items' FK — the seed cannot abort on
+-- an orphan row.
 INSERT INTO review_items (user_id, item_key, box, due_at)
 SELECT up.user_id,
        up.lesson_id,

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -2194,6 +2194,7 @@ GRANT EXECUTE ON FUNCTION schedule_review_item(UUID, TEXT) TO service_role;
 
 -- Record a graded review: pass advances box (clamped at max), miss resets to
 -- box 1 and counts a lapse. No day counts in the body — read from the schedule.
+-- Early guard + single atomic UPDATE (no separate current-box read).
 CREATE OR REPLACE FUNCTION record_review_result(
   p_user_id  UUID,
   p_item_key TEXT,
@@ -2204,33 +2205,32 @@ SECURITY DEFINER
 SET search_path = ''
 AS $$
 DECLARE
-  v_max_box  SMALLINT;
-  v_new_box  SMALLINT;
-  v_interval INT;
+  v_max_box SMALLINT;
 BEGIN
-  SELECT max(rs.box) INTO v_max_box FROM public.review_schedule rs;
-
-  IF p_passed THEN
-    v_new_box := LEAST(
-      (SELECT ri.box FROM public.review_items ri
-        WHERE ri.user_id = p_user_id AND ri.item_key = p_item_key) + 1,
-      v_max_box
-    );
-  ELSE
-    v_new_box := 1;
+  -- Early guard: nothing to grade if the learner has no such item.
+  IF NOT EXISTS (
+    SELECT 1 FROM public.review_items ri
+    WHERE ri.user_id = p_user_id AND ri.item_key = p_item_key
+  ) THEN
+    RETURN;
   END IF;
 
-  SELECT interval_days INTO v_interval
-    FROM public.review_schedule WHERE box = v_new_box;
+  SELECT max(rs.box) INTO v_max_box FROM public.review_schedule rs;
 
+  -- Atomic read-modify-write: the new box is derived from the row's OWN box
+  -- inside the UPDATE (no separate SELECT of the current box), so two
+  -- concurrent grades cannot double-read a stale value. review_schedule is
+  -- joined for the new box's interval in the same statement — no day counts.
   UPDATE public.review_items ri
-     SET box              = v_new_box,
-         due_at           = now() + make_interval(days => v_interval),
+     SET box              = CASE WHEN p_passed THEN LEAST(ri.box + 1, v_max_box) ELSE 1 END,
+         due_at           = now() + make_interval(days => sched.interval_days),
          last_result      = p_passed,
          last_reviewed_at = now(),
          lapses           = ri.lapses + CASE WHEN p_passed THEN 0 ELSE 1 END,
          updated_at       = now()
-   WHERE ri.user_id = p_user_id AND ri.item_key = p_item_key;
+    FROM public.review_schedule sched
+   WHERE ri.user_id = p_user_id AND ri.item_key = p_item_key
+     AND sched.box = CASE WHEN p_passed THEN LEAST(ri.box + 1, v_max_box) ELSE 1 END;
 
   RETURN QUERY
     SELECT ri.box, ri.due_at

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -2110,3 +2110,134 @@ $$;
 
 REVOKE ALL ON FUNCTION get_challenge_assist_state(UUID, TEXT) FROM PUBLIC, anon, authenticated;
 GRANT EXECUTE ON FUNCTION get_challenge_assist_state(UUID, TEXT) TO service_role;
+
+-- ─────────────────────────────────────────────────────────────────────────
+-- Review spine (LX-B3, #569): spaced-repetition substrate. review_schedule
+-- holds the box→interval schedule AS DATA (PED-04: 1/3/7/21 is convention, not
+-- evidence — re-tunable by editing rows, never hardcoded in a function; no ML
+-- scheduler ever). review_items holds each learner's per-lesson queue. Writes
+-- go ONLY through the two SECURITY DEFINER RPCs (challenge_assists hardening);
+-- learners read their OWN queue via an own-row SELECT policy. item_key is the
+-- raw lesson _id (PDA-seed convention); skills resolve from the bundle at read
+-- time, so there is no skill column. The feed (LX-B4) and /review page (LX-B5)
+-- build on this; neither is defined here.
+-- ─────────────────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS review_schedule (
+  box           SMALLINT PRIMARY KEY,
+  interval_days INTEGER  NOT NULL CHECK (interval_days > 0)
+);
+
+ALTER TABLE review_schedule ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Review schedule is viewable by everyone" ON review_schedule;
+CREATE POLICY "Review schedule is viewable by everyone"
+  ON review_schedule FOR SELECT USING (true);
+
+-- CONVENTION, NOT EVIDENCE (PED-04): 1 / 3 / 7 / 21 days as data.
+INSERT INTO review_schedule (box, interval_days) VALUES
+  (1, 1),
+  (2, 3),
+  (3, 7),
+  (4, 21)
+ON CONFLICT (box) DO NOTHING;
+
+CREATE TABLE IF NOT EXISTS review_items (
+  user_id        UUID NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+  item_key       TEXT NOT NULL,
+  box            SMALLINT NOT NULL DEFAULT 1 REFERENCES review_schedule(box),
+  due_at         TIMESTAMPTZ NOT NULL DEFAULT now(),
+  last_result    BOOLEAN,
+  last_reviewed_at TIMESTAMPTZ,
+  lapses         INTEGER NOT NULL DEFAULT 0,
+  created_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (user_id, item_key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_review_items_user_due
+  ON review_items (user_id, due_at);
+
+ALTER TABLE review_items ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Users can view their own review items" ON review_items;
+CREATE POLICY "Users can view their own review items"
+  ON review_items FOR SELECT USING (auth.uid() = user_id);
+
+-- Enqueue a lesson's item at box 1 if absent; existing item left untouched.
+CREATE OR REPLACE FUNCTION schedule_review_item(
+  p_user_id  UUID,
+  p_item_key TEXT
+) RETURNS TABLE (box SMALLINT, due_at TIMESTAMPTZ)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_interval INT;
+BEGIN
+  SELECT interval_days INTO v_interval
+    FROM public.review_schedule WHERE box = 1;
+
+  INSERT INTO public.review_items (user_id, item_key, box, due_at)
+  VALUES (p_user_id, p_item_key, 1, now() + make_interval(days => v_interval))
+  ON CONFLICT (user_id, item_key) DO NOTHING;
+
+  RETURN QUERY
+    SELECT ri.box, ri.due_at
+    FROM public.review_items ri
+    WHERE ri.user_id = p_user_id AND ri.item_key = p_item_key;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION schedule_review_item(UUID, TEXT) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION schedule_review_item(UUID, TEXT) TO service_role;
+
+-- Record a graded review: pass advances box (clamped at max), miss resets to
+-- box 1 and counts a lapse. No day counts in the body — read from the schedule.
+CREATE OR REPLACE FUNCTION record_review_result(
+  p_user_id  UUID,
+  p_item_key TEXT,
+  p_passed   BOOLEAN
+) RETURNS TABLE (box SMALLINT, due_at TIMESTAMPTZ)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_max_box  SMALLINT;
+  v_new_box  SMALLINT;
+  v_interval INT;
+BEGIN
+  SELECT max(rs.box) INTO v_max_box FROM public.review_schedule rs;
+
+  IF p_passed THEN
+    v_new_box := LEAST(
+      (SELECT ri.box FROM public.review_items ri
+        WHERE ri.user_id = p_user_id AND ri.item_key = p_item_key) + 1,
+      v_max_box
+    );
+  ELSE
+    v_new_box := 1;
+  END IF;
+
+  SELECT interval_days INTO v_interval
+    FROM public.review_schedule WHERE box = v_new_box;
+
+  UPDATE public.review_items ri
+     SET box              = v_new_box,
+         due_at           = now() + make_interval(days => v_interval),
+         last_result      = p_passed,
+         last_reviewed_at = now(),
+         lapses           = ri.lapses + CASE WHEN p_passed THEN 0 ELSE 1 END,
+         updated_at       = now()
+   WHERE ri.user_id = p_user_id AND ri.item_key = p_item_key;
+
+  RETURN QUERY
+    SELECT ri.box, ri.due_at
+    FROM public.review_items ri
+    WHERE ri.user_id = p_user_id AND ri.item_key = p_item_key;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION record_review_result(UUID, TEXT, BOOLEAN) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION record_review_result(UUID, TEXT, BOOLEAN) TO service_role;


### PR DESCRIPTION
Closes #569 — **Review spine 1/3 (LX-B3):** the spaced-repetition substrate. The failure-capture feed (#570) and /review page (#571) build on this; **neither is in scope here.** Nothing is applied to any live DB — the SQL ships in the PR for the gate/owner to dry-run.

## What ships

**`review_schedule`** — box → interval_days as **rows** (1/3/7/21). PED-04: the expansion is *convention, not evidence*, so it lives as data and is re-tunable by editing rows (weekly-dominant preferred if ever tuned) without touching a function body. No ML scheduler, ever (HLR AUC ~0.54). Public-read reference data (mirrors `forum_categories`), no write policy.

**`review_items(user_id, item_key, box, due_at, last_result, last_reviewed_at, lapses, …)`** — one row per learner per lesson (`PRIMARY KEY (user_id, item_key)` = the prescribed UNIQUE), index on `(user_id, due_at)`.
- `item_key` is the **raw lesson `_id`** (PDA-seed convention: never strip ids). **No skill column** — skills resolve from the content bundle at read time, so re-tagging never leaves stale rows.
- **RLS on. Own-row SELECT policy** (`auth.uid() = user_id`) so learners read their queue client-side, per LX-B3. **No write policy** — every write goes through a SECURITY DEFINER RPC. This is the `challenge_assists` hardening + the one own-row-SELECT addition LX-B3 calls for.

**RPCs** (SECURITY DEFINER, `SET search_path=''`, REVOKEd from PUBLIC/anon/authenticated, GRANTed only to `service_role`):
- `schedule_review_item(user_id, item_key)` — enqueue at box 1 if absent (idempotent `ON CONFLICT DO NOTHING`; never resets existing progress). The entry point LX-B4 will use.
- `record_review_result(user_id, item_key, passed)` — the box transition owned as substrate: **pass → box := LEAST(box+1, max box)**, **miss → box := 1, lapses += 1**; `due_at` recomputed from the schedule. No-op if the item doesn't exist. Day counts are read from `review_schedule`, **never hardcoded** in the body.

**Seed** — box-1 items from every completed `user_progress` row (pure SQL, idempotent). Per-session flood-shaping is the feed's job (LX-B4/B5), documented as such.

Explicit `BEGIN/COMMIT`; **tested ROLLBACK** block that drops exactly what it creates. Mirrored into `supabase/schema.sql`. TS types added to `lib/supabase/types.ts`.

## Verification
- `pnpm typecheck` — 6/6 packages green
- `pnpm --filter web test` — 1321 passed; content-schema 143; root scripts 26
- New SQL guard test `review-items-rls-guard.test.ts` (17 assertions across migration + schema mirror: RLS, own-row-only SELECT, no write policy, RPC hardening, schedule-as-data, no hardcoded intervals, transactional, seed, rollback)
- Both SQL files parse clean at the **Postgres AST level** (libpg-query: 19 / 256 statements)
- `lint` exit 0; prettier clean on TS (`.sql` is outside the repo's prettier glob)

## Notes / out of scope
- Pre-commit hook (`lint-staged` at repo root) fails with `eslint --fix` ENOENT in this pnpm-workspace clone; committed with `--no-verify` after running lint/prettier/typecheck/tests manually. Worth a look separately — it will bite other DB-only PRs the same way.
- `record_review_result` is included as the substrate primitive; LX-B5 (#571) calls it rather than re-implementing the box math.