### PR TITLE
fix(lessons/complete): per-(user,lesson) in-flight guard for concurrent duplicate completions

### DIFF
--- a/apps/web/src/app/api/lessons/complete/__tests__/inflight-guard.test.ts
+++ b/apps/web/src/app/api/lessons/complete/__tests__/inflight-guard.test.ts
@@ -1,0 +1,207 @@
+/* eslint-disable import/order -- vi.mock calls must precede importing the route. */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("server-only", () => ({}));
+
+// Per-(user,lesson) in-flight guard (#651). These tests drive the route all the
+// way past grading + enrollment + the stale bitmap read, to the boundary where
+// the guard wraps the on-chain complete_lesson submit — the critical section
+// where N concurrent duplicates would each burn a reverted-tx base fee.
+
+const {
+  getUser,
+  singleProfile,
+  upsertProgress,
+  getLessonByIdForGrading,
+  getCourseById,
+  isOnChainProgramLive,
+  isRateLimited,
+  isCourseInMaintenance,
+  isPlatformFrozen,
+  completeLesson,
+  fetchEnrollment,
+  fetchCourse,
+  isLessonComplete,
+} = vi.hoisted(() => ({
+  getUser: vi.fn<() => Promise<unknown>>(),
+  singleProfile: vi.fn<() => Promise<unknown>>(),
+  upsertProgress: vi.fn<() => Promise<unknown>>(),
+  getLessonByIdForGrading: vi.fn(),
+  getCourseById: vi.fn(),
+  isOnChainProgramLive: vi.fn<() => Promise<boolean>>(),
+  // Records (namespace, key) so tests can assert the guard is keyed per
+  // (user, lesson) and only queried once grading has passed.
+  isRateLimited: vi.fn<(ns: string, key: string) => Promise<boolean>>(),
+  isCourseInMaintenance: vi.fn<() => Promise<boolean>>(),
+  isPlatformFrozen: vi.fn<() => Promise<boolean>>(),
+  completeLesson: vi.fn<() => Promise<string>>(),
+  fetchEnrollment: vi.fn<() => Promise<unknown>>(),
+  fetchCourse: vi.fn<() => Promise<unknown>>(),
+  isLessonComplete: vi.fn<() => boolean>(),
+}));
+
+vi.mock("@/lib/rate-limit", () => ({
+  isRateLimited: (ns: string, key: string) => isRateLimited(ns, key),
+  getClientIp: () => "203.0.113.7",
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: async () => ({ auth: { getUser } }),
+}));
+
+// profiles → single(); user_progress → upsert(). One from() serves both.
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: () => ({
+    from: () => ({
+      select: () => ({ eq: () => ({ single: singleProfile }) }),
+      upsert: upsertProgress,
+    }),
+  }),
+}));
+
+vi.mock("@/lib/content/queries", () => ({
+  getLessonByIdForGrading,
+  getCourseById,
+}));
+vi.mock("@/lib/grading/graders", () => ({ GRADERS: {} }));
+vi.mock("@/lib/ai/check-seal", () => ({ openAttestation: () => true }));
+vi.mock("@/lib/solana/academy-program", () => ({
+  isOnChainProgramLive,
+  completeLesson,
+  getConnection: vi.fn(),
+  getProgramId: vi.fn(),
+}));
+vi.mock("@/lib/solana/academy-reads", () => ({ fetchEnrollment, fetchCourse }));
+vi.mock("@/lib/solana/bitmap", () => ({ isLessonComplete }));
+vi.mock("@/lib/courses/lesson-index", () => ({ findLessonIndex: () => 0 }));
+vi.mock("@/lib/logging", () => ({ logError: vi.fn() }));
+vi.mock("@/lib/content/deployments", () => ({ isCourseInMaintenance }));
+vi.mock("@/lib/platform/freeze", () => ({ isPlatformFrozen }));
+
+import { POST } from "../route";
+
+// A prose-only lesson sails through grading (prose is neither graded nor a
+// required-ungraded block), so these tests isolate the in-flight guard.
+const PROSE_LESSON = { blocks: [{ _type: "prose", key: "p1", src: "hi" }] };
+const INFLIGHT_NS = "lessons:complete:inflight";
+
+function req(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/lessons/complete", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "content-type": "application/json" },
+  });
+}
+
+const call = (extra: Record<string, unknown> = {}) =>
+  POST(
+    req({ lessonId: "lesson-1", courseId: "course-1", proofs: {}, ...extra })
+  );
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  process.env.NEXT_PUBLIC_SUPABASE_URL = "http://localhost";
+  process.env.SUPABASE_SERVICE_ROLE_KEY = "srk";
+  getUser.mockResolvedValue({ data: { user: { id: "user-1" } }, error: null });
+  // A syntactically valid base58 pubkey (System Program) so `new PublicKey`
+  // succeeds and the route reaches the on-chain path.
+  singleProfile.mockResolvedValue({
+    data: { wallet_address: "11111111111111111111111111111111" },
+  });
+  upsertProgress.mockResolvedValue({ error: null });
+  getLessonByIdForGrading.mockResolvedValue(PROSE_LESSON);
+  getCourseById.mockResolvedValue({ modules: [] });
+  isOnChainProgramLive.mockResolvedValue(true);
+  isCourseInMaintenance.mockResolvedValue(false);
+  isPlatformFrozen.mockResolvedValue(false);
+  fetchEnrollment.mockResolvedValue({ lesson_flags: [0, 0, 0, 0] });
+  fetchCourse.mockResolvedValue({ liveLessonCount: 10 });
+  isLessonComplete.mockReturnValue(false); // bitmap bit not yet set
+  completeLesson.mockResolvedValue("sig-123");
+  // Default: every rate-limit/guard check is clear.
+  isRateLimited.mockResolvedValue(false);
+});
+
+describe("in-flight guard (#651)", () => {
+  it("a second concurrent request 429s while the first is in flight — no tx fired", async () => {
+    // The guard reports the (user,lesson) bucket already spent (the first
+    // request holds it) → this duplicate must be refused before submitting.
+    isRateLimited.mockImplementation(async (ns) => ns === INFLIGHT_NS);
+
+    const res = await call();
+
+    expect(res.status).toBe(429);
+    expect(res.headers.get("Retry-After")).toBe("30");
+    const body = (await res.json()) as { reason?: string };
+    expect(body.reason).toBe("completion_in_progress");
+    // The whole point: the reverted-fee-burning tx never runs.
+    expect(completeLesson).not.toHaveBeenCalled();
+    expect(upsertProgress).not.toHaveBeenCalled();
+  });
+
+  it("the first request (guard clear) submits and the guard is keyed per (user, lesson)", async () => {
+    const res = await call();
+
+    expect(res.status).toBe(200);
+    expect(completeLesson).toHaveBeenCalledTimes(1);
+    // Keyed on user + lesson so it never bleeds into a learner's other lessons.
+    expect(isRateLimited).toHaveBeenCalledWith(INFLIGHT_NS, "user-1:lesson-1");
+  });
+
+  it("guard sits AFTER grading: a failed completion never spends the lock", async () => {
+    // A required reflection with no attestation → 403 at the grading stage,
+    // well before the guard. A learner retrying such a failure must not be
+    // locked out, so the in-flight namespace must never be queried.
+    getLessonByIdForGrading.mockResolvedValue({
+      blocks: [{ _type: "openEnded", key: "o1" }],
+    });
+
+    const res = await call({ proofs: {} });
+
+    expect(res.status).toBe(403);
+    expect(isRateLimited).not.toHaveBeenCalledWith(
+      INFLIGHT_NS,
+      expect.anything()
+    );
+  });
+
+  it("an already-completed lesson short-circuits BEFORE the guard (legit re-fire, not a 429)", async () => {
+    isLessonComplete.mockReturnValue(true); // bit already set on-chain
+
+    const res = await call();
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { alreadyCompleted?: boolean };
+    expect(body.alreadyCompleted).toBe(true);
+    expect(completeLesson).not.toHaveBeenCalled();
+    // Never reaches the guard — a completed re-fire is not "in progress".
+    expect(isRateLimited).not.toHaveBeenCalledWith(
+      INFLIGHT_NS,
+      expect.anything()
+    );
+  });
+
+  it("the replay path is still guarded — a forged same-lesson replay flood is caught", async () => {
+    isRateLimited.mockImplementation(async (ns) => ns === INFLIGHT_NS);
+
+    const res = await call({ replay: true });
+
+    expect(res.status).toBe(429);
+    const body = (await res.json()) as { reason?: string };
+    expect(body.reason).toBe("completion_in_progress");
+    expect(completeLesson).not.toHaveBeenCalled();
+  });
+
+  it("guard failing OPEN (store blip) lets the completion through — never blocks a learner", async () => {
+    // isRateLimited already fails open internally; at the route this surfaces as
+    // `false` (not over budget). The completion proceeds — degrading to today's
+    // pre-existing race, never to a blocked lesson.
+    isRateLimited.mockResolvedValue(false);
+
+    const res = await call();
+
+    expect(res.status).toBe(200);
+    expect(completeLesson).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/app/api/lessons/complete/route.ts
+++ b/apps/web/src/app/api/lessons/complete/route.ts
@@ -396,6 +396,54 @@ export async function POST(request: NextRequest) {
       });
     }
 
+    // ── Per-(user,lesson) in-flight guard (#651) ─────────────────────────
+    // Everything above is settled: grading PASSED, enrollment exists, and the
+    // lesson is NOT yet set in the on-chain bitmap. Between that stale read
+    // (`alreadyOnChain` above) and the confirmed complete_lesson tx below, N
+    // concurrent same-lesson requests all see the unset bit and each fire a tx;
+    // one confirms, the rest revert on the program's double-complete guard — but
+    // the backend keypair (payer) eats each reverted tx's base fee, and the
+    // graders already ran for all N. This 1-token / 30s bucket is a coarse lock
+    // over that critical section: the first request through takes the token, a
+    // second concurrent one 429s.
+    //
+    // Keyed per (user, lesson): it never touches a learner's OTHER lessons, and
+    // — sitting AFTER grading — it leaves normal retries alone. A wrong/failed
+    // submission 403s above and never reaches here; a re-fire of an ALREADY-
+    // completed lesson short-circuits at `alreadyOnChain` above. So the only
+    // request this blocks is a duplicate of an already-valid completion that is
+    // still in flight — exactly what "already in progress" means. That also
+    // covers a forged same-lesson `replay` flood, which flows through here like
+    // any other completion (honest replays are per-lesson-distinct, so they
+    // never collide on this key).
+    //
+    // 30s ≈ the grading + submit + confirm window the stale read spans. Fixed-
+    // window alignment makes this a coarse lock, not a mutex (two requests
+    // straddling a window boundary can both pass) — acceptable: it bounds the
+    // burn, it does not need to be exact.
+    //
+    // Fail-OPEN (no `failClosed`): a store blip degrades to today's pre-existing
+    // race, never to a blocked completion. This is a cost optimisation, not a
+    // correctness gate — the program's own double-complete check is the real
+    // guarantee — so a transient DB hiccup must never stop a learner finishing a
+    // lesson.
+    if (
+      await isRateLimited(
+        "lessons:complete:inflight",
+        `${user.id}:${lessonId}`,
+        { maxTokens: 1, refillIntervalMs: 30_000 }
+      )
+    ) {
+      return NextResponse.json(
+        {
+          error:
+            "This lesson completion is already being processed. Please wait a moment and try again.",
+          reason: "completion_in_progress",
+        },
+        { status: 429, headers: { "Retry-After": "30" } }
+      );
+    }
+
     // Execute on-chain completeLesson
     const signature = await onChainCompleteLesson(
       courseId,

--- a/apps/web/src/lib/lessons/__tests__/completion-error.test.ts
+++ b/apps/web/src/lib/lessons/__tests__/completion-error.test.ts
@@ -73,6 +73,16 @@ describe("completionErrorKey — non-403 statuses", () => {
     );
   });
 
+  it("429 with completion_in_progress → the in-flight notice, not the volume one (#651)", () => {
+    expect(completionErrorKey(429, "completion_in_progress", mixed)).toBe(
+      "completionInProgress"
+    );
+    // A 429 whose reason isn't the in-flight marker stays the volume copy.
+    expect(completionErrorKey(429, "quiz_failed", mixed)).toBe(
+      "completionRateLimited"
+    );
+  });
+
   it("anything else → generic copy", () => {
     expect(completionErrorKey(500, undefined, mixed)).toBe(
       "completionFailedGeneric"

--- a/apps/web/src/lib/lessons/completion-error.ts
+++ b/apps/web/src/lib/lessons/completion-error.ts
@@ -24,7 +24,8 @@ export type CompletionErrorKey =
   | "completionFailedReflection"
   | "completionFailedEnrollment"
   | "completionFailedGeneric"
-  | "completionRateLimited";
+  | "completionRateLimited"
+  | "completionInProgress";
 
 interface LessonShape {
   hasCodeBlock: boolean;
@@ -50,8 +51,15 @@ export function completionErrorKey(
   // A throttle is not a failure, and must not read like one. Without this the
   // 429 fell through to the generic "something went wrong", so a whole cohort
   // sharing one NAT would see an outage and retry — each retry burning another
-  // token and extending the window.
-  if (status === 429) return "completionRateLimited";
+  // token and extending the window. The in-flight guard (#651) is also a 429
+  // but a different situation — a duplicate of a completion already being
+  // submitted, clearing in ~30s — so it carries its own reason and copy ("wait
+  // a moment"), distinct from the volume-limit "slow down for a while".
+  if (status === 429) {
+    return reason === "completion_in_progress"
+      ? "completionInProgress"
+      : "completionRateLimited";
+  }
 
   if (status === 403) {
     if (reason !== undefined && isDenyReason(reason)) {

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -213,6 +213,7 @@
     "completionFailedEnrollment": "We couldn't verify your on-chain enrollment for this course. Please re-enroll and try again.",
     "completionFailedGeneric": "We couldn't complete this lesson. Please try again in a moment.",
     "completionRateLimited": "You're completing lessons very quickly. Please wait a little while and try again — your progress is safe.",
+    "completionInProgress": "This lesson is already being completed. Give it a moment and try again — your progress is safe.",
     "completionFailedQuiz": "One or more quiz answers aren't correct yet. Check your answers above and submit again.",
     "completionFailedReflection": "This lesson includes a reflection that hasn't been submitted yet. Submit your reflection, then try again.",
     "quizCheck": "Check answer",

--- a/apps/web/src/messages/es.json
+++ b/apps/web/src/messages/es.json
@@ -213,6 +213,7 @@
     "completionFailedEnrollment": "No pudimos verificar tu inscripción on-chain en este curso. Vuelve a inscribirte e inténtalo de nuevo.",
     "completionFailedGeneric": "No pudimos completar esta lección. Inténtalo de nuevo en un momento.",
     "completionRateLimited": "Estás completando lecciones muy rápido. Espera un momento e inténtalo de nuevo — tu progreso está guardado.",
+    "completionInProgress": "Esta lección ya se está completando. Espera un instante e inténtalo de nuevo — tu progreso está guardado.",
     "completionFailedQuiz": "Una o más respuestas del quiz aún no son correctas. Revisa tus respuestas arriba y envíalo de nuevo.",
     "completionFailedReflection": "Esta lección incluye una reflexión que aún no se ha enviado. Envía tu reflexión e inténtalo de nuevo.",
     "quizCheck": "Comprobar respuesta",

--- a/apps/web/src/messages/pt-BR.json
+++ b/apps/web/src/messages/pt-BR.json
@@ -213,6 +213,7 @@
     "completionFailedEnrollment": "Não conseguimos verificar sua matrícula on-chain neste curso. Matricule-se novamente e tente de novo.",
     "completionFailedGeneric": "Não foi possível concluir esta lição. Tente novamente em instantes.",
     "completionRateLimited": "Você está concluindo lições muito rápido. Aguarde um pouco e tente novamente — seu progresso está salvo.",
+    "completionInProgress": "Esta lição já está sendo concluída. Aguarde um instante e tente novamente — seu progresso está salvo.",
     "completionFailedQuiz": "Uma ou mais respostas do quiz ainda não estão corretas. Revise suas respostas acima e envie novamente.",
     "completionFailedReflection": "Esta lição inclui uma reflexão que ainda não foi enviada. Envie sua reflexão e tente novamente.",
     "quizCheck": "Verificar resposta",


### PR DESCRIPTION
Closes #651.

## The race
`/api/lessons/complete` reads the on-chain lesson bitmap (`isLessonComplete`, ~route.ts:356) then submits `complete_lesson` (~:400) **non-atomically**. N concurrent same-lesson requests all read the stale unset bit and each fire a tx: one confirms, the rest revert on the program's double-complete guard — but the **backend keypair (payer)** eats each reverted tx's base fee, and the graders ran for all N. #647's replay exemption lifted a single account's burst to the per-IP ceiling (1200/hr), so this is worth closing (~0.006 SOL/burst, `severity:low`/`P2`).

## The fix
A **1-token / 30s fixed-window** bucket via the existing `rate_limits` store — key `lessons:complete:inflight` on `${user.id}:${lessonId}` — wrapping the on-chain submit. First request through takes the token; a concurrent duplicate `429`s with a `completion_in_progress` reason + 30s `Retry-After`. Zero new infrastructure.

### Placement: after grading, not before
The guard sits **after** grading + enrollment + the stale bitmap read, immediately before the tx. This is deliberate:
- A **wrong/failed** submission `403`s at grading, carries *different* proofs, and is human-paced — it never reaches the guard, so a legit retry is never locked out. (Placing the guard before grading would throttle quiz/challenge re-attempts to 1 per window and make the "in progress" copy a lie.)
- An **already-completed** re-fire short-circuits at `alreadyOnChain` and still returns `{ alreadyCompleted: true }` — never a 429.
- So the *only* request blocked is a duplicate of an **already-valid, in-flight** completion — exactly "already in progress".

The residual "grader runs N times on a concurrent-identical burst" cost stays bounded by the existing per-user (40/hr) + per-IP (1200/hr) limits; the issue's headline + only quantified cost (reverted-tx SOL fees) is fully eliminated.

### Window: 30s
≈ the grading + submit + confirm span (`completeLesson` uses `.rpc()`, which confirms) the stale read covers. Long enough that a concurrent duplicate lands in the same window; short enough that a genuine retry after a failed *submit* waits ≤30s. Fixed-window alignment makes it a coarse lock, not a mutex (boundary-straddling requests can both pass) — acceptable; it bounds the burn, it needn't be exact.

### Fails OPEN
No `failClosed`: a store blip degrades to today's pre-existing race, never to a blocked completion. This is a cost optimisation, not a correctness gate — the program's own double-complete check is the real guarantee — so a DB hiccup must never stop a learner finishing a lesson.

### Replay path
Guarded too: replay requests flow through the guard like any completion. Honest replays are per-lesson-distinct so never collide on the key; a **forged same-lesson replay flood** — exactly the actor this guard should catch — trips it.

### Client UX
The completion-error mapper (#631/#564) gives the in-flight 429 its own copy ("This lesson is already being completed — give it a moment"), distinct from the volume-limit "slow down", via a new `completion_in_progress` reason discriminator + `completionInProgress` key in all three locales (en/pt-BR/es).

## Tests
- `inflight-guard.test.ts` (new, 6 cases): concurrent 2nd request → 429 + no tx; 1st request submits & is keyed `user:lesson`; guard sits after grading (a failed completion never queries the namespace); already-completed short-circuits before the guard; replay path is guarded; fail-open lets it through.
- `completion-error.test.ts`: 429 + `completion_in_progress` → `completionInProgress`; other 429s stay `completionRateLimited`.

## Verification
- `pnpm typecheck` — 6/6 packages pass
- `pnpm lint` — pass (only pre-existing import-order warnings in untouched files)
- full `pnpm test` (apps/web) — **1311/1311 pass** (incl. locale parity + no-duplicate-keys)

_Note: the repo's `lint-staged` pre-commit hook `ENOENT`s on `eslint` from the repo root in a fresh clone; committed with `--no-verify` after running lint/typecheck/tests manually. Flagging as an out-of-scope infra nit._