### PR TITLE
feat(gamification): surprise XP bonuses + skill mastery panel

### DIFF
--- a/apps/web/src/app/[locale]/(platform)/dashboard/page.tsx
+++ b/apps/web/src/app/[locale]/(platform)/dashboard/page.tsx
@@ -13,6 +13,7 @@ import {
   type ContinueCardTarget,
 } from "@/components/dashboard/continue-card";
 import { CurrentCoursesSection } from "@/components/dashboard/current-courses-section";
+import { MasteryPanel } from "@/components/dashboard/mastery-panel";
 import { NameRevealDialog } from "@/components/dashboard/name-reveal-dialog";
 import { RecommendedCoursesSection } from "@/components/dashboard/recommended-courses-section";
 
@@ -118,6 +119,9 @@ export default function DashboardPage() {
         currentCourses={data.currentCourses}
         userId={data.userId}
       />
+
+      {/* ═══ Skill Mastery (LX-B16) ═══ */}
+      <MasteryPanel skills={data.masterySkills} />
 
       {/* ═══ Activity ═══ */}
       <ActivitySection recentActivity={data.recentActivity} />

--- a/apps/web/src/components/dashboard/mastery-panel.tsx
+++ b/apps/web/src/components/dashboard/mastery-panel.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import type { MasterySkill } from "@/lib/gamification/mastery";
+import { Card, CardContent } from "@/components/ui/card";
+
+interface MasteryPanelProps {
+  /** Per-skill progress derived from completed lessons × their skill tags. */
+  skills: MasterySkill[];
+}
+
+/**
+ * "Skill mastery" dashboard slot (LX-B16). Per-skill progress bars derived from
+ * the learner's completed lessons and each lesson's skill tags. Renders nothing
+ * until the learner has practiced at least one tagged skill.
+ */
+export function MasteryPanel({ skills }: MasteryPanelProps) {
+  const t = useTranslations("mastery");
+
+  if (skills.length === 0) return null;
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h2 className="font-display text-[24px] font-extrabold">
+          {t("title")}
+        </h2>
+        <p className="mt-1 text-sm text-text-3">{t("caption")}</p>
+      </div>
+      <Card className="shadow-[var(--shadow)]">
+        <CardContent className="flex flex-col gap-4 p-6">
+          {skills.map((skill) => (
+            <div key={skill.slug} className="flex flex-col gap-1.5">
+              <div className="flex items-baseline justify-between gap-2">
+                <span className="text-sm font-semibold">{skill.label}</span>
+                <span className="text-xs tabular-nums text-text-3">
+                  {t("lessonsRatio", {
+                    completed: skill.completed,
+                    total: skill.total,
+                  })}
+                </span>
+              </div>
+              <div
+                className="bg-surface-3 h-2 overflow-hidden rounded-full"
+                role="progressbar"
+                aria-valuenow={skill.progress}
+                aria-valuemin={0}
+                aria-valuemax={100}
+                aria-label={t("progressLabel", {
+                  skill: skill.label,
+                  completed: skill.completed,
+                  total: skill.total,
+                })}
+              >
+                <div
+                  className="h-full rounded-full bg-gradient-to-r from-solana-purple to-solana-green transition-[width]"
+                  style={{ width: `${skill.progress}%` }}
+                />
+              </div>
+            </div>
+          ))}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/src/components/gamification/gamification-overlays.tsx
+++ b/apps/web/src/components/gamification/gamification-overlays.tsx
@@ -6,6 +6,7 @@ import { CertificatePopup } from "@/components/gamification/certificate-popup";
 import { LevelUpPopup } from "@/components/gamification/level-up-popup";
 import { useGamificationEvents } from "@/hooks/use-gamification-events";
 import { ToastContainer } from "@/components/ui/toast-container";
+import { SurpriseBonusToastListener } from "@/components/gamification/surprise-bonus-toast";
 import { BankedProgressReplay } from "@/components/lessons/banked-progress-replay";
 
 export function GamificationOverlays() {
@@ -18,6 +19,8 @@ export function GamificationOverlays() {
     <>
       {/* Toast container always renders — works for auth and non-auth contexts */}
       <ToastContainer />
+      {/* Localizes + shows the LX-B15 surprise-bonus toast (informational tier) */}
+      <SurpriseBonusToastListener />
       {/* Replays anonymously-banked completions once signed in (LX-A4c). */}
       <BankedProgressReplay />
       {!userId ? null : (

--- a/apps/web/src/components/gamification/surprise-bonus-toast.tsx
+++ b/apps/web/src/components/gamification/surprise-bonus-toast.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { useEffect } from "react";
+import { useTranslations } from "next-intl";
+import { dispatchToast } from "@/components/ui/toast-container";
+
+const SURPRISE_BONUS_EVENT = "superteam:surprise-bonus";
+
+/**
+ * Announce a granted surprise XP bonus (LX-B15). Fired from the Realtime
+ * gamification hook AFTER the bonus lands server-side — never before, so the
+ * reward stays genuinely unexpected. Localization lives in the mounted
+ * listener below, keeping the hook itself provider-free.
+ */
+export function dispatchSurpriseBonus(amount: number): void {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(
+    new CustomEvent(SURPRISE_BONUS_EVENT, { detail: { amount } })
+  );
+}
+
+/**
+ * Renders nothing; listens for surprise-bonus events and shows an informational
+ * toast (the LX-B15 "none" celebration tier — a calm success toast, never
+ * confetti). Mount once inside the intl provider.
+ */
+export function SurpriseBonusToastListener() {
+  const t = useTranslations("gamification");
+
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const { amount } = (e as CustomEvent<{ amount: number }>).detail;
+      dispatchToast(t("surpriseBonus", { amount }), "success");
+    };
+    window.addEventListener(SURPRISE_BONUS_EVENT, handler);
+    return () => window.removeEventListener(SURPRISE_BONUS_EVENT, handler);
+  }, [t]);
+
+  return null;
+}

--- a/apps/web/src/hooks/use-dashboard-data.ts
+++ b/apps/web/src/hooks/use-dashboard-data.ts
@@ -12,7 +12,9 @@ import {
   getLessonsByIds,
   getRecommendedCourses,
   getAllAchievements,
+  getAllLessonSkills,
 } from "@/lib/content/client-queries";
+import { deriveMastery, type MasterySkill } from "@/lib/gamification/mastery";
 import type {
   RecommendedCourse,
   DeployedAchievement,
@@ -73,6 +75,8 @@ export interface DashboardData {
   /** Next-incomplete-lesson derivation for the hero Continue card (LX-B2). */
   continueTarget: ContinueTarget | null;
   recommendedCourses: RecommendedCourse[];
+  /** Per-skill mastery progress derived from completed lessons × skill tags (LX-B16). */
+  masterySkills: MasterySkill[];
   recentActivity: ActivityItem[];
   username: string;
   userId: string;
@@ -98,6 +102,7 @@ export function useDashboardData(
     currentCourses: [],
     continueTarget: null,
     recommendedCourses: [],
+    masterySkills: [],
     recentActivity: [],
     username: "Builder",
     userId: "",
@@ -235,6 +240,7 @@ export function useDashboardData(
           /^Course completion bonus:\s*(.+)$/;
         const dailyQuestPattern = /^daily_quest:(.+)$/;
         const communityPattern = /^community:(.+)$/;
+        const surpriseBonusPattern = /^surprise_bonus:(.+)$/;
         const lessonIdsFromTx: string[] = [];
         const courseCompleteIdsFromTx: string[] = [];
         for (const tx of transactions ?? []) {
@@ -285,17 +291,30 @@ export function useDashboardData(
         const excludeFromRecommended = [
           ...new Set([...allEnrolledIds, ...mintedCourseIds]),
         ];
-        const [courseSummaries, recommended, achievementCatalog, lessonOrders] =
-          await Promise.all([
-            allCourseIdsToFetch.length > 0
-              ? getCoursesByIds(allCourseIdsToFetch)
-              : Promise.resolve([]),
-            getRecommendedCourses(excludeFromRecommended),
-            getAllAchievements(),
-            allEnrolledIds.length > 0
-              ? getCourseLessonOrders(allEnrolledIds)
-              : Promise.resolve([]),
-          ]);
+        const [
+          courseSummaries,
+          recommended,
+          achievementCatalog,
+          lessonOrders,
+          allLessonSkills,
+        ] = await Promise.all([
+          allCourseIdsToFetch.length > 0
+            ? getCoursesByIds(allCourseIdsToFetch)
+            : Promise.resolve([]),
+          getRecommendedCourses(excludeFromRecommended),
+          getAllAchievements(),
+          allEnrolledIds.length > 0
+            ? getCourseLessonOrders(allEnrolledIds)
+            : Promise.resolve([]),
+          // Mastery is a secondary P2 panel — never let it fail the dashboard.
+          getAllLessonSkills().catch(() => []),
+        ]);
+
+        // Per-skill mastery from completed lessons × their skill tags (LX-B16).
+        const masterySkills = deriveMastery(
+          (progressRows ?? []).map((r) => r.lesson_id),
+          allLessonSkills
+        );
         // Build a lookup map: course _id -> Sanity data
         const courseMap = new Map(courseSummaries.map((c) => [c._id, c]));
 
@@ -471,6 +490,15 @@ export function useDashboardData(
               txSignature: tx.tx_signature ?? null,
               href: "/community",
             });
+          } else if (surpriseBonusPattern.exec(tx.reason)?.[1]) {
+            raw.push({
+              type: "xp_other",
+              action: tDash("surpriseBonus"),
+              xp: tx.amount,
+              time: tx.created_at ?? new Date().toISOString(),
+              txSignature: tx.tx_signature ?? null,
+              href: null,
+            });
           } else {
             raw.push({
               type: "xp_other",
@@ -556,6 +584,7 @@ export function useDashboardData(
           currentCourses,
           continueTarget,
           recommendedCourses: recommended,
+          masterySkills,
           recentActivity,
           username: profile?.username ?? "Builder",
           userId: authUserId,

--- a/apps/web/src/hooks/use-gamification-events.ts
+++ b/apps/web/src/hooks/use-gamification-events.ts
@@ -3,12 +3,15 @@
 import { useEffect, useRef } from "react";
 import { trackCredentialMinted } from "@/lib/analytics/events";
 import { createClient } from "@/lib/supabase/client";
+import { celebrate } from "@/lib/gamification/celebration";
+import { isSurpriseBonusReason } from "@/lib/gamification/surprise-bonus";
 import {
   dispatchAchievementUnlock,
   dispatchAchievementXp,
 } from "@/components/gamification/achievement-popup";
 import { dispatchCertificateMinted } from "@/components/gamification/certificate-popup";
 import { dispatchLevelUp } from "@/components/gamification/level-up-popup";
+import { dispatchSurpriseBonus } from "@/components/gamification/surprise-bonus-toast";
 
 let xpEventCounter = 0;
 
@@ -116,6 +119,17 @@ export function useGamificationEvents(userId: string | undefined) {
 
           // Daily quest XP → suppress popup (quests panel already shows the reward)
           if (row.reason?.startsWith("daily_quest:")) return;
+
+          // Surprise bonus (LX-B15) → informational toast (never confetti). The
+          // reward only surfaces here, AFTER it is granted server-side — there
+          // is no pre-announcement anywhere in the UI. Localization happens in
+          // the mounted SurpriseBonusToastListener (inside the intl provider).
+          if (row.reason && isSurpriseBonusReason(row.reason)) {
+            celebrate("surprise-bonus");
+            dispatchSurpriseBonus(amount);
+            dispatchXpGain(amount);
+            return;
+          }
 
           dispatchXpGain(amount);
         }

--- a/apps/web/src/lib/gamification/__tests__/celebration.test.ts
+++ b/apps/web/src/lib/gamification/__tests__/celebration.test.ts
@@ -50,6 +50,7 @@ describe("celebrationTierFor — the LX-B11 tier map", () => {
     "deploy-success": "medium",
     "level-up": "popup",
     "credential-mint": "full",
+    "surprise-bonus": "none",
   };
 
   for (const [event, tier] of Object.entries(expected)) {

--- a/apps/web/src/lib/gamification/__tests__/mastery.test.ts
+++ b/apps/web/src/lib/gamification/__tests__/mastery.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { deriveMastery, labelForSkill } from "@/lib/gamification/mastery";
+
+const catalog = [
+  { _id: "l1", skills: ["pdas", "account-model"] },
+  { _id: "l2", skills: ["pdas"] },
+  { _id: "l3", skills: ["pdas", "cpi"] },
+  { _id: "l4", skills: ["cpi"] },
+  { _id: "l5", skills: ["anchor"] },
+];
+
+describe("labelForSkill", () => {
+  it("humanizes kebab-case slugs", () => {
+    expect(labelForSkill("account-model")).toBe("Account Model");
+    expect(labelForSkill("pdas")).toBe("Pdas");
+  });
+});
+
+describe("deriveMastery", () => {
+  it("counts completed vs total lessons per skill and computes progress", () => {
+    // Completed l1, l2 → pdas 2/3, account-model 1/1
+    const result = deriveMastery(["l1", "l2"], catalog);
+    const pdas = result.find((s) => s.slug === "pdas");
+    const account = result.find((s) => s.slug === "account-model");
+    expect(pdas).toMatchObject({ completed: 2, total: 3, progress: 67 });
+    expect(account).toMatchObject({ completed: 1, total: 1, progress: 100 });
+  });
+
+  it("omits skills the learner has not started", () => {
+    const result = deriveMastery(["l5"], catalog);
+    expect(result.map((s) => s.slug)).toEqual(["anchor"]);
+    // cpi/pdas exist in the catalog but were never completed → absent
+    expect(result.some((s) => s.slug === "cpi")).toBe(false);
+  });
+
+  it("ranks by lessons completed, then progress, and caps the list", () => {
+    const result = deriveMastery(["l1", "l2", "l3", "l4"], catalog, {
+      maxSkills: 2,
+    });
+    expect(result).toHaveLength(2);
+    // pdas: 3 completed, cpi: 2 completed → pdas first
+    expect(result[0]?.slug).toBe("pdas");
+    expect(result[1]?.slug).toBe("cpi");
+  });
+
+  it("returns an empty list when nothing is completed", () => {
+    expect(deriveMastery([], catalog)).toEqual([]);
+  });
+
+  it("attributes a completed lesson only to its own skills, never a course smear", () => {
+    // l4 carries only cpi; completing it must not credit pdas
+    const result = deriveMastery(["l4"], catalog);
+    expect(result.map((s) => s.slug)).toEqual(["cpi"]);
+    expect(result[0]).toMatchObject({ completed: 1, total: 2, progress: 50 });
+  });
+});

--- a/apps/web/src/lib/gamification/__tests__/surprise-bonus.test.ts
+++ b/apps/web/src/lib/gamification/__tests__/surprise-bonus.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi } from "vitest";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@/lib/supabase/types";
+import {
+  SURPRISE_BONUS_AMOUNTS,
+  SURPRISE_BONUS_PROBABILITY,
+  SURPRISE_BONUS_REASON_PREFIX,
+  SURPRISE_BONUS_WEEKLY_CAP,
+  isSurpriseBonusReason,
+  maybeAwardSurpriseBonus,
+  rollSurpriseBonusXp,
+  startOfIsoWeekUtc,
+  surpriseBonusReason,
+} from "@/lib/gamification/surprise-bonus";
+
+/** Deterministic RNG that returns each value in sequence. */
+function seq(values: number[]): () => number {
+  let i = 0;
+  return () => values[i++] ?? 1;
+}
+
+/**
+ * Minimal chainable Supabase mock. The count query resolves to `weekCount`;
+ * `rpc("award_xp", …)` resolves to `{ error: rpcError }` and records its args.
+ */
+function makeSupabaseMock({
+  weekCount = 0,
+  countError = null as { message: string } | null,
+  rpcError = null as { message: string } | null,
+} = {}) {
+  const rpc = vi.fn().mockResolvedValue({ error: rpcError });
+  const builder = {
+    select: vi.fn(() => builder),
+    eq: vi.fn(() => builder),
+    like: vi.fn(() => builder),
+    gte: vi.fn(() => Promise.resolve({ count: weekCount, error: countError })),
+  };
+  const from = vi.fn(() => builder);
+  const client = { from, rpc } as unknown as SupabaseClient<Database>;
+  return { client, from, rpc, builder };
+}
+
+describe("rollSurpriseBonusXp", () => {
+  it("returns null when the roll is at or above the probability threshold", () => {
+    expect(rollSurpriseBonusXp(seq([SURPRISE_BONUS_PROBABILITY]))).toBeNull();
+    expect(rollSurpriseBonusXp(seq([0.99]))).toBeNull();
+  });
+
+  it("returns an amount from the fixed ladder when the roll lands", () => {
+    // gate passes (0.01 < prob), amount index 0 → first ladder value
+    expect(rollSurpriseBonusXp(seq([0.01, 0]))).toBe(SURPRISE_BONUS_AMOUNTS[0]);
+    // amount index at the top of the ladder
+    expect(rollSurpriseBonusXp(seq([0.01, 0.999]))).toBe(
+      SURPRISE_BONUS_AMOUNTS[SURPRISE_BONUS_AMOUNTS.length - 1]
+    );
+  });
+
+  it("only ever returns capped, small amounts (well under award_xp's 2000 ceiling)", () => {
+    for (const amount of SURPRISE_BONUS_AMOUNTS) {
+      expect(amount).toBeGreaterThan(0);
+      expect(amount).toBeLessThanOrEqual(50);
+    }
+  });
+});
+
+describe("startOfIsoWeekUtc", () => {
+  it("returns the Monday 00:00 UTC of the containing week", () => {
+    // 2026-07-26 is a Sunday → week starts Monday 2026-07-20
+    const start = startOfIsoWeekUtc(new Date("2026-07-26T18:30:00Z"));
+    expect(start.toISOString()).toBe("2026-07-20T00:00:00.000Z");
+    // A Monday maps to itself
+    const monday = startOfIsoWeekUtc(new Date("2026-07-20T09:00:00Z"));
+    expect(monday.toISOString()).toBe("2026-07-20T00:00:00.000Z");
+  });
+});
+
+describe("reason format", () => {
+  it("prefixes the lesson id and round-trips through the detector", () => {
+    const reason = surpriseBonusReason("lesson-pdas-1");
+    expect(reason).toBe(`${SURPRISE_BONUS_REASON_PREFIX}lesson-pdas-1`);
+    expect(isSurpriseBonusReason(reason)).toBe(true);
+    expect(isSurpriseBonusReason("Completed lesson: lesson-pdas-1")).toBe(
+      false
+    );
+  });
+});
+
+describe("maybeAwardSurpriseBonus", () => {
+  const base = {
+    userId: "user-1",
+    lessonId: "lesson-pdas-1",
+    txSignature: "sig-abc",
+  };
+
+  it("grants nothing — and touches no storage — when the roll misses", async () => {
+    // Non-predictability: a missed roll writes NOTHING, so no bonus artifact
+    // can ever exist before it is granted. There is no pre-announcement path.
+    const { client, from, rpc } = makeSupabaseMock();
+    const result = await maybeAwardSurpriseBonus(client, {
+      ...base,
+      rng: seq([0.9]),
+    });
+    expect(result).toBeNull();
+    expect(from).not.toHaveBeenCalled();
+    expect(rpc).not.toHaveBeenCalled();
+  });
+
+  it("awards via award_xp with the correct amount, reason and idempotency key when under the weekly cap", async () => {
+    const { client, rpc } = makeSupabaseMock({ weekCount: 0 });
+    const result = await maybeAwardSurpriseBonus(client, {
+      ...base,
+      rng: seq([0.01, 0]),
+    });
+    expect(result).toBe(SURPRISE_BONUS_AMOUNTS[0]);
+    expect(rpc).toHaveBeenCalledWith("award_xp", {
+      p_user_id: "user-1",
+      p_amount: SURPRISE_BONUS_AMOUNTS[0],
+      p_reason: `${SURPRISE_BONUS_REASON_PREFIX}lesson-pdas-1`,
+      p_idempotency_key: "sig-abc:SurpriseBonus",
+      p_tx_signature: "sig-abc",
+    });
+  });
+
+  it("enforces the weekly cap — no award once the cap is reached", async () => {
+    const { client, rpc } = makeSupabaseMock({
+      weekCount: SURPRISE_BONUS_WEEKLY_CAP,
+    });
+    const result = await maybeAwardSurpriseBonus(client, {
+      ...base,
+      rng: seq([0.01, 0]),
+    });
+    expect(result).toBeNull();
+    expect(rpc).not.toHaveBeenCalled();
+  });
+
+  it("fail-safe: does not grant when the cap count query errors", async () => {
+    const { client, rpc } = makeSupabaseMock({
+      countError: { message: "db down" },
+    });
+    const result = await maybeAwardSurpriseBonus(client, {
+      ...base,
+      rng: seq([0.01, 0]),
+    });
+    expect(result).toBeNull();
+    expect(rpc).not.toHaveBeenCalled();
+  });
+
+  it("throws when the award itself fails, so the caller can log it", async () => {
+    const { client } = makeSupabaseMock({ rpcError: { message: "rpc boom" } });
+    await expect(
+      maybeAwardSurpriseBonus(client, { ...base, rng: seq([0.01, 0]) })
+    ).rejects.toThrow("rpc boom");
+  });
+});

--- a/apps/web/src/lib/gamification/celebration.ts
+++ b/apps/web/src/lib/gamification/celebration.ts
@@ -20,7 +20,8 @@ export type CelebrationEvent =
   | "challenge-pass"
   | "deploy-success"
   | "level-up"
-  | "credential-mint";
+  | "credential-mint"
+  | "surprise-bonus";
 
 export type CelebrationTier = "none" | "popup" | "medium" | "full";
 
@@ -30,6 +31,9 @@ export const CELEBRATION_TIERS: Record<CelebrationEvent, CelebrationTier> = {
   "deploy-success": "medium",
   "level-up": "popup",
   "credential-mint": "full",
+  // A surprise bonus (LX-B15) is an informational moment — a calm toast, never
+  // confetti. Its delight is the unexpectedness of the reward, not spectacle.
+  "surprise-bonus": "none",
 } as const;
 
 export function celebrationTierFor(event: CelebrationEvent): CelebrationTier {

--- a/apps/web/src/lib/gamification/mastery.ts
+++ b/apps/web/src/lib/gamification/mastery.ts
@@ -1,0 +1,69 @@
+/**
+ * Per-skill mastery derivation (LX-B16, UIUX R16/F30).
+ *
+ * Derives skill-level *progress* from completed lessons × their own skill tags
+ * (#498, bundle-resolved). Distinct from the profile Skills radar, which shows
+ * a learner's strongest skills normalized against each other: mastery shows
+ * absolute progress — how many of the lessons carrying a skill the learner has
+ * completed. Competence-framed (LX-B10 / #550): a count of lessons practiced,
+ * never a spendable balance.
+ *
+ * Pure and DB-free — unit-testable without Supabase or the content store.
+ */
+
+export interface MasterySkill {
+  slug: string;
+  label: string;
+  /** Completed lessons carrying this skill. */
+  completed: number;
+  /** Total catalog lessons carrying this skill. */
+  total: number;
+  /** completed / total as a 0-100 percentage. */
+  progress: number;
+}
+
+/** Humanize a kebab-case skill slug: "account-model" → "Account Model". */
+export function labelForSkill(slug: string): string {
+  return slug
+    .split("-")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+/**
+ * Tally per-skill progress. For every catalog lesson, its `total` counts once
+ * per skill it carries; if that lesson is completed, its `completed` counts
+ * too. Only skills the learner has started (completed ≥ 1) are returned,
+ * ranked by lessons completed then progress, capped at `maxSkills`.
+ */
+export function deriveMastery(
+  completedLessonIds: readonly string[],
+  allLessonSkills: readonly { _id: string; skills: string[] }[],
+  { maxSkills = 8 }: { maxSkills?: number } = {}
+): MasterySkill[] {
+  const completedSet = new Set(completedLessonIds);
+  const totals = new Map<string, number>();
+  const completed = new Map<string, number>();
+
+  for (const lesson of allLessonSkills) {
+    const isDone = completedSet.has(lesson._id);
+    for (const skill of lesson.skills) {
+      totals.set(skill, (totals.get(skill) ?? 0) + 1);
+      if (isDone) completed.set(skill, (completed.get(skill) ?? 0) + 1);
+    }
+  }
+
+  return [...completed.entries()]
+    .map(([slug, done]) => {
+      const total = totals.get(slug) ?? done;
+      return {
+        slug,
+        label: labelForSkill(slug),
+        completed: done,
+        total,
+        progress: total > 0 ? Math.round((done / total) * 100) : 0,
+      };
+    })
+    .sort((a, b) => b.completed - a.completed || b.progress - a.progress)
+    .slice(0, maxSkills);
+}

--- a/apps/web/src/lib/gamification/surprise-bonus.ts
+++ b/apps/web/src/lib/gamification/surprise-bonus.ts
@@ -1,0 +1,112 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@/lib/supabase/types";
+
+/**
+ * Surprise XP delight bonuses (LX-B15, pedagogy roadmap #8b).
+ *
+ * Unexpected rewards are the only reward form that does NOT undermine intrinsic
+ * motivation (unified spec §2.1 / PED-10, d≈0.01). To keep that property the
+ * bonus must be genuinely unpredictable: the trigger lives ONLY on the
+ * server-side award path (the Helius `LessonCompleted` handler), rolls a
+ * server-side RNG, is never pre-announced in any UI, follows no schedule a
+ * learner could learn, and is capped per user per week. It rides the existing
+ * `award_xp` rails unchanged — no schema change, no new SECURITY DEFINER
+ * function; the weekly cap is enforced by counting prior bonus rows already in
+ * `xp_transactions`.
+ */
+
+/** Probability that a completed lesson earns a surprise bonus. Server-only. */
+export const SURPRISE_BONUS_PROBABILITY = 0.08;
+
+/** Candidate bonus amounts (small, well under award_xp's 2000 per-award cap). */
+export const SURPRISE_BONUS_AMOUNTS = [10, 15, 20, 25, 30, 35, 40] as const;
+
+/** Most surprise bonuses a single user can receive in one ISO week. */
+export const SURPRISE_BONUS_WEEKLY_CAP = 3;
+
+/** Reason prefix — machine-readable, produced ONLY by the server award path. */
+export const SURPRISE_BONUS_REASON_PREFIX = "surprise_bonus:";
+
+/**
+ * Roll for a surprise bonus. Returns the XP amount when the roll lands, else
+ * `null`. `rng` is injectable so the roll is deterministic under test; in
+ * production it is `Math.random`, evaluated server-side where no client can
+ * observe or probe it.
+ */
+export function rollSurpriseBonusXp(
+  rng: () => number = Math.random
+): number | null {
+  if (rng() >= SURPRISE_BONUS_PROBABILITY) return null;
+  const index = Math.min(
+    SURPRISE_BONUS_AMOUNTS.length - 1,
+    Math.floor(rng() * SURPRISE_BONUS_AMOUNTS.length)
+  );
+  return SURPRISE_BONUS_AMOUNTS[index] ?? SURPRISE_BONUS_AMOUNTS[0];
+}
+
+/** Start (Monday 00:00 UTC) of the ISO week containing `now`. */
+export function startOfIsoWeekUtc(now: Date): Date {
+  const d = new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate())
+  );
+  const daysSinceMonday = (d.getUTCDay() + 6) % 7;
+  d.setUTCDate(d.getUTCDate() - daysSinceMonday);
+  return d;
+}
+
+export function surpriseBonusReason(lessonId: string): string {
+  return `${SURPRISE_BONUS_REASON_PREFIX}${lessonId}`;
+}
+
+export function isSurpriseBonusReason(reason: string): boolean {
+  return reason.startsWith(SURPRISE_BONUS_REASON_PREFIX);
+}
+
+interface SurpriseBonusInput {
+  userId: string;
+  lessonId: string;
+  txSignature: string;
+  /** Injectable RNG for tests; production uses `Math.random`. */
+  rng?: () => number;
+}
+
+/**
+ * Server-side surprise-bonus award. Rolls, enforces the weekly cap by counting
+ * this week's existing bonus rows, and awards via `award_xp` when eligible.
+ * Returns the awarded amount, or `null` when no bonus was granted.
+ *
+ * Fail-safe: if the cap cannot be verified (count query error) NO bonus is
+ * granted — the function never over-grants. Idempotency is keyed on the
+ * lesson-completion signature so a webhook retry can never double-award.
+ * Throws only if the award itself fails, so the caller can log it as a
+ * non-fatal side effect.
+ */
+export async function maybeAwardSurpriseBonus(
+  supabase: SupabaseClient<Database>,
+  { userId, lessonId, txSignature, rng = Math.random }: SurpriseBonusInput
+): Promise<number | null> {
+  const amount = rollSurpriseBonusXp(rng);
+  if (amount === null) return null;
+
+  const weekStart = startOfIsoWeekUtc(new Date());
+  const { count, error: countError } = await supabase
+    .from("xp_transactions")
+    .select("id", { count: "exact", head: true })
+    .eq("user_id", userId)
+    .like("reason", `${SURPRISE_BONUS_REASON_PREFIX}%`)
+    .gte("created_at", weekStart.toISOString());
+
+  if (countError) return null;
+  if ((count ?? 0) >= SURPRISE_BONUS_WEEKLY_CAP) return null;
+
+  const { error } = await supabase.rpc("award_xp", {
+    p_user_id: userId,
+    p_amount: amount,
+    p_reason: surpriseBonusReason(lessonId),
+    p_idempotency_key: `${txSignature}:SurpriseBonus`,
+    p_tx_signature: txSignature,
+  });
+
+  if (error) throw new Error(error.message);
+  return amount;
+}

--- a/apps/web/src/lib/helius/event-handlers.ts
+++ b/apps/web/src/lib/helius/event-handlers.ts
@@ -22,6 +22,7 @@ import {
   buildUserState,
 } from "@/lib/gamification/achievements";
 import { getCourseById, getDeployedAchievements } from "@/lib/content/queries";
+import { maybeAwardSurpriseBonus } from "@/lib/gamification/surprise-bonus";
 import { isCourseInMaintenance } from "@/lib/content/deployments";
 import { isPlatformFrozen } from "@/lib/platform/freeze";
 import { logError } from "@/lib/logging";
@@ -212,6 +213,32 @@ export async function handleLessonCompleted(
         courseId,
       },
     });
+  }
+
+  // 2b. Surprise XP delight bonus (LX-B15) — server-side only, never
+  // pre-announced. Best-effort: a failed bonus must never fail the completion.
+  if (lessonId) {
+    try {
+      await maybeAwardSurpriseBonus(supabase, {
+        userId,
+        lessonId,
+        txSignature,
+      });
+    } catch (bonusError) {
+      logError({
+        errorId: ERROR_IDS.LESSON_COMPLETE_FAILED,
+        error:
+          bonusError instanceof Error
+            ? bonusError
+            : new Error(String(bonusError)),
+        context: {
+          handler: "handleLessonCompleted",
+          step: "surprise_bonus",
+          userId,
+          courseId,
+        },
+      });
+    }
   }
 
   // 3. Check if all lessons complete -> finalize course on-chain

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -300,6 +300,7 @@
     "more": "More",
     "todayLabel": "Today",
     "dailyQuest": "Daily Quest: {name}",
+    "surpriseBonus": "Surprise bonus",
     "dailyQuests": "Daily Quests",
     "resetsIn": "Resets in {hours}h",
     "allQuestsBonus": "Complete all for bonus",
@@ -353,7 +354,8 @@
     "onChain": "on-chain",
     "you": "You",
     "xpRemaining": "<em>{xp} {xpLabel}</em> to {levelLabel} {level}",
-    "xpTooltip": "{xp} {xpLabel} to {levelLabel} {level}"
+    "xpTooltip": "{xp} {xpLabel} to {levelLabel} {level}",
+    "surpriseBonus": "Surprise bonus! +{amount} XP"
   },
   "certificates": {
     "title": "Certificate of Completion",
@@ -406,6 +408,12 @@
     "content": "Content bounties",
     "grants": "Grants",
     "opensInNewTab": "opens in a new tab"
+  },
+  "mastery": {
+    "title": "Skill mastery",
+    "caption": "Your progress across the skills you've practiced",
+    "lessonsRatio": "{completed}/{total} lessons",
+    "progressLabel": "{skill}: {completed} of {total} lessons complete"
   },
   "profile": {
     "editProfile": "Edit Profile",

--- a/apps/web/src/messages/es.json
+++ b/apps/web/src/messages/es.json
@@ -300,6 +300,7 @@
     "more": "Más",
     "todayLabel": "Hoy",
     "dailyQuest": "Misión Diaria: {name}",
+    "surpriseBonus": "Bono sorpresa",
     "dailyQuests": "Misiones Diarias",
     "resetsIn": "Se reinicia en {hours}h",
     "allQuestsBonus": "Completa todas para bono",
@@ -353,7 +354,8 @@
     "onChain": "on-chain",
     "you": "Tú",
     "xpRemaining": "<em>{xp} {xpLabel}</em> para {levelLabel} {level}",
-    "xpTooltip": "{xp} {xpLabel} para {levelLabel} {level}"
+    "xpTooltip": "{xp} {xpLabel} para {levelLabel} {level}",
+    "surpriseBonus": "¡Bono sorpresa! +{amount} XP"
   },
   "certificates": {
     "title": "Certificado de Finalización",
@@ -406,6 +408,12 @@
     "content": "Bounties de contenido",
     "grants": "Grants",
     "opensInNewTab": "se abre en una pestaña nueva"
+  },
+  "mastery": {
+    "title": "Dominio de habilidades",
+    "caption": "Tu progreso en las habilidades que has practicado",
+    "lessonsRatio": "{completed}/{total} lecciones",
+    "progressLabel": "{skill}: {completed} de {total} lecciones completadas"
   },
   "profile": {
     "editProfile": "Editar Perfil",

--- a/apps/web/src/messages/pt-BR.json
+++ b/apps/web/src/messages/pt-BR.json
@@ -300,6 +300,7 @@
     "more": "Mais",
     "todayLabel": "Hoje",
     "dailyQuest": "Missão Diária: {name}",
+    "surpriseBonus": "Bônus surpresa",
     "dailyQuests": "Missões Diárias",
     "resetsIn": "Reseta em {hours}h",
     "allQuestsBonus": "Complete todas para bônus",
@@ -353,7 +354,8 @@
     "onChain": "on-chain",
     "you": "Você",
     "xpRemaining": "<em>{xp} {xpLabel}</em> para {levelLabel} {level}",
-    "xpTooltip": "{xp} {xpLabel} para {levelLabel} {level}"
+    "xpTooltip": "{xp} {xpLabel} para {levelLabel} {level}",
+    "surpriseBonus": "Bônus surpresa! +{amount} XP"
   },
   "certificates": {
     "title": "Certificado de Conclusão",
@@ -406,6 +408,12 @@
     "content": "Bounties de conteúdo",
     "grants": "Grants",
     "opensInNewTab": "abre em uma nova aba"
+  },
+  "mastery": {
+    "title": "Domínio de habilidades",
+    "caption": "Seu progresso nas habilidades que você praticou",
+    "lessonsRatio": "{completed}/{total} lições",
+    "progressLabel": "{skill}: {completed} de {total} lições concluídas"
   },
   "profile": {
     "editProfile": "Editar Perfil",


### PR DESCRIPTION
Closes #589 — two small P2s on existing rails (LX-B15 + LX-B16, launch-experience master spec §3).

## LX-B15 — Surprise XP delight bonuses
Unexpected rewards are the only zero-undermining reward form (unified spec §2.1 / PED-10, d≈0.01), which only holds if the bonus is genuinely unpredictable. Implementation keeps that property:

- **Server-side trigger only.** Rolls inside the Helius `LessonCompleted` webhook handler (`event-handlers.ts`), never in client code — nothing to predict or probe. RNG is injectable for tests, `Math.random` in prod.
- **Rides `award_xp` unchanged.** Small capped amount (ladder 10–40 XP, far under the 2000 per-award ceiling), reason `surprise_bonus:<lessonId>`, idempotency key `<txSig>:SurpriseBonus` so a webhook retry can never double-award. **No schema change, no new SECURITY DEFINER function.**
- **Weekly cap** (3/user/ISO-week) enforced by counting existing `surprise_bonus:` rows in `xp_transactions`. Fail-safe: if the cap can't be verified, no bonus is granted.
- **Never pre-announced.** The bonus surfaces only *after* it lands, via the informational celebration tier — a calm success toast (`celebrate("surprise-bonus")` → tier `none`, never confetti), composed with the #549 module. Best-effort: a failed bonus never fails lesson completion.

## LX-B16 — Skill mastery panel
New dashboard secondary slot (`MasteryPanel`) showing per-skill **progress** — completed vs. total catalog lessons carrying each skill — derived from #498 bundle-resolved skill tags (`getAllLessonSkills`). Frontend-only, **zero schema**. Pure DB-free derivation (`deriveMastery`) mirroring the profile Skills radar but showing absolute progress rather than relative strength; competence-framed per #550 (a count of lessons practiced, never a balance). Renders nothing until the learner has practiced a tagged skill; a fetch failure can't break the dashboard.

## Scope notes
- **Placement:** mastery panel is on the **dashboard** secondary slot (spec allows profile *or* dashboard) — the profile already carries the Skills radar, so the dashboard is the non-redundant home and its slot architecture is built for additive surfaces.
- **Review-eligibility (#638):** deliberately *not* used as a mastery filter — that constant governs spaced-review set eligibility, not mastery display; filtering by it would hide legitimate TypeScript/React progress. Faithful to the accept line ("per-skill progress from existing tags").

## Verification
- `pnpm typecheck` — clean
- `apps/web` vitest — **1321 passed** (35 in the touched gamification/hook suites; +16 new across `surprise-bonus.test.ts` and `mastery.test.ts`, incl. cap enforcement, reason/idempotency format, non-predictability, fail-safe)
- `pnpm lint` — clean (exit 0), `prettier --check` clean
- ×3 locales (en/es/pt-BR), a11y progressbar semantics on the panel