### PR TITLE
fix(schema): mirror prod wallet-write lock trigger into schema.sql

### DIFF
--- a/apps/web/src/lib/supabase/__tests__/wallet-write-lock-guard.test.ts
+++ b/apps/web/src/lib/supabase/__tests__/wallet-write-lock-guard.test.ts
@@ -1,0 +1,133 @@
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, it, expect } from "vitest";
+
+// #696 (mirrors the prod fix from #408): profiles.wallet_address was
+// self-writable — the self-service profiles RLS policies (auth.uid() = id for
+// INSERT/UPDATE) do not constrain WHICH columns are written, so any
+// authenticated user could overwrite their own wallet_address and spoof the
+// wallet identity that Helius XP resolution and the linked-wallet trust chain
+// depend on. Production carries trg_enforce_profile_wallet_write (live since
+// 2026-07-10) but supabase/schema.sql never mirrored it, so any DB built from
+// the snapshot shipped WITHOUT the guard. RLS/triggers cannot be exercised in
+// unit tests, so — as with the #493 profile guard and the #569 review spine —
+// pin the security-critical SQL invariants in BOTH the migration that applies
+// the fix and the schema.sql mirror new environments are built from. A drift
+// between them is exactly the class of bug this test exists to prevent.
+
+function findRepoRoot(): string {
+  let dir = dirname(fileURLToPath(import.meta.url));
+  while (!existsSync(resolve(dir, "supabase/schema.sql"))) {
+    const parent = dirname(dir);
+    if (parent === dir)
+      throw new Error("repo root (supabase/schema.sql) not found");
+    dir = parent;
+  }
+  return dir;
+}
+
+const repoRoot = findRepoRoot();
+// The committed source of truth for the trigger definition (#408 was closed by
+// this migration; the wallet-lock stanza lives in section (b)).
+const migration = readFileSync(
+  resolve(repoRoot, "supabase/migrations/20260710120000_drop_teacher_role.sql"),
+  "utf8"
+);
+const schema = readFileSync(resolve(repoRoot, "supabase/schema.sql"), "utf8");
+
+const FN = "public.enforce_profile_wallet_write()";
+const TRIGGER = "trg_enforce_profile_wallet_write";
+
+// The guard must hold in the migration (what gets applied) AND in schema.sql
+// (the snapshot fresh environments are built from).
+for (const [label, sql] of [
+  ["migration", migration] as const,
+  ["schema.sql", schema] as const,
+]) {
+  describe(`#696 wallet-write lock — ${label}`, () => {
+    it("defines the trigger function exactly once", () => {
+      const defs = sql.split(`CREATE OR REPLACE FUNCTION ${FN}`).length - 1;
+      expect(defs).toBe(1);
+    });
+
+    it("installs the BEFORE INSERT OR UPDATE trigger exactly once", () => {
+      const creates = sql.split(`CREATE TRIGGER ${TRIGGER}`).length - 1;
+      expect(creates).toBe(1);
+      const start = sql.indexOf(`CREATE TRIGGER ${TRIGGER}`);
+      const body = sql.slice(start, start + 200);
+      expect(body).toContain("BEFORE INSERT OR UPDATE ON public.profiles");
+      expect(body).toContain("FOR EACH ROW");
+      expect(body).toContain(`EXECUTE FUNCTION ${FN}`);
+      // Drop-then-create so re-running the SQL is idempotent.
+      expect(sql).toContain(
+        `DROP TRIGGER IF EXISTS ${TRIGGER} ON public.profiles;`
+      );
+    });
+
+    it("observes the CALLER's role (SECURITY INVOKER, pinned search_path)", () => {
+      const start = sql.indexOf(`CREATE OR REPLACE FUNCTION ${FN}`);
+      const body = sql.slice(start, sql.indexOf("$$;", start));
+      // SECURITY DEFINER here would read the owner's role and defeat the check.
+      expect(body).toContain("SECURITY INVOKER");
+      expect(body).toContain("SET search_path = ''");
+    });
+
+    it("treats only service_role as privileged (direct role OR JWT claim)", () => {
+      const start = sql.indexOf(`CREATE OR REPLACE FUNCTION ${FN}`);
+      const body = sql.slice(start, sql.indexOf("$$;", start));
+      expect(body).toContain("current_setting('request.jwt.claims', true)");
+      expect(body).toContain(
+        "current_user = 'service_role' OR jwt_role = 'service_role'"
+      );
+    });
+
+    it("is keyed on wallet_address — non-service UPDATE that changes it errors", () => {
+      const start = sql.indexOf(`CREATE OR REPLACE FUNCTION ${FN}`);
+      const body = sql.slice(start, sql.indexOf("$$;", start));
+      expect(body).toContain(
+        "NEW.wallet_address IS DISTINCT FROM OLD.wallet_address"
+      );
+      expect(body).toContain(
+        "wallet_address may only be changed by service_role"
+      );
+      expect(body).toContain("USING ERRCODE = 'insufficient_privilege'");
+    });
+
+    it("coerces a non-service INSERT's wallet_address to NULL", () => {
+      const start = sql.indexOf(`CREATE OR REPLACE FUNCTION ${FN}`);
+      const body = sql.slice(start, sql.indexOf("$$;", start));
+      expect(body).toContain("IF NEW.wallet_address IS NOT NULL THEN");
+      expect(body).toContain("NEW.wallet_address := NULL;");
+    });
+
+    it("revokes EXECUTE so the helper is not callable via PostgREST RPC", () => {
+      expect(sql).toContain(
+        `REVOKE EXECUTE ON FUNCTION ${FN} FROM PUBLIC, anon, authenticated;`
+      );
+    });
+  });
+}
+
+describe("#696 wallet-write lock — coexistence", () => {
+  it("schema.sql keeps the role-write lock alongside the wallet lock", () => {
+    // The wallet guard is additive: it must not displace the role guard. Both
+    // BEFORE-write triggers run on profiles and are column-specific.
+    expect(schema).toContain(
+      "CREATE OR REPLACE FUNCTION public.enforce_profile_role_write()"
+    );
+    expect(schema).toContain("CREATE TRIGGER trg_enforce_profile_role_write");
+    expect(schema).toContain(`CREATE TRIGGER ${TRIGGER}`);
+  });
+
+  it("guards a distinct column — no crosstalk between the two triggers", () => {
+    // The wallet trigger touches only wallet_address; it never reads or writes
+    // any segment/goal/daily_goal column (#695) or role (the role trigger's
+    // domain), so those policies/columns are orthogonal to it.
+    const start = schema.indexOf(`CREATE OR REPLACE FUNCTION ${FN}`);
+    const body = schema.slice(start, schema.indexOf("$$;", start));
+    expect(body).not.toMatch(/\bNEW\.role\b/);
+    expect(body).not.toMatch(/\bsegment\b/);
+    expect(body).not.toMatch(/\bdaily_goal\b/);
+  });
+});

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -640,6 +640,63 @@ CREATE TRIGGER trg_enforce_profile_role_write
 REVOKE EXECUTE ON FUNCTION public.enforce_profile_role_write() FROM PUBLIC, anon, authenticated;
 
 -- ─────────────────────────────────────────────
+-- 5a-bis. LOCK profiles.wallet_address WRITES TO service_role (#408)
+-- ─────────────────────────────────────────────
+-- Same escalation class as the role lock above, different column. The
+-- self-service profiles RLS policies (auth.uid() = id for INSERT/UPDATE) do not
+-- constrain WHICH columns are written, so without this guard any authenticated
+-- user could overwrite wallet_address on their own row — clobbering their linked
+-- wallet, or squatting an unclaimed wallet before its real owner links it — via
+-- a PostgREST INSERT/UPDATE, spoofing the wallet identity that Helius XP
+-- resolution and the linked-wallet trust chain rely on. wallet_address is
+-- legitimately written only by the two service-role SIWS paths (api/auth/wallet,
+-- api/auth/link-wallet). This BEFORE trigger makes it writable only by
+-- service_role: non-privileged UPDATEs that change it error; non-privileged
+-- INSERTs are coerced back to NULL (the signup path never sets it). SECURITY
+-- INVOKER so current_user reflects the actual caller. Live on prod since
+-- 2026-07-10. See migration 20260710120000_drop_teacher_role.sql.
+CREATE OR REPLACE FUNCTION public.enforce_profile_wallet_write()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+DECLARE
+  jwt_role TEXT;
+  is_privileged BOOLEAN;
+BEGIN
+  jwt_role := NULLIF(current_setting('request.jwt.claims', true), '')::jsonb ->> 'role';
+  is_privileged := COALESCE(current_user = 'service_role' OR jwt_role = 'service_role', false);
+
+  IF is_privileged THEN
+    RETURN NEW;
+  END IF;
+
+  IF TG_OP = 'UPDATE' THEN
+    IF NEW.wallet_address IS DISTINCT FROM OLD.wallet_address THEN
+      RAISE EXCEPTION
+        'permission denied: wallet_address may only be changed by service_role'
+        USING ERRCODE = 'insufficient_privilege';
+    END IF;
+  ELSIF TG_OP = 'INSERT' THEN
+    IF NEW.wallet_address IS NOT NULL THEN
+      NEW.wallet_address := NULL;
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_enforce_profile_wallet_write ON public.profiles;
+CREATE TRIGGER trg_enforce_profile_wallet_write
+  BEFORE INSERT OR UPDATE ON public.profiles
+  FOR EACH ROW
+  EXECUTE FUNCTION public.enforce_profile_wallet_write();
+
+REVOKE EXECUTE ON FUNCTION public.enforce_profile_wallet_write() FROM PUBLIC, anon, authenticated;
+
+-- ─────────────────────────────────────────────
 -- 5b. LEADERBOARD RPC
 -- ─────────────────────────────────────────────
 


### PR DESCRIPTION
## What

`supabase/schema.sql` never mirrored `trg_enforce_profile_wallet_write` — the wallet-write lock that **closed #408 in production on 2026-07-10** (prod-verified: an authenticated self-write of `wallet_address` is rejected with `insufficient_privilege`; a service-role SIWS link still succeeds). This PR mirrors the trigger + function + `REVOKE` into `schema.sql` and adds a guard test pinning it.

`Closes #696`

## Why it matters

The profiles self-service RLS policies (`auth.uid() = id` for INSERT/UPDATE) don't constrain **which** columns are written, so without the guard any authenticated user could overwrite their own `wallet_address` and spoof the wallet identity that Helius XP resolution and #620's linked-wallet trust chain depend on. Because the fix lived only in prod (never in the committed snapshot), **any DB built from `schema.sql` — staging, local dev, a future environment — shipped without the guard**, re-opening the exact vector. PR #695's adversarial reviewer independently re-derived the whole attack from `schema.sql` alone tonight, which is what surfaced the drift.

## Source of truth (which case)

**Committed migration FOUND** — no reconstruction needed. The exact definition is in `supabase/migrations/20260710120000_drop_teacher_role.sql` section **(b)** (that migration closed #408; its header carries the full threat write-up). This PR mirrors that function/trigger/`REVOKE` into `schema.sql` **verbatim** (executable SQL byte-identical; inline comments condensed to match how `schema.sql` already condensed the sibling `enforce_profile_role_write` block).

**No live DB was touched** — prod already has the trigger; these files just make the committed snapshot tell the truth.

## Placement

Inserted as section **5a-bis**, immediately after the role-write lock (section 5a) it mirrors — `enforce_profile_role_write` — and before the leaderboard RPC (5b). The two triggers are column-specific and coexist on `profiles`.

## Guard test

`apps/web/src/lib/supabase/__tests__/wallet-write-lock-guard.test.ts`, following the #569 / #493 guard-test pattern. Asserts, in **both** the migration and the `schema.sql` mirror:

- function + trigger present **exactly once**; drop-then-create (idempotent)
- `SECURITY INVOKER` + `SET search_path = ''` (must observe the caller, not the definer)
- service_role-only privilege check (direct `current_user` **or** PostgREST JWT claim)
- keyed on `wallet_address`: non-service UPDATE that changes it raises `insufficient_privilege`; non-service INSERT coerces it to NULL
- `REVOKE EXECUTE` from `PUBLIC, anon, authenticated`
- coexistence with the role-write lock; no crosstalk into `role` / #695's `segment`/`daily_goal` columns

## Cross-check vs #695

#695's migration (adds `segment`/`goal`/`daily_goal` columns ridden by the same own-row UPDATE policy) is not yet in the repo. The wallet trigger is **column-specific** — it only fires when `wallet_address` changes and never reads/writes those columns — so there is no interaction; the coexistence test pins that. It also coexists with the role trigger.

## Verification

- SQL parse (libpg-query): `schema.sql` **260 statements OK**, migration **8 statements OK**
- `tsc --noEmit`: clean
- Guard test: **16/16**; full web suite: **1365/1365** (151 files)
- `next lint` on the new file: clean (two pre-existing `import/order` warnings in untouched `client.ts`/`server.ts` are not from this PR)

## Out of scope (flagged)

`schema.sql` still carries the `profiles.role` column, `chk_profiles_role`, and `enforce_profile_role_write` — all of which `20260710120000_drop_teacher_role.sql` **drops** in its section (a). Whether prod dropped the role machinery or only applied the wallet stanza (the migration's own apply-gate note defers the role drop until the teacher-authoring repoint ships) is a separate, larger snapshot-vs-migration drift. This PR deliberately leaves the role machinery in `schema.sql` untouched — mirroring the wallet guard beside a still-present role guard reflects the most likely current prod state (both triggers live) and keeps the change scoped to #696.