### PR TITLE
feat(ai): post-pass idiomatic review action (LX-C9)

### DIFF
--- a/apps/web/src/app/api/ai/__tests__/partner-route.test.ts
+++ b/apps/web/src/app/api/ai/__tests__/partner-route.test.ts
@@ -850,4 +850,176 @@ describe("POST /api/ai/partner", () => {
 
     expect(res.status).toBe(502);
   });
+
+  // --- LX-C9: post-pass idiomatic review (`review` action) ---
+
+  const REVIEW_BODY = {
+    ...VALID_BODY,
+    action: "review",
+    testSummary: "3/3 passing",
+  };
+
+  const REVIEW_GEMINI_TEXT = JSON.stringify({
+    type: "review",
+    summary: "Your solution passes and reads clearly.",
+    notes: [
+      "Prefer iter().sum() over the manual loop.",
+      "Name `n` for clarity.",
+    ],
+  });
+
+  it("passes through a well-formed review response for the review action", async () => {
+    stubGeminiFetch(REVIEW_GEMINI_TEXT);
+
+    const { POST } = await import("../partner/route");
+    const res = await POST(makeRequest(REVIEW_BODY));
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json).toEqual({
+      type: "review",
+      summary: "Your solution passes and reads clearly.",
+      notes: [
+        "Prefer iter().sum() over the manual loop.",
+        "Name `n` for clarity.",
+      ],
+    });
+  });
+
+  it("accepts a review with an empty notes array (already idiomatic)", async () => {
+    stubGeminiFetch(
+      JSON.stringify({
+        type: "review",
+        summary: "Already idiomatic — nothing to change.",
+        notes: [],
+      })
+    );
+
+    const { POST } = await import("../partner/route");
+    const res = await POST(makeRequest(REVIEW_BODY));
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json).toEqual({
+      type: "review",
+      summary: "Already idiomatic — nothing to change.",
+      notes: [],
+    });
+  });
+
+  it("is a metered paid action: spends once, records billed once, no refund (billed-path)", async () => {
+    stubGeminiFetch(REVIEW_GEMINI_TEXT);
+
+    const { POST } = await import("../partner/route");
+    const res = await POST(makeRequest(REVIEW_BODY));
+
+    expect(res.status).toBe(200);
+    // The review rides the same billed, fail-closed, assist-metered path as
+    // every other action — never an unmetered generation.
+    expect(spendAssist).toHaveBeenCalledTimes(1);
+    expect(spendAssist).toHaveBeenCalledWith("user-1", "lesson-1");
+    expect(recordBilledAssist).toHaveBeenCalledTimes(1);
+    expect(refundAssist).not.toHaveBeenCalled();
+  });
+
+  it("returns budgetExhausted for review when the assist budget is spent", async () => {
+    spendAssist.mockResolvedValue({ allowed: false, used: 4 });
+    stubGeminiFetch(REVIEW_GEMINI_TEXT);
+
+    const { POST } = await import("../partner/route");
+    const res = await POST(makeRequest(REVIEW_BODY));
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json).toMatchObject({ budgetExhausted: true, used: 4 });
+  });
+
+  it("caps review output below propose and uses the summary+notes schema", async () => {
+    const fetchSpy = vi.fn(async (_url: string, init: { body: string }) => {
+      void init;
+      return {
+        ok: true,
+        text: async () => "",
+        json: async () => ({
+          candidates: [{ content: { parts: [{ text: REVIEW_GEMINI_TEXT }] } }],
+          usageMetadata: { cachedContentTokenCount: 0 },
+        }),
+      };
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const { POST } = await import("../partner/route");
+    await POST(makeRequest(REVIEW_BODY));
+
+    const [, init] = fetchSpy.mock.calls[0]!;
+    const sent = JSON.parse(init.body) as {
+      contents: { parts: { text: string }[] }[];
+      generationConfig: {
+        maxOutputTokens: number;
+        responseSchema: { properties: Record<string, unknown> };
+      };
+    };
+    expect(sent.generationConfig.maxOutputTokens).toBe(1536);
+    const schema = sent.generationConfig.responseSchema;
+    expect(schema.properties).toHaveProperty("summary");
+    expect(schema.properties).toHaveProperty("notes");
+    expect(schema.properties).not.toHaveProperty("edits");
+    // The post-pass instruction block reaches the model only for review.
+    const prompt = sent.contents[0]!.parts[0]!.text;
+    expect(prompt).toContain("[REVIEW_INSTRUCTIONS]");
+  });
+
+  it("returns 502 on a review payload missing summary — billed, not refunded", async () => {
+    stubGeminiFetch(JSON.stringify({ type: "review", notes: ["a note"] }));
+
+    const { POST } = await import("../partner/route");
+    const res = await POST(makeRequest(REVIEW_BODY));
+
+    expect(res.status).toBe(502);
+    expect(refundAssist).not.toHaveBeenCalled();
+    expect(recordBilledAssist).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns 502 when a review note is not a non-empty string", async () => {
+    stubGeminiFetch(
+      JSON.stringify({ type: "review", summary: "s", notes: ["ok", ""] })
+    );
+
+    const { POST } = await import("../partner/route");
+    const res = await POST(makeRequest(REVIEW_BODY));
+
+    expect(res.status).toBe(502);
+  });
+
+  it("re-bounds an over-long review notes list to the ceiling", async () => {
+    const eight = Array.from({ length: 8 }, (_, i) => `note ${i}`);
+    stubGeminiFetch(
+      JSON.stringify({ type: "review", summary: "s", notes: eight })
+    );
+
+    const { POST } = await import("../partner/route");
+    const res = await POST(makeRequest(REVIEW_BODY));
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    // Six-note ceiling (MAX_REVIEW_NOTES) enforced at the money surface.
+    expect(json.notes).toHaveLength(6);
+    expect(json.notes).not.toContain("note 6");
+  });
+
+  it("persists the review turn to the assist log with no user turn", async () => {
+    stubGeminiFetch(REVIEW_GEMINI_TEXT);
+
+    const { POST } = await import("../partner/route");
+    await POST(makeRequest(REVIEW_BODY));
+
+    expect(appendAssistLog).toHaveBeenCalledTimes(1);
+    const [, , entries] = appendAssistLog.mock.calls[0]!;
+    // review carries no user message — only the AI reply.
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      role: "ai",
+      response: { type: "review" },
+    });
+  });
 });

--- a/apps/web/src/app/api/ai/partner/route.ts
+++ b/apps/web/src/app/api/ai/partner/route.ts
@@ -16,6 +16,7 @@ import {
   maxTokensFor,
   responseSchemaFor,
   MAX_PROPOSE_EDITS,
+  MAX_REVIEW_NOTES,
 } from "@/lib/ai/partner-prompt";
 import type {
   PartnerAction,
@@ -24,6 +25,7 @@ import type {
   PartnerMessage,
   HintResponse,
   AnswerResponse,
+  ReviewResponse,
   CodeEdit,
 } from "@/lib/ai/partner-types";
 import { serverEnv } from "@/lib/env.server";
@@ -49,7 +51,12 @@ const MAX_TEST_SUMMARY_CHARS = 2_000;
 const GEMINI_URL =
   "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.5-flash:generateContent";
 
-const VALID_ACTIONS: readonly PartnerAction[] = ["hint", "propose", "ask"];
+const VALID_ACTIONS: readonly PartnerAction[] = [
+  "hint",
+  "propose",
+  "ask",
+  "review",
+];
 
 function isPartnerAction(value: string): value is PartnerAction {
   return (VALID_ACTIONS as readonly string[]).includes(value);
@@ -95,6 +102,7 @@ function validateEdits(value: unknown): CodeEdit[] | null {
 type ValidatedResponse =
   | HintResponse
   | AnswerResponse
+  | ReviewResponse
   | ValidatedProposeResponse;
 
 /**
@@ -113,6 +121,23 @@ function validatePartnerResponse(parsed: unknown): ValidatedResponse | null {
   if (obj.type === "hint" || obj.type === "answer") {
     if (typeof obj.text !== "string" || obj.text.length === 0) return null;
     return { type: obj.type, text: obj.text };
+  }
+
+  if (obj.type === "review") {
+    // summary must be present; notes may be empty (already idiomatic) but every
+    // entry must be a non-empty string, and the list is re-bounded here even
+    // though the schema caps it — a malformed/oversized payload 502s rather than
+    // forwarding unbounded text. Truncate defensively to the same ceiling.
+    if (typeof obj.summary !== "string" || obj.summary.length === 0)
+      return null;
+    if (!Array.isArray(obj.notes)) return null;
+    if (!obj.notes.every((n) => typeof n === "string" && n.length > 0))
+      return null;
+    return {
+      type: "review",
+      summary: obj.summary,
+      notes: (obj.notes as string[]).slice(0, MAX_REVIEW_NOTES),
+    };
   }
 
   if (obj.type === "propose") {

--- a/apps/web/src/components/editor/ai-partner/__tests__/ai-partner-pane.test.tsx
+++ b/apps/web/src/components/editor/ai-partner/__tests__/ai-partner-pane.test.tsx
@@ -1,0 +1,95 @@
+// @vitest-environment jsdom
+// LX-C9 post-pass review: the opt-in "Review my solution" button lives in the
+// AI Partner pane and is gated on `solutionPassed`. It appears ONLY after a
+// passing run, never pre-pass. Suppression (an unanswered quiz block) is
+// enforced one level up in ChallengeInterface, which does not mount this pane
+// at all while suppressed (see challenge-interface-ai-gate.test.tsx), so a
+// suppressed lesson can never surface this button.
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import messages from "@/messages/en.json";
+import { AiPartnerPane } from "../ai-partner-pane";
+
+const review = vi.fn();
+const hookState = {
+  messages: [] as unknown[],
+  freeHintsUsed: 0,
+  paidUsed: 0,
+  paidRemaining: 4,
+  budgetExhausted: false,
+  loading: false,
+  error: null as string | null,
+  requestHint: vi.fn(),
+  proposeFix: vi.fn(),
+  ask: vi.fn(),
+  review,
+  verifyCheck: vi.fn(),
+};
+
+vi.mock("@/lib/ai/use-ai-partner", () => ({
+  useAiPartner: () => hookState,
+}));
+
+function renderPane(
+  props: { solutionPassed?: boolean; disabled?: boolean } = {}
+) {
+  return render(
+    <NextIntlClientProvider locale="en" messages={messages}>
+      <AiPartnerPane
+        lessonSlug="l"
+        courseSlug="c"
+        hints={[]}
+        getCode={() => "code"}
+        getTestSummary={() => "3/3 passing"}
+        onApply={() => {}}
+        {...props}
+      />
+    </NextIntlClientProvider>
+  );
+}
+
+const reviewLabel = messages.aiPartner.actions.review;
+
+beforeEach(() => {
+  review.mockReset();
+  hookState.budgetExhausted = false;
+  hookState.loading = false;
+});
+
+describe("AiPartnerPane — post-pass review button (LX-C9)", () => {
+  it("does NOT render the review button before a passing run", () => {
+    renderPane({ solutionPassed: false });
+    expect(
+      screen.queryByRole("button", { name: reviewLabel })
+    ).not.toBeInTheDocument();
+  });
+
+  it("does NOT render the review button when the prop is omitted", () => {
+    renderPane();
+    expect(
+      screen.queryByRole("button", { name: reviewLabel })
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders the review button after a passing run and calls review() on click", () => {
+    renderPane({ solutionPassed: true });
+    const button = screen.getByRole("button", { name: reviewLabel });
+    expect(button).toBeEnabled();
+    fireEvent.click(button);
+    expect(review).toHaveBeenCalledTimes(1);
+  });
+
+  it("offers the review even after the lesson is complete (disabled=true) — it is post-pass", () => {
+    // `disabled` (lesson complete) hard-stops hints/propose/ask but NOT review:
+    // reviewing the solution you just passed is the point of the surface.
+    renderPane({ solutionPassed: true, disabled: true });
+    expect(screen.getByRole("button", { name: reviewLabel })).toBeEnabled();
+  });
+
+  it("disables the review button when the paid budget is exhausted", () => {
+    hookState.budgetExhausted = true;
+    renderPane({ solutionPassed: true });
+    expect(screen.getByRole("button", { name: reviewLabel })).toBeDisabled();
+  });
+});

--- a/apps/web/src/components/editor/ai-partner/__tests__/message-list.test.tsx
+++ b/apps/web/src/components/editor/ai-partner/__tests__/message-list.test.tsx
@@ -3,9 +3,9 @@ import type { ReactElement } from "react";
 import { it, expect, vi } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { NextIntlClientProvider } from "next-intl";
-import { MessageList } from "../message-list";
 import messages from "@/messages/en.json";
 import type { PartnerMessage } from "@/lib/ai/use-ai-partner";
+import { MessageList } from "../message-list";
 
 function renderWithIntl(ui: ReactElement) {
   return render(
@@ -30,6 +30,62 @@ const proposeMessages: PartnerMessage[] = [
     },
   },
 ];
+
+it("renders a post-pass review with its summary and idiomatic notes", () => {
+  const reviewMessages: PartnerMessage[] = [
+    {
+      role: "ai",
+      response: {
+        type: "review",
+        summary: "Your solution passes and is clear.",
+        notes: ["Use iter().sum().", "Rename n to count."],
+      },
+    },
+  ];
+
+  renderWithIntl(
+    <MessageList
+      messages={reviewMessages}
+      onApply={() => {}}
+      getCode={() => "a"}
+      onVerify={vi.fn()}
+    />
+  );
+
+  expect(
+    screen.getByText("Your solution passes and is clear.")
+  ).toBeInTheDocument();
+  expect(screen.getByText("Use iter().sum().")).toBeInTheDocument();
+  expect(screen.getByText("Rename n to count.")).toBeInTheDocument();
+});
+
+it("renders an already-idiomatic review (empty notes) with just the summary", () => {
+  const reviewMessages: PartnerMessage[] = [
+    {
+      role: "ai",
+      response: {
+        type: "review",
+        summary: "Already idiomatic — nothing to change.",
+        notes: [],
+      },
+    },
+  ];
+
+  renderWithIntl(
+    <MessageList
+      messages={reviewMessages}
+      onApply={() => {}}
+      getCode={() => "a"}
+      onVerify={vi.fn()}
+    />
+  );
+
+  expect(
+    screen.getByText("Already idiomatic — nothing to change.")
+  ).toBeInTheDocument();
+  // No list is rendered when there are no notes.
+  expect(screen.queryByRole("list")).not.toBeInTheDocument();
+});
 
 it("dismisses a proposal when Dismiss is clicked", () => {
   renderWithIntl(

--- a/apps/web/src/components/editor/ai-partner/ai-partner-pane.tsx
+++ b/apps/web/src/components/editor/ai-partner/ai-partner-pane.tsx
@@ -1,12 +1,13 @@
 "use client";
 
 import { useTranslations } from "next-intl";
-import { Robot } from "@phosphor-icons/react";
+import { Robot, MagnifyingGlass } from "@phosphor-icons/react";
+import { useAiPartner } from "@/lib/ai/use-ai-partner";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
 import { AssistMeter } from "./assist-meter";
 import { MessageList } from "./message-list";
 import { QuickActions } from "./quick-actions";
-import { cn } from "@/lib/utils";
-import { useAiPartner } from "@/lib/ai/use-ai-partner";
 
 interface AiPartnerPaneProps {
   lessonSlug: string;
@@ -18,6 +19,11 @@ interface AiPartnerPaneProps {
   /** When true (the lesson is already complete), every AI action is disabled —
    * the challenge is done, so no more hints / proposals / questions. */
   disabled?: boolean;
+  /** True once the most recent run PASSED every test (LX-C9). Gates the opt-in
+   * post-pass idiomatic-review button: it is offered only after a passing run,
+   * never automatically and never pre-pass. Independent of `disabled` — a
+   * post-pass review is valid (and most natural) once the challenge is solved. */
+  solutionPassed?: boolean;
   className?: string;
 }
 
@@ -29,6 +35,7 @@ export function AiPartnerPane({
   getTestSummary,
   onApply,
   disabled = false,
+  solutionPassed = false,
   className,
 }: AiPartnerPaneProps) {
   const t = useTranslations("aiPartner");
@@ -43,6 +50,7 @@ export function AiPartnerPane({
     requestHint,
     proposeFix,
     ask,
+    review,
     verifyCheck,
   } = useAiPartner({ lessonSlug, courseSlug, hints, getCode, getTestSummary });
 
@@ -115,6 +123,31 @@ export function AiPartnerPane({
               aria-hidden="true"
             />
             {t("messages.loading")}
+          </p>
+        </div>
+      )}
+
+      {/* Post-pass idiomatic review (LX-C9): an opt-in CTA shown ONLY after a
+          passing run. It spends a paid assist like any other billed action, so
+          it hard-disables on budgetExhausted. It is intentionally NOT gated by
+          `disabled` (lesson complete) — reviewing the solution you just passed
+          is the whole point. Suppression is handled upstream: this pane is not
+          mounted at all while a quiz block is unanswered (LX-C1/F18). */}
+      {solutionPassed && (
+        <div className="shrink-0 border-t border-border px-3 pt-3">
+          <Button
+            type="button"
+            variant="secondary"
+            size="sm"
+            onClick={() => review()}
+            disabled={loading || budgetExhausted}
+            className="w-full gap-1.5"
+          >
+            <MagnifyingGlass size={14} weight="duotone" aria-hidden="true" />
+            {t("actions.review")}
+          </Button>
+          <p className="mt-1.5 text-[11px] text-text-3">
+            {t("actions.reviewHint")}
           </p>
         </div>
       )}

--- a/apps/web/src/components/editor/ai-partner/message-list.tsx
+++ b/apps/web/src/components/editor/ai-partner/message-list.tsx
@@ -3,9 +3,9 @@
 import { useState } from "react";
 import { useTranslations } from "next-intl";
 import { User, Sparkle, Lightbulb } from "@phosphor-icons/react";
-import { DiffCard } from "./diff-card";
 import { cn } from "@/lib/utils";
 import type { PartnerMessage } from "@/lib/ai/use-ai-partner";
+import { DiffCard } from "./diff-card";
 
 interface MessageListProps {
   messages: PartnerMessage[];
@@ -167,6 +167,31 @@ export function MessageList({
                 stale={index !== lastProposeIndex}
                 className="w-full"
               />
+            </MessageBubble>
+          );
+        }
+
+        // Post-pass idiomatic review (LX-C9) — a summary plus a bounded list of
+        // idiomatic notes. An empty notes list is a valid, affirming outcome
+        // ("already idiomatic"), so render the summary alone in that case.
+        if (response.type === "review") {
+          return (
+            <MessageBubble
+              key={index}
+              role="ai"
+              icon={<Sparkle size={14} weight="duotone" aria-hidden="true" />}
+              label={t("messages.ai")}
+            >
+              <div className="space-y-2 rounded-lg rounded-tl-sm bg-card px-3 py-2 text-sm text-text shadow-[var(--shadow-card)]">
+                <p>{response.summary}</p>
+                {response.notes.length > 0 && (
+                  <ul className="list-disc space-y-1 pl-4 text-text-2">
+                    {response.notes.map((note, noteIndex) => (
+                      <li key={noteIndex}>{note}</li>
+                    ))}
+                  </ul>
+                )}
+              </div>
             </MessageBubble>
           );
         }

--- a/apps/web/src/components/editor/challenge-interface.tsx
+++ b/apps/web/src/components/editor/challenge-interface.tsx
@@ -9,16 +9,6 @@ import {
   Trophy,
   X,
 } from "@phosphor-icons/react";
-import { CodeEditor, resetEditorStorage } from "./code-editor";
-import { OutputPanel } from "./output-panel";
-import { ChallengeRunner } from "./challenge-runner";
-import { AiPartnerPane } from "./ai-partner/ai-partner-pane";
-import type {
-  ChallengeInterfaceProps,
-  ChallengeState,
-  CodeEditorHandle,
-  ExecutionResult,
-} from "./types";
 import {
   challengeKindFor,
   trackChallengeFailed,
@@ -31,6 +21,16 @@ import {
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { shouldShowEncouragement } from "@/lib/gamification/celebration";
+import { CodeEditor, resetEditorStorage } from "./code-editor";
+import { OutputPanel } from "./output-panel";
+import { ChallengeRunner } from "./challenge-runner";
+import { AiPartnerPane } from "./ai-partner/ai-partner-pane";
+import type {
+  ChallengeInterfaceProps,
+  ChallengeState,
+  CodeEditorHandle,
+  ExecutionResult,
+} from "./types";
 
 const LESSON_COMPLETE_EVENT = "superteam:lesson-complete";
 // Carries the passing code to lesson-client WITHOUT driving a completion, so an
@@ -436,6 +436,7 @@ export function ChallengeInterface({
                 getTestSummary={() => summarize(challengeState.executionResult)}
                 onApply={(proposed) => setCode(proposed)}
                 disabled={isComplete}
+                solutionPassed={challengeState.status === "success"}
                 className="h-full rounded-none border-0"
               />
             </div>

--- a/apps/web/src/lib/ai/__tests__/partner-prompt.test.ts
+++ b/apps/web/src/lib/ai/__tests__/partner-prompt.test.ts
@@ -84,4 +84,52 @@ describe("partner-prompt", () => {
     expect(prefix).toContain("replace");
     expect(prefix).not.toContain("the full updated file");
   });
+
+  // LX-C9: the post-pass review action.
+  it("review output cap is bounded and sits between hint and propose", () => {
+    expect(maxTokensFor("hint")).toBeLessThan(maxTokensFor("review"));
+    expect(maxTokensFor("review")).toBeLessThan(maxTokensFor("propose"));
+    expect(maxTokensFor("review")).toBe(1536);
+  });
+
+  it("review schema requests summary + notes, never a code/edit/whole-file field", () => {
+    const schema = responseSchemaFor("review");
+    expect(schema.properties).toHaveProperty("summary");
+    expect(schema.properties).toHaveProperty("notes");
+    // A review is feedback, not a fix: it can carry no rewrite or applicable edit.
+    expect(schema.properties).not.toHaveProperty("edits");
+    expect(schema.properties).not.toHaveProperty("proposedCode");
+    expect(schema.properties).not.toHaveProperty("text");
+    expect(schema.required).toEqual(["type", "summary", "notes"]);
+  });
+
+  it("appends the post-pass REVIEW_INSTRUCTIONS block ONLY for the review action", () => {
+    const base = {
+      lessonSlug: "l",
+      courseSlug: "c",
+      code: "let x = 1;",
+      testSummary: "3/3 passing",
+    } as const;
+
+    const reviewSuffix = buildDynamicSuffix({ ...base, action: "review" });
+    expect(reviewSuffix).toContain("[REVIEW_INSTRUCTIONS]");
+    expect(reviewSuffix).toContain("post-pass idiomatic review");
+    // The review must not regrade or rewrite.
+    expect(reviewSuffix).toContain("never claim it is wrong");
+
+    // The pre-pass actions carry a byte-identical suffix to today's — no review
+    // block leaks into the no-answer contract.
+    for (const action of ["hint", "propose", "ask"] as const) {
+      const suffix = buildDynamicSuffix({ ...base, action });
+      expect(suffix).not.toContain("[REVIEW_INSTRUCTIONS]");
+    }
+  });
+
+  it("static prefix is byte-identical regardless of action (review adds nothing to the cache)", () => {
+    // The review instructions live in the suffix, so the cached static prefix —
+    // task, tests, solution, persona — is untouched: pre-pass behavior is
+    // byte-identical whether or not the review action exists.
+    expect(buildStaticPrefix(ctx)).not.toContain("[REVIEW_INSTRUCTIONS]");
+    expect(buildStaticPrefix(ctx)).not.toContain("post-pass");
+  });
 });

--- a/apps/web/src/lib/ai/__tests__/use-ai-partner.test.tsx
+++ b/apps/web/src/lib/ai/__tests__/use-ai-partner.test.tsx
@@ -229,6 +229,30 @@ describe("useAiPartner", () => {
     });
   });
 
+  it("review() POSTs action:review and pushes the structured review response", async () => {
+    const response: PartnerResponse = {
+      type: "review",
+      summary: "Passes and reads clearly.",
+      notes: ["Use iter().sum()."],
+    };
+    vi.mocked(global.fetch).mockResolvedValue(jsonResponse(response));
+
+    const { result } = await renderPartner();
+
+    await act(async () => {
+      await result.current.review();
+    });
+
+    const [url, init] = vi.mocked(global.fetch).mock.calls[0]!;
+    expect(url).toBe("/api/ai/partner");
+    const sentBody = JSON.parse((init as RequestInit).body as string);
+    expect(sentBody.action).toBe("review");
+    // review carries no local user turn — only the AI reply lands in the chat.
+    expect(result.current.paidUsed).toBe(1);
+    expect(result.current.messages).toHaveLength(1);
+    expect(result.current.messages[0]).toMatchObject({ role: "ai", response });
+  });
+
   it("sets loading true during a paid fetch and false after it resolves", async () => {
     let resolveFetch!: (value: Response) => void;
     vi.mocked(global.fetch).mockReturnValue(

--- a/apps/web/src/lib/ai/partner-prompt.ts
+++ b/apps/web/src/lib/ai/partner-prompt.ts
@@ -64,10 +64,28 @@ export function buildStaticPrefix(ctx: StaticPrefixContext): string {
   return sections.join("\n\n");
 }
 
+// Max number of idiomatic-review notes a single `review` response may carry.
+// Mirrors the schema's `maxItems` and gives `validatePartnerResponse` a hard
+// ceiling to reject past. A review MAY carry zero notes (already idiomatic).
+export const MAX_REVIEW_NOTES = 6;
+
+// Instruction block appended to the DYNAMIC SUFFIX for the post-pass `review`
+// action ONLY (LX-C9). It lives in the suffix — not the cached static prefix or
+// the shared SYSTEM_PERSONA — so the pre-pass prompt (hint/propose/ask) stays
+// byte-identical: the no-answer contract is untouched. Post-pass semantics: the
+// solution already passes, so the model reviews idiom/clarity WITHOUT regrading,
+// claiming failure, or rewriting the whole solution.
+const REVIEW_INSTRUCTIONS = `[REVIEW_INSTRUCTIONS]
+The learner's code above ALREADY PASSES every visible test — this is a post-pass idiomatic review, NOT grading and NOT a fix. Do not re-run or re-grade it, never claim it is wrong or failing, and never rewrite the whole solution or emit a code block. Compare it against the reference solution for idiom, clarity, and language conventions, then return:
+- "summary": ONE or TWO sentences affirming the solution passes and giving the overall idiomatic read.
+- "notes": zero to ${MAX_REVIEW_NOTES} short, specific suggestions for more idiomatic or clearer code (naming, standard-library usage, error handling, structure) — each a single sentence, none a rewrite. If the solution is already idiomatic, return an EMPTY notes array rather than inventing problems.`;
+
 /**
  * Builds the dynamic, per-turn suffix: the learner's live code (delimited
  * and labeled as data), the latest test-run summary, the optional free-form
- * "ask" message, and the requested action.
+ * "ask" message, and the requested action. The `review` action also appends
+ * its post-pass instruction block here (never in the cached prefix), so the
+ * pre-pass suffix for the other actions is unchanged.
  */
 export function buildDynamicSuffix(req: PartnerRequest): string {
   const sections = [
@@ -80,6 +98,10 @@ export function buildDynamicSuffix(req: PartnerRequest): string {
   }
 
   sections.push(`[ACTION]\n${req.action}`);
+
+  if (req.action === "review") {
+    sections.push(REVIEW_INSTRUCTIONS);
+  }
 
   return sections.join("\n\n");
 }
@@ -102,6 +124,11 @@ const MAX_TOKENS: Record<PartnerAction, number> = {
   hint: 512,
   propose: 2048,
   ask: 4096,
+  // `review` is a bounded structured payload — one/two-sentence summary + up to
+  // MAX_REVIEW_NOTES single-sentence notes — so it sits between hint and propose.
+  // It cannot echo the whole file (schema has no code field), so there is no
+  // truncation lever to inflate; 1536 leaves headroom for the JSON envelope.
+  review: 1536,
 };
 
 export function maxTokensFor(action: PartnerAction): number {
@@ -192,12 +219,41 @@ const PROPOSE_RESPONSE_SCHEMA = {
   required: ["type", "rationale", "edits", "check"],
 } as const;
 
+// Schema for the post-pass `review` variant (LX-C9). A bounded `summary` plus a
+// `notes` array (0..MAX_REVIEW_NOTES). Deliberately has NO code/edit/whole-file
+// field, so a review is structured feedback the model physically cannot turn
+// into a rewrite or a full-file echo — it reviews, it does not fix.
+const REVIEW_RESPONSE_SCHEMA = {
+  type: "object",
+  properties: {
+    type: { type: "string", enum: ["review"] },
+    summary: {
+      type: "string",
+      description:
+        "ONE or TWO sentences: the overall idiomatic read, affirming the solution passes.",
+    },
+    notes: {
+      type: "array",
+      items: { type: "string" },
+      // No `minItems`: an already-idiomatic solution yields an empty list rather
+      // than invented problems. `maxItems` bounds a runaway list.
+      maxItems: MAX_REVIEW_NOTES,
+      description:
+        "Zero to six short, single-sentence idiomatic/clarity suggestions — never a rewrite.",
+    },
+  },
+  required: ["type", "summary", "notes"],
+} as const;
+
 /**
  * The Gemini `responseSchema` for a given action. `propose` gets a schema with
  * no `text` field (forcing the structured fields and preventing a runaway
- * narrative); `hint`/`ask` get the text-body schema. Paired with
+ * narrative); `review` gets a summary+notes schema with no code field;
+ * `hint`/`ask` get the text-body schema. Paired with
  * `responseMimeType: "application/json"` at the call site.
  */
 export function responseSchemaFor(action: PartnerAction) {
-  return action === "propose" ? PROPOSE_RESPONSE_SCHEMA : TEXT_RESPONSE_SCHEMA;
+  if (action === "propose") return PROPOSE_RESPONSE_SCHEMA;
+  if (action === "review") return REVIEW_RESPONSE_SCHEMA;
+  return TEXT_RESPONSE_SCHEMA;
 }

--- a/apps/web/src/lib/ai/partner-types.ts
+++ b/apps/web/src/lib/ai/partner-types.ts
@@ -1,4 +1,4 @@
-export type PartnerAction = "hint" | "propose" | "ask";
+export type PartnerAction = "hint" | "propose" | "ask" | "review";
 
 export interface PartnerRequest {
   lessonSlug: string;
@@ -17,6 +17,21 @@ export interface HintResponse {
 export interface AnswerResponse {
   type: "answer";
   text: string;
+}
+
+/**
+ * A post-pass idiomatic review of the learner's PASSING solution (LX-C9). Strictly
+ * additive: it gates nothing and grants nothing — the learner has already solved
+ * the challenge, and this reviews the working code for idiom/clarity against the
+ * reference. `summary` is a one/two-sentence overall read that affirms the pass;
+ * `notes` is a bounded list of short, specific suggestions and MAY be empty when
+ * the solution is already idiomatic (the model must not invent problems). Never
+ * carries a rewrite or applicable edits — it is feedback, not a fix.
+ */
+export interface ReviewResponse {
+  type: "review";
+  summary: string;
+  notes: string[];
 }
 
 /**
@@ -50,7 +65,11 @@ export interface ProposeResponse {
   checkToken: string;
 }
 
-export type PartnerResponse = HintResponse | AnswerResponse | ProposeResponse;
+export type PartnerResponse =
+  | HintResponse
+  | AnswerResponse
+  | ProposeResponse
+  | ReviewResponse;
 
 /**
  * A single rendered turn in the AI Partner chat. Persisted server-side per

--- a/apps/web/src/lib/ai/use-ai-partner.ts
+++ b/apps/web/src/lib/ai/use-ai-partner.ts
@@ -43,6 +43,7 @@ interface UseAiPartnerResult {
   requestHint: () => Promise<void>;
   proposeFix: () => Promise<void>;
   ask: (message: string) => Promise<void>;
+  review: () => Promise<void>;
   verifyCheck: (
     checkToken: string,
     pickedIndex: 0 | 1 | 2
@@ -170,6 +171,13 @@ export function useAiPartner({
     await callPartnerRoute("propose");
   }, [callPartnerRoute]);
 
+  // Post-pass idiomatic review (LX-C9). A paid action like propose/ask — it
+  // spends an assist and appends the AI review to the chat. The caller gates
+  // this on a passing run; the route is agnostic to that (it grades nothing).
+  const review = useCallback(async () => {
+    await callPartnerRoute("review");
+  }, [callPartnerRoute]);
+
   const ask = useCallback(
     async (message: string) => {
       setMessages((prev) => [...prev, { role: "user", text: message }]);
@@ -216,6 +224,7 @@ export function useAiPartner({
     requestHint,
     proposeFix,
     ask,
+    review,
     verifyCheck,
   };
 }

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -876,6 +876,8 @@
       "propose": "Propose fix",
       "askPlaceholder": "Ask a question about this challenge...",
       "askSend": "Send",
+      "review": "Review my solution",
+      "reviewHint": "Get idiomatic feedback on your passing solution — this doesn't change your XP.",
       "budgetExhausted": "You've used all {max} paid assists for this challenge."
     },
     "diff": {

--- a/apps/web/src/messages/es.json
+++ b/apps/web/src/messages/es.json
@@ -876,6 +876,8 @@
       "propose": "Proponer corrección",
       "askPlaceholder": "Haz una pregunta sobre este desafío...",
       "askSend": "Enviar",
+      "review": "Revisar mi solución",
+      "reviewHint": "Recibe comentarios idiomáticos sobre tu solución ya resuelta — esto no cambia tu XP.",
       "budgetExhausted": "Ya usaste las {max} asistencias pagas de este desafío."
     },
     "diff": {

--- a/apps/web/src/messages/pt-BR.json
+++ b/apps/web/src/messages/pt-BR.json
@@ -876,6 +876,8 @@
       "propose": "Propor correção",
       "askPlaceholder": "Faça uma pergunta sobre este desafio...",
       "askSend": "Enviar",
+      "review": "Revisar minha solução",
+      "reviewHint": "Receba comentários idiomáticos sobre a solução que você já concluiu — isto não altera seu XP.",
       "budgetExhausted": "Você já usou todas as {max} assistências pagas deste desafio."
     },
     "diff": {


### PR DESCRIPTION
Closes #587 — LX-C9 (launch-experience master spec §3).

## What

Adds an **opt-in AI review of a *passing* solution** for idiomatic improvement. Strictly post-pass: it gates nothing, grants nothing, and leaves the pre-pass no-answer contract byte-identical.

## Action design (`review`)

Rides the existing billed, latched, fail-closed `/api/ai/partner` route as a fourth action, following the ask/hint/propose pattern exactly:

- **Metered** — spends one paid assist via `spendAssist`, records a billed assist, refunds only on a pre-billing throw. Same fail-closed rate limits (per-user + per-IP). No unmetered path.
- **Cap** — `maxTokensFor("review") = 1536` (between `hint` 512 and `propose` 2048). Bounded structured payload; no code/whole-file field, so there is no truncation lever to inflate.
- **Schema** — `{ type: "review", summary: string, notes: string[] }`. `summary` is a 1–2 sentence affirming read; `notes` is 0–6 short idiomatic suggestions and **may be empty** (already-idiomatic → no invented problems). No `edits`/`text`/`proposedCode` field: it is feedback, not a fix or a rewrite. Re-bounded server-side at the money surface.
- **Prompt** — the idiomatic-review persona lives in the **dynamic suffix** (review action only). The cached static prefix, `SYSTEM_PERSONA`, task/tests/solution, and the pre-pass suffix for hint/propose/ask stay byte-identical.

## Button + gating

The "Review my solution" button lives in the existing AI pane (`AiPartnerPane`) and is surfaced **only when the most recent run passed** (`challengeState.status === "success"`, threaded as `solutionPassed`). Never automatic, never pre-pass. It is intentionally **not** gated by the lesson-complete `disabled` (reviewing the solution you just passed is the whole point) but **is** disabled on `budgetExhausted`.

**Quiz suppression is respected for free**: `ChallengeInterface` does not mount the pane at all while a quiz block is unanswered (LX-C1/F18), so a suppressed lesson can never surface the button.

×3 locales (EN/ES/PT-BR), a11y button + labels.

## Tests

- Route: passthrough, empty-notes, billed-path (spend×1 / billed×1 / no refund), budget-exhausted, cap+schema, malformed→502-not-refunded, note re-bounding, assist-log (no user turn).
- Prompt: review cap ordering, schema shape, suffix injection only for `review`, pre-pass suffixes/prefix byte-clean.
- Hook: `review()` POSTs `action:review`.
- UI: message-list renders summary+notes (and empty-notes); pane button gating (hidden pre-pass, shown+clickable post-pass, enabled when complete, disabled on budget-exhausted).

## Verification

- `pnpm typecheck` — 6/6 packages green
- `pnpm --filter web test` — 1370/1370 green
- `pnpm --filter web lint` — 0 errors (cleared the pane's import-order warnings while touching it)
- `prettier --check` on touched files — clean

## Out of scope / notes

- The route trusts the client's `testSummary` as untrusted context (as it already does for every action); the pass gate is client-side, consistent with the rest of the surface. A review of non-passing code is harmless (grants nothing) and still metered.