### PR TITLE
feat(content): originality gate for catalog code samples (CAT-15)

### DIFF
--- a/docs/CONTENT-ORIGINALITY.md
+++ b/docs/CONTENT-ORIGINALITY.md
@@ -1,0 +1,104 @@
+# Content originality & code licensing
+
+**Rule: every word and every line of example code in the catalog is original.**
+(Unified launch spec 2026-07-25 §3 item 31; catalog-redesign spec §Licensing;
+CAT-15.)
+
+The reference corpora authors are pointed at are **technical anchors, coverage
+checklists and outbound links only — never copy sources.** This document is the
+originality policy, the reviewer protocol, and the content-repo PR-template
+checkbox that item 31 asks for "at minimum."
+
+## Why: the corpora are not adaptable
+
+CAT-15 audited every Solana teaching corpus for its license:
+
+| Corpus                                                                                                                                                            | License                        | Usable how                         |
+| ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------ | ---------------------------------- |
+| `solana-foundation/program-examples`, `coral-xyz/sealevel-attacks`, archived `developer-content`, cookbook repo, Ackee school, `developer-bootcamp-2024`, Neodyme | **none = all-rights-reserved** | checklist / anchor / outbound link |
+| Metaplex docs, `mpl-core`                                                                                                                                         | all-rights-reserved / bespoke  | checklist / anchor / outbound link |
+| Live Solana docs & cookbook (`solana.com`)                                                                                                                        | **GPL-3.0** (copyleft)         | checklist / anchor / outbound link |
+| **LiteSVM, Mollusk, Surfpool**                                                                                                                                    | **Apache-2.0**                 | **adaptable with attribution**     |
+| **Trident**                                                                                                                                                       | **MIT**                        | **adaptable with attribution**     |
+
+Only the last two rows may be adapted. Everything else must be written from
+scratch — the vulnerability _classes_, API _shapes_ and topic _coverage_ are
+facts you may learn from and cite, but the _lines_ must be yours.
+
+## The two enforcement layers
+
+Originality cannot be proven by a CI check — a linter cannot know a hand-written
+function is not a paraphrase. So enforcement is a human review step, with a
+machine assist for the one case a machine can check.
+
+### 1. Human review (the gate) — originality checkbox
+
+Every content PR that adds or changes a code sample carries an originality
+checkbox in its PR body (see the template below). The reviewer confirms it. This
+is the actual originality guarantee; the linter below is only an assist.
+
+### 2. Content-lint gate 20 (the assist) — declared-adaptation check
+
+When a code block **legitimately adapts** LiteSVM/Mollusk/Surfpool/Trident, the
+author declares it with the optional `attribution` field:
+
+```yaml
+- key: exercise
+  type: code
+  language: rust
+  starter: exercise/starter.rs
+  solution: exercise/solution.rs
+  tests: exercise/tests.json
+  attribution:
+    source: LiteSVM
+    license: Apache-2.0
+    url: https://github.com/LiteSVM/litesvm
+```
+
+`content-lint` gate 20 then checks:
+
+- **20a** — `source`/`url` must not name a forbidden corpus, **regardless of the
+  license typed** (a mislabelled SPDX id cannot launder an all-rights-reserved or
+  GPL-3.0 corpus).
+- **20b** — `license` must be `Apache-2.0` or `MIT`.
+
+**No `attribution` = the sample is claimed original**, and gate 20 says nothing —
+that case is what the human checkbox attests. The field is the honest author's
+way to record "I adapted this from X"; it does not and cannot catch undeclared
+copying. Do not read a green gate 20 as proof of originality.
+
+## Reviewer protocol
+
+For each code block a PR adds or changes:
+
+1. **Is it original?** Spot-check the non-trivial functions against the corpora
+   the lesson cites (they are outbound links in the prose). If a block reads like
+   a paraphrase of an all-rights-reserved or GPL-3.0 source, request a rewrite.
+2. **If it declares `attribution`:** confirm the upstream really is
+   LiteSVM/Mollusk/Surfpool (Apache-2.0) or Trident (MIT), and that the adaptation
+   is genuinely derived from that Apache/MIT project — not from a forbidden corpus
+   relabelled. Gate 20 catches the named-corpus and wrong-license cases; you catch
+   the "adapted from Neodyme but attributed to LiteSVM" case.
+3. **Tick the originality checkbox** only when both hold.
+
+## Follow-up: content-repo PR template (courses-academy)
+
+The originality checkbox lives in the **content repo's** PR template, which is a
+separate repository from this monorepo. Add the following to
+`academy-courses/.github/pull_request_template.md` in a follow-up content PR
+(this monorepo cannot push there):
+
+```markdown
+## Originality & licensing (CAT-15)
+
+- [ ] Every line of code I added is **original** — I did not copy or paraphrase
+      `program-examples`, `sealevel-attacks`, `developer-content`, the cookbook,
+      Ackee, `developer-bootcamp-2024`, Neodyme, Metaplex docs, or the GPL-3.0
+      `solana.com` docs. Those corpora were checklists and outbound links only.
+- [ ] Any code I **adapted** comes only from LiteSVM/Mollusk/Surfpool (Apache-2.0)
+      or Trident (MIT), and every such block declares it via `attribution:`
+      (`source`, `license`, `url`) so content-lint gate 20 can check it.
+```
+
+See `docs/superpowers/specs/2026-07-25-catalog-redesign-spec.md` §Licensing for
+the full corpus audit, and `packages/content-lint/README.md` for gate 20.

--- a/packages/content-lint/README.md
+++ b/packages/content-lint/README.md
@@ -23,10 +23,15 @@ exits non-zero **iff** any `error`-severity diagnostic is produced; `warning` an
 | **13b**                | Every block `type` is a `BLOCK_REGISTRY` key.                                                                                                                                                                                                                                 | error    |
 | **13c**                | Each `program-explorer` block's `idl` file parses as JSON with a non-empty `instructions` array and a non-empty `metadata.name`.                                                                                                                                              | error    |
 | **13d**                | Slot-exhaustion warning when a course's `slots.lock.json` `next > 200` (of 256).                                                                                                                                                                                              | warning  |
+| **19a–d**              | Skill-tag vocabulary — every lesson `skills:` slug resolves to `skills.yaml` (19a, error); reuse bar (19b, warning), interleaving pairs (19c, warning), facet-only tags (19d, notice). Unified launch spec §3 item 7.                                                         | mixed    |
+| **20a**                | Originality/licensing — a code block's optional `attribution` must not cite a forbidden corpus (program-examples, sealevel-attacks, developer-content, developer-bootcamp, Ackee, Neodyme, Metaplex, GPL-3.0 solana.com docs); fires regardless of declared license (CAT-15). | error    |
+| **20b**                | Originality/licensing — a declared `attribution.license` must be adaptable (Apache-2.0 or MIT: LiteSVM/Mollusk/Surfpool/Trident). No `attribution` = claimed original, attested by human review, not the linter. See `docs/CONTENT-ORIGINALITY.md`.                           | error    |
 
 Gates 8–12 (quest/achievement/path enums + caps) are enforced by the
 content-schema Zod refines at Gate 1. Gates 14–18 (governance, Sanity/Supabase/
 chain-config) run server-side at sync-time (spec §6.2), not in repo CI.
+Gate 19 (skill vocabulary) and gate 20 (originality/licensing) are numbered
+after §6.2's reserved 1–18.
 
 ## CLI
 

--- a/packages/content-lint/src/__tests__/gate20.test.ts
+++ b/packages/content-lint/src/__tests__/gate20.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from "vitest";
+import { runLint } from "../lint";
+import "../checks/gate1-schema";
+import "../checks/gate20-originality";
+import { makeTempRepo } from "./helpers";
+
+/**
+ * A lesson with a single code block. `attribution` is spliced in verbatim (or
+ * omitted) so each test drives exactly one declared-adaptation shape.
+ */
+function codeLesson(attributionYaml: string): Record<string, string> {
+  return {
+    "courses/x/lessons/a/lesson.yaml": `id: lesson-a
+slug: a
+title: A
+skills: [general]
+blocks:
+  - key: exercise
+    type: code
+    language: typescript
+    starter: exercise/starter.ts
+    solution: exercise/solution.ts
+    tests: exercise/tests.json
+${attributionYaml}`,
+  };
+}
+
+const of = (r: Awaited<ReturnType<typeof runLint>>, gate: string) =>
+  r.diagnostics.filter((d) => d.gate === gate);
+
+describe("gate 20 — originality & licensing attribution", () => {
+  it("says nothing when a code block has no attribution (claimed original)", async () => {
+    const r = await runLint(makeTempRepo(codeLesson("")));
+    expect(of(r, "gate-20a")).toEqual([]);
+    expect(of(r, "gate-20b")).toEqual([]);
+    expect(r.ok).toBe(true);
+  });
+
+  it("passes an Apache-2.0 upstream (LiteSVM)", async () => {
+    const r = await runLint(
+      makeTempRepo(
+        codeLesson(
+          `    attribution: { source: LiteSVM, license: Apache-2.0, url: "https://github.com/LiteSVM/litesvm" }\n`
+        )
+      )
+    );
+    expect(of(r, "gate-20a")).toEqual([]);
+    expect(of(r, "gate-20b")).toEqual([]);
+    expect(r.ok).toBe(true);
+  });
+
+  it("passes an MIT upstream (Trident)", async () => {
+    const r = await runLint(
+      makeTempRepo(
+        codeLesson(`    attribution: { source: Trident, license: MIT }\n`)
+      )
+    );
+    expect(of(r, "gate-20a")).toEqual([]);
+    expect(of(r, "gate-20b")).toEqual([]);
+    expect(r.ok).toBe(true);
+  });
+
+  it("errors 20b on a copyleft license (GPL-3.0)", async () => {
+    const r = await runLint(
+      makeTempRepo(
+        codeLesson(
+          `    attribution: { source: "some project", license: GPL-3.0 }\n`
+        )
+      )
+    );
+    const errs = of(r, "gate-20b");
+    expect(errs).toHaveLength(1);
+    expect(errs[0]!.severity).toBe("error");
+    expect(r.ok).toBe(false);
+  });
+
+  it("errors 20b on an unrecognised license", async () => {
+    const r = await runLint(
+      makeTempRepo(
+        codeLesson(
+          `    attribution: { source: "some project", license: "WTFPL" }\n`
+        )
+      )
+    );
+    expect(of(r, "gate-20b")).toHaveLength(1);
+    expect(r.ok).toBe(false);
+  });
+
+  it("errors 20a on a forbidden corpus even when the license claims MIT", async () => {
+    const r = await runLint(
+      makeTempRepo(
+        codeLesson(
+          `    attribution: { source: sealevel-attacks, license: MIT }\n`
+        )
+      )
+    );
+    // The forbidden-corpus gate fires and short-circuits the license gate.
+    expect(of(r, "gate-20a")).toHaveLength(1);
+    expect(of(r, "gate-20b")).toEqual([]);
+    expect(r.ok).toBe(false);
+  });
+
+  it("errors 20a when a forbidden corpus is named only in the url", async () => {
+    const r = await runLint(
+      makeTempRepo(
+        codeLesson(
+          `    attribution: { source: "an example", license: Apache-2.0, url: "https://github.com/solana-foundation/program-examples" }\n`
+        )
+      )
+    );
+    expect(of(r, "gate-20a")).toHaveLength(1);
+    expect(r.ok).toBe(false);
+  });
+
+  it("errors 20a on the GPL-3.0 live docs (solana.com)", async () => {
+    const r = await runLint(
+      makeTempRepo(
+        codeLesson(
+          `    attribution: { source: "cookbook", license: Apache-2.0, url: "https://solana.com/docs" }\n`
+        )
+      )
+    );
+    expect(of(r, "gate-20a")).toHaveLength(1);
+    expect(r.ok).toBe(false);
+  });
+});

--- a/packages/content-lint/src/checks/gate20-originality.ts
+++ b/packages/content-lint/src/checks/gate20-originality.ts
@@ -1,0 +1,86 @@
+import {
+  ALLOWED_LICENSES,
+  FORBIDDEN_CORPORA,
+  type AttributionT,
+} from "@superteam-lms/content-schema";
+import { registerCheck } from "../lint";
+import { type RepoModel } from "../model";
+import { diag, type Diagnostic } from "../diagnostics";
+
+/**
+ * Gate 20 — originality & licensing attribution (unified launch spec 2026-07-25
+ * §3 item 31, CAT-15). Numbered after §6.2's reserved 1–18 and gate 19 (item 7).
+ *
+ * The catalog rule is original-by-default: the reference corpora authors are
+ * pointed at are all-rights-reserved (program-examples, sealevel-attacks,
+ * developer-content, developer-bootcamp-2024, Ackee, Neodyme, Metaplex) or
+ * GPL-3.0 (the live solana.com docs/cookbook); only LiteSVM, Mollusk, Surfpool
+ * (Apache-2.0) and Trident (MIT) are adaptable. A CI check cannot prove a line
+ * of code is original — that is the human review checkbox item 31 asks for at
+ * minimum (docs/CONTENT-ORIGINALITY.md). What it CAN do is hold every *declared*
+ * adaptation to the allow-list, so the one place an author writes down "I copied
+ * this from X" is machine-verified:
+ *
+ *  20a (error)  the declared `source`/`url` matches a forbidden corpus — a hard
+ *               fail regardless of the license typed, because a mislabelled SPDX
+ *               id cannot launder an all-rights-reserved / GPL-3.0 corpus.
+ *  20b (error)  the declared `license` is not in ALLOWED_LICENSES (Apache-2.0,
+ *               MIT).
+ *
+ * A code block with no `attribution` emits nothing: it is claimed original, and
+ * the review checkbox is what attests that.
+ */
+
+const ALLOWED = new Set<string>(ALLOWED_LICENSES);
+
+/** Matches an attribution's source + url against the forbidden-corpus needles. */
+function forbiddenHit(
+  a: AttributionT
+): (typeof FORBIDDEN_CORPORA)[number] | undefined {
+  const haystack = `${a.source} ${a.url ?? ""}`.toLowerCase();
+  return FORBIDDEN_CORPORA.find((c) => haystack.includes(c.pattern));
+}
+
+export function gate20Check(model: RepoModel): Diagnostic[] {
+  const out: Diagnostic[] = [];
+  for (const entry of model.lessons) {
+    for (const raw of entry.lesson.blocks as Record<string, unknown>[]) {
+      if (raw.type !== "code") continue;
+      const attribution = raw.attribution as AttributionT | undefined;
+      if (!attribution) continue; // claimed original — the review checkbox covers it.
+
+      const key = String(raw.key);
+
+      // 20a — forbidden corpus wins over any declared license.
+      const hit = forbiddenHit(attribution);
+      if (hit) {
+        out.push(
+          diag(
+            "gate-20a",
+            "error",
+            entry.file,
+            `block "${key}" attributes code to "${attribution.source}", which is ${hit.name} — ${hit.reason}; it is a checklist/anchor only and cannot be adapted (CAT-15). Every line of catalog code must be original.`
+          )
+        );
+        continue;
+      }
+
+      // 20b — the declared license must be adaptable.
+      if (!ALLOWED.has(attribution.license)) {
+        out.push(
+          diag(
+            "gate-20b",
+            "error",
+            entry.file,
+            `block "${key}" declares license "${attribution.license}" for "${attribution.source}" — only ${ALLOWED_LICENSES.join(
+              " and "
+            )} upstreams (LiteSVM, Mollusk, Surfpool, Trident) may be adapted (CAT-15). Everything else is all-rights-reserved or GPL-3.0; write the sample from scratch.`
+          )
+        );
+      }
+    }
+  }
+  return out;
+}
+
+registerCheck(gate20Check);

--- a/packages/content-lint/src/index.ts
+++ b/packages/content-lint/src/index.ts
@@ -13,3 +13,4 @@ export * from "./checks/gate7-quiz";
 export * from "./checks/gate13a-capabilities";
 export * from "./checks/gate13bcd-widgets";
 export * from "./checks/gate19-skills";
+export * from "./checks/gate20-originality";

--- a/packages/content-schema/schema/lesson.schema.json
+++ b/packages/content-schema/schema/lesson.schema.json
@@ -173,6 +173,27 @@
                   "minLength": 1,
                   "maxLength": 500
                 }
+              },
+              "attribution": {
+                "type": "object",
+                "properties": {
+                  "source": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "license": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "url": {
+                    "type": "string",
+                    "format": "uri"
+                  }
+                },
+                "required": [
+                  "source",
+                  "license"
+                ]
               }
             },
             "required": [

--- a/packages/content-schema/src/__tests__/code.test.ts
+++ b/packages/content-schema/src/__tests__/code.test.ts
@@ -114,6 +114,40 @@ describe("CodeBlock", () => {
     expect(r.success).toBe(false);
   });
 
+  it("omits attribution by default (a code sample is claimed original)", () => {
+    expect(CodeBlock.parse(valid).attribution).toBeUndefined();
+  });
+
+  it("accepts an adaptation declaration; the license allow-list is gate 20's job", () => {
+    // Schema validates SHAPE only — a GPL-3.0 value parses here and is caught by
+    // content-lint gate 20 with an educational message (mirrors gate 19).
+    const b = CodeBlock.parse({
+      ...valid,
+      attribution: { source: "LiteSVM", license: "GPL-3.0" },
+    });
+    expect(b.attribution?.source).toBe("LiteSVM");
+  });
+
+  it("rejects an attribution with an empty source", () => {
+    const r = CodeBlock.safeParse({
+      ...valid,
+      attribution: { source: "", license: "MIT" },
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it("rejects an attribution url that is not a url", () => {
+    const r = CodeBlock.safeParse({
+      ...valid,
+      attribution: {
+        source: "LiteSVM",
+        license: "Apache-2.0",
+        url: "not a url",
+      },
+    });
+    expect(r.success).toBe(false);
+  });
+
   it("rejects a code block producing a capability it cannot create", () => {
     const r = CodeBlock.safeParse({
       ...valid,

--- a/packages/content-schema/src/blocks/code.ts
+++ b/packages/content-schema/src/blocks/code.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { blockBase, relativePath } from "./base";
+import { Attribution } from "../licensing";
 
 export const LANGUAGES = ["typescript", "rust"] as const;
 export const BUILD_TYPES = ["standard", "buildable"] as const;
@@ -53,6 +54,16 @@ export const CodeBlock = z
      * so authored input can never dominate the cache-shaped prefix.
      */
     tutorNotes: z.array(z.string().min(1).max(500)).max(6).optional(),
+    /**
+     * Optional adaptation declaration (unified launch spec §3 item 31, CAT-15).
+     * Absent = the sample is claimed ORIGINAL — the catalog default, and the
+     * common case; nothing is emitted. Present = the author is asserting they
+     * adapted an upstream, and content-lint gate 20 holds `license` to the
+     * ALLOWED_LICENSES allow-list and `source`/`url` to the forbidden-corpus
+     * list. The field cannot prove undeclared code is original — that is the
+     * human review checkbox (docs/CONTENT-ORIGINALITY.md).
+     */
+    attribution: Attribution.optional(),
   })
   .refine((b) => b.buildType !== "buildable" || b.language === "rust", {
     message: "buildType 'buildable' requires language 'rust'",

--- a/packages/content-schema/src/index.ts
+++ b/packages/content-schema/src/index.ts
@@ -2,6 +2,7 @@ export * from "./constants";
 export * from "./ids";
 export * from "./wallet";
 export * from "./capabilities";
+export * from "./licensing";
 export * from "./skills";
 export * from "./blocks";
 export * from "./lesson";

--- a/packages/content-schema/src/licensing.ts
+++ b/packages/content-schema/src/licensing.ts
@@ -1,0 +1,104 @@
+import { z } from "zod";
+
+/**
+ * Code-sample licensing policy (unified launch spec 2026-07-25 §3 item 31,
+ * CAT-15; catalog-redesign spec §Licensing).
+ *
+ * The catalog rule is **original-by-default**: "every word and every line of
+ * example code in this catalog is original." The reference corpora authors are
+ * pointed at are technical anchors, coverage checklists and outbound links — NOT
+ * copy sources. This module encodes the one machine-checkable corner of that
+ * rule: when a code block *declares* it adapted an upstream (the `attribution`
+ * field), content-lint gate 20 checks that the upstream is actually adaptable.
+ *
+ * It cannot prove originality of undeclared code — that is a human review step
+ * (the content-repo PR-template originality checkbox, see docs/CONTENT-ORIGINALITY.md).
+ * This is the assist, not the proof.
+ */
+
+/**
+ * SPDX ids of the only licenses whose code may be adapted into the catalog.
+ * CAT-15: LiteSVM, Mollusk and Surfpool are Apache-2.0; Trident is MIT — the
+ * testing layer C3 needs, and the only corpora that may be adapted at all.
+ * Everything else is all-rights-reserved (no license) or GPL-3.0 (copyleft,
+ * incompatible with this repo).
+ */
+export const ALLOWED_LICENSES = ["Apache-2.0", "MIT"] as const;
+export type AllowedLicense = (typeof ALLOWED_LICENSES)[number];
+
+/**
+ * The corpora authors are told to treat as checklists/anchors only, keyed by a
+ * lowercase substring matched against an attribution's `source` and `url`. A
+ * declared adaptation of any of these is a hard fail *regardless of the license
+ * the author typed* — a mislabelled SPDX id cannot launder an all-rights-reserved
+ * or GPL-3.0 corpus (CAT-15, catalog-redesign spec §Licensing).
+ */
+export const FORBIDDEN_CORPORA: readonly {
+  /** Human name for the diagnostic. */
+  name: string;
+  /** Lowercase needle matched against `source` + `url`. */
+  pattern: string;
+  /** Why it cannot be adapted. */
+  reason: string;
+}[] = [
+  {
+    name: "solana-foundation/program-examples",
+    pattern: "program-examples",
+    reason: "no license = all-rights-reserved",
+  },
+  {
+    name: "coral-xyz/sealevel-attacks",
+    pattern: "sealevel-attacks",
+    reason: "no license = all-rights-reserved",
+  },
+  {
+    name: "archived developer-content courses",
+    pattern: "developer-content",
+    reason: "no license = all-rights-reserved",
+  },
+  {
+    name: "developer-bootcamp-2024",
+    pattern: "developer-bootcamp",
+    reason: "no license = all-rights-reserved",
+  },
+  {
+    name: "Ackee school",
+    pattern: "ackee",
+    reason: "no license = all-rights-reserved",
+  },
+  {
+    name: "Neodyme",
+    pattern: "neodyme",
+    reason: "no license = all-rights-reserved",
+  },
+  {
+    name: "Metaplex docs / mpl-core",
+    pattern: "metaplex",
+    reason: "all-rights-reserved (mpl-core is a bespoke non-standard license)",
+  },
+  {
+    name: "live Solana docs / cookbook (solana-com)",
+    pattern: "solana.com",
+    reason: "GPL-3.0 — copyleft, incompatible with this repo",
+  },
+] as const;
+
+/**
+ * An optional per-code-block adaptation declaration. Absent = the block is
+ * claimed original (the catalog default), and gate 20 says nothing. Present =
+ * the author is asserting an upstream, and gate 20 holds them to the allow-list.
+ *
+ * Shape only lives here; the license allow-list and forbidden-corpus resolution
+ * are gate 20's job (mirroring gate 19: slug *shape* in schema, vocabulary
+ * *resolution* in the gate) so a bad value yields an educational gate-20 error
+ * naming the finding, not a terse gate-1 schema rejection.
+ */
+export const Attribution = z.object({
+  /** The upstream project the code was adapted from (e.g. "LiteSVM"). */
+  source: z.string().min(1),
+  /** The upstream's SPDX license id; checked against ALLOWED_LICENSES by gate 20. */
+  license: z.string().min(1),
+  /** Optional link to the upstream. */
+  url: z.string().url().optional(),
+});
+export type AttributionT = z.infer<typeof Attribution>;


### PR DESCRIPTION
Closes #604.

## What item 31 prescribes vs. what shipped

Unified launch spec `§3 item 31` ("Originality gate for catalog code") is
deliberately minimal: *"No CI check and no review gate enforces 'every word and
line is original'. **Add a review checkbox at minimum.**"* It is a cross-cutting
process item with **no issue**, not a plagiarism-detection build. CAT-15 is the
finding it rests on: the reference corpora authors are pointed at are
all-rights-reserved (program-examples, sealevel-attacks, developer-content,
Ackee, developer-bootcamp-2024, Neodyme, Metaplex) or GPL-3.0 (live solana.com
docs); only **LiteSVM/Mollusk/Surfpool (Apache-2.0)** and **Trident (MIT)** are
adaptable.

Shipped in two honest layers:

### 1. Human review — the item-31 "minimum" (`docs/CONTENT-ORIGINALITY.md`)
The originality policy, the CAT-15 corpus audit, a reviewer protocol, and the
exact **PR-template originality checkbox** to add to the *content repo*
(`academy-courses/.github/pull_request_template.md`) — documented here because
this monorepo cannot push to the content repo; it needs a follow-up content PR.
This human attestation is the actual originality guarantee. A linter cannot prove
a hand-written function is not a paraphrase, and the doc says so plainly.

### 2. content-lint **gate 20** — the machine assist
An optional `attribution` field on the code block (`source` / `license` / `url`),
checked by a new gate, numbered after §6.2's reserved 1–18 following gate 19:
- **20a** — a declared `source`/`url` that names a forbidden corpus fails,
  **regardless of the license typed** (a mislabelled SPDX id can't launder an
  all-rights-reserved / GPL-3.0 corpus).
- **20b** — a declared `license` outside Apache-2.0/MIT fails.

**No `attribution` = claimed original**, and gate 20 stays silent — that case is
what the human checkbox covers. The gate only holds *declared* adaptations to the
allow-list; it is not and does not claim to be originality-proof.

## Out of scope (deliberately not built)
No AI/plagiarism scanner, no fetching external corpora in CI — item 31 does not
ask for it and it would be theater. The undeclared-copy case is unclosable by a
linter by construction; it is closed by the human review step instead.

## Non-breaking
`attribution` is optional, so every existing code block lints clean. Regenerated
`lesson.schema.json` (byte-identical test enforced).

## Verification
- `content-schema`: 147 tests pass (incl. 4 new attribution schema cases)
- `content-lint`: 67 tests pass (incl. 8 new gate-20 cases)
- `typecheck` clean on both packages
- Prettier clean on all changed files (Husky/lint-staged passed on commit)
- E2E: CLI run against a temp tree with a `sealevel-attacks` attribution emits
  the gate-20a error and exits non-zero