### PR TITLE
feat(review): failure-capture feed on the completion deny path (LX-B4)

### DIFF
--- a/apps/web/src/app/api/lessons/complete/__tests__/gate.test.ts
+++ b/apps/web/src/app/api/lessons/complete/__tests__/gate.test.ts
@@ -57,6 +57,10 @@ vi.mock("@/lib/grading/graders", () => ({
   GRADERS: { code: () => codeGrader() },
 }));
 
+vi.mock("@/lib/review/schedule-review", () => ({
+  captureReviewFailure: vi.fn().mockResolvedValue(undefined),
+}));
+
 vi.mock("@/lib/ai/check-seal", () => ({
   openAttestation: () => openAttestation(),
 }));

--- a/apps/web/src/app/api/lessons/complete/__tests__/inflight-guard.test.ts
+++ b/apps/web/src/app/api/lessons/complete/__tests__/inflight-guard.test.ts
@@ -65,6 +65,9 @@ vi.mock("@/lib/content/queries", () => ({
   getCourseById,
 }));
 vi.mock("@/lib/grading/graders", () => ({ GRADERS: {} }));
+vi.mock("@/lib/review/schedule-review", () => ({
+  captureReviewFailure: vi.fn().mockResolvedValue(undefined),
+}));
 vi.mock("@/lib/ai/check-seal", () => ({ openAttestation: () => true }));
 vi.mock("@/lib/solana/academy-program", () => ({
   isOnChainProgramLive,

--- a/apps/web/src/app/api/lessons/complete/__tests__/review-capture.test.ts
+++ b/apps/web/src/app/api/lessons/complete/__tests__/review-capture.test.ts
@@ -1,9 +1,9 @@
 /* eslint-disable import/order -- vi.mock calls must precede importing the route. */
-// The 403 `reason` discriminator (#564): the route's 403 bodies must carry a
-// machine string the client can map to the RIGHT localized copy — without it a
-// failed quiz rendered the "verify enrollment" message. Companion to
-// gate.test.ts, with BOTH graders registered (gate.test.ts deliberately omits
-// `quiz` to prove the no-grader 503 path).
+// LX-B4: a GRADED miss on the completion route's deny path is captured into the
+// review substrate; a "could-not-judge" 503 and the non-learning denials
+// (enrollment / reflection) are NOT. Capture is best-effort — a capture failure
+// must never change the deny response. Shares the mock harness with
+// deny-reasons.test.ts.
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { NextRequest } from "next/server";
 import type { GradeResult } from "@/lib/grading/types";
@@ -22,6 +22,7 @@ const {
   isRateLimited,
   isCourseInMaintenance,
   isPlatformFrozen,
+  captureReviewFailure,
 } = vi.hoisted(() => ({
   getUser: vi.fn<() => Promise<unknown>>(),
   singleProfile: vi.fn<() => Promise<unknown>>(),
@@ -34,42 +35,34 @@ const {
   isRateLimited: vi.fn<(ns: string) => Promise<boolean>>(),
   isCourseInMaintenance: vi.fn<() => Promise<boolean>>(),
   isPlatformFrozen: vi.fn<() => Promise<boolean>>(),
+  captureReviewFailure: vi.fn<() => Promise<void>>(),
 }));
 
 vi.mock("@/lib/rate-limit", () => ({
   isRateLimited: (ns: string) => isRateLimited(ns),
   getClientIp: () => "203.0.113.7",
 }));
-
 vi.mock("@/lib/supabase/server", () => ({
   createClient: async () => ({ auth: { getUser } }),
 }));
-
 vi.mock("@/lib/supabase/admin", () => ({
   createAdminClient: () => ({
-    from: () => ({
-      select: () => ({ eq: () => ({ single: singleProfile }) }),
-    }),
+    from: () => ({ select: () => ({ eq: () => ({ single: singleProfile }) }) }),
   }),
 }));
-
 vi.mock("@/lib/content/queries", () => ({
   getLessonByIdForGrading,
   getCourseById,
 }));
-
 vi.mock("@/lib/grading/graders", () => ({
   GRADERS: { code: () => codeGrader(), quiz: () => quizGrader() },
 }));
-
 vi.mock("@/lib/review/schedule-review", () => ({
-  captureReviewFailure: vi.fn().mockResolvedValue(undefined),
+  captureReviewFailure: (...a: unknown[]) => captureReviewFailure(...(a as [])),
 }));
-
 vi.mock("@/lib/ai/check-seal", () => ({
   openAttestation: () => openAttestation(),
 }));
-
 vi.mock("@/lib/solana/academy-program", () => ({
   isOnChainProgramLive,
   completeLesson: vi.fn(),
@@ -96,14 +89,8 @@ function req(body: unknown): NextRequest {
     headers: { "content-type": "application/json" },
   });
 }
-
 const call = (proofs: Record<string, unknown> = {}) =>
   POST(req({ lessonId: "lesson-1", courseId: "course-1", proofs }));
-
-interface DenyBody {
-  error: string;
-  reason?: string;
-}
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -117,10 +104,11 @@ beforeEach(() => {
   isRateLimited.mockResolvedValue(false);
   isCourseInMaintenance.mockResolvedValue(false);
   isPlatformFrozen.mockResolvedValue(false);
+  captureReviewFailure.mockResolvedValue(undefined);
 });
 
-describe("403 reason discriminator (#564)", () => {
-  it("failed quiz grade → reason 'quiz_failed'", async () => {
+describe("LX-B4 failure capture on the deny path", () => {
+  it("captures a failed QUIZ (403) keyed by lesson id, reason quiz_failed", async () => {
     getLessonByIdForGrading.mockResolvedValue({
       blocks: [{ _type: "quiz", key: "q1" }],
     });
@@ -129,49 +117,48 @@ describe("403 reason discriminator (#564)", () => {
     const res = await call({ q1: { selections: { x: ["wrong"] } } });
 
     expect(res.status).toBe(403);
-    expect(((await res.json()) as DenyBody).reason).toBe("quiz_failed");
+    expect(captureReviewFailure).toHaveBeenCalledTimes(1);
+    expect(captureReviewFailure).toHaveBeenCalledWith({
+      userId: "user-1",
+      lessonId: "lesson-1",
+      reason: "quiz_failed",
+      failedTests: undefined,
+    });
   });
 
-  it("failed code grade → reason 'challenge_failed'", async () => {
+  it("captures a failed CHALLENGE (403) and plumbs its failedTests through", async () => {
     getLessonByIdForGrading.mockResolvedValue({
       blocks: [{ _type: "code", key: "c1" }],
     });
-    codeGrader.mockResolvedValue({ ok: false, status: 403 });
+    const failedTests = [
+      { id: "t2", hidden: true, passed: false, detail: "wrong output" },
+    ];
+    codeGrader.mockResolvedValue({ ok: false, status: 403, failedTests });
 
     const res = await call({ c1: { code: "wrong" } });
 
     expect(res.status).toBe(403);
-    expect(((await res.json()) as DenyBody).reason).toBe("challenge_failed");
-  });
-
-  it("mixed lesson where only the QUIZ fails → 'quiz_failed', not 'challenge_failed'", async () => {
-    getLessonByIdForGrading.mockResolvedValue({
-      blocks: [
-        { _type: "code", key: "c1" },
-        { _type: "quiz", key: "q1" },
-      ],
+    expect(captureReviewFailure).toHaveBeenCalledWith({
+      userId: "user-1",
+      lessonId: "lesson-1",
+      reason: "challenge_failed",
+      failedTests,
     });
-    codeGrader.mockResolvedValue({ ok: true });
-    quizGrader.mockResolvedValue({ ok: false, status: 403 });
-
-    const res = await call({ c1: { code: "ok" }, q1: { selections: {} } });
-
-    expect(res.status).toBe(403);
-    expect(((await res.json()) as DenyBody).reason).toBe("quiz_failed");
   });
 
-  it("missing reflection attestation → reason 'reflection_required'", async () => {
+  it("does NOT capture a 503 (could-not-judge, not a learning signal)", async () => {
     getLessonByIdForGrading.mockResolvedValue({
-      blocks: [{ _type: "openEnded", key: "o1" }],
+      blocks: [{ _type: "code", key: "c1" }],
     });
+    codeGrader.mockResolvedValue({ ok: false, status: 503 });
 
-    const res = await call({});
+    const res = await call({ c1: { code: "x" } });
 
-    expect(res.status).toBe(403);
-    expect(((await res.json()) as DenyBody).reason).toBe("reflection_required");
+    expect(res.status).toBe(503);
+    expect(captureReviewFailure).not.toHaveBeenCalled();
   });
 
-  it("missing on-chain enrollment → reason 'enrollment_missing'", async () => {
+  it("does NOT capture a missing-enrollment deny (grading passed — not a miss)", async () => {
     getLessonByIdForGrading.mockResolvedValue({
       blocks: [{ _type: "quiz", key: "q1" }],
     });
@@ -181,18 +168,32 @@ describe("403 reason discriminator (#564)", () => {
     const res = await call({ q1: { selections: {} } });
 
     expect(res.status).toBe(403);
-    expect(((await res.json()) as DenyBody).reason).toBe("enrollment_missing");
+    expect(captureReviewFailure).not.toHaveBeenCalled();
   });
 
-  it("grader 503 (could-not-judge) carries NO reason — the block did not fail", async () => {
+  it("does NOT capture a missing-reflection deny (not a graded miss)", async () => {
     getLessonByIdForGrading.mockResolvedValue({
-      blocks: [{ _type: "code", key: "c1" }],
+      blocks: [{ _type: "openEnded", key: "o1" }],
     });
-    codeGrader.mockResolvedValue({ ok: false, status: 503 });
 
-    const res = await call({ c1: { code: "x" } });
+    const res = await call({});
 
-    expect(res.status).toBe(503);
-    expect(((await res.json()) as DenyBody).reason).toBeUndefined();
+    expect(res.status).toBe(403);
+    expect(captureReviewFailure).not.toHaveBeenCalled();
+  });
+
+  it("best-effort: a capture throw NEVER changes the deny response", async () => {
+    getLessonByIdForGrading.mockResolvedValue({
+      blocks: [{ _type: "quiz", key: "q1" }],
+    });
+    quizGrader.mockResolvedValue({ ok: false, status: 403 });
+    captureReviewFailure.mockRejectedValue(new Error("substrate down"));
+
+    const res = await call({ q1: { selections: { x: ["wrong"] } } });
+
+    expect(res.status).toBe(403);
+    expect(((await res.json()) as { reason?: string }).reason).toBe(
+      "quiz_failed"
+    );
   });
 });

--- a/apps/web/src/app/api/lessons/complete/route.ts
+++ b/apps/web/src/app/api/lessons/complete/route.ts
@@ -6,6 +6,7 @@ import { createAdminClient } from "@/lib/supabase/admin";
 import { getCourseById, getLessonByIdForGrading } from "@/lib/content/queries";
 import type { CompletionDenyReason } from "@/lib/lessons/completion-error";
 import { GRADERS, type GradedBlockType } from "@/lib/grading/graders";
+import { captureReviewFailure } from "@/lib/review/schedule-review";
 import { openAttestation } from "@/lib/ai/check-seal";
 import { isRateLimited, getClientIp } from "@/lib/rate-limit";
 import { logError } from "@/lib/logging";
@@ -227,6 +228,20 @@ export async function POST(request: NextRequest) {
       if (!grader) return deny(503, "No grader for this block type");
       const result = await grader(block, proofs[block.key]);
       if (!result.ok) {
+        // A genuine graded MISS (403) is a learning signal → capture it into the
+        // review substrate keyed by this lesson (LX-B4). A 503 is "could not
+        // judge" (executor outage), not a miss — never captured. Best-effort:
+        // the helper never throws by contract, and the `.catch` here is a second
+        // guard so a review-write hiccup can NEVER change this deny response.
+        if (result.status === 403) {
+          await captureReviewFailure({
+            userId: user.id,
+            lessonId,
+            reason: type === "quiz" ? "quiz_failed" : "challenge_failed",
+            failedTests:
+              "failedTests" in result ? result.failedTests : undefined,
+          }).catch(() => {});
+        }
         // 503 = we could not judge (executor outage) — no `reason`, since the
         // block did not "fail"; grading was unavailable.
         return deny(

--- a/apps/web/src/lib/challenge/__tests__/executor.test.ts
+++ b/apps/web/src/lib/challenge/__tests__/executor.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect, vi, afterEach } from "vitest";
 
 vi.mock("server-only", () => ({}));
 import type { AdminTestCase, CodeBlockData } from "@superteam-lms/types";
-import { isExecutorAvailable, runJsSubmission } from "../executor";
 import { gradeCode } from "@/lib/grading/graders/code";
+import { isExecutorAvailable, runJsSubmission } from "../executor";
 
 // The executor runs on QuickJS compiled to WebAssembly (no native addon), so it
 // loads in every environment — CI, and Vercel serverless. EXECUTOR_AVAILABLE is
@@ -262,20 +262,24 @@ describe.skipIf(!EXECUTOR_AVAILABLE)("gradeCode (executor present)", () => {
     });
   });
 
-  it("403 for a wrong submission (gate would 403)", async () => {
-    expect(await gradeCode(codeBlock(), { code: WRONG })).toEqual({
-      ok: false,
-      status: 403,
-    });
+  it("403 for a wrong submission (gate would 403), carrying the failed tests (LX-B4)", async () => {
+    const result = await gradeCode(codeBlock(), { code: WRONG });
+    expect(result).toMatchObject({ ok: false, status: 403 });
+    // The failure-capture feed reads these; the real executor must surface them.
+    const failedTests = (result as { failedTests?: { passed: boolean }[] })
+      .failedTests;
+    expect(failedTests?.length).toBeGreaterThan(0);
+    expect(failedTests?.every((t) => !t.passed)).toBe(true);
   });
 
-  it("403 for a forged-visible-only submission", async () => {
-    expect(await gradeCode(codeBlock(), { code: PASSES_VISIBLE_ONLY })).toEqual(
-      {
-        ok: false,
-        status: 403,
-      }
-    );
+  it("403 for a forged-visible-only submission, capturing the failed HIDDEN test", async () => {
+    const result = await gradeCode(codeBlock(), { code: PASSES_VISIBLE_ONLY });
+    expect(result).toMatchObject({ ok: false, status: 403 });
+    const failedTests = (
+      result as { failedTests?: { hidden: boolean; passed: boolean }[] }
+    ).failedTests;
+    expect(failedTests?.some((t) => t.hidden)).toBe(true);
+    expect(failedTests?.every((t) => !t.passed)).toBe(true);
   });
 });
 

--- a/apps/web/src/lib/grading/__tests__/code-grader.test.ts
+++ b/apps/web/src/lib/grading/__tests__/code-grader.test.ts
@@ -68,6 +68,38 @@ describe("gradeCode", () => {
     });
   });
 
+  it("plumbs the FAILED test cases through on a 403 (LX-B4)", async () => {
+    isExecutorAvailable.mockResolvedValue(true);
+    runJsSubmission.mockResolvedValue({
+      available: true,
+      passed: false,
+      results: [
+        { id: "t1", hidden: false, passed: true, detail: "pass" },
+        { id: "t2", hidden: true, passed: false, detail: "wrong output" },
+      ],
+    });
+    expect(await gradeCode(jsBlock, { code: "wrong" })).toEqual({
+      ok: false,
+      status: 403,
+      // only the FAILING subset rides along — passing cases are dropped
+      failedTests: [
+        { id: "t2", hidden: true, passed: false, detail: "wrong output" },
+      ],
+    });
+  });
+
+  it("omits failedTests when the run has no per-test rows (degenerate verdict)", async () => {
+    runRustSubmission.mockResolvedValue({
+      available: true,
+      passed: false,
+      results: [],
+    });
+    const rustBlock = { ...jsBlock, language: "rust" as const };
+    const result = await gradeCode(rustBlock, { code: "fn main(){}" });
+    expect(result).toEqual({ ok: false, status: 403 });
+    expect("failedTests" in result).toBe(false);
+  });
+
   it("503 when the isolate is unavailable (degrade closed)", async () => {
     isExecutorAvailable.mockResolvedValue(false);
     expect(await gradeCode(jsBlock, { code: "x" })).toEqual({

--- a/apps/web/src/lib/grading/graders/code.ts
+++ b/apps/web/src/lib/grading/graders/code.ts
@@ -20,10 +20,21 @@ function isCodeProof(proof: unknown): proof is CodeProof {
   );
 }
 
-/** Map an executor run onto a grade verdict: pass→ok, fail→403, outage→503. */
+/**
+ * Map an executor run onto a grade verdict: pass→ok, fail→403, outage→503.
+ *
+ * On a fail with per-test detail, the failed cases ride along in `failedTests`
+ * (LX-B4 — stop discarding `run.results`): the failure-capture feed reads them
+ * to enrich the review item. Omitted when the run reported no per-test rows (a
+ * degenerate rust/build verdict) so the fail verdict stays exactly `{ok,status}`.
+ */
 function fromRun(run: SubmissionRunResult): GradeResult {
   if (!run.available) return { ok: false, status: 503 };
-  return run.passed ? { ok: true } : { ok: false, status: 403 };
+  if (run.passed) return { ok: true };
+  const failedTests = run.results.filter((r) => !r.passed);
+  return failedTests.length
+    ? { ok: false, status: 403, failedTests }
+    : { ok: false, status: 403 };
 }
 
 /**

--- a/apps/web/src/lib/grading/types.ts
+++ b/apps/web/src/lib/grading/types.ts
@@ -1,8 +1,18 @@
+import type { ServerTestResult } from "@/lib/challenge/executor";
+
 /**
  * A grader's verdict. `403` = a genuine wrong/absent answer; `503` = we could
  * NOT judge (executor outage, unrecognised type) → degrade CLOSED, never grant.
+ *
+ * `failedTests` (LX-B4) is present only on a `403` from a code grader that
+ * produced per-test results: the subset that failed, carried up so the
+ * failure-capture feed can enrich the review item. It is OMITTED (not `[]`) when
+ * there are no per-test results — a quiz miss, or a degenerate rust/build verdict
+ * with no rows. It never gates completion; the `status` alone does that.
  */
-export type GradeResult = { ok: true } | { ok: false; status: 403 | 503 };
+export type GradeResult =
+  | { ok: true }
+  | { ok: false; status: 403 | 503; failedTests?: ServerTestResult[] };
 
 /**
  * A grader is deterministic. It takes a projected block (`unknown` so the

--- a/apps/web/src/lib/review/__tests__/due-items.test.ts
+++ b/apps/web/src/lib/review/__tests__/due-items.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@/lib/supabase/types";
+import { getDueReviewItems, REVIEW_SESSION_CAP } from "../due-items";
+
+/**
+ * A fake query builder that records the terminal `.limit()` and `.lte()`/`.eq()`
+ * args and resolves like PostgREST. Every chain method returns `this` until the
+ * awaited `.limit()` resolves the recorded result.
+ */
+function fakeClient(rows: unknown[] = []) {
+  const calls: Record<string, unknown> = {};
+  const builder = {
+    select: vi.fn(() => builder),
+    eq: vi.fn((col: string, v: unknown) => {
+      calls[`eq:${col}`] = v;
+      return builder;
+    }),
+    lte: vi.fn((col: string, v: unknown) => {
+      calls[`lte:${col}`] = v;
+      return builder;
+    }),
+    order: vi.fn(() => builder),
+    limit: vi.fn((n: number) => {
+      calls.limit = n;
+      return Promise.resolve({ data: rows, error: null });
+    }),
+  };
+  const client = {
+    from: vi.fn(() => builder),
+  } as unknown as SupabaseClient<Database>;
+  return { client, builder, calls };
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("getDueReviewItems cap primitive (LX-B4)", () => {
+  it("caps at REVIEW_SESSION_CAP when no limit is given", async () => {
+    const { client, calls } = fakeClient();
+    await getDueReviewItems(client, "user-1");
+    expect(calls.limit).toBe(REVIEW_SESSION_CAP);
+  });
+
+  it("CLAMPS a caller that requests more than the cap — cannot ship uncapped", async () => {
+    const { client, calls } = fakeClient();
+    await getDueReviewItems(client, "user-1", { limit: 100 });
+    expect(calls.limit).toBe(REVIEW_SESSION_CAP);
+  });
+
+  it("honors a smaller limit (e.g. a 3-item dashboard strip)", async () => {
+    const { client, calls } = fakeClient();
+    await getDueReviewItems(client, "user-1", { limit: 3 });
+    expect(calls.limit).toBe(3);
+  });
+
+  it("returns the empty set for a non-positive limit (no negative .limit)", async () => {
+    const { client, builder } = fakeClient([{ item_key: "x" }]);
+    const out = await getDueReviewItems(client, "user-1", { limit: 0 });
+    expect(out).toEqual([]);
+    expect(builder.limit).not.toHaveBeenCalled();
+  });
+
+  it("scopes to the user and to DUE items (due_at <= now)", async () => {
+    const { client, calls } = fakeClient();
+    const now = new Date("2026-07-26T12:00:00.000Z");
+    await getDueReviewItems(client, "user-9", { now });
+    expect(calls["eq:user_id"]).toBe("user-9");
+    expect(calls["lte:due_at"]).toBe(now.toISOString());
+  });
+
+  it("passes rows through", async () => {
+    const rows = [{ item_key: "lesson-1", box: 1, due_at: "d", lapses: 0 }];
+    const { client } = fakeClient(rows);
+    expect(await getDueReviewItems(client, "user-1")).toEqual(rows);
+  });
+
+  it("throws on a query error (own-row read must surface failures)", async () => {
+    const client = {
+      from: () => ({
+        select: () => ({
+          eq: () => ({
+            lte: () => ({
+              order: () => ({
+                limit: () =>
+                  Promise.resolve({ data: null, error: { message: "rls" } }),
+              }),
+            }),
+          }),
+        }),
+      }),
+    } as unknown as SupabaseClient<Database>;
+    await expect(getDueReviewItems(client, "user-1")).rejects.toThrow("rls");
+  });
+});

--- a/apps/web/src/lib/review/__tests__/schedule-review.test.ts
+++ b/apps/web/src/lib/review/__tests__/schedule-review.test.ts
@@ -1,0 +1,91 @@
+/* eslint-disable import/order -- vi.mock must precede importing the helper. */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const { rpc, logError } = vi.hoisted(() => ({
+  rpc: vi.fn<(...a: unknown[]) => Promise<{ error: unknown }>>(),
+  logError: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: () => ({ rpc: (...a: unknown[]) => rpc(...a) }),
+}));
+vi.mock("@/lib/logging", () => ({ logError }));
+
+import { captureReviewFailure } from "../schedule-review";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  rpc.mockResolvedValue({ error: null });
+});
+
+describe("captureReviewFailure", () => {
+  it("enqueues the lesson id as the review item_key via the RPC", async () => {
+    await captureReviewFailure({
+      userId: "user-1",
+      lessonId: "lesson-abc",
+      reason: "quiz_failed",
+    });
+
+    expect(rpc).toHaveBeenCalledWith("schedule_review_item", {
+      p_user_id: "user-1",
+      p_item_key: "lesson-abc",
+    });
+    expect(logError).not.toHaveBeenCalled();
+  });
+
+  it("does NOT strip/transform the lesson id (PDA-seed convention)", async () => {
+    await captureReviewFailure({
+      userId: "u",
+      lessonId: "lesson-what-is-a-pda",
+      reason: "challenge_failed",
+    });
+    expect(rpc).toHaveBeenCalledWith("schedule_review_item", {
+      p_user_id: "u",
+      p_item_key: "lesson-what-is-a-pda",
+    });
+  });
+
+  it("swallows an RPC error — never throws (best-effort contract)", async () => {
+    rpc.mockResolvedValue({ error: { message: "boom" } });
+    await expect(
+      captureReviewFailure({
+        userId: "u",
+        lessonId: "l",
+        reason: "quiz_failed",
+      })
+    ).resolves.toBeUndefined();
+    expect(logError).toHaveBeenCalledTimes(1);
+  });
+
+  it("swallows a thrown client error too", async () => {
+    rpc.mockRejectedValue(new Error("network down"));
+    await expect(
+      captureReviewFailure({
+        userId: "u",
+        lessonId: "l",
+        reason: "quiz_failed",
+      })
+    ).resolves.toBeUndefined();
+    expect(logError).toHaveBeenCalledTimes(1);
+  });
+
+  it("logs the failing test ids for observability, not the box math", async () => {
+    rpc.mockResolvedValue({ error: { message: "x" } });
+    await captureReviewFailure({
+      userId: "u",
+      lessonId: "l",
+      reason: "challenge_failed",
+      failedTests: [
+        { id: "t2", hidden: true, passed: false, detail: "wrong" },
+        { id: "t5", hidden: false, passed: false, detail: "wrong" },
+      ],
+    });
+    const arg = logError.mock.calls[0]?.[0] as {
+      context: { failedTestIds: string[]; step: string };
+    };
+    expect(arg.context.failedTestIds).toEqual(["t2", "t5"]);
+    expect(arg.context.step).toBe("review_capture");
+  });
+});

--- a/apps/web/src/lib/review/due-items.ts
+++ b/apps/web/src/lib/review/due-items.ts
@@ -1,0 +1,60 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@/lib/supabase/types";
+
+/**
+ * Per-session flood-shaping cap (LX-B4 hard constraint, from PR #689's
+ * adversarial review). The #569 seed enqueues EVERY completed lesson as a box-1
+ * item due tomorrow, simultaneously, for the whole cohort — so the first time
+ * any learner-facing surface reads the queue, a heavy learner would face their
+ * entire backlog as one wall. The spec sizes the review surface at "a 3–6-item
+ * Leitner review strip" (unified spec §1; LX-B6 dashboard strip: "3–6 due
+ * items"). `6` is the upper bound of that band and the HARD ceiling: no surface
+ * may pull more than this in one read.
+ *
+ * This is why the cap is a shared primitive and not a per-caller `.limit(...)`:
+ * the /review page (#571) and the dashboard strip (#572) both go through
+ * `getDueReviewItems`, which clamps to `REVIEW_SESSION_CAP` regardless of the
+ * requested limit, so neither can ship an uncapped read.
+ */
+export const REVIEW_SESSION_CAP = 6;
+
+/** A due review item as the feed surfaces consume it (own-row read). */
+export type DueReviewItem = Pick<
+  Database["public"]["Tables"]["review_items"]["Row"],
+  "item_key" | "box" | "due_at" | "lapses"
+>;
+
+/**
+ * Read a learner's DUE review items (`due_at <= now`), soonest first, capped to
+ * `REVIEW_SESSION_CAP`. This is the ONE read path for every review surface.
+ *
+ * Works with any client: own-row RLS SELECT (LX-B3) restricts an authenticated
+ * client to the learner's own rows automatically, while the explicit
+ * `user_id` filter keeps it correct under the RLS-bypassing admin client too.
+ *
+ * `limit` may narrow the pull (e.g. a 3-item dashboard strip) but is CLAMPED to
+ * the cap — a caller can never widen past it. A non-positive limit yields the
+ * empty set (nothing due to show), never a negative `.limit`.
+ */
+export async function getDueReviewItems(
+  supabase: SupabaseClient<Database>,
+  userId: string,
+  options: { limit?: number; now?: Date } = {}
+): Promise<DueReviewItem[]> {
+  const requested = options.limit ?? REVIEW_SESSION_CAP;
+  const cap = Math.min(Math.max(0, requested), REVIEW_SESSION_CAP);
+  if (cap === 0) return [];
+
+  const nowIso = (options.now ?? new Date()).toISOString();
+
+  const { data, error } = await supabase
+    .from("review_items")
+    .select("item_key, box, due_at, lapses")
+    .eq("user_id", userId)
+    .lte("due_at", nowIso)
+    .order("due_at", { ascending: true })
+    .limit(cap);
+
+  if (error) throw new Error(error.message);
+  return data ?? [];
+}

--- a/apps/web/src/lib/review/schedule-review.ts
+++ b/apps/web/src/lib/review/schedule-review.ts
@@ -1,0 +1,68 @@
+import "server-only";
+import type { ServerTestResult } from "@/lib/challenge/executor";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { logError } from "@/lib/logging";
+import { ERROR_IDS } from "@/constants/errorIds";
+
+/**
+ * A failed-completion signal worth reviewing (LX-B4). Only a GRADED miss — a
+ * wrong quiz or a failed challenge — is a learning signal. Enrollment,
+ * attestation, and maintenance denials are NOT: they say nothing about what the
+ * learner does or doesn't know, so they never reach here.
+ */
+export interface ReviewFailureCapture {
+  userId: string;
+  /**
+   * The raw lesson `_id` — the review substrate's `item_key` (PDA-seed
+   * convention: never strip/transform ids). One review row per learner per
+   * lesson, regardless of which block inside the lesson failed.
+   */
+  lessonId: string;
+  reason: "quiz_failed" | "challenge_failed";
+  /**
+   * The failing test cases, when the grader produced per-test detail (code
+   * challenges). Carried for observability / future item enrichment; the box
+   * math never reads it. Absent for quiz misses and degenerate rust/build rows.
+   */
+  failedTests?: ServerTestResult[];
+}
+
+/**
+ * Enqueue a failed lesson's retrieval item into the review substrate (LX-B4).
+ *
+ * BEST-EFFORT BY CONTRACT: this never throws and never returns a signal the
+ * caller must branch on. A capture failure must never change the completion
+ * route's deny response — the learner already failed grading; whether the review
+ * row was written is orthogonal. Every error is swallowed here (and logged), and
+ * the call site adds a second `.catch` so even a contract violation can't leak.
+ *
+ * Box math lives ONLY in the `schedule_review_item` / `record_review_result`
+ * SECURITY DEFINER RPCs (service_role, via the admin client). This helper is a
+ * thin, idempotent enqueue: `schedule_review_item` is `ON CONFLICT DO NOTHING`,
+ * so re-capturing a lesson never resets a learner's hard-won box progress.
+ */
+export async function captureReviewFailure(
+  capture: ReviewFailureCapture
+): Promise<void> {
+  try {
+    const admin = createAdminClient();
+    const { error } = await admin.rpc("schedule_review_item", {
+      p_user_id: capture.userId,
+      p_item_key: capture.lessonId,
+    });
+    if (error) throw new Error(error.message);
+  } catch (err) {
+    logError({
+      errorId: ERROR_IDS.LESSON_COMPLETE_FAILED,
+      error: err instanceof Error ? err : new Error(String(err)),
+      context: {
+        route: "/api/lessons/complete",
+        step: "review_capture",
+        userId: capture.userId,
+        lessonId: capture.lessonId,
+        reason: capture.reason,
+        failedTestIds: capture.failedTests?.map((t) => t.id),
+      },
+    });
+  }
+}


### PR DESCRIPTION
Closes #570 — **Review spine 2/3: failure-capture feed** (LX-B4). Builds on #689's `review_items` substrate.

## What this does
Stops discarding per-test grading results and turns a **failed completion** into a spaced-repetition review item, keyed by lesson `_id`.

### 1. Plumb `ServerTestResult[]` through `fromRun` (`graders/code.ts`)
`fromRun` collapsed every run to `{ok,status}`, throwing away `run.results`. Now a `403` carries the **failing** `ServerTestResult[]` in `GradeResult.failedTests` (omitted — not `[]` — when the run produced no per-test rows, e.g. a degenerate rust/build verdict, so the fail shape stays `{ok,status}`). `failedTests` never gates completion; `status` alone does.

### 2. Capture on the deny path (`/api/lessons/complete`)
On a **graded miss only** — `quiz_failed` / `challenge_failed` (403) — the route best-effort enqueues the lesson into the review substrate. Explicitly **not** captured:
- **503** (executor outage / could-not-judge) — not a learning signal.
- **enrollment_missing**, **reflection_required** — grading already passed / not a graded miss; these say nothing about what the learner knows.

Capture is isolated two ways: `captureReviewFailure` never throws by contract (swallows + logs internally), **and** the call site adds `.catch(() => {})`. A review-write hiccup can never change the deny response the learner sees.

### 3. Cap-before-feed primitive (`lib/review/due-items.ts`)
Per #570's pinned hard constraint (from #689's adversarial review): the #569 seed floods box-1 items due-tomorrow for the whole cohort, so the first learner-facing read must be capped. `getDueReviewItems` is the **one** read path for every review surface; it clamps any requested limit to `REVIEW_SESSION_CAP = 6` (upper bound of the spec's "3–6 item" review strip). #571's /review page and the dashboard strip both go through it, so **neither can ship an uncapped read**. No caller in this PR yet — it's the shared, tested primitive #571 consumes.

Box math stays entirely in #689's `schedule_review_item` / `record_review_result` RPCs — not re-implemented here.

## Verification
- `pnpm typecheck` (turbo, 6/6 packages) — clean
- `pnpm test` (apps/web) — **1433 passed**; the real-QuickJS integration tests (`gradeCode (executor present)`) ran (not skipped), proving `failedTests` flows end-to-end from the actual executor through `fromRun`
- `pnpm lint` — clean (only pre-existing import/order warnings in untouched files)

New tests: `fromRun` plumbing (unit + real-executor); deny-path capture fires on qualifying denials only + best-effort isolation; `captureReviewFailure` never-throws contract; `getDueReviewItems` cap clamping.

## Out of scope / notes
- No new caller for `getDueReviewItems` — #571 (/review) and the dashboard strip consume it.
- `/api/lessons/validate-challenge` remains a verified orphan; wiring it is optional per the spec, not done.
- v1 feeds on **submit-failure only** — practice "Run" stays client-side; no new rate-limit exposure.