### PR TITLE
content: bump content.lock to e1190680 — retrieval closes + 52b fixes + tutorNotes + reviewExempt

### DIFF
--- a/apps/web/content.lock
+++ b/apps/web/content.lock
@@ -1,4 +1,4 @@
 {
   "repo": "solanabr/courses-academy",
-  "sha": "012cd03ddcaa1122283a742862d5c5b885a7a913"
+  "sha": "e1190680421e8190ab4deb9b41376667abc7a398"
 }

--- a/apps/web/src/content/generated/lessons.json
+++ b/apps/web/src/content/generated/lessons.json
@@ -67,6 +67,62 @@
         "_key": "intro",
         "_type": "prose",
         "src": "# Understanding Solana's Account Model\n\nSolana's account model is fundamentally different from Ethereum's contract-based approach. Understanding this model is crucial for building efficient Solana programs.\n\n## Everything is an Account\n\nIn Solana, **everything is an account**. Unlike Ethereum where contracts hold state, Solana separates code (programs) from data (accounts):\n\n- **Programs**: Executable code (stateless)\n- **Accounts**: Store data and SOL balance\n\n```typescript\ninterface Account {\n  publicKey: PublicKey;     // Account address\n  owner: PublicKey;         // Program that owns this account\n  lamports: number;         // SOL balance (1 SOL = 1B lamports)\n  data: Uint8Array;         // Raw account data\n  executable: boolean;      // Is this a program?\n  rentEpoch: number;        // Rent collection tracking\n}\n```\n\n## The Owner-Account Relationship\n\nEvery account has an **owner** (a program). Only the owner program can:\n- Modify the account's data\n- Deduct lamports from the account\n\nFor example:\n- Your wallet is owned by the **System Program**\n- Token accounts are owned by the **Token Program**\n- Your custom program owns its data accounts\n\n```typescript\nconst accountInfo = await connection.getAccountInfo(publicKey);\nconsole.log('Owner:', accountInfo.owner.toBase58());\n// System Program: 11111111111111111111111111111111\n// Token Program: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA\n```\n\n## Rent and Account Lifetime\n\nSolana accounts must maintain a minimum SOL balance to remain active (called **rent exemption**). The required balance depends on the account's data size:\n\n```typescript\nconst rentExemption = await connection.getMinimumBalanceForRentExemption(\n  dataSize // bytes\n);\n```\n\n**Best Practice**: Always create accounts with enough SOL to be rent-exempt. Rent-exempt accounts never expire.\n\n## System Accounts vs Program Accounts\n\n### System Accounts\n- Owned by the System Program (`11111111111111111111111111111111`)\n- Hold SOL but no custom data\n- Your wallet is a system account\n\n### Program Accounts\n- Owned by custom programs\n- Store structured data (game state, user profiles, DeFi positions, etc.)\n- Created via CPI (Cross-Program Invocation) to the System Program\n\n## Real-World Example: Jupiter Aggregator\n\nJupiter, the leading Solana DEX aggregator, uses accounts to store:\n- User token accounts (owned by Token Program)\n- Swap routing data (owned by Jupiter Program)\n- Price feed data (owned by Pyth oracle program)\n\nEach account has a specific owner and purpose, creating a composable ecosystem.\n\n## Key Takeaways\n\n1. Programs are stateless; accounts hold all data\n2. Only the owner program can modify an account's data\n3. Accounts must be rent-exempt to persist\n4. The account model enables Solana's parallel processing\n"
+      },
+      {
+        "_key": "retrieval-close",
+        "_type": "quiz",
+        "questions": [
+          {
+            "explanation": "Every account names an owner program, and the runtime lets only that owner mutate the account's data or reduce its lamports. To move SOL out of a wallet you must go through the System Program via a signed transfer, not reach in from another program — this ownership rule is what keeps funds safe.",
+            "id": "q1",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "It fails — only the account's owner program (here the System Program) can deduct its lamports or modify its data"
+              },
+              {
+                "correct": false,
+                "feedback": "Being passed an account grants read access, not write access. Only the owner program may mutate data or debit lamports — this is the core safety invariant.",
+                "id": "b",
+                "label": "It succeeds, because any program can modify any account it is passed"
+              },
+              {
+                "correct": false,
+                "feedback": "Writable marks intent, but the runtime still enforces ownership: a non-owner cannot debit lamports even on a writable account. The System Program owns wallets.",
+                "id": "c",
+                "label": "It succeeds only if the account is marked writable"
+              }
+            ],
+            "prompt": "Your custom program tries to directly subtract lamports from a user's wallet (a System Program account). What happens?"
+          },
+          {
+            "explanation": "Solana can reclaim accounts that fall below a size-based minimum balance. Funding to rent-exemption at creation means the account holds enough SOL to persist forever, so your program's state does not silently disappear.",
+            "id": "q2",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "Below the rent-exempt balance the account can be purged; at or above it, the account persists indefinitely"
+              },
+              {
+                "correct": false,
+                "feedback": "Rent-exemption is not a fee for the treasury — it is a balance threshold. Fall below it and the account can be reclaimed; meet it and it never expires.",
+                "id": "b",
+                "label": "Rent is a one-time network fee unrelated to keeping the account alive"
+              },
+              {
+                "correct": false,
+                "feedback": "Rent-exemption has nothing to do with execution speed. It is the minimum balance, scaled by data size, that keeps the account from being garbage-collected.",
+                "id": "c",
+                "label": "It pays the validator to execute your program faster"
+              }
+            ],
+            "prompt": "Why must you fund a new account to its 'rent-exempt' minimum when you create it?"
+          }
+        ]
       }
     ],
     "skills": [
@@ -167,6 +223,62 @@
         "_key": "intro",
         "_type": "prose",
         "src": "# Anchor Account Constraints\n\nAnchor's constraint system is one of its most powerful features. Constraints allow you to declaratively specify account validation rules, and Anchor enforces them automatically.\n\n## The #[account] Attribute\n\nThe `#[account(...)]` attribute is used to apply constraints to accounts in your instruction context:\n\n```rust\n#[derive(Accounts)]\npub struct UpdateUserData<'info> {\n    #[account(\n        mut,\n        has_one = authority,\n        constraint = user.data_version < 10 @ ErrorCode::VersionTooHigh\n    )]\n    pub user: Account<'info, UserAccount>,\n    pub authority: Signer<'info>,\n}\n```\n\n## Common Constraints\n\n### 1. init - Initialize a New Account\n\n```rust\n#[account(\n    init,\n    payer = user,\n    space = 8 + 32 + 8\n)]\npub my_account: Account<'info, MyAccount>,\n```\n\n- Allocates space for the account\n- Transfers lamports from payer\n- Assigns account to the program\n- Sets account discriminator\n\n**Space calculation**: `8 (discriminator) + account_data_size`\n\n### 2. mut - Mark Account as Mutable\n\n```rust\n#[account(mut)]\npub user: Account<'info, UserAccount>,\n```\n\nRequires the account to be writable. Anchor will reject the transaction if the account isn't marked as writable.\n\n### 3. has_one - Verify Account Relationship\n\n```rust\n#[account]\npub struct UserAccount {\n    pub authority: Pubkey,\n    pub counter: u64,\n}\n\n#[derive(Accounts)]\npub struct Increment<'info> {\n    #[account(\n        mut,\n        has_one = authority\n    )]\n    pub user: Account<'info, UserAccount>,\n    pub authority: Signer<'info>,\n}\n```\n\n`has_one = authority` checks that `user.authority == authority.key()`. This prevents unauthorized updates.\n\n### 4. seeds & bump - PDA Derivation\n\n```rust\n#[account(\n    init,\n    payer = user,\n    space = 8 + 32 + 8,\n    seeds = [b\"user\", user.key().as_ref()],\n    bump\n)]\npub user_account: Account<'info, UserAccount>,\n```\n\n- `seeds`: The seeds used to derive the PDA\n- `bump`: Anchor finds the canonical bump automatically\n\nYou can also use a saved bump:\n\n```rust\n#[account(\n    mut,\n    seeds = [b\"user\", authority.key().as_ref()],\n    bump = user_account.bump\n)]\npub user_account: Account<'info, UserAccount>,\n```\n\n### 5. constraint - Custom Constraints\n\n```rust\n#[account(\n    mut,\n    constraint = user.balance >= 100 @ ErrorCode::InsufficientFunds,\n    constraint = user.is_active @ ErrorCode::AccountInactive\n)]\npub user: Account<'info, UserAccount>,\n```\n\nCustom constraints let you enforce arbitrary rules. The `@ ErrorCode::...` syntax specifies which error to return if the constraint fails.\n\n## Space Calculation\n\nWhen using `init`, you must specify the account size:\n\n```rust\n#[account]\npub struct UserAccount {\n    pub authority: Pubkey,    // 32 bytes\n    pub counter: u64,         // 8 bytes\n    pub name: String,         // 4 + length (max 32) = 36 bytes\n}\n\n// Space = 8 (discriminator) + 32 + 8 + 36 = 84 bytes\n```\n\n**Common sizes**:\n- Pubkey: 32 bytes\n- u64/i64: 8 bytes\n- u32/i32: 4 bytes\n- bool: 1 byte\n- String: 4 (length prefix) + max_length\n- Vec<T>: 4 (length prefix) + (item_size * max_count)\n\n## Constraint Execution Order\n\nAnchor executes constraints in this order:\n1. `init` / `init_if_needed`\n2. `mut`\n3. `seeds` + `bump`\n4. `has_one`\n5. Custom `constraint`s\n\nThis ensures accounts are properly initialized and validated before your instruction logic runs.\n\n## Next Challenge\n\nYou'll implement account validation logic that mimics Anchor's constraint system.\n"
+      },
+      {
+        "_key": "retrieval-close",
+        "_type": "quiz",
+        "questions": [
+          {
+            "explanation": "`has_one = authority` enforces that the account's stored `authority` field matches the `authority` account supplied to the instruction. Without it, anyone could pass someone else's account and update it — the constraint turns a stored relationship into an authorization gate.",
+            "id": "q1",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "It checks `user.authority == authority.key()`, blocking a caller from modifying an account they do not own"
+              },
+              {
+                "correct": false,
+                "feedback": "Writability is `mut`. `has_one = authority` verifies the account's stored `authority` field equals the passed authority account — an authorization check.",
+                "id": "b",
+                "label": "It checks that the account is writable"
+              },
+              {
+                "correct": false,
+                "feedback": "That is not what has_one does. It ties a stored pubkey field to a passed account, preventing unauthorized updates.",
+                "id": "c",
+                "label": "It checks that the account was created by the System Program"
+              }
+            ],
+            "prompt": "`has_one = authority` on a `UserAccount` field checks what, and which attack does it stop?"
+          },
+          {
+            "explanation": "A `constraint = <expr>` must hold or the instruction is rejected, and `@ ErrorCode::X` names the error emitted on failure. This lets you attach a specific, client-readable reason to each declarative check rather than a generic failure.",
+            "id": "q2",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "The specific error returned if the constraint is false, so the client learns why validation failed"
+              },
+              {
+                "correct": false,
+                "feedback": "Constraints validate, they never assign. `@ ErrorCode::...` only names the error returned on failure; it does not change `balance`.",
+                "id": "b",
+                "label": "It sets the balance to 100 if the check fails"
+              },
+              {
+                "correct": false,
+                "feedback": "No retry happens. A failed constraint aborts the instruction and returns the named error.",
+                "id": "c",
+                "label": "It retries the instruction until balance reaches 100"
+              }
+            ],
+            "prompt": "A constraint reads `constraint = user.balance >= 100 @ ErrorCode::InsufficientFunds`. What does the `@ ErrorCode::...` part control?"
+          }
+        ]
       }
     ],
     "skills": [
@@ -272,7 +384,7 @@
       {
         "_key": "intro",
         "_type": "prose",
-        "src": "# What is the Anchor Framework?\n\nAnchor is the most popular framework for Solana smart contract development. It provides a Rust-based DSL (domain-specific language) that dramatically reduces boilerplate and makes programs safer, faster to write, and easier to read.\n\n## Why Use Anchor?\n\nWriting native Solana programs in Rust requires:\n- Manual account deserialization and validation\n- Verbose error handling\n- Security checks spread across your code\n- Repetitive boilerplate for common patterns\n\nAnchor handles all of this for you through **macros** and **attributes**.\n\n### Native Solana Program\n\n```rust\n// Manual account deserialization\nlet account_info_iter = &mut accounts.iter();\nlet user_account = next_account_info(account_info_iter)?;\n\n// Manual validation\nif !user_account.is_writable {\n    return Err(ProgramError::InvalidAccountData);\n}\n\n// Manual owner check\nif user_account.owner != program_id {\n    return Err(ProgramError::IncorrectProgramId);\n}\n```\n\n### Anchor Program\n\n```rust\n#[derive(Accounts)]\npub struct UpdateUser<'info> {\n    #[account(mut)]\n    pub user: Account<'info, UserAccount>,\n}\n```\n\nAnchor automatically validates that the account is writable and owned by the program!\n\n## Anchor Project Structure\n\nA typical Anchor project:\n\n```\nmy-anchor-project/\n├── programs/\n│   └── my-program/\n│       └── src/\n│           └── lib.rs      # Your program code\n├── tests/\n│   └── my-program.ts       # TypeScript tests\n├── migrations/\n│   └── deploy.ts           # Deployment scripts\n└── Anchor.toml             # Configuration\n```\n\n## Key Anchor Components\n\n### 1. Program Module\n\n```rust\nuse anchor_lang::prelude::*;\n\ndeclare_id!(\"YourProgramIDHere\");\n\n#[program]\npub mod my_program {\n    use super::*;\n\n    pub fn initialize(ctx: Context<Initialize>) -> Result<()> {\n        // Your logic here\n        Ok(())\n    }\n}\n```\n\nThe `#[program]` macro defines your program's instruction handlers.\n\n### 2. Accounts Struct\n\n```rust\n#[derive(Accounts)]\npub struct Initialize<'info> {\n    #[account(\n        init,\n        payer = user,\n        space = 8 + 32 + 8\n    )]\n    pub my_account: Account<'info, MyAccount>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n    pub system_program: Program<'info, System>,\n}\n```\n\nAccounts structs define what accounts your instruction needs and how to validate them.\n\n### 3. Account Data\n\n```rust\n#[account]\npub struct MyAccount {\n    pub authority: Pubkey,\n    pub counter: u64,\n}\n```\n\nThe `#[account]` macro adds serialization/deserialization and a discriminator for account type safety.\n\n## Anchor vs Native: Security Benefits\n\n| Security Check | Native | Anchor |\n|----------------|--------|--------|\n| Account ownership | Manual check | Automatic via Account<'info, T> |\n| Signer verification | Manual check | Automatic via Signer<'info> |\n| Writable validation | Manual check | Automatic via #[account(mut)] |\n| Account initialization | Manual allocation | Automatic via #[account(init)] |\n| Discriminator (type safety) | None | Automatic 8-byte discriminator |\n\nAnchor programs are **harder to exploit** because common security pitfalls are prevented by the framework itself.\n\n## Next Steps\n\nIn the next challenge, you'll build a mock Anchor program structure to understand how programs are organized on Solana.\n"
+        "src": "# What is the Anchor Framework?\n\nAnchor is the most popular framework for Solana smart contract development. It provides a Rust-based DSL (domain-specific language) that dramatically reduces boilerplate and makes programs safer, faster to write, and easier to read.\n\n## Who This Course Is For\n\nThis course is aimed at JavaScript and TypeScript developers moving into Solana — **no Solidity or prior smart-contract experience is assumed.** If you can write JS/TS, you have enough to start; the Rust and Anchor concepts you need are introduced from the ground up as they come up. You do not have to \"learn Ethereum first\" to build here.\n\n## Why Use Anchor?\n\nWriting native Solana programs in Rust requires:\n- Manual account deserialization and validation\n- Verbose error handling\n- Security checks spread across your code\n- Repetitive boilerplate for common patterns\n\nAnchor handles all of this for you through **macros** and **attributes**.\n\n### Native Solana Program\n\n```rust\n// Manual account deserialization\nlet account_info_iter = &mut accounts.iter();\nlet user_account = next_account_info(account_info_iter)?;\n\n// Manual validation\nif !user_account.is_writable {\n    return Err(ProgramError::InvalidAccountData);\n}\n\n// Manual owner check\nif user_account.owner != program_id {\n    return Err(ProgramError::IncorrectProgramId);\n}\n```\n\n### Anchor Program\n\n```rust\n#[derive(Accounts)]\npub struct UpdateUser<'info> {\n    #[account(mut)]\n    pub user: Account<'info, UserAccount>,\n}\n```\n\nAnchor automatically validates that the account is writable and owned by the program!\n\n## Anchor Project Structure\n\nA typical Anchor project:\n\n```\nmy-anchor-project/\n├── programs/\n│   └── my-program/\n│       └── src/\n│           └── lib.rs      # Your program code\n├── tests/\n│   └── my-program.ts       # TypeScript tests\n├── migrations/\n│   └── deploy.ts           # Deployment scripts\n└── Anchor.toml             # Configuration\n```\n\n## Key Anchor Components\n\n### 1. Program Module\n\n```rust\nuse anchor_lang::prelude::*;\n\ndeclare_id!(\"YourProgramIDHere\");\n\n#[program]\npub mod my_program {\n    use super::*;\n\n    pub fn initialize(ctx: Context<Initialize>) -> Result<()> {\n        // Your logic here\n        Ok(())\n    }\n}\n```\n\nThe `#[program]` macro defines your program's instruction handlers.\n\n### 2. Accounts Struct\n\n```rust\n#[derive(Accounts)]\npub struct Initialize<'info> {\n    #[account(\n        init,\n        payer = user,\n        space = 8 + 32 + 8\n    )]\n    pub my_account: Account<'info, MyAccount>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n    pub system_program: Program<'info, System>,\n}\n```\n\nAccounts structs define what accounts your instruction needs and how to validate them.\n\n### 3. Account Data\n\n```rust\n#[account]\npub struct MyAccount {\n    pub authority: Pubkey,\n    pub counter: u64,\n}\n```\n\nThe `#[account]` macro adds serialization/deserialization and a discriminator for account type safety.\n\n## Anchor vs Native: Security Benefits\n\n| Security Check | Native | Anchor |\n|----------------|--------|--------|\n| Account ownership | Manual check | Automatic via Account<'info, T> |\n| Signer verification | Manual check | Automatic via Signer<'info> |\n| Writable validation | Manual check | Automatic via #[account(mut)] |\n| Account initialization | Manual allocation | Automatic via #[account(init)] |\n| Discriminator (type safety) | None | Automatic 8-byte discriminator |\n\nAnchor programs are **harder to exploit** because common security pitfalls are prevented by the framework itself.\n\n## Next Steps\n\nIn the next challenge, you'll build a mock Anchor program structure to understand how programs are organized on Solana.\n"
       }
     ],
     "skills": [
@@ -428,6 +540,62 @@
         "_key": "intro",
         "_type": "prose",
         "src": "# Account Constraints Deep Dive\n\nAnchor's account constraints are the guard rails of Solana development. They validate accounts before your instruction logic runs, preventing entire classes of bugs.\n\n## Essential Constraints\n\n### `#[account(init, payer = X, space = N)]`\nCreates a new account. The `payer` funds the rent-exempt deposit. `space` sets the data size in bytes. Can only be used once per account.\n\n### `#[account(mut)]`\nMarks an account as mutable. Required for any account whose data or lamport balance changes. Forgetting `mut` gives you:\n```\nerror: A mut constraint was expected but not found.\n```\n\n### `Signer<'info>`\nThe account must have signed the transaction. Used for authorization — proving the caller owns the account. Signers automatically have their signature verified by the runtime.\n\n### `Program<'info, System>`\nReferences a program account. `System` is the System Program (`11111111...`), which handles account creation and SOL transfers.\n\n## Account Types\n\n| Type | Use Case | Mutable Data? |\n|------|----------|---------------|\n| `Account<'info, T>` | Typed data account | Yes |\n| `Signer<'info>` | Must have signed tx | No data |\n| `SystemAccount<'info>` | Any system-owned account | No |\n| `Program<'info, T>` | A program account | No |\n| `UncheckedAccount<'info>` | No validation (dangerous) | Depends |\n\n## Common Errors\n\n### Missing `system_program`\nIf your instruction creates an account (`init`), you **must** include the System Program:\n```rust\npub system_program: Program<'info, System>,\n```\nWithout it, the compiler error is:\n```\nerror[E0277]: the trait bound `Initialize<'_>: anchor_lang::Accounts<'_>` is not satisfied\n```\n\nThis error is cryptic because Anchor generates the account validation code via macros. The fix is always: add the missing account.\n\n### Missing `mut` on payer\nThe payer's balance decreases (pays rent), so it must be `#[account(mut)]`:\n```rust\n#[account(mut)]\npub user: Signer<'info>,\n```\n\n### Wrong `space` calculation\nIf `space` is too small, the account can't hold your data. If too large, the payer overpays for rent. Always calculate: `8 (discriminator) + field sizes`.\n\n## In the Next Challenge\n\nYou'll encounter a deliberate compiler error — a program with a missing account. Your job is to read the error output and fix it.\n"
+      },
+      {
+        "_key": "retrieval-close",
+        "_type": "quiz",
+        "questions": [
+          {
+            "explanation": "Constraints validate accounts before your logic runs. `init` with `payer = user` reduces the user's lamports, and any account whose lamports or data change must be `#[account(mut)]` — otherwise Anchor emits 'a mut constraint was expected but not found.'",
+            "id": "q1",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "Compile error — the payer's lamports decrease to fund the rent, so it must be declared mutable"
+              },
+              {
+                "correct": false,
+                "feedback": "`Signer` proves the account signed; it says nothing about mutability. A payer's balance drops, so it needs `#[account(mut)]` on top.",
+                "id": "b",
+                "label": "It works, because `Signer` already implies mutable"
+              },
+              {
+                "correct": false,
+                "feedback": "Programs do not pay rent for you. The declared payer's lamports fund it, which is exactly why the payer must be `mut`.",
+                "id": "c",
+                "label": "It works, but the rent is silently paid by the program"
+              }
+            ],
+            "prompt": "You mark the payer account as `Signer<'info>` but forget `#[account(mut)]`. The instruction uses `init` to create a new account funded by that payer. What happens?"
+          },
+          {
+            "explanation": "New accounts are allocated by the System Program, so `init` expands into a `create_account` CPI that needs the System Program in the accounts struct. Leaving it out fails the `Accounts` trait bound at compile time — the fix is always to add the missing account.",
+            "id": "q2",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "Creating an account is a CPI to the System Program, so it must be present for Anchor's generated code to make that call"
+              },
+              {
+                "correct": false,
+                "feedback": "Account creation itself is a System Program instruction. `init` generates a `create_account` CPI, so the System Program must be in the struct.",
+                "id": "b",
+                "label": "It is only needed to transfer SOL, not to create accounts"
+              },
+              {
+                "correct": false,
+                "feedback": "Anchor does not inject it — you must declare it. Omitting it produces a cryptic trait-bound error on the accounts struct.",
+                "id": "c",
+                "label": "It documents intent but Anchor injects it automatically"
+              }
+            ],
+            "prompt": "Why does an instruction that uses `#[account(init)]` also require `system_program: Program<'info, System>` in its accounts struct?"
+          }
+        ]
       }
     ],
     "skills": [
@@ -482,6 +650,62 @@
             "input": ""
           }
         ]
+      },
+      {
+        "_key": "retrieval-close",
+        "_type": "quiz",
+        "questions": [
+          {
+            "explanation": "Each handler's `Context<T>` must point at a defined `#[derive(Accounts)]` struct, even an empty one. The struct name has to match the generic exactly, so omitting `Greet` leaves an undefined type and breaks the build.",
+            "id": "q1",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "It fails to compile — `Context<Greet>` references a type that must exist and derive `Accounts`"
+              },
+              {
+                "correct": false,
+                "feedback": "Anchor generates nothing for you here. `Context<Greet>` needs a real `#[derive(Accounts)]` struct Greet to reference, or the type is undefined.",
+                "id": "b",
+                "label": "It compiles; Anchor generates an empty Greet struct automatically"
+              },
+              {
+                "correct": false,
+                "feedback": "There is no silent no-op — a missing referenced type is a compile error, caught at build time.",
+                "id": "c",
+                "label": "It compiles but greet silently never runs"
+              }
+            ],
+            "prompt": "You add `pub fn greet(_ctx: Context<Greet>)` but forget to write the `Greet` accounts struct. What happens?"
+          },
+          {
+            "explanation": "An accounts struct declares exactly the accounts an instruction reads or writes. `greet` only calls `msg!`, touching no accounts, so its struct is legitimately empty — whereas `Initialize` creates a Counter and must declare it, the payer, and the System Program.",
+            "id": "q2",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "greet only logs a message — it reads and writes no accounts, so it declares none"
+              },
+              {
+                "correct": false,
+                "feedback": "Not required — the struct lists exactly the accounts an instruction touches. greet touches none; Initialize creates an account, so its struct is non-empty.",
+                "id": "b",
+                "label": "Empty structs are required for every instruction"
+              },
+              {
+                "correct": false,
+                "feedback": "Programs are stateless and store nothing internally. greet simply has no state to touch, which is why its accounts struct is empty.",
+                "id": "c",
+                "label": "greet stores its state inside the program, so no account is needed"
+              }
+            ],
+            "prompt": "The `Greet` accounts struct can be empty (`pub struct Greet {}`). Why is that valid when `Initialize`'s struct is not?"
+          }
+        ]
       }
     ],
     "skills": [
@@ -522,6 +746,62 @@
         "_key": "intro",
         "_type": "prose",
         "src": "# Anatomy of an Anchor Program\n\nBefore we start adding features, let's break down every line of the program you just compiled.\n\n## The Import\n\n```rust\nuse anchor_lang::prelude::*;\n```\n\nThis single import brings in everything Anchor needs: the `#[program]` macro, `Context`, `Account`, `Signer`, `Result`, error types, and more.\n\n## Program ID\n\n```rust\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n```\n\nEvery Solana program has a unique address (public key). The `declare_id!` macro hardcodes this address into the binary. When you deploy, Solana verifies the binary matches this ID.\n\nFor development, you can use any valid base58 public key. For production, you'd generate one with `solana-keygen grind`.\n\n## The Program Module\n\n```rust\n#[program]\npub mod academy_program {\n    use super::*;\n\n    pub fn initialize(_ctx: Context<Initialize>) -> Result<()> {\n        msg!(\"Superteam Academy default program\");\n        Ok(())\n    }\n}\n```\n\nThe `#[program]` attribute tells Anchor this module contains your instruction handlers. Each `pub fn` inside becomes a callable instruction on-chain.\n\n**Key rules:**\n- First parameter is always `Context<T>` where `T` is an accounts struct\n- Return type is always `Result<()>`\n- `msg!()` logs to the transaction log (visible in explorers)\n\n## Accounts Structs\n\n```rust\n#[derive(Accounts)]\npub struct Initialize {}\n```\n\nEvery instruction needs an accounts struct that defines which accounts the instruction reads/writes. This empty struct means `initialize` doesn't need any accounts.\n\nIn the next lesson, you'll add your first real instruction with a non-empty accounts struct.\n\n## What the Compiler Checks\n\nWhen you hit Build, `cargo-build-sbf` validates:\n- Rust syntax and type safety\n- Anchor macro expansion (accounts, constraints, errors)\n- SBF compatibility (no system calls, no heap abuse)\n\nIf any of these fail, you get a compiler error with the exact line number.\n"
+      },
+      {
+        "_key": "retrieval-close",
+        "_type": "quiz",
+        "questions": [
+          {
+            "explanation": "declare_id! embeds the program's expected public key into the binary. On deploy, Solana checks the program account address against it — a guard against deploying a binary under the wrong id, which would break every client that derives PDAs from that id.",
+            "id": "q1",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "It verifies the deployed program's account address matches the declared id"
+              },
+              {
+                "correct": false,
+                "feedback": "declare_id! generates no keys — it states the expected address. Solana checks the deployed program matches it; a mismatch is an error.",
+                "id": "b",
+                "label": "It generates a fresh keypair for the program"
+              },
+              {
+                "correct": false,
+                "feedback": "The macro reserves nothing on its own. It is a claim that Solana validates against the actual deploy address.",
+                "id": "c",
+                "label": "It reserves the address so no one else can use it before you deploy"
+              }
+            ],
+            "prompt": "`declare_id!(...)` hardcodes an address into your binary. What does Solana do with it at deploy time?"
+          },
+          {
+            "explanation": "Every `#[program]` handler has the same shape: `Context<T>` first (T being the accounts struct that declares and validates accounts), then optional instruction args, returning `Result<()>`. Anchor generates the on-chain dispatch from exactly this signature.",
+            "id": "q2",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "Its first parameter is `Context<T>` for some `#[derive(Accounts)]` struct T, and it returns `Result<()>`"
+              },
+              {
+                "correct": false,
+                "feedback": "The `#[program]` contract is fixed: every handler takes a `Context<T>` first and returns `Result<()>`. Anchor's macro expansion depends on it.",
+                "id": "b",
+                "label": "It can take any parameters and return any type"
+              },
+              {
+                "correct": false,
+                "feedback": "Accounts are always bundled in `Context<T>`, never passed individually. The struct T is where accounts and their constraints live.",
+                "id": "c",
+                "label": "It must take each account as a separate argument, not a Context"
+              }
+            ],
+            "prompt": "You add a new `pub fn withdraw(...)` inside the `#[program]` module. What must be true of its signature?"
+          }
+        ]
       }
     ],
     "skills": [
@@ -574,6 +854,69 @@
             "expectedOutput": "true",
             "id": "test-3",
             "input": ""
+          }
+        ],
+        "tutorNotes": [
+          "Learners re-use `init` on the counter in the Increment accounts struct; the account already exists at this point and only needs `mut`.",
+          "They forget `mut` on the counter, so the compiler rejects `counter.count += 1` or the write never persists.",
+          "They drop the `seeds` + `bump` from the Increment struct, so Anchor stops verifying the account is the caller's own counter PDA.",
+          "They add `system_program` to Increment out of habit — it is only needed when an account is being created, not mutated.",
+          "They borrow the counter immutably with `&ctx.accounts.counter` and then try to mutate it."
+        ]
+      },
+      {
+        "_key": "retrieval-close",
+        "_type": "quiz",
+        "questions": [
+          {
+            "explanation": "The counter's address is derived from the user's key, so Anchor needs `user` to recompute the seeds and confirm the passed counter is that wallet's PDA. That check doubles as authorization: only the wallet in the seeds can modify its own counter. No lamports move, so `user` is not `mut`.",
+            "id": "q1",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "Anchor re-derives the counter PDA from the user's key to verify the passed account is the right one, which also authorizes only that wallet"
+              },
+              {
+                "correct": false,
+                "feedback": "No rent is paid on increment — the account already exists, so `user` is not `mut`. It is present so Anchor can re-derive and check the PDA seeds.",
+                "id": "b",
+                "label": "To pay rent for the increment"
+              },
+              {
+                "correct": false,
+                "feedback": "Not every instruction needs a signer. Here `user` is required specifically to re-derive the PDA seeds and gate who may modify this counter.",
+                "id": "c",
+                "label": "Because every instruction must have a signer"
+              }
+            ],
+            "prompt": "`Increment` includes the `user: Signer` and the same PDA seeds as `Initialize`, but no `init`. Why is `user` needed here at all?"
+          },
+          {
+            "explanation": "`init` allocates and owns a fresh account; you use it once, in `Initialize`. `increment` operates on the already-created PDA, so it uses `mut` + `seeds` + `bump` to locate and mutate it. Leaving `init` on would attempt a second creation at an address already in use and fail.",
+            "id": "q2",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "It would try to create the account again and fail, because the PDA already exists"
+              },
+              {
+                "correct": false,
+                "feedback": "`init` does not reset — it allocates a new account. On an existing PDA it fails outright ('already in use'), rather than silently zeroing.",
+                "id": "b",
+                "label": "It would reset the counter to zero"
+              },
+              {
+                "correct": false,
+                "feedback": "`init` is not idempotent (that is `init_if_needed`). Re-running `init` on an existing address errors.",
+                "id": "c",
+                "label": "Nothing — `init` is idempotent"
+              }
+            ],
+            "prompt": "`Increment` uses `#[account(mut, seeds = [...], bump)]` on the counter but drops `init`. What would happen if you left `init` on it?"
           }
         ]
       }
@@ -629,6 +972,69 @@
             "id": "test-3",
             "input": ""
           }
+        ],
+        "tutorNotes": [
+          "Learners subtract before checking, so a decrement at zero underflows the `u64` and panics instead of returning the custom error.",
+          "They guard with `count >= 0`, which is always true for an unsigned integer and stops nothing — the meaningful check is strictly greater than zero.",
+          "They define the error enum but omit the `#[error_code]` attribute, so `require!` will not accept the variant.",
+          "They give the Decrement accounts struct different PDA seeds than Increment, so it resolves a different account than the one they initialized.",
+          "They handle the zero case by returning `Ok(())` and doing nothing, silently swallowing the error instead of surfacing it to the caller."
+        ]
+      },
+      {
+        "_key": "retrieval-close",
+        "_type": "quiz",
+        "questions": [
+          {
+            "explanation": "`require!` returns the custom error and aborts the instruction when the condition is false, so a decrement at zero fails and leaves state untouched. This is the on-chain defense against u64 underflow wrapping 0 into a near-limitless value — a real class of bug.",
+            "id": "q1",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "The instruction returns the Underflow error, the transaction fails, and no state changes"
+              },
+              {
+                "correct": false,
+                "feedback": "That is exactly what the guard prevents. Without `require!`, subtracting 1 from 0 on a u64 would underflow-wrap; with it, the instruction fails cleanly and count stays 0.",
+                "id": "b",
+                "label": "count wraps around to a huge u64 value"
+              },
+              {
+                "correct": false,
+                "feedback": "A `u64` cannot hold -1. Unguarded subtraction would wrap to a huge number; the `require!` guard rejects the call instead.",
+                "id": "c",
+                "label": "count goes to -1"
+              }
+            ],
+            "prompt": "`decrement` guards with `require!(counter.count > 0, ErrorCode::Underflow)`. What happens when a user calls decrement while count is 0?"
+          },
+          {
+            "explanation": "`#[error_code]` turns the enum into Anchor program errors with stable codes, and `#[msg]` attaches the readable string returned to clients on failure. Combined with `require!`, your program enforces its own rules and explains violations to the caller.",
+            "id": "q2",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "A program-specific error whose human-readable message is surfaced to clients when the instruction fails"
+              },
+              {
+                "correct": false,
+                "feedback": "The compiler does not prove that — the runtime `require!` does. `#[error_code]` and `#[msg]` just define the error and the message clients see.",
+                "id": "b",
+                "label": "A compile-time check that count never underflows"
+              },
+              {
+                "correct": false,
+                "feedback": "There is no automatic retry. The macros define a typed error and message; the transaction simply fails and the client reads the message.",
+                "id": "c",
+                "label": "Automatic retry of the failed instruction"
+              }
+            ],
+            "prompt": "What does `#[error_code]` on the `ErrorCode` enum plus `#[msg]` on the `Underflow` variant give you?"
+          }
         ]
       }
     ],
@@ -682,6 +1088,69 @@
             "expectedOutput": "true",
             "id": "test-3",
             "input": ""
+          }
+        ],
+        "tutorNotes": [
+          "Learners size `space` by adding up only the fields and forget the 8-byte discriminator Anchor prepends to every `#[account]`, so the account is under-allocated.",
+          "They omit the `<'info>` lifetime on the `Initialize` struct once it holds account references, then get opaque lifetime errors and edit the wrong line.",
+          "They leave `user` without `#[account(mut)]`; the payer that funds an `init` has its lamports changed and must be mutable.",
+          "They reach for `#[account(mut)]` on the counter, but the account is being created here for the first time, which needs `init`, not `mut`.",
+          "They write the PDA seed as a plain text string instead of a byte literal, or leave off `bump`, so the constraints do not compile."
+        ]
+      },
+      {
+        "_key": "retrieval-close",
+        "_type": "quiz",
+        "questions": [
+          {
+            "explanation": "A PDA address is a pure function of its seeds and the program id. Seeding with the user's pubkey means one deterministic counter per wallet, re-derivable by any client, with no private key — the program signs for it via the bump.",
+            "id": "q1",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "Each wallet gets exactly one counter for this program, at a deterministic address anyone can re-derive"
+              },
+              {
+                "correct": false,
+                "feedback": "The seeds fix the address: for a given user those seeds derive one address. A second init there fails — one counter per wallet.",
+                "id": "b",
+                "label": "Each wallet can create unlimited counters"
+              },
+              {
+                "correct": false,
+                "feedback": "PDAs have no private key — that is the point. The program controls the PDA; the seeds just make its address deterministic.",
+                "id": "c",
+                "label": "The counter has a private key the user controls"
+              }
+            ],
+            "prompt": "The counter is a PDA seeded on the counter label plus the user's public key. What does this seed choice guarantee?"
+          },
+          {
+            "explanation": "`init` allocates the counter and `payer = user` funds its rent-exempt deposit, so the user's lamport balance decreases. Any account whose lamports or data change must be declared `mut`, or Anchor rejects the instruction.",
+            "id": "q2",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "Creating the counter with `init` debits rent from the user, changing their lamport balance — a mutation"
+              },
+              {
+                "correct": false,
+                "feedback": "Signing is `Signer`, a separate thing. `mut` is required because the payer's lamports decrease to fund the new account's rent.",
+                "id": "b",
+                "label": "Because the user signs the transaction"
+              },
+              {
+                "correct": false,
+                "feedback": "The user account's own data is not modified. What changes is its lamport balance, since `payer = user` funds the rent — that is why it must be `mut`.",
+                "id": "c",
+                "label": "Because the user's data is written into the counter"
+              }
+            ],
+            "prompt": "Why does the `user` field need `#[account(mut)]` in `Initialize`?"
           }
         ]
       }
@@ -747,6 +1216,62 @@
         "_key": "intro",
         "_type": "prose",
         "src": "# From Code to Chain\n\nYou've written Anchor programs in the previous courses. Now it's time to compile and deploy them for real.\n\n## The Build Pipeline\n\nWhen you write an Anchor program, it goes through several stages before it reaches the Solana blockchain:\n\n1. **Rust source code** — what you write in your editor\n2. **`cargo-build-sbf`** — the Solana compiler that transforms Rust into Solana Bytecode Format (SBF)\n3. **`.so` binary** — the compiled program, an ELF shared object file\n4. **`solana program deploy`** — uploads the binary to a Solana cluster\n\n## What is SBF?\n\nSolana Bytecode Format (SBF) is a variant of eBPF (extended Berkeley Packet Filter) adapted for the Solana runtime. It's a register-based instruction set designed for:\n\n- **Safety**: Programs run in a sandboxed VM with no access to the host system\n- **Performance**: Near-native execution speed\n- **Determinism**: Same inputs always produce the same outputs\n\n## The Build Server\n\nIn this course, you won't need a local Rust toolchain. The **Superteam Academy Build Server** handles compilation in the cloud:\n\n1. You write Anchor code in the browser editor\n2. Click **Build** to submit your code\n3. The build server runs `cargo-build-sbf` on your code\n4. You get back either compiler errors or a compiled binary UUID\n\nThe build server uses the same Anchor 0.32 and Solana SDK that you'd use locally. Think of it as a cloud-hosted `anchor build`.\n\n## What Gets Compiled\n\nYour `lib.rs` file is placed into a pre-configured Anchor project with:\n- `anchor-lang` 0.32.1 (with `init-if-needed` feature)\n- `anchor-spl` 0.32.1\n- `solana-program` via the Agave 3.0 toolchain\n\nThe build server rejects dangerous patterns (`std::process`, `std::fs`, `std::net`) to keep the sandbox secure.\n\n## Ready to Build?\n\nIn the next lesson, you'll hit the **Build** button for the first time. Your only job: see the green checkmark.\n"
+      },
+      {
+        "_key": "retrieval-close",
+        "_type": "quiz",
+        "questions": [
+          {
+            "explanation": "Solana programs compile to SBF and run in a deterministic, sandboxed VM. There is no filesystem, network, or process table on-chain, so those calls are meaningless — and determinism requires the same input to always yield the same output, which host I/O would break.",
+            "id": "q1",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "SBF programs run in a sandboxed VM with no access to the host's filesystem, network, or OS, so those calls have no meaning on-chain"
+              },
+              {
+                "correct": false,
+                "feedback": "They cannot run at all — the SBF VM has no host access. The build server rejects them early rather than shipping a program that could never execute.",
+                "id": "b",
+                "label": "They compile fine on-chain but slow the validator down"
+              },
+              {
+                "correct": false,
+                "feedback": "The sandbox is fundamental to the runtime too: an on-chain program has no OS to call. The build-server block just surfaces that constraint sooner.",
+                "id": "c",
+                "label": "They are blocked only to protect the build server, not the runtime"
+              }
+            ],
+            "prompt": "The build server rejects programs that use `std::fs`, `std::net`, or `std::process`. Why would those never work in a deployed Solana program anyway?"
+          },
+          {
+            "explanation": "The pipeline is Rust source, then `cargo-build-sbf`, then a `.so` ELF containing SBF bytecode, then `solana program deploy` uploads that binary. Validators execute bytecode, never source — which is why the compile step happens before deployment.",
+            "id": "q2",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "A `.so` ELF binary of SBF bytecode; deploy uploads that binary to a cluster"
+              },
+              {
+                "correct": false,
+                "feedback": "The IDL is separate metadata. The compiler output that gets deployed is the `.so` SBF binary — the executable itself.",
+                "id": "b",
+                "label": "A JSON IDL; deploy registers it with the RPC"
+              },
+              {
+                "correct": false,
+                "feedback": "Validators never compile source. Compilation to `.so` happens off-chain (here, on the build server); only the finished bytecode is uploaded.",
+                "id": "c",
+                "label": "Raw Rust source; deploy compiles it on the validator"
+              }
+            ],
+            "prompt": "What artifact does `cargo-build-sbf` produce, and what does `solana program deploy` do with it?"
+          }
+        ]
       }
     ],
     "skills": [
@@ -767,7 +1292,7 @@
       {
         "_key": "intro",
         "_type": "prose",
-        "src": "# Airdrop & Fund Your Wallet\n\nBefore deploying your program, you need devnet SOL to pay for the on-chain storage (called \"rent\").\n\n## How Much SOL Do You Need?\n\nDeploying an Anchor program requires approximately **2 SOL** on devnet:\n- **~1.4 SOL** for the buffer account (temporary storage during upload)\n- **~0.1 SOL** for the program account\n- **~0.3 SOL** for transaction fees (200+ transactions)\n\nThe good news: most of this rent is **reclaimable** after deployment.\n\n## The Devnet Faucet\n\nSolana provides a free faucet on devnet. You can request **2 SOL per airdrop**.\n\nUse the widget below to fund your wallet. You'll need at least 4-5 SOL to comfortably deploy.\n\n> **Tip**: The faucet can be slow during peak hours. If you see \"faucet is busy,\" just wait 30-60 seconds and try again. This is normal — devnet is a shared resource.\n\n## What is Rent?\n\nOn Solana, every account must maintain a minimum balance called **rent**. This prevents spam accounts from filling up validator storage.\n\nThe rent amount depends on the account's data size:\n\n```\nrent = base_rent + (data_size * rent_per_byte)\n```\n\nFor a 200KB program binary, the buffer account rent is ~1.4 SOL.\n\nAccounts that maintain the minimum balance are **rent-exempt** — they won't be garbage collected.\n"
+        "src": "# Airdrop & Fund Your Wallet\n\nBefore deploying your program, you need devnet SOL to pay for the on-chain storage (called \"rent\").\n\n## How Much SOL Do You Need?\n\nDeploying an Anchor program requires approximately **2 SOL** on devnet:\n- **~1.4 SOL** for the buffer account (temporary storage during upload)\n- **~0.1 SOL** for the program account\n- **~0.3 SOL** for transaction fees (200+ transactions)\n\nThe good news: most of this rent is **reclaimable** after deployment.\n\n## The Devnet Faucet\n\nSolana provides a free faucet on devnet. The web faucet at [faucet.solana.com](https://faucet.solana.com) is the reliable path — airdrops through the public RPC (`solana airdrop`) are throttled more aggressively. The web faucet is rate-limited by **request frequency** (a maximum of 2 requests every 8 hours, as of mid-2026); signing in with GitHub raises that limit.\n\nUse the widget below to fund your wallet. You'll need at least 4-5 SOL to comfortably deploy — because of the request-frequency limit, that may take more than one faucet visit, which is expected, not a failure.\n\n> **Tip**: The faucet can be slow during peak hours. If you see \"faucet is busy,\" just wait 30-60 seconds and try again. This is normal — devnet is a shared resource.\n\n## What is Rent?\n\nOn Solana, every account must maintain a minimum balance called **rent**. This prevents spam accounts from filling up validator storage.\n\nThe rent amount depends on the account's data size:\n\n```\nrent = base_rent + (data_size * rent_per_byte)\n```\n\nFor a 200KB program binary, the buffer account rent is ~1.4 SOL.\n\nAccounts that maintain the minimum balance are **rent-exempt** — they won't be garbage collected.\n"
       },
       {
         "_key": "fund",
@@ -775,6 +1300,62 @@
         "amount": 2,
         "network": "devnet",
         "produces": "funded-wallet"
+      },
+      {
+        "_key": "retrieval-close",
+        "_type": "quiz",
+        "questions": [
+          {
+            "explanation": "Deployment first uploads the binary into a temporary buffer account whose rent follows base + data_size * rent_per_byte. A 200KB binary needs a 200KB buffer, hence ~1.4 SOL — and because most of that rent is reclaimable, you get much of it back after finalizing.",
+            "id": "q1",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "The buffer temporarily stores the whole binary on-chain, and rent is proportional to an account's data size"
+              },
+              {
+                "correct": false,
+                "feedback": "It is not a fixed fee — the cost is rent on the buffer account, and rent scales with bytes stored. A bigger binary needs a bigger, costlier buffer.",
+                "id": "b",
+                "label": "Larger programs pay a higher fixed deployment fee"
+              },
+              {
+                "correct": false,
+                "feedback": "The ~1.4 SOL is buffer-account rent, sized by the binary's byte length, not a per-instruction charge.",
+                "id": "c",
+                "label": "The validator charges per instruction, and big programs have more instructions"
+              }
+            ],
+            "prompt": "Deploying a ~200KB program needs ~1.4 SOL just for the buffer account. Why does the buffer cost scale with the program's size?"
+          },
+          {
+            "explanation": "Real deployment cost is ~2 SOL (buffer ~1.4, program ~0.1, fees ~0.3 across 200+ transactions). Airdropping only 2 leaves zero room for a failed-and-resumed upload or fee variance, so the lesson buffers you to 4-5 SOL.",
+            "id": "q2",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "Deployment needs ~2 SOL for buffer + program + fees, so 2 leaves no margin for retries or fee variance"
+              },
+              {
+                "correct": false,
+                "feedback": "Airdrops are not burned. The buffer alone can be ~1.4 SOL and fees ~0.3, so 2 SOL leaves no cushion; 4-5 gives comfortable margin.",
+                "id": "b",
+                "label": "Because half of every airdrop is burned"
+              },
+              {
+                "correct": false,
+                "feedback": "There is no fixed 4 SOL minimum — actual cost is ~2 SOL. You aim for 4-5 to absorb retries, fee spikes, and the 200+ transactions.",
+                "id": "c",
+                "label": "Because programs require a minimum 4 SOL balance to deploy"
+              }
+            ],
+            "prompt": "You airdrop exactly 2 SOL, then try to deploy. Why does the lesson tell you to get 4-5 SOL instead?"
+          }
+        ]
       }
     ],
     "skills": [
@@ -801,6 +1382,62 @@
         "_type": "deployed-program-card",
         "consumes": [
           "deployed-program"
+        ]
+      },
+      {
+        "_key": "retrieval-close",
+        "_type": "quiz",
+        "questions": [
+          {
+            "explanation": "Under the BPF Loader Upgradeable, the program account points to executable data that the upgrade authority can replace, so you fix or extend the program at the same id. State lives in separate accounts and is unaffected — the stateless-program design is what makes clean upgrades possible.",
+            "id": "q1",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "Replace the program's bytecode at the same program id later, without changing its address"
+              },
+              {
+                "correct": false,
+                "feedback": "Only the upgrade authority can upgrade, not anyone. Upgradeable means the code behind the id can be replaced by that authority, keeping the same address.",
+                "id": "b",
+                "label": "Let anyone modify the program's code"
+              },
+              {
+                "correct": false,
+                "feedback": "Upgrades swap code only; account data is untouched and stays where it is. Any data migration is the developer's job.",
+                "id": "c",
+                "label": "Automatically migrate all account data when the code changes"
+              }
+            ],
+            "prompt": "Your program was deployed via the BPF Loader Upgradeable. What does 'upgradeable' let the upgrade authority do?"
+          },
+          {
+            "explanation": "An upgradeable program account references executable data that the upgrade authority can swap, so bug fixes reuse the same program id. Because state is stored in separate accounts, existing counters persist across the upgrade — code and data are decoupled by design.",
+            "id": "q2",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "The program account points to the executable; the upgrade authority uploads new bytecode and the account points to it"
+              },
+              {
+                "correct": false,
+                "feedback": "Only if it were non-upgradeable. As upgradeable, you replace the bytecode at the same id via the upgrade authority — clients and PDAs keep working.",
+                "id": "b",
+                "label": "You must deploy a new program at a new id and abandon the old one"
+              },
+              {
+                "correct": false,
+                "feedback": "Counter accounts are separate state and survive an upgrade. Upgrading changes code, not the accounts your program created.",
+                "id": "c",
+                "label": "Editing the program automatically wipes existing counter accounts"
+              }
+            ],
+            "prompt": "You want to fix a bug in your deployed counter. Which statement about the program account and its data is true?"
+          }
         ]
       }
     ],
@@ -848,6 +1485,62 @@
             "input": ""
           }
         ]
+      },
+      {
+        "_key": "retrieval-close",
+        "_type": "quiz",
+        "questions": [
+          {
+            "explanation": "Solana caps transaction size around 1232 bytes, far smaller than a program binary, so the loader writes the binary into a buffer ~1000 bytes at a time — hence 200+ transactions. Batch-signing every ~30 keeps a fresh-enough blockhash so chunks do not expire mid-upload.",
+            "id": "q1",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "A Solana transaction has a strict ~1232-byte size limit, so a large binary must be split across many transactions"
+              },
+              {
+                "correct": false,
+                "feedback": "It is about size limits, not speed. A whole 200KB binary cannot fit in one ~1232-byte transaction, so it is split into many.",
+                "id": "b",
+                "label": "Chunking makes the upload faster than a single transaction"
+              },
+              {
+                "correct": false,
+                "feedback": "All chunks build one program in a buffer. They are pieces of a single binary, not separate programs.",
+                "id": "c",
+                "label": "Each chunk deploys a separate program"
+              }
+            ],
+            "prompt": "The binary is uploaded in ~1000-byte chunks across 200+ transactions, with batch signing every ~30 chunks. Why not upload it in one transaction?"
+          },
+          {
+            "explanation": "Confirmed chunks are already written to the on-chain buffer, so Resume checks what has landed and uploads only the remainder. This is why a flaky connection mid-deploy costs seconds, not a full re-upload of 200+ transactions.",
+            "id": "q2",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "It continues uploading only the chunks that have not landed yet, reusing the buffer, without re-sending confirmed chunks"
+              },
+              {
+                "correct": false,
+                "feedback": "Resume is the point of the buffer: already-confirmed chunks persist on-chain, so it picks up where it stopped rather than redoing 200 transactions.",
+                "id": "b",
+                "label": "It restarts the entire upload from chunk zero"
+              },
+              {
+                "correct": false,
+                "feedback": "The program id and buffer are preserved. Resume finishes the same deployment; it does not mint a new program.",
+                "id": "c",
+                "label": "It redeploys as a brand-new program with a new id"
+              }
+            ],
+            "prompt": "Deployment fails halfway through the chunk uploads. You click Resume. What does Resume do?"
+          }
+        ]
       }
     ],
     "skills": [
@@ -876,6 +1569,62 @@
           "deployed-program"
         ],
         "idl": "{\"address\":\"11111111111111111111111111111111\",\"metadata\":{\"name\":\"counter\",\"version\":\"0.1.0\",\"spec\":\"0.1.0\"},\"instructions\":[{\"name\":\"initialize\",\"discriminator\":[175,175,109,31,13,152,155,237],\"accounts\":[{\"name\":\"counter\",\"writable\":true,\"pda\":{\"seeds\":[{\"kind\":\"const\",\"value\":[99,111,117,110,116,101,114]},{\"kind\":\"account\",\"path\":\"user\"}]}},{\"name\":\"user\",\"writable\":true,\"signer\":true},{\"name\":\"system_program\",\"address\":\"11111111111111111111111111111111\"}],\"args\":[]},{\"name\":\"increment\",\"discriminator\":[11,18,104,9,104,174,59,33],\"accounts\":[{\"name\":\"counter\",\"writable\":true,\"pda\":{\"seeds\":[{\"kind\":\"const\",\"value\":[99,111,117,110,116,101,114]},{\"kind\":\"account\",\"path\":\"user\"}]}},{\"name\":\"user\",\"signer\":true}],\"args\":[]},{\"name\":\"decrement\",\"discriminator\":[106,227,168,59,248,27,150,101],\"accounts\":[{\"name\":\"counter\",\"writable\":true,\"pda\":{\"seeds\":[{\"kind\":\"const\",\"value\":[99,111,117,110,116,101,114]},{\"kind\":\"account\",\"path\":\"user\"}]}},{\"name\":\"user\",\"signer\":true}],\"args\":[]}],\"accounts\":[{\"name\":\"Counter\",\"discriminator\":[255,176,4,245,188,253,124,25]}],\"types\":[{\"name\":\"Counter\",\"type\":{\"kind\":\"struct\",\"fields\":[{\"name\":\"count\",\"type\":\"u64\"},{\"name\":\"authority\",\"type\":\"publicKey\"}]}}],\"errors\":[{\"code\":6000,\"name\":\"Underflow\",\"msg\":\"Cannot decrement below zero\"}]}\n"
+      },
+      {
+        "_key": "retrieval-close",
+        "_type": "quiz",
+        "questions": [
+          {
+            "explanation": "A `u64` equal to 3 is `03 00 00 00 00 00 00 00` in little-endian, the byte order Solana uses. Reading raw account data means accounting for both the leading 8-byte discriminator and little-endian integer layout — exactly what a manual byte decoder must handle.",
+            "id": "q1",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "3 — the u64 is stored little-endian, so the least significant byte comes first"
+              },
+              {
+                "correct": false,
+                "feedback": "Solana stores integers little-endian, so `03 00 ...` is 3, not a huge big-endian value. The least significant byte leads.",
+                "id": "b",
+                "label": "A very large number — the bytes read left to right as big-endian"
+              },
+              {
+                "correct": false,
+                "feedback": "Little-endian puts the least significant byte first, so 3 is `03 00 00 00 00 00 00 00`. The `00 ... 03` layout is big-endian.",
+                "id": "c",
+                "label": "3, but little-endian would write it as `00 00 00 00 00 00 00 03`"
+              }
+            ],
+            "prompt": "The raw hex for the counter reads (after the discriminator) `03 00 00 00 00 00 00 00`. What is the value, and why is `03` first?"
+          },
+          {
+            "explanation": "The `#[error_code]` Underflow and its `require!` guard run inside your program on-chain, so the Solana runtime enforces them regardless of which client sends the transaction. That is the difference between a UI check anyone can skip and a rule that actually holds on a public network.",
+            "id": "q2",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "By the Solana runtime executing your deployed program's `require!` check — your own on-chain code"
+              },
+              {
+                "correct": false,
+                "feedback": "The UI is not the enforcer; a client could bypass it. The rule lives in your deployed program and the runtime enforces it, which is why it holds against any caller.",
+                "id": "b",
+                "label": "By the browser UI before the transaction is sent"
+              },
+              {
+                "correct": false,
+                "feedback": "RPC nodes forward transactions; they do not run your business rules. The `require!` guard executes inside your program on the validator.",
+                "id": "c",
+                "label": "By the RPC node validating the request"
+              }
+            ],
+            "prompt": "When you decrement below zero, the error `Cannot decrement below zero` appears. Where is that rule actually enforced?"
+          }
+        ]
       }
     ],
     "skills": [
@@ -897,6 +1646,62 @@
         "_key": "intro",
         "_type": "prose",
         "src": "# On-Chain State\n\nSo far, our program doesn't store any data. Every instruction just logs a message and exits. To build anything useful, you need **on-chain state** — data that persists between transactions.\n\n## Accounts = Storage\n\nOn Solana, all state lives in **accounts**. An account is a buffer of bytes owned by a program. Think of it like a row in a database, but on-chain.\n\nEvery account has:\n- **Address** (public key) — how you find it\n- **Owner** (program ID) — which program can modify it\n- **Data** (byte array) — the actual state\n- **Lamports** (balance) — rent deposit to keep it alive\n\n## The Discriminator\n\nAnchor adds an 8-byte **discriminator** at the start of every account's data. This is a hash of the account type name, used to prevent account type confusion attacks.\n\n```\n[8 bytes discriminator][...your data...]\n```\n\nYou never read or write the discriminator directly — Anchor handles it.\n\n## Space Calculation\n\nWhen you create an account, you must specify its size upfront (accounts can't be resized after creation). The formula:\n\n```\nspace = 8 (discriminator) + sum of field sizes\n```\n\nCommon field sizes:\n- `u8` / `i8` / `bool` = 1 byte\n- `u16` / `i16` = 2 bytes\n- `u32` / `i32` = 4 bytes\n- `u64` / `i64` = 8 bytes\n- `u128` / `i128` = 16 bytes\n- `Pubkey` = 32 bytes\n- `String` = 4 (length prefix) + content bytes\n- `Vec<T>` = 4 (length prefix) + (count * size_of::<T>())\n\n## Example: A Counter\n\nA simple counter needs one `u64` field:\n\n```rust\n#[account]\npub struct Counter {\n    pub count: u64,  // 8 bytes\n}\n// Total space = 8 (discriminator) + 8 (u64) = 16 bytes\n```\n\nThe `#[account]` attribute tells Anchor to:\n1. Add serialization/deserialization (Borsh)\n2. Add the 8-byte discriminator\n3. Implement account validation traits\n\nIn the next challenge, you'll define this Counter account and wire it into your program.\n"
+      },
+      {
+        "_key": "retrieval-close",
+        "_type": "quiz",
+        "questions": [
+          {
+            "explanation": "space = 8 (discriminator) + sum of field sizes. A `u64` is 8 bytes, so a Counter is 8 + 8 = 16. This matters because accounts cannot be resized after creation — too small and writes fail, too large and the payer overpays rent.",
+            "id": "q1",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "16 bytes — 8 for the discriminator plus 8 for the u64"
+              },
+              {
+                "correct": false,
+                "feedback": "You forgot the discriminator. Every Anchor account starts with an 8-byte type discriminator, so a single u64 account needs 8 + 8 = 16.",
+                "id": "b",
+                "label": "8 bytes — just the u64"
+              },
+              {
+                "correct": false,
+                "feedback": "A fixed-size `u64` has no length prefix; only dynamic types like String and Vec add one. The total is 8 + 8 = 16.",
+                "id": "c",
+                "label": "24 bytes — 8 discriminator + 8 length prefix + 8 u64"
+              }
+            ],
+            "prompt": "A `Counter` holds one `u64`. What `space` must you allocate, and why that number?"
+          },
+          {
+            "explanation": "The 8-byte discriminator is derived from the account's type name, so Anchor rejects an account whose leading bytes do not match the expected `Counter` type. Without it, an attacker could pass a look-alike account and trick the program into interpreting foreign bytes as your struct.",
+            "id": "q2",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "Account type confusion — passing a different account type where a Counter is expected, since its discriminator will not match"
+              },
+              {
+                "correct": false,
+                "feedback": "The discriminator is about type identity, not balances. It stops a program from mistaking one account type for another.",
+                "id": "b",
+                "label": "Double-spending of lamports"
+              },
+              {
+                "correct": false,
+                "feedback": "Replay is handled by the recent blockhash, not the discriminator. The discriminator guards account type identity on deserialize.",
+                "id": "c",
+                "label": "Replaying an old transaction"
+              }
+            ],
+            "prompt": "Anchor prepends an 8-byte discriminator (a hash of the account type name) to every account. What attack does this prevent?"
+          }
+        ]
       }
     ],
     "skills": [
@@ -950,6 +1755,68 @@
             "id": "test-3",
             "input": ""
           }
+        ],
+        "tutorNotes": [
+          "Learners try to satisfy the failing build by deleting or loosening the `init` constraint, instead of supplying the account that `init` requires.",
+          "They read only the surface of the trait-bound error, which names `Accounts` rather than a field, and start editing the wrong struct.",
+          "They guess at a fix without clicking Build first, so they never read what the compiler is actually asking for.",
+          "When they do add the missing account they give it a bare `AccountInfo` or `UncheckedAccount` type instead of the typed program wrapper Anchor expects."
+        ]
+      },
+      {
+        "_key": "retrieval-close",
+        "_type": "quiz",
+        "questions": [
+          {
+            "explanation": "Account creation is a CPI to the System Program, so `init` only compiles when that program is in the accounts struct. Omitting it makes Anchor's generated code fail the `Accounts` trait bound — a cryptic-looking error whose fix is always to add the missing account.",
+            "id": "q1",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "A trait-bound error on `Accounts` — `init` generates a `create_account` CPI that needs the System Program present"
+              },
+              {
+                "correct": false,
+                "feedback": "It fails at compile time, not runtime. Anchor cannot generate valid account-creation code without the System Program, so the build breaks.",
+                "id": "b",
+                "label": "A runtime 'account not found' error, only when the instruction is called"
+              },
+              {
+                "correct": false,
+                "feedback": "Anchor does not inject it. `init` requires you to declare `system_program: Program<'info, System>` explicitly, or the generated code fails the Accounts trait.",
+                "id": "c",
+                "label": "No error — Anchor injects the System Program automatically"
+              }
+            ],
+            "prompt": "An `Initialize` struct uses `#[account(init, ...)]` but omits the System Program. What does the compiler tell you, and why?"
+          },
+          {
+            "explanation": "Because Anchor generates account-validation code via macros, a missing account surfaces as a trait-bound error on `Accounts`, not a plain 'you forgot system_program.' Recognizing that pattern turns hours of confusion into a one-line fix.",
+            "id": "q2",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "It is the most common Anchor compile error, and its message points at a trait rather than the real cause: a missing account"
+              },
+              {
+                "correct": false,
+                "feedback": "It is a compile-time error, identical everywhere. The lesson exists because the message is indirect, not because it is environment-specific.",
+                "id": "b",
+                "label": "Because it only appears on devnet, never locally"
+              },
+              {
+                "correct": false,
+                "feedback": "It is not a safety warning — it is a missing-account compile error. The point is recognizing the indirect message and knowing the fix.",
+                "id": "c",
+                "label": "Because it means your program is unsafe to deploy"
+              }
+            ],
+            "prompt": "Why is learning to read this trait-bound error worth a whole lesson?"
+          }
         ]
       }
     ],
@@ -991,6 +1858,62 @@
             "expectedOutput": "true",
             "id": "test-1",
             "input": ""
+          }
+        ]
+      },
+      {
+        "_key": "retrieval-close",
+        "_type": "quiz",
+        "questions": [
+          {
+            "explanation": "A cold build resolves and compiles the entire dependency graph, which dominates the time. Those compiled dependencies are cached, so later builds recompile only your source — the same reason local `cargo build` is slow once and fast after.",
+            "id": "q1",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "The first build downloads and compiles all dependencies; those are cached, so later builds only recompile your changed code"
+              },
+              {
+                "correct": false,
+                "feedback": "It is not hardware warm-up. The first build resolves and compiles the full dependency tree; that work is cached afterward.",
+                "id": "b",
+                "label": "The build server is warming up its hardware"
+              },
+              {
+                "correct": false,
+                "feedback": "Later builds still compile — but only your changed code, reusing cached dependencies. They do not blindly reuse the old binary, or your edits would never take effect.",
+                "id": "c",
+                "label": "Later builds skip compilation and reuse the same binary"
+              }
+            ],
+            "prompt": "The first build takes 30-60 seconds but later builds are fast. Why?"
+          },
+          {
+            "explanation": "The green check means `cargo-build-sbf` turned your source into a `.so` binary and returned it, proving the pipeline works. Deployment and on-chain execution are later, separate steps.",
+            "id": "q2",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "Your code compiled to a `.so` binary and the whole browser-to-build-server-to-compiler pipeline works end-to-end"
+              },
+              {
+                "correct": false,
+                "feedback": "Building is not deploying. A green check means compilation succeeded; deployment is a separate step later in the course.",
+                "id": "b",
+                "label": "Your program is now deployed and live on devnet"
+              },
+              {
+                "correct": false,
+                "feedback": "No on-chain execution happened yet. The check confirms compilation to a binary, not runtime behavior.",
+                "id": "c",
+                "label": "Your program passed its on-chain tests"
+              }
+            ],
+            "prompt": "A green checkmark appears after your build. What does it actually confirm?"
           }
         ]
       }
@@ -1128,6 +2051,62 @@
         "_key": "intro",
         "_type": "prose",
         "src": "# Cross-Program Invocations (CPIs)\n\nCross-Program Invocations allow one Solana program to call another program. This is what makes Solana programs **composable** — you can build on top of existing programs like building blocks.\n\n## Why CPIs Matter\n\nCPIs enable:\n- **Token transfers** via the Token Program\n- **NFT minting** via Metaplex programs\n- **Swaps** through DEX programs (Jupiter, Raydium)\n- **Lending** through DeFi protocols (Solend, MarginFi)\n\nWithout CPIs, every program would need to reimplement basic functionality. With CPIs, you compose existing programs.\n\n## How CPIs Work\n\nWhen Program A calls Program B:\n\n```\nUser Transaction\n  |\n  v\nProgram A (your program)\n  |\n  v (CPI)\nProgram B (Token Program, System Program, etc.)\n```\n\nThe Solana runtime tracks the **call stack** and ensures:\n- Account ownership rules are enforced\n- Signers are propagated correctly\n- Programs can't exceed the call depth limit (4 levels)\n\n## invoke vs invoke_signed\n\n### invoke - Regular CPI\n\n```rust\nuse solana_program::program::invoke;\n\ninvoke(\n    &instruction,\n    &[\n        source_account.clone(),\n        destination_account.clone(),\n        authority.clone(),\n    ],\n)?;\n```\n\nUse `invoke` when the required signers are already in your instruction's signer list.\n\n### invoke_signed - CPI with PDA Signer\n\n```rust\nuse solana_program::program::invoke_signed;\n\ninvoke_signed(\n    &instruction,\n    &[\n        pda_account.clone(),\n        destination_account.clone(),\n        system_program.clone(),\n    ],\n    &[&[b\"vault\", &[bump]]], // PDA seeds\n)?;\n```\n\nUse `invoke_signed` when a **PDA** needs to sign. The program derives the PDA and \"signs\" on its behalf.\n\n## CPI in Anchor\n\nAnchor provides a cleaner API for CPIs:\n\n```rust\nuse anchor_lang::prelude::*;\nuse anchor_spl::token::{self, Transfer};\n\npub fn transfer_tokens(ctx: Context<TransferTokens>, amount: u64) -> Result<()> {\n    let cpi_accounts = Transfer {\n        from: ctx.accounts.from.to_account_info(),\n        to: ctx.accounts.to.to_account_info(),\n        authority: ctx.accounts.authority.to_account_info(),\n    };\n\n    let cpi_program = ctx.accounts.token_program.to_account_info();\n    let cpi_ctx = CpiContext::new(cpi_program, cpi_accounts);\n\n    token::transfer(cpi_ctx, amount)?;\n    Ok(())\n}\n```\n\n### CPI with PDA Signer in Anchor\n\n```rust\npub fn transfer_from_pda(ctx: Context<TransferFromPDA>, amount: u64) -> Result<()> {\n    let seeds = &[\n        b\"vault\",\n        ctx.accounts.authority.key().as_ref(),\n        &[ctx.accounts.vault.bump],\n    ];\n    let signer_seeds = &[&seeds[..]];\n\n    let cpi_accounts = Transfer {\n        from: ctx.accounts.vault_token_account.to_account_info(),\n        to: ctx.accounts.user_token_account.to_account_info(),\n        authority: ctx.accounts.vault.to_account_info(),\n    };\n\n    let cpi_program = ctx.accounts.token_program.to_account_info();\n    let cpi_ctx = CpiContext::new_with_signer(\n        cpi_program,\n        cpi_accounts,\n        signer_seeds,\n    );\n\n    token::transfer(cpi_ctx, amount)?;\n    Ok(())\n}\n```\n\n## Common CPI Patterns\n\n### 1. Token Transfer\n\n```rust\n// Transfer SPL tokens from user to program vault\ntoken::transfer(\n    CpiContext::new(token_program, transfer_accounts),\n    amount,\n)?;\n```\n\n### 2. Minting Tokens\n\n```rust\n// Mint new tokens (requires mint authority)\ntoken::mint_to(\n    CpiContext::new_with_signer(token_program, mint_accounts, signer_seeds),\n    amount,\n)?;\n```\n\n### 3. Creating Accounts\n\n```rust\n// Create a new account (CPI to System Program)\nsystem_program::create_account(\n    CpiContext::new(system_program, create_accounts),\n    lamports,\n    space,\n    program_id,\n)?;\n```\n\n## CPI Security Considerations\n\n### 1. Account Validation\n\nAlways validate accounts before CPI:\n\n```rust\nrequire_keys_eq!(\n    ctx.accounts.token_program.key(),\n    token::ID,\n    ErrorCode::InvalidTokenProgram\n);\n```\n\n### 2. Signer Propagation\n\nSigners in your instruction are automatically propagated to CPIs. But be careful:\n\n```rust\n// BAD: Anyone can call this and spend vault tokens!\npub fn dangerous_withdraw(ctx: Context<Withdraw>, amount: u64) -> Result<()> {\n    token::transfer(\n        CpiContext::new_with_signer(...),\n        amount,\n    )\n}\n\n// GOOD: Check authority first\npub fn safe_withdraw(ctx: Context<Withdraw>, amount: u64) -> Result<()> {\n    require_keys_eq!(\n        ctx.accounts.authority.key(),\n        ctx.accounts.vault.authority,\n        ErrorCode::Unauthorized\n    );\n    token::transfer(...)\n}\n```\n\n### 3. Reentrancy\n\nSolana programs are **not reentrant** by default (a program can't call itself). This prevents classic reentrancy attacks.\n\n## Real-World CPI Examples\n\n**Escrow program**:\n1. User deposits tokens → CPI to Token Program to transfer tokens to escrow PDA\n2. Trade executes → CPI to Token Program to transfer from escrow PDA to recipient\n\n**Staking program**:\n1. User stakes tokens → CPI to Token Program to transfer to staking vault\n2. User claims rewards → CPI to Token Program to mint reward tokens\n3. User unstakes → CPI to Token Program to transfer staked tokens back\n\n**NFT marketplace**:\n1. User lists NFT → CPI to Token Program to transfer NFT to marketplace PDA\n2. Buyer purchases → CPI to System Program (SOL payment) + CPI to Token Program (NFT transfer)\n\n## Next Challenge\n\nYou'll construct a CPI instruction to transfer SOL from a PDA-owned account.\n"
+      },
+      {
+        "_key": "retrieval-close",
+        "_type": "quiz",
+        "questions": [
+          {
+            "explanation": "`invoke` works when the needed signatures already exist in the instruction's signer set. `invoke_signed` adds the PDA's seeds so the runtime lets the program sign for the PDA — the only way a keyless, program-controlled account can authorize a CPI.",
+            "id": "q1",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "When a PDA must sign the CPI — the program supplies the PDA's seeds so it can sign without a private key"
+              },
+              {
+                "correct": false,
+                "feedback": "The choice has nothing to do with amount. `invoke_signed` is specifically for when a PDA needs to sign; `invoke` is used when required signers are already present.",
+                "id": "b",
+                "label": "When the CPI transfers more than a set amount of SOL"
+              },
+              {
+                "correct": false,
+                "feedback": "Both call other programs. The distinction is the signer: `invoke_signed` provides PDA seeds so the program can sign on the PDA's behalf.",
+                "id": "c",
+                "label": "When calling a program you did not write"
+              }
+            ],
+            "prompt": "When do you use `invoke_signed` instead of `invoke` for a CPI?"
+          },
+          {
+            "explanation": "invoke_signed makes the program sign for its PDA, so the transfer succeeds for whoever calls. The missing piece is a caller-versus-authority check (require_keys_eq!) — the runtime will not supply your authorization logic, so an unchecked signed CPI is an open withdrawal for anyone.",
+            "id": "q2",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "Anyone can call it and drain the vault — the program signs for the PDA without verifying the caller's authority"
+              },
+              {
+                "correct": false,
+                "feedback": "The runtime enforces account ownership and signer propagation, not your business rules. If you do not check the caller against the vault authority, anyone can trigger the withdrawal.",
+                "id": "b",
+                "label": "Nothing — Solana blocks unauthorized CPIs automatically"
+              },
+              {
+                "correct": false,
+                "feedback": "PDAs sign token transfers fine via invoke_signed — that is the problem here. Without an authority check, that signing power is exposed to any caller.",
+                "id": "c",
+                "label": "The CPI fails because PDAs cannot sign token transfers"
+              }
+            ],
+            "prompt": "A `withdraw` instruction does a signed CPI to move vault tokens but never checks who called it. What is the flaw?"
+          }
+        ]
       }
     ],
     "skills": [
@@ -1351,6 +2330,62 @@
         "_key": "intro",
         "_type": "prose",
         "src": "# Error Handling in Solana Programs\n\nRobust error handling is critical for secure Solana programs. Rust's `Result` type and pattern matching make it impossible to accidentally ignore errors, unlike languages with exceptions.\n\n## The Result Type\n\nEvery fallible operation in Rust returns a `Result<T, E>`:\n- `Ok(value)`: Success, contains the result\n- `Err(error)`: Failure, contains the error\n\n```rust\npub fn divide(a: u64, b: u64) -> Result<u64, String> {\n    if b == 0 {\n        Err(\"Division by zero\".to_string())\n    } else {\n        Ok(a / b)\n    }\n}\n\nmatch divide(10, 2) {\n    Ok(result) => println!(\"Result: {}\", result),\n    Err(e) => println!(\"Error: {}\", e),\n}\n```\n\n## Error Propagation with `?`\n\nThe `?` operator automatically returns an error if the operation fails, or unwraps the value if it succeeds:\n\n```rust\npub fn process_transfer(\n    accounts: &[AccountInfo],\n    amount: u64,\n) -> ProgramResult {\n    let sender = next_account_info(&mut accounts.iter())?; // Returns early if fails\n    let recipient = next_account_info(&mut accounts.iter())?;\n    \n    if sender.lamports() < amount {\n        return Err(ProgramError::InsufficientFunds);\n    }\n    \n    **sender.lamports.borrow_mut() -= amount;\n    **recipient.lamports.borrow_mut() += amount;\n    \n    Ok(())\n}\n```\n\nThis is much cleaner than manual error checking:\n\n```rust\n// Without ?\nlet sender = match next_account_info(&mut accounts.iter()) {\n    Ok(acc) => acc,\n    Err(e) => return Err(e),\n};\n```\n\n## ProgramError Enum\n\nSolana provides a standard `ProgramError` enum for common failures:\n\n```rust\npub enum ProgramError {\n    InvalidArgument,\n    InsufficientFunds,\n    IncorrectProgramId,\n    MissingRequiredSignature,\n    AccountAlreadyInitialized,\n    UninitializedAccount,\n    // ... and 20+ more variants\n}\n```\n\nReturn these from your `process_instruction` function:\n\n```rust\nif !sender.is_signer {\n    return Err(ProgramError::MissingRequiredSignature);\n}\n```\n\n## Custom Error Types\n\nFor domain-specific errors, define your own enum:\n\n```rust\nuse num_derive::FromPrimitive;\nuse thiserror::Error;\n\n#[derive(Error, Debug, Copy, Clone, FromPrimitive)]\npub enum TokenError {\n    #[error(\"Insufficient token balance\")]\n    InsufficientBalance,\n    \n    #[error(\"Account is frozen\")]\n    AccountFrozen,\n    \n    #[error(\"Invalid mint authority\")]\n    InvalidMintAuthority,\n}\n\nimpl From<TokenError> for ProgramError {\n    fn from(e: TokenError) -> Self {\n        ProgramError::Custom(e as u32)\n    }\n}\n```\n\nNow you can return custom errors that convert to `ProgramError::Custom`:\n\n```rust\nif account.frozen {\n    return Err(TokenError::AccountFrozen.into());\n}\n```\n\n## Validation Patterns\n\nAlways validate inputs at the start of your instruction handler:\n\n```rust\npub fn process_transfer(\n    program_id: &Pubkey,\n    accounts: &[AccountInfo],\n    amount: u64,\n) -> ProgramResult {\n    // 1. Validate account count\n    if accounts.len() < 2 {\n        return Err(ProgramError::NotEnoughAccountKeys);\n    }\n    \n    let account_iter = &mut accounts.iter();\n    let sender = next_account_info(account_iter)?;\n    let recipient = next_account_info(account_iter)?;\n    \n    // 2. Validate ownership\n    if sender.owner != program_id {\n        return Err(ProgramError::IncorrectProgramId);\n    }\n    \n    // 3. Validate signer\n    if !sender.is_signer {\n        return Err(ProgramError::MissingRequiredSignature);\n    }\n    \n    // 4. Validate amount\n    if amount == 0 {\n        return Err(ProgramError::InvalidArgument);\n    }\n    \n    // 5. Validate balance\n    if sender.lamports() < amount {\n        return Err(ProgramError::InsufficientFunds);\n    }\n    \n    // Now perform the transfer\n    **sender.lamports.borrow_mut() -= amount;\n    **recipient.lamports.borrow_mut() += amount;\n    \n    Ok(())\n}\n```\n\n## Error Messages\n\nUse the `msg!` macro to log errors for debugging (visible in transaction logs):\n\n```rust\nmsg!(\"Transfer failed: insufficient balance ({} < {})\", sender.lamports(), amount);\nreturn Err(ProgramError::InsufficientFunds);\n```\n\n**Important**: Never log sensitive data like private keys or user PII.\n\n## Key Takeaways\n\n1. **Always use `Result`**: Never use `unwrap()` or `expect()` in production programs\n2. **Validate early**: Check all preconditions before mutating state\n3. **Use `?` for propagation**: Cleaner than manual error handling\n4. **Return specific errors**: Help clients diagnose failures\n5. **Log for debugging**: Use `msg!` to provide context in transaction logs\n"
+      },
+      {
+        "_key": "retrieval-close",
+        "_type": "quiz",
+        "questions": [
+          {
+            "explanation": "`?` unwraps on Ok and returns the Err upward, letting the instruction fail with a specific ProgramError the client can read. `.unwrap()` panics on Err — which is why the guidance is never to unwrap in program code; propagate with `?` instead.",
+            "id": "q1",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "On the Err case unwrap panics, aborting the program abnormally instead of returning a clean error to the caller"
+              },
+              {
+                "correct": false,
+                "feedback": "They differ on failure: `?` returns the error up the stack; `.unwrap()` panics. In a program you want the clean error return, not a panic.",
+                "id": "b",
+                "label": "Nothing — unwrap and ? behave identically"
+              },
+              {
+                "correct": false,
+                "feedback": "unwrap never retries; it panics on Err. `?` propagates the error so the transaction fails cleanly with a diagnosable code.",
+                "id": "c",
+                "label": "unwrap makes the instruction retry automatically"
+              }
+            ],
+            "prompt": "You replace a `?` on `next_account_info(...)` with `.unwrap()`. What is the risk in a Solana program?"
+          },
+          {
+            "explanation": "A handler's signature returns `ProgramError`, so a domain-specific `TokenError` needs a bridge into that type. Mapping it to `ProgramError::Custom(e as u32)` carries your error out as a numeric code clients can decode, while letting you write `return Err(TokenError::AccountFrozen.into())`.",
+            "id": "q2",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "process_instruction must return `ProgramError`, so custom errors are mapped into `Custom(code)` to travel through that return type"
+              },
+              {
+                "correct": false,
+                "feedback": "It does the opposite — it surfaces a numeric code to the client. The conversion exists so a domain error fits the required `ProgramError` return type.",
+                "id": "b",
+                "label": "It renames the error so clients cannot see the code"
+              },
+              {
+                "correct": false,
+                "feedback": "The conversion does not suppress anything; it lets `TokenError` be returned where a `ProgramError` is expected, carrying a `Custom` code.",
+                "id": "c",
+                "label": "It makes the error impossible to trigger"
+              }
+            ],
+            "prompt": "A custom `TokenError` implements `From<TokenError> for ProgramError`, returning `ProgramError::Custom(e as u32)`. Why is that conversion needed?"
+          }
+        ]
       }
     ],
     "skills": [
@@ -1371,6 +2406,68 @@
         "_key": "intro",
         "_type": "prose",
         "src": "# Your First Transaction\n\nLet's send your first transaction on Solana devnet!\n\n## Understanding Transactions\n\nA Solana transaction consists of:\n- **Instructions**: The operations to perform\n- **Signers**: The accounts that must sign the transaction\n- **Recent Blockhash**: Prevents duplicate transactions\n\n## Sending SOL\n\n```typescript\nimport {\n  Connection,\n  Keypair,\n  LAMPORTS_PER_SOL,\n  SystemProgram,\n  Transaction,\n  sendAndConfirmTransaction,\n} from '@solana/web3.js';\n\nasync function sendSol() {\n  // Connect to devnet\n  const connection = new Connection('https://api.devnet.solana.com', 'confirmed');\n\n  // Create sender keypair (in production, use wallet adapter)\n  const sender = Keypair.generate();\n\n  // Airdrop SOL to sender\n  const airdropSig = await connection.requestAirdrop(\n    sender.publicKey,\n    2 * LAMPORTS_PER_SOL\n  );\n  await connection.confirmTransaction(airdropSig);\n\n  // Create recipient\n  const recipient = Keypair.generate();\n\n  // Create transfer instruction\n  const transaction = new Transaction().add(\n    SystemProgram.transfer({\n      fromPubkey: sender.publicKey,\n      toPubkey: recipient.publicKey,\n      lamports: 0.5 * LAMPORTS_PER_SOL,\n    })\n  );\n\n  // Send and confirm\n  const signature = await sendAndConfirmTransaction(\n    connection,\n    transaction,\n    [sender]\n  );\n\n  console.log('Transaction signature:', signature);\n}\n```\n\n## Key Concepts\n\n- **Lamports**: The smallest unit of SOL (1 SOL = 1,000,000,000 lamports)\n- **Connection**: Connects your code to a Solana cluster\n- **SystemProgram**: Built-in program for basic operations like transfers\n\n## Viewing Your Transaction\n\nAfter sending, view your transaction on [Solana Explorer](https://explorer.solana.com/?cluster=devnet).\n"
+      },
+      {
+        "_key": "retrieval-close",
+        "_type": "quiz",
+        "questions": [
+          {
+            "explanation": "The recent blockhash gives each transaction a short validity window of a few minutes. This both prevents replay of an old signed transaction and forces clients to rebuild stale ones — which is why long-running signing flows must fetch a fresh blockhash before sending.",
+            "id": "q1",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "The blockhash expires and the network rejects the transaction, so you must rebuild it with a fresh one"
+              },
+              {
+                "correct": false,
+                "feedback": "The blockhash is load-bearing: it bounds how long a transaction is valid and prevents an old signed transaction from being replayed later. An expired one is rejected.",
+                "id": "b",
+                "label": "Nothing — the blockhash is only informational"
+              },
+              {
+                "correct": false,
+                "feedback": "The opposite — the recent-blockhash mechanism exists precisely to stop duplicate submissions. A stale blockhash causes rejection, not a double-send.",
+                "id": "c",
+                "label": "The transaction sends twice"
+              },
+              {
+                "correct": false,
+                "feedback": "Fees are not tied to blockhash age. An expired blockhash simply invalidates the transaction.",
+                "id": "d",
+                "label": "The fee doubles"
+              }
+            ],
+            "prompt": "Every Solana transaction includes a recent blockhash. What happens if you build a transaction but wait too long before sending it?"
+          },
+          {
+            "explanation": "1 SOL = 1,000,000,000 lamports, so 0.5 SOL = 500,000,000 lamports. Working in the integer base unit avoids the floating-point rounding errors that would be unacceptable in financial state.",
+            "id": "q2",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "500,000,000 lamports — balances are integer lamports, so there is no floating-point rounding on-chain"
+              },
+              {
+                "correct": false,
+                "feedback": "1 SOL = 1,000,000,000 lamports, not 10. So 0.5 SOL = 500,000,000 lamports.",
+                "id": "b",
+                "label": "5 lamports — LAMPORTS_PER_SOL is 10"
+              },
+              {
+                "correct": false,
+                "feedback": "The chain never stores fractions. Lamports are the indivisible base unit; all balances are whole lamports, which is why the API takes lamports.",
+                "id": "c",
+                "label": "0.5 lamports — the chain stores fractional SOL"
+              }
+            ],
+            "prompt": "You transfer `0.5 * LAMPORTS_PER_SOL`. How many lamports is that, and why does the API take lamports instead of SOL?"
+          }
+        ]
       }
     ],
     "skills": [
@@ -1390,7 +2487,75 @@
       {
         "_key": "intro",
         "_type": "prose",
-        "src": "# What is Solana?\n\nSolana is a high-performance blockchain supporting builders around the world creating crypto apps that scale.\n\n## Key Features\n\n- **Speed**: Solana can process 65,000+ transactions per second\n- **Low Cost**: Average transaction cost is $0.00025\n- **Energy Efficient**: Solana uses a Proof-of-Stake consensus mechanism\n- **Developer Friendly**: Programs can be written in Rust, C, or C++\n\n## How Solana Works\n\nSolana uses a unique combination of **Proof of History (PoH)** and **Proof of Stake (PoS)** to achieve high throughput.\n\n### Proof of History\n\nPoH creates a historical record that proves events occurred at a specific moment in time. Think of it as a cryptographic clock that helps the network agree on the order of transactions without waiting for other validators.\n\n### The Solana Runtime\n\nSolana programs (smart contracts) run inside the **Sealevel** runtime, which allows thousands of smart contracts to run in parallel. This is one of the key innovations that enables Solana's speed.\n\n## The Solana Ecosystem\n\nThe Solana ecosystem includes:\n- **DeFi**: Jupiter, Raydium, Marinade\n- **NFTs**: Magic Eden, Tensor\n- **Payments**: Solana Pay\n- **Infrastructure**: Helius, Jito\n\n## Why Learn Solana?\n\n1. Growing developer demand\n2. Active grants and bounty programs (like Superteam!)\n3. Fast iteration cycles due to quick finality\n4. Strong community support\n"
+        "src": "# What is Solana?\n\nSolana is a high-performance blockchain supporting builders around the world creating crypto apps that scale.\n\n## Key Features\n\n- **Speed**: Solana sustains thousands of transactions per second in practice (roughly 1,000–4,000 as of mid-2026), with a theoretical ceiling near 65,000 TPS\n- **Low Cost**: The base fee is 0.000005 SOL (5,000 lamports) per signature — a small fraction of a cent\n- **Energy Efficient**: Solana uses a Proof-of-Stake consensus mechanism\n- **Developer Friendly**: Programs are written in Rust, most often with the Anchor framework\n\n## How Solana Works\n\nSolana uses a unique combination of **Proof of History (PoH)** and **Proof of Stake (PoS)** to achieve high throughput.\n\n### Proof of History\n\nPoH creates a historical record that proves events occurred at a specific moment in time. Think of it as a cryptographic clock that helps the network agree on the order of transactions without waiting for other validators.\n\n### The Solana Runtime\n\nSolana programs (smart contracts) run inside the **Sealevel** runtime, which allows thousands of smart contracts to run in parallel. This is one of the key innovations that enables Solana's speed.\n\n## The Solana Ecosystem\n\nThe Solana ecosystem includes:\n- **DeFi**: Jupiter, Raydium, Marinade\n- **NFTs**: Magic Eden, Tensor\n- **Payments**: Solana Pay\n- **Infrastructure**: Helius, Jito\n\n## Why Learn Solana?\n\n1. Growing developer demand\n2. Active grants and bounty programs (like Superteam!)\n3. Fast iteration cycles due to quick finality\n4. Strong community support\n"
+      },
+      {
+        "_key": "retrieval-close",
+        "_type": "quiz",
+        "questions": [
+          {
+            "explanation": "PoH is a pre-computed hash chain where each output proves a specific amount of time passed since the previous one. Because order is baked into the clock, validators agree on sequence without a round of voting — removing a latency bottleneck other chains pay on every block.",
+            "id": "q1",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "It establishes a verifiable ordering of events in time, so validators don't have to message each other to agree on transaction order"
+              },
+              {
+                "correct": false,
+                "feedback": "That is Proof of Stake's job. PoH is the cryptographic clock; PoS handles leader selection and security. They solve different problems.",
+                "id": "b",
+                "label": "It selects which validator produces the next block based on stake"
+              },
+              {
+                "correct": false,
+                "feedback": "PoH is not encryption — Solana transactions are public. It is a hash chain that proves time passed between events.",
+                "id": "c",
+                "label": "It encrypts transactions so they stay private until finalized"
+              },
+              {
+                "correct": false,
+                "feedback": "Parallel execution is the Sealevel runtime, not PoH. PoH orders events; Sealevel executes non-conflicting transactions at the same time.",
+                "id": "d",
+                "label": "It lets thousands of programs run in parallel"
+              }
+            ],
+            "prompt": "Solana pairs Proof of History (PoH) with Proof of Stake. What problem does PoH solve on its own?"
+          },
+          {
+            "explanation": "Every transaction declares the accounts it will read and write up front. Sealevel runs any transactions whose writable-account sets do not overlap simultaneously — which is exactly why declaring accounts ahead of time makes the parallelism possible.",
+            "id": "q2",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "Their writable-account sets do not overlap"
+              },
+              {
+                "correct": false,
+                "feedback": "Parallelism is decided by account access, not by which program runs. Two calls to the same program on disjoint accounts still parallelize.",
+                "id": "b",
+                "label": "They must call the same program"
+              },
+              {
+                "correct": false,
+                "feedback": "The signer is irrelevant. Sealevel looks at which accounts each transaction writes, not who signed.",
+                "id": "c",
+                "label": "They must be submitted by the same wallet"
+              },
+              {
+                "correct": false,
+                "feedback": "Read-only helps but is not required — two writes parallelize fine as long as they touch different accounts.",
+                "id": "d",
+                "label": "They must both be read-only"
+              }
+            ],
+            "prompt": "Sealevel runs many Solana programs at once. What must be true of two transactions for them to execute in parallel?"
+          }
+        ]
       }
     ],
     "skills": [
@@ -1543,7 +2708,7 @@
       {
         "_key": "intro",
         "_type": "prose",
-        "src": "# Transaction Notifications\n\nReal-time notifications keep users informed about transaction status without requiring them to poll or refresh. Let's build a robust notification system.\n\n## Toast Notifications\n\nToasts are perfect for transaction feedback. Use libraries like `react-hot-toast` or `sonner`:\n\n```typescript\nimport toast from 'react-hot-toast';\nimport { ExternalLink } from 'lucide-react';\n\nfunction useTransactionToast() {\n  const cluster = 'mainnet-beta';\n\n  function toastSignature(signature: string) {\n    const explorerUrl = `https://explorer.solana.com/tx/${signature}?cluster=${cluster}`;\n    \n    toast.success(\n      <div className=\"flex items-center gap-2\">\n        <span>Transaction confirmed!</span>\n        <a\n          href={explorerUrl}\n          target=\"_blank\"\n          rel=\"noopener noreferrer\"\n          className=\"text-purple-600 hover:underline flex items-center gap-1\"\n        >\n          View <ExternalLink className=\"w-3 h-3\" />\n        </a>\n      </div>,\n      { duration: 8000 }\n    );\n  }\n\n  function toastError(message: string) {\n    toast.error(message, { duration: 5000 });\n  }\n\n  return { toastSignature, toastError };\n}\n\n// Usage\nasync function handleTransfer() {\n  const { toastSignature, toastError } = useTransactionToast();\n\n  try {\n    toast.loading('Sending transaction...');\n    const signature = await sendTransaction(tx, connection);\n    \n    toast.loading('Confirming...');\n    await connection.confirmTransaction(signature);\n    \n    toast.dismiss();\n    toastSignature(signature);\n  } catch (err) {\n    toast.dismiss();\n    toastError('Transaction failed. Please try again.');\n  }\n}\n```\n\n## WebSocket Subscriptions for Real-Time Updates\n\nMonitor accounts for changes without polling:\n\n```typescript\nfunction useAccountChangeNotifications(publicKey: PublicKey | null) {\n  const { connection } = useConnection();\n  const previousBalance = useRef<number | null>(null);\n\n  useEffect(() => {\n    if (!publicKey) return;\n\n    const subscriptionId = connection.onAccountChange(\n      publicKey,\n      (accountInfo) => {\n        const newBalance = accountInfo.lamports / LAMPORTS_PER_SOL;\n\n        if (previousBalance.current !== null) {\n          const change = newBalance - previousBalance.current;\n\n          if (change > 0) {\n            toast.success(`Received ${change.toFixed(4)} SOL`);\n          } else if (change < 0) {\n            toast.info(`Sent ${Math.abs(change).toFixed(4)} SOL`);\n          }\n        }\n\n        previousBalance.current = newBalance;\n      },\n      'confirmed'\n    );\n\n    return () => {\n      connection.removeAccountChangeListener(subscriptionId);\n    };\n  }, [publicKey, connection]);\n}\n```\n\n## Transaction Status Polling\n\nFor critical operations, poll transaction status:\n\n```typescript\nasync function waitForConfirmation(\n  connection: Connection,\n  signature: string,\n  commitment: Commitment = 'confirmed',\n  timeout = 60000\n): Promise<boolean> {\n  const start = Date.now();\n\n  while (Date.now() - start < timeout) {\n    const status = await connection.getSignatureStatus(signature);\n\n    if (status.value?.confirmationStatus === commitment) {\n      return true;\n    }\n\n    if (status.value?.err) {\n      throw new Error('Transaction failed');\n    }\n\n    // Wait 1s before next check\n    await new Promise(resolve => setTimeout(resolve, 1000));\n  }\n\n  throw new Error('Transaction confirmation timeout');\n}\n\n// Usage with notifications\nasync function sendWithNotifications(tx: Transaction) {\n  const toastId = toast.loading('Sending transaction...');\n\n  try {\n    const signature = await sendTransaction(tx, connection);\n    \n    toast.loading('Confirming on-chain...', { id: toastId });\n    \n    await waitForConfirmation(connection, signature);\n    \n    toast.success(\n      <span>\n        Transaction confirmed!\n        <a href={`https://explorer.solana.com/tx/${signature}`}>View</a>\n      </span>,\n      { id: toastId }\n    );\n  } catch (err) {\n    toast.error('Transaction failed', { id: toastId });\n  }\n}\n```\n\n## Notification Permission (Browser Notifications)\n\nFor background notifications when tab isn't focused:\n\n```typescript\nfunction useNotificationPermission() {\n  const [permission, setPermission] = useState<NotificationPermission>(\n    typeof Notification !== 'undefined' ? Notification.permission : 'default'\n  );\n\n  async function requestPermission() {\n    if (typeof Notification === 'undefined') return;\n    \n    const result = await Notification.requestPermission();\n    setPermission(result);\n  }\n\n  function notify(title: string, body: string) {\n    if (permission !== 'granted') return;\n    \n    new Notification(title, {\n      body,\n      icon: '/solana-logo.png',\n      badge: '/notification-badge.png',\n    });\n  }\n\n  return { permission, requestPermission, notify };\n}\n\n// Usage\nfunction TransactionMonitor() {\n  const { notify } = useNotificationPermission();\n  const { publicKey } = useWallet();\n  const { connection } = useConnection();\n\n  useEffect(() => {\n    if (!publicKey) return;\n\n    const sub = connection.onAccountChange(\n      publicKey,\n      () => {\n        if (!document.hasFocus()) {\n          notify('Solana Transaction', 'Your wallet balance changed');\n        }\n      },\n      'confirmed'\n    );\n\n    return () => connection.removeAccountChangeListener(sub);\n  }, [publicKey, connection, notify]);\n\n  return null;\n}\n```\n\n## Notification Sound\n\nAdd audio feedback for important events:\n\n```typescript\nfunction useTransactionSound() {\n  const successSound = useRef<HTMLAudioElement | null>(null);\n  const errorSound = useRef<HTMLAudioElement | null>(null);\n\n  useEffect(() => {\n    successSound.current = new Audio('/sounds/success.mp3');\n    errorSound.current = new Audio('/sounds/error.mp3');\n  }, []);\n\n  function playSuccess() {\n    successSound.current?.play();\n  }\n\n  function playError() {\n    errorSound.current?.play();\n  }\n\n  return { playSuccess, playError };\n}\n```\n\n## Notification Queue\n\nManage multiple notifications without overwhelming the UI:\n\n```typescript\nfunction NotificationQueue() {\n  const [queue, setQueue] = useState<Notification[]>([]);\n  const maxVisible = 3;\n\n  function addNotification(notification: Notification) {\n    setQueue(prev => [...prev, notification]);\n\n    setTimeout(() => {\n      setQueue(prev => prev.filter(n => n.id !== notification.id));\n    }, notification.duration || 5000);\n  }\n\n  return (\n    <div className=\"fixed bottom-4 right-4 space-y-2 z-50\">\n      {queue.slice(-maxVisible).map(notification => (\n        <NotificationCard key={notification.id} {...notification} />\n      ))}\n    </div>\n  );\n}\n```\n\n## Real-World Examples\n\n### Phantom Wallet\n- Shows in-app toast when transaction is signed\n- Browser notification when transaction confirms (if tab not focused)\n- Sound effect on success/failure\n\n### Jupiter Aggregator\n- Loading toast while routing\n- Progress indicator during swap\n- Success toast with explorer link\n- Error toast with retry button\n\n## Best Practices\n\n1. Use toast notifications for transaction updates\n2. Include explorer links in success notifications\n3. Implement WebSocket subscriptions for real-time balance changes\n4. Request browser notification permission for background updates\n5. Add sound effects for important events (success, error)\n6. Limit visible notifications to avoid UI clutter\n7. Auto-dismiss notifications after 5-8 seconds\n"
+        "src": "# Transaction Notifications\n\nReal-time notifications keep users informed about transaction status without requiring them to poll or refresh. Let's build a robust notification system.\n\n## Toast Notifications\n\nToasts are perfect for transaction feedback. Use libraries like `react-hot-toast` or `sonner`:\n\n```typescript\nimport toast from 'react-hot-toast';\nimport { ExternalLink } from 'lucide-react';\n\nfunction useTransactionToast(cluster: 'devnet' | 'testnet' | 'mainnet-beta' = 'devnet') {\n  function toastSignature(signature: string) {\n    // Point the explorer at the cluster your app is actually on — mainnet-beta is the default and omits the query param.\n    const explorerUrl = `https://explorer.solana.com/tx/${signature}${cluster !== 'mainnet-beta' ? `?cluster=${cluster}` : ''}`;\n    \n    toast.success(\n      <div className=\"flex items-center gap-2\">\n        <span>Transaction confirmed!</span>\n        <a\n          href={explorerUrl}\n          target=\"_blank\"\n          rel=\"noopener noreferrer\"\n          className=\"text-purple-600 hover:underline flex items-center gap-1\"\n        >\n          View <ExternalLink className=\"w-3 h-3\" />\n        </a>\n      </div>,\n      { duration: 8000 }\n    );\n  }\n\n  function toastError(message: string) {\n    toast.error(message, { duration: 5000 });\n  }\n\n  return { toastSignature, toastError };\n}\n\n// Usage\nasync function handleTransfer() {\n  const { toastSignature, toastError } = useTransactionToast();\n\n  try {\n    toast.loading('Sending transaction...');\n    const signature = await sendTransaction(tx, connection);\n    \n    toast.loading('Confirming...');\n    await connection.confirmTransaction(signature);\n    \n    toast.dismiss();\n    toastSignature(signature);\n  } catch (err) {\n    toast.dismiss();\n    toastError('Transaction failed. Please try again.');\n  }\n}\n```\n\n## WebSocket Subscriptions for Real-Time Updates\n\nMonitor accounts for changes without polling:\n\n```typescript\nfunction useAccountChangeNotifications(publicKey: PublicKey | null) {\n  const { connection } = useConnection();\n  const previousBalance = useRef<number | null>(null);\n\n  useEffect(() => {\n    if (!publicKey) return;\n\n    const subscriptionId = connection.onAccountChange(\n      publicKey,\n      (accountInfo) => {\n        const newBalance = accountInfo.lamports / LAMPORTS_PER_SOL;\n\n        if (previousBalance.current !== null) {\n          const change = newBalance - previousBalance.current;\n\n          if (change > 0) {\n            toast.success(`Received ${change.toFixed(4)} SOL`);\n          } else if (change < 0) {\n            toast.info(`Sent ${Math.abs(change).toFixed(4)} SOL`);\n          }\n        }\n\n        previousBalance.current = newBalance;\n      },\n      'confirmed'\n    );\n\n    return () => {\n      connection.removeAccountChangeListener(subscriptionId);\n    };\n  }, [publicKey, connection]);\n}\n```\n\n## Transaction Status Polling\n\nFor critical operations, poll transaction status:\n\n```typescript\nasync function waitForConfirmation(\n  connection: Connection,\n  signature: string,\n  commitment: Commitment = 'confirmed',\n  timeout = 60000\n): Promise<boolean> {\n  const start = Date.now();\n\n  while (Date.now() - start < timeout) {\n    const status = await connection.getSignatureStatus(signature);\n\n    if (status.value?.confirmationStatus === commitment) {\n      return true;\n    }\n\n    if (status.value?.err) {\n      throw new Error('Transaction failed');\n    }\n\n    // Wait 1s before next check\n    await new Promise(resolve => setTimeout(resolve, 1000));\n  }\n\n  throw new Error('Transaction confirmation timeout');\n}\n\n// Usage with notifications\nasync function sendWithNotifications(tx: Transaction) {\n  const toastId = toast.loading('Sending transaction...');\n\n  try {\n    const signature = await sendTransaction(tx, connection);\n    \n    toast.loading('Confirming on-chain...', { id: toastId });\n    \n    await waitForConfirmation(connection, signature);\n    \n    toast.success(\n      <span>\n        Transaction confirmed!\n        <a href={`https://explorer.solana.com/tx/${signature}`}>View</a>\n      </span>,\n      { id: toastId }\n    );\n  } catch (err) {\n    toast.error('Transaction failed', { id: toastId });\n  }\n}\n```\n\n## Notification Permission (Browser Notifications)\n\nFor background notifications when tab isn't focused:\n\n```typescript\nfunction useNotificationPermission() {\n  const [permission, setPermission] = useState<NotificationPermission>(\n    typeof Notification !== 'undefined' ? Notification.permission : 'default'\n  );\n\n  async function requestPermission() {\n    if (typeof Notification === 'undefined') return;\n    \n    const result = await Notification.requestPermission();\n    setPermission(result);\n  }\n\n  function notify(title: string, body: string) {\n    if (permission !== 'granted') return;\n    \n    new Notification(title, {\n      body,\n      icon: '/solana-logo.png',\n      badge: '/notification-badge.png',\n    });\n  }\n\n  return { permission, requestPermission, notify };\n}\n\n// Usage\nfunction TransactionMonitor() {\n  const { notify } = useNotificationPermission();\n  const { publicKey } = useWallet();\n  const { connection } = useConnection();\n\n  useEffect(() => {\n    if (!publicKey) return;\n\n    const sub = connection.onAccountChange(\n      publicKey,\n      () => {\n        if (!document.hasFocus()) {\n          notify('Solana Transaction', 'Your wallet balance changed');\n        }\n      },\n      'confirmed'\n    );\n\n    return () => connection.removeAccountChangeListener(sub);\n  }, [publicKey, connection, notify]);\n\n  return null;\n}\n```\n\n## Notification Sound\n\nAdd audio feedback for important events:\n\n```typescript\nfunction useTransactionSound() {\n  const successSound = useRef<HTMLAudioElement | null>(null);\n  const errorSound = useRef<HTMLAudioElement | null>(null);\n\n  useEffect(() => {\n    successSound.current = new Audio('/sounds/success.mp3');\n    errorSound.current = new Audio('/sounds/error.mp3');\n  }, []);\n\n  function playSuccess() {\n    successSound.current?.play();\n  }\n\n  function playError() {\n    errorSound.current?.play();\n  }\n\n  return { playSuccess, playError };\n}\n```\n\n## Notification Queue\n\nManage multiple notifications without overwhelming the UI:\n\n```typescript\nfunction NotificationQueue() {\n  const [queue, setQueue] = useState<Notification[]>([]);\n  const maxVisible = 3;\n\n  function addNotification(notification: Notification) {\n    setQueue(prev => [...prev, notification]);\n\n    setTimeout(() => {\n      setQueue(prev => prev.filter(n => n.id !== notification.id));\n    }, notification.duration || 5000);\n  }\n\n  return (\n    <div className=\"fixed bottom-4 right-4 space-y-2 z-50\">\n      {queue.slice(-maxVisible).map(notification => (\n        <NotificationCard key={notification.id} {...notification} />\n      ))}\n    </div>\n  );\n}\n```\n\n## Real-World Examples\n\n### Phantom Wallet\n- Shows in-app toast when transaction is signed\n- Browser notification when transaction confirms (if tab not focused)\n- Sound effect on success/failure\n\n### Jupiter Aggregator\n- Loading toast while routing\n- Progress indicator during swap\n- Success toast with explorer link\n- Error toast with retry button\n\n## Best Practices\n\n1. Use toast notifications for transaction updates\n2. Include explorer links in success notifications\n3. Implement WebSocket subscriptions for real-time balance changes\n4. Request browser notification permission for background updates\n5. Add sound effects for important events (success, error)\n6. Limit visible notifications to avoid UI clutter\n7. Auto-dismiss notifications after 5-8 seconds\n"
       }
     ],
     "skills": [
@@ -1604,6 +2769,62 @@
         "_key": "intro",
         "_type": "prose",
         "src": "# Ownership and Borrowing in Rust\n\nRust's ownership system is its most distinctive feature. Understanding it is essential for writing Solana programs, as it directly maps to how accounts are passed to your program.\n\n## The Three Rules of Ownership\n\n1. **Each value has a single owner**: Only one variable owns a piece of data at any time\n2. **When the owner goes out of scope, the value is dropped**: Automatic cleanup, no memory leaks\n3. **Ownership can be transferred (moved)**: Passing a value to a function or assigning it to another variable moves ownership\n\n```rust\nlet account_data = vec![1, 2, 3, 4];\nlet moved_data = account_data; // Ownership transferred\n// println!(\":{?}\", account_data); // Error: value moved\n```\n\n## Borrowing: Using Data Without Taking Ownership\n\nBorrowing lets you reference data without taking ownership. There are two types:\n\n### Immutable Borrowing (`&T`)\n\nYou can have **multiple** immutable borrows simultaneously:\n\n```rust\nfn calculate_balance(accounts: &[AccountInfo]) -> u64 {\n    accounts.iter().map(|a| a.lamports).sum()\n}\n\nlet accounts = vec![/* ... */];\nlet total = calculate_balance(&accounts);\n// accounts still valid here\n```\n\n### Mutable Borrowing (`&mut T`)\n\nYou can have **only ONE** mutable borrow at a time, and no immutable borrows can exist simultaneously:\n\n```rust\nfn debit_account(account: &mut AccountInfo, amount: u64) {\n    account.lamports -= amount;\n}\n\nlet mut account = /* ... */;\ndebit_account(&mut account);\n```\n\n## How This Maps to Solana\n\nWhen you write a Solana program, accounts are passed as `&[AccountInfo]` (immutable borrow) or extracted as `&mut AccountInfo` (mutable borrow):\n\n```rust\npub fn process_instruction(\n    program_id: &Pubkey,\n    accounts: &[AccountInfo], // immutable borrow of the slice\n    instruction_data: &[u8],\n) -> ProgramResult {\n    let account_iter = &mut accounts.iter();\n    let sender = next_account_info(account_iter)?; // immutable borrow\n    let recipient = next_account_info(account_iter)?;\n    \n    // To modify, you need mutable access:\n    **sender.lamports.borrow_mut() -= amount;\n    **recipient.lamports.borrow_mut() += amount;\n    Ok(())\n}\n```\n\n## Key Insight\n\nSolana's runtime enforces similar rules:\n- Multiple programs can read an account simultaneously (immutable borrows)\n- Only ONE program can write to an account in a transaction (mutable borrow)\n- The runtime prevents data races at the transaction level, and Rust prevents them at compile time\n\nThis alignment makes Rust the perfect fit for Solana development.\n"
+      },
+      {
+        "_key": "retrieval-close",
+        "_type": "quiz",
+        "questions": [
+          {
+            "explanation": "Each value has a single owner. Assigning it to another variable moves ownership and invalidates the original binding, so using `account_data` after the move fails to compile. This is what prevents two owners from freeing the same data.",
+            "id": "q1",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "An error — ownership moved to `moved`, so `account_data` is no longer valid to use"
+              },
+              {
+                "correct": false,
+                "feedback": "Assignment moves ownership, it does not share. After the move `account_data` is invalid; only `moved` owns the value.",
+                "id": "b",
+                "label": "Nothing — both variables now share the data"
+              },
+              {
+                "correct": false,
+                "feedback": "For a non-Copy type like `Vec`, assignment moves rather than copies. Using the moved-from variable is a compile error, not a silent copy.",
+                "id": "c",
+                "label": "It compiles but silently copies the data"
+              }
+            ],
+            "prompt": "You write `let moved = account_data;` then try to use `account_data` again. What does the compiler say?"
+          },
+          {
+            "explanation": "Rust enforces mutable-XOR-shared: either one `&mut` and nothing else, or any number of `&`. This prevents data races at compile time — the same single-writer discipline Solana's runtime enforces on accounts within a transaction.",
+            "id": "q2",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "No — a mutable borrow is exclusive; no other borrow, mutable or immutable, may coexist with it"
+              },
+              {
+                "correct": false,
+                "feedback": "That mixes the rules. Many immutable borrows can coexist, but a mutable borrow must be the only borrow. You cannot hold `&mut` and `&` at once.",
+                "id": "b",
+                "label": "Yes — one mutable and any number of immutable borrows are fine together"
+              },
+              {
+                "correct": false,
+                "feedback": "The rule is structural, not about whether you write: while a `&mut` exists, no other borrow is allowed regardless of use.",
+                "id": "c",
+                "label": "Yes, as long as you do not write through the mutable one"
+              }
+            ],
+            "prompt": "Inside a function you hold `&mut account`. Can you also take an immutable `&account` at the same time?"
+          }
+        ]
       }
     ],
     "skills": [
@@ -1807,6 +3028,62 @@
         "_key": "intro",
         "_type": "prose",
         "src": "# Program Derived Addresses (PDAs) Deep Dive\n\nProgram Derived Addresses are one of Solana's most powerful and unique features. They enable programs to \"own\" accounts and sign transactions without needing a private key.\n\n## What Are PDAs?\n\nA PDA is a public key that:\n1. Is derived deterministically from seeds and a program ID\n2. Is **not** on the Ed25519 elliptic curve (no corresponding private key exists)\n3. Can only be \"signed for\" by the program that derived it\n\n```rust\n// In Anchor\nlet (pda, bump) = Pubkey::find_program_address(\n    &[b\"user\", user.key().as_ref()],\n    program_id\n);\n```\n\n## Why PDAs Are Off-Curve\n\nSolana uses Ed25519 for signatures. Ed25519 keys lie on an elliptic curve. PDAs are specifically designed to fall **off** this curve, which means:\n- No private key can exist for a PDA\n- Only the deriving program can sign for the PDA (via CPI with `invoke_signed`)\n\nThis creates **program-controlled accounts** that can't be compromised by key theft.\n\n## PDA Derivation Process\n\n```\nseeds = [b\"user\", user_pubkey.as_ref()]\nprogram_id = your_program_id\n\nfor bump in 255..=0 {\n    candidate = sha256(seeds + [bump] + program_id)\n    if !is_on_curve(candidate) {\n        return (candidate, bump)  // This is your PDA\n    }\n}\n```\n\nThe **canonical bump** is the first bump (starting from 255) that produces an off-curve address.\n\n## Seeds Design Patterns\n\n### Pattern 1: User-Scoped Account\n\n```rust\nseeds = [b\"user\", user.key().as_ref()]\n```\n\nOne account per user. Used for user profiles, settings, etc.\n\n### Pattern 2: User + Resource\n\n```rust\nseeds = [b\"escrow\", user.key().as_ref(), trade_id.to_le_bytes().as_ref()]\n```\n\nMultiple accounts per user, one per resource (escrow, order, etc.).\n\n### Pattern 3: Global Singleton\n\n```rust\nseeds = [b\"config\"]\n```\n\nOne global account for the program (config, authority, etc.).\n\n### Pattern 4: Nested PDAs\n\n```rust\n// User stats PDA\nseeds_stats = [b\"stats\", user.key().as_ref()]\n\n// User vault PDA (derived from stats PDA)\nseeds_vault = [b\"vault\", stats_pda.key().as_ref()]\n```\n\nPDAs can be derived from other PDAs for complex hierarchies.\n\n## Storing the Bump\n\nAlways store the canonical bump in your account data:\n\n```rust\n#[account]\npub struct UserAccount {\n    pub authority: Pubkey,\n    pub bump: u8,  // Store this!\n    pub data: u64,\n}\n```\n\nWhy? Because recalculating the bump on every instruction is expensive (requires up to 256 hash operations). Storing it makes subsequent operations cheaper.\n\n## PDAs as Signers\n\nPDAs can sign CPIs using `invoke_signed`:\n\n```rust\ninvoke_signed(\n    &transfer_instruction,\n    &[\n        pda_account.to_account_info(),\n        recipient.to_account_info(),\n        system_program.to_account_info(),\n    ],\n    &[&[b\"user\", user.key().as_ref(), &[bump]]], // Signer seeds\n)?;\n```\n\nThe program derives the PDA, verifies it matches, and \"signs\" the CPI.\n\n## Security Considerations\n\n### 1. Seed Collision\n\nBe careful with seed design:\n\n```rust\n// BAD: Can collide if strings contain delimiters\nseeds = [user_name.as_bytes()]  // \"alice\" and \"ali\" + \"ce\" collide!\n\n// GOOD: Use fixed-size data or well-defined separators\nseeds = [b\"user\", user.key().as_ref()]\n```\n\n### 2. Bump Validation\n\nAlways use the canonical bump:\n\n```rust\n// In Anchor, this is automatic:\n#[account(\n    seeds = [b\"user\", authority.key().as_ref()],\n    bump = user.bump  // Validates stored bump is canonical\n)]\n```\n\n## PDA vs Regular Account\n\n| Feature | Regular Account | PDA |\n|---------|----------------|-----|\n| Has private key | Yes | No |\n| Can self-sign | Yes | No (requires program) |\n| Can hold SOL | Yes | Yes |\n| Can own other accounts | Yes | Yes |\n| Deterministic address | No | Yes |\n| On Ed25519 curve | Yes | No |\n\n## Real-World Examples\n\n**Token vaults** (escrow programs):\n```rust\nseeds = [b\"vault\", escrow.key().as_ref()]\n```\n\n**Associated Token Accounts**:\n```rust\nseeds = [wallet.key(), token_program.key(), mint.key()]\n```\n\n**Governance proposal accounts**:\n```rust\nseeds = [b\"proposal\", governance.key(), proposal_id.to_le_bytes()]\n```\n\n## Next Challenge\n\nYou'll derive multiple related PDAs from a common base to understand PDA hierarchies.\n"
+      },
+      {
+        "_key": "retrieval-close",
+        "_type": "quiz",
+        "questions": [
+          {
+            "explanation": "Ed25519 signing keys lie on the curve; a PDA is derived to sit off it, so no private key can exist. That is precisely what makes a PDA program-controlled: only the program that derived it can sign for it through invoke_signed, and no leaked key can drain it.",
+            "id": "q1",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "No private key exists for the address, so only the deriving program can sign for it via invoke_signed"
+              },
+              {
+                "correct": false,
+                "feedback": "Off-curve addresses are the same 32-byte size. What off-curve buys you is that no private key exists — the program alone can authorize it.",
+                "id": "b",
+                "label": "The address is shorter than a normal pubkey"
+              },
+              {
+                "correct": false,
+                "feedback": "PDAs can hold SOL fine. Off-curve means no private key, which is what makes them program-controlled and theft-proof.",
+                "id": "c",
+                "label": "The account can never hold SOL"
+              }
+            ],
+            "prompt": "A PDA is deliberately chosen to fall OFF the Ed25519 curve. What does off-curve guarantee?"
+          },
+          {
+            "explanation": "find_program_address tries bumps from 255 downward until it finds an off-curve address, up to 256 hash operations. Since that canonical bump is fixed for the seeds, storing it in the account lets later instructions validate the PDA with `bump = account.bump` instead of repeating the expensive search.",
+            "id": "q2",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "Re-finding the canonical bump can cost up to 256 hash attempts; storing it makes later instructions cheaper"
+              },
+              {
+                "correct": false,
+                "feedback": "The canonical bump is deterministic and stable for given seeds — it does not change. You store it to skip the costly search, not because it varies.",
+                "id": "b",
+                "label": "The bump changes every transaction, so it must be saved"
+              },
+              {
+                "correct": false,
+                "feedback": "Holding SOL has nothing to do with the bump. You store it purely to avoid recomputing the canonical bump on each call.",
+                "id": "c",
+                "label": "Storing the bump is required for the PDA to hold SOL"
+              }
+            ],
+            "prompt": "The lesson says to store the canonical `bump` in the account rather than re-deriving it each time. Why?"
+          }
+        ]
       }
     ],
     "skills": [
@@ -1906,7 +3183,63 @@
       {
         "_key": "intro",
         "_type": "prose",
-        "src": "# Introduction to Solana Programs\n\nSolana programs (often called \"smart contracts\" on other blockchains) are the executable code that runs on the Solana network. Understanding how they work is essential for building decentralized applications.\n\n## Programs are Stateless\n\nUnlike Ethereum smart contracts that store state internally, **Solana programs are completely stateless**. They only contain executable code. All state is stored in separate accounts.\n\n```\n┌─────────────────┐         ┌──────────────┐\n│  Your Program   │ ────>   │ Account Data │\n│  (Stateless)    │         │  (Stateful)  │\n└─────────────────┘         └──────────────┘\n```\n\nThis separation enables:\n- **Parallel execution**: Multiple transactions can run simultaneously\n- **Composability**: Programs can easily interact with each other\n- **Upgradability**: Update code without migrating state\n\n## Instruction Anatomy\n\nPrograms are invoked via **instructions**. Each instruction contains:\n\n```typescript\ninterface Instruction {\n  programId: PublicKey;           // Which program to call\n  keys: AccountMeta[];            // Which accounts to pass\n  data: Uint8Array;               // Instruction-specific data\n}\n\ninterface AccountMeta {\n  pubkey: PublicKey;              // Account address\n  isSigner: boolean;              // Must sign transaction?\n  isWritable: boolean;            // Program will modify?\n}\n```\n\n### Example: Transfer Instruction\n\n```typescript\nimport { SystemProgram, PublicKey, LAMPORTS_PER_SOL } from '@solana/web3.js';\n\nconst instruction = SystemProgram.transfer({\n  fromPubkey: sender,             // Signer, writable\n  toPubkey: recipient,            // Writable\n  lamports: 0.5 * LAMPORTS_PER_SOL\n});\n\nconsole.log('Program ID:', instruction.programId.toBase58());\n// 11111111111111111111111111111111 (System Program)\nconsole.log('Keys:', instruction.keys);\n// [{ pubkey: sender, isSigner: true, isWritable: true },\n//  { pubkey: recipient, isSigner: false, isWritable: true }]\n```\n\n## Built-in Programs vs Custom Programs\n\n### System Program\n- **ID**: `11111111111111111111111111111111`\n- **Purpose**: Account creation, SOL transfers, account assignment\n- **Used by**: Every Solana transaction\n\n### Token Program\n- **ID**: `TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA`\n- **Purpose**: SPL token minting, transfers, account management\n- **Used by**: All DeFi protocols, NFT platforms, token projects\n\n### Custom Programs\n- Deployed by developers\n- Written in Rust, C, or C++ (compiled to BPF bytecode)\n- Examples: Raydium AMM, Magic Eden marketplace, Jupiter aggregator\n\n## The BPF Runtime (Sealevel)\n\nSolana programs run in the **BPF (Berkeley Packet Filter)** virtual machine called **Sealevel**. Key features:\n\n- **Deterministic**: Same input always produces same output\n- **Metered**: Compute units prevent infinite loops\n- **Sandboxed**: Programs cannot access system resources\n- **Parallel**: Thousands of programs run simultaneously\n\n```typescript\n// Programs have a compute budget\nconst COMPUTE_UNITS_PER_INSTRUCTION = 200_000;\nconst MAX_COMPUTE_UNITS_PER_TX = 1_400_000;\n```\n\n## Cross-Program Invocation (CPI)\n\nPrograms can call other programs via **CPI**. This is how Solana achieves composability:\n\n```rust\n// Your program calling the Token Program (Rust example)\ninvoke(\n    &transfer_instruction,\n    &[\n        token_account.clone(),\n        destination.clone(),\n        authority.clone(),\n    ],\n)?;\n```\n\nReal example: Jupiter aggregates multiple DEXs by making CPIs to Raydium, Orca, and other AMM programs in a single transaction.\n\n## Next Steps\n\nIn the next challenge, you'll construct a custom instruction from scratch, understanding how programs receive and process data.\n"
+        "src": "# Introduction to Solana Programs\n\nSolana programs (often called \"smart contracts\" on other blockchains) are the executable code that runs on the Solana network. Understanding how they work is essential for building decentralized applications.\n\n## Programs are Stateless\n\nUnlike Ethereum smart contracts that store state internally, **Solana programs are completely stateless**. They only contain executable code. All state is stored in separate accounts.\n\n```\n┌─────────────────┐         ┌──────────────┐\n│  Your Program   │ ────>   │ Account Data │\n│  (Stateless)    │         │  (Stateful)  │\n└─────────────────┘         └──────────────┘\n```\n\nThis separation enables:\n- **Parallel execution**: Multiple transactions can run simultaneously\n- **Composability**: Programs can easily interact with each other\n- **Upgradability**: Update code without migrating state\n\n## Instruction Anatomy\n\nPrograms are invoked via **instructions**. Each instruction contains:\n\n```typescript\ninterface Instruction {\n  programId: PublicKey;           // Which program to call\n  keys: AccountMeta[];            // Which accounts to pass\n  data: Uint8Array;               // Instruction-specific data\n}\n\ninterface AccountMeta {\n  pubkey: PublicKey;              // Account address\n  isSigner: boolean;              // Must sign transaction?\n  isWritable: boolean;            // Program will modify?\n}\n```\n\n### Example: Transfer Instruction\n\n```typescript\nimport { SystemProgram, PublicKey, LAMPORTS_PER_SOL } from '@solana/web3.js';\n\nconst instruction = SystemProgram.transfer({\n  fromPubkey: sender,             // Signer, writable\n  toPubkey: recipient,            // Writable\n  lamports: 0.5 * LAMPORTS_PER_SOL\n});\n\nconsole.log('Program ID:', instruction.programId.toBase58());\n// 11111111111111111111111111111111 (System Program)\nconsole.log('Keys:', instruction.keys);\n// [{ pubkey: sender, isSigner: true, isWritable: true },\n//  { pubkey: recipient, isSigner: false, isWritable: true }]\n```\n\n## Built-in Programs vs Custom Programs\n\n### System Program\n- **ID**: `11111111111111111111111111111111`\n- **Purpose**: Account creation, SOL transfers, account assignment\n- **Used by**: Every Solana transaction\n\n### Token Program\n- **ID**: `TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA`\n- **Purpose**: SPL token minting, transfers, account management\n- **Used by**: All DeFi protocols, NFT platforms, token projects\n\n### Custom Programs\n- Deployed by developers\n- Written in Rust (compiled to BPF bytecode)\n- Examples: Raydium AMM, Magic Eden marketplace, Jupiter aggregator\n\n## The BPF Runtime (Sealevel)\n\nSolana programs run in the **BPF (Berkeley Packet Filter)** virtual machine called **Sealevel**. Key features:\n\n- **Deterministic**: Same input always produces same output\n- **Metered**: Compute units prevent infinite loops\n- **Sandboxed**: Programs cannot access system resources\n- **Parallel**: Thousands of programs run simultaneously\n\n```typescript\n// Programs have a compute budget\nconst COMPUTE_UNITS_PER_INSTRUCTION = 200_000;\nconst MAX_COMPUTE_UNITS_PER_TX = 1_400_000;\n```\n\n## Cross-Program Invocation (CPI)\n\nPrograms can call other programs via **CPI**. This is how Solana achieves composability:\n\n```rust\n// Your program calling the Token Program (Rust example)\ninvoke(\n    &transfer_instruction,\n    &[\n        token_account.clone(),\n        destination.clone(),\n        authority.clone(),\n    ],\n)?;\n```\n\nReal example: Jupiter aggregates multiple DEXs by making CPIs to Raydium, Orca, and other AMM programs in a single transaction.\n\n## Next Steps\n\nIn the next challenge, you'll construct a custom instruction from scratch, understanding how programs receive and process data.\n"
+      },
+      {
+        "_key": "retrieval-close",
+        "_type": "quiz",
+        "questions": [
+          {
+            "explanation": "Because a program is just code and all state sits in accounts it operates on, you can deploy new bytecode to the same program id without touching or migrating data. The same separation is what lets Sealevel run many transactions in parallel.",
+            "id": "q1",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "Upgrading a program's code without migrating any state, because the state lives in separate accounts"
+              },
+              {
+                "correct": false,
+                "feedback": "That is the Ethereum model this design rejects. Solana state lives in accounts, not in the program — which is exactly what makes upgrades and parallelism possible.",
+                "id": "b",
+                "label": "Storing user balances inside the program for fast access"
+              },
+              {
+                "correct": false,
+                "feedback": "Statelessness does not imply immutability. Separating code from state is what makes an upgrade clean — you swap the code and the account state is untouched.",
+                "id": "c",
+                "label": "Guaranteeing the program can never be changed once deployed"
+              }
+            ],
+            "prompt": "Solana programs are stateless — they hold only code, never data. Which capability does this separation directly enable?"
+          },
+          {
+            "explanation": "Every account a transaction touches is declared with its access flags before execution. The runtime enforces those flags, and it is precisely this up-front declaration that lets Sealevel know which transactions can run in parallel.",
+            "id": "q2",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "It rejects the transaction — writable intent must be declared up front"
+              },
+              {
+                "correct": false,
+                "feedback": "Nothing is silent. Declaring `isWritable` up front is mandatory; a write to a non-writable account aborts the transaction. This declaration is what lets Sealevel schedule parallel execution safely.",
+                "id": "b",
+                "label": "It silently allows the write since the program was handed the account"
+              },
+              {
+                "correct": false,
+                "feedback": "There is no after-the-fact rollback — the attempt fails immediately. Accounts must be declared writable before the instruction runs.",
+                "id": "c",
+                "label": "It writes, but rolls the change back after the transaction"
+              }
+            ],
+            "prompt": "An instruction's `AccountMeta` marks each account with `isSigner` and `isWritable`. What does the runtime do if a program tries to modify an account passed with `isWritable: false`?"
+          }
+        ]
       }
     ],
     "skills": [
@@ -2138,6 +3471,13 @@
             "id": "t6",
             "input": "'s-precision'"
           }
+        ],
+        "tutorNotes": [
+          "Learners settle first and check the budget afterwards, so a task that outruns the allowance reports extra calls and a negative balance instead of halting before the unaffordable call.",
+          "They continue after a refusal — the fixtures place a successful settlement right after the refused one to catch this — counting a spend that never happened.",
+          "They retry a program refusal as if it were transient; a policy refusal is terminal on-chain state and retrying only burns fees for the same answer.",
+          "They do the arithmetic in `Number`, so a u64-sized allowance loses precision above 2^53 and the final balance is silently wrong.",
+          "They report an error string they invented instead of the program's code verbatim, or let `signatures.length` drift out of step with `calls`."
         ]
       },
       {
@@ -2341,6 +3681,13 @@
             "id": "t6",
             "input": "'digest'"
           }
+        ],
+        "tutorNotes": [
+          "Learners leave `maxAmountRequired` as a number or a float; it must be a decimal string of base units because u64 amounts exceed JSON's safe integer range.",
+          "They put a human amount where base units are required — there is no decimals conversion in the protocol, so a quote priced at cents ships as dollars.",
+          "They hand-type the CAIP-2 network id or the mint literal and typo it; a one-character slip yields a challenge no client can match and looks like 'the client just never pays'.",
+          "They forget network and asset are a pair — pairing mainnet USDC with the devnet network id, or the reverse, so nothing on that cluster can satisfy the challenge.",
+          "They leave `PAY_TO` as the placeholder or use a non-base58 string, so the address never receives tokens."
         ]
       },
       {
@@ -2544,6 +3891,13 @@
             "id": "t6",
             "input": "'v2-evm-only'"
           }
+        ],
+        "tutorNotes": [
+          "Learners take `accepts[0]` instead of filtering the menu, so they try to pay the EVM entry the server happened to list first.",
+          "They filter on network or asset alone; the two are a pair, and a menu offering Solana mainnet and devnet with the same scheme will match the wrong one.",
+          "They parse and pay before decoding — assuming the envelope is in the body and the version is 2 — which passes one fixture and fails the rest.",
+          "They treat 'no payable entry' as an exception to throw, when it is a normal reported outcome; some servers only accept EVM money.",
+          "They only read `res.body` and miss that the envelope can arrive base64 in the `payment-required` header when the body is empty."
         ]
       },
       {
@@ -2759,6 +4113,12 @@
             "id": "t8",
             "input": "'annual-invoice', 'domestic-br', false"
           }
+        ],
+        "tutorNotes": [
+          "Learners treat the compliance stop as one branch among the rails rather than a gate that runs before any rail is chosen, so a cross-border-FX requirement gets a rail and only afterwards a stop that can no longer fire.",
+          "They add a second cross-border check instead of relocating the existing one, leaving two guards and duplicated logic.",
+          "They assume `unsupported` is the catch-all for anything unusual and route blocked FX requirements there instead of to the compliance stop.",
+          "They reorder the rail branches too, breaking cases the starter already handled correctly — only the guard's position is wrong."
         ]
       },
       {
@@ -2973,6 +4333,13 @@
             "id": "t8",
             "input": "25000000, 7, 7, 20000000, 10000000"
           }
+        ],
+        "tutorNotes": [
+          "Learners expect skipped periods to accumulate — that missing two months lets a merchant collect three periods' worth at once. The cap is a per-period ceiling, not an accruing balance.",
+          "They compute a cap that subtracts what was already charged but never notices the clock rolled into a new period, so the delegation works once and then refuses everything forever.",
+          "They place the success return before the over-cap guard, making the guard unreachable and approving every request.",
+          "They confuse `AMOUNT_EXCEEDS_PERIOD_LIMIT` (the full cap was used this period) with `PERIOD_NOT_ELAPSED` (collecting before the period has started).",
+          "They treat a refused second pull inside one period as a transient failure to retry, instead of the signal that the charge already landed."
         ]
       },
       {
@@ -3766,6 +5133,13 @@
             "id": "t7",
             "input": "false, 5, false"
           }
+        ],
+        "tutorNotes": [
+          "Learners plan `initSubscriptionAuthority` unconditionally, so a returning user whose authority already exists fails — the init belongs only on the branch where the read found it absent.",
+          "They drop the read step when the authority already exists; the read always runs because reading is how you learned whether the init is needed.",
+          "They convert the human amount with float math and lose sub-unit precision, or return a `number` or string where a `bigint` is required.",
+          "They inline the decimals conversion in several places instead of doing it once, so the base-unit factor drifts between call sites.",
+          "They order the steps so the transfer precedes creating the delegation — you cannot draw from a delegation you have not opened."
         ]
       },
       {
@@ -4170,6 +5544,13 @@
             "id": "t9",
             "input": "'token-2022', 'metadata-pointer', 'interest-bearing'"
           }
+        ],
+        "tutorNotes": [
+          "Learners scan the mint's own configured extensions and return the first one, so a mint carrying two gets a verdict that depends on authoring order rather than the fixed DISQUALIFYING order.",
+          "They check the required extension or the veto before confirming the owner is a token program at all, so the precedence between design-errors and rail-vetoes comes out wrong.",
+          "They treat Token-2022-with-nothing-to-justify-it as a rejection; the rail accepts it (`accepted: true`) while still flagging the choice as unnecessary.",
+          "They conflate a required extension being absent from the mint with the mint carrying a disqualifying extension — different reasons, different verdict codes.",
+          "They forget legacy Token has no extensions at all, so asking for one on a `token` mint is a design error caught before minting, not a runtime veto."
         ]
       }
     ],
@@ -4444,6 +5825,62 @@
         "_key": "intro",
         "_type": "prose",
         "src": "# Borsh Serialization for Solana\n\nSolana programs store data in accounts as raw bytes. To work with structured data (structs, enums), you need a serialization format. Solana uses **Borsh** (Binary Object Representation Serializer for Hashing).\n\n## Why Borsh?\n\nBorsh was designed specifically for blockchain use cases and offers several advantages over alternatives like JSON or MessagePack:\n\n### 1. Deterministic Serialization\n\nThe same data **always** produces the same byte sequence. This is critical for:\n- **Consensus**: All validators must agree on account state\n- **Hashing**: Content-addressed storage requires consistent hashes\n- **Merkle proofs**: Deterministic encoding enables efficient proofs\n\n```rust\n// JSON is NOT deterministic (field order can vary):\n{\"balance\": 100, \"owner\": \"abc\"} vs {\"owner\": \"abc\", \"balance\": 100}\n\n// Borsh IS deterministic:\nstruct { balance: 100, owner: \"abc\" } → always [100, 0, 0, 0, 3, 0, 0, 0, 97, 98, 99]\n```\n\n### 2. Compact Encoding\n\nBorsh doesn't include field names or type metadata in the output:\n\n```json\n// JSON: 42 bytes\n{\"balance\":1000000,\"frozen\":false}\n\n// Borsh: 9 bytes (4 for u64 + 4 for length prefix + 1 for bool)\n```\n\nSolana charges rent based on account size, so smaller serialization = lower costs.\n\n### 3. Fixed vs Variable-Size Data\n\n**Fixed-size types** (primitives) have a known byte length:\n- `u8`: 1 byte\n- `u32`, `i32`: 4 bytes\n- `u64`, `i64`: 8 bytes\n- `bool`: 1 byte (0 or 1)\n- `[u8; 32]`: 32 bytes (fixed array)\n\n**Variable-size types** include a 4-byte length prefix:\n- `String`: 4-byte length + UTF-8 bytes\n- `Vec<T>`: 4-byte length + serialized elements\n- `Option<T>`: 1-byte discriminant (0 or 1) + value if Some\n\n```rust\n// Example encoding:\nlet name = \"Alice\"; // Borsh: [5, 0, 0, 0, 65, 108, 105, 99, 101]\n                    //         ^^^^len=5  ^^^^UTF-8 bytes\n\nlet numbers = vec![1u32, 2, 3]; // [3, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0]\n                                //  ^^^^len=3  ^^^^^^^^^^ three u32s\n```\n\n## How Solana Uses Borsh\n\n### Account Data\n\nPrograms deserialize account data at the start of `process_instruction`:\n\n```rust\nlet user_account = UserAccount::try_from_slice(&account.data.borrow())?;\n```\n\nAfter modifying the struct, serialize it back:\n\n```rust\nuser_account.balance += amount;\nuser_account.serialize(&mut &mut account.data.borrow_mut()[..])?;\n```\n\n### Instruction Data\n\nClients serialize instructions before sending transactions:\n\n```rust\nlet instruction = TokenInstruction::Transfer { amount: 1000 };\nlet data = instruction.try_to_vec()?; // Serialize to bytes\n```\n\nThe program deserializes it to determine which function to call:\n\n```rust\nlet instruction = TokenInstruction::try_from_slice(instruction_data)?;\nmatch instruction { /* ... */ }\n```\n\n## Comparison with JSON\n\n| Feature | Borsh | JSON |\n|---------|-------|------|\n| Deterministic | ✅ Yes | ❌ No (field order) |\n| Size | Small (no field names) | Large (verbose) |\n| Speed | Fast (binary) | Slow (text parsing) |\n| Human-readable | ❌ No | ✅ Yes |\n| Schema required | ✅ Yes (Rust structs) | ❌ No |\n\nJSON is great for APIs and config files, but Borsh is the clear winner for on-chain data.\n\n## Next Steps\n\nIn the next challenge, you'll manually serialize and deserialize data using JavaScript's `DataView` and `TextEncoder` to understand how Borsh encoding works under the hood.\n"
+      },
+      {
+        "_key": "retrieval-close",
+        "_type": "quiz",
+        "questions": [
+          {
+            "explanation": "Fixed-size types (like a 32-byte array) encode as exactly their byte length; variable-size types (`String`, `Vec`, `Option`) carry a length or discriminant prefix so the decoder knows how far to read. The name Alice is a 4-byte length (5) plus 5 UTF-8 bytes = 9.",
+            "id": "q1",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "9 bytes — a 4-byte length prefix (value 5) plus 5 UTF-8 bytes"
+              },
+              {
+                "correct": false,
+                "feedback": "Variable-length types add a 4-byte length prefix so the decoder knows where the field ends. Alice is 4 + 5 = 9 bytes.",
+                "id": "b",
+                "label": "5 bytes — just the UTF-8 characters"
+              },
+              {
+                "correct": false,
+                "feedback": "Borsh does not pad strings. A `String` is a 4-byte length prefix plus its UTF-8 bytes: here 4 + 5 = 9.",
+                "id": "c",
+                "label": "32 bytes — strings are padded to a fixed size"
+              }
+            ],
+            "prompt": "A struct has a `Pubkey` (a 32-byte array) and a `String` field holding the name Alice. How many bytes does the String occupy in Borsh, and why?"
+          },
+          {
+            "explanation": "Consensus needs every validator to derive the same account state and the same hashes from the same value. JSON can vary field order, producing different bytes for equal data; Borsh always yields one canonical byte sequence, which is why it underpins account state and Merkle proofs.",
+            "id": "q2",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "All validators must agree on identical account bytes and hashes; non-deterministic field order would break consensus"
+              },
+              {
+                "correct": false,
+                "feedback": "Determinism is about reproducible bytes, not readability. JSON is the readable one; Borsh trades that away for consensus-safe encoding.",
+                "id": "b",
+                "label": "Determinism makes the data human-readable"
+              },
+              {
+                "correct": false,
+                "feedback": "Determinism does not remove the need to validate. It ensures every node encodes the same value to the same bytes, which consensus and hashing require.",
+                "id": "c",
+                "label": "It lets the program skip validating the data"
+              }
+            ],
+            "prompt": "Borsh is chosen over JSON for on-chain data largely because it is deterministic. Why does determinism matter here specifically?"
+          }
+        ]
       }
     ],
     "skills": [
@@ -4724,6 +6161,62 @@
         "_key": "intro",
         "_type": "prose",
         "src": "# Structs and Enums for Solana Programs\n\nSolana programs store data in accounts and process instructions. Rust's `struct` and `enum` types are perfect for modeling both.\n\n## Structs for Account Data\n\nA `struct` groups related data together. In Solana, you'll use structs to define the layout of account data:\n\n```rust\nuse borsh::{BorshDeserialize, BorshSerialize};\n\n#[derive(BorshSerialize, BorshDeserialize, Debug)]\npub struct UserAccount {\n    pub owner: Pubkey,\n    pub balance: u64,\n    pub last_login: i64,\n    pub is_frozen: bool,\n}\n```\n\n### Derive Macros\n\n`#[derive(...)]` automatically implements common traits:\n- `BorshSerialize`: Converts the struct to bytes for storage\n- `BorshDeserialize`: Reconstructs the struct from bytes\n- `Debug`: Enables `println!(\"{:?}\", user)` for debugging\n- `Clone`, `Copy`, `PartialEq`: Other useful traits\n\n## Enums for Instruction Types\n\nAn `enum` represents a value that can be one of several variants. Use enums to define the different instructions your program accepts:\n\n```rust\n#[derive(BorshSerialize, BorshDeserialize, Debug)]\npub enum TokenInstruction {\n    /// Initialize a new token mint\n    InitializeMint { decimals: u8 },\n    \n    /// Transfer tokens from one account to another\n    Transfer { amount: u64 },\n    \n    /// Burn tokens from an account\n    Burn { amount: u64 },\n}\n```\n\nEach variant can hold different data types, making enums incredibly flexible.\n\n## Pattern Matching\n\nUse `match` to handle different enum variants. Rust's compiler ensures you handle ALL cases:\n\n```rust\npub fn process_instruction(\n    program_id: &Pubkey,\n    accounts: &[AccountInfo],\n    instruction_data: &[u8],\n) -> ProgramResult {\n    let instruction = TokenInstruction::try_from_slice(instruction_data)?;\n    \n    match instruction {\n        TokenInstruction::InitializeMint { decimals } => {\n            msg!(\"Initializing mint with {} decimals\", decimals);\n            process_init_mint(accounts, decimals)\n        }\n        TokenInstruction::Transfer { amount } => {\n            msg!(\"Transferring {} tokens\", amount);\n            process_transfer(accounts, amount)\n        }\n        TokenInstruction::Burn { amount } => {\n            msg!(\"Burning {} tokens\", amount);\n            process_burn(accounts, amount)\n        }\n    }\n}\n```\n\n## Borsh Serialization\n\nBorsh (Binary Object Representation Serializer for Hashing) is Solana's preferred serialization format:\n- **Deterministic**: Same data always serializes to the same bytes\n- **Compact**: No field names or type tags in the output\n- **Fast**: Optimized for blockchain use cases\n\n```rust\nlet user = UserAccount {\n    owner: pubkey,\n    balance: 1000,\n    last_login: 1640000000,\n    is_frozen: false,\n};\n\n// Serialize to bytes\nlet bytes = user.try_to_vec()?;\n\n// Deserialize from bytes\nlet restored = UserAccount::try_from_slice(&bytes)?;\n```\n\nIn the next lessons, we'll dive deeper into Borsh and see how to manually serialize data when needed.\n"
+      },
+      {
+        "_key": "retrieval-close",
+        "_type": "quiz",
+        "questions": [
+          {
+            "explanation": "Rust checks `match` exhaustiveness at compile time, so every enum variant must be handled. Adding a new instruction variant without a handler breaks the build rather than silently dropping the instruction — a strong guard for a program's dispatch logic.",
+            "id": "q1",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "It must handle every variant — a missing case is a compile error, so a new instruction cannot be silently unhandled"
+              },
+              {
+                "correct": false,
+                "feedback": "`match` selects exactly one arm by the value's variant; it does not run them in sequence. Its guarantee is exhaustiveness, not fall-through.",
+                "id": "b",
+                "label": "It runs each arm in turn until one returns Ok"
+              },
+              {
+                "correct": false,
+                "feedback": "There is no silent default. If you add a variant and forget its arm, the code fails to compile — that is the safety property.",
+                "id": "c",
+                "label": "It defaults unknown variants to the first arm"
+              }
+            ],
+            "prompt": "Instruction types are modeled as an `enum` and dispatched with `match`. What does Rust's compiler guarantee about that match?"
+          },
+          {
+            "explanation": "Accounts store bytes, so a struct must serialize to a byte layout. Borsh is deterministic (same value, same bytes on every validator) and compact (no field names), which is required for consensus and cheap because Solana charges rent by account size.",
+            "id": "q2",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "Account data is raw bytes; Borsh gives a compact, deterministic byte layout that all validators reproduce identically"
+              },
+              {
+                "correct": false,
+                "feedback": "Borsh is binary and not human-readable — that is JSON's trait. Borsh is chosen for determinism and compactness, not readability.",
+                "id": "b",
+                "label": "Borsh makes the struct human-readable in the explorer"
+              },
+              {
+                "correct": false,
+                "feedback": "The opposite — Borsh encodes fields in a fixed order so the bytes are deterministic. Reorderable encodings like JSON break consensus.",
+                "id": "c",
+                "label": "Borsh lets fields be reordered freely at runtime"
+              }
+            ],
+            "prompt": "Why do these structs derive `BorshSerialize`/`BorshDeserialize` instead of being stored as JSON?"
+          }
+        ]
       }
     ],
     "skills": [
@@ -4858,6 +6351,62 @@
         "_key": "intro",
         "_type": "prose",
         "src": "# Understanding SPL Tokens\n\nSPL Tokens are the token standard on Solana, similar to ERC-20 on Ethereum but with key differences.\n\n## How SPL Tokens Work\n\nOn Solana, tokens are managed by the **Token Program**:\n\n1. **Mint Account**: Defines the token (supply, decimals, mint authority)\n2. **Token Account**: Holds tokens for a specific owner\n3. **Associated Token Account (ATA)**: A deterministically derived token account for a given wallet and mint\n\n```\nMint Account (Token Definition)\n  ├── Token Account (User A's balance)\n  ├── Token Account (User B's balance)\n  └── Token Account (User C's balance)\n```\n\n## Key Differences from Ethereum\n\n| Feature | Solana (SPL) | Ethereum (ERC-20) |\n|---------|-------------|-------------------|\n| Token balances | Separate accounts | Single contract |\n| Creating tokens | Token Program | Deploy new contract |\n| Account model | Account-based | Contract storage |\n| Cost | ~0.002 SOL per account | Gas fees vary |\n\n## The Token Program\n\n```typescript\nimport { createMint } from '@solana/spl-token';\n\nconst mint = await createMint(\n  connection,      // Connection\n  payer,           // Fee payer\n  mintAuthority,   // Who can mint new tokens\n  freezeAuthority, // Who can freeze accounts (null = no one)\n  9                // Decimals (9 = standard for SOL-like tokens)\n);\n\nconsole.log('Mint address:', mint.toBase58());\n```\n\n## Creating Token Accounts\n\n```typescript\nimport { getOrCreateAssociatedTokenAccount } from '@solana/spl-token';\n\nconst tokenAccount = await getOrCreateAssociatedTokenAccount(\n  connection,\n  payer,\n  mint,\n  owner.publicKey\n);\n```\n\n## Next Steps\n\nIn the next lesson, you will create your own SPL token on devnet!\n"
+      },
+      {
+        "_key": "retrieval-close",
+        "_type": "quiz",
+        "questions": [
+          {
+            "explanation": "ERC-20 keeps every balance in one contract's storage, so any two transfers contend on the same contract. Solana gives each (owner, mint) pair its own Token Account, so disjoint transfers parallelize — the same account-model reason Solana scales.",
+            "id": "q1",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "Separate per-owner accounts let transfers involving different holders run in parallel and be modified only by the Token Program"
+              },
+              {
+                "correct": false,
+                "feedback": "It is not a limitation but a deliberate design. Per-account balances enable parallelism, since two transfers involving different holders touch different accounts.",
+                "id": "b",
+                "label": "Because Solana cannot store mappings, so balances must be split"
+              },
+              {
+                "correct": false,
+                "feedback": "Freezing is a separate authority feature. The per-account model is about parallel execution and clear ownership, not bulk freezing.",
+                "id": "c",
+                "label": "So the mint authority can freeze the entire supply at once"
+              }
+            ],
+            "prompt": "On Solana a holder's balance of a token lives in its own Token Account, not in the mint. Why give each holder a separate account instead of one contract tracking everyone like ERC-20?"
+          },
+          {
+            "explanation": "Because the ATA address is a pure function of (wallet, mint), any client can compute it deterministically. That is why you can send tokens to someone who has not created their account yet, and why get-or-create is a safe idempotent operation.",
+            "id": "q2",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "Compute the exact ATA address for any wallet+mint off-chain, so you can send to it or create it at a known address"
+              },
+              {
+                "correct": false,
+                "feedback": "ATAs are not random — they are derived by a fixed formula from the wallet and mint, so the address is knowable in advance.",
+                "id": "b",
+                "label": "Nothing until it is created and assigned a random address"
+              },
+              {
+                "correct": false,
+                "feedback": "ATAs are program-derived addresses with no private key at all. Derivation gives you the address, never a signing key.",
+                "id": "c",
+                "label": "Recover the private key of the token account"
+              }
+            ],
+            "prompt": "An Associated Token Account (ATA) is 'deterministically derived' from a wallet and a mint. What does that let you do before the account even exists?"
+          }
+        ]
       }
     ],
     "skills": [
@@ -4877,7 +6426,7 @@
       {
         "_key": "intro",
         "_type": "prose",
-        "src": "# Solana Token Standards\n\nSolana has two token programs: the original **SPL Token** and the newer **Token-2022** with advanced extensions.\n\n## SPL Token Program\n\nThe original token standard (still used by 99% of tokens):\n\n```\nProgram ID: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA\n```\n\n### Account Structure\n\n**Mint Account** (defines the token):\n```\n- Mint Authority: Can mint new tokens\n- Supply: Total tokens in circulation\n- Decimals: Number of decimal places (9 for SOL-like)\n- Freeze Authority: Can freeze token accounts\n```\n\n**Token Account** (holds tokens for an owner):\n```\n- Mint: Which token this account holds\n- Owner: Who owns these tokens\n- Amount: Token balance\n- Delegate: Optional account that can spend on behalf of owner\n- State: Normal, Frozen, or Uninitialized\n```\n\n### Associated Token Account (ATA)\n\nA deterministic token account address:\n\n```typescript\nimport { getAssociatedTokenAddress } from '@solana/spl-token';\n\nconst ata = await getAssociatedTokenAddress(\n  mint,         // Token mint address\n  owner,        // Wallet address\n);\n\n// Derivation: PDA with seeds [owner, TOKEN_PROGRAM_ID, mint]\n```\n\nATAs simplify token transfers (one account per mint per wallet).\n\n## Token-2022 (Token Extensions)\n\nThe new token program with powerful extensions:\n\n```\nProgram ID: TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb\n```\n\n### Why Token-2022?\n\n- **Backwards compatible** with SPL Token\n- **Extensions** add features without changing core program\n- **Future-proof** (can add new extensions)\n\n### Available Extensions\n\n#### 1. Transfer Hooks\n\nExecute custom logic on every transfer:\n\n```rust\n// Example: Charge a fee on every transfer\npub fn transfer_hook(\n    ctx: Context<TransferHook>,\n    amount: u64,\n) -> Result<()> {\n    let fee = amount / 100;  // 1% fee\n    // Deduct fee, send to treasury\n    Ok(())\n}\n```\n\nUse cases:\n- Transaction fees\n- Blacklist/whitelist enforcement\n- Royalties on token transfers\n\n#### 2. Confidential Transfers\n\nPrivacy via zero-knowledge proofs:\n\n```\nNormal transfer: \"Alice sent 100 USDC to Bob\" (public)\nConfidential transfer: \"Alice sent ??? USDC to Bob\" (amount hidden)\n```\n\nBalances are encrypted, but the network verifies the math is correct.\n\n#### 3. Transfer Fees\n\nBuilt-in transfer fee without hooks:\n\n```\nTransfer 1000 tokens with 1% fee:\nRecipient receives: 990 tokens\nFee account receives: 10 tokens\n```\n\n#### 4. Interest-Bearing Tokens\n\nTokens that accrue interest:\n\n```\nRate: 5% APY\nYou hold: 1000 tokens\nAfter 1 year: Balance shows 1050 tokens (automatically)\n```\n\nImplemented via an exchange rate that updates over time.\n\n#### 5. Non-Transferable Tokens\n\nSoulbound tokens (can't be transferred):\n\n```\nUse cases:\n- Credentials (diplomas, certificates)\n- Achievements (non-tradeable NFTs)\n- Identity tokens\n```\n\n#### 6. Permanent Delegate\n\nA delegate that can't be revoked:\n\n```\nUse case: Staking program that needs permanent control\n```\n\n#### 7. Metadata Pointer\n\nStore metadata on-chain (no external JSON):\n\n```json\n{\n  \"name\": \"My Token\",\n  \"symbol\": \"MTK\",\n  \"uri\": \"https://example.com/metadata.json\"\n}\n```\n\nMetaplex Token Metadata is still more common, but metadata pointer is simpler.\n\n### Creating a Token-2022 Mint\n\n```typescript\nimport { createMint } from '@solana/spl-token';\nimport { TOKEN_2022_PROGRAM_ID } from '@solana/spl-token';\n\nconst mint = await createMint(\n  connection,\n  payer,\n  mintAuthority,\n  freezeAuthority,\n  decimals,\n  undefined,  // keypair (optional)\n  undefined,  // confirm options\n  TOKEN_2022_PROGRAM_ID  // Use Token-2022 instead of SPL Token\n);\n```\n\n### Adding Extensions\n\n```typescript\nimport {\n  createInitializeTransferFeeConfigInstruction,\n  createInitializeMintInstruction,\n} from '@solana/spl-token';\n\n// 1. Calculate space needed\nconst extensions = [ExtensionType.TransferFeeConfig];\nconst mintLen = getMintLen(extensions);\n\n// 2. Create account\nconst createAccountIx = SystemProgram.createAccount({\n  fromPubkey: payer.publicKey,\n  newAccountPubkey: mint.publicKey,\n  space: mintLen,\n  lamports: await connection.getMinimumBalanceForRentExemption(mintLen),\n  programId: TOKEN_2022_PROGRAM_ID,\n});\n\n// 3. Initialize extension\nconst initTransferFeeIx = createInitializeTransferFeeConfigInstruction(\n  mint.publicKey,\n  feeAuthority.publicKey,\n  withdrawAuthority.publicKey,\n  feeBasisPoints,  // 100 = 1%\n  maxFee,\n  TOKEN_2022_PROGRAM_ID\n);\n\n// 4. Initialize mint\nconst initMintIx = createInitializeMintInstruction(\n  mint.publicKey,\n  decimals,\n  mintAuthority.publicKey,\n  freezeAuthority.publicKey,\n  TOKEN_2022_PROGRAM_ID\n);\n\n// Send transaction with all 3 instructions\n```\n\n## Token Metadata (Metaplex)\n\nMetaplex Token Metadata is the standard for NFT metadata:\n\n```\nMetadata Account (PDA):\n- Name: \"Solana Monkey #1234\"\n- Symbol: \"SMB\"\n- URI: \"https://arweave.net/...\"\n- Creators: [{ address, verified, share }]\n- Seller Fee Basis Points: 500 (5% royalty)\n- Primary Sale Happened: true/false\n```\n\nThe URI points to JSON:\n\n```json\n{\n  \"name\": \"Solana Monkey #1234\",\n  \"description\": \"A cool monkey\",\n  \"image\": \"https://arweave.net/image.png\",\n  \"attributes\": [\n    { \"trait_type\": \"Background\", \"value\": \"Blue\" },\n    { \"trait_type\": \"Hat\", \"value\": \"Crown\" }\n  ]\n}\n```\n\n## Choosing the Right Standard\n\n| Feature | SPL Token | Token-2022 |\n|---------|-----------|------------|\n| Mature ecosystem | ✅ | ❌ (newer) |\n| DEX support | ✅ All DEXs | ⚠️ Limited |\n| Transfer fees | ❌ | ✅ |\n| Transfer hooks | ❌ | ✅ |\n| Confidential transfers | ❌ | ✅ |\n| Interest-bearing | ❌ | ✅ |\n\n**Use SPL Token** for:\n- General purpose tokens\n- Maximum compatibility\n- Production DeFi\n\n**Use Token-2022** for:\n- Compliance requirements (transfer hooks for KYC)\n- Privacy (confidential transfers)\n- Novel token mechanics (interest-bearing, non-transferable)\n\n## Token Account Rent\n\nToken accounts require rent (~0.002 SOL):\n\n```\nCreate 100 token accounts = 0.2 SOL locked\n```\n\nYou can close accounts to reclaim rent:\n\n```typescript\nimport { closeAccount } from '@solana/spl-token';\n\nawait closeAccount(\n  connection,\n  payer,\n  tokenAccount,\n  destination,  // Where to send reclaimed SOL\n  owner\n);\n```\n\n## Best Practices\n\n1. **Use ATAs** for user-facing wallets (simplifies UX)\n2. **Close unused accounts** to reclaim rent\n3. **Validate token mint** before accepting transfers (prevent spam)\n4. **Check program ID** (SPL Token vs Token-2022 vs fake programs)\n5. **Handle decimals** correctly (9 decimals = 1.0 = 1_000_000_000 base units)\n\n## Next Challenge\n\nYou'll implement token math functions for handling decimals, price calculations, and LP token formulas.\n"
+        "src": "# Solana Token Standards\n\nSolana has two token programs: the original **SPL Token** and the newer **Token-2022** with advanced extensions.\n\n## SPL Token Program\n\nThe original token standard (still used by 99% of tokens):\n\n```\nProgram ID: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA\n```\n\n### Account Structure\n\n**Mint Account** (defines the token):\n```\n- Mint Authority: Can mint new tokens\n- Supply: Total tokens in circulation\n- Decimals: Number of decimal places (9 for SOL-like)\n- Freeze Authority: Can freeze token accounts\n```\n\n**Token Account** (holds tokens for an owner):\n```\n- Mint: Which token this account holds\n- Owner: Who owns these tokens\n- Amount: Token balance\n- Delegate: Optional account that can spend on behalf of owner\n- State: Normal, Frozen, or Uninitialized\n```\n\n### Associated Token Account (ATA)\n\nA deterministic token account address:\n\n```typescript\nimport { getAssociatedTokenAddress } from '@solana/spl-token';\n\nconst ata = await getAssociatedTokenAddress(\n  mint,         // Token mint address\n  owner,        // Wallet address\n);\n\n// Derivation: PDA with seeds [owner, TOKEN_PROGRAM_ID, mint]\n```\n\nATAs simplify token transfers (one account per mint per wallet).\n\n## Token-2022 (Token Extensions)\n\nThe new token program with powerful extensions:\n\n```\nProgram ID: TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb\n```\n\n### Why Token-2022?\n\n- **Backwards compatible** with SPL Token\n- **Extensions** add features without changing core program\n- **Future-proof** (can add new extensions)\n\n### Available Extensions\n\n#### 1. Transfer Hooks\n\nExecute custom logic on every transfer:\n\n```rust\n// Example: Charge a fee on every transfer\npub fn transfer_hook(\n    ctx: Context<TransferHook>,\n    amount: u64,\n) -> Result<()> {\n    let fee = amount / 100;  // 1% fee\n    // Deduct fee, send to treasury\n    Ok(())\n}\n```\n\nUse cases:\n- Transaction fees\n- Blacklist/whitelist enforcement\n- Royalties on token transfers\n\n#### 2. Confidential Transfers\n\nPrivacy via zero-knowledge proofs:\n\n```\nNormal transfer: \"Alice sent 100 USDC to Bob\" (public)\nConfidential transfer: \"Alice sent ??? USDC to Bob\" (amount hidden)\n```\n\nBalances are encrypted, but the network verifies the math is correct.\n\n#### 3. Transfer Fees\n\nBuilt-in transfer fee without hooks:\n\n```\nTransfer 1000 tokens with 1% fee:\nRecipient receives: 990 tokens\nFee account receives: 10 tokens\n```\n\n#### 4. Interest-Bearing Tokens\n\nTokens that accrue interest:\n\n```\nRate: 5% APY\nYou hold: 1000 tokens\nAfter 1 year: Balance shows 1050 tokens (automatically)\n```\n\nImplemented via an exchange rate that updates over time.\n\n#### 5. Non-Transferable Tokens\n\nSoulbound tokens (can't be transferred):\n\n```\nUse cases:\n- Credentials (diplomas, certificates)\n- Achievements (non-tradeable NFTs)\n- Identity tokens\n```\n\n#### 6. Permanent Delegate\n\nA delegate that can't be revoked:\n\n```\nUse case: Staking program that needs permanent control\n```\n\n#### 7. Metadata Pointer\n\nStore metadata on-chain (no external JSON):\n\n```json\n{\n  \"name\": \"My Token\",\n  \"symbol\": \"MTK\",\n  \"uri\": \"https://example.com/metadata.json\"\n}\n```\n\nMetaplex Token Metadata is still more common, but metadata pointer is simpler.\n\n### Creating a Token-2022 Mint\n\n```typescript\nimport { createMint } from '@solana/spl-token';\nimport { TOKEN_2022_PROGRAM_ID } from '@solana/spl-token';\n\nconst mint = await createMint(\n  connection,\n  payer,\n  mintAuthority,\n  freezeAuthority,\n  decimals,\n  undefined,  // keypair (optional)\n  undefined,  // confirm options\n  TOKEN_2022_PROGRAM_ID  // Use Token-2022 instead of SPL Token\n);\n```\n\n### Adding Extensions\n\n```typescript\nimport {\n  createInitializeTransferFeeConfigInstruction,\n  createInitializeMintInstruction,\n} from '@solana/spl-token';\n\n// 1. Calculate space needed\nconst extensions = [ExtensionType.TransferFeeConfig];\nconst mintLen = getMintLen(extensions);\n\n// 2. Create account\nconst createAccountIx = SystemProgram.createAccount({\n  fromPubkey: payer.publicKey,\n  newAccountPubkey: mint.publicKey,\n  space: mintLen,\n  lamports: await connection.getMinimumBalanceForRentExemption(mintLen),\n  programId: TOKEN_2022_PROGRAM_ID,\n});\n\n// 3. Initialize extension\nconst initTransferFeeIx = createInitializeTransferFeeConfigInstruction(\n  mint.publicKey,\n  feeAuthority.publicKey,\n  withdrawAuthority.publicKey,\n  feeBasisPoints,  // 100 = 1%\n  maxFee,\n  TOKEN_2022_PROGRAM_ID\n);\n\n// 4. Initialize mint\nconst initMintIx = createInitializeMintInstruction(\n  mint.publicKey,\n  decimals,\n  mintAuthority.publicKey,\n  freezeAuthority.publicKey,\n  TOKEN_2022_PROGRAM_ID\n);\n\n// Send transaction with all 3 instructions\n```\n\n## Token Metadata (Metaplex)\n\nMetaplex Token Metadata is the standard for NFT metadata:\n\n```\nMetadata Account (PDA):\n- Name: \"Solana Monkey #1234\"\n- Symbol: \"SMB\"\n- URI: \"https://arweave.net/...\"\n- Creators: [{ address, verified, share }]\n- Seller Fee Basis Points: 500 (5% royalty)\n- Primary Sale Happened: true/false\n```\n\nThe URI points to JSON:\n\n```json\n{\n  \"name\": \"Solana Monkey #1234\",\n  \"description\": \"A cool monkey\",\n  \"image\": \"https://arweave.net/image.png\",\n  \"attributes\": [\n    { \"trait_type\": \"Background\", \"value\": \"Blue\" },\n    { \"trait_type\": \"Hat\", \"value\": \"Crown\" }\n  ]\n}\n```\n\n## Choosing the Right Standard\n\n| Feature | SPL Token | Token-2022 |\n|---------|-----------|------------|\n| DEX support | ✅ All DEXs | ✅ Broad (at parity) |\n| Transfer fees | ❌ | ✅ |\n| Transfer hooks | ❌ | ✅ |\n| Confidential transfers | ❌ | ✅ |\n| Interest-bearing | ❌ | ✅ |\n\n**Use SPL Token** for:\n- General purpose tokens\n- Maximum compatibility\n- Production DeFi\n\n**Use Token-2022** for:\n- Compliance requirements (transfer hooks for KYC)\n- Privacy (confidential transfers)\n- Novel token mechanics (interest-bearing, non-transferable)\n\n## Token Account Rent\n\nToken accounts require rent (~0.002 SOL):\n\n```\nCreate 100 token accounts = 0.2 SOL locked\n```\n\nYou can close accounts to reclaim rent:\n\n```typescript\nimport { closeAccount } from '@solana/spl-token';\n\nawait closeAccount(\n  connection,\n  payer,\n  tokenAccount,\n  destination,  // Where to send reclaimed SOL\n  owner\n);\n```\n\n## Best Practices\n\n1. **Use ATAs** for user-facing wallets (simplifies UX)\n2. **Close unused accounts** to reclaim rent\n3. **Validate token mint** before accepting transfers (prevent spam)\n4. **Check program ID** (SPL Token vs Token-2022 vs fake programs)\n5. **Handle decimals** correctly (9 decimals = 1.0 = 1_000_000_000 base units)\n\n## Next Challenge\n\nYou'll implement token math functions for handling decimals, price calculations, and LP token formulas.\n"
       }
     ],
     "skills": [
@@ -5053,6 +6602,68 @@
         "_key": "intro",
         "_type": "prose",
         "src": "# Setting Up a Solana Wallet\n\nA wallet is your gateway to the Solana ecosystem. It stores your private keys and lets you sign transactions.\n\n## Phantom Wallet (Recommended)\n\n1. Visit [phantom.app](https://phantom.app) and install the browser extension\n2. Click \"Create a new wallet\"\n3. **Write down your recovery phrase** and store it safely\n4. Set a password for your wallet\n\n## Understanding Keypairs\n\nIn Solana, a **keypair** consists of:\n- **Public Key**: Your wallet address (safe to share)\n- **Private Key**: Used to sign transactions (NEVER share this)\n\n```typescript\nimport { Keypair } from '@solana/web3.js';\n\n// Generate a new keypair\nconst keypair = Keypair.generate();\n\nconsole.log('Public Key:', keypair.publicKey.toBase58());\n// Example: 7C4jsPZpht42Tw6MjXWF56Q5RQUocjBBmciEjDa8HRtp\n```\n\n## Connecting to Devnet\n\nSwitch your Phantom wallet to Devnet:\n1. Open Phantom settings\n2. Go to \"Developer Settings\"\n3. Change network to \"Devnet\"\n\n## Getting Devnet SOL\n\nYou can get free devnet SOL from:\n- Solana CLI: `solana airdrop 2`\n- [Sol Faucet](https://faucet.solana.com)\n\nDevnet SOL has no real value and is only for testing.\n"
+      },
+      {
+        "_key": "retrieval-close",
+        "_type": "quiz",
+        "questions": [
+          {
+            "explanation": "A recovery phrase deterministically regenerates your private key. Your public key is safe to share (it is your address); the private key and the phrase that derives it authorize spending. No password or app boundary protects you once the phrase leaks.",
+            "id": "q1",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "Anyone with that phrase can reconstruct your private key and sign transactions as you, draining the wallet"
+              },
+              {
+                "correct": false,
+                "feedback": "The phrase is portable by design: it regenerates the same keypair in any wallet. That portability is exactly why it must never be shared.",
+                "id": "b",
+                "label": "Nothing — the phrase only works inside your original Phantom install"
+              },
+              {
+                "correct": false,
+                "feedback": "The app password only unlocks the local extension. The recovery phrase reconstructs the private key itself, which is all that is needed to sign transfers.",
+                "id": "c",
+                "label": "They can see your balance but cannot move funds without your app password"
+              }
+            ],
+            "prompt": "You paste your wallet's recovery phrase into a site that asks for it 'to verify your account.' What is the consequence?"
+          },
+          {
+            "explanation": "The keypair splits by role: the public key is your shareable address for receiving, and the private key is the secret that produces signatures when sending. Signing proves ownership without ever revealing the private key.",
+            "id": "q2",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "Share the public key to receive; the private key signs when you send"
+              },
+              {
+                "correct": false,
+                "feedback": "Reversed, and dangerous. The private key is never shared — it is the secret that signs. The public key is your address, safe to hand out.",
+                "id": "b",
+                "label": "Share the private key to receive; the public key signs when you send"
+              },
+              {
+                "correct": false,
+                "feedback": "Receiving uses the public key, but signing requires the private key — the public key alone cannot authorize a transfer.",
+                "id": "c",
+                "label": "Both use the public key"
+              },
+              {
+                "correct": false,
+                "feedback": "You would never share a private key to receive funds. Receiving only needs your public address.",
+                "id": "d",
+                "label": "Both use the private key"
+              }
+            ],
+            "prompt": "Which key do you give someone so they can send you SOL, and which one signs when you send SOL?"
+          }
+        ]
       }
     ],
     "skills": [
@@ -5073,6 +6684,62 @@
         "_key": "intro",
         "_type": "prose",
         "src": "# Why Rust for Solana\n\nSolana chose Rust as its primary programming language for smart contracts (called \"programs\" in Solana) for several compelling reasons that directly impact security, performance, and developer experience.\n\n## Memory Safety Without Garbage Collection\n\nRust's ownership system guarantees memory safety at compile time without needing a garbage collector. This is critical for blockchain programs where:\n- **Predictable performance**: No GC pauses that could cause transaction timeouts\n- **Low resource usage**: Programs run in a constrained environment with limited compute units\n- **Security**: Buffer overflows and use-after-free bugs are prevented at compile time\n\n```rust\n// Rust prevents this at compile time:\nlet data = vec![1, 2, 3];\nlet reference = &data[0];\ndrop(data); // Error: cannot drop while borrowed\nprintln!(\"{}\", reference);\n```\n\n## Zero-Cost Abstractions\n\nRust allows you to write high-level code that compiles down to the same performance as hand-written assembly. Abstractions like iterators, generics, and trait objects have no runtime overhead:\n\n```rust\n// This iterator chain compiles to the same code as a manual loop:\nlet sum: u64 = accounts.iter()\n    .filter(|a| a.lamports > 0)\n    .map(|a| a.lamports)\n    .sum();\n```\n\n## Ownership Model Maps to Solana's Account Model\n\nSolana's account model and Rust's ownership system align perfectly:\n- **Mutable XOR shared**: An account can be passed as mutable to only ONE program at a time, just like Rust's `&mut` borrows\n- **Explicit transfers**: Ownership transfers are explicit in both systems\n- **Lifetime tracking**: Rust ensures references don't outlive the data they point to, preventing dangling account references\n\n## Comparison with Other Languages\n\n**C/C++**: Similar performance, but no memory safety guarantees. Vulnerabilities like reentrancy attacks and buffer overflows are common.\n\n**JavaScript/Python**: Easy to write but interpreted, slow, and unsuitable for blockchain's performance constraints.\n\n**Go**: Has garbage collection which introduces unpredictable pauses.\n\nRust gives you C-level performance with Python-level safety guarantees—the perfect balance for blockchain development.\n"
+      },
+      {
+        "_key": "retrieval-close",
+        "_type": "quiz",
+        "questions": [
+          {
+            "explanation": "Rust's compiler enforces ownership and borrowing statically and inserts deterministic cleanup when values leave scope. There is no runtime collector, so no GC pauses can blow a transaction's compute budget — exactly what a constrained on-chain environment needs.",
+            "id": "q1",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "Its ownership and borrow rules are checked at compile time, so memory is freed deterministically with no runtime collector"
+              },
+              {
+                "correct": false,
+                "feedback": "Rust has no garbage collector at all. Safety is proven at compile time via ownership, so there is nothing to pause at runtime.",
+                "id": "b",
+                "label": "It runs a lightweight garbage collector tuned for short pauses"
+              },
+              {
+                "correct": false,
+                "feedback": "It does not rely on leaking. Ownership frees values deterministically when they go out of scope — no leak, no GC.",
+                "id": "c",
+                "label": "It leaks memory but the validator resets between transactions"
+              }
+            ],
+            "prompt": "Solana runs programs under a tight compute budget with no room for GC pauses. How does Rust give memory safety without a garbage collector?"
+          },
+          {
+            "explanation": "Rust allows either one mutable borrow or many immutable borrows, never both. Solana lets one transaction write an account while others read — the same mutable-XOR-shared shape. That alignment is why the ownership discipline you learn in Rust transfers directly to reasoning about account access.",
+            "id": "q2",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "One-mutable-XOR-many-shared borrows mirror one-writer-XOR-many-readers on an account per transaction"
+              },
+              {
+                "correct": false,
+                "feedback": "Upgrade authority is unrelated. The mapping is between Rust's exclusive-mutable-borrow rule and Solana allowing only one writer to an account at a time.",
+                "id": "b",
+                "label": "Rust's `&mut` maps to a program's upgrade authority"
+              },
+              {
+                "correct": false,
+                "feedback": "Block production is consensus, not ownership. The analogy is borrow exclusivity mapping to single-writer account access.",
+                "id": "c",
+                "label": "Rust ownership maps to which validator produces the next block"
+              }
+            ],
+            "prompt": "The lesson says Rust's `&mut` rule maps to Solana's account model. Which pairing is correct?"
+          }
+        ]
       }
     ],
     "skills": [

--- a/apps/web/src/content/generated/meta.json
+++ b/apps/web/src/content/generated/meta.json
@@ -1,5 +1,5 @@
 {
-  "compiledAt": "2026-07-26T14:14:04Z",
+  "compiledAt": "2026-07-26T19:38:50Z",
   "counts": {
     "achievements": 10,
     "courses": 7,
@@ -7,5 +7,5 @@
     "lessons": 85,
     "quests": 5
   },
-  "sha": "012cd03ddcaa1122283a742862d5c5b885a7a913"
+  "sha": "e1190680421e8190ab4deb9b41376667abc7a398"
 }

--- a/apps/web/src/content/generated/skills.json
+++ b/apps/web/src/content/generated/skills.json
@@ -161,10 +161,12 @@
   },
   {
     "label": "Brazil Compliance",
+    "reviewExempt": true,
     "slug": "brazil-compliance"
   },
   {
     "label": "Earn Submission",
+    "reviewExempt": true,
     "slug": "earn-submission"
   }
 ]

--- a/apps/web/src/lib/content/__tests__/fixtures/golden/course-by-slug.json
+++ b/apps/web/src/lib/content/__tests__/fixtures/golden/course-by-slug.json
@@ -1,613 +1,12 @@
 {
   "_id": "course-anchor-framework",
-  "creator": "B7o8NfV81HzjuZFWQTTx3Xdvh77Dqoajwib3kWEnvzJF",
+  "title": "Anchor Framework Mastery",
+  "slug": "anchor-framework",
   "description": "Master the Anchor framework for Solana smart contract development. From account constraints to PDAs, CPIs, testing, and deployment — build production-ready programs with confidence.",
   "difficulty": "intermediate",
   "duration": 14,
-  "modules": [
-    {
-      "description": "Learn the fundamentals of the Anchor framework, program structure, and account constraints.",
-      "key": "anchor-basics",
-      "lessons": [
-        {
-          "_id": "lesson-anchor-intro",
-          "blocks": [
-            {
-              "_type": "prose",
-              "amount": null,
-              "buildType": null,
-              "consumes": null,
-              "deployable": null,
-              "hints": null,
-              "idl": null,
-              "key": "intro",
-              "language": null,
-              "maxWords": null,
-              "network": null,
-              "produces": null,
-              "prompt": null,
-              "questions": null,
-              "solution": null,
-              "src": "# What is the Anchor Framework?\n\nAnchor is the most popular framework for Solana smart contract development. It provides a Rust-based DSL (domain-specific language) that dramatically reduces boilerplate and makes programs safer, faster to write, and easier to read.\n\n## Why Use Anchor?\n\nWriting native Solana programs in Rust requires:\n- Manual account deserialization and validation\n- Verbose error handling\n- Security checks spread across your code\n- Repetitive boilerplate for common patterns\n\nAnchor handles all of this for you through **macros** and **attributes**.\n\n### Native Solana Program\n\n```rust\n// Manual account deserialization\nlet account_info_iter = &mut accounts.iter();\nlet user_account = next_account_info(account_info_iter)?;\n\n// Manual validation\nif !user_account.is_writable {\n    return Err(ProgramError::InvalidAccountData);\n}\n\n// Manual owner check\nif user_account.owner != program_id {\n    return Err(ProgramError::IncorrectProgramId);\n}\n```\n\n### Anchor Program\n\n```rust\n#[derive(Accounts)]\npub struct UpdateUser<'info> {\n    #[account(mut)]\n    pub user: Account<'info, UserAccount>,\n}\n```\n\nAnchor automatically validates that the account is writable and owned by the program!\n\n## Anchor Project Structure\n\nA typical Anchor project:\n\n```\nmy-anchor-project/\n├── programs/\n│   └── my-program/\n│       └── src/\n│           └── lib.rs      # Your program code\n├── tests/\n│   └── my-program.ts       # TypeScript tests\n├── migrations/\n│   └── deploy.ts           # Deployment scripts\n└── Anchor.toml             # Configuration\n```\n\n## Key Anchor Components\n\n### 1. Program Module\n\n```rust\nuse anchor_lang::prelude::*;\n\ndeclare_id!(\"YourProgramIDHere\");\n\n#[program]\npub mod my_program {\n    use super::*;\n\n    pub fn initialize(ctx: Context<Initialize>) -> Result<()> {\n        // Your logic here\n        Ok(())\n    }\n}\n```\n\nThe `#[program]` macro defines your program's instruction handlers.\n\n### 2. Accounts Struct\n\n```rust\n#[derive(Accounts)]\npub struct Initialize<'info> {\n    #[account(\n        init,\n        payer = user,\n        space = 8 + 32 + 8\n    )]\n    pub my_account: Account<'info, MyAccount>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n    pub system_program: Program<'info, System>,\n}\n```\n\nAccounts structs define what accounts your instruction needs and how to validate them.\n\n### 3. Account Data\n\n```rust\n#[account]\npub struct MyAccount {\n    pub authority: Pubkey,\n    pub counter: u64,\n}\n```\n\nThe `#[account]` macro adds serialization/deserialization and a discriminator for account type safety.\n\n## Anchor vs Native: Security Benefits\n\n| Security Check | Native | Anchor |\n|----------------|--------|--------|\n| Account ownership | Manual check | Automatic via Account<'info, T> |\n| Signer verification | Manual check | Automatic via Signer<'info> |\n| Writable validation | Manual check | Automatic via #[account(mut)] |\n| Account initialization | Manual allocation | Automatic via #[account(init)] |\n| Discriminator (type safety) | None | Automatic 8-byte discriminator |\n\nAnchor programs are **harder to exploit** because common security pitfalls are prevented by the framework itself.\n\n## Next Steps\n\nIn the next challenge, you'll build a mock Anchor program structure to understand how programs are organized on Solana.\n",
-              "starter": null,
-              "tests": null,
-              "url": null
-            }
-          ],
-          "slug": "anchor-intro",
-          "title": "What is the Anchor Framework?"
-        },
-        {
-          "_id": "lesson-anchor-setup-challenge",
-          "blocks": [
-            {
-              "_type": "prose",
-              "amount": null,
-              "buildType": null,
-              "consumes": null,
-              "deployable": null,
-              "hints": null,
-              "idl": null,
-              "key": "intro",
-              "language": null,
-              "maxWords": null,
-              "network": null,
-              "produces": null,
-              "prompt": null,
-              "questions": null,
-              "solution": null,
-              "src": "# Challenge: Model Anchor Program Structure in Rust\n\nAnchor programs follow a specific pattern: instructions contain account metadata and serialized data. You'll model this structure using Rust structs and enums.\n\n## Your Task\n\nImplement `build_instruction(program_id, user_key, instruction_name)` that constructs an Anchor-style instruction:\n\n1. Encode the instruction name as bytes and compute its length\n2. Build account metadata for two accounts:\n   - User account: signer=true, writable=true\n   - System program (`\"11111111111111111111111111111111\"`): signer=false, writable=false\n3. Return a formatted string: `\"program:<id>,accounts:<count>,data_len:<len>\"`\n\n**This mirrors Anchor's `#[derive(Accounts)]` pattern** where each instruction declares which accounts it needs and how they should be validated.\n\n**Rust Concepts Used:**\n- Structs with boolean fields\n- `Vec` collection\n- String formatting with `format!()`\n- Byte conversion with `.as_bytes()`\n",
-              "starter": null,
-              "tests": null,
-              "url": null
-            },
-            {
-              "_type": "code",
-              "amount": null,
-              "buildType": "standard",
-              "consumes": null,
-              "deployable": false,
-              "hints": [
-                "Get instruction data length with instruction_name.as_bytes().len().",
-                "Create two AccountMeta structs in a Vec: one for the user (signer + writable) and one for the system program (neither).",
-                "Return format!(\"program:{},accounts:{},data_len:{}\", program_id, accounts.len(), data_len)."
-              ],
-              "idl": null,
-              "key": "exercise",
-              "language": "rust",
-              "maxWords": null,
-              "network": null,
-              "produces": null,
-              "prompt": null,
-              "questions": null,
-              "solution": "#[derive(Debug)]\nstruct AccountMeta {\n    pubkey: String,\n    is_signer: bool,\n    is_writable: bool,\n}\n\nfn build_instruction(program_id: &str, user_key: &str, instruction_name: &str) -> String {\n    let data_len = instruction_name.as_bytes().len();\n\n    let accounts = vec![\n        AccountMeta {\n            pubkey: user_key.to_string(),\n            is_signer: true,\n            is_writable: true,\n        },\n        AccountMeta {\n            pubkey: \"11111111111111111111111111111111\".to_string(),\n            is_signer: false,\n            is_writable: false,\n        },\n    ];\n\n    format!(\"program:{},accounts:{},data_len:{}\", program_id, accounts.len(), data_len)\n}\n",
-              "src": null,
-              "starter": "#[derive(Debug)]\nstruct AccountMeta {\n    pubkey: String,\n    is_signer: bool,\n    is_writable: bool,\n}\n\nfn build_instruction(program_id: &str, user_key: &str, instruction_name: &str) -> String {\n    // TODO: Encode instruction_name as bytes and get its length\n\n    // TODO: Build account metas Vec with 2 entries:\n    //   - user_key: signer=true, writable=true\n    //   - system program: signer=false, writable=false\n\n    // TODO: Return \"program:<id>,accounts:<count>,data_len:<len>\"\n    todo!()\n}\n",
-              "tests": [
-                {
-                  "description": "Includes the account count",
-                  "expectedOutput": "__result__.contains(\"accounts:2\")",
-                  "id": "t1",
-                  "input": "\"progXYZ\", \"userABC\", \"initialize\""
-                },
-                {
-                  "description": "Includes the instruction data length",
-                  "expectedOutput": "__result__.contains(\"data_len:10\")",
-                  "id": "t2",
-                  "input": "\"progXYZ\", \"userABC\", \"initialize\""
-                },
-                {
-                  "description": "Starts with the program id",
-                  "expectedOutput": "__result__.starts_with(\"program:progXYZ\")",
-                  "id": "t3",
-                  "input": "\"progXYZ\", \"userABC\", \"initialize\""
-                },
-                {
-                  "description": "Exact output for a different instruction",
-                  "expectedOutput": "\"program:myProg,accounts:2,data_len:4\".to_string()",
-                  "id": "t4",
-                  "input": "\"myProg\", \"user1\", \"mint\""
-                }
-              ],
-              "url": null
-            }
-          ],
-          "slug": "anchor-setup-challenge",
-          "title": "Challenge: Anchor Program Structure"
-        },
-        {
-          "_id": "lesson-anchor-accounts",
-          "blocks": [
-            {
-              "_type": "prose",
-              "amount": null,
-              "buildType": null,
-              "consumes": null,
-              "deployable": null,
-              "hints": null,
-              "idl": null,
-              "key": "intro",
-              "language": null,
-              "maxWords": null,
-              "network": null,
-              "produces": null,
-              "prompt": null,
-              "questions": null,
-              "solution": null,
-              "src": "# Anchor Account Constraints\n\nAnchor's constraint system is one of its most powerful features. Constraints allow you to declaratively specify account validation rules, and Anchor enforces them automatically.\n\n## The #[account] Attribute\n\nThe `#[account(...)]` attribute is used to apply constraints to accounts in your instruction context:\n\n```rust\n#[derive(Accounts)]\npub struct UpdateUserData<'info> {\n    #[account(\n        mut,\n        has_one = authority,\n        constraint = user.data_version < 10 @ ErrorCode::VersionTooHigh\n    )]\n    pub user: Account<'info, UserAccount>,\n    pub authority: Signer<'info>,\n}\n```\n\n## Common Constraints\n\n### 1. init - Initialize a New Account\n\n```rust\n#[account(\n    init,\n    payer = user,\n    space = 8 + 32 + 8\n)]\npub my_account: Account<'info, MyAccount>,\n```\n\n- Allocates space for the account\n- Transfers lamports from payer\n- Assigns account to the program\n- Sets account discriminator\n\n**Space calculation**: `8 (discriminator) + account_data_size`\n\n### 2. mut - Mark Account as Mutable\n\n```rust\n#[account(mut)]\npub user: Account<'info, UserAccount>,\n```\n\nRequires the account to be writable. Anchor will reject the transaction if the account isn't marked as writable.\n\n### 3. has_one - Verify Account Relationship\n\n```rust\n#[account]\npub struct UserAccount {\n    pub authority: Pubkey,\n    pub counter: u64,\n}\n\n#[derive(Accounts)]\npub struct Increment<'info> {\n    #[account(\n        mut,\n        has_one = authority\n    )]\n    pub user: Account<'info, UserAccount>,\n    pub authority: Signer<'info>,\n}\n```\n\n`has_one = authority` checks that `user.authority == authority.key()`. This prevents unauthorized updates.\n\n### 4. seeds & bump - PDA Derivation\n\n```rust\n#[account(\n    init,\n    payer = user,\n    space = 8 + 32 + 8,\n    seeds = [b\"user\", user.key().as_ref()],\n    bump\n)]\npub user_account: Account<'info, UserAccount>,\n```\n\n- `seeds`: The seeds used to derive the PDA\n- `bump`: Anchor finds the canonical bump automatically\n\nYou can also use a saved bump:\n\n```rust\n#[account(\n    mut,\n    seeds = [b\"user\", authority.key().as_ref()],\n    bump = user_account.bump\n)]\npub user_account: Account<'info, UserAccount>,\n```\n\n### 5. constraint - Custom Constraints\n\n```rust\n#[account(\n    mut,\n    constraint = user.balance >= 100 @ ErrorCode::InsufficientFunds,\n    constraint = user.is_active @ ErrorCode::AccountInactive\n)]\npub user: Account<'info, UserAccount>,\n```\n\nCustom constraints let you enforce arbitrary rules. The `@ ErrorCode::...` syntax specifies which error to return if the constraint fails.\n\n## Space Calculation\n\nWhen using `init`, you must specify the account size:\n\n```rust\n#[account]\npub struct UserAccount {\n    pub authority: Pubkey,    // 32 bytes\n    pub counter: u64,         // 8 bytes\n    pub name: String,         // 4 + length (max 32) = 36 bytes\n}\n\n// Space = 8 (discriminator) + 32 + 8 + 36 = 84 bytes\n```\n\n**Common sizes**:\n- Pubkey: 32 bytes\n- u64/i64: 8 bytes\n- u32/i32: 4 bytes\n- bool: 1 byte\n- String: 4 (length prefix) + max_length\n- Vec<T>: 4 (length prefix) + (item_size * max_count)\n\n## Constraint Execution Order\n\nAnchor executes constraints in this order:\n1. `init` / `init_if_needed`\n2. `mut`\n3. `seeds` + `bump`\n4. `has_one`\n5. Custom `constraint`s\n\nThis ensures accounts are properly initialized and validated before your instruction logic runs.\n\n## Next Challenge\n\nYou'll implement account validation logic that mimics Anchor's constraint system.\n",
-              "starter": null,
-              "tests": null,
-              "url": null
-            }
-          ],
-          "slug": "anchor-accounts",
-          "title": "Anchor Account Constraints"
-        },
-        {
-          "_id": "lesson-anchor-accounts-challenge",
-          "blocks": [
-            {
-              "_type": "prose",
-              "amount": null,
-              "buildType": null,
-              "consumes": null,
-              "deployable": null,
-              "hints": null,
-              "idl": null,
-              "key": "intro",
-              "language": null,
-              "maxWords": null,
-              "network": null,
-              "produces": null,
-              "prompt": null,
-              "questions": null,
-              "solution": null,
-              "src": "# Challenge: Simulate Anchor Account Validation in Rust\n\nAnchor's `#[account]` constraints validate accounts automatically. Here you'll implement the same checks manually — this is exactly what Anchor generates under the hood.\n\n## Your Task\n\nImplement `validate_account(account_owner, expected_owner, is_signer, require_signer, is_writable, require_writable)` that performs Anchor-style validation:\n\n1. Check if `account_owner == expected_owner` → if not, return `Err(\"IncorrectProgramId\")`\n2. Check if signer is required but missing → return `Err(\"MissingRequiredSignature\")`\n3. Check if writable is required but missing → return `Err(\"AccountNotWritable\")`\n4. If all pass, return `Ok(\"Valid\")`\n\n**This mirrors these Anchor constraints:**\n- `#[account(owner = expected_owner)]` → ownership check\n- `Signer<'info>` → signer check\n- `#[account(mut)]` → writable check\n\n**Check order matters** — validate in the order listed above (owner → signer → writable).\n",
-              "starter": null,
-              "tests": null,
-              "url": null
-            },
-            {
-              "_type": "code",
-              "amount": null,
-              "buildType": "standard",
-              "consumes": null,
-              "deployable": false,
-              "hints": [
-                "Check owner first: if account_owner != expected_owner { return Err(\"IncorrectProgramId\".to_string()); }",
-                "Then check signer: if require_signer && !is_signer { return Err(...); }",
-                "Same pattern for writable. If all pass, return Ok(\"Valid\".to_string())."
-              ],
-              "idl": null,
-              "key": "exercise",
-              "language": "rust",
-              "maxWords": null,
-              "network": null,
-              "produces": null,
-              "prompt": null,
-              "questions": null,
-              "solution": "fn validate_account(\n    account_owner: &str,\n    expected_owner: &str,\n    is_signer: bool,\n    require_signer: bool,\n    is_writable: bool,\n    require_writable: bool,\n) -> Result<String, String> {\n    if account_owner != expected_owner {\n        return Err(\"IncorrectProgramId\".to_string());\n    }\n    if require_signer && !is_signer {\n        return Err(\"MissingRequiredSignature\".to_string());\n    }\n    if require_writable && !is_writable {\n        return Err(\"AccountNotWritable\".to_string());\n    }\n    Ok(\"Valid\".to_string())\n}\n",
-              "src": null,
-              "starter": "fn validate_account(\n    account_owner: &str,\n    expected_owner: &str,\n    is_signer: bool,\n    require_signer: bool,\n    is_writable: bool,\n    require_writable: bool,\n) -> Result<String, String> {\n    // TODO: Check owner matches expected_owner\n    //       -> Err(\"IncorrectProgramId\")\n\n    // TODO: Check signer requirement\n    //       -> Err(\"MissingRequiredSignature\")\n\n    // TODO: Check writable requirement\n    //       -> Err(\"AccountNotWritable\")\n\n    // TODO: All checks passed -> Ok(\"Valid\")\n    todo!()\n}\n",
-              "tests": [
-                {
-                  "description": "Valid account passes",
-                  "expectedOutput": "__result__.is_ok()",
-                  "id": "t1",
-                  "input": "\"programA\", \"programA\", true, true, true, true"
-                },
-                {
-                  "description": "Wrong owner is rejected",
-                  "expectedOutput": "__result__ == Err(\"IncorrectProgramId\".to_string())",
-                  "id": "t2",
-                  "input": "\"programA\", \"programB\", true, true, true, true"
-                },
-                {
-                  "description": "Missing required signer is rejected",
-                  "expectedOutput": "__result__ == Err(\"MissingRequiredSignature\".to_string())",
-                  "id": "t3",
-                  "input": "\"programA\", \"programA\", false, true, true, true"
-                },
-                {
-                  "description": "Non-writable when writable is required is rejected",
-                  "expectedOutput": "__result__ == Err(\"AccountNotWritable\".to_string())",
-                  "id": "t4",
-                  "input": "\"programA\", \"programA\", true, true, false, true"
-                },
-                {
-                  "description": "Passes when no signer/writable requirements",
-                  "expectedOutput": "__result__.is_ok()",
-                  "id": "t5",
-                  "input": "\"progX\", \"progX\", true, false, true, false"
-                }
-              ],
-              "url": null
-            }
-          ],
-          "slug": "anchor-accounts-challenge",
-          "title": "Challenge: Account Validation"
-        }
-      ],
-      "title": "Anchor Basics"
-    },
-    {
-      "description": "Master Program Derived Addresses and Cross-Program Invocations for building composable programs.",
-      "key": "pdas-cpis",
-      "lessons": [
-        {
-          "_id": "lesson-pda-deep-dive",
-          "blocks": [
-            {
-              "_type": "prose",
-              "amount": null,
-              "buildType": null,
-              "consumes": null,
-              "deployable": null,
-              "hints": null,
-              "idl": null,
-              "key": "intro",
-              "language": null,
-              "maxWords": null,
-              "network": null,
-              "produces": null,
-              "prompt": null,
-              "questions": null,
-              "solution": null,
-              "src": "# Program Derived Addresses (PDAs) Deep Dive\n\nProgram Derived Addresses are one of Solana's most powerful and unique features. They enable programs to \"own\" accounts and sign transactions without needing a private key.\n\n## What Are PDAs?\n\nA PDA is a public key that:\n1. Is derived deterministically from seeds and a program ID\n2. Is **not** on the Ed25519 elliptic curve (no corresponding private key exists)\n3. Can only be \"signed for\" by the program that derived it\n\n```rust\n// In Anchor\nlet (pda, bump) = Pubkey::find_program_address(\n    &[b\"user\", user.key().as_ref()],\n    program_id\n);\n```\n\n## Why PDAs Are Off-Curve\n\nSolana uses Ed25519 for signatures. Ed25519 keys lie on an elliptic curve. PDAs are specifically designed to fall **off** this curve, which means:\n- No private key can exist for a PDA\n- Only the deriving program can sign for the PDA (via CPI with `invoke_signed`)\n\nThis creates **program-controlled accounts** that can't be compromised by key theft.\n\n## PDA Derivation Process\n\n```\nseeds = [b\"user\", user_pubkey.as_ref()]\nprogram_id = your_program_id\n\nfor bump in 255..=0 {\n    candidate = sha256(seeds + [bump] + program_id)\n    if !is_on_curve(candidate) {\n        return (candidate, bump)  // This is your PDA\n    }\n}\n```\n\nThe **canonical bump** is the first bump (starting from 255) that produces an off-curve address.\n\n## Seeds Design Patterns\n\n### Pattern 1: User-Scoped Account\n\n```rust\nseeds = [b\"user\", user.key().as_ref()]\n```\n\nOne account per user. Used for user profiles, settings, etc.\n\n### Pattern 2: User + Resource\n\n```rust\nseeds = [b\"escrow\", user.key().as_ref(), trade_id.to_le_bytes().as_ref()]\n```\n\nMultiple accounts per user, one per resource (escrow, order, etc.).\n\n### Pattern 3: Global Singleton\n\n```rust\nseeds = [b\"config\"]\n```\n\nOne global account for the program (config, authority, etc.).\n\n### Pattern 4: Nested PDAs\n\n```rust\n// User stats PDA\nseeds_stats = [b\"stats\", user.key().as_ref()]\n\n// User vault PDA (derived from stats PDA)\nseeds_vault = [b\"vault\", stats_pda.key().as_ref()]\n```\n\nPDAs can be derived from other PDAs for complex hierarchies.\n\n## Storing the Bump\n\nAlways store the canonical bump in your account data:\n\n```rust\n#[account]\npub struct UserAccount {\n    pub authority: Pubkey,\n    pub bump: u8,  // Store this!\n    pub data: u64,\n}\n```\n\nWhy? Because recalculating the bump on every instruction is expensive (requires up to 256 hash operations). Storing it makes subsequent operations cheaper.\n\n## PDAs as Signers\n\nPDAs can sign CPIs using `invoke_signed`:\n\n```rust\ninvoke_signed(\n    &transfer_instruction,\n    &[\n        pda_account.to_account_info(),\n        recipient.to_account_info(),\n        system_program.to_account_info(),\n    ],\n    &[&[b\"user\", user.key().as_ref(), &[bump]]], // Signer seeds\n)?;\n```\n\nThe program derives the PDA, verifies it matches, and \"signs\" the CPI.\n\n## Security Considerations\n\n### 1. Seed Collision\n\nBe careful with seed design:\n\n```rust\n// BAD: Can collide if strings contain delimiters\nseeds = [user_name.as_bytes()]  // \"alice\" and \"ali\" + \"ce\" collide!\n\n// GOOD: Use fixed-size data or well-defined separators\nseeds = [b\"user\", user.key().as_ref()]\n```\n\n### 2. Bump Validation\n\nAlways use the canonical bump:\n\n```rust\n// In Anchor, this is automatic:\n#[account(\n    seeds = [b\"user\", authority.key().as_ref()],\n    bump = user.bump  // Validates stored bump is canonical\n)]\n```\n\n## PDA vs Regular Account\n\n| Feature | Regular Account | PDA |\n|---------|----------------|-----|\n| Has private key | Yes | No |\n| Can self-sign | Yes | No (requires program) |\n| Can hold SOL | Yes | Yes |\n| Can own other accounts | Yes | Yes |\n| Deterministic address | No | Yes |\n| On Ed25519 curve | Yes | No |\n\n## Real-World Examples\n\n**Token vaults** (escrow programs):\n```rust\nseeds = [b\"vault\", escrow.key().as_ref()]\n```\n\n**Associated Token Accounts**:\n```rust\nseeds = [wallet.key(), token_program.key(), mint.key()]\n```\n\n**Governance proposal accounts**:\n```rust\nseeds = [b\"proposal\", governance.key(), proposal_id.to_le_bytes()]\n```\n\n## Next Challenge\n\nYou'll derive multiple related PDAs from a common base to understand PDA hierarchies.\n",
-              "starter": null,
-              "tests": null,
-              "url": null
-            }
-          ],
-          "slug": "pda-deep-dive",
-          "title": "PDA Deep Dive"
-        },
-        {
-          "_id": "lesson-pda-advanced-challenge",
-          "blocks": [
-            {
-              "_type": "prose",
-              "amount": null,
-              "buildType": null,
-              "consumes": null,
-              "deployable": null,
-              "hints": null,
-              "idl": null,
-              "key": "intro",
-              "language": null,
-              "maxWords": null,
-              "network": null,
-              "produces": null,
-              "prompt": null,
-              "questions": null,
-              "solution": null,
-              "src": "# Challenge: Derive Multiple Related PDAs in Rust\n\nReal Anchor programs often derive multiple PDAs per user — profile, stats, vault, etc. Each uses different seed prefixes but the same user key.\n\nUsing the simulated PDA derivation from earlier, derive 3 related PDAs and return their hashes as a tuple.\n\n## Your Task\n\nImplement `derive_user_pdas(user, program_id)` that:\n\n1. Derives a **user PDA** with seeds `[\"user\", user]`\n2. Derives a **stats PDA** with seeds `[\"stats\", user]`\n3. Derives a **vault PDA** with seeds `[\"vault\", user]`\n4. Returns `(user_hash, stats_hash, vault_hash)` as a `(u64, u64, u64)` tuple\n\nA helper `find_pda` is provided — use it to derive each PDA.\n\n**Requirements:**\n- All three hashes must be off-curve (even)\n- All three must be different from each other\n- Same inputs must always produce same outputs (deterministic)\n",
-              "starter": null,
-              "tests": null,
-              "url": null
-            },
-            {
-              "_type": "code",
-              "amount": null,
-              "buildType": "standard",
-              "consumes": null,
-              "deployable": false,
-              "hints": [
-                "Call find_pda with different seed prefixes: find_pda(&[\"user\", user], program_id) for the user PDA.",
-                "Each find_pda returns (hash, bump) — you only need the hash (the .0 field) for the return tuple.",
-                "let (user_h, _) = find_pda(&[\"user\", user], program_id); then same for stats and vault."
-              ],
-              "idl": null,
-              "key": "exercise",
-              "language": "rust",
-              "maxWords": null,
-              "network": null,
-              "produces": null,
-              "prompt": null,
-              "questions": null,
-              "solution": "use std::collections::hash_map::DefaultHasher;\nuse std::hash::{Hash, Hasher};\n\nfn hash_with_bump(seeds: &[&str], bump: u8, program_id: &str) -> u64 {\n    let mut hasher = DefaultHasher::new();\n    for seed in seeds {\n        seed.hash(&mut hasher);\n    }\n    bump.hash(&mut hasher);\n    program_id.hash(&mut hasher);\n    hasher.finish()\n}\n\nfn find_pda(seeds: &[&str], program_id: &str) -> (u64, u8) {\n    for bump in (0..=255u8).rev() {\n        let hash = hash_with_bump(seeds, bump, program_id);\n        if hash % 2 == 0 {\n            return (hash, bump);\n        }\n    }\n    panic!(\"No valid bump found\");\n}\n\nfn derive_user_pdas(user: &str, program_id: &str) -> (u64, u64, u64) {\n    let (user_h, _) = find_pda(&[\"user\", user], program_id);\n    let (stats_h, _) = find_pda(&[\"stats\", user], program_id);\n    let (vault_h, _) = find_pda(&[\"vault\", user], program_id);\n    (user_h, stats_h, vault_h)\n}\n",
-              "src": null,
-              "starter": "use std::collections::hash_map::DefaultHasher;\nuse std::hash::{Hash, Hasher};\n\nfn hash_with_bump(seeds: &[&str], bump: u8, program_id: &str) -> u64 {\n    let mut hasher = DefaultHasher::new();\n    for seed in seeds {\n        seed.hash(&mut hasher);\n    }\n    bump.hash(&mut hasher);\n    program_id.hash(&mut hasher);\n    hasher.finish()\n}\n\nfn find_pda(seeds: &[&str], program_id: &str) -> (u64, u8) {\n    for bump in (0..=255u8).rev() {\n        let hash = hash_with_bump(seeds, bump, program_id);\n        if hash % 2 == 0 {\n            return (hash, bump);\n        }\n    }\n    panic!(\"No valid bump found\");\n}\n\n/// Derive user, stats, and vault PDAs for the given user.\n/// Returns (user_hash, stats_hash, vault_hash).\nfn derive_user_pdas(user: &str, program_id: &str) -> (u64, u64, u64) {\n    // TODO: Derive user PDA with seeds [\"user\", user]\n    // TODO: Derive stats PDA with seeds [\"stats\", user]\n    // TODO: Derive vault PDA with seeds [\"vault\", user]\n    // TODO: Return the three hashes as a tuple\n    todo!()\n}\n",
-              "tests": [
-                {
-                  "description": "All PDAs should be off-curve (even hashes)",
-                  "expectedOutput": "__result__.0 % 2 == 0 && __result__.1 % 2 == 0 && __result__.2 % 2 == 0",
-                  "id": "test-1",
-                  "input": "\"alice\", \"prog1\""
-                },
-                {
-                  "description": "All three PDAs should be different",
-                  "expectedOutput": "__result__.0 != __result__.1 && __result__.1 != __result__.2",
-                  "id": "test-2",
-                  "input": "\"alice\", \"prog1\""
-                },
-                {
-                  "description": "Different users should produce different PDAs",
-                  "expectedOutput": "__result__.0 != derive_user_pdas(\"alice\", \"prog1\").0",
-                  "id": "test-3",
-                  "input": "\"bob\", \"prog1\""
-                }
-              ],
-              "url": null
-            }
-          ],
-          "slug": "pda-advanced-challenge",
-          "title": "Challenge: Multi-PDA Derivation"
-        },
-        {
-          "_id": "lesson-cpi-overview",
-          "blocks": [
-            {
-              "_type": "prose",
-              "amount": null,
-              "buildType": null,
-              "consumes": null,
-              "deployable": null,
-              "hints": null,
-              "idl": null,
-              "key": "intro",
-              "language": null,
-              "maxWords": null,
-              "network": null,
-              "produces": null,
-              "prompt": null,
-              "questions": null,
-              "solution": null,
-              "src": "# Cross-Program Invocations (CPIs)\n\nCross-Program Invocations allow one Solana program to call another program. This is what makes Solana programs **composable** — you can build on top of existing programs like building blocks.\n\n## Why CPIs Matter\n\nCPIs enable:\n- **Token transfers** via the Token Program\n- **NFT minting** via Metaplex programs\n- **Swaps** through DEX programs (Jupiter, Raydium)\n- **Lending** through DeFi protocols (Solend, MarginFi)\n\nWithout CPIs, every program would need to reimplement basic functionality. With CPIs, you compose existing programs.\n\n## How CPIs Work\n\nWhen Program A calls Program B:\n\n```\nUser Transaction\n  |\n  v\nProgram A (your program)\n  |\n  v (CPI)\nProgram B (Token Program, System Program, etc.)\n```\n\nThe Solana runtime tracks the **call stack** and ensures:\n- Account ownership rules are enforced\n- Signers are propagated correctly\n- Programs can't exceed the call depth limit (4 levels)\n\n## invoke vs invoke_signed\n\n### invoke - Regular CPI\n\n```rust\nuse solana_program::program::invoke;\n\ninvoke(\n    &instruction,\n    &[\n        source_account.clone(),\n        destination_account.clone(),\n        authority.clone(),\n    ],\n)?;\n```\n\nUse `invoke` when the required signers are already in your instruction's signer list.\n\n### invoke_signed - CPI with PDA Signer\n\n```rust\nuse solana_program::program::invoke_signed;\n\ninvoke_signed(\n    &instruction,\n    &[\n        pda_account.clone(),\n        destination_account.clone(),\n        system_program.clone(),\n    ],\n    &[&[b\"vault\", &[bump]]], // PDA seeds\n)?;\n```\n\nUse `invoke_signed` when a **PDA** needs to sign. The program derives the PDA and \"signs\" on its behalf.\n\n## CPI in Anchor\n\nAnchor provides a cleaner API for CPIs:\n\n```rust\nuse anchor_lang::prelude::*;\nuse anchor_spl::token::{self, Transfer};\n\npub fn transfer_tokens(ctx: Context<TransferTokens>, amount: u64) -> Result<()> {\n    let cpi_accounts = Transfer {\n        from: ctx.accounts.from.to_account_info(),\n        to: ctx.accounts.to.to_account_info(),\n        authority: ctx.accounts.authority.to_account_info(),\n    };\n\n    let cpi_program = ctx.accounts.token_program.to_account_info();\n    let cpi_ctx = CpiContext::new(cpi_program, cpi_accounts);\n\n    token::transfer(cpi_ctx, amount)?;\n    Ok(())\n}\n```\n\n### CPI with PDA Signer in Anchor\n\n```rust\npub fn transfer_from_pda(ctx: Context<TransferFromPDA>, amount: u64) -> Result<()> {\n    let seeds = &[\n        b\"vault\",\n        ctx.accounts.authority.key().as_ref(),\n        &[ctx.accounts.vault.bump],\n    ];\n    let signer_seeds = &[&seeds[..]];\n\n    let cpi_accounts = Transfer {\n        from: ctx.accounts.vault_token_account.to_account_info(),\n        to: ctx.accounts.user_token_account.to_account_info(),\n        authority: ctx.accounts.vault.to_account_info(),\n    };\n\n    let cpi_program = ctx.accounts.token_program.to_account_info();\n    let cpi_ctx = CpiContext::new_with_signer(\n        cpi_program,\n        cpi_accounts,\n        signer_seeds,\n    );\n\n    token::transfer(cpi_ctx, amount)?;\n    Ok(())\n}\n```\n\n## Common CPI Patterns\n\n### 1. Token Transfer\n\n```rust\n// Transfer SPL tokens from user to program vault\ntoken::transfer(\n    CpiContext::new(token_program, transfer_accounts),\n    amount,\n)?;\n```\n\n### 2. Minting Tokens\n\n```rust\n// Mint new tokens (requires mint authority)\ntoken::mint_to(\n    CpiContext::new_with_signer(token_program, mint_accounts, signer_seeds),\n    amount,\n)?;\n```\n\n### 3. Creating Accounts\n\n```rust\n// Create a new account (CPI to System Program)\nsystem_program::create_account(\n    CpiContext::new(system_program, create_accounts),\n    lamports,\n    space,\n    program_id,\n)?;\n```\n\n## CPI Security Considerations\n\n### 1. Account Validation\n\nAlways validate accounts before CPI:\n\n```rust\nrequire_keys_eq!(\n    ctx.accounts.token_program.key(),\n    token::ID,\n    ErrorCode::InvalidTokenProgram\n);\n```\n\n### 2. Signer Propagation\n\nSigners in your instruction are automatically propagated to CPIs. But be careful:\n\n```rust\n// BAD: Anyone can call this and spend vault tokens!\npub fn dangerous_withdraw(ctx: Context<Withdraw>, amount: u64) -> Result<()> {\n    token::transfer(\n        CpiContext::new_with_signer(...),\n        amount,\n    )\n}\n\n// GOOD: Check authority first\npub fn safe_withdraw(ctx: Context<Withdraw>, amount: u64) -> Result<()> {\n    require_keys_eq!(\n        ctx.accounts.authority.key(),\n        ctx.accounts.vault.authority,\n        ErrorCode::Unauthorized\n    );\n    token::transfer(...)\n}\n```\n\n### 3. Reentrancy\n\nSolana programs are **not reentrant** by default (a program can't call itself). This prevents classic reentrancy attacks.\n\n## Real-World CPI Examples\n\n**Escrow program**:\n1. User deposits tokens → CPI to Token Program to transfer tokens to escrow PDA\n2. Trade executes → CPI to Token Program to transfer from escrow PDA to recipient\n\n**Staking program**:\n1. User stakes tokens → CPI to Token Program to transfer to staking vault\n2. User claims rewards → CPI to Token Program to mint reward tokens\n3. User unstakes → CPI to Token Program to transfer staked tokens back\n\n**NFT marketplace**:\n1. User lists NFT → CPI to Token Program to transfer NFT to marketplace PDA\n2. Buyer purchases → CPI to System Program (SOL payment) + CPI to Token Program (NFT transfer)\n\n## Next Challenge\n\nYou'll construct a CPI instruction to transfer SOL from a PDA-owned account.\n",
-              "starter": null,
-              "tests": null,
-              "url": null
-            }
-          ],
-          "slug": "cpi-overview",
-          "title": "Cross-Program Invocations"
-        },
-        {
-          "_id": "lesson-cpi-challenge",
-          "blocks": [
-            {
-              "_type": "prose",
-              "amount": null,
-              "buildType": null,
-              "consumes": null,
-              "deployable": null,
-              "hints": null,
-              "idl": null,
-              "key": "intro",
-              "language": null,
-              "maxWords": null,
-              "network": null,
-              "produces": null,
-              "prompt": null,
-              "questions": null,
-              "solution": null,
-              "src": "# Challenge: Simulate a CPI Vault Transfer in Rust\n\nCross-Program Invocations (CPIs) let programs transfer SOL from PDA-controlled vaults. You'll simulate this pattern: derive a vault PDA, verify it has funds, and compute the transfer.\n\n## Your Task\n\nImplement `build_vault_transfer(user, vault_balance, recipient_balance, amount)` that:\n\n1. Derives the vault PDA using `find_pda(&[\"vault\", user], \"system\")` to get the bump\n2. Checks the vault has enough balance for the transfer\n3. Returns `Ok((new_vault_balance, new_recipient_balance, bump))` on success\n4. Returns `Err(\"INSUFFICIENT_VAULT_BALANCE\")` if vault can't cover the amount\n\n**This mirrors the real Anchor pattern:**\n```rust\ninvoke_signed(\n    &transfer_instruction,\n    &[vault_pda, recipient, system_program],\n    &[&[b\"vault\", user.key().as_ref(), &[bump]]],\n)?;\n```\n\nThe bump is needed for `invoke_signed` — the program proves it controls the PDA.\n",
-              "starter": null,
-              "tests": null,
-              "url": null
-            },
-            {
-              "_type": "code",
-              "amount": null,
-              "buildType": "standard",
-              "consumes": null,
-              "deployable": false,
-              "hints": [
-                "First derive the PDA: let (_, bump) = find_pda(&[\"vault\", user], \"system\");",
-                "Then check: if vault_balance < amount { return Err(\"INSUFFICIENT_VAULT_BALANCE\".to_string()); }",
-                "Return Ok((vault_balance - amount, recipient_balance + amount, bump))."
-              ],
-              "idl": null,
-              "key": "exercise",
-              "language": "rust",
-              "maxWords": null,
-              "network": null,
-              "produces": null,
-              "prompt": null,
-              "questions": null,
-              "solution": "use std::collections::hash_map::DefaultHasher;\nuse std::hash::{Hash, Hasher};\n\nfn hash_with_bump(seeds: &[&str], bump: u8, program_id: &str) -> u64 {\n    let mut hasher = DefaultHasher::new();\n    for seed in seeds { seed.hash(&mut hasher); }\n    bump.hash(&mut hasher);\n    program_id.hash(&mut hasher);\n    hasher.finish()\n}\n\nfn find_pda(seeds: &[&str], program_id: &str) -> (u64, u8) {\n    for bump in (0..=255u8).rev() {\n        let hash = hash_with_bump(seeds, bump, program_id);\n        if hash % 2 == 0 { return (hash, bump); }\n    }\n    panic!(\"No valid bump found\");\n}\n\nfn build_vault_transfer(\n    user: &str,\n    vault_balance: u64,\n    recipient_balance: u64,\n    amount: u64,\n) -> Result<(u64, u64, u8), String> {\n    let (_, bump) = find_pda(&[\"vault\", user], \"system\");\n    if vault_balance < amount {\n        return Err(\"INSUFFICIENT_VAULT_BALANCE\".to_string());\n    }\n    Ok((vault_balance - amount, recipient_balance + amount, bump))\n}\n",
-              "src": null,
-              "starter": "use std::collections::hash_map::DefaultHasher;\nuse std::hash::{Hash, Hasher};\n\nfn hash_with_bump(seeds: &[&str], bump: u8, program_id: &str) -> u64 {\n    let mut hasher = DefaultHasher::new();\n    for seed in seeds { seed.hash(&mut hasher); }\n    bump.hash(&mut hasher);\n    program_id.hash(&mut hasher);\n    hasher.finish()\n}\n\nfn find_pda(seeds: &[&str], program_id: &str) -> (u64, u8) {\n    for bump in (0..=255u8).rev() {\n        let hash = hash_with_bump(seeds, bump, program_id);\n        if hash % 2 == 0 { return (hash, bump); }\n    }\n    panic!(\"No valid bump found\");\n}\n\n/// Simulate a CPI transfer from a PDA vault to a recipient.\n/// Returns Ok((new_vault_balance, new_recipient_balance, bump)).\nfn build_vault_transfer(\n    user: &str,\n    vault_balance: u64,\n    recipient_balance: u64,\n    amount: u64,\n) -> Result<(u64, u64, u8), String> {\n    // TODO: Derive the vault PDA to get the bump\n    // TODO: Check vault_balance >= amount\n    // TODO: Return updated balances and the bump\n    todo!()\n}\n",
-              "tests": [
-                {
-                  "description": "Sufficient balance succeeds",
-                  "expectedOutput": "__result__.is_ok()",
-                  "id": "t1",
-                  "input": "\"alice\", 1000, 500, 200"
-                },
-                {
-                  "description": "Insufficient balance fails",
-                  "expectedOutput": "__result__.is_err()",
-                  "id": "t2",
-                  "input": "\"alice\", 100, 500, 200"
-                },
-                {
-                  "description": "Balances update correctly",
-                  "expectedOutput": "{ let r = __result__.unwrap(); r.0 == 800 && r.1 == 700 }",
-                  "id": "t3",
-                  "input": "\"alice\", 1000, 500, 200"
-                },
-                {
-                  "description": "Balances update correctly for a different transfer",
-                  "expectedOutput": "{ let r = __result__.unwrap(); r.0 == 3500 && r.1 == 2500 }",
-                  "id": "t4",
-                  "input": "\"bob\", 5000, 1000, 1500"
-                }
-              ],
-              "url": null
-            }
-          ],
-          "slug": "cpi-challenge",
-          "title": "Challenge: Simulate a CPI Vault Transfer"
-        }
-      ],
-      "title": "PDAs & CPIs"
-    },
-    {
-      "description": "Learn to test, debug, and deploy production-ready Anchor programs.",
-      "key": "anchor-testing",
-      "lessons": [
-        {
-          "_id": "lesson-anchor-testing",
-          "blocks": [
-            {
-              "_type": "prose",
-              "amount": null,
-              "buildType": null,
-              "consumes": null,
-              "deployable": null,
-              "hints": null,
-              "idl": null,
-              "key": "intro",
-              "language": null,
-              "maxWords": null,
-              "network": null,
-              "produces": null,
-              "prompt": null,
-              "questions": null,
-              "solution": null,
-              "src": "# Testing Anchor Programs\n\nTesting is critical for Solana programs. Bugs in smart contracts can lead to loss of funds, so comprehensive testing is non-negotiable.\n\n## Anchor Test Setup\n\nAnchor projects come with a `tests/` folder and pre-configured testing:\n\n```bash\nanchor test\n```\n\nThis command:\n1. Builds your program\n2. Deploys to a local validator\n3. Runs your TypeScript tests\n4. Shuts down the validator\n\n## Basic Test Structure\n\n```typescript\nimport * as anchor from '@coral-xyz/anchor';\nimport { Program } from '@coral-xyz/anchor';\nimport { MyProgram } from '../target/types/my_program';\nimport { expect } from 'chai';\n\ndescribe('my-program', () => {\n  const provider = anchor.AnchorProvider.env();\n  anchor.setProvider(provider);\n\n  const program = anchor.workspace.MyProgram as Program<MyProgram>;\n\n  it('Initializes the program', async () => {\n    const myAccount = anchor.web3.Keypair.generate();\n\n    await program.methods\n      .initialize()\n      .accounts({\n        myAccount: myAccount.publicKey,\n        user: provider.wallet.publicKey,\n        systemProgram: anchor.web3.SystemProgram.programId,\n      })\n      .signers([myAccount])\n      .rpc();\n\n    const account = await program.account.myAccount.fetch(\n      myAccount.publicKey\n    );\n\n    expect(account.data.toNumber()).to.equal(0);\n  });\n});\n```\n\n## Bankrun: Fast Local Testing\n\nBankrun is a lightweight Solana test validator that runs in-process:\n\n```typescript\nimport { BankrunProvider } from 'anchor-bankrun';\nimport { startAnchor } from 'solana-bankrun';\n\ndescribe('fast tests', () => {\n  let context;\n  let provider;\n  let program;\n\n  before(async () => {\n    context = await startAnchor(\n      '',\n      [{ name: 'my_program', programId: PROGRAM_ID }],\n      []\n    );\n\n    provider = new BankrunProvider(context);\n    program = new Program<MyProgram>(IDL, provider);\n  });\n\n  it('runs 10x faster', async () => {\n    // Your test\n  });\n});\n```\n\nBankrun is **much faster** than spinning up a full validator for each test.\n\n## Testing Patterns\n\n### 1. Test Fixtures\n\n```typescript\nconst createUser = async () => {\n  const user = anchor.web3.Keypair.generate();\n\n  // Airdrop SOL\n  await provider.connection.requestAirdrop(\n    user.publicKey,\n    2 * anchor.web3.LAMPORTS_PER_SOL\n  );\n\n  return user;\n};\n\nconst createTokenAccount = async (owner, mint) => {\n  // Create token account for testing\n};\n```\n\n### 2. Account Assertions\n\n```typescript\nconst account = await program.account.userAccount.fetch(userPDA);\n\nexpect(account.authority.toBase58()).to.equal(\n  user.publicKey.toBase58()\n);\nexpect(account.balance.toNumber()).to.equal(1000);\nexpect(account.isActive).to.be.true;\n```\n\n### 3. Error Testing\n\n```typescript\ntry {\n  await program.methods\n    .withdraw(new anchor.BN(10000))\n    .accounts({ user: userPDA })\n    .rpc();\n\n  // Should not reach here\n  expect.fail('Expected error was not thrown');\n} catch (err) {\n  expect(err.error.errorCode.code).to.equal('InsufficientFunds');\n}\n```\n\n### 4. Event Testing\n\nAnchor can emit events:\n\n```rust\n#[event]\npub struct TransferEvent {\n    pub from: Pubkey,\n    pub to: Pubkey,\n    pub amount: u64,\n}\n\nemit!(TransferEvent {\n    from: ctx.accounts.from.key(),\n    to: ctx.accounts.to.key(),\n    amount,\n});\n```\n\nTest events:\n\n```typescript\nconst listener = program.addEventListener('TransferEvent', (event) => {\n  console.log('Transfer:', event);\n  expect(event.amount.toNumber()).to.equal(100);\n});\n\nawait program.methods.transfer(new anchor.BN(100)).rpc();\n\nprogram.removeEventListener(listener);\n```\n\n## Test Organization\n\n```\ntests/\n├── setup.ts              # Shared setup logic\n├── fixtures.ts           # Test data generators\n├── initialize.test.ts    # Initialization tests\n├── transfer.test.ts      # Transfer logic tests\n└── errors.test.ts        # Error condition tests\n```\n\n## Mocking Accounts\n\nFor unit-testing complex logic:\n\n```typescript\nconst mockAccount = {\n  authority: user.publicKey,\n  balance: new anchor.BN(1000),\n  lastUpdate: new anchor.BN(Date.now() / 1000),\n};\n\n// Serialize and write to test validator\nconst accountData = program.coder.accounts.encode(\n  'UserAccount',\n  mockAccount\n);\n```\n\n## Best Practices\n\n1. **Test happy path first**, then edge cases\n2. **Test all error conditions** (unauthorized access, insufficient funds, etc.)\n3. **Use descriptive test names**: `it('rejects withdrawal when balance is insufficient')`\n4. **Clean up state** between tests (or use Bankrun snapshots)\n5. **Test with realistic data** (not just 0s and 1s)\n6. **Measure code coverage** (use `solana-program-test` for Rust unit tests)\n\n## Continuous Integration\n\n```yaml\n# .github/workflows/test.yml\nname: Test\n\non: [push, pull_request]\n\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/checkout@v3\n      - uses: actions/setup-node@v3\n      - name: Install Solana\n        run: sh -c \"$(curl -sSfL https://release.anza.xyz/stable/install)\"\n      - name: Install Anchor\n        run: cargo install --git https://github.com/coral-xyz/anchor avm --force\n      - name: Run tests\n        run: anchor test\n```\n\n## Next Lesson\n\nYou'll learn how to define custom errors in Anchor programs.\n",
-              "starter": null,
-              "tests": null,
-              "url": null
-            }
-          ],
-          "slug": "anchor-testing",
-          "title": "Testing Anchor Programs"
-        },
-        {
-          "_id": "lesson-anchor-errors",
-          "blocks": [
-            {
-              "_type": "prose",
-              "amount": null,
-              "buildType": null,
-              "consumes": null,
-              "deployable": null,
-              "hints": null,
-              "idl": null,
-              "key": "intro",
-              "language": null,
-              "maxWords": null,
-              "network": null,
-              "produces": null,
-              "prompt": null,
-              "questions": null,
-              "solution": null,
-              "src": "# Custom Errors in Anchor\n\nProperly handling errors is essential for debugging and security. Anchor provides a clean way to define and use custom errors.\n\n## Defining Custom Errors\n\n```rust\nuse anchor_lang::prelude::*;\n\n#[error_code]\npub enum ErrorCode {\n    #[msg(\"Insufficient funds for this operation\")]\n    InsufficientFunds,\n\n    #[msg(\"User is not authorized to perform this action\")]\n    Unauthorized,\n\n    #[msg(\"The provided amount exceeds the maximum allowed\")]\n    AmountTooLarge,\n\n    #[msg(\"Account has already been initialized\")]\n    AlreadyInitialized,\n}\n```\n\nEach error gets:\n- A unique error code (auto-assigned)\n- A human-readable message\n- Integration with Anchor's error handling\n\n## Using the require! Macro\n\nThe `require!` macro is the cleanest way to enforce conditions:\n\n```rust\npub fn transfer(ctx: Context<Transfer>, amount: u64) -> Result<()> {\n    let user_account = &mut ctx.accounts.user;\n\n    // Check balance\n    require!(\n        user_account.balance >= amount,\n        ErrorCode::InsufficientFunds\n    );\n\n    // Check authorization\n    require_keys_eq!(\n        ctx.accounts.authority.key(),\n        user_account.authority,\n        ErrorCode::Unauthorized\n    );\n\n    // Check amount limit\n    require!(\n        amount <= 1_000_000,\n        ErrorCode::AmountTooLarge\n    );\n\n    user_account.balance -= amount;\n    Ok(())\n}\n```\n\n## Anchor's Built-in require! Variants\n\n### require_keys_eq!\n\n```rust\nrequire_keys_eq!(\n    ctx.accounts.user.authority,\n    ctx.accounts.signer.key(),\n    ErrorCode::Unauthorized\n);\n```\n\nCompares two public keys.\n\n### require_keys_neq!\n\n```rust\nrequire_keys_neq!(\n    ctx.accounts.from.key(),\n    ctx.accounts.to.key(),\n    ErrorCode::CannotTransferToSelf\n);\n```\n\nEnsures two keys are different.\n\n### require_gt! / require_gte!\n\n```rust\nrequire_gte!(\n    user.balance,\n    MIN_BALANCE,\n    ErrorCode::BalanceTooLow\n);\n```\n\nNumeric comparisons (gt = greater than, gte = greater than or equal).\n\n## Constraint Errors\n\nConstraints in `#[account(...)]` automatically return errors:\n\n```rust\n#[derive(Accounts)]\npub struct UpdateUser<'info> {\n    #[account(\n        mut,\n        has_one = authority @ ErrorCode::Unauthorized,\n        constraint = user.is_active @ ErrorCode::AccountInactive\n    )]\n    pub user: Account<'info, UserAccount>,\n    pub authority: Signer<'info>,\n}\n```\n\nIf `has_one` or `constraint` fails, Anchor returns your custom error.\n\n## Error Handling in TypeScript Tests\n\nAnchor errors are automatically parsed in TypeScript:\n\n```typescript\ntry {\n  await program.methods\n    .transfer(new anchor.BN(10000))\n    .accounts({ user: userPDA })\n    .rpc();\n\n  throw new Error('Should have failed');\n} catch (err) {\n  // Anchor error structure\n  expect(err.error.errorCode.code).to.equal('InsufficientFunds');\n  expect(err.error.errorCode.number).to.equal(6000); // First custom error\n  expect(err.error.errorMessage).to.include('Insufficient funds');\n}\n```\n\n## Error Codes\n\nAnchor assigns error codes starting at **6000**:\n\n```rust\n#[error_code]\npub enum ErrorCode {\n    InsufficientFunds,    // 6000\n    Unauthorized,         // 6001\n    AmountTooLarge,       // 6002\n}\n```\n\nYou can also manually assign codes:\n\n```rust\n#[error_code]\npub enum ErrorCode {\n    #[msg(\"Insufficient funds\")]\n    InsufficientFunds = 7000,\n}\n```\n\n## Anchor's Built-in Errors\n\nAnchor provides common errors automatically:\n\n- `ErrorCode::ConstraintMut` - Account not marked as mutable\n- `ErrorCode::ConstraintHasOne` - has_one constraint failed\n- `ErrorCode::ConstraintSigner` - Account not a signer\n- `ErrorCode::ConstraintRaw` - Generic constraint failed\n- `ErrorCode::AccountNotInitialized` - Account data is empty\n- `ErrorCode::AccountOwnedByWrongProgram` - Account owned by wrong program\n\n## Best Practices\n\n### 1. Be Specific\n\n```rust\n// BAD: Vague error\n#[msg(\"Invalid input\")]\nInvalidInput,\n\n// GOOD: Specific error\n#[msg(\"Amount must be between 1 and 1,000,000 lamports\")]\nAmountOutOfRange,\n```\n\n### 2. Use Constraints Where Possible\n\nInstead of:\n\n```rust\npub fn update(ctx: Context<Update>) -> Result<()> {\n    require!(\n        ctx.accounts.user.authority == ctx.accounts.signer.key(),\n        ErrorCode::Unauthorized\n    );\n    // ...\n}\n```\n\nUse:\n\n```rust\n#[derive(Accounts)]\npub struct Update<'info> {\n    #[account(\n        mut,\n        has_one = authority @ ErrorCode::Unauthorized\n    )]\n    pub user: Account<'info, UserAccount>,\n    pub authority: Signer<'info>,\n}\n```\n\n### 3. Log Context for Debugging\n\n```rust\nrequire!(\n    amount > 0,\n    ErrorCode::AmountMustBePositive\n);\n\nmsg!(\"Transferring {} lamports\", amount);\n```\n\nUse `msg!()` to log values for debugging.\n\n## Matching Errors in Integration Tests\n\n```typescript\nconst expectError = async (fn, errorCode) => {\n  try {\n    await fn();\n    throw new Error(`Expected ${errorCode} error`);\n  } catch (err) {\n    expect(err.error.errorCode.code).to.equal(errorCode);\n  }\n};\n\nawait expectError(\n  () => program.methods.transfer(tooMuch).rpc(),\n  'InsufficientFunds'\n);\n```\n\n## Next Lesson\n\nYou'll learn how to deploy Anchor programs to devnet and mainnet.\n",
-              "starter": null,
-              "tests": null,
-              "url": null
-            }
-          ],
-          "slug": "anchor-errors",
-          "title": "Custom Errors in Anchor"
-        },
-        {
-          "_id": "lesson-deployment",
-          "blocks": [
-            {
-              "_type": "prose",
-              "amount": null,
-              "buildType": null,
-              "consumes": null,
-              "deployable": null,
-              "hints": null,
-              "idl": null,
-              "key": "intro",
-              "language": null,
-              "maxWords": null,
-              "network": null,
-              "produces": null,
-              "prompt": null,
-              "questions": null,
-              "solution": null,
-              "src": "# Deploying Solana Programs\n\nDeploying to Solana is straightforward with Anchor, but there are important considerations for security and upgrades.\n\n## Building Your Program\n\n```bash\nanchor build\n```\n\nThis compiles your program and generates:\n- `target/deploy/my_program.so` - The compiled program\n- `target/idl/my_program.json` - The Interface Definition Language file\n- `target/types/my_program.ts` - TypeScript types for your program\n\n## Deploying to Devnet\n\n1. **Configure your CLI for devnet**:\n\n```bash\nsolana config set --url devnet\n```\n\n2. **Ensure you have SOL**:\n\n```bash\nsolana balance\nsolana airdrop 2  # If needed\n```\n\n3. **Deploy**:\n\n```bash\nanchor deploy\n```\n\nAnchor will:\n- Upload the program binary\n- Create the program account\n- Set you as the upgrade authority\n\n## Understanding Program IDs\n\nYour program ID is declared in `lib.rs`:\n\n```rust\ndeclare_id!(\"YourProgramIDHere\");\n```\n\nThis ID is generated when you run `anchor init` and stored in `target/deploy/my_program-keypair.json`.\n\n**Important**: Once deployed, the program ID is permanent for that deployment. If you want a new ID, you need to create a new keypair.\n\n## The IDL (Interface Definition Language)\n\nThe IDL is a JSON file describing your program's interface:\n\n```json\n{\n  \"version\": \"0.1.0\",\n  \"name\": \"my_program\",\n  \"instructions\": [\n    {\n      \"name\": \"initialize\",\n      \"accounts\": [\n        { \"name\": \"myAccount\", \"isMut\": true, \"isSigner\": true },\n        { \"name\": \"user\", \"isMut\": true, \"isSigner\": true },\n        { \"name\": \"systemProgram\", \"isMut\": false, \"isSigner\": false }\n      ],\n      \"args\": []\n    }\n  ],\n  \"accounts\": [\n    {\n      \"name\": \"MyAccount\",\n      \"type\": {\n        \"kind\": \"struct\",\n        \"fields\": [\n          { \"name\": \"data\", \"type\": \"u64\" }\n        ]\n      }\n    }\n  ]\n}\n```\n\nClients use the IDL to interact with your program.\n\n## Uploading the IDL\n\n```bash\nanchor idl init -f target/idl/my_program.json <PROGRAM_ID>\n```\n\nThis stores the IDL on-chain, making it easier for tools like Anchor Explorer to understand your program.\n\nUpdate an existing IDL:\n\n```bash\nanchor idl upgrade -f target/idl/my_program.json <PROGRAM_ID>\n```\n\n## Program Upgrades\n\nSolana programs are **upgradeable** by default. The upgrade authority can replace the program code:\n\n```bash\nanchor upgrade target/deploy/my_program.so --program-id <PROGRAM_ID>\n```\n\n### Checking Upgrade Authority\n\n```bash\nsolana program show <PROGRAM_ID>\n```\n\nOutput:\n```\nProgram Id: YourProgramID\nOwner: BPFLoaderUpgradeab1e11111111111111111111111\nProgramData Address: ...\nAuthority: YourWalletPublicKey\nLast Deployed In Slot: 123456789\nData Length: 200000 bytes\n```\n\n### Transferring Upgrade Authority\n\n```bash\nsolana program set-upgrade-authority <PROGRAM_ID> --new-upgrade-authority <NEW_AUTHORITY>\n```\n\n### Revoking Upgrade Authority (Immutable Program)\n\nFor maximum security, you can make a program **immutable**:\n\n```bash\nsolana program set-upgrade-authority <PROGRAM_ID> --final\n```\n\n**Warning**: This is irreversible! No one can ever upgrade the program again.\n\n## Multisig Upgrade Authority\n\nFor production programs, use a multisig as the upgrade authority:\n\n```bash\n# Create a multisig with Squads Protocol\n# Set multisig as upgrade authority\nsolana program set-upgrade-authority <PROGRAM_ID> --new-upgrade-authority <MULTISIG_ADDRESS>\n```\n\nThis requires multiple team members to approve upgrades.\n\n## Verifiable Builds\n\nVerifiable builds let anyone verify your deployed program matches your source code:\n\n```bash\nanchor build --verifiable\n```\n\nThis builds your program in a Docker container with a deterministic environment.\n\nVerify a deployed program:\n\n```bash\nanchor verify <PROGRAM_ID>\n```\n\n## Deploying to Mainnet\n\n1. **Switch to mainnet**:\n\n```bash\nsolana config set --url mainnet-beta\n```\n\n2. **Fund your wallet** (deploying costs ~2-5 SOL depending on program size)\n\n3. **Audit your code** (get a professional audit for production programs)\n\n4. **Deploy**:\n\n```bash\nanchor deploy\n```\n\n5. **Upload IDL**:\n\n```bash\nanchor idl init -f target/idl/my_program.json <PROGRAM_ID>\n```\n\n6. **Set up multisig authority** or **revoke authority** if appropriate\n\n## Best Practices\n\n1. **Test on devnet first** - Always deploy and test on devnet before mainnet\n2. **Use verifiable builds** - Builds trust with users\n3. **Store keypairs securely** - Never commit `target/deploy/*-keypair.json` to Git\n4. **Plan your upgrade strategy** - Multisig for most cases, immutable for critical infrastructure\n5. **Monitor program accounts** - Track rent, data size, and usage\n6. **Document your IDL** - Add comments to your Rust code; they appear in the IDL\n\n## Common Deployment Issues\n\n### Insufficient SOL\n\n```\nError: Account <PROGRAM_ID> has insufficient funds\n```\n\nSolution: Airdrop more SOL (devnet) or fund your wallet (mainnet)\n\n### Program Already Deployed\n\n```\nError: Program already exists\n```\n\nSolution: Use `anchor upgrade` instead of `anchor deploy`\n\n### Wrong Upgrade Authority\n\n```\nError: Upgrade authority mismatch\n```\n\nSolution: Ensure the wallet you're using matches the upgrade authority\n\n## Next Challenge\n\nYou'll write a test that simulates a program execution scenario.\n",
-              "starter": null,
-              "tests": null,
-              "url": null
-            }
-          ],
-          "slug": "deployment",
-          "title": "Deploying Solana Programs"
-        },
-        {
-          "_id": "lesson-testing-challenge",
-          "blocks": [
-            {
-              "_type": "prose",
-              "amount": null,
-              "buildType": null,
-              "consumes": null,
-              "deployable": null,
-              "hints": null,
-              "idl": null,
-              "key": "intro",
-              "language": null,
-              "maxWords": null,
-              "network": null,
-              "produces": null,
-              "prompt": null,
-              "questions": null,
-              "solution": null,
-              "src": "# Challenge: Simulate a Transfer Test in Rust\n\nTest-driven development is critical for Solana programs. You'll write a function that simulates a complete transfer test scenario — the same logic you'd verify with `anchor test`.\n\n## Your Task\n\nImplement `simulate_transfer_test(sender_initial, transfer_amount, fee)` that:\n\n1. Checks if sender can afford `transfer_amount + fee`\n2. If yes, computes final balances and returns `\"PASS:sender=<final>,receiver=<final>\"`\n3. If no, returns `\"FAIL:insufficient_funds\"`\n\n**Test constants:**\n- Receiver starts with 0 balance\n- Fee is paid by sender and burned (not added to receiver)\n- The function simulates what an Anchor test's `assert` checks would verify\n\n**This mirrors the Anchor test pattern:**\n```typescript\nit('transfers SOL correctly', async () => {\n  const balanceBefore = await connection.getBalance(sender);\n  await program.methods.transfer(amount).rpc();\n  const balanceAfter = await connection.getBalance(sender);\n  expect(balanceAfter).to.equal(balanceBefore - amount - fee);\n});\n```\n",
-              "starter": null,
-              "tests": null,
-              "url": null
-            },
-            {
-              "_type": "code",
-              "amount": null,
-              "buildType": "standard",
-              "consumes": null,
-              "deployable": false,
-              "hints": [
-                "Check if sender_initial >= transfer_amount + fee (use checked_add or just add — small test values won't overflow).",
-                "sender_final = sender_initial - transfer_amount - fee. receiver_final = receiver_initial + transfer_amount.",
-                "Format with: format!(\"PASS:sender={},receiver={}\", sender_final, receiver_final)."
-              ],
-              "idl": null,
-              "key": "exercise",
-              "language": "rust",
-              "maxWords": null,
-              "network": null,
-              "produces": null,
-              "prompt": null,
-              "questions": null,
-              "solution": "fn simulate_transfer_test(\n    sender_initial: u64,\n    transfer_amount: u64,\n    fee: u64,\n) -> String {\n    let receiver_initial: u64 = 0;\n\n    if sender_initial < transfer_amount + fee {\n        return \"FAIL:insufficient_funds\".to_string();\n    }\n\n    let sender_final = sender_initial - transfer_amount - fee;\n    let receiver_final = receiver_initial + transfer_amount;\n\n    format!(\"PASS:sender={},receiver={}\", sender_final, receiver_final)\n}\n",
-              "src": null,
-              "starter": "fn simulate_transfer_test(\n    sender_initial: u64,\n    transfer_amount: u64,\n    fee: u64,\n) -> String {\n    let receiver_initial: u64 = 0;\n\n    // TODO: Check if sender can afford transfer_amount + fee\n\n    // TODO: If yes, compute final balances and return:\n    //   \"PASS:sender=<sender_final>,receiver=<receiver_final>\"\n\n    // TODO: If no, return \"FAIL:insufficient_funds\"\n    todo!()\n}\n",
-              "tests": [
-                {
-                  "description": "Exact balances after a successful transfer",
-                  "expectedOutput": "\"PASS:sender=1499995000,receiver=500000000\".to_string()",
-                  "id": "t1",
-                  "input": "2_000_000_000, 500_000_000, 5000"
-                },
-                {
-                  "description": "Insufficient funds fails",
-                  "expectedOutput": "\"FAIL:insufficient_funds\".to_string()",
-                  "id": "t2",
-                  "input": "100, 200, 5000"
-                },
-                {
-                  "description": "Exact balances for a different transfer",
-                  "expectedOutput": "\"PASS:sender=699000,receiver=300000\".to_string()",
-                  "id": "t3",
-                  "input": "1000000, 300000, 1000"
-                }
-              ],
-              "url": null
-            }
-          ],
-          "slug": "testing-challenge",
-          "title": "Challenge: Test a Transfer Program"
-        }
-      ],
-      "title": "Testing & Deployment"
-    }
-  ],
-  "slug": "anchor-framework",
+  "thumbnail": null,
+  "creator": "B7o8NfV81HzjuZFWQTTx3Xdvh77Dqoajwib3kWEnvzJF",
   "tags": [
     "account-model",
     "anchor",
@@ -617,9 +16,832 @@
     "program-testing",
     "solana-programs"
   ],
-  "thumbnail": null,
-  "title": "Anchor Framework Mastery",
+  "xpReward": 900,
   "trackId": 3,
   "trackLevel": 1,
-  "xpReward": 900
+  "modules": [
+    {
+      "key": "anchor-basics",
+      "title": "Anchor Basics",
+      "description": "Learn the fundamentals of the Anchor framework, program structure, and account constraints.",
+      "lessons": [
+        {
+          "_id": "lesson-anchor-intro",
+          "title": "What is the Anchor Framework?",
+          "slug": "anchor-intro",
+          "blocks": [
+            {
+              "key": "intro",
+              "_type": "prose",
+              "produces": null,
+              "consumes": null,
+              "src": "# What is the Anchor Framework?\n\nAnchor is the most popular framework for Solana smart contract development. It provides a Rust-based DSL (domain-specific language) that dramatically reduces boilerplate and makes programs safer, faster to write, and easier to read.\n\n## Who This Course Is For\n\nThis course is aimed at JavaScript and TypeScript developers moving into Solana — **no Solidity or prior smart-contract experience is assumed.** If you can write JS/TS, you have enough to start; the Rust and Anchor concepts you need are introduced from the ground up as they come up. You do not have to \"learn Ethereum first\" to build here.\n\n## Why Use Anchor?\n\nWriting native Solana programs in Rust requires:\n- Manual account deserialization and validation\n- Verbose error handling\n- Security checks spread across your code\n- Repetitive boilerplate for common patterns\n\nAnchor handles all of this for you through **macros** and **attributes**.\n\n### Native Solana Program\n\n```rust\n// Manual account deserialization\nlet account_info_iter = &mut accounts.iter();\nlet user_account = next_account_info(account_info_iter)?;\n\n// Manual validation\nif !user_account.is_writable {\n    return Err(ProgramError::InvalidAccountData);\n}\n\n// Manual owner check\nif user_account.owner != program_id {\n    return Err(ProgramError::IncorrectProgramId);\n}\n```\n\n### Anchor Program\n\n```rust\n#[derive(Accounts)]\npub struct UpdateUser<'info> {\n    #[account(mut)]\n    pub user: Account<'info, UserAccount>,\n}\n```\n\nAnchor automatically validates that the account is writable and owned by the program!\n\n## Anchor Project Structure\n\nA typical Anchor project:\n\n```\nmy-anchor-project/\n├── programs/\n│   └── my-program/\n│       └── src/\n│           └── lib.rs      # Your program code\n├── tests/\n│   └── my-program.ts       # TypeScript tests\n├── migrations/\n│   └── deploy.ts           # Deployment scripts\n└── Anchor.toml             # Configuration\n```\n\n## Key Anchor Components\n\n### 1. Program Module\n\n```rust\nuse anchor_lang::prelude::*;\n\ndeclare_id!(\"YourProgramIDHere\");\n\n#[program]\npub mod my_program {\n    use super::*;\n\n    pub fn initialize(ctx: Context<Initialize>) -> Result<()> {\n        // Your logic here\n        Ok(())\n    }\n}\n```\n\nThe `#[program]` macro defines your program's instruction handlers.\n\n### 2. Accounts Struct\n\n```rust\n#[derive(Accounts)]\npub struct Initialize<'info> {\n    #[account(\n        init,\n        payer = user,\n        space = 8 + 32 + 8\n    )]\n    pub my_account: Account<'info, MyAccount>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n    pub system_program: Program<'info, System>,\n}\n```\n\nAccounts structs define what accounts your instruction needs and how to validate them.\n\n### 3. Account Data\n\n```rust\n#[account]\npub struct MyAccount {\n    pub authority: Pubkey,\n    pub counter: u64,\n}\n```\n\nThe `#[account]` macro adds serialization/deserialization and a discriminator for account type safety.\n\n## Anchor vs Native: Security Benefits\n\n| Security Check | Native | Anchor |\n|----------------|--------|--------|\n| Account ownership | Manual check | Automatic via Account<'info, T> |\n| Signer verification | Manual check | Automatic via Signer<'info> |\n| Writable validation | Manual check | Automatic via #[account(mut)] |\n| Account initialization | Manual allocation | Automatic via #[account(init)] |\n| Discriminator (type safety) | None | Automatic 8-byte discriminator |\n\nAnchor programs are **harder to exploit** because common security pitfalls are prevented by the framework itself.\n\n## Next Steps\n\nIn the next challenge, you'll build a mock Anchor program structure to understand how programs are organized on Solana.\n",
+              "url": null,
+              "language": null,
+              "buildType": null,
+              "deployable": null,
+              "starter": null,
+              "solution": null,
+              "tests": null,
+              "hints": null,
+              "questions": null,
+              "prompt": null,
+              "maxWords": null,
+              "amount": null,
+              "network": null,
+              "idl": null
+            }
+          ]
+        },
+        {
+          "_id": "lesson-anchor-setup-challenge",
+          "title": "Challenge: Anchor Program Structure",
+          "slug": "anchor-setup-challenge",
+          "blocks": [
+            {
+              "key": "intro",
+              "_type": "prose",
+              "produces": null,
+              "consumes": null,
+              "src": "# Challenge: Model Anchor Program Structure in Rust\n\nAnchor programs follow a specific pattern: instructions contain account metadata and serialized data. You'll model this structure using Rust structs and enums.\n\n## Your Task\n\nImplement `build_instruction(program_id, user_key, instruction_name)` that constructs an Anchor-style instruction:\n\n1. Encode the instruction name as bytes and compute its length\n2. Build account metadata for two accounts:\n   - User account: signer=true, writable=true\n   - System program (`\"11111111111111111111111111111111\"`): signer=false, writable=false\n3. Return a formatted string: `\"program:<id>,accounts:<count>,data_len:<len>\"`\n\n**This mirrors Anchor's `#[derive(Accounts)]` pattern** where each instruction declares which accounts it needs and how they should be validated.\n\n**Rust Concepts Used:**\n- Structs with boolean fields\n- `Vec` collection\n- String formatting with `format!()`\n- Byte conversion with `.as_bytes()`\n",
+              "url": null,
+              "language": null,
+              "buildType": null,
+              "deployable": null,
+              "starter": null,
+              "solution": null,
+              "tests": null,
+              "hints": null,
+              "questions": null,
+              "prompt": null,
+              "maxWords": null,
+              "amount": null,
+              "network": null,
+              "idl": null
+            },
+            {
+              "key": "exercise",
+              "_type": "code",
+              "produces": null,
+              "consumes": null,
+              "src": null,
+              "url": null,
+              "language": "rust",
+              "buildType": "standard",
+              "deployable": false,
+              "starter": "#[derive(Debug)]\nstruct AccountMeta {\n    pubkey: String,\n    is_signer: bool,\n    is_writable: bool,\n}\n\nfn build_instruction(program_id: &str, user_key: &str, instruction_name: &str) -> String {\n    // TODO: Encode instruction_name as bytes and get its length\n\n    // TODO: Build account metas Vec with 2 entries:\n    //   - user_key: signer=true, writable=true\n    //   - system program: signer=false, writable=false\n\n    // TODO: Return \"program:<id>,accounts:<count>,data_len:<len>\"\n    todo!()\n}\n",
+              "solution": "#[derive(Debug)]\nstruct AccountMeta {\n    pubkey: String,\n    is_signer: bool,\n    is_writable: bool,\n}\n\nfn build_instruction(program_id: &str, user_key: &str, instruction_name: &str) -> String {\n    let data_len = instruction_name.as_bytes().len();\n\n    let accounts = vec![\n        AccountMeta {\n            pubkey: user_key.to_string(),\n            is_signer: true,\n            is_writable: true,\n        },\n        AccountMeta {\n            pubkey: \"11111111111111111111111111111111\".to_string(),\n            is_signer: false,\n            is_writable: false,\n        },\n    ];\n\n    format!(\"program:{},accounts:{},data_len:{}\", program_id, accounts.len(), data_len)\n}\n",
+              "tests": [
+                {
+                  "id": "t1",
+                  "description": "Includes the account count",
+                  "input": "\"progXYZ\", \"userABC\", \"initialize\"",
+                  "expectedOutput": "__result__.contains(\"accounts:2\")"
+                },
+                {
+                  "id": "t2",
+                  "description": "Includes the instruction data length",
+                  "input": "\"progXYZ\", \"userABC\", \"initialize\"",
+                  "expectedOutput": "__result__.contains(\"data_len:10\")"
+                },
+                {
+                  "id": "t3",
+                  "description": "Starts with the program id",
+                  "input": "\"progXYZ\", \"userABC\", \"initialize\"",
+                  "expectedOutput": "__result__.starts_with(\"program:progXYZ\")"
+                },
+                {
+                  "id": "t4",
+                  "description": "Exact output for a different instruction",
+                  "input": "\"myProg\", \"user1\", \"mint\"",
+                  "expectedOutput": "\"program:myProg,accounts:2,data_len:4\".to_string()"
+                }
+              ],
+              "hints": [
+                "Get instruction data length with instruction_name.as_bytes().len().",
+                "Create two AccountMeta structs in a Vec: one for the user (signer + writable) and one for the system program (neither).",
+                "Return format!(\"program:{},accounts:{},data_len:{}\", program_id, accounts.len(), data_len)."
+              ],
+              "questions": null,
+              "prompt": null,
+              "maxWords": null,
+              "amount": null,
+              "network": null,
+              "idl": null
+            }
+          ]
+        },
+        {
+          "_id": "lesson-anchor-accounts",
+          "title": "Anchor Account Constraints",
+          "slug": "anchor-accounts",
+          "blocks": [
+            {
+              "key": "intro",
+              "_type": "prose",
+              "produces": null,
+              "consumes": null,
+              "src": "# Anchor Account Constraints\n\nAnchor's constraint system is one of its most powerful features. Constraints allow you to declaratively specify account validation rules, and Anchor enforces them automatically.\n\n## The #[account] Attribute\n\nThe `#[account(...)]` attribute is used to apply constraints to accounts in your instruction context:\n\n```rust\n#[derive(Accounts)]\npub struct UpdateUserData<'info> {\n    #[account(\n        mut,\n        has_one = authority,\n        constraint = user.data_version < 10 @ ErrorCode::VersionTooHigh\n    )]\n    pub user: Account<'info, UserAccount>,\n    pub authority: Signer<'info>,\n}\n```\n\n## Common Constraints\n\n### 1. init - Initialize a New Account\n\n```rust\n#[account(\n    init,\n    payer = user,\n    space = 8 + 32 + 8\n)]\npub my_account: Account<'info, MyAccount>,\n```\n\n- Allocates space for the account\n- Transfers lamports from payer\n- Assigns account to the program\n- Sets account discriminator\n\n**Space calculation**: `8 (discriminator) + account_data_size`\n\n### 2. mut - Mark Account as Mutable\n\n```rust\n#[account(mut)]\npub user: Account<'info, UserAccount>,\n```\n\nRequires the account to be writable. Anchor will reject the transaction if the account isn't marked as writable.\n\n### 3. has_one - Verify Account Relationship\n\n```rust\n#[account]\npub struct UserAccount {\n    pub authority: Pubkey,\n    pub counter: u64,\n}\n\n#[derive(Accounts)]\npub struct Increment<'info> {\n    #[account(\n        mut,\n        has_one = authority\n    )]\n    pub user: Account<'info, UserAccount>,\n    pub authority: Signer<'info>,\n}\n```\n\n`has_one = authority` checks that `user.authority == authority.key()`. This prevents unauthorized updates.\n\n### 4. seeds & bump - PDA Derivation\n\n```rust\n#[account(\n    init,\n    payer = user,\n    space = 8 + 32 + 8,\n    seeds = [b\"user\", user.key().as_ref()],\n    bump\n)]\npub user_account: Account<'info, UserAccount>,\n```\n\n- `seeds`: The seeds used to derive the PDA\n- `bump`: Anchor finds the canonical bump automatically\n\nYou can also use a saved bump:\n\n```rust\n#[account(\n    mut,\n    seeds = [b\"user\", authority.key().as_ref()],\n    bump = user_account.bump\n)]\npub user_account: Account<'info, UserAccount>,\n```\n\n### 5. constraint - Custom Constraints\n\n```rust\n#[account(\n    mut,\n    constraint = user.balance >= 100 @ ErrorCode::InsufficientFunds,\n    constraint = user.is_active @ ErrorCode::AccountInactive\n)]\npub user: Account<'info, UserAccount>,\n```\n\nCustom constraints let you enforce arbitrary rules. The `@ ErrorCode::...` syntax specifies which error to return if the constraint fails.\n\n## Space Calculation\n\nWhen using `init`, you must specify the account size:\n\n```rust\n#[account]\npub struct UserAccount {\n    pub authority: Pubkey,    // 32 bytes\n    pub counter: u64,         // 8 bytes\n    pub name: String,         // 4 + length (max 32) = 36 bytes\n}\n\n// Space = 8 (discriminator) + 32 + 8 + 36 = 84 bytes\n```\n\n**Common sizes**:\n- Pubkey: 32 bytes\n- u64/i64: 8 bytes\n- u32/i32: 4 bytes\n- bool: 1 byte\n- String: 4 (length prefix) + max_length\n- Vec<T>: 4 (length prefix) + (item_size * max_count)\n\n## Constraint Execution Order\n\nAnchor executes constraints in this order:\n1. `init` / `init_if_needed`\n2. `mut`\n3. `seeds` + `bump`\n4. `has_one`\n5. Custom `constraint`s\n\nThis ensures accounts are properly initialized and validated before your instruction logic runs.\n\n## Next Challenge\n\nYou'll implement account validation logic that mimics Anchor's constraint system.\n",
+              "url": null,
+              "language": null,
+              "buildType": null,
+              "deployable": null,
+              "starter": null,
+              "solution": null,
+              "tests": null,
+              "hints": null,
+              "questions": null,
+              "prompt": null,
+              "maxWords": null,
+              "amount": null,
+              "network": null,
+              "idl": null
+            },
+            {
+              "key": "retrieval-close",
+              "_type": "quiz",
+              "produces": null,
+              "consumes": null,
+              "src": null,
+              "url": null,
+              "language": null,
+              "buildType": null,
+              "deployable": null,
+              "starter": null,
+              "solution": null,
+              "tests": null,
+              "hints": null,
+              "questions": [
+                {
+                  "id": "q1",
+                  "prompt": "`has_one = authority` on a `UserAccount` field checks what, and which attack does it stop?",
+                  "multiSelect": false,
+                  "options": [
+                    {
+                      "id": "a",
+                      "label": "It checks `user.authority == authority.key()`, blocking a caller from modifying an account they do not own",
+                      "correct": true,
+                      "feedback": null
+                    },
+                    {
+                      "id": "b",
+                      "label": "It checks that the account is writable",
+                      "correct": false,
+                      "feedback": "Writability is `mut`. `has_one = authority` verifies the account's stored `authority` field equals the passed authority account — an authorization check."
+                    },
+                    {
+                      "id": "c",
+                      "label": "It checks that the account was created by the System Program",
+                      "correct": false,
+                      "feedback": "That is not what has_one does. It ties a stored pubkey field to a passed account, preventing unauthorized updates."
+                    }
+                  ],
+                  "explanation": "`has_one = authority` enforces that the account's stored `authority` field matches the `authority` account supplied to the instruction. Without it, anyone could pass someone else's account and update it — the constraint turns a stored relationship into an authorization gate."
+                },
+                {
+                  "id": "q2",
+                  "prompt": "A constraint reads `constraint = user.balance >= 100 @ ErrorCode::InsufficientFunds`. What does the `@ ErrorCode::...` part control?",
+                  "multiSelect": false,
+                  "options": [
+                    {
+                      "id": "a",
+                      "label": "The specific error returned if the constraint is false, so the client learns why validation failed",
+                      "correct": true,
+                      "feedback": null
+                    },
+                    {
+                      "id": "b",
+                      "label": "It sets the balance to 100 if the check fails",
+                      "correct": false,
+                      "feedback": "Constraints validate, they never assign. `@ ErrorCode::...` only names the error returned on failure; it does not change `balance`."
+                    },
+                    {
+                      "id": "c",
+                      "label": "It retries the instruction until balance reaches 100",
+                      "correct": false,
+                      "feedback": "No retry happens. A failed constraint aborts the instruction and returns the named error."
+                    }
+                  ],
+                  "explanation": "A `constraint = <expr>` must hold or the instruction is rejected, and `@ ErrorCode::X` names the error emitted on failure. This lets you attach a specific, client-readable reason to each declarative check rather than a generic failure."
+                }
+              ],
+              "prompt": null,
+              "maxWords": null,
+              "amount": null,
+              "network": null,
+              "idl": null
+            }
+          ]
+        },
+        {
+          "_id": "lesson-anchor-accounts-challenge",
+          "title": "Challenge: Account Validation",
+          "slug": "anchor-accounts-challenge",
+          "blocks": [
+            {
+              "key": "intro",
+              "_type": "prose",
+              "produces": null,
+              "consumes": null,
+              "src": "# Challenge: Simulate Anchor Account Validation in Rust\n\nAnchor's `#[account]` constraints validate accounts automatically. Here you'll implement the same checks manually — this is exactly what Anchor generates under the hood.\n\n## Your Task\n\nImplement `validate_account(account_owner, expected_owner, is_signer, require_signer, is_writable, require_writable)` that performs Anchor-style validation:\n\n1. Check if `account_owner == expected_owner` → if not, return `Err(\"IncorrectProgramId\")`\n2. Check if signer is required but missing → return `Err(\"MissingRequiredSignature\")`\n3. Check if writable is required but missing → return `Err(\"AccountNotWritable\")`\n4. If all pass, return `Ok(\"Valid\")`\n\n**This mirrors these Anchor constraints:**\n- `#[account(owner = expected_owner)]` → ownership check\n- `Signer<'info>` → signer check\n- `#[account(mut)]` → writable check\n\n**Check order matters** — validate in the order listed above (owner → signer → writable).\n",
+              "url": null,
+              "language": null,
+              "buildType": null,
+              "deployable": null,
+              "starter": null,
+              "solution": null,
+              "tests": null,
+              "hints": null,
+              "questions": null,
+              "prompt": null,
+              "maxWords": null,
+              "amount": null,
+              "network": null,
+              "idl": null
+            },
+            {
+              "key": "exercise",
+              "_type": "code",
+              "produces": null,
+              "consumes": null,
+              "src": null,
+              "url": null,
+              "language": "rust",
+              "buildType": "standard",
+              "deployable": false,
+              "starter": "fn validate_account(\n    account_owner: &str,\n    expected_owner: &str,\n    is_signer: bool,\n    require_signer: bool,\n    is_writable: bool,\n    require_writable: bool,\n) -> Result<String, String> {\n    // TODO: Check owner matches expected_owner\n    //       -> Err(\"IncorrectProgramId\")\n\n    // TODO: Check signer requirement\n    //       -> Err(\"MissingRequiredSignature\")\n\n    // TODO: Check writable requirement\n    //       -> Err(\"AccountNotWritable\")\n\n    // TODO: All checks passed -> Ok(\"Valid\")\n    todo!()\n}\n",
+              "solution": "fn validate_account(\n    account_owner: &str,\n    expected_owner: &str,\n    is_signer: bool,\n    require_signer: bool,\n    is_writable: bool,\n    require_writable: bool,\n) -> Result<String, String> {\n    if account_owner != expected_owner {\n        return Err(\"IncorrectProgramId\".to_string());\n    }\n    if require_signer && !is_signer {\n        return Err(\"MissingRequiredSignature\".to_string());\n    }\n    if require_writable && !is_writable {\n        return Err(\"AccountNotWritable\".to_string());\n    }\n    Ok(\"Valid\".to_string())\n}\n",
+              "tests": [
+                {
+                  "id": "t1",
+                  "description": "Valid account passes",
+                  "input": "\"programA\", \"programA\", true, true, true, true",
+                  "expectedOutput": "__result__.is_ok()"
+                },
+                {
+                  "id": "t2",
+                  "description": "Wrong owner is rejected",
+                  "input": "\"programA\", \"programB\", true, true, true, true",
+                  "expectedOutput": "__result__ == Err(\"IncorrectProgramId\".to_string())"
+                },
+                {
+                  "id": "t3",
+                  "description": "Missing required signer is rejected",
+                  "input": "\"programA\", \"programA\", false, true, true, true",
+                  "expectedOutput": "__result__ == Err(\"MissingRequiredSignature\".to_string())"
+                },
+                {
+                  "id": "t4",
+                  "description": "Non-writable when writable is required is rejected",
+                  "input": "\"programA\", \"programA\", true, true, false, true",
+                  "expectedOutput": "__result__ == Err(\"AccountNotWritable\".to_string())"
+                },
+                {
+                  "id": "t5",
+                  "description": "Passes when no signer/writable requirements",
+                  "input": "\"progX\", \"progX\", true, false, true, false",
+                  "expectedOutput": "__result__.is_ok()"
+                }
+              ],
+              "hints": [
+                "Check owner first: if account_owner != expected_owner { return Err(\"IncorrectProgramId\".to_string()); }",
+                "Then check signer: if require_signer && !is_signer { return Err(...); }",
+                "Same pattern for writable. If all pass, return Ok(\"Valid\".to_string())."
+              ],
+              "questions": null,
+              "prompt": null,
+              "maxWords": null,
+              "amount": null,
+              "network": null,
+              "idl": null
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "pdas-cpis",
+      "title": "PDAs & CPIs",
+      "description": "Master Program Derived Addresses and Cross-Program Invocations for building composable programs.",
+      "lessons": [
+        {
+          "_id": "lesson-pda-deep-dive",
+          "title": "PDA Deep Dive",
+          "slug": "pda-deep-dive",
+          "blocks": [
+            {
+              "key": "intro",
+              "_type": "prose",
+              "produces": null,
+              "consumes": null,
+              "src": "# Program Derived Addresses (PDAs) Deep Dive\n\nProgram Derived Addresses are one of Solana's most powerful and unique features. They enable programs to \"own\" accounts and sign transactions without needing a private key.\n\n## What Are PDAs?\n\nA PDA is a public key that:\n1. Is derived deterministically from seeds and a program ID\n2. Is **not** on the Ed25519 elliptic curve (no corresponding private key exists)\n3. Can only be \"signed for\" by the program that derived it\n\n```rust\n// In Anchor\nlet (pda, bump) = Pubkey::find_program_address(\n    &[b\"user\", user.key().as_ref()],\n    program_id\n);\n```\n\n## Why PDAs Are Off-Curve\n\nSolana uses Ed25519 for signatures. Ed25519 keys lie on an elliptic curve. PDAs are specifically designed to fall **off** this curve, which means:\n- No private key can exist for a PDA\n- Only the deriving program can sign for the PDA (via CPI with `invoke_signed`)\n\nThis creates **program-controlled accounts** that can't be compromised by key theft.\n\n## PDA Derivation Process\n\n```\nseeds = [b\"user\", user_pubkey.as_ref()]\nprogram_id = your_program_id\n\nfor bump in 255..=0 {\n    candidate = sha256(seeds + [bump] + program_id)\n    if !is_on_curve(candidate) {\n        return (candidate, bump)  // This is your PDA\n    }\n}\n```\n\nThe **canonical bump** is the first bump (starting from 255) that produces an off-curve address.\n\n## Seeds Design Patterns\n\n### Pattern 1: User-Scoped Account\n\n```rust\nseeds = [b\"user\", user.key().as_ref()]\n```\n\nOne account per user. Used for user profiles, settings, etc.\n\n### Pattern 2: User + Resource\n\n```rust\nseeds = [b\"escrow\", user.key().as_ref(), trade_id.to_le_bytes().as_ref()]\n```\n\nMultiple accounts per user, one per resource (escrow, order, etc.).\n\n### Pattern 3: Global Singleton\n\n```rust\nseeds = [b\"config\"]\n```\n\nOne global account for the program (config, authority, etc.).\n\n### Pattern 4: Nested PDAs\n\n```rust\n// User stats PDA\nseeds_stats = [b\"stats\", user.key().as_ref()]\n\n// User vault PDA (derived from stats PDA)\nseeds_vault = [b\"vault\", stats_pda.key().as_ref()]\n```\n\nPDAs can be derived from other PDAs for complex hierarchies.\n\n## Storing the Bump\n\nAlways store the canonical bump in your account data:\n\n```rust\n#[account]\npub struct UserAccount {\n    pub authority: Pubkey,\n    pub bump: u8,  // Store this!\n    pub data: u64,\n}\n```\n\nWhy? Because recalculating the bump on every instruction is expensive (requires up to 256 hash operations). Storing it makes subsequent operations cheaper.\n\n## PDAs as Signers\n\nPDAs can sign CPIs using `invoke_signed`:\n\n```rust\ninvoke_signed(\n    &transfer_instruction,\n    &[\n        pda_account.to_account_info(),\n        recipient.to_account_info(),\n        system_program.to_account_info(),\n    ],\n    &[&[b\"user\", user.key().as_ref(), &[bump]]], // Signer seeds\n)?;\n```\n\nThe program derives the PDA, verifies it matches, and \"signs\" the CPI.\n\n## Security Considerations\n\n### 1. Seed Collision\n\nBe careful with seed design:\n\n```rust\n// BAD: Can collide if strings contain delimiters\nseeds = [user_name.as_bytes()]  // \"alice\" and \"ali\" + \"ce\" collide!\n\n// GOOD: Use fixed-size data or well-defined separators\nseeds = [b\"user\", user.key().as_ref()]\n```\n\n### 2. Bump Validation\n\nAlways use the canonical bump:\n\n```rust\n// In Anchor, this is automatic:\n#[account(\n    seeds = [b\"user\", authority.key().as_ref()],\n    bump = user.bump  // Validates stored bump is canonical\n)]\n```\n\n## PDA vs Regular Account\n\n| Feature | Regular Account | PDA |\n|---------|----------------|-----|\n| Has private key | Yes | No |\n| Can self-sign | Yes | No (requires program) |\n| Can hold SOL | Yes | Yes |\n| Can own other accounts | Yes | Yes |\n| Deterministic address | No | Yes |\n| On Ed25519 curve | Yes | No |\n\n## Real-World Examples\n\n**Token vaults** (escrow programs):\n```rust\nseeds = [b\"vault\", escrow.key().as_ref()]\n```\n\n**Associated Token Accounts**:\n```rust\nseeds = [wallet.key(), token_program.key(), mint.key()]\n```\n\n**Governance proposal accounts**:\n```rust\nseeds = [b\"proposal\", governance.key(), proposal_id.to_le_bytes()]\n```\n\n## Next Challenge\n\nYou'll derive multiple related PDAs from a common base to understand PDA hierarchies.\n",
+              "url": null,
+              "language": null,
+              "buildType": null,
+              "deployable": null,
+              "starter": null,
+              "solution": null,
+              "tests": null,
+              "hints": null,
+              "questions": null,
+              "prompt": null,
+              "maxWords": null,
+              "amount": null,
+              "network": null,
+              "idl": null
+            },
+            {
+              "key": "retrieval-close",
+              "_type": "quiz",
+              "produces": null,
+              "consumes": null,
+              "src": null,
+              "url": null,
+              "language": null,
+              "buildType": null,
+              "deployable": null,
+              "starter": null,
+              "solution": null,
+              "tests": null,
+              "hints": null,
+              "questions": [
+                {
+                  "id": "q1",
+                  "prompt": "A PDA is deliberately chosen to fall OFF the Ed25519 curve. What does off-curve guarantee?",
+                  "multiSelect": false,
+                  "options": [
+                    {
+                      "id": "a",
+                      "label": "No private key exists for the address, so only the deriving program can sign for it via invoke_signed",
+                      "correct": true,
+                      "feedback": null
+                    },
+                    {
+                      "id": "b",
+                      "label": "The address is shorter than a normal pubkey",
+                      "correct": false,
+                      "feedback": "Off-curve addresses are the same 32-byte size. What off-curve buys you is that no private key exists — the program alone can authorize it."
+                    },
+                    {
+                      "id": "c",
+                      "label": "The account can never hold SOL",
+                      "correct": false,
+                      "feedback": "PDAs can hold SOL fine. Off-curve means no private key, which is what makes them program-controlled and theft-proof."
+                    }
+                  ],
+                  "explanation": "Ed25519 signing keys lie on the curve; a PDA is derived to sit off it, so no private key can exist. That is precisely what makes a PDA program-controlled: only the program that derived it can sign for it through invoke_signed, and no leaked key can drain it."
+                },
+                {
+                  "id": "q2",
+                  "prompt": "The lesson says to store the canonical `bump` in the account rather than re-deriving it each time. Why?",
+                  "multiSelect": false,
+                  "options": [
+                    {
+                      "id": "a",
+                      "label": "Re-finding the canonical bump can cost up to 256 hash attempts; storing it makes later instructions cheaper",
+                      "correct": true,
+                      "feedback": null
+                    },
+                    {
+                      "id": "b",
+                      "label": "The bump changes every transaction, so it must be saved",
+                      "correct": false,
+                      "feedback": "The canonical bump is deterministic and stable for given seeds — it does not change. You store it to skip the costly search, not because it varies."
+                    },
+                    {
+                      "id": "c",
+                      "label": "Storing the bump is required for the PDA to hold SOL",
+                      "correct": false,
+                      "feedback": "Holding SOL has nothing to do with the bump. You store it purely to avoid recomputing the canonical bump on each call."
+                    }
+                  ],
+                  "explanation": "find_program_address tries bumps from 255 downward until it finds an off-curve address, up to 256 hash operations. Since that canonical bump is fixed for the seeds, storing it in the account lets later instructions validate the PDA with `bump = account.bump` instead of repeating the expensive search."
+                }
+              ],
+              "prompt": null,
+              "maxWords": null,
+              "amount": null,
+              "network": null,
+              "idl": null
+            }
+          ]
+        },
+        {
+          "_id": "lesson-pda-advanced-challenge",
+          "title": "Challenge: Multi-PDA Derivation",
+          "slug": "pda-advanced-challenge",
+          "blocks": [
+            {
+              "key": "intro",
+              "_type": "prose",
+              "produces": null,
+              "consumes": null,
+              "src": "# Challenge: Derive Multiple Related PDAs in Rust\n\nReal Anchor programs often derive multiple PDAs per user — profile, stats, vault, etc. Each uses different seed prefixes but the same user key.\n\nUsing the simulated PDA derivation from earlier, derive 3 related PDAs and return their hashes as a tuple.\n\n## Your Task\n\nImplement `derive_user_pdas(user, program_id)` that:\n\n1. Derives a **user PDA** with seeds `[\"user\", user]`\n2. Derives a **stats PDA** with seeds `[\"stats\", user]`\n3. Derives a **vault PDA** with seeds `[\"vault\", user]`\n4. Returns `(user_hash, stats_hash, vault_hash)` as a `(u64, u64, u64)` tuple\n\nA helper `find_pda` is provided — use it to derive each PDA.\n\n**Requirements:**\n- All three hashes must be off-curve (even)\n- All three must be different from each other\n- Same inputs must always produce same outputs (deterministic)\n",
+              "url": null,
+              "language": null,
+              "buildType": null,
+              "deployable": null,
+              "starter": null,
+              "solution": null,
+              "tests": null,
+              "hints": null,
+              "questions": null,
+              "prompt": null,
+              "maxWords": null,
+              "amount": null,
+              "network": null,
+              "idl": null
+            },
+            {
+              "key": "exercise",
+              "_type": "code",
+              "produces": null,
+              "consumes": null,
+              "src": null,
+              "url": null,
+              "language": "rust",
+              "buildType": "standard",
+              "deployable": false,
+              "starter": "use std::collections::hash_map::DefaultHasher;\nuse std::hash::{Hash, Hasher};\n\nfn hash_with_bump(seeds: &[&str], bump: u8, program_id: &str) -> u64 {\n    let mut hasher = DefaultHasher::new();\n    for seed in seeds {\n        seed.hash(&mut hasher);\n    }\n    bump.hash(&mut hasher);\n    program_id.hash(&mut hasher);\n    hasher.finish()\n}\n\nfn find_pda(seeds: &[&str], program_id: &str) -> (u64, u8) {\n    for bump in (0..=255u8).rev() {\n        let hash = hash_with_bump(seeds, bump, program_id);\n        if hash % 2 == 0 {\n            return (hash, bump);\n        }\n    }\n    panic!(\"No valid bump found\");\n}\n\n/// Derive user, stats, and vault PDAs for the given user.\n/// Returns (user_hash, stats_hash, vault_hash).\nfn derive_user_pdas(user: &str, program_id: &str) -> (u64, u64, u64) {\n    // TODO: Derive user PDA with seeds [\"user\", user]\n    // TODO: Derive stats PDA with seeds [\"stats\", user]\n    // TODO: Derive vault PDA with seeds [\"vault\", user]\n    // TODO: Return the three hashes as a tuple\n    todo!()\n}\n",
+              "solution": "use std::collections::hash_map::DefaultHasher;\nuse std::hash::{Hash, Hasher};\n\nfn hash_with_bump(seeds: &[&str], bump: u8, program_id: &str) -> u64 {\n    let mut hasher = DefaultHasher::new();\n    for seed in seeds {\n        seed.hash(&mut hasher);\n    }\n    bump.hash(&mut hasher);\n    program_id.hash(&mut hasher);\n    hasher.finish()\n}\n\nfn find_pda(seeds: &[&str], program_id: &str) -> (u64, u8) {\n    for bump in (0..=255u8).rev() {\n        let hash = hash_with_bump(seeds, bump, program_id);\n        if hash % 2 == 0 {\n            return (hash, bump);\n        }\n    }\n    panic!(\"No valid bump found\");\n}\n\nfn derive_user_pdas(user: &str, program_id: &str) -> (u64, u64, u64) {\n    let (user_h, _) = find_pda(&[\"user\", user], program_id);\n    let (stats_h, _) = find_pda(&[\"stats\", user], program_id);\n    let (vault_h, _) = find_pda(&[\"vault\", user], program_id);\n    (user_h, stats_h, vault_h)\n}\n",
+              "tests": [
+                {
+                  "id": "test-1",
+                  "description": "All PDAs should be off-curve (even hashes)",
+                  "input": "\"alice\", \"prog1\"",
+                  "expectedOutput": "__result__.0 % 2 == 0 && __result__.1 % 2 == 0 && __result__.2 % 2 == 0"
+                },
+                {
+                  "id": "test-2",
+                  "description": "All three PDAs should be different",
+                  "input": "\"alice\", \"prog1\"",
+                  "expectedOutput": "__result__.0 != __result__.1 && __result__.1 != __result__.2"
+                },
+                {
+                  "id": "test-3",
+                  "description": "Different users should produce different PDAs",
+                  "input": "\"bob\", \"prog1\"",
+                  "expectedOutput": "__result__.0 != derive_user_pdas(\"alice\", \"prog1\").0"
+                }
+              ],
+              "hints": [
+                "Call find_pda with different seed prefixes: find_pda(&[\"user\", user], program_id) for the user PDA.",
+                "Each find_pda returns (hash, bump) — you only need the hash (the .0 field) for the return tuple.",
+                "let (user_h, _) = find_pda(&[\"user\", user], program_id); then same for stats and vault."
+              ],
+              "questions": null,
+              "prompt": null,
+              "maxWords": null,
+              "amount": null,
+              "network": null,
+              "idl": null
+            }
+          ]
+        },
+        {
+          "_id": "lesson-cpi-overview",
+          "title": "Cross-Program Invocations",
+          "slug": "cpi-overview",
+          "blocks": [
+            {
+              "key": "intro",
+              "_type": "prose",
+              "produces": null,
+              "consumes": null,
+              "src": "# Cross-Program Invocations (CPIs)\n\nCross-Program Invocations allow one Solana program to call another program. This is what makes Solana programs **composable** — you can build on top of existing programs like building blocks.\n\n## Why CPIs Matter\n\nCPIs enable:\n- **Token transfers** via the Token Program\n- **NFT minting** via Metaplex programs\n- **Swaps** through DEX programs (Jupiter, Raydium)\n- **Lending** through DeFi protocols (Solend, MarginFi)\n\nWithout CPIs, every program would need to reimplement basic functionality. With CPIs, you compose existing programs.\n\n## How CPIs Work\n\nWhen Program A calls Program B:\n\n```\nUser Transaction\n  |\n  v\nProgram A (your program)\n  |\n  v (CPI)\nProgram B (Token Program, System Program, etc.)\n```\n\nThe Solana runtime tracks the **call stack** and ensures:\n- Account ownership rules are enforced\n- Signers are propagated correctly\n- Programs can't exceed the call depth limit (4 levels)\n\n## invoke vs invoke_signed\n\n### invoke - Regular CPI\n\n```rust\nuse solana_program::program::invoke;\n\ninvoke(\n    &instruction,\n    &[\n        source_account.clone(),\n        destination_account.clone(),\n        authority.clone(),\n    ],\n)?;\n```\n\nUse `invoke` when the required signers are already in your instruction's signer list.\n\n### invoke_signed - CPI with PDA Signer\n\n```rust\nuse solana_program::program::invoke_signed;\n\ninvoke_signed(\n    &instruction,\n    &[\n        pda_account.clone(),\n        destination_account.clone(),\n        system_program.clone(),\n    ],\n    &[&[b\"vault\", &[bump]]], // PDA seeds\n)?;\n```\n\nUse `invoke_signed` when a **PDA** needs to sign. The program derives the PDA and \"signs\" on its behalf.\n\n## CPI in Anchor\n\nAnchor provides a cleaner API for CPIs:\n\n```rust\nuse anchor_lang::prelude::*;\nuse anchor_spl::token::{self, Transfer};\n\npub fn transfer_tokens(ctx: Context<TransferTokens>, amount: u64) -> Result<()> {\n    let cpi_accounts = Transfer {\n        from: ctx.accounts.from.to_account_info(),\n        to: ctx.accounts.to.to_account_info(),\n        authority: ctx.accounts.authority.to_account_info(),\n    };\n\n    let cpi_program = ctx.accounts.token_program.to_account_info();\n    let cpi_ctx = CpiContext::new(cpi_program, cpi_accounts);\n\n    token::transfer(cpi_ctx, amount)?;\n    Ok(())\n}\n```\n\n### CPI with PDA Signer in Anchor\n\n```rust\npub fn transfer_from_pda(ctx: Context<TransferFromPDA>, amount: u64) -> Result<()> {\n    let seeds = &[\n        b\"vault\",\n        ctx.accounts.authority.key().as_ref(),\n        &[ctx.accounts.vault.bump],\n    ];\n    let signer_seeds = &[&seeds[..]];\n\n    let cpi_accounts = Transfer {\n        from: ctx.accounts.vault_token_account.to_account_info(),\n        to: ctx.accounts.user_token_account.to_account_info(),\n        authority: ctx.accounts.vault.to_account_info(),\n    };\n\n    let cpi_program = ctx.accounts.token_program.to_account_info();\n    let cpi_ctx = CpiContext::new_with_signer(\n        cpi_program,\n        cpi_accounts,\n        signer_seeds,\n    );\n\n    token::transfer(cpi_ctx, amount)?;\n    Ok(())\n}\n```\n\n## Common CPI Patterns\n\n### 1. Token Transfer\n\n```rust\n// Transfer SPL tokens from user to program vault\ntoken::transfer(\n    CpiContext::new(token_program, transfer_accounts),\n    amount,\n)?;\n```\n\n### 2. Minting Tokens\n\n```rust\n// Mint new tokens (requires mint authority)\ntoken::mint_to(\n    CpiContext::new_with_signer(token_program, mint_accounts, signer_seeds),\n    amount,\n)?;\n```\n\n### 3. Creating Accounts\n\n```rust\n// Create a new account (CPI to System Program)\nsystem_program::create_account(\n    CpiContext::new(system_program, create_accounts),\n    lamports,\n    space,\n    program_id,\n)?;\n```\n\n## CPI Security Considerations\n\n### 1. Account Validation\n\nAlways validate accounts before CPI:\n\n```rust\nrequire_keys_eq!(\n    ctx.accounts.token_program.key(),\n    token::ID,\n    ErrorCode::InvalidTokenProgram\n);\n```\n\n### 2. Signer Propagation\n\nSigners in your instruction are automatically propagated to CPIs. But be careful:\n\n```rust\n// BAD: Anyone can call this and spend vault tokens!\npub fn dangerous_withdraw(ctx: Context<Withdraw>, amount: u64) -> Result<()> {\n    token::transfer(\n        CpiContext::new_with_signer(...),\n        amount,\n    )\n}\n\n// GOOD: Check authority first\npub fn safe_withdraw(ctx: Context<Withdraw>, amount: u64) -> Result<()> {\n    require_keys_eq!(\n        ctx.accounts.authority.key(),\n        ctx.accounts.vault.authority,\n        ErrorCode::Unauthorized\n    );\n    token::transfer(...)\n}\n```\n\n### 3. Reentrancy\n\nSolana programs are **not reentrant** by default (a program can't call itself). This prevents classic reentrancy attacks.\n\n## Real-World CPI Examples\n\n**Escrow program**:\n1. User deposits tokens → CPI to Token Program to transfer tokens to escrow PDA\n2. Trade executes → CPI to Token Program to transfer from escrow PDA to recipient\n\n**Staking program**:\n1. User stakes tokens → CPI to Token Program to transfer to staking vault\n2. User claims rewards → CPI to Token Program to mint reward tokens\n3. User unstakes → CPI to Token Program to transfer staked tokens back\n\n**NFT marketplace**:\n1. User lists NFT → CPI to Token Program to transfer NFT to marketplace PDA\n2. Buyer purchases → CPI to System Program (SOL payment) + CPI to Token Program (NFT transfer)\n\n## Next Challenge\n\nYou'll construct a CPI instruction to transfer SOL from a PDA-owned account.\n",
+              "url": null,
+              "language": null,
+              "buildType": null,
+              "deployable": null,
+              "starter": null,
+              "solution": null,
+              "tests": null,
+              "hints": null,
+              "questions": null,
+              "prompt": null,
+              "maxWords": null,
+              "amount": null,
+              "network": null,
+              "idl": null
+            },
+            {
+              "key": "retrieval-close",
+              "_type": "quiz",
+              "produces": null,
+              "consumes": null,
+              "src": null,
+              "url": null,
+              "language": null,
+              "buildType": null,
+              "deployable": null,
+              "starter": null,
+              "solution": null,
+              "tests": null,
+              "hints": null,
+              "questions": [
+                {
+                  "id": "q1",
+                  "prompt": "When do you use `invoke_signed` instead of `invoke` for a CPI?",
+                  "multiSelect": false,
+                  "options": [
+                    {
+                      "id": "a",
+                      "label": "When a PDA must sign the CPI — the program supplies the PDA's seeds so it can sign without a private key",
+                      "correct": true,
+                      "feedback": null
+                    },
+                    {
+                      "id": "b",
+                      "label": "When the CPI transfers more than a set amount of SOL",
+                      "correct": false,
+                      "feedback": "The choice has nothing to do with amount. `invoke_signed` is specifically for when a PDA needs to sign; `invoke` is used when required signers are already present."
+                    },
+                    {
+                      "id": "c",
+                      "label": "When calling a program you did not write",
+                      "correct": false,
+                      "feedback": "Both call other programs. The distinction is the signer: `invoke_signed` provides PDA seeds so the program can sign on the PDA's behalf."
+                    }
+                  ],
+                  "explanation": "`invoke` works when the needed signatures already exist in the instruction's signer set. `invoke_signed` adds the PDA's seeds so the runtime lets the program sign for the PDA — the only way a keyless, program-controlled account can authorize a CPI."
+                },
+                {
+                  "id": "q2",
+                  "prompt": "A `withdraw` instruction does a signed CPI to move vault tokens but never checks who called it. What is the flaw?",
+                  "multiSelect": false,
+                  "options": [
+                    {
+                      "id": "a",
+                      "label": "Anyone can call it and drain the vault — the program signs for the PDA without verifying the caller's authority",
+                      "correct": true,
+                      "feedback": null
+                    },
+                    {
+                      "id": "b",
+                      "label": "Nothing — Solana blocks unauthorized CPIs automatically",
+                      "correct": false,
+                      "feedback": "The runtime enforces account ownership and signer propagation, not your business rules. If you do not check the caller against the vault authority, anyone can trigger the withdrawal."
+                    },
+                    {
+                      "id": "c",
+                      "label": "The CPI fails because PDAs cannot sign token transfers",
+                      "correct": false,
+                      "feedback": "PDAs sign token transfers fine via invoke_signed — that is the problem here. Without an authority check, that signing power is exposed to any caller."
+                    }
+                  ],
+                  "explanation": "invoke_signed makes the program sign for its PDA, so the transfer succeeds for whoever calls. The missing piece is a caller-versus-authority check (require_keys_eq!) — the runtime will not supply your authorization logic, so an unchecked signed CPI is an open withdrawal for anyone."
+                }
+              ],
+              "prompt": null,
+              "maxWords": null,
+              "amount": null,
+              "network": null,
+              "idl": null
+            }
+          ]
+        },
+        {
+          "_id": "lesson-cpi-challenge",
+          "title": "Challenge: Simulate a CPI Vault Transfer",
+          "slug": "cpi-challenge",
+          "blocks": [
+            {
+              "key": "intro",
+              "_type": "prose",
+              "produces": null,
+              "consumes": null,
+              "src": "# Challenge: Simulate a CPI Vault Transfer in Rust\n\nCross-Program Invocations (CPIs) let programs transfer SOL from PDA-controlled vaults. You'll simulate this pattern: derive a vault PDA, verify it has funds, and compute the transfer.\n\n## Your Task\n\nImplement `build_vault_transfer(user, vault_balance, recipient_balance, amount)` that:\n\n1. Derives the vault PDA using `find_pda(&[\"vault\", user], \"system\")` to get the bump\n2. Checks the vault has enough balance for the transfer\n3. Returns `Ok((new_vault_balance, new_recipient_balance, bump))` on success\n4. Returns `Err(\"INSUFFICIENT_VAULT_BALANCE\")` if vault can't cover the amount\n\n**This mirrors the real Anchor pattern:**\n```rust\ninvoke_signed(\n    &transfer_instruction,\n    &[vault_pda, recipient, system_program],\n    &[&[b\"vault\", user.key().as_ref(), &[bump]]],\n)?;\n```\n\nThe bump is needed for `invoke_signed` — the program proves it controls the PDA.\n",
+              "url": null,
+              "language": null,
+              "buildType": null,
+              "deployable": null,
+              "starter": null,
+              "solution": null,
+              "tests": null,
+              "hints": null,
+              "questions": null,
+              "prompt": null,
+              "maxWords": null,
+              "amount": null,
+              "network": null,
+              "idl": null
+            },
+            {
+              "key": "exercise",
+              "_type": "code",
+              "produces": null,
+              "consumes": null,
+              "src": null,
+              "url": null,
+              "language": "rust",
+              "buildType": "standard",
+              "deployable": false,
+              "starter": "use std::collections::hash_map::DefaultHasher;\nuse std::hash::{Hash, Hasher};\n\nfn hash_with_bump(seeds: &[&str], bump: u8, program_id: &str) -> u64 {\n    let mut hasher = DefaultHasher::new();\n    for seed in seeds { seed.hash(&mut hasher); }\n    bump.hash(&mut hasher);\n    program_id.hash(&mut hasher);\n    hasher.finish()\n}\n\nfn find_pda(seeds: &[&str], program_id: &str) -> (u64, u8) {\n    for bump in (0..=255u8).rev() {\n        let hash = hash_with_bump(seeds, bump, program_id);\n        if hash % 2 == 0 { return (hash, bump); }\n    }\n    panic!(\"No valid bump found\");\n}\n\n/// Simulate a CPI transfer from a PDA vault to a recipient.\n/// Returns Ok((new_vault_balance, new_recipient_balance, bump)).\nfn build_vault_transfer(\n    user: &str,\n    vault_balance: u64,\n    recipient_balance: u64,\n    amount: u64,\n) -> Result<(u64, u64, u8), String> {\n    // TODO: Derive the vault PDA to get the bump\n    // TODO: Check vault_balance >= amount\n    // TODO: Return updated balances and the bump\n    todo!()\n}\n",
+              "solution": "use std::collections::hash_map::DefaultHasher;\nuse std::hash::{Hash, Hasher};\n\nfn hash_with_bump(seeds: &[&str], bump: u8, program_id: &str) -> u64 {\n    let mut hasher = DefaultHasher::new();\n    for seed in seeds { seed.hash(&mut hasher); }\n    bump.hash(&mut hasher);\n    program_id.hash(&mut hasher);\n    hasher.finish()\n}\n\nfn find_pda(seeds: &[&str], program_id: &str) -> (u64, u8) {\n    for bump in (0..=255u8).rev() {\n        let hash = hash_with_bump(seeds, bump, program_id);\n        if hash % 2 == 0 { return (hash, bump); }\n    }\n    panic!(\"No valid bump found\");\n}\n\nfn build_vault_transfer(\n    user: &str,\n    vault_balance: u64,\n    recipient_balance: u64,\n    amount: u64,\n) -> Result<(u64, u64, u8), String> {\n    let (_, bump) = find_pda(&[\"vault\", user], \"system\");\n    if vault_balance < amount {\n        return Err(\"INSUFFICIENT_VAULT_BALANCE\".to_string());\n    }\n    Ok((vault_balance - amount, recipient_balance + amount, bump))\n}\n",
+              "tests": [
+                {
+                  "id": "t1",
+                  "description": "Sufficient balance succeeds",
+                  "input": "\"alice\", 1000, 500, 200",
+                  "expectedOutput": "__result__.is_ok()"
+                },
+                {
+                  "id": "t2",
+                  "description": "Insufficient balance fails",
+                  "input": "\"alice\", 100, 500, 200",
+                  "expectedOutput": "__result__.is_err()"
+                },
+                {
+                  "id": "t3",
+                  "description": "Balances update correctly",
+                  "input": "\"alice\", 1000, 500, 200",
+                  "expectedOutput": "{ let r = __result__.unwrap(); r.0 == 800 && r.1 == 700 }"
+                },
+                {
+                  "id": "t4",
+                  "description": "Balances update correctly for a different transfer",
+                  "input": "\"bob\", 5000, 1000, 1500",
+                  "expectedOutput": "{ let r = __result__.unwrap(); r.0 == 3500 && r.1 == 2500 }"
+                }
+              ],
+              "hints": [
+                "First derive the PDA: let (_, bump) = find_pda(&[\"vault\", user], \"system\");",
+                "Then check: if vault_balance < amount { return Err(\"INSUFFICIENT_VAULT_BALANCE\".to_string()); }",
+                "Return Ok((vault_balance - amount, recipient_balance + amount, bump))."
+              ],
+              "questions": null,
+              "prompt": null,
+              "maxWords": null,
+              "amount": null,
+              "network": null,
+              "idl": null
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "anchor-testing",
+      "title": "Testing & Deployment",
+      "description": "Learn to test, debug, and deploy production-ready Anchor programs.",
+      "lessons": [
+        {
+          "_id": "lesson-anchor-testing",
+          "title": "Testing Anchor Programs",
+          "slug": "anchor-testing",
+          "blocks": [
+            {
+              "key": "intro",
+              "_type": "prose",
+              "produces": null,
+              "consumes": null,
+              "src": "# Testing Anchor Programs\n\nTesting is critical for Solana programs. Bugs in smart contracts can lead to loss of funds, so comprehensive testing is non-negotiable.\n\n## Anchor Test Setup\n\nAnchor projects come with a `tests/` folder and pre-configured testing:\n\n```bash\nanchor test\n```\n\nThis command:\n1. Builds your program\n2. Deploys to a local validator\n3. Runs your TypeScript tests\n4. Shuts down the validator\n\n## Basic Test Structure\n\n```typescript\nimport * as anchor from '@coral-xyz/anchor';\nimport { Program } from '@coral-xyz/anchor';\nimport { MyProgram } from '../target/types/my_program';\nimport { expect } from 'chai';\n\ndescribe('my-program', () => {\n  const provider = anchor.AnchorProvider.env();\n  anchor.setProvider(provider);\n\n  const program = anchor.workspace.MyProgram as Program<MyProgram>;\n\n  it('Initializes the program', async () => {\n    const myAccount = anchor.web3.Keypair.generate();\n\n    await program.methods\n      .initialize()\n      .accounts({\n        myAccount: myAccount.publicKey,\n        user: provider.wallet.publicKey,\n        systemProgram: anchor.web3.SystemProgram.programId,\n      })\n      .signers([myAccount])\n      .rpc();\n\n    const account = await program.account.myAccount.fetch(\n      myAccount.publicKey\n    );\n\n    expect(account.data.toNumber()).to.equal(0);\n  });\n});\n```\n\n## Bankrun: Fast Local Testing\n\nBankrun is a lightweight Solana test validator that runs in-process:\n\n```typescript\nimport { BankrunProvider } from 'anchor-bankrun';\nimport { startAnchor } from 'solana-bankrun';\n\ndescribe('fast tests', () => {\n  let context;\n  let provider;\n  let program;\n\n  before(async () => {\n    context = await startAnchor(\n      '',\n      [{ name: 'my_program', programId: PROGRAM_ID }],\n      []\n    );\n\n    provider = new BankrunProvider(context);\n    program = new Program<MyProgram>(IDL, provider);\n  });\n\n  it('runs 10x faster', async () => {\n    // Your test\n  });\n});\n```\n\nBankrun is **much faster** than spinning up a full validator for each test.\n\n## Testing Patterns\n\n### 1. Test Fixtures\n\n```typescript\nconst createUser = async () => {\n  const user = anchor.web3.Keypair.generate();\n\n  // Airdrop SOL\n  await provider.connection.requestAirdrop(\n    user.publicKey,\n    2 * anchor.web3.LAMPORTS_PER_SOL\n  );\n\n  return user;\n};\n\nconst createTokenAccount = async (owner, mint) => {\n  // Create token account for testing\n};\n```\n\n### 2. Account Assertions\n\n```typescript\nconst account = await program.account.userAccount.fetch(userPDA);\n\nexpect(account.authority.toBase58()).to.equal(\n  user.publicKey.toBase58()\n);\nexpect(account.balance.toNumber()).to.equal(1000);\nexpect(account.isActive).to.be.true;\n```\n\n### 3. Error Testing\n\n```typescript\ntry {\n  await program.methods\n    .withdraw(new anchor.BN(10000))\n    .accounts({ user: userPDA })\n    .rpc();\n\n  // Should not reach here\n  expect.fail('Expected error was not thrown');\n} catch (err) {\n  expect(err.error.errorCode.code).to.equal('InsufficientFunds');\n}\n```\n\n### 4. Event Testing\n\nAnchor can emit events:\n\n```rust\n#[event]\npub struct TransferEvent {\n    pub from: Pubkey,\n    pub to: Pubkey,\n    pub amount: u64,\n}\n\nemit!(TransferEvent {\n    from: ctx.accounts.from.key(),\n    to: ctx.accounts.to.key(),\n    amount,\n});\n```\n\nTest events:\n\n```typescript\nconst listener = program.addEventListener('TransferEvent', (event) => {\n  console.log('Transfer:', event);\n  expect(event.amount.toNumber()).to.equal(100);\n});\n\nawait program.methods.transfer(new anchor.BN(100)).rpc();\n\nprogram.removeEventListener(listener);\n```\n\n## Test Organization\n\n```\ntests/\n├── setup.ts              # Shared setup logic\n├── fixtures.ts           # Test data generators\n├── initialize.test.ts    # Initialization tests\n├── transfer.test.ts      # Transfer logic tests\n└── errors.test.ts        # Error condition tests\n```\n\n## Mocking Accounts\n\nFor unit-testing complex logic:\n\n```typescript\nconst mockAccount = {\n  authority: user.publicKey,\n  balance: new anchor.BN(1000),\n  lastUpdate: new anchor.BN(Date.now() / 1000),\n};\n\n// Serialize and write to test validator\nconst accountData = program.coder.accounts.encode(\n  'UserAccount',\n  mockAccount\n);\n```\n\n## Best Practices\n\n1. **Test happy path first**, then edge cases\n2. **Test all error conditions** (unauthorized access, insufficient funds, etc.)\n3. **Use descriptive test names**: `it('rejects withdrawal when balance is insufficient')`\n4. **Clean up state** between tests (or use Bankrun snapshots)\n5. **Test with realistic data** (not just 0s and 1s)\n6. **Measure code coverage** (use `solana-program-test` for Rust unit tests)\n\n## Continuous Integration\n\n```yaml\n# .github/workflows/test.yml\nname: Test\n\non: [push, pull_request]\n\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/checkout@v3\n      - uses: actions/setup-node@v3\n      - name: Install Solana\n        run: sh -c \"$(curl -sSfL https://release.anza.xyz/stable/install)\"\n      - name: Install Anchor\n        run: cargo install --git https://github.com/coral-xyz/anchor avm --force\n      - name: Run tests\n        run: anchor test\n```\n\n## Next Lesson\n\nYou'll learn how to define custom errors in Anchor programs.\n",
+              "url": null,
+              "language": null,
+              "buildType": null,
+              "deployable": null,
+              "starter": null,
+              "solution": null,
+              "tests": null,
+              "hints": null,
+              "questions": null,
+              "prompt": null,
+              "maxWords": null,
+              "amount": null,
+              "network": null,
+              "idl": null
+            }
+          ]
+        },
+        {
+          "_id": "lesson-anchor-errors",
+          "title": "Custom Errors in Anchor",
+          "slug": "anchor-errors",
+          "blocks": [
+            {
+              "key": "intro",
+              "_type": "prose",
+              "produces": null,
+              "consumes": null,
+              "src": "# Custom Errors in Anchor\n\nProperly handling errors is essential for debugging and security. Anchor provides a clean way to define and use custom errors.\n\n## Defining Custom Errors\n\n```rust\nuse anchor_lang::prelude::*;\n\n#[error_code]\npub enum ErrorCode {\n    #[msg(\"Insufficient funds for this operation\")]\n    InsufficientFunds,\n\n    #[msg(\"User is not authorized to perform this action\")]\n    Unauthorized,\n\n    #[msg(\"The provided amount exceeds the maximum allowed\")]\n    AmountTooLarge,\n\n    #[msg(\"Account has already been initialized\")]\n    AlreadyInitialized,\n}\n```\n\nEach error gets:\n- A unique error code (auto-assigned)\n- A human-readable message\n- Integration with Anchor's error handling\n\n## Using the require! Macro\n\nThe `require!` macro is the cleanest way to enforce conditions:\n\n```rust\npub fn transfer(ctx: Context<Transfer>, amount: u64) -> Result<()> {\n    let user_account = &mut ctx.accounts.user;\n\n    // Check balance\n    require!(\n        user_account.balance >= amount,\n        ErrorCode::InsufficientFunds\n    );\n\n    // Check authorization\n    require_keys_eq!(\n        ctx.accounts.authority.key(),\n        user_account.authority,\n        ErrorCode::Unauthorized\n    );\n\n    // Check amount limit\n    require!(\n        amount <= 1_000_000,\n        ErrorCode::AmountTooLarge\n    );\n\n    user_account.balance -= amount;\n    Ok(())\n}\n```\n\n## Anchor's Built-in require! Variants\n\n### require_keys_eq!\n\n```rust\nrequire_keys_eq!(\n    ctx.accounts.user.authority,\n    ctx.accounts.signer.key(),\n    ErrorCode::Unauthorized\n);\n```\n\nCompares two public keys.\n\n### require_keys_neq!\n\n```rust\nrequire_keys_neq!(\n    ctx.accounts.from.key(),\n    ctx.accounts.to.key(),\n    ErrorCode::CannotTransferToSelf\n);\n```\n\nEnsures two keys are different.\n\n### require_gt! / require_gte!\n\n```rust\nrequire_gte!(\n    user.balance,\n    MIN_BALANCE,\n    ErrorCode::BalanceTooLow\n);\n```\n\nNumeric comparisons (gt = greater than, gte = greater than or equal).\n\n## Constraint Errors\n\nConstraints in `#[account(...)]` automatically return errors:\n\n```rust\n#[derive(Accounts)]\npub struct UpdateUser<'info> {\n    #[account(\n        mut,\n        has_one = authority @ ErrorCode::Unauthorized,\n        constraint = user.is_active @ ErrorCode::AccountInactive\n    )]\n    pub user: Account<'info, UserAccount>,\n    pub authority: Signer<'info>,\n}\n```\n\nIf `has_one` or `constraint` fails, Anchor returns your custom error.\n\n## Error Handling in TypeScript Tests\n\nAnchor errors are automatically parsed in TypeScript:\n\n```typescript\ntry {\n  await program.methods\n    .transfer(new anchor.BN(10000))\n    .accounts({ user: userPDA })\n    .rpc();\n\n  throw new Error('Should have failed');\n} catch (err) {\n  // Anchor error structure\n  expect(err.error.errorCode.code).to.equal('InsufficientFunds');\n  expect(err.error.errorCode.number).to.equal(6000); // First custom error\n  expect(err.error.errorMessage).to.include('Insufficient funds');\n}\n```\n\n## Error Codes\n\nAnchor assigns error codes starting at **6000**:\n\n```rust\n#[error_code]\npub enum ErrorCode {\n    InsufficientFunds,    // 6000\n    Unauthorized,         // 6001\n    AmountTooLarge,       // 6002\n}\n```\n\nYou can also manually assign codes:\n\n```rust\n#[error_code]\npub enum ErrorCode {\n    #[msg(\"Insufficient funds\")]\n    InsufficientFunds = 7000,\n}\n```\n\n## Anchor's Built-in Errors\n\nAnchor provides common errors automatically:\n\n- `ErrorCode::ConstraintMut` - Account not marked as mutable\n- `ErrorCode::ConstraintHasOne` - has_one constraint failed\n- `ErrorCode::ConstraintSigner` - Account not a signer\n- `ErrorCode::ConstraintRaw` - Generic constraint failed\n- `ErrorCode::AccountNotInitialized` - Account data is empty\n- `ErrorCode::AccountOwnedByWrongProgram` - Account owned by wrong program\n\n## Best Practices\n\n### 1. Be Specific\n\n```rust\n// BAD: Vague error\n#[msg(\"Invalid input\")]\nInvalidInput,\n\n// GOOD: Specific error\n#[msg(\"Amount must be between 1 and 1,000,000 lamports\")]\nAmountOutOfRange,\n```\n\n### 2. Use Constraints Where Possible\n\nInstead of:\n\n```rust\npub fn update(ctx: Context<Update>) -> Result<()> {\n    require!(\n        ctx.accounts.user.authority == ctx.accounts.signer.key(),\n        ErrorCode::Unauthorized\n    );\n    // ...\n}\n```\n\nUse:\n\n```rust\n#[derive(Accounts)]\npub struct Update<'info> {\n    #[account(\n        mut,\n        has_one = authority @ ErrorCode::Unauthorized\n    )]\n    pub user: Account<'info, UserAccount>,\n    pub authority: Signer<'info>,\n}\n```\n\n### 3. Log Context for Debugging\n\n```rust\nrequire!(\n    amount > 0,\n    ErrorCode::AmountMustBePositive\n);\n\nmsg!(\"Transferring {} lamports\", amount);\n```\n\nUse `msg!()` to log values for debugging.\n\n## Matching Errors in Integration Tests\n\n```typescript\nconst expectError = async (fn, errorCode) => {\n  try {\n    await fn();\n    throw new Error(`Expected ${errorCode} error`);\n  } catch (err) {\n    expect(err.error.errorCode.code).to.equal(errorCode);\n  }\n};\n\nawait expectError(\n  () => program.methods.transfer(tooMuch).rpc(),\n  'InsufficientFunds'\n);\n```\n\n## Next Lesson\n\nYou'll learn how to deploy Anchor programs to devnet and mainnet.\n",
+              "url": null,
+              "language": null,
+              "buildType": null,
+              "deployable": null,
+              "starter": null,
+              "solution": null,
+              "tests": null,
+              "hints": null,
+              "questions": null,
+              "prompt": null,
+              "maxWords": null,
+              "amount": null,
+              "network": null,
+              "idl": null
+            }
+          ]
+        },
+        {
+          "_id": "lesson-deployment",
+          "title": "Deploying Solana Programs",
+          "slug": "deployment",
+          "blocks": [
+            {
+              "key": "intro",
+              "_type": "prose",
+              "produces": null,
+              "consumes": null,
+              "src": "# Deploying Solana Programs\n\nDeploying to Solana is straightforward with Anchor, but there are important considerations for security and upgrades.\n\n## Building Your Program\n\n```bash\nanchor build\n```\n\nThis compiles your program and generates:\n- `target/deploy/my_program.so` - The compiled program\n- `target/idl/my_program.json` - The Interface Definition Language file\n- `target/types/my_program.ts` - TypeScript types for your program\n\n## Deploying to Devnet\n\n1. **Configure your CLI for devnet**:\n\n```bash\nsolana config set --url devnet\n```\n\n2. **Ensure you have SOL**:\n\n```bash\nsolana balance\nsolana airdrop 2  # If needed\n```\n\n3. **Deploy**:\n\n```bash\nanchor deploy\n```\n\nAnchor will:\n- Upload the program binary\n- Create the program account\n- Set you as the upgrade authority\n\n## Understanding Program IDs\n\nYour program ID is declared in `lib.rs`:\n\n```rust\ndeclare_id!(\"YourProgramIDHere\");\n```\n\nThis ID is generated when you run `anchor init` and stored in `target/deploy/my_program-keypair.json`.\n\n**Important**: Once deployed, the program ID is permanent for that deployment. If you want a new ID, you need to create a new keypair.\n\n## The IDL (Interface Definition Language)\n\nThe IDL is a JSON file describing your program's interface:\n\n```json\n{\n  \"version\": \"0.1.0\",\n  \"name\": \"my_program\",\n  \"instructions\": [\n    {\n      \"name\": \"initialize\",\n      \"accounts\": [\n        { \"name\": \"myAccount\", \"isMut\": true, \"isSigner\": true },\n        { \"name\": \"user\", \"isMut\": true, \"isSigner\": true },\n        { \"name\": \"systemProgram\", \"isMut\": false, \"isSigner\": false }\n      ],\n      \"args\": []\n    }\n  ],\n  \"accounts\": [\n    {\n      \"name\": \"MyAccount\",\n      \"type\": {\n        \"kind\": \"struct\",\n        \"fields\": [\n          { \"name\": \"data\", \"type\": \"u64\" }\n        ]\n      }\n    }\n  ]\n}\n```\n\nClients use the IDL to interact with your program.\n\n## Uploading the IDL\n\n```bash\nanchor idl init -f target/idl/my_program.json <PROGRAM_ID>\n```\n\nThis stores the IDL on-chain, making it easier for tools like Anchor Explorer to understand your program.\n\nUpdate an existing IDL:\n\n```bash\nanchor idl upgrade -f target/idl/my_program.json <PROGRAM_ID>\n```\n\n## Program Upgrades\n\nSolana programs are **upgradeable** by default. The upgrade authority can replace the program code:\n\n```bash\nanchor upgrade target/deploy/my_program.so --program-id <PROGRAM_ID>\n```\n\n### Checking Upgrade Authority\n\n```bash\nsolana program show <PROGRAM_ID>\n```\n\nOutput:\n```\nProgram Id: YourProgramID\nOwner: BPFLoaderUpgradeab1e11111111111111111111111\nProgramData Address: ...\nAuthority: YourWalletPublicKey\nLast Deployed In Slot: 123456789\nData Length: 200000 bytes\n```\n\n### Transferring Upgrade Authority\n\n```bash\nsolana program set-upgrade-authority <PROGRAM_ID> --new-upgrade-authority <NEW_AUTHORITY>\n```\n\n### Revoking Upgrade Authority (Immutable Program)\n\nFor maximum security, you can make a program **immutable**:\n\n```bash\nsolana program set-upgrade-authority <PROGRAM_ID> --final\n```\n\n**Warning**: This is irreversible! No one can ever upgrade the program again.\n\n## Multisig Upgrade Authority\n\nFor production programs, use a multisig as the upgrade authority:\n\n```bash\n# Create a multisig with Squads Protocol\n# Set multisig as upgrade authority\nsolana program set-upgrade-authority <PROGRAM_ID> --new-upgrade-authority <MULTISIG_ADDRESS>\n```\n\nThis requires multiple team members to approve upgrades.\n\n## Verifiable Builds\n\nVerifiable builds let anyone verify your deployed program matches your source code:\n\n```bash\nanchor build --verifiable\n```\n\nThis builds your program in a Docker container with a deterministic environment.\n\nVerify a deployed program:\n\n```bash\nanchor verify <PROGRAM_ID>\n```\n\n## Deploying to Mainnet\n\n1. **Switch to mainnet**:\n\n```bash\nsolana config set --url mainnet-beta\n```\n\n2. **Fund your wallet** (deploying costs ~2-5 SOL depending on program size)\n\n3. **Audit your code** (get a professional audit for production programs)\n\n4. **Deploy**:\n\n```bash\nanchor deploy\n```\n\n5. **Upload IDL**:\n\n```bash\nanchor idl init -f target/idl/my_program.json <PROGRAM_ID>\n```\n\n6. **Set up multisig authority** or **revoke authority** if appropriate\n\n## Best Practices\n\n1. **Test on devnet first** - Always deploy and test on devnet before mainnet\n2. **Use verifiable builds** - Builds trust with users\n3. **Store keypairs securely** - Never commit `target/deploy/*-keypair.json` to Git\n4. **Plan your upgrade strategy** - Multisig for most cases, immutable for critical infrastructure\n5. **Monitor program accounts** - Track rent, data size, and usage\n6. **Document your IDL** - Add comments to your Rust code; they appear in the IDL\n\n## Common Deployment Issues\n\n### Insufficient SOL\n\n```\nError: Account <PROGRAM_ID> has insufficient funds\n```\n\nSolution: Airdrop more SOL (devnet) or fund your wallet (mainnet)\n\n### Program Already Deployed\n\n```\nError: Program already exists\n```\n\nSolution: Use `anchor upgrade` instead of `anchor deploy`\n\n### Wrong Upgrade Authority\n\n```\nError: Upgrade authority mismatch\n```\n\nSolution: Ensure the wallet you're using matches the upgrade authority\n\n## Next Challenge\n\nYou'll write a test that simulates a program execution scenario.\n",
+              "url": null,
+              "language": null,
+              "buildType": null,
+              "deployable": null,
+              "starter": null,
+              "solution": null,
+              "tests": null,
+              "hints": null,
+              "questions": null,
+              "prompt": null,
+              "maxWords": null,
+              "amount": null,
+              "network": null,
+              "idl": null
+            }
+          ]
+        },
+        {
+          "_id": "lesson-testing-challenge",
+          "title": "Challenge: Test a Transfer Program",
+          "slug": "testing-challenge",
+          "blocks": [
+            {
+              "key": "intro",
+              "_type": "prose",
+              "produces": null,
+              "consumes": null,
+              "src": "# Challenge: Simulate a Transfer Test in Rust\n\nTest-driven development is critical for Solana programs. You'll write a function that simulates a complete transfer test scenario — the same logic you'd verify with `anchor test`.\n\n## Your Task\n\nImplement `simulate_transfer_test(sender_initial, transfer_amount, fee)` that:\n\n1. Checks if sender can afford `transfer_amount + fee`\n2. If yes, computes final balances and returns `\"PASS:sender=<final>,receiver=<final>\"`\n3. If no, returns `\"FAIL:insufficient_funds\"`\n\n**Test constants:**\n- Receiver starts with 0 balance\n- Fee is paid by sender and burned (not added to receiver)\n- The function simulates what an Anchor test's `assert` checks would verify\n\n**This mirrors the Anchor test pattern:**\n```typescript\nit('transfers SOL correctly', async () => {\n  const balanceBefore = await connection.getBalance(sender);\n  await program.methods.transfer(amount).rpc();\n  const balanceAfter = await connection.getBalance(sender);\n  expect(balanceAfter).to.equal(balanceBefore - amount - fee);\n});\n```\n",
+              "url": null,
+              "language": null,
+              "buildType": null,
+              "deployable": null,
+              "starter": null,
+              "solution": null,
+              "tests": null,
+              "hints": null,
+              "questions": null,
+              "prompt": null,
+              "maxWords": null,
+              "amount": null,
+              "network": null,
+              "idl": null
+            },
+            {
+              "key": "exercise",
+              "_type": "code",
+              "produces": null,
+              "consumes": null,
+              "src": null,
+              "url": null,
+              "language": "rust",
+              "buildType": "standard",
+              "deployable": false,
+              "starter": "fn simulate_transfer_test(\n    sender_initial: u64,\n    transfer_amount: u64,\n    fee: u64,\n) -> String {\n    let receiver_initial: u64 = 0;\n\n    // TODO: Check if sender can afford transfer_amount + fee\n\n    // TODO: If yes, compute final balances and return:\n    //   \"PASS:sender=<sender_final>,receiver=<receiver_final>\"\n\n    // TODO: If no, return \"FAIL:insufficient_funds\"\n    todo!()\n}\n",
+              "solution": "fn simulate_transfer_test(\n    sender_initial: u64,\n    transfer_amount: u64,\n    fee: u64,\n) -> String {\n    let receiver_initial: u64 = 0;\n\n    if sender_initial < transfer_amount + fee {\n        return \"FAIL:insufficient_funds\".to_string();\n    }\n\n    let sender_final = sender_initial - transfer_amount - fee;\n    let receiver_final = receiver_initial + transfer_amount;\n\n    format!(\"PASS:sender={},receiver={}\", sender_final, receiver_final)\n}\n",
+              "tests": [
+                {
+                  "id": "t1",
+                  "description": "Exact balances after a successful transfer",
+                  "input": "2_000_000_000, 500_000_000, 5000",
+                  "expectedOutput": "\"PASS:sender=1499995000,receiver=500000000\".to_string()"
+                },
+                {
+                  "id": "t2",
+                  "description": "Insufficient funds fails",
+                  "input": "100, 200, 5000",
+                  "expectedOutput": "\"FAIL:insufficient_funds\".to_string()"
+                },
+                {
+                  "id": "t3",
+                  "description": "Exact balances for a different transfer",
+                  "input": "1000000, 300000, 1000",
+                  "expectedOutput": "\"PASS:sender=699000,receiver=300000\".to_string()"
+                }
+              ],
+              "hints": [
+                "Check if sender_initial >= transfer_amount + fee (use checked_add or just add — small test values won't overflow).",
+                "sender_final = sender_initial - transfer_amount - fee. receiver_final = receiver_initial + transfer_amount.",
+                "Format with: format!(\"PASS:sender={},receiver={}\", sender_final, receiver_final)."
+              ],
+              "questions": null,
+              "prompt": null,
+              "maxWords": null,
+              "amount": null,
+              "network": null,
+              "idl": null
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/apps/web/src/lib/content/__tests__/fixtures/golden/lessons.json
+++ b/apps/web/src/lib/content/__tests__/fixtures/golden/lessons.json
@@ -1,1070 +1,1831 @@
 [
   {
     "_id": "lesson-account-challenge",
+    "title": "Challenge: Explore the Account Model",
+    "slug": "account-challenge",
     "blocks": [
       {
-        "_type": "prose",
-        "amount": null,
-        "buildType": null,
-        "consumes": null,
-        "deployable": null,
-        "hints": null,
-        "idl": null,
         "key": "intro",
-        "language": null,
-        "maxWords": null,
-        "network": null,
+        "_type": "prose",
         "produces": null,
-        "prompt": null,
-        "questions": null,
-        "solution": null,
+        "consumes": null,
         "src": "# Challenge: Explore the Account Model\n\nCreate a function that builds a mock Solana account structure. This will help you understand the key properties every account has.\n\n## Requirements\n\n- Create a function that accepts `owner` (PublicKey), `lamports` (number), `data` (Uint8Array), and `executable` (boolean)\n- Return an object representing an account with these properties\n- The object should also include a `publicKey` (generate a new one) and `rentEpoch` (set to 0 for this mock)\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
         "starter": null,
+        "solution": null,
         "tests": null,
-        "url": null
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       },
       {
+        "key": "exercise",
         "_type": "code",
-        "amount": null,
-        "buildType": "standard",
+        "produces": null,
         "consumes": null,
+        "src": null,
+        "url": null,
+        "language": "typescript",
+        "buildType": "standard",
         "deployable": false,
+        "starter": "import { Keypair, PublicKey } from '@solana/web3.js';\n\nfunction createMockAccount(\n  owner: PublicKey,\n  lamports: number,\n  data: Uint8Array,\n  executable: boolean\n): {\n  publicKey: PublicKey;\n  owner: PublicKey;\n  lamports: number;\n  data: Uint8Array;\n  executable: boolean;\n  rentEpoch: number;\n} {\n  // Your code here\n}\n",
+        "solution": "import { Keypair, PublicKey } from '@solana/web3.js';\n\nfunction createMockAccount(\n  owner: PublicKey,\n  lamports: number,\n  data: Uint8Array,\n  executable: boolean\n): {\n  publicKey: PublicKey;\n  owner: PublicKey;\n  lamports: number;\n  data: Uint8Array;\n  executable: boolean;\n  rentEpoch: number;\n} {\n  return {\n    publicKey: Keypair.generate().publicKey,\n    owner,\n    lamports,\n    data,\n    executable,\n    rentEpoch: 0,\n  };\n}\n",
+        "tests": [
+          {
+            "id": "t1",
+            "description": "Returns an object with all account fields",
+            "input": "owner, 1000000, data, true",
+            "expectedOutput": "'publicKey' in result && 'owner' in result && 'lamports' in result && 'data' in result && 'executable' in result && 'rentEpoch' in result"
+          },
+          {
+            "id": "t2",
+            "description": "lamports reflects the input",
+            "input": "owner, 500000, data, false",
+            "expectedOutput": "typeof result.lamports === 'number' && result.lamports === 500000"
+          },
+          {
+            "id": "t3",
+            "description": "executable reflects the input and rentEpoch is numeric",
+            "input": "owner, 1000000, data, true",
+            "expectedOutput": "result.executable === true && typeof result.rentEpoch === 'number'"
+          },
+          {
+            "id": "t4",
+            "description": "executable and lamports reflect a different input",
+            "input": "owner, 250000, data, false",
+            "expectedOutput": "result.executable === false && result.lamports === 250000"
+          }
+        ],
         "hints": [
           "Use Keypair.generate().publicKey to create a new public key for the account",
           "Simply return an object with all the required fields",
           "The rentEpoch should be set to 0 for this mock exercise"
         ],
-        "idl": null,
-        "key": "exercise",
-        "language": "typescript",
-        "maxWords": null,
-        "network": null,
-        "produces": null,
-        "prompt": null,
         "questions": null,
-        "solution": "import { Keypair, PublicKey } from '@solana/web3.js';\n\nfunction createMockAccount(\n  owner: PublicKey,\n  lamports: number,\n  data: Uint8Array,\n  executable: boolean\n): {\n  publicKey: PublicKey;\n  owner: PublicKey;\n  lamports: number;\n  data: Uint8Array;\n  executable: boolean;\n  rentEpoch: number;\n} {\n  return {\n    publicKey: Keypair.generate().publicKey,\n    owner,\n    lamports,\n    data,\n    executable,\n    rentEpoch: 0,\n  };\n}\n",
-        "src": null,
-        "starter": "import { Keypair, PublicKey } from '@solana/web3.js';\n\nfunction createMockAccount(\n  owner: PublicKey,\n  lamports: number,\n  data: Uint8Array,\n  executable: boolean\n): {\n  publicKey: PublicKey;\n  owner: PublicKey;\n  lamports: number;\n  data: Uint8Array;\n  executable: boolean;\n  rentEpoch: number;\n} {\n  // Your code here\n}\n",
-        "tests": [
-          {
-            "description": "Returns an object with all account fields",
-            "expectedOutput": "'publicKey' in result && 'owner' in result && 'lamports' in result && 'data' in result && 'executable' in result && 'rentEpoch' in result",
-            "id": "t1",
-            "input": "owner, 1000000, data, true"
-          },
-          {
-            "description": "lamports reflects the input",
-            "expectedOutput": "typeof result.lamports === 'number' && result.lamports === 500000",
-            "id": "t2",
-            "input": "owner, 500000, data, false"
-          },
-          {
-            "description": "executable reflects the input and rentEpoch is numeric",
-            "expectedOutput": "result.executable === true && typeof result.rentEpoch === 'number'",
-            "id": "t3",
-            "input": "owner, 1000000, data, true"
-          },
-          {
-            "description": "executable and lamports reflect a different input",
-            "expectedOutput": "result.executable === false && result.lamports === 250000",
-            "id": "t4",
-            "input": "owner, 250000, data, false"
-          }
-        ],
-        "url": null
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       }
-    ],
-    "slug": "account-challenge",
-    "title": "Challenge: Explore the Account Model"
+    ]
   },
   {
     "_id": "lesson-account-model",
+    "title": "Understanding Solana's Account Model",
+    "slug": "account-model",
     "blocks": [
       {
-        "_type": "prose",
-        "amount": null,
-        "buildType": null,
-        "consumes": null,
-        "deployable": null,
-        "hints": null,
-        "idl": null,
         "key": "intro",
-        "language": null,
-        "maxWords": null,
-        "network": null,
+        "_type": "prose",
         "produces": null,
-        "prompt": null,
-        "questions": null,
-        "solution": null,
+        "consumes": null,
         "src": "# Understanding Solana's Account Model\n\nSolana's account model is fundamentally different from Ethereum's contract-based approach. Understanding this model is crucial for building efficient Solana programs.\n\n## Everything is an Account\n\nIn Solana, **everything is an account**. Unlike Ethereum where contracts hold state, Solana separates code (programs) from data (accounts):\n\n- **Programs**: Executable code (stateless)\n- **Accounts**: Store data and SOL balance\n\n```typescript\ninterface Account {\n  publicKey: PublicKey;     // Account address\n  owner: PublicKey;         // Program that owns this account\n  lamports: number;         // SOL balance (1 SOL = 1B lamports)\n  data: Uint8Array;         // Raw account data\n  executable: boolean;      // Is this a program?\n  rentEpoch: number;        // Rent collection tracking\n}\n```\n\n## The Owner-Account Relationship\n\nEvery account has an **owner** (a program). Only the owner program can:\n- Modify the account's data\n- Deduct lamports from the account\n\nFor example:\n- Your wallet is owned by the **System Program**\n- Token accounts are owned by the **Token Program**\n- Your custom program owns its data accounts\n\n```typescript\nconst accountInfo = await connection.getAccountInfo(publicKey);\nconsole.log('Owner:', accountInfo.owner.toBase58());\n// System Program: 11111111111111111111111111111111\n// Token Program: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA\n```\n\n## Rent and Account Lifetime\n\nSolana accounts must maintain a minimum SOL balance to remain active (called **rent exemption**). The required balance depends on the account's data size:\n\n```typescript\nconst rentExemption = await connection.getMinimumBalanceForRentExemption(\n  dataSize // bytes\n);\n```\n\n**Best Practice**: Always create accounts with enough SOL to be rent-exempt. Rent-exempt accounts never expire.\n\n## System Accounts vs Program Accounts\n\n### System Accounts\n- Owned by the System Program (`11111111111111111111111111111111`)\n- Hold SOL but no custom data\n- Your wallet is a system account\n\n### Program Accounts\n- Owned by custom programs\n- Store structured data (game state, user profiles, DeFi positions, etc.)\n- Created via CPI (Cross-Program Invocation) to the System Program\n\n## Real-World Example: Jupiter Aggregator\n\nJupiter, the leading Solana DEX aggregator, uses accounts to store:\n- User token accounts (owned by Token Program)\n- Swap routing data (owned by Jupiter Program)\n- Price feed data (owned by Pyth oracle program)\n\nEach account has a specific owner and purpose, creating a composable ecosystem.\n\n## Key Takeaways\n\n1. Programs are stateless; accounts hold all data\n2. Only the owner program can modify an account's data\n3. Accounts must be rent-exempt to persist\n4. The account model enables Solana's parallel processing\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
         "starter": null,
+        "solution": null,
         "tests": null,
-        "url": null
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "retrieval-close",
+        "_type": "quiz",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": [
+          {
+            "id": "q1",
+            "prompt": "Your custom program tries to directly subtract lamports from a user's wallet (a System Program account). What happens?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "It fails — only the account's owner program (here the System Program) can deduct its lamports or modify its data",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "It succeeds, because any program can modify any account it is passed",
+                "correct": false,
+                "feedback": "Being passed an account grants read access, not write access. Only the owner program may mutate data or debit lamports — this is the core safety invariant."
+              },
+              {
+                "id": "c",
+                "label": "It succeeds only if the account is marked writable",
+                "correct": false,
+                "feedback": "Writable marks intent, but the runtime still enforces ownership: a non-owner cannot debit lamports even on a writable account. The System Program owns wallets."
+              }
+            ],
+            "explanation": "Every account names an owner program, and the runtime lets only that owner mutate the account's data or reduce its lamports. To move SOL out of a wallet you must go through the System Program via a signed transfer, not reach in from another program — this ownership rule is what keeps funds safe."
+          },
+          {
+            "id": "q2",
+            "prompt": "Why must you fund a new account to its 'rent-exempt' minimum when you create it?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "Below the rent-exempt balance the account can be purged; at or above it, the account persists indefinitely",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "Rent is a one-time network fee unrelated to keeping the account alive",
+                "correct": false,
+                "feedback": "Rent-exemption is not a fee for the treasury — it is a balance threshold. Fall below it and the account can be reclaimed; meet it and it never expires."
+              },
+              {
+                "id": "c",
+                "label": "It pays the validator to execute your program faster",
+                "correct": false,
+                "feedback": "Rent-exemption has nothing to do with execution speed. It is the minimum balance, scaled by data size, that keeps the account from being garbage-collected."
+              }
+            ],
+            "explanation": "Solana can reclaim accounts that fall below a size-based minimum balance. Funding to rent-exemption at creation means the account holds enough SOL to persist forever, so your program's state does not silently disappear."
+          }
+        ],
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       }
-    ],
-    "slug": "account-model",
-    "title": "Understanding Solana's Account Model"
+    ]
   },
   {
     "_id": "lesson-amm-challenge",
+    "title": "Challenge: Constant Product AMM",
+    "slug": "amm-challenge",
     "blocks": [
       {
-        "_type": "prose",
-        "amount": null,
-        "buildType": null,
-        "consumes": null,
-        "deployable": null,
-        "hints": null,
-        "idl": null,
         "key": "intro",
-        "language": null,
-        "maxWords": null,
-        "network": null,
+        "_type": "prose",
         "produces": null,
-        "prompt": null,
-        "questions": null,
-        "solution": null,
+        "consumes": null,
         "src": "# Challenge: Constant Product AMM\n\nImplement a constant product AMM with swap, liquidity, and price impact calculations.\n\n## Requirements\n\nImplement three functions:\n\n### 1. `swap(reserveIn, reserveOut, inputAmount, fee)`\n\nCalculate output amount for a swap:\n- Apply fee (e.g., 0.3% means fee = 0.003)\n- Use constant product formula: `x * y = k`\n- Return `{ outputAmount, newReserveIn, newReserveOut, priceImpact }`\n\n### 2. `addLiquidity(reserveA, reserveB, depositA, depositB, totalLPTokens)`\n\nCalculate LP tokens minted:\n- If pool is empty (totalLPTokens === 0), mint `sqrt(depositA * depositB)`\n- Otherwise, mint proportional to deposit: `min(depositA/reserveA, depositB/reserveB) * totalLPTokens`\n- Return `{ lpTokens, finalDepositA, finalDepositB }`\n\n### 3. `calculatePriceImpact(inputAmount, reserveIn, reserveOut)`\n\nCalculate price impact percentage:\n- Spot price: `reserveOut / reserveIn`\n- Execution price: `outputAmount / inputAmount`\n- Price impact: `((executionPrice / spotPrice) - 1) * 100`\n- Return price impact as a percentage (negative value means worse than spot)\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
         "starter": null,
+        "solution": null,
         "tests": null,
-        "url": null
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       },
       {
+        "key": "exercise",
         "_type": "code",
-        "amount": null,
-        "buildType": "standard",
+        "produces": null,
         "consumes": null,
+        "src": null,
+        "url": null,
+        "language": "typescript",
+        "buildType": "standard",
         "deployable": false,
+        "starter": "function swap(reserveIn, reserveOut, inputAmount, fee) {\n  // Apply fee\n  // Calculate output using (x + Δx_after_fee) * (y - Δy) = x * y\n  // Calculate price impact\n  // Return result\n}\n\nfunction addLiquidity(reserveA, reserveB, depositA, depositB, totalLPTokens) {\n  // Calculate LP tokens to mint\n  // Adjust deposits to match pool ratio\n  // Return result\n}\n\nfunction calculatePriceImpact(inputAmount, reserveIn, reserveOut) {\n  // Calculate spot price\n  // Calculate execution price\n  // Return price impact percentage\n}\n",
+        "solution": "function swap(reserveIn, reserveOut, inputAmount, fee) {\n  // Apply fee\n  const inputAfterFee = inputAmount * (1 - fee);\n\n  // Constant product: k = x * y\n  const k = reserveIn * reserveOut;\n\n  // New reserve in\n  const newReserveIn = reserveIn + inputAfterFee;\n\n  // Calculate new reserve out from constant product\n  const newReserveOut = k / newReserveIn;\n\n  // Output amount\n  const outputAmount = reserveOut - newReserveOut;\n\n  // Price impact\n  const spotPrice = reserveOut / reserveIn;\n  const executionPrice = outputAmount / inputAmount;\n  const priceImpact = ((executionPrice / spotPrice) - 1) * 100;\n\n  return {\n    outputAmount,\n    newReserveIn: reserveIn + inputAmount,  // Include fee in reserves\n    newReserveOut,\n    priceImpact,\n  };\n}\n\nfunction addLiquidity(reserveA, reserveB, depositA, depositB, totalLPTokens) {\n  let lpTokens;\n  let finalDepositA = depositA;\n  let finalDepositB = depositB;\n\n  if (totalLPTokens === 0) {\n    // First liquidity provider\n    lpTokens = Math.sqrt(depositA * depositB);\n  } else {\n    // Calculate proportional LP tokens\n    const ratioA = depositA / reserveA;\n    const ratioB = depositB / reserveB;\n\n    // Use minimum ratio to prevent imbalance\n    const ratio = Math.min(ratioA, ratioB);\n    lpTokens = ratio * totalLPTokens;\n\n    // Adjust deposits to match pool ratio\n    finalDepositA = ratio * reserveA;\n    finalDepositB = ratio * reserveB;\n  }\n\n  return {\n    lpTokens,\n    finalDepositA,\n    finalDepositB,\n  };\n}\n\nfunction calculatePriceImpact(inputAmount, reserveIn, reserveOut) {\n  const spotPrice = reserveOut / reserveIn;\n\n  // Calculate output (assuming 0 fee for price impact)\n  const k = reserveIn * reserveOut;\n  const newReserveIn = reserveIn + inputAmount;\n  const newReserveOut = k / newReserveIn;\n  const outputAmount = reserveOut - newReserveOut;\n\n  const executionPrice = outputAmount / inputAmount;\n  const priceImpact = ((executionPrice / spotPrice) - 1) * 100;\n\n  return priceImpact;\n}\n",
+        "tests": [
+          {
+            "id": "t1",
+            "description": "Returns all swap result fields",
+            "input": "1000, 100000, 10, 0.003",
+            "expectedOutput": "'outputAmount' in result && 'newReserveIn' in result && 'newReserveOut' in result && 'priceImpact' in result"
+          },
+          {
+            "id": "t2",
+            "description": "Produces a positive output amount",
+            "input": "1000, 100000, 10, 0.003",
+            "expectedOutput": "typeof result.outputAmount === 'number' && result.outputAmount > 0"
+          },
+          {
+            "id": "t3",
+            "description": "Reserves move in the correct direction",
+            "input": "1000, 100000, 10, 0.003",
+            "expectedOutput": "result.newReserveIn > 1000 && result.newReserveOut < 100000"
+          },
+          {
+            "id": "t4",
+            "description": "Reserves update correctly for a different pool",
+            "input": "2000, 50000, 20, 0.003",
+            "expectedOutput": "result.newReserveIn > 2000 && result.newReserveOut < 50000 && result.outputAmount > 0"
+          }
+        ],
         "hints": [
           "Constant product formula: (reserveIn + inputAfterFee) * (reserveOut - output) = reserveIn * reserveOut",
           "For adding liquidity, calculate ratio for both tokens and use the minimum to prevent imbalance",
           "Use Math.sqrt() for square root calculation in initial LP mint"
         ],
-        "idl": null,
-        "key": "exercise",
-        "language": "typescript",
-        "maxWords": null,
-        "network": null,
-        "produces": null,
-        "prompt": null,
         "questions": null,
-        "solution": "function swap(reserveIn, reserveOut, inputAmount, fee) {\n  // Apply fee\n  const inputAfterFee = inputAmount * (1 - fee);\n\n  // Constant product: k = x * y\n  const k = reserveIn * reserveOut;\n\n  // New reserve in\n  const newReserveIn = reserveIn + inputAfterFee;\n\n  // Calculate new reserve out from constant product\n  const newReserveOut = k / newReserveIn;\n\n  // Output amount\n  const outputAmount = reserveOut - newReserveOut;\n\n  // Price impact\n  const spotPrice = reserveOut / reserveIn;\n  const executionPrice = outputAmount / inputAmount;\n  const priceImpact = ((executionPrice / spotPrice) - 1) * 100;\n\n  return {\n    outputAmount,\n    newReserveIn: reserveIn + inputAmount,  // Include fee in reserves\n    newReserveOut,\n    priceImpact,\n  };\n}\n\nfunction addLiquidity(reserveA, reserveB, depositA, depositB, totalLPTokens) {\n  let lpTokens;\n  let finalDepositA = depositA;\n  let finalDepositB = depositB;\n\n  if (totalLPTokens === 0) {\n    // First liquidity provider\n    lpTokens = Math.sqrt(depositA * depositB);\n  } else {\n    // Calculate proportional LP tokens\n    const ratioA = depositA / reserveA;\n    const ratioB = depositB / reserveB;\n\n    // Use minimum ratio to prevent imbalance\n    const ratio = Math.min(ratioA, ratioB);\n    lpTokens = ratio * totalLPTokens;\n\n    // Adjust deposits to match pool ratio\n    finalDepositA = ratio * reserveA;\n    finalDepositB = ratio * reserveB;\n  }\n\n  return {\n    lpTokens,\n    finalDepositA,\n    finalDepositB,\n  };\n}\n\nfunction calculatePriceImpact(inputAmount, reserveIn, reserveOut) {\n  const spotPrice = reserveOut / reserveIn;\n\n  // Calculate output (assuming 0 fee for price impact)\n  const k = reserveIn * reserveOut;\n  const newReserveIn = reserveIn + inputAmount;\n  const newReserveOut = k / newReserveIn;\n  const outputAmount = reserveOut - newReserveOut;\n\n  const executionPrice = outputAmount / inputAmount;\n  const priceImpact = ((executionPrice / spotPrice) - 1) * 100;\n\n  return priceImpact;\n}\n",
-        "src": null,
-        "starter": "function swap(reserveIn, reserveOut, inputAmount, fee) {\n  // Apply fee\n  // Calculate output using (x + Δx_after_fee) * (y - Δy) = x * y\n  // Calculate price impact\n  // Return result\n}\n\nfunction addLiquidity(reserveA, reserveB, depositA, depositB, totalLPTokens) {\n  // Calculate LP tokens to mint\n  // Adjust deposits to match pool ratio\n  // Return result\n}\n\nfunction calculatePriceImpact(inputAmount, reserveIn, reserveOut) {\n  // Calculate spot price\n  // Calculate execution price\n  // Return price impact percentage\n}\n",
-        "tests": [
-          {
-            "description": "Returns all swap result fields",
-            "expectedOutput": "'outputAmount' in result && 'newReserveIn' in result && 'newReserveOut' in result && 'priceImpact' in result",
-            "id": "t1",
-            "input": "1000, 100000, 10, 0.003"
-          },
-          {
-            "description": "Produces a positive output amount",
-            "expectedOutput": "typeof result.outputAmount === 'number' && result.outputAmount > 0",
-            "id": "t2",
-            "input": "1000, 100000, 10, 0.003"
-          },
-          {
-            "description": "Reserves move in the correct direction",
-            "expectedOutput": "result.newReserveIn > 1000 && result.newReserveOut < 100000",
-            "id": "t3",
-            "input": "1000, 100000, 10, 0.003"
-          },
-          {
-            "description": "Reserves update correctly for a different pool",
-            "expectedOutput": "result.newReserveIn > 2000 && result.newReserveOut < 50000 && result.outputAmount > 0",
-            "id": "t4",
-            "input": "2000, 50000, 20, 0.003"
-          }
-        ],
-        "url": null
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       }
-    ],
-    "slug": "amm-challenge",
-    "title": "Challenge: Constant Product AMM"
+    ]
   },
   {
     "_id": "lesson-amm-concepts",
+    "title": "Automated Market Makers",
+    "slug": "amm-concepts",
     "blocks": [
       {
-        "_type": "prose",
-        "amount": null,
-        "buildType": null,
-        "consumes": null,
-        "deployable": null,
-        "hints": null,
-        "idl": null,
         "key": "intro",
-        "language": null,
-        "maxWords": null,
-        "network": null,
+        "_type": "prose",
         "produces": null,
-        "prompt": null,
-        "questions": null,
-        "solution": null,
+        "consumes": null,
         "src": "# Automated Market Makers (AMMs)\n\nAutomated Market Makers revolutionized DeFi by replacing traditional orderbooks with mathematical formulas. Let's understand how they work.\n\n## The Constant Product Formula\n\nThe most popular AMM design uses the **constant product formula**:\n\n```\nx * y = k\n```\n\nWhere:\n- `x` = reserves of token A\n- `y` = reserves of token B\n- `k` = constant (product of reserves)\n\n### Example\n\n```\nPool: 100 SOL × 10,000 USDC = 1,000,000 (k)\nPrice: 10,000 / 100 = 100 USDC per SOL\n```\n\n## How Swaps Work\n\nWhen someone swaps, they add to one reserve and remove from the other, keeping `k` constant.\n\n**User wants to buy 10 SOL:**\n\n```\nBefore: 100 SOL × 10,000 USDC = 1,000,000\nAfter: 90 SOL × y USDC = 1,000,000\ny = 1,000,000 / 90 = 11,111.11 USDC\n\nUser pays: 11,111.11 - 10,000 = 1,111.11 USDC\nEffective price: 1,111.11 / 10 = 111.11 USDC per SOL\n```\n\nNotice the price increased from 100 to 111.11 - this is **slippage**.\n\n## Slippage\n\nSlippage is the difference between expected and executed price:\n\n```\nExpected price: 100 USDC/SOL\nActual price: 111.11 USDC/SOL\nSlippage: (111.11 - 100) / 100 = 11.11%\n```\n\n**Larger trades = more slippage**. This is why AMMs work best for smaller trades relative to pool size.\n\n## Providing Liquidity\n\nLiquidity providers (LPs) deposit both tokens in proportion to current reserves:\n\n```\nPool: 100 SOL × 10,000 USDC\nLP deposits: 10 SOL + 1,000 USDC\n\nLP share: 10 / (100 + 10) = 9.09%\n```\n\nLPs receive **LP tokens** representing their share. When they withdraw, they burn LP tokens and receive their share of the pool.\n\n### LP Rewards\n\nLPs earn fees from swaps:\n\n```\nSwap fee: 0.3%\nSwap volume: $1,000,000/day\nDaily fees: $3,000\n\nLP with 9.09% share earns: $3,000 × 9.09% = $272.70/day\n```\n\n## Impermanent Loss\n\nImpermanent loss (IL) occurs when token prices diverge.\n\n**Example:**\n\nLP deposits when 1 SOL = 100 USDC:\n- 10 SOL + 1,000 USDC = $2,000 total value\n\nSOL price doubles to 200 USDC:\n- Arbitrageurs rebalance pool\n- New pool: 7.07 SOL × 1,414.21 USDC\n- LP share: 7.07 SOL × 200 USDC = $1,414.21 + $1,414.21 = $2,828.42\n\nIf LP had just held:\n- 10 SOL × 200 = $2,000 + $1,000 = $3,000\n\nImpermanent loss: $3,000 - $2,828.42 = **$171.58 (5.7%)**\n\n### IL Formula\n\n```\nIL = (2 × sqrt(price_ratio)) / (1 + price_ratio) - 1\n\nPrice 2x: IL = 5.7%\nPrice 3x: IL = 13.4%\nPrice 5x: IL = 25.5%\n```\n\nIL is \"impermanent\" because it only realizes if you withdraw. If price returns to original, IL disappears.\n\n## Fee Structures\n\n### Uniswap v2 Style (Raydium Standard Pools)\n\n- **0.3%** swap fee\n- All fees go to LPs\n- Simple, battle-tested\n\n### Uniswap v3 Style (Raydium CLMM, Orca Whirlpools)\n\n- **0.01%, 0.05%, 0.3%, 1%** fee tiers\n- Different tiers for different volatility pairs\n- Stable pairs (USDC/USDT): 0.01%\n- Volatile pairs (SOL/BONK): 1%\n\n## Concentrated Liquidity\n\nStandard AMMs spread liquidity across the entire price curve (0 → ∞). Concentrated liquidity lets LPs choose a range:\n\n```\nStandard AMM: $10,000 spread across $0 - $∞\nConcentrated: $10,000 focused on $95 - $105\n\nResult: In the $95-$105 range, concentrated liquidity acts like $100,000+\n```\n\n### Benefits\n\n- **Capital efficiency**: Same liquidity with less capital\n- **Higher LP rewards**: More fees per dollar\n\n### Risks\n\n- **Out of range**: If price exits your range, you stop earning fees\n- **More IL**: Concentrated positions amplify impermanent loss\n- **Active management**: Need to rebalance ranges\n\n## AMM Variants\n\n### StableSwap (for stablecoins)\n\nRaydium and Orca use StableSwap for USDC/USDT pairs:\n\n```\nA × x × y = k (for prices near 1:1)\n\nResult: Much lower slippage for stable pairs\n```\n\n### Weighted Pools (Balancer Style)\n\nPools with custom weights:\n\n```\n80% SOL / 20% USDC\n\nProvides more SOL exposure with less IL\n```\n\n## Price Impact Calculation\n\nPrice impact is the slippage from your trade:\n\n```javascript\nfunction calculatePriceImpact(inputAmount, reserveIn, reserveOut) {\n  const constantProduct = reserveIn * reserveOut;\n  const newReserveIn = reserveIn + inputAmount;\n  const newReserveOut = constantProduct / newReserveIn;\n  const outputAmount = reserveOut - newReserveOut;\n\n  const executionPrice = inputAmount / outputAmount;\n  const spotPrice = reserveOut / reserveIn;\n\n  const priceImpact = (executionPrice / spotPrice) - 1;\n  return priceImpact * 100; // As percentage\n}\n```\n\n## MEV and AMMs\n\nAMMs are vulnerable to MEV (Maximal Extractable Value):\n\n### Sandwich Attacks\n\n1. Bot sees your large buy order in mempool\n2. Bot front-runs with a buy (pushes price up)\n3. Your transaction executes (at worse price)\n4. Bot back-runs with a sell (profits from price increase)\n\n**Mitigation**: Slippage tolerance, private RPCs (Jito), batch auctions\n\n### Just-in-Time (JIT) Liquidity\n\n1. LP sees large swap incoming\n2. LP adds concentrated liquidity in that block\n3. LP earns most of the swap fee\n4. LP withdraws liquidity immediately\n\nThis is actually beneficial (provides liquidity when needed), but can be seen as unfair to long-term LPs.\n\n## Real-World AMM Strategies\n\n### Passive LP\n\n- Deposit to stable pairs (USDC/USDT)\n- Wide range or full-range\n- Low IL, steady fees\n\n### Active LP\n\n- Concentrated positions on volatile pairs\n- Rebalance ranges frequently\n- Higher risk, higher reward\n\n### Liquidity Mining\n\n- Provide liquidity to incentivized pools\n- Earn swap fees + token rewards\n- Watch for impermanent loss vs. rewards\n\n## Next Challenge\n\nYou'll implement the constant product AMM formula and calculate swaps, liquidity, and price impact.\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
         "starter": null,
+        "solution": null,
         "tests": null,
-        "url": null
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       }
-    ],
-    "slug": "amm-concepts",
-    "title": "Automated Market Makers"
+    ]
   },
   {
     "_id": "lesson-anchor-accounts",
+    "title": "Anchor Account Constraints",
+    "slug": "anchor-accounts",
     "blocks": [
       {
-        "_type": "prose",
-        "amount": null,
-        "buildType": null,
-        "consumes": null,
-        "deployable": null,
-        "hints": null,
-        "idl": null,
         "key": "intro",
-        "language": null,
-        "maxWords": null,
-        "network": null,
+        "_type": "prose",
         "produces": null,
-        "prompt": null,
-        "questions": null,
-        "solution": null,
+        "consumes": null,
         "src": "# Anchor Account Constraints\n\nAnchor's constraint system is one of its most powerful features. Constraints allow you to declaratively specify account validation rules, and Anchor enforces them automatically.\n\n## The #[account] Attribute\n\nThe `#[account(...)]` attribute is used to apply constraints to accounts in your instruction context:\n\n```rust\n#[derive(Accounts)]\npub struct UpdateUserData<'info> {\n    #[account(\n        mut,\n        has_one = authority,\n        constraint = user.data_version < 10 @ ErrorCode::VersionTooHigh\n    )]\n    pub user: Account<'info, UserAccount>,\n    pub authority: Signer<'info>,\n}\n```\n\n## Common Constraints\n\n### 1. init - Initialize a New Account\n\n```rust\n#[account(\n    init,\n    payer = user,\n    space = 8 + 32 + 8\n)]\npub my_account: Account<'info, MyAccount>,\n```\n\n- Allocates space for the account\n- Transfers lamports from payer\n- Assigns account to the program\n- Sets account discriminator\n\n**Space calculation**: `8 (discriminator) + account_data_size`\n\n### 2. mut - Mark Account as Mutable\n\n```rust\n#[account(mut)]\npub user: Account<'info, UserAccount>,\n```\n\nRequires the account to be writable. Anchor will reject the transaction if the account isn't marked as writable.\n\n### 3. has_one - Verify Account Relationship\n\n```rust\n#[account]\npub struct UserAccount {\n    pub authority: Pubkey,\n    pub counter: u64,\n}\n\n#[derive(Accounts)]\npub struct Increment<'info> {\n    #[account(\n        mut,\n        has_one = authority\n    )]\n    pub user: Account<'info, UserAccount>,\n    pub authority: Signer<'info>,\n}\n```\n\n`has_one = authority` checks that `user.authority == authority.key()`. This prevents unauthorized updates.\n\n### 4. seeds & bump - PDA Derivation\n\n```rust\n#[account(\n    init,\n    payer = user,\n    space = 8 + 32 + 8,\n    seeds = [b\"user\", user.key().as_ref()],\n    bump\n)]\npub user_account: Account<'info, UserAccount>,\n```\n\n- `seeds`: The seeds used to derive the PDA\n- `bump`: Anchor finds the canonical bump automatically\n\nYou can also use a saved bump:\n\n```rust\n#[account(\n    mut,\n    seeds = [b\"user\", authority.key().as_ref()],\n    bump = user_account.bump\n)]\npub user_account: Account<'info, UserAccount>,\n```\n\n### 5. constraint - Custom Constraints\n\n```rust\n#[account(\n    mut,\n    constraint = user.balance >= 100 @ ErrorCode::InsufficientFunds,\n    constraint = user.is_active @ ErrorCode::AccountInactive\n)]\npub user: Account<'info, UserAccount>,\n```\n\nCustom constraints let you enforce arbitrary rules. The `@ ErrorCode::...` syntax specifies which error to return if the constraint fails.\n\n## Space Calculation\n\nWhen using `init`, you must specify the account size:\n\n```rust\n#[account]\npub struct UserAccount {\n    pub authority: Pubkey,    // 32 bytes\n    pub counter: u64,         // 8 bytes\n    pub name: String,         // 4 + length (max 32) = 36 bytes\n}\n\n// Space = 8 (discriminator) + 32 + 8 + 36 = 84 bytes\n```\n\n**Common sizes**:\n- Pubkey: 32 bytes\n- u64/i64: 8 bytes\n- u32/i32: 4 bytes\n- bool: 1 byte\n- String: 4 (length prefix) + max_length\n- Vec<T>: 4 (length prefix) + (item_size * max_count)\n\n## Constraint Execution Order\n\nAnchor executes constraints in this order:\n1. `init` / `init_if_needed`\n2. `mut`\n3. `seeds` + `bump`\n4. `has_one`\n5. Custom `constraint`s\n\nThis ensures accounts are properly initialized and validated before your instruction logic runs.\n\n## Next Challenge\n\nYou'll implement account validation logic that mimics Anchor's constraint system.\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
         "starter": null,
+        "solution": null,
         "tests": null,
-        "url": null
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "retrieval-close",
+        "_type": "quiz",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": [
+          {
+            "id": "q1",
+            "prompt": "`has_one = authority` on a `UserAccount` field checks what, and which attack does it stop?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "It checks `user.authority == authority.key()`, blocking a caller from modifying an account they do not own",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "It checks that the account is writable",
+                "correct": false,
+                "feedback": "Writability is `mut`. `has_one = authority` verifies the account's stored `authority` field equals the passed authority account — an authorization check."
+              },
+              {
+                "id": "c",
+                "label": "It checks that the account was created by the System Program",
+                "correct": false,
+                "feedback": "That is not what has_one does. It ties a stored pubkey field to a passed account, preventing unauthorized updates."
+              }
+            ],
+            "explanation": "`has_one = authority` enforces that the account's stored `authority` field matches the `authority` account supplied to the instruction. Without it, anyone could pass someone else's account and update it — the constraint turns a stored relationship into an authorization gate."
+          },
+          {
+            "id": "q2",
+            "prompt": "A constraint reads `constraint = user.balance >= 100 @ ErrorCode::InsufficientFunds`. What does the `@ ErrorCode::...` part control?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "The specific error returned if the constraint is false, so the client learns why validation failed",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "It sets the balance to 100 if the check fails",
+                "correct": false,
+                "feedback": "Constraints validate, they never assign. `@ ErrorCode::...` only names the error returned on failure; it does not change `balance`."
+              },
+              {
+                "id": "c",
+                "label": "It retries the instruction until balance reaches 100",
+                "correct": false,
+                "feedback": "No retry happens. A failed constraint aborts the instruction and returns the named error."
+              }
+            ],
+            "explanation": "A `constraint = <expr>` must hold or the instruction is rejected, and `@ ErrorCode::X` names the error emitted on failure. This lets you attach a specific, client-readable reason to each declarative check rather than a generic failure."
+          }
+        ],
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       }
-    ],
-    "slug": "anchor-accounts",
-    "title": "Anchor Account Constraints"
+    ]
   },
   {
     "_id": "lesson-anchor-accounts-challenge",
+    "title": "Challenge: Account Validation",
+    "slug": "anchor-accounts-challenge",
     "blocks": [
       {
-        "_type": "prose",
-        "amount": null,
-        "buildType": null,
-        "consumes": null,
-        "deployable": null,
-        "hints": null,
-        "idl": null,
         "key": "intro",
-        "language": null,
-        "maxWords": null,
-        "network": null,
+        "_type": "prose",
         "produces": null,
-        "prompt": null,
-        "questions": null,
-        "solution": null,
+        "consumes": null,
         "src": "# Challenge: Simulate Anchor Account Validation in Rust\n\nAnchor's `#[account]` constraints validate accounts automatically. Here you'll implement the same checks manually — this is exactly what Anchor generates under the hood.\n\n## Your Task\n\nImplement `validate_account(account_owner, expected_owner, is_signer, require_signer, is_writable, require_writable)` that performs Anchor-style validation:\n\n1. Check if `account_owner == expected_owner` → if not, return `Err(\"IncorrectProgramId\")`\n2. Check if signer is required but missing → return `Err(\"MissingRequiredSignature\")`\n3. Check if writable is required but missing → return `Err(\"AccountNotWritable\")`\n4. If all pass, return `Ok(\"Valid\")`\n\n**This mirrors these Anchor constraints:**\n- `#[account(owner = expected_owner)]` → ownership check\n- `Signer<'info>` → signer check\n- `#[account(mut)]` → writable check\n\n**Check order matters** — validate in the order listed above (owner → signer → writable).\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
         "starter": null,
+        "solution": null,
         "tests": null,
-        "url": null
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       },
       {
+        "key": "exercise",
         "_type": "code",
-        "amount": null,
-        "buildType": "standard",
+        "produces": null,
         "consumes": null,
+        "src": null,
+        "url": null,
+        "language": "rust",
+        "buildType": "standard",
         "deployable": false,
+        "starter": "fn validate_account(\n    account_owner: &str,\n    expected_owner: &str,\n    is_signer: bool,\n    require_signer: bool,\n    is_writable: bool,\n    require_writable: bool,\n) -> Result<String, String> {\n    // TODO: Check owner matches expected_owner\n    //       -> Err(\"IncorrectProgramId\")\n\n    // TODO: Check signer requirement\n    //       -> Err(\"MissingRequiredSignature\")\n\n    // TODO: Check writable requirement\n    //       -> Err(\"AccountNotWritable\")\n\n    // TODO: All checks passed -> Ok(\"Valid\")\n    todo!()\n}\n",
+        "solution": "fn validate_account(\n    account_owner: &str,\n    expected_owner: &str,\n    is_signer: bool,\n    require_signer: bool,\n    is_writable: bool,\n    require_writable: bool,\n) -> Result<String, String> {\n    if account_owner != expected_owner {\n        return Err(\"IncorrectProgramId\".to_string());\n    }\n    if require_signer && !is_signer {\n        return Err(\"MissingRequiredSignature\".to_string());\n    }\n    if require_writable && !is_writable {\n        return Err(\"AccountNotWritable\".to_string());\n    }\n    Ok(\"Valid\".to_string())\n}\n",
+        "tests": [
+          {
+            "id": "t1",
+            "description": "Valid account passes",
+            "input": "\"programA\", \"programA\", true, true, true, true",
+            "expectedOutput": "__result__.is_ok()"
+          },
+          {
+            "id": "t2",
+            "description": "Wrong owner is rejected",
+            "input": "\"programA\", \"programB\", true, true, true, true",
+            "expectedOutput": "__result__ == Err(\"IncorrectProgramId\".to_string())"
+          },
+          {
+            "id": "t3",
+            "description": "Missing required signer is rejected",
+            "input": "\"programA\", \"programA\", false, true, true, true",
+            "expectedOutput": "__result__ == Err(\"MissingRequiredSignature\".to_string())"
+          },
+          {
+            "id": "t4",
+            "description": "Non-writable when writable is required is rejected",
+            "input": "\"programA\", \"programA\", true, true, false, true",
+            "expectedOutput": "__result__ == Err(\"AccountNotWritable\".to_string())"
+          },
+          {
+            "id": "t5",
+            "description": "Passes when no signer/writable requirements",
+            "input": "\"progX\", \"progX\", true, false, true, false",
+            "expectedOutput": "__result__.is_ok()"
+          }
+        ],
         "hints": [
           "Check owner first: if account_owner != expected_owner { return Err(\"IncorrectProgramId\".to_string()); }",
           "Then check signer: if require_signer && !is_signer { return Err(...); }",
           "Same pattern for writable. If all pass, return Ok(\"Valid\".to_string())."
         ],
-        "idl": null,
-        "key": "exercise",
-        "language": "rust",
-        "maxWords": null,
-        "network": null,
-        "produces": null,
-        "prompt": null,
         "questions": null,
-        "solution": "fn validate_account(\n    account_owner: &str,\n    expected_owner: &str,\n    is_signer: bool,\n    require_signer: bool,\n    is_writable: bool,\n    require_writable: bool,\n) -> Result<String, String> {\n    if account_owner != expected_owner {\n        return Err(\"IncorrectProgramId\".to_string());\n    }\n    if require_signer && !is_signer {\n        return Err(\"MissingRequiredSignature\".to_string());\n    }\n    if require_writable && !is_writable {\n        return Err(\"AccountNotWritable\".to_string());\n    }\n    Ok(\"Valid\".to_string())\n}\n",
-        "src": null,
-        "starter": "fn validate_account(\n    account_owner: &str,\n    expected_owner: &str,\n    is_signer: bool,\n    require_signer: bool,\n    is_writable: bool,\n    require_writable: bool,\n) -> Result<String, String> {\n    // TODO: Check owner matches expected_owner\n    //       -> Err(\"IncorrectProgramId\")\n\n    // TODO: Check signer requirement\n    //       -> Err(\"MissingRequiredSignature\")\n\n    // TODO: Check writable requirement\n    //       -> Err(\"AccountNotWritable\")\n\n    // TODO: All checks passed -> Ok(\"Valid\")\n    todo!()\n}\n",
-        "tests": [
-          {
-            "description": "Valid account passes",
-            "expectedOutput": "__result__.is_ok()",
-            "id": "t1",
-            "input": "\"programA\", \"programA\", true, true, true, true"
-          },
-          {
-            "description": "Wrong owner is rejected",
-            "expectedOutput": "__result__ == Err(\"IncorrectProgramId\".to_string())",
-            "id": "t2",
-            "input": "\"programA\", \"programB\", true, true, true, true"
-          },
-          {
-            "description": "Missing required signer is rejected",
-            "expectedOutput": "__result__ == Err(\"MissingRequiredSignature\".to_string())",
-            "id": "t3",
-            "input": "\"programA\", \"programA\", false, true, true, true"
-          },
-          {
-            "description": "Non-writable when writable is required is rejected",
-            "expectedOutput": "__result__ == Err(\"AccountNotWritable\".to_string())",
-            "id": "t4",
-            "input": "\"programA\", \"programA\", true, true, false, true"
-          },
-          {
-            "description": "Passes when no signer/writable requirements",
-            "expectedOutput": "__result__.is_ok()",
-            "id": "t5",
-            "input": "\"progX\", \"progX\", true, false, true, false"
-          }
-        ],
-        "url": null
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       }
-    ],
-    "slug": "anchor-accounts-challenge",
-    "title": "Challenge: Account Validation"
+    ]
   },
   {
     "_id": "lesson-anchor-errors",
+    "title": "Custom Errors in Anchor",
+    "slug": "anchor-errors",
     "blocks": [
       {
-        "_type": "prose",
-        "amount": null,
-        "buildType": null,
-        "consumes": null,
-        "deployable": null,
-        "hints": null,
-        "idl": null,
         "key": "intro",
-        "language": null,
-        "maxWords": null,
-        "network": null,
+        "_type": "prose",
         "produces": null,
-        "prompt": null,
-        "questions": null,
-        "solution": null,
+        "consumes": null,
         "src": "# Custom Errors in Anchor\n\nProperly handling errors is essential for debugging and security. Anchor provides a clean way to define and use custom errors.\n\n## Defining Custom Errors\n\n```rust\nuse anchor_lang::prelude::*;\n\n#[error_code]\npub enum ErrorCode {\n    #[msg(\"Insufficient funds for this operation\")]\n    InsufficientFunds,\n\n    #[msg(\"User is not authorized to perform this action\")]\n    Unauthorized,\n\n    #[msg(\"The provided amount exceeds the maximum allowed\")]\n    AmountTooLarge,\n\n    #[msg(\"Account has already been initialized\")]\n    AlreadyInitialized,\n}\n```\n\nEach error gets:\n- A unique error code (auto-assigned)\n- A human-readable message\n- Integration with Anchor's error handling\n\n## Using the require! Macro\n\nThe `require!` macro is the cleanest way to enforce conditions:\n\n```rust\npub fn transfer(ctx: Context<Transfer>, amount: u64) -> Result<()> {\n    let user_account = &mut ctx.accounts.user;\n\n    // Check balance\n    require!(\n        user_account.balance >= amount,\n        ErrorCode::InsufficientFunds\n    );\n\n    // Check authorization\n    require_keys_eq!(\n        ctx.accounts.authority.key(),\n        user_account.authority,\n        ErrorCode::Unauthorized\n    );\n\n    // Check amount limit\n    require!(\n        amount <= 1_000_000,\n        ErrorCode::AmountTooLarge\n    );\n\n    user_account.balance -= amount;\n    Ok(())\n}\n```\n\n## Anchor's Built-in require! Variants\n\n### require_keys_eq!\n\n```rust\nrequire_keys_eq!(\n    ctx.accounts.user.authority,\n    ctx.accounts.signer.key(),\n    ErrorCode::Unauthorized\n);\n```\n\nCompares two public keys.\n\n### require_keys_neq!\n\n```rust\nrequire_keys_neq!(\n    ctx.accounts.from.key(),\n    ctx.accounts.to.key(),\n    ErrorCode::CannotTransferToSelf\n);\n```\n\nEnsures two keys are different.\n\n### require_gt! / require_gte!\n\n```rust\nrequire_gte!(\n    user.balance,\n    MIN_BALANCE,\n    ErrorCode::BalanceTooLow\n);\n```\n\nNumeric comparisons (gt = greater than, gte = greater than or equal).\n\n## Constraint Errors\n\nConstraints in `#[account(...)]` automatically return errors:\n\n```rust\n#[derive(Accounts)]\npub struct UpdateUser<'info> {\n    #[account(\n        mut,\n        has_one = authority @ ErrorCode::Unauthorized,\n        constraint = user.is_active @ ErrorCode::AccountInactive\n    )]\n    pub user: Account<'info, UserAccount>,\n    pub authority: Signer<'info>,\n}\n```\n\nIf `has_one` or `constraint` fails, Anchor returns your custom error.\n\n## Error Handling in TypeScript Tests\n\nAnchor errors are automatically parsed in TypeScript:\n\n```typescript\ntry {\n  await program.methods\n    .transfer(new anchor.BN(10000))\n    .accounts({ user: userPDA })\n    .rpc();\n\n  throw new Error('Should have failed');\n} catch (err) {\n  // Anchor error structure\n  expect(err.error.errorCode.code).to.equal('InsufficientFunds');\n  expect(err.error.errorCode.number).to.equal(6000); // First custom error\n  expect(err.error.errorMessage).to.include('Insufficient funds');\n}\n```\n\n## Error Codes\n\nAnchor assigns error codes starting at **6000**:\n\n```rust\n#[error_code]\npub enum ErrorCode {\n    InsufficientFunds,    // 6000\n    Unauthorized,         // 6001\n    AmountTooLarge,       // 6002\n}\n```\n\nYou can also manually assign codes:\n\n```rust\n#[error_code]\npub enum ErrorCode {\n    #[msg(\"Insufficient funds\")]\n    InsufficientFunds = 7000,\n}\n```\n\n## Anchor's Built-in Errors\n\nAnchor provides common errors automatically:\n\n- `ErrorCode::ConstraintMut` - Account not marked as mutable\n- `ErrorCode::ConstraintHasOne` - has_one constraint failed\n- `ErrorCode::ConstraintSigner` - Account not a signer\n- `ErrorCode::ConstraintRaw` - Generic constraint failed\n- `ErrorCode::AccountNotInitialized` - Account data is empty\n- `ErrorCode::AccountOwnedByWrongProgram` - Account owned by wrong program\n\n## Best Practices\n\n### 1. Be Specific\n\n```rust\n// BAD: Vague error\n#[msg(\"Invalid input\")]\nInvalidInput,\n\n// GOOD: Specific error\n#[msg(\"Amount must be between 1 and 1,000,000 lamports\")]\nAmountOutOfRange,\n```\n\n### 2. Use Constraints Where Possible\n\nInstead of:\n\n```rust\npub fn update(ctx: Context<Update>) -> Result<()> {\n    require!(\n        ctx.accounts.user.authority == ctx.accounts.signer.key(),\n        ErrorCode::Unauthorized\n    );\n    // ...\n}\n```\n\nUse:\n\n```rust\n#[derive(Accounts)]\npub struct Update<'info> {\n    #[account(\n        mut,\n        has_one = authority @ ErrorCode::Unauthorized\n    )]\n    pub user: Account<'info, UserAccount>,\n    pub authority: Signer<'info>,\n}\n```\n\n### 3. Log Context for Debugging\n\n```rust\nrequire!(\n    amount > 0,\n    ErrorCode::AmountMustBePositive\n);\n\nmsg!(\"Transferring {} lamports\", amount);\n```\n\nUse `msg!()` to log values for debugging.\n\n## Matching Errors in Integration Tests\n\n```typescript\nconst expectError = async (fn, errorCode) => {\n  try {\n    await fn();\n    throw new Error(`Expected ${errorCode} error`);\n  } catch (err) {\n    expect(err.error.errorCode.code).to.equal(errorCode);\n  }\n};\n\nawait expectError(\n  () => program.methods.transfer(tooMuch).rpc(),\n  'InsufficientFunds'\n);\n```\n\n## Next Lesson\n\nYou'll learn how to deploy Anchor programs to devnet and mainnet.\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
         "starter": null,
+        "solution": null,
         "tests": null,
-        "url": null
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       }
-    ],
-    "slug": "anchor-errors",
-    "title": "Custom Errors in Anchor"
+    ]
   },
   {
     "_id": "lesson-anchor-intro",
+    "title": "What is the Anchor Framework?",
+    "slug": "anchor-intro",
     "blocks": [
       {
-        "_type": "prose",
-        "amount": null,
-        "buildType": null,
-        "consumes": null,
-        "deployable": null,
-        "hints": null,
-        "idl": null,
         "key": "intro",
-        "language": null,
-        "maxWords": null,
-        "network": null,
+        "_type": "prose",
         "produces": null,
-        "prompt": null,
-        "questions": null,
-        "solution": null,
-        "src": "# What is the Anchor Framework?\n\nAnchor is the most popular framework for Solana smart contract development. It provides a Rust-based DSL (domain-specific language) that dramatically reduces boilerplate and makes programs safer, faster to write, and easier to read.\n\n## Why Use Anchor?\n\nWriting native Solana programs in Rust requires:\n- Manual account deserialization and validation\n- Verbose error handling\n- Security checks spread across your code\n- Repetitive boilerplate for common patterns\n\nAnchor handles all of this for you through **macros** and **attributes**.\n\n### Native Solana Program\n\n```rust\n// Manual account deserialization\nlet account_info_iter = &mut accounts.iter();\nlet user_account = next_account_info(account_info_iter)?;\n\n// Manual validation\nif !user_account.is_writable {\n    return Err(ProgramError::InvalidAccountData);\n}\n\n// Manual owner check\nif user_account.owner != program_id {\n    return Err(ProgramError::IncorrectProgramId);\n}\n```\n\n### Anchor Program\n\n```rust\n#[derive(Accounts)]\npub struct UpdateUser<'info> {\n    #[account(mut)]\n    pub user: Account<'info, UserAccount>,\n}\n```\n\nAnchor automatically validates that the account is writable and owned by the program!\n\n## Anchor Project Structure\n\nA typical Anchor project:\n\n```\nmy-anchor-project/\n├── programs/\n│   └── my-program/\n│       └── src/\n│           └── lib.rs      # Your program code\n├── tests/\n│   └── my-program.ts       # TypeScript tests\n├── migrations/\n│   └── deploy.ts           # Deployment scripts\n└── Anchor.toml             # Configuration\n```\n\n## Key Anchor Components\n\n### 1. Program Module\n\n```rust\nuse anchor_lang::prelude::*;\n\ndeclare_id!(\"YourProgramIDHere\");\n\n#[program]\npub mod my_program {\n    use super::*;\n\n    pub fn initialize(ctx: Context<Initialize>) -> Result<()> {\n        // Your logic here\n        Ok(())\n    }\n}\n```\n\nThe `#[program]` macro defines your program's instruction handlers.\n\n### 2. Accounts Struct\n\n```rust\n#[derive(Accounts)]\npub struct Initialize<'info> {\n    #[account(\n        init,\n        payer = user,\n        space = 8 + 32 + 8\n    )]\n    pub my_account: Account<'info, MyAccount>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n    pub system_program: Program<'info, System>,\n}\n```\n\nAccounts structs define what accounts your instruction needs and how to validate them.\n\n### 3. Account Data\n\n```rust\n#[account]\npub struct MyAccount {\n    pub authority: Pubkey,\n    pub counter: u64,\n}\n```\n\nThe `#[account]` macro adds serialization/deserialization and a discriminator for account type safety.\n\n## Anchor vs Native: Security Benefits\n\n| Security Check | Native | Anchor |\n|----------------|--------|--------|\n| Account ownership | Manual check | Automatic via Account<'info, T> |\n| Signer verification | Manual check | Automatic via Signer<'info> |\n| Writable validation | Manual check | Automatic via #[account(mut)] |\n| Account initialization | Manual allocation | Automatic via #[account(init)] |\n| Discriminator (type safety) | None | Automatic 8-byte discriminator |\n\nAnchor programs are **harder to exploit** because common security pitfalls are prevented by the framework itself.\n\n## Next Steps\n\nIn the next challenge, you'll build a mock Anchor program structure to understand how programs are organized on Solana.\n",
+        "consumes": null,
+        "src": "# What is the Anchor Framework?\n\nAnchor is the most popular framework for Solana smart contract development. It provides a Rust-based DSL (domain-specific language) that dramatically reduces boilerplate and makes programs safer, faster to write, and easier to read.\n\n## Who This Course Is For\n\nThis course is aimed at JavaScript and TypeScript developers moving into Solana — **no Solidity or prior smart-contract experience is assumed.** If you can write JS/TS, you have enough to start; the Rust and Anchor concepts you need are introduced from the ground up as they come up. You do not have to \"learn Ethereum first\" to build here.\n\n## Why Use Anchor?\n\nWriting native Solana programs in Rust requires:\n- Manual account deserialization and validation\n- Verbose error handling\n- Security checks spread across your code\n- Repetitive boilerplate for common patterns\n\nAnchor handles all of this for you through **macros** and **attributes**.\n\n### Native Solana Program\n\n```rust\n// Manual account deserialization\nlet account_info_iter = &mut accounts.iter();\nlet user_account = next_account_info(account_info_iter)?;\n\n// Manual validation\nif !user_account.is_writable {\n    return Err(ProgramError::InvalidAccountData);\n}\n\n// Manual owner check\nif user_account.owner != program_id {\n    return Err(ProgramError::IncorrectProgramId);\n}\n```\n\n### Anchor Program\n\n```rust\n#[derive(Accounts)]\npub struct UpdateUser<'info> {\n    #[account(mut)]\n    pub user: Account<'info, UserAccount>,\n}\n```\n\nAnchor automatically validates that the account is writable and owned by the program!\n\n## Anchor Project Structure\n\nA typical Anchor project:\n\n```\nmy-anchor-project/\n├── programs/\n│   └── my-program/\n│       └── src/\n│           └── lib.rs      # Your program code\n├── tests/\n│   └── my-program.ts       # TypeScript tests\n├── migrations/\n│   └── deploy.ts           # Deployment scripts\n└── Anchor.toml             # Configuration\n```\n\n## Key Anchor Components\n\n### 1. Program Module\n\n```rust\nuse anchor_lang::prelude::*;\n\ndeclare_id!(\"YourProgramIDHere\");\n\n#[program]\npub mod my_program {\n    use super::*;\n\n    pub fn initialize(ctx: Context<Initialize>) -> Result<()> {\n        // Your logic here\n        Ok(())\n    }\n}\n```\n\nThe `#[program]` macro defines your program's instruction handlers.\n\n### 2. Accounts Struct\n\n```rust\n#[derive(Accounts)]\npub struct Initialize<'info> {\n    #[account(\n        init,\n        payer = user,\n        space = 8 + 32 + 8\n    )]\n    pub my_account: Account<'info, MyAccount>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n    pub system_program: Program<'info, System>,\n}\n```\n\nAccounts structs define what accounts your instruction needs and how to validate them.\n\n### 3. Account Data\n\n```rust\n#[account]\npub struct MyAccount {\n    pub authority: Pubkey,\n    pub counter: u64,\n}\n```\n\nThe `#[account]` macro adds serialization/deserialization and a discriminator for account type safety.\n\n## Anchor vs Native: Security Benefits\n\n| Security Check | Native | Anchor |\n|----------------|--------|--------|\n| Account ownership | Manual check | Automatic via Account<'info, T> |\n| Signer verification | Manual check | Automatic via Signer<'info> |\n| Writable validation | Manual check | Automatic via #[account(mut)] |\n| Account initialization | Manual allocation | Automatic via #[account(init)] |\n| Discriminator (type safety) | None | Automatic 8-byte discriminator |\n\nAnchor programs are **harder to exploit** because common security pitfalls are prevented by the framework itself.\n\n## Next Steps\n\nIn the next challenge, you'll build a mock Anchor program structure to understand how programs are organized on Solana.\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
         "starter": null,
+        "solution": null,
         "tests": null,
-        "url": null
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       }
-    ],
-    "slug": "anchor-intro",
-    "title": "What is the Anchor Framework?"
+    ]
   },
   {
     "_id": "lesson-anchor-setup-challenge",
+    "title": "Challenge: Anchor Program Structure",
+    "slug": "anchor-setup-challenge",
     "blocks": [
       {
-        "_type": "prose",
-        "amount": null,
-        "buildType": null,
-        "consumes": null,
-        "deployable": null,
-        "hints": null,
-        "idl": null,
         "key": "intro",
-        "language": null,
-        "maxWords": null,
-        "network": null,
+        "_type": "prose",
         "produces": null,
-        "prompt": null,
-        "questions": null,
-        "solution": null,
+        "consumes": null,
         "src": "# Challenge: Model Anchor Program Structure in Rust\n\nAnchor programs follow a specific pattern: instructions contain account metadata and serialized data. You'll model this structure using Rust structs and enums.\n\n## Your Task\n\nImplement `build_instruction(program_id, user_key, instruction_name)` that constructs an Anchor-style instruction:\n\n1. Encode the instruction name as bytes and compute its length\n2. Build account metadata for two accounts:\n   - User account: signer=true, writable=true\n   - System program (`\"11111111111111111111111111111111\"`): signer=false, writable=false\n3. Return a formatted string: `\"program:<id>,accounts:<count>,data_len:<len>\"`\n\n**This mirrors Anchor's `#[derive(Accounts)]` pattern** where each instruction declares which accounts it needs and how they should be validated.\n\n**Rust Concepts Used:**\n- Structs with boolean fields\n- `Vec` collection\n- String formatting with `format!()`\n- Byte conversion with `.as_bytes()`\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
         "starter": null,
+        "solution": null,
         "tests": null,
-        "url": null
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       },
       {
+        "key": "exercise",
         "_type": "code",
-        "amount": null,
-        "buildType": "standard",
+        "produces": null,
         "consumes": null,
+        "src": null,
+        "url": null,
+        "language": "rust",
+        "buildType": "standard",
         "deployable": false,
+        "starter": "#[derive(Debug)]\nstruct AccountMeta {\n    pubkey: String,\n    is_signer: bool,\n    is_writable: bool,\n}\n\nfn build_instruction(program_id: &str, user_key: &str, instruction_name: &str) -> String {\n    // TODO: Encode instruction_name as bytes and get its length\n\n    // TODO: Build account metas Vec with 2 entries:\n    //   - user_key: signer=true, writable=true\n    //   - system program: signer=false, writable=false\n\n    // TODO: Return \"program:<id>,accounts:<count>,data_len:<len>\"\n    todo!()\n}\n",
+        "solution": "#[derive(Debug)]\nstruct AccountMeta {\n    pubkey: String,\n    is_signer: bool,\n    is_writable: bool,\n}\n\nfn build_instruction(program_id: &str, user_key: &str, instruction_name: &str) -> String {\n    let data_len = instruction_name.as_bytes().len();\n\n    let accounts = vec![\n        AccountMeta {\n            pubkey: user_key.to_string(),\n            is_signer: true,\n            is_writable: true,\n        },\n        AccountMeta {\n            pubkey: \"11111111111111111111111111111111\".to_string(),\n            is_signer: false,\n            is_writable: false,\n        },\n    ];\n\n    format!(\"program:{},accounts:{},data_len:{}\", program_id, accounts.len(), data_len)\n}\n",
+        "tests": [
+          {
+            "id": "t1",
+            "description": "Includes the account count",
+            "input": "\"progXYZ\", \"userABC\", \"initialize\"",
+            "expectedOutput": "__result__.contains(\"accounts:2\")"
+          },
+          {
+            "id": "t2",
+            "description": "Includes the instruction data length",
+            "input": "\"progXYZ\", \"userABC\", \"initialize\"",
+            "expectedOutput": "__result__.contains(\"data_len:10\")"
+          },
+          {
+            "id": "t3",
+            "description": "Starts with the program id",
+            "input": "\"progXYZ\", \"userABC\", \"initialize\"",
+            "expectedOutput": "__result__.starts_with(\"program:progXYZ\")"
+          },
+          {
+            "id": "t4",
+            "description": "Exact output for a different instruction",
+            "input": "\"myProg\", \"user1\", \"mint\"",
+            "expectedOutput": "\"program:myProg,accounts:2,data_len:4\".to_string()"
+          }
+        ],
         "hints": [
           "Get instruction data length with instruction_name.as_bytes().len().",
           "Create two AccountMeta structs in a Vec: one for the user (signer + writable) and one for the system program (neither).",
           "Return format!(\"program:{},accounts:{},data_len:{}\", program_id, accounts.len(), data_len)."
         ],
-        "idl": null,
-        "key": "exercise",
-        "language": "rust",
-        "maxWords": null,
-        "network": null,
-        "produces": null,
-        "prompt": null,
         "questions": null,
-        "solution": "#[derive(Debug)]\nstruct AccountMeta {\n    pubkey: String,\n    is_signer: bool,\n    is_writable: bool,\n}\n\nfn build_instruction(program_id: &str, user_key: &str, instruction_name: &str) -> String {\n    let data_len = instruction_name.as_bytes().len();\n\n    let accounts = vec![\n        AccountMeta {\n            pubkey: user_key.to_string(),\n            is_signer: true,\n            is_writable: true,\n        },\n        AccountMeta {\n            pubkey: \"11111111111111111111111111111111\".to_string(),\n            is_signer: false,\n            is_writable: false,\n        },\n    ];\n\n    format!(\"program:{},accounts:{},data_len:{}\", program_id, accounts.len(), data_len)\n}\n",
-        "src": null,
-        "starter": "#[derive(Debug)]\nstruct AccountMeta {\n    pubkey: String,\n    is_signer: bool,\n    is_writable: bool,\n}\n\nfn build_instruction(program_id: &str, user_key: &str, instruction_name: &str) -> String {\n    // TODO: Encode instruction_name as bytes and get its length\n\n    // TODO: Build account metas Vec with 2 entries:\n    //   - user_key: signer=true, writable=true\n    //   - system program: signer=false, writable=false\n\n    // TODO: Return \"program:<id>,accounts:<count>,data_len:<len>\"\n    todo!()\n}\n",
-        "tests": [
-          {
-            "description": "Includes the account count",
-            "expectedOutput": "__result__.contains(\"accounts:2\")",
-            "id": "t1",
-            "input": "\"progXYZ\", \"userABC\", \"initialize\""
-          },
-          {
-            "description": "Includes the instruction data length",
-            "expectedOutput": "__result__.contains(\"data_len:10\")",
-            "id": "t2",
-            "input": "\"progXYZ\", \"userABC\", \"initialize\""
-          },
-          {
-            "description": "Starts with the program id",
-            "expectedOutput": "__result__.starts_with(\"program:progXYZ\")",
-            "id": "t3",
-            "input": "\"progXYZ\", \"userABC\", \"initialize\""
-          },
-          {
-            "description": "Exact output for a different instruction",
-            "expectedOutput": "\"program:myProg,accounts:2,data_len:4\".to_string()",
-            "id": "t4",
-            "input": "\"myProg\", \"user1\", \"mint\""
-          }
-        ],
-        "url": null
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       }
-    ],
-    "slug": "anchor-setup-challenge",
-    "title": "Challenge: Anchor Program Structure"
+    ]
   },
   {
     "_id": "lesson-anchor-testing",
+    "title": "Testing Anchor Programs",
+    "slug": "anchor-testing",
     "blocks": [
       {
-        "_type": "prose",
-        "amount": null,
-        "buildType": null,
-        "consumes": null,
-        "deployable": null,
-        "hints": null,
-        "idl": null,
         "key": "intro",
-        "language": null,
-        "maxWords": null,
-        "network": null,
+        "_type": "prose",
         "produces": null,
-        "prompt": null,
-        "questions": null,
-        "solution": null,
+        "consumes": null,
         "src": "# Testing Anchor Programs\n\nTesting is critical for Solana programs. Bugs in smart contracts can lead to loss of funds, so comprehensive testing is non-negotiable.\n\n## Anchor Test Setup\n\nAnchor projects come with a `tests/` folder and pre-configured testing:\n\n```bash\nanchor test\n```\n\nThis command:\n1. Builds your program\n2. Deploys to a local validator\n3. Runs your TypeScript tests\n4. Shuts down the validator\n\n## Basic Test Structure\n\n```typescript\nimport * as anchor from '@coral-xyz/anchor';\nimport { Program } from '@coral-xyz/anchor';\nimport { MyProgram } from '../target/types/my_program';\nimport { expect } from 'chai';\n\ndescribe('my-program', () => {\n  const provider = anchor.AnchorProvider.env();\n  anchor.setProvider(provider);\n\n  const program = anchor.workspace.MyProgram as Program<MyProgram>;\n\n  it('Initializes the program', async () => {\n    const myAccount = anchor.web3.Keypair.generate();\n\n    await program.methods\n      .initialize()\n      .accounts({\n        myAccount: myAccount.publicKey,\n        user: provider.wallet.publicKey,\n        systemProgram: anchor.web3.SystemProgram.programId,\n      })\n      .signers([myAccount])\n      .rpc();\n\n    const account = await program.account.myAccount.fetch(\n      myAccount.publicKey\n    );\n\n    expect(account.data.toNumber()).to.equal(0);\n  });\n});\n```\n\n## Bankrun: Fast Local Testing\n\nBankrun is a lightweight Solana test validator that runs in-process:\n\n```typescript\nimport { BankrunProvider } from 'anchor-bankrun';\nimport { startAnchor } from 'solana-bankrun';\n\ndescribe('fast tests', () => {\n  let context;\n  let provider;\n  let program;\n\n  before(async () => {\n    context = await startAnchor(\n      '',\n      [{ name: 'my_program', programId: PROGRAM_ID }],\n      []\n    );\n\n    provider = new BankrunProvider(context);\n    program = new Program<MyProgram>(IDL, provider);\n  });\n\n  it('runs 10x faster', async () => {\n    // Your test\n  });\n});\n```\n\nBankrun is **much faster** than spinning up a full validator for each test.\n\n## Testing Patterns\n\n### 1. Test Fixtures\n\n```typescript\nconst createUser = async () => {\n  const user = anchor.web3.Keypair.generate();\n\n  // Airdrop SOL\n  await provider.connection.requestAirdrop(\n    user.publicKey,\n    2 * anchor.web3.LAMPORTS_PER_SOL\n  );\n\n  return user;\n};\n\nconst createTokenAccount = async (owner, mint) => {\n  // Create token account for testing\n};\n```\n\n### 2. Account Assertions\n\n```typescript\nconst account = await program.account.userAccount.fetch(userPDA);\n\nexpect(account.authority.toBase58()).to.equal(\n  user.publicKey.toBase58()\n);\nexpect(account.balance.toNumber()).to.equal(1000);\nexpect(account.isActive).to.be.true;\n```\n\n### 3. Error Testing\n\n```typescript\ntry {\n  await program.methods\n    .withdraw(new anchor.BN(10000))\n    .accounts({ user: userPDA })\n    .rpc();\n\n  // Should not reach here\n  expect.fail('Expected error was not thrown');\n} catch (err) {\n  expect(err.error.errorCode.code).to.equal('InsufficientFunds');\n}\n```\n\n### 4. Event Testing\n\nAnchor can emit events:\n\n```rust\n#[event]\npub struct TransferEvent {\n    pub from: Pubkey,\n    pub to: Pubkey,\n    pub amount: u64,\n}\n\nemit!(TransferEvent {\n    from: ctx.accounts.from.key(),\n    to: ctx.accounts.to.key(),\n    amount,\n});\n```\n\nTest events:\n\n```typescript\nconst listener = program.addEventListener('TransferEvent', (event) => {\n  console.log('Transfer:', event);\n  expect(event.amount.toNumber()).to.equal(100);\n});\n\nawait program.methods.transfer(new anchor.BN(100)).rpc();\n\nprogram.removeEventListener(listener);\n```\n\n## Test Organization\n\n```\ntests/\n├── setup.ts              # Shared setup logic\n├── fixtures.ts           # Test data generators\n├── initialize.test.ts    # Initialization tests\n├── transfer.test.ts      # Transfer logic tests\n└── errors.test.ts        # Error condition tests\n```\n\n## Mocking Accounts\n\nFor unit-testing complex logic:\n\n```typescript\nconst mockAccount = {\n  authority: user.publicKey,\n  balance: new anchor.BN(1000),\n  lastUpdate: new anchor.BN(Date.now() / 1000),\n};\n\n// Serialize and write to test validator\nconst accountData = program.coder.accounts.encode(\n  'UserAccount',\n  mockAccount\n);\n```\n\n## Best Practices\n\n1. **Test happy path first**, then edge cases\n2. **Test all error conditions** (unauthorized access, insufficient funds, etc.)\n3. **Use descriptive test names**: `it('rejects withdrawal when balance is insufficient')`\n4. **Clean up state** between tests (or use Bankrun snapshots)\n5. **Test with realistic data** (not just 0s and 1s)\n6. **Measure code coverage** (use `solana-program-test` for Rust unit tests)\n\n## Continuous Integration\n\n```yaml\n# .github/workflows/test.yml\nname: Test\n\non: [push, pull_request]\n\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/checkout@v3\n      - uses: actions/setup-node@v3\n      - name: Install Solana\n        run: sh -c \"$(curl -sSfL https://release.anza.xyz/stable/install)\"\n      - name: Install Anchor\n        run: cargo install --git https://github.com/coral-xyz/anchor avm --force\n      - name: Run tests\n        run: anchor test\n```\n\n## Next Lesson\n\nYou'll learn how to define custom errors in Anchor programs.\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
         "starter": null,
+        "solution": null,
         "tests": null,
-        "url": null
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       }
-    ],
-    "slug": "anchor-testing",
-    "title": "Testing Anchor Programs"
+    ]
   },
   {
     "_id": "lesson-balance-checker-challenge",
+    "title": "Challenge: Multi-Wallet Balance Checker",
+    "slug": "balance-checker-challenge",
     "blocks": [
       {
-        "_type": "prose",
-        "amount": null,
-        "buildType": null,
-        "consumes": null,
-        "deployable": null,
-        "hints": null,
-        "idl": null,
         "key": "intro",
-        "language": null,
-        "maxWords": null,
-        "network": null,
+        "_type": "prose",
         "produces": null,
-        "prompt": null,
-        "questions": null,
-        "solution": null,
+        "consumes": null,
         "src": "# Challenge: Multi-Wallet Balance Checker\n\nBuild a function that checks the SOL balance of multiple wallets and returns formatted results.\n\n## Requirements\n\n- Create an async function that accepts a `Connection` and an array of `PublicKey` objects\n- For each wallet, fetch the balance using `connection.getBalance()`\n- Convert lamports to SOL (divide by `LAMPORTS_PER_SOL`)\n- Return an array of objects with `publicKey` (base58 string) and `balanceInSol` (number, rounded to 4 decimals)\n- Use `Promise.all()` to fetch all balances in parallel\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
         "starter": null,
+        "solution": null,
         "tests": null,
-        "url": null
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       },
       {
+        "key": "exercise",
         "_type": "code",
-        "amount": null,
-        "buildType": "standard",
+        "produces": null,
         "consumes": null,
+        "src": null,
+        "url": null,
+        "language": "typescript",
+        "buildType": "standard",
         "deployable": false,
+        "starter": "import { Connection, PublicKey, LAMPORTS_PER_SOL } from '@solana/web3.js';\n\ninterface WalletBalance {\n  publicKey: string;\n  balanceInSol: number;\n}\n\nasync function checkMultipleBalances(\n  connection: Connection,\n  wallets: PublicKey[]\n): Promise<WalletBalance[]> {\n  // Your code here\n}\n",
+        "solution": "import { Connection, PublicKey, LAMPORTS_PER_SOL } from '@solana/web3.js';\n\ninterface WalletBalance {\n  publicKey: string;\n  balanceInSol: number;\n}\n\nasync function checkMultipleBalances(\n  connection: Connection,\n  wallets: PublicKey[]\n): Promise<WalletBalance[]> {\n  const balancePromises = wallets.map(async (wallet) => {\n    const lamports = await connection.getBalance(wallet);\n    const balanceInSol = parseFloat((lamports / LAMPORTS_PER_SOL).toFixed(4));\n    \n    return {\n      publicKey: wallet.toBase58(),\n      balanceInSol,\n    };\n  });\n\n  return Promise.all(balancePromises);\n}\n",
+        "tests": [
+          {
+            "id": "test-1",
+            "description": "Should return array of { publicKey, balanceInSol }",
+            "input": "connection, wallets",
+            "expectedOutput": "Array.isArray(result) && result.length > 0 && typeof result[0].publicKey === 'string' && typeof result[0].balanceInSol === 'number'"
+          },
+          {
+            "id": "test-2",
+            "description": "Balance should be correctly converted from lamports to SOL",
+            "input": "connection, wallets",
+            "expectedOutput": "result[0].balanceInSol === 2"
+          },
+          {
+            "id": "test-3",
+            "description": "Should return results for all wallets provided",
+            "input": "connection, wallets",
+            "expectedOutput": "result.length >= 1"
+          }
+        ],
         "hints": [
           "Use Promise.all() to fetch all balances concurrently instead of sequentially",
           "Convert lamports to SOL by dividing by LAMPORTS_PER_SOL, then use .toFixed(4) to round",
           "Map each wallet to a promise that resolves to { publicKey: wallet.toBase58(), balanceInSol: ... }"
         ],
-        "idl": null,
-        "key": "exercise",
-        "language": "typescript",
-        "maxWords": null,
-        "network": null,
-        "produces": null,
-        "prompt": null,
         "questions": null,
-        "solution": "import { Connection, PublicKey, LAMPORTS_PER_SOL } from '@solana/web3.js';\n\ninterface WalletBalance {\n  publicKey: string;\n  balanceInSol: number;\n}\n\nasync function checkMultipleBalances(\n  connection: Connection,\n  wallets: PublicKey[]\n): Promise<WalletBalance[]> {\n  const balancePromises = wallets.map(async (wallet) => {\n    const lamports = await connection.getBalance(wallet);\n    const balanceInSol = parseFloat((lamports / LAMPORTS_PER_SOL).toFixed(4));\n    \n    return {\n      publicKey: wallet.toBase58(),\n      balanceInSol,\n    };\n  });\n\n  return Promise.all(balancePromises);\n}\n",
-        "src": null,
-        "starter": "import { Connection, PublicKey, LAMPORTS_PER_SOL } from '@solana/web3.js';\n\ninterface WalletBalance {\n  publicKey: string;\n  balanceInSol: number;\n}\n\nasync function checkMultipleBalances(\n  connection: Connection,\n  wallets: PublicKey[]\n): Promise<WalletBalance[]> {\n  // Your code here\n}\n",
-        "tests": [
-          {
-            "description": "Should return array of { publicKey, balanceInSol }",
-            "expectedOutput": "Array.isArray(result) && result.length > 0 && typeof result[0].publicKey === 'string' && typeof result[0].balanceInSol === 'number'",
-            "id": "test-1",
-            "input": "connection, wallets"
-          },
-          {
-            "description": "Balance should be correctly converted from lamports to SOL",
-            "expectedOutput": "result[0].balanceInSol === 2",
-            "id": "test-2",
-            "input": "connection, wallets"
-          },
-          {
-            "description": "Should return results for all wallets provided",
-            "expectedOutput": "result.length >= 1",
-            "id": "test-3",
-            "input": "connection, wallets"
-          }
-        ],
-        "url": null
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       }
-    ],
-    "slug": "balance-checker-challenge",
-    "title": "Challenge: Multi-Wallet Balance Checker"
+    ]
   },
   {
     "_id": "lesson-bfsp-account-constraints",
+    "title": "Account Constraints Deep Dive",
+    "slug": "account-constraints-deep-dive",
     "blocks": [
       {
-        "_type": "prose",
-        "amount": null,
-        "buildType": null,
-        "consumes": null,
-        "deployable": null,
-        "hints": null,
-        "idl": null,
         "key": "intro",
-        "language": null,
-        "maxWords": null,
-        "network": null,
+        "_type": "prose",
         "produces": null,
-        "prompt": null,
-        "questions": null,
-        "solution": null,
+        "consumes": null,
         "src": "# Account Constraints Deep Dive\n\nAnchor's account constraints are the guard rails of Solana development. They validate accounts before your instruction logic runs, preventing entire classes of bugs.\n\n## Essential Constraints\n\n### `#[account(init, payer = X, space = N)]`\nCreates a new account. The `payer` funds the rent-exempt deposit. `space` sets the data size in bytes. Can only be used once per account.\n\n### `#[account(mut)]`\nMarks an account as mutable. Required for any account whose data or lamport balance changes. Forgetting `mut` gives you:\n```\nerror: A mut constraint was expected but not found.\n```\n\n### `Signer<'info>`\nThe account must have signed the transaction. Used for authorization — proving the caller owns the account. Signers automatically have their signature verified by the runtime.\n\n### `Program<'info, System>`\nReferences a program account. `System` is the System Program (`11111111...`), which handles account creation and SOL transfers.\n\n## Account Types\n\n| Type | Use Case | Mutable Data? |\n|------|----------|---------------|\n| `Account<'info, T>` | Typed data account | Yes |\n| `Signer<'info>` | Must have signed tx | No data |\n| `SystemAccount<'info>` | Any system-owned account | No |\n| `Program<'info, T>` | A program account | No |\n| `UncheckedAccount<'info>` | No validation (dangerous) | Depends |\n\n## Common Errors\n\n### Missing `system_program`\nIf your instruction creates an account (`init`), you **must** include the System Program:\n```rust\npub system_program: Program<'info, System>,\n```\nWithout it, the compiler error is:\n```\nerror[E0277]: the trait bound `Initialize<'_>: anchor_lang::Accounts<'_>` is not satisfied\n```\n\nThis error is cryptic because Anchor generates the account validation code via macros. The fix is always: add the missing account.\n\n### Missing `mut` on payer\nThe payer's balance decreases (pays rent), so it must be `#[account(mut)]`:\n```rust\n#[account(mut)]\npub user: Signer<'info>,\n```\n\n### Wrong `space` calculation\nIf `space` is too small, the account can't hold your data. If too large, the payer overpays for rent. Always calculate: `8 (discriminator) + field sizes`.\n\n## In the Next Challenge\n\nYou'll encounter a deliberate compiler error — a program with a missing account. Your job is to read the error output and fix it.\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
         "starter": null,
+        "solution": null,
         "tests": null,
-        "url": null
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "retrieval-close",
+        "_type": "quiz",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": [
+          {
+            "id": "q1",
+            "prompt": "You mark the payer account as `Signer<'info>` but forget `#[account(mut)]`. The instruction uses `init` to create a new account funded by that payer. What happens?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "Compile error — the payer's lamports decrease to fund the rent, so it must be declared mutable",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "It works, because `Signer` already implies mutable",
+                "correct": false,
+                "feedback": "`Signer` proves the account signed; it says nothing about mutability. A payer's balance drops, so it needs `#[account(mut)]` on top."
+              },
+              {
+                "id": "c",
+                "label": "It works, but the rent is silently paid by the program",
+                "correct": false,
+                "feedback": "Programs do not pay rent for you. The declared payer's lamports fund it, which is exactly why the payer must be `mut`."
+              }
+            ],
+            "explanation": "Constraints validate accounts before your logic runs. `init` with `payer = user` reduces the user's lamports, and any account whose lamports or data change must be `#[account(mut)]` — otherwise Anchor emits 'a mut constraint was expected but not found.'"
+          },
+          {
+            "id": "q2",
+            "prompt": "Why does an instruction that uses `#[account(init)]` also require `system_program: Program<'info, System>` in its accounts struct?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "Creating an account is a CPI to the System Program, so it must be present for Anchor's generated code to make that call",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "It is only needed to transfer SOL, not to create accounts",
+                "correct": false,
+                "feedback": "Account creation itself is a System Program instruction. `init` generates a `create_account` CPI, so the System Program must be in the struct."
+              },
+              {
+                "id": "c",
+                "label": "It documents intent but Anchor injects it automatically",
+                "correct": false,
+                "feedback": "Anchor does not inject it — you must declare it. Omitting it produces a cryptic trait-bound error on the accounts struct."
+              }
+            ],
+            "explanation": "New accounts are allocated by the System Program, so `init` expands into a `create_account` CPI that needs the System Program in the accounts struct. Leaving it out fails the `Accounts` trait bound at compile time — the fix is always to add the missing account."
+          }
+        ],
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       }
-    ],
-    "slug": "account-constraints-deep-dive",
-    "title": "Account Constraints Deep Dive"
+    ]
   },
   {
     "_id": "lesson-bfsp-add-instruction",
+    "title": "Add an Instruction",
+    "slug": "add-instruction",
     "blocks": [
       {
-        "_type": "prose",
-        "amount": null,
-        "buildType": null,
-        "consumes": null,
-        "deployable": null,
-        "hints": null,
-        "idl": null,
         "key": "intro",
-        "language": null,
-        "maxWords": null,
-        "network": null,
+        "_type": "prose",
         "produces": null,
-        "prompt": null,
-        "questions": null,
-        "solution": null,
+        "consumes": null,
         "src": "# Challenge: Add an Instruction\n\nTime to modify the program. Add a `greet` instruction that logs a greeting message.\n\n## Requirements\n\n1. Add a new function `greet` inside the `#[program]` module\n2. It should take `_ctx: Context<Greet>` as its parameter\n3. It should call `msg!(\"Hello, Solana!\")` and return `Ok(())`\n4. Add a corresponding `Greet` accounts struct (can be empty, like `Initialize`)\n\n## Tips\n\n- Follow the same pattern as the existing `initialize` function\n- The accounts struct name must match the `Context<T>` generic\n- Don't forget `#[derive(Accounts)]` on your new struct\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
         "starter": null,
+        "solution": null,
         "tests": null,
-        "url": null
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       },
       {
+        "key": "exercise",
         "_type": "code",
-        "amount": null,
-        "buildType": "buildable",
+        "produces": null,
         "consumes": null,
+        "src": null,
+        "url": null,
+        "language": "rust",
+        "buildType": "buildable",
         "deployable": false,
+        "starter": "use anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n#[program]\npub mod academy_program {\n    use super::*;\n\n    pub fn initialize(_ctx: Context<Initialize>) -> Result<()> {\n        msg!(\"Superteam Academy default program\");\n        Ok(())\n    }\n\n    // TODO: Add a greet instruction here\n}\n\n#[derive(Accounts)]\npub struct Initialize {}\n\n// TODO: Add a Greet accounts struct here\n",
+        "solution": "use anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n#[program]\npub mod academy_program {\n    use super::*;\n\n    pub fn initialize(_ctx: Context<Initialize>) -> Result<()> {\n        msg!(\"Superteam Academy default program\");\n        Ok(())\n    }\n\n    pub fn greet(_ctx: Context<Greet>) -> Result<()> {\n        msg!(\"Hello, Solana!\");\n        Ok(())\n    }\n}\n\n#[derive(Accounts)]\npub struct Initialize {}\n\n#[derive(Accounts)]\npub struct Greet {}\n",
+        "tests": [
+          {
+            "id": "test-1",
+            "description": "Program compiles successfully",
+            "input": "",
+            "expectedOutput": "true"
+          },
+          {
+            "id": "test-2",
+            "description": "Code contains a greet function",
+            "input": "",
+            "expectedOutput": "true"
+          },
+          {
+            "id": "test-3",
+            "description": "Code contains a Greet accounts struct",
+            "input": "",
+            "expectedOutput": "true"
+          }
+        ],
         "hints": [
           "The greet function follows the exact same pattern as initialize — just change the name and the log message",
           "Don't forget to add `#[derive(Accounts)]` before `pub struct Greet {}`",
           "The full signature is: `pub fn greet(_ctx: Context<Greet>) -> Result<()>`"
         ],
-        "idl": null,
-        "key": "exercise",
-        "language": "rust",
-        "maxWords": null,
-        "network": null,
-        "produces": null,
-        "prompt": null,
         "questions": null,
-        "solution": "use anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n#[program]\npub mod academy_program {\n    use super::*;\n\n    pub fn initialize(_ctx: Context<Initialize>) -> Result<()> {\n        msg!(\"Superteam Academy default program\");\n        Ok(())\n    }\n\n    pub fn greet(_ctx: Context<Greet>) -> Result<()> {\n        msg!(\"Hello, Solana!\");\n        Ok(())\n    }\n}\n\n#[derive(Accounts)]\npub struct Initialize {}\n\n#[derive(Accounts)]\npub struct Greet {}\n",
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "retrieval-close",
+        "_type": "quiz",
+        "produces": null,
+        "consumes": null,
         "src": null,
-        "starter": "use anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n#[program]\npub mod academy_program {\n    use super::*;\n\n    pub fn initialize(_ctx: Context<Initialize>) -> Result<()> {\n        msg!(\"Superteam Academy default program\");\n        Ok(())\n    }\n\n    // TODO: Add a greet instruction here\n}\n\n#[derive(Accounts)]\npub struct Initialize {}\n\n// TODO: Add a Greet accounts struct here\n",
-        "tests": [
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": [
           {
-            "description": "Program compiles successfully",
-            "expectedOutput": "true",
-            "id": "test-1",
-            "input": ""
+            "id": "q1",
+            "prompt": "You add `pub fn greet(_ctx: Context<Greet>)` but forget to write the `Greet` accounts struct. What happens?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "It fails to compile — `Context<Greet>` references a type that must exist and derive `Accounts`",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "It compiles; Anchor generates an empty Greet struct automatically",
+                "correct": false,
+                "feedback": "Anchor generates nothing for you here. `Context<Greet>` needs a real `#[derive(Accounts)]` struct Greet to reference, or the type is undefined."
+              },
+              {
+                "id": "c",
+                "label": "It compiles but greet silently never runs",
+                "correct": false,
+                "feedback": "There is no silent no-op — a missing referenced type is a compile error, caught at build time."
+              }
+            ],
+            "explanation": "Each handler's `Context<T>` must point at a defined `#[derive(Accounts)]` struct, even an empty one. The struct name has to match the generic exactly, so omitting `Greet` leaves an undefined type and breaks the build."
           },
           {
-            "description": "Code contains a greet function",
-            "expectedOutput": "true",
-            "id": "test-2",
-            "input": ""
-          },
-          {
-            "description": "Code contains a Greet accounts struct",
-            "expectedOutput": "true",
-            "id": "test-3",
-            "input": ""
+            "id": "q2",
+            "prompt": "The `Greet` accounts struct can be empty (`pub struct Greet {}`). Why is that valid when `Initialize`'s struct is not?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "greet only logs a message — it reads and writes no accounts, so it declares none",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "Empty structs are required for every instruction",
+                "correct": false,
+                "feedback": "Not required — the struct lists exactly the accounts an instruction touches. greet touches none; Initialize creates an account, so its struct is non-empty."
+              },
+              {
+                "id": "c",
+                "label": "greet stores its state inside the program, so no account is needed",
+                "correct": false,
+                "feedback": "Programs are stateless and store nothing internally. greet simply has no state to touch, which is why its accounts struct is empty."
+              }
+            ],
+            "explanation": "An accounts struct declares exactly the accounts an instruction reads or writes. `greet` only calls `msg!`, touching no accounts, so its struct is legitimately empty — whereas `Initialize` creates a Counter and must declare it, the payer, and the System Program."
           }
         ],
-        "url": null
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       }
-    ],
-    "slug": "add-instruction",
-    "title": "Add an Instruction"
+    ]
   },
   {
     "_id": "lesson-bfsp-adding-instructions",
+    "title": "Adding Instructions",
+    "slug": "adding-instructions",
     "blocks": [
       {
-        "_type": "prose",
-        "amount": null,
-        "buildType": null,
-        "consumes": null,
-        "deployable": null,
-        "hints": null,
-        "idl": null,
         "key": "intro",
-        "language": null,
-        "maxWords": null,
-        "network": null,
+        "_type": "prose",
         "produces": null,
-        "prompt": null,
-        "questions": null,
-        "solution": null,
+        "consumes": null,
         "src": "# Adding Instructions\n\nA program with just `initialize` isn't very useful. Real programs have multiple instructions that modify state.\n\n## The Pattern\n\nEvery new instruction follows the same pattern:\n\n1. Add a `pub fn` inside `#[program]`\n2. Create a corresponding accounts struct with `#[derive(Accounts)]`\n3. Define which accounts the instruction needs and their constraints\n\n## Increment: Modifying State\n\nTo increment a counter, we need:\n\n```rust\npub fn increment(ctx: Context<Increment>) -> Result<()> {\n    let counter = &mut ctx.accounts.counter;\n    counter.count += 1;\n    Ok(())\n}\n```\n\nThe `Increment` accounts struct needs the counter PDA and the user (to derive the PDA seeds):\n\n```rust\n#[derive(Accounts)]\npub struct Increment<'info> {\n    #[account(\n        mut,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    pub user: Signer<'info>,\n}\n```\n\nNote: `mut` is required because we're modifying `count`. The `seeds` and `bump` tell Anchor to verify the PDA address matches. The `user` provides the wallet pubkey used in the seeds.\n\n## Decrement with Safety\n\nWhat happens if someone tries to decrement a counter that's already at 0? With `u64`, subtraction would underflow and panic.\n\nAnchor provides `require!` for safe checks:\n\n```rust\npub fn decrement(ctx: Context<Decrement>) -> Result<()> {\n    let counter = &mut ctx.accounts.counter;\n    require!(counter.count > 0, ErrorCode::Underflow);\n    counter.count -= 1;\n    Ok(())\n}\n```\n\n## Custom Errors\n\nThe `ErrorCode::Underflow` needs to be defined:\n\n```rust\n#[error_code]\npub enum ErrorCode {\n    #[msg(\"Cannot decrement below zero\")]\n    Underflow,\n}\n```\n\n`#[error_code]` generates Anchor-compatible error types. The `#[msg]` attribute provides a human-readable error message visible in transaction logs.\n\n## Coming Up\n\nYou'll build the increment instruction first, then combine everything into the complete counter program with error handling.\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
         "starter": null,
+        "solution": null,
         "tests": null,
-        "url": null
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       }
-    ],
-    "slug": "adding-instructions",
-    "title": "Adding Instructions"
+    ]
   },
   {
     "_id": "lesson-bfsp-anatomy-anchor-program",
+    "title": "Anatomy of an Anchor Program",
+    "slug": "anatomy-anchor-program",
     "blocks": [
       {
-        "_type": "prose",
-        "amount": null,
-        "buildType": null,
-        "consumes": null,
-        "deployable": null,
-        "hints": null,
-        "idl": null,
         "key": "intro",
-        "language": null,
-        "maxWords": null,
-        "network": null,
+        "_type": "prose",
         "produces": null,
-        "prompt": null,
-        "questions": null,
-        "solution": null,
+        "consumes": null,
         "src": "# Anatomy of an Anchor Program\n\nBefore we start adding features, let's break down every line of the program you just compiled.\n\n## The Import\n\n```rust\nuse anchor_lang::prelude::*;\n```\n\nThis single import brings in everything Anchor needs: the `#[program]` macro, `Context`, `Account`, `Signer`, `Result`, error types, and more.\n\n## Program ID\n\n```rust\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n```\n\nEvery Solana program has a unique address (public key). The `declare_id!` macro hardcodes this address into the binary. When you deploy, Solana verifies the binary matches this ID.\n\nFor development, you can use any valid base58 public key. For production, you'd generate one with `solana-keygen grind`.\n\n## The Program Module\n\n```rust\n#[program]\npub mod academy_program {\n    use super::*;\n\n    pub fn initialize(_ctx: Context<Initialize>) -> Result<()> {\n        msg!(\"Superteam Academy default program\");\n        Ok(())\n    }\n}\n```\n\nThe `#[program]` attribute tells Anchor this module contains your instruction handlers. Each `pub fn` inside becomes a callable instruction on-chain.\n\n**Key rules:**\n- First parameter is always `Context<T>` where `T` is an accounts struct\n- Return type is always `Result<()>`\n- `msg!()` logs to the transaction log (visible in explorers)\n\n## Accounts Structs\n\n```rust\n#[derive(Accounts)]\npub struct Initialize {}\n```\n\nEvery instruction needs an accounts struct that defines which accounts the instruction reads/writes. This empty struct means `initialize` doesn't need any accounts.\n\nIn the next lesson, you'll add your first real instruction with a non-empty accounts struct.\n\n## What the Compiler Checks\n\nWhen you hit Build, `cargo-build-sbf` validates:\n- Rust syntax and type safety\n- Anchor macro expansion (accounts, constraints, errors)\n- SBF compatibility (no system calls, no heap abuse)\n\nIf any of these fail, you get a compiler error with the exact line number.\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
         "starter": null,
+        "solution": null,
         "tests": null,
-        "url": null
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "retrieval-close",
+        "_type": "quiz",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": [
+          {
+            "id": "q1",
+            "prompt": "`declare_id!(...)` hardcodes an address into your binary. What does Solana do with it at deploy time?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "It verifies the deployed program's account address matches the declared id",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "It generates a fresh keypair for the program",
+                "correct": false,
+                "feedback": "declare_id! generates no keys — it states the expected address. Solana checks the deployed program matches it; a mismatch is an error."
+              },
+              {
+                "id": "c",
+                "label": "It reserves the address so no one else can use it before you deploy",
+                "correct": false,
+                "feedback": "The macro reserves nothing on its own. It is a claim that Solana validates against the actual deploy address."
+              }
+            ],
+            "explanation": "declare_id! embeds the program's expected public key into the binary. On deploy, Solana checks the program account address against it — a guard against deploying a binary under the wrong id, which would break every client that derives PDAs from that id."
+          },
+          {
+            "id": "q2",
+            "prompt": "You add a new `pub fn withdraw(...)` inside the `#[program]` module. What must be true of its signature?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "Its first parameter is `Context<T>` for some `#[derive(Accounts)]` struct T, and it returns `Result<()>`",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "It can take any parameters and return any type",
+                "correct": false,
+                "feedback": "The `#[program]` contract is fixed: every handler takes a `Context<T>` first and returns `Result<()>`. Anchor's macro expansion depends on it."
+              },
+              {
+                "id": "c",
+                "label": "It must take each account as a separate argument, not a Context",
+                "correct": false,
+                "feedback": "Accounts are always bundled in `Context<T>`, never passed individually. The struct T is where accounts and their constraints live."
+              }
+            ],
+            "explanation": "Every `#[program]` handler has the same shape: `Context<T>` first (T being the accounts struct that declares and validates accounts), then optional instruction args, returning `Result<()>`. Anchor generates the on-chain dispatch from exactly this signature."
+          }
+        ],
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       }
-    ],
-    "slug": "anatomy-anchor-program",
-    "title": "Anatomy of an Anchor Program"
+    ]
   },
   {
     "_id": "lesson-bfsp-build-increment",
+    "title": "Build the Increment",
+    "slug": "build-increment",
     "blocks": [
       {
-        "_type": "prose",
-        "amount": null,
-        "buildType": null,
-        "consumes": null,
-        "deployable": null,
-        "hints": null,
-        "idl": null,
         "key": "intro",
-        "language": null,
-        "maxWords": null,
-        "network": null,
+        "_type": "prose",
         "produces": null,
-        "prompt": null,
-        "questions": null,
-        "solution": null,
+        "consumes": null,
         "src": "# Challenge: Build the Increment\n\nAdd an `increment` instruction to the counter program.\n\n## Requirements\n\n1. Add a `pub fn increment` inside the `#[program]` module\n2. It should take `ctx: Context<Increment>` and return `Result<()>`\n3. Get a mutable reference to `ctx.accounts.counter` and add 1 to `count`\n4. Add an `Increment` accounts struct with `counter` (PDA, `mut`, same seeds as Initialize) and `user` (`Signer`)\n\n## Why `user` is needed in Increment\n\nThe counter is a PDA derived from `[b\"counter\", user.key()]`. To verify the PDA matches, Anchor needs the `user` account to re-derive the seeds. This also acts as authorization — only the wallet that matches the seeds can modify this counter.\n\n## Tips\n\n- The `Increment` struct needs the `<'info>` lifetime, just like `Initialize`\n- The counter field needs `seeds` and `bump` (same seeds as Initialize, but no `init`)\n- The `user` field is `Signer<'info>` (not mut — they don't pay anything here)\n- Don't change the existing `initialize` or `greet` instructions\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
         "starter": null,
+        "solution": null,
         "tests": null,
-        "url": null
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       },
       {
+        "key": "exercise",
         "_type": "code",
-        "amount": null,
-        "buildType": "buildable",
+        "produces": null,
         "consumes": null,
+        "src": null,
+        "url": null,
+        "language": "rust",
+        "buildType": "buildable",
         "deployable": false,
+        "starter": "use anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n#[program]\npub mod academy_program {\n    use super::*;\n\n    pub fn initialize(ctx: Context<Initialize>) -> Result<()> {\n        let counter = &mut ctx.accounts.counter;\n        counter.count = 0;\n        counter.authority = ctx.accounts.user.key();\n        msg!(\"Counter initialized!\");\n        Ok(())\n    }\n\n    pub fn greet(_ctx: Context<Greet>) -> Result<()> {\n        msg!(\"Hello, Solana!\");\n        Ok(())\n    }\n\n    // TODO: Add an increment instruction\n}\n\n#[derive(Accounts)]\npub struct Initialize<'info> {\n    #[account(\n        init,\n        payer = user,\n        space = 8 + 8 + 32,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n    pub system_program: Program<'info, System>,\n}\n\n#[derive(Accounts)]\npub struct Greet {}\n\n// TODO: Add an Increment accounts struct with counter (PDA) and user (Signer)\n\n#[account]\npub struct Counter {\n    pub count: u64,\n    pub authority: Pubkey,\n}\n",
+        "solution": "use anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n#[program]\npub mod academy_program {\n    use super::*;\n\n    pub fn initialize(ctx: Context<Initialize>) -> Result<()> {\n        let counter = &mut ctx.accounts.counter;\n        counter.count = 0;\n        counter.authority = ctx.accounts.user.key();\n        msg!(\"Counter initialized!\");\n        Ok(())\n    }\n\n    pub fn greet(_ctx: Context<Greet>) -> Result<()> {\n        msg!(\"Hello, Solana!\");\n        Ok(())\n    }\n\n    pub fn increment(ctx: Context<Increment>) -> Result<()> {\n        let counter = &mut ctx.accounts.counter;\n        counter.count += 1;\n        Ok(())\n    }\n}\n\n#[derive(Accounts)]\npub struct Initialize<'info> {\n    #[account(\n        init,\n        payer = user,\n        space = 8 + 8 + 32,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n    pub system_program: Program<'info, System>,\n}\n\n#[derive(Accounts)]\npub struct Greet {}\n\n#[derive(Accounts)]\npub struct Increment<'info> {\n    #[account(\n        mut,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    pub user: Signer<'info>,\n}\n\n#[account]\npub struct Counter {\n    pub count: u64,\n    pub authority: Pubkey,\n}\n",
+        "tests": [
+          {
+            "id": "test-1",
+            "description": "Program compiles successfully",
+            "input": "",
+            "expectedOutput": "true"
+          },
+          {
+            "id": "test-2",
+            "description": "Code contains an increment function",
+            "input": "",
+            "expectedOutput": "true"
+          },
+          {
+            "id": "test-3",
+            "description": "Increment struct has mut counter",
+            "input": "",
+            "expectedOutput": "true"
+          }
+        ],
         "hints": [
           "The increment function body is just two lines: get `&mut ctx.accounts.counter` and then `counter.count += 1`",
           "The Increment struct needs `<'info>` lifetime, a `counter` field with `#[account(mut, seeds = [b\"counter\", user.key().as_ref()], bump)]`, and a `user: Signer<'info>` field",
           "Make sure increment returns `Ok(())` at the end"
         ],
-        "idl": null,
-        "key": "exercise",
-        "language": "rust",
-        "maxWords": null,
-        "network": null,
-        "produces": null,
-        "prompt": null,
         "questions": null,
-        "solution": "use anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n#[program]\npub mod academy_program {\n    use super::*;\n\n    pub fn initialize(ctx: Context<Initialize>) -> Result<()> {\n        let counter = &mut ctx.accounts.counter;\n        counter.count = 0;\n        counter.authority = ctx.accounts.user.key();\n        msg!(\"Counter initialized!\");\n        Ok(())\n    }\n\n    pub fn greet(_ctx: Context<Greet>) -> Result<()> {\n        msg!(\"Hello, Solana!\");\n        Ok(())\n    }\n\n    pub fn increment(ctx: Context<Increment>) -> Result<()> {\n        let counter = &mut ctx.accounts.counter;\n        counter.count += 1;\n        Ok(())\n    }\n}\n\n#[derive(Accounts)]\npub struct Initialize<'info> {\n    #[account(\n        init,\n        payer = user,\n        space = 8 + 8 + 32,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n    pub system_program: Program<'info, System>,\n}\n\n#[derive(Accounts)]\npub struct Greet {}\n\n#[derive(Accounts)]\npub struct Increment<'info> {\n    #[account(\n        mut,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    pub user: Signer<'info>,\n}\n\n#[account]\npub struct Counter {\n    pub count: u64,\n    pub authority: Pubkey,\n}\n",
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null,
+        "tutorNotes": [
+          "Learners re-use `init` on the counter in the Increment accounts struct; the account already exists at this point and only needs `mut`.",
+          "They forget `mut` on the counter, so the compiler rejects `counter.count += 1` or the write never persists.",
+          "They drop the `seeds` + `bump` from the Increment struct, so Anchor stops verifying the account is the caller's own counter PDA.",
+          "They add `system_program` to Increment out of habit — it is only needed when an account is being created, not mutated.",
+          "They borrow the counter immutably with `&ctx.accounts.counter` and then try to mutate it."
+        ]
+      },
+      {
+        "key": "retrieval-close",
+        "_type": "quiz",
+        "produces": null,
+        "consumes": null,
         "src": null,
-        "starter": "use anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n#[program]\npub mod academy_program {\n    use super::*;\n\n    pub fn initialize(ctx: Context<Initialize>) -> Result<()> {\n        let counter = &mut ctx.accounts.counter;\n        counter.count = 0;\n        counter.authority = ctx.accounts.user.key();\n        msg!(\"Counter initialized!\");\n        Ok(())\n    }\n\n    pub fn greet(_ctx: Context<Greet>) -> Result<()> {\n        msg!(\"Hello, Solana!\");\n        Ok(())\n    }\n\n    // TODO: Add an increment instruction\n}\n\n#[derive(Accounts)]\npub struct Initialize<'info> {\n    #[account(\n        init,\n        payer = user,\n        space = 8 + 8 + 32,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n    pub system_program: Program<'info, System>,\n}\n\n#[derive(Accounts)]\npub struct Greet {}\n\n// TODO: Add an Increment accounts struct with counter (PDA) and user (Signer)\n\n#[account]\npub struct Counter {\n    pub count: u64,\n    pub authority: Pubkey,\n}\n",
-        "tests": [
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": [
           {
-            "description": "Program compiles successfully",
-            "expectedOutput": "true",
-            "id": "test-1",
-            "input": ""
+            "id": "q1",
+            "prompt": "`Increment` includes the `user: Signer` and the same PDA seeds as `Initialize`, but no `init`. Why is `user` needed here at all?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "Anchor re-derives the counter PDA from the user's key to verify the passed account is the right one, which also authorizes only that wallet",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "To pay rent for the increment",
+                "correct": false,
+                "feedback": "No rent is paid on increment — the account already exists, so `user` is not `mut`. It is present so Anchor can re-derive and check the PDA seeds."
+              },
+              {
+                "id": "c",
+                "label": "Because every instruction must have a signer",
+                "correct": false,
+                "feedback": "Not every instruction needs a signer. Here `user` is required specifically to re-derive the PDA seeds and gate who may modify this counter."
+              }
+            ],
+            "explanation": "The counter's address is derived from the user's key, so Anchor needs `user` to recompute the seeds and confirm the passed counter is that wallet's PDA. That check doubles as authorization: only the wallet in the seeds can modify its own counter. No lamports move, so `user` is not `mut`."
           },
           {
-            "description": "Code contains an increment function",
-            "expectedOutput": "true",
-            "id": "test-2",
-            "input": ""
-          },
-          {
-            "description": "Increment struct has mut counter",
-            "expectedOutput": "true",
-            "id": "test-3",
-            "input": ""
+            "id": "q2",
+            "prompt": "`Increment` uses `#[account(mut, seeds = [...], bump)]` on the counter but drops `init`. What would happen if you left `init` on it?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "It would try to create the account again and fail, because the PDA already exists",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "It would reset the counter to zero",
+                "correct": false,
+                "feedback": "`init` does not reset — it allocates a new account. On an existing PDA it fails outright ('already in use'), rather than silently zeroing."
+              },
+              {
+                "id": "c",
+                "label": "Nothing — `init` is idempotent",
+                "correct": false,
+                "feedback": "`init` is not idempotent (that is `init_if_needed`). Re-running `init` on an existing address errors."
+              }
+            ],
+            "explanation": "`init` allocates and owns a fresh account; you use it once, in `Initialize`. `increment` operates on the already-created PDA, so it uses `mut` + `seeds` + `bump` to locate and mutate it. Leaving `init` on would attempt a second creation at an address already in use and fail."
           }
         ],
-        "url": null
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       }
-    ],
-    "slug": "build-increment",
-    "title": "Build the Increment"
+    ]
   },
   {
     "_id": "lesson-bfsp-complete-counter",
+    "title": "Complete Counter Program",
+    "slug": "complete-counter-program",
     "blocks": [
       {
-        "_type": "prose",
-        "amount": null,
-        "buildType": null,
-        "consumes": null,
-        "deployable": null,
-        "hints": null,
-        "idl": null,
         "key": "intro",
-        "language": null,
-        "maxWords": null,
-        "network": null,
+        "_type": "prose",
         "produces": null,
-        "prompt": null,
-        "questions": null,
-        "solution": null,
+        "consumes": null,
         "src": "# Capstone: Complete Counter Program\n\nThis is the capstone challenge. Build the complete counter program with:\n- `initialize` — create the counter PDA, set to 0\n- `increment` — add 1\n- `decrement` — subtract 1, with underflow protection\n\n## Requirements\n\n1. Add a `decrement` instruction that subtracts 1 from `counter.count`\n2. Use `require!(counter.count > 0, ErrorCode::Underflow)` to prevent underflow\n3. Add a `Decrement` accounts struct (same shape as `Increment` — PDA counter + user Signer)\n4. Define a custom `ErrorCode` enum with an `Underflow` variant\n\n## Custom Error Enum\n\nAnchor uses `#[error_code]` to define program-specific errors:\n\n```rust\n#[error_code]\npub enum ErrorCode {\n    #[msg(\"Cannot decrement below zero\")]\n    Underflow,\n}\n```\n\nThe `#[msg]` attribute provides the human-readable error message.\n\n## This Is It\n\nWhen this compiles, you've built a real Solana program from scratch using PDAs — the production-standard pattern. The next lesson covers deployment.\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
         "starter": null,
+        "solution": null,
         "tests": null,
-        "url": null
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       },
       {
+        "key": "exercise",
         "_type": "code",
-        "amount": null,
-        "buildType": "buildable",
+        "produces": null,
         "consumes": null,
+        "src": null,
+        "url": null,
+        "language": "rust",
+        "buildType": "buildable",
         "deployable": false,
+        "starter": "use anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n#[program]\npub mod academy_program {\n    use super::*;\n\n    pub fn initialize(ctx: Context<Initialize>) -> Result<()> {\n        let counter = &mut ctx.accounts.counter;\n        counter.count = 0;\n        counter.authority = ctx.accounts.user.key();\n        msg!(\"Counter initialized!\");\n        Ok(())\n    }\n\n    pub fn greet(_ctx: Context<Greet>) -> Result<()> {\n        msg!(\"Hello, Solana!\");\n        Ok(())\n    }\n\n    pub fn increment(ctx: Context<Increment>) -> Result<()> {\n        let counter = &mut ctx.accounts.counter;\n        counter.count += 1;\n        Ok(())\n    }\n\n    // TODO: Add a decrement instruction with underflow protection\n}\n\n#[derive(Accounts)]\npub struct Initialize<'info> {\n    #[account(\n        init,\n        payer = user,\n        space = 8 + 8 + 32,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n    pub system_program: Program<'info, System>,\n}\n\n#[derive(Accounts)]\npub struct Greet {}\n\n#[derive(Accounts)]\npub struct Increment<'info> {\n    #[account(\n        mut,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    pub user: Signer<'info>,\n}\n\n// TODO: Add a Decrement accounts struct (same as Increment)\n\n#[account]\npub struct Counter {\n    pub count: u64,\n    pub authority: Pubkey,\n}\n\n// TODO: Add a custom ErrorCode enum with Underflow variant\n",
+        "solution": "use anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n#[program]\npub mod academy_program {\n    use super::*;\n\n    pub fn initialize(ctx: Context<Initialize>) -> Result<()> {\n        let counter = &mut ctx.accounts.counter;\n        counter.count = 0;\n        counter.authority = ctx.accounts.user.key();\n        msg!(\"Counter initialized!\");\n        Ok(())\n    }\n\n    pub fn greet(_ctx: Context<Greet>) -> Result<()> {\n        msg!(\"Hello, Solana!\");\n        Ok(())\n    }\n\n    pub fn increment(ctx: Context<Increment>) -> Result<()> {\n        let counter = &mut ctx.accounts.counter;\n        counter.count += 1;\n        Ok(())\n    }\n\n    pub fn decrement(ctx: Context<Decrement>) -> Result<()> {\n        let counter = &mut ctx.accounts.counter;\n        require!(counter.count > 0, ErrorCode::Underflow);\n        counter.count -= 1;\n        Ok(())\n    }\n}\n\n#[derive(Accounts)]\npub struct Initialize<'info> {\n    #[account(\n        init,\n        payer = user,\n        space = 8 + 8 + 32,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n    pub system_program: Program<'info, System>,\n}\n\n#[derive(Accounts)]\npub struct Greet {}\n\n#[derive(Accounts)]\npub struct Increment<'info> {\n    #[account(\n        mut,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    pub user: Signer<'info>,\n}\n\n#[derive(Accounts)]\npub struct Decrement<'info> {\n    #[account(\n        mut,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    pub user: Signer<'info>,\n}\n\n#[account]\npub struct Counter {\n    pub count: u64,\n    pub authority: Pubkey,\n}\n\n#[error_code]\npub enum ErrorCode {\n    #[msg(\"Cannot decrement below zero\")]\n    Underflow,\n}\n",
+        "tests": [
+          {
+            "id": "test-1",
+            "description": "Program compiles successfully",
+            "input": "",
+            "expectedOutput": "true"
+          },
+          {
+            "id": "test-2",
+            "description": "Code contains decrement function with underflow check",
+            "input": "",
+            "expectedOutput": "true"
+          },
+          {
+            "id": "test-3",
+            "description": "Custom ErrorCode enum is defined",
+            "input": "",
+            "expectedOutput": "true"
+          }
+        ],
         "hints": [
           "The decrement function is almost identical to increment, but starts with `require!(counter.count > 0, ErrorCode::Underflow);`",
           "The Decrement accounts struct is the same shape as Increment — counter with PDA seeds and user as Signer",
           "Don't forget `#[error_code]` on the enum and `#[msg(\"Cannot decrement below zero\")]` on the Underflow variant"
         ],
-        "idl": null,
-        "key": "exercise",
-        "language": "rust",
-        "maxWords": null,
-        "network": null,
-        "produces": null,
-        "prompt": null,
         "questions": null,
-        "solution": "use anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n#[program]\npub mod academy_program {\n    use super::*;\n\n    pub fn initialize(ctx: Context<Initialize>) -> Result<()> {\n        let counter = &mut ctx.accounts.counter;\n        counter.count = 0;\n        counter.authority = ctx.accounts.user.key();\n        msg!(\"Counter initialized!\");\n        Ok(())\n    }\n\n    pub fn greet(_ctx: Context<Greet>) -> Result<()> {\n        msg!(\"Hello, Solana!\");\n        Ok(())\n    }\n\n    pub fn increment(ctx: Context<Increment>) -> Result<()> {\n        let counter = &mut ctx.accounts.counter;\n        counter.count += 1;\n        Ok(())\n    }\n\n    pub fn decrement(ctx: Context<Decrement>) -> Result<()> {\n        let counter = &mut ctx.accounts.counter;\n        require!(counter.count > 0, ErrorCode::Underflow);\n        counter.count -= 1;\n        Ok(())\n    }\n}\n\n#[derive(Accounts)]\npub struct Initialize<'info> {\n    #[account(\n        init,\n        payer = user,\n        space = 8 + 8 + 32,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n    pub system_program: Program<'info, System>,\n}\n\n#[derive(Accounts)]\npub struct Greet {}\n\n#[derive(Accounts)]\npub struct Increment<'info> {\n    #[account(\n        mut,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    pub user: Signer<'info>,\n}\n\n#[derive(Accounts)]\npub struct Decrement<'info> {\n    #[account(\n        mut,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    pub user: Signer<'info>,\n}\n\n#[account]\npub struct Counter {\n    pub count: u64,\n    pub authority: Pubkey,\n}\n\n#[error_code]\npub enum ErrorCode {\n    #[msg(\"Cannot decrement below zero\")]\n    Underflow,\n}\n",
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null,
+        "tutorNotes": [
+          "Learners subtract before checking, so a decrement at zero underflows the `u64` and panics instead of returning the custom error.",
+          "They guard with `count >= 0`, which is always true for an unsigned integer and stops nothing — the meaningful check is strictly greater than zero.",
+          "They define the error enum but omit the `#[error_code]` attribute, so `require!` will not accept the variant.",
+          "They give the Decrement accounts struct different PDA seeds than Increment, so it resolves a different account than the one they initialized.",
+          "They handle the zero case by returning `Ok(())` and doing nothing, silently swallowing the error instead of surfacing it to the caller."
+        ]
+      },
+      {
+        "key": "retrieval-close",
+        "_type": "quiz",
+        "produces": null,
+        "consumes": null,
         "src": null,
-        "starter": "use anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n#[program]\npub mod academy_program {\n    use super::*;\n\n    pub fn initialize(ctx: Context<Initialize>) -> Result<()> {\n        let counter = &mut ctx.accounts.counter;\n        counter.count = 0;\n        counter.authority = ctx.accounts.user.key();\n        msg!(\"Counter initialized!\");\n        Ok(())\n    }\n\n    pub fn greet(_ctx: Context<Greet>) -> Result<()> {\n        msg!(\"Hello, Solana!\");\n        Ok(())\n    }\n\n    pub fn increment(ctx: Context<Increment>) -> Result<()> {\n        let counter = &mut ctx.accounts.counter;\n        counter.count += 1;\n        Ok(())\n    }\n\n    // TODO: Add a decrement instruction with underflow protection\n}\n\n#[derive(Accounts)]\npub struct Initialize<'info> {\n    #[account(\n        init,\n        payer = user,\n        space = 8 + 8 + 32,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n    pub system_program: Program<'info, System>,\n}\n\n#[derive(Accounts)]\npub struct Greet {}\n\n#[derive(Accounts)]\npub struct Increment<'info> {\n    #[account(\n        mut,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    pub user: Signer<'info>,\n}\n\n// TODO: Add a Decrement accounts struct (same as Increment)\n\n#[account]\npub struct Counter {\n    pub count: u64,\n    pub authority: Pubkey,\n}\n\n// TODO: Add a custom ErrorCode enum with Underflow variant\n",
-        "tests": [
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": [
           {
-            "description": "Program compiles successfully",
-            "expectedOutput": "true",
-            "id": "test-1",
-            "input": ""
+            "id": "q1",
+            "prompt": "`decrement` guards with `require!(counter.count > 0, ErrorCode::Underflow)`. What happens when a user calls decrement while count is 0?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "The instruction returns the Underflow error, the transaction fails, and no state changes",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "count wraps around to a huge u64 value",
+                "correct": false,
+                "feedback": "That is exactly what the guard prevents. Without `require!`, subtracting 1 from 0 on a u64 would underflow-wrap; with it, the instruction fails cleanly and count stays 0."
+              },
+              {
+                "id": "c",
+                "label": "count goes to -1",
+                "correct": false,
+                "feedback": "A `u64` cannot hold -1. Unguarded subtraction would wrap to a huge number; the `require!` guard rejects the call instead."
+              }
+            ],
+            "explanation": "`require!` returns the custom error and aborts the instruction when the condition is false, so a decrement at zero fails and leaves state untouched. This is the on-chain defense against u64 underflow wrapping 0 into a near-limitless value — a real class of bug."
           },
           {
-            "description": "Code contains decrement function with underflow check",
-            "expectedOutput": "true",
-            "id": "test-2",
-            "input": ""
-          },
-          {
-            "description": "Custom ErrorCode enum is defined",
-            "expectedOutput": "true",
-            "id": "test-3",
-            "input": ""
+            "id": "q2",
+            "prompt": "What does `#[error_code]` on the `ErrorCode` enum plus `#[msg]` on the `Underflow` variant give you?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "A program-specific error whose human-readable message is surfaced to clients when the instruction fails",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "A compile-time check that count never underflows",
+                "correct": false,
+                "feedback": "The compiler does not prove that — the runtime `require!` does. `#[error_code]` and `#[msg]` just define the error and the message clients see."
+              },
+              {
+                "id": "c",
+                "label": "Automatic retry of the failed instruction",
+                "correct": false,
+                "feedback": "There is no automatic retry. The macros define a typed error and message; the transaction simply fails and the client reads the message."
+              }
+            ],
+            "explanation": "`#[error_code]` turns the enum into Anchor program errors with stable codes, and `#[msg]` attaches the readable string returned to clients on failure. Combined with `require!`, your program enforces its own rules and explains violations to the caller."
           }
         ],
-        "url": null
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       }
-    ],
-    "slug": "complete-counter-program",
-    "title": "Complete Counter Program"
+    ]
   },
   {
     "_id": "lesson-bfsp-define-counter",
+    "title": "Define a Counter Account",
+    "slug": "define-counter-account",
     "blocks": [
       {
-        "_type": "prose",
-        "amount": null,
-        "buildType": null,
-        "consumes": null,
-        "deployable": null,
-        "hints": null,
-        "idl": null,
         "key": "intro",
-        "language": null,
-        "maxWords": null,
-        "network": null,
+        "_type": "prose",
         "produces": null,
-        "prompt": null,
-        "questions": null,
-        "solution": null,
+        "consumes": null,
         "src": "# Challenge: Define a Counter Account (PDA)\n\nAdd a `Counter` account struct and update the `Initialize` accounts to create it as a **Program Derived Address** (PDA).\n\n## What is a PDA?\n\nA PDA is an account address derived deterministically from **seeds** and the **program ID**. Unlike keypair accounts, PDAs don't have a private key — the program itself controls them. The same seeds always produce the same address.\n\nFor our counter: `seeds = [\"counter\", user_wallet_pubkey]` means each wallet gets exactly one counter per program.\n\n## Requirements\n\n1. Add a `Counter` struct with `#[account]` attribute containing `pub count: u64` and `pub authority: Pubkey`\n2. Add lifetime `<'info>` to the `Initialize` struct\n3. Add a `counter` field with `#[account(init, payer = user, space = 8 + 8 + 32, seeds = [b\"counter\", user.key().as_ref()], bump)]`\n4. Add a `user` field as `Signer<'info>` with `#[account(mut)]`\n5. Add `system_program` as `Program<'info, System>`\n\n## What Each Constraint Does\n\n- `init` — creates the account (allocates space, assigns owner)\n- `payer = user` — the `user` account pays the rent deposit\n- `space = 8 + 8 + 32` — 8 bytes discriminator + 8 bytes `u64` + 32 bytes `Pubkey`\n- `seeds` — the byte arrays used to derive the PDA address\n- `bump` — Anchor finds the valid bump seed automatically\n- `mut` on `user` — required because their lamport balance changes (pays rent)\n\n## Tips\n\n- The `Counter` struct goes outside the `#[program]` module\n- The `Initialize` struct needs a lifetime parameter: `pub struct Initialize<'info>`\n- Make sure `counter` has type `Account<'info, Counter>`\n- The `authority` field records who created the counter (useful for access control later)\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
         "starter": null,
+        "solution": null,
         "tests": null,
-        "url": null
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       },
       {
+        "key": "exercise",
         "_type": "code",
-        "amount": null,
-        "buildType": "buildable",
+        "produces": null,
         "consumes": null,
+        "src": null,
+        "url": null,
+        "language": "rust",
+        "buildType": "buildable",
         "deployable": false,
+        "starter": "use anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n#[program]\npub mod academy_program {\n    use super::*;\n\n    pub fn initialize(_ctx: Context<Initialize>) -> Result<()> {\n        msg!(\"Superteam Academy default program\");\n        Ok(())\n    }\n\n    pub fn greet(_ctx: Context<Greet>) -> Result<()> {\n        msg!(\"Hello, Solana!\");\n        Ok(())\n    }\n}\n\n// TODO: Update Initialize to create a Counter PDA account\n// Use seeds = [b\"counter\", user.key().as_ref()] and bump\n#[derive(Accounts)]\npub struct Initialize {}\n\n#[derive(Accounts)]\npub struct Greet {}\n\n// TODO: Add a Counter account struct with count: u64 and authority: Pubkey\n",
+        "solution": "use anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n#[program]\npub mod academy_program {\n    use super::*;\n\n    pub fn initialize(_ctx: Context<Initialize>) -> Result<()> {\n        msg!(\"Superteam Academy default program\");\n        Ok(())\n    }\n\n    pub fn greet(_ctx: Context<Greet>) -> Result<()> {\n        msg!(\"Hello, Solana!\");\n        Ok(())\n    }\n}\n\n#[derive(Accounts)]\npub struct Initialize<'info> {\n    #[account(\n        init,\n        payer = user,\n        space = 8 + 8 + 32,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n    pub system_program: Program<'info, System>,\n}\n\n#[derive(Accounts)]\npub struct Greet {}\n\n#[account]\npub struct Counter {\n    pub count: u64,\n    pub authority: Pubkey,\n}\n",
+        "tests": [
+          {
+            "id": "test-1",
+            "description": "Program compiles successfully",
+            "input": "",
+            "expectedOutput": "true"
+          },
+          {
+            "id": "test-2",
+            "description": "Counter struct is defined",
+            "input": "",
+            "expectedOutput": "true"
+          },
+          {
+            "id": "test-3",
+            "description": "Initialize struct has account constraints",
+            "input": "",
+            "expectedOutput": "true"
+          }
+        ],
         "hints": [
           "Start by adding the Counter struct at the bottom: `#[account]\\npub struct Counter { pub count: u64, pub authority: Pubkey }`",
           "The Initialize struct needs a lifetime: `pub struct Initialize<'info>` with three fields: counter, user, and system_program",
           "The counter field needs PDA constraints: `#[account(init, payer = user, space = 8 + 8 + 32, seeds = [b\"counter\", user.key().as_ref()], bump)]`"
         ],
-        "idl": null,
-        "key": "exercise",
-        "language": "rust",
-        "maxWords": null,
-        "network": null,
-        "produces": null,
-        "prompt": null,
         "questions": null,
-        "solution": "use anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n#[program]\npub mod academy_program {\n    use super::*;\n\n    pub fn initialize(_ctx: Context<Initialize>) -> Result<()> {\n        msg!(\"Superteam Academy default program\");\n        Ok(())\n    }\n\n    pub fn greet(_ctx: Context<Greet>) -> Result<()> {\n        msg!(\"Hello, Solana!\");\n        Ok(())\n    }\n}\n\n#[derive(Accounts)]\npub struct Initialize<'info> {\n    #[account(\n        init,\n        payer = user,\n        space = 8 + 8 + 32,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n    pub system_program: Program<'info, System>,\n}\n\n#[derive(Accounts)]\npub struct Greet {}\n\n#[account]\npub struct Counter {\n    pub count: u64,\n    pub authority: Pubkey,\n}\n",
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null,
+        "tutorNotes": [
+          "Learners size `space` by adding up only the fields and forget the 8-byte discriminator Anchor prepends to every `#[account]`, so the account is under-allocated.",
+          "They omit the `<'info>` lifetime on the `Initialize` struct once it holds account references, then get opaque lifetime errors and edit the wrong line.",
+          "They leave `user` without `#[account(mut)]`; the payer that funds an `init` has its lamports changed and must be mutable.",
+          "They reach for `#[account(mut)]` on the counter, but the account is being created here for the first time, which needs `init`, not `mut`.",
+          "They write the PDA seed as a plain text string instead of a byte literal, or leave off `bump`, so the constraints do not compile."
+        ]
+      },
+      {
+        "key": "retrieval-close",
+        "_type": "quiz",
+        "produces": null,
+        "consumes": null,
         "src": null,
-        "starter": "use anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n#[program]\npub mod academy_program {\n    use super::*;\n\n    pub fn initialize(_ctx: Context<Initialize>) -> Result<()> {\n        msg!(\"Superteam Academy default program\");\n        Ok(())\n    }\n\n    pub fn greet(_ctx: Context<Greet>) -> Result<()> {\n        msg!(\"Hello, Solana!\");\n        Ok(())\n    }\n}\n\n// TODO: Update Initialize to create a Counter PDA account\n// Use seeds = [b\"counter\", user.key().as_ref()] and bump\n#[derive(Accounts)]\npub struct Initialize {}\n\n#[derive(Accounts)]\npub struct Greet {}\n\n// TODO: Add a Counter account struct with count: u64 and authority: Pubkey\n",
-        "tests": [
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": [
           {
-            "description": "Program compiles successfully",
-            "expectedOutput": "true",
-            "id": "test-1",
-            "input": ""
+            "id": "q1",
+            "prompt": "The counter is a PDA seeded on the counter label plus the user's public key. What does this seed choice guarantee?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "Each wallet gets exactly one counter for this program, at a deterministic address anyone can re-derive",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "Each wallet can create unlimited counters",
+                "correct": false,
+                "feedback": "The seeds fix the address: for a given user those seeds derive one address. A second init there fails — one counter per wallet."
+              },
+              {
+                "id": "c",
+                "label": "The counter has a private key the user controls",
+                "correct": false,
+                "feedback": "PDAs have no private key — that is the point. The program controls the PDA; the seeds just make its address deterministic."
+              }
+            ],
+            "explanation": "A PDA address is a pure function of its seeds and the program id. Seeding with the user's pubkey means one deterministic counter per wallet, re-derivable by any client, with no private key — the program signs for it via the bump."
           },
           {
-            "description": "Counter struct is defined",
-            "expectedOutput": "true",
-            "id": "test-2",
-            "input": ""
-          },
-          {
-            "description": "Initialize struct has account constraints",
-            "expectedOutput": "true",
-            "id": "test-3",
-            "input": ""
+            "id": "q2",
+            "prompt": "Why does the `user` field need `#[account(mut)]` in `Initialize`?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "Creating the counter with `init` debits rent from the user, changing their lamport balance — a mutation",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "Because the user signs the transaction",
+                "correct": false,
+                "feedback": "Signing is `Signer`, a separate thing. `mut` is required because the payer's lamports decrease to fund the new account's rent."
+              },
+              {
+                "id": "c",
+                "label": "Because the user's data is written into the counter",
+                "correct": false,
+                "feedback": "The user account's own data is not modified. What changes is its lamport balance, since `payer = user` funds the rent — that is why it must be `mut`."
+              }
+            ],
+            "explanation": "`init` allocates the counter and `payer = user` funds its rent-exempt deposit, so the user's lamport balance decreases. Any account whose lamports or data change must be declared `mut`, or Anchor rejects the instruction."
           }
         ],
-        "url": null
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       }
-    ],
-    "slug": "define-counter-account",
-    "title": "Define a Counter Account"
+    ]
   },
   {
     "_id": "lesson-bfsp-deploy-to-devnet",
+    "title": "Deploy to Devnet",
+    "slug": "deploy-to-devnet",
     "blocks": [
       {
-        "_type": "prose",
-        "amount": null,
-        "buildType": null,
-        "consumes": null,
-        "deployable": null,
-        "hints": null,
-        "idl": null,
         "key": "intro",
-        "language": null,
-        "maxWords": null,
-        "network": null,
+        "_type": "prose",
         "produces": null,
-        "prompt": null,
-        "questions": null,
-        "solution": null,
+        "consumes": null,
         "src": "# Deploy to Devnet\n\nYou've built the complete counter program. Now compile it one final time and learn how to deploy it.\n\n## Final Build\n\nThe starter code is your complete counter program. Hit **Build** to compile it. When it succeeds, you'll see a **Build UUID** in the output — this is the identifier for your compiled `.so` binary.\n\n## What Happens After Build\n\nThe build server compiled your Rust code into a Solana program binary (`.so` file). To deploy it to Devnet, you'd run:\n\n```bash\n# Download the compiled binary\ncurl -H 'X-API-Key: YOUR_KEY' \\\n  https://build-server-url/deploy/YOUR_UUID \\\n  -o program.so\n\n# Deploy to Devnet\nsolana program deploy program.so --url devnet\n```\n\nThe `solana program deploy` command:\n1. Uploads the binary to a buffer account\n2. Creates the program account\n3. Sets the program as executable\n4. Returns the **Program ID** — the on-chain address of your program\n\n## Interacting with Your Program\n\nOnce deployed, anyone can call your program's instructions:\n\n```typescript\n// TypeScript client using Anchor\nconst program = new Program(idl, programId, provider);\n\n// Initialize a counter\nawait program.methods\n  .initialize()\n  .accounts({ counter: counterKeypair.publicKey })\n  .signers([counterKeypair])\n  .rpc();\n\n// Increment\nawait program.methods\n  .increment()\n  .accounts({ counter: counterKeypair.publicKey })\n  .rpc();\n```\n\n## What You've Accomplished\n\nYou wrote a Solana program from scratch:\n- **4 instructions**: initialize, greet, increment, decrement\n- **Account management**: init with payer, mutable state, space calculation\n- **Error handling**: Custom error enum with underflow protection\n- **Compilation**: cargo-build-sbf via the build server\n\nThis counter program follows the same patterns used by every production Anchor program on Solana. The complexity scales, but the fundamentals are the same.\n\n## Next Steps\n\n- **DeFi on Solana** course — build a token vault with PDAs and CPIs\n- **Deploy locally** — install the Solana CLI and Anchor to build on your machine\n- **Read the Anchor Book** — [book.anchor-lang.com](https://book.anchor-lang.com)\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
         "starter": null,
+        "solution": null,
         "tests": null,
-        "url": null
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       },
       {
+        "key": "exercise",
         "_type": "code",
-        "amount": null,
-        "buildType": "buildable",
+        "produces": null,
         "consumes": null,
+        "src": null,
+        "url": null,
+        "language": "rust",
+        "buildType": "buildable",
         "deployable": false,
+        "starter": "use anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n#[program]\npub mod academy_program {\n    use super::*;\n\n    pub fn initialize(ctx: Context<Initialize>) -> Result<()> {\n        let counter = &mut ctx.accounts.counter;\n        counter.count = 0;\n        counter.authority = ctx.accounts.user.key();\n        msg!(\"Counter initialized!\");\n        Ok(())\n    }\n\n    pub fn greet(_ctx: Context<Greet>) -> Result<()> {\n        msg!(\"Hello, Solana!\");\n        Ok(())\n    }\n\n    pub fn increment(ctx: Context<Increment>) -> Result<()> {\n        let counter = &mut ctx.accounts.counter;\n        counter.count += 1;\n        Ok(())\n    }\n\n    pub fn decrement(ctx: Context<Decrement>) -> Result<()> {\n        let counter = &mut ctx.accounts.counter;\n        require!(counter.count > 0, ErrorCode::Underflow);\n        counter.count -= 1;\n        Ok(())\n    }\n}\n\n#[derive(Accounts)]\npub struct Initialize<'info> {\n    #[account(\n        init,\n        payer = user,\n        space = 8 + 8 + 32,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n    pub system_program: Program<'info, System>,\n}\n\n#[derive(Accounts)]\npub struct Greet {}\n\n#[derive(Accounts)]\npub struct Increment<'info> {\n    #[account(\n        mut,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    pub user: Signer<'info>,\n}\n\n#[derive(Accounts)]\npub struct Decrement<'info> {\n    #[account(\n        mut,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    pub user: Signer<'info>,\n}\n\n#[account]\npub struct Counter {\n    pub count: u64,\n    pub authority: Pubkey,\n}\n\n#[error_code]\npub enum ErrorCode {\n    #[msg(\"Cannot decrement below zero\")]\n    Underflow,\n}\n",
+        "solution": "use anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n#[program]\npub mod academy_program {\n    use super::*;\n\n    pub fn initialize(ctx: Context<Initialize>) -> Result<()> {\n        let counter = &mut ctx.accounts.counter;\n        counter.count = 0;\n        counter.authority = ctx.accounts.user.key();\n        msg!(\"Counter initialized!\");\n        Ok(())\n    }\n\n    pub fn greet(_ctx: Context<Greet>) -> Result<()> {\n        msg!(\"Hello, Solana!\");\n        Ok(())\n    }\n\n    pub fn increment(ctx: Context<Increment>) -> Result<()> {\n        let counter = &mut ctx.accounts.counter;\n        counter.count += 1;\n        Ok(())\n    }\n\n    pub fn decrement(ctx: Context<Decrement>) -> Result<()> {\n        let counter = &mut ctx.accounts.counter;\n        require!(counter.count > 0, ErrorCode::Underflow);\n        counter.count -= 1;\n        Ok(())\n    }\n}\n\n#[derive(Accounts)]\npub struct Initialize<'info> {\n    #[account(\n        init,\n        payer = user,\n        space = 8 + 8 + 32,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n    pub system_program: Program<'info, System>,\n}\n\n#[derive(Accounts)]\npub struct Greet {}\n\n#[derive(Accounts)]\npub struct Increment<'info> {\n    #[account(\n        mut,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    pub user: Signer<'info>,\n}\n\n#[derive(Accounts)]\npub struct Decrement<'info> {\n    #[account(\n        mut,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    pub user: Signer<'info>,\n}\n\n#[account]\npub struct Counter {\n    pub count: u64,\n    pub authority: Pubkey,\n}\n\n#[error_code]\npub enum ErrorCode {\n    #[msg(\"Cannot decrement below zero\")]\n    Underflow,\n}\n",
+        "tests": [
+          {
+            "id": "test-1",
+            "description": "Complete counter program compiles successfully",
+            "input": "",
+            "expectedOutput": "true"
+          }
+        ],
         "hints": [
           "This is the complete program from the previous challenge. Just click Build to compile it.",
           "If you see errors, make sure you haven't accidentally modified the code. Click Reset Code to restore.",
           "The build UUID in the output panel is your program's compiled binary identifier."
         ],
-        "idl": null,
-        "key": "exercise",
-        "language": "rust",
-        "maxWords": null,
-        "network": null,
-        "produces": null,
-        "prompt": null,
         "questions": null,
-        "solution": "use anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n#[program]\npub mod academy_program {\n    use super::*;\n\n    pub fn initialize(ctx: Context<Initialize>) -> Result<()> {\n        let counter = &mut ctx.accounts.counter;\n        counter.count = 0;\n        counter.authority = ctx.accounts.user.key();\n        msg!(\"Counter initialized!\");\n        Ok(())\n    }\n\n    pub fn greet(_ctx: Context<Greet>) -> Result<()> {\n        msg!(\"Hello, Solana!\");\n        Ok(())\n    }\n\n    pub fn increment(ctx: Context<Increment>) -> Result<()> {\n        let counter = &mut ctx.accounts.counter;\n        counter.count += 1;\n        Ok(())\n    }\n\n    pub fn decrement(ctx: Context<Decrement>) -> Result<()> {\n        let counter = &mut ctx.accounts.counter;\n        require!(counter.count > 0, ErrorCode::Underflow);\n        counter.count -= 1;\n        Ok(())\n    }\n}\n\n#[derive(Accounts)]\npub struct Initialize<'info> {\n    #[account(\n        init,\n        payer = user,\n        space = 8 + 8 + 32,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n    pub system_program: Program<'info, System>,\n}\n\n#[derive(Accounts)]\npub struct Greet {}\n\n#[derive(Accounts)]\npub struct Increment<'info> {\n    #[account(\n        mut,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    pub user: Signer<'info>,\n}\n\n#[derive(Accounts)]\npub struct Decrement<'info> {\n    #[account(\n        mut,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    pub user: Signer<'info>,\n}\n\n#[account]\npub struct Counter {\n    pub count: u64,\n    pub authority: Pubkey,\n}\n\n#[error_code]\npub enum ErrorCode {\n    #[msg(\"Cannot decrement below zero\")]\n    Underflow,\n}\n",
-        "src": null,
-        "starter": "use anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n#[program]\npub mod academy_program {\n    use super::*;\n\n    pub fn initialize(ctx: Context<Initialize>) -> Result<()> {\n        let counter = &mut ctx.accounts.counter;\n        counter.count = 0;\n        counter.authority = ctx.accounts.user.key();\n        msg!(\"Counter initialized!\");\n        Ok(())\n    }\n\n    pub fn greet(_ctx: Context<Greet>) -> Result<()> {\n        msg!(\"Hello, Solana!\");\n        Ok(())\n    }\n\n    pub fn increment(ctx: Context<Increment>) -> Result<()> {\n        let counter = &mut ctx.accounts.counter;\n        counter.count += 1;\n        Ok(())\n    }\n\n    pub fn decrement(ctx: Context<Decrement>) -> Result<()> {\n        let counter = &mut ctx.accounts.counter;\n        require!(counter.count > 0, ErrorCode::Underflow);\n        counter.count -= 1;\n        Ok(())\n    }\n}\n\n#[derive(Accounts)]\npub struct Initialize<'info> {\n    #[account(\n        init,\n        payer = user,\n        space = 8 + 8 + 32,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n    pub system_program: Program<'info, System>,\n}\n\n#[derive(Accounts)]\npub struct Greet {}\n\n#[derive(Accounts)]\npub struct Increment<'info> {\n    #[account(\n        mut,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    pub user: Signer<'info>,\n}\n\n#[derive(Accounts)]\npub struct Decrement<'info> {\n    #[account(\n        mut,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    pub user: Signer<'info>,\n}\n\n#[account]\npub struct Counter {\n    pub count: u64,\n    pub authority: Pubkey,\n}\n\n#[error_code]\npub enum ErrorCode {\n    #[msg(\"Cannot decrement below zero\")]\n    Underflow,\n}\n",
-        "tests": [
-          {
-            "description": "Complete counter program compiles successfully",
-            "expectedOutput": "true",
-            "id": "test-1",
-            "input": ""
-          }
-        ],
-        "url": null
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       }
-    ],
-    "slug": "deploy-to-devnet",
-    "title": "Deploy to Devnet"
+    ]
   },
   {
     "_id": "lesson-bfsp-from-code-to-chain",
+    "title": "From Code to Chain",
+    "slug": "from-code-to-chain",
     "blocks": [
       {
-        "_type": "prose",
-        "amount": null,
-        "buildType": null,
-        "consumes": null,
-        "deployable": null,
-        "hints": null,
-        "idl": null,
         "key": "intro",
-        "language": null,
-        "maxWords": null,
-        "network": null,
+        "_type": "prose",
         "produces": null,
-        "prompt": null,
-        "questions": null,
-        "solution": null,
+        "consumes": null,
         "src": "# From Code to Chain\n\nYou've written Anchor programs in the previous courses. Now it's time to compile and deploy them for real.\n\n## The Build Pipeline\n\nWhen you write an Anchor program, it goes through several stages before it reaches the Solana blockchain:\n\n1. **Rust source code** — what you write in your editor\n2. **`cargo-build-sbf`** — the Solana compiler that transforms Rust into Solana Bytecode Format (SBF)\n3. **`.so` binary** — the compiled program, an ELF shared object file\n4. **`solana program deploy`** — uploads the binary to a Solana cluster\n\n## What is SBF?\n\nSolana Bytecode Format (SBF) is a variant of eBPF (extended Berkeley Packet Filter) adapted for the Solana runtime. It's a register-based instruction set designed for:\n\n- **Safety**: Programs run in a sandboxed VM with no access to the host system\n- **Performance**: Near-native execution speed\n- **Determinism**: Same inputs always produce the same outputs\n\n## The Build Server\n\nIn this course, you won't need a local Rust toolchain. The **Superteam Academy Build Server** handles compilation in the cloud:\n\n1. You write Anchor code in the browser editor\n2. Click **Build** to submit your code\n3. The build server runs `cargo-build-sbf` on your code\n4. You get back either compiler errors or a compiled binary UUID\n\nThe build server uses the same Anchor 0.32 and Solana SDK that you'd use locally. Think of it as a cloud-hosted `anchor build`.\n\n## What Gets Compiled\n\nYour `lib.rs` file is placed into a pre-configured Anchor project with:\n- `anchor-lang` 0.32.1 (with `init-if-needed` feature)\n- `anchor-spl` 0.32.1\n- `solana-program` via the Agave 3.0 toolchain\n\nThe build server rejects dangerous patterns (`std::process`, `std::fs`, `std::net`) to keep the sandbox secure.\n\n## Ready to Build?\n\nIn the next lesson, you'll hit the **Build** button for the first time. Your only job: see the green checkmark.\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
         "starter": null,
+        "solution": null,
         "tests": null,
-        "url": null
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "retrieval-close",
+        "_type": "quiz",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": [
+          {
+            "id": "q1",
+            "prompt": "The build server rejects programs that use `std::fs`, `std::net`, or `std::process`. Why would those never work in a deployed Solana program anyway?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "SBF programs run in a sandboxed VM with no access to the host's filesystem, network, or OS, so those calls have no meaning on-chain",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "They compile fine on-chain but slow the validator down",
+                "correct": false,
+                "feedback": "They cannot run at all — the SBF VM has no host access. The build server rejects them early rather than shipping a program that could never execute."
+              },
+              {
+                "id": "c",
+                "label": "They are blocked only to protect the build server, not the runtime",
+                "correct": false,
+                "feedback": "The sandbox is fundamental to the runtime too: an on-chain program has no OS to call. The build-server block just surfaces that constraint sooner."
+              }
+            ],
+            "explanation": "Solana programs compile to SBF and run in a deterministic, sandboxed VM. There is no filesystem, network, or process table on-chain, so those calls are meaningless — and determinism requires the same input to always yield the same output, which host I/O would break."
+          },
+          {
+            "id": "q2",
+            "prompt": "What artifact does `cargo-build-sbf` produce, and what does `solana program deploy` do with it?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "A `.so` ELF binary of SBF bytecode; deploy uploads that binary to a cluster",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "A JSON IDL; deploy registers it with the RPC",
+                "correct": false,
+                "feedback": "The IDL is separate metadata. The compiler output that gets deployed is the `.so` SBF binary — the executable itself."
+              },
+              {
+                "id": "c",
+                "label": "Raw Rust source; deploy compiles it on the validator",
+                "correct": false,
+                "feedback": "Validators never compile source. Compilation to `.so` happens off-chain (here, on the build server); only the finished bytecode is uploaded."
+              }
+            ],
+            "explanation": "The pipeline is Rust source, then `cargo-build-sbf`, then a `.so` ELF containing SBF bytecode, then `solana program deploy` uploads that binary. Validators execute bytecode, never source — which is why the compile step happens before deployment."
+          }
+        ],
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       }
-    ],
-    "slug": "from-code-to-chain",
-    "title": "From Code to Chain"
+    ]
   },
   {
     "_id": "lesson-bfsp-m4-airdrop",
+    "title": "Airdrop & Fund Your Wallet",
+    "slug": "airdrop-fund-wallet",
     "blocks": [
       {
-        "_type": "prose",
-        "amount": null,
-        "buildType": null,
-        "consumes": null,
-        "deployable": null,
-        "hints": null,
-        "idl": null,
         "key": "intro",
-        "language": null,
-        "maxWords": null,
-        "network": null,
+        "_type": "prose",
         "produces": null,
-        "prompt": null,
-        "questions": null,
-        "solution": null,
-        "src": "# Airdrop & Fund Your Wallet\n\nBefore deploying your program, you need devnet SOL to pay for the on-chain storage (called \"rent\").\n\n## How Much SOL Do You Need?\n\nDeploying an Anchor program requires approximately **2 SOL** on devnet:\n- **~1.4 SOL** for the buffer account (temporary storage during upload)\n- **~0.1 SOL** for the program account\n- **~0.3 SOL** for transaction fees (200+ transactions)\n\nThe good news: most of this rent is **reclaimable** after deployment.\n\n## The Devnet Faucet\n\nSolana provides a free faucet on devnet. You can request **2 SOL per airdrop**.\n\nUse the widget below to fund your wallet. You'll need at least 4-5 SOL to comfortably deploy.\n\n> **Tip**: The faucet can be slow during peak hours. If you see \"faucet is busy,\" just wait 30-60 seconds and try again. This is normal — devnet is a shared resource.\n\n## What is Rent?\n\nOn Solana, every account must maintain a minimum balance called **rent**. This prevents spam accounts from filling up validator storage.\n\nThe rent amount depends on the account's data size:\n\n```\nrent = base_rent + (data_size * rent_per_byte)\n```\n\nFor a 200KB program binary, the buffer account rent is ~1.4 SOL.\n\nAccounts that maintain the minimum balance are **rent-exempt** — they won't be garbage collected.\n",
+        "consumes": null,
+        "src": "# Airdrop & Fund Your Wallet\n\nBefore deploying your program, you need devnet SOL to pay for the on-chain storage (called \"rent\").\n\n## How Much SOL Do You Need?\n\nDeploying an Anchor program requires approximately **2 SOL** on devnet:\n- **~1.4 SOL** for the buffer account (temporary storage during upload)\n- **~0.1 SOL** for the program account\n- **~0.3 SOL** for transaction fees (200+ transactions)\n\nThe good news: most of this rent is **reclaimable** after deployment.\n\n## The Devnet Faucet\n\nSolana provides a free faucet on devnet. The web faucet at [faucet.solana.com](https://faucet.solana.com) is the reliable path — airdrops through the public RPC (`solana airdrop`) are throttled more aggressively. The web faucet is rate-limited by **request frequency** (a maximum of 2 requests every 8 hours, as of mid-2026); signing in with GitHub raises that limit.\n\nUse the widget below to fund your wallet. You'll need at least 4-5 SOL to comfortably deploy — because of the request-frequency limit, that may take more than one faucet visit, which is expected, not a failure.\n\n> **Tip**: The faucet can be slow during peak hours. If you see \"faucet is busy,\" just wait 30-60 seconds and try again. This is normal — devnet is a shared resource.\n\n## What is Rent?\n\nOn Solana, every account must maintain a minimum balance called **rent**. This prevents spam accounts from filling up validator storage.\n\nThe rent amount depends on the account's data size:\n\n```\nrent = base_rent + (data_size * rent_per_byte)\n```\n\nFor a 200KB program binary, the buffer account rent is ~1.4 SOL.\n\nAccounts that maintain the minimum balance are **rent-exempt** — they won't be garbage collected.\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
         "starter": null,
+        "solution": null,
         "tests": null,
-        "url": null
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       },
       {
-        "_type": "wallet-funding",
-        "amount": 2,
-        "buildType": null,
-        "consumes": null,
-        "deployable": null,
-        "hints": null,
-        "idl": null,
         "key": "fund",
-        "language": null,
-        "maxWords": null,
-        "network": "devnet",
+        "_type": "wallet-funding",
         "produces": "funded-wallet",
-        "prompt": null,
-        "questions": null,
-        "solution": null,
+        "consumes": null,
         "src": null,
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
         "starter": null,
+        "solution": null,
         "tests": null,
-        "url": null
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": 2,
+        "network": "devnet",
+        "idl": null
+      },
+      {
+        "key": "retrieval-close",
+        "_type": "quiz",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": [
+          {
+            "id": "q1",
+            "prompt": "Deploying a ~200KB program needs ~1.4 SOL just for the buffer account. Why does the buffer cost scale with the program's size?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "The buffer temporarily stores the whole binary on-chain, and rent is proportional to an account's data size",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "Larger programs pay a higher fixed deployment fee",
+                "correct": false,
+                "feedback": "It is not a fixed fee — the cost is rent on the buffer account, and rent scales with bytes stored. A bigger binary needs a bigger, costlier buffer."
+              },
+              {
+                "id": "c",
+                "label": "The validator charges per instruction, and big programs have more instructions",
+                "correct": false,
+                "feedback": "The ~1.4 SOL is buffer-account rent, sized by the binary's byte length, not a per-instruction charge."
+              }
+            ],
+            "explanation": "Deployment first uploads the binary into a temporary buffer account whose rent follows base + data_size * rent_per_byte. A 200KB binary needs a 200KB buffer, hence ~1.4 SOL — and because most of that rent is reclaimable, you get much of it back after finalizing."
+          },
+          {
+            "id": "q2",
+            "prompt": "You airdrop exactly 2 SOL, then try to deploy. Why does the lesson tell you to get 4-5 SOL instead?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "Deployment needs ~2 SOL for buffer + program + fees, so 2 leaves no margin for retries or fee variance",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "Because half of every airdrop is burned",
+                "correct": false,
+                "feedback": "Airdrops are not burned. The buffer alone can be ~1.4 SOL and fees ~0.3, so 2 SOL leaves no cushion; 4-5 gives comfortable margin."
+              },
+              {
+                "id": "c",
+                "label": "Because programs require a minimum 4 SOL balance to deploy",
+                "correct": false,
+                "feedback": "There is no fixed 4 SOL minimum — actual cost is ~2 SOL. You aim for 4-5 to absorb retries, fee spikes, and the 200+ transactions."
+              }
+            ],
+            "explanation": "Real deployment cost is ~2 SOL (buffer ~1.4, program ~0.1, fees ~0.3 across 200+ transactions). Airdropping only 2 leaves zero room for a failed-and-resumed upload or fee variance, so the lesson buffers you to 4-5 SOL."
+          }
+        ],
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       }
-    ],
-    "slug": "airdrop-fund-wallet",
-    "title": "Airdrop & Fund Your Wallet"
+    ]
   },
   {
     "_id": "lesson-bfsp-m4-capstone",
@@ -1096,8 +1857,1145 @@
         "key": "deployed",
         "_type": "deployed-program-card",
         "produces": null,
-        "consumes": ["deployed-program"],
+        "consumes": [
+          "deployed-program"
+        ],
         "src": null,
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "retrieval-close",
+        "_type": "quiz",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": [
+          {
+            "id": "q1",
+            "prompt": "Your program was deployed via the BPF Loader Upgradeable. What does 'upgradeable' let the upgrade authority do?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "Replace the program's bytecode at the same program id later, without changing its address",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "Let anyone modify the program's code",
+                "correct": false,
+                "feedback": "Only the upgrade authority can upgrade, not anyone. Upgradeable means the code behind the id can be replaced by that authority, keeping the same address."
+              },
+              {
+                "id": "c",
+                "label": "Automatically migrate all account data when the code changes",
+                "correct": false,
+                "feedback": "Upgrades swap code only; account data is untouched and stays where it is. Any data migration is the developer's job."
+              }
+            ],
+            "explanation": "Under the BPF Loader Upgradeable, the program account points to executable data that the upgrade authority can replace, so you fix or extend the program at the same id. State lives in separate accounts and is unaffected — the stateless-program design is what makes clean upgrades possible."
+          },
+          {
+            "id": "q2",
+            "prompt": "You want to fix a bug in your deployed counter. Which statement about the program account and its data is true?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "The program account points to the executable; the upgrade authority uploads new bytecode and the account points to it",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "You must deploy a new program at a new id and abandon the old one",
+                "correct": false,
+                "feedback": "Only if it were non-upgradeable. As upgradeable, you replace the bytecode at the same id via the upgrade authority — clients and PDAs keep working."
+              },
+              {
+                "id": "c",
+                "label": "Editing the program automatically wipes existing counter accounts",
+                "correct": false,
+                "feedback": "Counter accounts are separate state and survive an upgrade. Upgrading changes code, not the accounts your program created."
+              }
+            ],
+            "explanation": "An upgradeable program account references executable data that the upgrade authority can swap, so bug fixes reuse the same program id. Because state is stored in separate accounts, existing counters persist across the upgrade — code and data are decoupled by design."
+          }
+        ],
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      }
+    ]
+  },
+  {
+    "_id": "lesson-bfsp-m4-deploy",
+    "title": "Deploy Your Program to Devnet",
+    "slug": "deploy-program-devnet",
+    "blocks": [
+      {
+        "key": "intro",
+        "_type": "prose",
+        "produces": null,
+        "consumes": null,
+        "src": "# Deploy Your Program to Devnet\n\nThis is it — you're about to deploy your counter program to the Solana blockchain.\n\n## The Deployment Process\n\nDeploying a Solana program involves 4 steps:\n\n1. **Compile**: Your Rust code → `.so` binary (already done by the build server)\n2. **Create Buffer**: A temporary on-chain account to hold the binary during upload\n3. **Upload Chunks**: The binary is uploaded in ~1000-byte chunks (200+ transactions for a typical program)\n4. **Finalize**: Link the buffer to a new program account, making it executable\n\nThis follows the **BPF Loader Upgradeable** protocol — the standard way all Anchor programs are deployed.\n\n## What You'll See\n\n- **1 wallet popup** to create the buffer account\n- **Batch signing** every ~30 chunks (to avoid blockhash expiry)\n- **A real-time transaction log** showing each chunk being confirmed\n- **Your Program ID** when deployment completes\n\n## Instructions\n\n1. Click **Build** to compile your counter program\n2. When the build succeeds, click **Deploy to Devnet**\n3. Approve the transactions in your wallet\n4. Watch the deployment progress in real time!\n\n> **If deployment fails**: Don't worry! The system saves your progress. Click **Resume** to pick up where you left off — you won't re-upload chunks that already succeeded.\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "exercise",
+        "_type": "code",
+        "produces": "deployed-program",
+        "consumes": [
+          "funded-wallet"
+        ],
+        "src": null,
+        "url": null,
+        "language": "rust",
+        "buildType": "buildable",
+        "deployable": true,
+        "starter": "use anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n#[program]\npub mod academy_program {\n    use super::*;\n\n    pub fn initialize(ctx: Context<Initialize>) -> Result<()> {\n        let counter = &mut ctx.accounts.counter;\n        counter.count = 0;\n        counter.authority = ctx.accounts.user.key();\n        msg!(\"Counter initialized!\");\n        Ok(())\n    }\n\n    pub fn greet(_ctx: Context<Greet>) -> Result<()> {\n        msg!(\"Hello, Solana!\");\n        Ok(())\n    }\n\n    pub fn increment(ctx: Context<Increment>) -> Result<()> {\n        let counter = &mut ctx.accounts.counter;\n        counter.count += 1;\n        Ok(())\n    }\n\n    pub fn decrement(ctx: Context<Decrement>) -> Result<()> {\n        let counter = &mut ctx.accounts.counter;\n        require!(counter.count > 0, ErrorCode::Underflow);\n        counter.count -= 1;\n        Ok(())\n    }\n}\n\n#[derive(Accounts)]\npub struct Initialize<'info> {\n    #[account(\n        init,\n        payer = user,\n        space = 8 + 8 + 32,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n    pub system_program: Program<'info, System>,\n}\n\n#[derive(Accounts)]\npub struct Greet {}\n\n#[derive(Accounts)]\npub struct Increment<'info> {\n    #[account(\n        mut,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    pub user: Signer<'info>,\n}\n\n#[derive(Accounts)]\npub struct Decrement<'info> {\n    #[account(\n        mut,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    pub user: Signer<'info>,\n}\n\n#[account]\npub struct Counter {\n    pub count: u64,\n    pub authority: Pubkey,\n}\n\n#[error_code]\npub enum ErrorCode {\n    #[msg(\"Cannot decrement below zero\")]\n    Underflow,\n}\n",
+        "solution": "use anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n#[program]\npub mod academy_program {\n    use super::*;\n\n    pub fn initialize(ctx: Context<Initialize>) -> Result<()> {\n        let counter = &mut ctx.accounts.counter;\n        counter.count = 0;\n        counter.authority = ctx.accounts.user.key();\n        msg!(\"Counter initialized!\");\n        Ok(())\n    }\n\n    pub fn greet(_ctx: Context<Greet>) -> Result<()> {\n        msg!(\"Hello, Solana!\");\n        Ok(())\n    }\n\n    pub fn increment(ctx: Context<Increment>) -> Result<()> {\n        let counter = &mut ctx.accounts.counter;\n        counter.count += 1;\n        Ok(())\n    }\n\n    pub fn decrement(ctx: Context<Decrement>) -> Result<()> {\n        let counter = &mut ctx.accounts.counter;\n        require!(counter.count > 0, ErrorCode::Underflow);\n        counter.count -= 1;\n        Ok(())\n    }\n}\n\n#[derive(Accounts)]\npub struct Initialize<'info> {\n    #[account(\n        init,\n        payer = user,\n        space = 8 + 8 + 32,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n    pub system_program: Program<'info, System>,\n}\n\n#[derive(Accounts)]\npub struct Greet {}\n\n#[derive(Accounts)]\npub struct Increment<'info> {\n    #[account(\n        mut,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    pub user: Signer<'info>,\n}\n\n#[derive(Accounts)]\npub struct Decrement<'info> {\n    #[account(\n        mut,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    pub user: Signer<'info>,\n}\n\n#[account]\npub struct Counter {\n    pub count: u64,\n    pub authority: Pubkey,\n}\n\n#[error_code]\npub enum ErrorCode {\n    #[msg(\"Cannot decrement below zero\")]\n    Underflow,\n}\n",
+        "tests": [
+          {
+            "id": "test-deploy-1",
+            "description": "Complete counter program compiles successfully",
+            "input": "",
+            "expectedOutput": "true"
+          }
+        ],
+        "hints": [
+          "This is the same counter program from Module 3. Click Build to compile it, then Deploy to Devnet.",
+          "Make sure you have at least 2 SOL in your wallet. Use the previous lesson to airdrop if needed.",
+          "If deployment fails mid-way, click Resume — it will pick up where it left off."
+        ],
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "retrieval-close",
+        "_type": "quiz",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": [
+          {
+            "id": "q1",
+            "prompt": "The binary is uploaded in ~1000-byte chunks across 200+ transactions, with batch signing every ~30 chunks. Why not upload it in one transaction?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "A Solana transaction has a strict ~1232-byte size limit, so a large binary must be split across many transactions",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "Chunking makes the upload faster than a single transaction",
+                "correct": false,
+                "feedback": "It is about size limits, not speed. A whole 200KB binary cannot fit in one ~1232-byte transaction, so it is split into many."
+              },
+              {
+                "id": "c",
+                "label": "Each chunk deploys a separate program",
+                "correct": false,
+                "feedback": "All chunks build one program in a buffer. They are pieces of a single binary, not separate programs."
+              }
+            ],
+            "explanation": "Solana caps transaction size around 1232 bytes, far smaller than a program binary, so the loader writes the binary into a buffer ~1000 bytes at a time — hence 200+ transactions. Batch-signing every ~30 keeps a fresh-enough blockhash so chunks do not expire mid-upload."
+          },
+          {
+            "id": "q2",
+            "prompt": "Deployment fails halfway through the chunk uploads. You click Resume. What does Resume do?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "It continues uploading only the chunks that have not landed yet, reusing the buffer, without re-sending confirmed chunks",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "It restarts the entire upload from chunk zero",
+                "correct": false,
+                "feedback": "Resume is the point of the buffer: already-confirmed chunks persist on-chain, so it picks up where it stopped rather than redoing 200 transactions."
+              },
+              {
+                "id": "c",
+                "label": "It redeploys as a brand-new program with a new id",
+                "correct": false,
+                "feedback": "The program id and buffer are preserved. Resume finishes the same deployment; it does not mint a new program."
+              }
+            ],
+            "explanation": "Confirmed chunks are already written to the on-chain buffer, so Resume checks what has landed and uploads only the remainder. This is why a flaky connection mid-deploy costs seconds, not a full re-upload of 200+ transactions."
+          }
+        ],
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      }
+    ]
+  },
+  {
+    "_id": "lesson-bfsp-m4-interact",
+    "title": "Interact with Your Program",
+    "slug": "interact-with-program",
+    "blocks": [
+      {
+        "key": "intro",
+        "_type": "prose",
+        "produces": null,
+        "consumes": null,
+        "src": "# Interact with Your Program\n\nYour counter program is live on Solana Devnet. Now let's call its instructions and watch the on-chain state change in real time.\n\n## What You'll Do\n\n1. **Initialize** a counter account — creates a new account owned by your program\n2. **Increment** the counter — modifies the on-chain state\n3. **Decrement** the counter — see your custom error handling in action\n\n## Understanding the Data\n\nThe Program Explorer below shows two views of your counter account:\n\n### Parsed Data\nThe human-readable version: `count: 3`\n\n### Raw Data (Hex)\nWhat's actually stored on-chain:\n```\n[a8 fc 0b 1f 05 77 32 45 | 03 00 00 00 00 00 00 00]\n ^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^^^^^^^^^^\n discriminator (8 bytes)    count: 3 (u64 LE)\n```\n\nThe **discriminator** is Anchor's way of identifying account types. It's the first 8 bytes of `sha256(\"account:Counter\")`. Every Anchor account starts with this — it's how the runtime knows it's looking at a `Counter` struct and not random data.\n\nThe **count** is stored as a `u64` in **little-endian** byte order. The value `3` is `03 00 00 00 00 00 00 00` because the least significant byte comes first.\n\n## Try This\n\n1. Click **Initialize** — watch the discriminator bytes appear\n2. Click **Increment** 3 times — watch `count` change from `00` to `03`\n3. Click **Decrement** down to 0, then try decrementing again\n4. See your `#[error_code] Underflow` in action!\n\n> **Teaching moment**: When you decrement below zero, your custom error `Cannot decrement below zero` is enforced by the Solana runtime. This is your code running on a real blockchain, enforcing rules you defined.\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "explore",
+        "_type": "program-explorer",
+        "produces": null,
+        "consumes": [
+          "deployed-program"
+        ],
+        "src": null,
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": "{\"address\":\"11111111111111111111111111111111\",\"metadata\":{\"name\":\"counter\",\"version\":\"0.1.0\",\"spec\":\"0.1.0\"},\"instructions\":[{\"name\":\"initialize\",\"discriminator\":[175,175,109,31,13,152,155,237],\"accounts\":[{\"name\":\"counter\",\"writable\":true,\"pda\":{\"seeds\":[{\"kind\":\"const\",\"value\":[99,111,117,110,116,101,114]},{\"kind\":\"account\",\"path\":\"user\"}]}},{\"name\":\"user\",\"writable\":true,\"signer\":true},{\"name\":\"system_program\",\"address\":\"11111111111111111111111111111111\"}],\"args\":[]},{\"name\":\"increment\",\"discriminator\":[11,18,104,9,104,174,59,33],\"accounts\":[{\"name\":\"counter\",\"writable\":true,\"pda\":{\"seeds\":[{\"kind\":\"const\",\"value\":[99,111,117,110,116,101,114]},{\"kind\":\"account\",\"path\":\"user\"}]}},{\"name\":\"user\",\"signer\":true}],\"args\":[]},{\"name\":\"decrement\",\"discriminator\":[106,227,168,59,248,27,150,101],\"accounts\":[{\"name\":\"counter\",\"writable\":true,\"pda\":{\"seeds\":[{\"kind\":\"const\",\"value\":[99,111,117,110,116,101,114]},{\"kind\":\"account\",\"path\":\"user\"}]}},{\"name\":\"user\",\"signer\":true}],\"args\":[]}],\"accounts\":[{\"name\":\"Counter\",\"discriminator\":[255,176,4,245,188,253,124,25]}],\"types\":[{\"name\":\"Counter\",\"type\":{\"kind\":\"struct\",\"fields\":[{\"name\":\"count\",\"type\":\"u64\"},{\"name\":\"authority\",\"type\":\"publicKey\"}]}}],\"errors\":[{\"code\":6000,\"name\":\"Underflow\",\"msg\":\"Cannot decrement below zero\"}]}\n"
+      },
+      {
+        "key": "retrieval-close",
+        "_type": "quiz",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": [
+          {
+            "id": "q1",
+            "prompt": "The raw hex for the counter reads (after the discriminator) `03 00 00 00 00 00 00 00`. What is the value, and why is `03` first?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "3 — the u64 is stored little-endian, so the least significant byte comes first",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "A very large number — the bytes read left to right as big-endian",
+                "correct": false,
+                "feedback": "Solana stores integers little-endian, so `03 00 ...` is 3, not a huge big-endian value. The least significant byte leads."
+              },
+              {
+                "id": "c",
+                "label": "3, but little-endian would write it as `00 00 00 00 00 00 00 03`",
+                "correct": false,
+                "feedback": "Little-endian puts the least significant byte first, so 3 is `03 00 00 00 00 00 00 00`. The `00 ... 03` layout is big-endian."
+              }
+            ],
+            "explanation": "A `u64` equal to 3 is `03 00 00 00 00 00 00 00` in little-endian, the byte order Solana uses. Reading raw account data means accounting for both the leading 8-byte discriminator and little-endian integer layout — exactly what a manual byte decoder must handle."
+          },
+          {
+            "id": "q2",
+            "prompt": "When you decrement below zero, the error `Cannot decrement below zero` appears. Where is that rule actually enforced?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "By the Solana runtime executing your deployed program's `require!` check — your own on-chain code",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "By the browser UI before the transaction is sent",
+                "correct": false,
+                "feedback": "The UI is not the enforcer; a client could bypass it. The rule lives in your deployed program and the runtime enforces it, which is why it holds against any caller."
+              },
+              {
+                "id": "c",
+                "label": "By the RPC node validating the request",
+                "correct": false,
+                "feedback": "RPC nodes forward transactions; they do not run your business rules. The `require!` guard executes inside your program on the validator."
+              }
+            ],
+            "explanation": "The `#[error_code]` Underflow and its `require!` guard run inside your program on-chain, so the Solana runtime enforces them regardless of which client sends the transaction. That is the difference between a UI check anyone can skip and a rule that actually holds on a public network."
+          }
+        ],
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      }
+    ]
+  },
+  {
+    "_id": "lesson-bfsp-on-chain-state",
+    "title": "On-Chain State",
+    "slug": "on-chain-state",
+    "blocks": [
+      {
+        "key": "intro",
+        "_type": "prose",
+        "produces": null,
+        "consumes": null,
+        "src": "# On-Chain State\n\nSo far, our program doesn't store any data. Every instruction just logs a message and exits. To build anything useful, you need **on-chain state** — data that persists between transactions.\n\n## Accounts = Storage\n\nOn Solana, all state lives in **accounts**. An account is a buffer of bytes owned by a program. Think of it like a row in a database, but on-chain.\n\nEvery account has:\n- **Address** (public key) — how you find it\n- **Owner** (program ID) — which program can modify it\n- **Data** (byte array) — the actual state\n- **Lamports** (balance) — rent deposit to keep it alive\n\n## The Discriminator\n\nAnchor adds an 8-byte **discriminator** at the start of every account's data. This is a hash of the account type name, used to prevent account type confusion attacks.\n\n```\n[8 bytes discriminator][...your data...]\n```\n\nYou never read or write the discriminator directly — Anchor handles it.\n\n## Space Calculation\n\nWhen you create an account, you must specify its size upfront (accounts can't be resized after creation). The formula:\n\n```\nspace = 8 (discriminator) + sum of field sizes\n```\n\nCommon field sizes:\n- `u8` / `i8` / `bool` = 1 byte\n- `u16` / `i16` = 2 bytes\n- `u32` / `i32` = 4 bytes\n- `u64` / `i64` = 8 bytes\n- `u128` / `i128` = 16 bytes\n- `Pubkey` = 32 bytes\n- `String` = 4 (length prefix) + content bytes\n- `Vec<T>` = 4 (length prefix) + (count * size_of::<T>())\n\n## Example: A Counter\n\nA simple counter needs one `u64` field:\n\n```rust\n#[account]\npub struct Counter {\n    pub count: u64,  // 8 bytes\n}\n// Total space = 8 (discriminator) + 8 (u64) = 16 bytes\n```\n\nThe `#[account]` attribute tells Anchor to:\n1. Add serialization/deserialization (Borsh)\n2. Add the 8-byte discriminator\n3. Implement account validation traits\n\nIn the next challenge, you'll define this Counter account and wire it into your program.\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "retrieval-close",
+        "_type": "quiz",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": [
+          {
+            "id": "q1",
+            "prompt": "A `Counter` holds one `u64`. What `space` must you allocate, and why that number?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "16 bytes — 8 for the discriminator plus 8 for the u64",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "8 bytes — just the u64",
+                "correct": false,
+                "feedback": "You forgot the discriminator. Every Anchor account starts with an 8-byte type discriminator, so a single u64 account needs 8 + 8 = 16."
+              },
+              {
+                "id": "c",
+                "label": "24 bytes — 8 discriminator + 8 length prefix + 8 u64",
+                "correct": false,
+                "feedback": "A fixed-size `u64` has no length prefix; only dynamic types like String and Vec add one. The total is 8 + 8 = 16."
+              }
+            ],
+            "explanation": "space = 8 (discriminator) + sum of field sizes. A `u64` is 8 bytes, so a Counter is 8 + 8 = 16. This matters because accounts cannot be resized after creation — too small and writes fail, too large and the payer overpays rent."
+          },
+          {
+            "id": "q2",
+            "prompt": "Anchor prepends an 8-byte discriminator (a hash of the account type name) to every account. What attack does this prevent?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "Account type confusion — passing a different account type where a Counter is expected, since its discriminator will not match",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "Double-spending of lamports",
+                "correct": false,
+                "feedback": "The discriminator is about type identity, not balances. It stops a program from mistaking one account type for another."
+              },
+              {
+                "id": "c",
+                "label": "Replaying an old transaction",
+                "correct": false,
+                "feedback": "Replay is handled by the recent blockhash, not the discriminator. The discriminator guards account type identity on deserialize."
+              }
+            ],
+            "explanation": "The 8-byte discriminator is derived from the account's type name, so Anchor rejects an account whose leading bytes do not match the expected `Counter` type. Without it, an attacker could pass a look-alike account and trick the program into interpreting foreign bytes as your struct."
+          }
+        ],
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      }
+    ]
+  },
+  {
+    "_id": "lesson-bfsp-wire-up-initialize",
+    "title": "Wire Up Initialize",
+    "slug": "wire-up-initialize",
+    "blocks": [
+      {
+        "key": "intro",
+        "_type": "prose",
+        "produces": null,
+        "consumes": null,
+        "src": "# Challenge: Wire Up Initialize\n\nThis challenge is different. The starter code has a **deliberate bug** — it won't compile.\n\nYour job:\n1. Click **Build** to see the compiler error\n2. Read the error message carefully\n3. Fix the code\n4. Build again until it compiles\n\n## The Bug\n\nThe `Initialize` struct uses `#[account(init, ...)]` to create a `Counter` PDA, but it's missing a required account. When Anchor generates the account creation code, it needs the System Program to execute the `create_account` instruction.\n\n## What You'll Learn\n\nThis is the most common Anchor compile error you'll encounter in the wild. Learning to diagnose it now saves you hours of debugging later.\n\n## Requirements\n\n1. Read the compiler error output\n2. Add the missing account to `Initialize`\n3. Make sure `initialize` sets `counter.count = 0` and `counter.authority = ctx.accounts.user.key()`\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "exercise",
+        "_type": "code",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": "rust",
+        "buildType": "buildable",
+        "deployable": false,
+        "starter": "use anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n#[program]\npub mod academy_program {\n    use super::*;\n\n    pub fn initialize(ctx: Context<Initialize>) -> Result<()> {\n        let counter = &mut ctx.accounts.counter;\n        counter.count = 0;\n        counter.authority = ctx.accounts.user.key();\n        msg!(\"Counter initialized!\");\n        Ok(())\n    }\n\n    pub fn greet(_ctx: Context<Greet>) -> Result<()> {\n        msg!(\"Hello, Solana!\");\n        Ok(())\n    }\n}\n\n#[derive(Accounts)]\npub struct Initialize<'info> {\n    #[account(\n        init,\n        payer = user,\n        space = 8 + 8 + 32,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n    // BUG: Something is missing here...\n}\n\n#[derive(Accounts)]\npub struct Greet {}\n\n#[account]\npub struct Counter {\n    pub count: u64,\n    pub authority: Pubkey,\n}\n",
+        "solution": "use anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n#[program]\npub mod academy_program {\n    use super::*;\n\n    pub fn initialize(ctx: Context<Initialize>) -> Result<()> {\n        let counter = &mut ctx.accounts.counter;\n        counter.count = 0;\n        counter.authority = ctx.accounts.user.key();\n        msg!(\"Counter initialized!\");\n        Ok(())\n    }\n\n    pub fn greet(_ctx: Context<Greet>) -> Result<()> {\n        msg!(\"Hello, Solana!\");\n        Ok(())\n    }\n}\n\n#[derive(Accounts)]\npub struct Initialize<'info> {\n    #[account(\n        init,\n        payer = user,\n        space = 8 + 8 + 32,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n    pub system_program: Program<'info, System>,\n}\n\n#[derive(Accounts)]\npub struct Greet {}\n\n#[account]\npub struct Counter {\n    pub count: u64,\n    pub authority: Pubkey,\n}\n",
+        "tests": [
+          {
+            "id": "test-1",
+            "description": "Program compiles successfully",
+            "input": "",
+            "expectedOutput": "true"
+          },
+          {
+            "id": "test-2",
+            "description": "Initialize struct includes system_program",
+            "input": "",
+            "expectedOutput": "true"
+          },
+          {
+            "id": "test-3",
+            "description": "Counter is initialized to zero",
+            "input": "",
+            "expectedOutput": "true"
+          }
+        ],
+        "hints": [
+          "Click Build first to see the error. The compiler will tell you what's missing.",
+          "The error mentions a trait bound related to Accounts. This happens when a required account is missing from the struct.",
+          "Add `pub system_program: Program<'info, System>,` to the Initialize struct. The System Program is required whenever you use `#[account(init)]`."
+        ],
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null,
+        "tutorNotes": [
+          "Learners try to satisfy the failing build by deleting or loosening the `init` constraint, instead of supplying the account that `init` requires.",
+          "They read only the surface of the trait-bound error, which names `Accounts` rather than a field, and start editing the wrong struct.",
+          "They guess at a fix without clicking Build first, so they never read what the compiler is actually asking for.",
+          "When they do add the missing account they give it a bare `AccountInfo` or `UncheckedAccount` type instead of the typed program wrapper Anchor expects."
+        ]
+      },
+      {
+        "key": "retrieval-close",
+        "_type": "quiz",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": [
+          {
+            "id": "q1",
+            "prompt": "An `Initialize` struct uses `#[account(init, ...)]` but omits the System Program. What does the compiler tell you, and why?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "A trait-bound error on `Accounts` — `init` generates a `create_account` CPI that needs the System Program present",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "A runtime 'account not found' error, only when the instruction is called",
+                "correct": false,
+                "feedback": "It fails at compile time, not runtime. Anchor cannot generate valid account-creation code without the System Program, so the build breaks."
+              },
+              {
+                "id": "c",
+                "label": "No error — Anchor injects the System Program automatically",
+                "correct": false,
+                "feedback": "Anchor does not inject it. `init` requires you to declare `system_program: Program<'info, System>` explicitly, or the generated code fails the Accounts trait."
+              }
+            ],
+            "explanation": "Account creation is a CPI to the System Program, so `init` only compiles when that program is in the accounts struct. Omitting it makes Anchor's generated code fail the `Accounts` trait bound — a cryptic-looking error whose fix is always to add the missing account."
+          },
+          {
+            "id": "q2",
+            "prompt": "Why is learning to read this trait-bound error worth a whole lesson?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "It is the most common Anchor compile error, and its message points at a trait rather than the real cause: a missing account",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "Because it only appears on devnet, never locally",
+                "correct": false,
+                "feedback": "It is a compile-time error, identical everywhere. The lesson exists because the message is indirect, not because it is environment-specific."
+              },
+              {
+                "id": "c",
+                "label": "Because it means your program is unsafe to deploy",
+                "correct": false,
+                "feedback": "It is not a safety warning — it is a missing-account compile error. The point is recognizing the indirect message and knowing the fix."
+              }
+            ],
+            "explanation": "Because Anchor generates account-validation code via macros, a missing account surfaces as a trait-bound error on `Accounts`, not a plain 'you forgot system_program.' Recognizing that pattern turns hours of confusion into a one-line fix."
+          }
+        ],
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      }
+    ]
+  },
+  {
+    "_id": "lesson-bfsp-your-first-build",
+    "title": "Your First Build",
+    "slug": "your-first-build",
+    "blocks": [
+      {
+        "key": "intro",
+        "_type": "prose",
+        "produces": null,
+        "consumes": null,
+        "src": "# Your First Build\n\nThis is the simplest challenge in the entire course. Your goal: **hit the Build button and see it succeed.**\n\nThe starter code is a minimal Anchor program that compiles with zero changes. Don't modify anything — just click **Build** and watch the build server compile your first Solana program.\n\n## What to Expect\n\n- The build takes 30-60 seconds on first run (dependencies are cached after that)\n- You'll see compiler output in the panel below\n- A green checkmark means your program compiled to a `.so` binary\n- The build UUID is your compiled program's identifier\n\n## Why This Matters\n\nThis proves the pipeline works end-to-end: your code leaves the browser, reaches the build server, gets compiled by `cargo-build-sbf`, and the result comes back. Every lesson after this builds on this foundation.\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "exercise",
+        "_type": "code",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": "rust",
+        "buildType": "buildable",
+        "deployable": false,
+        "starter": "use anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n#[program]\npub mod academy_program {\n    use super::*;\n\n    pub fn initialize(_ctx: Context<Initialize>) -> Result<()> {\n        msg!(\"Superteam Academy default program\");\n        Ok(())\n    }\n}\n\n#[derive(Accounts)]\npub struct Initialize {}\n",
+        "solution": "use anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n#[program]\npub mod academy_program {\n    use super::*;\n\n    pub fn initialize(_ctx: Context<Initialize>) -> Result<()> {\n        msg!(\"Superteam Academy default program\");\n        Ok(())\n    }\n}\n\n#[derive(Accounts)]\npub struct Initialize {}\n",
+        "tests": [
+          {
+            "id": "test-1",
+            "description": "Program compiles successfully",
+            "input": "",
+            "expectedOutput": "true"
+          }
+        ],
+        "hints": [
+          "You don't need to change anything — just click the Build button",
+          "If the build times out, try again. First builds take longer because dependencies are being downloaded.",
+          "If you see errors, make sure you haven't accidentally modified the starter code. Click Reset Code to restore it."
+        ],
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "retrieval-close",
+        "_type": "quiz",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": [
+          {
+            "id": "q1",
+            "prompt": "The first build takes 30-60 seconds but later builds are fast. Why?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "The first build downloads and compiles all dependencies; those are cached, so later builds only recompile your changed code",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "The build server is warming up its hardware",
+                "correct": false,
+                "feedback": "It is not hardware warm-up. The first build resolves and compiles the full dependency tree; that work is cached afterward."
+              },
+              {
+                "id": "c",
+                "label": "Later builds skip compilation and reuse the same binary",
+                "correct": false,
+                "feedback": "Later builds still compile — but only your changed code, reusing cached dependencies. They do not blindly reuse the old binary, or your edits would never take effect."
+              }
+            ],
+            "explanation": "A cold build resolves and compiles the entire dependency graph, which dominates the time. Those compiled dependencies are cached, so later builds recompile only your source — the same reason local `cargo build` is slow once and fast after."
+          },
+          {
+            "id": "q2",
+            "prompt": "A green checkmark appears after your build. What does it actually confirm?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "Your code compiled to a `.so` binary and the whole browser-to-build-server-to-compiler pipeline works end-to-end",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "Your program is now deployed and live on devnet",
+                "correct": false,
+                "feedback": "Building is not deploying. A green check means compilation succeeded; deployment is a separate step later in the course."
+              },
+              {
+                "id": "c",
+                "label": "Your program passed its on-chain tests",
+                "correct": false,
+                "feedback": "No on-chain execution happened yet. The check confirms compilation to a binary, not runtime behavior."
+              }
+            ],
+            "explanation": "The green check means `cargo-build-sbf` turned your source into a `.so` binary and returned it, proving the pipeline works. Deployment and on-chain execution are later, separate steps."
+          }
+        ],
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      }
+    ]
+  },
+  {
+    "_id": "lesson-connect-wallet-challenge",
+    "title": "Challenge: Wallet Connection Flow",
+    "slug": "connect-wallet-challenge",
+    "blocks": [
+      {
+        "key": "intro",
+        "_type": "prose",
+        "produces": null,
+        "consumes": null,
+        "src": "# Challenge: Wallet Connection Flow\n\nSimulate a wallet connection flow by generating a keypair (representing a wallet) and extracting key information.\n\n## Requirements\n\n- Create a function that simulates connecting to a wallet\n- Generate a new keypair to represent the wallet\n- Validate that the public key is on the ed25519 curve\n- Return an object with `publicKey` (base58 string), `connected` (boolean), and `isValid` (boolean)\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "exercise",
+        "_type": "code",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": "typescript",
+        "buildType": "standard",
+        "deployable": false,
+        "starter": "import { Keypair, PublicKey } from '@solana/web3.js';\n\nfunction simulateWalletConnection(): {\n  publicKey: string;\n  connected: boolean;\n  isValid: boolean;\n} {\n  // Your code here\n}\n",
+        "solution": "import { Keypair, PublicKey } from '@solana/web3.js';\n\nfunction simulateWalletConnection(): {\n  publicKey: string;\n  connected: boolean;\n  isValid: boolean;\n} {\n  const keypair = Keypair.generate();\n  const publicKeyStr = keypair.publicKey.toBase58();\n  \n  return {\n    publicKey: publicKeyStr,\n    connected: true,\n    isValid: PublicKey.isOnCurve(keypair.publicKey.toBytes()),\n  };\n}\n",
+        "tests": [
+          {
+            "id": "t1",
+            "description": "Returns publicKey, connected and isValid with correct types",
+            "input": "",
+            "expectedOutput": "typeof result.publicKey === 'string' && typeof result.connected === 'boolean' && typeof result.isValid === 'boolean'"
+          },
+          {
+            "id": "t2",
+            "description": "publicKey has a valid base58 length",
+            "input": "",
+            "expectedOutput": "result.publicKey.length >= 32 && result.publicKey.length <= 44"
+          },
+          {
+            "id": "t3",
+            "description": "Wallet is connected and the key is on-curve",
+            "input": "",
+            "expectedOutput": "result.connected === true && result.isValid === true"
+          }
+        ],
+        "hints": [
+          "Use Keypair.generate() to create a new wallet keypair",
+          "Extract the public key with keypair.publicKey.toBase58()",
+          "Use PublicKey.isOnCurve() to validate the key, passing the public key bytes"
+        ],
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      }
+    ]
+  },
+  {
+    "_id": "lesson-cpi-challenge",
+    "title": "Challenge: Simulate a CPI Vault Transfer",
+    "slug": "cpi-challenge",
+    "blocks": [
+      {
+        "key": "intro",
+        "_type": "prose",
+        "produces": null,
+        "consumes": null,
+        "src": "# Challenge: Simulate a CPI Vault Transfer in Rust\n\nCross-Program Invocations (CPIs) let programs transfer SOL from PDA-controlled vaults. You'll simulate this pattern: derive a vault PDA, verify it has funds, and compute the transfer.\n\n## Your Task\n\nImplement `build_vault_transfer(user, vault_balance, recipient_balance, amount)` that:\n\n1. Derives the vault PDA using `find_pda(&[\"vault\", user], \"system\")` to get the bump\n2. Checks the vault has enough balance for the transfer\n3. Returns `Ok((new_vault_balance, new_recipient_balance, bump))` on success\n4. Returns `Err(\"INSUFFICIENT_VAULT_BALANCE\")` if vault can't cover the amount\n\n**This mirrors the real Anchor pattern:**\n```rust\ninvoke_signed(\n    &transfer_instruction,\n    &[vault_pda, recipient, system_program],\n    &[&[b\"vault\", user.key().as_ref(), &[bump]]],\n)?;\n```\n\nThe bump is needed for `invoke_signed` — the program proves it controls the PDA.\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "exercise",
+        "_type": "code",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": "rust",
+        "buildType": "standard",
+        "deployable": false,
+        "starter": "use std::collections::hash_map::DefaultHasher;\nuse std::hash::{Hash, Hasher};\n\nfn hash_with_bump(seeds: &[&str], bump: u8, program_id: &str) -> u64 {\n    let mut hasher = DefaultHasher::new();\n    for seed in seeds { seed.hash(&mut hasher); }\n    bump.hash(&mut hasher);\n    program_id.hash(&mut hasher);\n    hasher.finish()\n}\n\nfn find_pda(seeds: &[&str], program_id: &str) -> (u64, u8) {\n    for bump in (0..=255u8).rev() {\n        let hash = hash_with_bump(seeds, bump, program_id);\n        if hash % 2 == 0 { return (hash, bump); }\n    }\n    panic!(\"No valid bump found\");\n}\n\n/// Simulate a CPI transfer from a PDA vault to a recipient.\n/// Returns Ok((new_vault_balance, new_recipient_balance, bump)).\nfn build_vault_transfer(\n    user: &str,\n    vault_balance: u64,\n    recipient_balance: u64,\n    amount: u64,\n) -> Result<(u64, u64, u8), String> {\n    // TODO: Derive the vault PDA to get the bump\n    // TODO: Check vault_balance >= amount\n    // TODO: Return updated balances and the bump\n    todo!()\n}\n",
+        "solution": "use std::collections::hash_map::DefaultHasher;\nuse std::hash::{Hash, Hasher};\n\nfn hash_with_bump(seeds: &[&str], bump: u8, program_id: &str) -> u64 {\n    let mut hasher = DefaultHasher::new();\n    for seed in seeds { seed.hash(&mut hasher); }\n    bump.hash(&mut hasher);\n    program_id.hash(&mut hasher);\n    hasher.finish()\n}\n\nfn find_pda(seeds: &[&str], program_id: &str) -> (u64, u8) {\n    for bump in (0..=255u8).rev() {\n        let hash = hash_with_bump(seeds, bump, program_id);\n        if hash % 2 == 0 { return (hash, bump); }\n    }\n    panic!(\"No valid bump found\");\n}\n\nfn build_vault_transfer(\n    user: &str,\n    vault_balance: u64,\n    recipient_balance: u64,\n    amount: u64,\n) -> Result<(u64, u64, u8), String> {\n    let (_, bump) = find_pda(&[\"vault\", user], \"system\");\n    if vault_balance < amount {\n        return Err(\"INSUFFICIENT_VAULT_BALANCE\".to_string());\n    }\n    Ok((vault_balance - amount, recipient_balance + amount, bump))\n}\n",
+        "tests": [
+          {
+            "id": "t1",
+            "description": "Sufficient balance succeeds",
+            "input": "\"alice\", 1000, 500, 200",
+            "expectedOutput": "__result__.is_ok()"
+          },
+          {
+            "id": "t2",
+            "description": "Insufficient balance fails",
+            "input": "\"alice\", 100, 500, 200",
+            "expectedOutput": "__result__.is_err()"
+          },
+          {
+            "id": "t3",
+            "description": "Balances update correctly",
+            "input": "\"alice\", 1000, 500, 200",
+            "expectedOutput": "{ let r = __result__.unwrap(); r.0 == 800 && r.1 == 700 }"
+          },
+          {
+            "id": "t4",
+            "description": "Balances update correctly for a different transfer",
+            "input": "\"bob\", 5000, 1000, 1500",
+            "expectedOutput": "{ let r = __result__.unwrap(); r.0 == 3500 && r.1 == 2500 }"
+          }
+        ],
+        "hints": [
+          "First derive the PDA: let (_, bump) = find_pda(&[\"vault\", user], \"system\");",
+          "Then check: if vault_balance < amount { return Err(\"INSUFFICIENT_VAULT_BALANCE\".to_string()); }",
+          "Return Ok((vault_balance - amount, recipient_balance + amount, bump))."
+        ],
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      }
+    ]
+  },
+  {
+    "_id": "lesson-cpi-overview",
+    "title": "Cross-Program Invocations",
+    "slug": "cpi-overview",
+    "blocks": [
+      {
+        "key": "intro",
+        "_type": "prose",
+        "produces": null,
+        "consumes": null,
+        "src": "# Cross-Program Invocations (CPIs)\n\nCross-Program Invocations allow one Solana program to call another program. This is what makes Solana programs **composable** — you can build on top of existing programs like building blocks.\n\n## Why CPIs Matter\n\nCPIs enable:\n- **Token transfers** via the Token Program\n- **NFT minting** via Metaplex programs\n- **Swaps** through DEX programs (Jupiter, Raydium)\n- **Lending** through DeFi protocols (Solend, MarginFi)\n\nWithout CPIs, every program would need to reimplement basic functionality. With CPIs, you compose existing programs.\n\n## How CPIs Work\n\nWhen Program A calls Program B:\n\n```\nUser Transaction\n  |\n  v\nProgram A (your program)\n  |\n  v (CPI)\nProgram B (Token Program, System Program, etc.)\n```\n\nThe Solana runtime tracks the **call stack** and ensures:\n- Account ownership rules are enforced\n- Signers are propagated correctly\n- Programs can't exceed the call depth limit (4 levels)\n\n## invoke vs invoke_signed\n\n### invoke - Regular CPI\n\n```rust\nuse solana_program::program::invoke;\n\ninvoke(\n    &instruction,\n    &[\n        source_account.clone(),\n        destination_account.clone(),\n        authority.clone(),\n    ],\n)?;\n```\n\nUse `invoke` when the required signers are already in your instruction's signer list.\n\n### invoke_signed - CPI with PDA Signer\n\n```rust\nuse solana_program::program::invoke_signed;\n\ninvoke_signed(\n    &instruction,\n    &[\n        pda_account.clone(),\n        destination_account.clone(),\n        system_program.clone(),\n    ],\n    &[&[b\"vault\", &[bump]]], // PDA seeds\n)?;\n```\n\nUse `invoke_signed` when a **PDA** needs to sign. The program derives the PDA and \"signs\" on its behalf.\n\n## CPI in Anchor\n\nAnchor provides a cleaner API for CPIs:\n\n```rust\nuse anchor_lang::prelude::*;\nuse anchor_spl::token::{self, Transfer};\n\npub fn transfer_tokens(ctx: Context<TransferTokens>, amount: u64) -> Result<()> {\n    let cpi_accounts = Transfer {\n        from: ctx.accounts.from.to_account_info(),\n        to: ctx.accounts.to.to_account_info(),\n        authority: ctx.accounts.authority.to_account_info(),\n    };\n\n    let cpi_program = ctx.accounts.token_program.to_account_info();\n    let cpi_ctx = CpiContext::new(cpi_program, cpi_accounts);\n\n    token::transfer(cpi_ctx, amount)?;\n    Ok(())\n}\n```\n\n### CPI with PDA Signer in Anchor\n\n```rust\npub fn transfer_from_pda(ctx: Context<TransferFromPDA>, amount: u64) -> Result<()> {\n    let seeds = &[\n        b\"vault\",\n        ctx.accounts.authority.key().as_ref(),\n        &[ctx.accounts.vault.bump],\n    ];\n    let signer_seeds = &[&seeds[..]];\n\n    let cpi_accounts = Transfer {\n        from: ctx.accounts.vault_token_account.to_account_info(),\n        to: ctx.accounts.user_token_account.to_account_info(),\n        authority: ctx.accounts.vault.to_account_info(),\n    };\n\n    let cpi_program = ctx.accounts.token_program.to_account_info();\n    let cpi_ctx = CpiContext::new_with_signer(\n        cpi_program,\n        cpi_accounts,\n        signer_seeds,\n    );\n\n    token::transfer(cpi_ctx, amount)?;\n    Ok(())\n}\n```\n\n## Common CPI Patterns\n\n### 1. Token Transfer\n\n```rust\n// Transfer SPL tokens from user to program vault\ntoken::transfer(\n    CpiContext::new(token_program, transfer_accounts),\n    amount,\n)?;\n```\n\n### 2. Minting Tokens\n\n```rust\n// Mint new tokens (requires mint authority)\ntoken::mint_to(\n    CpiContext::new_with_signer(token_program, mint_accounts, signer_seeds),\n    amount,\n)?;\n```\n\n### 3. Creating Accounts\n\n```rust\n// Create a new account (CPI to System Program)\nsystem_program::create_account(\n    CpiContext::new(system_program, create_accounts),\n    lamports,\n    space,\n    program_id,\n)?;\n```\n\n## CPI Security Considerations\n\n### 1. Account Validation\n\nAlways validate accounts before CPI:\n\n```rust\nrequire_keys_eq!(\n    ctx.accounts.token_program.key(),\n    token::ID,\n    ErrorCode::InvalidTokenProgram\n);\n```\n\n### 2. Signer Propagation\n\nSigners in your instruction are automatically propagated to CPIs. But be careful:\n\n```rust\n// BAD: Anyone can call this and spend vault tokens!\npub fn dangerous_withdraw(ctx: Context<Withdraw>, amount: u64) -> Result<()> {\n    token::transfer(\n        CpiContext::new_with_signer(...),\n        amount,\n    )\n}\n\n// GOOD: Check authority first\npub fn safe_withdraw(ctx: Context<Withdraw>, amount: u64) -> Result<()> {\n    require_keys_eq!(\n        ctx.accounts.authority.key(),\n        ctx.accounts.vault.authority,\n        ErrorCode::Unauthorized\n    );\n    token::transfer(...)\n}\n```\n\n### 3. Reentrancy\n\nSolana programs are **not reentrant** by default (a program can't call itself). This prevents classic reentrancy attacks.\n\n## Real-World CPI Examples\n\n**Escrow program**:\n1. User deposits tokens → CPI to Token Program to transfer tokens to escrow PDA\n2. Trade executes → CPI to Token Program to transfer from escrow PDA to recipient\n\n**Staking program**:\n1. User stakes tokens → CPI to Token Program to transfer to staking vault\n2. User claims rewards → CPI to Token Program to mint reward tokens\n3. User unstakes → CPI to Token Program to transfer staked tokens back\n\n**NFT marketplace**:\n1. User lists NFT → CPI to Token Program to transfer NFT to marketplace PDA\n2. Buyer purchases → CPI to System Program (SOL payment) + CPI to Token Program (NFT transfer)\n\n## Next Challenge\n\nYou'll construct a CPI instruction to transfer SOL from a PDA-owned account.\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "retrieval-close",
+        "_type": "quiz",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": [
+          {
+            "id": "q1",
+            "prompt": "When do you use `invoke_signed` instead of `invoke` for a CPI?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "When a PDA must sign the CPI — the program supplies the PDA's seeds so it can sign without a private key",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "When the CPI transfers more than a set amount of SOL",
+                "correct": false,
+                "feedback": "The choice has nothing to do with amount. `invoke_signed` is specifically for when a PDA needs to sign; `invoke` is used when required signers are already present."
+              },
+              {
+                "id": "c",
+                "label": "When calling a program you did not write",
+                "correct": false,
+                "feedback": "Both call other programs. The distinction is the signer: `invoke_signed` provides PDA seeds so the program can sign on the PDA's behalf."
+              }
+            ],
+            "explanation": "`invoke` works when the needed signatures already exist in the instruction's signer set. `invoke_signed` adds the PDA's seeds so the runtime lets the program sign for the PDA — the only way a keyless, program-controlled account can authorize a CPI."
+          },
+          {
+            "id": "q2",
+            "prompt": "A `withdraw` instruction does a signed CPI to move vault tokens but never checks who called it. What is the flaw?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "Anyone can call it and drain the vault — the program signs for the PDA without verifying the caller's authority",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "Nothing — Solana blocks unauthorized CPIs automatically",
+                "correct": false,
+                "feedback": "The runtime enforces account ownership and signer propagation, not your business rules. If you do not check the caller against the vault authority, anyone can trigger the withdrawal."
+              },
+              {
+                "id": "c",
+                "label": "The CPI fails because PDAs cannot sign token transfers",
+                "correct": false,
+                "feedback": "PDAs sign token transfers fine via invoke_signed — that is the problem here. Without an authority check, that signing power is exposed to any caller."
+              }
+            ],
+            "explanation": "invoke_signed makes the program sign for its PDA, so the transfer succeeds for whoever calls. The missing piece is a caller-versus-authority check (require_keys_eq!) — the runtime will not supply your authorization logic, so an unchecked signed CPI is an open withdrawal for anyone."
+          }
+        ],
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      }
+    ]
+  },
+  {
+    "_id": "lesson-create-token-challenge",
+    "title": "Challenge: Create a Token Mint",
+    "slug": "create-token-challenge",
+    "blocks": [
+      {
+        "key": "intro",
+        "_type": "prose",
+        "produces": null,
+        "consumes": null,
+        "src": "# Challenge: Create a Token Mint\n\nWrite a function that creates a new SPL token mint on Solana devnet.\n\n## Requirements\n\n- Create a new token mint with 9 decimals\n- The payer should be both the mint authority and freeze authority\n- Return the mint address as a base58 string\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "exercise",
+        "_type": "code",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": "typescript",
+        "buildType": "standard",
+        "deployable": false,
+        "starter": "import { Connection, Keypair } from '@solana/web3.js';\nimport { createMint } from '@solana/spl-token';\n\nasync function createTokenMint(\n  connection: Connection,\n  payer: Keypair\n): Promise<string> {\n  // Your code here\n}\n",
+        "solution": "import { Connection, Keypair } from '@solana/web3.js';\nimport { createMint } from '@solana/spl-token';\n\nasync function createTokenMint(\n  connection: Connection,\n  payer: Keypair\n): Promise<string> {\n  const mint = await createMint(\n    connection,\n    payer,\n    payer.publicKey,\n    payer.publicKey,\n    9\n  );\n\n  return mint.toBase58();\n}\n",
+        "tests": [
+          {
+            "id": "t1",
+            "description": "Returns a valid mint address string (base58 length)",
+            "input": "connection, payer",
+            "expectedOutput": "typeof result === 'string' && result.length >= 32 && result.length <= 44"
+          }
+        ],
+        "hints": [
+          "Use createMint() from @solana/spl-token",
+          "Pass payer.publicKey as both mintAuthority and freezeAuthority",
+          "The function returns a PublicKey; use .toBase58() to convert to string"
+        ],
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      }
+    ]
+  },
+  {
+    "_id": "lesson-dapp-challenge",
+    "title": "Challenge: SOL Transfer Form",
+    "slug": "dapp-challenge",
+    "blocks": [
+      {
+        "key": "intro",
+        "_type": "prose",
+        "produces": null,
+        "consumes": null,
+        "src": "# Challenge: SOL Transfer Form\n\nBuild the validation and transaction construction logic for a SOL transfer form.\n\n## Requirements\n\n- Create a function that validates a transfer request and constructs the transaction\n- Accept `senderPublicKey` (PublicKey), `recipientAddress` (string), `amountInSol` (number), and `connection` (Connection)\n- Validate:\n  1. Recipient address is a valid PublicKey (use try/catch)\n  2. Amount is positive and non-zero\n  3. Sender has sufficient balance (check with `connection.getBalance()`)\n- If validation fails, return `{ success: false, error: string }`\n- If validation passes, construct a Transaction with SystemProgram.transfer and return `{ success: true, transaction: Transaction }`\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "exercise",
+        "_type": "code",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": "typescript",
+        "buildType": "standard",
+        "deployable": false,
+        "starter": "import {\n  Connection,\n  PublicKey,\n  SystemProgram,\n  Transaction,\n  LAMPORTS_PER_SOL,\n} from '@solana/web3.js';\n\ninterface ValidationResult {\n  success: boolean;\n  error?: string;\n  transaction?: Transaction;\n}\n\nasync function validateAndBuildTransfer(\n  senderPublicKey: PublicKey,\n  recipientAddress: string,\n  amountInSol: number,\n  connection: Connection\n): Promise<ValidationResult> {\n  // Your code here\n}\n",
+        "solution": "import {\n  Connection,\n  PublicKey,\n  SystemProgram,\n  Transaction,\n  LAMPORTS_PER_SOL,\n} from '@solana/web3.js';\n\ninterface ValidationResult {\n  success: boolean;\n  error?: string;\n  transaction?: Transaction;\n}\n\nasync function validateAndBuildTransfer(\n  senderPublicKey: PublicKey,\n  recipientAddress: string,\n  amountInSol: number,\n  connection: Connection\n): Promise<ValidationResult> {\n  // Validate recipient address\n  let recipientPublicKey: PublicKey;\n  try {\n    recipientPublicKey = new PublicKey(recipientAddress);\n  } catch {\n    return { success: false, error: 'Invalid recipient address' };\n  }\n\n  // Validate amount\n  if (amountInSol <= 0) {\n    return { success: false, error: 'Amount must be positive' };\n  }\n\n  // Check sender balance\n  const senderBalance = await connection.getBalance(senderPublicKey);\n  const requiredLamports = amountInSol * LAMPORTS_PER_SOL;\n\n  if (senderBalance < requiredLamports) {\n    return { success: false, error: 'Insufficient balance' };\n  }\n\n  // Build transaction\n  const transaction = new Transaction().add(\n    SystemProgram.transfer({\n      fromPubkey: senderPublicKey,\n      toPubkey: recipientPublicKey,\n      lamports: requiredLamports,\n    })\n  );\n\n  return { success: true, transaction };\n}\n",
+        "tests": [
+          {
+            "id": "test-1",
+            "description": "Should reject invalid recipient address",
+            "input": "sender, 'invalid', 1.0, connection",
+            "expectedOutput": "result.success === false && typeof result.error === 'string'"
+          },
+          {
+            "id": "test-2",
+            "description": "Should reject negative amounts",
+            "input": "sender, 'invalid', -1, connection",
+            "expectedOutput": "result.success === false"
+          },
+          {
+            "id": "test-3",
+            "description": "Should return object with success field",
+            "input": "sender, 'invalid', 1.0, connection",
+            "expectedOutput": "typeof result === 'object' && 'success' in result"
+          }
+        ],
+        "hints": [
+          "Wrap new PublicKey(recipientAddress) in try/catch to validate the address",
+          "Check amount > 0 before proceeding with balance check",
+          "Use connection.getBalance() to get sender balance in lamports, then compare with amountInSol * LAMPORTS_PER_SOL"
+        ],
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      }
+    ]
+  },
+  {
+    "_id": "lesson-defi-overview",
+    "title": "DeFi on Solana Overview",
+    "slug": "defi-overview",
+    "blocks": [
+      {
+        "key": "intro",
+        "_type": "prose",
+        "produces": null,
+        "consumes": null,
+        "src": "# DeFi on Solana Overview\n\nDecentralized Finance (DeFi) on Solana has exploded in growth thanks to the chain's speed, low costs, and composability. Let's explore the landscape.\n\n## Why Solana for DeFi?\n\n### Speed\n- **400ms block time** - Near-instant transaction finality\n- **65,000+ TPS** - Handles high-frequency trading\n- **Parallel execution** - Multiple programs run simultaneously\n\n### Cost\n- **$0.00025 average transaction** - Makes micro-transactions viable\n- **No gas wars** - Predictable fees even during congestion\n\n### Composability\n- **Single global state** - All programs share the same state\n- **Atomic composability** - Multi-program transactions are atomic\n- **No bridges needed** - Everything is native\n\n## The Solana DeFi Ecosystem\n\n### Decentralized Exchanges (DEXs)\n\n**Jupiter** - Aggregates liquidity from all Solana DEXs\n- Routes trades through multiple DEXs for best price\n- 15+ DEX integrations\n- Limit orders, DCA, perpetuals\n\n**Raydium** - Automated Market Maker (AMM)\n- Concentrated liquidity (like Uniswap v3)\n- OpenBook integration (hybrid AMM/orderbook)\n- Top 3 by volume on Solana\n\n**Orca** - User-friendly AMM\n- Whirlpools (concentrated liquidity)\n- Clean UX, popular for beginners\n\n**Phoenix** - Central Limit Order Book (CLOB)\n- Fully on-chain orderbook\n- Sub-second matching\n- Successor to Serum\n\n### Lending Protocols\n\n**Solend** - Algorithmic lending/borrowing\n- Supply assets, earn yield\n- Borrow against collateral\n- Isolated pools for risk management\n\n**MarginFi** - Decentralized margin trading\n- Leveraged positions\n- Portfolio margin\n- Integrated with major DEXs\n\n**Kamino Finance** - Automated liquidity strategies\n- Vaults for concentrated liquidity\n- Leveraged yield farming\n- Risk-adjusted returns\n\n### Liquid Staking\n\n**Marinade (mSOL)** - Largest liquid staking protocol\n- Stake SOL, receive mSOL\n- mSOL accrues staking rewards\n- Can use mSOL in DeFi while earning staking yield\n\n**Jito (jitoSOL)** - MEV-enhanced staking\n- Distributes MEV rewards to stakers\n- Higher APY than native staking\n\n**BlazeStake (bSOL)** - Focuses on decentralization\n- Delegates to smaller validators\n- Supports Solana decentralization\n\n### Perpetuals & Derivatives\n\n**Drift Protocol** - Decentralized perpetuals\n- Up to 10x leverage\n- Virtual AMM design\n- Insurance fund for trader protection\n\n**Zeta Markets** - Options and futures\n- Undercollateralized DeFi options\n- On-chain orderbook\n\n## Total Value Locked (TVL)\n\nAs of 2025, Solana DeFi TVL:\n- **Total**: ~$7B USD\n- **Jito**: $2.5B (liquid staking)\n- **Kamino**: $1.8B (lending/vaults)\n- **Marinade**: $1.2B (liquid staking)\n- **Raydium**: $1.5B (DEX)\n\nSolana is the 4th largest DeFi ecosystem after Ethereum, Tron, and BNB Chain.\n\n## DeFi Primitives on Solana\n\n### 1. Automated Market Makers (AMMs)\n\nConstant product formula: `x * y = k`\n\n```\nPool: 1000 SOL × 100,000 USDC = 100,000,000\nPrice: 100,000 / 1000 = 100 USDC per SOL\n```\n\n### 2. Concentrated Liquidity\n\nLiquidity providers choose a price range:\n\n```\nStandard AMM: Capital spread across 0 → ∞\nConcentrated: Capital focused on $95-$105 range\nResult: 10-100x capital efficiency\n```\n\n### 3. Lending Pools\n\nSupply rate = Borrow rate × Utilization × (1 - Reserve factor)\n\n```\nTotal supplied: 1000 SOL\nTotal borrowed: 700 SOL\nUtilization: 70%\nBorrow APY: 8%\nSupply APY: 8% × 70% × 90% = 5.04%\n```\n\n### 4. Liquidations\n\n```\nHealth Factor = Collateral Value / (Debt Value / LTV)\nIf Health Factor < 1.0 → Liquidatable\n```\n\n## Composability in Action\n\n**Example: Leveraged Yield Farming**\n\n1. Deposit SOL to Kamino\n2. Borrow USDC against SOL collateral\n3. Swap USDC → SOL on Jupiter\n4. Deposit SOL to liquidity pool on Raydium\n5. Earn swap fees + USDC rewards\n\nAll of this can happen in **one atomic transaction**.\n\n## Security Considerations\n\n### Smart Contract Risk\n- Programs can have bugs (test thoroughly, get audits)\n- Upgradeable programs can be changed by authority\n- Check if program authority is a multisig or revoked\n\n### Oracle Risk\n- Price feeds can be manipulated or go stale\n- Use multiple oracles (Pyth, Switchboard)\n- Implement staleness checks and circuit breakers\n\n### Liquidation Risk\n- Solana's speed helps (faster liquidations = less bad debt)\n- But volatility can still cause cascading liquidations\n\n### Protocol Composability Risk\n- A bug in one protocol can cascade to others\n- Isolated pools mitigate this\n\n## The Future of Solana DeFi\n\n**Token Extensions (Token-2022)**\n- Transfer hooks (fees, restrictions)\n- Confidential transfers (privacy)\n- Interest-bearing tokens\n\n**Firedancer**\n- New validator client → 1M+ TPS\n- Even faster DeFi execution\n\n**Cross-chain**\n- Wormhole, Allbridge for bridging\n- But Solana's goal is to be self-contained\n\n## Next Lessons\n\nYou'll dive deep into AMM mechanics, lending protocols, and build DeFi primitives yourself.\n",
         "url": null,
         "language": null,
         "buildType": null,
@@ -1116,2585 +3014,2816 @@
     ]
   },
   {
-    "_id": "lesson-bfsp-m4-deploy",
-    "blocks": [
-      {
-        "_type": "prose",
-        "amount": null,
-        "buildType": null,
-        "consumes": null,
-        "deployable": null,
-        "hints": null,
-        "idl": null,
-        "key": "intro",
-        "language": null,
-        "maxWords": null,
-        "network": null,
-        "produces": null,
-        "prompt": null,
-        "questions": null,
-        "solution": null,
-        "src": "# Deploy Your Program to Devnet\n\nThis is it — you're about to deploy your counter program to the Solana blockchain.\n\n## The Deployment Process\n\nDeploying a Solana program involves 4 steps:\n\n1. **Compile**: Your Rust code → `.so` binary (already done by the build server)\n2. **Create Buffer**: A temporary on-chain account to hold the binary during upload\n3. **Upload Chunks**: The binary is uploaded in ~1000-byte chunks (200+ transactions for a typical program)\n4. **Finalize**: Link the buffer to a new program account, making it executable\n\nThis follows the **BPF Loader Upgradeable** protocol — the standard way all Anchor programs are deployed.\n\n## What You'll See\n\n- **1 wallet popup** to create the buffer account\n- **Batch signing** every ~30 chunks (to avoid blockhash expiry)\n- **A real-time transaction log** showing each chunk being confirmed\n- **Your Program ID** when deployment completes\n\n## Instructions\n\n1. Click **Build** to compile your counter program\n2. When the build succeeds, click **Deploy to Devnet**\n3. Approve the transactions in your wallet\n4. Watch the deployment progress in real time!\n\n> **If deployment fails**: Don't worry! The system saves your progress. Click **Resume** to pick up where you left off — you won't re-upload chunks that already succeeded.\n",
-        "starter": null,
-        "tests": null,
-        "url": null
-      },
-      {
-        "_type": "code",
-        "amount": null,
-        "buildType": "buildable",
-        "consumes": ["funded-wallet"],
-        "deployable": true,
-        "hints": [
-          "This is the same counter program from Module 3. Click Build to compile it, then Deploy to Devnet.",
-          "Make sure you have at least 2 SOL in your wallet. Use the previous lesson to airdrop if needed.",
-          "If deployment fails mid-way, click Resume — it will pick up where it left off."
-        ],
-        "idl": null,
-        "key": "exercise",
-        "language": "rust",
-        "maxWords": null,
-        "network": null,
-        "produces": "deployed-program",
-        "prompt": null,
-        "questions": null,
-        "solution": "use anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n#[program]\npub mod academy_program {\n    use super::*;\n\n    pub fn initialize(ctx: Context<Initialize>) -> Result<()> {\n        let counter = &mut ctx.accounts.counter;\n        counter.count = 0;\n        counter.authority = ctx.accounts.user.key();\n        msg!(\"Counter initialized!\");\n        Ok(())\n    }\n\n    pub fn greet(_ctx: Context<Greet>) -> Result<()> {\n        msg!(\"Hello, Solana!\");\n        Ok(())\n    }\n\n    pub fn increment(ctx: Context<Increment>) -> Result<()> {\n        let counter = &mut ctx.accounts.counter;\n        counter.count += 1;\n        Ok(())\n    }\n\n    pub fn decrement(ctx: Context<Decrement>) -> Result<()> {\n        let counter = &mut ctx.accounts.counter;\n        require!(counter.count > 0, ErrorCode::Underflow);\n        counter.count -= 1;\n        Ok(())\n    }\n}\n\n#[derive(Accounts)]\npub struct Initialize<'info> {\n    #[account(\n        init,\n        payer = user,\n        space = 8 + 8 + 32,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n    pub system_program: Program<'info, System>,\n}\n\n#[derive(Accounts)]\npub struct Greet {}\n\n#[derive(Accounts)]\npub struct Increment<'info> {\n    #[account(\n        mut,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    pub user: Signer<'info>,\n}\n\n#[derive(Accounts)]\npub struct Decrement<'info> {\n    #[account(\n        mut,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    pub user: Signer<'info>,\n}\n\n#[account]\npub struct Counter {\n    pub count: u64,\n    pub authority: Pubkey,\n}\n\n#[error_code]\npub enum ErrorCode {\n    #[msg(\"Cannot decrement below zero\")]\n    Underflow,\n}\n",
-        "src": null,
-        "starter": "use anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n#[program]\npub mod academy_program {\n    use super::*;\n\n    pub fn initialize(ctx: Context<Initialize>) -> Result<()> {\n        let counter = &mut ctx.accounts.counter;\n        counter.count = 0;\n        counter.authority = ctx.accounts.user.key();\n        msg!(\"Counter initialized!\");\n        Ok(())\n    }\n\n    pub fn greet(_ctx: Context<Greet>) -> Result<()> {\n        msg!(\"Hello, Solana!\");\n        Ok(())\n    }\n\n    pub fn increment(ctx: Context<Increment>) -> Result<()> {\n        let counter = &mut ctx.accounts.counter;\n        counter.count += 1;\n        Ok(())\n    }\n\n    pub fn decrement(ctx: Context<Decrement>) -> Result<()> {\n        let counter = &mut ctx.accounts.counter;\n        require!(counter.count > 0, ErrorCode::Underflow);\n        counter.count -= 1;\n        Ok(())\n    }\n}\n\n#[derive(Accounts)]\npub struct Initialize<'info> {\n    #[account(\n        init,\n        payer = user,\n        space = 8 + 8 + 32,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n    pub system_program: Program<'info, System>,\n}\n\n#[derive(Accounts)]\npub struct Greet {}\n\n#[derive(Accounts)]\npub struct Increment<'info> {\n    #[account(\n        mut,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    pub user: Signer<'info>,\n}\n\n#[derive(Accounts)]\npub struct Decrement<'info> {\n    #[account(\n        mut,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    pub user: Signer<'info>,\n}\n\n#[account]\npub struct Counter {\n    pub count: u64,\n    pub authority: Pubkey,\n}\n\n#[error_code]\npub enum ErrorCode {\n    #[msg(\"Cannot decrement below zero\")]\n    Underflow,\n}\n",
-        "tests": [
-          {
-            "description": "Complete counter program compiles successfully",
-            "expectedOutput": "true",
-            "id": "test-deploy-1",
-            "input": ""
-          }
-        ],
-        "url": null
-      }
-    ],
-    "slug": "deploy-program-devnet",
-    "title": "Deploy Your Program to Devnet"
-  },
-  {
-    "_id": "lesson-bfsp-m4-interact",
-    "blocks": [
-      {
-        "_type": "prose",
-        "amount": null,
-        "buildType": null,
-        "consumes": null,
-        "deployable": null,
-        "hints": null,
-        "idl": null,
-        "key": "intro",
-        "language": null,
-        "maxWords": null,
-        "network": null,
-        "produces": null,
-        "prompt": null,
-        "questions": null,
-        "solution": null,
-        "src": "# Interact with Your Program\n\nYour counter program is live on Solana Devnet. Now let's call its instructions and watch the on-chain state change in real time.\n\n## What You'll Do\n\n1. **Initialize** a counter account — creates a new account owned by your program\n2. **Increment** the counter — modifies the on-chain state\n3. **Decrement** the counter — see your custom error handling in action\n\n## Understanding the Data\n\nThe Program Explorer below shows two views of your counter account:\n\n### Parsed Data\nThe human-readable version: `count: 3`\n\n### Raw Data (Hex)\nWhat's actually stored on-chain:\n```\n[a8 fc 0b 1f 05 77 32 45 | 03 00 00 00 00 00 00 00]\n ^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^^^^^^^^^^\n discriminator (8 bytes)    count: 3 (u64 LE)\n```\n\nThe **discriminator** is Anchor's way of identifying account types. It's the first 8 bytes of `sha256(\"account:Counter\")`. Every Anchor account starts with this — it's how the runtime knows it's looking at a `Counter` struct and not random data.\n\nThe **count** is stored as a `u64` in **little-endian** byte order. The value `3` is `03 00 00 00 00 00 00 00` because the least significant byte comes first.\n\n## Try This\n\n1. Click **Initialize** — watch the discriminator bytes appear\n2. Click **Increment** 3 times — watch `count` change from `00` to `03`\n3. Click **Decrement** down to 0, then try decrementing again\n4. See your `#[error_code] Underflow` in action!\n\n> **Teaching moment**: When you decrement below zero, your custom error `Cannot decrement below zero` is enforced by the Solana runtime. This is your code running on a real blockchain, enforcing rules you defined.\n",
-        "starter": null,
-        "tests": null,
-        "url": null
-      },
-      {
-        "_type": "program-explorer",
-        "amount": null,
-        "buildType": null,
-        "consumes": ["deployed-program"],
-        "deployable": null,
-        "hints": null,
-        "idl": "{\"address\":\"11111111111111111111111111111111\",\"metadata\":{\"name\":\"counter\",\"version\":\"0.1.0\",\"spec\":\"0.1.0\"},\"instructions\":[{\"name\":\"initialize\",\"discriminator\":[175,175,109,31,13,152,155,237],\"accounts\":[{\"name\":\"counter\",\"writable\":true,\"pda\":{\"seeds\":[{\"kind\":\"const\",\"value\":[99,111,117,110,116,101,114]},{\"kind\":\"account\",\"path\":\"user\"}]}},{\"name\":\"user\",\"writable\":true,\"signer\":true},{\"name\":\"system_program\",\"address\":\"11111111111111111111111111111111\"}],\"args\":[]},{\"name\":\"increment\",\"discriminator\":[11,18,104,9,104,174,59,33],\"accounts\":[{\"name\":\"counter\",\"writable\":true,\"pda\":{\"seeds\":[{\"kind\":\"const\",\"value\":[99,111,117,110,116,101,114]},{\"kind\":\"account\",\"path\":\"user\"}]}},{\"name\":\"user\",\"signer\":true}],\"args\":[]},{\"name\":\"decrement\",\"discriminator\":[106,227,168,59,248,27,150,101],\"accounts\":[{\"name\":\"counter\",\"writable\":true,\"pda\":{\"seeds\":[{\"kind\":\"const\",\"value\":[99,111,117,110,116,101,114]},{\"kind\":\"account\",\"path\":\"user\"}]}},{\"name\":\"user\",\"signer\":true}],\"args\":[]}],\"accounts\":[{\"name\":\"Counter\",\"discriminator\":[255,176,4,245,188,253,124,25]}],\"types\":[{\"name\":\"Counter\",\"type\":{\"kind\":\"struct\",\"fields\":[{\"name\":\"count\",\"type\":\"u64\"},{\"name\":\"authority\",\"type\":\"publicKey\"}]}}],\"errors\":[{\"code\":6000,\"name\":\"Underflow\",\"msg\":\"Cannot decrement below zero\"}]}\n",
-        "key": "explore",
-        "language": null,
-        "maxWords": null,
-        "network": null,
-        "produces": null,
-        "prompt": null,
-        "questions": null,
-        "solution": null,
-        "src": null,
-        "starter": null,
-        "tests": null,
-        "url": null
-      }
-    ],
-    "slug": "interact-with-program",
-    "title": "Interact with Your Program"
-  },
-  {
-    "_id": "lesson-bfsp-on-chain-state",
-    "blocks": [
-      {
-        "_type": "prose",
-        "amount": null,
-        "buildType": null,
-        "consumes": null,
-        "deployable": null,
-        "hints": null,
-        "idl": null,
-        "key": "intro",
-        "language": null,
-        "maxWords": null,
-        "network": null,
-        "produces": null,
-        "prompt": null,
-        "questions": null,
-        "solution": null,
-        "src": "# On-Chain State\n\nSo far, our program doesn't store any data. Every instruction just logs a message and exits. To build anything useful, you need **on-chain state** — data that persists between transactions.\n\n## Accounts = Storage\n\nOn Solana, all state lives in **accounts**. An account is a buffer of bytes owned by a program. Think of it like a row in a database, but on-chain.\n\nEvery account has:\n- **Address** (public key) — how you find it\n- **Owner** (program ID) — which program can modify it\n- **Data** (byte array) — the actual state\n- **Lamports** (balance) — rent deposit to keep it alive\n\n## The Discriminator\n\nAnchor adds an 8-byte **discriminator** at the start of every account's data. This is a hash of the account type name, used to prevent account type confusion attacks.\n\n```\n[8 bytes discriminator][...your data...]\n```\n\nYou never read or write the discriminator directly — Anchor handles it.\n\n## Space Calculation\n\nWhen you create an account, you must specify its size upfront (accounts can't be resized after creation). The formula:\n\n```\nspace = 8 (discriminator) + sum of field sizes\n```\n\nCommon field sizes:\n- `u8` / `i8` / `bool` = 1 byte\n- `u16` / `i16` = 2 bytes\n- `u32` / `i32` = 4 bytes\n- `u64` / `i64` = 8 bytes\n- `u128` / `i128` = 16 bytes\n- `Pubkey` = 32 bytes\n- `String` = 4 (length prefix) + content bytes\n- `Vec<T>` = 4 (length prefix) + (count * size_of::<T>())\n\n## Example: A Counter\n\nA simple counter needs one `u64` field:\n\n```rust\n#[account]\npub struct Counter {\n    pub count: u64,  // 8 bytes\n}\n// Total space = 8 (discriminator) + 8 (u64) = 16 bytes\n```\n\nThe `#[account]` attribute tells Anchor to:\n1. Add serialization/deserialization (Borsh)\n2. Add the 8-byte discriminator\n3. Implement account validation traits\n\nIn the next challenge, you'll define this Counter account and wire it into your program.\n",
-        "starter": null,
-        "tests": null,
-        "url": null
-      }
-    ],
-    "slug": "on-chain-state",
-    "title": "On-Chain State"
-  },
-  {
-    "_id": "lesson-bfsp-wire-up-initialize",
-    "blocks": [
-      {
-        "_type": "prose",
-        "amount": null,
-        "buildType": null,
-        "consumes": null,
-        "deployable": null,
-        "hints": null,
-        "idl": null,
-        "key": "intro",
-        "language": null,
-        "maxWords": null,
-        "network": null,
-        "produces": null,
-        "prompt": null,
-        "questions": null,
-        "solution": null,
-        "src": "# Challenge: Wire Up Initialize\n\nThis challenge is different. The starter code has a **deliberate bug** — it won't compile.\n\nYour job:\n1. Click **Build** to see the compiler error\n2. Read the error message carefully\n3. Fix the code\n4. Build again until it compiles\n\n## The Bug\n\nThe `Initialize` struct uses `#[account(init, ...)]` to create a `Counter` PDA, but it's missing a required account. When Anchor generates the account creation code, it needs the System Program to execute the `create_account` instruction.\n\n## What You'll Learn\n\nThis is the most common Anchor compile error you'll encounter in the wild. Learning to diagnose it now saves you hours of debugging later.\n\n## Requirements\n\n1. Read the compiler error output\n2. Add the missing account to `Initialize`\n3. Make sure `initialize` sets `counter.count = 0` and `counter.authority = ctx.accounts.user.key()`\n",
-        "starter": null,
-        "tests": null,
-        "url": null
-      },
-      {
-        "_type": "code",
-        "amount": null,
-        "buildType": "buildable",
-        "consumes": null,
-        "deployable": false,
-        "hints": [
-          "Click Build first to see the error. The compiler will tell you what's missing.",
-          "The error mentions a trait bound related to Accounts. This happens when a required account is missing from the struct.",
-          "Add `pub system_program: Program<'info, System>,` to the Initialize struct. The System Program is required whenever you use `#[account(init)]`."
-        ],
-        "idl": null,
-        "key": "exercise",
-        "language": "rust",
-        "maxWords": null,
-        "network": null,
-        "produces": null,
-        "prompt": null,
-        "questions": null,
-        "solution": "use anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n#[program]\npub mod academy_program {\n    use super::*;\n\n    pub fn initialize(ctx: Context<Initialize>) -> Result<()> {\n        let counter = &mut ctx.accounts.counter;\n        counter.count = 0;\n        counter.authority = ctx.accounts.user.key();\n        msg!(\"Counter initialized!\");\n        Ok(())\n    }\n\n    pub fn greet(_ctx: Context<Greet>) -> Result<()> {\n        msg!(\"Hello, Solana!\");\n        Ok(())\n    }\n}\n\n#[derive(Accounts)]\npub struct Initialize<'info> {\n    #[account(\n        init,\n        payer = user,\n        space = 8 + 8 + 32,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n    pub system_program: Program<'info, System>,\n}\n\n#[derive(Accounts)]\npub struct Greet {}\n\n#[account]\npub struct Counter {\n    pub count: u64,\n    pub authority: Pubkey,\n}\n",
-        "src": null,
-        "starter": "use anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n#[program]\npub mod academy_program {\n    use super::*;\n\n    pub fn initialize(ctx: Context<Initialize>) -> Result<()> {\n        let counter = &mut ctx.accounts.counter;\n        counter.count = 0;\n        counter.authority = ctx.accounts.user.key();\n        msg!(\"Counter initialized!\");\n        Ok(())\n    }\n\n    pub fn greet(_ctx: Context<Greet>) -> Result<()> {\n        msg!(\"Hello, Solana!\");\n        Ok(())\n    }\n}\n\n#[derive(Accounts)]\npub struct Initialize<'info> {\n    #[account(\n        init,\n        payer = user,\n        space = 8 + 8 + 32,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n    // BUG: Something is missing here...\n}\n\n#[derive(Accounts)]\npub struct Greet {}\n\n#[account]\npub struct Counter {\n    pub count: u64,\n    pub authority: Pubkey,\n}\n",
-        "tests": [
-          {
-            "description": "Program compiles successfully",
-            "expectedOutput": "true",
-            "id": "test-1",
-            "input": ""
-          },
-          {
-            "description": "Initialize struct includes system_program",
-            "expectedOutput": "true",
-            "id": "test-2",
-            "input": ""
-          },
-          {
-            "description": "Counter is initialized to zero",
-            "expectedOutput": "true",
-            "id": "test-3",
-            "input": ""
-          }
-        ],
-        "url": null
-      }
-    ],
-    "slug": "wire-up-initialize",
-    "title": "Wire Up Initialize"
-  },
-  {
-    "_id": "lesson-bfsp-your-first-build",
-    "blocks": [
-      {
-        "_type": "prose",
-        "amount": null,
-        "buildType": null,
-        "consumes": null,
-        "deployable": null,
-        "hints": null,
-        "idl": null,
-        "key": "intro",
-        "language": null,
-        "maxWords": null,
-        "network": null,
-        "produces": null,
-        "prompt": null,
-        "questions": null,
-        "solution": null,
-        "src": "# Your First Build\n\nThis is the simplest challenge in the entire course. Your goal: **hit the Build button and see it succeed.**\n\nThe starter code is a minimal Anchor program that compiles with zero changes. Don't modify anything — just click **Build** and watch the build server compile your first Solana program.\n\n## What to Expect\n\n- The build takes 30-60 seconds on first run (dependencies are cached after that)\n- You'll see compiler output in the panel below\n- A green checkmark means your program compiled to a `.so` binary\n- The build UUID is your compiled program's identifier\n\n## Why This Matters\n\nThis proves the pipeline works end-to-end: your code leaves the browser, reaches the build server, gets compiled by `cargo-build-sbf`, and the result comes back. Every lesson after this builds on this foundation.\n",
-        "starter": null,
-        "tests": null,
-        "url": null
-      },
-      {
-        "_type": "code",
-        "amount": null,
-        "buildType": "buildable",
-        "consumes": null,
-        "deployable": false,
-        "hints": [
-          "You don't need to change anything — just click the Build button",
-          "If the build times out, try again. First builds take longer because dependencies are being downloaded.",
-          "If you see errors, make sure you haven't accidentally modified the starter code. Click Reset Code to restore it."
-        ],
-        "idl": null,
-        "key": "exercise",
-        "language": "rust",
-        "maxWords": null,
-        "network": null,
-        "produces": null,
-        "prompt": null,
-        "questions": null,
-        "solution": "use anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n#[program]\npub mod academy_program {\n    use super::*;\n\n    pub fn initialize(_ctx: Context<Initialize>) -> Result<()> {\n        msg!(\"Superteam Academy default program\");\n        Ok(())\n    }\n}\n\n#[derive(Accounts)]\npub struct Initialize {}\n",
-        "src": null,
-        "starter": "use anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n#[program]\npub mod academy_program {\n    use super::*;\n\n    pub fn initialize(_ctx: Context<Initialize>) -> Result<()> {\n        msg!(\"Superteam Academy default program\");\n        Ok(())\n    }\n}\n\n#[derive(Accounts)]\npub struct Initialize {}\n",
-        "tests": [
-          {
-            "description": "Program compiles successfully",
-            "expectedOutput": "true",
-            "id": "test-1",
-            "input": ""
-          }
-        ],
-        "url": null
-      }
-    ],
-    "slug": "your-first-build",
-    "title": "Your First Build"
-  },
-  {
-    "_id": "lesson-connect-wallet-challenge",
-    "blocks": [
-      {
-        "_type": "prose",
-        "amount": null,
-        "buildType": null,
-        "consumes": null,
-        "deployable": null,
-        "hints": null,
-        "idl": null,
-        "key": "intro",
-        "language": null,
-        "maxWords": null,
-        "network": null,
-        "produces": null,
-        "prompt": null,
-        "questions": null,
-        "solution": null,
-        "src": "# Challenge: Wallet Connection Flow\n\nSimulate a wallet connection flow by generating a keypair (representing a wallet) and extracting key information.\n\n## Requirements\n\n- Create a function that simulates connecting to a wallet\n- Generate a new keypair to represent the wallet\n- Validate that the public key is on the ed25519 curve\n- Return an object with `publicKey` (base58 string), `connected` (boolean), and `isValid` (boolean)\n",
-        "starter": null,
-        "tests": null,
-        "url": null
-      },
-      {
-        "_type": "code",
-        "amount": null,
-        "buildType": "standard",
-        "consumes": null,
-        "deployable": false,
-        "hints": [
-          "Use Keypair.generate() to create a new wallet keypair",
-          "Extract the public key with keypair.publicKey.toBase58()",
-          "Use PublicKey.isOnCurve() to validate the key, passing the public key bytes"
-        ],
-        "idl": null,
-        "key": "exercise",
-        "language": "typescript",
-        "maxWords": null,
-        "network": null,
-        "produces": null,
-        "prompt": null,
-        "questions": null,
-        "solution": "import { Keypair, PublicKey } from '@solana/web3.js';\n\nfunction simulateWalletConnection(): {\n  publicKey: string;\n  connected: boolean;\n  isValid: boolean;\n} {\n  const keypair = Keypair.generate();\n  const publicKeyStr = keypair.publicKey.toBase58();\n  \n  return {\n    publicKey: publicKeyStr,\n    connected: true,\n    isValid: PublicKey.isOnCurve(keypair.publicKey.toBytes()),\n  };\n}\n",
-        "src": null,
-        "starter": "import { Keypair, PublicKey } from '@solana/web3.js';\n\nfunction simulateWalletConnection(): {\n  publicKey: string;\n  connected: boolean;\n  isValid: boolean;\n} {\n  // Your code here\n}\n",
-        "tests": [
-          {
-            "description": "Returns publicKey, connected and isValid with correct types",
-            "expectedOutput": "typeof result.publicKey === 'string' && typeof result.connected === 'boolean' && typeof result.isValid === 'boolean'",
-            "id": "t1",
-            "input": ""
-          },
-          {
-            "description": "publicKey has a valid base58 length",
-            "expectedOutput": "result.publicKey.length >= 32 && result.publicKey.length <= 44",
-            "id": "t2",
-            "input": ""
-          },
-          {
-            "description": "Wallet is connected and the key is on-curve",
-            "expectedOutput": "result.connected === true && result.isValid === true",
-            "id": "t3",
-            "input": ""
-          }
-        ],
-        "url": null
-      }
-    ],
-    "slug": "connect-wallet-challenge",
-    "title": "Challenge: Wallet Connection Flow"
-  },
-  {
-    "_id": "lesson-cpi-challenge",
-    "blocks": [
-      {
-        "_type": "prose",
-        "amount": null,
-        "buildType": null,
-        "consumes": null,
-        "deployable": null,
-        "hints": null,
-        "idl": null,
-        "key": "intro",
-        "language": null,
-        "maxWords": null,
-        "network": null,
-        "produces": null,
-        "prompt": null,
-        "questions": null,
-        "solution": null,
-        "src": "# Challenge: Simulate a CPI Vault Transfer in Rust\n\nCross-Program Invocations (CPIs) let programs transfer SOL from PDA-controlled vaults. You'll simulate this pattern: derive a vault PDA, verify it has funds, and compute the transfer.\n\n## Your Task\n\nImplement `build_vault_transfer(user, vault_balance, recipient_balance, amount)` that:\n\n1. Derives the vault PDA using `find_pda(&[\"vault\", user], \"system\")` to get the bump\n2. Checks the vault has enough balance for the transfer\n3. Returns `Ok((new_vault_balance, new_recipient_balance, bump))` on success\n4. Returns `Err(\"INSUFFICIENT_VAULT_BALANCE\")` if vault can't cover the amount\n\n**This mirrors the real Anchor pattern:**\n```rust\ninvoke_signed(\n    &transfer_instruction,\n    &[vault_pda, recipient, system_program],\n    &[&[b\"vault\", user.key().as_ref(), &[bump]]],\n)?;\n```\n\nThe bump is needed for `invoke_signed` — the program proves it controls the PDA.\n",
-        "starter": null,
-        "tests": null,
-        "url": null
-      },
-      {
-        "_type": "code",
-        "amount": null,
-        "buildType": "standard",
-        "consumes": null,
-        "deployable": false,
-        "hints": [
-          "First derive the PDA: let (_, bump) = find_pda(&[\"vault\", user], \"system\");",
-          "Then check: if vault_balance < amount { return Err(\"INSUFFICIENT_VAULT_BALANCE\".to_string()); }",
-          "Return Ok((vault_balance - amount, recipient_balance + amount, bump))."
-        ],
-        "idl": null,
-        "key": "exercise",
-        "language": "rust",
-        "maxWords": null,
-        "network": null,
-        "produces": null,
-        "prompt": null,
-        "questions": null,
-        "solution": "use std::collections::hash_map::DefaultHasher;\nuse std::hash::{Hash, Hasher};\n\nfn hash_with_bump(seeds: &[&str], bump: u8, program_id: &str) -> u64 {\n    let mut hasher = DefaultHasher::new();\n    for seed in seeds { seed.hash(&mut hasher); }\n    bump.hash(&mut hasher);\n    program_id.hash(&mut hasher);\n    hasher.finish()\n}\n\nfn find_pda(seeds: &[&str], program_id: &str) -> (u64, u8) {\n    for bump in (0..=255u8).rev() {\n        let hash = hash_with_bump(seeds, bump, program_id);\n        if hash % 2 == 0 { return (hash, bump); }\n    }\n    panic!(\"No valid bump found\");\n}\n\nfn build_vault_transfer(\n    user: &str,\n    vault_balance: u64,\n    recipient_balance: u64,\n    amount: u64,\n) -> Result<(u64, u64, u8), String> {\n    let (_, bump) = find_pda(&[\"vault\", user], \"system\");\n    if vault_balance < amount {\n        return Err(\"INSUFFICIENT_VAULT_BALANCE\".to_string());\n    }\n    Ok((vault_balance - amount, recipient_balance + amount, bump))\n}\n",
-        "src": null,
-        "starter": "use std::collections::hash_map::DefaultHasher;\nuse std::hash::{Hash, Hasher};\n\nfn hash_with_bump(seeds: &[&str], bump: u8, program_id: &str) -> u64 {\n    let mut hasher = DefaultHasher::new();\n    for seed in seeds { seed.hash(&mut hasher); }\n    bump.hash(&mut hasher);\n    program_id.hash(&mut hasher);\n    hasher.finish()\n}\n\nfn find_pda(seeds: &[&str], program_id: &str) -> (u64, u8) {\n    for bump in (0..=255u8).rev() {\n        let hash = hash_with_bump(seeds, bump, program_id);\n        if hash % 2 == 0 { return (hash, bump); }\n    }\n    panic!(\"No valid bump found\");\n}\n\n/// Simulate a CPI transfer from a PDA vault to a recipient.\n/// Returns Ok((new_vault_balance, new_recipient_balance, bump)).\nfn build_vault_transfer(\n    user: &str,\n    vault_balance: u64,\n    recipient_balance: u64,\n    amount: u64,\n) -> Result<(u64, u64, u8), String> {\n    // TODO: Derive the vault PDA to get the bump\n    // TODO: Check vault_balance >= amount\n    // TODO: Return updated balances and the bump\n    todo!()\n}\n",
-        "tests": [
-          {
-            "description": "Sufficient balance succeeds",
-            "expectedOutput": "__result__.is_ok()",
-            "id": "t1",
-            "input": "\"alice\", 1000, 500, 200"
-          },
-          {
-            "description": "Insufficient balance fails",
-            "expectedOutput": "__result__.is_err()",
-            "id": "t2",
-            "input": "\"alice\", 100, 500, 200"
-          },
-          {
-            "description": "Balances update correctly",
-            "expectedOutput": "{ let r = __result__.unwrap(); r.0 == 800 && r.1 == 700 }",
-            "id": "t3",
-            "input": "\"alice\", 1000, 500, 200"
-          },
-          {
-            "description": "Balances update correctly for a different transfer",
-            "expectedOutput": "{ let r = __result__.unwrap(); r.0 == 3500 && r.1 == 2500 }",
-            "id": "t4",
-            "input": "\"bob\", 5000, 1000, 1500"
-          }
-        ],
-        "url": null
-      }
-    ],
-    "slug": "cpi-challenge",
-    "title": "Challenge: Simulate a CPI Vault Transfer"
-  },
-  {
-    "_id": "lesson-cpi-overview",
-    "blocks": [
-      {
-        "_type": "prose",
-        "amount": null,
-        "buildType": null,
-        "consumes": null,
-        "deployable": null,
-        "hints": null,
-        "idl": null,
-        "key": "intro",
-        "language": null,
-        "maxWords": null,
-        "network": null,
-        "produces": null,
-        "prompt": null,
-        "questions": null,
-        "solution": null,
-        "src": "# Cross-Program Invocations (CPIs)\n\nCross-Program Invocations allow one Solana program to call another program. This is what makes Solana programs **composable** — you can build on top of existing programs like building blocks.\n\n## Why CPIs Matter\n\nCPIs enable:\n- **Token transfers** via the Token Program\n- **NFT minting** via Metaplex programs\n- **Swaps** through DEX programs (Jupiter, Raydium)\n- **Lending** through DeFi protocols (Solend, MarginFi)\n\nWithout CPIs, every program would need to reimplement basic functionality. With CPIs, you compose existing programs.\n\n## How CPIs Work\n\nWhen Program A calls Program B:\n\n```\nUser Transaction\n  |\n  v\nProgram A (your program)\n  |\n  v (CPI)\nProgram B (Token Program, System Program, etc.)\n```\n\nThe Solana runtime tracks the **call stack** and ensures:\n- Account ownership rules are enforced\n- Signers are propagated correctly\n- Programs can't exceed the call depth limit (4 levels)\n\n## invoke vs invoke_signed\n\n### invoke - Regular CPI\n\n```rust\nuse solana_program::program::invoke;\n\ninvoke(\n    &instruction,\n    &[\n        source_account.clone(),\n        destination_account.clone(),\n        authority.clone(),\n    ],\n)?;\n```\n\nUse `invoke` when the required signers are already in your instruction's signer list.\n\n### invoke_signed - CPI with PDA Signer\n\n```rust\nuse solana_program::program::invoke_signed;\n\ninvoke_signed(\n    &instruction,\n    &[\n        pda_account.clone(),\n        destination_account.clone(),\n        system_program.clone(),\n    ],\n    &[&[b\"vault\", &[bump]]], // PDA seeds\n)?;\n```\n\nUse `invoke_signed` when a **PDA** needs to sign. The program derives the PDA and \"signs\" on its behalf.\n\n## CPI in Anchor\n\nAnchor provides a cleaner API for CPIs:\n\n```rust\nuse anchor_lang::prelude::*;\nuse anchor_spl::token::{self, Transfer};\n\npub fn transfer_tokens(ctx: Context<TransferTokens>, amount: u64) -> Result<()> {\n    let cpi_accounts = Transfer {\n        from: ctx.accounts.from.to_account_info(),\n        to: ctx.accounts.to.to_account_info(),\n        authority: ctx.accounts.authority.to_account_info(),\n    };\n\n    let cpi_program = ctx.accounts.token_program.to_account_info();\n    let cpi_ctx = CpiContext::new(cpi_program, cpi_accounts);\n\n    token::transfer(cpi_ctx, amount)?;\n    Ok(())\n}\n```\n\n### CPI with PDA Signer in Anchor\n\n```rust\npub fn transfer_from_pda(ctx: Context<TransferFromPDA>, amount: u64) -> Result<()> {\n    let seeds = &[\n        b\"vault\",\n        ctx.accounts.authority.key().as_ref(),\n        &[ctx.accounts.vault.bump],\n    ];\n    let signer_seeds = &[&seeds[..]];\n\n    let cpi_accounts = Transfer {\n        from: ctx.accounts.vault_token_account.to_account_info(),\n        to: ctx.accounts.user_token_account.to_account_info(),\n        authority: ctx.accounts.vault.to_account_info(),\n    };\n\n    let cpi_program = ctx.accounts.token_program.to_account_info();\n    let cpi_ctx = CpiContext::new_with_signer(\n        cpi_program,\n        cpi_accounts,\n        signer_seeds,\n    );\n\n    token::transfer(cpi_ctx, amount)?;\n    Ok(())\n}\n```\n\n## Common CPI Patterns\n\n### 1. Token Transfer\n\n```rust\n// Transfer SPL tokens from user to program vault\ntoken::transfer(\n    CpiContext::new(token_program, transfer_accounts),\n    amount,\n)?;\n```\n\n### 2. Minting Tokens\n\n```rust\n// Mint new tokens (requires mint authority)\ntoken::mint_to(\n    CpiContext::new_with_signer(token_program, mint_accounts, signer_seeds),\n    amount,\n)?;\n```\n\n### 3. Creating Accounts\n\n```rust\n// Create a new account (CPI to System Program)\nsystem_program::create_account(\n    CpiContext::new(system_program, create_accounts),\n    lamports,\n    space,\n    program_id,\n)?;\n```\n\n## CPI Security Considerations\n\n### 1. Account Validation\n\nAlways validate accounts before CPI:\n\n```rust\nrequire_keys_eq!(\n    ctx.accounts.token_program.key(),\n    token::ID,\n    ErrorCode::InvalidTokenProgram\n);\n```\n\n### 2. Signer Propagation\n\nSigners in your instruction are automatically propagated to CPIs. But be careful:\n\n```rust\n// BAD: Anyone can call this and spend vault tokens!\npub fn dangerous_withdraw(ctx: Context<Withdraw>, amount: u64) -> Result<()> {\n    token::transfer(\n        CpiContext::new_with_signer(...),\n        amount,\n    )\n}\n\n// GOOD: Check authority first\npub fn safe_withdraw(ctx: Context<Withdraw>, amount: u64) -> Result<()> {\n    require_keys_eq!(\n        ctx.accounts.authority.key(),\n        ctx.accounts.vault.authority,\n        ErrorCode::Unauthorized\n    );\n    token::transfer(...)\n}\n```\n\n### 3. Reentrancy\n\nSolana programs are **not reentrant** by default (a program can't call itself). This prevents classic reentrancy attacks.\n\n## Real-World CPI Examples\n\n**Escrow program**:\n1. User deposits tokens → CPI to Token Program to transfer tokens to escrow PDA\n2. Trade executes → CPI to Token Program to transfer from escrow PDA to recipient\n\n**Staking program**:\n1. User stakes tokens → CPI to Token Program to transfer to staking vault\n2. User claims rewards → CPI to Token Program to mint reward tokens\n3. User unstakes → CPI to Token Program to transfer staked tokens back\n\n**NFT marketplace**:\n1. User lists NFT → CPI to Token Program to transfer NFT to marketplace PDA\n2. Buyer purchases → CPI to System Program (SOL payment) + CPI to Token Program (NFT transfer)\n\n## Next Challenge\n\nYou'll construct a CPI instruction to transfer SOL from a PDA-owned account.\n",
-        "starter": null,
-        "tests": null,
-        "url": null
-      }
-    ],
-    "slug": "cpi-overview",
-    "title": "Cross-Program Invocations"
-  },
-  {
-    "_id": "lesson-create-token-challenge",
-    "blocks": [
-      {
-        "_type": "prose",
-        "amount": null,
-        "buildType": null,
-        "consumes": null,
-        "deployable": null,
-        "hints": null,
-        "idl": null,
-        "key": "intro",
-        "language": null,
-        "maxWords": null,
-        "network": null,
-        "produces": null,
-        "prompt": null,
-        "questions": null,
-        "solution": null,
-        "src": "# Challenge: Create a Token Mint\n\nWrite a function that creates a new SPL token mint on Solana devnet.\n\n## Requirements\n\n- Create a new token mint with 9 decimals\n- The payer should be both the mint authority and freeze authority\n- Return the mint address as a base58 string\n",
-        "starter": null,
-        "tests": null,
-        "url": null
-      },
-      {
-        "_type": "code",
-        "amount": null,
-        "buildType": "standard",
-        "consumes": null,
-        "deployable": false,
-        "hints": [
-          "Use createMint() from @solana/spl-token",
-          "Pass payer.publicKey as both mintAuthority and freezeAuthority",
-          "The function returns a PublicKey; use .toBase58() to convert to string"
-        ],
-        "idl": null,
-        "key": "exercise",
-        "language": "typescript",
-        "maxWords": null,
-        "network": null,
-        "produces": null,
-        "prompt": null,
-        "questions": null,
-        "solution": "import { Connection, Keypair } from '@solana/web3.js';\nimport { createMint } from '@solana/spl-token';\n\nasync function createTokenMint(\n  connection: Connection,\n  payer: Keypair\n): Promise<string> {\n  const mint = await createMint(\n    connection,\n    payer,\n    payer.publicKey,\n    payer.publicKey,\n    9\n  );\n\n  return mint.toBase58();\n}\n",
-        "src": null,
-        "starter": "import { Connection, Keypair } from '@solana/web3.js';\nimport { createMint } from '@solana/spl-token';\n\nasync function createTokenMint(\n  connection: Connection,\n  payer: Keypair\n): Promise<string> {\n  // Your code here\n}\n",
-        "tests": [
-          {
-            "description": "Returns a valid mint address string (base58 length)",
-            "expectedOutput": "typeof result === 'string' && result.length >= 32 && result.length <= 44",
-            "id": "t1",
-            "input": "connection, payer"
-          }
-        ],
-        "url": null
-      }
-    ],
-    "slug": "create-token-challenge",
-    "title": "Challenge: Create a Token Mint"
-  },
-  {
-    "_id": "lesson-dapp-challenge",
-    "blocks": [
-      {
-        "_type": "prose",
-        "amount": null,
-        "buildType": null,
-        "consumes": null,
-        "deployable": null,
-        "hints": null,
-        "idl": null,
-        "key": "intro",
-        "language": null,
-        "maxWords": null,
-        "network": null,
-        "produces": null,
-        "prompt": null,
-        "questions": null,
-        "solution": null,
-        "src": "# Challenge: SOL Transfer Form\n\nBuild the validation and transaction construction logic for a SOL transfer form.\n\n## Requirements\n\n- Create a function that validates a transfer request and constructs the transaction\n- Accept `senderPublicKey` (PublicKey), `recipientAddress` (string), `amountInSol` (number), and `connection` (Connection)\n- Validate:\n  1. Recipient address is a valid PublicKey (use try/catch)\n  2. Amount is positive and non-zero\n  3. Sender has sufficient balance (check with `connection.getBalance()`)\n- If validation fails, return `{ success: false, error: string }`\n- If validation passes, construct a Transaction with SystemProgram.transfer and return `{ success: true, transaction: Transaction }`\n",
-        "starter": null,
-        "tests": null,
-        "url": null
-      },
-      {
-        "_type": "code",
-        "amount": null,
-        "buildType": "standard",
-        "consumes": null,
-        "deployable": false,
-        "hints": [
-          "Wrap new PublicKey(recipientAddress) in try/catch to validate the address",
-          "Check amount > 0 before proceeding with balance check",
-          "Use connection.getBalance() to get sender balance in lamports, then compare with amountInSol * LAMPORTS_PER_SOL"
-        ],
-        "idl": null,
-        "key": "exercise",
-        "language": "typescript",
-        "maxWords": null,
-        "network": null,
-        "produces": null,
-        "prompt": null,
-        "questions": null,
-        "solution": "import {\n  Connection,\n  PublicKey,\n  SystemProgram,\n  Transaction,\n  LAMPORTS_PER_SOL,\n} from '@solana/web3.js';\n\ninterface ValidationResult {\n  success: boolean;\n  error?: string;\n  transaction?: Transaction;\n}\n\nasync function validateAndBuildTransfer(\n  senderPublicKey: PublicKey,\n  recipientAddress: string,\n  amountInSol: number,\n  connection: Connection\n): Promise<ValidationResult> {\n  // Validate recipient address\n  let recipientPublicKey: PublicKey;\n  try {\n    recipientPublicKey = new PublicKey(recipientAddress);\n  } catch {\n    return { success: false, error: 'Invalid recipient address' };\n  }\n\n  // Validate amount\n  if (amountInSol <= 0) {\n    return { success: false, error: 'Amount must be positive' };\n  }\n\n  // Check sender balance\n  const senderBalance = await connection.getBalance(senderPublicKey);\n  const requiredLamports = amountInSol * LAMPORTS_PER_SOL;\n\n  if (senderBalance < requiredLamports) {\n    return { success: false, error: 'Insufficient balance' };\n  }\n\n  // Build transaction\n  const transaction = new Transaction().add(\n    SystemProgram.transfer({\n      fromPubkey: senderPublicKey,\n      toPubkey: recipientPublicKey,\n      lamports: requiredLamports,\n    })\n  );\n\n  return { success: true, transaction };\n}\n",
-        "src": null,
-        "starter": "import {\n  Connection,\n  PublicKey,\n  SystemProgram,\n  Transaction,\n  LAMPORTS_PER_SOL,\n} from '@solana/web3.js';\n\ninterface ValidationResult {\n  success: boolean;\n  error?: string;\n  transaction?: Transaction;\n}\n\nasync function validateAndBuildTransfer(\n  senderPublicKey: PublicKey,\n  recipientAddress: string,\n  amountInSol: number,\n  connection: Connection\n): Promise<ValidationResult> {\n  // Your code here\n}\n",
-        "tests": [
-          {
-            "description": "Should reject invalid recipient address",
-            "expectedOutput": "result.success === false && typeof result.error === 'string'",
-            "id": "test-1",
-            "input": "sender, 'invalid', 1.0, connection"
-          },
-          {
-            "description": "Should reject negative amounts",
-            "expectedOutput": "result.success === false",
-            "id": "test-2",
-            "input": "sender, 'invalid', -1, connection"
-          },
-          {
-            "description": "Should return object with success field",
-            "expectedOutput": "typeof result === 'object' && 'success' in result",
-            "id": "test-3",
-            "input": "sender, 'invalid', 1.0, connection"
-          }
-        ],
-        "url": null
-      }
-    ],
-    "slug": "dapp-challenge",
-    "title": "Challenge: SOL Transfer Form"
-  },
-  {
-    "_id": "lesson-defi-overview",
-    "blocks": [
-      {
-        "_type": "prose",
-        "amount": null,
-        "buildType": null,
-        "consumes": null,
-        "deployable": null,
-        "hints": null,
-        "idl": null,
-        "key": "intro",
-        "language": null,
-        "maxWords": null,
-        "network": null,
-        "produces": null,
-        "prompt": null,
-        "questions": null,
-        "solution": null,
-        "src": "# DeFi on Solana Overview\n\nDecentralized Finance (DeFi) on Solana has exploded in growth thanks to the chain's speed, low costs, and composability. Let's explore the landscape.\n\n## Why Solana for DeFi?\n\n### Speed\n- **400ms block time** - Near-instant transaction finality\n- **65,000+ TPS** - Handles high-frequency trading\n- **Parallel execution** - Multiple programs run simultaneously\n\n### Cost\n- **$0.00025 average transaction** - Makes micro-transactions viable\n- **No gas wars** - Predictable fees even during congestion\n\n### Composability\n- **Single global state** - All programs share the same state\n- **Atomic composability** - Multi-program transactions are atomic\n- **No bridges needed** - Everything is native\n\n## The Solana DeFi Ecosystem\n\n### Decentralized Exchanges (DEXs)\n\n**Jupiter** - Aggregates liquidity from all Solana DEXs\n- Routes trades through multiple DEXs for best price\n- 15+ DEX integrations\n- Limit orders, DCA, perpetuals\n\n**Raydium** - Automated Market Maker (AMM)\n- Concentrated liquidity (like Uniswap v3)\n- OpenBook integration (hybrid AMM/orderbook)\n- Top 3 by volume on Solana\n\n**Orca** - User-friendly AMM\n- Whirlpools (concentrated liquidity)\n- Clean UX, popular for beginners\n\n**Phoenix** - Central Limit Order Book (CLOB)\n- Fully on-chain orderbook\n- Sub-second matching\n- Successor to Serum\n\n### Lending Protocols\n\n**Solend** - Algorithmic lending/borrowing\n- Supply assets, earn yield\n- Borrow against collateral\n- Isolated pools for risk management\n\n**MarginFi** - Decentralized margin trading\n- Leveraged positions\n- Portfolio margin\n- Integrated with major DEXs\n\n**Kamino Finance** - Automated liquidity strategies\n- Vaults for concentrated liquidity\n- Leveraged yield farming\n- Risk-adjusted returns\n\n### Liquid Staking\n\n**Marinade (mSOL)** - Largest liquid staking protocol\n- Stake SOL, receive mSOL\n- mSOL accrues staking rewards\n- Can use mSOL in DeFi while earning staking yield\n\n**Jito (jitoSOL)** - MEV-enhanced staking\n- Distributes MEV rewards to stakers\n- Higher APY than native staking\n\n**BlazeStake (bSOL)** - Focuses on decentralization\n- Delegates to smaller validators\n- Supports Solana decentralization\n\n### Perpetuals & Derivatives\n\n**Drift Protocol** - Decentralized perpetuals\n- Up to 10x leverage\n- Virtual AMM design\n- Insurance fund for trader protection\n\n**Zeta Markets** - Options and futures\n- Undercollateralized DeFi options\n- On-chain orderbook\n\n## Total Value Locked (TVL)\n\nAs of 2025, Solana DeFi TVL:\n- **Total**: ~$7B USD\n- **Jito**: $2.5B (liquid staking)\n- **Kamino**: $1.8B (lending/vaults)\n- **Marinade**: $1.2B (liquid staking)\n- **Raydium**: $1.5B (DEX)\n\nSolana is the 4th largest DeFi ecosystem after Ethereum, Tron, and BNB Chain.\n\n## DeFi Primitives on Solana\n\n### 1. Automated Market Makers (AMMs)\n\nConstant product formula: `x * y = k`\n\n```\nPool: 1000 SOL × 100,000 USDC = 100,000,000\nPrice: 100,000 / 1000 = 100 USDC per SOL\n```\n\n### 2. Concentrated Liquidity\n\nLiquidity providers choose a price range:\n\n```\nStandard AMM: Capital spread across 0 → ∞\nConcentrated: Capital focused on $95-$105 range\nResult: 10-100x capital efficiency\n```\n\n### 3. Lending Pools\n\nSupply rate = Borrow rate × Utilization × (1 - Reserve factor)\n\n```\nTotal supplied: 1000 SOL\nTotal borrowed: 700 SOL\nUtilization: 70%\nBorrow APY: 8%\nSupply APY: 8% × 70% × 90% = 5.04%\n```\n\n### 4. Liquidations\n\n```\nHealth Factor = Collateral Value / (Debt Value / LTV)\nIf Health Factor < 1.0 → Liquidatable\n```\n\n## Composability in Action\n\n**Example: Leveraged Yield Farming**\n\n1. Deposit SOL to Kamino\n2. Borrow USDC against SOL collateral\n3. Swap USDC → SOL on Jupiter\n4. Deposit SOL to liquidity pool on Raydium\n5. Earn swap fees + USDC rewards\n\nAll of this can happen in **one atomic transaction**.\n\n## Security Considerations\n\n### Smart Contract Risk\n- Programs can have bugs (test thoroughly, get audits)\n- Upgradeable programs can be changed by authority\n- Check if program authority is a multisig or revoked\n\n### Oracle Risk\n- Price feeds can be manipulated or go stale\n- Use multiple oracles (Pyth, Switchboard)\n- Implement staleness checks and circuit breakers\n\n### Liquidation Risk\n- Solana's speed helps (faster liquidations = less bad debt)\n- But volatility can still cause cascading liquidations\n\n### Protocol Composability Risk\n- A bug in one protocol can cascade to others\n- Isolated pools mitigate this\n\n## The Future of Solana DeFi\n\n**Token Extensions (Token-2022)**\n- Transfer hooks (fees, restrictions)\n- Confidential transfers (privacy)\n- Interest-bearing tokens\n\n**Firedancer**\n- New validator client → 1M+ TPS\n- Even faster DeFi execution\n\n**Cross-chain**\n- Wormhole, Allbridge for bridging\n- But Solana's goal is to be self-contained\n\n## Next Lessons\n\nYou'll dive deep into AMM mechanics, lending protocols, and build DeFi primitives yourself.\n",
-        "starter": null,
-        "tests": null,
-        "url": null
-      }
-    ],
-    "slug": "defi-overview",
-    "title": "DeFi on Solana Overview"
-  },
-  {
     "_id": "lesson-deployment",
+    "title": "Deploying Solana Programs",
+    "slug": "deployment",
     "blocks": [
       {
-        "_type": "prose",
-        "amount": null,
-        "buildType": null,
-        "consumes": null,
-        "deployable": null,
-        "hints": null,
-        "idl": null,
         "key": "intro",
-        "language": null,
-        "maxWords": null,
-        "network": null,
+        "_type": "prose",
         "produces": null,
-        "prompt": null,
-        "questions": null,
-        "solution": null,
+        "consumes": null,
         "src": "# Deploying Solana Programs\n\nDeploying to Solana is straightforward with Anchor, but there are important considerations for security and upgrades.\n\n## Building Your Program\n\n```bash\nanchor build\n```\n\nThis compiles your program and generates:\n- `target/deploy/my_program.so` - The compiled program\n- `target/idl/my_program.json` - The Interface Definition Language file\n- `target/types/my_program.ts` - TypeScript types for your program\n\n## Deploying to Devnet\n\n1. **Configure your CLI for devnet**:\n\n```bash\nsolana config set --url devnet\n```\n\n2. **Ensure you have SOL**:\n\n```bash\nsolana balance\nsolana airdrop 2  # If needed\n```\n\n3. **Deploy**:\n\n```bash\nanchor deploy\n```\n\nAnchor will:\n- Upload the program binary\n- Create the program account\n- Set you as the upgrade authority\n\n## Understanding Program IDs\n\nYour program ID is declared in `lib.rs`:\n\n```rust\ndeclare_id!(\"YourProgramIDHere\");\n```\n\nThis ID is generated when you run `anchor init` and stored in `target/deploy/my_program-keypair.json`.\n\n**Important**: Once deployed, the program ID is permanent for that deployment. If you want a new ID, you need to create a new keypair.\n\n## The IDL (Interface Definition Language)\n\nThe IDL is a JSON file describing your program's interface:\n\n```json\n{\n  \"version\": \"0.1.0\",\n  \"name\": \"my_program\",\n  \"instructions\": [\n    {\n      \"name\": \"initialize\",\n      \"accounts\": [\n        { \"name\": \"myAccount\", \"isMut\": true, \"isSigner\": true },\n        { \"name\": \"user\", \"isMut\": true, \"isSigner\": true },\n        { \"name\": \"systemProgram\", \"isMut\": false, \"isSigner\": false }\n      ],\n      \"args\": []\n    }\n  ],\n  \"accounts\": [\n    {\n      \"name\": \"MyAccount\",\n      \"type\": {\n        \"kind\": \"struct\",\n        \"fields\": [\n          { \"name\": \"data\", \"type\": \"u64\" }\n        ]\n      }\n    }\n  ]\n}\n```\n\nClients use the IDL to interact with your program.\n\n## Uploading the IDL\n\n```bash\nanchor idl init -f target/idl/my_program.json <PROGRAM_ID>\n```\n\nThis stores the IDL on-chain, making it easier for tools like Anchor Explorer to understand your program.\n\nUpdate an existing IDL:\n\n```bash\nanchor idl upgrade -f target/idl/my_program.json <PROGRAM_ID>\n```\n\n## Program Upgrades\n\nSolana programs are **upgradeable** by default. The upgrade authority can replace the program code:\n\n```bash\nanchor upgrade target/deploy/my_program.so --program-id <PROGRAM_ID>\n```\n\n### Checking Upgrade Authority\n\n```bash\nsolana program show <PROGRAM_ID>\n```\n\nOutput:\n```\nProgram Id: YourProgramID\nOwner: BPFLoaderUpgradeab1e11111111111111111111111\nProgramData Address: ...\nAuthority: YourWalletPublicKey\nLast Deployed In Slot: 123456789\nData Length: 200000 bytes\n```\n\n### Transferring Upgrade Authority\n\n```bash\nsolana program set-upgrade-authority <PROGRAM_ID> --new-upgrade-authority <NEW_AUTHORITY>\n```\n\n### Revoking Upgrade Authority (Immutable Program)\n\nFor maximum security, you can make a program **immutable**:\n\n```bash\nsolana program set-upgrade-authority <PROGRAM_ID> --final\n```\n\n**Warning**: This is irreversible! No one can ever upgrade the program again.\n\n## Multisig Upgrade Authority\n\nFor production programs, use a multisig as the upgrade authority:\n\n```bash\n# Create a multisig with Squads Protocol\n# Set multisig as upgrade authority\nsolana program set-upgrade-authority <PROGRAM_ID> --new-upgrade-authority <MULTISIG_ADDRESS>\n```\n\nThis requires multiple team members to approve upgrades.\n\n## Verifiable Builds\n\nVerifiable builds let anyone verify your deployed program matches your source code:\n\n```bash\nanchor build --verifiable\n```\n\nThis builds your program in a Docker container with a deterministic environment.\n\nVerify a deployed program:\n\n```bash\nanchor verify <PROGRAM_ID>\n```\n\n## Deploying to Mainnet\n\n1. **Switch to mainnet**:\n\n```bash\nsolana config set --url mainnet-beta\n```\n\n2. **Fund your wallet** (deploying costs ~2-5 SOL depending on program size)\n\n3. **Audit your code** (get a professional audit for production programs)\n\n4. **Deploy**:\n\n```bash\nanchor deploy\n```\n\n5. **Upload IDL**:\n\n```bash\nanchor idl init -f target/idl/my_program.json <PROGRAM_ID>\n```\n\n6. **Set up multisig authority** or **revoke authority** if appropriate\n\n## Best Practices\n\n1. **Test on devnet first** - Always deploy and test on devnet before mainnet\n2. **Use verifiable builds** - Builds trust with users\n3. **Store keypairs securely** - Never commit `target/deploy/*-keypair.json` to Git\n4. **Plan your upgrade strategy** - Multisig for most cases, immutable for critical infrastructure\n5. **Monitor program accounts** - Track rent, data size, and usage\n6. **Document your IDL** - Add comments to your Rust code; they appear in the IDL\n\n## Common Deployment Issues\n\n### Insufficient SOL\n\n```\nError: Account <PROGRAM_ID> has insufficient funds\n```\n\nSolution: Airdrop more SOL (devnet) or fund your wallet (mainnet)\n\n### Program Already Deployed\n\n```\nError: Program already exists\n```\n\nSolution: Use `anchor upgrade` instead of `anchor deploy`\n\n### Wrong Upgrade Authority\n\n```\nError: Upgrade authority mismatch\n```\n\nSolution: Ensure the wallet you're using matches the upgrade authority\n\n## Next Challenge\n\nYou'll write a test that simulates a program execution scenario.\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
         "starter": null,
+        "solution": null,
         "tests": null,
-        "url": null
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       }
-    ],
-    "slug": "deployment",
-    "title": "Deploying Solana Programs"
+    ]
   },
   {
     "_id": "lesson-error-challenge",
+    "title": "Challenge: Transaction Validator",
+    "slug": "error-challenge",
     "blocks": [
       {
-        "_type": "prose",
-        "amount": null,
-        "buildType": null,
-        "consumes": null,
-        "deployable": null,
-        "hints": null,
-        "idl": null,
         "key": "intro",
-        "language": null,
-        "maxWords": null,
-        "network": null,
+        "_type": "prose",
         "produces": null,
-        "prompt": null,
-        "questions": null,
-        "solution": null,
+        "consumes": null,
         "src": "# Challenge: Build a Transaction Validator in Rust\n\nApply your error handling knowledge using Rust's `Result<T, E>` type. You'll validate a transfer by checking multiple conditions and returning typed errors — the same pattern used in real Solana programs.\n\n## Your Task\n\nImplement `validate_transfer(sender, recipient, amount, sender_balance)` that:\n\n1. Returns `Err(\"INVALID_RECIPIENT\")` if recipient is empty\n2. Returns `Err(\"ZERO_AMOUNT\")` if amount is 0\n3. Returns `Err(\"INSUFFICIENT_BALANCE\")` if sender_balance < amount\n4. Returns `Err(\"SAME_ACCOUNT\")` if sender equals recipient\n5. Returns `Ok(())` if all validations pass\n\n**Validation Order**: Check in the order listed above (return the first error).\n\n**Rust Concepts Used:**\n- `Result<(), String>` return type\n- Early returns with `return Err(...)`\n- String comparison with `==`\n- The `?` operator pattern (for learning)\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
         "starter": null,
+        "solution": null,
         "tests": null,
-        "url": null
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       },
       {
+        "key": "exercise",
         "_type": "code",
-        "amount": null,
-        "buildType": "standard",
+        "produces": null,
         "consumes": null,
+        "src": null,
+        "url": null,
+        "language": "rust",
+        "buildType": "standard",
         "deployable": false,
+        "starter": "fn validate_transfer(\n    sender: &str,\n    recipient: &str,\n    amount: u64,\n    sender_balance: u64,\n) -> Result<(), String> {\n    // TODO: Check if recipient is empty -> Err(\"INVALID_RECIPIENT\")\n\n    // TODO: Check if amount is 0 -> Err(\"ZERO_AMOUNT\")\n\n    // TODO: Check if sender_balance < amount -> Err(\"INSUFFICIENT_BALANCE\")\n\n    // TODO: Check if sender == recipient -> Err(\"SAME_ACCOUNT\")\n\n    // TODO: All checks passed -> Ok(())\n    todo!()\n}\n",
+        "solution": "fn validate_transfer(\n    sender: &str,\n    recipient: &str,\n    amount: u64,\n    sender_balance: u64,\n) -> Result<(), String> {\n    if recipient.is_empty() {\n        return Err(\"INVALID_RECIPIENT\".to_string());\n    }\n    if amount == 0 {\n        return Err(\"ZERO_AMOUNT\".to_string());\n    }\n    if sender_balance < amount {\n        return Err(\"INSUFFICIENT_BALANCE\".to_string());\n    }\n    if sender == recipient {\n        return Err(\"SAME_ACCOUNT\".to_string());\n    }\n    Ok(())\n}\n",
+        "tests": [
+          {
+            "id": "t1",
+            "description": "Valid transfer succeeds",
+            "input": "\"alice\", \"bob\", 100, 500",
+            "expectedOutput": "__result__.is_ok()"
+          },
+          {
+            "id": "t2",
+            "description": "Empty recipient is rejected",
+            "input": "\"alice\", \"\", 100, 500",
+            "expectedOutput": "__result__ == Err(\"INVALID_RECIPIENT\".to_string())"
+          },
+          {
+            "id": "t3",
+            "description": "Zero amount is rejected",
+            "input": "\"alice\", \"bob\", 0, 500",
+            "expectedOutput": "__result__ == Err(\"ZERO_AMOUNT\".to_string())"
+          },
+          {
+            "id": "t4",
+            "description": "Insufficient balance is rejected",
+            "input": "\"alice\", \"bob\", 600, 500",
+            "expectedOutput": "__result__ == Err(\"INSUFFICIENT_BALANCE\".to_string())"
+          },
+          {
+            "id": "t5",
+            "description": "Sender equal to recipient is rejected",
+            "input": "\"alice\", \"alice\", 100, 500",
+            "expectedOutput": "__result__ == Err(\"SAME_ACCOUNT\".to_string())"
+          }
+        ],
         "hints": [
           "Check recipient.is_empty() first. If true, return Err(\"INVALID_RECIPIENT\".to_string()).",
           "Then check amount == 0, then sender_balance < amount. Each returns the corresponding Err string.",
           "Finally check if sender == recipient for the SAME_ACCOUNT error. If all pass, return Ok(())."
         ],
-        "idl": null,
-        "key": "exercise",
-        "language": "rust",
-        "maxWords": null,
-        "network": null,
-        "produces": null,
-        "prompt": null,
         "questions": null,
-        "solution": "fn validate_transfer(\n    sender: &str,\n    recipient: &str,\n    amount: u64,\n    sender_balance: u64,\n) -> Result<(), String> {\n    if recipient.is_empty() {\n        return Err(\"INVALID_RECIPIENT\".to_string());\n    }\n    if amount == 0 {\n        return Err(\"ZERO_AMOUNT\".to_string());\n    }\n    if sender_balance < amount {\n        return Err(\"INSUFFICIENT_BALANCE\".to_string());\n    }\n    if sender == recipient {\n        return Err(\"SAME_ACCOUNT\".to_string());\n    }\n    Ok(())\n}\n",
-        "src": null,
-        "starter": "fn validate_transfer(\n    sender: &str,\n    recipient: &str,\n    amount: u64,\n    sender_balance: u64,\n) -> Result<(), String> {\n    // TODO: Check if recipient is empty -> Err(\"INVALID_RECIPIENT\")\n\n    // TODO: Check if amount is 0 -> Err(\"ZERO_AMOUNT\")\n\n    // TODO: Check if sender_balance < amount -> Err(\"INSUFFICIENT_BALANCE\")\n\n    // TODO: Check if sender == recipient -> Err(\"SAME_ACCOUNT\")\n\n    // TODO: All checks passed -> Ok(())\n    todo!()\n}\n",
-        "tests": [
-          {
-            "description": "Valid transfer succeeds",
-            "expectedOutput": "__result__.is_ok()",
-            "id": "t1",
-            "input": "\"alice\", \"bob\", 100, 500"
-          },
-          {
-            "description": "Empty recipient is rejected",
-            "expectedOutput": "__result__ == Err(\"INVALID_RECIPIENT\".to_string())",
-            "id": "t2",
-            "input": "\"alice\", \"\", 100, 500"
-          },
-          {
-            "description": "Zero amount is rejected",
-            "expectedOutput": "__result__ == Err(\"ZERO_AMOUNT\".to_string())",
-            "id": "t3",
-            "input": "\"alice\", \"bob\", 0, 500"
-          },
-          {
-            "description": "Insufficient balance is rejected",
-            "expectedOutput": "__result__ == Err(\"INSUFFICIENT_BALANCE\".to_string())",
-            "id": "t4",
-            "input": "\"alice\", \"bob\", 600, 500"
-          },
-          {
-            "description": "Sender equal to recipient is rejected",
-            "expectedOutput": "__result__ == Err(\"SAME_ACCOUNT\".to_string())",
-            "id": "t5",
-            "input": "\"alice\", \"alice\", 100, 500"
-          }
-        ],
-        "url": null
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       }
-    ],
-    "slug": "error-challenge",
-    "title": "Challenge: Transaction Validator"
+    ]
   },
   {
     "_id": "lesson-error-handling",
+    "title": "Error Handling in Solana Programs",
+    "slug": "error-handling",
     "blocks": [
       {
-        "_type": "prose",
-        "amount": null,
-        "buildType": null,
-        "consumes": null,
-        "deployable": null,
-        "hints": null,
-        "idl": null,
         "key": "intro",
-        "language": null,
-        "maxWords": null,
-        "network": null,
+        "_type": "prose",
         "produces": null,
-        "prompt": null,
-        "questions": null,
-        "solution": null,
+        "consumes": null,
         "src": "# Error Handling in Solana Programs\n\nRobust error handling is critical for secure Solana programs. Rust's `Result` type and pattern matching make it impossible to accidentally ignore errors, unlike languages with exceptions.\n\n## The Result Type\n\nEvery fallible operation in Rust returns a `Result<T, E>`:\n- `Ok(value)`: Success, contains the result\n- `Err(error)`: Failure, contains the error\n\n```rust\npub fn divide(a: u64, b: u64) -> Result<u64, String> {\n    if b == 0 {\n        Err(\"Division by zero\".to_string())\n    } else {\n        Ok(a / b)\n    }\n}\n\nmatch divide(10, 2) {\n    Ok(result) => println!(\"Result: {}\", result),\n    Err(e) => println!(\"Error: {}\", e),\n}\n```\n\n## Error Propagation with `?`\n\nThe `?` operator automatically returns an error if the operation fails, or unwraps the value if it succeeds:\n\n```rust\npub fn process_transfer(\n    accounts: &[AccountInfo],\n    amount: u64,\n) -> ProgramResult {\n    let sender = next_account_info(&mut accounts.iter())?; // Returns early if fails\n    let recipient = next_account_info(&mut accounts.iter())?;\n    \n    if sender.lamports() < amount {\n        return Err(ProgramError::InsufficientFunds);\n    }\n    \n    **sender.lamports.borrow_mut() -= amount;\n    **recipient.lamports.borrow_mut() += amount;\n    \n    Ok(())\n}\n```\n\nThis is much cleaner than manual error checking:\n\n```rust\n// Without ?\nlet sender = match next_account_info(&mut accounts.iter()) {\n    Ok(acc) => acc,\n    Err(e) => return Err(e),\n};\n```\n\n## ProgramError Enum\n\nSolana provides a standard `ProgramError` enum for common failures:\n\n```rust\npub enum ProgramError {\n    InvalidArgument,\n    InsufficientFunds,\n    IncorrectProgramId,\n    MissingRequiredSignature,\n    AccountAlreadyInitialized,\n    UninitializedAccount,\n    // ... and 20+ more variants\n}\n```\n\nReturn these from your `process_instruction` function:\n\n```rust\nif !sender.is_signer {\n    return Err(ProgramError::MissingRequiredSignature);\n}\n```\n\n## Custom Error Types\n\nFor domain-specific errors, define your own enum:\n\n```rust\nuse num_derive::FromPrimitive;\nuse thiserror::Error;\n\n#[derive(Error, Debug, Copy, Clone, FromPrimitive)]\npub enum TokenError {\n    #[error(\"Insufficient token balance\")]\n    InsufficientBalance,\n    \n    #[error(\"Account is frozen\")]\n    AccountFrozen,\n    \n    #[error(\"Invalid mint authority\")]\n    InvalidMintAuthority,\n}\n\nimpl From<TokenError> for ProgramError {\n    fn from(e: TokenError) -> Self {\n        ProgramError::Custom(e as u32)\n    }\n}\n```\n\nNow you can return custom errors that convert to `ProgramError::Custom`:\n\n```rust\nif account.frozen {\n    return Err(TokenError::AccountFrozen.into());\n}\n```\n\n## Validation Patterns\n\nAlways validate inputs at the start of your instruction handler:\n\n```rust\npub fn process_transfer(\n    program_id: &Pubkey,\n    accounts: &[AccountInfo],\n    amount: u64,\n) -> ProgramResult {\n    // 1. Validate account count\n    if accounts.len() < 2 {\n        return Err(ProgramError::NotEnoughAccountKeys);\n    }\n    \n    let account_iter = &mut accounts.iter();\n    let sender = next_account_info(account_iter)?;\n    let recipient = next_account_info(account_iter)?;\n    \n    // 2. Validate ownership\n    if sender.owner != program_id {\n        return Err(ProgramError::IncorrectProgramId);\n    }\n    \n    // 3. Validate signer\n    if !sender.is_signer {\n        return Err(ProgramError::MissingRequiredSignature);\n    }\n    \n    // 4. Validate amount\n    if amount == 0 {\n        return Err(ProgramError::InvalidArgument);\n    }\n    \n    // 5. Validate balance\n    if sender.lamports() < amount {\n        return Err(ProgramError::InsufficientFunds);\n    }\n    \n    // Now perform the transfer\n    **sender.lamports.borrow_mut() -= amount;\n    **recipient.lamports.borrow_mut() += amount;\n    \n    Ok(())\n}\n```\n\n## Error Messages\n\nUse the `msg!` macro to log errors for debugging (visible in transaction logs):\n\n```rust\nmsg!(\"Transfer failed: insufficient balance ({} < {})\", sender.lamports(), amount);\nreturn Err(ProgramError::InsufficientFunds);\n```\n\n**Important**: Never log sensitive data like private keys or user PII.\n\n## Key Takeaways\n\n1. **Always use `Result`**: Never use `unwrap()` or `expect()` in production programs\n2. **Validate early**: Check all preconditions before mutating state\n3. **Use `?` for propagation**: Cleaner than manual error handling\n4. **Return specific errors**: Help clients diagnose failures\n5. **Log for debugging**: Use `msg!` to provide context in transaction logs\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
         "starter": null,
+        "solution": null,
         "tests": null,
-        "url": null
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "retrieval-close",
+        "_type": "quiz",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": [
+          {
+            "id": "q1",
+            "prompt": "You replace a `?` on `next_account_info(...)` with `.unwrap()`. What is the risk in a Solana program?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "On the Err case unwrap panics, aborting the program abnormally instead of returning a clean error to the caller",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "Nothing — unwrap and ? behave identically",
+                "correct": false,
+                "feedback": "They differ on failure: `?` returns the error up the stack; `.unwrap()` panics. In a program you want the clean error return, not a panic."
+              },
+              {
+                "id": "c",
+                "label": "unwrap makes the instruction retry automatically",
+                "correct": false,
+                "feedback": "unwrap never retries; it panics on Err. `?` propagates the error so the transaction fails cleanly with a diagnosable code."
+              }
+            ],
+            "explanation": "`?` unwraps on Ok and returns the Err upward, letting the instruction fail with a specific ProgramError the client can read. `.unwrap()` panics on Err — which is why the guidance is never to unwrap in program code; propagate with `?` instead."
+          },
+          {
+            "id": "q2",
+            "prompt": "A custom `TokenError` implements `From<TokenError> for ProgramError`, returning `ProgramError::Custom(e as u32)`. Why is that conversion needed?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "process_instruction must return `ProgramError`, so custom errors are mapped into `Custom(code)` to travel through that return type",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "It renames the error so clients cannot see the code",
+                "correct": false,
+                "feedback": "It does the opposite — it surfaces a numeric code to the client. The conversion exists so a domain error fits the required `ProgramError` return type."
+              },
+              {
+                "id": "c",
+                "label": "It makes the error impossible to trigger",
+                "correct": false,
+                "feedback": "The conversion does not suppress anything; it lets `TokenError` be returned where a `ProgramError` is expected, carrying a `Custom` code."
+              }
+            ],
+            "explanation": "A handler's signature returns `ProgramError`, so a domain-specific `TokenError` needs a bridge into that type. Mapping it to `ProgramError::Custom(e as u32)` carries your error out as a numeric code clients can decode, while letting you write `return Err(TokenError::AccountFrozen.into())`."
+          }
+        ],
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       }
-    ],
-    "slug": "error-handling",
-    "title": "Error Handling in Solana Programs"
+    ]
   },
   {
     "_id": "lesson-first-transaction",
+    "title": "Your First Transaction",
+    "slug": "first-transaction",
     "blocks": [
       {
-        "_type": "prose",
-        "amount": null,
-        "buildType": null,
-        "consumes": null,
-        "deployable": null,
-        "hints": null,
-        "idl": null,
         "key": "intro",
-        "language": null,
-        "maxWords": null,
-        "network": null,
+        "_type": "prose",
         "produces": null,
-        "prompt": null,
-        "questions": null,
-        "solution": null,
+        "consumes": null,
         "src": "# Your First Transaction\n\nLet's send your first transaction on Solana devnet!\n\n## Understanding Transactions\n\nA Solana transaction consists of:\n- **Instructions**: The operations to perform\n- **Signers**: The accounts that must sign the transaction\n- **Recent Blockhash**: Prevents duplicate transactions\n\n## Sending SOL\n\n```typescript\nimport {\n  Connection,\n  Keypair,\n  LAMPORTS_PER_SOL,\n  SystemProgram,\n  Transaction,\n  sendAndConfirmTransaction,\n} from '@solana/web3.js';\n\nasync function sendSol() {\n  // Connect to devnet\n  const connection = new Connection('https://api.devnet.solana.com', 'confirmed');\n\n  // Create sender keypair (in production, use wallet adapter)\n  const sender = Keypair.generate();\n\n  // Airdrop SOL to sender\n  const airdropSig = await connection.requestAirdrop(\n    sender.publicKey,\n    2 * LAMPORTS_PER_SOL\n  );\n  await connection.confirmTransaction(airdropSig);\n\n  // Create recipient\n  const recipient = Keypair.generate();\n\n  // Create transfer instruction\n  const transaction = new Transaction().add(\n    SystemProgram.transfer({\n      fromPubkey: sender.publicKey,\n      toPubkey: recipient.publicKey,\n      lamports: 0.5 * LAMPORTS_PER_SOL,\n    })\n  );\n\n  // Send and confirm\n  const signature = await sendAndConfirmTransaction(\n    connection,\n    transaction,\n    [sender]\n  );\n\n  console.log('Transaction signature:', signature);\n}\n```\n\n## Key Concepts\n\n- **Lamports**: The smallest unit of SOL (1 SOL = 1,000,000,000 lamports)\n- **Connection**: Connects your code to a Solana cluster\n- **SystemProgram**: Built-in program for basic operations like transfers\n\n## Viewing Your Transaction\n\nAfter sending, view your transaction on [Solana Explorer](https://explorer.solana.com/?cluster=devnet).\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
         "starter": null,
+        "solution": null,
         "tests": null,
-        "url": null
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "retrieval-close",
+        "_type": "quiz",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": [
+          {
+            "id": "q1",
+            "prompt": "Every Solana transaction includes a recent blockhash. What happens if you build a transaction but wait too long before sending it?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "The blockhash expires and the network rejects the transaction, so you must rebuild it with a fresh one",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "Nothing — the blockhash is only informational",
+                "correct": false,
+                "feedback": "The blockhash is load-bearing: it bounds how long a transaction is valid and prevents an old signed transaction from being replayed later. An expired one is rejected."
+              },
+              {
+                "id": "c",
+                "label": "The transaction sends twice",
+                "correct": false,
+                "feedback": "The opposite — the recent-blockhash mechanism exists precisely to stop duplicate submissions. A stale blockhash causes rejection, not a double-send."
+              },
+              {
+                "id": "d",
+                "label": "The fee doubles",
+                "correct": false,
+                "feedback": "Fees are not tied to blockhash age. An expired blockhash simply invalidates the transaction."
+              }
+            ],
+            "explanation": "The recent blockhash gives each transaction a short validity window of a few minutes. This both prevents replay of an old signed transaction and forces clients to rebuild stale ones — which is why long-running signing flows must fetch a fresh blockhash before sending."
+          },
+          {
+            "id": "q2",
+            "prompt": "You transfer `0.5 * LAMPORTS_PER_SOL`. How many lamports is that, and why does the API take lamports instead of SOL?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "500,000,000 lamports — balances are integer lamports, so there is no floating-point rounding on-chain",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "5 lamports — LAMPORTS_PER_SOL is 10",
+                "correct": false,
+                "feedback": "1 SOL = 1,000,000,000 lamports, not 10. So 0.5 SOL = 500,000,000 lamports."
+              },
+              {
+                "id": "c",
+                "label": "0.5 lamports — the chain stores fractional SOL",
+                "correct": false,
+                "feedback": "The chain never stores fractions. Lamports are the indivisible base unit; all balances are whole lamports, which is why the API takes lamports."
+              }
+            ],
+            "explanation": "1 SOL = 1,000,000,000 lamports, so 0.5 SOL = 500,000,000 lamports. Working in the integer base unit avoids the floating-point rounding errors that would be unacceptable in financial state."
+          }
+        ],
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       }
-    ],
-    "slug": "first-transaction",
-    "title": "Your First Transaction"
+    ]
   },
   {
     "_id": "lesson-intro-solana",
+    "title": "What is Solana?",
+    "slug": "what-is-solana",
     "blocks": [
       {
-        "_type": "prose",
-        "amount": null,
-        "buildType": null,
-        "consumes": null,
-        "deployable": null,
-        "hints": null,
-        "idl": null,
         "key": "intro",
-        "language": null,
-        "maxWords": null,
-        "network": null,
+        "_type": "prose",
         "produces": null,
-        "prompt": null,
-        "questions": null,
-        "solution": null,
-        "src": "# What is Solana?\n\nSolana is a high-performance blockchain supporting builders around the world creating crypto apps that scale.\n\n## Key Features\n\n- **Speed**: Solana can process 65,000+ transactions per second\n- **Low Cost**: Average transaction cost is $0.00025\n- **Energy Efficient**: Solana uses a Proof-of-Stake consensus mechanism\n- **Developer Friendly**: Programs can be written in Rust, C, or C++\n\n## How Solana Works\n\nSolana uses a unique combination of **Proof of History (PoH)** and **Proof of Stake (PoS)** to achieve high throughput.\n\n### Proof of History\n\nPoH creates a historical record that proves events occurred at a specific moment in time. Think of it as a cryptographic clock that helps the network agree on the order of transactions without waiting for other validators.\n\n### The Solana Runtime\n\nSolana programs (smart contracts) run inside the **Sealevel** runtime, which allows thousands of smart contracts to run in parallel. This is one of the key innovations that enables Solana's speed.\n\n## The Solana Ecosystem\n\nThe Solana ecosystem includes:\n- **DeFi**: Jupiter, Raydium, Marinade\n- **NFTs**: Magic Eden, Tensor\n- **Payments**: Solana Pay\n- **Infrastructure**: Helius, Jito\n\n## Why Learn Solana?\n\n1. Growing developer demand\n2. Active grants and bounty programs (like Superteam!)\n3. Fast iteration cycles due to quick finality\n4. Strong community support\n",
+        "consumes": null,
+        "src": "# What is Solana?\n\nSolana is a high-performance blockchain supporting builders around the world creating crypto apps that scale.\n\n## Key Features\n\n- **Speed**: Solana sustains thousands of transactions per second in practice (roughly 1,000–4,000 as of mid-2026), with a theoretical ceiling near 65,000 TPS\n- **Low Cost**: The base fee is 0.000005 SOL (5,000 lamports) per signature — a small fraction of a cent\n- **Energy Efficient**: Solana uses a Proof-of-Stake consensus mechanism\n- **Developer Friendly**: Programs are written in Rust, most often with the Anchor framework\n\n## How Solana Works\n\nSolana uses a unique combination of **Proof of History (PoH)** and **Proof of Stake (PoS)** to achieve high throughput.\n\n### Proof of History\n\nPoH creates a historical record that proves events occurred at a specific moment in time. Think of it as a cryptographic clock that helps the network agree on the order of transactions without waiting for other validators.\n\n### The Solana Runtime\n\nSolana programs (smart contracts) run inside the **Sealevel** runtime, which allows thousands of smart contracts to run in parallel. This is one of the key innovations that enables Solana's speed.\n\n## The Solana Ecosystem\n\nThe Solana ecosystem includes:\n- **DeFi**: Jupiter, Raydium, Marinade\n- **NFTs**: Magic Eden, Tensor\n- **Payments**: Solana Pay\n- **Infrastructure**: Helius, Jito\n\n## Why Learn Solana?\n\n1. Growing developer demand\n2. Active grants and bounty programs (like Superteam!)\n3. Fast iteration cycles due to quick finality\n4. Strong community support\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
         "starter": null,
+        "solution": null,
         "tests": null,
-        "url": null
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "retrieval-close",
+        "_type": "quiz",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": [
+          {
+            "id": "q1",
+            "prompt": "Solana pairs Proof of History (PoH) with Proof of Stake. What problem does PoH solve on its own?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "It establishes a verifiable ordering of events in time, so validators don't have to message each other to agree on transaction order",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "It selects which validator produces the next block based on stake",
+                "correct": false,
+                "feedback": "That is Proof of Stake's job. PoH is the cryptographic clock; PoS handles leader selection and security. They solve different problems."
+              },
+              {
+                "id": "c",
+                "label": "It encrypts transactions so they stay private until finalized",
+                "correct": false,
+                "feedback": "PoH is not encryption — Solana transactions are public. It is a hash chain that proves time passed between events."
+              },
+              {
+                "id": "d",
+                "label": "It lets thousands of programs run in parallel",
+                "correct": false,
+                "feedback": "Parallel execution is the Sealevel runtime, not PoH. PoH orders events; Sealevel executes non-conflicting transactions at the same time."
+              }
+            ],
+            "explanation": "PoH is a pre-computed hash chain where each output proves a specific amount of time passed since the previous one. Because order is baked into the clock, validators agree on sequence without a round of voting — removing a latency bottleneck other chains pay on every block."
+          },
+          {
+            "id": "q2",
+            "prompt": "Sealevel runs many Solana programs at once. What must be true of two transactions for them to execute in parallel?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "Their writable-account sets do not overlap",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "They must call the same program",
+                "correct": false,
+                "feedback": "Parallelism is decided by account access, not by which program runs. Two calls to the same program on disjoint accounts still parallelize."
+              },
+              {
+                "id": "c",
+                "label": "They must be submitted by the same wallet",
+                "correct": false,
+                "feedback": "The signer is irrelevant. Sealevel looks at which accounts each transaction writes, not who signed."
+              },
+              {
+                "id": "d",
+                "label": "They must both be read-only",
+                "correct": false,
+                "feedback": "Read-only helps but is not required — two writes parallelize fine as long as they touch different accounts."
+              }
+            ],
+            "explanation": "Every transaction declares the accounts it will read and write up front. Sealevel runs any transactions whose writable-account sets do not overlap simultaneously — which is exactly why declaring accounts ahead of time makes the parallelism possible."
+          }
+        ],
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       }
-    ],
-    "slug": "what-is-solana",
-    "title": "What is Solana?"
+    ]
   },
   {
     "_id": "lesson-keypair-challenge",
+    "title": "Challenge: Generate a Keypair",
+    "slug": "keypair-challenge",
     "blocks": [
       {
-        "_type": "prose",
-        "amount": null,
-        "buildType": null,
-        "consumes": null,
-        "deployable": null,
-        "hints": null,
-        "idl": null,
         "key": "intro",
-        "language": null,
-        "maxWords": null,
-        "network": null,
+        "_type": "prose",
         "produces": null,
-        "prompt": null,
-        "questions": null,
-        "solution": null,
+        "consumes": null,
         "src": "# Challenge: Generate a Keypair\n\nNow it is your turn! Write a function that generates a new Solana keypair and returns an object with the public key (as a base58 string) and a boolean indicating whether the keypair is valid.\n\n## Requirements\n\n- Import `Keypair` from `@solana/web3.js`\n- Generate a new keypair\n- Return an object with `publicKey` (base58 string) and `isValid` (boolean)\n- A keypair is valid if the public key is on the ed25519 curve\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
         "starter": null,
+        "solution": null,
         "tests": null,
-        "url": null
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       },
       {
+        "key": "exercise",
         "_type": "code",
-        "amount": null,
-        "buildType": "standard",
+        "produces": null,
         "consumes": null,
+        "src": null,
+        "url": null,
+        "language": "typescript",
+        "buildType": "standard",
         "deployable": false,
+        "starter": "import { Keypair } from '@solana/web3.js';\n\nfunction generateKeypair(): { publicKey: string; isValid: boolean } {\n  // Your code here\n}\n",
+        "solution": "import { Keypair } from '@solana/web3.js';\n\nfunction generateKeypair(): { publicKey: string; isValid: boolean } {\n  const keypair = Keypair.generate();\n  return {\n    publicKey: keypair.publicKey.toBase58(),\n    isValid: true,\n  };\n}\n",
+        "tests": [
+          {
+            "id": "test-1",
+            "description": "Should return an object with publicKey and isValid",
+            "input": "",
+            "expectedOutput": "typeof result === 'object' && result.publicKey && result.isValid !== undefined"
+          },
+          {
+            "id": "test-2",
+            "description": "Public key should be a valid base58 string",
+            "input": "",
+            "expectedOutput": "typeof result.publicKey === 'string' && result.publicKey.length >= 32"
+          },
+          {
+            "id": "test-3",
+            "description": "isValid should be true",
+            "input": "",
+            "expectedOutput": "result.isValid === true"
+          }
+        ],
         "hints": [
           "Use Keypair.generate() to create a new keypair",
           "Use keypair.publicKey.toBase58() to get the base58 string representation",
           "A generated keypair from Keypair.generate() is always valid"
         ],
-        "idl": null,
-        "key": "exercise",
-        "language": "typescript",
-        "maxWords": null,
-        "network": null,
-        "produces": null,
-        "prompt": null,
         "questions": null,
-        "solution": "import { Keypair } from '@solana/web3.js';\n\nfunction generateKeypair(): { publicKey: string; isValid: boolean } {\n  const keypair = Keypair.generate();\n  return {\n    publicKey: keypair.publicKey.toBase58(),\n    isValid: true,\n  };\n}\n",
-        "src": null,
-        "starter": "import { Keypair } from '@solana/web3.js';\n\nfunction generateKeypair(): { publicKey: string; isValid: boolean } {\n  // Your code here\n}\n",
-        "tests": [
-          {
-            "description": "Should return an object with publicKey and isValid",
-            "expectedOutput": "typeof result === 'object' && result.publicKey && result.isValid !== undefined",
-            "id": "test-1",
-            "input": ""
-          },
-          {
-            "description": "Public key should be a valid base58 string",
-            "expectedOutput": "typeof result.publicKey === 'string' && result.publicKey.length >= 32",
-            "id": "test-2",
-            "input": ""
-          },
-          {
-            "description": "isValid should be true",
-            "expectedOutput": "result.isValid === true",
-            "id": "test-3",
-            "input": ""
-          }
-        ],
-        "url": null
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       }
-    ],
-    "slug": "keypair-challenge",
-    "title": "Challenge: Generate a Keypair"
+    ]
   },
   {
     "_id": "lesson-lending-concepts",
+    "title": "Lending & Borrowing Protocols",
+    "slug": "lending-concepts",
     "blocks": [
       {
-        "_type": "prose",
-        "amount": null,
-        "buildType": null,
-        "consumes": null,
-        "deployable": null,
-        "hints": null,
-        "idl": null,
         "key": "intro",
-        "language": null,
-        "maxWords": null,
-        "network": null,
+        "_type": "prose",
         "produces": null,
-        "prompt": null,
-        "questions": null,
-        "solution": null,
+        "consumes": null,
         "src": "# Lending & Borrowing Protocols\n\nLending protocols are core DeFi primitives that enable users to earn yield on deposits and borrow against collateral.\n\n## How Lending Works\n\n### Supplying (Lending)\n\n1. User deposits tokens into a lending pool\n2. User receives **pool tokens** (e.g., deposit SOL, receive cSOL)\n3. Pool tokens earn interest (redeem for more SOL over time)\n4. Can withdraw anytime (if liquidity available)\n\n### Borrowing\n\n1. User deposits collateral (e.g., SOL)\n2. User borrows against collateral (e.g., borrow USDC)\n3. User pays interest on borrowed amount\n4. Must maintain **collateralization ratio** or face liquidation\n\n## Interest Rates\n\nInterest rates are **algorithmic** (set by supply/demand, not by humans).\n\n### Utilization Rate\n\n```\nUtilization = Total Borrowed / Total Supplied\n\nExample:\nTotal Supplied: 1,000 SOL\nTotal Borrowed: 700 SOL\nUtilization: 70%\n```\n\nHigh utilization → higher borrow rates (to incentivize more supply)\n\n### Interest Rate Model\n\nTypical model has two slopes:\n\n```\nif Utilization < 80%:\n  Borrow APY = Base + (Utilization × Multiplier)\nelse:\n  Borrow APY = Base + (80% × Multiplier) + ((Utilization - 80%) × JumpMultiplier)\n\nExample parameters:\nBase = 2%\nMultiplier = 5%\nJumpMultiplier = 100%\n\nAt 70% utilization:\n  Borrow APY = 2% + (70% × 5%) = 5.5%\n\nAt 90% utilization:\n  Borrow APY = 2% + (80% × 5%) + (10% × 100%) = 16%\n```\n\nThe \"kink\" at 80% prevents the pool from running out of liquidity.\n\n### Supply APY Calculation\n\n```\nSupply APY = Borrow APY × Utilization × (1 - Reserve Factor)\n\nReserve Factor = 10% (protocol fee)\nUtilization = 70%\nBorrow APY = 8%\n\nSupply APY = 8% × 70% × 90% = 5.04%\n```\n\n## Overcollateralization\n\nCrypto lending requires **overcollateralization** (you can't borrow more than your collateral value).\n\n```\nUser deposits: 10 SOL @ $100 = $1,000\nMax LTV (Loan-to-Value): 75%\nMax borrow: $1,000 × 75% = $750 USDC\n```\n\nWhy overcollateralization?\n- No credit scores in DeFi\n- Instant liquidation if collateral drops\n- Protects lenders from bad debt\n\n## Collateralization Ratios\n\n### LTV (Loan-to-Value)\n\nMaximum you can borrow against collateral:\n\n```\nSOL LTV: 75%\nMeans: For every $100 SOL, borrow up to $75\n```\n\n### Liquidation Threshold\n\nWhen your position can be liquidated:\n\n```\nSOL Liquidation Threshold: 80%\nMeans: If debt reaches 80% of collateral value → liquidation\n```\n\nLiquidation threshold > LTV provides a safety buffer.\n\n### Health Factor\n\n```\nHealth Factor = (Collateral Value × Liquidation Threshold) / Debt Value\n\nExample:\nCollateral: 10 SOL @ $100 = $1,000\nLiquidation Threshold: 80%\nDebt: $750 USDC\n\nHealth Factor = ($1,000 × 0.8) / $750 = 1.067\n\nIf Health Factor < 1.0 → Liquidatable\n```\n\n## Liquidations\n\nWhen a position becomes undercollateralized, liquidators can repay the debt and seize collateral.\n\n### Liquidation Process\n\n1. Health factor drops below 1.0\n2. Liquidator repays portion of debt (close factor)\n3. Liquidator receives collateral + bonus\n4. Remaining position (if any) is healthier\n\n### Example\n\n```\nBorrower:\nCollateral: 10 SOL @ $90 = $900\nDebt: $750 USDC\nLiquidation Threshold: 80%\nHealth Factor: ($900 × 0.8) / $750 = 0.96 ❌\n\nLiquidation:\nClose Factor: 50% (can liquidate up to 50% of debt)\nLiquidator repays: $375 USDC\nCollateral seized: $375 / $90 = 4.17 SOL\nLiquidation Bonus: 5%\nActual seized: 4.17 × 1.05 = 4.38 SOL\n\nAfter liquidation:\nBorrower has: 5.62 SOL, $375 debt\nHealth Factor: ($506 × 0.8) / $375 = 1.08 ✅\n```\n\n### Close Factor\n\nLimits how much of a position can be liquidated at once:\n\n```\nClose Factor = 50%\nMeans: Max 50% of debt can be repaid in one liquidation\n\nPrevents: Liquidating entire position when only slightly undercollateralized\n```\n\n## Risk Parameters\n\nEach asset has custom risk parameters:\n\n| Asset | LTV | Liq Threshold | Liq Bonus |\n|-------|-----|---------------|----------|\n| SOL | 75% | 80% | 5% |\n| USDC | 80% | 85% | 4% |\n| BONK | 50% | 60% | 15% |\n\nMore volatile/risky assets → lower LTV, higher liquidation bonus.\n\n## Isolated Pools\n\nTo manage risk, protocols create **isolated pools**:\n\n```\nMain Pool: SOL, USDC, USDT, ETH (blue-chip assets)\nIsolated Pool 1: SOL + New Token X\nIsolated Pool 2: USDC + Experimental Asset Y\n```\n\nIf one isolated pool has bad debt, it doesn't affect others.\n\n## Borrowing Strategies\n\n### Leveraged Long\n\n1. Deposit 10 SOL as collateral\n2. Borrow 7 SOL worth of USDC\n3. Buy 7 more SOL with USDC\n4. Now have 17 SOL exposure with 10 SOL capital\n5. If SOL ↑ 10%, profit is 17% (minus borrow costs)\n\n### Yield Farming\n\n1. Deposit stablecoins, borrow SOL\n2. Use SOL in high-APY liquidity pool\n3. Earn more from LP fees than borrow cost\n4. Profit = LP APY - Borrow APY\n\n### Short Position\n\n1. Deposit USDC collateral\n2. Borrow SOL\n3. Sell SOL for USDC\n4. If SOL drops, buy back cheaper and repay\n\n## Oracle Dependency\n\nLending protocols rely on **oracles** for price feeds:\n\n### Pyth Network\n\n- Pull-based oracle (request price on-demand)\n- Sub-second updates\n- 350+ price feeds\n\n### Switchboard\n\n- Decentralized oracle network\n- Customizable feeds\n- TEE (Trusted Execution Environment) support\n\n### Oracle Risks\n\n- **Stale prices**: If oracle doesn't update, liquidations may fail or be unfair\n- **Manipulation**: Flash loan attacks can manipulate some oracles\n- **Downtime**: If oracle is down, protocol may pause\n\nMitigation: Use multiple oracles, TWAP (Time-Weighted Average Price), circuit breakers.\n\n## Protocol Revenue\n\n```\nReserve Factor: 10%\nTotal Interest Paid: $100,000\nTo Suppliers: $90,000\nTo Protocol: $10,000\n```\n\nProtocols earn from the spread between borrow and supply rates.\n\n## Real-World Examples\n\n### Solend\n\n- TVL: ~$300M\n- Main pool + multiple isolated pools\n- Pyth oracles\n- SLND token rewards\n\n### MarginFi\n\n- TVL: ~$600M\n- Risk-adjusted portfolio margin\n- Integrated with DEXs for leveraged trading\n\n### Kamino Finance\n\n- TVL: ~$1.8B\n- Focuses on automated liquidity strategies\n- Multiply (leveraged yield vaults)\n\n## Next Challenge\n\nYou'll implement the constant product AMM formula with fees, price impact, and liquidity calculations.\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
         "starter": null,
+        "solution": null,
         "tests": null,
-        "url": null
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       }
-    ],
-    "slug": "lending-concepts",
-    "title": "Lending & Borrowing Protocols"
+    ]
   },
   {
     "_id": "lesson-liquidation-challenge",
+    "title": "Liquidation Engine",
+    "slug": "liquidation-challenge",
     "blocks": [
       {
-        "_type": "prose",
-        "amount": null,
-        "buildType": null,
-        "consumes": null,
-        "deployable": null,
-        "hints": null,
-        "idl": null,
         "key": "intro",
-        "language": null,
-        "maxWords": null,
-        "network": null,
+        "_type": "prose",
         "produces": null,
-        "prompt": null,
-        "questions": null,
-        "solution": null,
+        "consumes": null,
         "src": "# Liquidation Engine\n\nBuild a liquidation engine for a lending protocol.\n\nLending platforms like Solend and MarginFi allow users to borrow against collateral. If the collateral value drops too much, the position becomes unhealthy and must be liquidated to protect the protocol.\n\n**Health Factor**: `(collateral_value * collateral_factor) / debt_value`\n- Health > 1.0: Position is safe\n- Health < 1.0: Position is liquidatable\n\n**Liquidation**: A liquidator repays the debt and receives the collateral plus a bonus (typically 5-10%).\n\nYour challenge: implement health factor calculation, identify liquidatable positions, and execute liquidations with proper accounting.\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
         "starter": null,
+        "solution": null,
         "tests": null,
-        "url": null
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       },
       {
+        "key": "exercise",
         "_type": "code",
-        "amount": null,
-        "buildType": "standard",
+        "produces": null,
         "consumes": null,
+        "src": null,
+        "url": null,
+        "language": "typescript",
+        "buildType": "standard",
         "deployable": false,
+        "starter": "/**\n * Check if a lending position is liquidatable\n *\n * Health Factor = collateral / debt\n * A position is liquidatable when healthFactor < collateralFactor (threshold)\n *\n * In DeFi lending (Solend, MarginFi), borrowers post collateral.\n * If collateral value drops below the threshold, liquidators can\n * repay the debt and seize collateral + a bonus.\n *\n * @param {number} collateral - Collateral value in USD\n * @param {number} debt - Debt value in USD\n * @param {number} collateralFactor - Liquidation threshold (e.g., 1.5 = 150%)\n * @returns {object} - { isLiquidatable, healthFactor }\n */\nfunction checkLiquidation(collateral, debt, collateralFactor) {\n  // TODO: Handle edge case where debt is 0 (no debt = never liquidatable)\n  \n  // TODO: Calculate health factor\n  // healthFactor = collateral / debt\n  \n  // TODO: Determine if position is liquidatable\n  // isLiquidatable = healthFactor < collateralFactor\n  \n  return {\n    isLiquidatable: false,\n    healthFactor: 0\n  };\n}\n\n// Test cases\nconsole.log(checkLiquidation(100, 50, 1.5));\n// Expected: { isLiquidatable: false, healthFactor: 2.0 } (100/50 = 2.0 > 1.5)\nconsole.log(checkLiquidation(100, 80, 1.5));\n// Expected: { isLiquidatable: true, healthFactor: 1.25 } (100/80 = 1.25 < 1.5)\n",
+        "solution": "function checkLiquidation(collateral, debt, collateralFactor) {\n  if (debt === 0) {\n    return { isLiquidatable: false, healthFactor: Infinity };\n  }\n  \n  const healthFactor = collateral / debt;\n  const isLiquidatable = healthFactor < collateralFactor;\n  \n  return { isLiquidatable, healthFactor };\n}\n\nconsole.log(checkLiquidation(100, 50, 1.5));\nconsole.log(checkLiquidation(100, 80, 1.5));\n",
+        "tests": [
+          {
+            "id": "t1",
+            "description": "Returns an object with isLiquidatable",
+            "input": "100, 50, 1.5",
+            "expectedOutput": "typeof result === 'object' && 'isLiquidatable' in result"
+          },
+          {
+            "id": "t2",
+            "description": "Under-collateralized position is liquidatable",
+            "input": "100, 80, 1.5",
+            "expectedOutput": "result.isLiquidatable === true"
+          },
+          {
+            "id": "t3",
+            "description": "Healthy position is not liquidatable",
+            "input": "100, 50, 1.5",
+            "expectedOutput": "result.isLiquidatable === false"
+          },
+          {
+            "id": "t4",
+            "description": "Correctly flags a different liquidatable position",
+            "input": "100, 100, 2.0",
+            "expectedOutput": "result.isLiquidatable === true"
+          }
+        ],
         "hints": [
           "Health factor = collateral / debt. If debt is 0, the position can never be liquidated (return Infinity for healthFactor).",
           "A position is liquidatable when its health factor drops below the collateral factor threshold. Compare healthFactor < collateralFactor.",
           "Return an object with both isLiquidatable (boolean) and healthFactor (number). Example: { isLiquidatable: true, healthFactor: 1.25 }"
         ],
-        "idl": null,
-        "key": "exercise",
-        "language": "typescript",
-        "maxWords": null,
-        "network": null,
-        "produces": null,
-        "prompt": null,
         "questions": null,
-        "solution": "function checkLiquidation(collateral, debt, collateralFactor) {\n  if (debt === 0) {\n    return { isLiquidatable: false, healthFactor: Infinity };\n  }\n  \n  const healthFactor = collateral / debt;\n  const isLiquidatable = healthFactor < collateralFactor;\n  \n  return { isLiquidatable, healthFactor };\n}\n\nconsole.log(checkLiquidation(100, 50, 1.5));\nconsole.log(checkLiquidation(100, 80, 1.5));\n",
-        "src": null,
-        "starter": "/**\n * Check if a lending position is liquidatable\n *\n * Health Factor = collateral / debt\n * A position is liquidatable when healthFactor < collateralFactor (threshold)\n *\n * In DeFi lending (Solend, MarginFi), borrowers post collateral.\n * If collateral value drops below the threshold, liquidators can\n * repay the debt and seize collateral + a bonus.\n *\n * @param {number} collateral - Collateral value in USD\n * @param {number} debt - Debt value in USD\n * @param {number} collateralFactor - Liquidation threshold (e.g., 1.5 = 150%)\n * @returns {object} - { isLiquidatable, healthFactor }\n */\nfunction checkLiquidation(collateral, debt, collateralFactor) {\n  // TODO: Handle edge case where debt is 0 (no debt = never liquidatable)\n  \n  // TODO: Calculate health factor\n  // healthFactor = collateral / debt\n  \n  // TODO: Determine if position is liquidatable\n  // isLiquidatable = healthFactor < collateralFactor\n  \n  return {\n    isLiquidatable: false,\n    healthFactor: 0\n  };\n}\n\n// Test cases\nconsole.log(checkLiquidation(100, 50, 1.5));\n// Expected: { isLiquidatable: false, healthFactor: 2.0 } (100/50 = 2.0 > 1.5)\nconsole.log(checkLiquidation(100, 80, 1.5));\n// Expected: { isLiquidatable: true, healthFactor: 1.25 } (100/80 = 1.25 < 1.5)\n",
-        "tests": [
-          {
-            "description": "Returns an object with isLiquidatable",
-            "expectedOutput": "typeof result === 'object' && 'isLiquidatable' in result",
-            "id": "t1",
-            "input": "100, 50, 1.5"
-          },
-          {
-            "description": "Under-collateralized position is liquidatable",
-            "expectedOutput": "result.isLiquidatable === true",
-            "id": "t2",
-            "input": "100, 80, 1.5"
-          },
-          {
-            "description": "Healthy position is not liquidatable",
-            "expectedOutput": "result.isLiquidatable === false",
-            "id": "t3",
-            "input": "100, 50, 1.5"
-          },
-          {
-            "description": "Correctly flags a different liquidatable position",
-            "expectedOutput": "result.isLiquidatable === true",
-            "id": "t4",
-            "input": "100, 100, 2.0"
-          }
-        ],
-        "url": null
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       }
-    ],
-    "slug": "liquidation-challenge",
-    "title": "Liquidation Engine"
+    ]
   },
   {
     "_id": "lesson-notifications",
+    "title": "Transaction Notifications",
+    "slug": "notifications",
     "blocks": [
       {
-        "_type": "prose",
-        "amount": null,
-        "buildType": null,
-        "consumes": null,
-        "deployable": null,
-        "hints": null,
-        "idl": null,
         "key": "intro",
-        "language": null,
-        "maxWords": null,
-        "network": null,
+        "_type": "prose",
         "produces": null,
-        "prompt": null,
-        "questions": null,
-        "solution": null,
-        "src": "# Transaction Notifications\n\nReal-time notifications keep users informed about transaction status without requiring them to poll or refresh. Let's build a robust notification system.\n\n## Toast Notifications\n\nToasts are perfect for transaction feedback. Use libraries like `react-hot-toast` or `sonner`:\n\n```typescript\nimport toast from 'react-hot-toast';\nimport { ExternalLink } from 'lucide-react';\n\nfunction useTransactionToast() {\n  const cluster = 'mainnet-beta';\n\n  function toastSignature(signature: string) {\n    const explorerUrl = `https://explorer.solana.com/tx/${signature}?cluster=${cluster}`;\n    \n    toast.success(\n      <div className=\"flex items-center gap-2\">\n        <span>Transaction confirmed!</span>\n        <a\n          href={explorerUrl}\n          target=\"_blank\"\n          rel=\"noopener noreferrer\"\n          className=\"text-purple-600 hover:underline flex items-center gap-1\"\n        >\n          View <ExternalLink className=\"w-3 h-3\" />\n        </a>\n      </div>,\n      { duration: 8000 }\n    );\n  }\n\n  function toastError(message: string) {\n    toast.error(message, { duration: 5000 });\n  }\n\n  return { toastSignature, toastError };\n}\n\n// Usage\nasync function handleTransfer() {\n  const { toastSignature, toastError } = useTransactionToast();\n\n  try {\n    toast.loading('Sending transaction...');\n    const signature = await sendTransaction(tx, connection);\n    \n    toast.loading('Confirming...');\n    await connection.confirmTransaction(signature);\n    \n    toast.dismiss();\n    toastSignature(signature);\n  } catch (err) {\n    toast.dismiss();\n    toastError('Transaction failed. Please try again.');\n  }\n}\n```\n\n## WebSocket Subscriptions for Real-Time Updates\n\nMonitor accounts for changes without polling:\n\n```typescript\nfunction useAccountChangeNotifications(publicKey: PublicKey | null) {\n  const { connection } = useConnection();\n  const previousBalance = useRef<number | null>(null);\n\n  useEffect(() => {\n    if (!publicKey) return;\n\n    const subscriptionId = connection.onAccountChange(\n      publicKey,\n      (accountInfo) => {\n        const newBalance = accountInfo.lamports / LAMPORTS_PER_SOL;\n\n        if (previousBalance.current !== null) {\n          const change = newBalance - previousBalance.current;\n\n          if (change > 0) {\n            toast.success(`Received ${change.toFixed(4)} SOL`);\n          } else if (change < 0) {\n            toast.info(`Sent ${Math.abs(change).toFixed(4)} SOL`);\n          }\n        }\n\n        previousBalance.current = newBalance;\n      },\n      'confirmed'\n    );\n\n    return () => {\n      connection.removeAccountChangeListener(subscriptionId);\n    };\n  }, [publicKey, connection]);\n}\n```\n\n## Transaction Status Polling\n\nFor critical operations, poll transaction status:\n\n```typescript\nasync function waitForConfirmation(\n  connection: Connection,\n  signature: string,\n  commitment: Commitment = 'confirmed',\n  timeout = 60000\n): Promise<boolean> {\n  const start = Date.now();\n\n  while (Date.now() - start < timeout) {\n    const status = await connection.getSignatureStatus(signature);\n\n    if (status.value?.confirmationStatus === commitment) {\n      return true;\n    }\n\n    if (status.value?.err) {\n      throw new Error('Transaction failed');\n    }\n\n    // Wait 1s before next check\n    await new Promise(resolve => setTimeout(resolve, 1000));\n  }\n\n  throw new Error('Transaction confirmation timeout');\n}\n\n// Usage with notifications\nasync function sendWithNotifications(tx: Transaction) {\n  const toastId = toast.loading('Sending transaction...');\n\n  try {\n    const signature = await sendTransaction(tx, connection);\n    \n    toast.loading('Confirming on-chain...', { id: toastId });\n    \n    await waitForConfirmation(connection, signature);\n    \n    toast.success(\n      <span>\n        Transaction confirmed!\n        <a href={`https://explorer.solana.com/tx/${signature}`}>View</a>\n      </span>,\n      { id: toastId }\n    );\n  } catch (err) {\n    toast.error('Transaction failed', { id: toastId });\n  }\n}\n```\n\n## Notification Permission (Browser Notifications)\n\nFor background notifications when tab isn't focused:\n\n```typescript\nfunction useNotificationPermission() {\n  const [permission, setPermission] = useState<NotificationPermission>(\n    typeof Notification !== 'undefined' ? Notification.permission : 'default'\n  );\n\n  async function requestPermission() {\n    if (typeof Notification === 'undefined') return;\n    \n    const result = await Notification.requestPermission();\n    setPermission(result);\n  }\n\n  function notify(title: string, body: string) {\n    if (permission !== 'granted') return;\n    \n    new Notification(title, {\n      body,\n      icon: '/solana-logo.png',\n      badge: '/notification-badge.png',\n    });\n  }\n\n  return { permission, requestPermission, notify };\n}\n\n// Usage\nfunction TransactionMonitor() {\n  const { notify } = useNotificationPermission();\n  const { publicKey } = useWallet();\n  const { connection } = useConnection();\n\n  useEffect(() => {\n    if (!publicKey) return;\n\n    const sub = connection.onAccountChange(\n      publicKey,\n      () => {\n        if (!document.hasFocus()) {\n          notify('Solana Transaction', 'Your wallet balance changed');\n        }\n      },\n      'confirmed'\n    );\n\n    return () => connection.removeAccountChangeListener(sub);\n  }, [publicKey, connection, notify]);\n\n  return null;\n}\n```\n\n## Notification Sound\n\nAdd audio feedback for important events:\n\n```typescript\nfunction useTransactionSound() {\n  const successSound = useRef<HTMLAudioElement | null>(null);\n  const errorSound = useRef<HTMLAudioElement | null>(null);\n\n  useEffect(() => {\n    successSound.current = new Audio('/sounds/success.mp3');\n    errorSound.current = new Audio('/sounds/error.mp3');\n  }, []);\n\n  function playSuccess() {\n    successSound.current?.play();\n  }\n\n  function playError() {\n    errorSound.current?.play();\n  }\n\n  return { playSuccess, playError };\n}\n```\n\n## Notification Queue\n\nManage multiple notifications without overwhelming the UI:\n\n```typescript\nfunction NotificationQueue() {\n  const [queue, setQueue] = useState<Notification[]>([]);\n  const maxVisible = 3;\n\n  function addNotification(notification: Notification) {\n    setQueue(prev => [...prev, notification]);\n\n    setTimeout(() => {\n      setQueue(prev => prev.filter(n => n.id !== notification.id));\n    }, notification.duration || 5000);\n  }\n\n  return (\n    <div className=\"fixed bottom-4 right-4 space-y-2 z-50\">\n      {queue.slice(-maxVisible).map(notification => (\n        <NotificationCard key={notification.id} {...notification} />\n      ))}\n    </div>\n  );\n}\n```\n\n## Real-World Examples\n\n### Phantom Wallet\n- Shows in-app toast when transaction is signed\n- Browser notification when transaction confirms (if tab not focused)\n- Sound effect on success/failure\n\n### Jupiter Aggregator\n- Loading toast while routing\n- Progress indicator during swap\n- Success toast with explorer link\n- Error toast with retry button\n\n## Best Practices\n\n1. Use toast notifications for transaction updates\n2. Include explorer links in success notifications\n3. Implement WebSocket subscriptions for real-time balance changes\n4. Request browser notification permission for background updates\n5. Add sound effects for important events (success, error)\n6. Limit visible notifications to avoid UI clutter\n7. Auto-dismiss notifications after 5-8 seconds\n",
+        "consumes": null,
+        "src": "# Transaction Notifications\n\nReal-time notifications keep users informed about transaction status without requiring them to poll or refresh. Let's build a robust notification system.\n\n## Toast Notifications\n\nToasts are perfect for transaction feedback. Use libraries like `react-hot-toast` or `sonner`:\n\n```typescript\nimport toast from 'react-hot-toast';\nimport { ExternalLink } from 'lucide-react';\n\nfunction useTransactionToast(cluster: 'devnet' | 'testnet' | 'mainnet-beta' = 'devnet') {\n  function toastSignature(signature: string) {\n    // Point the explorer at the cluster your app is actually on — mainnet-beta is the default and omits the query param.\n    const explorerUrl = `https://explorer.solana.com/tx/${signature}${cluster !== 'mainnet-beta' ? `?cluster=${cluster}` : ''}`;\n    \n    toast.success(\n      <div className=\"flex items-center gap-2\">\n        <span>Transaction confirmed!</span>\n        <a\n          href={explorerUrl}\n          target=\"_blank\"\n          rel=\"noopener noreferrer\"\n          className=\"text-purple-600 hover:underline flex items-center gap-1\"\n        >\n          View <ExternalLink className=\"w-3 h-3\" />\n        </a>\n      </div>,\n      { duration: 8000 }\n    );\n  }\n\n  function toastError(message: string) {\n    toast.error(message, { duration: 5000 });\n  }\n\n  return { toastSignature, toastError };\n}\n\n// Usage\nasync function handleTransfer() {\n  const { toastSignature, toastError } = useTransactionToast();\n\n  try {\n    toast.loading('Sending transaction...');\n    const signature = await sendTransaction(tx, connection);\n    \n    toast.loading('Confirming...');\n    await connection.confirmTransaction(signature);\n    \n    toast.dismiss();\n    toastSignature(signature);\n  } catch (err) {\n    toast.dismiss();\n    toastError('Transaction failed. Please try again.');\n  }\n}\n```\n\n## WebSocket Subscriptions for Real-Time Updates\n\nMonitor accounts for changes without polling:\n\n```typescript\nfunction useAccountChangeNotifications(publicKey: PublicKey | null) {\n  const { connection } = useConnection();\n  const previousBalance = useRef<number | null>(null);\n\n  useEffect(() => {\n    if (!publicKey) return;\n\n    const subscriptionId = connection.onAccountChange(\n      publicKey,\n      (accountInfo) => {\n        const newBalance = accountInfo.lamports / LAMPORTS_PER_SOL;\n\n        if (previousBalance.current !== null) {\n          const change = newBalance - previousBalance.current;\n\n          if (change > 0) {\n            toast.success(`Received ${change.toFixed(4)} SOL`);\n          } else if (change < 0) {\n            toast.info(`Sent ${Math.abs(change).toFixed(4)} SOL`);\n          }\n        }\n\n        previousBalance.current = newBalance;\n      },\n      'confirmed'\n    );\n\n    return () => {\n      connection.removeAccountChangeListener(subscriptionId);\n    };\n  }, [publicKey, connection]);\n}\n```\n\n## Transaction Status Polling\n\nFor critical operations, poll transaction status:\n\n```typescript\nasync function waitForConfirmation(\n  connection: Connection,\n  signature: string,\n  commitment: Commitment = 'confirmed',\n  timeout = 60000\n): Promise<boolean> {\n  const start = Date.now();\n\n  while (Date.now() - start < timeout) {\n    const status = await connection.getSignatureStatus(signature);\n\n    if (status.value?.confirmationStatus === commitment) {\n      return true;\n    }\n\n    if (status.value?.err) {\n      throw new Error('Transaction failed');\n    }\n\n    // Wait 1s before next check\n    await new Promise(resolve => setTimeout(resolve, 1000));\n  }\n\n  throw new Error('Transaction confirmation timeout');\n}\n\n// Usage with notifications\nasync function sendWithNotifications(tx: Transaction) {\n  const toastId = toast.loading('Sending transaction...');\n\n  try {\n    const signature = await sendTransaction(tx, connection);\n    \n    toast.loading('Confirming on-chain...', { id: toastId });\n    \n    await waitForConfirmation(connection, signature);\n    \n    toast.success(\n      <span>\n        Transaction confirmed!\n        <a href={`https://explorer.solana.com/tx/${signature}`}>View</a>\n      </span>,\n      { id: toastId }\n    );\n  } catch (err) {\n    toast.error('Transaction failed', { id: toastId });\n  }\n}\n```\n\n## Notification Permission (Browser Notifications)\n\nFor background notifications when tab isn't focused:\n\n```typescript\nfunction useNotificationPermission() {\n  const [permission, setPermission] = useState<NotificationPermission>(\n    typeof Notification !== 'undefined' ? Notification.permission : 'default'\n  );\n\n  async function requestPermission() {\n    if (typeof Notification === 'undefined') return;\n    \n    const result = await Notification.requestPermission();\n    setPermission(result);\n  }\n\n  function notify(title: string, body: string) {\n    if (permission !== 'granted') return;\n    \n    new Notification(title, {\n      body,\n      icon: '/solana-logo.png',\n      badge: '/notification-badge.png',\n    });\n  }\n\n  return { permission, requestPermission, notify };\n}\n\n// Usage\nfunction TransactionMonitor() {\n  const { notify } = useNotificationPermission();\n  const { publicKey } = useWallet();\n  const { connection } = useConnection();\n\n  useEffect(() => {\n    if (!publicKey) return;\n\n    const sub = connection.onAccountChange(\n      publicKey,\n      () => {\n        if (!document.hasFocus()) {\n          notify('Solana Transaction', 'Your wallet balance changed');\n        }\n      },\n      'confirmed'\n    );\n\n    return () => connection.removeAccountChangeListener(sub);\n  }, [publicKey, connection, notify]);\n\n  return null;\n}\n```\n\n## Notification Sound\n\nAdd audio feedback for important events:\n\n```typescript\nfunction useTransactionSound() {\n  const successSound = useRef<HTMLAudioElement | null>(null);\n  const errorSound = useRef<HTMLAudioElement | null>(null);\n\n  useEffect(() => {\n    successSound.current = new Audio('/sounds/success.mp3');\n    errorSound.current = new Audio('/sounds/error.mp3');\n  }, []);\n\n  function playSuccess() {\n    successSound.current?.play();\n  }\n\n  function playError() {\n    errorSound.current?.play();\n  }\n\n  return { playSuccess, playError };\n}\n```\n\n## Notification Queue\n\nManage multiple notifications without overwhelming the UI:\n\n```typescript\nfunction NotificationQueue() {\n  const [queue, setQueue] = useState<Notification[]>([]);\n  const maxVisible = 3;\n\n  function addNotification(notification: Notification) {\n    setQueue(prev => [...prev, notification]);\n\n    setTimeout(() => {\n      setQueue(prev => prev.filter(n => n.id !== notification.id));\n    }, notification.duration || 5000);\n  }\n\n  return (\n    <div className=\"fixed bottom-4 right-4 space-y-2 z-50\">\n      {queue.slice(-maxVisible).map(notification => (\n        <NotificationCard key={notification.id} {...notification} />\n      ))}\n    </div>\n  );\n}\n```\n\n## Real-World Examples\n\n### Phantom Wallet\n- Shows in-app toast when transaction is signed\n- Browser notification when transaction confirms (if tab not focused)\n- Sound effect on success/failure\n\n### Jupiter Aggregator\n- Loading toast while routing\n- Progress indicator during swap\n- Success toast with explorer link\n- Error toast with retry button\n\n## Best Practices\n\n1. Use toast notifications for transaction updates\n2. Include explorer links in success notifications\n3. Implement WebSocket subscriptions for real-time balance changes\n4. Request browser notification permission for background updates\n5. Add sound effects for important events (success, error)\n6. Limit visible notifications to avoid UI clutter\n7. Auto-dismiss notifications after 5-8 seconds\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
         "starter": null,
+        "solution": null,
         "tests": null,
-        "url": null
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       }
-    ],
-    "slug": "notifications",
-    "title": "Transaction Notifications"
+    ]
   },
   {
     "_id": "lesson-oracle-design",
+    "title": "Price Oracles for DeFi",
+    "slug": "oracle-design",
     "blocks": [
       {
-        "_type": "prose",
-        "amount": null,
-        "buildType": null,
-        "consumes": null,
-        "deployable": null,
-        "hints": null,
-        "idl": null,
         "key": "intro",
-        "language": null,
-        "maxWords": null,
-        "network": null,
+        "_type": "prose",
         "produces": null,
-        "prompt": null,
-        "questions": null,
-        "solution": null,
+        "consumes": null,
         "src": "# Price Oracles for DeFi\n\nDeFi protocols need reliable asset prices to function. Lending platforms must know collateral values, DEXs need reference prices for limit orders, and derivatives require settlement prices. Price oracles solve this problem by bringing off-chain price data on-chain.\n\n## Oracle Mechanisms\n\n**Push oracles** proactively write price updates to on-chain accounts on a schedule (e.g., every 60 seconds) or when prices deviate beyond a threshold. Protocols simply read the latest price from the oracle account. Switchboard uses this model with validator-operated data feeds.\n\n**Pull oracles** store signed price attestations off-chain. Protocols fetch the latest attestation when needed and submit it with their transaction. The oracle program verifies the signature before allowing the price to be used. Pyth Network pioneered this model for Solana.\n\n## Pyth Network\n\nPyth aggregates price data from over 90 first-party sources including exchanges, market makers, and trading firms. Each data provider signs their price contribution, and the on-chain program computes a confidence-weighted median.\n\n**Key features**:\n- Sub-second price updates for major assets\n- Confidence intervals indicating price uncertainty\n- Exponentially-weighted moving average (EMA) for smooth prices\n- Publisher attribution for transparency\n\nPyth's pull model reduces costs by only updating on-chain prices when transactions need them, rather than constantly pushing updates.\n\n## Time-Weighted Average Price (TWAP)\n\nTWAP oracles compute the average price over a time window, making price manipulation expensive. An attacker would need to sustain artificial prices for the entire window, not just a single block.\n\nProtocols can construct TWAP from Pyth EMA prices or compute it directly from DEX swap observations. TWAP is essential for lending protocols to prevent flash loan attacks that temporarily spike prices.\n\n## Oracle Safety\n\nRobust oracle integration requires:\n- **Staleness checks**: Reject prices older than acceptable threshold (e.g., 60 seconds)\n- **Confidence intervals**: Only use prices with acceptable confidence (low uncertainty)\n- **Circuit breakers**: Halt operations if price deviates too far from recent values\n- **Multi-oracle redundancy**: Compare prices from multiple sources\n\nPoor oracle design has caused hundreds of millions in DeFi exploits. Always validate oracle data before using it in critical logic.\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
         "starter": null,
+        "solution": null,
         "tests": null,
-        "url": null
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       }
-    ],
-    "slug": "oracle-design",
-    "title": "Price Oracles for DeFi"
+    ]
   },
   {
     "_id": "lesson-orderbook-design",
+    "title": "On-Chain Orderbooks on Solana",
+    "slug": "orderbook-design",
     "blocks": [
       {
-        "_type": "prose",
-        "amount": null,
-        "buildType": null,
-        "consumes": null,
-        "deployable": null,
-        "hints": null,
-        "idl": null,
         "key": "intro",
-        "language": null,
-        "maxWords": null,
-        "network": null,
+        "_type": "prose",
         "produces": null,
-        "prompt": null,
-        "questions": null,
-        "solution": null,
+        "consumes": null,
         "src": "# On-Chain Orderbooks on Solana\n\nOrderbook-based decentralized exchanges (DEXs) bring the familiar trading experience of centralized exchanges to DeFi. Solana's high throughput and low latency make it uniquely suited for on-chain orderbooks.\n\n## Central Limit Order Books (CLOBs)\n\nA CLOB maintains separate bid (buy) and ask (sell) order lists sorted by price. When a new order arrives, the matching engine searches for counterparty orders at compatible prices. Matching happens on a price-time priority basis: the best price gets filled first, and among orders at the same price, earlier orders have priority.\n\n**Key protocols**:\n- **Phoenix**: Next-generation CLOB with optimized matching and reduced memory footprint\n- **OpenBook**: Community fork of Serum's original CLOB implementation\n- **Zeta Markets**: Options and futures orderbook specialized for derivatives\n\n## Orderbooks vs AMMs\n\nAutomated Market Makers (AMMs) like Raydium and Orca use liquidity pools with algorithmic pricing (x*y=k). Orderbooks offer several advantages:\n\n**Capital efficiency**: Liquidity providers can specify exact prices instead of providing liquidity across the entire price curve. A market maker can place tight bid-ask spreads at current market price without locking capital in extreme price ranges.\n\n**Price discovery**: Order flow directly determines market price rather than relying on arbitrageurs to rebalance pools. This enables better price discovery, especially for less liquid assets.\n\n**Professional trading tools**: Limit orders, stop losses, fill-or-kill orders, and post-only orders give traders precise execution control.\n\n## Solana's Advantages\n\nTraditional blockchain throughput (15-30 TPS) makes on-chain orderbooks impractical due to slow settlement and high fees. Solana's 400ms block times and 65,000 TPS capacity enable:\n\n- Real-time order updates visible to all participants\n- Sub-second trade settlement and confirmation\n- Low fees enabling profitable market making with tight spreads\n- Atomic order matching preventing front-running\n\nOrderbooks represent the future of professional DeFi trading, combining CEX user experience with DEX trustlessness.\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
         "starter": null,
+        "solution": null,
         "tests": null,
-        "url": null
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       }
-    ],
-    "slug": "orderbook-design",
-    "title": "On-Chain Orderbooks on Solana"
+    ]
   },
   {
     "_id": "lesson-ownership-borrowing",
+    "title": "Ownership and Borrowing",
+    "slug": "ownership-borrowing",
     "blocks": [
       {
-        "_type": "prose",
-        "amount": null,
-        "buildType": null,
-        "consumes": null,
-        "deployable": null,
-        "hints": null,
-        "idl": null,
         "key": "intro",
-        "language": null,
-        "maxWords": null,
-        "network": null,
+        "_type": "prose",
         "produces": null,
-        "prompt": null,
-        "questions": null,
-        "solution": null,
+        "consumes": null,
         "src": "# Ownership and Borrowing in Rust\n\nRust's ownership system is its most distinctive feature. Understanding it is essential for writing Solana programs, as it directly maps to how accounts are passed to your program.\n\n## The Three Rules of Ownership\n\n1. **Each value has a single owner**: Only one variable owns a piece of data at any time\n2. **When the owner goes out of scope, the value is dropped**: Automatic cleanup, no memory leaks\n3. **Ownership can be transferred (moved)**: Passing a value to a function or assigning it to another variable moves ownership\n\n```rust\nlet account_data = vec![1, 2, 3, 4];\nlet moved_data = account_data; // Ownership transferred\n// println!(\":{?}\", account_data); // Error: value moved\n```\n\n## Borrowing: Using Data Without Taking Ownership\n\nBorrowing lets you reference data without taking ownership. There are two types:\n\n### Immutable Borrowing (`&T`)\n\nYou can have **multiple** immutable borrows simultaneously:\n\n```rust\nfn calculate_balance(accounts: &[AccountInfo]) -> u64 {\n    accounts.iter().map(|a| a.lamports).sum()\n}\n\nlet accounts = vec![/* ... */];\nlet total = calculate_balance(&accounts);\n// accounts still valid here\n```\n\n### Mutable Borrowing (`&mut T`)\n\nYou can have **only ONE** mutable borrow at a time, and no immutable borrows can exist simultaneously:\n\n```rust\nfn debit_account(account: &mut AccountInfo, amount: u64) {\n    account.lamports -= amount;\n}\n\nlet mut account = /* ... */;\ndebit_account(&mut account);\n```\n\n## How This Maps to Solana\n\nWhen you write a Solana program, accounts are passed as `&[AccountInfo]` (immutable borrow) or extracted as `&mut AccountInfo` (mutable borrow):\n\n```rust\npub fn process_instruction(\n    program_id: &Pubkey,\n    accounts: &[AccountInfo], // immutable borrow of the slice\n    instruction_data: &[u8],\n) -> ProgramResult {\n    let account_iter = &mut accounts.iter();\n    let sender = next_account_info(account_iter)?; // immutable borrow\n    let recipient = next_account_info(account_iter)?;\n    \n    // To modify, you need mutable access:\n    **sender.lamports.borrow_mut() -= amount;\n    **recipient.lamports.borrow_mut() += amount;\n    Ok(())\n}\n```\n\n## Key Insight\n\nSolana's runtime enforces similar rules:\n- Multiple programs can read an account simultaneously (immutable borrows)\n- Only ONE program can write to an account in a transaction (mutable borrow)\n- The runtime prevents data races at the transaction level, and Rust prevents them at compile time\n\nThis alignment makes Rust the perfect fit for Solana development.\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
         "starter": null,
+        "solution": null,
         "tests": null,
-        "url": null
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "retrieval-close",
+        "_type": "quiz",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": [
+          {
+            "id": "q1",
+            "prompt": "You write `let moved = account_data;` then try to use `account_data` again. What does the compiler say?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "An error — ownership moved to `moved`, so `account_data` is no longer valid to use",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "Nothing — both variables now share the data",
+                "correct": false,
+                "feedback": "Assignment moves ownership, it does not share. After the move `account_data` is invalid; only `moved` owns the value."
+              },
+              {
+                "id": "c",
+                "label": "It compiles but silently copies the data",
+                "correct": false,
+                "feedback": "For a non-Copy type like `Vec`, assignment moves rather than copies. Using the moved-from variable is a compile error, not a silent copy."
+              }
+            ],
+            "explanation": "Each value has a single owner. Assigning it to another variable moves ownership and invalidates the original binding, so using `account_data` after the move fails to compile. This is what prevents two owners from freeing the same data."
+          },
+          {
+            "id": "q2",
+            "prompt": "Inside a function you hold `&mut account`. Can you also take an immutable `&account` at the same time?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "No — a mutable borrow is exclusive; no other borrow, mutable or immutable, may coexist with it",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "Yes — one mutable and any number of immutable borrows are fine together",
+                "correct": false,
+                "feedback": "That mixes the rules. Many immutable borrows can coexist, but a mutable borrow must be the only borrow. You cannot hold `&mut` and `&` at once."
+              },
+              {
+                "id": "c",
+                "label": "Yes, as long as you do not write through the mutable one",
+                "correct": false,
+                "feedback": "The rule is structural, not about whether you write: while a `&mut` exists, no other borrow is allowed regardless of use."
+              }
+            ],
+            "explanation": "Rust enforces mutable-XOR-shared: either one `&mut` and nothing else, or any number of `&`. This prevents data races at compile time — the same single-writer discipline Solana's runtime enforces on accounts within a transaction."
+          }
+        ],
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       }
-    ],
-    "slug": "ownership-borrowing",
-    "title": "Ownership and Borrowing"
+    ]
   },
   {
     "_id": "lesson-parse-data-challenge",
+    "title": "Challenge: Parse Account Data Buffer",
+    "slug": "parse-data-challenge",
     "blocks": [
       {
-        "_type": "prose",
-        "amount": null,
-        "buildType": null,
-        "consumes": null,
-        "deployable": null,
-        "hints": null,
-        "idl": null,
         "key": "intro",
-        "language": null,
-        "maxWords": null,
-        "network": null,
+        "_type": "prose",
         "produces": null,
-        "prompt": null,
-        "questions": null,
-        "solution": null,
+        "consumes": null,
         "src": "# Challenge: Parse Account Data Buffer\n\nWrite a function that parses a binary account data buffer into a structured object.\n\n## Requirements\n\n- Parse a `Uint8Array` containing the following fields (in order):\n  1. **version** (u8, 1 byte): Account version number\n  2. **level** (u32, 4 bytes, little-endian): User level\n  3. **username** (string): Length-prefixed UTF-8 string (u32 length + bytes)\n- Return an object with `{ version: number, level: number, username: string }`\n- Use `DataView` for reading integers and `TextDecoder` for the string\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
         "starter": null,
+        "solution": null,
         "tests": null,
-        "url": null
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       },
       {
+        "key": "exercise",
         "_type": "code",
-        "amount": null,
-        "buildType": "standard",
+        "produces": null,
         "consumes": null,
+        "src": null,
+        "url": null,
+        "language": "typescript",
+        "buildType": "standard",
         "deployable": false,
+        "starter": "function parseAccountData(data: Uint8Array): {\n  version: number;\n  level: number;\n  username: string;\n} {\n  // Your code here\n}\n",
+        "solution": "function parseAccountData(data: Uint8Array): {\n  version: number;\n  level: number;\n  username: string;\n} {\n  const view = new DataView(data.buffer, data.byteOffset, data.byteLength);\n  \n  // Parse version (u8, 1 byte)\n  const version = view.getUint8(0);\n  \n  // Parse level (u32, 4 bytes, little-endian)\n  const level = view.getUint32(1, true);\n  \n  // Parse string (u32 length prefix + UTF-8 bytes)\n  const stringLength = view.getUint32(5, true);\n  const stringBytes = data.slice(9, 9 + stringLength);\n  const username = new TextDecoder().decode(stringBytes);\n  \n  return { version, level, username };\n}\n",
+        "tests": [
+          {
+            "id": "t1",
+            "description": "Returns an object with version, level and username",
+            "input": "data",
+            "expectedOutput": "typeof result === 'object' && 'version' in result && 'level' in result && 'username' in result"
+          },
+          {
+            "id": "t2",
+            "description": "Fields have the correct types",
+            "input": "data",
+            "expectedOutput": "typeof result.version === 'number' && typeof result.level === 'number' && typeof result.username === 'string'"
+          },
+          {
+            "id": "t3",
+            "description": "Parses the exact values from the byte buffer",
+            "input": "data",
+            "expectedOutput": "result.version === 1 && result.level === 5 && result.username === 'SolDev'"
+          }
+        ],
         "hints": [
           "Use DataView to read the u8 (getUint8) and u32 (getUint32 with littleEndian=true)",
           "After reading version (1 byte) and level (4 bytes), read the string length (4 bytes) then the UTF-8 bytes",
           "Use TextDecoder to decode the string bytes: new TextDecoder().decode(stringBytes)"
         ],
-        "idl": null,
-        "key": "exercise",
-        "language": "typescript",
-        "maxWords": null,
-        "network": null,
-        "produces": null,
-        "prompt": null,
         "questions": null,
-        "solution": "function parseAccountData(data: Uint8Array): {\n  version: number;\n  level: number;\n  username: string;\n} {\n  const view = new DataView(data.buffer, data.byteOffset, data.byteLength);\n  \n  // Parse version (u8, 1 byte)\n  const version = view.getUint8(0);\n  \n  // Parse level (u32, 4 bytes, little-endian)\n  const level = view.getUint32(1, true);\n  \n  // Parse string (u32 length prefix + UTF-8 bytes)\n  const stringLength = view.getUint32(5, true);\n  const stringBytes = data.slice(9, 9 + stringLength);\n  const username = new TextDecoder().decode(stringBytes);\n  \n  return { version, level, username };\n}\n",
-        "src": null,
-        "starter": "function parseAccountData(data: Uint8Array): {\n  version: number;\n  level: number;\n  username: string;\n} {\n  // Your code here\n}\n",
-        "tests": [
-          {
-            "description": "Returns an object with version, level and username",
-            "expectedOutput": "typeof result === 'object' && 'version' in result && 'level' in result && 'username' in result",
-            "id": "t1",
-            "input": "data"
-          },
-          {
-            "description": "Fields have the correct types",
-            "expectedOutput": "typeof result.version === 'number' && typeof result.level === 'number' && typeof result.username === 'string'",
-            "id": "t2",
-            "input": "data"
-          },
-          {
-            "description": "Parses the exact values from the byte buffer",
-            "expectedOutput": "result.version === 1 && result.level === 5 && result.username === 'SolDev'",
-            "id": "t3",
-            "input": "data"
-          }
-        ],
-        "url": null
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       }
-    ],
-    "slug": "parse-data-challenge",
-    "title": "Challenge: Parse Account Data Buffer"
+    ]
   },
   {
     "_id": "lesson-parsing-data",
+    "title": "Parsing Account Data",
+    "slug": "parsing-data",
     "blocks": [
       {
-        "_type": "prose",
-        "amount": null,
-        "buildType": null,
-        "consumes": null,
-        "deployable": null,
-        "hints": null,
-        "idl": null,
         "key": "intro",
-        "language": null,
-        "maxWords": null,
-        "network": null,
+        "_type": "prose",
         "produces": null,
-        "prompt": null,
-        "questions": null,
-        "solution": null,
+        "consumes": null,
         "src": "# Parsing Account Data\n\nAccount data on Solana is stored as raw bytes (`Uint8Array`). To use this data in your application, you must **deserialize** it into structured JavaScript objects.\n\n## Why Binary Encoding?\n\nSolana stores data as compact binary to:\n- **Minimize storage costs** (rent is based on account size)\n- **Maximize throughput** (smaller data = faster network transmission)\n- **Enable cross-language compatibility** (Rust programs, JS clients, Python bots all read the same bytes)\n\n## Borsh Encoding Standard\n\nMost Solana programs use **Borsh** (Binary Object Representation Serializer for Hashing):\n\n```typescript\nimport { serialize, deserialize, Schema } from 'borsh';\n\n// Define schema\nclass UserProfile {\n  username: string = '';\n  level: number = 0;\n  xp: bigint = 0n;\n\n  constructor(fields: { username: string; level: number; xp: bigint }) {\n    Object.assign(this, fields);\n  }\n}\n\nconst schema: Schema = {\n  struct: {\n    username: 'string',\n    level: 'u8',\n    xp: 'u64',\n  },\n};\n\n// Deserialize\nconst accountData = await connection.getAccountInfo(profilePubkey);\nconst profile = deserialize(schema, UserProfile, accountData.data);\n\nconsole.log(profile.username); // \"SolDev123\"\nconsole.log(profile.level);    // 5\nconsole.log(profile.xp);       // 1200n\n```\n\n## Manual Parsing with DataView\n\nFor simple data structures, you can parse manually:\n\n```typescript\nfunction parseTokenAccount(data: Uint8Array) {\n  const view = new DataView(data.buffer);\n\n  return {\n    mint: new PublicKey(data.slice(0, 32)),\n    owner: new PublicKey(data.slice(32, 64)),\n    amount: view.getBigUint64(64, true), // little-endian\n    delegateOption: view.getUint32(72, true),\n    state: view.getUint8(108),\n  };\n}\n```\n\n## Common Data Types\n\n| Borsh Type | JavaScript | Bytes | Range |\n|------------|------------|-------|-------|\n| `u8` | number | 1 | 0 to 255 |\n| `u32` | number | 4 | 0 to 4,294,967,295 |\n| `u64` | bigint | 8 | 0 to 2^64-1 |\n| `string` | string | variable | Length prefix + UTF-8 |\n| `[u8; 32]` | Uint8Array | 32 | Fixed-size byte array |\n| `Vec<T>` | Array<T> | variable | Length prefix + items |\n\n## String Encoding\n\nStrings are encoded as:\n1. **4-byte length prefix** (u32, little-endian)\n2. **UTF-8 bytes**\n\n```typescript\nfunction parseString(data: Uint8Array, offset: number): [string, number] {\n  const view = new DataView(data.buffer);\n  const length = view.getUint32(offset, true); // little-endian\n  \n  const stringBytes = data.slice(offset + 4, offset + 4 + length);\n  const str = new TextDecoder().decode(stringBytes);\n  \n  return [str, offset + 4 + length]; // [parsed string, new offset]\n}\n```\n\n## Real-World Example: Metaplex NFT Metadata\n\nMetaplex stores NFT metadata on-chain:\n\n```typescript\nimport { Metadata } from '@metaplex-foundation/mpl-token-metadata';\n\nconst metadataPDA = await Metadata.getPDA(mintPublicKey);\nconst accountInfo = await connection.getAccountInfo(metadataPDA);\n\nconst metadata = Metadata.deserialize(accountInfo.data);\n\nconsole.log('Name:', metadata[0].data.name);\nconsole.log('Symbol:', metadata[0].data.symbol);\nconsole.log('URI:', metadata[0].data.uri);\n```\n\n## Anchor Discriminators\n\nAnchor programs use an 8-byte **discriminator** at the start of each account:\n\n```typescript\nconst discriminator = data.slice(0, 8);\n// Hash of \"account:YourAccountName\"\n```\n\nThis helps identify the account type. Anchor's TypeScript client automatically handles discriminators.\n\n## Debugging Tips\n\n### View Raw Bytes\n\n```typescript\nconsole.log('Raw bytes:', Array.from(data).map(b => b.toString(16).padStart(2, '0')).join(' '));\n// 01 00 00 00 0a 00 00 00 48 65 6c 6c 6f ...\n```\n\n### Use Solana Explorer\n\nPaste your account address into [Solana Explorer](https://explorer.solana.com) → \"Account Data\" tab to view hex dump.\n\n## Best Practices\n\n1. **Use existing parsers** when available (Metaplex, SPL Token, Anchor)\n2. **Handle endianness** consistently (Solana uses little-endian)\n3. **Validate data length** before parsing to avoid out-of-bounds errors\n4. **Cache parsed data** (parsing is CPU-intensive; don't re-parse on every render)\n\n## Next Steps\n\nIn the next challenge, you'll manually parse a binary data buffer into structured fields.\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
         "starter": null,
+        "solution": null,
         "tests": null,
-        "url": null
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       }
-    ],
-    "slug": "parsing-data",
-    "title": "Parsing Account Data"
+    ]
   },
   {
     "_id": "lesson-pda-advanced-challenge",
+    "title": "Challenge: Multi-PDA Derivation",
+    "slug": "pda-advanced-challenge",
     "blocks": [
       {
-        "_type": "prose",
-        "amount": null,
-        "buildType": null,
-        "consumes": null,
-        "deployable": null,
-        "hints": null,
-        "idl": null,
         "key": "intro",
-        "language": null,
-        "maxWords": null,
-        "network": null,
+        "_type": "prose",
         "produces": null,
-        "prompt": null,
-        "questions": null,
-        "solution": null,
+        "consumes": null,
         "src": "# Challenge: Derive Multiple Related PDAs in Rust\n\nReal Anchor programs often derive multiple PDAs per user — profile, stats, vault, etc. Each uses different seed prefixes but the same user key.\n\nUsing the simulated PDA derivation from earlier, derive 3 related PDAs and return their hashes as a tuple.\n\n## Your Task\n\nImplement `derive_user_pdas(user, program_id)` that:\n\n1. Derives a **user PDA** with seeds `[\"user\", user]`\n2. Derives a **stats PDA** with seeds `[\"stats\", user]`\n3. Derives a **vault PDA** with seeds `[\"vault\", user]`\n4. Returns `(user_hash, stats_hash, vault_hash)` as a `(u64, u64, u64)` tuple\n\nA helper `find_pda` is provided — use it to derive each PDA.\n\n**Requirements:**\n- All three hashes must be off-curve (even)\n- All three must be different from each other\n- Same inputs must always produce same outputs (deterministic)\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
         "starter": null,
+        "solution": null,
         "tests": null,
-        "url": null
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       },
       {
+        "key": "exercise",
         "_type": "code",
-        "amount": null,
-        "buildType": "standard",
+        "produces": null,
         "consumes": null,
+        "src": null,
+        "url": null,
+        "language": "rust",
+        "buildType": "standard",
         "deployable": false,
+        "starter": "use std::collections::hash_map::DefaultHasher;\nuse std::hash::{Hash, Hasher};\n\nfn hash_with_bump(seeds: &[&str], bump: u8, program_id: &str) -> u64 {\n    let mut hasher = DefaultHasher::new();\n    for seed in seeds {\n        seed.hash(&mut hasher);\n    }\n    bump.hash(&mut hasher);\n    program_id.hash(&mut hasher);\n    hasher.finish()\n}\n\nfn find_pda(seeds: &[&str], program_id: &str) -> (u64, u8) {\n    for bump in (0..=255u8).rev() {\n        let hash = hash_with_bump(seeds, bump, program_id);\n        if hash % 2 == 0 {\n            return (hash, bump);\n        }\n    }\n    panic!(\"No valid bump found\");\n}\n\n/// Derive user, stats, and vault PDAs for the given user.\n/// Returns (user_hash, stats_hash, vault_hash).\nfn derive_user_pdas(user: &str, program_id: &str) -> (u64, u64, u64) {\n    // TODO: Derive user PDA with seeds [\"user\", user]\n    // TODO: Derive stats PDA with seeds [\"stats\", user]\n    // TODO: Derive vault PDA with seeds [\"vault\", user]\n    // TODO: Return the three hashes as a tuple\n    todo!()\n}\n",
+        "solution": "use std::collections::hash_map::DefaultHasher;\nuse std::hash::{Hash, Hasher};\n\nfn hash_with_bump(seeds: &[&str], bump: u8, program_id: &str) -> u64 {\n    let mut hasher = DefaultHasher::new();\n    for seed in seeds {\n        seed.hash(&mut hasher);\n    }\n    bump.hash(&mut hasher);\n    program_id.hash(&mut hasher);\n    hasher.finish()\n}\n\nfn find_pda(seeds: &[&str], program_id: &str) -> (u64, u8) {\n    for bump in (0..=255u8).rev() {\n        let hash = hash_with_bump(seeds, bump, program_id);\n        if hash % 2 == 0 {\n            return (hash, bump);\n        }\n    }\n    panic!(\"No valid bump found\");\n}\n\nfn derive_user_pdas(user: &str, program_id: &str) -> (u64, u64, u64) {\n    let (user_h, _) = find_pda(&[\"user\", user], program_id);\n    let (stats_h, _) = find_pda(&[\"stats\", user], program_id);\n    let (vault_h, _) = find_pda(&[\"vault\", user], program_id);\n    (user_h, stats_h, vault_h)\n}\n",
+        "tests": [
+          {
+            "id": "test-1",
+            "description": "All PDAs should be off-curve (even hashes)",
+            "input": "\"alice\", \"prog1\"",
+            "expectedOutput": "__result__.0 % 2 == 0 && __result__.1 % 2 == 0 && __result__.2 % 2 == 0"
+          },
+          {
+            "id": "test-2",
+            "description": "All three PDAs should be different",
+            "input": "\"alice\", \"prog1\"",
+            "expectedOutput": "__result__.0 != __result__.1 && __result__.1 != __result__.2"
+          },
+          {
+            "id": "test-3",
+            "description": "Different users should produce different PDAs",
+            "input": "\"bob\", \"prog1\"",
+            "expectedOutput": "__result__.0 != derive_user_pdas(\"alice\", \"prog1\").0"
+          }
+        ],
         "hints": [
           "Call find_pda with different seed prefixes: find_pda(&[\"user\", user], program_id) for the user PDA.",
           "Each find_pda returns (hash, bump) — you only need the hash (the .0 field) for the return tuple.",
           "let (user_h, _) = find_pda(&[\"user\", user], program_id); then same for stats and vault."
         ],
-        "idl": null,
-        "key": "exercise",
-        "language": "rust",
-        "maxWords": null,
-        "network": null,
-        "produces": null,
-        "prompt": null,
         "questions": null,
-        "solution": "use std::collections::hash_map::DefaultHasher;\nuse std::hash::{Hash, Hasher};\n\nfn hash_with_bump(seeds: &[&str], bump: u8, program_id: &str) -> u64 {\n    let mut hasher = DefaultHasher::new();\n    for seed in seeds {\n        seed.hash(&mut hasher);\n    }\n    bump.hash(&mut hasher);\n    program_id.hash(&mut hasher);\n    hasher.finish()\n}\n\nfn find_pda(seeds: &[&str], program_id: &str) -> (u64, u8) {\n    for bump in (0..=255u8).rev() {\n        let hash = hash_with_bump(seeds, bump, program_id);\n        if hash % 2 == 0 {\n            return (hash, bump);\n        }\n    }\n    panic!(\"No valid bump found\");\n}\n\nfn derive_user_pdas(user: &str, program_id: &str) -> (u64, u64, u64) {\n    let (user_h, _) = find_pda(&[\"user\", user], program_id);\n    let (stats_h, _) = find_pda(&[\"stats\", user], program_id);\n    let (vault_h, _) = find_pda(&[\"vault\", user], program_id);\n    (user_h, stats_h, vault_h)\n}\n",
-        "src": null,
-        "starter": "use std::collections::hash_map::DefaultHasher;\nuse std::hash::{Hash, Hasher};\n\nfn hash_with_bump(seeds: &[&str], bump: u8, program_id: &str) -> u64 {\n    let mut hasher = DefaultHasher::new();\n    for seed in seeds {\n        seed.hash(&mut hasher);\n    }\n    bump.hash(&mut hasher);\n    program_id.hash(&mut hasher);\n    hasher.finish()\n}\n\nfn find_pda(seeds: &[&str], program_id: &str) -> (u64, u8) {\n    for bump in (0..=255u8).rev() {\n        let hash = hash_with_bump(seeds, bump, program_id);\n        if hash % 2 == 0 {\n            return (hash, bump);\n        }\n    }\n    panic!(\"No valid bump found\");\n}\n\n/// Derive user, stats, and vault PDAs for the given user.\n/// Returns (user_hash, stats_hash, vault_hash).\nfn derive_user_pdas(user: &str, program_id: &str) -> (u64, u64, u64) {\n    // TODO: Derive user PDA with seeds [\"user\", user]\n    // TODO: Derive stats PDA with seeds [\"stats\", user]\n    // TODO: Derive vault PDA with seeds [\"vault\", user]\n    // TODO: Return the three hashes as a tuple\n    todo!()\n}\n",
-        "tests": [
-          {
-            "description": "All PDAs should be off-curve (even hashes)",
-            "expectedOutput": "__result__.0 % 2 == 0 && __result__.1 % 2 == 0 && __result__.2 % 2 == 0",
-            "id": "test-1",
-            "input": "\"alice\", \"prog1\""
-          },
-          {
-            "description": "All three PDAs should be different",
-            "expectedOutput": "__result__.0 != __result__.1 && __result__.1 != __result__.2",
-            "id": "test-2",
-            "input": "\"alice\", \"prog1\""
-          },
-          {
-            "description": "Different users should produce different PDAs",
-            "expectedOutput": "__result__.0 != derive_user_pdas(\"alice\", \"prog1\").0",
-            "id": "test-3",
-            "input": "\"bob\", \"prog1\""
-          }
-        ],
-        "url": null
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       }
-    ],
-    "slug": "pda-advanced-challenge",
-    "title": "Challenge: Multi-PDA Derivation"
+    ]
   },
   {
     "_id": "lesson-pda-challenge",
+    "title": "Challenge: Derive PDAs",
+    "slug": "pda-challenge",
     "blocks": [
       {
-        "_type": "prose",
-        "amount": null,
-        "buildType": null,
-        "consumes": null,
-        "deployable": null,
-        "hints": null,
-        "idl": null,
         "key": "intro",
-        "language": null,
-        "maxWords": null,
-        "network": null,
+        "_type": "prose",
         "produces": null,
-        "prompt": null,
-        "questions": null,
-        "solution": null,
+        "consumes": null,
         "src": "# Challenge: Simulate PDA Derivation in Rust\n\nUnderstand how Program Derived Addresses work by implementing a simplified PDA derivation algorithm using Rust's standard library hashing.\n\nReal Solana PDAs use SHA-256 and check if the result is on the Ed25519 curve. Here we simulate this concept using `DefaultHasher` and check if the hash is even (our proxy for \"off-curve\").\n\n## Your Task\n\nImplement `find_program_address(seeds, program_id)` that:\n\n1. Iterates bumps from 255 down to 0\n2. For each bump, hashes all seeds + bump + program_id together\n3. Returns the first hash that is **even** (simulating \"off-curve\")\n4. Returns `(hash, bump)` as a tuple\n\n**Requirements:**\n- Use `std::collections::hash_map::DefaultHasher`\n- Hash each seed, then the bump byte, then the program_id\n- Return the first even hash (hash % 2 == 0)\n- This is deterministic: same seeds always produce the same result\n\n**Rust Concepts Used:**\n- `std::hash::{Hash, Hasher}` traits\n- Iterating with `for bump in (0..=255u8).rev()`\n- Tuples as return types\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
         "starter": null,
+        "solution": null,
         "tests": null,
-        "url": null
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       },
       {
+        "key": "exercise",
         "_type": "code",
-        "amount": null,
-        "buildType": "standard",
+        "produces": null,
         "consumes": null,
+        "src": null,
+        "url": null,
+        "language": "rust",
+        "buildType": "standard",
         "deployable": false,
+        "starter": "use std::collections::hash_map::DefaultHasher;\nuse std::hash::{Hash, Hasher};\n\nfn hash_with_bump(seeds: &[&str], bump: u8, program_id: &str) -> u64 {\n    let mut hasher = DefaultHasher::new();\n    for seed in seeds {\n        seed.hash(&mut hasher);\n    }\n    bump.hash(&mut hasher);\n    program_id.hash(&mut hasher);\n    hasher.finish()\n}\n\n/// Find a \"program address\" by trying bumps from 255 down to 0.\n/// Returns the first (hash, bump) where hash is even (off-curve).\nfn find_program_address(seeds: &[&str], program_id: &str) -> (u64, u8) {\n    // TODO: Iterate bumps from 255 down to 0\n    // TODO: For each bump, call hash_with_bump(seeds, bump, program_id)\n    // TODO: If hash % 2 == 0, return (hash, bump)\n    // TODO: If no bump works, panic!(\"No valid bump found\")\n    todo!()\n}\n",
+        "solution": "use std::collections::hash_map::DefaultHasher;\nuse std::hash::{Hash, Hasher};\n\nfn hash_with_bump(seeds: &[&str], bump: u8, program_id: &str) -> u64 {\n    let mut hasher = DefaultHasher::new();\n    for seed in seeds {\n        seed.hash(&mut hasher);\n    }\n    bump.hash(&mut hasher);\n    program_id.hash(&mut hasher);\n    hasher.finish()\n}\n\nfn find_program_address(seeds: &[&str], program_id: &str) -> (u64, u8) {\n    for bump in (0..=255u8).rev() {\n        let hash = hash_with_bump(seeds, bump, program_id);\n        if hash % 2 == 0 {\n            return (hash, bump);\n        }\n    }\n    panic!(\"No valid bump found\");\n}\n",
+        "tests": [
+          {
+            "id": "test-1",
+            "description": "Derived address should be off-curve (even hash)",
+            "input": "&[\"user\", \"alice\"], \"program1\"",
+            "expectedOutput": "__result__.0 % 2 == 0"
+          },
+          {
+            "id": "test-2",
+            "description": "Different seeds should produce different addresses",
+            "input": "&[\"vault\", \"alice\"], \"program1\"",
+            "expectedOutput": "__result__.0 != find_program_address(&[\"user\", \"alice\"], \"program1\").0"
+          },
+          {
+            "id": "test-3",
+            "description": "Different users should produce different addresses",
+            "input": "&[\"user\", \"bob\"], \"program1\"",
+            "expectedOutput": "__result__.0 != find_program_address(&[\"user\", \"alice\"], \"program1\").0"
+          }
+        ],
         "hints": [
           "Use for bump in (0..=255u8).rev() to iterate from 255 down to 0.",
           "Call hash_with_bump(seeds, bump, program_id) inside the loop. Check if hash % 2 == 0.",
           "When the condition is met, return (hash, bump). After the loop, panic!(\"No valid bump found\")."
         ],
-        "idl": null,
-        "key": "exercise",
-        "language": "rust",
-        "maxWords": null,
-        "network": null,
-        "produces": null,
-        "prompt": null,
         "questions": null,
-        "solution": "use std::collections::hash_map::DefaultHasher;\nuse std::hash::{Hash, Hasher};\n\nfn hash_with_bump(seeds: &[&str], bump: u8, program_id: &str) -> u64 {\n    let mut hasher = DefaultHasher::new();\n    for seed in seeds {\n        seed.hash(&mut hasher);\n    }\n    bump.hash(&mut hasher);\n    program_id.hash(&mut hasher);\n    hasher.finish()\n}\n\nfn find_program_address(seeds: &[&str], program_id: &str) -> (u64, u8) {\n    for bump in (0..=255u8).rev() {\n        let hash = hash_with_bump(seeds, bump, program_id);\n        if hash % 2 == 0 {\n            return (hash, bump);\n        }\n    }\n    panic!(\"No valid bump found\");\n}\n",
-        "src": null,
-        "starter": "use std::collections::hash_map::DefaultHasher;\nuse std::hash::{Hash, Hasher};\n\nfn hash_with_bump(seeds: &[&str], bump: u8, program_id: &str) -> u64 {\n    let mut hasher = DefaultHasher::new();\n    for seed in seeds {\n        seed.hash(&mut hasher);\n    }\n    bump.hash(&mut hasher);\n    program_id.hash(&mut hasher);\n    hasher.finish()\n}\n\n/// Find a \"program address\" by trying bumps from 255 down to 0.\n/// Returns the first (hash, bump) where hash is even (off-curve).\nfn find_program_address(seeds: &[&str], program_id: &str) -> (u64, u8) {\n    // TODO: Iterate bumps from 255 down to 0\n    // TODO: For each bump, call hash_with_bump(seeds, bump, program_id)\n    // TODO: If hash % 2 == 0, return (hash, bump)\n    // TODO: If no bump works, panic!(\"No valid bump found\")\n    todo!()\n}\n",
-        "tests": [
-          {
-            "description": "Derived address should be off-curve (even hash)",
-            "expectedOutput": "__result__.0 % 2 == 0",
-            "id": "test-1",
-            "input": "&[\"user\", \"alice\"], \"program1\""
-          },
-          {
-            "description": "Different seeds should produce different addresses",
-            "expectedOutput": "__result__.0 != find_program_address(&[\"user\", \"alice\"], \"program1\").0",
-            "id": "test-2",
-            "input": "&[\"vault\", \"alice\"], \"program1\""
-          },
-          {
-            "description": "Different users should produce different addresses",
-            "expectedOutput": "__result__.0 != find_program_address(&[\"user\", \"alice\"], \"program1\").0",
-            "id": "test-3",
-            "input": "&[\"user\", \"bob\"], \"program1\""
-          }
-        ],
-        "url": null
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       }
-    ],
-    "slug": "pda-challenge",
-    "title": "Challenge: Derive PDAs"
+    ]
   },
   {
     "_id": "lesson-pda-deep-dive",
+    "title": "PDA Deep Dive",
+    "slug": "pda-deep-dive",
     "blocks": [
       {
-        "_type": "prose",
-        "amount": null,
-        "buildType": null,
-        "consumes": null,
-        "deployable": null,
-        "hints": null,
-        "idl": null,
         "key": "intro",
-        "language": null,
-        "maxWords": null,
-        "network": null,
+        "_type": "prose",
         "produces": null,
-        "prompt": null,
-        "questions": null,
-        "solution": null,
+        "consumes": null,
         "src": "# Program Derived Addresses (PDAs) Deep Dive\n\nProgram Derived Addresses are one of Solana's most powerful and unique features. They enable programs to \"own\" accounts and sign transactions without needing a private key.\n\n## What Are PDAs?\n\nA PDA is a public key that:\n1. Is derived deterministically from seeds and a program ID\n2. Is **not** on the Ed25519 elliptic curve (no corresponding private key exists)\n3. Can only be \"signed for\" by the program that derived it\n\n```rust\n// In Anchor\nlet (pda, bump) = Pubkey::find_program_address(\n    &[b\"user\", user.key().as_ref()],\n    program_id\n);\n```\n\n## Why PDAs Are Off-Curve\n\nSolana uses Ed25519 for signatures. Ed25519 keys lie on an elliptic curve. PDAs are specifically designed to fall **off** this curve, which means:\n- No private key can exist for a PDA\n- Only the deriving program can sign for the PDA (via CPI with `invoke_signed`)\n\nThis creates **program-controlled accounts** that can't be compromised by key theft.\n\n## PDA Derivation Process\n\n```\nseeds = [b\"user\", user_pubkey.as_ref()]\nprogram_id = your_program_id\n\nfor bump in 255..=0 {\n    candidate = sha256(seeds + [bump] + program_id)\n    if !is_on_curve(candidate) {\n        return (candidate, bump)  // This is your PDA\n    }\n}\n```\n\nThe **canonical bump** is the first bump (starting from 255) that produces an off-curve address.\n\n## Seeds Design Patterns\n\n### Pattern 1: User-Scoped Account\n\n```rust\nseeds = [b\"user\", user.key().as_ref()]\n```\n\nOne account per user. Used for user profiles, settings, etc.\n\n### Pattern 2: User + Resource\n\n```rust\nseeds = [b\"escrow\", user.key().as_ref(), trade_id.to_le_bytes().as_ref()]\n```\n\nMultiple accounts per user, one per resource (escrow, order, etc.).\n\n### Pattern 3: Global Singleton\n\n```rust\nseeds = [b\"config\"]\n```\n\nOne global account for the program (config, authority, etc.).\n\n### Pattern 4: Nested PDAs\n\n```rust\n// User stats PDA\nseeds_stats = [b\"stats\", user.key().as_ref()]\n\n// User vault PDA (derived from stats PDA)\nseeds_vault = [b\"vault\", stats_pda.key().as_ref()]\n```\n\nPDAs can be derived from other PDAs for complex hierarchies.\n\n## Storing the Bump\n\nAlways store the canonical bump in your account data:\n\n```rust\n#[account]\npub struct UserAccount {\n    pub authority: Pubkey,\n    pub bump: u8,  // Store this!\n    pub data: u64,\n}\n```\n\nWhy? Because recalculating the bump on every instruction is expensive (requires up to 256 hash operations). Storing it makes subsequent operations cheaper.\n\n## PDAs as Signers\n\nPDAs can sign CPIs using `invoke_signed`:\n\n```rust\ninvoke_signed(\n    &transfer_instruction,\n    &[\n        pda_account.to_account_info(),\n        recipient.to_account_info(),\n        system_program.to_account_info(),\n    ],\n    &[&[b\"user\", user.key().as_ref(), &[bump]]], // Signer seeds\n)?;\n```\n\nThe program derives the PDA, verifies it matches, and \"signs\" the CPI.\n\n## Security Considerations\n\n### 1. Seed Collision\n\nBe careful with seed design:\n\n```rust\n// BAD: Can collide if strings contain delimiters\nseeds = [user_name.as_bytes()]  // \"alice\" and \"ali\" + \"ce\" collide!\n\n// GOOD: Use fixed-size data or well-defined separators\nseeds = [b\"user\", user.key().as_ref()]\n```\n\n### 2. Bump Validation\n\nAlways use the canonical bump:\n\n```rust\n// In Anchor, this is automatic:\n#[account(\n    seeds = [b\"user\", authority.key().as_ref()],\n    bump = user.bump  // Validates stored bump is canonical\n)]\n```\n\n## PDA vs Regular Account\n\n| Feature | Regular Account | PDA |\n|---------|----------------|-----|\n| Has private key | Yes | No |\n| Can self-sign | Yes | No (requires program) |\n| Can hold SOL | Yes | Yes |\n| Can own other accounts | Yes | Yes |\n| Deterministic address | No | Yes |\n| On Ed25519 curve | Yes | No |\n\n## Real-World Examples\n\n**Token vaults** (escrow programs):\n```rust\nseeds = [b\"vault\", escrow.key().as_ref()]\n```\n\n**Associated Token Accounts**:\n```rust\nseeds = [wallet.key(), token_program.key(), mint.key()]\n```\n\n**Governance proposal accounts**:\n```rust\nseeds = [b\"proposal\", governance.key(), proposal_id.to_le_bytes()]\n```\n\n## Next Challenge\n\nYou'll derive multiple related PDAs from a common base to understand PDA hierarchies.\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
         "starter": null,
+        "solution": null,
         "tests": null,
-        "url": null
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "retrieval-close",
+        "_type": "quiz",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": [
+          {
+            "id": "q1",
+            "prompt": "A PDA is deliberately chosen to fall OFF the Ed25519 curve. What does off-curve guarantee?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "No private key exists for the address, so only the deriving program can sign for it via invoke_signed",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "The address is shorter than a normal pubkey",
+                "correct": false,
+                "feedback": "Off-curve addresses are the same 32-byte size. What off-curve buys you is that no private key exists — the program alone can authorize it."
+              },
+              {
+                "id": "c",
+                "label": "The account can never hold SOL",
+                "correct": false,
+                "feedback": "PDAs can hold SOL fine. Off-curve means no private key, which is what makes them program-controlled and theft-proof."
+              }
+            ],
+            "explanation": "Ed25519 signing keys lie on the curve; a PDA is derived to sit off it, so no private key can exist. That is precisely what makes a PDA program-controlled: only the program that derived it can sign for it through invoke_signed, and no leaked key can drain it."
+          },
+          {
+            "id": "q2",
+            "prompt": "The lesson says to store the canonical `bump` in the account rather than re-deriving it each time. Why?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "Re-finding the canonical bump can cost up to 256 hash attempts; storing it makes later instructions cheaper",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "The bump changes every transaction, so it must be saved",
+                "correct": false,
+                "feedback": "The canonical bump is deterministic and stable for given seeds — it does not change. You store it to skip the costly search, not because it varies."
+              },
+              {
+                "id": "c",
+                "label": "Storing the bump is required for the PDA to hold SOL",
+                "correct": false,
+                "feedback": "Holding SOL has nothing to do with the bump. You store it purely to avoid recomputing the canonical bump on each call."
+              }
+            ],
+            "explanation": "find_program_address tries bumps from 255 downward until it finds an off-curve address, up to 256 hash operations. Since that canonical bump is fixed for the seeds, storing it in the account lets later instructions validate the PDA with `bump = account.bump` instead of repeating the expensive search."
+          }
+        ],
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       }
-    ],
-    "slug": "pda-deep-dive",
-    "title": "PDA Deep Dive"
+    ]
   },
   {
     "_id": "lesson-program-challenge",
+    "title": "Challenge: Build a Custom Instruction",
+    "slug": "program-challenge",
     "blocks": [
       {
-        "_type": "prose",
-        "amount": null,
-        "buildType": null,
-        "consumes": null,
-        "deployable": null,
-        "hints": null,
-        "idl": null,
         "key": "intro",
-        "language": null,
-        "maxWords": null,
-        "network": null,
+        "_type": "prose",
         "produces": null,
-        "prompt": null,
-        "questions": null,
-        "solution": null,
+        "consumes": null,
         "src": "# Challenge: Build a Custom Instruction\n\nConstruct a custom Solana instruction that could be used to interact with a program. You'll define the program ID, the accounts involved, and the instruction data.\n\n## Requirements\n\n- Create a function that accepts `programId` (PublicKey), `payer` (PublicKey), `dataAccount` (PublicKey), and `amount` (number)\n- Return an instruction object with:\n  - `programId`: the program to call\n  - `keys`: an array of AccountMeta objects (payer as signer + writable, dataAccount as writable)\n  - `data`: a Uint8Array containing the amount encoded as 8 bytes (little-endian u64)\n- Use `DataView` to encode the amount as a little-endian 64-bit unsigned integer\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
         "starter": null,
+        "solution": null,
         "tests": null,
-        "url": null
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       },
       {
+        "key": "exercise",
         "_type": "code",
-        "amount": null,
-        "buildType": "standard",
+        "produces": null,
         "consumes": null,
+        "src": null,
+        "url": null,
+        "language": "typescript",
+        "buildType": "standard",
         "deployable": false,
+        "starter": "import { PublicKey } from '@solana/web3.js';\n\ninterface AccountMeta {\n  pubkey: PublicKey;\n  isSigner: boolean;\n  isWritable: boolean;\n}\n\ninterface Instruction {\n  programId: PublicKey;\n  keys: AccountMeta[];\n  data: Uint8Array;\n}\n\nfunction buildCustomInstruction(\n  programId: PublicKey,\n  payer: PublicKey,\n  dataAccount: PublicKey,\n  amount: number\n): Instruction {\n  // Your code here\n}\n",
+        "solution": "import { PublicKey } from '@solana/web3.js';\n\ninterface AccountMeta {\n  pubkey: PublicKey;\n  isSigner: boolean;\n  isWritable: boolean;\n}\n\ninterface Instruction {\n  programId: PublicKey;\n  keys: AccountMeta[];\n  data: Uint8Array;\n}\n\nfunction buildCustomInstruction(\n  programId: PublicKey,\n  payer: PublicKey,\n  dataAccount: PublicKey,\n  amount: number\n): Instruction {\n  // Encode amount as 8-byte little-endian u64\n  const data = new Uint8Array(8);\n  const view = new DataView(data.buffer);\n  view.setBigUint64(0, BigInt(amount), true); // true = little-endian\n\n  return {\n    programId,\n    keys: [\n      { pubkey: payer, isSigner: true, isWritable: true },\n      { pubkey: dataAccount, isSigner: false, isWritable: true },\n    ],\n    data,\n  };\n}\n",
+        "tests": [
+          {
+            "id": "t1",
+            "description": "Returns programId, keys array and Uint8Array data",
+            "input": "programId, sender, recipient, 1000",
+            "expectedOutput": "result.programId && Array.isArray(result.keys) && result.data instanceof Uint8Array"
+          },
+          {
+            "id": "t2",
+            "description": "Has at least 2 keys, first is a signer",
+            "input": "programId, sender, recipient, 1000",
+            "expectedOutput": "result.keys.length >= 2 && result.keys[0].isSigner === true"
+          },
+          {
+            "id": "t3",
+            "description": "Encodes the amount as an 8-byte little-endian u64",
+            "input": "programId, sender, recipient, 1000",
+            "expectedOutput": "result.data.length === 8 && result.data[0] === 232 && result.data[1] === 3"
+          },
+          {
+            "id": "t4",
+            "description": "Encodes a different amount correctly (little-endian)",
+            "input": "programId, sender, recipient, 500000000",
+            "expectedOutput": "result.data.length === 8 && result.data[0] === 0 && result.data[1] === 101 && result.data[2] === 205 && result.data[3] === 29"
+          }
+        ],
         "hints": [
           "Create an 8-byte Uint8Array and use DataView to write the amount as a little-endian u64",
           "The keys array should have payer first (isSigner: true, isWritable: true), then dataAccount (isSigner: false, isWritable: true)",
           "Use new DataView(buffer).setBigUint64(0, BigInt(amount), true) where true means little-endian"
         ],
-        "idl": null,
-        "key": "exercise",
-        "language": "typescript",
-        "maxWords": null,
-        "network": null,
-        "produces": null,
-        "prompt": null,
         "questions": null,
-        "solution": "import { PublicKey } from '@solana/web3.js';\n\ninterface AccountMeta {\n  pubkey: PublicKey;\n  isSigner: boolean;\n  isWritable: boolean;\n}\n\ninterface Instruction {\n  programId: PublicKey;\n  keys: AccountMeta[];\n  data: Uint8Array;\n}\n\nfunction buildCustomInstruction(\n  programId: PublicKey,\n  payer: PublicKey,\n  dataAccount: PublicKey,\n  amount: number\n): Instruction {\n  // Encode amount as 8-byte little-endian u64\n  const data = new Uint8Array(8);\n  const view = new DataView(data.buffer);\n  view.setBigUint64(0, BigInt(amount), true); // true = little-endian\n\n  return {\n    programId,\n    keys: [\n      { pubkey: payer, isSigner: true, isWritable: true },\n      { pubkey: dataAccount, isSigner: false, isWritable: true },\n    ],\n    data,\n  };\n}\n",
-        "src": null,
-        "starter": "import { PublicKey } from '@solana/web3.js';\n\ninterface AccountMeta {\n  pubkey: PublicKey;\n  isSigner: boolean;\n  isWritable: boolean;\n}\n\ninterface Instruction {\n  programId: PublicKey;\n  keys: AccountMeta[];\n  data: Uint8Array;\n}\n\nfunction buildCustomInstruction(\n  programId: PublicKey,\n  payer: PublicKey,\n  dataAccount: PublicKey,\n  amount: number\n): Instruction {\n  // Your code here\n}\n",
-        "tests": [
-          {
-            "description": "Returns programId, keys array and Uint8Array data",
-            "expectedOutput": "result.programId && Array.isArray(result.keys) && result.data instanceof Uint8Array",
-            "id": "t1",
-            "input": "programId, sender, recipient, 1000"
-          },
-          {
-            "description": "Has at least 2 keys, first is a signer",
-            "expectedOutput": "result.keys.length >= 2 && result.keys[0].isSigner === true",
-            "id": "t2",
-            "input": "programId, sender, recipient, 1000"
-          },
-          {
-            "description": "Encodes the amount as an 8-byte little-endian u64",
-            "expectedOutput": "result.data.length === 8 && result.data[0] === 232 && result.data[1] === 3",
-            "id": "t3",
-            "input": "programId, sender, recipient, 1000"
-          },
-          {
-            "description": "Encodes a different amount correctly (little-endian)",
-            "expectedOutput": "result.data.length === 8 && result.data[0] === 0 && result.data[1] === 101 && result.data[2] === 205 && result.data[3] === 29",
-            "id": "t4",
-            "input": "programId, sender, recipient, 500000000"
-          }
-        ],
-        "url": null
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       }
-    ],
-    "slug": "program-challenge",
-    "title": "Challenge: Build a Custom Instruction"
+    ]
   },
   {
     "_id": "lesson-program-structure",
+    "title": "Solana Program Structure",
+    "slug": "program-structure",
     "blocks": [
       {
-        "_type": "prose",
-        "amount": null,
-        "buildType": null,
-        "consumes": null,
-        "deployable": null,
-        "hints": null,
-        "idl": null,
         "key": "intro",
-        "language": null,
-        "maxWords": null,
-        "network": null,
+        "_type": "prose",
         "produces": null,
-        "prompt": null,
-        "questions": null,
-        "solution": null,
+        "consumes": null,
         "src": "# Solana Program Structure\n\nSolana programs (smart contracts) follow a specific structure. Understanding this architecture is essential before writing your first program.\n\n## The Entrypoint Macro\n\nEvery Solana program starts with the `entrypoint!` macro, which defines the entry function the runtime calls:\n\n```rust\nuse solana_program::{\n    account_info::AccountInfo,\n    entrypoint,\n    entrypoint::ProgramResult,\n    pubkey::Pubkey,\n};\n\nentrypoint!(process_instruction);\n\npub fn process_instruction(\n    program_id: &Pubkey,\n    accounts: &[AccountInfo],\n    instruction_data: &[u8],\n) -> ProgramResult {\n    // Your program logic here\n    Ok(())\n}\n```\n\n## The Three Parameters\n\n### 1. `program_id: &Pubkey`\n\nThe public key (address) of your deployed program. Use this to:\n- Verify that accounts are owned by your program\n- Derive PDAs (Program Derived Addresses)\n- Check that the correct program was called\n\n```rust\nif account.owner != program_id {\n    return Err(ProgramError::IncorrectProgramId);\n}\n```\n\n### 2. `accounts: &[AccountInfo]`\n\nA slice of all accounts passed to the instruction. Each `AccountInfo` contains:\n\n```rust\npub struct AccountInfo<'a> {\n    pub key: &'a Pubkey,           // Account's public key\n    pub lamports: Rc<RefCell<&'a mut u64>>, // Balance in lamports\n    pub data: Rc<RefCell<&'a mut [u8]>>,    // Raw account data\n    pub owner: &'a Pubkey,         // Program that owns this account\n    pub rent_epoch: u64,           // When rent is next due\n    pub is_signer: bool,           // True if account signed the transaction\n    pub is_writable: bool,         // True if account is mutable\n    pub executable: bool,          // True if account is a program\n}\n```\n\nAccess accounts using an iterator:\n\n```rust\nlet account_iter = &mut accounts.iter();\nlet sender = next_account_info(account_iter)?;\nlet recipient = next_account_info(account_iter)?;\nlet system_program = next_account_info(account_iter)?;\n```\n\n### 3. `instruction_data: &[u8]`\n\nRaw bytes representing the instruction. Deserialize to determine what action to perform:\n\n```rust\nlet instruction = MyInstruction::try_from_slice(instruction_data)?;\n\nmatch instruction {\n    MyInstruction::Initialize { amount } => process_initialize(accounts, amount),\n    MyInstruction::Transfer { amount } => process_transfer(accounts, amount),\n    MyInstruction::Close => process_close(accounts),\n}\n```\n\n## Account Validation\n\n**Critical**: Always validate accounts before using them. Attackers can pass malicious accounts to exploit your program.\n\n```rust\npub fn process_transfer(\n    program_id: &Pubkey,\n    accounts: &[AccountInfo],\n    amount: u64,\n) -> ProgramResult {\n    let account_iter = &mut accounts.iter();\n    let sender = next_account_info(account_iter)?;\n    let recipient = next_account_info(account_iter)?;\n    \n    // 1. Verify sender signed the transaction\n    if !sender.is_signer {\n        return Err(ProgramError::MissingRequiredSignature);\n    }\n    \n    // 2. Verify sender is writable (we'll modify balance)\n    if !sender.is_writable {\n        return Err(ProgramError::InvalidAccountData);\n    }\n    \n    // 3. Verify sender is owned by this program\n    if sender.owner != program_id {\n        return Err(ProgramError::IncorrectProgramId);\n    }\n    \n    // 4. Verify recipient is writable\n    if !recipient.is_writable {\n        return Err(ProgramError::InvalidAccountData);\n    }\n    \n    // Now safe to proceed\n    // ...\n    Ok(())\n}\n```\n\n## Common Validation Checks\n\n| Check | Prevents |\n|-------|----------|\n| `!is_signer` | Unauthorized access |\n| `!is_writable` | Mutating read-only accounts |\n| `owner != program_id` | Cross-program account hijacking |\n| `accounts.len() < N` | Index out of bounds |\n| `data.len() < expected` | Uninitialized accounts |\n| `key != expected_key` | Account substitution attacks |\n\n## Program Flow\n\n```rust\nentrypoint!(process_instruction);\n\npub fn process_instruction(\n    program_id: &Pubkey,\n    accounts: &[AccountInfo],\n    instruction_data: &[u8],\n) -> ProgramResult {\n    // 1. Parse instruction\n    let instruction = MyInstruction::try_from_slice(instruction_data)\n        .map_err(|_| ProgramError::InvalidInstructionData)?;\n    \n    // 2. Route to handler based on instruction type\n    match instruction {\n        MyInstruction::Initialize { amount } => {\n            msg!(\"Instruction: Initialize\");\n            process_initialize(program_id, accounts, amount)\n        }\n        MyInstruction::Transfer { amount } => {\n            msg!(\"Instruction: Transfer\");\n            process_transfer(program_id, accounts, amount)\n        }\n    }\n}\n\nfn process_initialize(\n    program_id: &Pubkey,\n    accounts: &[AccountInfo],\n    amount: u64,\n) -> ProgramResult {\n    // 3. Validate accounts\n    // 4. Deserialize account data\n    // 5. Perform business logic\n    // 6. Serialize account data back\n    Ok(())\n}\n```\n\n## Key Principles\n\n1. **Validate everything**: Never trust input data or accounts\n2. **Fail early**: Return errors before mutating state\n3. **Log actions**: Use `msg!()` to help debug transactions\n4. **Minimize compute**: Solana charges for compute units used\n5. **Test thoroughly**: Write unit tests for all code paths\n\nIn the next challenge, you'll build a complete instruction handler that validates accounts and processes a transfer!\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
         "starter": null,
+        "solution": null,
         "tests": null,
-        "url": null
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       }
-    ],
-    "slug": "program-structure",
-    "title": "Solana Program Structure"
+    ]
   },
   {
     "_id": "lesson-programs-overview",
+    "title": "Introduction to Solana Programs",
+    "slug": "programs-overview",
     "blocks": [
       {
-        "_type": "prose",
-        "amount": null,
-        "buildType": null,
-        "consumes": null,
-        "deployable": null,
-        "hints": null,
-        "idl": null,
         "key": "intro",
-        "language": null,
-        "maxWords": null,
-        "network": null,
+        "_type": "prose",
         "produces": null,
-        "prompt": null,
-        "questions": null,
-        "solution": null,
-        "src": "# Introduction to Solana Programs\n\nSolana programs (often called \"smart contracts\" on other blockchains) are the executable code that runs on the Solana network. Understanding how they work is essential for building decentralized applications.\n\n## Programs are Stateless\n\nUnlike Ethereum smart contracts that store state internally, **Solana programs are completely stateless**. They only contain executable code. All state is stored in separate accounts.\n\n```\n┌─────────────────┐         ┌──────────────┐\n│  Your Program   │ ────>   │ Account Data │\n│  (Stateless)    │         │  (Stateful)  │\n└─────────────────┘         └──────────────┘\n```\n\nThis separation enables:\n- **Parallel execution**: Multiple transactions can run simultaneously\n- **Composability**: Programs can easily interact with each other\n- **Upgradability**: Update code without migrating state\n\n## Instruction Anatomy\n\nPrograms are invoked via **instructions**. Each instruction contains:\n\n```typescript\ninterface Instruction {\n  programId: PublicKey;           // Which program to call\n  keys: AccountMeta[];            // Which accounts to pass\n  data: Uint8Array;               // Instruction-specific data\n}\n\ninterface AccountMeta {\n  pubkey: PublicKey;              // Account address\n  isSigner: boolean;              // Must sign transaction?\n  isWritable: boolean;            // Program will modify?\n}\n```\n\n### Example: Transfer Instruction\n\n```typescript\nimport { SystemProgram, PublicKey, LAMPORTS_PER_SOL } from '@solana/web3.js';\n\nconst instruction = SystemProgram.transfer({\n  fromPubkey: sender,             // Signer, writable\n  toPubkey: recipient,            // Writable\n  lamports: 0.5 * LAMPORTS_PER_SOL\n});\n\nconsole.log('Program ID:', instruction.programId.toBase58());\n// 11111111111111111111111111111111 (System Program)\nconsole.log('Keys:', instruction.keys);\n// [{ pubkey: sender, isSigner: true, isWritable: true },\n//  { pubkey: recipient, isSigner: false, isWritable: true }]\n```\n\n## Built-in Programs vs Custom Programs\n\n### System Program\n- **ID**: `11111111111111111111111111111111`\n- **Purpose**: Account creation, SOL transfers, account assignment\n- **Used by**: Every Solana transaction\n\n### Token Program\n- **ID**: `TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA`\n- **Purpose**: SPL token minting, transfers, account management\n- **Used by**: All DeFi protocols, NFT platforms, token projects\n\n### Custom Programs\n- Deployed by developers\n- Written in Rust, C, or C++ (compiled to BPF bytecode)\n- Examples: Raydium AMM, Magic Eden marketplace, Jupiter aggregator\n\n## The BPF Runtime (Sealevel)\n\nSolana programs run in the **BPF (Berkeley Packet Filter)** virtual machine called **Sealevel**. Key features:\n\n- **Deterministic**: Same input always produces same output\n- **Metered**: Compute units prevent infinite loops\n- **Sandboxed**: Programs cannot access system resources\n- **Parallel**: Thousands of programs run simultaneously\n\n```typescript\n// Programs have a compute budget\nconst COMPUTE_UNITS_PER_INSTRUCTION = 200_000;\nconst MAX_COMPUTE_UNITS_PER_TX = 1_400_000;\n```\n\n## Cross-Program Invocation (CPI)\n\nPrograms can call other programs via **CPI**. This is how Solana achieves composability:\n\n```rust\n// Your program calling the Token Program (Rust example)\ninvoke(\n    &transfer_instruction,\n    &[\n        token_account.clone(),\n        destination.clone(),\n        authority.clone(),\n    ],\n)?;\n```\n\nReal example: Jupiter aggregates multiple DEXs by making CPIs to Raydium, Orca, and other AMM programs in a single transaction.\n\n## Next Steps\n\nIn the next challenge, you'll construct a custom instruction from scratch, understanding how programs receive and process data.\n",
+        "consumes": null,
+        "src": "# Introduction to Solana Programs\n\nSolana programs (often called \"smart contracts\" on other blockchains) are the executable code that runs on the Solana network. Understanding how they work is essential for building decentralized applications.\n\n## Programs are Stateless\n\nUnlike Ethereum smart contracts that store state internally, **Solana programs are completely stateless**. They only contain executable code. All state is stored in separate accounts.\n\n```\n┌─────────────────┐         ┌──────────────┐\n│  Your Program   │ ────>   │ Account Data │\n│  (Stateless)    │         │  (Stateful)  │\n└─────────────────┘         └──────────────┘\n```\n\nThis separation enables:\n- **Parallel execution**: Multiple transactions can run simultaneously\n- **Composability**: Programs can easily interact with each other\n- **Upgradability**: Update code without migrating state\n\n## Instruction Anatomy\n\nPrograms are invoked via **instructions**. Each instruction contains:\n\n```typescript\ninterface Instruction {\n  programId: PublicKey;           // Which program to call\n  keys: AccountMeta[];            // Which accounts to pass\n  data: Uint8Array;               // Instruction-specific data\n}\n\ninterface AccountMeta {\n  pubkey: PublicKey;              // Account address\n  isSigner: boolean;              // Must sign transaction?\n  isWritable: boolean;            // Program will modify?\n}\n```\n\n### Example: Transfer Instruction\n\n```typescript\nimport { SystemProgram, PublicKey, LAMPORTS_PER_SOL } from '@solana/web3.js';\n\nconst instruction = SystemProgram.transfer({\n  fromPubkey: sender,             // Signer, writable\n  toPubkey: recipient,            // Writable\n  lamports: 0.5 * LAMPORTS_PER_SOL\n});\n\nconsole.log('Program ID:', instruction.programId.toBase58());\n// 11111111111111111111111111111111 (System Program)\nconsole.log('Keys:', instruction.keys);\n// [{ pubkey: sender, isSigner: true, isWritable: true },\n//  { pubkey: recipient, isSigner: false, isWritable: true }]\n```\n\n## Built-in Programs vs Custom Programs\n\n### System Program\n- **ID**: `11111111111111111111111111111111`\n- **Purpose**: Account creation, SOL transfers, account assignment\n- **Used by**: Every Solana transaction\n\n### Token Program\n- **ID**: `TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA`\n- **Purpose**: SPL token minting, transfers, account management\n- **Used by**: All DeFi protocols, NFT platforms, token projects\n\n### Custom Programs\n- Deployed by developers\n- Written in Rust (compiled to BPF bytecode)\n- Examples: Raydium AMM, Magic Eden marketplace, Jupiter aggregator\n\n## The BPF Runtime (Sealevel)\n\nSolana programs run in the **BPF (Berkeley Packet Filter)** virtual machine called **Sealevel**. Key features:\n\n- **Deterministic**: Same input always produces same output\n- **Metered**: Compute units prevent infinite loops\n- **Sandboxed**: Programs cannot access system resources\n- **Parallel**: Thousands of programs run simultaneously\n\n```typescript\n// Programs have a compute budget\nconst COMPUTE_UNITS_PER_INSTRUCTION = 200_000;\nconst MAX_COMPUTE_UNITS_PER_TX = 1_400_000;\n```\n\n## Cross-Program Invocation (CPI)\n\nPrograms can call other programs via **CPI**. This is how Solana achieves composability:\n\n```rust\n// Your program calling the Token Program (Rust example)\ninvoke(\n    &transfer_instruction,\n    &[\n        token_account.clone(),\n        destination.clone(),\n        authority.clone(),\n    ],\n)?;\n```\n\nReal example: Jupiter aggregates multiple DEXs by making CPIs to Raydium, Orca, and other AMM programs in a single transaction.\n\n## Next Steps\n\nIn the next challenge, you'll construct a custom instruction from scratch, understanding how programs receive and process data.\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
         "starter": null,
+        "solution": null,
         "tests": null,
-        "url": null
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "retrieval-close",
+        "_type": "quiz",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": [
+          {
+            "id": "q1",
+            "prompt": "Solana programs are stateless — they hold only code, never data. Which capability does this separation directly enable?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "Upgrading a program's code without migrating any state, because the state lives in separate accounts",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "Storing user balances inside the program for fast access",
+                "correct": false,
+                "feedback": "That is the Ethereum model this design rejects. Solana state lives in accounts, not in the program — which is exactly what makes upgrades and parallelism possible."
+              },
+              {
+                "id": "c",
+                "label": "Guaranteeing the program can never be changed once deployed",
+                "correct": false,
+                "feedback": "Statelessness does not imply immutability. Separating code from state is what makes an upgrade clean — you swap the code and the account state is untouched."
+              }
+            ],
+            "explanation": "Because a program is just code and all state sits in accounts it operates on, you can deploy new bytecode to the same program id without touching or migrating data. The same separation is what lets Sealevel run many transactions in parallel."
+          },
+          {
+            "id": "q2",
+            "prompt": "An instruction's `AccountMeta` marks each account with `isSigner` and `isWritable`. What does the runtime do if a program tries to modify an account passed with `isWritable: false`?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "It rejects the transaction — writable intent must be declared up front",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "It silently allows the write since the program was handed the account",
+                "correct": false,
+                "feedback": "Nothing is silent. Declaring `isWritable` up front is mandatory; a write to a non-writable account aborts the transaction. This declaration is what lets Sealevel schedule parallel execution safely."
+              },
+              {
+                "id": "c",
+                "label": "It writes, but rolls the change back after the transaction",
+                "correct": false,
+                "feedback": "There is no after-the-fact rollback — the attempt fails immediately. Accounts must be declared writable before the instruction runs."
+              }
+            ],
+            "explanation": "Every account a transaction touches is declared with its access flags before execution. The runtime enforces those flags, and it is precisely this up-front declaration that lets Sealevel know which transactions can run in parallel."
+          }
+        ],
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       }
-    ],
-    "slug": "programs-overview",
-    "title": "Introduction to Solana Programs"
+    ]
   },
   {
     "_id": "lesson-react-patterns",
+    "title": "React Patterns for Solana dApps",
+    "slug": "react-patterns",
     "blocks": [
       {
-        "_type": "prose",
-        "amount": null,
-        "buildType": null,
-        "consumes": null,
-        "deployable": null,
-        "hints": null,
-        "idl": null,
         "key": "intro",
-        "language": null,
-        "maxWords": null,
-        "network": null,
+        "_type": "prose",
         "produces": null,
-        "prompt": null,
-        "questions": null,
-        "solution": null,
+        "consumes": null,
         "src": "# React Patterns for Solana dApps\n\nBuilding Solana frontends requires handling asynchronous blockchain operations gracefully. Let's explore essential React patterns for production-ready dApps.\n\n## Loading States\n\nBlockchain operations are async and can take seconds. Always show loading feedback:\n\n```typescript\nfunction BalanceDisplay() {\n  const { publicKey } = useWallet();\n  const { connection } = useConnection();\n  const [balance, setBalance] = useState<number | null>(null);\n  const [loading, setLoading] = useState(true);\n\n  useEffect(() => {\n    if (!publicKey) {\n      setBalance(null);\n      setLoading(false);\n      return;\n    }\n\n    setLoading(true);\n    connection.getBalance(publicKey)\n      .then(lamports => setBalance(lamports / LAMPORTS_PER_SOL))\n      .catch(err => console.error(err))\n      .finally(() => setLoading(false));\n  }, [publicKey, connection]);\n\n  if (loading) return <Spinner />;\n  if (!publicKey) return <p>Connect your wallet</p>;\n  \n  return <p>Balance: {balance?.toFixed(4)} SOL</p>;\n}\n```\n\n## Error Handling\n\nNetwork errors, rejected transactions, and insufficient funds are common. Handle them explicitly:\n\n```typescript\nfunction TransferForm() {\n  const [error, setError] = useState<string | null>(null);\n  const [sending, setSending] = useState(false);\n\n  async function handleTransfer() {\n    setError(null);\n    setSending(true);\n\n    try {\n      const signature = await sendTransaction(transaction, connection);\n      await connection.confirmTransaction(signature);\n      toast.success(`Transfer successful! ${signature}`);\n    } catch (err) {\n      if (err instanceof Error) {\n        if (err.message.includes('insufficient')) {\n          setError('Insufficient SOL balance for this transaction');\n        } else if (err.message.includes('rejected')) {\n          setError('Transaction rejected by wallet');\n        } else {\n          setError('Transaction failed. Please try again.');\n        }\n      }\n    } finally {\n      setSending(false);\n    }\n  }\n\n  return (\n    <div>\n      <button onClick={handleTransfer} disabled={sending}>\n        {sending ? 'Sending...' : 'Send SOL'}\n      </button>\n      {error && <ErrorAlert>{error}</ErrorAlert>}\n    </div>\n  );\n}\n```\n\n## Optimistic Updates\n\nUpdate UI immediately while the transaction confirms in the background:\n\n```typescript\nfunction LikeButton({ postId }: { postId: string }) {\n  const [likes, setLikes] = useState(42);\n  const [hasLiked, setHasLiked] = useState(false);\n\n  async function handleLike() {\n    // Optimistic update\n    setLikes(prev => prev + 1);\n    setHasLiked(true);\n\n    try {\n      // Send transaction\n      const signature = await sendLikeTransaction(postId);\n      await connection.confirmTransaction(signature);\n    } catch (err) {\n      // Revert on error\n      setLikes(prev => prev - 1);\n      setHasLiked(false);\n      toast.error('Failed to like post');\n    }\n  }\n\n  return (\n    <button onClick={handleLike} disabled={hasLiked}>\n      {hasLiked ? 'Liked!' : 'Like'} ({likes})\n    </button>\n  );\n}\n```\n\n## Data Fetching with React Query\n\n`@tanstack/react-query` is perfect for caching blockchain data:\n\n```typescript\nimport { useQuery } from '@tanstack/react-query';\n\nfunction useWalletBalance(publicKey: PublicKey | null) {\n  const { connection } = useConnection();\n\n  return useQuery({\n    queryKey: ['balance', publicKey?.toBase58()],\n    queryFn: async () => {\n      if (!publicKey) return null;\n      const lamports = await connection.getBalance(publicKey);\n      return lamports / LAMPORTS_PER_SOL;\n    },\n    enabled: !!publicKey,\n    staleTime: 30_000, // Consider fresh for 30s\n    refetchInterval: 60_000, // Auto-refresh every 60s\n  });\n}\n\n// Usage\nfunction BalanceCard() {\n  const { publicKey } = useWallet();\n  const { data: balance, isLoading, error } = useWalletBalance(publicKey);\n\n  if (isLoading) return <Skeleton />;\n  if (error) return <ErrorState />;\n  \n  return <p>{balance?.toFixed(4)} SOL</p>;\n}\n```\n\n## Subscription Pattern for Real-Time Updates\n\nUse WebSocket subscriptions for instant updates:\n\n```typescript\nfunction useAccountSubscription(publicKey: PublicKey | null) {\n  const { connection } = useConnection();\n  const [accountInfo, setAccountInfo] = useState<AccountInfo<Buffer> | null>(null);\n\n  useEffect(() => {\n    if (!publicKey) return;\n\n    const subscriptionId = connection.onAccountChange(\n      publicKey,\n      (updatedAccountInfo) => {\n        setAccountInfo(updatedAccountInfo);\n      },\n      'confirmed'\n    );\n\n    // Cleanup on unmount\n    return () => {\n      connection.removeAccountChangeListener(subscriptionId);\n    };\n  }, [publicKey, connection]);\n\n  return accountInfo;\n}\n```\n\n## Debouncing User Input\n\nValidate addresses without overwhelming the RPC:\n\n```typescript\nimport { useDebouncedValue } from '@/hooks/useDebouncedValue';\n\nfunction RecipientInput() {\n  const [address, setAddress] = useState('');\n  const debouncedAddress = useDebouncedValue(address, 500);\n  const [isValid, setIsValid] = useState<boolean | null>(null);\n\n  useEffect(() => {\n    if (!debouncedAddress) {\n      setIsValid(null);\n      return;\n    }\n\n    try {\n      new PublicKey(debouncedAddress);\n      setIsValid(true);\n    } catch {\n      setIsValid(false);\n    }\n  }, [debouncedAddress]);\n\n  return (\n    <div>\n      <input\n        value={address}\n        onChange={(e) => setAddress(e.target.value)}\n        placeholder=\"Recipient address\"\n      />\n      {isValid === false && <Error>Invalid Solana address</Error>}\n      {isValid === true && <Success>Valid address</Success>}\n    </div>\n  );\n}\n```\n\n## Best Practices Summary\n\n1. Always show loading states for async operations\n2. Handle errors gracefully with user-friendly messages\n3. Use optimistic updates for instant UX feedback\n4. Cache blockchain data to reduce RPC calls\n5. Debounce user input validation\n6. Use WebSocket subscriptions for real-time updates\n7. Clean up subscriptions on component unmount\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
         "starter": null,
+        "solution": null,
         "tests": null,
-        "url": null
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       }
-    ],
-    "slug": "react-patterns",
-    "title": "React Patterns for Solana dApps"
+    ]
   },
   {
     "_id": "lesson-rpc-methods",
+    "title": "Solana RPC Methods",
+    "slug": "rpc-methods",
     "blocks": [
       {
-        "_type": "prose",
-        "amount": null,
-        "buildType": null,
-        "consumes": null,
-        "deployable": null,
-        "hints": null,
-        "idl": null,
         "key": "intro",
-        "language": null,
-        "maxWords": null,
-        "network": null,
+        "_type": "prose",
         "produces": null,
-        "prompt": null,
-        "questions": null,
-        "solution": null,
+        "consumes": null,
         "src": "# Solana RPC Methods\n\nThe Solana JSON-RPC API is how your frontend communicates with the blockchain. Understanding RPC methods is essential for reading on-chain data.\n\n## What is JSON-RPC?\n\nJSON-RPC is a lightweight remote procedure call protocol. You send a JSON request to a Solana validator node and get a JSON response:\n\n```javascript\n// Request\n{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 1,\n  \"method\": \"getBalance\",\n  \"params\": [\"7C4jsPZpht42Tw6MjXWF56Q5RQUocjBBmciEjDa8HRtp\"]\n}\n\n// Response\n{\n  \"jsonrpc\": \"2.0\",\n  \"result\": { \"value\": 1000000000 },\n  \"id\": 1\n}\n```\n\nThe `@solana/web3.js` library wraps these RPC calls in convenient JavaScript methods.\n\n## The Connection Object\n\n```typescript\nimport { Connection, clusterApiUrl } from '@solana/web3.js';\n\nconst connection = new Connection(\n  clusterApiUrl('devnet'),\n  'confirmed' // commitment level\n);\n```\n\n**RPC Endpoints**:\n- **Devnet**: `https://api.devnet.solana.com`\n- **Mainnet**: `https://api.mainnet-beta.solana.com`\n- **Custom**: Helius, QuickNode, Alchemy (faster, more reliable)\n\n## Essential RPC Methods\n\n### getBalance()\n\nGet SOL balance in lamports:\n\n```typescript\nconst balance = await connection.getBalance(publicKey);\nconsole.log(`Balance: ${balance / LAMPORTS_PER_SOL} SOL`);\n```\n\n### getAccountInfo()\n\nGet full account details:\n\n```typescript\nconst accountInfo = await connection.getAccountInfo(publicKey);\n\nif (accountInfo) {\n  console.log('Owner:', accountInfo.owner.toBase58());\n  console.log('Lamports:', accountInfo.lamports);\n  console.log('Data:', accountInfo.data);\n  console.log('Executable:', accountInfo.executable);\n}\n```\n\n### getTransaction()\n\nFetch a transaction by signature:\n\n```typescript\nconst tx = await connection.getTransaction(signature, {\n  maxSupportedTransactionVersion: 0,\n});\n\nif (tx) {\n  console.log('Slot:', tx.slot);\n  console.log('Block Time:', new Date(tx.blockTime! * 1000));\n  console.log('Fee:', tx.meta?.fee);\n}\n```\n\n### getLatestBlockhash()\n\nRequired for constructing transactions:\n\n```typescript\nconst { blockhash } = await connection.getLatestBlockhash();\ntransaction.recentBlockhash = blockhash;\n```\n\n## Commitment Levels\n\nCommitment levels define how finalized a transaction must be:\n\n| Level | Finalized? | Use Case |\n|-------|-----------|----------|\n| **processed** | No | Real-time updates (may be rolled back) |\n| **confirmed** | Partially | Most dApp reads (balance checks, etc.) |\n| **finalized** | Yes | High-value transactions, withdrawals |\n\n```typescript\nconst balance = await connection.getBalance(\n  publicKey,\n  'confirmed' // commitment level\n);\n```\n\n**Best Practice**: Use `'confirmed'` for UI updates, `'finalized'` for critical operations.\n\n## Advanced: getProgramAccounts()\n\nFetch all accounts owned by a program:\n\n```typescript\nconst TOKEN_PROGRAM_ID = new PublicKey(\n  'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'\n);\n\nconst tokenAccounts = await connection.getProgramAccounts(\n  TOKEN_PROGRAM_ID,\n  {\n    filters: [\n      { dataSize: 165 }, // Token account size\n      {\n        memcmp: {\n          offset: 32, // Owner field offset\n          bytes: userPublicKey.toBase58(),\n        },\n      },\n    ],\n  }\n);\n\nconsole.log(`Found ${tokenAccounts.length} token accounts`);\n```\n\n## Rate Limits and Best Practices\n\nPublic RPC endpoints have strict rate limits:\n- **Devnet**: ~100 requests/10 seconds\n- **Mainnet**: ~40 requests/10 seconds\n\n**Solutions**:\n1. Use premium RPC providers (Helius, QuickNode)\n2. Implement request caching (React Query, SWR)\n3. Batch requests where possible\n4. Use WebSocket subscriptions for real-time data\n\n## WebSocket Subscriptions\n\nFor real-time updates, use subscriptions instead of polling:\n\n```typescript\nconst subscriptionId = connection.onAccountChange(\n  publicKey,\n  (accountInfo) => {\n    console.log('Account changed!', accountInfo);\n  },\n  'confirmed'\n);\n\n// Cleanup\nconnection.removeAccountChangeListener(subscriptionId);\n```\n\n## Next Steps\n\nIn the next challenge, you'll use `getBalance()` to build a multi-wallet balance checker.\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
         "starter": null,
+        "solution": null,
         "tests": null,
-        "url": null
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       }
-    ],
-    "slug": "rpc-methods",
-    "title": "Solana RPC Methods"
+    ]
   },
   {
     "_id": "lesson-rust-basics-challenge",
+    "title": "Challenge: Rust Structs & Methods",
+    "slug": "rust-basics-challenge",
     "blocks": [
       {
-        "_type": "prose",
-        "amount": null,
-        "buildType": null,
-        "consumes": null,
-        "deployable": null,
-        "hints": null,
-        "idl": null,
         "key": "intro",
-        "language": null,
-        "maxWords": null,
-        "network": null,
+        "_type": "prose",
         "produces": null,
-        "prompt": null,
-        "questions": null,
-        "solution": null,
+        "consumes": null,
         "src": "# Challenge: Build a Solana Account Struct\n\nApply what you've learned about Rust ownership, structs, and methods. You'll create a `SolanaAccount` struct that models an on-chain account with balance management.\n\n## Your Task\n\nComplete the `SolanaAccount` struct and its methods, then implement `create_and_withdraw` which:\n1. Creates a new `SolanaAccount` using `SolanaAccount::new(owner, initial_balance)`\n2. Attempts to withdraw `withdraw_amount`\n3. Returns a `String` describing the result\n\n**Requirements:**\n- `new()` creates an account that is **not frozen** by default\n- `withdraw()` returns `Err(\"Account is frozen\")` if the account is frozen\n- `withdraw()` returns `Err(\"Insufficient balance\")` if `amount > balance`\n- `withdraw()` subtracts the amount and returns `Ok(remaining_balance)`\n- `create_and_withdraw` formats the result as `\"OK:<remaining>\"` or `\"ERR:<message>\"`\n\n**Rust Concepts Used:**\n- Structs with `impl` blocks\n- `Result<T, E>` return type\n- Pattern matching with `match`\n- String formatting with `format!()`\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
         "starter": null,
+        "solution": null,
         "tests": null,
-        "url": null
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       },
       {
+        "key": "exercise",
         "_type": "code",
-        "amount": null,
-        "buildType": "standard",
+        "produces": null,
         "consumes": null,
+        "src": null,
+        "url": null,
+        "language": "rust",
+        "buildType": "standard",
         "deployable": false,
+        "starter": "#[derive(Debug, PartialEq)]\nstruct SolanaAccount {\n    owner: String,\n    balance: u64,\n    is_frozen: bool,\n}\n\nimpl SolanaAccount {\n    fn new(owner: &str, balance: u64) -> Self {\n        // TODO: Create a new account (not frozen by default)\n        todo!()\n    }\n\n    fn withdraw(&mut self, amount: u64) -> Result<u64, String> {\n        // TODO: Return Err if frozen\n        // TODO: Return Err if insufficient balance\n        // TODO: Subtract amount and return Ok(remaining)\n        todo!()\n    }\n}\n\nfn create_and_withdraw(owner: &str, initial_balance: u64, withdraw_amount: u64) -> String {\n    let mut account = SolanaAccount::new(owner, initial_balance);\n    match account.withdraw(withdraw_amount) {\n        Ok(remaining) => format!(\"OK:{}\", remaining),\n        Err(e) => format!(\"ERR:{}\", e),\n    }\n}\n",
+        "solution": "#[derive(Debug, PartialEq)]\nstruct SolanaAccount {\n    owner: String,\n    balance: u64,\n    is_frozen: bool,\n}\n\nimpl SolanaAccount {\n    fn new(owner: &str, balance: u64) -> Self {\n        SolanaAccount {\n            owner: owner.to_string(),\n            balance,\n            is_frozen: false,\n        }\n    }\n\n    fn withdraw(&mut self, amount: u64) -> Result<u64, String> {\n        if self.is_frozen {\n            return Err(\"Account is frozen\".to_string());\n        }\n        if amount > self.balance {\n            return Err(\"Insufficient balance\".to_string());\n        }\n        self.balance -= amount;\n        Ok(self.balance)\n    }\n}\n\nfn create_and_withdraw(owner: &str, initial_balance: u64, withdraw_amount: u64) -> String {\n    let mut account = SolanaAccount::new(owner, initial_balance);\n    match account.withdraw(withdraw_amount) {\n        Ok(remaining) => format!(\"OK:{}\", remaining),\n        Err(e) => format!(\"ERR:{}\", e),\n    }\n}\n",
+        "tests": [
+          {
+            "id": "t1",
+            "description": "Successful withdrawal returns remaining balance",
+            "input": "\"Alice\", 1000, 300",
+            "expectedOutput": "\"OK:700\".to_string()"
+          },
+          {
+            "id": "t2",
+            "description": "Over-withdrawal returns an error",
+            "input": "\"Bob\", 500, 600",
+            "expectedOutput": "__result__.starts_with(\"ERR:\")"
+          },
+          {
+            "id": "t3",
+            "description": "Withdrawing the full balance returns OK:0",
+            "input": "\"Charlie\", 1000, 1000",
+            "expectedOutput": "\"OK:0\".to_string()"
+          },
+          {
+            "id": "t4",
+            "description": "Correct remaining balance for a different withdrawal",
+            "input": "\"Dave\", 750, 250",
+            "expectedOutput": "\"OK:500\".to_string()"
+          }
+        ],
         "hints": [
           "In new(), return SolanaAccount { owner: owner.to_string(), balance, is_frozen: false }",
           "In withdraw(), check self.is_frozen first, then check if amount > self.balance. Both should return Err(...).",
           "After validation, subtract: self.balance -= amount; and return Ok(self.balance)."
         ],
-        "idl": null,
-        "key": "exercise",
-        "language": "rust",
-        "maxWords": null,
-        "network": null,
-        "produces": null,
-        "prompt": null,
         "questions": null,
-        "solution": "#[derive(Debug, PartialEq)]\nstruct SolanaAccount {\n    owner: String,\n    balance: u64,\n    is_frozen: bool,\n}\n\nimpl SolanaAccount {\n    fn new(owner: &str, balance: u64) -> Self {\n        SolanaAccount {\n            owner: owner.to_string(),\n            balance,\n            is_frozen: false,\n        }\n    }\n\n    fn withdraw(&mut self, amount: u64) -> Result<u64, String> {\n        if self.is_frozen {\n            return Err(\"Account is frozen\".to_string());\n        }\n        if amount > self.balance {\n            return Err(\"Insufficient balance\".to_string());\n        }\n        self.balance -= amount;\n        Ok(self.balance)\n    }\n}\n\nfn create_and_withdraw(owner: &str, initial_balance: u64, withdraw_amount: u64) -> String {\n    let mut account = SolanaAccount::new(owner, initial_balance);\n    match account.withdraw(withdraw_amount) {\n        Ok(remaining) => format!(\"OK:{}\", remaining),\n        Err(e) => format!(\"ERR:{}\", e),\n    }\n}\n",
-        "src": null,
-        "starter": "#[derive(Debug, PartialEq)]\nstruct SolanaAccount {\n    owner: String,\n    balance: u64,\n    is_frozen: bool,\n}\n\nimpl SolanaAccount {\n    fn new(owner: &str, balance: u64) -> Self {\n        // TODO: Create a new account (not frozen by default)\n        todo!()\n    }\n\n    fn withdraw(&mut self, amount: u64) -> Result<u64, String> {\n        // TODO: Return Err if frozen\n        // TODO: Return Err if insufficient balance\n        // TODO: Subtract amount and return Ok(remaining)\n        todo!()\n    }\n}\n\nfn create_and_withdraw(owner: &str, initial_balance: u64, withdraw_amount: u64) -> String {\n    let mut account = SolanaAccount::new(owner, initial_balance);\n    match account.withdraw(withdraw_amount) {\n        Ok(remaining) => format!(\"OK:{}\", remaining),\n        Err(e) => format!(\"ERR:{}\", e),\n    }\n}\n",
-        "tests": [
-          {
-            "description": "Successful withdrawal returns remaining balance",
-            "expectedOutput": "\"OK:700\".to_string()",
-            "id": "t1",
-            "input": "\"Alice\", 1000, 300"
-          },
-          {
-            "description": "Over-withdrawal returns an error",
-            "expectedOutput": "__result__.starts_with(\"ERR:\")",
-            "id": "t2",
-            "input": "\"Bob\", 500, 600"
-          },
-          {
-            "description": "Withdrawing the full balance returns OK:0",
-            "expectedOutput": "\"OK:0\".to_string()",
-            "id": "t3",
-            "input": "\"Charlie\", 1000, 1000"
-          },
-          {
-            "description": "Correct remaining balance for a different withdrawal",
-            "expectedOutput": "\"OK:500\".to_string()",
-            "id": "t4",
-            "input": "\"Dave\", 750, 250"
-          }
-        ],
-        "url": null
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       }
-    ],
-    "slug": "rust-basics-challenge",
-    "title": "Challenge: Rust Structs & Methods"
+    ]
   },
   {
     "_id": "lesson-rust-program-challenge",
+    "title": "Challenge: Process Transfer Instruction",
+    "slug": "rust-program-challenge",
     "blocks": [
       {
-        "_type": "prose",
-        "amount": null,
-        "buildType": null,
-        "consumes": null,
-        "deployable": null,
-        "hints": null,
-        "idl": null,
         "key": "intro",
-        "language": null,
-        "maxWords": null,
-        "network": null,
+        "_type": "prose",
         "produces": null,
-        "prompt": null,
-        "questions": null,
-        "solution": null,
+        "consumes": null,
         "src": "# Challenge: Process a Transfer Instruction\n\nSimulate Solana's `process_instruction` pattern in pure Rust. You'll process a transfer by validating balances, deducting fees, and returning updated state.\n\n## Your Task\n\nImplement `process_transfer(sender_balance, recipient_balance, amount, fee)` that:\n\n1. Checks the sender can afford `amount + fee`\n2. If not, returns `Err(\"INSUFFICIENT_BALANCE\")`\n3. If yes, computes new balances and returns `Ok((new_sender, new_recipient))`\n\n**Requirements:**\n- Sender pays both the transfer amount AND the fee\n- Recipient receives only the amount (not the fee)\n- The fee is burned (deducted from sender, not added anywhere)\n- Use checked arithmetic to prevent overflow\n\n**This mirrors how Solana programs work:**\n- `process_instruction` receives account balances\n- Validates preconditions\n- Mutates balances\n- Returns success or error\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
         "starter": null,
+        "solution": null,
         "tests": null,
-        "url": null
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       },
       {
+        "key": "exercise",
         "_type": "code",
-        "amount": null,
-        "buildType": "standard",
+        "produces": null,
         "consumes": null,
+        "src": null,
+        "url": null,
+        "language": "rust",
+        "buildType": "standard",
         "deployable": false,
+        "starter": "fn process_transfer(\n    sender_balance: u64,\n    recipient_balance: u64,\n    amount: u64,\n    fee: u64,\n) -> Result<(u64, u64), String> {\n    // TODO: Check sender can afford amount + fee\n\n    // TODO: Calculate new sender balance (subtract amount and fee)\n\n    // TODO: Calculate new recipient balance (add amount)\n\n    // TODO: Return Ok((new_sender, new_recipient))\n    todo!()\n}\n",
+        "solution": "fn process_transfer(\n    sender_balance: u64,\n    recipient_balance: u64,\n    amount: u64,\n    fee: u64,\n) -> Result<(u64, u64), String> {\n    let total_cost = amount.checked_add(fee)\n        .ok_or_else(|| \"Overflow\".to_string())?;\n    if sender_balance < total_cost {\n        return Err(\"INSUFFICIENT_BALANCE\".to_string());\n    }\n    let new_sender = sender_balance - total_cost;\n    let new_recipient = recipient_balance + amount;\n    Ok((new_sender, new_recipient))\n}\n",
+        "tests": [
+          {
+            "id": "t1",
+            "description": "Deducts amount + fee, credits recipient",
+            "input": "1000, 500, 200, 5",
+            "expectedOutput": "Ok((795, 700))"
+          },
+          {
+            "id": "t2",
+            "description": "Insufficient balance fails",
+            "input": "100, 0, 100, 5",
+            "expectedOutput": "__result__.is_err()"
+          },
+          {
+            "id": "t3",
+            "description": "Handles zero fee and exact drain",
+            "input": "500, 200, 500, 0",
+            "expectedOutput": "Ok((0, 700))"
+          },
+          {
+            "id": "t4",
+            "description": "Correct balances for a different transfer",
+            "input": "2000, 1000, 300, 50",
+            "expectedOutput": "Ok((1650, 1300))"
+          }
+        ],
         "hints": [
           "First check: if sender_balance < amount + fee (use checked_add to prevent overflow, or just amount + fee if you trust the inputs).",
           "New sender balance = sender_balance - amount - fee. New recipient balance = recipient_balance + amount.",
           "Return Ok((new_sender_balance, new_recipient_balance)) on success."
         ],
-        "idl": null,
-        "key": "exercise",
-        "language": "rust",
-        "maxWords": null,
-        "network": null,
-        "produces": null,
-        "prompt": null,
         "questions": null,
-        "solution": "fn process_transfer(\n    sender_balance: u64,\n    recipient_balance: u64,\n    amount: u64,\n    fee: u64,\n) -> Result<(u64, u64), String> {\n    let total_cost = amount.checked_add(fee)\n        .ok_or_else(|| \"Overflow\".to_string())?;\n    if sender_balance < total_cost {\n        return Err(\"INSUFFICIENT_BALANCE\".to_string());\n    }\n    let new_sender = sender_balance - total_cost;\n    let new_recipient = recipient_balance + amount;\n    Ok((new_sender, new_recipient))\n}\n",
-        "src": null,
-        "starter": "fn process_transfer(\n    sender_balance: u64,\n    recipient_balance: u64,\n    amount: u64,\n    fee: u64,\n) -> Result<(u64, u64), String> {\n    // TODO: Check sender can afford amount + fee\n\n    // TODO: Calculate new sender balance (subtract amount and fee)\n\n    // TODO: Calculate new recipient balance (add amount)\n\n    // TODO: Return Ok((new_sender, new_recipient))\n    todo!()\n}\n",
-        "tests": [
-          {
-            "description": "Deducts amount + fee, credits recipient",
-            "expectedOutput": "Ok((795, 700))",
-            "id": "t1",
-            "input": "1000, 500, 200, 5"
-          },
-          {
-            "description": "Insufficient balance fails",
-            "expectedOutput": "__result__.is_err()",
-            "id": "t2",
-            "input": "100, 0, 100, 5"
-          },
-          {
-            "description": "Handles zero fee and exact drain",
-            "expectedOutput": "Ok((0, 700))",
-            "id": "t3",
-            "input": "500, 200, 500, 0"
-          },
-          {
-            "description": "Correct balances for a different transfer",
-            "expectedOutput": "Ok((1650, 1300))",
-            "id": "t4",
-            "input": "2000, 1000, 300, 50"
-          }
-        ],
-        "url": null
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       }
-    ],
-    "slug": "rust-program-challenge",
-    "title": "Challenge: Process Transfer Instruction"
+    ]
   },
   {
     "_id": "lesson-serialization",
+    "title": "Borsh Serialization for Solana",
+    "slug": "serialization",
     "blocks": [
       {
-        "_type": "prose",
-        "amount": null,
-        "buildType": null,
-        "consumes": null,
-        "deployable": null,
-        "hints": null,
-        "idl": null,
         "key": "intro",
-        "language": null,
-        "maxWords": null,
-        "network": null,
+        "_type": "prose",
         "produces": null,
-        "prompt": null,
-        "questions": null,
-        "solution": null,
+        "consumes": null,
         "src": "# Borsh Serialization for Solana\n\nSolana programs store data in accounts as raw bytes. To work with structured data (structs, enums), you need a serialization format. Solana uses **Borsh** (Binary Object Representation Serializer for Hashing).\n\n## Why Borsh?\n\nBorsh was designed specifically for blockchain use cases and offers several advantages over alternatives like JSON or MessagePack:\n\n### 1. Deterministic Serialization\n\nThe same data **always** produces the same byte sequence. This is critical for:\n- **Consensus**: All validators must agree on account state\n- **Hashing**: Content-addressed storage requires consistent hashes\n- **Merkle proofs**: Deterministic encoding enables efficient proofs\n\n```rust\n// JSON is NOT deterministic (field order can vary):\n{\"balance\": 100, \"owner\": \"abc\"} vs {\"owner\": \"abc\", \"balance\": 100}\n\n// Borsh IS deterministic:\nstruct { balance: 100, owner: \"abc\" } → always [100, 0, 0, 0, 3, 0, 0, 0, 97, 98, 99]\n```\n\n### 2. Compact Encoding\n\nBorsh doesn't include field names or type metadata in the output:\n\n```json\n// JSON: 42 bytes\n{\"balance\":1000000,\"frozen\":false}\n\n// Borsh: 9 bytes (4 for u64 + 4 for length prefix + 1 for bool)\n```\n\nSolana charges rent based on account size, so smaller serialization = lower costs.\n\n### 3. Fixed vs Variable-Size Data\n\n**Fixed-size types** (primitives) have a known byte length:\n- `u8`: 1 byte\n- `u32`, `i32`: 4 bytes\n- `u64`, `i64`: 8 bytes\n- `bool`: 1 byte (0 or 1)\n- `[u8; 32]`: 32 bytes (fixed array)\n\n**Variable-size types** include a 4-byte length prefix:\n- `String`: 4-byte length + UTF-8 bytes\n- `Vec<T>`: 4-byte length + serialized elements\n- `Option<T>`: 1-byte discriminant (0 or 1) + value if Some\n\n```rust\n// Example encoding:\nlet name = \"Alice\"; // Borsh: [5, 0, 0, 0, 65, 108, 105, 99, 101]\n                    //         ^^^^len=5  ^^^^UTF-8 bytes\n\nlet numbers = vec![1u32, 2, 3]; // [3, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0]\n                                //  ^^^^len=3  ^^^^^^^^^^ three u32s\n```\n\n## How Solana Uses Borsh\n\n### Account Data\n\nPrograms deserialize account data at the start of `process_instruction`:\n\n```rust\nlet user_account = UserAccount::try_from_slice(&account.data.borrow())?;\n```\n\nAfter modifying the struct, serialize it back:\n\n```rust\nuser_account.balance += amount;\nuser_account.serialize(&mut &mut account.data.borrow_mut()[..])?;\n```\n\n### Instruction Data\n\nClients serialize instructions before sending transactions:\n\n```rust\nlet instruction = TokenInstruction::Transfer { amount: 1000 };\nlet data = instruction.try_to_vec()?; // Serialize to bytes\n```\n\nThe program deserializes it to determine which function to call:\n\n```rust\nlet instruction = TokenInstruction::try_from_slice(instruction_data)?;\nmatch instruction { /* ... */ }\n```\n\n## Comparison with JSON\n\n| Feature | Borsh | JSON |\n|---------|-------|------|\n| Deterministic | ✅ Yes | ❌ No (field order) |\n| Size | Small (no field names) | Large (verbose) |\n| Speed | Fast (binary) | Slow (text parsing) |\n| Human-readable | ❌ No | ✅ Yes |\n| Schema required | ✅ Yes (Rust structs) | ❌ No |\n\nJSON is great for APIs and config files, but Borsh is the clear winner for on-chain data.\n\n## Next Steps\n\nIn the next challenge, you'll manually serialize and deserialize data using JavaScript's `DataView` and `TextEncoder` to understand how Borsh encoding works under the hood.\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
         "starter": null,
+        "solution": null,
         "tests": null,
-        "url": null
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "retrieval-close",
+        "_type": "quiz",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": [
+          {
+            "id": "q1",
+            "prompt": "A struct has a `Pubkey` (a 32-byte array) and a `String` field holding the name Alice. How many bytes does the String occupy in Borsh, and why?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "9 bytes — a 4-byte length prefix (value 5) plus 5 UTF-8 bytes",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "5 bytes — just the UTF-8 characters",
+                "correct": false,
+                "feedback": "Variable-length types add a 4-byte length prefix so the decoder knows where the field ends. Alice is 4 + 5 = 9 bytes."
+              },
+              {
+                "id": "c",
+                "label": "32 bytes — strings are padded to a fixed size",
+                "correct": false,
+                "feedback": "Borsh does not pad strings. A `String` is a 4-byte length prefix plus its UTF-8 bytes: here 4 + 5 = 9."
+              }
+            ],
+            "explanation": "Fixed-size types (like a 32-byte array) encode as exactly their byte length; variable-size types (`String`, `Vec`, `Option`) carry a length or discriminant prefix so the decoder knows how far to read. The name Alice is a 4-byte length (5) plus 5 UTF-8 bytes = 9."
+          },
+          {
+            "id": "q2",
+            "prompt": "Borsh is chosen over JSON for on-chain data largely because it is deterministic. Why does determinism matter here specifically?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "All validators must agree on identical account bytes and hashes; non-deterministic field order would break consensus",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "Determinism makes the data human-readable",
+                "correct": false,
+                "feedback": "Determinism is about reproducible bytes, not readability. JSON is the readable one; Borsh trades that away for consensus-safe encoding."
+              },
+              {
+                "id": "c",
+                "label": "It lets the program skip validating the data",
+                "correct": false,
+                "feedback": "Determinism does not remove the need to validate. It ensures every node encodes the same value to the same bytes, which consensus and hashing require."
+              }
+            ],
+            "explanation": "Consensus needs every validator to derive the same account state and the same hashes from the same value. JSON can vary field order, producing different bytes for equal data; Borsh always yields one canonical byte sequence, which is why it underpins account state and Merkle proofs."
+          }
+        ],
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       }
-    ],
-    "slug": "serialization",
-    "title": "Borsh Serialization for Solana"
+    ]
   },
   {
     "_id": "lesson-serialization-challenge",
+    "title": "Challenge: Serialize Account Data",
+    "slug": "serialization-challenge",
     "blocks": [
       {
-        "_type": "prose",
-        "amount": null,
-        "buildType": null,
-        "consumes": null,
-        "deployable": null,
-        "hints": null,
-        "idl": null,
         "key": "intro",
-        "language": null,
-        "maxWords": null,
-        "network": null,
+        "_type": "prose",
         "produces": null,
-        "prompt": null,
-        "questions": null,
-        "solution": null,
+        "consumes": null,
         "src": "# Challenge: Manual Borsh-Style Serialization in Rust\n\nTo truly understand how Borsh works under the hood, you'll manually serialize account data to bytes using Rust's standard library.\n\n## Your Task\n\nImplement `serialize_account(owner, balance, frozen)` that converts account fields to a `Vec<u8>` with this Borsh-like layout:\n\n- **4 bytes**: owner name length as `u32` (little-endian)\n- **N bytes**: owner name as UTF-8 bytes\n- **8 bytes**: balance as `u64` (little-endian)\n- **1 byte**: frozen flag (`0` = false, `1` = true)\n\n**Requirements:**\n- Use `u32::to_le_bytes()` for the length prefix\n- Use `.as_bytes()` to get UTF-8 bytes from a `&str`\n- Use `u64::to_le_bytes()` for the balance\n- Push `0u8` or `1u8` for the boolean\n- Total size should be `4 + owner.len() + 8 + 1` bytes\n\n**Rust APIs:**\n- `Vec::new()`, `Vec::extend_from_slice()`\n- `u32::to_le_bytes()`, `u64::to_le_bytes()`\n- `str::as_bytes()`, `str::len()`\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
         "starter": null,
+        "solution": null,
         "tests": null,
-        "url": null
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       },
       {
+        "key": "exercise",
         "_type": "code",
-        "amount": null,
-        "buildType": "standard",
+        "produces": null,
         "consumes": null,
+        "src": null,
+        "url": null,
+        "language": "rust",
+        "buildType": "standard",
         "deployable": false,
+        "starter": "/// Serialize account data to bytes (Borsh-like layout):\n/// [4-byte owner_len][owner UTF-8 bytes][8-byte balance LE][1-byte frozen]\nfn serialize_account(owner: &str, balance: u64, frozen: bool) -> Vec<u8> {\n    // TODO: Create a new Vec<u8>\n    // TODO: Write owner length as u32 little-endian (4 bytes)\n    // TODO: Write owner string as UTF-8 bytes\n    // TODO: Write balance as u64 little-endian (8 bytes)\n    // TODO: Write frozen as 0 or 1 (1 byte)\n    todo!()\n}\n",
+        "solution": "fn serialize_account(owner: &str, balance: u64, frozen: bool) -> Vec<u8> {\n    let mut buf = Vec::new();\n    // Write owner length as u32 little-endian\n    buf.extend_from_slice(&(owner.len() as u32).to_le_bytes());\n    // Write owner as UTF-8 bytes\n    buf.extend_from_slice(owner.as_bytes());\n    // Write balance as u64 little-endian\n    buf.extend_from_slice(&balance.to_le_bytes());\n    // Write frozen flag\n    buf.push(if frozen { 1 } else { 0 });\n    buf\n}\n",
+        "tests": [
+          {
+            "id": "t1",
+            "description": "Serialized length for a 5-char owner",
+            "input": "\"Alice\", 1000, false",
+            "expectedOutput": "__result__.len() == 18"
+          },
+          {
+            "id": "t2",
+            "description": "Serialized length for a 3-char owner",
+            "input": "\"Bob\", 42, true",
+            "expectedOutput": "__result__.len() == 16"
+          },
+          {
+            "id": "t3",
+            "description": "Owner bytes start at offset 4",
+            "input": "\"Alice\", 1000, false",
+            "expectedOutput": "__result__[4] == b'A'"
+          },
+          {
+            "id": "t4",
+            "description": "Correct layout for a different input (len prefix, owner, frozen flag)",
+            "input": "\"Sol\", 7, true",
+            "expectedOutput": "__result__[0] == 3 && __result__[4] == b'S' && __result__[15] == 1"
+          }
+        ],
         "hints": [
           "Start with let mut buf = Vec::new(); then use buf.extend_from_slice(&(owner.len() as u32).to_le_bytes()) for the 4-byte length prefix.",
           "Append the owner bytes with buf.extend_from_slice(owner.as_bytes()), then the balance with buf.extend_from_slice(&balance.to_le_bytes()).",
           "Finally push the frozen flag: buf.push(if frozen { 1 } else { 0 }); and return buf."
         ],
-        "idl": null,
-        "key": "exercise",
-        "language": "rust",
-        "maxWords": null,
-        "network": null,
-        "produces": null,
-        "prompt": null,
         "questions": null,
-        "solution": "fn serialize_account(owner: &str, balance: u64, frozen: bool) -> Vec<u8> {\n    let mut buf = Vec::new();\n    // Write owner length as u32 little-endian\n    buf.extend_from_slice(&(owner.len() as u32).to_le_bytes());\n    // Write owner as UTF-8 bytes\n    buf.extend_from_slice(owner.as_bytes());\n    // Write balance as u64 little-endian\n    buf.extend_from_slice(&balance.to_le_bytes());\n    // Write frozen flag\n    buf.push(if frozen { 1 } else { 0 });\n    buf\n}\n",
-        "src": null,
-        "starter": "/// Serialize account data to bytes (Borsh-like layout):\n/// [4-byte owner_len][owner UTF-8 bytes][8-byte balance LE][1-byte frozen]\nfn serialize_account(owner: &str, balance: u64, frozen: bool) -> Vec<u8> {\n    // TODO: Create a new Vec<u8>\n    // TODO: Write owner length as u32 little-endian (4 bytes)\n    // TODO: Write owner string as UTF-8 bytes\n    // TODO: Write balance as u64 little-endian (8 bytes)\n    // TODO: Write frozen as 0 or 1 (1 byte)\n    todo!()\n}\n",
-        "tests": [
-          {
-            "description": "Serialized length for a 5-char owner",
-            "expectedOutput": "__result__.len() == 18",
-            "id": "t1",
-            "input": "\"Alice\", 1000, false"
-          },
-          {
-            "description": "Serialized length for a 3-char owner",
-            "expectedOutput": "__result__.len() == 16",
-            "id": "t2",
-            "input": "\"Bob\", 42, true"
-          },
-          {
-            "description": "Owner bytes start at offset 4",
-            "expectedOutput": "__result__[4] == b'A'",
-            "id": "t3",
-            "input": "\"Alice\", 1000, false"
-          },
-          {
-            "description": "Correct layout for a different input (len prefix, owner, frozen flag)",
-            "expectedOutput": "__result__[0] == 3 && __result__[4] == b'S' && __result__[15] == 1",
-            "id": "t4",
-            "input": "\"Sol\", 7, true"
-          }
-        ],
-        "url": null
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       }
-    ],
-    "slug": "serialization-challenge",
-    "title": "Challenge: Serialize Account Data"
+    ]
   },
   {
     "_id": "lesson-setup-environment",
+    "title": "Setting Up Your Development Environment",
+    "slug": "setup-environment",
     "blocks": [
       {
-        "_type": "prose",
-        "amount": null,
-        "buildType": null,
-        "consumes": null,
-        "deployable": null,
-        "hints": null,
-        "idl": null,
         "key": "intro",
-        "language": null,
-        "maxWords": null,
-        "network": null,
+        "_type": "prose",
         "produces": null,
-        "prompt": null,
-        "questions": null,
-        "solution": null,
+        "consumes": null,
         "src": "# Setting Up Your Development Environment\n\nBefore you can start building on Solana, you need to set up your development environment.\n\n## Prerequisites\n\n- **Node.js** (v18 or later)\n- **Rust** (latest stable)\n- **Git**\n\n## Install the Solana CLI\n\n```bash\nsh -c \"$(curl -sSfL https://release.anza.xyz/stable/install)\"\n```\n\nAfter installation, verify:\n\n```bash\nsolana --version\n```\n\n## Configure Solana CLI for Devnet\n\n```bash\nsolana config set --url devnet\n```\n\n## Create a Keypair\n\n```bash\nsolana-keygen new --outfile ~/.config/solana/devnet.json\n```\n\nThis creates a new keypair that you will use for development on devnet.\n\n## Get Devnet SOL\n\n```bash\nsolana airdrop 2\n```\n\nYou can request up to 2 SOL per airdrop on devnet.\n\n## Install Anchor Framework\n\nAnchor is the most popular framework for Solana development:\n\n```bash\ncargo install --git https://github.com/coral-xyz/anchor avm --force\navm install latest\navm use latest\n```\n\nVerify the installation:\n\n```bash\nanchor --version\n```\n\n## Recommended IDE Setup\n\n- **VS Code** with the following extensions:\n  - rust-analyzer\n  - Solana (by Solana Labs)\n  - Better TOML\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
         "starter": null,
+        "solution": null,
         "tests": null,
-        "url": null
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       }
-    ],
-    "slug": "setup-environment",
-    "title": "Setting Up Your Development Environment"
+    ]
   },
   {
     "_id": "lesson-sign-message-challenge",
+    "title": "Challenge: Build a SIWS Message",
+    "slug": "sign-message-challenge",
     "blocks": [
       {
-        "_type": "prose",
-        "amount": null,
-        "buildType": null,
-        "consumes": null,
-        "deployable": null,
-        "hints": null,
-        "idl": null,
         "key": "intro",
-        "language": null,
-        "maxWords": null,
-        "network": null,
+        "_type": "prose",
         "produces": null,
-        "prompt": null,
-        "questions": null,
-        "solution": null,
+        "consumes": null,
         "src": "# Challenge: Build a SIWS Message\n\nConstruct a properly formatted Sign-In With Solana (SIWS) message that can be used for authentication.\n\n## Requirements\n\n- Create a function that accepts `domain` (string), `publicKey` (PublicKey), `nonce` (string), and `statement` (string)\n- Generate an ISO timestamp for \"Issued At\" (use `new Date().toISOString()`)\n- Return a formatted SIWS message string following this structure:\n  ```\n  {domain} wants you to sign in with your Solana account:\n  {publicKey}\n  \n  {statement}\n  \n  URI: https://{domain}\n  Version: 1\n  Nonce: {nonce}\n  Issued At: {issuedAt}\n  ```\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
         "starter": null,
+        "solution": null,
         "tests": null,
-        "url": null
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       },
       {
+        "key": "exercise",
         "_type": "code",
-        "amount": null,
-        "buildType": "standard",
+        "produces": null,
         "consumes": null,
+        "src": null,
+        "url": null,
+        "language": "typescript",
+        "buildType": "standard",
         "deployable": false,
+        "starter": "import { PublicKey } from '@solana/web3.js';\n\nfunction buildSIWSMessage(\n  domain: string,\n  publicKey: PublicKey,\n  nonce: string,\n  statement: string\n): string {\n  // Your code here\n}\n",
+        "solution": "import { PublicKey } from '@solana/web3.js';\n\nfunction buildSIWSMessage(\n  domain: string,\n  publicKey: PublicKey,\n  nonce: string,\n  statement: string\n): string {\n  const issuedAt = new Date().toISOString();\n  \n  return `${domain} wants you to sign in with your Solana account:\n${publicKey.toBase58()}\n\n${statement}\n\nURI: https://${domain}\nVersion: 1\nNonce: ${nonce}\nIssued At: ${issuedAt}`;\n}\n",
+        "tests": [
+          {
+            "id": "t1",
+            "description": "Returns a SIWS message string containing the domain",
+            "input": "'academy.courses', sender, 'nonce123', 'Sign in'",
+            "expectedOutput": "typeof result === 'string' && result.includes('academy.courses')"
+          },
+          {
+            "id": "t2",
+            "description": "Includes the version header and reflects the nonce",
+            "input": "'academy.courses', sender, 'nonce123', 'Sign in'",
+            "expectedOutput": "result.includes('Version: 1') && result.includes('Nonce: nonce123')"
+          },
+          {
+            "id": "t3",
+            "description": "Includes the URI (built from the domain) and an Issued At timestamp",
+            "input": "'academy.courses', sender, 'nonce123', 'Sign in'",
+            "expectedOutput": "result.includes('URI: https://academy.courses') && result.includes('Issued At:')"
+          },
+          {
+            "id": "t4",
+            "description": "Reflects a different domain and nonce (not hardcoded)",
+            "input": "'app.example.com', sender, 'abc456', 'Log in'",
+            "expectedOutput": "result.includes('Nonce: abc456') && result.includes('URI: https://app.example.com')"
+          }
+        ],
         "hints": [
           "Use template literals (backticks) to build the multi-line message",
           "Get the public key as base58 with publicKey.toBase58()",
           "The Issued At timestamp should be in ISO 8601 format (new Date().toISOString())"
         ],
-        "idl": null,
-        "key": "exercise",
-        "language": "typescript",
-        "maxWords": null,
-        "network": null,
-        "produces": null,
-        "prompt": null,
         "questions": null,
-        "solution": "import { PublicKey } from '@solana/web3.js';\n\nfunction buildSIWSMessage(\n  domain: string,\n  publicKey: PublicKey,\n  nonce: string,\n  statement: string\n): string {\n  const issuedAt = new Date().toISOString();\n  \n  return `${domain} wants you to sign in with your Solana account:\n${publicKey.toBase58()}\n\n${statement}\n\nURI: https://${domain}\nVersion: 1\nNonce: ${nonce}\nIssued At: ${issuedAt}`;\n}\n",
-        "src": null,
-        "starter": "import { PublicKey } from '@solana/web3.js';\n\nfunction buildSIWSMessage(\n  domain: string,\n  publicKey: PublicKey,\n  nonce: string,\n  statement: string\n): string {\n  // Your code here\n}\n",
-        "tests": [
-          {
-            "description": "Returns a SIWS message string containing the domain",
-            "expectedOutput": "typeof result === 'string' && result.includes('academy.courses')",
-            "id": "t1",
-            "input": "'academy.courses', sender, 'nonce123', 'Sign in'"
-          },
-          {
-            "description": "Includes the version header and reflects the nonce",
-            "expectedOutput": "result.includes('Version: 1') && result.includes('Nonce: nonce123')",
-            "id": "t2",
-            "input": "'academy.courses', sender, 'nonce123', 'Sign in'"
-          },
-          {
-            "description": "Includes the URI (built from the domain) and an Issued At timestamp",
-            "expectedOutput": "result.includes('URI: https://academy.courses') && result.includes('Issued At:')",
-            "id": "t3",
-            "input": "'academy.courses', sender, 'nonce123', 'Sign in'"
-          },
-          {
-            "description": "Reflects a different domain and nonce (not hardcoded)",
-            "expectedOutput": "result.includes('Nonce: abc456') && result.includes('URI: https://app.example.com')",
-            "id": "t4",
-            "input": "'app.example.com', sender, 'abc456', 'Log in'"
-          }
-        ],
-        "url": null
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       }
-    ],
-    "slug": "sign-message-challenge",
-    "title": "Challenge: Build a SIWS Message"
+    ]
   },
   {
     "_id": "lesson-signing-messages",
+    "title": "Sign-In With Solana (SIWS)",
+    "slug": "signing-messages",
     "blocks": [
       {
-        "_type": "prose",
-        "amount": null,
-        "buildType": null,
-        "consumes": null,
-        "deployable": null,
-        "hints": null,
-        "idl": null,
         "key": "intro",
-        "language": null,
-        "maxWords": null,
-        "network": null,
+        "_type": "prose",
         "produces": null,
-        "prompt": null,
-        "questions": null,
-        "solution": null,
+        "consumes": null,
         "src": "# Sign-In With Solana (SIWS)\n\nSign-In With Solana (SIWS) is a standard for authenticating users using their Solana wallet, similar to \"Sign-In With Ethereum\" (SIWE).\n\n## Why Message Signing?\n\nTraditional web apps use passwords. Web3 apps use **cryptographic signatures**:\n\n1. Server generates a unique message\n2. User signs the message with their wallet\n3. Server verifies the signature matches the public key\n4. User is authenticated without ever sharing a password\n\n**Benefits**:\n- No password management\n- Wallet handles all cryptography\n- Cannot be phished (signature is specific to the message)\n- Works across all Solana dApps\n\n## SIWS Message Format\n\nA SIWS message typically includes:\n\n```\nacademy.courses wants you to sign in with your Solana account:\n7C4jsPZpht42Tw6MjXWF56Q5RQUocjBBmciEjDa8HRtp\n\nSign in to Superteam Academy to access your courses and track your progress.\n\nURI: https://academy.courses\nVersion: 1\nNonce: k3j2n4k5j6h7g8f9d\nIssued At: 2025-02-09T15:30:00.000Z\nExpiration Time: 2025-02-09T15:45:00.000Z\n```\n\n**Key Components**:\n- **Domain**: Which site is requesting the signature\n- **Address**: User's public key\n- **Statement**: Human-readable purpose\n- **Nonce**: Prevents replay attacks (must be unique)\n- **Issued At/Expiration**: Time-bound authentication\n\n## Signing Flow\n\n```typescript\nimport { useWallet } from '@solana/wallet-adapter-react';\nimport bs58 from 'bs58';\n\nasync function signInWithSolana() {\n  const { publicKey, signMessage } = useWallet();\n  if (!publicKey || !signMessage) throw new Error('Wallet not connected');\n\n  // 1. Get nonce from server\n  const { nonce } = await fetch('/api/auth/nonce').then(r => r.json());\n\n  // 2. Build message\n  const message = `\nacademy.courses wants you to sign in with your Solana account:\n${publicKey.toBase58()}\n\nSign in to Superteam Academy.\n\nNonce: ${nonce}\nIssued At: ${new Date().toISOString()}\n  `.trim();\n\n  // 3. Sign message\n  const encodedMessage = new TextEncoder().encode(message);\n  const signature = await signMessage(encodedMessage);\n\n  // 4. Send to server for verification\n  await fetch('/api/auth/verify', {\n    method: 'POST',\n    headers: { 'Content-Type': 'application/json' },\n    body: JSON.stringify({\n      message,\n      signature: bs58.encode(signature),\n      publicKey: publicKey.toBase58(),\n    }),\n  });\n}\n```\n\n## Server-Side Verification\n\nThe server verifies the signature using the Ed25519 algorithm:\n\n```typescript\nimport { PublicKey } from '@solana/web3.js';\nimport nacl from 'tweetnacl';\nimport bs58 from 'bs58';\n\nfunction verifySignature(\n  message: string,\n  signature: string,\n  publicKey: string\n): boolean {\n  const messageBytes = new TextEncoder().encode(message);\n  const signatureBytes = bs58.decode(signature);\n  const publicKeyBytes = new PublicKey(publicKey).toBytes();\n\n  return nacl.sign.detached.verify(\n    messageBytes,\n    signatureBytes,\n    publicKeyBytes\n  );\n}\n```\n\n## Security Considerations\n\n### Nonce Management\n- Generate cryptographically random nonces (use `crypto.randomBytes(32)`)\n- Store nonces in Redis/memory with TTL (5-15 minutes)\n- Delete nonce after successful verification (prevent replay)\n\n### Message Validation\n- Verify message format matches expected structure\n- Check `Issued At` is recent (within 5 minutes)\n- Verify domain matches your application\n- Ensure `Expiration Time` hasn't passed\n\n### Example: Nonce Replay Attack\n\nWithout nonce verification:\n```\nAttacker intercepts a valid signature\nAttacker replays it multiple times\nServer accepts each replay as valid ❌\n```\n\nWith nonce verification:\n```\nAttacker intercepts a valid signature\nServer marks nonce as used\nAttacker replays signature\nServer rejects (nonce already used) ✅\n```\n\n## Real-World Implementation\n\nMost Solana dApps use SIWS for:\n- Gating premium content (Dialect, Squads)\n- Personalized dashboards (Jupiter, Raydium)\n- User settings and preferences\n- Subscription verification\n\n## Next Steps\n\nIn the next challenge, you'll construct a SIWS message with all required fields.\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
         "starter": null,
+        "solution": null,
         "tests": null,
-        "url": null
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       }
-    ],
-    "slug": "signing-messages",
-    "title": "Sign-In With Solana (SIWS)"
+    ]
   },
   {
     "_id": "lesson-staking-challenge",
+    "title": "Staking Rewards Calculator",
+    "slug": "staking-challenge",
     "blocks": [
       {
-        "_type": "prose",
-        "amount": null,
-        "buildType": null,
-        "consumes": null,
-        "deployable": null,
-        "hints": null,
-        "idl": null,
         "key": "intro",
-        "language": null,
-        "maxWords": null,
-        "network": null,
+        "_type": "prose",
         "produces": null,
-        "prompt": null,
-        "questions": null,
-        "solution": null,
+        "consumes": null,
         "src": "# Staking Rewards Calculator\n\nBuild a staking rewards calculator that computes compound interest over multiple epochs.\n\nYour calculator should compute:\n1. **Final balance** after N epochs with compound rewards\n2. **Effective APY** accounting for compounding\n3. **Total rewards** earned over the staking period\n\nThis is the math behind every staking dashboard and validator calculator. Master compound interest to build accurate DeFi UIs.\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
         "starter": null,
+        "solution": null,
         "tests": null,
-        "url": null
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       },
       {
+        "key": "exercise",
         "_type": "code",
-        "amount": null,
-        "buildType": "standard",
+        "produces": null,
         "consumes": null,
+        "src": null,
+        "url": null,
+        "language": "typescript",
+        "buildType": "standard",
         "deployable": false,
+        "starter": "/**\n * Calculate staking rewards with compound interest\n * @param {number} stakeAmount - Initial stake in SOL\n * @param {number} apyPercent - Annual percentage yield (e.g., 7.5 for 7.5%)\n * @param {number} epochDurationDays - Days per epoch (e.g., 2.5)\n * @param {number} numEpochs - Number of epochs to calculate\n * @returns {object} - { finalBalance, effectiveApy, totalRewards }\n */\nfunction calculateStakingRewards(stakeAmount, apyPercent, epochDurationDays, numEpochs) {\n  // TODO: Calculate epoch rate from APY\n  // epochsPerYear = 365 / epochDurationDays\n  // epochRate = (1 + apyPercent/100)^(epochDurationDays/365) - 1\n  \n  // TODO: Apply compound interest over numEpochs\n  // finalBalance = stakeAmount * (1 + epochRate)^numEpochs\n  \n  // TODO: Calculate effective APY from final balance\n  // effectiveApy = ((finalBalance / stakeAmount)^(365/(epochDurationDays*numEpochs)) - 1) * 100\n  \n  // TODO: Calculate total rewards\n  // totalRewards = finalBalance - stakeAmount\n  \n  return {\n    finalBalance: 0,\n    effectiveApy: 0,\n    totalRewards: 0\n  };\n}\n\nconst result = calculateStakingRewards(100, 7.5, 2.5, 146);\nconsole.log(result.finalBalance); // Should be ~107.5\nconsole.log(result.effectiveApy); // Should be ~7.5\nconsole.log(result.totalRewards); // Should be ~7.5\n",
+        "solution": "function calculateStakingRewards(stakeAmount, apyPercent, epochDurationDays, numEpochs) {\n  const epochsPerYear = 365 / epochDurationDays;\n  const annualMultiplier = 1 + (apyPercent / 100);\n  const epochRate = Math.pow(annualMultiplier, epochDurationDays / 365) - 1;\n  \n  const finalBalance = stakeAmount * Math.pow(1 + epochRate, numEpochs);\n  \n  const totalDays = epochDurationDays * numEpochs;\n  const effectiveApy = (Math.pow(finalBalance / stakeAmount, 365 / totalDays) - 1) * 100;\n  \n  const totalRewards = finalBalance - stakeAmount;\n  \n  return {\n    finalBalance: finalBalance,\n    effectiveApy: effectiveApy,\n    totalRewards: totalRewards\n  };\n}\n\nconst result = calculateStakingRewards(100, 7.5, 2.5, 146);\nconsole.log(result.finalBalance);\nconsole.log(result.effectiveApy);\nconsole.log(result.totalRewards);\n",
+        "tests": [
+          {
+            "id": "test-1",
+            "description": "Should return object with finalBalance, totalRewards, effectiveApy",
+            "input": "100, 7.5, 2.5, 146",
+            "expectedOutput": "typeof result === 'object' && 'finalBalance' in result && 'totalRewards' in result && 'effectiveApy' in result"
+          },
+          {
+            "id": "test-2",
+            "description": "Final balance should be greater than initial stake",
+            "input": "100, 7.5, 2.5, 146",
+            "expectedOutput": "typeof result.finalBalance === 'number' && result.finalBalance > 100"
+          },
+          {
+            "id": "test-3",
+            "description": "Total rewards should be positive",
+            "input": "100, 7.5, 2.5, 146",
+            "expectedOutput": "typeof result.totalRewards === 'number' && result.totalRewards > 0"
+          },
+          {
+            "id": "test-4",
+            "description": "Final balance should exceed initial for longer stake",
+            "input": "1000, 5.0, 1.0, 365",
+            "expectedOutput": "result.finalBalance > 1000"
+          }
+        ],
         "hints": [
           "Calculate epoch rate using the formula: (1 + APY)^(epoch_days/365) - 1. This converts annual rate to per-epoch rate.",
           "Apply compound interest by multiplying stake amount by (1 + epoch_rate) raised to the number of epochs.",
           "To find effective APY from final balance, use the inverse operation: ((final/initial)^(365/total_days) - 1) * 100"
         ],
-        "idl": null,
-        "key": "exercise",
-        "language": "typescript",
-        "maxWords": null,
-        "network": null,
-        "produces": null,
-        "prompt": null,
         "questions": null,
-        "solution": "function calculateStakingRewards(stakeAmount, apyPercent, epochDurationDays, numEpochs) {\n  const epochsPerYear = 365 / epochDurationDays;\n  const annualMultiplier = 1 + (apyPercent / 100);\n  const epochRate = Math.pow(annualMultiplier, epochDurationDays / 365) - 1;\n  \n  const finalBalance = stakeAmount * Math.pow(1 + epochRate, numEpochs);\n  \n  const totalDays = epochDurationDays * numEpochs;\n  const effectiveApy = (Math.pow(finalBalance / stakeAmount, 365 / totalDays) - 1) * 100;\n  \n  const totalRewards = finalBalance - stakeAmount;\n  \n  return {\n    finalBalance: finalBalance,\n    effectiveApy: effectiveApy,\n    totalRewards: totalRewards\n  };\n}\n\nconst result = calculateStakingRewards(100, 7.5, 2.5, 146);\nconsole.log(result.finalBalance);\nconsole.log(result.effectiveApy);\nconsole.log(result.totalRewards);\n",
-        "src": null,
-        "starter": "/**\n * Calculate staking rewards with compound interest\n * @param {number} stakeAmount - Initial stake in SOL\n * @param {number} apyPercent - Annual percentage yield (e.g., 7.5 for 7.5%)\n * @param {number} epochDurationDays - Days per epoch (e.g., 2.5)\n * @param {number} numEpochs - Number of epochs to calculate\n * @returns {object} - { finalBalance, effectiveApy, totalRewards }\n */\nfunction calculateStakingRewards(stakeAmount, apyPercent, epochDurationDays, numEpochs) {\n  // TODO: Calculate epoch rate from APY\n  // epochsPerYear = 365 / epochDurationDays\n  // epochRate = (1 + apyPercent/100)^(epochDurationDays/365) - 1\n  \n  // TODO: Apply compound interest over numEpochs\n  // finalBalance = stakeAmount * (1 + epochRate)^numEpochs\n  \n  // TODO: Calculate effective APY from final balance\n  // effectiveApy = ((finalBalance / stakeAmount)^(365/(epochDurationDays*numEpochs)) - 1) * 100\n  \n  // TODO: Calculate total rewards\n  // totalRewards = finalBalance - stakeAmount\n  \n  return {\n    finalBalance: 0,\n    effectiveApy: 0,\n    totalRewards: 0\n  };\n}\n\nconst result = calculateStakingRewards(100, 7.5, 2.5, 146);\nconsole.log(result.finalBalance); // Should be ~107.5\nconsole.log(result.effectiveApy); // Should be ~7.5\nconsole.log(result.totalRewards); // Should be ~7.5\n",
-        "tests": [
-          {
-            "description": "Should return object with finalBalance, totalRewards, effectiveApy",
-            "expectedOutput": "typeof result === 'object' && 'finalBalance' in result && 'totalRewards' in result && 'effectiveApy' in result",
-            "id": "test-1",
-            "input": "100, 7.5, 2.5, 146"
-          },
-          {
-            "description": "Final balance should be greater than initial stake",
-            "expectedOutput": "typeof result.finalBalance === 'number' && result.finalBalance > 100",
-            "id": "test-2",
-            "input": "100, 7.5, 2.5, 146"
-          },
-          {
-            "description": "Total rewards should be positive",
-            "expectedOutput": "typeof result.totalRewards === 'number' && result.totalRewards > 0",
-            "id": "test-3",
-            "input": "100, 7.5, 2.5, 146"
-          },
-          {
-            "description": "Final balance should exceed initial for longer stake",
-            "expectedOutput": "result.finalBalance > 1000",
-            "id": "test-4",
-            "input": "1000, 5.0, 1.0, 365"
-          }
-        ],
-        "url": null
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       }
-    ],
-    "slug": "staking-challenge",
-    "title": "Staking Rewards Calculator"
+    ]
   },
   {
     "_id": "lesson-staking-mechanisms",
+    "title": "Staking Mechanisms on Solana",
+    "slug": "staking-mechanisms",
     "blocks": [
       {
-        "_type": "prose",
-        "amount": null,
-        "buildType": null,
-        "consumes": null,
-        "deployable": null,
-        "hints": null,
-        "idl": null,
         "key": "intro",
-        "language": null,
-        "maxWords": null,
-        "network": null,
+        "_type": "prose",
         "produces": null,
-        "prompt": null,
-        "questions": null,
-        "solution": null,
+        "consumes": null,
         "src": "# Staking Mechanisms on Solana\n\nStaking is fundamental to Solana's proof-of-stake consensus and DeFi ecosystem. Understanding staking mechanisms is essential for building yield-generating applications.\n\n## Native Staking\n\nSolana's native staking allows SOL holders to delegate their tokens to validators. Validators process transactions and secure the network, earning rewards that are shared with delegators. Staking requires locking SOL for the duration of an epoch (approximately 2-3 days), during which it cannot be transferred.\n\n**Key mechanics**:\n- **Delegation**: Users create a stake account and delegate to a validator\n- **Activation**: Stakes activate at the next epoch boundary\n- **Deactivation**: Unstaking requires waiting for the current epoch to end\n- **Rewards**: Automatically compounded into the stake account\n\n## Liquid Staking Tokens\n\nLiquid staking protocols like Marinade (mSOL) and Jito (jitoSOL) solve the liquidity problem. Users deposit SOL and receive liquid staking tokens (LSTs) that represent their staked position plus accrued rewards. LSTs can be traded, used as collateral, or deployed in DeFi while still earning staking yields.\n\n**Advantages**:\n- Instant liquidity without waiting for epoch changes\n- Automatic validator diversification across multiple validators\n- Compound staking rewards with DeFi yields\n- Exchange rate appreciation as rewards accrue\n\n## Stake Pools\n\nThe Solana Program Library includes the Stake Pool program, which enables permissionless creation of staking pools. Pool managers can add validators, set fees, and manage pool operations. The pool issues pool tokens that track the stake account value.\n\n**Rewards calculation**: Staking APY varies by validator commission (typically 5-10%) and network inflation rate. Effective APY = (1 + epoch_rate)^epochs_per_year - 1, accounting for compound interest.\n\nUnderstanding these mechanisms is critical for building staking UIs, yield aggregators, and advanced DeFi protocols that leverage staked SOL as collateral.\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
         "starter": null,
+        "solution": null,
         "tests": null,
-        "url": null
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       }
-    ],
-    "slug": "staking-mechanisms",
-    "title": "Staking Mechanisms on Solana"
+    ]
   },
   {
     "_id": "lesson-state-management",
+    "title": "PDAs and State Management",
+    "slug": "state-management",
     "blocks": [
       {
-        "_type": "prose",
-        "amount": null,
-        "buildType": null,
-        "consumes": null,
-        "deployable": null,
-        "hints": null,
-        "idl": null,
         "key": "intro",
-        "language": null,
-        "maxWords": null,
-        "network": null,
+        "_type": "prose",
         "produces": null,
-        "prompt": null,
-        "questions": null,
-        "solution": null,
+        "consumes": null,
         "src": "# PDAs and State Management\n\nProgram Derived Addresses (PDAs) are one of Solana's most powerful features. They enable programs to \"own\" accounts and sign transactions programmatically, unlocking patterns impossible in other blockchains.\n\n## What Are PDAs?\n\nA PDA is a public key that:\n1. **Has no private key**: It's derived from seeds, not generated randomly\n2. **Is off the Ed25519 curve**: Cannot be signed by a regular keypair\n3. **Can only be signed by the program** that derives it: Using `invoke_signed`\n\nThink of PDAs as accounts controlled by code, not by a person holding a private key.\n\n## Deriving PDAs\n\nUse `Pubkey::find_program_address()` (or `findProgramAddressSync()` in JS) to derive a PDA:\n\n```rust\nlet (pda, bump) = Pubkey::find_program_address(\n    &[\n        b\"user\",                    // Static seed\n        user_pubkey.as_ref(),      // Dynamic seed (user's pubkey)\n    ],\n    program_id,\n);\n```\n\nThe function returns:\n- **`pda`**: The derived public key\n- **`bump`**: A single byte (0-255) that ensures the PDA is off-curve\n\n### How It Works\n\nInternally, Solana:\n1. Concatenates the seeds + program_id\n2. Hashes them with SHA-256\n3. Checks if the result is on the Ed25519 curve\n4. If yes, decrements the bump (starting at 255) and tries again\n5. Returns the first off-curve result (the \"canonical bump\")\n\n```rust\n// Pseudocode\nfor bump in (0..=255).rev() {\n    let hash = sha256(seeds + [bump] + program_id);\n    if !is_on_curve(hash) {\n        return (PublicKey(hash), bump);\n    }\n}\n```\n\n## Why PDAs?\n\n### 1. Deterministic Account Addresses\n\nYou can calculate account addresses before they're created:\n\n```rust\n// Client-side: Calculate where the user's token account will be\nlet (token_account_pda, _) = Pubkey::find_program_address(\n    &[b\"token\", user_pubkey.as_ref(), mint_pubkey.as_ref()],\n    &token_program_id,\n);\n\n// No need to store this address—just recompute it when needed!\n```\n\n### 2. Program-Controlled Signing\n\nPrograms can sign transactions on behalf of PDAs using `invoke_signed`:\n\n```rust\n// Transfer tokens FROM a PDA (not from the user)\ninvoke_signed(\n    &transfer_instruction,\n    &[source_pda, destination, token_program],\n    &[&[b\"vault\", user_pubkey.as_ref(), &[bump]]], // Signer seeds\n)?;\n```\n\nThis enables:\n- **Escrow contracts**: Lock tokens until conditions are met\n- **Vaults**: Store user funds under program control\n- **Proxies**: Programs calling other programs\n\n### 3. One Account Per User (No Collisions)\n\nBy including the user's pubkey in the seeds, each user gets a unique PDA:\n\n```rust\nlet (user_account, _) = Pubkey::find_program_address(\n    &[b\"account\", user_pubkey.as_ref()],\n    program_id,\n);\n```\n\nNo two users will ever get the same PDA, even if millions of users exist.\n\n## Canonical Bumps\n\n**Always use the canonical bump** (the first one returned by `find_program_address`). Storing non-canonical bumps enables bump seed attacks where an attacker creates multiple PDAs with different bumps.\n\n```rust\n// Good: Store the canonical bump\nlet (pda, bump) = Pubkey::find_program_address(seeds, program_id);\naccount.bump = bump; // Save this for later\n\n// Bad: Never recompute with a different bump\nlet pda = Pubkey::create_program_address(&[seeds, &[wrong_bump]], program_id)?;\n```\n\n## Common PDA Patterns\n\n### Pattern 1: Global State (One PDA per Program)\n\n```rust\nlet (config_pda, _) = Pubkey::find_program_address(\n    &[b\"config\"],\n    program_id,\n);\n```\n\n### Pattern 2: User-Specific Accounts\n\n```rust\nlet (user_account, _) = Pubkey::find_program_address(\n    &[b\"user\", user_pubkey.as_ref()],\n    program_id,\n);\n```\n\n### Pattern 3: Associated Accounts (Multiple PDAs per User)\n\n```rust\n// User's stats PDA\nlet (stats_pda, _) = Pubkey::find_program_address(\n    &[b\"stats\", user_pubkey.as_ref()],\n    program_id,\n);\n\n// User's vault PDA\nlet (vault_pda, _) = Pubkey::find_program_address(\n    &[b\"vault\", user_pubkey.as_ref()],\n    program_id,\n);\n```\n\n### Pattern 4: Indexed PDAs (Lists)\n\n```rust\n// 10th post by this user\nlet (post_pda, _) = Pubkey::find_program_address(\n    &[b\"post\", user_pubkey.as_ref(), &10u64.to_le_bytes()],\n    program_id,\n);\n```\n\n## PDA Validation\n\nAlways verify that a passed PDA matches the expected derivation:\n\n```rust\nlet expected_pda = Pubkey::create_program_address(\n    &[b\"user\", user_pubkey.as_ref(), &[bump]],\n    program_id,\n)?;\n\nif account.key != &expected_pda {\n    return Err(ProgramError::InvalidAccountData);\n}\n```\n\nThis prevents attackers from passing malicious accounts.\n\n## Next Challenge\n\nYou'll derive multiple PDAs using different seed patterns and verify they're off-curve using the `PublicKey.isOnCurve()` mock method!\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
         "starter": null,
+        "solution": null,
         "tests": null,
-        "url": null
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       }
-    ],
-    "slug": "state-management",
-    "title": "PDAs and State Management"
+    ]
   },
   {
     "_id": "lesson-structs-enums",
+    "title": "Structs and Enums for Solana",
+    "slug": "structs-enums",
     "blocks": [
       {
-        "_type": "prose",
-        "amount": null,
-        "buildType": null,
-        "consumes": null,
-        "deployable": null,
-        "hints": null,
-        "idl": null,
         "key": "intro",
-        "language": null,
-        "maxWords": null,
-        "network": null,
+        "_type": "prose",
         "produces": null,
-        "prompt": null,
-        "questions": null,
-        "solution": null,
+        "consumes": null,
         "src": "# Structs and Enums for Solana Programs\n\nSolana programs store data in accounts and process instructions. Rust's `struct` and `enum` types are perfect for modeling both.\n\n## Structs for Account Data\n\nA `struct` groups related data together. In Solana, you'll use structs to define the layout of account data:\n\n```rust\nuse borsh::{BorshDeserialize, BorshSerialize};\n\n#[derive(BorshSerialize, BorshDeserialize, Debug)]\npub struct UserAccount {\n    pub owner: Pubkey,\n    pub balance: u64,\n    pub last_login: i64,\n    pub is_frozen: bool,\n}\n```\n\n### Derive Macros\n\n`#[derive(...)]` automatically implements common traits:\n- `BorshSerialize`: Converts the struct to bytes for storage\n- `BorshDeserialize`: Reconstructs the struct from bytes\n- `Debug`: Enables `println!(\"{:?}\", user)` for debugging\n- `Clone`, `Copy`, `PartialEq`: Other useful traits\n\n## Enums for Instruction Types\n\nAn `enum` represents a value that can be one of several variants. Use enums to define the different instructions your program accepts:\n\n```rust\n#[derive(BorshSerialize, BorshDeserialize, Debug)]\npub enum TokenInstruction {\n    /// Initialize a new token mint\n    InitializeMint { decimals: u8 },\n    \n    /// Transfer tokens from one account to another\n    Transfer { amount: u64 },\n    \n    /// Burn tokens from an account\n    Burn { amount: u64 },\n}\n```\n\nEach variant can hold different data types, making enums incredibly flexible.\n\n## Pattern Matching\n\nUse `match` to handle different enum variants. Rust's compiler ensures you handle ALL cases:\n\n```rust\npub fn process_instruction(\n    program_id: &Pubkey,\n    accounts: &[AccountInfo],\n    instruction_data: &[u8],\n) -> ProgramResult {\n    let instruction = TokenInstruction::try_from_slice(instruction_data)?;\n    \n    match instruction {\n        TokenInstruction::InitializeMint { decimals } => {\n            msg!(\"Initializing mint with {} decimals\", decimals);\n            process_init_mint(accounts, decimals)\n        }\n        TokenInstruction::Transfer { amount } => {\n            msg!(\"Transferring {} tokens\", amount);\n            process_transfer(accounts, amount)\n        }\n        TokenInstruction::Burn { amount } => {\n            msg!(\"Burning {} tokens\", amount);\n            process_burn(accounts, amount)\n        }\n    }\n}\n```\n\n## Borsh Serialization\n\nBorsh (Binary Object Representation Serializer for Hashing) is Solana's preferred serialization format:\n- **Deterministic**: Same data always serializes to the same bytes\n- **Compact**: No field names or type tags in the output\n- **Fast**: Optimized for blockchain use cases\n\n```rust\nlet user = UserAccount {\n    owner: pubkey,\n    balance: 1000,\n    last_login: 1640000000,\n    is_frozen: false,\n};\n\n// Serialize to bytes\nlet bytes = user.try_to_vec()?;\n\n// Deserialize from bytes\nlet restored = UserAccount::try_from_slice(&bytes)?;\n```\n\nIn the next lessons, we'll dive deeper into Borsh and see how to manually serialize data when needed.\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
         "starter": null,
+        "solution": null,
         "tests": null,
-        "url": null
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "retrieval-close",
+        "_type": "quiz",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": [
+          {
+            "id": "q1",
+            "prompt": "Instruction types are modeled as an `enum` and dispatched with `match`. What does Rust's compiler guarantee about that match?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "It must handle every variant — a missing case is a compile error, so a new instruction cannot be silently unhandled",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "It runs each arm in turn until one returns Ok",
+                "correct": false,
+                "feedback": "`match` selects exactly one arm by the value's variant; it does not run them in sequence. Its guarantee is exhaustiveness, not fall-through."
+              },
+              {
+                "id": "c",
+                "label": "It defaults unknown variants to the first arm",
+                "correct": false,
+                "feedback": "There is no silent default. If you add a variant and forget its arm, the code fails to compile — that is the safety property."
+              }
+            ],
+            "explanation": "Rust checks `match` exhaustiveness at compile time, so every enum variant must be handled. Adding a new instruction variant without a handler breaks the build rather than silently dropping the instruction — a strong guard for a program's dispatch logic."
+          },
+          {
+            "id": "q2",
+            "prompt": "Why do these structs derive `BorshSerialize`/`BorshDeserialize` instead of being stored as JSON?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "Account data is raw bytes; Borsh gives a compact, deterministic byte layout that all validators reproduce identically",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "Borsh makes the struct human-readable in the explorer",
+                "correct": false,
+                "feedback": "Borsh is binary and not human-readable — that is JSON's trait. Borsh is chosen for determinism and compactness, not readability."
+              },
+              {
+                "id": "c",
+                "label": "Borsh lets fields be reordered freely at runtime",
+                "correct": false,
+                "feedback": "The opposite — Borsh encodes fields in a fixed order so the bytes are deterministic. Reorderable encodings like JSON break consensus."
+              }
+            ],
+            "explanation": "Accounts store bytes, so a struct must serialize to a byte layout. Borsh is deterministic (same value, same bytes on every validator) and compact (no field names), which is required for consensus and cheap because Solana charges rent by account size."
+          }
+        ],
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       }
-    ],
-    "slug": "structs-enums",
-    "title": "Structs and Enums for Solana"
+    ]
   },
   {
     "_id": "lesson-testing-challenge",
+    "title": "Challenge: Test a Transfer Program",
+    "slug": "testing-challenge",
     "blocks": [
       {
-        "_type": "prose",
-        "amount": null,
-        "buildType": null,
-        "consumes": null,
-        "deployable": null,
-        "hints": null,
-        "idl": null,
         "key": "intro",
-        "language": null,
-        "maxWords": null,
-        "network": null,
+        "_type": "prose",
         "produces": null,
-        "prompt": null,
-        "questions": null,
-        "solution": null,
+        "consumes": null,
         "src": "# Challenge: Simulate a Transfer Test in Rust\n\nTest-driven development is critical for Solana programs. You'll write a function that simulates a complete transfer test scenario — the same logic you'd verify with `anchor test`.\n\n## Your Task\n\nImplement `simulate_transfer_test(sender_initial, transfer_amount, fee)` that:\n\n1. Checks if sender can afford `transfer_amount + fee`\n2. If yes, computes final balances and returns `\"PASS:sender=<final>,receiver=<final>\"`\n3. If no, returns `\"FAIL:insufficient_funds\"`\n\n**Test constants:**\n- Receiver starts with 0 balance\n- Fee is paid by sender and burned (not added to receiver)\n- The function simulates what an Anchor test's `assert` checks would verify\n\n**This mirrors the Anchor test pattern:**\n```typescript\nit('transfers SOL correctly', async () => {\n  const balanceBefore = await connection.getBalance(sender);\n  await program.methods.transfer(amount).rpc();\n  const balanceAfter = await connection.getBalance(sender);\n  expect(balanceAfter).to.equal(balanceBefore - amount - fee);\n});\n```\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
         "starter": null,
+        "solution": null,
         "tests": null,
-        "url": null
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       },
       {
+        "key": "exercise",
         "_type": "code",
-        "amount": null,
-        "buildType": "standard",
+        "produces": null,
         "consumes": null,
+        "src": null,
+        "url": null,
+        "language": "rust",
+        "buildType": "standard",
         "deployable": false,
+        "starter": "fn simulate_transfer_test(\n    sender_initial: u64,\n    transfer_amount: u64,\n    fee: u64,\n) -> String {\n    let receiver_initial: u64 = 0;\n\n    // TODO: Check if sender can afford transfer_amount + fee\n\n    // TODO: If yes, compute final balances and return:\n    //   \"PASS:sender=<sender_final>,receiver=<receiver_final>\"\n\n    // TODO: If no, return \"FAIL:insufficient_funds\"\n    todo!()\n}\n",
+        "solution": "fn simulate_transfer_test(\n    sender_initial: u64,\n    transfer_amount: u64,\n    fee: u64,\n) -> String {\n    let receiver_initial: u64 = 0;\n\n    if sender_initial < transfer_amount + fee {\n        return \"FAIL:insufficient_funds\".to_string();\n    }\n\n    let sender_final = sender_initial - transfer_amount - fee;\n    let receiver_final = receiver_initial + transfer_amount;\n\n    format!(\"PASS:sender={},receiver={}\", sender_final, receiver_final)\n}\n",
+        "tests": [
+          {
+            "id": "t1",
+            "description": "Exact balances after a successful transfer",
+            "input": "2_000_000_000, 500_000_000, 5000",
+            "expectedOutput": "\"PASS:sender=1499995000,receiver=500000000\".to_string()"
+          },
+          {
+            "id": "t2",
+            "description": "Insufficient funds fails",
+            "input": "100, 200, 5000",
+            "expectedOutput": "\"FAIL:insufficient_funds\".to_string()"
+          },
+          {
+            "id": "t3",
+            "description": "Exact balances for a different transfer",
+            "input": "1000000, 300000, 1000",
+            "expectedOutput": "\"PASS:sender=699000,receiver=300000\".to_string()"
+          }
+        ],
         "hints": [
           "Check if sender_initial >= transfer_amount + fee (use checked_add or just add — small test values won't overflow).",
           "sender_final = sender_initial - transfer_amount - fee. receiver_final = receiver_initial + transfer_amount.",
           "Format with: format!(\"PASS:sender={},receiver={}\", sender_final, receiver_final)."
         ],
-        "idl": null,
-        "key": "exercise",
-        "language": "rust",
-        "maxWords": null,
-        "network": null,
-        "produces": null,
-        "prompt": null,
         "questions": null,
-        "solution": "fn simulate_transfer_test(\n    sender_initial: u64,\n    transfer_amount: u64,\n    fee: u64,\n) -> String {\n    let receiver_initial: u64 = 0;\n\n    if sender_initial < transfer_amount + fee {\n        return \"FAIL:insufficient_funds\".to_string();\n    }\n\n    let sender_final = sender_initial - transfer_amount - fee;\n    let receiver_final = receiver_initial + transfer_amount;\n\n    format!(\"PASS:sender={},receiver={}\", sender_final, receiver_final)\n}\n",
-        "src": null,
-        "starter": "fn simulate_transfer_test(\n    sender_initial: u64,\n    transfer_amount: u64,\n    fee: u64,\n) -> String {\n    let receiver_initial: u64 = 0;\n\n    // TODO: Check if sender can afford transfer_amount + fee\n\n    // TODO: If yes, compute final balances and return:\n    //   \"PASS:sender=<sender_final>,receiver=<receiver_final>\"\n\n    // TODO: If no, return \"FAIL:insufficient_funds\"\n    todo!()\n}\n",
-        "tests": [
-          {
-            "description": "Exact balances after a successful transfer",
-            "expectedOutput": "\"PASS:sender=1499995000,receiver=500000000\".to_string()",
-            "id": "t1",
-            "input": "2_000_000_000, 500_000_000, 5000"
-          },
-          {
-            "description": "Insufficient funds fails",
-            "expectedOutput": "\"FAIL:insufficient_funds\".to_string()",
-            "id": "t2",
-            "input": "100, 200, 5000"
-          },
-          {
-            "description": "Exact balances for a different transfer",
-            "expectedOutput": "\"PASS:sender=699000,receiver=300000\".to_string()",
-            "id": "t3",
-            "input": "1000000, 300000, 1000"
-          }
-        ],
-        "url": null
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       }
-    ],
-    "slug": "testing-challenge",
-    "title": "Challenge: Test a Transfer Program"
+    ]
   },
   {
     "_id": "lesson-token-math-challenge",
+    "title": "Token Math Challenge",
+    "slug": "token-math-challenge",
     "blocks": [
       {
-        "_type": "prose",
-        "amount": null,
-        "buildType": null,
-        "consumes": null,
-        "deployable": null,
-        "hints": null,
-        "idl": null,
         "key": "intro",
-        "language": null,
-        "maxWords": null,
-        "network": null,
+        "_type": "prose",
         "produces": null,
-        "prompt": null,
-        "questions": null,
-        "solution": null,
+        "consumes": null,
         "src": "# Token Math Challenge\n\nMaster the essential mathematical operations for working with SPL tokens on Solana.\n\nIn this challenge, you'll implement three critical token math functions:\n\n1. **Unit Conversion**: Convert between base units (smallest indivisible units) and display units using decimals\n2. **Price Calculation**: Calculate token prices from liquidity pool reserves\n3. **LP Share Calculation**: Compute a user's percentage share of a liquidity pool\n\nThese calculations are fundamental to every DeFi protocol. Understanding token math ensures you handle user funds correctly and display accurate information.\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
         "starter": null,
+        "solution": null,
         "tests": null,
-        "url": null
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       },
       {
+        "key": "exercise",
         "_type": "code",
-        "amount": null,
-        "buildType": "standard",
+        "produces": null,
         "consumes": null,
+        "src": null,
+        "url": null,
+        "language": "typescript",
+        "buildType": "standard",
         "deployable": false,
+        "starter": "/**\n * Convert base units to display units using decimals\n * @param {number} baseAmount - Amount in base units (e.g., 1_000_000)\n * @param {number} decimals - Token decimals (e.g., 6 for USDC)\n * @returns {number} - Amount in display units (e.g., 1.0)\n */\nfunction baseToDisplay(baseAmount, decimals) {\n  // TODO: Divide baseAmount by 10^decimals\n  return 0;\n}\n\n/**\n * Calculate token price from pool reserves\n * @param {number} reserveA - Reserve of token A\n * @param {number} reserveB - Reserve of token B\n * @returns {number} - Price of token A in terms of token B\n */\nfunction calculatePrice(reserveA, reserveB) {\n  // TODO: Price of A = reserveB / reserveA\n  // Handle division by zero\n  return 0;\n}\n\n/**\n * Calculate user's LP token share percentage\n * @param {number} userLpTokens - User's LP token balance\n * @param {number} totalLpTokens - Total LP tokens in pool\n * @returns {number} - Percentage share (0-100)\n */\nfunction calculateLpShare(userLpTokens, totalLpTokens) {\n  // TODO: (userLpTokens / totalLpTokens) * 100\n  // Handle division by zero\n  return 0;\n}\n\nconsole.log(baseToDisplay(1000000, 6)); // Should output: 1\nconsole.log(calculatePrice(100000, 200000)); // Should output: 2\nconsole.log(calculateLpShare(500, 10000)); // Should output: 5\n",
+        "solution": "function baseToDisplay(baseAmount, decimals) {\n  return baseAmount / Math.pow(10, decimals);\n}\n\nfunction calculatePrice(reserveA, reserveB) {\n  if (reserveA === 0) return 0;\n  return reserveB / reserveA;\n}\n\nfunction calculateLpShare(userLpTokens, totalLpTokens) {\n  if (totalLpTokens === 0) return 0;\n  return (userLpTokens / totalLpTokens) * 100;\n}\n\nconsole.log(baseToDisplay(1000000, 6));\nconsole.log(calculatePrice(100000, 200000));\nconsole.log(calculateLpShare(500, 10000));\n",
+        "tests": [
+          {
+            "id": "t1",
+            "description": "Converts base units to display (9 decimals)",
+            "input": "1000000000, 9",
+            "expectedOutput": "result === 1"
+          },
+          {
+            "id": "t2",
+            "description": "Converts a larger amount (9 decimals)",
+            "input": "2000000000, 9",
+            "expectedOutput": "result === 2"
+          },
+          {
+            "id": "t3",
+            "description": "Uses the decimals argument (6 decimals)",
+            "input": "5000000, 6",
+            "expectedOutput": "result === 5"
+          },
+          {
+            "id": "t4",
+            "description": "Handles fractional results with a different scale",
+            "input": "250, 2",
+            "expectedOutput": "result === 2.5"
+          }
+        ],
         "hints": [
           "Use Math.pow(10, decimals) to calculate the divisor for unit conversion",
           "For price calculation, always divide reserveB by reserveA to get the price of A in terms of B",
           "Remember to multiply by 100 when converting a decimal to a percentage"
         ],
-        "idl": null,
-        "key": "exercise",
-        "language": "typescript",
-        "maxWords": null,
-        "network": null,
-        "produces": null,
-        "prompt": null,
         "questions": null,
-        "solution": "function baseToDisplay(baseAmount, decimals) {\n  return baseAmount / Math.pow(10, decimals);\n}\n\nfunction calculatePrice(reserveA, reserveB) {\n  if (reserveA === 0) return 0;\n  return reserveB / reserveA;\n}\n\nfunction calculateLpShare(userLpTokens, totalLpTokens) {\n  if (totalLpTokens === 0) return 0;\n  return (userLpTokens / totalLpTokens) * 100;\n}\n\nconsole.log(baseToDisplay(1000000, 6));\nconsole.log(calculatePrice(100000, 200000));\nconsole.log(calculateLpShare(500, 10000));\n",
-        "src": null,
-        "starter": "/**\n * Convert base units to display units using decimals\n * @param {number} baseAmount - Amount in base units (e.g., 1_000_000)\n * @param {number} decimals - Token decimals (e.g., 6 for USDC)\n * @returns {number} - Amount in display units (e.g., 1.0)\n */\nfunction baseToDisplay(baseAmount, decimals) {\n  // TODO: Divide baseAmount by 10^decimals\n  return 0;\n}\n\n/**\n * Calculate token price from pool reserves\n * @param {number} reserveA - Reserve of token A\n * @param {number} reserveB - Reserve of token B\n * @returns {number} - Price of token A in terms of token B\n */\nfunction calculatePrice(reserveA, reserveB) {\n  // TODO: Price of A = reserveB / reserveA\n  // Handle division by zero\n  return 0;\n}\n\n/**\n * Calculate user's LP token share percentage\n * @param {number} userLpTokens - User's LP token balance\n * @param {number} totalLpTokens - Total LP tokens in pool\n * @returns {number} - Percentage share (0-100)\n */\nfunction calculateLpShare(userLpTokens, totalLpTokens) {\n  // TODO: (userLpTokens / totalLpTokens) * 100\n  // Handle division by zero\n  return 0;\n}\n\nconsole.log(baseToDisplay(1000000, 6)); // Should output: 1\nconsole.log(calculatePrice(100000, 200000)); // Should output: 2\nconsole.log(calculateLpShare(500, 10000)); // Should output: 5\n",
-        "tests": [
-          {
-            "description": "Converts base units to display (9 decimals)",
-            "expectedOutput": "result === 1",
-            "id": "t1",
-            "input": "1000000000, 9"
-          },
-          {
-            "description": "Converts a larger amount (9 decimals)",
-            "expectedOutput": "result === 2",
-            "id": "t2",
-            "input": "2000000000, 9"
-          },
-          {
-            "description": "Uses the decimals argument (6 decimals)",
-            "expectedOutput": "result === 5",
-            "id": "t3",
-            "input": "5000000, 6"
-          },
-          {
-            "description": "Handles fractional results with a different scale",
-            "expectedOutput": "result === 2.5",
-            "id": "t4",
-            "input": "250, 2"
-          }
-        ],
-        "url": null
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       }
-    ],
-    "slug": "token-math-challenge",
-    "title": "Token Math Challenge"
+    ]
   },
   {
     "_id": "lesson-token-overview",
+    "title": "Understanding SPL Tokens",
+    "slug": "token-overview",
     "blocks": [
       {
-        "_type": "prose",
-        "amount": null,
-        "buildType": null,
-        "consumes": null,
-        "deployable": null,
-        "hints": null,
-        "idl": null,
         "key": "intro",
-        "language": null,
-        "maxWords": null,
-        "network": null,
+        "_type": "prose",
         "produces": null,
-        "prompt": null,
-        "questions": null,
-        "solution": null,
+        "consumes": null,
         "src": "# Understanding SPL Tokens\n\nSPL Tokens are the token standard on Solana, similar to ERC-20 on Ethereum but with key differences.\n\n## How SPL Tokens Work\n\nOn Solana, tokens are managed by the **Token Program**:\n\n1. **Mint Account**: Defines the token (supply, decimals, mint authority)\n2. **Token Account**: Holds tokens for a specific owner\n3. **Associated Token Account (ATA)**: A deterministically derived token account for a given wallet and mint\n\n```\nMint Account (Token Definition)\n  ├── Token Account (User A's balance)\n  ├── Token Account (User B's balance)\n  └── Token Account (User C's balance)\n```\n\n## Key Differences from Ethereum\n\n| Feature | Solana (SPL) | Ethereum (ERC-20) |\n|---------|-------------|-------------------|\n| Token balances | Separate accounts | Single contract |\n| Creating tokens | Token Program | Deploy new contract |\n| Account model | Account-based | Contract storage |\n| Cost | ~0.002 SOL per account | Gas fees vary |\n\n## The Token Program\n\n```typescript\nimport { createMint } from '@solana/spl-token';\n\nconst mint = await createMint(\n  connection,      // Connection\n  payer,           // Fee payer\n  mintAuthority,   // Who can mint new tokens\n  freezeAuthority, // Who can freeze accounts (null = no one)\n  9                // Decimals (9 = standard for SOL-like tokens)\n);\n\nconsole.log('Mint address:', mint.toBase58());\n```\n\n## Creating Token Accounts\n\n```typescript\nimport { getOrCreateAssociatedTokenAccount } from '@solana/spl-token';\n\nconst tokenAccount = await getOrCreateAssociatedTokenAccount(\n  connection,\n  payer,\n  mint,\n  owner.publicKey\n);\n```\n\n## Next Steps\n\nIn the next lesson, you will create your own SPL token on devnet!\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
         "starter": null,
+        "solution": null,
         "tests": null,
-        "url": null
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "retrieval-close",
+        "_type": "quiz",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": [
+          {
+            "id": "q1",
+            "prompt": "On Solana a holder's balance of a token lives in its own Token Account, not in the mint. Why give each holder a separate account instead of one contract tracking everyone like ERC-20?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "Separate per-owner accounts let transfers involving different holders run in parallel and be modified only by the Token Program",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "Because Solana cannot store mappings, so balances must be split",
+                "correct": false,
+                "feedback": "It is not a limitation but a deliberate design. Per-account balances enable parallelism, since two transfers involving different holders touch different accounts."
+              },
+              {
+                "id": "c",
+                "label": "So the mint authority can freeze the entire supply at once",
+                "correct": false,
+                "feedback": "Freezing is a separate authority feature. The per-account model is about parallel execution and clear ownership, not bulk freezing."
+              }
+            ],
+            "explanation": "ERC-20 keeps every balance in one contract's storage, so any two transfers contend on the same contract. Solana gives each (owner, mint) pair its own Token Account, so disjoint transfers parallelize — the same account-model reason Solana scales."
+          },
+          {
+            "id": "q2",
+            "prompt": "An Associated Token Account (ATA) is 'deterministically derived' from a wallet and a mint. What does that let you do before the account even exists?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "Compute the exact ATA address for any wallet+mint off-chain, so you can send to it or create it at a known address",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "Nothing until it is created and assigned a random address",
+                "correct": false,
+                "feedback": "ATAs are not random — they are derived by a fixed formula from the wallet and mint, so the address is knowable in advance."
+              },
+              {
+                "id": "c",
+                "label": "Recover the private key of the token account",
+                "correct": false,
+                "feedback": "ATAs are program-derived addresses with no private key at all. Derivation gives you the address, never a signing key."
+              }
+            ],
+            "explanation": "Because the ATA address is a pure function of (wallet, mint), any client can compute it deterministically. That is why you can send tokens to someone who has not created their account yet, and why get-or-create is a safe idempotent operation."
+          }
+        ],
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       }
-    ],
-    "slug": "token-overview",
-    "title": "Understanding SPL Tokens"
+    ]
   },
   {
     "_id": "lesson-token-standards",
+    "title": "Solana Token Standards",
+    "slug": "token-standards",
     "blocks": [
       {
-        "_type": "prose",
-        "amount": null,
-        "buildType": null,
-        "consumes": null,
-        "deployable": null,
-        "hints": null,
-        "idl": null,
         "key": "intro",
-        "language": null,
-        "maxWords": null,
-        "network": null,
+        "_type": "prose",
         "produces": null,
-        "prompt": null,
-        "questions": null,
-        "solution": null,
-        "src": "# Solana Token Standards\n\nSolana has two token programs: the original **SPL Token** and the newer **Token-2022** with advanced extensions.\n\n## SPL Token Program\n\nThe original token standard (still used by 99% of tokens):\n\n```\nProgram ID: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA\n```\n\n### Account Structure\n\n**Mint Account** (defines the token):\n```\n- Mint Authority: Can mint new tokens\n- Supply: Total tokens in circulation\n- Decimals: Number of decimal places (9 for SOL-like)\n- Freeze Authority: Can freeze token accounts\n```\n\n**Token Account** (holds tokens for an owner):\n```\n- Mint: Which token this account holds\n- Owner: Who owns these tokens\n- Amount: Token balance\n- Delegate: Optional account that can spend on behalf of owner\n- State: Normal, Frozen, or Uninitialized\n```\n\n### Associated Token Account (ATA)\n\nA deterministic token account address:\n\n```typescript\nimport { getAssociatedTokenAddress } from '@solana/spl-token';\n\nconst ata = await getAssociatedTokenAddress(\n  mint,         // Token mint address\n  owner,        // Wallet address\n);\n\n// Derivation: PDA with seeds [owner, TOKEN_PROGRAM_ID, mint]\n```\n\nATAs simplify token transfers (one account per mint per wallet).\n\n## Token-2022 (Token Extensions)\n\nThe new token program with powerful extensions:\n\n```\nProgram ID: TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb\n```\n\n### Why Token-2022?\n\n- **Backwards compatible** with SPL Token\n- **Extensions** add features without changing core program\n- **Future-proof** (can add new extensions)\n\n### Available Extensions\n\n#### 1. Transfer Hooks\n\nExecute custom logic on every transfer:\n\n```rust\n// Example: Charge a fee on every transfer\npub fn transfer_hook(\n    ctx: Context<TransferHook>,\n    amount: u64,\n) -> Result<()> {\n    let fee = amount / 100;  // 1% fee\n    // Deduct fee, send to treasury\n    Ok(())\n}\n```\n\nUse cases:\n- Transaction fees\n- Blacklist/whitelist enforcement\n- Royalties on token transfers\n\n#### 2. Confidential Transfers\n\nPrivacy via zero-knowledge proofs:\n\n```\nNormal transfer: \"Alice sent 100 USDC to Bob\" (public)\nConfidential transfer: \"Alice sent ??? USDC to Bob\" (amount hidden)\n```\n\nBalances are encrypted, but the network verifies the math is correct.\n\n#### 3. Transfer Fees\n\nBuilt-in transfer fee without hooks:\n\n```\nTransfer 1000 tokens with 1% fee:\nRecipient receives: 990 tokens\nFee account receives: 10 tokens\n```\n\n#### 4. Interest-Bearing Tokens\n\nTokens that accrue interest:\n\n```\nRate: 5% APY\nYou hold: 1000 tokens\nAfter 1 year: Balance shows 1050 tokens (automatically)\n```\n\nImplemented via an exchange rate that updates over time.\n\n#### 5. Non-Transferable Tokens\n\nSoulbound tokens (can't be transferred):\n\n```\nUse cases:\n- Credentials (diplomas, certificates)\n- Achievements (non-tradeable NFTs)\n- Identity tokens\n```\n\n#### 6. Permanent Delegate\n\nA delegate that can't be revoked:\n\n```\nUse case: Staking program that needs permanent control\n```\n\n#### 7. Metadata Pointer\n\nStore metadata on-chain (no external JSON):\n\n```json\n{\n  \"name\": \"My Token\",\n  \"symbol\": \"MTK\",\n  \"uri\": \"https://example.com/metadata.json\"\n}\n```\n\nMetaplex Token Metadata is still more common, but metadata pointer is simpler.\n\n### Creating a Token-2022 Mint\n\n```typescript\nimport { createMint } from '@solana/spl-token';\nimport { TOKEN_2022_PROGRAM_ID } from '@solana/spl-token';\n\nconst mint = await createMint(\n  connection,\n  payer,\n  mintAuthority,\n  freezeAuthority,\n  decimals,\n  undefined,  // keypair (optional)\n  undefined,  // confirm options\n  TOKEN_2022_PROGRAM_ID  // Use Token-2022 instead of SPL Token\n);\n```\n\n### Adding Extensions\n\n```typescript\nimport {\n  createInitializeTransferFeeConfigInstruction,\n  createInitializeMintInstruction,\n} from '@solana/spl-token';\n\n// 1. Calculate space needed\nconst extensions = [ExtensionType.TransferFeeConfig];\nconst mintLen = getMintLen(extensions);\n\n// 2. Create account\nconst createAccountIx = SystemProgram.createAccount({\n  fromPubkey: payer.publicKey,\n  newAccountPubkey: mint.publicKey,\n  space: mintLen,\n  lamports: await connection.getMinimumBalanceForRentExemption(mintLen),\n  programId: TOKEN_2022_PROGRAM_ID,\n});\n\n// 3. Initialize extension\nconst initTransferFeeIx = createInitializeTransferFeeConfigInstruction(\n  mint.publicKey,\n  feeAuthority.publicKey,\n  withdrawAuthority.publicKey,\n  feeBasisPoints,  // 100 = 1%\n  maxFee,\n  TOKEN_2022_PROGRAM_ID\n);\n\n// 4. Initialize mint\nconst initMintIx = createInitializeMintInstruction(\n  mint.publicKey,\n  decimals,\n  mintAuthority.publicKey,\n  freezeAuthority.publicKey,\n  TOKEN_2022_PROGRAM_ID\n);\n\n// Send transaction with all 3 instructions\n```\n\n## Token Metadata (Metaplex)\n\nMetaplex Token Metadata is the standard for NFT metadata:\n\n```\nMetadata Account (PDA):\n- Name: \"Solana Monkey #1234\"\n- Symbol: \"SMB\"\n- URI: \"https://arweave.net/...\"\n- Creators: [{ address, verified, share }]\n- Seller Fee Basis Points: 500 (5% royalty)\n- Primary Sale Happened: true/false\n```\n\nThe URI points to JSON:\n\n```json\n{\n  \"name\": \"Solana Monkey #1234\",\n  \"description\": \"A cool monkey\",\n  \"image\": \"https://arweave.net/image.png\",\n  \"attributes\": [\n    { \"trait_type\": \"Background\", \"value\": \"Blue\" },\n    { \"trait_type\": \"Hat\", \"value\": \"Crown\" }\n  ]\n}\n```\n\n## Choosing the Right Standard\n\n| Feature | SPL Token | Token-2022 |\n|---------|-----------|------------|\n| Mature ecosystem | ✅ | ❌ (newer) |\n| DEX support | ✅ All DEXs | ⚠️ Limited |\n| Transfer fees | ❌ | ✅ |\n| Transfer hooks | ❌ | ✅ |\n| Confidential transfers | ❌ | ✅ |\n| Interest-bearing | ❌ | ✅ |\n\n**Use SPL Token** for:\n- General purpose tokens\n- Maximum compatibility\n- Production DeFi\n\n**Use Token-2022** for:\n- Compliance requirements (transfer hooks for KYC)\n- Privacy (confidential transfers)\n- Novel token mechanics (interest-bearing, non-transferable)\n\n## Token Account Rent\n\nToken accounts require rent (~0.002 SOL):\n\n```\nCreate 100 token accounts = 0.2 SOL locked\n```\n\nYou can close accounts to reclaim rent:\n\n```typescript\nimport { closeAccount } from '@solana/spl-token';\n\nawait closeAccount(\n  connection,\n  payer,\n  tokenAccount,\n  destination,  // Where to send reclaimed SOL\n  owner\n);\n```\n\n## Best Practices\n\n1. **Use ATAs** for user-facing wallets (simplifies UX)\n2. **Close unused accounts** to reclaim rent\n3. **Validate token mint** before accepting transfers (prevent spam)\n4. **Check program ID** (SPL Token vs Token-2022 vs fake programs)\n5. **Handle decimals** correctly (9 decimals = 1.0 = 1_000_000_000 base units)\n\n## Next Challenge\n\nYou'll implement token math functions for handling decimals, price calculations, and LP token formulas.\n",
+        "consumes": null,
+        "src": "# Solana Token Standards\n\nSolana has two token programs: the original **SPL Token** and the newer **Token-2022** with advanced extensions.\n\n## SPL Token Program\n\nThe original token standard (still used by 99% of tokens):\n\n```\nProgram ID: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA\n```\n\n### Account Structure\n\n**Mint Account** (defines the token):\n```\n- Mint Authority: Can mint new tokens\n- Supply: Total tokens in circulation\n- Decimals: Number of decimal places (9 for SOL-like)\n- Freeze Authority: Can freeze token accounts\n```\n\n**Token Account** (holds tokens for an owner):\n```\n- Mint: Which token this account holds\n- Owner: Who owns these tokens\n- Amount: Token balance\n- Delegate: Optional account that can spend on behalf of owner\n- State: Normal, Frozen, or Uninitialized\n```\n\n### Associated Token Account (ATA)\n\nA deterministic token account address:\n\n```typescript\nimport { getAssociatedTokenAddress } from '@solana/spl-token';\n\nconst ata = await getAssociatedTokenAddress(\n  mint,         // Token mint address\n  owner,        // Wallet address\n);\n\n// Derivation: PDA with seeds [owner, TOKEN_PROGRAM_ID, mint]\n```\n\nATAs simplify token transfers (one account per mint per wallet).\n\n## Token-2022 (Token Extensions)\n\nThe new token program with powerful extensions:\n\n```\nProgram ID: TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb\n```\n\n### Why Token-2022?\n\n- **Backwards compatible** with SPL Token\n- **Extensions** add features without changing core program\n- **Future-proof** (can add new extensions)\n\n### Available Extensions\n\n#### 1. Transfer Hooks\n\nExecute custom logic on every transfer:\n\n```rust\n// Example: Charge a fee on every transfer\npub fn transfer_hook(\n    ctx: Context<TransferHook>,\n    amount: u64,\n) -> Result<()> {\n    let fee = amount / 100;  // 1% fee\n    // Deduct fee, send to treasury\n    Ok(())\n}\n```\n\nUse cases:\n- Transaction fees\n- Blacklist/whitelist enforcement\n- Royalties on token transfers\n\n#### 2. Confidential Transfers\n\nPrivacy via zero-knowledge proofs:\n\n```\nNormal transfer: \"Alice sent 100 USDC to Bob\" (public)\nConfidential transfer: \"Alice sent ??? USDC to Bob\" (amount hidden)\n```\n\nBalances are encrypted, but the network verifies the math is correct.\n\n#### 3. Transfer Fees\n\nBuilt-in transfer fee without hooks:\n\n```\nTransfer 1000 tokens with 1% fee:\nRecipient receives: 990 tokens\nFee account receives: 10 tokens\n```\n\n#### 4. Interest-Bearing Tokens\n\nTokens that accrue interest:\n\n```\nRate: 5% APY\nYou hold: 1000 tokens\nAfter 1 year: Balance shows 1050 tokens (automatically)\n```\n\nImplemented via an exchange rate that updates over time.\n\n#### 5. Non-Transferable Tokens\n\nSoulbound tokens (can't be transferred):\n\n```\nUse cases:\n- Credentials (diplomas, certificates)\n- Achievements (non-tradeable NFTs)\n- Identity tokens\n```\n\n#### 6. Permanent Delegate\n\nA delegate that can't be revoked:\n\n```\nUse case: Staking program that needs permanent control\n```\n\n#### 7. Metadata Pointer\n\nStore metadata on-chain (no external JSON):\n\n```json\n{\n  \"name\": \"My Token\",\n  \"symbol\": \"MTK\",\n  \"uri\": \"https://example.com/metadata.json\"\n}\n```\n\nMetaplex Token Metadata is still more common, but metadata pointer is simpler.\n\n### Creating a Token-2022 Mint\n\n```typescript\nimport { createMint } from '@solana/spl-token';\nimport { TOKEN_2022_PROGRAM_ID } from '@solana/spl-token';\n\nconst mint = await createMint(\n  connection,\n  payer,\n  mintAuthority,\n  freezeAuthority,\n  decimals,\n  undefined,  // keypair (optional)\n  undefined,  // confirm options\n  TOKEN_2022_PROGRAM_ID  // Use Token-2022 instead of SPL Token\n);\n```\n\n### Adding Extensions\n\n```typescript\nimport {\n  createInitializeTransferFeeConfigInstruction,\n  createInitializeMintInstruction,\n} from '@solana/spl-token';\n\n// 1. Calculate space needed\nconst extensions = [ExtensionType.TransferFeeConfig];\nconst mintLen = getMintLen(extensions);\n\n// 2. Create account\nconst createAccountIx = SystemProgram.createAccount({\n  fromPubkey: payer.publicKey,\n  newAccountPubkey: mint.publicKey,\n  space: mintLen,\n  lamports: await connection.getMinimumBalanceForRentExemption(mintLen),\n  programId: TOKEN_2022_PROGRAM_ID,\n});\n\n// 3. Initialize extension\nconst initTransferFeeIx = createInitializeTransferFeeConfigInstruction(\n  mint.publicKey,\n  feeAuthority.publicKey,\n  withdrawAuthority.publicKey,\n  feeBasisPoints,  // 100 = 1%\n  maxFee,\n  TOKEN_2022_PROGRAM_ID\n);\n\n// 4. Initialize mint\nconst initMintIx = createInitializeMintInstruction(\n  mint.publicKey,\n  decimals,\n  mintAuthority.publicKey,\n  freezeAuthority.publicKey,\n  TOKEN_2022_PROGRAM_ID\n);\n\n// Send transaction with all 3 instructions\n```\n\n## Token Metadata (Metaplex)\n\nMetaplex Token Metadata is the standard for NFT metadata:\n\n```\nMetadata Account (PDA):\n- Name: \"Solana Monkey #1234\"\n- Symbol: \"SMB\"\n- URI: \"https://arweave.net/...\"\n- Creators: [{ address, verified, share }]\n- Seller Fee Basis Points: 500 (5% royalty)\n- Primary Sale Happened: true/false\n```\n\nThe URI points to JSON:\n\n```json\n{\n  \"name\": \"Solana Monkey #1234\",\n  \"description\": \"A cool monkey\",\n  \"image\": \"https://arweave.net/image.png\",\n  \"attributes\": [\n    { \"trait_type\": \"Background\", \"value\": \"Blue\" },\n    { \"trait_type\": \"Hat\", \"value\": \"Crown\" }\n  ]\n}\n```\n\n## Choosing the Right Standard\n\n| Feature | SPL Token | Token-2022 |\n|---------|-----------|------------|\n| DEX support | ✅ All DEXs | ✅ Broad (at parity) |\n| Transfer fees | ❌ | ✅ |\n| Transfer hooks | ❌ | ✅ |\n| Confidential transfers | ❌ | ✅ |\n| Interest-bearing | ❌ | ✅ |\n\n**Use SPL Token** for:\n- General purpose tokens\n- Maximum compatibility\n- Production DeFi\n\n**Use Token-2022** for:\n- Compliance requirements (transfer hooks for KYC)\n- Privacy (confidential transfers)\n- Novel token mechanics (interest-bearing, non-transferable)\n\n## Token Account Rent\n\nToken accounts require rent (~0.002 SOL):\n\n```\nCreate 100 token accounts = 0.2 SOL locked\n```\n\nYou can close accounts to reclaim rent:\n\n```typescript\nimport { closeAccount } from '@solana/spl-token';\n\nawait closeAccount(\n  connection,\n  payer,\n  tokenAccount,\n  destination,  // Where to send reclaimed SOL\n  owner\n);\n```\n\n## Best Practices\n\n1. **Use ATAs** for user-facing wallets (simplifies UX)\n2. **Close unused accounts** to reclaim rent\n3. **Validate token mint** before accepting transfers (prevent spam)\n4. **Check program ID** (SPL Token vs Token-2022 vs fake programs)\n5. **Handle decimals** correctly (9 decimals = 1.0 = 1_000_000_000 base units)\n\n## Next Challenge\n\nYou'll implement token math functions for handling decimals, price calculations, and LP token formulas.\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
         "starter": null,
+        "solution": null,
         "tests": null,
-        "url": null
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       }
-    ],
-    "slug": "token-standards",
-    "title": "Solana Token Standards"
+    ]
   },
   {
     "_id": "lesson-transaction-ui",
+    "title": "Transaction UI Patterns",
+    "slug": "transaction-ui",
     "blocks": [
       {
-        "_type": "prose",
-        "amount": null,
-        "buildType": null,
-        "consumes": null,
-        "deployable": null,
-        "hints": null,
-        "idl": null,
         "key": "intro",
-        "language": null,
-        "maxWords": null,
-        "network": null,
+        "_type": "prose",
         "produces": null,
-        "prompt": null,
-        "questions": null,
-        "solution": null,
+        "consumes": null,
         "src": "# Transaction UI Patterns\n\nSending transactions is the core interaction in any Solana dApp. Great UX requires clear transaction flows, status tracking, and helpful feedback.\n\n## Multi-Step Confirmation Flow\n\nBreak complex transactions into clear steps:\n\n```typescript\nenum TxStep {\n  IDLE = 'idle',\n  CONFIRMING = 'confirming',\n  SIGNING = 'signing',\n  SENDING = 'sending',\n  CONFIRMING_TX = 'confirming_tx',\n  SUCCESS = 'success',\n  ERROR = 'error',\n}\n\nfunction SwapInterface() {\n  const [step, setStep] = useState<TxStep>(TxStep.IDLE);\n  const [signature, setSignature] = useState<string>('');\n\n  async function handleSwap() {\n    try {\n      setStep(TxStep.CONFIRMING);\n      // User reviews swap details\n\n      setStep(TxStep.SIGNING);\n      const { signature } = await sendTransaction(tx, connection);\n      setSignature(signature);\n\n      setStep(TxStep.SENDING);\n      // Transaction sent to network\n\n      setStep(TxStep.CONFIRMING_TX);\n      await connection.confirmTransaction(signature, 'confirmed');\n\n      setStep(TxStep.SUCCESS);\n    } catch (err) {\n      setStep(TxStep.ERROR);\n    }\n  }\n\n  return (\n    <div>\n      {step === TxStep.CONFIRMING && <ReviewModal />}\n      {step === TxStep.SIGNING && <WalletSigningPrompt />}\n      {step === TxStep.SENDING && <SendingAnimation />}\n      {step === TxStep.CONFIRMING_TX && <ConfirmingAnimation signature={signature} />}\n      {step === TxStep.SUCCESS && <SuccessMessage signature={signature} />}\n      {step === TxStep.ERROR && <ErrorMessage />}\n    </div>\n  );\n}\n```\n\n## Status Indicators\n\nShow clear visual feedback for each stage:\n\n```typescript\nfunction TransactionStatus({ step }: { step: TxStep }) {\n  const stages = [\n    { label: 'Review', step: TxStep.CONFIRMING },\n    { label: 'Sign', step: TxStep.SIGNING },\n    { label: 'Send', step: TxStep.SENDING },\n    { label: 'Confirm', step: TxStep.CONFIRMING_TX },\n  ];\n\n  return (\n    <div className=\"flex gap-2\">\n      {stages.map((stage, idx) => (\n        <div key={idx} className=\"flex items-center\">\n          <div className={cn(\n            \"w-8 h-8 rounded-full flex items-center justify-center\",\n            step === stage.step && \"bg-purple-600 text-white\",\n            idx < stages.findIndex(s => s.step === step) && \"bg-green-600\",\n          )}>\n            {idx < stages.findIndex(s => s.step === step) ? '✓' : idx + 1}\n          </div>\n          <span className=\"ml-2\">{stage.label}</span>\n        </div>\n      ))}\n    </div>\n  );\n}\n```\n\n## Explorer Links\n\nAlways provide links to view transactions on-chain:\n\n```typescript\nfunction ExplorerLink({\n  signature,\n  cluster = 'mainnet-beta',\n}: {\n  signature: string;\n  cluster?: string;\n}) {\n  const url = `https://explorer.solana.com/tx/${signature}${cluster !== 'mainnet-beta' ? `?cluster=${cluster}` : ''}`;\n\n  return (\n    <a\n      href={url}\n      target=\"_blank\"\n      rel=\"noopener noreferrer\"\n      className=\"text-purple-600 hover:underline flex items-center gap-1\"\n    >\n      View on Solana Explorer\n      <ExternalLinkIcon className=\"w-4 h-4\" />\n    </a>\n  );\n}\n```\n\n## Estimated Cost Display\n\nShow users the transaction cost before signing:\n\n```typescript\nasync function estimateTransactionCost(\n  transaction: Transaction,\n  connection: Connection\n): Promise<number> {\n  const { blockhash } = await connection.getLatestBlockhash();\n  transaction.recentBlockhash = blockhash;\n  \n  // Estimate fee\n  const fee = await transaction.getEstimatedFee(connection);\n  return fee || 5000; // Default fallback\n}\n\nfunction TransactionPreview({ transaction }: { transaction: Transaction }) {\n  const { connection } = useConnection();\n  const [fee, setFee] = useState<number | null>(null);\n\n  useEffect(() => {\n    estimateTransactionCost(transaction, connection).then(setFee);\n  }, [transaction, connection]);\n\n  return (\n    <div className=\"bg-gray-100 p-4 rounded\">\n      <p className=\"text-sm text-gray-600\">Estimated network fee</p>\n      <p className=\"text-lg font-bold\">\n        {fee ? `${(fee / LAMPORTS_PER_SOL).toFixed(6)} SOL` : 'Calculating...'}\n      </p>\n    </div>\n  );\n}\n```\n\n## Retry Logic\n\nHandle failed transactions gracefully:\n\n```typescript\nfunction useTransactionSender() {\n  const { connection } = useConnection();\n  const { sendTransaction } = useWallet();\n  const [attempts, setAttempts] = useState(0);\n\n  async function sendWithRetry(\n    transaction: Transaction,\n    maxRetries = 3\n  ): Promise<string> {\n    for (let i = 0; i < maxRetries; i++) {\n      setAttempts(i + 1);\n\n      try {\n        const signature = await sendTransaction(transaction, connection);\n        await connection.confirmTransaction(signature, 'confirmed');\n        return signature;\n      } catch (err) {\n        if (i === maxRetries - 1) throw err;\n        \n        // Wait before retry (exponential backoff)\n        await new Promise(resolve => setTimeout(resolve, 1000 * Math.pow(2, i)));\n      }\n    }\n\n    throw new Error('Transaction failed after retries');\n  }\n\n  return { sendWithRetry, attempts };\n}\n```\n\n## Transaction History\n\nShow users their past transactions:\n\n```typescript\nfunction TransactionHistory() {\n  const { publicKey } = useWallet();\n  const { connection } = useConnection();\n  const [txs, setTxs] = useState<ParsedTransactionWithMeta[]>([]);\n\n  useEffect(() => {\n    if (!publicKey) return;\n\n    connection.getSignaturesForAddress(publicKey, { limit: 10 })\n      .then(async (sigs) => {\n        const txPromises = sigs.map(sig => \n          connection.getParsedTransaction(sig.signature, {\n            maxSupportedTransactionVersion: 0,\n          })\n        );\n        const txs = await Promise.all(txPromises);\n        setTxs(txs.filter(tx => tx !== null));\n      });\n  }, [publicKey, connection]);\n\n  return (\n    <div>\n      {txs.map((tx, idx) => (\n        <TransactionCard key={idx} tx={tx} />\n      ))}\n    </div>\n  );\n}\n```\n\n## Real-World Examples\n\n### Jupiter Swap Flow\n1. Review swap (token amounts, slippage, price impact)\n2. Approve transaction in wallet\n3. Show \"Swapping...\" animation with explorer link\n4. Confirm on-chain (with retry logic)\n5. Show success with new token balance\n\n### Magic Eden NFT Purchase\n1. Show NFT details and price\n2. Check buyer has sufficient SOL\n3. Request wallet signature\n4. Stream transaction status updates\n5. Display purchase confirmation with NFT preview\n\n## Best Practices\n\n1. Always show transaction cost before signing\n2. Provide explorer links for every transaction\n3. Use optimistic updates for instant feedback\n4. Implement retry logic for network hiccups\n5. Clear error messages (insufficient funds, rejected, timeout)\n6. Show multi-step progress for complex flows\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
         "starter": null,
+        "solution": null,
         "tests": null,
-        "url": null
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       }
-    ],
-    "slug": "transaction-ui",
-    "title": "Transaction UI Patterns"
+    ]
   },
   {
     "_id": "lesson-transfer-challenge",
+    "title": "Challenge: Build a Transfer Function",
+    "slug": "transfer-challenge",
     "blocks": [
       {
-        "_type": "prose",
-        "amount": null,
-        "buildType": null,
-        "consumes": null,
-        "deployable": null,
-        "hints": null,
-        "idl": null,
         "key": "intro",
-        "language": null,
-        "maxWords": null,
-        "network": null,
+        "_type": "prose",
         "produces": null,
-        "prompt": null,
-        "questions": null,
-        "solution": null,
+        "consumes": null,
         "src": "# Challenge: Build a Transfer Function\n\nCreate a function that builds a SOL transfer transaction. The function should take a sender public key, recipient public key, and amount in SOL, then return the transaction object ready to be signed.\n\n## Requirements\n\n- Accept sender (PublicKey), recipient (PublicKey), and amount (number, in SOL)\n- Convert SOL amount to lamports\n- Create and return a Transaction with a SystemProgram.transfer instruction\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
         "starter": null,
+        "solution": null,
         "tests": null,
-        "url": null
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       },
       {
+        "key": "exercise",
         "_type": "code",
-        "amount": null,
-        "buildType": "standard",
+        "produces": null,
         "consumes": null,
+        "src": null,
+        "url": null,
+        "language": "typescript",
+        "buildType": "standard",
         "deployable": false,
+        "starter": "import {\n  PublicKey,\n  SystemProgram,\n  Transaction,\n  LAMPORTS_PER_SOL,\n} from '@solana/web3.js';\n\nfunction buildTransferTransaction(\n  sender: PublicKey,\n  recipient: PublicKey,\n  amountInSol: number\n): Transaction {\n  // Your code here\n}\n",
+        "solution": "import {\n  PublicKey,\n  SystemProgram,\n  Transaction,\n  LAMPORTS_PER_SOL,\n} from '@solana/web3.js';\n\nfunction buildTransferTransaction(\n  sender: PublicKey,\n  recipient: PublicKey,\n  amountInSol: number\n): Transaction {\n  const transaction = new Transaction().add(\n    SystemProgram.transfer({\n      fromPubkey: sender,\n      toPubkey: recipient,\n      lamports: amountInSol * LAMPORTS_PER_SOL,\n    })\n  );\n\n  return transaction;\n}\n",
+        "tests": [
+          {
+            "id": "t1",
+            "description": "Returns a Transaction",
+            "input": "sender, recipient, 1.0",
+            "expectedOutput": "result instanceof Transaction"
+          },
+          {
+            "id": "t2",
+            "description": "Contains exactly one instruction",
+            "input": "sender, recipient, 1.0",
+            "expectedOutput": "result.instructions.length === 1"
+          },
+          {
+            "id": "t3",
+            "description": "Converts SOL to the correct lamports amount",
+            "input": "sender, recipient, 1.0",
+            "expectedOutput": "result.instructions[0].lamports === 1000000000"
+          },
+          {
+            "id": "t4",
+            "description": "Converts a different SOL amount to lamports",
+            "input": "sender, recipient, 2.5",
+            "expectedOutput": "result.instructions[0].lamports === 2500000000"
+          }
+        ],
         "hints": [
           "Use LAMPORTS_PER_SOL to convert SOL to lamports",
           "SystemProgram.transfer() creates the instruction; wrap it in new Transaction().add()",
           "The lamports field expects a whole number, so multiply amountInSol * LAMPORTS_PER_SOL"
         ],
-        "idl": null,
-        "key": "exercise",
-        "language": "typescript",
-        "maxWords": null,
-        "network": null,
-        "produces": null,
-        "prompt": null,
         "questions": null,
-        "solution": "import {\n  PublicKey,\n  SystemProgram,\n  Transaction,\n  LAMPORTS_PER_SOL,\n} from '@solana/web3.js';\n\nfunction buildTransferTransaction(\n  sender: PublicKey,\n  recipient: PublicKey,\n  amountInSol: number\n): Transaction {\n  const transaction = new Transaction().add(\n    SystemProgram.transfer({\n      fromPubkey: sender,\n      toPubkey: recipient,\n      lamports: amountInSol * LAMPORTS_PER_SOL,\n    })\n  );\n\n  return transaction;\n}\n",
-        "src": null,
-        "starter": "import {\n  PublicKey,\n  SystemProgram,\n  Transaction,\n  LAMPORTS_PER_SOL,\n} from '@solana/web3.js';\n\nfunction buildTransferTransaction(\n  sender: PublicKey,\n  recipient: PublicKey,\n  amountInSol: number\n): Transaction {\n  // Your code here\n}\n",
-        "tests": [
-          {
-            "description": "Returns a Transaction",
-            "expectedOutput": "result instanceof Transaction",
-            "id": "t1",
-            "input": "sender, recipient, 1.0"
-          },
-          {
-            "description": "Contains exactly one instruction",
-            "expectedOutput": "result.instructions.length === 1",
-            "id": "t2",
-            "input": "sender, recipient, 1.0"
-          },
-          {
-            "description": "Converts SOL to the correct lamports amount",
-            "expectedOutput": "result.instructions[0].lamports === 1000000000",
-            "id": "t3",
-            "input": "sender, recipient, 1.0"
-          },
-          {
-            "description": "Converts a different SOL amount to lamports",
-            "expectedOutput": "result.instructions[0].lamports === 2500000000",
-            "id": "t4",
-            "input": "sender, recipient, 2.5"
-          }
-        ],
-        "url": null
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       }
-    ],
-    "slug": "transfer-challenge",
-    "title": "Challenge: Build a Transfer Function"
+    ]
   },
   {
     "_id": "lesson-vault-challenge",
+    "title": "DeFi Vault Simulator",
+    "slug": "vault-challenge",
     "blocks": [
       {
-        "_type": "prose",
-        "amount": null,
-        "buildType": null,
-        "consumes": null,
-        "deployable": null,
-        "hints": null,
-        "idl": null,
         "key": "intro",
-        "language": null,
-        "maxWords": null,
-        "network": null,
+        "_type": "prose",
         "produces": null,
-        "prompt": null,
-        "questions": null,
-        "solution": null,
+        "consumes": null,
         "src": "# DeFi Vault Simulator\n\nBuild a simplified DeFi vault that tracks deposits, shares, and exchange rates.\n\nYour vault accepts deposits of an underlying token and mints vault shares. As the vault generates yield, the exchange rate between shares and underlying increases. Users can redeem shares for their proportional amount of underlying assets.\n\n**Key concepts**:\n- Track total underlying assets and total shares issued\n- Calculate exchange rate when depositing and withdrawing\n- Ensure the first depositor doesn't get unfair advantages\n\nThis is the core mechanic behind yield aggregators like Francium and Tulip Protocol.\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
         "starter": null,
+        "solution": null,
         "tests": null,
-        "url": null
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       },
       {
+        "key": "exercise",
         "_type": "code",
-        "amount": null,
-        "buildType": "standard",
+        "produces": null,
         "consumes": null,
+        "src": null,
+        "url": null,
+        "language": "typescript",
+        "buildType": "standard",
         "deployable": false,
+        "starter": "const vault = {\n  totalAssets: 0,\n  totalShares: 0,\n  users: {} // username -> shares balance\n};\n\n/**\n * Deposit assets into vault and mint shares\n * @param {string} user - Username\n * @param {number} amount - Amount to deposit\n */\nfunction deposit(user, amount) {\n  // TODO: Calculate shares to mint\n  // If vault is empty: shares = amount (1:1 ratio)\n  // Otherwise: shares = (amount * totalShares) / totalAssets\n  \n  // TODO: Update vault state\n  // vault.totalAssets += amount\n  // vault.totalShares += shares\n  \n  // TODO: Update user balance\n  // vault.users[user] = (vault.users[user] || 0) + shares\n  \n  return 0;\n}\n\n/**\n * Withdraw assets from vault by burning shares\n * @param {string} user - Username\n * @param {number} shares - Number of shares to burn\n * @returns {number} - Amount of assets withdrawn\n */\nfunction withdraw(user, shares) {\n  // TODO: Calculate assets to return\n  // assets = (shares * totalAssets) / totalShares\n  \n  // TODO: Update vault state\n  // vault.totalShares -= shares\n  // vault.totalAssets -= assets\n  \n  // TODO: Update user balance\n  // vault.users[user] -= shares\n  \n  return 0;\n}\n\n/**\n * Simulate yield generation\n * @param {number} amount - Yield amount to add\n */\nfunction addYield(amount) {\n  // TODO: Add to totalAssets (increases exchange rate)\n  vault.totalAssets += amount;\n}\n",
+        "solution": "const vault = {\n  totalAssets: 0,\n  totalShares: 0,\n  users: {}\n};\n\nfunction deposit(user, amount) {\n  let shares;\n  \n  if (vault.totalShares === 0) {\n    shares = amount;\n  } else {\n    shares = (amount * vault.totalShares) / vault.totalAssets;\n  }\n  \n  vault.totalAssets += amount;\n  vault.totalShares += shares;\n  vault.users[user] = (vault.users[user] || 0) + shares;\n  \n  return shares;\n}\n\nfunction withdraw(user, shares) {\n  const assets = (shares * vault.totalAssets) / vault.totalShares;\n  \n  vault.totalShares -= shares;\n  vault.totalAssets -= assets;\n  vault.users[user] -= shares;\n  \n  return assets;\n}\n\nfunction addYield(amount) {\n  vault.totalAssets += amount;\n}\n",
+        "tests": [
+          {
+            "id": "test-1",
+            "description": "First deposit of 100 should return 100 shares",
+            "input": "'alice', 100",
+            "expectedOutput": "typeof result === 'number' && result === 100"
+          },
+          {
+            "id": "test-2",
+            "description": "Deposit should return positive share amount",
+            "input": "'alice', 200",
+            "expectedOutput": "typeof result === 'number' && result > 0"
+          },
+          {
+            "id": "test-3",
+            "description": "Any valid deposit should yield shares",
+            "input": "'alice', 50",
+            "expectedOutput": "typeof result === 'number' && result > 0"
+          }
+        ],
         "hints": [
           "For the first deposit, mint shares equal to the deposit amount (1:1 ratio). For subsequent deposits, maintain the current exchange rate: shares = amount * totalShares / totalAssets",
           "When withdrawing, convert shares back to assets using the current exchange rate: assets = shares * totalAssets / totalShares",
           "The addYield function only needs to increase totalAssets. This automatically improves the exchange rate for all share holders."
         ],
-        "idl": null,
-        "key": "exercise",
-        "language": "typescript",
-        "maxWords": null,
-        "network": null,
-        "produces": null,
-        "prompt": null,
         "questions": null,
-        "solution": "const vault = {\n  totalAssets: 0,\n  totalShares: 0,\n  users: {}\n};\n\nfunction deposit(user, amount) {\n  let shares;\n  \n  if (vault.totalShares === 0) {\n    shares = amount;\n  } else {\n    shares = (amount * vault.totalShares) / vault.totalAssets;\n  }\n  \n  vault.totalAssets += amount;\n  vault.totalShares += shares;\n  vault.users[user] = (vault.users[user] || 0) + shares;\n  \n  return shares;\n}\n\nfunction withdraw(user, shares) {\n  const assets = (shares * vault.totalAssets) / vault.totalShares;\n  \n  vault.totalShares -= shares;\n  vault.totalAssets -= assets;\n  vault.users[user] -= shares;\n  \n  return assets;\n}\n\nfunction addYield(amount) {\n  vault.totalAssets += amount;\n}\n",
-        "src": null,
-        "starter": "const vault = {\n  totalAssets: 0,\n  totalShares: 0,\n  users: {} // username -> shares balance\n};\n\n/**\n * Deposit assets into vault and mint shares\n * @param {string} user - Username\n * @param {number} amount - Amount to deposit\n */\nfunction deposit(user, amount) {\n  // TODO: Calculate shares to mint\n  // If vault is empty: shares = amount (1:1 ratio)\n  // Otherwise: shares = (amount * totalShares) / totalAssets\n  \n  // TODO: Update vault state\n  // vault.totalAssets += amount\n  // vault.totalShares += shares\n  \n  // TODO: Update user balance\n  // vault.users[user] = (vault.users[user] || 0) + shares\n  \n  return 0;\n}\n\n/**\n * Withdraw assets from vault by burning shares\n * @param {string} user - Username\n * @param {number} shares - Number of shares to burn\n * @returns {number} - Amount of assets withdrawn\n */\nfunction withdraw(user, shares) {\n  // TODO: Calculate assets to return\n  // assets = (shares * totalAssets) / totalShares\n  \n  // TODO: Update vault state\n  // vault.totalShares -= shares\n  // vault.totalAssets -= assets\n  \n  // TODO: Update user balance\n  // vault.users[user] -= shares\n  \n  return 0;\n}\n\n/**\n * Simulate yield generation\n * @param {number} amount - Yield amount to add\n */\nfunction addYield(amount) {\n  // TODO: Add to totalAssets (increases exchange rate)\n  vault.totalAssets += amount;\n}\n",
-        "tests": [
-          {
-            "description": "First deposit of 100 should return 100 shares",
-            "expectedOutput": "typeof result === 'number' && result === 100",
-            "id": "test-1",
-            "input": "'alice', 100"
-          },
-          {
-            "description": "Deposit should return positive share amount",
-            "expectedOutput": "typeof result === 'number' && result > 0",
-            "id": "test-2",
-            "input": "'alice', 200"
-          },
-          {
-            "description": "Any valid deposit should yield shares",
-            "expectedOutput": "typeof result === 'number' && result > 0",
-            "id": "test-3",
-            "input": "'alice', 50"
-          }
-        ],
-        "url": null
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       }
-    ],
-    "slug": "vault-challenge",
-    "title": "DeFi Vault Simulator"
+    ]
   },
   {
     "_id": "lesson-wallet-adapter-intro",
+    "title": "Solana Wallet Adapter Architecture",
+    "slug": "wallet-adapter-intro",
     "blocks": [
       {
-        "_type": "prose",
-        "amount": null,
-        "buildType": null,
-        "consumes": null,
-        "deployable": null,
-        "hints": null,
-        "idl": null,
         "key": "intro",
-        "language": null,
-        "maxWords": null,
-        "network": null,
+        "_type": "prose",
         "produces": null,
-        "prompt": null,
-        "questions": null,
-        "solution": null,
+        "consumes": null,
         "src": "# Solana Wallet Adapter Architecture\n\nThe Solana Wallet Adapter is the standard library for integrating wallet connections in Solana dApps. It provides a unified interface for multiple wallet providers.\n\n## Why Wallet Adapter?\n\nWithout Wallet Adapter, you would need to write custom integration code for each wallet:\n- Phantom has its own API\n- Solflare has different methods\n- Backpack uses a different connection flow\n\nWallet Adapter **abstracts all of this** into a single, consistent API.\n\n## Core Architecture\n\n```\n┌──────────────────────┐\n│   Your React App     │\n└──────────┬───────────┘\n           │\n┌──────────▼───────────┐\n│  Wallet Adapter      │  ← Hooks: useWallet, useConnection\n│  Context Provider    │\n└──────────┬───────────┘\n           │\n    ┌──────┴──────┐\n    │             │\n┌───▼────┐   ┌───▼────┐   ┌─────────┐\n│Phantom │   │Solflare│   │Backpack │  ← Wallet Implementations\n└────────┘   └────────┘   └─────────┘\n```\n\n## Setting Up the Provider\n\n```typescript\nimport { WalletAdapterNetwork } from '@solana/wallet-adapter-base';\nimport { PhantomWalletAdapter, SolflareWalletAdapter } from '@solana/wallet-adapter-wallets';\nimport { ConnectionProvider, WalletProvider } from '@solana/wallet-adapter-react';\nimport { WalletModalProvider } from '@solana/wallet-adapter-react-ui';\nimport { clusterApiUrl } from '@solana/web3.js';\n\nfunction App() {\n  const network = WalletAdapterNetwork.Devnet;\n  const endpoint = clusterApiUrl(network);\n  \n  const wallets = [\n    new PhantomWalletAdapter(),\n    new SolflareWalletAdapter({ network }),\n  ];\n\n  return (\n    <ConnectionProvider endpoint={endpoint}>\n      <WalletProvider wallets={wallets} autoConnect>\n        <WalletModalProvider>\n          <YourApp />\n        </WalletModalProvider>\n      </WalletProvider>\n    </ConnectionProvider>\n  );\n}\n```\n\n## Key Hooks\n\n### useWallet()\n\nAccess wallet state and methods:\n\n```typescript\nimport { useWallet } from '@solana/wallet-adapter-react';\n\nfunction ConnectButton() {\n  const { publicKey, connected, connect, disconnect, signMessage } = useWallet();\n\n  if (connected && publicKey) {\n    return (\n      <div>\n        <p>Connected: {publicKey.toBase58().slice(0, 8)}...</p>\n        <button onClick={disconnect}>Disconnect</button>\n      </div>\n    );\n  }\n\n  return <button onClick={connect}>Connect Wallet</button>;\n}\n```\n\n### useConnection()\n\nAccess the RPC connection:\n\n```typescript\nimport { useConnection } from '@solana/wallet-adapter-react';\nimport { LAMPORTS_PER_SOL } from '@solana/web3.js';\n\nfunction BalanceDisplay() {\n  const { connection } = useConnection();\n  const { publicKey } = useWallet();\n  const [balance, setBalance] = useState(0);\n\n  useEffect(() => {\n    if (!publicKey) return;\n\n    connection.getBalance(publicKey).then(lamports => {\n      setBalance(lamports / LAMPORTS_PER_SOL);\n    });\n  }, [publicKey, connection]);\n\n  return <p>Balance: {balance.toFixed(2)} SOL</p>;\n}\n```\n\n## Supported Wallets\n\nThe adapter supports all major Solana wallets:\n- **Phantom**: Most popular, mobile + extension\n- **Solflare**: Advanced features, built-in swap\n- **Backpack**: xNFT platform, mobile-first\n- **Ledger**: Hardware wallet support\n- **Glow**: Focused on validator staking\n\n## Auto-Connect and Persistence\n\nThe `autoConnect` prop attempts to reconnect on page load:\n\n```typescript\n<WalletProvider wallets={wallets} autoConnect>\n  {/* ... */}\n</WalletProvider>\n```\n\nWallet Adapter automatically saves the last connected wallet to localStorage and restores it on refresh.\n\n## Next Steps\n\nIn the next challenge, you'll implement a wallet connection flow and extract the user's public key.\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
         "starter": null,
+        "solution": null,
         "tests": null,
-        "url": null
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       }
-    ],
-    "slug": "wallet-adapter-intro",
-    "title": "Solana Wallet Adapter Architecture"
+    ]
   },
   {
     "_id": "lesson-wallet-setup",
+    "title": "Setting Up a Solana Wallet",
+    "slug": "wallet-setup",
     "blocks": [
       {
-        "_type": "prose",
-        "amount": null,
-        "buildType": null,
-        "consumes": null,
-        "deployable": null,
-        "hints": null,
-        "idl": null,
         "key": "intro",
-        "language": null,
-        "maxWords": null,
-        "network": null,
+        "_type": "prose",
         "produces": null,
-        "prompt": null,
-        "questions": null,
-        "solution": null,
+        "consumes": null,
         "src": "# Setting Up a Solana Wallet\n\nA wallet is your gateway to the Solana ecosystem. It stores your private keys and lets you sign transactions.\n\n## Phantom Wallet (Recommended)\n\n1. Visit [phantom.app](https://phantom.app) and install the browser extension\n2. Click \"Create a new wallet\"\n3. **Write down your recovery phrase** and store it safely\n4. Set a password for your wallet\n\n## Understanding Keypairs\n\nIn Solana, a **keypair** consists of:\n- **Public Key**: Your wallet address (safe to share)\n- **Private Key**: Used to sign transactions (NEVER share this)\n\n```typescript\nimport { Keypair } from '@solana/web3.js';\n\n// Generate a new keypair\nconst keypair = Keypair.generate();\n\nconsole.log('Public Key:', keypair.publicKey.toBase58());\n// Example: 7C4jsPZpht42Tw6MjXWF56Q5RQUocjBBmciEjDa8HRtp\n```\n\n## Connecting to Devnet\n\nSwitch your Phantom wallet to Devnet:\n1. Open Phantom settings\n2. Go to \"Developer Settings\"\n3. Change network to \"Devnet\"\n\n## Getting Devnet SOL\n\nYou can get free devnet SOL from:\n- Solana CLI: `solana airdrop 2`\n- [Sol Faucet](https://faucet.solana.com)\n\nDevnet SOL has no real value and is only for testing.\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
         "starter": null,
+        "solution": null,
         "tests": null,
-        "url": null
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "retrieval-close",
+        "_type": "quiz",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": [
+          {
+            "id": "q1",
+            "prompt": "You paste your wallet's recovery phrase into a site that asks for it 'to verify your account.' What is the consequence?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "Anyone with that phrase can reconstruct your private key and sign transactions as you, draining the wallet",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "Nothing — the phrase only works inside your original Phantom install",
+                "correct": false,
+                "feedback": "The phrase is portable by design: it regenerates the same keypair in any wallet. That portability is exactly why it must never be shared."
+              },
+              {
+                "id": "c",
+                "label": "They can see your balance but cannot move funds without your app password",
+                "correct": false,
+                "feedback": "The app password only unlocks the local extension. The recovery phrase reconstructs the private key itself, which is all that is needed to sign transfers."
+              }
+            ],
+            "explanation": "A recovery phrase deterministically regenerates your private key. Your public key is safe to share (it is your address); the private key and the phrase that derives it authorize spending. No password or app boundary protects you once the phrase leaks."
+          },
+          {
+            "id": "q2",
+            "prompt": "Which key do you give someone so they can send you SOL, and which one signs when you send SOL?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "Share the public key to receive; the private key signs when you send",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "Share the private key to receive; the public key signs when you send",
+                "correct": false,
+                "feedback": "Reversed, and dangerous. The private key is never shared — it is the secret that signs. The public key is your address, safe to hand out."
+              },
+              {
+                "id": "c",
+                "label": "Both use the public key",
+                "correct": false,
+                "feedback": "Receiving uses the public key, but signing requires the private key — the public key alone cannot authorize a transfer."
+              },
+              {
+                "id": "d",
+                "label": "Both use the private key",
+                "correct": false,
+                "feedback": "You would never share a private key to receive funds. Receiving only needs your public address."
+              }
+            ],
+            "explanation": "The keypair splits by role: the public key is your shareable address for receiving, and the private key is the secret that produces signatures when sending. Signing proves ownership without ever revealing the private key."
+          }
+        ],
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       }
-    ],
-    "slug": "wallet-setup",
-    "title": "Setting Up a Solana Wallet"
+    ]
   },
   {
     "_id": "lesson-why-rust",
+    "title": "Why Rust for Solana",
+    "slug": "why-rust",
     "blocks": [
       {
-        "_type": "prose",
-        "amount": null,
-        "buildType": null,
-        "consumes": null,
-        "deployable": null,
-        "hints": null,
-        "idl": null,
         "key": "intro",
-        "language": null,
-        "maxWords": null,
-        "network": null,
+        "_type": "prose",
         "produces": null,
-        "prompt": null,
-        "questions": null,
-        "solution": null,
+        "consumes": null,
         "src": "# Why Rust for Solana\n\nSolana chose Rust as its primary programming language for smart contracts (called \"programs\" in Solana) for several compelling reasons that directly impact security, performance, and developer experience.\n\n## Memory Safety Without Garbage Collection\n\nRust's ownership system guarantees memory safety at compile time without needing a garbage collector. This is critical for blockchain programs where:\n- **Predictable performance**: No GC pauses that could cause transaction timeouts\n- **Low resource usage**: Programs run in a constrained environment with limited compute units\n- **Security**: Buffer overflows and use-after-free bugs are prevented at compile time\n\n```rust\n// Rust prevents this at compile time:\nlet data = vec![1, 2, 3];\nlet reference = &data[0];\ndrop(data); // Error: cannot drop while borrowed\nprintln!(\"{}\", reference);\n```\n\n## Zero-Cost Abstractions\n\nRust allows you to write high-level code that compiles down to the same performance as hand-written assembly. Abstractions like iterators, generics, and trait objects have no runtime overhead:\n\n```rust\n// This iterator chain compiles to the same code as a manual loop:\nlet sum: u64 = accounts.iter()\n    .filter(|a| a.lamports > 0)\n    .map(|a| a.lamports)\n    .sum();\n```\n\n## Ownership Model Maps to Solana's Account Model\n\nSolana's account model and Rust's ownership system align perfectly:\n- **Mutable XOR shared**: An account can be passed as mutable to only ONE program at a time, just like Rust's `&mut` borrows\n- **Explicit transfers**: Ownership transfers are explicit in both systems\n- **Lifetime tracking**: Rust ensures references don't outlive the data they point to, preventing dangling account references\n\n## Comparison with Other Languages\n\n**C/C++**: Similar performance, but no memory safety guarantees. Vulnerabilities like reentrancy attacks and buffer overflows are common.\n\n**JavaScript/Python**: Easy to write but interpreted, slow, and unsuitable for blockchain's performance constraints.\n\n**Go**: Has garbage collection which introduces unpredictable pauses.\n\nRust gives you C-level performance with Python-level safety guarantees—the perfect balance for blockchain development.\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
         "starter": null,
+        "solution": null,
         "tests": null,
-        "url": null
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "retrieval-close",
+        "_type": "quiz",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": [
+          {
+            "id": "q1",
+            "prompt": "Solana runs programs under a tight compute budget with no room for GC pauses. How does Rust give memory safety without a garbage collector?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "Its ownership and borrow rules are checked at compile time, so memory is freed deterministically with no runtime collector",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "It runs a lightweight garbage collector tuned for short pauses",
+                "correct": false,
+                "feedback": "Rust has no garbage collector at all. Safety is proven at compile time via ownership, so there is nothing to pause at runtime."
+              },
+              {
+                "id": "c",
+                "label": "It leaks memory but the validator resets between transactions",
+                "correct": false,
+                "feedback": "It does not rely on leaking. Ownership frees values deterministically when they go out of scope — no leak, no GC."
+              }
+            ],
+            "explanation": "Rust's compiler enforces ownership and borrowing statically and inserts deterministic cleanup when values leave scope. There is no runtime collector, so no GC pauses can blow a transaction's compute budget — exactly what a constrained on-chain environment needs."
+          },
+          {
+            "id": "q2",
+            "prompt": "The lesson says Rust's `&mut` rule maps to Solana's account model. Which pairing is correct?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "One-mutable-XOR-many-shared borrows mirror one-writer-XOR-many-readers on an account per transaction",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "Rust's `&mut` maps to a program's upgrade authority",
+                "correct": false,
+                "feedback": "Upgrade authority is unrelated. The mapping is between Rust's exclusive-mutable-borrow rule and Solana allowing only one writer to an account at a time."
+              },
+              {
+                "id": "c",
+                "label": "Rust ownership maps to which validator produces the next block",
+                "correct": false,
+                "feedback": "Block production is consensus, not ownership. The analogy is borrow exclusivity mapping to single-writer account access."
+              }
+            ],
+            "explanation": "Rust allows either one mutable borrow or many immutable borrows, never both. Solana lets one transaction write an account while others read — the same mutable-XOR-shared shape. That alignment is why the ownership discipline you learn in Rust transfers directly to reasoning about account access."
+          }
+        ],
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
       }
-    ],
-    "slug": "why-rust",
-    "title": "Why Rust for Solana"
+    ]
   },
   {
     "_id": "lesson-sap-payment-rails-decision-map",
@@ -3794,7 +5923,13 @@
         "maxWords": null,
         "amount": null,
         "network": null,
-        "idl": null
+        "idl": null,
+        "tutorNotes": [
+          "Learners treat the compliance stop as one branch among the rails rather than a gate that runs before any rail is chosen, so a cross-border-FX requirement gets a rail and only afterwards a stop that can no longer fire.",
+          "They add a second cross-border check instead of relocating the existing one, leaving two guards and duplicated logic.",
+          "They assume `unsupported` is the catch-all for anything unusual and route blocked FX requirements there instead of to the compliance stop.",
+          "They reorder the rail branches too, breaking cases the starter already handled correctly — only the guard's position is wrong."
+        ]
       },
       {
         "key": "check",
@@ -4234,7 +6369,14 @@
         "maxWords": null,
         "amount": null,
         "network": null,
-        "idl": null
+        "idl": null,
+        "tutorNotes": [
+          "Learners scan the mint's own configured extensions and return the first one, so a mint carrying two gets a verdict that depends on authoring order rather than the fixed DISQUALIFYING order.",
+          "They check the required extension or the veto before confirming the owner is a token program at all, so the precedence between design-errors and rail-vetoes comes out wrong.",
+          "They treat Token-2022-with-nothing-to-justify-it as a rejection; the rail accepts it (`accepted: true`) while still flagging the choice as unnecessary.",
+          "They conflate a required extension being absent from the mint with the mint carrying a disqualifying extension — different reasons, different verdict codes.",
+          "They forget legacy Token has no extensions at all, so asking for one on a `token` mint is a design error caught before minting, not a runtime veto."
+        ]
       }
     ]
   },
@@ -4330,7 +6472,14 @@
         "maxWords": null,
         "amount": null,
         "network": null,
-        "idl": null
+        "idl": null,
+        "tutorNotes": [
+          "Learners plan `initSubscriptionAuthority` unconditionally, so a returning user whose authority already exists fails — the init belongs only on the branch where the read found it absent.",
+          "They drop the read step when the authority already exists; the read always runs because reading is how you learned whether the init is needed.",
+          "They convert the human amount with float math and lose sub-unit precision, or return a `number` or string where a `bigint` is required.",
+          "They inline the decimals conversion in several places instead of doing it once, so the base-unit factor drifts between call sites.",
+          "They order the steps so the transfer precedes creating the delegation — you cannot draw from a delegation you have not opened."
+        ]
       },
       {
         "key": "check",
@@ -4614,7 +6763,14 @@
         "maxWords": null,
         "amount": null,
         "network": null,
-        "idl": null
+        "idl": null,
+        "tutorNotes": [
+          "Learners expect skipped periods to accumulate — that missing two months lets a merchant collect three periods' worth at once. The cap is a per-period ceiling, not an accruing balance.",
+          "They compute a cap that subtracts what was already charged but never notices the clock rolled into a new period, so the delegation works once and then refuses everything forever.",
+          "They place the success return before the over-cap guard, making the guard unreachable and approving every request.",
+          "They confuse `AMOUNT_EXCEEDS_PERIOD_LIMIT` (the full cap was used this period) with `PERIOD_NOT_ELAPSED` (collecting before the period has started).",
+          "They treat a refused second pull inside one period as a transient failure to retry, instead of the signal that the charge already landed."
+        ]
       },
       {
         "key": "check",
@@ -4886,7 +7042,14 @@
         "maxWords": null,
         "amount": null,
         "network": null,
-        "idl": null
+        "idl": null,
+        "tutorNotes": [
+          "Learners leave `maxAmountRequired` as a number or a float; it must be a decimal string of base units because u64 amounts exceed JSON's safe integer range.",
+          "They put a human amount where base units are required — there is no decimals conversion in the protocol, so a quote priced at cents ships as dollars.",
+          "They hand-type the CAIP-2 network id or the mint literal and typo it; a one-character slip yields a challenge no client can match and looks like 'the client just never pays'.",
+          "They forget network and asset are a pair — pairing mainnet USDC with the devnet network id, or the reverse, so nothing on that cluster can satisfy the challenge.",
+          "They leave `PAY_TO` as the placeholder or use a non-base58 string, so the address never receives tokens."
+        ]
       },
       {
         "key": "check",
@@ -5127,7 +7290,14 @@
         "maxWords": null,
         "amount": null,
         "network": null,
-        "idl": null
+        "idl": null,
+        "tutorNotes": [
+          "Learners take `accepts[0]` instead of filtering the menu, so they try to pay the EVM entry the server happened to list first.",
+          "They filter on network or asset alone; the two are a pair, and a menu offering Solana mainnet and devnet with the same scheme will match the wrong one.",
+          "They parse and pay before decoding — assuming the envelope is in the body and the version is 2 — which passes one fixture and fails the rest.",
+          "They treat 'no payable entry' as an exception to throw, when it is a normal reported outcome; some servers only accept EVM money.",
+          "They only read `res.body` and miss that the envelope can arrive base64 in the `payment-required` header when the body is empty."
+        ]
       },
       {
         "key": "check",
@@ -5368,7 +7538,14 @@
         "maxWords": null,
         "amount": null,
         "network": null,
-        "idl": null
+        "idl": null,
+        "tutorNotes": [
+          "Learners settle first and check the budget afterwards, so a task that outruns the allowance reports extra calls and a negative balance instead of halting before the unaffordable call.",
+          "They continue after a refusal — the fixtures place a successful settlement right after the refused one to catch this — counting a spend that never happened.",
+          "They retry a program refusal as if it were transient; a policy refusal is terminal on-chain state and retrying only burns fees for the same answer.",
+          "They do the arithmetic in `Number`, so a u64-sized allowance loses precision above 2^53 and the final balance is silently wrong.",
+          "They report an error string they invented instead of the program's code verbatim, or let `signatures.length` drift out of step with `calls`."
+        ]
       },
       {
         "key": "check",

--- a/apps/web/src/lib/content/__tests__/project.golden.test.ts
+++ b/apps/web/src/lib/content/__tests__/project.golden.test.ts
@@ -50,6 +50,13 @@ vi.mock("server-only", () => ({}));
 //    Sanity capture, so for these docs the golden = the projected bundle (the
 //    committed bundle is the post-SP2 source of truth); every pre-existing
 //    doc still matches the original prod-Sanity capture unchanged.
+//  - launch-content wave 2 (bump to courses-academy @e1190680): retrieval
+//    closes across the flagship spine (courses-academy #11, 28 quiz blocks
+//    keyed `retrieval-close`), item-52b factual fixes (#9: faucet rate-limit
+//    mechanism, Token-2022 maturity row deleted), challenge tutorNotes (#10),
+//    and reviewExempt skill markers (#8). lessons.json and course-by-slug.json
+//    were regenerated from the bundle through the real projectors for the
+//    affected docs; all other fixtures untouched.
 const deps = { lessonsById };
 
 function bundleCourse(id: string): CourseDoc {


### PR DESCRIPTION
## What

Final scheduled content bump: pins `courses-academy@e1190680` and recompiles the committed bundle. Picks up **four** merged content PRs (the activation pin `012cd03` = #7's merge commit predated #8 and #10):

| Content PR | What lands |
|---|---|
| solanabr/courses-academy#11 | Retrieval closes across the flagship spine (LX-D2) — 28 `retrieval-close` quiz blocks |
| solanabr/courses-academy#9 | Item-52b factual fixes — faucet **rate-limit mechanism** (2 req/8h, date-stamped, no invented SOL figure) + Token-2022 stale "Mature ecosystem" row deleted |
| solanabr/courses-academy#10 | tutorNotes on 11 launch-catalog challenge lessons |
| solanabr/courses-academy#8 | `reviewExempt` markers on brazil-compliance + earn-submission skills |

## Verification (run locally at this head)

- `compile-content`: `Emitted 8 modules… courses:7, learningPaths:8, lessons:85, quests:5, achievements:10` — counts unchanged vs `012cd03` (content edits only, no doc adds/removes)
- Bundle spot-checks: faucet lesson carries "2 requests every 8 hours", stale "5 SOL per day" gone; "Mature ecosystem" row gone; 11 lessons carry tutorNotes; 2 reviewExempt markers in skills.json
- Golden fixtures: only `lessons.json` + `course-by-slug.json` regenerated (through the real projectors, existing doc order preserved — no reordering, verified via diff); delta documented in the test-header comment per the established convention (#679 precedent)
- `pnpm typecheck`: 6/6 green. `pnpm --filter web test`: **173 files / 1524 tests, exit 0**

## Routing

`area:content`, SAFE lane. Closes out the #9/#11 merge trigger from the loop plan.