### PR TITLE
ci: enforce + exercise SHA-pin guard, cover composite actions (#662, #681)

### DIFF
--- a/.github/workflows/action-pin-guard.yml
+++ b/.github/workflows/action-pin-guard.yml
@@ -31,5 +31,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      # Prove the guard actually rejects unpinned refs (in workflows AND composite
+      # actions) and accepts pinned trees before trusting its verdict — #662 /
+      # #614 "don't ship an unexercised guard".
+      - name: Self-test the guard against fixtures
+        run: ./scripts/__tests__/check-action-pins.test.sh
       - name: Assert every `uses:` is SHA-pinned
         run: ./scripts/check-action-pins.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,7 +246,7 @@ jobs:
       github.event.action != 'labeled' &&
       (needs.changes.outputs.buildserver == 'true' || github.event_name == 'workflow_dispatch')
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # Needed for the GHA layer cache below (the default docker driver cannot
       # export type=gha).

--- a/scripts/__tests__/check-action-pins.test.sh
+++ b/scripts/__tests__/check-action-pins.test.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+# Exercises scripts/check-action-pins.sh against fixture trees so the guard is
+# never shipped unexercised (#662 "prove it fails on a bad line"; #614). Runs in
+# the Action pin guard workflow *before* the real scan, so every PR proves the
+# guard both accepts a fully-pinned tree and rejects an unpinned ref — in a
+# workflow file AND in a composite action (#681).
+#
+# Pure bash, no test framework: the guard itself is pure bash and CI runs the
+# monorepo vitest via `pnpm -r test`, not the root `scripts/` suite, so a vitest
+# spec here would not gate. Self-contained + exit-code assertions do.
+set -uo pipefail
+
+guard="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/check-action-pins.sh"
+sha="1111111111111111111111111111111111111111"   # 40 hex, shape-valid
+fails=0
+tmproot=""
+
+cleanup() { [ -n "$tmproot" ] && rm -rf "$tmproot"; }
+trap cleanup EXIT
+
+# run <expected_exit> <description> — invokes the guard against $fixture (built by
+# the caller) and asserts its exit code. On mismatch, dumps output and flags.
+run() {
+  local expected="$1" desc="$2" out rc
+  out="$(CHECK_ACTION_PINS_ROOT="$fixture" bash "$guard" 2>&1)"
+  rc=$?
+  if [ "$rc" -eq "$expected" ]; then
+    printf 'ok   — %s (exit %s)\n' "$desc" "$rc"
+  else
+    printf 'FAIL — %s: expected exit %s, got %s\n%s\n' "$desc" "$expected" "$rc" "$out"
+    fails=$((fails + 1))
+  fi
+}
+
+new_fixture() {
+  tmproot="$(mktemp -d)"
+  fixture="$tmproot/repo"
+  mkdir -p "$fixture/.github/workflows" "$fixture/.github/actions"
+}
+
+# 1. Fully pinned workflow + pinned composite action + legit exclusions → pass.
+new_fixture
+cat > "$fixture/.github/workflows/ci.yml" <<EOF
+jobs:
+  a:
+    steps:
+      - uses: actions/checkout@$sha # v7.0.1
+      - uses: ./.github/actions/local-thing
+      - uses: docker://alpine@sha256:$sha
+EOF
+mkdir -p "$fixture/.github/actions/local-thing"
+cat > "$fixture/.github/actions/local-thing/action.yml" <<EOF
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-node@$sha # v4
+EOF
+run 0 "fully pinned workflow + composite action + ./ and docker:// exclusions"
+cleanup
+
+# 2. Unpinned tag in a WORKFLOW → fail.
+new_fixture
+cat > "$fixture/.github/workflows/ci.yml" <<EOF
+jobs:
+  a:
+    steps:
+      - uses: actions/checkout@v4
+EOF
+run 1 "unpinned tag in workflow is rejected"
+cleanup
+
+# 3. Unpinned tag in a COMPOSITE ACTION → fail (the #681 regression this closes).
+new_fixture
+cat > "$fixture/.github/workflows/ci.yml" <<EOF
+jobs:
+  a:
+    steps:
+      - uses: actions/checkout@$sha # v7.0.1
+EOF
+mkdir -p "$fixture/.github/actions/build"
+cat > "$fixture/.github/actions/build/action.yml" <<EOF
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-node@v4
+EOF
+run 1 "unpinned tag in composite action is rejected (#681)"
+cleanup
+
+# 4. Empty .github (no workflow or action files) → fail loudly, not vacuous pass.
+new_fixture
+run 1 "empty .github fails loudly (no vacuous pass)"
+cleanup
+
+# 5. Branch ref and short SHA are not full-SHA pins → fail.
+new_fixture
+cat > "$fixture/.github/workflows/ci.yml" <<EOF
+jobs:
+  a:
+    steps:
+      - uses: actions/checkout@main
+      - uses: actions/setup-node@1111111 # short SHA
+EOF
+run 1 "branch ref / short SHA rejected"
+cleanup
+
+if [ "$fails" -gt 0 ]; then
+  echo "check-action-pins.test.sh: $fails case(s) FAILED"
+  exit 1
+fi
+echo "check-action-pins.test.sh: all cases passed ✓"

--- a/scripts/check-action-pins.sh
+++ b/scripts/check-action-pins.sh
@@ -1,21 +1,30 @@
 #!/bin/bash
-# CI guard (#661, follows #635/#659): every third-party GitHub Action referenced
-# by a `uses:` in .github/workflows/*.yml MUST be pinned to a 40-char commit SHA,
-# never a mutable tag/branch (@v4, @main). A mutable tag lets an upstream
-# compromise or re-point silently change what runs in CI with our permissions.
+# CI guard (#661, follows #635/#659; #681 composite-action coverage): every
+# third-party GitHub Action referenced by a `uses:` MUST be pinned to a 40-char
+# commit SHA, never a mutable tag/branch (@v4, @main). A mutable tag lets an
+# upstream compromise or re-point silently change what runs in CI with our
+# permissions.
+#
+# Scan surface (#681): both workflow files (.github/workflows/*.yml) AND composite
+# actions (.github/actions/**/action.yml), because a composite action can carry its
+# own `uses:` steps — an unpinned one there is the same arbitrary-code-execution
+# risk with the guard otherwise green.
 #
 # The whole repo is uniformly SHA-pinned today (checkout/cache included), so the
 # rule is simple and exceptionless: EVERY `uses:` needs a SHA. The only refs
 # that are legitimately not SHA-pinnable are excluded:
-#   - local reusable workflows:  uses: ./.github/workflows/foo.yml
+#   - local reusable workflows / composite actions:  uses: ./.github/actions/foo
 #   - Docker image refs:         uses: docker://alpine:3.20  (pin by @sha256 digest)
 #
 # Pure bash + grep — no third-party action or tool, so the guard can't itself
 # reintroduce an unpinned dependency. Runnable locally: scripts/check-action-pins.sh
+# Test seam: CHECK_ACTION_PINS_ROOT overrides the repo root so the guard can be
+# exercised against fixture trees (scripts/__tests__/check-action-pins.test.sh).
 set -euo pipefail
 
-repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+repo_root="${CHECK_ACTION_PINS_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 workflow_dir="$repo_root/.github/workflows"
+actions_dir="$repo_root/.github/actions"
 sha_re='^[0-9a-fA-F]{40}$'
 violations=0
 
@@ -23,8 +32,17 @@ shopt -s nullglob
 files=("$workflow_dir"/*.yml "$workflow_dir"/*.yaml)
 shopt -u nullglob
 
+# Composite actions (.github/actions/**/action.yml) at any nesting depth. `find`
+# rather than a `**` glob: globstar is bash 4+ only and this must also run under
+# the bash 3.2 that ships on macOS (local runs, .husky pre-commit).
+if [ -d "$actions_dir" ]; then
+  while IFS= read -r action_file; do
+    files+=("$action_file")
+  done < <(find "$actions_dir" -type f \( -name action.yml -o -name action.yaml \))
+fi
+
 if [ ${#files[@]} -eq 0 ]; then
-  echo "::error::No workflow files found under .github/workflows — check-action-pins.sh misconfigured."
+  echo "::error::No workflow or composite-action files found under .github/ — check-action-pins.sh misconfigured (broken checkout?)."
   exit 1
 fi
 
@@ -59,4 +77,4 @@ if [ "$violations" -gt 0 ]; then
   exit 1
 fi
 
-echo "All GitHub Actions \`uses:\` refs are SHA-pinned across .github/workflows/. ✓"
+echo "All GitHub Actions \`uses:\` refs are SHA-pinned across ${#files[@]} file(s) in .github/workflows/ and .github/actions/. ✓"


### PR DESCRIPTION
Closes #662. Closes #681.

## What

Completes the SHA-pin guard so it is **enforcing, exercised, and covers composite actions**:

1. **#681 — composite-action coverage.** `scripts/check-action-pins.sh` now also scans `.github/actions/**/action.yml`, not just `.github/workflows/`. A composite action can carry its own `uses:` steps; an unpinned one there was arbitrary code execution in CI with the guard green. Collected via `find` (not a `**` glob) so it runs under the bash 3.2 that ships on macOS / `.husky` pre-commit.
2. **#662 — exercise the guard.** New `scripts/__tests__/check-action-pins.test.sh`, run as a step in `action-pin-guard.yml` *before* the real scan, so every PR proves the guard rejects an unpinned ref in a workflow **and** in a composite action, and accepts a fully-pinned tree. No unexercised guard (#662 / #614). A `CHECK_ACTION_PINS_ROOT` env seam lets the guard point at fixture trees.
3. **#662 — last inconsistent pin.** `build-server-image`'s checkout was still `9c091bb2…` (v7.0.0) while every other checkout in `ci.yml` is `3d3c42e5…` (v7.0.1). Already SHA-pinned (not a security gap), bumped for consistency.

## Already resolved, not re-done

- **The guard already enforces** (`set -euo pipefail`, `exit 1`) — landed in #680, made a registerable required check in #682. This PR does not re-add enforcement.
- **#681 fix #2 (extend `on.paths` trigger) is moot** — #682 removed the `on.paths` filter entirely so the guard runs on every PR regardless of touched paths. Nothing to change there.

## Coverage matrix

| Surface | Scanned before | Scanned now | Exercised by self-test |
|---|---|---|---|
| `.github/workflows/*.yml` | yes | yes | yes (pinned pass + unpinned fail) |
| `.github/actions/**/action.yml` (composite) | **no** | **yes** | yes (pinned pass + unpinned fail) |
| `./`-local refs | excluded | excluded | yes (pass) |
| `docker://…@sha256` | excluded | excluded | yes (pass) |
| branch ref / short SHA | rejected | rejected | yes (fail) |
| empty `.github/` (broken checkout) | fails loudly | fails loudly | yes (fail) |

### Pinned fixes in this PR
- `ci.yml` `build-server-image` checkout: `9c091bb2… # v7.0.0` → `3d3c42e5… # v7.0.1`.
- No unpinned (mutable-tag) `uses:` existed anywhere in the repo; the real guard passes clean.

## Verification (local, bash 3.2.57 on macOS)

```
$ ./scripts/__tests__/check-action-pins.test.sh
ok   — fully pinned workflow + composite action + ./ and docker:// exclusions (exit 0)
ok   — unpinned tag in workflow is rejected (exit 1)
ok   — unpinned tag in composite action is rejected (#681) (exit 1)
ok   — empty .github fails loudly (no vacuous pass) (exit 1)
ok   — branch ref / short SHA rejected (exit 1)
check-action-pins.test.sh: all cases passed ✓

$ ./scripts/check-action-pins.sh
All GitHub Actions `uses:` refs are SHA-pinned across 8 file(s) in .github/workflows/ and .github/actions/. ✓
```

No TS touched, so no typecheck run. Changes are limited to `.github/**` and `scripts/**`.

> SENSITIVE (`.github/workflows/**`) — do not merge without adversarial review + gate.
