### PR TITLE
feat(landing): deep-link CTAs into flagship lesson 1 (LX-A1, #562)

### DIFF
--- a/apps/web/src/app/[locale]/(marketing)/__tests__/landing-client.test.tsx
+++ b/apps/web/src/app/[locale]/(marketing)/__tests__/landing-client.test.tsx
@@ -1,0 +1,129 @@
+// @vitest-environment jsdom
+import type { ReactElement, ReactNode } from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import messages from "@/messages/en.json";
+import { LandingPageClient } from "../landing-client";
+
+// Heavy children / browser-bound modules are stubbed — the CTA wiring is the
+// unit under test, not the showcase animations or the auth flow.
+vi.mock("next/image", () => ({
+  default: (props: Record<string, unknown>) => {
+    const { alt, src } = props as { alt?: string; src?: string };
+    // eslint-disable-next-line @next/next/no-img-element
+    return <img alt={alt ?? ""} src={typeof src === "string" ? src : ""} />;
+  },
+}));
+vi.mock("@/components/layout/footer", () => ({ Footer: () => <footer /> }));
+vi.mock("@/components/auth/auth-error-toast", () => ({
+  AuthErrorToast: () => null,
+}));
+vi.mock("@/components/landing/hero-showcase", () => ({
+  HeroShowcase: () => <div data-testid="hero-showcase" />,
+}));
+vi.mock("@/components/landing/loop-widgets", () => ({
+  BuildWidget: () => <div />,
+  EarnWidget: () => <div />,
+  ProveWidget: () => <div />,
+}));
+vi.mock("@/components/landing/paths-explorer", () => ({
+  PathsExplorer: () => <div />,
+}));
+// AuthModal renders its trigger inside a marker so a test can prove a given CTA
+// is (or is not) an auth-modal trigger.
+vi.mock("@/components/auth/auth-modal", () => ({
+  AuthModal: ({ trigger }: { trigger?: ReactNode }) => (
+    <span data-testid="auth-modal">{trigger}</span>
+  ),
+}));
+vi.mock("@/lib/supabase/client", () => ({
+  createClient: () => ({
+    auth: {
+      getSession: async () => ({ data: { session: null } }),
+      onAuthStateChange: () => ({
+        data: { subscription: { unsubscribe: vi.fn() } },
+      }),
+    },
+  }),
+}));
+
+beforeEach(() => {
+  // jsdom lacks these; the landing page touches them at mount.
+  vi.stubGlobal(
+    "IntersectionObserver",
+    class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+  );
+  vi.stubGlobal("matchMedia", () => ({
+    matches: false,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  }));
+  // LiveSlot fetches the RPC on mount; never resolve — it's decorative.
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(() => new Promise(() => {}))
+  );
+});
+
+const FLAGSHIP_HREF = "/en/courses/course-solana-fundamentals/lessons/intro";
+
+function renderLanding(href = FLAGSHIP_HREF): ReturnType<typeof render> {
+  const ui: ReactElement = (
+    <NextIntlClientProvider locale="en" messages={messages}>
+      <LandingPageClient
+        courseCount={5}
+        totalXpMinted={0}
+        enrolledBuilders={0}
+        credentialsIssued={0}
+        learningPaths={[]}
+        achievements={[]}
+        flagshipLessonHref={href}
+      />
+    </NextIntlClientProvider>
+  );
+  return render(ui);
+}
+
+describe("LandingPageClient — LX-A1 deep-link CTAs", () => {
+  it("hero primary CTA is a deep-link to flagship lesson 1, not an auth trigger", () => {
+    renderLanding();
+    const hero = screen.getByRole("link", { name: /start building/i });
+    expect(hero).toHaveAttribute("href", FLAGSHIP_HREF);
+    // It is a real anchor, not a button that opens the modal.
+    expect(hero.tagName).toBe("A");
+    expect(hero.closest("[data-testid='auth-modal']")).toBeNull();
+  });
+
+  it("bottom Get Started deep-links instead of opening the auth modal", () => {
+    renderLanding();
+    const getStarted = screen.getByRole("link", { name: /get started/i });
+    expect(getStarted).toHaveAttribute("href", FLAGSHIP_HREF);
+    // No auth modal wraps it, and there is no Get Started *button* anymore.
+    expect(getStarted.closest("[data-testid='auth-modal']")).toBeNull();
+    expect(screen.queryByRole("button", { name: /get started/i })).toBeNull();
+  });
+
+  it("the only auth modal left on the page is the deliberate Sign Up affordance", () => {
+    renderLanding();
+    const modals = screen.getAllByTestId("auth-modal");
+    expect(modals).toHaveLength(1);
+    expect(within(modals[0]!).getByText(/sign up/i)).toBeInTheDocument();
+  });
+
+  it("renders the deep-link href verbatim under a non-default locale prefix", () => {
+    const ptHref = "/pt-BR/courses/course-solana-fundamentals/lessons/intro";
+    renderLanding(ptHref);
+    expect(
+      screen.getByRole("link", { name: /start building/i })
+    ).toHaveAttribute("href", ptHref);
+    expect(screen.getByRole("link", { name: /get started/i })).toHaveAttribute(
+      "href",
+      ptHref
+    );
+  });
+});

--- a/apps/web/src/app/[locale]/(marketing)/landing-client.tsx
+++ b/apps/web/src/app/[locale]/(marketing)/landing-client.tsx
@@ -246,6 +246,13 @@ interface LandingPageProps {
   credentialsIssued: number;
   learningPaths: LearningPath[];
   achievements: DeployedAchievement[];
+  /**
+   * LX-A1: anonymous-first deep-link into the flagship path's lesson 1
+   * (locale-prefixed, sync-gated to `/{locale}/courses` when unsynced). The
+   * primary hero and bottom CTAs point here instead of opening the auth modal —
+   * anonymous access already works; auth is deferred to the completion attempt.
+   */
+  flagshipLessonHref: string;
 }
 
 // Community stats stay hidden until seeding gives them weight (GTM cold-start:
@@ -277,6 +284,7 @@ export function LandingPageClient({
   credentialsIssued,
   learningPaths,
   achievements,
+  flagshipLessonHref,
 }: LandingPageProps) {
   const t = useTranslations("landing");
   const tCommon = useTranslations("common");
@@ -461,8 +469,11 @@ export function LandingPageClient({
                   className="hero-seq flex flex-wrap gap-3"
                   style={{ "--seq": 4 } as React.CSSProperties}
                 >
+                  {/* LX-A1: primary hero CTA deep-links straight into flagship
+                      lesson 1 \u2014 one click, no auth modal (anonymous access
+                      works; auth is deferred to the first completion attempt). */}
                   <Button variant="push" size="lg" asChild>
-                    <Link href={`/${locale}/courses`}>
+                    <Link href={flagshipLessonHref}>
                       {t("exploreCourses")} {"\u2192"}
                     </Link>
                   </Button>
@@ -752,14 +763,14 @@ export function LandingPageClient({
               {t("ctaSubtitle")}
             </p>
             <div className="flex flex-wrap items-center justify-center gap-4">
+              {/* LX-A1: bottom "Get Started" deep-links into flagship lesson 1
+                  instead of opening the auth modal. */}
               {!isLoggedIn && (
-                <AuthModal
-                  trigger={
-                    <Button variant="pushAccent" size="lg">
-                      {tCommon("getStarted")} {"\u2192"}
-                    </Button>
-                  }
-                />
+                <Button variant="pushAccent" size="lg" asChild>
+                  <Link href={flagshipLessonHref}>
+                    {tCommon("getStarted")} {"\u2192"}
+                  </Link>
+                </Button>
               )}
               <Button
                 variant="push"

--- a/apps/web/src/app/[locale]/(marketing)/page.tsx
+++ b/apps/web/src/app/[locale]/(marketing)/page.tsx
@@ -1,10 +1,11 @@
-import { LandingPageClient } from "./landing-client";
 import {
   getAllCourses,
   getAllLearningPaths,
   getDeployedAchievements,
 } from "@/lib/content/queries";
+import { resolveFlagshipLessonHref } from "@/lib/courses/entry-lesson";
 import { createAdminClient } from "@/lib/supabase/admin";
+import { LandingPageClient } from "./landing-client";
 
 // The landing shows live platform stats (courses, enrolled builders, credentials,
 // XP). Without revalidation it renders fully static and freezes at build time —
@@ -12,12 +13,21 @@ import { createAdminClient } from "@/lib/supabase/admin";
 // and never refreshed. 5-minute ISR keeps the numbers current without per-request cost.
 export const revalidate = 300;
 
-export default async function LandingPage() {
-  const [courses, learningPaths, achievements] = await Promise.all([
-    getAllCourses(),
-    getAllLearningPaths(),
-    getDeployedAchievements(),
-  ]);
+export default async function LandingPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  const [courses, learningPaths, achievements, flagshipLessonHref] =
+    await Promise.all([
+      getAllCourses(),
+      getAllLearningPaths(),
+      getDeployedAchievements(),
+      // LX-A1: the anonymous-first deep-link target — flagship lesson 1, or the
+      // catalog when that course isn't synced (resolveFlagshipLessonHref gate).
+      resolveFlagshipLessonHref(locale),
+    ]);
 
   // Fetch on-chain stats from Supabase
   let totalXpMinted = 0;
@@ -56,6 +66,7 @@ export default async function LandingPage() {
       credentialsIssued={credentialsIssued}
       learningPaths={learningPaths}
       achievements={achievements}
+      flagshipLessonHref={flagshipLessonHref}
     />
   );
 }

--- a/apps/web/src/app/[locale]/(marketing)/start/routes.ts
+++ b/apps/web/src/app/[locale]/(marketing)/start/routes.ts
@@ -1,4 +1,4 @@
-import { getCourseById, getCourseLessons } from "@/lib/content/queries";
+import { resolveEntryLessonHref } from "@/lib/courses/entry-lesson";
 import {
   SEGMENT_ENTRY_COURSE,
   type LearnerSegment,
@@ -12,15 +12,10 @@ const SEGMENTS: LearnerSegment[] = [1, 2, 3];
  * post-intake destination. Runs server-side so the client never imports the
  * content bundle.
  *
- * SYNC-GATED (F1): the destination is the entry course's first lesson ONLY when
- * that course is actually deployed+synced — resolved through `getCourseLessons`,
- * which returns `[]` for a course that is absent, unsynced, OR whose deployment
- * read failed (getActiveDeployments yields an empty map on DB error). Every
- * other funnel destination gates the same way (the lesson page → notFound() on
- * an unsynced course), so deep-linking an unsynced entry course would 404 every
- * /start completer. When the entry course can't be deep-linked we fall back to
- * the always-available catalog (`/courses`), never a course/lesson page that
- * would itself 404.
+ * The first-lesson destination is SYNC-GATED (F1) by `resolveEntryLessonHref`:
+ * an absent/unsynced/deployment-read-failed entry course falls back to the
+ * always-available catalog (`/courses`), never a course/lesson page that would
+ * itself `notFound()` and 404 the funnel.
  */
 export async function resolveSegmentRoutes(
   locale: string
@@ -28,15 +23,7 @@ export async function resolveSegmentRoutes(
   const entries = await Promise.all(
     SEGMENTS.map(async (segment) => {
       const courseId = SEGMENT_ENTRY_COURSE[segment];
-      const course = await getCourseById(courseId);
-      const slug = course?.slug ?? null;
-      // Sync gate: [] when absent / unsynced / deployment-read-failed.
-      const lessons = slug ? await getCourseLessons(slug) : [];
-      const firstLessonSlug = lessons[0]?.slug ?? null;
-      const href =
-        slug && firstLessonSlug
-          ? `/${locale}/courses/${slug}/lessons/${firstLessonSlug}`
-          : `/${locale}/courses`;
+      const href = await resolveEntryLessonHref(locale, courseId);
       return [segment, { courseId, href }] as const;
     })
   );

--- a/apps/web/src/lib/courses/__tests__/entry-lesson.test.ts
+++ b/apps/web/src/lib/courses/__tests__/entry-lesson.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { getCourseById, getCourseLessons } from "@/lib/content/queries";
+import {
+  DEFAULT_SEGMENT,
+  SEGMENT_ENTRY_COURSE,
+} from "@/lib/courses/learner-segment";
+import {
+  resolveEntryLessonHref,
+  resolveFlagshipLessonHref,
+} from "../entry-lesson";
+
+vi.mock("@/lib/content/queries", () => ({
+  getCourseById: vi.fn(),
+  getCourseLessons: vi.fn(),
+}));
+
+const byId = vi.mocked(getCourseById);
+const lessonsOf = vi.mocked(getCourseLessons);
+
+const FLAGSHIP = SEGMENT_ENTRY_COURSE[DEFAULT_SEGMENT];
+
+beforeEach(() => {
+  byId.mockReset();
+  lessonsOf.mockReset();
+  // Course present in the bundle; use its id as slug (1:1, arbitrary).
+  byId.mockImplementation(
+    async (id: string) =>
+      ({ slug: id }) as Awaited<ReturnType<typeof getCourseById>>
+  );
+});
+
+function lesson(slug: string) {
+  return { _id: `l-${slug}`, title: slug, slug };
+}
+
+describe("resolveEntryLessonHref — F1 sync gating", () => {
+  it("deep-links to the first lesson when the course is synced", async () => {
+    lessonsOf.mockResolvedValue([lesson("intro"), lesson("second")]);
+    const href = await resolveEntryLessonHref("en", "course-x");
+    expect(href).toBe("/en/courses/course-x/lessons/intro");
+  });
+
+  it("locale-prefixes the deep-link (pt-BR)", async () => {
+    lessonsOf.mockResolvedValue([lesson("intro")]);
+    const href = await resolveEntryLessonHref("pt-BR", "course-x");
+    expect(href).toBe("/pt-BR/courses/course-x/lessons/intro");
+  });
+
+  it("falls back to the locale catalog when the course is UNSYNCED", async () => {
+    lessonsOf.mockResolvedValue([]); // unsynced / deployment-read-failed
+    const href = await resolveEntryLessonHref("es", "course-x");
+    expect(href).toBe("/es/courses");
+  });
+
+  it("falls back to the locale catalog when the course is ABSENT", async () => {
+    byId.mockResolvedValue(null);
+    lessonsOf.mockResolvedValue([]);
+    const href = await resolveEntryLessonHref("en", "course-x");
+    expect(href).toBe("/en/courses");
+    // Absent course short-circuits before ever querying lessons.
+    expect(lessonsOf).not.toHaveBeenCalled();
+  });
+});
+
+describe("resolveFlagshipLessonHref — landing deep-link (LX-A1)", () => {
+  it("targets the DEFAULT_SEGMENT entry course's first lesson", async () => {
+    lessonsOf.mockResolvedValue([lesson("welcome")]);
+    const href = await resolveFlagshipLessonHref("en");
+    expect(byId).toHaveBeenCalledWith(FLAGSHIP);
+    expect(href).toBe(`/en/courses/${FLAGSHIP}/lessons/welcome`);
+  });
+
+  it("falls back to the catalog when the flagship course is unsynced", async () => {
+    lessonsOf.mockResolvedValue([]);
+    const href = await resolveFlagshipLessonHref("pt-BR");
+    expect(href).toBe("/pt-BR/courses");
+  });
+});

--- a/apps/web/src/lib/courses/entry-lesson.ts
+++ b/apps/web/src/lib/courses/entry-lesson.ts
@@ -1,0 +1,42 @@
+import { getCourseById, getCourseLessons } from "@/lib/content/queries";
+import {
+  DEFAULT_SEGMENT,
+  SEGMENT_ENTRY_COURSE,
+} from "@/lib/courses/learner-segment";
+
+/**
+ * Resolves a content course id into its first-lesson deep-link for `locale`.
+ *
+ * SYNC-GATED (F1): returns the lesson URL ONLY when the course is present in
+ * the content bundle AND deployed+synced — `getCourseLessons` returns `[]` for
+ * a course that is absent, unsynced, OR whose deployment read failed
+ * (getActiveDeployments yields an empty map on DB error). When the course can't
+ * be deep-linked we fall back to the always-available catalog (`/courses`),
+ * never a course/lesson page that would itself `notFound()` on an unsynced
+ * course. This is the single source of truth for that gate, shared by the
+ * landing deep-link (LX-A1) and the /start funnel routes (LX-A2).
+ */
+export async function resolveEntryLessonHref(
+  locale: string,
+  courseId: string
+): Promise<string> {
+  const course = await getCourseById(courseId);
+  const slug = course?.slug ?? null;
+  const lessons = slug ? await getCourseLessons(slug) : [];
+  const firstLessonSlug = lessons[0]?.slug ?? null;
+  return slug && firstLessonSlug
+    ? `/${locale}/courses/${slug}/lessons/${firstLessonSlug}`
+    : `/${locale}/courses`;
+}
+
+/**
+ * The flagship "Zero to Deployed" path's lesson 1 — the landing-page deep-link
+ * target (LX-A1). The flagship entry is the DEFAULT_SEGMENT entry course, so an
+ * anonymous landing visitor and a /start segment-1 completer converge on the
+ * same first lesson. Sync-gated identically to the funnel routes.
+ */
+export async function resolveFlagshipLessonHref(
+  locale: string
+): Promise<string> {
+  return resolveEntryLessonHref(locale, SEGMENT_ENTRY_COURSE[DEFAULT_SEGMENT]);
+}


### PR DESCRIPTION
Closes #562. Implements spec task **LX-A1** (launch-experience master spec §3).

## What / why
Anonymous access to lessons already works (middleware verified public), so the landing page shouldn't gate learners behind the auth modal. This drops a signed-out visitor into the **flagship path's lesson 1 in one click** and defers auth to the first completion attempt.

- **New shared resolver** `apps/web/src/lib/courses/entry-lesson.ts`:
  - `resolveEntryLessonHref(locale, courseId)` — a single **sync-gated (F1)** first-lesson deep-link resolver: returns the lesson URL only when the course is present in the content bundle *and* deployed+synced (`getCourseLessons` returns `[]` otherwise), else falls back to the always-available locale catalog `/{locale}/courses` (never a page that would `notFound()`).
  - `resolveFlagshipLessonHref(locale)` — the flagship = `DEFAULT_SEGMENT` entry course (`course-solana-fundamentals`), so anonymous landing visitors and `/start` segment-1 completers converge on the same lesson.
  - `resolveSegmentRoutes` (the `/start` funnel, PR #695 lineage) now **reuses** this resolver — one source of truth for the gate, consistent with #695 rather than around it.
- **Landing** (`page.tsx` + `landing-client.tsx`): the server component resolves the flagship deep-link per locale and passes it down. The **hero primary CTA** and the **bottom "Get Started"** now link there; "Get Started" no longer opens `AuthModal`. The deliberate hero **"Sign Up"** affordance is unchanged (the header also offers sign-in).

## LX-A1 acceptance
- [x] Signed-out visitor reaches lesson 1 in **one click** from the landing page (hero primary + bottom Get Started).
- [x] **No auth modal** is forced until a completion attempt — bottom "Get Started" deep-links instead of triggering `AuthModal`.
- [x] Sync-gated: unsynced/absent flagship course falls back to `/{locale}/courses` (never a 404).

## Scope / constraints
- LX-A1 only. **No new i18n strings** — reuses existing keys (`landing.exploreCourses`, `common.getStarted`), present in all 3 locales (EN/PT-BR/ES). CTAs remain proper links (`Button asChild` → `next/link`), `focus-visible` preserved.
- Zero `any`, strict TS.

## Verification
- `pnpm install --frozen-lockfile` ✔
- `pnpm typecheck` ✔ (6/6 packages)
- `pnpm --filter web test` ✔ **175 files, 1534 tests passed** (incl. 10 new/affected: `entry-lesson` resolver ×6, `landing-client` CTA wiring ×4, and the refactored `start/routes` suite still green)
- `pnpm --filter web lint` ✔ (exit 0)

Do not merge — awaiting gate + owner sign-off.