### PR TITLE
fix(lessons/complete): dedup grading suite for concurrent duplicate submissions (#693)

### DIFF
--- a/apps/web/src/app/api/lessons/complete/__tests__/deny-reasons.test.ts
+++ b/apps/web/src/app/api/lessons/complete/__tests__/deny-reasons.test.ts
@@ -38,6 +38,7 @@ const {
 
 vi.mock("@/lib/rate-limit", () => ({
   isRateLimited: (ns: string) => isRateLimited(ns),
+  releaseRateLimit: () => Promise.resolve(),
   getClientIp: () => "203.0.113.7",
 }));
 

--- a/apps/web/src/app/api/lessons/complete/__tests__/gate.test.ts
+++ b/apps/web/src/app/api/lessons/complete/__tests__/gate.test.ts
@@ -31,6 +31,7 @@ const {
 
 vi.mock("@/lib/rate-limit", () => ({
   isRateLimited: (ns: string) => isRateLimited(ns),
+  releaseRateLimit: () => Promise.resolve(),
   getClientIp: () => "203.0.113.7",
 }));
 

--- a/apps/web/src/app/api/lessons/complete/__tests__/grading-dedup.test.ts
+++ b/apps/web/src/app/api/lessons/complete/__tests__/grading-dedup.test.ts
@@ -1,0 +1,219 @@
+/* eslint-disable import/order -- vi.mock calls must precede importing the route. */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+import type { GradeResult } from "@/lib/grading/types";
+
+vi.mock("server-only", () => ({}));
+
+// Pre-grading submission-dedup guard (#693). Residual of #651/#690: the
+// per-(user,lesson) in-flight guard sits AFTER grading, so N concurrent
+// duplicates of the SAME submission each ran the full grading suite before one
+// took the on-chain token. This guard dedups them BEFORE grading, keyed on the
+// SUBMISSION FINGERPRINT — so a true duplicate short-circuits while a genuine
+// re-attempt (different answers → different fingerprint) is never blocked.
+
+const {
+  getUser,
+  singleProfile,
+  getLessonByIdForGrading,
+  getCourseById,
+  codeGrader,
+  isRateLimited,
+  isOnChainProgramLive,
+  isCourseInMaintenance,
+  isPlatformFrozen,
+} = vi.hoisted(() => ({
+  getUser: vi.fn<() => Promise<unknown>>(),
+  singleProfile: vi.fn<() => Promise<unknown>>(),
+  getLessonByIdForGrading: vi.fn(),
+  getCourseById: vi.fn(),
+  codeGrader: vi.fn<() => Promise<GradeResult>>(),
+  // Records BOTH (namespace, key) so tests can assert the guard is keyed on the
+  // proofs fingerprint, not on (user, lesson) alone.
+  isRateLimited: vi.fn<(ns: string, key: string) => Promise<boolean>>(),
+  isOnChainProgramLive: vi.fn<() => Promise<boolean>>(),
+  isCourseInMaintenance: vi.fn<() => Promise<boolean>>(),
+  isPlatformFrozen: vi.fn<() => Promise<boolean>>(),
+}));
+
+vi.mock("@/lib/rate-limit", () => ({
+  isRateLimited: (ns: string, key: string) => isRateLimited(ns, key),
+  getClientIp: () => "203.0.113.7",
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: async () => ({ auth: { getUser } }),
+}));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: () => ({
+    from: () => ({
+      select: () => ({ eq: () => ({ single: singleProfile }) }),
+    }),
+  }),
+}));
+
+vi.mock("@/lib/content/queries", () => ({
+  getLessonByIdForGrading,
+  getCourseById,
+}));
+
+vi.mock("@/lib/grading/graders", () => ({
+  GRADERS: { code: () => codeGrader() },
+}));
+
+vi.mock("@/lib/review/schedule-review", () => ({
+  captureReviewFailure: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("@/lib/ai/check-seal", () => ({ openAttestation: () => true }));
+vi.mock("@/lib/solana/academy-program", () => ({
+  isOnChainProgramLive,
+  completeLesson: vi.fn(),
+  getConnection: vi.fn(),
+  getProgramId: vi.fn(),
+}));
+vi.mock("@/lib/solana/academy-reads", () => ({
+  fetchEnrollment: vi.fn(),
+  fetchCourse: vi.fn(),
+}));
+vi.mock("@/lib/solana/bitmap", () => ({ isLessonComplete: vi.fn() }));
+vi.mock("@/lib/courses/lesson-index", () => ({ findLessonIndex: () => 0 }));
+vi.mock("@/lib/logging", () => ({ logError: vi.fn() }));
+vi.mock("@/lib/content/deployments", () => ({ isCourseInMaintenance }));
+vi.mock("@/lib/platform/freeze", () => ({ isPlatformFrozen }));
+
+import { POST } from "../route";
+
+// A code block routes through GRADERS.code, so codeGrader running (or not) is a
+// direct proxy for "the grading suite ran".
+const CODE_LESSON = { blocks: [{ _type: "code", key: "c1" }] };
+const DEDUP_NS = "lessons:complete:grading-dedup";
+
+function req(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/lessons/complete", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "content-type": "application/json" },
+  });
+}
+
+const call = (proofs: Record<string, unknown>) =>
+  POST(req({ lessonId: "lesson-1", courseId: "course-1", proofs }));
+
+/** Keys the route passed to the grading-dedup namespace, in call order. */
+const dedupKeys = () =>
+  isRateLimited.mock.calls.filter((c) => c[0] === DEDUP_NS).map((c) => c[1]);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  process.env.NEXT_PUBLIC_SUPABASE_URL = "http://localhost";
+  process.env.SUPABASE_SERVICE_ROLE_KEY = "srk";
+  getUser.mockResolvedValue({ data: { user: { id: "user-1" } }, error: null });
+  singleProfile.mockResolvedValue({ data: { wallet_address: "wallet-1" } });
+  getLessonByIdForGrading.mockResolvedValue(CODE_LESSON);
+  getCourseById.mockResolvedValue({ modules: [] });
+  isOnChainProgramLive.mockResolvedValue(false);
+  isCourseInMaintenance.mockResolvedValue(false);
+  isPlatformFrozen.mockResolvedValue(false);
+  // A failed grade keeps every test on the cheap side of the on-chain path while
+  // still proving the grader RAN. Behaviour under a passing grade is identical
+  // w.r.t. this guard, which sits before grading either way.
+  codeGrader.mockResolvedValue({ ok: false, status: 403 });
+  // Default: every gate/guard clear.
+  isRateLimited.mockResolvedValue(false);
+});
+
+describe("pre-grading submission-dedup guard (#693)", () => {
+  it("a concurrent duplicate short-circuits BEFORE grading — the suite does not re-run", async () => {
+    // The dedup bucket for this submission is already spent (the first request
+    // holds it) → this duplicate must be refused before the graders run.
+    isRateLimited.mockImplementation(async (ns) => ns === DEDUP_NS);
+
+    const res = await call({ c1: { code: "correct" } });
+
+    expect(res.status).toBe(429);
+    expect(res.headers.get("Retry-After")).toBe("30");
+    const body = (await res.json()) as { reason?: string };
+    expect(body.reason).toBe("completion_in_progress");
+    // The whole point: the grading suite never runs for the deduped duplicate.
+    expect(codeGrader).not.toHaveBeenCalled();
+  });
+
+  it("is keyed on user + lesson + proofs fingerprint (a 64-hex digest)", async () => {
+    await call({ c1: { code: "correct" } });
+
+    const keys = dedupKeys();
+    expect(keys).toHaveLength(1);
+    expect(keys[0]).toMatch(/^user-1:lesson-1:[a-f0-9]{64}$/);
+  });
+
+  it("identical proofs → identical key; a different attempt → a different key", async () => {
+    await call({ c1: { code: "attempt-A" } });
+    await call({ c1: { code: "attempt-A" } });
+    await call({ c1: { code: "attempt-B" } });
+
+    const [firstA, secondA, b] = dedupKeys();
+    expect(firstA).toBe(secondA); // a true duplicate collides
+    expect(b).not.toBe(firstA); // a genuine re-attempt does not
+  });
+
+  it("fingerprint is order-independent — key spelling order does not change the key", async () => {
+    await call({ c1: { code: "x" }, c2: { code: "y" } });
+    await call({ c2: { code: "y" }, c1: { code: "x" } });
+
+    const [first, second] = dedupKeys();
+    expect(first).toBe(second);
+  });
+
+  it("real 1-token bucket: same submission twice is deduped, a different one is not", async () => {
+    // Emulate the fixed-window 1-token bucket: first sight of a dedup key passes
+    // and spends it; a second sight of the SAME key is refused. Every other
+    // namespace (the volume gates) always clears.
+    const spent = new Set<string>();
+    isRateLimited.mockImplementation(async (ns, key) => {
+      if (ns !== DEDUP_NS) return false;
+      if (spent.has(key)) return true;
+      spent.add(key);
+      return false;
+    });
+
+    // First submission of attempt A → guard clear → grading runs, 403s.
+    const first = await call({ c1: { code: "attempt-A" } });
+    expect(first.status).toBe(403);
+    expect(codeGrader).toHaveBeenCalledTimes(1);
+
+    // Same submission again (duplicate) → deduped → grading does NOT re-run.
+    const dup = await call({ c1: { code: "attempt-A" } });
+    expect(dup.status).toBe(429);
+    const dupBody = (await dup.json()) as { reason?: string };
+    expect(dupBody.reason).toBe("completion_in_progress");
+    expect(codeGrader).toHaveBeenCalledTimes(1); // unchanged — no second run
+
+    // A genuinely different attempt → new fingerprint → NOT blocked, grading runs.
+    const reattempt = await call({ c1: { code: "attempt-B-fixed" } });
+    expect(reattempt.status).toBe(403);
+    expect(codeGrader).toHaveBeenCalledTimes(2);
+  });
+
+  it("403 grading reasons are preserved when the dedup guard is clear", async () => {
+    const res = await call({ c1: { code: "wrong" } });
+
+    // The guard ran (before grading) but was clear, so grading proceeded and the
+    // failure surfaces with its normal 403 + challenge reason — unchanged by #693.
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { reason?: string };
+    expect(body.reason).toBe("challenge_failed");
+    expect(codeGrader).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails OPEN — a store blip lets grading proceed, never blocking a learner", async () => {
+    // isRateLimited fails open internally; at the route a blip surfaces as
+    // `false` (not over budget), so the completion path continues into grading.
+    isRateLimited.mockResolvedValue(false);
+
+    const res = await call({ c1: { code: "wrong" } });
+
+    expect(res.status).toBe(403); // reached grading, not short-circuited
+    expect(codeGrader).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/app/api/lessons/complete/__tests__/grading-dedup.test.ts
+++ b/apps/web/src/app/api/lessons/complete/__tests__/grading-dedup.test.ts
@@ -5,39 +5,51 @@ import type { GradeResult } from "@/lib/grading/types";
 
 vi.mock("server-only", () => ({}));
 
-// Pre-grading submission-dedup guard (#693). Residual of #651/#690: the
-// per-(user,lesson) in-flight guard sits AFTER grading, so N concurrent
-// duplicates of the SAME submission each ran the full grading suite before one
-// took the on-chain token. This guard dedups them BEFORE grading, keyed on the
-// SUBMISSION FINGERPRINT — so a true duplicate short-circuits while a genuine
-// re-attempt (different answers → different fingerprint) is never blocked.
+// Pre-grading submission-dedup guard (#693). It is a true IN-PROGRESS LOCK:
+// acquire a 1-token key keyed on the submission fingerprint, then RELEASE it in
+// a `finally` on every exit. So concurrent duplicates 429 only WHILE a twin is
+// processing, and an honest sequential resubmit (identical or not) finds the key
+// free and re-grades — getting its real 403/reason, never a false 429.
 
 const {
   getUser,
   singleProfile,
+  upsertProgress,
   getLessonByIdForGrading,
   getCourseById,
   codeGrader,
   isRateLimited,
+  releaseRateLimit,
   isOnChainProgramLive,
   isCourseInMaintenance,
   isPlatformFrozen,
+  completeLesson,
+  fetchEnrollment,
+  fetchCourse,
+  isLessonComplete,
 } = vi.hoisted(() => ({
   getUser: vi.fn<() => Promise<unknown>>(),
   singleProfile: vi.fn<() => Promise<unknown>>(),
+  upsertProgress: vi.fn<() => Promise<unknown>>(),
   getLessonByIdForGrading: vi.fn(),
   getCourseById: vi.fn(),
   codeGrader: vi.fn<() => Promise<GradeResult>>(),
   // Records BOTH (namespace, key) so tests can assert the guard is keyed on the
-  // proofs fingerprint, not on (user, lesson) alone.
+  // proofs fingerprint, and can drive a stateful lock (acquire/release).
   isRateLimited: vi.fn<(ns: string, key: string) => Promise<boolean>>(),
+  releaseRateLimit: vi.fn<(ns: string, key: string) => Promise<void>>(),
   isOnChainProgramLive: vi.fn<() => Promise<boolean>>(),
   isCourseInMaintenance: vi.fn<() => Promise<boolean>>(),
   isPlatformFrozen: vi.fn<() => Promise<boolean>>(),
+  completeLesson: vi.fn<() => Promise<string>>(),
+  fetchEnrollment: vi.fn<() => Promise<unknown>>(),
+  fetchCourse: vi.fn<() => Promise<unknown>>(),
+  isLessonComplete: vi.fn<() => boolean>(),
 }));
 
 vi.mock("@/lib/rate-limit", () => ({
   isRateLimited: (ns: string, key: string) => isRateLimited(ns, key),
+  releaseRateLimit: (ns: string, key: string) => releaseRateLimit(ns, key),
   getClientIp: () => "203.0.113.7",
 }));
 
@@ -49,6 +61,7 @@ vi.mock("@/lib/supabase/admin", () => ({
   createAdminClient: () => ({
     from: () => ({
       select: () => ({ eq: () => ({ single: singleProfile }) }),
+      upsert: upsertProgress,
     }),
   }),
 }));
@@ -68,15 +81,12 @@ vi.mock("@/lib/review/schedule-review", () => ({
 vi.mock("@/lib/ai/check-seal", () => ({ openAttestation: () => true }));
 vi.mock("@/lib/solana/academy-program", () => ({
   isOnChainProgramLive,
-  completeLesson: vi.fn(),
+  completeLesson,
   getConnection: vi.fn(),
   getProgramId: vi.fn(),
 }));
-vi.mock("@/lib/solana/academy-reads", () => ({
-  fetchEnrollment: vi.fn(),
-  fetchCourse: vi.fn(),
-}));
-vi.mock("@/lib/solana/bitmap", () => ({ isLessonComplete: vi.fn() }));
+vi.mock("@/lib/solana/academy-reads", () => ({ fetchEnrollment, fetchCourse }));
+vi.mock("@/lib/solana/bitmap", () => ({ isLessonComplete }));
 vi.mock("@/lib/courses/lesson-index", () => ({ findLessonIndex: () => 0 }));
 vi.mock("@/lib/logging", () => ({ logError: vi.fn() }));
 vi.mock("@/lib/content/deployments", () => ({ isCourseInMaintenance }));
@@ -104,29 +114,58 @@ const call = (proofs: Record<string, unknown>) =>
 const dedupKeys = () =>
   isRateLimited.mock.calls.filter((c) => c[0] === DEDUP_NS).map((c) => c[1]);
 
+/**
+ * Install a real acquire/release lock over the dedup namespace: first sight of a
+ * key acquires it, a concurrent second sight is refused, and `releaseRateLimit`
+ * hands it back. With sequentially-awaited test calls this models the honest
+ * path — each request releases before the next begins, so a resubmit re-grades.
+ */
+function statefulLock(): Set<string> {
+  const held = new Set<string>();
+  isRateLimited.mockImplementation(async (ns, key) => {
+    if (ns !== DEDUP_NS) return false; // volume gates always clear here
+    if (held.has(key)) return true; // a twin is mid-flight
+    held.add(key);
+    return false;
+  });
+  releaseRateLimit.mockImplementation(async (ns, key) => {
+    if (ns === DEDUP_NS) held.delete(key);
+  });
+  return held;
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
   process.env.NEXT_PUBLIC_SUPABASE_URL = "http://localhost";
   process.env.SUPABASE_SERVICE_ROLE_KEY = "srk";
   getUser.mockResolvedValue({ data: { user: { id: "user-1" } }, error: null });
-  singleProfile.mockResolvedValue({ data: { wallet_address: "wallet-1" } });
+  // A syntactically valid base58 pubkey (System Program) so `new PublicKey`
+  // succeeds and the route can reach the on-chain path when a test needs it.
+  singleProfile.mockResolvedValue({
+    data: { wallet_address: "11111111111111111111111111111111" },
+  });
+  upsertProgress.mockResolvedValue({ error: null });
   getLessonByIdForGrading.mockResolvedValue(CODE_LESSON);
   getCourseById.mockResolvedValue({ modules: [] });
-  isOnChainProgramLive.mockResolvedValue(false);
+  isOnChainProgramLive.mockResolvedValue(true);
   isCourseInMaintenance.mockResolvedValue(false);
   isPlatformFrozen.mockResolvedValue(false);
-  // A failed grade keeps every test on the cheap side of the on-chain path while
-  // still proving the grader RAN. Behaviour under a passing grade is identical
-  // w.r.t. this guard, which sits before grading either way.
+  fetchEnrollment.mockResolvedValue({ lesson_flags: [0, 0, 0, 0] });
+  fetchCourse.mockResolvedValue({ liveLessonCount: 10 });
+  isLessonComplete.mockReturnValue(false);
+  completeLesson.mockResolvedValue("sig-123");
+  // Default: grading FAILS, keeping most tests on the cheap 403 path while still
+  // proving the grader RAN. Tests that need the on-chain path flip this to ok.
   codeGrader.mockResolvedValue({ ok: false, status: 403 });
-  // Default: every gate/guard clear.
+  // Default: every gate/guard clear; release is a no-op unless a test drives it.
   isRateLimited.mockResolvedValue(false);
+  releaseRateLimit.mockResolvedValue(undefined);
 });
 
-describe("pre-grading submission-dedup guard (#693)", () => {
-  it("a concurrent duplicate short-circuits BEFORE grading — the suite does not re-run", async () => {
-    // The dedup bucket for this submission is already spent (the first request
-    // holds it) → this duplicate must be refused before the graders run.
+describe("in-progress lock — concurrent duplicates (#693)", () => {
+  it("a twin holding the lock → 429, grading does not run, and the twin's lock is NOT released", async () => {
+    // The dedup key already reads as held (a twin request is processing) → this
+    // duplicate must be refused before the graders run.
     isRateLimited.mockImplementation(async (ns) => ns === DEDUP_NS);
 
     const res = await call({ c1: { code: "correct" } });
@@ -135,10 +174,83 @@ describe("pre-grading submission-dedup guard (#693)", () => {
     expect(res.headers.get("Retry-After")).toBe("30");
     const body = (await res.json()) as { reason?: string };
     expect(body.reason).toBe("completion_in_progress");
-    // The whole point: the grading suite never runs for the deduped duplicate.
+    // Grading never runs for the deduped duplicate.
     expect(codeGrader).not.toHaveBeenCalled();
+    // We did NOT acquire the lock, so we must NOT release it — that would free
+    // the twin's lock and defeat the dedup.
+    expect(releaseRateLimit).not.toHaveBeenCalled();
   });
 
+  it("the acquiring request grades, then releases the SAME fingerprint key it acquired", async () => {
+    const res = await call({ c1: { code: "wrong" } });
+
+    expect(res.status).toBe(403);
+    expect(codeGrader).toHaveBeenCalledTimes(1);
+    const acquiredKey = dedupKeys()[0];
+    expect(acquiredKey).toMatch(/^user-1:lesson-1:[a-f0-9]{64}$/);
+    expect(releaseRateLimit).toHaveBeenCalledWith(DEDUP_NS, acquiredKey);
+  });
+});
+
+describe("lock released on every exit — honest resubmit re-grades (#693)", () => {
+  it("failed grading → identical resubmit RE-GRADES and returns the real 403 reason, not 429", async () => {
+    statefulLock();
+    codeGrader.mockResolvedValue({ ok: false, status: 403 });
+
+    const first = await call({ c1: { code: "wrong" } });
+    expect(first.status).toBe(403);
+    expect(((await first.json()) as { reason?: string }).reason).toBe(
+      "challenge_failed"
+    );
+    expect(codeGrader).toHaveBeenCalledTimes(1);
+
+    // Byte-identical resubmit within the window: the lock was released after the
+    // first failure, so this re-grades and gets its true reason (NOT 429).
+    const second = await call({ c1: { code: "wrong" } });
+    expect(second.status).toBe(403);
+    expect(((await second.json()) as { reason?: string }).reason).toBe(
+      "challenge_failed"
+    );
+    expect(codeGrader).toHaveBeenCalledTimes(2);
+  });
+
+  it("wallet-not-connected → identical resubmit gets the wallet reason again, never 429", async () => {
+    statefulLock();
+    codeGrader.mockResolvedValue({ ok: true }); // grading passes
+    singleProfile.mockResolvedValue({ data: { wallet_address: null } });
+
+    const first = await call({ c1: { code: "correct" } });
+    expect(first.status).toBe(400);
+    expect(((await first.json()) as { error?: string }).error).toMatch(
+      /Wallet not connected/
+    );
+
+    const second = await call({ c1: { code: "correct" } });
+    expect(second.status).toBe(400); // the true reason, not a false 429
+    expect(((await second.json()) as { error?: string }).error).toMatch(
+      /Wallet not connected/
+    );
+  });
+
+  it("a thrown on-chain submit still releases the lock (finally) → resubmit re-grades and can succeed", async () => {
+    statefulLock();
+    codeGrader.mockResolvedValue({ ok: true }); // grading passes → reaches submit
+    completeLesson.mockRejectedValueOnce(new Error("RPC unreachable"));
+
+    const first = await call({ c1: { code: "correct" } });
+    expect(first.status).toBe(500); // outer catch
+    expect(codeGrader).toHaveBeenCalledTimes(1);
+
+    // Despite the throw, `finally` released the lock, so an identical resubmit is
+    // not stuck on a leaked 429 — it re-grades and, with the RPC back, completes.
+    const second = await call({ c1: { code: "correct" } });
+    expect(second.status).toBe(200);
+    expect(codeGrader).toHaveBeenCalledTimes(2);
+    expect(completeLesson).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("submission fingerprint keying (#693)", () => {
   it("is keyed on user + lesson + proofs fingerprint (a 64-hex digest)", async () => {
     await call({ c1: { code: "correct" } });
 
@@ -164,49 +276,10 @@ describe("pre-grading submission-dedup guard (#693)", () => {
     const [first, second] = dedupKeys();
     expect(first).toBe(second);
   });
+});
 
-  it("real 1-token bucket: same submission twice is deduped, a different one is not", async () => {
-    // Emulate the fixed-window 1-token bucket: first sight of a dedup key passes
-    // and spends it; a second sight of the SAME key is refused. Every other
-    // namespace (the volume gates) always clears.
-    const spent = new Set<string>();
-    isRateLimited.mockImplementation(async (ns, key) => {
-      if (ns !== DEDUP_NS) return false;
-      if (spent.has(key)) return true;
-      spent.add(key);
-      return false;
-    });
-
-    // First submission of attempt A → guard clear → grading runs, 403s.
-    const first = await call({ c1: { code: "attempt-A" } });
-    expect(first.status).toBe(403);
-    expect(codeGrader).toHaveBeenCalledTimes(1);
-
-    // Same submission again (duplicate) → deduped → grading does NOT re-run.
-    const dup = await call({ c1: { code: "attempt-A" } });
-    expect(dup.status).toBe(429);
-    const dupBody = (await dup.json()) as { reason?: string };
-    expect(dupBody.reason).toBe("completion_in_progress");
-    expect(codeGrader).toHaveBeenCalledTimes(1); // unchanged — no second run
-
-    // A genuinely different attempt → new fingerprint → NOT blocked, grading runs.
-    const reattempt = await call({ c1: { code: "attempt-B-fixed" } });
-    expect(reattempt.status).toBe(403);
-    expect(codeGrader).toHaveBeenCalledTimes(2);
-  });
-
-  it("403 grading reasons are preserved when the dedup guard is clear", async () => {
-    const res = await call({ c1: { code: "wrong" } });
-
-    // The guard ran (before grading) but was clear, so grading proceeded and the
-    // failure surfaces with its normal 403 + challenge reason — unchanged by #693.
-    expect(res.status).toBe(403);
-    const body = (await res.json()) as { reason?: string };
-    expect(body.reason).toBe("challenge_failed");
-    expect(codeGrader).toHaveBeenCalledTimes(1);
-  });
-
-  it("fails OPEN — a store blip lets grading proceed, never blocking a learner", async () => {
+describe("fail-open (#693)", () => {
+  it("a store blip lets grading proceed, never blocking a learner", async () => {
     // isRateLimited fails open internally; at the route a blip surfaces as
     // `false` (not over budget), so the completion path continues into grading.
     isRateLimited.mockResolvedValue(false);

--- a/apps/web/src/app/api/lessons/complete/__tests__/inflight-guard.test.ts
+++ b/apps/web/src/app/api/lessons/complete/__tests__/inflight-guard.test.ts
@@ -43,6 +43,7 @@ const {
 
 vi.mock("@/lib/rate-limit", () => ({
   isRateLimited: (ns: string, key: string) => isRateLimited(ns, key),
+  releaseRateLimit: () => Promise.resolve(),
   getClientIp: () => "203.0.113.7",
 }));
 

--- a/apps/web/src/app/api/lessons/complete/__tests__/review-capture.test.ts
+++ b/apps/web/src/app/api/lessons/complete/__tests__/review-capture.test.ts
@@ -40,6 +40,7 @@ const {
 
 vi.mock("@/lib/rate-limit", () => ({
   isRateLimited: (ns: string) => isRateLimited(ns),
+  releaseRateLimit: () => Promise.resolve(),
   getClientIp: () => "203.0.113.7",
 }));
 vi.mock("@/lib/supabase/server", () => ({

--- a/apps/web/src/app/api/lessons/complete/route.ts
+++ b/apps/web/src/app/api/lessons/complete/route.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { NextRequest, NextResponse } from "next/server";
 import { PublicKey } from "@solana/web3.js";
 import { BLOCK_REGISTRY, type BlockType } from "@superteam-lms/content-schema";
@@ -56,6 +57,41 @@ async function deriveLessonIndex(
   const index = findLessonIndex(course, lessonId);
   if (index === -1) throw new Error(`Lesson not found in course: ${lessonId}`);
   return index;
+}
+
+/**
+ * Order-independent canonical form of a JSON value: object keys sorted
+ * recursively, array order preserved (answer/test order is meaningful). Two
+ * payloads that differ only in key spelling order collapse to the same string;
+ * any difference in actual content survives. Used to fingerprint a submission
+ * so a byte-for-byte re-fire hashes identically while a genuinely different
+ * attempt does not.
+ */
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (value && typeof value === "object") {
+    const source = value as Record<string, unknown>;
+    return Object.keys(source)
+      .sort()
+      .reduce<Record<string, unknown>>((acc, key) => {
+        acc[key] = canonicalize(source[key]);
+        return acc;
+      }, {});
+  }
+  return value;
+}
+
+/**
+ * Fingerprint of the graded submission — a hash of the canonicalised proofs.
+ * A true duplicate (the client re-firing the same body) yields the same digest;
+ * a legitimate re-attempt carries different answers/code and therefore a
+ * different one. This is what lets the pre-grading dedup guard tell "the same
+ * request twice" from "a second, different attempt" (#693).
+ */
+function proofsFingerprint(proofs: Record<string, unknown>): string {
+  return createHash("sha256")
+    .update(JSON.stringify(canonicalize(proofs)))
+    .digest("hex");
 }
 
 /**
@@ -182,6 +218,52 @@ export async function POST(request: NextRequest) {
       return NextResponse.json(
         { error: "Too many lesson completions from this network." },
         { status: 429, headers: { "Retry-After": "3600" } }
+      );
+    }
+
+    // ── Pre-grading submission-dedup guard (#693) ────────────────────────
+    // The per-(user,lesson) in-flight guard further down sits AFTER grading (so
+    // it can never throttle a legitimate re-attempt) and only dedups the on-chain
+    // submit. That leaves a residual: N concurrent duplicates of the SAME
+    // submission each still run the full server grading suite (code executors,
+    // quiz checks) before one of them takes the in-flight token — wasted CPU on
+    // a platform-funded resource.
+    //
+    // This guard closes that gap without reintroducing the throttle the in-flight
+    // guard was careful to avoid. It is keyed on the SUBMISSION IDENTITY — the
+    // (user, lesson, proofs-fingerprint) triple — NOT on (user, lesson) alone.
+    // That distinction is the whole point:
+    //   • A genuine re-attempt of a failed submission carries DIFFERENT answers/
+    //     code, hence a different fingerprint and a different key, so it is never
+    //     blocked — the 403 path and its reasons are untouched.
+    //   • A true duplicate (the client re-firing the identical body, or a forged
+    //     replay flood of the same payload) carries the SAME fingerprint and
+    //     short-circuits here, so grading runs once for the burst.
+    //
+    // The window matches the in-flight guard's: 1 token / 30s spans a request's
+    // grade+submit+confirm lifetime, so a duplicate arriving anytime while the
+    // first is still in flight is caught. The response mirrors the in-flight
+    // guard exactly (429 + `completion_in_progress` + Retry-After: 30) so the
+    // client copy is identical whether a duplicate is deduped before or after
+    // grading — this adds no new client contract.
+    //
+    // Fail-OPEN (no `failClosed`, inherited from isRateLimited's default): a
+    // store blip degrades to today's behaviour — grading runs — never to a
+    // blocked completion. This is a cost optimisation, not a correctness gate.
+    if (
+      await isRateLimited(
+        "lessons:complete:grading-dedup",
+        `${user.id}:${lessonId}:${proofsFingerprint(proofs)}`,
+        { maxTokens: 1, refillIntervalMs: 30_000 }
+      )
+    ) {
+      return NextResponse.json(
+        {
+          error:
+            "This lesson completion is already being processed. Please wait a moment and try again.",
+          reason: "completion_in_progress",
+        },
+        { status: 429, headers: { "Retry-After": "30" } }
       );
     }
 

--- a/apps/web/src/app/api/lessons/complete/route.ts
+++ b/apps/web/src/app/api/lessons/complete/route.ts
@@ -9,7 +9,7 @@ import type { CompletionDenyReason } from "@/lib/lessons/completion-error";
 import { GRADERS, type GradedBlockType } from "@/lib/grading/graders";
 import { captureReviewFailure } from "@/lib/review/schedule-review";
 import { openAttestation } from "@/lib/ai/check-seal";
-import { isRateLimited, getClientIp } from "@/lib/rate-limit";
+import { isRateLimited, getClientIp, releaseRateLimit } from "@/lib/rate-limit";
 import { logError } from "@/lib/logging";
 import { ERROR_IDS } from "@/constants/errorIds";
 import {
@@ -229,34 +229,48 @@ export async function POST(request: NextRequest) {
     // quiz checks) before one of them takes the in-flight token — wasted CPU on
     // a platform-funded resource.
     //
-    // This guard closes that gap without reintroducing the throttle the in-flight
-    // guard was careful to avoid. It is keyed on the SUBMISSION IDENTITY — the
-    // (user, lesson, proofs-fingerprint) triple — NOT on (user, lesson) alone.
-    // That distinction is the whole point:
-    //   • A genuine re-attempt of a failed submission carries DIFFERENT answers/
-    //     code, hence a different fingerprint and a different key, so it is never
-    //     blocked — the 403 path and its reasons are untouched.
-    //   • A true duplicate (the client re-firing the identical body, or a forged
-    //     replay flood of the same payload) carries the SAME fingerprint and
-    //     short-circuits here, so grading runs once for the burst.
+    // This is a true IN-PROGRESS LOCK, not a 30s window. It ACQUIRES a 1-token
+    // key atomically here, then RELEASES it in the `finally` below on EVERY exit
+    // once the request stops processing. So the key means exactly what its 429
+    // copy says — "a twin request is processing right now" — and never lingers
+    // after a request that failed, threw, or finished.
     //
-    // The window matches the in-flight guard's: 1 token / 30s spans a request's
-    // grade+submit+confirm lifetime, so a duplicate arriving anytime while the
-    // first is still in flight is caught. The response mirrors the in-flight
-    // guard exactly (429 + `completion_in_progress` + Retry-After: 30) so the
-    // client copy is identical whether a duplicate is deduped before or after
-    // grading — this adds no new client contract.
+    // Keyed on the SUBMISSION IDENTITY — the (user, lesson, proofs-fingerprint)
+    // triple, NOT (user, lesson) alone — for two independent reasons:
+    //   • Concurrency: two truly-simultaneous identical submissions collide on
+    //     one key, so grading runs once for the burst and the losers 429 WHILE
+    //     the winner is in flight.
+    //   • Honesty: because the lock is released the instant the winner exits, a
+    //     later sequential resubmit — identical or not — finds the key free and
+    //     re-grades normally, getting its real 403/reason. The fingerprint keeps
+    //     even the pathological "resubmit the exact failing answer twice in the
+    //     same millisecond" case from blocking a DIFFERENT concurrent attempt.
+    //
+    // We RELEASE on the success path too: once the tx lands the on-chain bit is
+    // set, so any later duplicate short-circuits at `alreadyOnChain`, and the
+    // brief concurrent-submit window is already covered by #651's guard below —
+    // holding this lock past success would only risk a false 429 on a genuine
+    // (bit-not-yet-propagated) retry, buying nothing.
+    //
+    // Release is AWAITED (release-before-response), not fire-and-forget: it makes
+    // the lock provably gone before the caller can resubmit, so an honest
+    // re-click never races the delete. The extra round-trip is one indexed
+    // DELETE and off the concurrency-sensitive path.
     //
     // Fail-OPEN (no `failClosed`, inherited from isRateLimited's default): a
     // store blip degrades to today's behaviour — grading runs — never to a
     // blocked completion. This is a cost optimisation, not a correctness gate.
+    const gradingDedupNs = "lessons:complete:grading-dedup";
+    const gradingDedupKey = `${user.id}:${lessonId}:${proofsFingerprint(proofs)}`;
     if (
-      await isRateLimited(
-        "lessons:complete:grading-dedup",
-        `${user.id}:${lessonId}:${proofsFingerprint(proofs)}`,
-        { maxTokens: 1, refillIntervalMs: 30_000 }
-      )
+      await isRateLimited(gradingDedupNs, gradingDedupKey, {
+        maxTokens: 1,
+        refillIntervalMs: 30_000,
+      })
     ) {
+      // A twin request holds the lock → it is genuinely in progress. We did NOT
+      // acquire it, so we must NOT release it here (that would free the twin's
+      // lock) — hence this return is OUTSIDE the try/finally below.
       return NextResponse.json(
         {
           error:
@@ -267,200 +281,302 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // ── Server-authoritative completion gate (block model, spec §7.2) ──────
-    // Inverted from the old fail-OPEN `if (answerKey.type === "challenge")`:
-    // every dispatch below defaults to DENY. An unknown block type, a graded
-    // block with no grader/wrong proof, an executor outage, or a missing/forged
-    // required-block attestation each blocks completion — a forged client
-    // "passed" can never mint XP. Block-level results are transient (never
-    // persisted); the lesson stays the only durable progress unit.
-    const gradedLesson = await getLessonByIdForGrading(courseId, lessonId);
-    if (!gradedLesson) {
-      return NextResponse.json({ error: "Lesson not found" }, { status: 404 });
-    }
-
-    // `reason` is the client's ONLY discriminator between the 403 causes (wrong
-    // quiz answer vs failed code suite vs missing reflection vs missing
-    // enrollment) — without it the client guessed from lesson shape and showed
-    // quiz-failers the "verify enrollment" copy (#564). Deliberately a bare
-    // machine string: the human copy stays localized client-side.
-    const deny = (
-      status: 403 | 404 | 503,
-      error: string,
-      reason?: CompletionDenyReason
-    ) => NextResponse.json(reason ? { error, reason } : { error }, { status });
-
-    // 0) Unknown block type → CLOSED. A block whose _type is not in the registry
-    //    cannot be reasoned about, so completion is denied (not silently skipped).
-    for (const block of gradedLesson.blocks) {
-      if (!((block._type as string) in BLOCK_REGISTRY)) {
-        return deny(
-          503,
-          "This lesson has an unrecognized block and cannot be completed yet"
+    // We hold the lock. Every path out of here — deny, 503, 409, the already-
+    // completed 200, the success 200, or a throw — must hand it back, so the
+    // guarded section is wrapped in try/finally with the release in `finally`.
+    try {
+      // ── Server-authoritative completion gate (block model, spec §7.2) ──────
+      // Inverted from the old fail-OPEN `if (answerKey.type === "challenge")`:
+      // every dispatch below defaults to DENY. An unknown block type, a graded
+      // block with no grader/wrong proof, an executor outage, or a missing/forged
+      // required-block attestation each blocks completion — a forged client
+      // "passed" can never mint XP. Block-level results are transient (never
+      // persisted); the lesson stays the only durable progress unit.
+      const gradedLesson = await getLessonByIdForGrading(courseId, lessonId);
+      if (!gradedLesson) {
+        return NextResponse.json(
+          { error: "Lesson not found" },
+          { status: 404 }
         );
       }
-    }
 
-    // 1) Graded blocks (code, quiz): a deterministic grader MUST pass. A missing
-    //    grader for a graded type is a second, independent fail-closed path.
-    for (const block of gradedLesson.blocks) {
-      const type = block._type as BlockType;
-      if (!BLOCK_REGISTRY[type].graded) continue;
-      const grader = GRADERS[type as GradedBlockType];
-      if (!grader) return deny(503, "No grader for this block type");
-      const result = await grader(block, proofs[block.key]);
-      if (!result.ok) {
-        // A genuine graded MISS (403) is a learning signal → capture it into the
-        // review substrate keyed by this lesson (LX-B4). A 503 is "could not
-        // judge" (executor outage), not a miss — never captured. Best-effort:
-        // the helper never throws by contract, and the `.catch` here is a second
-        // guard so a review-write hiccup can NEVER change this deny response.
-        if (result.status === 403) {
-          await captureReviewFailure({
-            userId: user.id,
-            lessonId,
-            reason: type === "quiz" ? "quiz_failed" : "challenge_failed",
-            failedTests:
-              "failedTests" in result ? result.failedTests : undefined,
-          }).catch(() => {});
+      // `reason` is the client's ONLY discriminator between the 403 causes (wrong
+      // quiz answer vs failed code suite vs missing reflection vs missing
+      // enrollment) — without it the client guessed from lesson shape and showed
+      // quiz-failers the "verify enrollment" copy (#564). Deliberately a bare
+      // machine string: the human copy stays localized client-side.
+      const deny = (
+        status: 403 | 404 | 503,
+        error: string,
+        reason?: CompletionDenyReason
+      ) =>
+        NextResponse.json(reason ? { error, reason } : { error }, { status });
+
+      // 0) Unknown block type → CLOSED. A block whose _type is not in the registry
+      //    cannot be reasoned about, so completion is denied (not silently skipped).
+      for (const block of gradedLesson.blocks) {
+        if (!((block._type as string) in BLOCK_REGISTRY)) {
+          return deny(
+            503,
+            "This lesson has an unrecognized block and cannot be completed yet"
+          );
         }
-        // 503 = we could not judge (executor outage) — no `reason`, since the
-        // block did not "fail"; grading was unavailable.
-        return deny(
-          result.status,
-          "Block did not pass",
-          result.status === 403
-            ? type === "quiz"
-              ? "quiz_failed"
-              : type === "parsons"
-                ? "parsons_failed"
-                : "challenge_failed"
-            : undefined
+      }
+
+      // 1) Graded blocks (code, quiz): a deterministic grader MUST pass. A missing
+      //    grader for a graded type is a second, independent fail-closed path.
+      for (const block of gradedLesson.blocks) {
+        const type = block._type as BlockType;
+        if (!BLOCK_REGISTRY[type].graded) continue;
+        const grader = GRADERS[type as GradedBlockType];
+        if (!grader) return deny(503, "No grader for this block type");
+        const result = await grader(block, proofs[block.key]);
+        if (!result.ok) {
+          // A genuine graded MISS (403) is a learning signal → capture it into the
+          // review substrate keyed by this lesson (LX-B4). A 503 is "could not
+          // judge" (executor outage), not a miss — never captured. Best-effort:
+          // the helper never throws by contract, and the `.catch` here is a second
+          // guard so a review-write hiccup can NEVER change this deny response.
+          if (result.status === 403) {
+            await captureReviewFailure({
+              userId: user.id,
+              lessonId,
+              reason: type === "quiz" ? "quiz_failed" : "challenge_failed",
+              failedTests:
+                "failedTests" in result ? result.failedTests : undefined,
+            }).catch(() => {});
+          }
+          // 503 = we could not judge (executor outage) — no `reason`, since the
+          // block did not "fail"; grading was unavailable.
+          return deny(
+            result.status,
+            "Block did not pass",
+            result.status === 403
+              ? type === "quiz"
+                ? "quiz_failed"
+                : type === "parsons"
+                  ? "parsons_failed"
+                  : "challenge_failed"
+              : undefined
+          );
+        }
+      }
+
+      // 2) Required-but-UNGRADED blocks (openEnded): a sealed attestation must
+      //    prove the server saw a submission for THIS lesson+block+user. The
+      //    `!graded` filter is essential — a graded block's proof is an answer set,
+      //    not an attestation, so running it through openAttestation would 403
+      //    every valid code/quiz completion.
+      for (const block of gradedLesson.blocks) {
+        const type = block._type as BlockType;
+        if (!(BLOCK_REGISTRY[type].required && !BLOCK_REGISTRY[type].graded)) {
+          continue;
+        }
+        const token = proofs[block.key];
+        if (
+          typeof token !== "string" ||
+          !openAttestation(token, {
+            courseId,
+            lessonId,
+            blockKey: block.key,
+            userId: user.id,
+          })
+        ) {
+          return deny(
+            403,
+            "This lesson requires a completed reflection",
+            "reflection_required"
+          );
+        }
+      }
+
+      // Look up user's wallet — required for on-chain operations
+      const supabaseAdmin = createAdminClient();
+      const { data: profile } = await supabaseAdmin
+        .from("profiles")
+        .select("wallet_address")
+        .eq("id", user.id)
+        .single();
+
+      if (!profile?.wallet_address) {
+        return NextResponse.json(
+          {
+            error:
+              "Wallet not connected. Link your wallet to earn on-chain XP.",
+          },
+          { status: 400 }
         );
       }
-    }
 
-    // 2) Required-but-UNGRADED blocks (openEnded): a sealed attestation must
-    //    prove the server saw a submission for THIS lesson+block+user. The
-    //    `!graded` filter is essential — a graded block's proof is an answer set,
-    //    not an attestation, so running it through openAttestation would 403
-    //    every valid code/quiz completion.
-    for (const block of gradedLesson.blocks) {
-      const type = block._type as BlockType;
-      if (!(BLOCK_REGISTRY[type].required && !BLOCK_REGISTRY[type].graded)) {
-        continue;
+      const programLive = await isOnChainProgramLive();
+      if (!programLive) {
+        return NextResponse.json(
+          { error: "On-chain program not available" },
+          { status: 503 }
+        );
       }
-      const token = proofs[block.key];
-      if (
-        typeof token !== "string" ||
-        !openAttestation(token, {
-          courseId,
-          lessonId,
-          blockKey: block.key,
-          userId: user.id,
-        })
-      ) {
+
+      // WS-2 #453 rail 3 — the affected course is mid close+recreate (the Course
+      // PDA is briefly absent, non-atomically). Refuse rather than racing that
+      // window; the learner's proofs/grading above are already validated and
+      // durable client-side, so a retry shortly after is lossless.
+      if (await isCourseInMaintenance(courseId)) {
+        return NextResponse.json(
+          {
+            error:
+              "This course is undergoing maintenance. Please try again in a few minutes.",
+          },
+          { status: 503, headers: { "Retry-After": "60" } }
+        );
+      }
+
+      const walletPubkey = new PublicKey(profile.wallet_address);
+      const connection = getConnection();
+
+      // Verify on-chain enrollment exists. The course fetch (for the lesson-count
+      // guard below) is independent, so run both RPC reads in parallel.
+      const [onChainEnrollment, onChainCourse] = await Promise.all([
+        fetchEnrollment(courseId, walletPubkey, connection, getProgramId()),
+        fetchCourse(courseId, connection, getProgramId()),
+      ]);
+
+      if (!onChainEnrollment) {
         return deny(
           403,
-          "This lesson requires a completed reflection",
-          "reflection_required"
+          "On-chain enrollment not found. Please re-enroll the course.",
+          "enrollment_missing"
         );
       }
-    }
 
-    // Look up user's wallet — required for on-chain operations
-    const supabaseAdmin = createAdminClient();
-    const { data: profile } = await supabaseAdmin
-      .from("profiles")
-      .select("wallet_address")
-      .eq("id", user.id)
-      .single();
+      // Derive lesson index from content-bundle lesson order
+      const lessonIndex = await deriveLessonIndex(courseId, lessonId);
 
-    if (!profile?.wallet_address) {
-      return NextResponse.json(
-        {
-          error: "Wallet not connected. Link your wallet to earn on-chain XP.",
-        },
-        { status: 400 }
+      // Guard: the on-chain complete_lesson reverts when lessonIndex >=
+      // course.lesson_count. That happens when a teacher appended lessons to an
+      // already-deployed course but the Course PDA's lesson_count has not yet been
+      // raised by an admin re-sync (update_course.new_lesson_count). Detect it here
+      // and return a clear 409 instead of letting the on-chain TX throw a generic
+      // 500. fetchCourse returns the normalised `liveLessonCount`.
+      // Count-based and only correct while masks are dense (today). Once a
+      // sparse-mask course can exist, this must become a per-slot bit test
+      // against `activeLessons` instead of a count comparison.
+      const onChainLessonCount = onChainCourse?.liveLessonCount;
+      if (
+        typeof onChainLessonCount === "number" &&
+        lessonIndex >= onChainLessonCount
+      ) {
+        return NextResponse.json(
+          {
+            error:
+              "This course was recently extended and is pending an admin re-sync — try again shortly.",
+          },
+          { status: 409 }
+        );
+      }
+
+      // Idempotency: skip on-chain TX if lesson already completed in bitmap
+      const alreadyOnChain = isLessonComplete(
+        onChainEnrollment.lesson_flags as (bigint | number)[],
+        lessonIndex
       );
-    }
 
-    const programLive = await isOnChainProgramLive();
-    if (!programLive) {
-      return NextResponse.json(
-        { error: "On-chain program not available" },
-        { status: 503 }
+      if (alreadyOnChain) {
+        // Sync progress in case the Helius webhook missed this completion.
+        // ignoreDuplicates avoids overwriting an existing tx_signature with null.
+        const { error: recoveryError } = await supabaseAdmin
+          .from("user_progress")
+          .upsert(
+            {
+              user_id: user.id,
+              course_id: courseId,
+              lesson_id: lessonId,
+              completed: true,
+              completed_at: new Date().toISOString(),
+              tx_signature: null,
+              lesson_index: lessonIndex,
+            },
+            { onConflict: "user_id,lesson_id", ignoreDuplicates: true }
+          );
+
+        if (recoveryError) {
+          logError({
+            errorId: ERROR_IDS.LESSON_COMPLETE_FAILED,
+            error: new Error(recoveryError.message),
+            context: {
+              route: "/api/lessons/complete",
+              step: "recovery_sync",
+              userId: user.id,
+              courseId,
+              lessonId,
+            },
+          });
+        }
+        return NextResponse.json({
+          success: true,
+          alreadyCompleted: true,
+          signature: null,
+        });
+      }
+
+      // ── Per-(user,lesson) in-flight guard (#651) ─────────────────────────
+      // Everything above is settled: grading PASSED, enrollment exists, and the
+      // lesson is NOT yet set in the on-chain bitmap. Between that stale read
+      // (`alreadyOnChain` above) and the confirmed complete_lesson tx below, N
+      // concurrent same-lesson requests all see the unset bit and each fire a tx;
+      // one confirms, the rest revert on the program's double-complete guard — but
+      // the backend keypair (payer) eats each reverted tx's base fee, and the
+      // graders already ran for all N. This 1-token / 30s bucket is a coarse lock
+      // over that critical section: the first request through takes the token, a
+      // second concurrent one 429s.
+      //
+      // Keyed per (user, lesson): it never touches a learner's OTHER lessons, and
+      // — sitting AFTER grading — it leaves normal retries alone. A wrong/failed
+      // submission 403s above and never reaches here; a re-fire of an ALREADY-
+      // completed lesson short-circuits at `alreadyOnChain` above. So the only
+      // request this blocks is a duplicate of an already-valid completion that is
+      // still in flight — exactly what "already in progress" means. That also
+      // covers a forged same-lesson `replay` flood, which flows through here like
+      // any other completion (honest replays are per-lesson-distinct, so they
+      // never collide on this key).
+      //
+      // 30s ≈ the grading + submit + confirm window the stale read spans. Fixed-
+      // window alignment makes this a coarse lock, not a mutex (two requests
+      // straddling a window boundary can both pass) — acceptable: it bounds the
+      // burn, it does not need to be exact.
+      //
+      // Fail-OPEN (no `failClosed`): a store blip degrades to today's pre-existing
+      // race, never to a blocked completion. This is a cost optimisation, not a
+      // correctness gate — the program's own double-complete check is the real
+      // guarantee — so a transient DB hiccup must never stop a learner finishing a
+      // lesson.
+      if (
+        await isRateLimited(
+          "lessons:complete:inflight",
+          `${user.id}:${lessonId}`,
+          { maxTokens: 1, refillIntervalMs: 30_000 }
+        )
+      ) {
+        return NextResponse.json(
+          {
+            error:
+              "This lesson completion is already being processed. Please wait a moment and try again.",
+            reason: "completion_in_progress",
+          },
+          { status: 429, headers: { "Retry-After": "30" } }
+        );
+      }
+
+      // Execute on-chain completeLesson
+      const signature = await onChainCompleteLesson(
+        courseId,
+        walletPubkey,
+        lessonIndex
       );
-    }
 
-    // WS-2 #453 rail 3 — the affected course is mid close+recreate (the Course
-    // PDA is briefly absent, non-atomically). Refuse rather than racing that
-    // window; the learner's proofs/grading above are already validated and
-    // durable client-side, so a retry shortly after is lossless.
-    if (await isCourseInMaintenance(courseId)) {
-      return NextResponse.json(
-        {
-          error:
-            "This course is undergoing maintenance. Please try again in a few minutes.",
-        },
-        { status: 503, headers: { "Retry-After": "60" } }
-      );
-    }
-
-    const walletPubkey = new PublicKey(profile.wallet_address);
-    const connection = getConnection();
-
-    // Verify on-chain enrollment exists. The course fetch (for the lesson-count
-    // guard below) is independent, so run both RPC reads in parallel.
-    const [onChainEnrollment, onChainCourse] = await Promise.all([
-      fetchEnrollment(courseId, walletPubkey, connection, getProgramId()),
-      fetchCourse(courseId, connection, getProgramId()),
-    ]);
-
-    if (!onChainEnrollment) {
-      return deny(
-        403,
-        "On-chain enrollment not found. Please re-enroll the course.",
-        "enrollment_missing"
-      );
-    }
-
-    // Derive lesson index from content-bundle lesson order
-    const lessonIndex = await deriveLessonIndex(courseId, lessonId);
-
-    // Guard: the on-chain complete_lesson reverts when lessonIndex >=
-    // course.lesson_count. That happens when a teacher appended lessons to an
-    // already-deployed course but the Course PDA's lesson_count has not yet been
-    // raised by an admin re-sync (update_course.new_lesson_count). Detect it here
-    // and return a clear 409 instead of letting the on-chain TX throw a generic
-    // 500. fetchCourse returns the normalised `liveLessonCount`.
-    // Count-based and only correct while masks are dense (today). Once a
-    // sparse-mask course can exist, this must become a per-slot bit test
-    // against `activeLessons` instead of a count comparison.
-    const onChainLessonCount = onChainCourse?.liveLessonCount;
-    if (
-      typeof onChainLessonCount === "number" &&
-      lessonIndex >= onChainLessonCount
-    ) {
-      return NextResponse.json(
-        {
-          error:
-            "This course was recently extended and is pending an admin re-sync — try again shortly.",
-        },
-        { status: 409 }
-      );
-    }
-
-    // Idempotency: skip on-chain TX if lesson already completed in bitmap
-    const alreadyOnChain = isLessonComplete(
-      onChainEnrollment.lesson_flags as (bigint | number)[],
-      lessonIndex
-    );
-
-    if (alreadyOnChain) {
-      // Sync progress in case the Helius webhook missed this completion.
-      // ignoreDuplicates avoids overwriting an existing tx_signature with null.
-      const { error: recoveryError } = await supabaseAdmin
+      // Write directly to Supabase so progress is visible on the dashboard
+      // immediately, without depending on Helius webhook delivery timing.
+      // The webhook will upsert the same row again (idempotent) when it arrives.
+      const { error: progressError } = await supabaseAdmin
         .from("user_progress")
         .upsert(
           {
@@ -469,120 +585,36 @@ export async function POST(request: NextRequest) {
             lesson_id: lessonId,
             completed: true,
             completed_at: new Date().toISOString(),
-            tx_signature: null,
+            tx_signature: signature,
             lesson_index: lessonIndex,
           },
-          { onConflict: "user_id,lesson_id", ignoreDuplicates: true }
+          { onConflict: "user_id,lesson_id" }
         );
 
-      if (recoveryError) {
+      if (progressError) {
         logError({
           errorId: ERROR_IDS.LESSON_COMPLETE_FAILED,
-          error: new Error(recoveryError.message),
+          error: new Error(progressError.message),
           context: {
             route: "/api/lessons/complete",
-            step: "recovery_sync",
+            step: "sync_progress",
             userId: user.id,
             courseId,
             lessonId,
           },
         });
       }
-      return NextResponse.json({
-        success: true,
-        alreadyCompleted: true,
-        signature: null,
-      });
+
+      return NextResponse.json({ success: true, signature });
+    } finally {
+      // Hand the in-progress lock back on EVERY exit from the guarded section —
+      // graded-failure 403s, reflection_required, wallet-not-connected,
+      // program-not-live, maintenance, pending-re-sync, already-completed,
+      // success, and thrown errors alike. A `finally` is the only placement that
+      // no return or throw can bypass, so the key never outlives the request
+      // that held it and a later honest resubmit always re-grades.
+      await releaseRateLimit(gradingDedupNs, gradingDedupKey);
     }
-
-    // ── Per-(user,lesson) in-flight guard (#651) ─────────────────────────
-    // Everything above is settled: grading PASSED, enrollment exists, and the
-    // lesson is NOT yet set in the on-chain bitmap. Between that stale read
-    // (`alreadyOnChain` above) and the confirmed complete_lesson tx below, N
-    // concurrent same-lesson requests all see the unset bit and each fire a tx;
-    // one confirms, the rest revert on the program's double-complete guard — but
-    // the backend keypair (payer) eats each reverted tx's base fee, and the
-    // graders already ran for all N. This 1-token / 30s bucket is a coarse lock
-    // over that critical section: the first request through takes the token, a
-    // second concurrent one 429s.
-    //
-    // Keyed per (user, lesson): it never touches a learner's OTHER lessons, and
-    // — sitting AFTER grading — it leaves normal retries alone. A wrong/failed
-    // submission 403s above and never reaches here; a re-fire of an ALREADY-
-    // completed lesson short-circuits at `alreadyOnChain` above. So the only
-    // request this blocks is a duplicate of an already-valid completion that is
-    // still in flight — exactly what "already in progress" means. That also
-    // covers a forged same-lesson `replay` flood, which flows through here like
-    // any other completion (honest replays are per-lesson-distinct, so they
-    // never collide on this key).
-    //
-    // 30s ≈ the grading + submit + confirm window the stale read spans. Fixed-
-    // window alignment makes this a coarse lock, not a mutex (two requests
-    // straddling a window boundary can both pass) — acceptable: it bounds the
-    // burn, it does not need to be exact.
-    //
-    // Fail-OPEN (no `failClosed`): a store blip degrades to today's pre-existing
-    // race, never to a blocked completion. This is a cost optimisation, not a
-    // correctness gate — the program's own double-complete check is the real
-    // guarantee — so a transient DB hiccup must never stop a learner finishing a
-    // lesson.
-    if (
-      await isRateLimited(
-        "lessons:complete:inflight",
-        `${user.id}:${lessonId}`,
-        { maxTokens: 1, refillIntervalMs: 30_000 }
-      )
-    ) {
-      return NextResponse.json(
-        {
-          error:
-            "This lesson completion is already being processed. Please wait a moment and try again.",
-          reason: "completion_in_progress",
-        },
-        { status: 429, headers: { "Retry-After": "30" } }
-      );
-    }
-
-    // Execute on-chain completeLesson
-    const signature = await onChainCompleteLesson(
-      courseId,
-      walletPubkey,
-      lessonIndex
-    );
-
-    // Write directly to Supabase so progress is visible on the dashboard
-    // immediately, without depending on Helius webhook delivery timing.
-    // The webhook will upsert the same row again (idempotent) when it arrives.
-    const { error: progressError } = await supabaseAdmin
-      .from("user_progress")
-      .upsert(
-        {
-          user_id: user.id,
-          course_id: courseId,
-          lesson_id: lessonId,
-          completed: true,
-          completed_at: new Date().toISOString(),
-          tx_signature: signature,
-          lesson_index: lessonIndex,
-        },
-        { onConflict: "user_id,lesson_id" }
-      );
-
-    if (progressError) {
-      logError({
-        errorId: ERROR_IDS.LESSON_COMPLETE_FAILED,
-        error: new Error(progressError.message),
-        context: {
-          route: "/api/lessons/complete",
-          step: "sync_progress",
-          userId: user.id,
-          courseId,
-          lessonId,
-        },
-      });
-    }
-
-    return NextResponse.json({ success: true, signature });
   } catch (err: unknown) {
     logError({
       errorId: ERROR_IDS.LESSON_COMPLETE_FAILED,

--- a/apps/web/src/lib/__tests__/rate-limit.test.ts
+++ b/apps/web/src/lib/__tests__/rate-limit.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 vi.mock("server-only", () => ({}));
 vi.mock("@/lib/supabase/admin", () => ({ createAdminClient: vi.fn() }));
 
-import { getClientIp, isRateLimited } from "@/lib/rate-limit";
+import { getClientIp, isRateLimited, releaseRateLimit } from "@/lib/rate-limit";
 import { createAdminClient } from "@/lib/supabase/admin";
 
 const h = (headers: Record<string, string>) => new Headers(headers);
@@ -185,5 +185,52 @@ describe("isRateLimited — fail-open default, fail-closed opt-in", () => {
     expect(
       await isRateLimited("ai:partner", "key", { ...OPTS, failClosed: true })
     ).toBe(true);
+  });
+});
+
+// Release hands a lock-style key (maxTokens: 1) back early so the next request
+// starts clean instead of waiting out the window — the correctness half of the
+// #693 grading-dedup guard. It deletes the row directly (check_rate_limit only
+// counts up) and must fail SOFT: a store blip can never surface to the caller,
+// since a leaked lock self-heals when its window expires.
+describe("releaseRateLimit — early lock hand-back, fail-soft", () => {
+  beforeEach(() => {
+    vi.mocked(createAdminClient).mockReset();
+  });
+
+  /** Capture the `.eq("key", …)` filter and return a canned delete outcome. */
+  function stubDelete(outcome: { error?: unknown } | Error) {
+    const eq = vi.fn(async () => {
+      if (outcome instanceof Error) throw outcome;
+      return { error: outcome.error ?? null };
+    });
+    const from = vi.fn(() => ({ delete: () => ({ eq }) }));
+    vi.mocked(createAdminClient).mockReturnValue({
+      from,
+    } as unknown as ReturnType<typeof createAdminClient>);
+    return { from, eq };
+  }
+
+  it("deletes the rate_limits row keyed EXACTLY `${namespace}:${key}`", async () => {
+    const { from, eq } = stubDelete({});
+    await releaseRateLimit(
+      "lessons:complete:grading-dedup",
+      "user-1:lesson-1:ab"
+    );
+    expect(from).toHaveBeenCalledWith("rate_limits");
+    expect(eq).toHaveBeenCalledWith(
+      "key",
+      "lessons:complete:grading-dedup:user-1:lesson-1:ab"
+    );
+  });
+
+  it("fails SOFT when the delete returns an error (never throws)", async () => {
+    stubDelete({ error: { message: "delete failed" } });
+    await expect(releaseRateLimit("ns", "key")).resolves.toBeUndefined();
+  });
+
+  it("fails SOFT when the admin client throws (never throws)", async () => {
+    stubDelete(new Error("connection refused"));
+    await expect(releaseRateLimit("ns", "key")).resolves.toBeUndefined();
   });
 });

--- a/apps/web/src/lib/rate-limit.ts
+++ b/apps/web/src/lib/rate-limit.ts
@@ -132,3 +132,47 @@ export async function isRateLimited(
     return opts.failClosed === true;
   }
 }
+
+/**
+ * Release a lock-style rate-limit key by deleting its row(s), so the very next
+ * request with the same key starts from a clean window instead of waiting out
+ * the fixed window.
+ *
+ * This is ONLY meaningful for a 1-token "in-progress lock" (maxTokens: 1), where
+ * the single token means "a request holding this key is processing right now"
+ * and must be handed back the moment that request stops. Calling it on a
+ * volume/burst limiter (maxTokens > 1) would defeat the limit — don't.
+ *
+ * Keyed EXACTLY like `isRateLimited`: the stored row's key is `${namespace}:
+ * ${key}`, and the delete matches all windows for it (there is at most a current
+ * row plus a stale one check_rate_limit would have pruned anyway). Touches the
+ * table directly rather than through check_rate_limit — that function only
+ * counts up; releasing is a delete — and stays service-role-only (the table has
+ * no RLS policies, so only the admin client reaches it).
+ *
+ * Fails SOFT: a delete error is logged and swallowed. A lock that fails to
+ * release self-heals when its window expires (≤ the window length), so a
+ * transient store blip must never surface to the caller — exactly mirroring the
+ * fail-open stance of the acquire side.
+ */
+export async function releaseRateLimit(
+  namespace: string,
+  key: string
+): Promise<void> {
+  try {
+    const admin = createAdminClient();
+    const { error } = await admin
+      .from("rate_limits")
+      .delete()
+      .eq("key", `${namespace}:${key}`);
+    if (error) {
+      console.warn(
+        `[rate-limit] release failed for ${namespace}:`,
+        error.message
+      );
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.warn(`[rate-limit] release unavailable for ${namespace}:`, message);
+  }
+}

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -1939,8 +1939,10 @@ GRANT SELECT ON community_stats TO anon, authenticated;
 -- ============================================================
 -- Shared rate-limit store (P1-7)
 -- ============================================================
--- Atomic, cross-instance fixed-window limiter. Accessed only via
--- check_rate_limit() (service_role); the table is service_role-only.
+-- Atomic, cross-instance fixed-window limiter. Counted up via check_rate_limit()
+-- (service_role); lock-style keys (maxTokens: 1) are also handed back early by a
+-- direct service_role DELETE (see releaseRateLimit in lib/rate-limit.ts). The
+-- table is service_role-only (no RLS policies), so both paths are privileged.
 
 CREATE TABLE IF NOT EXISTS rate_limits (
   key          TEXT        NOT NULL,


### PR DESCRIPTION
Closes #693.

## What

Adds a **pre-grading submission-dedup guard** to `/api/lessons/complete` so N concurrent duplicates of the *same* submission run the server grading suite (code executors, quiz checks) **once**, not N times — implemented as a true **in-progress lock**, not a fixed window.

## Why

Residual of #651 / #690. #690's per-`(user, lesson)` in-flight guard sits **after** grading — correctly, since moving it earlier would throttle a learner's legitimate re-attempts. So #690 only dedups the on-chain submit; the graders still ran for every concurrent duplicate. This follows **Option 1** from the issue: dedup on **submission identity**, not on `(user, lesson)`.

## Adversarial-review fix (v2 on this branch)

The first cut acquired a 1-token / 30s key **before** grading and never released it. That leaked a false `429 completion_in_progress` onto every honest failure-then-resubmit path (nothing was actually "in progress"). Fixed by making the guard a real **acquire / release lock**:

- **Acquire** the fingerprint key atomically (unchanged — the mechanism the review verified sound).
- The guarded section is wrapped in **`try / finally`**, and the key is **released on every exit** — every deny/`503`/`409`, the already-completed `200`, the success `200`, and thrown errors — via a new `releaseRateLimit(namespace, key)` (service-role `DELETE` of the `rate_limits` row, fail-soft).
- The `429` for a genuine twin returns **outside** the `try/finally`: a request that did **not** acquire must never release the twin's lock.
- **Release is awaited** (release-before-response) so an honest re-click can't race the delete. Released on success too — the on-chain bit + #651's guard already cover post-success duplicates, so holding it would only risk a false 429 on a genuine retry.

## Before / after concurrency semantics

| Scenario | Before this PR | After this PR |
|---|---|---|
| N concurrent duplicates of the **same** submission | grading runs N times; #690 dedups only the on-chain tx | grading runs **once**; the rest `429 completion_in_progress` **while a twin is genuinely in flight** |
| Legitimate re-attempt with **different** answers/code | grading runs (correct) | grading runs — different fingerprint → different key → **never blocked** |
| Failed grading → **identical** resubmit (re-click Submit) | `403` + reason | lock released after the first failure → **re-grades**, real `403` + reason (**not** a false 429) |
| `wallet-not-connected` → connect → resubmit same answers | `400` wallet reason | `400` wallet reason again (**not** a false 429) |
| Thrown on-chain submit (`500`) → resubmit | `500`, retryable | `finally` released the lock → resubmit **re-grades** and can succeed |
| #690 in-flight guard (on-chain submit) | dedups `(user, lesson)` | **unchanged** — still dedups valid payloads the fingerprint guard lets through |

## How the fix differs from — and preserves — #690's guard

- **Key.** #690: `${user}:${lessonId}` (coarse, per-lesson). New guard: `${user}:${lessonId}:${sha256(canonical(proofs))}` — keyed on the **proofs fingerprint**, so a corrected re-attempt (different proofs) is never blocked.
- **Placement.** #690 stays **after** grading (dedups the tx). New guard sits **before** grading (dedups the CPU). Both coexist; #690 is untouched.
- **Lifecycle.** #690 is a coarse 30s window. The new guard is an acquire/release lock that is handed back the moment the request stops processing — so it means "a twin is processing right now", which is exactly what its `completion_in_progress` copy claims.
- **Response.** Identical to #690 — `429` + `reason: "completion_in_progress"` + `Retry-After: 30`. No new client contract.
- **Fail mode.** Acquire fails **open** (store blip → grading runs). Release fails **soft** (a leaked lock self-heals when its window expires). Never a blocked completion.

The fingerprint canonicalises `proofs` (recursively sorted object keys, array order preserved) so key-spelling order can't split a true duplicate, while any real content difference always yields a different key.

## Verification

- `pnpm install --frozen-lockfile` — clean
- `pnpm typecheck` — 6/6 packages pass
- `pnpm --filter web test` — **1573 passed** (178 files)
- `/api/lessons/complete` suite + `rate-limit` unit suite — **66 passed** (6 files). New/updated coverage: concurrent twin → 429, grading skipped, twin's lock **not** released; acquiring request releases the same fingerprint key; **failed grading → identical resubmit re-grades + real 403** (inverts the prior test); wallet-not-connected resubmit → wallet reason (not 429); thrown submit → `finally` releases → resubmit re-grades; fingerprint keying (64-hex, identical vs different, order-independent); fail-open; `releaseRateLimit` unit tests (exact key, fail-soft on error and on throw).
- eslint clean on changed files; zero `any`, strict TS.
