### PR TITLE
feat(ai): fail-closed daily spend ledger + degrade-first caps for the AI tutor (#591)

### DIFF
--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -78,6 +78,21 @@ AI_PARTNER_SEAL_SECRET=            # Optional dedicated key for sealing the comp
                                     # SUPABASE_SERVICE_ROLE_KEY.
 AI_PARTNER_DEBUG=                  # Set to "1" to log per-call prompt-cache token counts
                                     # from /api/ai/partner. Default off (quiet in production).
+
+# Optional — AI tutor daily spend caps (#591). Whole/decimal USD, per
+# America/Sao_Paulo day, enforced by the ai_spend_ledger (lib/ai/spend-ledger).
+# Derived DOWNWARD from the $500/mo sponsor commitment (O-1); config, not
+# constants — bump when the commitment moves. Over a SOFT cap the tutor degrades
+# (shorter output budget); only a HARD cap denies (503, fail-closed). Defaults
+# shown; unset/"" uses the default.
+AI_SPEND_GLOBAL_SOFT_USD=          # Global degrade threshold      (default 14)
+AI_SPEND_GLOBAL_HARD_USD=          # Global hard deny              (default 25)
+AI_SPEND_ACCOUNT_SOFT_USD=         # Per-account degrade           (default 0.5)
+AI_SPEND_ACCOUNT_HARD_USD=         # Per-account hard deny         (default 1.5)
+AI_SPEND_IP_SOFT_USD=              # Per-IP degrade                (default 2)
+AI_SPEND_IP_HARD_USD=              # Per-IP hard deny              (default 5)
+AI_SPEND_INPUT_USD_PER_MTOK=       # Gemini input price  $/1M tok  (default 0.3)
+AI_SPEND_OUTPUT_USD_PER_MTOK=      # Gemini output price $/1M tok  (default 2.5; thinking bills here)
 OPENENDED_AI_REPLY=                # Set to "1" to enable the best-effort AI reply on
                                     # /api/lessons/reflect (openEnded reflections). Default OFF:
                                     # the reflection SEAL is always returned regardless; the reply

--- a/apps/web/src/app/api/ai/__tests__/partner-route.test.ts
+++ b/apps/web/src/app/api/ai/__tests__/partner-route.test.ts
@@ -27,6 +27,16 @@ vi.mock("@/lib/rate-limit", () => ({
   getClientIp,
 }));
 
+// #591 spend ledger. checkAiSpend gates the call fail-closed; recordAiSpend
+// books the cost. degradedMaxTokens is the real pure helper (halve, floor 256).
+const checkAiSpend = vi.fn();
+const recordAiSpend = vi.fn();
+vi.mock("@/lib/ai/spend-ledger", () => ({
+  checkAiSpend,
+  recordAiSpend,
+  degradedMaxTokens: (base: number) => Math.max(256, Math.floor(base / 2)),
+}));
+
 const getLessonBySlug = vi.fn();
 vi.mock("@/lib/content/queries", () => ({
   getLessonBySlug,
@@ -150,6 +160,8 @@ beforeEach(() => {
   appendAssistLog.mockReset();
   isRateLimited.mockReset();
   getLessonBySlug.mockReset();
+  checkAiSpend.mockReset();
+  recordAiSpend.mockReset();
 
   // Happy-path defaults; individual tests override as needed.
   getUser.mockResolvedValue({ data: { user: { id: "user-1" } }, error: null });
@@ -159,6 +171,9 @@ beforeEach(() => {
   refundAssist.mockResolvedValue(undefined);
   recordBilledAssist.mockResolvedValue(undefined);
   appendAssistLog.mockResolvedValue(undefined);
+  // Under every spend cap by default → serve at full budget.
+  checkAiSpend.mockResolvedValue({ decision: "full" });
+  recordAiSpend.mockResolvedValue(undefined);
 });
 
 afterEach(() => {
@@ -1021,5 +1036,141 @@ describe("POST /api/ai/partner", () => {
       role: "ai",
       response: { type: "review" },
     });
+  });
+
+  // --- #591: daily spend ledger gate (per-account / per-IP / global) ---
+
+  it("checks the spend ledger with the user id and client IP before spending", async () => {
+    stubGeminiFetch(PROPOSE_GEMINI_TEXT);
+
+    const { POST } = await import("../partner/route");
+    await POST(makeRequest(VALID_BODY));
+
+    expect(checkAiSpend).toHaveBeenCalledTimes(1);
+    expect(checkAiSpend).toHaveBeenCalledWith("user-1", "203.0.113.9");
+  });
+
+  it("under cap: serves at the FULL output budget and records the spend", async () => {
+    checkAiSpend.mockResolvedValue({ decision: "full" });
+    const fetchSpy = vi.fn(async (_url: string, init: { body: string }) => {
+      void init;
+      return {
+        ok: true,
+        text: async () => "",
+        json: async () => ({
+          candidates: [{ content: { parts: [{ text: PROPOSE_GEMINI_TEXT }] } }],
+          usageMetadata: {
+            promptTokenCount: 1000,
+            candidatesTokenCount: 500,
+            thoughtsTokenCount: 0,
+          },
+        }),
+      };
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const { POST } = await import("../partner/route");
+    const res = await POST(makeRequest(VALID_BODY));
+
+    expect(res.status).toBe(200);
+    // Full budget: propose stays at 2048, not the degraded 1024.
+    const [, init] = fetchSpy.mock.calls[0]!;
+    const sent = JSON.parse(init.body) as {
+      generationConfig: { maxOutputTokens: number };
+    };
+    expect(sent.generationConfig.maxOutputTokens).toBe(2048);
+    // The actual usage is booked against the ledger with the request's IP.
+    expect(recordAiSpend).toHaveBeenCalledTimes(1);
+    expect(recordAiSpend).toHaveBeenCalledWith("user-1", "203.0.113.9", {
+      promptTokenCount: 1000,
+      candidatesTokenCount: 500,
+      thoughtsTokenCount: 0,
+    });
+  });
+
+  it("soft cap: DEGRADES to a shorter output budget but still serves (200)", async () => {
+    checkAiSpend.mockResolvedValue({ decision: "degraded" });
+    const fetchSpy = vi.fn(async (_url: string, init: { body: string }) => {
+      void init;
+      return {
+        ok: true,
+        text: async () => "",
+        json: async () => ({
+          candidates: [{ content: { parts: [{ text: PROPOSE_GEMINI_TEXT }] } }],
+          usageMetadata: { promptTokenCount: 10, candidatesTokenCount: 10 },
+        }),
+      };
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const { POST } = await import("../partner/route");
+    const res = await POST(makeRequest(VALID_BODY));
+
+    expect(res.status).toBe(200);
+    // Degrade first: propose output budget halved 2048 -> 1024 before any refusal.
+    const [, init] = fetchSpy.mock.calls[0]!;
+    const sent = JSON.parse(init.body) as {
+      generationConfig: { maxOutputTokens: number };
+    };
+    expect(sent.generationConfig.maxOutputTokens).toBe(1024);
+    // A degraded call is still a real paid, billed, booked call.
+    expect(spendAssist).toHaveBeenCalledTimes(1);
+    expect(recordAiSpend).toHaveBeenCalledTimes(1);
+  });
+
+  it("hard cap: DENIES with 503 + spendCapped, spends no assist, calls no model", async () => {
+    checkAiSpend.mockResolvedValue({
+      decision: "denied",
+      reason: "spend_cap",
+    });
+    const fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const { POST } = await import("../partner/route");
+    const res = await POST(makeRequest(VALID_BODY));
+    const json = await res.json();
+
+    expect(res.status).toBe(503);
+    expect(json).toMatchObject({ spendCapped: true, reason: "spend_cap" });
+    // No assist burned, no model call, no spend recorded — the gate is before spend.
+    expect(spendAssist).not.toHaveBeenCalled();
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(recordAiSpend).not.toHaveBeenCalled();
+  });
+
+  it("ledger unreachable: FAILS CLOSED with 503, never serving unmetered", async () => {
+    // checkAiSpend returns "denied" on any ledger error (fail-closed contract).
+    checkAiSpend.mockResolvedValue({
+      decision: "denied",
+      reason: "ledger_unavailable",
+    });
+    const fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const { POST } = await import("../partner/route");
+    const res = await POST(makeRequest(VALID_BODY));
+    const json = await res.json();
+
+    expect(res.status).toBe(503);
+    expect(json).toMatchObject({
+      spendCapped: true,
+      reason: "ledger_unavailable",
+    });
+    expect(spendAssist).not.toHaveBeenCalled();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not leak the solution in a hard-cap 503 body", async () => {
+    checkAiSpend.mockResolvedValue({
+      decision: "denied",
+      reason: "spend_cap",
+    });
+    vi.stubGlobal("fetch", vi.fn());
+
+    const { POST } = await import("../partner/route");
+    const res = await POST(makeRequest(VALID_BODY));
+    const json = await res.json();
+
+    expect(JSON.stringify(json)).not.toContain("the answer");
   });
 });

--- a/apps/web/src/app/api/ai/partner/route.ts
+++ b/apps/web/src/app/api/ai/partner/route.ts
@@ -9,6 +9,11 @@ import {
   recordBilledAssist,
   appendAssistLog,
 } from "@/lib/ai/assist-budget";
+import {
+  checkAiSpend,
+  recordAiSpend,
+  degradedMaxTokens,
+} from "@/lib/ai/spend-ledger";
 import { sealCheck } from "@/lib/ai/check-seal";
 import {
   buildStaticPrefix,
@@ -284,8 +289,9 @@ export async function POST(request: NextRequest) {
   // 600/min clears that with headroom while still bounding a Sybil actor's burn
   // rate from a single address. The cost CEILING is the fail-closed assist
   // budget below (+ #591's spend ledger), not this throttle.
+  const clientIp = getClientIp(request.headers);
   if (
-    await isRateLimited("ai:partner:ip", getClientIp(request.headers), {
+    await isRateLimited("ai:partner:ip", clientIp, {
       maxTokens: 600,
       refillIntervalMs: 60_000,
       failClosed: true,
@@ -309,6 +315,30 @@ export async function POST(request: NextRequest) {
   if (!lesson || !codeBlock) {
     return NextResponse.json({ error: "Lesson not found" }, { status: 404 });
   }
+
+  // Daily SPEND gate (#591) — the cost ceiling on the Superteam-sponsored key,
+  // separate from the per-lesson assist quota below. Reads today's accumulated
+  // micro-USD for this account, this IP, and the global envelope and picks a
+  // tier. FAIL CLOSED: a ledger error denies (503), never serves unmetered. This
+  // runs BEFORE spendAssist so a hard-cap / ledger-outage denial does not burn
+  // one of the learner's paid assists.
+  const spendGate = await checkAiSpend(user.id, clientIp);
+  if (spendGate.decision === "denied") {
+    // Both the hard-cap and the fail-closed ledger-outage return 503 with a
+    // `spendCapped` flag the client localizes; `reason` distinguishes them for
+    // logs/tests without changing the learner-facing copy.
+    return NextResponse.json(
+      {
+        error: "AI tutor daily limit reached",
+        spendCapped: true,
+        reason: spendGate.reason,
+      },
+      { status: 503 }
+    );
+  }
+  // Over a soft cap → degrade: serve with a shorter output budget (the dominant
+  // cost lever) rather than refusing. "Degrade first, then stop" (owner).
+  const degraded = spendGate.decision === "degraded";
 
   // Every request that reaches this route is a PAID action — free authored
   // hints are served client-side from the block's `hints` ladder and never
@@ -391,7 +421,11 @@ export async function POST(request: NextRequest) {
         ],
         generationConfig: {
           temperature: 0.3,
-          maxOutputTokens: maxTokensFor(action),
+          // Degrade-first (#591): past a soft spend cap, halve the output budget
+          // (floored to stay usable) to cut the dominant cost before any refusal.
+          maxOutputTokens: degraded
+            ? degradedMaxTokens(maxTokensFor(action))
+            : maxTokensFor(action),
           // gemini-3.5-flash is a thinking model and thinking tokens share the
           // maxOutputTokens budget; disable it so the full budget goes to the
           // structured response (and to cut latency/cost).
@@ -431,6 +465,14 @@ export async function POST(request: NextRequest) {
     await recordBilledAssist(user.id, lesson._id);
 
     const data = await response.json();
+    // Record the ACTUAL cost of this billed generation into the spend ledger
+    // (#591) from usageMetadata — prompt + candidate + thinking tokens, thinking
+    // billed at the output rate. Runs on EVERY billed path (including the
+    // empty / non-JSON / truncated branches below, which all still cost tokens),
+    // so it sits right after the parse. Best-effort and awaited for the same
+    // Vercel-freeze reason as recordBilledAssist: the cost audit must settle
+    // before the response returns. Never throws.
+    await recordAiSpend(user.id, clientIp, data?.usageMetadata);
     // Prompt-cache observability — useful for tuning the cache-shaped prefix, but
     // this is the SUCCESS path of every paid call, so keep it opt-in (default
     // off) rather than logging on every request in production. Set

--- a/apps/web/src/components/editor/ai-partner/__tests__/ai-partner-pane.test.tsx
+++ b/apps/web/src/components/editor/ai-partner/__tests__/ai-partner-pane.test.tsx
@@ -18,6 +18,7 @@ const hookState = {
   paidUsed: 0,
   paidRemaining: 4,
   budgetExhausted: false,
+  spendCapped: false,
   loading: false,
   error: null as string | null,
   requestHint: vi.fn(),
@@ -54,7 +55,22 @@ const reviewLabel = messages.aiPartner.actions.review;
 beforeEach(() => {
   review.mockReset();
   hookState.budgetExhausted = false;
+  hookState.spendCapped = false;
   hookState.loading = false;
+  hookState.error = null;
+});
+
+describe("AiPartnerPane — daily spend cap (#591)", () => {
+  it("shows the localized spend-cap copy, not the generic error, when spendCapped", () => {
+    hookState.spendCapped = true;
+    renderPane();
+    expect(
+      screen.getByText(messages.aiPartner.messages.spendCapped)
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(messages.aiPartner.messages.error)
+    ).not.toBeInTheDocument();
+  });
 });
 
 describe("AiPartnerPane — post-pass review button (LX-C9)", () => {

--- a/apps/web/src/components/editor/ai-partner/ai-partner-pane.tsx
+++ b/apps/web/src/components/editor/ai-partner/ai-partner-pane.tsx
@@ -45,6 +45,7 @@ export function AiPartnerPane({
     freeHintsUsed,
     paidUsed,
     budgetExhausted,
+    spendCapped,
     loading,
     error,
     requestHint,
@@ -109,7 +110,13 @@ export function AiPartnerPane({
         />
       )}
 
-      {error && (
+      {spendCapped && (
+        <div className="shrink-0 border-t border-border px-4 py-2">
+          <p className="text-xs text-text-3">{t("messages.spendCapped")}</p>
+        </div>
+      )}
+
+      {error && !spendCapped && (
         <div className="shrink-0 border-t border-border px-4 py-2">
           <p className="text-xs text-danger">{t("messages.error")}</p>
         </div>

--- a/apps/web/src/lib/ai/__tests__/spend-ledger.test.ts
+++ b/apps/web/src/lib/ai/__tests__/spend-ledger.test.ts
@@ -1,0 +1,232 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+// One rpc mock backs a single fake admin client for every test.
+const rpc = vi.fn();
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: () => ({ rpc }),
+}));
+
+import {
+  estimateSpendMicroUsd,
+  degradedMaxTokens,
+  checkAiSpend,
+  recordAiSpend,
+  getAiSpendToday,
+} from "../spend-ledger";
+
+// The wrapper reads caps/rates from serverEnv, which in tests takes the
+// env.server defaults (O-1 numbers): account soft/hard $0.50/$1.50, IP $2/$5,
+// global $14/$25; rates $0.30 input, $2.50 output per Mtok. Micro-USD = USD×1e6.
+const RATES = { inputUsdPerMTok: 0.3, outputUsdPerMTok: 2.5 };
+
+beforeEach(() => {
+  rpc.mockReset();
+});
+
+describe("estimateSpendMicroUsd", () => {
+  it("sums input + output at their rates (micro-USD = tokens × usdPerMtok)", () => {
+    // 1000 input × 0.30 = 300; 500 output × 2.50 = 1250; total 1550 micro = $0.00155.
+    expect(
+      estimateSpendMicroUsd(
+        { promptTokenCount: 1000, candidatesTokenCount: 500 },
+        RATES
+      )
+    ).toBe(1550);
+  });
+
+  it("bills thinking tokens at the OUTPUT rate (#591)", () => {
+    // thinking 100 joins the 500 output → 600 × 2.50 = 1500; + 1000×0.30=300 → 1800.
+    expect(
+      estimateSpendMicroUsd(
+        {
+          promptTokenCount: 1000,
+          candidatesTokenCount: 500,
+          thoughtsTokenCount: 100,
+        },
+        RATES
+      )
+    ).toBe(1800);
+  });
+
+  it("is zero for missing usage metadata (records the request, no cost)", () => {
+    expect(estimateSpendMicroUsd(undefined, RATES)).toBe(0);
+    expect(estimateSpendMicroUsd({}, RATES)).toBe(0);
+  });
+
+  it("treats negative / NaN token counts as zero (never credits)", () => {
+    expect(
+      estimateSpendMicroUsd(
+        { promptTokenCount: -5, candidatesTokenCount: Number.NaN },
+        RATES
+      )
+    ).toBe(0);
+  });
+});
+
+describe("degradedMaxTokens", () => {
+  it("halves the budget, floored at 256 so the reply stays usable", () => {
+    expect(degradedMaxTokens(2048)).toBe(1024);
+    expect(degradedMaxTokens(1536)).toBe(768);
+    expect(degradedMaxTokens(300)).toBe(256); // floor wins
+  });
+});
+
+function mockCheck(row: unknown, error: unknown = null) {
+  rpc.mockResolvedValue({ data: [row], error });
+}
+
+describe("checkAiSpend", () => {
+  it("returns full when every dimension is under its soft cap", async () => {
+    mockCheck({
+      account_micro_usd: 0,
+      ip_micro_usd: 0,
+      global_micro_usd: 0,
+    });
+    expect(await checkAiSpend("u", "1.2.3.4")).toEqual({ decision: "full" });
+  });
+
+  it("degrades when a dimension crosses its soft cap (account $0.50)", async () => {
+    mockCheck({
+      account_micro_usd: 600_000, // $0.60 > $0.50 soft, < $1.50 hard
+      ip_micro_usd: 0,
+      global_micro_usd: 0,
+    });
+    expect(await checkAiSpend("u", "1.2.3.4")).toEqual({
+      decision: "degraded",
+    });
+  });
+
+  it("denies (spend_cap) when the account hard cap is reached ($1.50)", async () => {
+    mockCheck({
+      account_micro_usd: 1_500_000,
+      ip_micro_usd: 0,
+      global_micro_usd: 0,
+    });
+    expect(await checkAiSpend("u", "1.2.3.4")).toEqual({
+      decision: "denied",
+      reason: "spend_cap",
+    });
+  });
+
+  it("denies (spend_cap) when the IP hard cap is reached ($5)", async () => {
+    mockCheck({
+      account_micro_usd: 0,
+      ip_micro_usd: 5_000_000,
+      global_micro_usd: 0,
+    });
+    expect(await checkAiSpend("u", "1.2.3.4")).toEqual({
+      decision: "denied",
+      reason: "spend_cap",
+    });
+  });
+
+  it("denies (spend_cap) when the GLOBAL hard cap is reached ($25)", async () => {
+    mockCheck({
+      account_micro_usd: 0,
+      ip_micro_usd: 0,
+      global_micro_usd: 25_000_000,
+    });
+    expect(await checkAiSpend("u", "1.2.3.4")).toEqual({
+      decision: "denied",
+      reason: "spend_cap",
+    });
+  });
+
+  it("coerces BIGINT-as-string totals from PostgREST before comparing", async () => {
+    mockCheck({
+      account_micro_usd: "600000", // string, still > soft
+      ip_micro_usd: "0",
+      global_micro_usd: "0",
+    });
+    expect(await checkAiSpend("u", "1.2.3.4")).toEqual({
+      decision: "degraded",
+    });
+  });
+
+  it("FAILS CLOSED (denied/ledger_unavailable) on an RPC error", async () => {
+    mockCheck(null, { message: "connection refused" });
+    expect(await checkAiSpend("u", "1.2.3.4")).toEqual({
+      decision: "denied",
+      reason: "ledger_unavailable",
+    });
+  });
+
+  it("FAILS CLOSED on a missing row", async () => {
+    rpc.mockResolvedValue({ data: [], error: null });
+    expect(await checkAiSpend("u", "1.2.3.4")).toEqual({
+      decision: "denied",
+      reason: "ledger_unavailable",
+    });
+  });
+
+  it("FAILS CLOSED on non-numeric totals", async () => {
+    mockCheck({
+      account_micro_usd: "not-a-number",
+      ip_micro_usd: 0,
+      global_micro_usd: 0,
+    });
+    expect(await checkAiSpend("u", "1.2.3.4")).toEqual({
+      decision: "denied",
+      reason: "ledger_unavailable",
+    });
+  });
+
+  it("FAILS CLOSED when the rpc call itself throws", async () => {
+    rpc.mockRejectedValue(new Error("boom"));
+    expect(await checkAiSpend("u", "1.2.3.4")).toEqual({
+      decision: "denied",
+      reason: "ledger_unavailable",
+    });
+  });
+});
+
+describe("recordAiSpend", () => {
+  it("books the computed micro-USD via record_ai_spend", async () => {
+    rpc.mockResolvedValue({ data: null, error: null });
+
+    await recordAiSpend("u", "1.2.3.4", {
+      promptTokenCount: 1000,
+      candidatesTokenCount: 500,
+    });
+
+    expect(rpc).toHaveBeenCalledWith("record_ai_spend", {
+      p_user_id: "u",
+      p_ip: "1.2.3.4",
+      p_micro_usd: 1550,
+    });
+  });
+
+  it("never throws when the record RPC errors (best-effort audit)", async () => {
+    rpc.mockResolvedValue({ data: null, error: { message: "down" } });
+    await expect(
+      recordAiSpend("u", "1.2.3.4", { promptTokenCount: 10 })
+    ).resolves.toBeUndefined();
+  });
+
+  it("never throws when the record RPC rejects", async () => {
+    rpc.mockRejectedValue(new Error("network"));
+    await expect(
+      recordAiSpend("u", "1.2.3.4", { promptTokenCount: 10 })
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe("getAiSpendToday", () => {
+  it("returns today's global burn + request count", async () => {
+    rpc.mockResolvedValue({
+      data: [{ micro_usd: 4_200_000, request_count: 137 }],
+      error: null,
+    });
+    expect(await getAiSpendToday()).toEqual({
+      microUsd: 4_200_000,
+      requestCount: 137,
+    });
+  });
+
+  it("fails soft to zeros on a read error", async () => {
+    rpc.mockResolvedValue({ data: null, error: { message: "down" } });
+    expect(await getAiSpendToday()).toEqual({ microUsd: 0, requestCount: 0 });
+  });
+});

--- a/apps/web/src/lib/ai/__tests__/use-ai-partner.test.tsx
+++ b/apps/web/src/lib/ai/__tests__/use-ai-partner.test.tsx
@@ -294,6 +294,41 @@ describe("useAiPartner", () => {
     expect(result.current.loading).toBe(false);
   });
 
+  it("flips spendCapped (not error) on a 503 with spendCapped, without paying", async () => {
+    vi.mocked(global.fetch).mockResolvedValue({
+      ok: false,
+      status: 503,
+      json: async () => ({ spendCapped: true, reason: "spend_cap" }),
+    } as Response);
+
+    const { result } = await renderPartner(baseProps({ hints: [] }));
+
+    await act(async () => {
+      await result.current.requestHint();
+    });
+
+    expect(result.current.spendCapped).toBe(true);
+    expect(result.current.error).toBeNull();
+    expect(result.current.paidUsed).toBe(0);
+  });
+
+  it("shows the generic error (not spendCapped) on a 503 that is not a spend cap", async () => {
+    vi.mocked(global.fetch).mockResolvedValue({
+      ok: false,
+      status: 503,
+      json: async () => ({ error: "AI partner not configured" }),
+    } as Response);
+
+    const { result } = await renderPartner(baseProps({ hints: [] }));
+
+    await act(async () => {
+      await result.current.requestHint();
+    });
+
+    expect(result.current.spendCapped).toBe(false);
+    expect(result.current.error).toBeTruthy();
+  });
+
   it("requestHint() pays immediately when hints ladder is shorter than 2", async () => {
     const response: PartnerResponse = { type: "hint", text: "paid hint" };
     vi.mocked(global.fetch).mockResolvedValue(jsonResponse(response));

--- a/apps/web/src/lib/ai/spend-ledger.ts
+++ b/apps/web/src/lib/ai/spend-ledger.ts
@@ -1,0 +1,217 @@
+import "server-only";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { serverEnv } from "@/lib/env.server";
+
+// AI tutor spend ledger (#591). The AI Partner spends a Superteam-sponsored
+// Gemini key; `challenge_assists` counts turns, not cost. This module gates and
+// records the ACTUAL micro-USD spend against per-account, per-IP, and global
+// daily ceilings (America/Sao_Paulo days), enforced by the ai_spend_ledger
+// RPCs. It fails CLOSED: any check error denies (503), never waves traffic
+// through unmetered on the platform-funded key — the assist-budget contract
+// (#590), the opposite of check_rate_limit's fail-open.
+
+const MICRO_PER_USD = 1_000_000;
+
+/**
+ * The route's spend decision for a single request, chosen BEFORE the model call
+ * from today's accumulated spend:
+ *   - "full"     — under every soft cap; serve at the normal output budget.
+ *   - "degraded" — at/over a soft cap; serve with a shorter output budget.
+ *   - "denied"   — at/over a hard cap, OR the ledger was unreachable (fail
+ *                  closed). The route 503s; no assist is spent.
+ */
+export type SpendDecision = "full" | "degraded" | "denied";
+
+export type SpendDenyReason = "spend_cap" | "ledger_unavailable";
+
+export interface SpendGate {
+  decision: SpendDecision;
+  reason?: SpendDenyReason;
+}
+
+interface SpendCapsMicroUsd {
+  accountSoft: number;
+  accountHard: number;
+  ipSoft: number;
+  ipHard: number;
+  globalSoft: number;
+  globalHard: number;
+}
+
+interface SpendRates {
+  inputUsdPerMTok: number;
+  outputUsdPerMTok: number;
+}
+
+// The Gemini token accounting we bill against. Thinking tokens
+// (`thoughtsTokenCount`) bill at the OUTPUT rate (#591), so they are summed with
+// candidate tokens. All fields are optional — a response missing usageMetadata
+// records a zero-cost request (still counted) rather than throwing.
+export interface GeminiUsageMetadata {
+  promptTokenCount?: number;
+  candidatesTokenCount?: number;
+  thoughtsTokenCount?: number;
+}
+
+function capsMicroUsd(): SpendCapsMicroUsd {
+  return {
+    accountSoft: Math.round(
+      serverEnv.AI_SPEND_ACCOUNT_SOFT_USD * MICRO_PER_USD
+    ),
+    accountHard: Math.round(
+      serverEnv.AI_SPEND_ACCOUNT_HARD_USD * MICRO_PER_USD
+    ),
+    ipSoft: Math.round(serverEnv.AI_SPEND_IP_SOFT_USD * MICRO_PER_USD),
+    ipHard: Math.round(serverEnv.AI_SPEND_IP_HARD_USD * MICRO_PER_USD),
+    globalSoft: Math.round(serverEnv.AI_SPEND_GLOBAL_SOFT_USD * MICRO_PER_USD),
+    globalHard: Math.round(serverEnv.AI_SPEND_GLOBAL_HARD_USD * MICRO_PER_USD),
+  };
+}
+
+function rates(): SpendRates {
+  return {
+    inputUsdPerMTok: serverEnv.AI_SPEND_INPUT_USD_PER_MTOK,
+    outputUsdPerMTok: serverEnv.AI_SPEND_OUTPUT_USD_PER_MTOK,
+  };
+}
+
+function nonNegInt(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? value
+    : 0;
+}
+
+/**
+ * Micro-USD cost of one billed generation from its usageMetadata. Pure and
+ * env-free (rates are injected) so it is unit-testable. Since cost_usd =
+ * tokens/1e6 × usdPerMTok, micro_usd (= cost_usd × 1e6) = tokens × usdPerMTok.
+ * Thinking tokens are billed at the output rate.
+ */
+export function estimateSpendMicroUsd(
+  usage: GeminiUsageMetadata | undefined,
+  r: SpendRates
+): number {
+  if (!usage) return 0;
+  const prompt = nonNegInt(usage.promptTokenCount);
+  const output = nonNegInt(usage.candidatesTokenCount);
+  const thinking = nonNegInt(usage.thoughtsTokenCount);
+  const inputMicro = prompt * r.inputUsdPerMTok;
+  const outputMicro = (output + thinking) * r.outputUsdPerMTok;
+  return Math.max(0, Math.round(inputMicro + outputMicro));
+}
+
+/**
+ * The degraded output-token budget: half the normal budget, floored so the
+ * reply stays usable. Degrade is a SHORTER OUTPUT (the dominant cost lever), not
+ * a model swap — gemini's cheaper flash-lite tier is gated for new keys (the
+ * route documents the 404), so shrinking the output budget is the real,
+ * always-available degrade.
+ */
+export function degradedMaxTokens(base: number): number {
+  return Math.max(256, Math.floor(base / 2));
+}
+
+/**
+ * Read today's accumulated spend across all three dimensions and pick a tier.
+ * FAIL CLOSED: an RPC error, a missing row, or a non-numeric total all deny with
+ * `ledger_unavailable` — the ledger going dark must never wave unmetered traffic
+ * through onto the sponsor's card.
+ */
+export async function checkAiSpend(
+  userId: string,
+  ip: string
+): Promise<SpendGate> {
+  const caps = capsMicroUsd();
+  try {
+    const { data, error } = await createAdminClient().rpc("check_ai_spend", {
+      p_user_id: userId,
+      p_ip: ip,
+    });
+    const row = Array.isArray(data) ? data[0] : data;
+    if (error || !row) {
+      console.warn(
+        "[spend-ledger] check failed, denying:",
+        error?.message ?? JSON.stringify(data)
+      );
+      return { decision: "denied", reason: "ledger_unavailable" };
+    }
+    // BIGINT can arrive as a string from PostgREST; coerce and re-validate.
+    const account = Number(row.account_micro_usd);
+    const perIp = Number(row.ip_micro_usd);
+    const global = Number(row.global_micro_usd);
+    if (![account, perIp, global].every(Number.isFinite)) {
+      console.warn("[spend-ledger] non-numeric totals, denying:", row);
+      return { decision: "denied", reason: "ledger_unavailable" };
+    }
+
+    if (
+      account >= caps.accountHard ||
+      perIp >= caps.ipHard ||
+      global >= caps.globalHard
+    ) {
+      return { decision: "denied", reason: "spend_cap" };
+    }
+    if (
+      account >= caps.accountSoft ||
+      perIp >= caps.ipSoft ||
+      global >= caps.globalSoft
+    ) {
+      return { decision: "degraded" };
+    }
+    return { decision: "full" };
+  } catch (err) {
+    console.warn("[spend-ledger] check threw, denying:", err);
+    return { decision: "denied", reason: "ledger_unavailable" };
+  }
+}
+
+/**
+ * Record the actual micro-USD cost of a billed generation into all three daily
+ * buckets. Best-effort: called only after Gemini has billed us, on the paid
+ * path, and must never break the reply the learner is owed, so it never throws.
+ * A recording failure loses one data point of audit, not correctness — the CAP
+ * is enforced by `checkAiSpend`, which fails closed on its own.
+ */
+export async function recordAiSpend(
+  userId: string,
+  ip: string,
+  usage: GeminiUsageMetadata | undefined
+): Promise<void> {
+  const microUsd = estimateSpendMicroUsd(usage, rates());
+  try {
+    const { error } = await createAdminClient().rpc("record_ai_spend", {
+      p_user_id: userId,
+      p_ip: ip,
+      p_micro_usd: microUsd,
+    });
+    if (error) {
+      console.warn("[spend-ledger] record failed:", error.message);
+    }
+  } catch (err) {
+    console.warn("[spend-ledger] record threw:", err);
+  }
+}
+
+/**
+ * Admin observability: today's global spend (micro-USD) and request count, so
+ * the sponsor's burn is visible before the invoice. Fails soft to zeros so a
+ * read error shows an empty-but-present figure, never a crash.
+ */
+export async function getAiSpendToday(): Promise<{
+  microUsd: number;
+  requestCount: number;
+}> {
+  try {
+    const { data, error } = await createAdminClient().rpc("get_ai_spend_today");
+    const row = Array.isArray(data) ? data[0] : data;
+    if (error || !row) return { microUsd: 0, requestCount: 0 };
+    const microUsd = Number(row.micro_usd);
+    const requestCount = Number(row.request_count);
+    return {
+      microUsd: Number.isFinite(microUsd) ? microUsd : 0,
+      requestCount: Number.isFinite(requestCount) ? requestCount : 0,
+    };
+  } catch {
+    return { microUsd: 0, requestCount: 0 };
+  }
+}

--- a/apps/web/src/lib/ai/use-ai-partner.ts
+++ b/apps/web/src/lib/ai/use-ai-partner.ts
@@ -38,6 +38,10 @@ interface UseAiPartnerResult {
   paidUsed: number;
   paidRemaining: number;
   budgetExhausted: boolean;
+  // The platform-wide daily spend cap was hit (#591) — distinct from
+  // budgetExhausted (this learner's per-lesson assist quota). The route 503s
+  // with `spendCapped: true`; the pane shows dedicated localized copy.
+  spendCapped: boolean;
   loading: boolean;
   error: string | null;
   requestHint: () => Promise<void>;
@@ -71,6 +75,7 @@ export function useAiPartner({
   const [freeHintsUsed, setFreeHintsUsed] = useState(0);
   const [paidUsed, setPaidUsed] = useState(0);
   const [budgetExhausted, setBudgetExhausted] = useState(false);
+  const [spendCapped, setSpendCapped] = useState(false);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -119,6 +124,7 @@ export function useAiPartner({
     async (action: PartnerAction, message?: string) => {
       setLoading(true);
       setError(null);
+      setSpendCapped(false);
       try {
         const res = await fetch(PARTNER_ROUTE, {
           method: "POST",
@@ -134,6 +140,25 @@ export function useAiPartner({
         });
 
         if (!res.ok) {
+          // The daily spend cap (#591) returns 503 with `spendCapped: true`.
+          // Surface it as its own state so the pane shows dedicated localized
+          // copy ("tutor at capacity today") rather than the generic error.
+          if (res.status === 503) {
+            try {
+              const body: unknown = await res.json();
+              if (
+                typeof body === "object" &&
+                body !== null &&
+                "spendCapped" in body &&
+                (body as { spendCapped?: unknown }).spendCapped === true
+              ) {
+                setSpendCapped(true);
+                return;
+              }
+            } catch {
+              // Non-JSON 503 → fall through to the generic error below.
+            }
+          }
           setError(`Request failed (${res.status})`);
           return;
         }
@@ -219,6 +244,7 @@ export function useAiPartner({
     paidUsed,
     paidRemaining: Math.max(0, MAX_PAID_ASSISTS - paidUsed),
     budgetExhausted,
+    spendCapped,
     loading,
     error,
     requestHint,

--- a/apps/web/src/lib/env.server.ts
+++ b/apps/web/src/lib/env.server.ts
@@ -14,6 +14,16 @@ const optUrl = z.preprocess(
   z.url().optional()
 );
 
+// A non-negative USD amount from an env var, with a default. Treats "" (blank
+// Vercel placeholder) and unset as the default, and coerces the string value to
+// a number. Rejects a set-to-garbage or negative value so a fat-fingered cap
+// fails loudly at boot rather than silently disabling the ledger.
+const usdNum = (fallback: number) =>
+  z.preprocess(
+    (v) => (v === "" || v === undefined ? fallback : v),
+    z.coerce.number().min(0)
+  );
+
 /**
  * Server-only secrets. Never imported into client code (`server-only` enforces
  * this). Validated eagerly at boot via `instrumentation.ts`.
@@ -70,6 +80,25 @@ const serverEnvSchema = z.object({
   // attestation tokens (lib/ai/check-seal.ts). Falls back to
   // SUPABASE_SERVICE_ROLE_KEY when unset.
   AI_PARTNER_SEAL_SECRET: optStr,
+
+  // AI tutor spend caps (#591). Daily ceilings in whole US dollars, per
+  // America/Sao_Paulo day, enforced by the ai_spend_ledger (lib/ai/spend-ledger).
+  // Derived DOWNWARD from the $500/mo sponsor commitment (O-1): a $16.67/day
+  // envelope. Config, not constants — bump these when the commitment moves; the
+  // ledger binds on the envelope, not on any cost estimate. Over a *soft* cap the
+  // route DEGRADES (shorter output budget); only a *hard* cap denies (503).
+  // usdNum: whole/decimal dollars, "" → default. Must be non-negative.
+  AI_SPEND_GLOBAL_SOFT_USD: usdNum(14), // ~84% of the daily envelope
+  AI_SPEND_GLOBAL_HARD_USD: usdNum(25), // 1.5× envelope; absorbs a spike day
+  AI_SPEND_ACCOUNT_SOFT_USD: usdNum(0.5), // ~17× the $0.03/learner/mo average
+  AI_SPEND_ACCOUNT_HARD_USD: usdNum(1.5), // a single account ≤ ~9% of the envelope
+  AI_SPEND_IP_SOFT_USD: usdNum(2), // survives a NAT'd classroom
+  AI_SPEND_IP_HARD_USD: usdNum(5), // caps a single-IP farm at ~30% of the envelope
+  // Gemini price sheet (USD per 1M tokens) used to turn usageMetadata token
+  // counts into micro-USD. Thinking tokens bill at the OUTPUT rate (#591). These
+  // move with the provider's pricing, not the sponsor commitment.
+  AI_SPEND_INPUT_USD_PER_MTOK: usdNum(0.3),
+  AI_SPEND_OUTPUT_USD_PER_MTOK: usdNum(2.5),
 });
 
 const parsed = serverEnvSchema.safeParse({
@@ -88,6 +117,14 @@ const parsed = serverEnvSchema.safeParse({
   ARWEAVE_UPLOADER_SECRET: process.env.ARWEAVE_UPLOADER_SECRET,
   HELIUS_API_KEY: process.env.HELIUS_API_KEY,
   AI_PARTNER_SEAL_SECRET: process.env.AI_PARTNER_SEAL_SECRET,
+  AI_SPEND_GLOBAL_SOFT_USD: process.env.AI_SPEND_GLOBAL_SOFT_USD,
+  AI_SPEND_GLOBAL_HARD_USD: process.env.AI_SPEND_GLOBAL_HARD_USD,
+  AI_SPEND_ACCOUNT_SOFT_USD: process.env.AI_SPEND_ACCOUNT_SOFT_USD,
+  AI_SPEND_ACCOUNT_HARD_USD: process.env.AI_SPEND_ACCOUNT_HARD_USD,
+  AI_SPEND_IP_SOFT_USD: process.env.AI_SPEND_IP_SOFT_USD,
+  AI_SPEND_IP_HARD_USD: process.env.AI_SPEND_IP_HARD_USD,
+  AI_SPEND_INPUT_USD_PER_MTOK: process.env.AI_SPEND_INPUT_USD_PER_MTOK,
+  AI_SPEND_OUTPUT_USD_PER_MTOK: process.env.AI_SPEND_OUTPUT_USD_PER_MTOK,
 });
 
 if (!parsed.success) {

--- a/apps/web/src/lib/supabase/__tests__/ai-spend-ledger-guard.test.ts
+++ b/apps/web/src/lib/supabase/__tests__/ai-spend-ledger-guard.test.ts
@@ -1,0 +1,119 @@
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, it, expect } from "vitest";
+
+// #591 (AI tutor spend caps): the ai_spend_ledger substrate. RLS cannot be
+// exercised in unit tests, so — as with the #569 review-spine guard — pin the
+// security-critical SQL invariants in BOTH the migration and the schema.sql
+// mirror:
+//   * ai_spend_ledger has RLS on and NO policies (reached only via the
+//     SECURITY DEFINER RPCs called by service_role) — the challenge_assists /
+//     award_xp pattern, the money surface's fail-closed lock.
+//   * all three RPCs are SECURITY DEFINER, search_path-pinned, REVOKEd from
+//     clients, GRANTed only to service_role.
+//   * daily windows are America/Sao_Paulo (AIE-21), and money is integer
+//     micro-USD (BIGINT), never float dollars.
+
+function findRepoRoot(): string {
+  let dir = dirname(fileURLToPath(import.meta.url));
+  while (!existsSync(resolve(dir, "supabase/schema.sql"))) {
+    const parent = dirname(dir);
+    if (parent === dir)
+      throw new Error("repo root (supabase/schema.sql) not found");
+    dir = parent;
+  }
+  return dir;
+}
+
+const repoRoot = findRepoRoot();
+const migration = readFileSync(
+  resolve(repoRoot, "supabase/migrations/20260726180000_ai_spend_ledger.sql"),
+  "utf8"
+);
+const schema = readFileSync(resolve(repoRoot, "supabase/schema.sql"), "utf8");
+
+const RPCS: ReadonlyArray<[string, string]> = [
+  ["record_ai_spend", "(UUID, TEXT, BIGINT)"],
+  ["check_ai_spend", "(UUID, TEXT)"],
+  ["get_ai_spend_today", "()"],
+];
+
+// The invariants must hold in the migration (what gets applied) AND in
+// schema.sql (the snapshot fresh environments are built from) — a drift between
+// them is the exact class of bug the #449 IDL memory warns about.
+for (const [label, sql] of [
+  ["migration", migration] as const,
+  ["schema.sql", schema] as const,
+]) {
+  describe(`#591 ai_spend_ledger — ${label}`, () => {
+    it("creates the ledger table with an integer micro-USD money column", () => {
+      expect(sql).toContain("CREATE TABLE IF NOT EXISTS ai_spend_ledger");
+      expect(sql).toContain("micro_usd     BIGINT NOT NULL DEFAULT 0");
+    });
+
+    it("constrains scope to the three known dimensions", () => {
+      expect(sql).toContain("CHECK (scope IN ('account', 'ip', 'global'))");
+    });
+
+    it("enables RLS and defines NO policy (RPC-only write/read path)", () => {
+      expect(sql).toContain(
+        "ALTER TABLE ai_spend_ledger ENABLE ROW LEVEL SECURITY"
+      );
+      // Any policy on this table would open a path around the SECURITY DEFINER
+      // RPCs — the money surface must be reachable only by service_role.
+      expect(sql).not.toMatch(
+        /ON ai_spend_ledger FOR (SELECT|INSERT|UPDATE|DELETE|ALL)/
+      );
+    });
+
+    it("hardens every RPC (SECURITY DEFINER, pinned path, service_role only)", () => {
+      for (const [fn, args] of RPCS) {
+        const start = sql.indexOf(`CREATE OR REPLACE FUNCTION ${fn}(`);
+        expect(start, `${fn} defined`).toBeGreaterThan(-1);
+        const body = sql.slice(
+          start,
+          sql.indexOf("GRANT EXECUTE", start) + 200
+        );
+        expect(body).toContain("SECURITY DEFINER");
+        expect(body).toContain("SET search_path = ''");
+        expect(body).toContain(
+          `REVOKE ALL ON FUNCTION ${fn}${args} FROM PUBLIC, anon, authenticated`
+        );
+        expect(body).toContain(
+          `GRANT EXECUTE ON FUNCTION ${fn}${args} TO service_role`
+        );
+      }
+    });
+
+    it("windows all daily reads/writes on America/Sao_Paulo days (AIE-21)", () => {
+      // No UTC/naive date bucket — every day boundary is the SP calendar day.
+      expect(sql).toContain("(now() AT TIME ZONE 'America/Sao_Paulo')::date");
+      expect(sql).not.toMatch(/spend_day\s*=\s*(CURRENT_DATE|now\(\)::date)/);
+    });
+
+    it("clamps recorded spend to non-negative (never credits)", () => {
+      expect(sql).toContain("GREATEST(COALESCE(p_micro_usd, 0), 0)");
+    });
+  });
+}
+
+describe("#591 ai_spend_ledger — migration-only guarantees", () => {
+  it("runs in one explicit transaction", () => {
+    expect(migration).toContain("BEGIN;");
+    expect(migration).toContain("COMMIT;");
+  });
+
+  it("ships a rollback that drops exactly what it created", () => {
+    expect(migration).toContain(
+      "DROP FUNCTION IF EXISTS public.get_ai_spend_today();"
+    );
+    expect(migration).toContain(
+      "DROP FUNCTION IF EXISTS public.check_ai_spend(UUID, TEXT);"
+    );
+    expect(migration).toContain(
+      "DROP FUNCTION IF EXISTS public.record_ai_spend(UUID, TEXT, BIGINT);"
+    );
+    expect(migration).toContain("DROP TABLE IF EXISTS public.ai_spend_ledger;");
+  });
+});

--- a/apps/web/src/lib/supabase/types.ts
+++ b/apps/web/src/lib/supabase/types.ts
@@ -1130,6 +1130,32 @@ export type Database = {
           due_at: string;
         }[];
       };
+      check_ai_spend: {
+        Args: {
+          p_user_id: string;
+          p_ip: string;
+        };
+        Returns: {
+          account_micro_usd: number;
+          ip_micro_usd: number;
+          global_micro_usd: number;
+        }[];
+      };
+      record_ai_spend: {
+        Args: {
+          p_user_id: string;
+          p_ip: string;
+          p_micro_usd: number;
+        };
+        Returns: undefined;
+      };
+      get_ai_spend_today: {
+        Args: Record<string, never>;
+        Returns: {
+          micro_usd: number;
+          request_count: number;
+        }[];
+      };
       award_xp: {
         Args: {
           p_amount: number;

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -889,7 +889,8 @@
       "you": "You",
       "ai": "AI Partner",
       "loading": "Thinking...",
-      "error": "Something went wrong. Try again."
+      "error": "Something went wrong. Try again.",
+      "spendCapped": "The AI Partner has reached today's usage limit. It'll be back tomorrow — meanwhile, the authored hints and tests are still here to help."
     },
     "actions": {
       "hint": "Hint",

--- a/apps/web/src/messages/es.json
+++ b/apps/web/src/messages/es.json
@@ -889,7 +889,8 @@
       "you": "Tú",
       "ai": "Compañero de IA",
       "loading": "Pensando...",
-      "error": "Algo salió mal. Inténtalo de nuevo."
+      "error": "Algo salió mal. Inténtalo de nuevo.",
+      "spendCapped": "El Compañero de IA alcanzó el límite de uso de hoy. Volverá mañana; mientras tanto, las pistas y las pruebas siguen disponibles para ayudarte."
     },
     "actions": {
       "hint": "Pista",

--- a/apps/web/src/messages/pt-BR.json
+++ b/apps/web/src/messages/pt-BR.json
@@ -889,7 +889,8 @@
       "you": "Você",
       "ai": "Parceiro de IA",
       "loading": "Pensando...",
-      "error": "Algo deu errado. Tente novamente."
+      "error": "Algo deu errado. Tente novamente.",
+      "spendCapped": "O Parceiro de IA atingiu o limite de uso de hoje. Ele volta amanhã; enquanto isso, as dicas e os testes continuam aqui para ajudar."
     },
     "actions": {
       "hint": "Dica",

--- a/supabase/migrations/20260726180000_ai_spend_ledger.sql
+++ b/supabase/migrations/20260726180000_ai_spend_ledger.sql
@@ -1,0 +1,137 @@
+-- Migration: ai_spend_ledger (#591 — AI tutor spend caps)
+-- The AI Partner spends a platform-funded (Superteam-sponsored) Gemini key.
+-- `challenge_assists` counts TURNS per lesson, which is not spend — a turn can be
+-- 200 output tokens or a truncated 8k propose. This ledger records the actual
+-- micro-USD cost of every billed generation and enforces daily ceilings so a
+-- single farmer cannot drain the sponsor's card before the invoice arrives.
+--
+-- Three daily buckets on America/Sao_Paulo days (AIE-21), one table keyed by
+-- (scope, scope_key, spend_day):
+--   * account — per-learner burn (scope_key = profiles.id)
+--   * ip      — per-actor burn; free wallet signup means per-user keys alone
+--               cannot bound a Sybil, so the IP dimension is the actor bound
+--   * global  — the sponsor envelope backstop (scope_key = '')
+--
+-- The route reads the three current totals via check_ai_spend BEFORE calling
+-- Gemini and picks a tier: under soft → full; over soft → DEGRADE (shorter
+-- output budget); over hard → DENY. It records actual usage via record_ai_spend
+-- AFTER the model bills us. Thresholds are config (env), derived downward from
+-- the $500/mo sponsor commitment (O-1) — they are NOT baked into this SQL.
+--
+-- All RPCs follow the challenge_assists / award_xp hardening pattern: SECURITY
+-- DEFINER, search_path-pinned, on an RLS-on table with NO policies, REVOKEd from
+-- PUBLIC/anon/authenticated and GRANTed only to service_role. The TS wrapper
+-- (apps/web/src/lib/ai/spend-ledger.ts) treats any check error as DENY — fail
+-- CLOSED (the assist-budget contract, #590), never fail-open like check_rate_limit.
+--
+-- Additive + idempotent (IF NOT EXISTS / CREATE OR REPLACE). Mirrors the block
+-- appended to supabase/schema.sql. Runs in one explicit transaction.
+
+BEGIN;
+
+-- Micro-USD (USD × 1e6) as BIGINT — integer money, no float drift. A single
+-- day's global envelope is ~$25 = 25,000,000 micro, far inside BIGINT range.
+CREATE TABLE IF NOT EXISTS ai_spend_ledger (
+  scope         TEXT NOT NULL,
+  scope_key     TEXT NOT NULL,
+  spend_day     DATE NOT NULL,
+  micro_usd     BIGINT NOT NULL DEFAULT 0,
+  request_count INTEGER NOT NULL DEFAULT 0,
+  updated_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (scope, scope_key, spend_day),
+  CONSTRAINT ai_spend_ledger_scope_check CHECK (scope IN ('account', 'ip', 'global'))
+);
+
+ALTER TABLE ai_spend_ledger ENABLE ROW LEVEL SECURITY;
+-- No policies: reached only through SECURITY DEFINER RPCs called by service_role.
+
+-- Add p_micro_usd to all three of today's buckets in one upsert. Called AFTER a
+-- confirmed Gemini bill, best-effort from the route (never blocks the paid
+-- reply). Negative input is clamped to 0 so a bad estimate can only under-count,
+-- never credit. The SP-day is computed here so callers never pass a clock.
+CREATE OR REPLACE FUNCTION record_ai_spend(
+  p_user_id   UUID,
+  p_ip        TEXT,
+  p_micro_usd BIGINT
+) RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_day    DATE   := (now() AT TIME ZONE 'America/Sao_Paulo')::date;
+  v_amount BIGINT := GREATEST(COALESCE(p_micro_usd, 0), 0);
+  v_ip     TEXT   := COALESCE(NULLIF(p_ip, ''), 'unknown');
+BEGIN
+  INSERT INTO public.ai_spend_ledger (scope, scope_key, spend_day, micro_usd, request_count, updated_at)
+  VALUES
+    ('account', p_user_id::text, v_day, v_amount, 1, now()),
+    ('ip',      v_ip,            v_day, v_amount, 1, now()),
+    ('global',  '',              v_day, v_amount, 1, now())
+  ON CONFLICT (scope, scope_key, spend_day)
+  DO UPDATE SET
+    micro_usd     = public.ai_spend_ledger.micro_usd + EXCLUDED.micro_usd,
+    request_count = public.ai_spend_ledger.request_count + 1,
+    updated_at    = now();
+END;
+$$;
+
+REVOKE ALL ON FUNCTION record_ai_spend(UUID, TEXT, BIGINT) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION record_ai_spend(UUID, TEXT, BIGINT) TO service_role;
+
+-- Read today's accumulated micro-USD for the account, IP, and global buckets in
+-- one call. The route compares these to the env thresholds to pick full/degrade/
+-- deny — the decision (and thus the thresholds) live in TS, not here, so caps
+-- move with the sponsor commitment without a migration.
+CREATE OR REPLACE FUNCTION check_ai_spend(
+  p_user_id UUID,
+  p_ip      TEXT
+) RETURNS TABLE (account_micro_usd BIGINT, ip_micro_usd BIGINT, global_micro_usd BIGINT)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+  SELECT
+    COALESCE((SELECT micro_usd FROM public.ai_spend_ledger
+      WHERE scope = 'account' AND scope_key = p_user_id::text
+        AND spend_day = (now() AT TIME ZONE 'America/Sao_Paulo')::date), 0),
+    COALESCE((SELECT micro_usd FROM public.ai_spend_ledger
+      WHERE scope = 'ip' AND scope_key = COALESCE(NULLIF(p_ip, ''), 'unknown')
+        AND spend_day = (now() AT TIME ZONE 'America/Sao_Paulo')::date), 0),
+    COALESCE((SELECT micro_usd FROM public.ai_spend_ledger
+      WHERE scope = 'global' AND scope_key = ''
+        AND spend_day = (now() AT TIME ZONE 'America/Sao_Paulo')::date), 0);
+$$;
+
+REVOKE ALL ON FUNCTION check_ai_spend(UUID, TEXT) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION check_ai_spend(UUID, TEXT) TO service_role;
+
+-- Admin observability: the global burn for the current SP day, so the sponsor's
+-- spend is visible BEFORE the invoice (issue "Done when"). service_role only.
+CREATE OR REPLACE FUNCTION get_ai_spend_today()
+RETURNS TABLE (micro_usd BIGINT, request_count INTEGER)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+  SELECT
+    COALESCE(l.micro_usd, 0),
+    COALESCE(l.request_count, 0)
+  FROM (SELECT 1) AS one
+  LEFT JOIN public.ai_spend_ledger l
+    ON l.scope = 'global' AND l.scope_key = ''
+   AND l.spend_day = (now() AT TIME ZONE 'America/Sao_Paulo')::date;
+$$;
+
+REVOKE ALL ON FUNCTION get_ai_spend_today() FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION get_ai_spend_today() TO service_role;
+
+COMMIT;
+
+-- Rollback (manual):
+--   DROP FUNCTION IF EXISTS public.get_ai_spend_today();
+--   DROP FUNCTION IF EXISTS public.check_ai_spend(UUID, TEXT);
+--   DROP FUNCTION IF EXISTS public.record_ai_spend(UUID, TEXT, BIGINT);
+--   DROP TABLE IF EXISTS public.ai_spend_ledger;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -2326,3 +2326,108 @@ $$;
 
 REVOKE ALL ON FUNCTION record_review_result(UUID, TEXT, BOOLEAN) FROM PUBLIC, anon, authenticated;
 GRANT EXECUTE ON FUNCTION record_review_result(UUID, TEXT, BOOLEAN) TO service_role;
+
+-- ─────────────────────────────────────────────────────────────────────────
+-- AI tutor spend ledger (#591): the AI Partner spends a Superteam-sponsored
+-- Gemini key. challenge_assists counts TURNS, not spend. ai_spend_ledger records
+-- actual micro-USD (USD × 1e6, integer money) per billed generation in three
+-- daily buckets on America/Sao_Paulo days (AIE-21): account, ip, and a global
+-- envelope backstop. The route reads the totals via check_ai_spend BEFORE the
+-- model call (under soft → full; over soft → degrade; over hard → deny) and
+-- records usage via record_ai_spend AFTER it bills us. Thresholds live in env
+-- (TS), not here, so caps move with the sponsor commitment (O-1, $500/mo). All
+-- RPCs follow the challenge_assists hardening: SECURITY DEFINER, pinned path,
+-- RLS-on table with no policies, REVOKEd from clients, GRANTed to service_role.
+-- The TS wrapper fails CLOSED (any check error → deny), never open.
+-- ─────────────────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS ai_spend_ledger (
+  scope         TEXT NOT NULL,
+  scope_key     TEXT NOT NULL,
+  spend_day     DATE NOT NULL,
+  micro_usd     BIGINT NOT NULL DEFAULT 0,
+  request_count INTEGER NOT NULL DEFAULT 0,
+  updated_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (scope, scope_key, spend_day),
+  CONSTRAINT ai_spend_ledger_scope_check CHECK (scope IN ('account', 'ip', 'global'))
+);
+
+ALTER TABLE ai_spend_ledger ENABLE ROW LEVEL SECURITY;
+-- No policies: reached only through SECURITY DEFINER RPCs called by service_role.
+
+-- Add p_micro_usd to all three of today's buckets in one upsert. Negative input
+-- is clamped to 0. The SP-day is computed here so callers never pass a clock.
+CREATE OR REPLACE FUNCTION record_ai_spend(
+  p_user_id   UUID,
+  p_ip        TEXT,
+  p_micro_usd BIGINT
+) RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_day    DATE   := (now() AT TIME ZONE 'America/Sao_Paulo')::date;
+  v_amount BIGINT := GREATEST(COALESCE(p_micro_usd, 0), 0);
+  v_ip     TEXT   := COALESCE(NULLIF(p_ip, ''), 'unknown');
+BEGIN
+  INSERT INTO public.ai_spend_ledger (scope, scope_key, spend_day, micro_usd, request_count, updated_at)
+  VALUES
+    ('account', p_user_id::text, v_day, v_amount, 1, now()),
+    ('ip',      v_ip,            v_day, v_amount, 1, now()),
+    ('global',  '',              v_day, v_amount, 1, now())
+  ON CONFLICT (scope, scope_key, spend_day)
+  DO UPDATE SET
+    micro_usd     = public.ai_spend_ledger.micro_usd + EXCLUDED.micro_usd,
+    request_count = public.ai_spend_ledger.request_count + 1,
+    updated_at    = now();
+END;
+$$;
+
+REVOKE ALL ON FUNCTION record_ai_spend(UUID, TEXT, BIGINT) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION record_ai_spend(UUID, TEXT, BIGINT) TO service_role;
+
+-- Read today's accumulated micro-USD for account, IP, and global. The route
+-- compares these to the env thresholds to pick full/degrade/deny.
+CREATE OR REPLACE FUNCTION check_ai_spend(
+  p_user_id UUID,
+  p_ip      TEXT
+) RETURNS TABLE (account_micro_usd BIGINT, ip_micro_usd BIGINT, global_micro_usd BIGINT)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+  SELECT
+    COALESCE((SELECT micro_usd FROM public.ai_spend_ledger
+      WHERE scope = 'account' AND scope_key = p_user_id::text
+        AND spend_day = (now() AT TIME ZONE 'America/Sao_Paulo')::date), 0),
+    COALESCE((SELECT micro_usd FROM public.ai_spend_ledger
+      WHERE scope = 'ip' AND scope_key = COALESCE(NULLIF(p_ip, ''), 'unknown')
+        AND spend_day = (now() AT TIME ZONE 'America/Sao_Paulo')::date), 0),
+    COALESCE((SELECT micro_usd FROM public.ai_spend_ledger
+      WHERE scope = 'global' AND scope_key = ''
+        AND spend_day = (now() AT TIME ZONE 'America/Sao_Paulo')::date), 0);
+$$;
+
+REVOKE ALL ON FUNCTION check_ai_spend(UUID, TEXT) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION check_ai_spend(UUID, TEXT) TO service_role;
+
+-- Admin observability: the global burn for the current SP day.
+CREATE OR REPLACE FUNCTION get_ai_spend_today()
+RETURNS TABLE (micro_usd BIGINT, request_count INTEGER)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+  SELECT
+    COALESCE(l.micro_usd, 0),
+    COALESCE(l.request_count, 0)
+  FROM (SELECT 1) AS one
+  LEFT JOIN public.ai_spend_ledger l
+    ON l.scope = 'global' AND l.scope_key = ''
+   AND l.spend_day = (now() AT TIME ZONE 'America/Sao_Paulo')::date;
+$$;
+
+REVOKE ALL ON FUNCTION get_ai_spend_today() FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION get_ai_spend_today() TO service_role;


### PR DESCRIPTION
Closes #591.

## What & why
The AI Partner spends a platform-funded Gemini key with **no record of what it costs**. `challenge_assists` counts *turns*, not spend, so there was no ceiling and no way to spot an abusive account before the bill. This adds an `ai_spend_ledger` that records actual micro-USD usage per billed generation and enforces daily ceilings **fail-closed**, degrading before it denies. Thresholds are derived per the owner decision recorded in #591.

## Cap semantics & defaults
Windows are **America/Sao_Paulo** days. Three dimensions, each with a soft (degrade) and hard (deny) threshold — **any** dimension over hard denies; over soft degrades:

| dimension | soft (degrade) | hard (deny) | env var |
|---|---|---|---|
| global | $14/day | $25/day | `AI_SPEND_GLOBAL_SOFT_USD` / `..._HARD_USD` |
| per-account | $0.50/day | $1.50/day | `AI_SPEND_ACCOUNT_SOFT_USD` / `..._HARD_USD` |
| per-IP | $2/day | $5/day | `AI_SPEND_IP_SOFT_USD` / `..._HARD_USD` |

Gemini pricing (→ micro-USD from `usageMetadata`) is also config: `AI_SPEND_INPUT_USD_PER_MTOK` (0.3), `AI_SPEND_OUTPUT_USD_PER_MTOK` (2.5). **Thresholds are config, not constants** — they move without a migration. All documented in `apps/web/CLAUDE.md`.

### Enforcement (route: `/api/ai/partner`)
- **`checkAiSpend` gates BEFORE the model call**, and before `spendAssist`, so a hard-cap / outage denial burns no paid assist.
  - under every soft cap → **full** (normal output budget)
  - over a soft cap → **degrade**: halve the output budget (the dominant cost lever), floored at 256. Degrade is a shorter output, not a model swap — the cheaper tier is gated for new keys (route already documents the 404).
  - over a hard cap → **deny** (503, `spendCapped: true`, `reason: "spend_cap"`)
  - **ledger unreachable ⇒ 503** (`reason: "ledger_unavailable"`) — the `assist-budget`/#590 fail-closed contract, *not* `check_rate_limit`'s fail-open.
- **`recordAiSpend` books actual usage** after Gemini bills us, on every billed path (including empty/non-JSON/truncated): prompt + candidate + **thinking** tokens, thinking billed at the output rate.
- Hard-cap 503 surfaces dedicated **localized copy** in the pane (en / es / pt-BR); degrade-first, then stop.

### Data layer
`ai_spend_ledger` (integer micro-USD), RPCs `record_ai_spend` / `check_ai_spend` / `get_ai_spend_today` (admin burn observability). All follow the `challenge_assists` hardening: `SECURITY DEFINER`, `SET search_path = ''`, RLS-on table with **no policies**, REVOKEd from PUBLIC/anon/authenticated, GRANTed to `service_role` only. Byte-mirrored into `supabase/schema.sql`.

## Migration
`supabase/migrations/20260726180000_ai_spend_ledger.sql` — timestamp verified unique (latest existing was `20260726170000`; open PR #702 uses `160000`). Idempotent (`IF NOT EXISTS` / `CREATE OR REPLACE`), explicit `BEGIN;`/`COMMIT;`, manual-rollback block. **SQL-only — NOT applied to any database**; the owner dry-runs before it lands.

## Verification
- `pnpm install --frozen-lockfile` — OK
- `pnpm typecheck` — 6 packages successful, zero errors, zero `any`.
- `pnpm --filter web test` — **175 files, 1567 tests passed** (+113 new/changed across 6 touched test files; re-verified green post-format).
- `pnpm --filter web lint` — exit 0 (only pre-existing import/order warnings, none in changed files).

New tests: SQL guard (migration + schema mirror invariants), spend-ledger unit (cost math incl. thinking-at-output-rate, degrade helper, tier decisions, BIGINT-as-string coercion, fail-closed on error/missing-row/non-numeric/throw), route (checks with user+IP, under-cap full + records spend, soft-cap degrades to 1024, hard-cap 503 no-assist-no-model, ledger-error 503 fail-closed, no solution leak), hook + pane (`spendCapped` copy vs generic error).

## Deviations from the issue's proposal (with reasons)
1. **Decision logic lives in TS, not the RPC.** `check_ai_spend` returns the three daily totals; the tier (full/degrade/deny) is picked in `lib/ai/spend-ledger.ts`. Reason: the issue also requires "thresholds are config, not constants" — keeping the numbers in env means no migration when they move. The wrapper is still fail-closed (any error → deny).
2. **Degrade = shorter output budget, not a cheaper model.** The cheaper tier is gated for new keys (documented 404), so a model swap isn't reliably available; halving the output budget is the real, always-available lever.
3. **Admin observability is the `get_ai_spend_today` RPC + wrapper, not a UI page.** The data primitive is shipped and tested; wiring an `/admin` surface is a small follow-up (no admin metrics page exists to hook into today).

Do not merge — for gate review + owner dry-run of the migration.
