### PR TITLE
feat(credentials): capstone-gated credential (LX-E2, #561)

### DIFF
--- a/apps/web/src/app/api/certificates/mint/__tests__/capstone-gate.test.ts
+++ b/apps/web/src/app/api/certificates/mint/__tests__/capstone-gate.test.ts
@@ -1,0 +1,151 @@
+/* eslint-disable import/order -- vi.mock('server-only') must be hoisted above
+   the route import so the `server-only` graph loads under vitest. */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("server-only", () => ({}));
+
+// LX-E2 — the manual mint route must apply the same capstone deploy gate as the
+// webhook: no verified deploy → a specific "deploy required" state (localized on
+// the client via a stable code); an unreadable deploy state → fail-closed 503.
+
+const {
+  getUser,
+  isCourseInMaintenance,
+  isPlatformFrozen,
+  isRateLimited,
+  fetchEnrollment,
+  fetchCourse,
+  getCourseById,
+  issueCredential,
+  checkCapstoneCredentialGate,
+} = vi.hoisted(() => ({
+  getUser: vi.fn<() => Promise<unknown>>(),
+  isCourseInMaintenance: vi.fn<() => Promise<boolean>>(),
+  isPlatformFrozen: vi.fn<() => Promise<boolean>>(),
+  isRateLimited: vi.fn<() => Promise<boolean>>(),
+  fetchEnrollment: vi.fn(),
+  fetchCourse: vi.fn(),
+  getCourseById: vi.fn(),
+  issueCredential: vi.fn(),
+  checkCapstoneCredentialGate: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: async () => ({ auth: { getUser } }),
+}));
+vi.mock("@/lib/supabase/admin", () => {
+  // A valid base58 pubkey so the route's `new PublicKey(wallet_address)` works.
+  const chain: {
+    eq: () => typeof chain;
+    single: () => Promise<{ data: { wallet_address: string } }>;
+    maybeSingle: () => Promise<{ data: null }>;
+  } = {
+    eq: () => chain,
+    single: async () => ({
+      data: { wallet_address: "11111111111111111111111111111111" },
+    }),
+    maybeSingle: async () => ({ data: null }),
+  };
+  return {
+    createAdminClient: () => ({ from: () => ({ select: () => chain }) }),
+  };
+});
+vi.mock("@/lib/content/queries", () => ({ getCourseById }));
+vi.mock("@/lib/solana/academy-program", () => ({
+  issueCredential,
+  getConnection: () => ({}),
+  describeProgramError: () => "unknown",
+}));
+vi.mock("@/lib/solana/academy-reads", () => ({ fetchEnrollment, fetchCourse }));
+vi.mock("@/lib/solana/pda", () => ({ getProgramId: () => "program-id" }));
+vi.mock("@/lib/solana/arweave", () => ({ uploadCertificateMetadata: vi.fn() }));
+vi.mock("@/lib/solana/credential-metadata", () => ({
+  capCredentialName: (n: string) => n,
+}));
+vi.mock("@/lib/rate-limit", () => ({
+  isRateLimited,
+  getClientIp: () => "203.0.113.7",
+}));
+vi.mock("@/lib/content/deployments", () => ({ isCourseInMaintenance }));
+vi.mock("@/lib/platform/freeze", () => ({ isPlatformFrozen }));
+vi.mock("@/lib/platform/freeze-http", () => ({
+  platformFrozenResponse: () =>
+    new Response(JSON.stringify({ maintenance: true }), { status: 503 }),
+}));
+vi.mock("@/lib/credentials/capstone-gate", () => ({
+  checkCapstoneCredentialGate,
+}));
+vi.mock("@/lib/logging", () => ({ logError: vi.fn() }));
+
+import { POST } from "../route";
+
+const CAPSTONE = "course-building-first-program";
+
+function req(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/certificates/mint", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "content-type": "application/json" },
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getUser.mockResolvedValue({ data: { user: { id: "user-1" } }, error: null });
+  isRateLimited.mockResolvedValue(false);
+  isCourseInMaintenance.mockResolvedValue(false);
+  isPlatformFrozen.mockResolvedValue(false);
+  // Course finalized on-chain, credential not yet issued — reaches the gate.
+  fetchEnrollment.mockResolvedValue({
+    completed_at: new Date().toISOString(),
+    credential_asset: null,
+  });
+  // After the gate passes, the route reads the content bundle; return null so
+  // it stops at a 404 without needing the full mint mocked — a 404 proves the
+  // gate did NOT block.
+  getCourseById.mockResolvedValue(null);
+});
+
+describe("POST /api/certificates/mint — capstone gate (LX-E2)", () => {
+  it("returns 403 with a stable code when the capstone deploy is missing", async () => {
+    checkCapstoneCredentialGate.mockResolvedValue({
+      status: "deploy_required",
+    });
+
+    const res = await POST(req({ courseId: CAPSTONE }));
+
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { code?: string };
+    expect(body.code).toBe("capstone_deploy_required");
+    expect(issueCredential).not.toHaveBeenCalled();
+  });
+
+  it("fails closed with 503 when the deploy state is indeterminate", async () => {
+    checkCapstoneCredentialGate.mockResolvedValue({ status: "indeterminate" });
+
+    const res = await POST(req({ courseId: CAPSTONE }));
+
+    expect(res.status).toBe(503);
+    expect(issueCredential).not.toHaveBeenCalled();
+  });
+
+  it("passes the gate (reaches mint) when the deploy is verified", async () => {
+    checkCapstoneCredentialGate.mockResolvedValue({ status: "allowed" });
+
+    const res = await POST(req({ courseId: CAPSTONE }));
+
+    // Gate passed → route proceeded to the content read (404 here), not blocked.
+    expect(res.status).toBe(404);
+    expect(getCourseById).toHaveBeenCalledWith(CAPSTONE);
+  });
+
+  it("does not gate a non-capstone course", async () => {
+    checkCapstoneCredentialGate.mockResolvedValue({ status: "not_capstone" });
+
+    const res = await POST(req({ courseId: "course-solana-fundamentals" }));
+
+    expect(res.status).toBe(404);
+    expect(getCourseById).toHaveBeenCalledWith("course-solana-fundamentals");
+  });
+});

--- a/apps/web/src/app/api/certificates/mint/route.ts
+++ b/apps/web/src/app/api/certificates/mint/route.ts
@@ -18,6 +18,7 @@ import { isRateLimited, getClientIp } from "@/lib/rate-limit";
 import { isCourseInMaintenance } from "@/lib/content/deployments";
 import { isPlatformFrozen } from "@/lib/platform/freeze";
 import { platformFrozenResponse } from "@/lib/platform/freeze-http";
+import { checkCapstoneCredentialGate } from "@/lib/credentials/capstone-gate";
 import { logError } from "@/lib/logging";
 import { ERROR_IDS } from "@/constants/errorIds";
 
@@ -156,6 +157,37 @@ export async function POST(request: NextRequest) {
       return NextResponse.json(
         { error: "Credential already issued on-chain" },
         { status: 409 }
+      );
+    }
+
+    // LX-E2 (owner decision O-2) — the capstone credential requires a VERIFIED
+    // deploy (a `deployed_programs` row for the capstone deploy lesson, written
+    // only by the on-chain-verified /api/deploy/save). Non-capstone courses
+    // return `not_capstone` and proceed unchanged. This runs AFTER the
+    // already-issued short-circuit above, so a pre-gate holder is never
+    // re-evaluated (grandfathered). `code` is stable and machine-readable so
+    // the client can render a localized "deploy required" state.
+    const gate = await checkCapstoneCredentialGate(
+      adminClient,
+      user.id,
+      courseId
+    );
+    if (gate.status === "deploy_required") {
+      return NextResponse.json(
+        {
+          error:
+            "Deploy your capstone program to devnet before minting this credential.",
+          code: "capstone_deploy_required",
+        },
+        { status: 403 }
+      );
+    }
+    if (gate.status === "indeterminate") {
+      // Fail-closed on an unreadable deploy state — transient, so "try again"
+      // rather than a hard denial, and before any paid work (Arweave, tx).
+      return NextResponse.json(
+        { error: "Unable to verify your deploy right now. Please try again." },
+        { status: 503, headers: { "Retry-After": "30" } }
       );
     }
 

--- a/apps/web/src/components/certificates/course-completion-mint.tsx
+++ b/apps/web/src/components/certificates/course-completion-mint.tsx
@@ -4,11 +4,11 @@ import { useEffect, useState } from "react";
 import { useTranslations, useLocale } from "next-intl";
 import Link from "next/link";
 import { GraduationCap, CheckCircle, Wallet } from "@phosphor-icons/react";
-import { EarnHandoffCard } from "./earn-handoff-card";
-import { CredentialShareNudge } from "./credential-share-nudge";
 import { trackCredentialMinted } from "@/lib/analytics/events";
 import { celebrate } from "@/lib/gamification/celebration";
 import { createClient } from "@/lib/supabase/client";
+import { CredentialShareNudge } from "./credential-share-nudge";
+import { EarnHandoffCard } from "./earn-handoff-card";
 
 interface CourseCompletionMintProps {
   courseId: string;
@@ -123,7 +123,11 @@ export function CourseCompletionMint({
         body: JSON.stringify({ courseId }),
       });
       if (!res.ok) {
-        const data = (await res.json()) as { error?: string; reason?: string };
+        const data = (await res.json()) as {
+          error?: string;
+          reason?: string;
+          code?: string;
+        };
         if (res.status === 409) {
           setState({
             status: "already_minted",
@@ -133,6 +137,12 @@ export function CourseCompletionMint({
               courseId
             ),
           });
+          return;
+        }
+        // LX-E2 — the capstone gate returns a stable machine code so the copy
+        // is localized here rather than served in English from the route.
+        if (data.code === "capstone_deploy_required") {
+          setState({ status: "mint_error", message: t("deployRequired") });
           return;
         }
         const base = data.error ?? "Minting failed";

--- a/apps/web/src/lib/credentials/__tests__/capstone-gate.test.ts
+++ b/apps/web/src/lib/credentials/__tests__/capstone-gate.test.ts
@@ -1,0 +1,161 @@
+/* eslint-disable import/order -- vi.mock('server-only') must be hoisted above
+   the module import so the `server-only` graph loads under vitest. */
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  CAPSTONE_CREDENTIAL,
+  isCapstoneCourse,
+  checkCapstoneCredentialGate,
+} from "../capstone-gate";
+
+// Read the committed bundle from disk rather than importing it: the generated
+// JSON is a restricted import (it carries quiz answers / solutions / hidden
+// tests) and must only be loaded via the server-only content store. Reading the
+// file here keeps this constant-vs-bundle assertion without pulling secrets
+// into a module graph.
+const GENERATED = join(process.cwd(), "src/content/generated");
+const coursesJson = JSON.parse(
+  readFileSync(join(GENERATED, "courses.json"), "utf8")
+) as Array<{
+  _id: string;
+  modules?: Array<{ lessons?: Array<{ _ref?: string }> }>;
+}>;
+const lessonsJson = JSON.parse(
+  readFileSync(join(GENERATED, "lessons.json"), "utf8")
+) as Array<{ _id: string; blocks?: Array<{ _type?: string }> }>;
+
+// A `deployed_programs` query mock: chain `.select().eq().eq().eq().limit()`
+// then resolve `.maybeSingle()` with the given row/error. Records the eq()
+// filters so the test can assert the gate scopes to the capstone constants.
+function adminClientWith(result: {
+  data?: { id: string } | null;
+  error?: { message: string } | null;
+}) {
+  const eqCalls: Array<[string, unknown]> = [];
+  const chain = {
+    select: () => chain,
+    eq: (col: string, val: unknown) => {
+      eqCalls.push([col, val]);
+      return chain;
+    },
+    limit: () => chain,
+    maybeSingle: async () => ({
+      data: result.data ?? null,
+      error: result.error ?? null,
+    }),
+  };
+  const from = vi.fn(() => chain);
+  return {
+    client: { from } as never,
+    from,
+    eqCalls,
+  };
+}
+
+describe("capstone-gate — constants match the committed content bundle", () => {
+  // If the capstone course or its deploy lesson is renamed in content without
+  // updating CAPSTONE_CREDENTIAL, the gate would query a non-existent row and
+  // deny EVERY legitimate capstone credential. These assertions fail loudly at
+  // that moment instead.
+  it("the capstone course id exists in courses.json", () => {
+    const ids = coursesJson.map((c) => c._id);
+    expect(ids).toContain(CAPSTONE_CREDENTIAL.courseId);
+  });
+
+  it("the deploy lesson exists and hosts the deployed-program-card block", () => {
+    const lesson = lessonsJson.find(
+      (l) => l._id === CAPSTONE_CREDENTIAL.deployLessonId
+    );
+    expect(lesson, "capstone deploy lesson must exist").toBeDefined();
+    const hasDeployPanel = (lesson?.blocks ?? []).some(
+      (b) => b._type === "deployed-program-card"
+    );
+    expect(
+      hasDeployPanel,
+      "capstone deploy lesson must host the deploy panel block"
+    ).toBe(true);
+  });
+
+  it("the deploy lesson belongs to the capstone course", () => {
+    const course = coursesJson.find(
+      (c) => c._id === CAPSTONE_CREDENTIAL.courseId
+    );
+    const lessonIds = (course?.modules ?? []).flatMap((m) =>
+      (m.lessons ?? []).map((l) => l._ref)
+    );
+    expect(lessonIds).toContain(CAPSTONE_CREDENTIAL.deployLessonId);
+  });
+
+  it("exactly one lesson in the bundle hosts a deploy panel (the capstone)", () => {
+    const deployLessons = lessonsJson.filter((l) =>
+      (l.blocks ?? []).some((b) => b._type === "deployed-program-card")
+    );
+    expect(deployLessons.map((l) => l._id)).toEqual([
+      CAPSTONE_CREDENTIAL.deployLessonId,
+    ]);
+  });
+});
+
+describe("isCapstoneCourse", () => {
+  it("is true only for the capstone course", () => {
+    expect(isCapstoneCourse(CAPSTONE_CREDENTIAL.courseId)).toBe(true);
+    expect(isCapstoneCourse("course-solana-fundamentals")).toBe(false);
+    expect(isCapstoneCourse("")).toBe(false);
+  });
+});
+
+describe("checkCapstoneCredentialGate", () => {
+  it("returns not_capstone for a non-capstone course without touching the DB", async () => {
+    const { client, from } = adminClientWith({ data: null });
+    const result = await checkCapstoneCredentialGate(
+      client,
+      "user-1",
+      "course-solana-fundamentals"
+    );
+    expect(result).toEqual({ status: "not_capstone" });
+    expect(from).not.toHaveBeenCalled();
+  });
+
+  it("returns allowed when a verified deploy row exists, scoped to the capstone lesson", async () => {
+    const { client, eqCalls } = adminClientWith({ data: { id: "dp-1" } });
+    const result = await checkCapstoneCredentialGate(
+      client,
+      "user-1",
+      CAPSTONE_CREDENTIAL.courseId
+    );
+    expect(result).toEqual({ status: "allowed" });
+    // The query is scoped to this user + the capstone course + deploy lesson.
+    expect(eqCalls).toEqual([
+      ["user_id", "user-1"],
+      ["course_id", CAPSTONE_CREDENTIAL.courseId],
+      ["lesson_id", CAPSTONE_CREDENTIAL.deployLessonId],
+    ]);
+  });
+
+  it("returns deploy_required when no deploy row exists", async () => {
+    const { client } = adminClientWith({ data: null });
+    const result = await checkCapstoneCredentialGate(
+      client,
+      "user-1",
+      CAPSTONE_CREDENTIAL.courseId
+    );
+    expect(result).toEqual({ status: "deploy_required" });
+  });
+
+  it("fails closed (indeterminate) on a read error — never allowed", async () => {
+    const { client } = adminClientWith({
+      data: null,
+      error: { message: "db down" },
+    });
+    const result = await checkCapstoneCredentialGate(
+      client,
+      "user-1",
+      CAPSTONE_CREDENTIAL.courseId
+    );
+    expect(result).toEqual({ status: "indeterminate" });
+  });
+});

--- a/apps/web/src/lib/credentials/capstone-gate.ts
+++ b/apps/web/src/lib/credentials/capstone-gate.ts
@@ -1,0 +1,88 @@
+import "server-only";
+
+import type { createAdminClient } from "@/lib/supabase/admin";
+
+type AdminClient = ReturnType<typeof createAdminClient>;
+
+// ---------------------------------------------------------------------------
+// LX-E2 — Capstone-gated credential (owner decision O-2)
+// ---------------------------------------------------------------------------
+//
+// The "Zero to Deployed" spine terminates in ONE graded, follow-along deploy:
+// the learner ships the reference vault to devnet under their own upgrade
+// authority. That verified deploy is the artifact the capstone credential
+// attests, so the credential for the capstone course is withheld until a
+// verified `deployed_programs` row exists for the capstone deploy lesson.
+//
+// "Verified" is load-bearing: `deployed_programs` has NO client INSERT/UPDATE
+// RLS policy (20260726120000_lockdown_deployed_programs_rls), and the only
+// write path is `/api/deploy/save`, which first confirms on-chain that the
+// program is live, executable, and upgrade-authority-owned by the learner's
+// linked wallet (#620 / LX-E1). A row therefore means a real, attributable
+// deploy — not a self-reported claim.
+//
+// Identity is an app-side constant for launch; a content-schema flag comes
+// later. The values below MUST match what the deploy panel writes to
+// `deployed_programs`:
+//   - courseId       = the page-level course `_id`   (courseInfo._id)
+//   - deployLessonId = the lesson hosting the `deployed-program-card` block
+//                      (ctx.lesson._id)
+// Both are asserted against the committed content bundle in the accompanying
+// test, so a content rename cannot silently break the gate (which would then
+// deny every legitimate capstone credential).
+//
+// GRANDFATHERING: this gate never revokes. All three credential paths short-
+// circuit on an already-issued credential (on-chain `credential_asset` / an
+// existing `certificates` row) BEFORE reaching the gate, so pre-gate devnet
+// certificates minted without a recorded deploy stay valid and are never
+// re-evaluated.
+
+export const CAPSTONE_CREDENTIAL = {
+  courseId: "course-building-first-program",
+  deployLessonId: "lesson-bfsp-m4-capstone",
+} as const;
+
+/** Whether a course's credential is subject to the capstone deploy gate. */
+export function isCapstoneCourse(courseId: string): boolean {
+  return courseId === CAPSTONE_CREDENTIAL.courseId;
+}
+
+export type CapstoneGateResult =
+  // The course is not the capstone — the deploy gate does not apply; issue as usual.
+  | { status: "not_capstone" }
+  // Capstone course AND a verified deploy row exists — the credential may issue.
+  | { status: "allowed" }
+  // Capstone course but no verified deploy yet — withhold (fail-closed).
+  | { status: "deploy_required" }
+  // Capstone course but the deploy state could not be read — withhold (fail-closed).
+  | { status: "indeterminate" };
+
+/**
+ * Decide whether a course credential may be issued to `userId`.
+ *
+ * Fail-closed by construction: a non-capstone course always returns
+ * `not_capstone`; the capstone course returns `allowed` ONLY when a verified
+ * `deployed_programs` row for the capstone deploy lesson exists. A read error
+ * returns `indeterminate` (never `allowed`), so a database blip can never leak
+ * an ungated credential — callers defer/deny on both `deploy_required` and
+ * `indeterminate`.
+ */
+export async function checkCapstoneCredentialGate(
+  adminClient: AdminClient,
+  userId: string,
+  courseId: string
+): Promise<CapstoneGateResult> {
+  if (!isCapstoneCourse(courseId)) return { status: "not_capstone" };
+
+  const { data, error } = await adminClient
+    .from("deployed_programs")
+    .select("id")
+    .eq("user_id", userId)
+    .eq("course_id", CAPSTONE_CREDENTIAL.courseId)
+    .eq("lesson_id", CAPSTONE_CREDENTIAL.deployLessonId)
+    .limit(1)
+    .maybeSingle();
+
+  if (error) return { status: "indeterminate" };
+  return data ? { status: "allowed" } : { status: "deploy_required" };
+}

--- a/apps/web/src/lib/helius/__tests__/credential-gate.test.ts
+++ b/apps/web/src/lib/helius/__tests__/credential-gate.test.ts
@@ -1,0 +1,221 @@
+/* eslint-disable import/order -- vi.mock('server-only') must be hoisted above
+   the module imports so the `server-only` graph loads under vitest. */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Keypair } from "@solana/web3.js";
+
+vi.mock("server-only", () => ({}));
+
+// LX-E2 — the capstone credential gate must (a) withhold + queue the capstone
+// credential when there is no verified deploy, on BOTH the webhook path here
+// and the login drainer, and (b) leave the XP path completely untouched.
+
+const {
+  isPlatformFrozen,
+  fetchEnrollment,
+  fetchCourse,
+  getCourseById,
+  uploadCertificateMetadata,
+  issueCredential,
+  checkCapstoneCredentialGate,
+  queueUpsert,
+  certUpsert,
+  awardXpRpc,
+  resolveUserId,
+  resolveCourseId,
+} = vi.hoisted(() => ({
+  isPlatformFrozen: vi.fn<() => Promise<boolean>>(),
+  fetchEnrollment: vi.fn(),
+  fetchCourse: vi.fn(),
+  getCourseById: vi.fn(),
+  uploadCertificateMetadata: vi.fn(),
+  issueCredential: vi.fn(),
+  checkCapstoneCredentialGate: vi.fn(),
+  queueUpsert: vi.fn<(row: { action_type: string }) => Promise<unknown>>(
+    async () => ({ error: null })
+  ),
+  certUpsert: vi.fn(async () => ({ error: null })),
+  awardXpRpc: vi.fn<
+    (fn: string, params: Record<string, unknown>) => Promise<unknown>
+  >(async () => ({ data: 1, error: null })),
+  resolveUserId: vi.fn(),
+  resolveCourseId: vi.fn(),
+}));
+
+vi.mock("@/lib/platform/freeze", () => ({ isPlatformFrozen }));
+vi.mock("@/lib/content/deployments", () => ({
+  isCourseInMaintenance: vi.fn(async () => false),
+}));
+vi.mock("@/lib/solana/academy-reads", () => ({ fetchEnrollment, fetchCourse }));
+vi.mock("@/lib/solana/bitmap", () => ({ isCourseComplete: () => false }));
+vi.mock("@/lib/solana/pda", () => ({ getProgramId: () => "program-id" }));
+vi.mock("@/lib/solana/academy-program", () => ({
+  finalizeCourse: vi.fn(),
+  issueCredential,
+  awardAchievement: vi.fn(),
+  getConnection: () => ({}),
+}));
+vi.mock("@/lib/solana/arweave", () => ({ uploadCertificateMetadata }));
+vi.mock("@/lib/content/queries", () => ({
+  getCourseById,
+  getDeployedAchievements: vi.fn(async () => []),
+}));
+vi.mock("@/lib/gamification/achievements", () => ({
+  checkNewAchievements: vi.fn(() => []),
+  buildUserState: vi.fn(),
+}));
+vi.mock("@/lib/gamification/surprise-bonus", () => ({
+  maybeAwardSurpriseBonus: vi.fn(),
+}));
+vi.mock("@/lib/helius/resolvers", () => ({
+  resolveUserId,
+  resolveCourseId,
+  resolveLessonId: vi.fn(async () => "lesson-1"),
+}));
+vi.mock("@/lib/logging", () => ({ logError: vi.fn() }));
+vi.mock("@/lib/credentials/capstone-gate", () => ({
+  checkCapstoneCredentialGate,
+  CAPSTONE_CREDENTIAL: {
+    courseId: "course-building-first-program",
+    deployLessonId: "lesson-bfsp-m4-capstone",
+  },
+}));
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: () => ({
+    from: (table: string) => {
+      if (table === "pending_onchain_actions") return { upsert: queueUpsert };
+      if (table === "certificates") return { upsert: certUpsert };
+      if (table === "nft_metadata")
+        return {
+          insert: () => ({
+            select: () => ({
+              single: async () => ({ data: { id: "meta-1" }, error: null }),
+            }),
+          }),
+          delete: () => ({ eq: async () => ({ error: null }) }),
+        };
+      if (table === "profiles")
+        return {
+          select: () => ({
+            eq: () => ({
+              single: async () => ({ data: { username: "alice" } }),
+            }),
+          }),
+        };
+      if (table === "enrollments")
+        return {
+          update: () => ({ eq: () => ({ eq: async () => ({ error: null }) }) }),
+        };
+      throw new Error(`unexpected table ${table}`);
+    },
+    rpc: awardXpRpc,
+  }),
+}));
+
+import { tryIssueCredential, handleCourseFinalized } from "../event-handlers";
+import { CAPSTONE_CREDENTIAL } from "@/lib/credentials/capstone-gate";
+import type { CourseFinalizedEvent } from "@/lib/helius/types";
+
+const CAPSTONE = CAPSTONE_CREDENTIAL.courseId;
+const WALLET = Keypair.generate().publicKey.toBase58();
+const CONNECTION = {} as never;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  isPlatformFrozen.mockResolvedValue(false);
+  // Enrollment exists, not yet credentialed.
+  fetchEnrollment.mockResolvedValue({ credential_asset: null });
+  // A fully-synced on-chain course so the allowed path can reach issueCredential.
+  fetchCourse.mockResolvedValue({
+    collection: Keypair.generate().publicKey.toBase58(),
+    xp_per_lesson: 10,
+    liveLessonCount: 4,
+    version: 1,
+  });
+  getCourseById.mockResolvedValue({ title: "Building Your First Program" });
+  uploadCertificateMetadata.mockResolvedValue(null);
+  issueCredential.mockResolvedValue({
+    signature: "sig",
+    mintAddress: Keypair.generate().publicKey,
+  });
+});
+
+describe("tryIssueCredential — capstone gate (webhook path)", () => {
+  it("withholds + queues the capstone credential when deploy is required", async () => {
+    checkCapstoneCredentialGate.mockResolvedValue({
+      status: "deploy_required",
+    });
+
+    await tryIssueCredential("user-1", CAPSTONE, WALLET, CONNECTION);
+
+    expect(issueCredential).not.toHaveBeenCalled();
+    // Deferred onto the certificate queue (fail-closed, retried on next drain).
+    expect(queueUpsert).toHaveBeenCalledTimes(1);
+    const queued = queueUpsert.mock.calls[0]?.[0];
+    expect(queued?.action_type).toBe("certificate");
+  });
+
+  it("fails closed (queues, never issues) when deploy state is indeterminate", async () => {
+    checkCapstoneCredentialGate.mockResolvedValue({ status: "indeterminate" });
+
+    await tryIssueCredential("user-1", CAPSTONE, WALLET, CONNECTION);
+
+    expect(issueCredential).not.toHaveBeenCalled();
+    expect(queueUpsert).toHaveBeenCalledTimes(1);
+  });
+
+  it("issues the capstone credential once the deploy is verified", async () => {
+    checkCapstoneCredentialGate.mockResolvedValue({ status: "allowed" });
+
+    await tryIssueCredential("user-1", CAPSTONE, WALLET, CONNECTION);
+
+    expect(issueCredential).toHaveBeenCalledTimes(1);
+    expect(queueUpsert).not.toHaveBeenCalled();
+  });
+
+  it("issues a non-capstone credential without any deploy requirement", async () => {
+    checkCapstoneCredentialGate.mockResolvedValue({ status: "not_capstone" });
+
+    await tryIssueCredential(
+      "user-1",
+      "course-solana-fundamentals",
+      WALLET,
+      CONNECTION
+    );
+
+    expect(issueCredential).toHaveBeenCalledTimes(1);
+    expect(queueUpsert).not.toHaveBeenCalled();
+  });
+});
+
+describe("handleCourseFinalized — XP path is untouched by the gate", () => {
+  function finalizedEvent(): CourseFinalizedEvent {
+    return {
+      learner: WALLET,
+      course: "course-onchain",
+      totalXp: 40,
+      bonusXp: 250,
+      creator: WALLET,
+      creatorXp: 0,
+      timestamp: Math.floor(Date.now() / 1000),
+    };
+  }
+
+  it("awards completion-bonus XP even when the capstone credential is withheld", async () => {
+    resolveUserId.mockResolvedValue("user-1");
+    resolveCourseId.mockResolvedValue(CAPSTONE);
+    checkCapstoneCredentialGate.mockResolvedValue({
+      status: "deploy_required",
+    });
+
+    await handleCourseFinalized(finalizedEvent(), "tx-123");
+
+    // Bonus XP still awarded — the gate only guards issue_credential.
+    const bonusCall = awardXpRpc.mock.calls.find(
+      (c) => c[0] === "award_xp" && /bonus/i.test(String(c[1].p_reason ?? ""))
+    );
+    expect(bonusCall, "completion-bonus XP must be awarded").toBeTruthy();
+    // ...but the credential is deferred, not minted.
+    expect(issueCredential).not.toHaveBeenCalled();
+    expect(queueUpsert).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/lib/helius/event-handlers.ts
+++ b/apps/web/src/lib/helius/event-handlers.ts
@@ -25,6 +25,7 @@ import { getCourseById, getDeployedAchievements } from "@/lib/content/queries";
 import { maybeAwardSurpriseBonus } from "@/lib/gamification/surprise-bonus";
 import { isCourseInMaintenance } from "@/lib/content/deployments";
 import { isPlatformFrozen } from "@/lib/platform/freeze";
+import { checkCapstoneCredentialGate } from "@/lib/credentials/capstone-gate";
 import { logError } from "@/lib/logging";
 import { ERROR_IDS } from "@/constants/errorIds";
 import type {
@@ -528,7 +529,7 @@ export async function tryFinalizeCourse(
 // Internal: try to issue a credential NFT after course finalization
 // ---------------------------------------------------------------------------
 
-async function tryIssueCredential(
+export async function tryIssueCredential(
   userId: string,
   courseId: string,
   walletAddress: string,
@@ -556,6 +557,25 @@ async function tryIssueCredential(
     );
     if (!enrollment) return;
     if (enrollment.credential_asset) return;
+
+    const supabase = createAdminClient();
+
+    // LX-E2 (owner decision O-2) — the capstone credential is withheld until
+    // the learner's graded deploy is VERIFIED (a `deployed_programs` row for
+    // the capstone deploy lesson). Non-capstone courses return `not_capstone`
+    // and are unaffected — learner XP already landed on lesson completion, so
+    // gating here never delays XP (spec §LX-E2 cross-check). `deploy_required`
+    // and `indeterminate` both DEFER (throw → `certificate` queue) rather than
+    // issue: fail-closed, and a genuine capstone finalized before its deploy
+    // row lands (the #622 silent-save class) still mints once the row appears
+    // on a later drain. The login drainer re-runs this same gate, so a queued
+    // capstone can never mint ungated.
+    const gate = await checkCapstoneCredentialGate(supabase, userId, courseId);
+    if (gate.status === "deploy_required" || gate.status === "indeterminate") {
+      throw new Error(
+        `Capstone credential for "${courseId}" withheld (${gate.status}) — no verified deploy`
+      );
+    }
 
     // Fetch course data from the content bundle for the display name
     const sanityCourse = await getCourseById(courseId);
@@ -594,7 +614,6 @@ async function tryIssueCredential(
       Number(onChainCourse.xp_per_lesson) * onChainCourse.liveLessonCount;
 
     // Fetch user profile for metadata
-    const supabase = createAdminClient();
     const { data: profile } = await supabase
       .from("profiles")
       .select("username")

--- a/apps/web/src/lib/solana/__tests__/onchain-queue.test.ts
+++ b/apps/web/src/lib/solana/__tests__/onchain-queue.test.ts
@@ -45,6 +45,14 @@ const h = vi.hoisted(() => ({
   isCourseInMaintenance: vi.fn<(courseId: string) => Promise<boolean>>(),
   isPlatformFrozen: vi.fn<() => Promise<boolean>>(),
   getCourseById: vi.fn(),
+  checkCapstoneCredentialGate:
+    vi.fn<
+      (
+        client: unknown,
+        userId: string,
+        courseId: string
+      ) => Promise<{ status: string }>
+    >(),
   // F5 — simulate the maintenance-defer marker WRITE itself failing (a
   // transient DB error), independent of any other update in the sweep.
   deferWriteShouldError: false,
@@ -89,6 +97,11 @@ vi.mock("@/lib/content/deployments", () => ({
 
 vi.mock("@/lib/platform/freeze", () => ({
   isPlatformFrozen: () => h.isPlatformFrozen(),
+}));
+
+vi.mock("@/lib/credentials/capstone-gate", () => ({
+  checkCapstoneCredentialGate: (...args: [unknown, string, string]) =>
+    h.checkCapstoneCredentialGate(...args),
 }));
 
 vi.mock("@/lib/supabase/admin", () => {
@@ -185,6 +198,10 @@ beforeEach(() => {
   h.isPlatformFrozen.mockReset();
   h.isPlatformFrozen.mockResolvedValue(false);
   h.getCourseById.mockReset();
+  h.checkCapstoneCredentialGate.mockReset();
+  // Default: non-capstone course — the gate is a no-op so the existing
+  // certificate/finalize tests exercise their original paths unchanged.
+  h.checkCapstoneCredentialGate.mockResolvedValue({ status: "not_capstone" });
   h.deferWriteShouldError = false;
   // Default: course already finalized on-chain, so finalizeCourse is skipped
   // and each test exercises the XP-settlement path in isolation.
@@ -610,5 +627,101 @@ describe("retryPendingOnchainActions — global freeze deferral (reset wave B2)"
     const patch = patchFor("r-xp-ok");
     expect(patch?.last_error).not.toBe("platform-frozen");
     expect(typeof patch?.resolved_at).toBe("string");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// LX-E2 — the login drainer is a THIRD credential-mint path. A `certificate`
+// row queued by the webhook (deploy save lagged behind finalize) must not be
+// minted ungated on the next drain: the same capstone gate runs here, and a
+// missing/indeterminate deploy DEFERS without burning a retry (so it lands the
+// moment the verified deploy row appears, and never before).
+// ---------------------------------------------------------------------------
+
+describe("retryPendingOnchainActions — capstone credential gate (LX-E2)", () => {
+  it("defers a capstone certificate row when deploy is required, WITHOUT bumping retry_count or minting", async () => {
+    h.rows = [
+      {
+        id: "r-cap-cert",
+        action_type: "certificate",
+        reference_id: "course-building-first-program",
+        retry_count: 1,
+        payload: { courseId: "course-building-first-program" },
+      },
+    ];
+    h.fetchEnrollment.mockResolvedValue({
+      completed_at: 1,
+      credential_asset: null,
+    });
+    h.checkCapstoneCredentialGate.mockResolvedValue({
+      status: "deploy_required",
+    });
+
+    await retryPendingOnchainActions(USER_ID);
+
+    const patch = patchFor("r-cap-cert");
+    expect(patch).toBeDefined();
+    expect(patch?.resolved_at).toBeUndefined();
+    expect(patch?.retry_count).toBeUndefined();
+    expect(String(patch?.last_error)).toContain(
+      "capstone-gate-deploy_required"
+    );
+    // Deferred BEFORE any mint machinery — no credential derived or issued.
+    expect(h.getCourseById).not.toHaveBeenCalled();
+  });
+
+  it("fails closed (defers, never mints) when the deploy state is indeterminate", async () => {
+    h.rows = [
+      {
+        id: "r-cap-cert-ind",
+        action_type: "certificate",
+        reference_id: "course-building-first-program",
+        retry_count: 0,
+        payload: { courseId: "course-building-first-program" },
+      },
+    ];
+    h.fetchEnrollment.mockResolvedValue({
+      completed_at: 1,
+      credential_asset: null,
+    });
+    h.checkCapstoneCredentialGate.mockResolvedValue({
+      status: "indeterminate",
+    });
+
+    await retryPendingOnchainActions(USER_ID);
+
+    const patch = patchFor("r-cap-cert-ind");
+    expect(patch?.retry_count).toBeUndefined();
+    expect(String(patch?.last_error)).toContain("capstone-gate-indeterminate");
+    expect(h.getCourseById).not.toHaveBeenCalled();
+  });
+
+  it("proceeds past the gate to mint machinery once the deploy is verified", async () => {
+    h.rows = [
+      {
+        id: "r-cap-cert-ok",
+        action_type: "certificate",
+        reference_id: "course-building-first-program",
+        retry_count: 0,
+        payload: { courseId: "course-building-first-program" },
+      },
+    ];
+    h.fetchEnrollment.mockResolvedValue({
+      completed_at: 1,
+      credential_asset: null,
+    });
+    h.checkCapstoneCredentialGate.mockResolvedValue({ status: "allowed" });
+    // Gate passed → the drainer reads the content bundle. Return null so it
+    // stops there (bumps retry) instead of needing the full mint mocked; the
+    // point is only that the gate did NOT block.
+    h.getCourseById.mockResolvedValue(null);
+
+    await retryPendingOnchainActions(USER_ID);
+
+    expect(h.getCourseById).toHaveBeenCalledWith(
+      "course-building-first-program"
+    );
+    const patch = patchFor("r-cap-cert-ok");
+    expect(String(patch?.last_error ?? "")).not.toContain("capstone-gate");
   });
 });

--- a/apps/web/src/lib/solana/onchain-queue.ts
+++ b/apps/web/src/lib/solana/onchain-queue.ts
@@ -1,23 +1,24 @@
 import "server-only";
 
 import { PublicKey } from "@solana/web3.js";
-import { getProgramId } from "./pda";
+import { getCourseById } from "@/lib/content/queries";
+import { isCourseInMaintenance } from "@/lib/content/deployments";
+import { isPlatformFrozen } from "@/lib/platform/freeze";
+import { checkCapstoneCredentialGate } from "@/lib/credentials/capstone-gate";
+import { createAdminClient } from "@/lib/supabase/admin";
+import type { Database } from "@/lib/supabase/types";
+import {
+  fetchAchievementReceipt,
+  fetchEnrollment,
+  fetchCourse,
+} from "./academy-reads";
 import {
   getConnection,
   awardAchievement,
   finalizeCourse,
   issueCredential,
 } from "./academy-program";
-import {
-  fetchAchievementReceipt,
-  fetchEnrollment,
-  fetchCourse,
-} from "./academy-reads";
-import { getCourseById } from "@/lib/content/queries";
-import { isCourseInMaintenance } from "@/lib/content/deployments";
-import { isPlatformFrozen } from "@/lib/platform/freeze";
-import { createAdminClient } from "@/lib/supabase/admin";
-import type { Database } from "@/lib/supabase/types";
+import { getProgramId } from "./pda";
 
 type OnchainActionType =
   | "achievement"
@@ -178,6 +179,27 @@ export async function retryPendingOnchainActions(
 
           // Already issued on-chain — just resolve the queue entry
           if (enrollment?.credential_asset) break;
+
+          // LX-E2 — re-run the capstone gate HERE too: a `certificate` row
+          // queued by the webhook (e.g. the deploy save lagged behind finalize)
+          // must never be minted ungated by the drainer. `deploy_required` /
+          // `indeterminate` DEFER without burning a retry (mirrors the
+          // maintenance defer), so a capstone credential lands once the
+          // verified deploy row appears — and never before. Runs after the
+          // already-issued short-circuit above, so pre-gate holders resolve
+          // cleanly (grandfathered).
+          const gate = await checkCapstoneCredentialGate(
+            adminClient,
+            userId,
+            courseId
+          );
+          if (
+            gate.status === "deploy_required" ||
+            gate.status === "indeterminate"
+          ) {
+            await deferForCapstoneGate(adminClient, row, courseId, gate.status);
+            continue;
+          }
 
           // Derive all fields fresh from the content bundle + on-chain (self-sufficient retry)
           const sanityCourse = await getCourseById(courseId);
@@ -638,6 +660,33 @@ async function deferForCourseMaintenance(
     const message = err instanceof Error ? err.message : String(err);
     console.error(
       `[onchain-queue] ${courseId}: failed to write maintenance-defer marker for row ${row.id}: ${message}`
+    );
+  }
+}
+
+// LX-E2 capstone-gate deferral. Same contract as deferForCourseMaintenance:
+// leave the row unresolved, record why, and do NOT touch retry_count, so a
+// capstone credential queued before its verified deploy is neither minted
+// ungated nor abandoned (the < 5 retry budget is never burned). The next drain
+// re-checks the gate and mints the moment the `deployed_programs` row appears.
+// Log-and-swallow a marker-write failure for the same F5 reason: a transient DB
+// error must not fall through to the caller's outer catch and bump retry_count.
+async function deferForCapstoneGate(
+  adminClient: AdminClient,
+  row: PendingActionRow,
+  courseId: string,
+  reason: string
+): Promise<void> {
+  try {
+    const { error } = await adminClient
+      .from("pending_onchain_actions")
+      .update({ last_error: `capstone-gate-${reason}:${courseId}` })
+      .eq("id", row.id);
+    if (error) throw new Error(error.message);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(
+      `[onchain-queue] ${courseId}: failed to write capstone-gate-defer marker for row ${row.id}: ${message}`
     );
   }
 }

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -399,6 +399,7 @@
     "unknownError": "Unknown error",
     "courseComplete": "Course complete! Mint your NFT certificate.",
     "mintDescription": "Claim your on-chain certificate as an NFT on Solana Devnet.",
+    "deployRequired": "Deploy your capstone program to devnet to unlock this credential.",
     "completed": "Completed",
     "mint": "Mint",
     "collection": "Superteam Academy Certificates",

--- a/apps/web/src/messages/es.json
+++ b/apps/web/src/messages/es.json
@@ -399,6 +399,7 @@
     "unknownError": "Error desconocido",
     "courseComplete": "¡Curso completado! Emite tu certificado NFT.",
     "mintDescription": "Reclama tu certificado on-chain como NFT en Solana Devnet.",
+    "deployRequired": "Despliega tu programa capstone en devnet para desbloquear esta credencial.",
     "completed": "Completado",
     "mint": "Mint",
     "collection": "Superteam Academy Certificates",

--- a/apps/web/src/messages/pt-BR.json
+++ b/apps/web/src/messages/pt-BR.json
@@ -399,6 +399,7 @@
     "unknownError": "Erro desconhecido",
     "courseComplete": "Curso concluído! Emita seu certificado NFT.",
     "mintDescription": "Reivindique seu certificado on-chain como NFT na Solana Devnet.",
+    "deployRequired": "Faça o deploy do seu programa capstone na devnet para desbloquear esta credencial.",
     "completed": "Concluído",
     "mint": "Mint",
     "collection": "Superteam Academy Certificates",


### PR DESCRIPTION
Closes #561 · spec task **LX-E2** (`docs/superpowers/specs/2026-07-25-launch-experience-master-spec.md` §3).

## What

Withhold the **capstone course** credential until the learner's graded deploy is **verified** — a `deployed_programs` row for the capstone deploy lesson, which is written only by the on-chain-verified `/api/deploy/save` (#620 / LX-E1). Every other course's credential, and all XP, are unchanged.

## Why

Owner decision **O-2**: the capstone is follow-along; the credential must attest a real deployed program ("deployed a Solana program"), not attendance. `deployed_programs` is on-chain-verified (executable + upgrade-authority-is-the-learner), so a row is a genuine artifact.

## How — three mint paths, one shared gate

New `apps/web/src/lib/credentials/capstone-gate.ts`: an app-side capstone constant (`course-building-first-program` / `lesson-bfsp-m4-capstone`) + `checkCapstoneCredentialGate`, which is **fail-closed** (`indeterminate` never returns `allowed`). The constant is asserted against the committed content bundle so a content rename fails the test instead of silently denying every capstone.

1. **Webhook** (`event-handlers.ts` `tryIssueCredential`): `finalize_course` + completion-bonus XP proceed on lesson completion **as today**; only `issue_credential` gains the gate. `deploy_required`/`indeterminate` → throw → deferred onto the existing `certificate` queue.
2. **Manual mint** (`POST /api/certificates/mint`): returns a stable `capstone_deploy_required` code (403) — localized client-side in `course-completion-mint.tsx` across en / pt-BR / es — or fail-closed 503 on `indeterminate`.
3. **Login drainer** (`onchain-queue.ts` `certificate` case): the same gate runs here too, so a queued capstone certificate can **never** mint ungated on the next drain. Defers **without burning the retry budget** (mirrors the maintenance defer), so it lands the moment the verified deploy row appears — and never before.

**Grandfathering:** all three paths short-circuit on an already-issued credential (`credential_asset` / existing `certificates` row) **before** the gate, so pre-gate devnet certs stay valid and are never re-evaluated.

No program change; server-route + queue logic only.

## LX-E2 acceptance criteria

- [x] Credential mints only with a verified deploy (capstone course)
- [x] Completion-XP timing unchanged (`finalize_course` + bonus XP proceed; gate guards only `issue_credential`) — regression test on `handleCourseFinalized`
- [x] Manual mint route returns a specific, localized "deploy required" state (`capstone_deploy_required` → `certificates.deployRequired`, x3 locales)
- [x] Fail-closed on indeterminate deploy state (defer/deny, never issue)
- [x] Manual mint gated **and** the login-drainer mint path gated (else a deferred capstone mints ungated on next login)
- [x] Capstone identity is an app-side constant, asserted against the content bundle
- [x] Grandfather pre-gate devnet certs
- [x] No program / on-chain change

## Verification

- `pnpm install --frozen-lockfile` ✓
- `pnpm typecheck` ✓ (6/6 packages)
- `pnpm --filter web test` ✓ — **176 files, 1545 tests passing**
- `pnpm lint` ✓ (exit 0, no new errors)
- New tests (21): gate unit + bundle-constant assertions (9), webhook gate + XP-untouched regression (5), manual-mint gate (4), drainer defer/allow (3)

Zero `any`, strict TS. Do **not** merge — awaiting gate review + owner sign-off.