### PR TITLE
content: bump content.lock to 1b74e4a6 — C2 staged + CARRY tutorNotes + C5/template explanations

### DIFF
--- a/apps/web/content.lock
+++ b/apps/web/content.lock
@@ -1,4 +1,4 @@
 {
   "repo": "solanabr/courses-academy",
-  "sha": "e1190680421e8190ab4deb9b41376667abc7a398"
+  "sha": "1b74e4a60f8813374219451b60436af832df2d91"
 }

--- a/apps/web/src/content/generated/courses.json
+++ b/apps/web/src/content/generated/courses.json
@@ -418,6 +418,174 @@
     "xpReward": 1000
   },
   {
+    "_id": "course-rust-for-program-devs",
+    "_type": "course",
+    "creator": "B7o8NfV81HzjuZFWQTTx3Xdvh77Dqoajwib3kWEnvzJF",
+    "creatorRewardXp": 30,
+    "description": "You can read a Solana account's bytes. You cannot yet write the struct those bytes came from. You finish this course holding `vault_core.rs` — a `VaultState` with `owner`, `balance` and `bump`, `deposit` and `withdraw` built on `checked_add`/`checked_sub` so a `u64` can never silently wrap, a `VaultError` enum with four named variants, and not one `unwrap()` — compiled green against the real Anchor 1.x toolchain on our build server. Nothing is installed locally — no rustup, no cargo, no `.so` upload. Ownership, borrowing and lifetimes are taught here rather than deferred, because `Account<'info, Vault>` is unreadable without them. Your file deliberately carries no `#[program]` and no `#[derive(Accounts)]` — that omission is the handoff, and Course 3 is what wraps around it.",
+    "difficulty": "intermediate",
+    "duration": 12,
+    "minCompletionsForReward": 10,
+    "modules": [
+      {
+        "_key": "rpd-rust-that-compiles",
+        "_type": "courseModule",
+        "description": "Get a green build before learning any syntax, then meet exactly the types the vault needs — `u64` lamports, `u8` bump, `i64` timestamps — and the compiler's opinions about mutability, tail expressions and the missing `return`. You end holding a file of your own — two `const fn` helpers that add and subtract lamports and return `None` on overflow or underflow instead of wrapping or panicking, verified by compile-time assertions. That arithmetic becomes `VaultState::withdraw` nine lessons later.",
+        "key": "rpd-rust-that-compiles",
+        "lessons": [
+          {
+            "_key": "lesson-rpd-your-first-rust-build",
+            "_ref": "lesson-rpd-your-first-rust-build",
+            "_type": "reference",
+            "_weak": true
+          },
+          {
+            "_key": "lesson-rpd-types-and-mutability",
+            "_ref": "lesson-rpd-types-and-mutability",
+            "_type": "reference",
+            "_weak": true
+          },
+          {
+            "_key": "lesson-rpd-functions-and-control-flow",
+            "_ref": "lesson-rpd-functions-and-control-flow",
+            "_type": "reference",
+            "_weak": true
+          },
+          {
+            "_key": "lesson-rpd-checked-lamport-math",
+            "_ref": "lesson-rpd-checked-lamport-math",
+            "_type": "reference",
+            "_weak": true
+          }
+        ],
+        "title": "Rust That Compiles"
+      },
+      {
+        "_key": "rpd-ownership-borrowing-lifetimes",
+        "_type": "courseModule",
+        "description": "Moves, `Copy`, `.clone()`, shared versus mutable borrows, and lifetimes — taught against account-shaped signatures instead of toy strings, and with the compiler as the teacher. You read four real borrow-checker errors (E0382, E0502, E0499, and a reference outliving its local) and repair each one. You leave with three functions compiling in your own file — `balance_of(&VaultLike) -> u64`, `credit(&mut VaultLike, u64)` and `discriminator(&[u8]) -> Option<&[u8]>`, a real borrowed reader over Anchor's 8-byte discriminator. The first two are the exact method receivers you write in module 4, and the `'info` in `Account<'info, Vault>` stops being noise.",
+        "key": "rpd-ownership-borrowing-lifetimes",
+        "lessons": [
+          {
+            "_key": "lesson-rpd-moves-copy-and-clone",
+            "_ref": "lesson-rpd-moves-copy-and-clone",
+            "_type": "reference",
+            "_weak": true
+          },
+          {
+            "_key": "lesson-rpd-borrowing-shared-vs-mutable",
+            "_ref": "lesson-rpd-borrowing-shared-vs-mutable",
+            "_type": "reference",
+            "_weak": true
+          },
+          {
+            "_key": "lesson-rpd-fix-the-borrow-checker",
+            "_ref": "lesson-rpd-fix-the-borrow-checker",
+            "_type": "reference",
+            "_weak": true
+          },
+          {
+            "_key": "lesson-rpd-lifetimes-and-slices",
+            "_ref": "lesson-rpd-lifetimes-and-slices",
+            "_type": "reference",
+            "_weak": true
+          },
+          {
+            "_key": "lesson-rpd-ownership-checkpoint",
+            "_ref": "lesson-rpd-ownership-checkpoint",
+            "_type": "reference",
+            "_weak": true
+          }
+        ],
+        "title": "Ownership, Borrowing, Lifetimes"
+      },
+      {
+        "_key": "rpd-modeling-state",
+        "_type": "courseModule",
+        "description": "The vault's data model, compiling. Define `VaultState` and hand-write one of the traits `#[derive]` would have generated, so the macro stops being magic and the byte layout stops being a mystery. Define `VaultError`, then add a fifth variant just to watch the compiler enumerate every site you failed to handle. Finally, replace panics with `Result` and let `?` carry errors up a chain of fallible functions, converting between error types on the way through.",
+        "key": "rpd-modeling-state",
+        "lessons": [
+          {
+            "_key": "lesson-rpd-structs-traits-and-derives",
+            "_ref": "lesson-rpd-structs-traits-and-derives",
+            "_type": "reference",
+            "_weak": true
+          },
+          {
+            "_key": "lesson-rpd-enums-option-result",
+            "_ref": "lesson-rpd-enums-option-result",
+            "_type": "reference",
+            "_weak": true
+          },
+          {
+            "_key": "lesson-rpd-error-plumbing",
+            "_ref": "lesson-rpd-error-plumbing",
+            "_type": "reference",
+            "_weak": true
+          }
+        ],
+        "title": "Modeling State: Structs, Enums, Result"
+      },
+      {
+        "_key": "rpd-the-vault-core",
+        "_type": "courseModule",
+        "description": "Write the whole core — `VaultState`, checked `deposit` and `withdraw`, `VaultError`, an inline `mod` and its `use` — first by completing a given skeleton, then from signatures alone against a fixed verification harness you are not allowed to edit. You close by rereading your own file line by line, mapping each line back to the lesson that produced it, and copying it out. `vault_core.rs` is the named input to Course 3.",
+        "key": "rpd-the-vault-core",
+        "lessons": [
+          {
+            "_key": "lesson-rpd-build-the-vault-core",
+            "_ref": "lesson-rpd-build-the-vault-core",
+            "_type": "reference",
+            "_weak": true
+          },
+          {
+            "_key": "lesson-rpd-what-you-built",
+            "_ref": "lesson-rpd-what-you-built",
+            "_type": "reference",
+            "_weak": true
+          }
+        ],
+        "title": "The Vault Core"
+      }
+    ],
+    "slug": {
+      "_type": "slug",
+      "current": "rust-for-program-devs"
+    },
+    "tags": [
+      "account-layout",
+      "anchor",
+      "borsh-serialization",
+      "build-server",
+      "checked-arithmetic",
+      "compiler-errors",
+      "debugging",
+      "error-handling",
+      "pdas",
+      "program-security",
+      "rust",
+      "rust-borrowing",
+      "rust-control-flow",
+      "rust-enums",
+      "rust-lifetimes",
+      "rust-modules",
+      "rust-move-semantics",
+      "rust-option",
+      "rust-ownership",
+      "rust-result",
+      "rust-slices",
+      "rust-structs",
+      "rust-traits",
+      "rust-types",
+      "toolchain-versions"
+    ],
+    "title": "Rust for Program Developers",
+    "trackId": 1,
+    "trackLevel": 2,
+    "xpPerLesson": 20,
+    "xpReward": 800
+  },
+  {
     "_id": "course-rust-for-solana",
     "_type": "course",
     "creator": "B7o8NfV81HzjuZFWQTTx3Xdvh77Dqoajwib3kWEnvzJF",

--- a/apps/web/src/content/generated/lessons.json
+++ b/apps/web/src/content/generated/lessons.json
@@ -1484,6 +1484,14 @@
             "id": "test-deploy-1",
             "input": ""
           }
+        ],
+        "tutorNotes": [
+          "Learners hit a mid-deploy failure and restart from zero, re-uploading chunks that already landed, instead of clicking Resume, which skips the confirmed ones.",
+          "They run out of devnet SOL partway through the 200+ upload transactions and read the abort as a code bug; the buffer and fees simply drained the wallet — fund it and Resume.",
+          "They deploy with the wallet or CLI pointed at the wrong cluster, so a devnet program seems to vanish when they look for it on mainnet, or the deploy fails against an unfunded network.",
+          "They rebuild after a failed deploy and expect the same Program ID; a fresh program keypair yields a new id, so they then search the explorer for the old one and find nothing.",
+          "They reject or ignore one of the batch-signing popups and treat the stalled upload as a crash, rather than approving the next batch so the chunks keep confirming.",
+          "They read the green build check as a finished deploy — building only produced the `.so`; the on-chain upload is the separate step happening here."
         ]
       },
       {
@@ -1859,6 +1867,13 @@
             "id": "test-1",
             "input": ""
           }
+        ],
+        "tutorNotes": [
+          "Learners edit the starter to feel productive, but it already compiles unchanged; a broken build here is almost always a self-inflicted edit, and the fix is Reset Code, not a new one.",
+          "They read the slow first build (dependencies downloading) or a timeout as a real failure and give up, instead of simply clicking Build again as the hints say.",
+          "They expect a local `cargo build` on their own machine and are thrown that compilation runs on the build server through the sbf toolchain, not their terminal.",
+          "They treat a compiler warning as the error and chase it, missing that the build actually succeeded — a green check means the `.so` compiled and there is nothing to fix.",
+          "They take the green check to mean the program is deployed and live on devnet, and go hunting for it on-chain; building only produced a binary — deployment is a later lesson."
         ]
       },
       {
@@ -3293,6 +3308,2560 @@
     "title": "Solana RPC Methods"
   },
   {
+    "_id": "lesson-rpd-borrowing-shared-vs-mutable",
+    "_type": "lesson",
+    "blocks": [
+      {
+        "_key": "intro",
+        "_type": "prose",
+        "src": "# Borrowing: `&T` and `&mut T`\n\n> **Version stamp — checked 2026-07-26.** `anchor-lang 1.1.2` (crates.io latest stable) · `borsh` 1.5.7 declared / **1.8.0** resolved · edition 2021 · Agave ≥ 3.1.10 / rustc per the build server's pinned platform-tools.\n\nMoving a value into a function and getting it back out is unbearable. Real code needs to look at a vault without consuming it, and change a vault without rebuilding it. That is borrowing, and there are exactly two kinds.\n\n| | Written | How many at once | What it grants |\n| --- | --- | --- | --- |\n| **Shared borrow** | `&VaultLike` | Any number | Read every field |\n| **Mutable borrow** | `&mut VaultLike` | Exactly one | Read and write every field |\n\nAnd the rule that connects them: **while a mutable borrow is alive, no other borrow of that value may exist — shared or mutable.** Many readers, or one writer. Never both.\n\nThis is the same invariant as the runtime's account locks from Course 1. A transaction declares each account as readonly or writable, and the scheduler will not run two transactions that write the same account concurrently. Rust applies that rule to a value inside your function, at compile time, for free. The reason you are learning it here rather than in Course 3 is that `&mut Account<'info, Vault>` is unreadable until this table is boring.\n\n## Two signatures, and they are the ones you keep\n\n```rust\npub fn balance_of(v: &VaultLike) -> u64;\npub fn credit(v: &mut VaultLike, amount: u64);\n```\n\nRead them out loud as promises to the caller. The first says: *I will look and I will not touch, and you keep your vault.* The second says: *for the duration of this call the vault is mine alone, and then you get it back changed.*\n\nIn module 4 these become methods and the receiver moves to the front, which is the only difference:\n\n```rust\nimpl VaultState {\n    pub fn balance(&self) -> u64;\n    pub fn deposit(&mut self, amount: u64) -> Result<()>;\n}\n```\n\n`&self` is `&VaultState`. `&mut self` is `&mut VaultState`. There is no third thing to learn later.\n\n## `mut` in two places, meaning two things\n\n```rust\nlet mut vault = sample_vault();   // (1) this BINDING may be reassigned or mutated\ncredit(&mut vault, 1_000);        // (2) hand out an exclusive borrow\n```\n\n`let mut` is about the variable you own. `&mut` is about the loan you give away. A caller needs (1) before it can produce (2) — you cannot lend out write access to something you were not allowed to write yourself.\n\n## When does a borrow end?\n\nHere is where most \"why is this still borrowed?\" confusion comes from. Since the 2018 edition, a borrow ends **at its last use**, not at the closing brace of the block. This is called non-lexical lifetimes, and it is why this compiles:\n\n```rust\nlet mut vault = sample_vault();\nlet before = balance_of(&vault);   // shared borrow starts and ends on this line\ncredit(&mut vault, 1_000);         // fine — nothing is borrowed any more\n```\n\nand why the near-identical version below does **not**:\n\n```rust\nlet mut vault = sample_vault();\nlet before = &vault.balance;       // shared borrow starts …\ncredit(&mut vault, 1_000);         // … mutable borrow while it is alive\nmsg!(\"{}\", before);                // … and it is used AFTER, so it is still alive here\n```\n\nDelete that last line and the second version compiles too. The borrow was never a problem in itself — holding it *across* the mutation was. A great deal of Rust advice written before 2018 tells you borrows run to end of scope. It is out of date, and following it makes you write scopes and `drop()` calls you do not need.\n\nThe fix in the first version is worth naming, because it is the payoff from the previous lesson: `balance_of` returns a `u64` **by value**. `u64` is `Copy`, so you hold a number, not a loan, and there is nothing left to conflict with.\n\n## One honest gap\n\n`credit` has no way to report failure. Its return type is `()`.\n\nSo when `add_lamports` hands back `None` — the addition would have wrapped a `u64` — the only thing this version can do is leave the balance untouched and say nothing. **That is not acceptable in a program.** A deposit that silently does nothing is a support ticket at best and an exploit at worst.\n\nIt is a deliberate placeholder, and closing it is what module 3 is for: `credit` grows a `-> Result<()>`, the `None` arm becomes `err!(VaultError::Overflow)`, and the caller is forced by the compiler to deal with it. Write the placeholder now, know that it is one, and do not carry the pattern into anything real.\n\n## Three subgoals\n\nThe exercise ships three numbered subgoals as comment headers. The first is done for you as a worked reference; you write the second and third. Read all three headers before you start — the third one is the borrow-checker lesson, and knowing it is coming changes how you write the second.\n\nThe file does not build as delivered: each unwritten body carries a `compile_error!` naming its subgoal, so your first build is a to-do list rather than a green tick. Delete each one along with the `todo!()` beneath it.\n\nA note on what the grader can see. The build server checks that your file **compiles**; it does not run your functions. The `mod verify` block at the bottom is not editable and pins all three functions to their exact signatures, borrows included — rename one, or take `VaultLike` by value instead of by reference, and the build stops. That is a check on names and types only. Nothing verifies that `credit` adds rather than subtracts.\n\nNothing verifies subgoal 3's ordering either, and it is worth being exact about why, because the temptation is to assume the borrow checker has your back here. It does not. `E0502` fires for **one specific shape**: holding `&v.balance` across the call to `credit` and then using it afterwards. The spec tells you not to write that — bind the `u64` by value instead — and once you do, there is no borrow left for the checker to have an opinion about. Write `credit(v, …)` first and read the balance second and the file compiles clean.\n\nSo the compile-time guarantee here is narrow and real: *if* you hold a reference across a mutation, you are stopped. The wider thing — that the read happens before the write — is checked by you. Which is the honest version of every exercise in this course, and the reason lesson 9 spends a whole lesson on diagnosing code you have not built.\n"
+      },
+      {
+        "_key": "exercise",
+        "_type": "code",
+        "buildType": "buildable",
+        "deployable": false,
+        "hints": [
+          "Subgoal 2 is four lines. `if let Some(new_balance) = add_lamports(v.balance, amount) { … }` — and the `None` case is deliberately nothing at all.",
+          "Subgoal 3, step 1: `let current = balance_of(v);`. You are passing the `&mut` where a `&` is expected, which Rust does for you as a reborrow. Bind the `u64` it returns — do not bind `&v.balance`.",
+          "Subgoal 3, step 2: `match sub_lamports(target, current) { Some(gap) => gap, None => 0 }`. `sub_lamports` returning `None` means `target` is below the current balance, so there is nothing to add."
+        ],
+        "language": "rust",
+        "solution": "// ---------------------------------------------------------------------------\n// Lesson 6 — Borrowing: &T and &mut T.\n//\n// Reference solution. All three subgoals filled in.\n//\n// Toolchain: anchor-lang 1.1.2 (declared) · borsh 1.5.7 declared / 1.8.0\n// resolved · edition 2021.\n// ---------------------------------------------------------------------------\n\nuse anchor_lang::prelude::*;\n\n#[derive(Clone, Debug)]\npub struct VaultLike {\n    pub owner: Pubkey,\n    pub balance: u64,\n    pub bump: u8,\n}\n\npub fn sample_vault() -> VaultLike {\n    VaultLike {\n        owner: Pubkey::default(),\n        balance: 500_000,\n        bump: 254,\n    }\n}\n\n// Carried forward from lesson 4, unchanged — same names, same parameter names,\n// same signatures. `None` means the operation would have wrapped a u64, which is\n// the failure the whole course exists to prevent.\npub const fn add_lamports(balance: u64, amount: u64) -> Option<u64> {\n    balance.checked_add(amount)\n}\n\npub const fn sub_lamports(balance: u64, amount: u64) -> Option<u64> {\n    balance.checked_sub(amount)\n}\n\n// ===== Subgoal 1 of 3 — read through a shared borrow =======================\n//\n// DONE FOR YOU. Read it before you write anything else.\n//\n// `&VaultLike` is a shared borrow: read access to every field, no write access,\n// and the caller keeps the vault. The return type is `u64` BY VALUE, not\n// `&u64` — `u64` is `Copy`, so the caller walks away holding a number rather\n// than a loan. That choice is what makes subgoal 3 possible.\npub fn balance_of(v: &VaultLike) -> u64 {\n    v.balance\n}\n\n// ===== Subgoal 2 of 3 — write through a mutable borrow =====================\n//\n// `&mut` grants write access to every field, so `v.balance = …` is legal here\n// and would not be legal through `&VaultLike`.\n//\n// `if let Some(x) = …` is `match` with one arm named and the other ignored. The\n// ignored arm is the honest gap: on overflow the balance is left as it was and\n// nobody is told. Module 3 turns that arm into `err!(VaultError::Overflow)`.\npub fn credit(v: &mut VaultLike, amount: u64) {\n    if let Some(new_balance) = add_lamports(v.balance, amount) {\n        v.balance = new_balance;\n    }\n}\n\n// ===== Subgoal 3 of 3 — read, then write, without overlapping =============\n//\n// `balance_of(v)` takes `&*v` — a shared reborrow of the exclusive borrow you\n// were handed — and returns a `u64` by value. The reborrow is over by the end\n// of the line, so `credit(v, …)` gets its exclusive access with nothing to\n// argue about.\n//\n// Had step 1 been `let current = &v.balance;`, the shared borrow would still be\n// alive at step 3 only if something used it afterwards. Holding a `Copy` value\n// instead of a reference removes the question from the code entirely, which is\n// the reason `balance_of` returns `u64` and not `&u64`.\n//\n// And note what that costs: with no borrow held, nothing stops you writing the\n// two statements the other way round. `credit(v, 1); let current = balance_of(v);`\n// compiles perfectly well. The order below is correct because it is the order a\n// transfer has to happen in, not because the compiler insisted.\npub fn top_up_to(v: &mut VaultLike, target: u64) -> u64 {\n    let current = balance_of(v);\n\n    let shortfall = match sub_lamports(target, current) {\n        Some(gap) => gap,\n        None => 0, // already at or above target\n    };\n\n    credit(v, shortfall);\n    shortfall\n}\n\n// ===== Given: a caller, so you can see the shapes meet ====================\n//\n// Note `let mut` on the binding. Without it you could not produce `&mut vault`\n// on the following line — you cannot lend out write access you do not have.\npub fn demo() -> (u64, u64) {\n    let mut vault = sample_vault();\n\n    let added = top_up_to(&mut vault, 750_000);\n    let now = balance_of(&vault);\n\n    (added, now) // expect (250_000, 750_000)\n}\n\n// ── DO NOT EDIT ──────────────────────────────────────────────────────────────\n// Pins the three functions above to their exact signatures. If one is renamed,\n// or a borrow turns into a by-value parameter, or a return type drifts, this\n// stops compiling.\n//\n// It checks names and types — NOT what your bodies compute. It cannot tell\n// `add_lamports` from `sub_lamports`, and it cannot see whether subgoal 3 reads\n// before it writes either. The borrow checker catches exactly one wrong shape —\n// holding `&v.balance` across `credit` and using it afterwards, which is E0502.\n// Read the balance by value, as the spec says, and there is no borrow left to\n// complain about: writing first and reading second compiles clean. The ordering\n// is on you.\n#[allow(dead_code)]\nmod verify {\n    use super::*;\n\n    const _BALANCE_OF: fn(&VaultLike) -> u64 = balance_of;\n    const _CREDIT: fn(&mut VaultLike, u64) = credit;\n    const _TOP_UP_TO: fn(&mut VaultLike, u64) -> u64 = top_up_to;\n}\n",
+        "starter": "// ---------------------------------------------------------------------------\n// Lesson 6 — Borrowing: &T and &mut T.\n//\n// Three numbered subgoals below. Subgoal 1 is done for you as a reference;\n// you write 2 and 3. Replace each `todo!()` — it is a placeholder that panics,\n// and nothing that panics belongs in a finished program.\n//\n// As shipped this file does NOT build. Each unwritten body carries a\n// `compile_error!` line whose message names the subgoal it belongs to, so the\n// first build tells you exactly what is outstanding. Delete that line together\n// with the `todo!()` under it when you write the body. This is deliberate:\n// `todo!()` alone type-checks fine, so a file full of them would compile green\n// and tell you nothing.\n//\n// Toolchain: anchor-lang 1.1.2 (declared) · borsh 1.5.7 declared / 1.8.0\n// resolved · edition 2021.\n// ---------------------------------------------------------------------------\n\nuse anchor_lang::prelude::*;\n\n#[derive(Clone, Debug)]\npub struct VaultLike {\n    pub owner: Pubkey,\n    pub balance: u64,\n    pub bump: u8,\n}\n\npub fn sample_vault() -> VaultLike {\n    VaultLike {\n        owner: Pubkey::default(),\n        balance: 500_000,\n        bump: 254,\n    }\n}\n\n// Carried forward from lesson 4, unchanged — same names, same parameter names,\n// same signatures. `None` means the operation would have wrapped a u64, which is\n// the failure the whole course exists to prevent.\npub const fn add_lamports(balance: u64, amount: u64) -> Option<u64> {\n    balance.checked_add(amount)\n}\n\npub const fn sub_lamports(balance: u64, amount: u64) -> Option<u64> {\n    balance.checked_sub(amount)\n}\n\n// ===== Subgoal 1 of 3 — read through a shared borrow =======================\n//\n// DONE FOR YOU. Read it before you write anything else.\n//\n// `&VaultLike` is a shared borrow: read access to every field, no write access,\n// and the caller keeps the vault. The return type is `u64` BY VALUE, not\n// `&u64` — `u64` is `Copy`, so the caller walks away holding a number rather\n// than a loan. That choice is what makes subgoal 3 possible.\npub fn balance_of(v: &VaultLike) -> u64 {\n    v.balance\n}\n\n// ===== Subgoal 2 of 3 — write through a mutable borrow =====================\n//\n// YOUR CODE. Add `amount` to the vault's balance.\n//\n//   - `&mut VaultLike` is exclusive: for the duration of this call nothing else\n//     may read or write this vault.\n//   - Use `add_lamports`, not `+`. Never let a u64 wrap.\n//   - `add_lamports` returns `Option<u64>`. Handle BOTH arms with `match` or\n//     `if let`. On `Some(new_balance)`, store it. On `None`, leave the balance\n//     exactly as it was — this function has no way to report a failure, which\n//     is a known gap that module 3 closes with `Result`.\npub fn credit(v: &mut VaultLike, amount: u64) {\n    compile_error!(\"Subgoal 2 of 3 is not written yet: give `credit` a body that adds `amount` via `add_lamports` and handles both arms. Delete this line and the `todo!()` below it.\");\n    todo!()\n}\n\n// ===== Subgoal 3 of 3 — read, then write, without overlapping =============\n//\n// YOUR CODE. Raise the balance up to `target` and return how much you added.\n// If the balance already meets or exceeds `target`, add nothing and return 0.\n//\n// The order matters. The borrow checker will only tell you so if you write step 1\n// the wrong way — see the note under step 4:\n//\n//   1. Get the current balance. Call `balance_of(v)` and bind the u64 it\n//      returns. Do NOT write `let before = &v.balance;` — see the note below.\n//   2. Compute the shortfall with `sub_lamports(target, current)`. On `None`\n//      (target is below the current balance) the answer is 0.\n//   3. Call `credit(v, shortfall)`. This needs the mutable borrow, and it can\n//      only have it if step 1 is finished with the vault.\n//   4. Return the shortfall.\n//\n// Note for step 1: `&v.balance` would hold a shared borrow, and step 3 needs an\n// exclusive one. Whether that is an error depends on whether the shared borrow\n// is still used after step 3 — a borrow ends at its LAST USE, not at the\n// closing brace. Binding the u64 by value sidesteps the question entirely.\n//\n// Which means: once you follow that advice, nothing enforces the order. Writing\n// step 3 before step 1 compiles clean. The order is correct because a transfer\n// has to read before it commits, not because rustc made you.\npub fn top_up_to(v: &mut VaultLike, target: u64) -> u64 {\n    compile_error!(\"Subgoal 3 of 3 is not written yet: read the balance, compute the shortfall, credit it, return it. Delete this line and the `todo!()` below it.\");\n    todo!()\n}\n\n// ===== Given: a caller, so you can see the shapes meet ====================\n//\n// Note `let mut` on the binding. Without it you could not produce `&mut vault`\n// on the following line — you cannot lend out write access you do not have.\npub fn demo() -> (u64, u64) {\n    let mut vault = sample_vault();\n\n    let added = top_up_to(&mut vault, 750_000);\n    let now = balance_of(&vault);\n\n    (added, now) // expect (250_000, 750_000)\n}\n\n// ── DO NOT EDIT ──────────────────────────────────────────────────────────────\n// Pins the three functions above to their exact signatures. If one is renamed,\n// or a borrow turns into a by-value parameter, or a return type drifts, this\n// stops compiling.\n//\n// It checks names and types — NOT what your bodies compute. It cannot tell\n// `add_lamports` from `sub_lamports`, and it cannot see whether subgoal 3 reads\n// before it writes either. The borrow checker catches exactly one wrong shape —\n// holding `&v.balance` across `credit` and using it afterwards, which is E0502.\n// Read the balance by value, as the spec says, and there is no borrow left to\n// complain about: writing first and reading second compiles clean. The ordering\n// is on you.\n#[allow(dead_code)]\nmod verify {\n    use super::*;\n\n    const _BALANCE_OF: fn(&VaultLike) -> u64 = balance_of;\n    const _CREDIT: fn(&mut VaultLike, u64) = credit;\n    const _TOP_UP_TO: fn(&mut VaultLike, u64) -> u64 = top_up_to;\n}\n",
+        "tests": [
+          {
+            "description": "The file compiles against anchor-lang 1.1.2 on the build server",
+            "expectedOutput": "true",
+            "id": "test-1",
+            "input": ""
+          },
+          {
+            "description": "Compiles ⇒ both unwritten bodies were replaced: the shipped starter carries a `compile_error!` per subgoal, so a file that still has one cannot build",
+            "expectedOutput": "true",
+            "id": "test-2",
+            "input": ""
+          },
+          {
+            "description": "Compiles ⇒ the non-editable `mod verify` block resolves: balance_of, credit and top_up_to exist with the exact declared signatures, borrows included. Note what this cannot see: it checks names and types, not what a body computes",
+            "expectedOutput": "true",
+            "id": "test-3",
+            "input": ""
+          }
+        ]
+      },
+      {
+        "_key": "check",
+        "_type": "quiz",
+        "questions": [
+          {
+            "explanation": "The message is worth memorising: \"cannot borrow `*v` as mutable because it is also borrowed as immutable\". It names the mutable borrow as the offender, but the fix almost always belongs to the shared one.",
+            "id": "q1",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "`E0502` as written; deleting the last line makes it compile, because a borrow ends at its last use"
+              },
+              {
+                "correct": false,
+                "feedback": "That was true before the 2018 edition, and a lot of surviving blog posts still say it. Non-lexical lifetimes end a borrow at its last use, which is why removing the use removes the conflict.",
+                "id": "b",
+                "label": "`E0502` either way — the shared borrow lives until the closing brace of the function"
+              },
+              {
+                "correct": false,
+                "feedback": "It is the forbidden combination. Any number of shared borrows, or exactly one mutable borrow, never a mix — that is the whole rule.",
+                "id": "c",
+                "label": "Compiles as written — `before` is a `&u64`, and one shared borrow plus one mutable borrow is the allowed combination"
+              },
+              {
+                "correct": false,
+                "feedback": "This is the bug the rule exists to prevent — a reference that silently shows you stale data after a mutation. Rust does not let the reference survive the mutation, so there is no stale read to have.",
+                "id": "d",
+                "label": "Compiles, and `*before` reads the balance from before the credit"
+              }
+            ],
+            "prompt": "You write `let before = &v.balance;`, then `credit(v, 1_000);`, then `return *before;`. Predict the compiler's verdict — and what changes if you delete the last line."
+          },
+          {
+            "id": "q2",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "`E0594` — cannot assign to `v.balance`, which is behind a `&` reference"
+              },
+              {
+                "correct": false,
+                "feedback": "What the field's type is does not matter. `&T` grants read access and nothing else, all the way down.",
+                "id": "b",
+                "label": "Compiles — the reference is shared, but the field is a plain `u64`"
+              },
+              {
+                "correct": false,
+                "feedback": "A call site cannot upgrade a shared borrow to an exclusive one. The signature is the promise, and this one promised not to write.",
+                "id": "c",
+                "label": "Compiles if the parameter is declared `v: &mut VaultLike` at the call site"
+              },
+              {
+                "correct": false,
+                "feedback": "Close but a different failure. `E0596` is what you get when you try to take `&mut` of a binding declared without `let mut`. Here nothing is being borrowed — an assignment is being attempted through a reference that forbids it.",
+                "id": "d",
+                "label": "`E0596` — cannot borrow as mutable, as it is not declared as mutable"
+              }
+            ],
+            "prompt": "Someone writes `pub fn zero_out(v: &VaultLike) { v.balance = 0; }`. Predict what happens."
+          },
+          {
+            "explanation": "Worth knowing early because it removes a class of imagined restrictions. The checker is more precise than the summary rule suggests, and the summary rule is about a single place, not a whole value.",
+            "id": "q3",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "Compiles — the two borrows are of different fields, and the borrow checker tracks fields separately"
+              },
+              {
+                "correct": false,
+                "feedback": "You did not borrow `v` twice; you borrowed two disjoint pieces of it. `E0499` fires when the two borrows genuinely overlap — for example `&mut v.balance` twice.",
+                "id": "b",
+                "label": "`E0499` — two mutable borrows of `v` cannot coexist"
+              },
+              {
+                "correct": false,
+                "feedback": "Blocks are the workaround for borrows that really do overlap. These do not, so no scoping trick is needed.",
+                "id": "c",
+                "label": "Compiles only if you wrap each borrow in its own block"
+              },
+              {
+                "correct": false,
+                "feedback": "It does not. Borrowing a field borrows that field's place, which is precisely what makes ordinary struct-mutating code writable without fighting the compiler.",
+                "id": "d",
+                "label": "`E0502` — a mutable borrow of a field implies a shared borrow of the whole struct"
+              }
+            ],
+            "prompt": "Inside `fn f(v: &mut VaultLike)` you write `let b = &mut v.balance;` and on the next line `let p = &mut v.bump;`, then use both. Predict the verdict."
+          },
+          {
+            "id": "q4",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "`E0596` — cannot borrow `vault` as mutable, as it is not declared as mutable"
+              },
+              {
+                "correct": false,
+                "feedback": "You cannot lend out write access you were never granted. `let mut` on the binding is what grants it; `&mut` at the call site is what passes it on.",
+                "id": "b",
+                "label": "Compiles — `&mut` at the call site is all that is needed to get write access"
+              },
+              {
+                "correct": false,
+                "feedback": "A mutable borrow is a loan, not a move. `credit` gives the vault back when it returns, which is exactly why the signature is `&mut VaultLike` and not `VaultLike`.",
+                "id": "c",
+                "label": "`E0382` — `&mut vault` moves the vault into `credit`"
+              },
+              {
+                "correct": false,
+                "feedback": "There is no hidden copy. That is JavaScript's pass-a-primitive behaviour; a Rust `&mut` points at the caller's own value, and silently copying instead would be a language bug.",
+                "id": "d",
+                "label": "Compiles, but `credit` mutates a temporary copy and the caller sees no change"
+              }
+            ],
+            "prompt": "Carried over from the previous lesson. You write `let vault = sample_vault();` and then `credit(&mut vault, 1_000);`. Predict what the compiler says."
+          }
+        ]
+      }
+    ],
+    "skills": [
+      "rust-borrowing",
+      "rust-ownership"
+    ],
+    "slug": {
+      "_type": "slug",
+      "current": "borrowing-shared-vs-mutable"
+    },
+    "title": "Borrowing: `&T` and `&mut T`"
+  },
+  {
+    "_id": "lesson-rpd-build-the-vault-core",
+    "_type": "lesson",
+    "blocks": [
+      {
+        "_key": "spec",
+        "_type": "prose",
+        "src": "# Build the Vault Core\n\n> **Version stamp — checked 2026-07-26.** `anchor-lang 1.1.2` (published 2026-06-26, latest on crates.io) · `borsh` resolves to **1.8.0** from the manifest's `borsh = \"1.5.7\"` · edition 2021 · Agave ≥ 3.1.10 · rustc 1.89+. Both exercises below were compiled clean against exactly that manifest on that date.\n\nTwelve lessons of parts. This is the assembly.\n\nYou have already written every piece of this file, each one somewhere else: `checked_sub` returning `None` in lesson 4, a `&mut self` receiver in lesson 6, a `#[derive]`d struct in lesson 10, a `#[error_code]` enum in lesson 11, `?` carrying an error up a chain in lesson 12. What you have not done is put them in one file and hand it to the build server.\n\nYou do it twice. The first exercise gives you the struct, the enum and the two method signatures, and scrambles the seven lines that go inside them — five belong, two do not. The second gives you this spec, a `mod vault` with nothing in it, and a verification harness you may not edit.\n\n## The spec\n\n`declare_id!` first, because it is the one line that looks optional and is not.\n\n```rust\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n```\n\nThat address is a placeholder — Course 3 replaces it with the program id of your own deployment. It has to be there today anyway: `#[account]` expands to an `impl Owner for VaultState` whose body reads `crate::ID`, and `declare_id!` is what defines `ID`. Delete the line and the compiler does not complain about the missing macro. It complains at your struct:\n\n```\nerror[E0425]: cannot find value `ID` in the crate root\n```\n\nWhich is a nice illustration of how macro-generated code fails: the error lands where the expansion happened, not where you made the mistake.\n\nThen the state, the errors and the two methods.\n\n| Item        | Exactly                                                                                                                |\n| ----------- | ---------------------------------------------------------------------------------------------------------------------- |\n| **Module**  | `pub mod vault { … }` — everything below lives inside it, and is re-exported from the crate root                        |\n| **State**   | `#[account]` + `#[derive(InitSpace)]` on `pub struct VaultState { pub owner: Pubkey, pub balance: u64, pub bump: u8 }`  |\n| **Errors**  | `#[error_code] pub enum VaultError` with exactly four variants: `Overflow`, `InsufficientFunds`, `ZeroAmount`, `NotOwner` |\n| **Deposit** | `pub fn deposit(&mut self, amount: u64) -> Result<()>`                                                                  |\n| **Withdraw**| `pub fn withdraw(&mut self, amount: u64) -> Result<()>`                                                                 |\n\nField names, field types, method names, parameter type and return type are all fixed. Course 3 wraps around this exact surface, and a client written against `balance` cannot read a field you decided to call `amount_held`.\n\n### Invariants\n\n1. **A zero amount is rejected before anything is written.** Both methods. `VaultError::ZeroAmount`.\n2. **`deposit` adds with `checked_add`** and returns `VaultError::Overflow` when it gets `None`.\n3. **`withdraw` subtracts with `checked_sub`** and returns `VaultError::InsufficientFunds` when it gets `None`.\n4. **No `unwrap()`, no `expect()`, no bare `+` or `-` on `balance`.** A panic inside a program is an aborted instruction carrying no error code — the caller gets a generic failure and no message. Turning `None` into a named variant is the entire point of the last nine lessons.\n5. **`balance` is only ever written through these two methods.** Nothing else in the file touches it.\n\n`NotOwner` is declared and never used, deliberately. It is the error Course 3's ownership constraint returns, and declaring the enum complete now means Course 3 adds a constraint rather than editing your error type. The harness checks only that the variant **exists** and converts — nothing in a compile-time check can observe which errors your code raises, and a `deposit` that returned `err!(VaultError::NotOwner)` compiles identically.\n\n## What is deliberately missing\n\nYour file has **no `#[program]` module and no `#[derive(Accounts)]` struct**. It is not an unfinished program. It is the half of a program that does not depend on the runtime — no accounts, no signers, no clock, no CPI — which is exactly the half you can check by reading. Course 3 supplies the other half and the tests that exercise this one. Lesson 14 spells the split out line by line.\n\n## One file, so modules are inline\n\nThe code block ships exactly one starter, and the manifest points at `src/lib.rs`, so everything you write is in one file. That is why the module is `pub mod vault { … }` written out inline rather than `mod vault;`. In a one-file crate `mod vault;` sends the compiler looking for `src/vault.rs`:\n\n```\nerror[E0583]: file not found for module `vault`\n```\n\nInline modules are not a workaround for the platform. They are how you namespace inside a file, and `use super::*;` at the top of the module body is what makes the crate root's imports — `Pubkey`, `Result`, `require!` — visible inside it. The crate root then needs one line to name the items back out:\n\n```rust\npub use vault::{VaultError, VaultState};\n```\n\nWithout it the items exist and nothing outside the module can say their names. The harness lives outside the module, so this is not a style point — it is a compile error.\n\n## How this is graded, precisely\n\nThe build server compiles your file and grades on one bit: **did it compile.** There is no `cargo test` step on the Rust path, and the grader never reads your code or this description.\n\nSo the checking is done by the `mod verify` block at the bottom of both starters, and its reach is exact.\n\n**It catches:**\n\n- a missing or renamed item — `VaultState`, `VaultError`, `deposit`, `withdraw`\n- a renamed or re-typed field, because `assert!(VaultState::INIT_SPACE == 41)` only holds for `Pubkey` (32) + `u64` (8) + `u8` (1)\n- a missing `#[account]`, because that is what supplies the 8-byte discriminator the harness measures\n- a missing `#[derive(InitSpace)]`, because that is what generates `INIT_SPACE`\n- a wrong receiver (`self` instead of `&mut self`), a wrong parameter type, a wrong return type — the harness binds each method to a typed function pointer\n- a missing `VaultError` variant, or an enum without `#[error_code]`\n- items you left unreachable from the crate root\n\n**It does not catch — verified, by compiling each of these clean:**\n\n- a `withdraw` that calls `checked_add`. Every signature still matches and the build goes green with a vault that pays you for withdrawing.\n- a dropped `require!(amount > 0, …)`. The zero guard is invariant 1 and no type changes when it is gone.\n- `self.balance = self.balance.checked_sub(amount).unwrap();` — invariant 4, and a panic is not a type.\n- `self.balance = self.balance - amount;` — bare arithmetic, same reason.\n\nWhich means exercise 1's pool is not policed either: two of its seven lines do not belong, and both of the two compile. \"Two do not belong\" is a claim about the spec, not about the build. Picking them out is the exercise; the grader is not scoring it.\n\nThat is a property of compile-only grading, not something to work around, and pretending otherwise would be worse than saying it. The thing that catches a swapped operator is a test that runs `withdraw` and looks at the number — which is Course 3, with LiteSVM. Until then it is you, rereading the file, which is what lesson 14 is for.\n\n## Order of work\n\nExercise 1: assemble the two bodies and the re-export from the pool. Exercise 2: write all of it from this page and the harness, with nothing above the harness line but your own typing.\n\nOne warning about that second block, because the platform will not give it to you. Exercise 1 is on the same page, one block above, and by the time you reach exercise 2 it contains the finished `VaultState`, the finished `VaultError`, and — in its pool — every line of both method bodies. **If you scroll up, you are typing, not writing.** Nothing stops you and nothing detects it; the surface Course 3 needs is fixed, so exercise 2 cannot ask for anything exercise 1 did not show you.\n\nThe version of this that is worth your time: read the spec and the harness, close the lesson, write the file from the signatures, and only then scroll up to compare. Getting it wrong first and finding out where is the entire mechanism by which the second block is worth more than the first. Copying it is a green build and nothing else.\n"
+      },
+      {
+        "_key": "manifest",
+        "_type": "prose",
+        "src": "## The `Cargo.toml` you never see\n\nYour editor shows one file. The build server compiles a crate, and a crate is a manifest plus source. You do not edit the manifest, and it decides what your code is allowed to say — so read it once.\n\n```toml\n[package]\nname = \"academy-program\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n[lib]\ncrate-type = [\"cdylib\", \"lib\"]\npath = \"src/lib.rs\"\n\n[profile.release]\noverflow-checks = true\nlto = true\ncodegen-units = 1\nopt-level = \"z\"\n\n[dependencies]\nanchor-lang = { version = \"1.1.2\", features = [\"init-if-needed\"] }\nborsh = \"1.5.7\"\n```\n\nSix lines in it are load-bearing for what you are about to write.\n\n**`path = \"src/lib.rs\"`** — the file in the editor *is* `src/lib.rs`. One starter, one file, one crate. This is the reason the module is inline.\n\n**`crate-type = [\"cdylib\", \"lib\"]`** — two outputs from one source. `cdylib` is the shared object the chain loads and runs. `lib` is an ordinary Rust library, which is what makes the crate importable by something else — a test harness, for instance. Nothing imports it today. It is the hook a `cargo test --lib` grading step would hang on, and it costs nothing to leave in.\n\n**`edition = \"2021\"`, not 2024** — editions are per-crate, and a crate cannot be on an edition the Cargo compiling it has not stabilised. The build server's `cargo-build-sbf` ships its own pinned Rust, and that is the constraint. Practical effect: a snippet from a recent blog post that needs an edition-2024 feature will not compile here. Nothing in this course needs one.\n\n**`overflow-checks = true` under `[profile.release]`** — worth understanding because it is so easily mistaken for a safety net. A release build normally *wraps* on integer overflow: `0u64 - 1` silently becomes `u64::MAX`. This line turns the panic back on, so it wraps no more. It is still not a substitute for `checked_sub`:\n\n| What you write               | Release behaviour with this profile | What the caller of your instruction sees      |\n| ---------------------------- | ----------------------------------- | --------------------------------------------- |\n| `balance - amount`           | panic                               | aborted instruction, no error code, no message |\n| `balance.checked_sub(amount)`| `None`                              | `InsufficientFunds` — a code and a `#[msg]` string you wrote |\n\nA panic tells the caller that something went wrong. `checked_sub` + `ok_or` tells them what. That is lesson 4's argument, restated at the manifest level.\n\n**`anchor-lang = { version = \"1.1.2\", … }`** — Anchor's Rust crate, at the version this course is written against. It re-exports the Solana crates it needs, which is why one `use anchor_lang::prelude::*;` is enough to get `Pubkey`, `Result`, `require!` and `msg!` without naming a single `solana-*` dependency yourself.\n\n**`borsh = \"1.5.7\"`** — a range, not a pin. On a `1.x` crate, `\"1.5.7\"` means `>=1.5.7, <2.0.0`, so the version that actually compiles today is **1.8.0**, published 2026-07-16. To pin exactly you write `=1.5.7`. Internalise the habit now, because it is the same habit that keeps a client library from moving under you: the number in a manifest is usually a range, and the number that shipped is in the lockfile.\n\nWhat is *not* here is also informative, and it is a different file. There is no `Anchor.toml` in play at all — the build server invokes `cargo-build-sbf` directly on this manifest, so the workspace file you will see in every Anchor tutorial has no part in grading. And even where there is one, the `[registry]` section and `anchor publish` it used to carry are gone from the toolchain: the on-chain IDL is now written by the **Program Metadata Program**. You will meet both in Course 3, at deploy time, when your program finally has an id to attach metadata to.\n"
+      },
+      {
+        "_key": "complete",
+        "_type": "code",
+        "buildType": "buildable",
+        "deployable": false,
+        "hints": [
+          "Build before you change anything. Fourteen errors come back and the first twelve are all the same *problem*: twelve unresolved names, eight of `VaultState` and four of `VaultError`, reported as E0412, E0422 and E0433 depending on where each one is used. All twelve are in the harness. `mod verify` is a sibling of `mod vault`, not a child, so `use super::*` reaches the crate root and finds nothing there. One pool line fixes all twelve.",
+          "The last two errors are the real work: `mismatched types: expected Result<(), Error>, found ()`. An empty body evaluates to `()`. Each body is three pool lines — reject zero, do the checked arithmetic and turn `None` into a named error, hand back `Ok(())`. Lines (6) and (1) are the two that are used in both bodies.",
+          "Two pool lines belong nowhere. (5) is bare subtraction, which panics under `overflow-checks = true` instead of returning your error, and (2) calls `.unwrap()`, which panics for the same reason with better manners. Neither one can produce `InsufficientFunds`, which is the entire reason `VaultError` exists."
+        ],
+        "language": "rust",
+        "solution": "// Exercise 1 of 2 — completed.\n//\n// Pool lines (6), (3), (1) fill `deposit`; (6), (7), (1) fill `withdraw`;\n// (4) is the crate-root re-export. Lines (2) and (5) belong nowhere: (5) is\n// bare subtraction, which panics instead of returning a named error, and (2)\n// calls `.unwrap()`, which panics for the same reason with better manners.\n\nuse anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\npub mod vault {\n    use super::*;\n\n    #[account]\n    #[derive(InitSpace)]\n    pub struct VaultState {\n        pub owner: Pubkey,\n        pub balance: u64,\n        pub bump: u8,\n    }\n\n    #[error_code]\n    pub enum VaultError {\n        #[msg(\"Deposit would overflow the vault balance\")]\n        Overflow,\n        #[msg(\"Withdrawal is larger than the vault balance\")]\n        InsufficientFunds,\n        #[msg(\"Amount must be greater than zero\")]\n        ZeroAmount,\n        #[msg(\"Signer is not the vault owner\")]\n        NotOwner,\n    }\n\n    impl VaultState {\n        pub fn deposit(&mut self, amount: u64) -> Result<()> {\n            require!(amount > 0, VaultError::ZeroAmount);\n            self.balance = self\n                .balance\n                .checked_add(amount)\n                .ok_or(VaultError::Overflow)?;\n            Ok(())\n        }\n\n        pub fn withdraw(&mut self, amount: u64) -> Result<()> {\n            require!(amount > 0, VaultError::ZeroAmount);\n            self.balance = self\n                .balance\n                .checked_sub(amount)\n                .ok_or(VaultError::InsufficientFunds)?;\n            Ok(())\n        }\n    }\n}\n\npub use vault::{VaultError, VaultState};\n\n// ─────────────────────────────────────────────────────────────────────────────\n// VERIFICATION HARNESS — DO NOT EDIT ANYTHING BELOW THIS LINE.\n//\n// This module compiles only if every item the spec asks for exists with the\n// name, shape and signature the spec gives. It is a TYPE check, not a behaviour\n// check. Four ways to be wrong and still green, each one confirmed by compiling\n// it: `checked_add` where `checked_sub` belongs, a dropped `require!(amount > 0)`,\n// `.unwrap()` instead of `.ok_or(…)?`, and bare `+`/`-` on `self.balance`.\n// Nothing below can see any of them.\n// ─────────────────────────────────────────────────────────────────────────────\n#[doc(hidden)]\n#[allow(dead_code)]\nmod verify {\n    use super::*;\n\n    // `VaultState` exists with exactly these three field names and types.\n    fn state(owner: Pubkey, balance: u64, bump: u8) -> VaultState {\n        VaultState {\n            owner,\n            balance,\n            bump,\n        }\n    }\n\n    // `#[account]` is present — it is what supplies the 8-byte discriminator.\n    const _: () = assert!(VaultState::DISCRIMINATOR.len() == 8);\n\n    // `#[derive(InitSpace)]` is present, and the fields are exactly\n    // Pubkey (32) + u64 (8) + u8 (1). Widen any of them and this trips.\n    const _: () = assert!(VaultState::INIT_SPACE == 41);\n\n    // Both methods take `&mut self` and a `u64`, and return `Result<()>`.\n    const DEPOSIT: fn(&mut VaultState, u64) -> Result<()> = VaultState::deposit;\n    const WITHDRAW: fn(&mut VaultState, u64) -> Result<()> = VaultState::withdraw;\n\n    // All four variants exist and the enum carries `#[error_code]`, which is\n    // what gives it a conversion into `anchor_lang::error::Error`.\n    fn errors() -> [anchor_lang::error::Error; 4] {\n        [\n            VaultError::Overflow.into(),\n            VaultError::InsufficientFunds.into(),\n            VaultError::ZeroAmount.into(),\n            VaultError::NotOwner.into(),\n        ]\n    }\n}\n",
+        "starter": "// Exercise 1 of 2 — complete the impl block.\n//\n// VaultState, VaultError and the two method signatures are already written.\n// Below are seven candidate lines. FIVE of them belong in this file. The other\n// two compile and are still wrong — the grader cannot tell the difference, which\n// is the point of asking you. Two of the five are used TWICE. Order matters\n// inside a body.\n//\n//   (1)  Ok(())\n//   (2)  self.balance = self.balance.checked_sub(amount).unwrap();\n//   (3)  self.balance = self.balance.checked_add(amount).ok_or(VaultError::Overflow)?;\n//   (4)  pub use vault::{VaultError, VaultState};\n//   (5)  self.balance = self.balance - amount;\n//   (6)  require!(amount > 0, VaultError::ZeroAmount);\n//   (7)  self.balance = self.balance.checked_sub(amount).ok_or(VaultError::InsufficientFunds)?;\n//\n// This file does NOT compile as shipped. Build it first. The errors arrive in\n// two groups, and each group points at a different missing line.\n\nuse anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\npub mod vault {\n    use super::*;\n\n    #[account]\n    #[derive(InitSpace)]\n    pub struct VaultState {\n        pub owner: Pubkey,\n        pub balance: u64,\n        pub bump: u8,\n    }\n\n    #[error_code]\n    pub enum VaultError {\n        #[msg(\"Deposit would overflow the vault balance\")]\n        Overflow,\n        #[msg(\"Withdrawal is larger than the vault balance\")]\n        InsufficientFunds,\n        #[msg(\"Amount must be greater than zero\")]\n        ZeroAmount,\n        #[msg(\"Signer is not the vault owner\")]\n        NotOwner,\n    }\n\n    impl VaultState {\n        pub fn deposit(&mut self, amount: u64) -> Result<()> {\n            // Three lines from the pool, in order.\n        }\n\n        pub fn withdraw(&mut self, amount: u64) -> Result<()> {\n            // Three lines from the pool, in order.\n        }\n    }\n}\n\n// One line from the pool goes here.\n\n// ─────────────────────────────────────────────────────────────────────────────\n// VERIFICATION HARNESS — DO NOT EDIT ANYTHING BELOW THIS LINE.\n//\n// This module compiles only if every item the spec asks for exists with the\n// name, shape and signature the spec gives. It is a TYPE check, not a behaviour\n// check. Four ways to be wrong and still green, each one confirmed by compiling\n// it: `checked_add` where `checked_sub` belongs, a dropped `require!(amount > 0)`,\n// `.unwrap()` instead of `.ok_or(…)?`, and bare `+`/`-` on `self.balance`.\n// Nothing below can see any of them.\n// ─────────────────────────────────────────────────────────────────────────────\n#[doc(hidden)]\n#[allow(dead_code)]\nmod verify {\n    use super::*;\n\n    // `VaultState` exists with exactly these three field names and types.\n    fn state(owner: Pubkey, balance: u64, bump: u8) -> VaultState {\n        VaultState {\n            owner,\n            balance,\n            bump,\n        }\n    }\n\n    // `#[account]` is present — it is what supplies the 8-byte discriminator.\n    const _: () = assert!(VaultState::DISCRIMINATOR.len() == 8);\n\n    // `#[derive(InitSpace)]` is present, and the fields are exactly\n    // Pubkey (32) + u64 (8) + u8 (1). Widen any of them and this trips.\n    const _: () = assert!(VaultState::INIT_SPACE == 41);\n\n    // Both methods take `&mut self` and a `u64`, and return `Result<()>`.\n    const DEPOSIT: fn(&mut VaultState, u64) -> Result<()> = VaultState::deposit;\n    const WITHDRAW: fn(&mut VaultState, u64) -> Result<()> = VaultState::withdraw;\n\n    // All four variants exist and the enum carries `#[error_code]`, which is\n    // what gives it a conversion into `anchor_lang::error::Error`.\n    fn errors() -> [anchor_lang::error::Error; 4] {\n        [\n            VaultError::Overflow.into(),\n            VaultError::InsufficientFunds.into(),\n            VaultError::ZeroAmount.into(),\n            VaultError::NotOwner.into(),\n        ]\n    }\n}\n",
+        "tests": [
+          {
+            "description": "The file compiles on the build server against anchor-lang 1.1.2",
+            "expectedOutput": "true",
+            "id": "t1",
+            "input": ""
+          },
+          {
+            "description": "Compiles ⇒ neither method body was left empty: both evaluate to Result<()>",
+            "expectedOutput": "true",
+            "id": "t2",
+            "input": ""
+          },
+          {
+            "description": "Compiles ⇒ VaultState and VaultError are nameable from the crate root, so the re-export is in place",
+            "expectedOutput": "true",
+            "id": "t3",
+            "input": ""
+          }
+        ]
+      },
+      {
+        "_key": "write",
+        "_type": "code",
+        "buildType": "buildable",
+        "deployable": false,
+        "hints": [
+          "The harness is the acceptance criteria, written in Rust. Read it top to bottom before you type — it names every item, every field, every type and both signatures you owe, and it is the only thing the build server can check.",
+          "`assert!(VaultState::INIT_SPACE == 41)` holds only for `Pubkey` (32) + `u64` (8) + `u8` (1). If it trips you widened a field — a `u64` bump is the usual one, and it costs 7 bytes of rent per vault forever.",
+          "Your items go inside `pub mod vault` and the harness sits outside it, so the crate root needs one line: `pub use vault::{VaultError, VaultState};` Without it every harness reference fails with `cannot find type`, and the items you wrote are unreachable from anywhere Course 3 could call them."
+        ],
+        "language": "rust",
+        "solution": "// Exercise 2 of 2 — the vault core, written from the spec.\n//\n// This is one correct shape, not the only one: the fields may be declared in\n// any order, the `#[msg]` strings are yours, and `require!` could be a plain\n// `if amount == 0 { return err!(VaultError::ZeroAmount); }`. What is fixed is\n// the surface the harness names — and the operator in each method, which the\n// harness cannot see and Course 3's tests can.\n\nuse anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\npub mod vault {\n    use super::*;\n\n    #[account]\n    #[derive(InitSpace)]\n    pub struct VaultState {\n        pub owner: Pubkey,\n        pub balance: u64,\n        pub bump: u8,\n    }\n\n    #[error_code]\n    pub enum VaultError {\n        #[msg(\"Deposit would overflow the vault balance\")]\n        Overflow,\n        #[msg(\"Withdrawal is larger than the vault balance\")]\n        InsufficientFunds,\n        #[msg(\"Amount must be greater than zero\")]\n        ZeroAmount,\n        #[msg(\"Signer is not the vault owner\")]\n        NotOwner,\n    }\n\n    impl VaultState {\n        pub fn deposit(&mut self, amount: u64) -> Result<()> {\n            require!(amount > 0, VaultError::ZeroAmount);\n            self.balance = self\n                .balance\n                .checked_add(amount)\n                .ok_or(VaultError::Overflow)?;\n            Ok(())\n        }\n\n        pub fn withdraw(&mut self, amount: u64) -> Result<()> {\n            require!(amount > 0, VaultError::ZeroAmount);\n            self.balance = self\n                .balance\n                .checked_sub(amount)\n                .ok_or(VaultError::InsufficientFunds)?;\n            Ok(())\n        }\n    }\n}\n\npub use vault::{VaultError, VaultState};\n\n// ─────────────────────────────────────────────────────────────────────────────\n// VERIFICATION HARNESS — DO NOT EDIT ANYTHING BELOW THIS LINE.\n//\n// This module compiles only if every item the spec asks for exists with the\n// name, shape and signature the spec gives. It is a TYPE check, not a behaviour\n// check. Four ways to be wrong and still green, each one confirmed by compiling\n// it: `checked_add` where `checked_sub` belongs, a dropped `require!(amount > 0)`,\n// `.unwrap()` instead of `.ok_or(…)?`, and bare `+`/`-` on `self.balance`.\n// Nothing below can see any of them.\n// ─────────────────────────────────────────────────────────────────────────────\n#[doc(hidden)]\n#[allow(dead_code)]\nmod verify {\n    use super::*;\n\n    // `VaultState` exists with exactly these three field names and types.\n    fn state(owner: Pubkey, balance: u64, bump: u8) -> VaultState {\n        VaultState {\n            owner,\n            balance,\n            bump,\n        }\n    }\n\n    // `#[account]` is present — it is what supplies the 8-byte discriminator.\n    const _: () = assert!(VaultState::DISCRIMINATOR.len() == 8);\n\n    // `#[derive(InitSpace)]` is present, and the fields are exactly\n    // Pubkey (32) + u64 (8) + u8 (1). Widen any of them and this trips.\n    const _: () = assert!(VaultState::INIT_SPACE == 41);\n\n    // Both methods take `&mut self` and a `u64`, and return `Result<()>`.\n    const DEPOSIT: fn(&mut VaultState, u64) -> Result<()> = VaultState::deposit;\n    const WITHDRAW: fn(&mut VaultState, u64) -> Result<()> = VaultState::withdraw;\n\n    // All four variants exist and the enum carries `#[error_code]`, which is\n    // what gives it a conversion into `anchor_lang::error::Error`.\n    fn errors() -> [anchor_lang::error::Error; 4] {\n        [\n            VaultError::Overflow.into(),\n            VaultError::InsufficientFunds.into(),\n            VaultError::ZeroAmount.into(),\n            VaultError::NotOwner.into(),\n        ]\n    }\n}\n",
+        "starter": "// Exercise 2 of 2 — write the vault core.\n//\n// Nothing above the harness line is written for you. The spec is on the lesson\n// page; the harness below is the same spec expressed in Rust, and it is the\n// only thing the build server can check. Read it before you type.\n//\n// Exercise 1 is one block above this one and it contains the answer, pool lines\n// and all. Nothing stops you scrolling up and nothing detects it — but a file you\n// transcribed teaches you nothing a file you wrote does not. Write it from the\n// harness first, compare afterwards.\n//\n// This file does NOT compile as shipped. Every error you see names something\n// you still owe.\n\nuse anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\npub mod vault {\n    use super::*;\n\n    // TODO 1 — `VaultState`: an `#[account]` struct that also derives\n    //          `InitSpace`, with three public fields.\n    //\n    // TODO 2 — `VaultError`: an `#[error_code]` enum with four variants, each\n    //          carrying a `#[msg(\"…\")]` a caller can read.\n    //\n    // TODO 3 — `impl VaultState`, with `deposit` and `withdraw`. Reject a zero\n    //          amount before writing anything, do the arithmetic with\n    //          `checked_add` / `checked_sub`, and turn `None` into the right\n    //          named variant. No `unwrap()`, no `expect()`, no bare `+`/`-`.\n}\n\n// TODO 4 — one line: make `VaultState` and `VaultError` nameable from the\n//          crate root, where the harness can see them.\n\n// ─────────────────────────────────────────────────────────────────────────────\n// VERIFICATION HARNESS — DO NOT EDIT ANYTHING BELOW THIS LINE.\n//\n// This module compiles only if every item the spec asks for exists with the\n// name, shape and signature the spec gives. It is a TYPE check, not a behaviour\n// check. Four ways to be wrong and still green, each one confirmed by compiling\n// it: `checked_add` where `checked_sub` belongs, a dropped `require!(amount > 0)`,\n// `.unwrap()` instead of `.ok_or(…)?`, and bare `+`/`-` on `self.balance`.\n// Nothing below can see any of them.\n// ─────────────────────────────────────────────────────────────────────────────\n#[doc(hidden)]\n#[allow(dead_code)]\nmod verify {\n    use super::*;\n\n    // `VaultState` exists with exactly these three field names and types.\n    fn state(owner: Pubkey, balance: u64, bump: u8) -> VaultState {\n        VaultState {\n            owner,\n            balance,\n            bump,\n        }\n    }\n\n    // `#[account]` is present — it is what supplies the 8-byte discriminator.\n    const _: () = assert!(VaultState::DISCRIMINATOR.len() == 8);\n\n    // `#[derive(InitSpace)]` is present, and the fields are exactly\n    // Pubkey (32) + u64 (8) + u8 (1). Widen any of them and this trips.\n    const _: () = assert!(VaultState::INIT_SPACE == 41);\n\n    // Both methods take `&mut self` and a `u64`, and return `Result<()>`.\n    const DEPOSIT: fn(&mut VaultState, u64) -> Result<()> = VaultState::deposit;\n    const WITHDRAW: fn(&mut VaultState, u64) -> Result<()> = VaultState::withdraw;\n\n    // All four variants exist and the enum carries `#[error_code]`, which is\n    // what gives it a conversion into `anchor_lang::error::Error`.\n    fn errors() -> [anchor_lang::error::Error; 4] {\n        [\n            VaultError::Overflow.into(),\n            VaultError::InsufficientFunds.into(),\n            VaultError::ZeroAmount.into(),\n            VaultError::NotOwner.into(),\n        ]\n    }\n}\n",
+        "tests": [
+          {
+            "description": "The file compiles on the build server against anchor-lang 1.1.2",
+            "expectedOutput": "true",
+            "id": "t1",
+            "input": ""
+          },
+          {
+            "description": "Compiles ⇒ VaultState has owner: Pubkey, balance: u64 and bump: u8 — INIT_SPACE is 41",
+            "expectedOutput": "true",
+            "id": "t2",
+            "input": ""
+          },
+          {
+            "description": "Compiles ⇒ #[account] and #[derive(InitSpace)] are both present: an 8-byte discriminator plus INIT_SPACE",
+            "expectedOutput": "true",
+            "id": "t3",
+            "input": ""
+          },
+          {
+            "description": "Compiles ⇒ deposit and withdraw take (&mut self, u64) and return Result<()>",
+            "expectedOutput": "true",
+            "id": "t4",
+            "input": ""
+          },
+          {
+            "description": "Compiles ⇒ VaultError is an #[error_code] enum carrying Overflow, InsufficientFunds, ZeroAmount and NotOwner",
+            "expectedOutput": "true",
+            "id": "t5",
+            "input": ""
+          }
+        ]
+      },
+      {
+        "_key": "check",
+        "_type": "quiz",
+        "questions": [
+          {
+            "explanation": "This is the honest limit of the harness and it is worth carrying forward: it proves your file has the right *shape*, and nothing more. Until a test runs `withdraw` and looks at the number, the operator is checked by you.",
+            "id": "q1",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "Green. Grading is compile-only, and both methods return `Option<u64>`, so nothing about the file's types changed."
+              },
+              {
+                "correct": false,
+                "feedback": "The binding checks `fn(&mut VaultState, u64) -> Result<()>`. The operator lives inside the body; it does not appear in the signature, so the pointer still coerces.",
+                "id": "b",
+                "label": "Red — the harness binds `withdraw` to a function pointer, and a wrong operator changes the type it binds."
+              },
+              {
+                "correct": false,
+                "feedback": "`overflow-checks` changes what a release binary does at runtime when an operation overflows. It cannot see an operator you intended to write, and nothing about it runs at compile time.",
+                "id": "c",
+                "label": "Red — `overflow-checks = true` turns the wrong operator into a compile error."
+              },
+              {
+                "correct": false,
+                "feedback": "There are no hidden tests on the Rust path. The build step shells `cargo-build-sbf` and nothing else, and a submission passes iff the program compiled. Behavioural checks arrive in Course 3, with LiteSVM.",
+                "id": "d",
+                "label": "Red — the lesson's hidden tests call `withdraw(100)` on a balance of 10 and check for `InsufficientFunds`."
+              }
+            ],
+            "prompt": "You finish the second exercise, but in `withdraw` you typed `checked_add` where you meant `checked_sub`. Everything else matches the spec. Predict what the build server reports."
+          },
+          {
+            "id": "q2",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "`cannot find type VaultState in this scope` — `mod verify` is a sibling of `mod vault`, so `use super::*` reaches the crate root, where nothing of that name has been declared."
+              },
+              {
+                "correct": false,
+                "feedback": "A glob import pulls in what is in scope exactly one level up. It never searches downwards into sibling modules — that is what a re-export is for.",
+                "id": "b",
+                "label": "It compiles. `use super::*` keeps walking up and down the module tree until it finds the name."
+              },
+              {
+                "correct": false,
+                "feedback": "You did write `pub struct`. The item is public; the problem is that nothing at the crate root has named it. Different failure.",
+                "id": "c",
+                "label": "`private type VaultState in public interface` — the struct needs `pub`."
+              },
+              {
+                "correct": false,
+                "feedback": "`use super::*` always resolves; the crate root exists and is a valid module. The failure lands on the names the harness then tries to use.",
+                "id": "d",
+                "label": "`unresolved import super::*` — there is nothing to glob."
+              }
+            ],
+            "prompt": "You write `VaultState` and `VaultError` inside `pub mod vault { … }` and forget the crate-root re-export. The harness below begins with `use super::*;`. Predict the first error."
+          },
+          {
+            "id": "q3",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "It compiles, and at runtime the subtraction panics — the instruction aborts with no `VaultError` attached and no message for the caller."
+              },
+              {
+                "correct": false,
+                "feedback": "That is the default release behaviour, but this manifest sets `overflow-checks = true`, which restores the panic. Both outcomes are worse than an error code; only one of them is what this profile actually does.",
+                "id": "b",
+                "label": "It compiles, and `balance` wraps around to a value near `u64::MAX`."
+              },
+              {
+                "correct": false,
+                "feedback": "The compiler only rejects overflow it can evaluate at compile time, in a constant. `balance` and `amount` are runtime values.",
+                "id": "c",
+                "label": "It does not compile — subtracting a larger `u64` from a smaller one is rejected by the compiler."
+              },
+              {
+                "correct": false,
+                "feedback": "Nothing converts a panic into a named error. That conversion is the thing you write by hand, with `checked_sub(...).ok_or(...)?`.",
+                "id": "d",
+                "label": "It compiles and returns `Err(VaultError::InsufficientFunds)`, because that is what the enum is for."
+              }
+            ],
+            "prompt": "Carried over from lesson 4. You write `self.balance = self.balance - amount;` with `balance == 10` and `amount == 25`, and it ships in the build server's release profile. Predict what happens."
+          }
+        ]
+      }
+    ],
+    "skills": [
+      "rust-structs",
+      "rust-enums",
+      "rust-result",
+      "checked-arithmetic",
+      "rust-modules",
+      "error-handling",
+      "anchor",
+      "program-security"
+    ],
+    "slug": {
+      "_type": "slug",
+      "current": "build-the-vault-core"
+    },
+    "title": "Build the Vault Core"
+  },
+  {
+    "_id": "lesson-rpd-checked-lamport-math",
+    "_type": "lesson",
+    "blocks": [
+      {
+        "_key": "intro",
+        "_type": "prose",
+        "src": "# Checked Lamport Math\n\n> **Version stamp — checked 2026-07-26.** `anchor-lang` **1.1.2** · Rust **edition 2021** · Agave **≥ 3.1.10**. The build crate sets `overflow-checks = true` in `[profile.release]`, which this lesson depends on and discusses. The exercise is plain Rust and imports nothing.\n\nHere is a withdrawal, written the way it reads:\n\n```rust\nlet new_balance = balance - amount;\n```\n\nA vault holding 5 lamports, someone asking for 7. Decide what that line does before reading on, and be specific — there are three different answers depending on how the program was compiled, and none of them is the one you want.\n\n## The three answers\n\n**In a debug build, or any build with overflow checks on: it panics.** The subtraction is detected as an underflow and the program aborts. On-chain, an aborted program means a failed transaction, a log line about a panic, and no way for a caller to distinguish \"you asked for too much\" from \"the program has a bug\". You cannot handle it, you cannot match on it, and you cannot return a useful error alongside it.\n\n**In a release build with overflow checks off: it wraps.** `5u64 - 7` becomes 18 446 744 073 709 551 614. No panic, no log, no signal of any kind. Your vault now believes it holds eighteen quintillion lamports, and the very next line of code will act on that belief. This is not a hypothetical failure mode — unchecked arithmetic is one of the most-exploited bug classes in on-chain programs, and it is exploited precisely because it is silent.\n\n**The third answer is the one you build today: it returns `None`.** No panic, no wrap. The impossible result is represented as a value, handed back to the caller, and the caller has to deal with it before it can get at a number.\n\nOur build server compiles with `overflow-checks = true`, so a wrap becomes a panic here. Be clear about what that does and does not buy you. It converts a silent corruption into a loud crash, which is strictly better and is why it is switched on. It is **not** a substitute for checked arithmetic: a crash is still not an error you can return, and the flag is a property of the build profile rather than of your code. Code whose correctness depends on a profile setting is code that is one `Cargo.toml` away from being wrong.\n\nThis is the Rust half of the `u64` problem lesson 2 planted on the JavaScript side. There, `Number(hugeU64)` handed you a nearby number with no complaint. Here, `balance - amount` hands you a wrong number or a crash. The languages fail differently and both failures are silent-or-useless by default. The fix in Rust is to ask for the checked operation by name.\n\n## `Option<T>`: a value or the absence of one\n\n```rust\npub enum Option<T> {\n    Some(T),\n    None,\n}\n```\n\nThat is the whole definition. `Option<u64>` is *either* a `u64` wrapped in `Some`, *or* `None`. It is an ordinary enum from the standard library, not compiler magic, and it is what Rust has instead of `null`.\n\nThe difference from `null` is not philosophical, it is mechanical: **`Option<u64>` and `u64` are different types.** You cannot add 1 to an `Option<u64>`, pass it where a `u64` is wanted, or compare it to a number. To get at the value you have to handle the `None` case, and the compiler will not let you skip it. There is no equivalent of a null-pointer dereference to defer to run time, because the check is not at run time.\n\nRust's standard library gives every integer type a `checked_` operation for exactly this shape:\n\n```rust\n5u64.checked_sub(7)   // None\n7u64.checked_sub(5)   // Some(2)\nu64::MAX.checked_add(1)  // None\n1u64.checked_add(2)   // Some(3)\n```\n\n`checked_add`, `checked_sub`, `checked_mul`, `checked_div`. Each returns `Option`, each returns `None` exactly when the true result cannot be represented, and using them is not defensive programming — it is the only way to write arithmetic on untrusted numbers that says what it means.\n\n## Getting the value out with `match`\n\n`match` from lesson 3 works on `Option`, and this is where its exhaustiveness earns its keep — there are two variants, so there are two arms, and forgetting one is `error[E0004]`:\n\n```rust\nmatch balance.checked_sub(amount) {\n    None => { /* the caller asked for too much */ }\n    Some(remaining) => { /* `remaining` is a plain u64 here */ }\n}\n```\n\n`Some(remaining)` both tests the variant and binds the value out of it in one move. That is destructuring, and it is the normal way to read any enum in Rust.\n\nYou may have seen `.unwrap()` do the same job in one word. `unwrap()` panics on `None`. **It must never appear in program code**, it does not appear anywhere in this course's code, and every tutorial you find will be full of it. Lesson 11 makes the full argument for why; take the rule on trust until then.\n\nThere is also `?`, the operator that propagates the failure case for you and turns a five-line `match` into one character. You will meet it in lesson 12, and there is a specific reason it is not available today — see the constraints below.\n\n## Why these are `const fn`\n\nEvery function you write in this exercise is declared `const fn`. That means the compiler is able to evaluate it during compilation, given constant inputs.\n\nThis is not decoration and it is not for performance. It is what makes the exercise gradeable. Grading a Rust submission here means compiling it — that is the whole signal. A file that compiles has told the grader nothing about whether `sub_lamports` subtracts or adds. But a `const fn` can be called by an assertion the compiler must evaluate:\n\n```rust\nconst _: () = assert!(matches!(sub_lamports(5, 7), None));\n```\n\nIf your `sub_lamports(5, 7)` returns anything other than `None`, that assertion fails **during compilation** and the build goes red, with the assertion reproduced in the error:\n\n```\nerror[E0080]: evaluation panicked: assertion failed: matches!(sub_lamports(5, 7), None)\n```\n\nTen of those sit at the bottom of the file. They are the first behavioural check in this course rather than a signature check, and they are what makes a `sub_lamports` that quietly calls `checked_add` fail rather than pass.\n\nBe clear about the size of that win. Ten specific inputs is not a test suite, and this trick reaches only as far as `const fn` does — by module 4, when the same logic becomes a method taking `&mut self` and returning `Result`, it is no longer const-evaluable and the harness goes back to pinning shapes. Today it works, so today we use it.\n\nTwo consequences of `const fn` you need before you start:\n\n- **`?` is not allowed in a `const fn`.** You get `error[E0015]` — \"`?` is not allowed on `Option<u64>` in constant functions\" — with the note \"calls in constant functions are limited to constant functions, tuple structs and tuple variants\". That note is the actual reason: `?` desugars to calls into the `Try` machinery, and those functions are not `const fn`, so from the compiler's point of view you made a non-const call. Use `match`. This is the reason the spec says `match`, and lesson 12 is where `?` finally arrives — on `Result`, in a function that is not const.\n- **`panic!`, and anything built on it, ends the build rather than the program.** A `panic!` reached during const evaluation is a compile error. `unwrap()` on a `None` in a `const fn` called from an assertion does not fail at run time; it fails at *your* keyboard.\n\n`checked_add` and `checked_sub` are themselves `const fn`, so they are available to you inside yours.\n\n## The spec\n\nThree functions, no bodies. Signatures are fixed and pinned by the harness.\n\n### `add_lamports(balance, amount) -> Option<u64>`\n\n`Some(sum)` when `balance + amount` is representable as a `u64`. `None` when it is not.\n\n`amount` of zero is fine and returns `Some(balance)`. Rejecting a zero-amount deposit is a *policy*, and it belongs in the vault's `deposit` method in lesson 13, not in an arithmetic helper. Keep the two separate.\n\n### `sub_lamports(balance, amount) -> Option<u64>`\n\n`Some(remaining)` when `amount <= balance`. `None` when it is not, because a `u64` has no negative values to land on. Withdrawing exactly the whole balance is valid and returns `Some(0)`.\n\n### `transfer_lamports(from, to, amount) -> Option<(u64, u64)>`\n\nMove `amount` from one balance to the other and return **both new balances** as `Some((new_from, new_to))`. Return `None` if either half is impossible.\n\nThis one is the point of the lesson. The requirement is *all or nothing*: if the debit works but the credit would overflow, nothing moved, and the answer is `None` — not `Some` with one side updated. Which means you cannot compute the two halves independently and hope; you have to look at the first result before committing to the second, and you have to do it with `match` because `?` is unavailable. This is the shape of every value transfer you will ever write on-chain, and it is why `withdraw` in lesson 13 does its checked subtraction *before* it writes anything.\n\nBuild the empty file first. Ten `error[E0080]` lines come back, one per assertion, all of them reporting `not yet implemented` — that is `todo!()` doing its job. As you fill each body in, the failures that remain start naming the specific input they disagree with, and at that point the harness is a better-specified to-do list than this page is.\n"
+      },
+      {
+        "_key": "exercise",
+        "_type": "code",
+        "buildType": "buildable",
+        "deployable": false,
+        "hints": [
+          "Build the empty file first. All ten assertions fail with `error[E0080]: evaluation panicked: not yet implemented`, which is `todo!()` being reached — the comments above each group name the cases. Once a function has a real body, a failure prints the assertion verbatim (`assertion failed: matches!(sub_lamports(5, 7), None)`) and names the exact input that is wrong.",
+          "`u64` already has the two operations you need, and both are themselves `const fn`, so they are callable from inside yours. Look for the methods whose return type is `Option<u64>`.",
+          "For `transfer_lamports`, the obstacle rather than the shape: you cannot use `?`, so there is no way to bail out of the middle of an expression. The second operation therefore has to be inspected somewhere the first one has already succeeded. If you find yourself wanting `?`, that is the right instinct and lesson 12 is where it becomes legal."
+        ],
+        "language": "rust",
+        "solution": "//! Checked lamport math — solved.\n\n/// `Some(balance + amount)`, or `None` if that would exceed `u64::MAX`.\n///\n/// An `amount` of zero is valid and returns `Some(balance)`.\npub const fn add_lamports(balance: u64, amount: u64) -> Option<u64> {\n    balance.checked_add(amount)\n}\n\n/// `Some(balance - amount)`, or `None` if `amount` is greater than\n/// `balance` — a `u64` has no negative values to land on.\n///\n/// Withdrawing the whole balance is valid and returns `Some(0)`.\npub const fn sub_lamports(balance: u64, amount: u64) -> Option<u64> {\n    balance.checked_sub(amount)\n}\n\n/// Move `amount` from `from` to `to`, all or nothing.\n///\n/// The debit is inspected before the credit is committed to. If the credit\n/// cannot happen, the whole operation reports `None` and neither balance is\n/// returned — which is why the debited value stays inside the `match` arm\n/// instead of being written anywhere.\npub const fn transfer_lamports(from: u64, to: u64, amount: u64) -> Option<(u64, u64)> {\n    match sub_lamports(from, amount) {\n        None => None,\n        Some(debited) => match add_lamports(to, amount) {\n            None => None,\n            Some(credited) => Some((debited, credited)),\n        },\n    }\n}\n\n// ════════════════════════════════════════════════════════════════════════\n// DO NOT EDIT BELOW THIS LINE\n//\n// The first three bindings pin the signatures. The rest are assertions the\n// compiler evaluates during the build, so a wrong answer is a red build\n// rather than a silent pass. Ten specific inputs is not a test suite, and\n// this only works because the functions are `const fn` — but it is a real\n// behavioural check, which is more than the rest of this module gets.\n// ════════════════════════════════════════════════════════════════════════\n\nconst _: fn(u64, u64) -> Option<u64> = add_lamports;\nconst _: fn(u64, u64) -> Option<u64> = sub_lamports;\nconst _: fn(u64, u64, u64) -> Option<(u64, u64)> = transfer_lamports;\n\n// add: the ordinary case, the ceiling, and zero\nconst _: () = assert!(matches!(add_lamports(1, 2), Some(3)));\nconst _: () = assert!(matches!(add_lamports(u64::MAX, 1), None));\nconst _: () = assert!(matches!(add_lamports(u64::MAX, 0), Some(u64::MAX)));\n\n// sub: the ordinary case, the floor, and draining to exactly zero\nconst _: () = assert!(matches!(sub_lamports(7, 5), Some(2)));\nconst _: () = assert!(matches!(sub_lamports(5, 7), None));\nconst _: () = assert!(matches!(sub_lamports(5, 5), Some(0)));\n\n// transfer: both sides move, or neither does\nconst _: () = assert!(matches!(transfer_lamports(10, 0, 4), Some((6, 4))));\nconst _: () = assert!(matches!(transfer_lamports(10, 0, 0), Some((10, 0))));\nconst _: () = assert!(matches!(transfer_lamports(3, 0, 4), None));\nconst _: () = assert!(matches!(transfer_lamports(10, u64::MAX, 1), None));\n",
+        "starter": "//! Checked lamport math.\n//!\n//! Three signatures, no bodies. The spec is in the lesson text; the\n//! acceptance criteria are the assertions at the bottom of this file, and\n//! the compiler evaluates them while it builds.\n//!\n//! This file does not build as it ships. Build it anyway. The first build\n//! reports all ten assertions failing with `error[E0080]: evaluation\n//! panicked: not yet implemented` — that is `todo!()` being reached, and\n//! the comment above each group of assertions names the cases.\n//!\n//! Once a function has a real body, a failing assertion prints itself\n//! verbatim instead, for example:\n//!\n//!   error[E0080]: evaluation panicked:\n//!     assertion failed: matches!(sub_lamports(5, 7), None)\n//!\n//! which names the exact input that is wrong.\n//!\n//! Constraints:\n//!   * every function stays a `const fn` — the assertions can only run if\n//!     the compiler can evaluate your code\n//!   * no `?` — it is not allowed in a `const fn`. Use `match`.\n//!   * no `unwrap()`, no `expect()`, no `panic!`, no `as`\n//!   * no bare `+` or `-` on lamports\n\n/// `Some(balance + amount)`, or `None` if that would exceed `u64::MAX`.\n///\n/// An `amount` of zero is valid and returns `Some(balance)`.\npub const fn add_lamports(balance: u64, amount: u64) -> Option<u64> {\n    todo!()\n}\n\n/// `Some(balance - amount)`, or `None` if `amount` is greater than\n/// `balance` — a `u64` has no negative values to land on.\n///\n/// Withdrawing the whole balance is valid and returns `Some(0)`.\npub const fn sub_lamports(balance: u64, amount: u64) -> Option<u64> {\n    todo!()\n}\n\n/// Move `amount` from `from` to `to`, all or nothing.\n///\n/// `Some((new_from, new_to))` when both halves succeed. `None` when either\n/// half is impossible — and in that case neither balance moved, so there\n/// is nothing partial to report.\n///\n/// You cannot use `?` here. Look at the first result with `match` before\n/// committing to the second.\npub const fn transfer_lamports(from: u64, to: u64, amount: u64) -> Option<(u64, u64)> {\n    todo!()\n}\n\n// ════════════════════════════════════════════════════════════════════════\n// DO NOT EDIT BELOW THIS LINE\n//\n// The first three bindings pin the signatures. The rest are assertions the\n// compiler evaluates during the build, so a wrong answer is a red build\n// rather than a silent pass. Ten specific inputs is not a test suite, and\n// this only works because the functions are `const fn` — but it is a real\n// behavioural check, which is more than the rest of this module gets.\n// ════════════════════════════════════════════════════════════════════════\n\nconst _: fn(u64, u64) -> Option<u64> = add_lamports;\nconst _: fn(u64, u64) -> Option<u64> = sub_lamports;\nconst _: fn(u64, u64, u64) -> Option<(u64, u64)> = transfer_lamports;\n\n// add: the ordinary case, the ceiling, and zero\nconst _: () = assert!(matches!(add_lamports(1, 2), Some(3)));\nconst _: () = assert!(matches!(add_lamports(u64::MAX, 1), None));\nconst _: () = assert!(matches!(add_lamports(u64::MAX, 0), Some(u64::MAX)));\n\n// sub: the ordinary case, the floor, and draining to exactly zero\nconst _: () = assert!(matches!(sub_lamports(7, 5), Some(2)));\nconst _: () = assert!(matches!(sub_lamports(5, 7), None));\nconst _: () = assert!(matches!(sub_lamports(5, 5), Some(0)));\n\n// transfer: both sides move, or neither does\nconst _: () = assert!(matches!(transfer_lamports(10, 0, 4), Some((6, 4))));\nconst _: () = assert!(matches!(transfer_lamports(10, 0, 0), Some((10, 0))));\nconst _: () = assert!(matches!(transfer_lamports(3, 0, 4), None));\nconst _: () = assert!(matches!(transfer_lamports(10, u64::MAX, 1), None));\n",
+        "tests": [
+          {
+            "description": "Program compiles successfully",
+            "expectedOutput": "true",
+            "id": "test-1",
+            "input": ""
+          },
+          {
+            "description": "add_lamports and sub_lamports return None at the u64 ceiling and floor — checked by compile-time assertion",
+            "expectedOutput": "true",
+            "id": "test-2",
+            "input": ""
+          },
+          {
+            "description": "transfer_lamports is all-or-nothing: None when either half is impossible — checked by compile-time assertion",
+            "expectedOutput": "true",
+            "id": "test-3",
+            "input": ""
+          }
+        ]
+      },
+      {
+        "_key": "check",
+        "_type": "quiz",
+        "questions": [
+          {
+            "id": "q1",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "It panics, the transaction fails, and the caller gets an aborted program rather than an error it can distinguish — the check turns a silent corruption into a crash, not into a handled case."
+              },
+              {
+                "correct": false,
+                "feedback": "That is the answer with overflow checks *off*, and it is the more dangerous one — which is why the flag is on. But the flag lives in `Cargo.toml`, not in your code, so correctness that depends on it is one profile change away from being wrong.",
+                "id": "b",
+                "label": "It wraps to 18446744073709551614 and the vault believes it is enormously funded."
+              },
+              {
+                "correct": false,
+                "feedback": "The `-` operator returns `u64`, never `Option<u64>`. Nothing about its type could carry a `None`. You have to call `checked_sub` to get one.",
+                "id": "c",
+                "label": "It returns `None`, because `u64` subtraction is checked by default."
+              },
+              {
+                "correct": false,
+                "feedback": "With literal constants the compiler does catch it. With runtime values it cannot possibly know, which is the entire situation your program is in — the amount came from an instruction someone else wrote.",
+                "id": "d",
+                "label": "It is a compile error, since the compiler can see the subtraction might underflow."
+              }
+            ],
+            "prompt": "A vault holds 5 lamports. A withdrawal for 7 reaches `let new_balance = balance - amount;`. The program was compiled by our build server, which sets `overflow-checks = true` in its release profile. Predict what happens, and what a caller can do about it."
+          },
+          {
+            "id": "q2",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "It fails to compile — `error[E0015]`, \"`?` is not allowed on `Option<u64>` in constant functions\". That is exactly why the spec asks for `match`."
+              },
+              {
+                "correct": false,
+                "feedback": "It would be, in an ordinary function. `?` on `Option` is still unstable in const context, so it does not compile here — and dropping `const fn` to get it would disable the assertions that grade this lesson. Lesson 12 is where `?` becomes available, on `Result`, in a function that is not const.",
+                "id": "b",
+                "label": "It compiles and is the neatest possible answer."
+              },
+              {
+                "correct": false,
+                "feedback": "`?` returns from the enclosing *function*, not from the expression it sits in, so the nesting would not have been the problem. The problem is that it is unavailable in const context at all.",
+                "id": "c",
+                "label": "It compiles but always returns `Some`, because `?` cannot escape from inside a `Some(...)` call."
+              },
+              {
+                "correct": false,
+                "feedback": "`Some(x?)` on an `Option` is genuinely redundant — the value is already the right type — but Rust does not lint for it, and in a `const fn` you never get that far.",
+                "id": "d",
+                "label": "It compiles with a warning that `?` is redundant here."
+              }
+            ],
+            "prompt": "A submission writes `pub const fn sub_lamports(b: u64, a: u64) -> Option<u64> { Some(b.checked_sub(a)?) }`. Predict the outcome."
+          },
+          {
+            "id": "q3",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "`error[E0308]` — expected `Option<u64>`, found `()`. The semicolon discarded the value, so the body evaluates to nothing."
+              },
+              {
+                "correct": false,
+                "feedback": "There is no implicit `None`, and no implicit anything. A body whose value is `()` does not satisfy a `-> Option<u64>` signature, and the compiler says so before the question of what it returns can arise.",
+                "id": "b",
+                "label": "It compiles and returns `None`, since nothing was returned."
+              },
+              {
+                "correct": false,
+                "feedback": "You would get an unused-result warning if the return type were `()`. It is not, so the mismatch is an error — and note that the compiler's `help:` line will point straight at the semicolon.",
+                "id": "c",
+                "label": "It compiles with a `path_statements` warning about an expression whose result is unused."
+              },
+              {
+                "correct": false,
+                "feedback": "A tail expression is defined by the *absence* of the semicolon. Adding one is what turns it from the body's value into a discarded statement — the same rule that broke `if a < b { a; } else { b; }` in lesson 3.",
+                "id": "d",
+                "label": "It compiles, because `checked_sub` is the last expression and semicolons are optional at the end of a body."
+              }
+            ],
+            "prompt": "Carried over from lesson 3. Predict the outcome of `pub const fn sub_lamports(b: u64, a: u64) -> Option<u64> { b.checked_sub(a); }`"
+          }
+        ]
+      }
+    ],
+    "skills": [
+      "rust-types",
+      "checked-arithmetic",
+      "rust-option",
+      "program-security"
+    ],
+    "slug": {
+      "_type": "slug",
+      "current": "checked-lamport-math"
+    },
+    "title": "Checked Lamport Math"
+  },
+  {
+    "_id": "lesson-rpd-enums-option-result",
+    "_type": "lesson",
+    "blocks": [
+      {
+        "_key": "intro",
+        "_type": "prose",
+        "src": "# Enums, `Option`, and `Result`\n\n> **Version stamp — checked 2026-07-26.** `anchor-lang 1.1.2` (latest on crates.io, published 2026-06-26) · `borsh 1.8.0` · `cargo-build-sbf` with platform-tools v1.54 (rustc 1.89) · edition 2021. `ERROR_CODE_OFFSET = 6000` and the numbering rule below were read out of `anchor-lang-error 1.1.2` and `anchor-syn 1.1.2`; the compiler messages quoted were produced by compiling this lesson's file.\n\nLesson 4's `sub_lamports` returned `None` when the vault did not hold enough. That was true and it was useless. `None` cannot tell a client whether the amount was zero, or larger than the balance, or whether the signer had no business asking. It says only \"no\".\n\n`Option` was the training-wheels version. This lesson is the real one.\n\n## An enum is a closed set of alternatives\n\nIn TypeScript you would reach for a union of string literals, and the compiler would help you a little:\n\n```ts\ntype VaultFailure = \"overflow\" | \"insufficient\" | \"zero\" | \"not-owner\";\n```\n\nA Rust enum is that idea with two properties the union does not have. First, a variant can carry data (`Option::Some(u64)` carries a `u64`; `None` carries nothing). Second — and this is the one that matters today — **the compiler will not let you handle some of the variants and forget the rest.**\n\n```rust\nmatch failure {\n    VaultError::Overflow => \"overflow\",\n    VaultError::InsufficientFunds => \"insufficient_funds\",\n    VaultError::ZeroAmount => \"zero_amount\",\n    // forget NotOwner and the file does not compile\n}\n```\n\nThat property has a name — exhaustiveness — and subgoal 3 is where you feel it rather than read about it.\n\n## `#[error_code]` and the 6000\n\n`#[error_code]` on an ordinary enum generates:\n\n| Generated | What it gives you |\n| --- | --- |\n| `#[derive(Debug, Clone, Copy)]`, `#[repr(u32)]` | the enum is cheap to pass around, by value |\n| `fn name(&self) -> String` | `\"ZeroAmount\"` — the variant's own name |\n| `impl From<VaultError> for u32` | `variant as u32 + 6000` |\n| `impl Display for VaultError` | your `#[msg]` string, reachable as `.to_string()` |\n| `impl From<VaultError> for Error` | why `.ok_or(VaultError::Overflow)?` converts on the way out |\n| `#[msg(\"...\")]` carried into the IDL | the string a client displays |\n\nTwo of those are worth separating, because it is easy to attribute the wrong one. **`error!(VaultError::ZeroAmount)` does not use the `From<VaultError> for Error` impl.** It expands to `Error::from(AnchorError { error_name: e.name(), error_code_number: e.into(), error_msg: e.to_string(), … })` — so it uses `name()`, the `u32` conversion, and `Display`, and builds the `Error` from an `AnchorError`. You can prove it: hand-roll an enum with only those three and `error!` compiles on it.\n\n`From<VaultError> for Error` is what `?` needs, which is lesson 12's subject and the reason `.ok_or(VaultError::Overflow)?` works in lesson 13 without an `error!` anywhere in the expression. Two routes to the same wire format, and knowing which is which is the difference between reading an `E0277` and guessing at it.\n\nThe 6000 is `anchor_lang::error::ERROR_CODE_OFFSET`. Everything below it is taken: the Solana runtime's own errors, and Anchor's built-in `ErrorCode` (`AccountDiscriminatorMismatch`, `ConstraintSeeds`, and about a hundred others). Your first variant is therefore **6000**, your second is 6001, and so on down the declaration order.\n\nSo the order of variants in the enum is part of your program's public interface. Insert a new variant in the middle and every code after it shifts by one — clients that hard-coded `6002` are now reading the wrong failure. Add at the end.\n\nThis is also why Anchor's guidance is **one `#[error_code]` enum per program**. Nothing stops you writing two — it compiles — and that is the problem: both start numbering at 6000, so `OtherError`'s first variant and `VaultError`'s first variant are the same code on the wire and no client can tell them apart. If you genuinely need a second enum, the mechanism is an explicit offset, `#[error_code(offset = 1000)]`, which replaces 6000 rather than adding to it.\n\n## `Result<T>` in an Anchor program\n\n`Result` is just an enum with two variants, `Ok(T)` and `Err(E)`. Anchor gives you a type alias:\n\n```rust\n// anchor_lang::Result<T> is\ncore::result::Result<T, anchor_lang::error::Error>\n```\n\nThat is what `Result<u64>` means everywhere in this file — one type parameter, because the error half is already decided. You will read `Result<()>` constantly in Course 3: an instruction handler that succeeds and returns nothing.\n\n`error!(VaultError::Overflow)` builds the `Error` value, and it captures the file and line where you wrote it, which is why the log tells you *where* the failure was raised, not just what it was.\n\nThere are two shorthands for this — `err!()` and `require!()` — and they belong to lesson 12. Today you write `match` and `Err(error!(...))` by hand, because the shorthands are much easier to read once you have seen what they replace.\n\n## Matching on `Option`, matching on `Result`\n\nBoth are enums, so both are matched the same way, and this is the whole of subgoal 2:\n\n```rust\n// Option -> Result: keep the value, name the failure\nmatch balance.checked_add(amount) {\n    Some(new_balance) => Ok(new_balance),\n    None => Err(error!(VaultError::Overflow)),\n}\n\n// Result -> plain value: decide what a failure means here\nmatch add_lamports(balance, amount) {\n    Ok(new_balance) => new_balance,\n    Err(_) => balance,        // a rejected deposit changes nothing\n}\n```\n\n`Err(_)` is the one place a wildcard is the right answer: you are deliberately saying *any* failure means the same thing here. Contrast that with subgoal 3, where a wildcard would be a bug.\n\n## `unwrap()`, and why this lesson is where it gets argued\n\nLesson 4 banned `.unwrap()` in one sentence and said module 3 would do it properly. This is that.\n\n`.unwrap()` takes an `Option` or a `Result` and either hands you the value or panics. You will see it in nearly every Rust tutorial you read, Solana ones included, and you must never put it in program code.\n\nA panic aborts the instruction with a generic runtime failure. The client gets no error code, no `#[msg]` string, no way to distinguish your four named failures from each other or from a bug. Every bit of the design in this lesson is thrown away at the moment you write `.unwrap()`.\n\nThat is the argument, and it is the only place in this course that makes it at length. `unwrap()` gets named again later — the compiler suggests it at you in lesson 9, and lesson 13 lists it among the things the vault core must not contain — but the reason is here.\n\n## Subgoal 3 is the point\n\nWrite the two exhaustive `match`es, get them green, and then add a fifth variant — `VaultFrozen` — and build **before** you change anything else.\n\nYou will get two errors, one per match site:\n\n```\nerror[E0004]: non-exhaustive patterns: `VaultError::VaultFrozen` not covered\n  --> src/lib.rs:77:11\n   |\n77 |     match e {\n   |           ^ pattern `VaultError::VaultFrozen` not covered\n```\n\nThat is the compiler handing you a to-do list of every place in the program that now has an unhandled case. If you have ever shipped a `switch` with a missing branch and found out from a user, this is the version of that bug that cannot happen.\n\nAnd this is exactly what a `_ =>` arm costs you. Add a catch-all to those matches and the fifth variant compiles silently, mapping to whatever the catch-all says — which will be wrong, and quiet about it. A wildcard is not a shortcut for \"handle the rest\"; it is a decision to stop being told when the set changes.\n\n## What the grader can and cannot see\n\nThe build server checks that your file **compiles** against Anchor 1.1.2. It does not run your functions.\n\nThe `mod verify` block at the bottom is not editable, and it pins each of the five function names to its exact signature — a missing function or a drifted type stops the build. That is a real check, and it is a check on *names and types only*. Nothing verifies that your `sub_lamports` subtracts rather than adds. Subgoal 3 is different: exhaustiveness is a compile-time property, so the compiler really does verify it, and that is why the fifth variant is where the lesson spends its effort.\n\nOne more thing the build does check, for a duller reason: each stub body ships a `compile_error!` naming its subgoal, so the file as delivered cannot build. Without it the placeholder bodies would compile green and an untouched submission would pass — which would tell you nothing about whether you had learned anything. Delete each one as you replace the line beneath it.\n"
+      },
+      {
+        "_key": "exercise",
+        "_type": "code",
+        "buildType": "buildable",
+        "deployable": false,
+        "hints": [
+          "Subgoal 2 is one shape, used twice: `match balance.checked_add(amount) { Some(new_balance) => Ok(new_balance), None => Err(error!(VaultError::Overflow)) }`, then the same with `checked_sub` and `InsufficientFunds`. Do NOT add a zero-amount guard — that is policy, it lives in lesson 13's `deposit`, and lesson 4 said so.",
+          "Subgoal 3: get both matches green over the four existing variants FIRST, then add `VaultFrozen` and build before touching anything else. The two `error[E0004]: non-exhaustive patterns` messages are the exercise — they name the file, the line and the variant.",
+          "Stuck on a type error in 2c? `balance_after_deposit` returns a plain `u64`, not a `Result`, so the `match` has to produce a `u64` from both arms: `Ok(new_balance) => new_balance` and `Err(_) => balance`. This is the one place a wildcard is correct — you are deliberately saying every failure means the same thing here."
+        ],
+        "language": "rust",
+        "solution": "// vault_core.rs — the error type, and Result instead of panic.\n\nuse anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n// ═════════════════════════════════════════════════════════════════════════════\n// SUBGOAL 1 — the error enum. PRE-FILLED. Read it; do not change it.\n// ═════════════════════════════════════════════════════════════════════════════\n//\n// `#[error_code]` takes an ordinary enum and generates:\n//   - `#[derive(Debug, Clone, Copy)]` and `#[repr(u32)]` on it\n//   - `fn name(&self) -> String`, returning the variant's name\n//   - `impl From<VaultError> for u32`  ->  `variant as u32 + 6000`\n//   - `impl Display for VaultError`, from your `#[msg]` strings\n//   - `impl From<VaultError> for anchor_lang::error::Error`\n//\n// `error!(VaultError::Overflow)` uses the first three, not the last one: it\n// builds an `AnchorError` out of `name()`, `into()` and `to_string()`. The\n// `From<VaultError> for Error` impl is what `?` needs, and lesson 12 is where\n// that matters.\n//\n// The 6000 is `anchor_lang::error::ERROR_CODE_OFFSET`. Codes below it belong to\n// the runtime and to Anchor itself, so your first variant is 6000, not 0.\n// `#[msg(...)]` is the string a client displays; it is carried into the IDL.\n#[error_code]\npub enum VaultError {\n    #[msg(\"Deposit would overflow the vault balance\")]\n    Overflow, // 6000\n    #[msg(\"Withdrawal exceeds the vault balance\")]\n    InsufficientFunds, // 6001\n    #[msg(\"Amount must be greater than zero\")]\n    ZeroAmount, // 6002\n    #[msg(\"Signer is not the vault owner\")]\n    NotOwner, // 6003\n    #[msg(\"Vault is frozen and cannot move lamports\")]\n    VaultFrozen, // 6004  <- added in SUBGOAL 3\n}\n\n// ═════════════════════════════════════════════════════════════════════════════\n// SUBGOAL 2 — turn lesson 4's `Option` into a `Result` that says why.\n// ═════════════════════════════════════════════════════════════════════════════\n\n/// 2a. `checked_add` answers \"did it fit?\". A program has to answer \"why not?\".\n///\n/// Note what is NOT here: a zero-amount check. `add_lamports(500, 0)` is\n/// `Ok(500)`. Rejecting a zero deposit is a policy, it belongs in the method\n/// that owns the vault, and lesson 13's `VaultState::deposit` is where\n/// `ZeroAmount` is finally raised — exactly as lesson 4 promised. The variant is\n/// declared here because the enum is the program's complete failure set; the\n/// enum being complete does not mean every variant is raised in this file.\npub fn add_lamports(balance: u64, amount: u64) -> Result<u64> {\n    match balance.checked_add(amount) {\n        Some(new_balance) => Ok(new_balance),\n        None => Err(error!(VaultError::Overflow)),\n    }\n}\n\n/// 2b. The same shape, and a different reason for the same shape of failure.\n/// `sub_lamports(500, 500)` is `Ok(0)` — withdrawing the whole balance is legal.\npub fn sub_lamports(balance: u64, amount: u64) -> Result<u64> {\n    match balance.checked_sub(amount) {\n        Some(remaining) => Ok(remaining),\n        None => Err(error!(VaultError::InsufficientFunds)),\n    }\n}\n\n/// 2c. Consuming a `Result` by matching on it. A rejected deposit leaves the\n/// balance where it was — no `.unwrap()`, no panic, no lost lamports.\npub fn balance_after_deposit(balance: u64, amount: u64) -> u64 {\n    match add_lamports(balance, amount) {\n        Ok(new_balance) => new_balance,\n        Err(_) => balance,\n    }\n}\n\n// ═════════════════════════════════════════════════════════════════════════════\n// SUBGOAL 3 — exhaustive matching, then add a fifth variant and watch.\n// ═════════════════════════════════════════════════════════════════════════════\n\n/// 3a. A stable code for logs and clients. Exhaustive `match`, no `_ =>` arm.\n/// `#[error_code]` derived `Copy`, so this takes the error by value — lesson 5's\n/// rule, applied.\npub fn error_slug(e: VaultError) -> &'static str {\n    match e {\n        VaultError::Overflow => \"overflow\",\n        VaultError::InsufficientFunds => \"insufficient_funds\",\n        VaultError::ZeroAmount => \"zero_amount\",\n        VaultError::NotOwner => \"not_owner\",\n        VaultError::VaultFrozen => \"vault_frozen\",\n    }\n}\n\n/// 3b. A second exhaustive `match` over the same enum: can the caller do\n/// anything about this, or is retrying pointless?\npub fn is_caller_fixable(e: VaultError) -> bool {\n    match e {\n        VaultError::Overflow => false,\n        VaultError::InsufficientFunds => true,\n        VaultError::ZeroAmount => true,\n        VaultError::NotOwner => false,\n        VaultError::VaultFrozen => false,\n    }\n}\n\n// ── DO NOT EDIT ──────────────────────────────────────────────────────────────\n// Pins the four names above to their exact signatures. If one is missing, or\n// its types drift, this stops compiling. It checks names and types — not what\n// your bodies compute.\n#[allow(dead_code)]\nmod verify {\n    use super::*;\n\n    const _ADD: fn(u64, u64) -> Result<u64> = add_lamports;\n    const _SUB: fn(u64, u64) -> Result<u64> = sub_lamports;\n    const _AFTER: fn(u64, u64) -> u64 = balance_after_deposit;\n    const _SLUG: fn(VaultError) -> &'static str = error_slug;\n    const _FIXABLE: fn(VaultError) -> bool = is_caller_fixable;\n}\n",
+        "starter": "// vault_core.rs — the error type, and Result instead of panic.\n//\n// Three subgoals. Do them in order; each one builds on the last.\n//\n// This file does NOT compile as given, and the code it ships is wrong as given —\n// both on purpose. Each stub body keeps the wrong line visible (read it, it is\n// the mistake being deleted) above a `compile_error!` that names the subgoal.\n// Build it once to see all three at once, then start at SUBGOAL 2, deleting each\n// `compile_error!` as you replace the line under it.\n\nuse anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n// ═════════════════════════════════════════════════════════════════════════════\n// SUBGOAL 1 — the error enum. PRE-FILLED. Read it; do not change it yet.\n// ═════════════════════════════════════════════════════════════════════════════\n//\n// `#[error_code]` takes an ordinary enum and generates:\n//   - `#[derive(Debug, Clone, Copy)]` and `#[repr(u32)]` on it\n//   - `fn name(&self) -> String`, returning the variant's name\n//   - `impl From<VaultError> for u32`  ->  `variant as u32 + 6000`\n//   - `impl Display for VaultError`, from your `#[msg]` strings\n//   - `impl From<VaultError> for anchor_lang::error::Error`\n//\n// `error!(VaultError::Overflow)` uses the first three, not the last one: it\n// builds an `AnchorError` out of `name()`, `into()` and `to_string()`. The\n// `From<VaultError> for Error` impl is what `?` needs, and lesson 12 is where\n// that matters.\n//\n// The 6000 is `anchor_lang::error::ERROR_CODE_OFFSET`. Codes below it belong to\n// the runtime and to Anchor itself, so your first variant is 6000, not 0.\n// `#[msg(...)]` is the string a client displays; it is carried into the IDL.\n#[error_code]\npub enum VaultError {\n    #[msg(\"Deposit would overflow the vault balance\")]\n    Overflow, // 6000\n    #[msg(\"Withdrawal exceeds the vault balance\")]\n    InsufficientFunds, // 6001\n    #[msg(\"Amount must be greater than zero\")]\n    ZeroAmount, // 6002\n    #[msg(\"Signer is not the vault owner\")]\n    NotOwner, // 6003\n    // SUBGOAL 3 adds a fifth variant right here. Not yet.\n}\n\n// ═════════════════════════════════════════════════════════════════════════════\n// SUBGOAL 2 — turn lesson 4's `Option` into a `Result` that says why.\n// ═════════════════════════════════════════════════════════════════════════════\n//\n// Lesson 4 gave you `Option<u64>`: Some means it fit, None means it did not.\n// A program has to tell a client WHICH failure happened, so the answer becomes\n// `Result<u64>` — that is `anchor_lang::Result<u64>`, i.e.\n// `core::result::Result<u64, anchor_lang::error::Error>`.\n//\n// Use `match` on the Option. Do NOT use `?` — that is lesson 12.\n// Do NOT use `.unwrap()` — see the note at the bottom of this file.\n\n/// 2a. `match` on `balance.checked_add(amount)`:\n///       Some(new_balance) => Ok(new_balance)\n///       None              => Err(error!(VaultError::Overflow))\n///\n///     One thing NOT to add: a zero-amount check. Lesson 4 said rejecting a\n///     zero deposit is a policy and belongs in the vault's `deposit` method,\n///     and that still holds — `ZeroAmount` gets raised in lesson 13, not here.\n///     `add_lamports(500, 0)` is `Ok(500)`. Arithmetic answers \"did it fit?\".\npub fn add_lamports(balance: u64, amount: u64) -> Result<u64> {\n    // TODO (2a) — replace this. `balance + amount` is the bug this whole course\n    // exists to delete: the build server compiles with `overflow-checks = true`,\n    // so on a u64 wrap this panics instead of returning your named error.\n    compile_error!(\"Subgoal 2a is not written yet: match on checked_add, Some -> Ok, None -> Err(error!(VaultError::Overflow)). Delete this line and replace the `balance + amount` line below it.\");\n    Ok(balance + amount)\n}\n\n/// 2b. Same shape, different reason: `checked_sub`, and `None` means the vault\n///     does not hold that much -> `VaultError::InsufficientFunds`.\npub fn sub_lamports(balance: u64, amount: u64) -> Result<u64> {\n    // TODO (2b) — replace this.\n    compile_error!(\"Subgoal 2b is not written yet: same shape as 2a, but checked_sub, and None means VaultError::InsufficientFunds. Delete this line and replace the line below it.\");\n    Ok(balance - amount)\n}\n\n/// 2c. Now consume a `Result` by matching on it. A rejected deposit must leave\n///     the balance exactly where it was.\n///       Ok(new_balance) => new_balance\n///       Err(_)          => balance\npub fn balance_after_deposit(balance: u64, amount: u64) -> u64 {\n    // TODO (2c) — replace this with a `match` on `add_lamports(balance, amount)`.\n    compile_error!(\"Subgoal 2c is not written yet: match on add_lamports(balance, amount) — Ok(new_balance) => new_balance, Err(_) => balance. Delete this line and the two below it.\");\n    let _ = amount;\n    balance\n}\n\n// ═════════════════════════════════════════════════════════════════════════════\n// SUBGOAL 3 — exhaustive matching, then add a fifth variant and watch.\n// ═════════════════════════════════════════════════════════════════════════════\n//\n// Order matters here. Write 3a and 3b first, build them green, and only then\n// do step 3c.\n\n/// 3a. A stable code for logs and clients. Write an exhaustive `match` over\n///     every variant of `VaultError`. NO `_ =>` arm — a catch-all is how you\n///     throw exhaustiveness away, which is the one thing this lesson is about.\n///     Suggested strings: \"overflow\", \"insufficient_funds\", \"zero_amount\",\n///     \"not_owner\".\n///\n///     `#[error_code]` derived `Copy`, so this takes the error by value rather\n///     than by reference. That is lesson 5's rule, applied.\npub fn error_slug(e: VaultError) -> &'static str {\n    // TODO (3a) — replace this with the match.\n    compile_error!(\"Subgoal 3a is not written yet: an exhaustive match over every VaultError variant, no `_ =>` arm. Delete this line and the two below it.\");\n    let _ = e;\n    \"todo\"\n}\n\n/// 3b. A second exhaustive `match` over the same enum. Can the caller do\n///     anything about this, or is retrying pointless?\n///       Overflow => false, InsufficientFunds => true,\n///       ZeroAmount => true, NotOwner => false\npub fn is_caller_fixable(e: VaultError) -> bool {\n    // TODO (3b) — replace this with the match.\n    compile_error!(\"Subgoal 3b is not written yet: a second exhaustive match over VaultError returning bool. Delete this line and the two below it.\");\n    let _ = e;\n    false\n}\n\n// TODO (3c) — the point of the whole lesson.\n//\n// Add a fifth variant to VaultError, in SUBGOAL 1:\n//\n//     #[msg(\"Vault is frozen and cannot move lamports\")]\n//     VaultFrozen,\n//\n// Then BUILD, before you change anything else. Read the errors. There will be\n// two of them, one per match site, each one naming the file and the line and\n// the variant you did not handle: `error[E0004]: non-exhaustive patterns:\n// `VaultError::VaultFrozen` not covered`.\n//\n// That is the compiler enumerating your unhandled cases. It is the JavaScript\n// `switch` you forgot to update, caught before the code shipped instead of by a\n// user. Now add the two arms — \"vault_frozen\", and false — and build green.\n\n// ── DO NOT EDIT ──────────────────────────────────────────────────────────────\n// Pins the five names above to their exact signatures. If one is missing, or its\n// types drift, this stops compiling. It checks names and types — not what your\n// bodies compute.\n#[allow(dead_code)]\nmod verify {\n    use super::*;\n\n    const _ADD: fn(u64, u64) -> Result<u64> = add_lamports;\n    const _SUB: fn(u64, u64) -> Result<u64> = sub_lamports;\n    const _AFTER: fn(u64, u64) -> u64 = balance_after_deposit;\n    const _SLUG: fn(VaultError) -> &'static str = error_slug;\n    const _FIXABLE: fn(VaultError) -> bool = is_caller_fixable;\n}\n\n// ── `unwrap()` ───────────────────────────────────────────────────────────────\n// Do not use it here. The reason is on the lesson page, argued in full: a panic\n// aborts the instruction with no error code and no `#[msg]` string, so every\n// named variant above becomes indistinguishable noise.\n",
+        "tests": [
+          {
+            "description": "The file compiles against anchor-lang 1.1.2 on the build server",
+            "expectedOutput": "true",
+            "id": "compiles",
+            "input": ""
+          },
+          {
+            "description": "The non-editable `mod verify` block resolves: add_lamports, sub_lamports, balance_after_deposit, error_slug and is_caller_fixable all exist with the exact declared signatures — a missing name or a drifted type is a compile error",
+            "expectedOutput": "true",
+            "id": "verify-harness-resolves",
+            "input": ""
+          },
+          {
+            "description": "Every `match` over VaultError covers every variant you declared — omitting one is E0004 at compile time. Note what this cannot see: a `_ =>` catch-all also compiles, so dropping the wildcard is your discipline, not the grader's",
+            "expectedOutput": "true",
+            "id": "matches-cover-declared-variants",
+            "input": ""
+          }
+        ]
+      },
+      {
+        "_key": "check",
+        "_type": "quiz",
+        "questions": [
+          {
+            "explanation": "A wildcard is not a shortcut for \"handle the rest\". It is a decision to stop being told when the set of cases changes. Two match sites with no wildcard gave you a to-do list; two with a wildcard give you silence.",
+            "id": "q1",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "It compiles, and `error_slug(VaultError::VaultFrozen)` silently returns \"unknown\""
+              },
+              {
+                "correct": false,
+                "feedback": "A `_` arm makes the match exhaustive by definition. That is the whole reason it silences E0004, and the whole reason it is a bad idea here.",
+                "id": "b",
+                "label": "`error[E0004]` still fires — the compiler requires named arms for every variant regardless of a catch-all"
+              },
+              {
+                "correct": false,
+                "feedback": "That warning appears when every variant IS named above the wildcard. In this question only four are, so the wildcard is reachable — it is doing exactly the thing you did not want.",
+                "id": "c",
+                "label": "`warning: unreachable pattern` on the `_` arm, because all five variants are named above it"
+              },
+              {
+                "correct": false,
+                "feedback": "The number and the slug are unrelated. `error_slug` returns whatever your match arms say, and the catch-all says \"unknown\".",
+                "id": "d",
+                "label": "It compiles and `VaultFrozen` gets code 6004, so the slug is derived from the number"
+              }
+            ],
+            "prompt": "You add `_ => \"unknown\"` as a final arm to `error_slug`, and only then add the fifth variant `VaultFrozen`. Predict."
+          },
+          {
+            "explanation": "Because the code is the declaration index plus 6000, variant order is part of your program's public interface. Insert a variant in the middle and every code after it shifts. Add at the end.",
+            "id": "q2",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "`ZeroAmount` — custom codes start at 6000, so index 2 is 6002"
+              },
+              {
+                "correct": false,
+                "feedback": "The variant is right and the reasoning is not. Without the 6000 offset the code would be 2, which collides with the Solana runtime's own error space. `impl From<VaultError> for u32` is literally `variant as u32 + 6000`.",
+                "id": "b",
+                "label": "`ZeroAmount` — but only because you declared it third; the code is the declaration index alone, with no offset"
+              },
+              {
+                "correct": false,
+                "feedback": "Enum discriminants start at 0, so the first variant is 6000 exactly.",
+                "id": "c",
+                "label": "`NotOwner` — the offset is 6000 and codes are 1-based, so 6001 is the first variant"
+              },
+              {
+                "correct": false,
+                "feedback": "Anchor's built-in `ErrorCode` sits below 6000. Everything from 6000 up is yours, which is exactly what the offset buys.",
+                "id": "d",
+                "label": "Not determinable — 6002 is Anchor's own error space, not yours"
+              }
+            ],
+            "prompt": "A client's transaction fails and the log shows `custom program error: 0x1772`. That is 6002 in decimal. Given the enum in the exercise — `Overflow`, `InsufficientFunds`, `ZeroAmount`, `NotOwner`, `VaultFrozen`, in that order — which failure was it?"
+          },
+          {
+            "explanation": "One error enum per program is the rule, and the reason is the numbering, not the compiler. If you truly need a second one, give it an explicit range with `#[error_code(offset = 1000)]` — which replaces 6000 rather than adding to it.",
+            "id": "q3",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "It compiles — and that is the problem: `LayoutError::TooShort` is also 6000, indistinguishable on the wire from `VaultError::Overflow`"
+              },
+              {
+                "correct": false,
+                "feedback": "There is no such check in anchor-lang 1.1.2 — verified by compiling it. The guidance is real; the compiler does not enforce it, which is why the failure is silent and on the wire.",
+                "id": "b",
+                "label": "`error: only one #[error_code] enum is permitted per program`"
+              },
+              {
+                "correct": false,
+                "feedback": "Nothing auto-assigns a second range. Both enums default to `ERROR_CODE_OFFSET`, which is 6000 for every enum that does not say otherwise.",
+                "id": "c",
+                "label": "It compiles, and Anchor numbers the second enum from 7000 so the two cannot collide"
+              },
+              {
+                "correct": false,
+                "feedback": "That is not the failure mode. Both are generated; the collision is in the numbers a client reads back.",
+                "id": "d",
+                "label": "It compiles, but only one of the two ends up in the IDL, so the other's `#[msg]` strings are lost"
+              }
+            ],
+            "prompt": "You decide layout failures deserve their own type, so you add a second `#[error_code] pub enum LayoutError { TooShort }` to the same file. Predict."
+          },
+          {
+            "explanation": "Every named variant, every `#[msg]` string and every error code in this lesson is thrown away at the moment you write `.unwrap()`. It appears nowhere in this course's code — the one place you will see it written out is lesson 9, where the compiler itself suggests it and the right answer is to refuse.",
+            "id": "q4",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "A panic that aborts the instruction — no 6001, no \"Withdrawal exceeds the vault balance\", nothing to distinguish it from a bug"
+              },
+              {
+                "correct": false,
+                "feedback": "`.unwrap()` does not propagate anything. It panics, and the named error never reaches the client. Propagating is `?`, which is lesson 12.",
+                "id": "b",
+                "label": "`custom program error: 0x1771` — `.unwrap()` propagates the error, it just does not let you inspect it"
+              },
+              {
+                "correct": false,
+                "feedback": "It compiles. That is the danger: nothing in the toolchain stops you, which is why the rule has to be yours.",
+                "id": "c",
+                "label": "A compile error — `.unwrap()` is not available on `anchor_lang::Result`"
+              },
+              {
+                "correct": false,
+                "feedback": "That is `unwrap_or_default()`, a different method. `.unwrap()` has no fallback — it panics.",
+                "id": "d",
+                "label": "`remaining` is 0, since `.unwrap()` falls back to the type's default on `Err`"
+              }
+            ],
+            "prompt": "Carried over from lesson 4. There, `sub_lamports(5, 7)` returned `None`. Here it returns `Err(error!(VaultError::InsufficientFunds))`. A caller inside a program writes `let remaining = sub_lamports(5, 7).unwrap();`. Predict what the client sees."
+          }
+        ]
+      }
+    ],
+    "skills": [
+      "rust-enums",
+      "rust-option",
+      "rust-result",
+      "error-handling"
+    ],
+    "slug": {
+      "_type": "slug",
+      "current": "enums-option-result"
+    },
+    "title": "Enums, `Option`, and `Result`"
+  },
+  {
+    "_id": "lesson-rpd-error-plumbing",
+    "_type": "lesson",
+    "blocks": [
+      {
+        "_key": "intro",
+        "_type": "prose",
+        "src": "# Error Plumbing with `?`\n\n> **Version stamp — checked 2026-07-26.** `anchor-lang 1.1.2` (latest on crates.io, published 2026-06-26) · `borsh 1.8.0` · `cargo-build-sbf` with platform-tools v1.54 (rustc 1.89) · edition 2021. Every compiler message quoted below was produced by compiling this lesson's file; the `require!` / `require_keys_eq!` expansions were read out of `anchor-lang 1.1.2`'s source.\n\nLesson 11 gave every failure a name. Now they have to travel.\n\nA real instruction is a chain: read the bytes, validate what they say, apply the policy, do the arithmetic. Any link can fail, and the failure has to arrive at the top intact. Written by hand, the middle of that chain is nothing but plumbing:\n\n```rust\nlet amount = match read_amount(data) {\n    Ok(amount) => amount,\n    Err(e) => return Err(e.into()),\n};\n```\n\nFour lines to say \"if this failed, stop.\" `?` is that, in one character.\n\n## What `?` actually does\n\n```rust\nlet amount = read_amount(data)?;\n```\n\ndesugars to roughly:\n\n1. Evaluate `read_amount(data)`.\n2. If it is `Ok(v)`, the expression's value is `v` and execution continues.\n3. If it is `Err(e)`, **return `Err(From::from(e))` from the enclosing function immediately.**\n\nStep 3 is the whole lesson. `?` does not just propagate the error, it **converts** it — by calling `From::from` on the way out. Which means `?` only works across two different error types if a `From` impl connects them.\n\nThat is why `?` stops feeling arbitrary once you have lesson 10's trait material. It is not a special language feature that knows about your errors. It is one trait lookup, and you can write the trait impl yourself.\n\n## The seam this file has\n\nThe exercise chain has three layers and two error types.\n\n| Layer | Function | Fails with |\n| --- | --- | --- |\n| Layout | `read_amount(&[u8])` | `LayoutError` — a plain enum |\n| Policy | `check_amount(u64)`, `check_owner(&Pubkey, &Pubkey)` | `VaultError` — the `#[error_code]` enum |\n| Caller | `withdraw_amount(...)` | `anchor_lang::error::Error` |\n\n`LayoutError` is deliberately **not** an `#[error_code]` enum. Lesson 11's rule holds: one `#[error_code]` per program, because a second one numbers from 6000 too and collides on the wire. A malformed instruction is an internal concern, so `LayoutError` stays a plain enum and is translated at the boundary:\n\n```rust\nimpl From<LayoutError> for anchor_lang::error::Error {\n    fn from(e: LayoutError) -> Self {\n        match e {\n            LayoutError::TooShort => error!(ErrorCode::InstructionDidNotDeserialize),\n        }\n    }\n}\n```\n\n`ErrorCode` there is Anchor's own built-in enum — the one that lives below 6000 — and `InstructionDidNotDeserialize` is exactly what a client should be told when the instruction data was the wrong shape.\n\nDelete that impl and the chain stops compiling:\n\n```\nerror[E0277]: `?` couldn't convert the error to `anchor_lang::prelude::Error`\n   |\n   | ) -> Result<u64> {\n   |      ----------- expected `anchor_lang::prelude::Error` because of this\n   |     let amount = read_amount(data)?;\n   |                  -----------------^ the trait `std::convert::From<LayoutError>` is not implemented for `anchor_lang::prelude::Error`\n   |                  |\n   |                  this can't be annotated with `?` because it has type `Result<_, LayoutError>`\n   |\nnote: `LayoutError` needs to implement `Into<anchor_lang::prelude::Error>`\n```\n\nRead that error twice. It is not saying `?` is broken. It is naming the exact trait impl that is missing, which is the most useful error message in this course.\n\n## `require!` and `err!`, with the covers off\n\nBoth are shorthands you have already written longhand.\n\n```rust\nrequire!(amount > 0, VaultError::ZeroAmount);\n// expands to:\nif !(amount > 0) { return Err(error!(VaultError::ZeroAmount)); }\n\nerr!(VaultError::Overflow)\n// expands to:\nErr(error!(VaultError::Overflow))\n```\n\nThat is the entire definition of each. `require!` is for testing a condition; `err!` is for returning an error you have already decided on — a `match` arm, usually. Neither does anything you could not type yourself, and both make the intent legible at a glance, which in a program full of guard clauses is worth a lot.\n\nOne near-miss worth knowing: for pubkeys, use `require_keys_eq!`, not `require_eq!`. `require_eq!` will compile — `Pubkey` implements `ToString`, so the generic version accepts it — but Anchor's own docs reserve it for non-pubkey values, and `require_keys_eq!` records the two operands as pubkeys and logs them with `Pubkey::log()` rather than allocating two strings. Same check, fewer compute units, and the log shape a client expects.\n\n## `?` does not work on `Option`\n\nThis is the error you will hit most, and the compiler is unusually helpful about it:\n\n```\nerror[E0277]: the `?` operator can only be used on `Result`s, not `Option`s,\n              in a function that returns `Result`\n   |\n   |     let remaining = balance.checked_sub(amount)?;\n   |                                                ^ use `.ok_or(...)?` to provide\n   |                                                  an error compatible with\n   |                                                  `Result<u64, Error>`\n```\n\nThe reason follows from step 3 above: `?` converts the error by calling `From::from` on it, and `None` is not an error value — there is nothing to convert. So you supply one:\n\n```rust\nlet remaining = balance\n    .checked_sub(amount)\n    .ok_or(error!(VaultError::InsufficientFunds))?;\n```\n\n`ok_or` turns `Option<u64>` into `Result<u64, Error>` by naming the failure, and *then* `?` has something to carry. This single line is the bridge from lesson 4's `Option`-returning helpers to a program that reports real errors — and it is where `checked_sub` finally becomes `VaultState::withdraw`.\n\n## Closing the lesson-4 loop\n\nLesson 4's helpers were `const fn`, and they matched on `Option` by hand instead of using `?`. Now you know why: **`?` is not allowed in a `const fn`.**\n\n```\nerror[E0015]: `?` is not allowed on `Option<u64>` in constant functions\n  = note: calls in constant functions are limited to constant functions, tuple\n          structs and tuple variants\n```\n\nThe note is the mechanism: `?` desugars to calls into the `Try` machinery, those functions are not `const fn`, and a `const fn` may only call `const fn`. So the compiler does not report a missing feature — it reports a non-const call. `match` works in a `const fn`; `?` does not. That constraint is what made the compile-time assertion harness in lesson 4 possible, and it is why those two functions look different from everything in this file.\n\n## The exercise\n\nThe file does not compile as given, and that is the exercise. Every line you need is present; two functions have had their statements shuffled, and one of them carries two decoy lines.\n\nBuild first. The compiler's first pass gives you four errors, and each one is a location:\n\n- `error[E0425]: cannot find value 'head' in this scope` — a line uses a name that a later line defines. Order.\n- `error[E0425]: cannot find value 'amount' in this scope` — same problem, other function.\n- `error[E0308]: mismatched types ... expected 'u64', found 'Result<u64, LayoutError>'` — decoy: somebody dropped the `?`.\n- `error[E0277]: the '?' operator can only be used on 'Result's, not 'Option's` — decoy: `?` on `checked_sub`.\n\nWork in two passes: fix the order first, then delete the decoys. Do not try to repair a decoy — it is meant to go.\n\nBoth decoys are compile errors rather than silent bugs, which buys something real and less than it sounds. What the grader can tell is that **neither decoy survived** — leave either one in place and the build is red. What it cannot tell is whether you kept every *correct* line, or what order you put them in. Delete `let amount = check_amount(amount)?;` as though it were a third decoy and the file compiles green with the zero-amount policy simply gone. Move `check_owner(signer, owner)?;` to the bottom and it compiles green with the authorisation check running after the arithmetic — the exact inversion of step 1 above.\n\nSo: the two decoys are enforced, the ordering and the completeness are on you. That is the same limit as every other exercise in this course, narrowed by two lines rather than removed. It is still why the lesson is shaped as an ordering-and-discrimination task — a decoy that fails loudly is worth more than a blank page — but do not read a green build as \"the chain is right\".\n"
+      },
+      {
+        "_key": "exercise",
+        "_type": "code",
+        "buildType": "buildable",
+        "deployable": false,
+        "hints": [
+          "Build it first. The file is not supposed to compile yet, and the four errors are the instructions. Read only the first one — the rest of a Rust error list is usually cascade from the first.",
+          "Order before deletion. Both `E0425: cannot find value` errors mean a statement uses a name that a later statement defines, so move the definition up. In `withdraw_amount` the chain is: owner check, read, policy check, subtract.",
+          "The two decoys are `let amount = read_amount(data);` (no `?`, so `amount` is a `Result` and the next call rejects it) and `let remaining = balance.checked_sub(amount)?;` (`?` on an `Option`, which cannot work because `None` carries no error to convert). Delete both — the correct subtraction line, with `.ok_or(error!(VaultError::InsufficientFunds))?`, is already in the file."
+        ],
+        "language": "rust",
+        "solution": "// vault_core.rs — errors that travel.\n\nuse anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n// ── GIVEN: the program's one error enum ──────────────────────────────────────\n#[error_code]\npub enum VaultError {\n    #[msg(\"Deposit would overflow the vault balance\")]\n    Overflow,\n    #[msg(\"Withdrawal exceeds the vault balance\")]\n    InsufficientFunds,\n    #[msg(\"Amount must be greater than zero\")]\n    ZeroAmount,\n    #[msg(\"Signer is not the vault owner\")]\n    NotOwner,\n}\n\n// ── GIVEN: a SECOND error type, deliberately not an #[error_code] ────────────\n//\n// One `#[error_code]` enum per program: a second one would also number from\n// 6000 and collide on the wire. Layout failures are an internal concern, so\n// `LayoutError` is a plain enum that never reaches a client under its own name.\n#[derive(Debug, Clone, Copy, PartialEq, Eq)]\npub enum LayoutError {\n    TooShort,\n}\n\n// ── GIVEN: the conversion that makes `?` work across the seam ────────────────\n//\n// This is the payoff from lesson 10. `?` does not know anything about your error\n// types; it calls `From::from` on the error it is carrying. Write the `From` impl\n// and `?` starts crossing the boundary. Delete it and `?` stops compiling — the\n// operator is not magic, it is one trait lookup.\nimpl From<LayoutError> for anchor_lang::error::Error {\n    fn from(e: LayoutError) -> Self {\n        match e {\n            LayoutError::TooShort => error!(ErrorCode::InstructionDidNotDeserialize),\n        }\n    }\n}\n\n// ── LAYER 1: layout. Fails with LayoutError. ─────────────────────────────────\n//\n// Note the return type: `core::result::Result<u64, LayoutError>`, spelled out,\n// because bare `Result<u64>` in this file means Anchor's alias.\nfn read_amount(data: &[u8]) -> core::result::Result<u64, LayoutError> {\n    let head = data.get(..8).ok_or(LayoutError::TooShort)?;\n    let bytes: [u8; 8] = head.try_into().map_err(|_| LayoutError::TooShort)?;\n    Ok(u64::from_le_bytes(bytes))\n}\n\n// ── LAYER 2: policy. Fails with VaultError. ──────────────────────────────────\n//\n// `require!(cond, E)` expands to `if !(cond) { return Err(error!(E)); }`.\n// Nothing more. It reads better than the `if`, and that is its whole value.\nfn check_amount(amount: u64) -> Result<u64> {\n    require!(amount > 0, VaultError::ZeroAmount);\n    Ok(amount)\n}\n\n// `require_eq!` would also compile here — `Pubkey` implements `ToString`. Use\n// `require_keys_eq!` anyway: Anchor's own docs reserve `require_eq!` for\n// non-pubkey values, and the pubkey version records the two operands as pubkeys\n// and logs them with `Pubkey::log()` instead of allocating two strings. Same\n// check, fewer compute units, and the log a client expects.\nfn check_owner(signer: &Pubkey, owner: &Pubkey) -> Result<()> {\n    require_keys_eq!(*signer, *owner, VaultError::NotOwner);\n    Ok(())\n}\n\n// ── LAYER 3: the caller. Chains both layers with `?`. ────────────────────────\npub fn withdraw_amount(\n    data: &[u8],\n    balance: u64,\n    signer: &Pubkey,\n    owner: &Pubkey,\n) -> Result<u64> {\n    check_owner(signer, owner)?;\n    let amount = read_amount(data)?;\n    let amount = check_amount(amount)?;\n    let remaining = balance\n        .checked_sub(amount)\n        .ok_or(error!(VaultError::InsufficientFunds))?;\n    Ok(remaining)\n}\n\n/// The deposit half. Two `?` in one expression, and `err!(E)` — which is exactly\n/// `Err(error!(E))`, for when you are returning the error rather than testing a\n/// condition.\npub fn deposit_amount(data: &[u8], balance: u64) -> Result<u64> {\n    let amount = check_amount(read_amount(data)?)?;\n    match balance.checked_add(amount) {\n        Some(new_balance) => Ok(new_balance),\n        None => err!(VaultError::Overflow),\n    }\n}\n\n/// GIVEN, to read rather than to call: `?` with the sugar taken off.\n/// It is a `match`, an early `return`, and one call to `From::from`.\npub fn read_amount_the_long_way(data: &[u8]) -> Result<u64> {\n    match read_amount(data) {\n        Ok(amount) => Ok(amount),\n        Err(layout) => Err(anchor_lang::error::Error::from(layout)),\n    }\n}\n\n// ── DO NOT EDIT ──────────────────────────────────────────────────────────────\n// Pins the chain's shape: the three names below must exist with exactly these\n// types. Names and types only — nothing here checks what your bodies compute.\n#[allow(dead_code)]\nmod verify {\n    use super::*;\n\n    const _WITHDRAW: fn(&[u8], u64, &Pubkey, &Pubkey) -> Result<u64> = withdraw_amount;\n    const _DEPOSIT: fn(&[u8], u64) -> Result<u64> = deposit_amount;\n    const _LONG_WAY: fn(&[u8]) -> Result<u64> = read_amount_the_long_way;\n}\n",
+        "starter": "// vault_core.rs — errors that travel.\n//\n// THIS FILE DOES NOT COMPILE AS GIVEN. That is the exercise.\n//\n// Two functions have had their lines shuffled, and one of them carries two decoy\n// lines that look plausible and are not. Every piece you need is already here —\n// nothing has to be invented. Build first and let the compiler tell you what is\n// out of order; then reorder, and delete the two decoys.\n\nuse anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n// ── GIVEN: the program's one error enum ──────────────────────────────────────\n#[error_code]\npub enum VaultError {\n    #[msg(\"Deposit would overflow the vault balance\")]\n    Overflow,\n    #[msg(\"Withdrawal exceeds the vault balance\")]\n    InsufficientFunds,\n    #[msg(\"Amount must be greater than zero\")]\n    ZeroAmount,\n    #[msg(\"Signer is not the vault owner\")]\n    NotOwner,\n}\n\n// ── GIVEN: a SECOND error type, deliberately not an #[error_code] ────────────\n//\n// One `#[error_code]` enum per program: a second one would also number from\n// 6000 and collide on the wire. Layout failures are an internal concern, so\n// `LayoutError` is a plain enum that never reaches a client under its own name.\n#[derive(Debug, Clone, Copy, PartialEq, Eq)]\npub enum LayoutError {\n    TooShort,\n}\n\n// ── GIVEN: the conversion that makes `?` work across the seam ────────────────\n//\n// This is the payoff from lesson 10. `?` does not know anything about your error\n// types; it calls `From::from` on the error it is carrying. Write the `From` impl\n// and `?` starts crossing the boundary. Delete it and `?` stops compiling — the\n// operator is not magic, it is one trait lookup.\nimpl From<LayoutError> for anchor_lang::error::Error {\n    fn from(e: LayoutError) -> Self {\n        match e {\n            LayoutError::TooShort => error!(ErrorCode::InstructionDidNotDeserialize),\n        }\n    }\n}\n\n// ── LAYER 1: layout. SCRAMBLED — two correct lines, wrong order. ─────────────\n//\n// Note the return type: `core::result::Result<u64, LayoutError>`, spelled out,\n// because bare `Result<u64>` in this file means Anchor's alias.\n//\n// Swap the two statements. Think about which name has to exist before the next\n// line can use it. The tail expression at the bottom is correct — leave it.\nfn read_amount(data: &[u8]) -> core::result::Result<u64, LayoutError> {\n    let bytes: [u8; 8] = head.try_into().map_err(|_| LayoutError::TooShort)?;\n    let head = data.get(..8).ok_or(LayoutError::TooShort)?;\n\n    Ok(u64::from_le_bytes(bytes))\n}\n\n// ── LAYER 2: policy. GIVEN — read these two, they are your reference. ────────\n//\n// `require!(cond, E)` expands to `if !(cond) { return Err(error!(E)); }`.\n// Nothing more. It reads better than the `if`, and that is its whole value.\nfn check_amount(amount: u64) -> Result<u64> {\n    require!(amount > 0, VaultError::ZeroAmount);\n    Ok(amount)\n}\n\n// `require_eq!` would also compile here — `Pubkey` implements `ToString`. Use\n// `require_keys_eq!` anyway: Anchor's own docs reserve `require_eq!` for\n// non-pubkey values, and the pubkey version records the two operands as pubkeys\n// and logs them with `Pubkey::log()` instead of allocating two strings. Same\n// check, fewer compute units, and the log a client expects.\nfn check_owner(signer: &Pubkey, owner: &Pubkey) -> Result<()> {\n    require_keys_eq!(*signer, *owner, VaultError::NotOwner);\n    Ok(())\n}\n\n// ── LAYER 3: the caller. SCRAMBLED, plus two decoys. ─────────────────────────\n//\n// Six statements below. FOUR are correct and in the wrong order. TWO are decoys:\n// delete them, do not try to make them work. The tail expression is correct.\n//\n// Do it in two passes.\n//\n// Pass 1 — order. The chain you want, in words:\n//   1. refuse anyone who is not the owner\n//   2. read the amount out of the instruction data\n//   3. check the amount against policy\n//   4. subtract it from the balance, refusing to underflow\n//\n// Pass 2 — discrimination. Delete the two decoys. Both are compile errors rather\n// than silent bugs, so the build server genuinely cannot pass this block while\n// one is still here. Read each error before you delete the line; the decoy that\n// calls `?` on an `Option` produces the single most useful message in this\n// lesson, and the compiler suggests the fix in the error text itself.\n//\n// What pass 2 does NOT get you: the ordering from pass 1 is not checked by\n// anything. Delete a correct line as though it were a third decoy, or run the\n// owner check last, and this file still compiles. Two lines are enforced; the\n// chain is yours.\npub fn withdraw_amount(\n    data: &[u8],\n    balance: u64,\n    signer: &Pubkey,\n    owner: &Pubkey,\n) -> Result<u64> {\n    let amount = check_amount(amount)?;\n    let amount = read_amount(data);\n    check_owner(signer, owner)?;\n    let remaining = balance.checked_sub(amount)?;\n    let amount = read_amount(data)?;\n    let remaining = balance\n        .checked_sub(amount)\n        .ok_or(error!(VaultError::InsufficientFunds))?;\n\n    Ok(remaining)\n}\n\n/// GIVEN: the deposit half. Two `?` in one expression, and `err!(E)` — which is\n/// exactly `Err(error!(E))`, for when you are returning the error rather than\n/// testing a condition.\npub fn deposit_amount(data: &[u8], balance: u64) -> Result<u64> {\n    let amount = check_amount(read_amount(data)?)?;\n    match balance.checked_add(amount) {\n        Some(new_balance) => Ok(new_balance),\n        None => err!(VaultError::Overflow),\n    }\n}\n\n/// GIVEN, to read rather than to call: `?` with the sugar taken off.\n/// It is a `match`, an early `return`, and one call to `From::from`.\npub fn read_amount_the_long_way(data: &[u8]) -> Result<u64> {\n    match read_amount(data) {\n        Ok(amount) => Ok(amount),\n        Err(layout) => Err(anchor_lang::error::Error::from(layout)),\n    }\n}\n\n// ── DO NOT EDIT ──────────────────────────────────────────────────────────────\n// Pins the chain's shape: the three names below must exist with exactly these\n// types. Names and types only — nothing here checks what your bodies compute.\n#[allow(dead_code)]\nmod verify {\n    use super::*;\n\n    const _WITHDRAW: fn(&[u8], u64, &Pubkey, &Pubkey) -> Result<u64> = withdraw_amount;\n    const _DEPOSIT: fn(&[u8], u64) -> Result<u64> = deposit_amount;\n    const _LONG_WAY: fn(&[u8]) -> Result<u64> = read_amount_the_long_way;\n}\n\n// ── Why lesson 4 could not use `?` ───────────────────────────────────────────\n// Lesson 4's helpers were `const fn`, and matched on `Option` by hand. Now you\n// know why: `?` is not allowed in a `const fn`. Try it and the compiler says\n// `error[E0015]: '?' is not allowed on 'Option<u64>' in constant functions`,\n// because the `Try` trait is not yet const. `match` works in a `const fn`;\n// `?` does not. That is the entire reason those two functions look different\n// from everything in this file.\n",
+        "tests": [
+          {
+            "description": "The file compiles against anchor-lang 1.1.2 on the build server — which for this exercise means the scrambled statements are in a working order",
+            "expectedOutput": "true",
+            "id": "compiles",
+            "input": ""
+          },
+          {
+            "description": "Neither decoy survives: `read_amount(data)` without `?` is E0308, and `?` on `checked_sub`'s Option is E0277, so a file that still contains either one does not compile",
+            "expectedOutput": "true",
+            "id": "decoys-removed",
+            "input": ""
+          },
+          {
+            "description": "The non-editable `mod verify` block resolves: withdraw_amount, deposit_amount and read_amount_the_long_way exist with the exact declared signatures — a missing name or a drifted type is a compile error",
+            "expectedOutput": "true",
+            "id": "verify-harness-resolves",
+            "input": ""
+          }
+        ]
+      },
+      {
+        "_key": "check",
+        "_type": "quiz",
+        "questions": [
+          {
+            "explanation": "`.ok_or(error!(VaultError::InsufficientFunds))?` turns the `Option` into a `Result` by naming the failure, and only then does `?` have something to carry. That one line is where lesson 4's `checked_sub` becomes a program that reports a real error.",
+            "id": "q1",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "`error[E0277]: the ? operator can only be used on Results, not Options` — and the compiler suggests `.ok_or(...)?`"
+              },
+              {
+                "correct": false,
+                "feedback": "There is no automatic mapping from `None` to an error. `?` propagates by calling `From::from` on an error value, and `None` does not carry one — which is exactly what the message says.",
+                "id": "b",
+                "label": "It compiles, and an underflow returns `Err` with Anchor's built-in arithmetic error"
+              },
+              {
+                "correct": false,
+                "feedback": "`?` never invents a value. If this compiled at all it would have to return something from the function, not substitute a default.",
+                "id": "c",
+                "label": "It compiles, and an underflow silently yields 0 because `?` unwraps the `Option`"
+              },
+              {
+                "correct": false,
+                "feedback": "Close, and it is a different error. E0308 is a plain type mismatch; this is E0277, a missing trait — the `Try` machinery has no conversion to offer. The distinction is why the fix is `.ok_or`, not a cast.",
+                "id": "d",
+                "label": "`error[E0308]: mismatched types` — `checked_sub` returns `Option<u64>` and the function returns `Result<u64>`"
+              }
+            ],
+            "prompt": "Inside `withdraw_amount`, which returns `Result<u64>`, you write `let remaining = balance.checked_sub(amount)?;`. Predict."
+          },
+          {
+            "explanation": "This is the payback for lesson 10. `?` is not a special language feature that understands your errors — it is one `From` lookup. Write the impl and errors cross the seam; delete it and they cannot.",
+            "id": "q2",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "`error[E0277]: ? couldn't convert the error` — the trait `From<LayoutError>` is not implemented for `Error`"
+              },
+              {
+                "correct": false,
+                "feedback": "`?` always converts — the desugaring is `return Err(From::from(e))`. With two different error types the conversion is not optional, it is the only way the return type can be satisfied.",
+                "id": "b",
+                "label": "It compiles. `?` propagates the error unchanged; conversion only happens if you ask for it with `.into()`"
+              },
+              {
+                "correct": false,
+                "feedback": "`LayoutError` has no error code at all — it is a plain enum, not an `#[error_code]` one. There is nothing to send.",
+                "id": "c",
+                "label": "It compiles, and `LayoutError::TooShort` reaches the client as custom error 6000"
+              },
+              {
+                "correct": false,
+                "feedback": "Rust does not coerce types through `Debug`, and missing trait impls are errors rather than warnings.",
+                "id": "d",
+                "label": "A warning, and the error is coerced through `Debug` at runtime"
+              }
+            ],
+            "prompt": "You delete the `impl From<LayoutError> for anchor_lang::error::Error` block and change nothing else. `read_amount` still returns `Result<u64, LayoutError>` and `withdraw_amount` still calls it with `?`. Predict."
+          },
+          {
+            "explanation": "`match` works in a `const fn`; `?` does not. That is the entire reason lesson 4's helpers look different from every function in this lesson, and why the compile-time assertion harness was possible there and is not possible on `deposit(&mut self)` in module 4.",
+            "id": "q3",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "`error[E0015]: ? is not allowed on Option<u64> in constant functions` — the `Try` trait is not const yet"
+              },
+              {
+                "correct": false,
+                "feedback": "`checked_sub` being const is necessary and not sufficient. `?` goes through the `Try` trait, and trait methods are only callable in a `const fn` once the trait itself is const — which `Try` is not.",
+                "id": "b",
+                "label": "It compiles — `checked_sub` is itself a `const fn`, so everything in the expression is const-evaluable"
+              },
+              {
+                "correct": false,
+                "feedback": "The assertions are the reason the function is `const fn` in the first place. If the function compiled, they would keep working; the function is what does not compile.",
+                "id": "c",
+                "label": "It compiles, but the compile-time assertions from lesson 4 stop working"
+              },
+              {
+                "correct": false,
+                "feedback": "That combination is normally fine — `?` on `Option` inside a function returning `Option` is ordinary Rust. The problem here is `const`, not the types.",
+                "id": "d",
+                "label": "`error[E0308]` — `?` on an `Option` in a function returning `Option` is a type mismatch"
+              }
+            ],
+            "prompt": "Carried over from lesson 4. Those two helpers were `const fn` and matched on `Option` by hand. You now try to write `pub const fn sub_lamports(a: u64, b: u64) -> Option<u64> { let r = a.checked_sub(b)?; Some(r) }`. Predict."
+          }
+        ]
+      }
+    ],
+    "skills": [
+      "rust-result",
+      "error-handling",
+      "rust-traits",
+      "anchor"
+    ],
+    "slug": {
+      "_type": "slug",
+      "current": "error-plumbing"
+    },
+    "title": "Error Plumbing with `?`"
+  },
+  {
+    "_id": "lesson-rpd-fix-the-borrow-checker",
+    "_type": "lesson",
+    "blocks": [
+      {
+        "_key": "reading-errors",
+        "_type": "prose",
+        "src": "# Fix the Borrow Checker\n\n> **Version stamp — checked 2026-07-26.** `anchor-lang 1.1.2` (crates.io latest stable) · `borsh` 1.5.7 declared / **1.8.0** resolved · edition 2021 · Agave ≥ 3.1.10 / rustc per the build server's pinned platform-tools. Every error message quoted below was produced by compiling the starter file as shipped.\n\nYou have read the rules twice. Reading them a third time will not help. What helps is reading the compiler.\n\nThe exercise below does not build. Four functions, four real errors, and every fix is already somewhere on the page — commented out among a set of candidate lines, some of which are wrong. Your job is to pick and order, not to invent.\n\n**Build it before you change anything.** Then read the *first* error only. Rust reports every error it finds, and a borrow error early in a file usually produces two or three more downstream that vanish the moment you fix the first. Chasing them in parallel is how people conclude the borrow checker is arbitrary.\n\n## The four you will meet\n\n### `E0382` — use of moved value\n\n```text\nerror[E0382]: use of moved value: `vault`\n  |\n  |     consume_and_log(vault);\n  |                     ----- value moved here\n  |     vault.balance\n  |     ^^^^^^^^^^^^^ value used here after move\n```\n\nRead it bottom-up: the caret is where you used it, the dashes are where you lost it. The question to ask is never \"how do I get it back\" — it is **did that function need to own it at all?** Usually not, and the fix is a borrow. When it genuinely does need to own it, take what you need out first, or clone.\n\n### `E0502` — cannot borrow as mutable because it is also borrowed as immutable\n\n```text\nerror[E0502]: cannot borrow `*v` as mutable because it is also borrowed as immutable\n  |\n  |     let before = &v.balance;\n  |                  ---------- immutable borrow occurs here\n  |     credit(v, shortfall);\n  |     ^^^^^^^^^^^^^^^^^^^^ mutable borrow occurs here\n  |     *before\n  |     ------- immutable borrow later used here\n```\n\nThree lines named, and the third is the one that matters. The mutable borrow gets the caret, but it is not the problem — the problem is that the shared borrow is **used again afterwards**, which is what keeps it alive across the mutation. Delete that last use and the error disappears.\n\nSo the fix is almost never \"make the mutable borrow later\". It is: stop holding the shared borrow. If what you needed was a `u64`, take the `u64` by value; it is `Copy`, and a copied number cannot conflict with anything.\n\n### `E0499` — cannot borrow as mutable more than once at a time\n\n```text\nerror[E0499]: cannot borrow `*v` as mutable more than once at a time\n  |\n  |     let one = &mut *v;\n  |               ------- first mutable borrow occurs here\n  |     let two = &mut *v;\n  |               ^^^^^^^ second mutable borrow occurs here\n  |     credit(one, first);\n  |            --- first borrow later used here\n```\n\nThe honest reading: you asked for exclusive access twice and called it exclusive both times. The fix is nearly always to stop naming the borrows and just make the two calls in sequence — each call takes its borrow, uses it, and gives it back before the next line starts.\n\nNote what this error is *not*. Two mutable borrows of **different fields** of the same struct are fine (`&mut v.balance` and `&mut v.bump` coexist happily) — the checker tracks each field as its own place. If you have talked yourself into a `RefCell` to work around this error, re-read it first; most of the time the borrows were disjoint and the code just needed reordering.\n\n### `E0515` — cannot return reference to local variable\n\n```text\nerror[E0515]: cannot return value referencing local variable `owned`\n  |\n  |     &owned[..8]\n  |     ^-----^^^^^\n  |     ||\n  |     |`owned` is borrowed here\n  |     returns a value referencing data owned by the current function\n```\n\nThis one is not about the rules of borrowing. It is about **time**. `owned` is dropped when the function returns, so a reference into it would point at freed memory the instant the caller received it — the exact class of bug that makes C hard and that Rust exists to make impossible.\n\nEvery returned reference has to borrow from something that outlives the call. A parameter does. A local does not. The fix in bug 4 replaces two lines with one, and the one it keeps borrows from the parameter.\n\nAnd that question — *which* input does the returned reference borrow from? — is the question lifetime annotations answer. That is the next lesson, and bug 4 is the reason it exists.\n\n## Working method\n\n1. Build. Read the first error. Ignore the rest.\n2. Look at the candidate lines under that function. Decide which belong and in what order.\n3. Comment out the lines marked `BUG`, uncomment your choice, build again.\n4. Repeat. Four builds, four errors, in order.\n\nIf you get a fifth error you did not expect, you have chosen a decoy. That is a useful outcome — read what it says before you undo it.\n\nOne route is closed off deliberately. Four broken functions in a file that has to compile makes deleting them look like a fix; it is not, and the non-editable `mod verify` block at the bottom pins all five signatures, so a deletion fails to build with `E0425: cannot find value`. What that block cannot do is check a body. Bug 3 fixed in the wrong order still compiles, which is what quiz question 3 is about.\n"
+      },
+      {
+        "_key": "exercise",
+        "_type": "code",
+        "buildType": "buildable",
+        "deployable": false,
+        "hints": [
+          "Build it first and read only the first error. The others are cascades — they will move or disappear as you fix the one above them.",
+          "Bug 2: the shared borrow is only fatal because the last line uses it again. `u64` is `Copy`, so take the number instead of a reference to it — and drop the `*` from the two places that were dereferencing it.",
+          "Bug 4: the returned reference has to come from something that outlives the call. `data` does. A `Vec` you created inside the function does not — and neither does a temporary you create inline in the return expression."
+        ],
+        "language": "rust",
+        "solution": "// ---------------------------------------------------------------------------\n// Lesson 7 — Fix the Borrow Checker.\n//\n// Reference solution — all four bugs repaired, and the decoys explained.\n//\n// Toolchain: anchor-lang 1.1.2 · borsh 1.5.7 declared / 1.8.0 resolved · edition 2021.\n// ---------------------------------------------------------------------------\n\nuse anchor_lang::prelude::*;\n\n#[derive(Clone, Debug)]\npub struct VaultLike {\n    pub owner: Pubkey,\n    pub balance: u64,\n    pub bump: u8,\n}\n\npub const fn add_lamports(balance: u64, amount: u64) -> Option<u64> {\n    balance.checked_add(amount)\n}\n\npub const fn sub_lamports(balance: u64, amount: u64) -> Option<u64> {\n    balance.checked_sub(amount)\n}\n\n/// From lesson 6, unchanged.\npub fn credit(v: &mut VaultLike, amount: u64) {\n    if let Some(new_balance) = add_lamports(v.balance, amount) {\n        v.balance = new_balance;\n    }\n}\n\n/// Given. Takes the vault BY VALUE, so calling it hands the vault over for\n/// good. You are not allowed to change this signature — plenty of real APIs\n/// consume their argument and you do not get to rewrite them either.\npub fn consume_and_log(v: VaultLike) {\n    msg!(\"vault {} holds {} lamports\", v.owner, v.balance);\n}\n\n// ===== Bug 1 of 4 — E0382, use of moved value ==============================\n// Answer: (1), (2), (3).\n//\n// `consume_and_log` insists on owning the vault, so the vault is gone after the\n// call and no ordering saves you. Take the one number you need out FIRST. It is\n// a `u64`, so `snapshot` is an independent copy that owes nothing to `vault`.\n//\n// Decoys (4) + (5): `&vault.balance` is a borrow, and you cannot move a value\n// out while it is borrowed. That trades E0382 for E0505 — a different error,\n// same underlying mistake of trying to keep a thread back to a value you gave\n// away. `.clone()` would also work here (the compiler suggests it), at the cost\n// of copying the whole struct to read 8 bytes of it.\npub fn audit_then_read(vault: VaultLike) -> u64 {\n    let snapshot = vault.balance;\n    consume_and_log(vault);\n    snapshot\n}\n\n// ===== Bug 2 of 4 — E0502, mutable while shared ============================\n// Answer: (1) and (4). Note `sub_lamports(target, before)` loses its `*` too,\n// because `before` is now a `u64` rather than a `&u64`.\n//\n// The shared borrow was only fatal because the last line used it again, which\n// kept it alive across `credit`. Copying the number out removes the borrow\n// entirely, and a copied `u64` cannot conflict with anything.\n//\n// Decoy (3): `&mut v.balance` held across `credit(v, …)` is E0499 instead —\n// two mutable borrows. Decoy (5): `*before` on a `u64` is E0614, you cannot\n// dereference something that is not a reference.\npub fn top_up_to(v: &mut VaultLike, target: u64) -> u64 {\n    let before = v.balance;\n\n    let shortfall = match sub_lamports(target, before) {\n        Some(gap) => gap,\n        None => 0,\n    };\n    credit(v, shortfall);\n\n    before\n}\n\n// ===== Bug 3 of 4 — E0499, two mutable borrows =============================\n// Answer: (1) then (2). Both named borrows go away.\n//\n// Naming a `&mut` keeps it alive for as long as the name is used. Passing `v`\n// straight into the call lets each call take its exclusive borrow, finish with\n// it, and give it back before the next line begins. Nothing overlaps, so there\n// is nothing to reject.\n//\n// Decoy (5) `credit(one, first);` only makes sense if you kept (3), which is\n// the bug. Sequencing beats scoping: no blocks, no `drop()`, no `RefCell`.\npub fn credit_twice(v: &mut VaultLike, first: u64, second: u64) {\n    credit(v, first);\n    credit(v, second);\n}\n\n// ===== Bug 4 of 4 — E0515, returning a reference to a local ================\n// Answer: (1), alone.\n//\n// `data.to_vec()` allocates a fresh buffer owned by this function, and that\n// buffer is dropped on the way out. Borrow from `data` instead: it belongs to\n// the caller, so it is still alive when the caller reads the result.\n//\n// Decoy (2) `&data.to_vec()[..8]` is the same bug written on one line — the\n// temporary Vec is dropped at the end of the statement, so it is E0515 again.\n//\n// This version still panics if `data` is shorter than 8 bytes, because `[..8]`\n// on a 3-byte slice is a runtime bounds failure. The next lesson replaces the\n// signature with `Option<&[u8]>` and the panic with `None` — and makes you say\n// out loud, in the signature, that the returned reference came from `data`.\npub fn head(data: &[u8]) -> &[u8] {\n    &data[..8]\n}\n\n// ===== Given: callers, so a green build means the shapes still line up =====\npub fn demo() -> (u64, u64, usize) {\n    let mut vault = VaultLike {\n        owner: Pubkey::default(),\n        balance: 500_000,\n        bump: 254,\n    };\n\n    let before = top_up_to(&mut vault, 750_000);\n    credit_twice(&mut vault, 1_000, 2_000);\n\n    let account_data = vec![0u8; 49];\n    let disc = head(&account_data);\n\n    let logged = audit_then_read(vault);\n\n    (before, logged, disc.len())\n}\n\n// ── DO NOT EDIT ──────────────────────────────────────────────────────────────\n// Pins the five functions above to their exact signatures. Deleting a broken\n// function is the one \"fix\" that would otherwise compile, so this block exists\n// to close it: a missing name, a borrow that turned into a by-value parameter,\n// or a drifted return type all stop the build.\n//\n// `head`'s pin is written `for<'a> fn(&'a [u8]) -> &'a [u8]`, which is the\n// signature you get from elision — and be precise about what it buys: a `head`\n// returning `&'static [u8]` also satisfies it, because a longer-lived reference\n// is accepted wherever a shorter-lived one is wanted. What stops bug 4's wrong\n// fix is E0515 in the body, not this line. Lesson 8 is where the annotation\n// itself becomes the subject, and where a WRONG annotation does fail the pin.\n//\n// Names, types and borrows only. Nothing here checks what a body computes: a\n// `credit_twice` that applies `second` before `first` compiles fine.\n#[allow(dead_code)]\nmod verify {\n    use super::*;\n\n    const _AUDIT_THEN_READ: fn(VaultLike) -> u64 = audit_then_read;\n    const _TOP_UP_TO: fn(&mut VaultLike, u64) -> u64 = top_up_to;\n    const _CREDIT_TWICE: fn(&mut VaultLike, u64, u64) = credit_twice;\n    const _HEAD: for<'a> fn(&'a [u8]) -> &'a [u8] = head;\n    const _CONSUME_AND_LOG: fn(VaultLike) = consume_and_log;\n    const _DEMO: fn() -> (u64, u64, usize) = demo;\n}\n",
+        "starter": "// ---------------------------------------------------------------------------\n// Lesson 7 — Fix the Borrow Checker.\n//\n// THIS FILE DOES NOT COMPILE, AND THAT IS THE POINT. Four functions, four real\n// borrow-checker errors. Build it FIRST and read only the first error.\n//\n// Every fix is already on the page. Under each broken function is a numbered\n// list of candidate lines: some belong, some are decoys that fail in a\n// different way. For each bug:\n//\n//   1. Read the error.\n//   2. Choose the candidates that belong, and the order they go in.\n//   3. Comment out the lines marked BUG, uncomment your choice, build again.\n//\n// Nothing above the first bug needs changing.\n//\n// Toolchain: anchor-lang 1.1.2 · borsh 1.5.7 declared / 1.8.0 resolved · edition 2021.\n// ---------------------------------------------------------------------------\n\nuse anchor_lang::prelude::*;\n\n#[derive(Clone, Debug)]\npub struct VaultLike {\n    pub owner: Pubkey,\n    pub balance: u64,\n    pub bump: u8,\n}\n\npub const fn add_lamports(balance: u64, amount: u64) -> Option<u64> {\n    balance.checked_add(amount)\n}\n\npub const fn sub_lamports(balance: u64, amount: u64) -> Option<u64> {\n    balance.checked_sub(amount)\n}\n\n/// From lesson 6, unchanged.\npub fn credit(v: &mut VaultLike, amount: u64) {\n    if let Some(new_balance) = add_lamports(v.balance, amount) {\n        v.balance = new_balance;\n    }\n}\n\n/// Given. Takes the vault BY VALUE, so calling it hands the vault over for\n/// good. You are not allowed to change this signature — plenty of real APIs\n/// consume their argument and you do not get to rewrite them either.\npub fn consume_and_log(v: VaultLike) {\n    msg!(\"vault {} holds {} lamports\", v.owner, v.balance);\n}\n\n// ===== Bug 1 of 4 =========================================================\n// Should log the vault, then return the balance it had.\n//\n// Candidates:\n//   (1) let snapshot = vault.balance;\n//   (2) consume_and_log(vault);\n//   (3) snapshot\n//   (4) let snapshot = &vault.balance;\n//   (5) *snapshot\npub fn audit_then_read(vault: VaultLike) -> u64 {\n    consume_and_log(vault); // BUG\n    vault.balance // BUG\n}\n\n// ===== Bug 2 of 4 =========================================================\n// Should raise the balance to at least `target` and return the balance as it\n// was BEFORE the top-up.\n//\n// Candidates:\n//   (1) let before = v.balance;\n//   (2) let before = &v.balance;\n//   (3) let before = &mut v.balance;\n//   (4) before\n//   (5) *before\npub fn top_up_to(v: &mut VaultLike, target: u64) -> u64 {\n    let before = &v.balance; // BUG\n\n    let shortfall = match sub_lamports(target, *before) {\n        Some(gap) => gap,\n        None => 0,\n    };\n    credit(v, shortfall);\n\n    *before // BUG\n}\n\n// ===== Bug 3 of 4 =========================================================\n// Should apply two credits to the same vault, in order.\n//\n// Candidates:\n//   (1) credit(v, first);\n//   (2) credit(v, second);\n//   (3) let one = &mut *v;\n//   (4) let two = &mut *v;\n//   (5) credit(one, first);\npub fn credit_twice(v: &mut VaultLike, first: u64, second: u64) {\n    let one = &mut *v; // BUG\n    let two = &mut *v; // BUG\n\n    credit(one, first);\n    credit(two, second);\n}\n\n// ===== Bug 4 of 4 =========================================================\n// Should return the first 8 bytes of `data` — an Anchor account's\n// discriminator. One candidate line replaces both BUG lines.\n//\n// Candidates:\n//   (1) &data[..8]\n//   (2) &data.to_vec()[..8]\n//   (3) let owned = data.to_vec();\n//   (4) &owned[..8]\npub fn head(data: &[u8]) -> &[u8] {\n    let owned = data.to_vec(); // BUG\n    &owned[..8] // BUG\n}\n\n// ===== Given: callers, so a green build means the shapes still line up =====\n//\n// Also: `demo` is what makes `head` reachable and gives the other three a call\n// site. Do not delete it. See the harness note at the bottom.\npub fn demo() -> (u64, u64, usize) {\n    let mut vault = VaultLike {\n        owner: Pubkey::default(),\n        balance: 500_000,\n        bump: 254,\n    };\n\n    let before = top_up_to(&mut vault, 750_000);\n    credit_twice(&mut vault, 1_000, 2_000);\n\n    let account_data = vec![0u8; 49];\n    let disc = head(&account_data);\n\n    let logged = audit_then_read(vault);\n\n    (before, logged, disc.len())\n}\n\n// ── DO NOT EDIT ──────────────────────────────────────────────────────────────\n// Pins the five functions above to their exact signatures. Deleting a broken\n// function is the one \"fix\" that would otherwise compile, so this block exists\n// to close it: a missing name, a borrow that turned into a by-value parameter,\n// or a drifted return type all stop the build.\n//\n// `head`'s pin is written `for<'a> fn(&'a [u8]) -> &'a [u8]`, which is the\n// signature you get from elision — and be precise about what it buys: a `head`\n// returning `&'static [u8]` also satisfies it, because a longer-lived reference\n// is accepted wherever a shorter-lived one is wanted. What stops bug 4's wrong\n// fix is E0515 in the body, not this line. Lesson 8 is where the annotation\n// itself becomes the subject, and where a WRONG annotation does fail the pin.\n//\n// Names, types and borrows only. Nothing here checks what a body computes: a\n// `credit_twice` that applies `second` before `first` compiles fine.\n#[allow(dead_code)]\nmod verify {\n    use super::*;\n\n    const _AUDIT_THEN_READ: fn(VaultLike) -> u64 = audit_then_read;\n    const _TOP_UP_TO: fn(&mut VaultLike, u64) -> u64 = top_up_to;\n    const _CREDIT_TWICE: fn(&mut VaultLike, u64, u64) = credit_twice;\n    const _HEAD: for<'a> fn(&'a [u8]) -> &'a [u8] = head;\n    const _CONSUME_AND_LOG: fn(VaultLike) = consume_and_log;\n    const _DEMO: fn() -> (u64, u64, usize) = demo;\n}\n",
+        "tests": [
+          {
+            "description": "The file compiles against anchor-lang 1.1.2 on the build server",
+            "expectedOutput": "true",
+            "id": "test-1",
+            "input": ""
+          },
+          {
+            "description": "Compiles ⇒ none of the four borrow-checker errors (E0382, E0502, E0499, E0515) is still in the file — each one is a hard compile failure, so a green build means all four are gone",
+            "expectedOutput": "true",
+            "id": "test-2",
+            "input": ""
+          },
+          {
+            "description": "Compiles ⇒ the non-editable `mod verify` block resolves: audit_then_read, top_up_to, credit_twice, head, consume_and_log and demo all still exist with the exact declared signatures, so deleting a broken function is not a fix. Note what this cannot see: it checks names, types and borrows, not what a body computes",
+            "expectedOutput": "true",
+            "id": "test-3",
+            "input": ""
+          }
+        ]
+      },
+      {
+        "_key": "check",
+        "_type": "quiz",
+        "questions": [
+          {
+            "id": "q1",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "`E0499` — cannot borrow `*v` as mutable more than once at a time"
+              },
+              {
+                "correct": false,
+                "feedback": "The rule that broke is a different one, and so is the message. `E0502` is shared-then-mutable; two mutable borrows is `E0499`. Telling them apart is how you know whether to remove the borrow or reorder the calls.",
+                "id": "b",
+                "label": "Still `E0502` — a mutable borrow is a superset of a shared one, so the same conflict applies"
+              },
+              {
+                "correct": false,
+                "feedback": "\"Stronger\" is the wrong axis. `&mut` is *exclusive*, so a second one is worse, not better. Only one may exist at a time.",
+                "id": "c",
+                "label": "It compiles — `&mut` is the stronger borrow, and `credit` needs a mutable borrow anyway"
+              },
+              {
+                "correct": false,
+                "feedback": "Reborrowing a `&mut` is completely legal and you do it every time you pass `v` to another function. The problem is doing it twice and keeping both.",
+                "id": "d",
+                "label": "`E0596` — `v` is already a `&mut`, so you cannot take `&mut` of it again"
+              }
+            ],
+            "prompt": "In bug 2 you replace `let before = &v.balance;` with `let before = &mut v.balance;` and change nothing else. Predict the error you now get."
+          },
+          {
+            "id": "q2",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "`E0515` again — cannot return value referencing temporary value; the `Vec` is dropped at the end of the statement"
+              },
+              {
+                "correct": false,
+                "feedback": "There is no such rule, and if there were it would be unimplementable: the `Vec`'s heap allocation has to be freed by someone, and the only code that could do it is the function that is returning.",
+                "id": "b",
+                "label": "Compiles — a temporary in a return expression lives as long as the return value"
+              },
+              {
+                "correct": false,
+                "feedback": "You would see `E0716` in some contexts, but binding it with `let` is the two-line version, which is the original bug. The problem is not where the `Vec` is written; it is that a `Vec` was created at all.",
+                "id": "c",
+                "label": "`E0716` — temporary value dropped while borrowed, because the fix is to bind it with `let`"
+              },
+              {
+                "correct": false,
+                "feedback": "Reading freed memory is precisely what does not happen. This is the whole reason the error exists, and it is caught at compile time, so there is no observable garbage to read.",
+                "id": "d",
+                "label": "Compiles, and returns a slice of zeroes because the buffer was freed"
+              }
+            ],
+            "prompt": "For bug 4, someone tries `&data.to_vec()[..8]` on one line instead of two. Predict what the compiler says."
+          },
+          {
+            "explanation": "Worth being blunt about: the build server proves your file compiles. It does not prove your function does what its name says. This snippet is a silent, compiling, wrong program, and only reading it catches that. The same limit applies to your own exercises for the rest of this course.",
+            "id": "q3",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "Raised by `first` only — the second credit landed on a throwaway clone that was dropped immediately"
+              },
+              {
+                "correct": false,
+                "feedback": "Nothing writes through a clone. `.clone()` produced an independent `VaultLike`; the `&mut` pointed at that one, and it was dropped at the end of the statement.",
+                "id": "b",
+                "label": "Raised by `first + second` — `.clone()` returns a copy that writes through to the original"
+              },
+              {
+                "correct": false,
+                "feedback": "There is no \"later write wins\" — the two calls touched two different values. The vault only ever saw the first.",
+                "id": "c",
+                "label": "Raised by `second` only — the later write wins"
+              },
+              {
+                "correct": false,
+                "feedback": "You can. Rust promotes the temporary to a place you may borrow mutably, which is exactly why this bug builds green.",
+                "id": "d",
+                "label": "It does not compile — you cannot take `&mut` of a temporary"
+              }
+            ],
+            "prompt": "Instead of sequencing bug 3, someone writes `credit(v, first);` then `credit(&mut v.clone(), second);`. It compiles green. Predict what the vault's balance is afterwards."
+          }
+        ]
+      }
+    ],
+    "skills": [
+      "rust-borrowing",
+      "compiler-errors",
+      "debugging"
+    ],
+    "slug": {
+      "_type": "slug",
+      "current": "fix-the-borrow-checker"
+    },
+    "title": "Fix the Borrow Checker"
+  },
+  {
+    "_id": "lesson-rpd-functions-and-control-flow",
+    "_type": "lesson",
+    "blocks": [
+      {
+        "_key": "intro",
+        "_type": "prose",
+        "src": "# Functions, Expressions, and the Missing `return`\n\n> **Version stamp — checked 2026-07-26.** `anchor-lang` **1.1.2** · Rust **edition 2021** · Agave **≥ 3.1.10**. This lesson's exercise is plain Rust and imports nothing.\n\nRead this function and decide, before scrolling, whether it compiles.\n\n```rust\nfn min_balance(a: u64, b: u64) -> u64 {\n    if a < b { a; } else { b; }\n}\n```\n\nIt does not. There are two semicolons in it and they are the entire problem. Everything below is about why one character does that, because it is the error JavaScript developers hit in their first week of Rust and it does not go away by being told about it once.\n\n## Almost everything is an expression\n\nIn JavaScript there are statements and there are expressions, and `if` is firmly a statement. You cannot assign one to a variable. That is why the ternary exists.\n\nIn Rust the split is much narrower. `if` is an expression. So is `match`. So is a block, `{ … }`. Each of them evaluates to a value, so each can appear anywhere a value is wanted:\n\n```rust\nlet tier = if balance == 0 { \"empty\" } else { \"funded\" };\n```\n\nNo ternary needed, because `if` already does that job. Rust has no `?:` operator at all, and this is why.\n\n## What a semicolon actually does\n\nA semicolon does not end a line. It **discards a value** and turns the expression into a statement whose value is `()` — the unit type, \"nothing useful\".\n\nThat is exact, and it is the whole rule:\n\n| Written | Value of the block |\n| --- | --- |\n| `{ a }` | `a` |\n| `{ a; }` | `()` |\n\nWhich explains the broken function. `{ a; }` evaluates to `()`, so both arms of the `if` are `()`, so the `if` is `()`, while the signature promises `u64`. The compiler type-checks each arm against what is expected, so it reports this **twice** — once per arm:\n\n```\nerror[E0308]: mismatched types\n --> src/lib.rs:2:14\n  |\n1 | fn min_balance(a: u64, b: u64) -> u64 {\n  |                                   --- expected `u64` because of return type\n2 |     if a < b { a; } else { b; }\n  |                 ^  help: remove this semicolon to return this value\n  |                 |\n  |                 expected `u64`, found `()`\n```\n\nNote the `help:`. When you see \"remove this semicolon to return this value\" you have found this bug and you can stop reading the rest of the error.\n\n## Tail expressions, and why `return` is rare\n\nA function's value is the value of its body block — which means the **last expression, with no semicolon**. That is called the tail expression:\n\n```rust\nfn min_balance(a: u64, b: u64) -> u64 {\n    if a < b { a } else { b }\n}\n```\n\nNo `return`. Idiomatic Rust uses `return` for one thing: leaving early, from somewhere other than the end.\n\n```rust\nfn withdraw(balance: u64, amount: u64) -> u64 {\n    if amount == 0 {\n        return balance;      // early exit, `return` earns its keep\n    }\n    balance - amount         // tail expression, no `return`\n}\n```\n\nA `return` on the last line is not an error and nobody will fail your review for it. It is just noise, and once you have the habit of reading the last line as *the answer*, functions get easier to skim.\n\nTwo things people trip on:\n\n- **`return x` needs its semicolon.** It is a statement. `return` and a tail expression are different mechanisms, not two spellings of one.\n- **A block's tail works too**, not only a function's. `let x = { let a = 2; a * 3 };` binds 6. This becomes useful in module 2, where the size of a block decides how long a borrow lasts.\n\n## `match` on ranges\n\n`match` is Rust's pattern dispatch, and for our purposes it is a `switch` with two upgrades that matter.\n\n```rust\nfn describe_state(balance: u64) -> &'static str {\n    match balance {\n        0 => \"empty\",\n        1..=999_999 => \"dust\",\n        1_000_000..=999_999_999 => \"funded\",\n        _ => \"whale\",\n    }\n}\n```\n\n**Upgrade one: it is an expression.** Every arm produces a value, all arms must agree on the type, and the whole `match` is that value. No `break`, and therefore no accidental fall-through — the bug class that eats a `switch` does not exist here.\n\n**Upgrade two: it must be exhaustive.** Every possible value of `balance` has to be matched by some arm, and the compiler proves it. Leave a gap and you get `error[E0004]: non-exhaustive patterns`, which is a compile-time guarantee that a missing case cannot ship. `_` is the catch-all that closes the gap, and `..=` is an inclusive range.\n\nTwo details about ordering, because they are the difference between this working and this looking like it works:\n\n**Arms are tried top to bottom, first match wins.** Not most-specific-wins. Order is semantics.\n\n**An arm the earlier ones already cover is a warning, not an error.** Put `0..=999_999 => \"dust\"` above `0 => \"empty\"` and the `0` arm becomes dead:\n\n```\nwarning: unreachable pattern\n --> src/lib.rs:5:9\n  |\n4 |         0..=999_999 => \"dust\",\n  |         ----------- matches all the values already\n5 |         0 => \"empty\",\n  |         ^ no value can reach this\n```\n\nThat file **compiles**, and this lesson is graded on compilation, so it passes — and `describe_state(0)` returns `\"dust\"`. This is a good moment to notice how much work a warning can be doing. `unreachable_patterns` is one of the highest-value warnings Rust emits, and nothing forces you to read it.\n\n`&'static str` in the return type is a borrowed string that lives for the whole program — which is true of a literal baked into the binary. The apostrophe is a lifetime, and module 2 is where you learn to write your own. Take it as given for now.\n\n## The exercise\n\nBoth function bodies are empty, so the file does not build. Every line you need is in the parts bin at the top of the file, commented out and out of order. **Two of the lines are decoys.** One of them compiles and does the wrong thing; one of them does not compile at all. Working out which is which is the exercise.\n\nDo not add lines that are not in the bin. Assembling exactly the right subset in the right order is a smaller job than writing it from scratch, and it is the whole job here — lesson 4 is where the blank page arrives.\n"
+      },
+      {
+        "_key": "exercise",
+        "_type": "code",
+        "buildType": "buildable",
+        "deployable": false,
+        "hints": [
+          "Start with `min_balance`, because the compiler tells you outright which of (F) and (G) is the decoy. Paste one, build, and read the `help:` line — it names the exact character to delete.",
+          "`describe_state` needs exactly four arms and the last one must be `_`. Two of the five candidate arms overlap each other; pick the one that leaves 0 to the `0 => \"empty\"` arm rather than swallowing it.",
+          "The wrong `dust` arm still compiles, and you will not be told. It produces `warning: unreachable pattern` and then answers \"dust\" for an empty vault — but this platform shows you the compiler log only when the build FAILS, so on a green build that warning is discarded before it reaches you. Nothing external will catch this one. Read your two range arms against the `0 => \"empty\"` arm and decide by hand which of them swallows 0."
+        ],
+        "language": "rust",
+        "solution": "//! Functions, expressions, and the missing `return` — solved.\n//!\n//! (C) was a decoy: `0..=999_999 => \"dust\"` covers 0, so placing it before\n//! `0 => \"empty\"` makes that arm unreachable — a warning, not an error, so\n//! the file would still have compiled while answering \"dust\" for an empty\n//! vault. (E) is the same range with 0 excluded, which is the one that\n//! belongs.\n//!\n//! (F) was the other decoy: `{ a; }` evaluates to `()`, so the `if` is\n//! `()`, so the body does not match the `-> u64` return type. That is the\n//! `help: consider removing this semicolon` error.\n\n/// Classify a lamport balance. Every `u64` gets exactly one answer.\n///\n///   0                          -> \"empty\"\n///   1 .. 999_999               -> \"dust\"\n///   1_000_000 .. 999_999_999   -> \"funded\"\n///   1_000_000_000 and above    -> \"whale\"\npub fn describe_state(balance: u64) -> &'static str {\n    match balance {\n        0 => \"empty\",\n        1..=999_999 => \"dust\",\n        1_000_000..=999_999_999 => \"funded\",\n        _ => \"whale\",\n    }\n}\n\n/// The smaller of two balances.\npub fn min_balance(a: u64, b: u64) -> u64 {\n    if a < b { a } else { b }\n}\n\n// ════════════════════════════════════════════════════════════════════════\n// DO NOT EDIT BELOW THIS LINE\n//\n// These bindings pin both signatures so that renaming or deleting a\n// function is a compile error rather than a way through. They check\n// shapes, not behaviour. What checks behaviour here is `match`\n// exhaustiveness — the compiler will not accept a set of arms that leaves\n// a `u64` unmatched — plus the type of the `if`, which a stray semicolon\n// changes to `()`.\n// ════════════════════════════════════════════════════════════════════════\n\nconst _: fn(u64) -> &'static str = describe_state;\nconst _: fn(u64, u64) -> u64 = min_balance;\n",
+        "starter": "//! Functions, expressions, and the missing `return`.\n//!\n//! Both bodies below are empty, so this file does not build.\n//!\n//! Every line you need is in the parts bin. Two of the seven lines are\n//! decoys: one compiles and quietly does the wrong thing, one does not\n//! compile at all. Copy the lines you want into the bodies, in the right\n//! order. Do not write lines that are not in the bin.\n//!\n//! ┌─ PARTS BIN ─────────────────────────────────────────────────────────┐\n//! │                                                                     │\n//! │  Arms for `describe_state`. Four of these five belong. Arms are     │\n//! │  tried top to bottom and the first match wins, so order is part of  │\n//! │  the answer — and `match` must cover every possible `u64`.          │\n//! │                                                                     │\n//! │    (A)    _ => \"whale\",                                             │\n//! │    (B)    1_000_000..=999_999_999 => \"funded\",                      │\n//! │    (C)    0..=999_999 => \"dust\",                                    │\n//! │    (D)    0 => \"empty\",                                             │\n//! │    (E)    1..=999_999 => \"dust\",                                    │\n//! │                                                                     │\n//! │  Body for `min_balance`. One of these two belongs.                  │\n//! │                                                                     │\n//! │    (F)    if a < b { a; } else { b; }                               │\n//! │    (G)    if a < b { a } else { b }                                 │\n//! │                                                                     │\n//! └─────────────────────────────────────────────────────────────────────┘\n\n/// Classify a lamport balance. Every `u64` gets exactly one answer.\n///\n///   0                          -> \"empty\"\n///   1 .. 999_999               -> \"dust\"\n///   1_000_000 .. 999_999_999   -> \"funded\"\n///   1_000_000_000 and above    -> \"whale\"\npub fn describe_state(balance: u64) -> &'static str {\n    match balance {\n        // Four arms from the bin go here, in the right order.\n    }\n}\n\n/// The smaller of two balances.\npub fn min_balance(a: u64, b: u64) -> u64 {\n    // One line from the bin goes here.\n}\n\n// ════════════════════════════════════════════════════════════════════════\n// DO NOT EDIT BELOW THIS LINE\n//\n// These bindings pin both signatures so that renaming or deleting a\n// function is a compile error rather than a way through. They check\n// shapes, not behaviour. What checks behaviour here is `match`\n// exhaustiveness — the compiler will not accept a set of arms that leaves\n// a `u64` unmatched — plus the type of the `if`, which a stray semicolon\n// changes to `()`.\n// ════════════════════════════════════════════════════════════════════════\n\nconst _: fn(u64) -> &'static str = describe_state;\nconst _: fn(u64, u64) -> u64 = min_balance;\n",
+        "tests": [
+          {
+            "description": "Program compiles successfully",
+            "expectedOutput": "true",
+            "id": "test-1",
+            "input": ""
+          },
+          {
+            "description": "describe_state's match covers every u64 — a non-exhaustive set of arms is E0004",
+            "expectedOutput": "true",
+            "id": "test-2",
+            "input": ""
+          },
+          {
+            "description": "min_balance's body evaluates to a u64 rather than to ()",
+            "expectedOutput": "true",
+            "id": "test-3",
+            "input": ""
+          }
+        ]
+      },
+      {
+        "_key": "check",
+        "_type": "quiz",
+        "questions": [
+          {
+            "id": "q1",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "`error[E0308]` twice, once per arm — expected `u64`, found `()`. Each semicolon discards its arm's value, and the `help:` line reads \"remove this semicolon to return this value\"."
+              },
+              {
+                "correct": false,
+                "feedback": "A semicolon in Rust is not punctuation, it is an operation: it throws away the value of the expression it follows and yields `()` instead. That is why one character changes the type of the whole function body.",
+                "id": "b",
+                "label": "It compiles. Semicolons are optional line terminators in Rust, as they effectively are in JavaScript."
+              },
+              {
+                "correct": false,
+                "feedback": "The arms agree perfectly: both are `()`. E0317 is for an `if` with no `else` used in value position. Here the disagreement is between the body and the return type.",
+                "id": "c",
+                "label": "`error[E0317]: if may be missing an else clause` — the arms disagree."
+              },
+              {
+                "correct": false,
+                "feedback": "`()` does not coerce to anything. It is a distinct type with one value, and Rust has no implicit conversions to paper over the gap — the same rule you met with `u8` and `u64` in lesson 2.",
+                "id": "d",
+                "label": "It compiles, and returns 0, because `()` coerces to the numeric zero value."
+              }
+            ],
+            "prompt": "Predict the outcome. `pub fn min_balance(a: u64, b: u64) -> u64 { if a < b { a; } else { b; } }`"
+          },
+          {
+            "id": "q2",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "It compiles, with `warning: unreachable pattern`, and returns \"dust\" — arms are tried top to bottom, so the first arm claims 0 before the `0` arm is reached."
+              },
+              {
+                "correct": false,
+                "feedback": "It is a lint, and its default level is warn, not deny. Which means a lesson graded on compilation passes this submission. Worse: this platform discards the compiler log on a successful build, so the warning is not merely easy to skip — it never reaches you at all. Nothing here catches a wrong-order `match` except reading it.",
+                "id": "b",
+                "label": "`error[E0001]: unreachable pattern`. An arm that can never match is rejected."
+              },
+              {
+                "correct": false,
+                "feedback": "No specificity ranking exists. `match` is strictly top to bottom, first match wins. This is the assumption most people import from overload resolution in other languages, and it is wrong here.",
+                "id": "c",
+                "label": "It compiles and returns \"empty\", because `match` picks the most specific pattern that applies."
+              },
+              {
+                "correct": false,
+                "feedback": "Pattern *kind* has no bearing on order either. Source order is the whole rule.",
+                "id": "d",
+                "label": "It compiles and returns \"empty\", because a literal pattern is checked before any range pattern."
+              }
+            ],
+            "prompt": "A submission orders the arms `0..=999_999 => \"dust\",` then `0 => \"empty\",` then the rest, and it is otherwise exhaustive. Predict both the build result and what `describe_state(0)` returns."
+          },
+          {
+            "id": "q3",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "A compile error — the literal is out of range for `u8`. The check is a lint, but it is deny-by-default, so it stops the build."
+              },
+              {
+                "correct": false,
+                "feedback": "You would get 44 from `300u32 as u8`, which is exactly why this course does not use `as` on numbers. A literal that does not fit its annotated type is caught at compile time instead.",
+                "id": "b",
+                "label": "It compiles and `bump` is 44, since 300 wraps modulo 256."
+              },
+              {
+                "correct": false,
+                "feedback": "Rust never silently clamps. Saturating behaviour exists, but you have to ask for it by name (`saturating_add` and friends).",
+                "id": "c",
+                "label": "It compiles and `bump` is 255, clamped to the maximum."
+              },
+              {
+                "correct": false,
+                "feedback": "Nothing about integer behaviour in Rust is implementation-defined, and this particular lint denies rather than warns.",
+                "id": "d",
+                "label": "It compiles with a warning, and the value is implementation-defined."
+              }
+            ],
+            "prompt": "Carried over from lesson 2. Predict the outcome of `let bump: u8 = 300;`"
+          }
+        ]
+      }
+    ],
+    "skills": [
+      "rust",
+      "rust-control-flow"
+    ],
+    "slug": {
+      "_type": "slug",
+      "current": "functions-and-control-flow"
+    },
+    "title": "Functions, Expressions, and the Missing `return`"
+  },
+  {
+    "_id": "lesson-rpd-lifetimes-and-slices",
+    "_type": "lesson",
+    "blocks": [
+      {
+        "_key": "intro",
+        "_type": "prose",
+        "src": "# Lifetimes and Slices\n\n> **Version stamp — checked 2026-07-26.** `anchor-lang 1.1.2` (crates.io latest stable) · `borsh` 1.5.7 declared / **1.8.0** resolved · edition 2021 · Agave ≥ 3.1.10 / rustc per the build server's pinned platform-tools. `anchor-lang` 1.0 removed three of the four redundant lifetime parameters from `Context`, so the surface described here is smaller than in any tutorial written before June 2026.\n\nBug 4 in the last lesson ended with a question the compiler asked and you answered by accident: **which value does the returned reference borrow from?**\n\nFor `head(data: &[u8]) -> &[u8]` there is exactly one candidate, so the compiler filled it in silently. Add a second reference parameter and it stops guessing, because guessing wrong would mean returning a reference to something already freed.\n\nThat is all a lifetime annotation is. Say it out loud once:\n\n> **A lifetime does not change how long anything lives. It tells the compiler which input a returned reference came from.**\n\nNothing is allocated, nothing is freed, nothing is reference-counted, and no code is generated. Annotations are a compile-time claim, checked and then discarded.\n\n## What `'a` actually says\n\n```rust\npub fn discriminator<'a>(data: &'a [u8]) -> Option<&'a [u8]>\n```\n\nWord for word: *for some lifetime `'a`, I take a slice that is valid for `'a`, and if I return a slice it is valid for the same `'a`.* Which means: the thing I hand back points into `data`, so it stays valid exactly as long as `data` does — and the compiler will reject any caller who drops `data` while still holding the result.\n\nYou can drop the annotations here:\n\n```rust\npub fn discriminator(data: &[u8]) -> Option<&[u8]>\n```\n\nThis is the identical signature. **Lifetime elision** fills in the same `'a` for you when there is exactly one input reference, because there is only one possible answer. That is why you have written a dozen functions taking `&VaultLike` without ever typing a `'`.\n\nElision has two other rules worth knowing, and no more:\n\n- One input reference → the output borrows from it.\n- A method with `&self` or `&mut self` → the output borrows from `self`, no matter how many other reference parameters there are.\n- Otherwise → **you must say.**\n\n`balance_of(&self) -> u64` returns no reference, so it never comes up. `deposit(&mut self, amount: u64)` likewise. Which is why module 4's vault has no annotations in it anywhere, and why meeting them here rather than there is the right order.\n\n## The case elision cannot solve\n\n```rust\npub fn discriminator_if(data: &[u8], expected: &[u8; 8]) -> Option<&[u8]>\n```\n\nTwo input references, one output reference, no `self`. The compiler will not choose:\n\n```text\nerror[E0106]: missing lifetime specifier\n  |\n  | pub fn discriminator_if(data: &[u8], expected: &[u8; 8]) -> Option<&[u8]>\n  |                               -----            --------            ^ expected named lifetime parameter\n  |\n  = help: this function's return type contains a borrowed value, but the\n          signature does not say whether it is borrowed from `data` or `expected`\n```\n\nThe help text *is* the lesson. There is a right answer here and it is a design decision, not a formality: the discriminator you return is bytes out of the account, so it borrows from `data`. `expected` is a caller's constant that this function only reads and never hands back — it gets its own lifetime, unrelated to the return value.\n\n```rust\npub fn discriminator_if<'a, 'b>(data: &'a [u8], expected: &'b [u8; 8]) -> Option<&'a [u8]>\n```\n\nTwo names because there are two independent answers. Writing `<'a>` on both would compile the function and quietly over-constrain every caller — it would demand that the account buffer and the expected constant live equally long, which is a promise callers have no reason to be able to make.\n\n## Slices, and why the first 8 bytes matter\n\n`&[u8]` is a **borrowed view** into bytes someone else owns: an address plus a length, 16 bytes total, no allocation, no copy. `Vec<u8>` owns its buffer; `&[u8]` looks at it. That distinction is the whole of bug 4.\n\nThe bytes you are about to look at are real. Every Anchor account starts with an 8-byte discriminator — a hash of the account type's name — followed by the fields:\n\n| Offset | Bytes | Field |\n| --- | --- | --- |\n| 0 | 8 | discriminator |\n| 8 | 32 | `owner: Pubkey` |\n| 40 | 8 | `balance: u64`, little-endian |\n| 48 | 1 | `bump: u8` |\n\nTotal 49. This is the same table you decoded byte by byte in Course 1, and the same layout `#[account]` will generate for you in module 3. Anchor checks that discriminator before it deserializes anything — wrong discriminator, wrong account type, refuse — which is exactly the function you are about to write.\n\n## What you are writing\n\nTwo functions, signatures given, spec given, no worked pattern. Both are `const fn`, for a reason worth stating plainly:\n\n**Grading on this platform is compile-only.** A submission passes when the build server reports that it compiled. There are no hidden tests on the Rust path, so a function whose body was `todo!()` would normally sail through.\n\n`const fn` closes that. The exercise ships a `mod verify` block you may not edit, which calls your functions at **compile time** and asserts on the answers:\n\n```rust\nconst _: () = assert!(super::discriminator(&[0u8; 7]).is_none());\n```\n\nA `const fn` that panics — including `todo!()` — fails const evaluation, which is a compile error. A `discriminator` that returns 4 bytes fails the length assertion, which is a compile error. So for this lesson the build genuinely does check your logic, not just your syntax.\n\nBe clear about the limit: this works because both functions are `const fn` over plain slices. It will not work for `deposit(&mut self) -> Result<()>` in module 4 — you cannot const-evaluate a method that mutates account state — and that lesson's harness therefore checks names and types only, and says so.\n"
+      },
+      {
+        "_key": "exercise",
+        "_type": "code",
+        "buildType": "buildable",
+        "deployable": false,
+        "hints": [
+          "Function 1 is three lines. Guard the length first and return `None`; otherwise hand back the first eight bytes. `split_at` is a `const fn` and returns `(before, after)` — you want `.0`.",
+          "Function 2 needs TWO lifetime parameters, not one. Ask the question the compiler is asking: which of the two inputs do the returned bytes come out of? Whichever it is gets the name that also appears in the return type; the other input's lifetime is never mentioned again, and giving both the same name is the over-constraint quiz question 2 is about.",
+          "Function 2's body — the constraint, not the code: slice `==` and iterators are both unavailable in a `const fn`, so comparing eight bytes leaves you with indexing. `while` is const; `for` is not. And reuse `discriminator` rather than re-checking the length."
+        ],
+        "language": "rust",
+        "solution": "// ---------------------------------------------------------------------------\n// Lesson 8 — Lifetimes and Slices.\n//\n// Reference solution. Both bodies filled in, lifetimes annotated, harness\n// untouched.\n//\n// Toolchain: anchor-lang 1.1.2 · borsh 1.5.7 declared / 1.8.0 resolved · edition 2021.\n// ---------------------------------------------------------------------------\n\n/// Every Anchor account begins with 8 discriminator bytes. Do not change this.\npub const DISCRIMINATOR_LEN: usize = 8;\n\n// ===== 1. discriminator ====================================================\n//\n// SPEC\n//   Return a borrowed view of the first `DISCRIMINATOR_LEN` bytes of `data`.\n//   If `data` is shorter than that, return `None` — never panic, and never\n//   return a shorter slice.\n//\n// ACCEPTANCE\n//   discriminator(&[])            == None\n//   discriminator(&[0u8; 7])      == None\n//   discriminator(&[0u8; 8])      == Some(..) with len 8\n//   discriminator(&[0u8; 49])     == Some(..) with len 8, the FIRST eight\n//\n// NOTES\n//   - The signature below has no `'a` on it. That is legal: one input\n//     reference means elision has exactly one answer, and it fills it in.\n//   - `const fn` restricts you: no `?`, no iterators, no closures. `if`,\n//     `match`, `while` and slice methods that are themselves `const` are in.\n//   - Indexing with `[..8]` panics on a short slice. The spec says `None`, so\n//     check the length before you take anything.\n//\n// `split_at(8).0` is the first eight bytes and `.1` is everything after. It is\n// a `const fn`, it allocates nothing, and it hands back views into the same\n// buffer — the borrowed-view point from the prose, in one call.\npub const fn discriminator(data: &[u8]) -> Option<&[u8]> {\n    if data.len() < DISCRIMINATOR_LEN {\n        return None;\n    }\n    Some(data.split_at(DISCRIMINATOR_LEN).0)\n}\n\n// ===== 2. discriminator_if =================================================\n//\n// SPEC\n//   Return the account's discriminator ONLY when it equals `expected`.\n//   Otherwise return `None`. This is what Anchor does before it deserializes\n//   an account: wrong discriminator, wrong account type, refuse.\n//\n// ACCEPTANCE\n//   discriminator_if(&[1u8; 49], &[1u8; 8])  == Some(..) with len 8\n//   discriminator_if(&[1u8; 49], &[2u8; 8])  == None\n//   discriminator_if(&[0u8; 7],  &[0u8; 8])  == None   (too short)\n//\n// THE LIFETIME WORK — this is the lesson\n//   As written, this does not compile: E0106, missing lifetime specifier. Two\n//   input references, one output reference, no `self`, so elision has nothing\n//   to go on and the compiler refuses to guess.\n//\n//   Annotate it yourself, and get the answer RIGHT rather than merely legal:\n//     - The slice you return is bytes out of `data`, so it borrows from `data`.\n//     - `expected` is a caller's constant. You read it and never hand it back,\n//       so it needs its OWN lifetime, unconnected to the return type.\n//   Two lifetime parameters, therefore. Putting one name on both compiles the\n//   function but over-constrains every caller, and the harness rejects it —\n//   read the `expected fn pointer` / `found fn item` lines if you try it.\n//\n// NOTES\n//   - Reuse `discriminator`. Do not re-implement the length check.\n//   - Comparing bytes in a `const fn` means a `while` loop and indexing. There\n//     is no `==` on slices you can call here, and no iterator.\n//\n// Read the signature as two independent promises: what I return lives as long\n// as `data` ('a), and I also borrowed something else for some unrelated stretch\n// ('b) that you may forget about the moment this call returns.\npub const fn discriminator_if<'a, 'b>(\n    data: &'a [u8],\n    expected: &'b [u8; DISCRIMINATOR_LEN],\n) -> Option<&'a [u8]> {\n    let found = match discriminator(data) {\n        Some(bytes) => bytes,\n        None => return None,\n    };\n\n    let mut i = 0;\n    while i < DISCRIMINATOR_LEN {\n        if found[i] != expected[i] {\n            return None;\n        }\n        i += 1;\n    }\n\n    Some(found)\n}\n\n// ===========================================================================\n// VERIFICATION HARNESS — DO NOT EDIT.\n//\n// These items run inside the compiler. The two `_SIG_*` constants pin each\n// function's exact shape, including which input the returned reference borrows\n// from. The `const _: () = assert!(…)` items call your code during compilation,\n// so a wrong answer is reported as an `error[E0080]` const-evaluation failure\n// naming the assertion that did not hold.\n//\n// This trick works here only because both functions are `const fn` over plain\n// slices. It does not reach `deposit(&mut self)` in module 4.\n// ===========================================================================\n#[allow(dead_code)]\nmod verify {\n    const _SIG_DISCRIMINATOR: for<'a> fn(&'a [u8]) -> Option<&'a [u8]> = super::discriminator;\n\n    const _SIG_DISCRIMINATOR_IF: for<'a, 'b> fn(&'a [u8], &'b [u8; 8]) -> Option<&'a [u8]> =\n        super::discriminator_if;\n\n    const _: () = assert!(super::DISCRIMINATOR_LEN == 8);\n\n    const _: () = assert!(super::discriminator(&[]).is_none());\n    const _: () = assert!(super::discriminator(&[0u8; 7]).is_none());\n    const _: () = assert!(match super::discriminator(&[0u8; 8]) {\n        Some(d) => d.len() == 8,\n        None => false,\n    });\n    const _: () = assert!(match super::discriminator(&[7u8; 49]) {\n        Some(d) => d.len() == 8 && d[0] == 7 && d[7] == 7,\n        None => false,\n    });\n\n    const _: () = assert!(super::discriminator_if(&[1u8; 49], &[1u8; 8]).is_some());\n    const _: () = assert!(super::discriminator_if(&[1u8; 49], &[2u8; 8]).is_none());\n    const _: () = assert!(super::discriminator_if(&[0u8; 7], &[0u8; 8]).is_none());\n}\n",
+        "starter": "// ---------------------------------------------------------------------------\n// Lesson 8 — Lifetimes and Slices.\n//\n// Two functions. Signatures and spec below, no worked example. The `mod verify`\n// block at the bottom is NOT EDITABLE — it calls your functions at compile time\n// and asserts on the answers, so a `todo!()` body or a wrong length is a build\n// failure, not a silent pass.\n//\n// Toolchain: anchor-lang 1.1.2 · borsh 1.5.7 declared / 1.8.0 resolved · edition 2021.\n// ---------------------------------------------------------------------------\n\n/// Every Anchor account begins with 8 discriminator bytes. Do not change this.\npub const DISCRIMINATOR_LEN: usize = 8;\n\n// ===== 1. discriminator ====================================================\n//\n// SPEC\n//   Return a borrowed view of the first `DISCRIMINATOR_LEN` bytes of `data`.\n//   If `data` is shorter than that, return `None` — never panic, and never\n//   return a shorter slice.\n//\n// ACCEPTANCE\n//   discriminator(&[])            == None\n//   discriminator(&[0u8; 7])      == None\n//   discriminator(&[0u8; 8])      == Some(..) with len 8\n//   discriminator(&[0u8; 49])     == Some(..) with len 8, the FIRST eight\n//\n// NOTES\n//   - The signature below has no `'a` on it. That is legal: one input\n//     reference means elision has exactly one answer, and it fills it in.\n//   - `const fn` restricts you: no `?`, no iterators, no closures. `if`,\n//     `match`, `while` and slice methods that are themselves `const` are in.\n//   - Indexing with `[..8]` panics on a short slice. The spec says `None`, so\n//     check the length before you take anything.\npub const fn discriminator(data: &[u8]) -> Option<&[u8]> {\n    todo!()\n}\n\n// ===== 2. discriminator_if =================================================\n//\n// SPEC\n//   Return the account's discriminator ONLY when it equals `expected`.\n//   Otherwise return `None`. This is what Anchor does before it deserializes\n//   an account: wrong discriminator, wrong account type, refuse.\n//\n// ACCEPTANCE\n//   discriminator_if(&[1u8; 49], &[1u8; 8])  == Some(..) with len 8\n//   discriminator_if(&[1u8; 49], &[2u8; 8])  == None\n//   discriminator_if(&[0u8; 7],  &[0u8; 8])  == None   (too short)\n//\n// THE LIFETIME WORK — this is the lesson\n//   As written, this does not compile: E0106, missing lifetime specifier. Two\n//   input references, one output reference, no `self`, so elision has nothing\n//   to go on and the compiler refuses to guess.\n//\n//   Annotate it yourself, and get the answer RIGHT rather than merely legal:\n//     - The slice you return is bytes out of `data`, so it borrows from `data`.\n//     - `expected` is a caller's constant. You read it and never hand it back,\n//       so it needs its OWN lifetime, unconnected to the return type.\n//   Two lifetime parameters, therefore. Putting one name on both compiles the\n//   function but over-constrains every caller, and the harness rejects it —\n//   read the `expected fn pointer` / `found fn item` lines if you try it.\n//\n// NOTES\n//   - Reuse `discriminator`. Do not re-implement the length check.\n//   - Comparing bytes in a `const fn` means a `while` loop and indexing. There\n//     is no `==` on slices you can call here, and no iterator.\npub const fn discriminator_if(data: &[u8], expected: &[u8; DISCRIMINATOR_LEN]) -> Option<&[u8]> {\n    todo!()\n}\n\n// ===========================================================================\n// VERIFICATION HARNESS — DO NOT EDIT.\n//\n// These items run inside the compiler. The two `_SIG_*` constants pin each\n// function's exact shape, including which input the returned reference borrows\n// from. The `const _: () = assert!(…)` items call your code during compilation,\n// so a wrong answer is reported as an `error[E0080]` const-evaluation failure\n// naming the assertion that did not hold.\n//\n// This trick works here only because both functions are `const fn` over plain\n// slices. It does not reach `deposit(&mut self)` in module 4.\n// ===========================================================================\n#[allow(dead_code)]\nmod verify {\n    const _SIG_DISCRIMINATOR: for<'a> fn(&'a [u8]) -> Option<&'a [u8]> = super::discriminator;\n\n    const _SIG_DISCRIMINATOR_IF: for<'a, 'b> fn(&'a [u8], &'b [u8; 8]) -> Option<&'a [u8]> =\n        super::discriminator_if;\n\n    const _: () = assert!(super::DISCRIMINATOR_LEN == 8);\n\n    const _: () = assert!(super::discriminator(&[]).is_none());\n    const _: () = assert!(super::discriminator(&[0u8; 7]).is_none());\n    const _: () = assert!(match super::discriminator(&[0u8; 8]) {\n        Some(d) => d.len() == 8,\n        None => false,\n    });\n    const _: () = assert!(match super::discriminator(&[7u8; 49]) {\n        Some(d) => d.len() == 8 && d[0] == 7 && d[7] == 7,\n        None => false,\n    });\n\n    const _: () = assert!(super::discriminator_if(&[1u8; 49], &[1u8; 8]).is_some());\n    const _: () = assert!(super::discriminator_if(&[1u8; 49], &[2u8; 8]).is_none());\n    const _: () = assert!(super::discriminator_if(&[0u8; 7], &[0u8; 8]).is_none());\n}\n",
+        "tests": [
+          {
+            "description": "Program compiles successfully",
+            "expectedOutput": "true",
+            "id": "test-1",
+            "input": ""
+          },
+          {
+            "description": "mod verify's compile-time assertions on discriminator all evaluate (length check and first-8-bytes)",
+            "expectedOutput": "true",
+            "id": "test-2",
+            "input": ""
+          },
+          {
+            "description": "mod verify's fn-pointer constants accept discriminator_if — return borrows from data, expected has its own lifetime",
+            "expectedOutput": "true",
+            "id": "test-3",
+            "input": ""
+          }
+        ]
+      },
+      {
+        "_key": "check",
+        "_type": "quiz",
+        "questions": [
+          {
+            "explanation": "The help text spells out the whole lesson: \"this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from `data` or `expected`.\"",
+            "id": "q1",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "`E0106`, missing lifetime specifier — with two input references and no `self`, elision cannot tell whether the result borrows from `data` or `expected`"
+              },
+              {
+                "correct": false,
+                "feedback": "There is no first-parameter-wins rule. Elision applies when there is exactly one input reference, or when there is a `&self`. Two plain references and no receiver is precisely the case it refuses.",
+                "id": "b",
+                "label": "It compiles — elision assigns the return value the lifetime of the first reference parameter"
+              },
+              {
+                "correct": false,
+                "feedback": "`'static` means \"valid for the whole program\", which is a much stronger claim than either input can support. The compiler never invents it; it asks you.",
+                "id": "c",
+                "label": "It compiles, and the returned reference gets `'static` because the compiler cannot prove anything shorter"
+              },
+              {
+                "correct": false,
+                "feedback": "`E0621` shows up when the annotations exist but do not line up. Here there are none at all to line up, which is `E0106`.",
+                "id": "d",
+                "label": "`E0621` — explicit lifetime required in the type of `data`"
+              }
+            ],
+            "prompt": "You write `fn discriminator_if(data: &[u8], expected: &[u8; 8]) -> Option<&[u8]>` with no lifetime annotations. Predict what the compiler says and why."
+          },
+          {
+            "explanation": "Also why the harness pins `for<'a, 'b> fn(&'a [u8], &'b [u8; 8]) -> Option<&'a [u8]>`. The single-name version is a *less general* function type, so it does not fit the constant, and the mismatch is reported as `expected fn pointer` versus `found fn item` with the lifetimes shown.",
+            "id": "q2",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "Required that both arguments be usable over one common stretch, so a caller holding a short-lived `expected` and a long-lived `data` is refused for no reason"
+              },
+              {
+                "correct": false,
+                "feedback": "Two names are two independent claims. Collapsing them to one adds a constraint the function never needed: it makes the two inputs' lifetimes each other's problem.",
+                "id": "b",
+                "label": "Nothing — one lifetime for everything is the same signature written more briefly"
+              },
+              {
+                "correct": false,
+                "feedback": "An annotation never extends a lifetime. It only describes a relationship the compiler then checks. Nothing you write in a signature keeps a value alive one instruction longer.",
+                "id": "c",
+                "label": "Made the returned reference live as long as the longer of the two inputs"
+              },
+              {
+                "correct": false,
+                "feedback": "The opposite: it is over-strict, not unsafe. Rust's guarantee is never weakened by the annotation you choose — the worst you can do is reject callers you meant to accept.",
+                "id": "d",
+                "label": "Introduced a use-after-free risk, since `expected` may be dropped while the result is alive"
+              }
+            ],
+            "prompt": "You annotate it as `<'a>(data: &'a [u8], expected: &'a [u8; 8]) -> Option<&'a [u8]>` — one name on everything. The function body compiles. What have you actually done to your callers?"
+          },
+          {
+            "explanation": "Same rule as lesson 7's bug 4, opposite side of the call. `discriminator` is correct; the caller structured its scopes so the result outlives its source. Move `let data` outside the block and it compiles unchanged.",
+            "id": "q3",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "`E0597` — `data` does not live long enough; the borrow is still used after the block that owns the buffer ends"
+              },
+              {
+                "correct": false,
+                "feedback": "`Option<&[u8]>` owns the enum's one-word tag, not the bytes. The variant holds a borrow, and a borrow is only as good as what it points at.",
+                "id": "b",
+                "label": "Compiles — `disc` is an `Option`, and an `Option` owns its contents"
+              },
+              {
+                "correct": false,
+                "feedback": "Nothing rewrites `disc` at runtime. Rust has no mechanism that nulls out a reference when its target dies — which is exactly why the check has to happen at compile time.",
+                "id": "c",
+                "label": "Compiles, and `disc` is `None` after the block because the buffer was dropped"
+              },
+              {
+                "correct": false,
+                "feedback": "`E0515` is the same mistake seen from inside a function that is returning. Here the mistake is in the caller, spanning two scopes, and the compiler names the value that died too early instead.",
+                "id": "d",
+                "label": "`E0515` — cannot return a value referencing a local variable"
+              }
+            ],
+            "prompt": "A caller does this — declares `let disc;`, opens a block, builds `let data = vec![0u8; 49];` inside it, assigns `disc = discriminator(&data);`, closes the block, then reads `disc`. Predict the verdict."
+          }
+        ]
+      }
+    ],
+    "skills": [
+      "rust-lifetimes",
+      "rust-slices",
+      "account-layout"
+    ],
+    "slug": {
+      "_type": "slug",
+      "current": "lifetimes-and-slices"
+    },
+    "title": "Lifetimes and Slices"
+  },
+  {
+    "_id": "lesson-rpd-moves-copy-and-clone",
+    "_type": "lesson",
+    "blocks": [
+      {
+        "_key": "intro",
+        "_type": "prose",
+        "src": "# Moves, Copy, and Clone\n\n> **Version stamp — checked 2026-07-26.** `anchor-lang 1.1.2` (crates.io latest stable) · `borsh` 1.5.7 declared / **1.8.0** resolved · edition 2021 · Agave ≥ 3.1.10 / rustc per the build server's pinned platform-tools. Every line in this lesson's exercise was compiled against that toolchain.\n\nThe two functions you wrote in the last lesson never argued with you about ownership. That is not because you got it right — it is because `u64` is a special case. Four lessons in, every value you have touched has been a number small enough to sit in a register, and Rust duplicates those for free.\n\nThe moment a value owns something — a `Vec<u8>` of account data, a struct you defined yourself — assignment stops meaning what it means in JavaScript, and the compiler starts refusing code that looks obviously fine.\n\n## The one sentence\n\nIn JavaScript, `const b = a` gives you **two names for one object**.\n\n```js\nconst vault = { owner: \"…\", balance: 500n };\nconst backup = vault;\nbackup.balance = 0n;\nvault.balance; // 0n — there was only ever one object\n```\n\nIn Rust, `let b = a` gives you **one name and invalidates the other**.\n\n```rust\nlet vault = VaultLike { /* … */ };\nlet backup = vault;   // `vault` is no longer usable\n```\n\nNothing was copied and nothing was freed. The value did not move in memory — the *right to use it* moved, from `vault` to `backup`, at compile time. Reading `vault` afterwards is not a runtime error you can catch. It is a build failure, `E0382: use of moved value`, and the message points at both lines:\n\n```text\nerror[E0382]: use of moved value: `vault`\n    |\n    |     let vault = sample_vault();\n    |         ----- move occurs because `vault` has type `VaultLike`,\n    |               which does not implement the `Copy` trait\n    |     let backup = vault;\n    |                  ----- value moved here\n    |     let _oops = vault.balance;\n    |                 ^^^^^^^^^^^^^ value used here after move\n```\n\nTwo lines named, and the reason stated in the middle of them: *does not implement the `Copy` trait*. Almost every ownership error you will read has that shape — the line that failed, the line that caused it, and the trait that would have made it legal.\n\n## Three rules, and they are actually three\n\n1. Every value has exactly one owner.\n2. When the owner goes out of scope, the value is dropped.\n3. Ownership can be **moved**, **copied** (only for types that opt in), or **borrowed** (next lesson).\n\nThat is the whole model. There is no garbage collector deciding when rule 2 fires; the compiler inserts the drop at the closing brace, and that is why Rust has no runtime and no GC pauses — which is why programs on Solana are written in it.\n\n## Why you already know this shape\n\nYou met this rule in Course 1 without it being called ownership. A Solana transaction declares, up front, which accounts it will **read** and which it will **write**, and the runtime will not schedule two transactions that write the same account at the same time. Many readers, or one writer. Never both.\n\nRust's rule for references is the same sentence: many shared borrows, or one mutable borrow, never both. The runtime enforces it across transactions at runtime; the compiler enforces it inside your function at build time. Same invariant, two places. When `&mut` starts feeling arbitrary, this is the analogy to come back to.\n\n## `Copy` is opt-in, and that is the whole trick\n\nA type is `Copy` only if it says so. Assignment copies instead of moving for:\n\n| Type | Why |\n| --- | --- |\n| `u8`, `u64`, `i64`, `usize`, `bool` | Fixed size, no heap, no destructor |\n| `Pubkey` | 32 plain bytes; the type derives `Copy` |\n| `[u8; 8]` | An array of `Copy` values is `Copy` |\n| `&T` (a shared reference) | A reference is itself just an address |\n\nAssignment **moves** for:\n\n| Type | Why |\n| --- | --- |\n| `Vec<u8>` — a raw account buffer | Owns a heap allocation. Two owners would mean two frees |\n| `String` | Same |\n| `VaultLike`, and any struct you write | **`Copy` is not inferred.** A struct whose every field is `Copy` still moves unless you derive `Copy` on the struct itself |\n\nThat last row is the one that catches people. `VaultLike { owner: Pubkey, balance: u64, bump: u8 }` is 41 bytes of pure `Copy` fields, and it still moves — because `Copy` is a claim about the *type*, not a computed property of its fields, and Rust makes you state it.\n\n## `.clone()` is allowed\n\nThere is a genre of Rust advice that treats `.clone()` as a confession. Ignore it. `.clone()` is an explicit, visible, correct way to get a second independent value, and reaching for it while the model is still settling is the right call. It has exactly one cost: the copy actually happens at runtime, and for a `Vec` that is a heap allocation.\n\nThe reason it barely matters here is that the vault you are building is 41 bytes. The reason it will matter in Course 3 is that account data can be kilobytes and compute units are metered. Clone now, and learn where the borrow goes later — in that order.\n\n## What you are about to do\n\nThis exercise is complete and correct. There is nothing to fix. Build it, then read it top to bottom against its six numbered sections and check each one against the prediction you would have made before this page.\n\nSection 6 is a single-line experiment: uncomment the line marked `BREAK IT`, build, read the error the compiler gives you, then comment it back. That error message is the one you will see most often for the next week, and meeting it deliberately once is cheaper than meeting it by accident five times.\n"
+      },
+      {
+        "_key": "exercise",
+        "_type": "code",
+        "buildType": "buildable",
+        "deployable": false,
+        "hints": [
+          "Nothing needs fixing. Click Build first, then read the six numbered sections against the predictions you would have made before the page above.",
+          "First builds are slow — the toolchain is downloading anchor-lang 1.1.2 and its dependencies. A second build of the same file is much faster.",
+          "Section 6 is the whole exercise: uncomment the line marked BREAK IT, build, read which TWO lines the error names, then comment it back. Click Reset Code if you lose the file."
+        ],
+        "language": "rust",
+        "solution": "// ---------------------------------------------------------------------------\n// Lesson 5 — Moves, Copy, and Clone.\n//\n// WORKED EXAMPLE — reference copy. Identical to the starter, because there was\n// nothing to fix. The only difference is the note at the bottom recording the\n// error the experiment produces, so you can check what you read against it.\n//\n// Toolchain: anchor-lang 1.1.2 · borsh 1.5.7 declared / 1.8.0 resolved · edition 2021.\n// ---------------------------------------------------------------------------\n\nuse anchor_lang::prelude::*;\n\n/// The vault, as a plain Rust struct — field for field the account layout you\n/// decoded in Course 1. In module 3 this grows an `#[account]` attribute and\n/// becomes the real thing; for now it is an ordinary struct so that ownership\n/// is the only thing in the room.\n///\n/// `Clone` is derived. `Copy` deliberately is NOT, even though all three fields\n/// are `Copy` types. That single omission is what makes every assignment in\n/// section 3 a move.\n///\n/// Note the shape change from lesson 2: `last_deposit_at` is gone and\n/// `owner: Pubkey` has arrived. Lesson 2 needed somewhere to put an `i64`;\n/// from here on the stand-in matches module 4's real `VaultState`\n/// — `{ owner, balance, bump }` — because `owner` is the field that makes\n/// the move rules interesting.\n#[derive(Clone, Debug)]\npub struct VaultLike {\n    pub owner: Pubkey,\n    pub balance: u64,\n    pub bump: u8,\n}\n\n/// A fresh vault to experiment on. `Pubkey::default()` is the all-zero address.\npub fn sample_vault() -> VaultLike {\n    VaultLike {\n        owner: Pubkey::default(),\n        balance: 500_000,\n        bump: 254,\n    }\n}\n\n// === 1. `u64` is Copy: assignment duplicates the value =====================\n// `snapshot` is a second, independent 8 bytes. `balance` is untouched and\n// still readable, which is why lesson 4 never made you think about ownership.\npub fn copy_a_number() -> u64 {\n    let balance: u64 = 1_000_000;\n    let snapshot = balance;\n    balance + snapshot // 2_000_000 — both names are live\n}\n\n// === 2. `Pubkey` is Copy too ==============================================\n// 32 plain bytes, no heap, no destructor, and the type derives `Copy`. So you\n// can read the field out of a borrowed vault as many times as you like.\npub fn copy_an_address(v: &VaultLike) -> (Pubkey, Pubkey) {\n    let owner = v.owner;\n    let owner_again = v.owner;\n    (owner, owner_again)\n}\n\n// === 3. `VaultLike` is NOT Copy: assignment MOVES =========================\n// Every field is `Copy` and the struct still moves, because `Copy` is a claim\n// you make about a type, not something inferred from its fields. After the\n// second line, the name `vault` is dead — the compiler will not let you read\n// it, and there is no runtime check involved.\npub fn move_a_struct() -> u64 {\n    let vault = sample_vault();\n    let moved = vault;\n    moved.balance\n}\n\n// === 4. A `Vec<u8>` can never be Copy =====================================\n// Raw account data is a heap buffer with exactly one owner, because two owners\n// would mean two frees. Passing it by value into `consume_bytes` moves it, and\n// `data` is unusable on the next line.\npub fn move_account_data() -> usize {\n    let data: Vec<u8> = vec![0u8; 49]; // 8 discriminator + 32 owner + 8 balance + 1 bump\n    consume_bytes(data)\n}\n\nfn consume_bytes(bytes: Vec<u8>) -> usize {\n    bytes.len()\n}\n\n// === 5. `.clone()` is the escape hatch, and it is legitimate ==============\n// An explicit, visible request for a second independent value. Both names are\n// live afterwards. The cost is real but it is written down at the call site,\n// which is the entire design intent.\npub fn clone_a_struct() -> (u64, u64) {\n    let vault = sample_vault();\n    let mut backup = vault.clone();\n    backup.balance = 0;\n    (vault.balance, backup.balance) // (500_000, 0) — two separate vaults\n}\n\n// === 6. Borrowing: pass a reference and nothing moves at all ==============\n// `&VaultLike` is a shared borrow. It grants read access and takes nothing, so\n// the caller still owns the vault after the call returns — which is why you can\n// call it twice. This signature is the first function you write in the next\n// lesson, and it is a method on the real `VaultState` in module 4.\npub fn balance_of(v: &VaultLike) -> u64 {\n    v.balance\n}\n\npub fn read_twice() -> (u64, u64) {\n    let vault = sample_vault();\n    let a = balance_of(&vault);\n    let b = balance_of(&vault);\n    (a, b)\n}\n\n// === The experiment =======================================================\n// Uncomment the line marked BREAK IT. Build. Read the error — note that it\n// names the line where the move happened, not just the line that failed. Then\n// comment it back and build again to confirm you are green.\n//\n// If you lose track of the file, Reset Code restores it.\npub fn experiment() -> u64 {\n    let vault = sample_vault();\n    let moved = vault;\n\n    // let _oops = vault.balance; // <-- BREAK IT\n\n    moved.balance\n}\n\n// Uncommented, that line produces exactly this:\n//\n//   error[E0382]: use of moved value: `vault`\n//       |\n//       |     let vault = sample_vault();\n//       |         ----- move occurs because `vault` has type `VaultLike`,\n//       |               which does not implement the `Copy` trait\n//       |     let moved = vault;\n//       |                 ----- value moved here\n//       |     let _oops = vault.balance;\n//       |                 ^^^^^^^^^^^^^ value used here after move\n//       |\n//   help: consider cloning the value if the performance cost is acceptable\n//       |\n//       |     let moved = vault.clone();\n//       |                      ++++++++\n//\n// Note what the compiler does NOT say: nothing about `balance` being a `u64`.\n// The field is `Copy`, but you cannot reach through a binding that no longer\n// owns anything to get at it. And note the suggestion — `.clone()` really is\n// the fix the compiler itself proposes.\n",
+        "starter": "// ---------------------------------------------------------------------------\n// Lesson 5 — Moves, Copy, and Clone.\n//\n// WORKED EXAMPLE. This file is complete and it compiles. Nothing here is\n// broken and nothing is missing.\n//\n// Build it once, then read the six numbered sections in order. Each one is\n// three or four lines and demonstrates exactly one rule. Section 6 is the only\n// place you touch: one line to uncomment, build, read, and comment back.\n//\n// Toolchain: anchor-lang 1.1.2 · borsh 1.5.7 declared / 1.8.0 resolved · edition 2021.\n// ---------------------------------------------------------------------------\n\nuse anchor_lang::prelude::*;\n\n/// The vault, as a plain Rust struct — field for field the account layout you\n/// decoded in Course 1. In module 3 this grows an `#[account]` attribute and\n/// becomes the real thing; for now it is an ordinary struct so that ownership\n/// is the only thing in the room.\n///\n/// `Clone` is derived. `Copy` deliberately is NOT, even though all three fields\n/// are `Copy` types. That single omission is what makes every assignment in\n/// section 3 a move.\n///\n/// Note the shape change from lesson 2: `last_deposit_at` is gone and\n/// `owner: Pubkey` has arrived. Lesson 2 needed somewhere to put an `i64`;\n/// from here on the stand-in matches module 4's real `VaultState`\n/// — `{ owner, balance, bump }` — because `owner` is the field that makes\n/// the move rules interesting.\n#[derive(Clone, Debug)]\npub struct VaultLike {\n    pub owner: Pubkey,\n    pub balance: u64,\n    pub bump: u8,\n}\n\n/// A fresh vault to experiment on. `Pubkey::default()` is the all-zero address.\npub fn sample_vault() -> VaultLike {\n    VaultLike {\n        owner: Pubkey::default(),\n        balance: 500_000,\n        bump: 254,\n    }\n}\n\n// === 1. `u64` is Copy: assignment duplicates the value =====================\n// `snapshot` is a second, independent 8 bytes. `balance` is untouched and\n// still readable, which is why lesson 4 never made you think about ownership.\npub fn copy_a_number() -> u64 {\n    let balance: u64 = 1_000_000;\n    let snapshot = balance;\n    balance + snapshot // 2_000_000 — both names are live\n}\n\n// === 2. `Pubkey` is Copy too ==============================================\n// 32 plain bytes, no heap, no destructor, and the type derives `Copy`. So you\n// can read the field out of a borrowed vault as many times as you like.\npub fn copy_an_address(v: &VaultLike) -> (Pubkey, Pubkey) {\n    let owner = v.owner;\n    let owner_again = v.owner;\n    (owner, owner_again)\n}\n\n// === 3. `VaultLike` is NOT Copy: assignment MOVES =========================\n// Every field is `Copy` and the struct still moves, because `Copy` is a claim\n// you make about a type, not something inferred from its fields. After the\n// second line, the name `vault` is dead — the compiler will not let you read\n// it, and there is no runtime check involved.\npub fn move_a_struct() -> u64 {\n    let vault = sample_vault();\n    let moved = vault;\n    moved.balance\n}\n\n// === 4. A `Vec<u8>` can never be Copy =====================================\n// Raw account data is a heap buffer with exactly one owner, because two owners\n// would mean two frees. Passing it by value into `consume_bytes` moves it, and\n// `data` is unusable on the next line.\npub fn move_account_data() -> usize {\n    let data: Vec<u8> = vec![0u8; 49]; // 8 discriminator + 32 owner + 8 balance + 1 bump\n    consume_bytes(data)\n}\n\nfn consume_bytes(bytes: Vec<u8>) -> usize {\n    bytes.len()\n}\n\n// === 5. `.clone()` is the escape hatch, and it is legitimate ==============\n// An explicit, visible request for a second independent value. Both names are\n// live afterwards. The cost is real but it is written down at the call site,\n// which is the entire design intent.\npub fn clone_a_struct() -> (u64, u64) {\n    let vault = sample_vault();\n    let mut backup = vault.clone();\n    backup.balance = 0;\n    (vault.balance, backup.balance) // (500_000, 0) — two separate vaults\n}\n\n// === 6. Borrowing: pass a reference and nothing moves at all ==============\n// `&VaultLike` is a shared borrow. It grants read access and takes nothing, so\n// the caller still owns the vault after the call returns — which is why you can\n// call it twice. This signature is the first function you write in the next\n// lesson, and it is a method on the real `VaultState` in module 4.\npub fn balance_of(v: &VaultLike) -> u64 {\n    v.balance\n}\n\npub fn read_twice() -> (u64, u64) {\n    let vault = sample_vault();\n    let a = balance_of(&vault);\n    let b = balance_of(&vault);\n    (a, b)\n}\n\n// === The experiment =======================================================\n// Uncomment the line marked BREAK IT. Build. Read the error — note that it\n// names the line where the move happened, not just the line that failed. Then\n// comment it back and build again to confirm you are green.\n//\n// If you lose track of the file, Reset Code restores it.\npub fn experiment() -> u64 {\n    let vault = sample_vault();\n    let moved = vault;\n\n    // let _oops = vault.balance; // <-- BREAK IT\n\n    moved.balance\n}\n",
+        "tests": [
+          {
+            "description": "The file compiles against anchor-lang 1.1.2 on the build server",
+            "expectedOutput": "true",
+            "id": "test-1",
+            "input": ""
+          },
+          {
+            "description": "Compiles ⇒ the BREAK IT line in the experiment is commented out — an uncommented use-after-move is E0382, so a green build means it is back under its comment. Nothing here checks whether you read the error first",
+            "expectedOutput": "true",
+            "id": "test-2",
+            "input": ""
+          }
+        ]
+      },
+      {
+        "_key": "check",
+        "_type": "quiz",
+        "questions": [
+          {
+            "explanation": "The error names two lines — where the move happened and where the dead name was used — and states the reason between them: \"does not implement the `Copy` trait\".",
+            "id": "q1",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "Rejects it — `E0382`, because `Copy` is opt-in on the struct and `VaultLike` does not derive it"
+              },
+              {
+                "correct": false,
+                "feedback": "This is the single most common wrong model. `Copy` is a claim you make about a type with a derive, not a property Rust computes from the fields. All-`Copy` fields make the derive *possible*; they do not make it happen.",
+                "id": "b",
+                "label": "Accepts it — a struct whose every field is `Copy` is itself `Copy`"
+              },
+              {
+                "correct": false,
+                "feedback": "The field is indeed `Copy`, but you are reaching for it through `vault`, and `vault` no longer owns anything. There is nothing to read the field out of.",
+                "id": "c",
+                "label": "Accepts it — `balance` is a `u64`, and reading a `Copy` field is always allowed"
+              },
+              {
+                "correct": false,
+                "feedback": "There is no runtime check and no panic. Ownership is enforced entirely at compile time, which is why it costs zero instructions and zero compute units.",
+                "id": "d",
+                "label": "Compiles, then panics at runtime with a use-after-move error"
+              }
+            ],
+            "prompt": "`VaultLike` holds a `Pubkey`, a `u64` and a `u8` — every field is a `Copy` type. You write `let moved = vault;` and then read `vault.balance`. Predict what the compiler does."
+          },
+          {
+            "id": "q2",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "Both compile — `Pubkey` derives `Copy`, so each line copies 32 bytes out of the borrow"
+              },
+              {
+                "correct": false,
+                "feedback": "A `Copy` field is never moved by a read. If `Pubkey` were not `Copy` you would not get `E0382` either — you would get `E0507`, cannot move out of borrowed content, because you do not own `v` at all.",
+                "id": "b",
+                "label": "The first compiles and the second is `E0382`, because the first one moved the field out"
+              },
+              {
+                "correct": false,
+                "feedback": "Reading is exactly what a shared reference is for. `&T` grants read access to every field; what it withholds is mutation.",
+                "id": "c",
+                "label": "Neither compiles — you cannot read any field through a shared reference"
+              },
+              {
+                "correct": false,
+                "feedback": "32 bytes on the stack, no allocator involved. Heap allocation is what `Vec` and `String` do, and it is exactly why those two are not `Copy`.",
+                "id": "d",
+                "label": "Both compile, but each one allocates because `Pubkey` is 32 bytes"
+              }
+            ],
+            "prompt": "Inside `fn copy_an_address(v: &VaultLike)` you write `let a = v.owner;` and then `let b = v.owner;`. Predict the outcome."
+          },
+          {
+            "id": "q3",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "`E0382` on the second call — the first call moved the buffer, and a `Vec` can never be `Copy`"
+              },
+              {
+                "correct": false,
+                "feedback": "What the body does is irrelevant. Ownership follows the *signature*: `Vec<u8>` by value means the caller hands it over, and the value is dropped at the end of the callee.",
+                "id": "b",
+                "label": "It works — the function only reads the length, so nothing is consumed"
+              },
+              {
+                "correct": false,
+                "feedback": "There is no \"emptied\" state to observe. The compiler refuses to build the call rather than letting you look at a moved-from value.",
+                "id": "c",
+                "label": "It works, but the second call sees an empty vector"
+              },
+              {
+                "correct": false,
+                "feedback": "Nothing was borrowed. The parameter is `Vec<u8>`, not `&mut Vec<u8>`, so this is a move, not a borrow, and moves report `E0382`.",
+                "id": "d",
+                "label": "`E0499` — two calls means two mutable borrows of `data`"
+              }
+            ],
+            "prompt": "`fn consume_bytes(bytes: Vec<u8>) -> usize` takes its argument by value. You call `consume_bytes(data)` twice with the same `data`. Predict what happens on the second call."
+          },
+          {
+            "explanation": "Borrowing is the answer the language wants, and it is the whole of the next lesson: `&VaultLike` to read, `&mut VaultLike` to write.",
+            "id": "q4",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "Change the helper to take `&VaultLike`"
+              },
+              {
+                "correct": false,
+                "feedback": "It would compile here, but `Copy` is a permanent claim about the type — that duplicating it is always cheap and always correct. The day the struct gains a `Vec` field the derive becomes impossible, and every call site that silently relied on copying breaks at once.",
+                "id": "b",
+                "label": "Add `Copy` to the struct's derive list"
+              },
+              {
+                "correct": false,
+                "feedback": "This works and is not shameful — but it does copy the 41 bytes, which is what the question ruled out. Reach for it when a borrow genuinely will not fit the shape of your code.",
+                "id": "c",
+                "label": "Pass `vault.clone()` at the call site"
+              },
+              {
+                "correct": false,
+                "feedback": "This also compiles, and it is the right move for one `Copy` field. It does not keep the *vault* alive though — `vault` is still dead after the call, so anything else you needed from it is gone.",
+                "id": "d",
+                "label": "Read `vault.balance` into a variable before the call, then use that"
+              }
+            ],
+            "prompt": "You hand a `VaultLike` by value to a logging helper and need to read the balance afterwards. Which fix keeps the caller's vault alive without copying 41 bytes and without changing what the type claims about itself?"
+          }
+        ]
+      }
+    ],
+    "skills": [
+      "rust-ownership",
+      "rust-move-semantics"
+    ],
+    "slug": {
+      "_type": "slug",
+      "current": "moves-copy-and-clone"
+    },
+    "title": "Moves, Copy, and Clone"
+  },
+  {
+    "_id": "lesson-rpd-ownership-checkpoint",
+    "_type": "lesson",
+    "blocks": [
+      {
+        "_key": "retrieval",
+        "_type": "quiz",
+        "questions": [
+          {
+            "id": "q1",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "`E0382` — `for v in vaults` calls `.into_iter()`, which takes the `Vec` by value, so `vaults` is gone by the last line"
+              },
+              {
+                "correct": false,
+                "feedback": "`for x in collection` moves it; `for x in &collection` borrows it. The sugar hides an ordinary by-value call to `into_iter`, and the compiler's own suggestion is to add the `&`.",
+                "id": "b",
+                "label": "Compiles — a `for` loop borrows what it iterates"
+              },
+              {
+                "correct": false,
+                "feedback": "A read is a borrow, and you cannot borrow what you no longer own. The error even says so: \"value borrowed here after move\".",
+                "id": "c",
+                "label": "Compiles — `len()` only reads, and a read after a move is allowed"
+              },
+              {
+                "correct": false,
+                "feedback": "Nothing borrowed it first. `E0507` is for moving out of something you only have a reference to. Here you owned the `Vec` outright and gave it away.",
+                "id": "d",
+                "label": "`E0507` — cannot move out of `vaults` because it is borrowed"
+              }
+            ],
+            "prompt": "A function takes `vaults: Vec<VaultLike>`, sums the balances with `for v in vaults { sum += v.balance; }`, then returns the tuple `(sum, vaults.len())`. Predict the verdict."
+          },
+          {
+            "explanation": "The compiler names the semicolon and offers to delete it: \"help: remove this semicolon to return this value\".",
+            "id": "q2",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "`E0308` — expected `&str`, found `()`; the semicolon discards the match's value and the body ends with nothing"
+              },
+              {
+                "correct": false,
+                "feedback": "The semicolon is exactly what decides that. With it the line is a statement whose value is thrown away; without it the line is the body's tail expression and its value is returned.",
+                "id": "b",
+                "label": "Compiles — the last expression in a body is returned whether or not it has a semicolon"
+              },
+              {
+                "correct": false,
+                "feedback": "The match is exhaustive — `_` covers everything. The arms are not the problem; what happens to the value they produce is.",
+                "id": "c",
+                "label": "`E0317` — `if`/`match` may be missing an `else` clause"
+              },
+              {
+                "correct": false,
+                "feedback": "There is no implicit empty value in Rust and no coercion from `()` to `&str`. A type mismatch is a build failure, not a default.",
+                "id": "d",
+                "label": "Compiles, and returns an empty string"
+              }
+            ],
+            "prompt": "`pub fn describe(balance: u64) -> &'static str` has a body consisting of `match balance { 0 => \"empty\", _ => \"funded\" };` — note the semicolon. Predict the verdict."
+          },
+          {
+            "explanation": "`balance` starts at **40**. Every Anchor account spends its first 8 bytes on a hash of the account type's name, and `Pubkey` is 32, and Borsh adds no padding — the fields sit back to back in declaration order. Offset 32 is where the last 8 bytes of the owner's address live, which is why the wrong answer looks like a number rather than an error.",
+            "id": "q3",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "The read starts 8 bytes early — `balance` begins at 8 + 32 = 40, so offset 32 straddles the last 8 bytes of `owner` and the first nothing of `balance`, and you decoded address bytes as a number"
+              },
+              {
+                "correct": false,
+                "feedback": "A real cause of exactly this symptom, and not this one: the offset is wrong before endianness gets a say. Worth checking second — if offset 40 still gives you nonsense, that is where you look.",
+                "id": "b",
+                "label": "The bytes were read big-endian. Borsh writes a `u64` little-endian, and reversing the byte order of 500 000 000 gives a gigantic value"
+              },
+              {
+                "correct": false,
+                "feedback": "Precision loss perturbs a large number; it does not turn 500 000 000 into a quintillion. And 0.5 SOL is 5 × 10^8 lamports, far below 2^53 − 1, so a double holds it exactly.",
+                "id": "c",
+                "label": "`Number` lost precision. A `u64` lamport balance above 2^53 − 1 is silently rounded by a JavaScript double"
+              },
+              {
+                "correct": false,
+                "feedback": "Nothing \"falls through\". A discriminator mismatch is something you check for and reject; a decoder pointed at the wrong offset happily reads eight real bytes and reports a real number that means something else.",
+                "id": "d",
+                "label": "The discriminator did not match, so the decoder fell through and read whatever was in the buffer"
+              }
+            ],
+            "prompt": "Seeded from Course 1. Your inspector reads 8 bytes at offset 32 of a 49-byte vault account and prints a balance in the quintillions. The vault actually holds 0.5 SOL. The layout is 8-byte discriminator, `owner: Pubkey`, `balance: u64`, `bump: u8`. Diagnose it."
+          },
+          {
+            "explanation": "Both directions of `E0502` name three lines, and the third — \"mutable borrow later used here\" — is the one that tells you which borrow to get rid of.",
+            "id": "q4",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "`E0502` — cannot borrow `*v` as immutable because it is also borrowed as mutable"
+              },
+              {
+                "correct": false,
+                "feedback": "Right code, wrong direction. That wording is for the case where the shared borrow came first. Here the `&mut` came first, so the compiler complains about the shared one arriving second — read which borrow gets the caret.",
+                "id": "b",
+                "label": "`E0502` — cannot borrow `*v` as mutable because it is also borrowed as immutable"
+              },
+              {
+                "correct": false,
+                "feedback": "`balance_of` takes `&VaultLike`. Passing a `&mut` where a `&` is wanted produces a *shared* reborrow, not a second exclusive one.",
+                "id": "c",
+                "label": "`E0499` — two mutable borrows, since `balance_of` reborrows `v` mutably"
+              },
+              {
+                "correct": false,
+                "feedback": "Field-level disjointness only helps when both borrows are of distinct fields. `balance_of(v)` borrows the whole vault, which includes the field already borrowed mutably.",
+                "id": "d",
+                "label": "Compiles — `slot` borrows one field and `balance_of` reads the whole struct, so nothing overlaps"
+              }
+            ],
+            "prompt": "Inside `fn stash(v: &mut VaultLike) -> u64` you write `let slot = &mut v.balance;`, then `let total = balance_of(v);`, then `*slot = total;`. Predict the error and its exact direction."
+          },
+          {
+            "id": "q5",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "`E0308`, expected `usize` found `u32` — and refuse the suggested `.try_into().unwrap()`, writing `usize::try_from(field_count)` and handling the `Err` instead"
+              },
+              {
+                "correct": false,
+                "feedback": "Rust has no implicit numeric coercion at all, lossless or not. The literal `8` infers `u32` from its neighbour and the sum stays a `u32`.",
+                "id": "b",
+                "label": "Compiles — `u32` widens to `usize` automatically because it cannot lose information"
+              },
+              {
+                "correct": false,
+                "feedback": "It compiles, and it is a panic waiting for the input that triggers it. The compiler does not know it is writing on-chain code; its diagnostics are authoritative and its suggestions are not. Keep the `try_into`, drop the `unwrap`.",
+                "id": "c",
+                "label": "`E0308`, and the right fix is the `.try_into().unwrap()` the compiler proposes"
+              },
+              {
+                "correct": false,
+                "feedback": "`usize::from` does not exist for `u32` — `impl From<u32> for usize` is not in the standard library, because `usize` is 16 bits on some targets and the conversion is therefore not universally lossless. `impl From<u16> for usize` does exist. `TryFrom` is what you get for `u32`, and it hands you a `Result` rather than a promise.",
+                "id": "d",
+                "label": "`E0308`, and the fix is `usize::from(field_count) + 8`, the infallible conversion"
+              }
+            ],
+            "prompt": "`pub fn space(field_count: u32) -> usize { 8 + field_count }`. Predict the verdict, and what you should do with the compiler's suggested fix."
+          },
+          {
+            "explanation": "`v.owner.as_ref()` is the fix — a `&[u8]` view of the `Pubkey` the caller already owns. When you borrow from a method's return value, check first whether that method returned a reference or a value.",
+            "id": "q6",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "`E0515` — cannot return reference to local variable `bytes`; `to_bytes` returned an owned array this function drops on the way out"
+              },
+              {
+                "correct": false,
+                "feedback": "`Copy` decides whether assignment duplicates the value. It has nothing to say about how long the local lives, and the local dies at the closing brace either way.",
+                "id": "b",
+                "label": "Compiles — `[u8; 32]` is `Copy`, so returning a reference to it is fine"
+              },
+              {
+                "correct": false,
+                "feedback": "The stack frame goes away too. Where the bytes live does not change when they stop existing.",
+                "id": "c",
+                "label": "Compiles — `bytes` is on the stack, not the heap, so there is nothing to free"
+              },
+              {
+                "correct": false,
+                "feedback": "Elision handles this signature fine: one input reference, so the return borrows from `v`. The problem is that the body tried to borrow from something else entirely.",
+                "id": "d",
+                "label": "`E0106` — the signature needs an explicit lifetime because the return borrows from a local"
+              }
+            ],
+            "prompt": "`pub fn owner_bytes(v: &VaultLike) -> &[u8]` with the body `let bytes = v.owner.to_bytes(); &bytes`. `Pubkey::to_bytes` returns `[u8; 32]`. Predict the verdict."
+          },
+          {
+            "explanation": "This constraint is the origin of `u64` in the struct you are about to write. In Rust the width is in the type, and the only way to lose a lamport is to let the arithmetic wrap.",
+            "id": "q7",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "`Number` is a double: integers above 2^53 − 1 stop being exactly representable and are silently rounded, and a `u64` lamport balance clears that comfortably"
+              },
+              {
+                "correct": false,
+                "feedback": "It is slower, and that is an acceptable price. The reason is correctness: a wrong balance that looks plausible is worse than a slow one.",
+                "id": "b",
+                "label": "`BigInt` is faster for arithmetic on large values"
+              },
+              {
+                "correct": false,
+                "feedback": "Wrong boundary. A double holds far more than 2^32; the limit is where *exact integer* representation stops, at 2^53 − 1.",
+                "id": "c",
+                "label": "`Number` cannot hold values above 2^32, so any balance over ~4.29 billion lamports overflows"
+              },
+              {
+                "correct": false,
+                "feedback": "How the number arrives on the wire is a separate question. The decoder's choice is about what can hold the value once parsed.",
+                "id": "d",
+                "label": "Because JSON-RPC returns balances as strings and `BigInt` is what parses them"
+              }
+            ],
+            "prompt": "Also seeded from Course 1. Kit's `getU64Decoder` gives you a `BigInt` for the vault's `balance`, not a `Number`. Why does that matter enough to change the API?"
+          },
+          {
+            "explanation": "`overflow-checks = true` is a safety net for testing, not a substitute for checked arithmetic. `sub_lamports` from lesson 4 becomes `VaultState::withdraw` returning `VaultError::InsufficientFunds` in module 4 — same arithmetic, with a reason attached.",
+            "id": "q8",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "It panics and the instruction aborts with no useful message — and no, because the correct behaviour is a typed error the caller can act on, which is what `checked_sub` gives you"
+              },
+              {
+                "correct": false,
+                "feedback": "With the checks on it panics rather than wrapping, so the setting does change the outcome — but \"panic\" is not the behaviour you want. It converts a silent wrong answer into an opaque failure, which is an improvement, not a solution.",
+                "id": "b",
+                "label": "It wraps to a huge number, and `overflow-checks = true` is the fix"
+              },
+              {
+                "correct": false,
+                "feedback": "`-` returns a `u64`, never an `Option`. `checked_sub` is a different method with a different return type, and you have to choose it.",
+                "id": "c",
+                "label": "It returns `None`, because Rust's `-` on unsigned integers is checked by default"
+              },
+              {
+                "correct": false,
+                "feedback": "Nothing clamps. Saturating behaviour exists but you have to ask for it by name (`saturating_sub`), and silently clamping a withdrawal to zero would be its own exploit.",
+                "id": "d",
+                "label": "Nothing bad — `v.balance` is a `u64` and cannot go negative, so the result clamps at zero"
+              }
+            ],
+            "prompt": "`pub fn withdraw(v: &mut VaultLike, amount: u64) { v.balance = v.balance - amount; }` compiles. The build server's release profile sets `overflow-checks = true`. Predict what happens when `amount` exceeds the balance, and whether that setting is enough."
+          }
+        ]
+      },
+      {
+        "_key": "worked-answers",
+        "_type": "prose",
+        "src": "# Worked Answers\n\n> **Version stamp — checked 2026-07-26.** Every message below is real `rustc` output, produced by compiling the snippet above it against `anchor-lang 1.1.2` / borsh 1.5.7 declared / 1.8.0 resolved / edition 2021 — the same toolchain the build server uses. Nothing here is paraphrased.\n\nRead this after the quiz, not before. Getting a question wrong and then reading why is worth several times more than reading first and nodding.\n\nTwo of the eight questions had nothing to fail to compile — the misread-balance one and the `BigInt` one. Those two are from Course 1, they are diagnoses rather than predictions, and they are here because you are about to write the Rust struct whose bytes you were decoding in JavaScript six lessons ago.\n\n---\n\n## 1 — A `for` loop consumes what it iterates\n\n```rust\npub fn total(vaults: Vec<VaultLike>) -> (u64, usize) {\n    let mut sum = 0u64;\n    for v in vaults {\n        sum += v.balance;\n    }\n    (sum, vaults.len())\n}\n```\n\n```text\nerror[E0382]: borrow of moved value: `vaults`\n   |\n   | pub fn total(vaults: Vec<VaultLike>) -> (u64, usize) {\n   |              ------ move occurs because `vaults` has type `Vec<VaultLike>`,\n   |                     which does not implement the `Copy` trait\n   |     for v in vaults {\n   |              ------ `vaults` moved due to this implicit call to `.into_iter()`\n...\n   |     (sum, vaults.len())\n   |           ^^^^^^ value borrowed here after move\n   |\nnote: `into_iter` takes ownership of the receiver `self`, which moves `vaults`\nhelp: consider iterating over a slice of the `Vec<VaultLike>`'s content to avoid\n      moving into the `for` loop\n   |\n   |     for v in &vaults {\n   |              +\n```\n\n`for x in collection` calls `.into_iter()`, which takes `self`. The loop is not doing anything unusual; it is an ordinary by-value call written with sugar, and the sugar is what hides it. `for v in &vaults` iterates `&VaultLike` instead, which is the fix the compiler hands you and the one you want almost every time.\n\nThe one-character diff is worth internalising because you will write this loop over `remaining_accounts` in Course 3.\n\n---\n\n## 2 — A trailing semicolon changes the type of the function\n\n```rust\npub fn describe(balance: u64) -> &'static str {\n    match balance { 0 => \"empty\", _ => \"funded\" };\n}\n```\n\n```text\nerror[E0308]: mismatched types\n  |\n  | pub fn describe(balance: u64) -> &'static str {\n  |        --------                  ^^^^^^^^^^^^ expected `&str`, found `()`\n  |        |\n  |        implicitly returns `()` as its body has no tail or `return` expression\n  |     match balance { 0 => \"empty\", _ => \"funded\" };\n  |                                                  - help: remove this semicolon\n  |                                                         to return this value\n```\n\n`match` is an expression and produces `&str`. The semicolon throws that value away and turns the line into a statement, so the function body ends with nothing and evaluates to `()`.\n\nNote how precise the diagnostic is — it names the semicolon and offers to delete it. This is the single most common first-week Rust error for anyone arriving from JavaScript, where `return` is mandatory and a stray semicolon is free.\n\n---\n\n## 3 — A balance in the quintillions, from an offset that is 8 bytes early\n\nNo compiler involved. Anchor's layout for the account you decoded in Course 1:\n\n| Offset | Bytes | Field |\n| --- | --- | --- |\n| 0 | 8 | discriminator |\n| 8 | 32 | `owner: Pubkey` |\n| **40** | 8 | `balance: u64`, little-endian |\n| 48 | 1 | `bump: u8` |\n\n49 bytes. `balance` starts at 40, because the discriminator is 8 and a `Pubkey` is 32 — and `8 + 32` is arithmetic you will write literally, as `space = 8 + 32 + 8 + 1`, in Course 3's account constraint. `discriminator(data)` from the last lesson returns the first row of that table.\n\nA read at offset 32 therefore takes the **last eight bytes of the owner's address** and calls them a balance. That is why the symptom is a plausible-looking wrong number rather than a crash: a `Pubkey` is 32 bytes of hash output, so interpreting any eight of them as a little-endian `u64` gives you something in the 10^18 range roughly half the time.\n\nTwo things to take from the shape of that bug. First, an off-by-8 in an account decoder produces *data*, not an error — nothing in the byte array is self-describing, which is the whole reason the discriminator exists and the whole reason lesson 8 makes you write the length check. Second, the two other suspects on the list are both real and both worth ruling out in order: wrong endianness (Borsh is little-endian; `getU64Decoder` already knows that) and `Number` precision above 2^53 − 1 (which is why Kit hands you a `BigInt`, and which question 7 is about). Diagnose offset first, because it is the only one of the three that can be wrong while the other two are right.\n\n---\n\n## 4 — `E0502` runs in both directions\n\n```rust\npub fn stash(v: &mut VaultLike) -> u64 {\n    let slot = &mut v.balance;\n    let total = balance_of(v);\n    *slot = total;\n    total\n}\n```\n\n```text\nerror[E0502]: cannot borrow `*v` as immutable because it is also borrowed as mutable\n   |\n   |     let slot = &mut v.balance;\n   |                -------------- mutable borrow occurs here\n   |     let total = balance_of(v);\n   |                            ^ immutable borrow occurs here\n   |     *slot = total;\n   |     ------------- mutable borrow later used here\n```\n\nIn lesson 7 you read the mirror image of this — *cannot borrow as mutable because it is also borrowed as immutable*. Same rule, reported from whichever side arrived second. Both times the third line named is the one that keeps the first borrow alive.\n\nThe fix is the same as it was: `let total = balance_of(v);` **first**, then take the mutable borrow, or skip it entirely and write `v.balance = total;`.\n\n---\n\n## 5 — Rust does not widen integers for you, and the compiler's suggestion here is wrong for us\n\n```rust\npub fn space(field_count: u32) -> usize {\n    8 + field_count\n}\n```\n\n```text\nerror[E0308]: mismatched types\n   |\n   | pub fn space(field_count: u32) -> usize {\n   |                                   ----- expected `usize` because of return type\n   |     8 + field_count\n   |     ^^^^^^^^^^^^^^^ expected `usize`, found `u32`\n   |\nhelp: you can convert a `u32` to a `usize` and panic if the converted value\n      doesn't fit\n   |\n   |     (8 + field_count).try_into().unwrap()\n   |     +               +++++++++++++++++++++\n```\n\nThree things to take from this.\n\nFirst, the error itself: no implicit numeric coercion, ever, not even the apparently-lossless `u32` → `usize`. The literal `8` infers as `u32` from its neighbour, the sum is a `u32`, and the return type is a `usize`.\n\nSecond: the obvious infallible conversion is not available. `usize::from(field_count)` does not compile — `impl From<u32> for usize` is not in the standard library, and the reason is that `usize` is 16 bits on some targets, so the conversion is not lossless everywhere. (`impl From<u16> for usize` does exist, for exactly that reason.) What `u32` gets is `TryFrom`:\n\n```rust\npub fn space(field_count: u32) -> Option<usize> {\n    match usize::try_from(field_count) {\n        Ok(n) => n.checked_add(8),\n        Err(_) => None,\n    }\n}\n```\n\nThat is the shape lesson 4 taught, applied to a conversion rather than to arithmetic: a fallible operation returns a value that names the failure, and the caller deals with it. Note the return type had to change. That is not a workaround — it is the honest signature.\n\nThird, and most important: **read the suggestion and refuse the second half of it.** `.try_into()` is right; `.unwrap()` is not. `unwrap()` in a program is a panic waiting for the input that triggers it. The compiler does not know it is writing on-chain code. Its diagnostics are excellent and its suggestions are not policy — this course's rule is that `unwrap()` and `expect()` never appear in program code, and module 3 gives you the `Result` machinery that makes obeying it painless.\n\n**And what about `field_count as usize`?** It compiles, it is a widening cast on SBF (a 64-bit target, so `usize` is 8 bytes and nothing can be lost), and lesson 2 still told you not to write it. That rule stands and the carve-out is narrow: `as` is defensible only when you have *pinned the target* and can therefore prove the cast widens. Course 3 compiles for one target and you could argue it there. Here you cannot, because `space` is an ordinary function in a crate that also builds `lib` for the host — and more to the point, `usize::try_from` costs you one `match` and removes the argument entirely. Prefer the conversion that cannot be wrong when the platform changes under you.\n\n---\n\n## 6 — `to_bytes()` hands you an owned array\n\n```rust\npub fn owner_bytes(v: &VaultLike) -> &[u8] {\n    let bytes = v.owner.to_bytes();\n    &bytes\n}\n```\n\n```text\nerror[E0515]: cannot return reference to local variable `bytes`\n   |\n   |     &bytes\n   |     ^^^^^^ returns a reference to data owned by the current function\n```\n\n`Pubkey::to_bytes` returns `[u8; 32]` **by value** — a fresh 32-byte array that this function owns and drops on the way out. Same shape as lesson 7's bug 4, different disguise: nothing here looks like an allocation, and the array is on the stack rather than the heap, but ownership is ownership.\n\nThe fix names the borrow properly: `v.owner.as_ref()` gives you a `&[u8]` view of the `Pubkey` the caller already owns, and lives as long as `v` does. When you find yourself borrowing from a method's return value, check whether that method returned a reference or a value.\n\n---\n\n## 7 — Why Course 1 handed you a `BigInt`\n\n`balance` is a `u64`, so its maximum is 18,446,744,073,709,551,615. JavaScript's `Number` is a double: integers above 2^53 − 1 (9,007,199,254,740,991) stop being exactly representable, and the excess is silently rounded rather than reported. A whale's lamport balance clears 2^53 comfortably.\n\nSo a decoder that returned `Number` would hand you a value that is *nearly* right, which is worse than an error, and that is why Kit's `getU64Decoder` gives you a `BigInt`.\n\nThat constraint is the origin of `u64` in the struct you are about to write. In Rust the width is in the type, `u64 + u64` never silently becomes a float, and the only way to lose a lamport is to let the arithmetic wrap — which is what the next answer is about.\n\n---\n\n## 8 — `-` on a `u64` is not safe, and `overflow-checks` is not the fix\n\n```rust\npub fn withdraw(v: &mut VaultLike, amount: u64) {\n    v.balance = v.balance - amount;\n}\n```\n\nThis compiles. That is the problem.\n\nWith `amount` greater than the balance, `u64` subtraction underflows. What happens next depends on the build profile, which is the worst possible thing for it to depend on:\n\n- With overflow checks **on** — and the build server's release profile does set `overflow-checks = true` — the subtraction panics. In a program a panic aborts the instruction, and the caller gets a failure with no useful message.\n- With overflow checks **off**, `5 - 7` wraps to 18,446,744,073,709,551,614. Your vault now reports a balance of eighteen quintillion lamports, and there is no error anywhere.\n\n`overflow-checks = true` is a safety net for your own testing. It is **not** a substitute for checked arithmetic, because the correct behaviour is not \"panic\" — it is \"return an error the caller can act on\". That is `checked_sub`, which you wrote in lesson 4 as `sub_lamports` returning `Option<u64>`, and which becomes `VaultState::withdraw` returning `Result<()>` with `VaultError::InsufficientFunds` in module 4.\n\nThree lessons from now the `None` arm gets a name. That is the whole arc: `Option` first because it is the smaller idea, `Result` second because it carries a reason, and `unwrap()` never, because it discards both.\n"
+      },
+      {
+        "_key": "explain",
+        "_type": "openEnded",
+        "maxWords": 150,
+        "prompt": "Explain to someone who writes JavaScript, in your own words and without re-reading the lessons, why `fn credit(v: &mut VaultLike, amount: u64)` cannot be called while any other reference to that vault exists — and name one bug the rule prevents that a JavaScript developer would otherwise have to catch in review. Then finish this sentence: \"A lifetime annotation does not change how long anything lives; it tells the compiler ___.\" Writing it out badly is worth more than reading it again — this is not graded, awards no XP, and gates nothing."
+      }
+    ],
+    "skills": [
+      "rust-ownership",
+      "rust-borrowing",
+      "rust-lifetimes",
+      "checked-arithmetic"
+    ],
+    "slug": {
+      "_type": "slug",
+      "current": "ownership-checkpoint"
+    },
+    "title": "Checkpoint: Ownership"
+  },
+  {
+    "_id": "lesson-rpd-structs-traits-and-derives",
+    "_type": "lesson",
+    "blocks": [
+      {
+        "_key": "intro",
+        "_type": "prose",
+        "src": "# Structs, Traits, and What `#[derive]` Really Does\n\n> **Version stamp — checked 2026-07-26.** `anchor-lang 1.1.2` (latest on crates.io, published 2026-06-26) · `borsh 1.8.0` (what the build server's lockfile resolves) · `cargo-build-sbf` with platform-tools v1.54 (rustc 1.89) · edition 2021. Every number in the byte table below was read out of `anchor-derive-space 1.1.2`'s source on that date, and every compiler message quoted was produced by compiling the code in this lesson.\n\nIn lesson 8 you wrote `discriminator(data: &[u8]) -> Option<&[u8]>` — a borrowed view over the first eight bytes of an account. It worked, and you still do not know who put those eight bytes there or what decides they are eight.\n\nThis lesson is that answer. It is also the first file in this course that Course 3 will actually deploy.\n\n## The struct is the layout\n\n```rust\n#[account]\n#[derive(InitSpace)]\npub struct VaultState {\n    pub owner: Pubkey,\n    pub balance: u64,\n    pub bump: u8,\n}\n```\n\nIn JavaScript a `class Vault { owner; balance; bump }` says nothing about memory. Field order is irrelevant, adding a field costs nothing, and there is no such thing as \"how many bytes is a Vault.\"\n\nOn Solana that question has one answer and you have to know it before the account exists, because you pay rent for the bytes and you allocate them once. So a Rust struct is not a bag of names. It is a **layout**: this many bytes, in this order.\n\nBorsh — the serialization format Anchor uses — encodes each field back to back, little-endian, with no padding and no field names on the wire. The sizes, straight out of `anchor-derive-space 1.1.2`:\n\n| Rust type | Bytes |\n| --- | --- |\n| `bool`, `u8`, `i8` | 1 |\n| `u16`, `i16` | 2 |\n| `u32`, `i32`, `f32` | 4 |\n| `u64`, `i64`, `f64` | 8 |\n| `u128`, `i128` | 16 |\n| `Pubkey` | 32 |\n| `[T; N]` | `N` × size of `T` |\n| `Option<T>` | 1 (present/absent tag) + size of `T` |\n| `String` | 4 (length prefix) + `max_len` |\n| `Vec<T>` | 4 (length prefix) + size of `T` × `max_len` |\n\nSo `VaultState` is `32 + 8 + 1 = 41` bytes of data. The account it lives in is **49** bytes, because eight more go in front. Those are lesson 8's eight bytes.\n\nTwo traps in that table, both of which produce wrong-sized accounts in real programs:\n\n- **The length prefix is 4 bytes, not 1, and not zero.** A `String` capped at 16 characters costs `4 + 16 = 20`, not 16. Forgetting the prefix is the classic under-allocation.\n- **`Option<T>` costs the tag even when it is `None`.** Borsh writes a fixed layout; there is no \"absent field\" on the wire.\n\n## A trait is a promise about a type. `impl` is where you keep it\n\nA trait is a named set of function signatures. A type that has those functions \"implements\" the trait.\n\nIf you know TypeScript interfaces, the shape is familiar and one detail is not: **a Rust trait implementation lives outside the type.**\n\n```ts\n// TypeScript: the promise is declared inside the type\nclass Vault implements Serializable {\n  serialize() { /* ... */ }\n}\n```\n\n```rust\n// Rust: the struct is one block, each promise is another\npub struct VaultState { /* fields only */ }\n\nimpl Default for VaultState { /* one promise */ }\nimpl Serializable for VaultState { /* another */ }\n```\n\nThat separation is not cosmetic. It means you can implement a trait for a type long after it was defined, in a different block, and — as long as either the trait or the type is yours — in a different crate entirely. It also means an `impl` block is just *some code that sits next to your struct*.\n\nHold on to that sentence, because it is the whole explanation of `#[derive]`.\n\nTwo kinds of `impl` show up in the exercise, and they are different things:\n\n```rust\nimpl VaultState {              // inherent impl: methods that are just VaultState's own\n    pub fn new(/* ... */) -> Self { /* ... */ }\n}\n\nimpl Default for VaultState {  // trait impl: keeping a promise the language defined\n    fn default() -> Self { /* ... */ }\n}\n```\n\n`VaultState::new` exists because you wrote it and nothing else in the language knows about it. `VaultState::default()` exists because `Default` is a standard trait, which is why generic code — including a lot of Anchor — can call it on any type that implements it without knowing your type at all.\n\n## What `#[derive]` really does\n\n`#[derive(Default)]` is a **macro**. At compile time it reads your struct's fields and writes out an `impl Default for VaultState` block, then hands that block to the compiler along with your file. That is the entire mechanism.\n\nThere is no runtime reflection here. Nothing inspects your struct while the program runs. JavaScript decorators and `Object.keys()` have no equivalent in the compiled binary — by the time your program is bytes on-chain, the macro has already run, the field names are gone, and only the generated code remains.\n\nWhich means the honest way to stop `#[derive]` being magic is to write, once, by hand, the impl it would have generated. That is what the exercise does with `Default`. Afterwards, derive it — you will not learn anything the second time.\n\n## What `#[account]` hands you\n\n`#[account]` is the big one. On `VaultState` it generates:\n\n| What it generates | Why you care |\n| --- | --- |\n| `#[derive(AnchorSerialize, AnchorDeserialize, Clone)]` on your struct | borsh encode/decode, plus `Clone` |\n| `impl AccountSerialize` | `try_serialize` — writes the discriminator, then the fields |\n| `impl AccountDeserialize` | `try_deserialize` — **checks** the discriminator, then reads the fields |\n| `impl Discriminator` | `const DISCRIMINATOR: &'static [u8]` |\n| `impl Owner` | `fn owner() -> Pubkey { crate::ID }` |\n\nThe discriminator is the first eight bytes of `sha256(\"account:VaultState\")`. For this struct that is `[228, 196, 82, 165, 98, 210, 235, 152]`, and you can assert on it at compile time because it is a `const`. Rename the struct and every byte changes.\n\nIts job is type safety across a trust boundary. An account is a bag of bytes; nothing about the bytes says what they are. So `try_deserialize` reads the first eight, compares them against `VaultState::DISCRIMINATOR`, and if they disagree it returns `Err(AccountDiscriminatorMismatch)` **without attempting to decode the rest**. Hand a program somebody else's account and you get a named error, not a garbage `VaultState` with a plausible-looking balance.\n\nOne currency note: in Anchor 1.x `DISCRIMINATOR` is a `&'static [u8]`. Older tutorials treat it as `[u8; 8]` and index or destructure it as an array. That does not compile against 1.1.2.\n\n### `declare_id!` is not decoration\n\nLook at the `Owner` impl again: it returns `crate::ID`. `declare_id!` is what defines `ID`. Delete the `declare_id!` line and the compiler says:\n\n```\nerror[E0425]: cannot find value `ID` in the crate root\n --> src/lib.rs:3:1\n  |\n3 | #[account]\n  | ^^^^^^^^^^ not found in the crate root\n```\n\nRead that carefully, because the arrow points at `#[account]` and the problem is somewhere else entirely. `#[account]` is fine. The program id is missing. This is the single most confusing error in the lesson and it is worth meeting it here, deliberately, rather than in module 4 when you have forty lines of your own code to suspect.\n\nThe id in the starter — `Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS` — is a placeholder. Course 3 replaces it with the id of the program you actually deploy.\n\n## `#[derive(InitSpace)]` and the off-by-eight\n\n`InitSpace` generates `impl Space for VaultState { const INIT_SPACE: usize = 32 + 8 + 1; }` — the arithmetic from the table above, done by the macro, at compile time. `INIT_SPACE` is a `const`, so you can assert on it and the assertion is checked while the file compiles.\n\n**`INIT_SPACE` does not include the discriminator.** It is 41, not 49. Anchor's allocation looks like this:\n\n```rust\nspace = 8 + VaultState::INIT_SPACE\n```\n\nThat `8 +` is on you every single time, and forgetting it is the most common allocation bug in Anchor programs: the account is eight bytes too small, the write runs off the end, and the failure surfaces at serialization time as something that reads nothing like \"you allocated wrong.\"\n\n`InitSpace` also refuses to guess about variable-length fields. Add a `String` with no cap and the build stops:\n\n```\nerror: Expected max_len attribute.\n```\n\nWhich is the correct behaviour — a `String` has no size until you name one, and an account has to have a size.\n\n## What is deliberately not in this file\n\nThere is no `#[program]` and no `#[derive(Accounts)]`. That is not an omission you should fix.\n\nThis course produces `vault_core.rs`: the data model and the arithmetic, compiling on its own. Course 3 is what wraps instruction handlers and account-validation structs around it. Keeping them apart is the reason your file is readable, and it is the reason you can be confident the struct is right before anything is deployed.\n\n## The exercise\n\nThe starter is complete and correct. Build it first, unchanged, and read it.\n\nThen do one experiment, in this order:\n\n1. Add `pub created_at: i64,` to `VaultState`.\n2. Build. The `INIT_SPACE` assertion fails, and the failure names the new number — 41 became 49, and the account went from 49 bytes to 57. The struct *is* the layout, and you just watched the layout move.\n3. Undo it (Reset Code is the fast way) and build again so the file is green.\n\nOne honest note on grading: the build server checks that your file **compiles** against the real Anchor 1.1.2 toolchain. It does not run your code, and nothing here is unit-tested. The compile-time assertions in the file are doing the real verification work, which is exactly why they are written as `const _: () = assert!(...)` rather than as tests.\n"
+      },
+      {
+        "_key": "exercise",
+        "_type": "code",
+        "buildType": "buildable",
+        "deployable": false,
+        "hints": [
+          "The starter is already correct. Build it unchanged before you touch anything — the first build downloads and compiles the Anchor crates, so it is the slow one.",
+          "For the experiment, add `pub created_at: i64,` as the last field of `VaultState` and build. The failure you want is on the `assert!(VaultState::INIT_SPACE == 41)` line: an `i64` is 8 bytes, so 41 became 49 and the account went from 49 bytes to 57.",
+          "To get back to green, click Reset Code and build again. If instead you tried `pub memo: String`, the build stops with `error: Expected max_len attribute.` — `InitSpace` will not guess a size for a variable-length field, and neither can an account."
+        ],
+        "language": "rust",
+        "solution": "// vault_core.rs — the data model, step one.\n//\n// This file is COMPLETE and CORRECT. Build it unchanged first, then read it\n// top to bottom. The experiment at the bottom is the only edit you make.\n\nuse anchor_lang::prelude::*;\n\n// Defines `crate::ID`. `#[account]` below expands to an `Owner` impl that\n// returns `crate::ID`, so deleting this line breaks the struct, not this line.\n// Course 3 replaces this placeholder with your real program id.\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n/// The vault's on-chain state.\n///\n/// `#[account]` generates, at compile time:\n///   - `#[derive(AnchorSerialize, AnchorDeserialize, Clone)]` on the struct\n///   - `impl AccountSerialize`   -> `try_serialize`: writes discriminator, then fields\n///   - `impl AccountDeserialize` -> `try_deserialize`: CHECKS discriminator, then reads\n///   - `impl Discriminator`      -> `const DISCRIMINATOR: &'static [u8]`\n///   - `impl Owner`              -> `fn owner() -> Pubkey { crate::ID }`\n///\n/// `#[derive(InitSpace)]` generates `impl Space`, i.e. `const INIT_SPACE: usize`,\n/// summing the borsh size of every field: 32 + 8 + 1.\n#[account]\n#[derive(InitSpace)]\npub struct VaultState {\n    /// 32 bytes. Who is allowed to withdraw.\n    pub owner: Pubkey,\n    /// 8 bytes, little-endian. Lamports the vault is holding.\n    pub balance: u64,\n    /// 1 byte. The canonical PDA bump, stored so it is never recomputed.\n    pub bump: u8,\n}\n\n// An INHERENT impl. These methods belong to VaultState and to nothing else;\n// no trait, no promise, no generic code can find them.\nimpl VaultState {\n    pub fn new(owner: Pubkey, bump: u8) -> Self {\n        Self {\n            owner,\n            balance: 0,\n            bump,\n        }\n    }\n}\n\n// A TRAIT impl — the one we write by hand so `#[derive]` stops being magic.\n//\n// `#[derive(Default)]` would generate exactly this: every field set to its own\n// type's default. Write it once, read it, then derive it forever after.\nimpl Default for VaultState {\n    fn default() -> Self {\n        Self {\n            owner: Pubkey::default(), // the all-zero pubkey\n            balance: 0,\n            bump: 0,\n        }\n    }\n}\n\n/// The number you hand Anchor's `space =` constraint in Course 3.\n///\n/// `INIT_SPACE` is the FIELDS only. The 8 discriminator bytes are yours to add,\n/// every single time. Getting this wrong under-allocates the account.\npub const VAULT_ACCOUNT_SIZE: usize = 8 + VaultState::INIT_SPACE;\n\n// Compile-time proof, not tests. `INIT_SPACE` and `DISCRIMINATOR` are `const`,\n// so the compiler evaluates these while it compiles the file. Break one and the\n// build fails with the number that is actually true.\nconst _: () = assert!(VaultState::INIT_SPACE == 41);\nconst _: () = assert!(VaultState::DISCRIMINATOR.len() == 8);\nconst _: () = assert!(VAULT_ACCOUNT_SIZE == 49);\n\n/// Uses the derived `AccountSerialize` impl: writes the 8 discriminator bytes,\n/// then borsh-encodes the fields. Returns 49 for any `VaultState`, because a\n/// struct of fixed-width fields has one size.\npub fn encoded_len(state: &VaultState) -> Result<usize> {\n    let mut buf: Vec<u8> = Vec::new();\n    state.try_serialize(&mut buf)?;\n    Ok(buf.len())\n}\n\n// ── THE EXPERIMENT ────────────────────────────────────────────────────────────\n// 1. Add `pub created_at: i64,` to VaultState above.\n// 2. Build. The INIT_SPACE assertion fails and names the new number.\n//    41 became 49; the account went from 49 bytes to 57.\n// 3. Undo it (Reset Code) and build again so the file is green.\n// ─────────────────────────────────────────────────────────────────────────────\n",
+        "starter": "// vault_core.rs — the data model, step one.\n//\n// This file is COMPLETE and CORRECT. Build it unchanged first, then read it\n// top to bottom. The experiment at the bottom is the only edit you make.\n\nuse anchor_lang::prelude::*;\n\n// Defines `crate::ID`. `#[account]` below expands to an `Owner` impl that\n// returns `crate::ID`, so deleting this line breaks the struct, not this line.\n// Course 3 replaces this placeholder with your real program id.\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n/// The vault's on-chain state.\n///\n/// `#[account]` generates, at compile time:\n///   - `#[derive(AnchorSerialize, AnchorDeserialize, Clone)]` on the struct\n///   - `impl AccountSerialize`   -> `try_serialize`: writes discriminator, then fields\n///   - `impl AccountDeserialize` -> `try_deserialize`: CHECKS discriminator, then reads\n///   - `impl Discriminator`      -> `const DISCRIMINATOR: &'static [u8]`\n///   - `impl Owner`              -> `fn owner() -> Pubkey { crate::ID }`\n///\n/// `#[derive(InitSpace)]` generates `impl Space`, i.e. `const INIT_SPACE: usize`,\n/// summing the borsh size of every field: 32 + 8 + 1.\n#[account]\n#[derive(InitSpace)]\npub struct VaultState {\n    /// 32 bytes. Who is allowed to withdraw.\n    pub owner: Pubkey,\n    /// 8 bytes, little-endian. Lamports the vault is holding.\n    pub balance: u64,\n    /// 1 byte. The canonical PDA bump, stored so it is never recomputed.\n    pub bump: u8,\n}\n\n// An INHERENT impl. These methods belong to VaultState and to nothing else;\n// no trait, no promise, no generic code can find them.\nimpl VaultState {\n    pub fn new(owner: Pubkey, bump: u8) -> Self {\n        Self {\n            owner,\n            balance: 0,\n            bump,\n        }\n    }\n}\n\n// A TRAIT impl — the one we write by hand so `#[derive]` stops being magic.\n//\n// `#[derive(Default)]` would generate exactly this: every field set to its own\n// type's default. Write it once, read it, then derive it forever after.\nimpl Default for VaultState {\n    fn default() -> Self {\n        Self {\n            owner: Pubkey::default(), // the all-zero pubkey\n            balance: 0,\n            bump: 0,\n        }\n    }\n}\n\n/// The number you hand Anchor's `space =` constraint in Course 3.\n///\n/// `INIT_SPACE` is the FIELDS only. The 8 discriminator bytes are yours to add,\n/// every single time. Getting this wrong under-allocates the account.\npub const VAULT_ACCOUNT_SIZE: usize = 8 + VaultState::INIT_SPACE;\n\n// Compile-time proof, not tests. `INIT_SPACE` and `DISCRIMINATOR` are `const`,\n// so the compiler evaluates these while it compiles the file. Break one and the\n// build fails with the number that is actually true.\nconst _: () = assert!(VaultState::INIT_SPACE == 41);\nconst _: () = assert!(VaultState::DISCRIMINATOR.len() == 8);\nconst _: () = assert!(VAULT_ACCOUNT_SIZE == 49);\n\n/// Uses the derived `AccountSerialize` impl: writes the 8 discriminator bytes,\n/// then borsh-encodes the fields. Returns 49 for any `VaultState`, because a\n/// struct of fixed-width fields has one size.\npub fn encoded_len(state: &VaultState) -> Result<usize> {\n    let mut buf: Vec<u8> = Vec::new();\n    state.try_serialize(&mut buf)?;\n    Ok(buf.len())\n}\n\n// ── THE EXPERIMENT ────────────────────────────────────────────────────────────\n// 1. Add `pub created_at: i64,` to VaultState above.\n// 2. Build. The INIT_SPACE assertion fails and names the new number.\n//    41 became 49; the account went from 49 bytes to 57.\n// 3. Undo it (Reset Code) and build again so the file is green.\n// ─────────────────────────────────────────────────────────────────────────────\n",
+        "tests": [
+          {
+            "description": "The file compiles against anchor-lang 1.1.2 on the build server",
+            "expectedOutput": "true",
+            "id": "compiles",
+            "input": ""
+          },
+          {
+            "description": "Every `const _: () = assert!(...)` in the file evaluates true at compile time (INIT_SPACE == 41, DISCRIMINATOR.len() == 8, VAULT_ACCOUNT_SIZE == 49) — a false one is a compile error, not a test failure",
+            "expectedOutput": "true",
+            "id": "const-assertions-hold",
+            "input": ""
+          }
+        ]
+      },
+      {
+        "_key": "check",
+        "_type": "quiz",
+        "questions": [
+          {
+            "explanation": "`4 + max_len` for `String`, `4 + size_of(T) * max_len` for `Vec<T>`, `1 + size_of(T)` for `Option<T>`. The prefix is always 4 bytes and the `Option` tag is always 1, present or not.",
+            "id": "q1",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "61 — the 41 you had, plus a 4-byte length prefix, plus 16 bytes of text"
+              },
+              {
+                "correct": false,
+                "feedback": "That drops the length prefix. Borsh writes a `String` as a 4-byte length followed by the UTF-8 bytes, so a 16-character cap costs 20. Under-allocating by exactly 4 bytes is the classic version of this bug.",
+                "id": "b",
+                "label": "57 — the 41 you had plus the 16 characters you capped it at"
+              },
+              {
+                "correct": false,
+                "feedback": "There is no separate account. Borsh inlines the bytes, which is why `#[max_len]` is required — the cap you name is space you allocate.",
+                "id": "c",
+                "label": "45 — the 41 you had plus the 4-byte length prefix; the text lives in a separate account"
+              },
+              {
+                "correct": false,
+                "feedback": "`String` is allowed. What is not allowed is a `String` with no `#[max_len]`, and that failure is `error: Expected max_len attribute.`",
+                "id": "d",
+                "label": "It will not compile — `String` cannot appear in an `#[account]` struct"
+              }
+            ],
+            "prompt": "You add `#[max_len(16)] pub memo: String` as a fourth field of `VaultState` and update the assertion. Predict the new `INIT_SPACE`."
+          },
+          {
+            "explanation": "The arrow points at `#[account]` and the fault is a missing `declare_id!` two lines above. Recognise this one now; in module 4 you will have forty lines of your own code to suspect first.",
+            "id": "q2",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "`error[E0425]: cannot find value ID in the crate root`, with the arrow pointing at `#[account]`"
+              },
+              {
+                "correct": false,
+                "feedback": "`#[account]` expands to `impl Owner { fn owner() -> Pubkey { crate::ID } }`. `crate::ID` has to exist at compile time, and `declare_id!` is what defines it.",
+                "id": "b",
+                "label": "It compiles. `declare_id!` only matters once the program is deployed, and nothing here is deployed yet."
+              },
+              {
+                "correct": false,
+                "feedback": "There is no such check. The macro emits code referencing `crate::ID` and the failure is an ordinary name-resolution error, which is exactly why it reads so badly.",
+                "id": "c",
+                "label": "`error: missing declare_id!` — Anchor detects the omission and names it"
+              },
+              {
+                "correct": false,
+                "feedback": "Missing names are errors, not warnings, and there is no default id to fall back to.",
+                "id": "d",
+                "label": "A warning only, and `VaultState::owner()` returns the all-zero pubkey at runtime"
+              }
+            ],
+            "prompt": "You delete the `declare_id!(...)` line and leave everything else alone. Predict what the compiler says."
+          },
+          {
+            "explanation": "That is the whole point of writing it by hand once. `#[derive]` is a macro that reads your fields and emits an `impl` block — no runtime reflection, nothing you could not have typed yourself.",
+            "id": "q3",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "It compiles, and `VaultState::default()` returns the same values — the macro generates the block you just deleted"
+              },
+              {
+                "correct": false,
+                "feedback": "`#[account]` derives `AnchorSerialize`, `AnchorDeserialize` and `Clone`. `Default` is not on that list, so there is nothing to conflict with.",
+                "id": "b",
+                "label": "It does not compile — `#[account]` already derives `Default`, so this is a conflicting implementation"
+              },
+              {
+                "correct": false,
+                "feedback": "`Pubkey` does implement `Default` — it is the all-zero pubkey, which is precisely what the hand-written block wrote out by name.",
+                "id": "c",
+                "label": "It does not compile — `Pubkey` has no `Default`, so the derive cannot produce a value for `owner`"
+              },
+              {
+                "correct": false,
+                "feedback": "Rust has no uninitialised values in safe code. The derive uses each field type's own `default()`, which for integers is 0.",
+                "id": "d",
+                "label": "It compiles, but `balance` and `bump` are left uninitialised rather than zeroed"
+              }
+            ],
+            "prompt": "You delete the hand-written `impl Default for VaultState` block and add `Default` to the derive list instead: `#[derive(InitSpace, Default)]`. Predict."
+          },
+          {
+            "explanation": "An account is a bag of bytes and nothing about the bytes says what they are. `try_deserialize` compares the first 8 against `VaultState::DISCRIMINATOR` — `sha256(\"account:VaultState\")[..8]`, which for this struct is `[228, 196, 82, 165, 98, 210, 235, 152]` — and stops on disagreement.",
+            "id": "q4",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "It returns `Err(AccountDiscriminatorMismatch)` and never decodes the remaining 41 bytes"
+              },
+              {
+                "correct": false,
+                "feedback": "That is exactly the failure the discriminator exists to prevent. The check happens first, and a mismatch returns before any field is read.",
+                "id": "b",
+                "label": "It decodes anyway and returns a `VaultState` whose fields are whatever those bytes happen to mean"
+              },
+              {
+                "correct": false,
+                "feedback": "It returns a `Result`. Anchor does not panic on untrusted input — that is the entire reason your code returns `Result` too.",
+                "id": "c",
+                "label": "It panics, because a discriminator mismatch is unrecoverable"
+              },
+              {
+                "correct": false,
+                "feedback": "`NotFound` is for a buffer shorter than 8 bytes. Eight bytes that are present and wrong is `Mismatch` — two distinct errors, and telling them apart tells you whether the account is empty or is somebody else's.",
+                "id": "d",
+                "label": "It returns `Err(AccountDiscriminatorNotFound)`, since the bytes it wanted were not there"
+              }
+            ],
+            "prompt": "Carried over from lesson 8. Your `discriminator(data: &[u8])` returned the first 8 bytes as `Option<&[u8]>`. Now a caller hands `VaultState::try_deserialize` a 49-byte buffer whose first 8 bytes are a *different* account type's discriminator. Predict."
+          }
+        ]
+      }
+    ],
+    "skills": [
+      "rust-structs",
+      "rust-traits",
+      "borsh-serialization",
+      "account-layout",
+      "anchor"
+    ],
+    "slug": {
+      "_type": "slug",
+      "current": "structs-traits-and-derives"
+    },
+    "title": "Structs, Traits, and What `#[derive]` Really Does"
+  },
+  {
+    "_id": "lesson-rpd-types-and-mutability",
+    "_type": "lesson",
+    "blocks": [
+      {
+        "_key": "intro",
+        "_type": "prose",
+        "src": "# Types, Mutability, and Why the Compiler Argues\n\n> **Version stamp — checked 2026-07-26.** `anchor-lang` **1.1.2** · Rust **edition 2021** · Agave **≥ 3.1.10**. This lesson's exercise is plain Rust and imports nothing — the arguments you are about to have with the compiler are not Anchor's.\n\nThe compiler is about to reject four things a JavaScript engine would have accepted without comment. All four rejections are about the same disagreement: **JavaScript defers, Rust decides.**\n\nJavaScript has one number type and it decides what to do with your value at run time. Rust has twelve integer types and decides what to do with your value while compiling, which means it has to be told. Being told is what the next twenty minutes are.\n\n## The four widths the vault needs\n\nYou are not going to learn twelve integer types. You need four, and each one is fixed by something outside your control.\n\n| Type | What it holds | Why that width |\n| --- | --- | --- |\n| `u64` | lamports — a balance, a deposit amount, a slot number | The runtime stores lamport balances as unsigned 64-bit integers. This is not a choice you get to make. |\n| `u8` | a PDA bump seed | A bump is one byte, `0..=255`, by construction. The search that finds it walks downward from 255. |\n| `i64` | a UNIX timestamp from the cluster clock | The clock's `unix_timestamp` is **signed**. It is `i64`, not `u64`, so a timestamp field in your struct is `i64` too. |\n| `usize` | an index into a byte slice | The type Rust uses to index collections. On the SBF target it is 8 bytes wide, exactly like `u64` — which is precisely why treating the two as interchangeable is a habit that breaks the day something is not 64-bit. |\n\n`u` is unsigned, `i` is signed, the number is the bit width. `u8` holds `0..=255`; `i64` holds roughly ±9.2 × 10¹⁸.\n\n## The one that will bite you outside of Rust\n\n`u64` holds up to 18 446 744 073 709 551 615. JavaScript's `Number` is an IEEE-754 double, so it represents every integer exactly only up to 2⁵³ − 1, which is 9 007 199 254 740 991 — smaller by a factor of 2¹¹, about two thousand times.\n\nBoth of those are large. The gap between them is not theoretical: it is roughly nine million SOL expressed in lamports, and mainnet holds considerably more than that.\n\nThe failure mode is what makes this worth planting now. JavaScript does not throw when you exceed it. It does not warn. It hands you a nearby number and continues:\n\n```js\nNumber(18_446_744_073_709_551_615n); // → 18446744073709552000\n```\n\nNothing in that line is an error, and nothing downstream can tell that a value was quietly rounded. This is why a Solana client reads `u64` fields as `BigInt`, why an amount arriving over the wire as a JSON number is a bug waiting for a large account, and — the reason it is in *this* lesson — why the balance field you will write in module 4 is a `u64` and stays one.\n\nRust's version of the same class of problem does not get to be silent. That is lesson 4.\n\n## `mut` is not a type, and it appears in two places\n\nEverything in Rust is immutable unless declared otherwise, including local variables. That trips people up in a specific way, because `mut` shows up in two syntactically unrelated positions.\n\n**On a binding** — permission to reassign the variable:\n\n```rust\nlet bump: u8 = 255;\nbump -= 1;          // error[E0384]: cannot assign twice to immutable variable\n\nlet mut bump: u8 = 255;\nbump -= 1;          // fine\n```\n\n**On a reference** — permission to write through it:\n\n```rust\nfn credit(vault: &VaultLike, amount: u64) {\n    vault.balance = amount;   // error[E0594]: cannot assign to `vault.balance`,\n}                             // which is behind a `&` reference\n\nfn credit(vault: &mut VaultLike, amount: u64) {\n    vault.balance = amount;   // fine\n}\n```\n\nNote what the second one is *not*: it is not about `pub`. Making a field public controls who can name it, not who can change it. And it is not about the caller — a caller holding a perfectly mutable value still cannot write through a `&T` you asked for. The function's signature is the contract, and `&T` is a promise not to write.\n\n`&T` and `&mut T` are a much bigger subject than \"add the keyword\" — module 2 is entirely about the rules that make them safe. For now, take the compiler's suggestion and move on.\n\n## Rust converts nothing for you\n\nThis is the rule with the widest reach and the shortest statement: **there are no implicit numeric conversions in Rust.** None. Not even the lossless ones.\n\n```rust\nfn bump_as_u64(bump: u8) -> u64 {\n    bump    // error[E0308]: expected `u64`, found `u8`\n}\n```\n\nEvery `u8` value fits in a `u64` with room to spare. C widens it for you, Java widens it for you, JavaScript does not have the distinction. Rust makes you write it:\n\n```rust\nu64::from(bump)\n```\n\n`From` is the conversion that cannot fail, so it needs no error handling and no decision from you. It exists between exactly those pairs of types where the target can hold every value of the source. `u64::from(u8)`, yes. `u64::from(i64)`, no — negative numbers have nowhere to go.\n\nYou will also see `as`:\n\n```rust\nlet small = big as u8;   // compiles for any integer `big`\n```\n\n`as` always compiles and silently discards whatever does not fit. `300 as u8` is 44. `-1i64 as u64` is 18 446 744 073 709 551 615. That is a wrapping cast wearing the costume of a conversion, and it is a genuinely common source of exploitable arithmetic in on-chain programs. **This course does not use `as` on numbers.** When the conversion cannot fail, `u64::from` says so. When it can, module 3 gives you `TryFrom` and a `Result` to handle.\n\nThe other side of the same rule: when two values need to be compared, do not convert one to match the other by reflex. Ask which width is *correct*. A timestamp is `i64` because the clock says so, so the parameter you compare it against should have been `i64` in the first place.\n\n## Indexing wants `usize`\n\n```rust\nfn byte_at(data: &[u8], index: u64) -> u8 {\n    data[index]   // error[E0277]: the type `[u8]` cannot be indexed by `u64`\n}\n```\n\n`&[u8]` is a **slice** — a borrowed window onto a run of bytes, which is how raw account data arrives. Indexing it requires `usize`, the platform's pointer-sized integer, and that requirement is a trait bound rather than a coercion, which is why the error is `E0277` (a trait is not implemented) rather than `E0308` (mismatched types). Two different error codes for what feels like one mistake; recognising which one you have is worth the ten seconds.\n\nOne warning about the exercise, so it does not surprise you later: `data[index]` **panics** if the index is past the end of the slice, and a panic in a program aborts the transaction with no useful error. That is a real defect, it is deliberate, and lesson 8 replaces it with `data.get(index)` — which returns an `Option` instead of exploding. We are not equipped for `Option` yet. Lesson 4 is where that starts.\n\n## The exercise\n\nThe file ships broken. That is the exercise: four numbered subgoals, the first already done and worth reading, the other three each producing errors you now know how to read.\n\nBelow the marked line there is a block you must not edit. It is a set of bindings that pin every function's name and signature, so that deleting a function you cannot fix is a compile error rather than a way through. It checks **shapes only** — nothing in it can tell a correct body from a plausible wrong one. That limit is real, and lesson 4 is where it partially lifts.\n\nNo `unwrap()`, no `expect()`, no `as`.\n"
+      },
+      {
+        "_key": "exercise",
+        "_type": "code",
+        "buildType": "buildable",
+        "deployable": false,
+        "hints": [
+          "Build it before you change anything. All four subgoals report at once, and the error codes tell you which kind of mistake each one is — E0384 and E0594 are mutability, E0308 is a width, E0277 is indexing.",
+          "Subgoal 2 needs the word `mut` twice, in two different positions: once on the reference in `set_balance`'s parameter (`&mut VaultLike`), once on the `let` binding in `seed_bump`.",
+          "Subgoals 3 and 4 are three separate fixes and only one of them touches a function body. `bump_as_u64` needs `u64::from(bump)`. `is_after` and `byte_at` each need a parameter type changed — to `i64` and to `usize` — and the harness at the bottom of the file already pins both, so it is also the answer key."
+        ],
+        "language": "rust",
+        "solution": "//! Types, mutability, and why the compiler argues — solved.\n\n/// A stand-in for the vault account you write in module 4.\n/// The widths are not decoration — each one is fixed by the runtime.\n///\n/// This stand-in is shaped for THIS lesson: it carries a timestamp so that\n/// `i64` has somewhere to live. It is not the final shape. Lesson 5 drops\n/// `last_deposit_at` and adds `owner: Pubkey`, and module 4's real\n/// `VaultState` is `{ owner, balance, bump }`. Only `balance` and `bump`\n/// survive all the way through.\npub struct VaultLike {\n    /// Lamports. The runtime stores balances as u64, so you do too.\n    pub balance: u64,\n    /// A PDA bump seed. One byte, 0..=255.\n    pub bump: u8,\n    /// A UNIX timestamp from the cluster clock. Signed, 64-bit.\n    pub last_deposit_at: i64,\n}\n\n// ── Subgoal 1 of 4 ──────────────────────────────────────────────────────\n\npub const LAMPORTS_PER_SOL: u64 = 1_000_000_000;\n\npub fn one_sol() -> u64 {\n    LAMPORTS_PER_SOL\n}\n\n// ── Subgoal 2 of 4 — `mut` on the reference, `mut` on the binding ───────\n\npub fn set_balance(vault: &mut VaultLike, lamports: u64) {\n    vault.balance = lamports;\n}\n\npub fn seed_bump() -> u8 {\n    let mut bump: u8 = 255;\n    bump -= 1;\n    bump -= 1;\n    bump\n}\n\n// ── Subgoal 3 of 4 — one explicit conversion, one corrected width ───────\n\npub fn bump_as_u64(bump: u8) -> u64 {\n    u64::from(bump)\n}\n\npub fn is_after(now: i64, last_deposit_at: i64) -> bool {\n    now > last_deposit_at\n}\n\n// ── Subgoal 4 of 4 — slices are indexed by `usize` ──────────────────────\n\npub fn byte_at(data: &[u8], index: usize) -> u8 {\n    data[index]\n}\n\n// ════════════════════════════════════════════════════════════════════════\n// DO NOT EDIT BELOW THIS LINE\n//\n// The grader compiles this file and nothing more. These bindings exist so\n// that a missing item, or one with the wrong type, is a compile error\n// instead of a silent pass. They check shapes, not behaviour — nothing\n// here can tell a correct body from a plausible wrong one.\n// ════════════════════════════════════════════════════════════════════════\n\nconst _: u64 = LAMPORTS_PER_SOL;\nconst _: fn() -> u64 = one_sol;\nconst _: fn(&mut VaultLike, u64) = set_balance;\nconst _: fn() -> u8 = seed_bump;\nconst _: fn(u8) -> u64 = bump_as_u64;\nconst _: fn(i64, i64) -> bool = is_after;\nconst _: fn(&[u8], usize) -> u8 = byte_at;\n\n#[allow(dead_code)]\nfn verify_vault_fields(v: &VaultLike) -> (u64, u8, i64) {\n    (v.balance, v.bump, v.last_deposit_at)\n}\n",
+        "starter": "//! Types, mutability, and why the compiler argues.\n//!\n//! Four subgoals, in order. Subgoal 1 is already done — read it first.\n//! Subgoals 2, 3 and 4 do not compile as they ship. That is the exercise.\n//!\n//! Build it now, before changing anything. `rustc` reports every\n//! independent error in one pass, so the first build hands you the whole\n//! to-do list at once.\n//!\n//! Rules: no `unwrap()`, no `expect()`, no `as` casts.\n\n/// A stand-in for the vault account you write in module 4.\n/// The widths are not decoration — each one is fixed by the runtime.\n///\n/// This stand-in is shaped for THIS lesson: it carries a timestamp so that\n/// `i64` has somewhere to live. It is not the final shape. Lesson 5 drops\n/// `last_deposit_at` and adds `owner: Pubkey`, and module 4's real\n/// `VaultState` is `{ owner, balance, bump }`. Only `balance` and `bump`\n/// survive all the way through.\npub struct VaultLike {\n    /// Lamports. The runtime stores balances as u64, so you do too.\n    pub balance: u64,\n    /// A PDA bump seed. One byte, 0..=255.\n    pub bump: u8,\n    /// A UNIX timestamp from the cluster clock. Signed, 64-bit.\n    pub last_deposit_at: i64,\n}\n\n// ── Subgoal 1 of 4 — DONE. Read it. ─────────────────────────────────────\n// One SOL is 1_000_000_000 lamports. Declared as a `u64` constant, with\n// underscores as digit separators — the compiler ignores them and your\n// eyes do not. Note that the type is written out: a `const` never infers.\n\npub const LAMPORTS_PER_SOL: u64 = 1_000_000_000;\n\npub fn one_sol() -> u64 {\n    LAMPORTS_PER_SOL\n}\n\n// ── Subgoal 2 of 4 — `mut`, in both of the places it appears ────────────\n// `set_balance` writes through a reference. `seed_bump` reassigns a local,\n// walking downward from 255 the way Anchor's bump search does. Neither is\n// currently allowed to write to what it has. Fix both.\n//\n// (255 - 1 - 1 cannot underflow, so plain subtraction is safe here.\n//  Lesson 4 is about the case where you cannot know that in advance.)\n\npub fn set_balance(vault: &VaultLike, lamports: u64) {\n    vault.balance = lamports;\n}\n\npub fn seed_bump() -> u8 {\n    let bump: u8 = 255;\n    bump -= 1;\n    bump -= 1;\n    bump\n}\n\n// ── Subgoal 3 of 4 — widths do not convert themselves ───────────────────\n// Rust performs no implicit numeric conversion, not even the lossless\n// widening ones C and Java do silently.\n//\n// In `bump_as_u64`, make the conversion explicit — it cannot fail, so\n// `From` is the right tool and no error handling is needed.\n//\n// In `is_after`, do NOT convert. Ask which width is correct: the cluster\n// clock hands out `i64`, and `VaultLike::last_deposit_at` above is `i64`\n// for that reason. Fix the parameter, not the comparison.\n\npub fn bump_as_u64(bump: u8) -> u64 {\n    bump\n}\n\npub fn is_after(now: i64, last_deposit_at: u64) -> bool {\n    now > last_deposit_at\n}\n\n// ── Subgoal 4 of 4 — you index with `usize` ─────────────────────────────\n// Anchor puts an 8-byte discriminator at the front of every account, so\n// reading one byte out of raw account data is an everyday operation.\n// Slices are indexed by `usize`, and that is a trait bound rather than a\n// conversion — which is why the error code is E0277, not E0308.\n//\n// (`data[index]` panics if `index` is past the end. That is a real defect\n//  and it is deliberate; lesson 8 replaces it with `data.get(index)`.)\n\npub fn byte_at(data: &[u8], index: u64) -> u8 {\n    data[index]\n}\n\n// ════════════════════════════════════════════════════════════════════════\n// DO NOT EDIT BELOW THIS LINE\n//\n// The grader compiles this file and nothing more. These bindings exist so\n// that a missing item, or one with the wrong type, is a compile error\n// instead of a silent pass. They check shapes, not behaviour — nothing\n// here can tell a correct body from a plausible wrong one.\n// ════════════════════════════════════════════════════════════════════════\n\nconst _: u64 = LAMPORTS_PER_SOL;\nconst _: fn() -> u64 = one_sol;\nconst _: fn(&mut VaultLike, u64) = set_balance;\nconst _: fn() -> u8 = seed_bump;\nconst _: fn(u8) -> u64 = bump_as_u64;\nconst _: fn(i64, i64) -> bool = is_after;\nconst _: fn(&[u8], usize) -> u8 = byte_at;\n\n#[allow(dead_code)]\nfn verify_vault_fields(v: &VaultLike) -> (u64, u8, i64) {\n    (v.balance, v.bump, v.last_deposit_at)\n}\n",
+        "tests": [
+          {
+            "description": "Program compiles successfully",
+            "expectedOutput": "true",
+            "id": "test-1",
+            "input": ""
+          },
+          {
+            "description": "Every subgoal's function still exists with the signature the verification harness pins",
+            "expectedOutput": "true",
+            "id": "test-2",
+            "input": ""
+          },
+          {
+            "description": "VaultLike still declares balance: u64, bump: u8 and last_deposit_at: i64",
+            "expectedOutput": "true",
+            "id": "test-3",
+            "input": ""
+          }
+        ]
+      },
+      {
+        "_key": "check",
+        "_type": "quiz",
+        "questions": [
+          {
+            "id": "q1",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "`error[E0308]: mismatched types` — expected `u64`, found `u8`. Rust performs no implicit numeric conversion at all, lossless included."
+              },
+              {
+                "correct": false,
+                "feedback": "That is the C and Java rule, and it is the reason this is the most frequently mispredicted line in the lesson. Rust has no implicit numeric conversions in either direction. Write `u64::from(bump)`.",
+                "id": "b",
+                "label": "It compiles. Widening conversions are implicit because they cannot lose information."
+              },
+              {
+                "correct": false,
+                "feedback": "A type mismatch is never a warning in Rust — the compiler has no type to proceed with. You do get a `help:` block containing the fix, but it is attached to an error.",
+                "id": "c",
+                "label": "It compiles with a warning suggesting an explicit conversion."
+              },
+              {
+                "correct": false,
+                "feedback": "E0605 is for `as` between types where it makes no sense. Both of these are primitive integers, so `as` would compile — it is just the wrong tool, because `as` silently truncates when the widths go the other way.",
+                "id": "d",
+                "label": "`error[E0605]: non-primitive cast`, because the conversion needs `as`."
+              }
+            ],
+            "prompt": "Predict the outcome. `pub fn bump_as_u64(bump: u8) -> u64 { bump }` — and note that every possible `u8` value fits in a `u64`."
+          },
+          {
+            "id": "q2",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "All four, in one pass, each with its own code and span — `rustc` does not stop at the first."
+              },
+              {
+                "correct": false,
+                "feedback": "That is a runtime's behaviour, not a compiler's. `rustc` finishes the pass and reports every independent error, which is why the first build of a broken file is a complete to-do list.",
+                "id": "b",
+                "label": "The first one only. Compilation halts at the first error, as a JS runtime halts at the first exception."
+              },
+              {
+                "correct": false,
+                "feedback": "Cascades happen, but from a mistake that leaves the compiler guessing at a *type* other code depends on. Four independent mistakes in four independent functions produce four errors. When you do see a cascade, fix the first error and rebuild.",
+                "id": "c",
+                "label": "Four errors plus a cascade of dozens more, because each mistake poisons everything after it."
+              },
+              {
+                "correct": false,
+                "feedback": "Severity is a property of the diagnostic, not of its position. Four type errors are four errors.",
+                "id": "d",
+                "label": "One error, and three warnings, since only the first is fatal."
+              }
+            ],
+            "prompt": "Carried over from lesson 1. Your file has four unrelated mistakes in four different functions. Predict what one build gives you."
+          },
+          {
+            "id": "q3",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "`error[E0594]` — cannot assign to `vault.balance`, which is behind a shared reference. The parameter type is a promise not to write, and neither `pub` nor the caller's ownership overrides it."
+              },
+              {
+                "correct": false,
+                "feedback": "`pub` controls who can *name* the field. Whether it can be written through a particular reference is decided by that reference's type. They are orthogonal, and conflating them is the most common version of this mistake.",
+                "id": "b",
+                "label": "It compiles, because the field is `pub` and therefore writable from anywhere it is visible."
+              },
+              {
+                "correct": false,
+                "feedback": "The signature is the contract. A caller with a perfectly mutable value that hands out `&T` has handed out read-only access, and the function cannot widen it.",
+                "id": "c",
+                "label": "It compiles, because the caller owns a mutable value and mutability is a property of the value, not the reference."
+              },
+              {
+                "correct": false,
+                "feedback": "E0384 is the *binding* case — reassigning a `let` without `mut`. This is the *reference* case, E0594. Both are fixed by the word `mut`, in two different positions, and telling them apart tells you which position.",
+                "id": "d",
+                "label": "`error[E0384]: cannot assign twice to immutable variable`."
+              }
+            ],
+            "prompt": "Predict the outcome. `pub fn set_balance(vault: &VaultLike, lamports: u64) { vault.balance = lamports; }` — where `balance` is declared `pub`, and the caller passes a value it owns and can freely modify."
+          },
+          {
+            "id": "q4",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "18446744073709552000 — a nearby number, silently. No error, no warning, and nothing downstream can tell it was rounded."
+              },
+              {
+                "correct": false,
+                "feedback": "`Number.MAX_SAFE_INTEGER` is documentation, not a guard. Exceeding it is not an error condition in JavaScript — you get the nearest representable double and execution continues. That silence is the whole problem.",
+                "id": "b",
+                "label": "A `RangeError`, because the value exceeds `Number.MAX_SAFE_INTEGER`."
+              },
+              {
+                "correct": false,
+                "feedback": "A double reaches about 1.8 × 10³⁰⁸. This value is nowhere near overflowing it. The loss is *precision*, not magnitude, which is exactly why it is hard to notice.",
+                "id": "c",
+                "label": "`Infinity`, since the value overflows the double."
+              },
+              {
+                "correct": false,
+                "feedback": "Both are 64 bits, but a double spends 11 of them on an exponent and one on a sign, leaving 53 bits of integer precision. Every integer above 2^53 - 1 is representable only approximately, which is why Solana clients read `u64` fields as `BigInt`.",
+                "id": "d",
+                "label": "The exact value. `Number` is 64-bit, and so is `u64`."
+              }
+            ],
+            "prompt": "A vault account holds 18_446_744_073_709_551_615 lamports, the largest value a `u64` can hold. Your TypeScript client reads the raw field and does `Number(raw)`. Predict what you get."
+          }
+        ]
+      }
+    ],
+    "skills": [
+      "rust",
+      "rust-types"
+    ],
+    "slug": {
+      "_type": "slug",
+      "current": "types-and-mutability"
+    },
+    "title": "Types, Mutability, and Why the Compiler Argues"
+  },
+  {
+    "_id": "lesson-rpd-what-you-built",
+    "_type": "lesson",
+    "blocks": [
+      {
+        "_key": "reread",
+        "_type": "prose",
+        "src": "# What You Built\n\n> **Version stamp — checked 2026-07-26.** `anchor-lang 1.1.2` · `borsh 1.8.0` (resolved) · edition 2021 · Agave ≥ 3.1.10. No new code in this lesson; every claim below was compiled against that toolchain on that date.\n\nOpen your file from the last exercise. Not the reference below — yours. Read it once, top to bottom, before you read anything else on this page.\n\nHere is the reference version, so you can check yours item for item:\n\n```rust\nuse anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\npub mod vault {\n    use super::*;\n\n    #[account]\n    #[derive(InitSpace)]\n    pub struct VaultState {\n        pub owner: Pubkey,\n        pub balance: u64,\n        pub bump: u8,\n    }\n\n    #[error_code]\n    pub enum VaultError {\n        #[msg(\"Deposit would overflow the vault balance\")]\n        Overflow,\n        #[msg(\"Withdrawal is larger than the vault balance\")]\n        InsufficientFunds,\n        #[msg(\"Amount must be greater than zero\")]\n        ZeroAmount,\n        #[msg(\"Signer is not the vault owner\")]\n        NotOwner,\n    }\n\n    impl VaultState {\n        pub fn deposit(&mut self, amount: u64) -> Result<()> {\n            require!(amount > 0, VaultError::ZeroAmount);\n            self.balance = self\n                .balance\n                .checked_add(amount)\n                .ok_or(VaultError::Overflow)?;\n            Ok(())\n        }\n\n        pub fn withdraw(&mut self, amount: u64) -> Result<()> {\n            require!(amount > 0, VaultError::ZeroAmount);\n            self.balance = self\n                .balance\n                .checked_sub(amount)\n                .ok_or(VaultError::InsufficientFunds)?;\n            Ok(())\n        }\n    }\n}\n\npub use vault::{VaultError, VaultState};\n```\n\nForty-odd lines. Thirteen lessons. Every line came from somewhere specific, and being able to say where is the difference between having finished a course and being able to write the next file without one.\n\n## Line by line\n\n| Line                                        | What it actually is                                                                                                                                                                                                    | Where you got it                                    |\n| ------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |\n| `use anchor_lang::prelude::*;`              | One glob import supplies `Pubkey`, `Result`, `require!`, `msg!`. Anchor re-exports the Solana crates, which is why you never named a `solana-*` dependency.                                                              | L1 · Your First Rust Build                          |\n| `declare_id!(\"Fg6Pa…\")`                     | Not decoration. `#[account]` expands to an `impl Owner` whose body reads `crate::ID`. Delete the macro and the error appears at your struct: `cannot find value ID in the crate root`.                                   | L1, and paid for at L10                             |\n| `pub mod vault { use super::*; }`            | A module is a namespace, not a file. `use super::*` is what makes the crate root's imports visible inside the module body.                                                                                              | L13 · Build the Vault Core                          |\n| `#[account]`                                | A macro that writes trait impls you would otherwise hand-write: `AnchorSerialize`, `AnchorDeserialize`, `Discriminator`, `Owner`. The discriminator is the 8 bytes your Course 1 decoder sliced off before reading `owner`. | L10 · Structs, Traits, and What `#[derive]` Really Does |\n| `#[derive(InitSpace)]`                      | Generates the associated const `VaultState::INIT_SPACE`. Here it is **41**: 32 + 8 + 1. Course 3 spends it as `space = 8 + VaultState::INIT_SPACE`.                                                                      | L10                                                 |\n| `pub owner: Pubkey`                         | 32 bytes. The same 32 bytes you read with `getAddressDecoder()` in Course 1, now on the writing side.                                                                                                                    | L2 · C1 L2                                          |\n| `pub balance: u64`                          | Lamports stop being exact in a JavaScript `Number` above 2⁵³. This is the type for which that is not a question.                                                                                                        | L2 · Types, Mutability, and Why the Compiler Argues |\n| `pub bump: u8`                              | One byte, and a *stored* bump rather than a recomputed one. It is the value the derivation in Course 1 found by counting down from 255 until the result fell off the curve.                                               | L2 · C1 L3                                          |\n| `#[error_code]`                             | Turns a plain enum into program errors: attaches the `#[msg]` strings and generates the conversion into `anchor_lang::error::Error`, offsetting the codes by `ERROR_CODE_OFFSET` = 6000. Exactly one of these per program. | L11 · Enums, `Option`, and `Result`                 |\n| the four variants                           | On the wire: `Overflow` = 6000, `InsufficientFunds` = 6001, `ZeroAmount` = 6002, `NotOwner` = 6003. Custom errors start at 6000 so they cannot collide with Anchor's own.                                                | L11                                                 |\n| `impl VaultState`                           | A method is just a function whose first parameter is a form of `self`.                                                                                                                                                  | L10                                                 |\n| `&mut self`                                 | One mutable borrow, and no shared borrows alongside it — the same shape as one writable account at a time. `self` by value would consume the account.                                                                    | L6 · Borrowing, L5 · Moves                          |\n| `-> Result<()>`                             | Anchor's alias for `Result<(), anchor_lang::error::Error>`. The reason the function can fail without panicking.                                                                                                          | L12 · Error Plumbing with `?`                       |\n| `require!(amount > 0, …)`                    | Guard first, mutate second. It expands to an early `return Err(...)`, which is why it reads like an assertion and behaves like a branch.                                                                                | L12                                                 |\n| `.checked_add(…)` / `.checked_sub(…)`        | Returns `Option<u64>` — `None` instead of wrapping or panicking. This is lesson 4's `add_lamports` / `sub_lamports`, moved onto a method.                                                                                | L4 · Checked Lamport Math                           |\n| `.ok_or(VaultError::Overflow)?`             | `ok_or` converts `Option` into `Result`; `?` either unwraps the `Ok` or returns early, applying the `From` conversion `#[error_code]` generated. Two lessons meeting inside one expression.                              | L11 (`Option`) + L12 (`?`)                          |\n| `Ok(())`                                    | A tail expression: no `return`, no semicolon. Add the semicolon and the body evaluates to `()`, and the error is `mismatched types`.                                                                                     | L3 · Functions, Expressions, and the Missing `return` |\n| `pub use vault::{VaultError, VaultState};`   | A re-export. Without it the items exist and nothing outside the module can name them.                                                                                                                                   | L13                                                 |\n\n## Three absences, which are also the point\n\n**`.clone()` appears zero times.** Lesson 5 was explicit that cloning is a legitimate escape hatch and not a moral failing. It is also true that in a `&mut self` method you never reach for it, because you never moved anything: you borrowed the account, wrote through the borrow, and gave it back.\n\n**`unwrap()` appears zero times.** Every tutorial you will read on the way to your first real program uses it. In a program, a panic is an aborted instruction with no code and no message — the caller learns that something failed and nothing else. Your file returns 6001 with the string \"Withdrawal is larger than the vault balance\". That difference is the whole of lessons 4, 11 and 12.\n\n**Lifetimes appear zero times**, and lesson 8 was not wasted on you. `VaultState` owns all three of its fields — a `Pubkey`, a `u64` and a `u8` are all owned values — so nothing in the struct borrows and there is no lifetime to name. What lesson 8 bought you is the *next* file: `Account<'info, VaultState>` in Course 3 is a borrowed view over these bytes, and `'info` is the same annotation you wrote by hand on `discriminator(data: &'a [u8]) -> Option<&'a [u8]>`. Graduates who skip lifetimes read `Account<'info, Vault>` as noise for years. Question 6 below is that payoff, asked before you meet it.\n\n## Copy the file out. Now.\n\nSay this plainly, because the platform does not: **no block type on this platform persists your source file.** The build server graded a submission; it did not keep a copy you can come back to. Select everything in the editor, save it locally as `vault_core.rs`, and put it somewhere you will find it next week.\n\nIf you lose it, Course 3's first lesson ships a known-good reference copy — the file above — so nothing dead-ends. But it will be *a* vault core, not yours, and the first thing Course 3 does is replace that placeholder in `declare_id!` with the program id of your own deployment.\n"
+      },
+      {
+        "_key": "handoff",
+        "_type": "prose",
+        "src": "## What Course 3 adds, and why none of it is in your file\n\nYour file has no `#[program]` module and no `#[derive(Accounts)]` struct. Read it cold and it looks like a program someone abandoned two-thirds of the way in. It is not. It is the two-thirds you can check by reading, deliberately separated from the third you cannot.\n\n| Course 3 adds                                                                                                                                       | Why it is not here                                                                                                                                                       |\n| --------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |\n| `#[program] pub mod vault_program { … }` with `deposit` and `withdraw` **instruction handlers**                                                       | A handler is an entrypoint. An entrypoint needs a deployed program id and a real account list, and its body is two lines: validate, then call the method you already wrote. |\n| `#[derive(Accounts)] pub struct Deposit<'info>` with `#[account(mut, seeds = [b\"vault\", owner.key().as_ref()], bump = vault.bump)]`                     | Constraints validate *accounts*. Nothing in your file is an account — that is precisely why it can be reasoned about without a runtime. This is also where your stored `bump` field gets spent, and where `NotOwner` is finally returned. |\n| `init` with `space = 8 + VaultState::INIT_SPACE` — 49 bytes, and the rent-exemption number that follows from it                                        | Space and rent are properties of an account, not of a struct. Your struct only had to know its own size, and `#[derive(InitSpace)]` is how it knows.                       |\n| A CPI to the System Program to move the actual lamports: `CpiContext::new(System::id(), Transfer { … })`                                              | Your `balance` field is bookkeeping. The lamports move in a separate call, and keeping the two apart is what lets a test check the arithmetic without a runtime.            |\n| **LiteSVM tests that call `withdraw` and assert on the number that comes back**                                                                       | This is the one that matters. It is what catches a `checked_add` you meant to be `checked_sub` — the exact failure the build server cannot see, and the reason Course 2's grading stops at \"it compiles\". |\n| A deploy, after which `declare_id!` stops being a placeholder and your program has an address on devnet                                              | You had nothing to deploy. You had something to be correct.                                                                                                               |\n\nOne currency note for when you start reading Course 3's material against the rest of the internet: **`CpiContext::new(System::id(), …)` is the current shape.** Every CPI tutorial written before Anchor 1.0 passes an account info instead — `CpiContext::new(ctx.accounts.system_program.to_account_info(), …)` — and it does not compile against the toolchain you have been building on. It is the single most common stale snippet in Solana material, and now you know why your copy-paste failed.\n\n### Why the split is the right shape, not a teaching convenience\n\nLook at what your file does *not* depend on: no accounts, no signers, no clock, no CPI, no runtime of any kind. That is what makes it the part a reviewer reads first and the part a test can exercise in microseconds. Real audit findings cluster at the seam between the two halves — a handler that forgets to compare `vault.owner` to the signer, a constraint that validates the wrong account — and you cannot see a seam until the two sides of it are separate things.\n\nIt also means Course 3 is enterable on its own. Anyone arriving without this course gets the reference `vault_core.rs`, because a course whose first lesson requires a file you do not have is a dead end, not a prerequisite. You are arriving with your own version, which is a better place to start from.\n\n### What you can say you can do\n\nNot \"you can now write Solana programs\" — you cannot yet, and one more course is why. What you can say is narrower and true: **you can model on-chain state in Rust, make its invariants unbreakable by construction, and return named errors instead of panicking.** That is the part of program development that no framework does for you.\n"
+      },
+      {
+        "_key": "recall",
+        "_type": "quiz",
+        "questions": [
+          {
+            "id": "q1",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "Red — `assert!(VaultState::INIT_SPACE == 41)` fails, because `InitSpace` now computes 48."
+              },
+              {
+                "correct": false,
+                "feedback": "It is an associated const generated by the derive and evaluated at compile time. That is exactly why a `const _: () = assert!(...)` can check it at all.",
+                "id": "b",
+                "label": "Green — `INIT_SPACE` is computed when the account is created, so a compile-time assertion cannot read it."
+              },
+              {
+                "correct": false,
+                "feedback": "It plainly is: `balance` is one. The problem is the size, not the legality.",
+                "id": "c",
+                "label": "Red — `u64` is not a legal field type for an Anchor account."
+              },
+              {
+                "correct": false,
+                "feedback": "`space` is computed from the same const, so it grows with the struct. Under-allocation is what happens when you hardcode the number instead of deriving it.",
+                "id": "d",
+                "label": "Green, but Course 3's `space = 8 + VaultState::INIT_SPACE` would then under-allocate the account."
+              }
+            ],
+            "prompt": "You change `pub bump: u8` to `pub bump: u64` and rebuild against the verification harness. Predict what happens."
+          },
+          {
+            "explanation": "`#[error_code]` generates four things: `name()`, `From<VaultError> for u32`, `From<VaultError> for Error`, and `Display` from your `#[msg]` strings. `?` uses the third. `error!(…)` uses the first, second and fourth — it builds an `AnchorError` out of them and never touches the `Error` impl at all. Two paths to the same wire format, and lesson 11 made you tell them apart.",
+            "id": "q2",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "`impl From<VaultError> for anchor_lang::error::Error`. `ok_or` builds `Result<u64, VaultError>`; `?` either yields the `Ok` value or returns early through that conversion. The caller sees code 6000."
+              },
+              {
+                "correct": false,
+                "feedback": "That impl exists — it is `variant as u32 + 6000` — but `?` is typed, not numeric: it needs `From<VaultError>` for the function's declared error type, which is `anchor_lang::error::Error`. The `u32` conversion is what the `Error` impl calls *inside* itself.",
+                "id": "b",
+                "label": "`impl From<VaultError> for u32`, the other impl `#[error_code]` generates. `?` converts to the numeric code and the runtime wraps it into an error on the way out."
+              },
+              {
+                "correct": false,
+                "feedback": "There is no `error!` in this line. `ok_or(VaultError::Overflow)` hands `?` a bare `VaultError`, which is exactly why the conversion has to exist — delete that impl and this line stops compiling with `E0277`.",
+                "id": "c",
+                "label": "No `From` impl is involved: `error!` already produced an `Error`, so `?` has nothing to convert."
+              },
+              {
+                "correct": false,
+                "feedback": "Right impl, wrong operator. `.unwrap()` panics; `?` returns. That is the entire difference, and it is why one of them is banned in program code and the other is the idiom.",
+                "id": "d",
+                "label": "`impl From<VaultError> for Error`, and `?` is shorthand for `.unwrap()` on the `Result` it produces."
+              }
+            ],
+            "prompt": "In `self.balance = self.balance.checked_add(amount).ok_or(VaultError::Overflow)?;` — `?` converts the error by calling `From::from`. Name the generated impl it lands on, and what reaches the caller."
+          },
+          {
+            "id": "q3",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "Red at the harness — it binds `withdraw` to `fn(&mut VaultState, u64) -> Result<()>` and the method is now `fn(VaultState, u64) -> Result<()>`."
+              },
+              {
+                "correct": false,
+                "feedback": "Both let you write, but they differ in whether the caller still owns the value afterwards. `mut self` consumes it. That difference is visible in the type, and the harness reads types.",
+                "id": "b",
+                "label": "Green — `mut self` and `&mut self` differ only in style; both mutate in place."
+              },
+              {
+                "correct": false,
+                "feedback": "It can; `fn into_parts(self)` is an everyday Rust idiom. Taking `self` by value is wrong *here*, not illegal.",
+                "id": "c",
+                "label": "Red — a method cannot take `self` by value in an `impl` block."
+              },
+              {
+                "correct": false,
+                "feedback": "Anchor hands you `Account<'info, VaultState>` and you reach the data through a mutable deref. A method that consumes `self` cannot be called through a borrow.",
+                "id": "d",
+                "label": "Green, and Course 3 would still work, because Anchor hands instruction handlers their accounts by value."
+              }
+            ],
+            "prompt": "You change `pub fn withdraw(&mut self, amount: u64)` to `pub fn withdraw(mut self, amount: u64)`. Both let you write to the fields. Predict what the build reports."
+          },
+          {
+            "id": "q4",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "The Anchor discriminator — 8 bytes derived from the account type's name, written at offset 0 and skipped before decoding. They are the first 8 bytes your Course 1 decoder sliced off before reading `owner`."
+              },
+              {
+                "correct": false,
+                "feedback": "Lamports live in the account's metadata, not in `data`. Your Course 1 decoder read them from a different field of the RPC response and never out of the byte array.",
+                "id": "b",
+                "label": "The account's `lamports` balance, stored inline ahead of the struct data."
+              },
+              {
+                "correct": false,
+                "feedback": "Borsh's length prefix is 4 bytes and only appears on variable-length types. A fixed-size struct carries no prefix at all.",
+                "id": "c",
+                "label": "An 8-byte length prefix for the struct, the way borsh prefixes a `Vec` or a `String`."
+              },
+              {
+                "correct": false,
+                "feedback": "The bump is one byte and it is inside the 41. Anchor adds no padding — the layout is the fields, back to back, after the discriminator.",
+                "id": "d",
+                "label": "Reserved space for the bump plus padding to an 8-byte boundary."
+              }
+            ],
+            "prompt": "Carried over from Course 1. `VaultState::INIT_SPACE` is 41 and Course 3 allocates `8 + 41 = 49` bytes. What are the 8, and where have you met them before?"
+          },
+          {
+            "id": "q5",
+            "multiSelect": true,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "The bump is the value the derivation counted down from 255 until the resulting address fell off the ed25519 curve."
+              },
+              {
+                "correct": true,
+                "id": "b",
+                "label": "Storing it lets a later instruction validate the PDA without re-running that search, which costs compute every time."
+              },
+              {
+                "correct": false,
+                "feedback": "A mock SDK in this platform's own history hardcoded 254, and that was the bug. The canonical bump is whatever the search found for those particular seeds — usually 255, often not.",
+                "id": "c",
+                "label": "It is 254 in practice, so a program can safely hardcode it."
+              },
+              {
+                "correct": false,
+                "feedback": "Hashing is order-sensitive. Reorder the seeds and you get a different address — you proved that to yourself in Course 1 by deriving it both ways.",
+                "id": "d",
+                "label": "Putting the bump in a different seed position gives the same address, since the seeds are all hashed together anyway."
+              }
+            ],
+            "prompt": "Also from Course 1. Your struct stores `bump: u8`. Which of these are true?"
+          },
+          {
+            "explanation": "Same rule as `discriminator(data: &'a [u8]) -> Option<&'a [u8]>` in lesson 8, one layer up. `VaultState` owns all three of its fields, so your file needed no annotation at all — but every account type you touch in Course 3 is a borrowed view, and `'info` is the name of the borrow.",
+            "id": "q6",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "It is rejected, and the annotation is the mechanism: `'info` names how long the borrowed account data is valid, and a struct outliving it cannot hold a reference into it. The error names the value that dies too early, not the reference."
+              },
+              {
+                "correct": false,
+                "feedback": "`'info` is the lifetime of the borrow the runtime lent you for the length of one instruction, which is the opposite of `'static`. The compiler never invents `'static` — lesson 8's question 1 was exactly this mistake.",
+                "id": "b",
+                "label": "It compiles. `'info` is `'static` in practice, because the account data is owned by the runtime rather than by your handler."
+              },
+              {
+                "correct": false,
+                "feedback": "Rust has no mechanism that nulls out a reference when its target dies. That is precisely why the check has to happen at compile time and why there is nothing to warn about — it is an error or it is fine.",
+                "id": "c",
+                "label": "It compiles with a warning, and the reference is null after the instruction ends."
+              },
+              {
+                "correct": false,
+                "feedback": "A second name adds no lifetime. Annotations describe relationships the compiler then checks; nothing you write in a signature keeps a value alive one instruction longer. The fix is to copy the `Pubkey` out — it is `Copy`, 32 bytes, and owning it removes the question.",
+                "id": "d",
+                "label": "It is rejected, and the fix is to add a second lifetime parameter so the struct and the account each get their own."
+              }
+            ],
+            "prompt": "Lifetimes appear zero times in your file, and lesson 8 was still worth it. Course 3 hands a handler `vault: Account<'info, VaultState>`. A handler stashes `&vault.owner` into a struct it returns, so the reference outlives the instruction. Predict what the compiler does, and what `'info` had to do with it."
+          },
+          {
+            "explanation": "Exhaustiveness is the one property in this course the compiler genuinely verifies, and a wildcard is what you trade it away for. Two match sites with no wildcard gave you a to-do list in lesson 11; the same thing happens across a course boundary here.",
+            "id": "q7",
+            "multiSelect": true,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "Every exhaustive `match` over `VaultError` that lacks a `_ =>` arm now fails to compile with `E0004`, naming the file, line and uncovered variant."
+              },
+              {
+                "correct": true,
+                "id": "b",
+                "label": "Any `match` that does have a `_ =>` arm compiles unchanged and silently routes `VaultFrozen` to whatever the wildcard says."
+              },
+              {
+                "correct": true,
+                "id": "c",
+                "label": "Appending rather than inserting is what keeps `Overflow` at 6000 and `NotOwner` at 6003, so no deployed client's hardcoded code changes meaning."
+              },
+              {
+                "correct": false,
+                "feedback": "The code is the declaration index plus `ERROR_CODE_OFFSET`, computed per enum. Nothing is annotated and nothing is coordinated across enums — which is the entire reason a second `#[error_code]` enum collides at 6000.",
+                "id": "d",
+                "label": "The new variant gets 6004 only if you annotate it; without an explicit code Anchor assigns the next free number across all enums in the crate."
+              }
+            ],
+            "prompt": "Course 3 adds a fifth variant to your `VaultError` — `VaultFrozen` — and appends it after `NotOwner`. Your file's two methods and Course 3's own code both `match` on the enum in places. Which of these are true?"
+          }
+        ]
+      },
+      {
+        "_key": "reflect",
+        "_type": "openEnded",
+        "maxWords": 120,
+        "prompt": "Your `withdraw` compiles whether it calls `checked_sub` or `checked_add`, and the build server cannot tell the difference. In 120 words or fewer: name the specific mechanism that would catch the swap, and say at what point in Course 3 it runs. Then name one other thing in your file that no compiler can check. This is not graded and awards no XP — it is here because writing the answer is what makes you keep it."
+      }
+    ],
+    "skills": [
+      "rust-ownership",
+      "rust-structs",
+      "rust-enums",
+      "rust-result",
+      "checked-arithmetic",
+      "rust-lifetimes",
+      "rust-traits",
+      "account-layout",
+      "pdas"
+    ],
+    "slug": {
+      "_type": "slug",
+      "current": "what-you-built"
+    },
+    "title": "What You Built"
+  },
+  {
+    "_id": "lesson-rpd-your-first-rust-build",
+    "_type": "lesson",
+    "blocks": [
+      {
+        "_key": "intro",
+        "_type": "prose",
+        "src": "# Your First Rust Build\n\n> **Version stamp — checked 2026-07-26.** `anchor-lang` **1.1.2** (published 2026-06-26; the newest release on crates.io on the date this lesson was written) · Rust **edition 2021** · Agave **≥ 3.1.10** · borsh **1.5.7 declared / 1.8.0 resolved** · the build server compiles with `cargo-build-sbf --tools-version v1.54`, whose pinned `rustc` reports 1.89.0-dev. That last number is not printed anywhere in your build log, which is why it is written here — this stamp is the only place you can read it. Lesson 4 depends on `overflow-checks = true`, which is set in the build crate's `[profile.release]`.\n\nIn Course 1 your inspector took an address, pulled the account back off devnet, and turned the bytes into fields with names — `owner`, `balance`, `bump`.\n\nThose bytes had no names on the chain. They had names because somebody wrote a `struct` in Rust, and the memory layout of that struct **is** the account. Your decoder was reading a shape it had been told about. This course is about being the person who defines the shape.\n\nFourteen lessons from now you will hold a file called `vault_core.rs`: a `VaultState`, a `deposit`, a `withdraw` that cannot silently wrap a `u64`, and an error enum with four named variants. Course 3 wraps a program around it and puts it on devnet.\n\nRight now, none of that. Right now: a green build.\n\n## Nothing to install\n\nYou are not going to install Rust. There is no `rustup`, no `cargo`, no toolchain to keep in sync with a tutorial, and no `.so` file to upload from your machine.\n\nThe editor below sends one file to a build server that already has the Solana platform toolchain on it. It compiles the file for the SBF target — the bytecode format Solana validators execute — and sends back the result. That is the whole loop, and it is the loop for every code exercise in this course and the next.\n\nThis first exercise exists to prove that loop works for you, on your network, before any Rust matters. Nothing in the file needs changing.\n\n## The file, line by line\n\n```rust\nuse anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\npub fn vault_core_banner() -> Result<()> {\n    msg!(\"vault core reporting in from {}\", ID);\n    Ok(())\n}\n```\n\nFour things, and each one is worth a sentence.\n\n**`use anchor_lang::prelude::*;`** — Rust has no ambient globals. Nothing is in scope that you did not bring into scope. A `prelude` module is a crate's answer to that: a curated bundle of the names you will want in almost every file, imported in one line. `Result`, `msg!` and `declare_id!` all arrive through this import.\n\n**`declare_id!(\"Fg6Pa…\")`** — the address the program lives at, as a compile-time constant named `ID`. It is a placeholder here; Course 3 replaces it with the id of the program you actually deploy. It is not optional decoration. Anchor's account macros generate code that refers to `crate::ID`, so a file that uses them and forgets this line does not compile — and the error appears at the macro, not here, which is why it is worth recognising now.\n\n**`pub fn vault_core_banner() -> Result<()>`** — `fn` declares a function. `pub` makes it visible outside this module. `-> Result<()>` is the return type: *either* success carrying nothing, *or* an error. Anchor's `Result<()>` is a program's standard return shape, and one of the reasons Solana programs written in Rust do not throw. There is no `throw`. Failure is a value you return.\n\n**`Ok(())`** — the success value. `()` is the unit type, Rust's \"no meaningful value\" — the closest thing it has to `void`, except that it is a real type with exactly one value, so it can be put inside `Ok(...)` like anything else. Note the absence of a semicolon: this is the function's **tail expression**, and it is what the function evaluates to. Lesson 3 is about how much that missing semicolon matters.\n\nThe keen-eyed will notice this file has no `#[program]` and no `#[derive(Accounts)]` — no instruction handlers, no account lists. That is deliberate, and it stays that way for all fourteen lessons. Those two macros are Course 3's job. Your file is the logic they wrap around.\n\n## Press Build\n\nExpect **30 to 90 seconds** the first time. The server is compiling Anchor and its dependency tree, not just your eight lines. Subsequent builds reuse that work and come back in seconds.\n\nThis one will pass, which means you get one line back and no log. Read the next section anyway — it is about what arrives when a build *fails*, which is the interesting case and the one you will be in for the next thirteen lessons. For the rest of this course the compiler is not an obstacle between you and a passing grade. It is the fastest reviewer you will ever have, and it works for free.\n"
+      },
+      {
+        "_key": "exercise",
+        "_type": "code",
+        "buildType": "buildable",
+        "deployable": false,
+        "hints": [
+          "You don't need to change anything — just click the Build button",
+          "If the build times out, try again. First builds take longer because dependencies are being downloaded.",
+          "If you see errors, make sure you haven't accidentally modified the starter code. Click Reset Code to restore it."
+        ],
+        "language": "rust",
+        "solution": "use anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n/// Nothing in this file needs changing. Press Build, then read the log.\npub fn vault_core_banner() -> Result<()> {\n    msg!(\"vault core reporting in from {}\", ID);\n    Ok(())\n}\n",
+        "starter": "use anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n/// Nothing in this file needs changing. Press Build. This one passes, so you\n/// get one success line and no log — the prose below explains why, and what you\n/// get instead when a build fails.\npub fn vault_core_banner() -> Result<()> {\n    msg!(\"vault core reporting in from {}\", ID);\n    Ok(())\n}\n",
+        "tests": [
+          {
+            "description": "Program compiles successfully",
+            "expectedOutput": "true",
+            "id": "test-1",
+            "input": ""
+          }
+        ]
+      },
+      {
+        "_key": "output",
+        "_type": "prose",
+        "src": "## Reading the compiler output\n\nThe build log is not noise you scroll past on the way to a green tick. It is the primary interface of this course. Learn its shapes now and the next thirteen lessons get much shorter.\n\n### 0. When you get a log at all\n\nStart here, because it is the platform fact that shapes everything else.\n\n**A failing build hands you the compiler's whole output. A passing build hands you one line and a build id.** That is what the runner does: on success it reports `Program compiled successfully!` and discards the log; on failure it prints the captured output verbatim.\n\nSo the log is the *failure* interface. Everything below is what you read when something is wrong — which is most of the time, and is when you need it.\n\nTwo consequences worth carrying:\n\n- **Warnings on a green build are invisible to you here.** They exist, `rustc` emitted them, and this platform throws them away along with the rest of a successful log. When a lesson says a mistake \"only produces a warning\", read that as *nothing on this platform will tell you*. That is a real limitation and it is worth knowing rather than working around.\n- **A green build is one bit of information.** Not zero — it means the file compiled against the real Anchor 1.x toolchain, which is more than a linter can say. But one bit.\n\n### 1. `Compiling` and `Finished`\n\nThis is what the log looks like on the server, whether or not any of it reaches you:\n\n```\n   Compiling academy-program v0.1.0 (/build/program)\n    Finished `release` profile [optimized] target(s) in 3.41s\n```\n\n`Finished` is the whole verdict. If the build reaches it, the file compiled and the lesson is graded as passed. Grading in this course is a **compilation check** — passing means it compiled. It does not mean it is correct. Lesson 4 is the first place where the file itself carries assertions the compiler must also satisfy, and that is a deliberate design, not a default.\n\nA failing build reaches the `Compiling` line and never the `Finished` one. It ends with a summary instead:\n\n```\n   Compiling academy-program v0.1.0 (/build/program)\nerror[E0308]: mismatched types\n   …\nerror: could not compile `academy-program` (lib) due to 1 previous error\n```\n\nSo the pair you will actually read is `Compiling` at the top and `could not compile` at the bottom, with the errors in between. `Finished` is a line you infer from the success message rather than one you see.\n\nOne `Compiling` line per crate, so a failing build with a cold dependency cache prints the whole tree with each crate's resolved version — `Compiling borsh v1.8.0`, `Compiling anchor-lang v1.1.2`. That is the only place the pinned stack states itself out loud, and if you ever see it, note `borsh v1.8.0` against a manifest that asked for `1.5.7`. Lesson 13 explains why those differ.\n\nWhat the log does **not** contain, at any point: a line naming the Rust compiler version or the target triple. `cargo-build-sbf` prints neither. The pinned `rustc` arrives with the platform-tools version the build server passes on the command line, which is not visible in the output — and that is why every lesson in this course carries a **version stamp** at the top of its prose. The stamp is the source of truth. There is no banner to check it against.\n\n### 2. Version pinning as a ceiling\n\nThe compiler the build server runs is older than the newest Rust release, and that is normal — platform-tools lags upstream by design, because validators run what the toolchain produced.\n\nTreat it as a **ceiling**. Any language feature stabilised after it does not exist for you, no matter what the Rust release notes say, and no matter that the copy of Rust on your laptop is newer. This is the single most common way a snippet from a blog post fails here for a reason that has nothing to do with the snippet: it was written against a newer compiler.\n\nThe same goes at the library level. This course pins `anchor-lang` **1.1.2**. Anchor 1.0 was a breaking major release, so a large amount of the Anchor material on the internet — most of it, by volume — was written against 0.2x or 0.3x. One example you will meet immediately if you go looking:\n\n- `CpiContext::new(ctx.accounts.system_program.to_account_info(), …)` was the 0.x shape. On 1.x it is `CpiContext::new(System::id(), …)`, and the 0.x form does not compile here.\n\nA second rule you will read as though it were a compile error, and it is not: **one `#[error_code]` enum per program.** Two enums compile perfectly well on 1.1.2 — we checked by compiling them. The problem is that both start numbering at 6000, so each one's first variant is the same code on the wire and no client can tell them apart. It is a convention enforced by consequences, not by `rustc`. Lesson 11 makes you predict that one.\n\nWhen you copy Rust from anywhere, check what it was written against first. \"Rust from 2024\" is not a version.\n\n### 3. `warning:` — free advice you will only see next to an error\n\n```\nwarning: unused variable: `amount`\n --> src/lib.rs:12:16\n   |\n12 | pub fn credit(amount: u64) {\n   |               ^^^^^^ help: if this is intentional, prefix it with an underscore: `_amount`\n```\n\nWarnings do not stop the build and do not fail the lesson. When they are shown, read them: Rust's warnings are unusually good at pointing straight at real mistakes — `unused variable`, `unreachable pattern`, `value assigned is never read` are each, in practice, a bug about a third of the time.\n\n\"When they are shown\" is doing real work in that sentence. Per section 0, you see them only in a failing build's log, alongside the error that failed it. A file that compiles green with a `warning: unreachable pattern` in it looks, from where you are sitting, identical to a file with no warning at all.\n\nYou will also see warnings you cannot fix and should ignore, including a run of `unexpected cfg condition value` lines coming out of Anchor's own macros. Those are Anchor's, not yours.\n\n### 4. `error[E….]` — the one you came for\n\n```\nerror[E0308]: mismatched types\n  --> src/lib.rs:14:5\n   |\n13 | pub fn bump_as_u64(bump: u8) -> u64 {\n   |                                 --- expected `u64` because of return type\n14 |     bump\n   |     ^^^^ expected `u64`, found `u8`\n   |\nhelp: you can convert a `u8` to a `u64`\n   |\n14 |     bump.into()\n   |         +++++++\n```\n\nFive things are in there, and you want all five:\n\n1. **The code**, `E0308`. Every Rust error has a stable numbered code. It is searchable and it is documented — the Rust error index has a page per code, with a minimal example. Search the code, not the message.\n2. **`--> src/lib.rs:14:5`** — file, line, column. Your submission is always compiled as `src/lib.rs`, so the line number is the line number in the editor.\n3. **The excerpt with the carets**, pointing at the exact expression, plus a second span showing *why* — here, the return type on line 13 is what created the expectation.\n4. **`expected … found …`**, in that order. Expected is what the surrounding code demands; found is what you gave it. Getting the direction the right way round is most of the skill.\n5. **`help:`**, which frequently contains the literal fix. Not always right — lesson 9 has a case where the suggestion compiles and is wrong for on-chain code. Usually right.\n\nYou will also see `For more information about this error, try 'rustc --explain E0308'` and, at the very bottom, the `error: could not compile` summary from section 1. Neither adds anything the block above did not already tell you.\n\n### Read the first error only\n\nA file with one real mistake often produces a wall of errors, because everything downstream of the mistake is now being checked against a type the compiler had to guess at. Fix the **first** error, rebuild, and watch most of the rest disappear. Working bottom-up through a cascade is the most reliable way to waste an afternoon.\n\nAnd unlike a JavaScript runtime, which stops dead at the first exception, `rustc` keeps going and reports every independent error in one pass. Four unrelated mistakes give you four errors in a single build. That is a feature: it means one round-trip per batch of work, not one per bug.\n\n### What to carry into lesson 2\n\n- You get the log when the build **fails**. A pass is one line, and warnings go in the bin with it.\n- The pinned compiler is a ceiling on what you can use, and the lesson's version stamp is where you read it.\n- `Finished` = compiled = passed. Compiled does not mean correct.\n- Errors have numbered codes worth searching. Fix the first one, then rebuild.\n"
+      },
+      {
+        "_key": "check",
+        "_type": "quiz",
+        "questions": [
+          {
+            "id": "q1",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "Passes, and you see `Program compiled successfully!` and a build id — nothing else. The warning was emitted and this platform discards the log on a successful build, so it never reaches you."
+              },
+              {
+                "correct": false,
+                "feedback": "It is not. On success the runner reports the success line and the build id and throws the captured output away; only a failing build hands you the log. Worth knowing before a later lesson tells you \"that mistake only warns\".",
+                "id": "b",
+                "label": "Passes, and the warning is shown above the success message so you can act on it."
+              },
+              {
+                "correct": false,
+                "feedback": "Nothing counts warnings. `rustc` treats them as advice and exits successfully, the build server reports success, and the lesson passes. They do not gate anything — the problem is the opposite one, that you cannot see them.",
+                "id": "c",
+                "label": "Fails. Warnings are collected and counted against the submission."
+              },
+              {
+                "correct": false,
+                "feedback": "There is no partial credit on a buildable lesson. The signal the grader has is one bit: did it compile.",
+                "id": "d",
+                "label": "Passes, but with partial credit, since the code is not clean."
+              }
+            ],
+            "prompt": "You submit a file that compiles but makes `rustc` emit `warning: unreachable pattern`. There is no `error[E….]` anywhere. Predict both the grade and what appears in the output panel."
+          },
+          {
+            "id": "q2",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "A compile error, because `ID` no longer exists — `declare_id!` is what generates it, and `msg!` on the next line uses it."
+              },
+              {
+                "correct": false,
+                "feedback": "It is a compile-time constant, not deploy metadata. Anything that refers to `ID` — your `msg!` here, and every account macro you write from lesson 10 onward — needs it to exist during compilation.",
+                "id": "b",
+                "label": "It compiles. `declare_id!` only matters at deploy time, when the program needs an address."
+              },
+              {
+                "correct": false,
+                "feedback": "There is no default and no fallback. The name is either generated or absent.",
+                "id": "c",
+                "label": "It compiles with a warning, and `ID` falls back to the all-zeros default program id."
+              },
+              {
+                "correct": false,
+                "feedback": "A missing name is caught during compilation. Rust does not resolve names at run time, so there is no \"later\" for this class of mistake.",
+                "id": "d",
+                "label": "It compiles, and the failure surfaces later as a runtime error on devnet."
+              }
+            ],
+            "prompt": "You delete the `declare_id!` line from this lesson's file and leave everything else alone. Predict the outcome."
+          },
+          {
+            "id": "q3",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "It fails to compile here, even though it is valid Rust on a newer toolchain. The server's compiler is the ceiling, and it is not the latest release."
+              },
+              {
+                "correct": false,
+                "feedback": "The toolchain is pinned by the `--tools-version` the build server passes to `cargo-build-sbf`. Nothing about your submission can change it — which is the point of pinning it, and why a version stamp sits at the top of every lesson instead.",
+                "id": "b",
+                "label": "It compiles. The build server fetches whatever toolchain the submitted code requires."
+              },
+              {
+                "correct": false,
+                "feedback": "Whether a feature exists is a property of the compiler version, not a channel you can talk your way onto from inside a submission.",
+                "id": "c",
+                "label": "It compiles, because the feature is only rejected on the stable channel and SBF builds use nightly."
+              },
+              {
+                "correct": false,
+                "feedback": "A compiler cannot warn about syntax it does not understand. You get an error — often an unhelpful parse error rather than a polite \"this needs a newer Rust\".",
+                "id": "d",
+                "label": "It compiles with a `future_incompatible` warning naming the required version."
+              }
+            ],
+            "prompt": "This lesson's version stamp names the pinned `rustc`, and it is older than the newest Rust release. Nothing in the build log states that version. You paste in a snippet that relies on a language feature stabilised after it. Predict what happens."
+          }
+        ]
+      }
+    ],
+    "skills": [
+      "rust",
+      "build-server",
+      "toolchain-versions"
+    ],
+    "slug": {
+      "_type": "slug",
+      "current": "your-first-rust-build"
+    },
+    "title": "Your First Rust Build"
+  },
+  {
     "_id": "lesson-rust-basics-challenge",
     "_type": "lesson",
     "blocks": [
@@ -4157,6 +6726,7 @@
             "prompt": "A regulated Brazilian eFX provider wants to take reais from a client, convert them to USDC, and settle the client's obligation to a supplier abroad on-chain. It is 2026-11-01. What does your decision map return, and why?"
           },
           {
+            "explanation": "x402 is the only rail that needs no prior relationship with the payer: the price rides in the 402 response and is satisfied in the same request cycle. Delegations and subscriptions both require onboarding an account first, and Solana Pay assumes a human is present to approve — none of which an anonymous script has.",
             "id": "q2",
             "multiSelect": false,
             "options": [
@@ -4187,6 +6757,7 @@
             "prompt": "Your API charges $0.002 per call. Callers are other people's scripts; they have no account with you and never will. Which rail?"
           },
           {
+            "explanation": "A recurring cap is a per-period ceiling, not a balance that accrues. Each period resets to the full cap and unused capacity from skipped periods is gone, so May allows 50 USDC and no more. If a business needs missed periods to be collectable, that is an invoice it builds in its own system.",
             "id": "q3",
             "multiSelect": false,
             "options": [
@@ -4347,6 +6918,7 @@
         "_type": "quiz",
         "questions": [
           {
+            "explanation": "The per-period cap is also your idempotency guard. Once 25 USDC is pulled, a second pull in the same period fails with `AMOUNT_EXCEEDS_PERIOD_LIMIT` — read that as \"already collected\" and stop. Retrying treats a charge that already landed as a transient failure, which is how you would double-bill.",
             "id": "q1",
             "multiSelect": false,
             "options": [
@@ -4408,6 +6980,7 @@
             "prompt": "A merchant with a 25 USDC/month recurring delegation forgets to collect in March and April, then runs the job in May. How much can it pull in May, and why?"
           },
           {
+            "explanation": "An unattended service holds the delegatee key and nothing more: it can pull up to the cap each period and cannot touch the terms. Setup and revoke are signed by the user (the delegator); changing `expiryTs` means a new delegation the user signs again. That split is exactly why the delegatee key is safe to leave running unattended.",
             "id": "q3",
             "multiSelect": false,
             "options": [
@@ -4438,6 +7011,7 @@
             "prompt": "Your unattended billing service holds one key. Which key must it be, and what can it do with it?"
           },
           {
+            "explanation": "`startTs: 0n` means \"start when this lands\", which is only allowed when paired with a bounded, non-zero expiry. Combined with `expiryTs: 0n` (\"never expire\") it is the least-bounded authorisation the program could issue, so it is rejected at creation — not later, at transfer time.",
             "id": "q4",
             "multiSelect": false,
             "options": [
@@ -4468,6 +7042,7 @@
             "prompt": "You call `createRecurringDelegation` with `startTs: 0n` and `expiryTs: 0n`. Predict the result."
           },
           {
+            "explanation": "`revokeDelegation` closes that one delegation's PDA and returns its rent, and because each delegation is its own PDA under the shared authority the user's others are untouched. There is no pause in this model — re-establishing means a fresh `createRecurringDelegation` with a new nonce, signed by the user, so consent is given again.",
             "id": "q5",
             "multiSelect": true,
             "options": [
@@ -5147,6 +7722,7 @@
         "_type": "quiz",
         "questions": [
           {
+            "explanation": "The SubscriptionAuthority PDA is derived from `(user, tokenMint)`, so a returning user already has one and calling `init` on an account that exists fails — leaving them worse off than a newcomer. Read first with a `fetchMaybe*` and branch on its `exists` discriminant; nothing here is idempotent by convenience.",
             "id": "q1",
             "multiSelect": false,
             "options": [
@@ -5177,6 +7753,7 @@
             "prompt": "You call `initSubscriptionAuthority` unconditionally, without reading the account first. A user who set this up last month comes back. Predict what happens."
           },
           {
+            "explanation": "Every amount in this API is base units — there is no decimals scaling anywhere — so `amount: 25n` caps the delegation at 25 base units, 0.000025 USDC, and the first real charge fails with `AMOUNT_EXCEEDS_LIMIT`. Convert human amounts to base units once, in one function, so the mistake cannot recur.",
             "id": "q2",
             "multiSelect": false,
             "options": [
@@ -5207,6 +7784,7 @@
             "prompt": "You mean to cap a delegation at 25 USDC and pass `amount: 25n`. Predict the cost of the mistake."
           },
           {
+            "explanation": "Expiry is enforced on the transfer, not just at creation, so a delegation 40 seconds past `expiryTs` fails with `DELEGATION_EXPIRED` — no grace window, no auto-renewal. Renewal is a new `createFixedDelegation` with a new nonce that the user signs; if a product wants a grace period, the product builds it.",
             "id": "q3",
             "multiSelect": false,
             "options": [
@@ -5237,6 +7815,7 @@
             "prompt": "A fixed delegation's `expiryTs` passed 40 seconds ago. Your merchant service tries to collect. Predict the behaviour."
           },
           {
+            "explanation": "The types are the answer: `delegatee` is a `TransactionSigner` and `delegator` is a plain `Address`, so only the delegatee signs the charge. The user consented once at setup and is not present per-pull; their protection is the cap, the expiry and the revoke, not a signature on every transfer.",
             "id": "q4",
             "multiSelect": false,
             "options": [
@@ -5326,6 +7905,7 @@
         "_type": "quiz",
         "questions": [
           {
+            "explanation": "The token program id is one of the ATA seeds (`[owner, tokenProgram, mint]`), so passing the legacy id for a Token-2022 mint derives a real but wrong address — and because derivation is pure math over seeds and never reads the mint, nothing catches the mismatch. A transfer there goes nowhere useful. Derive with the mint's actual owning program.",
             "id": "q1",
             "multiSelect": false,
             "options": [
@@ -5356,6 +7936,7 @@
             "prompt": "You derive an ATA with `findAssociatedTokenPda({ mint, owner, tokenProgram })` and pass the legacy Token program id, but the mint was created under Token-2022. Predict what happens."
           },
           {
+            "explanation": "The rail vetoes on what the mint carries, not on which extension you meant to use, and one disqualifying extension is enough: `MINT_HAS_PERMANENT_DELEGATE` fires regardless of the interest-bearing intent. A user-revocable allowance is meaningless when the mint authority already holds an irrevocable permanent delegate.",
             "id": "q2",
             "multiSelect": false,
             "options": [
@@ -5386,6 +7967,7 @@
             "prompt": "A mint is Token-2022 and carries both `permanent-delegate` and `interest-bearing`. Your product needs the interest-bearing behaviour. Predict the outcome of opening a delegation against it."
           },
           {
+            "explanation": "The rule is legacy Token by default; Token-2022 is justified only by a capability you need now — a named extension the rail accepts, or a compliance transfer-hook whose rail you have verified resolves hook accounts on your path. \"Newer\" and \"might want one later\" are not grounds: extensions are fixed at mint creation, so choosing the program early buys nothing and still costs the compatibility check.",
             "id": "q3",
             "multiSelect": true,
             "options": [
@@ -5415,6 +7997,7 @@
             "prompt": "Which of these are grounds for choosing Token-2022 for a payment mint under the rule taught here?"
           },
           {
+            "explanation": "This is the Course 4 semver rule: below `1.0.0` the minor is the breaking position, so a caret pins it. `^0.9.0` means `>=0.9.0 <0.10.0` — patches like `0.9.7` still float, but `0.15.0` is out of range. A lockfile only pins what already resolved; it never widens a range that never admitted `0.15.0`.",
             "id": "q4",
             "multiSelect": false,
             "options": [
@@ -5445,6 +8028,7 @@
             "prompt": "Carried over from Course 4 — semver. `@x402/svm@2.19.0` depends on `@solana-program/token` at `^0.9.0`. The published latest is `0.15.0`. Does that range resolve to `0.15.0`?"
           },
           {
+            "explanation": "Reading the decoded constant is the Course 4 skill: the program names the model in the error. `...AMOUNT_EXCEEDS_PERIOD_LIMIT` (\"Transfer amount exceeds period limit\") is the recurring-delegation cap; the fixed model raises `AMOUNT_EXCEEDS_LIMIT` and plans raise `PLAN_*`. The constant tells you which cap you hit without guessing.",
             "id": "q5",
             "multiSelect": false,
             "options": [

--- a/apps/web/src/content/generated/meta.json
+++ b/apps/web/src/content/generated/meta.json
@@ -1,11 +1,11 @@
 {
-  "compiledAt": "2026-07-26T19:38:50Z",
+  "compiledAt": "2026-07-26T20:09:22Z",
   "counts": {
     "achievements": 10,
-    "courses": 7,
+    "courses": 8,
     "learningPaths": 8,
-    "lessons": 85,
+    "lessons": 99,
     "quests": 5
   },
-  "sha": "e1190680421e8190ab4deb9b41376667abc7a398"
+  "sha": "1b74e4a60f8813374219451b60436af832df2d91"
 }

--- a/apps/web/src/content/generated/skills.json
+++ b/apps/web/src/content/generated/skills.json
@@ -168,5 +168,85 @@
     "label": "Earn Submission",
     "reviewExempt": true,
     "slug": "earn-submission"
+  },
+  {
+    "label": "Rust Types & Integer Widths",
+    "slug": "rust-types"
+  },
+  {
+    "label": "Rust Control Flow",
+    "slug": "rust-control-flow"
+  },
+  {
+    "label": "Ownership",
+    "slug": "rust-ownership"
+  },
+  {
+    "label": "Move Semantics",
+    "slug": "rust-move-semantics"
+  },
+  {
+    "label": "Borrowing",
+    "slug": "rust-borrowing"
+  },
+  {
+    "label": "Lifetimes",
+    "slug": "rust-lifetimes"
+  },
+  {
+    "label": "Slices & Byte Views",
+    "slug": "rust-slices"
+  },
+  {
+    "label": "Structs",
+    "slug": "rust-structs"
+  },
+  {
+    "label": "Enums & Pattern Matching",
+    "slug": "rust-enums"
+  },
+  {
+    "label": "Traits & Derives",
+    "slug": "rust-traits"
+  },
+  {
+    "label": "Option",
+    "slug": "rust-option"
+  },
+  {
+    "label": "Result",
+    "slug": "rust-result"
+  },
+  {
+    "label": "Modules & Visibility",
+    "slug": "rust-modules"
+  },
+  {
+    "label": "Checked Arithmetic",
+    "slug": "checked-arithmetic"
+  },
+  {
+    "label": "Reading Compiler Errors",
+    "slug": "compiler-errors"
+  },
+  {
+    "label": "Debugging",
+    "slug": "debugging"
+  },
+  {
+    "label": "Browser Build Server",
+    "slug": "build-server"
+  },
+  {
+    "label": "Toolchain Versions",
+    "slug": "toolchain-versions"
+  },
+  {
+    "label": "Account Layout",
+    "slug": "account-layout"
+  },
+  {
+    "label": "Program Security",
+    "slug": "program-security"
   }
 ]

--- a/apps/web/src/content/generated/slots.json
+++ b/apps/web/src/content/generated/slots.json
@@ -60,6 +60,27 @@
     },
     "version": 1
   },
+  "course-rust-for-program-devs": {
+    "next": 14,
+    "retired": [],
+    "slots": {
+      "lesson-rpd-borrowing-shared-vs-mutable": 5,
+      "lesson-rpd-build-the-vault-core": 12,
+      "lesson-rpd-checked-lamport-math": 3,
+      "lesson-rpd-enums-option-result": 10,
+      "lesson-rpd-error-plumbing": 11,
+      "lesson-rpd-fix-the-borrow-checker": 6,
+      "lesson-rpd-functions-and-control-flow": 2,
+      "lesson-rpd-lifetimes-and-slices": 7,
+      "lesson-rpd-moves-copy-and-clone": 4,
+      "lesson-rpd-ownership-checkpoint": 8,
+      "lesson-rpd-structs-traits-and-derives": 9,
+      "lesson-rpd-types-and-mutability": 1,
+      "lesson-rpd-what-you-built": 13,
+      "lesson-rpd-your-first-rust-build": 0
+    },
+    "version": 1
+  },
   "course-rust-for-solana": {
     "next": 12,
     "retired": [],

--- a/apps/web/src/lib/content/__tests__/fixtures/golden/courses.json
+++ b/apps/web/src/lib/content/__tests__/fixtures/golden/courses.json
@@ -1,94 +1,13 @@
 [
   {
     "_id": "course-anchor-framework",
-    "creator": "B7o8NfV81HzjuZFWQTTx3Xdvh77Dqoajwib3kWEnvzJF",
+    "title": "Anchor Framework Mastery",
+    "slug": "anchor-framework",
     "description": "Master the Anchor framework for Solana smart contract development. From account constraints to PDAs, CPIs, testing, and deployment — build production-ready programs with confidence.",
     "difficulty": "intermediate",
     "duration": 14,
-    "modules": [
-      {
-        "description": "Learn the fundamentals of the Anchor framework, program structure, and account constraints.",
-        "key": "anchor-basics",
-        "lessons": [
-          {
-            "_id": "lesson-anchor-intro",
-            "slug": "anchor-intro",
-            "title": "What is the Anchor Framework?"
-          },
-          {
-            "_id": "lesson-anchor-setup-challenge",
-            "slug": "anchor-setup-challenge",
-            "title": "Challenge: Anchor Program Structure"
-          },
-          {
-            "_id": "lesson-anchor-accounts",
-            "slug": "anchor-accounts",
-            "title": "Anchor Account Constraints"
-          },
-          {
-            "_id": "lesson-anchor-accounts-challenge",
-            "slug": "anchor-accounts-challenge",
-            "title": "Challenge: Account Validation"
-          }
-        ],
-        "title": "Anchor Basics"
-      },
-      {
-        "description": "Master Program Derived Addresses and Cross-Program Invocations for building composable programs.",
-        "key": "pdas-cpis",
-        "lessons": [
-          {
-            "_id": "lesson-pda-deep-dive",
-            "slug": "pda-deep-dive",
-            "title": "PDA Deep Dive"
-          },
-          {
-            "_id": "lesson-pda-advanced-challenge",
-            "slug": "pda-advanced-challenge",
-            "title": "Challenge: Multi-PDA Derivation"
-          },
-          {
-            "_id": "lesson-cpi-overview",
-            "slug": "cpi-overview",
-            "title": "Cross-Program Invocations"
-          },
-          {
-            "_id": "lesson-cpi-challenge",
-            "slug": "cpi-challenge",
-            "title": "Challenge: Simulate a CPI Vault Transfer"
-          }
-        ],
-        "title": "PDAs & CPIs"
-      },
-      {
-        "description": "Learn to test, debug, and deploy production-ready Anchor programs.",
-        "key": "anchor-testing",
-        "lessons": [
-          {
-            "_id": "lesson-anchor-testing",
-            "slug": "anchor-testing",
-            "title": "Testing Anchor Programs"
-          },
-          {
-            "_id": "lesson-anchor-errors",
-            "slug": "anchor-errors",
-            "title": "Custom Errors in Anchor"
-          },
-          {
-            "_id": "lesson-deployment",
-            "slug": "deployment",
-            "title": "Deploying Solana Programs"
-          },
-          {
-            "_id": "lesson-testing-challenge",
-            "slug": "testing-challenge",
-            "title": "Challenge: Test a Transfer Program"
-          }
-        ],
-        "title": "Testing & Deployment"
-      }
-    ],
-    "slug": "anchor-framework",
+    "thumbnail": null,
+    "creator": "B7o8NfV81HzjuZFWQTTx3Xdvh77Dqoajwib3kWEnvzJF",
     "tags": [
       "account-model",
       "anchor",
@@ -98,129 +17,102 @@
       "program-testing",
       "solana-programs"
     ],
-    "thumbnail": null,
-    "title": "Anchor Framework Mastery",
+    "xpReward": 900,
     "trackId": 3,
     "trackLevel": 1,
-    "xpReward": 900
+    "modules": [
+      {
+        "key": "anchor-basics",
+        "title": "Anchor Basics",
+        "description": "Learn the fundamentals of the Anchor framework, program structure, and account constraints.",
+        "lessons": [
+          {
+            "_id": "lesson-anchor-intro",
+            "title": "What is the Anchor Framework?",
+            "slug": "anchor-intro"
+          },
+          {
+            "_id": "lesson-anchor-setup-challenge",
+            "title": "Challenge: Anchor Program Structure",
+            "slug": "anchor-setup-challenge"
+          },
+          {
+            "_id": "lesson-anchor-accounts",
+            "title": "Anchor Account Constraints",
+            "slug": "anchor-accounts"
+          },
+          {
+            "_id": "lesson-anchor-accounts-challenge",
+            "title": "Challenge: Account Validation",
+            "slug": "anchor-accounts-challenge"
+          }
+        ]
+      },
+      {
+        "key": "pdas-cpis",
+        "title": "PDAs & CPIs",
+        "description": "Master Program Derived Addresses and Cross-Program Invocations for building composable programs.",
+        "lessons": [
+          {
+            "_id": "lesson-pda-deep-dive",
+            "title": "PDA Deep Dive",
+            "slug": "pda-deep-dive"
+          },
+          {
+            "_id": "lesson-pda-advanced-challenge",
+            "title": "Challenge: Multi-PDA Derivation",
+            "slug": "pda-advanced-challenge"
+          },
+          {
+            "_id": "lesson-cpi-overview",
+            "title": "Cross-Program Invocations",
+            "slug": "cpi-overview"
+          },
+          {
+            "_id": "lesson-cpi-challenge",
+            "title": "Challenge: Simulate a CPI Vault Transfer",
+            "slug": "cpi-challenge"
+          }
+        ]
+      },
+      {
+        "key": "anchor-testing",
+        "title": "Testing & Deployment",
+        "description": "Learn to test, debug, and deploy production-ready Anchor programs.",
+        "lessons": [
+          {
+            "_id": "lesson-anchor-testing",
+            "title": "Testing Anchor Programs",
+            "slug": "anchor-testing"
+          },
+          {
+            "_id": "lesson-anchor-errors",
+            "title": "Custom Errors in Anchor",
+            "slug": "anchor-errors"
+          },
+          {
+            "_id": "lesson-deployment",
+            "title": "Deploying Solana Programs",
+            "slug": "deployment"
+          },
+          {
+            "_id": "lesson-testing-challenge",
+            "title": "Challenge: Test a Transfer Program",
+            "slug": "testing-challenge"
+          }
+        ]
+      }
+    ]
   },
   {
     "_id": "course-building-first-program",
-    "creator": "B7o8NfV81HzjuZFWQTTx3Xdvh77Dqoajwib3kWEnvzJF",
+    "title": "Building Your First Solana Program",
+    "slug": "building-your-first-solana-program",
     "description": "Take your Anchor knowledge from theory to practice. Write, compile, and deploy real Solana programs using the Superteam Academy Build Server — no local toolchain setup required. By the end, you'll have a working counter program deployed to Devnet.",
     "difficulty": "intermediate",
     "duration": 12,
-    "modules": [
-      {
-        "description": "Understand how Solana programs get compiled and get your first successful build through the Superteam Academy Build Server.",
-        "key": "bfsp-build-pipeline",
-        "lessons": [
-          {
-            "_id": "lesson-bfsp-from-code-to-chain",
-            "slug": "from-code-to-chain",
-            "title": "From Code to Chain"
-          },
-          {
-            "_id": "lesson-bfsp-your-first-build",
-            "slug": "your-first-build",
-            "title": "Your First Build"
-          },
-          {
-            "_id": "lesson-bfsp-anatomy-anchor-program",
-            "slug": "anatomy-anchor-program",
-            "title": "Anatomy of an Anchor Program"
-          },
-          {
-            "_id": "lesson-bfsp-add-instruction",
-            "slug": "add-instruction",
-            "title": "Add an Instruction"
-          }
-        ],
-        "title": "The Build Pipeline"
-      },
-      {
-        "description": "Define on-chain state with account structs, learn account constraints, and debug compiler errors.",
-        "key": "bfsp-state-accounts",
-        "lessons": [
-          {
-            "_id": "lesson-bfsp-on-chain-state",
-            "slug": "on-chain-state",
-            "title": "On-Chain State"
-          },
-          {
-            "_id": "lesson-bfsp-define-counter",
-            "slug": "define-counter-account",
-            "title": "Define a Counter Account"
-          },
-          {
-            "_id": "lesson-bfsp-account-constraints",
-            "slug": "account-constraints-deep-dive",
-            "title": "Account Constraints Deep Dive"
-          },
-          {
-            "_id": "lesson-bfsp-wire-up-initialize",
-            "slug": "wire-up-initialize",
-            "title": "Wire Up Initialize"
-          }
-        ],
-        "title": "State & Accounts"
-      },
-      {
-        "description": "Build the complete counter program with multiple instructions, error handling, and deploy it to Devnet.",
-        "key": "bfsp-full-counter",
-        "lessons": [
-          {
-            "_id": "lesson-bfsp-adding-instructions",
-            "slug": "adding-instructions",
-            "title": "Adding Instructions"
-          },
-          {
-            "_id": "lesson-bfsp-build-increment",
-            "slug": "build-increment",
-            "title": "Build the Increment"
-          },
-          {
-            "_id": "lesson-bfsp-complete-counter",
-            "slug": "complete-counter-program",
-            "title": "Complete Counter Program"
-          },
-          {
-            "_id": "lesson-bfsp-deploy-to-devnet",
-            "slug": "deploy-to-devnet",
-            "title": "Deploy to Devnet"
-          }
-        ],
-        "title": "The Full Counter"
-      },
-      {
-        "description": "Deploy your counter program to Solana Devnet and interact with it on-chain. Fund your wallet, deploy your binary, and call your program's instructions.",
-        "key": "bfsp-deploy-interact",
-        "lessons": [
-          {
-            "_id": "lesson-bfsp-m4-airdrop",
-            "slug": "airdrop-fund-wallet",
-            "title": "Airdrop & Fund Your Wallet"
-          },
-          {
-            "_id": "lesson-bfsp-m4-deploy",
-            "slug": "deploy-program-devnet",
-            "title": "Deploy Your Program to Devnet"
-          },
-          {
-            "_id": "lesson-bfsp-m4-interact",
-            "slug": "interact-with-program",
-            "title": "Interact with Your Program"
-          },
-          {
-            "_id": "lesson-bfsp-m4-capstone",
-            "slug": "what-you-built",
-            "title": "What You've Built"
-          }
-        ],
-        "title": "Deploy & Interact"
-      }
-    ],
-    "slug": "building-your-first-solana-program",
+    "thumbnail": null,
+    "creator": "B7o8NfV81HzjuZFWQTTx3Xdvh77Dqoajwib3kWEnvzJF",
     "tags": [
       "account-model",
       "anchor",
@@ -229,296 +121,335 @@
       "solana-programs",
       "transactions"
     ],
-    "thumbnail": null,
-    "title": "Building Your First Solana Program",
+    "xpReward": 850,
     "trackId": 1,
     "trackLevel": 2,
-    "xpReward": 850
+    "modules": [
+      {
+        "key": "bfsp-build-pipeline",
+        "title": "The Build Pipeline",
+        "description": "Understand how Solana programs get compiled and get your first successful build through the Superteam Academy Build Server.",
+        "lessons": [
+          {
+            "_id": "lesson-bfsp-from-code-to-chain",
+            "title": "From Code to Chain",
+            "slug": "from-code-to-chain"
+          },
+          {
+            "_id": "lesson-bfsp-your-first-build",
+            "title": "Your First Build",
+            "slug": "your-first-build"
+          },
+          {
+            "_id": "lesson-bfsp-anatomy-anchor-program",
+            "title": "Anatomy of an Anchor Program",
+            "slug": "anatomy-anchor-program"
+          },
+          {
+            "_id": "lesson-bfsp-add-instruction",
+            "title": "Add an Instruction",
+            "slug": "add-instruction"
+          }
+        ]
+      },
+      {
+        "key": "bfsp-state-accounts",
+        "title": "State & Accounts",
+        "description": "Define on-chain state with account structs, learn account constraints, and debug compiler errors.",
+        "lessons": [
+          {
+            "_id": "lesson-bfsp-on-chain-state",
+            "title": "On-Chain State",
+            "slug": "on-chain-state"
+          },
+          {
+            "_id": "lesson-bfsp-define-counter",
+            "title": "Define a Counter Account",
+            "slug": "define-counter-account"
+          },
+          {
+            "_id": "lesson-bfsp-account-constraints",
+            "title": "Account Constraints Deep Dive",
+            "slug": "account-constraints-deep-dive"
+          },
+          {
+            "_id": "lesson-bfsp-wire-up-initialize",
+            "title": "Wire Up Initialize",
+            "slug": "wire-up-initialize"
+          }
+        ]
+      },
+      {
+        "key": "bfsp-full-counter",
+        "title": "The Full Counter",
+        "description": "Build the complete counter program with multiple instructions, error handling, and deploy it to Devnet.",
+        "lessons": [
+          {
+            "_id": "lesson-bfsp-adding-instructions",
+            "title": "Adding Instructions",
+            "slug": "adding-instructions"
+          },
+          {
+            "_id": "lesson-bfsp-build-increment",
+            "title": "Build the Increment",
+            "slug": "build-increment"
+          },
+          {
+            "_id": "lesson-bfsp-complete-counter",
+            "title": "Complete Counter Program",
+            "slug": "complete-counter-program"
+          },
+          {
+            "_id": "lesson-bfsp-deploy-to-devnet",
+            "title": "Deploy to Devnet",
+            "slug": "deploy-to-devnet"
+          }
+        ]
+      },
+      {
+        "key": "bfsp-deploy-interact",
+        "title": "Deploy & Interact",
+        "description": "Deploy your counter program to Solana Devnet and interact with it on-chain. Fund your wallet, deploy your binary, and call your program's instructions.",
+        "lessons": [
+          {
+            "_id": "lesson-bfsp-m4-airdrop",
+            "title": "Airdrop & Fund Your Wallet",
+            "slug": "airdrop-fund-wallet"
+          },
+          {
+            "_id": "lesson-bfsp-m4-deploy",
+            "title": "Deploy Your Program to Devnet",
+            "slug": "deploy-program-devnet"
+          },
+          {
+            "_id": "lesson-bfsp-m4-interact",
+            "title": "Interact with Your Program",
+            "slug": "interact-with-program"
+          },
+          {
+            "_id": "lesson-bfsp-m4-capstone",
+            "title": "What You've Built",
+            "slug": "what-you-built"
+          }
+        ]
+      }
+    ]
   },
   {
     "_id": "course-defi-on-solana",
-    "creator": "B7o8NfV81HzjuZFWQTTx3Xdvh77Dqoajwib3kWEnvzJF",
+    "title": "DeFi on Solana",
+    "slug": "defi-on-solana",
     "description": "Dive deep into decentralized finance on Solana. Understand AMMs, lending protocols, token mechanics, staking, and build DeFi primitives from vaults to liquidation engines.",
     "difficulty": "advanced",
     "duration": 16,
+    "thumbnail": null,
+    "creator": "B7o8NfV81HzjuZFWQTTx3Xdvh77Dqoajwib3kWEnvzJF",
+    "tags": [
+      "amm",
+      "defi",
+      "lending",
+      "oracles",
+      "spl-tokens",
+      "staking"
+    ],
+    "xpReward": 1000,
+    "trackId": 5,
+    "trackLevel": 1,
     "modules": [
       {
-        "description": "Understand the core concepts of decentralized finance on Solana: AMMs, lending, and market mechanics.",
         "key": "defi-primitives",
+        "title": "DeFi Primitives",
+        "description": "Understand the core concepts of decentralized finance on Solana: AMMs, lending, and market mechanics.",
         "lessons": [
           {
             "_id": "lesson-defi-overview",
-            "slug": "defi-overview",
-            "title": "DeFi on Solana Overview"
+            "title": "DeFi on Solana Overview",
+            "slug": "defi-overview"
           },
           {
             "_id": "lesson-amm-concepts",
-            "slug": "amm-concepts",
-            "title": "Automated Market Makers"
+            "title": "Automated Market Makers",
+            "slug": "amm-concepts"
           },
           {
             "_id": "lesson-lending-concepts",
-            "slug": "lending-concepts",
-            "title": "Lending & Borrowing Protocols"
+            "title": "Lending & Borrowing Protocols",
+            "slug": "lending-concepts"
           },
           {
             "_id": "lesson-amm-challenge",
-            "slug": "amm-challenge",
-            "title": "Challenge: Constant Product AMM"
+            "title": "Challenge: Constant Product AMM",
+            "slug": "amm-challenge"
           }
-        ],
-        "title": "DeFi Primitives"
+        ]
       },
       {
-        "description": "Deep dive into SPL Token standards, token math, and staking mechanisms on Solana.",
         "key": "token-mechanics",
+        "title": "Token Mechanics",
+        "description": "Deep dive into SPL Token standards, token math, and staking mechanisms on Solana.",
         "lessons": [
           {
             "_id": "lesson-token-standards",
-            "slug": "token-standards",
-            "title": "Solana Token Standards"
+            "title": "Solana Token Standards",
+            "slug": "token-standards"
           },
           {
             "_id": "lesson-token-math-challenge",
-            "slug": "token-math-challenge",
-            "title": "Token Math Challenge"
+            "title": "Token Math Challenge",
+            "slug": "token-math-challenge"
           },
           {
             "_id": "lesson-staking-mechanisms",
-            "slug": "staking-mechanisms",
-            "title": "Staking Mechanisms on Solana"
+            "title": "Staking Mechanisms on Solana",
+            "slug": "staking-mechanisms"
           },
           {
             "_id": "lesson-staking-challenge",
-            "slug": "staking-challenge",
-            "title": "Staking Rewards Calculator"
+            "title": "Staking Rewards Calculator",
+            "slug": "staking-challenge"
           }
-        ],
-        "title": "Token Mechanics"
+        ]
       },
       {
-        "description": "Learn advanced DeFi architecture: orderbooks, oracles, vaults, and liquidation systems.",
         "key": "building-defi",
+        "title": "Building DeFi Protocols",
+        "description": "Learn advanced DeFi architecture: orderbooks, oracles, vaults, and liquidation systems.",
         "lessons": [
           {
             "_id": "lesson-orderbook-design",
-            "slug": "orderbook-design",
-            "title": "On-Chain Orderbooks on Solana"
+            "title": "On-Chain Orderbooks on Solana",
+            "slug": "orderbook-design"
           },
           {
             "_id": "lesson-oracle-design",
-            "slug": "oracle-design",
-            "title": "Price Oracles for DeFi"
+            "title": "Price Oracles for DeFi",
+            "slug": "oracle-design"
           },
           {
             "_id": "lesson-vault-challenge",
-            "slug": "vault-challenge",
-            "title": "DeFi Vault Simulator"
+            "title": "DeFi Vault Simulator",
+            "slug": "vault-challenge"
           },
           {
             "_id": "lesson-liquidation-challenge",
-            "slug": "liquidation-challenge",
-            "title": "Liquidation Engine"
+            "title": "Liquidation Engine",
+            "slug": "liquidation-challenge"
           }
-        ],
-        "title": "Building DeFi Protocols"
+        ]
       }
-    ],
-    "slug": "defi-on-solana",
-    "tags": ["amm", "defi", "lending", "oracles", "spl-tokens", "staking"],
-    "thumbnail": null,
-    "title": "DeFi on Solana",
-    "trackId": 5,
-    "trackLevel": 1,
-    "xpReward": 1000
+    ]
   },
   {
     "_id": "course-rust-for-solana",
-    "creator": "B7o8NfV81HzjuZFWQTTx3Xdvh77Dqoajwib3kWEnvzJF",
+    "title": "Rust for Solana Developers",
+    "slug": "rust-for-solana",
     "description": "Master Rust fundamentals tailored for Solana smart contract development. From ownership and borrowing to serialization, error handling, PDAs, and program architecture — build the skills to write native Solana programs.",
     "difficulty": "intermediate",
     "duration": 12,
+    "thumbnail": null,
+    "creator": "B7o8NfV81HzjuZFWQTTx3Xdvh77Dqoajwib3kWEnvzJF",
+    "tags": [
+      "borsh-serialization",
+      "pdas",
+      "rust",
+      "solana-programs"
+    ],
+    "xpReward": 800,
+    "trackId": 2,
+    "trackLevel": 1,
     "modules": [
       {
-        "description": "Learn Rust fundamentals essential for Solana development: ownership, borrowing, structs, enums, and pattern matching.",
         "key": "rust-basics",
+        "title": "Rust Basics",
+        "description": "Learn Rust fundamentals essential for Solana development: ownership, borrowing, structs, enums, and pattern matching.",
         "lessons": [
           {
             "_id": "lesson-why-rust",
-            "slug": "why-rust",
-            "title": "Why Rust for Solana"
+            "title": "Why Rust for Solana",
+            "slug": "why-rust"
           },
           {
             "_id": "lesson-ownership-borrowing",
-            "slug": "ownership-borrowing",
-            "title": "Ownership and Borrowing"
+            "title": "Ownership and Borrowing",
+            "slug": "ownership-borrowing"
           },
           {
             "_id": "lesson-structs-enums",
-            "slug": "structs-enums",
-            "title": "Structs and Enums for Solana"
+            "title": "Structs and Enums for Solana",
+            "slug": "structs-enums"
           },
           {
             "_id": "lesson-rust-basics-challenge",
-            "slug": "rust-basics-challenge",
-            "title": "Challenge: Rust Structs & Methods"
+            "title": "Challenge: Rust Structs & Methods",
+            "slug": "rust-basics-challenge"
           }
-        ],
-        "title": "Rust Basics"
+        ]
       },
       {
-        "description": "Apply Rust skills to blockchain concepts: serialization with Borsh, error handling patterns, and on-chain data management.",
         "key": "rust-blockchain",
+        "title": "Rust for Blockchain",
+        "description": "Apply Rust skills to blockchain concepts: serialization with Borsh, error handling patterns, and on-chain data management.",
         "lessons": [
           {
             "_id": "lesson-serialization",
-            "slug": "serialization",
-            "title": "Borsh Serialization for Solana"
+            "title": "Borsh Serialization for Solana",
+            "slug": "serialization"
           },
           {
             "_id": "lesson-serialization-challenge",
-            "slug": "serialization-challenge",
-            "title": "Challenge: Serialize Account Data"
+            "title": "Challenge: Serialize Account Data",
+            "slug": "serialization-challenge"
           },
           {
             "_id": "lesson-error-handling",
-            "slug": "error-handling",
-            "title": "Error Handling in Solana Programs"
+            "title": "Error Handling in Solana Programs",
+            "slug": "error-handling"
           },
           {
             "_id": "lesson-error-challenge",
-            "slug": "error-challenge",
-            "title": "Challenge: Transaction Validator"
+            "title": "Challenge: Transaction Validator",
+            "slug": "error-challenge"
           }
-        ],
-        "title": "Rust for Blockchain"
+        ]
       },
       {
-        "description": "Build native Solana programs: program structure, instruction processing, PDAs, and state management.",
         "key": "rust-programs",
+        "title": "Building Solana Programs",
+        "description": "Build native Solana programs: program structure, instruction processing, PDAs, and state management.",
         "lessons": [
           {
             "_id": "lesson-program-structure",
-            "slug": "program-structure",
-            "title": "Solana Program Structure"
+            "title": "Solana Program Structure",
+            "slug": "program-structure"
           },
           {
             "_id": "lesson-rust-program-challenge",
-            "slug": "rust-program-challenge",
-            "title": "Challenge: Process Transfer Instruction"
+            "title": "Challenge: Process Transfer Instruction",
+            "slug": "rust-program-challenge"
           },
           {
             "_id": "lesson-state-management",
-            "slug": "state-management",
-            "title": "PDAs and State Management"
+            "title": "PDAs and State Management",
+            "slug": "state-management"
           },
           {
             "_id": "lesson-pda-challenge",
-            "slug": "pda-challenge",
-            "title": "Challenge: Derive PDAs"
+            "title": "Challenge: Derive PDAs",
+            "slug": "pda-challenge"
           }
-        ],
-        "title": "Building Solana Programs"
+        ]
       }
-    ],
-    "slug": "rust-for-solana",
-    "tags": ["borsh-serialization", "pdas", "rust", "solana-programs"],
-    "thumbnail": null,
-    "title": "Rust for Solana Developers",
-    "trackId": 2,
-    "trackLevel": 1,
-    "xpReward": 800
+    ]
   },
   {
     "_id": "course-solana-frontend",
-    "creator": "B7o8NfV81HzjuZFWQTTx3Xdvh77Dqoajwib3kWEnvzJF",
+    "title": "Solana Frontend Development",
+    "slug": "solana-frontend",
     "description": "Build production-ready Solana dApp frontends. Master wallet integration, on-chain data reading, and interactive transaction UIs using React and the Solana Wallet Adapter.",
     "difficulty": "intermediate",
     "duration": 10,
-    "modules": [
-      {
-        "description": "Master Solana wallet integration using the Wallet Adapter. Learn to connect wallets, sign messages, and implement Sign-In With Solana (SIWS) authentication.",
-        "key": "wallet-integration",
-        "lessons": [
-          {
-            "_id": "lesson-wallet-adapter-intro",
-            "slug": "wallet-adapter-intro",
-            "title": "Solana Wallet Adapter Architecture"
-          },
-          {
-            "_id": "lesson-connect-wallet-challenge",
-            "slug": "connect-wallet-challenge",
-            "title": "Challenge: Wallet Connection Flow"
-          },
-          {
-            "_id": "lesson-signing-messages",
-            "slug": "signing-messages",
-            "title": "Sign-In With Solana (SIWS)"
-          },
-          {
-            "_id": "lesson-sign-message-challenge",
-            "slug": "sign-message-challenge",
-            "title": "Challenge: Build a SIWS Message"
-          }
-        ],
-        "title": "Wallet Integration"
-      },
-      {
-        "description": "Learn to read and parse on-chain data using Solana's RPC methods. Master account data deserialization and binary encoding patterns.",
-        "key": "reading-onchain",
-        "lessons": [
-          {
-            "_id": "lesson-rpc-methods",
-            "slug": "rpc-methods",
-            "title": "Solana RPC Methods"
-          },
-          {
-            "_id": "lesson-balance-checker-challenge",
-            "slug": "balance-checker-challenge",
-            "title": "Challenge: Multi-Wallet Balance Checker"
-          },
-          {
-            "_id": "lesson-parsing-data",
-            "slug": "parsing-data",
-            "title": "Parsing Account Data"
-          },
-          {
-            "_id": "lesson-parse-data-challenge",
-            "slug": "parse-data-challenge",
-            "title": "Challenge: Parse Account Data Buffer"
-          }
-        ],
-        "title": "Reading On-Chain Data"
-      },
-      {
-        "description": "Build production-ready dApp user interfaces. Master React patterns, transaction flows, and real-time notifications for Solana applications.",
-        "key": "dapp-ui",
-        "lessons": [
-          {
-            "_id": "lesson-react-patterns",
-            "slug": "react-patterns",
-            "title": "React Patterns for Solana dApps"
-          },
-          {
-            "_id": "lesson-transaction-ui",
-            "slug": "transaction-ui",
-            "title": "Transaction UI Patterns"
-          },
-          {
-            "_id": "lesson-notifications",
-            "slug": "notifications",
-            "title": "Transaction Notifications"
-          },
-          {
-            "_id": "lesson-dapp-challenge",
-            "slug": "dapp-challenge",
-            "title": "Challenge: SOL Transfer Form"
-          }
-        ],
-        "title": "Building dApp UIs"
-      }
-    ],
-    "slug": "solana-frontend",
+    "thumbnail": null,
+    "creator": "B7o8NfV81HzjuZFWQTTx3Xdvh77Dqoajwib3kWEnvzJF",
     "tags": [
       "account-model",
       "borsh-serialization",
@@ -530,102 +461,102 @@
       "wallet-adapter",
       "web3-frontend"
     ],
-    "thumbnail": null,
-    "title": "Solana Frontend Development",
+    "xpReward": 700,
     "trackId": 4,
     "trackLevel": 1,
-    "xpReward": 700
+    "modules": [
+      {
+        "key": "wallet-integration",
+        "title": "Wallet Integration",
+        "description": "Master Solana wallet integration using the Wallet Adapter. Learn to connect wallets, sign messages, and implement Sign-In With Solana (SIWS) authentication.",
+        "lessons": [
+          {
+            "_id": "lesson-wallet-adapter-intro",
+            "title": "Solana Wallet Adapter Architecture",
+            "slug": "wallet-adapter-intro"
+          },
+          {
+            "_id": "lesson-connect-wallet-challenge",
+            "title": "Challenge: Wallet Connection Flow",
+            "slug": "connect-wallet-challenge"
+          },
+          {
+            "_id": "lesson-signing-messages",
+            "title": "Sign-In With Solana (SIWS)",
+            "slug": "signing-messages"
+          },
+          {
+            "_id": "lesson-sign-message-challenge",
+            "title": "Challenge: Build a SIWS Message",
+            "slug": "sign-message-challenge"
+          }
+        ]
+      },
+      {
+        "key": "reading-onchain",
+        "title": "Reading On-Chain Data",
+        "description": "Learn to read and parse on-chain data using Solana's RPC methods. Master account data deserialization and binary encoding patterns.",
+        "lessons": [
+          {
+            "_id": "lesson-rpc-methods",
+            "title": "Solana RPC Methods",
+            "slug": "rpc-methods"
+          },
+          {
+            "_id": "lesson-balance-checker-challenge",
+            "title": "Challenge: Multi-Wallet Balance Checker",
+            "slug": "balance-checker-challenge"
+          },
+          {
+            "_id": "lesson-parsing-data",
+            "title": "Parsing Account Data",
+            "slug": "parsing-data"
+          },
+          {
+            "_id": "lesson-parse-data-challenge",
+            "title": "Challenge: Parse Account Data Buffer",
+            "slug": "parse-data-challenge"
+          }
+        ]
+      },
+      {
+        "key": "dapp-ui",
+        "title": "Building dApp UIs",
+        "description": "Build production-ready dApp user interfaces. Master React patterns, transaction flows, and real-time notifications for Solana applications.",
+        "lessons": [
+          {
+            "_id": "lesson-react-patterns",
+            "title": "React Patterns for Solana dApps",
+            "slug": "react-patterns"
+          },
+          {
+            "_id": "lesson-transaction-ui",
+            "title": "Transaction UI Patterns",
+            "slug": "transaction-ui"
+          },
+          {
+            "_id": "lesson-notifications",
+            "title": "Transaction Notifications",
+            "slug": "notifications"
+          },
+          {
+            "_id": "lesson-dapp-challenge",
+            "title": "Challenge: SOL Transfer Form",
+            "slug": "dapp-challenge"
+          }
+        ]
+      }
+    ]
   },
   {
     "_id": "course-solana-fundamentals",
-    "creator": "B7o8NfV81HzjuZFWQTTx3Xdvh77Dqoajwib3kWEnvzJF",
+    "title": "Solana Fundamentals",
+    "slug": "solana-fundamentals",
     "description": "A comprehensive beginner course covering the fundamentals of Solana blockchain development. Learn to set up your environment, create wallets, send transactions, and work with SPL tokens. Perfect for developers new to Solana who want to start building decentralized applications.",
     "difficulty": "beginner",
     "duration": 10,
-    "modules": [
-      {
-        "description": "Learn the fundamentals of Solana blockchain, set up your development environment, and configure your first wallet.",
-        "key": "getting-started",
-        "lessons": [
-          {
-            "_id": "lesson-intro-solana",
-            "slug": "what-is-solana",
-            "title": "What is Solana?"
-          },
-          {
-            "_id": "lesson-setup-environment",
-            "slug": "setup-environment",
-            "title": "Setting Up Your Development Environment"
-          },
-          {
-            "_id": "lesson-wallet-setup",
-            "slug": "wallet-setup",
-            "title": "Setting Up a Solana Wallet"
-          },
-          {
-            "_id": "lesson-keypair-challenge",
-            "slug": "keypair-challenge",
-            "title": "Challenge: Generate a Keypair"
-          }
-        ],
-        "title": "Getting Started with Solana"
-      },
-      {
-        "description": "Master Solana transactions, learn about SPL tokens, and build your first on-chain programs.",
-        "key": "transactions-tokens",
-        "lessons": [
-          {
-            "_id": "lesson-first-transaction",
-            "slug": "first-transaction",
-            "title": "Your First Transaction"
-          },
-          {
-            "_id": "lesson-transfer-challenge",
-            "slug": "transfer-challenge",
-            "title": "Challenge: Build a Transfer Function"
-          },
-          {
-            "_id": "lesson-token-overview",
-            "slug": "token-overview",
-            "title": "Understanding SPL Tokens"
-          },
-          {
-            "_id": "lesson-create-token-challenge",
-            "slug": "create-token-challenge",
-            "title": "Challenge: Create a Token Mint"
-          }
-        ],
-        "title": "Transactions & Tokens"
-      },
-      {
-        "description": "Deep dive into Solana's account model and program architecture. Learn how programs interact with accounts and build custom instructions.",
-        "key": "accounts-programs",
-        "lessons": [
-          {
-            "_id": "lesson-account-model",
-            "slug": "account-model",
-            "title": "Understanding Solana's Account Model"
-          },
-          {
-            "_id": "lesson-account-challenge",
-            "slug": "account-challenge",
-            "title": "Challenge: Explore the Account Model"
-          },
-          {
-            "_id": "lesson-programs-overview",
-            "slug": "programs-overview",
-            "title": "Introduction to Solana Programs"
-          },
-          {
-            "_id": "lesson-program-challenge",
-            "slug": "program-challenge",
-            "title": "Challenge: Build a Custom Instruction"
-          }
-        ],
-        "title": "Accounts & Programs"
-      }
-    ],
-    "slug": "solana-fundamentals",
+    "thumbnail": null,
+    "creator": "B7o8NfV81HzjuZFWQTTx3Xdvh77Dqoajwib3kWEnvzJF",
     "tags": [
       "account-model",
       "keypairs-wallets",
@@ -634,11 +565,92 @@
       "spl-tokens",
       "transactions"
     ],
-    "thumbnail": null,
-    "title": "Solana Fundamentals",
+    "xpReward": 600,
     "trackId": 1,
     "trackLevel": 1,
-    "xpReward": 600
+    "modules": [
+      {
+        "key": "getting-started",
+        "title": "Getting Started with Solana",
+        "description": "Learn the fundamentals of Solana blockchain, set up your development environment, and configure your first wallet.",
+        "lessons": [
+          {
+            "_id": "lesson-intro-solana",
+            "title": "What is Solana?",
+            "slug": "what-is-solana"
+          },
+          {
+            "_id": "lesson-setup-environment",
+            "title": "Setting Up Your Development Environment",
+            "slug": "setup-environment"
+          },
+          {
+            "_id": "lesson-wallet-setup",
+            "title": "Setting Up a Solana Wallet",
+            "slug": "wallet-setup"
+          },
+          {
+            "_id": "lesson-keypair-challenge",
+            "title": "Challenge: Generate a Keypair",
+            "slug": "keypair-challenge"
+          }
+        ]
+      },
+      {
+        "key": "transactions-tokens",
+        "title": "Transactions & Tokens",
+        "description": "Master Solana transactions, learn about SPL tokens, and build your first on-chain programs.",
+        "lessons": [
+          {
+            "_id": "lesson-first-transaction",
+            "title": "Your First Transaction",
+            "slug": "first-transaction"
+          },
+          {
+            "_id": "lesson-transfer-challenge",
+            "title": "Challenge: Build a Transfer Function",
+            "slug": "transfer-challenge"
+          },
+          {
+            "_id": "lesson-token-overview",
+            "title": "Understanding SPL Tokens",
+            "slug": "token-overview"
+          },
+          {
+            "_id": "lesson-create-token-challenge",
+            "title": "Challenge: Create a Token Mint",
+            "slug": "create-token-challenge"
+          }
+        ]
+      },
+      {
+        "key": "accounts-programs",
+        "title": "Accounts & Programs",
+        "description": "Deep dive into Solana's account model and program architecture. Learn how programs interact with accounts and build custom instructions.",
+        "lessons": [
+          {
+            "_id": "lesson-account-model",
+            "title": "Understanding Solana's Account Model",
+            "slug": "account-model"
+          },
+          {
+            "_id": "lesson-account-challenge",
+            "title": "Challenge: Explore the Account Model",
+            "slug": "account-challenge"
+          },
+          {
+            "_id": "lesson-programs-overview",
+            "title": "Introduction to Solana Programs",
+            "slug": "programs-overview"
+          },
+          {
+            "_id": "lesson-program-challenge",
+            "title": "Challenge: Build a Custom Instruction",
+            "slug": "program-challenge"
+          }
+        ]
+      }
+    ]
   },
   {
     "_id": "course-stablecoin-payments",
@@ -738,6 +750,146 @@
             "_id": "lesson-sap-submit-and-what-you-built",
             "title": "Submit It — and What You Built",
             "slug": "submit-and-what-you-built"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "_id": "course-rust-for-program-devs",
+    "title": "Rust for Program Developers",
+    "slug": "rust-for-program-devs",
+    "description": "You can read a Solana account's bytes. You cannot yet write the struct those bytes came from. You finish this course holding `vault_core.rs` — a `VaultState` with `owner`, `balance` and `bump`, `deposit` and `withdraw` built on `checked_add`/`checked_sub` so a `u64` can never silently wrap, a `VaultError` enum with four named variants, and not one `unwrap()` — compiled green against the real Anchor 1.x toolchain on our build server. Nothing is installed locally — no rustup, no cargo, no `.so` upload. Ownership, borrowing and lifetimes are taught here rather than deferred, because `Account<'info, Vault>` is unreadable without them. Your file deliberately carries no `#[program]` and no `#[derive(Accounts)]` — that omission is the handoff, and Course 3 is what wraps around it.",
+    "difficulty": "intermediate",
+    "duration": 12,
+    "thumbnail": null,
+    "creator": "B7o8NfV81HzjuZFWQTTx3Xdvh77Dqoajwib3kWEnvzJF",
+    "tags": [
+      "account-layout",
+      "anchor",
+      "borsh-serialization",
+      "build-server",
+      "checked-arithmetic",
+      "compiler-errors",
+      "debugging",
+      "error-handling",
+      "pdas",
+      "program-security",
+      "rust",
+      "rust-borrowing",
+      "rust-control-flow",
+      "rust-enums",
+      "rust-lifetimes",
+      "rust-modules",
+      "rust-move-semantics",
+      "rust-option",
+      "rust-ownership",
+      "rust-result",
+      "rust-slices",
+      "rust-structs",
+      "rust-traits",
+      "rust-types",
+      "toolchain-versions"
+    ],
+    "xpReward": 800,
+    "trackId": 1,
+    "trackLevel": 2,
+    "modules": [
+      {
+        "key": "rpd-rust-that-compiles",
+        "title": "Rust That Compiles",
+        "description": "Get a green build before learning any syntax, then meet exactly the types the vault needs — `u64` lamports, `u8` bump, `i64` timestamps — and the compiler's opinions about mutability, tail expressions and the missing `return`. You end holding a file of your own — two `const fn` helpers that add and subtract lamports and return `None` on overflow or underflow instead of wrapping or panicking, verified by compile-time assertions. That arithmetic becomes `VaultState::withdraw` nine lessons later.",
+        "lessons": [
+          {
+            "_id": "lesson-rpd-your-first-rust-build",
+            "title": "Your First Rust Build",
+            "slug": "your-first-rust-build"
+          },
+          {
+            "_id": "lesson-rpd-types-and-mutability",
+            "title": "Types, Mutability, and Why the Compiler Argues",
+            "slug": "types-and-mutability"
+          },
+          {
+            "_id": "lesson-rpd-functions-and-control-flow",
+            "title": "Functions, Expressions, and the Missing `return`",
+            "slug": "functions-and-control-flow"
+          },
+          {
+            "_id": "lesson-rpd-checked-lamport-math",
+            "title": "Checked Lamport Math",
+            "slug": "checked-lamport-math"
+          }
+        ]
+      },
+      {
+        "key": "rpd-ownership-borrowing-lifetimes",
+        "title": "Ownership, Borrowing, Lifetimes",
+        "description": "Moves, `Copy`, `.clone()`, shared versus mutable borrows, and lifetimes — taught against account-shaped signatures instead of toy strings, and with the compiler as the teacher. You read four real borrow-checker errors (E0382, E0502, E0499, and a reference outliving its local) and repair each one. You leave with three functions compiling in your own file — `balance_of(&VaultLike) -> u64`, `credit(&mut VaultLike, u64)` and `discriminator(&[u8]) -> Option<&[u8]>`, a real borrowed reader over Anchor's 8-byte discriminator. The first two are the exact method receivers you write in module 4, and the `'info` in `Account<'info, Vault>` stops being noise.",
+        "lessons": [
+          {
+            "_id": "lesson-rpd-moves-copy-and-clone",
+            "title": "Moves, Copy, and Clone",
+            "slug": "moves-copy-and-clone"
+          },
+          {
+            "_id": "lesson-rpd-borrowing-shared-vs-mutable",
+            "title": "Borrowing: `&T` and `&mut T`",
+            "slug": "borrowing-shared-vs-mutable"
+          },
+          {
+            "_id": "lesson-rpd-fix-the-borrow-checker",
+            "title": "Fix the Borrow Checker",
+            "slug": "fix-the-borrow-checker"
+          },
+          {
+            "_id": "lesson-rpd-lifetimes-and-slices",
+            "title": "Lifetimes and Slices",
+            "slug": "lifetimes-and-slices"
+          },
+          {
+            "_id": "lesson-rpd-ownership-checkpoint",
+            "title": "Checkpoint: Ownership",
+            "slug": "ownership-checkpoint"
+          }
+        ]
+      },
+      {
+        "key": "rpd-modeling-state",
+        "title": "Modeling State: Structs, Enums, Result",
+        "description": "The vault's data model, compiling. Define `VaultState` and hand-write one of the traits `#[derive]` would have generated, so the macro stops being magic and the byte layout stops being a mystery. Define `VaultError`, then add a fifth variant just to watch the compiler enumerate every site you failed to handle. Finally, replace panics with `Result` and let `?` carry errors up a chain of fallible functions, converting between error types on the way through.",
+        "lessons": [
+          {
+            "_id": "lesson-rpd-structs-traits-and-derives",
+            "title": "Structs, Traits, and What `#[derive]` Really Does",
+            "slug": "structs-traits-and-derives"
+          },
+          {
+            "_id": "lesson-rpd-enums-option-result",
+            "title": "Enums, `Option`, and `Result`",
+            "slug": "enums-option-result"
+          },
+          {
+            "_id": "lesson-rpd-error-plumbing",
+            "title": "Error Plumbing with `?`",
+            "slug": "error-plumbing"
+          }
+        ]
+      },
+      {
+        "key": "rpd-the-vault-core",
+        "title": "The Vault Core",
+        "description": "Write the whole core — `VaultState`, checked `deposit` and `withdraw`, `VaultError`, an inline `mod` and its `use` — first by completing a given skeleton, then from signatures alone against a fixed verification harness you are not allowed to edit. You close by rereading your own file line by line, mapping each line back to the lesson that produced it, and copying it out. `vault_core.rs` is the named input to Course 3.",
+        "lessons": [
+          {
+            "_id": "lesson-rpd-build-the-vault-core",
+            "title": "Build the Vault Core",
+            "slug": "build-the-vault-core"
+          },
+          {
+            "_id": "lesson-rpd-what-you-built",
+            "title": "What You Built",
+            "slug": "what-you-built"
           }
         ]
       }

--- a/apps/web/src/lib/content/__tests__/fixtures/golden/lessons.json
+++ b/apps/web/src/lib/content/__tests__/fixtures/golden/lessons.json
@@ -2010,7 +2010,15 @@
         "maxWords": null,
         "amount": null,
         "network": null,
-        "idl": null
+        "idl": null,
+        "tutorNotes": [
+          "Learners hit a mid-deploy failure and restart from zero, re-uploading chunks that already landed, instead of clicking Resume, which skips the confirmed ones.",
+          "They run out of devnet SOL partway through the 200+ upload transactions and read the abort as a code bug; the buffer and fees simply drained the wallet — fund it and Resume.",
+          "They deploy with the wallet or CLI pointed at the wrong cluster, so a devnet program seems to vanish when they look for it on mainnet, or the deploy fails against an unfunded network.",
+          "They rebuild after a failed deploy and expect the same Program ID; a fresh program keypair yields a new id, so they then search the explorer for the old one and find nothing.",
+          "They reject or ignore one of the batch-signing popups and treat the stalled upload as a crash, rather than approving the next batch so the chunks keep confirming.",
+          "They read the green build check as a finished deploy — building only produced the `.so`; the on-chain upload is the separate step happening here."
+        ]
       },
       {
         "key": "retrieval-close",
@@ -2523,7 +2531,14 @@
         "maxWords": null,
         "amount": null,
         "network": null,
-        "idl": null
+        "idl": null,
+        "tutorNotes": [
+          "Learners edit the starter to feel productive, but it already compiles unchanged; a broken build here is almost always a self-inflicted edit, and the fix is Reset Code, not a new one.",
+          "They read the slow first build (dependencies downloading) or a timeout as a real failure and give up, instead of simply clicking Build again as the hints say.",
+          "They expect a local `cargo build` on their own machine and are thrown that compilation runs on the build server through the sbf toolchain, not their terminal.",
+          "They treat a compiler warning as the error and chase it, missing that the build actually succeeded — a green check means the `.so` compiled and there is nothing to fix.",
+          "They take the green check to mean the program is deployed and live on devnet, and go hunting for it on-chain; building only produced a binary — deployment is a later lesson."
+        ]
       },
       {
         "key": "retrieval-close",
@@ -6008,7 +6023,7 @@
                 "feedback": "Solana Pay assumes a human is present to approve. Nobody is scanning a QR code inside a script's retry loop."
               }
             ],
-            "explanation": null
+            "explanation": "x402 is the only rail that needs no prior relationship with the payer: the price rides in the 402 response and is satisfied in the same request cycle. Delegations and subscriptions both require onboarding an account first, and Solana Pay assumes a human is present to approve — none of which an anonymous script has."
           },
           {
             "id": "q3",
@@ -6040,7 +6055,7 @@
                 "feedback": "No period carries. The cap is per period, full stop."
               }
             ],
-            "explanation": null
+            "explanation": "A recurring cap is a per-period ceiling, not a balance that accrues. Each period resets to the full cap and unused capacity from skipped periods is gone, so May allows 50 USDC and no more. If a business needs missed periods to be collectable, that is an invoice it builds in its own system."
           },
           {
             "id": "q4",
@@ -6154,7 +6169,7 @@
                 "feedback": "It does both. It selects the program AND it is a seed, so it moves the address."
               }
             ],
-            "explanation": null
+            "explanation": "The token program id is one of the ATA seeds (`[owner, tokenProgram, mint]`), so passing the legacy id for a Token-2022 mint derives a real but wrong address — and because derivation is pure math over seeds and never reads the mint, nothing catches the mismatch. A transfer there goes nowhere useful. Derive with the mint's actual owning program."
           },
           {
             "id": "q2",
@@ -6186,7 +6201,7 @@
                 "feedback": "Interest accrual is an exchange-rate mechanism, not a transfer fee. Different extension, different error."
               }
             ],
-            "explanation": null
+            "explanation": "The rail vetoes on what the mint carries, not on which extension you meant to use, and one disqualifying extension is enough: `MINT_HAS_PERMANENT_DELEGATE` fires regardless of the interest-bearing intent. A user-revocable allowance is meaningless when the mint authority already holds an irrevocable permanent delegate."
           },
           {
             "id": "q3",
@@ -6218,7 +6233,7 @@
                 "feedback": "Extensions are configured at mint creation. Choosing the program early does not let you add one later, so this buys nothing and costs the check."
               }
             ],
-            "explanation": null
+            "explanation": "The rule is legacy Token by default; Token-2022 is justified only by a capability you need now — a named extension the rail accepts, or a compliance transfer-hook whose rail you have verified resolves hook accounts on your path. \"Newer\" and \"might want one later\" are not grounds: extensions are fixed at mint creation, so choosing the program early buys nothing and still costs the compatibility check."
           },
           {
             "id": "q4",
@@ -6250,7 +6265,7 @@
                 "feedback": "Patches still float. `^0.9.0` accepts `0.9.7`; it stops at `0.10.0`."
               }
             ],
-            "explanation": null
+            "explanation": "This is the Course 4 semver rule: below `1.0.0` the minor is the breaking position, so a caret pins it. `^0.9.0` means `>=0.9.0 <0.10.0` — patches like `0.9.7` still float, but `0.15.0` is out of range. A lockfile only pins what already resolved; it never widens a range that never admitted `0.15.0`."
           },
           {
             "id": "q5",
@@ -6282,7 +6297,7 @@
                 "feedback": "Plan-related failures come back as `PLAN_*` constants (`PLAN_EXPIRED`, `PLAN_TERMS_MISMATCH`, and so on)."
               }
             ],
-            "explanation": null
+            "explanation": "Reading the decoded constant is the Course 4 skill: the program names the model in the error. `...AMOUNT_EXCEEDS_PERIOD_LIMIT` (\"Transfer amount exceeds period limit\") is the recurring-delegation cap; the fixed model raises `AMOUNT_EXCEEDS_LIMIT` and plans raise `PLAN_*`. The constant tells you which cap you hit without guessing."
           }
         ],
         "prompt": null,
@@ -6526,7 +6541,7 @@
                 "feedback": "Tearing down an authority and invalidating its delegations is what `closeSubscriptionAuthority` is for, and it is deliberate. `init` does not silently do it."
               }
             ],
-            "explanation": null
+            "explanation": "The SubscriptionAuthority PDA is derived from `(user, tokenMint)`, so a returning user already has one and calling `init` on an account that exists fails — leaving them worse off than a newcomer. Read first with a `fetchMaybe*` and branch on its `exists` discriminant; nothing here is idempotent by convenience."
           },
           {
             "id": "q2",
@@ -6558,7 +6573,7 @@
                 "feedback": "`amount` is the cap. The balance is a separate constraint that also has to hold."
               }
             ],
-            "explanation": null
+            "explanation": "Every amount in this API is base units — there is no decimals scaling anywhere — so `amount: 25n` caps the delegation at 25 base units, 0.000025 USDC, and the first real charge fails with `AMOUNT_EXCEEDS_LIMIT`. Convert human amounts to base units once, in one function, so the mistake cannot recur."
           },
           {
             "id": "q3",
@@ -6590,7 +6605,7 @@
                 "feedback": "Nothing renews. Renewal is a new `createFixedDelegation` with a new nonce, signed by the user."
               }
             ],
-            "explanation": null
+            "explanation": "Expiry is enforced on the transfer, not just at creation, so a delegation 40 seconds past `expiryTs` fails with `DELEGATION_EXPIRED` — no grace window, no auto-renewal. Renewal is a new `createFixedDelegation` with a new nonce that the user signs; if a product wants a grace period, the product builds it."
           },
           {
             "id": "q4",
@@ -6622,7 +6637,7 @@
                 "feedback": "The authority is the SPL delegate and the program signs for it, but the transaction still needs an authorised human or service to sign — and that is the delegatee."
               }
             ],
-            "explanation": null
+            "explanation": "The types are the answer: `delegatee` is a `TransactionSigner` and `delegator` is a plain `Address`, so only the delegatee signs the charge. The user consented once at setup and is not present per-pull; their protection is the cap, the expiry and the revoke, not a signature on every transfer."
           },
           {
             "id": "q5",
@@ -6817,7 +6832,7 @@
                 "feedback": "The program does not silently rewrite your amount. It refuses the instruction."
               }
             ],
-            "explanation": null
+            "explanation": "The per-period cap is also your idempotency guard. Once 25 USDC is pulled, a second pull in the same period fails with `AMOUNT_EXCEEDS_PERIOD_LIMIT` — read that as \"already collected\" and stop. Retrying treats a charge that already landed as a transient failure, which is how you would double-bill."
           },
           {
             "id": "q2",
@@ -6881,7 +6896,7 @@
                 "feedback": "The delegatee cannot change the terms. Extending means a new delegation with a new nonce, signed by the user — which means the user consents again."
               }
             ],
-            "explanation": null
+            "explanation": "An unattended service holds the delegatee key and nothing more: it can pull up to the cap each period and cannot touch the terms. Setup and revoke are signed by the user (the delegator); changing `expiryTs` means a new delegation the user signs again. That split is exactly why the delegatee key is safe to leave running unattended."
           },
           {
             "id": "q4",
@@ -6913,7 +6928,7 @@
                 "feedback": "`DELEGATION_NOT_STARTED` is real, and it is what you get from a `startTs` in the future. This case fails earlier, at creation."
               }
             ],
-            "explanation": null
+            "explanation": "`startTs: 0n` means \"start when this lands\", which is only allowed when paired with a bounded, non-zero expiry. Combined with `expiryTs: 0n` (\"never expire\") it is the least-bounded authorisation the program could issue, so it is rejected at creation — not later, at transfer time."
           },
           {
             "id": "q5",
@@ -6945,7 +6960,7 @@
                 "feedback": "Each delegation is its own PDA under the shared authority — that is the whole point. Revoking all of them at once is `closeSubscriptionAuthority`, and it is a separate, deliberate kill switch."
               }
             ],
-            "explanation": null
+            "explanation": "`revokeDelegation` closes that one delegation's PDA and returns its rent, and because each delegation is its own PDA under the shared authority the user's others are untouched. There is no pause in this model — re-establishing means a fresh `createRecurringDelegation` with a new nonce, signed by the user, so consent is given again."
           }
         ],
         "prompt": null,
@@ -8599,6 +8614,3163 @@
               }
             ],
             "explanation": "The single most common first-publish failure, and the reason to pre-empt it rather than debug it in front of a bounty deadline."
+          }
+        ],
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      }
+    ]
+  },
+  {
+    "_id": "lesson-rpd-borrowing-shared-vs-mutable",
+    "title": "Borrowing: `&T` and `&mut T`",
+    "slug": "borrowing-shared-vs-mutable",
+    "blocks": [
+      {
+        "key": "intro",
+        "_type": "prose",
+        "produces": null,
+        "consumes": null,
+        "src": "# Borrowing: `&T` and `&mut T`\n\n> **Version stamp — checked 2026-07-26.** `anchor-lang 1.1.2` (crates.io latest stable) · `borsh` 1.5.7 declared / **1.8.0** resolved · edition 2021 · Agave ≥ 3.1.10 / rustc per the build server's pinned platform-tools.\n\nMoving a value into a function and getting it back out is unbearable. Real code needs to look at a vault without consuming it, and change a vault without rebuilding it. That is borrowing, and there are exactly two kinds.\n\n| | Written | How many at once | What it grants |\n| --- | --- | --- | --- |\n| **Shared borrow** | `&VaultLike` | Any number | Read every field |\n| **Mutable borrow** | `&mut VaultLike` | Exactly one | Read and write every field |\n\nAnd the rule that connects them: **while a mutable borrow is alive, no other borrow of that value may exist — shared or mutable.** Many readers, or one writer. Never both.\n\nThis is the same invariant as the runtime's account locks from Course 1. A transaction declares each account as readonly or writable, and the scheduler will not run two transactions that write the same account concurrently. Rust applies that rule to a value inside your function, at compile time, for free. The reason you are learning it here rather than in Course 3 is that `&mut Account<'info, Vault>` is unreadable until this table is boring.\n\n## Two signatures, and they are the ones you keep\n\n```rust\npub fn balance_of(v: &VaultLike) -> u64;\npub fn credit(v: &mut VaultLike, amount: u64);\n```\n\nRead them out loud as promises to the caller. The first says: *I will look and I will not touch, and you keep your vault.* The second says: *for the duration of this call the vault is mine alone, and then you get it back changed.*\n\nIn module 4 these become methods and the receiver moves to the front, which is the only difference:\n\n```rust\nimpl VaultState {\n    pub fn balance(&self) -> u64;\n    pub fn deposit(&mut self, amount: u64) -> Result<()>;\n}\n```\n\n`&self` is `&VaultState`. `&mut self` is `&mut VaultState`. There is no third thing to learn later.\n\n## `mut` in two places, meaning two things\n\n```rust\nlet mut vault = sample_vault();   // (1) this BINDING may be reassigned or mutated\ncredit(&mut vault, 1_000);        // (2) hand out an exclusive borrow\n```\n\n`let mut` is about the variable you own. `&mut` is about the loan you give away. A caller needs (1) before it can produce (2) — you cannot lend out write access to something you were not allowed to write yourself.\n\n## When does a borrow end?\n\nHere is where most \"why is this still borrowed?\" confusion comes from. Since the 2018 edition, a borrow ends **at its last use**, not at the closing brace of the block. This is called non-lexical lifetimes, and it is why this compiles:\n\n```rust\nlet mut vault = sample_vault();\nlet before = balance_of(&vault);   // shared borrow starts and ends on this line\ncredit(&mut vault, 1_000);         // fine — nothing is borrowed any more\n```\n\nand why the near-identical version below does **not**:\n\n```rust\nlet mut vault = sample_vault();\nlet before = &vault.balance;       // shared borrow starts …\ncredit(&mut vault, 1_000);         // … mutable borrow while it is alive\nmsg!(\"{}\", before);                // … and it is used AFTER, so it is still alive here\n```\n\nDelete that last line and the second version compiles too. The borrow was never a problem in itself — holding it *across* the mutation was. A great deal of Rust advice written before 2018 tells you borrows run to end of scope. It is out of date, and following it makes you write scopes and `drop()` calls you do not need.\n\nThe fix in the first version is worth naming, because it is the payoff from the previous lesson: `balance_of` returns a `u64` **by value**. `u64` is `Copy`, so you hold a number, not a loan, and there is nothing left to conflict with.\n\n## One honest gap\n\n`credit` has no way to report failure. Its return type is `()`.\n\nSo when `add_lamports` hands back `None` — the addition would have wrapped a `u64` — the only thing this version can do is leave the balance untouched and say nothing. **That is not acceptable in a program.** A deposit that silently does nothing is a support ticket at best and an exploit at worst.\n\nIt is a deliberate placeholder, and closing it is what module 3 is for: `credit` grows a `-> Result<()>`, the `None` arm becomes `err!(VaultError::Overflow)`, and the caller is forced by the compiler to deal with it. Write the placeholder now, know that it is one, and do not carry the pattern into anything real.\n\n## Three subgoals\n\nThe exercise ships three numbered subgoals as comment headers. The first is done for you as a worked reference; you write the second and third. Read all three headers before you start — the third one is the borrow-checker lesson, and knowing it is coming changes how you write the second.\n\nThe file does not build as delivered: each unwritten body carries a `compile_error!` naming its subgoal, so your first build is a to-do list rather than a green tick. Delete each one along with the `todo!()` beneath it.\n\nA note on what the grader can see. The build server checks that your file **compiles**; it does not run your functions. The `mod verify` block at the bottom is not editable and pins all three functions to their exact signatures, borrows included — rename one, or take `VaultLike` by value instead of by reference, and the build stops. That is a check on names and types only. Nothing verifies that `credit` adds rather than subtracts.\n\nNothing verifies subgoal 3's ordering either, and it is worth being exact about why, because the temptation is to assume the borrow checker has your back here. It does not. `E0502` fires for **one specific shape**: holding `&v.balance` across the call to `credit` and then using it afterwards. The spec tells you not to write that — bind the `u64` by value instead — and once you do, there is no borrow left for the checker to have an opinion about. Write `credit(v, …)` first and read the balance second and the file compiles clean.\n\nSo the compile-time guarantee here is narrow and real: *if* you hold a reference across a mutation, you are stopped. The wider thing — that the read happens before the write — is checked by you. Which is the honest version of every exercise in this course, and the reason lesson 9 spends a whole lesson on diagnosing code you have not built.\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "exercise",
+        "_type": "code",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": "rust",
+        "buildType": "buildable",
+        "deployable": false,
+        "starter": "// ---------------------------------------------------------------------------\n// Lesson 6 — Borrowing: &T and &mut T.\n//\n// Three numbered subgoals below. Subgoal 1 is done for you as a reference;\n// you write 2 and 3. Replace each `todo!()` — it is a placeholder that panics,\n// and nothing that panics belongs in a finished program.\n//\n// As shipped this file does NOT build. Each unwritten body carries a\n// `compile_error!` line whose message names the subgoal it belongs to, so the\n// first build tells you exactly what is outstanding. Delete that line together\n// with the `todo!()` under it when you write the body. This is deliberate:\n// `todo!()` alone type-checks fine, so a file full of them would compile green\n// and tell you nothing.\n//\n// Toolchain: anchor-lang 1.1.2 (declared) · borsh 1.5.7 declared / 1.8.0\n// resolved · edition 2021.\n// ---------------------------------------------------------------------------\n\nuse anchor_lang::prelude::*;\n\n#[derive(Clone, Debug)]\npub struct VaultLike {\n    pub owner: Pubkey,\n    pub balance: u64,\n    pub bump: u8,\n}\n\npub fn sample_vault() -> VaultLike {\n    VaultLike {\n        owner: Pubkey::default(),\n        balance: 500_000,\n        bump: 254,\n    }\n}\n\n// Carried forward from lesson 4, unchanged — same names, same parameter names,\n// same signatures. `None` means the operation would have wrapped a u64, which is\n// the failure the whole course exists to prevent.\npub const fn add_lamports(balance: u64, amount: u64) -> Option<u64> {\n    balance.checked_add(amount)\n}\n\npub const fn sub_lamports(balance: u64, amount: u64) -> Option<u64> {\n    balance.checked_sub(amount)\n}\n\n// ===== Subgoal 1 of 3 — read through a shared borrow =======================\n//\n// DONE FOR YOU. Read it before you write anything else.\n//\n// `&VaultLike` is a shared borrow: read access to every field, no write access,\n// and the caller keeps the vault. The return type is `u64` BY VALUE, not\n// `&u64` — `u64` is `Copy`, so the caller walks away holding a number rather\n// than a loan. That choice is what makes subgoal 3 possible.\npub fn balance_of(v: &VaultLike) -> u64 {\n    v.balance\n}\n\n// ===== Subgoal 2 of 3 — write through a mutable borrow =====================\n//\n// YOUR CODE. Add `amount` to the vault's balance.\n//\n//   - `&mut VaultLike` is exclusive: for the duration of this call nothing else\n//     may read or write this vault.\n//   - Use `add_lamports`, not `+`. Never let a u64 wrap.\n//   - `add_lamports` returns `Option<u64>`. Handle BOTH arms with `match` or\n//     `if let`. On `Some(new_balance)`, store it. On `None`, leave the balance\n//     exactly as it was — this function has no way to report a failure, which\n//     is a known gap that module 3 closes with `Result`.\npub fn credit(v: &mut VaultLike, amount: u64) {\n    compile_error!(\"Subgoal 2 of 3 is not written yet: give `credit` a body that adds `amount` via `add_lamports` and handles both arms. Delete this line and the `todo!()` below it.\");\n    todo!()\n}\n\n// ===== Subgoal 3 of 3 — read, then write, without overlapping =============\n//\n// YOUR CODE. Raise the balance up to `target` and return how much you added.\n// If the balance already meets or exceeds `target`, add nothing and return 0.\n//\n// The order matters. The borrow checker will only tell you so if you write step 1\n// the wrong way — see the note under step 4:\n//\n//   1. Get the current balance. Call `balance_of(v)` and bind the u64 it\n//      returns. Do NOT write `let before = &v.balance;` — see the note below.\n//   2. Compute the shortfall with `sub_lamports(target, current)`. On `None`\n//      (target is below the current balance) the answer is 0.\n//   3. Call `credit(v, shortfall)`. This needs the mutable borrow, and it can\n//      only have it if step 1 is finished with the vault.\n//   4. Return the shortfall.\n//\n// Note for step 1: `&v.balance` would hold a shared borrow, and step 3 needs an\n// exclusive one. Whether that is an error depends on whether the shared borrow\n// is still used after step 3 — a borrow ends at its LAST USE, not at the\n// closing brace. Binding the u64 by value sidesteps the question entirely.\n//\n// Which means: once you follow that advice, nothing enforces the order. Writing\n// step 3 before step 1 compiles clean. The order is correct because a transfer\n// has to read before it commits, not because rustc made you.\npub fn top_up_to(v: &mut VaultLike, target: u64) -> u64 {\n    compile_error!(\"Subgoal 3 of 3 is not written yet: read the balance, compute the shortfall, credit it, return it. Delete this line and the `todo!()` below it.\");\n    todo!()\n}\n\n// ===== Given: a caller, so you can see the shapes meet ====================\n//\n// Note `let mut` on the binding. Without it you could not produce `&mut vault`\n// on the following line — you cannot lend out write access you do not have.\npub fn demo() -> (u64, u64) {\n    let mut vault = sample_vault();\n\n    let added = top_up_to(&mut vault, 750_000);\n    let now = balance_of(&vault);\n\n    (added, now) // expect (250_000, 750_000)\n}\n\n// ── DO NOT EDIT ──────────────────────────────────────────────────────────────\n// Pins the three functions above to their exact signatures. If one is renamed,\n// or a borrow turns into a by-value parameter, or a return type drifts, this\n// stops compiling.\n//\n// It checks names and types — NOT what your bodies compute. It cannot tell\n// `add_lamports` from `sub_lamports`, and it cannot see whether subgoal 3 reads\n// before it writes either. The borrow checker catches exactly one wrong shape —\n// holding `&v.balance` across `credit` and using it afterwards, which is E0502.\n// Read the balance by value, as the spec says, and there is no borrow left to\n// complain about: writing first and reading second compiles clean. The ordering\n// is on you.\n#[allow(dead_code)]\nmod verify {\n    use super::*;\n\n    const _BALANCE_OF: fn(&VaultLike) -> u64 = balance_of;\n    const _CREDIT: fn(&mut VaultLike, u64) = credit;\n    const _TOP_UP_TO: fn(&mut VaultLike, u64) -> u64 = top_up_to;\n}\n",
+        "solution": "// ---------------------------------------------------------------------------\n// Lesson 6 — Borrowing: &T and &mut T.\n//\n// Reference solution. All three subgoals filled in.\n//\n// Toolchain: anchor-lang 1.1.2 (declared) · borsh 1.5.7 declared / 1.8.0\n// resolved · edition 2021.\n// ---------------------------------------------------------------------------\n\nuse anchor_lang::prelude::*;\n\n#[derive(Clone, Debug)]\npub struct VaultLike {\n    pub owner: Pubkey,\n    pub balance: u64,\n    pub bump: u8,\n}\n\npub fn sample_vault() -> VaultLike {\n    VaultLike {\n        owner: Pubkey::default(),\n        balance: 500_000,\n        bump: 254,\n    }\n}\n\n// Carried forward from lesson 4, unchanged — same names, same parameter names,\n// same signatures. `None` means the operation would have wrapped a u64, which is\n// the failure the whole course exists to prevent.\npub const fn add_lamports(balance: u64, amount: u64) -> Option<u64> {\n    balance.checked_add(amount)\n}\n\npub const fn sub_lamports(balance: u64, amount: u64) -> Option<u64> {\n    balance.checked_sub(amount)\n}\n\n// ===== Subgoal 1 of 3 — read through a shared borrow =======================\n//\n// DONE FOR YOU. Read it before you write anything else.\n//\n// `&VaultLike` is a shared borrow: read access to every field, no write access,\n// and the caller keeps the vault. The return type is `u64` BY VALUE, not\n// `&u64` — `u64` is `Copy`, so the caller walks away holding a number rather\n// than a loan. That choice is what makes subgoal 3 possible.\npub fn balance_of(v: &VaultLike) -> u64 {\n    v.balance\n}\n\n// ===== Subgoal 2 of 3 — write through a mutable borrow =====================\n//\n// `&mut` grants write access to every field, so `v.balance = …` is legal here\n// and would not be legal through `&VaultLike`.\n//\n// `if let Some(x) = …` is `match` with one arm named and the other ignored. The\n// ignored arm is the honest gap: on overflow the balance is left as it was and\n// nobody is told. Module 3 turns that arm into `err!(VaultError::Overflow)`.\npub fn credit(v: &mut VaultLike, amount: u64) {\n    if let Some(new_balance) = add_lamports(v.balance, amount) {\n        v.balance = new_balance;\n    }\n}\n\n// ===== Subgoal 3 of 3 — read, then write, without overlapping =============\n//\n// `balance_of(v)` takes `&*v` — a shared reborrow of the exclusive borrow you\n// were handed — and returns a `u64` by value. The reborrow is over by the end\n// of the line, so `credit(v, …)` gets its exclusive access with nothing to\n// argue about.\n//\n// Had step 1 been `let current = &v.balance;`, the shared borrow would still be\n// alive at step 3 only if something used it afterwards. Holding a `Copy` value\n// instead of a reference removes the question from the code entirely, which is\n// the reason `balance_of` returns `u64` and not `&u64`.\n//\n// And note what that costs: with no borrow held, nothing stops you writing the\n// two statements the other way round. `credit(v, 1); let current = balance_of(v);`\n// compiles perfectly well. The order below is correct because it is the order a\n// transfer has to happen in, not because the compiler insisted.\npub fn top_up_to(v: &mut VaultLike, target: u64) -> u64 {\n    let current = balance_of(v);\n\n    let shortfall = match sub_lamports(target, current) {\n        Some(gap) => gap,\n        None => 0, // already at or above target\n    };\n\n    credit(v, shortfall);\n    shortfall\n}\n\n// ===== Given: a caller, so you can see the shapes meet ====================\n//\n// Note `let mut` on the binding. Without it you could not produce `&mut vault`\n// on the following line — you cannot lend out write access you do not have.\npub fn demo() -> (u64, u64) {\n    let mut vault = sample_vault();\n\n    let added = top_up_to(&mut vault, 750_000);\n    let now = balance_of(&vault);\n\n    (added, now) // expect (250_000, 750_000)\n}\n\n// ── DO NOT EDIT ──────────────────────────────────────────────────────────────\n// Pins the three functions above to their exact signatures. If one is renamed,\n// or a borrow turns into a by-value parameter, or a return type drifts, this\n// stops compiling.\n//\n// It checks names and types — NOT what your bodies compute. It cannot tell\n// `add_lamports` from `sub_lamports`, and it cannot see whether subgoal 3 reads\n// before it writes either. The borrow checker catches exactly one wrong shape —\n// holding `&v.balance` across `credit` and using it afterwards, which is E0502.\n// Read the balance by value, as the spec says, and there is no borrow left to\n// complain about: writing first and reading second compiles clean. The ordering\n// is on you.\n#[allow(dead_code)]\nmod verify {\n    use super::*;\n\n    const _BALANCE_OF: fn(&VaultLike) -> u64 = balance_of;\n    const _CREDIT: fn(&mut VaultLike, u64) = credit;\n    const _TOP_UP_TO: fn(&mut VaultLike, u64) -> u64 = top_up_to;\n}\n",
+        "tests": [
+          {
+            "id": "test-1",
+            "description": "The file compiles against anchor-lang 1.1.2 on the build server",
+            "input": "",
+            "expectedOutput": "true"
+          },
+          {
+            "id": "test-2",
+            "description": "Compiles ⇒ both unwritten bodies were replaced: the shipped starter carries a `compile_error!` per subgoal, so a file that still has one cannot build",
+            "input": "",
+            "expectedOutput": "true"
+          },
+          {
+            "id": "test-3",
+            "description": "Compiles ⇒ the non-editable `mod verify` block resolves: balance_of, credit and top_up_to exist with the exact declared signatures, borrows included. Note what this cannot see: it checks names and types, not what a body computes",
+            "input": "",
+            "expectedOutput": "true"
+          }
+        ],
+        "hints": [
+          "Subgoal 2 is four lines. `if let Some(new_balance) = add_lamports(v.balance, amount) { … }` — and the `None` case is deliberately nothing at all.",
+          "Subgoal 3, step 1: `let current = balance_of(v);`. You are passing the `&mut` where a `&` is expected, which Rust does for you as a reborrow. Bind the `u64` it returns — do not bind `&v.balance`.",
+          "Subgoal 3, step 2: `match sub_lamports(target, current) { Some(gap) => gap, None => 0 }`. `sub_lamports` returning `None` means `target` is below the current balance, so there is nothing to add."
+        ],
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "check",
+        "_type": "quiz",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": [
+          {
+            "id": "q1",
+            "prompt": "You write `let before = &v.balance;`, then `credit(v, 1_000);`, then `return *before;`. Predict the compiler's verdict — and what changes if you delete the last line.",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "`E0502` as written; deleting the last line makes it compile, because a borrow ends at its last use",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "`E0502` either way — the shared borrow lives until the closing brace of the function",
+                "correct": false,
+                "feedback": "That was true before the 2018 edition, and a lot of surviving blog posts still say it. Non-lexical lifetimes end a borrow at its last use, which is why removing the use removes the conflict."
+              },
+              {
+                "id": "c",
+                "label": "Compiles as written — `before` is a `&u64`, and one shared borrow plus one mutable borrow is the allowed combination",
+                "correct": false,
+                "feedback": "It is the forbidden combination. Any number of shared borrows, or exactly one mutable borrow, never a mix — that is the whole rule."
+              },
+              {
+                "id": "d",
+                "label": "Compiles, and `*before` reads the balance from before the credit",
+                "correct": false,
+                "feedback": "This is the bug the rule exists to prevent — a reference that silently shows you stale data after a mutation. Rust does not let the reference survive the mutation, so there is no stale read to have."
+              }
+            ],
+            "explanation": "The message is worth memorising: \"cannot borrow `*v` as mutable because it is also borrowed as immutable\". It names the mutable borrow as the offender, but the fix almost always belongs to the shared one."
+          },
+          {
+            "id": "q2",
+            "prompt": "Someone writes `pub fn zero_out(v: &VaultLike) { v.balance = 0; }`. Predict what happens.",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "`E0594` — cannot assign to `v.balance`, which is behind a `&` reference",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "Compiles — the reference is shared, but the field is a plain `u64`",
+                "correct": false,
+                "feedback": "What the field's type is does not matter. `&T` grants read access and nothing else, all the way down."
+              },
+              {
+                "id": "c",
+                "label": "Compiles if the parameter is declared `v: &mut VaultLike` at the call site",
+                "correct": false,
+                "feedback": "A call site cannot upgrade a shared borrow to an exclusive one. The signature is the promise, and this one promised not to write."
+              },
+              {
+                "id": "d",
+                "label": "`E0596` — cannot borrow as mutable, as it is not declared as mutable",
+                "correct": false,
+                "feedback": "Close but a different failure. `E0596` is what you get when you try to take `&mut` of a binding declared without `let mut`. Here nothing is being borrowed — an assignment is being attempted through a reference that forbids it."
+              }
+            ],
+            "explanation": null
+          },
+          {
+            "id": "q3",
+            "prompt": "Inside `fn f(v: &mut VaultLike)` you write `let b = &mut v.balance;` and on the next line `let p = &mut v.bump;`, then use both. Predict the verdict.",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "Compiles — the two borrows are of different fields, and the borrow checker tracks fields separately",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "`E0499` — two mutable borrows of `v` cannot coexist",
+                "correct": false,
+                "feedback": "You did not borrow `v` twice; you borrowed two disjoint pieces of it. `E0499` fires when the two borrows genuinely overlap — for example `&mut v.balance` twice."
+              },
+              {
+                "id": "c",
+                "label": "Compiles only if you wrap each borrow in its own block",
+                "correct": false,
+                "feedback": "Blocks are the workaround for borrows that really do overlap. These do not, so no scoping trick is needed."
+              },
+              {
+                "id": "d",
+                "label": "`E0502` — a mutable borrow of a field implies a shared borrow of the whole struct",
+                "correct": false,
+                "feedback": "It does not. Borrowing a field borrows that field's place, which is precisely what makes ordinary struct-mutating code writable without fighting the compiler."
+              }
+            ],
+            "explanation": "Worth knowing early because it removes a class of imagined restrictions. The checker is more precise than the summary rule suggests, and the summary rule is about a single place, not a whole value."
+          },
+          {
+            "id": "q4",
+            "prompt": "Carried over from the previous lesson. You write `let vault = sample_vault();` and then `credit(&mut vault, 1_000);`. Predict what the compiler says.",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "`E0596` — cannot borrow `vault` as mutable, as it is not declared as mutable",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "Compiles — `&mut` at the call site is all that is needed to get write access",
+                "correct": false,
+                "feedback": "You cannot lend out write access you were never granted. `let mut` on the binding is what grants it; `&mut` at the call site is what passes it on."
+              },
+              {
+                "id": "c",
+                "label": "`E0382` — `&mut vault` moves the vault into `credit`",
+                "correct": false,
+                "feedback": "A mutable borrow is a loan, not a move. `credit` gives the vault back when it returns, which is exactly why the signature is `&mut VaultLike` and not `VaultLike`."
+              },
+              {
+                "id": "d",
+                "label": "Compiles, but `credit` mutates a temporary copy and the caller sees no change",
+                "correct": false,
+                "feedback": "There is no hidden copy. That is JavaScript's pass-a-primitive behaviour; a Rust `&mut` points at the caller's own value, and silently copying instead would be a language bug."
+              }
+            ],
+            "explanation": null
+          }
+        ],
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      }
+    ]
+  },
+  {
+    "_id": "lesson-rpd-build-the-vault-core",
+    "title": "Build the Vault Core",
+    "slug": "build-the-vault-core",
+    "blocks": [
+      {
+        "key": "spec",
+        "_type": "prose",
+        "produces": null,
+        "consumes": null,
+        "src": "# Build the Vault Core\n\n> **Version stamp — checked 2026-07-26.** `anchor-lang 1.1.2` (published 2026-06-26, latest on crates.io) · `borsh` resolves to **1.8.0** from the manifest's `borsh = \"1.5.7\"` · edition 2021 · Agave ≥ 3.1.10 · rustc 1.89+. Both exercises below were compiled clean against exactly that manifest on that date.\n\nTwelve lessons of parts. This is the assembly.\n\nYou have already written every piece of this file, each one somewhere else: `checked_sub` returning `None` in lesson 4, a `&mut self` receiver in lesson 6, a `#[derive]`d struct in lesson 10, a `#[error_code]` enum in lesson 11, `?` carrying an error up a chain in lesson 12. What you have not done is put them in one file and hand it to the build server.\n\nYou do it twice. The first exercise gives you the struct, the enum and the two method signatures, and scrambles the seven lines that go inside them — five belong, two do not. The second gives you this spec, a `mod vault` with nothing in it, and a verification harness you may not edit.\n\n## The spec\n\n`declare_id!` first, because it is the one line that looks optional and is not.\n\n```rust\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n```\n\nThat address is a placeholder — Course 3 replaces it with the program id of your own deployment. It has to be there today anyway: `#[account]` expands to an `impl Owner for VaultState` whose body reads `crate::ID`, and `declare_id!` is what defines `ID`. Delete the line and the compiler does not complain about the missing macro. It complains at your struct:\n\n```\nerror[E0425]: cannot find value `ID` in the crate root\n```\n\nWhich is a nice illustration of how macro-generated code fails: the error lands where the expansion happened, not where you made the mistake.\n\nThen the state, the errors and the two methods.\n\n| Item        | Exactly                                                                                                                |\n| ----------- | ---------------------------------------------------------------------------------------------------------------------- |\n| **Module**  | `pub mod vault { … }` — everything below lives inside it, and is re-exported from the crate root                        |\n| **State**   | `#[account]` + `#[derive(InitSpace)]` on `pub struct VaultState { pub owner: Pubkey, pub balance: u64, pub bump: u8 }`  |\n| **Errors**  | `#[error_code] pub enum VaultError` with exactly four variants: `Overflow`, `InsufficientFunds`, `ZeroAmount`, `NotOwner` |\n| **Deposit** | `pub fn deposit(&mut self, amount: u64) -> Result<()>`                                                                  |\n| **Withdraw**| `pub fn withdraw(&mut self, amount: u64) -> Result<()>`                                                                 |\n\nField names, field types, method names, parameter type and return type are all fixed. Course 3 wraps around this exact surface, and a client written against `balance` cannot read a field you decided to call `amount_held`.\n\n### Invariants\n\n1. **A zero amount is rejected before anything is written.** Both methods. `VaultError::ZeroAmount`.\n2. **`deposit` adds with `checked_add`** and returns `VaultError::Overflow` when it gets `None`.\n3. **`withdraw` subtracts with `checked_sub`** and returns `VaultError::InsufficientFunds` when it gets `None`.\n4. **No `unwrap()`, no `expect()`, no bare `+` or `-` on `balance`.** A panic inside a program is an aborted instruction carrying no error code — the caller gets a generic failure and no message. Turning `None` into a named variant is the entire point of the last nine lessons.\n5. **`balance` is only ever written through these two methods.** Nothing else in the file touches it.\n\n`NotOwner` is declared and never used, deliberately. It is the error Course 3's ownership constraint returns, and declaring the enum complete now means Course 3 adds a constraint rather than editing your error type. The harness checks only that the variant **exists** and converts — nothing in a compile-time check can observe which errors your code raises, and a `deposit` that returned `err!(VaultError::NotOwner)` compiles identically.\n\n## What is deliberately missing\n\nYour file has **no `#[program]` module and no `#[derive(Accounts)]` struct**. It is not an unfinished program. It is the half of a program that does not depend on the runtime — no accounts, no signers, no clock, no CPI — which is exactly the half you can check by reading. Course 3 supplies the other half and the tests that exercise this one. Lesson 14 spells the split out line by line.\n\n## One file, so modules are inline\n\nThe code block ships exactly one starter, and the manifest points at `src/lib.rs`, so everything you write is in one file. That is why the module is `pub mod vault { … }` written out inline rather than `mod vault;`. In a one-file crate `mod vault;` sends the compiler looking for `src/vault.rs`:\n\n```\nerror[E0583]: file not found for module `vault`\n```\n\nInline modules are not a workaround for the platform. They are how you namespace inside a file, and `use super::*;` at the top of the module body is what makes the crate root's imports — `Pubkey`, `Result`, `require!` — visible inside it. The crate root then needs one line to name the items back out:\n\n```rust\npub use vault::{VaultError, VaultState};\n```\n\nWithout it the items exist and nothing outside the module can say their names. The harness lives outside the module, so this is not a style point — it is a compile error.\n\n## How this is graded, precisely\n\nThe build server compiles your file and grades on one bit: **did it compile.** There is no `cargo test` step on the Rust path, and the grader never reads your code or this description.\n\nSo the checking is done by the `mod verify` block at the bottom of both starters, and its reach is exact.\n\n**It catches:**\n\n- a missing or renamed item — `VaultState`, `VaultError`, `deposit`, `withdraw`\n- a renamed or re-typed field, because `assert!(VaultState::INIT_SPACE == 41)` only holds for `Pubkey` (32) + `u64` (8) + `u8` (1)\n- a missing `#[account]`, because that is what supplies the 8-byte discriminator the harness measures\n- a missing `#[derive(InitSpace)]`, because that is what generates `INIT_SPACE`\n- a wrong receiver (`self` instead of `&mut self`), a wrong parameter type, a wrong return type — the harness binds each method to a typed function pointer\n- a missing `VaultError` variant, or an enum without `#[error_code]`\n- items you left unreachable from the crate root\n\n**It does not catch — verified, by compiling each of these clean:**\n\n- a `withdraw` that calls `checked_add`. Every signature still matches and the build goes green with a vault that pays you for withdrawing.\n- a dropped `require!(amount > 0, …)`. The zero guard is invariant 1 and no type changes when it is gone.\n- `self.balance = self.balance.checked_sub(amount).unwrap();` — invariant 4, and a panic is not a type.\n- `self.balance = self.balance - amount;` — bare arithmetic, same reason.\n\nWhich means exercise 1's pool is not policed either: two of its seven lines do not belong, and both of the two compile. \"Two do not belong\" is a claim about the spec, not about the build. Picking them out is the exercise; the grader is not scoring it.\n\nThat is a property of compile-only grading, not something to work around, and pretending otherwise would be worse than saying it. The thing that catches a swapped operator is a test that runs `withdraw` and looks at the number — which is Course 3, with LiteSVM. Until then it is you, rereading the file, which is what lesson 14 is for.\n\n## Order of work\n\nExercise 1: assemble the two bodies and the re-export from the pool. Exercise 2: write all of it from this page and the harness, with nothing above the harness line but your own typing.\n\nOne warning about that second block, because the platform will not give it to you. Exercise 1 is on the same page, one block above, and by the time you reach exercise 2 it contains the finished `VaultState`, the finished `VaultError`, and — in its pool — every line of both method bodies. **If you scroll up, you are typing, not writing.** Nothing stops you and nothing detects it; the surface Course 3 needs is fixed, so exercise 2 cannot ask for anything exercise 1 did not show you.\n\nThe version of this that is worth your time: read the spec and the harness, close the lesson, write the file from the signatures, and only then scroll up to compare. Getting it wrong first and finding out where is the entire mechanism by which the second block is worth more than the first. Copying it is a green build and nothing else.\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "manifest",
+        "_type": "prose",
+        "produces": null,
+        "consumes": null,
+        "src": "## The `Cargo.toml` you never see\n\nYour editor shows one file. The build server compiles a crate, and a crate is a manifest plus source. You do not edit the manifest, and it decides what your code is allowed to say — so read it once.\n\n```toml\n[package]\nname = \"academy-program\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n[lib]\ncrate-type = [\"cdylib\", \"lib\"]\npath = \"src/lib.rs\"\n\n[profile.release]\noverflow-checks = true\nlto = true\ncodegen-units = 1\nopt-level = \"z\"\n\n[dependencies]\nanchor-lang = { version = \"1.1.2\", features = [\"init-if-needed\"] }\nborsh = \"1.5.7\"\n```\n\nSix lines in it are load-bearing for what you are about to write.\n\n**`path = \"src/lib.rs\"`** — the file in the editor *is* `src/lib.rs`. One starter, one file, one crate. This is the reason the module is inline.\n\n**`crate-type = [\"cdylib\", \"lib\"]`** — two outputs from one source. `cdylib` is the shared object the chain loads and runs. `lib` is an ordinary Rust library, which is what makes the crate importable by something else — a test harness, for instance. Nothing imports it today. It is the hook a `cargo test --lib` grading step would hang on, and it costs nothing to leave in.\n\n**`edition = \"2021\"`, not 2024** — editions are per-crate, and a crate cannot be on an edition the Cargo compiling it has not stabilised. The build server's `cargo-build-sbf` ships its own pinned Rust, and that is the constraint. Practical effect: a snippet from a recent blog post that needs an edition-2024 feature will not compile here. Nothing in this course needs one.\n\n**`overflow-checks = true` under `[profile.release]`** — worth understanding because it is so easily mistaken for a safety net. A release build normally *wraps* on integer overflow: `0u64 - 1` silently becomes `u64::MAX`. This line turns the panic back on, so it wraps no more. It is still not a substitute for `checked_sub`:\n\n| What you write               | Release behaviour with this profile | What the caller of your instruction sees      |\n| ---------------------------- | ----------------------------------- | --------------------------------------------- |\n| `balance - amount`           | panic                               | aborted instruction, no error code, no message |\n| `balance.checked_sub(amount)`| `None`                              | `InsufficientFunds` — a code and a `#[msg]` string you wrote |\n\nA panic tells the caller that something went wrong. `checked_sub` + `ok_or` tells them what. That is lesson 4's argument, restated at the manifest level.\n\n**`anchor-lang = { version = \"1.1.2\", … }`** — Anchor's Rust crate, at the version this course is written against. It re-exports the Solana crates it needs, which is why one `use anchor_lang::prelude::*;` is enough to get `Pubkey`, `Result`, `require!` and `msg!` without naming a single `solana-*` dependency yourself.\n\n**`borsh = \"1.5.7\"`** — a range, not a pin. On a `1.x` crate, `\"1.5.7\"` means `>=1.5.7, <2.0.0`, so the version that actually compiles today is **1.8.0**, published 2026-07-16. To pin exactly you write `=1.5.7`. Internalise the habit now, because it is the same habit that keeps a client library from moving under you: the number in a manifest is usually a range, and the number that shipped is in the lockfile.\n\nWhat is *not* here is also informative, and it is a different file. There is no `Anchor.toml` in play at all — the build server invokes `cargo-build-sbf` directly on this manifest, so the workspace file you will see in every Anchor tutorial has no part in grading. And even where there is one, the `[registry]` section and `anchor publish` it used to carry are gone from the toolchain: the on-chain IDL is now written by the **Program Metadata Program**. You will meet both in Course 3, at deploy time, when your program finally has an id to attach metadata to.\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "complete",
+        "_type": "code",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": "rust",
+        "buildType": "buildable",
+        "deployable": false,
+        "starter": "// Exercise 1 of 2 — complete the impl block.\n//\n// VaultState, VaultError and the two method signatures are already written.\n// Below are seven candidate lines. FIVE of them belong in this file. The other\n// two compile and are still wrong — the grader cannot tell the difference, which\n// is the point of asking you. Two of the five are used TWICE. Order matters\n// inside a body.\n//\n//   (1)  Ok(())\n//   (2)  self.balance = self.balance.checked_sub(amount).unwrap();\n//   (3)  self.balance = self.balance.checked_add(amount).ok_or(VaultError::Overflow)?;\n//   (4)  pub use vault::{VaultError, VaultState};\n//   (5)  self.balance = self.balance - amount;\n//   (6)  require!(amount > 0, VaultError::ZeroAmount);\n//   (7)  self.balance = self.balance.checked_sub(amount).ok_or(VaultError::InsufficientFunds)?;\n//\n// This file does NOT compile as shipped. Build it first. The errors arrive in\n// two groups, and each group points at a different missing line.\n\nuse anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\npub mod vault {\n    use super::*;\n\n    #[account]\n    #[derive(InitSpace)]\n    pub struct VaultState {\n        pub owner: Pubkey,\n        pub balance: u64,\n        pub bump: u8,\n    }\n\n    #[error_code]\n    pub enum VaultError {\n        #[msg(\"Deposit would overflow the vault balance\")]\n        Overflow,\n        #[msg(\"Withdrawal is larger than the vault balance\")]\n        InsufficientFunds,\n        #[msg(\"Amount must be greater than zero\")]\n        ZeroAmount,\n        #[msg(\"Signer is not the vault owner\")]\n        NotOwner,\n    }\n\n    impl VaultState {\n        pub fn deposit(&mut self, amount: u64) -> Result<()> {\n            // Three lines from the pool, in order.\n        }\n\n        pub fn withdraw(&mut self, amount: u64) -> Result<()> {\n            // Three lines from the pool, in order.\n        }\n    }\n}\n\n// One line from the pool goes here.\n\n// ─────────────────────────────────────────────────────────────────────────────\n// VERIFICATION HARNESS — DO NOT EDIT ANYTHING BELOW THIS LINE.\n//\n// This module compiles only if every item the spec asks for exists with the\n// name, shape and signature the spec gives. It is a TYPE check, not a behaviour\n// check. Four ways to be wrong and still green, each one confirmed by compiling\n// it: `checked_add` where `checked_sub` belongs, a dropped `require!(amount > 0)`,\n// `.unwrap()` instead of `.ok_or(…)?`, and bare `+`/`-` on `self.balance`.\n// Nothing below can see any of them.\n// ─────────────────────────────────────────────────────────────────────────────\n#[doc(hidden)]\n#[allow(dead_code)]\nmod verify {\n    use super::*;\n\n    // `VaultState` exists with exactly these three field names and types.\n    fn state(owner: Pubkey, balance: u64, bump: u8) -> VaultState {\n        VaultState {\n            owner,\n            balance,\n            bump,\n        }\n    }\n\n    // `#[account]` is present — it is what supplies the 8-byte discriminator.\n    const _: () = assert!(VaultState::DISCRIMINATOR.len() == 8);\n\n    // `#[derive(InitSpace)]` is present, and the fields are exactly\n    // Pubkey (32) + u64 (8) + u8 (1). Widen any of them and this trips.\n    const _: () = assert!(VaultState::INIT_SPACE == 41);\n\n    // Both methods take `&mut self` and a `u64`, and return `Result<()>`.\n    const DEPOSIT: fn(&mut VaultState, u64) -> Result<()> = VaultState::deposit;\n    const WITHDRAW: fn(&mut VaultState, u64) -> Result<()> = VaultState::withdraw;\n\n    // All four variants exist and the enum carries `#[error_code]`, which is\n    // what gives it a conversion into `anchor_lang::error::Error`.\n    fn errors() -> [anchor_lang::error::Error; 4] {\n        [\n            VaultError::Overflow.into(),\n            VaultError::InsufficientFunds.into(),\n            VaultError::ZeroAmount.into(),\n            VaultError::NotOwner.into(),\n        ]\n    }\n}\n",
+        "solution": "// Exercise 1 of 2 — completed.\n//\n// Pool lines (6), (3), (1) fill `deposit`; (6), (7), (1) fill `withdraw`;\n// (4) is the crate-root re-export. Lines (2) and (5) belong nowhere: (5) is\n// bare subtraction, which panics instead of returning a named error, and (2)\n// calls `.unwrap()`, which panics for the same reason with better manners.\n\nuse anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\npub mod vault {\n    use super::*;\n\n    #[account]\n    #[derive(InitSpace)]\n    pub struct VaultState {\n        pub owner: Pubkey,\n        pub balance: u64,\n        pub bump: u8,\n    }\n\n    #[error_code]\n    pub enum VaultError {\n        #[msg(\"Deposit would overflow the vault balance\")]\n        Overflow,\n        #[msg(\"Withdrawal is larger than the vault balance\")]\n        InsufficientFunds,\n        #[msg(\"Amount must be greater than zero\")]\n        ZeroAmount,\n        #[msg(\"Signer is not the vault owner\")]\n        NotOwner,\n    }\n\n    impl VaultState {\n        pub fn deposit(&mut self, amount: u64) -> Result<()> {\n            require!(amount > 0, VaultError::ZeroAmount);\n            self.balance = self\n                .balance\n                .checked_add(amount)\n                .ok_or(VaultError::Overflow)?;\n            Ok(())\n        }\n\n        pub fn withdraw(&mut self, amount: u64) -> Result<()> {\n            require!(amount > 0, VaultError::ZeroAmount);\n            self.balance = self\n                .balance\n                .checked_sub(amount)\n                .ok_or(VaultError::InsufficientFunds)?;\n            Ok(())\n        }\n    }\n}\n\npub use vault::{VaultError, VaultState};\n\n// ─────────────────────────────────────────────────────────────────────────────\n// VERIFICATION HARNESS — DO NOT EDIT ANYTHING BELOW THIS LINE.\n//\n// This module compiles only if every item the spec asks for exists with the\n// name, shape and signature the spec gives. It is a TYPE check, not a behaviour\n// check. Four ways to be wrong and still green, each one confirmed by compiling\n// it: `checked_add` where `checked_sub` belongs, a dropped `require!(amount > 0)`,\n// `.unwrap()` instead of `.ok_or(…)?`, and bare `+`/`-` on `self.balance`.\n// Nothing below can see any of them.\n// ─────────────────────────────────────────────────────────────────────────────\n#[doc(hidden)]\n#[allow(dead_code)]\nmod verify {\n    use super::*;\n\n    // `VaultState` exists with exactly these three field names and types.\n    fn state(owner: Pubkey, balance: u64, bump: u8) -> VaultState {\n        VaultState {\n            owner,\n            balance,\n            bump,\n        }\n    }\n\n    // `#[account]` is present — it is what supplies the 8-byte discriminator.\n    const _: () = assert!(VaultState::DISCRIMINATOR.len() == 8);\n\n    // `#[derive(InitSpace)]` is present, and the fields are exactly\n    // Pubkey (32) + u64 (8) + u8 (1). Widen any of them and this trips.\n    const _: () = assert!(VaultState::INIT_SPACE == 41);\n\n    // Both methods take `&mut self` and a `u64`, and return `Result<()>`.\n    const DEPOSIT: fn(&mut VaultState, u64) -> Result<()> = VaultState::deposit;\n    const WITHDRAW: fn(&mut VaultState, u64) -> Result<()> = VaultState::withdraw;\n\n    // All four variants exist and the enum carries `#[error_code]`, which is\n    // what gives it a conversion into `anchor_lang::error::Error`.\n    fn errors() -> [anchor_lang::error::Error; 4] {\n        [\n            VaultError::Overflow.into(),\n            VaultError::InsufficientFunds.into(),\n            VaultError::ZeroAmount.into(),\n            VaultError::NotOwner.into(),\n        ]\n    }\n}\n",
+        "tests": [
+          {
+            "id": "t1",
+            "description": "The file compiles on the build server against anchor-lang 1.1.2",
+            "input": "",
+            "expectedOutput": "true"
+          },
+          {
+            "id": "t2",
+            "description": "Compiles ⇒ neither method body was left empty: both evaluate to Result<()>",
+            "input": "",
+            "expectedOutput": "true"
+          },
+          {
+            "id": "t3",
+            "description": "Compiles ⇒ VaultState and VaultError are nameable from the crate root, so the re-export is in place",
+            "input": "",
+            "expectedOutput": "true"
+          }
+        ],
+        "hints": [
+          "Build before you change anything. Fourteen errors come back and the first twelve are all the same *problem*: twelve unresolved names, eight of `VaultState` and four of `VaultError`, reported as E0412, E0422 and E0433 depending on where each one is used. All twelve are in the harness. `mod verify` is a sibling of `mod vault`, not a child, so `use super::*` reaches the crate root and finds nothing there. One pool line fixes all twelve.",
+          "The last two errors are the real work: `mismatched types: expected Result<(), Error>, found ()`. An empty body evaluates to `()`. Each body is three pool lines — reject zero, do the checked arithmetic and turn `None` into a named error, hand back `Ok(())`. Lines (6) and (1) are the two that are used in both bodies.",
+          "Two pool lines belong nowhere. (5) is bare subtraction, which panics under `overflow-checks = true` instead of returning your error, and (2) calls `.unwrap()`, which panics for the same reason with better manners. Neither one can produce `InsufficientFunds`, which is the entire reason `VaultError` exists."
+        ],
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "write",
+        "_type": "code",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": "rust",
+        "buildType": "buildable",
+        "deployable": false,
+        "starter": "// Exercise 2 of 2 — write the vault core.\n//\n// Nothing above the harness line is written for you. The spec is on the lesson\n// page; the harness below is the same spec expressed in Rust, and it is the\n// only thing the build server can check. Read it before you type.\n//\n// Exercise 1 is one block above this one and it contains the answer, pool lines\n// and all. Nothing stops you scrolling up and nothing detects it — but a file you\n// transcribed teaches you nothing a file you wrote does not. Write it from the\n// harness first, compare afterwards.\n//\n// This file does NOT compile as shipped. Every error you see names something\n// you still owe.\n\nuse anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\npub mod vault {\n    use super::*;\n\n    // TODO 1 — `VaultState`: an `#[account]` struct that also derives\n    //          `InitSpace`, with three public fields.\n    //\n    // TODO 2 — `VaultError`: an `#[error_code]` enum with four variants, each\n    //          carrying a `#[msg(\"…\")]` a caller can read.\n    //\n    // TODO 3 — `impl VaultState`, with `deposit` and `withdraw`. Reject a zero\n    //          amount before writing anything, do the arithmetic with\n    //          `checked_add` / `checked_sub`, and turn `None` into the right\n    //          named variant. No `unwrap()`, no `expect()`, no bare `+`/`-`.\n}\n\n// TODO 4 — one line: make `VaultState` and `VaultError` nameable from the\n//          crate root, where the harness can see them.\n\n// ─────────────────────────────────────────────────────────────────────────────\n// VERIFICATION HARNESS — DO NOT EDIT ANYTHING BELOW THIS LINE.\n//\n// This module compiles only if every item the spec asks for exists with the\n// name, shape and signature the spec gives. It is a TYPE check, not a behaviour\n// check. Four ways to be wrong and still green, each one confirmed by compiling\n// it: `checked_add` where `checked_sub` belongs, a dropped `require!(amount > 0)`,\n// `.unwrap()` instead of `.ok_or(…)?`, and bare `+`/`-` on `self.balance`.\n// Nothing below can see any of them.\n// ─────────────────────────────────────────────────────────────────────────────\n#[doc(hidden)]\n#[allow(dead_code)]\nmod verify {\n    use super::*;\n\n    // `VaultState` exists with exactly these three field names and types.\n    fn state(owner: Pubkey, balance: u64, bump: u8) -> VaultState {\n        VaultState {\n            owner,\n            balance,\n            bump,\n        }\n    }\n\n    // `#[account]` is present — it is what supplies the 8-byte discriminator.\n    const _: () = assert!(VaultState::DISCRIMINATOR.len() == 8);\n\n    // `#[derive(InitSpace)]` is present, and the fields are exactly\n    // Pubkey (32) + u64 (8) + u8 (1). Widen any of them and this trips.\n    const _: () = assert!(VaultState::INIT_SPACE == 41);\n\n    // Both methods take `&mut self` and a `u64`, and return `Result<()>`.\n    const DEPOSIT: fn(&mut VaultState, u64) -> Result<()> = VaultState::deposit;\n    const WITHDRAW: fn(&mut VaultState, u64) -> Result<()> = VaultState::withdraw;\n\n    // All four variants exist and the enum carries `#[error_code]`, which is\n    // what gives it a conversion into `anchor_lang::error::Error`.\n    fn errors() -> [anchor_lang::error::Error; 4] {\n        [\n            VaultError::Overflow.into(),\n            VaultError::InsufficientFunds.into(),\n            VaultError::ZeroAmount.into(),\n            VaultError::NotOwner.into(),\n        ]\n    }\n}\n",
+        "solution": "// Exercise 2 of 2 — the vault core, written from the spec.\n//\n// This is one correct shape, not the only one: the fields may be declared in\n// any order, the `#[msg]` strings are yours, and `require!` could be a plain\n// `if amount == 0 { return err!(VaultError::ZeroAmount); }`. What is fixed is\n// the surface the harness names — and the operator in each method, which the\n// harness cannot see and Course 3's tests can.\n\nuse anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\npub mod vault {\n    use super::*;\n\n    #[account]\n    #[derive(InitSpace)]\n    pub struct VaultState {\n        pub owner: Pubkey,\n        pub balance: u64,\n        pub bump: u8,\n    }\n\n    #[error_code]\n    pub enum VaultError {\n        #[msg(\"Deposit would overflow the vault balance\")]\n        Overflow,\n        #[msg(\"Withdrawal is larger than the vault balance\")]\n        InsufficientFunds,\n        #[msg(\"Amount must be greater than zero\")]\n        ZeroAmount,\n        #[msg(\"Signer is not the vault owner\")]\n        NotOwner,\n    }\n\n    impl VaultState {\n        pub fn deposit(&mut self, amount: u64) -> Result<()> {\n            require!(amount > 0, VaultError::ZeroAmount);\n            self.balance = self\n                .balance\n                .checked_add(amount)\n                .ok_or(VaultError::Overflow)?;\n            Ok(())\n        }\n\n        pub fn withdraw(&mut self, amount: u64) -> Result<()> {\n            require!(amount > 0, VaultError::ZeroAmount);\n            self.balance = self\n                .balance\n                .checked_sub(amount)\n                .ok_or(VaultError::InsufficientFunds)?;\n            Ok(())\n        }\n    }\n}\n\npub use vault::{VaultError, VaultState};\n\n// ─────────────────────────────────────────────────────────────────────────────\n// VERIFICATION HARNESS — DO NOT EDIT ANYTHING BELOW THIS LINE.\n//\n// This module compiles only if every item the spec asks for exists with the\n// name, shape and signature the spec gives. It is a TYPE check, not a behaviour\n// check. Four ways to be wrong and still green, each one confirmed by compiling\n// it: `checked_add` where `checked_sub` belongs, a dropped `require!(amount > 0)`,\n// `.unwrap()` instead of `.ok_or(…)?`, and bare `+`/`-` on `self.balance`.\n// Nothing below can see any of them.\n// ─────────────────────────────────────────────────────────────────────────────\n#[doc(hidden)]\n#[allow(dead_code)]\nmod verify {\n    use super::*;\n\n    // `VaultState` exists with exactly these three field names and types.\n    fn state(owner: Pubkey, balance: u64, bump: u8) -> VaultState {\n        VaultState {\n            owner,\n            balance,\n            bump,\n        }\n    }\n\n    // `#[account]` is present — it is what supplies the 8-byte discriminator.\n    const _: () = assert!(VaultState::DISCRIMINATOR.len() == 8);\n\n    // `#[derive(InitSpace)]` is present, and the fields are exactly\n    // Pubkey (32) + u64 (8) + u8 (1). Widen any of them and this trips.\n    const _: () = assert!(VaultState::INIT_SPACE == 41);\n\n    // Both methods take `&mut self` and a `u64`, and return `Result<()>`.\n    const DEPOSIT: fn(&mut VaultState, u64) -> Result<()> = VaultState::deposit;\n    const WITHDRAW: fn(&mut VaultState, u64) -> Result<()> = VaultState::withdraw;\n\n    // All four variants exist and the enum carries `#[error_code]`, which is\n    // what gives it a conversion into `anchor_lang::error::Error`.\n    fn errors() -> [anchor_lang::error::Error; 4] {\n        [\n            VaultError::Overflow.into(),\n            VaultError::InsufficientFunds.into(),\n            VaultError::ZeroAmount.into(),\n            VaultError::NotOwner.into(),\n        ]\n    }\n}\n",
+        "tests": [
+          {
+            "id": "t1",
+            "description": "The file compiles on the build server against anchor-lang 1.1.2",
+            "input": "",
+            "expectedOutput": "true"
+          },
+          {
+            "id": "t2",
+            "description": "Compiles ⇒ VaultState has owner: Pubkey, balance: u64 and bump: u8 — INIT_SPACE is 41",
+            "input": "",
+            "expectedOutput": "true"
+          },
+          {
+            "id": "t3",
+            "description": "Compiles ⇒ #[account] and #[derive(InitSpace)] are both present: an 8-byte discriminator plus INIT_SPACE",
+            "input": "",
+            "expectedOutput": "true"
+          },
+          {
+            "id": "t4",
+            "description": "Compiles ⇒ deposit and withdraw take (&mut self, u64) and return Result<()>",
+            "input": "",
+            "expectedOutput": "true"
+          },
+          {
+            "id": "t5",
+            "description": "Compiles ⇒ VaultError is an #[error_code] enum carrying Overflow, InsufficientFunds, ZeroAmount and NotOwner",
+            "input": "",
+            "expectedOutput": "true"
+          }
+        ],
+        "hints": [
+          "The harness is the acceptance criteria, written in Rust. Read it top to bottom before you type — it names every item, every field, every type and both signatures you owe, and it is the only thing the build server can check.",
+          "`assert!(VaultState::INIT_SPACE == 41)` holds only for `Pubkey` (32) + `u64` (8) + `u8` (1). If it trips you widened a field — a `u64` bump is the usual one, and it costs 7 bytes of rent per vault forever.",
+          "Your items go inside `pub mod vault` and the harness sits outside it, so the crate root needs one line: `pub use vault::{VaultError, VaultState};` Without it every harness reference fails with `cannot find type`, and the items you wrote are unreachable from anywhere Course 3 could call them."
+        ],
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "check",
+        "_type": "quiz",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": [
+          {
+            "id": "q1",
+            "prompt": "You finish the second exercise, but in `withdraw` you typed `checked_add` where you meant `checked_sub`. Everything else matches the spec. Predict what the build server reports.",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "Green. Grading is compile-only, and both methods return `Option<u64>`, so nothing about the file's types changed.",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "Red — the harness binds `withdraw` to a function pointer, and a wrong operator changes the type it binds.",
+                "correct": false,
+                "feedback": "The binding checks `fn(&mut VaultState, u64) -> Result<()>`. The operator lives inside the body; it does not appear in the signature, so the pointer still coerces."
+              },
+              {
+                "id": "c",
+                "label": "Red — `overflow-checks = true` turns the wrong operator into a compile error.",
+                "correct": false,
+                "feedback": "`overflow-checks` changes what a release binary does at runtime when an operation overflows. It cannot see an operator you intended to write, and nothing about it runs at compile time."
+              },
+              {
+                "id": "d",
+                "label": "Red — the lesson's hidden tests call `withdraw(100)` on a balance of 10 and check for `InsufficientFunds`.",
+                "correct": false,
+                "feedback": "There are no hidden tests on the Rust path. The build step shells `cargo-build-sbf` and nothing else, and a submission passes iff the program compiled. Behavioural checks arrive in Course 3, with LiteSVM."
+              }
+            ],
+            "explanation": "This is the honest limit of the harness and it is worth carrying forward: it proves your file has the right *shape*, and nothing more. Until a test runs `withdraw` and looks at the number, the operator is checked by you."
+          },
+          {
+            "id": "q2",
+            "prompt": "You write `VaultState` and `VaultError` inside `pub mod vault { … }` and forget the crate-root re-export. The harness below begins with `use super::*;`. Predict the first error.",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "`cannot find type VaultState in this scope` — `mod verify` is a sibling of `mod vault`, so `use super::*` reaches the crate root, where nothing of that name has been declared.",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "It compiles. `use super::*` keeps walking up and down the module tree until it finds the name.",
+                "correct": false,
+                "feedback": "A glob import pulls in what is in scope exactly one level up. It never searches downwards into sibling modules — that is what a re-export is for."
+              },
+              {
+                "id": "c",
+                "label": "`private type VaultState in public interface` — the struct needs `pub`.",
+                "correct": false,
+                "feedback": "You did write `pub struct`. The item is public; the problem is that nothing at the crate root has named it. Different failure."
+              },
+              {
+                "id": "d",
+                "label": "`unresolved import super::*` — there is nothing to glob.",
+                "correct": false,
+                "feedback": "`use super::*` always resolves; the crate root exists and is a valid module. The failure lands on the names the harness then tries to use."
+              }
+            ],
+            "explanation": null
+          },
+          {
+            "id": "q3",
+            "prompt": "Carried over from lesson 4. You write `self.balance = self.balance - amount;` with `balance == 10` and `amount == 25`, and it ships in the build server's release profile. Predict what happens.",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "It compiles, and at runtime the subtraction panics — the instruction aborts with no `VaultError` attached and no message for the caller.",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "It compiles, and `balance` wraps around to a value near `u64::MAX`.",
+                "correct": false,
+                "feedback": "That is the default release behaviour, but this manifest sets `overflow-checks = true`, which restores the panic. Both outcomes are worse than an error code; only one of them is what this profile actually does."
+              },
+              {
+                "id": "c",
+                "label": "It does not compile — subtracting a larger `u64` from a smaller one is rejected by the compiler.",
+                "correct": false,
+                "feedback": "The compiler only rejects overflow it can evaluate at compile time, in a constant. `balance` and `amount` are runtime values."
+              },
+              {
+                "id": "d",
+                "label": "It compiles and returns `Err(VaultError::InsufficientFunds)`, because that is what the enum is for.",
+                "correct": false,
+                "feedback": "Nothing converts a panic into a named error. That conversion is the thing you write by hand, with `checked_sub(...).ok_or(...)?`."
+              }
+            ],
+            "explanation": null
+          }
+        ],
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      }
+    ]
+  },
+  {
+    "_id": "lesson-rpd-checked-lamport-math",
+    "title": "Checked Lamport Math",
+    "slug": "checked-lamport-math",
+    "blocks": [
+      {
+        "key": "intro",
+        "_type": "prose",
+        "produces": null,
+        "consumes": null,
+        "src": "# Checked Lamport Math\n\n> **Version stamp — checked 2026-07-26.** `anchor-lang` **1.1.2** · Rust **edition 2021** · Agave **≥ 3.1.10**. The build crate sets `overflow-checks = true` in `[profile.release]`, which this lesson depends on and discusses. The exercise is plain Rust and imports nothing.\n\nHere is a withdrawal, written the way it reads:\n\n```rust\nlet new_balance = balance - amount;\n```\n\nA vault holding 5 lamports, someone asking for 7. Decide what that line does before reading on, and be specific — there are three different answers depending on how the program was compiled, and none of them is the one you want.\n\n## The three answers\n\n**In a debug build, or any build with overflow checks on: it panics.** The subtraction is detected as an underflow and the program aborts. On-chain, an aborted program means a failed transaction, a log line about a panic, and no way for a caller to distinguish \"you asked for too much\" from \"the program has a bug\". You cannot handle it, you cannot match on it, and you cannot return a useful error alongside it.\n\n**In a release build with overflow checks off: it wraps.** `5u64 - 7` becomes 18 446 744 073 709 551 614. No panic, no log, no signal of any kind. Your vault now believes it holds eighteen quintillion lamports, and the very next line of code will act on that belief. This is not a hypothetical failure mode — unchecked arithmetic is one of the most-exploited bug classes in on-chain programs, and it is exploited precisely because it is silent.\n\n**The third answer is the one you build today: it returns `None`.** No panic, no wrap. The impossible result is represented as a value, handed back to the caller, and the caller has to deal with it before it can get at a number.\n\nOur build server compiles with `overflow-checks = true`, so a wrap becomes a panic here. Be clear about what that does and does not buy you. It converts a silent corruption into a loud crash, which is strictly better and is why it is switched on. It is **not** a substitute for checked arithmetic: a crash is still not an error you can return, and the flag is a property of the build profile rather than of your code. Code whose correctness depends on a profile setting is code that is one `Cargo.toml` away from being wrong.\n\nThis is the Rust half of the `u64` problem lesson 2 planted on the JavaScript side. There, `Number(hugeU64)` handed you a nearby number with no complaint. Here, `balance - amount` hands you a wrong number or a crash. The languages fail differently and both failures are silent-or-useless by default. The fix in Rust is to ask for the checked operation by name.\n\n## `Option<T>`: a value or the absence of one\n\n```rust\npub enum Option<T> {\n    Some(T),\n    None,\n}\n```\n\nThat is the whole definition. `Option<u64>` is *either* a `u64` wrapped in `Some`, *or* `None`. It is an ordinary enum from the standard library, not compiler magic, and it is what Rust has instead of `null`.\n\nThe difference from `null` is not philosophical, it is mechanical: **`Option<u64>` and `u64` are different types.** You cannot add 1 to an `Option<u64>`, pass it where a `u64` is wanted, or compare it to a number. To get at the value you have to handle the `None` case, and the compiler will not let you skip it. There is no equivalent of a null-pointer dereference to defer to run time, because the check is not at run time.\n\nRust's standard library gives every integer type a `checked_` operation for exactly this shape:\n\n```rust\n5u64.checked_sub(7)   // None\n7u64.checked_sub(5)   // Some(2)\nu64::MAX.checked_add(1)  // None\n1u64.checked_add(2)   // Some(3)\n```\n\n`checked_add`, `checked_sub`, `checked_mul`, `checked_div`. Each returns `Option`, each returns `None` exactly when the true result cannot be represented, and using them is not defensive programming — it is the only way to write arithmetic on untrusted numbers that says what it means.\n\n## Getting the value out with `match`\n\n`match` from lesson 3 works on `Option`, and this is where its exhaustiveness earns its keep — there are two variants, so there are two arms, and forgetting one is `error[E0004]`:\n\n```rust\nmatch balance.checked_sub(amount) {\n    None => { /* the caller asked for too much */ }\n    Some(remaining) => { /* `remaining` is a plain u64 here */ }\n}\n```\n\n`Some(remaining)` both tests the variant and binds the value out of it in one move. That is destructuring, and it is the normal way to read any enum in Rust.\n\nYou may have seen `.unwrap()` do the same job in one word. `unwrap()` panics on `None`. **It must never appear in program code**, it does not appear anywhere in this course's code, and every tutorial you find will be full of it. Lesson 11 makes the full argument for why; take the rule on trust until then.\n\nThere is also `?`, the operator that propagates the failure case for you and turns a five-line `match` into one character. You will meet it in lesson 12, and there is a specific reason it is not available today — see the constraints below.\n\n## Why these are `const fn`\n\nEvery function you write in this exercise is declared `const fn`. That means the compiler is able to evaluate it during compilation, given constant inputs.\n\nThis is not decoration and it is not for performance. It is what makes the exercise gradeable. Grading a Rust submission here means compiling it — that is the whole signal. A file that compiles has told the grader nothing about whether `sub_lamports` subtracts or adds. But a `const fn` can be called by an assertion the compiler must evaluate:\n\n```rust\nconst _: () = assert!(matches!(sub_lamports(5, 7), None));\n```\n\nIf your `sub_lamports(5, 7)` returns anything other than `None`, that assertion fails **during compilation** and the build goes red, with the assertion reproduced in the error:\n\n```\nerror[E0080]: evaluation panicked: assertion failed: matches!(sub_lamports(5, 7), None)\n```\n\nTen of those sit at the bottom of the file. They are the first behavioural check in this course rather than a signature check, and they are what makes a `sub_lamports` that quietly calls `checked_add` fail rather than pass.\n\nBe clear about the size of that win. Ten specific inputs is not a test suite, and this trick reaches only as far as `const fn` does — by module 4, when the same logic becomes a method taking `&mut self` and returning `Result`, it is no longer const-evaluable and the harness goes back to pinning shapes. Today it works, so today we use it.\n\nTwo consequences of `const fn` you need before you start:\n\n- **`?` is not allowed in a `const fn`.** You get `error[E0015]` — \"`?` is not allowed on `Option<u64>` in constant functions\" — with the note \"calls in constant functions are limited to constant functions, tuple structs and tuple variants\". That note is the actual reason: `?` desugars to calls into the `Try` machinery, and those functions are not `const fn`, so from the compiler's point of view you made a non-const call. Use `match`. This is the reason the spec says `match`, and lesson 12 is where `?` finally arrives — on `Result`, in a function that is not const.\n- **`panic!`, and anything built on it, ends the build rather than the program.** A `panic!` reached during const evaluation is a compile error. `unwrap()` on a `None` in a `const fn` called from an assertion does not fail at run time; it fails at *your* keyboard.\n\n`checked_add` and `checked_sub` are themselves `const fn`, so they are available to you inside yours.\n\n## The spec\n\nThree functions, no bodies. Signatures are fixed and pinned by the harness.\n\n### `add_lamports(balance, amount) -> Option<u64>`\n\n`Some(sum)` when `balance + amount` is representable as a `u64`. `None` when it is not.\n\n`amount` of zero is fine and returns `Some(balance)`. Rejecting a zero-amount deposit is a *policy*, and it belongs in the vault's `deposit` method in lesson 13, not in an arithmetic helper. Keep the two separate.\n\n### `sub_lamports(balance, amount) -> Option<u64>`\n\n`Some(remaining)` when `amount <= balance`. `None` when it is not, because a `u64` has no negative values to land on. Withdrawing exactly the whole balance is valid and returns `Some(0)`.\n\n### `transfer_lamports(from, to, amount) -> Option<(u64, u64)>`\n\nMove `amount` from one balance to the other and return **both new balances** as `Some((new_from, new_to))`. Return `None` if either half is impossible.\n\nThis one is the point of the lesson. The requirement is *all or nothing*: if the debit works but the credit would overflow, nothing moved, and the answer is `None` — not `Some` with one side updated. Which means you cannot compute the two halves independently and hope; you have to look at the first result before committing to the second, and you have to do it with `match` because `?` is unavailable. This is the shape of every value transfer you will ever write on-chain, and it is why `withdraw` in lesson 13 does its checked subtraction *before* it writes anything.\n\nBuild the empty file first. Ten `error[E0080]` lines come back, one per assertion, all of them reporting `not yet implemented` — that is `todo!()` doing its job. As you fill each body in, the failures that remain start naming the specific input they disagree with, and at that point the harness is a better-specified to-do list than this page is.\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "exercise",
+        "_type": "code",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": "rust",
+        "buildType": "buildable",
+        "deployable": false,
+        "starter": "//! Checked lamport math.\n//!\n//! Three signatures, no bodies. The spec is in the lesson text; the\n//! acceptance criteria are the assertions at the bottom of this file, and\n//! the compiler evaluates them while it builds.\n//!\n//! This file does not build as it ships. Build it anyway. The first build\n//! reports all ten assertions failing with `error[E0080]: evaluation\n//! panicked: not yet implemented` — that is `todo!()` being reached, and\n//! the comment above each group of assertions names the cases.\n//!\n//! Once a function has a real body, a failing assertion prints itself\n//! verbatim instead, for example:\n//!\n//!   error[E0080]: evaluation panicked:\n//!     assertion failed: matches!(sub_lamports(5, 7), None)\n//!\n//! which names the exact input that is wrong.\n//!\n//! Constraints:\n//!   * every function stays a `const fn` — the assertions can only run if\n//!     the compiler can evaluate your code\n//!   * no `?` — it is not allowed in a `const fn`. Use `match`.\n//!   * no `unwrap()`, no `expect()`, no `panic!`, no `as`\n//!   * no bare `+` or `-` on lamports\n\n/// `Some(balance + amount)`, or `None` if that would exceed `u64::MAX`.\n///\n/// An `amount` of zero is valid and returns `Some(balance)`.\npub const fn add_lamports(balance: u64, amount: u64) -> Option<u64> {\n    todo!()\n}\n\n/// `Some(balance - amount)`, or `None` if `amount` is greater than\n/// `balance` — a `u64` has no negative values to land on.\n///\n/// Withdrawing the whole balance is valid and returns `Some(0)`.\npub const fn sub_lamports(balance: u64, amount: u64) -> Option<u64> {\n    todo!()\n}\n\n/// Move `amount` from `from` to `to`, all or nothing.\n///\n/// `Some((new_from, new_to))` when both halves succeed. `None` when either\n/// half is impossible — and in that case neither balance moved, so there\n/// is nothing partial to report.\n///\n/// You cannot use `?` here. Look at the first result with `match` before\n/// committing to the second.\npub const fn transfer_lamports(from: u64, to: u64, amount: u64) -> Option<(u64, u64)> {\n    todo!()\n}\n\n// ════════════════════════════════════════════════════════════════════════\n// DO NOT EDIT BELOW THIS LINE\n//\n// The first three bindings pin the signatures. The rest are assertions the\n// compiler evaluates during the build, so a wrong answer is a red build\n// rather than a silent pass. Ten specific inputs is not a test suite, and\n// this only works because the functions are `const fn` — but it is a real\n// behavioural check, which is more than the rest of this module gets.\n// ════════════════════════════════════════════════════════════════════════\n\nconst _: fn(u64, u64) -> Option<u64> = add_lamports;\nconst _: fn(u64, u64) -> Option<u64> = sub_lamports;\nconst _: fn(u64, u64, u64) -> Option<(u64, u64)> = transfer_lamports;\n\n// add: the ordinary case, the ceiling, and zero\nconst _: () = assert!(matches!(add_lamports(1, 2), Some(3)));\nconst _: () = assert!(matches!(add_lamports(u64::MAX, 1), None));\nconst _: () = assert!(matches!(add_lamports(u64::MAX, 0), Some(u64::MAX)));\n\n// sub: the ordinary case, the floor, and draining to exactly zero\nconst _: () = assert!(matches!(sub_lamports(7, 5), Some(2)));\nconst _: () = assert!(matches!(sub_lamports(5, 7), None));\nconst _: () = assert!(matches!(sub_lamports(5, 5), Some(0)));\n\n// transfer: both sides move, or neither does\nconst _: () = assert!(matches!(transfer_lamports(10, 0, 4), Some((6, 4))));\nconst _: () = assert!(matches!(transfer_lamports(10, 0, 0), Some((10, 0))));\nconst _: () = assert!(matches!(transfer_lamports(3, 0, 4), None));\nconst _: () = assert!(matches!(transfer_lamports(10, u64::MAX, 1), None));\n",
+        "solution": "//! Checked lamport math — solved.\n\n/// `Some(balance + amount)`, or `None` if that would exceed `u64::MAX`.\n///\n/// An `amount` of zero is valid and returns `Some(balance)`.\npub const fn add_lamports(balance: u64, amount: u64) -> Option<u64> {\n    balance.checked_add(amount)\n}\n\n/// `Some(balance - amount)`, or `None` if `amount` is greater than\n/// `balance` — a `u64` has no negative values to land on.\n///\n/// Withdrawing the whole balance is valid and returns `Some(0)`.\npub const fn sub_lamports(balance: u64, amount: u64) -> Option<u64> {\n    balance.checked_sub(amount)\n}\n\n/// Move `amount` from `from` to `to`, all or nothing.\n///\n/// The debit is inspected before the credit is committed to. If the credit\n/// cannot happen, the whole operation reports `None` and neither balance is\n/// returned — which is why the debited value stays inside the `match` arm\n/// instead of being written anywhere.\npub const fn transfer_lamports(from: u64, to: u64, amount: u64) -> Option<(u64, u64)> {\n    match sub_lamports(from, amount) {\n        None => None,\n        Some(debited) => match add_lamports(to, amount) {\n            None => None,\n            Some(credited) => Some((debited, credited)),\n        },\n    }\n}\n\n// ════════════════════════════════════════════════════════════════════════\n// DO NOT EDIT BELOW THIS LINE\n//\n// The first three bindings pin the signatures. The rest are assertions the\n// compiler evaluates during the build, so a wrong answer is a red build\n// rather than a silent pass. Ten specific inputs is not a test suite, and\n// this only works because the functions are `const fn` — but it is a real\n// behavioural check, which is more than the rest of this module gets.\n// ════════════════════════════════════════════════════════════════════════\n\nconst _: fn(u64, u64) -> Option<u64> = add_lamports;\nconst _: fn(u64, u64) -> Option<u64> = sub_lamports;\nconst _: fn(u64, u64, u64) -> Option<(u64, u64)> = transfer_lamports;\n\n// add: the ordinary case, the ceiling, and zero\nconst _: () = assert!(matches!(add_lamports(1, 2), Some(3)));\nconst _: () = assert!(matches!(add_lamports(u64::MAX, 1), None));\nconst _: () = assert!(matches!(add_lamports(u64::MAX, 0), Some(u64::MAX)));\n\n// sub: the ordinary case, the floor, and draining to exactly zero\nconst _: () = assert!(matches!(sub_lamports(7, 5), Some(2)));\nconst _: () = assert!(matches!(sub_lamports(5, 7), None));\nconst _: () = assert!(matches!(sub_lamports(5, 5), Some(0)));\n\n// transfer: both sides move, or neither does\nconst _: () = assert!(matches!(transfer_lamports(10, 0, 4), Some((6, 4))));\nconst _: () = assert!(matches!(transfer_lamports(10, 0, 0), Some((10, 0))));\nconst _: () = assert!(matches!(transfer_lamports(3, 0, 4), None));\nconst _: () = assert!(matches!(transfer_lamports(10, u64::MAX, 1), None));\n",
+        "tests": [
+          {
+            "id": "test-1",
+            "description": "Program compiles successfully",
+            "input": "",
+            "expectedOutput": "true"
+          },
+          {
+            "id": "test-2",
+            "description": "add_lamports and sub_lamports return None at the u64 ceiling and floor — checked by compile-time assertion",
+            "input": "",
+            "expectedOutput": "true"
+          },
+          {
+            "id": "test-3",
+            "description": "transfer_lamports is all-or-nothing: None when either half is impossible — checked by compile-time assertion",
+            "input": "",
+            "expectedOutput": "true"
+          }
+        ],
+        "hints": [
+          "Build the empty file first. All ten assertions fail with `error[E0080]: evaluation panicked: not yet implemented`, which is `todo!()` being reached — the comments above each group name the cases. Once a function has a real body, a failure prints the assertion verbatim (`assertion failed: matches!(sub_lamports(5, 7), None)`) and names the exact input that is wrong.",
+          "`u64` already has the two operations you need, and both are themselves `const fn`, so they are callable from inside yours. Look for the methods whose return type is `Option<u64>`.",
+          "For `transfer_lamports`, the obstacle rather than the shape: you cannot use `?`, so there is no way to bail out of the middle of an expression. The second operation therefore has to be inspected somewhere the first one has already succeeded. If you find yourself wanting `?`, that is the right instinct and lesson 12 is where it becomes legal."
+        ],
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "check",
+        "_type": "quiz",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": [
+          {
+            "id": "q1",
+            "prompt": "A vault holds 5 lamports. A withdrawal for 7 reaches `let new_balance = balance - amount;`. The program was compiled by our build server, which sets `overflow-checks = true` in its release profile. Predict what happens, and what a caller can do about it.",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "It panics, the transaction fails, and the caller gets an aborted program rather than an error it can distinguish — the check turns a silent corruption into a crash, not into a handled case.",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "It wraps to 18446744073709551614 and the vault believes it is enormously funded.",
+                "correct": false,
+                "feedback": "That is the answer with overflow checks *off*, and it is the more dangerous one — which is why the flag is on. But the flag lives in `Cargo.toml`, not in your code, so correctness that depends on it is one profile change away from being wrong."
+              },
+              {
+                "id": "c",
+                "label": "It returns `None`, because `u64` subtraction is checked by default.",
+                "correct": false,
+                "feedback": "The `-` operator returns `u64`, never `Option<u64>`. Nothing about its type could carry a `None`. You have to call `checked_sub` to get one."
+              },
+              {
+                "id": "d",
+                "label": "It is a compile error, since the compiler can see the subtraction might underflow.",
+                "correct": false,
+                "feedback": "With literal constants the compiler does catch it. With runtime values it cannot possibly know, which is the entire situation your program is in — the amount came from an instruction someone else wrote."
+              }
+            ],
+            "explanation": null
+          },
+          {
+            "id": "q2",
+            "prompt": "A submission writes `pub const fn sub_lamports(b: u64, a: u64) -> Option<u64> { Some(b.checked_sub(a)?) }`. Predict the outcome.",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "It fails to compile — `error[E0015]`, \"`?` is not allowed on `Option<u64>` in constant functions\". That is exactly why the spec asks for `match`.",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "It compiles and is the neatest possible answer.",
+                "correct": false,
+                "feedback": "It would be, in an ordinary function. `?` on `Option` is still unstable in const context, so it does not compile here — and dropping `const fn` to get it would disable the assertions that grade this lesson. Lesson 12 is where `?` becomes available, on `Result`, in a function that is not const."
+              },
+              {
+                "id": "c",
+                "label": "It compiles but always returns `Some`, because `?` cannot escape from inside a `Some(...)` call.",
+                "correct": false,
+                "feedback": "`?` returns from the enclosing *function*, not from the expression it sits in, so the nesting would not have been the problem. The problem is that it is unavailable in const context at all."
+              },
+              {
+                "id": "d",
+                "label": "It compiles with a warning that `?` is redundant here.",
+                "correct": false,
+                "feedback": "`Some(x?)` on an `Option` is genuinely redundant — the value is already the right type — but Rust does not lint for it, and in a `const fn` you never get that far."
+              }
+            ],
+            "explanation": null
+          },
+          {
+            "id": "q3",
+            "prompt": "Carried over from lesson 3. Predict the outcome of `pub const fn sub_lamports(b: u64, a: u64) -> Option<u64> { b.checked_sub(a); }`",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "`error[E0308]` — expected `Option<u64>`, found `()`. The semicolon discarded the value, so the body evaluates to nothing.",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "It compiles and returns `None`, since nothing was returned.",
+                "correct": false,
+                "feedback": "There is no implicit `None`, and no implicit anything. A body whose value is `()` does not satisfy a `-> Option<u64>` signature, and the compiler says so before the question of what it returns can arise."
+              },
+              {
+                "id": "c",
+                "label": "It compiles with a `path_statements` warning about an expression whose result is unused.",
+                "correct": false,
+                "feedback": "You would get an unused-result warning if the return type were `()`. It is not, so the mismatch is an error — and note that the compiler's `help:` line will point straight at the semicolon."
+              },
+              {
+                "id": "d",
+                "label": "It compiles, because `checked_sub` is the last expression and semicolons are optional at the end of a body.",
+                "correct": false,
+                "feedback": "A tail expression is defined by the *absence* of the semicolon. Adding one is what turns it from the body's value into a discarded statement — the same rule that broke `if a < b { a; } else { b; }` in lesson 3."
+              }
+            ],
+            "explanation": null
+          }
+        ],
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      }
+    ]
+  },
+  {
+    "_id": "lesson-rpd-enums-option-result",
+    "title": "Enums, `Option`, and `Result`",
+    "slug": "enums-option-result",
+    "blocks": [
+      {
+        "key": "intro",
+        "_type": "prose",
+        "produces": null,
+        "consumes": null,
+        "src": "# Enums, `Option`, and `Result`\n\n> **Version stamp — checked 2026-07-26.** `anchor-lang 1.1.2` (latest on crates.io, published 2026-06-26) · `borsh 1.8.0` · `cargo-build-sbf` with platform-tools v1.54 (rustc 1.89) · edition 2021. `ERROR_CODE_OFFSET = 6000` and the numbering rule below were read out of `anchor-lang-error 1.1.2` and `anchor-syn 1.1.2`; the compiler messages quoted were produced by compiling this lesson's file.\n\nLesson 4's `sub_lamports` returned `None` when the vault did not hold enough. That was true and it was useless. `None` cannot tell a client whether the amount was zero, or larger than the balance, or whether the signer had no business asking. It says only \"no\".\n\n`Option` was the training-wheels version. This lesson is the real one.\n\n## An enum is a closed set of alternatives\n\nIn TypeScript you would reach for a union of string literals, and the compiler would help you a little:\n\n```ts\ntype VaultFailure = \"overflow\" | \"insufficient\" | \"zero\" | \"not-owner\";\n```\n\nA Rust enum is that idea with two properties the union does not have. First, a variant can carry data (`Option::Some(u64)` carries a `u64`; `None` carries nothing). Second — and this is the one that matters today — **the compiler will not let you handle some of the variants and forget the rest.**\n\n```rust\nmatch failure {\n    VaultError::Overflow => \"overflow\",\n    VaultError::InsufficientFunds => \"insufficient_funds\",\n    VaultError::ZeroAmount => \"zero_amount\",\n    // forget NotOwner and the file does not compile\n}\n```\n\nThat property has a name — exhaustiveness — and subgoal 3 is where you feel it rather than read about it.\n\n## `#[error_code]` and the 6000\n\n`#[error_code]` on an ordinary enum generates:\n\n| Generated | What it gives you |\n| --- | --- |\n| `#[derive(Debug, Clone, Copy)]`, `#[repr(u32)]` | the enum is cheap to pass around, by value |\n| `fn name(&self) -> String` | `\"ZeroAmount\"` — the variant's own name |\n| `impl From<VaultError> for u32` | `variant as u32 + 6000` |\n| `impl Display for VaultError` | your `#[msg]` string, reachable as `.to_string()` |\n| `impl From<VaultError> for Error` | why `.ok_or(VaultError::Overflow)?` converts on the way out |\n| `#[msg(\"...\")]` carried into the IDL | the string a client displays |\n\nTwo of those are worth separating, because it is easy to attribute the wrong one. **`error!(VaultError::ZeroAmount)` does not use the `From<VaultError> for Error` impl.** It expands to `Error::from(AnchorError { error_name: e.name(), error_code_number: e.into(), error_msg: e.to_string(), … })` — so it uses `name()`, the `u32` conversion, and `Display`, and builds the `Error` from an `AnchorError`. You can prove it: hand-roll an enum with only those three and `error!` compiles on it.\n\n`From<VaultError> for Error` is what `?` needs, which is lesson 12's subject and the reason `.ok_or(VaultError::Overflow)?` works in lesson 13 without an `error!` anywhere in the expression. Two routes to the same wire format, and knowing which is which is the difference between reading an `E0277` and guessing at it.\n\nThe 6000 is `anchor_lang::error::ERROR_CODE_OFFSET`. Everything below it is taken: the Solana runtime's own errors, and Anchor's built-in `ErrorCode` (`AccountDiscriminatorMismatch`, `ConstraintSeeds`, and about a hundred others). Your first variant is therefore **6000**, your second is 6001, and so on down the declaration order.\n\nSo the order of variants in the enum is part of your program's public interface. Insert a new variant in the middle and every code after it shifts by one — clients that hard-coded `6002` are now reading the wrong failure. Add at the end.\n\nThis is also why Anchor's guidance is **one `#[error_code]` enum per program**. Nothing stops you writing two — it compiles — and that is the problem: both start numbering at 6000, so `OtherError`'s first variant and `VaultError`'s first variant are the same code on the wire and no client can tell them apart. If you genuinely need a second enum, the mechanism is an explicit offset, `#[error_code(offset = 1000)]`, which replaces 6000 rather than adding to it.\n\n## `Result<T>` in an Anchor program\n\n`Result` is just an enum with two variants, `Ok(T)` and `Err(E)`. Anchor gives you a type alias:\n\n```rust\n// anchor_lang::Result<T> is\ncore::result::Result<T, anchor_lang::error::Error>\n```\n\nThat is what `Result<u64>` means everywhere in this file — one type parameter, because the error half is already decided. You will read `Result<()>` constantly in Course 3: an instruction handler that succeeds and returns nothing.\n\n`error!(VaultError::Overflow)` builds the `Error` value, and it captures the file and line where you wrote it, which is why the log tells you *where* the failure was raised, not just what it was.\n\nThere are two shorthands for this — `err!()` and `require!()` — and they belong to lesson 12. Today you write `match` and `Err(error!(...))` by hand, because the shorthands are much easier to read once you have seen what they replace.\n\n## Matching on `Option`, matching on `Result`\n\nBoth are enums, so both are matched the same way, and this is the whole of subgoal 2:\n\n```rust\n// Option -> Result: keep the value, name the failure\nmatch balance.checked_add(amount) {\n    Some(new_balance) => Ok(new_balance),\n    None => Err(error!(VaultError::Overflow)),\n}\n\n// Result -> plain value: decide what a failure means here\nmatch add_lamports(balance, amount) {\n    Ok(new_balance) => new_balance,\n    Err(_) => balance,        // a rejected deposit changes nothing\n}\n```\n\n`Err(_)` is the one place a wildcard is the right answer: you are deliberately saying *any* failure means the same thing here. Contrast that with subgoal 3, where a wildcard would be a bug.\n\n## `unwrap()`, and why this lesson is where it gets argued\n\nLesson 4 banned `.unwrap()` in one sentence and said module 3 would do it properly. This is that.\n\n`.unwrap()` takes an `Option` or a `Result` and either hands you the value or panics. You will see it in nearly every Rust tutorial you read, Solana ones included, and you must never put it in program code.\n\nA panic aborts the instruction with a generic runtime failure. The client gets no error code, no `#[msg]` string, no way to distinguish your four named failures from each other or from a bug. Every bit of the design in this lesson is thrown away at the moment you write `.unwrap()`.\n\nThat is the argument, and it is the only place in this course that makes it at length. `unwrap()` gets named again later — the compiler suggests it at you in lesson 9, and lesson 13 lists it among the things the vault core must not contain — but the reason is here.\n\n## Subgoal 3 is the point\n\nWrite the two exhaustive `match`es, get them green, and then add a fifth variant — `VaultFrozen` — and build **before** you change anything else.\n\nYou will get two errors, one per match site:\n\n```\nerror[E0004]: non-exhaustive patterns: `VaultError::VaultFrozen` not covered\n  --> src/lib.rs:77:11\n   |\n77 |     match e {\n   |           ^ pattern `VaultError::VaultFrozen` not covered\n```\n\nThat is the compiler handing you a to-do list of every place in the program that now has an unhandled case. If you have ever shipped a `switch` with a missing branch and found out from a user, this is the version of that bug that cannot happen.\n\nAnd this is exactly what a `_ =>` arm costs you. Add a catch-all to those matches and the fifth variant compiles silently, mapping to whatever the catch-all says — which will be wrong, and quiet about it. A wildcard is not a shortcut for \"handle the rest\"; it is a decision to stop being told when the set changes.\n\n## What the grader can and cannot see\n\nThe build server checks that your file **compiles** against Anchor 1.1.2. It does not run your functions.\n\nThe `mod verify` block at the bottom is not editable, and it pins each of the five function names to its exact signature — a missing function or a drifted type stops the build. That is a real check, and it is a check on *names and types only*. Nothing verifies that your `sub_lamports` subtracts rather than adds. Subgoal 3 is different: exhaustiveness is a compile-time property, so the compiler really does verify it, and that is why the fifth variant is where the lesson spends its effort.\n\nOne more thing the build does check, for a duller reason: each stub body ships a `compile_error!` naming its subgoal, so the file as delivered cannot build. Without it the placeholder bodies would compile green and an untouched submission would pass — which would tell you nothing about whether you had learned anything. Delete each one as you replace the line beneath it.\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "exercise",
+        "_type": "code",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": "rust",
+        "buildType": "buildable",
+        "deployable": false,
+        "starter": "// vault_core.rs — the error type, and Result instead of panic.\n//\n// Three subgoals. Do them in order; each one builds on the last.\n//\n// This file does NOT compile as given, and the code it ships is wrong as given —\n// both on purpose. Each stub body keeps the wrong line visible (read it, it is\n// the mistake being deleted) above a `compile_error!` that names the subgoal.\n// Build it once to see all three at once, then start at SUBGOAL 2, deleting each\n// `compile_error!` as you replace the line under it.\n\nuse anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n// ═════════════════════════════════════════════════════════════════════════════\n// SUBGOAL 1 — the error enum. PRE-FILLED. Read it; do not change it yet.\n// ═════════════════════════════════════════════════════════════════════════════\n//\n// `#[error_code]` takes an ordinary enum and generates:\n//   - `#[derive(Debug, Clone, Copy)]` and `#[repr(u32)]` on it\n//   - `fn name(&self) -> String`, returning the variant's name\n//   - `impl From<VaultError> for u32`  ->  `variant as u32 + 6000`\n//   - `impl Display for VaultError`, from your `#[msg]` strings\n//   - `impl From<VaultError> for anchor_lang::error::Error`\n//\n// `error!(VaultError::Overflow)` uses the first three, not the last one: it\n// builds an `AnchorError` out of `name()`, `into()` and `to_string()`. The\n// `From<VaultError> for Error` impl is what `?` needs, and lesson 12 is where\n// that matters.\n//\n// The 6000 is `anchor_lang::error::ERROR_CODE_OFFSET`. Codes below it belong to\n// the runtime and to Anchor itself, so your first variant is 6000, not 0.\n// `#[msg(...)]` is the string a client displays; it is carried into the IDL.\n#[error_code]\npub enum VaultError {\n    #[msg(\"Deposit would overflow the vault balance\")]\n    Overflow, // 6000\n    #[msg(\"Withdrawal exceeds the vault balance\")]\n    InsufficientFunds, // 6001\n    #[msg(\"Amount must be greater than zero\")]\n    ZeroAmount, // 6002\n    #[msg(\"Signer is not the vault owner\")]\n    NotOwner, // 6003\n    // SUBGOAL 3 adds a fifth variant right here. Not yet.\n}\n\n// ═════════════════════════════════════════════════════════════════════════════\n// SUBGOAL 2 — turn lesson 4's `Option` into a `Result` that says why.\n// ═════════════════════════════════════════════════════════════════════════════\n//\n// Lesson 4 gave you `Option<u64>`: Some means it fit, None means it did not.\n// A program has to tell a client WHICH failure happened, so the answer becomes\n// `Result<u64>` — that is `anchor_lang::Result<u64>`, i.e.\n// `core::result::Result<u64, anchor_lang::error::Error>`.\n//\n// Use `match` on the Option. Do NOT use `?` — that is lesson 12.\n// Do NOT use `.unwrap()` — see the note at the bottom of this file.\n\n/// 2a. `match` on `balance.checked_add(amount)`:\n///       Some(new_balance) => Ok(new_balance)\n///       None              => Err(error!(VaultError::Overflow))\n///\n///     One thing NOT to add: a zero-amount check. Lesson 4 said rejecting a\n///     zero deposit is a policy and belongs in the vault's `deposit` method,\n///     and that still holds — `ZeroAmount` gets raised in lesson 13, not here.\n///     `add_lamports(500, 0)` is `Ok(500)`. Arithmetic answers \"did it fit?\".\npub fn add_lamports(balance: u64, amount: u64) -> Result<u64> {\n    // TODO (2a) — replace this. `balance + amount` is the bug this whole course\n    // exists to delete: the build server compiles with `overflow-checks = true`,\n    // so on a u64 wrap this panics instead of returning your named error.\n    compile_error!(\"Subgoal 2a is not written yet: match on checked_add, Some -> Ok, None -> Err(error!(VaultError::Overflow)). Delete this line and replace the `balance + amount` line below it.\");\n    Ok(balance + amount)\n}\n\n/// 2b. Same shape, different reason: `checked_sub`, and `None` means the vault\n///     does not hold that much -> `VaultError::InsufficientFunds`.\npub fn sub_lamports(balance: u64, amount: u64) -> Result<u64> {\n    // TODO (2b) — replace this.\n    compile_error!(\"Subgoal 2b is not written yet: same shape as 2a, but checked_sub, and None means VaultError::InsufficientFunds. Delete this line and replace the line below it.\");\n    Ok(balance - amount)\n}\n\n/// 2c. Now consume a `Result` by matching on it. A rejected deposit must leave\n///     the balance exactly where it was.\n///       Ok(new_balance) => new_balance\n///       Err(_)          => balance\npub fn balance_after_deposit(balance: u64, amount: u64) -> u64 {\n    // TODO (2c) — replace this with a `match` on `add_lamports(balance, amount)`.\n    compile_error!(\"Subgoal 2c is not written yet: match on add_lamports(balance, amount) — Ok(new_balance) => new_balance, Err(_) => balance. Delete this line and the two below it.\");\n    let _ = amount;\n    balance\n}\n\n// ═════════════════════════════════════════════════════════════════════════════\n// SUBGOAL 3 — exhaustive matching, then add a fifth variant and watch.\n// ═════════════════════════════════════════════════════════════════════════════\n//\n// Order matters here. Write 3a and 3b first, build them green, and only then\n// do step 3c.\n\n/// 3a. A stable code for logs and clients. Write an exhaustive `match` over\n///     every variant of `VaultError`. NO `_ =>` arm — a catch-all is how you\n///     throw exhaustiveness away, which is the one thing this lesson is about.\n///     Suggested strings: \"overflow\", \"insufficient_funds\", \"zero_amount\",\n///     \"not_owner\".\n///\n///     `#[error_code]` derived `Copy`, so this takes the error by value rather\n///     than by reference. That is lesson 5's rule, applied.\npub fn error_slug(e: VaultError) -> &'static str {\n    // TODO (3a) — replace this with the match.\n    compile_error!(\"Subgoal 3a is not written yet: an exhaustive match over every VaultError variant, no `_ =>` arm. Delete this line and the two below it.\");\n    let _ = e;\n    \"todo\"\n}\n\n/// 3b. A second exhaustive `match` over the same enum. Can the caller do\n///     anything about this, or is retrying pointless?\n///       Overflow => false, InsufficientFunds => true,\n///       ZeroAmount => true, NotOwner => false\npub fn is_caller_fixable(e: VaultError) -> bool {\n    // TODO (3b) — replace this with the match.\n    compile_error!(\"Subgoal 3b is not written yet: a second exhaustive match over VaultError returning bool. Delete this line and the two below it.\");\n    let _ = e;\n    false\n}\n\n// TODO (3c) — the point of the whole lesson.\n//\n// Add a fifth variant to VaultError, in SUBGOAL 1:\n//\n//     #[msg(\"Vault is frozen and cannot move lamports\")]\n//     VaultFrozen,\n//\n// Then BUILD, before you change anything else. Read the errors. There will be\n// two of them, one per match site, each one naming the file and the line and\n// the variant you did not handle: `error[E0004]: non-exhaustive patterns:\n// `VaultError::VaultFrozen` not covered`.\n//\n// That is the compiler enumerating your unhandled cases. It is the JavaScript\n// `switch` you forgot to update, caught before the code shipped instead of by a\n// user. Now add the two arms — \"vault_frozen\", and false — and build green.\n\n// ── DO NOT EDIT ──────────────────────────────────────────────────────────────\n// Pins the five names above to their exact signatures. If one is missing, or its\n// types drift, this stops compiling. It checks names and types — not what your\n// bodies compute.\n#[allow(dead_code)]\nmod verify {\n    use super::*;\n\n    const _ADD: fn(u64, u64) -> Result<u64> = add_lamports;\n    const _SUB: fn(u64, u64) -> Result<u64> = sub_lamports;\n    const _AFTER: fn(u64, u64) -> u64 = balance_after_deposit;\n    const _SLUG: fn(VaultError) -> &'static str = error_slug;\n    const _FIXABLE: fn(VaultError) -> bool = is_caller_fixable;\n}\n\n// ── `unwrap()` ───────────────────────────────────────────────────────────────\n// Do not use it here. The reason is on the lesson page, argued in full: a panic\n// aborts the instruction with no error code and no `#[msg]` string, so every\n// named variant above becomes indistinguishable noise.\n",
+        "solution": "// vault_core.rs — the error type, and Result instead of panic.\n\nuse anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n// ═════════════════════════════════════════════════════════════════════════════\n// SUBGOAL 1 — the error enum. PRE-FILLED. Read it; do not change it.\n// ═════════════════════════════════════════════════════════════════════════════\n//\n// `#[error_code]` takes an ordinary enum and generates:\n//   - `#[derive(Debug, Clone, Copy)]` and `#[repr(u32)]` on it\n//   - `fn name(&self) -> String`, returning the variant's name\n//   - `impl From<VaultError> for u32`  ->  `variant as u32 + 6000`\n//   - `impl Display for VaultError`, from your `#[msg]` strings\n//   - `impl From<VaultError> for anchor_lang::error::Error`\n//\n// `error!(VaultError::Overflow)` uses the first three, not the last one: it\n// builds an `AnchorError` out of `name()`, `into()` and `to_string()`. The\n// `From<VaultError> for Error` impl is what `?` needs, and lesson 12 is where\n// that matters.\n//\n// The 6000 is `anchor_lang::error::ERROR_CODE_OFFSET`. Codes below it belong to\n// the runtime and to Anchor itself, so your first variant is 6000, not 0.\n// `#[msg(...)]` is the string a client displays; it is carried into the IDL.\n#[error_code]\npub enum VaultError {\n    #[msg(\"Deposit would overflow the vault balance\")]\n    Overflow, // 6000\n    #[msg(\"Withdrawal exceeds the vault balance\")]\n    InsufficientFunds, // 6001\n    #[msg(\"Amount must be greater than zero\")]\n    ZeroAmount, // 6002\n    #[msg(\"Signer is not the vault owner\")]\n    NotOwner, // 6003\n    #[msg(\"Vault is frozen and cannot move lamports\")]\n    VaultFrozen, // 6004  <- added in SUBGOAL 3\n}\n\n// ═════════════════════════════════════════════════════════════════════════════\n// SUBGOAL 2 — turn lesson 4's `Option` into a `Result` that says why.\n// ═════════════════════════════════════════════════════════════════════════════\n\n/// 2a. `checked_add` answers \"did it fit?\". A program has to answer \"why not?\".\n///\n/// Note what is NOT here: a zero-amount check. `add_lamports(500, 0)` is\n/// `Ok(500)`. Rejecting a zero deposit is a policy, it belongs in the method\n/// that owns the vault, and lesson 13's `VaultState::deposit` is where\n/// `ZeroAmount` is finally raised — exactly as lesson 4 promised. The variant is\n/// declared here because the enum is the program's complete failure set; the\n/// enum being complete does not mean every variant is raised in this file.\npub fn add_lamports(balance: u64, amount: u64) -> Result<u64> {\n    match balance.checked_add(amount) {\n        Some(new_balance) => Ok(new_balance),\n        None => Err(error!(VaultError::Overflow)),\n    }\n}\n\n/// 2b. The same shape, and a different reason for the same shape of failure.\n/// `sub_lamports(500, 500)` is `Ok(0)` — withdrawing the whole balance is legal.\npub fn sub_lamports(balance: u64, amount: u64) -> Result<u64> {\n    match balance.checked_sub(amount) {\n        Some(remaining) => Ok(remaining),\n        None => Err(error!(VaultError::InsufficientFunds)),\n    }\n}\n\n/// 2c. Consuming a `Result` by matching on it. A rejected deposit leaves the\n/// balance where it was — no `.unwrap()`, no panic, no lost lamports.\npub fn balance_after_deposit(balance: u64, amount: u64) -> u64 {\n    match add_lamports(balance, amount) {\n        Ok(new_balance) => new_balance,\n        Err(_) => balance,\n    }\n}\n\n// ═════════════════════════════════════════════════════════════════════════════\n// SUBGOAL 3 — exhaustive matching, then add a fifth variant and watch.\n// ═════════════════════════════════════════════════════════════════════════════\n\n/// 3a. A stable code for logs and clients. Exhaustive `match`, no `_ =>` arm.\n/// `#[error_code]` derived `Copy`, so this takes the error by value — lesson 5's\n/// rule, applied.\npub fn error_slug(e: VaultError) -> &'static str {\n    match e {\n        VaultError::Overflow => \"overflow\",\n        VaultError::InsufficientFunds => \"insufficient_funds\",\n        VaultError::ZeroAmount => \"zero_amount\",\n        VaultError::NotOwner => \"not_owner\",\n        VaultError::VaultFrozen => \"vault_frozen\",\n    }\n}\n\n/// 3b. A second exhaustive `match` over the same enum: can the caller do\n/// anything about this, or is retrying pointless?\npub fn is_caller_fixable(e: VaultError) -> bool {\n    match e {\n        VaultError::Overflow => false,\n        VaultError::InsufficientFunds => true,\n        VaultError::ZeroAmount => true,\n        VaultError::NotOwner => false,\n        VaultError::VaultFrozen => false,\n    }\n}\n\n// ── DO NOT EDIT ──────────────────────────────────────────────────────────────\n// Pins the four names above to their exact signatures. If one is missing, or\n// its types drift, this stops compiling. It checks names and types — not what\n// your bodies compute.\n#[allow(dead_code)]\nmod verify {\n    use super::*;\n\n    const _ADD: fn(u64, u64) -> Result<u64> = add_lamports;\n    const _SUB: fn(u64, u64) -> Result<u64> = sub_lamports;\n    const _AFTER: fn(u64, u64) -> u64 = balance_after_deposit;\n    const _SLUG: fn(VaultError) -> &'static str = error_slug;\n    const _FIXABLE: fn(VaultError) -> bool = is_caller_fixable;\n}\n",
+        "tests": [
+          {
+            "id": "compiles",
+            "description": "The file compiles against anchor-lang 1.1.2 on the build server",
+            "input": "",
+            "expectedOutput": "true"
+          },
+          {
+            "id": "verify-harness-resolves",
+            "description": "The non-editable `mod verify` block resolves: add_lamports, sub_lamports, balance_after_deposit, error_slug and is_caller_fixable all exist with the exact declared signatures — a missing name or a drifted type is a compile error",
+            "input": "",
+            "expectedOutput": "true"
+          },
+          {
+            "id": "matches-cover-declared-variants",
+            "description": "Every `match` over VaultError covers every variant you declared — omitting one is E0004 at compile time. Note what this cannot see: a `_ =>` catch-all also compiles, so dropping the wildcard is your discipline, not the grader's",
+            "input": "",
+            "expectedOutput": "true"
+          }
+        ],
+        "hints": [
+          "Subgoal 2 is one shape, used twice: `match balance.checked_add(amount) { Some(new_balance) => Ok(new_balance), None => Err(error!(VaultError::Overflow)) }`, then the same with `checked_sub` and `InsufficientFunds`. Do NOT add a zero-amount guard — that is policy, it lives in lesson 13's `deposit`, and lesson 4 said so.",
+          "Subgoal 3: get both matches green over the four existing variants FIRST, then add `VaultFrozen` and build before touching anything else. The two `error[E0004]: non-exhaustive patterns` messages are the exercise — they name the file, the line and the variant.",
+          "Stuck on a type error in 2c? `balance_after_deposit` returns a plain `u64`, not a `Result`, so the `match` has to produce a `u64` from both arms: `Ok(new_balance) => new_balance` and `Err(_) => balance`. This is the one place a wildcard is correct — you are deliberately saying every failure means the same thing here."
+        ],
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "check",
+        "_type": "quiz",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": [
+          {
+            "id": "q1",
+            "prompt": "You add `_ => \"unknown\"` as a final arm to `error_slug`, and only then add the fifth variant `VaultFrozen`. Predict.",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "It compiles, and `error_slug(VaultError::VaultFrozen)` silently returns \"unknown\"",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "`error[E0004]` still fires — the compiler requires named arms for every variant regardless of a catch-all",
+                "correct": false,
+                "feedback": "A `_` arm makes the match exhaustive by definition. That is the whole reason it silences E0004, and the whole reason it is a bad idea here."
+              },
+              {
+                "id": "c",
+                "label": "`warning: unreachable pattern` on the `_` arm, because all five variants are named above it",
+                "correct": false,
+                "feedback": "That warning appears when every variant IS named above the wildcard. In this question only four are, so the wildcard is reachable — it is doing exactly the thing you did not want."
+              },
+              {
+                "id": "d",
+                "label": "It compiles and `VaultFrozen` gets code 6004, so the slug is derived from the number",
+                "correct": false,
+                "feedback": "The number and the slug are unrelated. `error_slug` returns whatever your match arms say, and the catch-all says \"unknown\"."
+              }
+            ],
+            "explanation": "A wildcard is not a shortcut for \"handle the rest\". It is a decision to stop being told when the set of cases changes. Two match sites with no wildcard gave you a to-do list; two with a wildcard give you silence."
+          },
+          {
+            "id": "q2",
+            "prompt": "A client's transaction fails and the log shows `custom program error: 0x1772`. That is 6002 in decimal. Given the enum in the exercise — `Overflow`, `InsufficientFunds`, `ZeroAmount`, `NotOwner`, `VaultFrozen`, in that order — which failure was it?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "`ZeroAmount` — custom codes start at 6000, so index 2 is 6002",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "`ZeroAmount` — but only because you declared it third; the code is the declaration index alone, with no offset",
+                "correct": false,
+                "feedback": "The variant is right and the reasoning is not. Without the 6000 offset the code would be 2, which collides with the Solana runtime's own error space. `impl From<VaultError> for u32` is literally `variant as u32 + 6000`."
+              },
+              {
+                "id": "c",
+                "label": "`NotOwner` — the offset is 6000 and codes are 1-based, so 6001 is the first variant",
+                "correct": false,
+                "feedback": "Enum discriminants start at 0, so the first variant is 6000 exactly."
+              },
+              {
+                "id": "d",
+                "label": "Not determinable — 6002 is Anchor's own error space, not yours",
+                "correct": false,
+                "feedback": "Anchor's built-in `ErrorCode` sits below 6000. Everything from 6000 up is yours, which is exactly what the offset buys."
+              }
+            ],
+            "explanation": "Because the code is the declaration index plus 6000, variant order is part of your program's public interface. Insert a variant in the middle and every code after it shifts. Add at the end."
+          },
+          {
+            "id": "q3",
+            "prompt": "You decide layout failures deserve their own type, so you add a second `#[error_code] pub enum LayoutError { TooShort }` to the same file. Predict.",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "It compiles — and that is the problem: `LayoutError::TooShort` is also 6000, indistinguishable on the wire from `VaultError::Overflow`",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "`error: only one #[error_code] enum is permitted per program`",
+                "correct": false,
+                "feedback": "There is no such check in anchor-lang 1.1.2 — verified by compiling it. The guidance is real; the compiler does not enforce it, which is why the failure is silent and on the wire."
+              },
+              {
+                "id": "c",
+                "label": "It compiles, and Anchor numbers the second enum from 7000 so the two cannot collide",
+                "correct": false,
+                "feedback": "Nothing auto-assigns a second range. Both enums default to `ERROR_CODE_OFFSET`, which is 6000 for every enum that does not say otherwise."
+              },
+              {
+                "id": "d",
+                "label": "It compiles, but only one of the two ends up in the IDL, so the other's `#[msg]` strings are lost",
+                "correct": false,
+                "feedback": "That is not the failure mode. Both are generated; the collision is in the numbers a client reads back."
+              }
+            ],
+            "explanation": "One error enum per program is the rule, and the reason is the numbering, not the compiler. If you truly need a second one, give it an explicit range with `#[error_code(offset = 1000)]` — which replaces 6000 rather than adding to it."
+          },
+          {
+            "id": "q4",
+            "prompt": "Carried over from lesson 4. There, `sub_lamports(5, 7)` returned `None`. Here it returns `Err(error!(VaultError::InsufficientFunds))`. A caller inside a program writes `let remaining = sub_lamports(5, 7).unwrap();`. Predict what the client sees.",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "A panic that aborts the instruction — no 6001, no \"Withdrawal exceeds the vault balance\", nothing to distinguish it from a bug",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "`custom program error: 0x1771` — `.unwrap()` propagates the error, it just does not let you inspect it",
+                "correct": false,
+                "feedback": "`.unwrap()` does not propagate anything. It panics, and the named error never reaches the client. Propagating is `?`, which is lesson 12."
+              },
+              {
+                "id": "c",
+                "label": "A compile error — `.unwrap()` is not available on `anchor_lang::Result`",
+                "correct": false,
+                "feedback": "It compiles. That is the danger: nothing in the toolchain stops you, which is why the rule has to be yours."
+              },
+              {
+                "id": "d",
+                "label": "`remaining` is 0, since `.unwrap()` falls back to the type's default on `Err`",
+                "correct": false,
+                "feedback": "That is `unwrap_or_default()`, a different method. `.unwrap()` has no fallback — it panics."
+              }
+            ],
+            "explanation": "Every named variant, every `#[msg]` string and every error code in this lesson is thrown away at the moment you write `.unwrap()`. It appears nowhere in this course's code — the one place you will see it written out is lesson 9, where the compiler itself suggests it and the right answer is to refuse."
+          }
+        ],
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      }
+    ]
+  },
+  {
+    "_id": "lesson-rpd-error-plumbing",
+    "title": "Error Plumbing with `?`",
+    "slug": "error-plumbing",
+    "blocks": [
+      {
+        "key": "intro",
+        "_type": "prose",
+        "produces": null,
+        "consumes": null,
+        "src": "# Error Plumbing with `?`\n\n> **Version stamp — checked 2026-07-26.** `anchor-lang 1.1.2` (latest on crates.io, published 2026-06-26) · `borsh 1.8.0` · `cargo-build-sbf` with platform-tools v1.54 (rustc 1.89) · edition 2021. Every compiler message quoted below was produced by compiling this lesson's file; the `require!` / `require_keys_eq!` expansions were read out of `anchor-lang 1.1.2`'s source.\n\nLesson 11 gave every failure a name. Now they have to travel.\n\nA real instruction is a chain: read the bytes, validate what they say, apply the policy, do the arithmetic. Any link can fail, and the failure has to arrive at the top intact. Written by hand, the middle of that chain is nothing but plumbing:\n\n```rust\nlet amount = match read_amount(data) {\n    Ok(amount) => amount,\n    Err(e) => return Err(e.into()),\n};\n```\n\nFour lines to say \"if this failed, stop.\" `?` is that, in one character.\n\n## What `?` actually does\n\n```rust\nlet amount = read_amount(data)?;\n```\n\ndesugars to roughly:\n\n1. Evaluate `read_amount(data)`.\n2. If it is `Ok(v)`, the expression's value is `v` and execution continues.\n3. If it is `Err(e)`, **return `Err(From::from(e))` from the enclosing function immediately.**\n\nStep 3 is the whole lesson. `?` does not just propagate the error, it **converts** it — by calling `From::from` on the way out. Which means `?` only works across two different error types if a `From` impl connects them.\n\nThat is why `?` stops feeling arbitrary once you have lesson 10's trait material. It is not a special language feature that knows about your errors. It is one trait lookup, and you can write the trait impl yourself.\n\n## The seam this file has\n\nThe exercise chain has three layers and two error types.\n\n| Layer | Function | Fails with |\n| --- | --- | --- |\n| Layout | `read_amount(&[u8])` | `LayoutError` — a plain enum |\n| Policy | `check_amount(u64)`, `check_owner(&Pubkey, &Pubkey)` | `VaultError` — the `#[error_code]` enum |\n| Caller | `withdraw_amount(...)` | `anchor_lang::error::Error` |\n\n`LayoutError` is deliberately **not** an `#[error_code]` enum. Lesson 11's rule holds: one `#[error_code]` per program, because a second one numbers from 6000 too and collides on the wire. A malformed instruction is an internal concern, so `LayoutError` stays a plain enum and is translated at the boundary:\n\n```rust\nimpl From<LayoutError> for anchor_lang::error::Error {\n    fn from(e: LayoutError) -> Self {\n        match e {\n            LayoutError::TooShort => error!(ErrorCode::InstructionDidNotDeserialize),\n        }\n    }\n}\n```\n\n`ErrorCode` there is Anchor's own built-in enum — the one that lives below 6000 — and `InstructionDidNotDeserialize` is exactly what a client should be told when the instruction data was the wrong shape.\n\nDelete that impl and the chain stops compiling:\n\n```\nerror[E0277]: `?` couldn't convert the error to `anchor_lang::prelude::Error`\n   |\n   | ) -> Result<u64> {\n   |      ----------- expected `anchor_lang::prelude::Error` because of this\n   |     let amount = read_amount(data)?;\n   |                  -----------------^ the trait `std::convert::From<LayoutError>` is not implemented for `anchor_lang::prelude::Error`\n   |                  |\n   |                  this can't be annotated with `?` because it has type `Result<_, LayoutError>`\n   |\nnote: `LayoutError` needs to implement `Into<anchor_lang::prelude::Error>`\n```\n\nRead that error twice. It is not saying `?` is broken. It is naming the exact trait impl that is missing, which is the most useful error message in this course.\n\n## `require!` and `err!`, with the covers off\n\nBoth are shorthands you have already written longhand.\n\n```rust\nrequire!(amount > 0, VaultError::ZeroAmount);\n// expands to:\nif !(amount > 0) { return Err(error!(VaultError::ZeroAmount)); }\n\nerr!(VaultError::Overflow)\n// expands to:\nErr(error!(VaultError::Overflow))\n```\n\nThat is the entire definition of each. `require!` is for testing a condition; `err!` is for returning an error you have already decided on — a `match` arm, usually. Neither does anything you could not type yourself, and both make the intent legible at a glance, which in a program full of guard clauses is worth a lot.\n\nOne near-miss worth knowing: for pubkeys, use `require_keys_eq!`, not `require_eq!`. `require_eq!` will compile — `Pubkey` implements `ToString`, so the generic version accepts it — but Anchor's own docs reserve it for non-pubkey values, and `require_keys_eq!` records the two operands as pubkeys and logs them with `Pubkey::log()` rather than allocating two strings. Same check, fewer compute units, and the log shape a client expects.\n\n## `?` does not work on `Option`\n\nThis is the error you will hit most, and the compiler is unusually helpful about it:\n\n```\nerror[E0277]: the `?` operator can only be used on `Result`s, not `Option`s,\n              in a function that returns `Result`\n   |\n   |     let remaining = balance.checked_sub(amount)?;\n   |                                                ^ use `.ok_or(...)?` to provide\n   |                                                  an error compatible with\n   |                                                  `Result<u64, Error>`\n```\n\nThe reason follows from step 3 above: `?` converts the error by calling `From::from` on it, and `None` is not an error value — there is nothing to convert. So you supply one:\n\n```rust\nlet remaining = balance\n    .checked_sub(amount)\n    .ok_or(error!(VaultError::InsufficientFunds))?;\n```\n\n`ok_or` turns `Option<u64>` into `Result<u64, Error>` by naming the failure, and *then* `?` has something to carry. This single line is the bridge from lesson 4's `Option`-returning helpers to a program that reports real errors — and it is where `checked_sub` finally becomes `VaultState::withdraw`.\n\n## Closing the lesson-4 loop\n\nLesson 4's helpers were `const fn`, and they matched on `Option` by hand instead of using `?`. Now you know why: **`?` is not allowed in a `const fn`.**\n\n```\nerror[E0015]: `?` is not allowed on `Option<u64>` in constant functions\n  = note: calls in constant functions are limited to constant functions, tuple\n          structs and tuple variants\n```\n\nThe note is the mechanism: `?` desugars to calls into the `Try` machinery, those functions are not `const fn`, and a `const fn` may only call `const fn`. So the compiler does not report a missing feature — it reports a non-const call. `match` works in a `const fn`; `?` does not. That constraint is what made the compile-time assertion harness in lesson 4 possible, and it is why those two functions look different from everything in this file.\n\n## The exercise\n\nThe file does not compile as given, and that is the exercise. Every line you need is present; two functions have had their statements shuffled, and one of them carries two decoy lines.\n\nBuild first. The compiler's first pass gives you four errors, and each one is a location:\n\n- `error[E0425]: cannot find value 'head' in this scope` — a line uses a name that a later line defines. Order.\n- `error[E0425]: cannot find value 'amount' in this scope` — same problem, other function.\n- `error[E0308]: mismatched types ... expected 'u64', found 'Result<u64, LayoutError>'` — decoy: somebody dropped the `?`.\n- `error[E0277]: the '?' operator can only be used on 'Result's, not 'Option's` — decoy: `?` on `checked_sub`.\n\nWork in two passes: fix the order first, then delete the decoys. Do not try to repair a decoy — it is meant to go.\n\nBoth decoys are compile errors rather than silent bugs, which buys something real and less than it sounds. What the grader can tell is that **neither decoy survived** — leave either one in place and the build is red. What it cannot tell is whether you kept every *correct* line, or what order you put them in. Delete `let amount = check_amount(amount)?;` as though it were a third decoy and the file compiles green with the zero-amount policy simply gone. Move `check_owner(signer, owner)?;` to the bottom and it compiles green with the authorisation check running after the arithmetic — the exact inversion of step 1 above.\n\nSo: the two decoys are enforced, the ordering and the completeness are on you. That is the same limit as every other exercise in this course, narrowed by two lines rather than removed. It is still why the lesson is shaped as an ordering-and-discrimination task — a decoy that fails loudly is worth more than a blank page — but do not read a green build as \"the chain is right\".\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "exercise",
+        "_type": "code",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": "rust",
+        "buildType": "buildable",
+        "deployable": false,
+        "starter": "// vault_core.rs — errors that travel.\n//\n// THIS FILE DOES NOT COMPILE AS GIVEN. That is the exercise.\n//\n// Two functions have had their lines shuffled, and one of them carries two decoy\n// lines that look plausible and are not. Every piece you need is already here —\n// nothing has to be invented. Build first and let the compiler tell you what is\n// out of order; then reorder, and delete the two decoys.\n\nuse anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n// ── GIVEN: the program's one error enum ──────────────────────────────────────\n#[error_code]\npub enum VaultError {\n    #[msg(\"Deposit would overflow the vault balance\")]\n    Overflow,\n    #[msg(\"Withdrawal exceeds the vault balance\")]\n    InsufficientFunds,\n    #[msg(\"Amount must be greater than zero\")]\n    ZeroAmount,\n    #[msg(\"Signer is not the vault owner\")]\n    NotOwner,\n}\n\n// ── GIVEN: a SECOND error type, deliberately not an #[error_code] ────────────\n//\n// One `#[error_code]` enum per program: a second one would also number from\n// 6000 and collide on the wire. Layout failures are an internal concern, so\n// `LayoutError` is a plain enum that never reaches a client under its own name.\n#[derive(Debug, Clone, Copy, PartialEq, Eq)]\npub enum LayoutError {\n    TooShort,\n}\n\n// ── GIVEN: the conversion that makes `?` work across the seam ────────────────\n//\n// This is the payoff from lesson 10. `?` does not know anything about your error\n// types; it calls `From::from` on the error it is carrying. Write the `From` impl\n// and `?` starts crossing the boundary. Delete it and `?` stops compiling — the\n// operator is not magic, it is one trait lookup.\nimpl From<LayoutError> for anchor_lang::error::Error {\n    fn from(e: LayoutError) -> Self {\n        match e {\n            LayoutError::TooShort => error!(ErrorCode::InstructionDidNotDeserialize),\n        }\n    }\n}\n\n// ── LAYER 1: layout. SCRAMBLED — two correct lines, wrong order. ─────────────\n//\n// Note the return type: `core::result::Result<u64, LayoutError>`, spelled out,\n// because bare `Result<u64>` in this file means Anchor's alias.\n//\n// Swap the two statements. Think about which name has to exist before the next\n// line can use it. The tail expression at the bottom is correct — leave it.\nfn read_amount(data: &[u8]) -> core::result::Result<u64, LayoutError> {\n    let bytes: [u8; 8] = head.try_into().map_err(|_| LayoutError::TooShort)?;\n    let head = data.get(..8).ok_or(LayoutError::TooShort)?;\n\n    Ok(u64::from_le_bytes(bytes))\n}\n\n// ── LAYER 2: policy. GIVEN — read these two, they are your reference. ────────\n//\n// `require!(cond, E)` expands to `if !(cond) { return Err(error!(E)); }`.\n// Nothing more. It reads better than the `if`, and that is its whole value.\nfn check_amount(amount: u64) -> Result<u64> {\n    require!(amount > 0, VaultError::ZeroAmount);\n    Ok(amount)\n}\n\n// `require_eq!` would also compile here — `Pubkey` implements `ToString`. Use\n// `require_keys_eq!` anyway: Anchor's own docs reserve `require_eq!` for\n// non-pubkey values, and the pubkey version records the two operands as pubkeys\n// and logs them with `Pubkey::log()` instead of allocating two strings. Same\n// check, fewer compute units, and the log a client expects.\nfn check_owner(signer: &Pubkey, owner: &Pubkey) -> Result<()> {\n    require_keys_eq!(*signer, *owner, VaultError::NotOwner);\n    Ok(())\n}\n\n// ── LAYER 3: the caller. SCRAMBLED, plus two decoys. ─────────────────────────\n//\n// Six statements below. FOUR are correct and in the wrong order. TWO are decoys:\n// delete them, do not try to make them work. The tail expression is correct.\n//\n// Do it in two passes.\n//\n// Pass 1 — order. The chain you want, in words:\n//   1. refuse anyone who is not the owner\n//   2. read the amount out of the instruction data\n//   3. check the amount against policy\n//   4. subtract it from the balance, refusing to underflow\n//\n// Pass 2 — discrimination. Delete the two decoys. Both are compile errors rather\n// than silent bugs, so the build server genuinely cannot pass this block while\n// one is still here. Read each error before you delete the line; the decoy that\n// calls `?` on an `Option` produces the single most useful message in this\n// lesson, and the compiler suggests the fix in the error text itself.\n//\n// What pass 2 does NOT get you: the ordering from pass 1 is not checked by\n// anything. Delete a correct line as though it were a third decoy, or run the\n// owner check last, and this file still compiles. Two lines are enforced; the\n// chain is yours.\npub fn withdraw_amount(\n    data: &[u8],\n    balance: u64,\n    signer: &Pubkey,\n    owner: &Pubkey,\n) -> Result<u64> {\n    let amount = check_amount(amount)?;\n    let amount = read_amount(data);\n    check_owner(signer, owner)?;\n    let remaining = balance.checked_sub(amount)?;\n    let amount = read_amount(data)?;\n    let remaining = balance\n        .checked_sub(amount)\n        .ok_or(error!(VaultError::InsufficientFunds))?;\n\n    Ok(remaining)\n}\n\n/// GIVEN: the deposit half. Two `?` in one expression, and `err!(E)` — which is\n/// exactly `Err(error!(E))`, for when you are returning the error rather than\n/// testing a condition.\npub fn deposit_amount(data: &[u8], balance: u64) -> Result<u64> {\n    let amount = check_amount(read_amount(data)?)?;\n    match balance.checked_add(amount) {\n        Some(new_balance) => Ok(new_balance),\n        None => err!(VaultError::Overflow),\n    }\n}\n\n/// GIVEN, to read rather than to call: `?` with the sugar taken off.\n/// It is a `match`, an early `return`, and one call to `From::from`.\npub fn read_amount_the_long_way(data: &[u8]) -> Result<u64> {\n    match read_amount(data) {\n        Ok(amount) => Ok(amount),\n        Err(layout) => Err(anchor_lang::error::Error::from(layout)),\n    }\n}\n\n// ── DO NOT EDIT ──────────────────────────────────────────────────────────────\n// Pins the chain's shape: the three names below must exist with exactly these\n// types. Names and types only — nothing here checks what your bodies compute.\n#[allow(dead_code)]\nmod verify {\n    use super::*;\n\n    const _WITHDRAW: fn(&[u8], u64, &Pubkey, &Pubkey) -> Result<u64> = withdraw_amount;\n    const _DEPOSIT: fn(&[u8], u64) -> Result<u64> = deposit_amount;\n    const _LONG_WAY: fn(&[u8]) -> Result<u64> = read_amount_the_long_way;\n}\n\n// ── Why lesson 4 could not use `?` ───────────────────────────────────────────\n// Lesson 4's helpers were `const fn`, and matched on `Option` by hand. Now you\n// know why: `?` is not allowed in a `const fn`. Try it and the compiler says\n// `error[E0015]: '?' is not allowed on 'Option<u64>' in constant functions`,\n// because the `Try` trait is not yet const. `match` works in a `const fn`;\n// `?` does not. That is the entire reason those two functions look different\n// from everything in this file.\n",
+        "solution": "// vault_core.rs — errors that travel.\n\nuse anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n// ── GIVEN: the program's one error enum ──────────────────────────────────────\n#[error_code]\npub enum VaultError {\n    #[msg(\"Deposit would overflow the vault balance\")]\n    Overflow,\n    #[msg(\"Withdrawal exceeds the vault balance\")]\n    InsufficientFunds,\n    #[msg(\"Amount must be greater than zero\")]\n    ZeroAmount,\n    #[msg(\"Signer is not the vault owner\")]\n    NotOwner,\n}\n\n// ── GIVEN: a SECOND error type, deliberately not an #[error_code] ────────────\n//\n// One `#[error_code]` enum per program: a second one would also number from\n// 6000 and collide on the wire. Layout failures are an internal concern, so\n// `LayoutError` is a plain enum that never reaches a client under its own name.\n#[derive(Debug, Clone, Copy, PartialEq, Eq)]\npub enum LayoutError {\n    TooShort,\n}\n\n// ── GIVEN: the conversion that makes `?` work across the seam ────────────────\n//\n// This is the payoff from lesson 10. `?` does not know anything about your error\n// types; it calls `From::from` on the error it is carrying. Write the `From` impl\n// and `?` starts crossing the boundary. Delete it and `?` stops compiling — the\n// operator is not magic, it is one trait lookup.\nimpl From<LayoutError> for anchor_lang::error::Error {\n    fn from(e: LayoutError) -> Self {\n        match e {\n            LayoutError::TooShort => error!(ErrorCode::InstructionDidNotDeserialize),\n        }\n    }\n}\n\n// ── LAYER 1: layout. Fails with LayoutError. ─────────────────────────────────\n//\n// Note the return type: `core::result::Result<u64, LayoutError>`, spelled out,\n// because bare `Result<u64>` in this file means Anchor's alias.\nfn read_amount(data: &[u8]) -> core::result::Result<u64, LayoutError> {\n    let head = data.get(..8).ok_or(LayoutError::TooShort)?;\n    let bytes: [u8; 8] = head.try_into().map_err(|_| LayoutError::TooShort)?;\n    Ok(u64::from_le_bytes(bytes))\n}\n\n// ── LAYER 2: policy. Fails with VaultError. ──────────────────────────────────\n//\n// `require!(cond, E)` expands to `if !(cond) { return Err(error!(E)); }`.\n// Nothing more. It reads better than the `if`, and that is its whole value.\nfn check_amount(amount: u64) -> Result<u64> {\n    require!(amount > 0, VaultError::ZeroAmount);\n    Ok(amount)\n}\n\n// `require_eq!` would also compile here — `Pubkey` implements `ToString`. Use\n// `require_keys_eq!` anyway: Anchor's own docs reserve `require_eq!` for\n// non-pubkey values, and the pubkey version records the two operands as pubkeys\n// and logs them with `Pubkey::log()` instead of allocating two strings. Same\n// check, fewer compute units, and the log a client expects.\nfn check_owner(signer: &Pubkey, owner: &Pubkey) -> Result<()> {\n    require_keys_eq!(*signer, *owner, VaultError::NotOwner);\n    Ok(())\n}\n\n// ── LAYER 3: the caller. Chains both layers with `?`. ────────────────────────\npub fn withdraw_amount(\n    data: &[u8],\n    balance: u64,\n    signer: &Pubkey,\n    owner: &Pubkey,\n) -> Result<u64> {\n    check_owner(signer, owner)?;\n    let amount = read_amount(data)?;\n    let amount = check_amount(amount)?;\n    let remaining = balance\n        .checked_sub(amount)\n        .ok_or(error!(VaultError::InsufficientFunds))?;\n    Ok(remaining)\n}\n\n/// The deposit half. Two `?` in one expression, and `err!(E)` — which is exactly\n/// `Err(error!(E))`, for when you are returning the error rather than testing a\n/// condition.\npub fn deposit_amount(data: &[u8], balance: u64) -> Result<u64> {\n    let amount = check_amount(read_amount(data)?)?;\n    match balance.checked_add(amount) {\n        Some(new_balance) => Ok(new_balance),\n        None => err!(VaultError::Overflow),\n    }\n}\n\n/// GIVEN, to read rather than to call: `?` with the sugar taken off.\n/// It is a `match`, an early `return`, and one call to `From::from`.\npub fn read_amount_the_long_way(data: &[u8]) -> Result<u64> {\n    match read_amount(data) {\n        Ok(amount) => Ok(amount),\n        Err(layout) => Err(anchor_lang::error::Error::from(layout)),\n    }\n}\n\n// ── DO NOT EDIT ──────────────────────────────────────────────────────────────\n// Pins the chain's shape: the three names below must exist with exactly these\n// types. Names and types only — nothing here checks what your bodies compute.\n#[allow(dead_code)]\nmod verify {\n    use super::*;\n\n    const _WITHDRAW: fn(&[u8], u64, &Pubkey, &Pubkey) -> Result<u64> = withdraw_amount;\n    const _DEPOSIT: fn(&[u8], u64) -> Result<u64> = deposit_amount;\n    const _LONG_WAY: fn(&[u8]) -> Result<u64> = read_amount_the_long_way;\n}\n",
+        "tests": [
+          {
+            "id": "compiles",
+            "description": "The file compiles against anchor-lang 1.1.2 on the build server — which for this exercise means the scrambled statements are in a working order",
+            "input": "",
+            "expectedOutput": "true"
+          },
+          {
+            "id": "decoys-removed",
+            "description": "Neither decoy survives: `read_amount(data)` without `?` is E0308, and `?` on `checked_sub`'s Option is E0277, so a file that still contains either one does not compile",
+            "input": "",
+            "expectedOutput": "true"
+          },
+          {
+            "id": "verify-harness-resolves",
+            "description": "The non-editable `mod verify` block resolves: withdraw_amount, deposit_amount and read_amount_the_long_way exist with the exact declared signatures — a missing name or a drifted type is a compile error",
+            "input": "",
+            "expectedOutput": "true"
+          }
+        ],
+        "hints": [
+          "Build it first. The file is not supposed to compile yet, and the four errors are the instructions. Read only the first one — the rest of a Rust error list is usually cascade from the first.",
+          "Order before deletion. Both `E0425: cannot find value` errors mean a statement uses a name that a later statement defines, so move the definition up. In `withdraw_amount` the chain is: owner check, read, policy check, subtract.",
+          "The two decoys are `let amount = read_amount(data);` (no `?`, so `amount` is a `Result` and the next call rejects it) and `let remaining = balance.checked_sub(amount)?;` (`?` on an `Option`, which cannot work because `None` carries no error to convert). Delete both — the correct subtraction line, with `.ok_or(error!(VaultError::InsufficientFunds))?`, is already in the file."
+        ],
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "check",
+        "_type": "quiz",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": [
+          {
+            "id": "q1",
+            "prompt": "Inside `withdraw_amount`, which returns `Result<u64>`, you write `let remaining = balance.checked_sub(amount)?;`. Predict.",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "`error[E0277]: the ? operator can only be used on Results, not Options` — and the compiler suggests `.ok_or(...)?`",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "It compiles, and an underflow returns `Err` with Anchor's built-in arithmetic error",
+                "correct": false,
+                "feedback": "There is no automatic mapping from `None` to an error. `?` propagates by calling `From::from` on an error value, and `None` does not carry one — which is exactly what the message says."
+              },
+              {
+                "id": "c",
+                "label": "It compiles, and an underflow silently yields 0 because `?` unwraps the `Option`",
+                "correct": false,
+                "feedback": "`?` never invents a value. If this compiled at all it would have to return something from the function, not substitute a default."
+              },
+              {
+                "id": "d",
+                "label": "`error[E0308]: mismatched types` — `checked_sub` returns `Option<u64>` and the function returns `Result<u64>`",
+                "correct": false,
+                "feedback": "Close, and it is a different error. E0308 is a plain type mismatch; this is E0277, a missing trait — the `Try` machinery has no conversion to offer. The distinction is why the fix is `.ok_or`, not a cast."
+              }
+            ],
+            "explanation": "`.ok_or(error!(VaultError::InsufficientFunds))?` turns the `Option` into a `Result` by naming the failure, and only then does `?` have something to carry. That one line is where lesson 4's `checked_sub` becomes a program that reports a real error."
+          },
+          {
+            "id": "q2",
+            "prompt": "You delete the `impl From<LayoutError> for anchor_lang::error::Error` block and change nothing else. `read_amount` still returns `Result<u64, LayoutError>` and `withdraw_amount` still calls it with `?`. Predict.",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "`error[E0277]: ? couldn't convert the error` — the trait `From<LayoutError>` is not implemented for `Error`",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "It compiles. `?` propagates the error unchanged; conversion only happens if you ask for it with `.into()`",
+                "correct": false,
+                "feedback": "`?` always converts — the desugaring is `return Err(From::from(e))`. With two different error types the conversion is not optional, it is the only way the return type can be satisfied."
+              },
+              {
+                "id": "c",
+                "label": "It compiles, and `LayoutError::TooShort` reaches the client as custom error 6000",
+                "correct": false,
+                "feedback": "`LayoutError` has no error code at all — it is a plain enum, not an `#[error_code]` one. There is nothing to send."
+              },
+              {
+                "id": "d",
+                "label": "A warning, and the error is coerced through `Debug` at runtime",
+                "correct": false,
+                "feedback": "Rust does not coerce types through `Debug`, and missing trait impls are errors rather than warnings."
+              }
+            ],
+            "explanation": "This is the payback for lesson 10. `?` is not a special language feature that understands your errors — it is one `From` lookup. Write the impl and errors cross the seam; delete it and they cannot."
+          },
+          {
+            "id": "q3",
+            "prompt": "Carried over from lesson 4. Those two helpers were `const fn` and matched on `Option` by hand. You now try to write `pub const fn sub_lamports(a: u64, b: u64) -> Option<u64> { let r = a.checked_sub(b)?; Some(r) }`. Predict.",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "`error[E0015]: ? is not allowed on Option<u64> in constant functions` — the `Try` trait is not const yet",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "It compiles — `checked_sub` is itself a `const fn`, so everything in the expression is const-evaluable",
+                "correct": false,
+                "feedback": "`checked_sub` being const is necessary and not sufficient. `?` goes through the `Try` trait, and trait methods are only callable in a `const fn` once the trait itself is const — which `Try` is not."
+              },
+              {
+                "id": "c",
+                "label": "It compiles, but the compile-time assertions from lesson 4 stop working",
+                "correct": false,
+                "feedback": "The assertions are the reason the function is `const fn` in the first place. If the function compiled, they would keep working; the function is what does not compile."
+              },
+              {
+                "id": "d",
+                "label": "`error[E0308]` — `?` on an `Option` in a function returning `Option` is a type mismatch",
+                "correct": false,
+                "feedback": "That combination is normally fine — `?` on `Option` inside a function returning `Option` is ordinary Rust. The problem here is `const`, not the types."
+              }
+            ],
+            "explanation": "`match` works in a `const fn`; `?` does not. That is the entire reason lesson 4's helpers look different from every function in this lesson, and why the compile-time assertion harness was possible there and is not possible on `deposit(&mut self)` in module 4."
+          }
+        ],
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      }
+    ]
+  },
+  {
+    "_id": "lesson-rpd-fix-the-borrow-checker",
+    "title": "Fix the Borrow Checker",
+    "slug": "fix-the-borrow-checker",
+    "blocks": [
+      {
+        "key": "reading-errors",
+        "_type": "prose",
+        "produces": null,
+        "consumes": null,
+        "src": "# Fix the Borrow Checker\n\n> **Version stamp — checked 2026-07-26.** `anchor-lang 1.1.2` (crates.io latest stable) · `borsh` 1.5.7 declared / **1.8.0** resolved · edition 2021 · Agave ≥ 3.1.10 / rustc per the build server's pinned platform-tools. Every error message quoted below was produced by compiling the starter file as shipped.\n\nYou have read the rules twice. Reading them a third time will not help. What helps is reading the compiler.\n\nThe exercise below does not build. Four functions, four real errors, and every fix is already somewhere on the page — commented out among a set of candidate lines, some of which are wrong. Your job is to pick and order, not to invent.\n\n**Build it before you change anything.** Then read the *first* error only. Rust reports every error it finds, and a borrow error early in a file usually produces two or three more downstream that vanish the moment you fix the first. Chasing them in parallel is how people conclude the borrow checker is arbitrary.\n\n## The four you will meet\n\n### `E0382` — use of moved value\n\n```text\nerror[E0382]: use of moved value: `vault`\n  |\n  |     consume_and_log(vault);\n  |                     ----- value moved here\n  |     vault.balance\n  |     ^^^^^^^^^^^^^ value used here after move\n```\n\nRead it bottom-up: the caret is where you used it, the dashes are where you lost it. The question to ask is never \"how do I get it back\" — it is **did that function need to own it at all?** Usually not, and the fix is a borrow. When it genuinely does need to own it, take what you need out first, or clone.\n\n### `E0502` — cannot borrow as mutable because it is also borrowed as immutable\n\n```text\nerror[E0502]: cannot borrow `*v` as mutable because it is also borrowed as immutable\n  |\n  |     let before = &v.balance;\n  |                  ---------- immutable borrow occurs here\n  |     credit(v, shortfall);\n  |     ^^^^^^^^^^^^^^^^^^^^ mutable borrow occurs here\n  |     *before\n  |     ------- immutable borrow later used here\n```\n\nThree lines named, and the third is the one that matters. The mutable borrow gets the caret, but it is not the problem — the problem is that the shared borrow is **used again afterwards**, which is what keeps it alive across the mutation. Delete that last use and the error disappears.\n\nSo the fix is almost never \"make the mutable borrow later\". It is: stop holding the shared borrow. If what you needed was a `u64`, take the `u64` by value; it is `Copy`, and a copied number cannot conflict with anything.\n\n### `E0499` — cannot borrow as mutable more than once at a time\n\n```text\nerror[E0499]: cannot borrow `*v` as mutable more than once at a time\n  |\n  |     let one = &mut *v;\n  |               ------- first mutable borrow occurs here\n  |     let two = &mut *v;\n  |               ^^^^^^^ second mutable borrow occurs here\n  |     credit(one, first);\n  |            --- first borrow later used here\n```\n\nThe honest reading: you asked for exclusive access twice and called it exclusive both times. The fix is nearly always to stop naming the borrows and just make the two calls in sequence — each call takes its borrow, uses it, and gives it back before the next line starts.\n\nNote what this error is *not*. Two mutable borrows of **different fields** of the same struct are fine (`&mut v.balance` and `&mut v.bump` coexist happily) — the checker tracks each field as its own place. If you have talked yourself into a `RefCell` to work around this error, re-read it first; most of the time the borrows were disjoint and the code just needed reordering.\n\n### `E0515` — cannot return reference to local variable\n\n```text\nerror[E0515]: cannot return value referencing local variable `owned`\n  |\n  |     &owned[..8]\n  |     ^-----^^^^^\n  |     ||\n  |     |`owned` is borrowed here\n  |     returns a value referencing data owned by the current function\n```\n\nThis one is not about the rules of borrowing. It is about **time**. `owned` is dropped when the function returns, so a reference into it would point at freed memory the instant the caller received it — the exact class of bug that makes C hard and that Rust exists to make impossible.\n\nEvery returned reference has to borrow from something that outlives the call. A parameter does. A local does not. The fix in bug 4 replaces two lines with one, and the one it keeps borrows from the parameter.\n\nAnd that question — *which* input does the returned reference borrow from? — is the question lifetime annotations answer. That is the next lesson, and bug 4 is the reason it exists.\n\n## Working method\n\n1. Build. Read the first error. Ignore the rest.\n2. Look at the candidate lines under that function. Decide which belong and in what order.\n3. Comment out the lines marked `BUG`, uncomment your choice, build again.\n4. Repeat. Four builds, four errors, in order.\n\nIf you get a fifth error you did not expect, you have chosen a decoy. That is a useful outcome — read what it says before you undo it.\n\nOne route is closed off deliberately. Four broken functions in a file that has to compile makes deleting them look like a fix; it is not, and the non-editable `mod verify` block at the bottom pins all five signatures, so a deletion fails to build with `E0425: cannot find value`. What that block cannot do is check a body. Bug 3 fixed in the wrong order still compiles, which is what quiz question 3 is about.\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "exercise",
+        "_type": "code",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": "rust",
+        "buildType": "buildable",
+        "deployable": false,
+        "starter": "// ---------------------------------------------------------------------------\n// Lesson 7 — Fix the Borrow Checker.\n//\n// THIS FILE DOES NOT COMPILE, AND THAT IS THE POINT. Four functions, four real\n// borrow-checker errors. Build it FIRST and read only the first error.\n//\n// Every fix is already on the page. Under each broken function is a numbered\n// list of candidate lines: some belong, some are decoys that fail in a\n// different way. For each bug:\n//\n//   1. Read the error.\n//   2. Choose the candidates that belong, and the order they go in.\n//   3. Comment out the lines marked BUG, uncomment your choice, build again.\n//\n// Nothing above the first bug needs changing.\n//\n// Toolchain: anchor-lang 1.1.2 · borsh 1.5.7 declared / 1.8.0 resolved · edition 2021.\n// ---------------------------------------------------------------------------\n\nuse anchor_lang::prelude::*;\n\n#[derive(Clone, Debug)]\npub struct VaultLike {\n    pub owner: Pubkey,\n    pub balance: u64,\n    pub bump: u8,\n}\n\npub const fn add_lamports(balance: u64, amount: u64) -> Option<u64> {\n    balance.checked_add(amount)\n}\n\npub const fn sub_lamports(balance: u64, amount: u64) -> Option<u64> {\n    balance.checked_sub(amount)\n}\n\n/// From lesson 6, unchanged.\npub fn credit(v: &mut VaultLike, amount: u64) {\n    if let Some(new_balance) = add_lamports(v.balance, amount) {\n        v.balance = new_balance;\n    }\n}\n\n/// Given. Takes the vault BY VALUE, so calling it hands the vault over for\n/// good. You are not allowed to change this signature — plenty of real APIs\n/// consume their argument and you do not get to rewrite them either.\npub fn consume_and_log(v: VaultLike) {\n    msg!(\"vault {} holds {} lamports\", v.owner, v.balance);\n}\n\n// ===== Bug 1 of 4 =========================================================\n// Should log the vault, then return the balance it had.\n//\n// Candidates:\n//   (1) let snapshot = vault.balance;\n//   (2) consume_and_log(vault);\n//   (3) snapshot\n//   (4) let snapshot = &vault.balance;\n//   (5) *snapshot\npub fn audit_then_read(vault: VaultLike) -> u64 {\n    consume_and_log(vault); // BUG\n    vault.balance // BUG\n}\n\n// ===== Bug 2 of 4 =========================================================\n// Should raise the balance to at least `target` and return the balance as it\n// was BEFORE the top-up.\n//\n// Candidates:\n//   (1) let before = v.balance;\n//   (2) let before = &v.balance;\n//   (3) let before = &mut v.balance;\n//   (4) before\n//   (5) *before\npub fn top_up_to(v: &mut VaultLike, target: u64) -> u64 {\n    let before = &v.balance; // BUG\n\n    let shortfall = match sub_lamports(target, *before) {\n        Some(gap) => gap,\n        None => 0,\n    };\n    credit(v, shortfall);\n\n    *before // BUG\n}\n\n// ===== Bug 3 of 4 =========================================================\n// Should apply two credits to the same vault, in order.\n//\n// Candidates:\n//   (1) credit(v, first);\n//   (2) credit(v, second);\n//   (3) let one = &mut *v;\n//   (4) let two = &mut *v;\n//   (5) credit(one, first);\npub fn credit_twice(v: &mut VaultLike, first: u64, second: u64) {\n    let one = &mut *v; // BUG\n    let two = &mut *v; // BUG\n\n    credit(one, first);\n    credit(two, second);\n}\n\n// ===== Bug 4 of 4 =========================================================\n// Should return the first 8 bytes of `data` — an Anchor account's\n// discriminator. One candidate line replaces both BUG lines.\n//\n// Candidates:\n//   (1) &data[..8]\n//   (2) &data.to_vec()[..8]\n//   (3) let owned = data.to_vec();\n//   (4) &owned[..8]\npub fn head(data: &[u8]) -> &[u8] {\n    let owned = data.to_vec(); // BUG\n    &owned[..8] // BUG\n}\n\n// ===== Given: callers, so a green build means the shapes still line up =====\n//\n// Also: `demo` is what makes `head` reachable and gives the other three a call\n// site. Do not delete it. See the harness note at the bottom.\npub fn demo() -> (u64, u64, usize) {\n    let mut vault = VaultLike {\n        owner: Pubkey::default(),\n        balance: 500_000,\n        bump: 254,\n    };\n\n    let before = top_up_to(&mut vault, 750_000);\n    credit_twice(&mut vault, 1_000, 2_000);\n\n    let account_data = vec![0u8; 49];\n    let disc = head(&account_data);\n\n    let logged = audit_then_read(vault);\n\n    (before, logged, disc.len())\n}\n\n// ── DO NOT EDIT ──────────────────────────────────────────────────────────────\n// Pins the five functions above to their exact signatures. Deleting a broken\n// function is the one \"fix\" that would otherwise compile, so this block exists\n// to close it: a missing name, a borrow that turned into a by-value parameter,\n// or a drifted return type all stop the build.\n//\n// `head`'s pin is written `for<'a> fn(&'a [u8]) -> &'a [u8]`, which is the\n// signature you get from elision — and be precise about what it buys: a `head`\n// returning `&'static [u8]` also satisfies it, because a longer-lived reference\n// is accepted wherever a shorter-lived one is wanted. What stops bug 4's wrong\n// fix is E0515 in the body, not this line. Lesson 8 is where the annotation\n// itself becomes the subject, and where a WRONG annotation does fail the pin.\n//\n// Names, types and borrows only. Nothing here checks what a body computes: a\n// `credit_twice` that applies `second` before `first` compiles fine.\n#[allow(dead_code)]\nmod verify {\n    use super::*;\n\n    const _AUDIT_THEN_READ: fn(VaultLike) -> u64 = audit_then_read;\n    const _TOP_UP_TO: fn(&mut VaultLike, u64) -> u64 = top_up_to;\n    const _CREDIT_TWICE: fn(&mut VaultLike, u64, u64) = credit_twice;\n    const _HEAD: for<'a> fn(&'a [u8]) -> &'a [u8] = head;\n    const _CONSUME_AND_LOG: fn(VaultLike) = consume_and_log;\n    const _DEMO: fn() -> (u64, u64, usize) = demo;\n}\n",
+        "solution": "// ---------------------------------------------------------------------------\n// Lesson 7 — Fix the Borrow Checker.\n//\n// Reference solution — all four bugs repaired, and the decoys explained.\n//\n// Toolchain: anchor-lang 1.1.2 · borsh 1.5.7 declared / 1.8.0 resolved · edition 2021.\n// ---------------------------------------------------------------------------\n\nuse anchor_lang::prelude::*;\n\n#[derive(Clone, Debug)]\npub struct VaultLike {\n    pub owner: Pubkey,\n    pub balance: u64,\n    pub bump: u8,\n}\n\npub const fn add_lamports(balance: u64, amount: u64) -> Option<u64> {\n    balance.checked_add(amount)\n}\n\npub const fn sub_lamports(balance: u64, amount: u64) -> Option<u64> {\n    balance.checked_sub(amount)\n}\n\n/// From lesson 6, unchanged.\npub fn credit(v: &mut VaultLike, amount: u64) {\n    if let Some(new_balance) = add_lamports(v.balance, amount) {\n        v.balance = new_balance;\n    }\n}\n\n/// Given. Takes the vault BY VALUE, so calling it hands the vault over for\n/// good. You are not allowed to change this signature — plenty of real APIs\n/// consume their argument and you do not get to rewrite them either.\npub fn consume_and_log(v: VaultLike) {\n    msg!(\"vault {} holds {} lamports\", v.owner, v.balance);\n}\n\n// ===== Bug 1 of 4 — E0382, use of moved value ==============================\n// Answer: (1), (2), (3).\n//\n// `consume_and_log` insists on owning the vault, so the vault is gone after the\n// call and no ordering saves you. Take the one number you need out FIRST. It is\n// a `u64`, so `snapshot` is an independent copy that owes nothing to `vault`.\n//\n// Decoys (4) + (5): `&vault.balance` is a borrow, and you cannot move a value\n// out while it is borrowed. That trades E0382 for E0505 — a different error,\n// same underlying mistake of trying to keep a thread back to a value you gave\n// away. `.clone()` would also work here (the compiler suggests it), at the cost\n// of copying the whole struct to read 8 bytes of it.\npub fn audit_then_read(vault: VaultLike) -> u64 {\n    let snapshot = vault.balance;\n    consume_and_log(vault);\n    snapshot\n}\n\n// ===== Bug 2 of 4 — E0502, mutable while shared ============================\n// Answer: (1) and (4). Note `sub_lamports(target, before)` loses its `*` too,\n// because `before` is now a `u64` rather than a `&u64`.\n//\n// The shared borrow was only fatal because the last line used it again, which\n// kept it alive across `credit`. Copying the number out removes the borrow\n// entirely, and a copied `u64` cannot conflict with anything.\n//\n// Decoy (3): `&mut v.balance` held across `credit(v, …)` is E0499 instead —\n// two mutable borrows. Decoy (5): `*before` on a `u64` is E0614, you cannot\n// dereference something that is not a reference.\npub fn top_up_to(v: &mut VaultLike, target: u64) -> u64 {\n    let before = v.balance;\n\n    let shortfall = match sub_lamports(target, before) {\n        Some(gap) => gap,\n        None => 0,\n    };\n    credit(v, shortfall);\n\n    before\n}\n\n// ===== Bug 3 of 4 — E0499, two mutable borrows =============================\n// Answer: (1) then (2). Both named borrows go away.\n//\n// Naming a `&mut` keeps it alive for as long as the name is used. Passing `v`\n// straight into the call lets each call take its exclusive borrow, finish with\n// it, and give it back before the next line begins. Nothing overlaps, so there\n// is nothing to reject.\n//\n// Decoy (5) `credit(one, first);` only makes sense if you kept (3), which is\n// the bug. Sequencing beats scoping: no blocks, no `drop()`, no `RefCell`.\npub fn credit_twice(v: &mut VaultLike, first: u64, second: u64) {\n    credit(v, first);\n    credit(v, second);\n}\n\n// ===== Bug 4 of 4 — E0515, returning a reference to a local ================\n// Answer: (1), alone.\n//\n// `data.to_vec()` allocates a fresh buffer owned by this function, and that\n// buffer is dropped on the way out. Borrow from `data` instead: it belongs to\n// the caller, so it is still alive when the caller reads the result.\n//\n// Decoy (2) `&data.to_vec()[..8]` is the same bug written on one line — the\n// temporary Vec is dropped at the end of the statement, so it is E0515 again.\n//\n// This version still panics if `data` is shorter than 8 bytes, because `[..8]`\n// on a 3-byte slice is a runtime bounds failure. The next lesson replaces the\n// signature with `Option<&[u8]>` and the panic with `None` — and makes you say\n// out loud, in the signature, that the returned reference came from `data`.\npub fn head(data: &[u8]) -> &[u8] {\n    &data[..8]\n}\n\n// ===== Given: callers, so a green build means the shapes still line up =====\npub fn demo() -> (u64, u64, usize) {\n    let mut vault = VaultLike {\n        owner: Pubkey::default(),\n        balance: 500_000,\n        bump: 254,\n    };\n\n    let before = top_up_to(&mut vault, 750_000);\n    credit_twice(&mut vault, 1_000, 2_000);\n\n    let account_data = vec![0u8; 49];\n    let disc = head(&account_data);\n\n    let logged = audit_then_read(vault);\n\n    (before, logged, disc.len())\n}\n\n// ── DO NOT EDIT ──────────────────────────────────────────────────────────────\n// Pins the five functions above to their exact signatures. Deleting a broken\n// function is the one \"fix\" that would otherwise compile, so this block exists\n// to close it: a missing name, a borrow that turned into a by-value parameter,\n// or a drifted return type all stop the build.\n//\n// `head`'s pin is written `for<'a> fn(&'a [u8]) -> &'a [u8]`, which is the\n// signature you get from elision — and be precise about what it buys: a `head`\n// returning `&'static [u8]` also satisfies it, because a longer-lived reference\n// is accepted wherever a shorter-lived one is wanted. What stops bug 4's wrong\n// fix is E0515 in the body, not this line. Lesson 8 is where the annotation\n// itself becomes the subject, and where a WRONG annotation does fail the pin.\n//\n// Names, types and borrows only. Nothing here checks what a body computes: a\n// `credit_twice` that applies `second` before `first` compiles fine.\n#[allow(dead_code)]\nmod verify {\n    use super::*;\n\n    const _AUDIT_THEN_READ: fn(VaultLike) -> u64 = audit_then_read;\n    const _TOP_UP_TO: fn(&mut VaultLike, u64) -> u64 = top_up_to;\n    const _CREDIT_TWICE: fn(&mut VaultLike, u64, u64) = credit_twice;\n    const _HEAD: for<'a> fn(&'a [u8]) -> &'a [u8] = head;\n    const _CONSUME_AND_LOG: fn(VaultLike) = consume_and_log;\n    const _DEMO: fn() -> (u64, u64, usize) = demo;\n}\n",
+        "tests": [
+          {
+            "id": "test-1",
+            "description": "The file compiles against anchor-lang 1.1.2 on the build server",
+            "input": "",
+            "expectedOutput": "true"
+          },
+          {
+            "id": "test-2",
+            "description": "Compiles ⇒ none of the four borrow-checker errors (E0382, E0502, E0499, E0515) is still in the file — each one is a hard compile failure, so a green build means all four are gone",
+            "input": "",
+            "expectedOutput": "true"
+          },
+          {
+            "id": "test-3",
+            "description": "Compiles ⇒ the non-editable `mod verify` block resolves: audit_then_read, top_up_to, credit_twice, head, consume_and_log and demo all still exist with the exact declared signatures, so deleting a broken function is not a fix. Note what this cannot see: it checks names, types and borrows, not what a body computes",
+            "input": "",
+            "expectedOutput": "true"
+          }
+        ],
+        "hints": [
+          "Build it first and read only the first error. The others are cascades — they will move or disappear as you fix the one above them.",
+          "Bug 2: the shared borrow is only fatal because the last line uses it again. `u64` is `Copy`, so take the number instead of a reference to it — and drop the `*` from the two places that were dereferencing it.",
+          "Bug 4: the returned reference has to come from something that outlives the call. `data` does. A `Vec` you created inside the function does not — and neither does a temporary you create inline in the return expression."
+        ],
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "check",
+        "_type": "quiz",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": [
+          {
+            "id": "q1",
+            "prompt": "In bug 2 you replace `let before = &v.balance;` with `let before = &mut v.balance;` and change nothing else. Predict the error you now get.",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "`E0499` — cannot borrow `*v` as mutable more than once at a time",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "Still `E0502` — a mutable borrow is a superset of a shared one, so the same conflict applies",
+                "correct": false,
+                "feedback": "The rule that broke is a different one, and so is the message. `E0502` is shared-then-mutable; two mutable borrows is `E0499`. Telling them apart is how you know whether to remove the borrow or reorder the calls."
+              },
+              {
+                "id": "c",
+                "label": "It compiles — `&mut` is the stronger borrow, and `credit` needs a mutable borrow anyway",
+                "correct": false,
+                "feedback": "\"Stronger\" is the wrong axis. `&mut` is *exclusive*, so a second one is worse, not better. Only one may exist at a time."
+              },
+              {
+                "id": "d",
+                "label": "`E0596` — `v` is already a `&mut`, so you cannot take `&mut` of it again",
+                "correct": false,
+                "feedback": "Reborrowing a `&mut` is completely legal and you do it every time you pass `v` to another function. The problem is doing it twice and keeping both."
+              }
+            ],
+            "explanation": null
+          },
+          {
+            "id": "q2",
+            "prompt": "For bug 4, someone tries `&data.to_vec()[..8]` on one line instead of two. Predict what the compiler says.",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "`E0515` again — cannot return value referencing temporary value; the `Vec` is dropped at the end of the statement",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "Compiles — a temporary in a return expression lives as long as the return value",
+                "correct": false,
+                "feedback": "There is no such rule, and if there were it would be unimplementable: the `Vec`'s heap allocation has to be freed by someone, and the only code that could do it is the function that is returning."
+              },
+              {
+                "id": "c",
+                "label": "`E0716` — temporary value dropped while borrowed, because the fix is to bind it with `let`",
+                "correct": false,
+                "feedback": "You would see `E0716` in some contexts, but binding it with `let` is the two-line version, which is the original bug. The problem is not where the `Vec` is written; it is that a `Vec` was created at all."
+              },
+              {
+                "id": "d",
+                "label": "Compiles, and returns a slice of zeroes because the buffer was freed",
+                "correct": false,
+                "feedback": "Reading freed memory is precisely what does not happen. This is the whole reason the error exists, and it is caught at compile time, so there is no observable garbage to read."
+              }
+            ],
+            "explanation": null
+          },
+          {
+            "id": "q3",
+            "prompt": "Instead of sequencing bug 3, someone writes `credit(v, first);` then `credit(&mut v.clone(), second);`. It compiles green. Predict what the vault's balance is afterwards.",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "Raised by `first` only — the second credit landed on a throwaway clone that was dropped immediately",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "Raised by `first + second` — `.clone()` returns a copy that writes through to the original",
+                "correct": false,
+                "feedback": "Nothing writes through a clone. `.clone()` produced an independent `VaultLike`; the `&mut` pointed at that one, and it was dropped at the end of the statement."
+              },
+              {
+                "id": "c",
+                "label": "Raised by `second` only — the later write wins",
+                "correct": false,
+                "feedback": "There is no \"later write wins\" — the two calls touched two different values. The vault only ever saw the first."
+              },
+              {
+                "id": "d",
+                "label": "It does not compile — you cannot take `&mut` of a temporary",
+                "correct": false,
+                "feedback": "You can. Rust promotes the temporary to a place you may borrow mutably, which is exactly why this bug builds green."
+              }
+            ],
+            "explanation": "Worth being blunt about: the build server proves your file compiles. It does not prove your function does what its name says. This snippet is a silent, compiling, wrong program, and only reading it catches that. The same limit applies to your own exercises for the rest of this course."
+          }
+        ],
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      }
+    ]
+  },
+  {
+    "_id": "lesson-rpd-functions-and-control-flow",
+    "title": "Functions, Expressions, and the Missing `return`",
+    "slug": "functions-and-control-flow",
+    "blocks": [
+      {
+        "key": "intro",
+        "_type": "prose",
+        "produces": null,
+        "consumes": null,
+        "src": "# Functions, Expressions, and the Missing `return`\n\n> **Version stamp — checked 2026-07-26.** `anchor-lang` **1.1.2** · Rust **edition 2021** · Agave **≥ 3.1.10**. This lesson's exercise is plain Rust and imports nothing.\n\nRead this function and decide, before scrolling, whether it compiles.\n\n```rust\nfn min_balance(a: u64, b: u64) -> u64 {\n    if a < b { a; } else { b; }\n}\n```\n\nIt does not. There are two semicolons in it and they are the entire problem. Everything below is about why one character does that, because it is the error JavaScript developers hit in their first week of Rust and it does not go away by being told about it once.\n\n## Almost everything is an expression\n\nIn JavaScript there are statements and there are expressions, and `if` is firmly a statement. You cannot assign one to a variable. That is why the ternary exists.\n\nIn Rust the split is much narrower. `if` is an expression. So is `match`. So is a block, `{ … }`. Each of them evaluates to a value, so each can appear anywhere a value is wanted:\n\n```rust\nlet tier = if balance == 0 { \"empty\" } else { \"funded\" };\n```\n\nNo ternary needed, because `if` already does that job. Rust has no `?:` operator at all, and this is why.\n\n## What a semicolon actually does\n\nA semicolon does not end a line. It **discards a value** and turns the expression into a statement whose value is `()` — the unit type, \"nothing useful\".\n\nThat is exact, and it is the whole rule:\n\n| Written | Value of the block |\n| --- | --- |\n| `{ a }` | `a` |\n| `{ a; }` | `()` |\n\nWhich explains the broken function. `{ a; }` evaluates to `()`, so both arms of the `if` are `()`, so the `if` is `()`, while the signature promises `u64`. The compiler type-checks each arm against what is expected, so it reports this **twice** — once per arm:\n\n```\nerror[E0308]: mismatched types\n --> src/lib.rs:2:14\n  |\n1 | fn min_balance(a: u64, b: u64) -> u64 {\n  |                                   --- expected `u64` because of return type\n2 |     if a < b { a; } else { b; }\n  |                 ^  help: remove this semicolon to return this value\n  |                 |\n  |                 expected `u64`, found `()`\n```\n\nNote the `help:`. When you see \"remove this semicolon to return this value\" you have found this bug and you can stop reading the rest of the error.\n\n## Tail expressions, and why `return` is rare\n\nA function's value is the value of its body block — which means the **last expression, with no semicolon**. That is called the tail expression:\n\n```rust\nfn min_balance(a: u64, b: u64) -> u64 {\n    if a < b { a } else { b }\n}\n```\n\nNo `return`. Idiomatic Rust uses `return` for one thing: leaving early, from somewhere other than the end.\n\n```rust\nfn withdraw(balance: u64, amount: u64) -> u64 {\n    if amount == 0 {\n        return balance;      // early exit, `return` earns its keep\n    }\n    balance - amount         // tail expression, no `return`\n}\n```\n\nA `return` on the last line is not an error and nobody will fail your review for it. It is just noise, and once you have the habit of reading the last line as *the answer*, functions get easier to skim.\n\nTwo things people trip on:\n\n- **`return x` needs its semicolon.** It is a statement. `return` and a tail expression are different mechanisms, not two spellings of one.\n- **A block's tail works too**, not only a function's. `let x = { let a = 2; a * 3 };` binds 6. This becomes useful in module 2, where the size of a block decides how long a borrow lasts.\n\n## `match` on ranges\n\n`match` is Rust's pattern dispatch, and for our purposes it is a `switch` with two upgrades that matter.\n\n```rust\nfn describe_state(balance: u64) -> &'static str {\n    match balance {\n        0 => \"empty\",\n        1..=999_999 => \"dust\",\n        1_000_000..=999_999_999 => \"funded\",\n        _ => \"whale\",\n    }\n}\n```\n\n**Upgrade one: it is an expression.** Every arm produces a value, all arms must agree on the type, and the whole `match` is that value. No `break`, and therefore no accidental fall-through — the bug class that eats a `switch` does not exist here.\n\n**Upgrade two: it must be exhaustive.** Every possible value of `balance` has to be matched by some arm, and the compiler proves it. Leave a gap and you get `error[E0004]: non-exhaustive patterns`, which is a compile-time guarantee that a missing case cannot ship. `_` is the catch-all that closes the gap, and `..=` is an inclusive range.\n\nTwo details about ordering, because they are the difference between this working and this looking like it works:\n\n**Arms are tried top to bottom, first match wins.** Not most-specific-wins. Order is semantics.\n\n**An arm the earlier ones already cover is a warning, not an error.** Put `0..=999_999 => \"dust\"` above `0 => \"empty\"` and the `0` arm becomes dead:\n\n```\nwarning: unreachable pattern\n --> src/lib.rs:5:9\n  |\n4 |         0..=999_999 => \"dust\",\n  |         ----------- matches all the values already\n5 |         0 => \"empty\",\n  |         ^ no value can reach this\n```\n\nThat file **compiles**, and this lesson is graded on compilation, so it passes — and `describe_state(0)` returns `\"dust\"`. This is a good moment to notice how much work a warning can be doing. `unreachable_patterns` is one of the highest-value warnings Rust emits, and nothing forces you to read it.\n\n`&'static str` in the return type is a borrowed string that lives for the whole program — which is true of a literal baked into the binary. The apostrophe is a lifetime, and module 2 is where you learn to write your own. Take it as given for now.\n\n## The exercise\n\nBoth function bodies are empty, so the file does not build. Every line you need is in the parts bin at the top of the file, commented out and out of order. **Two of the lines are decoys.** One of them compiles and does the wrong thing; one of them does not compile at all. Working out which is which is the exercise.\n\nDo not add lines that are not in the bin. Assembling exactly the right subset in the right order is a smaller job than writing it from scratch, and it is the whole job here — lesson 4 is where the blank page arrives.\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "exercise",
+        "_type": "code",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": "rust",
+        "buildType": "buildable",
+        "deployable": false,
+        "starter": "//! Functions, expressions, and the missing `return`.\n//!\n//! Both bodies below are empty, so this file does not build.\n//!\n//! Every line you need is in the parts bin. Two of the seven lines are\n//! decoys: one compiles and quietly does the wrong thing, one does not\n//! compile at all. Copy the lines you want into the bodies, in the right\n//! order. Do not write lines that are not in the bin.\n//!\n//! ┌─ PARTS BIN ─────────────────────────────────────────────────────────┐\n//! │                                                                     │\n//! │  Arms for `describe_state`. Four of these five belong. Arms are     │\n//! │  tried top to bottom and the first match wins, so order is part of  │\n//! │  the answer — and `match` must cover every possible `u64`.          │\n//! │                                                                     │\n//! │    (A)    _ => \"whale\",                                             │\n//! │    (B)    1_000_000..=999_999_999 => \"funded\",                      │\n//! │    (C)    0..=999_999 => \"dust\",                                    │\n//! │    (D)    0 => \"empty\",                                             │\n//! │    (E)    1..=999_999 => \"dust\",                                    │\n//! │                                                                     │\n//! │  Body for `min_balance`. One of these two belongs.                  │\n//! │                                                                     │\n//! │    (F)    if a < b { a; } else { b; }                               │\n//! │    (G)    if a < b { a } else { b }                                 │\n//! │                                                                     │\n//! └─────────────────────────────────────────────────────────────────────┘\n\n/// Classify a lamport balance. Every `u64` gets exactly one answer.\n///\n///   0                          -> \"empty\"\n///   1 .. 999_999               -> \"dust\"\n///   1_000_000 .. 999_999_999   -> \"funded\"\n///   1_000_000_000 and above    -> \"whale\"\npub fn describe_state(balance: u64) -> &'static str {\n    match balance {\n        // Four arms from the bin go here, in the right order.\n    }\n}\n\n/// The smaller of two balances.\npub fn min_balance(a: u64, b: u64) -> u64 {\n    // One line from the bin goes here.\n}\n\n// ════════════════════════════════════════════════════════════════════════\n// DO NOT EDIT BELOW THIS LINE\n//\n// These bindings pin both signatures so that renaming or deleting a\n// function is a compile error rather than a way through. They check\n// shapes, not behaviour. What checks behaviour here is `match`\n// exhaustiveness — the compiler will not accept a set of arms that leaves\n// a `u64` unmatched — plus the type of the `if`, which a stray semicolon\n// changes to `()`.\n// ════════════════════════════════════════════════════════════════════════\n\nconst _: fn(u64) -> &'static str = describe_state;\nconst _: fn(u64, u64) -> u64 = min_balance;\n",
+        "solution": "//! Functions, expressions, and the missing `return` — solved.\n//!\n//! (C) was a decoy: `0..=999_999 => \"dust\"` covers 0, so placing it before\n//! `0 => \"empty\"` makes that arm unreachable — a warning, not an error, so\n//! the file would still have compiled while answering \"dust\" for an empty\n//! vault. (E) is the same range with 0 excluded, which is the one that\n//! belongs.\n//!\n//! (F) was the other decoy: `{ a; }` evaluates to `()`, so the `if` is\n//! `()`, so the body does not match the `-> u64` return type. That is the\n//! `help: consider removing this semicolon` error.\n\n/// Classify a lamport balance. Every `u64` gets exactly one answer.\n///\n///   0                          -> \"empty\"\n///   1 .. 999_999               -> \"dust\"\n///   1_000_000 .. 999_999_999   -> \"funded\"\n///   1_000_000_000 and above    -> \"whale\"\npub fn describe_state(balance: u64) -> &'static str {\n    match balance {\n        0 => \"empty\",\n        1..=999_999 => \"dust\",\n        1_000_000..=999_999_999 => \"funded\",\n        _ => \"whale\",\n    }\n}\n\n/// The smaller of two balances.\npub fn min_balance(a: u64, b: u64) -> u64 {\n    if a < b { a } else { b }\n}\n\n// ════════════════════════════════════════════════════════════════════════\n// DO NOT EDIT BELOW THIS LINE\n//\n// These bindings pin both signatures so that renaming or deleting a\n// function is a compile error rather than a way through. They check\n// shapes, not behaviour. What checks behaviour here is `match`\n// exhaustiveness — the compiler will not accept a set of arms that leaves\n// a `u64` unmatched — plus the type of the `if`, which a stray semicolon\n// changes to `()`.\n// ════════════════════════════════════════════════════════════════════════\n\nconst _: fn(u64) -> &'static str = describe_state;\nconst _: fn(u64, u64) -> u64 = min_balance;\n",
+        "tests": [
+          {
+            "id": "test-1",
+            "description": "Program compiles successfully",
+            "input": "",
+            "expectedOutput": "true"
+          },
+          {
+            "id": "test-2",
+            "description": "describe_state's match covers every u64 — a non-exhaustive set of arms is E0004",
+            "input": "",
+            "expectedOutput": "true"
+          },
+          {
+            "id": "test-3",
+            "description": "min_balance's body evaluates to a u64 rather than to ()",
+            "input": "",
+            "expectedOutput": "true"
+          }
+        ],
+        "hints": [
+          "Start with `min_balance`, because the compiler tells you outright which of (F) and (G) is the decoy. Paste one, build, and read the `help:` line — it names the exact character to delete.",
+          "`describe_state` needs exactly four arms and the last one must be `_`. Two of the five candidate arms overlap each other; pick the one that leaves 0 to the `0 => \"empty\"` arm rather than swallowing it.",
+          "The wrong `dust` arm still compiles, and you will not be told. It produces `warning: unreachable pattern` and then answers \"dust\" for an empty vault — but this platform shows you the compiler log only when the build FAILS, so on a green build that warning is discarded before it reaches you. Nothing external will catch this one. Read your two range arms against the `0 => \"empty\"` arm and decide by hand which of them swallows 0."
+        ],
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "check",
+        "_type": "quiz",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": [
+          {
+            "id": "q1",
+            "prompt": "Predict the outcome. `pub fn min_balance(a: u64, b: u64) -> u64 { if a < b { a; } else { b; } }`",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "`error[E0308]` twice, once per arm — expected `u64`, found `()`. Each semicolon discards its arm's value, and the `help:` line reads \"remove this semicolon to return this value\".",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "It compiles. Semicolons are optional line terminators in Rust, as they effectively are in JavaScript.",
+                "correct": false,
+                "feedback": "A semicolon in Rust is not punctuation, it is an operation: it throws away the value of the expression it follows and yields `()` instead. That is why one character changes the type of the whole function body."
+              },
+              {
+                "id": "c",
+                "label": "`error[E0317]: if may be missing an else clause` — the arms disagree.",
+                "correct": false,
+                "feedback": "The arms agree perfectly: both are `()`. E0317 is for an `if` with no `else` used in value position. Here the disagreement is between the body and the return type."
+              },
+              {
+                "id": "d",
+                "label": "It compiles, and returns 0, because `()` coerces to the numeric zero value.",
+                "correct": false,
+                "feedback": "`()` does not coerce to anything. It is a distinct type with one value, and Rust has no implicit conversions to paper over the gap — the same rule you met with `u8` and `u64` in lesson 2."
+              }
+            ],
+            "explanation": null
+          },
+          {
+            "id": "q2",
+            "prompt": "A submission orders the arms `0..=999_999 => \"dust\",` then `0 => \"empty\",` then the rest, and it is otherwise exhaustive. Predict both the build result and what `describe_state(0)` returns.",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "It compiles, with `warning: unreachable pattern`, and returns \"dust\" — arms are tried top to bottom, so the first arm claims 0 before the `0` arm is reached.",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "`error[E0001]: unreachable pattern`. An arm that can never match is rejected.",
+                "correct": false,
+                "feedback": "It is a lint, and its default level is warn, not deny. Which means a lesson graded on compilation passes this submission. Worse: this platform discards the compiler log on a successful build, so the warning is not merely easy to skip — it never reaches you at all. Nothing here catches a wrong-order `match` except reading it."
+              },
+              {
+                "id": "c",
+                "label": "It compiles and returns \"empty\", because `match` picks the most specific pattern that applies.",
+                "correct": false,
+                "feedback": "No specificity ranking exists. `match` is strictly top to bottom, first match wins. This is the assumption most people import from overload resolution in other languages, and it is wrong here."
+              },
+              {
+                "id": "d",
+                "label": "It compiles and returns \"empty\", because a literal pattern is checked before any range pattern.",
+                "correct": false,
+                "feedback": "Pattern *kind* has no bearing on order either. Source order is the whole rule."
+              }
+            ],
+            "explanation": null
+          },
+          {
+            "id": "q3",
+            "prompt": "Carried over from lesson 2. Predict the outcome of `let bump: u8 = 300;`",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "A compile error — the literal is out of range for `u8`. The check is a lint, but it is deny-by-default, so it stops the build.",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "It compiles and `bump` is 44, since 300 wraps modulo 256.",
+                "correct": false,
+                "feedback": "You would get 44 from `300u32 as u8`, which is exactly why this course does not use `as` on numbers. A literal that does not fit its annotated type is caught at compile time instead."
+              },
+              {
+                "id": "c",
+                "label": "It compiles and `bump` is 255, clamped to the maximum.",
+                "correct": false,
+                "feedback": "Rust never silently clamps. Saturating behaviour exists, but you have to ask for it by name (`saturating_add` and friends)."
+              },
+              {
+                "id": "d",
+                "label": "It compiles with a warning, and the value is implementation-defined.",
+                "correct": false,
+                "feedback": "Nothing about integer behaviour in Rust is implementation-defined, and this particular lint denies rather than warns."
+              }
+            ],
+            "explanation": null
+          }
+        ],
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      }
+    ]
+  },
+  {
+    "_id": "lesson-rpd-lifetimes-and-slices",
+    "title": "Lifetimes and Slices",
+    "slug": "lifetimes-and-slices",
+    "blocks": [
+      {
+        "key": "intro",
+        "_type": "prose",
+        "produces": null,
+        "consumes": null,
+        "src": "# Lifetimes and Slices\n\n> **Version stamp — checked 2026-07-26.** `anchor-lang 1.1.2` (crates.io latest stable) · `borsh` 1.5.7 declared / **1.8.0** resolved · edition 2021 · Agave ≥ 3.1.10 / rustc per the build server's pinned platform-tools. `anchor-lang` 1.0 removed three of the four redundant lifetime parameters from `Context`, so the surface described here is smaller than in any tutorial written before June 2026.\n\nBug 4 in the last lesson ended with a question the compiler asked and you answered by accident: **which value does the returned reference borrow from?**\n\nFor `head(data: &[u8]) -> &[u8]` there is exactly one candidate, so the compiler filled it in silently. Add a second reference parameter and it stops guessing, because guessing wrong would mean returning a reference to something already freed.\n\nThat is all a lifetime annotation is. Say it out loud once:\n\n> **A lifetime does not change how long anything lives. It tells the compiler which input a returned reference came from.**\n\nNothing is allocated, nothing is freed, nothing is reference-counted, and no code is generated. Annotations are a compile-time claim, checked and then discarded.\n\n## What `'a` actually says\n\n```rust\npub fn discriminator<'a>(data: &'a [u8]) -> Option<&'a [u8]>\n```\n\nWord for word: *for some lifetime `'a`, I take a slice that is valid for `'a`, and if I return a slice it is valid for the same `'a`.* Which means: the thing I hand back points into `data`, so it stays valid exactly as long as `data` does — and the compiler will reject any caller who drops `data` while still holding the result.\n\nYou can drop the annotations here:\n\n```rust\npub fn discriminator(data: &[u8]) -> Option<&[u8]>\n```\n\nThis is the identical signature. **Lifetime elision** fills in the same `'a` for you when there is exactly one input reference, because there is only one possible answer. That is why you have written a dozen functions taking `&VaultLike` without ever typing a `'`.\n\nElision has two other rules worth knowing, and no more:\n\n- One input reference → the output borrows from it.\n- A method with `&self` or `&mut self` → the output borrows from `self`, no matter how many other reference parameters there are.\n- Otherwise → **you must say.**\n\n`balance_of(&self) -> u64` returns no reference, so it never comes up. `deposit(&mut self, amount: u64)` likewise. Which is why module 4's vault has no annotations in it anywhere, and why meeting them here rather than there is the right order.\n\n## The case elision cannot solve\n\n```rust\npub fn discriminator_if(data: &[u8], expected: &[u8; 8]) -> Option<&[u8]>\n```\n\nTwo input references, one output reference, no `self`. The compiler will not choose:\n\n```text\nerror[E0106]: missing lifetime specifier\n  |\n  | pub fn discriminator_if(data: &[u8], expected: &[u8; 8]) -> Option<&[u8]>\n  |                               -----            --------            ^ expected named lifetime parameter\n  |\n  = help: this function's return type contains a borrowed value, but the\n          signature does not say whether it is borrowed from `data` or `expected`\n```\n\nThe help text *is* the lesson. There is a right answer here and it is a design decision, not a formality: the discriminator you return is bytes out of the account, so it borrows from `data`. `expected` is a caller's constant that this function only reads and never hands back — it gets its own lifetime, unrelated to the return value.\n\n```rust\npub fn discriminator_if<'a, 'b>(data: &'a [u8], expected: &'b [u8; 8]) -> Option<&'a [u8]>\n```\n\nTwo names because there are two independent answers. Writing `<'a>` on both would compile the function and quietly over-constrain every caller — it would demand that the account buffer and the expected constant live equally long, which is a promise callers have no reason to be able to make.\n\n## Slices, and why the first 8 bytes matter\n\n`&[u8]` is a **borrowed view** into bytes someone else owns: an address plus a length, 16 bytes total, no allocation, no copy. `Vec<u8>` owns its buffer; `&[u8]` looks at it. That distinction is the whole of bug 4.\n\nThe bytes you are about to look at are real. Every Anchor account starts with an 8-byte discriminator — a hash of the account type's name — followed by the fields:\n\n| Offset | Bytes | Field |\n| --- | --- | --- |\n| 0 | 8 | discriminator |\n| 8 | 32 | `owner: Pubkey` |\n| 40 | 8 | `balance: u64`, little-endian |\n| 48 | 1 | `bump: u8` |\n\nTotal 49. This is the same table you decoded byte by byte in Course 1, and the same layout `#[account]` will generate for you in module 3. Anchor checks that discriminator before it deserializes anything — wrong discriminator, wrong account type, refuse — which is exactly the function you are about to write.\n\n## What you are writing\n\nTwo functions, signatures given, spec given, no worked pattern. Both are `const fn`, for a reason worth stating plainly:\n\n**Grading on this platform is compile-only.** A submission passes when the build server reports that it compiled. There are no hidden tests on the Rust path, so a function whose body was `todo!()` would normally sail through.\n\n`const fn` closes that. The exercise ships a `mod verify` block you may not edit, which calls your functions at **compile time** and asserts on the answers:\n\n```rust\nconst _: () = assert!(super::discriminator(&[0u8; 7]).is_none());\n```\n\nA `const fn` that panics — including `todo!()` — fails const evaluation, which is a compile error. A `discriminator` that returns 4 bytes fails the length assertion, which is a compile error. So for this lesson the build genuinely does check your logic, not just your syntax.\n\nBe clear about the limit: this works because both functions are `const fn` over plain slices. It will not work for `deposit(&mut self) -> Result<()>` in module 4 — you cannot const-evaluate a method that mutates account state — and that lesson's harness therefore checks names and types only, and says so.\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "exercise",
+        "_type": "code",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": "rust",
+        "buildType": "buildable",
+        "deployable": false,
+        "starter": "// ---------------------------------------------------------------------------\n// Lesson 8 — Lifetimes and Slices.\n//\n// Two functions. Signatures and spec below, no worked example. The `mod verify`\n// block at the bottom is NOT EDITABLE — it calls your functions at compile time\n// and asserts on the answers, so a `todo!()` body or a wrong length is a build\n// failure, not a silent pass.\n//\n// Toolchain: anchor-lang 1.1.2 · borsh 1.5.7 declared / 1.8.0 resolved · edition 2021.\n// ---------------------------------------------------------------------------\n\n/// Every Anchor account begins with 8 discriminator bytes. Do not change this.\npub const DISCRIMINATOR_LEN: usize = 8;\n\n// ===== 1. discriminator ====================================================\n//\n// SPEC\n//   Return a borrowed view of the first `DISCRIMINATOR_LEN` bytes of `data`.\n//   If `data` is shorter than that, return `None` — never panic, and never\n//   return a shorter slice.\n//\n// ACCEPTANCE\n//   discriminator(&[])            == None\n//   discriminator(&[0u8; 7])      == None\n//   discriminator(&[0u8; 8])      == Some(..) with len 8\n//   discriminator(&[0u8; 49])     == Some(..) with len 8, the FIRST eight\n//\n// NOTES\n//   - The signature below has no `'a` on it. That is legal: one input\n//     reference means elision has exactly one answer, and it fills it in.\n//   - `const fn` restricts you: no `?`, no iterators, no closures. `if`,\n//     `match`, `while` and slice methods that are themselves `const` are in.\n//   - Indexing with `[..8]` panics on a short slice. The spec says `None`, so\n//     check the length before you take anything.\npub const fn discriminator(data: &[u8]) -> Option<&[u8]> {\n    todo!()\n}\n\n// ===== 2. discriminator_if =================================================\n//\n// SPEC\n//   Return the account's discriminator ONLY when it equals `expected`.\n//   Otherwise return `None`. This is what Anchor does before it deserializes\n//   an account: wrong discriminator, wrong account type, refuse.\n//\n// ACCEPTANCE\n//   discriminator_if(&[1u8; 49], &[1u8; 8])  == Some(..) with len 8\n//   discriminator_if(&[1u8; 49], &[2u8; 8])  == None\n//   discriminator_if(&[0u8; 7],  &[0u8; 8])  == None   (too short)\n//\n// THE LIFETIME WORK — this is the lesson\n//   As written, this does not compile: E0106, missing lifetime specifier. Two\n//   input references, one output reference, no `self`, so elision has nothing\n//   to go on and the compiler refuses to guess.\n//\n//   Annotate it yourself, and get the answer RIGHT rather than merely legal:\n//     - The slice you return is bytes out of `data`, so it borrows from `data`.\n//     - `expected` is a caller's constant. You read it and never hand it back,\n//       so it needs its OWN lifetime, unconnected to the return type.\n//   Two lifetime parameters, therefore. Putting one name on both compiles the\n//   function but over-constrains every caller, and the harness rejects it —\n//   read the `expected fn pointer` / `found fn item` lines if you try it.\n//\n// NOTES\n//   - Reuse `discriminator`. Do not re-implement the length check.\n//   - Comparing bytes in a `const fn` means a `while` loop and indexing. There\n//     is no `==` on slices you can call here, and no iterator.\npub const fn discriminator_if(data: &[u8], expected: &[u8; DISCRIMINATOR_LEN]) -> Option<&[u8]> {\n    todo!()\n}\n\n// ===========================================================================\n// VERIFICATION HARNESS — DO NOT EDIT.\n//\n// These items run inside the compiler. The two `_SIG_*` constants pin each\n// function's exact shape, including which input the returned reference borrows\n// from. The `const _: () = assert!(…)` items call your code during compilation,\n// so a wrong answer is reported as an `error[E0080]` const-evaluation failure\n// naming the assertion that did not hold.\n//\n// This trick works here only because both functions are `const fn` over plain\n// slices. It does not reach `deposit(&mut self)` in module 4.\n// ===========================================================================\n#[allow(dead_code)]\nmod verify {\n    const _SIG_DISCRIMINATOR: for<'a> fn(&'a [u8]) -> Option<&'a [u8]> = super::discriminator;\n\n    const _SIG_DISCRIMINATOR_IF: for<'a, 'b> fn(&'a [u8], &'b [u8; 8]) -> Option<&'a [u8]> =\n        super::discriminator_if;\n\n    const _: () = assert!(super::DISCRIMINATOR_LEN == 8);\n\n    const _: () = assert!(super::discriminator(&[]).is_none());\n    const _: () = assert!(super::discriminator(&[0u8; 7]).is_none());\n    const _: () = assert!(match super::discriminator(&[0u8; 8]) {\n        Some(d) => d.len() == 8,\n        None => false,\n    });\n    const _: () = assert!(match super::discriminator(&[7u8; 49]) {\n        Some(d) => d.len() == 8 && d[0] == 7 && d[7] == 7,\n        None => false,\n    });\n\n    const _: () = assert!(super::discriminator_if(&[1u8; 49], &[1u8; 8]).is_some());\n    const _: () = assert!(super::discriminator_if(&[1u8; 49], &[2u8; 8]).is_none());\n    const _: () = assert!(super::discriminator_if(&[0u8; 7], &[0u8; 8]).is_none());\n}\n",
+        "solution": "// ---------------------------------------------------------------------------\n// Lesson 8 — Lifetimes and Slices.\n//\n// Reference solution. Both bodies filled in, lifetimes annotated, harness\n// untouched.\n//\n// Toolchain: anchor-lang 1.1.2 · borsh 1.5.7 declared / 1.8.0 resolved · edition 2021.\n// ---------------------------------------------------------------------------\n\n/// Every Anchor account begins with 8 discriminator bytes. Do not change this.\npub const DISCRIMINATOR_LEN: usize = 8;\n\n// ===== 1. discriminator ====================================================\n//\n// SPEC\n//   Return a borrowed view of the first `DISCRIMINATOR_LEN` bytes of `data`.\n//   If `data` is shorter than that, return `None` — never panic, and never\n//   return a shorter slice.\n//\n// ACCEPTANCE\n//   discriminator(&[])            == None\n//   discriminator(&[0u8; 7])      == None\n//   discriminator(&[0u8; 8])      == Some(..) with len 8\n//   discriminator(&[0u8; 49])     == Some(..) with len 8, the FIRST eight\n//\n// NOTES\n//   - The signature below has no `'a` on it. That is legal: one input\n//     reference means elision has exactly one answer, and it fills it in.\n//   - `const fn` restricts you: no `?`, no iterators, no closures. `if`,\n//     `match`, `while` and slice methods that are themselves `const` are in.\n//   - Indexing with `[..8]` panics on a short slice. The spec says `None`, so\n//     check the length before you take anything.\n//\n// `split_at(8).0` is the first eight bytes and `.1` is everything after. It is\n// a `const fn`, it allocates nothing, and it hands back views into the same\n// buffer — the borrowed-view point from the prose, in one call.\npub const fn discriminator(data: &[u8]) -> Option<&[u8]> {\n    if data.len() < DISCRIMINATOR_LEN {\n        return None;\n    }\n    Some(data.split_at(DISCRIMINATOR_LEN).0)\n}\n\n// ===== 2. discriminator_if =================================================\n//\n// SPEC\n//   Return the account's discriminator ONLY when it equals `expected`.\n//   Otherwise return `None`. This is what Anchor does before it deserializes\n//   an account: wrong discriminator, wrong account type, refuse.\n//\n// ACCEPTANCE\n//   discriminator_if(&[1u8; 49], &[1u8; 8])  == Some(..) with len 8\n//   discriminator_if(&[1u8; 49], &[2u8; 8])  == None\n//   discriminator_if(&[0u8; 7],  &[0u8; 8])  == None   (too short)\n//\n// THE LIFETIME WORK — this is the lesson\n//   As written, this does not compile: E0106, missing lifetime specifier. Two\n//   input references, one output reference, no `self`, so elision has nothing\n//   to go on and the compiler refuses to guess.\n//\n//   Annotate it yourself, and get the answer RIGHT rather than merely legal:\n//     - The slice you return is bytes out of `data`, so it borrows from `data`.\n//     - `expected` is a caller's constant. You read it and never hand it back,\n//       so it needs its OWN lifetime, unconnected to the return type.\n//   Two lifetime parameters, therefore. Putting one name on both compiles the\n//   function but over-constrains every caller, and the harness rejects it —\n//   read the `expected fn pointer` / `found fn item` lines if you try it.\n//\n// NOTES\n//   - Reuse `discriminator`. Do not re-implement the length check.\n//   - Comparing bytes in a `const fn` means a `while` loop and indexing. There\n//     is no `==` on slices you can call here, and no iterator.\n//\n// Read the signature as two independent promises: what I return lives as long\n// as `data` ('a), and I also borrowed something else for some unrelated stretch\n// ('b) that you may forget about the moment this call returns.\npub const fn discriminator_if<'a, 'b>(\n    data: &'a [u8],\n    expected: &'b [u8; DISCRIMINATOR_LEN],\n) -> Option<&'a [u8]> {\n    let found = match discriminator(data) {\n        Some(bytes) => bytes,\n        None => return None,\n    };\n\n    let mut i = 0;\n    while i < DISCRIMINATOR_LEN {\n        if found[i] != expected[i] {\n            return None;\n        }\n        i += 1;\n    }\n\n    Some(found)\n}\n\n// ===========================================================================\n// VERIFICATION HARNESS — DO NOT EDIT.\n//\n// These items run inside the compiler. The two `_SIG_*` constants pin each\n// function's exact shape, including which input the returned reference borrows\n// from. The `const _: () = assert!(…)` items call your code during compilation,\n// so a wrong answer is reported as an `error[E0080]` const-evaluation failure\n// naming the assertion that did not hold.\n//\n// This trick works here only because both functions are `const fn` over plain\n// slices. It does not reach `deposit(&mut self)` in module 4.\n// ===========================================================================\n#[allow(dead_code)]\nmod verify {\n    const _SIG_DISCRIMINATOR: for<'a> fn(&'a [u8]) -> Option<&'a [u8]> = super::discriminator;\n\n    const _SIG_DISCRIMINATOR_IF: for<'a, 'b> fn(&'a [u8], &'b [u8; 8]) -> Option<&'a [u8]> =\n        super::discriminator_if;\n\n    const _: () = assert!(super::DISCRIMINATOR_LEN == 8);\n\n    const _: () = assert!(super::discriminator(&[]).is_none());\n    const _: () = assert!(super::discriminator(&[0u8; 7]).is_none());\n    const _: () = assert!(match super::discriminator(&[0u8; 8]) {\n        Some(d) => d.len() == 8,\n        None => false,\n    });\n    const _: () = assert!(match super::discriminator(&[7u8; 49]) {\n        Some(d) => d.len() == 8 && d[0] == 7 && d[7] == 7,\n        None => false,\n    });\n\n    const _: () = assert!(super::discriminator_if(&[1u8; 49], &[1u8; 8]).is_some());\n    const _: () = assert!(super::discriminator_if(&[1u8; 49], &[2u8; 8]).is_none());\n    const _: () = assert!(super::discriminator_if(&[0u8; 7], &[0u8; 8]).is_none());\n}\n",
+        "tests": [
+          {
+            "id": "test-1",
+            "description": "Program compiles successfully",
+            "input": "",
+            "expectedOutput": "true"
+          },
+          {
+            "id": "test-2",
+            "description": "mod verify's compile-time assertions on discriminator all evaluate (length check and first-8-bytes)",
+            "input": "",
+            "expectedOutput": "true"
+          },
+          {
+            "id": "test-3",
+            "description": "mod verify's fn-pointer constants accept discriminator_if — return borrows from data, expected has its own lifetime",
+            "input": "",
+            "expectedOutput": "true"
+          }
+        ],
+        "hints": [
+          "Function 1 is three lines. Guard the length first and return `None`; otherwise hand back the first eight bytes. `split_at` is a `const fn` and returns `(before, after)` — you want `.0`.",
+          "Function 2 needs TWO lifetime parameters, not one. Ask the question the compiler is asking: which of the two inputs do the returned bytes come out of? Whichever it is gets the name that also appears in the return type; the other input's lifetime is never mentioned again, and giving both the same name is the over-constraint quiz question 2 is about.",
+          "Function 2's body — the constraint, not the code: slice `==` and iterators are both unavailable in a `const fn`, so comparing eight bytes leaves you with indexing. `while` is const; `for` is not. And reuse `discriminator` rather than re-checking the length."
+        ],
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "check",
+        "_type": "quiz",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": [
+          {
+            "id": "q1",
+            "prompt": "You write `fn discriminator_if(data: &[u8], expected: &[u8; 8]) -> Option<&[u8]>` with no lifetime annotations. Predict what the compiler says and why.",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "`E0106`, missing lifetime specifier — with two input references and no `self`, elision cannot tell whether the result borrows from `data` or `expected`",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "It compiles — elision assigns the return value the lifetime of the first reference parameter",
+                "correct": false,
+                "feedback": "There is no first-parameter-wins rule. Elision applies when there is exactly one input reference, or when there is a `&self`. Two plain references and no receiver is precisely the case it refuses."
+              },
+              {
+                "id": "c",
+                "label": "It compiles, and the returned reference gets `'static` because the compiler cannot prove anything shorter",
+                "correct": false,
+                "feedback": "`'static` means \"valid for the whole program\", which is a much stronger claim than either input can support. The compiler never invents it; it asks you."
+              },
+              {
+                "id": "d",
+                "label": "`E0621` — explicit lifetime required in the type of `data`",
+                "correct": false,
+                "feedback": "`E0621` shows up when the annotations exist but do not line up. Here there are none at all to line up, which is `E0106`."
+              }
+            ],
+            "explanation": "The help text spells out the whole lesson: \"this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from `data` or `expected`.\""
+          },
+          {
+            "id": "q2",
+            "prompt": "You annotate it as `<'a>(data: &'a [u8], expected: &'a [u8; 8]) -> Option<&'a [u8]>` — one name on everything. The function body compiles. What have you actually done to your callers?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "Required that both arguments be usable over one common stretch, so a caller holding a short-lived `expected` and a long-lived `data` is refused for no reason",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "Nothing — one lifetime for everything is the same signature written more briefly",
+                "correct": false,
+                "feedback": "Two names are two independent claims. Collapsing them to one adds a constraint the function never needed: it makes the two inputs' lifetimes each other's problem."
+              },
+              {
+                "id": "c",
+                "label": "Made the returned reference live as long as the longer of the two inputs",
+                "correct": false,
+                "feedback": "An annotation never extends a lifetime. It only describes a relationship the compiler then checks. Nothing you write in a signature keeps a value alive one instruction longer."
+              },
+              {
+                "id": "d",
+                "label": "Introduced a use-after-free risk, since `expected` may be dropped while the result is alive",
+                "correct": false,
+                "feedback": "The opposite: it is over-strict, not unsafe. Rust's guarantee is never weakened by the annotation you choose — the worst you can do is reject callers you meant to accept."
+              }
+            ],
+            "explanation": "Also why the harness pins `for<'a, 'b> fn(&'a [u8], &'b [u8; 8]) -> Option<&'a [u8]>`. The single-name version is a *less general* function type, so it does not fit the constant, and the mismatch is reported as `expected fn pointer` versus `found fn item` with the lifetimes shown."
+          },
+          {
+            "id": "q3",
+            "prompt": "A caller does this — declares `let disc;`, opens a block, builds `let data = vec![0u8; 49];` inside it, assigns `disc = discriminator(&data);`, closes the block, then reads `disc`. Predict the verdict.",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "`E0597` — `data` does not live long enough; the borrow is still used after the block that owns the buffer ends",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "Compiles — `disc` is an `Option`, and an `Option` owns its contents",
+                "correct": false,
+                "feedback": "`Option<&[u8]>` owns the enum's one-word tag, not the bytes. The variant holds a borrow, and a borrow is only as good as what it points at."
+              },
+              {
+                "id": "c",
+                "label": "Compiles, and `disc` is `None` after the block because the buffer was dropped",
+                "correct": false,
+                "feedback": "Nothing rewrites `disc` at runtime. Rust has no mechanism that nulls out a reference when its target dies — which is exactly why the check has to happen at compile time."
+              },
+              {
+                "id": "d",
+                "label": "`E0515` — cannot return a value referencing a local variable",
+                "correct": false,
+                "feedback": "`E0515` is the same mistake seen from inside a function that is returning. Here the mistake is in the caller, spanning two scopes, and the compiler names the value that died too early instead."
+              }
+            ],
+            "explanation": "Same rule as lesson 7's bug 4, opposite side of the call. `discriminator` is correct; the caller structured its scopes so the result outlives its source. Move `let data` outside the block and it compiles unchanged."
+          }
+        ],
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      }
+    ]
+  },
+  {
+    "_id": "lesson-rpd-moves-copy-and-clone",
+    "title": "Moves, Copy, and Clone",
+    "slug": "moves-copy-and-clone",
+    "blocks": [
+      {
+        "key": "intro",
+        "_type": "prose",
+        "produces": null,
+        "consumes": null,
+        "src": "# Moves, Copy, and Clone\n\n> **Version stamp — checked 2026-07-26.** `anchor-lang 1.1.2` (crates.io latest stable) · `borsh` 1.5.7 declared / **1.8.0** resolved · edition 2021 · Agave ≥ 3.1.10 / rustc per the build server's pinned platform-tools. Every line in this lesson's exercise was compiled against that toolchain.\n\nThe two functions you wrote in the last lesson never argued with you about ownership. That is not because you got it right — it is because `u64` is a special case. Four lessons in, every value you have touched has been a number small enough to sit in a register, and Rust duplicates those for free.\n\nThe moment a value owns something — a `Vec<u8>` of account data, a struct you defined yourself — assignment stops meaning what it means in JavaScript, and the compiler starts refusing code that looks obviously fine.\n\n## The one sentence\n\nIn JavaScript, `const b = a` gives you **two names for one object**.\n\n```js\nconst vault = { owner: \"…\", balance: 500n };\nconst backup = vault;\nbackup.balance = 0n;\nvault.balance; // 0n — there was only ever one object\n```\n\nIn Rust, `let b = a` gives you **one name and invalidates the other**.\n\n```rust\nlet vault = VaultLike { /* … */ };\nlet backup = vault;   // `vault` is no longer usable\n```\n\nNothing was copied and nothing was freed. The value did not move in memory — the *right to use it* moved, from `vault` to `backup`, at compile time. Reading `vault` afterwards is not a runtime error you can catch. It is a build failure, `E0382: use of moved value`, and the message points at both lines:\n\n```text\nerror[E0382]: use of moved value: `vault`\n    |\n    |     let vault = sample_vault();\n    |         ----- move occurs because `vault` has type `VaultLike`,\n    |               which does not implement the `Copy` trait\n    |     let backup = vault;\n    |                  ----- value moved here\n    |     let _oops = vault.balance;\n    |                 ^^^^^^^^^^^^^ value used here after move\n```\n\nTwo lines named, and the reason stated in the middle of them: *does not implement the `Copy` trait*. Almost every ownership error you will read has that shape — the line that failed, the line that caused it, and the trait that would have made it legal.\n\n## Three rules, and they are actually three\n\n1. Every value has exactly one owner.\n2. When the owner goes out of scope, the value is dropped.\n3. Ownership can be **moved**, **copied** (only for types that opt in), or **borrowed** (next lesson).\n\nThat is the whole model. There is no garbage collector deciding when rule 2 fires; the compiler inserts the drop at the closing brace, and that is why Rust has no runtime and no GC pauses — which is why programs on Solana are written in it.\n\n## Why you already know this shape\n\nYou met this rule in Course 1 without it being called ownership. A Solana transaction declares, up front, which accounts it will **read** and which it will **write**, and the runtime will not schedule two transactions that write the same account at the same time. Many readers, or one writer. Never both.\n\nRust's rule for references is the same sentence: many shared borrows, or one mutable borrow, never both. The runtime enforces it across transactions at runtime; the compiler enforces it inside your function at build time. Same invariant, two places. When `&mut` starts feeling arbitrary, this is the analogy to come back to.\n\n## `Copy` is opt-in, and that is the whole trick\n\nA type is `Copy` only if it says so. Assignment copies instead of moving for:\n\n| Type | Why |\n| --- | --- |\n| `u8`, `u64`, `i64`, `usize`, `bool` | Fixed size, no heap, no destructor |\n| `Pubkey` | 32 plain bytes; the type derives `Copy` |\n| `[u8; 8]` | An array of `Copy` values is `Copy` |\n| `&T` (a shared reference) | A reference is itself just an address |\n\nAssignment **moves** for:\n\n| Type | Why |\n| --- | --- |\n| `Vec<u8>` — a raw account buffer | Owns a heap allocation. Two owners would mean two frees |\n| `String` | Same |\n| `VaultLike`, and any struct you write | **`Copy` is not inferred.** A struct whose every field is `Copy` still moves unless you derive `Copy` on the struct itself |\n\nThat last row is the one that catches people. `VaultLike { owner: Pubkey, balance: u64, bump: u8 }` is 41 bytes of pure `Copy` fields, and it still moves — because `Copy` is a claim about the *type*, not a computed property of its fields, and Rust makes you state it.\n\n## `.clone()` is allowed\n\nThere is a genre of Rust advice that treats `.clone()` as a confession. Ignore it. `.clone()` is an explicit, visible, correct way to get a second independent value, and reaching for it while the model is still settling is the right call. It has exactly one cost: the copy actually happens at runtime, and for a `Vec` that is a heap allocation.\n\nThe reason it barely matters here is that the vault you are building is 41 bytes. The reason it will matter in Course 3 is that account data can be kilobytes and compute units are metered. Clone now, and learn where the borrow goes later — in that order.\n\n## What you are about to do\n\nThis exercise is complete and correct. There is nothing to fix. Build it, then read it top to bottom against its six numbered sections and check each one against the prediction you would have made before this page.\n\nSection 6 is a single-line experiment: uncomment the line marked `BREAK IT`, build, read the error the compiler gives you, then comment it back. That error message is the one you will see most often for the next week, and meeting it deliberately once is cheaper than meeting it by accident five times.\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "exercise",
+        "_type": "code",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": "rust",
+        "buildType": "buildable",
+        "deployable": false,
+        "starter": "// ---------------------------------------------------------------------------\n// Lesson 5 — Moves, Copy, and Clone.\n//\n// WORKED EXAMPLE. This file is complete and it compiles. Nothing here is\n// broken and nothing is missing.\n//\n// Build it once, then read the six numbered sections in order. Each one is\n// three or four lines and demonstrates exactly one rule. Section 6 is the only\n// place you touch: one line to uncomment, build, read, and comment back.\n//\n// Toolchain: anchor-lang 1.1.2 · borsh 1.5.7 declared / 1.8.0 resolved · edition 2021.\n// ---------------------------------------------------------------------------\n\nuse anchor_lang::prelude::*;\n\n/// The vault, as a plain Rust struct — field for field the account layout you\n/// decoded in Course 1. In module 3 this grows an `#[account]` attribute and\n/// becomes the real thing; for now it is an ordinary struct so that ownership\n/// is the only thing in the room.\n///\n/// `Clone` is derived. `Copy` deliberately is NOT, even though all three fields\n/// are `Copy` types. That single omission is what makes every assignment in\n/// section 3 a move.\n///\n/// Note the shape change from lesson 2: `last_deposit_at` is gone and\n/// `owner: Pubkey` has arrived. Lesson 2 needed somewhere to put an `i64`;\n/// from here on the stand-in matches module 4's real `VaultState`\n/// — `{ owner, balance, bump }` — because `owner` is the field that makes\n/// the move rules interesting.\n#[derive(Clone, Debug)]\npub struct VaultLike {\n    pub owner: Pubkey,\n    pub balance: u64,\n    pub bump: u8,\n}\n\n/// A fresh vault to experiment on. `Pubkey::default()` is the all-zero address.\npub fn sample_vault() -> VaultLike {\n    VaultLike {\n        owner: Pubkey::default(),\n        balance: 500_000,\n        bump: 254,\n    }\n}\n\n// === 1. `u64` is Copy: assignment duplicates the value =====================\n// `snapshot` is a second, independent 8 bytes. `balance` is untouched and\n// still readable, which is why lesson 4 never made you think about ownership.\npub fn copy_a_number() -> u64 {\n    let balance: u64 = 1_000_000;\n    let snapshot = balance;\n    balance + snapshot // 2_000_000 — both names are live\n}\n\n// === 2. `Pubkey` is Copy too ==============================================\n// 32 plain bytes, no heap, no destructor, and the type derives `Copy`. So you\n// can read the field out of a borrowed vault as many times as you like.\npub fn copy_an_address(v: &VaultLike) -> (Pubkey, Pubkey) {\n    let owner = v.owner;\n    let owner_again = v.owner;\n    (owner, owner_again)\n}\n\n// === 3. `VaultLike` is NOT Copy: assignment MOVES =========================\n// Every field is `Copy` and the struct still moves, because `Copy` is a claim\n// you make about a type, not something inferred from its fields. After the\n// second line, the name `vault` is dead — the compiler will not let you read\n// it, and there is no runtime check involved.\npub fn move_a_struct() -> u64 {\n    let vault = sample_vault();\n    let moved = vault;\n    moved.balance\n}\n\n// === 4. A `Vec<u8>` can never be Copy =====================================\n// Raw account data is a heap buffer with exactly one owner, because two owners\n// would mean two frees. Passing it by value into `consume_bytes` moves it, and\n// `data` is unusable on the next line.\npub fn move_account_data() -> usize {\n    let data: Vec<u8> = vec![0u8; 49]; // 8 discriminator + 32 owner + 8 balance + 1 bump\n    consume_bytes(data)\n}\n\nfn consume_bytes(bytes: Vec<u8>) -> usize {\n    bytes.len()\n}\n\n// === 5. `.clone()` is the escape hatch, and it is legitimate ==============\n// An explicit, visible request for a second independent value. Both names are\n// live afterwards. The cost is real but it is written down at the call site,\n// which is the entire design intent.\npub fn clone_a_struct() -> (u64, u64) {\n    let vault = sample_vault();\n    let mut backup = vault.clone();\n    backup.balance = 0;\n    (vault.balance, backup.balance) // (500_000, 0) — two separate vaults\n}\n\n// === 6. Borrowing: pass a reference and nothing moves at all ==============\n// `&VaultLike` is a shared borrow. It grants read access and takes nothing, so\n// the caller still owns the vault after the call returns — which is why you can\n// call it twice. This signature is the first function you write in the next\n// lesson, and it is a method on the real `VaultState` in module 4.\npub fn balance_of(v: &VaultLike) -> u64 {\n    v.balance\n}\n\npub fn read_twice() -> (u64, u64) {\n    let vault = sample_vault();\n    let a = balance_of(&vault);\n    let b = balance_of(&vault);\n    (a, b)\n}\n\n// === The experiment =======================================================\n// Uncomment the line marked BREAK IT. Build. Read the error — note that it\n// names the line where the move happened, not just the line that failed. Then\n// comment it back and build again to confirm you are green.\n//\n// If you lose track of the file, Reset Code restores it.\npub fn experiment() -> u64 {\n    let vault = sample_vault();\n    let moved = vault;\n\n    // let _oops = vault.balance; // <-- BREAK IT\n\n    moved.balance\n}\n",
+        "solution": "// ---------------------------------------------------------------------------\n// Lesson 5 — Moves, Copy, and Clone.\n//\n// WORKED EXAMPLE — reference copy. Identical to the starter, because there was\n// nothing to fix. The only difference is the note at the bottom recording the\n// error the experiment produces, so you can check what you read against it.\n//\n// Toolchain: anchor-lang 1.1.2 · borsh 1.5.7 declared / 1.8.0 resolved · edition 2021.\n// ---------------------------------------------------------------------------\n\nuse anchor_lang::prelude::*;\n\n/// The vault, as a plain Rust struct — field for field the account layout you\n/// decoded in Course 1. In module 3 this grows an `#[account]` attribute and\n/// becomes the real thing; for now it is an ordinary struct so that ownership\n/// is the only thing in the room.\n///\n/// `Clone` is derived. `Copy` deliberately is NOT, even though all three fields\n/// are `Copy` types. That single omission is what makes every assignment in\n/// section 3 a move.\n///\n/// Note the shape change from lesson 2: `last_deposit_at` is gone and\n/// `owner: Pubkey` has arrived. Lesson 2 needed somewhere to put an `i64`;\n/// from here on the stand-in matches module 4's real `VaultState`\n/// — `{ owner, balance, bump }` — because `owner` is the field that makes\n/// the move rules interesting.\n#[derive(Clone, Debug)]\npub struct VaultLike {\n    pub owner: Pubkey,\n    pub balance: u64,\n    pub bump: u8,\n}\n\n/// A fresh vault to experiment on. `Pubkey::default()` is the all-zero address.\npub fn sample_vault() -> VaultLike {\n    VaultLike {\n        owner: Pubkey::default(),\n        balance: 500_000,\n        bump: 254,\n    }\n}\n\n// === 1. `u64` is Copy: assignment duplicates the value =====================\n// `snapshot` is a second, independent 8 bytes. `balance` is untouched and\n// still readable, which is why lesson 4 never made you think about ownership.\npub fn copy_a_number() -> u64 {\n    let balance: u64 = 1_000_000;\n    let snapshot = balance;\n    balance + snapshot // 2_000_000 — both names are live\n}\n\n// === 2. `Pubkey` is Copy too ==============================================\n// 32 plain bytes, no heap, no destructor, and the type derives `Copy`. So you\n// can read the field out of a borrowed vault as many times as you like.\npub fn copy_an_address(v: &VaultLike) -> (Pubkey, Pubkey) {\n    let owner = v.owner;\n    let owner_again = v.owner;\n    (owner, owner_again)\n}\n\n// === 3. `VaultLike` is NOT Copy: assignment MOVES =========================\n// Every field is `Copy` and the struct still moves, because `Copy` is a claim\n// you make about a type, not something inferred from its fields. After the\n// second line, the name `vault` is dead — the compiler will not let you read\n// it, and there is no runtime check involved.\npub fn move_a_struct() -> u64 {\n    let vault = sample_vault();\n    let moved = vault;\n    moved.balance\n}\n\n// === 4. A `Vec<u8>` can never be Copy =====================================\n// Raw account data is a heap buffer with exactly one owner, because two owners\n// would mean two frees. Passing it by value into `consume_bytes` moves it, and\n// `data` is unusable on the next line.\npub fn move_account_data() -> usize {\n    let data: Vec<u8> = vec![0u8; 49]; // 8 discriminator + 32 owner + 8 balance + 1 bump\n    consume_bytes(data)\n}\n\nfn consume_bytes(bytes: Vec<u8>) -> usize {\n    bytes.len()\n}\n\n// === 5. `.clone()` is the escape hatch, and it is legitimate ==============\n// An explicit, visible request for a second independent value. Both names are\n// live afterwards. The cost is real but it is written down at the call site,\n// which is the entire design intent.\npub fn clone_a_struct() -> (u64, u64) {\n    let vault = sample_vault();\n    let mut backup = vault.clone();\n    backup.balance = 0;\n    (vault.balance, backup.balance) // (500_000, 0) — two separate vaults\n}\n\n// === 6. Borrowing: pass a reference and nothing moves at all ==============\n// `&VaultLike` is a shared borrow. It grants read access and takes nothing, so\n// the caller still owns the vault after the call returns — which is why you can\n// call it twice. This signature is the first function you write in the next\n// lesson, and it is a method on the real `VaultState` in module 4.\npub fn balance_of(v: &VaultLike) -> u64 {\n    v.balance\n}\n\npub fn read_twice() -> (u64, u64) {\n    let vault = sample_vault();\n    let a = balance_of(&vault);\n    let b = balance_of(&vault);\n    (a, b)\n}\n\n// === The experiment =======================================================\n// Uncomment the line marked BREAK IT. Build. Read the error — note that it\n// names the line where the move happened, not just the line that failed. Then\n// comment it back and build again to confirm you are green.\n//\n// If you lose track of the file, Reset Code restores it.\npub fn experiment() -> u64 {\n    let vault = sample_vault();\n    let moved = vault;\n\n    // let _oops = vault.balance; // <-- BREAK IT\n\n    moved.balance\n}\n\n// Uncommented, that line produces exactly this:\n//\n//   error[E0382]: use of moved value: `vault`\n//       |\n//       |     let vault = sample_vault();\n//       |         ----- move occurs because `vault` has type `VaultLike`,\n//       |               which does not implement the `Copy` trait\n//       |     let moved = vault;\n//       |                 ----- value moved here\n//       |     let _oops = vault.balance;\n//       |                 ^^^^^^^^^^^^^ value used here after move\n//       |\n//   help: consider cloning the value if the performance cost is acceptable\n//       |\n//       |     let moved = vault.clone();\n//       |                      ++++++++\n//\n// Note what the compiler does NOT say: nothing about `balance` being a `u64`.\n// The field is `Copy`, but you cannot reach through a binding that no longer\n// owns anything to get at it. And note the suggestion — `.clone()` really is\n// the fix the compiler itself proposes.\n",
+        "tests": [
+          {
+            "id": "test-1",
+            "description": "The file compiles against anchor-lang 1.1.2 on the build server",
+            "input": "",
+            "expectedOutput": "true"
+          },
+          {
+            "id": "test-2",
+            "description": "Compiles ⇒ the BREAK IT line in the experiment is commented out — an uncommented use-after-move is E0382, so a green build means it is back under its comment. Nothing here checks whether you read the error first",
+            "input": "",
+            "expectedOutput": "true"
+          }
+        ],
+        "hints": [
+          "Nothing needs fixing. Click Build first, then read the six numbered sections against the predictions you would have made before the page above.",
+          "First builds are slow — the toolchain is downloading anchor-lang 1.1.2 and its dependencies. A second build of the same file is much faster.",
+          "Section 6 is the whole exercise: uncomment the line marked BREAK IT, build, read which TWO lines the error names, then comment it back. Click Reset Code if you lose the file."
+        ],
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "check",
+        "_type": "quiz",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": [
+          {
+            "id": "q1",
+            "prompt": "`VaultLike` holds a `Pubkey`, a `u64` and a `u8` — every field is a `Copy` type. You write `let moved = vault;` and then read `vault.balance`. Predict what the compiler does.",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "Rejects it — `E0382`, because `Copy` is opt-in on the struct and `VaultLike` does not derive it",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "Accepts it — a struct whose every field is `Copy` is itself `Copy`",
+                "correct": false,
+                "feedback": "This is the single most common wrong model. `Copy` is a claim you make about a type with a derive, not a property Rust computes from the fields. All-`Copy` fields make the derive *possible*; they do not make it happen."
+              },
+              {
+                "id": "c",
+                "label": "Accepts it — `balance` is a `u64`, and reading a `Copy` field is always allowed",
+                "correct": false,
+                "feedback": "The field is indeed `Copy`, but you are reaching for it through `vault`, and `vault` no longer owns anything. There is nothing to read the field out of."
+              },
+              {
+                "id": "d",
+                "label": "Compiles, then panics at runtime with a use-after-move error",
+                "correct": false,
+                "feedback": "There is no runtime check and no panic. Ownership is enforced entirely at compile time, which is why it costs zero instructions and zero compute units."
+              }
+            ],
+            "explanation": "The error names two lines — where the move happened and where the dead name was used — and states the reason between them: \"does not implement the `Copy` trait\"."
+          },
+          {
+            "id": "q2",
+            "prompt": "Inside `fn copy_an_address(v: &VaultLike)` you write `let a = v.owner;` and then `let b = v.owner;`. Predict the outcome.",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "Both compile — `Pubkey` derives `Copy`, so each line copies 32 bytes out of the borrow",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "The first compiles and the second is `E0382`, because the first one moved the field out",
+                "correct": false,
+                "feedback": "A `Copy` field is never moved by a read. If `Pubkey` were not `Copy` you would not get `E0382` either — you would get `E0507`, cannot move out of borrowed content, because you do not own `v` at all."
+              },
+              {
+                "id": "c",
+                "label": "Neither compiles — you cannot read any field through a shared reference",
+                "correct": false,
+                "feedback": "Reading is exactly what a shared reference is for. `&T` grants read access to every field; what it withholds is mutation."
+              },
+              {
+                "id": "d",
+                "label": "Both compile, but each one allocates because `Pubkey` is 32 bytes",
+                "correct": false,
+                "feedback": "32 bytes on the stack, no allocator involved. Heap allocation is what `Vec` and `String` do, and it is exactly why those two are not `Copy`."
+              }
+            ],
+            "explanation": null
+          },
+          {
+            "id": "q3",
+            "prompt": "`fn consume_bytes(bytes: Vec<u8>) -> usize` takes its argument by value. You call `consume_bytes(data)` twice with the same `data`. Predict what happens on the second call.",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "`E0382` on the second call — the first call moved the buffer, and a `Vec` can never be `Copy`",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "It works — the function only reads the length, so nothing is consumed",
+                "correct": false,
+                "feedback": "What the body does is irrelevant. Ownership follows the *signature*: `Vec<u8>` by value means the caller hands it over, and the value is dropped at the end of the callee."
+              },
+              {
+                "id": "c",
+                "label": "It works, but the second call sees an empty vector",
+                "correct": false,
+                "feedback": "There is no \"emptied\" state to observe. The compiler refuses to build the call rather than letting you look at a moved-from value."
+              },
+              {
+                "id": "d",
+                "label": "`E0499` — two calls means two mutable borrows of `data`",
+                "correct": false,
+                "feedback": "Nothing was borrowed. The parameter is `Vec<u8>`, not `&mut Vec<u8>`, so this is a move, not a borrow, and moves report `E0382`."
+              }
+            ],
+            "explanation": null
+          },
+          {
+            "id": "q4",
+            "prompt": "You hand a `VaultLike` by value to a logging helper and need to read the balance afterwards. Which fix keeps the caller's vault alive without copying 41 bytes and without changing what the type claims about itself?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "Change the helper to take `&VaultLike`",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "Add `Copy` to the struct's derive list",
+                "correct": false,
+                "feedback": "It would compile here, but `Copy` is a permanent claim about the type — that duplicating it is always cheap and always correct. The day the struct gains a `Vec` field the derive becomes impossible, and every call site that silently relied on copying breaks at once."
+              },
+              {
+                "id": "c",
+                "label": "Pass `vault.clone()` at the call site",
+                "correct": false,
+                "feedback": "This works and is not shameful — but it does copy the 41 bytes, which is what the question ruled out. Reach for it when a borrow genuinely will not fit the shape of your code."
+              },
+              {
+                "id": "d",
+                "label": "Read `vault.balance` into a variable before the call, then use that",
+                "correct": false,
+                "feedback": "This also compiles, and it is the right move for one `Copy` field. It does not keep the *vault* alive though — `vault` is still dead after the call, so anything else you needed from it is gone."
+              }
+            ],
+            "explanation": "Borrowing is the answer the language wants, and it is the whole of the next lesson: `&VaultLike` to read, `&mut VaultLike` to write."
+          }
+        ],
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      }
+    ]
+  },
+  {
+    "_id": "lesson-rpd-ownership-checkpoint",
+    "title": "Checkpoint: Ownership",
+    "slug": "ownership-checkpoint",
+    "blocks": [
+      {
+        "key": "retrieval",
+        "_type": "quiz",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": [
+          {
+            "id": "q1",
+            "prompt": "A function takes `vaults: Vec<VaultLike>`, sums the balances with `for v in vaults { sum += v.balance; }`, then returns the tuple `(sum, vaults.len())`. Predict the verdict.",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "`E0382` — `for v in vaults` calls `.into_iter()`, which takes the `Vec` by value, so `vaults` is gone by the last line",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "Compiles — a `for` loop borrows what it iterates",
+                "correct": false,
+                "feedback": "`for x in collection` moves it; `for x in &collection` borrows it. The sugar hides an ordinary by-value call to `into_iter`, and the compiler's own suggestion is to add the `&`."
+              },
+              {
+                "id": "c",
+                "label": "Compiles — `len()` only reads, and a read after a move is allowed",
+                "correct": false,
+                "feedback": "A read is a borrow, and you cannot borrow what you no longer own. The error even says so: \"value borrowed here after move\"."
+              },
+              {
+                "id": "d",
+                "label": "`E0507` — cannot move out of `vaults` because it is borrowed",
+                "correct": false,
+                "feedback": "Nothing borrowed it first. `E0507` is for moving out of something you only have a reference to. Here you owned the `Vec` outright and gave it away."
+              }
+            ],
+            "explanation": null
+          },
+          {
+            "id": "q2",
+            "prompt": "`pub fn describe(balance: u64) -> &'static str` has a body consisting of `match balance { 0 => \"empty\", _ => \"funded\" };` — note the semicolon. Predict the verdict.",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "`E0308` — expected `&str`, found `()`; the semicolon discards the match's value and the body ends with nothing",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "Compiles — the last expression in a body is returned whether or not it has a semicolon",
+                "correct": false,
+                "feedback": "The semicolon is exactly what decides that. With it the line is a statement whose value is thrown away; without it the line is the body's tail expression and its value is returned."
+              },
+              {
+                "id": "c",
+                "label": "`E0317` — `if`/`match` may be missing an `else` clause",
+                "correct": false,
+                "feedback": "The match is exhaustive — `_` covers everything. The arms are not the problem; what happens to the value they produce is."
+              },
+              {
+                "id": "d",
+                "label": "Compiles, and returns an empty string",
+                "correct": false,
+                "feedback": "There is no implicit empty value in Rust and no coercion from `()` to `&str`. A type mismatch is a build failure, not a default."
+              }
+            ],
+            "explanation": "The compiler names the semicolon and offers to delete it: \"help: remove this semicolon to return this value\"."
+          },
+          {
+            "id": "q3",
+            "prompt": "Seeded from Course 1. Your inspector reads 8 bytes at offset 32 of a 49-byte vault account and prints a balance in the quintillions. The vault actually holds 0.5 SOL. The layout is 8-byte discriminator, `owner: Pubkey`, `balance: u64`, `bump: u8`. Diagnose it.",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "The read starts 8 bytes early — `balance` begins at 8 + 32 = 40, so offset 32 straddles the last 8 bytes of `owner` and the first nothing of `balance`, and you decoded address bytes as a number",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "The bytes were read big-endian. Borsh writes a `u64` little-endian, and reversing the byte order of 500 000 000 gives a gigantic value",
+                "correct": false,
+                "feedback": "A real cause of exactly this symptom, and not this one: the offset is wrong before endianness gets a say. Worth checking second — if offset 40 still gives you nonsense, that is where you look."
+              },
+              {
+                "id": "c",
+                "label": "`Number` lost precision. A `u64` lamport balance above 2^53 − 1 is silently rounded by a JavaScript double",
+                "correct": false,
+                "feedback": "Precision loss perturbs a large number; it does not turn 500 000 000 into a quintillion. And 0.5 SOL is 5 × 10^8 lamports, far below 2^53 − 1, so a double holds it exactly."
+              },
+              {
+                "id": "d",
+                "label": "The discriminator did not match, so the decoder fell through and read whatever was in the buffer",
+                "correct": false,
+                "feedback": "Nothing \"falls through\". A discriminator mismatch is something you check for and reject; a decoder pointed at the wrong offset happily reads eight real bytes and reports a real number that means something else."
+              }
+            ],
+            "explanation": "`balance` starts at **40**. Every Anchor account spends its first 8 bytes on a hash of the account type's name, and `Pubkey` is 32, and Borsh adds no padding — the fields sit back to back in declaration order. Offset 32 is where the last 8 bytes of the owner's address live, which is why the wrong answer looks like a number rather than an error."
+          },
+          {
+            "id": "q4",
+            "prompt": "Inside `fn stash(v: &mut VaultLike) -> u64` you write `let slot = &mut v.balance;`, then `let total = balance_of(v);`, then `*slot = total;`. Predict the error and its exact direction.",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "`E0502` — cannot borrow `*v` as immutable because it is also borrowed as mutable",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "`E0502` — cannot borrow `*v` as mutable because it is also borrowed as immutable",
+                "correct": false,
+                "feedback": "Right code, wrong direction. That wording is for the case where the shared borrow came first. Here the `&mut` came first, so the compiler complains about the shared one arriving second — read which borrow gets the caret."
+              },
+              {
+                "id": "c",
+                "label": "`E0499` — two mutable borrows, since `balance_of` reborrows `v` mutably",
+                "correct": false,
+                "feedback": "`balance_of` takes `&VaultLike`. Passing a `&mut` where a `&` is wanted produces a *shared* reborrow, not a second exclusive one."
+              },
+              {
+                "id": "d",
+                "label": "Compiles — `slot` borrows one field and `balance_of` reads the whole struct, so nothing overlaps",
+                "correct": false,
+                "feedback": "Field-level disjointness only helps when both borrows are of distinct fields. `balance_of(v)` borrows the whole vault, which includes the field already borrowed mutably."
+              }
+            ],
+            "explanation": "Both directions of `E0502` name three lines, and the third — \"mutable borrow later used here\" — is the one that tells you which borrow to get rid of."
+          },
+          {
+            "id": "q5",
+            "prompt": "`pub fn space(field_count: u32) -> usize { 8 + field_count }`. Predict the verdict, and what you should do with the compiler's suggested fix.",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "`E0308`, expected `usize` found `u32` — and refuse the suggested `.try_into().unwrap()`, writing `usize::try_from(field_count)` and handling the `Err` instead",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "Compiles — `u32` widens to `usize` automatically because it cannot lose information",
+                "correct": false,
+                "feedback": "Rust has no implicit numeric coercion at all, lossless or not. The literal `8` infers `u32` from its neighbour and the sum stays a `u32`."
+              },
+              {
+                "id": "c",
+                "label": "`E0308`, and the right fix is the `.try_into().unwrap()` the compiler proposes",
+                "correct": false,
+                "feedback": "It compiles, and it is a panic waiting for the input that triggers it. The compiler does not know it is writing on-chain code; its diagnostics are authoritative and its suggestions are not. Keep the `try_into`, drop the `unwrap`."
+              },
+              {
+                "id": "d",
+                "label": "`E0308`, and the fix is `usize::from(field_count) + 8`, the infallible conversion",
+                "correct": false,
+                "feedback": "`usize::from` does not exist for `u32` — `impl From<u32> for usize` is not in the standard library, because `usize` is 16 bits on some targets and the conversion is therefore not universally lossless. `impl From<u16> for usize` does exist. `TryFrom` is what you get for `u32`, and it hands you a `Result` rather than a promise."
+              }
+            ],
+            "explanation": null
+          },
+          {
+            "id": "q6",
+            "prompt": "`pub fn owner_bytes(v: &VaultLike) -> &[u8]` with the body `let bytes = v.owner.to_bytes(); &bytes`. `Pubkey::to_bytes` returns `[u8; 32]`. Predict the verdict.",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "`E0515` — cannot return reference to local variable `bytes`; `to_bytes` returned an owned array this function drops on the way out",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "Compiles — `[u8; 32]` is `Copy`, so returning a reference to it is fine",
+                "correct": false,
+                "feedback": "`Copy` decides whether assignment duplicates the value. It has nothing to say about how long the local lives, and the local dies at the closing brace either way."
+              },
+              {
+                "id": "c",
+                "label": "Compiles — `bytes` is on the stack, not the heap, so there is nothing to free",
+                "correct": false,
+                "feedback": "The stack frame goes away too. Where the bytes live does not change when they stop existing."
+              },
+              {
+                "id": "d",
+                "label": "`E0106` — the signature needs an explicit lifetime because the return borrows from a local",
+                "correct": false,
+                "feedback": "Elision handles this signature fine: one input reference, so the return borrows from `v`. The problem is that the body tried to borrow from something else entirely."
+              }
+            ],
+            "explanation": "`v.owner.as_ref()` is the fix — a `&[u8]` view of the `Pubkey` the caller already owns. When you borrow from a method's return value, check first whether that method returned a reference or a value."
+          },
+          {
+            "id": "q7",
+            "prompt": "Also seeded from Course 1. Kit's `getU64Decoder` gives you a `BigInt` for the vault's `balance`, not a `Number`. Why does that matter enough to change the API?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "`Number` is a double: integers above 2^53 − 1 stop being exactly representable and are silently rounded, and a `u64` lamport balance clears that comfortably",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "`BigInt` is faster for arithmetic on large values",
+                "correct": false,
+                "feedback": "It is slower, and that is an acceptable price. The reason is correctness: a wrong balance that looks plausible is worse than a slow one."
+              },
+              {
+                "id": "c",
+                "label": "`Number` cannot hold values above 2^32, so any balance over ~4.29 billion lamports overflows",
+                "correct": false,
+                "feedback": "Wrong boundary. A double holds far more than 2^32; the limit is where *exact integer* representation stops, at 2^53 − 1."
+              },
+              {
+                "id": "d",
+                "label": "Because JSON-RPC returns balances as strings and `BigInt` is what parses them",
+                "correct": false,
+                "feedback": "How the number arrives on the wire is a separate question. The decoder's choice is about what can hold the value once parsed."
+              }
+            ],
+            "explanation": "This constraint is the origin of `u64` in the struct you are about to write. In Rust the width is in the type, and the only way to lose a lamport is to let the arithmetic wrap."
+          },
+          {
+            "id": "q8",
+            "prompt": "`pub fn withdraw(v: &mut VaultLike, amount: u64) { v.balance = v.balance - amount; }` compiles. The build server's release profile sets `overflow-checks = true`. Predict what happens when `amount` exceeds the balance, and whether that setting is enough.",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "It panics and the instruction aborts with no useful message — and no, because the correct behaviour is a typed error the caller can act on, which is what `checked_sub` gives you",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "It wraps to a huge number, and `overflow-checks = true` is the fix",
+                "correct": false,
+                "feedback": "With the checks on it panics rather than wrapping, so the setting does change the outcome — but \"panic\" is not the behaviour you want. It converts a silent wrong answer into an opaque failure, which is an improvement, not a solution."
+              },
+              {
+                "id": "c",
+                "label": "It returns `None`, because Rust's `-` on unsigned integers is checked by default",
+                "correct": false,
+                "feedback": "`-` returns a `u64`, never an `Option`. `checked_sub` is a different method with a different return type, and you have to choose it."
+              },
+              {
+                "id": "d",
+                "label": "Nothing bad — `v.balance` is a `u64` and cannot go negative, so the result clamps at zero",
+                "correct": false,
+                "feedback": "Nothing clamps. Saturating behaviour exists but you have to ask for it by name (`saturating_sub`), and silently clamping a withdrawal to zero would be its own exploit."
+              }
+            ],
+            "explanation": "`overflow-checks = true` is a safety net for testing, not a substitute for checked arithmetic. `sub_lamports` from lesson 4 becomes `VaultState::withdraw` returning `VaultError::InsufficientFunds` in module 4 — same arithmetic, with a reason attached."
+          }
+        ],
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "worked-answers",
+        "_type": "prose",
+        "produces": null,
+        "consumes": null,
+        "src": "# Worked Answers\n\n> **Version stamp — checked 2026-07-26.** Every message below is real `rustc` output, produced by compiling the snippet above it against `anchor-lang 1.1.2` / borsh 1.5.7 declared / 1.8.0 resolved / edition 2021 — the same toolchain the build server uses. Nothing here is paraphrased.\n\nRead this after the quiz, not before. Getting a question wrong and then reading why is worth several times more than reading first and nodding.\n\nTwo of the eight questions had nothing to fail to compile — the misread-balance one and the `BigInt` one. Those two are from Course 1, they are diagnoses rather than predictions, and they are here because you are about to write the Rust struct whose bytes you were decoding in JavaScript six lessons ago.\n\n---\n\n## 1 — A `for` loop consumes what it iterates\n\n```rust\npub fn total(vaults: Vec<VaultLike>) -> (u64, usize) {\n    let mut sum = 0u64;\n    for v in vaults {\n        sum += v.balance;\n    }\n    (sum, vaults.len())\n}\n```\n\n```text\nerror[E0382]: borrow of moved value: `vaults`\n   |\n   | pub fn total(vaults: Vec<VaultLike>) -> (u64, usize) {\n   |              ------ move occurs because `vaults` has type `Vec<VaultLike>`,\n   |                     which does not implement the `Copy` trait\n   |     for v in vaults {\n   |              ------ `vaults` moved due to this implicit call to `.into_iter()`\n...\n   |     (sum, vaults.len())\n   |           ^^^^^^ value borrowed here after move\n   |\nnote: `into_iter` takes ownership of the receiver `self`, which moves `vaults`\nhelp: consider iterating over a slice of the `Vec<VaultLike>`'s content to avoid\n      moving into the `for` loop\n   |\n   |     for v in &vaults {\n   |              +\n```\n\n`for x in collection` calls `.into_iter()`, which takes `self`. The loop is not doing anything unusual; it is an ordinary by-value call written with sugar, and the sugar is what hides it. `for v in &vaults` iterates `&VaultLike` instead, which is the fix the compiler hands you and the one you want almost every time.\n\nThe one-character diff is worth internalising because you will write this loop over `remaining_accounts` in Course 3.\n\n---\n\n## 2 — A trailing semicolon changes the type of the function\n\n```rust\npub fn describe(balance: u64) -> &'static str {\n    match balance { 0 => \"empty\", _ => \"funded\" };\n}\n```\n\n```text\nerror[E0308]: mismatched types\n  |\n  | pub fn describe(balance: u64) -> &'static str {\n  |        --------                  ^^^^^^^^^^^^ expected `&str`, found `()`\n  |        |\n  |        implicitly returns `()` as its body has no tail or `return` expression\n  |     match balance { 0 => \"empty\", _ => \"funded\" };\n  |                                                  - help: remove this semicolon\n  |                                                         to return this value\n```\n\n`match` is an expression and produces `&str`. The semicolon throws that value away and turns the line into a statement, so the function body ends with nothing and evaluates to `()`.\n\nNote how precise the diagnostic is — it names the semicolon and offers to delete it. This is the single most common first-week Rust error for anyone arriving from JavaScript, where `return` is mandatory and a stray semicolon is free.\n\n---\n\n## 3 — A balance in the quintillions, from an offset that is 8 bytes early\n\nNo compiler involved. Anchor's layout for the account you decoded in Course 1:\n\n| Offset | Bytes | Field |\n| --- | --- | --- |\n| 0 | 8 | discriminator |\n| 8 | 32 | `owner: Pubkey` |\n| **40** | 8 | `balance: u64`, little-endian |\n| 48 | 1 | `bump: u8` |\n\n49 bytes. `balance` starts at 40, because the discriminator is 8 and a `Pubkey` is 32 — and `8 + 32` is arithmetic you will write literally, as `space = 8 + 32 + 8 + 1`, in Course 3's account constraint. `discriminator(data)` from the last lesson returns the first row of that table.\n\nA read at offset 32 therefore takes the **last eight bytes of the owner's address** and calls them a balance. That is why the symptom is a plausible-looking wrong number rather than a crash: a `Pubkey` is 32 bytes of hash output, so interpreting any eight of them as a little-endian `u64` gives you something in the 10^18 range roughly half the time.\n\nTwo things to take from the shape of that bug. First, an off-by-8 in an account decoder produces *data*, not an error — nothing in the byte array is self-describing, which is the whole reason the discriminator exists and the whole reason lesson 8 makes you write the length check. Second, the two other suspects on the list are both real and both worth ruling out in order: wrong endianness (Borsh is little-endian; `getU64Decoder` already knows that) and `Number` precision above 2^53 − 1 (which is why Kit hands you a `BigInt`, and which question 7 is about). Diagnose offset first, because it is the only one of the three that can be wrong while the other two are right.\n\n---\n\n## 4 — `E0502` runs in both directions\n\n```rust\npub fn stash(v: &mut VaultLike) -> u64 {\n    let slot = &mut v.balance;\n    let total = balance_of(v);\n    *slot = total;\n    total\n}\n```\n\n```text\nerror[E0502]: cannot borrow `*v` as immutable because it is also borrowed as mutable\n   |\n   |     let slot = &mut v.balance;\n   |                -------------- mutable borrow occurs here\n   |     let total = balance_of(v);\n   |                            ^ immutable borrow occurs here\n   |     *slot = total;\n   |     ------------- mutable borrow later used here\n```\n\nIn lesson 7 you read the mirror image of this — *cannot borrow as mutable because it is also borrowed as immutable*. Same rule, reported from whichever side arrived second. Both times the third line named is the one that keeps the first borrow alive.\n\nThe fix is the same as it was: `let total = balance_of(v);` **first**, then take the mutable borrow, or skip it entirely and write `v.balance = total;`.\n\n---\n\n## 5 — Rust does not widen integers for you, and the compiler's suggestion here is wrong for us\n\n```rust\npub fn space(field_count: u32) -> usize {\n    8 + field_count\n}\n```\n\n```text\nerror[E0308]: mismatched types\n   |\n   | pub fn space(field_count: u32) -> usize {\n   |                                   ----- expected `usize` because of return type\n   |     8 + field_count\n   |     ^^^^^^^^^^^^^^^ expected `usize`, found `u32`\n   |\nhelp: you can convert a `u32` to a `usize` and panic if the converted value\n      doesn't fit\n   |\n   |     (8 + field_count).try_into().unwrap()\n   |     +               +++++++++++++++++++++\n```\n\nThree things to take from this.\n\nFirst, the error itself: no implicit numeric coercion, ever, not even the apparently-lossless `u32` → `usize`. The literal `8` infers as `u32` from its neighbour, the sum is a `u32`, and the return type is a `usize`.\n\nSecond: the obvious infallible conversion is not available. `usize::from(field_count)` does not compile — `impl From<u32> for usize` is not in the standard library, and the reason is that `usize` is 16 bits on some targets, so the conversion is not lossless everywhere. (`impl From<u16> for usize` does exist, for exactly that reason.) What `u32` gets is `TryFrom`:\n\n```rust\npub fn space(field_count: u32) -> Option<usize> {\n    match usize::try_from(field_count) {\n        Ok(n) => n.checked_add(8),\n        Err(_) => None,\n    }\n}\n```\n\nThat is the shape lesson 4 taught, applied to a conversion rather than to arithmetic: a fallible operation returns a value that names the failure, and the caller deals with it. Note the return type had to change. That is not a workaround — it is the honest signature.\n\nThird, and most important: **read the suggestion and refuse the second half of it.** `.try_into()` is right; `.unwrap()` is not. `unwrap()` in a program is a panic waiting for the input that triggers it. The compiler does not know it is writing on-chain code. Its diagnostics are excellent and its suggestions are not policy — this course's rule is that `unwrap()` and `expect()` never appear in program code, and module 3 gives you the `Result` machinery that makes obeying it painless.\n\n**And what about `field_count as usize`?** It compiles, it is a widening cast on SBF (a 64-bit target, so `usize` is 8 bytes and nothing can be lost), and lesson 2 still told you not to write it. That rule stands and the carve-out is narrow: `as` is defensible only when you have *pinned the target* and can therefore prove the cast widens. Course 3 compiles for one target and you could argue it there. Here you cannot, because `space` is an ordinary function in a crate that also builds `lib` for the host — and more to the point, `usize::try_from` costs you one `match` and removes the argument entirely. Prefer the conversion that cannot be wrong when the platform changes under you.\n\n---\n\n## 6 — `to_bytes()` hands you an owned array\n\n```rust\npub fn owner_bytes(v: &VaultLike) -> &[u8] {\n    let bytes = v.owner.to_bytes();\n    &bytes\n}\n```\n\n```text\nerror[E0515]: cannot return reference to local variable `bytes`\n   |\n   |     &bytes\n   |     ^^^^^^ returns a reference to data owned by the current function\n```\n\n`Pubkey::to_bytes` returns `[u8; 32]` **by value** — a fresh 32-byte array that this function owns and drops on the way out. Same shape as lesson 7's bug 4, different disguise: nothing here looks like an allocation, and the array is on the stack rather than the heap, but ownership is ownership.\n\nThe fix names the borrow properly: `v.owner.as_ref()` gives you a `&[u8]` view of the `Pubkey` the caller already owns, and lives as long as `v` does. When you find yourself borrowing from a method's return value, check whether that method returned a reference or a value.\n\n---\n\n## 7 — Why Course 1 handed you a `BigInt`\n\n`balance` is a `u64`, so its maximum is 18,446,744,073,709,551,615. JavaScript's `Number` is a double: integers above 2^53 − 1 (9,007,199,254,740,991) stop being exactly representable, and the excess is silently rounded rather than reported. A whale's lamport balance clears 2^53 comfortably.\n\nSo a decoder that returned `Number` would hand you a value that is *nearly* right, which is worse than an error, and that is why Kit's `getU64Decoder` gives you a `BigInt`.\n\nThat constraint is the origin of `u64` in the struct you are about to write. In Rust the width is in the type, `u64 + u64` never silently becomes a float, and the only way to lose a lamport is to let the arithmetic wrap — which is what the next answer is about.\n\n---\n\n## 8 — `-` on a `u64` is not safe, and `overflow-checks` is not the fix\n\n```rust\npub fn withdraw(v: &mut VaultLike, amount: u64) {\n    v.balance = v.balance - amount;\n}\n```\n\nThis compiles. That is the problem.\n\nWith `amount` greater than the balance, `u64` subtraction underflows. What happens next depends on the build profile, which is the worst possible thing for it to depend on:\n\n- With overflow checks **on** — and the build server's release profile does set `overflow-checks = true` — the subtraction panics. In a program a panic aborts the instruction, and the caller gets a failure with no useful message.\n- With overflow checks **off**, `5 - 7` wraps to 18,446,744,073,709,551,614. Your vault now reports a balance of eighteen quintillion lamports, and there is no error anywhere.\n\n`overflow-checks = true` is a safety net for your own testing. It is **not** a substitute for checked arithmetic, because the correct behaviour is not \"panic\" — it is \"return an error the caller can act on\". That is `checked_sub`, which you wrote in lesson 4 as `sub_lamports` returning `Option<u64>`, and which becomes `VaultState::withdraw` returning `Result<()>` with `VaultError::InsufficientFunds` in module 4.\n\nThree lessons from now the `None` arm gets a name. That is the whole arc: `Option` first because it is the smaller idea, `Result` second because it carries a reason, and `unwrap()` never, because it discards both.\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "explain",
+        "_type": "openEnded",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": null,
+        "prompt": "Explain to someone who writes JavaScript, in your own words and without re-reading the lessons, why `fn credit(v: &mut VaultLike, amount: u64)` cannot be called while any other reference to that vault exists — and name one bug the rule prevents that a JavaScript developer would otherwise have to catch in review. Then finish this sentence: \"A lifetime annotation does not change how long anything lives; it tells the compiler ___.\" Writing it out badly is worth more than reading it again — this is not graded, awards no XP, and gates nothing.",
+        "maxWords": 150,
+        "amount": null,
+        "network": null,
+        "idl": null
+      }
+    ]
+  },
+  {
+    "_id": "lesson-rpd-structs-traits-and-derives",
+    "title": "Structs, Traits, and What `#[derive]` Really Does",
+    "slug": "structs-traits-and-derives",
+    "blocks": [
+      {
+        "key": "intro",
+        "_type": "prose",
+        "produces": null,
+        "consumes": null,
+        "src": "# Structs, Traits, and What `#[derive]` Really Does\n\n> **Version stamp — checked 2026-07-26.** `anchor-lang 1.1.2` (latest on crates.io, published 2026-06-26) · `borsh 1.8.0` (what the build server's lockfile resolves) · `cargo-build-sbf` with platform-tools v1.54 (rustc 1.89) · edition 2021. Every number in the byte table below was read out of `anchor-derive-space 1.1.2`'s source on that date, and every compiler message quoted was produced by compiling the code in this lesson.\n\nIn lesson 8 you wrote `discriminator(data: &[u8]) -> Option<&[u8]>` — a borrowed view over the first eight bytes of an account. It worked, and you still do not know who put those eight bytes there or what decides they are eight.\n\nThis lesson is that answer. It is also the first file in this course that Course 3 will actually deploy.\n\n## The struct is the layout\n\n```rust\n#[account]\n#[derive(InitSpace)]\npub struct VaultState {\n    pub owner: Pubkey,\n    pub balance: u64,\n    pub bump: u8,\n}\n```\n\nIn JavaScript a `class Vault { owner; balance; bump }` says nothing about memory. Field order is irrelevant, adding a field costs nothing, and there is no such thing as \"how many bytes is a Vault.\"\n\nOn Solana that question has one answer and you have to know it before the account exists, because you pay rent for the bytes and you allocate them once. So a Rust struct is not a bag of names. It is a **layout**: this many bytes, in this order.\n\nBorsh — the serialization format Anchor uses — encodes each field back to back, little-endian, with no padding and no field names on the wire. The sizes, straight out of `anchor-derive-space 1.1.2`:\n\n| Rust type | Bytes |\n| --- | --- |\n| `bool`, `u8`, `i8` | 1 |\n| `u16`, `i16` | 2 |\n| `u32`, `i32`, `f32` | 4 |\n| `u64`, `i64`, `f64` | 8 |\n| `u128`, `i128` | 16 |\n| `Pubkey` | 32 |\n| `[T; N]` | `N` × size of `T` |\n| `Option<T>` | 1 (present/absent tag) + size of `T` |\n| `String` | 4 (length prefix) + `max_len` |\n| `Vec<T>` | 4 (length prefix) + size of `T` × `max_len` |\n\nSo `VaultState` is `32 + 8 + 1 = 41` bytes of data. The account it lives in is **49** bytes, because eight more go in front. Those are lesson 8's eight bytes.\n\nTwo traps in that table, both of which produce wrong-sized accounts in real programs:\n\n- **The length prefix is 4 bytes, not 1, and not zero.** A `String` capped at 16 characters costs `4 + 16 = 20`, not 16. Forgetting the prefix is the classic under-allocation.\n- **`Option<T>` costs the tag even when it is `None`.** Borsh writes a fixed layout; there is no \"absent field\" on the wire.\n\n## A trait is a promise about a type. `impl` is where you keep it\n\nA trait is a named set of function signatures. A type that has those functions \"implements\" the trait.\n\nIf you know TypeScript interfaces, the shape is familiar and one detail is not: **a Rust trait implementation lives outside the type.**\n\n```ts\n// TypeScript: the promise is declared inside the type\nclass Vault implements Serializable {\n  serialize() { /* ... */ }\n}\n```\n\n```rust\n// Rust: the struct is one block, each promise is another\npub struct VaultState { /* fields only */ }\n\nimpl Default for VaultState { /* one promise */ }\nimpl Serializable for VaultState { /* another */ }\n```\n\nThat separation is not cosmetic. It means you can implement a trait for a type long after it was defined, in a different block, and — as long as either the trait or the type is yours — in a different crate entirely. It also means an `impl` block is just *some code that sits next to your struct*.\n\nHold on to that sentence, because it is the whole explanation of `#[derive]`.\n\nTwo kinds of `impl` show up in the exercise, and they are different things:\n\n```rust\nimpl VaultState {              // inherent impl: methods that are just VaultState's own\n    pub fn new(/* ... */) -> Self { /* ... */ }\n}\n\nimpl Default for VaultState {  // trait impl: keeping a promise the language defined\n    fn default() -> Self { /* ... */ }\n}\n```\n\n`VaultState::new` exists because you wrote it and nothing else in the language knows about it. `VaultState::default()` exists because `Default` is a standard trait, which is why generic code — including a lot of Anchor — can call it on any type that implements it without knowing your type at all.\n\n## What `#[derive]` really does\n\n`#[derive(Default)]` is a **macro**. At compile time it reads your struct's fields and writes out an `impl Default for VaultState` block, then hands that block to the compiler along with your file. That is the entire mechanism.\n\nThere is no runtime reflection here. Nothing inspects your struct while the program runs. JavaScript decorators and `Object.keys()` have no equivalent in the compiled binary — by the time your program is bytes on-chain, the macro has already run, the field names are gone, and only the generated code remains.\n\nWhich means the honest way to stop `#[derive]` being magic is to write, once, by hand, the impl it would have generated. That is what the exercise does with `Default`. Afterwards, derive it — you will not learn anything the second time.\n\n## What `#[account]` hands you\n\n`#[account]` is the big one. On `VaultState` it generates:\n\n| What it generates | Why you care |\n| --- | --- |\n| `#[derive(AnchorSerialize, AnchorDeserialize, Clone)]` on your struct | borsh encode/decode, plus `Clone` |\n| `impl AccountSerialize` | `try_serialize` — writes the discriminator, then the fields |\n| `impl AccountDeserialize` | `try_deserialize` — **checks** the discriminator, then reads the fields |\n| `impl Discriminator` | `const DISCRIMINATOR: &'static [u8]` |\n| `impl Owner` | `fn owner() -> Pubkey { crate::ID }` |\n\nThe discriminator is the first eight bytes of `sha256(\"account:VaultState\")`. For this struct that is `[228, 196, 82, 165, 98, 210, 235, 152]`, and you can assert on it at compile time because it is a `const`. Rename the struct and every byte changes.\n\nIts job is type safety across a trust boundary. An account is a bag of bytes; nothing about the bytes says what they are. So `try_deserialize` reads the first eight, compares them against `VaultState::DISCRIMINATOR`, and if they disagree it returns `Err(AccountDiscriminatorMismatch)` **without attempting to decode the rest**. Hand a program somebody else's account and you get a named error, not a garbage `VaultState` with a plausible-looking balance.\n\nOne currency note: in Anchor 1.x `DISCRIMINATOR` is a `&'static [u8]`. Older tutorials treat it as `[u8; 8]` and index or destructure it as an array. That does not compile against 1.1.2.\n\n### `declare_id!` is not decoration\n\nLook at the `Owner` impl again: it returns `crate::ID`. `declare_id!` is what defines `ID`. Delete the `declare_id!` line and the compiler says:\n\n```\nerror[E0425]: cannot find value `ID` in the crate root\n --> src/lib.rs:3:1\n  |\n3 | #[account]\n  | ^^^^^^^^^^ not found in the crate root\n```\n\nRead that carefully, because the arrow points at `#[account]` and the problem is somewhere else entirely. `#[account]` is fine. The program id is missing. This is the single most confusing error in the lesson and it is worth meeting it here, deliberately, rather than in module 4 when you have forty lines of your own code to suspect.\n\nThe id in the starter — `Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS` — is a placeholder. Course 3 replaces it with the id of the program you actually deploy.\n\n## `#[derive(InitSpace)]` and the off-by-eight\n\n`InitSpace` generates `impl Space for VaultState { const INIT_SPACE: usize = 32 + 8 + 1; }` — the arithmetic from the table above, done by the macro, at compile time. `INIT_SPACE` is a `const`, so you can assert on it and the assertion is checked while the file compiles.\n\n**`INIT_SPACE` does not include the discriminator.** It is 41, not 49. Anchor's allocation looks like this:\n\n```rust\nspace = 8 + VaultState::INIT_SPACE\n```\n\nThat `8 +` is on you every single time, and forgetting it is the most common allocation bug in Anchor programs: the account is eight bytes too small, the write runs off the end, and the failure surfaces at serialization time as something that reads nothing like \"you allocated wrong.\"\n\n`InitSpace` also refuses to guess about variable-length fields. Add a `String` with no cap and the build stops:\n\n```\nerror: Expected max_len attribute.\n```\n\nWhich is the correct behaviour — a `String` has no size until you name one, and an account has to have a size.\n\n## What is deliberately not in this file\n\nThere is no `#[program]` and no `#[derive(Accounts)]`. That is not an omission you should fix.\n\nThis course produces `vault_core.rs`: the data model and the arithmetic, compiling on its own. Course 3 is what wraps instruction handlers and account-validation structs around it. Keeping them apart is the reason your file is readable, and it is the reason you can be confident the struct is right before anything is deployed.\n\n## The exercise\n\nThe starter is complete and correct. Build it first, unchanged, and read it.\n\nThen do one experiment, in this order:\n\n1. Add `pub created_at: i64,` to `VaultState`.\n2. Build. The `INIT_SPACE` assertion fails, and the failure names the new number — 41 became 49, and the account went from 49 bytes to 57. The struct *is* the layout, and you just watched the layout move.\n3. Undo it (Reset Code is the fast way) and build again so the file is green.\n\nOne honest note on grading: the build server checks that your file **compiles** against the real Anchor 1.1.2 toolchain. It does not run your code, and nothing here is unit-tested. The compile-time assertions in the file are doing the real verification work, which is exactly why they are written as `const _: () = assert!(...)` rather than as tests.\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "exercise",
+        "_type": "code",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": "rust",
+        "buildType": "buildable",
+        "deployable": false,
+        "starter": "// vault_core.rs — the data model, step one.\n//\n// This file is COMPLETE and CORRECT. Build it unchanged first, then read it\n// top to bottom. The experiment at the bottom is the only edit you make.\n\nuse anchor_lang::prelude::*;\n\n// Defines `crate::ID`. `#[account]` below expands to an `Owner` impl that\n// returns `crate::ID`, so deleting this line breaks the struct, not this line.\n// Course 3 replaces this placeholder with your real program id.\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n/// The vault's on-chain state.\n///\n/// `#[account]` generates, at compile time:\n///   - `#[derive(AnchorSerialize, AnchorDeserialize, Clone)]` on the struct\n///   - `impl AccountSerialize`   -> `try_serialize`: writes discriminator, then fields\n///   - `impl AccountDeserialize` -> `try_deserialize`: CHECKS discriminator, then reads\n///   - `impl Discriminator`      -> `const DISCRIMINATOR: &'static [u8]`\n///   - `impl Owner`              -> `fn owner() -> Pubkey { crate::ID }`\n///\n/// `#[derive(InitSpace)]` generates `impl Space`, i.e. `const INIT_SPACE: usize`,\n/// summing the borsh size of every field: 32 + 8 + 1.\n#[account]\n#[derive(InitSpace)]\npub struct VaultState {\n    /// 32 bytes. Who is allowed to withdraw.\n    pub owner: Pubkey,\n    /// 8 bytes, little-endian. Lamports the vault is holding.\n    pub balance: u64,\n    /// 1 byte. The canonical PDA bump, stored so it is never recomputed.\n    pub bump: u8,\n}\n\n// An INHERENT impl. These methods belong to VaultState and to nothing else;\n// no trait, no promise, no generic code can find them.\nimpl VaultState {\n    pub fn new(owner: Pubkey, bump: u8) -> Self {\n        Self {\n            owner,\n            balance: 0,\n            bump,\n        }\n    }\n}\n\n// A TRAIT impl — the one we write by hand so `#[derive]` stops being magic.\n//\n// `#[derive(Default)]` would generate exactly this: every field set to its own\n// type's default. Write it once, read it, then derive it forever after.\nimpl Default for VaultState {\n    fn default() -> Self {\n        Self {\n            owner: Pubkey::default(), // the all-zero pubkey\n            balance: 0,\n            bump: 0,\n        }\n    }\n}\n\n/// The number you hand Anchor's `space =` constraint in Course 3.\n///\n/// `INIT_SPACE` is the FIELDS only. The 8 discriminator bytes are yours to add,\n/// every single time. Getting this wrong under-allocates the account.\npub const VAULT_ACCOUNT_SIZE: usize = 8 + VaultState::INIT_SPACE;\n\n// Compile-time proof, not tests. `INIT_SPACE` and `DISCRIMINATOR` are `const`,\n// so the compiler evaluates these while it compiles the file. Break one and the\n// build fails with the number that is actually true.\nconst _: () = assert!(VaultState::INIT_SPACE == 41);\nconst _: () = assert!(VaultState::DISCRIMINATOR.len() == 8);\nconst _: () = assert!(VAULT_ACCOUNT_SIZE == 49);\n\n/// Uses the derived `AccountSerialize` impl: writes the 8 discriminator bytes,\n/// then borsh-encodes the fields. Returns 49 for any `VaultState`, because a\n/// struct of fixed-width fields has one size.\npub fn encoded_len(state: &VaultState) -> Result<usize> {\n    let mut buf: Vec<u8> = Vec::new();\n    state.try_serialize(&mut buf)?;\n    Ok(buf.len())\n}\n\n// ── THE EXPERIMENT ────────────────────────────────────────────────────────────\n// 1. Add `pub created_at: i64,` to VaultState above.\n// 2. Build. The INIT_SPACE assertion fails and names the new number.\n//    41 became 49; the account went from 49 bytes to 57.\n// 3. Undo it (Reset Code) and build again so the file is green.\n// ─────────────────────────────────────────────────────────────────────────────\n",
+        "solution": "// vault_core.rs — the data model, step one.\n//\n// This file is COMPLETE and CORRECT. Build it unchanged first, then read it\n// top to bottom. The experiment at the bottom is the only edit you make.\n\nuse anchor_lang::prelude::*;\n\n// Defines `crate::ID`. `#[account]` below expands to an `Owner` impl that\n// returns `crate::ID`, so deleting this line breaks the struct, not this line.\n// Course 3 replaces this placeholder with your real program id.\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n/// The vault's on-chain state.\n///\n/// `#[account]` generates, at compile time:\n///   - `#[derive(AnchorSerialize, AnchorDeserialize, Clone)]` on the struct\n///   - `impl AccountSerialize`   -> `try_serialize`: writes discriminator, then fields\n///   - `impl AccountDeserialize` -> `try_deserialize`: CHECKS discriminator, then reads\n///   - `impl Discriminator`      -> `const DISCRIMINATOR: &'static [u8]`\n///   - `impl Owner`              -> `fn owner() -> Pubkey { crate::ID }`\n///\n/// `#[derive(InitSpace)]` generates `impl Space`, i.e. `const INIT_SPACE: usize`,\n/// summing the borsh size of every field: 32 + 8 + 1.\n#[account]\n#[derive(InitSpace)]\npub struct VaultState {\n    /// 32 bytes. Who is allowed to withdraw.\n    pub owner: Pubkey,\n    /// 8 bytes, little-endian. Lamports the vault is holding.\n    pub balance: u64,\n    /// 1 byte. The canonical PDA bump, stored so it is never recomputed.\n    pub bump: u8,\n}\n\n// An INHERENT impl. These methods belong to VaultState and to nothing else;\n// no trait, no promise, no generic code can find them.\nimpl VaultState {\n    pub fn new(owner: Pubkey, bump: u8) -> Self {\n        Self {\n            owner,\n            balance: 0,\n            bump,\n        }\n    }\n}\n\n// A TRAIT impl — the one we write by hand so `#[derive]` stops being magic.\n//\n// `#[derive(Default)]` would generate exactly this: every field set to its own\n// type's default. Write it once, read it, then derive it forever after.\nimpl Default for VaultState {\n    fn default() -> Self {\n        Self {\n            owner: Pubkey::default(), // the all-zero pubkey\n            balance: 0,\n            bump: 0,\n        }\n    }\n}\n\n/// The number you hand Anchor's `space =` constraint in Course 3.\n///\n/// `INIT_SPACE` is the FIELDS only. The 8 discriminator bytes are yours to add,\n/// every single time. Getting this wrong under-allocates the account.\npub const VAULT_ACCOUNT_SIZE: usize = 8 + VaultState::INIT_SPACE;\n\n// Compile-time proof, not tests. `INIT_SPACE` and `DISCRIMINATOR` are `const`,\n// so the compiler evaluates these while it compiles the file. Break one and the\n// build fails with the number that is actually true.\nconst _: () = assert!(VaultState::INIT_SPACE == 41);\nconst _: () = assert!(VaultState::DISCRIMINATOR.len() == 8);\nconst _: () = assert!(VAULT_ACCOUNT_SIZE == 49);\n\n/// Uses the derived `AccountSerialize` impl: writes the 8 discriminator bytes,\n/// then borsh-encodes the fields. Returns 49 for any `VaultState`, because a\n/// struct of fixed-width fields has one size.\npub fn encoded_len(state: &VaultState) -> Result<usize> {\n    let mut buf: Vec<u8> = Vec::new();\n    state.try_serialize(&mut buf)?;\n    Ok(buf.len())\n}\n\n// ── THE EXPERIMENT ────────────────────────────────────────────────────────────\n// 1. Add `pub created_at: i64,` to VaultState above.\n// 2. Build. The INIT_SPACE assertion fails and names the new number.\n//    41 became 49; the account went from 49 bytes to 57.\n// 3. Undo it (Reset Code) and build again so the file is green.\n// ─────────────────────────────────────────────────────────────────────────────\n",
+        "tests": [
+          {
+            "id": "compiles",
+            "description": "The file compiles against anchor-lang 1.1.2 on the build server",
+            "input": "",
+            "expectedOutput": "true"
+          },
+          {
+            "id": "const-assertions-hold",
+            "description": "Every `const _: () = assert!(...)` in the file evaluates true at compile time (INIT_SPACE == 41, DISCRIMINATOR.len() == 8, VAULT_ACCOUNT_SIZE == 49) — a false one is a compile error, not a test failure",
+            "input": "",
+            "expectedOutput": "true"
+          }
+        ],
+        "hints": [
+          "The starter is already correct. Build it unchanged before you touch anything — the first build downloads and compiles the Anchor crates, so it is the slow one.",
+          "For the experiment, add `pub created_at: i64,` as the last field of `VaultState` and build. The failure you want is on the `assert!(VaultState::INIT_SPACE == 41)` line: an `i64` is 8 bytes, so 41 became 49 and the account went from 49 bytes to 57.",
+          "To get back to green, click Reset Code and build again. If instead you tried `pub memo: String`, the build stops with `error: Expected max_len attribute.` — `InitSpace` will not guess a size for a variable-length field, and neither can an account."
+        ],
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "check",
+        "_type": "quiz",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": [
+          {
+            "id": "q1",
+            "prompt": "You add `#[max_len(16)] pub memo: String` as a fourth field of `VaultState` and update the assertion. Predict the new `INIT_SPACE`.",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "61 — the 41 you had, plus a 4-byte length prefix, plus 16 bytes of text",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "57 — the 41 you had plus the 16 characters you capped it at",
+                "correct": false,
+                "feedback": "That drops the length prefix. Borsh writes a `String` as a 4-byte length followed by the UTF-8 bytes, so a 16-character cap costs 20. Under-allocating by exactly 4 bytes is the classic version of this bug."
+              },
+              {
+                "id": "c",
+                "label": "45 — the 41 you had plus the 4-byte length prefix; the text lives in a separate account",
+                "correct": false,
+                "feedback": "There is no separate account. Borsh inlines the bytes, which is why `#[max_len]` is required — the cap you name is space you allocate."
+              },
+              {
+                "id": "d",
+                "label": "It will not compile — `String` cannot appear in an `#[account]` struct",
+                "correct": false,
+                "feedback": "`String` is allowed. What is not allowed is a `String` with no `#[max_len]`, and that failure is `error: Expected max_len attribute.`"
+              }
+            ],
+            "explanation": "`4 + max_len` for `String`, `4 + size_of(T) * max_len` for `Vec<T>`, `1 + size_of(T)` for `Option<T>`. The prefix is always 4 bytes and the `Option` tag is always 1, present or not."
+          },
+          {
+            "id": "q2",
+            "prompt": "You delete the `declare_id!(...)` line and leave everything else alone. Predict what the compiler says.",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "`error[E0425]: cannot find value ID in the crate root`, with the arrow pointing at `#[account]`",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "It compiles. `declare_id!` only matters once the program is deployed, and nothing here is deployed yet.",
+                "correct": false,
+                "feedback": "`#[account]` expands to `impl Owner { fn owner() -> Pubkey { crate::ID } }`. `crate::ID` has to exist at compile time, and `declare_id!` is what defines it."
+              },
+              {
+                "id": "c",
+                "label": "`error: missing declare_id!` — Anchor detects the omission and names it",
+                "correct": false,
+                "feedback": "There is no such check. The macro emits code referencing `crate::ID` and the failure is an ordinary name-resolution error, which is exactly why it reads so badly."
+              },
+              {
+                "id": "d",
+                "label": "A warning only, and `VaultState::owner()` returns the all-zero pubkey at runtime",
+                "correct": false,
+                "feedback": "Missing names are errors, not warnings, and there is no default id to fall back to."
+              }
+            ],
+            "explanation": "The arrow points at `#[account]` and the fault is a missing `declare_id!` two lines above. Recognise this one now; in module 4 you will have forty lines of your own code to suspect first."
+          },
+          {
+            "id": "q3",
+            "prompt": "You delete the hand-written `impl Default for VaultState` block and add `Default` to the derive list instead: `#[derive(InitSpace, Default)]`. Predict.",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "It compiles, and `VaultState::default()` returns the same values — the macro generates the block you just deleted",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "It does not compile — `#[account]` already derives `Default`, so this is a conflicting implementation",
+                "correct": false,
+                "feedback": "`#[account]` derives `AnchorSerialize`, `AnchorDeserialize` and `Clone`. `Default` is not on that list, so there is nothing to conflict with."
+              },
+              {
+                "id": "c",
+                "label": "It does not compile — `Pubkey` has no `Default`, so the derive cannot produce a value for `owner`",
+                "correct": false,
+                "feedback": "`Pubkey` does implement `Default` — it is the all-zero pubkey, which is precisely what the hand-written block wrote out by name."
+              },
+              {
+                "id": "d",
+                "label": "It compiles, but `balance` and `bump` are left uninitialised rather than zeroed",
+                "correct": false,
+                "feedback": "Rust has no uninitialised values in safe code. The derive uses each field type's own `default()`, which for integers is 0."
+              }
+            ],
+            "explanation": "That is the whole point of writing it by hand once. `#[derive]` is a macro that reads your fields and emits an `impl` block — no runtime reflection, nothing you could not have typed yourself."
+          },
+          {
+            "id": "q4",
+            "prompt": "Carried over from lesson 8. Your `discriminator(data: &[u8])` returned the first 8 bytes as `Option<&[u8]>`. Now a caller hands `VaultState::try_deserialize` a 49-byte buffer whose first 8 bytes are a *different* account type's discriminator. Predict.",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "It returns `Err(AccountDiscriminatorMismatch)` and never decodes the remaining 41 bytes",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "It decodes anyway and returns a `VaultState` whose fields are whatever those bytes happen to mean",
+                "correct": false,
+                "feedback": "That is exactly the failure the discriminator exists to prevent. The check happens first, and a mismatch returns before any field is read."
+              },
+              {
+                "id": "c",
+                "label": "It panics, because a discriminator mismatch is unrecoverable",
+                "correct": false,
+                "feedback": "It returns a `Result`. Anchor does not panic on untrusted input — that is the entire reason your code returns `Result` too."
+              },
+              {
+                "id": "d",
+                "label": "It returns `Err(AccountDiscriminatorNotFound)`, since the bytes it wanted were not there",
+                "correct": false,
+                "feedback": "`NotFound` is for a buffer shorter than 8 bytes. Eight bytes that are present and wrong is `Mismatch` — two distinct errors, and telling them apart tells you whether the account is empty or is somebody else's."
+              }
+            ],
+            "explanation": "An account is a bag of bytes and nothing about the bytes says what they are. `try_deserialize` compares the first 8 against `VaultState::DISCRIMINATOR` — `sha256(\"account:VaultState\")[..8]`, which for this struct is `[228, 196, 82, 165, 98, 210, 235, 152]` — and stops on disagreement."
+          }
+        ],
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      }
+    ]
+  },
+  {
+    "_id": "lesson-rpd-types-and-mutability",
+    "title": "Types, Mutability, and Why the Compiler Argues",
+    "slug": "types-and-mutability",
+    "blocks": [
+      {
+        "key": "intro",
+        "_type": "prose",
+        "produces": null,
+        "consumes": null,
+        "src": "# Types, Mutability, and Why the Compiler Argues\n\n> **Version stamp — checked 2026-07-26.** `anchor-lang` **1.1.2** · Rust **edition 2021** · Agave **≥ 3.1.10**. This lesson's exercise is plain Rust and imports nothing — the arguments you are about to have with the compiler are not Anchor's.\n\nThe compiler is about to reject four things a JavaScript engine would have accepted without comment. All four rejections are about the same disagreement: **JavaScript defers, Rust decides.**\n\nJavaScript has one number type and it decides what to do with your value at run time. Rust has twelve integer types and decides what to do with your value while compiling, which means it has to be told. Being told is what the next twenty minutes are.\n\n## The four widths the vault needs\n\nYou are not going to learn twelve integer types. You need four, and each one is fixed by something outside your control.\n\n| Type | What it holds | Why that width |\n| --- | --- | --- |\n| `u64` | lamports — a balance, a deposit amount, a slot number | The runtime stores lamport balances as unsigned 64-bit integers. This is not a choice you get to make. |\n| `u8` | a PDA bump seed | A bump is one byte, `0..=255`, by construction. The search that finds it walks downward from 255. |\n| `i64` | a UNIX timestamp from the cluster clock | The clock's `unix_timestamp` is **signed**. It is `i64`, not `u64`, so a timestamp field in your struct is `i64` too. |\n| `usize` | an index into a byte slice | The type Rust uses to index collections. On the SBF target it is 8 bytes wide, exactly like `u64` — which is precisely why treating the two as interchangeable is a habit that breaks the day something is not 64-bit. |\n\n`u` is unsigned, `i` is signed, the number is the bit width. `u8` holds `0..=255`; `i64` holds roughly ±9.2 × 10¹⁸.\n\n## The one that will bite you outside of Rust\n\n`u64` holds up to 18 446 744 073 709 551 615. JavaScript's `Number` is an IEEE-754 double, so it represents every integer exactly only up to 2⁵³ − 1, which is 9 007 199 254 740 991 — smaller by a factor of 2¹¹, about two thousand times.\n\nBoth of those are large. The gap between them is not theoretical: it is roughly nine million SOL expressed in lamports, and mainnet holds considerably more than that.\n\nThe failure mode is what makes this worth planting now. JavaScript does not throw when you exceed it. It does not warn. It hands you a nearby number and continues:\n\n```js\nNumber(18_446_744_073_709_551_615n); // → 18446744073709552000\n```\n\nNothing in that line is an error, and nothing downstream can tell that a value was quietly rounded. This is why a Solana client reads `u64` fields as `BigInt`, why an amount arriving over the wire as a JSON number is a bug waiting for a large account, and — the reason it is in *this* lesson — why the balance field you will write in module 4 is a `u64` and stays one.\n\nRust's version of the same class of problem does not get to be silent. That is lesson 4.\n\n## `mut` is not a type, and it appears in two places\n\nEverything in Rust is immutable unless declared otherwise, including local variables. That trips people up in a specific way, because `mut` shows up in two syntactically unrelated positions.\n\n**On a binding** — permission to reassign the variable:\n\n```rust\nlet bump: u8 = 255;\nbump -= 1;          // error[E0384]: cannot assign twice to immutable variable\n\nlet mut bump: u8 = 255;\nbump -= 1;          // fine\n```\n\n**On a reference** — permission to write through it:\n\n```rust\nfn credit(vault: &VaultLike, amount: u64) {\n    vault.balance = amount;   // error[E0594]: cannot assign to `vault.balance`,\n}                             // which is behind a `&` reference\n\nfn credit(vault: &mut VaultLike, amount: u64) {\n    vault.balance = amount;   // fine\n}\n```\n\nNote what the second one is *not*: it is not about `pub`. Making a field public controls who can name it, not who can change it. And it is not about the caller — a caller holding a perfectly mutable value still cannot write through a `&T` you asked for. The function's signature is the contract, and `&T` is a promise not to write.\n\n`&T` and `&mut T` are a much bigger subject than \"add the keyword\" — module 2 is entirely about the rules that make them safe. For now, take the compiler's suggestion and move on.\n\n## Rust converts nothing for you\n\nThis is the rule with the widest reach and the shortest statement: **there are no implicit numeric conversions in Rust.** None. Not even the lossless ones.\n\n```rust\nfn bump_as_u64(bump: u8) -> u64 {\n    bump    // error[E0308]: expected `u64`, found `u8`\n}\n```\n\nEvery `u8` value fits in a `u64` with room to spare. C widens it for you, Java widens it for you, JavaScript does not have the distinction. Rust makes you write it:\n\n```rust\nu64::from(bump)\n```\n\n`From` is the conversion that cannot fail, so it needs no error handling and no decision from you. It exists between exactly those pairs of types where the target can hold every value of the source. `u64::from(u8)`, yes. `u64::from(i64)`, no — negative numbers have nowhere to go.\n\nYou will also see `as`:\n\n```rust\nlet small = big as u8;   // compiles for any integer `big`\n```\n\n`as` always compiles and silently discards whatever does not fit. `300 as u8` is 44. `-1i64 as u64` is 18 446 744 073 709 551 615. That is a wrapping cast wearing the costume of a conversion, and it is a genuinely common source of exploitable arithmetic in on-chain programs. **This course does not use `as` on numbers.** When the conversion cannot fail, `u64::from` says so. When it can, module 3 gives you `TryFrom` and a `Result` to handle.\n\nThe other side of the same rule: when two values need to be compared, do not convert one to match the other by reflex. Ask which width is *correct*. A timestamp is `i64` because the clock says so, so the parameter you compare it against should have been `i64` in the first place.\n\n## Indexing wants `usize`\n\n```rust\nfn byte_at(data: &[u8], index: u64) -> u8 {\n    data[index]   // error[E0277]: the type `[u8]` cannot be indexed by `u64`\n}\n```\n\n`&[u8]` is a **slice** — a borrowed window onto a run of bytes, which is how raw account data arrives. Indexing it requires `usize`, the platform's pointer-sized integer, and that requirement is a trait bound rather than a coercion, which is why the error is `E0277` (a trait is not implemented) rather than `E0308` (mismatched types). Two different error codes for what feels like one mistake; recognising which one you have is worth the ten seconds.\n\nOne warning about the exercise, so it does not surprise you later: `data[index]` **panics** if the index is past the end of the slice, and a panic in a program aborts the transaction with no useful error. That is a real defect, it is deliberate, and lesson 8 replaces it with `data.get(index)` — which returns an `Option` instead of exploding. We are not equipped for `Option` yet. Lesson 4 is where that starts.\n\n## The exercise\n\nThe file ships broken. That is the exercise: four numbered subgoals, the first already done and worth reading, the other three each producing errors you now know how to read.\n\nBelow the marked line there is a block you must not edit. It is a set of bindings that pin every function's name and signature, so that deleting a function you cannot fix is a compile error rather than a way through. It checks **shapes only** — nothing in it can tell a correct body from a plausible wrong one. That limit is real, and lesson 4 is where it partially lifts.\n\nNo `unwrap()`, no `expect()`, no `as`.\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "exercise",
+        "_type": "code",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": "rust",
+        "buildType": "buildable",
+        "deployable": false,
+        "starter": "//! Types, mutability, and why the compiler argues.\n//!\n//! Four subgoals, in order. Subgoal 1 is already done — read it first.\n//! Subgoals 2, 3 and 4 do not compile as they ship. That is the exercise.\n//!\n//! Build it now, before changing anything. `rustc` reports every\n//! independent error in one pass, so the first build hands you the whole\n//! to-do list at once.\n//!\n//! Rules: no `unwrap()`, no `expect()`, no `as` casts.\n\n/// A stand-in for the vault account you write in module 4.\n/// The widths are not decoration — each one is fixed by the runtime.\n///\n/// This stand-in is shaped for THIS lesson: it carries a timestamp so that\n/// `i64` has somewhere to live. It is not the final shape. Lesson 5 drops\n/// `last_deposit_at` and adds `owner: Pubkey`, and module 4's real\n/// `VaultState` is `{ owner, balance, bump }`. Only `balance` and `bump`\n/// survive all the way through.\npub struct VaultLike {\n    /// Lamports. The runtime stores balances as u64, so you do too.\n    pub balance: u64,\n    /// A PDA bump seed. One byte, 0..=255.\n    pub bump: u8,\n    /// A UNIX timestamp from the cluster clock. Signed, 64-bit.\n    pub last_deposit_at: i64,\n}\n\n// ── Subgoal 1 of 4 — DONE. Read it. ─────────────────────────────────────\n// One SOL is 1_000_000_000 lamports. Declared as a `u64` constant, with\n// underscores as digit separators — the compiler ignores them and your\n// eyes do not. Note that the type is written out: a `const` never infers.\n\npub const LAMPORTS_PER_SOL: u64 = 1_000_000_000;\n\npub fn one_sol() -> u64 {\n    LAMPORTS_PER_SOL\n}\n\n// ── Subgoal 2 of 4 — `mut`, in both of the places it appears ────────────\n// `set_balance` writes through a reference. `seed_bump` reassigns a local,\n// walking downward from 255 the way Anchor's bump search does. Neither is\n// currently allowed to write to what it has. Fix both.\n//\n// (255 - 1 - 1 cannot underflow, so plain subtraction is safe here.\n//  Lesson 4 is about the case where you cannot know that in advance.)\n\npub fn set_balance(vault: &VaultLike, lamports: u64) {\n    vault.balance = lamports;\n}\n\npub fn seed_bump() -> u8 {\n    let bump: u8 = 255;\n    bump -= 1;\n    bump -= 1;\n    bump\n}\n\n// ── Subgoal 3 of 4 — widths do not convert themselves ───────────────────\n// Rust performs no implicit numeric conversion, not even the lossless\n// widening ones C and Java do silently.\n//\n// In `bump_as_u64`, make the conversion explicit — it cannot fail, so\n// `From` is the right tool and no error handling is needed.\n//\n// In `is_after`, do NOT convert. Ask which width is correct: the cluster\n// clock hands out `i64`, and `VaultLike::last_deposit_at` above is `i64`\n// for that reason. Fix the parameter, not the comparison.\n\npub fn bump_as_u64(bump: u8) -> u64 {\n    bump\n}\n\npub fn is_after(now: i64, last_deposit_at: u64) -> bool {\n    now > last_deposit_at\n}\n\n// ── Subgoal 4 of 4 — you index with `usize` ─────────────────────────────\n// Anchor puts an 8-byte discriminator at the front of every account, so\n// reading one byte out of raw account data is an everyday operation.\n// Slices are indexed by `usize`, and that is a trait bound rather than a\n// conversion — which is why the error code is E0277, not E0308.\n//\n// (`data[index]` panics if `index` is past the end. That is a real defect\n//  and it is deliberate; lesson 8 replaces it with `data.get(index)`.)\n\npub fn byte_at(data: &[u8], index: u64) -> u8 {\n    data[index]\n}\n\n// ════════════════════════════════════════════════════════════════════════\n// DO NOT EDIT BELOW THIS LINE\n//\n// The grader compiles this file and nothing more. These bindings exist so\n// that a missing item, or one with the wrong type, is a compile error\n// instead of a silent pass. They check shapes, not behaviour — nothing\n// here can tell a correct body from a plausible wrong one.\n// ════════════════════════════════════════════════════════════════════════\n\nconst _: u64 = LAMPORTS_PER_SOL;\nconst _: fn() -> u64 = one_sol;\nconst _: fn(&mut VaultLike, u64) = set_balance;\nconst _: fn() -> u8 = seed_bump;\nconst _: fn(u8) -> u64 = bump_as_u64;\nconst _: fn(i64, i64) -> bool = is_after;\nconst _: fn(&[u8], usize) -> u8 = byte_at;\n\n#[allow(dead_code)]\nfn verify_vault_fields(v: &VaultLike) -> (u64, u8, i64) {\n    (v.balance, v.bump, v.last_deposit_at)\n}\n",
+        "solution": "//! Types, mutability, and why the compiler argues — solved.\n\n/// A stand-in for the vault account you write in module 4.\n/// The widths are not decoration — each one is fixed by the runtime.\n///\n/// This stand-in is shaped for THIS lesson: it carries a timestamp so that\n/// `i64` has somewhere to live. It is not the final shape. Lesson 5 drops\n/// `last_deposit_at` and adds `owner: Pubkey`, and module 4's real\n/// `VaultState` is `{ owner, balance, bump }`. Only `balance` and `bump`\n/// survive all the way through.\npub struct VaultLike {\n    /// Lamports. The runtime stores balances as u64, so you do too.\n    pub balance: u64,\n    /// A PDA bump seed. One byte, 0..=255.\n    pub bump: u8,\n    /// A UNIX timestamp from the cluster clock. Signed, 64-bit.\n    pub last_deposit_at: i64,\n}\n\n// ── Subgoal 1 of 4 ──────────────────────────────────────────────────────\n\npub const LAMPORTS_PER_SOL: u64 = 1_000_000_000;\n\npub fn one_sol() -> u64 {\n    LAMPORTS_PER_SOL\n}\n\n// ── Subgoal 2 of 4 — `mut` on the reference, `mut` on the binding ───────\n\npub fn set_balance(vault: &mut VaultLike, lamports: u64) {\n    vault.balance = lamports;\n}\n\npub fn seed_bump() -> u8 {\n    let mut bump: u8 = 255;\n    bump -= 1;\n    bump -= 1;\n    bump\n}\n\n// ── Subgoal 3 of 4 — one explicit conversion, one corrected width ───────\n\npub fn bump_as_u64(bump: u8) -> u64 {\n    u64::from(bump)\n}\n\npub fn is_after(now: i64, last_deposit_at: i64) -> bool {\n    now > last_deposit_at\n}\n\n// ── Subgoal 4 of 4 — slices are indexed by `usize` ──────────────────────\n\npub fn byte_at(data: &[u8], index: usize) -> u8 {\n    data[index]\n}\n\n// ════════════════════════════════════════════════════════════════════════\n// DO NOT EDIT BELOW THIS LINE\n//\n// The grader compiles this file and nothing more. These bindings exist so\n// that a missing item, or one with the wrong type, is a compile error\n// instead of a silent pass. They check shapes, not behaviour — nothing\n// here can tell a correct body from a plausible wrong one.\n// ════════════════════════════════════════════════════════════════════════\n\nconst _: u64 = LAMPORTS_PER_SOL;\nconst _: fn() -> u64 = one_sol;\nconst _: fn(&mut VaultLike, u64) = set_balance;\nconst _: fn() -> u8 = seed_bump;\nconst _: fn(u8) -> u64 = bump_as_u64;\nconst _: fn(i64, i64) -> bool = is_after;\nconst _: fn(&[u8], usize) -> u8 = byte_at;\n\n#[allow(dead_code)]\nfn verify_vault_fields(v: &VaultLike) -> (u64, u8, i64) {\n    (v.balance, v.bump, v.last_deposit_at)\n}\n",
+        "tests": [
+          {
+            "id": "test-1",
+            "description": "Program compiles successfully",
+            "input": "",
+            "expectedOutput": "true"
+          },
+          {
+            "id": "test-2",
+            "description": "Every subgoal's function still exists with the signature the verification harness pins",
+            "input": "",
+            "expectedOutput": "true"
+          },
+          {
+            "id": "test-3",
+            "description": "VaultLike still declares balance: u64, bump: u8 and last_deposit_at: i64",
+            "input": "",
+            "expectedOutput": "true"
+          }
+        ],
+        "hints": [
+          "Build it before you change anything. All four subgoals report at once, and the error codes tell you which kind of mistake each one is — E0384 and E0594 are mutability, E0308 is a width, E0277 is indexing.",
+          "Subgoal 2 needs the word `mut` twice, in two different positions: once on the reference in `set_balance`'s parameter (`&mut VaultLike`), once on the `let` binding in `seed_bump`.",
+          "Subgoals 3 and 4 are three separate fixes and only one of them touches a function body. `bump_as_u64` needs `u64::from(bump)`. `is_after` and `byte_at` each need a parameter type changed — to `i64` and to `usize` — and the harness at the bottom of the file already pins both, so it is also the answer key."
+        ],
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "check",
+        "_type": "quiz",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": [
+          {
+            "id": "q1",
+            "prompt": "Predict the outcome. `pub fn bump_as_u64(bump: u8) -> u64 { bump }` — and note that every possible `u8` value fits in a `u64`.",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "`error[E0308]: mismatched types` — expected `u64`, found `u8`. Rust performs no implicit numeric conversion at all, lossless included.",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "It compiles. Widening conversions are implicit because they cannot lose information.",
+                "correct": false,
+                "feedback": "That is the C and Java rule, and it is the reason this is the most frequently mispredicted line in the lesson. Rust has no implicit numeric conversions in either direction. Write `u64::from(bump)`."
+              },
+              {
+                "id": "c",
+                "label": "It compiles with a warning suggesting an explicit conversion.",
+                "correct": false,
+                "feedback": "A type mismatch is never a warning in Rust — the compiler has no type to proceed with. You do get a `help:` block containing the fix, but it is attached to an error."
+              },
+              {
+                "id": "d",
+                "label": "`error[E0605]: non-primitive cast`, because the conversion needs `as`.",
+                "correct": false,
+                "feedback": "E0605 is for `as` between types where it makes no sense. Both of these are primitive integers, so `as` would compile — it is just the wrong tool, because `as` silently truncates when the widths go the other way."
+              }
+            ],
+            "explanation": null
+          },
+          {
+            "id": "q2",
+            "prompt": "Carried over from lesson 1. Your file has four unrelated mistakes in four different functions. Predict what one build gives you.",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "All four, in one pass, each with its own code and span — `rustc` does not stop at the first.",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "The first one only. Compilation halts at the first error, as a JS runtime halts at the first exception.",
+                "correct": false,
+                "feedback": "That is a runtime's behaviour, not a compiler's. `rustc` finishes the pass and reports every independent error, which is why the first build of a broken file is a complete to-do list."
+              },
+              {
+                "id": "c",
+                "label": "Four errors plus a cascade of dozens more, because each mistake poisons everything after it.",
+                "correct": false,
+                "feedback": "Cascades happen, but from a mistake that leaves the compiler guessing at a *type* other code depends on. Four independent mistakes in four independent functions produce four errors. When you do see a cascade, fix the first error and rebuild."
+              },
+              {
+                "id": "d",
+                "label": "One error, and three warnings, since only the first is fatal.",
+                "correct": false,
+                "feedback": "Severity is a property of the diagnostic, not of its position. Four type errors are four errors."
+              }
+            ],
+            "explanation": null
+          },
+          {
+            "id": "q3",
+            "prompt": "Predict the outcome. `pub fn set_balance(vault: &VaultLike, lamports: u64) { vault.balance = lamports; }` — where `balance` is declared `pub`, and the caller passes a value it owns and can freely modify.",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "`error[E0594]` — cannot assign to `vault.balance`, which is behind a shared reference. The parameter type is a promise not to write, and neither `pub` nor the caller's ownership overrides it.",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "It compiles, because the field is `pub` and therefore writable from anywhere it is visible.",
+                "correct": false,
+                "feedback": "`pub` controls who can *name* the field. Whether it can be written through a particular reference is decided by that reference's type. They are orthogonal, and conflating them is the most common version of this mistake."
+              },
+              {
+                "id": "c",
+                "label": "It compiles, because the caller owns a mutable value and mutability is a property of the value, not the reference.",
+                "correct": false,
+                "feedback": "The signature is the contract. A caller with a perfectly mutable value that hands out `&T` has handed out read-only access, and the function cannot widen it."
+              },
+              {
+                "id": "d",
+                "label": "`error[E0384]: cannot assign twice to immutable variable`.",
+                "correct": false,
+                "feedback": "E0384 is the *binding* case — reassigning a `let` without `mut`. This is the *reference* case, E0594. Both are fixed by the word `mut`, in two different positions, and telling them apart tells you which position."
+              }
+            ],
+            "explanation": null
+          },
+          {
+            "id": "q4",
+            "prompt": "A vault account holds 18_446_744_073_709_551_615 lamports, the largest value a `u64` can hold. Your TypeScript client reads the raw field and does `Number(raw)`. Predict what you get.",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "18446744073709552000 — a nearby number, silently. No error, no warning, and nothing downstream can tell it was rounded.",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "A `RangeError`, because the value exceeds `Number.MAX_SAFE_INTEGER`.",
+                "correct": false,
+                "feedback": "`Number.MAX_SAFE_INTEGER` is documentation, not a guard. Exceeding it is not an error condition in JavaScript — you get the nearest representable double and execution continues. That silence is the whole problem."
+              },
+              {
+                "id": "c",
+                "label": "`Infinity`, since the value overflows the double.",
+                "correct": false,
+                "feedback": "A double reaches about 1.8 × 10³⁰⁸. This value is nowhere near overflowing it. The loss is *precision*, not magnitude, which is exactly why it is hard to notice."
+              },
+              {
+                "id": "d",
+                "label": "The exact value. `Number` is 64-bit, and so is `u64`.",
+                "correct": false,
+                "feedback": "Both are 64 bits, but a double spends 11 of them on an exponent and one on a sign, leaving 53 bits of integer precision. Every integer above 2^53 - 1 is representable only approximately, which is why Solana clients read `u64` fields as `BigInt`."
+              }
+            ],
+            "explanation": null
+          }
+        ],
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      }
+    ]
+  },
+  {
+    "_id": "lesson-rpd-what-you-built",
+    "title": "What You Built",
+    "slug": "what-you-built",
+    "blocks": [
+      {
+        "key": "reread",
+        "_type": "prose",
+        "produces": null,
+        "consumes": null,
+        "src": "# What You Built\n\n> **Version stamp — checked 2026-07-26.** `anchor-lang 1.1.2` · `borsh 1.8.0` (resolved) · edition 2021 · Agave ≥ 3.1.10. No new code in this lesson; every claim below was compiled against that toolchain on that date.\n\nOpen your file from the last exercise. Not the reference below — yours. Read it once, top to bottom, before you read anything else on this page.\n\nHere is the reference version, so you can check yours item for item:\n\n```rust\nuse anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\npub mod vault {\n    use super::*;\n\n    #[account]\n    #[derive(InitSpace)]\n    pub struct VaultState {\n        pub owner: Pubkey,\n        pub balance: u64,\n        pub bump: u8,\n    }\n\n    #[error_code]\n    pub enum VaultError {\n        #[msg(\"Deposit would overflow the vault balance\")]\n        Overflow,\n        #[msg(\"Withdrawal is larger than the vault balance\")]\n        InsufficientFunds,\n        #[msg(\"Amount must be greater than zero\")]\n        ZeroAmount,\n        #[msg(\"Signer is not the vault owner\")]\n        NotOwner,\n    }\n\n    impl VaultState {\n        pub fn deposit(&mut self, amount: u64) -> Result<()> {\n            require!(amount > 0, VaultError::ZeroAmount);\n            self.balance = self\n                .balance\n                .checked_add(amount)\n                .ok_or(VaultError::Overflow)?;\n            Ok(())\n        }\n\n        pub fn withdraw(&mut self, amount: u64) -> Result<()> {\n            require!(amount > 0, VaultError::ZeroAmount);\n            self.balance = self\n                .balance\n                .checked_sub(amount)\n                .ok_or(VaultError::InsufficientFunds)?;\n            Ok(())\n        }\n    }\n}\n\npub use vault::{VaultError, VaultState};\n```\n\nForty-odd lines. Thirteen lessons. Every line came from somewhere specific, and being able to say where is the difference between having finished a course and being able to write the next file without one.\n\n## Line by line\n\n| Line                                        | What it actually is                                                                                                                                                                                                    | Where you got it                                    |\n| ------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |\n| `use anchor_lang::prelude::*;`              | One glob import supplies `Pubkey`, `Result`, `require!`, `msg!`. Anchor re-exports the Solana crates, which is why you never named a `solana-*` dependency.                                                              | L1 · Your First Rust Build                          |\n| `declare_id!(\"Fg6Pa…\")`                     | Not decoration. `#[account]` expands to an `impl Owner` whose body reads `crate::ID`. Delete the macro and the error appears at your struct: `cannot find value ID in the crate root`.                                   | L1, and paid for at L10                             |\n| `pub mod vault { use super::*; }`            | A module is a namespace, not a file. `use super::*` is what makes the crate root's imports visible inside the module body.                                                                                              | L13 · Build the Vault Core                          |\n| `#[account]`                                | A macro that writes trait impls you would otherwise hand-write: `AnchorSerialize`, `AnchorDeserialize`, `Discriminator`, `Owner`. The discriminator is the 8 bytes your Course 1 decoder sliced off before reading `owner`. | L10 · Structs, Traits, and What `#[derive]` Really Does |\n| `#[derive(InitSpace)]`                      | Generates the associated const `VaultState::INIT_SPACE`. Here it is **41**: 32 + 8 + 1. Course 3 spends it as `space = 8 + VaultState::INIT_SPACE`.                                                                      | L10                                                 |\n| `pub owner: Pubkey`                         | 32 bytes. The same 32 bytes you read with `getAddressDecoder()` in Course 1, now on the writing side.                                                                                                                    | L2 · C1 L2                                          |\n| `pub balance: u64`                          | Lamports stop being exact in a JavaScript `Number` above 2⁵³. This is the type for which that is not a question.                                                                                                        | L2 · Types, Mutability, and Why the Compiler Argues |\n| `pub bump: u8`                              | One byte, and a *stored* bump rather than a recomputed one. It is the value the derivation in Course 1 found by counting down from 255 until the result fell off the curve.                                               | L2 · C1 L3                                          |\n| `#[error_code]`                             | Turns a plain enum into program errors: attaches the `#[msg]` strings and generates the conversion into `anchor_lang::error::Error`, offsetting the codes by `ERROR_CODE_OFFSET` = 6000. Exactly one of these per program. | L11 · Enums, `Option`, and `Result`                 |\n| the four variants                           | On the wire: `Overflow` = 6000, `InsufficientFunds` = 6001, `ZeroAmount` = 6002, `NotOwner` = 6003. Custom errors start at 6000 so they cannot collide with Anchor's own.                                                | L11                                                 |\n| `impl VaultState`                           | A method is just a function whose first parameter is a form of `self`.                                                                                                                                                  | L10                                                 |\n| `&mut self`                                 | One mutable borrow, and no shared borrows alongside it — the same shape as one writable account at a time. `self` by value would consume the account.                                                                    | L6 · Borrowing, L5 · Moves                          |\n| `-> Result<()>`                             | Anchor's alias for `Result<(), anchor_lang::error::Error>`. The reason the function can fail without panicking.                                                                                                          | L12 · Error Plumbing with `?`                       |\n| `require!(amount > 0, …)`                    | Guard first, mutate second. It expands to an early `return Err(...)`, which is why it reads like an assertion and behaves like a branch.                                                                                | L12                                                 |\n| `.checked_add(…)` / `.checked_sub(…)`        | Returns `Option<u64>` — `None` instead of wrapping or panicking. This is lesson 4's `add_lamports` / `sub_lamports`, moved onto a method.                                                                                | L4 · Checked Lamport Math                           |\n| `.ok_or(VaultError::Overflow)?`             | `ok_or` converts `Option` into `Result`; `?` either unwraps the `Ok` or returns early, applying the `From` conversion `#[error_code]` generated. Two lessons meeting inside one expression.                              | L11 (`Option`) + L12 (`?`)                          |\n| `Ok(())`                                    | A tail expression: no `return`, no semicolon. Add the semicolon and the body evaluates to `()`, and the error is `mismatched types`.                                                                                     | L3 · Functions, Expressions, and the Missing `return` |\n| `pub use vault::{VaultError, VaultState};`   | A re-export. Without it the items exist and nothing outside the module can name them.                                                                                                                                   | L13                                                 |\n\n## Three absences, which are also the point\n\n**`.clone()` appears zero times.** Lesson 5 was explicit that cloning is a legitimate escape hatch and not a moral failing. It is also true that in a `&mut self` method you never reach for it, because you never moved anything: you borrowed the account, wrote through the borrow, and gave it back.\n\n**`unwrap()` appears zero times.** Every tutorial you will read on the way to your first real program uses it. In a program, a panic is an aborted instruction with no code and no message — the caller learns that something failed and nothing else. Your file returns 6001 with the string \"Withdrawal is larger than the vault balance\". That difference is the whole of lessons 4, 11 and 12.\n\n**Lifetimes appear zero times**, and lesson 8 was not wasted on you. `VaultState` owns all three of its fields — a `Pubkey`, a `u64` and a `u8` are all owned values — so nothing in the struct borrows and there is no lifetime to name. What lesson 8 bought you is the *next* file: `Account<'info, VaultState>` in Course 3 is a borrowed view over these bytes, and `'info` is the same annotation you wrote by hand on `discriminator(data: &'a [u8]) -> Option<&'a [u8]>`. Graduates who skip lifetimes read `Account<'info, Vault>` as noise for years. Question 6 below is that payoff, asked before you meet it.\n\n## Copy the file out. Now.\n\nSay this plainly, because the platform does not: **no block type on this platform persists your source file.** The build server graded a submission; it did not keep a copy you can come back to. Select everything in the editor, save it locally as `vault_core.rs`, and put it somewhere you will find it next week.\n\nIf you lose it, Course 3's first lesson ships a known-good reference copy — the file above — so nothing dead-ends. But it will be *a* vault core, not yours, and the first thing Course 3 does is replace that placeholder in `declare_id!` with the program id of your own deployment.\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "handoff",
+        "_type": "prose",
+        "produces": null,
+        "consumes": null,
+        "src": "## What Course 3 adds, and why none of it is in your file\n\nYour file has no `#[program]` module and no `#[derive(Accounts)]` struct. Read it cold and it looks like a program someone abandoned two-thirds of the way in. It is not. It is the two-thirds you can check by reading, deliberately separated from the third you cannot.\n\n| Course 3 adds                                                                                                                                       | Why it is not here                                                                                                                                                       |\n| --------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |\n| `#[program] pub mod vault_program { … }` with `deposit` and `withdraw` **instruction handlers**                                                       | A handler is an entrypoint. An entrypoint needs a deployed program id and a real account list, and its body is two lines: validate, then call the method you already wrote. |\n| `#[derive(Accounts)] pub struct Deposit<'info>` with `#[account(mut, seeds = [b\"vault\", owner.key().as_ref()], bump = vault.bump)]`                     | Constraints validate *accounts*. Nothing in your file is an account — that is precisely why it can be reasoned about without a runtime. This is also where your stored `bump` field gets spent, and where `NotOwner` is finally returned. |\n| `init` with `space = 8 + VaultState::INIT_SPACE` — 49 bytes, and the rent-exemption number that follows from it                                        | Space and rent are properties of an account, not of a struct. Your struct only had to know its own size, and `#[derive(InitSpace)]` is how it knows.                       |\n| A CPI to the System Program to move the actual lamports: `CpiContext::new(System::id(), Transfer { … })`                                              | Your `balance` field is bookkeeping. The lamports move in a separate call, and keeping the two apart is what lets a test check the arithmetic without a runtime.            |\n| **LiteSVM tests that call `withdraw` and assert on the number that comes back**                                                                       | This is the one that matters. It is what catches a `checked_add` you meant to be `checked_sub` — the exact failure the build server cannot see, and the reason Course 2's grading stops at \"it compiles\". |\n| A deploy, after which `declare_id!` stops being a placeholder and your program has an address on devnet                                              | You had nothing to deploy. You had something to be correct.                                                                                                               |\n\nOne currency note for when you start reading Course 3's material against the rest of the internet: **`CpiContext::new(System::id(), …)` is the current shape.** Every CPI tutorial written before Anchor 1.0 passes an account info instead — `CpiContext::new(ctx.accounts.system_program.to_account_info(), …)` — and it does not compile against the toolchain you have been building on. It is the single most common stale snippet in Solana material, and now you know why your copy-paste failed.\n\n### Why the split is the right shape, not a teaching convenience\n\nLook at what your file does *not* depend on: no accounts, no signers, no clock, no CPI, no runtime of any kind. That is what makes it the part a reviewer reads first and the part a test can exercise in microseconds. Real audit findings cluster at the seam between the two halves — a handler that forgets to compare `vault.owner` to the signer, a constraint that validates the wrong account — and you cannot see a seam until the two sides of it are separate things.\n\nIt also means Course 3 is enterable on its own. Anyone arriving without this course gets the reference `vault_core.rs`, because a course whose first lesson requires a file you do not have is a dead end, not a prerequisite. You are arriving with your own version, which is a better place to start from.\n\n### What you can say you can do\n\nNot \"you can now write Solana programs\" — you cannot yet, and one more course is why. What you can say is narrower and true: **you can model on-chain state in Rust, make its invariants unbreakable by construction, and return named errors instead of panicking.** That is the part of program development that no framework does for you.\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "recall",
+        "_type": "quiz",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": [
+          {
+            "id": "q1",
+            "prompt": "You change `pub bump: u8` to `pub bump: u64` and rebuild against the verification harness. Predict what happens.",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "Red — `assert!(VaultState::INIT_SPACE == 41)` fails, because `InitSpace` now computes 48.",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "Green — `INIT_SPACE` is computed when the account is created, so a compile-time assertion cannot read it.",
+                "correct": false,
+                "feedback": "It is an associated const generated by the derive and evaluated at compile time. That is exactly why a `const _: () = assert!(...)` can check it at all."
+              },
+              {
+                "id": "c",
+                "label": "Red — `u64` is not a legal field type for an Anchor account.",
+                "correct": false,
+                "feedback": "It plainly is: `balance` is one. The problem is the size, not the legality."
+              },
+              {
+                "id": "d",
+                "label": "Green, but Course 3's `space = 8 + VaultState::INIT_SPACE` would then under-allocate the account.",
+                "correct": false,
+                "feedback": "`space` is computed from the same const, so it grows with the struct. Under-allocation is what happens when you hardcode the number instead of deriving it."
+              }
+            ],
+            "explanation": null
+          },
+          {
+            "id": "q2",
+            "prompt": "In `self.balance = self.balance.checked_add(amount).ok_or(VaultError::Overflow)?;` — `?` converts the error by calling `From::from`. Name the generated impl it lands on, and what reaches the caller.",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "`impl From<VaultError> for anchor_lang::error::Error`. `ok_or` builds `Result<u64, VaultError>`; `?` either yields the `Ok` value or returns early through that conversion. The caller sees code 6000.",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "`impl From<VaultError> for u32`, the other impl `#[error_code]` generates. `?` converts to the numeric code and the runtime wraps it into an error on the way out.",
+                "correct": false,
+                "feedback": "That impl exists — it is `variant as u32 + 6000` — but `?` is typed, not numeric: it needs `From<VaultError>` for the function's declared error type, which is `anchor_lang::error::Error`. The `u32` conversion is what the `Error` impl calls *inside* itself."
+              },
+              {
+                "id": "c",
+                "label": "No `From` impl is involved: `error!` already produced an `Error`, so `?` has nothing to convert.",
+                "correct": false,
+                "feedback": "There is no `error!` in this line. `ok_or(VaultError::Overflow)` hands `?` a bare `VaultError`, which is exactly why the conversion has to exist — delete that impl and this line stops compiling with `E0277`."
+              },
+              {
+                "id": "d",
+                "label": "`impl From<VaultError> for Error`, and `?` is shorthand for `.unwrap()` on the `Result` it produces.",
+                "correct": false,
+                "feedback": "Right impl, wrong operator. `.unwrap()` panics; `?` returns. That is the entire difference, and it is why one of them is banned in program code and the other is the idiom."
+              }
+            ],
+            "explanation": "`#[error_code]` generates four things: `name()`, `From<VaultError> for u32`, `From<VaultError> for Error`, and `Display` from your `#[msg]` strings. `?` uses the third. `error!(…)` uses the first, second and fourth — it builds an `AnchorError` out of them and never touches the `Error` impl at all. Two paths to the same wire format, and lesson 11 made you tell them apart."
+          },
+          {
+            "id": "q3",
+            "prompt": "You change `pub fn withdraw(&mut self, amount: u64)` to `pub fn withdraw(mut self, amount: u64)`. Both let you write to the fields. Predict what the build reports.",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "Red at the harness — it binds `withdraw` to `fn(&mut VaultState, u64) -> Result<()>` and the method is now `fn(VaultState, u64) -> Result<()>`.",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "Green — `mut self` and `&mut self` differ only in style; both mutate in place.",
+                "correct": false,
+                "feedback": "Both let you write, but they differ in whether the caller still owns the value afterwards. `mut self` consumes it. That difference is visible in the type, and the harness reads types."
+              },
+              {
+                "id": "c",
+                "label": "Red — a method cannot take `self` by value in an `impl` block.",
+                "correct": false,
+                "feedback": "It can; `fn into_parts(self)` is an everyday Rust idiom. Taking `self` by value is wrong *here*, not illegal."
+              },
+              {
+                "id": "d",
+                "label": "Green, and Course 3 would still work, because Anchor hands instruction handlers their accounts by value.",
+                "correct": false,
+                "feedback": "Anchor hands you `Account<'info, VaultState>` and you reach the data through a mutable deref. A method that consumes `self` cannot be called through a borrow."
+              }
+            ],
+            "explanation": null
+          },
+          {
+            "id": "q4",
+            "prompt": "Carried over from Course 1. `VaultState::INIT_SPACE` is 41 and Course 3 allocates `8 + 41 = 49` bytes. What are the 8, and where have you met them before?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "The Anchor discriminator — 8 bytes derived from the account type's name, written at offset 0 and skipped before decoding. They are the first 8 bytes your Course 1 decoder sliced off before reading `owner`.",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "The account's `lamports` balance, stored inline ahead of the struct data.",
+                "correct": false,
+                "feedback": "Lamports live in the account's metadata, not in `data`. Your Course 1 decoder read them from a different field of the RPC response and never out of the byte array."
+              },
+              {
+                "id": "c",
+                "label": "An 8-byte length prefix for the struct, the way borsh prefixes a `Vec` or a `String`.",
+                "correct": false,
+                "feedback": "Borsh's length prefix is 4 bytes and only appears on variable-length types. A fixed-size struct carries no prefix at all."
+              },
+              {
+                "id": "d",
+                "label": "Reserved space for the bump plus padding to an 8-byte boundary.",
+                "correct": false,
+                "feedback": "The bump is one byte and it is inside the 41. Anchor adds no padding — the layout is the fields, back to back, after the discriminator."
+              }
+            ],
+            "explanation": null
+          },
+          {
+            "id": "q5",
+            "prompt": "Also from Course 1. Your struct stores `bump: u8`. Which of these are true?",
+            "multiSelect": true,
+            "options": [
+              {
+                "id": "a",
+                "label": "The bump is the value the derivation counted down from 255 until the resulting address fell off the ed25519 curve.",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "Storing it lets a later instruction validate the PDA without re-running that search, which costs compute every time.",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "c",
+                "label": "It is 254 in practice, so a program can safely hardcode it.",
+                "correct": false,
+                "feedback": "A mock SDK in this platform's own history hardcoded 254, and that was the bug. The canonical bump is whatever the search found for those particular seeds — usually 255, often not."
+              },
+              {
+                "id": "d",
+                "label": "Putting the bump in a different seed position gives the same address, since the seeds are all hashed together anyway.",
+                "correct": false,
+                "feedback": "Hashing is order-sensitive. Reorder the seeds and you get a different address — you proved that to yourself in Course 1 by deriving it both ways."
+              }
+            ],
+            "explanation": null
+          },
+          {
+            "id": "q6",
+            "prompt": "Lifetimes appear zero times in your file, and lesson 8 was still worth it. Course 3 hands a handler `vault: Account<'info, VaultState>`. A handler stashes `&vault.owner` into a struct it returns, so the reference outlives the instruction. Predict what the compiler does, and what `'info` had to do with it.",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "It is rejected, and the annotation is the mechanism: `'info` names how long the borrowed account data is valid, and a struct outliving it cannot hold a reference into it. The error names the value that dies too early, not the reference.",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "It compiles. `'info` is `'static` in practice, because the account data is owned by the runtime rather than by your handler.",
+                "correct": false,
+                "feedback": "`'info` is the lifetime of the borrow the runtime lent you for the length of one instruction, which is the opposite of `'static`. The compiler never invents `'static` — lesson 8's question 1 was exactly this mistake."
+              },
+              {
+                "id": "c",
+                "label": "It compiles with a warning, and the reference is null after the instruction ends.",
+                "correct": false,
+                "feedback": "Rust has no mechanism that nulls out a reference when its target dies. That is precisely why the check has to happen at compile time and why there is nothing to warn about — it is an error or it is fine."
+              },
+              {
+                "id": "d",
+                "label": "It is rejected, and the fix is to add a second lifetime parameter so the struct and the account each get their own.",
+                "correct": false,
+                "feedback": "A second name adds no lifetime. Annotations describe relationships the compiler then checks; nothing you write in a signature keeps a value alive one instruction longer. The fix is to copy the `Pubkey` out — it is `Copy`, 32 bytes, and owning it removes the question."
+              }
+            ],
+            "explanation": "Same rule as `discriminator(data: &'a [u8]) -> Option<&'a [u8]>` in lesson 8, one layer up. `VaultState` owns all three of its fields, so your file needed no annotation at all — but every account type you touch in Course 3 is a borrowed view, and `'info` is the name of the borrow."
+          },
+          {
+            "id": "q7",
+            "prompt": "Course 3 adds a fifth variant to your `VaultError` — `VaultFrozen` — and appends it after `NotOwner`. Your file's two methods and Course 3's own code both `match` on the enum in places. Which of these are true?",
+            "multiSelect": true,
+            "options": [
+              {
+                "id": "a",
+                "label": "Every exhaustive `match` over `VaultError` that lacks a `_ =>` arm now fails to compile with `E0004`, naming the file, line and uncovered variant.",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "Any `match` that does have a `_ =>` arm compiles unchanged and silently routes `VaultFrozen` to whatever the wildcard says.",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "c",
+                "label": "Appending rather than inserting is what keeps `Overflow` at 6000 and `NotOwner` at 6003, so no deployed client's hardcoded code changes meaning.",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "d",
+                "label": "The new variant gets 6004 only if you annotate it; without an explicit code Anchor assigns the next free number across all enums in the crate.",
+                "correct": false,
+                "feedback": "The code is the declaration index plus `ERROR_CODE_OFFSET`, computed per enum. Nothing is annotated and nothing is coordinated across enums — which is the entire reason a second `#[error_code]` enum collides at 6000."
+              }
+            ],
+            "explanation": "Exhaustiveness is the one property in this course the compiler genuinely verifies, and a wildcard is what you trade it away for. Two match sites with no wildcard gave you a to-do list in lesson 11; the same thing happens across a course boundary here."
+          }
+        ],
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "reflect",
+        "_type": "openEnded",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": null,
+        "prompt": "Your `withdraw` compiles whether it calls `checked_sub` or `checked_add`, and the build server cannot tell the difference. In 120 words or fewer: name the specific mechanism that would catch the swap, and say at what point in Course 3 it runs. Then name one other thing in your file that no compiler can check. This is not graded and awards no XP — it is here because writing the answer is what makes you keep it.",
+        "maxWords": 120,
+        "amount": null,
+        "network": null,
+        "idl": null
+      }
+    ]
+  },
+  {
+    "_id": "lesson-rpd-your-first-rust-build",
+    "title": "Your First Rust Build",
+    "slug": "your-first-rust-build",
+    "blocks": [
+      {
+        "key": "intro",
+        "_type": "prose",
+        "produces": null,
+        "consumes": null,
+        "src": "# Your First Rust Build\n\n> **Version stamp — checked 2026-07-26.** `anchor-lang` **1.1.2** (published 2026-06-26; the newest release on crates.io on the date this lesson was written) · Rust **edition 2021** · Agave **≥ 3.1.10** · borsh **1.5.7 declared / 1.8.0 resolved** · the build server compiles with `cargo-build-sbf --tools-version v1.54`, whose pinned `rustc` reports 1.89.0-dev. That last number is not printed anywhere in your build log, which is why it is written here — this stamp is the only place you can read it. Lesson 4 depends on `overflow-checks = true`, which is set in the build crate's `[profile.release]`.\n\nIn Course 1 your inspector took an address, pulled the account back off devnet, and turned the bytes into fields with names — `owner`, `balance`, `bump`.\n\nThose bytes had no names on the chain. They had names because somebody wrote a `struct` in Rust, and the memory layout of that struct **is** the account. Your decoder was reading a shape it had been told about. This course is about being the person who defines the shape.\n\nFourteen lessons from now you will hold a file called `vault_core.rs`: a `VaultState`, a `deposit`, a `withdraw` that cannot silently wrap a `u64`, and an error enum with four named variants. Course 3 wraps a program around it and puts it on devnet.\n\nRight now, none of that. Right now: a green build.\n\n## Nothing to install\n\nYou are not going to install Rust. There is no `rustup`, no `cargo`, no toolchain to keep in sync with a tutorial, and no `.so` file to upload from your machine.\n\nThe editor below sends one file to a build server that already has the Solana platform toolchain on it. It compiles the file for the SBF target — the bytecode format Solana validators execute — and sends back the result. That is the whole loop, and it is the loop for every code exercise in this course and the next.\n\nThis first exercise exists to prove that loop works for you, on your network, before any Rust matters. Nothing in the file needs changing.\n\n## The file, line by line\n\n```rust\nuse anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\npub fn vault_core_banner() -> Result<()> {\n    msg!(\"vault core reporting in from {}\", ID);\n    Ok(())\n}\n```\n\nFour things, and each one is worth a sentence.\n\n**`use anchor_lang::prelude::*;`** — Rust has no ambient globals. Nothing is in scope that you did not bring into scope. A `prelude` module is a crate's answer to that: a curated bundle of the names you will want in almost every file, imported in one line. `Result`, `msg!` and `declare_id!` all arrive through this import.\n\n**`declare_id!(\"Fg6Pa…\")`** — the address the program lives at, as a compile-time constant named `ID`. It is a placeholder here; Course 3 replaces it with the id of the program you actually deploy. It is not optional decoration. Anchor's account macros generate code that refers to `crate::ID`, so a file that uses them and forgets this line does not compile — and the error appears at the macro, not here, which is why it is worth recognising now.\n\n**`pub fn vault_core_banner() -> Result<()>`** — `fn` declares a function. `pub` makes it visible outside this module. `-> Result<()>` is the return type: *either* success carrying nothing, *or* an error. Anchor's `Result<()>` is a program's standard return shape, and one of the reasons Solana programs written in Rust do not throw. There is no `throw`. Failure is a value you return.\n\n**`Ok(())`** — the success value. `()` is the unit type, Rust's \"no meaningful value\" — the closest thing it has to `void`, except that it is a real type with exactly one value, so it can be put inside `Ok(...)` like anything else. Note the absence of a semicolon: this is the function's **tail expression**, and it is what the function evaluates to. Lesson 3 is about how much that missing semicolon matters.\n\nThe keen-eyed will notice this file has no `#[program]` and no `#[derive(Accounts)]` — no instruction handlers, no account lists. That is deliberate, and it stays that way for all fourteen lessons. Those two macros are Course 3's job. Your file is the logic they wrap around.\n\n## Press Build\n\nExpect **30 to 90 seconds** the first time. The server is compiling Anchor and its dependency tree, not just your eight lines. Subsequent builds reuse that work and come back in seconds.\n\nThis one will pass, which means you get one line back and no log. Read the next section anyway — it is about what arrives when a build *fails*, which is the interesting case and the one you will be in for the next thirteen lessons. For the rest of this course the compiler is not an obstacle between you and a passing grade. It is the fastest reviewer you will ever have, and it works for free.\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "exercise",
+        "_type": "code",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": "rust",
+        "buildType": "buildable",
+        "deployable": false,
+        "starter": "use anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n/// Nothing in this file needs changing. Press Build. This one passes, so you\n/// get one success line and no log — the prose below explains why, and what you\n/// get instead when a build fails.\npub fn vault_core_banner() -> Result<()> {\n    msg!(\"vault core reporting in from {}\", ID);\n    Ok(())\n}\n",
+        "solution": "use anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n/// Nothing in this file needs changing. Press Build, then read the log.\npub fn vault_core_banner() -> Result<()> {\n    msg!(\"vault core reporting in from {}\", ID);\n    Ok(())\n}\n",
+        "tests": [
+          {
+            "id": "test-1",
+            "description": "Program compiles successfully",
+            "input": "",
+            "expectedOutput": "true"
+          }
+        ],
+        "hints": [
+          "You don't need to change anything — just click the Build button",
+          "If the build times out, try again. First builds take longer because dependencies are being downloaded.",
+          "If you see errors, make sure you haven't accidentally modified the starter code. Click Reset Code to restore it."
+        ],
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "output",
+        "_type": "prose",
+        "produces": null,
+        "consumes": null,
+        "src": "## Reading the compiler output\n\nThe build log is not noise you scroll past on the way to a green tick. It is the primary interface of this course. Learn its shapes now and the next thirteen lessons get much shorter.\n\n### 0. When you get a log at all\n\nStart here, because it is the platform fact that shapes everything else.\n\n**A failing build hands you the compiler's whole output. A passing build hands you one line and a build id.** That is what the runner does: on success it reports `Program compiled successfully!` and discards the log; on failure it prints the captured output verbatim.\n\nSo the log is the *failure* interface. Everything below is what you read when something is wrong — which is most of the time, and is when you need it.\n\nTwo consequences worth carrying:\n\n- **Warnings on a green build are invisible to you here.** They exist, `rustc` emitted them, and this platform throws them away along with the rest of a successful log. When a lesson says a mistake \"only produces a warning\", read that as *nothing on this platform will tell you*. That is a real limitation and it is worth knowing rather than working around.\n- **A green build is one bit of information.** Not zero — it means the file compiled against the real Anchor 1.x toolchain, which is more than a linter can say. But one bit.\n\n### 1. `Compiling` and `Finished`\n\nThis is what the log looks like on the server, whether or not any of it reaches you:\n\n```\n   Compiling academy-program v0.1.0 (/build/program)\n    Finished `release` profile [optimized] target(s) in 3.41s\n```\n\n`Finished` is the whole verdict. If the build reaches it, the file compiled and the lesson is graded as passed. Grading in this course is a **compilation check** — passing means it compiled. It does not mean it is correct. Lesson 4 is the first place where the file itself carries assertions the compiler must also satisfy, and that is a deliberate design, not a default.\n\nA failing build reaches the `Compiling` line and never the `Finished` one. It ends with a summary instead:\n\n```\n   Compiling academy-program v0.1.0 (/build/program)\nerror[E0308]: mismatched types\n   …\nerror: could not compile `academy-program` (lib) due to 1 previous error\n```\n\nSo the pair you will actually read is `Compiling` at the top and `could not compile` at the bottom, with the errors in between. `Finished` is a line you infer from the success message rather than one you see.\n\nOne `Compiling` line per crate, so a failing build with a cold dependency cache prints the whole tree with each crate's resolved version — `Compiling borsh v1.8.0`, `Compiling anchor-lang v1.1.2`. That is the only place the pinned stack states itself out loud, and if you ever see it, note `borsh v1.8.0` against a manifest that asked for `1.5.7`. Lesson 13 explains why those differ.\n\nWhat the log does **not** contain, at any point: a line naming the Rust compiler version or the target triple. `cargo-build-sbf` prints neither. The pinned `rustc` arrives with the platform-tools version the build server passes on the command line, which is not visible in the output — and that is why every lesson in this course carries a **version stamp** at the top of its prose. The stamp is the source of truth. There is no banner to check it against.\n\n### 2. Version pinning as a ceiling\n\nThe compiler the build server runs is older than the newest Rust release, and that is normal — platform-tools lags upstream by design, because validators run what the toolchain produced.\n\nTreat it as a **ceiling**. Any language feature stabilised after it does not exist for you, no matter what the Rust release notes say, and no matter that the copy of Rust on your laptop is newer. This is the single most common way a snippet from a blog post fails here for a reason that has nothing to do with the snippet: it was written against a newer compiler.\n\nThe same goes at the library level. This course pins `anchor-lang` **1.1.2**. Anchor 1.0 was a breaking major release, so a large amount of the Anchor material on the internet — most of it, by volume — was written against 0.2x or 0.3x. One example you will meet immediately if you go looking:\n\n- `CpiContext::new(ctx.accounts.system_program.to_account_info(), …)` was the 0.x shape. On 1.x it is `CpiContext::new(System::id(), …)`, and the 0.x form does not compile here.\n\nA second rule you will read as though it were a compile error, and it is not: **one `#[error_code]` enum per program.** Two enums compile perfectly well on 1.1.2 — we checked by compiling them. The problem is that both start numbering at 6000, so each one's first variant is the same code on the wire and no client can tell them apart. It is a convention enforced by consequences, not by `rustc`. Lesson 11 makes you predict that one.\n\nWhen you copy Rust from anywhere, check what it was written against first. \"Rust from 2024\" is not a version.\n\n### 3. `warning:` — free advice you will only see next to an error\n\n```\nwarning: unused variable: `amount`\n --> src/lib.rs:12:16\n   |\n12 | pub fn credit(amount: u64) {\n   |               ^^^^^^ help: if this is intentional, prefix it with an underscore: `_amount`\n```\n\nWarnings do not stop the build and do not fail the lesson. When they are shown, read them: Rust's warnings are unusually good at pointing straight at real mistakes — `unused variable`, `unreachable pattern`, `value assigned is never read` are each, in practice, a bug about a third of the time.\n\n\"When they are shown\" is doing real work in that sentence. Per section 0, you see them only in a failing build's log, alongside the error that failed it. A file that compiles green with a `warning: unreachable pattern` in it looks, from where you are sitting, identical to a file with no warning at all.\n\nYou will also see warnings you cannot fix and should ignore, including a run of `unexpected cfg condition value` lines coming out of Anchor's own macros. Those are Anchor's, not yours.\n\n### 4. `error[E….]` — the one you came for\n\n```\nerror[E0308]: mismatched types\n  --> src/lib.rs:14:5\n   |\n13 | pub fn bump_as_u64(bump: u8) -> u64 {\n   |                                 --- expected `u64` because of return type\n14 |     bump\n   |     ^^^^ expected `u64`, found `u8`\n   |\nhelp: you can convert a `u8` to a `u64`\n   |\n14 |     bump.into()\n   |         +++++++\n```\n\nFive things are in there, and you want all five:\n\n1. **The code**, `E0308`. Every Rust error has a stable numbered code. It is searchable and it is documented — the Rust error index has a page per code, with a minimal example. Search the code, not the message.\n2. **`--> src/lib.rs:14:5`** — file, line, column. Your submission is always compiled as `src/lib.rs`, so the line number is the line number in the editor.\n3. **The excerpt with the carets**, pointing at the exact expression, plus a second span showing *why* — here, the return type on line 13 is what created the expectation.\n4. **`expected … found …`**, in that order. Expected is what the surrounding code demands; found is what you gave it. Getting the direction the right way round is most of the skill.\n5. **`help:`**, which frequently contains the literal fix. Not always right — lesson 9 has a case where the suggestion compiles and is wrong for on-chain code. Usually right.\n\nYou will also see `For more information about this error, try 'rustc --explain E0308'` and, at the very bottom, the `error: could not compile` summary from section 1. Neither adds anything the block above did not already tell you.\n\n### Read the first error only\n\nA file with one real mistake often produces a wall of errors, because everything downstream of the mistake is now being checked against a type the compiler had to guess at. Fix the **first** error, rebuild, and watch most of the rest disappear. Working bottom-up through a cascade is the most reliable way to waste an afternoon.\n\nAnd unlike a JavaScript runtime, which stops dead at the first exception, `rustc` keeps going and reports every independent error in one pass. Four unrelated mistakes give you four errors in a single build. That is a feature: it means one round-trip per batch of work, not one per bug.\n\n### What to carry into lesson 2\n\n- You get the log when the build **fails**. A pass is one line, and warnings go in the bin with it.\n- The pinned compiler is a ceiling on what you can use, and the lesson's version stamp is where you read it.\n- `Finished` = compiled = passed. Compiled does not mean correct.\n- Errors have numbered codes worth searching. Fix the first one, then rebuild.\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "check",
+        "_type": "quiz",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": [
+          {
+            "id": "q1",
+            "prompt": "You submit a file that compiles but makes `rustc` emit `warning: unreachable pattern`. There is no `error[E….]` anywhere. Predict both the grade and what appears in the output panel.",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "Passes, and you see `Program compiled successfully!` and a build id — nothing else. The warning was emitted and this platform discards the log on a successful build, so it never reaches you.",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "Passes, and the warning is shown above the success message so you can act on it.",
+                "correct": false,
+                "feedback": "It is not. On success the runner reports the success line and the build id and throws the captured output away; only a failing build hands you the log. Worth knowing before a later lesson tells you \"that mistake only warns\"."
+              },
+              {
+                "id": "c",
+                "label": "Fails. Warnings are collected and counted against the submission.",
+                "correct": false,
+                "feedback": "Nothing counts warnings. `rustc` treats them as advice and exits successfully, the build server reports success, and the lesson passes. They do not gate anything — the problem is the opposite one, that you cannot see them."
+              },
+              {
+                "id": "d",
+                "label": "Passes, but with partial credit, since the code is not clean.",
+                "correct": false,
+                "feedback": "There is no partial credit on a buildable lesson. The signal the grader has is one bit: did it compile."
+              }
+            ],
+            "explanation": null
+          },
+          {
+            "id": "q2",
+            "prompt": "You delete the `declare_id!` line from this lesson's file and leave everything else alone. Predict the outcome.",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "A compile error, because `ID` no longer exists — `declare_id!` is what generates it, and `msg!` on the next line uses it.",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "It compiles. `declare_id!` only matters at deploy time, when the program needs an address.",
+                "correct": false,
+                "feedback": "It is a compile-time constant, not deploy metadata. Anything that refers to `ID` — your `msg!` here, and every account macro you write from lesson 10 onward — needs it to exist during compilation."
+              },
+              {
+                "id": "c",
+                "label": "It compiles with a warning, and `ID` falls back to the all-zeros default program id.",
+                "correct": false,
+                "feedback": "There is no default and no fallback. The name is either generated or absent."
+              },
+              {
+                "id": "d",
+                "label": "It compiles, and the failure surfaces later as a runtime error on devnet.",
+                "correct": false,
+                "feedback": "A missing name is caught during compilation. Rust does not resolve names at run time, so there is no \"later\" for this class of mistake."
+              }
+            ],
+            "explanation": null
+          },
+          {
+            "id": "q3",
+            "prompt": "This lesson's version stamp names the pinned `rustc`, and it is older than the newest Rust release. Nothing in the build log states that version. You paste in a snippet that relies on a language feature stabilised after it. Predict what happens.",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "It fails to compile here, even though it is valid Rust on a newer toolchain. The server's compiler is the ceiling, and it is not the latest release.",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "It compiles. The build server fetches whatever toolchain the submitted code requires.",
+                "correct": false,
+                "feedback": "The toolchain is pinned by the `--tools-version` the build server passes to `cargo-build-sbf`. Nothing about your submission can change it — which is the point of pinning it, and why a version stamp sits at the top of every lesson instead."
+              },
+              {
+                "id": "c",
+                "label": "It compiles, because the feature is only rejected on the stable channel and SBF builds use nightly.",
+                "correct": false,
+                "feedback": "Whether a feature exists is a property of the compiler version, not a channel you can talk your way onto from inside a submission."
+              },
+              {
+                "id": "d",
+                "label": "It compiles with a `future_incompatible` warning naming the required version.",
+                "correct": false,
+                "feedback": "A compiler cannot warn about syntax it does not understand. You get an error — often an unhelpful parse error rather than a polite \"this needs a newer Rust\"."
+              }
+            ],
+            "explanation": null
           }
         ],
         "prompt": null,

--- a/apps/web/src/lib/content/__tests__/fixtures/golden/quests-raw.json
+++ b/apps/web/src/lib/content/__tests__/fixtures/golden/quests-raw.json
@@ -24,22 +24,34 @@
     "lesson-pda-advanced-challenge",
     "lesson-pda-challenge",
     "lesson-program-challenge",
+    "lesson-rpd-borrowing-shared-vs-mutable",
+    "lesson-rpd-build-the-vault-core",
+    "lesson-rpd-checked-lamport-math",
+    "lesson-rpd-enums-option-result",
+    "lesson-rpd-error-plumbing",
+    "lesson-rpd-fix-the-borrow-checker",
+    "lesson-rpd-functions-and-control-flow",
+    "lesson-rpd-lifetimes-and-slices",
+    "lesson-rpd-moves-copy-and-clone",
+    "lesson-rpd-structs-traits-and-derives",
+    "lesson-rpd-types-and-mutability",
+    "lesson-rpd-your-first-rust-build",
     "lesson-rust-basics-challenge",
     "lesson-rust-program-challenge",
+    "lesson-sap-budgeted-agent-with-a-hard-cap",
+    "lesson-sap-meter-an-endpoint-with-x402",
+    "lesson-sap-pay-the-402-programmatically",
+    "lesson-sap-payment-rails-decision-map",
+    "lesson-sap-recurring-delegation-paid-tier",
+    "lesson-sap-subscription-authority-and-allowance",
+    "lesson-sap-token-or-token-2022",
     "lesson-serialization-challenge",
     "lesson-sign-message-challenge",
     "lesson-staking-challenge",
     "lesson-testing-challenge",
     "lesson-token-math-challenge",
     "lesson-transfer-challenge",
-    "lesson-vault-challenge",
-    "lesson-sap-payment-rails-decision-map",
-    "lesson-sap-token-or-token-2022",
-    "lesson-sap-subscription-authority-and-allowance",
-    "lesson-sap-recurring-delegation-paid-tier",
-    "lesson-sap-meter-an-endpoint-with-x402",
-    "lesson-sap-pay-the-402-programmatically",
-    "lesson-sap-budgeted-agent-with-a-hard-cap"
+    "lesson-vault-challenge"
   ],
   "moduleLessonMap": [
     {
@@ -130,6 +142,40 @@
         "lesson-oracle-design",
         "lesson-vault-challenge",
         "lesson-liquidation-challenge"
+      ]
+    },
+    {
+      "_id": "course-rust-for-program-devs:rpd-rust-that-compiles",
+      "lessonIds": [
+        "lesson-rpd-your-first-rust-build",
+        "lesson-rpd-types-and-mutability",
+        "lesson-rpd-functions-and-control-flow",
+        "lesson-rpd-checked-lamport-math"
+      ]
+    },
+    {
+      "_id": "course-rust-for-program-devs:rpd-ownership-borrowing-lifetimes",
+      "lessonIds": [
+        "lesson-rpd-moves-copy-and-clone",
+        "lesson-rpd-borrowing-shared-vs-mutable",
+        "lesson-rpd-fix-the-borrow-checker",
+        "lesson-rpd-lifetimes-and-slices",
+        "lesson-rpd-ownership-checkpoint"
+      ]
+    },
+    {
+      "_id": "course-rust-for-program-devs:rpd-modeling-state",
+      "lessonIds": [
+        "lesson-rpd-structs-traits-and-derives",
+        "lesson-rpd-enums-option-result",
+        "lesson-rpd-error-plumbing"
+      ]
+    },
+    {
+      "_id": "course-rust-for-program-devs:rpd-the-vault-core",
+      "lessonIds": [
+        "lesson-rpd-build-the-vault-core",
+        "lesson-rpd-what-you-built"
       ]
     },
     {

--- a/apps/web/src/lib/content/__tests__/project.golden.test.ts
+++ b/apps/web/src/lib/content/__tests__/project.golden.test.ts
@@ -57,6 +57,14 @@ vi.mock("server-only", () => ({}));
 //    and reviewExempt skill markers (#8). lessons.json and course-by-slug.json
 //    were regenerated from the bundle through the real projectors for the
 //    affected docs; all other fixtures untouched.
+//  - launch-content wave 3 (bump to courses-academy @1b74e4a6): C2
+//    `rust-for-program-devs` lands (courses-academy #12: +1 course, +14
+//    lessons, new challenge/module entries in quests-raw's derived fields —
+//    staged, not on-chain, so it stays hidden until owner course-creation),
+//    tutorNotes on the two CARRY deploy-path challenges (#14), C5 + template
+//    quiz explanations (#15). courses.json, lessons.json and quests-raw.json's
+//    challengeLessonIds/moduleLessonMap regenerated from the bundle through
+//    the real projectors (order preserved, raw quest docs untouched).
 const deps = { lessonsById };
 
 function bundleCourse(id: string): CourseDoc {


### PR DESCRIPTION
## What

Pins `courses-academy@1b74e4a6`, picking up four merged content PRs:

| Content PR | What lands | Learner-visible? |
|---|---|---|
| solanabr/courses-academy#12 | **C2 `rust-for-program-devs`** (14 lessons) | No — staged; not on-chain, hidden until owner course-creation (PB-7 instructor wallets) |
| solanabr/courses-academy#14 | tutorNotes on the two CARRY deploy-path challenges (`your-first-build`, `deploy-program-devnet`) | **Yes** — live Zero-to-Deployed path, feeds the AI tutor's [TUTOR_NOTES] |
| solanabr/courses-academy#15 | 15 C5 quiz explanations + `_template` quiz-bar fix | C5 hidden until on-chain window; template is authoring-time |
| solanabr/courses-academy#13 | CATALOG.md PB-7 currency amendment | Docs-only, not compiled |

Bundle counts: courses 7→**8**, lessons 85→**99**, paths/quests/achievements unchanged.

## Golden fixtures

C2's arrival triggers the coverage tests, so `courses.json`, `lessons.json`, and `quests-raw.json`'s two derived fields (`challengeLessonIds`, `moduleLessonMap`) were regenerated from the bundle through the real projectors — existing doc order preserved, raw quest docs untouched, delta documented in the test header (waves 1–3 now enumerated). All other fixtures untouched.

## Verification (local, at this head)

- compile-content: `courses:8, learningPaths:8, lessons:99, quests:5, achievements:10`
- Spot-checks: both CARRY lessons carry tutorNotes; 140 explanation fields across the bundle (was 97); C2 present with 14 lessons
- `pnpm typecheck` exit 0; `pnpm --filter web test` **179 files / 1571 tests, exit 0**
- Visibility safety: C2 (like C5) has no on-chain course → `isSynced` false → hidden from catalog; nothing learner-facing changes except the two tutorNotes lessons

## Routing

`area:content`, SAFE lane.