### PR TITLE
feat(lessons): render parsons paired-distractor markers + one exhaustive deny-reason map (#703)

### DIFF
--- a/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/blocks/__tests__/parsons-block.test.tsx
+++ b/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/blocks/__tests__/parsons-block.test.tsx
@@ -270,4 +270,38 @@ describe("ParsonsBlock — paired distractors (F13)", () => {
       screen.getByText("Not quite — some lines are out of order.")
     ).toBeInTheDocument();
   });
+
+  it("two look-alikes for ONE real line all share a single group (no orphan)", () => {
+    // Two traps for `ret` is legitimate authoring; grouping by target keeps the
+    // target + both distractors in one group of three, never orphaning the first
+    // distractor into its own marker.
+    const twoTraps: ParsonsBlockData = {
+      _type: "parsons",
+      key: "p-two-traps",
+      prompt: "Arrange the function.",
+      lines: [
+        { id: "sig", content: "function add(a, b) {" },
+        { id: "ret", content: "  return a + b;" },
+        { id: "close", content: "}" },
+        {
+          id: "bad1",
+          content: "  return a - b;",
+          distractor: true,
+          pairedWith: "ret",
+        },
+        {
+          id: "bad2",
+          content: "  return b - a;",
+          distractor: true,
+          pairedWith: "ret",
+        },
+      ],
+      correctOrder: ["sig", "ret", "close"],
+    };
+    renderWithIntl(<ParsonsBlock block={twoTraps} ctx={makeCtx()} />);
+    // ret + bad1 + bad2 = three members, one shared marker, and only one group
+    // exists (no stray "Look-alike 2").
+    expect(screen.getAllByText("Look-alike 1")).toHaveLength(3);
+    expect(screen.queryByText("Look-alike 2")).not.toBeInTheDocument();
+  });
 });

--- a/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/blocks/__tests__/parsons-block.test.tsx
+++ b/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/blocks/__tests__/parsons-block.test.tsx
@@ -187,6 +187,15 @@ describe("ParsonsBlock — arrange interaction", () => {
     ).toBeDisabled();
   });
 
+  it("no paired distractor → no look-alike marker and no pairing hint", () => {
+    // The default block's distractor carries no `pairedWith`, so nothing pairs.
+    renderWithIntl(<ParsonsBlock block={parsonsBlock} ctx={makeCtx()} />);
+    expect(screen.queryByText(/Look-alike/)).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/Some lines are look-alikes/)
+    ).not.toBeInTheDocument();
+  });
+
   it("renders the verdict inside an aria-live region", () => {
     const { container } = renderWithIntl(
       <ParsonsBlock block={parsonsBlock} ctx={makeCtx()} />
@@ -197,6 +206,68 @@ describe("ParsonsBlock — arrange interaction", () => {
     fireEvent.click(screen.getByRole("button", { name: "Check order" }));
     expect(
       within(live as HTMLElement).getByText("Correct!")
+    ).toBeInTheDocument();
+  });
+});
+
+/** A block whose distractor `bad` is paired with the real line `ret` (F13). */
+const pairedBlock: ParsonsBlockData = {
+  _type: "parsons",
+  key: "p-paired",
+  prompt: "Arrange the function.",
+  lines: [
+    { id: "sig", content: "function add(a, b) {" },
+    { id: "ret", content: "  return a + b;" },
+    { id: "close", content: "}" },
+    {
+      id: "bad",
+      content: "  return a - b;",
+      distractor: true,
+      pairedWith: "ret",
+    },
+  ],
+  correctOrder: ["sig", "ret", "close"],
+  explanation: "Signature first, then the body, then the closing brace.",
+};
+
+describe("ParsonsBlock — paired distractors (F13)", () => {
+  it("marks BOTH the distractor and its pairedWith target with one shared tag", () => {
+    renderWithIntl(<ParsonsBlock block={pairedBlock} ctx={makeCtx()} />);
+    // `bad` and its target `ret` share group 1 → two identical markers, and the
+    // marker never says which of the pair is the trap.
+    expect(screen.getAllByText("Look-alike 1")).toHaveLength(2);
+    expect(screen.getByText(/Some lines are look-alikes/)).toBeInTheDocument();
+  });
+
+  it("the marker is not colour-only — it carries the group text for AT", () => {
+    renderWithIntl(<ParsonsBlock block={pairedBlock} ctx={makeCtx()} />);
+    // The visible, machine-readable text is the accessible signal (colour is
+    // decorative), so a colour-blind or AT user still perceives the pairing.
+    expect(screen.getAllByText("Look-alike 1")[0]).toBeVisible();
+  });
+
+  it("the pairing marker follows a line as it moves into the solution", () => {
+    renderWithIntl(<ParsonsBlock block={pairedBlock} ctx={makeCtx()} />);
+    fireEvent.click(
+      screen.getByRole("button", { name: /Add line: return a \+ b/ })
+    );
+    // `ret` now sits in the solution and `bad` still in the bank — both keep the
+    // shared marker, so the count is unchanged.
+    expect(screen.getAllByText("Look-alike 1")).toHaveLength(2);
+  });
+
+  it("including a look-alike distractor grades wrong client-side", () => {
+    renderWithIntl(<ParsonsBlock block={pairedBlock} ctx={makeCtx()} />);
+    fireEvent.click(
+      screen.getByRole("button", { name: /Add line: function add/ })
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: /Add line: return a - b/ })
+    );
+    fireEvent.click(screen.getByRole("button", { name: /Add line: \}/ }));
+    fireEvent.click(screen.getByRole("button", { name: "Check order" }));
+    expect(
+      screen.getByText("Not quite — some lines are out of order.")
     ).toBeInTheDocument();
   });
 });

--- a/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/blocks/parsons-block.tsx
+++ b/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/blocks/parsons-block.tsx
@@ -9,6 +9,7 @@ import {
   X,
   CheckCircle,
   XCircle,
+  LinkSimple,
 } from "@phosphor-icons/react";
 import type { ParsonsBlockData, ParsonsLineData } from "@superteam-lms/types";
 import { Button } from "@/components/ui/button";
@@ -50,6 +51,42 @@ function sequenceEqual(a: readonly string[], b: readonly string[]): boolean {
 }
 
 /**
+ * Group every distractor with the solution line it mimics (`pairedWith`, F13),
+ * so both members of a pair carry the SAME group number. Symmetric on purpose:
+ * the marker says "one of this pair belongs, one doesn't" WITHOUT revealing
+ * which is the trap — that discrimination is the exercise. Presentational only;
+ * grading (sequence equality) is untouched. Lines with no pairing are absent
+ * from the map and render unmarked.
+ */
+function pairGroups(lines: ParsonsLineData[]): Map<string, number> {
+  const byId = new Map(lines.map((l) => [l.id, l]));
+  const groups = new Map<string, number>();
+  let next = 1;
+  for (const line of lines) {
+    if (line.distractor && line.pairedWith && byId.has(line.pairedWith)) {
+      groups.set(line.id, next);
+      groups.set(line.pairedWith, next);
+      next += 1;
+    }
+  }
+  return groups;
+}
+
+/**
+ * Marks a line as one half of a paired look-alike. NOT colour-only — carries an
+ * icon and the group text — so it survives for AT and colour-blind learners, per
+ * the keyboard/AT contract the renderer was built to.
+ */
+function PairMarker({ label }: { label: string }) {
+  return (
+    <span className="inline-flex w-fit items-center gap-1 rounded-full border-[1.5px] border-accent bg-accent-bg px-2 py-0.5 font-display text-[10px] font-bold uppercase tracking-wide text-accent-dark">
+      <LinkSimple size={11} weight="bold" aria-hidden="true" />
+      {label}
+    </span>
+  );
+}
+
+/**
  * Arrange-the-lines (Parsons) renderer. The learner moves lines from an
  * available "bank" into an ordered "solution" list and reorders them; the proof
  * is the solution's line ids in order (`{ order }`), reported via `ctx.setProof`.
@@ -72,6 +109,9 @@ export function ParsonsBlock({ block, ctx }: BlockRenderProps) {
     () => seededOrder(b.key, b.lines).map((l) => l.id),
     [b.key, b.lines]
   );
+  // id → paired look-alike group (distractor + its `pairedWith` target). Shared,
+  // symmetric marker; empty when the block authored no paired distractors.
+  const pairGroup = useMemo(() => pairGroups(b.lines), [b.lines]);
 
   // The solution is the ordered list of placed line ids; the bank is every line
   // not currently placed, kept in the stable seeded order.
@@ -126,9 +166,21 @@ export function ParsonsBlock({ block, ctx }: BlockRenderProps) {
 
   const lineText = (id: string): string => byId.get(id)?.content ?? id;
 
+  // A paired line's marker, or null. Rendered above the line in both the bank
+  // and the solution so the pairing follows the line wherever it sits.
+  const marker = (id: string) => {
+    const group = pairGroup.get(id);
+    return group === undefined ? null : (
+      <PairMarker label={t("parsonsPairLabel", { group })} />
+    );
+  };
+
   return (
     <div className="space-y-4 rounded-[var(--r-lg)] border-[2.5px] border-border bg-card p-5 shadow-card">
       <p className="font-display font-bold text-text">{b.prompt}</p>
+      {pairGroup.size > 0 && (
+        <p className="text-sm text-text-3">{t("parsonsPairHint")}</p>
+      )}
 
       <div className="grid gap-4 md:grid-cols-2">
         {/* Bank */}
@@ -139,9 +191,12 @@ export function ParsonsBlock({ block, ctx }: BlockRenderProps) {
           <ul className="space-y-1.5">
             {bank.map((id) => (
               <li key={id} className="flex items-stretch gap-2">
-                <pre className="flex-1 overflow-x-auto rounded-md border border-border bg-subtle px-2 py-1.5 font-mono text-sm text-text">
-                  {lineText(id)}
-                </pre>
+                <div className="flex flex-1 flex-col gap-1">
+                  {marker(id)}
+                  <pre className="w-full overflow-x-auto rounded-md border border-border bg-subtle px-2 py-1.5 font-mono text-sm text-text">
+                    {lineText(id)}
+                  </pre>
+                </div>
                 <Button
                   variant="secondary"
                   size="sm"
@@ -172,17 +227,20 @@ export function ParsonsBlock({ block, ctx }: BlockRenderProps) {
                 const slotOk = judged ? result!.slotOk[index] : undefined;
                 return (
                   <li key={id} className="flex items-stretch gap-2">
-                    <pre
-                      className={`flex-1 overflow-x-auto rounded-md border px-2 py-1.5 font-mono text-sm text-text ${
-                        slotOk === undefined
-                          ? "border-border bg-subtle"
-                          : slotOk
-                            ? "border-success"
-                            : "border-danger"
-                      }`}
-                    >
-                      {lineText(id)}
-                    </pre>
+                    <div className="flex flex-1 flex-col gap-1">
+                      {marker(id)}
+                      <pre
+                        className={`w-full overflow-x-auto rounded-md border px-2 py-1.5 font-mono text-sm text-text ${
+                          slotOk === undefined
+                            ? "border-border bg-subtle"
+                            : slotOk
+                              ? "border-success"
+                              : "border-danger"
+                        }`}
+                      >
+                        {lineText(id)}
+                      </pre>
+                    </div>
                     <div className="flex flex-col gap-1">
                       <Button
                         variant="secondary"

--- a/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/blocks/parsons-block.tsx
+++ b/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/blocks/parsons-block.tsx
@@ -52,21 +52,31 @@ function sequenceEqual(a: readonly string[], b: readonly string[]): boolean {
 
 /**
  * Group every distractor with the solution line it mimics (`pairedWith`, F13),
- * so both members of a pair carry the SAME group number. Symmetric on purpose:
- * the marker says "one of this pair belongs, one doesn't" WITHOUT revealing
- * which is the trap — that discrimination is the exercise. Presentational only;
- * grading (sequence equality) is untouched. Lines with no pairing are absent
- * from the map and render unmarked.
+ * so every member of a group carries the SAME number. Grouped by TARGET id, not
+ * per distractor: a real line may have more than one look-alike (two traps for
+ * one line is legitimate authoring — the schema allows repeated `pairedWith`),
+ * and all of them plus the target must share one marker. Keying on the distractor
+ * would mint a fresh group per distractor and overwrite the target, orphaning
+ * every look-alike but the last. Symmetric on purpose: the marker says "one of
+ * this group belongs, the rest don't" WITHOUT revealing which is real — that
+ * discrimination is the exercise. Presentational only; grading (sequence
+ * equality) is untouched. Lines with no pairing are absent and render unmarked.
  */
 function pairGroups(lines: ParsonsLineData[]): Map<string, number> {
   const byId = new Map(lines.map((l) => [l.id, l]));
   const groups = new Map<string, number>();
+  const groupOfTarget = new Map<string, number>();
   let next = 1;
   for (const line of lines) {
     if (line.distractor && line.pairedWith && byId.has(line.pairedWith)) {
-      groups.set(line.id, next);
-      groups.set(line.pairedWith, next);
-      next += 1;
+      const target = line.pairedWith;
+      let group = groupOfTarget.get(target);
+      if (group === undefined) {
+        group = next++;
+        groupOfTarget.set(target, group);
+        groups.set(target, group);
+      }
+      groups.set(line.id, group);
     }
   }
   return groups;

--- a/apps/web/src/app/api/lessons/complete/__tests__/deny-reasons.test.ts
+++ b/apps/web/src/app/api/lessons/complete/__tests__/deny-reasons.test.ts
@@ -17,6 +17,7 @@ const {
   getCourseById,
   codeGrader,
   quizGrader,
+  parsonsGrader,
   openAttestation,
   isOnChainProgramLive,
   isRateLimited,
@@ -29,6 +30,7 @@ const {
   getCourseById: vi.fn(),
   codeGrader: vi.fn<() => Promise<GradeResult>>(),
   quizGrader: vi.fn<() => Promise<GradeResult>>(),
+  parsonsGrader: vi.fn<() => Promise<GradeResult>>(),
   openAttestation: vi.fn<() => boolean>(),
   isOnChainProgramLive: vi.fn<() => Promise<boolean>>(),
   isRateLimited: vi.fn<(ns: string) => Promise<boolean>>(),
@@ -60,7 +62,11 @@ vi.mock("@/lib/content/queries", () => ({
 }));
 
 vi.mock("@/lib/grading/graders", () => ({
-  GRADERS: { code: () => codeGrader(), quiz: () => quizGrader() },
+  GRADERS: {
+    code: () => codeGrader(),
+    quiz: () => quizGrader(),
+    parsons: () => parsonsGrader(),
+  },
 }));
 
 vi.mock("@/lib/review/schedule-review", () => ({
@@ -143,6 +149,18 @@ describe("403 reason discriminator (#564)", () => {
 
     expect(res.status).toBe(403);
     expect(((await res.json()) as DenyBody).reason).toBe("challenge_failed");
+  });
+
+  it("failed parsons grade → reason 'parsons_failed'", async () => {
+    getLessonByIdForGrading.mockResolvedValue({
+      blocks: [{ _type: "parsons", key: "p1" }],
+    });
+    parsonsGrader.mockResolvedValue({ ok: false, status: 403 });
+
+    const res = await call({ p1: { order: ["wrong"] } });
+
+    expect(res.status).toBe(403);
+    expect(((await res.json()) as DenyBody).reason).toBe("parsons_failed");
   });
 
   it("mixed lesson where only the QUIZ fails → 'quiz_failed', not 'challenge_failed'", async () => {

--- a/apps/web/src/app/api/lessons/complete/route.ts
+++ b/apps/web/src/app/api/lessons/complete/route.ts
@@ -7,6 +7,7 @@ import { createAdminClient } from "@/lib/supabase/admin";
 import { getCourseById, getLessonByIdForGrading } from "@/lib/content/queries";
 import type { CompletionDenyReason } from "@/lib/lessons/completion-error";
 import { GRADERS, type GradedBlockType } from "@/lib/grading/graders";
+import { DENY_REASONS } from "@/lib/grading/deny-reason";
 import { captureReviewFailure } from "@/lib/review/schedule-review";
 import { openAttestation } from "@/lib/ai/check-seal";
 import { isRateLimited, getClientIp, releaseRateLimit } from "@/lib/rate-limit";
@@ -341,7 +342,7 @@ export async function POST(request: NextRequest) {
             await captureReviewFailure({
               userId: user.id,
               lessonId,
-              reason: type === "quiz" ? "quiz_failed" : "challenge_failed",
+              reason: DENY_REASONS[type as GradedBlockType],
               failedTests:
                 "failedTests" in result ? result.failedTests : undefined,
             }).catch(() => {});
@@ -352,11 +353,7 @@ export async function POST(request: NextRequest) {
             result.status,
             "Block did not pass",
             result.status === 403
-              ? type === "quiz"
-                ? "quiz_failed"
-                : type === "parsons"
-                  ? "parsons_failed"
-                  : "challenge_failed"
+              ? DENY_REASONS[type as GradedBlockType]
               : undefined
           );
         }

--- a/apps/web/src/lib/grading/deny-reason.ts
+++ b/apps/web/src/lib/grading/deny-reason.ts
@@ -1,0 +1,20 @@
+import type { CompletionDenyReason } from "@/lib/lessons/completion-error";
+import type { GradedBlockType } from "./graders";
+
+/**
+ * The single source of truth for a graded block's 403 deny reason, keyed by the
+ * SAME `GradedBlockType` as GRADERS (#703 item 2b). `satisfies Record<…>` makes
+ * a new graded block type a COMPILE error here until its reason is declared —
+ * closing the silent fork this replaces: two independent hand-kept ternaries
+ * each mapped a block type to a reason and had already diverged, one folding a
+ * failed `parsons` into `challenge_failed`. The client maps these strings to
+ * localized copy in `completion-error.ts`.
+ */
+export const DENY_REASONS = {
+  code: "challenge_failed",
+  quiz: "quiz_failed",
+  parsons: "parsons_failed",
+} satisfies Record<GradedBlockType, CompletionDenyReason>;
+
+/** The graded subset of CompletionDenyReason — the reasons a grader can emit. */
+export type GradedDenyReason = (typeof DENY_REASONS)[GradedBlockType];

--- a/apps/web/src/lib/review/schedule-review.ts
+++ b/apps/web/src/lib/review/schedule-review.ts
@@ -1,5 +1,6 @@
 import "server-only";
 import type { ServerTestResult } from "@/lib/challenge/executor";
+import type { GradedDenyReason } from "@/lib/grading/deny-reason";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { logError } from "@/lib/logging";
 import { ERROR_IDS } from "@/constants/errorIds";
@@ -18,7 +19,12 @@ export interface ReviewFailureCapture {
    * lesson, regardless of which block inside the lesson failed.
    */
   lessonId: string;
-  reason: "quiz_failed" | "challenge_failed";
+  /**
+   * Which graded block type missed, from the one exhaustive `DENY_REASONS` map
+   * (#703 item 2b) — so a new graded type can never silently fold into
+   * `challenge_failed` here. Observability only; the box math never reads it.
+   */
+  reason: GradedDenyReason;
   /**
    * The failing test cases, when the grader produced per-test detail (code
    * challenges). Carried for observability / future item enrichment; the box

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -236,6 +236,8 @@
     "parsonsCheck": "Check order",
     "parsonsCorrect": "Correct!",
     "parsonsIncorrect": "Not quite — some lines are out of order.",
+    "parsonsPairLabel": "Look-alike {group}",
+    "parsonsPairHint": "Some lines are look-alikes sharing a tag — only one of each pair belongs in your solution.",
     "reflectionSubmit": "Submit reflection",
     "reflectionSubmitting": "Submitting…",
     "reflectionSubmitted": "Reflection recorded",

--- a/apps/web/src/messages/es.json
+++ b/apps/web/src/messages/es.json
@@ -236,6 +236,8 @@
     "parsonsCheck": "Comprobar orden",
     "parsonsCorrect": "¡Correcto!",
     "parsonsIncorrect": "Todavía no — algunas líneas están fuera de orden.",
+    "parsonsPairLabel": "Parecida {group}",
+    "parsonsPairHint": "Algunas líneas son parecidas y comparten la misma etiqueta — solo una de cada par pertenece a tu solución.",
     "reflectionSubmit": "Enviar reflexión",
     "reflectionSubmitting": "Enviando…",
     "reflectionSubmitted": "Reflexión registrada",

--- a/apps/web/src/messages/pt-BR.json
+++ b/apps/web/src/messages/pt-BR.json
@@ -236,6 +236,8 @@
     "parsonsCheck": "Verificar ordem",
     "parsonsCorrect": "Correto!",
     "parsonsIncorrect": "Ainda não — algumas linhas estão fora de ordem.",
+    "parsonsPairLabel": "Parecida {group}",
+    "parsonsPairHint": "Algumas linhas são parecidas e compartilham a mesma etiqueta — só uma de cada par pertence à sua solução.",
     "reflectionSubmit": "Enviar reflexão",
     "reflectionSubmitting": "Enviando…",
     "reflectionSubmitted": "Reflexão registrada",


### PR DESCRIPTION
Closes #703.

Two follow-ups from gating #701, exactly as the issue prescribed (render the modelled fields — do not rip them out; add the missing test; and, per the item-2 update, collapse the divergent reason ternaries into one exhaustive map). Neither touches grading.

## 1. Render parsons paired-distractor markers (F13) — issue item 1

`distractor` / `pairedWith` were modelled, validated, and documented in `packages/content-schema` but `parsons-block.tsx` read neither — a paired distractor was visually indistinguishable from a real line, so the *discrimination* that is the whole point of a paired distractor never happened.

**Before:** every bank line rendered through identical markup; the pairing was invisible.

**After:** each distractor and its `pairedWith` target share one **`Look-alike N`** marker.
- **Symmetric** — the marker sits on *both* members and never reveals which of the pair is the trap (revealing it would hand the learner the answer).
- **Not colour-only** — an icon + the group text carry the signal, so it survives for AT and colour-blind learners (the renderer was built for keyboard/AT use).
- **Follows the line** — the marker shows in both the bank and the solution.
- **Grading untouched** — sequence equality already scores an included distractor wrong, client and server.
- A short hint appears only when a block authors paired distractors. i18n added for `en` / `pt-BR` / `es`.

## 2. One exhaustive graded-deny-reason map — issue item 2 (a + b)

Two independent ternaries mapped a graded block type → deny reason and had **already diverged** (#706's capture path folded a failed `parsons` into `challenge_failed`, and `ReviewFailureCapture.reason` was a closed two-value union in which `parsons` is unrepresentable).

- **(b)** New `DENY_REASONS` keyed by `GradedBlockType` with `satisfies Record<GradedBlockType, CompletionDenyReason>` — the same compile-time inversion `GRADERS` already uses. A new graded type now fails the build until its reason is declared. The route's capture + deny both read it; `ReviewFailureCapture.reason` widens to the derived `GradedDenyReason`.
- **(a)** Adds the missing `parsons_failed` case to `deny-reasons.test.ts` — the exhaustiveness the file already had for every other reason.

## Verification

- `pnpm typecheck` — 6/6 packages green.
- `pnpm --filter web test` — **179 files / 1577 tests pass** (was 1568; +9 new: 5 renderer pairing cases incl. a distractor-inclusion-grades-wrong assertion, 1 no-pairing case, 1 `parsons_failed` deny case, and the widened suite still green).
- `eslint` clean on all changed files.

Does **not** merge.
