### PR TITLE
feat(gamification): streak forgiveness across all streak paths (#573)

### DIFF
--- a/apps/web/src/components/gamification/__tests__/dashboard-identity-panel-quests.test.tsx
+++ b/apps/web/src/components/gamification/__tests__/dashboard-identity-panel-quests.test.tsx
@@ -15,6 +15,8 @@ const STREAK: StreakData = {
   longestStreak: 0,
   lastActivityDate: "",
   streakHistory: {},
+  frozenDays: [],
+  freezesRemaining: 0,
 };
 
 function quest(overrides: Partial<DailyQuest>): DailyQuest {

--- a/apps/web/src/components/gamification/dashboard-identity-panel.tsx
+++ b/apps/web/src/components/gamification/dashboard-identity-panel.tsx
@@ -34,6 +34,8 @@ interface HeatmapCell {
   level: 0 | 1 | 2 | 3 | 4;
   isToday: boolean;
   count: number;
+  /** An inactive day a streak freeze saved (LX-B8) — rendered as a snowflake. */
+  frozen: boolean;
 }
 
 interface HeatmapData {
@@ -86,11 +88,16 @@ function ordinal(n: number): string {
   }
 }
 
-function formatCellTooltip(dateStr: string, count: number): string {
+function formatCellTooltip(
+  dateStr: string,
+  count: number,
+  frozen: boolean
+): string {
   if (!dateStr) return "";
   const d = new Date(dateStr + "T00:00:00");
   const month = MONTH_FULL[d.getMonth()]!;
   const day = ordinal(d.getDate());
+  if (frozen) return `Streak frozen on ${month} ${day}`;
   if (count === 0) return `No activity on ${month} ${day}`;
   if (count === 1) return `1 lesson completed on ${month} ${day}`;
   return `${count} lessons completed on ${month} ${day}`;
@@ -104,7 +111,11 @@ function countToLevel(count: number): 0 | 1 | 2 | 3 | 4 {
   return 4;
 }
 
-function buildHeatmapData(streakHistory: Record<string, number>): HeatmapData {
+function buildHeatmapData(
+  streakHistory: Record<string, number>,
+  frozenDays: readonly string[] = []
+): HeatmapData {
+  const frozenSet = new Set(frozenDays);
   const today = new Date();
   const todayStr = today.toISOString().split("T")[0]!;
   const todayDow = today.getDay();
@@ -121,7 +132,13 @@ function buildHeatmapData(streakHistory: Record<string, number>): HeatmapData {
       const daysAgo = startOffset - cellIdx;
 
       if (daysAgo < 0) {
-        colCells.push({ date: "", level: 0, isToday: false, count: 0 });
+        colCells.push({
+          date: "",
+          level: 0,
+          isToday: false,
+          count: 0,
+          frozen: false,
+        });
         continue;
       }
 
@@ -131,8 +148,10 @@ function buildHeatmapData(streakHistory: Record<string, number>): HeatmapData {
       const isToday = dateStr === todayStr;
       const count = streakHistory[dateStr] ?? 0;
       const level = countToLevel(count);
+      // Activity always wins: a day is only "frozen" if it has no real activity.
+      const frozen = count === 0 && frozenSet.has(dateStr);
 
-      colCells.push({ date: dateStr, level, isToday, count });
+      colCells.push({ date: dateStr, level, isToday, count, frozen });
 
       if (row === 0 && !monthLabelMap.has(col)) {
         const month = d.getMonth();
@@ -376,8 +395,8 @@ export function DashboardIdentityPanel({
   }, []);
 
   const heatmap = useMemo(
-    () => buildHeatmapData(streak.streakHistory),
-    [streak.streakHistory]
+    () => buildHeatmapData(streak.streakHistory, streak.frozenDays),
+    [streak.streakHistory, streak.frozenDays]
   );
 
   // Tap-to-show tooltip state (mobile touch support)
@@ -543,6 +562,7 @@ export function DashboardIdentityPanel({
                                   cell.level === 2 && "l2",
                                   cell.level === 3 && "l3",
                                   cell.level === 4 && "l4",
+                                  cell.frozen && "frozen",
                                   cell.isToday && "today"
                                 )}
                                 onClick={(e) => {
@@ -559,7 +579,11 @@ export function DashboardIdentityPanel({
                                 sideOffset={6}
                                 side="top"
                               >
-                                {formatCellTooltip(cell.date, cell.count)}
+                                {formatCellTooltip(
+                                  cell.date,
+                                  cell.count,
+                                  cell.frozen
+                                )}
                                 <Tooltip.Arrow className="fill-[var(--card)]" />
                               </Tooltip.Content>
                             </Tooltip.Portal>

--- a/apps/web/src/components/gamification/streak-display.tsx
+++ b/apps/web/src/components/gamification/streak-display.tsx
@@ -2,7 +2,7 @@
 
 import { useTranslations } from "next-intl";
 import { useLocale } from "next-intl";
-import { Fire } from "@phosphor-icons/react";
+import { Fire, Snowflake } from "@phosphor-icons/react";
 import type { StreakData } from "@superteam-lms/types";
 // Import directly from the source module, not the @/lib/gamification barrel.
 // The barrel re-exports `achievements.ts`, which is `server-only`; importing
@@ -25,7 +25,10 @@ export function StreakDisplay({ streak, className }: StreakDisplayProps) {
   const t = useTranslations("gamification");
   const locale = useLocale();
   const activeToday = isActiveToday(streak);
-  const calendar = generateWeekCalendar(streak.streakHistory);
+  const calendar = generateWeekCalendar(
+    streak.streakHistory,
+    streak.frozenDays
+  );
   const milestones = getStreakMilestones(streak.currentStreak);
 
   const todayDate = todayDateString();
@@ -45,6 +48,17 @@ export function StreakDisplay({ streak, className }: StreakDisplayProps) {
             {activeToday ? t("active") : t("streakKeepGoing")}
           </div>
         </div>
+        {streak.freezesRemaining > 0 && (
+          <div
+            className="ml-auto inline-flex items-center gap-1 rounded-full bg-freeze-bg px-2.5 py-1 font-display text-xs font-bold text-freeze"
+            title={t("streakFreezesRemaining", {
+              count: streak.freezesRemaining,
+            })}
+          >
+            <Snowflake size={14} weight="fill" aria-hidden="true" />
+            {t("streakFreezesRemaining", { count: streak.freezesRemaining })}
+          </div>
+        )}
       </div>
 
       {/* Weekly day circles */}
@@ -68,11 +82,18 @@ export function StreakDisplay({ streak, className }: StreakDisplayProps) {
                   ? "animate-pulse-ring border-primary-dark bg-primary text-white shadow-[0_2px_0_0_var(--primary-dark)]"
                   : day.active
                     ? "border-success bg-success-light text-success-dark shadow-[0_2px_0_0_var(--success-dark)]"
-                    : "border-border bg-subtle text-text-3"
+                    : day.frozen
+                      ? "border-freeze bg-freeze-bg text-freeze"
+                      : "border-border bg-subtle text-text-3"
               )}
-              title={day.date}
+              title={day.frozen ? t("streakFrozenDay") : day.date}
+              aria-label={day.frozen ? t("streakFrozenDay") : undefined}
             >
-              {dayLabel}
+              {day.frozen ? (
+                <Snowflake size={16} weight="fill" aria-hidden="true" />
+              ) : (
+                dayLabel
+              )}
             </div>
           );
         })}

--- a/apps/web/src/hooks/use-dashboard-data.ts
+++ b/apps/web/src/hooks/use-dashboard-data.ts
@@ -30,6 +30,8 @@ const defaultStreak: StreakData = {
   longestStreak: 0,
   lastActivityDate: "",
   streakHistory: {},
+  frozenDays: [],
+  freezesRemaining: 0,
 };
 
 export interface CurrentCourse {

--- a/apps/web/src/lib/gamification/__tests__/streaks.test.ts
+++ b/apps/web/src/lib/gamification/__tests__/streaks.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import { generateStreakCalendar, generateWeekCalendar } from "../streaks";
+
+// #573 (LX-B8): the DISPLAY side of streak forgiveness. The freeze DECISION is
+// server-authoritative (award_xp / award_community_xp / get_daily_quest_state);
+// these helpers only RENDER the frozen days the server logged. What matters here
+// is the merge rule: a freeze fills an inactive day as a snowflake, and real
+// activity always wins over a freeze flag on the same day.
+
+function isoDaysAgo(days: number): string {
+  const d = new Date();
+  d.setDate(d.getDate() - days);
+  return d.toISOString().split("T")[0] as string;
+}
+
+describe("generateStreakCalendar — freeze merge", () => {
+  it("renders an inactive frozen day as frozen, not a hole", () => {
+    const frozen = isoDaysAgo(3);
+    const cal = generateStreakCalendar({}, 30, [frozen]);
+    const cell = cal.find((c) => c.date === frozen)!;
+    expect(cell.active).toBe(false);
+    expect(cell.frozen).toBe(true);
+  });
+
+  it("lets real activity win over a freeze flag on the same day", () => {
+    const day = isoDaysAgo(2);
+    const cal = generateStreakCalendar({ [day]: 1 }, 30, [day]);
+    const cell = cal.find((c) => c.date === day)!;
+    expect(cell.active).toBe(true);
+    expect(cell.frozen).toBe(false);
+  });
+
+  it("leaves ordinary inactive days neither active nor frozen", () => {
+    const day = isoDaysAgo(4);
+    const cal = generateStreakCalendar({}, 30, []);
+    const cell = cal.find((c) => c.date === day)!;
+    expect(cell.active).toBe(false);
+    expect(cell.frozen).toBe(false);
+  });
+
+  it("defaults to no frozen days when the argument is omitted", () => {
+    const cal = generateStreakCalendar({});
+    expect(cal.every((c) => c.frozen === false)).toBe(true);
+  });
+});
+
+describe("generateWeekCalendar — freeze merge", () => {
+  it("marks a frozen day within the current week as frozen", () => {
+    // Pick a day guaranteed to sit inside the current Sun–Sat window: today.
+    const today = isoDaysAgo(0);
+    const cal = generateWeekCalendar({}, [today]);
+    const cell = cal.find((c) => c.date === today)!;
+    expect(cell.frozen).toBe(true);
+    expect(cell.active).toBe(false);
+  });
+
+  it("returns seven days and never marks an active day frozen", () => {
+    const today = isoDaysAgo(0);
+    const cal = generateWeekCalendar({ [today]: 2 }, [today]);
+    expect(cal).toHaveLength(7);
+    const cell = cal.find((c) => c.date === today)!;
+    expect(cell.active).toBe(true);
+    expect(cell.frozen).toBe(false);
+  });
+});

--- a/apps/web/src/lib/gamification/streaks.ts
+++ b/apps/web/src/lib/gamification/streaks.ts
@@ -45,6 +45,10 @@ export function updateStreak(streak: StreakData): StreakData {
       ...streak.streakHistory,
       [today]: (streak.streakHistory[today] ?? 0) + 1,
     },
+    // Display-only helper: freeze state is server-authoritative, so it is passed
+    // through unchanged (this path never mints or consumes a freeze).
+    frozenDays: streak.frozenDays,
+    freezesRemaining: streak.freezesRemaining,
   };
 }
 
@@ -67,20 +71,37 @@ export function getNextMilestone(
   return STREAK_MILESTONES.find((m) => currentStreak < m.days) ?? null;
 }
 
+/** A calendar cell. `frozen` is a day a streak freeze saved (LX-B8) — an
+ *  inactive day that nonetheless kept the streak alive, rendered as a snowflake.
+ *  `active` and `frozen` are mutually exclusive: a day with real activity is
+ *  never "frozen" even if it also appears in the freeze log. */
+export interface StreakCalendarDay {
+  date: string;
+  active: boolean;
+  frozen: boolean;
+}
+
+/** Days a freeze saved, merged into the calendar so a forgiven gap renders as a
+ *  preserved streak rather than a hole. A day is `frozen` only when it has no
+ *  real activity (activity always wins). */
 export function generateStreakCalendar(
   streakHistory: Record<string, number>,
-  days: number = 30
-): { date: string; active: boolean }[] {
-  const calendar: { date: string; active: boolean }[] = [];
+  days: number = 30,
+  frozenDays: readonly string[] = []
+): StreakCalendarDay[] {
+  const frozen = new Set(frozenDays);
+  const calendar: StreakCalendarDay[] = [];
   const today = getNow();
 
   for (let i = days - 1; i >= 0; i--) {
     const date = new Date(today);
     date.setDate(today.getDate() - i);
     const dateStr = toDateString(date);
+    const active = (streakHistory[dateStr] ?? 0) > 0;
     calendar.push({
       date: dateStr,
-      active: (streakHistory[dateStr] ?? 0) > 0,
+      active,
+      frozen: !active && frozen.has(dateStr),
     });
   }
 
@@ -88,21 +109,25 @@ export function generateStreakCalendar(
 }
 
 export function generateWeekCalendar(
-  streakHistory: Record<string, number>
-): { date: string; active: boolean }[] {
+  streakHistory: Record<string, number>,
+  frozenDays: readonly string[] = []
+): StreakCalendarDay[] {
+  const frozen = new Set(frozenDays);
   const today = getNow();
   const dayOfWeek = today.getDay(); // 0 = Sunday
   const sunday = new Date(today);
   sunday.setDate(today.getDate() - dayOfWeek);
 
-  const calendar: { date: string; active: boolean }[] = [];
+  const calendar: StreakCalendarDay[] = [];
   for (let i = 0; i < 7; i++) {
     const date = new Date(sunday);
     date.setDate(sunday.getDate() + i);
     const dateStr = toDateString(date);
+    const active = (streakHistory[dateStr] ?? 0) > 0;
     calendar.push({
       date: dateStr,
-      active: (streakHistory[dateStr] ?? 0) > 0,
+      active,
+      frozen: !active && frozen.has(dateStr),
     });
   }
 

--- a/apps/web/src/lib/services/hybrid-progress-service.ts
+++ b/apps/web/src/lib/services/hybrid-progress-service.ts
@@ -194,17 +194,29 @@ export class HybridProgressService implements LearningProgressService {
   // -------------------------------------------------------------------------
 
   async getStreak(userId: string): Promise<StreakData> {
-    const { data } = await this.supabase
-      .from("user_xp")
-      .select("current_streak, longest_streak, last_activity_date")
-      .eq("user_id", userId)
-      .single();
+    const [{ data }, { data: frozen }] = await Promise.all([
+      this.supabase
+        .from("user_xp")
+        .select(
+          "current_streak, longest_streak, last_activity_date, streak_freezes"
+        )
+        .eq("user_id", userId)
+        .single(),
+      // Own-row read (RLS) of the days a freeze saved — drives the calendar
+      // snowflakes. Writes are server-only; this is display state.
+      this.supabase
+        .from("streak_freezes_used")
+        .select("frozen_date")
+        .eq("user_id", userId),
+    ]);
 
     return {
       currentStreak: data?.current_streak ?? 0,
       longestStreak: data?.longest_streak ?? 0,
       lastActivityDate: data?.last_activity_date ?? "",
       streakHistory: {},
+      frozenDays: (frozen ?? []).map((r) => r.frozen_date),
+      freezesRemaining: data?.streak_freezes ?? 0,
     };
   }
 

--- a/apps/web/src/lib/supabase/__tests__/streak-forgiveness-guard.test.ts
+++ b/apps/web/src/lib/supabase/__tests__/streak-forgiveness-guard.test.ts
@@ -1,0 +1,200 @@
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, it, expect } from "vitest";
+
+// #573 (LX-B8): streak forgiveness across ALL streak writers. RLS + PL/pgSQL
+// behavior cannot be exercised in unit tests (no DB harness in this repo — see
+// review-items-rls-guard / ai-spend-ledger-guard), so the security- and
+// correctness-critical SQL invariants are pinned in BOTH the migration (what is
+// applied) and schema.sql (the snapshot new environments are built from). A
+// drift between the two is exactly the #449 IDL-drift class of bug.
+//
+// The behavioral acceptance criteria (streak continues across a forgiven gap;
+// a second consecutive miss with no token resets; freeze refill/cap) are
+// enforced by the shared next_streak_value / cover_missed_days_with_freezes /
+// grant_streak_freeze functions; these tests pin that all three writers route
+// through them (so the paths agree by construction, not by three copies) and
+// that the consume/cap/log invariants hold.
+
+function findRepoRoot(): string {
+  let dir = dirname(fileURLToPath(import.meta.url));
+  while (!existsSync(resolve(dir, "supabase/schema.sql"))) {
+    const parent = dirname(dir);
+    if (parent === dir)
+      throw new Error("repo root (supabase/schema.sql) not found");
+    dir = parent;
+  }
+  return dir;
+}
+
+const repoRoot = findRepoRoot();
+const migration = readFileSync(
+  resolve(
+    repoRoot,
+    "supabase/migrations/20260726190000_streak_forgiveness.sql"
+  ),
+  "utf8"
+);
+const schema = readFileSync(resolve(repoRoot, "supabase/schema.sql"), "utf8");
+
+const HELPER_RPCS: ReadonlyArray<[string, string]> = [
+  ["cover_missed_days_with_freezes", "(UUID, DATE, DATE)"],
+  ["next_streak_value", "(UUID, DATE, INTEGER, DATE)"],
+  ["grant_streak_freeze", "(UUID)"],
+];
+
+for (const [label, sql] of [
+  ["migration", migration] as const,
+  ["schema.sql", schema] as const,
+]) {
+  describe(`#573 streak forgiveness — ${label}`, () => {
+    it("adds a capped freeze inventory column to user_xp", () => {
+      // Column exists (either as ADD COLUMN in the migration or in the table def
+      // in schema.sql) and is bounded 0..2 by a CHECK in both files.
+      expect(sql).toMatch(/streak_freezes\s+INTEGER\s+NOT NULL\s+DEFAULT 0/);
+      expect(sql).toContain("CHECK (streak_freezes BETWEEN 0 AND 2)");
+    });
+
+    it("logs consumed freezes in an own-row-readable, write-locked table", () => {
+      expect(sql).toContain(
+        "ALTER TABLE streak_freezes_used ENABLE ROW LEVEL SECURITY"
+      );
+      expect(sql).toContain(
+        "ON streak_freezes_used FOR SELECT USING (auth.uid() = user_id)"
+      );
+      // No client write path — writes go only through the SECURITY DEFINER
+      // helpers. A write policy would let a learner forge frozen days.
+      expect(sql).not.toMatch(
+        /ON streak_freezes_used FOR (INSERT|UPDATE|DELETE|ALL)/
+      );
+    });
+
+    it("cascades the freeze log on profile deletion", () => {
+      expect(sql).toContain(
+        "user_id     UUID NOT NULL REFERENCES profiles(id) ON DELETE CASCADE"
+      );
+    });
+
+    it("hardens every new helper (SECURITY DEFINER, pinned path, service_role only)", () => {
+      for (const [fn, args] of HELPER_RPCS) {
+        const start = sql.indexOf(`CREATE OR REPLACE FUNCTION ${fn}(`);
+        expect(start, `${fn} defined`).toBeGreaterThan(-1);
+        const body = sql.slice(
+          start,
+          sql.indexOf("GRANT EXECUTE", start) + 120
+        );
+        expect(body).toContain("SECURITY DEFINER");
+        expect(body).toContain("SET search_path = ''");
+        expect(body).toContain(
+          `REVOKE ALL ON FUNCTION ${fn}${args} FROM PUBLIC, anon, authenticated`
+        );
+        expect(body).toContain(
+          `GRANT EXECUTE ON FUNCTION ${fn}${args} TO service_role`
+        );
+      }
+    });
+
+    it("consumes freezes atomically — guarded decrement, never negative", () => {
+      // The whole concurrency story: one guarded UPDATE. No separate SELECT of
+      // the count that a concurrent path could double-read into an over-consume.
+      expect(sql).toContain("SET streak_freezes = streak_freezes - v_needed");
+      expect(sql).toContain(
+        "WHERE user_id = p_user_id AND streak_freezes >= v_needed"
+      );
+    });
+
+    it("only charges a freeze for a day not already frozen (idempotent log)", () => {
+      // Cross-writer idempotency: a day one path froze is not re-charged by
+      // another. Missed-day count excludes already-logged days; the log insert
+      // is ON CONFLICT DO NOTHING.
+      expect(sql).toContain("FROM public.streak_freezes_used sfu");
+      expect(sql).toContain("ON CONFLICT (user_id, frozen_date) DO NOTHING");
+    });
+
+    it("caps the freeze inventory at 2 in the grant path", () => {
+      expect(sql).toContain("LEAST(user_xp.streak_freezes + 1, 2)");
+    });
+
+    it("routes BOTH XP writers through the shared streak decision (no inline reset)", () => {
+      // award_xp and award_community_xp must both defer to next_streak_value so
+      // a frozen streak survives regardless of which path writes first. The old
+      // inline `ELSE ... := 1` / `ELSE 1` resets must be gone from both bodies.
+      const awardXp = sliceFn(sql, "CREATE OR REPLACE FUNCTION award_xp(");
+      expect(awardXp).toContain("public.next_streak_value(p_user_id");
+      expect(awardXp).not.toMatch(/Gap > 1 day, reset streak/);
+
+      const community = sliceFn(
+        sql,
+        "CREATE OR REPLACE FUNCTION award_community_xp("
+      );
+      expect(community).toContain("public.next_streak_value(p_user_id");
+      // The prior community body reset via `ELSE 1` inside the streak CASE.
+      expect(community).not.toMatch(
+        /WHEN user_xp\.last_activity_date = CURRENT_DATE - INTERVAL '1 day' THEN user_xp\.current_streak \+ 1/
+      );
+    });
+
+    it("forgives the quest login-streak gap and funds forgiveness on completion", () => {
+      const quest = sliceFn(
+        sql,
+        "CREATE OR REPLACE FUNCTION get_daily_quest_state("
+      );
+      // Case 3 consults the shared freeze cover before breaking the quest streak.
+      expect(quest).toContain("public.cover_missed_days_with_freezes(");
+      // Completing the login_streak quest banks a freeze (the quest reward).
+      expect(quest).toContain("PERFORM public.grant_streak_freeze(p_user_id)");
+    });
+  });
+}
+
+function sliceFn(sql: string, header: string): string {
+  const start = sql.indexOf(header);
+  expect(start, `${header} present`).toBeGreaterThan(-1);
+  // Function bodies end at the `$$;` terminator.
+  const end = sql.indexOf("$$;", start);
+  return sql.slice(start, end === -1 ? undefined : end);
+}
+
+describe("#573 streak forgiveness — migration-only guarantees", () => {
+  it("runs in one explicit transaction", () => {
+    expect(migration).toContain("BEGIN;");
+    expect(migration).toContain("COMMIT;");
+  });
+
+  it("adds the column idempotently (safe to re-apply)", () => {
+    expect(migration).toContain(
+      "ALTER TABLE user_xp ADD COLUMN IF NOT EXISTS streak_freezes"
+    );
+    expect(migration).toContain(
+      "CREATE TABLE IF NOT EXISTS streak_freezes_used"
+    );
+  });
+
+  it("ships a rollback that drops the new objects AND restores the writers", () => {
+    // Function-modifying migration: the rollback must both drop what it created
+    // and restore the two rewritten writers' prior bodies (get_daily_quest_state
+    // is restored by re-applying its prior migration).
+    expect(migration).toContain(
+      "DROP FUNCTION IF EXISTS public.grant_streak_freeze(UUID)"
+    );
+    expect(migration).toContain(
+      "DROP FUNCTION IF EXISTS public.next_streak_value(UUID, DATE, INTEGER, DATE)"
+    );
+    expect(migration).toContain(
+      "DROP FUNCTION IF EXISTS public.cover_missed_days_with_freezes(UUID, DATE, DATE)"
+    );
+    expect(migration).toContain(
+      "DROP TABLE IF EXISTS public.streak_freezes_used"
+    );
+    expect(migration).toContain(
+      "ALTER TABLE public.user_xp DROP COLUMN IF EXISTS streak_freezes"
+    );
+    // Restores the two rewritten XP writers, and points at the quest migration.
+    expect(migration).toMatch(/Restore award_xp to its pre-forgiveness body/);
+    expect(migration).toMatch(
+      /Restore award_community_xp to its pre-forgiveness body/
+    );
+    expect(migration).toContain("20260726170000_review_quest_kind.sql");
+  });
+});

--- a/apps/web/src/lib/supabase/__tests__/streak-forgiveness-guard.test.ts
+++ b/apps/web/src/lib/supabase/__tests__/streak-forgiveness-guard.test.ts
@@ -104,6 +104,25 @@ for (const [label, sql] of [
       );
     });
 
+    it("serializes the freeze decision across writers with ONE shared lock", () => {
+      // award_xp / award_community_xp hold DIFFERENT per-writer locks, so the
+      // freeze decision must take a SHARED 'streak:<uid>' advisory lock (inside
+      // cover_missed_days_with_freezes, before the count) or a concurrent pair
+      // races the unlocked count and the loser spuriously resets. Pin the exact
+      // key so a future edit cannot silently split it back into per-writer keys.
+      const cover = sliceFn(
+        sql,
+        "CREATE OR REPLACE FUNCTION cover_missed_days_with_freezes("
+      );
+      expect(cover).toContain(
+        "pg_advisory_xact_lock(hashtext('streak:' || p_user_id::text)::bigint)"
+      );
+      // The lock must precede the missed-day count (lock-then-read, not after).
+      expect(cover.indexOf("pg_advisory_xact_lock")).toBeLessThan(
+        cover.indexOf("SELECT COUNT(*) INTO v_needed")
+      );
+    });
+
     it("only charges a freeze for a day not already frozen (idempotent log)", () => {
       // Cross-writer idempotency: a day one path froze is not re-charged by
       // another. Missed-day count excludes already-logged days; the log insert

--- a/apps/web/src/lib/supabase/types.ts
+++ b/apps/web/src/lib/supabase/types.ts
@@ -775,6 +775,32 @@ export type Database = {
           },
         ];
       };
+      streak_freezes_used: {
+        Row: {
+          created_at: string;
+          frozen_date: string;
+          user_id: string;
+        };
+        Insert: {
+          created_at?: string;
+          frozen_date: string;
+          user_id: string;
+        };
+        Update: {
+          created_at?: string;
+          frozen_date?: string;
+          user_id?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "streak_freezes_used_user_id_fkey";
+            columns: ["user_id"];
+            isOneToOne: false;
+            referencedRelation: "profiles";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
       user_xp: {
         Row: {
           current_streak: number | null;
@@ -782,6 +808,7 @@ export type Database = {
           last_activity_date: string | null;
           level: number | null;
           longest_streak: number | null;
+          streak_freezes: number;
           total_xp: number | null;
           user_id: string | null;
         };
@@ -791,6 +818,7 @@ export type Database = {
           last_activity_date?: string | null;
           level?: number | null;
           longest_streak?: number | null;
+          streak_freezes?: number;
           total_xp?: number | null;
           user_id?: string | null;
         };
@@ -800,6 +828,7 @@ export type Database = {
           last_activity_date?: string | null;
           level?: number | null;
           longest_streak?: number | null;
+          streak_freezes?: number;
           total_xp?: number | null;
           user_id?: string | null;
         };

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -388,6 +388,8 @@
     "category_special": "Special",
     "noEntries": "No rankings yet. Complete lessons to earn XP and appear here.",
     "streakKeepGoing": "Learn today to keep it going!",
+    "streakFrozenDay": "Streak saved with a freeze",
+    "streakFreezesRemaining": "{count, plural, one {# freeze} other {# freezes}}",
     "noAchievements": "Complete a lesson to earn your first achievement",
     "showLocked": "Show locked",
     "tier_seed": "Seed",

--- a/apps/web/src/messages/es.json
+++ b/apps/web/src/messages/es.json
@@ -388,6 +388,8 @@
     "category_special": "Especial",
     "noEntries": "Sin ranking aún. Completa lecciones para ganar XP y aparecer aquí.",
     "streakKeepGoing": "¡Aprende hoy para mantener la racha!",
+    "streakFrozenDay": "Racha salvada con una congelación",
+    "streakFreezesRemaining": "{count, plural, one {# congelación} other {# congelaciones}}",
     "noAchievements": "Completa una lección para ganar tu primer logro",
     "showLocked": "Mostrar bloqueados",
     "tier_seed": "Semilla",

--- a/apps/web/src/messages/pt-BR.json
+++ b/apps/web/src/messages/pt-BR.json
@@ -388,6 +388,8 @@
     "category_special": "Especial",
     "noEntries": "Nenhum ranking ainda. Complete aulas para ganhar XP e aparecer aqui.",
     "streakKeepGoing": "Aprenda hoje para manter a sequência!",
+    "streakFrozenDay": "Sequência salva com um congelamento",
+    "streakFreezesRemaining": "{count, plural, one {# congelamento} other {# congelamentos}}",
     "noAchievements": "Complete uma lição para ganhar sua primeira conquista",
     "showLocked": "Mostrar bloqueados",
     "tier_seed": "Semente",

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -63,6 +63,11 @@
     --streak-dim: rgba(234, 88, 12, 0.1);
     --streak-light: rgba(234, 88, 12, 0.1);
     --streak-border: rgba(234, 88, 12, 0.4);
+    /* ── Streak freeze (LX-B8) — cool blue, distinct from the green activity
+       ramp and amber today marker ── */
+    --freeze: #0284c7;
+    --freeze-fg: #ffffff;
+    --freeze-bg: rgba(2, 132, 199, 0.12);
 
     /* ── Level ── */
     --level: #7c3aed;
@@ -206,6 +211,10 @@
     --streak-dim: rgba(249, 115, 22, 0.13);
     --streak-light: rgba(249, 115, 22, 0.12);
     --streak-border: rgba(249, 115, 22, 0.4);
+    /* ── Streak freeze (LX-B8) — cool blue for dark theme ── */
+    --freeze: #38bdf8;
+    --freeze-fg: #06283d;
+    --freeze-bg: rgba(56, 189, 248, 0.14);
 
     --level: #a78bfa;
     --level-dim: rgba(167, 139, 250, 0.13);
@@ -4353,6 +4362,13 @@ a.path-step-card:hover .path-step-badge.skip {
 .cday.today {
   background: var(--sg-today);
   animation: today-cell 2s ease-in-out infinite;
+}
+/* Streak-freeze day (LX-B8): an inactive day a freeze saved. Rendered in the
+   cool --freeze blue so it reads as "preserved", distinct from the green
+   activity ramp and the amber today marker. */
+.cday.frozen {
+  background: var(--freeze);
+  box-shadow: inset 0 0 0 1px var(--card);
 }
 .contrib-legend {
   display: flex;

--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -52,6 +52,12 @@ const config: Config = {
           DEFAULT: "var(--streak)",
           light: "var(--streak-light)",
         },
+        /* ── Streak freeze — Cool Blue (LX-B8) ── */
+        freeze: {
+          DEFAULT: "var(--freeze)",
+          fg: "var(--freeze-fg)",
+          bg: "var(--freeze-bg)",
+        },
         /* ── Danger — Warm Coral ── */
         danger: {
           DEFAULT: "var(--danger)",

--- a/packages/types/src/progress.ts
+++ b/packages/types/src/progress.ts
@@ -12,6 +12,15 @@ export interface StreakData {
   longestStreak: number;
   lastActivityDate: string;
   streakHistory: Record<string, number>;
+  /**
+   * Days a streak freeze saved (LX-B8), as `YYYY-MM-DD` strings. Rendered as
+   * retroactive snowflakes and merged into the calendar so a forgiven gap reads
+   * as "streak preserved". Populated server-side from streak_freezes_used; the
+   * client only displays them, it never mints them.
+   */
+  frozenDays: string[];
+  /** Freeze tokens the learner currently holds (0–2). Display-only. */
+  freezesRemaining: number;
 }
 
 export interface LeaderboardEntry {

--- a/supabase/migrations/20260726190000_streak_forgiveness.sql
+++ b/supabase/migrations/20260726190000_streak_forgiveness.sql
@@ -1,0 +1,773 @@
+-- ============================================================================
+-- Migration: streak forgiveness — ONE coordinated change across every streak
+-- writer (LX-B8, #573).
+--
+-- WHY ONE MIGRATION: three independent code paths compute/persist a streak, and
+-- forgiveness must be applied in ALL of them or a frozen streak silently
+-- hard-resets down whichever path fires first:
+--   1. award_xp                — the learning-XP streak (user_xp.current_streak).
+--   2. award_community_xp       — the SAME headline streak, updated from the
+--                                 community-XP path (its own `ELSE 1` reset).
+--   3. get_daily_quest_state    — the login_streak quest's own per-quest streak
+--                                 (user_daily_quests, period_start state machine).
+-- lib/gamification/streaks.ts is DISPLAY-ONLY (no state-writing caller) and is
+-- updated in the same PR to RENDER freezes, never to consume them.
+--
+-- MECHANIC (spec §3, LX-B8):
+--   * A missed day is CONSUMED from a freeze inventory instead of resetting the
+--     streak. Inventory is user_xp.streak_freezes, capped at 2.
+--   * Freezes are EARNED server-side via a quest reward (the login_streak quest
+--     grants one on completion, capped at 2) — never minted by the client.
+--   * Every covered day is logged in streak_freezes_used so the calendar can
+--     render a retroactive snowflake, and so the three concurrent writers do NOT
+--     double-charge the SAME calendar day (idempotent per (user_id, frozen_date)).
+--   * Coverage/consumption is atomic: the decrement is a single guarded UPDATE
+--     (row lock + `streak_freezes >= needed`), so no path can over-consume or
+--     drive the inventory negative under concurrency.
+--
+-- The freeze-decision logic is factored into two SECURITY DEFINER helpers
+-- (cover_missed_days_with_freezes, next_streak_value) so all three writers share
+-- ONE implementation — the "all paths agree" acceptance criterion is structural,
+-- not a matter of keeping three copies in sync.
+--
+-- Idempotent (repo convention): ADD COLUMN / CREATE TABLE / CREATE INDEX IF NOT
+-- EXISTS, DROP CONSTRAINT/POLICY IF EXISTS before create, CREATE OR REPLACE
+-- functions, ON CONFLICT DO NOTHING logging. Safe to re-apply. Explicit
+-- BEGIN/COMMIT so the whole file is one transaction even under a manual psql
+-- apply. A tested ROLLBACK block is at the very bottom.
+-- Mirrored into supabase/schema.sql (the full-schema snapshot).
+--
+-- DEFERRED (documented, out of this PR's acceptance): the weekly-cadence streak
+-- mode (spec F32) is gated on owner A/B decision (pedagogy open question #2) and
+-- is not part of the LX-B8 acceptance criteria; it is intentionally not built
+-- here so forgiveness can ship without waiting on that decision.
+-- ============================================================================
+
+BEGIN;
+
+-- ── Freeze inventory (on the existing user_xp row) ──────────────────────────
+-- Capped at 2 by CHECK — a safety net beneath the grant path's LEAST(...,2) and
+-- the consume path's guarded decrement. Existing rows default to 0 freezes.
+ALTER TABLE user_xp ADD COLUMN IF NOT EXISTS streak_freezes INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE user_xp DROP CONSTRAINT IF EXISTS chk_user_xp_streak_freezes_bounds;
+ALTER TABLE user_xp ADD CONSTRAINT chk_user_xp_streak_freezes_bounds
+  CHECK (streak_freezes BETWEEN 0 AND 2);
+
+-- ── Consumed-freeze log ─────────────────────────────────────────────────────
+-- One row per day a freeze saved. Drives the calendar snowflake AND makes freeze
+-- consumption idempotent per calendar day across the three concurrent writers:
+-- whichever writer fires first for a given missed day charges the freeze and logs
+-- it; the others see it already logged and do not re-charge.
+-- Write-side hardening copies the review_items / challenge_assists pattern:
+-- RLS on, NO write policy (writes only via the SECURITY DEFINER helpers below),
+-- plus an own-row SELECT policy so the client can read its own snowflakes for the
+-- calendar (the dashboard is a client surface). anon gets no read.
+CREATE TABLE IF NOT EXISTS streak_freezes_used (
+  user_id     UUID NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+  frozen_date DATE NOT NULL,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (user_id, frozen_date)
+);
+
+ALTER TABLE streak_freezes_used ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Users can view their own frozen days" ON streak_freezes_used;
+CREATE POLICY "Users can view their own frozen days"
+  ON streak_freezes_used FOR SELECT USING (auth.uid() = user_id);
+-- No INSERT/UPDATE/DELETE policy: writes go through the SECURITY DEFINER helpers.
+
+-- ── Helper: cover a gap's missed days with freezes (idempotent, atomic) ─────
+-- Covers every day in [p_from_date, p_to_date] that is not already frozen.
+-- Returns TRUE iff the whole gap is covered (streak survives), FALSE otherwise
+-- (streak breaks). Consumes exactly the number of NOT-already-frozen days, in a
+-- single guarded UPDATE so a concurrent path cannot push the inventory negative.
+CREATE OR REPLACE FUNCTION cover_missed_days_with_freezes(
+  p_user_id   UUID,
+  p_from_date DATE,
+  p_to_date   DATE
+) RETURNS BOOLEAN
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_needed INTEGER;
+  v_d      DATE;
+BEGIN
+  -- No missed days (defensive — callers only invoke this on a real gap).
+  IF p_to_date < p_from_date THEN
+    RETURN TRUE;
+  END IF;
+
+  -- Count missed days not already covered by a prior freeze. A day another
+  -- streak path already froze today does not re-charge a second freeze.
+  SELECT COUNT(*) INTO v_needed
+  FROM generate_series(p_from_date, p_to_date, INTERVAL '1 day') AS g(d)
+  WHERE NOT EXISTS (
+    SELECT 1 FROM public.streak_freezes_used sfu
+    WHERE sfu.user_id = p_user_id AND sfu.frozen_date = g.d::date
+  );
+
+  IF v_needed = 0 THEN
+    RETURN TRUE;  -- every missed day already frozen
+  END IF;
+
+  -- Consume exactly v_needed freezes atomically. The row lock + `>= v_needed`
+  -- guard is the whole concurrency story: two paths cannot both consume the
+  -- last freeze, and the inventory can never go negative (nor below the CHECK
+  -- floor of 0). A partial cover is impossible — either all needed freezes are
+  -- available and consumed, or none are and the streak breaks.
+  UPDATE public.user_xp
+  SET streak_freezes = streak_freezes - v_needed
+  WHERE user_id = p_user_id AND streak_freezes >= v_needed;
+
+  IF NOT FOUND THEN
+    RETURN FALSE;  -- not enough freezes — streak breaks
+  END IF;
+
+  -- Log each covered day so the calendar renders a snowflake and the other
+  -- writers treat it as already frozen (idempotent).
+  FOR v_d IN
+    SELECT g.d::date FROM generate_series(p_from_date, p_to_date, INTERVAL '1 day') AS g(d)
+  LOOP
+    INSERT INTO public.streak_freezes_used (user_id, frozen_date)
+    VALUES (p_user_id, v_d)
+    ON CONFLICT (user_id, frozen_date) DO NOTHING;
+  END LOOP;
+
+  RETURN TRUE;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION cover_missed_days_with_freezes(UUID, DATE, DATE) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION cover_missed_days_with_freezes(UUID, DATE, DATE) TO service_role;
+
+-- ── Helper: the shared headline-streak decision (award_xp + award_community_xp)
+-- Encapsulates the full state machine so BOTH XP writers agree by construction:
+--   no prior activity      → 1
+--   already active today    → keep current
+--   active yesterday        → +1
+--   gap > 1 day             → +1 if freezes cover the gap, else 1 (reset)
+CREATE OR REPLACE FUNCTION next_streak_value(
+  p_user_id        UUID,
+  p_last_activity  DATE,
+  p_current_streak INTEGER,
+  p_today          DATE
+) RETURNS INTEGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+  IF p_last_activity IS NULL THEN
+    RETURN 1;                                            -- first activity ever
+  ELSIF p_last_activity >= p_today THEN
+    RETURN GREATEST(COALESCE(p_current_streak, 1), 1);   -- already active today
+  ELSIF p_last_activity = p_today - 1 THEN
+    RETURN COALESCE(p_current_streak, 0) + 1;            -- active yesterday
+  ELSIF public.cover_missed_days_with_freezes(
+          p_user_id, p_last_activity + 1, p_today - 1) THEN
+    RETURN COALESCE(p_current_streak, 0) + 1;            -- gap forgiven
+  ELSE
+    RETURN 1;                                            -- gap, no freeze: reset
+  END IF;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION next_streak_value(UUID, DATE, INTEGER, DATE) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION next_streak_value(UUID, DATE, INTEGER, DATE) TO service_role;
+
+-- ── Grant a freeze (quest reward, capped at 2) ──────────────────────────────
+-- Auto-applied server-side when the login_streak quest completes. Upserts the
+-- user_xp row so a learner who has not yet earned any XP still banks the freeze;
+-- LEAST(...,2) enforces the cap. Returns the new inventory count.
+CREATE OR REPLACE FUNCTION grant_streak_freeze(p_user_id UUID)
+RETURNS INTEGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_count INTEGER;
+BEGIN
+  INSERT INTO public.user_xp (user_id, streak_freezes)
+  VALUES (p_user_id, 1)
+  ON CONFLICT (user_id) DO UPDATE SET
+    streak_freezes = LEAST(user_xp.streak_freezes + 1, 2)
+  RETURNING streak_freezes INTO v_count;
+  RETURN v_count;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION grant_streak_freeze(UUID) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION grant_streak_freeze(UUID) TO service_role;
+
+-- ── Writer 1: award_xp — streak decision delegated to next_streak_value ─────
+CREATE OR REPLACE FUNCTION award_xp(
+  p_user_id UUID,
+  p_amount INTEGER,
+  p_reason TEXT,
+  p_idempotency_key TEXT DEFAULT NULL,
+  p_tx_signature TEXT DEFAULT NULL
+) RETURNS INTEGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_last_activity DATE;
+  v_current_streak INTEGER;
+  v_longest_streak INTEGER;
+  v_new_streak INTEGER;
+  v_new_longest INTEGER;
+  v_daily_total INTEGER;
+  v_prev_amount INTEGER;
+  v_source TEXT;
+  c_max_award_xp CONSTANT INTEGER := 2000;
+  c_max_daily_award_xp CONSTANT INTEGER := 5000;
+BEGIN
+  IF p_amount IS NULL OR p_amount <= 0 THEN
+    RETURN 0;
+  END IF;
+
+  IF p_amount > c_max_award_xp THEN
+    p_amount := c_max_award_xp;
+  END IF;
+
+  PERFORM pg_advisory_xact_lock(hashtext('award_xp:' || p_user_id::text)::bigint);
+
+  SELECT COALESCE(SUM(amount), 0) INTO v_daily_total
+  FROM public.xp_transactions
+  WHERE user_id = p_user_id
+    AND created_at >= date_trunc('day', now() AT TIME ZONE 'UTC') AT TIME ZONE 'UTC'
+    AND reason NOT LIKE 'community:%';
+
+  IF v_daily_total >= c_max_daily_award_xp THEN
+    RETURN 0;
+  END IF;
+
+  IF v_daily_total + p_amount > c_max_daily_award_xp THEN
+    p_amount := c_max_daily_award_xp - v_daily_total;
+  END IF;
+
+  IF p_amount <= 0 THEN
+    RETURN 0;
+  END IF;
+
+  v_source := public.xp_source_for_reason(p_reason);
+
+  IF p_idempotency_key IS NOT NULL THEN
+    INSERT INTO public.xp_transactions (user_id, amount, reason, source, idempotency_key, tx_signature)
+    VALUES (p_user_id, p_amount, p_reason, v_source, p_idempotency_key, p_tx_signature)
+    ON CONFLICT (user_id, idempotency_key) WHERE idempotency_key IS NOT NULL DO NOTHING;
+
+    IF NOT FOUND THEN
+      SELECT amount INTO v_prev_amount
+      FROM public.xp_transactions
+      WHERE user_id = p_user_id
+        AND idempotency_key = p_idempotency_key;
+      RETURN COALESCE(v_prev_amount, 0);
+    END IF;
+  ELSE
+    INSERT INTO public.xp_transactions (user_id, amount, reason, source, tx_signature)
+    VALUES (p_user_id, p_amount, p_reason, v_source, p_tx_signature);
+  END IF;
+
+  -- Get current streak state, then apply the shared forgiveness-aware decision.
+  -- next_streak_value consumes freezes (and logs frozen days) on a forgiven gap
+  -- BEFORE the upsert below writes the surviving streak — same row, one txn.
+  SELECT last_activity_date, current_streak, longest_streak
+  INTO v_last_activity, v_current_streak, v_longest_streak
+  FROM public.user_xp
+  WHERE user_id = p_user_id;
+
+  v_new_streak := public.next_streak_value(p_user_id, v_last_activity, v_current_streak, CURRENT_DATE);
+  v_new_longest := GREATEST(COALESCE(v_longest_streak, 0), v_new_streak);
+
+  INSERT INTO public.user_xp (user_id, total_xp, level, last_activity_date, current_streak, longest_streak)
+  VALUES (
+    p_user_id,
+    p_amount,
+    floor(sqrt(p_amount / 100.0))::int,
+    CURRENT_DATE,
+    v_new_streak,
+    v_new_longest
+  )
+  ON CONFLICT (user_id) DO UPDATE SET
+    total_xp = user_xp.total_xp + p_amount,
+    level = floor(sqrt((user_xp.total_xp + p_amount) / 100.0))::int,
+    last_activity_date = CURRENT_DATE,
+    current_streak = v_new_streak,
+    longest_streak = v_new_longest;
+
+  RETURN p_amount;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION award_xp FROM authenticated, anon, public;
+GRANT EXECUTE ON FUNCTION award_xp TO service_role;
+
+-- ── Writer 2: award_community_xp — same shared streak decision ──────────────
+-- The prior inline `ELSE 1` in the ON CONFLICT CASE hard-reset a frozen streak
+-- whenever community XP was the day's first write. Now it reads the streak state
+-- and defers to next_streak_value, exactly like award_xp.
+CREATE OR REPLACE FUNCTION award_community_xp(
+  p_user_id UUID,
+  p_amount INTEGER,
+  p_reason TEXT,
+  p_idempotency_key TEXT DEFAULT NULL
+) RETURNS BOOLEAN
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_daily_total INTEGER;
+  v_daily_vote_total INTEGER;
+  v_is_vote_xp BOOLEAN;
+  v_last_activity DATE;
+  v_current_streak INTEGER;
+  v_longest_streak INTEGER;
+  v_new_streak INTEGER;
+  v_new_longest INTEGER;
+BEGIN
+  IF p_amount <= 0 THEN RETURN FALSE; END IF;
+
+  PERFORM pg_advisory_xact_lock(hashtext('award_community_xp:' || p_user_id::text)::bigint);
+
+  SELECT COALESCE(SUM(amount), 0) INTO v_daily_total
+  FROM public.xp_transactions
+  WHERE user_id = p_user_id
+    AND reason LIKE 'community:%'
+    AND created_at >= date_trunc('day', now() AT TIME ZONE 'UTC') AT TIME ZONE 'UTC';
+
+  IF v_daily_total >= 50 THEN RETURN FALSE; END IF;
+
+  v_is_vote_xp := p_reason LIKE 'community:upvote%';
+  IF v_is_vote_xp THEN
+    SELECT COALESCE(SUM(amount), 0) INTO v_daily_vote_total
+    FROM public.xp_transactions
+    WHERE user_id = p_user_id
+      AND reason LIKE 'community:upvote%'
+      AND created_at >= date_trunc('day', now() AT TIME ZONE 'UTC') AT TIME ZONE 'UTC';
+
+    IF v_daily_vote_total >= 10 THEN RETURN FALSE; END IF;
+
+    IF v_daily_vote_total + p_amount > 10 THEN
+      p_amount := 10 - v_daily_vote_total;
+    END IF;
+    IF p_amount <= 0 THEN RETURN FALSE; END IF;
+  END IF;
+
+  IF v_daily_total + p_amount > 50 THEN
+    p_amount := 50 - v_daily_total;
+  END IF;
+  IF p_amount <= 0 THEN RETURN FALSE; END IF;
+
+  IF p_idempotency_key IS NOT NULL THEN
+    INSERT INTO public.xp_transactions (user_id, amount, reason, source, idempotency_key)
+    VALUES (p_user_id, p_amount, p_reason, 'community', p_idempotency_key)
+    ON CONFLICT (user_id, idempotency_key) WHERE idempotency_key IS NOT NULL
+    DO NOTHING;
+
+    IF NOT FOUND THEN RETURN FALSE; END IF;
+  ELSE
+    INSERT INTO public.xp_transactions (user_id, amount, reason, source)
+    VALUES (p_user_id, p_amount, p_reason, 'community');
+  END IF;
+
+  -- Shared forgiveness-aware streak decision (identical rail to award_xp).
+  SELECT last_activity_date, current_streak, longest_streak
+  INTO v_last_activity, v_current_streak, v_longest_streak
+  FROM public.user_xp
+  WHERE user_id = p_user_id;
+
+  v_new_streak := public.next_streak_value(p_user_id, v_last_activity, v_current_streak, CURRENT_DATE);
+  v_new_longest := GREATEST(COALESCE(v_longest_streak, 0), v_new_streak);
+
+  INSERT INTO public.user_xp (id, user_id, total_xp, level, current_streak, longest_streak, last_activity_date)
+  VALUES (
+    gen_random_uuid(), p_user_id, p_amount,
+    floor(sqrt(p_amount / 100.0))::int,
+    v_new_streak, v_new_longest, CURRENT_DATE
+  )
+  ON CONFLICT (user_id) DO UPDATE SET
+    total_xp = user_xp.total_xp + p_amount,
+    level = floor(sqrt((user_xp.total_xp + p_amount) / 100.0))::int,
+    last_activity_date = CURRENT_DATE,
+    current_streak = v_new_streak,
+    longest_streak = v_new_longest;
+
+  RETURN TRUE;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION award_community_xp(UUID, INTEGER, TEXT, TEXT) FROM public, anon, authenticated;
+GRANT EXECUTE ON FUNCTION award_community_xp(UUID, INTEGER, TEXT, TEXT) TO service_role;
+
+-- ── Writer 3: get_daily_quest_state — login_streak gap forgiveness + grant ──
+-- Only the login_streak branch changes: Case 3 (gap) now defers to
+-- cover_missed_days_with_freezes before breaking the quest streak, and first
+-- completion grants a freeze (the quest reward that funds the mechanic). Every
+-- other quest type is byte-identical to the prior definition.
+CREATE OR REPLACE FUNCTION get_daily_quest_state(
+  p_user_id           UUID,
+  p_quest_definitions JSONB,
+  p_challenge_ids     TEXT[],
+  p_module_lesson_map JSONB
+) RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_quest        JSONB;
+  v_quest_id     TEXT;
+  v_type         TEXT;
+  v_target       INTEGER;
+  v_xp           INTEGER;
+  v_reset_type   TEXT;
+  v_current      INTEGER;
+  v_period       DATE;
+  v_existing     RECORD;
+  v_results      JSONB := '[]'::JSONB;
+  v_mod          JSONB;
+  v_mod_lessons  TEXT[];
+  v_all_done     BOOLEAN;
+  v_max_date     DATE;
+  v_just_awarded BOOLEAN;
+  v_completed    BOOLEAN;
+BEGIN
+  FOR v_quest IN SELECT * FROM jsonb_array_elements(p_quest_definitions)
+  LOOP
+    v_quest_id   := v_quest->>'id';
+    v_type       := v_quest->>'type';
+    v_target     := (v_quest->>'targetValue')::INTEGER;
+    v_xp         := (v_quest->>'xpReward')::INTEGER;
+    v_reset_type := v_quest->>'resetType';
+    v_current    := 0;
+    v_just_awarded := false;
+
+    IF v_type = 'lesson' OR v_type = 'lesson_batch' THEN
+      SELECT COUNT(*)::INTEGER INTO v_current
+      FROM public.user_progress
+      WHERE user_id = p_user_id
+        AND completed = true
+        AND completed_at::date = CURRENT_DATE;
+
+    ELSIF v_type = 'challenge' THEN
+      SELECT COUNT(*)::INTEGER INTO v_current
+      FROM public.user_progress
+      WHERE user_id = p_user_id
+        AND completed = true
+        AND completed_at::date = CURRENT_DATE
+        AND lesson_id = ANY(p_challenge_ids);
+
+    ELSIF v_type = 'login_streak' THEN
+      -- Dashboard load = login signal.
+      SELECT * INTO v_existing
+      FROM public.user_daily_quests
+      WHERE user_id = p_user_id
+        AND quest_id = v_quest_id
+        AND completed = false
+      ORDER BY period_start DESC
+      LIMIT 1;
+
+      -- Three-case state machine (see the diff walkthrough below). Case 3 (gap)
+      -- now consults streak freezes before breaking the quest streak, so a
+      -- forgiven gap keeps the quest streak alive exactly as it keeps the
+      -- headline streak alive — the two agree by using the same freeze log.
+      --   Day 1 created:       period_start=D1, current_value=1, diff=0
+      --   Day 2 first load:    diff=1, cv=1 → increment to 2
+      --   Day 3 first load:    diff=2, cv=2 → increment to 3 → COMPLETE
+      --   Day 5 (skipped D4):  diff=4, cv=3 → gap; forgiven iff D4 is covered
+      IF v_existing IS NULL THEN
+        v_current := 1;
+        v_period  := CURRENT_DATE;
+
+      ELSIF (CURRENT_DATE - v_existing.period_start)::INTEGER = v_existing.current_value - 1 THEN
+        -- Already counted today (idempotent reload) — no-op.
+        v_current := v_existing.current_value;
+        v_period  := v_existing.period_start;
+
+      ELSIF (CURRENT_DATE - v_existing.period_start)::INTEGER = v_existing.current_value THEN
+        -- Unbroken streak, new day — increment.
+        v_current := v_existing.current_value + 1;
+        v_period  := v_existing.period_start;
+
+      ELSIF public.cover_missed_days_with_freezes(
+              p_user_id,
+              v_existing.period_start + v_existing.current_value,
+              CURRENT_DATE - 1) THEN
+        -- Case 3a: gap, but freezes cover every missed day — streak survives and
+        -- today's login increments it. Missed days run from the first uncounted
+        -- day (period_start + current_value) through yesterday.
+        v_current := v_existing.current_value + 1;
+        v_period  := v_existing.period_start;
+
+      ELSE
+        -- Case 3b: gap with no freeze — streak breaks, start fresh today.
+        v_current := 1;
+        v_period  := CURRENT_DATE;
+      END IF;
+
+      v_completed := v_target > 0 AND v_current >= v_target;
+
+      INSERT INTO public.user_daily_quests (user_id, quest_id, current_value, completed, completed_at, xp_granted, period_start)
+      VALUES (p_user_id, v_quest_id, v_current, v_completed, CASE WHEN v_completed THEN NOW() ELSE NULL END, false, v_period)
+      ON CONFLICT (user_id, quest_id, period_start) DO UPDATE SET
+        current_value = EXCLUDED.current_value,
+        completed     = EXCLUDED.completed,
+        completed_at  = EXCLUDED.completed_at;
+
+      IF v_completed THEN
+        UPDATE public.user_daily_quests
+        SET xp_granted = true
+        WHERE user_id = p_user_id AND quest_id = v_quest_id AND period_start = v_period AND xp_granted = false;
+
+        IF FOUND THEN
+          v_just_awarded := true;
+          INSERT INTO public.pending_onchain_actions (user_id, action_type, reference_id, payload)
+          VALUES (
+            p_user_id,
+            'quest_xp',
+            v_quest_id || ':' || v_period::text,
+            jsonb_build_object('xpAmount', v_xp, 'memo', 'daily_quest:' || v_quest_id)
+          )
+          ON CONFLICT (user_id, action_type, reference_id) DO NOTHING;
+
+          -- Quest reward that funds forgiveness: completing the consistency quest
+          -- banks a freeze (capped at 2, server-side). Granted alongside the XP
+          -- enqueue on first completion only (guarded by the xp_granted flip).
+          PERFORM public.grant_streak_freeze(p_user_id);
+        END IF;
+      END IF;
+
+      v_results := v_results || jsonb_build_object(
+        'questId', v_quest_id,
+        'currentValue', v_current,
+        'completed', v_completed,
+        'justAwarded', v_just_awarded,
+        'xpReward', v_xp
+      );
+      CONTINUE;
+
+    ELSIF v_type = 'module' THEN
+      v_current := 0;
+      FOR v_mod IN SELECT * FROM jsonb_array_elements(p_module_lesson_map)
+      LOOP
+        v_mod_lessons := ARRAY(SELECT jsonb_array_elements_text(v_mod->'lessonIds'));
+        IF array_length(v_mod_lessons, 1) IS NULL OR array_length(v_mod_lessons, 1) = 0 THEN
+          CONTINUE;
+        END IF;
+
+        SELECT COUNT(*) = array_length(v_mod_lessons, 1) INTO v_all_done
+        FROM public.user_progress
+        WHERE user_id = p_user_id
+          AND completed = true
+          AND lesson_id = ANY(v_mod_lessons);
+
+        IF v_all_done THEN
+          SELECT MAX(completed_at::date) INTO v_max_date
+          FROM public.user_progress
+          WHERE user_id = p_user_id
+            AND completed = true
+            AND lesson_id = ANY(v_mod_lessons);
+
+          IF v_max_date = CURRENT_DATE THEN
+            v_current := 1;
+            EXIT;
+          END IF;
+        END IF;
+      END LOOP;
+
+    ELSIF v_type = 'review' THEN
+      SELECT COUNT(*)::INTEGER INTO v_current
+      FROM public.review_items
+      WHERE user_id = p_user_id
+        AND last_result = true
+        AND last_reviewed_at::date = CURRENT_DATE;
+
+    ELSE
+      RAISE WARNING 'get_daily_quest_state: skipping unknown quest type: %', v_type;
+      CONTINUE;
+    END IF;
+
+    -- ── Generic daily quest upsert (lesson, lesson_batch, challenge, module) ──
+    v_period := CURRENT_DATE;
+
+    v_completed := v_target > 0 AND v_current >= v_target;
+
+    INSERT INTO public.user_daily_quests (user_id, quest_id, current_value, completed, completed_at, xp_granted, period_start)
+    VALUES (p_user_id, v_quest_id, v_current, v_completed, CASE WHEN v_completed THEN NOW() ELSE NULL END, false, v_period)
+    ON CONFLICT (user_id, quest_id, period_start) DO UPDATE SET
+      current_value = EXCLUDED.current_value,
+      completed     = EXCLUDED.completed,
+      completed_at  = COALESCE(user_daily_quests.completed_at, EXCLUDED.completed_at);
+
+    IF v_completed THEN
+      UPDATE public.user_daily_quests
+      SET xp_granted = true
+      WHERE user_id = p_user_id AND quest_id = v_quest_id AND period_start = v_period AND xp_granted = false;
+
+      IF FOUND THEN
+        v_just_awarded := true;
+        INSERT INTO public.pending_onchain_actions (user_id, action_type, reference_id, payload)
+        VALUES (
+          p_user_id,
+          'quest_xp',
+          v_quest_id || ':' || v_period::text,
+          jsonb_build_object('xpAmount', v_xp, 'memo', 'daily_quest:' || v_quest_id)
+        )
+        ON CONFLICT (user_id, action_type, reference_id) DO NOTHING;
+      END IF;
+    END IF;
+
+    v_results := v_results || jsonb_build_object(
+      'questId', v_quest_id,
+      'currentValue', v_current,
+      'completed', v_completed,
+      'justAwarded', v_just_awarded,
+      'xpReward', v_xp
+    );
+  END LOOP;
+
+  RETURN v_results;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION get_daily_quest_state FROM authenticated, anon, public;
+GRANT EXECUTE ON FUNCTION get_daily_quest_state TO service_role;
+
+COMMIT;
+
+-- ============================================================================
+-- ROLLBACK (tested) — returns the DB to the exact pre-forgiveness state.
+-- This migration MODIFIED three existing writers, so the rollback both drops the
+-- new objects AND restores each writer's prior body verbatim. Run as one txn:
+-- ----------------------------------------------------------------------------
+-- BEGIN;
+--
+-- -- 1. Drop the new helper/grant functions and the freeze log + column.
+-- DROP FUNCTION IF EXISTS public.grant_streak_freeze(UUID);
+-- DROP FUNCTION IF EXISTS public.next_streak_value(UUID, DATE, INTEGER, DATE);
+-- DROP FUNCTION IF EXISTS public.cover_missed_days_with_freezes(UUID, DATE, DATE);
+-- DROP TABLE IF EXISTS public.streak_freezes_used;   -- drops its own-row policy
+-- ALTER TABLE public.user_xp DROP CONSTRAINT IF EXISTS chk_user_xp_streak_freezes_bounds;
+-- ALTER TABLE public.user_xp DROP COLUMN IF EXISTS streak_freezes;
+--
+-- -- 2. Restore award_xp to its pre-forgiveness body (inline gap → reset to 1).
+-- CREATE OR REPLACE FUNCTION award_xp(
+--   p_user_id UUID, p_amount INTEGER, p_reason TEXT,
+--   p_idempotency_key TEXT DEFAULT NULL, p_tx_signature TEXT DEFAULT NULL
+-- ) RETURNS INTEGER LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
+-- DECLARE
+--   v_last_activity DATE; v_current_streak INTEGER; v_longest_streak INTEGER;
+--   v_new_streak INTEGER; v_new_longest INTEGER; v_daily_total INTEGER;
+--   v_prev_amount INTEGER; v_source TEXT;
+--   c_max_award_xp CONSTANT INTEGER := 2000;
+--   c_max_daily_award_xp CONSTANT INTEGER := 5000;
+-- BEGIN
+--   IF p_amount IS NULL OR p_amount <= 0 THEN RETURN 0; END IF;
+--   IF p_amount > c_max_award_xp THEN p_amount := c_max_award_xp; END IF;
+--   PERFORM pg_advisory_xact_lock(hashtext('award_xp:' || p_user_id::text)::bigint);
+--   SELECT COALESCE(SUM(amount), 0) INTO v_daily_total FROM public.xp_transactions
+--     WHERE user_id = p_user_id
+--       AND created_at >= date_trunc('day', now() AT TIME ZONE 'UTC') AT TIME ZONE 'UTC'
+--       AND reason NOT LIKE 'community:%';
+--   IF v_daily_total >= c_max_daily_award_xp THEN RETURN 0; END IF;
+--   IF v_daily_total + p_amount > c_max_daily_award_xp THEN p_amount := c_max_daily_award_xp - v_daily_total; END IF;
+--   IF p_amount <= 0 THEN RETURN 0; END IF;
+--   v_source := public.xp_source_for_reason(p_reason);
+--   IF p_idempotency_key IS NOT NULL THEN
+--     INSERT INTO public.xp_transactions (user_id, amount, reason, source, idempotency_key, tx_signature)
+--     VALUES (p_user_id, p_amount, p_reason, v_source, p_idempotency_key, p_tx_signature)
+--     ON CONFLICT (user_id, idempotency_key) WHERE idempotency_key IS NOT NULL DO NOTHING;
+--     IF NOT FOUND THEN
+--       SELECT amount INTO v_prev_amount FROM public.xp_transactions
+--         WHERE user_id = p_user_id AND idempotency_key = p_idempotency_key;
+--       RETURN COALESCE(v_prev_amount, 0);
+--     END IF;
+--   ELSE
+--     INSERT INTO public.xp_transactions (user_id, amount, reason, source, tx_signature)
+--     VALUES (p_user_id, p_amount, p_reason, v_source, p_tx_signature);
+--   END IF;
+--   SELECT last_activity_date, current_streak, longest_streak
+--     INTO v_last_activity, v_current_streak, v_longest_streak
+--     FROM public.user_xp WHERE user_id = p_user_id;
+--   IF v_last_activity IS NULL THEN v_new_streak := 1;
+--   ELSIF v_last_activity = CURRENT_DATE THEN v_new_streak := COALESCE(v_current_streak, 1);
+--   ELSIF v_last_activity = CURRENT_DATE - INTERVAL '1 day' THEN v_new_streak := COALESCE(v_current_streak, 0) + 1;
+--   ELSE v_new_streak := 1; END IF;
+--   v_new_longest := GREATEST(COALESCE(v_longest_streak, 0), v_new_streak);
+--   INSERT INTO public.user_xp (user_id, total_xp, level, last_activity_date, current_streak, longest_streak)
+--   VALUES (p_user_id, p_amount, floor(sqrt(p_amount / 100.0))::int, CURRENT_DATE, v_new_streak, v_new_longest)
+--   ON CONFLICT (user_id) DO UPDATE SET
+--     total_xp = user_xp.total_xp + p_amount,
+--     level = floor(sqrt((user_xp.total_xp + p_amount) / 100.0))::int,
+--     last_activity_date = CURRENT_DATE, current_streak = v_new_streak, longest_streak = v_new_longest;
+--   RETURN p_amount;
+-- END; $$;
+-- REVOKE EXECUTE ON FUNCTION award_xp FROM authenticated, anon, public;
+-- GRANT EXECUTE ON FUNCTION award_xp TO service_role;
+--
+-- -- 3. Restore award_community_xp to its pre-forgiveness body (inline CASE reset).
+-- CREATE OR REPLACE FUNCTION award_community_xp(
+--   p_user_id UUID, p_amount INTEGER, p_reason TEXT, p_idempotency_key TEXT DEFAULT NULL
+-- ) RETURNS BOOLEAN LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
+-- DECLARE v_daily_total INTEGER; v_daily_vote_total INTEGER; v_is_vote_xp BOOLEAN;
+-- BEGIN
+--   IF p_amount <= 0 THEN RETURN FALSE; END IF;
+--   PERFORM pg_advisory_xact_lock(hashtext('award_community_xp:' || p_user_id::text)::bigint);
+--   SELECT COALESCE(SUM(amount), 0) INTO v_daily_total FROM public.xp_transactions
+--     WHERE user_id = p_user_id AND reason LIKE 'community:%'
+--       AND created_at >= date_trunc('day', now() AT TIME ZONE 'UTC') AT TIME ZONE 'UTC';
+--   IF v_daily_total >= 50 THEN RETURN FALSE; END IF;
+--   v_is_vote_xp := p_reason LIKE 'community:upvote%';
+--   IF v_is_vote_xp THEN
+--     SELECT COALESCE(SUM(amount), 0) INTO v_daily_vote_total FROM public.xp_transactions
+--       WHERE user_id = p_user_id AND reason LIKE 'community:upvote%'
+--         AND created_at >= date_trunc('day', now() AT TIME ZONE 'UTC') AT TIME ZONE 'UTC';
+--     IF v_daily_vote_total >= 10 THEN RETURN FALSE; END IF;
+--     IF v_daily_vote_total + p_amount > 10 THEN p_amount := 10 - v_daily_vote_total; END IF;
+--     IF p_amount <= 0 THEN RETURN FALSE; END IF;
+--   END IF;
+--   IF v_daily_total + p_amount > 50 THEN p_amount := 50 - v_daily_total; END IF;
+--   IF p_amount <= 0 THEN RETURN FALSE; END IF;
+--   IF p_idempotency_key IS NOT NULL THEN
+--     INSERT INTO public.xp_transactions (user_id, amount, reason, source, idempotency_key)
+--     VALUES (p_user_id, p_amount, p_reason, 'community', p_idempotency_key)
+--     ON CONFLICT (user_id, idempotency_key) WHERE idempotency_key IS NOT NULL DO NOTHING;
+--     IF NOT FOUND THEN RETURN FALSE; END IF;
+--   ELSE
+--     INSERT INTO public.xp_transactions (user_id, amount, reason, source)
+--     VALUES (p_user_id, p_amount, p_reason, 'community');
+--   END IF;
+--   INSERT INTO public.user_xp (id, user_id, total_xp, level, current_streak, longest_streak, last_activity_date)
+--   VALUES (gen_random_uuid(), p_user_id, p_amount, floor(sqrt(p_amount / 100.0))::int, 1, 1, CURRENT_DATE)
+--   ON CONFLICT (user_id) DO UPDATE SET
+--     total_xp = user_xp.total_xp + p_amount,
+--     level = floor(sqrt((user_xp.total_xp + p_amount) / 100.0))::int,
+--     last_activity_date = CURRENT_DATE,
+--     current_streak = CASE
+--       WHEN user_xp.last_activity_date IS NULL THEN 1
+--       WHEN user_xp.last_activity_date = CURRENT_DATE THEN user_xp.current_streak
+--       WHEN user_xp.last_activity_date = CURRENT_DATE - INTERVAL '1 day' THEN user_xp.current_streak + 1
+--       ELSE 1 END,
+--     longest_streak = GREATEST(user_xp.longest_streak, CASE
+--       WHEN user_xp.last_activity_date = CURRENT_DATE - INTERVAL '1 day' THEN user_xp.current_streak + 1
+--       WHEN user_xp.last_activity_date = CURRENT_DATE THEN user_xp.current_streak
+--       ELSE 1 END);
+--   RETURN TRUE;
+-- END; $$;
+-- REVOKE ALL ON FUNCTION award_community_xp(UUID, INTEGER, TEXT, TEXT) FROM public, anon, authenticated;
+-- GRANT EXECUTE ON FUNCTION award_community_xp(UUID, INTEGER, TEXT, TEXT) TO service_role;
+--
+-- -- 4. Restore get_daily_quest_state: re-apply the migration that last defined it
+-- --    before forgiveness — 20260726170000_review_quest_kind.sql (which carries the
+-- --    full function body with the original Case-3 reset and no freeze grant).
+-- --    (Its login_streak branch is the only part this migration changed.)
+--
+-- COMMIT;
+-- ============================================================================

--- a/supabase/migrations/20260726190000_streak_forgiveness.sql
+++ b/supabase/migrations/20260726190000_streak_forgiveness.sql
@@ -100,6 +100,17 @@ BEGIN
     RETURN TRUE;
   END IF;
 
+  -- Serialize the freeze decision ACROSS the three streak writers. award_xp and
+  -- award_community_xp hold DIFFERENT per-writer advisory locks (and the quest
+  -- path holds none), so without this a concurrent pair could both read the
+  -- count below before either consumed, and the loser would see 0 freezes,
+  -- return FALSE, and spuriously reset a streak while the freeze it needed was
+  -- burnt by the winner (snowflake logged, streak reset). A single shared
+  -- 'streak:<uid>' lock, taken BEFORE the count, forces the loser to run after
+  -- the winner committed: it then sees the day already in streak_freezes_used
+  -- (v_needed = 0) and returns TRUE, so both streaks survive on one freeze.
+  PERFORM pg_advisory_xact_lock(hashtext('streak:' || p_user_id::text)::bigint);
+
   -- Count missed days not already covered by a prior freeze. A day another
   -- streak path already froze today does not re-charge a second freeze.
   SELECT COUNT(*) INTO v_needed
@@ -159,18 +170,24 @@ LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path = ''
 AS $$
+-- The three non-gap branches are byte-faithful to the prior inline logic in
+-- award_xp (IS NULL → 1, = today → keep current, = yesterday → +1); only the
+-- ELSE (gap > 1 day) branch changes — it now forgives via freezes instead of an
+-- unconditional reset. `= p_today` (not `>=`) is deliberate: it preserves the
+-- base behavior of resetting on a future last_activity (clock skew), which
+-- writers never actually produce since they always stamp CURRENT_DATE.
 BEGIN
   IF p_last_activity IS NULL THEN
-    RETURN 1;                                            -- first activity ever
-  ELSIF p_last_activity >= p_today THEN
-    RETURN GREATEST(COALESCE(p_current_streak, 1), 1);   -- already active today
+    RETURN 1;                                    -- first activity ever
+  ELSIF p_last_activity = p_today THEN
+    RETURN COALESCE(p_current_streak, 1);        -- already active today: keep
   ELSIF p_last_activity = p_today - 1 THEN
-    RETURN COALESCE(p_current_streak, 0) + 1;            -- active yesterday
+    RETURN COALESCE(p_current_streak, 0) + 1;    -- active yesterday: increment
   ELSIF public.cover_missed_days_with_freezes(
           p_user_id, p_last_activity + 1, p_today - 1) THEN
-    RETURN COALESCE(p_current_streak, 0) + 1;            -- gap forgiven
+    RETURN COALESCE(p_current_streak, 0) + 1;    -- gap forgiven by freezes
   ELSE
-    RETURN 1;                                            -- gap, no freeze: reset
+    RETURN 1;                                    -- gap, no freeze: reset
   END IF;
 END;
 $$;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -73,7 +73,11 @@ CREATE TABLE user_xp (
   level INTEGER DEFAULT 0,
   current_streak INTEGER DEFAULT 0,
   longest_streak INTEGER DEFAULT 0,
-  last_activity_date DATE
+  last_activity_date DATE,
+  -- Streak-freeze inventory (LX-B8, #573). A missed day is consumed from here
+  -- instead of resetting the streak. Capped at 2 by chk_..._streak_freezes_bounds;
+  -- earned server-side via the login_streak quest reward, never client-minted.
+  streak_freezes INTEGER NOT NULL DEFAULT 0
 );
 
 CREATE TABLE xp_transactions (
@@ -89,6 +93,18 @@ CREATE TABLE xp_transactions (
   -- award_xp via xp_source_for_reason(); hardcoded 'community' inside
   -- award_community_xp. CHECK constraint below (chk_xp_transactions_source).
   source TEXT NOT NULL
+);
+
+-- Consumed-freeze log (LX-B8, #573): one row per day a streak freeze saved.
+-- Drives the retroactive calendar snowflake AND makes freeze consumption
+-- idempotent per calendar day across the three concurrent streak writers.
+-- Writes only via the SECURITY DEFINER streak helpers; own-row SELECT for the
+-- client calendar (RLS policy below).
+CREATE TABLE streak_freezes_used (
+  user_id     UUID NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+  frozen_date DATE NOT NULL,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (user_id, frozen_date)
 );
 
 CREATE TABLE user_achievements (
@@ -179,6 +195,8 @@ ALTER TABLE user_xp
   ADD CONSTRAINT chk_user_xp_longest_streak_non_negative CHECK (longest_streak >= 0);
 ALTER TABLE user_xp
   ADD CONSTRAINT chk_user_xp_longest_gte_current CHECK (longest_streak >= current_streak);
+ALTER TABLE user_xp
+  ADD CONSTRAINT chk_user_xp_streak_freezes_bounds CHECK (streak_freezes BETWEEN 0 AND 2);
 
 ALTER TABLE xp_transactions
   ADD CONSTRAINT chk_xp_transactions_amount_positive CHECK (amount > 0);
@@ -239,6 +257,7 @@ ALTER TABLE profiles ENABLE ROW LEVEL SECURITY;
 ALTER TABLE enrollments ENABLE ROW LEVEL SECURITY;
 ALTER TABLE user_progress ENABLE ROW LEVEL SECURITY;
 ALTER TABLE user_xp ENABLE ROW LEVEL SECURITY;
+ALTER TABLE streak_freezes_used ENABLE ROW LEVEL SECURITY;
 ALTER TABLE xp_transactions ENABLE ROW LEVEL SECURITY;
 ALTER TABLE user_achievements ENABLE ROW LEVEL SECURITY;
 ALTER TABLE certificates ENABLE ROW LEVEL SECURITY;
@@ -333,6 +352,13 @@ CREATE POLICY "Public profile progress is viewable"
 CREATE POLICY "Users can view their own XP"
   ON user_xp FOR SELECT USING (auth.uid() = user_id);
 
+-- streak_freezes_used (SELECT own only — the client calendar renders the
+-- learner's own snowflakes; writes only via the SECURITY DEFINER streak helpers.
+-- No INSERT/UPDATE/DELETE policy: a client write path would let a learner forge
+-- frozen days.)
+CREATE POLICY "Users can view their own frozen days"
+  ON streak_freezes_used FOR SELECT USING (auth.uid() = user_id);
+
 -- xp_transactions (SELECT own only — raw rows never exposed to anon; aggregates
 -- served via get_leaderboard()/community_stats; inserts via award_xp function)
 CREATE POLICY "Users can view their own XP transactions"
@@ -404,9 +430,124 @@ $$;
 -- award functions, which execute as the function owner.
 REVOKE EXECUTE ON FUNCTION public.xp_source_for_reason(TEXT) FROM PUBLIC, anon, authenticated;
 
+-- ── Streak forgiveness helpers (LX-B8, #573) ────────────────────────────────
+-- Shared by all three streak writers so they agree by construction. See
+-- migration 20260726190000_streak_forgiveness.sql for the full design rationale.
+
+-- Covers every day in [p_from_date, p_to_date] not already frozen. Returns TRUE
+-- iff the whole gap is covered (streak survives). Consumes exactly the number of
+-- not-already-frozen days in one guarded UPDATE (atomic, never over-consumes,
+-- never negative), and logs each covered day for the calendar snowflake.
+CREATE OR REPLACE FUNCTION cover_missed_days_with_freezes(
+  p_user_id   UUID,
+  p_from_date DATE,
+  p_to_date   DATE
+) RETURNS BOOLEAN
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_needed INTEGER;
+  v_d      DATE;
+BEGIN
+  IF p_to_date < p_from_date THEN
+    RETURN TRUE;
+  END IF;
+
+  SELECT COUNT(*) INTO v_needed
+  FROM generate_series(p_from_date, p_to_date, INTERVAL '1 day') AS g(d)
+  WHERE NOT EXISTS (
+    SELECT 1 FROM public.streak_freezes_used sfu
+    WHERE sfu.user_id = p_user_id AND sfu.frozen_date = g.d::date
+  );
+
+  IF v_needed = 0 THEN
+    RETURN TRUE;
+  END IF;
+
+  UPDATE public.user_xp
+  SET streak_freezes = streak_freezes - v_needed
+  WHERE user_id = p_user_id AND streak_freezes >= v_needed;
+
+  IF NOT FOUND THEN
+    RETURN FALSE;
+  END IF;
+
+  FOR v_d IN
+    SELECT g.d::date FROM generate_series(p_from_date, p_to_date, INTERVAL '1 day') AS g(d)
+  LOOP
+    INSERT INTO public.streak_freezes_used (user_id, frozen_date)
+    VALUES (p_user_id, v_d)
+    ON CONFLICT (user_id, frozen_date) DO NOTHING;
+  END LOOP;
+
+  RETURN TRUE;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION cover_missed_days_with_freezes(UUID, DATE, DATE) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION cover_missed_days_with_freezes(UUID, DATE, DATE) TO service_role;
+
+-- The shared headline-streak decision (award_xp + award_community_xp):
+--   no prior activity → 1 · active today → keep · active yesterday → +1 ·
+--   gap > 1 day → +1 if freezes cover it, else 1 (reset).
+CREATE OR REPLACE FUNCTION next_streak_value(
+  p_user_id        UUID,
+  p_last_activity  DATE,
+  p_current_streak INTEGER,
+  p_today          DATE
+) RETURNS INTEGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+  IF p_last_activity IS NULL THEN
+    RETURN 1;
+  ELSIF p_last_activity >= p_today THEN
+    RETURN GREATEST(COALESCE(p_current_streak, 1), 1);
+  ELSIF p_last_activity = p_today - 1 THEN
+    RETURN COALESCE(p_current_streak, 0) + 1;
+  ELSIF public.cover_missed_days_with_freezes(
+          p_user_id, p_last_activity + 1, p_today - 1) THEN
+    RETURN COALESCE(p_current_streak, 0) + 1;
+  ELSE
+    RETURN 1;
+  END IF;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION next_streak_value(UUID, DATE, INTEGER, DATE) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION next_streak_value(UUID, DATE, INTEGER, DATE) TO service_role;
+
+-- Grant a freeze (quest reward, capped at 2). Upserts user_xp so a learner with
+-- no XP yet still banks it; auto-applied server-side on login_streak completion.
+CREATE OR REPLACE FUNCTION grant_streak_freeze(p_user_id UUID)
+RETURNS INTEGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_count INTEGER;
+BEGIN
+  INSERT INTO public.user_xp (user_id, streak_freezes)
+  VALUES (p_user_id, 1)
+  ON CONFLICT (user_id) DO UPDATE SET
+    streak_freezes = LEAST(user_xp.streak_freezes + 1, 2)
+  RETURNING streak_freezes INTO v_count;
+  RETURN v_count;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION grant_streak_freeze(UUID) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION grant_streak_freeze(UUID) TO service_role;
+
 -- Award XP (called from API routes with service_role key only)
 -- Also handles streak tracking: increments current_streak if last activity was
--- yesterday, resets to 1 if gap > 1 day, and updates longest_streak.
+-- yesterday, applies a streak freeze (or resets to 1) if gap > 1 day, and
+-- updates longest_streak. Streak decision delegated to next_streak_value.
 -- p_idempotency_key: when provided, uses ON CONFLICT DO NOTHING to prevent
 -- double-award from concurrent retries (race-safe deduplication).
 --
@@ -518,27 +659,15 @@ BEGIN
     VALUES (p_user_id, p_amount, p_reason, v_source, p_tx_signature);
   END IF;
 
-  -- Get current streak state before updating
+  -- Get current streak state, then apply the shared forgiveness-aware decision.
+  -- next_streak_value consumes freezes (and logs frozen days) on a forgiven gap
+  -- BEFORE the upsert below writes the surviving streak — same row, one txn.
   SELECT last_activity_date, current_streak, longest_streak
   INTO v_last_activity, v_current_streak, v_longest_streak
   FROM public.user_xp
   WHERE user_id = p_user_id;
 
-  -- Calculate new streak
-  IF v_last_activity IS NULL THEN
-    -- First activity ever
-    v_new_streak := 1;
-  ELSIF v_last_activity = CURRENT_DATE THEN
-    -- Already active today, keep current streak
-    v_new_streak := COALESCE(v_current_streak, 1);
-  ELSIF v_last_activity = CURRENT_DATE - INTERVAL '1 day' THEN
-    -- Active yesterday, increment streak
-    v_new_streak := COALESCE(v_current_streak, 0) + 1;
-  ELSE
-    -- Gap > 1 day, reset streak
-    v_new_streak := 1;
-  END IF;
-
+  v_new_streak := public.next_streak_value(p_user_id, v_last_activity, v_current_streak, CURRENT_DATE);
   v_new_longest := GREATEST(COALESCE(v_longest_streak, 0), v_new_streak);
 
   INSERT INTO public.user_xp (user_id, total_xp, level, last_activity_date, current_streak, longest_streak)
@@ -1057,8 +1186,20 @@ BEGIN
         v_current := v_existing.current_value + 1;
         v_period  := v_existing.period_start;
 
+      ELSIF public.cover_missed_days_with_freezes(
+              p_user_id,
+              v_existing.period_start + v_existing.current_value,
+              CURRENT_DATE - 1) THEN
+        -- Case 3a (LX-B8): diff > cv — gap, but freezes cover every missed day,
+        -- so the quest streak survives and today's login increments it. Missed
+        -- days run from the first uncounted day (period_start + current_value)
+        -- through yesterday, using the SAME freeze log as the headline streak so
+        -- the two agree.
+        v_current := v_existing.current_value + 1;
+        v_period  := v_existing.period_start;
+
       ELSE
-        -- Case 3: diff > cv — gap detected, streak broken, start new
+        -- Case 3b: diff > cv, no freeze — streak broken, start new
         v_current := 1;
         v_period  := CURRENT_DATE;
       END IF;
@@ -1095,6 +1236,11 @@ BEGIN
             jsonb_build_object('xpAmount', v_xp, 'memo', 'daily_quest:' || v_quest_id)
           )
           ON CONFLICT (user_id, action_type, reference_id) DO NOTHING;
+
+          -- Quest reward that funds forgiveness (LX-B8): completing the
+          -- consistency quest banks a streak freeze (capped at 2, server-side),
+          -- on first completion only (guarded by the xp_granted flip above).
+          PERFORM public.grant_streak_freeze(p_user_id);
         END IF;
       END IF;
 
@@ -1626,6 +1772,11 @@ DECLARE
   v_daily_total INTEGER;
   v_daily_vote_total INTEGER;
   v_is_vote_xp BOOLEAN;
+  v_last_activity DATE;
+  v_current_streak INTEGER;
+  v_longest_streak INTEGER;
+  v_new_streak INTEGER;
+  v_new_longest INTEGER;
 BEGIN
   IF p_amount <= 0 THEN RETURN FALSE; END IF;
 
@@ -1680,30 +1831,29 @@ BEGIN
     VALUES (p_user_id, p_amount, p_reason, 'community');
   END IF;
 
+  -- Shared forgiveness-aware streak decision (identical rail to award_xp): the
+  -- prior inline CASE hard-reset a frozen streak whenever community XP was the
+  -- day's first write. Read the streak state, then defer to next_streak_value.
+  SELECT last_activity_date, current_streak, longest_streak
+  INTO v_last_activity, v_current_streak, v_longest_streak
+  FROM public.user_xp
+  WHERE user_id = p_user_id;
+
+  v_new_streak := public.next_streak_value(p_user_id, v_last_activity, v_current_streak, CURRENT_DATE);
+  v_new_longest := GREATEST(COALESCE(v_longest_streak, 0), v_new_streak);
+
   INSERT INTO public.user_xp (id, user_id, total_xp, level, current_streak, longest_streak, last_activity_date)
   VALUES (
     gen_random_uuid(), p_user_id, p_amount,
     floor(sqrt(p_amount / 100.0))::int,
-    1, 1, CURRENT_DATE
+    v_new_streak, v_new_longest, CURRENT_DATE
   )
   ON CONFLICT (user_id) DO UPDATE SET
     total_xp = user_xp.total_xp + p_amount,
     level = floor(sqrt((user_xp.total_xp + p_amount) / 100.0))::int,
     last_activity_date = CURRENT_DATE,
-    current_streak = CASE
-      WHEN user_xp.last_activity_date IS NULL THEN 1
-      WHEN user_xp.last_activity_date = CURRENT_DATE THEN user_xp.current_streak
-      WHEN user_xp.last_activity_date = CURRENT_DATE - INTERVAL '1 day' THEN user_xp.current_streak + 1
-      ELSE 1
-    END,
-    longest_streak = GREATEST(
-      user_xp.longest_streak,
-      CASE
-        WHEN user_xp.last_activity_date = CURRENT_DATE - INTERVAL '1 day' THEN user_xp.current_streak + 1
-        WHEN user_xp.last_activity_date = CURRENT_DATE THEN user_xp.current_streak
-        ELSE 1
-      END
-    );
+    current_streak = v_new_streak,
+    longest_streak = v_new_longest;
 
   RETURN TRUE;
 END;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -455,6 +455,13 @@ BEGIN
     RETURN TRUE;
   END IF;
 
+  -- Serialize the freeze decision across all three streak writers (they hold
+  -- different per-writer advisory locks, so without this a concurrent pair races
+  -- on the unlocked count below and the loser spuriously resets while burning
+  -- the freeze). Taken BEFORE the count: the loser runs after the winner
+  -- committed, sees the day already logged (v_needed = 0), and survives.
+  PERFORM pg_advisory_xact_lock(hashtext('streak:' || p_user_id::text)::bigint);
+
   SELECT COUNT(*) INTO v_needed
   FROM generate_series(p_from_date, p_to_date, INTERVAL '1 day') AS g(d)
   WHERE NOT EXISTS (
@@ -502,11 +509,14 @@ LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path = ''
 AS $$
+-- Non-gap branches are byte-faithful to award_xp's prior inline logic; only the
+-- ELSE (gap > 1 day) forgives via freezes instead of an unconditional reset.
+-- `= p_today` (not `>=`) preserves the base reset-on-future-date behavior.
 BEGIN
   IF p_last_activity IS NULL THEN
     RETURN 1;
-  ELSIF p_last_activity >= p_today THEN
-    RETURN GREATEST(COALESCE(p_current_streak, 1), 1);
+  ELSIF p_last_activity = p_today THEN
+    RETURN COALESCE(p_current_streak, 1);
   ELSIF p_last_activity = p_today - 1 THEN
     RETURN COALESCE(p_current_streak, 0) + 1;
   ELSIF public.cover_missed_days_with_freezes(


### PR DESCRIPTION
Closes #573 (LX-B8). One coordinated PR across every streak code path: a missed day consumes a **streak freeze** instead of hard-resetting the streak, applied in **all three** persisted-state writers so a frozen streak survives whichever path fires first.

## Streak paths found (and touched)

| Path | Kind | What it computes | Change |
|------|------|------------------|--------|
| `award_xp` (schema.sql / migration) | DB writer | headline streak on `user_xp.current_streak` (learning XP) | gap now defers to shared `next_streak_value` (freeze-or-reset) |
| `award_community_xp` | DB writer | the **same** headline streak, from the community-XP path | replaced its inline `ELSE 1` CASE reset with the same shared decision (the writer the original audit missed) |
| `get_daily_quest_state` `login_streak` branch | DB writer | the login-streak **quest's own** per-quest streak (`user_daily_quests` period_start machine) | Case 3 (gap) consults the shared freeze log before breaking; first completion **grants** a freeze |
| `lib/gamification/streaks.ts` (`generateWeekCalendar` / `generateStreakCalendar` / `updateStreak`) | Display only | weekly circles / month calendar | renders freeze days as snowflakes; **no state write** (confirmed zero state-writing callers) |
| `dashboard-identity-panel.tsx` `buildHeatmapData` | Display only | 270-day activity heatmap | merges freeze days as snowflake cells |
| `hybrid-progress-service.getStreak` | Read | assembles `StreakData` | reads `streak_freezes` + `streak_freezes_used` (own-row RLS) |

The three DB writers agree **by construction**: they route through shared SECURITY DEFINER helpers (`next_streak_value`, `cover_missed_days_with_freezes`), not three copies.

## Forgiveness semantics

| Situation | Result |
|-----------|--------|
| Active today / yesterday | unchanged (keep / +1) |
| Gap, every missed day covered by a freeze | streak **survives** (+1); each missed day logged as a snowflake |
| Gap, not enough freezes | streak **resets** to 1 |
| Missed day already frozen by another path | **not re-charged** (idempotent per `(user_id, frozen_date)`) |
| Freeze inventory | `user_xp.streak_freezes`, **capped at 2** (CHECK 0..2 + `LEAST(..+1, 2)`) |
| Earning | server-side only — login_streak quest completion banks 1 (never client-minted) |
| Consumption | single guarded `UPDATE ... WHERE streak_freezes >= needed` — atomic, never over-consumes, never negative |

## Migration (SQL-only, NOT applied to prod)

`supabase/migrations/20260726190000_streak_forgiveness.sql` — idempotent (ADD COLUMN / CREATE TABLE IF NOT EXISTS, DROP CONSTRAINT/POLICY before create, CREATE OR REPLACE), explicit `BEGIN/COMMIT`, byte-mirrored into `supabase/schema.sql`, every helper `SECURITY DEFINER` + `SET search_path=''` + REVOKE/GRANT, own-row RLS SELECT on `streak_freezes_used` with **no** client write policy. Ships a **tested ROLLBACK** block that drops the new objects and restores both rewritten XP writers' prior bodies (get_daily_quest_state restored by re-applying its prior migration). Timestamp `20260726190000` — unique vs `supabase/migrations/` and the only open PR (#718, no migration).

## Display

`StreakData` gains `frozenDays: string[]` + `freezesRemaining: number`; snowflakes merge into both calendars and the heatmap (**activity always wins** over a freeze flag); new i18n strings `streakFrozenDay` / `streakFreezesRemaining` in **en / pt-BR / es**; dedicated `--freeze` cool-blue token (light + dark); snowflake cells carry `title`/`aria-label`.

## Verification

- `pnpm install --frozen-lockfile && pnpm typecheck` — green (6/6 packages)
- `pnpm --filter web test` — **183 files / 1641 tests pass** (includes 27 new: SQL guard + calendar-merge display tests)
- `pnpm --filter web lint` — clean (only pre-existing import-order warnings, none in touched files)

## Deviation

- **Weekly-cadence mode (spec F32)** intentionally **not built** — it is gated on the owner's A/B decision (pedagogy open question #2) and is not part of the LX-B8 acceptance criteria. Deferring it lets forgiveness ship now; documented in the migration header.


---

## Post-review update (commit b69bf0e)

**Concurrency fix (MAJOR, from adversarial review):** `award_xp` and `award_community_xp` hold *different* per-writer advisory locks, so on a gap-boundary day with exactly one freeze both could read `v_needed=1` from `cover_missed_days_with_freezes`' unlocked `SELECT COUNT` before either consumed; the loser's guarded decrement then found 0 freezes, returned FALSE, and **spuriously reset the streak while the freeze was burnt**. Fixed by taking a **shared `pg_advisory_xact_lock('streak:<uid>')` before the count** inside `cover_missed_days_with_freezes` — one choke point covering all three writers' gap paths (the two XP writers via `next_streak_value`, the quest path directly). The loser now runs after the winner commits, sees the day already in `streak_freezes_used` (`v_needed=0`), returns TRUE, and both streaks survive on one freeze. No deadlock: `streak:<uid>` is the only cross-writer lock and is always acquired after any per-writer key. Guard test extended to pin the exact key + lock-before-count ordering (migration + schema.sql). Also reverted `next_streak_value`'s `>= p_today` to `= p_today` for byte-parity with the base writers' reset-on-future-date behavior.

**Owner decision to flag — shared freeze inventory:** freezes live in a single `user_xp.streak_freezes` pool shared by the headline streak and the login_streak quest streak. Because the quest streak also consumes from this pool on its own gaps, a login_streak-quest gap can burn a freeze the headline streak later needs (and vice-versa). This is intentional for launch (one inventory, one mental model), but if you'd rather the two streaks not compete for freezes, that's a **separate-pools** follow-up — calling it out now so it's a conscious choice, not a surprise.
