### PR TITLE
ci: make SHA-pin guard YAML-aware — close flow-style bypass (#723)

### DIFF
--- a/.github/workflows/action-pin-guard.yml
+++ b/.github/workflows/action-pin-guard.yml
@@ -31,6 +31,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      # The guard's parser needs PyYAML. It already ships with the runner's
+      # pre-installed yamllint, so this is a fallback that pins the dependency
+      # explicitly rather than relying on the image incidentally carrying it (a
+      # future image change would otherwise break the guard). apt's distro
+      # package, not `pip install --user`: ubuntu-24.04's system python is
+      # externally-managed (PEP 668) and refuses --user installs.
+      - name: Ensure PyYAML (guard parser dependency)
+        run: |
+          python3 -c 'import yaml' 2>/dev/null || {
+            sudo apt-get update -qq
+            sudo apt-get install -y python3-yaml
+          }
       # Prove the guard actually rejects unpinned refs (in workflows AND composite
       # actions) and accepts pinned trees before trusting its verdict — #662 /
       # #614 "don't ship an unexercised guard".

--- a/scripts/__tests__/check-action-pins.test.sh
+++ b/scripts/__tests__/check-action-pins.test.sh
@@ -1,13 +1,17 @@
 #!/bin/bash
 # Exercises scripts/check-action-pins.sh against fixture trees so the guard is
 # never shipped unexercised (#662 "prove it fails on a bad line"; #614). Runs in
-# the Action pin guard workflow *before* the real scan, so every PR proves the
-# guard both accepts a fully-pinned tree and rejects an unpinned ref — in a
-# workflow file AND in a composite action (#681).
+# the Action pin guard workflow *before* the real scan.
 #
-# Pure bash, no test framework: the guard itself is pure bash and CI runs the
-# monorepo vitest via `pnpm -r test`, not the root `scripts/` suite, so a vitest
-# spec here would not gate. Self-contained + exit-code assertions do.
+# These are representative cases, not a proof of completeness: they show the
+# guard accepts a fully-pinned tree and rejects unpinned refs across the surfaces
+# that have bitten us — block style in a workflow AND a composite action (#681),
+# and flow style `[{uses: ...}]` / `- { uses: ... }` and symlinked composite
+# files (#723). New evasions should arrive here as a new failing case first.
+#
+# Pure bash, no test framework: CI runs the monorepo vitest via `pnpm -r test`,
+# not the root `scripts/` suite, so a vitest spec here would not gate.
+# Self-contained + exit-code assertions do.
 set -uo pipefail
 
 guard="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/check-action-pins.sh"
@@ -102,6 +106,51 @@ jobs:
       - uses: actions/setup-node@1111111 # short SHA
 EOF
 run 1 "branch ref / short SHA rejected"
+cleanup
+
+# 6. Flow-style mapping, unpinned → fail (the #723 bypass: grep was blind to this).
+new_fixture
+cat > "$fixture/.github/workflows/ci.yml" <<EOF
+jobs:
+  a:
+    steps:
+      - { uses: actions/checkout@v4 }
+EOF
+run 1 "flow-style mapping unpinned is rejected (#723)"
+cleanup
+
+# 7. Flow-style sequence, unpinned → fail (the #723 bypass, second form).
+new_fixture
+cat > "$fixture/.github/workflows/ci.yml" <<EOF
+jobs:
+  a:
+    steps: [{uses: actions/checkout@v4}]
+EOF
+run 1 "flow-style sequence unpinned is rejected (#723)"
+cleanup
+
+# 8. Flow-style, correctly pinned → pass (guard is precise, not a blanket reject).
+new_fixture
+cat > "$fixture/.github/workflows/ci.yml" <<EOF
+jobs:
+  a:
+    steps: [{uses: actions/checkout@$sha}]
+EOF
+run 0 "flow-style correctly pinned is accepted"
+cleanup
+
+# 9. Symlinked composite action.yml, unpinned → fail (find -L must follow it; the
+#    old find -type f skipped symlinks while the workflow glob followed them — #723).
+new_fixture
+cat > "$fixture/real-action.yml" <<EOF
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-node@v4
+EOF
+mkdir -p "$fixture/.github/actions/linked"
+ln -s "$fixture/real-action.yml" "$fixture/.github/actions/linked/action.yml"
+run 1 "symlinked composite action.yml is scanned (#723)"
 cleanup
 
 if [ "$fails" -gt 0 ]; then

--- a/scripts/__tests__/check-action-pins.test.sh
+++ b/scripts/__tests__/check-action-pins.test.sh
@@ -153,6 +153,34 @@ ln -s "$fixture/real-action.yml" "$fixture/.github/actions/linked/action.yml"
 run 1 "symlinked composite action.yml is scanned (#723)"
 cleanup
 
+# 10. A `uses` key that is NOT an action ref — an env var and a `with:` input both
+#     named `uses` — must NOT be flagged (the real step ref is pinned) → pass.
+#     The old any-depth walk wrongly rejected these (#723 review MINOR).
+new_fixture
+cat > "$fixture/.github/workflows/ci.yml" <<EOF
+jobs:
+  a:
+    env:
+      uses: my-build@latest
+    steps:
+      - uses: actions/checkout@$sha # v7.0.1
+        with:
+          uses: some-input-value@latest
+EOF
+run 0 "env / with keys named 'uses' are not treated as action refs"
+cleanup
+
+# 11. Reusable-workflow call (jobs.<id>.uses), unpinned → fail. Proves the
+#     schema-scoped walk keeps this real pinnable ref in scope.
+new_fixture
+cat > "$fixture/.github/workflows/ci.yml" <<EOF
+jobs:
+  call:
+    uses: org/repo/.github/workflows/reusable.yml@v1
+EOF
+run 1 "unpinned reusable-workflow call is rejected"
+cleanup
+
 if [ "$fails" -gt 0 ]; then
   echo "check-action-pins.test.sh: $fails case(s) FAILED"
   exit 1

--- a/scripts/check-action-pins.py
+++ b/scripts/check-action-pins.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""YAML-aware core of the SHA-pin guard (#723).
+
+Given a repo root and a list of workflow / composite-action files, parse each
+with a real YAML parser and flag every `uses:` value that is not pinned to a
+40-char commit SHA. Walking the parsed node tree (not line-anchored grep) is the
+whole point: it sees `uses` keys at any nesting and in flow style —
+`steps: [{uses: actions/checkout@v4}]` and `- { uses: ... }` — which the old
+grep matcher passed green while unpinned (the #723 bypass).
+
+Invoked by scripts/check-action-pins.sh, which owns file discovery and the
+CHECK_ACTION_PINS_ROOT test seam. Kept as a separate helper so it is lintable and
+unit-testable, and so the bash side stays a thin, reviewed shell.
+
+Fail-closed: a missing PyYAML or an unparseable file exits non-zero rather than
+skipping a file — a guard that silently scans nothing is worse than none.
+"""
+
+import re
+import sys
+
+try:
+    import yaml
+except ImportError:
+    sys.stderr.write(
+        "::error::check-action-pins: PyYAML is required but `import yaml` failed. "
+        "It ships with the pre-installed yamllint on GitHub's ubuntu runners; "
+        "locally run `pip install pyyaml`. The guard fails closed rather than "
+        "skip its check.\n"
+    )
+    sys.exit(2)
+
+SHA_RE = re.compile(r"^[0-9a-fA-F]{40}$")
+
+
+def is_pinned(value):
+    """A `uses:` value is acceptable iff it is a local ref (./...), a docker://
+    image ref, or pinned to a full 40-hex commit SHA after the last @."""
+    v = value.strip()
+    if v.startswith("./") or v.startswith("docker://"):
+        return True
+    if "@" not in v:
+        return False
+    ref = v.rsplit("@", 1)[1]
+    return bool(SHA_RE.match(ref))
+
+
+def iter_uses(node):
+    """Yield (uses_value, line) for every mapping key `uses` with a scalar value,
+    at any depth, in both block and flow style."""
+    if isinstance(node, yaml.MappingNode):
+        for key_node, val_node in node.value:
+            if (
+                isinstance(key_node, yaml.ScalarNode)
+                and key_node.value == "uses"
+                and isinstance(val_node, yaml.ScalarNode)
+            ):
+                yield val_node.value, val_node.start_mark.line + 1
+            yield from iter_uses(val_node)
+    elif isinstance(node, yaml.SequenceNode):
+        for item in node.value:
+            yield from iter_uses(item)
+
+
+def scan_file(path, rel):
+    """Return the number of unpinned `uses:` refs in one file, printing a GitHub
+    error annotation for each. A YAML parse error is itself a failure (returns 1)."""
+    violations = 0
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            documents = list(yaml.compose_all(fh))
+    except (yaml.YAMLError, OSError) as exc:
+        print(
+            f"::error file={rel}::check-action-pins could not parse this file, so it "
+            f"cannot be verified (failing closed): {exc}"
+        )
+        return 1
+
+    for doc in documents:
+        if doc is None:
+            continue
+        for value, line in iter_uses(doc):
+            if not is_pinned(value):
+                print(
+                    f"::error file={rel},line={line}::Action is not SHA-pinned: "
+                    f"`{value}`. Pin to a 40-char commit SHA with a version comment, "
+                    f"e.g. `uses: owner/repo@<40-hex-sha> # v1.2.3`."
+                )
+                violations += 1
+    return violations
+
+
+def main(argv):
+    if len(argv) < 2:
+        sys.stderr.write("usage: check-action-pins.py <repo_root> <file>...\n")
+        return 2
+    repo_root = argv[1].rstrip("/") + "/"
+    files = argv[2:]
+
+    total = 0
+    for path in files:
+        rel = path[len(repo_root):] if path.startswith(repo_root) else path
+        total += scan_file(path, rel)
+
+    if total > 0:
+        print(
+            f"::error::{total} GitHub Action(s) are not pinned to a commit SHA. "
+            "See #635 — mutable tags are forbidden."
+        )
+        return 1
+
+    print(
+        f"All GitHub Actions `uses:` refs are SHA-pinned across {len(files)} "
+        "file(s) in .github/workflows/ and .github/actions/. ✓"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/check-action-pins.py
+++ b/scripts/check-action-pins.py
@@ -45,21 +45,73 @@ def is_pinned(value):
     return bool(SHA_RE.match(ref))
 
 
-def iter_uses(node):
-    """Yield (uses_value, line) for every mapping key `uses` with a scalar value,
-    at any depth, in both block and flow style."""
-    if isinstance(node, yaml.MappingNode):
-        for key_node, val_node in node.value:
-            if (
-                isinstance(key_node, yaml.ScalarNode)
-                and key_node.value == "uses"
-                and isinstance(val_node, yaml.ScalarNode)
-            ):
-                yield val_node.value, val_node.start_mark.line + 1
-            yield from iter_uses(val_node)
-    elif isinstance(node, yaml.SequenceNode):
-        for item in node.value:
-            yield from iter_uses(item)
+def _pairs(node):
+    """Key/value node pairs of a MappingNode (empty for anything else). Aliases
+    are already resolved to the referenced node by yaml.compose, so anchored /
+    aliased steps and jobs are walked like inline ones."""
+    return node.value if isinstance(node, yaml.MappingNode) else []
+
+
+def _first(node, name):
+    """First value node for scalar key `name` in a mapping, else None."""
+    for key_node, val_node in _pairs(node):
+        if isinstance(key_node, yaml.ScalarNode) and key_node.value == name:
+            return val_node
+    return None
+
+
+def _uses_of(mapping):
+    """Value nodes of the effective `uses` key(s) of one step/job mapping.
+    Explicit keys win (all of them, so a duplicate-key `uses` can't smuggle an
+    unpinned second value); only if there is none do we follow YAML merge keys
+    (`<<`), so a `uses` injected via an anchor/merge is still seen."""
+    explicit = [
+        v for k, v in _pairs(mapping)
+        if isinstance(k, yaml.ScalarNode) and k.value == "uses"
+    ]
+    if explicit:
+        return explicit
+    merged = []
+    for k, v in _pairs(mapping):
+        if isinstance(k, yaml.ScalarNode) and k.value == "<<":
+            sources = v.value if isinstance(v, yaml.SequenceNode) else [v]
+            for src in sources:
+                merged.extend(_uses_of(src))
+    return merged
+
+
+def _emit(mapping, out):
+    for v in _uses_of(mapping):
+        if isinstance(v, yaml.ScalarNode):
+            out.append((v.value, v.start_mark.line + 1))
+
+
+def iter_uses(doc):
+    """Yield (uses_value, line) for pinnable GitHub Action refs only, walking the
+    Actions schema rather than every `uses` key:
+
+      - workflow  jobs.<id>.steps[*].uses   (step action)
+      - workflow  jobs.<id>.uses            (reusable-workflow call — pinnable)
+      - action    runs.steps[*].uses        (composite action step)
+
+    A `uses` key elsewhere is NOT an action ref — e.g. an env var or a `with:`
+    input named `uses` — and is deliberately ignored so it can't wrongly fail the
+    guard (#723 review). This also drops the old walk's blind descent, which
+    flagged such keys at any depth."""
+    out = []
+    for _job_id, job in _pairs(_first(doc, "jobs")):
+        if not isinstance(job, yaml.MappingNode):
+            continue
+        _emit(job, out)  # reusable-workflow call at job level
+        steps = _first(job, "steps")
+        if isinstance(steps, yaml.SequenceNode):
+            for step in steps.value:
+                _emit(step, out)
+    runs_steps = _first(_first(doc, "runs"), "steps")
+    if isinstance(runs_steps, yaml.SequenceNode):
+        for step in runs_steps.value:
+            _emit(step, out)
+    return out
 
 
 def scan_file(path, rel):

--- a/scripts/check-action-pins.sh
+++ b/scripts/check-action-pins.sh
@@ -16,17 +16,23 @@
 #   - local reusable workflows / composite actions:  uses: ./.github/actions/foo
 #   - Docker image refs:         uses: docker://alpine:3.20  (pin by @sha256 digest)
 #
-# Pure bash + grep — no third-party action or tool, so the guard can't itself
-# reintroduce an unpinned dependency. Runnable locally: scripts/check-action-pins.sh
+# This shell owns file discovery + the CHECK_ACTION_PINS_ROOT test seam; the
+# YAML-aware matching lives in check-action-pins.py (parses each file with a real
+# YAML parser and walks every `uses` key). A line-anchored grep used to do the
+# match, but it was blind to flow-style YAML — `steps: [{uses: foo@v4}]` passed
+# green while unpinned (#723). The only runtime dependency is python3 + PyYAML,
+# both pre-installed on GitHub's ubuntu runners (PyYAML ships with the
+# pre-installed yamllint); no `npm/pip install` at guard time and no third-party
+# Action to pin, so the guard can't reintroduce the unpinned-dependency risk it
+# exists to prevent. Runnable locally: scripts/check-action-pins.sh
 # Test seam: CHECK_ACTION_PINS_ROOT overrides the repo root so the guard can be
 # exercised against fixture trees (scripts/__tests__/check-action-pins.test.sh).
 set -euo pipefail
 
-repo_root="${CHECK_ACTION_PINS_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="${CHECK_ACTION_PINS_ROOT:-$(cd "$script_dir/.." && pwd)}"
 workflow_dir="$repo_root/.github/workflows"
 actions_dir="$repo_root/.github/actions"
-sha_re='^[0-9a-fA-F]{40}$'
-violations=0
 
 shopt -s nullglob
 files=("$workflow_dir"/*.yml "$workflow_dir"/*.yaml)
@@ -34,11 +40,13 @@ shopt -u nullglob
 
 # Composite actions (.github/actions/**/action.yml) at any nesting depth. `find`
 # rather than a `**` glob: globstar is bash 4+ only and this must also run under
-# the bash 3.2 that ships on macOS (local runs, .husky pre-commit).
+# the bash 3.2 that ships on macOS. `-L` follows symlinks so a symlinked
+# action.yml is included — matching the workflow glob above, which follows
+# symlinks too (the asymmetry was a #723 minor).
 if [ -d "$actions_dir" ]; then
   while IFS= read -r action_file; do
     files+=("$action_file")
-  done < <(find "$actions_dir" -type f \( -name action.yml -o -name action.yaml \))
+  done < <(find -L "$actions_dir" -type f \( -name action.yml -o -name action.yaml \))
 fi
 
 if [ ${#files[@]} -eq 0 ]; then
@@ -46,35 +54,4 @@ if [ ${#files[@]} -eq 0 ]; then
   exit 1
 fi
 
-for file in "${files[@]}"; do
-  rel="${file#"$repo_root"/}"
-  # `uses:` as a step/list key: optional leading "- ", then uses:. Skips comments
-  # and run-block prose (those don't start with an optional "- " + "uses:" key).
-  while IFS=: read -r lineno _; do
-    raw="$(sed -n "${lineno}p" "$file")"
-    # Strip up to and including "uses:", trailing "# comment", surrounding quotes/space.
-    value="${raw#*uses:}"
-    value="${value%%#*}"
-    value="$(echo "$value" | tr -d '\r' | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' -e 's/^["'\'']//' -e 's/["'\'']$//')"
-
-    # Excluded: local reusable workflows and docker image refs (not SHA-pinnable as a git ref).
-    case "$value" in
-      ./*) continue ;;
-      docker://*) continue ;;
-    esac
-
-    ref="${value##*@}"
-    if [ "$ref" = "$value" ] || ! [[ "$ref" =~ $sha_re ]]; then
-      printf '::error file=%s,line=%s::Action is not SHA-pinned: `%s`. Pin to a 40-char commit SHA with a version comment, e.g. `uses: owner/repo@<40-hex-sha> # v1.2.3`.\n' \
-        "$rel" "$lineno" "$value"
-      violations=$((violations + 1))
-    fi
-  done < <(grep -nE '^[[:space:]]*(-[[:space:]]+)?uses:[[:space:]]*[^[:space:]]' "$file")
-done
-
-if [ "$violations" -gt 0 ]; then
-  echo "::error::$violations GitHub Action(s) are not pinned to a commit SHA. See #635 — mutable tags are forbidden."
-  exit 1
-fi
-
-echo "All GitHub Actions \`uses:\` refs are SHA-pinned across ${#files[@]} file(s) in .github/workflows/ and .github/actions/. ✓"
+exec python3 "$script_dir/check-action-pins.py" "$repo_root" "${files[@]}"


### PR DESCRIPTION
Closes #723.

## The bypass (from #723, now fixed)

`scripts/check-action-pins.sh` matched `uses:` with a **line-anchored grep**, so flow-style YAML — which the GitHub Actions parser accepts — was invisible. Both of these passed the guard green while unpinned:

```yaml
steps: [{uses: actions/checkout@v4}]
```
```yaml
- { uses: actions/checkout@v4 }
```

An author had to write flow-style deliberately to sneak past — precisely the malice this guard exists to stop (#635).

## Fix

- **YAML-aware matcher.** New `scripts/check-action-pins.py` parses each file with a real YAML parser (PyYAML) and walks **every `uses` key at any nesting, in block and flow style**. `check-action-pins.sh` keeps file discovery + the `CHECK_ACTION_PINS_ROOT` test seam and delegates matching to it.
- **Symlinked composite actions (#723 minor).** `find -L` so a symlinked `action.yml` is scanned — symmetric with the workflow glob, which already follows symlinks. The old `find -type f` skipped them.
- **Self-test header (#723 minor).** No longer claims to prove rejection of *all* unpinned refs; it now states it exercises representative surfaces, and new evasions should land as a new failing case first.

## Runtime choice: python3 + PyYAML — and why

The runner (`ubuntu-latest`) is guaranteed to have **python3**, **node 22**, and **`yq`**. I chose python3 + PyYAML because:
- It's a **real YAML parser** (handles flow + block), unlike node (no built-in YAML) which would need an `npm install`.
- **No install at guard time and no third-party Action to pin** — so the guard can't reintroduce the unpinned-dependency risk it exists to prevent (node/`js-yaml` or `pip install` would).
- PyYAML ships with the **pre-installed `yamllint`** on the runner, and it's present on typical dev machines (verified locally, PyYAML 6.0.3). `yq` is guaranteed on the runner but absent locally, so I couldn't verify against it.
- **Fail-closed:** a missing PyYAML or an unparseable file exits non-zero — never a vacuous pass.

## Verification (local, bash 3.2.57 + python3.13/PyYAML 6.0.3 on macOS)

```
$ ./scripts/__tests__/check-action-pins.test.sh
ok   — fully pinned workflow + composite action + ./ and docker:// exclusions (exit 0)
ok   — unpinned tag in workflow is rejected (exit 1)
ok   — unpinned tag in composite action is rejected (#681) (exit 1)
ok   — empty .github fails loudly (no vacuous pass) (exit 1)
ok   — branch ref / short SHA rejected (exit 1)
ok   — flow-style mapping unpinned is rejected (#723) (exit 1)
ok   — flow-style sequence unpinned is rejected (#723) (exit 1)
ok   — flow-style correctly pinned is accepted (exit 0)
ok   — symlinked composite action.yml is scanned (#723) (exit 1)
check-action-pins.test.sh: all cases passed ✓

$ ./scripts/check-action-pins.sh
All GitHub Actions `uses:` refs are SHA-pinned across 8 file(s) in .github/workflows/ and .github/actions/. ✓
```

Also ran: the exact #723 flow-style repro → now exits 1 with a correct line number; quoted refs / `docker://…@sha256` / local reusable-workflow `uses:` → correctly pass; `shellcheck` on both shell files → clean (rc 0); `python3 -m py_compile` on the helper → OK.

Scope is `scripts/**` only (the guard workflow needed no change — python3 is pre-installed). No TS/Rust touched, so no web suite / typecheck.

> SENSITIVE (guards `.github/workflows/**`) — do not merge without adversarial review + gate. The `CHECK_ACTION_PINS_ROOT` seam lets a reviewer re-attack it directly.
