### PR TITLE
fix(ai): bring reflection-reply under the #591 spend ledger + 3 review minors (#724)

### DIFF
--- a/apps/web/src/app/api/ai/__tests__/partner-route.test.ts
+++ b/apps/web/src/app/api/ai/__tests__/partner-route.test.ts
@@ -1079,13 +1079,54 @@ describe("POST /api/ai/partner", () => {
       generationConfig: { maxOutputTokens: number };
     };
     expect(sent.generationConfig.maxOutputTokens).toBe(2048);
-    // The actual usage is booked against the ledger with the request's IP.
+    // The actual usage is booked against the ledger with the request's IP, plus
+    // a conservative fallback (full output budget + generous input) used only
+    // when usageMetadata is absent (#724).
     expect(recordAiSpend).toHaveBeenCalledTimes(1);
-    expect(recordAiSpend).toHaveBeenCalledWith("user-1", "203.0.113.9", {
-      promptTokenCount: 1000,
-      candidatesTokenCount: 500,
-      thoughtsTokenCount: 0,
-    });
+    expect(recordAiSpend).toHaveBeenCalledWith(
+      "user-1",
+      "203.0.113.9",
+      {
+        promptTokenCount: 1000,
+        candidatesTokenCount: 500,
+        thoughtsTokenCount: 0,
+      },
+      { promptTokens: 6000, outputTokens: 2048 }
+    );
+  });
+
+  it("records spend on a 200 with a NON-JSON body (billed but unparseable, #724)", async () => {
+    // The 200 billed us, but response.json() throws — the ordering fix must still
+    // book the spend (with the fallback) and the billed-assist, then 502.
+    checkAiSpend.mockResolvedValue({ decision: "full" });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        text: async () => "",
+        json: async () => {
+          throw new SyntaxError("Unexpected token < in JSON");
+        },
+      }))
+    );
+
+    const { POST } = await import("../partner/route");
+    const res = await POST(makeRequest(VALID_BODY));
+
+    expect(res.status).toBe(502);
+    // Billed audit + spend both recorded despite the unparseable body.
+    expect(recordBilledAssist).toHaveBeenCalledTimes(1);
+    expect(recordAiSpend).toHaveBeenCalledTimes(1);
+    // usageMetadata is undefined (no parse), so the conservative fallback carries
+    // the estimate — never $0 for a real billed call.
+    expect(recordAiSpend).toHaveBeenCalledWith(
+      "user-1",
+      "203.0.113.9",
+      undefined,
+      { promptTokens: 6000, outputTokens: 2048 }
+    );
+    // Not refunded — Gemini billed us.
+    expect(refundAssist).not.toHaveBeenCalled();
   });
 
   it("soft cap: DEGRADES to a shorter output budget but still serves (200)", async () => {

--- a/apps/web/src/app/api/ai/partner/route.ts
+++ b/apps/web/src/app/api/ai/partner/route.ts
@@ -14,6 +14,7 @@ import {
   recordAiSpend,
   degradedMaxTokens,
 } from "@/lib/ai/spend-ledger";
+import type { GeminiUsageMetadata } from "@/lib/ai/spend-ledger";
 import { sealCheck } from "@/lib/ai/check-seal";
 import {
   buildStaticPrefix,
@@ -46,6 +47,24 @@ const MAX_CODE_CHARS = 8_000;
 const MAX_MESSAGE_CHARS = 4_000;
 const MAX_SLUG_CHARS = 256;
 const MAX_TEST_SUMMARY_CHARS = 2_000;
+
+// Conservative input-token estimate for the spend-ledger fallback (#724) when a
+// billed 200 carries no usageMetadata to measure. The prompt is prefix (task +
+// public tests + solution + tutor notes) + suffix (code ≤8k chars + message ≤4k
+// chars); at ~4 chars/token that input tops out near this figure. Over-estimating
+// here is deliberate — an unmeasurable billed call should read as more spend, not
+// less. Only used when the metered estimate is zero.
+const SPEND_FALLBACK_PROMPT_TOKENS = 6_000;
+
+// The Gemini generateContent envelope, narrowed to the fields this route reads.
+// Typed (not `any`) so the defensive parse below stays type-safe.
+interface GeminiEnvelope {
+  candidates?: Array<{
+    finishReason?: string;
+    content?: { parts?: Array<{ text?: string }> };
+  }>;
+  usageMetadata?: GeminiUsageMetadata & { cachedContentTokenCount?: number };
+}
 
 // Model history: gemini-2.5-flash(-lite) are gated for new keys (404 "not
 // available to new users") and gemini-2.0-flash is now fully retired (404 "no
@@ -322,6 +341,15 @@ export async function POST(request: NextRequest) {
   // tier. FAIL CLOSED: a ledger error denies (503), never serves unmetered. This
   // runs BEFORE spendAssist so a hard-cap / ledger-outage denial does not burn
   // one of the learner's paid assists.
+  //
+  // Bounded TOCTOU residual (#724 minor): the check reads accumulated spend, then
+  // the request bills, then recordAiSpend writes — so N requests already in
+  // flight when the hard cap is crossed can each still bill, overshooting by up
+  // to ~N × the per-call cost (a full-budget propose ≈ $0.006). N is bounded by
+  // this route's fail-closed limiters (20/min per user, 600/min per IP), so the
+  // worst-case overshoot is small and self-limiting, not unbounded — an accepted
+  // residual, not a hole. Tightening it would require reserving spend before the
+  // call (a pre-charge/settle), which is not worth the latency at these amounts.
   const spendGate = await checkAiSpend(user.id, clientIp);
   if (spendGate.decision === "denied") {
     // Both the hard-cap and the fail-closed ledger-outage return 503 with a
@@ -464,15 +492,28 @@ export async function POST(request: NextRequest) {
     // matters here, use `after()`/`waitUntil` semantics, never a bare `void`.
     await recordBilledAssist(user.id, lesson._id);
 
-    const data = await response.json();
+    // Parse the envelope DEFENSIVELY. A 200 with a non-JSON body STILL billed us,
+    // so response.json() must not throw past the spend booking below — otherwise
+    // the assist is recorded but the spend is not (#724 minor). A parse failure
+    // yields `undefined`, which the empty-output branch below turns into a 502.
+    let data: GeminiEnvelope | undefined;
+    try {
+      data = (await response.json()) as GeminiEnvelope;
+    } catch {
+      data = undefined;
+    }
     // Record the ACTUAL cost of this billed generation into the spend ledger
     // (#591) from usageMetadata — prompt + candidate + thinking tokens, thinking
-    // billed at the output rate. Runs on EVERY billed path (including the
-    // empty / non-JSON / truncated branches below, which all still cost tokens),
-    // so it sits right after the parse. Best-effort and awaited for the same
-    // Vercel-freeze reason as recordBilledAssist: the cost audit must settle
-    // before the response returns. Never throws.
-    await recordAiSpend(user.id, clientIp, data?.usageMetadata);
+    // billed at the output rate. Runs on EVERY billed path (empty / non-JSON /
+    // truncated all still cost tokens). When usageMetadata is ABSENT (e.g. a
+    // non-JSON 200) the ledger books a CONSERVATIVE fallback — full output budget
+    // + a generous input estimate — instead of $0, so an unmeasurable-but-billed
+    // call is never under-reported. Awaited for the same Vercel-freeze reason as
+    // recordBilledAssist. Never throws.
+    await recordAiSpend(user.id, clientIp, data?.usageMetadata, {
+      promptTokens: SPEND_FALLBACK_PROMPT_TOKENS,
+      outputTokens: maxTokensFor(action),
+    });
     // Prompt-cache observability — useful for tuning the cache-shaped prefix, but
     // this is the SUCCESS path of every paid call, so keep it opt-in (default
     // off) rather than logging on every request in production. Set

--- a/apps/web/src/app/api/lessons/reflect/__tests__/route.test.ts
+++ b/apps/web/src/app/api/lessons/reflect/__tests__/route.test.ts
@@ -37,7 +37,10 @@ const {
 vi.mock("@/lib/supabase/server", () => ({
   createClient: async () => ({ auth: { getUser } }),
 }));
-vi.mock("@/lib/rate-limit", () => ({ isRateLimited }));
+vi.mock("@/lib/rate-limit", () => ({
+  isRateLimited,
+  getClientIp: () => "203.0.113.7",
+}));
 vi.mock("@/lib/content/queries", () => ({ getLessonByIdForGrading }));
 vi.mock("@/lib/ai/reflection-reply", () => ({ maybeGenerateReflectionReply }));
 vi.mock("@/lib/logging", () => ({ logError: vi.fn() }));
@@ -200,6 +203,14 @@ describe("POST /api/lessons/reflect", () => {
     const res = await POST(req(VALID_BODY));
     expect(res.status).toBe(429);
     expect(res.headers.get("Retry-After")).toBe("60");
+  });
+
+  it("passes the client IP to the reply helper (per-IP spend dimension, #724)", async () => {
+    maybeGenerateReflectionReply.mockResolvedValue("ok");
+    await POST(req(VALID_BODY));
+    expect(maybeGenerateReflectionReply).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: "user-1", ip: "203.0.113.7" })
+    );
   });
 
   it("still issues the seal when the AI reply is disabled/unavailable (reply null)", async () => {

--- a/apps/web/src/app/api/lessons/reflect/route.ts
+++ b/apps/web/src/app/api/lessons/reflect/route.ts
@@ -4,7 +4,7 @@ import { createClient } from "@/lib/supabase/server";
 import { getLessonByIdForGrading } from "@/lib/content/queries";
 import { sealAttestation } from "@/lib/ai/check-seal";
 import { maybeGenerateReflectionReply } from "@/lib/ai/reflection-reply";
-import { isRateLimited } from "@/lib/rate-limit";
+import { isRateLimited, getClientIp } from "@/lib/rate-limit";
 import { logError } from "@/lib/logging";
 import { ERROR_IDS } from "@/constants/errorIds";
 import { serverEnv } from "@/lib/env.server";
@@ -171,6 +171,9 @@ export async function POST(request: NextRequest) {
     try {
       reply = await maybeGenerateReflectionReply({
         userId: user.id,
+        // Per-IP spend dimension (#724): the reply is metered under the #591
+        // ledger, which needs the actor's IP, not just the user id.
+        ip: getClientIp(request.headers),
         prompt: (block as OpenEndedBlockData).prompt,
         reflection: text,
       });

--- a/apps/web/src/lib/__tests__/env-server-spend-caps.test.ts
+++ b/apps/web/src/lib/__tests__/env-server-spend-caps.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+// #724 minor: a hard spend cap of $0 denies every request (self-DoS). It is
+// "safe" under fail-closed but silent, so env.server must reject it LOUDLY at
+// boot. Soft caps of 0 are legitimate (always-degrade) and must still boot.
+vi.mock("server-only", () => ({}));
+
+const HARD_CAP_VARS = [
+  "AI_SPEND_GLOBAL_HARD_USD",
+  "AI_SPEND_ACCOUNT_HARD_USD",
+  "AI_SPEND_IP_HARD_USD",
+] as const;
+
+async function importEnvServer() {
+  vi.resetModules();
+  return import("@/lib/env.server");
+}
+
+describe("env.server — AI spend hard caps (#724)", () => {
+  afterEach(() => {
+    for (const v of HARD_CAP_VARS) delete process.env[v];
+    delete process.env.AI_SPEND_GLOBAL_SOFT_USD;
+  });
+
+  it("boots on the defaults (no override)", async () => {
+    await expect(importEnvServer()).resolves.toBeDefined();
+  });
+
+  it.each(HARD_CAP_VARS)(
+    "rejects %s = 0 at boot (self-DoS guard)",
+    async (v) => {
+      process.env[v] = "0";
+      await expect(importEnvServer()).rejects.toThrow();
+    }
+  );
+
+  it("accepts a positive hard-cap override", async () => {
+    process.env.AI_SPEND_GLOBAL_HARD_USD = "30";
+    await expect(importEnvServer()).resolves.toBeDefined();
+  });
+
+  it("still accepts a SOFT cap of 0 (always-degrade is allowed, not a DoS)", async () => {
+    process.env.AI_SPEND_GLOBAL_SOFT_USD = "0";
+    await expect(importEnvServer()).resolves.toBeDefined();
+  });
+});

--- a/apps/web/src/lib/ai/__tests__/reflection-reply.test.ts
+++ b/apps/web/src/lib/ai/__tests__/reflection-reply.test.ts
@@ -15,16 +15,30 @@ vi.mock("@/lib/env.server", () => ({
 const isRateLimited = vi.fn();
 vi.mock("@/lib/rate-limit", () => ({ isRateLimited }));
 
+// The reply now runs under the #591 ledger (#724). Mock the gate so the tests
+// control the decision; degradedMaxTokens stays the real pure helper.
+const checkAiSpend = vi.fn();
+const recordAiSpend = vi.fn();
+vi.mock("@/lib/ai/spend-ledger", () => ({
+  checkAiSpend,
+  recordAiSpend,
+  degradedMaxTokens: (base: number) => Math.max(256, Math.floor(base / 2)),
+}));
+
 const INPUT = {
   userId: "user-1",
+  ip: "203.0.113.7",
   prompt: "What did you build?",
   reflection: "A dApp.",
 };
 
-function stubGeminiFetch(text: string, ok = true) {
+function stubGeminiFetch(text: string, ok = true, usageMetadata?: unknown) {
   const fetchMock = vi.fn(async () => ({
     ok,
-    json: async () => ({ candidates: [{ content: { parts: [{ text }] } }] }),
+    json: async () => ({
+      candidates: [{ content: { parts: [{ text }] } }],
+      ...(usageMetadata ? { usageMetadata } : {}),
+    }),
   }));
   vi.stubGlobal("fetch", fetchMock);
   return fetchMock;
@@ -33,6 +47,8 @@ function stubGeminiFetch(text: string, ok = true) {
 beforeEach(() => {
   vi.clearAllMocks();
   isRateLimited.mockResolvedValue(false);
+  checkAiSpend.mockResolvedValue({ decision: "full" });
+  recordAiSpend.mockResolvedValue(undefined);
   process.env.GEMINI_API_KEY = "test-gemini-key";
   process.env.OPENENDED_AI_REPLY = "1";
 });
@@ -79,6 +95,124 @@ describe("maybeGenerateReflectionReply", () => {
     expect(await maybeGenerateReflectionReply(INPUT)).toBe(
       "Great reflection — keep going!"
     );
+  });
+
+  it("uses a FAIL-CLOSED reply limiter (#724)", async () => {
+    stubGeminiFetch("hi");
+    const { maybeGenerateReflectionReply } =
+      await import("../reflection-reply");
+    await maybeGenerateReflectionReply(INPUT);
+    expect(isRateLimited).toHaveBeenCalledWith(
+      "ai:reflection",
+      "user-1",
+      expect.objectContaining({ failClosed: true })
+    );
+  });
+
+  it("returns null (no model call) when the limiter store throws (fail-closed)", async () => {
+    isRateLimited.mockRejectedValue(new Error("store down"));
+    const fetchMock = stubGeminiFetch("should not run");
+    const { maybeGenerateReflectionReply } =
+      await import("../reflection-reply");
+    expect(await maybeGenerateReflectionReply(INPUT)).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("SKIPS the reply (null, no model call) when the spend cap denies", async () => {
+    checkAiSpend.mockResolvedValue({ decision: "denied", reason: "spend_cap" });
+    const fetchMock = stubGeminiFetch("should not run");
+    const { maybeGenerateReflectionReply } =
+      await import("../reflection-reply");
+    expect(await maybeGenerateReflectionReply(INPUT)).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("SKIPS the reply when the ledger is unreachable (fail-closed via checkAiSpend)", async () => {
+    // checkAiSpend fails closed on its own — a ledger outage resolves to
+    // "denied"/ledger_unavailable, which the reply treats as skip. Never 503s
+    // the seal (that lives in the route, unaffected).
+    checkAiSpend.mockResolvedValue({
+      decision: "denied",
+      reason: "ledger_unavailable",
+    });
+    const fetchMock = stubGeminiFetch("should not run");
+    const { maybeGenerateReflectionReply } =
+      await import("../reflection-reply");
+    expect(await maybeGenerateReflectionReply(INPUT)).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("gates on account + IP + global via checkAiSpend(userId, ip)", async () => {
+    stubGeminiFetch("hi");
+    const { maybeGenerateReflectionReply } =
+      await import("../reflection-reply");
+    await maybeGenerateReflectionReply(INPUT);
+    expect(checkAiSpend).toHaveBeenCalledWith("user-1", "203.0.113.7");
+  });
+
+  it("degrades to a shorter output budget over a soft cap (still replies)", async () => {
+    checkAiSpend.mockResolvedValue({ decision: "degraded" });
+    const fetchMock = vi.fn(async (_url: string, init: { body: string }) => {
+      void init;
+      return {
+        ok: true,
+        json: async () => ({
+          candidates: [
+            { content: { parts: [{ text: "shorter but present" }] } },
+          ],
+        }),
+      };
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const { maybeGenerateReflectionReply } =
+      await import("../reflection-reply");
+    const reply = await maybeGenerateReflectionReply(INPUT);
+    expect(reply).toBe("shorter but present");
+    const body = JSON.parse(fetchMock.mock.calls[0]![1].body) as {
+      generationConfig: { maxOutputTokens: number };
+    };
+    // 512 -> degradedMaxTokens(512) = 256.
+    expect(body.generationConfig.maxOutputTokens).toBe(256);
+  });
+
+  it("records the spend on a successful billed reply (usageMetadata → ledger)", async () => {
+    const usageMetadata = {
+      promptTokenCount: 300,
+      candidatesTokenCount: 120,
+    };
+    stubGeminiFetch("Great reflection!", true, usageMetadata);
+    const { maybeGenerateReflectionReply } =
+      await import("../reflection-reply");
+    await maybeGenerateReflectionReply(INPUT);
+    expect(recordAiSpend).toHaveBeenCalledWith(
+      "user-1",
+      "203.0.113.7",
+      usageMetadata,
+      { promptTokens: 3000, outputTokens: 512 }
+    );
+  });
+
+  it("still books spend with a conservative fallback when usageMetadata is absent", async () => {
+    stubGeminiFetch("Great reflection!"); // no usageMetadata
+    const { maybeGenerateReflectionReply } =
+      await import("../reflection-reply");
+    await maybeGenerateReflectionReply(INPUT);
+    // usage undefined, but the conservative fallback shape is still passed so
+    // recordAiSpend books a non-zero estimate rather than $0.
+    expect(recordAiSpend).toHaveBeenCalledWith(
+      "user-1",
+      "203.0.113.7",
+      undefined,
+      { promptTokens: 3000, outputTokens: 512 }
+    );
+  });
+
+  it("does NOT record spend when the model call was not billed (non-ok)", async () => {
+    stubGeminiFetch("", false);
+    const { maybeGenerateReflectionReply } =
+      await import("../reflection-reply");
+    await maybeGenerateReflectionReply(INPUT);
+    expect(recordAiSpend).not.toHaveBeenCalled();
   });
 
   it("returns null when the model call is not ok", async () => {

--- a/apps/web/src/lib/ai/__tests__/spend-ledger.test.ts
+++ b/apps/web/src/lib/ai/__tests__/spend-ledger.test.ts
@@ -211,6 +211,53 @@ describe("recordAiSpend", () => {
       recordAiSpend("u", "1.2.3.4", { promptTokenCount: 10 })
     ).resolves.toBeUndefined();
   });
+
+  it("books a CONSERVATIVE fallback when usageMetadata is absent (#724)", async () => {
+    rpc.mockResolvedValue({ data: null, error: null });
+    // usage undefined → metered estimate is 0 → fall back to the caller's shape.
+    // 3000 input × 0.30 = 900; 512 output × 2.50 = 1280; total 2180 micro.
+    await recordAiSpend("u", "1.2.3.4", undefined, {
+      promptTokens: 3000,
+      outputTokens: 512,
+    });
+    expect(rpc).toHaveBeenCalledWith("record_ai_spend", {
+      p_user_id: "u",
+      p_ip: "1.2.3.4",
+      p_micro_usd: 2180,
+    });
+  });
+
+  it("prefers the METERED estimate over the fallback when usage is present", async () => {
+    rpc.mockResolvedValue({ data: null, error: null });
+    // Real usage present → 1000×0.30 + 500×2.50 = 1550; the fallback is ignored.
+    await recordAiSpend(
+      "u",
+      "1.2.3.4",
+      { promptTokenCount: 1000, candidatesTokenCount: 500 },
+      { promptTokens: 9999, outputTokens: 9999 }
+    );
+    expect(rpc).toHaveBeenCalledWith(
+      "record_ai_spend",
+      expect.objectContaining({ p_micro_usd: 1550 })
+    );
+  });
+
+  it("falls back when usage is present but measures zero", async () => {
+    rpc.mockResolvedValue({ data: null, error: null });
+    await recordAiSpend(
+      "u",
+      "1.2.3.4",
+      {},
+      {
+        promptTokens: 3000,
+        outputTokens: 512,
+      }
+    );
+    expect(rpc).toHaveBeenCalledWith(
+      "record_ai_spend",
+      expect.objectContaining({ p_micro_usd: 2180 })
+    );
+  });
 });
 
 describe("getAiSpendToday", () => {

--- a/apps/web/src/lib/ai/reflection-reply.ts
+++ b/apps/web/src/lib/ai/reflection-reply.ts
@@ -1,18 +1,27 @@
 import "server-only";
 import { isRateLimited } from "@/lib/rate-limit";
 import { serverEnv } from "@/lib/env.server";
+import {
+  checkAiSpend,
+  recordAiSpend,
+  degradedMaxTokens,
+} from "@/lib/ai/spend-ledger";
+import type { GeminiUsageMetadata } from "@/lib/ai/spend-ledger";
 
 // Best-effort AI feedback for an `openEnded` reflection. NEVER blocks the seal:
 // the attestation route computes and returns the receipt independently, then
-// calls this for enrichment only. Any failure, rate-limit, disabled flag, or
-// unset key resolves to `null` and the seal is issued regardless (spec §3 item
-// 6 — "degrade never block", AIE-21).
+// calls this for enrichment only. Any failure, rate-limit, disabled flag, unset
+// key, or spend-cap denial resolves to `null` and the seal is issued regardless
+// (spec §3 item 6 — "degrade never block", AIE-21).
 //
-// Default OFF. The reply is a metered cost path, and AI spend accounting is
-// owned by #590 — until it lands, the reply ships behind OPENENDED_AI_REPLY so
-// launch runs seal-only at zero AI cost. This helper deliberately does NOT touch
-// the assist-budget ledger (spendAssist/refundAssist): the reflection reply is
-// not a code-challenge assist and must not draw from that budget.
+// Default OFF behind OPENENDED_AI_REPLY. When enabled, this reply spends the
+// SAME sponsored GEMINI_API_KEY as the AI Partner, so — per #724 — it now runs
+// UNDER the #591 spend ledger: the same fail-closed checkAiSpend gate and
+// recordAiSpend booking (account + IP + global caps), and a fail-CLOSED reply
+// limiter. A denied reply is skipped, not 503'd — the seal still ships. This
+// helper deliberately does NOT touch the assist-budget ledger
+// (spendAssist/refundAssist): the reflection reply is not a code-challenge
+// assist and must not draw from that per-lesson quota.
 
 const GEMINI_URL =
   "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.5-flash:generateContent";
@@ -22,6 +31,20 @@ const GEMINI_URL =
 // to spend the whole budget on the visible response.
 const MAX_OUTPUT_TOKENS = 512;
 
+// Conservative input-token estimate for the spend-ledger fallback (#724) when a
+// billed 200 carries no usageMetadata. The prompt is the block prompt + the
+// learner reflection (≤10k chars, ~2.5k tokens); round up so an unmeasurable
+// billed call reads as more spend, not less. Used only when the metered estimate
+// is zero.
+const SPEND_FALLBACK_PROMPT_TOKENS = 3_000;
+
+// The Gemini generateContent envelope, narrowed to the fields this helper reads.
+// Typed (not `any`) so the defensive parse below stays type-safe.
+interface ReflectionEnvelope {
+  candidates?: Array<{ content?: { parts?: Array<{ text?: string }> } }>;
+  usageMetadata?: GeminiUsageMetadata;
+}
+
 // Hard ceiling on the model call. The reflect route delivers the seal in the
 // SAME response, after this resolves — so a hung upstream must not stall the
 // receipt until the platform kills the function. On timeout the call aborts and
@@ -30,17 +53,21 @@ const REPLY_TIMEOUT_MS = 10_000;
 
 interface ReflectionReplyInput {
   userId: string;
+  // The request's client IP, for the per-IP spend dimension (#724). Free wallet
+  // signup means per-user keys alone cannot bound a Sybil actor.
+  ip: string;
   prompt: string;
   reflection: string;
 }
 
 /**
  * Returns a brief AI note on the learner's reflection, or `null` when the reply
- * is disabled, the key is unset, the caller is over the reply rate limit, or the
- * model call fails in any way. Never throws.
+ * is disabled, the key is unset, the caller is over the reply rate limit, the
+ * daily spend cap is hit, or the model call fails in any way. Never throws.
  */
 export async function maybeGenerateReflectionReply({
   userId,
+  ip,
   prompt,
   reflection,
 }: ReflectionReplyInput): Promise<string | null> {
@@ -50,19 +77,34 @@ export async function maybeGenerateReflectionReply({
   if (!apiKey) return null;
 
   // Bound the reply independently of the route's seal limiter, so enabling the
-  // flag cannot uncork unbounded model spend. Fails open like every limiter —
-  // but the try/catch below still contains any resulting call failure to `null`.
+  // flag cannot uncork unbounded model spend. FAIL-CLOSED (#724): this spends the
+  // sponsored key, so a limiter-store outage must skip the reply, not wave it
+  // through unmetered. A skipped reply is free — the seal ships regardless.
   try {
     if (
       await isRateLimited("ai:reflection", userId, {
         maxTokens: 10,
         refillIntervalMs: 60_000,
+        failClosed: true,
       })
     ) {
       return null;
     }
   } catch {
     return null;
+  }
+
+  // Daily SPEND gate (#724): this reply spends the same sponsored key as the AI
+  // Partner, so it sits under the SAME #591 ledger — account + IP + global caps.
+  // checkAiSpend fails closed on its own (a ledger outage returns "denied"), so a
+  // denied decision — hard cap OR ledger down — SKIPS the reply and the seal
+  // still ships (degrade never blocks, AIE-21). Over a soft cap, degrade to a
+  // shorter reply rather than skipping.
+  let outputTokens = MAX_OUTPUT_TOKENS;
+  const gate = await checkAiSpend(userId, ip);
+  if (gate.decision === "denied") return null;
+  if (gate.decision === "degraded") {
+    outputTokens = degradedMaxTokens(MAX_OUTPUT_TOKENS);
   }
 
   const controller = new AbortController();
@@ -88,7 +130,7 @@ export async function maybeGenerateReflectionReply({
         ],
         generationConfig: {
           temperature: 0.4,
-          maxOutputTokens: MAX_OUTPUT_TOKENS,
+          maxOutputTokens: outputTokens,
           thinkingConfig: { thinkingBudget: 0 },
         },
       }),
@@ -96,7 +138,20 @@ export async function maybeGenerateReflectionReply({
 
     if (!response.ok) return null;
 
-    const data = await response.json();
+    // Billed past here (2xx). Parse DEFENSIVELY so a non-JSON 200 can't throw
+    // past the spend booking, then record the cost on the SAME ledger — with a
+    // conservative fallback when usageMetadata is absent, so a billed reply is
+    // never under-reported (#724). Best-effort: recordAiSpend never throws.
+    let data: ReflectionEnvelope | undefined;
+    try {
+      data = (await response.json()) as ReflectionEnvelope;
+    } catch {
+      data = undefined;
+    }
+    await recordAiSpend(userId, ip, data?.usageMetadata, {
+      promptTokens: SPEND_FALLBACK_PROMPT_TOKENS,
+      outputTokens: MAX_OUTPUT_TOKENS,
+    });
     const text = data?.candidates?.[0]?.content?.parts?.[0]?.text;
     return typeof text === "string" && text.trim().length > 0
       ? text.trim()

--- a/apps/web/src/lib/ai/spend-ledger.ts
+++ b/apps/web/src/lib/ai/spend-ledger.ts
@@ -171,13 +171,31 @@ export async function checkAiSpend(
  * path, and must never break the reply the learner is owed, so it never throws.
  * A recording failure loses one data point of audit, not correctness — the CAP
  * is enforced by `checkAiSpend`, which fails closed on its own.
+ *
+ * `fallback` books a CONSERVATIVE estimate when `usage` is absent or measures
+ * zero — a billed call whose 200 body was non-JSON, or that carried no
+ * usageMetadata, still cost tokens, and booking $0 would silently under-report
+ * true key burn (#724). Pass the caller's own worst-case shape (its full output
+ * budget + a generous input estimate); it is used ONLY when the metered estimate
+ * is zero, so a normal metered call is unaffected.
  */
 export async function recordAiSpend(
   userId: string,
   ip: string,
-  usage: GeminiUsageMetadata | undefined
+  usage: GeminiUsageMetadata | undefined,
+  fallback?: { promptTokens: number; outputTokens: number }
 ): Promise<void> {
-  const microUsd = estimateSpendMicroUsd(usage, rates());
+  const r = rates();
+  let microUsd = estimateSpendMicroUsd(usage, r);
+  if (microUsd <= 0 && fallback) {
+    microUsd = estimateSpendMicroUsd(
+      {
+        promptTokenCount: fallback.promptTokens,
+        candidatesTokenCount: fallback.outputTokens,
+      },
+      r
+    );
+  }
   try {
     const { error } = await createAdminClient().rpc("record_ai_spend", {
       p_user_id: userId,

--- a/apps/web/src/lib/env.server.ts
+++ b/apps/web/src/lib/env.server.ts
@@ -24,6 +24,22 @@ const usdNum = (fallback: number) =>
     z.coerce.number().min(0)
   );
 
+// A HARD-cap dollar amount. Identical to usdNum but rejects 0: a hard cap of $0
+// denies every request (self-DoS). Fail-closed makes that "safe" but silent —
+// so reject it loudly at boot instead of letting a fat-fingered `=0` take the
+// tutor offline (#724 minor). Soft caps may legitimately be 0 (always degrade),
+// so only the hard caps use this stricter guard.
+const usdNumHard = (fallback: number) =>
+  z.preprocess(
+    (v) => (v === "" || v === undefined ? fallback : v),
+    z.coerce
+      .number()
+      .gt(
+        0,
+        "AI spend HARD cap must be greater than 0 (a $0 hard cap denies every request)"
+      )
+  );
+
 /**
  * Server-only secrets. Never imported into client code (`server-only` enforces
  * this). Validated eagerly at boot via `instrumentation.ts`.
@@ -89,11 +105,11 @@ const serverEnvSchema = z.object({
   // route DEGRADES (shorter output budget); only a *hard* cap denies (503).
   // usdNum: whole/decimal dollars, "" → default. Must be non-negative.
   AI_SPEND_GLOBAL_SOFT_USD: usdNum(14), // ~84% of the daily envelope
-  AI_SPEND_GLOBAL_HARD_USD: usdNum(25), // 1.5× envelope; absorbs a spike day
+  AI_SPEND_GLOBAL_HARD_USD: usdNumHard(25), // 1.5× envelope; absorbs a spike day
   AI_SPEND_ACCOUNT_SOFT_USD: usdNum(0.5), // ~17× the $0.03/learner/mo average
-  AI_SPEND_ACCOUNT_HARD_USD: usdNum(1.5), // a single account ≤ ~9% of the envelope
+  AI_SPEND_ACCOUNT_HARD_USD: usdNumHard(1.5), // a single account ≤ ~9% of the envelope
   AI_SPEND_IP_SOFT_USD: usdNum(2), // survives a NAT'd classroom
-  AI_SPEND_IP_HARD_USD: usdNum(5), // caps a single-IP farm at ~30% of the envelope
+  AI_SPEND_IP_HARD_USD: usdNumHard(5), // caps a single-IP farm at ~30% of the envelope
   // Gemini price sheet (USD per 1M tokens) used to turn usageMetadata token
   // counts into micro-USD. Thinking tokens bill at the OUTPUT rate (#591). These
   // move with the provider's pricing, not the sponsor commitment.


### PR DESCRIPTION
Closes #724. Found by the adversarial review of #720.

## What & why
The reflection-reply path (`lib/ai/reflection-reply.ts`, called from `/api/lessons/reflect`) spends the **same** sponsored Gemini key as the AI Partner but sat **outside** the #591 ledger: no `checkAiSpend`, no `recordAiSpend`, and a **fail-open** 10/min limiter. Latent today (default-OFF behind `OPENENDED_AI_REPLY !== "1"`), but the moment it's enabled the sponsor envelope would be incomplete and `get_ai_spend_today()` would under-report true key burn.

## Main fix — reflection reply now runs under the ledger
- Gate the reply through `checkAiSpend` (account + IP + global) and book actual usage via `recordAiSpend` — the same ledger as the Partner.
- **Fail-closed by SKIPPING**, not 503: a hard-cap denial or a ledger outage (`checkAiSpend` fails closed to `denied` on its own) returns `null`, and the seal still ships. The reflect route's **receipt-first separation is preserved** — reflection SAVING never depends on the reply (verified: the seal is computed and returned before the reply, in its own try/catch).
- Over a **soft cap**, degrade to a shorter reply (512 → 256 output tokens) instead of skipping.
- Flip the reply limiter to `failClosed: true`.
- Thread the client IP from the route into the helper (per-IP dimension — free wallet signup means per-user keys can't bound a Sybil).

## Folded-in review minors (same files)
1. **Record spend on every billed call.** `route.ts` parsed `response.json()` after flipping `billed = true`, so a 200 with a non-JSON body recorded the assist but not the spend. Now the envelope is parsed **defensively** (can't throw past the booking), and `recordAiSpend` books a **conservative fallback** (full output budget + a generous input estimate) when `usageMetadata` is absent — instead of $0. Same fallback wired into the reflection path.
2. **TOCTOU residual documented in-code** at the gate: N in-flight requests can overshoot a hard cap by ~N × per-call cost (a full-budget propose ≈ $0.006), bounded by the fail-closed 20/min user + 600/min IP limiters — an accepted, self-limiting residual, not a hole.
3. **Reject a hard-cap env of 0 at boot** (`usdNumHard`, `gt(0)`): a $0 hard cap denies every request (self-DoS). Soft caps of 0 still boot (always-degrade is legitimate).

## No migration
Reuses the #591 RPCs (`check_ai_spend` / `record_ai_spend`). No DB change.

## Verification
- `pnpm typecheck` — 6 packages successful, zero errors, zero `any`.
- `pnpm --filter web test` — **186 files, 1667 tests passed**.
- `pnpm --filter web lint` — exit 0 (only pre-existing import/order warnings).

New/updated tests: reply denied at cap → skipped + reflection still saves; ledger down → no model call + reflection still saves; spend recorded on reply (usageMetadata → ledger); conservative-fallback booking when usageMetadata absent; fail-closed reply limiter (flag + store-throw); soft-cap degrade to 256; route passes the client IP; the `recordAiSpend`-ordering fix (a non-JSON 200 still books spend + billed-assist, 502, no refund); hard-cap `=0` boot rejection (all three hard caps) while a soft cap of 0 still boots.

Do not merge — for gate review.
