### PR TITLE
feat(courses): course changelog on course pages (#654)

### DIFF
--- a/apps/web/src/app/[locale]/(platform)/courses/[slug]/course-detail-client.tsx
+++ b/apps/web/src/app/[locale]/(platform)/courses/[slug]/course-detail-client.tsx
@@ -26,7 +26,9 @@ import { useOnChainEnroll } from "@/hooks/use-on-chain-enroll";
 import { findEnrollmentPDA } from "@/lib/solana/pda";
 import { ThreadList } from "@/components/community/thread-list";
 import { CreateThreadModal } from "@/components/community/create-thread-modal";
+import { CourseChangelog } from "@/components/course/course-changelog";
 import type { PublicProfile } from "@/lib/profiles/public-profile";
+import type { CourseChangelogEntry } from "@/lib/courses/changelog-types";
 
 interface CourseDetailClientProps {
   course: Course;
@@ -36,11 +38,17 @@ interface CourseDetailClientProps {
    * so the instructor section never has to fetch client-side.
    */
   instructorProfile: PublicProfile | null;
+  /**
+   * The course's post-deployment evolution log (issue #654), read server-side
+   * and passed in already decoded. Rendered below the curriculum.
+   */
+  changelog: CourseChangelogEntry[];
 }
 
 export function CourseDetailClient({
   course,
   instructorProfile,
+  changelog,
 }: CourseDetailClientProps) {
   const t = useTranslations("courses");
   const tCommon = useTranslations("common");
@@ -73,6 +81,9 @@ export function CourseDetailClient({
   const walletAddress = authProfile?.wallet_address ?? null;
 
   const [isEnrolled, setIsEnrolled] = useState(false);
+  // ISO enrollment timestamp — lets the changelog flag entries newer than the
+  // learner's enrollment (issue #654 point 3). Null when signed-out/unenrolled.
+  const [enrolledAt, setEnrolledAt] = useState<string | null>(null);
   const [completedLessons, setCompletedLessons] = useState<string[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [discussionModalOpen, setDiscussionModalOpen] = useState(false);
@@ -92,10 +103,12 @@ export function CourseDetailClient({
       // (enrollment PDA exists on-chain but Supabase has no record).
       const { data: enrollment } = await supabase
         .from("enrollments")
-        .select("id")
+        .select("id, enrolled_at")
         .eq("user_id", userId)
         .eq("course_id", course._id)
         .maybeSingle();
+
+      setEnrolledAt(enrollment?.enrolled_at ?? null);
 
       let enrolled = !!enrollment;
 
@@ -374,6 +387,9 @@ export function CourseDetailClient({
           />
         )}
       </div>
+
+      {/* Changelog (issue #654) — how the course has evolved since deployment. */}
+      <CourseChangelog entries={changelog} enrolledAt={enrolledAt} />
     </div>
   );
 }

--- a/apps/web/src/app/[locale]/(platform)/courses/[slug]/page.tsx
+++ b/apps/web/src/app/[locale]/(platform)/courses/[slug]/page.tsx
@@ -1,8 +1,9 @@
 import { notFound } from "next/navigation";
-import { CourseDetailClient } from "./course-detail-client";
 import { getCourseBySlug } from "@/lib/content/queries";
 import { resolvePublicProfileByWallet } from "@/lib/profiles/public-profile";
+import { getCourseChangelog } from "@/lib/courses/changelog";
 import { createClient } from "@/lib/supabase/server";
+import { CourseDetailClient } from "./course-detail-client";
 
 interface CourseDetailPageProps {
   params: Promise<{ slug: string }>;
@@ -23,7 +24,15 @@ export default async function CourseDetailPage({
     ? await resolvePublicProfileByWallet(await createClient(), course.creator)
     : null;
 
+  // Course changelog (#654) — the post-deployment evolution log, read server-
+  // side through the public RLS policy and passed down already decoded.
+  const changelog = await getCourseChangelog(course._id);
+
   return (
-    <CourseDetailClient course={course} instructorProfile={instructorProfile} />
+    <CourseDetailClient
+      course={course}
+      instructorProfile={instructorProfile}
+      changelog={changelog}
+    />
   );
 }

--- a/apps/web/src/app/api/admin/courses/sync/route.ts
+++ b/apps/web/src/app/api/admin/courses/sync/route.ts
@@ -327,17 +327,20 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
 
     // Course changelog (#654): record the first on-chain deploy. Non-fatal —
     // the course is already live; a missing log entry must not fail the sync.
-    try {
-      await recordCourseDeployed({
-        courseId,
-        txSignature: result.signature!,
-        lessonCount: course.lessonCount,
-      });
-    } catch (changelogErr) {
-      console.error(
-        "[admin/courses/sync] changelog (deploy) failed:",
-        changelogErr
-      );
+    // tx_signature is NOT NULL (the dedup key), so only log with a real sig.
+    if (result.signature) {
+      try {
+        await recordCourseDeployed({
+          courseId,
+          txSignature: result.signature,
+          lessonCount: course.lessonCount,
+        });
+      } catch (changelogErr) {
+        console.error(
+          "[admin/courses/sync] changelog (deploy) failed:",
+          changelogErr
+        );
+      }
     }
 
     // The course is now "synced" in Sanity — purge the catalog cache so it
@@ -576,12 +579,12 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   // state is in `updateParams`. `content_tx_id` being committed bumps the
   // on-chain version by 1 (update_course.rs). Non-fatal: a missing log entry
   // must not fail a landed on-chain update.
-  if (onChainCourse) {
+  if (onChainCourse && result.signature) {
     try {
       const contentCommitted = updateParams.contentTxId !== undefined;
       await recordCourseUpdate({
         courseId,
-        txSignature: result.signature!,
+        txSignature: result.signature,
         oldMask: onChainCourse.activeLessons,
         newMask: updateParams.newActiveLessons,
         oldXp: onChainCourse.xp_per_lesson,

--- a/apps/web/src/app/api/admin/courses/sync/route.ts
+++ b/apps/web/src/app/api/admin/courses/sync/route.ts
@@ -34,6 +34,10 @@ import {
   writeCourseOnChainStatus,
   writeCourseTrackCollection,
 } from "@/lib/content/deployment-writes";
+import {
+  recordCourseDeployed,
+  recordCourseUpdate,
+} from "@/lib/content/changelog-writes";
 import { slotsByCourseId } from "@/lib/content/store";
 import { SYNCED_SHA } from "@/lib/content/meta";
 import { MaskMismatchError } from "@/lib/github/types";
@@ -321,6 +325,21 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
       );
     }
 
+    // Course changelog (#654): record the first on-chain deploy. Non-fatal —
+    // the course is already live; a missing log entry must not fail the sync.
+    try {
+      await recordCourseDeployed({
+        courseId,
+        txSignature: result.signature!,
+        lessonCount: course.lessonCount,
+      });
+    } catch (changelogErr) {
+      console.error(
+        "[admin/courses/sync] changelog (deploy) failed:",
+        changelogErr
+      );
+    }
+
     // The course is now "synced" in Sanity — purge the catalog cache so it
     // appears immediately instead of after the 1h ISR window.
     revalidateTag(COURSES_CACHE_TAG);
@@ -549,6 +568,34 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
       "[admin/courses/sync] deployment write-back failed:",
       mutationErr
     );
+  }
+
+  // Course changelog (#654): record what this update_course changed — lessons
+  // added/retired (diffed from the mask), an xp-per-lesson delta, or a pure
+  // content re-sync. `onChainCourse` is the PRE-update state; the intended new
+  // state is in `updateParams`. `content_tx_id` being committed bumps the
+  // on-chain version by 1 (update_course.rs). Non-fatal: a missing log entry
+  // must not fail a landed on-chain update.
+  if (onChainCourse) {
+    try {
+      const contentCommitted = updateParams.contentTxId !== undefined;
+      await recordCourseUpdate({
+        courseId,
+        txSignature: result.signature!,
+        oldMask: onChainCourse.activeLessons,
+        newMask: updateParams.newActiveLessons,
+        oldXp: onChainCourse.xp_per_lesson,
+        newXp: updateParams.newXpPerLesson,
+        contentCommitted,
+        newVersion: onChainCourse.version + (contentCommitted ? 1 : 0),
+        contentSha: SYNCED_SHA,
+      });
+    } catch (changelogErr) {
+      console.error(
+        "[admin/courses/sync] changelog (update) failed:",
+        changelogErr
+      );
+    }
   }
 
   revalidateTag(COURSES_CACHE_TAG);

--- a/apps/web/src/components/course/__tests__/course-changelog.test.tsx
+++ b/apps/web/src/components/course/__tests__/course-changelog.test.tsx
@@ -1,0 +1,109 @@
+// @vitest-environment jsdom
+import type { ReactElement } from "react";
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import type { CourseChangelogEntry } from "@/lib/courses/changelog-types";
+import messages from "@/messages/en.json";
+import { CourseChangelog } from "../course-changelog";
+
+function renderWithIntl(ui: ReactElement) {
+  return render(
+    <NextIntlClientProvider locale="en" messages={messages}>
+      {ui}
+    </NextIntlClientProvider>
+  );
+}
+
+const entries: CourseChangelogEntry[] = [
+  {
+    id: 3,
+    kind: "lessons_added",
+    version: 2,
+    txSignature: "S3",
+    createdAt: "2026-07-25T12:00:00Z",
+    detail: { lessons: [{ slot: 2, id: "lesson-c", title: "Advanced PDAs" }] },
+  },
+  {
+    id: 2,
+    kind: "xp_changed",
+    version: 1,
+    txSignature: "S2",
+    createdAt: "2026-07-24T12:00:00Z",
+    detail: { from: 10, to: 20 },
+  },
+  {
+    id: 1,
+    kind: "deployed",
+    version: 1,
+    txSignature: "S1",
+    createdAt: "2026-07-23T12:00:00Z",
+    detail: { lessonCount: 5 },
+  },
+];
+
+describe("CourseChangelog", () => {
+  it("renders the section heading", () => {
+    renderWithIntl(<CourseChangelog entries={entries} />);
+    expect(
+      screen.getByRole("heading", { name: /changelog/i })
+    ).toBeInTheDocument();
+  });
+
+  it("renders a human-readable line per entry kind", () => {
+    renderWithIntl(<CourseChangelog entries={entries} />);
+    expect(screen.getByText("Course published")).toBeInTheDocument();
+    expect(screen.getByText("1 lesson added")).toBeInTheDocument();
+    expect(screen.getByText("Advanced PDAs")).toBeInTheDocument();
+    expect(screen.getByText("XP reward changed")).toBeInTheDocument();
+    expect(
+      screen.getByText("XP per lesson changed from 10 to 20.")
+    ).toBeInTheDocument();
+  });
+
+  it("stamps each entry with a version and a machine-readable date", () => {
+    const { container } = renderWithIntl(<CourseChangelog entries={entries} />);
+    expect(screen.getAllByText("v1").length).toBeGreaterThan(0);
+    expect(screen.getByText("v2")).toBeInTheDocument();
+    const times = container.querySelectorAll("time[datetime]");
+    expect(times.length).toBe(entries.length);
+  });
+
+  it("falls back to the slot number when a lesson has no title snapshot", () => {
+    renderWithIntl(
+      <CourseChangelog
+        entries={[
+          {
+            id: 9,
+            kind: "lessons_removed",
+            version: 4,
+            txSignature: "S9",
+            createdAt: "2026-07-26T12:00:00Z",
+            detail: { lessons: [{ slot: 7, id: null, title: null }] },
+          },
+        ]}
+      />
+    );
+    expect(screen.getByText("Lesson slot 7")).toBeInTheDocument();
+  });
+
+  it("renders an empty state when there are no entries", () => {
+    renderWithIntl(<CourseChangelog entries={[]} />);
+    expect(screen.getByText(/No changes recorded yet/i)).toBeInTheDocument();
+  });
+
+  it("flags entries newer than the learner's enrollment", () => {
+    // Enrolled on the 24th → only the 25th 'lessons_added' entry is new.
+    renderWithIntl(
+      <CourseChangelog entries={entries} enrolledAt="2026-07-24T18:00:00Z" />
+    );
+    expect(screen.getByText("New")).toBeInTheDocument();
+    expect(screen.getByText("1 update since you enrolled")).toBeInTheDocument();
+  });
+
+  it("shows no since-enrolled badge for a signed-out visitor", () => {
+    renderWithIntl(<CourseChangelog entries={entries} enrolledAt={null} />);
+    expect(screen.queryByText(/since you enrolled/i)).not.toBeInTheDocument();
+    expect(screen.queryByText("New")).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/course/course-changelog.tsx
+++ b/apps/web/src/components/course/course-changelog.tsx
@@ -1,0 +1,224 @@
+"use client";
+
+import { useMemo } from "react";
+import { useTranslations, useLocale } from "next-intl";
+import {
+  ClockCounterClockwise,
+  RocketLaunch,
+  PlusCircle,
+  MinusCircle,
+  Lightning,
+  ArrowsClockwise,
+} from "@phosphor-icons/react";
+import type {
+  CourseChangelogEntry,
+  ChangelogLessonRef,
+} from "@/lib/courses/changelog-types";
+
+interface CourseChangelogProps {
+  entries: CourseChangelogEntry[];
+  /**
+   * ISO timestamp the current learner enrolled, or `null` when signed-out /
+   * not enrolled. Entries newer than this are flagged "new since you enrolled"
+   * (issue #654 point 3) — a date compare, not an on-chain generation read.
+   */
+  enrolledAt?: string | null;
+}
+
+function iconFor(kind: CourseChangelogEntry["kind"]) {
+  switch (kind) {
+    case "deployed":
+      return RocketLaunch;
+    case "lessons_added":
+      return PlusCircle;
+    case "lessons_removed":
+      return MinusCircle;
+    case "xp_changed":
+      return Lightning;
+    case "content_updated":
+      return ArrowsClockwise;
+  }
+}
+
+/**
+ * Course changelog (#654) — learner-visible log of how a course evolved after
+ * deployment (lessons added/retired, xp changes, content re-syncs). Data is
+ * captured server-side at mutation time and passed in already decoded; this
+ * component only formats it. Titles are snapshots taken when the change
+ * happened, so a since-retired lesson still reads under its original name.
+ */
+export function CourseChangelog({ entries, enrolledAt }: CourseChangelogProps) {
+  const t = useTranslations("courses");
+  const locale = useLocale();
+
+  const dateFmt = useMemo(
+    () => new Intl.DateTimeFormat(locale, { dateStyle: "medium" }),
+    [locale]
+  );
+
+  const enrolledAtMs = enrolledAt ? Date.parse(enrolledAt) : NaN;
+  const newSinceEnrolled = useMemo(() => {
+    if (Number.isNaN(enrolledAtMs)) return 0;
+    return entries.filter((e) => Date.parse(e.createdAt) > enrolledAtMs).length;
+  }, [entries, enrolledAtMs]);
+
+  return (
+    <section
+      aria-labelledby="course-changelog-heading"
+      className="space-y-4 border-t border-border pt-6"
+    >
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <h2
+          id="course-changelog-heading"
+          className="flex items-center gap-2 font-display text-2xl font-extrabold"
+        >
+          <ClockCounterClockwise
+            size={24}
+            weight="duotone"
+            className="text-primary"
+            aria-hidden="true"
+          />
+          {t("changelog")}
+        </h2>
+        {newSinceEnrolled > 0 && (
+          <span className="border-primary/40 bg-primary/10 inline-flex items-center gap-1.5 rounded-full border px-3 py-1 font-display text-xs font-bold text-primary">
+            {t("changelogSinceEnrolled", { count: newSinceEnrolled })}
+          </span>
+        )}
+      </div>
+
+      {entries.length === 0 ? (
+        <p className="text-sm text-text-3">{t("changelogEmpty")}</p>
+      ) : (
+        <ol className="space-y-3">
+          {entries.map((entry) => {
+            const Icon = iconFor(entry.kind);
+            const isNew =
+              !Number.isNaN(enrolledAtMs) &&
+              Date.parse(entry.createdAt) > enrolledAtMs;
+            return (
+              <li
+                key={entry.id}
+                className={`rounded-xl border-[2px] bg-card p-4 shadow-card ${
+                  isNew ? "border-primary/50" : "border-border"
+                }`}
+              >
+                <div className="flex items-start gap-3">
+                  <Icon
+                    size={22}
+                    weight="duotone"
+                    className="mt-0.5 shrink-0 text-primary"
+                    aria-hidden="true"
+                  />
+                  <div className="min-w-0 flex-1 space-y-1">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <span className="font-display text-sm font-bold text-text">
+                        <ChangelogTitle entry={entry} t={t} />
+                      </span>
+                      {isNew && (
+                        <span className="rounded-full bg-primary px-2 py-0.5 font-mono text-[10px] font-bold uppercase tracking-wider text-primary-foreground">
+                          {t("changelogNew")}
+                        </span>
+                      )}
+                    </div>
+                    <ChangelogBody entry={entry} t={t} />
+                    <div className="flex flex-wrap items-center gap-2 pt-0.5 text-xs text-text-3">
+                      <time dateTime={entry.createdAt}>
+                        {dateFmt.format(new Date(entry.createdAt))}
+                      </time>
+                      <span aria-hidden="true">&middot;</span>
+                      <span className="font-mono">
+                        {t("changelogVersion", { version: entry.version })}
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              </li>
+            );
+          })}
+        </ol>
+      )}
+    </section>
+  );
+}
+
+type Translate = ReturnType<typeof useTranslations<"courses">>;
+
+function ChangelogTitle({
+  entry,
+  t,
+}: {
+  entry: CourseChangelogEntry;
+  t: Translate;
+}) {
+  switch (entry.kind) {
+    case "deployed":
+      return <>{t("changelogDeployed")}</>;
+    case "lessons_added":
+      return (
+        <>
+          {t("changelogLessonsAdded", { count: entry.detail.lessons.length })}
+        </>
+      );
+    case "lessons_removed":
+      return (
+        <>
+          {t("changelogLessonsRemoved", { count: entry.detail.lessons.length })}
+        </>
+      );
+    case "xp_changed":
+      return <>{t("changelogXpChanged")}</>;
+    case "content_updated":
+      return <>{t("changelogContentUpdated")}</>;
+  }
+}
+
+function lessonLabel(lesson: ChangelogLessonRef, t: Translate): string {
+  return lesson.title ?? t("changelogLessonSlot", { slot: lesson.slot });
+}
+
+function ChangelogBody({
+  entry,
+  t,
+}: {
+  entry: CourseChangelogEntry;
+  t: Translate;
+}) {
+  switch (entry.kind) {
+    case "deployed":
+      return (
+        <p className="text-sm text-text-2">
+          {t("changelogDeployedDetail", { count: entry.detail.lessonCount })}
+        </p>
+      );
+    case "lessons_added":
+    case "lessons_removed":
+      return (
+        <ul className="flex flex-wrap gap-1.5">
+          {entry.detail.lessons.map((lesson) => (
+            <li
+              key={lesson.slot}
+              className="rounded-full border border-border bg-subtle px-2.5 py-0.5 text-xs text-text-2"
+            >
+              {lessonLabel(lesson, t)}
+            </li>
+          ))}
+        </ul>
+      );
+    case "xp_changed":
+      return (
+        <p className="text-sm text-text-2">
+          {t("changelogXpChangedDetail", {
+            from: entry.detail.from,
+            to: entry.detail.to,
+          })}
+        </p>
+      );
+    case "content_updated":
+      return (
+        <p className="text-sm text-text-2">
+          {t("changelogContentUpdatedDetail")}
+        </p>
+      );
+  }
+}

--- a/apps/web/src/lib/content/__tests__/changelog-writes.test.ts
+++ b/apps/web/src/lib/content/__tests__/changelog-writes.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// #654: capture seam records course-evolution rows at mutation time. Mock the
+// service-role client + the content bundle so we can assert exactly which rows
+// each mutation kind writes, with title snapshots resolved from the bundle.
+
+vi.mock("server-only", () => ({}));
+
+let lastTable: string | null = null;
+let lastRows: Array<Record<string, unknown>> | null = null;
+let lastOptions: Record<string, unknown> | null = null;
+let upsertError: { message: string } | null = null;
+
+const upsert = vi.fn(
+  (rows: Array<Record<string, unknown>>, options: Record<string, unknown>) => {
+    lastRows = rows;
+    lastOptions = options;
+    return Promise.resolve({ error: upsertError });
+  }
+);
+
+const fromFn = vi.fn((table: string) => {
+  lastTable = table;
+  return { upsert };
+});
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: () => ({ from: fromFn }),
+}));
+
+// Three lessons at slots 0/1/2; slot 3 is deliberately unmapped so a removed
+// bit with no bundle lesson exercises the null-title fallback.
+vi.mock("@/lib/content/store", () => ({
+  slotsByCourseId: new Map([
+    [
+      "course-x",
+      {
+        version: 1,
+        next: 3,
+        retired: [],
+        slots: { "lesson-a": 0, "lesson-b": 1, "lesson-c": 2 },
+      },
+    ],
+  ]),
+  lessonsById: new Map([
+    ["lesson-a", { _id: "lesson-a", title: "Intro" }],
+    ["lesson-b", { _id: "lesson-b", title: "Basics" }],
+    ["lesson-c", { _id: "lesson-c", title: "Advanced" }],
+  ]),
+}));
+
+import { recordCourseDeployed, recordCourseUpdate } from "../changelog-writes";
+
+/** Build a single-word mask from a list of slot indices (all < 64). */
+function mask(...slots: number[]): bigint[] {
+  let w = 0n;
+  for (const s of slots) w |= 1n << BigInt(s);
+  return [w, 0n, 0n, 0n];
+}
+
+beforeEach(() => {
+  lastTable = null;
+  lastRows = null;
+  lastOptions = null;
+  upsertError = null;
+  upsert.mockClear();
+  fromFn.mockClear();
+});
+
+describe("recordCourseDeployed", () => {
+  it("writes a single deployed row at version 1 with the lesson count", async () => {
+    await recordCourseDeployed({
+      courseId: "course-x",
+      txSignature: "SIG_DEPLOY",
+      lessonCount: 3,
+    });
+
+    expect(lastTable).toBe("course_changelog");
+    expect(lastRows).toHaveLength(1);
+    expect(lastRows?.[0]).toMatchObject({
+      course_id: "course-x",
+      kind: "deployed",
+      version: 1,
+      tx_signature: "SIG_DEPLOY",
+      detail: { lessonCount: 3 },
+    });
+  });
+
+  it("upserts idempotently on (course_id, kind, tx_signature)", async () => {
+    await recordCourseDeployed({
+      courseId: "course-x",
+      txSignature: "SIG",
+      lessonCount: 1,
+    });
+    expect(lastOptions).toEqual({
+      onConflict: "course_id,kind,tx_signature",
+      ignoreDuplicates: true,
+    });
+  });
+});
+
+describe("recordCourseUpdate", () => {
+  const baseUpdate = {
+    courseId: "course-x",
+    txSignature: "SIG_UPDATE",
+    oldXp: 10,
+    contentCommitted: true,
+    newVersion: 2,
+    contentSha: "abc123",
+  };
+
+  it("records lessons_added with title snapshots for newly-live slots", async () => {
+    await recordCourseUpdate({
+      ...baseUpdate,
+      oldMask: mask(0, 1),
+      newMask: mask(0, 1, 2),
+    });
+
+    const added = lastRows?.find((r) => r.kind === "lessons_added");
+    expect(added).toBeDefined();
+    expect(added).toMatchObject({ course_id: "course-x", version: 2 });
+    expect(added?.detail).toEqual({
+      lessons: [{ slot: 2, id: "lesson-c", title: "Advanced" }],
+    });
+    // No removed/xp/content rows when only lessons were added.
+    expect(lastRows?.some((r) => r.kind === "lessons_removed")).toBe(false);
+    expect(lastRows?.some((r) => r.kind === "content_updated")).toBe(false);
+    expect(lastRows?.some((r) => r.kind === "xp_changed")).toBe(false);
+  });
+
+  it("records lessons_removed, falling back to slot when a slot is unmapped", async () => {
+    await recordCourseUpdate({
+      ...baseUpdate,
+      oldMask: mask(0, 1, 2, 3),
+      newMask: mask(0, 1),
+    });
+
+    const removed = lastRows?.find((r) => r.kind === "lessons_removed");
+    expect(removed?.detail).toEqual({
+      lessons: [
+        { slot: 2, id: "lesson-c", title: "Advanced" },
+        { slot: 3, id: null, title: null },
+      ],
+    });
+  });
+
+  it("records content_updated only when the live set did NOT change", async () => {
+    await recordCourseUpdate({
+      ...baseUpdate,
+      oldMask: mask(0, 1),
+      newMask: mask(0, 1), // unchanged
+    });
+
+    expect(lastRows?.map((r) => r.kind)).toEqual(["content_updated"]);
+    expect(lastRows?.[0]?.detail).toEqual({ sha: "abc123" });
+  });
+
+  it("does NOT emit content_updated alongside a lesson change (avoids redundancy)", async () => {
+    await recordCourseUpdate({
+      ...baseUpdate,
+      oldMask: mask(0),
+      newMask: mask(0, 1),
+    });
+
+    expect(lastRows?.some((r) => r.kind === "content_updated")).toBe(false);
+    expect(lastRows?.some((r) => r.kind === "lessons_added")).toBe(true);
+  });
+
+  it("records xp_changed only on a real delta, with from/to", async () => {
+    await recordCourseUpdate({
+      ...baseUpdate,
+      oldMask: mask(0),
+      newMask: mask(0),
+      oldXp: 10,
+      newXp: 25,
+    });
+    const xp = lastRows?.find((r) => r.kind === "xp_changed");
+    expect(xp?.detail).toEqual({ from: 10, to: 25 });
+  });
+
+  it("omits xp_changed when the value is unchanged", async () => {
+    await recordCourseUpdate({
+      ...baseUpdate,
+      oldMask: mask(0),
+      newMask: mask(0),
+      oldXp: 10,
+      newXp: 10,
+      contentCommitted: false, // no content row either
+    });
+    expect(lastRows ?? []).toHaveLength(0);
+    // Nothing meaningful changed → no write at all.
+    expect(upsert).not.toHaveBeenCalled();
+  });
+
+  it("emits BOTH a lesson row and an xp row for a combined update", async () => {
+    await recordCourseUpdate({
+      ...baseUpdate,
+      oldMask: mask(0, 1),
+      newMask: mask(0, 1, 2),
+      oldXp: 10,
+      newXp: 20,
+    });
+    const kinds = (lastRows ?? []).map((r) => r.kind).sort();
+    expect(kinds).toEqual(["lessons_added", "xp_changed"]);
+    // Both share the same tx + version (one on-chain update).
+    for (const row of lastRows ?? []) {
+      expect(row).toMatchObject({ tx_signature: "SIG_UPDATE", version: 2 });
+    }
+  });
+
+  it("does not throw when the upsert errors (non-fatal capture)", async () => {
+    upsertError = { message: "boom" };
+    await expect(
+      recordCourseUpdate({
+        ...baseUpdate,
+        oldMask: mask(0),
+        newMask: mask(0, 1),
+      })
+    ).resolves.toBeUndefined();
+  });
+});

--- a/apps/web/src/lib/content/changelog-writes.ts
+++ b/apps/web/src/lib/content/changelog-writes.ts
@@ -1,0 +1,189 @@
+import "server-only";
+
+import { createAdminClient } from "@/lib/supabase/admin";
+import { lessonsById, slotsByCourseId } from "@/lib/content/store";
+import { diffMasks } from "@/lib/courses/changelog-diff";
+import type {
+  ChangelogLessonRef,
+  DeployedDetail,
+  LessonsDetail,
+  XpChangedDetail,
+  ContentUpdatedDetail,
+} from "@/lib/courses/changelog-types";
+import type { Json } from "@/lib/supabase/types";
+
+/**
+ * Course changelog (#654) — WRITE seam.
+ *
+ * The admin sync route (`api/admin/courses/sync`) is the sole mutator of a
+ * course's on-chain state, and at mutation time it already holds BOTH the prior
+ * on-chain state (via `fetchCourse`) and the intended new state (the committed
+ * slots.lock mask + xp). So the changelog is captured HERE, at mutation time,
+ * not replayed from `CourseUpdated` events — the event carries only
+ * version/collection/timestamp and cannot say which lesson slots moved.
+ *
+ * Lesson titles are SNAPSHOTTED into `detail` at capture time (a changelog is an
+ * immutable historical record; a retired lesson may later vanish from the
+ * bundle, and a renamed lesson should read under the name it had when it
+ * changed). The read seam therefore never touches the content bundle.
+ *
+ * All writes go through the service-role client — the table has RLS on with a
+ * public SELECT policy and NO write policy, so only service_role can insert.
+ * Inserts are idempotent on `(course_id, kind, tx_signature)`: re-running the
+ * same sync (same tx) never double-logs.
+ */
+
+type ChangelogInsert = {
+  course_id: string;
+  kind:
+    | "deployed"
+    | "lessons_added"
+    | "lessons_removed"
+    | "xp_changed"
+    | "content_updated";
+  version: number;
+  detail: Json;
+  tx_signature: string | null;
+};
+
+/**
+ * Resolve a slot (bit index) to a lesson id + title snapshot from the committed
+ * bundle. Inverts the course's `slots` map (lessonId → slot) once per call set.
+ * Returns `{ slot, id: null, title: null }` when the slot is unknown to the
+ * bundle (e.g. a slot retired before its lesson was tracked) so the entry still
+ * records the slot number.
+ */
+function resolveSlots(courseId: string, slots: number[]): ChangelogLessonRef[] {
+  const lock = slotsByCourseId.get(courseId);
+  const slotToLessonId = new Map<number, string>();
+  if (lock) {
+    for (const [lessonId, slot] of Object.entries(lock.slots)) {
+      slotToLessonId.set(slot, lessonId);
+    }
+  }
+  return slots.map((slot) => {
+    const id = slotToLessonId.get(slot) ?? null;
+    const rawTitle = id ? lessonsById.get(id)?.title : undefined;
+    const title = typeof rawTitle === "string" ? rawTitle : null;
+    return { slot, id, title };
+  });
+}
+
+async function insertEntries(rows: ChangelogInsert[]): Promise<void> {
+  if (rows.length === 0) return;
+  const { error } = await createAdminClient()
+    .from("course_changelog")
+    .upsert(rows, {
+      onConflict: "course_id,kind,tx_signature",
+      ignoreDuplicates: true,
+    });
+  if (error) {
+    // Non-fatal for the sync itself (the on-chain change already landed), but
+    // surface it — a silently-dropped changelog row is a real regression.
+    console.error(
+      `[changelog] insert failed for ${rows[0]?.course_id}: ${error.message}`
+    );
+  }
+}
+
+/** Record a course's first on-chain deploy (create_course sets version = 1). */
+export async function recordCourseDeployed(params: {
+  courseId: string;
+  txSignature: string;
+  lessonCount: number;
+}): Promise<void> {
+  const detail: DeployedDetail = { lessonCount: params.lessonCount };
+  await insertEntries([
+    {
+      course_id: params.courseId,
+      kind: "deployed",
+      version: 1,
+      detail: detail as unknown as Json,
+      tx_signature: params.txSignature,
+    },
+  ]);
+}
+
+/**
+ * Record what an `update_course` changed. Given the prior on-chain state and the
+ * intended new state, emit one row per change kind (a single sync can add
+ * lessons AND change xp → two rows sharing tx/version).
+ */
+export async function recordCourseUpdate(params: {
+  courseId: string;
+  txSignature: string;
+  /** Prior on-chain live-lesson mask. */
+  oldMask: readonly bigint[];
+  /** New mask sent this update, or `undefined` when the mask was untouched. */
+  newMask?: readonly bigint[];
+  oldXp: number;
+  /** New xp-per-lesson sent this update, or `undefined` when untouched. */
+  newXp?: number;
+  /** True when `content_tx_id` was committed (bumps on-chain version by 1). */
+  contentCommitted: boolean;
+  /** New on-chain `course.version` after this update. */
+  newVersion: number;
+  /** The content bundle SHA pinned by this re-sync (for `content_updated`). */
+  contentSha: string;
+}): Promise<void> {
+  const rows: ChangelogInsert[] = [];
+  const base = {
+    course_id: params.courseId,
+    version: params.newVersion,
+    tx_signature: params.txSignature,
+  };
+
+  let liveSetChanged = false;
+  if (params.newMask) {
+    const { addedSlots, removedSlots } = diffMasks(
+      params.oldMask,
+      params.newMask
+    );
+    if (addedSlots.length > 0) {
+      liveSetChanged = true;
+      const detail: LessonsDetail = {
+        lessons: resolveSlots(params.courseId, addedSlots),
+      };
+      rows.push({
+        ...base,
+        kind: "lessons_added",
+        detail: detail as unknown as Json,
+      });
+    }
+    if (removedSlots.length > 0) {
+      liveSetChanged = true;
+      const detail: LessonsDetail = {
+        lessons: resolveSlots(params.courseId, removedSlots),
+      };
+      rows.push({
+        ...base,
+        kind: "lessons_removed",
+        detail: detail as unknown as Json,
+      });
+    }
+  }
+
+  // A content commit with NO live-lesson change is a pure re-sync (lesson text
+  // edited, lessons reordered within the bundle, etc.). When lessons changed,
+  // those rows already carry the version bump, so this would be redundant.
+  if (params.contentCommitted && !liveSetChanged) {
+    const detail: ContentUpdatedDetail = { sha: params.contentSha };
+    rows.push({
+      ...base,
+      kind: "content_updated",
+      detail: detail as unknown as Json,
+    });
+  }
+
+  // XP change is independent of the content commit — only log a real delta.
+  if (params.newXp !== undefined && params.newXp !== params.oldXp) {
+    const detail: XpChangedDetail = { from: params.oldXp, to: params.newXp };
+    rows.push({
+      ...base,
+      kind: "xp_changed",
+      detail: detail as unknown as Json,
+    });
+  }
+
+  await insertEntries(rows);
+}

--- a/apps/web/src/lib/content/changelog-writes.ts
+++ b/apps/web/src/lib/content/changelog-writes.ts
@@ -43,7 +43,7 @@ type ChangelogInsert = {
     | "content_updated";
   version: number;
   detail: Json;
-  tx_signature: string | null;
+  tx_signature: string;
 };
 
 /**

--- a/apps/web/src/lib/courses/__tests__/changelog-diff.test.ts
+++ b/apps/web/src/lib/courses/__tests__/changelog-diff.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import { maskToSlots, diffMasks } from "../changelog-diff";
+
+describe("maskToSlots", () => {
+  it("enumerates set bits within a single word", () => {
+    expect(maskToSlots([0b1011n, 0n, 0n, 0n])).toEqual([0, 1, 3]);
+  });
+
+  it("offsets bits by 64 per word", () => {
+    // bit 0 of word 1 = slot 64; bit 2 of word 2 = slot 130.
+    expect(maskToSlots([0n, 1n, 0b100n, 0n])).toEqual([64, 130]);
+  });
+
+  it("handles the top bit of a word (bit 63)", () => {
+    expect(maskToSlots([1n << 63n, 0n, 0n, 0n])).toEqual([63]);
+  });
+
+  it("returns nothing for an all-zero mask", () => {
+    expect(maskToSlots([0n, 0n, 0n, 0n])).toEqual([]);
+  });
+});
+
+describe("diffMasks", () => {
+  it("reports added slots (live now, not before)", () => {
+    const { addedSlots, removedSlots } = diffMasks(
+      [0b011n, 0n, 0n, 0n],
+      [0b111n, 0n, 0n, 0n]
+    );
+    expect(addedSlots).toEqual([2]);
+    expect(removedSlots).toEqual([]);
+  });
+
+  it("reports removed slots (live before, not now)", () => {
+    const { addedSlots, removedSlots } = diffMasks(
+      [0b111n, 0n, 0n, 0n],
+      [0b011n, 0n, 0n, 0n]
+    );
+    expect(addedSlots).toEqual([]);
+    expect(removedSlots).toEqual([2]);
+  });
+
+  it("reports both directions at once, ascending", () => {
+    // old: slots 0,1,3 ; new: slots 0,2,3 → added 2, removed 1.
+    const { addedSlots, removedSlots } = diffMasks(
+      [0b1011n, 0n, 0n, 0n],
+      [0b1101n, 0n, 0n, 0n]
+    );
+    expect(addedSlots).toEqual([2]);
+    expect(removedSlots).toEqual([1]);
+  });
+
+  it("is empty for an identical mask (a pure content re-sync)", () => {
+    const same = [0b1010n, 5n, 0n, 0n];
+    expect(diffMasks(same, same)).toEqual({ addedSlots: [], removedSlots: [] });
+  });
+
+  it("diffs across word boundaries", () => {
+    const { addedSlots, removedSlots } = diffMasks(
+      [0n, 0n, 0n, 0n],
+      [0n, 1n, 0n, 0n]
+    );
+    expect(addedSlots).toEqual([64]);
+    expect(removedSlots).toEqual([]);
+  });
+});

--- a/apps/web/src/lib/courses/__tests__/changelog-read.test.ts
+++ b/apps/web/src/lib/courses/__tests__/changelog-read.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// #654: read seam — decodes course_changelog rows into the discriminated entry
+// union through the RLS-respecting server client, dropping rows whose detail
+// doesn't match their kind. Mock the server client to feed it raw rows.
+
+vi.mock("server-only", () => ({}));
+
+let rows: Array<Record<string, unknown>> = [];
+let queryError: { message: string } | null = null;
+let lastCourseId: string | null = null;
+
+// Minimal thenable query builder: every filter/order returns `this`, and
+// awaiting it yields { data, error }.
+const builder: Record<string, unknown> = {};
+for (const m of ["select", "order", "limit"]) {
+  builder[m] = vi.fn(() => builder);
+}
+builder.eq = vi.fn((_col: string, val: string) => {
+  lastCourseId = val;
+  return builder;
+});
+builder.then = (resolve: (v: unknown) => unknown) =>
+  resolve({ data: queryError ? null : rows, error: queryError });
+
+const fromFn = vi.fn(() => builder);
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: () => Promise.resolve({ from: fromFn }),
+}));
+
+import { getCourseChangelog } from "../changelog";
+
+beforeEach(() => {
+  rows = [];
+  queryError = null;
+  lastCourseId = null;
+  fromFn.mockClear();
+});
+
+describe("getCourseChangelog", () => {
+  it("filters by the exact course id and reads from course_changelog", async () => {
+    await getCourseChangelog("course-x");
+    expect(fromFn).toHaveBeenCalledWith("course_changelog");
+    expect(lastCourseId).toBe("course-x");
+  });
+
+  it("decodes each kind into its typed detail", async () => {
+    rows = [
+      {
+        id: 4,
+        kind: "xp_changed",
+        version: 3,
+        detail: { from: 10, to: 20 },
+        tx_signature: "S4",
+        created_at: "2026-07-26T00:00:00Z",
+      },
+      {
+        id: 3,
+        kind: "lessons_added",
+        version: 3,
+        detail: { lessons: [{ slot: 2, id: "lesson-c", title: "Advanced" }] },
+        tx_signature: "S3",
+        created_at: "2026-07-25T00:00:00Z",
+      },
+      {
+        id: 1,
+        kind: "deployed",
+        version: 1,
+        detail: { lessonCount: 5 },
+        tx_signature: "S1",
+        created_at: "2026-07-24T00:00:00Z",
+      },
+    ];
+    const entries = await getCourseChangelog("course-x");
+    expect(entries).toHaveLength(3);
+    expect(entries[0]).toMatchObject({
+      kind: "xp_changed",
+      detail: { from: 10, to: 20 },
+    });
+    expect(entries[1]).toMatchObject({
+      kind: "lessons_added",
+      detail: { lessons: [{ slot: 2, id: "lesson-c", title: "Advanced" }] },
+    });
+    expect(entries[2]).toMatchObject({
+      kind: "deployed",
+      detail: { lessonCount: 5 },
+    });
+  });
+
+  it("drops a row whose detail does not match its kind", async () => {
+    rows = [
+      {
+        id: 2,
+        kind: "xp_changed",
+        version: 1,
+        detail: { nope: true }, // missing from/to
+        tx_signature: "S2",
+        created_at: "2026-07-26T00:00:00Z",
+      },
+      {
+        id: 1,
+        kind: "lessons_added",
+        version: 1,
+        detail: { lessons: [{ slot: 0, id: null, title: null }] },
+        tx_signature: "S1",
+        created_at: "2026-07-25T00:00:00Z",
+      },
+    ];
+    const entries = await getCourseChangelog("course-x");
+    expect(entries.map((e) => e.kind)).toEqual(["lessons_added"]);
+  });
+
+  it("returns [] on a query error (never breaks the course page)", async () => {
+    queryError = { message: "down" };
+    expect(await getCourseChangelog("course-x")).toEqual([]);
+  });
+
+  it("returns [] when the course has no recorded changes", async () => {
+    rows = [];
+    expect(await getCourseChangelog("course-x")).toEqual([]);
+  });
+});

--- a/apps/web/src/lib/courses/changelog-diff.ts
+++ b/apps/web/src/lib/courses/changelog-diff.ts
@@ -1,0 +1,47 @@
+/**
+ * Pure `active_lessons` mask-diff helpers for the course changelog (#654).
+ *
+ * The on-chain live-lesson set is a 256-bit bitmap held as four u64 words
+ * (`active_lessons: [u64; 4]`). A slot's bit index is its permanent position
+ * (never renumbered/reused — see packages/content-schema slots), so diffing the
+ * pre- and post-update masks yields exactly which slots went live (added) or
+ * were retired (removed). Kept free of server-only imports so it is unit
+ * testable in isolation from the content bundle.
+ */
+
+/** Enumerate the set bit indices (global slot numbers) of a 4-word mask. */
+export function maskToSlots(mask: readonly bigint[]): number[] {
+  const slots: number[] = [];
+  for (let w = 0; w < mask.length; w++) {
+    const word = mask[w] ?? 0n;
+    for (let b = 0; b < 64; b++) {
+      if ((word & (1n << BigInt(b))) !== 0n) {
+        slots.push(w * 64 + b);
+      }
+    }
+  }
+  return slots;
+}
+
+export interface MaskDiff {
+  /** Slots live now but not before — lessons added. Ascending. */
+  addedSlots: number[];
+  /** Slots live before but not now — lessons retired. Ascending. */
+  removedSlots: number[];
+}
+
+/** Slots that changed liveness between two masks. */
+export function diffMasks(
+  oldMask: readonly bigint[],
+  newMask: readonly bigint[]
+): MaskDiff {
+  const oldSet = new Set(maskToSlots(oldMask));
+  const newSet = new Set(maskToSlots(newMask));
+  const addedSlots = [...newSet]
+    .filter((s) => !oldSet.has(s))
+    .sort((a, b) => a - b);
+  const removedSlots = [...oldSet]
+    .filter((s) => !newSet.has(s))
+    .sort((a, b) => a - b);
+  return { addedSlots, removedSlots };
+}

--- a/apps/web/src/lib/courses/changelog-types.ts
+++ b/apps/web/src/lib/courses/changelog-types.ts
@@ -1,0 +1,67 @@
+/**
+ * Course changelog (#654) — shared shapes for the post-deployment evolution log.
+ *
+ * This module is intentionally FREE of server-only imports (no content bundle,
+ * no supabase) so both the capture seam (server) and the rendering component
+ * (client) can share one discriminated union. The row's `kind` column is the
+ * discriminant; `detail` is decoded into the matching payload at the read seam
+ * (see {@link file://./changelog.ts}).
+ */
+
+/** The change kinds captured at mutation time. Mirrors the DB CHECK constraint. */
+export type ChangelogKind =
+  | "deployed"
+  | "lessons_added"
+  | "lessons_removed"
+  | "xp_changed"
+  | "content_updated";
+
+/**
+ * A lesson referenced by a changelog entry. `slot` is the permanent bit index
+ * in the on-chain `active_lessons` mask (always known — it comes from the diff).
+ * `id`/`title` are SNAPSHOTS taken at capture time and may be `null` when the
+ * slot could not be resolved to a bundle lesson then (e.g. a retired slot whose
+ * lesson was already gone) — rendering falls back to the slot number.
+ */
+export interface ChangelogLessonRef {
+  slot: number;
+  id: string | null;
+  title: string | null;
+}
+
+export interface DeployedDetail {
+  /** Live lesson count at first deploy. */
+  lessonCount: number;
+}
+export interface LessonsDetail {
+  lessons: ChangelogLessonRef[];
+}
+export interface XpChangedDetail {
+  from: number;
+  to: number;
+}
+export interface ContentUpdatedDetail {
+  /** The content bundle git SHA this re-sync pinned. */
+  sha: string;
+}
+
+interface EntryBase {
+  id: number;
+  /** On-chain `course.version` after the change. */
+  version: number;
+  /** The mutation's on-chain signature (public), or `null`. */
+  txSignature: string | null;
+  /** ISO timestamp. */
+  createdAt: string;
+}
+
+/**
+ * A decoded, render-ready changelog entry. Discriminated on `kind` so the UI
+ * can switch exhaustively and TypeScript narrows `detail` per branch.
+ */
+export type CourseChangelogEntry =
+  | (EntryBase & { kind: "deployed"; detail: DeployedDetail })
+  | (EntryBase & { kind: "lessons_added"; detail: LessonsDetail })
+  | (EntryBase & { kind: "lessons_removed"; detail: LessonsDetail })
+  | (EntryBase & { kind: "xp_changed"; detail: XpChangedDetail })
+  | (EntryBase & { kind: "content_updated"; detail: ContentUpdatedDetail });

--- a/apps/web/src/lib/courses/changelog-types.ts
+++ b/apps/web/src/lib/courses/changelog-types.ts
@@ -49,8 +49,8 @@ interface EntryBase {
   id: number;
   /** On-chain `course.version` after the change. */
   version: number;
-  /** The mutation's on-chain signature (public), or `null`. */
-  txSignature: string | null;
+  /** The mutation's on-chain signature (public). NOT NULL — the dedup key. */
+  txSignature: string;
   /** ISO timestamp. */
   createdAt: string;
 }

--- a/apps/web/src/lib/courses/changelog.ts
+++ b/apps/web/src/lib/courses/changelog.ts
@@ -43,7 +43,7 @@ function decodeEntry(row: {
   kind: string;
   version: number;
   detail: Json;
-  tx_signature: string | null;
+  tx_signature: string;
   created_at: string;
 }): CourseChangelogEntry | null {
   const base = {

--- a/apps/web/src/lib/courses/changelog.ts
+++ b/apps/web/src/lib/courses/changelog.ts
@@ -1,0 +1,116 @@
+import "server-only";
+
+import { createClient } from "@/lib/supabase/server";
+import type { Json } from "@/lib/supabase/types";
+import type {
+  CourseChangelogEntry,
+  ChangelogLessonRef,
+} from "./changelog-types";
+
+/**
+ * Course changelog (#654) — READ seam.
+ *
+ * Reads the learner-visible evolution log for one course through the ordinary
+ * RLS-respecting server client (the table has a public SELECT policy, so anon +
+ * authenticated both read it). Titles are already snapshotted in `detail`, so
+ * this never touches the content bundle. The raw `detail` JSON is defensively
+ * narrowed into the discriminated `CourseChangelogEntry` union; a row whose
+ * `detail` doesn't match its `kind` is dropped rather than rendered as garbage.
+ */
+
+const MAX_ENTRIES = 50;
+
+function isRecord(v: Json): v is { [k: string]: Json } {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+function toLessonRefs(v: Json): ChangelogLessonRef[] | null {
+  if (!isRecord(v) || !Array.isArray(v.lessons)) return null;
+  const refs: ChangelogLessonRef[] = [];
+  for (const raw of v.lessons) {
+    if (!isRecord(raw) || typeof raw.slot !== "number") return null;
+    refs.push({
+      slot: raw.slot,
+      id: typeof raw.id === "string" ? raw.id : null,
+      title: typeof raw.title === "string" ? raw.title : null,
+    });
+  }
+  return refs;
+}
+
+function decodeEntry(row: {
+  id: number;
+  kind: string;
+  version: number;
+  detail: Json;
+  tx_signature: string | null;
+  created_at: string;
+}): CourseChangelogEntry | null {
+  const base = {
+    id: row.id,
+    version: row.version,
+    txSignature: row.tx_signature,
+    createdAt: row.created_at,
+  };
+  const d = row.detail;
+  switch (row.kind) {
+    case "deployed": {
+      const lessonCount =
+        isRecord(d) && typeof d.lessonCount === "number" ? d.lessonCount : 0;
+      return { ...base, kind: "deployed", detail: { lessonCount } };
+    }
+    case "lessons_added":
+    case "lessons_removed": {
+      const lessons = toLessonRefs(d);
+      if (!lessons) return null;
+      return { ...base, kind: row.kind, detail: { lessons } };
+    }
+    case "xp_changed": {
+      if (
+        !isRecord(d) ||
+        typeof d.from !== "number" ||
+        typeof d.to !== "number"
+      ) {
+        return null;
+      }
+      return {
+        ...base,
+        kind: "xp_changed",
+        detail: { from: d.from, to: d.to },
+      };
+    }
+    case "content_updated": {
+      const sha = isRecord(d) && typeof d.sha === "string" ? d.sha : "";
+      return { ...base, kind: "content_updated", detail: { sha } };
+    }
+    default:
+      return null;
+  }
+}
+
+/**
+ * Newest-first changelog entries for a course. Returns `[]` on any error (an
+ * unavailable log must never break the course page) or when the course has no
+ * recorded changes yet (the common case → the UI renders its empty state).
+ */
+export async function getCourseChangelog(
+  courseId: string
+): Promise<CourseChangelogEntry[]> {
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from("course_changelog")
+    .select("id, kind, version, detail, tx_signature, created_at")
+    .eq("course_id", courseId)
+    .order("created_at", { ascending: false })
+    .order("id", { ascending: false })
+    .limit(MAX_ENTRIES);
+
+  if (error || !data) return [];
+
+  const entries: CourseChangelogEntry[] = [];
+  for (const row of data) {
+    const decoded = decodeEntry(row);
+    if (decoded) entries.push(decoded);
+  }
+  return entries;
+}

--- a/apps/web/src/lib/supabase/__tests__/course-changelog-rls-guard.test.ts
+++ b/apps/web/src/lib/supabase/__tests__/course-changelog-rls-guard.test.ts
@@ -39,19 +39,33 @@ for (const [label, sql] of [
       );
     });
 
-    it("grants a PUBLIC read policy and NO write policy", () => {
-      expect(sql).toContain(
-        "ON public.course_changelog FOR SELECT USING (true)"
-      );
-      // Any INSERT/UPDATE/DELETE/ALL policy would open a client forge path —
-      // writes must stay service_role-only (bypasses RLS).
+    it("scopes SELECT to synced+active courses — NOT a blanket USING (true)", () => {
+      // MINOR-1: a blanket public read would let any anon PostgREST caller
+      // enumerate title history for a hidden/deactivated course. The policy must
+      // fail closed, gating on the catalog's own visibility state (isSynced).
+      expect(sql).toContain("ON public.course_changelog FOR SELECT");
+      // Mutation: reverting to `USING (true)` must break this guard.
+      expect(sql).not.toMatch(/course_changelog FOR SELECT USING \(true\)/);
+      // The EXISTS gates on the anon-readable deployments VIEW with the exact
+      // isSynced predicate (status = 'synced' AND coalesce(is_active, true)).
+      expect(sql).toContain("FROM public.public_onchain_deployments d");
+      expect(sql).toContain("d.content_id = course_changelog.course_id");
+      expect(sql).toMatch(/d\.status\s*=\s*'synced'/);
+      expect(sql).toMatch(/COALESCE\(d\.is_active,\s*true\)/);
+    });
+
+    it("keeps writes service_role-only — NO write policy", () => {
+      // Any INSERT/UPDATE/DELETE/ALL policy would open a client forge path.
       expect(sql).not.toMatch(
         /ON public\.course_changelog FOR (INSERT|UPDATE|DELETE|ALL)/
       );
     });
 
-    it("dedups on (course_id, kind, tx_signature) so a re-run never double-logs", () => {
+    it("dedups on (course_id, kind, tx_signature) with a NOT NULL signature", () => {
       expect(sql).toContain("UNIQUE (course_id, kind, tx_signature)");
+      // MINOR-2: a nullable tx_signature would silently defeat the UNIQUE
+      // (Postgres treats NULLs as distinct), so it must be NOT NULL.
+      expect(sql).toMatch(/tx_signature\s+TEXT NOT NULL/);
     });
 
     it("constrains kind to the five captured change types", () => {
@@ -86,7 +100,7 @@ describe("#654 course_changelog — migration-only guarantees", () => {
       "CREATE INDEX IF NOT EXISTS idx_course_changelog_course_created"
     );
     expect(migration).toContain(
-      'DROP POLICY IF EXISTS "Course changelog is viewable by everyone"'
+      'DROP POLICY IF EXISTS "Course changelog visible for synced-active courses"'
     );
   });
 

--- a/apps/web/src/lib/supabase/__tests__/course-changelog-rls-guard.test.ts
+++ b/apps/web/src/lib/supabase/__tests__/course-changelog-rls-guard.test.ts
@@ -1,0 +1,96 @@
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, it, expect } from "vitest";
+
+// #654: the course_changelog table is learner-visible (public SELECT) but
+// service_role-only for writes. RLS can't be exercised in unit tests, so — as
+// with the #569 review-items guard — pin the security-critical SQL invariants
+// in BOTH the migration (what gets applied) and the schema.sql mirror (what new
+// environments are built from). A drift between the two is exactly the class of
+// bug the #449 IDL memory warns about.
+
+function findRepoRoot(): string {
+  let dir = dirname(fileURLToPath(import.meta.url));
+  while (!existsSync(resolve(dir, "supabase/schema.sql"))) {
+    const parent = dirname(dir);
+    if (parent === dir)
+      throw new Error("repo root (supabase/schema.sql) not found");
+    dir = parent;
+  }
+  return dir;
+}
+
+const repoRoot = findRepoRoot();
+const migration = readFileSync(
+  resolve(repoRoot, "supabase/migrations/20260726210000_course_changelog.sql"),
+  "utf8"
+);
+const schema = readFileSync(resolve(repoRoot, "supabase/schema.sql"), "utf8");
+
+for (const [label, sql] of [
+  ["migration", migration] as const,
+  ["schema.sql", schema] as const,
+]) {
+  describe(`#654 course_changelog — ${label}`, () => {
+    it("enables RLS on the table", () => {
+      expect(sql).toContain(
+        "ALTER TABLE public.course_changelog ENABLE ROW LEVEL SECURITY"
+      );
+    });
+
+    it("grants a PUBLIC read policy and NO write policy", () => {
+      expect(sql).toContain(
+        "ON public.course_changelog FOR SELECT USING (true)"
+      );
+      // Any INSERT/UPDATE/DELETE/ALL policy would open a client forge path —
+      // writes must stay service_role-only (bypasses RLS).
+      expect(sql).not.toMatch(
+        /ON public\.course_changelog FOR (INSERT|UPDATE|DELETE|ALL)/
+      );
+    });
+
+    it("dedups on (course_id, kind, tx_signature) so a re-run never double-logs", () => {
+      expect(sql).toContain("UNIQUE (course_id, kind, tx_signature)");
+    });
+
+    it("constrains kind to the five captured change types", () => {
+      for (const kind of [
+        "deployed",
+        "lessons_added",
+        "lessons_removed",
+        "xp_changed",
+        "content_updated",
+      ]) {
+        expect(sql).toContain(`'${kind}'`);
+      }
+    });
+
+    it("uses course_id verbatim (TEXT, PDA-seed convention — never stripped)", () => {
+      expect(sql).toMatch(/course_id\s+TEXT NOT NULL/);
+    });
+  });
+}
+
+describe("#654 course_changelog — migration-only guarantees", () => {
+  it("runs in one explicit transaction", () => {
+    expect(migration).toContain("BEGIN;");
+    expect(migration).toContain("COMMIT;");
+  });
+
+  it("is idempotent (safe to re-apply)", () => {
+    expect(migration).toContain(
+      "CREATE TABLE IF NOT EXISTS public.course_changelog"
+    );
+    expect(migration).toContain(
+      "CREATE INDEX IF NOT EXISTS idx_course_changelog_course_created"
+    );
+    expect(migration).toContain(
+      'DROP POLICY IF EXISTS "Course changelog is viewable by everyone"'
+    );
+  });
+
+  it("ships a rollback that drops what it created", () => {
+    expect(migration).toContain("DROP TABLE IF EXISTS public.course_changelog");
+  });
+});

--- a/apps/web/src/lib/supabase/types.ts
+++ b/apps/web/src/lib/supabase/types.ts
@@ -1006,7 +1006,7 @@ export type Database = {
             | "content_updated";
           version: number;
           detail: Json;
-          tx_signature: string | null;
+          tx_signature: string;
           created_at: string;
         };
         Insert: {
@@ -1020,7 +1020,7 @@ export type Database = {
             | "content_updated";
           version: number;
           detail?: Json;
-          tx_signature?: string | null;
+          tx_signature: string;
           created_at?: string;
         };
         Update: {
@@ -1034,7 +1034,7 @@ export type Database = {
             | "content_updated";
           version?: number;
           detail?: Json;
-          tx_signature?: string | null;
+          tx_signature?: string;
           created_at?: string;
         };
         Relationships: [];

--- a/apps/web/src/lib/supabase/types.ts
+++ b/apps/web/src/lib/supabase/types.ts
@@ -990,6 +990,55 @@ export type Database = {
           },
         ];
       };
+      course_changelog: {
+        // #654: post-deployment course evolution log. Written service_role-only
+        // at mutation time by the admin sync route; public SELECT (RLS policy).
+        // `detail` is a kind-specific, title-snapshotted payload — decoded to a
+        // discriminated union at the read seam (lib/courses/changelog.ts).
+        Row: {
+          id: number;
+          course_id: string;
+          kind:
+            | "deployed"
+            | "lessons_added"
+            | "lessons_removed"
+            | "xp_changed"
+            | "content_updated";
+          version: number;
+          detail: Json;
+          tx_signature: string | null;
+          created_at: string;
+        };
+        Insert: {
+          id?: never;
+          course_id: string;
+          kind:
+            | "deployed"
+            | "lessons_added"
+            | "lessons_removed"
+            | "xp_changed"
+            | "content_updated";
+          version: number;
+          detail?: Json;
+          tx_signature?: string | null;
+          created_at?: string;
+        };
+        Update: {
+          id?: never;
+          course_id?: string;
+          kind?:
+            | "deployed"
+            | "lessons_added"
+            | "lessons_removed"
+            | "xp_changed"
+            | "content_updated";
+          version?: number;
+          detail?: Json;
+          tx_signature?: string | null;
+          created_at?: string;
+        };
+        Relationships: [];
+      };
     };
     Views: {
       public_onchain_deployments: {

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -194,7 +194,21 @@
     "pathGuidanceOpen": "Jump into any course — the order is a recommendation, not a requirement.",
     "pathGoalJob": "Your path to a Solana developer role starts here.",
     "pathGoalBuild": "Everything you need to ship your own Solana project.",
-    "pathGoalExplore": "Explore how Solana works, one course at a time."
+    "pathGoalExplore": "Explore how Solana works, one course at a time.",
+    "changelog": "Changelog",
+    "changelogEmpty": "No changes recorded yet. You'll see updates here when lessons or rewards change.",
+    "changelogSinceEnrolled": "{count, plural, one {# update since you enrolled} other {# updates since you enrolled}}",
+    "changelogNew": "New",
+    "changelogVersion": "v{version}",
+    "changelogDeployed": "Course published",
+    "changelogDeployedDetail": "{count, plural, one {# lesson at launch} other {# lessons at launch}}",
+    "changelogLessonsAdded": "{count, plural, one {# lesson added} other {# lessons added}}",
+    "changelogLessonsRemoved": "{count, plural, one {# lesson retired} other {# lessons retired}}",
+    "changelogXpChanged": "XP reward changed",
+    "changelogXpChangedDetail": "XP per lesson changed from {from} to {to}.",
+    "changelogContentUpdated": "Content updated",
+    "changelogContentUpdatedDetail": "Lesson content was refreshed.",
+    "changelogLessonSlot": "Lesson slot {slot}"
   },
   "lesson": {
     "content": "Content",

--- a/apps/web/src/messages/es.json
+++ b/apps/web/src/messages/es.json
@@ -194,7 +194,21 @@
     "pathGuidanceOpen": "Entra en cualquier curso — el orden es una recomendación, no un requisito.",
     "pathGoalJob": "Tu camino hacia un puesto de desarrollador Solana empieza aquí.",
     "pathGoalBuild": "Todo lo que necesitas para lanzar tu propio proyecto en Solana.",
-    "pathGoalExplore": "Explora cómo funciona Solana, un curso a la vez."
+    "pathGoalExplore": "Explora cómo funciona Solana, un curso a la vez.",
+    "changelog": "Historial de cambios",
+    "changelogEmpty": "Aún no hay cambios registrados. Verás las actualizaciones aquí cuando cambien las lecciones o las recompensas.",
+    "changelogSinceEnrolled": "{count, plural, one {# actualización desde que te inscribiste} other {# actualizaciones desde que te inscribiste}}",
+    "changelogNew": "Nuevo",
+    "changelogVersion": "v{version}",
+    "changelogDeployed": "Curso publicado",
+    "changelogDeployedDetail": "{count, plural, one {# lección al inicio} other {# lecciones al inicio}}",
+    "changelogLessonsAdded": "{count, plural, one {# lección añadida} other {# lecciones añadidas}}",
+    "changelogLessonsRemoved": "{count, plural, one {# lección retirada} other {# lecciones retiradas}}",
+    "changelogXpChanged": "Recompensa de XP modificada",
+    "changelogXpChangedDetail": "El XP por lección cambió de {from} a {to}.",
+    "changelogContentUpdated": "Contenido actualizado",
+    "changelogContentUpdatedDetail": "Se actualizó el contenido de las lecciones.",
+    "changelogLessonSlot": "Lección posición {slot}"
   },
   "lesson": {
     "content": "Contenido",

--- a/apps/web/src/messages/pt-BR.json
+++ b/apps/web/src/messages/pt-BR.json
@@ -194,7 +194,21 @@
     "pathGuidanceOpen": "Entre em qualquer curso — a ordem é uma recomendação, não uma exigência.",
     "pathGoalJob": "Sua trilha rumo a uma vaga de dev Solana começa aqui.",
     "pathGoalBuild": "Tudo o que você precisa para lançar seu próprio projeto Solana.",
-    "pathGoalExplore": "Explore como a Solana funciona, um curso de cada vez."
+    "pathGoalExplore": "Explore como a Solana funciona, um curso de cada vez.",
+    "changelog": "Histórico de alterações",
+    "changelogEmpty": "Nenhuma alteração registrada ainda. Você verá atualizações aqui quando lições ou recompensas mudarem.",
+    "changelogSinceEnrolled": "{count, plural, one {# atualização desde que você se inscreveu} other {# atualizações desde que você se inscreveu}}",
+    "changelogNew": "Novo",
+    "changelogVersion": "v{version}",
+    "changelogDeployed": "Curso publicado",
+    "changelogDeployedDetail": "{count, plural, one {# lição no lançamento} other {# lições no lançamento}}",
+    "changelogLessonsAdded": "{count, plural, one {# lição adicionada} other {# lições adicionadas}}",
+    "changelogLessonsRemoved": "{count, plural, one {# lição removida} other {# lições removidas}}",
+    "changelogXpChanged": "Recompensa de XP alterada",
+    "changelogXpChangedDetail": "O XP por lição mudou de {from} para {to}.",
+    "changelogContentUpdated": "Conteúdo atualizado",
+    "changelogContentUpdatedDetail": "O conteúdo das lições foi atualizado.",
+    "changelogLessonSlot": "Lição posição {slot}"
   },
   "lesson": {
     "content": "Conteúdo",

--- a/supabase/migrations/20260726210000_course_changelog.sql
+++ b/supabase/migrations/20260726210000_course_changelog.sql
@@ -1,0 +1,105 @@
+-- ============================================================================
+-- Migration: course_changelog — post-deployment course evolution log (#654)
+--
+-- Courses are MUTABLE after deployment: `update_course` can retire/rewrite the
+-- 256-bit live-lesson bitmap (`active_lessons: [u64; 4]`), change
+-- `xp_per_lesson`, and bump `version`/`content_tx_id` — all without closing the
+-- course. Today those changes are SILENT: a learner mid-course gets no signal
+-- that lessons were added or retired, and admins keep no in-app history.
+--
+-- DATA SOURCE — server-side capture at mutation time (NOT Helius replay).
+-- The issue floats two options (index CourseUpdated events vs. read on demand).
+-- We take a third, higher-fidelity path prescribed by the mutation model: the
+-- admin sync route (apps/web/src/app/api/admin/courses/sync/route.ts) is the
+-- ONLY writer of these on-chain changes, and at that point it already holds
+-- BOTH the prior on-chain state (via fetchCourse) AND the intended new state
+-- (the committed slots.lock mask + xp). The `CourseUpdated` event carries only
+-- `version`/`collection`/`timestamp` — it CANNOT tell you which lesson slots
+-- moved. So the route computes the human-readable diff at mutation time and
+-- writes rows here (service_role), exactly as `onchain_deployments` is written
+-- from the same route. Reads never touch RPC/Helius.
+--
+-- A changelog is an IMMUTABLE HISTORICAL record, so each row SNAPSHOTS the
+-- lesson titles as they were when the change happened (in `detail`), rather
+-- than resolving them from the live content bundle at read time — a lesson
+-- retired long ago may no longer exist in the bundle, and even a renamed lesson
+-- should read, in the log, under the name it had when it changed.
+--
+-- SECURITY — house pattern, learner-visible variant.
+-- Rows are non-sensitive: course id, on-chain version, change kind, lesson
+-- title snapshots, xp numbers, a public tx signature, a timestamp. Nothing here
+-- is a secret (quiz answers/solutions live only in the server-only bundle; the
+-- tx signature is already public on-chain). So — unlike `onchain_deployments`,
+-- which hides reward-path pubkeys behind a view — this table takes a PUBLIC
+-- SELECT policy (anon + authenticated; course pages are anon-accessible) and no
+-- write policy: RLS is on with no INSERT/UPDATE/DELETE policy, so ONLY
+-- service_role (which bypasses RLS) can write, and the sync route's
+-- createAdminClient() is the sole writer.
+--
+-- Idempotent (repo convention): CREATE TABLE/INDEX IF NOT EXISTS, DROP POLICY
+-- IF EXISTS before CREATE POLICY, a UNIQUE constraint + ON CONFLICT DO NOTHING
+-- at the write site so re-running a sync never double-logs. Explicit
+-- BEGIN/COMMIT so the whole file is one transaction under a manual psql apply.
+--
+-- A tested ROLLBACK block is at the very bottom of this file.
+-- Mirrored into supabase/schema.sql (the full-schema snapshot).
+-- ============================================================================
+
+BEGIN;
+
+-- ── course_changelog ────────────────────────────────────────────────────────
+-- One row per (mutation, change-kind). A single sync can add lessons AND change
+-- xp; that produces two rows sharing a `tx_signature` and `version`, so the UI
+-- renders both under one dated update. `course_id` is the content `_id`
+-- verbatim (PDA-seed convention: never strip/transform ids). `detail` carries
+-- the kind-specific payload (lesson snapshots, xp from/to, content sha).
+CREATE TABLE IF NOT EXISTS public.course_changelog (
+  id           BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  course_id    TEXT NOT NULL,
+  kind         TEXT NOT NULL CHECK (kind IN (
+                 'deployed',
+                 'lessons_added',
+                 'lessons_removed',
+                 'xp_changed',
+                 'content_updated'
+               )),
+  -- On-chain `course.version` AFTER the change (bumps only when content_tx_id
+  -- changes; an xp-only update keeps the prior version — informational).
+  version      INTEGER NOT NULL,
+  -- Kind-specific, title-snapshotted payload. Never resolved from the live
+  -- bundle at read time (a retired lesson may be gone from it).
+  detail       JSONB NOT NULL DEFAULT '{}'::jsonb,
+  -- The on-chain signature for this mutation (public data). NULL only for a
+  -- record with no single tx (none today). Used as the idempotency key.
+  tx_signature TEXT,
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+  -- Re-running the same sync (same tx) must not double-log: one row per
+  -- (course, kind, tx). NULLs are distinct in a UNIQUE, but the writer always
+  -- supplies a tx_signature, so ON CONFLICT DO NOTHING is effective.
+  CONSTRAINT course_changelog_dedup UNIQUE (course_id, kind, tx_signature)
+);
+
+-- Course-page read: newest-first entries for one course.
+CREATE INDEX IF NOT EXISTS idx_course_changelog_course_created
+  ON public.course_changelog (course_id, created_at DESC);
+
+-- ── RLS: public read, service_role-only write ───────────────────────────────
+ALTER TABLE public.course_changelog ENABLE ROW LEVEL SECURITY;
+
+-- Public read: the log is learner-facing and non-sensitive. anon + authenticated
+-- both get it (course pages are anon-accessible).
+DROP POLICY IF EXISTS "Course changelog is viewable by everyone" ON public.course_changelog;
+CREATE POLICY "Course changelog is viewable by everyone"
+  ON public.course_changelog FOR SELECT USING (true);
+-- NO write policy: writes only via service_role (bypasses RLS) from the admin
+-- sync route. An INSERT/UPDATE/DELETE policy here would open a client forge path.
+
+COMMIT;
+
+-- ============================================================================
+-- ROLLBACK (tested; not executed by the migration runner)
+-- ----------------------------------------------------------------------------
+-- BEGIN;
+--   DROP TABLE IF EXISTS public.course_changelog;
+-- COMMIT;
+-- ============================================================================

--- a/supabase/migrations/20260726210000_course_changelog.sql
+++ b/supabase/migrations/20260726210000_course_changelog.sql
@@ -25,16 +25,24 @@
 -- retired long ago may no longer exist in the bundle, and even a renamed lesson
 -- should read, in the log, under the name it had when it changed.
 --
--- SECURITY — house pattern, learner-visible variant.
--- Rows are non-sensitive: course id, on-chain version, change kind, lesson
--- title snapshots, xp numbers, a public tx signature, a timestamp. Nothing here
--- is a secret (quiz answers/solutions live only in the server-only bundle; the
--- tx signature is already public on-chain). So — unlike `onchain_deployments`,
--- which hides reward-path pubkeys behind a view — this table takes a PUBLIC
--- SELECT policy (anon + authenticated; course pages are anon-accessible) and no
--- write policy: RLS is on with no INSERT/UPDATE/DELETE policy, so ONLY
--- service_role (which bypasses RLS) can write, and the sync route's
--- createAdminClient() is the sole writer.
+-- SECURITY — house pattern, learner-visible-but-scoped variant.
+-- Rows carry no secrets (quiz answers/solutions live only in the server-only
+-- bundle; the tx signature is already public on-chain). But the snapshotted
+-- lesson TITLES must not leak for a course that isn't publicly visible — a
+-- course can be on-chain-deployed yet hidden from the catalog (deactivated, or
+-- synced-then-deactivated). A blanket `USING (true)` would let any anon
+-- PostgREST caller enumerate every course's title history regardless of catalog
+-- visibility. So the SELECT policy is FAIL-CLOSED and mirrors the catalog's own
+-- visibility gate EXACTLY: a row is visible only when its course currently has a
+-- `synced` AND active deployment — the same `status = 'synced' AND
+-- COALESCE(is_active, true)` predicate `isSynced` (lib/content/deployments.ts)
+-- applies. The EXISTS runs against `public_onchain_deployments` (the anon-
+-- readable owner-privilege VIEW), NOT the base `onchain_deployments` table
+-- (RLS-on/no-policy → anon sees zero rows, which would hide EVERYTHING). No
+-- deployment row, unsynced, or inactive ⇒ hidden.
+-- Writes: RLS is on with no INSERT/UPDATE/DELETE policy, so ONLY service_role
+-- (which bypasses RLS) can write — the sync route's createAdminClient() is the
+-- sole writer.
 --
 -- Idempotent (repo convention): CREATE TABLE/INDEX IF NOT EXISTS, DROP POLICY
 -- IF EXISTS before CREATE POLICY, a UNIQUE constraint + ON CONFLICT DO NOTHING
@@ -69,13 +77,15 @@ CREATE TABLE IF NOT EXISTS public.course_changelog (
   -- Kind-specific, title-snapshotted payload. Never resolved from the live
   -- bundle at read time (a retired lesson may be gone from it).
   detail       JSONB NOT NULL DEFAULT '{}'::jsonb,
-  -- The on-chain signature for this mutation (public data). NULL only for a
-  -- record with no single tx (none today). Used as the idempotency key.
-  tx_signature TEXT,
+  -- The on-chain signature for this mutation (public data). NOT NULL: it is the
+  -- dedup key, and Postgres treats NULLs as DISTINCT in a UNIQUE — a nullable
+  -- column would silently defeat the idempotency guard below. Every writer has
+  -- a confirmed signature (a mutation with none never reaches capture).
+  tx_signature TEXT NOT NULL,
   created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
   -- Re-running the same sync (same tx) must not double-log: one row per
-  -- (course, kind, tx). NULLs are distinct in a UNIQUE, but the writer always
-  -- supplies a tx_signature, so ON CONFLICT DO NOTHING is effective.
+  -- (course, kind, tx). With tx_signature NOT NULL, this UNIQUE fully
+  -- determines conflicts, so ON CONFLICT DO NOTHING at the write site is exact.
   CONSTRAINT course_changelog_dedup UNIQUE (course_id, kind, tx_signature)
 );
 
@@ -86,11 +96,25 @@ CREATE INDEX IF NOT EXISTS idx_course_changelog_course_created
 -- ── RLS: public read, service_role-only write ───────────────────────────────
 ALTER TABLE public.course_changelog ENABLE ROW LEVEL SECURITY;
 
--- Public read: the log is learner-facing and non-sensitive. anon + authenticated
--- both get it (course pages are anon-accessible).
+-- Scoped read: visible only for a course that is currently synced AND active —
+-- the SAME gate the catalog applies (isSynced). Fail-closed: a hidden/
+-- deactivated course's title history never leaks to an anon PostgREST caller.
+-- The EXISTS targets the anon-readable VIEW (owner-privilege), not the base
+-- table (RLS-on/no-policy would make this subquery see nothing → hide all).
 DROP POLICY IF EXISTS "Course changelog is viewable by everyone" ON public.course_changelog;
-CREATE POLICY "Course changelog is viewable by everyone"
-  ON public.course_changelog FOR SELECT USING (true);
+DROP POLICY IF EXISTS "Course changelog visible for synced-active courses" ON public.course_changelog;
+CREATE POLICY "Course changelog visible for synced-active courses"
+  ON public.course_changelog FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.public_onchain_deployments d
+      WHERE d.content_id = course_changelog.course_id
+        AND d.kind = 'course'
+        AND d.status = 'synced'
+        AND COALESCE(d.is_active, true)
+    )
+  );
 -- NO write policy: writes only via service_role (bypasses RLS) from the admin
 -- sync route. An INSERT/UPDATE/DELETE policy here would open a client forge path.
 

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -2447,3 +2447,36 @@ $$;
 
 REVOKE ALL ON FUNCTION get_ai_spend_today() FROM PUBLIC, anon, authenticated;
 GRANT EXECUTE ON FUNCTION get_ai_spend_today() TO service_role;
+
+-- ============================================================================
+-- course_changelog (#654) — post-deployment course evolution log.
+-- Mirror of supabase/migrations/20260726210000_course_changelog.sql. See that
+-- file's header for the full rationale. Server-side capture at mutation time
+-- (the admin sync route, service_role); learner-visible public read.
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS public.course_changelog (
+  id           BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  course_id    TEXT NOT NULL,
+  kind         TEXT NOT NULL CHECK (kind IN (
+                 'deployed',
+                 'lessons_added',
+                 'lessons_removed',
+                 'xp_changed',
+                 'content_updated'
+               )),
+  version      INTEGER NOT NULL,
+  detail       JSONB NOT NULL DEFAULT '{}'::jsonb,
+  tx_signature TEXT,
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CONSTRAINT course_changelog_dedup UNIQUE (course_id, kind, tx_signature)
+);
+
+CREATE INDEX IF NOT EXISTS idx_course_changelog_course_created
+  ON public.course_changelog (course_id, created_at DESC);
+
+ALTER TABLE public.course_changelog ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Course changelog is viewable by everyone" ON public.course_changelog;
+CREATE POLICY "Course changelog is viewable by everyone"
+  ON public.course_changelog FOR SELECT USING (true);
+-- NO write policy: service_role-only writes (bypasses RLS) from the admin sync route.

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -2466,7 +2466,7 @@ CREATE TABLE IF NOT EXISTS public.course_changelog (
                )),
   version      INTEGER NOT NULL,
   detail       JSONB NOT NULL DEFAULT '{}'::jsonb,
-  tx_signature TEXT,
+  tx_signature TEXT NOT NULL,
   created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
   CONSTRAINT course_changelog_dedup UNIQUE (course_id, kind, tx_signature)
 );
@@ -2476,7 +2476,21 @@ CREATE INDEX IF NOT EXISTS idx_course_changelog_course_created
 
 ALTER TABLE public.course_changelog ENABLE ROW LEVEL SECURITY;
 
+-- Fail-closed public read: visible only for a synced+active course (the catalog
+-- gate, isSynced). EXISTS runs against the anon-readable public_onchain_deployments
+-- view, defined by 20260711120000_onchain_deployments.sql.
 DROP POLICY IF EXISTS "Course changelog is viewable by everyone" ON public.course_changelog;
-CREATE POLICY "Course changelog is viewable by everyone"
-  ON public.course_changelog FOR SELECT USING (true);
+DROP POLICY IF EXISTS "Course changelog visible for synced-active courses" ON public.course_changelog;
+CREATE POLICY "Course changelog visible for synced-active courses"
+  ON public.course_changelog FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.public_onchain_deployments d
+      WHERE d.content_id = course_changelog.course_id
+        AND d.kind = 'course'
+        AND d.status = 'synced'
+        AND COALESCE(d.is_active, true)
+    )
+  );
 -- NO write policy: service_role-only writes (bypasses RLS) from the admin sync route.


### PR DESCRIPTION
Closes #654.

## What

A **course changelog** on course pages: a learner-visible log of how a course evolved after deployment — lessons added / retired (diffed from the on-chain `active_lessons` bitmap), XP-per-lesson changes, and content re-syncs. Post-deployment mutation is no longer silent.

Rendered below the curriculum + discussions. Entries newer than the learner's enrollment are flagged "new since you enrolled" (issue point 3).

## Data-source design

**Server-side capture at mutation time** — not Helius `CourseUpdated` replay.

The issue floats two options (index events vs. read on demand); I took the higher-fidelity third path the mutation model implies. The admin sync route (`api/admin/courses/sync`) is the *sole* mutator of a course's on-chain state, and at mutation time it already holds **both** the prior on-chain state (`fetchCourse`) **and** the intended new state (the committed `slots.lock` mask + xp). So it computes the human-readable diff there and writes `course_changelog` rows via `service_role` — mirroring how `onchain_deployments` is written from the same route. The `CourseUpdated` event carries only `version`/`collection`/`timestamp` and **cannot** say which lesson slots moved, so replay would be lossy.

Lesson titles are **snapshotted** into `detail` at capture time: a changelog is an immutable historical record, a retired lesson may later vanish from the content bundle, and a renamed lesson should read in the log under the name it had when it changed. The read seam therefore never touches the content bundle.

One row per `(mutation, change-kind)`: a single sync that adds a lesson *and* changes XP produces two rows sharing `tx_signature` + `version`, rendered under one dated update. Kinds: `deployed`, `lessons_added`, `lessons_removed`, `xp_changed`, `content_updated`.

**Design tradeoff — `content_updated` is suppressed when the live-lesson set changed in the same sync.** A `content_updated` row is emitted only for a *pure* re-sync (content `tx_id` bumped, no add/retire). When lessons were added or retired in the same update, those `lessons_added`/`lessons_removed` rows already carry the version bump, so a separate `content_updated` would be redundant noise on the same timestamp. This is a deliberate choice (chosen, not missed): the tradeoff is that a "lessons changed **and** other content edited" sync surfaces only the lesson rows, not a distinct "content refreshed" line — acceptable because the version bump is already visible on the lesson rows. Reorder is intentionally not a kind: the bitmap tracks liveness, not display order, so reordering isn't derivable from it.

## Migration

`20260726210000_course_changelog.sql` (+ `schema.sql` mirror):
- **RLS on, fail-closed SELECT policy**: a row is visible only when its course currently has a `synced` AND active deployment — the exact catalog gate (`isSynced` = `status = 'synced' AND COALESCE(is_active, true)`). The `EXISTS` targets the anon-readable `public_onchain_deployments` **view** (owner-privilege), not the RLS-blocked base table. A course can be on-chain-deployed yet hidden (deactivated / synced-then-deactivated); a blanket `USING (true)` would let any anon PostgREST caller enumerate its snapshotted lesson titles. No deployment / unsynced / inactive ⇒ hidden.
- **No write policy** → `service_role`-only writes (the sync route is the sole writer).
- **`tx_signature` NOT NULL**: it is the dedup key, and Postgres treats NULLs as distinct in a UNIQUE, so a nullable column would silently defeat idempotency. Dedup `UNIQUE (course_id, kind, tx_signature)` + `ON CONFLICT DO NOTHING` → re-running a sync never double-logs.
- Idempotent (`IF NOT EXISTS`, `DROP POLICY IF EXISTS`), explicit `BEGIN/COMMIT`, tested rollback block. `course_id` is the content `_id` verbatim (PDA-seed convention).

No live-DB changes — SQL-only, per repo conventions.

## Learner signal (issue pt.3)

Entries newer than the learner's enrollment are flagged "new since you enrolled" via a date compare against `enrollments.enrolled_at` — no on-chain generation read needed.

## i18n / a11y

Strings in `en` / `es` / `pt-BR` with ICU plurals. Section is `aria-labelledby` a heading, entries are an `<ol>`, dates are `<time datetime>`.

## Verification

`pnpm install --frozen-lockfile && pnpm typecheck && pnpm --filter web test` — all green.
- typecheck: 6/6 packages pass
- **web suite: 191 files, 1720 tests pass**

Tests: mask diff, capture per mutation kind + idempotency + null-title fallback + non-fatal error, RLS/schema-mirror guard (pins the scoped predicate; mutation: `USING(true)` fails the guard; NOT NULL pinned), RLS-safe read + defensive decode (drops malformed rows), component rendering + empty state + since-enrolled signal.

## Review fixes (adversarial review of #732)

Second commit (`183fc2c`) addresses:
- **MINOR-1** — scoped the SELECT policy fail-closed (see Migration above).
- **MINOR-2** — `tx_signature` NOT NULL; route drops the `!` assertions for truthy guards.
- **MINOR-3** — documented the `content_updated` suppression tradeoff (see Data-source design above).

PR diff is clean against origin/main (merge-base `5892eb9`); the branch carries only this change.

Do not merge — for review.
