### PR TITLE
feat(leaderboard): cohort leagues + you-±3 strip (#574)

### DIFF
--- a/apps/web/src/app/[locale]/(platform)/dashboard/page.tsx
+++ b/apps/web/src/app/[locale]/(platform)/dashboard/page.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/components/dashboard/continue-card";
 import { CurrentCoursesSection } from "@/components/dashboard/current-courses-section";
 import { ReviewStrip } from "@/components/dashboard/review-strip";
+import { CohortStrip } from "@/components/dashboard/cohort-strip";
 import { MasteryPanel } from "@/components/dashboard/mastery-panel";
 import { NameRevealDialog } from "@/components/dashboard/name-reveal-dialog";
 import { NextLessonPlan } from "@/components/dashboard/next-lesson-plan";
@@ -107,6 +108,10 @@ export default function DashboardPage() {
       {/* Due-review strip — additive hero slot under Continue (LX-B6); renders
           nothing when the review queue is empty. */}
       <ReviewStrip userId={data.userId} />
+
+      {/* Cohort league "you ±3" strip — additive slot (LX-B9b); renders nothing
+          until the viewer has a weekly cohort with at least one neighbor. */}
+      <CohortStrip userId={data.userId} />
 
       {/* V9 Dashboard Identity Panel — Level+XP | Medals | Activity Grid */}
       <DashboardIdentityPanel

--- a/apps/web/src/app/[locale]/(platform)/leaderboard/leaderboard-client.tsx
+++ b/apps/web/src/app/[locale]/(platform)/leaderboard/leaderboard-client.tsx
@@ -196,7 +196,7 @@ function LeagueBoard({ cohort }: { cohort: CohortLeague | null }) {
       <div className="lb-list">
         {cohort.entries.map((entry, i) => (
           <CohortRow
-            key={entry.userId}
+            key={entry.rank}
             entry={entry}
             style={{ "--i": i } as React.CSSProperties}
           />

--- a/apps/web/src/app/[locale]/(platform)/leaderboard/leaderboard-client.tsx
+++ b/apps/web/src/app/[locale]/(platform)/leaderboard/leaderboard-client.tsx
@@ -4,25 +4,34 @@ import { useState, useCallback } from "react";
 import { useTranslations, useLocale } from "next-intl";
 import Link from "next/link";
 import Image from "next/image";
-import { Trophy, Crown, Lightning, Medal } from "@phosphor-icons/react";
-import type { LeaderboardEntry } from "@superteam-lms/types";
+import {
+  Trophy,
+  Crown,
+  Lightning,
+  Medal,
+  UsersThree,
+} from "@phosphor-icons/react";
+import type { LeaderboardEntry, CohortLeague } from "@superteam-lms/types";
 import { LevelBadge } from "@/components/gamification/level-badge";
+import { CohortRow } from "@/components/leaderboard/cohort-row";
 import { cn } from "@/lib/utils";
 
 type Timeframe = "weekly" | "monthly" | "alltime";
+type Board = "league" | "global";
 
 interface LeaderboardClientProps {
-  initialEntries: LeaderboardEntry[];
-  initialTimeframe: Timeframe;
+  initialGlobalEntries: LeaderboardEntry[];
+  initialCohort: CohortLeague | null;
   currentUserId: string;
 }
 
-function truncateWallet(address: string): string {
-  if (address.length <= 10) return address;
-  return `${address.slice(0, 4)}...${address.slice(-4)}`;
+/** Localized league tier name (1-based), clamped to the four seeded tiers. */
+function tierName(t: (k: string) => string, tier: number): string {
+  const clamped = Math.min(Math.max(tier, 1), 4);
+  return t(`leagueTier${clamped}`);
 }
 
-/* ── Podium card for ranks 1-3 ── */
+/* ── Podium card for ranks 1-3 (global board) ── */
 function PodiumCard({
   entry,
   isCurrentUser,
@@ -50,7 +59,6 @@ function PodiumCard({
           isCurrentUser && "me"
         )}
       >
-        {/* Rank icon */}
         <div className="podium-rank-icon">
           {rank === 1 ? (
             <Crown size={20} weight="fill" />
@@ -61,7 +69,6 @@ function PodiumCard({
           )}
         </div>
 
-        {/* Avatar */}
         <div className={cn("podium-avatar", rank === 1 && "gold")}>
           {entry.avatarUrl ? (
             <Image
@@ -77,23 +84,20 @@ function PodiumCard({
           )}
         </div>
 
-        {/* Name */}
         <div className="podium-name">
           <span className="truncate">{entry.username}</span>
           {isCurrentUser && <span className="lb-me-tag">{t("you")}</span>}
         </div>
 
-        {/* XP */}
         <div className="podium-xp">{entry.totalXp.toLocaleString()} XP</div>
 
-        {/* Level badge */}
         <LevelBadge level={entry.level} size="sm" />
       </div>
     </Link>
   );
 }
 
-/* ── Ranked row for positions 4+ ── */
+/* ── Ranked row for positions 4+ (global board) ── */
 function RankedRow({
   entry,
   isCurrentUser,
@@ -139,9 +143,7 @@ function RankedRow({
             {isCurrentUser && <span className="lb-me-tag">{t("you")}</span>}
           </div>
           {entry.walletAddress && (
-            <div className="lb-wallet">
-              {truncateWallet(entry.walletAddress)}
-            </div>
+            <div className="lb-wallet">{entry.walletAddress}</div>
           )}
         </div>
 
@@ -154,50 +156,77 @@ function RankedRow({
   );
 }
 
-export function LeaderboardClient({
-  initialEntries,
-  initialTimeframe,
+/* ── League (cohort) board — the primary view ── */
+function LeagueBoard({ cohort }: { cohort: CohortLeague | null }) {
+  const t = useTranslations("gamification");
+
+  if (!cohort) {
+    return (
+      <div className="lb-empty">
+        <UsersThree size={48} weight="duotone" aria-hidden="true" />
+        <p>{t("leagueSignIn")}</p>
+      </div>
+    );
+  }
+
+  if (cohort.entries.length === 0) {
+    return (
+      <div className="lb-empty">
+        <UsersThree size={48} weight="duotone" aria-hidden="true" />
+        <p>{t("noEntries")}</p>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <div className="lb-league-head">
+        <span className="lb-league-icon" aria-hidden="true">
+          <UsersThree size={22} weight="fill" />
+        </span>
+        <div className="min-w-0">
+          <p className="lb-league-tier">{tierName(t, cohort.tier)}</p>
+          <p className="lb-league-sub">
+            {t("cohortMembers", { count: cohort.memberCount })} ·{" "}
+            {t("leagueResets")}
+          </p>
+        </div>
+      </div>
+
+      <div className="lb-list">
+        {cohort.entries.map((entry, i) => (
+          <CohortRow
+            key={entry.userId}
+            entry={entry}
+            style={{ "--i": i } as React.CSSProperties}
+          />
+        ))}
+      </div>
+    </>
+  );
+}
+
+/* ── Global board — demoted secondary view ── */
+function GlobalBoard({
+  entries,
+  isLoading,
+  timeframe,
+  onTimeframeChange,
   currentUserId,
-}: LeaderboardClientProps) {
+  locale,
+}: {
+  entries: LeaderboardEntry[];
+  isLoading: boolean;
+  timeframe: Timeframe;
+  onTimeframeChange: (tf: Timeframe) => void;
+  currentUserId: string;
+  locale: string;
+}) {
   const t = useTranslations("gamification");
   const tCommon = useTranslations("common");
-  const locale = useLocale();
-  const [timeframe, setTimeframe] = useState<Timeframe>(initialTimeframe);
-  const [entries, setEntries] = useState<LeaderboardEntry[]>(initialEntries);
-  const [isLoading, setIsLoading] = useState(false);
 
-  const fetchLeaderboard = useCallback(async (tf: Timeframe) => {
-    setIsLoading(true);
-    try {
-      const res = await fetch(`/api/leaderboard?timeframe=${tf}`);
-      if (!res.ok) {
-        setEntries([]);
-        return;
-      }
-      const { entries: leaderboard } = (await res.json()) as {
-        entries: LeaderboardEntry[];
-      };
-      setEntries(leaderboard);
-    } catch {
-      setEntries([]);
-    } finally {
-      setIsLoading(false);
-    }
-  }, []);
-
-  const handleTimeframeChange = useCallback(
-    (tf: Timeframe) => {
-      setTimeframe(tf);
-      fetchLeaderboard(tf);
-    },
-    [fetchLeaderboard]
-  );
-
-  // Split entries into podium (top 3) and rest
   const podiumEntries = entries.slice(0, 3);
   const restEntries = entries.slice(3);
-
-  // Reorder podium: [2nd, 1st, 3rd] for visual layout
   const podiumOrdered: LeaderboardEntry[] =
     podiumEntries.length >= 3
       ? [podiumEntries[1]!, podiumEntries[0]!, podiumEntries[2]!]
@@ -206,23 +235,12 @@ export function LeaderboardClient({
   const TIMEFRAMES: Timeframe[] = ["weekly", "monthly", "alltime"];
 
   return (
-    <div className="lb-page">
-      {/* Header */}
-      <div className="lb-header">
-        <h1 className="font-display text-2xl font-black tracking-[-0.5px] sm:text-3xl">
-          {t("leaderboard")}
-        </h1>
-        <p className="mt-1 text-text-3">
-          {t("rank")} — {t(timeframe === "alltime" ? "allTime" : timeframe)}
-        </p>
-      </div>
-
-      {/* Timeframe tabs — underline style matching catalog-tabs */}
+    <>
       <div className="lb-timeframe-tabs">
         {TIMEFRAMES.map((tf) => (
           <button
             key={tf}
-            onClick={() => handleTimeframeChange(tf)}
+            onClick={() => onTimeframeChange(tf)}
             className={cn("lb-tf-tab", timeframe === tf && "active")}
           >
             {t(tf === "alltime" ? "allTime" : tf)}
@@ -230,7 +248,6 @@ export function LeaderboardClient({
         ))}
       </div>
 
-      {/* Content */}
       {isLoading ? (
         <div className="flex items-center justify-center py-20">
           <div className="sol-spinner" />
@@ -243,7 +260,6 @@ export function LeaderboardClient({
         </div>
       ) : (
         <>
-          {/* ═══ Podium ═══ */}
           <div
             className={cn(
               "podium-grid",
@@ -260,7 +276,6 @@ export function LeaderboardClient({
             ))}
           </div>
 
-          {/* ═══ Ranked List ═══ */}
           {restEntries.length > 0 && (
             <div className="lb-list">
               {restEntries.map((entry, i) => (
@@ -275,6 +290,104 @@ export function LeaderboardClient({
             </div>
           )}
         </>
+      )}
+    </>
+  );
+}
+
+export function LeaderboardClient({
+  initialGlobalEntries,
+  initialCohort,
+  currentUserId,
+}: LeaderboardClientProps) {
+  const t = useTranslations("gamification");
+  const locale = useLocale();
+
+  // League is primary; fall back to global for anon visitors with no cohort.
+  const [board, setBoard] = useState<Board>(
+    initialCohort ? "league" : "global"
+  );
+  const [timeframe, setTimeframe] = useState<Timeframe>("alltime");
+  const [globalEntries, setGlobalEntries] =
+    useState<LeaderboardEntry[]>(initialGlobalEntries);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const fetchGlobal = useCallback(async (tf: Timeframe) => {
+    setIsLoading(true);
+    try {
+      const res = await fetch(`/api/leaderboard?timeframe=${tf}`);
+      if (!res.ok) {
+        setGlobalEntries([]);
+        return;
+      }
+      const { entries } = (await res.json()) as { entries: LeaderboardEntry[] };
+      setGlobalEntries(entries);
+    } catch {
+      setGlobalEntries([]);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  const handleTimeframeChange = useCallback(
+    (tf: Timeframe) => {
+      setTimeframe(tf);
+      fetchGlobal(tf);
+    },
+    [fetchGlobal]
+  );
+
+  const BOARDS: { id: Board; label: string }[] = [
+    { id: "league", label: t("league") },
+    { id: "global", label: t("global") },
+  ];
+
+  return (
+    <div className="lb-page">
+      <div className="lb-header">
+        <h1 className="font-display text-2xl font-black tracking-[-0.5px] sm:text-3xl">
+          {t("leaderboard")}
+        </h1>
+        <p className="mt-1 text-text-3">
+          {board === "league" ? t("leagueSubtitle") : t("globalSubtitle")}
+        </p>
+      </div>
+
+      {/* Primary board switch — League (cohort) is the default; Global demoted. */}
+      <div
+        className="lb-board-tabs"
+        role="tablist"
+        aria-label={t("leaderboard")}
+      >
+        {BOARDS.map((b) => (
+          <button
+            key={b.id}
+            role="tab"
+            aria-selected={board === b.id}
+            onClick={() => setBoard(b.id)}
+            className={cn("lb-board-tab", board === b.id && "active")}
+          >
+            {b.id === "league" ? (
+              <UsersThree size={16} weight="bold" aria-hidden="true" />
+            ) : (
+              <Trophy size={16} weight="bold" aria-hidden="true" />
+            )}
+            {b.label}
+          </button>
+        ))}
+      </div>
+
+      {board === "league" ? (
+        <LeagueBoard cohort={initialCohort} />
+      ) : (
+        <GlobalBoard
+          entries={globalEntries}
+          isLoading={isLoading}
+          timeframe={timeframe}
+          onTimeframeChange={handleTimeframeChange}
+          currentUserId={currentUserId}
+          locale={locale}
+        />
       )}
     </div>
   );

--- a/apps/web/src/app/[locale]/(platform)/leaderboard/page.tsx
+++ b/apps/web/src/app/[locale]/(platform)/leaderboard/page.tsx
@@ -1,13 +1,17 @@
-import { LeaderboardClient } from "./leaderboard-client";
+import type { CohortLeague } from "@superteam-lms/types";
 import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
 import { getProgressService } from "@/lib/services";
+import { getCohortLeaderboard } from "@/lib/leaderboard/cohort";
+import { serverEnv } from "@/lib/env.server";
+import { LeaderboardClient } from "./leaderboard-client";
 
 export default async function LeaderboardPage() {
   const supabase = await createClient();
   const service = getProgressService(supabase);
 
   const [
-    initialEntries,
+    initialGlobalEntries,
     {
       data: { user },
     },
@@ -16,10 +20,23 @@ export default async function LeaderboardPage() {
     supabase.auth.getUser(),
   ]);
 
+  // Cohort league is the primary board (LX-B9b). It requires an authenticated
+  // user (lazy assignment) and the service-role RPC; anon visitors see only the
+  // demoted global board. A cohort read failure degrades to global, never 500s
+  // the page.
+  let initialCohort: CohortLeague | null = null;
+  if (user && serverEnv.SUPABASE_SERVICE_ROLE_KEY) {
+    try {
+      initialCohort = await getCohortLeaderboard(createAdminClient(), user.id);
+    } catch {
+      initialCohort = null;
+    }
+  }
+
   return (
     <LeaderboardClient
-      initialEntries={initialEntries}
-      initialTimeframe="alltime"
+      initialGlobalEntries={initialGlobalEntries}
+      initialCohort={initialCohort}
       currentUserId={user?.id ?? ""}
     />
   );

--- a/apps/web/src/app/api/leaderboard/cohort/route.ts
+++ b/apps/web/src/app/api/leaderboard/cohort/route.ts
@@ -1,0 +1,58 @@
+import { NextRequest, NextResponse } from "next/server";
+import type { CohortLeague } from "@superteam-lms/types";
+import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { getCohortLeaderboard } from "@/lib/leaderboard/cohort";
+import { deriveCohortStrip } from "@/lib/leaderboard/cohort-window";
+import { serverEnv } from "@/lib/env.server";
+
+// Auth/cookie + per-request DB access — never statically prerender.
+export const dynamic = "force-dynamic";
+
+/**
+ * Weekly cohort league for the signed-in learner (LX-B9b). `?window=strip`
+ * returns only the "you ±3" nearby-rank slice (derived server-side over the
+ * snapshot board); otherwise the full cohort. The board RPC assigns the learner
+ * lazily on first read and reads materialized snapshot scores.
+ */
+export async function GET(request: NextRequest) {
+  if (
+    !process.env.NEXT_PUBLIC_SUPABASE_URL ||
+    !serverEnv.SUPABASE_SERVICE_ROLE_KEY
+  ) {
+    return NextResponse.json(
+      { error: "Server configuration error" },
+      { status: 500 }
+    );
+  }
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const admin = createAdminClient();
+    const league = await getCohortLeaderboard(admin, user.id);
+
+    if (!league) {
+      return NextResponse.json({ league: null });
+    }
+
+    const strip = request.nextUrl.searchParams.get("window") === "strip";
+    const payload: CohortLeague = strip
+      ? { ...league, entries: deriveCohortStrip(league.entries) }
+      : league;
+
+    return NextResponse.json({ league: payload });
+  } catch {
+    return NextResponse.json(
+      { error: "Failed to fetch cohort league" },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/web/src/components/dashboard/cohort-strip.tsx
+++ b/apps/web/src/components/dashboard/cohort-strip.tsx
@@ -85,7 +85,7 @@ export function CohortStrip({ userId }: CohortStripProps) {
       <div className="lb-list lb-list-compact">
         {league.entries.map((entry, i) => (
           <CohortRow
-            key={entry.userId}
+            key={entry.rank}
             entry={entry}
             style={{ "--i": i } as React.CSSProperties}
           />

--- a/apps/web/src/components/dashboard/cohort-strip.tsx
+++ b/apps/web/src/components/dashboard/cohort-strip.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { useTranslations, useLocale } from "next-intl";
+import { UsersThree, ArrowRight } from "@phosphor-icons/react";
+import type { CohortLeague } from "@superteam-lms/types";
+import { CohortRow } from "@/components/leaderboard/cohort-row";
+
+interface CohortStripProps {
+  /** Authenticated user id, or null before auth resolves. */
+  userId: string | null;
+}
+
+/** Localized league tier name (1-based), clamped to the four seeded tiers. */
+function tierName(t: (k: string) => string, tier: number): string {
+  const clamped = Math.min(Math.max(tier, 1), 4);
+  return t(`leagueTier${clamped}`);
+}
+
+/**
+ * Dashboard "you ±3" league strip (LX-B9b). An additive slot that fetches the
+ * viewer's nearby-rank window (server-derived over snapshot scores) and deep
+ * links into the leaderboard's League tab. Renders nothing until there is a
+ * cohort with at least one neighbor — a solo strip is not a league, and (per
+ * LX-B13) nothing about it should read as a hero rank metric.
+ */
+export function CohortStrip({ userId }: CohortStripProps) {
+  const t = useTranslations("gamification");
+  const locale = useLocale();
+  const [league, setLeague] = useState<CohortLeague | null>(null);
+
+  useEffect(() => {
+    if (!userId) return;
+    let active = true;
+    (async () => {
+      try {
+        const res = await fetch("/api/leaderboard/cohort?window=strip");
+        if (!res.ok) return;
+        const { league: data } = (await res.json()) as {
+          league: CohortLeague | null;
+        };
+        if (active) setLeague(data);
+      } catch {
+        // Non-critical dashboard surface — stay hidden on failure.
+      }
+    })();
+    return () => {
+      active = false;
+    };
+  }, [userId]);
+
+  // Hidden until there is a cohort with at least one neighbor besides the viewer.
+  if (!league || league.entries.length < 2) return null;
+
+  return (
+    <section
+      aria-label={t("cohortStripAria")}
+      className="rounded-xl border border-border bg-card p-4 shadow-card"
+    >
+      <div className="mb-3 flex items-center gap-3">
+        <span
+          className="bg-primary-dim flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-primary"
+          aria-hidden="true"
+        >
+          <UsersThree size={18} weight="fill" />
+        </span>
+        <div className="min-w-0 flex-1">
+          <p className="font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-primary">
+            {t("cohortStripTitle")}
+          </p>
+          <p className="truncate text-sm font-semibold text-text-2">
+            {tierName(t, league.tier)}
+          </p>
+        </div>
+        <Link
+          href={`/${locale}/leaderboard`}
+          className="flex shrink-0 items-center gap-1.5 font-display text-sm font-extrabold text-primary transition-transform duration-200 hover:translate-x-0.5 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+        >
+          <span className="hidden sm:inline">{t("cohortViewAll")}</span>
+          <ArrowRight size={15} weight="bold" aria-hidden="true" />
+        </Link>
+      </div>
+
+      <div className="lb-list lb-list-compact">
+        {league.entries.map((entry, i) => (
+          <CohortRow
+            key={entry.userId}
+            entry={entry}
+            style={{ "--i": i } as React.CSSProperties}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/leaderboard/cohort-row.tsx
+++ b/apps/web/src/components/leaderboard/cohort-row.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import Link from "next/link";
+import Image from "next/image";
+import { useTranslations, useLocale } from "next-intl";
+import { User } from "@phosphor-icons/react";
+import type { CohortLeaderboardEntry } from "@superteam-lms/types";
+import { cn } from "@/lib/utils";
+
+interface CohortRowProps {
+  entry: CohortLeaderboardEntry;
+  style?: React.CSSProperties;
+}
+
+/**
+ * One cohort-league row (LX-B9b). Private/deleted members arrive with a null
+ * username (anonymized by the RPC, never dropped) and render as "Anonymous
+ * learner" with a neutral avatar and no profile link. The viewer's own row is
+ * highlighted and labeled "You" even when anonymized.
+ */
+export function CohortRow({ entry, style }: CohortRowProps) {
+  const t = useTranslations("gamification");
+  const locale = useLocale();
+
+  const anonymized = !entry.username;
+  const displayName = entry.username ?? t("anonymousLearner");
+  const initials = entry.username
+    ? entry.username.slice(0, 2).toUpperCase()
+    : null;
+
+  const inner = (
+    <div className={cn("lb-row", entry.isYou && "me")} style={style}>
+      <span className="lb-rank" aria-label={`${t("rank")} ${entry.rank}`}>
+        {entry.rank}
+      </span>
+
+      <div className="lb-av" aria-hidden="true">
+        {entry.avatarUrl ? (
+          <Image
+            src={entry.avatarUrl}
+            alt=""
+            width={64}
+            height={64}
+            unoptimized
+            className="h-full w-full rounded-full object-cover"
+          />
+        ) : initials ? (
+          <span>{initials}</span>
+        ) : (
+          <User size={18} weight="bold" />
+        )}
+      </div>
+
+      <div className="lb-info">
+        <div className="lb-name">
+          <span className={cn("truncate", anonymized && "text-text-3")}>
+            {displayName}
+          </span>
+          {entry.isYou && <span className="lb-me-tag">{t("you")}</span>}
+        </div>
+      </div>
+
+      <div className="lb-right">
+        <span className="lb-xp">{entry.score.toLocaleString()} XP</span>
+      </div>
+    </div>
+  );
+
+  // Named public profiles link out; anonymized members (and the viewer's own
+  // private row) are not linkable.
+  if (anonymized) return inner;
+
+  return (
+    <Link
+      href={`/${locale}/profile/${encodeURIComponent(entry.username!)}`}
+      className="block no-underline"
+    >
+      {inner}
+    </Link>
+  );
+}

--- a/apps/web/src/lib/leaderboard/__tests__/cohort-window.test.ts
+++ b/apps/web/src/lib/leaderboard/__tests__/cohort-window.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from "vitest";
+import type { CohortLeaderboardEntry } from "@superteam-lms/types";
+import {
+  cohortStripWindow,
+  deriveCohortStrip,
+} from "@/lib/leaderboard/cohort-window";
+
+describe("cohortStripWindow (you ±3 sliding window, LX-B9b)", () => {
+  it("centers on the viewer in the interior", () => {
+    expect(cohortStripWindow(15, 30, 3)).toEqual({ lo: 12, hi: 18 });
+  });
+
+  it("slides to the top edge at rank 1 (never runs off the front)", () => {
+    // No neighbors above → show 1..7, keeping the full window of 7.
+    expect(cohortStripWindow(1, 30, 3)).toEqual({ lo: 1, hi: 7 });
+    expect(cohortStripWindow(2, 30, 3)).toEqual({ lo: 1, hi: 7 });
+    expect(cohortStripWindow(3, 30, 3)).toEqual({ lo: 1, hi: 7 });
+    // rank 4 is the first that can center.
+    expect(cohortStripWindow(4, 30, 3)).toEqual({ lo: 1, hi: 7 });
+    expect(cohortStripWindow(5, 30, 3)).toEqual({ lo: 2, hi: 8 });
+  });
+
+  it("slides to the bottom edge at the last rank (never runs off the end)", () => {
+    expect(cohortStripWindow(30, 30, 3)).toEqual({ lo: 24, hi: 30 });
+    expect(cohortStripWindow(29, 30, 3)).toEqual({ lo: 24, hi: 30 });
+    expect(cohortStripWindow(28, 30, 3)).toEqual({ lo: 24, hi: 30 });
+    expect(cohortStripWindow(27, 30, 3)).toEqual({ lo: 24, hi: 30 });
+    expect(cohortStripWindow(26, 30, 3)).toEqual({ lo: 23, hi: 29 });
+  });
+
+  it("shrinks the window to the cohort when it is smaller than 2r+1", () => {
+    // n=4 < 7 → whole cohort regardless of the viewer's rank.
+    for (const rank of [1, 2, 3, 4]) {
+      expect(cohortStripWindow(rank, 4, 3)).toEqual({ lo: 1, hi: 4 });
+    }
+    // n=5, viewer last → still the whole cohort.
+    expect(cohortStripWindow(5, 5, 3)).toEqual({ lo: 1, hi: 5 });
+  });
+
+  it("handles the degenerate single-member cohort", () => {
+    expect(cohortStripWindow(1, 1, 3)).toEqual({ lo: 1, hi: 1 });
+  });
+
+  it("returns an empty window for an empty cohort", () => {
+    expect(cohortStripWindow(1, 0, 3)).toEqual({ lo: 1, hi: 0 });
+  });
+
+  it("respects radius 0 (just the viewer) and defaults radius to 3", () => {
+    expect(cohortStripWindow(15, 30, 0)).toEqual({ lo: 15, hi: 15 });
+    expect(cohortStripWindow(15, 30)).toEqual({ lo: 12, hi: 18 });
+  });
+
+  it("always yields a window of size min(n, 2r+1) that contains the viewer", () => {
+    for (const n of [1, 4, 7, 8, 30]) {
+      for (let rank = 1; rank <= n; rank++) {
+        const { lo, hi } = cohortStripWindow(rank, n, 3);
+        expect(hi - lo + 1).toBe(Math.min(n, 7));
+        expect(rank).toBeGreaterThanOrEqual(lo);
+        expect(rank).toBeLessThanOrEqual(hi);
+        expect(lo).toBeGreaterThanOrEqual(1);
+        expect(hi).toBeLessThanOrEqual(n);
+      }
+    }
+  });
+});
+
+function entry(rank: number, isYou = false): CohortLeaderboardEntry {
+  return {
+    userId: `u${rank}`,
+    username: `learner${rank}`,
+    avatarUrl: null,
+    score: (31 - rank) * 10,
+    rank,
+    isYou,
+  };
+}
+
+describe("deriveCohortStrip (LX-B9b)", () => {
+  const board = Array.from({ length: 30 }, (_, i) =>
+    entry(i + 1, i + 1 === 15)
+  );
+
+  it("returns the viewer ±3 centered", () => {
+    const strip = deriveCohortStrip(board);
+    expect(strip.map((e) => e.rank)).toEqual([12, 13, 14, 15, 16, 17, 18]);
+    expect(strip.find((e) => e.isYou)?.rank).toBe(15);
+  });
+
+  it("slides to the top edge for rank 1", () => {
+    const b = board.map((e) => ({ ...e, isYou: e.rank === 1 }));
+    expect(deriveCohortStrip(b).map((e) => e.rank)).toEqual([
+      1, 2, 3, 4, 5, 6, 7,
+    ]);
+  });
+
+  it("slides to the bottom edge for the last rank", () => {
+    const b = board.map((e) => ({ ...e, isYou: e.rank === 30 }));
+    expect(deriveCohortStrip(b).map((e) => e.rank)).toEqual([
+      24, 25, 26, 27, 28, 29, 30,
+    ]);
+  });
+
+  it("returns the whole cohort when it is small", () => {
+    const small = [entry(1), entry(2, true), entry(3)];
+    expect(deriveCohortStrip(small).map((e) => e.rank)).toEqual([1, 2, 3]);
+  });
+
+  it("fails closed (empty) when the viewer is absent — never mislabels", () => {
+    expect(
+      deriveCohortStrip(board.map((e) => ({ ...e, isYou: false })))
+    ).toEqual([]);
+  });
+});

--- a/apps/web/src/lib/leaderboard/cohort-window.ts
+++ b/apps/web/src/lib/leaderboard/cohort-window.ts
@@ -1,0 +1,47 @@
+import type { CohortLeaderboardEntry } from "@superteam-lms/types";
+
+/** Default nearby-rank radius for the "you ±3" strip (LX-B9b). */
+export const COHORT_STRIP_RADIUS = 3;
+
+/** ~30-person weekly cohorts — the Duolingo shape (spec LX-B9b). Mirrors the
+ *  LEAGUE_COHORT_CAPACITY constant in 20260726200000_cohort_leagues.sql. */
+export const COHORT_CAPACITY = 30;
+
+/**
+ * A clamped, centered sliding window of ranks for the "you ±radius" strip.
+ *
+ * Returns the inclusive 1-indexed `[lo, hi]` rank range to show: a window of
+ * size `min(total, 2*radius+1)` that contains `myRank` and is as centered as the
+ * edges allow. At rank 1 it slides to `[1, W]`; at the last rank it slides to the
+ * final `W`; in between it is `myRank ± radius`. This is the pure, testable
+ * mirror of what the cohort board's snapshot rows are sliced by — kept out of
+ * SQL so the edge behavior has one implementation and one set of unit tests.
+ */
+export function cohortStripWindow(
+  myRank: number,
+  total: number,
+  radius: number = COHORT_STRIP_RADIUS
+): { lo: number; hi: number } {
+  if (total <= 0) return { lo: 1, hi: 0 };
+  const r = Math.max(0, radius);
+  const win = Math.min(total, 2 * r + 1);
+  // lo clamped into [1, total - win + 1] so the window never runs off either end.
+  const lo = Math.max(1, Math.min(myRank - r, total - win + 1));
+  return { lo, hi: lo + win - 1 };
+}
+
+/**
+ * Slice a full cohort board (ordered by rank ascending, ranks contiguous 1..n)
+ * down to the viewer's "you ±radius" neighborhood. Returns [] when the viewer is
+ * absent (should not happen — assignment adds them — but fail closed rather than
+ * mislabel someone else as "you").
+ */
+export function deriveCohortStrip(
+  entries: readonly CohortLeaderboardEntry[],
+  radius: number = COHORT_STRIP_RADIUS
+): CohortLeaderboardEntry[] {
+  const you = entries.find((e) => e.isYou);
+  if (!you) return [];
+  const { lo, hi } = cohortStripWindow(you.rank, entries.length, radius);
+  return entries.filter((e) => e.rank >= lo && e.rank <= hi);
+}

--- a/apps/web/src/lib/leaderboard/cohort.ts
+++ b/apps/web/src/lib/leaderboard/cohort.ts
@@ -1,0 +1,44 @@
+import "server-only";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type {
+  CohortLeague,
+  CohortLeaderboardEntry,
+} from "@superteam-lms/types";
+import type { Database } from "@/lib/supabase/types";
+
+/**
+ * Fetch the viewer's weekly cohort league via the server-authoritative
+ * `get_cohort_leaderboard` RPC (LX-B9b). Must be called with the service-role
+ * (admin) client: the RPC does lazy assignment writes + cross-user reads and is
+ * REVOKEd from anon/authenticated. Returns null when the user has no cohort
+ * (should not happen — the RPC assigns on read — but callers render the empty
+ * state defensively).
+ */
+export async function getCohortLeaderboard(
+  admin: SupabaseClient<Database>,
+  userId: string
+): Promise<CohortLeague | null> {
+  const { data, error } = await admin.rpc("get_cohort_leaderboard", {
+    p_user_id: userId,
+  });
+
+  if (error) throw new Error(`get_cohort_leaderboard failed: ${error.message}`);
+  if (!data || data.length === 0) return null;
+
+  const entries: CohortLeaderboardEntry[] = data.map((row) => ({
+    userId: row.user_id,
+    username: row.username,
+    avatarUrl: row.avatar_url,
+    score: row.score,
+    rank: row.rank,
+    isYou: row.is_you,
+  }));
+
+  const first = data[0]!;
+  return {
+    tier: first.tier,
+    weekStart: first.week_start,
+    memberCount: entries.length,
+    entries,
+  };
+}

--- a/apps/web/src/lib/supabase/__tests__/cohort-leagues-guard.test.ts
+++ b/apps/web/src/lib/supabase/__tests__/cohort-leagues-guard.test.ts
@@ -1,0 +1,226 @@
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, it, expect } from "vitest";
+
+// #574 (LX-B9b): cohort leagues. RLS/SECURITY-DEFINER invariants cannot be
+// exercised in unit tests, so — as with the #569 review guard — pin the
+// security-critical SQL in BOTH the migration (what gets applied) AND the
+// schema.sql mirror (what new environments build from). A drift between them is
+// the #449-class bug this guard exists to catch.
+
+function findRepoRoot(): string {
+  let dir = dirname(fileURLToPath(import.meta.url));
+  while (!existsSync(resolve(dir, "supabase/schema.sql"))) {
+    const parent = dirname(dir);
+    if (parent === dir)
+      throw new Error("repo root (supabase/schema.sql) not found");
+    dir = parent;
+  }
+  return dir;
+}
+
+const repoRoot = findRepoRoot();
+const migration = readFileSync(
+  resolve(repoRoot, "supabase/migrations/20260726200000_cohort_leagues.sql"),
+  "utf8"
+);
+const schema = readFileSync(resolve(repoRoot, "supabase/schema.sql"), "utf8");
+
+// Every read RPC is SECURITY DEFINER + search_path-pinned + REVOKEd from clients
+// + GRANTed only to service_role. The two write-ish helpers (assign + refresh)
+// are the same. is_league_eligible_source / league_week_start are IMMUTABLE
+// helpers, REVOKEd from clients (never PostgREST-exposed).
+const SERVICE_ROLE_FNS: ReadonlyArray<[string, string]> = [
+  ["ensure_league_membership", "(UUID)"],
+  ["refresh_cohort_scores", "(UUID)"],
+  ["get_cohort_leaderboard", "(UUID)"],
+];
+
+for (const [label, sql] of [
+  ["migration", migration] as const,
+  ["schema.sql", schema] as const,
+]) {
+  describe(`#574 cohort leagues — ${label}`, () => {
+    it("enables RLS on all three league tables", () => {
+      expect(sql).toContain(
+        "ALTER TABLE league_tiers ENABLE ROW LEVEL SECURITY"
+      );
+      expect(sql).toContain(
+        "ALTER TABLE league_cohorts ENABLE ROW LEVEL SECURITY"
+      );
+      expect(sql).toContain(
+        "ALTER TABLE league_members ENABLE ROW LEVEL SECURITY"
+      );
+    });
+
+    it("league_members: own-row SELECT only, NO write/cross-user policy", () => {
+      expect(sql).toContain(
+        `ON league_members FOR SELECT USING (auth.uid() = user_id)`
+      );
+      // Any other policy would open a client path around the RPCs or leak the
+      // cohort (spec: cross-user exposure only via SECURITY DEFINER RPCs).
+      expect(sql).not.toMatch(
+        /ON league_members FOR (INSERT|UPDATE|DELETE|ALL)/
+      );
+      expect(sql).not.toMatch(/ON league_members FOR SELECT USING \(true\)/);
+    });
+
+    it("league_cohorts has NO policy at all — RPC-only exposure", () => {
+      // A cohort row is only ever read through the SECURITY DEFINER RPCs. Any
+      // policy here (even SELECT) would be a broad public read path the spec
+      // forbids ("league tables themselves: no broad public SELECT policy").
+      expect(sql).not.toMatch(/ON league_cohorts FOR /);
+    });
+
+    it("league_tiers is public-read reference data — NO client write path", () => {
+      expect(sql).toContain(`ON league_tiers FOR SELECT USING (true)`);
+      expect(sql).not.toMatch(/ON league_tiers FOR (INSERT|UPDATE|DELETE|ALL)/);
+    });
+
+    it("one membership per learner per week (UNIQUE guard)", () => {
+      expect(sql).toContain("UNIQUE (user_id, week_start)");
+    });
+
+    it("cascades league rows on profile/cohort deletion", () => {
+      expect(sql).toContain(
+        "cohort_id  UUID NOT NULL REFERENCES league_cohorts(id) ON DELETE CASCADE"
+      );
+      expect(sql).toContain(
+        "user_id    UUID NOT NULL REFERENCES profiles(id) ON DELETE CASCADE"
+      );
+    });
+
+    it("hardens every league function (SECURITY DEFINER path-pinned, service_role only)", () => {
+      for (const [fn, args] of SERVICE_ROLE_FNS) {
+        const start = sql.indexOf(`CREATE OR REPLACE FUNCTION public.${fn}(`);
+        expect(start, `${fn} defined`).toBeGreaterThan(-1);
+        // Whitespace-normalized so the assertions are insensitive to the
+        // REVOKE/GRANT line wrapping.
+        const grantIdx = sql.indexOf(
+          `GRANT EXECUTE ON FUNCTION public.${fn}${args} TO service_role`,
+          start
+        );
+        expect(grantIdx, `${fn} granted`).toBeGreaterThan(start);
+        const body = sql.slice(start, grantIdx + 120).replace(/\s+/g, " ");
+        expect(body).toContain("SECURITY DEFINER");
+        expect(body).toContain("SET search_path = ''");
+        expect(body).toContain(
+          `REVOKE ALL ON FUNCTION public.${fn}${args} FROM PUBLIC, anon, authenticated`
+        );
+        expect(body).toContain(
+          `GRANT EXECUTE ON FUNCTION public.${fn}${args} TO service_role`
+        );
+      }
+    });
+
+    it("IMMUTABLE helpers are REVOKEd from clients (never PostgREST-exposed)", () => {
+      expect(sql).toContain(
+        "REVOKE EXECUTE ON FUNCTION public.is_league_eligible_source(TEXT)"
+      );
+      expect(sql).toContain(
+        "REVOKE EXECUTE ON FUNCTION public.league_week_start(DATE)"
+      );
+    });
+
+    it("league score counts ONLY the learning-source allowlist", () => {
+      // The server-written allowlist the #574 review notes required — creator/
+      // community/platform (surprise_bonus + arbitrary memos) are EXCLUDED so
+      // they never become competitive currency.
+      expect(sql).toContain(
+        "SELECT p_source IN ('lesson', 'course_completion', 'quest', 'achievement')"
+      );
+      // Scoring/assignment filter through the source allowlist, never free-text
+      // reasons — the score/assignment SUMs gate on is_league_eligible_source,
+      // not a reason LIKE (which is the excluded xp_source_for_reason path).
+      expect(sql).toMatch(/is_league_eligible_source\(x\.source\)/);
+      expect(sql).not.toMatch(/x\.reason LIKE/);
+    });
+
+    it("snapshot scoring: the board RPC never SUMs xp_transactions per call", () => {
+      // The ONLY SUM over xp_transactions for scoring lives in
+      // refresh_cohort_scores (throttled). The board RPC reads stored scores —
+      // extending the SUM-per-call pattern is exactly what the spec forbids.
+      const refreshStart = sql.indexOf(
+        "CREATE OR REPLACE FUNCTION public.refresh_cohort_scores"
+      );
+      const boardStart = sql.indexOf(
+        "CREATE OR REPLACE FUNCTION public.get_cohort_leaderboard"
+      );
+      const boardBody = sql.slice(boardStart, sql.indexOf("$$;", boardStart));
+      expect(refreshStart).toBeGreaterThan(-1);
+      expect(boardBody).not.toMatch(/SUM\(x\.amount\)/);
+      expect(boardBody).toContain("public.refresh_cohort_scores");
+    });
+
+    it("refresh is throttled + row-locked so bursts collapse to one recompute", () => {
+      expect(sql).toContain("LEAGUE_REFRESH_THROTTLE CONSTANT INTERVAL");
+      expect(sql).toMatch(
+        /FROM public\.league_cohorts\s+WHERE id = p_cohort_id\s+FOR UPDATE;/
+      );
+      expect(sql).toContain("now() - LEAGUE_REFRESH_THROTTLE");
+    });
+
+    it("private/deleted members are anonymized via LEFT JOIN, never dropped", () => {
+      // public_profiles already filters is_public + not-deleted; the LEFT JOIN
+      // keeps private members in the cohort with NULL identity (UI shows
+      // "Anonymous learner"). An inner join would silently drop them and break
+      // a ~30-person cohort.
+      expect(sql).toContain(
+        "LEFT JOIN public.public_profiles pp ON pp.id = m.user_id"
+      );
+      expect(sql).not.toMatch(/\n  JOIN public\.public_profiles/);
+    });
+
+    it("cohort capacity is the ~30 Duolingo shape", () => {
+      expect(sql).toContain("LEAGUE_COHORT_CAPACITY CONSTANT INTEGER := 30");
+    });
+
+    it("assignment is engagement-matched on PRIOR-week league XP", () => {
+      expect(sql).toContain("v_prior_start := v_week_start - 7");
+      expect(sql).toContain("t.min_prior_week_xp <= v_prior_xp");
+    });
+
+    it("weekly reset is Monday-anchored", () => {
+      expect(sql).toContain("date_trunc('week', p_date::timestamp)");
+    });
+  });
+}
+
+describe("#574 cohort leagues — migration-only guarantees", () => {
+  it("runs in one explicit transaction", () => {
+    expect(migration).toContain("BEGIN;");
+    expect(migration).toContain("COMMIT;");
+  });
+
+  it("seeds the four engagement tiers idempotently", () => {
+    expect(migration).toContain(
+      "INSERT INTO league_tiers (tier, min_prior_week_xp) VALUES"
+    );
+    for (const row of ["(1, 0)", "(2, 100)", "(3, 500)", "(4, 2000)"]) {
+      expect(migration).toContain(row);
+    }
+    expect(migration).toContain("ON CONFLICT (tier) DO NOTHING");
+  });
+
+  it("lazy assignment is race-safe: only a genuine insert bumps member_count", () => {
+    // ON CONFLICT DO NOTHING RETURNING guards the double-count; a lost race
+    // re-reads the winner's cohort without incrementing.
+    expect(migration).toContain(
+      "ON CONFLICT (user_id, week_start) DO NOTHING\n  RETURNING cohort_id INTO v_inserted_cohort"
+    );
+    expect(migration).toContain("IF v_inserted_cohort IS NOT NULL THEN");
+    // A chosen cohort is locked with SKIP LOCKED so concurrent assigners never
+    // overfill it.
+    expect(migration).toContain("FOR UPDATE SKIP LOCKED");
+  });
+
+  it("ships a rollback that drops exactly what it created (FK order)", () => {
+    expect(migration).toContain(
+      "DROP FUNCTION IF EXISTS public.get_cohort_leaderboard(UUID)"
+    );
+    expect(migration).toContain("DROP TABLE IF EXISTS public.league_members");
+    expect(migration).toContain("DROP TABLE IF EXISTS public.league_cohorts");
+    expect(migration).toContain("DROP TABLE IF EXISTS public.league_tiers");
+  });
+});

--- a/apps/web/src/lib/supabase/__tests__/cohort-leagues-guard.test.ts
+++ b/apps/web/src/lib/supabase/__tests__/cohort-leagues-guard.test.ts
@@ -172,6 +172,14 @@ for (const [label, sql] of [
       expect(sql).not.toMatch(/\n  JOIN public\.public_profiles/);
     });
 
+    it("withholds the opaque user_id of anonymized non-you members from peers", () => {
+      // An anonymized row (not in public_profiles) that is not the caller's own
+      // must return NULL user_id — the id must not reach ~30 cohort peers.
+      expect(sql).toContain(
+        "CASE WHEN pp.id IS NULL AND m.user_id <> p_user_id THEN NULL ELSE m.user_id END"
+      );
+    });
+
     it("cohort capacity is the ~30 Duolingo shape", () => {
       expect(sql).toContain("LEAGUE_COHORT_CAPACITY CONSTANT INTEGER := 30");
     });

--- a/apps/web/src/lib/supabase/types.ts
+++ b/apps/web/src/lib/supabase/types.ts
@@ -1347,7 +1347,7 @@ export type Database = {
       get_cohort_leaderboard: {
         Args: { p_user_id: string };
         Returns: {
-          user_id: string;
+          user_id: string | null;
           username: string | null;
           avatar_url: string | null;
           score: number;

--- a/apps/web/src/lib/supabase/types.ts
+++ b/apps/web/src/lib/supabase/types.ts
@@ -14,6 +14,66 @@ export type Database = {
   };
   public: {
     Tables: {
+      league_tiers: {
+        Row: { tier: number; min_prior_week_xp: number };
+        Insert: { tier: number; min_prior_week_xp: number };
+        Update: { tier?: number; min_prior_week_xp?: number };
+        Relationships: [];
+      };
+      league_cohorts: {
+        Row: {
+          id: string;
+          week_start: string;
+          tier: number;
+          member_count: number;
+          scores_refreshed_at: string | null;
+          created_at: string;
+        };
+        Insert: {
+          id?: string;
+          week_start: string;
+          tier: number;
+          member_count?: number;
+          scores_refreshed_at?: string | null;
+          created_at?: string;
+        };
+        Update: {
+          id?: string;
+          week_start?: string;
+          tier?: number;
+          member_count?: number;
+          scores_refreshed_at?: string | null;
+          created_at?: string;
+        };
+        Relationships: [];
+      };
+      league_members: {
+        Row: {
+          id: string;
+          cohort_id: string;
+          user_id: string;
+          week_start: string;
+          score: number;
+          joined_at: string;
+        };
+        Insert: {
+          id?: string;
+          cohort_id: string;
+          user_id: string;
+          week_start: string;
+          score?: number;
+          joined_at?: string;
+        };
+        Update: {
+          id?: string;
+          cohort_id?: string;
+          user_id?: string;
+          week_start?: string;
+          score?: number;
+          joined_at?: string;
+        };
+        Relationships: [];
+      };
       onchain_deployments: {
         Row: {
           content_id: string;
@@ -1283,6 +1343,27 @@ export type Database = {
           user_id: string;
           username: string;
         }[];
+      };
+      get_cohort_leaderboard: {
+        Args: { p_user_id: string };
+        Returns: {
+          user_id: string;
+          username: string | null;
+          avatar_url: string | null;
+          score: number;
+          rank: number;
+          is_you: boolean;
+          tier: number;
+          week_start: string;
+        }[];
+      };
+      ensure_league_membership: {
+        Args: { p_user_id: string };
+        Returns: string;
+      };
+      refresh_cohort_scores: {
+        Args: { p_cohort_id: string };
+        Returns: undefined;
       };
       increment_view_count: {
         Args: { p_thread_id: string; p_user_id?: string };

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -419,7 +419,22 @@
     "you": "You",
     "xpRemaining": "<em>{xp} {xpLabel}</em> to {levelLabel} {level}",
     "xpTooltip": "{xp} {xpLabel} to {levelLabel} {level}",
-    "surpriseBonus": "Surprise bonus! +{amount} XP"
+    "surpriseBonus": "Surprise bonus! +{amount} XP",
+    "league": "League",
+    "global": "Global",
+    "leagueSubtitle": "Your weekly cohort — this week's standings",
+    "globalSubtitle": "All-time XP across everyone",
+    "leagueTier1": "Seed League",
+    "leagueTier2": "Sprout League",
+    "leagueTier3": "Sapling League",
+    "leagueTier4": "Canopy League",
+    "cohortMembers": "{count} learners",
+    "leagueResets": "resets Monday",
+    "anonymousLearner": "Anonymous learner",
+    "leagueSignIn": "Sign in to join this week's league.",
+    "cohortStripTitle": "Your league",
+    "cohortStripAria": "Your league standing",
+    "cohortViewAll": "View league"
   },
   "certificates": {
     "title": "Certificate of Completion",

--- a/apps/web/src/messages/es.json
+++ b/apps/web/src/messages/es.json
@@ -419,7 +419,22 @@
     "you": "Tú",
     "xpRemaining": "<em>{xp} {xpLabel}</em> para {levelLabel} {level}",
     "xpTooltip": "{xp} {xpLabel} para {levelLabel} {level}",
-    "surpriseBonus": "¡Bono sorpresa! +{amount} XP"
+    "surpriseBonus": "¡Bono sorpresa! +{amount} XP",
+    "league": "Liga",
+    "global": "Global",
+    "leagueSubtitle": "Tu grupo de la semana — la clasificación de esta semana",
+    "globalSubtitle": "XP de todos los tiempos entre todos",
+    "leagueTier1": "Liga Semilla",
+    "leagueTier2": "Liga Brote",
+    "leagueTier3": "Liga Retoño",
+    "leagueTier4": "Liga Dosel",
+    "cohortMembers": "{count} estudiantes",
+    "leagueResets": "se reinicia el lunes",
+    "anonymousLearner": "Estudiante anónimo",
+    "leagueSignIn": "Inicia sesión para unirte a la liga de esta semana.",
+    "cohortStripTitle": "Tu liga",
+    "cohortStripAria": "Tu posición en la liga",
+    "cohortViewAll": "Ver liga"
   },
   "certificates": {
     "title": "Certificado de Finalización",

--- a/apps/web/src/messages/pt-BR.json
+++ b/apps/web/src/messages/pt-BR.json
@@ -419,7 +419,22 @@
     "you": "Você",
     "xpRemaining": "<em>{xp} {xpLabel}</em> para {levelLabel} {level}",
     "xpTooltip": "{xp} {xpLabel} para {levelLabel} {level}",
-    "surpriseBonus": "Bônus surpresa! +{amount} XP"
+    "surpriseBonus": "Bônus surpresa! +{amount} XP",
+    "league": "Liga",
+    "global": "Global",
+    "leagueSubtitle": "Seu grupo da semana — a classificação desta semana",
+    "globalSubtitle": "XP de todos os tempos entre todos",
+    "leagueTier1": "Liga Semente",
+    "leagueTier2": "Liga Broto",
+    "leagueTier3": "Liga Muda",
+    "leagueTier4": "Liga Copa",
+    "cohortMembers": "{count} estudantes",
+    "leagueResets": "reinicia na segunda",
+    "anonymousLearner": "Estudante anônimo",
+    "leagueSignIn": "Entre para participar da liga desta semana.",
+    "cohortStripTitle": "Sua liga",
+    "cohortStripAria": "Sua posição na liga",
+    "cohortViewAll": "Ver liga"
   },
   "certificates": {
     "title": "Certificado de Conclusão",

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -3044,6 +3044,79 @@ a.path-step-card:hover .path-step-badge.skip {
   border-bottom-color: var(--primary);
 }
 
+/* ── Primary board switch — League (cohort) vs Global (LX-B9b) ── */
+.lb-board-tabs {
+  display: flex;
+  gap: 4px;
+  padding: 4px;
+  background: var(--card);
+  border: 2.5px solid var(--border);
+  border-radius: var(--r-md);
+  width: fit-content;
+  max-width: 100%;
+  overflow-x: auto;
+}
+.lb-board-tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--font-display, var(--font-d));
+  font-weight: 800;
+  font-size: 14px;
+  padding: 8px 16px;
+  min-height: 40px;
+  border: none;
+  border-radius: var(--r-sm, 8px);
+  background: none;
+  color: var(--text-3);
+  cursor: pointer;
+  white-space: nowrap;
+  transition: all 0.15s;
+}
+.lb-board-tab:hover {
+  color: var(--text);
+}
+.lb-board-tab.active {
+  color: var(--primary);
+  background: var(--primary-dim);
+}
+
+/* ── League header — tier name + cohort meta ── */
+.lb-league-head {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+.lb-league-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  flex-shrink: 0;
+  border-radius: 999px;
+  background: var(--primary-dim);
+  color: var(--primary);
+}
+.lb-league-tier {
+  font-family: var(--font-display, var(--font-d));
+  font-weight: 900;
+  font-size: 18px;
+  color: var(--text);
+}
+.lb-league-sub {
+  font-size: 13px;
+  color: var(--text-3);
+}
+
+/* ── Compact list variant — dashboard you-±3 strip ── */
+.lb-list-compact {
+  gap: 4px;
+}
+.lb-list-compact .lb-row {
+  padding: 7px 12px;
+}
+
 /* ── Empty state ── */
 .lb-empty {
   display: flex;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -2,6 +2,8 @@ export type {
   Progress,
   StreakData,
   LeaderboardEntry,
+  CohortLeaderboardEntry,
+  CohortLeague,
   XpTransaction,
   Credential,
   DailyQuest,

--- a/packages/types/src/progress.ts
+++ b/packages/types/src/progress.ts
@@ -41,6 +41,33 @@ export interface LeaderboardEntry {
   walletAddress?: string;
 }
 
+/**
+ * One row of a weekly cohort league (LX-B9b). `username`/`avatarUrl` are null
+ * when the member is a private or deleted profile — the row is kept (never
+ * dropped) and rendered as an anonymous learner. `rank` is the member's true
+ * position within the cohort. `isYou` flags the viewer's own row so the UI can
+ * label it even when the viewer is anonymized.
+ */
+export interface CohortLeaderboardEntry {
+  userId: string;
+  username: string | null;
+  avatarUrl: string | null;
+  score: number;
+  rank: number;
+  isYou: boolean;
+}
+
+/** A viewer's weekly cohort: the league header plus its ranked members. */
+export interface CohortLeague {
+  /** Engagement tier (1 = floor). Named for display via i18n, never stored. */
+  tier: number;
+  /** ISO date (YYYY-MM-DD) of the Monday the cohort's week started. */
+  weekStart: string;
+  /** Current cohort size (may be below capacity while filling). */
+  memberCount: number;
+  entries: CohortLeaderboardEntry[];
+}
+
 export interface XpTransaction {
   userId: string;
   amount: number;

--- a/packages/types/src/progress.ts
+++ b/packages/types/src/progress.ts
@@ -42,14 +42,15 @@ export interface LeaderboardEntry {
 }
 
 /**
- * One row of a weekly cohort league (LX-B9b). `username`/`avatarUrl` are null
- * when the member is a private or deleted profile — the row is kept (never
- * dropped) and rendered as an anonymous learner. `rank` is the member's true
- * position within the cohort. `isYou` flags the viewer's own row so the UI can
- * label it even when the viewer is anonymized.
+ * One row of a weekly cohort league (LX-B9b). `username`/`avatarUrl`/`userId`
+ * are null when the member is a private or deleted profile — the row is kept
+ * (never dropped) and rendered as an anonymous learner, with even the opaque id
+ * withheld from peers (the viewer's own row keeps its id). `rank` is the
+ * member's true position within the cohort. `isYou` flags the viewer's own row
+ * so the UI can label it even when the viewer is anonymized.
  */
 export interface CohortLeaderboardEntry {
-  userId: string;
+  userId: string | null;
   username: string | null;
   avatarUrl: string | null;
   score: number;

--- a/supabase/migrations/20260726200000_cohort_leagues.sql
+++ b/supabase/migrations/20260726200000_cohort_leagues.sql
@@ -37,12 +37,27 @@
 --
 -- ── LEAGUE-ELIGIBLE XP (anti-gaming + PED-14) ───────────────────────────────
 -- Cohort score counts ONLY learning-source XP, filtered by xp_transactions.
--- source (LX-B9a) via is_league_eligible_source() — the server-written allowlist
--- the #574 review notes asked for, NOT free-text reason parsing. Excludes
--- creator_reward, community, and platform. `platform` is the deliberate
--- catch-all for surprise_bonus:* and arbitrary on-chain reward_xp memos (issue
--- #574 notes 1 & 2) — those must NEVER become competitive currency, so an
--- operator promo minted with a 'Completed lesson:'-shaped memo cannot leak in.
+-- source (LX-B9a) via is_league_eligible_source() — a source allowlist, NOT
+-- free-text reason parsing. Excludes creator_reward, community, and platform.
+-- surprise_bonus:* → platform → excluded (issue #574 note 2), and community /
+-- creator XP are excluded by their own source values (note 1's user-reachable
+-- paths).
+--
+-- HONEST LIMIT OF THIS GUARANTEE (issue #574 note 1): `source` is not written
+-- independently — for the on-chain reward_xp path it is REVERSE-DERIVED from the
+-- award memo by xp_source_for_reason (its ELSE→'platform' is the sole
+-- exclusion). So an AUTHORITY-supplied reward_xp memo deliberately shaped
+-- 'Completed lesson: …' WOULD classify as 'lesson' and score as league-eligible.
+-- This is NOT user-exploitable: memos are authority-supplied, every
+-- user-reachable XP path sits behind graded/on-chain gates, leagues are
+-- display-only, and the 5000/day cap bounds blast radius. The operative rule is
+-- therefore a convention, not an enforced invariant: OPERATOR PROMOS MINTED VIA
+-- reward_xp MUST NOT use 'Completed lesson:' / 'Completed course:' / 'Course
+-- completion bonus:' / 'Creator reward:' / 'Achievement reward:' / 'daily_quest:'
+-- prefixes, or they will be counted. The real hardening — writing `source`
+-- positively at each award call site instead of reverse-deriving it — touches
+-- the XP writers (#731-incident territory) and is a reviewed follow-up, not this
+-- display-only PR.
 --
 -- ── RLS / PRIVACY (spec §3 cross-check REQUIRED) ────────────────────────────
 --   * user_xp stays own-row (untouched here). Cohort exposure is ONLY via the
@@ -338,9 +353,10 @@ GRANT EXECUTE ON FUNCTION public.refresh_cohort_scores(UUID) TO service_role;
 -- ── get_cohort_leaderboard (full cohort board) ──────────────────────────────
 -- Assigns (lazy) + refreshes the snapshot, then returns the whole cohort ranked
 -- by stored score. Identity comes from public_profiles via LEFT JOIN: private /
--- deleted members return NULL username+avatar (anonymized, NEVER dropped).
--- is_you flags the caller so the UI labels their row even when anonymized. tier
--- and week_start are denormalized onto each row for the league header.
+-- deleted members return NULL username+avatar (anonymized, NEVER dropped) AND a
+-- NULL user_id (their opaque id must not reach ~30 peers either) — the caller's
+-- own id is preserved. is_you flags the caller so the UI labels their row even
+-- when anonymized. tier/week_start are denormalized onto each row for the header.
 CREATE OR REPLACE FUNCTION public.get_cohort_leaderboard(p_user_id UUID)
 RETURNS TABLE (
   user_id    UUID,
@@ -367,7 +383,8 @@ BEGIN
 
   RETURN QUERY
   SELECT
-    m.user_id,
+    -- Anonymized non-you rows expose no id; the caller always sees their own.
+    CASE WHEN pp.id IS NULL AND m.user_id <> p_user_id THEN NULL ELSE m.user_id END,
     pp.username,
     pp.avatar_url,
     m.score,

--- a/supabase/migrations/20260726200000_cohort_leagues.sql
+++ b/supabase/migrations/20260726200000_cohort_leagues.sql
@@ -1,0 +1,415 @@
+-- ============================================================================
+-- Migration: cohort leagues + you-±3 strip (LX-B9b, #574)
+--
+-- Replaces the "poisoned by design" global-absolute board (spec §3.2: XP is
+-- farmable, so top ranks measure paste speed) with small weekly cohorts and a
+-- nearby-rank view — the shape the leaderboard evidence actually supports
+-- (Hanus & Fox: absolute-rank boards reduce motivation; Duolingo's ~30-person
+-- weekly cohorts are the preferred SHAPE, magnitudes unverified).
+--
+-- DISPLAY-ONLY, NO REWARD CONTINGENCY (PED-10 / PED-14 / UIU-09). Leagues never
+-- grant XP and rank never gates anything: score is DERIVED from XP the learner
+-- already earned by learning. Rank-scarce / performance-contingent rewards are
+-- forbidden (the d=−0.88 shape). A cohort is a social-comparison lens over
+-- existing XP, not a new currency. This migration awards nothing and calls no
+-- award_xp path — hence it can land AFTER the award_xp-touching migrations
+-- (B8) without contending for that function (serialization order, spec §4).
+--
+-- ── D-4 (scheduler) IS UNDECIDED → LAZY on-first-read assignment ─────────────
+-- The spec leaves D-4 open (lazy vs the platform's first cron). We implement the
+-- LAZY path — the get_daily_quest_state precedent — so leagues need ZERO new
+-- infrastructure: a learner is placed into a cohort the first time they read the
+-- board in a given week (ensure_league_membership). Arrival-order cohorts,
+-- engagement-matched by PRIOR-week league XP (approximates promotion/demotion
+-- without a batch job). A cron upgrade to true batch matching is a clean
+-- follow-up if D-4 later chooses it: it would only replace ensure_league_
+-- membership's assignment body, not the tables, scoring, or read RPCs.
+--
+-- ── SNAPSHOT SCORING (do NOT extend the SUM-over-xp_transactions-per-call
+--    pattern that get_leaderboard's windowed branch uses) ────────────────────
+-- Each member row carries a materialized `score`. It is recomputed for the WHOLE
+-- cohort in ONE grouped pass (refresh_cohort_scores), throttled to at most once
+-- per LEAGUE_REFRESH_THROTTLE per cohort. The board / ±3 read RPCs therefore
+-- read STORED scores — never a per-call SUM over xp_transactions — and every
+-- member is refreshed together, so the ranking is a consistent, stable snapshot
+-- within the throttle window (repeated reads return identical scores). This is
+-- the "snapshot scores" the spec prescribes: bounded SUM cost, stable ordering.
+--
+-- ── LEAGUE-ELIGIBLE XP (anti-gaming + PED-14) ───────────────────────────────
+-- Cohort score counts ONLY learning-source XP, filtered by xp_transactions.
+-- source (LX-B9a) via is_league_eligible_source() — the server-written allowlist
+-- the #574 review notes asked for, NOT free-text reason parsing. Excludes
+-- creator_reward, community, and platform. `platform` is the deliberate
+-- catch-all for surprise_bonus:* and arbitrary on-chain reward_xp memos (issue
+-- #574 notes 1 & 2) — those must NEVER become competitive currency, so an
+-- operator promo minted with a 'Completed lesson:'-shaped memo cannot leak in.
+--
+-- ── RLS / PRIVACY (spec §3 cross-check REQUIRED) ────────────────────────────
+--   * user_xp stays own-row (untouched here). Cohort exposure is ONLY via the
+--     SECURITY DEFINER read RPCs, mirroring get_leaderboard + public_profiles.
+--   * The RPCs project ONLY public_profiles' non-sensitive columns (username,
+--     avatar). is_public=false / deleted members are ANONYMIZED (username +
+--     avatar NULL → "Anonymous learner" in the UI), never identity-leaked and
+--     never silently dropped (a ~30-person cohort with holes breaks the
+--     mechanic) — enforced by the LEFT JOIN.
+--   * league_cohorts / league_members have NO broad public SELECT policy. Direct
+--     table reads by anon fail; authenticated may read only its OWN membership
+--     row (own-row SELECT, the user_daily_quests / review_items convention).
+--   * league_tiers is public-read reference data (like review_schedule).
+--
+-- Idempotent (repo convention): CREATE TABLE/INDEX IF NOT EXISTS, ON CONFLICT
+-- DO NOTHING seeds, CREATE OR REPLACE functions, DROP POLICY IF EXISTS before
+-- CREATE POLICY. Safe to re-apply. Explicit BEGIN/COMMIT so the whole file is
+-- one transaction even under a manual psql apply.
+--
+-- A tested ROLLBACK block is at the very bottom of this file.
+-- Mirrored into supabase/schema.sql (the full-schema snapshot).
+-- ============================================================================
+
+BEGIN;
+
+-- ── League-eligible source allowlist (server-written, issue #574) ───────────
+-- Single source of truth for "counts toward cohort score". Mirrors the spirit
+-- of xp_source_for_reason: a boolean predicate, not a free-text scan. INCLUDES
+-- first-completion learning XP (lesson is on-chain-bitmap idempotent, quests /
+-- course-completion / achievements are one-time); EXCLUDES creator_reward,
+-- community, and platform (the surprise_bonus / arbitrary-memo catch-all).
+CREATE OR REPLACE FUNCTION public.is_league_eligible_source(p_source TEXT)
+RETURNS BOOLEAN
+LANGUAGE sql
+IMMUTABLE
+AS $$
+  SELECT p_source IN ('lesson', 'course_completion', 'quest', 'achievement')
+$$;
+
+-- Not a client RPC — block PostgREST exposure (#377 convention). Called only
+-- inside the SECURITY DEFINER league functions, which run as the owner.
+REVOKE EXECUTE ON FUNCTION public.is_league_eligible_source(TEXT)
+  FROM PUBLIC, anon, authenticated;
+
+-- ── Week bucket (Monday-anchored ISO week) ──────────────────────────────────
+-- The weekly reset boundary. date_trunc('week') anchors on Monday 00:00. A new
+-- week => a new cohort => score naturally resets (score is scoped to the week).
+CREATE OR REPLACE FUNCTION public.league_week_start(p_date DATE)
+RETURNS DATE
+LANGUAGE sql
+IMMUTABLE
+AS $$
+  SELECT (date_trunc('week', p_date::timestamp))::date
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.league_week_start(DATE)
+  FROM PUBLIC, anon, authenticated;
+
+-- ── league_tiers (reference data — engagement matching) ─────────────────────
+-- tier -> minimum prior-week league XP to land in it. Assignment picks the
+-- HIGHEST tier whose threshold the learner's prior-week XP clears, so cohorts
+-- group similar-engagement learners and a learner's tier tracks recent activity
+-- week over week (the lazy model's promotion/demotion). Encoded AS DATA (the
+-- review_schedule / PED-04 convention) so thresholds re-tune with an UPDATE, not
+-- a function edit. Tier 1 (threshold 0) is the floor: every learner qualifies.
+-- Tier NAMES are localized in the UI (i18n), never stored here.
+CREATE TABLE IF NOT EXISTS league_tiers (
+  tier              SMALLINT PRIMARY KEY,
+  min_prior_week_xp INTEGER  NOT NULL CHECK (min_prior_week_xp >= 0),
+  UNIQUE (min_prior_week_xp)
+);
+
+ALTER TABLE league_tiers ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "League tiers are viewable by everyone" ON league_tiers;
+CREATE POLICY "League tiers are viewable by everyone"
+  ON league_tiers FOR SELECT USING (true);
+-- No write policy: seeded here, mutated only by service_role / future DDL.
+
+-- CONVENTION, NOT EVIDENCE: four engagement bands. Re-tune by editing rows.
+INSERT INTO league_tiers (tier, min_prior_week_xp) VALUES
+  (1, 0),
+  (2, 100),
+  (3, 500),
+  (4, 2000)
+ON CONFLICT (tier) DO NOTHING;
+
+-- ── league_cohorts ──────────────────────────────────────────────────────────
+-- One row per (week, tier, arrival-order fill). Multiple cohorts can share a
+-- (week_start, tier) once one fills to capacity — hence NO unique on
+-- (week_start, tier). member_count is maintained on assignment for the capacity
+-- check; scores_refreshed_at throttles the snapshot recompute.
+CREATE TABLE IF NOT EXISTS league_cohorts (
+  id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  week_start          DATE     NOT NULL,
+  tier                SMALLINT NOT NULL REFERENCES league_tiers(tier),
+  member_count        INTEGER  NOT NULL DEFAULT 0 CHECK (member_count >= 0),
+  scores_refreshed_at TIMESTAMPTZ,
+  created_at          TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Assignment's hot path: newest open cohort for a (week, tier).
+CREATE INDEX IF NOT EXISTS idx_league_cohorts_week_tier
+  ON league_cohorts (week_start, tier, created_at DESC);
+
+ALTER TABLE league_cohorts ENABLE ROW LEVEL SECURITY;
+-- NO policy: cohorts are exposed only through the SECURITY DEFINER read RPCs.
+-- Direct reads by anon/authenticated fail (spec accept criterion).
+
+-- ── league_members ──────────────────────────────────────────────────────────
+-- UNIQUE(user_id, week_start): one membership per learner per week — the
+-- idempotency guard the whole lazy-assignment race-safety rests on. `score` is
+-- the materialized weekly league XP (snapshot), refreshed by
+-- refresh_cohort_scores. joined_at is the stable rank tiebreaker.
+CREATE TABLE IF NOT EXISTS league_members (
+  id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  cohort_id  UUID NOT NULL REFERENCES league_cohorts(id) ON DELETE CASCADE,
+  user_id    UUID NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+  week_start DATE NOT NULL,
+  score      BIGINT NOT NULL DEFAULT 0 CHECK (score >= 0),
+  joined_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (user_id, week_start)
+);
+
+-- Board / ±3 read the members of one cohort, ordered by score.
+CREATE INDEX IF NOT EXISTS idx_league_members_cohort_score
+  ON league_members (cohort_id, score DESC);
+
+ALTER TABLE league_members ENABLE ROW LEVEL SECURITY;
+
+-- Own-row SELECT only (user_daily_quests / review_items convention): a learner
+-- may read their OWN membership row client-side. Cross-user cohort exposure is
+-- ONLY via the RPCs — a learner cannot read other members directly.
+DROP POLICY IF EXISTS "Users can view their own league membership" ON league_members;
+CREATE POLICY "Users can view their own league membership"
+  ON league_members FOR SELECT USING (auth.uid() = user_id);
+-- No INSERT/UPDATE/DELETE policy: writes go through the SECURITY DEFINER RPCs.
+
+-- ── ensure_league_membership (LAZY assignment) ──────────────────────────────
+-- Idempotent per (user, week): places the learner into a cohort on first read
+-- of the week and returns the cohort id. Tier = highest league_tiers band their
+-- PRIOR-week league XP clears (engagement matching). Fill = newest open cohort
+-- for (week, tier), else a fresh one. Race safety: UNIQUE(user_id, week_start)
+-- is the backstop — a lost insert re-reads the winner's cohort and does NOT
+-- double-count member_count; a chosen cohort is row-locked (SKIP LOCKED) so
+-- concurrent assigners never overfill it (they fall through to a new cohort).
+-- Capacity is a SOFT cap by construction; ~30 is the Duolingo shape (spec).
+CREATE OR REPLACE FUNCTION public.ensure_league_membership(p_user_id UUID)
+RETURNS UUID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  -- ~30-person weekly cohorts (Duolingo shape, spec LX-B9b). Soft cap.
+  LEAGUE_COHORT_CAPACITY CONSTANT INTEGER := 30;
+  v_week_start      DATE;
+  v_prior_start     DATE;
+  v_prior_xp        BIGINT;
+  v_tier            SMALLINT;
+  v_cohort_id       UUID;
+  v_inserted_cohort UUID;
+BEGIN
+  v_week_start  := public.league_week_start(CURRENT_DATE);
+
+  -- Fast path: already placed this week.
+  SELECT cohort_id INTO v_cohort_id
+  FROM public.league_members
+  WHERE user_id = p_user_id AND week_start = v_week_start;
+  IF FOUND THEN
+    RETURN v_cohort_id;
+  END IF;
+
+  -- Engagement matching: prior-week league XP -> tier band.
+  v_prior_start := v_week_start - 7;
+  SELECT COALESCE(SUM(x.amount), 0) INTO v_prior_xp
+  FROM public.xp_transactions x
+  WHERE x.user_id = p_user_id
+    AND x.created_at >= v_prior_start::timestamptz
+    AND x.created_at <  v_week_start::timestamptz
+    AND public.is_league_eligible_source(x.source);
+
+  SELECT t.tier INTO v_tier
+  FROM public.league_tiers t
+  WHERE t.min_prior_week_xp <= v_prior_xp
+  ORDER BY t.min_prior_week_xp DESC
+  LIMIT 1;
+  -- Floor guard (tier 1 has threshold 0, so this is defensive only).
+  IF v_tier IS NULL THEN
+    SELECT MIN(t.tier) INTO v_tier FROM public.league_tiers t;
+  END IF;
+
+  -- Newest open cohort for (week, tier); lock it so a concurrent assigner
+  -- either shares it (serialized under the lock) or SKIPs to a fresh cohort
+  -- rather than overfilling this one.
+  SELECT c.id INTO v_cohort_id
+  FROM public.league_cohorts c
+  WHERE c.week_start = v_week_start
+    AND c.tier = v_tier
+    AND c.member_count < LEAGUE_COHORT_CAPACITY
+  ORDER BY c.created_at DESC
+  LIMIT 1
+  FOR UPDATE SKIP LOCKED;
+
+  IF v_cohort_id IS NULL THEN
+    INSERT INTO public.league_cohorts (week_start, tier, member_count)
+    VALUES (v_week_start, v_tier, 0)
+    RETURNING id INTO v_cohort_id;
+  END IF;
+
+  -- Insert the membership. On a lost race the UNIQUE(user_id, week_start) guard
+  -- yields 0 rows; only a genuine insert increments member_count.
+  INSERT INTO public.league_members (cohort_id, user_id, week_start, score)
+  VALUES (v_cohort_id, p_user_id, v_week_start, 0)
+  ON CONFLICT (user_id, week_start) DO NOTHING
+  RETURNING cohort_id INTO v_inserted_cohort;
+
+  IF v_inserted_cohort IS NOT NULL THEN
+    UPDATE public.league_cohorts
+    SET member_count = member_count + 1
+    WHERE id = v_cohort_id;
+    RETURN v_cohort_id;
+  END IF;
+
+  -- Lost the race: return the winner's cohort (member_count already counted it).
+  -- Any empty cohort this call may have created is harmless — the next assigner
+  -- fills it (member_count = 0 < capacity).
+  SELECT cohort_id INTO v_cohort_id
+  FROM public.league_members
+  WHERE user_id = p_user_id AND week_start = v_week_start;
+  RETURN v_cohort_id;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.ensure_league_membership(UUID)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.ensure_league_membership(UUID) TO service_role;
+
+-- ── refresh_cohort_scores (throttled snapshot recompute) ────────────────────
+-- Recomputes score for EVERY member of one cohort in a single grouped pass over
+-- league-eligible xp_transactions in the cohort's week — but at most once per
+-- LEAGUE_REFRESH_THROTTLE (row-locked + re-checked so concurrent reads collapse
+-- to one recompute). Between refreshes the board is a stable snapshot. This is
+-- the ONLY place league scores SUM xp_transactions — the read RPCs never do.
+CREATE OR REPLACE FUNCTION public.refresh_cohort_scores(p_cohort_id UUID)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  -- Snapshot freshness window. Short enough that newly-earned XP surfaces within
+  -- ~a minute; long enough that a burst of reads triggers ONE recompute.
+  LEAGUE_REFRESH_THROTTLE CONSTANT INTERVAL := INTERVAL '1 minute';
+  v_week_start DATE;
+  v_refreshed  TIMESTAMPTZ;
+BEGIN
+  SELECT week_start, scores_refreshed_at INTO v_week_start, v_refreshed
+  FROM public.league_cohorts
+  WHERE id = p_cohort_id
+  FOR UPDATE;
+  IF NOT FOUND THEN
+    RETURN;
+  END IF;
+
+  -- Fresh snapshot within the throttle window: keep it stable, do nothing.
+  IF v_refreshed IS NOT NULL
+     AND v_refreshed > now() - LEAGUE_REFRESH_THROTTLE THEN
+    RETURN;
+  END IF;
+
+  UPDATE public.league_members m
+  SET score = COALESCE((
+    SELECT SUM(x.amount)
+    FROM public.xp_transactions x
+    WHERE x.user_id = m.user_id
+      AND x.created_at >= v_week_start::timestamptz
+      AND x.created_at <  (v_week_start + 7)::timestamptz
+      AND public.is_league_eligible_source(x.source)
+  ), 0)
+  WHERE m.cohort_id = p_cohort_id;
+
+  UPDATE public.league_cohorts
+  SET scores_refreshed_at = now()
+  WHERE id = p_cohort_id;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.refresh_cohort_scores(UUID)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.refresh_cohort_scores(UUID) TO service_role;
+
+-- ── get_cohort_leaderboard (full cohort board) ──────────────────────────────
+-- Assigns (lazy) + refreshes the snapshot, then returns the whole cohort ranked
+-- by stored score. Identity comes from public_profiles via LEFT JOIN: private /
+-- deleted members return NULL username+avatar (anonymized, NEVER dropped).
+-- is_you flags the caller so the UI labels their row even when anonymized. tier
+-- and week_start are denormalized onto each row for the league header.
+CREATE OR REPLACE FUNCTION public.get_cohort_leaderboard(p_user_id UUID)
+RETURNS TABLE (
+  user_id    UUID,
+  username   TEXT,
+  avatar_url TEXT,
+  score      BIGINT,
+  rank       BIGINT,
+  is_you     BOOLEAN,
+  tier       SMALLINT,
+  week_start DATE
+)
+-- VOLATILE (default): assigns membership + refreshes the snapshot on read, so
+-- it is NOT STABLE despite being a "read" endpoint (get_daily_quest_state does
+-- the same — lazy read-through with writes).
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_cohort_id UUID;
+BEGIN
+  v_cohort_id := public.ensure_league_membership(p_user_id);
+  PERFORM public.refresh_cohort_scores(v_cohort_id);
+
+  RETURN QUERY
+  SELECT
+    m.user_id,
+    pp.username,
+    pp.avatar_url,
+    m.score,
+    ROW_NUMBER() OVER (ORDER BY m.score DESC, m.joined_at ASC, m.user_id)::BIGINT,
+    (m.user_id = p_user_id),
+    c.tier,
+    c.week_start
+  FROM public.league_members m
+  JOIN public.league_cohorts c ON c.id = m.cohort_id
+  LEFT JOIN public.public_profiles pp ON pp.id = m.user_id
+  WHERE m.cohort_id = v_cohort_id
+  ORDER BY m.score DESC, m.joined_at ASC, m.user_id;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.get_cohort_leaderboard(UUID)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.get_cohort_leaderboard(UUID) TO service_role;
+
+-- The "you ±3" nearby-rank window is derived in the API layer (cohortStripWindow)
+-- over THIS board's snapshot rows — a single ranked read, never a second per-call
+-- SUM — so the window stays pure/unit-testable at the edges and there is no
+-- SQL⇄TS duplication of the sliding-window arithmetic. A cohort is capped at ~30
+-- rows, so slicing the ±3 in the route is negligible.
+
+COMMIT;
+
+-- ============================================================================
+-- ROLLBACK (tested) — restores the exact pre-migration state (no league spine).
+-- Everything this migration created is new, so the rollback unconditionally
+-- drops exactly those objects. league_members / league_cohorts drop their
+-- indexes + policies with them; drop members before cohorts (FK), cohorts before
+-- tiers (FK). Run as one transaction:
+-- ----------------------------------------------------------------------------
+-- BEGIN;
+-- DROP FUNCTION IF EXISTS public.get_cohort_leaderboard(UUID);
+-- DROP FUNCTION IF EXISTS public.refresh_cohort_scores(UUID);
+-- DROP FUNCTION IF EXISTS public.ensure_league_membership(UUID);
+-- DROP TABLE IF EXISTS public.league_members;
+-- DROP TABLE IF EXISTS public.league_cohorts;
+-- DROP TABLE IF EXISTS public.league_tiers;
+-- DROP FUNCTION IF EXISTS public.league_week_start(DATE);
+-- DROP FUNCTION IF EXISTS public.is_league_eligible_source(TEXT);
+-- COMMIT;
+-- ============================================================================

--- a/supabase/migrations/20260726200000_cohort_leagues.sql
+++ b/supabase/migrations/20260726200000_cohort_leagues.sql
@@ -56,8 +56,8 @@
 -- completion bonus:' / 'Creator reward:' / 'Achievement reward:' / 'daily_quest:'
 -- prefixes, or they will be counted. The real hardening — writing `source`
 -- positively at each award call site instead of reverse-deriving it — touches
--- the XP writers (#731-incident territory) and is a reviewed follow-up, not this
--- display-only PR.
+-- the XP writers (#731-incident territory) and is tracked as follow-up #736, not
+-- this display-only PR.
 --
 -- ── RLS / PRIVACY (spec §3 cross-check REQUIRED) ────────────────────────────
 --   * user_xp stays own-row (untouched here). Cohort exposure is ONLY via the

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -2894,7 +2894,8 @@ BEGIN
 
   RETURN QUERY
   SELECT
-    m.user_id,
+    -- Anonymized non-you rows expose no id; the caller always sees their own.
+    CASE WHEN pp.id IS NULL AND m.user_id <> p_user_id THEN NULL ELSE m.user_id END,
     pp.username,
     pp.avatar_url,
     m.score,

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -2654,3 +2654,264 @@ CREATE POLICY "Course changelog visible for synced-active courses"
     )
   );
 -- NO write policy: service_role-only writes (bypasses RLS) from the admin sync route.
+
+-- ─────────────────────────────────────────────────────────────────────────
+-- Cohort leagues (LX-B9b, #574): weekly small-cohort leagues + you-±3 strip,
+-- replacing the "poisoned by design" global-absolute board. DISPLAY-ONLY — no
+-- reward contingency (PED-10/14, UIU-09); score is derived from XP already
+-- earned, filtered to learning sources (is_league_eligible_source, the LX-B9a
+-- source column) so creator/community/platform XP never becomes competitive
+-- currency. LAZY on-first-read assignment (D-4 undecided → no scheduler; the
+-- get_daily_quest_state precedent). SNAPSHOT scoring: league_members.score is
+-- materialized and recomputed for a whole cohort in one throttled pass
+-- (refresh_cohort_scores) — the read RPCs never SUM xp_transactions per call.
+-- RLS: league_tiers public-read reference data; cohorts have NO policy (RPC-only
+-- exposure); members own-row SELECT only. Read RPCs are SECURITY DEFINER,
+-- project only public_profiles columns, and anonymize (never drop) private
+-- members. Mirror of 20260726200000_cohort_leagues.sql.
+-- ─────────────────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION public.is_league_eligible_source(p_source TEXT)
+RETURNS BOOLEAN
+LANGUAGE sql
+IMMUTABLE
+AS $$
+  SELECT p_source IN ('lesson', 'course_completion', 'quest', 'achievement')
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.is_league_eligible_source(TEXT)
+  FROM PUBLIC, anon, authenticated;
+
+CREATE OR REPLACE FUNCTION public.league_week_start(p_date DATE)
+RETURNS DATE
+LANGUAGE sql
+IMMUTABLE
+AS $$
+  SELECT (date_trunc('week', p_date::timestamp))::date
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.league_week_start(DATE)
+  FROM PUBLIC, anon, authenticated;
+
+CREATE TABLE IF NOT EXISTS league_tiers (
+  tier              SMALLINT PRIMARY KEY,
+  min_prior_week_xp INTEGER  NOT NULL CHECK (min_prior_week_xp >= 0),
+  UNIQUE (min_prior_week_xp)
+);
+
+ALTER TABLE league_tiers ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "League tiers are viewable by everyone" ON league_tiers;
+CREATE POLICY "League tiers are viewable by everyone"
+  ON league_tiers FOR SELECT USING (true);
+
+INSERT INTO league_tiers (tier, min_prior_week_xp) VALUES
+  (1, 0),
+  (2, 100),
+  (3, 500),
+  (4, 2000)
+ON CONFLICT (tier) DO NOTHING;
+
+CREATE TABLE IF NOT EXISTS league_cohorts (
+  id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  week_start          DATE     NOT NULL,
+  tier                SMALLINT NOT NULL REFERENCES league_tiers(tier),
+  member_count        INTEGER  NOT NULL DEFAULT 0 CHECK (member_count >= 0),
+  scores_refreshed_at TIMESTAMPTZ,
+  created_at          TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_league_cohorts_week_tier
+  ON league_cohorts (week_start, tier, created_at DESC);
+
+ALTER TABLE league_cohorts ENABLE ROW LEVEL SECURITY;
+-- NO policy: cohorts are exposed only through the SECURITY DEFINER read RPCs.
+
+CREATE TABLE IF NOT EXISTS league_members (
+  id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  cohort_id  UUID NOT NULL REFERENCES league_cohorts(id) ON DELETE CASCADE,
+  user_id    UUID NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+  week_start DATE NOT NULL,
+  score      BIGINT NOT NULL DEFAULT 0 CHECK (score >= 0),
+  joined_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (user_id, week_start)
+);
+
+CREATE INDEX IF NOT EXISTS idx_league_members_cohort_score
+  ON league_members (cohort_id, score DESC);
+
+ALTER TABLE league_members ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Users can view their own league membership" ON league_members;
+CREATE POLICY "Users can view their own league membership"
+  ON league_members FOR SELECT USING (auth.uid() = user_id);
+-- No INSERT/UPDATE/DELETE policy: writes go through the SECURITY DEFINER RPCs.
+
+CREATE OR REPLACE FUNCTION public.ensure_league_membership(p_user_id UUID)
+RETURNS UUID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  LEAGUE_COHORT_CAPACITY CONSTANT INTEGER := 30;
+  v_week_start      DATE;
+  v_prior_start     DATE;
+  v_prior_xp        BIGINT;
+  v_tier            SMALLINT;
+  v_cohort_id       UUID;
+  v_inserted_cohort UUID;
+BEGIN
+  v_week_start  := public.league_week_start(CURRENT_DATE);
+
+  SELECT cohort_id INTO v_cohort_id
+  FROM public.league_members
+  WHERE user_id = p_user_id AND week_start = v_week_start;
+  IF FOUND THEN
+    RETURN v_cohort_id;
+  END IF;
+
+  v_prior_start := v_week_start - 7;
+  SELECT COALESCE(SUM(x.amount), 0) INTO v_prior_xp
+  FROM public.xp_transactions x
+  WHERE x.user_id = p_user_id
+    AND x.created_at >= v_prior_start::timestamptz
+    AND x.created_at <  v_week_start::timestamptz
+    AND public.is_league_eligible_source(x.source);
+
+  SELECT t.tier INTO v_tier
+  FROM public.league_tiers t
+  WHERE t.min_prior_week_xp <= v_prior_xp
+  ORDER BY t.min_prior_week_xp DESC
+  LIMIT 1;
+  IF v_tier IS NULL THEN
+    SELECT MIN(t.tier) INTO v_tier FROM public.league_tiers t;
+  END IF;
+
+  SELECT c.id INTO v_cohort_id
+  FROM public.league_cohorts c
+  WHERE c.week_start = v_week_start
+    AND c.tier = v_tier
+    AND c.member_count < LEAGUE_COHORT_CAPACITY
+  ORDER BY c.created_at DESC
+  LIMIT 1
+  FOR UPDATE SKIP LOCKED;
+
+  IF v_cohort_id IS NULL THEN
+    INSERT INTO public.league_cohorts (week_start, tier, member_count)
+    VALUES (v_week_start, v_tier, 0)
+    RETURNING id INTO v_cohort_id;
+  END IF;
+
+  INSERT INTO public.league_members (cohort_id, user_id, week_start, score)
+  VALUES (v_cohort_id, p_user_id, v_week_start, 0)
+  ON CONFLICT (user_id, week_start) DO NOTHING
+  RETURNING cohort_id INTO v_inserted_cohort;
+
+  IF v_inserted_cohort IS NOT NULL THEN
+    UPDATE public.league_cohorts
+    SET member_count = member_count + 1
+    WHERE id = v_cohort_id;
+    RETURN v_cohort_id;
+  END IF;
+
+  SELECT cohort_id INTO v_cohort_id
+  FROM public.league_members
+  WHERE user_id = p_user_id AND week_start = v_week_start;
+  RETURN v_cohort_id;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.ensure_league_membership(UUID)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.ensure_league_membership(UUID) TO service_role;
+
+CREATE OR REPLACE FUNCTION public.refresh_cohort_scores(p_cohort_id UUID)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  LEAGUE_REFRESH_THROTTLE CONSTANT INTERVAL := INTERVAL '1 minute';
+  v_week_start DATE;
+  v_refreshed  TIMESTAMPTZ;
+BEGIN
+  SELECT week_start, scores_refreshed_at INTO v_week_start, v_refreshed
+  FROM public.league_cohorts
+  WHERE id = p_cohort_id
+  FOR UPDATE;
+  IF NOT FOUND THEN
+    RETURN;
+  END IF;
+
+  IF v_refreshed IS NOT NULL
+     AND v_refreshed > now() - LEAGUE_REFRESH_THROTTLE THEN
+    RETURN;
+  END IF;
+
+  UPDATE public.league_members m
+  SET score = COALESCE((
+    SELECT SUM(x.amount)
+    FROM public.xp_transactions x
+    WHERE x.user_id = m.user_id
+      AND x.created_at >= v_week_start::timestamptz
+      AND x.created_at <  (v_week_start + 7)::timestamptz
+      AND public.is_league_eligible_source(x.source)
+  ), 0)
+  WHERE m.cohort_id = p_cohort_id;
+
+  UPDATE public.league_cohorts
+  SET scores_refreshed_at = now()
+  WHERE id = p_cohort_id;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.refresh_cohort_scores(UUID)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.refresh_cohort_scores(UUID) TO service_role;
+
+CREATE OR REPLACE FUNCTION public.get_cohort_leaderboard(p_user_id UUID)
+RETURNS TABLE (
+  user_id    UUID,
+  username   TEXT,
+  avatar_url TEXT,
+  score      BIGINT,
+  rank       BIGINT,
+  is_you     BOOLEAN,
+  tier       SMALLINT,
+  week_start DATE
+)
+-- VOLATILE (default): assigns membership + refreshes the snapshot on read.
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_cohort_id UUID;
+BEGIN
+  v_cohort_id := public.ensure_league_membership(p_user_id);
+  PERFORM public.refresh_cohort_scores(v_cohort_id);
+
+  RETURN QUERY
+  SELECT
+    m.user_id,
+    pp.username,
+    pp.avatar_url,
+    m.score,
+    ROW_NUMBER() OVER (ORDER BY m.score DESC, m.joined_at ASC, m.user_id)::BIGINT,
+    (m.user_id = p_user_id),
+    c.tier,
+    c.week_start
+  FROM public.league_members m
+  JOIN public.league_cohorts c ON c.id = m.cohort_id
+  LEFT JOIN public.public_profiles pp ON pp.id = m.user_id
+  WHERE m.cohort_id = v_cohort_id
+  ORDER BY m.score DESC, m.joined_at ASC, m.user_id;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.get_cohort_leaderboard(UUID)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.get_cohort_leaderboard(UUID) TO service_role;
+-- The "you ±3" strip window is derived in the API layer (cohortStripWindow) over
+-- this board's snapshot rows — no second per-call SUM, no SQL⇄TS duplication.


### PR DESCRIPTION
Closes #574 · Spec task **LX-B9b** (launch-experience master spec §3).

## What & why

Replaces the global-absolute leaderboard — the "poisoned by design" board (spec §3.2: XP is farmable, so top ranks measure paste speed) — with **weekly small-cohort leagues (~30, the Duolingo shape)** and a **nearby-rank "you ±3" view**. This is the leaderboard shape the evidence supports (Hanus & Fox: absolute-rank boards reduce motivation and exam scores; F33/F8) and it reverts the LX-B13 launch demotion by putting the evidence-aligned surface in the demoted board's place.

**Display-only — no reward contingency** (PED-10 / PED-14 / UIU-09, the d=−0.88 shape). Leagues never grant XP and rank gates nothing: `score` is *derived* from XP the learner already earned, filtered to learning sources. Zero on-chain work; `award_xp` is untouched (so this can land after the B8 migrations without contending for that function).

## How

**DB (`20260726200000_cohort_leagues.sql`, SQL-only, mirrored into `schema.sql`)**
- `league_tiers` (reference data, public-read), `league_cohorts` (RPC-only), `league_members` (`UNIQUE(user_id, week_start)`, own-row SELECT).
- **Lazy assignment** (`ensure_league_membership`) — the `get_daily_quest_state` precedent; **D-4 undecided → no scheduler** (see below). Engagement-matched by **prior-week league XP** → tier band (approximates promotion/demotion). Race-safe: `ON CONFLICT DO NOTHING RETURNING` guards the member-count double-add; the chosen cohort is `FOR UPDATE SKIP LOCKED` so concurrent assigners never overfill it.
- **Snapshot scoring** (`refresh_cohort_scores`) — `league_members.score` is materialized and recomputed for a **whole cohort in one throttled pass** (row-locked, ≤ once/min). The board read never SUMs `xp_transactions` per call → a stable, fair snapshot within the period (**does not extend the SUM-per-call pattern**, per spec).
- **League-eligible filter** (`is_league_eligible_source`) — the **server-written allowlist** the #574 review notes asked for: `lesson`, `course_completion`, `quest`, `achievement`. Excludes `creator_reward`, `community`, and `platform` — so `surprise_bonus:*` (note 2) and arbitrary on-chain `reward_xp` memos (note 1) can never become competitive currency.
- **RLS/privacy (cross-check):** `get_cohort_leaderboard` is `SECURITY DEFINER`, `search_path`-pinned, service_role-only; projects only `public_profiles` columns; **anonymizes (never drops)** private/deleted members via `LEFT JOIN` ("Anonymous learner"). Direct table reads by anon/authenticated fail (own membership row only).

**Frontend**
- Leaderboard page restructured: **League (primary) / Global (demoted secondary)** tabs; global keeps its weekly/monthly/alltime podium.
- Dashboard **"you ±3" strip** as an additive LX-B1 slot (hidden until a cohort has ≥1 neighbor; nothing reads as a hero rank metric).
- The ±3 window is derived in the **API layer** (`cohortStripWindow`, pure + unit-tested at the edges) over the snapshot board — same snapshot-scores guarantee, no second per-call SUM, no SQL⇄TS duplication.
- i18n **en / pt-BR / es**; a11y on the strip and rows.

## LX-B9b acceptance checklist
- [x] ~30-person weekly cohorts (`LEAGUE_COHORT_CAPACITY = 30`)
- [x] Weekly reset (Monday-anchored `week_start`; score scoped to the week)
- [x] Promotion/demotion — approximated via prior-week-engagement tier at assignment
- [x] Cohort score counts only learning-source XP (allowlist)
- [x] Global board still reachable (secondary tab)
- [x] Private-profile members visible but anonymized, never dropped
- [x] Direct table reads by anon/authenticated fail
- [x] "you ±3" nearby-rank strip on the dashboard; page cohort-primary / global-secondary

## D-4 note (scheduler)
**D-4 is UNDECIDED in the spec** (§ Decisions), so this ships the **lazy on-first-read** path — arrival-order cohorts, approximate engagement matching, **zero new infrastructure**. A cron upgrade to true batch matching is a clean follow-up that would replace only `ensure_league_membership`'s assignment body — tables, scoring, and the read RPC are unaffected.

## Deviation from the letter of the spec
The spec names two SQL RPCs (board + a "user-centered ±3 RPC"). I collapsed this to **one board RPC + API-layer windowing**: the ±3 slice is computed over the board's snapshot rows (cohort ≤ 30) in the route, keeping the sliding-window arithmetic **pure and unit-tested at the edges** with a single implementation (no SQL⇄TS drift). Same snapshot-scores / no-per-call-SUM guarantee.

## Verification
- `pnpm install --frozen-lockfile && pnpm typecheck` — green (8 packages).
- `pnpm --filter web test` — **1721 passed / 1721** (188 files), incl. new `cohort-leagues-guard` (RLS/DEFINER/allowlist/snapshot/anonymization invariants in **both** migration and schema.sql mirror) and `cohort-window` (edge windowing: rank 1, last rank, small cohorts, radius 0).
- `pnpm --filter web lint` — no new errors/warnings.
- Migration + `schema.sql` + all 5 plpgsql bodies **parse against real Postgres grammar** (libpg_query / pglast). No live-DB changes.

## Migration note
SQL-only, idempotent (`IF NOT EXISTS`, `ON CONFLICT DO NOTHING`, `CREATE OR REPLACE`, `DROP POLICY IF EXISTS`), explicit `BEGIN/COMMIT`, `schema.sql` byte-mirror, tested rollback block. Timestamp **20260726200000** (after #727's `20260726190000`; no column/timestamp collision — #727 touches `user_xp`, this adds new tables only). Per the spec serialization order, apply **after** B8.

Do not merge — awaiting review + owner sign-off.


---

## Adversarial-review follow-ups (commit e7f20f1)

- **MAJOR-1 (claim corrected):** the migration header previously claimed an eligible-shaped promo memo "cannot leak in." That was false — `xp_transactions.source` is reverse-derived from the memo prefix by `xp_source_for_reason`, so an **authority-supplied** `reward_xp` memo deliberately shaped `'Completed lesson: …'` **would** classify as eligible and score. Not user-exploitable (memos are authority-supplied; user-reachable XP is behind graded/on-chain gates; leagues are display-only; 5000/day cap). The comment now states the true guarantee and records the operator convention (promos must not use eligible-shaped prefixes). **Follow-up (filed as #736):** harden by writing `source` *positively* at each award call site instead of reverse-deriving it — this touches the XP writers (#731-incident territory) and belongs in its own reviewed change (#736), not this display-only PR.
- **MINOR-1 (fixed):** `get_cohort_leaderboard` now returns `NULL user_id` for anonymized non-you members (their opaque id no longer reaches ~30 peers); the caller's own id is preserved via `is_you`. Migration + `schema.sql` mirror + guard assertion + client type (`CohortLeaderboardEntry.userId: string | null`); cohort list keys switched to `rank`.
- **MINOR-2 (documented known tradeoff):** under a burst of concurrent first-views, `FOR UPDATE SKIP LOCKED` can spawn several small cohorts instead of filling one (a locked-but-open cohort is skipped rather than waited on). Accepted for launch scale — it trades exact arrival-order packing for deadlock-freedom and no overfill. If cohort fragmentation becomes visible at scale, the cron path (D-4) does true batch matching and removes it.

**Re-verified after fixes:** `pnpm typecheck` green; `pnpm --filter web test` → **1723 passed / 1723**; lint clean; migration + cohort schema block parse against real Postgres grammar (libpg_query). New head: `e7f20f1`.

