### PR TITLE
fix(content-lint): gate-3 base-ref fallback + non-destructive slots remedy (#737)

### DIFF
--- a/packages/content-lint/src/__tests__/gate3.test.ts
+++ b/packages/content-lint/src/__tests__/gate3.test.ts
@@ -22,6 +22,13 @@ title: ${id}
 blocks: [{ type: prose, key: intro, src: intro.md }]
 `;
 
+const correctLock = JSON.stringify({
+  version: 1,
+  slots: { "lesson-a": 0, "lesson-b": 1 },
+  retired: [],
+  next: 2,
+});
+
 describe("gate 3 — slots", () => {
   const tree = (lock: string) => ({
     "courses/x/course.yaml": course,
@@ -32,47 +39,143 @@ describe("gate 3 — slots", () => {
     "courses/x/lessons/b/intro.md": "# b",
   });
 
-  it("passes when the lock matches a fresh regeneration", async () => {
-    const lock = JSON.stringify({
-      version: 1,
-      slots: { "lesson-a": 0, "lesson-b": 1 },
-      retired: [],
-      next: 2,
-    });
-    const r = await runLint(makeTempRepo(tree(lock)));
+  /** A temp repo committed on `main` — a resolvable base ref for the immutability diff. */
+  const gitRepo = (lock: string): { root: string } => {
+    const root = makeTempRepo(tree(lock));
+    const git = (...args: string[]) =>
+      execFileSync("git", args, { cwd: root, stdio: "ignore" });
+    git("init", "-q");
+    git("config", "user.email", "t@t.t");
+    git("config", "user.name", "t");
+    git("add", "-A");
+    git("commit", "-qm", "c1");
+    git("branch", "-M", "main");
+    return { root };
+  };
+
+  it("passes when the lock matches the base regeneration", async () => {
+    const { root } = gitRepo(correctLock);
+    const r = await runLint(root, { baseRef: "main" });
     expect(r.diagnostics.filter((d) => d.gate === "gate-3")).toEqual([]);
   });
 
-  it("errors when a slot was renumbered", async () => {
-    const lock = JSON.stringify({
-      version: 1,
-      slots: { "lesson-a": 5, "lesson-b": 1 },
-      retired: [],
-      next: 6,
-    });
-    const r = await runLint(makeTempRepo(tree(lock)));
-    expect(r.diagnostics.some((d) => d.gate === "gate-3")).toBe(true);
+  it("errors when a slot was renumbered against the base", async () => {
+    // Base (committed on main) is correct; the working tree renumbers lesson-a.
+    const { root } = gitRepo(correctLock);
+    writeFileSync(
+      join(root, "courses/x/slots.lock.json"),
+      JSON.stringify({
+        version: 1,
+        slots: { "lesson-a": 5, "lesson-b": 1 },
+        retired: [],
+        next: 6,
+      }),
+      "utf8"
+    );
+    const r = await runLint(root, { baseRef: "main" });
+    expect(
+      r.diagnostics.some((d) => d.gate === "gate-3" && d.severity === "error")
+    ).toBe(true);
   });
 
   it("errors when a new lesson is missing from the lock", async () => {
-    const lock = JSON.stringify({
-      version: 1,
-      slots: { "lesson-a": 0 },
-      retired: [],
-      next: 1,
-    });
-    const r = await runLint(makeTempRepo(tree(lock)));
-    expect(r.diagnostics.some((d) => d.gate === "gate-3")).toBe(true);
+    // course.yaml lists lesson-a + lesson-b but the committed lock only has lesson-a.
+    const { root } = gitRepo(
+      JSON.stringify({
+        version: 1,
+        slots: { "lesson-a": 0 },
+        retired: [],
+        next: 1,
+      })
+    );
+    const r = await runLint(root, { baseRef: "main" });
+    expect(
+      r.diagnostics.some((d) => d.gate === "gate-3" && d.severity === "error")
+    ).toBe(true);
+  });
+
+  it("the mismatch remedy never suggests regenerating a deployed lock (#737)", async () => {
+    const { root } = gitRepo(correctLock);
+    writeFileSync(
+      join(root, "courses/x/slots.lock.json"),
+      JSON.stringify({
+        version: 1,
+        slots: { "lesson-a": 5, "lesson-b": 1 },
+        retired: [],
+        next: 6,
+      }),
+      "utf8"
+    );
+    const r = await runLint(root, { baseRef: "main" });
+    const msg = r.diagnostics.find(
+      (d) => d.gate === "gate-3" && d.severity === "error"
+    )?.message;
+    expect(msg).toBeDefined();
+    // The destructive suggestion is gone; the invariant + a DANGER note replace it.
+    expect(msg).not.toMatch(/content:slots/);
+    expect(msg).not.toMatch(/Run `/);
+    expect(msg).toMatch(/DANGER/);
+    expect(msg).toMatch(/invariant/i);
+    expect(msg).toMatch(/by hand/i);
+  });
+
+  it("skips (warning, never error) when no base ref is resolvable — #737", async () => {
+    // A renumbered lock that WOULD be a mismatch, but with no git repo and no base
+    // ref there is nothing to diff against: gate-3 must not fabricate a failure.
+    const root = makeTempRepo(
+      tree(
+        JSON.stringify({
+          version: 1,
+          slots: { "lesson-a": 5, "lesson-b": 1 },
+          retired: [],
+          next: 6,
+        })
+      )
+    );
+    const r = await runLint(root); // no baseRef, not a git repo
+    expect(
+      r.diagnostics.filter((d) => d.gate === "gate-3" && d.severity === "error")
+    ).toEqual([]);
+    expect(
+      r.diagnostics.some(
+        (d) =>
+          d.gate === "gate-3" &&
+          d.severity === "warning" &&
+          /no base ref/i.test(d.message)
+      )
+    ).toBe(true);
+  });
+
+  it("still errors on a genuinely missing lock even with no base ref", async () => {
+    const t = tree(correctLock) as Record<string, string>;
+    delete t["courses/x/slots.lock.json"];
+    const root = makeTempRepo(t);
+    const r = await runLint(root); // no baseRef
+    expect(
+      r.diagnostics.some(
+        (d) =>
+          d.gate === "gate-3" &&
+          d.severity === "error" &&
+          /missing slots\.lock\.json/i.test(d.message)
+      )
+    ).toBe(true);
+  });
+
+  it("resolves origin/main locally so a correct lock passes with no explicit base ref", async () => {
+    // Simulate a fresh clone: a bare invocation (no GITHUB_BASE_REF) must resolve
+    // origin/main and validate the lock instead of regenerating it from scratch.
+    const { root } = gitRepo(correctLock);
+    const git = (...args: string[]) =>
+      execFileSync("git", args, { cwd: root, stdio: "ignore" });
+    // Make origin/main a real remote-tracking ref pointing at the same commit.
+    git("update-ref", "refs/remotes/origin/main", "main");
+    git("symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/main");
+    const r = await runLint(root); // no explicit baseRef
+    expect(r.diagnostics.filter((d) => d.gate === "gate-3")).toEqual([]);
   });
 
   it("emits a warning (never silent) when no exact merge-base exists", async () => {
-    const lock = JSON.stringify({
-      version: 1,
-      slots: { "lesson-a": 0, "lesson-b": 1 },
-      retired: [],
-      next: 2,
-    });
-    const root = makeTempRepo(tree(lock));
+    const root = makeTempRepo(tree(correctLock));
     const git = (...args: string[]) => execFileSync("git", args, { cwd: root });
     git("init", "-q");
     git("config", "user.email", "t@t.t");

--- a/packages/content-lint/src/checks/gate3-slots.ts
+++ b/packages/content-lint/src/checks/gate3-slots.ts
@@ -6,7 +6,7 @@ import {
 import { registerCheck, type LintContext } from "../lint";
 import { type RepoModel, type CourseEntry } from "../model";
 import { diag, type Diagnostic } from "../diagnostics";
-import { mergeBase, gitShow } from "../git";
+import { mergeBase, gitShow, resolveLocalBase } from "../git";
 
 /** Order-independent structural equality of two locks. */
 function locksEqual(a: SlotsLockT, b: SlotsLockT): boolean {
@@ -33,44 +33,76 @@ function baseLock(
   return parsed.success ? parsed.data : null;
 }
 
+/** Emitted once when no base ref is resolvable — the check is skipped, not failed. */
+function missingLockDiag(course: CourseEntry): Diagnostic {
+  const file = course.slotsPath ?? `${course.dir}/slots.lock.json`;
+  // A brand-new course with no lock file yet is the ONLY safe place to generate a
+  // fresh 0-N assignment. A present-but-unparseable lock is different: the course
+  // may already be deployed, so we flag it for a human instead of inviting a
+  // from-scratch regeneration that would renumber live slots.
+  const message =
+    course.slotsPath === null
+      ? "missing slots.lock.json — a new course needs one generated from its lesson order"
+      : "slots.lock.json is present but does not parse against the schema — fix it by hand; do NOT regenerate a deployed course's lock from scratch (that renumbers live slots)";
+  return diag("gate-3", "error", file, message);
+}
+
 export function gate3Check(model: RepoModel, ctx: LintContext): Diagnostic[] {
   const out: Diagnostic[] = [];
+
+  // CI sets ctx.baseRef; a bare local run does not. Fall back to a remote-tracking
+  // default (origin/HEAD → origin/main) so a correct lock validates locally too,
+  // instead of being regenerated from scratch and reported as a false mismatch (#737).
+  const resolvedRef = ctx.baseRef ?? resolveLocalBase(ctx.root);
 
   // Resolve the fork point ONCE (same baseRef for every course). A degrade to the
   // base tip (e.g. a shallow --depth=1 fetch) makes the slots-lock immutability
   // comparison inexact, so surface it — never silently — exactly once.
-  const base = ctx.baseRef ? mergeBase(ctx.root, ctx.baseRef) : null;
-  if (base && !base.exact) {
+  const base = resolvedRef ? mergeBase(ctx.root, resolvedRef) : null;
+
+  // No base ref at all (no CI ref, no origin remote): slot immutability CANNOT be
+  // verified — the base state to diff against is unknown. Never regenerate a fresh
+  // 0-N lock and assert a mismatch against a correct one (#737); say the check was
+  // skipped and only catch a genuinely missing lock, which needs no base ref.
+  if (!base) {
     out.push(
       diag(
         "gate-3",
         "warning",
         "",
-        `could not compute an exact merge-base with "${ctx.baseRef}" (shallow base?) — regenerating slots against the base TIP instead of the fork point; results may be inaccurate. Fetch the base with full history (fetch-depth: 0).`
+        "slot immutability not checked — no base ref (set GITHUB_BASE_REF, or fetch origin/main with full history). Slot invariants are verified in CI."
+      )
+    );
+    for (const course of model.courses) {
+      if (!course.slotsLock) out.push(missingLockDiag(course));
+    }
+    return out;
+  }
+
+  if (!base.exact) {
+    out.push(
+      diag(
+        "gate-3",
+        "warning",
+        "",
+        `could not compute an exact merge-base with "${resolvedRef}" (shallow base?) — regenerating slots against the base TIP instead of the fork point; results may be inaccurate. Fetch the base with full history (fetch-depth: 0).`
       )
     );
   }
-  const baseRef = base?.ref ?? null;
+  const baseRef = base.ref;
 
   for (const course of model.courses) {
     const file = course.slotsPath ?? `${course.dir}/slots.lock.json`;
     if (!course.slotsLock) {
-      out.push(
-        diag(
-          "gate-3",
-          "error",
-          file,
-          "missing or invalid slots.lock.json (run `pnpm content:slots`)"
-        )
-      );
+      out.push(missingLockDiag(course));
       continue;
     }
     const displayOrder = course.course.modules.flatMap((m) => m.lessons);
     // KNOWN LIMITATION: regenerating from the merge-base assumes no add-then-remove
     // of the SAME lesson within one PR (which would retire a slot the base never knew
-    // about). `pnpm content:slots` regenerates incrementally from the immediately-
-    // preceding commit, so a correctly-generated lock always passes; the rare intra-PR
-    // churn case is the sync-time re-validation's job (spec §9.2).
+    // about). The generator regenerates incrementally from the base lock, so a
+    // correctly-generated lock always passes; the rare intra-PR churn case is the
+    // sync-time re-validation's job (spec §9.2).
     let expected: SlotsLockT;
     try {
       expected = assignSlots(baseLock(ctx, course, baseRef), displayOrder);
@@ -91,7 +123,14 @@ export function gate3Check(model: RepoModel, ctx: LintContext): Diagnostic[] {
           "gate-3",
           "error",
           file,
-          `slots.lock.json does not match regeneration — a slot was changed, reused, or a lesson is missing. Run \`pnpm content:slots\`. Expected ${JSON.stringify(expected)}`
+          // A slot is a permanent on-chain progress-bit position for enrolled
+          // learners. The remedy is to REPAIR the lock, never to regenerate it:
+          // regenerating a deployed course renumbers every slot and corrupts
+          // learner progress (#737).
+          `slots.lock.json violates the slot invariant — surviving lessons must keep their assigned slot, retired slots are never reused, and \`next\` only grows. ` +
+            `Fix the lock BY HAND to preserve every slot already assigned in the base ref (diff it: \`git show <base>:${file}\`). ` +
+            `DANGER: do NOT run any regenerate-from-scratch command on a deployed course — it renumbers slots and re-points 38+ learners' completed-lesson bitmaps. Regeneration is ONLY for a brand-new course that has never been deployed. ` +
+            `Expected ${JSON.stringify(expected)}`
         )
       );
     }

--- a/packages/content-lint/src/git.ts
+++ b/packages/content-lint/src/git.ts
@@ -35,6 +35,34 @@ export function mergeBase(
   return tip ? { ref: tip, exact: false } : null;
 }
 
+/**
+ * A best-effort base ref for a run with no explicit `GITHUB_BASE_REF` /
+ * `LINT_BASE_REF` (a bare local invocation). Prefers the remote's default branch
+ * (`origin/HEAD` → e.g. `origin/main`), then the common `origin/main` /
+ * `origin/master`. Returns null when no remote-tracking base exists — a repo with
+ * no fetched remote — in which case gates 2/3 cannot verify immutability and MUST
+ * say so rather than fabricate a comparison. Never invents `HEAD` as its own base.
+ */
+export function resolveLocalBase(root: string): string | null {
+  const head = git(root, [
+    "symbolic-ref",
+    "--quiet",
+    "refs/remotes/origin/HEAD",
+  ])
+    ?.trim()
+    .replace(/^refs\/remotes\//, "");
+  if (head && head !== "origin/HEAD") return head;
+  for (const cand of ["origin/main", "origin/master"]) {
+    if (
+      git(root, ["rev-parse", "--verify", "--quiet", `${cand}^{commit}`]) !==
+      null
+    ) {
+      return cand;
+    }
+  }
+  return null;
+}
+
 /** File contents at `ref`, or null when the path did not exist there. */
 export function gitShow(
   root: string,


### PR DESCRIPTION
Fixes #737.

`gate-3` (slots-lock immutability) had two coupled defects: a **spurious failure** outside CI, sitting exactly where it suggested a **destructive** remedy. A remediation agent nearly ran that remedy on a deployed course.

## Problem 1 — spurious failure outside CI
`gate3-slots.ts` computed its expectation with `assignSlots(baseLock(...))`. Without `GITHUB_BASE_REF` (any bare local run), `baseLock` was `null`, so `assignSlots(null, …)` regenerated a fresh `0–N` map and reported **any correct lock** as a mismatch. CI was fine (`validate-content.yml` sets `LINT_BASE_REF` with `fetch-depth: 0`); everyone else saw a red gate on a good lock.

**Fix:** when no CI ref is set, resolve a remote-tracking base (`origin/HEAD` → `origin/main`/`origin/master`) via the new `resolveLocalBase()` and diff against it, exactly like CI. If **no** base ref is resolvable (a repo with no fetched remote), gate-3 emits a warning — `slot immutability not checked — no base ref` — and skips the immutability comparison instead of fabricating a mismatch. It never invents `HEAD` as its own base. Same principle as #614/#694: a check that cannot run must not report a failure.

## Problem 2 — destructive remedy text
The mismatch error said *"Run `pnpm content:slots`."* On a deployed course that renumbers **every** slot; slots are permanent on-chain progress-bit positions and `building-your-first-solana-program` has **38 live enrolments**, so regeneration silently re-points every learner's completed-lesson bits.

**Fix:** the mismatch message no longer suggests any regenerate command. It states the invariant (surviving lessons keep their slot; retired slots are never reused; `next` only grows), tells the author to **repair the lock by hand** (with the exact `git show <base>:<file>` to diff), and carries a **DANGER** note that regeneration is only ever for a brand-new, never-deployed course. The missing-lock branch now distinguishes a genuinely-absent lock (new course, safe to generate) from a present-but-unparseable one (flag for a human, don't regenerate).

## CI is unchanged
When `ctx.baseRef` is set (CI), `resolveLocalBase` is never called and the merge-base / diff path is byte-identical to before, including the shallow-base warning.

## `pnpm content:slots` — the guard has no home
The command referenced in the old message **does not exist as a runnable script** anywhere: not in this monorepo's `package.json`s, and courses-academy has no `package.json` at all. It appears only in docs/specs and in these two error strings. The only real slot generator is `assignSlots` in `content-schema` (used correctly by the gate, which passes the base lock so it *preserves*) and the one-shot migration `scripts/cs8-extraction/extract.ts`. There is therefore no `content:slots` script to add a `--force-new` refusal guard to. A guard must **not** be added to `assignSlots` itself — gate-3 legitimately calls it with a base lock that has non-empty `retired[]`/`next`, so refusing that would break the gate. Routing the "build a guarded `content:slots`" half separately per the task brief.

## courses-academy validation matrix
Linter (this branch) run against `courses-academy@main` (read-only clone):

| invocation | before this PR | after this PR |
|---|---|---|
| bare (no base ref), `origin/main` present | exit 1, gate-3 error on every lock | **exit 0**, no gate-3 diagnostic (resolves `origin/main`, locks match) |
| CI-simulated (`GITHUB_BASE_REF=main`) | exit 0 | **exit 0** (byte-identical) |
| bare, no `origin` remote at all | exit 1, gate-3 error | **exit 0**, gate-3 **warning** "no base ref" |

## Tests
`pnpm --filter @superteam-lms/content-lint test` → 85 passed (gate3: 8). `content-schema` → 170 passed. `typecheck` clean on both touched packages (web is not in content-lint's dependency graph). New/updated gate-3 coverage: no-base-ref → warning not error; `origin/main` local resolution; base-ref mismatch still errors; remedy text asserts **no** `content:slots` / regenerate suggestion.

**Do not merge** — SENSITIVE (ci/lint semantics). Needs adversarial + gate review.
