### PR TITLE
feat(ops): make /api/deploy/save write path observable (#725)

### DIFF
--- a/apps/web/src/app/api/admin/capstone-funnel/__tests__/route.test.ts
+++ b/apps/web/src/app/api/admin/capstone-funnel/__tests__/route.test.ts
@@ -1,0 +1,99 @@
+/* eslint-disable import/order -- vi.mock('server-only') must be hoisted above
+   the route import so the `server-only` graph loads under vitest. */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { NextRequest } from "next/server";
+
+vi.mock("server-only", () => ({}));
+
+const { requireAdminAuth, getCapstoneFunnel, logEvent } = vi.hoisted(() => ({
+  requireAdminAuth: vi.fn(),
+  getCapstoneFunnel: vi.fn(),
+  logEvent: vi.fn(),
+}));
+
+vi.mock("@/lib/admin/auth", () => ({
+  AdminAuthError: class extends Error {},
+  adminUnauthorizedResponse: () => new Response("{}", { status: 401 }),
+  requireAdminAuth,
+}));
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: () => ({}) as never,
+}));
+vi.mock("@/lib/credentials/capstone-funnel", () => ({ getCapstoneFunnel }));
+vi.mock("@/lib/logging", () => ({ logEvent }));
+
+import { GET } from "../route";
+import { AdminAuthError } from "@/lib/admin/auth";
+
+function reqFor(): NextRequest {
+  return new Request(
+    "https://x/api/admin/capstone-funnel"
+  ) as unknown as NextRequest;
+}
+
+const healthyFunnel = {
+  courseId: "course-building-first-program",
+  deployLessonId: "lesson-bfsp-m4-capstone",
+  completions: 5,
+  deploys: 3,
+  deferrals: 0,
+  certificates: 3,
+  verdict: "healthy" as const,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  requireAdminAuth.mockReturnValue(undefined);
+  getCapstoneFunnel.mockResolvedValue(healthyFunnel);
+});
+
+describe("GET /api/admin/capstone-funnel", () => {
+  it("401s when admin auth fails, without reading the funnel", async () => {
+    requireAdminAuth.mockImplementation(() => {
+      throw new AdminAuthError();
+    });
+
+    const res = await GET(reqFor());
+
+    expect(res.status).toBe(401);
+    expect(getCapstoneFunnel).not.toHaveBeenCalled();
+  });
+
+  it("returns the funnel counters for an authed admin", async () => {
+    const res = await GET(reqFor());
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual(healthyFunnel);
+  });
+
+  it("does not raise an alert log when the funnel is healthy", async () => {
+    await GET(reqFor());
+    expect(logEvent).not.toHaveBeenCalled();
+  });
+
+  it("emits a loud error log when the funnel signals a broken write path", async () => {
+    getCapstoneFunnel.mockResolvedValue({
+      ...healthyFunnel,
+      completions: 4,
+      deploys: 0,
+      deferrals: 2,
+      certificates: 0,
+      verdict: "write_path_suspect",
+    });
+
+    const res = await GET(reqFor());
+
+    expect(res.status).toBe(200);
+    expect(logEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: "capstone-funnel.write_path_suspect",
+        level: "error",
+        context: expect.objectContaining({
+          completions: 4,
+          deploys: 0,
+          deferrals: 2,
+        }),
+      })
+    );
+  });
+});

--- a/apps/web/src/app/api/admin/capstone-funnel/route.ts
+++ b/apps/web/src/app/api/admin/capstone-funnel/route.ts
@@ -1,0 +1,53 @@
+import "server-only";
+
+import { NextRequest, NextResponse } from "next/server";
+import {
+  requireAdminAuth,
+  adminUnauthorizedResponse,
+  AdminAuthError,
+} from "@/lib/admin/auth";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { getCapstoneFunnel } from "@/lib/credentials/capstone-funnel";
+import { logEvent } from "@/lib/logging";
+
+// Auth/cookie + per-request DB access — never statically prerender (DYNAMIC_SERVER_USAGE).
+export const dynamic = "force-dynamic";
+
+/**
+ * Capstone credential funnel (#725). Aggregate counts of the four stages a
+ * learner passes through toward the capstone credential, so a broken
+ * `/api/deploy/save` — which writes no `deployed_programs` row and is otherwise
+ * indistinguishable from the gate correctly withholding — becomes visible at a
+ * glance. Admin-authed, service-role aggregate reads only (no PII).
+ *
+ * Returns 200 with the counters + a `verdict`. When the funnel shows the
+ * write-path-broken signature (`write_path_suspect`) it also emits a loud
+ * structured log line, so the same fact reaches log-based alerting and not
+ * only whoever happens to open this route.
+ */
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  try {
+    requireAdminAuth(req);
+  } catch (e) {
+    if (e instanceof AdminAuthError) return adminUnauthorizedResponse();
+    throw e;
+  }
+
+  const funnel = await getCapstoneFunnel(createAdminClient());
+
+  if (funnel.verdict === "write_path_suspect") {
+    logEvent({
+      event: "capstone-funnel.write_path_suspect",
+      level: "error",
+      context: {
+        courseId: funnel.courseId,
+        deployLessonId: funnel.deployLessonId,
+        completions: funnel.completions,
+        deploys: funnel.deploys,
+        deferrals: funnel.deferrals,
+      },
+    });
+  }
+
+  return NextResponse.json(funnel);
+}

--- a/apps/web/src/app/api/deploy/save/__tests__/route.test.ts
+++ b/apps/web/src/app/api/deploy/save/__tests__/route.test.ts
@@ -16,7 +16,16 @@ const {
   profileSingle,
   upsert,
   userClientFrom,
+  logEvent,
 } = vi.hoisted(() => ({
+  logEvent:
+    vi.fn<
+      (params: {
+        event: string;
+        level?: string;
+        context?: Record<string, unknown>;
+      }) => void
+    >(),
   getUser: vi.fn<() => Promise<unknown>>(),
   isRateLimited: vi.fn<
     (
@@ -38,7 +47,13 @@ const {
     >(),
   profileSingle:
     vi.fn<() => Promise<{ data: { wallet_address: string } | null }>>(),
-  upsert: vi.fn<(row: unknown, opts: unknown) => Promise<{ error: null }>>(),
+  upsert:
+    vi.fn<
+      (
+        row: unknown,
+        opts: unknown
+      ) => Promise<{ error: { message: string } | null }>
+    >(),
   // Spy so tests can prove POST never touches a table through the
   // user-scoped client — deployed_programs is service_role-write-only
   // (20260726120000_lockdown_deployed_programs_rls), so a user-client write
@@ -71,8 +86,10 @@ vi.mock("@/lib/rate-limit", () => ({
 vi.mock("@/lib/solana/academy-program", () => ({
   getConnection: () => ({ getAccountInfo }),
 }));
+vi.mock("@/lib/logging", () => ({ logEvent }));
 
 import { POST } from "../route";
+import { CAPSTONE_CREDENTIAL } from "@/lib/credentials/capstone-gate";
 
 // ---------------------------------------------------------------------------
 // BPF Upgradeable Loader fixtures
@@ -584,6 +601,148 @@ describe("POST /api/deploy/save — service_role-only writes (RLS lockdown)", ()
     expect(schema).toContain(`CREATE POLICY ${SELECT_POLICY}`);
     expect(schema).toContain(
       "ALTER TABLE deployed_programs ENABLE ROW LEVEL SECURITY;"
+    );
+  });
+});
+
+// #725 — the save path had silent deny/exception paths (incl. an empty
+// `catch {}`), so a broken write looked identical to the gate correctly
+// withholding. Every non-success path must now emit a structured, greppable
+// event; every success must too (0 prod rows ever — the first real run must be
+// visible).
+describe("POST /api/deploy/save — observability logging (#725)", () => {
+  function loggedEvents(): string[] {
+    return logEvent.mock.calls.map((c) => c[0].event);
+  }
+
+  it("logs a saved event (info) with the row keys on success", async () => {
+    setHappyChain();
+
+    await POST(req(validBody));
+
+    expect(logEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: "deploy-save.saved",
+        level: "info",
+        context: expect.objectContaining({
+          userId: "user-1",
+          courseId: "course-1",
+          lessonId: "lesson-1",
+          programId: programId.toBase58(),
+        }),
+      })
+    );
+  });
+
+  it("logs a rejected event carrying the on-chain reason (not leaked to client)", async () => {
+    setHappyChain(Keypair.generate().publicKey); // authority mismatch
+
+    const res = await POST(req(validBody));
+
+    expect(((await res.json()) as { error: string }).error).toBe(
+      "Program verification failed"
+    );
+    expect(logEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: "deploy-save.rejected",
+        context: expect.objectContaining({
+          reason: "verification:authority-mismatch",
+        }),
+      })
+    );
+  });
+
+  it("logs a rejected event when no wallet is linked", async () => {
+    profileSingle.mockResolvedValue({ data: null });
+
+    await POST(req(validBody));
+
+    expect(logEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: "deploy-save.rejected",
+        context: expect.objectContaining({ reason: "no-wallet-linked" }),
+      })
+    );
+  });
+
+  it("logs an error event when the RPC is unreachable (fail-closed 503)", async () => {
+    getAccountInfo.mockRejectedValue(new Error("fetch failed"));
+
+    const res = await POST(req(validBody));
+
+    expect(res.status).toBe(503);
+    expect(logEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: "deploy-save.rpc-unavailable",
+        level: "error",
+      })
+    );
+  });
+
+  it("logs an error event when the verified row fails to write", async () => {
+    setHappyChain();
+    upsert.mockResolvedValue({ error: { message: "insert failed" } });
+
+    const res = await POST(req(validBody));
+
+    expect(res.status).toBe(500);
+    expect(logEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: "deploy-save.write-failed",
+        level: "error",
+      })
+    );
+  });
+
+  it("logs an unhandled event instead of swallowing an unexpected throw", async () => {
+    getUser.mockRejectedValue(new Error("auth exploded"));
+
+    const res = await POST(req(validBody));
+
+    expect(res.status).toBe(500);
+    expect(logEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: "deploy-save.unhandled",
+        level: "error",
+      })
+    );
+  });
+
+  it("does not log a rejection on the happy path", async () => {
+    setHappyChain();
+
+    await POST(req(validBody));
+
+    expect(loggedEvents()).not.toContain("deploy-save.rejected");
+  });
+});
+
+// The gate reads a `deployed_programs` row keyed by (user_id, course_id,
+// lesson_id). This proves the WRITE side stamps exactly the keys the READ side
+// (checkCapstoneCredentialGate) queries — a mismatch would silently deny every
+// legitimate capstone credential. Pinned to the real capstone constants, so a
+// content rename that moves the gate also breaks this test.
+describe("POST /api/deploy/save — writes the keys the capstone gate reads (#721/#725)", () => {
+  it("upserts a row scoped to the capstone course + deploy lesson", async () => {
+    setHappyChain();
+
+    const res = await POST(
+      req({
+        courseId: CAPSTONE_CREDENTIAL.courseId,
+        lessonId: CAPSTONE_CREDENTIAL.deployLessonId,
+        programId: programId.toBase58(),
+      })
+    );
+
+    expect(res.status).toBe(200);
+    expect(upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        user_id: "user-1",
+        course_id: CAPSTONE_CREDENTIAL.courseId,
+        lesson_id: CAPSTONE_CREDENTIAL.deployLessonId,
+        program_id: programId.toBase58(),
+      }),
+      { onConflict: "user_id,course_id,lesson_id" }
     );
   });
 });

--- a/apps/web/src/app/api/deploy/save/route.ts
+++ b/apps/web/src/app/api/deploy/save/route.ts
@@ -8,6 +8,7 @@ import {
 } from "@/lib/solana/verify-program-deploy";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { createClient } from "@/lib/supabase/server";
+import { logEvent } from "@/lib/logging";
 
 interface SaveDeployRequest {
   lessonId: string;
@@ -119,6 +120,18 @@ export async function POST(request: NextRequest) {
       .single();
 
     if (!profile?.wallet_address) {
+      // A learner reached the deploy step with no linked wallet — they cannot
+      // pass the capstone credential gate until they connect one. Loud so a
+      // wave of these near launch is visible, not silent.
+      logEvent({
+        event: "deploy-save.rejected",
+        context: {
+          reason: "no-wallet-linked",
+          userId: user.id,
+          courseId: body.courseId,
+          lessonId: body.lessonId,
+        },
+      });
       return NextResponse.json(
         {
           error: "Wallet not connected. Link your wallet to save deployments.",
@@ -131,6 +144,18 @@ export async function POST(request: NextRequest) {
     try {
       walletPubkey = new PublicKey(profile.wallet_address);
     } catch {
+      // The stored wallet_address does not parse — a data-integrity fault, not
+      // a normal user error. Never silent: it fail-closes a legitimate deploy.
+      logEvent({
+        event: "deploy-save.rejected",
+        level: "error",
+        context: {
+          reason: "linked-wallet-unparseable",
+          userId: user.id,
+          courseId: body.courseId,
+          lessonId: body.lessonId,
+        },
+      });
       return NextResponse.json({ error: VERIFICATION_FAILED }, { status: 400 });
     }
 
@@ -157,8 +182,22 @@ export async function POST(request: NextRequest) {
           walletPubkey
         );
       }
-    } catch {
+    } catch (err) {
       // RPC unreachable — fail closed, but as "try again", not as a rejection.
+      // Loud: a stale/wrong RPC that always throws here would silently block
+      // every legitimate deploy (and the capstone credential behind it), and
+      // "verification fails closed" is exactly the invisible failure #725 is
+      // about.
+      logEvent({
+        event: "deploy-save.rpc-unavailable",
+        level: "error",
+        context: {
+          userId: user.id,
+          courseId: body.courseId,
+          lessonId: body.lessonId,
+          error: err instanceof Error ? err.message : String(err),
+        },
+      });
       return NextResponse.json(
         { error: "Verification temporarily unavailable. Please try again." },
         { status: 503, headers: { "Retry-After": "30" } }
@@ -166,9 +205,19 @@ export async function POST(request: NextRequest) {
     }
 
     if (!verification.ok) {
-      console.warn(
-        `[deploy-save] rejected program ${body.programId} for user ${user.id}: ${verification.reason}`
-      );
+      // Structured so a run of a single reason (e.g. authority-mismatch across
+      // many users → wrong RPC network) is greppable, without leaking the
+      // reason to the client (VERIFICATION_FAILED stays generic — #560).
+      logEvent({
+        event: "deploy-save.rejected",
+        context: {
+          reason: `verification:${verification.reason}`,
+          userId: user.id,
+          courseId: body.courseId,
+          lessonId: body.lessonId,
+          programId: body.programId,
+        },
+      });
       return NextResponse.json({ error: VERIFICATION_FAILED }, { status: 400 });
     }
 
@@ -190,15 +239,50 @@ export async function POST(request: NextRequest) {
     );
 
     if (error) {
-      console.error("Failed to save deployment:", error);
+      // The verified deploy could not be recorded — the capstone credential
+      // gate reads this exact row, so a swallowed write here is the #725
+      // failure mode itself. Loud and structured.
+      logEvent({
+        event: "deploy-save.write-failed",
+        level: "error",
+        context: {
+          userId: user.id,
+          courseId: body.courseId,
+          lessonId: body.lessonId,
+          programId: body.programId,
+          error: error.message,
+        },
+      });
       return NextResponse.json(
         { error: "Failed to save deployment" },
         { status: 500 }
       );
     }
 
+    // A successful write is the event #725 is waiting on (0 rows in prod, ever)
+    // — log it at info so the first real end-to-end run is observable and the
+    // funnel's `deploys` count has a per-event breadcrumb.
+    logEvent({
+      event: "deploy-save.saved",
+      level: "info",
+      context: {
+        userId: user.id,
+        courseId: body.courseId,
+        lessonId: body.lessonId,
+        programId: body.programId,
+      },
+    });
+
     return NextResponse.json({ success: true });
-  } catch {
+  } catch (err) {
+    // Previously an empty `catch {}` — any unexpected throw returned a generic
+    // 500 with NO log, making a broken save path completely invisible. Never
+    // silent again.
+    logEvent({
+      event: "deploy-save.unhandled",
+      level: "error",
+      context: { error: err instanceof Error ? err.message : String(err) },
+    });
     return NextResponse.json(
       { error: "Internal server error" },
       { status: 500 }

--- a/apps/web/src/lib/credentials/__tests__/capstone-funnel.test.ts
+++ b/apps/web/src/lib/credentials/__tests__/capstone-funnel.test.ts
@@ -1,0 +1,135 @@
+/* eslint-disable import/order -- vi.mock('server-only') must be hoisted above
+   the module import so the `server-only` graph loads under vitest. */
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import { getCapstoneFunnel } from "../capstone-funnel";
+import { CAPSTONE_CREDENTIAL } from "../capstone-gate";
+
+type CountResponse = {
+  count: number | null;
+  error: { message: string } | null;
+};
+
+// A head+count query builder mock: every chainable method returns the same
+// thenable, which resolves to the response configured for its table. Records
+// the eq()/is()/like() filters so tests can assert each count is scoped
+// correctly (a funnel that counts the wrong rows is worse than none).
+function adminClientWith(responses: Record<string, CountResponse>) {
+  const filters: Record<string, Array<[string, unknown]>> = {};
+
+  function builderFor(table: string) {
+    const bucket: Array<[string, unknown]> = [];
+    filters[table] = bucket;
+    const response = responses[table] ?? { count: 0, error: null };
+    const record =
+      (op: string) =>
+      (col: string, val: unknown = undefined) => {
+        bucket.push([`${op}:${col}`, val]);
+        return chain;
+      };
+    const chain = {
+      select: () => chain,
+      eq: record("eq"),
+      is: record("is"),
+      like: record("like"),
+      then: (resolve: (r: CountResponse) => unknown) => resolve(response),
+    };
+    return chain;
+  }
+
+  const from = vi.fn((table: string) => builderFor(table));
+  return { client: { from } as never, from, filters };
+}
+
+const { courseId, deployLessonId } = CAPSTONE_CREDENTIAL;
+
+describe("getCapstoneFunnel — counters and scoping", () => {
+  it("scopes each count to the capstone course + deploy lesson", async () => {
+    const { client, filters, from } = adminClientWith({
+      user_progress: { count: 3, error: null },
+      deployed_programs: { count: 2, error: null },
+      pending_onchain_actions: { count: 0, error: null },
+      certificates: { count: 1, error: null },
+    });
+
+    const funnel = await getCapstoneFunnel(client);
+
+    expect(funnel.completions).toBe(3);
+    expect(funnel.deploys).toBe(2);
+    expect(funnel.deferrals).toBe(0);
+    expect(funnel.certificates).toBe(1);
+
+    expect(from).toHaveBeenCalledWith("user_progress");
+    expect(filters.user_progress).toEqual([
+      ["eq:course_id", courseId],
+      ["eq:lesson_id", deployLessonId],
+      ["eq:completed", true],
+    ]);
+    expect(filters.deployed_programs).toEqual([
+      ["eq:course_id", courseId],
+      ["eq:lesson_id", deployLessonId],
+    ]);
+    // Deferrals: unresolved certificate queue rows parked by the capstone gate.
+    expect(filters.pending_onchain_actions).toEqual([
+      ["eq:action_type", "certificate"],
+      ["is:resolved_at", null],
+      ["like:last_error", `capstone-gate-%:${courseId}`],
+    ]);
+    expect(filters.certificates).toEqual([["eq:course_id", courseId]]);
+  });
+});
+
+describe("getCapstoneFunnel — verdict", () => {
+  async function verdictFor(counts: {
+    completions: number;
+    deploys: number;
+    deferrals: number;
+  }) {
+    const { client } = adminClientWith({
+      user_progress: { count: counts.completions, error: null },
+      deployed_programs: { count: counts.deploys, error: null },
+      pending_onchain_actions: { count: counts.deferrals, error: null },
+      certificates: { count: 0, error: null },
+    });
+    return (await getCapstoneFunnel(client)).verdict;
+  }
+
+  it("is idle when nobody has reached the deploy lesson", async () => {
+    expect(await verdictFor({ completions: 0, deploys: 0, deferrals: 0 })).toBe(
+      "idle"
+    );
+  });
+
+  it("is healthy the moment any deploy row lands", async () => {
+    expect(await verdictFor({ completions: 5, deploys: 1, deferrals: 3 })).toBe(
+      "healthy"
+    );
+  });
+
+  it("flags write_path_suspect: completions + deferrals but zero deploys", async () => {
+    expect(await verdictFor({ completions: 4, deploys: 0, deferrals: 2 })).toBe(
+      "write_path_suspect"
+    );
+  });
+
+  it("is watch when completions exist but nothing is deferred yet", async () => {
+    expect(await verdictFor({ completions: 2, deploys: 0, deferrals: 0 })).toBe(
+      "watch"
+    );
+  });
+
+  it("is unavailable (never healthy) when any count read errors", async () => {
+    const { client } = adminClientWith({
+      user_progress: { count: 3, error: null },
+      deployed_programs: { count: null, error: { message: "db down" } },
+      pending_onchain_actions: { count: 0, error: null },
+      certificates: { count: 0, error: null },
+    });
+    const funnel = await getCapstoneFunnel(client);
+    expect(funnel.verdict).toBe("unavailable");
+    // A failed read reports 0, not a stale/guessed number.
+    expect(funnel.deploys).toBe(0);
+  });
+});

--- a/apps/web/src/lib/credentials/capstone-funnel.ts
+++ b/apps/web/src/lib/credentials/capstone-funnel.ts
@@ -1,0 +1,144 @@
+import "server-only";
+
+import type { createAdminClient } from "@/lib/supabase/admin";
+import { CAPSTONE_CREDENTIAL } from "./capstone-gate";
+
+type AdminClient = ReturnType<typeof createAdminClient>;
+
+// ---------------------------------------------------------------------------
+// LX-E2 — Capstone credential funnel observability (#725)
+// ---------------------------------------------------------------------------
+//
+// The capstone credential is withheld until `/api/deploy/save` writes a
+// verified `deployed_programs` row for the capstone deploy lesson (see
+// capstone-gate.ts). That design is fail-closed on purpose, but it makes ONE
+// failure mode invisible: if the save path is broken, no row is ever written,
+// the gate returns `deploy_required`, the webhook defers the certificate onto
+// the retry queue — and "gate correctly withholding an unearned credential"
+// looks IDENTICAL to "write path silently broken". Nobody alerts on the
+// absence of a row.
+//
+// This funnel makes that difference legible at a glance. It counts, for the
+// capstone course only, the three stages a learner passes through:
+//
+//   completions  learners who finished the capstone DEPLOY lesson
+//                (user_progress.completed) — they reached the deploy step
+//   deploys      verified `deployed_programs` rows for that same lesson
+//                — the artifact the credential attests
+//   deferrals    unresolved `certificate` retry-queue rows parked by the
+//                capstone gate (last_error `capstone-gate-…`) — credentials
+//                withheld pending a deploy row
+//   certificates issued capstone credentials (terminal success)
+//
+// The tell: `completions > 0 AND deploys === 0 AND deferrals > 0` means
+// learners finished the deploy lesson, no verified deploy landed, and
+// credentials are piling up unissued — the write path is broken, not merely
+// idle. `verdict` encodes exactly that so a human (or an alert) doesn't have
+// to eyeball four numbers.
+
+export type CapstoneFunnelVerdict =
+  // No learner has reached the deploy lesson yet — nothing to conclude.
+  | "idle"
+  // Deploy rows are landing (deploys > 0) — the write path demonstrably works.
+  | "healthy"
+  // Learners completed the deploy lesson and credentials are deferred, yet no
+  // deploy row exists: the write path is the prime suspect.
+  | "write_path_suspect"
+  // Completions without deploys, but nothing is deferred yet — worth watching,
+  // not yet alarming (a learner mid-flow, or completion-without-deploy).
+  | "watch"
+  // A count read failed — cannot judge; treated as non-healthy by callers.
+  | "unavailable";
+
+export interface CapstoneFunnel {
+  courseId: string;
+  deployLessonId: string;
+  /** Learners who completed the capstone deploy lesson (user_progress). */
+  completions: number;
+  /** Verified deploy rows for the capstone deploy lesson. */
+  deploys: number;
+  /** Unresolved certificate retry-queue rows parked by the capstone gate. */
+  deferrals: number;
+  /** Capstone credentials actually issued. */
+  certificates: number;
+  verdict: CapstoneFunnelVerdict;
+}
+
+/** Read the exact count off a head+count response, or `null` if it errored. */
+function countOrNull(response: {
+  count: number | null;
+  error: unknown;
+}): number | null {
+  return response.error ? null : (response.count ?? 0);
+}
+
+function decideVerdict(
+  completions: number,
+  deploys: number,
+  deferrals: number
+): CapstoneFunnelVerdict {
+  if (deploys > 0) return "healthy";
+  if (completions === 0) return "idle";
+  // completions > 0, deploys === 0
+  return deferrals > 0 ? "write_path_suspect" : "watch";
+}
+
+/**
+ * Read the capstone credential funnel counters via the service-role client.
+ * Aggregate counts only (head+count, no rows transferred, no PII). A single
+ * failed read collapses `verdict` to `"unavailable"` rather than reporting a
+ * misleading "healthy".
+ */
+export async function getCapstoneFunnel(
+  adminClient: AdminClient
+): Promise<CapstoneFunnel> {
+  const { courseId, deployLessonId } = CAPSTONE_CREDENTIAL;
+
+  const [completionsRes, deploysRes, deferralsRes, certificatesRes] =
+    await Promise.all([
+      adminClient
+        .from("user_progress")
+        .select("id", { count: "exact", head: true })
+        .eq("course_id", courseId)
+        .eq("lesson_id", deployLessonId)
+        .eq("completed", true),
+      adminClient
+        .from("deployed_programs")
+        .select("id", { count: "exact", head: true })
+        .eq("course_id", courseId)
+        .eq("lesson_id", deployLessonId),
+      adminClient
+        .from("pending_onchain_actions")
+        .select("id", { count: "exact", head: true })
+        .eq("action_type", "certificate")
+        .is("resolved_at", null)
+        .like("last_error", `capstone-gate-%:${courseId}`),
+      adminClient
+        .from("certificates")
+        .select("id", { count: "exact", head: true })
+        .eq("course_id", courseId),
+    ]);
+
+  const completions = countOrNull(completionsRes);
+  const deploys = countOrNull(deploysRes);
+  const deferrals = countOrNull(deferralsRes);
+  const certificates = countOrNull(certificatesRes);
+
+  const anyUnavailable =
+    completions === null ||
+    deploys === null ||
+    deferrals === null ||
+    certificates === null;
+
+  return {
+    courseId,
+    deployLessonId,
+    completions: completions ?? 0,
+    deploys: deploys ?? 0,
+    deferrals: deferrals ?? 0,
+    certificates: certificates ?? 0,
+    verdict: anyUnavailable
+      ? "unavailable"
+      : decideVerdict(completions, deploys, deferrals),
+  };
+}

--- a/apps/web/src/lib/logging.ts
+++ b/apps/web/src/lib/logging.ts
@@ -7,3 +7,36 @@ interface LogErrorParams {
 export function logError({ errorId, error, context }: LogErrorParams): void {
   console.error(`[${errorId}]`, error.message, context ?? "");
 }
+
+type LogLevel = "info" | "warn" | "error";
+
+interface LogEventParams {
+  /** Stable, greppable event name, e.g. `deploy-save.rejected`. */
+  event: string;
+  /** Console severity. Defaults to `warn`. */
+  level?: LogLevel;
+  /** Structured, JSON-serializable fields. No secrets/PII beyond ids. */
+  context?: Record<string, unknown>;
+}
+
+/**
+ * Structured event log for paths that must be observable but are not errors —
+ * denials, fail-closed rejections, and notable successes. The point is that
+ * silence is a bug: a broken write path (e.g. `/api/deploy/save`, #725) whose
+ * every rejection returns a generic message is otherwise indistinguishable
+ * from correct behaviour in the logs. Emits a single greppable
+ * `[event] {…context}` line at the given level.
+ */
+export function logEvent({
+  event,
+  level = "warn",
+  context,
+}: LogEventParams): void {
+  const sink =
+    level === "error"
+      ? console.error
+      : level === "info"
+        ? console.info
+        : console.warn;
+  sink(`[${event}]`, context ?? "");
+}


### PR DESCRIPTION
Closes part of #725.

## The indistinguishability problem
`deployed_programs` has **0 rows in production, ever**, so `/api/deploy/save` — the on-chain-verified path that writes them — has no successful prod run behind it. #721 now makes the capstone credential depend on exactly that row. The failure mode is silent and identical to correct behaviour:

- Broken save path → no row → `checkCapstoneCredentialGate` returns `deploy_required`.
- The webhook (`tryIssueCredential`) defers the certificate onto the retry queue rather than erroring.
- Result: learner completes the capstone, never gets a credential, and the system *looks like* a working gate withholding an unearned one.

Fail-closed is the right design (a credential is a permanent on-chain attestation), but it means the only signal of a broken write path is the **absence** of something — which nobody alerts on. This PR makes that absence loud, and adds the tests the issue asks for.

**Scope note:** #725 also calls for one real end-to-end devnet deploy producing a row. That requires on-chain transactions + live DB and is out of scope here (a separate ops step during the #606 window); this PR is the observability + test half so that when that run happens — or fails — it is unambiguous.

## What is now observable
- **`GET /api/admin/capstone-funnel`** (new, admin-authed, service-role aggregate reads only, no PII): counts the four funnel stages for the capstone course — deploy-lesson **completions** vs verified **deploys** (`deployed_programs`) vs **deferrals** (unresolved `certificate` queue rows parked by the capstone gate) vs issued **certificates** — plus a `verdict`. `completions > 0 AND deploys = 0 AND deferrals > 0` ⇒ `write_path_suspect` (write path broken, not merely idle). A failed read ⇒ `unavailable`, never a misleading `healthy`. On `write_path_suspect` it also emits an error-level structured log, so the signal reaches log-based alerting, not only whoever opens the route.
- **Structured logging in `/api/deploy/save` on every deny/exception/success path.** Previously the outer `catch {}` swallowed *all* unexpected throws into a silent generic 500, and the RPC-unreachable 503 was silent too — precisely the invisible failures #725 is about. Now: `deploy-save.rejected` (with the on-chain reason, still generic to the client per #560), `deploy-save.rpc-unavailable`, `deploy-save.write-failed`, `deploy-save.unhandled`, and `deploy-save.saved` (info) so the first real prod success is visible.

## Bug found in the save path
No functional bug in verification/write logic — the #620 verification is sound. The concrete defect fixed is the **silent `catch {}`**: any unexpected throw returned a generic 500 with zero logging, making a broken save indistinguishable from a working one in the logs. That is the failure mode #725 describes, so it is fixed with a test that forces a throw and asserts the `deploy-save.unhandled` log.

## Test evidence
- New `capstone-funnel.test.ts` (unit): per-table count scoping (asserts the exact eq/is/like filters) + every `verdict` transition + `unavailable` on read error.
- New admin route test: 401 without admin auth, returns counters, alert log only on `write_path_suspect`.
- Extended `deploy/save` route test: asserts the structured log on success + each deny/exception path, and a test pinning that a save stamps **exactly the (user_id, course_id, lesson_id) keys `checkCapstoneCredentialGate` reads** — using the real `CAPSTONE_CREDENTIAL` constants, so a content rename that moves the gate breaks this test too.

```
pnpm install --frozen-lockfile   # ok (frozen)
pnpm typecheck                   # 6 packages, all successful
pnpm --filter web test           # 202 files, 1821 tests passed
```

SENSITIVE (credentials-adjacent): do not merge without adversarial + gate review. Head: e6b6d7b8909703f2636dac9291b20b25c7bbb5e3
