### PR TITLE
revert: content.lock bump to 7a49747 — #740 remaps on-chain bitmap indices (#741)

### DIFF
--- a/apps/web/content.lock
+++ b/apps/web/content.lock
@@ -1,4 +1,4 @@
 {
   "repo": "solanabr/courses-academy",
-  "sha": "7a497475e14f3f53e5353cd752476eb0b2120096"
+  "sha": "1b74e4a60f8813374219451b60436af832df2d91"
 }

--- a/apps/web/src/content/generated/courses.json
+++ b/apps/web/src/content/generated/courses.json
@@ -133,7 +133,7 @@
     "_type": "course",
     "creator": "B7o8NfV81HzjuZFWQTTx3Xdvh77Dqoajwib3kWEnvzJF",
     "creatorRewardXp": 30,
-    "description": "You arrive holding `vault_core.rs` — a `VaultState` and checked `deposit`/`withdraw` that compile, with no `#[program]` and no `#[derive(Accounts)]`. This course adds exactly that. You wrap your own Rust core in Anchor 1.x, create a per-user vault PDA with the space arithmetic derived rather than copied, and move real lamports: deposit through a System Program CPI, withdraw by debiting the program-owned vault directly above an enforced rent floor — and you learn why signer seeds are not the answer there. Then you write the account constraints that stop three named attacks, read the LiteSVM test that would catch what compiling cannot, deploy from a browser tab, publish the IDL on-chain, and call your own live program. Nothing is installed locally. You finish with a devnet program id, a fetchable IDL, and a build write-up.",
+    "description": "Take your Anchor knowledge from theory to practice. Write, compile, and deploy real Solana programs using the Superteam Academy Build Server — no local toolchain setup required. By the end, you'll have a working counter program deployed to Devnet.",
     "difficulty": "intermediate",
     "duration": 12,
     "minCompletionsForReward": 10,
@@ -141,12 +141,24 @@
       {
         "_key": "bfsp-build-pipeline",
         "_type": "courseModule",
-        "description": "Wrap your own C2 vault core in Anchor, name the four parts of every Anchor program, and extend it yourself — a green build from a browser tab.",
+        "description": "Understand how Solana programs get compiled and get your first successful build through the Superteam Academy Build Server.",
         "key": "bfsp-build-pipeline",
         "lessons": [
           {
+            "_key": "lesson-bfsp-from-code-to-chain",
+            "_ref": "lesson-bfsp-from-code-to-chain",
+            "_type": "reference",
+            "_weak": true
+          },
+          {
             "_key": "lesson-bfsp-your-first-build",
             "_ref": "lesson-bfsp-your-first-build",
+            "_type": "reference",
+            "_weak": true
+          },
+          {
+            "_key": "lesson-bfsp-anatomy-anchor-program",
+            "_ref": "lesson-bfsp-anatomy-anchor-program",
             "_type": "reference",
             "_weak": true
           },
@@ -155,31 +167,19 @@
             "_ref": "lesson-bfsp-add-instruction",
             "_type": "reference",
             "_weak": true
-          },
-          {
-            "_key": "lesson-bfsp-adding-instructions",
-            "_ref": "lesson-bfsp-adding-instructions",
-            "_type": "reference",
-            "_weak": true
           }
         ],
         "title": "The Build Pipeline"
       },
       {
-        "_key": "bfsp-state-vault-pda",
+        "_key": "bfsp-state-accounts",
         "_type": "courseModule",
-        "description": "Derive the byte size of the vault account, derive its address from seeds, store the canonical bump, and wire up initialize by reading a real compile error.",
-        "key": "bfsp-state-vault-pda",
+        "description": "Define on-chain state with account structs, learn account constraints, and debug compiler errors.",
+        "key": "bfsp-state-accounts",
         "lessons": [
           {
             "_key": "lesson-bfsp-on-chain-state",
             "_ref": "lesson-bfsp-on-chain-state",
-            "_type": "reference",
-            "_weak": true
-          },
-          {
-            "_key": "lesson-bfsp-pdas-vault",
-            "_ref": "lesson-bfsp-pdas-vault",
             "_type": "reference",
             "_weak": true
           },
@@ -190,23 +190,29 @@
             "_weak": true
           },
           {
+            "_key": "lesson-bfsp-account-constraints",
+            "_ref": "lesson-bfsp-account-constraints",
+            "_type": "reference",
+            "_weak": true
+          },
+          {
             "_key": "lesson-bfsp-wire-up-initialize",
             "_ref": "lesson-bfsp-wire-up-initialize",
             "_type": "reference",
             "_weak": true
           }
         ],
-        "title": "State and the Vault PDA"
+        "title": "State & Accounts"
       },
       {
-        "_key": "bfsp-deposit-withdraw-harden",
+        "_key": "bfsp-full-counter",
         "_type": "courseModule",
-        "description": "Move real lamports — deposit through a System Program CPI, withdraw by debiting the program-owned vault directly above a rent floor — find out why the PDA does not sign its own withdrawal, surface your checked arithmetic as typed Anchor errors, and write the constraints that stop the obvious attacks.",
-        "key": "bfsp-deposit-withdraw-harden",
+        "description": "Build the complete counter program with multiple instructions, error handling, and deploy it to Devnet.",
+        "key": "bfsp-full-counter",
         "lessons": [
           {
-            "_key": "lesson-bfsp-cpi-lamports",
-            "_ref": "lesson-bfsp-cpi-lamports",
+            "_key": "lesson-bfsp-adding-instructions",
+            "_ref": "lesson-bfsp-adding-instructions",
             "_type": "reference",
             "_weak": true
           },
@@ -223,26 +229,20 @@
             "_weak": true
           },
           {
-            "_key": "lesson-bfsp-account-constraints",
-            "_ref": "lesson-bfsp-account-constraints",
+            "_key": "lesson-bfsp-deploy-to-devnet",
+            "_ref": "lesson-bfsp-deploy-to-devnet",
             "_type": "reference",
             "_weak": true
           }
         ],
-        "title": "Deposit, Withdraw, Harden"
+        "title": "The Full Counter"
       },
       {
-        "_key": "bfsp-ship-it",
+        "_key": "bfsp-deploy-interact",
         "_type": "courseModule",
-        "description": "Prove the program behaves before you spend devnet SOL, fund the deploy wallet, deploy from the browser, publish the IDL on-chain, and write up what you built.",
-        "key": "bfsp-ship-it",
+        "description": "Deploy your counter program to Solana Devnet and interact with it on-chain. Fund your wallet, deploy your binary, and call your program's instructions.",
+        "key": "bfsp-deploy-interact",
         "lessons": [
-          {
-            "_key": "lesson-bfsp-pre-flight-check",
-            "_ref": "lesson-bfsp-pre-flight-check",
-            "_type": "reference",
-            "_weak": true
-          },
           {
             "_key": "lesson-bfsp-m4-airdrop",
             "_ref": "lesson-bfsp-m4-airdrop",
@@ -256,13 +256,19 @@
             "_weak": true
           },
           {
+            "_key": "lesson-bfsp-m4-interact",
+            "_ref": "lesson-bfsp-m4-interact",
+            "_type": "reference",
+            "_weak": true
+          },
+          {
             "_key": "lesson-bfsp-m4-capstone",
             "_ref": "lesson-bfsp-m4-capstone",
             "_type": "reference",
             "_weak": true
           }
         ],
-        "title": "Ship It"
+        "title": "Deploy & Interact"
       }
     ],
     "slug": {
@@ -272,26 +278,14 @@
     "tags": [
       "account-model",
       "anchor",
-      "checked-arithmetic",
-      "cpi",
-      "debugging",
-      "idl",
       "keypairs-wallets",
-      "pdas",
-      "program-build",
       "program-deployment",
-      "program-errors",
-      "program-security",
-      "program-testing",
-      "rent-and-space",
-      "solana-explorer",
       "solana-programs",
-      "technical-writing",
       "transactions"
     ],
     "title": "Building Your First Solana Program",
     "trackId": 1,
-    "trackLevel": 3,
+    "trackLevel": 2,
     "xpPerLesson": 20,
     "xpReward": 850
   },

--- a/apps/web/src/content/generated/lessons.json
+++ b/apps/web/src/content/generated/lessons.json
@@ -539,141 +539,74 @@
       {
         "_key": "intro",
         "_type": "prose",
-        "src": "# Harden the Vault\n\n> **Version stamp — checked 2026-07-26.** `anchor-lang 1.1.2` and `anchor-lang-error 1.1.2` (published 2026-06-26) · `cargo-build-sbf` with platform-tools v1.54 (rustc 1.89) · edition 2021. Every error code and message below was read out of `anchor-lang-error 1.1.2`'s enum; every compiler and macro error was produced by compiling this lesson's file. Every line of example code here is ours.\n\nYour vault works. Now assume the caller is hostile.\n\nEvery account your instruction touches arrived in the transaction because somebody put it there, and that somebody is not always you. `Deposit` and `Withdraw` are safe not because you wrote careful handler bodies but because of four or five words inside `#[account(...)]`. This lesson is about what those words do, which attack each one stops, and the one thing Anchor 1.0 changed underneath them.\n\n## Constraints run before your code does\n\n`#[derive(Accounts)]` is not documentation. It expands into a function that runs before your handler body and returns `Err` if anything fails to check out. By the time your first statement executes, every constraint has passed.\n\nThat is why validation belongs in the attribute rather than the body: an attribute cannot be forgotten halfway down a function, and it applies on every code path including the ones you did not think about.\n\n## The constraints you have used, and what each one refuses\n\n**`init, payer = user, space = N`** — allocates the account, moves the rent-exempt deposit from the payer, assigns the account to your program, and writes the 8-byte discriminator. Used exactly once per account, in `initialize_vault`.\n\n**`mut`** — required of any account whose data or lamports change. Anchor checks it at runtime and returns error **2000, \"A mut constraint was violated\"** if the account was not marked writable in the transaction. Note that this is a runtime failure, not a compile error: a struct missing `mut` compiles perfectly and fails on the first real call.\n\n**`Signer<'info>`** — the account signed the transaction. It says nothing about mutability, which is why a payer needs both `Signer` and `#[account(mut)]`.\n\n**`seeds = [...]` + `bump`** — re-derives the address and compares it to the account passed in. Mismatch is error **2006, \"A seeds constraint was violated\"**. This is the single most load-bearing constraint in your program, and the next section is about why.\n\n**`Account<'info, T>`** — not a constraint but a type, and it validates three things on deserialisation: the account is owned by your program (**3007**), the first eight bytes match `T`'s discriminator (**3002, \"Account discriminator did not match what was expected\"**), and the account has actually been initialised (**3012**). Compare with `UncheckedAccount<'info>`, which validates *nothing*. Convention — and the Anchor CLI — asks you to write a `/// CHECK:` comment above one, documenting why skipping validation is safe here. Be precise about who enforces that: it is a **lint in the Anchor CLI's IDL build**, not a `cargo-build-sbf` error. Our build server shells `cargo-build-sbf` and nothing else, so on this platform the missing comment builds green. Write it anyway — the reviewer who reads your program is the one enforcing it, and on a real Anchor project `anchor build` will stop you.\n\n**`has_one = field`** — checks `account.field == field_account.key()`, where `field` must be both a field on the stored struct and an account in the same struct. Failure is error **2001**. Precision worth having: `has_one = owner` only works if there is an account *named* `owner` in the accounts struct. Ours is named `user`, so `Withdraw` uses the explicit form instead:\n\n```rust\nconstraint = vault.owner == user.key() @ VaultError::NotOwner\n```\n\nSame check, one extra line, and it returns your own error instead of Anchor's generic one — which is what finally spends the `owner` field and the `NotOwner` variant you have been carrying since Course 2.\n\n## Three attacks, and the words that stop them\n\n### Attack 1 — someone else's vault\n\nThe caller signs as themselves and passes *your* vault as the `vault` account. Nothing in the handler body would notice: it is a well-formed `VaultState` owned by the right program.\n\n`seeds = [b\"vault\", user.key().as_ref()]` + `bump = vault.bump` stops it. The address is recomputed from the signer's key, so the only account that can satisfy the constraint is that signer's own vault. `constraint = vault.owner == user.key()` is a second, independent check on the same question — belt and braces, because the two would only disagree if something else had already gone badly wrong, and finding out cheaply is worth one comparison.\n\n### Attack 2 — an account that is not a vault\n\nThe caller passes an account of a different type, or one that has never been initialised, hoping your program interprets whatever bytes are there as `owner`, `balance` and `bump`.\n\n`Account<'info, VaultState>` stops it, in the type system rather than in your logic. The 8-byte discriminator that `#[account]` writes at creation is checked on every deserialisation, so an account of the wrong type fails with 3002 and an empty one with 3012. Reach for `UncheckedAccount` instead and you have opted out of all three checks — which is occasionally right, and is why the `/// CHECK:` comment exists to make you say so out loud.\n\n### Attack 3 — the same account passed twice\n\nThis is the interesting one, and the one Anchor 1.0 changed.\n\nSuppose an instruction moves balance from one vault to another and takes both as mutable accounts. Now suppose the caller passes the *same* account as both. Your handler does:\n\n```rust\nctx.accounts.from_vault.withdraw(amount)?;\nctx.accounts.to_vault.deposit(amount)?;\n```\n\nAnchor deserialised the account twice, into two independent copies. The first line subtracts from copy A. The second line adds to copy B — which never saw the subtraction. At the end of the instruction both copies are serialised back to the same account, and whichever writes last wins. The caller has minted `amount` out of nothing, and every individual line of your code was correct.\n\n**In Anchor 1.0 this is refused by default.** Two mutable accounts resolving to the same key produce error **2040, \"A duplicate mutable account constraint was violated\"** before your handler runs. If you genuinely want aliasing — and there are instructions where it is harmless — you opt in per account:\n\n```rust\n#[account(mut, dup)]\n```\n\nTwo cautions.\n\nThe syntax is `dup`. You will find `#[account(mut, unsafe(dup))]` written down; that is the v2 alpha (the `no_std` Pinocchio line), and on the toolchain that grades you it fails at macro-parse time with `error: expected =`. Verified.\n\nAnd the default is protection, not a suggestion. Adding `dup` because an error appeared is how you reintroduce the bug the error was reporting. The right question is never \"how do I silence 2040\" but \"is aliasing safe in this specific instruction\" — and for anything that moves value between two accounts, the answer is no.\n\n## The wider list\n\nAliasing, missing signer checks, missing owner checks, type confusion, arithmetic overflow, unchecked account closing, PDA seed collisions: these are *classes*, and the classes are stable even as the framework changes. Helius maintains a good public write-up of nineteen of them, and it makes a fine review checklist to read against your own program. Read it as a list of questions to ask, not as code to copy — the widely-circulated example repositories for these attacks ship with no licence at all, so every line of example code in this course is written by us.\n\n## The exercise\n\nIndependent write. You get the signature of a new instruction and a written spec — no more. The three instructions you already wrote are still in the file above it, and `Withdraw`'s constraint block in particular is close to what `from_vault` needs; reading your own earlier work and adapting it is the intended move, not cheating. What no one gives you is which constraints this instruction needs, in what combination, and what `to_vault` must derive from.\n\nBe clear-eyed about what the grading can see. The verification harness pins the field names and types, so **attack (b) is genuinely compile-enforced**: get `Account<'info, VaultState>` wrong and the build fails. The seeds, the ownership constraint and the `dup` decision are runtime behaviour, and a compile-only grader is blind to all three. Module 4 shows you the LiteSVM test that would exercise them, and why compiling cannot — read it before you spend a lamport of devnet SOL.\n"
-      },
-      {
-        "_key": "exercise",
-        "_type": "code",
-        "buildType": "buildable",
-        "deployable": false,
-        "hints": [
-          "The harness at the bottom is the acceptance criteria, written in Rust. Read it before you type: it names every field, its type and its position, and it is the only part of the spec the build server can check. The first build reports `error[E0412]: cannot find type TransferBetweenVaults` and `error[E0425]: cannot find value transfer_between_vaults` — nothing exists yet.",
-          "Work threat by threat rather than field by field. Attack (a) is answered by re-deriving `from_vault` from the SIGNER's key and asking a second time against the stored `owner` — `constraint = from_vault.owner == user.key() @ VaultError::NotOwner`, because `has_one = owner` would need an account literally named `owner`. Attack (b) is answered by the field types alone. Attack (c) needs you to add nothing at all.",
-          "If you have reached for `dup`, stop and reason about what error 2040 is telling you. Both vaults are `mut`, so when `recipient` is the signer the two slots are one account, Anchor refuses the instruction, and that refusal is correct: two deserialised copies, one subtraction, one addition, last write wins, and the caller has minted lamports. `dup` is for aliasing you have proven harmless; this is not that."
-        ],
-        "language": "rust",
-        "solution": "use anchor_lang::prelude::*;\nuse anchor_lang::system_program::{transfer, Transfer};\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n// ─── Your Course 2 core, imported unchanged. Do not edit it. ─────────────────\npub mod vault {\n    use super::*;\n\n    #[account]\n    #[derive(InitSpace)]\n    pub struct VaultState {\n        pub owner: Pubkey,\n        pub balance: u64,\n        pub bump: u8,\n    }\n\n    #[error_code]\n    pub enum VaultError {\n        #[msg(\"Deposit would overflow the vault balance\")]\n        Overflow,\n        #[msg(\"Withdrawal is larger than the vault balance\")]\n        InsufficientFunds,\n        #[msg(\"Amount must be greater than zero\")]\n        ZeroAmount,\n        #[msg(\"Signer is not the vault owner\")]\n        NotOwner,\n    }\n\n    impl VaultState {\n        pub fn deposit(&mut self, amount: u64) -> Result<()> {\n            require!(amount > 0, VaultError::ZeroAmount);\n            self.balance = self\n                .balance\n                .checked_add(amount)\n                .ok_or(VaultError::Overflow)?;\n            Ok(())\n        }\n\n        pub fn withdraw(&mut self, amount: u64) -> Result<()> {\n            require!(amount > 0, VaultError::ZeroAmount);\n            self.balance = self\n                .balance\n                .checked_sub(amount)\n                .ok_or(VaultError::InsufficientFunds)?;\n            Ok(())\n        }\n    }\n}\n\npub use vault::{VaultError, VaultState};\n\n#[program]\npub mod vault_program {\n    use super::*;\n\n    pub fn initialize_vault(ctx: Context<InitializeVault>) -> Result<()> {\n        let vault = &mut ctx.accounts.vault;\n        vault.owner = ctx.accounts.user.key();\n        vault.balance = 0;\n        vault.bump = ctx.bumps.vault;\n        Ok(())\n    }\n\n    pub fn deposit(ctx: Context<Deposit>, amount: u64) -> Result<()> {\n        transfer(\n            CpiContext::new(\n                System::id(),\n                Transfer {\n                    from: ctx.accounts.user.to_account_info(),\n                    to: ctx.accounts.vault.to_account_info(),\n                },\n            ),\n            amount,\n        )?;\n        ctx.accounts.vault.deposit(amount)?;\n        Ok(())\n    }\n\n    pub fn withdraw(ctx: Context<Withdraw>, amount: u64) -> Result<()> {\n        let vault_info = ctx.accounts.vault.to_account_info();\n        let user_info = ctx.accounts.user.to_account_info();\n\n        // Finished in the previous lesson. Bookkeeping via the Course 2 method,\n        // then a rent-floor check, then a direct debit — no CPI, because a\n        // program may move the lamports of an account it owns.\n        ctx.accounts.vault.withdraw(amount)?;\n\n        let rent_floor = Rent::get()?.minimum_balance(vault_info.data_len());\n        let remaining = vault_info\n            .lamports()\n            .checked_sub(amount)\n            .ok_or(VaultError::InsufficientFunds)?;\n        require!(remaining >= rent_floor, VaultError::InsufficientFunds);\n\n        let credited = user_info\n            .lamports()\n            .checked_add(amount)\n            .ok_or(VaultError::Overflow)?;\n        **vault_info.try_borrow_mut_lamports()? = remaining;\n        **user_info.try_borrow_mut_lamports()? = credited;\n\n        Ok(())\n    }\n\n    pub fn transfer_between_vaults(\n        ctx: Context<TransferBetweenVaults>,\n        amount: u64,\n    ) -> Result<()> {\n        // Debit first. If the signer's vault cannot cover `amount`, the Course 2\n        // method returns `InsufficientFunds` and nothing is credited.\n        ctx.accounts.from_vault.withdraw(amount)?;\n        ctx.accounts.to_vault.deposit(amount)?;\n        Ok(())\n    }\n}\n\n#[derive(Accounts)]\npub struct InitializeVault<'info> {\n    #[account(\n        init,\n        payer = user,\n        space = 8 + 32 + 8 + 1,\n        seeds = [b\"vault\", user.key().as_ref()],\n        bump\n    )]\n    pub vault: Account<'info, VaultState>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n    pub system_program: Program<'info, System>,\n}\n\n#[derive(Accounts)]\npub struct Deposit<'info> {\n    #[account(\n        mut,\n        seeds = [b\"vault\", user.key().as_ref()],\n        bump = vault.bump\n    )]\n    pub vault: Account<'info, VaultState>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n    pub system_program: Program<'info, System>,\n}\n\n// Finished in the previous lesson. No `system_program`: no CPI is made here.\n#[derive(Accounts)]\npub struct Withdraw<'info> {\n    #[account(\n        mut,\n        seeds = [b\"vault\", user.key().as_ref()],\n        bump = vault.bump,\n        constraint = vault.owner == user.key() @ VaultError::NotOwner\n    )]\n    pub vault: Account<'info, VaultState>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n}\n\n// Attack (a): `seeds` re-derives the address from the SIGNER's key, so the only\n// account that can satisfy it is the signer's own vault, and the explicit\n// `constraint` re-asks the same question against the stored `owner` field —\n// returning our error rather than Anchor's generic 2001/2006.\n//\n// Attack (b): `Account<'info, VaultState>` checks program ownership, the 8-byte\n// discriminator and initialisation on every deserialisation.\n//\n// Attack (c): no `dup`. Both vaults are mutable, so if `recipient` is the signer\n// the two slots resolve to one key and Anchor 1.0 refuses the instruction with\n// error 2040 before the body runs. Adding `dup` here would re-open exactly the\n// double-count bug 2040 is reporting: two copies of one account, one\n// subtraction, one addition, last write wins.\n#[derive(Accounts)]\npub struct TransferBetweenVaults<'info> {\n    #[account(\n        mut,\n        seeds = [b\"vault\", user.key().as_ref()],\n        bump = from_vault.bump,\n        constraint = from_vault.owner == user.key() @ VaultError::NotOwner\n    )]\n    pub from_vault: Account<'info, VaultState>,\n\n    #[account(\n        mut,\n        seeds = [b\"vault\", recipient.key().as_ref()],\n        bump = to_vault.bump\n    )]\n    pub to_vault: Account<'info, VaultState>,\n\n    pub user: Signer<'info>,\n\n    /// CHECK: read only as a PDA seed. Never written, never deserialised, and\n    /// never trusted for authorisation — `user` is the only signer here.\n    pub recipient: UncheckedAccount<'info>,\n}\n\n// ─────────────────────────────────────────────────────────────────────────────\n// VERIFICATION HARNESS — DO NOT EDIT ANYTHING BELOW THIS LINE.\n//\n// This is the acceptance criteria in Rust. It compiles only if the instruction\n// and the accounts struct exist with the names, order and types the spec gives.\n// A missing item is `error[E0433]` or `error[E0412]`; a missing field is\n// `error[E0609]`; a wrong type is `error[E0308]`.\n//\n// It is a TYPE check. It proves attack (b) is handled — `Account<'info, VaultState>`\n// carries the owner, discriminator and initialisation checks, and an\n// `UncheckedAccount` in either vault slot fails to compile here. It can see\n// nothing about attacks (a) or (c): seeds, the ownership constraint and the\n// duplicate-mutable-account default are all runtime behaviour. Confirmed ways to\n// be green and still be wrong: no `seeds`/`bump` at all, no owner constraint, a\n// bare `bump` instead of the stored one, `dup` added to silence error 2040, and\n// the two body calls in the wrong order.\n// ─────────────────────────────────────────────────────────────────────────────\n#[doc(hidden)]\n#[allow(dead_code)]\nmod verify {\n    use super::*;\n\n    const TRANSFER_BETWEEN: for<'info> fn(\n        Context<'info, TransferBetweenVaults<'info>>,\n        u64,\n    ) -> Result<()> = vault_program::transfer_between_vaults;\n\n    fn pin_accounts(a: &TransferBetweenVaults) {\n        // Both vault slots are typed accounts, not unchecked ones. This is the\n        // whole of attack (b), enforced by the compiler.\n        let _: &Account<VaultState> = &a.from_vault;\n        let _: &Account<VaultState> = &a.to_vault;\n        let _: &Signer = &a.user;\n        let _: &UncheckedAccount = &a.recipient;\n    }\n\n    // The earlier instructions are untouched and the Course 2 core still owns\n    // the arithmetic.\n    const DEPOSIT: for<'info> fn(Context<'info, Deposit<'info>>, u64) -> Result<()> =\n        vault_program::deposit;\n    const WITHDRAW: for<'info> fn(Context<'info, Withdraw<'info>>, u64) -> Result<()> =\n        vault_program::withdraw;\n    const CORE_DEPOSIT: fn(&mut VaultState, u64) -> Result<()> = VaultState::deposit;\n    const CORE_WITHDRAW: fn(&mut VaultState, u64) -> Result<()> = VaultState::withdraw;\n    const _: () = assert!(VaultState::INIT_SPACE == 41);\n}\n",
-        "starter": "// Independent write. Add ONE instruction and its accounts struct.\n//\n// SIGNATURES\n//\n//   pub fn transfer_between_vaults(\n//       ctx: Context<TransferBetweenVaults>,\n//       amount: u64,\n//   ) -> Result<()>\n//\n//   #[derive(Accounts)]\n//   pub struct TransferBetweenVaults<'info> {\n//       from_vault, to_vault, user, recipient      // in this order\n//   }\n//\n// WHAT IT DOES\n//\n//   Moves `amount` of recorded balance out of the signer's vault and into the\n//   vault belonging to `recipient`. Bookkeeping only — no lamports move, so\n//   there is no CPI and no `system_program`.\n//\n// ACCEPTANCE CRITERIA — criteria 3 and 4 name types, and types are the part the\n// harness at the bottom can check. The rest is on you; see the note below it.\n//\n//   1. `from_vault` is `Account<'info, VaultState>`, mutable, re-derived from\n//      the SIGNER's key using the bump stored on it, and constrained so the\n//      signer is its recorded owner. Return `VaultError::NotOwner` if not.\n//   2. `to_vault` is `Account<'info, VaultState>`, mutable, re-derived from\n//      `recipient`'s key using the bump stored on it.\n//   3. `user` is `Signer<'info>`.\n//   4. `recipient` is `UncheckedAccount<'info>`. It is read only as a seed and\n//      is never trusted for anything else. Put a `/// CHECK:` line above it\n//      saying exactly that. (The `/// CHECK:` requirement is an Anchor CLI\n//      lint, not a `cargo-build-sbf` error — this build will go green without\n//      it. Write it because the next human to read the program needs it.)\n//   5. The body is two calls into your Course 2 methods, in the order that\n//      makes an under-funded transfer fail before anything is credited.\n//   6. Decide, and be able to say why: does any account here need\n//      `#[account(mut, dup)]`? Work out what happens when `recipient` IS the\n//      signer, which error the runtime already returns for that, and whether\n//      `dup` would help you or disarm you. The harness is silent on this one\n//      either way — both choices compile.\n//\n// THREE ATTACKS THIS MUST STOP\n//\n//   (a) a caller passing somebody else's vault as `from_vault`\n//   (b) a caller passing an uninitialised account, or an account of another\n//       type, in either vault slot\n//   (c) a caller passing the same account as both vaults\n//\n// Only (b) is visible to a compiler — and only the *type* half of it. So is\n// criterion 4's `/// CHECK:` line: invisible. The build server compiles; it\n// does not run. Module 4 shows you the LiteSVM test that would exercise all\n// three attacks, and why compiling cannot.\n//\n// This file does NOT compile as shipped.\n\nuse anchor_lang::prelude::*;\nuse anchor_lang::system_program::{transfer, Transfer};\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n// ─── Your Course 2 core, imported unchanged. Do not edit it. ─────────────────\npub mod vault {\n    use super::*;\n\n    #[account]\n    #[derive(InitSpace)]\n    pub struct VaultState {\n        pub owner: Pubkey,\n        pub balance: u64,\n        pub bump: u8,\n    }\n\n    #[error_code]\n    pub enum VaultError {\n        #[msg(\"Deposit would overflow the vault balance\")]\n        Overflow,\n        #[msg(\"Withdrawal is larger than the vault balance\")]\n        InsufficientFunds,\n        #[msg(\"Amount must be greater than zero\")]\n        ZeroAmount,\n        #[msg(\"Signer is not the vault owner\")]\n        NotOwner,\n    }\n\n    impl VaultState {\n        pub fn deposit(&mut self, amount: u64) -> Result<()> {\n            require!(amount > 0, VaultError::ZeroAmount);\n            self.balance = self\n                .balance\n                .checked_add(amount)\n                .ok_or(VaultError::Overflow)?;\n            Ok(())\n        }\n\n        pub fn withdraw(&mut self, amount: u64) -> Result<()> {\n            require!(amount > 0, VaultError::ZeroAmount);\n            self.balance = self\n                .balance\n                .checked_sub(amount)\n                .ok_or(VaultError::InsufficientFunds)?;\n            Ok(())\n        }\n    }\n}\n\npub use vault::{VaultError, VaultState};\n\n#[program]\npub mod vault_program {\n    use super::*;\n\n    pub fn initialize_vault(ctx: Context<InitializeVault>) -> Result<()> {\n        let vault = &mut ctx.accounts.vault;\n        vault.owner = ctx.accounts.user.key();\n        vault.balance = 0;\n        vault.bump = ctx.bumps.vault;\n        Ok(())\n    }\n\n    pub fn deposit(ctx: Context<Deposit>, amount: u64) -> Result<()> {\n        transfer(\n            CpiContext::new(\n                System::id(),\n                Transfer {\n                    from: ctx.accounts.user.to_account_info(),\n                    to: ctx.accounts.vault.to_account_info(),\n                },\n            ),\n            amount,\n        )?;\n        ctx.accounts.vault.deposit(amount)?;\n        Ok(())\n    }\n\n    pub fn withdraw(ctx: Context<Withdraw>, amount: u64) -> Result<()> {\n        let vault_info = ctx.accounts.vault.to_account_info();\n        let user_info = ctx.accounts.user.to_account_info();\n\n        // Finished in the previous lesson. Bookkeeping via the Course 2 method,\n        // then a rent-floor check, then a direct debit — no CPI, because a\n        // program may move the lamports of an account it owns.\n        ctx.accounts.vault.withdraw(amount)?;\n\n        let rent_floor = Rent::get()?.minimum_balance(vault_info.data_len());\n        let remaining = vault_info\n            .lamports()\n            .checked_sub(amount)\n            .ok_or(VaultError::InsufficientFunds)?;\n        require!(remaining >= rent_floor, VaultError::InsufficientFunds);\n\n        let credited = user_info\n            .lamports()\n            .checked_add(amount)\n            .ok_or(VaultError::Overflow)?;\n        **vault_info.try_borrow_mut_lamports()? = remaining;\n        **user_info.try_borrow_mut_lamports()? = credited;\n\n        Ok(())\n    }\n\n    // YOUR INSTRUCTION GOES HERE. See ACCEPTANCE CRITERIA 5 at the top.\n}\n\n#[derive(Accounts)]\npub struct InitializeVault<'info> {\n    #[account(\n        init,\n        payer = user,\n        space = 8 + 32 + 8 + 1,\n        seeds = [b\"vault\", user.key().as_ref()],\n        bump\n    )]\n    pub vault: Account<'info, VaultState>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n    pub system_program: Program<'info, System>,\n}\n\n#[derive(Accounts)]\npub struct Deposit<'info> {\n    #[account(\n        mut,\n        seeds = [b\"vault\", user.key().as_ref()],\n        bump = vault.bump\n    )]\n    pub vault: Account<'info, VaultState>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n    pub system_program: Program<'info, System>,\n}\n\n// Finished in the previous lesson. No `system_program`: no CPI is made here.\n#[derive(Accounts)]\npub struct Withdraw<'info> {\n    #[account(\n        mut,\n        seeds = [b\"vault\", user.key().as_ref()],\n        bump = vault.bump,\n        constraint = vault.owner == user.key() @ VaultError::NotOwner\n    )]\n    pub vault: Account<'info, VaultState>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n}\n\n// YOUR STRUCT GOES HERE. Your instruction goes inside `#[program]`, above.\n\n// ─────────────────────────────────────────────────────────────────────────────\n// VERIFICATION HARNESS — DO NOT EDIT ANYTHING BELOW THIS LINE.\n//\n// This is the acceptance criteria in Rust. It compiles only if the instruction\n// and the accounts struct exist with the names, order and types the spec gives.\n// A missing item is `error[E0433]` or `error[E0412]`; a missing field is\n// `error[E0609]`; a wrong type is `error[E0308]`.\n//\n// It is a TYPE check. It proves attack (b) is handled — `Account<'info, VaultState>`\n// carries the owner, discriminator and initialisation checks, and an\n// `UncheckedAccount` in either vault slot fails to compile here. It can see\n// nothing about attacks (a) or (c): seeds, the ownership constraint and the\n// duplicate-mutable-account default are all runtime behaviour. Confirmed ways to\n// be green and still be wrong: no `seeds`/`bump` at all, no owner constraint, a\n// bare `bump` instead of the stored one, `dup` added to silence error 2040, and\n// the two body calls in the wrong order.\n// ─────────────────────────────────────────────────────────────────────────────\n#[doc(hidden)]\n#[allow(dead_code)]\nmod verify {\n    use super::*;\n\n    const TRANSFER_BETWEEN: for<'info> fn(\n        Context<'info, TransferBetweenVaults<'info>>,\n        u64,\n    ) -> Result<()> = vault_program::transfer_between_vaults;\n\n    fn pin_accounts(a: &TransferBetweenVaults) {\n        // Both vault slots are typed accounts, not unchecked ones. This is the\n        // whole of attack (b), enforced by the compiler.\n        let _: &Account<VaultState> = &a.from_vault;\n        let _: &Account<VaultState> = &a.to_vault;\n        let _: &Signer = &a.user;\n        let _: &UncheckedAccount = &a.recipient;\n    }\n\n    // The earlier instructions are untouched and the Course 2 core still owns\n    // the arithmetic.\n    const DEPOSIT: for<'info> fn(Context<'info, Deposit<'info>>, u64) -> Result<()> =\n        vault_program::deposit;\n    const WITHDRAW: for<'info> fn(Context<'info, Withdraw<'info>>, u64) -> Result<()> =\n        vault_program::withdraw;\n    const CORE_DEPOSIT: fn(&mut VaultState, u64) -> Result<()> = VaultState::deposit;\n    const CORE_WITHDRAW: fn(&mut VaultState, u64) -> Result<()> = VaultState::withdraw;\n    const _: () = assert!(VaultState::INIT_SPACE == 41);\n}\n",
-        "tests": [
-          {
-            "description": "The program compiles against the Anchor 1.x toolchain, with the verification harness intact",
-            "expectedOutput": "true",
-            "id": "compiles",
-            "input": ""
-          }
-        ]
+        "src": "# Account Constraints Deep Dive\n\nAnchor's account constraints are the guard rails of Solana development. They validate accounts before your instruction logic runs, preventing entire classes of bugs.\n\n## Essential Constraints\n\n### `#[account(init, payer = X, space = N)]`\nCreates a new account. The `payer` funds the rent-exempt deposit. `space` sets the data size in bytes. Can only be used once per account.\n\n### `#[account(mut)]`\nMarks an account as mutable. Required for any account whose data or lamport balance changes. Forgetting `mut` gives you:\n```\nerror: A mut constraint was expected but not found.\n```\n\n### `Signer<'info>`\nThe account must have signed the transaction. Used for authorization — proving the caller owns the account. Signers automatically have their signature verified by the runtime.\n\n### `Program<'info, System>`\nReferences a program account. `System` is the System Program (`11111111...`), which handles account creation and SOL transfers.\n\n## Account Types\n\n| Type | Use Case | Mutable Data? |\n|------|----------|---------------|\n| `Account<'info, T>` | Typed data account | Yes |\n| `Signer<'info>` | Must have signed tx | No data |\n| `SystemAccount<'info>` | Any system-owned account | No |\n| `Program<'info, T>` | A program account | No |\n| `UncheckedAccount<'info>` | No validation (dangerous) | Depends |\n\n## Common Errors\n\n### Missing `system_program`\nIf your instruction creates an account (`init`), you **must** include the System Program:\n```rust\npub system_program: Program<'info, System>,\n```\nWithout it, the compiler error is:\n```\nerror[E0277]: the trait bound `Initialize<'_>: anchor_lang::Accounts<'_>` is not satisfied\n```\n\nThis error is cryptic because Anchor generates the account validation code via macros. The fix is always: add the missing account.\n\n### Missing `mut` on payer\nThe payer's balance decreases (pays rent), so it must be `#[account(mut)]`:\n```rust\n#[account(mut)]\npub user: Signer<'info>,\n```\n\n### Wrong `space` calculation\nIf `space` is too small, the account can't hold your data. If too large, the payer overpays for rent. Always calculate: `8 (discriminator) + field sizes`.\n\n## In the Next Challenge\n\nYou'll encounter a deliberate compiler error — a program with a missing account. Your job is to read the error output and fix it.\n"
       },
       {
         "_key": "retrieval-close",
         "_type": "quiz",
         "questions": [
           {
-            "explanation": "Duplicate mutable accounts were a silent double-count for years and are now a default error, 2040. Opting back in is `#[account(mut, dup)]` — and note the syntax: `#[account(mut, unsafe(dup))]` belongs to the v2 alpha and fails at macro-parse time here with `error: expected =`. The decision is never \"how do I silence 2040\" but \"is aliasing safe in this instruction\", and for anything moving value between two accounts it is not.",
+            "explanation": "Constraints validate accounts before your logic runs. `init` with `payer = user` reduces the user's lamports, and any account whose lamports or data change must be `#[account(mut)]` — otherwise Anchor emits 'a mut constraint was expected but not found.'",
             "id": "q1",
             "multiSelect": false,
             "options": [
               {
                 "correct": true,
                 "id": "a",
-                "label": "Anchor returns error 2040, \"A duplicate mutable account constraint was violated\", before the handler runs. Without that default, the two deserialised copies would each miss the other's write and the caller would mint `amount` from nothing."
+                "label": "Compile error — the payer's lamports decrease to fund the rent, so it must be declared mutable"
               },
               {
                 "correct": false,
-                "feedback": "They are not the same in-memory account. Anchor deserialises each declared account independently, so you get two copies of the same bytes — which is precisely how the write of one can erase the write of the other.",
+                "feedback": "`Signer` proves the account signed; it says nothing about mutability. A payer's balance drops, so it needs `#[account(mut)]` on top.",
                 "id": "b",
-                "label": "Both field references point at the same in-memory account, so the subtraction and the addition cancel out and nothing happens."
+                "label": "It works, because `Signer` already implies mutable"
               },
               {
                 "correct": false,
-                "feedback": "Two mutable accounts of the same type is an ordinary, useful shape — any transfer instruction has it. The check is on the runtime *keys* being equal, which the compiler cannot know.",
+                "feedback": "Programs do not pay rent for you. The declared payer's lamports fund it, which is exactly why the payer must be `mut`.",
                 "id": "c",
-                "label": "It is a compile error, because two fields of the same type cannot both be `mut`."
-              },
-              {
-                "correct": false,
-                "feedback": "Transactions deduplicate account keys and pass the same index twice quite legally. The protection is Anchor's, in generated validation code, not the runtime's.",
-                "id": "d",
-                "label": "The transaction is rejected by the runtime before it reaches your program, because a transaction may not list an account twice."
+                "label": "It works, but the rent is silently paid by the program"
               }
             ],
-            "prompt": "An instruction takes two vaults, both `#[account(mut)]`, and a caller passes the same account for both. Predict the outcome under `anchor-lang` 1.1.2, and what the outcome would have been before Anchor 1.0 refused it."
+            "prompt": "You mark the payer account as `Signer<'info>` but forget `#[account(mut)]`. The instruction uses `init` to create a new account funded by that payer. What happens?"
           },
           {
-            "explanation": "`Account<'info, T>` is doing security work, not ergonomics work. Its deserialisation is where the discriminator that `#[account]` wrote at creation gets compared, and that comparison is the entire defence against type confusion. This is why the exercise's harness pins those two field types: it is the one attack of the three that a compile-only grader can genuinely enforce.",
+            "explanation": "New accounts are allocated by the System Program, so `init` expands into a `create_account` CPI that needs the System Program in the accounts struct. Leaving it out fails the `Accounts` trait bound at compile time — the fix is always to add the missing account.",
             "id": "q2",
             "multiSelect": false,
             "options": [
               {
                 "correct": true,
                 "id": "a",
-                "label": "The program-ownership check, the 8-byte discriminator check and the is-initialised check — errors 3007, 3002 and 3012 — all of which `Account<'info, T>` performs and `UncheckedAccount` performs none of."
+                "label": "Creating an account is a CPI to the System Program, so it must be present for Anchor's generated code to make that call"
               },
               {
                 "correct": false,
-                "feedback": "Seeds prove the *address*. They say nothing about who owns the account at that address, what type its bytes are, or whether it has ever been written to — a PDA that has never been initialised still has the derived address.",
+                "feedback": "Account creation itself is a System Program instruction. `init` generates a `create_account` CPI, so the System Program must be in the struct.",
                 "id": "b",
-                "label": "Nothing, as long as the seeds constraint still passes. The seeds prove the account is the right one."
+                "label": "It is only needed to transfer SOL, not to create accounts"
               },
               {
                 "correct": false,
-                "feedback": "`UncheckedAccount` can carry `mut` perfectly well. What it drops is every check that depends on knowing the account's owner and type.",
+                "feedback": "Anchor does not inject it — you must declare it. Omitting it produces a cryptic trait-bound error on the accounts struct.",
                 "id": "c",
-                "label": "Only the `mut` check, since `UncheckedAccount` cannot be marked mutable."
-              },
-              {
-                "correct": false,
-                "feedback": "The comment is a required acknowledgement, not a control. It exists to make you state in writing that you are opting out; it restores nothing.",
-                "id": "d",
-                "label": "Nothing at compile time, and nothing at runtime either — the `/// CHECK:` comment is what re-enables the validation."
+                "label": "It documents intent but Anchor injects it automatically"
               }
             ],
-            "prompt": "A submission types both vault slots as `UncheckedAccount<'info>` with `/// CHECK:` comments, keeps every `seeds` and `constraint`, and reads the balances by deserialising manually inside the handler. Predict what protection is lost."
-          },
-          {
-            "explanation": "`has_one = field` expands to `account.field == field_account.key()`, so the name has to exist twice — once on the stored struct and once as an account in the struct. The explicit `constraint` form is the general case, costs one line, and lets you attach your own error, which is why `VaultError::NotOwner` finally gets used four lessons after you wrote it.",
-            "id": "q3",
-            "multiSelect": false,
-            "options": [
-              {
-                "correct": true,
-                "id": "a",
-                "label": "`has_one = owner` requires an account *named* `owner` in the same accounts struct to compare against. Ours is named `user`, so the explicit comparison is the equivalent — and it returns our error instead of Anchor's 2001."
-              },
-              {
-                "correct": false,
-                "feedback": "`has_one` is current and idiomatic. The obstacle here is purely naming: it resolves the target as an account in the struct, and there is no `owner` account in `Withdraw`.",
-                "id": "b",
-                "label": "`has_one` was removed in Anchor 1.0 in favour of explicit constraints."
-              },
-              {
-                "correct": false,
-                "feedback": "It works on any account whose stored struct has the named field. Creation has nothing to do with it.",
-                "id": "c",
-                "label": "`has_one` only works on accounts created with `init` in the same instruction."
-              },
-              {
-                "correct": false,
-                "feedback": "`owner` is an ordinary field name on your struct and Anchor is happy with it. The account's program owner lives on the `AccountInfo`, not in your data.",
-                "id": "d",
-                "label": "Because `owner` is a reserved field name that Anchor uses for the account's program owner."
-              }
-            ],
-            "prompt": "`Withdraw` uses `constraint = vault.owner == user.key() @ VaultError::NotOwner` rather than `has_one = owner`. Why can it not use `has_one`?"
+            "prompt": "Why does an instruction that uses `#[account(init)]` also require `system_program: Program<'info, System>` in its accounts struct?"
           }
         ]
       }
     ],
     "skills": [
-      "account-model",
       "anchor",
-      "program-errors",
-      "program-security"
+      "account-model"
     ],
     "slug": {
       "_type": "slug",
-      "current": "harden-the-vault"
+      "current": "account-constraints-deep-dive"
     },
-    "title": "Harden the Vault"
+    "title": "Account Constraints Deep Dive"
   },
   {
     "_id": "lesson-bfsp-add-instruction",
@@ -682,7 +615,7 @@
       {
         "_key": "intro",
         "_type": "prose",
-        "src": "# Anatomy of an Anchor Program\n\n> **Version stamp — checked 2026-07-26.** `anchor-lang 1.1.2` (published 2026-06-26) · `cargo-build-sbf` with platform-tools v1.54 (rustc 1.89) · `borsh` resolves to **1.8.0** · edition 2021. Every compiler message quoted below was produced by compiling this lesson's starter on that toolchain.\n\nThe file you just compiled has four parts. Every Anchor program has the same four, conventionally in the same order, and once you can name them you can read any program on Solana — including the ones you did not write, which is most of the value.\n\nThe starter below is that program stripped to exactly those four parts, each behind a labeled banner. Two of them are complete. Two contain one worked example each, and your job is the second example in both.\n\n## Part 1 — `declare_id!`: the address\n\n```rust\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n```\n\nA program is reached by address, the same way an account is. `declare_id!` bakes that address into the binary and generates a `pub const ID: Pubkey` you can use in code — the starter's `version` handler logs it.\n\nTwo things it is not. It is not a keypair: the program's *upgrade* authority is a separate key, held by whoever deployed. And it is not checked at compile time — put any valid base58 pubkey here and the build is green. The value only starts mattering at deploy, when a mismatch between the declared id and the address being deployed to produces `DeclaredProgramIdMismatch`. In module 4 you will replace this placeholder with an address that is genuinely yours.\n\n## Part 2 — `#[program]`: the instruction handlers\n\n```rust\n#[program]\npub mod vault_program {\n    use super::*;\n\n    pub fn version(_ctx: Context<Version>) -> Result<()> {\n        msg!(\"vault program, id {}\", ID);\n        Ok(())\n    }\n}\n```\n\nThis attribute is what makes the crate a program rather than a library. It expands the module into a program entrypoint plus a dispatcher, and it turns every `pub fn` inside into a callable instruction.\n\nThe dispatch is by **discriminator**: Anchor hashes the handler's name and puts the first 8 bytes at the front of the instruction data, so a caller selects `version` by sending those 8 bytes. Two consequences you should file away. Renaming a handler changes its discriminator, which breaks every client already calling it — a rename is a breaking API change, not a cosmetic one. And the same mechanism is why the four-part order is a convention rather than a requirement: the macros do not care where in the file they appear.\n\nThe signature rules are absolute:\n\n- the first parameter is always `Context<T>`;\n- the return type is always `Result<()>` — Anchor's `Result`, which `use anchor_lang::prelude::*;` brings in;\n- any further parameters are instruction *arguments*, deserialized from the instruction data. `deposit(ctx, amount: u64)` in module 3 is the first one you write.\n\n`msg!` writes to the transaction log, which is what you read in an explorer and what stands in for a debugger on-chain. It costs compute units, so it is a tool for development, not a place to dump state.\n\nOne currency note, because this is where old code bites: in Anchor 1.x the handler return type is `Result<()>`. Material written before 0.24 uses `ProgramResult`, which no longer exists — if you paste a handler signature from an older tutorial you get `cannot find type ProgramResult in this scope`, and that error means *the snippet is old*, not that you mistyped.\n\n## Part 3 — `#[derive(Accounts)]`: the account list\n\n```rust\n#[derive(Accounts)]\npub struct Version {}\n```\n\nSolana programs are stateless. Everything an instruction reads or writes arrives as an account in the transaction, and this struct is where you declare which ones and under what conditions. The derive generates the deserialization and every validation check, and it runs *before* your handler body — by the time you are inside `version`, the account list has already been proved to satisfy whatever the struct demanded.\n\nThe name must match the `Context<T>` generic exactly. That is the only thing tying a handler to its account list, which is why forgetting the struct produces `cannot find type Greet in this scope` rather than anything more helpful.\n\n`Version {}` is empty, and empty is a claim rather than an omission: it says this instruction may touch no accounts at all. Anything not declared here is unreachable from the handler. Module 2 is where these structs get interesting — constraints, PDAs, `init`, signers — and where the vault finally becomes an account instead of a struct.\n\n## Part 4 — `#[account]`: the state\n\n```rust\n#[account]\n#[derive(InitSpace)]\npub struct VaultState {\n    pub owner: Pubkey,\n    pub balance: u64,\n    pub bump: u8,\n}\n```\n\nYour Course 2 struct, unchanged. `#[account]` says \"this type is the contents of an account owned by this program\": it generates the borsh serialization and an 8-byte **discriminator** — a different one from the instruction discriminators, doing the same job one level down. It marks the account's *type*, so a program that is handed the wrong account gets a deserialization failure instead of misreading someone else's bytes.\n\nNote what part 4 does not do. It describes a layout; it does not allocate anything. No account exists because of this struct. Creating one takes an `init` constraint in a part-3 struct, a payer, and rent — module 2, in that order.\n\n### The fifth thing, which is not one of the four\n\nYour Course 2 file also has `#[error_code] pub enum VaultError`. It is not in this starter, because it is not part of the anatomy — but it is worth one line now: **a program should carry exactly one `#[error_code]` enum.** Note \"should\". Anchor does not stop you adding a second, and that is precisely why the habit is worth forming early — every `#[error_code]` enum starts numbering at the same offset, so a second one silently collides with the first instead of failing loudly. You already have yours. When a later lesson needs a new failure mode, it becomes a variant of `VaultError`, not a new enum. The next lesson shows you the collision itself, which is not what most people expect.\n\n## Your job\n\nAdd the second handler and the second account list, copying the pattern that is already in each part:\n\n1. `greet`, inside `#[program]`, taking `_ctx: Context<Greet>`, returning `Result<()>`, logging something.\n2. `Greet`, an empty struct carrying `#[derive(Accounts)]`.\n\nThe starter does not compile as shipped. Build it first and read the four errors. All four come from the verification harness at the bottom of the file, because the harness is the only thing that references what you have not written yet: three of them say `cannot find type Greet` or `cannot find struct … Greet`, and the fourth says `cannot find value greet in module vault_program`. That is the harness working as intended — it is the acceptance criteria written in Rust, and it is the only thing the build server can check.\n"
+        "src": "# Challenge: Add an Instruction\n\nTime to modify the program. Add a `greet` instruction that logs a greeting message.\n\n## Requirements\n\n1. Add a new function `greet` inside the `#[program]` module\n2. It should take `_ctx: Context<Greet>` as its parameter\n3. It should call `msg!(\"Hello, Solana!\")` and return `Ok(())`\n4. Add a corresponding `Greet` accounts struct (can be empty, like `Initialize`)\n\n## Tips\n\n- Follow the same pattern as the existing `initialize` function\n- The accounts struct name must match the `Context<T>` generic\n- Don't forget `#[derive(Accounts)]` on your new struct\n"
       },
       {
         "_key": "exercise",
@@ -690,30 +623,30 @@
         "buildType": "buildable",
         "deployable": false,
         "hints": [
-          "Build before you write anything. Four errors come back and all four are raised by the harness at the bottom, which is the only code referencing the two items you owe: three of them name `Greet` and one names `greet`.",
-          "The greet function follows the exact same pattern as version — just change the name and the log message. It goes inside the `#[program]` module under part 2, and its accounts struct goes under part 3, where `#[derive(Accounts)]` is not optional: without the derive the struct exists but `Context<Greet>` still fails, because the derive is what supplies the trait `Context` requires.",
-          "Both signatures in full. Inside `#[program]`: `pub fn greet(_ctx: Context<Greet>) -> Result<()>`, with a `msg!` and `Ok(())` in the body. At the top level, next to `Version`: `#[derive(Accounts)]` on the line above `pub struct Greet {}`."
+          "The greet function follows the exact same pattern as initialize — just change the name and the log message",
+          "Don't forget to add `#[derive(Accounts)]` before `pub struct Greet {}`",
+          "The full signature is: `pub fn greet(_ctx: Context<Greet>) -> Result<()>`"
         ],
         "language": "rust",
-        "solution": "// Anatomy of an Anchor program — the four parts, with the second handler and\n// its account list filled in.\n//\n// The `msg!` string is yours; nothing checks it. What is fixed is the pair of\n// names: the handler is `greet` and the accounts struct is `Greet`, because\n// `Context<Greet>` in the signature is what ties them together.\n\nuse anchor_lang::prelude::*;\n\n// ─────────────────────────────────────────────────────────────────────────────\n// PART 1 of 4 — `declare_id!`: the program's address.\n// ─────────────────────────────────────────────────────────────────────────────\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n// ─────────────────────────────────────────────────────────────────────────────\n// PART 2 of 4 — `#[program]`: the instruction handlers.\n// ─────────────────────────────────────────────────────────────────────────────\n#[program]\npub mod vault_program {\n    use super::*;\n\n    pub fn version(_ctx: Context<Version>) -> Result<()> {\n        msg!(\"vault program, id {}\", ID);\n        Ok(())\n    }\n\n    pub fn greet(_ctx: Context<Greet>) -> Result<()> {\n        msg!(\"Hello, Solana!\");\n        Ok(())\n    }\n}\n\n// ─────────────────────────────────────────────────────────────────────────────\n// PART 3 of 4 — `#[derive(Accounts)]`: one account list per handler.\n//\n// Both are empty because neither handler touches an account. Empty is a claim,\n// not an omission: it says \"this instruction may read and write nothing\".\n// ─────────────────────────────────────────────────────────────────────────────\n#[derive(Accounts)]\npub struct Version {}\n\n#[derive(Accounts)]\npub struct Greet {}\n\n// ─────────────────────────────────────────────────────────────────────────────\n// PART 4 of 4 — `#[account]`: the state, unchanged from Course 2.\n// ─────────────────────────────────────────────────────────────────────────────\n#[account]\n#[derive(InitSpace)]\npub struct VaultState {\n    pub owner: Pubkey,\n    pub balance: u64,\n    pub bump: u8,\n}\n\n// ─────────────────────────────────────────────────────────────────────────────\n// VERIFICATION HARNESS — DO NOT EDIT ANYTHING BELOW THIS LINE.\n//\n// It compiles only if both items exist with the exact names and signatures the\n// lesson asks for. This is a TYPE check, not a behaviour check: it cannot see\n// what your `msg!` string says, and it cannot see whether the handler does\n// anything at all.\n// ─────────────────────────────────────────────────────────────────────────────\n#[doc(hidden)]\n#[allow(dead_code)]\nmod verify {\n    use super::*;\n\n    // Part 3: `Greet` exists, has no fields, and carries `#[derive(Accounts)]`\n    // — the derive is what supplies the `Bumps` impl `Context` requires below.\n    fn accounts() -> Greet {\n        Greet {}\n    }\n\n    // Part 2: a handler named `greet` exists inside the `#[program]` module,\n    // takes `Context<Greet>` and returns `Result<()>`.\n    const GREET: for<'info> fn(Context<'info, Greet>) -> Result<()> = vault_program::greet;\n\n    // Part 4 is unchanged from Course 2: three fields, 41 bytes of data.\n    const _: () = assert!(VaultState::INIT_SPACE == 41);\n}\n",
-        "starter": "// Anatomy of an Anchor program — the same vault program, reduced to its four\n// parts and nothing else. Each part is labeled below.\n//\n// Parts 1 and 4 are complete. Parts 2 and 3 each already contain one worked\n// example, `version` and `Version`. Your job is the second pair: `greet` and\n// `Greet`, following the pattern that is already there.\n//\n// This file does NOT compile as shipped. The harness at the bottom names both\n// items you owe, and every error you see comes from one of them.\n\nuse anchor_lang::prelude::*;\n\n// ─────────────────────────────────────────────────────────────────────────────\n// PART 1 of 4 — `declare_id!`: the program's address.  (done)\n//\n// One address per program, baked into the binary. At deploy time the runtime\n// compares this value against the address it is deploying to.\n// ─────────────────────────────────────────────────────────────────────────────\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n// ─────────────────────────────────────────────────────────────────────────────\n// PART 2 of 4 — `#[program]`: the instruction handlers.\n//\n// Every `pub fn` in here becomes a callable instruction. First parameter is\n// always `Context<T>`; return type is always `Result<()>`.\n//\n// TODO (part 2): add a second handler, `greet`, that logs \"Hello, Solana!\"\n//                and returns `Ok(())`. Copy the shape of `version`.\n// ─────────────────────────────────────────────────────────────────────────────\n#[program]\npub mod vault_program {\n    use super::*;\n\n    pub fn version(_ctx: Context<Version>) -> Result<()> {\n        msg!(\"vault program, id {}\", ID);\n        Ok(())\n    }\n}\n\n// ─────────────────────────────────────────────────────────────────────────────\n// PART 3 of 4 — `#[derive(Accounts)]`: one account list per handler.\n//\n// The struct name must match the `Context<T>` generic exactly. `Version`\n// declares no fields, because `version` reads and writes no accounts.\n//\n// TODO (part 3): add the `Greet` accounts struct. `greet` only logs, so it too\n//                needs no fields — but it does need the derive.\n// ─────────────────────────────────────────────────────────────────────────────\n#[derive(Accounts)]\npub struct Version {}\n\n// ─────────────────────────────────────────────────────────────────────────────\n// PART 4 of 4 — `#[account]`: the state.  (done — this is your Course 2 struct)\n//\n// `#[account]` marks a struct as the contents of a program-owned account: it\n// generates the serialization and the 8-byte discriminator that identifies the\n// type on-chain. Nothing here creates an account. Module 2 does that.\n// ─────────────────────────────────────────────────────────────────────────────\n#[account]\n#[derive(InitSpace)]\npub struct VaultState {\n    pub owner: Pubkey,\n    pub balance: u64,\n    pub bump: u8,\n}\n\n// ─────────────────────────────────────────────────────────────────────────────\n// VERIFICATION HARNESS — DO NOT EDIT ANYTHING BELOW THIS LINE.\n//\n// It compiles only if both items exist with the exact names and signatures the\n// lesson asks for. This is a TYPE check, not a behaviour check: it cannot see\n// what your `msg!` string says, and it cannot see whether the handler does\n// anything at all.\n// ─────────────────────────────────────────────────────────────────────────────\n#[doc(hidden)]\n#[allow(dead_code)]\nmod verify {\n    use super::*;\n\n    // Part 3: `Greet` exists, has no fields, and carries `#[derive(Accounts)]`\n    // — the derive is what supplies the `Bumps` impl `Context` requires below.\n    fn accounts() -> Greet {\n        Greet {}\n    }\n\n    // Part 2: a handler named `greet` exists inside the `#[program]` module,\n    // takes `Context<Greet>` and returns `Result<()>`.\n    const GREET: for<'info> fn(Context<'info, Greet>) -> Result<()> = vault_program::greet;\n\n    // Part 4 is unchanged from Course 2: three fields, 41 bytes of data.\n    const _: () = assert!(VaultState::INIT_SPACE == 41);\n}\n",
+        "solution": "use anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n#[program]\npub mod academy_program {\n    use super::*;\n\n    pub fn initialize(_ctx: Context<Initialize>) -> Result<()> {\n        msg!(\"Superteam Academy default program\");\n        Ok(())\n    }\n\n    pub fn greet(_ctx: Context<Greet>) -> Result<()> {\n        msg!(\"Hello, Solana!\");\n        Ok(())\n    }\n}\n\n#[derive(Accounts)]\npub struct Initialize {}\n\n#[derive(Accounts)]\npub struct Greet {}\n",
+        "starter": "use anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n#[program]\npub mod academy_program {\n    use super::*;\n\n    pub fn initialize(_ctx: Context<Initialize>) -> Result<()> {\n        msg!(\"Superteam Academy default program\");\n        Ok(())\n    }\n\n    // TODO: Add a greet instruction here\n}\n\n#[derive(Accounts)]\npub struct Initialize {}\n\n// TODO: Add a Greet accounts struct here\n",
         "tests": [
           {
-            "description": "The file compiles on the build server against anchor-lang 1.1.2",
+            "description": "Program compiles successfully",
             "expectedOutput": "true",
-            "id": "t1",
+            "id": "test-1",
             "input": ""
           },
           {
-            "description": "Compiles ⇒ a handler named greet exists inside #[program], taking Context<Greet> and returning Result<()>",
+            "description": "Code contains a greet function",
             "expectedOutput": "true",
-            "id": "t2",
+            "id": "test-2",
             "input": ""
           },
           {
-            "description": "Compiles ⇒ Greet exists, has no fields, and carries #[derive(Accounts)]",
+            "description": "Code contains a Greet accounts struct",
             "expectedOutput": "true",
-            "id": "t3",
+            "id": "test-3",
             "input": ""
           }
         ]
@@ -748,7 +681,7 @@
             "prompt": "You add `pub fn greet(_ctx: Context<Greet>)` but forget to write the `Greet` accounts struct. What happens?"
           },
           {
-            "explanation": "An accounts struct declares exactly the accounts an instruction reads or writes. `greet` only calls `msg!`, touching none, so its struct is legitimately empty — whereas creating the vault must declare the account being created, the payer who funds it, and the System Program that does the creating.",
+            "explanation": "An accounts struct declares exactly the accounts an instruction reads or writes. `greet` only calls `msg!`, touching no accounts, so its struct is legitimately empty — whereas `Initialize` creates a Counter and must declare it, the payer, and the System Program.",
             "id": "q2",
             "multiSelect": false,
             "options": [
@@ -759,7 +692,7 @@
               },
               {
                 "correct": false,
-                "feedback": "Not required — the struct lists exactly the accounts an instruction touches. greet touches none; creating a vault touches three, so its struct cannot be empty.",
+                "feedback": "Not required — the struct lists exactly the accounts an instruction touches. greet touches none; Initialize creates an account, so its struct is non-empty.",
                 "id": "b",
                 "label": "Empty structs are required for every instruction"
               },
@@ -770,38 +703,7 @@
                 "label": "greet stores its state inside the program, so no account is needed"
               }
             ],
-            "prompt": "The `Greet` accounts struct can be empty (`pub struct Greet {}`). Why is that valid, when module 2's `InitializeVault` will not be?"
-          },
-          {
-            "explanation": "Worth recognising by sight, because it is the cheapest possible age-detector for a snippet. An unresolved name in a signature you copied almost always means the material predates a breaking release rather than that you mistyped. Anchor 1.x: the return type is `Result<()>`.",
-            "id": "q3",
-            "multiSelect": false,
-            "options": [
-              {
-                "correct": true,
-                "id": "a",
-                "label": "`error[E0412]: cannot find type ProgramResult in this scope` — the type was removed from Anchor years ago; 1.x handlers return `Result<()>`."
-              },
-              {
-                "correct": false,
-                "feedback": "They were never aliases — `ProgramResult` carried a `ProgramError`, which is why Anchor replaced it with its own `Result` and richer error type. And it is not in the prelude at all any more, so the name does not resolve.",
-                "id": "b",
-                "label": "It compiles. `ProgramResult` and `Result<()>` are aliases for the same type."
-              },
-              {
-                "correct": false,
-                "feedback": "There is no deprecation shim. The removal is old enough that the type is simply gone; you get a hard error on an unresolved name.",
-                "id": "c",
-                "label": "It compiles with a deprecation warning, since Anchor keeps the old return type for compatibility."
-              },
-              {
-                "correct": false,
-                "feedback": "The macro expansion is fine — the failure is ordinary name resolution on your own signature, and the error points at the exact column of `ProgramResult`.",
-                "id": "d",
-                "label": "It fails inside the `#[program]` macro with an unhelpful error about the dispatcher."
-              }
-            ],
-            "prompt": "You copy a handler signature out of an older Anchor tutorial and end up with `pub fn greet(_ctx: Context<Greet>) -> ProgramResult {`. Predict what the build server reports."
+            "prompt": "The `Greet` accounts struct can be empty (`pub struct Greet {}`). Why is that valid when `Initialize`'s struct is not?"
           }
         ]
       }
@@ -812,9 +714,9 @@
     ],
     "slug": {
       "_type": "slug",
-      "current": "anatomy-of-an-anchor-program"
+      "current": "add-instruction"
     },
-    "title": "Anatomy of an Anchor Program"
+    "title": "Add an Instruction"
   },
   {
     "_id": "lesson-bfsp-adding-instructions",
@@ -823,39 +725,81 @@
       {
         "_key": "intro",
         "_type": "prose",
-        "src": "# Add an Instruction\n\n> **Version stamp — checked 2026-07-26.** `anchor-lang 1.1.2` (published 2026-06-26) · `cargo-build-sbf` with platform-tools v1.54 (rustc 1.89) · `borsh` resolves to **1.8.0** · edition 2021. Every compiler message quoted below was produced by compiling this lesson's starter on that toolchain.\n\nYou have named the four parts. Now add an instruction without being shown where each line goes.\n\nAdding one is always the same three steps:\n\n1. a `pub fn` inside `#[program]`;\n2. an accounts struct with `#[derive(Accounts)]`, named exactly what the handler's `Context<T>` says;\n3. inside that struct, the accounts the instruction needs — and the constraints they must satisfy.\n\nStep 3 is module 2, and it is most of the rest of the course. This lesson is steps 1 and 2, on a handler that reads nothing, so that the mechanics are the only thing in front of you: `vault_info`, which logs the program's own id and returns.\n\n## What adding an instruction does to your program's API\n\nAn instruction is selected by the 8-byte discriminator Anchor derives from its name, so adding a handler is a purely **additive** change: every existing caller keeps working, because their discriminators still resolve. Renaming or removing one is a **breaking** change for exactly the same reason. Program upgrades on Solana are in-place — the address does not change and clients do not get told — so this is the version-compatibility surface you actually have. `vault_info` is safe to add today and expensive to rename tomorrow.\n\n## The exercise is a completion, not a blank page\n\nEvery line you need is already in the file, commented out and shuffled into two pools. Your job is discrimination and order, not invention:\n\n- **Pool A**, inside `#[program]`: five lines, four of which make one complete handler. Rust is whitespace-insensitive, so indentation is not what you are being asked about — the sequence is. One line opens the block, one closes it, one is the body, one is the return value.\n- **Pool B**, at the top level: four lines, two of which belong. This is where the exercise gets interesting.\n\nThree of the nine lines belong nowhere. **Two of the three are caught by the compiler; one is not**, and knowing which one slips through is the actual content of this lesson.\n\n### `#[account]` is not `#[derive(Accounts)]`\n\nPool B offers you both. They are one letter apart in conversation and unrelated in function:\n\n| | Goes on | Means |\n| --- | --- | --- |\n| `#[account]` | a **state struct** | \"these are the bytes stored inside a program-owned account\" — generates the serialization and the 8-byte type discriminator |\n| `#[derive(Accounts)]` | an **account list** | \"these are the accounts one instruction may touch\" — generates the deserialization and every validation check |\n\n`VaultState` in this file has the first. `VaultInfo` needs the second. Choose `#[account]` for `VaultInfo` and the build fails on `the trait bound VaultInfo: Bumps is not satisfied` — `Bumps` is one of the traits the `Accounts` derive generates, and `Context<T>` requires it. That error message names the missing trait rather than the missing attribute, which is why it is worth meeting once deliberately.\n\n### The line the compiler will not save you from\n\nPool B also offers a second error enum:\n\n```rust\n#[error_code] pub enum InfoError { #[msg(\"no vault at that address\")] NoVault }\n```\n\n**A program should carry exactly one `#[error_code]` enum, and nothing enforces it.** You already have yours — `VaultError`, from Course 2, sitting at the bottom of this file.\n\nHere is the part that matters. Paste that line in and **the build is green.** Not because our grader is lenient — a second enum is legal Anchor, and the Anchor CLI would accept it too. There is no rule being skipped here. What you get instead of an error is silent and worse.\n\n`#[error_code]` generates `impl From<YourEnum> for u32` as `variant_index + ERROR_CODE_OFFSET`, and `ERROR_CODE_OFFSET` is `6000`. Two enums, neither given an explicit offset, both start numbering at 6000. So `VaultError::Overflow` and `InfoError::NoVault` are **both error code 6000**, and a client that catches 6000 cannot tell which failure it is looking at. Your error messages stop being diagnostic at the exact moment you need them.\n\nTwo correct moves, in order of preference:\n\n1. Add a variant to `VaultError`. One namespace, monotonic numbering, no collision. This is what module 3 does when `withdraw` needs `InsufficientFunds`.\n2. If you genuinely need a separate enum, `#[error_code(offset = 7000)]` moves its base. You will almost never need this, and reaching for it is usually a sign the first option was right.\n\nTake the general lesson too: a green build here proves your file compiles against the real Anchor 1.x toolchain and nothing more. It does not prove the file is correct, and this lesson contains a live example of the gap.\n\n## Your job\n\nAssemble `vault_info` from pool A and `VaultInfo` from pool B. Leave the lines that belong nowhere commented out. The verification harness at the bottom of the file names both items by signature — build first, and the errors will tell you exactly what is still missing.\n"
+        "src": "# Adding Instructions\n\nA program with just `initialize` isn't very useful. Real programs have multiple instructions that modify state.\n\n## The Pattern\n\nEvery new instruction follows the same pattern:\n\n1. Add a `pub fn` inside `#[program]`\n2. Create a corresponding accounts struct with `#[derive(Accounts)]`\n3. Define which accounts the instruction needs and their constraints\n\n## Increment: Modifying State\n\nTo increment a counter, we need:\n\n```rust\npub fn increment(ctx: Context<Increment>) -> Result<()> {\n    let counter = &mut ctx.accounts.counter;\n    counter.count += 1;\n    Ok(())\n}\n```\n\nThe `Increment` accounts struct needs the counter PDA and the user (to derive the PDA seeds):\n\n```rust\n#[derive(Accounts)]\npub struct Increment<'info> {\n    #[account(\n        mut,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    pub user: Signer<'info>,\n}\n```\n\nNote: `mut` is required because we're modifying `count`. The `seeds` and `bump` tell Anchor to verify the PDA address matches. The `user` provides the wallet pubkey used in the seeds.\n\n## Decrement with Safety\n\nWhat happens if someone tries to decrement a counter that's already at 0? With `u64`, subtraction would underflow and panic.\n\nAnchor provides `require!` for safe checks:\n\n```rust\npub fn decrement(ctx: Context<Decrement>) -> Result<()> {\n    let counter = &mut ctx.accounts.counter;\n    require!(counter.count > 0, ErrorCode::Underflow);\n    counter.count -= 1;\n    Ok(())\n}\n```\n\n## Custom Errors\n\nThe `ErrorCode::Underflow` needs to be defined:\n\n```rust\n#[error_code]\npub enum ErrorCode {\n    #[msg(\"Cannot decrement below zero\")]\n    Underflow,\n}\n```\n\n`#[error_code]` generates Anchor-compatible error types. The `#[msg]` attribute provides a human-readable error message visible in transaction logs.\n\n## Coming Up\n\nYou'll build the increment instruction first, then combine everything into the complete counter program with error handling.\n"
+      }
+    ],
+    "skills": [
+      "anchor",
+      "solana-programs"
+    ],
+    "slug": {
+      "_type": "slug",
+      "current": "adding-instructions"
+    },
+    "title": "Adding Instructions"
+  },
+  {
+    "_id": "lesson-bfsp-anatomy-anchor-program",
+    "_type": "lesson",
+    "blocks": [
+      {
+        "_key": "intro",
+        "_type": "prose",
+        "src": "# Anatomy of an Anchor Program\n\nBefore we start adding features, let's break down every line of the program you just compiled.\n\n## The Import\n\n```rust\nuse anchor_lang::prelude::*;\n```\n\nThis single import brings in everything Anchor needs: the `#[program]` macro, `Context`, `Account`, `Signer`, `Result`, error types, and more.\n\n## Program ID\n\n```rust\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n```\n\nEvery Solana program has a unique address (public key). The `declare_id!` macro hardcodes this address into the binary. When you deploy, Solana verifies the binary matches this ID.\n\nFor development, you can use any valid base58 public key. For production, you'd generate one with `solana-keygen grind`.\n\n## The Program Module\n\n```rust\n#[program]\npub mod academy_program {\n    use super::*;\n\n    pub fn initialize(_ctx: Context<Initialize>) -> Result<()> {\n        msg!(\"Superteam Academy default program\");\n        Ok(())\n    }\n}\n```\n\nThe `#[program]` attribute tells Anchor this module contains your instruction handlers. Each `pub fn` inside becomes a callable instruction on-chain.\n\n**Key rules:**\n- First parameter is always `Context<T>` where `T` is an accounts struct\n- Return type is always `Result<()>`\n- `msg!()` logs to the transaction log (visible in explorers)\n\n## Accounts Structs\n\n```rust\n#[derive(Accounts)]\npub struct Initialize {}\n```\n\nEvery instruction needs an accounts struct that defines which accounts the instruction reads/writes. This empty struct means `initialize` doesn't need any accounts.\n\nIn the next lesson, you'll add your first real instruction with a non-empty accounts struct.\n\n## What the Compiler Checks\n\nWhen you hit Build, `cargo-build-sbf` validates:\n- Rust syntax and type safety\n- Anchor macro expansion (accounts, constraints, errors)\n- SBF compatibility (no system calls, no heap abuse)\n\nIf any of these fail, you get a compiler error with the exact line number.\n"
       },
       {
-        "_key": "exercise",
-        "_type": "code",
-        "buildType": "buildable",
-        "deployable": false,
-        "hints": [
-          "Build before you place anything. Four errors come back and all four are raised by the harness, which is the only code in the file referencing what you have not placed yet: three name `VaultInfo` and one names `vault_info`. Neither pool is mentioned, because a commented-out line is invisible to the compiler.",
-          "Pool A, mechanically: the line that opens a block ends in `{`, the line that closes one is `}`, and between them the body runs top to bottom with the returned value last. That fixes the order completely. Then look at the two candidate signatures — only one names a return type that exists in Anchor 1.x, and you met the other one in the previous lesson's quiz.",
-          "Pool B is `(b2)` then `(b1)`. `#[account]` describes the bytes inside an account and `#[derive(Accounts)]` describes a list of accounts an instruction may touch; `Context<VaultInfo>` needs the second, and picking the first fails on `the trait bound VaultInfo: Bumps is not satisfied`. `(b4)` compiles cleanly and is still wrong — re-read the prose on error code 6000 before deciding it is harmless."
-        ],
-        "language": "rust",
-        "solution": "// Add an instruction — assembled.\n//\n// Pool A, in order: (a5) opens the handler, (a3) is the body, (a1) returns, (a2)\n// closes the block. (a4) is the same signature with `ProgramResult` as its return\n// type; that type was removed from Anchor years ago, so it does not resolve.\n//\n// Pool B, in order: (b2) then (b1). (b3) is `#[account]`, which marks the\n// *contents of an account*, not an account list — pick it and `Context<VaultInfo>`\n// fails with `the trait bound VaultInfo: Bumps is not satisfied`, because the\n// `Accounts` derive is the only thing that supplies that impl. (b4) is the one\n// wrong line the compiler does not catch; see the lesson prose.\n\nuse anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n#[program]\npub mod vault_program {\n    use super::*;\n\n    pub fn version(_ctx: Context<Version>) -> Result<()> {\n        msg!(\"vault program, id {}\", ID);\n        Ok(())\n    }\n\n    pub fn vault_info(_ctx: Context<VaultInfo>) -> Result<()> {\n        msg!(\"vault program id: {}\", ID);\n        Ok(())\n    }\n}\n\n#[derive(Accounts)]\npub struct Version {}\n\n#[derive(Accounts)]\npub struct VaultInfo {}\n\n#[account]\n#[derive(InitSpace)]\npub struct VaultState {\n    pub owner: Pubkey,\n    pub balance: u64,\n    pub bump: u8,\n}\n\n#[error_code]\npub enum VaultError {\n    #[msg(\"Deposit would overflow the vault balance\")]\n    Overflow,\n    #[msg(\"Withdrawal is larger than the vault balance\")]\n    InsufficientFunds,\n    #[msg(\"Amount must be greater than zero\")]\n    ZeroAmount,\n    #[msg(\"Signer is not the vault owner\")]\n    NotOwner,\n}\n\n// ─────────────────────────────────────────────────────────────────────────────\n// VERIFICATION HARNESS — DO NOT EDIT ANYTHING BELOW THIS LINE.\n//\n// It compiles only if `vault_info` and `VaultInfo` exist with exactly the names\n// and signatures the lesson asks for. It is a TYPE check and nothing more: it\n// cannot see the body of your handler, and it cannot see a second `#[error_code]`\n// enum sitting above it.\n// ─────────────────────────────────────────────────────────────────────────────\n#[doc(hidden)]\n#[allow(dead_code)]\nmod verify {\n    use super::*;\n\n    // Pool B: `VaultInfo` exists, has no fields, and carries\n    // `#[derive(Accounts)]` — the derive is what supplies the `Bumps` impl that\n    // `Context` demands on the next line.\n    fn accounts() -> VaultInfo {\n        VaultInfo {}\n    }\n\n    // Pool A: a handler named `vault_info` exists inside the `#[program]`\n    // module, takes `Context<VaultInfo>` and returns `Result<()>`.\n    const VAULT_INFO: for<'info> fn(Context<'info, VaultInfo>) -> Result<()> =\n        vault_program::vault_info;\n}\n",
-        "starter": "// Add an instruction — assemble it from the fragments below.\n//\n// Nothing here is for you to invent. Every line you need is already in this\n// file, commented out and out of order, in two pools. Uncomment the ones that\n// belong, put them in the right place in the right order, and leave the rest\n// commented.\n//\n// THREE of the nine pool lines belong nowhere. All three are mistakes people\n// actually make. TWO of them the compiler catches; ONE builds green and is\n// wrong anyway. Decide which is which before you build.\n//\n// Target, in full:\n//\n//     pub fn vault_info(_ctx: Context<VaultInfo>) -> Result<()>\n//     #[derive(Accounts)] pub struct VaultInfo {}\n//\n// This file does NOT compile as shipped.\n\nuse anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n#[program]\npub mod vault_program {\n    use super::*;\n\n    pub fn version(_ctx: Context<Version>) -> Result<()> {\n        msg!(\"vault program, id {}\", ID);\n        Ok(())\n    }\n\n    // ── POOL A — five lines. FOUR of them make one complete handler, here,\n    //    in some order. ONE belongs nowhere. Indentation is not graded; order\n    //    inside the block is the whole exercise.\n    //\n    // (a1)     Ok(())\n    // (a2) }\n    // (a3)     msg!(\"vault program id: {}\", ID);\n    // (a4) pub fn vault_info(_ctx: Context<VaultInfo>) -> ProgramResult {\n    // (a5) pub fn vault_info(_ctx: Context<VaultInfo>) -> Result<()> {\n}\n\n#[derive(Accounts)]\npub struct Version {}\n\n// ── POOL B — four lines. TWO of them belong here, in order. TWO belong nowhere.\n//\n// (b1) pub struct VaultInfo {}\n// (b2) #[derive(Accounts)]\n// (b3) #[account]\n// (b4) #[error_code] pub enum InfoError { #[msg(\"no vault at that address\")] NoVault }\n\n#[account]\n#[derive(InitSpace)]\npub struct VaultState {\n    pub owner: Pubkey,\n    pub balance: u64,\n    pub bump: u8,\n}\n\n#[error_code]\npub enum VaultError {\n    #[msg(\"Deposit would overflow the vault balance\")]\n    Overflow,\n    #[msg(\"Withdrawal is larger than the vault balance\")]\n    InsufficientFunds,\n    #[msg(\"Amount must be greater than zero\")]\n    ZeroAmount,\n    #[msg(\"Signer is not the vault owner\")]\n    NotOwner,\n}\n\n// ─────────────────────────────────────────────────────────────────────────────\n// VERIFICATION HARNESS — DO NOT EDIT ANYTHING BELOW THIS LINE.\n//\n// It compiles only if `vault_info` and `VaultInfo` exist with exactly the names\n// and signatures the lesson asks for. It is a TYPE check and nothing more: it\n// cannot see the body of your handler, and it cannot see a second `#[error_code]`\n// enum sitting above it.\n// ─────────────────────────────────────────────────────────────────────────────\n#[doc(hidden)]\n#[allow(dead_code)]\nmod verify {\n    use super::*;\n\n    // Pool B: `VaultInfo` exists, has no fields, and carries\n    // `#[derive(Accounts)]` — the derive is what supplies the `Bumps` impl that\n    // `Context` demands on the next line.\n    fn accounts() -> VaultInfo {\n        VaultInfo {}\n    }\n\n    // Pool A: a handler named `vault_info` exists inside the `#[program]`\n    // module, takes `Context<VaultInfo>` and returns `Result<()>`.\n    const VAULT_INFO: for<'info> fn(Context<'info, VaultInfo>) -> Result<()> =\n        vault_program::vault_info;\n}\n",
-        "tests": [
+        "_key": "retrieval-close",
+        "_type": "quiz",
+        "questions": [
           {
-            "description": "The file compiles on the build server against anchor-lang 1.1.2",
-            "expectedOutput": "true",
-            "id": "t1",
-            "input": ""
+            "explanation": "declare_id! embeds the program's expected public key into the binary. On deploy, Solana checks the program account address against it — a guard against deploying a binary under the wrong id, which would break every client that derives PDAs from that id.",
+            "id": "q1",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "It verifies the deployed program's account address matches the declared id"
+              },
+              {
+                "correct": false,
+                "feedback": "declare_id! generates no keys — it states the expected address. Solana checks the deployed program matches it; a mismatch is an error.",
+                "id": "b",
+                "label": "It generates a fresh keypair for the program"
+              },
+              {
+                "correct": false,
+                "feedback": "The macro reserves nothing on its own. It is a claim that Solana validates against the actual deploy address.",
+                "id": "c",
+                "label": "It reserves the address so no one else can use it before you deploy"
+              }
+            ],
+            "prompt": "`declare_id!(...)` hardcodes an address into your binary. What does Solana do with it at deploy time?"
           },
           {
-            "description": "Compiles ⇒ a handler named vault_info exists inside #[program], taking Context<VaultInfo> and returning Result<()>",
-            "expectedOutput": "true",
-            "id": "t2",
-            "input": ""
-          },
-          {
-            "description": "Compiles ⇒ VaultInfo exists, has no fields, and carries #[derive(Accounts)] rather than #[account]",
-            "expectedOutput": "true",
-            "id": "t3",
-            "input": ""
+            "explanation": "Every `#[program]` handler has the same shape: `Context<T>` first (T being the accounts struct that declares and validates accounts), then optional instruction args, returning `Result<()>`. Anchor generates the on-chain dispatch from exactly this signature.",
+            "id": "q2",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "Its first parameter is `Context<T>` for some `#[derive(Accounts)]` struct T, and it returns `Result<()>`"
+              },
+              {
+                "correct": false,
+                "feedback": "The `#[program]` contract is fixed: every handler takes a `Context<T>` first and returns `Result<()>`. Anchor's macro expansion depends on it.",
+                "id": "b",
+                "label": "It can take any parameters and return any type"
+              },
+              {
+                "correct": false,
+                "feedback": "Accounts are always bundled in `Context<T>`, never passed individually. The struct T is where accounts and their constraints live.",
+                "id": "c",
+                "label": "It must take each account as a separate argument, not a Context"
+              }
+            ],
+            "prompt": "You add a new `pub fn withdraw(...)` inside the `#[program]` module. What must be true of its signature?"
           }
         ]
       }
@@ -866,9 +810,9 @@
     ],
     "slug": {
       "_type": "slug",
-      "current": "add-an-instruction"
+      "current": "anatomy-anchor-program"
     },
-    "title": "Add an Instruction"
+    "title": "Anatomy of an Anchor Program"
   },
   {
     "_id": "lesson-bfsp-build-increment",
@@ -877,7 +821,7 @@
       {
         "_key": "intro",
         "_type": "prose",
-        "src": "# Write the Deposit\n\n> **Version stamp — checked 2026-07-26.** `anchor-lang 1.1.2` (published 2026-06-26) · `cargo-build-sbf` with platform-tools v1.54 (rustc 1.89) · edition 2021. Every compiler message quoted below was produced by compiling this lesson's file.\n\nYou read a working `deposit` in the last lesson. Now write one.\n\nThe starter has the vault program with `deposit` and its accounts struct removed, and three numbered subgoals in their place. The previous lesson is still open in another tab; that is deliberate. At this rung the work is not recall, it is knowing which piece goes where and why each line is there — and subgoal 3 asks for something no tutorial can hand you: a call into a file *you* wrote.\n\n## Subgoal 1 — `Deposit<'info>`\n\nThree accounts. `system_program` is pre-filled, because you already know why it stays even though `CpiContext::new` no longer takes it. The other two you write:\n\n- **the vault** — mutable, and re-derived from its seeds so Anchor can prove the account passed in really is *this* caller's vault.\n- **the user** — a signer, and mutable.\n\n`user` being `mut` is the one that catches people. In Module 2's `initialize_vault` the user was `mut` because they paid rent. Here nobody pays rent — the account already exists — but lamports still leave the user's wallet, and any account whose lamports change must be declared mutable. Same constraint, different reason.\n\n### `bump = vault.bump`, not bare `bump`\n\nBoth are legal. They do different amounts of work:\n\n| Written | What Anchor does |\n| --- | --- |\n| `bump` | searches from 255 downwards for the canonical bump, hashing at each step |\n| `bump = vault.bump` | one hash, using the byte you stored at initialize time |\n\nThe stored bump is *why* you spent a byte on it in Module 2. Use it. A bare `bump` here would be paying compute units to recompute an answer the account is already carrying.\n\n## Subgoal 2 — the CPI\n\nAsk the System Program to move `amount` lamports from the user to the vault. The shape from the last lesson, with the Anchor 1.0 first argument:\n\n```\ntransfer( CpiContext::new( <program id>, Transfer { from, to } ), amount )?\n```\n\n`Transfer`'s two fields are `AccountInfo`s, so both accounts need `.to_account_info()`. Get the direction right: the user is the source.\n\n## Subgoal 3 — call your own code\n\n```rust\nctx.accounts.vault.deposit(amount)?;\n```\n\nOne line. That line is the whole reason Course 2 exists.\n\nEverything it does — reject a zero amount, add with `checked_add`, return `VaultError::Overflow` instead of wrapping — is already written, already reasoned about, and lives in a module with no accounts in it. You are not going to retype `checked_add` here, and if you find yourself writing `ctx.accounts.vault.balance += amount` then stop: that is a fresh, unchecked, untested copy of a function you already own, and the version you already own is better.\n\nThis is what \"import, don't retype\" means as a mechanical fact rather than a slogan. Look at your finished file afterwards and note that the arithmetic appears exactly once in it.\n\n## Does the order matter?\n\nYou have two statements — the CPI and the bookkeeping — and you may be wondering which goes first.\n\nIt does not matter, and the reason is worth knowing: **a transaction either completes or is entirely rolled back.** If `vault.deposit(amount)` returns `Err` after the CPI has already moved lamports, the transfer is undone along with everything else. There is no state where the lamports moved and the balance did not.\n\nThat guarantee is what lets you write the happy path in the order that reads best.\n\n## What the build server can and cannot tell you\n\nAt the bottom of the starter is a `mod verify` block marked do-not-edit. It compiles only if `deposit` exists with exactly the right signature and `Deposit` has all three fields with the right types. Get a name or a type wrong and you get a compile error naming it.\n\nIt is a **type** check, not a behaviour check. It cannot see whether your CPI moves lamports in the right direction, and it cannot see whether you called `vault.deposit` at all — an empty handler body with a correct signature compiles. The harness comment lists exactly which mistakes it is blind to. Read that list; it is more useful than the part it does catch.\n"
+        "src": "# Challenge: Build the Increment\n\nAdd an `increment` instruction to the counter program.\n\n## Requirements\n\n1. Add a `pub fn increment` inside the `#[program]` module\n2. It should take `ctx: Context<Increment>` and return `Result<()>`\n3. Get a mutable reference to `ctx.accounts.counter` and add 1 to `count`\n4. Add an `Increment` accounts struct with `counter` (PDA, `mut`, same seeds as Initialize) and `user` (`Signer`)\n\n## Why `user` is needed in Increment\n\nThe counter is a PDA derived from `[b\"counter\", user.key()]`. To verify the PDA matches, Anchor needs the `user` account to re-derive the seeds. This also acts as authorization — only the wallet that matches the seeds can modify this counter.\n\n## Tips\n\n- The `Increment` struct needs the `<'info>` lifetime, just like `Initialize`\n- The counter field needs `seeds` and `bump` (same seeds as Initialize, but no `init`)\n- The `user` field is `Signer<'info>` (not mut — they don't pay anything here)\n- Don't change the existing `initialize` or `greet` instructions\n"
       },
       {
         "_key": "exercise",
@@ -885,28 +829,39 @@
         "buildType": "buildable",
         "deployable": false,
         "hints": [
-          "Build the unfinished file first. It fails with `error[E0609]: no field 'vault' on type '&Deposit<'_>'` and the same for `user` — that is the do-not-edit harness at the bottom telling you subgoal 1 is not done yet. Errors that name the missing thing are the cheapest feedback you will get all lesson.",
-          "The `deposit` body is two statements: `transfer(CpiContext::new(System::id(), Transfer { from, to }), amount)?` and then one call on `ctx.accounts.vault`. `Transfer`'s fields are `AccountInfo`s, so both accounts need `.to_account_info()`, and the user is the `from`.",
-          "`Deposit<'info>` needs the lifetime, `vault` needs `mut` + `seeds = [b\"vault\", user.key().as_ref()]` + `bump = vault.bump` (the stored byte, not a bare `bump`), and `user` needs `mut` as well as `Signer<'info>` — lamports leave that wallet even though no rent is paid. Then make sure the handler still ends in `Ok(())`."
+          "The increment function body is just two lines: get `&mut ctx.accounts.counter` and then `counter.count += 1`",
+          "The Increment struct needs `<'info>` lifetime, a `counter` field with `#[account(mut, seeds = [b\"counter\", user.key().as_ref()], bump)]`, and a `user: Signer<'info>` field",
+          "Make sure increment returns `Ok(())` at the end"
         ],
         "language": "rust",
-        "solution": "use anchor_lang::prelude::*;\nuse anchor_lang::system_program::{transfer, Transfer};\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n// ─── Your Course 2 core, imported unchanged. Do not edit it. ─────────────────\npub mod vault {\n    use super::*;\n\n    #[account]\n    #[derive(InitSpace)]\n    pub struct VaultState {\n        pub owner: Pubkey,\n        pub balance: u64,\n        pub bump: u8,\n    }\n\n    #[error_code]\n    pub enum VaultError {\n        #[msg(\"Deposit would overflow the vault balance\")]\n        Overflow,\n        #[msg(\"Withdrawal is larger than the vault balance\")]\n        InsufficientFunds,\n        #[msg(\"Amount must be greater than zero\")]\n        ZeroAmount,\n        #[msg(\"Signer is not the vault owner\")]\n        NotOwner,\n    }\n\n    impl VaultState {\n        pub fn deposit(&mut self, amount: u64) -> Result<()> {\n            require!(amount > 0, VaultError::ZeroAmount);\n            self.balance = self\n                .balance\n                .checked_add(amount)\n                .ok_or(VaultError::Overflow)?;\n            Ok(())\n        }\n\n        pub fn withdraw(&mut self, amount: u64) -> Result<()> {\n            require!(amount > 0, VaultError::ZeroAmount);\n            self.balance = self\n                .balance\n                .checked_sub(amount)\n                .ok_or(VaultError::InsufficientFunds)?;\n            Ok(())\n        }\n    }\n}\n\npub use vault::{VaultError, VaultState};\n\n#[program]\npub mod vault_program {\n    use super::*;\n\n    pub fn initialize_vault(ctx: Context<InitializeVault>) -> Result<()> {\n        let vault = &mut ctx.accounts.vault;\n        vault.owner = ctx.accounts.user.key();\n        vault.balance = 0;\n        vault.bump = ctx.bumps.vault;\n        Ok(())\n    }\n\n    pub fn deposit(ctx: Context<Deposit>, amount: u64) -> Result<()> {\n        // SUBGOAL 2 — the lamports. Program id first (a `Pubkey`), accounts\n        // second, amount last. The user's transaction signature is what the\n        // System Program checks; this program signs nothing.\n        transfer(\n            CpiContext::new(\n                System::id(),\n                Transfer {\n                    from: ctx.accounts.user.to_account_info(),\n                    to: ctx.accounts.vault.to_account_info(),\n                },\n            ),\n            amount,\n        )?;\n\n        // SUBGOAL 3 — the bookkeeping, in one line, by calling Course 2.\n        // The zero-amount guard, the `checked_add` and `VaultError::Overflow`\n        // all live inside this method. Nothing is retyped here.\n        ctx.accounts.vault.deposit(amount)?;\n\n        Ok(())\n    }\n}\n\n#[derive(Accounts)]\npub struct InitializeVault<'info> {\n    #[account(\n        init,\n        payer = user,\n        space = 8 + 32 + 8 + 1,\n        seeds = [b\"vault\", user.key().as_ref()],\n        bump\n    )]\n    pub vault: Account<'info, VaultState>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n    pub system_program: Program<'info, System>,\n}\n\n// SUBGOAL 1 — the accounts struct.\n#[derive(Accounts)]\npub struct Deposit<'info> {\n    // `mut`: both the lamports and the data change.\n    // `bump = vault.bump`: one hash, using the byte stored at initialize time,\n    // instead of searching from 255 down for a canonical bump we already have.\n    #[account(\n        mut,\n        seeds = [b\"vault\", user.key().as_ref()],\n        bump = vault.bump\n    )]\n    pub vault: Account<'info, VaultState>,\n\n    // `mut` because lamports leave this wallet — not because rent is paid.\n    // `Signer` because the System Program will not debit an account that did\n    // not sign, and that signature is the only authorisation in the instruction.\n    #[account(mut)]\n    pub user: Signer<'info>,\n\n    pub system_program: Program<'info, System>,\n}\n\n// ─────────────────────────────────────────────────────────────────────────────\n// VERIFICATION HARNESS — DO NOT EDIT ANYTHING BELOW THIS LINE.\n//\n// A TYPE check, not a behaviour check. Ways to be wrong and still be green,\n// each one confirmed by compiling it: an empty `deposit` body; `from` and `to`\n// swapped; `balance += amount` instead of the Course 2 method; a bare `bump`\n// instead of `bump = vault.bump`. The build server compiles, it does not run.\n// ─────────────────────────────────────────────────────────────────────────────\n#[doc(hidden)]\n#[allow(dead_code)]\nmod verify {\n    use super::*;\n\n    const DEPOSIT: for<'info> fn(Context<'info, Deposit<'info>>, u64) -> Result<()> =\n        vault_program::deposit;\n\n    fn pin_deposit_accounts(a: &Deposit) {\n        let _: &Account<VaultState> = &a.vault;\n        let _: &Signer = &a.user;\n        let _: &Program<System> = &a.system_program;\n    }\n\n    const CORE_DEPOSIT: fn(&mut VaultState, u64) -> Result<()> = VaultState::deposit;\n    const _: () = assert!(VaultState::INIT_SPACE == 41);\n}\n",
-        "starter": "use anchor_lang::prelude::*;\nuse anchor_lang::system_program::{transfer, Transfer};\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n// ─── Your Course 2 core, imported unchanged. Do not edit it. ─────────────────\npub mod vault {\n    use super::*;\n\n    #[account]\n    #[derive(InitSpace)]\n    pub struct VaultState {\n        pub owner: Pubkey,\n        pub balance: u64,\n        pub bump: u8,\n    }\n\n    #[error_code]\n    pub enum VaultError {\n        #[msg(\"Deposit would overflow the vault balance\")]\n        Overflow,\n        #[msg(\"Withdrawal is larger than the vault balance\")]\n        InsufficientFunds,\n        #[msg(\"Amount must be greater than zero\")]\n        ZeroAmount,\n        #[msg(\"Signer is not the vault owner\")]\n        NotOwner,\n    }\n\n    impl VaultState {\n        pub fn deposit(&mut self, amount: u64) -> Result<()> {\n            require!(amount > 0, VaultError::ZeroAmount);\n            self.balance = self\n                .balance\n                .checked_add(amount)\n                .ok_or(VaultError::Overflow)?;\n            Ok(())\n        }\n\n        pub fn withdraw(&mut self, amount: u64) -> Result<()> {\n            require!(amount > 0, VaultError::ZeroAmount);\n            self.balance = self\n                .balance\n                .checked_sub(amount)\n                .ok_or(VaultError::InsufficientFunds)?;\n            Ok(())\n        }\n    }\n}\n\npub use vault::{VaultError, VaultState};\n\n#[program]\npub mod vault_program {\n    use super::*;\n\n    // Finished in Module 2. Leave it alone.\n    pub fn initialize_vault(ctx: Context<InitializeVault>) -> Result<()> {\n        let vault = &mut ctx.accounts.vault;\n        vault.owner = ctx.accounts.user.key();\n        vault.balance = 0;\n        vault.bump = ctx.bumps.vault;\n        Ok(())\n    }\n\n    pub fn deposit(ctx: Context<Deposit>, amount: u64) -> Result<()> {\n        // ── SUBGOAL 2: move the lamports ────────────────────────────────────\n        //\n        // Ask the System Program to transfer `amount` from the user to the\n        // vault. Two things to get right:\n        //\n        //   * the first argument to `CpiContext::new` is a program id — a\n        //     `Pubkey`. Pass an `AccountInfo` and you get\n        //     `error[E0308]: expected Pubkey, found AccountInfo<'_>`.\n        //   * `Transfer { from, to }` takes `AccountInfo`s, so both accounts\n        //     need `.to_account_info()`. The user is the source.\n        //\n        // Propagate failure with `?` — never `.unwrap()`.\n\n        // ── SUBGOAL 3: update the balance using YOUR Course 2 method ────────\n        //\n        // One line. `ctx.accounts.vault` derefs to your `VaultState`, so the\n        // method you wrote and reasoned about in Course 2 is callable on it directly.\n        //\n        // Do NOT retype the arithmetic. If you are writing `checked_add` or\n        // `+= amount` in this file, you are shipping a second copy of a function\n        // you already own — one more place for the guard to go missing.\n\n        Ok(())\n    }\n}\n\n#[derive(Accounts)]\npub struct InitializeVault<'info> {\n    #[account(\n        init,\n        payer = user,\n        space = 8 + 32 + 8 + 1,\n        seeds = [b\"vault\", user.key().as_ref()],\n        bump\n    )]\n    pub vault: Account<'info, VaultState>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n    pub system_program: Program<'info, System>,\n}\n\n// ── SUBGOAL 1: the accounts struct ──────────────────────────────────────────\n//\n// Three accounts. One is pre-filled. Add the other two, in this order:\n//\n//   1a. `vault` — `Account<'info, VaultState>`. Mutable (both its lamports and\n//       its data change), re-derived from `[b\"vault\", user.key().as_ref()]`,\n//       and using the bump you STORED rather than searching for it again.\n//\n//   1b. `user`  — `Signer<'info>`. Mutable: no rent is paid here, but lamports\n//       leave this wallet, and any account whose lamports change must be `mut`.\n//\n#[derive(Accounts)]\npub struct Deposit<'info> {\n    // Still required even though `CpiContext::new` no longer takes it: the\n    // runtime must have the callee's program account loaded, and declaring it\n    // here is what makes the client include it in the transaction.\n    pub system_program: Program<'info, System>,\n}\n\n// ─────────────────────────────────────────────────────────────────────────────\n// VERIFICATION HARNESS — DO NOT EDIT ANYTHING BELOW THIS LINE.\n//\n// This compiles only if `deposit` and `Deposit` exist with exactly the names,\n// field names and types the subgoals ask for. A missing field is\n// `error[E0609]: no field ... on type &Deposit<'_>`; a wrong type is\n// `error[E0308]: mismatched types`; a missing item is `error[E0433]`.\n//\n// It is a TYPE check, not a behaviour check. Ways to be wrong and still be\n// green, each one confirmed by compiling it:\n//   * an empty `deposit` body — only the signature is pinned\n//   * `from` and `to` swapped, so the vault pays the user\n//   * `ctx.accounts.vault.balance += amount` instead of the Course 2 method\n//   * a bare `bump` instead of `bump = vault.bump`, which costs compute units\n// The build server compiles; it does not run, and neither does anything else in\n// this course. Module 4 shows you the LiteSVM test that would catch these three,\n// and why compiling cannot.\n// ─────────────────────────────────────────────────────────────────────────────\n#[doc(hidden)]\n#[allow(dead_code)]\nmod verify {\n    use super::*;\n\n    // `deposit` takes a `Deposit` context plus a `u64` and returns `Result<()>`.\n    const DEPOSIT: for<'info> fn(Context<'info, Deposit<'info>>, u64) -> Result<()> =\n        vault_program::deposit;\n\n    // `Deposit` carries all three accounts, each with the right type.\n    fn pin_deposit_accounts(a: &Deposit) {\n        let _: &Account<VaultState> = &a.vault;\n        let _: &Signer = &a.user;\n        let _: &Program<System> = &a.system_program;\n    }\n\n    // The Course 2 core is intact and still has the method subgoal 3 calls.\n    const CORE_DEPOSIT: fn(&mut VaultState, u64) -> Result<()> = VaultState::deposit;\n    const _: () = assert!(VaultState::INIT_SPACE == 41);\n}\n",
+        "solution": "use anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n#[program]\npub mod academy_program {\n    use super::*;\n\n    pub fn initialize(ctx: Context<Initialize>) -> Result<()> {\n        let counter = &mut ctx.accounts.counter;\n        counter.count = 0;\n        counter.authority = ctx.accounts.user.key();\n        msg!(\"Counter initialized!\");\n        Ok(())\n    }\n\n    pub fn greet(_ctx: Context<Greet>) -> Result<()> {\n        msg!(\"Hello, Solana!\");\n        Ok(())\n    }\n\n    pub fn increment(ctx: Context<Increment>) -> Result<()> {\n        let counter = &mut ctx.accounts.counter;\n        counter.count += 1;\n        Ok(())\n    }\n}\n\n#[derive(Accounts)]\npub struct Initialize<'info> {\n    #[account(\n        init,\n        payer = user,\n        space = 8 + 8 + 32,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n    pub system_program: Program<'info, System>,\n}\n\n#[derive(Accounts)]\npub struct Greet {}\n\n#[derive(Accounts)]\npub struct Increment<'info> {\n    #[account(\n        mut,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    pub user: Signer<'info>,\n}\n\n#[account]\npub struct Counter {\n    pub count: u64,\n    pub authority: Pubkey,\n}\n",
+        "starter": "use anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n#[program]\npub mod academy_program {\n    use super::*;\n\n    pub fn initialize(ctx: Context<Initialize>) -> Result<()> {\n        let counter = &mut ctx.accounts.counter;\n        counter.count = 0;\n        counter.authority = ctx.accounts.user.key();\n        msg!(\"Counter initialized!\");\n        Ok(())\n    }\n\n    pub fn greet(_ctx: Context<Greet>) -> Result<()> {\n        msg!(\"Hello, Solana!\");\n        Ok(())\n    }\n\n    // TODO: Add an increment instruction\n}\n\n#[derive(Accounts)]\npub struct Initialize<'info> {\n    #[account(\n        init,\n        payer = user,\n        space = 8 + 8 + 32,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n    pub system_program: Program<'info, System>,\n}\n\n#[derive(Accounts)]\npub struct Greet {}\n\n// TODO: Add an Increment accounts struct with counter (PDA) and user (Signer)\n\n#[account]\npub struct Counter {\n    pub count: u64,\n    pub authority: Pubkey,\n}\n",
         "tests": [
           {
-            "description": "The program compiles against the Anchor 1.x toolchain, with the verification harness intact",
+            "description": "Program compiles successfully",
             "expectedOutput": "true",
-            "id": "compiles",
+            "id": "test-1",
+            "input": ""
+          },
+          {
+            "description": "Code contains an increment function",
+            "expectedOutput": "true",
+            "id": "test-2",
+            "input": ""
+          },
+          {
+            "description": "Increment struct has mut counter",
+            "expectedOutput": "true",
+            "id": "test-3",
             "input": ""
           }
         ],
         "tutorNotes": [
-          "Learners re-use `init` on the vault in the Deposit accounts struct; the account already exists at this point and only needs `mut`.",
-          "They leave `user` as a bare `Signer` without `mut`, carrying over the habit that a non-payer is not mutable — but lamports leave the wallet here, so it must be `mut`.",
-          "They forget `mut` on the vault, so Anchor rejects the instruction at runtime on the mut constraint even though the file compiled.",
-          "They copy a pre-1.0 CPI and pass `system_program.to_account_info()` as the first argument to `CpiContext::new`, which is `error[E0308]: expected Pubkey, found AccountInfo<'_>` — that argument is a program id now.",
-          "They swap `from` and `to` in `Transfer`, which compiles and makes the vault pay the depositor; nothing in a compile-only grader can see it.",
-          "They retype the arithmetic as `vault.balance += amount` instead of calling the Course 2 `vault.deposit(amount)?`, discarding the zero guard, the `checked_add` and the typed `Overflow` error in one line."
+          "Learners re-use `init` on the counter in the Increment accounts struct; the account already exists at this point and only needs `mut`.",
+          "They forget `mut` on the counter, so the compiler rejects `counter.count += 1` or the write never persists.",
+          "They drop the `seeds` + `bump` from the Increment struct, so Anchor stops verifying the account is the caller's own counter PDA.",
+          "They add `system_program` to Increment out of habit — it is only needed when an account is being created, not mutated.",
+          "They borrow the counter immutably with `&ctx.accounts.counter` and then try to mutate it."
         ]
       },
       {
@@ -914,81 +869,67 @@
         "_type": "quiz",
         "questions": [
           {
-            "explanation": "The vault's address is derived from the user's key, so Anchor needs `user` to recompute the seeds and confirm the passed account is that wallet's vault. That check doubles as authorisation. On top of it, `#[account(mut)]` is required of any account whose lamports or data change — and a deposit is lamports leaving this wallet. Same constraint as in `initialize_vault`, different reason for it.",
+            "explanation": "The counter's address is derived from the user's key, so Anchor needs `user` to recompute the seeds and confirm the passed counter is that wallet's PDA. That check doubles as authorization: only the wallet in the seeds can modify its own counter. No lamports move, so `user` is not `mut`.",
             "id": "q1",
             "multiSelect": false,
             "options": [
               {
                 "correct": true,
                 "id": "a",
-                "label": "Anchor re-derives the vault PDA from the user's key to prove the passed account is that wallet's vault — which also authorises only that wallet — and `mut` is required because lamports leave the user's account."
+                "label": "Anchor re-derives the counter PDA from the user's key to verify the passed account is the right one, which also authorizes only that wallet"
               },
               {
                 "correct": false,
-                "feedback": "No rent is paid on a deposit — the vault already exists and its size never changes. The lamports leaving the wallet are the deposit itself, and that is what makes `mut` necessary.",
+                "feedback": "No rent is paid on increment — the account already exists, so `user` is not `mut`. It is present so Anchor can re-derive and check the PDA seeds.",
                 "id": "b",
-                "label": "`user` is `mut` because it pays rent for the deposit."
+                "label": "To pay rent for the increment"
               },
               {
                 "correct": false,
-                "feedback": "Neither half is a rule. Plenty of instructions have no signer at all, and plenty of signers are immutable. `user` is here to re-derive the seeds and to be debited.",
+                "feedback": "Not every instruction needs a signer. Here `user` is required specifically to re-derive the PDA seeds and gate who may modify this counter.",
                 "id": "c",
-                "label": "Because every instruction must include a mutable signer."
-              },
-              {
-                "correct": false,
-                "feedback": "It is needed as a seed *and* as the debited account, and `mut` is load-bearing rather than harmless — drop it and Anchor rejects the instruction at runtime on the mut constraint.",
-                "id": "d",
-                "label": "`user` is only needed as a seed; the `mut` is copied from `InitializeVault` and is harmless."
+                "label": "Because every instruction must have a signer"
               }
             ],
-            "prompt": "`Deposit` includes `user` and the same PDA seeds as `InitializeVault`, but no `init`. Why is `user` needed at all, and why is it `mut` here when nothing is being created?"
+            "prompt": "`Increment` includes the `user: Signer` and the same PDA seeds as `Initialize`, but no `init`. Why is `user` needed here at all?"
           },
           {
-            "explanation": "`init` allocates, funds and assigns a fresh account; you use it exactly once, in `initialize_vault`. Every later instruction operates on the account that already exists, so it uses `mut` plus `seeds` plus `bump = vault.bump` to locate and validate it. Adding `init` back is an attempt to create something at an address already in use. Note also that `init` and `bump = vault.bump` cannot coexist — you cannot read a bump off an account that does not exist yet.",
+            "explanation": "`init` allocates and owns a fresh account; you use it once, in `Initialize`. `increment` operates on the already-created PDA, so it uses `mut` + `seeds` + `bump` to locate and mutate it. Leaving `init` on would attempt a second creation at an address already in use and fail.",
             "id": "q2",
             "multiSelect": false,
             "options": [
               {
                 "correct": true,
                 "id": "a",
-                "label": "It tries to create the account a second time and fails, because the PDA already exists at that address."
+                "label": "It would try to create the account again and fail, because the PDA already exists"
               },
               {
                 "correct": false,
-                "feedback": "`init` does not reset anything — it allocates and assigns a new account. On an address already in use it fails outright rather than silently zeroing your balance.",
+                "feedback": "`init` does not reset — it allocates a new account. On an existing PDA it fails outright ('already in use'), rather than silently zeroing.",
                 "id": "b",
-                "label": "It resets the vault's balance to zero."
+                "label": "It would reset the counter to zero"
               },
               {
                 "correct": false,
-                "feedback": "`init_if_needed` is the idempotent one, and it carries its own re-initialisation hazards. Plain `init` on an existing address is an error.",
+                "feedback": "`init` is not idempotent (that is `init_if_needed`). Re-running `init` on an existing address errors.",
                 "id": "c",
-                "label": "Nothing changes; `init` is idempotent once the account exists."
-              },
-              {
-                "correct": false,
-                "feedback": "There is no fresh account to write to. The seeds are the same, so the derived address is the same address that is already in use — a PDA cannot be created twice.",
-                "id": "d",
-                "label": "The deposit succeeds but writes to a fresh account, leaving the old vault untouched."
+                "label": "Nothing — `init` is idempotent"
               }
             ],
-            "prompt": "A submission copies the whole constraint block over from `InitializeVault` — `init, payer = user, space = 8 + 32 + 8 + 1, seeds = [...], bump` — onto the vault in `Deposit`. It builds green. Predict what happens when the instruction is called on an existing vault."
+            "prompt": "`Increment` uses `#[account(mut, seeds = [...], bump)]` on the counter but drops `init`. What would happen if you left `init` on it?"
           }
         ]
       }
     ],
     "skills": [
-      "cpi",
-      "checked-arithmetic",
       "anchor",
       "solana-programs"
     ],
     "slug": {
       "_type": "slug",
-      "current": "write-the-deposit"
+      "current": "build-increment"
     },
-    "title": "Write the Deposit"
+    "title": "Build the Increment"
   },
   {
     "_id": "lesson-bfsp-complete-counter",
@@ -997,7 +938,7 @@
       {
         "_key": "intro",
         "_type": "prose",
-        "src": "# Withdraw With a PDA Signer\n\n> **Version stamp — checked 2026-07-26.** `anchor-lang 1.1.2` (published 2026-06-26) · `cargo-build-sbf` with platform-tools v1.54 (rustc 1.89) · edition 2021 · System Program and rent behaviour read out of Agave `solana-system-program` 3.1.14 / 4.1.2 and `solana-svm-rent-collector`. Every compiler message quoted below was produced by that toolchain — either by compiling this lesson's file or, where a counter-example is shown, by compiling that counter-example; every runtime message was read from that Agave source, not from memory.\n\nThis lesson is named after the thing everyone reaches for. By the end you will know why the vault does not, in fact, sign its own withdrawal — and exactly where that signature *is* required, because it is a mechanism you will need constantly.\n\nDeposit was easy: the user signed the transaction, and that signature was still valid when the System Program looked at it. Withdrawal has no such luck. The lamports are leaving the *vault*, and the vault has no private key. It is an address that was chosen precisely because no key can produce it.\n\n## The shape you would write\n\nAnchor has an answer for exactly this, and it is real:\n\n```rust\nlet user_key = ctx.accounts.user.key();\nlet signer_seeds: &[&[&[u8]]] = &[&[b\"vault\", user_key.as_ref(), &[ctx.accounts.vault.bump]]];\n\ntransfer(\n    CpiContext::new_with_signer(\n        System::id(),\n        Transfer { from: vault_info, to: user_info },\n        signer_seeds,\n    ),\n    amount,\n)?;\n```\n\n`new_with_signer` takes the seeds and, at the moment of the nested call, the runtime re-derives an address from them **under your program id**. If the result matches the account you are claiming signed, the signature is accepted. No key exists, and none is needed: the derivation *is* the proof, and only your program can produce it because your program id is one of the inputs.\n\nThat is one of the most important primitives on Solana. Learn the shape.\n\nNote the `let user_key = ...` on the first line. `key()` returns a `Pubkey` **by value** and `as_ref()` only borrows it, so the seeds array holds a reference to a temporary. In the exact form above you get away with it even without the binding: the initializer starts with `&`, which triggers temporary lifetime extension, and the `Pubkey` is promoted to live as long as the enclosing block. It compiles either way.\n\nThe moment you split the seeds out into their own array, the extension no longer applies and the temporary dies at the semicolon:\n\n```rust\n// Does NOT compile — no leading `&`, so no lifetime extension.\nlet seeds: [&[u8]; 3] = [b\"vault\", ctx.accounts.user.key().as_ref(), &[ctx.accounts.vault.bump]];\n```\n\n```\nerror[E0716]: temporary value dropped while borrowed\n  |\n  |     let seeds: [&[u8]; 3] = [b\"vault\", ctx.accounts.user.key().as_ref(), ...];\n  |                                        ^^^^^^^^^^^^^^^^^^^^^^^ creates a temporary value\n  |                                        which is freed while still in use\n```\n\nThat refactor is extremely common — two-line seeds are easier to read — so bind the key to a named variable regardless. It costs one line and it is correct in both shapes.\n\n## Why it does not work here\n\nNow the part almost no tutorial tells you. From Agave's System Program, `transfer_verified`:\n\n```rust\nlet mut from = instruction_context.try_borrow_instruction_account(from_account_index)?;\nif !from.get_data().is_empty() {\n    ic_msg!(invoke_context, \"Transfer: `from` must not carry data\");\n    return Err(InstructionError::InvalidArgument);\n}\n```\n\nThe System Program will not send lamports **out of** any account that carries data. Your vault carries 49 bytes of `VaultState`. There is a second, independent reason as well: only the program that *owns* an account may debit it, and your vault is owned by your program, not by the System Program.\n\nSo the code above compiles, passes this course's grading, deploys cleanly, and fails the first time a learner calls it:\n\n```\nTransfer: `from` must not carry data\n```\n\nAuthorisation was never the obstacle. Ownership was. The seeds were solving a problem you did not have.\n\n> Read that sequence again, because it is the most expensive shape of bug in this ecosystem: **compiles, deploys, then fails.** Our own course catalogue specified the broken version of this instruction until it was compiled and checked against the runtime source. Anything you read about Solana — including this — is a claim until you have watched it run.\n\n## What actually moves lamports out\n\nYour program owns the vault. Owners may debit their own accounts directly, with no CPI and nothing to sign:\n\n```rust\n**vault_info.try_borrow_mut_lamports()? = remaining;\n**user_info.try_borrow_mut_lamports()? = credited;\n```\n\nTwo mutable borrows of the runtime's lamport fields, and the runtime reconciles the totals when the instruction ends. If the sums do not balance, the transaction fails — you cannot create lamports this way, only move them between accounts already in the instruction.\n\nThis is not a workaround. It is what Anchor's own `close = destination` constraint does internally, and what every escrow that holds native SOL in a stateful PDA does. `Withdraw` therefore needs no `system_program` in its accounts struct at all: there is no CPI to make.\n\n## The floor you cannot go below\n\nOne more rule, and it is the one people discover in production. Rent collection is gone, but rent *exemption* is enforced at the end of every transaction. From the runtime's rent check, a transition to `RentPaying` is allowed only from `RentPaying`:\n\n```rust\nmatch post_rent_state {\n    RentState::Uninitialized | RentState::RentExempt => true,\n    RentState::RentPaying { .. } => match pre_rent_state {\n        RentState::Uninitialized | RentState::RentExempt => false,\n        // ...\n    }\n}\n```\n\nYour vault starts rent-exempt. Take it below the minimum balance for its 49 bytes and the transition is refused with `TransactionError::InsufficientFundsForRent` — the whole transaction, not just your instruction.\n\nWhich means a vault holding exactly its rent-exempt minimum plus 1 SOL cannot pay out 1 SOL *and* stay alive at the same lamport count. You have to know the floor and check against it:\n\n```rust\nlet rent_floor = Rent::get()?.minimum_balance(vault_info.data_len());\n```\n\n`data_len()` reads the account's real allocated size, so this number stays correct even if the struct grows later. Do not hardcode 49.\n\n## The error, and the one-enum question\n\nThe guard returns `VaultError::InsufficientFunds` — the variant you already wrote in Course 2. Do not add a new error enum for this.\n\nThat advice is usually given as \"Anchor 1.0 allows only one `#[error_code]` per program.\" **That is not true, and it matters that you know why the real reason is worse.** Two `#[error_code]` enums in one program compile without complaint — this was verified on the same toolchain that grades you. What happens instead is silent:\n\n```rust\nimpl From<VaultError> for u32 {\n    fn from(e: VaultError) -> u32 { e as u32 + ERROR_CODE_OFFSET }   // 6000\n}\n```\n\nEvery `#[error_code]` enum starts counting at the same `ERROR_CODE_OFFSET` of 6000 unless you pass an explicit offset. So a second enum's first variant is *also* error code 6000, and a client that receives 6000 has no way to tell `VaultError::Overflow` from `SomeOtherError::Whatever`. You have not gained a type; you have gained a collision, and the compiler is happy about it.\n\nOne enum, four variants, already written, already carrying `InsufficientFunds`. Use it.\n\n## The exercise\n\nCompletion, not a blank page. The accounts struct is given, the two `AccountInfo` bindings are given, and ten candidate lines sit in a comment block at the top. Eight belong in the file. Two do not, and one of those two is the CPI you just read about — present on purpose, because reaching for it is the correct instinct and rejecting it is the lesson.\n"
+        "src": "# Capstone: Complete Counter Program\n\nThis is the capstone challenge. Build the complete counter program with:\n- `initialize` — create the counter PDA, set to 0\n- `increment` — add 1\n- `decrement` — subtract 1, with underflow protection\n\n## Requirements\n\n1. Add a `decrement` instruction that subtracts 1 from `counter.count`\n2. Use `require!(counter.count > 0, ErrorCode::Underflow)` to prevent underflow\n3. Add a `Decrement` accounts struct (same shape as `Increment` — PDA counter + user Signer)\n4. Define a custom `ErrorCode` enum with an `Underflow` variant\n\n## Custom Error Enum\n\nAnchor uses `#[error_code]` to define program-specific errors:\n\n```rust\n#[error_code]\npub enum ErrorCode {\n    #[msg(\"Cannot decrement below zero\")]\n    Underflow,\n}\n```\n\nThe `#[msg]` attribute provides the human-readable error message.\n\n## This Is It\n\nWhen this compiles, you've built a real Solana program from scratch using PDAs — the production-standard pattern. The next lesson covers deployment.\n"
       },
       {
         "_key": "exercise",
@@ -1005,28 +946,39 @@
         "buildType": "buildable",
         "deployable": false,
         "hints": [
-          "Build before you change anything. One error comes back: `error[E0308]: mismatched types — expected Result<(), Error>, found ()`, pointing at `withdraw`'s return type with the note `implicitly returns () as its body has no tail`. An empty body evaluates to `()`, so one of the ten pool lines is simply `Ok(())` and it goes last.",
-          "Work out the dependencies before the order. `rent_floor` and `remaining` are both `let` bindings that a later line reads, and `remaining` has to exist before the guard that compares it. The guard has to run before any lamport is touched, and the Course 2 method has to run before anything at all — if the recorded balance cannot cover the amount, nothing else should happen.",
-          "Two lines belong nowhere. (9) is the `new_with_signer` CPI: add a `signer_seeds` binding and it compiles, deploys, and returns `Transfer: 'from' must not carry data`, because the System Program will not debit a data-carrying account and does not own your vault. (10) does bare subtraction with no floor check — under `overflow-checks = true` it panics instead of returning `InsufficientFunds`."
+          "The decrement function is almost identical to increment, but starts with `require!(counter.count > 0, ErrorCode::Underflow);`",
+          "The Decrement accounts struct is the same shape as Increment — counter with PDA seeds and user as Signer",
+          "Don't forget `#[error_code]` on the enum and `#[msg(\"Cannot decrement below zero\")]` on the Underflow variant"
         ],
         "language": "rust",
-        "solution": "// Exercise complete.\n//\n// Pool order is (1), (2), (3), (4), (5), (6), (7), (8). Lines (9) and (10)\n// belong nowhere:\n//\n//   (9)  is the CPI everyone reaches for. Give it a `signer_seeds` binding and\n//        it compiles, deploys, and then returns `Transfer: 'from' must not carry\n//        data` — the System Program refuses to debit any account with a\n//        non-empty data field, and it does not own our vault anyway. Signer\n//        seeds solve authorisation; authorisation was never the obstacle.\n//\n//  (10)  drops the rent floor and does bare subtraction. Under this crate's\n//        `overflow-checks = true` it panics instead of returning\n//        `InsufficientFunds`, and even when it does not underflow it will happily\n//        take the vault below its rent-exempt minimum, failing the entire\n//        transaction with `InsufficientFundsForRent`.\n//\n// Note what is NOT in this file: no `checked_sub` on `balance` (that is the\n// Course 2 method), no second `#[error_code]` enum, and no `system_program` in\n// `Withdraw`, because there is no CPI to make.\n\nuse anchor_lang::prelude::*;\nuse anchor_lang::system_program::{transfer, Transfer};\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n// ─── Your Course 2 core, imported unchanged. Do not edit it. ─────────────────\npub mod vault {\n    use super::*;\n\n    #[account]\n    #[derive(InitSpace)]\n    pub struct VaultState {\n        pub owner: Pubkey,\n        pub balance: u64,\n        pub bump: u8,\n    }\n\n    #[error_code]\n    pub enum VaultError {\n        #[msg(\"Deposit would overflow the vault balance\")]\n        Overflow,\n        #[msg(\"Withdrawal is larger than the vault balance\")]\n        InsufficientFunds,\n        #[msg(\"Amount must be greater than zero\")]\n        ZeroAmount,\n        #[msg(\"Signer is not the vault owner\")]\n        NotOwner,\n    }\n\n    impl VaultState {\n        pub fn deposit(&mut self, amount: u64) -> Result<()> {\n            require!(amount > 0, VaultError::ZeroAmount);\n            self.balance = self\n                .balance\n                .checked_add(amount)\n                .ok_or(VaultError::Overflow)?;\n            Ok(())\n        }\n\n        pub fn withdraw(&mut self, amount: u64) -> Result<()> {\n            require!(amount > 0, VaultError::ZeroAmount);\n            self.balance = self\n                .balance\n                .checked_sub(amount)\n                .ok_or(VaultError::InsufficientFunds)?;\n            Ok(())\n        }\n    }\n}\n\npub use vault::{VaultError, VaultState};\n\n#[program]\npub mod vault_program {\n    use super::*;\n\n    pub fn initialize_vault(ctx: Context<InitializeVault>) -> Result<()> {\n        let vault = &mut ctx.accounts.vault;\n        vault.owner = ctx.accounts.user.key();\n        vault.balance = 0;\n        vault.bump = ctx.bumps.vault;\n        Ok(())\n    }\n\n    pub fn deposit(ctx: Context<Deposit>, amount: u64) -> Result<()> {\n        transfer(\n            CpiContext::new(\n                System::id(),\n                Transfer {\n                    from: ctx.accounts.user.to_account_info(),\n                    to: ctx.accounts.vault.to_account_info(),\n                },\n            ),\n            amount,\n        )?;\n        ctx.accounts.vault.deposit(amount)?;\n        Ok(())\n    }\n\n    pub fn withdraw(ctx: Context<Withdraw>, amount: u64) -> Result<()> {\n        let vault_info = ctx.accounts.vault.to_account_info();\n        let user_info = ctx.accounts.user.to_account_info();\n\n        // (1) Bookkeeping first, and it is the Course 2 method — the zero guard,\n        // the `checked_sub` and `InsufficientFunds` all live inside it. If the\n        // vault's recorded balance cannot cover `amount`, nothing below runs.\n        ctx.accounts.vault.withdraw(amount)?;\n\n        // (2) The floor. `data_len()` reads the account's real allocated size,\n        // so this stays correct if `VaultState` ever grows. Never hardcode 49.\n        let rent_floor = Rent::get()?.minimum_balance(vault_info.data_len());\n\n        // (3) What the vault would hold afterwards, computed without trusting\n        // subtraction not to underflow.\n        let remaining = vault_info\n            .lamports()\n            .checked_sub(amount)\n            .ok_or(VaultError::InsufficientFunds)?;\n\n        // (4) The guard, before a single lamport moves. Below the floor, the\n        // runtime refuses the whole transaction with `InsufficientFundsForRent`\n        // — so we refuse it first, with an error the caller can read.\n        require!(remaining >= rent_floor, VaultError::InsufficientFunds);\n\n        // (5) Our program owns the vault, so our program may debit it. No CPI,\n        // nothing to sign.\n        **vault_info.try_borrow_mut_lamports()? = remaining;\n\n        // (6) and (7) The credit, also checked.\n        let credited = user_info\n            .lamports()\n            .checked_add(amount)\n            .ok_or(VaultError::Overflow)?;\n        **user_info.try_borrow_mut_lamports()? = credited;\n\n        // (8)\n        Ok(())\n    }\n}\n\n#[derive(Accounts)]\npub struct InitializeVault<'info> {\n    #[account(\n        init,\n        payer = user,\n        space = 8 + 32 + 8 + 1,\n        seeds = [b\"vault\", user.key().as_ref()],\n        bump\n    )]\n    pub vault: Account<'info, VaultState>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n    pub system_program: Program<'info, System>,\n}\n\n#[derive(Accounts)]\npub struct Deposit<'info> {\n    #[account(\n        mut,\n        seeds = [b\"vault\", user.key().as_ref()],\n        bump = vault.bump\n    )]\n    pub vault: Account<'info, VaultState>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n    pub system_program: Program<'info, System>,\n}\n\n// GIVEN. Two things to notice before you start.\n//\n//   * `constraint = vault.owner == user.key()` is what finally spends the\n//     `owner` field you have been carrying since Course 2, and it returns\n//     `NotOwner` — the fourth variant, previously unused.\n//   * there is no `system_program` here. `Withdraw` makes no CPI, so there is no\n//     callee program for the runtime to load. If your answer needs it, your\n//     answer is the wrong one.\n#[derive(Accounts)]\npub struct Withdraw<'info> {\n    #[account(\n        mut,\n        seeds = [b\"vault\", user.key().as_ref()],\n        bump = vault.bump,\n        constraint = vault.owner == user.key() @ VaultError::NotOwner\n    )]\n    pub vault: Account<'info, VaultState>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n}\n\n// ─────────────────────────────────────────────────────────────────────────────\n// VERIFICATION HARNESS — DO NOT EDIT ANYTHING BELOW THIS LINE.\n//\n// It pins the signature of `withdraw` and the fields of `Withdraw`, and nothing\n// else. It is a TYPE check, not a behaviour check. Ways to be wrong and still be\n// green, each one confirmed by compiling it:\n//   * pool line (9), which needs no more than a `signer_seeds` binding to\n//     compile, deploys fine, and returns `Transfer: 'from' must not carry data`\n//     the first time anyone calls it\n//   * pool line (10), which drops the rent floor and panics under\n//     `overflow-checks = true` instead of returning `InsufficientFunds`\n//   * crediting the user without debiting the vault, which the runtime catches\n//     at the end of the instruction — but not until it runs\n// The build server compiles; it does not run. Module 4 shows you the LiteSVM\n// test that would execute this program and catch the above, and why compiling\n// cannot — read it before any devnet SOL is spent.\n// ─────────────────────────────────────────────────────────────────────────────\n#[doc(hidden)]\n#[allow(dead_code)]\nmod verify {\n    use super::*;\n\n    const WITHDRAW: for<'info> fn(Context<'info, Withdraw<'info>>, u64) -> Result<()> =\n        vault_program::withdraw;\n\n    fn pin_withdraw_accounts(a: &Withdraw) {\n        let _: &Account<VaultState> = &a.vault;\n        let _: &Signer = &a.user;\n    }\n\n    // The Course 2 core is intact and still owns the arithmetic.\n    const CORE_WITHDRAW: fn(&mut VaultState, u64) -> Result<()> = VaultState::withdraw;\n\n    // All four variants still exist, including the one this lesson finally uses.\n    fn errors() -> [anchor_lang::error::Error; 4] {\n        [\n            VaultError::Overflow.into(),\n            VaultError::InsufficientFunds.into(),\n            VaultError::ZeroAmount.into(),\n            VaultError::NotOwner.into(),\n        ]\n    }\n}\n",
-        "starter": "// Complete `withdraw`.\n//\n// The accounts struct is written. The two `AccountInfo` bindings are written.\n// Below are ten candidate lines. EIGHT of them belong in this file, in an order\n// you have to work out. The other two compile — or all but compile — and are\n// still wrong, and a compile-only grader cannot tell the difference. That is the\n// point of asking you.\n//\n//   (1)  ctx.accounts.vault.withdraw(amount)?;\n//   (2)  let rent_floor = Rent::get()?.minimum_balance(vault_info.data_len());\n//   (3)  let remaining = vault_info.lamports().checked_sub(amount).ok_or(VaultError::InsufficientFunds)?;\n//   (4)  require!(remaining >= rent_floor, VaultError::InsufficientFunds);\n//   (5)  **vault_info.try_borrow_mut_lamports()? = remaining;\n//   (6)  let credited = user_info.lamports().checked_add(amount).ok_or(VaultError::Overflow)?;\n//   (7)  **user_info.try_borrow_mut_lamports()? = credited;\n//   (8)  Ok(())\n//   (9)  transfer(CpiContext::new_with_signer(System::id(), Transfer { from: vault_info.clone(), to: user_info.clone() }, signer_seeds), amount)?;\n//  (10)  **vault_info.try_borrow_mut_lamports()? -= amount;\n//\n// Order matters. Three of the eight read a value another one of them has to have\n// produced first, and the guard has to run before any lamport is touched.\n//\n// This file does NOT compile as shipped. Build it first — an empty body\n// evaluates to `()`, and the signature promises `Result<()>`.\n\nuse anchor_lang::prelude::*;\nuse anchor_lang::system_program::{transfer, Transfer};\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n// ─── Your Course 2 core, imported unchanged. Do not edit it. ─────────────────\npub mod vault {\n    use super::*;\n\n    #[account]\n    #[derive(InitSpace)]\n    pub struct VaultState {\n        pub owner: Pubkey,\n        pub balance: u64,\n        pub bump: u8,\n    }\n\n    #[error_code]\n    pub enum VaultError {\n        #[msg(\"Deposit would overflow the vault balance\")]\n        Overflow,\n        #[msg(\"Withdrawal is larger than the vault balance\")]\n        InsufficientFunds,\n        #[msg(\"Amount must be greater than zero\")]\n        ZeroAmount,\n        #[msg(\"Signer is not the vault owner\")]\n        NotOwner,\n    }\n\n    impl VaultState {\n        pub fn deposit(&mut self, amount: u64) -> Result<()> {\n            require!(amount > 0, VaultError::ZeroAmount);\n            self.balance = self\n                .balance\n                .checked_add(amount)\n                .ok_or(VaultError::Overflow)?;\n            Ok(())\n        }\n\n        pub fn withdraw(&mut self, amount: u64) -> Result<()> {\n            require!(amount > 0, VaultError::ZeroAmount);\n            self.balance = self\n                .balance\n                .checked_sub(amount)\n                .ok_or(VaultError::InsufficientFunds)?;\n            Ok(())\n        }\n    }\n}\n\npub use vault::{VaultError, VaultState};\n\n#[program]\npub mod vault_program {\n    use super::*;\n\n    pub fn initialize_vault(ctx: Context<InitializeVault>) -> Result<()> {\n        let vault = &mut ctx.accounts.vault;\n        vault.owner = ctx.accounts.user.key();\n        vault.balance = 0;\n        vault.bump = ctx.bumps.vault;\n        Ok(())\n    }\n\n    pub fn deposit(ctx: Context<Deposit>, amount: u64) -> Result<()> {\n        transfer(\n            CpiContext::new(\n                System::id(),\n                Transfer {\n                    from: ctx.accounts.user.to_account_info(),\n                    to: ctx.accounts.vault.to_account_info(),\n                },\n            ),\n            amount,\n        )?;\n        ctx.accounts.vault.deposit(amount)?;\n        Ok(())\n    }\n\n    pub fn withdraw(ctx: Context<Withdraw>, amount: u64) -> Result<()> {\n        let vault_info = ctx.accounts.vault.to_account_info();\n        let user_info = ctx.accounts.user.to_account_info();\n\n        // Eight lines from the pool, in order.\n    }\n}\n\n#[derive(Accounts)]\npub struct InitializeVault<'info> {\n    #[account(\n        init,\n        payer = user,\n        space = 8 + 32 + 8 + 1,\n        seeds = [b\"vault\", user.key().as_ref()],\n        bump\n    )]\n    pub vault: Account<'info, VaultState>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n    pub system_program: Program<'info, System>,\n}\n\n#[derive(Accounts)]\npub struct Deposit<'info> {\n    #[account(\n        mut,\n        seeds = [b\"vault\", user.key().as_ref()],\n        bump = vault.bump\n    )]\n    pub vault: Account<'info, VaultState>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n    pub system_program: Program<'info, System>,\n}\n\n// GIVEN. Two things to notice before you start.\n//\n//   * `constraint = vault.owner == user.key()` is what finally spends the\n//     `owner` field you have been carrying since Course 2, and it returns\n//     `NotOwner` — the fourth variant, previously unused.\n//   * there is no `system_program` here. `Withdraw` makes no CPI, so there is no\n//     callee program for the runtime to load. If your answer needs it, your\n//     answer is the wrong one.\n#[derive(Accounts)]\npub struct Withdraw<'info> {\n    #[account(\n        mut,\n        seeds = [b\"vault\", user.key().as_ref()],\n        bump = vault.bump,\n        constraint = vault.owner == user.key() @ VaultError::NotOwner\n    )]\n    pub vault: Account<'info, VaultState>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n}\n\n// ─────────────────────────────────────────────────────────────────────────────\n// VERIFICATION HARNESS — DO NOT EDIT ANYTHING BELOW THIS LINE.\n//\n// It pins the signature of `withdraw` and the fields of `Withdraw`, and nothing\n// else. It is a TYPE check, not a behaviour check. Ways to be wrong and still be\n// green, each one confirmed by compiling it:\n//   * pool line (9), which needs no more than a `signer_seeds` binding to\n//     compile, deploys fine, and returns `Transfer: 'from' must not carry data`\n//     the first time anyone calls it\n//   * pool line (10), which drops the rent floor and panics under\n//     `overflow-checks = true` instead of returning `InsufficientFunds`\n//   * crediting the user without debiting the vault, which the runtime catches\n//     at the end of the instruction — but not until it runs\n// The build server compiles; it does not run. Module 4 shows you the LiteSVM\n// test that would execute this program and catch the above, and why compiling\n// cannot — read it before any devnet SOL is spent.\n// ─────────────────────────────────────────────────────────────────────────────\n#[doc(hidden)]\n#[allow(dead_code)]\nmod verify {\n    use super::*;\n\n    const WITHDRAW: for<'info> fn(Context<'info, Withdraw<'info>>, u64) -> Result<()> =\n        vault_program::withdraw;\n\n    fn pin_withdraw_accounts(a: &Withdraw) {\n        let _: &Account<VaultState> = &a.vault;\n        let _: &Signer = &a.user;\n    }\n\n    // The Course 2 core is intact and still owns the arithmetic.\n    const CORE_WITHDRAW: fn(&mut VaultState, u64) -> Result<()> = VaultState::withdraw;\n\n    // All four variants still exist, including the one this lesson finally uses.\n    fn errors() -> [anchor_lang::error::Error; 4] {\n        [\n            VaultError::Overflow.into(),\n            VaultError::InsufficientFunds.into(),\n            VaultError::ZeroAmount.into(),\n            VaultError::NotOwner.into(),\n        ]\n    }\n}\n",
+        "solution": "use anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n#[program]\npub mod academy_program {\n    use super::*;\n\n    pub fn initialize(ctx: Context<Initialize>) -> Result<()> {\n        let counter = &mut ctx.accounts.counter;\n        counter.count = 0;\n        counter.authority = ctx.accounts.user.key();\n        msg!(\"Counter initialized!\");\n        Ok(())\n    }\n\n    pub fn greet(_ctx: Context<Greet>) -> Result<()> {\n        msg!(\"Hello, Solana!\");\n        Ok(())\n    }\n\n    pub fn increment(ctx: Context<Increment>) -> Result<()> {\n        let counter = &mut ctx.accounts.counter;\n        counter.count += 1;\n        Ok(())\n    }\n\n    pub fn decrement(ctx: Context<Decrement>) -> Result<()> {\n        let counter = &mut ctx.accounts.counter;\n        require!(counter.count > 0, ErrorCode::Underflow);\n        counter.count -= 1;\n        Ok(())\n    }\n}\n\n#[derive(Accounts)]\npub struct Initialize<'info> {\n    #[account(\n        init,\n        payer = user,\n        space = 8 + 8 + 32,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n    pub system_program: Program<'info, System>,\n}\n\n#[derive(Accounts)]\npub struct Greet {}\n\n#[derive(Accounts)]\npub struct Increment<'info> {\n    #[account(\n        mut,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    pub user: Signer<'info>,\n}\n\n#[derive(Accounts)]\npub struct Decrement<'info> {\n    #[account(\n        mut,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    pub user: Signer<'info>,\n}\n\n#[account]\npub struct Counter {\n    pub count: u64,\n    pub authority: Pubkey,\n}\n\n#[error_code]\npub enum ErrorCode {\n    #[msg(\"Cannot decrement below zero\")]\n    Underflow,\n}\n",
+        "starter": "use anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n#[program]\npub mod academy_program {\n    use super::*;\n\n    pub fn initialize(ctx: Context<Initialize>) -> Result<()> {\n        let counter = &mut ctx.accounts.counter;\n        counter.count = 0;\n        counter.authority = ctx.accounts.user.key();\n        msg!(\"Counter initialized!\");\n        Ok(())\n    }\n\n    pub fn greet(_ctx: Context<Greet>) -> Result<()> {\n        msg!(\"Hello, Solana!\");\n        Ok(())\n    }\n\n    pub fn increment(ctx: Context<Increment>) -> Result<()> {\n        let counter = &mut ctx.accounts.counter;\n        counter.count += 1;\n        Ok(())\n    }\n\n    // TODO: Add a decrement instruction with underflow protection\n}\n\n#[derive(Accounts)]\npub struct Initialize<'info> {\n    #[account(\n        init,\n        payer = user,\n        space = 8 + 8 + 32,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n    pub system_program: Program<'info, System>,\n}\n\n#[derive(Accounts)]\npub struct Greet {}\n\n#[derive(Accounts)]\npub struct Increment<'info> {\n    #[account(\n        mut,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    pub user: Signer<'info>,\n}\n\n// TODO: Add a Decrement accounts struct (same as Increment)\n\n#[account]\npub struct Counter {\n    pub count: u64,\n    pub authority: Pubkey,\n}\n\n// TODO: Add a custom ErrorCode enum with Underflow variant\n",
         "tests": [
           {
-            "description": "The program compiles against the Anchor 1.x toolchain, with the verification harness intact",
+            "description": "Program compiles successfully",
             "expectedOutput": "true",
-            "id": "compiles",
+            "id": "test-1",
+            "input": ""
+          },
+          {
+            "description": "Code contains decrement function with underflow check",
+            "expectedOutput": "true",
+            "id": "test-2",
+            "input": ""
+          },
+          {
+            "description": "Custom ErrorCode enum is defined",
+            "expectedOutput": "true",
+            "id": "test-3",
             "input": ""
           }
         ],
         "tutorNotes": [
-          "Learners reach for `CpiContext::new_with_signer` and a System `transfer` out of the vault. It compiles and deploys; on-chain it returns `Transfer: 'from' must not carry data`. The vault is owned by their program and holds 49 bytes, so the System Program will not debit it.",
-          "They debit the vault with no rent-floor check. It works while the vault is well funded and then fails the whole transaction with `InsufficientFundsForRent` once the balance nears the minimum for 49 bytes.",
-          "They hardcode 49 in `minimum_balance(...)` instead of `vault_info.data_len()`, which silently goes wrong the moment `VaultState` gains a field.",
-          "They retype `checked_sub` on `vault.balance` instead of calling the Course 2 `vault.withdraw(amount)?`, so the zero guard and the typed error are quietly dropped.",
-          "They add a second `#[error_code]` enum for the rent case. It compiles — both enums start at `ERROR_CODE_OFFSET` 6000, so the two first variants share error code 6000 and the client cannot tell them apart.",
-          "They add `system_program` to the Withdraw accounts struct out of habit. There is no CPI in this instruction, so there is no callee program for the runtime to load."
+          "Learners subtract before checking, so a decrement at zero underflows the `u64` and panics instead of returning the custom error.",
+          "They guard with `count >= 0`, which is always true for an unsigned integer and stops nothing — the meaningful check is strictly greater than zero.",
+          "They define the error enum but omit the `#[error_code]` attribute, so `require!` will not accept the variant.",
+          "They give the Decrement accounts struct different PDA seeds than Increment, so it resolves a different account than the one they initialized.",
+          "They handle the zero case by returning `Ok(())` and doing nothing, silently swallowing the error instead of surfacing it to the caller."
         ]
       },
       {
@@ -1034,254 +986,67 @@
         "_type": "quiz",
         "questions": [
           {
-            "explanation": "The rent check compares an account's state before and after the transaction, and a transition from `RentExempt` to `RentPaying` is refused. So the failure is real, it is transaction-wide, and it arrives as an opaque runtime error. Checking the floor yourself with `Rent::get()?.minimum_balance(vault_info.data_len())` is how the caller finds out what they actually did wrong.",
+            "explanation": "`require!` returns the custom error and aborts the instruction when the condition is false, so a decrement at zero fails and leaves state untouched. This is the on-chain defense against u64 underflow wrapping 0 into a near-limitless value — a real class of bug.",
             "id": "q1",
             "multiSelect": false,
             "options": [
               {
                 "correct": true,
                 "id": "a",
-                "label": "The whole transaction fails with `TransactionError::InsufficientFundsForRent` — nothing moves, and the caller gets a runtime error instead of your typed `InsufficientFunds`."
+                "label": "The instruction returns the Underflow error, the transaction fails, and no state changes"
               },
               {
                 "correct": false,
-                "feedback": "Rent *collection* is gone; rent *exemption* is still enforced at the end of every transaction. A rent-exempt account is not allowed to become rent-paying, which is exactly the transition this attempts.",
+                "feedback": "That is exactly what the guard prevents. Without `require!`, subtracting 1 from 0 on a u64 would underflow-wrap; with it, the instruction fails cleanly and count stays 0.",
                 "id": "b",
-                "label": "It succeeds. Rent collection was removed from Solana, so a low balance no longer matters."
+                "label": "count wraps around to a huge u64 value"
               },
               {
                 "correct": false,
-                "feedback": "Nothing closes accounts implicitly. Closing is a deliberate act — zero the lamports and hand back the data — and a partial drop below the minimum is refused rather than converted into one.",
+                "feedback": "A `u64` cannot hold -1. Unguarded subtraction would wrap to a huge number; the `require!` guard rejects the call instead.",
                 "id": "c",
-                "label": "It succeeds, and the account is closed automatically once it drops below the minimum."
-              },
-              {
-                "correct": false,
-                "feedback": "The runtime knows nothing about your enum. That mapping is the guard you just deleted — its whole job is to convert a runtime rejection you cannot label into an error the caller can read.",
-                "id": "d",
-                "label": "The instruction returns `VaultError::InsufficientFunds`, since the runtime maps the rent failure onto your error enum."
+                "label": "count goes to -1"
               }
             ],
-            "prompt": "A submission drops the `require!(remaining >= rent_floor, ...)` guard and debits the vault directly. A user then withdraws an amount that would leave the vault with fewer lamports than the rent-exempt minimum for its 49 bytes. Predict the outcome."
+            "prompt": "`decrement` guards with `require!(counter.count > 0, ErrorCode::Underflow)`. What happens when a user calls decrement while count is 0?"
           },
           {
-            "explanation": "One enum per program is the right *practice*, but not for the reason usually given. `#[error_code]` generates `impl From<Enum> for u32 { e as u32 + ERROR_CODE_OFFSET }`, and `ERROR_CODE_OFFSET` is 6000 for every enum, so a second enum's variants shadow the first enum's codes one for one. Course 2's `VaultError` already has `InsufficientFunds`; reuse it.",
+            "explanation": "`#[error_code]` turns the enum into Anchor program errors with stable codes, and `#[msg]` attaches the readable string returned to clients on failure. Combined with `require!`, your program enforces its own rules and explains violations to the caller.",
             "id": "q2",
             "multiSelect": false,
             "options": [
               {
                 "correct": true,
                 "id": "a",
-                "label": "It compiles — and both enums start at `ERROR_CODE_OFFSET`, so `BelowRentFloor` and `VaultError::Overflow` are both error code 6000 and no client can tell them apart."
+                "label": "A program-specific error whose human-readable message is surfaced to clients when the instruction fails"
               },
               {
                 "correct": false,
-                "feedback": "This is the version of the rule you will read almost everywhere, and it is wrong — verified on the toolchain that grades you. Lessons 2 and 3 told you to keep one enum, and that advice stands; what they were careful not to say is that the compiler enforces it. It does not. Two enums compile silently, which is worse than a compile error, because the collision only shows up in a client trying to interpret code 6000.",
+                "feedback": "The compiler does not prove that — the runtime `require!` does. `#[error_code]` and `#[msg]` just define the error and the message clients see.",
                 "id": "b",
-                "label": "It fails to compile. Anchor 1.0 permits only one `#[error_code]` enum per program."
+                "label": "A compile-time check that count never underflows"
               },
               {
                 "correct": false,
-                "feedback": "There is no automatic offsetting. `impl From<E> for u32` adds the same `ERROR_CODE_OFFSET` for every enum; you have to pass an offset yourself with `#[error_code(offset = ...)]` if you really want two.",
+                "feedback": "There is no automatic retry. The macros define a typed error and message; the transaction simply fails and the client reads the message.",
                 "id": "c",
-                "label": "It compiles, and Anchor offsets the second enum automatically so the codes stay distinct."
-              },
-              {
-                "correct": false,
-                "feedback": "Both enums are emitted. The problem is not absence, it is ambiguity — two different names claiming the same number.",
-                "id": "d",
-                "label": "It compiles but the second enum is stripped from the IDL, so clients see nothing at all."
+                "label": "Automatic retry of the failed instruction"
               }
             ],
-            "prompt": "Wanting a clearer message for the rent case, a submission adds `#[error_code] pub enum WithdrawError { #[msg(\"Would break rent exemption\")] BelowRentFloor }` alongside the Course 2 `VaultError`. Predict the outcome."
-          },
-          {
-            "explanation": "A CPI needs its callee present in the transaction, so `deposit` declares the System Program. `withdraw` asks no other program for anything — your program owns the vault, and owners may move their own accounts' lamports with `try_borrow_mut_lamports`. If your answer to `withdraw` needed the System Program, it was the wrong answer.",
-            "id": "q3",
-            "multiSelect": false,
-            "options": [
-              {
-                "correct": true,
-                "id": "a",
-                "label": "`deposit` makes a CPI and the runtime must have the callee's program account loaded; `withdraw` makes no CPI, because a program may debit an account it owns directly."
-              },
-              {
-                "correct": false,
-                "feedback": "`withdraw` mutates two lamport balances and the vault's data — it is about as far from read-only as an instruction gets. The reason is the absence of a CPI, not the absence of writes.",
-                "id": "b",
-                "label": "Because `withdraw` is a read-only instruction and read-only instructions never need the System Program."
-              },
-              {
-                "correct": false,
-                "feedback": "Anchor never injects accounts. Anything the instruction needs must be declared, which is why omitting it from an `init` instruction gives you a trait-bound error rather than working silently.",
-                "id": "c",
-                "label": "Anchor injects the System Program automatically for instructions that only move lamports."
-              },
-              {
-                "correct": false,
-                "feedback": "Nothing signs in `withdraw`. That is the lesson: the seeds would have proved authorisation, and authorisation was never what was missing.",
-                "id": "d",
-                "label": "Because the vault signs for itself in `withdraw`, replacing the need for the System Program."
-              }
-            ],
-            "prompt": "`Deposit` declares `system_program: Program<'info, System>` and `Withdraw` does not. Why is the asymmetry correct?"
+            "prompt": "What does `#[error_code]` on the `ErrorCode` enum plus `#[msg]` on the `Underflow` variant give you?"
           }
         ]
       }
     ],
     "skills": [
-      "pdas",
-      "cpi",
-      "program-errors",
-      "checked-arithmetic"
+      "anchor",
+      "solana-programs"
     ],
     "slug": {
       "_type": "slug",
-      "current": "withdraw-with-a-pda-signer"
+      "current": "complete-counter-program"
     },
-    "title": "Withdraw With a PDA Signer"
-  },
-  {
-    "_id": "lesson-bfsp-cpi-lamports",
-    "_type": "lesson",
-    "blocks": [
-      {
-        "_key": "intro",
-        "_type": "prose",
-        "src": "# CPI: Moving Real Lamports\n\n> **Version stamp — checked 2026-07-26.** `anchor-lang 1.1.2` (published 2026-06-26) · `cargo-build-sbf` with platform-tools v1.54 (rustc 1.89) · edition 2021 · System Program behaviour read out of Agave `solana-system-program` 3.1.14 and 4.1.2. Every compiler message and every runtime log quoted below was produced by compiling this lesson's file, or read verbatim from that Agave source.\n\nYour vault has a `balance` field. So far that field is a claim: it says how much the vault holds, and nothing enforces it. Nobody has moved a lamport.\n\nThis lesson is the one where the claim becomes true. You will read a finished `deposit` — not write it — and by the end you should be able to say exactly which program moved the money, who authorised it, and why the code looks the way it does rather than the way every tutorial written before Anchor 1.0 says it should.\n\n## Your program cannot move lamports\n\nNot the user's, anyway. An account's lamports may only be **debited by the program that owns the account**. The user's wallet is owned by the System Program, so the System Program is the only thing on the chain that can take lamports out of it.\n\nThat is not a limitation to work around. It is the whole security model: if any program could debit any account, a signature would mean nothing.\n\nSo `deposit` does not move lamports. It **asks** the System Program to. That request is a **cross-program invocation** — a CPI.\n\n## What composability actually buys you\n\nThe reason this matters beyond your vault: almost nothing on Solana is self-contained. A program that wants to move SOL calls the System Program. One that wants to move tokens calls the Token program. One that wants to price a swap calls an AMM, which calls the Token program twice. Each of those programs was audited once and is now reused by everyone, which is why a 200-line program can do something a 20,000-line program would otherwise have to.\n\nYour vault is the smallest honest example of that: about six lines of CPI, and it inherits every lamport-accounting guarantee the System Program has.\n\n## The call stack, and how far down it goes\n\nA CPI is a nested instruction. The runtime keeps a stack:\n\n```\ntransaction\n  └─ instruction 1: deposit          ← your program, stack depth 1\n       └─ CPI: System Program transfer  ← stack depth 2\n```\n\nThe ceiling is a constant in the runtime, `MAX_INSTRUCTION_STACK_DEPTH = 5`. Your top-level instruction occupies the first slot, so you get **four levels of nesting below you**. Deep call chains are a real constraint in composed DeFi; for a vault it is not close to a concern. Worth knowing the constant's name so you can check it yourself rather than trusting a blog post — the number has been proposed for a raise more than once.\n\n## Signer propagation: nobody signs twice\n\nHere is the part that surprises people. `transfer` needs the source account to have signed. The user signed the *transaction*. Does the signature reach the CPI?\n\nYes. Signatures established at the top of the transaction stay valid all the way down the stack. Your program does not re-sign, cannot re-sign, and does not need to. It hands the System Program a `from` account that is already marked as a signer, and the System Program sees a signer.\n\nThat single fact is why `deposit` is easy and why the next lesson is hard. Withdrawal needs *the vault* to authorise something, and the vault never signed anything — it has no private key to sign with.\n\n## The Anchor 1.0 `CpiContext`, and the one line the internet gets wrong\n\nA CPI in Anchor is two values: which accounts, and which program.\n\n```rust\ntransfer(\n    CpiContext::new(\n        System::id(),\n        Transfer {\n            from: ctx.accounts.user.to_account_info(),\n            to: ctx.accounts.vault.to_account_info(),\n        },\n    ),\n    amount,\n)?;\n```\n\nLook at the first argument to `CpiContext::new`. It is a **program id** — a `Pubkey`. In `anchor-lang` 1.1.2 the signature is:\n\n```rust\npub fn new(program_id: Pubkey, accounts: T) -> Self\n```\n\nEvery CPI tutorial published before Anchor 1.0 — including the earlier version of this course — passes an `AccountInfo` instead:\n\n```rust\n// pre-1.0. Does not compile against anchor-lang 1.x.\nCpiContext::new(ctx.accounts.system_program.to_account_info(), cpi_accounts)\n```\n\nPaste that into this lesson's file and the build server says:\n\n```\nerror[E0308]: mismatched types\n   |\n   |                 ctx.accounts.system_program.to_account_info(),\n   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Pubkey`, found `AccountInfo<'_>`\n```\n\nThis is the single most common stale snippet in Solana material, and it is a *good* break: it fails loudly at compile time instead of quietly at runtime. When your copy-paste from a 2024 blog post fails this way, you now know why.\n\nTwo details that follow from the new shape:\n\n- `System::id()` is a compile-time constant. Nothing is looked up, nothing is borrowed, and the context no longer depends on an account being present in order to be *built*.\n- You still declare `pub system_program: Program<'info, System>` in the accounts struct. The runtime has to have the callee's program account loaded to execute the nested instruction, and that field is what makes the client include it. What changed in 1.0 is only how `CpiContext` is told which program to call — not whether the program account travels with the transaction.\n\n## The direction rule: why deposit is a CPI and withdraw will not be\n\nRead this from the Agave System Program, `transfer_verified`:\n\n```rust\nlet mut from = instruction_context.try_borrow_instruction_account(from_account_index)?;\nif !from.get_data().is_empty() {\n    ic_msg!(invoke_context, \"Transfer: `from` must not carry data\");\n    return Err(InstructionError::InvalidArgument);\n}\n```\n\nThe System Program refuses to send lamports **out of** any account that carries data. Not \"out of a PDA\" — out of *anything with a non-empty data field*.\n\nYour vault carries 49 bytes. So:\n\n| Direction | Source | Data on the source? | System `transfer` CPI |\n| --- | --- | --- | --- |\n| deposit | user's wallet | no — wallets hold no data | ✅ works, and is what you read below |\n| withdraw | vault PDA | yes, 49 bytes of `VaultState` | ❌ `Transfer: 'from' must not carry data` |\n\nNote where that failure lands: **at runtime, on devnet, after a green build.** The compiler has no opinion about it. Hold that thought until the next lesson.\n\n## Where `new_with_signer` is genuinely required\n\nYou will meet `CpiContext::new_with_signer(program_id, accounts, signer_seeds)`. It exists so a PDA can authorise a call it has no key to sign for: the runtime accepts the signature if the seeds you pass re-derive the PDA under *your* program id. That is real, it is central, and it is used constantly — for a PDA that is the **authority** on a token account, or for a **dataless** PDA (allocated with zero bytes) used purely to hold SOL in escrow.\n\nIt is not what gets lamports out of a data-carrying vault. Anyone who tells you otherwise has written code that compiles.\n\n## What you are reading in the exercise\n\nThe file below is complete and correct. Build it — do not edit it — and read for four things:\n\n1. `Deposit<'info>` re-derives the vault from `bump = vault.bump` rather than re-searching for the canonical bump.\n2. The CPI moves the lamports. It is the only thing in the file that touches a balance the program does not own.\n3. `ctx.accounts.vault.deposit(amount)?` is your own Course 2 method, imported and called. The `checked_add` and the `ZeroAmount` guard are not retyped here; they are the same lines you already wrote and reasoned about.\n4. The two are separate on purpose. Lamports are the runtime's bookkeeping; `vault.balance` is yours. Every real audit finding in a vault lives in the gap between those two numbers, and you cannot inspect a gap whose sides are the same statement.\n\nOne honest note about grading, true for every Rust exercise in this course: **the build server grades by compiling.** A green check means the Anchor 1.x toolchain accepted your program. It does not mean the program behaves. That is not a gap we are hiding — it is the reason Module 4 opens by walking you through the LiteSVM test that *would* run the finished vault, and showing exactly which of these mistakes compiling can never catch.\n"
-      },
-      {
-        "_key": "exercise",
-        "_type": "code",
-        "buildType": "buildable",
-        "deployable": false,
-        "hints": [
-          "Nothing is broken. This file compiles exactly as shipped — click Build and read it while it runs. The first build of a session pulls and compiles the Anchor crates, so it is the slow one; later builds in the same lesson are seconds.",
-          "While it builds, find the two statements in `deposit` that do completely different jobs: one asks another program to move lamports, one updates a number your own program owns. Everything in this module hangs off the fact that those are separate.",
-          "Then find the three reasons `user` is `#[account(mut)]` and a `Signer`: lamports leave it, the System Program refuses to debit a non-signer, and that signature is the only authorisation anywhere in the instruction."
-        ],
-        "language": "rust",
-        "solution": "// ─────────────────────────────────────────────────────────────────────────────\n// WORKED EXAMPLE — nothing to fix. Build it, then read it.\n//\n// This is your vault after Module 2, plus one new instruction: `deposit`.\n// It compiles as shipped. The point of the exercise is the reading, so if you\n// change something and it breaks, `git`-less as you are, just reload the lesson.\n// ─────────────────────────────────────────────────────────────────────────────\n\nuse anchor_lang::prelude::*;\nuse anchor_lang::system_program::{transfer, Transfer};\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n// ─── Your Course 2 core, imported unchanged ──────────────────────────────────\n// Not one line of this module is new. It is the file you finished Course 2 with:\n// a struct that knows its own size, two methods that cannot silently overflow,\n// and one error enum. Nothing in it knows what an account is.\npub mod vault {\n    use super::*;\n\n    #[account]\n    #[derive(InitSpace)]\n    pub struct VaultState {\n        pub owner: Pubkey,\n        pub balance: u64,\n        pub bump: u8,\n    }\n\n    #[error_code]\n    pub enum VaultError {\n        #[msg(\"Deposit would overflow the vault balance\")]\n        Overflow,\n        #[msg(\"Withdrawal is larger than the vault balance\")]\n        InsufficientFunds,\n        #[msg(\"Amount must be greater than zero\")]\n        ZeroAmount,\n        #[msg(\"Signer is not the vault owner\")]\n        NotOwner,\n    }\n\n    impl VaultState {\n        pub fn deposit(&mut self, amount: u64) -> Result<()> {\n            require!(amount > 0, VaultError::ZeroAmount);\n            self.balance = self\n                .balance\n                .checked_add(amount)\n                .ok_or(VaultError::Overflow)?;\n            Ok(())\n        }\n\n        pub fn withdraw(&mut self, amount: u64) -> Result<()> {\n            require!(amount > 0, VaultError::ZeroAmount);\n            self.balance = self\n                .balance\n                .checked_sub(amount)\n                .ok_or(VaultError::InsufficientFunds)?;\n            Ok(())\n        }\n    }\n}\n\npub use vault::{VaultError, VaultState};\n\n#[program]\npub mod vault_program {\n    use super::*;\n\n    pub fn initialize_vault(ctx: Context<InitializeVault>) -> Result<()> {\n        let vault = &mut ctx.accounts.vault;\n        vault.owner = ctx.accounts.user.key();\n        vault.balance = 0;\n        vault.bump = ctx.bumps.vault;\n        Ok(())\n    }\n\n    pub fn deposit(ctx: Context<Deposit>, amount: u64) -> Result<()> {\n        // ── 1. The lamports. This is the CPI. ────────────────────────────────\n        //\n        // `transfer` here is `anchor_lang::system_program::transfer` — a thin\n        // wrapper that builds a System Program instruction and invokes it.\n        //\n        // First argument to `CpiContext::new` is a `Pubkey`: WHICH program.\n        // `System::id()` is a compile-time constant, so no account is read to\n        // build this. Anchor 1.0 changed this argument from an `AccountInfo`;\n        // passing one now is `error[E0308]: expected Pubkey, found AccountInfo`.\n        //\n        // The user signed the transaction, and that signature is still valid\n        // this far down the call stack. Our program signs nothing.\n        transfer(\n            CpiContext::new(\n                System::id(),\n                Transfer {\n                    from: ctx.accounts.user.to_account_info(),\n                    to: ctx.accounts.vault.to_account_info(),\n                },\n            ),\n            amount,\n        )?;\n\n        // ── 2. The bookkeeping. This is your Course 2 method. ────────────────\n        //\n        // Imported, not retyped. `checked_add`, the `ZeroAmount` guard and the\n        // `Overflow` error all live in `vault::VaultState`, already written and\n        // already reasoned about. If `amount` is 0 this returns before the\n        // balance changes — and because the CPI above already ran, the whole\n        // transaction is rolled back. Failure is all-or-nothing per instruction.\n        ctx.accounts.vault.deposit(amount)?;\n\n        Ok(())\n    }\n}\n\n#[derive(Accounts)]\npub struct InitializeVault<'info> {\n    #[account(\n        init,\n        payer = user,\n        space = 8 + 32 + 8 + 1,\n        seeds = [b\"vault\", user.key().as_ref()],\n        bump\n    )]\n    pub vault: Account<'info, VaultState>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n    pub system_program: Program<'info, System>,\n}\n\n#[derive(Accounts)]\npub struct Deposit<'info> {\n    // `mut` because the lamports AND the data both change.\n    //\n    // `bump = vault.bump` re-derives the address using the bump you stored at\n    // initialize time — one hash. A bare `bump` would make Anchor search from\n    // 255 downwards for the canonical bump, which costs compute units for an\n    // answer the account is already carrying.\n    #[account(\n        mut,\n        seeds = [b\"vault\", user.key().as_ref()],\n        bump = vault.bump\n    )]\n    pub vault: Account<'info, VaultState>,\n\n    // `mut` because lamports leave this account. `Signer` because the System\n    // Program will not debit an account that did not sign — and that signature\n    // is the only authorisation in the whole instruction.\n    #[account(mut)]\n    pub user: Signer<'info>,\n\n    // Required even though `CpiContext::new` no longer takes it. The runtime\n    // must have the callee's program account loaded; declaring it here is what\n    // makes the client include it in the transaction.\n    pub system_program: Program<'info, System>,\n}\n",
-        "starter": "// ─────────────────────────────────────────────────────────────────────────────\n// WORKED EXAMPLE — nothing to fix. Build it, then read it.\n//\n// This is your vault after Module 2, plus one new instruction: `deposit`.\n// It compiles as shipped. The point of the exercise is the reading, so if you\n// change something and it breaks, `git`-less as you are, just reload the lesson.\n// ─────────────────────────────────────────────────────────────────────────────\n\nuse anchor_lang::prelude::*;\nuse anchor_lang::system_program::{transfer, Transfer};\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n// ─── Your Course 2 core, imported unchanged ──────────────────────────────────\n// Not one line of this module is new. It is the file you finished Course 2 with:\n// a struct that knows its own size, two methods that cannot silently overflow,\n// and one error enum. Nothing in it knows what an account is.\npub mod vault {\n    use super::*;\n\n    #[account]\n    #[derive(InitSpace)]\n    pub struct VaultState {\n        pub owner: Pubkey,\n        pub balance: u64,\n        pub bump: u8,\n    }\n\n    #[error_code]\n    pub enum VaultError {\n        #[msg(\"Deposit would overflow the vault balance\")]\n        Overflow,\n        #[msg(\"Withdrawal is larger than the vault balance\")]\n        InsufficientFunds,\n        #[msg(\"Amount must be greater than zero\")]\n        ZeroAmount,\n        #[msg(\"Signer is not the vault owner\")]\n        NotOwner,\n    }\n\n    impl VaultState {\n        pub fn deposit(&mut self, amount: u64) -> Result<()> {\n            require!(amount > 0, VaultError::ZeroAmount);\n            self.balance = self\n                .balance\n                .checked_add(amount)\n                .ok_or(VaultError::Overflow)?;\n            Ok(())\n        }\n\n        pub fn withdraw(&mut self, amount: u64) -> Result<()> {\n            require!(amount > 0, VaultError::ZeroAmount);\n            self.balance = self\n                .balance\n                .checked_sub(amount)\n                .ok_or(VaultError::InsufficientFunds)?;\n            Ok(())\n        }\n    }\n}\n\npub use vault::{VaultError, VaultState};\n\n#[program]\npub mod vault_program {\n    use super::*;\n\n    pub fn initialize_vault(ctx: Context<InitializeVault>) -> Result<()> {\n        let vault = &mut ctx.accounts.vault;\n        vault.owner = ctx.accounts.user.key();\n        vault.balance = 0;\n        vault.bump = ctx.bumps.vault;\n        Ok(())\n    }\n\n    pub fn deposit(ctx: Context<Deposit>, amount: u64) -> Result<()> {\n        // ── 1. The lamports. This is the CPI. ────────────────────────────────\n        //\n        // `transfer` here is `anchor_lang::system_program::transfer` — a thin\n        // wrapper that builds a System Program instruction and invokes it.\n        //\n        // First argument to `CpiContext::new` is a `Pubkey`: WHICH program.\n        // `System::id()` is a compile-time constant, so no account is read to\n        // build this. Anchor 1.0 changed this argument from an `AccountInfo`;\n        // passing one now is `error[E0308]: expected Pubkey, found AccountInfo`.\n        //\n        // The user signed the transaction, and that signature is still valid\n        // this far down the call stack. Our program signs nothing.\n        transfer(\n            CpiContext::new(\n                System::id(),\n                Transfer {\n                    from: ctx.accounts.user.to_account_info(),\n                    to: ctx.accounts.vault.to_account_info(),\n                },\n            ),\n            amount,\n        )?;\n\n        // ── 2. The bookkeeping. This is your Course 2 method. ────────────────\n        //\n        // Imported, not retyped. `checked_add`, the `ZeroAmount` guard and the\n        // `Overflow` error all live in `vault::VaultState`, already written and\n        // already reasoned about. If `amount` is 0 this returns before the\n        // balance changes — and because the CPI above already ran, the whole\n        // transaction is rolled back. Failure is all-or-nothing per instruction.\n        ctx.accounts.vault.deposit(amount)?;\n\n        Ok(())\n    }\n}\n\n#[derive(Accounts)]\npub struct InitializeVault<'info> {\n    #[account(\n        init,\n        payer = user,\n        space = 8 + 32 + 8 + 1,\n        seeds = [b\"vault\", user.key().as_ref()],\n        bump\n    )]\n    pub vault: Account<'info, VaultState>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n    pub system_program: Program<'info, System>,\n}\n\n#[derive(Accounts)]\npub struct Deposit<'info> {\n    // `mut` because the lamports AND the data both change.\n    //\n    // `bump = vault.bump` re-derives the address using the bump you stored at\n    // initialize time — one hash. A bare `bump` would make Anchor search from\n    // 255 downwards for the canonical bump, which costs compute units for an\n    // answer the account is already carrying.\n    #[account(\n        mut,\n        seeds = [b\"vault\", user.key().as_ref()],\n        bump = vault.bump\n    )]\n    pub vault: Account<'info, VaultState>,\n\n    // `mut` because lamports leave this account. `Signer` because the System\n    // Program will not debit an account that did not sign — and that signature\n    // is the only authorisation in the whole instruction.\n    #[account(mut)]\n    pub user: Signer<'info>,\n\n    // Required even though `CpiContext::new` no longer takes it. The runtime\n    // must have the callee's program account loaded; declaring it here is what\n    // makes the client include it in the transaction.\n    pub system_program: Program<'info, System>,\n}\n",
-        "tests": [
-          {
-            "description": "The program compiles against the Anchor 1.x toolchain",
-            "expectedOutput": "true",
-            "id": "compiles",
-            "input": ""
-          }
-        ]
-      },
-      {
-        "_key": "retrieval-close",
-        "_type": "quiz",
-        "questions": [
-          {
-            "explanation": "`CpiContext::new(program_id: Pubkey, accounts: T)` is the Anchor 1.0 shape, and the pre-1.0 shape passed the callee's `AccountInfo` instead. Because a `Pubkey` is a compile-time value, the context no longer needs an account read in order to be built. You still declare `system_program: Program<'info, System>` in the accounts struct — the runtime needs the callee's program account loaded — but the context is told which program to call by id.",
-            "id": "q1",
-            "multiSelect": false,
-            "options": [
-              {
-                "correct": true,
-                "id": "a",
-                "label": "`error[E0308]: mismatched types` — expected `Pubkey`, found `AccountInfo<'_>`. In Anchor 1.x the first argument is the program id, so `System::id()` belongs there."
-              },
-              {
-                "correct": false,
-                "feedback": "There is no overload. `CpiContext::new` in `anchor-lang` 1.1.2 is `pub fn new(program_id: Pubkey, accounts: T) -> Self` — one signature, and an `AccountInfo` is not a `Pubkey`.",
-                "id": "b",
-                "label": "It compiles. Anchor accepts either an `AccountInfo` or a `Pubkey` and figures out which you meant."
-              },
-              {
-                "correct": false,
-                "feedback": "It never gets as far as running. This is a type error the compiler catches, which is the good case — a stale API that breaks loudly is far cheaper than one that breaks quietly.",
-                "id": "c",
-                "label": "It compiles and then fails on-chain, because the account info is stale by the time the CPI runs."
-              },
-              {
-                "correct": false,
-                "feedback": "The old argument type was removed, not deprecated, so there is no warning to emit — just a hard mismatch. Deprecation would have been kinder; assume nothing in a major version bump.",
-                "id": "d",
-                "label": "It compiles with a deprecation warning naming the 1.0 form."
-              }
-            ],
-            "prompt": "You copy a CPI snippet from a 2024 tutorial and it reads `CpiContext::new(ctx.accounts.system_program.to_account_info(), cpi_accounts)`. Predict the outcome when the build server compiles it."
-          },
-          {
-            "explanation": "Agave's `transfer_verified` opens with `if !from.get_data().is_empty() { ... return Err(InstructionError::InvalidArgument) }`. Deposit works because a wallet holds no data; withdraw cannot, because the vault does. Note exactly where that lands — a green build, then a runtime rejection — which is the reason Module 4 walks you through the LiteSVM test that would surface it before you spend devnet SOL.",
-            "id": "q2",
-            "multiSelect": false,
-            "options": [
-              {
-                "correct": true,
-                "id": "a",
-                "label": "It compiles, passes this course's grading, and fails on devnet with `Transfer: 'from' must not carry data` — the System Program refuses to debit any account with a non-empty data field."
-              },
-              {
-                "correct": false,
-                "feedback": "Signer seeds solve authorisation, and authorisation was never the obstacle. The obstacle is that the vault carries 49 bytes of `VaultState`, and the System Program checks `from.get_data()` is empty before it debits anything.",
-                "id": "b",
-                "label": "It works. Signer seeds are exactly the mechanism for letting a PDA spend from itself."
-              },
-              {
-                "correct": false,
-                "feedback": "`Transfer`'s fields are plain `AccountInfo`s, so any account fits and the types are satisfied. That is what makes this failure expensive: compile-time silence, runtime rejection.",
-                "id": "c",
-                "label": "It fails to compile, because a PDA cannot be the `from` of a `Transfer`."
-              },
-              {
-                "correct": false,
-                "feedback": "Solana instructions do not partially succeed. The nested instruction returns `InvalidArgument` and the whole transaction is rolled back — nothing transfers, silently or otherwise.",
-                "id": "d",
-                "label": "It works but silently transfers zero, because the PDA's signature is not recognised."
-              }
-            ],
-            "prompt": "Someone writes `withdraw` by mirroring `deposit`: the same `system_program::transfer` CPI, with `from` set to the vault PDA and `to` set to the user, signed with the vault's seeds. Predict the outcome."
-          },
-          {
-            "explanation": "The transaction carries the user's signature; the runtime keeps that fact as the call stack deepens, so the System Program sees a signed `from` without your program doing anything. That is also why the withdrawal direction is the hard one: it needs the *vault* to authorise, and the vault never signed — it has no private key to sign with.",
-            "id": "q3",
-            "multiSelect": false,
-            "options": [
-              {
-                "correct": true,
-                "id": "a",
-                "label": "The user, on the outer transaction. Signatures established at the top of the stack stay valid in nested instructions, so the program signs nothing."
-              },
-              {
-                "correct": false,
-                "feedback": "A program id can only ever authorise PDAs derived from it, and a user's wallet is not one. If a program could sign for a wallet it did not own, no balance on Solana would be safe.",
-                "id": "b",
-                "label": "The program signs on the user's behalf, using its program id as the signing authority."
-              },
-              {
-                "correct": false,
-                "feedback": "Destinations are never asked to sign — receiving lamports needs no permission. And the vault has no key to sign with; that is what the next lesson is about.",
-                "id": "c",
-                "label": "The vault PDA signs, since it is the destination of the transfer."
-              },
-              {
-                "correct": false,
-                "feedback": "Debiting an account always requires its signature, whatever the amount. Rent-exemption governs how *low* a balance may fall, not who may authorise the move.",
-                "id": "d",
-                "label": "Nobody. `transfer` only needs a signature when the amount exceeds the rent-exempt minimum."
-              }
-            ],
-            "prompt": "During `deposit`, the System Program requires that `from` signed. Who provided that signature, and at what point?"
-          }
-        ]
-      }
-    ],
-    "skills": [
-      "cpi",
-      "solana-programs",
-      "anchor"
-    ],
-    "slug": {
-      "_type": "slug",
-      "current": "cpi-moving-real-lamports"
-    },
-    "title": "CPI: Moving Real Lamports"
+    "title": "Complete Counter Program"
   },
   {
     "_id": "lesson-bfsp-define-counter",
@@ -1290,7 +1055,7 @@
       {
         "_key": "intro",
         "_type": "prose",
-        "src": "# Define the Vault Account\n\n> **Version stamp — checked 2026-07-26.** `anchor-lang 1.1.2` (published 2026-06-26) · `cargo-build-sbf` with platform-tools v1.54 (rustc 1.89) · `borsh` resolves to **1.8.0** · edition 2021. Every compiler message quoted below was produced by compiling this lesson's file on that toolchain. Scope of the harness: it pins the field names, their types and the `bump` constraint. It cannot see whether your `space =` expression is the right number — see \"The one thing the build cannot check\".\n\nYou have derived the size. You have derived the address. What you have not done is write the whole\naccounts struct yourself, in one piece, and that is this lesson.\n\nEvery line you need is in the file, commented out and out of order. Two of them belong nowhere. Your\njob is to pick, order and uncomment — not to invent.\n\n## What an accounts struct is for\n\n`#[derive(Accounts)]` is not a parameter list. It is a **validation contract**, checked by generated\ncode before your handler body runs. Each field says \"an account of this type, satisfying these\nconstraints, or the instruction fails.\"\n\n`InitializeVault` needs three accounts, each for a different reason:\n\n```\nvault           the account being created. Program-owned, PDA-addressed, 49 bytes\nuser            who is paying, and who the vault will belong to\nsystem_program  the program that actually allocates the bytes\n```\n\n## The five constraints on the vault\n\n```rust\ninit                                          // create it\npayer = user                                  // this account funds the rent deposit\nspace = 8 + 32 + 8 + 1                        // 49 bytes, derived not copied\nseeds = [b\"vault\", user.key().as_ref()]       // one vault per wallet\nbump                                          // at the canonical address, checked\n```\n\n`init` is the one that does the work, and it does more than it looks like:\n\n- allocates `space` bytes,\n- assigns the account's **owner** to your program id,\n- moves the rent-exempt deposit from `payer`,\n- writes `VaultState`'s 8-byte discriminator into the front,\n- and does all of that by **calling the System Program** — which is why `system_program` has to be in\n  the struct.\n\nThat last point is not a detail. Anchor does not inject accounts. If `init` needs the System Program,\nyou declare the System Program.\n\n## Why `user` needs both `mut` and `Signer`\n\nTwo separate facts about the same account, enforced separately.\n\n`Signer<'info>` says the transaction carries this account's signature. `#[account(mut)]` says this\ninstruction changes the account — and it does, because `payer = user` debits about 0.00123 SOL of rent\ndeposit from it.\n\nMiss the `mut` and Anchor rejects the instruction rather than silently spending someone's lamports. The\nruntime's rule is the broader one: **any account whose lamports or data change must be declared\nwritable**, all the way up at the transaction level. `mut` is how you declare it here.\n\n## The two lines that belong nowhere\n\nOne pool entry is `rent = rent`. That constraint was **removed in Anchor 0.31** — Anchor reads the rent\nparameters itself and derives the deposit from `space`. Use it and the build stops.\n\nThe other is `mut,` sitting among the vault's constraints. It is the line people reach for out of\nreflex, because the vault is obviously about to be written to. But the vault does not exist yet, and\n`mut` means \"this existing account will be modified.\" `init` is the request to bring an account into\nbeing, and it implies the write. Ask for both, or for `mut` alone with `space` and `payer` beside it,\nand Anchor tells you the combination is wrong.\n\nBoth traps compile-fail, which is the mercy of this rung. The one that does *not* compile-fail is\n`space`.\n\n## The one thing the build cannot check\n\n`space = 8 + 32 + 8 + 1` and `space = 8 + 999` compile identically. Nothing in Rust, nothing in Anchor\nand nothing in the grader compares your `space` to your struct. An account sized 8 bytes short deploys\nfine and fails on first write; an account sized 1024 bytes deploys fine and quietly locks twenty times\nthe rent deposit, per vault, for as long as it exists.\n\nThat is why lesson 1 walked the arithmetic instead of handing you the number, and why\n`8 + VaultState::INIT_SPACE` is what you would reach for in production. Here you write the sum, because\nhere the point is knowing what it is made of.\n\n## Requirements\n\n1. Replace `pub struct InitializeVault {}` with pool line (1). Note what is different about it, and why\n   an empty struct did not need it.\n2. Give the `vault` field its five constraints, inside one `#[account( ... )]`.\n3. Add the `user` field, as a mutable `Signer`.\n4. Add the `system_program` field.\n5. Leave the two dead pool lines alone.\n\nThe verification harness at the bottom of the file names every field and type a passing answer must\nhave. Read it — it is the acceptance criteria, written in Rust.\n"
+        "src": "# Challenge: Define a Counter Account (PDA)\n\nAdd a `Counter` account struct and update the `Initialize` accounts to create it as a **Program Derived Address** (PDA).\n\n## What is a PDA?\n\nA PDA is an account address derived deterministically from **seeds** and the **program ID**. Unlike keypair accounts, PDAs don't have a private key — the program itself controls them. The same seeds always produce the same address.\n\nFor our counter: `seeds = [\"counter\", user_wallet_pubkey]` means each wallet gets exactly one counter per program.\n\n## Requirements\n\n1. Add a `Counter` struct with `#[account]` attribute containing `pub count: u64` and `pub authority: Pubkey`\n2. Add lifetime `<'info>` to the `Initialize` struct\n3. Add a `counter` field with `#[account(init, payer = user, space = 8 + 8 + 32, seeds = [b\"counter\", user.key().as_ref()], bump)]`\n4. Add a `user` field as `Signer<'info>` with `#[account(mut)]`\n5. Add `system_program` as `Program<'info, System>`\n\n## What Each Constraint Does\n\n- `init` — creates the account (allocates space, assigns owner)\n- `payer = user` — the `user` account pays the rent deposit\n- `space = 8 + 8 + 32` — 8 bytes discriminator + 8 bytes `u64` + 32 bytes `Pubkey`\n- `seeds` — the byte arrays used to derive the PDA address\n- `bump` — Anchor finds the valid bump seed automatically\n- `mut` on `user` — required because their lamport balance changes (pays rent)\n\n## Tips\n\n- The `Counter` struct goes outside the `#[program]` module\n- The `Initialize` struct needs a lifetime parameter: `pub struct Initialize<'info>`\n- Make sure `counter` has type `Account<'info, Counter>`\n- The `authority` field records who created the counter (useful for access control later)\n"
       },
       {
         "_key": "exercise",
@@ -1298,52 +1063,39 @@
         "buildType": "buildable",
         "deployable": false,
         "hints": [
-          "Start with pool line (1). The struct in the file is `pub struct InitializeVault {}` and the pool's version is `pub struct InitializeVault<'info> {`. An empty struct holds nothing, so it needs no lifetime; the moment it holds borrowed account references it needs one, and every field type in the pool mentions `'info` to prove it. Get this wrong and the errors talk about lifetimes rather than fields, and you will edit the wrong line for ten minutes.",
-          "The vault takes five constraint lines inside one `#[account( ... )]` — pool (8), (11), (3), (7), (10) — and pool (4) is the field itself. Note that (10) `bump` is the only one with no trailing comma, because it comes last. Then two more fields: (6) above (9) for the user, and (2) for the System Program.",
-          "Pool (5) `rent = rent` and (12) `mut,` are the two that belong nowhere. `rent` was removed in Anchor 0.31 and the build refuses it outright. `mut` on the vault is the subtler one: it asks to modify an account that does not exist yet, and `init` is the request that brings it into existence — `init` already implies the write."
+          "Start by adding the Counter struct at the bottom: `#[account]\\npub struct Counter { pub count: u64, pub authority: Pubkey }`",
+          "The Initialize struct needs a lifetime: `pub struct Initialize<'info>` with three fields: counter, user, and system_program",
+          "The counter field needs PDA constraints: `#[account(init, payer = user, space = 8 + 8 + 32, seeds = [b\"counter\", user.key().as_ref()], bump)]`"
         ],
         "language": "rust",
-        "solution": "use anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n// ─────────────────────────────────────────────────────────────────────────────\n// Your Course 2 vault core, imported and not retyped.\n// ─────────────────────────────────────────────────────────────────────────────\npub mod vault {\n    use super::*;\n\n    #[account]\n    #[derive(InitSpace)]\n    pub struct VaultState {\n        pub owner: Pubkey,\n        pub balance: u64,\n        pub bump: u8,\n    }\n\n    #[error_code]\n    pub enum VaultError {\n        #[msg(\"Deposit would overflow the vault balance\")]\n        Overflow,\n        #[msg(\"Withdrawal is larger than the vault balance\")]\n        InsufficientFunds,\n        #[msg(\"Amount must be greater than zero\")]\n        ZeroAmount,\n        #[msg(\"Signer is not the vault owner\")]\n        NotOwner,\n    }\n\n    impl VaultState {\n        pub fn deposit(&mut self, amount: u64) -> Result<()> {\n            require!(amount > 0, VaultError::ZeroAmount);\n            self.balance = self\n                .balance\n                .checked_add(amount)\n                .ok_or(VaultError::Overflow)?;\n            Ok(())\n        }\n\n        pub fn withdraw(&mut self, amount: u64) -> Result<()> {\n            require!(amount > 0, VaultError::ZeroAmount);\n            self.balance = self\n                .balance\n                .checked_sub(amount)\n                .ok_or(VaultError::InsufficientFunds)?;\n            Ok(())\n        }\n    }\n}\n\npub use vault::{VaultError, VaultState};\n\n#[program]\npub mod vault_program {\n    use super::*;\n\n    pub fn initialize_vault(ctx: Context<InitializeVault>) -> Result<()> {\n        let vault = &mut ctx.accounts.vault;\n        vault.owner = ctx.accounts.user.key();\n        vault.balance = 0;\n        vault.bump = ctx.bumps.vault;\n        msg!(\"Vault initialized for {}\", vault.owner);\n        Ok(())\n    }\n\n    pub fn vault_info(_ctx: Context<VaultInfo>) -> Result<()> {\n        msg!(\"Vault program online\");\n        Ok(())\n    }\n}\n\n// One correct assembly. The three fields may be declared in any order, and the\n// constraints inside `#[account(...)]` in any order too. What is fixed is which\n// lines are here at all.\n//\n// Pool lines (5) `rent = rent` and (12) `mut,` are not used:\n//   · `rent = rent` was removed in Anchor 0.31. Anchor reads the rent parameters\n//     itself and derives the deposit from `space`.\n//   · `mut` on the vault would be asking to write an account that already\n//     exists. `init` is the request to create it — allocate `space` bytes, set\n//     the owner to this program, and fund the rent-exempt deposit from `payer`.\n//     `init` implies the write.\n#[derive(Accounts)]\npub struct InitializeVault<'info> {\n    #[account(\n        init,\n        payer = user,\n        space = 8 + 32 + 8 + 1,\n        seeds = [b\"vault\", user.key().as_ref()],\n        bump\n    )]\n    pub vault: Account<'info, VaultState>,\n    // `mut` because `payer = user` debits this account's lamports for the rent\n    // deposit. `Signer` because someone has to authorize spending them. Two\n    // separate facts, two separate pieces of syntax.\n    #[account(mut)]\n    pub user: Signer<'info>,\n    // `init` creates the account by calling the System Program, so the System\n    // Program has to be in the account list. Anchor does not add it for you.\n    pub system_program: Program<'info, System>,\n}\n\n#[derive(Accounts)]\npub struct VaultInfo {}\n\n// ─────────────────────────────────────────────────────────────────────────────\n// VERIFICATION HARNESS — DO NOT EDIT ANYTHING BELOW THIS LINE.\n// A type check, not a behaviour check. See the starter for its exact reach.\n// ─────────────────────────────────────────────────────────────────────────────\n#[doc(hidden)]\n#[allow(dead_code)]\nmod verify {\n    use super::*;\n\n    const _: () = assert!(VaultState::DISCRIMINATOR.len() == 8);\n    const _: () = assert!(VaultState::INIT_SPACE == 41);\n\n    fn pin_bump(bumps: &InitializeVaultBumps) -> u8 {\n        bumps.vault\n    }\n\n    fn pin_vault<'info>(a: &'info InitializeVault<'info>) -> &'info Account<'info, VaultState> {\n        &a.vault\n    }\n    fn pin_user<'info>(a: &'info InitializeVault<'info>) -> &'info Signer<'info> {\n        &a.user\n    }\n    fn pin_system<'info>(a: &'info InitializeVault<'info>) -> &'info Program<'info, System> {\n        &a.system_program\n    }\n}\n",
-        "starter": "use anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n// ─────────────────────────────────────────────────────────────────────────────\n// Your Course 2 vault core, imported and not retyped. Nothing in here changes.\n// ─────────────────────────────────────────────────────────────────────────────\npub mod vault {\n    use super::*;\n\n    #[account]\n    #[derive(InitSpace)]\n    pub struct VaultState {\n        pub owner: Pubkey,\n        pub balance: u64,\n        pub bump: u8,\n    }\n\n    #[error_code]\n    pub enum VaultError {\n        #[msg(\"Deposit would overflow the vault balance\")]\n        Overflow,\n        #[msg(\"Withdrawal is larger than the vault balance\")]\n        InsufficientFunds,\n        #[msg(\"Amount must be greater than zero\")]\n        ZeroAmount,\n        #[msg(\"Signer is not the vault owner\")]\n        NotOwner,\n    }\n\n    impl VaultState {\n        pub fn deposit(&mut self, amount: u64) -> Result<()> {\n            require!(amount > 0, VaultError::ZeroAmount);\n            self.balance = self\n                .balance\n                .checked_add(amount)\n                .ok_or(VaultError::Overflow)?;\n            Ok(())\n        }\n\n        pub fn withdraw(&mut self, amount: u64) -> Result<()> {\n            require!(amount > 0, VaultError::ZeroAmount);\n            self.balance = self\n                .balance\n                .checked_sub(amount)\n                .ok_or(VaultError::InsufficientFunds)?;\n            Ok(())\n        }\n    }\n}\n\npub use vault::{VaultError, VaultState};\n\n#[program]\npub mod vault_program {\n    use super::*;\n\n    pub fn initialize_vault(ctx: Context<InitializeVault>) -> Result<()> {\n        let vault = &mut ctx.accounts.vault;\n        vault.owner = ctx.accounts.user.key();\n        vault.balance = 0;\n        vault.bump = ctx.bumps.vault;\n        msg!(\"Vault initialized for {}\", vault.owner);\n        Ok(())\n    }\n\n    pub fn vault_info(_ctx: Context<VaultInfo>) -> Result<()> {\n        msg!(\"Vault program online\");\n        Ok(())\n    }\n}\n\n// ─────────────────────────────────────────────────────────────────────────────\n// THE FRAGMENT POOL\n//\n// Every line `InitializeVault` needs is here, out of order. Two of them belong\n// nowhere at all. Assemble the struct below from the ones you want; leave the\n// rest where they are.\n//\n//   (1)   pub struct InitializeVault<'info> {\n//   (2)       pub system_program: Program<'info, System>,\n//   (3)           space = 8 + 32 + 8 + 1,\n//   (4)       pub vault: Account<'info, VaultState>,\n//   (5)           rent = rent,\n//   (6)       #[account(mut)]\n//   (7)           seeds = [b\"vault\", user.key().as_ref()],\n//   (8)           init,\n//   (9)       pub user: Signer<'info>,\n//  (10)           bump\n//  (11)           payer = user,\n//  (12)           mut,\n//\n// The two indent levels are a hint: the ones indented further are constraints\n// and go inside `#[account( ... )]`. The others are fields of the struct.\n//\n// On the two lines that belong nowhere:\n//   · One is a constraint Anchor deleted. The build refuses it with a bare\n//     `error: Invalid attribute` pointing at the line — it will not tell you\n//     why, which is the point of knowing before you press the button.\n//   · The other is the constraint people reach for out of habit when an account\n//     is about to be written to. It is the wrong one here, because this account\n//     does not exist yet, and \"write to it\" and \"bring it into existence\" are\n//     different requests.\n//\n// One thing is not in the pool and is not optional: line (1) replaces the\n// `InitializeVault` below, and the difference between them is the part that\n// matters.\n// ─────────────────────────────────────────────────────────────────────────────\n\n// TODO: assemble InitializeVault from the pool above, replacing this.\n#[derive(Accounts)]\npub struct InitializeVault {}\n\n#[derive(Accounts)]\npub struct VaultInfo {}\n\n// ─────────────────────────────────────────────────────────────────────────────\n// VERIFICATION HARNESS — DO NOT EDIT ANYTHING BELOW THIS LINE.\n//\n// A TYPE check, not a behaviour check. Grading is compile-success: the build\n// server compiles the file and reports whether it built. Nothing reads your\n// source and there are no hidden tests on the Rust path — so the harness names,\n// in Rust, every item a passing file must have, and an absent or wrongly-typed\n// one becomes a compile error the grader already catches.\n//\n// It reaches: the three field names and their exact types, the lifetime on the\n// struct, and that `vault` carries a `bump` constraint (which Anchor accepts\n// only alongside `seeds`).\n//\n// It cannot reach: whether `space` is the right number. `8 + 32 + 8 + 1` and\n// `8 + 999` compile identically. That one is on you — which is why you derived\n// it two lessons ago instead of copying it.\n// ─────────────────────────────────────────────────────────────────────────────\n#[doc(hidden)]\n#[allow(dead_code)]\nmod verify {\n    use super::*;\n\n    const _: () = assert!(VaultState::DISCRIMINATOR.len() == 8);\n    const _: () = assert!(VaultState::INIT_SPACE == 41);\n\n    fn pin_bump(bumps: &InitializeVaultBumps) -> u8 {\n        bumps.vault\n    }\n\n    fn pin_vault<'info>(a: &'info InitializeVault<'info>) -> &'info Account<'info, VaultState> {\n        &a.vault\n    }\n    fn pin_user<'info>(a: &'info InitializeVault<'info>) -> &'info Signer<'info> {\n        &a.user\n    }\n    fn pin_system<'info>(a: &'info InitializeVault<'info>) -> &'info Program<'info, System> {\n        &a.system_program\n    }\n}\n",
+        "solution": "use anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n#[program]\npub mod academy_program {\n    use super::*;\n\n    pub fn initialize(_ctx: Context<Initialize>) -> Result<()> {\n        msg!(\"Superteam Academy default program\");\n        Ok(())\n    }\n\n    pub fn greet(_ctx: Context<Greet>) -> Result<()> {\n        msg!(\"Hello, Solana!\");\n        Ok(())\n    }\n}\n\n#[derive(Accounts)]\npub struct Initialize<'info> {\n    #[account(\n        init,\n        payer = user,\n        space = 8 + 8 + 32,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n    pub system_program: Program<'info, System>,\n}\n\n#[derive(Accounts)]\npub struct Greet {}\n\n#[account]\npub struct Counter {\n    pub count: u64,\n    pub authority: Pubkey,\n}\n",
+        "starter": "use anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n#[program]\npub mod academy_program {\n    use super::*;\n\n    pub fn initialize(_ctx: Context<Initialize>) -> Result<()> {\n        msg!(\"Superteam Academy default program\");\n        Ok(())\n    }\n\n    pub fn greet(_ctx: Context<Greet>) -> Result<()> {\n        msg!(\"Hello, Solana!\");\n        Ok(())\n    }\n}\n\n// TODO: Update Initialize to create a Counter PDA account\n// Use seeds = [b\"counter\", user.key().as_ref()] and bump\n#[derive(Accounts)]\npub struct Initialize {}\n\n#[derive(Accounts)]\npub struct Greet {}\n\n// TODO: Add a Counter account struct with count: u64 and authority: Pubkey\n",
         "tests": [
           {
-            "description": "The file compiles on the build server against anchor-lang 1.1.2",
+            "description": "Program compiles successfully",
             "expectedOutput": "true",
-            "id": "t1",
+            "id": "test-1",
             "input": ""
           },
           {
-            "description": "Compiles ⇒ InitializeVault carries the <'info> lifetime and holds account references",
+            "description": "Counter struct is defined",
             "expectedOutput": "true",
-            "id": "t2",
+            "id": "test-2",
             "input": ""
           },
           {
-            "description": "Compiles ⇒ vault is Account<'info, VaultState>, user is a mutable Signer, system_program is Program<'info, System>",
+            "description": "Initialize struct has account constraints",
             "expectedOutput": "true",
-            "id": "t3",
-            "input": ""
-          },
-          {
-            "description": "Compiles ⇒ the vault carries seeds + bump, so ctx.bumps.vault exists",
-            "expectedOutput": "true",
-            "id": "t4",
-            "input": ""
-          },
-          {
-            "description": "Compiles ⇒ neither dead pool line was used — rent was removed in 0.31, and mut cannot create an account",
-            "expectedOutput": "true",
-            "id": "t5",
+            "id": "test-3",
             "input": ""
           }
         ],
         "tutorNotes": [
-          "Learners size `space` by adding up only the fields and forget the 8-byte discriminator Anchor prepends to every `#[account]`, so the account is under-allocated and the first write past the field boundary fails.",
-          "They omit the `<'info>` lifetime on `InitializeVault` once it holds account references, then get opaque lifetime errors and start editing field types instead of the struct header.",
-          "They leave `user` without `#[account(mut)]`; the payer that funds an `init` has its lamports changed and must be declared writable, and this one survives the build and fails at runtime.",
-          "They reach for `mut` on the vault, but the account is being created here for the first time, which needs `init` — `mut` is for an account that already exists.",
-          "They write the PDA seed as the string `\"vault\"` instead of the byte literal `b\"vault\"`, or drop `bump`, and then read the resulting error cascade as a lifetime problem.",
-          "They copy `rent = rent` from a pre-0.31 tutorial and conclude their Anchor install is broken, rather than that the constraint was deleted."
+          "Learners size `space` by adding up only the fields and forget the 8-byte discriminator Anchor prepends to every `#[account]`, so the account is under-allocated.",
+          "They omit the `<'info>` lifetime on the `Initialize` struct once it holds account references, then get opaque lifetime errors and edit the wrong line.",
+          "They leave `user` without `#[account(mut)]`; the payer that funds an `init` has its lamports changed and must be mutable.",
+          "They reach for `#[account(mut)]` on the counter, but the account is being created here for the first time, which needs `init`, not `mut`.",
+          "They write the PDA seed as a plain text string instead of a byte literal, or leave off `bump`, so the constraints do not compile."
         ]
       },
       {
@@ -1351,112 +1103,187 @@
         "_type": "quiz",
         "questions": [
           {
-            "explanation": "A PDA's address is a pure function of its seeds and the program id. Seeding with the user's pubkey gives one deterministic vault per wallet, re-derivable by any client with no lookup table and no private key — and the `bump` constraint is what turns \"derivable\" into \"checked on every call.\"",
+            "explanation": "A PDA address is a pure function of its seeds and the program id. Seeding with the user's pubkey means one deterministic counter per wallet, re-derivable by any client, with no private key — the program signs for it via the bump.",
             "id": "q1",
             "multiSelect": false,
             "options": [
               {
                 "correct": true,
                 "id": "a",
-                "label": "One vault per wallet for this program, at an address any client can re-derive from the wallet alone"
+                "label": "Each wallet gets exactly one counter for this program, at a deterministic address anyone can re-derive"
               },
               {
                 "correct": false,
-                "feedback": "The seeds fix the address: for a given user those seeds derive exactly one. A second `init` there fails, because the account already exists. Multiple vaults per wallet would need a third seed in the list — an index, or a mint.",
+                "feedback": "The seeds fix the address: for a given user those seeds derive one address. A second init there fails — one counter per wallet.",
                 "id": "b",
-                "label": "Each wallet can create as many vaults as it likes"
+                "label": "Each wallet can create unlimited counters"
               },
               {
                 "correct": false,
-                "feedback": "PDAs have no private key; that is the point of deriving off the curve. The program authorizes the address by presenting its seeds, and the user's key is an *input* to the derivation, not a key for the result.",
+                "feedback": "PDAs have no private key — that is the point. The program controls the PDA; the seeds just make its address deterministic.",
                 "id": "c",
-                "label": "The vault has a private key that the user controls"
-              },
-              {
-                "correct": false,
-                "feedback": "Anyone can put any address into an instruction's account list. What the seeds guarantee is that the address is derivable from the user's key, so someone else's vault fails the seeds check instead of being quietly accepted.",
-                "id": "d",
-                "label": "Only the user can pass the vault into an instruction"
+                "label": "The counter has a private key the user controls"
               }
             ],
-            "prompt": "The vault is a PDA seeded on `b\"vault\"` plus the user's key. What does that seed choice actually guarantee?"
+            "prompt": "The counter is a PDA seeded on the counter label plus the user's public key. What does this seed choice guarantee?"
           },
           {
-            "explanation": "`Signer` is about authorization, `mut` is about mutation, and the payer of an `init` is both. The runtime requires every account whose lamports or data change to be writable at the transaction level, so a missing `mut` is a runtime rejection — after a successful build and a successful deploy. Failures only reachable by running are exactly what module 4's LiteSVM lesson is about — it shows you the test that would catch this one.",
+            "explanation": "`init` allocates the counter and `payer = user` funds its rent-exempt deposit, so the user's lamport balance decreases. Any account whose lamports or data change must be declared `mut`, or Anchor rejects the instruction.",
             "id": "q2",
             "multiSelect": false,
             "options": [
               {
                 "correct": true,
                 "id": "a",
-                "label": "It compiles, and every call fails at runtime — the payer's lamports change, so the account has to be declared writable"
+                "label": "Creating the counter with `init` debits rent from the user, changing their lamport balance — a mutation"
               },
               {
                 "correct": false,
-                "feedback": "Anchor does not couple them at compile time. The constraint is checked when the instruction runs, which is exactly why this one gets deployed and then breaks on first use.",
+                "feedback": "Signing is `Signer`, a separate thing. `mut` is required because the payer's lamports decrease to fund the new account's rent.",
                 "id": "b",
-                "label": "It fails to compile — `payer` requires `mut` on the field it names"
+                "label": "Because the user signs the transaction"
               },
               {
                 "correct": false,
-                "feedback": "Signing and writing are separate declarations. A read-only `Signer` is perfectly normal: an authority that approves an action without paying for it. Paying is what needs `mut`.",
+                "feedback": "The user account's own data is not modified. What changes is its lamport balance, since `payer = user` funds the rent — that is why it must be `mut`.",
                 "id": "c",
-                "label": "It works — `Signer` implies writability, because signing is what authorizes spending"
-              },
-              {
-                "correct": false,
-                "feedback": "The vault has no lamports yet — it is the account being created. `payer = user` names where the deposit comes from and there is no fallback.",
-                "id": "d",
-                "label": "It works, and the rent deposit comes from the vault instead"
+                "label": "Because the user's data is written into the counter"
               }
             ],
-            "prompt": "You forget `#[account(mut)]` on `user` but keep `payer = user`. Everything else is right. Predict what happens."
-          },
-          {
-            "explanation": "`init`, `payer`, `seeds` and `bump` all fail loudly — at build time for bad syntax, at runtime for a wrong address or an unsigned payer. `space` is a plain integer expression: too small and the account deploys and then fails on write, too large and it deploys and quietly locks extra rent deposit per vault for as long as it exists. Nothing anywhere reports it, which is why you derived it instead of copying it.",
-            "id": "q3",
-            "multiSelect": false,
-            "options": [
-              {
-                "correct": true,
-                "id": "a",
-                "label": "It is the only one whose wrong value still compiles and still deploys — the other four fail loudly"
-              },
-              {
-                "correct": false,
-                "feedback": "`space` costs nothing at runtime; it is a number baked into the account-creation call. Bare `bump` is the constraint with a per-call compute cost, because it re-runs the derivation search.",
-                "id": "b",
-                "label": "It is the only one that costs compute units"
-              },
-              {
-                "correct": false,
-                "feedback": "It is the least changeable of the five. The allocation is fixed at creation, and growing an account afterwards is a separate deliberate operation with its own payer. Seeds and bump, by contrast, are checks that simply re-run per instruction.",
-                "id": "c",
-                "label": "It can be changed later, unlike the others"
-              },
-              {
-                "correct": false,
-                "feedback": "Anchor validates none of them against `VaultState`. What makes the other four safe is that a wrong value is malformed syntax or a failed runtime check. A wrong `space` is a well-formed number.",
-                "id": "d",
-                "label": "Anchor validates the others against the struct but not `space`"
-              }
-            ],
-            "prompt": "Why does `space` deserve more care than the other four constraints on the vault?"
+            "prompt": "Why does the `user` field need `#[account(mut)]` in `Initialize`?"
           }
         ]
       }
     ],
     "skills": [
       "anchor",
-      "account-model",
-      "rent-and-space",
-      "pdas"
+      "solana-programs",
+      "account-model"
     ],
     "slug": {
       "_type": "slug",
-      "current": "define-the-vault-account"
+      "current": "define-counter-account"
     },
-    "title": "Define the Vault Account"
+    "title": "Define a Counter Account"
+  },
+  {
+    "_id": "lesson-bfsp-deploy-to-devnet",
+    "_type": "lesson",
+    "blocks": [
+      {
+        "_key": "intro",
+        "_type": "prose",
+        "src": "# Deploy to Devnet\n\nYou've built the complete counter program. Now compile it one final time and learn how to deploy it.\n\n## Final Build\n\nThe starter code is your complete counter program. Hit **Build** to compile it. When it succeeds, you'll see a **Build UUID** in the output — this is the identifier for your compiled `.so` binary.\n\n## What Happens After Build\n\nThe build server compiled your Rust code into a Solana program binary (`.so` file). To deploy it to Devnet, you'd run:\n\n```bash\n# Download the compiled binary\ncurl -H 'X-API-Key: YOUR_KEY' \\\n  https://build-server-url/deploy/YOUR_UUID \\\n  -o program.so\n\n# Deploy to Devnet\nsolana program deploy program.so --url devnet\n```\n\nThe `solana program deploy` command:\n1. Uploads the binary to a buffer account\n2. Creates the program account\n3. Sets the program as executable\n4. Returns the **Program ID** — the on-chain address of your program\n\n## Interacting with Your Program\n\nOnce deployed, anyone can call your program's instructions:\n\n```typescript\n// TypeScript client using Anchor\nconst program = new Program(idl, programId, provider);\n\n// Initialize a counter\nawait program.methods\n  .initialize()\n  .accounts({ counter: counterKeypair.publicKey })\n  .signers([counterKeypair])\n  .rpc();\n\n// Increment\nawait program.methods\n  .increment()\n  .accounts({ counter: counterKeypair.publicKey })\n  .rpc();\n```\n\n## What You've Accomplished\n\nYou wrote a Solana program from scratch:\n- **4 instructions**: initialize, greet, increment, decrement\n- **Account management**: init with payer, mutable state, space calculation\n- **Error handling**: Custom error enum with underflow protection\n- **Compilation**: cargo-build-sbf via the build server\n\nThis counter program follows the same patterns used by every production Anchor program on Solana. The complexity scales, but the fundamentals are the same.\n\n## Next Steps\n\n- **DeFi on Solana** course — build a token vault with PDAs and CPIs\n- **Deploy locally** — install the Solana CLI and Anchor to build on your machine\n- **Read the Anchor Book** — [book.anchor-lang.com](https://book.anchor-lang.com)\n"
+      },
+      {
+        "_key": "exercise",
+        "_type": "code",
+        "buildType": "buildable",
+        "deployable": false,
+        "hints": [
+          "This is the complete program from the previous challenge. Just click Build to compile it.",
+          "If you see errors, make sure you haven't accidentally modified the code. Click Reset Code to restore.",
+          "The build UUID in the output panel is your program's compiled binary identifier."
+        ],
+        "language": "rust",
+        "solution": "use anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n#[program]\npub mod academy_program {\n    use super::*;\n\n    pub fn initialize(ctx: Context<Initialize>) -> Result<()> {\n        let counter = &mut ctx.accounts.counter;\n        counter.count = 0;\n        counter.authority = ctx.accounts.user.key();\n        msg!(\"Counter initialized!\");\n        Ok(())\n    }\n\n    pub fn greet(_ctx: Context<Greet>) -> Result<()> {\n        msg!(\"Hello, Solana!\");\n        Ok(())\n    }\n\n    pub fn increment(ctx: Context<Increment>) -> Result<()> {\n        let counter = &mut ctx.accounts.counter;\n        counter.count += 1;\n        Ok(())\n    }\n\n    pub fn decrement(ctx: Context<Decrement>) -> Result<()> {\n        let counter = &mut ctx.accounts.counter;\n        require!(counter.count > 0, ErrorCode::Underflow);\n        counter.count -= 1;\n        Ok(())\n    }\n}\n\n#[derive(Accounts)]\npub struct Initialize<'info> {\n    #[account(\n        init,\n        payer = user,\n        space = 8 + 8 + 32,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n    pub system_program: Program<'info, System>,\n}\n\n#[derive(Accounts)]\npub struct Greet {}\n\n#[derive(Accounts)]\npub struct Increment<'info> {\n    #[account(\n        mut,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    pub user: Signer<'info>,\n}\n\n#[derive(Accounts)]\npub struct Decrement<'info> {\n    #[account(\n        mut,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    pub user: Signer<'info>,\n}\n\n#[account]\npub struct Counter {\n    pub count: u64,\n    pub authority: Pubkey,\n}\n\n#[error_code]\npub enum ErrorCode {\n    #[msg(\"Cannot decrement below zero\")]\n    Underflow,\n}\n",
+        "starter": "use anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n#[program]\npub mod academy_program {\n    use super::*;\n\n    pub fn initialize(ctx: Context<Initialize>) -> Result<()> {\n        let counter = &mut ctx.accounts.counter;\n        counter.count = 0;\n        counter.authority = ctx.accounts.user.key();\n        msg!(\"Counter initialized!\");\n        Ok(())\n    }\n\n    pub fn greet(_ctx: Context<Greet>) -> Result<()> {\n        msg!(\"Hello, Solana!\");\n        Ok(())\n    }\n\n    pub fn increment(ctx: Context<Increment>) -> Result<()> {\n        let counter = &mut ctx.accounts.counter;\n        counter.count += 1;\n        Ok(())\n    }\n\n    pub fn decrement(ctx: Context<Decrement>) -> Result<()> {\n        let counter = &mut ctx.accounts.counter;\n        require!(counter.count > 0, ErrorCode::Underflow);\n        counter.count -= 1;\n        Ok(())\n    }\n}\n\n#[derive(Accounts)]\npub struct Initialize<'info> {\n    #[account(\n        init,\n        payer = user,\n        space = 8 + 8 + 32,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n    pub system_program: Program<'info, System>,\n}\n\n#[derive(Accounts)]\npub struct Greet {}\n\n#[derive(Accounts)]\npub struct Increment<'info> {\n    #[account(\n        mut,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    pub user: Signer<'info>,\n}\n\n#[derive(Accounts)]\npub struct Decrement<'info> {\n    #[account(\n        mut,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    pub user: Signer<'info>,\n}\n\n#[account]\npub struct Counter {\n    pub count: u64,\n    pub authority: Pubkey,\n}\n\n#[error_code]\npub enum ErrorCode {\n    #[msg(\"Cannot decrement below zero\")]\n    Underflow,\n}\n",
+        "tests": [
+          {
+            "description": "Complete counter program compiles successfully",
+            "expectedOutput": "true",
+            "id": "test-1",
+            "input": ""
+          }
+        ]
+      }
+    ],
+    "skills": [
+      "anchor",
+      "program-deployment"
+    ],
+    "slug": {
+      "_type": "slug",
+      "current": "deploy-to-devnet"
+    },
+    "title": "Deploy to Devnet"
+  },
+  {
+    "_id": "lesson-bfsp-from-code-to-chain",
+    "_type": "lesson",
+    "blocks": [
+      {
+        "_key": "intro",
+        "_type": "prose",
+        "src": "# From Code to Chain\n\nYou've written Anchor programs in the previous courses. Now it's time to compile and deploy them for real.\n\n## The Build Pipeline\n\nWhen you write an Anchor program, it goes through several stages before it reaches the Solana blockchain:\n\n1. **Rust source code** — what you write in your editor\n2. **`cargo-build-sbf`** — the Solana compiler that transforms Rust into Solana Bytecode Format (SBF)\n3. **`.so` binary** — the compiled program, an ELF shared object file\n4. **`solana program deploy`** — uploads the binary to a Solana cluster\n\n## What is SBF?\n\nSolana Bytecode Format (SBF) is a variant of eBPF (extended Berkeley Packet Filter) adapted for the Solana runtime. It's a register-based instruction set designed for:\n\n- **Safety**: Programs run in a sandboxed VM with no access to the host system\n- **Performance**: Near-native execution speed\n- **Determinism**: Same inputs always produce the same outputs\n\n## The Build Server\n\nIn this course, you won't need a local Rust toolchain. The **Superteam Academy Build Server** handles compilation in the cloud:\n\n1. You write Anchor code in the browser editor\n2. Click **Build** to submit your code\n3. The build server runs `cargo-build-sbf` on your code\n4. You get back either compiler errors or a compiled binary UUID\n\nThe build server uses the same Anchor 0.32 and Solana SDK that you'd use locally. Think of it as a cloud-hosted `anchor build`.\n\n## What Gets Compiled\n\nYour `lib.rs` file is placed into a pre-configured Anchor project with:\n- `anchor-lang` 0.32.1 (with `init-if-needed` feature)\n- `anchor-spl` 0.32.1\n- `solana-program` via the Agave 3.0 toolchain\n\nThe build server rejects dangerous patterns (`std::process`, `std::fs`, `std::net`) to keep the sandbox secure.\n\n## Ready to Build?\n\nIn the next lesson, you'll hit the **Build** button for the first time. Your only job: see the green checkmark.\n"
+      },
+      {
+        "_key": "retrieval-close",
+        "_type": "quiz",
+        "questions": [
+          {
+            "explanation": "Solana programs compile to SBF and run in a deterministic, sandboxed VM. There is no filesystem, network, or process table on-chain, so those calls are meaningless — and determinism requires the same input to always yield the same output, which host I/O would break.",
+            "id": "q1",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "SBF programs run in a sandboxed VM with no access to the host's filesystem, network, or OS, so those calls have no meaning on-chain"
+              },
+              {
+                "correct": false,
+                "feedback": "They cannot run at all — the SBF VM has no host access. The build server rejects them early rather than shipping a program that could never execute.",
+                "id": "b",
+                "label": "They compile fine on-chain but slow the validator down"
+              },
+              {
+                "correct": false,
+                "feedback": "The sandbox is fundamental to the runtime too: an on-chain program has no OS to call. The build-server block just surfaces that constraint sooner.",
+                "id": "c",
+                "label": "They are blocked only to protect the build server, not the runtime"
+              }
+            ],
+            "prompt": "The build server rejects programs that use `std::fs`, `std::net`, or `std::process`. Why would those never work in a deployed Solana program anyway?"
+          },
+          {
+            "explanation": "The pipeline is Rust source, then `cargo-build-sbf`, then a `.so` ELF containing SBF bytecode, then `solana program deploy` uploads that binary. Validators execute bytecode, never source — which is why the compile step happens before deployment.",
+            "id": "q2",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "A `.so` ELF binary of SBF bytecode; deploy uploads that binary to a cluster"
+              },
+              {
+                "correct": false,
+                "feedback": "The IDL is separate metadata. The compiler output that gets deployed is the `.so` SBF binary — the executable itself.",
+                "id": "b",
+                "label": "A JSON IDL; deploy registers it with the RPC"
+              },
+              {
+                "correct": false,
+                "feedback": "Validators never compile source. Compilation to `.so` happens off-chain (here, on the build server); only the finished bytecode is uploaded.",
+                "id": "c",
+                "label": "Raw Rust source; deploy compiles it on the validator"
+              }
+            ],
+            "prompt": "What artifact does `cargo-build-sbf` produce, and what does `solana program deploy` do with it?"
+          }
+        ]
+      }
+    ],
+    "skills": [
+      "anchor",
+      "solana-programs",
+      "program-deployment"
+    ],
+    "slug": {
+      "_type": "slug",
+      "current": "from-code-to-chain"
+    },
+    "title": "From Code to Chain"
   },
   {
     "_id": "lesson-bfsp-m4-airdrop",
@@ -1465,7 +1292,7 @@
       {
         "_key": "intro",
         "_type": "prose",
-        "src": "# Fund Your Wallet\n\n> **Version stamp — checked 2026-07-26.** Rent constants from `solana-rent`; account-size constants from `solana-loader-v3-interface` (`size_of_program() = 36`, `size_of_programdata_metadata() = 45`, `size_of_buffer_metadata() = 37`). The 234,040-byte binary is this course's finished vault, compiled with `cargo-build-sbf --tools-version v1.54`. Faucet limits are policy, not protocol, and move without notice — treat the SOL figures as exact and the faucet rules as approximate.\n\nBefore deploying your program, you need devnet SOL to pay for the on-chain storage (called \"rent\").\n\n## You may already have some\n\nIf you came through Course 1 you funded this same wallet there, and it is very likely still holding SOL — devnet balances do not expire, and nothing in Courses 2 or 3 spent any. So check the balance in the widget below **before** you airdrop: if you are already at 4-5 SOL, you are done and the next lesson is waiting.\n\nIf Course 3 is your entry point, or the balance has drained, read on.\n\n## How Much SOL Do You Need?\n\nDeploying an Anchor program requires approximately **2 SOL** on devnet:\n- **~1.63 SOL** for the buffer account (temporary storage during upload)\n- **~1.63 SOL** for the **programdata** account, which holds your bytecode for the life of the program\n- **~0.00114 SOL** for the program account itself (it is only 36 bytes — a pointer, not the code)\n- **~0.3 SOL** for transaction fees (200+ transactions)\n\nThose figures are for a compiled Anchor program of roughly **229 KB**, which is what your vault actually comes out to. Most of that size is the framework's account-validation and error machinery, so it barely moves with the number of instructions you wrote — three instructions and thirty cost close to the same.\n\nRead that list again, because the two big numbers do not both stay spent. The buffer's deposit is **refunded automatically**: the deploy instruction drains the buffer back to your wallet in the same instruction that funds programdata. So you need ~2 SOL *on hand* to deploy, but you end up down roughly **1.63 SOL plus fees** — and that 1.63 stays locked as long as the program exists. Getting it back means `solana program close`, which permanently retires the program id.\n\n## The Devnet Faucet\n\nSolana provides a free faucet on devnet. The web faucet at [faucet.solana.com](https://faucet.solana.com) is the reliable path — airdrops through the public RPC (`solana airdrop`) are throttled more aggressively. The web faucet is rate-limited by **request frequency** (a maximum of 2 requests every 8 hours, as of mid-2026); signing in with GitHub raises that limit.\n\nUse the widget below to fund your wallet. You'll need at least 4-5 SOL to comfortably deploy — because of the request-frequency limit, that may take more than one faucet visit, which is expected, not a failure.\n\n> **Tip**: The faucet can be slow during peak hours. If you see \"faucet is busy,\" just wait 30-60 seconds and try again. This is normal — devnet is a shared resource.\n\n## The same rent, at a different scale\n\nThis is the rent-exempt deposit you already sized for the vault account in module 2 — `(128 + space) × 3480 × 2` — applied to something four thousand times larger. Nothing about the rule changed; only `space` did.\n\nRun it on the deploy accounts and the numbers above fall out:\n\n```\nprogramdata: (128 + 45 + 234,040) × 6,960  =  1,630,122,480 lamports  ≈  1.63 SOL\nprogram:     (128 +          36) × 6,960  =      1,141,440 lamports  ≈  0.00114 SOL\n```\n\nThe 45 and the 36 are the loader's own metadata headers, and 234,040 is your compiled `.so` in bytes. Note which account is expensive: the program account is a 36-byte pointer, and the bytecode lives in programdata.\n\nOne correction worth carrying forward from module 2: rent is a **deposit, not a meter**, and the buffer's deposit comes back to you automatically as part of deploying. The programdata deposit does not — that one is the real price of having a program on-chain.\n"
+        "src": "# Airdrop & Fund Your Wallet\n\nBefore deploying your program, you need devnet SOL to pay for the on-chain storage (called \"rent\").\n\n## How Much SOL Do You Need?\n\nDeploying an Anchor program requires approximately **2 SOL** on devnet:\n- **~1.4 SOL** for the buffer account (temporary storage during upload)\n- **~0.1 SOL** for the program account\n- **~0.3 SOL** for transaction fees (200+ transactions)\n\nThe good news: most of this rent is **reclaimable** after deployment.\n\n## The Devnet Faucet\n\nSolana provides a free faucet on devnet. The web faucet at [faucet.solana.com](https://faucet.solana.com) is the reliable path — airdrops through the public RPC (`solana airdrop`) are throttled more aggressively. The web faucet is rate-limited by **request frequency** (a maximum of 2 requests every 8 hours, as of mid-2026); signing in with GitHub raises that limit.\n\nUse the widget below to fund your wallet. You'll need at least 4-5 SOL to comfortably deploy — because of the request-frequency limit, that may take more than one faucet visit, which is expected, not a failure.\n\n> **Tip**: The faucet can be slow during peak hours. If you see \"faucet is busy,\" just wait 30-60 seconds and try again. This is normal — devnet is a shared resource.\n\n## What is Rent?\n\nOn Solana, every account must maintain a minimum balance called **rent**. This prevents spam accounts from filling up validator storage.\n\nThe rent amount depends on the account's data size:\n\n```\nrent = base_rent + (data_size * rent_per_byte)\n```\n\nFor a 200KB program binary, the buffer account rent is ~1.4 SOL.\n\nAccounts that maintain the minimum balance are **rent-exempt** — they won't be garbage collected.\n"
       },
       {
         "_key": "fund",
@@ -1479,7 +1306,7 @@
         "_type": "quiz",
         "questions": [
           {
-            "explanation": "Deployment first uploads the binary into a temporary buffer account whose rent follows (128 + space) * 3480 * 2 — the same formula you used on the vault in module 2. A 229KB binary needs a 229KB buffer, hence ~1.63 SOL. That specific deposit does come back: the deploy instruction drains the buffer to your wallet as it funds programdata. What stays locked is the ~1.63 SOL on the programdata account, for as long as the program exists.",
+            "explanation": "Deployment first uploads the binary into a temporary buffer account whose rent follows base + data_size * rent_per_byte. A 200KB binary needs a 200KB buffer, hence ~1.4 SOL — and because most of that rent is reclaimable, you get much of it back after finalizing.",
             "id": "q1",
             "multiSelect": false,
             "options": [
@@ -1496,15 +1323,15 @@
               },
               {
                 "correct": false,
-                "feedback": "The ~1.63 SOL is buffer-account rent, sized by the binary's byte length, not a per-instruction charge.",
+                "feedback": "The ~1.4 SOL is buffer-account rent, sized by the binary's byte length, not a per-instruction charge.",
                 "id": "c",
                 "label": "The validator charges per instruction, and big programs have more instructions"
               }
             ],
-            "prompt": "Deploying a ~229KB program needs ~1.63 SOL just for the buffer account. Why does the buffer cost scale with the program's size?"
+            "prompt": "Deploying a ~200KB program needs ~1.4 SOL just for the buffer account. Why does the buffer cost scale with the program's size?"
           },
           {
-            "explanation": "You need ~2 SOL on hand (buffer ~1.63 refunded on deploy, programdata ~1.63 locked, program account ~0.00114, fees ~0.3 across 200+ transactions). Airdropping only 2 leaves zero room for a failed-and-resumed upload or fee variance, so the lesson buffers you to 4-5 SOL.",
+            "explanation": "Real deployment cost is ~2 SOL (buffer ~1.4, program ~0.1, fees ~0.3 across 200+ transactions). Airdropping only 2 leaves zero room for a failed-and-resumed upload or fee variance, so the lesson buffers you to 4-5 SOL.",
             "id": "q2",
             "multiSelect": false,
             "options": [
@@ -1515,13 +1342,13 @@
               },
               {
                 "correct": false,
-                "feedback": "Airdrops are not burned. The buffer alone is ~1.63 SOL and fees ~0.3, so 2 SOL leaves no cushion; 4-5 gives comfortable margin.",
+                "feedback": "Airdrops are not burned. The buffer alone can be ~1.4 SOL and fees ~0.3, so 2 SOL leaves no cushion; 4-5 gives comfortable margin.",
                 "id": "b",
                 "label": "Because half of every airdrop is burned"
               },
               {
                 "correct": false,
-                "feedback": "There is no fixed 4 SOL minimum — you need ~2 SOL on hand. You aim for 4-5 to absorb retries, fee spikes, and the 200+ transactions.",
+                "feedback": "There is no fixed 4 SOL minimum — actual cost is ~2 SOL. You aim for 4-5 to absorb retries, fee spikes, and the 200+ transactions.",
                 "id": "c",
                 "label": "Because programs require a minimum 4 SOL balance to deploy"
               }
@@ -1537,9 +1364,9 @@
     ],
     "slug": {
       "_type": "slug",
-      "current": "fund-your-wallet"
+      "current": "airdrop-fund-wallet"
     },
-    "title": "Fund Your Wallet"
+    "title": "Airdrop & Fund Your Wallet"
   },
   {
     "_id": "lesson-bfsp-m4-capstone",
@@ -1548,7 +1375,7 @@
       {
         "_key": "intro",
         "_type": "prose",
-        "src": "# What You've Built — and Writing It Up\n\n> **Version stamp — checked 2026-07-26.** `anchor-lang 1.1.2` · `cargo-build-sbf` with platform-tools v1.54 (rustc 1.89) · edition 2021 · on-chain IDL via the **Program Metadata Program** (`@solana-program/program-metadata`), not the removed `anchor idl init`. Every claim this lesson tells you to make about your own build is one that is true of the artifact you actually shipped.\n\nYou have a program id. It is live on a public network, anyone can look it up without asking you, and it did not exist eleven lessons ago.\n\n## Name the pieces\n\nVague recaps are worth nothing, so here is the specific list. Every item is something you can point at.\n\n| What you shipped                | Where it came from                                                                                                       |\n| ------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |\n| **The Course 2 vault core**     | `VaultState`, `VaultError`, `deposit`, `withdraw` — imported into module 1 unchanged, not retyped. The half of a program that has no runtime dependency |\n| **The vault PDA**               | A per-user, program-owned account at `[b\"vault\", your_key]` — 49 bytes, space derived rather than guessed, canonical bump stored at init |\n| **A System Program CPI**        | `transfer(CpiContext::new(System::id(), Transfer { … }), amount)` on deposit — the Anchor 1.0 shape, where `new` takes the program's ID rather than its `AccountInfo` |\n| **The instruction with no CPI** | `withdraw`, which debits the vault directly because your program owns it — and which therefore has no `system_program` in its accounts struct at all |\n| **A rent floor you enforced**   | `Rent::get()?.minimum_balance(data_len())`, checked before a lamport moves, so a too-large withdrawal returns your `InsufficientFunds` instead of the runtime's `InsufficientFundsForRent` |\n| **Account constraints**         | `seeds` + `bump = vault.bump` binding the vault to its signer, `Account<'info, VaultState>` enforcing the discriminator, an ownership `constraint` raising `NotOwner`, and a decision about `dup` |\n| **A tested-by-reading pre-flight** | The LiteSVM tier: what a test that actually runs `withdraw` asserts, and why compile-success cannot assert it            |\n| **A program id**                | Yours, on devnet, under the BPF Loader Upgradeable, with your wallet as upgrade authority                                 |\n| **An on-chain IDL**             | Published through the Program Metadata Program, reachable from the program id alone                                       |\n\nThe distinction worth keeping: **Anchor generated the boilerplate; you made every decision.** The discriminator, the deserialization, the create-account CPI, the error-code plumbing — macros wrote those. Which seeds. How much space. Where the bump lives. Which error names which failure. Which constraint stops which attack. Those were yours, and they are the part that transfers to the next program you write, in any framework.\n\n## Two concrete next steps\n\n### 1. Course 4 starts from what you just made\n\n**`dapp-and-sdk-with-kit`** takes the program id and the IDL from the last lesson, runs Codama over the IDL to generate a typed client, and puts a real interface on your vault. That is why publishing the IDL was a step rather than a footnote: the next course is told nothing about your program except its address.\n\nBring the id. Nothing else is needed.\n\n### 2. Turbin3, and paid work on Earn\n\n**Turbin3's** admission process includes a Rust prerequisite task that requires executing a transaction on-chain. You have done exactly that, with a program you wrote, and you can point at the signature.\n\n**Superteam Earn** lists bounties judged on submissions rather than résumés, and the shape of your artifact matches two categories of listing well:\n\n- **Program work.** Chapter listings for Anchor vaults, escrows and security templates have run in the **$300–$4,000 USDG** range, at roughly **7–62 submissions** each. Your vault is a smaller version of exactly that brief. Start with the [development listings](https://superteam.fun/earn/category/development/) and prefer small, tightly-scoped deliverables for a first submission.\n- **Writing about program work.** Educational modules and technical deep dives have paid **$1,500–$3,000** at roughly **10–50 competitors** — noticeably fewer people per dollar than the development side. That asymmetry is the single best-odds thing on the board for someone who has just built something and can explain it. It is also why the write-up below is a deliverable and not homework.\n\nTreat those ranges as the historical shape of the board, not a forecast, and never read one day's submission count as a competition rate.\n\nIf you have a larger idea, [Superteam grants](https://superteam.fun/earn/grants/) fund builders directly. A live devnet program is the strongest artifact a first application can carry.\n\n## The write-up\n\nThis is the second deliverable of the course, and the block below is where you draft it. It is never graded, awards no XP and gates nothing — it exists because the version of you that just finished this has information that disappears within a week.\n\nA structure that works, and roughly what belongs in each part:\n\n1. **What it is, in two sentences.** \"A per-user SOL vault on Solana devnet: an Anchor program with `initialize_vault`, `deposit` and `withdraw`, where the vault is a program-owned PDA that the program debits directly, above an enforced rent floor.\" Then the program id, as a link with `?cluster=devnet`.\n2. **One design decision, defended.** Not a tour — one choice. Why the canonical bump is stored in the account instead of re-derived, and what re-deriving costs. Or why `checked_sub` and a named error beat bare subtraction even with `overflow-checks = true`. One paragraph on a real decision beats five paragraphs of narration, and it is the paragraph a reviewer reads to decide whether you understood what you built.\n3. **The thing that broke, and how you found it.** Everyone's write-up has the happy path. Almost none have this. If you hit the deliberate compile error in module 2, or a transaction that failed with a custom error code you had to look up, that is the most useful paragraph you can write — for a reader and for a sponsor assessing whether you can debug.\n4. **What you would do differently.** Short, specific, no false modesty.\n\nTwo rules about claims, because they are the kind of thing that costs credibility:\n\n- Say **\"compiled against the real Anchor 1.1 toolchain.\"** Do not say \"unit tested\" — grading here is compile-only, and the LiteSVM tier is something you read rather than ran. The precise claim is more impressive than the loose one to anyone who knows the difference, and the loose one is checkable.\n- Link the program id rather than describing it. It is on a public network; a reader can verify every claim you make about it in about ten seconds. That verifiability is worth more than any certificate screenshot, and it is the actual asset this course produced.\n\nYour deployed program stays on devnet. Nothing expires, nothing is collected, and the id keeps resolving.\n"
+        "src": "# What You've Built\n\nCongratulations! You've completed the full Solana developer lifecycle:\n\n## Your Journey\n\n1. **Write Code** — You wrote a counter program in Rust using the Anchor framework\n2. **Compile** — The Superteam Academy Build Server compiled it to a Solana program binary\n3. **Deploy** — You deployed it to Solana Devnet using the BPF Loader Upgradeable\n4. **Interact** — You called instructions and watched on-chain state change in real time\n\n## What You Learned\n\n### Anchor Framework\n- `#[program]` — defines your instruction handlers\n- `#[derive(Accounts)]` — specifies account constraints\n- `#[account]` — defines on-chain data structures\n- `#[error_code]` — custom errors enforced by the runtime\n\n### On-Chain Concepts\n- **Accounts** are Solana's storage primitive (not key-value pairs)\n- **Discriminators** identify account types (first 8 bytes)\n- **Rent** prevents spam (accounts must maintain minimum balance)\n- **Transactions** are batches of instructions signed by wallets\n\n### Deployment Protocol\n- Programs are uploaded in **~1000-byte chunks** via the BPF Loader\n- A **buffer account** holds the binary during upload\n- The **program account** is a pointer to the executable data\n- Upgradeable programs can be updated by the upgrade authority\n\n## Ship It: Your First Paid Solana Work\n\nYou now have something most applicants don't: a program you wrote, compiled, and deployed yourself, live on a public network. The next step isn't another course — it's putting that skill in front of teams that pay for it.\n\n**Superteam Earn** lists bounties and projects from real Solana teams, judged on submissions, not resumes. This is where deployed-a-program skills convert into your first $500–$5,000 of paid Solana work:\n\n1. **Browse open development work** — start with the [development bounties on Superteam Earn](https://superteam.fun/earn/category/development/). Look for small, scoped bounties with a defined deliverable: they are the fastest way to a first paid submission.\n2. **Write about what you built** — [content bounties](https://superteam.fun/earn/category/content/) pay for technical writing. A walkthrough of the counter program you just deployed — what confused you, and how you worked through it — is exactly the material sponsors ask for.\n3. **Have a bigger idea? Apply for a grant** — [Superteam grants](https://superteam.fun/earn/grants/) fund builders directly (avg $5.5k Brazil grants). A live Devnet program is the strongest artifact a first grant application can include.\n\nWhatever you submit, link your deployed program. It is live on a public network — anyone can verify it, and that proof is worth more than any certificate screenshot.\n\n## Keep Building\n\n- **Install locally** — Set up the Anchor CLI on your machine for faster iteration\n- **Solana Frontend Development** — Put a UI on your program: wallet integration, reading on-chain state, sending transactions from the browser\n\nYour deployed program will continue to live on Devnet. You can interact with it anytime using the Solana CLI or any Anchor client.\n"
       },
       {
         "_key": "deployed",
@@ -1587,7 +1414,7 @@
             "prompt": "Your program was deployed via the BPF Loader Upgradeable. What does 'upgradeable' let the upgrade authority do?"
           },
           {
-            "explanation": "An upgradeable program account references executable data that the upgrade authority can swap, so bug fixes reuse the same program id. Because state is stored in separate accounts, existing vaults persist across the upgrade — code and data are decoupled by design. That also means a change to `VaultState`'s layout is a data-migration problem, not a redeploy problem.",
+            "explanation": "An upgradeable program account references executable data that the upgrade authority can swap, so bug fixes reuse the same program id. Because state is stored in separate accounts, existing counters persist across the upgrade — code and data are decoupled by design.",
             "id": "q2",
             "multiSelect": false,
             "options": [
@@ -1604,311 +1431,25 @@
               },
               {
                 "correct": false,
-                "feedback": "Vault accounts are separate state and survive an upgrade. Upgrading changes code, not the accounts your program created.",
+                "feedback": "Counter accounts are separate state and survive an upgrade. Upgrading changes code, not the accounts your program created.",
                 "id": "c",
-                "label": "Editing the program automatically wipes existing vault accounts"
+                "label": "Editing the program automatically wipes existing counter accounts"
               }
             ],
-            "prompt": "You want to fix a bug in your deployed vault. Which statement about the program account and its data is true?"
-          },
-          {
-            "explanation": "A green build is one bit: it compiled. That bit is worth having, because Anchor's macros turn a large class of account-wiring mistakes into compile errors, and an uncompilable program cannot be deployed at all. It is also the whole of what was verified, which is why the pre-flight lesson listed eight ways to be green and wrong, and why the write-up should say \"compiled against the real Anchor 1.1 toolchain\" rather than \"tested\".",
-            "id": "q3",
-            "multiSelect": false,
-            "options": [
-              {
-                "correct": true,
-                "id": "a",
-                "label": "That the file compiles to an SBF binary against the real Anchor 1.1 toolchain — nothing about whether the instructions behave correctly"
-              },
-              {
-                "correct": false,
-                "feedback": "Nothing ran. Grading on this path is compile-success only; the grader never executes an instruction and never reads your code. Behaviour is exactly what a green build cannot speak to.",
-                "id": "b",
-                "label": "That the program compiles and its instructions produce the expected account state"
-              },
-              {
-                "correct": false,
-                "feedback": "There are no hidden tests on the Rust path — no `cargo test` step exists here. The single bit the server returns is whether compilation succeeded.",
-                "id": "c",
-                "label": "That the program compiles and passes the hidden tests attached to the lesson"
-              }
-            ],
-            "prompt": "The build server reported a green build before you deployed. Precisely what did that prove?"
-          },
-          {
-            "explanation": "Space is allocated once, at creation, and the rent deposit is sized to it then. Add a field and new vaults get the larger layout while old ones still hold 49 bytes with no room for it — so deserializing an old account against the new struct fails. This is why module 2 made you derive the sum aloud rather than copy someone else's `8 + 8 + 32`: a number you derived stays honest when the struct changes. The migration problem is yours either way.",
-            "id": "q4",
-            "multiSelect": false,
-            "options": [
-              {
-                "correct": true,
-                "id": "a",
-                "label": "A larger `space` for newly created vaults plus a migration for existing ones — an account's data length is fixed at creation and does not grow because the struct did"
-              },
-              {
-                "correct": false,
-                "feedback": "A wider `space` applies only to accounts created AFTER the upgrade. Existing accounts keep the 49 bytes they were allocated; nothing resizes them implicitly.",
-                "id": "b",
-                "label": "Nothing — you widen `space` and existing accounts resize on the next write"
-              },
-              {
-                "correct": false,
-                "feedback": "Two things wrong: accounts do not grow on their own, and rent is a one-time deposit rather than a running charge. A bigger account needs a bigger deposit at the moment it is allocated or reallocated.",
-                "id": "c",
-                "label": "Only more rent, charged automatically as the account grows"
-              }
-            ],
-            "prompt": "Your vault account was created with `space = 8 + 32 + 8 + 1`. You now want to add a `deposit_count: u64` field. What does that cost you?"
-          },
-          {
-            "explanation": "\"Address\" and \"public key\" are not synonyms on Solana. Your wallet is a keypair. The program account's address came from a keypair, but authority over the program is held by the upgrade authority, not that key. The vault PDA has no key by design — it is off the ed25519 curve, and the only way to authorise it is a program the runtime can check. Sorting these three apart is most of the account model.",
-            "id": "q5",
-            "multiSelect": false,
-            "options": [
-              {
-                "correct": true,
-                "id": "a",
-                "label": "Only your wallet. The vault PDA is off-curve by construction, and the program account's address came from a keypair that is irrelevant after deployment"
-              },
-              {
-                "correct": false,
-                "feedback": "Upgrades are authorised by the UPGRADE AUTHORITY, which is your wallet, not by the program's own keypair. That keypair's only job was to fix the address at deploy time.",
-                "id": "b",
-                "label": "Your wallet and the program account — the program's keypair is what authorises upgrades"
-              },
-              {
-                "correct": false,
-                "feedback": "This is the assumption PDAs exist to break. Derivation deliberately retries until the digest is NOT a valid curve point, so for a PDA no private key exists at all.",
-                "id": "c",
-                "label": "All three — every Solana address is a public key with a matching private key somewhere"
-              }
-            ],
-            "prompt": "Three addresses are involved in your deployment: your wallet, the vault PDA, and the program account. Which of them has a private key?"
-          },
-          {
-            "explanation": "Two rules doing one job. First, ownership: the executing program may debit only accounts assigned to it, so lamports leaving a wallet must go through System while lamports leaving your vault must not. Second, explicitness: Solana transactions declare every account up front and a program receives exactly that set — nothing is reached out to mid-instruction, which is what lets a wallet simulate a transaction before you sign it. Put together, the presence or absence of `system_program` in an accounts struct tells you whether that instruction calls out to anyone, and the empty account list on `Withdraw` is the visible consequence of your program owning the vault.",
-            "id": "q6",
-            "multiSelect": false,
-            "options": [
-              {
-                "correct": true,
-                "id": "a",
-                "label": "A program may only debit accounts it owns, and a CPI's callee must appear in the account list. Deposit debits a System-owned wallet so it needs System present; withdraw debits your own vault, needs no CPI, so there is no callee to load"
-              },
-              {
-                "correct": false,
-                "feedback": "It is not a size optimisation. There is genuinely no CPI in `withdraw`, so there is no callee program for the runtime to load; declaring System would be an account that goes unused.",
-                "id": "b",
-                "label": "Withdraw omits it as an optimisation — one fewer account keeps the transaction under the size limit"
-              },
-              {
-                "correct": false,
-                "feedback": "Anchor never injects accounts. Every account a program touches — including a callee program — must be in the instruction's account list, which is why `Deposit` names it explicitly and `Withdraw` has nothing to name.",
-                "id": "c",
-                "label": "Anchor injects the System Program automatically for instructions that only move lamports"
-              }
-            ],
-            "prompt": "`Deposit` declares `pub system_program: Program<'info, System>`. `Withdraw` does not. What single rule explains both?"
-          },
-          {
-            "explanation": "`checked_sub` returns `None`, `ok_or` names it, `?` carries it up, and Anchor maps your variant to 6000 + its index — 6001 for `InsufficientFunds`. The caller gets a code and a sentence you authored. The alternative, a panic, gives them an aborted instruction and nothing to display, which is why Course 2 refused `unwrap()` in program code even with `overflow-checks = true` turning wraps into panics.",
-            "id": "q7",
-            "multiSelect": false,
-            "options": [
-              {
-                "correct": true,
-                "id": "a",
-                "label": "A failed transaction carrying custom error 6001 and the `#[msg]` string you wrote, which any client can render without knowing your program"
-              },
-              {
-                "correct": false,
-                "feedback": "That is what a PANIC gives you, from `unwrap()` or bare subtraction. `checked_sub` + `ok_or` + `?` is the path that produces a code and a message instead.",
-                "id": "b",
-                "label": "A failed transaction with no error code — the instruction simply aborts"
-              },
-              {
-                "correct": false,
-                "feedback": "`?` propagates the error out of the handler, so the instruction fails and the whole transaction's account writes are discarded. Nothing partial is committed.",
-                "id": "c",
-                "label": "A successful transaction that leaves `balance` unchanged"
-              }
-            ],
-            "prompt": "Course 2 recall. Your `withdraw` uses `checked_sub(amount).ok_or(VaultError::InsufficientFunds)?`. What does a caller actually receive when the vault is short?"
-          },
-          {
-            "explanation": "Aliased mutable accounts are a classic source of silent double-credits and vanishing writes: you deserialize twice, modify one copy, and the second copy's serialization overwrites it. Anchor 1.0 flipped this to error-by-default and gave you `dup` for the rare instruction where aliasing is legitimate. The general lesson is the one running through module 3 — most account-level exploits are stopped by a constraint you either wrote or forgot, and the framework's defaults decide which mistakes are even reachable.",
-            "id": "q8",
-            "multiSelect": false,
-            "options": [
-              {
-                "correct": true,
-                "id": "a",
-                "label": "It fails by default with `ConstraintDuplicateMutableAccount`; allowing it requires opting that account out with `#[account(mut, dup)]`"
-              },
-              {
-                "correct": false,
-                "feedback": "There is no merge. Two mutable views of one account means one write can be overwritten by the other from stale data — which is precisely why Anchor 1.0 made the default an error.",
-                "id": "b",
-                "label": "It succeeds, and the two writes are merged safely because they target one account"
-              },
-              {
-                "correct": false,
-                "feedback": "Right diagnosis, wrong syntax: `unsafe(dup)` is Anchor v2-alpha (Pinocchio, `no_std`). On v1 the opt-out is plain `dup`.",
-                "id": "c",
-                "label": "It fails, and the fix is `#[account(mut, unsafe(dup))]`"
-              }
-            ],
-            "prompt": "You add a `transfer_between_vaults` instruction taking two mutable vault accounts. Under Anchor 1.0, what happens if a caller passes the same vault for both?"
-          },
-          {
-            "explanation": "This is the single most useful debugging habit for macro-heavy Rust. `#[derive(Accounts)]` writes a validation function from your attributes, and if that function does not compile, the error lands at the expansion site. So the reported line tells you which struct, and the message tells you what the generated code needed — a field that does not exist, a type that does not match. Deleting `system_program` from `InitializeVault` fails this same way, and Cargo's error ordering matters: the first error is usually the cause and the rest are its consequences.",
-            "id": "q9",
-            "multiSelect": false,
-            "options": [
-              {
-                "correct": true,
-                "id": "a",
-                "label": "The failing code is macro-generated, so it is reported where the macro expanded — read the FIRST error and treat the struct as the neighbourhood, not the line"
-              },
-              {
-                "correct": false,
-                "feedback": "The location is accurate — that genuinely is where the failing code exists after expansion. It is just not where you typed the mistake, which is a different problem and one you can plan around.",
-                "id": "b",
-                "label": "The compiler is confused by proc macros and the reported line is meaningless"
-              },
-              {
-                "correct": false,
-                "feedback": "Constraints expand into code at compile time; that is most of the point of Anchor. Runtime is where the generated checks RUN, not where they are written.",
-                "id": "c",
-                "label": "Anchor validates constraints at runtime, so this must be an unrelated error"
-              }
-            ],
-            "prompt": "You mistype a constraint inside `#[derive(Accounts)] pub struct Deposit`. The compiler reports the error on the `#[derive(Accounts)]` line, not on the constraint you edited. Why, and what do you do with that?"
-          },
-          {
-            "explanation": "Clusters are separate chains that share an address space, so the same 32 bytes name nothing on mainnet and your program on devnet. Solana Explorer defaults to mainnet, which makes a missing `?cluster=devnet` the most common false alarm in this whole course — and the reason every explorer link you share should carry the query parameter. Reading is permissionless on every cluster; the upgrade authority is what is scoped to your wallet.",
-            "id": "q10",
-            "multiSelect": false,
-            "options": [
-              {
-                "correct": true,
-                "id": "a",
-                "label": "Their URL is missing `?cluster=devnet`, so the explorer is searching mainnet, where your program was never deployed"
-              },
-              {
-                "correct": false,
-                "feedback": "Nothing on a public cluster is wallet-scoped. Anyone can read any account; only WRITING is gated, and only by signatures and program logic.",
-                "id": "b",
-                "label": "Devnet programs are only visible to the wallet that deployed them"
-              },
-              {
-                "correct": false,
-                "feedback": "The IDL affects how nicely a program is RENDERED, never whether the account is found. An account with no IDL still shows up with its owner, lamports and raw data.",
-                "id": "c",
-                "label": "The program needs its IDL published before the explorer can find the account"
-              }
-            ],
-            "prompt": "A friend opens your program id on Solana Explorer and reports that the address does not exist. Both of you are looking at the same 32 bytes. What is the most likely explanation?"
-          },
-          {
-            "explanation": "This is what makes the program id a complete handoff. Anchor 1.0 removed the legacy on-chain IDL instructions your program used to carry, and moved the job to a separate Program Metadata Program keyed by program id — so the description travels with the address rather than with your repo. Course 4 depends on exactly this: it fetches your IDL, runs Codama over it, and produces a typed client for a program it knows nothing else about.",
-            "id": "q11",
-            "multiSelect": false,
-            "options": [
-              {
-                "correct": true,
-                "id": "a",
-                "label": "Fetch the interface description from the chain using the id alone and generate a typed client from it, with nothing else from you"
-              },
-              {
-                "correct": false,
-                "feedback": "The IDL describes the interface — instruction names, discriminators, account lists, PDA seeds, layouts, error codes. Your source is not on-chain; the binary and this metadata are.",
-                "id": "b",
-                "label": "Read your Rust source, since the IDL is compiled from it"
-              },
-              {
-                "correct": false,
-                "feedback": "Publishing metadata REQUIRES the upgrade authority; it does not grant it. Only your wallet can upgrade the program or rewrite its metadata.",
-                "id": "c",
-                "label": "Upgrade the program, since the metadata records the upgrade authority"
-              }
-            ],
-            "prompt": "You publish your IDL through the Program Metadata Program. Someone is handed only your program id. What can they now do that they could not before?"
-          },
-          {
-            "explanation": "Precision is the cheapest credibility available to a developer writing about their own work, and overclaiming is the fastest way to lose it. Name the toolchain and the network, say what was and was not verified, and link the program id so every claim is checkable in ten seconds. The narrow, honest sentence is also more impressive to the audience you want, because it demonstrates you know the difference between compiling and testing — which is exactly what the pre-flight lesson was about.",
-            "id": "q12",
-            "multiSelect": false,
-            "options": [
-              {
-                "correct": true,
-                "id": "a",
-                "label": "\"Compiled against the real Anchor 1.1 toolchain and deployed to devnet; behaviour is verified by reading, not by an automated test suite.\""
-              },
-              {
-                "correct": false,
-                "feedback": "There is no test run anywhere in this course. Grading is compile-only and the LiteSVM file was reading material. This is the claim a reviewer can falsify in one question, which costs more than the sentence buys.",
-                "id": "b",
-                "label": "\"Unit tested and deployed to devnet.\""
-              },
-              {
-                "correct": false,
-                "feedback": "You applied constraints deliberately and can say so. \"Audited\" implies an adversarial review by someone other than the author, which did not happen.",
-                "id": "c",
-                "label": "\"Audited against the standard Anchor security constraints.\""
-              }
-            ],
-            "prompt": "You are writing up this build for a technical audience. Which sentence can you defend?"
-          },
-          {
-            "explanation": "This split is the most portable idea in the two courses. `VaultState`, `VaultError` and the two methods know nothing about accounts, signers, the clock or CPIs, which is why they could be written and checked in Course 2 and imported here unchanged. Everything the runtime forced on you — `Context`, `#[derive(Accounts)]`, the System Program CPI, the PDA signer — lives on the other side of the boundary. Programs written this way are the ones you can reason about, test in isolation, and port to another framework without a rewrite.",
-            "id": "q13",
-            "multiSelect": false,
-            "options": [
-              {
-                "correct": true,
-                "id": "a",
-                "label": "`vault` is the half with no runtime dependency — pure state and arithmetic, checkable by reading. `vault_program` is the half that needs accounts, the runtime and a CPI"
-              },
-              {
-                "correct": false,
-                "feedback": "`vault`'s items are public and re-exported at the crate root — the harness and the program module both depend on it. The split is by runtime dependency, not visibility.",
-                "id": "b",
-                "label": "`vault` holds private helpers and `vault_program` holds the public API"
-              },
-              {
-                "correct": false,
-                "feedback": "It is the deliberate architecture, not a leftover. Keeping the state machine free of runtime types is what let Course 2 grade it standalone and what lets Course 3 wrap it without editing a line.",
-                "id": "c",
-                "label": "`vault` is a legacy layout kept for compatibility with Course 2's grader"
-              }
-            ],
-            "prompt": "Course 2 recall. Your program has a `pub mod vault` and a `#[program] pub mod vault_program`. What separates them?"
+            "prompt": "You want to fix a bug in your deployed counter. Which statement about the program account and its data is true?"
           }
         ]
-      },
-      {
-        "_key": "writeup",
-        "_type": "openEnded",
-        "maxWords": 300,
-        "prompt": "Draft your build write-up here, following the four-part structure above: what it is (two sentences plus your program id as a `?cluster=devnet` link), one design decision defended, the thing that broke and how you found it, and what you would do differently. Nothing here is graded, no XP depends on it, and it gates nothing — it exists so the version of you that just finished still remembers what was hard. Keep the claims narrow: \"compiled against the real Anchor 1.1 toolchain\", never \"unit tested\"."
       }
     ],
     "skills": [
-      "program-deployment",
-      "technical-writing",
       "anchor",
-      "solana-programs",
-      "program-build",
-      "idl",
-      "solana-explorer"
+      "solana-programs"
     ],
     "slug": {
       "_type": "slug",
       "current": "what-you-built"
     },
-    "title": "What You've Built — and Writing It Up"
+    "title": "What You've Built"
   },
   {
     "_id": "lesson-bfsp-m4-deploy",
@@ -1917,7 +1458,7 @@
       {
         "_key": "intro",
         "_type": "prose",
-        "src": "# Deploy and Publish the IDL\n\n> **Version stamp — checked 2026-07-26.** `anchor-lang 1.1.2` · `borsh` resolves to **1.8.0** · Agave ≥ 3.1.10 · rustc 1.89+ · IDL spec 0.1.0 (Anchor 0.30+ shape).\n\nThis is it. The code block below is your vault as a deploy artifact: the Course 2 core, plus the three instructions that move lamports or create state — `initialize_vault`, `deposit`, `withdraw` — assembled into one file. (`transfer_between_vaults` from the last lesson is not in it, and the header comment says why.) Build it, then put it on a public network.\n\nTwo things come out of this lesson, and both of them are artifacts you keep:\n\n1. **A program id.** A 32-byte address that anyone, anywhere, can look up without your permission and without asking you for anything.\n2. **An IDL published on-chain at that id.** The machine-readable description of your instructions and accounts — which is what lets a client call your program having been told nothing but the id.\n\nCourse 4 consumes exactly those two. Keep the id somewhere you will find it again.\n\n## The Deployment Process\n\nDeploying a Solana program involves 4 steps:\n\n1. **Compile**: Your Rust code → `.so` binary (done by the build server)\n2. **Create Buffer**: A temporary on-chain account to hold the binary during upload\n3. **Upload Chunks**: The binary is uploaded in ~1000-byte chunks (200+ transactions for a typical program)\n4. **Finalize**: Link the buffer to a new program account, making it executable\n\nThis follows the **BPF Loader Upgradeable** protocol — the standard way all Anchor programs are deployed.\n\nYour vault compiles to roughly 229 KB, so expect the full 200-plus transactions. The chunking is not a platform quirk: a Solana transaction is capped near 1232 bytes, which is three orders of magnitude smaller than the binary, so a large upload has no other shape available to it.\n\n## What You'll See\n\n- **1 wallet popup** to create the buffer account\n- **Batch signing** every ~30 chunks (to avoid blockhash expiry)\n- **A real-time transaction log** showing each chunk being confirmed\n- **Your Program ID** when deployment completes\n\n## Instructions\n\n1. Click **Build** to compile the program\n2. When the build succeeds, click **Deploy to Devnet**\n3. Approve the transactions in your wallet\n4. Watch the deployment progress in real time!\n\n> **If deployment fails**: Don't worry! The system saves your progress. Click **Resume** to pick up where you left off — you won't re-upload chunks that already succeeded.\n\n## Publishing the IDL: what changed in Anchor 1.0\n\nYour program is on-chain. Nothing yet knows what its instructions are called.\n\nAn IDL is a JSON document describing every instruction, its 8-byte discriminator, the accounts it expects, the seeds of any PDA among them, your account layouts, and your error codes. It is the difference between an address a client can *see* and an address a client can *use*.\n\nFor years Anchor put that JSON on-chain through instructions built into your own program — the mechanism behind `anchor idl init`. **Anchor 1.0 removed those instructions.** Every tutorial that tells you to run `anchor idl init <PROGRAM_ID>` is describing a mechanism that no longer exists, and there are a great many of them.\n\nThe replacement is the **Program Metadata Program**, a separate on-chain program that stores metadata for *any* program, keyed by program id. It is not Anchor-specific and it is not part of your binary — which is the improvement: your program no longer carries instructions whose only purpose is to describe itself.\n\nPublishing to it is one command:\n\n```bash\nnpx @solana-program/program-metadata write idl <program-id> ./idl.json\n```\n\nIn a local Anchor repo `anchor deploy` does this for you as part of deploying, and `--no-idl` opts out. Deployment here happens in the browser and does not, so publishing is the separate step above — run against the id the panel just gave you, with the IDL from this lesson.\n\nTwo honest notes:\n\n- **The authority matters.** Writing metadata for a program id requires the program's upgrade authority, which is your wallet. Nobody else can publish an IDL for your program, and you cannot publish one for someone else's.\n- **Explorer support is uneven.** Not every explorer resolves and renders Program Metadata IDLs yet; several still look only for the legacy account that Anchor 1.0 stopped writing. If an explorer shows your program without an IDL, that is a gap in the explorer, not a failed publish. Clients that read the metadata PDA directly — Codama among them, which is what Course 4 uses — get it either way.\n\nThe property worth internalising: **once published, the IDL is reachable from the program id alone.** No repo, no npm package, no README. Hand someone 32 bytes and they can generate a typed client. That is the whole reason the next course can start from your program instead of its own.\n\n## Interacting with your live program\n\nThe panel below reads the IDL, derives every account it can, and builds real transactions against **your** deployed program. Work through it in order:\n\n1. **`initialize_vault`** — no arguments. Watch the account list: `vault` resolves as a PDA, derived from `[b\"vault\", your_wallet]` under your program id, and `user` resolves to your wallet. Nothing was typed in; the seeds in the IDL were enough. After it confirms, the account view shows `owner` (your address), `balance` (0) and `bump` (probably 255, occasionally lower).\n2. **`deposit`** — pass an amount in lamports. `1000000000` is 1 SOL; start smaller. Two things change and you should check both: the vault account's lamport balance on the explorer, and the `balance` field in the account view. They are separate writes — the System Program moved the lamports, your Course 2 `deposit` method recorded the number — and a program where they disagree is a program with a bug.\n3. **`withdraw`** — pass a smaller amount than you deposited. Look at the account list before you send: there are **two** accounts, not three. No `system_program`, because `withdraw` makes no CPI — the account being debited is the vault, your program owns it, and a program may move lamports out of an account it owns without asking anyone. That absence in the account list is module 3's hardest finding made visible.\n4. **Read the bytes.** Open the vault address on [Solana Explorer](https://explorer.solana.com) with `?cluster=devnet` and look at the raw account data. The first 8 bytes are the discriminator; then 32 bytes of `owner`; then `balance` as a little-endian `u64`, least significant byte first; then one byte of `bump`. 49 bytes, exactly the arithmetic you did in module 2, in front of you.\n\nThen try two errors on purpose, because a live program is the only place you can watch your own error strings travel.\n\n**Call `deposit` with `0`.** The transaction fails with custom error `6002`, and the message attached is the `#[msg(\"Amount must be greater than zero\")]` string you wrote — travelling from your `require!` through the runtime into a UI that had never heard of your program before this lesson. That is what a named error buys you, and it is why Course 2 refused to let you `unwrap`.\n\n**Then call `withdraw` for more than the vault holds** — or for an amount that would drop it below its rent floor. You get `6001`, `InsufficientFunds`, from your own guard, rather than the runtime's `InsufficientFundsForRent`. Both stop the transaction. Only one of them tells the caller what to do about it, and the difference is the rent-floor check you wrote instead of letting the runtime find out the hard way.\n"
+        "src": "# Deploy Your Program to Devnet\n\nThis is it — you're about to deploy your counter program to the Solana blockchain.\n\n## The Deployment Process\n\nDeploying a Solana program involves 4 steps:\n\n1. **Compile**: Your Rust code → `.so` binary (already done by the build server)\n2. **Create Buffer**: A temporary on-chain account to hold the binary during upload\n3. **Upload Chunks**: The binary is uploaded in ~1000-byte chunks (200+ transactions for a typical program)\n4. **Finalize**: Link the buffer to a new program account, making it executable\n\nThis follows the **BPF Loader Upgradeable** protocol — the standard way all Anchor programs are deployed.\n\n## What You'll See\n\n- **1 wallet popup** to create the buffer account\n- **Batch signing** every ~30 chunks (to avoid blockhash expiry)\n- **A real-time transaction log** showing each chunk being confirmed\n- **Your Program ID** when deployment completes\n\n## Instructions\n\n1. Click **Build** to compile your counter program\n2. When the build succeeds, click **Deploy to Devnet**\n3. Approve the transactions in your wallet\n4. Watch the deployment progress in real time!\n\n> **If deployment fails**: Don't worry! The system saves your progress. Click **Resume** to pick up where you left off — you won't re-upload chunks that already succeeded.\n"
       },
       {
         "_key": "exercise",
@@ -1928,39 +1469,30 @@
         ],
         "deployable": true,
         "hints": [
-          "This is the vault you assembled across modules 1-3, unchanged. Click Build to compile it, then Deploy to Devnet.",
+          "This is the same counter program from Module 3. Click Build to compile it, then Deploy to Devnet.",
           "Make sure you have at least 2 SOL in your wallet. Use the previous lesson to airdrop if needed.",
           "If deployment fails mid-way, click Resume — it will pick up where it left off."
         ],
         "language": "rust",
         "produces": "deployed-program",
-        "solution": "// The finished vault — the deploy artifact, in one file. Nothing here is new.\n// Read it once to confirm you recognise all of it, then click Build, then\n// Deploy to Devnet.\n//\n// WHAT SHIPS, AND WHAT DOES NOT. Three instructions go on-chain:\n// `initialize_vault`, `deposit` and `withdraw` — the three that move lamports\n// or create state, and the three Course 4 calls against this program id. Your\n// `transfer_between_vaults` from `harden-the-vault` is deliberately NOT here:\n// it moves recorded balance between two vaults and touches no lamports, so it\n// adds nothing to the artifact the next course consumes. It was an exercise in\n// writing constraints, not a feature of the vault. If you want it deployed,\n// add it back along with its entry in the IDL — nothing stops you.\n//\n// Version stamp — checked 2026-07-26: anchor-lang 1.1.2, borsh resolves to\n// 1.8.0, edition 2021, Agave >= 3.1.10, rustc 1.89+.\n\nuse anchor_lang::prelude::*;\nuse anchor_lang::system_program::{transfer, Transfer};\n\n// The one line that looks optional and is not: `#[account]` expands to an\n// `impl Owner for VaultState` whose body reads `crate::ID`, and this is what\n// defines `ID`. Deploying replaces this placeholder with your own program id.\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n// ─────────────────────────────────────────────────────────────────────────────\n// YOUR COURSE 2 CORE — imported, not retyped.\n//\n// This module is the file you wrote in Course 2, unchanged. It has no accounts,\n// no signers, no CPI: it is the half of a program that does not depend on the\n// runtime. Every checked_add / checked_sub / named-error decision in it is one\n// you already made and already defended.\n// ─────────────────────────────────────────────────────────────────────────────\npub mod vault {\n    use super::*;\n\n    #[account]\n    #[derive(InitSpace)]\n    pub struct VaultState {\n        pub owner: Pubkey,\n        pub balance: u64,\n        pub bump: u8,\n    }\n\n    // Exactly ONE `#[error_code]` enum per program — Anchor 1.0 permits no more\n    // than one, and this is it. Module 3 added no new error type; it added a\n    // constraint that raises `NotOwner`, which Course 2 declared and left unused\n    // for precisely that reason.\n    #[error_code]\n    pub enum VaultError {\n        #[msg(\"Deposit would overflow the vault balance\")]\n        Overflow,\n        #[msg(\"Withdrawal is larger than the vault balance\")]\n        InsufficientFunds,\n        #[msg(\"Amount must be greater than zero\")]\n        ZeroAmount,\n        #[msg(\"Signer is not the vault owner\")]\n        NotOwner,\n    }\n\n    impl VaultState {\n        pub fn deposit(&mut self, amount: u64) -> Result<()> {\n            require!(amount > 0, VaultError::ZeroAmount);\n            self.balance = self\n                .balance\n                .checked_add(amount)\n                .ok_or(VaultError::Overflow)?;\n            Ok(())\n        }\n\n        pub fn withdraw(&mut self, amount: u64) -> Result<()> {\n            require!(amount > 0, VaultError::ZeroAmount);\n            self.balance = self\n                .balance\n                .checked_sub(amount)\n                .ok_or(VaultError::InsufficientFunds)?;\n            Ok(())\n        }\n    }\n}\n\npub use vault::{VaultError, VaultState};\n\n// ─────────────────────────────────────────────────────────────────────────────\n// THE HALF COURSE 3 ADDED: the runtime-facing program.\n// ─────────────────────────────────────────────────────────────────────────────\n#[program]\npub mod vault_program {\n    use super::*;\n\n    /// Module 2. Creates the per-user vault PDA and stores the canonical bump.\n    pub fn initialize_vault(ctx: Context<InitializeVault>) -> Result<()> {\n        let vault = &mut ctx.accounts.vault;\n        vault.owner = ctx.accounts.user.key();\n        vault.balance = 0;\n        // `ctx.bumps` is keyed by the FIELD name in the accounts struct, not by\n        // the seed prefix. Store it now so no later instruction has to search.\n        vault.bump = ctx.bumps.vault;\n        msg!(\"Vault initialized for {}\", vault.owner);\n        Ok(())\n    }\n\n    /// Module 3. Lamports IN move via a System Program CPI, because the debited\n    /// account is the user's wallet and System owns that. The recorded balance\n    /// moves via your Course 2 method. Two writes that have to agree.\n    pub fn deposit(ctx: Context<Deposit>, amount: u64) -> Result<()> {\n        // Anchor 1.0: `CpiContext::new` takes the program's ID, not its\n        // AccountInfo. Every pre-1.0 CPI tutorial online has the old shape.\n        transfer(\n            CpiContext::new(\n                System::id(),\n                Transfer {\n                    from: ctx.accounts.user.to_account_info(),\n                    to: ctx.accounts.vault.to_account_info(),\n                },\n            ),\n            amount,\n        )?;\n        ctx.accounts.vault.deposit(amount)?;\n        Ok(())\n    }\n\n    /// Module 3, and the instruction with no CPI in it. The debited account is\n    /// the vault, which OUR program owns — so our program may move its lamports\n    /// directly. The System Program could not do it for us at any price: it\n    /// refuses to debit an account carrying data, and it does not own this one.\n    pub fn withdraw(ctx: Context<Withdraw>, amount: u64) -> Result<()> {\n        let vault_info = ctx.accounts.vault.to_account_info();\n        let user_info = ctx.accounts.user.to_account_info();\n\n        // Bookkeeping first, through the Course 2 method: the zero guard, the\n        // `checked_sub` and `InsufficientFunds` all live inside it.\n        ctx.accounts.vault.withdraw(amount)?;\n\n        // The rent floor, read from the account's real allocated size so it stays\n        // correct if `VaultState` ever grows. Never hardcode 49.\n        let rent_floor = Rent::get()?.minimum_balance(vault_info.data_len());\n        let remaining = vault_info\n            .lamports()\n            .checked_sub(amount)\n            .ok_or(VaultError::InsufficientFunds)?;\n        require!(remaining >= rent_floor, VaultError::InsufficientFunds);\n\n        **vault_info.try_borrow_mut_lamports()? = remaining;\n        let credited = user_info\n            .lamports()\n            .checked_add(amount)\n            .ok_or(VaultError::Overflow)?;\n        **user_info.try_borrow_mut_lamports()? = credited;\n\n        Ok(())\n    }\n}\n\n#[derive(Accounts)]\npub struct InitializeVault<'info> {\n    // 8 (discriminator) + 32 (owner) + 8 (balance) + 1 (bump) = 49, derived in\n    // module 2 rather than copied. No `rent` constraint — removed in 0.31.\n    #[account(\n        init,\n        payer = user,\n        space = 8 + 32 + 8 + 1,\n        seeds = [b\"vault\", user.key().as_ref()],\n        bump\n    )]\n    pub vault: Account<'info, VaultState>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n    pub system_program: Program<'info, System>,\n}\n\n#[derive(Accounts)]\npub struct Deposit<'info> {\n    // `bump = vault.bump` uses the stored canonical bump: one hash instead of a\n    // search from 255 down for a value you already wrote to the account.\n    #[account(\n        mut,\n        seeds = [b\"vault\", user.key().as_ref()],\n        bump = vault.bump\n    )]\n    pub vault: Account<'info, VaultState>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n    pub system_program: Program<'info, System>,\n}\n\n#[derive(Accounts)]\npub struct Withdraw<'info> {\n    // The `constraint` is what finally spends the `owner` field carried since\n    // Course 2, and it raises `NotOwner` — the fourth variant, previously unused.\n    // Note what is absent: no `system_program`, because `withdraw` makes no CPI\n    // and there is no callee program for the runtime to load.\n    #[account(\n        mut,\n        seeds = [b\"vault\", user.key().as_ref()],\n        bump = vault.bump,\n        constraint = vault.owner == user.key() @ VaultError::NotOwner\n    )]\n    pub vault: Account<'info, VaultState>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n}\n",
-        "starter": "// The finished vault — the deploy artifact, in one file. Nothing here is new.\n// Read it once to confirm you recognise all of it, then click Build, then\n// Deploy to Devnet.\n//\n// WHAT SHIPS, AND WHAT DOES NOT. Three instructions go on-chain:\n// `initialize_vault`, `deposit` and `withdraw` — the three that move lamports\n// or create state, and the three Course 4 calls against this program id. Your\n// `transfer_between_vaults` from `harden-the-vault` is deliberately NOT here:\n// it moves recorded balance between two vaults and touches no lamports, so it\n// adds nothing to the artifact the next course consumes. It was an exercise in\n// writing constraints, not a feature of the vault. If you want it deployed,\n// add it back along with its entry in the IDL — nothing stops you.\n//\n// Version stamp — checked 2026-07-26: anchor-lang 1.1.2, borsh resolves to\n// 1.8.0, edition 2021, Agave >= 3.1.10, rustc 1.89+.\n\nuse anchor_lang::prelude::*;\nuse anchor_lang::system_program::{transfer, Transfer};\n\n// The one line that looks optional and is not: `#[account]` expands to an\n// `impl Owner for VaultState` whose body reads `crate::ID`, and this is what\n// defines `ID`. Deploying replaces this placeholder with your own program id.\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n// ─────────────────────────────────────────────────────────────────────────────\n// YOUR COURSE 2 CORE — imported, not retyped.\n//\n// This module is the file you wrote in Course 2, unchanged. It has no accounts,\n// no signers, no CPI: it is the half of a program that does not depend on the\n// runtime. Every checked_add / checked_sub / named-error decision in it is one\n// you already made and already defended.\n// ─────────────────────────────────────────────────────────────────────────────\npub mod vault {\n    use super::*;\n\n    #[account]\n    #[derive(InitSpace)]\n    pub struct VaultState {\n        pub owner: Pubkey,\n        pub balance: u64,\n        pub bump: u8,\n    }\n\n    // Exactly ONE `#[error_code]` enum per program — Anchor 1.0 permits no more\n    // than one, and this is it. Module 3 added no new error type; it added a\n    // constraint that raises `NotOwner`, which Course 2 declared and left unused\n    // for precisely that reason.\n    #[error_code]\n    pub enum VaultError {\n        #[msg(\"Deposit would overflow the vault balance\")]\n        Overflow,\n        #[msg(\"Withdrawal is larger than the vault balance\")]\n        InsufficientFunds,\n        #[msg(\"Amount must be greater than zero\")]\n        ZeroAmount,\n        #[msg(\"Signer is not the vault owner\")]\n        NotOwner,\n    }\n\n    impl VaultState {\n        pub fn deposit(&mut self, amount: u64) -> Result<()> {\n            require!(amount > 0, VaultError::ZeroAmount);\n            self.balance = self\n                .balance\n                .checked_add(amount)\n                .ok_or(VaultError::Overflow)?;\n            Ok(())\n        }\n\n        pub fn withdraw(&mut self, amount: u64) -> Result<()> {\n            require!(amount > 0, VaultError::ZeroAmount);\n            self.balance = self\n                .balance\n                .checked_sub(amount)\n                .ok_or(VaultError::InsufficientFunds)?;\n            Ok(())\n        }\n    }\n}\n\npub use vault::{VaultError, VaultState};\n\n// ─────────────────────────────────────────────────────────────────────────────\n// THE HALF COURSE 3 ADDED: the runtime-facing program.\n// ─────────────────────────────────────────────────────────────────────────────\n#[program]\npub mod vault_program {\n    use super::*;\n\n    /// Module 2. Creates the per-user vault PDA and stores the canonical bump.\n    pub fn initialize_vault(ctx: Context<InitializeVault>) -> Result<()> {\n        let vault = &mut ctx.accounts.vault;\n        vault.owner = ctx.accounts.user.key();\n        vault.balance = 0;\n        // `ctx.bumps` is keyed by the FIELD name in the accounts struct, not by\n        // the seed prefix. Store it now so no later instruction has to search.\n        vault.bump = ctx.bumps.vault;\n        msg!(\"Vault initialized for {}\", vault.owner);\n        Ok(())\n    }\n\n    /// Module 3. Lamports IN move via a System Program CPI, because the debited\n    /// account is the user's wallet and System owns that. The recorded balance\n    /// moves via your Course 2 method. Two writes that have to agree.\n    pub fn deposit(ctx: Context<Deposit>, amount: u64) -> Result<()> {\n        // Anchor 1.0: `CpiContext::new` takes the program's ID, not its\n        // AccountInfo. Every pre-1.0 CPI tutorial online has the old shape.\n        transfer(\n            CpiContext::new(\n                System::id(),\n                Transfer {\n                    from: ctx.accounts.user.to_account_info(),\n                    to: ctx.accounts.vault.to_account_info(),\n                },\n            ),\n            amount,\n        )?;\n        ctx.accounts.vault.deposit(amount)?;\n        Ok(())\n    }\n\n    /// Module 3, and the instruction with no CPI in it. The debited account is\n    /// the vault, which OUR program owns — so our program may move its lamports\n    /// directly. The System Program could not do it for us at any price: it\n    /// refuses to debit an account carrying data, and it does not own this one.\n    pub fn withdraw(ctx: Context<Withdraw>, amount: u64) -> Result<()> {\n        let vault_info = ctx.accounts.vault.to_account_info();\n        let user_info = ctx.accounts.user.to_account_info();\n\n        // Bookkeeping first, through the Course 2 method: the zero guard, the\n        // `checked_sub` and `InsufficientFunds` all live inside it.\n        ctx.accounts.vault.withdraw(amount)?;\n\n        // The rent floor, read from the account's real allocated size so it stays\n        // correct if `VaultState` ever grows. Never hardcode 49.\n        let rent_floor = Rent::get()?.minimum_balance(vault_info.data_len());\n        let remaining = vault_info\n            .lamports()\n            .checked_sub(amount)\n            .ok_or(VaultError::InsufficientFunds)?;\n        require!(remaining >= rent_floor, VaultError::InsufficientFunds);\n\n        **vault_info.try_borrow_mut_lamports()? = remaining;\n        let credited = user_info\n            .lamports()\n            .checked_add(amount)\n            .ok_or(VaultError::Overflow)?;\n        **user_info.try_borrow_mut_lamports()? = credited;\n\n        Ok(())\n    }\n}\n\n#[derive(Accounts)]\npub struct InitializeVault<'info> {\n    // 8 (discriminator) + 32 (owner) + 8 (balance) + 1 (bump) = 49, derived in\n    // module 2 rather than copied. No `rent` constraint — removed in 0.31.\n    #[account(\n        init,\n        payer = user,\n        space = 8 + 32 + 8 + 1,\n        seeds = [b\"vault\", user.key().as_ref()],\n        bump\n    )]\n    pub vault: Account<'info, VaultState>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n    pub system_program: Program<'info, System>,\n}\n\n#[derive(Accounts)]\npub struct Deposit<'info> {\n    // `bump = vault.bump` uses the stored canonical bump: one hash instead of a\n    // search from 255 down for a value you already wrote to the account.\n    #[account(\n        mut,\n        seeds = [b\"vault\", user.key().as_ref()],\n        bump = vault.bump\n    )]\n    pub vault: Account<'info, VaultState>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n    pub system_program: Program<'info, System>,\n}\n\n#[derive(Accounts)]\npub struct Withdraw<'info> {\n    // The `constraint` is what finally spends the `owner` field carried since\n    // Course 2, and it raises `NotOwner` — the fourth variant, previously unused.\n    // Note what is absent: no `system_program`, because `withdraw` makes no CPI\n    // and there is no callee program for the runtime to load.\n    #[account(\n        mut,\n        seeds = [b\"vault\", user.key().as_ref()],\n        bump = vault.bump,\n        constraint = vault.owner == user.key() @ VaultError::NotOwner\n    )]\n    pub vault: Account<'info, VaultState>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n}\n",
+        "solution": "use anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n#[program]\npub mod academy_program {\n    use super::*;\n\n    pub fn initialize(ctx: Context<Initialize>) -> Result<()> {\n        let counter = &mut ctx.accounts.counter;\n        counter.count = 0;\n        counter.authority = ctx.accounts.user.key();\n        msg!(\"Counter initialized!\");\n        Ok(())\n    }\n\n    pub fn greet(_ctx: Context<Greet>) -> Result<()> {\n        msg!(\"Hello, Solana!\");\n        Ok(())\n    }\n\n    pub fn increment(ctx: Context<Increment>) -> Result<()> {\n        let counter = &mut ctx.accounts.counter;\n        counter.count += 1;\n        Ok(())\n    }\n\n    pub fn decrement(ctx: Context<Decrement>) -> Result<()> {\n        let counter = &mut ctx.accounts.counter;\n        require!(counter.count > 0, ErrorCode::Underflow);\n        counter.count -= 1;\n        Ok(())\n    }\n}\n\n#[derive(Accounts)]\npub struct Initialize<'info> {\n    #[account(\n        init,\n        payer = user,\n        space = 8 + 8 + 32,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n    pub system_program: Program<'info, System>,\n}\n\n#[derive(Accounts)]\npub struct Greet {}\n\n#[derive(Accounts)]\npub struct Increment<'info> {\n    #[account(\n        mut,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    pub user: Signer<'info>,\n}\n\n#[derive(Accounts)]\npub struct Decrement<'info> {\n    #[account(\n        mut,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    pub user: Signer<'info>,\n}\n\n#[account]\npub struct Counter {\n    pub count: u64,\n    pub authority: Pubkey,\n}\n\n#[error_code]\npub enum ErrorCode {\n    #[msg(\"Cannot decrement below zero\")]\n    Underflow,\n}\n",
+        "starter": "use anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n#[program]\npub mod academy_program {\n    use super::*;\n\n    pub fn initialize(ctx: Context<Initialize>) -> Result<()> {\n        let counter = &mut ctx.accounts.counter;\n        counter.count = 0;\n        counter.authority = ctx.accounts.user.key();\n        msg!(\"Counter initialized!\");\n        Ok(())\n    }\n\n    pub fn greet(_ctx: Context<Greet>) -> Result<()> {\n        msg!(\"Hello, Solana!\");\n        Ok(())\n    }\n\n    pub fn increment(ctx: Context<Increment>) -> Result<()> {\n        let counter = &mut ctx.accounts.counter;\n        counter.count += 1;\n        Ok(())\n    }\n\n    pub fn decrement(ctx: Context<Decrement>) -> Result<()> {\n        let counter = &mut ctx.accounts.counter;\n        require!(counter.count > 0, ErrorCode::Underflow);\n        counter.count -= 1;\n        Ok(())\n    }\n}\n\n#[derive(Accounts)]\npub struct Initialize<'info> {\n    #[account(\n        init,\n        payer = user,\n        space = 8 + 8 + 32,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n    pub system_program: Program<'info, System>,\n}\n\n#[derive(Accounts)]\npub struct Greet {}\n\n#[derive(Accounts)]\npub struct Increment<'info> {\n    #[account(\n        mut,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    pub user: Signer<'info>,\n}\n\n#[derive(Accounts)]\npub struct Decrement<'info> {\n    #[account(\n        mut,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    pub user: Signer<'info>,\n}\n\n#[account]\npub struct Counter {\n    pub count: u64,\n    pub authority: Pubkey,\n}\n\n#[error_code]\npub enum ErrorCode {\n    #[msg(\"Cannot decrement below zero\")]\n    Underflow,\n}\n",
         "tests": [
           {
-            "description": "The assembled vault program compiles successfully",
+            "description": "Complete counter program compiles successfully",
             "expectedOutput": "true",
-            "failureMessage": "The build server rejected the file, so there is nothing to deploy yet. Read the FIRST error, not the last: a failure inside #[program] or #[derive(Accounts)] is reported where the macro expanded, which is usually several lines above the edit that caused it.",
             "id": "test-deploy-1",
             "input": ""
           }
         ],
         "tutorNotes": [
-          "`declare_id!` is not the lever they think it is. The platform generates a program keypair and rewrites `declare_id!` with it before compiling, so the placeholder in the starter is irrelevant. A learner who pastes their previous program id in gets no effect at all — not an error, just nothing. If they ask how the program knows its own id, the answer is build-time injection, plus Anchor's runtime check that the invoked address equals `ID` (error 4100, DeclaredProgramIdMismatch).",
-          "Every Build mints a NEW program keypair, so a rebuild after a successful deploy produces a DIFFERENT program id. Learners who rebuild 'to be safe' then cannot tell which of two ids Course 4 wants. The id that counts is the one the panel reported after the Deploy that finished. Do not suggest rebuilding as a fix for anything except an actual compile error.",
-          "A deploy that dies partway usually died of money, not network. The upload is 200-plus transactions; a wallet holding exactly 2 SOL can run dry around chunk 150 and the symptom looks identical to a dropped connection. Check the balance before theorising about RPC. The recovery is fund-then-Resume; restarting from zero re-pays for chunks already on-chain.",
-          "Chunks are batch-signed roughly 30 at a time. Rejecting or dismissing one wallet popup aborts that whole batch, which reads as a mysterious stall. Resume is the correct next action — the confirmed chunks are already in the buffer, so nothing is lost, and re-deploying from scratch is the expensive mistake here.",
-          "`?cluster=devnet` is missing from their explorer URL. Solana Explorer defaults to mainnet, where their address does not exist, so it reports the account as not found and the learner concludes the deploy failed. Have them check the URL before they check anything else.",
-          "For the IDL step: `anchor idl init <PROGRAM_ID>` no longer exists — Anchor 1.0 removed the legacy on-chain IDL instructions, and most tutorials still teach it. The mechanism is the Program Metadata Program. Also, writing metadata requires the program's UPGRADE AUTHORITY, so a wallet switch between deploying and publishing fails with an authority error that looks nothing like an IDL problem."
+          "Learners hit a mid-deploy failure and restart from zero, re-uploading chunks that already landed, instead of clicking Resume, which skips the confirmed ones.",
+          "They run out of devnet SOL partway through the 200+ upload transactions and read the abort as a code bug; the buffer and fees simply drained the wallet — fund it and Resume.",
+          "They deploy with the wallet or CLI pointed at the wrong cluster, so a devnet program seems to vanish when they look for it on mainnet, or the deploy fails against an unfunded network.",
+          "They rebuild after a failed deploy and expect the same Program ID; a fresh program keypair yields a new id, so they then search the explorer for the old one and find nothing.",
+          "They reject or ignore one of the batch-signing popups and treat the stalled upload as a crash, rather than approving the next batch so the chunks keep confirming.",
+          "They read the green build check as a finished deploy — building only produced the `.so`; the on-chain upload is the separate step happening here."
         ]
-      },
-      {
-        "_key": "explore",
-        "_type": "program-explorer",
-        "consumes": [
-          "deployed-program"
-        ],
-        "idl": "{\n  \"address\": \"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\",\n  \"metadata\": {\n    \"name\": \"vault_program\",\n    \"version\": \"0.1.0\",\n    \"spec\": \"0.1.0\",\n    \"description\": \"Per-user SOL vault — Superteam Academy Course 3\"\n  },\n  \"instructions\": [\n    {\n      \"name\": \"initialize_vault\",\n      \"discriminator\": [48, 191, 163, 44, 71, 129, 63, 164],\n      \"accounts\": [\n        {\n          \"name\": \"vault\",\n          \"writable\": true,\n          \"pda\": {\n            \"seeds\": [\n              {\n                \"kind\": \"const\",\n                \"value\": [118, 97, 117, 108, 116]\n              },\n              {\n                \"kind\": \"account\",\n                \"path\": \"user\"\n              }\n            ]\n          }\n        },\n        {\n          \"name\": \"user\",\n          \"writable\": true,\n          \"signer\": true\n        },\n        {\n          \"name\": \"system_program\",\n          \"address\": \"11111111111111111111111111111111\"\n        }\n      ],\n      \"args\": []\n    },\n    {\n      \"name\": \"deposit\",\n      \"discriminator\": [242, 35, 198, 137, 82, 225, 242, 182],\n      \"accounts\": [\n        {\n          \"name\": \"vault\",\n          \"writable\": true,\n          \"pda\": {\n            \"seeds\": [\n              {\n                \"kind\": \"const\",\n                \"value\": [118, 97, 117, 108, 116]\n              },\n              {\n                \"kind\": \"account\",\n                \"path\": \"user\"\n              }\n            ]\n          }\n        },\n        {\n          \"name\": \"user\",\n          \"writable\": true,\n          \"signer\": true\n        },\n        {\n          \"name\": \"system_program\",\n          \"address\": \"11111111111111111111111111111111\"\n        }\n      ],\n      \"args\": [\n        {\n          \"name\": \"amount\",\n          \"type\": \"u64\"\n        }\n      ]\n    },\n    {\n      \"name\": \"withdraw\",\n      \"discriminator\": [183, 18, 70, 156, 148, 109, 161, 34],\n      \"accounts\": [\n        {\n          \"name\": \"vault\",\n          \"writable\": true,\n          \"pda\": {\n            \"seeds\": [\n              {\n                \"kind\": \"const\",\n                \"value\": [118, 97, 117, 108, 116]\n              },\n              {\n                \"kind\": \"account\",\n                \"path\": \"user\"\n              }\n            ]\n          }\n        },\n        {\n          \"name\": \"user\",\n          \"writable\": true,\n          \"signer\": true\n        }\n      ],\n      \"args\": [\n        {\n          \"name\": \"amount\",\n          \"type\": \"u64\"\n        }\n      ]\n    }\n  ],\n  \"accounts\": [\n    {\n      \"name\": \"VaultState\",\n      \"discriminator\": [228, 196, 82, 165, 98, 210, 235, 152]\n    }\n  ],\n  \"errors\": [\n    {\n      \"code\": 6000,\n      \"name\": \"Overflow\",\n      \"msg\": \"Deposit would overflow the vault balance\"\n    },\n    {\n      \"code\": 6001,\n      \"name\": \"InsufficientFunds\",\n      \"msg\": \"Withdrawal is larger than the vault balance\"\n    },\n    {\n      \"code\": 6002,\n      \"name\": \"ZeroAmount\",\n      \"msg\": \"Amount must be greater than zero\"\n    },\n    {\n      \"code\": 6003,\n      \"name\": \"NotOwner\",\n      \"msg\": \"Signer is not the vault owner\"\n    }\n  ],\n  \"types\": [\n    {\n      \"name\": \"VaultState\",\n      \"type\": {\n        \"kind\": \"struct\",\n        \"fields\": [\n          {\n            \"name\": \"owner\",\n            \"type\": \"pubkey\"\n          },\n          {\n            \"name\": \"balance\",\n            \"type\": \"u64\"\n          },\n          {\n            \"name\": \"bump\",\n            \"type\": \"u8\"\n          }\n        ]\n      }\n    }\n  ]\n}\n"
       },
       {
         "_key": "retrieval-close",
@@ -1978,7 +1510,7 @@
               },
               {
                 "correct": false,
-                "feedback": "It is about size limits, not speed. A whole 229KB binary cannot fit in one ~1232-byte transaction, so it is split into many.",
+                "feedback": "It is about size limits, not speed. A whole 200KB binary cannot fit in one ~1232-byte transaction, so it is split into many.",
                 "id": "b",
                 "label": "Chunking makes the upload faster than a single transaction"
               },
@@ -2015,97 +1547,104 @@
               }
             ],
             "prompt": "Deployment fails halfway through the chunk uploads. You click Resume. What does Resume do?"
-          },
-          {
-            "explanation": "Two things have to be right to read an account by hand: the offset and the byte order. The offset comes from the layout you derived in module 2 — 8 for the discriminator, 32 for `owner`, so `balance` begins at 40. The byte order is little-endian, which Solana uses throughout, so `00 ca 9a 3b 00 00 00 00` is 0x3B9ACA00 = 1,000,000,000. A client that gets either wrong reads plausible-looking garbage rather than failing loudly, which is why decoding is worth doing once by hand.",
-            "id": "q3",
-            "multiSelect": false,
-            "options": [
-              {
-                "correct": true,
-                "id": "a",
-                "label": "1,000,000,000 — a u64 is stored little-endian, least significant byte first, and the field starts at offset 40 because 8 (discriminator) + 32 (owner) come before it"
-              },
-              {
-                "correct": false,
-                "feedback": "Solana stores integers little-endian. Read as big-endian those bytes would be astronomically large; read correctly, least significant byte first, they are exactly 1,000,000,000 lamports.",
-                "id": "b",
-                "label": "An enormous number — read the bytes left to right as a big-endian integer"
-              },
-              {
-                "correct": false,
-                "feedback": "That byte order is big-endian. Little-endian puts the least significant byte first, which is why the `00 ca 9a 3b` end comes before the padding zeros.",
-                "id": "c",
-                "label": "1,000,000,000 — but little-endian would have written it as `00 00 00 00 3b 9a ca 00`"
-              }
-            ],
-            "prompt": "You deposit 1 SOL and open the vault account on the explorer. Bytes 40 through 47 of the raw data read `00 ca 9a 3b 00 00 00 00`. What is `balance`, and why is the layout that way round?"
-          },
-          {
-            "explanation": "This is the difference between a UI check and a rule. `require!(amount > 0, VaultError::ZeroAmount)` compiles into your program, so the validator runs it for every caller — the explorer panel, a script, a stranger's bot. The 6002 is Anchor's offset (6000) plus your variant's index, and the string is the `#[msg]` you wrote in Course 2, which is how a client that has never heard of your program can still render something a human can act on.",
-            "id": "q4",
-            "multiSelect": false,
-            "options": [
-              {
-                "correct": true,
-                "id": "a",
-                "label": "By the Solana runtime executing your deployed program's `require!` — the check is in your on-chain code, so it holds against any caller"
-              },
-              {
-                "correct": false,
-                "feedback": "The panel is a client, and any client can be bypassed or replaced. The guard lives in your program, which is why it holds for a caller you never wrote and cannot see.",
-                "id": "b",
-                "label": "By the explorer panel, which validates the amount before building the transaction"
-              },
-              {
-                "correct": false,
-                "feedback": "RPC nodes forward transactions; they do not know your business rules. The `require!` executes inside your program on the validator, and 6002 is your enum's third variant.",
-                "id": "c",
-                "label": "By the RPC node, which rejects instructions with zero-value arguments"
-              }
-            ],
-            "prompt": "You call `deposit` with `0` from the explorer panel and the transaction fails with custom error `6002` and the message \"Amount must be greater than zero\". Where is that rule actually enforced?"
-          },
-          {
-            "explanation": "The IDL is what turns an address into an interface. Published on-chain via the Program Metadata Program it is reachable from the program id alone, which is exactly what makes the next course possible: Course 4 fetches your IDL, runs Codama over it, and generates a typed client for a program it was told nothing else about. Note that Anchor 1.0 REMOVED the legacy on-chain IDL instructions — `anchor idl init` is no longer the mechanism, however many tutorials still say it is.",
-            "id": "q5",
-            "multiSelect": false,
-            "options": [
-              {
-                "correct": true,
-                "id": "a",
-                "label": "They can fetch the IDL from the chain using the id alone, and generate a typed client from it — no repo, no npm package, nothing from you"
-              },
-              {
-                "correct": false,
-                "feedback": "The IDL is an interface description — instruction names, discriminators, account lists, PDA seeds, layouts, error codes. Your Rust source is not on-chain; only the compiled binary and this metadata are.",
-                "id": "b",
-                "label": "They can read your program's source code on-chain"
-              },
-              {
-                "correct": false,
-                "feedback": "In principle a discriminator can be recovered by disassembly; in practice nobody does that. Names, argument types, account ordering and PDA seeds are not recoverable from the binary, and those are what an IDL supplies.",
-                "id": "c",
-                "label": "Nothing extra — they could already derive the instruction discriminators from the deployed binary"
-              }
-            ],
-            "prompt": "You publish your IDL with `npx @solana-program/program-metadata write idl <program-id> ./idl.json`. What does that actually buy someone who has only your program id?"
           }
         ]
       }
     ],
     "skills": [
-      "program-deployment",
-      "idl",
-      "solana-explorer",
-      "transactions",
-      "cpi"
+      "anchor",
+      "program-deployment"
     ],
     "slug": {
       "_type": "slug",
-      "current": "deploy-and-publish-the-idl"
+      "current": "deploy-program-devnet"
     },
-    "title": "Deploy and Publish the IDL"
+    "title": "Deploy Your Program to Devnet"
+  },
+  {
+    "_id": "lesson-bfsp-m4-interact",
+    "_type": "lesson",
+    "blocks": [
+      {
+        "_key": "intro",
+        "_type": "prose",
+        "src": "# Interact with Your Program\n\nYour counter program is live on Solana Devnet. Now let's call its instructions and watch the on-chain state change in real time.\n\n## What You'll Do\n\n1. **Initialize** a counter account — creates a new account owned by your program\n2. **Increment** the counter — modifies the on-chain state\n3. **Decrement** the counter — see your custom error handling in action\n\n## Understanding the Data\n\nThe Program Explorer below shows two views of your counter account:\n\n### Parsed Data\nThe human-readable version: `count: 3`\n\n### Raw Data (Hex)\nWhat's actually stored on-chain:\n```\n[a8 fc 0b 1f 05 77 32 45 | 03 00 00 00 00 00 00 00]\n ^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^^^^^^^^^^\n discriminator (8 bytes)    count: 3 (u64 LE)\n```\n\nThe **discriminator** is Anchor's way of identifying account types. It's the first 8 bytes of `sha256(\"account:Counter\")`. Every Anchor account starts with this — it's how the runtime knows it's looking at a `Counter` struct and not random data.\n\nThe **count** is stored as a `u64` in **little-endian** byte order. The value `3` is `03 00 00 00 00 00 00 00` because the least significant byte comes first.\n\n## Try This\n\n1. Click **Initialize** — watch the discriminator bytes appear\n2. Click **Increment** 3 times — watch `count` change from `00` to `03`\n3. Click **Decrement** down to 0, then try decrementing again\n4. See your `#[error_code] Underflow` in action!\n\n> **Teaching moment**: When you decrement below zero, your custom error `Cannot decrement below zero` is enforced by the Solana runtime. This is your code running on a real blockchain, enforcing rules you defined.\n"
+      },
+      {
+        "_key": "explore",
+        "_type": "program-explorer",
+        "consumes": [
+          "deployed-program"
+        ],
+        "idl": "{\"address\":\"11111111111111111111111111111111\",\"metadata\":{\"name\":\"counter\",\"version\":\"0.1.0\",\"spec\":\"0.1.0\"},\"instructions\":[{\"name\":\"initialize\",\"discriminator\":[175,175,109,31,13,152,155,237],\"accounts\":[{\"name\":\"counter\",\"writable\":true,\"pda\":{\"seeds\":[{\"kind\":\"const\",\"value\":[99,111,117,110,116,101,114]},{\"kind\":\"account\",\"path\":\"user\"}]}},{\"name\":\"user\",\"writable\":true,\"signer\":true},{\"name\":\"system_program\",\"address\":\"11111111111111111111111111111111\"}],\"args\":[]},{\"name\":\"increment\",\"discriminator\":[11,18,104,9,104,174,59,33],\"accounts\":[{\"name\":\"counter\",\"writable\":true,\"pda\":{\"seeds\":[{\"kind\":\"const\",\"value\":[99,111,117,110,116,101,114]},{\"kind\":\"account\",\"path\":\"user\"}]}},{\"name\":\"user\",\"signer\":true}],\"args\":[]},{\"name\":\"decrement\",\"discriminator\":[106,227,168,59,248,27,150,101],\"accounts\":[{\"name\":\"counter\",\"writable\":true,\"pda\":{\"seeds\":[{\"kind\":\"const\",\"value\":[99,111,117,110,116,101,114]},{\"kind\":\"account\",\"path\":\"user\"}]}},{\"name\":\"user\",\"signer\":true}],\"args\":[]}],\"accounts\":[{\"name\":\"Counter\",\"discriminator\":[255,176,4,245,188,253,124,25]}],\"types\":[{\"name\":\"Counter\",\"type\":{\"kind\":\"struct\",\"fields\":[{\"name\":\"count\",\"type\":\"u64\"},{\"name\":\"authority\",\"type\":\"publicKey\"}]}}],\"errors\":[{\"code\":6000,\"name\":\"Underflow\",\"msg\":\"Cannot decrement below zero\"}]}\n"
+      },
+      {
+        "_key": "retrieval-close",
+        "_type": "quiz",
+        "questions": [
+          {
+            "explanation": "A `u64` equal to 3 is `03 00 00 00 00 00 00 00` in little-endian, the byte order Solana uses. Reading raw account data means accounting for both the leading 8-byte discriminator and little-endian integer layout — exactly what a manual byte decoder must handle.",
+            "id": "q1",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "3 — the u64 is stored little-endian, so the least significant byte comes first"
+              },
+              {
+                "correct": false,
+                "feedback": "Solana stores integers little-endian, so `03 00 ...` is 3, not a huge big-endian value. The least significant byte leads.",
+                "id": "b",
+                "label": "A very large number — the bytes read left to right as big-endian"
+              },
+              {
+                "correct": false,
+                "feedback": "Little-endian puts the least significant byte first, so 3 is `03 00 00 00 00 00 00 00`. The `00 ... 03` layout is big-endian.",
+                "id": "c",
+                "label": "3, but little-endian would write it as `00 00 00 00 00 00 00 03`"
+              }
+            ],
+            "prompt": "The raw hex for the counter reads (after the discriminator) `03 00 00 00 00 00 00 00`. What is the value, and why is `03` first?"
+          },
+          {
+            "explanation": "The `#[error_code]` Underflow and its `require!` guard run inside your program on-chain, so the Solana runtime enforces them regardless of which client sends the transaction. That is the difference between a UI check anyone can skip and a rule that actually holds on a public network.",
+            "id": "q2",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "By the Solana runtime executing your deployed program's `require!` check — your own on-chain code"
+              },
+              {
+                "correct": false,
+                "feedback": "The UI is not the enforcer; a client could bypass it. The rule lives in your deployed program and the runtime enforces it, which is why it holds against any caller.",
+                "id": "b",
+                "label": "By the browser UI before the transaction is sent"
+              },
+              {
+                "correct": false,
+                "feedback": "RPC nodes forward transactions; they do not run your business rules. The `require!` guard executes inside your program on the validator.",
+                "id": "c",
+                "label": "By the RPC node validating the request"
+              }
+            ],
+            "prompt": "When you decrement below zero, the error `Cannot decrement below zero` appears. Where is that rule actually enforced?"
+          }
+        ]
+      }
+    ],
+    "skills": [
+      "solana-programs",
+      "transactions",
+      "account-model"
+    ],
+    "slug": {
+      "_type": "slug",
+      "current": "interact-with-program"
+    },
+    "title": "Interact with Your Program"
   },
   {
     "_id": "lesson-bfsp-on-chain-state",
@@ -2114,581 +1653,74 @@
       {
         "_key": "intro",
         "_type": "prose",
-        "src": "# Accounts Are Just Bytes\n\n> **Version stamp — checked 2026-07-26.** `anchor-lang 1.1.2` (published 2026-06-26) · `cargo-build-sbf` with platform-tools v1.54 (rustc 1.89) · `borsh` resolves to **1.8.0** · edition 2021. The three rent constants below — `ACCOUNT_STORAGE_OVERHEAD = 128`, `DEFAULT_LAMPORTS_PER_BYTE_YEAR = 3480`, `DEFAULT_EXEMPTION_THRESHOLD = 2.0` — were read out of `solana-rent`. The byte sizes were verified as `const` assertions compiled on the toolchain above.\n\nYour program so far has no memory. Every instruction logs a line and exits. Call it a thousand times\nand nothing about the chain is different afterwards.\n\nTo fix that you need an **account** — and an account is not an object, a row, or a document. It is a\nbyte buffer whose length you choose once, at creation, and can never change.\n\nThat single sentence is why this lesson comes before you write any code. The size decision is\nirreversible, it costs the payer money for as long as the account exists, and Anchor will not compute\nit for you unless you ask.\n\n## What the runtime actually stores\n\nEvery account on Solana carries exactly four things the runtime cares about:\n\n| Field    | What it is                                                    |\n| -------- | ------------------------------------------------------------- |\n| address  | 32 bytes. How anything finds the account                      |\n| owner    | 32 bytes. The **program id** allowed to write the data        |\n| lamports | The balance — and the rent-exemption deposit                  |\n| data     | A flat `[u8]` of fixed length. This is the part you design    |\n\nNote what is missing: no type, no schema, no column names. `data` is bytes. The only reason\n`[0, 0, 0, 0, 0, 0, 0, 0, 82, 12, …]` means anything at all is that a program agrees to read it a\nparticular way.\n\n\"Owner\" is the word people trip on. The **owner is a program**, not a person. Your vault's owner will\nbe your program id — that is what makes it program-controlled state rather than data sitting under\nsomebody's wallet. Your own `VaultState` has a field called `owner` too, and that one holds the\n*user's* wallet. Two different meanings, one word, both correct, and you will read code that uses\neach. The runtime's owner is enforced by the runtime. Yours is enforced only by the constraints you\nwrite in module 3.\n\n## The eight bytes you did not write\n\nAnchor puts an 8-byte **discriminator** at the front of every `#[account]` buffer. It is derived from\nthe account's type name, so `VaultState`'s eight bytes are not `Config`'s eight bytes.\n\n```\nbyte 0               8                                                          49\n  │  discriminator   │  your fields, Borsh-serialized in declaration order      │\n  └──────────────────┴──────────────────────────────────────────────────────────┘\n```\n\nEvery deserialize checks those eight bytes first. Hand your program some other program's account — or\nyour own `Config` where a `VaultState` is expected — and it fails on the discriminator instead of\nreading foreign bytes as if they were your struct. This is the cheapest security property in Anchor,\nand you get it by typing `#[account]`.\n\nYou never read or write those eight bytes yourself. You do have to **pay for them**.\n\n## Deriving the vault's size, out loud\n\nHere is the struct you wrote in Course 2, unchanged:\n\n```rust\n#[account]\n#[derive(InitSpace)]\npub struct VaultState {\n    pub owner: Pubkey,   // 32\n    pub balance: u64,    //  8\n    pub bump: u8,        //  1\n}\n```\n\nBorsh writes fields in declaration order, back to back, with no padding and no type information. So:\n\n```\n  8   discriminator   (Anchor, on every #[account])\n 32   owner: Pubkey   (32 raw bytes, no length prefix)\n  8   balance: u64    (little-endian, 8 bytes, fixed)\n  1   bump: u8        (one byte, values 0..=255)\n───\n 49   bytes total\n```\n\n**49.** Not \"about 48\", not \"round it to 64\". Forty-nine. You will type that as\n`space = 8 + 32 + 8 + 1` in the next two lessons — written as a sum rather than as `49`, so the reason\nfor every term stays visible in the code.\n\nThe sizes you need for anything else:\n\n| Type               | Bytes                                   |\n| ------------------ | --------------------------------------- |\n| `bool`, `u8`, `i8` | 1                                       |\n| `u16` / `i16`      | 2                                       |\n| `u32` / `i32`      | 4                                       |\n| `u64` / `i64`      | 8                                       |\n| `u128` / `i128`    | 16                                      |\n| `Pubkey`           | 32                                      |\n| `Option<T>`        | 1 + size of `T`                         |\n| `String`           | 4 (length prefix) + bytes of content    |\n| `Vec<T>`           | 4 (length prefix) + count × size of `T` |\n\nThe last two are where fixed-size accounts and variable-length data collide: you must allocate for the\n**maximum** length you will ever accept, and then enforce that maximum in code. A `String` field with\nno length cap is an account you cannot size.\n\n## Two ways to get 49 wrong\n\n**`std::mem::size_of::<VaultState>()` is not the answer.** Rust aligns struct fields for CPU access;\nBorsh does not. `size_of::<VaultState>()` is **48** — 41 bytes of fields rounded up to the struct's\n8-byte alignment — while Borsh writes **41**. Size with `size_of` and you allocate 56 bytes for a\n49-byte account, and overpay rent on every vault for as long as it exists, for no benefit. Rust's\nmemory layout and Borsh's wire layout are different problems that happen to be about the same struct.\n\n**Counting the discriminator twice, or not at all,** is the other one. `8 + 32 + 8 + 1` counts it\nonce. If you ever see a `space` that equals exactly the sum of the field sizes, that account is 8\nbytes short, and the first write past the field boundary fails.\n\nThe maintainable form is the one your Course 2 file already set up:\n\n```rust\nspace = 8 + VaultState::INIT_SPACE   // 8 + 41 = 49\n```\n\n`#[derive(InitSpace)]` generates `INIT_SPACE` as the sum of the field sizes — **without** the\ndiscriminator, which is why the `8 +` is still yours to write. Add a field later and the constant\nfollows; a literal sum does not. Ship `INIT_SPACE`. We write the sum in this course because you are\nlearning what it is made of.\n\n## Why the size is fixed, and what it costs\n\nThe runtime allocates `space` bytes at creation, and that is the account's size for life. There is a\nseparate `realloc` mechanism for growing an account later — a deliberate operation with its own payer\nand its own constraints, not something that happens because your struct grew.\n\nThe account also has to be **rent-exempt** to survive, which means holding a lamport balance above a\nminimum that scales with size:\n\n```\nminimum = (128 + space) × 3480 × 2 lamports\n```\n\n128 bytes is the per-account storage overhead the runtime charges regardless of your data, 3,480\nlamports is the per-byte-year price, and 2 is the exemption threshold in years. For the vault:\n\n```\n(128 + 49) × 3480 × 2  =  177 × 6960  =  1,231,920 lamports  ≈  0.00123 SOL\n```\n\nThat deposit is not a fee. It sits in the account and comes back if the account is ever closed. But it\nis the payer's SOL, locked, for as long as the account exists — which is why over-allocating has a\nprice tag and \"just make it 1024 bytes to be safe\" is a decision, not a precaution. Those three\nnumbers are protocol parameters, so the way to read the current value rather than trust a number in a\ntutorial is the `getMinimumBalanceForRentExemption` RPC method.\n\nOne thing that is **not** a cost: ongoing rent collection. It is gone. An account's `rent_epoch` field\nis vestigial — if you find prose describing it as \"when rent is next due\", that prose is describing a\nmechanism that no longer runs.\n\n## What Anchor stopped asking for\n\nSearch for account-creation examples and you will find this shape:\n\n```rust\n#[account(init, payer = user, space = 49, rent = rent)]\n```\n\n`rent = rent` was **removed in Anchor 0.31**. There is no `rent` constraint, and no\n`rent: Sysvar<'info, Rent>` field to add alongside it. Anchor reads the rent parameters itself and\ncomputes the deposit from `space`. Any tutorial still passing it predates 0.31 by definition — which\nis a useful dating signal for everything else on that page.\n\nWhat you do still supply, every time, is `space`. And now you know what each term in it pays for.\n"
+        "src": "# On-Chain State\n\nSo far, our program doesn't store any data. Every instruction just logs a message and exits. To build anything useful, you need **on-chain state** — data that persists between transactions.\n\n## Accounts = Storage\n\nOn Solana, all state lives in **accounts**. An account is a buffer of bytes owned by a program. Think of it like a row in a database, but on-chain.\n\nEvery account has:\n- **Address** (public key) — how you find it\n- **Owner** (program ID) — which program can modify it\n- **Data** (byte array) — the actual state\n- **Lamports** (balance) — rent deposit to keep it alive\n\n## The Discriminator\n\nAnchor adds an 8-byte **discriminator** at the start of every account's data. This is a hash of the account type name, used to prevent account type confusion attacks.\n\n```\n[8 bytes discriminator][...your data...]\n```\n\nYou never read or write the discriminator directly — Anchor handles it.\n\n## Space Calculation\n\nWhen you create an account, you must specify its size upfront (accounts can't be resized after creation). The formula:\n\n```\nspace = 8 (discriminator) + sum of field sizes\n```\n\nCommon field sizes:\n- `u8` / `i8` / `bool` = 1 byte\n- `u16` / `i16` = 2 bytes\n- `u32` / `i32` = 4 bytes\n- `u64` / `i64` = 8 bytes\n- `u128` / `i128` = 16 bytes\n- `Pubkey` = 32 bytes\n- `String` = 4 (length prefix) + content bytes\n- `Vec<T>` = 4 (length prefix) + (count * size_of::<T>())\n\n## Example: A Counter\n\nA simple counter needs one `u64` field:\n\n```rust\n#[account]\npub struct Counter {\n    pub count: u64,  // 8 bytes\n}\n// Total space = 8 (discriminator) + 8 (u64) = 16 bytes\n```\n\nThe `#[account]` attribute tells Anchor to:\n1. Add serialization/deserialization (Borsh)\n2. Add the 8-byte discriminator\n3. Implement account validation traits\n\nIn the next challenge, you'll define this Counter account and wire it into your program.\n"
       },
       {
         "_key": "retrieval-close",
         "_type": "quiz",
         "questions": [
           {
-            "explanation": "`space` = 8 (discriminator) + the Borsh size of every field, in declaration order, with no padding: 8 + 32 + 8 + 1 = 49. Write it as that sum rather than as `49` so each term stays traceable, and reach for `8 + VaultState::INIT_SPACE` in production code so that adding a field cannot silently under-allocate.",
+            "explanation": "space = 8 (discriminator) + sum of field sizes. A `u64` is 8 bytes, so a Counter is 8 + 8 = 16. This matters because accounts cannot be resized after creation — too small and writes fail, too large and the payer overpays rent.",
             "id": "q1",
             "multiSelect": false,
             "options": [
               {
                 "correct": true,
                 "id": "a",
-                "label": "49 — 8 discriminator + 32 + 8 + 1"
+                "label": "16 bytes — 8 for the discriminator plus 8 for the u64"
               },
               {
                 "correct": false,
-                "feedback": "41 is `VaultState::INIT_SPACE`, which is deliberately the fields only. `space` also has to pay for the 8-byte discriminator Anchor writes in front of them, so it is `8 + INIT_SPACE` = 49. An account sized 41 is 8 bytes short, and the first write past the field boundary fails.",
+                "feedback": "You forgot the discriminator. Every Anchor account starts with an 8-byte type discriminator, so a single u64 account needs 8 + 8 = 16.",
                 "id": "b",
-                "label": "41 — 32 + 8 + 1, the three fields"
+                "label": "8 bytes — just the u64"
               },
               {
                 "correct": false,
-                "feedback": "48 is Rust's in-memory size: 41 bytes of fields rounded up to the struct's 8-byte alignment. Borsh writes 41, with no padding at all. Sizing from `size_of` allocates for a layout that never reaches the account.",
+                "feedback": "A fixed-size `u64` has no length prefix; only dynamic types like String and Vec add one. The total is 8 + 8 = 16.",
                 "id": "c",
-                "label": "48 — that is what `std::mem::size_of::<VaultState>()` reports"
-              },
-              {
-                "correct": false,
-                "feedback": "Only variable-length types carry a length prefix — `String` and `Vec<T>` — and it is 4 bytes, not 8. Every field here is fixed-size, so there is no prefix to pay for.",
-                "id": "d",
-                "label": "57 — 8 discriminator + 8 length prefix + 32 + 8 + 1"
+                "label": "24 bytes — 8 discriminator + 8 length prefix + 8 u64"
               }
             ],
-            "prompt": "Your `VaultState` is `owner: Pubkey`, `balance: u64`, `bump: u8`. You are writing the `space` for its `init` constraint. What number does it have to come to, and why that number?"
+            "prompt": "A `Counter` holds one `u64`. What `space` must you allocate, and why that number?"
           },
           {
-            "explanation": "Rust's memory layout and Borsh's wire layout are different problems. `size_of::<VaultState>()` is 48 — 41 bytes rounded up to 8-byte alignment — so `8 + size_of` is 56 for an account that needs 49. Seven wasted bytes is roughly 48,700 lamports of deposit locked per vault (7 x 6,960), with nothing anywhere reporting it. `8 + VaultState::INIT_SPACE` is the form that stays correct.",
+            "explanation": "The 8-byte discriminator is derived from the account's type name, so Anchor rejects an account whose leading bytes do not match the expected `Counter` type. Without it, an attacker could pass a look-alike account and trick the program into interpreting foreign bytes as your struct.",
             "id": "q2",
             "multiSelect": false,
             "options": [
               {
                 "correct": true,
                 "id": "a",
-                "label": "It works, and silently over-allocates — 56 bytes for a 49-byte account, so every vault locks more rent deposit than it needs"
+                "label": "Account type confusion — passing a different account type where a Counter is expected, since its discriminator will not match"
               },
               {
                 "correct": false,
-                "feedback": "`size_of` is a `const fn`, so the expression evaluates fine at compile time. Nothing stops it, and that is exactly what makes this bug expensive: there is no error anywhere to point at it.",
+                "feedback": "The discriminator is about type identity, not balances. It stops a program from mistaking one account type for another.",
                 "id": "b",
-                "label": "It fails to compile — `size_of` is not const-evaluable in a constraint"
+                "label": "Double-spending of lamports"
               },
               {
                 "correct": false,
-                "feedback": "It goes the other way. Rust's `size_of` is 48 because of alignment padding; Borsh writes 41. The account ends up too big, never too small — so nothing fails, it just costs more.",
+                "feedback": "Replay is handled by the recent blockhash, not the discriminator. The discriminator guards account type identity on deserialize.",
                 "id": "c",
-                "label": "Writes past byte 49 fail, because Borsh needs more room than `size_of` reports"
-              },
-              {
-                "correct": false,
-                "feedback": "Anchor allocates exactly the `space` you give it and does not second-guess the number. `#[derive(InitSpace)]` offers you a correct one in `INIT_SPACE`, but only if you use it.",
-                "id": "d",
-                "label": "The account is created at 49 bytes anyway — Anchor recomputes `space` from the struct"
+                "label": "Replaying an old transaction"
               }
             ],
-            "prompt": "A teammate writes `space = 8 + std::mem::size_of::<VaultState>()`. It compiles and the program deploys. Predict what actually happens."
-          },
-          {
-            "explanation": "Type confusion is a runtime problem because account data arrives as bytes. Anchor's 8-byte discriminator is derived from the account type's name, so it is checked on every deserialize and a mismatch is an error instead of a reinterpretation of foreign bytes as your struct. You buy this by typing `#[account]`, and you pay for it with 8 bytes of `space`.",
-            "id": "q3",
-            "multiSelect": false,
-            "options": [
-              {
-                "correct": true,
-                "id": "a",
-                "label": "At deserialize, at runtime — the leading 8 bytes are that other type's discriminator, so they do not match `VaultState`'s"
-              },
-              {
-                "correct": false,
-                "feedback": "The type only constrains your Rust. What arrives on the wire is a 32-byte address and a buffer; nothing about a transaction is type-checked by rustc. The check has to happen at runtime, and the discriminator is what makes it possible.",
-                "id": "b",
-                "label": "At compile time — `Account<'info, VaultState>` is a type, so the wrong type cannot be passed"
-              },
-              {
-                "correct": false,
-                "feedback": "That is precisely what the discriminator exists to prevent, and what would happen without it. The first 8 bytes are checked before any field is read, and a mismatch is an error rather than a reinterpretation.",
-                "id": "c",
-                "label": "It does not stop — the sizes match, so the bytes deserialize into a valid-looking `VaultState`"
-              },
-              {
-                "correct": false,
-                "feedback": "The runtime enforces who may *write* an account, not who may pass one in. Anyone can put any address in an instruction's account list. Filtering what arrives is your program's job.",
-                "id": "d",
-                "label": "The runtime rejects it, because only your program may pass its own accounts"
-              }
-            ],
-            "prompt": "Your `withdraw` expects `Account<'info, VaultState>`. Someone passes an account of a different type that happens to be 49 bytes and owned by your program. Where does this stop, and how?"
-          },
-          {
-            "explanation": "`rent = rent` and its companion `rent: Sysvar<'info, Rent>` field were both removed in Anchor 0.31; Anchor computes the rent-exempt minimum from `space` on its own. The useful part is the dating signal — a page still passing `rent` predates 0.31, so treat everything else it tells you about Anchor as equally old.",
-            "id": "q4",
-            "multiSelect": false,
-            "options": [
-              {
-                "correct": true,
-                "id": "a",
-                "label": "It will not compile — the `rent` constraint was removed in Anchor 0.31, which also dates the rest of that post as pre-0.31"
-              },
-              {
-                "correct": false,
-                "feedback": "It is not optional, because it no longer exists. Anchor reads the rent parameters itself and derives the deposit from `space`. Leaving the constraint in is a build failure, not a stylistic choice.",
-                "id": "b",
-                "label": "Nothing — it is optional, and harmless to keep for clarity"
-              },
-              {
-                "correct": false,
-                "feedback": "`payer` is all Anchor needs. The deposit is computed from `space` and debited from the payer; there was never a version where `rent` proved anything about the payer's balance.",
-                "id": "c",
-                "label": "It is required whenever `payer` is present, to prove the payer can cover the deposit"
-              },
-              {
-                "correct": false,
-                "feedback": "Ongoing rent collection is gone, and an account's `rent_epoch` is vestigial. What remains is the one-time rent-exemption deposit, which scales with `space` and comes back if the account is closed.",
-                "id": "d",
-                "label": "Rent is still collected periodically, so the sysvar has to be passed to schedule it"
-              }
-            ],
-            "prompt": "You copy an `init` constraint from a blog post and it includes `rent = rent`. What does that tell you?"
+            "prompt": "Anchor prepends an 8-byte discriminator (a hash of the account type name) to every account. What attack does this prevent?"
           }
         ]
       }
     ],
     "skills": [
-      "account-model",
-      "rent-and-space",
-      "solana-programs"
+      "solana-programs",
+      "account-model"
     ],
     "slug": {
       "_type": "slug",
-      "current": "accounts-are-just-bytes"
+      "current": "on-chain-state"
     },
-    "title": "Accounts Are Just Bytes"
-  },
-  {
-    "_id": "lesson-bfsp-pdas-vault",
-    "_type": "lesson",
-    "blocks": [
-      {
-        "_key": "intro",
-        "_type": "prose",
-        "src": "# PDAs: An Address With No Key\n\n> **Version stamp — checked 2026-07-26.** `anchor-lang 1.1.2` (published 2026-06-26) · `cargo-build-sbf` with platform-tools v1.54 (rustc 1.89) · `borsh` resolves to **1.8.0** · edition 2021. Every compiler message quoted below was produced by compiling this lesson's starter on that toolchain.\n\nYou know how to size the vault. You do not yet know **where it lives**, and the answer is stranger than\nit looks: at an address that nobody can sign for.\n\n## The problem a PDA solves\n\nRight now your `initialize_vault` creates an account at whatever address the client hands it. That has\ntwo failures, and the compiler can see neither of them.\n\nThe first is that nothing ties the account to the user. Any address will do. There is no rule that\nAlice gets one vault, or that Alice's vault is Alice's.\n\nThe second is worse. A normal account's address **is** a public key, and somewhere there is a private\nkey that matches it. Whoever holds that private key can sign for the account. An account your program\nis supposed to control, sitting at an address someone can sign for, is not controlled by your program.\n\nA **Program Derived Address** fixes both at once. It is an address computed from inputs you choose, and\nit is deliberately an address for which no private key exists.\n\n## Why no private key exists\n\nSolana signatures are Ed25519, and every Ed25519 public key is a point on a particular elliptic curve.\nNot every 32-byte string is such a point — most are not. A byte string that is not on the curve cannot\nbe a public key, so no private key can correspond to it, so nothing can ever produce a signature for\nit.\n\nPDA derivation exploits exactly that. It searches for a 32-byte result that is **off** the curve:\n\n```\nfor bump in (0..=255).rev() {\n    candidate = sha256(seeds || [bump] || program_id || \"ProgramDerivedAddress\")\n    if !is_on_curve(candidate) {\n        return (candidate, bump)\n    }\n}\n```\n\nThree things to take from that loop.\n\n**The search runs downward from 255.** The first bump that yields an off-curve result is the\n**canonical bump** for those seeds. Roughly half of all candidates are off-curve, so it is usually 255\nand almost always found within the first few tries — but \"usually\" is not \"always\", which is why the\nbump is an output of the derivation and not a constant you can assume.\n\n**The program id is part of the hash.** The same seeds under a different program id give a different\naddress. A PDA belongs to one program by construction, and no other program can derive into your\naddress space.\n\n**The literal `\"ProgramDerivedAddress\"` marker is in there too.** It is what keeps PDA derivation from\ncolliding with the other ways addresses get derived on Solana.\n\nThe output is an address your program can *authorize* — not by signing, but by presenting the seeds\nduring a cross-program invocation and letting the runtime re-derive and check them. That is module 3's\nlesson. What matters here is the consequence: **the seeds are the credential**. Knowing them is what\nlets your program act for the address, and no key theft can substitute for them.\n\n## In Anchor, you do not run the loop\n\n`Pubkey::find_program_address` and `Pubkey::try_find_program_address` are the primitives, and you will\nsee them in client code and in native programs. Inside an Anchor accounts struct you almost never call\nthem, because two constraints do it declaratively:\n\n```rust\n#[account(\n    init,\n    payer = user,\n    space = 8 + 32 + 8 + 1,\n    seeds = [b\"vault\", user.key().as_ref()],\n    bump\n)]\npub vault: Account<'info, VaultState>,\n```\n\n`seeds` says what the address is derived from. Bare `bump` says \"derive the canonical bump and check\nthat the account you were handed is at that exact address.\" If the client passes anything else, the\ninstruction fails before your handler body runs — you do not write that check, and you cannot forget\nto.\n\nThe two constraints are a pair, and Anchor refuses either one alone — with a different\nmessage for each direction, which is a free hint about which half you forgot.\n`seeds` without `bump` reports `bump must be provided with seeds`. `bump` without\n`seeds` reports `seeds must be provided before bump`, because there is nothing to bump.\n\nAnchor also hands you the bump it just computed, on `ctx.bumps`, named after the field:\n\n```rust\nvault.bump = ctx.bumps.vault;\n```\n\n`ctx.bumps.vault` exists **only** if that account carries a `bump` constraint. Reference it without\none and the compiler says `no field 'vault' on type 'InitializeVaultBumps'`. That is a useful property:\nit makes one of this lesson's subgoals something the build can actually check.\n\n## Store the bump. Always store the bump.\n\nYou already have `bump: u8` in `VaultState`. This is the lesson where the reason lands.\n\nEvery later instruction — `deposit`, `withdraw`, anything that touches the vault — has to prove the\naccount it was given is the right PDA. It can do that two ways:\n\n```rust\n// re-derives: runs the search loop again, on-chain, every call\n#[account(mut, seeds = [b\"vault\", user.key().as_ref()], bump)]\n\n// reads the byte you stored, then verifies that one candidate\n#[account(mut, seeds = [b\"vault\", user.key().as_ref()], bump = vault.bump)]\n```\n\nThe first form pays for the search in compute units. Each candidate is a SHA-256 over the seeds plus\nthe program id plus the marker, followed by a curve check, and the loop stops at the first off-curve\nresult — typically after one round, occasionally after several. The second form does one hash with a\nknown bump and compares. It is strictly cheaper, and the difference is unbounded in the bad case\nwhereas the stored form is constant.\n\nThere is a correctness argument too, and it is the more important one. `bump = vault.bump` pins the\naccount to the bump that was canonical **when the vault was created**, which is the only bump that\naddress should ever be reachable by. Accepting a bump the caller supplies, without checking it against\na stored value, is how programs end up with several valid addresses for what was meant to be one\naccount. The stored byte is a one-byte commitment that removes the question.\n\nOne byte of `space`, about 0.000014 SOL of deposit, for a cheaper and tighter check on every future\ninstruction. That is the trade, and it is not close.\n\n## Designing seeds\n\nSeeds are an ordered list of byte slices. Up to 16 of them, each at most 32 bytes, and the bump counts\nas one — so 15 is your practical ceiling, which is far more than you will want.\n\n**One per user** — what the vault uses:\n\n```rust\nseeds = [b\"vault\", user.key().as_ref()]\n```\n\nThe `b\"vault\"` prefix is a namespace. Without it, a second per-user account in the same program would\nderive to the same address as the first.\n\n**One per user per resource** — the shape for orders, escrows, positions:\n\n```rust\nseeds = [b\"order\", user.key().as_ref(), &order_id.to_le_bytes()]\n```\n\nNote `to_le_bytes()`. Numbers go into seeds as their fixed-width little-endian bytes, never as decimal\ntext, because a fixed width is what keeps them from running into the next seed.\n\n**One per program** — config and authority singletons:\n\n```rust\nseeds = [b\"config\"]\n```\n\nThe hazard to actually avoid is **ambiguity between adjacent variable-length seeds**. If you derive\nfrom two user-supplied strings back to back, `[\"alice\", \"bob\"]` and `[\"alic\", \"ebob\"]` are different\nseed lists — but a design that lets a caller choose where the boundary falls is a design where two\ndifferent logical keys can land on one address. Fixed-width seeds (a `Pubkey` is always 32 bytes, a\n`u64` is always 8) do not have this problem, which is why almost every PDA in production is a constant\nprefix plus fixed-width parts.\n\n## What the build can and cannot see\n\nThe compiler will catch a `bump` with no `seeds`, and it will catch `ctx.bumps.vault` when no `bump`\nconstraint exists. It will not catch seeds that are simply *wrong* — `b\"vaults\"`, or the user's key\nwhere the mint's belongs. Those derive a perfectly valid PDA at an address your client never looks at,\nand the failure shows up as a puzzling `ConstraintSeeds` error at runtime, or as an account that\ninitializes fine and is then unreachable.\n\nThe check for that is the derivation you already wrote on the client side in Course 1: derive the\naddress off-chain, derive it on-chain, and require that they match. Module 4 shows you exactly that assertion written as a\nLiteSVM test — read it before you spend a lamport on devnet.\n\n---\n\n## Your task\n\nBuild the starter before you change anything. It reports **one** error, and the error is not in your\nprogram:\n\n```\nerror[E0609]: no field `vault` on type `&InitializeVaultBumps`\n```\n\nThat comes from the verification harness at the bottom of the file. Your `initialize_vault` compiles\nperfectly well as it stands — it creates a 49-byte account at whatever address the client passes, with\nno seeds, no bump, and no relationship to the user whatsoever. That is a legal Anchor program and a\nbroken vault, and nothing except the harness can tell the difference. Which is the whole reason the\nharness is there.\n\nThree labeled subgoals turn it into a PDA. Do them in order; each one is what makes the next one\npossible.\n"
-      },
-      {
-        "_key": "exercise",
-        "_type": "code",
-        "buildType": "buildable",
-        "deployable": false,
-        "hints": [
-          "Build before you type anything. One error comes back, from the harness rather than from your program: `no field 'vault' on type '&InitializeVaultBumps'`. Anchor grows that struct a field per account that carries a `bump` constraint, and yours carries none yet — so the error is telling you the vault is not a PDA. Subgoals 1 and 2 are what make the field appear.",
-          "Subgoal 1 is one line inside the `#[account(...)]` parentheses: `seeds = [b\"vault\", user.key().as_ref()],`. Two easy misses — the `space = 8 + 32 + 8 + 1` line above it now needs a trailing comma, and the prefix is the byte literal `b\"vault\"`, not the string `\"vault\"`. Subgoal 2 is the bare word `bump` on the next line. They are a pair, and the message names the missing half: add only `seeds` and Anchor answers `bump must be provided with seeds`; add only `bump` and it answers `seeds must be provided before bump`.",
-          "Subgoal 3 is `vault.bump = ctx.bumps.vault;` in the handler, above the `msg!`. It compiles only once subgoal 2 exists, which is the point — and note that the build cannot tell whether you wrote it, only whether it *could* be written. Skipping it leaves a vault whose stored bump is 0, and every `bump = vault.bump` check in module 3 fails against it."
-        ],
-        "language": "rust",
-        "solution": "use anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n// ─────────────────────────────────────────────────────────────────────────────\n// Your Course 2 vault core, imported and not retyped. Untouched by this lesson.\n// ─────────────────────────────────────────────────────────────────────────────\npub mod vault {\n    use super::*;\n\n    #[account]\n    #[derive(InitSpace)]\n    pub struct VaultState {\n        pub owner: Pubkey,\n        pub balance: u64,\n        pub bump: u8,\n    }\n\n    #[error_code]\n    pub enum VaultError {\n        #[msg(\"Deposit would overflow the vault balance\")]\n        Overflow,\n        #[msg(\"Withdrawal is larger than the vault balance\")]\n        InsufficientFunds,\n        #[msg(\"Amount must be greater than zero\")]\n        ZeroAmount,\n        #[msg(\"Signer is not the vault owner\")]\n        NotOwner,\n    }\n\n    impl VaultState {\n        pub fn deposit(&mut self, amount: u64) -> Result<()> {\n            require!(amount > 0, VaultError::ZeroAmount);\n            self.balance = self\n                .balance\n                .checked_add(amount)\n                .ok_or(VaultError::Overflow)?;\n            Ok(())\n        }\n\n        pub fn withdraw(&mut self, amount: u64) -> Result<()> {\n            require!(amount > 0, VaultError::ZeroAmount);\n            self.balance = self\n                .balance\n                .checked_sub(amount)\n                .ok_or(VaultError::InsufficientFunds)?;\n            Ok(())\n        }\n    }\n}\n\npub use vault::{VaultError, VaultState};\n\n#[program]\npub mod vault_program {\n    use super::*;\n\n    pub fn initialize_vault(ctx: Context<InitializeVault>) -> Result<()> {\n        let vault = &mut ctx.accounts.vault;\n        vault.owner = ctx.accounts.user.key();\n        vault.balance = 0;\n\n        // SUBGOAL 3. One byte, written once, so that `deposit` and `withdraw` can\n        // use `bump = vault.bump` instead of re-running the derivation search on\n        // every call.\n        vault.bump = ctx.bumps.vault;\n\n        msg!(\"Vault initialized for {}\", vault.owner);\n        Ok(())\n    }\n\n    pub fn vault_info(_ctx: Context<VaultInfo>) -> Result<()> {\n        msg!(\"Vault program online\");\n        Ok(())\n    }\n}\n\n#[derive(Accounts)]\npub struct InitializeVault<'info> {\n    #[account(\n        init,\n        payer = user,\n        space = 8 + 32 + 8 + 1,\n        // SUBGOAL 1. A namespace prefix, then the user's key as raw bytes. One\n        // vault per wallet, at an address any client can re-derive without\n        // being told it.\n        seeds = [b\"vault\", user.key().as_ref()],\n        // SUBGOAL 2. Derive the canonical bump and require that the account\n        // handed in is at that exact address. This is the check you would\n        // otherwise have to write by hand, and forget.\n        bump\n    )]\n    pub vault: Account<'info, VaultState>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n    pub system_program: Program<'info, System>,\n}\n\n#[derive(Accounts)]\npub struct VaultInfo {}\n\n// ─────────────────────────────────────────────────────────────────────────────\n// VERIFICATION HARNESS — DO NOT EDIT ANYTHING BELOW THIS LINE.\n// A type check, not a behaviour check. See the starter for what it does and\n// does not reach.\n// ─────────────────────────────────────────────────────────────────────────────\n#[doc(hidden)]\n#[allow(dead_code)]\nmod verify {\n    use super::*;\n\n    const _: () = assert!(VaultState::DISCRIMINATOR.len() == 8);\n    const _: () = assert!(VaultState::INIT_SPACE == 41);\n\n    fn pin_bump(bumps: &InitializeVaultBumps) -> u8 {\n        bumps.vault\n    }\n\n    fn pin_vault<'info>(a: &'info InitializeVault<'info>) -> &'info Account<'info, VaultState> {\n        &a.vault\n    }\n    fn pin_user<'info>(a: &'info InitializeVault<'info>) -> &'info Signer<'info> {\n        &a.user\n    }\n    fn pin_system<'info>(a: &'info InitializeVault<'info>) -> &'info Program<'info, System> {\n        &a.system_program\n    }\n}\n",
-        "starter": "use anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n// ─────────────────────────────────────────────────────────────────────────────\n// Your Course 2 vault core, imported and not retyped. Nothing in this module\n// needs to change in this lesson — `bump: u8` is already here, waiting for a\n// reason.\n// ─────────────────────────────────────────────────────────────────────────────\npub mod vault {\n    use super::*;\n\n    #[account]\n    #[derive(InitSpace)]\n    pub struct VaultState {\n        pub owner: Pubkey,\n        pub balance: u64,\n        pub bump: u8,\n    }\n\n    #[error_code]\n    pub enum VaultError {\n        #[msg(\"Deposit would overflow the vault balance\")]\n        Overflow,\n        #[msg(\"Withdrawal is larger than the vault balance\")]\n        InsufficientFunds,\n        #[msg(\"Amount must be greater than zero\")]\n        ZeroAmount,\n        #[msg(\"Signer is not the vault owner\")]\n        NotOwner,\n    }\n\n    impl VaultState {\n        pub fn deposit(&mut self, amount: u64) -> Result<()> {\n            require!(amount > 0, VaultError::ZeroAmount);\n            self.balance = self\n                .balance\n                .checked_add(amount)\n                .ok_or(VaultError::Overflow)?;\n            Ok(())\n        }\n\n        pub fn withdraw(&mut self, amount: u64) -> Result<()> {\n            require!(amount > 0, VaultError::ZeroAmount);\n            self.balance = self\n                .balance\n                .checked_sub(amount)\n                .ok_or(VaultError::InsufficientFunds)?;\n            Ok(())\n        }\n    }\n}\n\npub use vault::{VaultError, VaultState};\n\n#[program]\npub mod vault_program {\n    use super::*;\n\n    pub fn initialize_vault(ctx: Context<InitializeVault>) -> Result<()> {\n        let vault = &mut ctx.accounts.vault;\n        vault.owner = ctx.accounts.user.key();\n        vault.balance = 0;\n\n        // ── SUBGOAL 3 ────────────────────────────────────────────────────────\n        // Store the canonical bump, so that no later instruction has to run the\n        // derivation search again. Anchor hands you the bump it just computed on\n        // `ctx.bumps`, under the field's own name.\n        //\n        // One line, right here. It only compiles once subgoal 2 is done.\n\n        msg!(\"Vault initialized for {}\", vault.owner);\n        Ok(())\n    }\n\n    pub fn vault_info(_ctx: Context<VaultInfo>) -> Result<()> {\n        msg!(\"Vault program online\");\n        Ok(())\n    }\n}\n\n#[derive(Accounts)]\npub struct InitializeVault<'info> {\n    #[account(\n        init,\n        payer = user,\n        space = 8 + 32 + 8 + 1\n        // ── SUBGOAL 1 ────────────────────────────────────────────────────────\n        // Derive this account's address instead of accepting whatever the client\n        // passed. Add a `seeds` constraint: a `b\"vault\"` namespace prefix, then\n        // the user's key as raw bytes.\n        //\n        // Remember the trailing comma on the line above once you add a line\n        // below it.\n        //\n        // ── SUBGOAL 2 ────────────────────────────────────────────────────────\n        // Ask Anchor for the canonical bump and check that the account handed in\n        // really is at that address. One bare word. `seeds` without it does not\n        // compile, and neither does it without `seeds`.\n    )]\n    pub vault: Account<'info, VaultState>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n    pub system_program: Program<'info, System>,\n}\n\n#[derive(Accounts)]\npub struct VaultInfo {}\n\n// ─────────────────────────────────────────────────────────────────────────────\n// VERIFICATION HARNESS — DO NOT EDIT ANYTHING BELOW THIS LINE.\n//\n// This is a TYPE check, not a behaviour check. Grading on this platform is\n// compile-success: the build server compiles your file and reports whether it\n// built. Nothing inspects your source, and there are no hidden tests on the Rust\n// path. So the harness names, in Rust, the things a passing file must have —\n// and an absent or wrongly-typed item becomes a compile error the grader\n// already catches.\n//\n// What it reaches: subgoals 1 and 2, via `InitializeVaultBumps`. `ctx.bumps`\n// only grows a field for an account that carries a `bump` constraint, and\n// Anchor only accepts `bump` alongside `seeds`.\n//\n// What it cannot reach: whether your seeds are the *right* seeds, and whether\n// you actually stored the bump in subgoal 3. Those are proven in module 4,\n// against a real runtime.\n// ─────────────────────────────────────────────────────────────────────────────\n#[doc(hidden)]\n#[allow(dead_code)]\nmod verify {\n    use super::*;\n\n    // `#[account]` is present: 8 bytes of discriminator.\n    const _: () = assert!(VaultState::DISCRIMINATOR.len() == 8);\n\n    // `#[derive(InitSpace)]` is present and the fields are still exactly\n    // Pubkey (32) + u64 (8) + u8 (1) = 41. `space` is 8 + this.\n    const _: () = assert!(VaultState::INIT_SPACE == 41);\n\n    // The vault account is a PDA: this field exists only when `vault` carries a\n    // `bump` constraint, which Anchor accepts only alongside `seeds`.\n    fn pin_bump(bumps: &InitializeVaultBumps) -> u8 {\n        bumps.vault\n    }\n\n    fn pin_vault<'info>(a: &'info InitializeVault<'info>) -> &'info Account<'info, VaultState> {\n        &a.vault\n    }\n    fn pin_user<'info>(a: &'info InitializeVault<'info>) -> &'info Signer<'info> {\n        &a.user\n    }\n    fn pin_system<'info>(a: &'info InitializeVault<'info>) -> &'info Program<'info, System> {\n        &a.system_program\n    }\n}\n",
-        "tests": [
-          {
-            "description": "The file compiles on the build server against anchor-lang 1.1.2",
-            "expectedOutput": "true",
-            "id": "t1",
-            "input": ""
-          },
-          {
-            "description": "Compiles ⇒ the vault account carries a bump constraint, so ctx.bumps.vault exists",
-            "expectedOutput": "true",
-            "id": "t2",
-            "input": ""
-          },
-          {
-            "description": "Compiles ⇒ that bump constraint sits alongside seeds — Anchor rejects one without the other",
-            "expectedOutput": "true",
-            "id": "t3",
-            "input": ""
-          },
-          {
-            "description": "Compiles ⇒ VaultState still has owner: Pubkey, balance: u64, bump: u8 — INIT_SPACE is 41",
-            "expectedOutput": "true",
-            "id": "t4",
-            "input": ""
-          },
-          {
-            "description": "Compiles ⇒ InitializeVault holds vault, a mutable user Signer, and the System Program",
-            "expectedOutput": "true",
-            "id": "t5",
-            "input": ""
-          }
-        ]
-      },
-      {
-        "_key": "retrieval-close",
-        "_type": "quiz",
-        "questions": [
-          {
-            "explanation": "Ed25519 public keys are points on a curve, and most 32-byte strings are not points. PDA derivation hashes `seeds || bump || program_id || \"ProgramDerivedAddress\"`, counting the bump down from 255, and returns the first result that is off the curve. No key exists, so no key can be stolen — and what authorizes the address is knowledge of its seeds, which only the deriving program can present.",
-            "id": "q1",
-            "multiSelect": false,
-            "options": [
-              {
-                "correct": true,
-                "id": "a",
-                "label": "Derivation searches for a result that is **off** the Ed25519 curve, and only curve points can be public keys — so nothing can ever sign for it, and the seeds become the credential instead"
-              },
-              {
-                "correct": false,
-                "feedback": "A program has no secrets. Its bytecode is public, its accounts are public, and anything it stored would be readable by everyone. PDA authority works precisely because there is no key to hold — the runtime re-derives from seeds instead.",
-                "id": "b",
-                "label": "The private key exists but is held by the program, which keeps it in its own account data"
-              },
-              {
-                "correct": false,
-                "feedback": "There is nothing to discard. The derivation never produces a keypair; it hashes seeds and keeps going until the 32-byte result is not a valid curve point, which means no matching private key can exist at all.",
-                "id": "c",
-                "label": "The private key is discarded after derivation, so nobody has a copy"
-              },
-              {
-                "correct": false,
-                "feedback": "The runtime does not need such a rule, and account ownership is a separate matter — a plain keypair account can be owned by a program too. The guarantee here is mathematical, not a policy check.",
-                "id": "d",
-                "label": "It has one, but the runtime refuses signatures for accounts owned by a program"
-              }
-            ],
-            "prompt": "Why is there no private key for the vault PDA, and what follows from that?"
-          },
-          {
-            "explanation": "Bare `bump` runs the search: SHA-256 over the seeds plus program id plus marker, then a curve check, repeated until a candidate is off-curve. Usually that is one round; the worst case is unbounded. `bump = vault.bump` does one hash with a known bump and compares. One byte of `space` buys a constant-cost check on every future instruction, and pins the account to a single canonical bump instead of whichever one a caller supplies.",
-            "id": "q2",
-            "multiSelect": false,
-            "options": [
-              {
-                "correct": true,
-                "id": "a",
-                "label": "Bare `bump` re-runs the derivation search on-chain; `bump = vault.bump` verifies the one stored byte — cheaper in compute units, and pinned to the bump the vault was created with"
-              },
-              {
-                "correct": false,
-                "feedback": "They generate different code. Bare `bump` derives the canonical bump from scratch, hashing candidates until one lands off the curve. `bump = vault.bump` reads your stored byte and verifies that single candidate.",
-                "id": "b",
-                "label": "No difference — both compile to the same check, and `vault.bump` is only documentation"
-              },
-              {
-                "correct": false,
-                "feedback": "It is not trusted blindly — Anchor still derives the address from the seeds plus that bump and requires the account to be at it. Storing the bump is what pins the vault to the bump that was canonical at creation, which is tighter than accepting whatever a caller offers.",
-                "id": "c",
-                "label": "`bump = vault.bump` is less safe, because it trusts a value from account data instead of deriving it"
-              },
-              {
-                "correct": false,
-                "feedback": "Nothing is cached between instructions — each one is a fresh execution with no memory of the last. Any derivation it performs, it performs from scratch.",
-                "id": "d",
-                "label": "Bare `bump` is cheaper, because Anchor caches the canonical bump between instructions"
-              }
-            ],
-            "prompt": "`deposit` needs to verify its vault account. Compare `bump = vault.bump` with a bare `bump`. What is the difference at runtime?"
-          },
-          {
-            "explanation": "`seeds` and `bump` are a pair, and Anchor says so in as many words: `bump must be provided with seeds`. Everything after it — `the trait bound InitializeVault: Bumps is not satisfied`, `no function named try_accounts`, `unresolved import crate` — is fallout from the derive macro having given up. That shape recurs throughout Anchor: the first error is the real one and the rest are debris. Read from the top, fix one thing, build again.",
-            "id": "q3",
-            "multiSelect": false,
-            "options": [
-              {
-                "correct": true,
-                "id": "a",
-                "label": "\"`error: bump must be provided with seeds` first, then a cascade of trait-bound errors on `InitializeVault` — the first line is the real one, the rest are debris from the accounts struct failing to generate\""
-              },
-              {
-                "correct": false,
-                "feedback": "Anchor's own message does come first and does name the fix, but a `#[derive(Accounts)]` that aborts takes the generated `Bumps`, `Accounts` and `try_accounts` items with it — so you get ten or more errors. Learning to read only the top one is most of the skill.",
-                "id": "b",
-                "label": "One error, pointing at the `seeds` line, and nothing else"
-              },
-              {
-                "correct": false,
-                "feedback": "There is no such default. 255 is only where the search *starts*; which bump is canonical depends on the seeds and the program id, so assuming it would be wrong roughly half the time. The macro rejects the constraint instead.",
-                "id": "c",
-                "label": "It compiles, and Anchor treats the bump as 255"
-              },
-              {
-                "correct": false,
-                "feedback": "`ConstraintSeeds` is a real runtime error — you get it for seeds that derive to an address other than the account passed in. This one never builds at all.",
-                "id": "d",
-                "label": "It compiles, and fails at runtime with `ConstraintSeeds`"
-              }
-            ],
-            "prompt": "You add the `seeds` line to the vault's constraint and forget the bare `bump` under it. Predict the build output."
-          }
-        ]
-      }
-    ],
-    "skills": [
-      "pdas",
-      "account-model",
-      "anchor"
-    ],
-    "slug": {
-      "_type": "slug",
-      "current": "pdas-an-address-with-no-key"
-    },
-    "title": "PDAs: An Address With No Key"
-  },
-  {
-    "_id": "lesson-bfsp-pre-flight-check",
-    "_type": "lesson",
-    "blocks": [
-      {
-        "_key": "intro",
-        "_type": "prose",
-        "src": "# Pre-Flight Check\n\n> **Version stamp — checked 2026-07-26.** `anchor-lang 1.1.2` · `borsh` resolves to **1.8.0** · `litesvm 0.15.x` (minor pinned; patch moves weekly) · Agave ≥ 3.1.10 · rustc 1.89+ · edition 2021.\n\nEverything after this page costs something. The next lesson puts real devnet SOL in your wallet, the one after that spends it on 200-odd transactions, and the program id that comes out is the artifact your credential is keyed to. This is the last page where being wrong is free.\n\nSo before you spend a lamport: what do you actually know, and what have you only compiled?\n\n## A green build is one bit of information\n\nThe build server compiles your file and grades on exactly that: **did it compile.** There is no test step on the Rust path. The grader never reads your code.\n\nThat bit is worth having — a program that does not compile cannot be deployed, and Anchor's macros catch a large class of account-wiring mistakes at compile time, which is most of why this course uses Anchor at all. But it is one bit, and Course 2 already showed you four ways to spend it on a vault that does not work:\n\n| What you wrote                                       | Build | What happens on-chain                              |\n| ---------------------------------------------------- | ----- | -------------------------------------------------- |\n| `withdraw` calling `checked_add`                     | green | the vault pays you for withdrawing                 |\n| the `require!(amount > 0, …)` guard dropped          | green | zero-amount instructions succeed and write nothing |\n| `.unwrap()` where `.ok_or(…)?` belongs               | green | a panic — aborted instruction, no error code       |\n| `self.balance = self.balance - amount`               | green | a panic, for the same reason                       |\n\nNone of those changes a type, and nothing type-level can see them.\n\nCourse 3 adds four more of its own:\n\n- **`deposit` that moves the lamports but forgets `vault.deposit(amount)`.** The CPI lands; the stored `balance` stays at zero. Two numbers that are supposed to agree, and only one of them got written.\n- **`withdraw` written as a System Program CPI with signer seeds.** It compiles. It deploys. It fails the first time anyone calls it, with `Transfer: 'from' must not carry data` — because System will not debit an account that carries data, and does not own your vault in any case. Signer seeds solve authorisation, and authorisation was never the obstacle.\n- **A dropped rent floor.** Debit the vault below its rent-exempt minimum and the runtime kills the whole transaction with `InsufficientFundsForRent` — a failure your caller cannot act on, in place of the `InsufficientFunds` you would have returned.\n- **A bump that is re-derived instead of read.** `bump` (bare) and `bump = vault.bump` both compile and both usually resolve to the same address. They diverge in compute units, and they diverge in intent: one trusts what you stored, the other recomputes it every call.\n\nThe compiler is indifferent to all eight. So is the grader.\n\n## The tool that is not indifferent: LiteSVM\n\n**LiteSVM** is the SVM — the same runtime a validator executes your program in — as a Rust library you construct in-process. No validator to boot, no RPC, no ports, no keypair files. You build a machine, load your `.so` into it, fund an address, send a transaction, and read the account back. Milliseconds, not tens of seconds.\n\nThat is the whole reason it matters here: the thing that catches a swapped operator is a test that **runs** `withdraw` and looks at the number afterwards. Nothing else does.\n\n```rust\n// litesvm 0.15.x — reading material, not a graded exercise.\nlet mut svm = LiteSVM::new();\nsvm.add_program_from_file(program_id, \"target/deploy/academy_program.so\")\n    .unwrap();\nsvm.airdrop(&user.pubkey(), 10 * LAMPORTS_PER_SOL).unwrap();\n\n// initialize → deposit 2 SOL → withdraw 1 SOL\nsvm.send_transaction(initialize_vault_tx(&svm, &user)).unwrap();\nsvm.send_transaction(deposit_tx(&svm, &user, 2 * LAMPORTS_PER_SOL)).unwrap();\nsvm.send_transaction(withdraw_tx(&svm, &user, 1 * LAMPORTS_PER_SOL)).unwrap();\n\n// The assertion the compiler cannot make.\nlet raw = svm.get_account(&vault_pda).unwrap().data;\nlet state = VaultState::try_deserialize(&mut raw.as_slice()).unwrap();\nassert_eq!(state.balance, 1 * LAMPORTS_PER_SOL);\n```\n\nThree things to notice, because they are the point rather than the syntax.\n\n**The `unwrap()`s are fine here.** Course 2 spent a lesson on why a panic inside a program is unacceptable: the caller gets an aborted instruction with no code and no message. A test is the opposite situation — a panic *is* the failure report, and it is the shortest one available. The rule was never \"never `unwrap`\"; it was \"never `unwrap` where someone else has to read the error.\"\n\n**`assert_eq!(state.balance, …)` is the assertion nothing else in this course can make.** It compares a number the runtime produced against a number you predicted. Every green build up to now has compared a shape against a shape.\n\n**The last line reads the account back rather than trusting the return value.** `send_transaction` succeeding means the instruction did not error. It does not mean it wrote what you meant. Those are different claims and the second one is the one you care about.\n\nLiteSVM is Apache-2.0, which makes it the one major testing corpus in this ecosystem whose examples you can adapt into your own repo with attribution rather than reimplement from scratch. Pin the minor — it ships roughly weekly, and `0.15.x` is what the snippet above was written against.\n\n## What this platform runs, stated plainly\n\nThe code block on a lesson has two modes, `standard` and `buildable`. `buildable` shells out to the Anchor toolchain and compiles. **There is no test mode.** Adding one is a two-stage build-then-run pipeline on the build server, not a flag, and it is tracked separately.\n\nWhich means: the LiteSVM file above is not something you submit here today. It is something you read, and then write for real the first time you have a repo of your own — which, if you follow this path, is Course 4.\n\nIt also means the honest description of what you are about to deploy is *\"compiled against the real Anchor 1.1 toolchain,\"* and never *\"unit tested.\"* If you write up this build — and the last lesson asks you to — use the first one. The distinction is the kind of thing a reviewer notices.\n\n## So the pre-flight check is you\n\nNo new material below. The checkpoint asks about decisions you made across the last eleven lessons, cold, out of the order you made them in, plus two from Course 2 that Course 3 has been quietly leaning on the whole time.\n\nGetting one wrong here costs nothing. Getting it wrong after the deploy costs an upgrade transaction and the walk back through this module to find out which of the eight silent failures you shipped.\n"
-      },
-      {
-        "_key": "checkpoint",
-        "_type": "quiz",
-        "questions": [
-          {
-            "explanation": "`INIT_SPACE` (41) counts the fields; the `8 +` is Anchor's account discriminator, written at offset 0 and checked on every deserialize. 8 + 32 + 8 + 1 = 49, and that number is fixed at creation — an account's data length cannot grow later without a realloc, which is why you derive it rather than guess it.",
-            "id": "q1",
-            "multiSelect": false,
-            "options": [
-              {
-                "correct": true,
-                "id": "a",
-                "label": "49 bytes — 8 for the discriminator Anchor writes at offset 0, then 32 + 8 + 1 for the fields"
-              },
-              {
-                "correct": false,
-                "feedback": "41 is `INIT_SPACE`, the fields alone. The extra 8 is the account discriminator, which sits ahead of every field — total 49.",
-                "id": "b",
-                "label": "41 bytes — 32 + 8 + 1; the 8 is the u64 `balance`, already counted"
-              },
-              {
-                "correct": false,
-                "feedback": "The 8 is not padding you could grow into. It is the discriminator: the first 8 bytes of sha256 of the type name, which is how the runtime knows this account is a `VaultState` and not some other struct of the same length.",
-                "id": "c",
-                "label": "49 bytes — 8 reserved for future fields, then 32 + 8 + 1"
-              }
-            ],
-            "prompt": "Your vault account is created with `space = 8 + 32 + 8 + 1`, where `VaultState` is `{ owner: Pubkey, balance: u64, bump: u8 }`. How many bytes is the account, and what is the leading 8 for?"
-          },
-          {
-            "explanation": "The rule is ownership: whichever program is executing may debit only accounts assigned to it. Lamports IN move through System because the source is a wallet System owns. Lamports OUT do not, because the source is your vault — so your program writes `try_borrow_mut_lamports` itself, and a System CPI would fail whatever seeds you attached. This is why `Withdraw` has no `system_program` field: there is no callee program to load. Getting this backwards is the single most common PDA mistake on Solana, which is why module 3 shipped it as a decoy rather than a footnote.",
-            "id": "q2",
-            "multiSelect": false,
-            "options": [
-              {
-                "correct": true,
-                "id": "a",
-                "label": "A program may only debit accounts it owns. Deposit debits the user's wallet, owned by System, so System must do it; withdraw debits the vault, owned by your program, so your program does it directly"
-              },
-              {
-                "correct": false,
-                "feedback": "The System CPI is not a slower alternative — it does not work at all. System refuses to debit an account carrying data (`Transfer: 'from' must not carry data`) and does not own the vault regardless. Signer seeds solve authorisation, and authorisation was never the obstacle.",
-                "id": "b",
-                "label": "Withdraw could use a System CPI with `new_with_signer`, but direct lamport arithmetic costs fewer compute units"
-              },
-              {
-                "correct": false,
-                "feedback": "Being a PDA is not the blocker — a dataless PDA can absolutely be the `from` of a System transfer when its program signs with seeds. What blocks it here is that this PDA carries 49 bytes of data and is owned by your program.",
-                "id": "c",
-                "label": "Withdraw skips the CPI because the vault is a PDA, and PDAs cannot be the source of a transfer"
-              }
-            ],
-            "prompt": "`deposit` makes a System Program CPI — `transfer(CpiContext::new(System::id(), Transfer { from: user, to: vault }), amount)`. `withdraw` makes no CPI at all. Why the asymmetry?"
-          },
-          {
-            "explanation": "PDA derivation hashes the seeds, the program id and a marker, and retries with bump 255, 254, … until the digest is not a valid curve point. Off-curve means no keypair exists, which is exactly the property you want for an account holding value: the only path to authorising it is a program the runtime can check, not a secret someone can leak.",
-            "id": "q3",
-            "multiSelect": false,
-            "options": [
-              {
-                "correct": true,
-                "id": "a",
-                "label": "Its address is found by hashing seeds until the result falls OFF the ed25519 curve, so no key can correspond to it — and if one could, its holder could move the vault's lamports without the program"
-              },
-              {
-                "correct": false,
-                "feedback": "There is no key anywhere. Derivation deliberately retries with a decreasing bump until it lands off the curve, precisely so no keypair can exist for the address.",
-                "id": "b",
-                "label": "The key exists but is held by the program, which keeps it secret"
-              },
-              {
-                "correct": false,
-                "feedback": "Nothing is reconstructed. A PDA is off-curve by construction; the program's authority over it comes from the runtime checking seeds, not from possessing anything.",
-                "id": "c",
-                "label": "The key is derived from the program id, so only the program can reconstruct it"
-              }
-            ],
-            "prompt": "Why does the vault PDA have no private key, and what would break if it did?"
-          },
-          {
-            "explanation": "Seeds are the cheapest and strongest account-substitution defence available: `[b\"vault\", user.key().as_ref()]` makes the address itself a function of the signer, so there is exactly one vault the transaction can name for a given signer. The discriminator check and `mut` guard other things — wrong type, and writability — and all three are needed for different reasons.",
-            "id": "q4",
-            "multiSelect": false,
-            "options": [
-              {
-                "correct": true,
-                "id": "a",
-                "label": "`seeds = [b\"vault\", user.key().as_ref()]` — the vault's address is a function of the signer's key, so a different vault simply is not the account at that address and the constraint fails"
-              },
-              {
-                "correct": false,
-                "feedback": "The discriminator check stops a wrong TYPE (or an uninitialised account) being passed, which is a different attack. It happily accepts a correctly-typed vault belonging to somebody else. The seeds are what bind the account to the signer.",
-                "id": "b",
-                "label": "`Account<'info, VaultState>`, because it verifies the discriminator"
-              },
-              {
-                "correct": false,
-                "feedback": "`mut` marks the account writable; it says nothing about whose vault was supplied. The binding comes from deriving the vault address from `user.key()`.",
-                "id": "c",
-                "label": "`#[account(mut)]` on `user`, because only a mutable signer can receive lamports"
-              }
-            ],
-            "prompt": "An attacker calls your `withdraw` and passes someone else's vault account, hoping to drain it into their own wallet. Which single piece of the accounts struct stops that?"
-          },
-          {
-            "explanation": "Two mutable handles to one account is how a `transfer_between_vaults` silently becomes a no-op or a double-credit: you write through one view, then the second view overwrites it from stale data. Anchor 1.0 makes that an error by default and gives you `#[account(mut, dup)]` to say \"yes, I meant it here.\" Write `dup`, never `unsafe(dup)` — that is v2-alpha syntax for a different framework generation.",
-            "id": "q5",
-            "multiSelect": false,
-            "options": [
-              {
-                "correct": true,
-                "id": "a",
-                "label": "Passing the same account twice as two mutable inputs now fails with `ConstraintDuplicateMutableAccount`; `dup` opts a specific account out, for instructions where aliasing is legitimate"
-              },
-              {
-                "correct": false,
-                "feedback": "It is the reverse, and that reversal is the 1.0 change. The check is on by default and errors; `dup` is the opt-OUT for the rare instruction that genuinely wants the same account in two slots.",
-                "id": "b",
-                "label": "Duplicates are allowed by default; `dup` turns on the check for accounts where aliasing would be a bug"
-              },
-              {
-                "correct": false,
-                "feedback": "Nothing is removed. `dup` only suppresses the duplicate-mutable-account error for that field; the account still appears in both positions and both borrows are yours to reason about.",
-                "id": "c",
-                "label": "`dup` deduplicates the account list before the instruction runs"
-              }
-            ],
-            "prompt": "Anchor 1.0 changed the default for duplicate mutable accounts. What is the default now, and what does `#[account(mut, dup)]` do?"
-          },
-          {
-            "explanation": "Creating an account is not something your program can do alone; only the System Program can allocate and assign. `init` hides that CPI, but hiding is not removing, and the generated call names the field. This is also why the error lands on your accounts struct rather than on the line you deleted: macro-generated code fails where it was expanded.",
-            "id": "q6",
-            "multiSelect": false,
-            "options": [
-              {
-                "correct": true,
-                "id": "a",
-                "label": "The build fails: `init` expands into a CPI that creates the account, and that expansion needs a System Program account in the struct to call — there is no field left to reference"
-              },
-              {
-                "correct": false,
-                "feedback": "It never gets that far. `init` is a macro that writes the create-account CPI for you, and the code it writes names `system_program`. Remove the field and the generated code refers to something that does not exist.",
-                "id": "b",
-                "label": "The build succeeds; the instruction fails at runtime when it tries to create the account"
-              },
-              {
-                "correct": false,
-                "feedback": "The address is a constant, but the ACCOUNT still has to be in the instruction's account list — the runtime only lends a program the accounts it was passed. Anchor requires you to declare it.",
-                "id": "c",
-                "label": "The build succeeds and Anchor supplies the System Program automatically, since its address is a constant"
-              }
-            ],
-            "prompt": "You delete `pub system_program: Program<'info, System>` from `InitializeVault` and click Build. What happens?"
-          },
-          {
-            "explanation": "This is why `VaultState` carries a `bump: u8` field at all. The canonical bump is found by trying 255, 254, … until the result is off-curve, and that search costs compute units every single call. Store it once at init, then hand it back with `bump = vault.bump` — one hash, same guarantee. It is the clearest instance in the course of paying 1 byte of rent to stop paying compute forever.",
-            "id": "q7",
-            "multiSelect": false,
-            "options": [
-              {
-                "correct": true,
-                "id": "a",
-                "label": "Bare `bump` re-runs the derivation search, hashing once per candidate bump until it finds the canonical one; `bump = vault.bump` hashes once with the bump you stored at init"
-              },
-              {
-                "correct": false,
-                "feedback": "Bare `bump` finds and requires the CANONICAL bump — it is not permissive. The cost is that finding it means repeating the search on every call.",
-                "id": "b",
-                "label": "Bare `bump` accepts any valid bump, so a caller could supply a non-canonical one"
-              },
-              {
-                "correct": false,
-                "feedback": "Verification still happens: Anchor derives the address from your seeds plus that bump and compares it to the account passed in. It just does one hash instead of a search.",
-                "id": "c",
-                "label": "`bump = vault.bump` skips PDA verification entirely and trusts the account"
-              }
-            ],
-            "prompt": "`bump` (bare) and `bump = vault.bump` on the same account both compile and usually resolve to the same address. What is the actual difference?"
-          },
-          {
-            "explanation": "`overflow-checks = true` turns a wrap into a panic, which is strictly better than a wrap and still the wrong shape for a program. A panic is an aborted instruction carrying no error code, so a client can render nothing useful. `checked_sub` returns `None`, `ok_or` names it `InsufficientFunds`, and `?` carries it up — the caller gets 6001 and a string you authored. Turning `None` into a named variant was the whole point of Course 2's last five lessons, and it is what makes an error a feature rather than a crash.",
-            "id": "q8",
-            "multiSelect": false,
-            "options": [
-              {
-                "correct": true,
-                "id": "a",
-                "label": "A panic aborts the instruction with no error code and no message, so the caller learns only that something failed; `checked_sub` + `ok_or` returns a named variant with the `#[msg]` string you wrote"
-              },
-              {
-                "correct": false,
-                "feedback": "They stop the same bad write, but they report it completely differently. One gives the caller a code and a sentence; the other gives them a failed transaction and nothing to act on.",
-                "id": "b",
-                "label": "It is not worse — with `overflow-checks = true` the two are equivalent"
-              },
-              {
-                "correct": false,
-                "feedback": "That line is exactly what `overflow-checks = true` prevents — it panics instead of wrapping. The problem is the panic itself, not a wrap.",
-                "id": "c",
-                "label": "Bare subtraction would silently wrap to a huge number even with `overflow-checks = true`"
-              },
-              {
-                "correct": false,
-                "feedback": "Compute cost is not the argument, and the difference is negligible. The argument is the quality of the failure your caller receives.",
-                "id": "d",
-                "label": "`checked_sub` is faster, so the checked version costs fewer compute units"
-              }
-            ],
-            "prompt": "Course 2 recall. Your `withdraw` does `self.balance.checked_sub(amount).ok_or(VaultError::InsufficientFunds)?`. Someone suggests `self.balance - amount` instead, noting that the release profile sets `overflow-checks = true` so it will panic rather than wrap. Why is that still worse?"
-          },
-          {
-            "explanation": "A verification harness is a TYPE check, and an operator is not a type. `checked_add` and `checked_sub` have identical signatures, so every binding in the harness still matches and the build goes green on a vault that credits you for withdrawing. That gap is not a flaw in the harness — it is the boundary of what compilation can observe, and it is exactly the boundary a LiteSVM test crosses by running the instruction and reading the number back.",
-            "id": "q9",
-            "multiSelect": false,
-            "options": [
-              {
-                "correct": true,
-                "id": "a",
-                "label": "A `withdraw` whose body calls `checked_add` instead of `checked_sub`"
-              },
-              {
-                "correct": false,
-                "feedback": "The harness constructs `VaultState { owner, balance, bump }` by field name, so a rename is a compile error. That is the class of mistake a type-level check does catch.",
-                "id": "b",
-                "label": "Renaming `balance` to `amount_held`"
-              },
-              {
-                "correct": false,
-                "feedback": "That moves `INIT_SPACE` from 41 to 48 and trips `const _: () = assert!(VaultState::INIT_SPACE == 41)` at compile time.",
-                "id": "c",
-                "label": "Widening `bump` from `u8` to `u64`"
-              },
-              {
-                "correct": false,
-                "feedback": "`#[account]` is what supplies the discriminator the harness measures with `assert!(VaultState::DISCRIMINATOR.len() == 8)`, so removing it fails the build.",
-                "id": "d",
-                "label": "Deleting the `#[account]` attribute"
-              }
-            ],
-            "prompt": "Course 2 recall. Course 2's `mod verify` harness binds `VaultState::withdraw` to `fn(&mut VaultState, u64) -> Result<()>` and asserts `INIT_SPACE == 41`. Which of these would the harness let through?"
-          }
-        ]
-      }
-    ],
-    "skills": [
-      "program-testing",
-      "account-model",
-      "pdas",
-      "rent-and-space",
-      "cpi"
-    ],
-    "slug": {
-      "_type": "slug",
-      "current": "pre-flight-check"
-    },
-    "title": "Pre-Flight Check"
+    "title": "On-Chain State"
   },
   {
     "_id": "lesson-bfsp-wire-up-initialize",
@@ -2697,7 +1729,7 @@
       {
         "_key": "intro",
         "_type": "prose",
-        "src": "# Wire Up Initialize\n\n> **Version stamp — checked 2026-07-26.** `anchor-lang 1.1.2` (published 2026-06-26) · `cargo-build-sbf` with platform-tools v1.54 (rustc 1.89) · `borsh` resolves to **1.8.0** · edition 2021. Every compiler message quoted below — including the error count and the order they arrive in — was produced by compiling this lesson's deliberately-broken starter on that toolchain.\n\nThis lesson is different. The starter **does not compile**, on purpose, and the first thing you do is\npress Build and read what comes back.\n\nThat is not a warm-up. Reading Anchor's build output is a distinct skill from writing Anchor, most\npeople never practise it deliberately, and it is the difference between a five-second fix and an\nafternoon.\n\n## Task 1 — diagnose the bug\n\n1. Click **Build** before you change anything.\n2. Read the output **from the top**.\n3. Fix one thing.\n4. Build again.\n\nThe `InitializeVault` struct uses `#[account(init, ...)]` to create the vault PDA, and it is missing a\nrequired account. There is a comment where it should be.\n\n### What the output will look like\n\nYou will get ten errors. Nine of them are noise, and knowing that is most of the skill.\n\nThe **first** line is Anchor's own, and in Anchor 1.x it is unusually direct:\n\n```\nerror: a non-optional init constraint requires a non-optional system_program field\nto exist in the account validation struct. Use the Program type to add the\nsystem_program field to your validation struct.\n```\n\nEverything after it is fallout. `#[derive(Accounts)]` gave up, so the items it was going to generate\nnever appeared, and rustc reports each absence separately:\n\n```\nerror[E0432]: unresolved import `crate`\nerror[E0277]: the trait bound `InitializeVault<'_>: Bumps` is not satisfied\nerror[E0599]: no function or associated item named `try_accounts` found for struct `InitializeVault`\nerror[E0277]: the trait bound `InitializeVault<'_>: anchor_lang::Accounts<'_, _>` is not satisfied\n```\n\nNone of those is a real problem. There is one problem, stated once, at the top.\n\nOlder Anchor versions did not print that first line at all — you got the trait-bound cascade and\nnothing else, which is why \"the trait bound `Accounts` is not satisfied\" is still the most-searched\nAnchor error on the internet and why so many answers to it are guesswork. Anchor 1.x tells you the\nanswer plainly and then buries it under nine more lines. **Read from the top, fix one thing, build\nagain.**\n\nOne of those nine is the verification harness at the bottom of the file also noticing the missing\nfield. It lands last, long after Anchor has already told you.\n\n### Why `init` needs the System Program at all\n\nYour program cannot create accounts. Nothing can, except the System Program — allocation and ownership\nassignment are its instructions, and every account on Solana was created by a call to it.\n\nSo `init` is not a local operation. It expands into a **cross-program invocation**: your program calls\nthe System Program's `create_account`, which allocates `space` bytes, assigns the new account's owner to\nyour program id, and moves the rent-exempt deposit from `payer`. A CPI needs the callee in the\ntransaction's account list, so `system_program` has to be a field on the struct. Anchor will not add it\nfor you, and it is telling you so.\n\nModule 3 makes CPIs explicit, with transfers you write yourself. This one you have been making since\nlesson 3 without seeing it.\n\n### One thing not to do\n\nThere is a way to make the build pass that is worse than the bug. Deleting `init` — or replacing it\nwith `mut` — removes the constraint that needed the System Program, and the file compiles. It also no\nlonger creates anything.\n\nThe verification harness at the bottom of the file names `system_program` as a required field, so that\nparticular escape is closed: drop `init` and stop there, and the harness fails you. Be precise about\nhow far that goes, though — drop `init` *and* add `system_program` anyway, and the build is green on a\nprogram that creates nothing. `init` is not something a compiler can check for. Take it as the general\nwarning: on this platform a green build means *the file compiled*, and \"make the error go away\" and\n\"make the program correct\" are different goals that occasionally point in opposite directions.\n\n## Task 2 — write the body\n\nOnce it builds, the handler is yours to write. No scaffolding this time.\n\nBy the time `initialize_vault` runs, the account exists: 49 bytes allocated, owner set to your program,\ndiscriminator written, every field zero. What it does not have is meaning. Three assignments give it\nsome:\n\n1. **`owner`** — the wallet this vault belongs to. Module 3's `has_one = owner` check reads exactly this\n   field to reject a withdrawal signed by somebody else. Get it from the accounts struct.\n2. **`balance`** — zero. The bytes are already zero, so the line changes nothing; write it anyway,\n   because the next person to read the handler should not have to know that in order to trust it.\n3. **`bump`** — the canonical bump Anchor derived a moment ago, so `deposit` and `withdraw` can use\n   `bump = vault.bump` instead of re-running the search on every call. Anchor hands it to you on\n   `ctx.bumps`, under this account's own field name.\n\n### What the grader can and cannot see\n\nCompile-only grading means the harness can prove your struct holds the right three accounts, and can\nprove `ctx.bumps.vault` is reachable. It cannot see the body. A handler that assigns nothing at all\ncompiles exactly as well as a correct one.\n\nSo this rung is graded on the bug and trusted on the body — and the untrusted half is exactly what\nmodule 4's LiteSVM lesson shows you how to check, before you spend a lamport of devnet SOL on it.\nReading that test and knowing why compiling could not replace it is the point.\n"
+        "src": "# Challenge: Wire Up Initialize\n\nThis challenge is different. The starter code has a **deliberate bug** — it won't compile.\n\nYour job:\n1. Click **Build** to see the compiler error\n2. Read the error message carefully\n3. Fix the code\n4. Build again until it compiles\n\n## The Bug\n\nThe `Initialize` struct uses `#[account(init, ...)]` to create a `Counter` PDA, but it's missing a required account. When Anchor generates the account creation code, it needs the System Program to execute the `create_account` instruction.\n\n## What You'll Learn\n\nThis is the most common Anchor compile error you'll encounter in the wild. Learning to diagnose it now saves you hours of debugging later.\n\n## Requirements\n\n1. Read the compiler error output\n2. Add the missing account to `Initialize`\n3. Make sure `initialize` sets `counter.count = 0` and `counter.authority = ctx.accounts.user.key()`\n"
       },
       {
         "_key": "exercise",
@@ -2706,46 +1738,37 @@
         "deployable": false,
         "hints": [
           "Click Build first to see the error. The compiler will tell you what's missing.",
-          "Read the output from the top. The first line is Anchor's own and it names the fix outright — everything after it is a cascade of trait-bound errors on `InitializeVault` caused by `#[derive(Accounts)]` having aborted. Ten errors, one problem, stated once, at the top.",
-          "Add `pub system_program: Program<'info, System>,` to the `InitializeVault` struct. The System Program is required whenever you use `#[account(init)]`, because creating an account is a CPI to it.",
-          "For task 2: the handler has to persist three things, and `ctx` carries all of them. Two are values you already know at call time — who the owner is, and what a brand-new balance should be. The third is the bump Anchor just computed while deriving the address, which it hands back on `ctx.bumps`, named after the field. Do not hardcode it."
+          "The error mentions a trait bound related to Accounts. This happens when a required account is missing from the struct.",
+          "Add `pub system_program: Program<'info, System>,` to the Initialize struct. The System Program is required whenever you use `#[account(init)]`."
         ],
         "language": "rust",
-        "solution": "use anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n// ─────────────────────────────────────────────────────────────────────────────\n// Your Course 2 vault core, imported and not retyped.\n// ─────────────────────────────────────────────────────────────────────────────\npub mod vault {\n    use super::*;\n\n    #[account]\n    #[derive(InitSpace)]\n    pub struct VaultState {\n        pub owner: Pubkey,\n        pub balance: u64,\n        pub bump: u8,\n    }\n\n    #[error_code]\n    pub enum VaultError {\n        #[msg(\"Deposit would overflow the vault balance\")]\n        Overflow,\n        #[msg(\"Withdrawal is larger than the vault balance\")]\n        InsufficientFunds,\n        #[msg(\"Amount must be greater than zero\")]\n        ZeroAmount,\n        #[msg(\"Signer is not the vault owner\")]\n        NotOwner,\n    }\n\n    impl VaultState {\n        pub fn deposit(&mut self, amount: u64) -> Result<()> {\n            require!(amount > 0, VaultError::ZeroAmount);\n            self.balance = self\n                .balance\n                .checked_add(amount)\n                .ok_or(VaultError::Overflow)?;\n            Ok(())\n        }\n\n        pub fn withdraw(&mut self, amount: u64) -> Result<()> {\n            require!(amount > 0, VaultError::ZeroAmount);\n            self.balance = self\n                .balance\n                .checked_sub(amount)\n                .ok_or(VaultError::InsufficientFunds)?;\n            Ok(())\n        }\n    }\n}\n\npub use vault::{VaultError, VaultState};\n\n#[program]\npub mod vault_program {\n    use super::*;\n\n    pub fn initialize_vault(ctx: Context<InitializeVault>) -> Result<()> {\n        let vault = &mut ctx.accounts.vault;\n\n        // TASK 2. Three assignments, and every one of them is load-bearing later:\n        //   · `owner` is what module 3's `has_one = owner` check reads to reject\n        //     somebody else's withdrawal.\n        //   · `balance` starts at zero explicitly. The bytes are already zero, so\n        //     this line changes nothing — and it is still worth writing, because\n        //     the next person to read the handler should not have to know that.\n        //   · `bump` is stored once here so that `deposit` and `withdraw` can use\n        //     `bump = vault.bump` instead of re-running the derivation search.\n        vault.owner = ctx.accounts.user.key();\n        vault.balance = 0;\n        vault.bump = ctx.bumps.vault;\n\n        msg!(\"Vault initialized for {}\", vault.owner);\n        Ok(())\n    }\n\n    pub fn vault_info(_ctx: Context<VaultInfo>) -> Result<()> {\n        msg!(\"Vault program online\");\n        Ok(())\n    }\n}\n\n#[derive(Accounts)]\npub struct InitializeVault<'info> {\n    #[account(\n        init,\n        payer = user,\n        space = 8 + 32 + 8 + 1,\n        seeds = [b\"vault\", user.key().as_ref()],\n        bump\n    )]\n    pub vault: Account<'info, VaultState>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n    // TASK 1. `init` creates the account by calling the System Program, so the\n    // System Program has to be in the account list. Anchor never injects it.\n    pub system_program: Program<'info, System>,\n}\n\n#[derive(Accounts)]\npub struct VaultInfo {}\n\n// ─────────────────────────────────────────────────────────────────────────────\n// VERIFICATION HARNESS — DO NOT EDIT ANYTHING BELOW THIS LINE.\n// A type check, not a behaviour check. See the starter for its exact reach.\n// ─────────────────────────────────────────────────────────────────────────────\n#[doc(hidden)]\n#[allow(dead_code)]\nmod verify {\n    use super::*;\n\n    const _: () = assert!(VaultState::DISCRIMINATOR.len() == 8);\n    const _: () = assert!(VaultState::INIT_SPACE == 41);\n\n    fn pin_bump(bumps: &InitializeVaultBumps) -> u8 {\n        bumps.vault\n    }\n\n    fn pin_vault<'info>(a: &'info InitializeVault<'info>) -> &'info Account<'info, VaultState> {\n        &a.vault\n    }\n    fn pin_user<'info>(a: &'info InitializeVault<'info>) -> &'info Signer<'info> {\n        &a.user\n    }\n    fn pin_system<'info>(a: &'info InitializeVault<'info>) -> &'info Program<'info, System> {\n        &a.system_program\n    }\n}\n",
-        "starter": "use anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n// ─────────────────────────────────────────────────────────────────────────────\n// Your Course 2 vault core, imported and not retyped. Nothing in here is broken.\n// ─────────────────────────────────────────────────────────────────────────────\npub mod vault {\n    use super::*;\n\n    #[account]\n    #[derive(InitSpace)]\n    pub struct VaultState {\n        pub owner: Pubkey,\n        pub balance: u64,\n        pub bump: u8,\n    }\n\n    #[error_code]\n    pub enum VaultError {\n        #[msg(\"Deposit would overflow the vault balance\")]\n        Overflow,\n        #[msg(\"Withdrawal is larger than the vault balance\")]\n        InsufficientFunds,\n        #[msg(\"Amount must be greater than zero\")]\n        ZeroAmount,\n        #[msg(\"Signer is not the vault owner\")]\n        NotOwner,\n    }\n\n    impl VaultState {\n        pub fn deposit(&mut self, amount: u64) -> Result<()> {\n            require!(amount > 0, VaultError::ZeroAmount);\n            self.balance = self\n                .balance\n                .checked_add(amount)\n                .ok_or(VaultError::Overflow)?;\n            Ok(())\n        }\n\n        pub fn withdraw(&mut self, amount: u64) -> Result<()> {\n            require!(amount > 0, VaultError::ZeroAmount);\n            self.balance = self\n                .balance\n                .checked_sub(amount)\n                .ok_or(VaultError::InsufficientFunds)?;\n            Ok(())\n        }\n    }\n}\n\npub use vault::{VaultError, VaultState};\n\n#[program]\npub mod vault_program {\n    use super::*;\n\n    pub fn initialize_vault(ctx: Context<InitializeVault>) -> Result<()> {\n        let vault = &mut ctx.accounts.vault;\n\n        // TASK 2 — the handler body. Three lines, no scaffolding this time.\n        //\n        // By the time this runs the account exists: allocated, program-owned,\n        // discriminator written, every field zero. What it does not have is\n        // meaning. Give it the three things `deposit` and `withdraw` will need —\n        // who it belongs to, what it holds, and the bump that proves its address.\n        //\n        // Names and types are in `VaultState` above. The bump Anchor just derived\n        // is on `ctx.bumps`, under this account's own field name.\n\n        msg!(\"Vault initialized for {}\", vault.owner);\n        Ok(())\n    }\n\n    pub fn vault_info(_ctx: Context<VaultInfo>) -> Result<()> {\n        msg!(\"Vault program online\");\n        Ok(())\n    }\n}\n\n#[derive(Accounts)]\npub struct InitializeVault<'info> {\n    #[account(\n        init,\n        payer = user,\n        space = 8 + 32 + 8 + 1,\n        seeds = [b\"vault\", user.key().as_ref()],\n        bump\n    )]\n    pub vault: Account<'info, VaultState>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n    // BUG: Something is missing here...\n}\n\n#[derive(Accounts)]\npub struct VaultInfo {}\n\n// ─────────────────────────────────────────────────────────────────────────────\n// VERIFICATION HARNESS — DO NOT EDIT ANYTHING BELOW THIS LINE.\n//\n// A TYPE check, not a behaviour check. It names the three accounts the struct\n// must hold, so that \"make the build pass\" cannot be satisfied by deleting the\n// constraint that caused the failure.\n//\n// It cannot see the handler body at all. Whether you assigned the three fields,\n// and whether you assigned them the right values, is invisible to a compile-only\n// grader — there are no hidden tests on the Rust path. Module 4 proves that part\n// against a real runtime.\n// ─────────────────────────────────────────────────────────────────────────────\n#[doc(hidden)]\n#[allow(dead_code)]\nmod verify {\n    use super::*;\n\n    const _: () = assert!(VaultState::DISCRIMINATOR.len() == 8);\n    const _: () = assert!(VaultState::INIT_SPACE == 41);\n\n    fn pin_bump(bumps: &InitializeVaultBumps) -> u8 {\n        bumps.vault\n    }\n\n    fn pin_vault<'info>(a: &'info InitializeVault<'info>) -> &'info Account<'info, VaultState> {\n        &a.vault\n    }\n    fn pin_user<'info>(a: &'info InitializeVault<'info>) -> &'info Signer<'info> {\n        &a.user\n    }\n    fn pin_system<'info>(a: &'info InitializeVault<'info>) -> &'info Program<'info, System> {\n        &a.system_program\n    }\n}\n",
+        "solution": "use anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n#[program]\npub mod academy_program {\n    use super::*;\n\n    pub fn initialize(ctx: Context<Initialize>) -> Result<()> {\n        let counter = &mut ctx.accounts.counter;\n        counter.count = 0;\n        counter.authority = ctx.accounts.user.key();\n        msg!(\"Counter initialized!\");\n        Ok(())\n    }\n\n    pub fn greet(_ctx: Context<Greet>) -> Result<()> {\n        msg!(\"Hello, Solana!\");\n        Ok(())\n    }\n}\n\n#[derive(Accounts)]\npub struct Initialize<'info> {\n    #[account(\n        init,\n        payer = user,\n        space = 8 + 8 + 32,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n    pub system_program: Program<'info, System>,\n}\n\n#[derive(Accounts)]\npub struct Greet {}\n\n#[account]\npub struct Counter {\n    pub count: u64,\n    pub authority: Pubkey,\n}\n",
+        "starter": "use anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n#[program]\npub mod academy_program {\n    use super::*;\n\n    pub fn initialize(ctx: Context<Initialize>) -> Result<()> {\n        let counter = &mut ctx.accounts.counter;\n        counter.count = 0;\n        counter.authority = ctx.accounts.user.key();\n        msg!(\"Counter initialized!\");\n        Ok(())\n    }\n\n    pub fn greet(_ctx: Context<Greet>) -> Result<()> {\n        msg!(\"Hello, Solana!\");\n        Ok(())\n    }\n}\n\n#[derive(Accounts)]\npub struct Initialize<'info> {\n    #[account(\n        init,\n        payer = user,\n        space = 8 + 8 + 32,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n    // BUG: Something is missing here...\n}\n\n#[derive(Accounts)]\npub struct Greet {}\n\n#[account]\npub struct Counter {\n    pub count: u64,\n    pub authority: Pubkey,\n}\n",
         "tests": [
           {
-            "description": "The file compiles on the build server against anchor-lang 1.1.2 — the deliberate bug is fixed",
+            "description": "Program compiles successfully",
             "expectedOutput": "true",
-            "id": "t1",
+            "id": "test-1",
             "input": ""
           },
           {
-            "description": "Compiles ⇒ InitializeVault holds system_program: Program<'info, System>, which init requires",
+            "description": "Initialize struct includes system_program",
             "expectedOutput": "true",
-            "id": "t2",
+            "id": "test-2",
             "input": ""
           },
           {
-            "description": "Compiles ⇒ the vault still carries seeds + bump: the build was fixed by adding an account, not by dropping the PDA derivation. (init itself is not compile-visible — the harness cannot see it.)",
+            "description": "Counter is initialized to zero",
             "expectedOutput": "true",
-            "id": "t3",
-            "input": ""
-          },
-          {
-            "description": "Compiles ⇒ VaultState still has owner: Pubkey, balance: u64, bump: u8 — INIT_SPACE is 41",
-            "expectedOutput": "true",
-            "id": "t4",
+            "id": "test-3",
             "input": ""
           }
         ],
         "tutorNotes": [
-          "Learners try to satisfy the failing build by deleting or loosening the `init` constraint, instead of supplying the account that `init` requires. The harness only half-closes this: drop `seeds`/`bump` and it fails, but drop `init` alone and the build goes green on a program that creates nothing. Name the instinct — the compiler will not.",
-          "They scroll to the *last* error, or the loudest, rather than the first. Anchor 1.x prints the real diagnosis on line one and then nine consequences of the derive macro aborting.",
-          "They guess at a fix without clicking Build first, so they never read what the compiler is actually asking for — and hint 1 exists only to make them read it.",
-          "When they do add the missing account they give it a bare `AccountInfo` or `UncheckedAccount` type instead of `Program<'info, System>`, which loses the check that this is really the System Program.",
-          "On task 2 they write `vault.bump = 255`, having read that the search starts at 255. Which bump is canonical depends on the seeds and the program id, so a hardcoded 255 is wrong for roughly half of all vaults — and compiles.",
-          "Task 2 is invisible to the grader. A learner who fixes the bug and writes no body at all gets a green build, so say plainly that the body is trusted here, and that module 4 shows the test that would prove it."
+          "Learners try to satisfy the failing build by deleting or loosening the `init` constraint, instead of supplying the account that `init` requires.",
+          "They read only the surface of the trait-bound error, which names `Accounts` rather than a field, and start editing the wrong struct.",
+          "They guess at a fix without clicking Build first, so they never read what the compiler is actually asking for.",
+          "When they do add the missing account they give it a bare `AccountInfo` or `UncheckedAccount` type instead of the typed program wrapper Anchor expects."
         ]
       },
       {
@@ -2753,106 +1776,61 @@
         "_type": "quiz",
         "questions": [
           {
-            "explanation": "Creating an account is a CPI to the System Program, so `init` compiles only when that program is in the accounts struct. Anchor 1.x reports it directly — \"a non-optional init constraint requires a non-optional system_program field\" — and then `#[derive(Accounts)]` aborts, so the `Bumps`, `Accounts` and `try_accounts` items it was going to generate all come back missing. One problem, ten errors, and the real one is first.",
+            "explanation": "Account creation is a CPI to the System Program, so `init` only compiles when that program is in the accounts struct. Omitting it makes Anchor's generated code fail the `Accounts` trait bound — a cryptic-looking error whose fix is always to add the missing account.",
             "id": "q1",
             "multiSelect": false,
             "options": [
               {
                 "correct": true,
                 "id": "a",
-                "label": "One Anchor error naming `system_program` outright, followed by nine more errors on `InitializeVault` — all consequences of the derive macro aborting"
+                "label": "A trait-bound error on `Accounts` — `init` generates a `create_account` CPI that needs the System Program present"
               },
               {
                 "correct": false,
-                "feedback": "That was the pre-1.x experience, and it is why \"the trait bound `Accounts` is not satisfied\" is still the most-searched Anchor error on the internet. Anchor 1.x prints an explicit diagnosis first — you just have to read from the top to find it.",
+                "feedback": "It fails at compile time, not runtime. Anchor cannot generate valid account-creation code without the System Program, so the build breaks.",
                 "id": "b",
-                "label": "Only the trait-bound errors, with nothing naming the missing field"
+                "label": "A runtime 'account not found' error, only when the instruction is called"
               },
               {
                 "correct": false,
-                "feedback": "It fails at compile time. Anchor cannot generate the account-creation code without knowing which program to call, so the build breaks before anything is deployable.",
+                "feedback": "Anchor does not inject it. `init` requires you to declare `system_program: Program<'info, System>` explicitly, or the generated code fails the Accounts trait.",
                 "id": "c",
-                "label": "A runtime \"account not found\" error, only when the instruction is called"
-              },
-              {
-                "correct": false,
-                "feedback": "Anchor never injects accounts. `init` requires you to declare `system_program: Program<'info, System>` explicitly, and the whole point of the message is to say so.",
-                "id": "d",
                 "label": "No error — Anchor injects the System Program automatically"
               }
             ],
-            "prompt": "An `InitializeVault` struct uses `#[account(init, ...)]` and omits the System Program. Predict the build output on Anchor 1.x."
+            "prompt": "An `Initialize` struct uses `#[account(init, ...)]` but omits the System Program. What does the compiler tell you, and why?"
           },
           {
-            "explanation": "Anchor generates account validation through macros, so a single missing field takes every generated item down with it and rustc reports each absence separately. Every constraint mistake you make from here on will look like this: one honest line, then a wall. Read the top, fix one thing, build again — that loop is the actual deliverable of this lesson.",
+            "explanation": "Because Anchor generates account-validation code via macros, a missing account surfaces as a trait-bound error on `Accounts`, not a plain 'you forgot system_program.' Recognizing that pattern turns hours of confusion into a one-line fix.",
             "id": "q2",
             "multiSelect": false,
             "options": [
               {
                 "correct": true,
                 "id": "a",
-                "label": "Because macro-generated code fails in cascades — one mistake produces ten errors — and the habit of reading the first one is what makes Anchor tractable"
+                "label": "It is the most common Anchor compile error, and its message points at a trait rather than the real cause: a missing account"
               },
               {
                 "correct": false,
-                "feedback": "It is a compile-time error, identical everywhere. The lesson exists because the output is *shaped* confusingly, not because it is environment-specific.",
+                "feedback": "It is a compile-time error, identical everywhere. The lesson exists because the message is indirect, not because it is environment-specific.",
                 "id": "b",
                 "label": "Because it only appears on devnet, never locally"
               },
               {
                 "correct": false,
-                "feedback": "It is not a safety warning; it is a missing-account compile error. The transferable part is the reading habit, not this one fix.",
+                "feedback": "It is not a safety warning — it is a missing-account compile error. The point is recognizing the indirect message and knowing the fix.",
                 "id": "c",
                 "label": "Because it means your program is unsafe to deploy"
-              },
-              {
-                "correct": false,
-                "feedback": "The fix has been the same since Anchor learned the constraint: declare the System Program. What changed in 1.x is the quality of the message, not the answer.",
-                "id": "d",
-                "label": "Because the fix differs between Anchor versions"
               }
             ],
-            "prompt": "Why is learning to read this particular build output worth a whole lesson?"
-          },
-          {
-            "explanation": "The canonical bump is the first value counting down from 255 whose derived address lands off the Ed25519 curve, and which value that is depends on the seeds and the program id. `ctx.bumps.vault` is the one Anchor just computed for this exact account; a hardcoded 255 is a guess that compiles, deploys, and then makes `bump = vault.bump` fail in `deposit` for every vault where the guess was wrong. A build server that only compiles cannot catch this — module 4 shows you the LiteSVM test that would, on the first call.",
-            "id": "q3",
-            "multiSelect": false,
-            "options": [
-              {
-                "correct": true,
-                "id": "a",
-                "label": "It compiles and deploys, and roughly half of all vaults store the wrong bump — every later `bump = vault.bump` check on those fails"
-              },
-              {
-                "correct": false,
-                "feedback": "`vault.bump` is a plain `u8` field and `255` is a plain `u8`. Nothing in the type system connects that assignment to the bump Anchor derived. This is exactly the class of bug compile-only grading cannot see.",
-                "id": "b",
-                "label": "It fails to compile — Anchor knows the canonical bump and rejects a literal"
-              },
-              {
-                "correct": false,
-                "feedback": "255 is where the search *starts*. About half of all candidates land off the curve, so 255 works about half the time and the answer depends entirely on the seeds and the program id. That is precisely why the derivation returns the bump rather than assuming it.",
-                "id": "c",
-                "label": "It works — 255 is always the canonical bump"
-              },
-              {
-                "correct": false,
-                "feedback": "Anchor deserializes what is in the account's bytes and never rewrites your fields. Whatever you store is what every later instruction reads.",
-                "id": "d",
-                "label": "It works, because Anchor overwrites the field with the real bump on deserialize"
-              }
-            ],
-            "prompt": "You fix the bug, then write `vault.bump = 255;` in the handler because the derivation search starts at 255. Predict what happens."
+            "prompt": "Why is learning to read this trait-bound error worth a whole lesson?"
           }
         ]
       }
     ],
     "skills": [
       "anchor",
-      "solana-programs",
-      "debugging",
-      "account-model"
+      "solana-programs"
     ],
     "slug": {
       "_type": "slug",
@@ -2867,7 +1845,7 @@
       {
         "_key": "intro",
         "_type": "prose",
-        "src": "# From Rust Core to Anchor\n\n> **Version stamp — checked 2026-07-26.** `anchor-lang 1.1.2` (published 2026-06-26) · `cargo-build-sbf` with platform-tools v1.54 (rustc 1.89) · `borsh` resolves to **1.8.0** · edition 2021. This lesson's starter and solution were both compiled against that toolchain; the build is green with no edits.\n\nYou have a file that compiles. It is called `vault_core.rs`, you wrote it at the end of Course 2, and it holds a `VaultState` struct, a `VaultError` enum, and two methods that do checked arithmetic and return named errors instead of panicking.\n\nIt is not a Solana program. It has no `#[program]` module and no `#[derive(Accounts)]` struct — **that is what this course adds.**\n\nThat distinction is the shape of all fifteen lessons in this course, so be precise about it. Nothing in Course 2 was a program: `#[account]` and `#[error_code]` are Anchor attributes and you used both, but neither one makes a crate into something the runtime can call. A program needs an entrypoint and a dispatcher. You have not written one yet. You are about to compile one.\n\n## The two halves, side by side\n\nThe starter below is your Course 2 file with the wrapper added underneath it, separated by a labeled line. Here is the same split as a table.\n\n| Your Course 2 file                                   | What Course 3 adds                                                             |\n| ---------------------------------------------------- | ------------------------------------------------------------------------------ |\n| `pub mod vault { … }` — an ordinary Rust module       | `#[program] pub mod vault_program { … }` — instruction handlers                 |\n| `#[account] pub struct VaultState` — a *shape*        | `#[derive(Accounts)] pub struct DryRun` — an *account list*                     |\n| `#[error_code] pub enum VaultError` — named failures  | nothing: one per program is the practice, and you already have yours            |\n| `impl VaultState { deposit, withdraw }` — the logic   | handler bodies that **call** `deposit` and `withdraw`                           |\n| Callable only from other Rust                        | Callable from a transaction, by address                                        |\n\nTwo attributes doing two different jobs:\n\n**`#[program]`** expands the module into a dispatcher and a program entrypoint. Every `pub fn` inside becomes a callable instruction, selected by an 8-byte discriminator derived from its name. This is the line that turns a library into a program.\n\n**`#[derive(Accounts)]`** generates the deserialization and validation code for one instruction's account list. `DryRun` is empty, so `dry_run` may touch no accounts at all — which is exactly why nothing it does survives the transaction. Read the handler and notice what is absent: there is no account, so `VaultState` is a value on the stack, `deposit` mutates it, and it is gone when the instruction returns. Module 2 is where the vault stops being a local variable.\n\nWhat the body *does* show is the division of labour for the rest of the course. It calls `vault.deposit(1_000)?` — your method, imported, not retyped. Handlers validate accounts and delegate; the arithmetic stays in the core you already reasoned through line by line.\n\n## What happens when you press Build\n\nFour stages, none of them on your machine:\n\n1. **Rust source** — the single file in the editor. It becomes `src/lib.rs` of a fixed crate, the one whose `Cargo.toml` you read at the end of Course 2.\n2. **`cargo-build-sbf`** — the Solana compiler driver. It compiles the crate to Solana Bytecode Format, a register-based instruction set derived from eBPF and executed by the runtime's VM: sandboxed, with no host filesystem and no sockets, and deterministic, because the same inputs must produce the same result on every validator.\n3. **A `.so` binary** — an ELF shared object. The build response carries its identifier; in module 4 one of these gets uploaded to devnet.\n4. **A green check, or compiler output** — back in the browser tab.\n\nThe toolchain the build server pins, which is the version stamp for every code block in this course:\n\n| Layer          | Version                                             |\n| -------------- | --------------------------------------------------- |\n| `anchor-lang`  | **1.1.2**                                           |\n| platform-tools | **v1.54** — rustc 1.89, Anchor 1.x's minimum        |\n| Rust edition   | 2021                                                |\n| `borsh`        | `1.5.7`, a range — so 1.8.0 is what actually resolves |\n\nTwo consequences worth internalising now. **Warnings are not failures:** this starter returns six of them, every one from inside the `#[program]` expansion, and the build is green. And **the sandbox is real:** the server rejects a submission containing `std::process`, `std::fs::`, `std::net::`, `std::env::`, `Command::new`, `include_bytes!`, `include_str!`, `env!(`, `option_env!` or `proc_macro` before the compiler ever sees it. None of those belongs in a program anyway.\n\nBe exact about what a green check proves: **your code compiled against the real Anchor 1.x toolchain.** No test ran. Nothing executed. A `withdraw` that calls `checked_add` compiles perfectly, and nothing in this course will catch it — module 4 shows you the LiteSVM test that would, and why no compiler can.\n\n## The seam: two things called \"Anchor\"\n\nSearch for Anchor documentation today and you will land on material for a different version of a differently-named package. Three facts save you an afternoon.\n\n- **The Rust crate is `anchor-lang`, at `1.1`.** Anchor 1.0 was a breaking release and the internet has not caught up. When a snippet does not compile here, suspect its age before you suspect yourself; the specific breakages are called out in the lessons where they bite.\n- **The TypeScript package is `@anchor-lang/core`.** The old one, `@coral-xyz/anchor`, is frozen at 0.32.1 and still pulls roughly 659k weekly downloads against `@anchor-lang/core`'s 16k. Popularity is not currency — that ratio measures how much stale tutorial code is in circulation. You need the TS side in Course 4, not here, but you will meet the wrong package name long before then.\n- **The version manager installs from `otter-sec/anchor`,** not `coral-xyz/anchor`. Maintenance moved. A `cargo install --git …/coral-xyz/anchor avm` line dates a blog post on its own.\n\nNone of this is your problem in this lesson, because you are installing nothing. That is what the build server is for: no toolchain, no version manager, no `PATH`. Browser builds are not new — Solana Playground has offered them for years and the Foundation's own quickstart uses one. What is different here is that this path is **graded, sequenced and credentialed**, and the program you deploy in module 4 is an artifact that three later things consume.\n\n## Your job\n\nPress **Build**. Change nothing. Read the output.\n"
+        "src": "# Your First Build\n\nThis is the simplest challenge in the entire course. Your goal: **hit the Build button and see it succeed.**\n\nThe starter code is a minimal Anchor program that compiles with zero changes. Don't modify anything — just click **Build** and watch the build server compile your first Solana program.\n\n## What to Expect\n\n- The build takes 30-60 seconds on first run (dependencies are cached after that)\n- You'll see compiler output in the panel below\n- A green checkmark means your program compiled to a `.so` binary\n- The build UUID is your compiled program's identifier\n\n## Why This Matters\n\nThis proves the pipeline works end-to-end: your code leaves the browser, reaches the build server, gets compiled by `cargo-build-sbf`, and the result comes back. Every lesson after this builds on this foundation.\n"
       },
       {
         "_key": "exercise",
@@ -2880,29 +1858,22 @@
           "If you see errors, make sure you haven't accidentally modified the starter code. Click Reset Code to restore it."
         ],
         "language": "rust",
-        "solution": "// From Rust core to Anchor — the solution is the starter, unchanged.\n//\n// This is a no-edit lesson: the starter already compiles, and \"solving\" it means\n// pressing Build. The two files are identical on purpose, so that Reset Code and\n// Show Solution land you in exactly the same place.\n//\n// This file is your Course 2 `vault_core.rs`, unchanged, with the Anchor wrapper\n// added underneath it. The two halves are separated by a labeled line so you can\n// see exactly where your code stops and this course's material starts.\n//\n// If you did not take Course 2, this is the reference version — it is a correct\n// vault core, and starting here is a supported path.\n\n// ─────────────────────────────────────────────────────────────────────────────\n// YOUR COURSE 2 FILE — copied in verbatim, from the `use` line to the re-export.\n// Not one character of it changes in this course.\n// ─────────────────────────────────────────────────────────────────────────────\nuse anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\npub mod vault {\n    use super::*;\n\n    #[account]\n    #[derive(InitSpace)]\n    pub struct VaultState {\n        pub owner: Pubkey,\n        pub balance: u64,\n        pub bump: u8,\n    }\n\n    #[error_code]\n    pub enum VaultError {\n        #[msg(\"Deposit would overflow the vault balance\")]\n        Overflow,\n        #[msg(\"Withdrawal is larger than the vault balance\")]\n        InsufficientFunds,\n        #[msg(\"Amount must be greater than zero\")]\n        ZeroAmount,\n        #[msg(\"Signer is not the vault owner\")]\n        NotOwner,\n    }\n\n    impl VaultState {\n        pub fn deposit(&mut self, amount: u64) -> Result<()> {\n            require!(amount > 0, VaultError::ZeroAmount);\n            self.balance = self\n                .balance\n                .checked_add(amount)\n                .ok_or(VaultError::Overflow)?;\n            Ok(())\n        }\n\n        pub fn withdraw(&mut self, amount: u64) -> Result<()> {\n            require!(amount > 0, VaultError::ZeroAmount);\n            self.balance = self\n                .balance\n                .checked_sub(amount)\n                .ok_or(VaultError::InsufficientFunds)?;\n            Ok(())\n        }\n    }\n}\n\npub use vault::{VaultError, VaultState};\n\n// ─────────────────────────────────────────────────────────────────────────────\n// EVERYTHING BELOW THIS LINE IS WHAT COURSE 3 ADDS.\n//\n// Two items, and they are the two your Course 2 file was missing:\n//\n//   #[program]          — turns a plain Rust module into a set of instructions\n//                         the Solana runtime can dispatch to. This is what makes\n//                         the crate a *program* and not a library.\n//   #[derive(Accounts)] — declares which accounts an instruction may touch.\n//                         `DryRun` declares none, and that is the entire reason\n//                         nothing below persists.\n//\n// Read the body of `dry_run`: it builds a `VaultState`, calls the `deposit` you\n// wrote in Course 2, and logs the result. The method is imported, not retyped.\n// That is the pattern for the rest of the course — a handler validates accounts\n// and then calls core logic that was already correct.\n// ─────────────────────────────────────────────────────────────────────────────\n#[program]\npub mod vault_program {\n    use super::*;\n\n    pub fn dry_run(_ctx: Context<DryRun>) -> Result<()> {\n        // Not an account — a value on this handler's stack, alive for exactly\n        // as long as this instruction runs.\n        let mut vault = VaultState {\n            owner: Pubkey::default(),\n            balance: 0,\n            bump: 0,\n        };\n\n        // Your Course 2 method, called unmodified. `?` needs no conversion here\n        // because `deposit` already returns `anchor_lang::Result<()>`.\n        vault.deposit(1_000)?;\n\n        msg!(\"program id: {}\", ID);\n        msg!(\"balance after deposit: {}\", vault.balance);\n        Ok(())\n    }\n}\n\n#[derive(Accounts)]\npub struct DryRun {}\n",
-        "starter": "// From Rust core to Anchor — nothing to write. Click Build.\n//\n// This file is your Course 2 `vault_core.rs`, unchanged, with the Anchor wrapper\n// added underneath it. The two halves are separated by a labeled line so you can\n// see exactly where your code stops and this course's material starts.\n//\n// If you did not take Course 2, this is the reference version — it is a correct\n// vault core, and starting here is a supported path.\n\n// ─────────────────────────────────────────────────────────────────────────────\n// YOUR COURSE 2 FILE — copied in verbatim, from the `use` line to the re-export.\n// Not one character of it changes in this course.\n// ─────────────────────────────────────────────────────────────────────────────\nuse anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\npub mod vault {\n    use super::*;\n\n    #[account]\n    #[derive(InitSpace)]\n    pub struct VaultState {\n        pub owner: Pubkey,\n        pub balance: u64,\n        pub bump: u8,\n    }\n\n    #[error_code]\n    pub enum VaultError {\n        #[msg(\"Deposit would overflow the vault balance\")]\n        Overflow,\n        #[msg(\"Withdrawal is larger than the vault balance\")]\n        InsufficientFunds,\n        #[msg(\"Amount must be greater than zero\")]\n        ZeroAmount,\n        #[msg(\"Signer is not the vault owner\")]\n        NotOwner,\n    }\n\n    impl VaultState {\n        pub fn deposit(&mut self, amount: u64) -> Result<()> {\n            require!(amount > 0, VaultError::ZeroAmount);\n            self.balance = self\n                .balance\n                .checked_add(amount)\n                .ok_or(VaultError::Overflow)?;\n            Ok(())\n        }\n\n        pub fn withdraw(&mut self, amount: u64) -> Result<()> {\n            require!(amount > 0, VaultError::ZeroAmount);\n            self.balance = self\n                .balance\n                .checked_sub(amount)\n                .ok_or(VaultError::InsufficientFunds)?;\n            Ok(())\n        }\n    }\n}\n\npub use vault::{VaultError, VaultState};\n\n// ─────────────────────────────────────────────────────────────────────────────\n// EVERYTHING BELOW THIS LINE IS WHAT COURSE 3 ADDS.\n//\n// Two items, and they are the two your Course 2 file was missing:\n//\n//   #[program]          — turns a plain Rust module into a set of instructions\n//                         the Solana runtime can dispatch to. This is what makes\n//                         the crate a *program* and not a library.\n//   #[derive(Accounts)] — declares which accounts an instruction may touch.\n//                         `DryRun` declares none, and that is the entire reason\n//                         nothing below persists.\n//\n// Read the body of `dry_run`: it builds a `VaultState`, calls the `deposit` you\n// wrote in Course 2, and logs the result. The method is imported, not retyped.\n// That is the pattern for the rest of the course — a handler validates accounts\n// and then calls core logic that was already correct.\n// ─────────────────────────────────────────────────────────────────────────────\n#[program]\npub mod vault_program {\n    use super::*;\n\n    pub fn dry_run(_ctx: Context<DryRun>) -> Result<()> {\n        // Not an account — a value on this handler's stack, alive for exactly\n        // as long as this instruction runs.\n        let mut vault = VaultState {\n            owner: Pubkey::default(),\n            balance: 0,\n            bump: 0,\n        };\n\n        // Your Course 2 method, called unmodified. `?` needs no conversion here\n        // because `deposit` already returns `anchor_lang::Result<()>`.\n        vault.deposit(1_000)?;\n\n        msg!(\"program id: {}\", ID);\n        msg!(\"balance after deposit: {}\", vault.balance);\n        Ok(())\n    }\n}\n\n#[derive(Accounts)]\npub struct DryRun {}\n",
+        "solution": "use anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n#[program]\npub mod academy_program {\n    use super::*;\n\n    pub fn initialize(_ctx: Context<Initialize>) -> Result<()> {\n        msg!(\"Superteam Academy default program\");\n        Ok(())\n    }\n}\n\n#[derive(Accounts)]\npub struct Initialize {}\n",
+        "starter": "use anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n#[program]\npub mod academy_program {\n    use super::*;\n\n    pub fn initialize(_ctx: Context<Initialize>) -> Result<()> {\n        msg!(\"Superteam Academy default program\");\n        Ok(())\n    }\n}\n\n#[derive(Accounts)]\npub struct Initialize {}\n",
         "tests": [
           {
-            "description": "The file compiles on the build server against anchor-lang 1.1.2",
+            "description": "Program compiles successfully",
             "expectedOutput": "true",
-            "id": "t1",
-            "input": ""
-          },
-          {
-            "description": "Compiles ⇒ the Course 2 vault core and the #[program] wrapper coexist in one crate",
-            "expectedOutput": "true",
-            "id": "t2",
+            "id": "test-1",
             "input": ""
           }
         ],
         "tutorNotes": [
-          "Six `unexpected cfg condition value` warnings come back from inside the `#[program]` expansion on a correct build. They are warnings, the build is green, and a learner reading the first `warning:` as the reason it \"failed\" is the single most common confusion on this lesson. Point at the final line, not the first one.",
-          "The editor shows one file and the build server compiles it as `src/lib.rs` of a fixed crate. The manifest, the lockfile and the dependency versions are not editable. Requests to \"add a dependency\", \"split this into modules\" or \"put the vault in its own file\" cannot be satisfied by this pipeline — the inline `pub mod vault` is the workaround, not a style preference.",
-          "The build cache is keyed on the dependency graph, not on the learner's source, so the slow build is once per session and every later lesson in the course is fast even though the file changed. A learner who edits and waits 40 seconds again usually hit a cold worker, not their own code.",
-          "`declare_id!` is a placeholder until module 4. Pasting a different pubkey into it still builds green — nothing checks the value at compile time. The mismatch only surfaces at deploy, as `DeclaredProgramIdMismatch`, which is why the id is not worth changing here.",
-          "Nothing in this lesson executes. Grading is compile-success only: the server shells `cargo-build-sbf` and reports whether a `.so` came back. If asked whether `deposit` \"passed\", the honest answer is that no test ran — behaviour is not checked anywhere in this course — module 4 shows you the LiteSVM test that would check it, and why compiling cannot.",
-          "`dry_run` builds a `VaultState` on the stack, so its `balance` is discarded when the instruction returns. Learners often read the log line as proof that state was saved. Nothing was saved: `DryRun` declares no accounts, and `#[account]` describes a shape rather than creating storage."
+          "Learners edit the starter to feel productive, but it already compiles unchanged; a broken build here is almost always a self-inflicted edit, and the fix is Reset Code, not a new one.",
+          "They read the slow first build (dependencies downloading) or a timeout as a real failure and give up, instead of simply clicking Build again as the hints say.",
+          "They expect a local `cargo build` on their own machine and are thrown that compilation runs on the build server through the sbf toolchain, not their terminal.",
+          "They treat a compiler warning as the error and chase it, missing that the build actually succeeded — a green check means the `.so` compiled and there is nothing to fix.",
+          "They take the green check to mean the program is deployed and live on devnet, and go hunting for it on-chain; building only produced a binary — deployment is a later lesson."
         ]
       },
       {
@@ -2958,51 +1929,19 @@
               }
             ],
             "prompt": "A green checkmark appears after your build. What does it actually confirm?"
-          },
-          {
-            "explanation": "This is the seam the course closes. `#[program]` gave you an entrypoint, `#[derive(Accounts)]` gave you a place to declare accounts, and your Course 2 methods gave you correct arithmetic — but no one gave you an account. Module 2 is where the vault becomes something that exists between transactions.",
-            "id": "q3",
-            "multiSelect": false,
-            "options": [
-              {
-                "correct": true,
-                "id": "a",
-                "label": "Nothing new. The `VaultState` was a value on the handler's stack; `DryRun` declares no accounts, so nothing was created or written and the balance is gone the moment the instruction returns."
-              },
-              {
-                "correct": false,
-                "feedback": "`#[account]` supplies serialization and the 8-byte discriminator for a struct that is *stored in* an account. It does not create one. Creation is an `init` constraint on an accounts struct, and this instruction has no accounts struct fields at all.",
-                "id": "b",
-                "label": "An account owned by your program holding `balance: 1000` — `#[account]` on `VaultState` is what creates it."
-              },
-              {
-                "correct": false,
-                "feedback": "A handler that only computes and logs is perfectly legal and succeeds. Every Anchor quickstart's first instruction does exactly this.",
-                "id": "c",
-                "label": "Nothing persists, and the transaction fails — the runtime rejects an instruction that writes no account."
-              },
-              {
-                "correct": false,
-                "feedback": "Programs are stateless. `#[program]` generates an entrypoint and a dispatcher — code, not storage. All mutable state on Solana lives in accounts that are passed in.",
-                "id": "d",
-                "label": "The values persist inside the program binary, because `#[program]` gives the module somewhere to keep them."
-              }
-            ],
-            "prompt": "`dry_run` builds a `VaultState`, calls your Course 2 `deposit(1_000)`, logs `balance after deposit: 1000` and returns `Ok(())` — green build, successful transaction. Predict what exists on-chain afterwards."
           }
         ]
       }
     ],
     "skills": [
       "anchor",
-      "solana-programs",
-      "program-build"
+      "solana-programs"
     ],
     "slug": {
       "_type": "slug",
-      "current": "from-rust-core-to-anchor"
+      "current": "your-first-build"
     },
-    "title": "From Rust Core to Anchor"
+    "title": "Your First Build"
   },
   {
     "_id": "lesson-connect-wallet-challenge",
@@ -4447,7 +3386,6 @@
             "prompt": "You write `let before = &v.balance;`, then `credit(v, 1_000);`, then `return *before;`. Predict the compiler's verdict — and what changes if you delete the last line."
           },
           {
-            "explanation": "`&T` grants read access and nothing else, all the way down and regardless of the field's type, so assigning to `v.balance` through `&VaultLike` is `E0594`. A call site cannot upgrade a shared borrow to an exclusive one — the signature is the promise — which also sets it apart from `E0596`, taking `&mut` of a binding declared without `let mut`.",
             "id": "q2",
             "multiSelect": false,
             "options": [
@@ -4509,7 +3447,6 @@
             "prompt": "Inside `fn f(v: &mut VaultLike)` you write `let b = &mut v.balance;` and on the next line `let p = &mut v.bump;`, then use both. Predict the verdict."
           },
           {
-            "explanation": "You cannot lend out write access you were never granted: `let vault = ...` binds immutably, so `&mut vault` is `E0596` even though the call site asks for `&mut`. `let mut` on the binding grants the write; `&mut` at the call site only passes it on. A mutable borrow is a loan, not a move, which is why it is never `E0382`.",
             "id": "q4",
             "multiSelect": false,
             "options": [
@@ -4682,7 +3619,6 @@
             "prompt": "You finish the second exercise, but in `withdraw` you typed `checked_add` where you meant `checked_sub`. Everything else matches the spec. Predict what the build server reports."
           },
           {
-            "explanation": "`use super::*` pulls in exactly what is in scope one level up — the crate root, where `mod verify` is a sibling of `mod vault` — and never searches downward into sibling modules, so the harness cannot see `VaultState` and fails with \"cannot find type\". A crate-root re-export is what bridges a sibling module; the items are already `pub`, so visibility is not the problem.",
             "id": "q2",
             "multiSelect": false,
             "options": [
@@ -4713,7 +3649,6 @@
             "prompt": "You write `VaultState` and `VaultError` inside `pub mod vault { … }` and forget the crate-root re-export. The harness below begins with `use super::*;`. Predict the first error."
           },
           {
-            "explanation": "With `overflow-checks = true` in the release profile, `self.balance - amount` when `amount` exceeds the balance panics at runtime and aborts the instruction — no `VaultError`, no message for the caller. The compiler only rejects overflow it can evaluate on constants; runtime values need `checked_sub(...).ok_or(...)?` to convert the panic into a named error, the lesson-4 rule.",
             "id": "q3",
             "multiSelect": false,
             "options": [
@@ -4810,7 +3745,6 @@
         "_type": "quiz",
         "questions": [
           {
-            "explanation": "`-` on `u64` always returns `u64`, never an `Option`, so with `overflow-checks = true` an underflow panics and the transaction aborts — the caller gets a crash, not an error it can distinguish. The flag lives in `Cargo.toml`, not your code, so correctness that leans on it is one profile change from wrong; call `checked_sub` to get an `Option` you handle.",
             "id": "q1",
             "multiSelect": false,
             "options": [
@@ -4841,7 +3775,6 @@
             "prompt": "A vault holds 5 lamports. A withdrawal for 7 reaches `let new_balance = balance - amount;`. The program was compiled by our build server, which sets `overflow-checks = true` in its release profile. Predict what happens, and what a caller can do about it."
           },
           {
-            "explanation": "`?` on `Option` is still unstable in const context, so it fails with `E0015` inside a `const fn` — which is why the spec asks for `match`. Dropping `const fn` to reach for `?` would disable the assertions that grade the lesson; `?` on `Result`, in a non-const function, arrives in lesson 12.",
             "id": "q2",
             "multiSelect": false,
             "options": [
@@ -4872,7 +3805,6 @@
             "prompt": "A submission writes `pub const fn sub_lamports(b: u64, a: u64) -> Option<u64> { Some(b.checked_sub(a)?) }`. Predict the outcome."
           },
           {
-            "explanation": "A trailing semicolon turns `checked_sub`'s result into a discarded statement, so the body evaluates to `()` and fails a `-> Option<u64>` signature with `E0308` — there is no implicit `None`. This is the same tail-expression rule that broke `if a < b { a; } else { b; }` in lesson 3: the semicolon, not the value, decides what a body returns.",
             "id": "q3",
             "multiSelect": false,
             "options": [
@@ -5306,7 +4238,6 @@
         "_type": "quiz",
         "questions": [
           {
-            "explanation": "Swapping the shared borrow for `&mut v.balance` trades one rule for another: `&mut` is exclusive, so holding it across the `credit(v, ...)` call is a second mutable borrow and fails with `E0499`, not the shared-then-mutable `E0502`. Telling the two apart is how you know whether to drop a borrow or reorder the calls.",
             "id": "q1",
             "multiSelect": false,
             "options": [
@@ -5337,7 +4268,6 @@
             "prompt": "In bug 2 you replace `let before = &v.balance;` with `let before = &mut v.balance;` and change nothing else. Predict the error you now get."
           },
           {
-            "explanation": "`data.to_vec()` creates a `Vec` that is dropped at the end of the statement, so returning `&...[..8]` into it is `E0515` — a reference outliving the value it points at. The fix is not to bind the `Vec` with `let` (that is the two-line original bug) but to avoid creating an owned `Vec` at all; the freed memory is never read because the error is caught at compile time.",
             "id": "q2",
             "multiSelect": false,
             "options": [
@@ -5460,7 +4390,6 @@
         "_type": "quiz",
         "questions": [
           {
-            "explanation": "A semicolon is an operation, not punctuation: it discards its expression's value and yields `()`, so both arms become `()` and the body fails its `u64` return with `E0308`, once per arm. `()` coerces to nothing — the same no-implicit-conversion rule you met with `u8` and `u64` — and the `help:` line offers to remove the semicolon.",
             "id": "q1",
             "multiSelect": false,
             "options": [
@@ -5491,7 +4420,6 @@
             "prompt": "Predict the outcome. `pub fn min_balance(a: u64, b: u64) -> u64 { if a < b { a; } else { b; } }`"
           },
           {
-            "explanation": "`match` is strictly source order, first match wins — there is no specificity ranking and no literal-before-range rule — so a `0..=999_999` arm above `0` claims 0 and returns \"dust\". The shadowed arm is only a warn-level `unreachable pattern` lint, so a compile-graded lesson passes it and the log is discarded on success; nothing but reading the arms catches a wrong order.",
             "id": "q2",
             "multiSelect": false,
             "options": [
@@ -5522,7 +4450,6 @@
             "prompt": "A submission orders the arms `0..=999_999 => \"dust\",` then `0 => \"empty\",` then the rest, and it is otherwise exhaustive. Predict both the build result and what `describe_state(0)` returns."
           },
           {
-            "explanation": "A literal that does not fit its annotated type is caught at compile time by a deny-by-default lint, so `let bump: u8 = 300` stops the build rather than wrapping to 44 or clamping to 255. Wrapping is what `300u32 as u8` would do — exactly why this course avoids `as` on numbers, the rule from lesson 2.",
             "id": "q3",
             "multiSelect": false,
             "options": [
@@ -5792,7 +4719,6 @@
             "prompt": "`VaultLike` holds a `Pubkey`, a `u64` and a `u8` — every field is a `Copy` type. You write `let moved = vault;` and then read `vault.balance`. Predict what the compiler does."
           },
           {
-            "explanation": "`Pubkey` derives `Copy`, so `let a = v.owner` copies 32 bytes out of the shared borrow rather than moving the field, and a `Copy` field is never moved by a read — both lines compile. Reading is exactly what `&T` is for, and the copy is 32 stack bytes with no allocator, which is why the heap types `Vec` and `String` are not `Copy`.",
             "id": "q2",
             "multiSelect": false,
             "options": [
@@ -5823,7 +4749,6 @@
             "prompt": "Inside `fn copy_an_address(v: &VaultLike)` you write `let a = v.owner;` and then `let b = v.owner;`. Predict the outcome."
           },
           {
-            "explanation": "Ownership follows the signature, not the body: `consume_bytes(bytes: Vec<u8>)` takes the buffer by value, so the first call moves `data` and drops it and the second is `E0382`. A `Vec` can never be `Copy`, and the compiler refuses to build the second call rather than let you observe a moved-from or \"emptied\" value.",
             "id": "q3",
             "multiSelect": false,
             "options": [
@@ -5906,7 +4831,6 @@
         "_type": "quiz",
         "questions": [
           {
-            "explanation": "`for v in vaults` desugars to `vaults.into_iter()`, which takes the `Vec` by value, so `vaults` is gone by the time `vaults.len()` runs and the read is `E0382`. `for v in &vaults` borrows instead — the compiler's own suggestion — because a read is a borrow and you cannot borrow what you no longer own.",
             "id": "q1",
             "multiSelect": false,
             "options": [
@@ -6030,7 +4954,6 @@
             "prompt": "Inside `fn stash(v: &mut VaultLike) -> u64` you write `let slot = &mut v.balance;`, then `let total = balance_of(v);`, then `*slot = total;`. Predict the error and its exact direction."
           },
           {
-            "explanation": "The literal `8` infers `u32` from `field_count`, so the sum stays `u32` and fails a `-> usize` return with `E0308` — Rust has no implicit numeric widening. The compiler's diagnostics are authoritative but its suggestions are not: `.try_into().unwrap()` compiles and panics on the input that overflows, so keep `usize::try_from(field_count)` and handle the `Err`. (`usize::from` does not exist for `u32`; that conversion is only `TryFrom`.)",
             "id": "q5",
             "multiSelect": false,
             "options": [
@@ -6408,7 +5331,6 @@
         "_type": "quiz",
         "questions": [
           {
-            "explanation": "Rust performs no implicit numeric conversion in either direction, lossless widenings included, so a `u8` where `u64` is expected is a hard `E0308` — not a warning and not an `as`-cast. Convert explicitly with `u64::from(bump)`, which is infallible precisely because every `u8` fits.",
             "id": "q1",
             "multiSelect": false,
             "options": [
@@ -6439,7 +5361,6 @@
             "prompt": "Predict the outcome. `pub fn bump_as_u64(bump: u8) -> u64 { bump }` — and note that every possible `u8` value fits in a `u64`."
           },
           {
-            "explanation": "`rustc` finishes the whole pass before reporting, so four independent mistakes come back as four errors, each with its own code and span — not one at a time the way a runtime halts on the first exception. The first build of a broken file is a complete to-do list; a real cascade only comes from a mistake that leaves the compiler guessing at a type other code depends on.",
             "id": "q2",
             "multiSelect": false,
             "options": [
@@ -6470,7 +5391,6 @@
             "prompt": "Carried over from lesson 1. Your file has four unrelated mistakes in four different functions. Predict what one build gives you."
           },
           {
-            "explanation": "A parameter typed `&VaultLike` is a promise not to write, and nothing overrides it: `pub` only controls who may name the field, and the caller's ownership stays on the caller's side of the signature. Assigning through it is `E0594`, fixed by `&mut` in the signature — distinct from `E0384`, the immutable-binding case.",
             "id": "q3",
             "multiSelect": false,
             "options": [
@@ -6501,7 +5421,6 @@
             "prompt": "Predict the outcome. `pub fn set_balance(vault: &VaultLike, lamports: u64) { vault.balance = lamports; }` — where `balance` is declared `pub`, and the caller passes a value it owns and can freely modify."
           },
           {
-            "explanation": "`Number` is a 64-bit double with only 53 bits of integer precision, so any `u64` above 2^53 - 1 is silently rounded to a nearby value — no error, no warning, and `Number.MAX_SAFE_INTEGER` is documentation, not a guard. That silent rounding is why Solana clients read `u64` fields as `BigInt`.",
             "id": "q4",
             "multiSelect": false,
             "options": [
@@ -6563,7 +5482,6 @@
         "_type": "quiz",
         "questions": [
           {
-            "explanation": "`INIT_SPACE` is an associated const the `InitSpace` derive computes at compile time, so widening `bump` to `u64` makes it 48 and the `const _: () = assert!(... == 41)` fails the build — a `u64` field is perfectly legal, the size is the problem. Deriving `space = 8 + INIT_SPACE` from the same const keeps allocation correct; hardcoding the number is what under-allocates.",
             "id": "q1",
             "multiSelect": false,
             "options": [
@@ -6625,7 +5543,6 @@
             "prompt": "In `self.balance = self.balance.checked_add(amount).ok_or(VaultError::Overflow)?;` — `?` converts the error by calling `From::from`. Name the generated impl it lands on, and what reaches the caller."
           },
           {
-            "explanation": "`&mut self` and `mut self` both let you write, but they differ in ownership: `mut self` consumes the value while `&mut self` borrows it, and that difference is in the type the harness binds — `fn(VaultState, ...)` versus `fn(&mut VaultState, ...)`. Taking `self` by value is legal Rust (`into_parts(self)`) but wrong here, because Anchor reaches account data through a mutable deref, not by value.",
             "id": "q3",
             "multiSelect": false,
             "options": [
@@ -6656,7 +5573,6 @@
             "prompt": "You change `pub fn withdraw(&mut self, amount: u64)` to `pub fn withdraw(mut self, amount: u64)`. Both let you write to the fields. Predict what the build reports."
           },
           {
-            "explanation": "The 8 bytes are the Anchor discriminator — a hash of the account type's name written at offset 0 — the same first 8 bytes your Course 1 decoder sliced off before reading `owner`. They are not lamports (those live in the account's metadata), not a borsh length prefix (4 bytes, and only on variable-length types), and not padding, since Anchor lays fields back to back after the discriminator.",
             "id": "q4",
             "multiSelect": false,
             "options": [
@@ -6687,7 +5603,6 @@
             "prompt": "Carried over from Course 1. `VaultState::INIT_SPACE` is 41 and Course 3 allocates `8 + 41 = 49` bytes. What are the 8, and where have you met them before?"
           },
           {
-            "explanation": "The bump is what the derivation counted down from 255 until the address left the ed25519 curve, and storing it lets a later instruction re-validate the PDA without paying to re-run that search. Hardcoding 254 is not safe — a mock SDK's hardcoded 254 was exactly the Course 1 bug; the canonical bump is whatever the search found for those seeds, and seed order changes the address because hashing is order-sensitive.",
             "id": "q5",
             "multiSelect": true,
             "options": [
@@ -6843,7 +5758,6 @@
         "_type": "quiz",
         "questions": [
           {
-            "explanation": "A buildable lesson is graded on one bit — did it compile — and `rustc` treats warnings as advice and exits successfully, so an unreachable-pattern warning still passes. The trap is that this platform discards the build log on success, so the warning never reaches you; that matters when a later lesson tells you a mistake \"only warns\".",
             "id": "q1",
             "multiSelect": false,
             "options": [
@@ -6874,7 +5788,6 @@
             "prompt": "You submit a file that compiles but makes `rustc` emit `warning: unreachable pattern`. There is no `error[E….]` anywhere. Predict both the grade and what appears in the output panel."
           },
           {
-            "explanation": "`declare_id!` generates the compile-time constant `ID`, and the `msg!` on the next line uses it, so deleting the macro makes the name absent and the build fails during compilation. It is not deploy metadata and there is no all-zeros fallback — Rust resolves names at compile time, so there is no \"later\" for this class of mistake.",
             "id": "q2",
             "multiSelect": false,
             "options": [
@@ -6905,7 +5818,6 @@
             "prompt": "You delete the `declare_id!` line from this lesson's file and leave everything else alone. Predict the outcome."
           },
           {
-            "explanation": "The toolchain is pinned by the `--tools-version` the build server passes to `cargo-build-sbf`, and nothing in a submission can raise it, so a feature stabilised after that version fails to compile here even though it is valid Rust on a newer toolchain. The server's compiler is the ceiling, which is why every lesson carries a version stamp at the top.",
             "id": "q3",
             "multiSelect": false,
             "options": [

--- a/apps/web/src/content/generated/meta.json
+++ b/apps/web/src/content/generated/meta.json
@@ -1,11 +1,11 @@
 {
-  "compiledAt": "2026-07-26T22:44:16Z",
+  "compiledAt": "2026-07-26T20:09:22Z",
   "counts": {
     "achievements": 10,
     "courses": 8,
     "learningPaths": 8,
-    "lessons": 98,
+    "lessons": 99,
     "quests": 5
   },
-  "sha": "7a497475e14f3f53e5353cd752476eb0b2120096"
+  "sha": "1b74e4a60f8813374219451b60436af832df2d91"
 }

--- a/apps/web/src/content/generated/skills.json
+++ b/apps/web/src/content/generated/skills.json
@@ -248,25 +248,5 @@
   {
     "label": "Program Security",
     "slug": "program-security"
-  },
-  {
-    "label": "Program Build Pipeline",
-    "slug": "program-build"
-  },
-  {
-    "label": "Rent & Account Space",
-    "slug": "rent-and-space"
-  },
-  {
-    "label": "Program Errors",
-    "slug": "program-errors"
-  },
-  {
-    "label": "IDL",
-    "slug": "idl"
-  },
-  {
-    "label": "Solana Explorer",
-    "slug": "solana-explorer"
   }
 ]

--- a/apps/web/src/content/generated/slots.json
+++ b/apps/web/src/content/generated/slots.json
@@ -19,27 +19,23 @@
     "version": 1
   },
   "course-building-first-program": {
-    "next": 19,
-    "retired": [
-      0,
-      2,
-      11,
-      14
-    ],
+    "next": 16,
+    "retired": [],
     "slots": {
       "lesson-bfsp-account-constraints": 6,
       "lesson-bfsp-add-instruction": 3,
       "lesson-bfsp-adding-instructions": 8,
+      "lesson-bfsp-anatomy-anchor-program": 2,
       "lesson-bfsp-build-increment": 9,
       "lesson-bfsp-complete-counter": 10,
-      "lesson-bfsp-cpi-lamports": 17,
       "lesson-bfsp-define-counter": 5,
+      "lesson-bfsp-deploy-to-devnet": 11,
+      "lesson-bfsp-from-code-to-chain": 0,
       "lesson-bfsp-m4-airdrop": 12,
       "lesson-bfsp-m4-capstone": 15,
       "lesson-bfsp-m4-deploy": 13,
+      "lesson-bfsp-m4-interact": 14,
       "lesson-bfsp-on-chain-state": 4,
-      "lesson-bfsp-pdas-vault": 16,
-      "lesson-bfsp-pre-flight-check": 18,
       "lesson-bfsp-wire-up-initialize": 7,
       "lesson-bfsp-your-first-build": 1
     },

--- a/apps/web/src/lib/content/__tests__/fixtures/golden/course-summaries.json
+++ b/apps/web/src/lib/content/__tests__/fixtures/golden/course-summaries.json
@@ -1,10 +1,80 @@
 {
+  "courseTags": [
+    {
+      "_id": "course-anchor-framework",
+      "tags": [
+        "account-model",
+        "anchor",
+        "cpi",
+        "pdas",
+        "program-deployment",
+        "program-testing",
+        "solana-programs"
+      ],
+      "title": "Anchor Framework Mastery",
+      "totalLessons": 12
+    },
+    {
+      "_id": "course-building-first-program",
+      "tags": [
+        "account-model",
+        "anchor",
+        "keypairs-wallets",
+        "program-deployment",
+        "solana-programs",
+        "transactions"
+      ],
+      "title": "Building Your First Solana Program",
+      "totalLessons": 16
+    },
+    {
+      "_id": "course-defi-on-solana",
+      "tags": ["amm", "defi", "lending", "oracles", "spl-tokens", "staking"],
+      "title": "DeFi on Solana",
+      "totalLessons": 12
+    },
+    {
+      "_id": "course-rust-for-solana",
+      "tags": ["borsh-serialization", "pdas", "rust", "solana-programs"],
+      "title": "Rust for Solana Developers",
+      "totalLessons": 12
+    },
+    {
+      "_id": "course-solana-frontend",
+      "tags": [
+        "account-model",
+        "borsh-serialization",
+        "react",
+        "rpc",
+        "siws",
+        "transactions",
+        "typescript",
+        "wallet-adapter",
+        "web3-frontend"
+      ],
+      "title": "Solana Frontend Development",
+      "totalLessons": 12
+    },
+    {
+      "_id": "course-solana-fundamentals",
+      "tags": [
+        "account-model",
+        "keypairs-wallets",
+        "solana-fundamentals",
+        "solana-programs",
+        "spl-tokens",
+        "transactions"
+      ],
+      "title": "Solana Fundamentals",
+      "totalLessons": 12
+    }
+  ],
   "coursesByIds": [
     {
       "_id": "course-anchor-framework",
-      "title": "Anchor Framework Mastery",
+      "difficulty": "intermediate",
+      "learningPath": "Rust & Programs",
       "slug": "anchor-framework",
-      "thumbnail": null,
       "tags": [
         "account-model",
         "anchor",
@@ -14,76 +84,52 @@
         "program-testing",
         "solana-programs"
       ],
-      "difficulty": "intermediate",
-      "totalLessons": 12,
-      "learningPath": "Rust & Programs"
+      "thumbnail": null,
+      "title": "Anchor Framework Mastery",
+      "totalLessons": 12
     },
     {
       "_id": "course-building-first-program",
-      "title": "Building Your First Solana Program",
+      "difficulty": "intermediate",
+      "learningPath": "Solana Core",
       "slug": "building-your-first-solana-program",
-      "thumbnail": null,
       "tags": [
         "account-model",
         "anchor",
-        "checked-arithmetic",
-        "cpi",
-        "debugging",
-        "idl",
         "keypairs-wallets",
-        "pdas",
-        "program-build",
         "program-deployment",
-        "program-errors",
-        "program-security",
-        "program-testing",
-        "rent-and-space",
-        "solana-explorer",
         "solana-programs",
-        "technical-writing",
         "transactions"
       ],
-      "difficulty": "intermediate",
-      "totalLessons": 15,
-      "learningPath": "Solana Core"
+      "thumbnail": null,
+      "title": "Building Your First Solana Program",
+      "totalLessons": 16
     },
     {
       "_id": "course-defi-on-solana",
-      "title": "DeFi on Solana",
-      "slug": "defi-on-solana",
-      "thumbnail": null,
-      "tags": [
-        "amm",
-        "defi",
-        "lending",
-        "oracles",
-        "spl-tokens",
-        "staking"
-      ],
       "difficulty": "advanced",
-      "totalLessons": 12,
-      "learningPath": "DeFi"
+      "learningPath": "DeFi",
+      "slug": "defi-on-solana",
+      "tags": ["amm", "defi", "lending", "oracles", "spl-tokens", "staking"],
+      "thumbnail": null,
+      "title": "DeFi on Solana",
+      "totalLessons": 12
     },
     {
       "_id": "course-rust-for-solana",
-      "title": "Rust for Solana Developers",
-      "slug": "rust-for-solana",
-      "thumbnail": null,
-      "tags": [
-        "borsh-serialization",
-        "pdas",
-        "rust",
-        "solana-programs"
-      ],
       "difficulty": "intermediate",
-      "totalLessons": 12,
-      "learningPath": "Rust & Programs"
+      "learningPath": "Rust & Programs",
+      "slug": "rust-for-solana",
+      "tags": ["borsh-serialization", "pdas", "rust", "solana-programs"],
+      "thumbnail": null,
+      "title": "Rust for Solana Developers",
+      "totalLessons": 12
     },
     {
       "_id": "course-solana-frontend",
-      "title": "Solana Frontend Development",
+      "difficulty": "intermediate",
+      "learningPath": "Frontend",
       "slug": "solana-frontend",
-      "thumbnail": null,
       "tags": [
         "account-model",
         "borsh-serialization",
@@ -95,167 +141,15 @@
         "wallet-adapter",
         "web3-frontend"
       ],
-      "difficulty": "intermediate",
-      "totalLessons": 12,
-      "learningPath": "Frontend"
-    },
-    {
-      "_id": "course-solana-fundamentals",
-      "title": "Solana Fundamentals",
-      "slug": "solana-fundamentals",
       "thumbnail": null,
-      "tags": [
-        "account-model",
-        "keypairs-wallets",
-        "solana-fundamentals",
-        "solana-programs",
-        "spl-tokens",
-        "transactions"
-      ],
-      "difficulty": "beginner",
-      "totalLessons": 12,
-      "learningPath": "Solana Core"
-    }
-  ],
-  "recommended": [
-    {
-      "_id": "course-anchor-framework",
-      "title": "Anchor Framework Mastery",
-      "slug": "anchor-framework",
-      "description": "Master the Anchor framework for Solana smart contract development. From account constraints to PDAs, CPIs, testing, and deployment — build production-ready programs with confidence.",
-      "difficulty": "intermediate",
-      "duration": 14,
-      "thumbnail": null,
-      "creator": "B7o8NfV81HzjuZFWQTTx3Xdvh77Dqoajwib3kWEnvzJF",
-      "tags": [
-        "account-model",
-        "anchor",
-        "cpi",
-        "pdas",
-        "program-deployment",
-        "program-testing",
-        "solana-programs"
-      ],
-      "xpReward": 900,
-      "totalLessons": 12,
-      "trackId": 3,
-      "trackLevel": 1,
-      "learningPath": "Rust & Programs"
-    },
-    {
-      "_id": "course-building-first-program",
-      "title": "Building Your First Solana Program",
-      "slug": "building-your-first-solana-program",
-      "description": "You arrive holding `vault_core.rs` — a `VaultState` and checked `deposit`/`withdraw` that compile, with no `#[program]` and no `#[derive(Accounts)]`. This course adds exactly that. You wrap your own Rust core in Anchor 1.x, create a per-user vault PDA with the space arithmetic derived rather than copied, and move real lamports: deposit through a System Program CPI, withdraw by debiting the program-owned vault directly above an enforced rent floor — and you learn why signer seeds are not the answer there. Then you write the account constraints that stop three named attacks, read the LiteSVM test that would catch what compiling cannot, deploy from a browser tab, publish the IDL on-chain, and call your own live program. Nothing is installed locally. You finish with a devnet program id, a fetchable IDL, and a build write-up.",
-      "difficulty": "intermediate",
-      "duration": 12,
-      "thumbnail": null,
-      "creator": "B7o8NfV81HzjuZFWQTTx3Xdvh77Dqoajwib3kWEnvzJF",
-      "tags": [
-        "account-model",
-        "anchor",
-        "checked-arithmetic",
-        "cpi",
-        "debugging",
-        "idl",
-        "keypairs-wallets",
-        "pdas",
-        "program-build",
-        "program-deployment",
-        "program-errors",
-        "program-security",
-        "program-testing",
-        "rent-and-space",
-        "solana-explorer",
-        "solana-programs",
-        "technical-writing",
-        "transactions"
-      ],
-      "xpReward": 850,
-      "totalLessons": 15,
-      "trackId": 1,
-      "trackLevel": 3,
-      "learningPath": "Solana Core"
-    },
-    {
-      "_id": "course-defi-on-solana",
-      "title": "DeFi on Solana",
-      "slug": "defi-on-solana",
-      "description": "Dive deep into decentralized finance on Solana. Understand AMMs, lending protocols, token mechanics, staking, and build DeFi primitives from vaults to liquidation engines.",
-      "difficulty": "advanced",
-      "duration": 16,
-      "thumbnail": null,
-      "creator": "B7o8NfV81HzjuZFWQTTx3Xdvh77Dqoajwib3kWEnvzJF",
-      "tags": [
-        "amm",
-        "defi",
-        "lending",
-        "oracles",
-        "spl-tokens",
-        "staking"
-      ],
-      "xpReward": 1000,
-      "totalLessons": 12,
-      "trackId": 5,
-      "trackLevel": 1,
-      "learningPath": "DeFi"
-    },
-    {
-      "_id": "course-rust-for-solana",
-      "title": "Rust for Solana Developers",
-      "slug": "rust-for-solana",
-      "description": "Master Rust fundamentals tailored for Solana smart contract development. From ownership and borrowing to serialization, error handling, PDAs, and program architecture — build the skills to write native Solana programs.",
-      "difficulty": "intermediate",
-      "duration": 12,
-      "thumbnail": null,
-      "creator": "B7o8NfV81HzjuZFWQTTx3Xdvh77Dqoajwib3kWEnvzJF",
-      "tags": [
-        "borsh-serialization",
-        "pdas",
-        "rust",
-        "solana-programs"
-      ],
-      "xpReward": 800,
-      "totalLessons": 12,
-      "trackId": 2,
-      "trackLevel": 1,
-      "learningPath": "Rust & Programs"
-    },
-    {
-      "_id": "course-solana-frontend",
       "title": "Solana Frontend Development",
-      "slug": "solana-frontend",
-      "description": "Build production-ready Solana dApp frontends. Master wallet integration, on-chain data reading, and interactive transaction UIs using React and the Solana Wallet Adapter.",
-      "difficulty": "intermediate",
-      "duration": 10,
-      "thumbnail": null,
-      "creator": "B7o8NfV81HzjuZFWQTTx3Xdvh77Dqoajwib3kWEnvzJF",
-      "tags": [
-        "account-model",
-        "borsh-serialization",
-        "react",
-        "rpc",
-        "siws",
-        "transactions",
-        "typescript",
-        "wallet-adapter",
-        "web3-frontend"
-      ],
-      "xpReward": 700,
-      "totalLessons": 12,
-      "trackId": 4,
-      "trackLevel": 1,
-      "learningPath": "Frontend"
+      "totalLessons": 12
     },
     {
       "_id": "course-solana-fundamentals",
-      "title": "Solana Fundamentals",
-      "slug": "solana-fundamentals",
-      "description": "A comprehensive beginner course covering the fundamentals of Solana blockchain development. Learn to set up your environment, create wallets, send transactions, and work with SPL tokens. Perfect for developers new to Solana who want to start building decentralized applications.",
       "difficulty": "beginner",
-      "duration": 10,
-      "thumbnail": null,
-      "creator": "B7o8NfV81HzjuZFWQTTx3Xdvh77Dqoajwib3kWEnvzJF",
+      "learningPath": "Solana Core",
+      "slug": "solana-fundamentals",
       "tags": [
         "account-model",
         "keypairs-wallets",
@@ -264,11 +158,9 @@
         "spl-tokens",
         "transactions"
       ],
-      "xpReward": 600,
-      "totalLessons": 12,
-      "trackId": 1,
-      "trackLevel": 1,
-      "learningPath": "Solana Core"
+      "thumbnail": null,
+      "title": "Solana Fundamentals",
+      "totalLessons": 12
     }
   ],
   "lessonCounts": [
@@ -278,7 +170,7 @@
     },
     {
       "_id": "course-building-first-program",
-      "totalLessons": 15
+      "totalLessons": 16
     },
     {
       "_id": "course-defi-on-solana",
@@ -295,6 +187,136 @@
     {
       "_id": "course-solana-fundamentals",
       "totalLessons": 12
+    }
+  ],
+  "recommended": [
+    {
+      "_id": "course-anchor-framework",
+      "creator": "B7o8NfV81HzjuZFWQTTx3Xdvh77Dqoajwib3kWEnvzJF",
+      "description": "Master the Anchor framework for Solana smart contract development. From account constraints to PDAs, CPIs, testing, and deployment — build production-ready programs with confidence.",
+      "difficulty": "intermediate",
+      "duration": 14,
+      "learningPath": "Rust & Programs",
+      "slug": "anchor-framework",
+      "tags": [
+        "account-model",
+        "anchor",
+        "cpi",
+        "pdas",
+        "program-deployment",
+        "program-testing",
+        "solana-programs"
+      ],
+      "thumbnail": null,
+      "title": "Anchor Framework Mastery",
+      "totalLessons": 12,
+      "trackId": 3,
+      "trackLevel": 1,
+      "xpReward": 900
+    },
+    {
+      "_id": "course-building-first-program",
+      "creator": "B7o8NfV81HzjuZFWQTTx3Xdvh77Dqoajwib3kWEnvzJF",
+      "description": "Take your Anchor knowledge from theory to practice. Write, compile, and deploy real Solana programs using the Superteam Academy Build Server — no local toolchain setup required. By the end, you'll have a working counter program deployed to Devnet.",
+      "difficulty": "intermediate",
+      "duration": 12,
+      "learningPath": "Solana Core",
+      "slug": "building-your-first-solana-program",
+      "tags": [
+        "account-model",
+        "anchor",
+        "keypairs-wallets",
+        "program-deployment",
+        "solana-programs",
+        "transactions"
+      ],
+      "thumbnail": null,
+      "title": "Building Your First Solana Program",
+      "totalLessons": 16,
+      "trackId": 1,
+      "trackLevel": 2,
+      "xpReward": 850
+    },
+    {
+      "_id": "course-defi-on-solana",
+      "creator": "B7o8NfV81HzjuZFWQTTx3Xdvh77Dqoajwib3kWEnvzJF",
+      "description": "Dive deep into decentralized finance on Solana. Understand AMMs, lending protocols, token mechanics, staking, and build DeFi primitives from vaults to liquidation engines.",
+      "difficulty": "advanced",
+      "duration": 16,
+      "learningPath": "DeFi",
+      "slug": "defi-on-solana",
+      "tags": ["amm", "defi", "lending", "oracles", "spl-tokens", "staking"],
+      "thumbnail": null,
+      "title": "DeFi on Solana",
+      "totalLessons": 12,
+      "trackId": 5,
+      "trackLevel": 1,
+      "xpReward": 1000
+    },
+    {
+      "_id": "course-rust-for-solana",
+      "creator": "B7o8NfV81HzjuZFWQTTx3Xdvh77Dqoajwib3kWEnvzJF",
+      "description": "Master Rust fundamentals tailored for Solana smart contract development. From ownership and borrowing to serialization, error handling, PDAs, and program architecture — build the skills to write native Solana programs.",
+      "difficulty": "intermediate",
+      "duration": 12,
+      "learningPath": "Rust & Programs",
+      "slug": "rust-for-solana",
+      "tags": ["borsh-serialization", "pdas", "rust", "solana-programs"],
+      "thumbnail": null,
+      "title": "Rust for Solana Developers",
+      "totalLessons": 12,
+      "trackId": 2,
+      "trackLevel": 1,
+      "xpReward": 800
+    },
+    {
+      "_id": "course-solana-frontend",
+      "creator": "B7o8NfV81HzjuZFWQTTx3Xdvh77Dqoajwib3kWEnvzJF",
+      "description": "Build production-ready Solana dApp frontends. Master wallet integration, on-chain data reading, and interactive transaction UIs using React and the Solana Wallet Adapter.",
+      "difficulty": "intermediate",
+      "duration": 10,
+      "learningPath": "Frontend",
+      "slug": "solana-frontend",
+      "tags": [
+        "account-model",
+        "borsh-serialization",
+        "react",
+        "rpc",
+        "siws",
+        "transactions",
+        "typescript",
+        "wallet-adapter",
+        "web3-frontend"
+      ],
+      "thumbnail": null,
+      "title": "Solana Frontend Development",
+      "totalLessons": 12,
+      "trackId": 4,
+      "trackLevel": 1,
+      "xpReward": 700
+    },
+    {
+      "_id": "course-solana-fundamentals",
+      "creator": "B7o8NfV81HzjuZFWQTTx3Xdvh77Dqoajwib3kWEnvzJF",
+      "description": "A comprehensive beginner course covering the fundamentals of Solana blockchain development. Learn to set up your environment, create wallets, send transactions, and work with SPL tokens. Perfect for developers new to Solana who want to start building decentralized applications.",
+      "difficulty": "beginner",
+      "duration": 10,
+      "learningPath": "Solana Core",
+      "slug": "solana-fundamentals",
+      "tags": [
+        "account-model",
+        "keypairs-wallets",
+        "solana-fundamentals",
+        "solana-programs",
+        "spl-tokens",
+        "transactions"
+      ],
+      "thumbnail": null,
+      "title": "Solana Fundamentals",
+      "totalLessons": 12,
+      "trackId": 1,
+      "trackLevel": 1,
+      "xpReward": 600
     }
   ]
 }

--- a/apps/web/src/lib/content/__tests__/fixtures/golden/courses.json
+++ b/apps/web/src/lib/content/__tests__/fixtures/golden/courses.json
@@ -108,7 +108,7 @@
     "_id": "course-building-first-program",
     "title": "Building Your First Solana Program",
     "slug": "building-your-first-solana-program",
-    "description": "You arrive holding `vault_core.rs` — a `VaultState` and checked `deposit`/`withdraw` that compile, with no `#[program]` and no `#[derive(Accounts)]`. This course adds exactly that. You wrap your own Rust core in Anchor 1.x, create a per-user vault PDA with the space arithmetic derived rather than copied, and move real lamports: deposit through a System Program CPI, withdraw by debiting the program-owned vault directly above an enforced rent floor — and you learn why signer seeds are not the answer there. Then you write the account constraints that stop three named attacks, read the LiteSVM test that would catch what compiling cannot, deploy from a browser tab, publish the IDL on-chain, and call your own live program. Nothing is installed locally. You finish with a devnet program id, a fetchable IDL, and a build write-up.",
+    "description": "Take your Anchor knowledge from theory to practice. Write, compile, and deploy real Solana programs using the Superteam Academy Build Server — no local toolchain setup required. By the end, you'll have a working counter program deployed to Devnet.",
     "difficulty": "intermediate",
     "duration": 12,
     "thumbnail": null,
@@ -116,68 +116,61 @@
     "tags": [
       "account-model",
       "anchor",
-      "checked-arithmetic",
-      "cpi",
-      "debugging",
-      "idl",
       "keypairs-wallets",
-      "pdas",
-      "program-build",
       "program-deployment",
-      "program-errors",
-      "program-security",
-      "program-testing",
-      "rent-and-space",
-      "solana-explorer",
       "solana-programs",
-      "technical-writing",
       "transactions"
     ],
     "xpReward": 850,
     "trackId": 1,
-    "trackLevel": 3,
+    "trackLevel": 2,
     "modules": [
       {
         "key": "bfsp-build-pipeline",
         "title": "The Build Pipeline",
-        "description": "Wrap your own C2 vault core in Anchor, name the four parts of every Anchor program, and extend it yourself — a green build from a browser tab.",
+        "description": "Understand how Solana programs get compiled and get your first successful build through the Superteam Academy Build Server.",
         "lessons": [
           {
+            "_id": "lesson-bfsp-from-code-to-chain",
+            "title": "From Code to Chain",
+            "slug": "from-code-to-chain"
+          },
+          {
             "_id": "lesson-bfsp-your-first-build",
-            "title": "From Rust Core to Anchor",
-            "slug": "from-rust-core-to-anchor"
+            "title": "Your First Build",
+            "slug": "your-first-build"
+          },
+          {
+            "_id": "lesson-bfsp-anatomy-anchor-program",
+            "title": "Anatomy of an Anchor Program",
+            "slug": "anatomy-anchor-program"
           },
           {
             "_id": "lesson-bfsp-add-instruction",
-            "title": "Anatomy of an Anchor Program",
-            "slug": "anatomy-of-an-anchor-program"
-          },
-          {
-            "_id": "lesson-bfsp-adding-instructions",
             "title": "Add an Instruction",
-            "slug": "add-an-instruction"
+            "slug": "add-instruction"
           }
         ]
       },
       {
-        "key": "bfsp-state-vault-pda",
-        "title": "State and the Vault PDA",
-        "description": "Derive the byte size of the vault account, derive its address from seeds, store the canonical bump, and wire up initialize by reading a real compile error.",
+        "key": "bfsp-state-accounts",
+        "title": "State & Accounts",
+        "description": "Define on-chain state with account structs, learn account constraints, and debug compiler errors.",
         "lessons": [
           {
             "_id": "lesson-bfsp-on-chain-state",
-            "title": "Accounts Are Just Bytes",
-            "slug": "accounts-are-just-bytes"
-          },
-          {
-            "_id": "lesson-bfsp-pdas-vault",
-            "title": "PDAs: An Address With No Key",
-            "slug": "pdas-an-address-with-no-key"
+            "title": "On-Chain State",
+            "slug": "on-chain-state"
           },
           {
             "_id": "lesson-bfsp-define-counter",
-            "title": "Define the Vault Account",
-            "slug": "define-the-vault-account"
+            "title": "Define a Counter Account",
+            "slug": "define-counter-account"
+          },
+          {
+            "_id": "lesson-bfsp-account-constraints",
+            "title": "Account Constraints Deep Dive",
+            "slug": "account-constraints-deep-dive"
           },
           {
             "_id": "lesson-bfsp-wire-up-initialize",
@@ -187,55 +180,55 @@
         ]
       },
       {
-        "key": "bfsp-deposit-withdraw-harden",
-        "title": "Deposit, Withdraw, Harden",
-        "description": "Move real lamports — deposit through a System Program CPI, withdraw by debiting the program-owned vault directly above a rent floor — find out why the PDA does not sign its own withdrawal, surface your checked arithmetic as typed Anchor errors, and write the constraints that stop the obvious attacks.",
+        "key": "bfsp-full-counter",
+        "title": "The Full Counter",
+        "description": "Build the complete counter program with multiple instructions, error handling, and deploy it to Devnet.",
         "lessons": [
           {
-            "_id": "lesson-bfsp-cpi-lamports",
-            "title": "CPI: Moving Real Lamports",
-            "slug": "cpi-moving-real-lamports"
+            "_id": "lesson-bfsp-adding-instructions",
+            "title": "Adding Instructions",
+            "slug": "adding-instructions"
           },
           {
             "_id": "lesson-bfsp-build-increment",
-            "title": "Write the Deposit",
-            "slug": "write-the-deposit"
+            "title": "Build the Increment",
+            "slug": "build-increment"
           },
           {
             "_id": "lesson-bfsp-complete-counter",
-            "title": "Withdraw With a PDA Signer",
-            "slug": "withdraw-with-a-pda-signer"
+            "title": "Complete Counter Program",
+            "slug": "complete-counter-program"
           },
           {
-            "_id": "lesson-bfsp-account-constraints",
-            "title": "Harden the Vault",
-            "slug": "harden-the-vault"
+            "_id": "lesson-bfsp-deploy-to-devnet",
+            "title": "Deploy to Devnet",
+            "slug": "deploy-to-devnet"
           }
         ]
       },
       {
-        "key": "bfsp-ship-it",
-        "title": "Ship It",
-        "description": "Prove the program behaves before you spend devnet SOL, fund the deploy wallet, deploy from the browser, publish the IDL on-chain, and write up what you built.",
+        "key": "bfsp-deploy-interact",
+        "title": "Deploy & Interact",
+        "description": "Deploy your counter program to Solana Devnet and interact with it on-chain. Fund your wallet, deploy your binary, and call your program's instructions.",
         "lessons": [
           {
-            "_id": "lesson-bfsp-pre-flight-check",
-            "title": "Pre-Flight Check",
-            "slug": "pre-flight-check"
-          },
-          {
             "_id": "lesson-bfsp-m4-airdrop",
-            "title": "Fund Your Wallet",
-            "slug": "fund-your-wallet"
+            "title": "Airdrop & Fund Your Wallet",
+            "slug": "airdrop-fund-wallet"
           },
           {
             "_id": "lesson-bfsp-m4-deploy",
-            "title": "Deploy and Publish the IDL",
-            "slug": "deploy-and-publish-the-idl"
+            "title": "Deploy Your Program to Devnet",
+            "slug": "deploy-program-devnet"
+          },
+          {
+            "_id": "lesson-bfsp-m4-interact",
+            "title": "Interact with Your Program",
+            "slug": "interact-with-program"
           },
           {
             "_id": "lesson-bfsp-m4-capstone",
-            "title": "What You've Built — and Writing It Up",
+            "title": "What You've Built",
             "slug": "what-you-built"
           }
         ]

--- a/apps/web/src/lib/content/__tests__/fixtures/golden/lessons.json
+++ b/apps/web/src/lib/content/__tests__/fixtures/golden/lessons.json
@@ -707,15 +707,15 @@
   },
   {
     "_id": "lesson-bfsp-account-constraints",
-    "title": "Harden the Vault",
-    "slug": "harden-the-vault",
+    "title": "Account Constraints Deep Dive",
+    "slug": "account-constraints-deep-dive",
     "blocks": [
       {
         "key": "intro",
         "_type": "prose",
         "produces": null,
         "consumes": null,
-        "src": "# Harden the Vault\n\n> **Version stamp — checked 2026-07-26.** `anchor-lang 1.1.2` and `anchor-lang-error 1.1.2` (published 2026-06-26) · `cargo-build-sbf` with platform-tools v1.54 (rustc 1.89) · edition 2021. Every error code and message below was read out of `anchor-lang-error 1.1.2`'s enum; every compiler and macro error was produced by compiling this lesson's file. Every line of example code here is ours.\n\nYour vault works. Now assume the caller is hostile.\n\nEvery account your instruction touches arrived in the transaction because somebody put it there, and that somebody is not always you. `Deposit` and `Withdraw` are safe not because you wrote careful handler bodies but because of four or five words inside `#[account(...)]`. This lesson is about what those words do, which attack each one stops, and the one thing Anchor 1.0 changed underneath them.\n\n## Constraints run before your code does\n\n`#[derive(Accounts)]` is not documentation. It expands into a function that runs before your handler body and returns `Err` if anything fails to check out. By the time your first statement executes, every constraint has passed.\n\nThat is why validation belongs in the attribute rather than the body: an attribute cannot be forgotten halfway down a function, and it applies on every code path including the ones you did not think about.\n\n## The constraints you have used, and what each one refuses\n\n**`init, payer = user, space = N`** — allocates the account, moves the rent-exempt deposit from the payer, assigns the account to your program, and writes the 8-byte discriminator. Used exactly once per account, in `initialize_vault`.\n\n**`mut`** — required of any account whose data or lamports change. Anchor checks it at runtime and returns error **2000, \"A mut constraint was violated\"** if the account was not marked writable in the transaction. Note that this is a runtime failure, not a compile error: a struct missing `mut` compiles perfectly and fails on the first real call.\n\n**`Signer<'info>`** — the account signed the transaction. It says nothing about mutability, which is why a payer needs both `Signer` and `#[account(mut)]`.\n\n**`seeds = [...]` + `bump`** — re-derives the address and compares it to the account passed in. Mismatch is error **2006, \"A seeds constraint was violated\"**. This is the single most load-bearing constraint in your program, and the next section is about why.\n\n**`Account<'info, T>`** — not a constraint but a type, and it validates three things on deserialisation: the account is owned by your program (**3007**), the first eight bytes match `T`'s discriminator (**3002, \"Account discriminator did not match what was expected\"**), and the account has actually been initialised (**3012**). Compare with `UncheckedAccount<'info>`, which validates *nothing*. Convention — and the Anchor CLI — asks you to write a `/// CHECK:` comment above one, documenting why skipping validation is safe here. Be precise about who enforces that: it is a **lint in the Anchor CLI's IDL build**, not a `cargo-build-sbf` error. Our build server shells `cargo-build-sbf` and nothing else, so on this platform the missing comment builds green. Write it anyway — the reviewer who reads your program is the one enforcing it, and on a real Anchor project `anchor build` will stop you.\n\n**`has_one = field`** — checks `account.field == field_account.key()`, where `field` must be both a field on the stored struct and an account in the same struct. Failure is error **2001**. Precision worth having: `has_one = owner` only works if there is an account *named* `owner` in the accounts struct. Ours is named `user`, so `Withdraw` uses the explicit form instead:\n\n```rust\nconstraint = vault.owner == user.key() @ VaultError::NotOwner\n```\n\nSame check, one extra line, and it returns your own error instead of Anchor's generic one — which is what finally spends the `owner` field and the `NotOwner` variant you have been carrying since Course 2.\n\n## Three attacks, and the words that stop them\n\n### Attack 1 — someone else's vault\n\nThe caller signs as themselves and passes *your* vault as the `vault` account. Nothing in the handler body would notice: it is a well-formed `VaultState` owned by the right program.\n\n`seeds = [b\"vault\", user.key().as_ref()]` + `bump = vault.bump` stops it. The address is recomputed from the signer's key, so the only account that can satisfy the constraint is that signer's own vault. `constraint = vault.owner == user.key()` is a second, independent check on the same question — belt and braces, because the two would only disagree if something else had already gone badly wrong, and finding out cheaply is worth one comparison.\n\n### Attack 2 — an account that is not a vault\n\nThe caller passes an account of a different type, or one that has never been initialised, hoping your program interprets whatever bytes are there as `owner`, `balance` and `bump`.\n\n`Account<'info, VaultState>` stops it, in the type system rather than in your logic. The 8-byte discriminator that `#[account]` writes at creation is checked on every deserialisation, so an account of the wrong type fails with 3002 and an empty one with 3012. Reach for `UncheckedAccount` instead and you have opted out of all three checks — which is occasionally right, and is why the `/// CHECK:` comment exists to make you say so out loud.\n\n### Attack 3 — the same account passed twice\n\nThis is the interesting one, and the one Anchor 1.0 changed.\n\nSuppose an instruction moves balance from one vault to another and takes both as mutable accounts. Now suppose the caller passes the *same* account as both. Your handler does:\n\n```rust\nctx.accounts.from_vault.withdraw(amount)?;\nctx.accounts.to_vault.deposit(amount)?;\n```\n\nAnchor deserialised the account twice, into two independent copies. The first line subtracts from copy A. The second line adds to copy B — which never saw the subtraction. At the end of the instruction both copies are serialised back to the same account, and whichever writes last wins. The caller has minted `amount` out of nothing, and every individual line of your code was correct.\n\n**In Anchor 1.0 this is refused by default.** Two mutable accounts resolving to the same key produce error **2040, \"A duplicate mutable account constraint was violated\"** before your handler runs. If you genuinely want aliasing — and there are instructions where it is harmless — you opt in per account:\n\n```rust\n#[account(mut, dup)]\n```\n\nTwo cautions.\n\nThe syntax is `dup`. You will find `#[account(mut, unsafe(dup))]` written down; that is the v2 alpha (the `no_std` Pinocchio line), and on the toolchain that grades you it fails at macro-parse time with `error: expected =`. Verified.\n\nAnd the default is protection, not a suggestion. Adding `dup` because an error appeared is how you reintroduce the bug the error was reporting. The right question is never \"how do I silence 2040\" but \"is aliasing safe in this specific instruction\" — and for anything that moves value between two accounts, the answer is no.\n\n## The wider list\n\nAliasing, missing signer checks, missing owner checks, type confusion, arithmetic overflow, unchecked account closing, PDA seed collisions: these are *classes*, and the classes are stable even as the framework changes. Helius maintains a good public write-up of nineteen of them, and it makes a fine review checklist to read against your own program. Read it as a list of questions to ask, not as code to copy — the widely-circulated example repositories for these attacks ship with no licence at all, so every line of example code in this course is written by us.\n\n## The exercise\n\nIndependent write. You get the signature of a new instruction and a written spec — no more. The three instructions you already wrote are still in the file above it, and `Withdraw`'s constraint block in particular is close to what `from_vault` needs; reading your own earlier work and adapting it is the intended move, not cheating. What no one gives you is which constraints this instruction needs, in what combination, and what `to_vault` must derive from.\n\nBe clear-eyed about what the grading can see. The verification harness pins the field names and types, so **attack (b) is genuinely compile-enforced**: get `Account<'info, VaultState>` wrong and the build fails. The seeds, the ownership constraint and the `dup` decision are runtime behaviour, and a compile-only grader is blind to all three. Module 4 shows you the LiteSVM test that would exercise them, and why compiling cannot — read it before you spend a lamport of devnet SOL.\n",
+        "src": "# Account Constraints Deep Dive\n\nAnchor's account constraints are the guard rails of Solana development. They validate accounts before your instruction logic runs, preventing entire classes of bugs.\n\n## Essential Constraints\n\n### `#[account(init, payer = X, space = N)]`\nCreates a new account. The `payer` funds the rent-exempt deposit. `space` sets the data size in bytes. Can only be used once per account.\n\n### `#[account(mut)]`\nMarks an account as mutable. Required for any account whose data or lamport balance changes. Forgetting `mut` gives you:\n```\nerror: A mut constraint was expected but not found.\n```\n\n### `Signer<'info>`\nThe account must have signed the transaction. Used for authorization — proving the caller owns the account. Signers automatically have their signature verified by the runtime.\n\n### `Program<'info, System>`\nReferences a program account. `System` is the System Program (`11111111...`), which handles account creation and SOL transfers.\n\n## Account Types\n\n| Type | Use Case | Mutable Data? |\n|------|----------|---------------|\n| `Account<'info, T>` | Typed data account | Yes |\n| `Signer<'info>` | Must have signed tx | No data |\n| `SystemAccount<'info>` | Any system-owned account | No |\n| `Program<'info, T>` | A program account | No |\n| `UncheckedAccount<'info>` | No validation (dangerous) | Depends |\n\n## Common Errors\n\n### Missing `system_program`\nIf your instruction creates an account (`init`), you **must** include the System Program:\n```rust\npub system_program: Program<'info, System>,\n```\nWithout it, the compiler error is:\n```\nerror[E0277]: the trait bound `Initialize<'_>: anchor_lang::Accounts<'_>` is not satisfied\n```\n\nThis error is cryptic because Anchor generates the account validation code via macros. The fix is always: add the missing account.\n\n### Missing `mut` on payer\nThe payer's balance decreases (pays rent), so it must be `#[account(mut)]`:\n```rust\n#[account(mut)]\npub user: Signer<'info>,\n```\n\n### Wrong `space` calculation\nIf `space` is too small, the account can't hold your data. If too large, the payer overpays for rent. Always calculate: `8 (discriminator) + field sizes`.\n\n## In the Next Challenge\n\nYou'll encounter a deliberate compiler error — a program with a missing account. Your job is to read the error output and fix it.\n",
         "url": null,
         "language": null,
         "buildType": null,
@@ -724,38 +724,6 @@
         "solution": null,
         "tests": null,
         "hints": null,
-        "questions": null,
-        "prompt": null,
-        "maxWords": null,
-        "amount": null,
-        "network": null,
-        "idl": null
-      },
-      {
-        "key": "exercise",
-        "_type": "code",
-        "produces": null,
-        "consumes": null,
-        "src": null,
-        "url": null,
-        "language": "rust",
-        "buildType": "buildable",
-        "deployable": false,
-        "starter": "// Independent write. Add ONE instruction and its accounts struct.\n//\n// SIGNATURES\n//\n//   pub fn transfer_between_vaults(\n//       ctx: Context<TransferBetweenVaults>,\n//       amount: u64,\n//   ) -> Result<()>\n//\n//   #[derive(Accounts)]\n//   pub struct TransferBetweenVaults<'info> {\n//       from_vault, to_vault, user, recipient      // in this order\n//   }\n//\n// WHAT IT DOES\n//\n//   Moves `amount` of recorded balance out of the signer's vault and into the\n//   vault belonging to `recipient`. Bookkeeping only — no lamports move, so\n//   there is no CPI and no `system_program`.\n//\n// ACCEPTANCE CRITERIA — criteria 3 and 4 name types, and types are the part the\n// harness at the bottom can check. The rest is on you; see the note below it.\n//\n//   1. `from_vault` is `Account<'info, VaultState>`, mutable, re-derived from\n//      the SIGNER's key using the bump stored on it, and constrained so the\n//      signer is its recorded owner. Return `VaultError::NotOwner` if not.\n//   2. `to_vault` is `Account<'info, VaultState>`, mutable, re-derived from\n//      `recipient`'s key using the bump stored on it.\n//   3. `user` is `Signer<'info>`.\n//   4. `recipient` is `UncheckedAccount<'info>`. It is read only as a seed and\n//      is never trusted for anything else. Put a `/// CHECK:` line above it\n//      saying exactly that. (The `/// CHECK:` requirement is an Anchor CLI\n//      lint, not a `cargo-build-sbf` error — this build will go green without\n//      it. Write it because the next human to read the program needs it.)\n//   5. The body is two calls into your Course 2 methods, in the order that\n//      makes an under-funded transfer fail before anything is credited.\n//   6. Decide, and be able to say why: does any account here need\n//      `#[account(mut, dup)]`? Work out what happens when `recipient` IS the\n//      signer, which error the runtime already returns for that, and whether\n//      `dup` would help you or disarm you. The harness is silent on this one\n//      either way — both choices compile.\n//\n// THREE ATTACKS THIS MUST STOP\n//\n//   (a) a caller passing somebody else's vault as `from_vault`\n//   (b) a caller passing an uninitialised account, or an account of another\n//       type, in either vault slot\n//   (c) a caller passing the same account as both vaults\n//\n// Only (b) is visible to a compiler — and only the *type* half of it. So is\n// criterion 4's `/// CHECK:` line: invisible. The build server compiles; it\n// does not run. Module 4 shows you the LiteSVM test that would exercise all\n// three attacks, and why compiling cannot.\n//\n// This file does NOT compile as shipped.\n\nuse anchor_lang::prelude::*;\nuse anchor_lang::system_program::{transfer, Transfer};\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n// ─── Your Course 2 core, imported unchanged. Do not edit it. ─────────────────\npub mod vault {\n    use super::*;\n\n    #[account]\n    #[derive(InitSpace)]\n    pub struct VaultState {\n        pub owner: Pubkey,\n        pub balance: u64,\n        pub bump: u8,\n    }\n\n    #[error_code]\n    pub enum VaultError {\n        #[msg(\"Deposit would overflow the vault balance\")]\n        Overflow,\n        #[msg(\"Withdrawal is larger than the vault balance\")]\n        InsufficientFunds,\n        #[msg(\"Amount must be greater than zero\")]\n        ZeroAmount,\n        #[msg(\"Signer is not the vault owner\")]\n        NotOwner,\n    }\n\n    impl VaultState {\n        pub fn deposit(&mut self, amount: u64) -> Result<()> {\n            require!(amount > 0, VaultError::ZeroAmount);\n            self.balance = self\n                .balance\n                .checked_add(amount)\n                .ok_or(VaultError::Overflow)?;\n            Ok(())\n        }\n\n        pub fn withdraw(&mut self, amount: u64) -> Result<()> {\n            require!(amount > 0, VaultError::ZeroAmount);\n            self.balance = self\n                .balance\n                .checked_sub(amount)\n                .ok_or(VaultError::InsufficientFunds)?;\n            Ok(())\n        }\n    }\n}\n\npub use vault::{VaultError, VaultState};\n\n#[program]\npub mod vault_program {\n    use super::*;\n\n    pub fn initialize_vault(ctx: Context<InitializeVault>) -> Result<()> {\n        let vault = &mut ctx.accounts.vault;\n        vault.owner = ctx.accounts.user.key();\n        vault.balance = 0;\n        vault.bump = ctx.bumps.vault;\n        Ok(())\n    }\n\n    pub fn deposit(ctx: Context<Deposit>, amount: u64) -> Result<()> {\n        transfer(\n            CpiContext::new(\n                System::id(),\n                Transfer {\n                    from: ctx.accounts.user.to_account_info(),\n                    to: ctx.accounts.vault.to_account_info(),\n                },\n            ),\n            amount,\n        )?;\n        ctx.accounts.vault.deposit(amount)?;\n        Ok(())\n    }\n\n    pub fn withdraw(ctx: Context<Withdraw>, amount: u64) -> Result<()> {\n        let vault_info = ctx.accounts.vault.to_account_info();\n        let user_info = ctx.accounts.user.to_account_info();\n\n        // Finished in the previous lesson. Bookkeeping via the Course 2 method,\n        // then a rent-floor check, then a direct debit — no CPI, because a\n        // program may move the lamports of an account it owns.\n        ctx.accounts.vault.withdraw(amount)?;\n\n        let rent_floor = Rent::get()?.minimum_balance(vault_info.data_len());\n        let remaining = vault_info\n            .lamports()\n            .checked_sub(amount)\n            .ok_or(VaultError::InsufficientFunds)?;\n        require!(remaining >= rent_floor, VaultError::InsufficientFunds);\n\n        let credited = user_info\n            .lamports()\n            .checked_add(amount)\n            .ok_or(VaultError::Overflow)?;\n        **vault_info.try_borrow_mut_lamports()? = remaining;\n        **user_info.try_borrow_mut_lamports()? = credited;\n\n        Ok(())\n    }\n\n    // YOUR INSTRUCTION GOES HERE. See ACCEPTANCE CRITERIA 5 at the top.\n}\n\n#[derive(Accounts)]\npub struct InitializeVault<'info> {\n    #[account(\n        init,\n        payer = user,\n        space = 8 + 32 + 8 + 1,\n        seeds = [b\"vault\", user.key().as_ref()],\n        bump\n    )]\n    pub vault: Account<'info, VaultState>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n    pub system_program: Program<'info, System>,\n}\n\n#[derive(Accounts)]\npub struct Deposit<'info> {\n    #[account(\n        mut,\n        seeds = [b\"vault\", user.key().as_ref()],\n        bump = vault.bump\n    )]\n    pub vault: Account<'info, VaultState>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n    pub system_program: Program<'info, System>,\n}\n\n// Finished in the previous lesson. No `system_program`: no CPI is made here.\n#[derive(Accounts)]\npub struct Withdraw<'info> {\n    #[account(\n        mut,\n        seeds = [b\"vault\", user.key().as_ref()],\n        bump = vault.bump,\n        constraint = vault.owner == user.key() @ VaultError::NotOwner\n    )]\n    pub vault: Account<'info, VaultState>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n}\n\n// YOUR STRUCT GOES HERE. Your instruction goes inside `#[program]`, above.\n\n// ─────────────────────────────────────────────────────────────────────────────\n// VERIFICATION HARNESS — DO NOT EDIT ANYTHING BELOW THIS LINE.\n//\n// This is the acceptance criteria in Rust. It compiles only if the instruction\n// and the accounts struct exist with the names, order and types the spec gives.\n// A missing item is `error[E0433]` or `error[E0412]`; a missing field is\n// `error[E0609]`; a wrong type is `error[E0308]`.\n//\n// It is a TYPE check. It proves attack (b) is handled — `Account<'info, VaultState>`\n// carries the owner, discriminator and initialisation checks, and an\n// `UncheckedAccount` in either vault slot fails to compile here. It can see\n// nothing about attacks (a) or (c): seeds, the ownership constraint and the\n// duplicate-mutable-account default are all runtime behaviour. Confirmed ways to\n// be green and still be wrong: no `seeds`/`bump` at all, no owner constraint, a\n// bare `bump` instead of the stored one, `dup` added to silence error 2040, and\n// the two body calls in the wrong order.\n// ─────────────────────────────────────────────────────────────────────────────\n#[doc(hidden)]\n#[allow(dead_code)]\nmod verify {\n    use super::*;\n\n    const TRANSFER_BETWEEN: for<'info> fn(\n        Context<'info, TransferBetweenVaults<'info>>,\n        u64,\n    ) -> Result<()> = vault_program::transfer_between_vaults;\n\n    fn pin_accounts(a: &TransferBetweenVaults) {\n        // Both vault slots are typed accounts, not unchecked ones. This is the\n        // whole of attack (b), enforced by the compiler.\n        let _: &Account<VaultState> = &a.from_vault;\n        let _: &Account<VaultState> = &a.to_vault;\n        let _: &Signer = &a.user;\n        let _: &UncheckedAccount = &a.recipient;\n    }\n\n    // The earlier instructions are untouched and the Course 2 core still owns\n    // the arithmetic.\n    const DEPOSIT: for<'info> fn(Context<'info, Deposit<'info>>, u64) -> Result<()> =\n        vault_program::deposit;\n    const WITHDRAW: for<'info> fn(Context<'info, Withdraw<'info>>, u64) -> Result<()> =\n        vault_program::withdraw;\n    const CORE_DEPOSIT: fn(&mut VaultState, u64) -> Result<()> = VaultState::deposit;\n    const CORE_WITHDRAW: fn(&mut VaultState, u64) -> Result<()> = VaultState::withdraw;\n    const _: () = assert!(VaultState::INIT_SPACE == 41);\n}\n",
-        "solution": "use anchor_lang::prelude::*;\nuse anchor_lang::system_program::{transfer, Transfer};\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n// ─── Your Course 2 core, imported unchanged. Do not edit it. ─────────────────\npub mod vault {\n    use super::*;\n\n    #[account]\n    #[derive(InitSpace)]\n    pub struct VaultState {\n        pub owner: Pubkey,\n        pub balance: u64,\n        pub bump: u8,\n    }\n\n    #[error_code]\n    pub enum VaultError {\n        #[msg(\"Deposit would overflow the vault balance\")]\n        Overflow,\n        #[msg(\"Withdrawal is larger than the vault balance\")]\n        InsufficientFunds,\n        #[msg(\"Amount must be greater than zero\")]\n        ZeroAmount,\n        #[msg(\"Signer is not the vault owner\")]\n        NotOwner,\n    }\n\n    impl VaultState {\n        pub fn deposit(&mut self, amount: u64) -> Result<()> {\n            require!(amount > 0, VaultError::ZeroAmount);\n            self.balance = self\n                .balance\n                .checked_add(amount)\n                .ok_or(VaultError::Overflow)?;\n            Ok(())\n        }\n\n        pub fn withdraw(&mut self, amount: u64) -> Result<()> {\n            require!(amount > 0, VaultError::ZeroAmount);\n            self.balance = self\n                .balance\n                .checked_sub(amount)\n                .ok_or(VaultError::InsufficientFunds)?;\n            Ok(())\n        }\n    }\n}\n\npub use vault::{VaultError, VaultState};\n\n#[program]\npub mod vault_program {\n    use super::*;\n\n    pub fn initialize_vault(ctx: Context<InitializeVault>) -> Result<()> {\n        let vault = &mut ctx.accounts.vault;\n        vault.owner = ctx.accounts.user.key();\n        vault.balance = 0;\n        vault.bump = ctx.bumps.vault;\n        Ok(())\n    }\n\n    pub fn deposit(ctx: Context<Deposit>, amount: u64) -> Result<()> {\n        transfer(\n            CpiContext::new(\n                System::id(),\n                Transfer {\n                    from: ctx.accounts.user.to_account_info(),\n                    to: ctx.accounts.vault.to_account_info(),\n                },\n            ),\n            amount,\n        )?;\n        ctx.accounts.vault.deposit(amount)?;\n        Ok(())\n    }\n\n    pub fn withdraw(ctx: Context<Withdraw>, amount: u64) -> Result<()> {\n        let vault_info = ctx.accounts.vault.to_account_info();\n        let user_info = ctx.accounts.user.to_account_info();\n\n        // Finished in the previous lesson. Bookkeeping via the Course 2 method,\n        // then a rent-floor check, then a direct debit — no CPI, because a\n        // program may move the lamports of an account it owns.\n        ctx.accounts.vault.withdraw(amount)?;\n\n        let rent_floor = Rent::get()?.minimum_balance(vault_info.data_len());\n        let remaining = vault_info\n            .lamports()\n            .checked_sub(amount)\n            .ok_or(VaultError::InsufficientFunds)?;\n        require!(remaining >= rent_floor, VaultError::InsufficientFunds);\n\n        let credited = user_info\n            .lamports()\n            .checked_add(amount)\n            .ok_or(VaultError::Overflow)?;\n        **vault_info.try_borrow_mut_lamports()? = remaining;\n        **user_info.try_borrow_mut_lamports()? = credited;\n\n        Ok(())\n    }\n\n    pub fn transfer_between_vaults(\n        ctx: Context<TransferBetweenVaults>,\n        amount: u64,\n    ) -> Result<()> {\n        // Debit first. If the signer's vault cannot cover `amount`, the Course 2\n        // method returns `InsufficientFunds` and nothing is credited.\n        ctx.accounts.from_vault.withdraw(amount)?;\n        ctx.accounts.to_vault.deposit(amount)?;\n        Ok(())\n    }\n}\n\n#[derive(Accounts)]\npub struct InitializeVault<'info> {\n    #[account(\n        init,\n        payer = user,\n        space = 8 + 32 + 8 + 1,\n        seeds = [b\"vault\", user.key().as_ref()],\n        bump\n    )]\n    pub vault: Account<'info, VaultState>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n    pub system_program: Program<'info, System>,\n}\n\n#[derive(Accounts)]\npub struct Deposit<'info> {\n    #[account(\n        mut,\n        seeds = [b\"vault\", user.key().as_ref()],\n        bump = vault.bump\n    )]\n    pub vault: Account<'info, VaultState>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n    pub system_program: Program<'info, System>,\n}\n\n// Finished in the previous lesson. No `system_program`: no CPI is made here.\n#[derive(Accounts)]\npub struct Withdraw<'info> {\n    #[account(\n        mut,\n        seeds = [b\"vault\", user.key().as_ref()],\n        bump = vault.bump,\n        constraint = vault.owner == user.key() @ VaultError::NotOwner\n    )]\n    pub vault: Account<'info, VaultState>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n}\n\n// Attack (a): `seeds` re-derives the address from the SIGNER's key, so the only\n// account that can satisfy it is the signer's own vault, and the explicit\n// `constraint` re-asks the same question against the stored `owner` field —\n// returning our error rather than Anchor's generic 2001/2006.\n//\n// Attack (b): `Account<'info, VaultState>` checks program ownership, the 8-byte\n// discriminator and initialisation on every deserialisation.\n//\n// Attack (c): no `dup`. Both vaults are mutable, so if `recipient` is the signer\n// the two slots resolve to one key and Anchor 1.0 refuses the instruction with\n// error 2040 before the body runs. Adding `dup` here would re-open exactly the\n// double-count bug 2040 is reporting: two copies of one account, one\n// subtraction, one addition, last write wins.\n#[derive(Accounts)]\npub struct TransferBetweenVaults<'info> {\n    #[account(\n        mut,\n        seeds = [b\"vault\", user.key().as_ref()],\n        bump = from_vault.bump,\n        constraint = from_vault.owner == user.key() @ VaultError::NotOwner\n    )]\n    pub from_vault: Account<'info, VaultState>,\n\n    #[account(\n        mut,\n        seeds = [b\"vault\", recipient.key().as_ref()],\n        bump = to_vault.bump\n    )]\n    pub to_vault: Account<'info, VaultState>,\n\n    pub user: Signer<'info>,\n\n    /// CHECK: read only as a PDA seed. Never written, never deserialised, and\n    /// never trusted for authorisation — `user` is the only signer here.\n    pub recipient: UncheckedAccount<'info>,\n}\n\n// ─────────────────────────────────────────────────────────────────────────────\n// VERIFICATION HARNESS — DO NOT EDIT ANYTHING BELOW THIS LINE.\n//\n// This is the acceptance criteria in Rust. It compiles only if the instruction\n// and the accounts struct exist with the names, order and types the spec gives.\n// A missing item is `error[E0433]` or `error[E0412]`; a missing field is\n// `error[E0609]`; a wrong type is `error[E0308]`.\n//\n// It is a TYPE check. It proves attack (b) is handled — `Account<'info, VaultState>`\n// carries the owner, discriminator and initialisation checks, and an\n// `UncheckedAccount` in either vault slot fails to compile here. It can see\n// nothing about attacks (a) or (c): seeds, the ownership constraint and the\n// duplicate-mutable-account default are all runtime behaviour. Confirmed ways to\n// be green and still be wrong: no `seeds`/`bump` at all, no owner constraint, a\n// bare `bump` instead of the stored one, `dup` added to silence error 2040, and\n// the two body calls in the wrong order.\n// ─────────────────────────────────────────────────────────────────────────────\n#[doc(hidden)]\n#[allow(dead_code)]\nmod verify {\n    use super::*;\n\n    const TRANSFER_BETWEEN: for<'info> fn(\n        Context<'info, TransferBetweenVaults<'info>>,\n        u64,\n    ) -> Result<()> = vault_program::transfer_between_vaults;\n\n    fn pin_accounts(a: &TransferBetweenVaults) {\n        // Both vault slots are typed accounts, not unchecked ones. This is the\n        // whole of attack (b), enforced by the compiler.\n        let _: &Account<VaultState> = &a.from_vault;\n        let _: &Account<VaultState> = &a.to_vault;\n        let _: &Signer = &a.user;\n        let _: &UncheckedAccount = &a.recipient;\n    }\n\n    // The earlier instructions are untouched and the Course 2 core still owns\n    // the arithmetic.\n    const DEPOSIT: for<'info> fn(Context<'info, Deposit<'info>>, u64) -> Result<()> =\n        vault_program::deposit;\n    const WITHDRAW: for<'info> fn(Context<'info, Withdraw<'info>>, u64) -> Result<()> =\n        vault_program::withdraw;\n    const CORE_DEPOSIT: fn(&mut VaultState, u64) -> Result<()> = VaultState::deposit;\n    const CORE_WITHDRAW: fn(&mut VaultState, u64) -> Result<()> = VaultState::withdraw;\n    const _: () = assert!(VaultState::INIT_SPACE == 41);\n}\n",
-        "tests": [
-          {
-            "id": "compiles",
-            "description": "The program compiles against the Anchor 1.x toolchain, with the verification harness intact",
-            "input": "",
-            "expectedOutput": "true"
-          }
-        ],
-        "hints": [
-          "The harness at the bottom is the acceptance criteria, written in Rust. Read it before you type: it names every field, its type and its position, and it is the only part of the spec the build server can check. The first build reports `error[E0412]: cannot find type TransferBetweenVaults` and `error[E0425]: cannot find value transfer_between_vaults` — nothing exists yet.",
-          "Work threat by threat rather than field by field. Attack (a) is answered by re-deriving `from_vault` from the SIGNER's key and asking a second time against the stored `owner` — `constraint = from_vault.owner == user.key() @ VaultError::NotOwner`, because `has_one = owner` would need an account literally named `owner`. Attack (b) is answered by the field types alone. Attack (c) needs you to add nothing at all.",
-          "If you have reached for `dup`, stop and reason about what error 2040 is telling you. Both vaults are `mut`, so when `recipient` is the signer the two slots are one account, Anchor refuses the instruction, and that refusal is correct: two deserialised copies, one subtraction, one addition, last write wins, and the caller has minted lamports. `dup` is for aliasing you have proven harmless; this is not that."
-        ],
         "questions": null,
         "prompt": null,
         "maxWords": null,
@@ -780,99 +748,55 @@
         "questions": [
           {
             "id": "q1",
-            "prompt": "An instruction takes two vaults, both `#[account(mut)]`, and a caller passes the same account for both. Predict the outcome under `anchor-lang` 1.1.2, and what the outcome would have been before Anchor 1.0 refused it.",
+            "prompt": "You mark the payer account as `Signer<'info>` but forget `#[account(mut)]`. The instruction uses `init` to create a new account funded by that payer. What happens?",
             "multiSelect": false,
             "options": [
               {
                 "id": "a",
-                "label": "Anchor returns error 2040, \"A duplicate mutable account constraint was violated\", before the handler runs. Without that default, the two deserialised copies would each miss the other's write and the caller would mint `amount` from nothing.",
+                "label": "Compile error — the payer's lamports decrease to fund the rent, so it must be declared mutable",
                 "correct": true,
                 "feedback": null
               },
               {
                 "id": "b",
-                "label": "Both field references point at the same in-memory account, so the subtraction and the addition cancel out and nothing happens.",
+                "label": "It works, because `Signer` already implies mutable",
                 "correct": false,
-                "feedback": "They are not the same in-memory account. Anchor deserialises each declared account independently, so you get two copies of the same bytes — which is precisely how the write of one can erase the write of the other."
+                "feedback": "`Signer` proves the account signed; it says nothing about mutability. A payer's balance drops, so it needs `#[account(mut)]` on top."
               },
               {
                 "id": "c",
-                "label": "It is a compile error, because two fields of the same type cannot both be `mut`.",
+                "label": "It works, but the rent is silently paid by the program",
                 "correct": false,
-                "feedback": "Two mutable accounts of the same type is an ordinary, useful shape — any transfer instruction has it. The check is on the runtime *keys* being equal, which the compiler cannot know."
-              },
-              {
-                "id": "d",
-                "label": "The transaction is rejected by the runtime before it reaches your program, because a transaction may not list an account twice.",
-                "correct": false,
-                "feedback": "Transactions deduplicate account keys and pass the same index twice quite legally. The protection is Anchor's, in generated validation code, not the runtime's."
+                "feedback": "Programs do not pay rent for you. The declared payer's lamports fund it, which is exactly why the payer must be `mut`."
               }
             ],
-            "explanation": "Duplicate mutable accounts were a silent double-count for years and are now a default error, 2040. Opting back in is `#[account(mut, dup)]` — and note the syntax: `#[account(mut, unsafe(dup))]` belongs to the v2 alpha and fails at macro-parse time here with `error: expected =`. The decision is never \"how do I silence 2040\" but \"is aliasing safe in this instruction\", and for anything moving value between two accounts it is not."
+            "explanation": "Constraints validate accounts before your logic runs. `init` with `payer = user` reduces the user's lamports, and any account whose lamports or data change must be `#[account(mut)]` — otherwise Anchor emits 'a mut constraint was expected but not found.'"
           },
           {
             "id": "q2",
-            "prompt": "A submission types both vault slots as `UncheckedAccount<'info>` with `/// CHECK:` comments, keeps every `seeds` and `constraint`, and reads the balances by deserialising manually inside the handler. Predict what protection is lost.",
+            "prompt": "Why does an instruction that uses `#[account(init)]` also require `system_program: Program<'info, System>` in its accounts struct?",
             "multiSelect": false,
             "options": [
               {
                 "id": "a",
-                "label": "The program-ownership check, the 8-byte discriminator check and the is-initialised check — errors 3007, 3002 and 3012 — all of which `Account<'info, T>` performs and `UncheckedAccount` performs none of.",
+                "label": "Creating an account is a CPI to the System Program, so it must be present for Anchor's generated code to make that call",
                 "correct": true,
                 "feedback": null
               },
               {
                 "id": "b",
-                "label": "Nothing, as long as the seeds constraint still passes. The seeds prove the account is the right one.",
+                "label": "It is only needed to transfer SOL, not to create accounts",
                 "correct": false,
-                "feedback": "Seeds prove the *address*. They say nothing about who owns the account at that address, what type its bytes are, or whether it has ever been written to — a PDA that has never been initialised still has the derived address."
+                "feedback": "Account creation itself is a System Program instruction. `init` generates a `create_account` CPI, so the System Program must be in the struct."
               },
               {
                 "id": "c",
-                "label": "Only the `mut` check, since `UncheckedAccount` cannot be marked mutable.",
+                "label": "It documents intent but Anchor injects it automatically",
                 "correct": false,
-                "feedback": "`UncheckedAccount` can carry `mut` perfectly well. What it drops is every check that depends on knowing the account's owner and type."
-              },
-              {
-                "id": "d",
-                "label": "Nothing at compile time, and nothing at runtime either — the `/// CHECK:` comment is what re-enables the validation.",
-                "correct": false,
-                "feedback": "The comment is a required acknowledgement, not a control. It exists to make you state in writing that you are opting out; it restores nothing."
+                "feedback": "Anchor does not inject it — you must declare it. Omitting it produces a cryptic trait-bound error on the accounts struct."
               }
             ],
-            "explanation": "`Account<'info, T>` is doing security work, not ergonomics work. Its deserialisation is where the discriminator that `#[account]` wrote at creation gets compared, and that comparison is the entire defence against type confusion. This is why the exercise's harness pins those two field types: it is the one attack of the three that a compile-only grader can genuinely enforce."
-          },
-          {
-            "id": "q3",
-            "prompt": "`Withdraw` uses `constraint = vault.owner == user.key() @ VaultError::NotOwner` rather than `has_one = owner`. Why can it not use `has_one`?",
-            "multiSelect": false,
-            "options": [
-              {
-                "id": "a",
-                "label": "`has_one = owner` requires an account *named* `owner` in the same accounts struct to compare against. Ours is named `user`, so the explicit comparison is the equivalent — and it returns our error instead of Anchor's 2001.",
-                "correct": true,
-                "feedback": null
-              },
-              {
-                "id": "b",
-                "label": "`has_one` was removed in Anchor 1.0 in favour of explicit constraints.",
-                "correct": false,
-                "feedback": "`has_one` is current and idiomatic. The obstacle here is purely naming: it resolves the target as an account in the struct, and there is no `owner` account in `Withdraw`."
-              },
-              {
-                "id": "c",
-                "label": "`has_one` only works on accounts created with `init` in the same instruction.",
-                "correct": false,
-                "feedback": "It works on any account whose stored struct has the named field. Creation has nothing to do with it."
-              },
-              {
-                "id": "d",
-                "label": "Because `owner` is a reserved field name that Anchor uses for the account's program owner.",
-                "correct": false,
-                "feedback": "`owner` is an ordinary field name on your struct and Anchor is happy with it. The account's program owner lives on the `AccountInfo`, not in your data."
-              }
-            ],
-            "explanation": "`has_one = field` expands to `account.field == field_account.key()`, so the name has to exist twice — once on the stored struct and once as an account in the struct. The explicit `constraint` form is the general case, costs one line, and lets you attach your own error, which is why `VaultError::NotOwner` finally gets used four lessons after you wrote it."
+            "explanation": "New accounts are allocated by the System Program, so `init` expands into a `create_account` CPI that needs the System Program in the accounts struct. Leaving it out fails the `Accounts` trait bound at compile time — the fix is always to add the missing account."
           }
         ],
         "prompt": null,
@@ -885,15 +809,15 @@
   },
   {
     "_id": "lesson-bfsp-add-instruction",
-    "title": "Anatomy of an Anchor Program",
-    "slug": "anatomy-of-an-anchor-program",
+    "title": "Add an Instruction",
+    "slug": "add-instruction",
     "blocks": [
       {
         "key": "intro",
         "_type": "prose",
         "produces": null,
         "consumes": null,
-        "src": "# Anatomy of an Anchor Program\n\n> **Version stamp — checked 2026-07-26.** `anchor-lang 1.1.2` (published 2026-06-26) · `cargo-build-sbf` with platform-tools v1.54 (rustc 1.89) · `borsh` resolves to **1.8.0** · edition 2021. Every compiler message quoted below was produced by compiling this lesson's starter on that toolchain.\n\nThe file you just compiled has four parts. Every Anchor program has the same four, conventionally in the same order, and once you can name them you can read any program on Solana — including the ones you did not write, which is most of the value.\n\nThe starter below is that program stripped to exactly those four parts, each behind a labeled banner. Two of them are complete. Two contain one worked example each, and your job is the second example in both.\n\n## Part 1 — `declare_id!`: the address\n\n```rust\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n```\n\nA program is reached by address, the same way an account is. `declare_id!` bakes that address into the binary and generates a `pub const ID: Pubkey` you can use in code — the starter's `version` handler logs it.\n\nTwo things it is not. It is not a keypair: the program's *upgrade* authority is a separate key, held by whoever deployed. And it is not checked at compile time — put any valid base58 pubkey here and the build is green. The value only starts mattering at deploy, when a mismatch between the declared id and the address being deployed to produces `DeclaredProgramIdMismatch`. In module 4 you will replace this placeholder with an address that is genuinely yours.\n\n## Part 2 — `#[program]`: the instruction handlers\n\n```rust\n#[program]\npub mod vault_program {\n    use super::*;\n\n    pub fn version(_ctx: Context<Version>) -> Result<()> {\n        msg!(\"vault program, id {}\", ID);\n        Ok(())\n    }\n}\n```\n\nThis attribute is what makes the crate a program rather than a library. It expands the module into a program entrypoint plus a dispatcher, and it turns every `pub fn` inside into a callable instruction.\n\nThe dispatch is by **discriminator**: Anchor hashes the handler's name and puts the first 8 bytes at the front of the instruction data, so a caller selects `version` by sending those 8 bytes. Two consequences you should file away. Renaming a handler changes its discriminator, which breaks every client already calling it — a rename is a breaking API change, not a cosmetic one. And the same mechanism is why the four-part order is a convention rather than a requirement: the macros do not care where in the file they appear.\n\nThe signature rules are absolute:\n\n- the first parameter is always `Context<T>`;\n- the return type is always `Result<()>` — Anchor's `Result`, which `use anchor_lang::prelude::*;` brings in;\n- any further parameters are instruction *arguments*, deserialized from the instruction data. `deposit(ctx, amount: u64)` in module 3 is the first one you write.\n\n`msg!` writes to the transaction log, which is what you read in an explorer and what stands in for a debugger on-chain. It costs compute units, so it is a tool for development, not a place to dump state.\n\nOne currency note, because this is where old code bites: in Anchor 1.x the handler return type is `Result<()>`. Material written before 0.24 uses `ProgramResult`, which no longer exists — if you paste a handler signature from an older tutorial you get `cannot find type ProgramResult in this scope`, and that error means *the snippet is old*, not that you mistyped.\n\n## Part 3 — `#[derive(Accounts)]`: the account list\n\n```rust\n#[derive(Accounts)]\npub struct Version {}\n```\n\nSolana programs are stateless. Everything an instruction reads or writes arrives as an account in the transaction, and this struct is where you declare which ones and under what conditions. The derive generates the deserialization and every validation check, and it runs *before* your handler body — by the time you are inside `version`, the account list has already been proved to satisfy whatever the struct demanded.\n\nThe name must match the `Context<T>` generic exactly. That is the only thing tying a handler to its account list, which is why forgetting the struct produces `cannot find type Greet in this scope` rather than anything more helpful.\n\n`Version {}` is empty, and empty is a claim rather than an omission: it says this instruction may touch no accounts at all. Anything not declared here is unreachable from the handler. Module 2 is where these structs get interesting — constraints, PDAs, `init`, signers — and where the vault finally becomes an account instead of a struct.\n\n## Part 4 — `#[account]`: the state\n\n```rust\n#[account]\n#[derive(InitSpace)]\npub struct VaultState {\n    pub owner: Pubkey,\n    pub balance: u64,\n    pub bump: u8,\n}\n```\n\nYour Course 2 struct, unchanged. `#[account]` says \"this type is the contents of an account owned by this program\": it generates the borsh serialization and an 8-byte **discriminator** — a different one from the instruction discriminators, doing the same job one level down. It marks the account's *type*, so a program that is handed the wrong account gets a deserialization failure instead of misreading someone else's bytes.\n\nNote what part 4 does not do. It describes a layout; it does not allocate anything. No account exists because of this struct. Creating one takes an `init` constraint in a part-3 struct, a payer, and rent — module 2, in that order.\n\n### The fifth thing, which is not one of the four\n\nYour Course 2 file also has `#[error_code] pub enum VaultError`. It is not in this starter, because it is not part of the anatomy — but it is worth one line now: **a program should carry exactly one `#[error_code]` enum.** Note \"should\". Anchor does not stop you adding a second, and that is precisely why the habit is worth forming early — every `#[error_code]` enum starts numbering at the same offset, so a second one silently collides with the first instead of failing loudly. You already have yours. When a later lesson needs a new failure mode, it becomes a variant of `VaultError`, not a new enum. The next lesson shows you the collision itself, which is not what most people expect.\n\n## Your job\n\nAdd the second handler and the second account list, copying the pattern that is already in each part:\n\n1. `greet`, inside `#[program]`, taking `_ctx: Context<Greet>`, returning `Result<()>`, logging something.\n2. `Greet`, an empty struct carrying `#[derive(Accounts)]`.\n\nThe starter does not compile as shipped. Build it first and read the four errors. All four come from the verification harness at the bottom of the file, because the harness is the only thing that references what you have not written yet: three of them say `cannot find type Greet` or `cannot find struct … Greet`, and the fourth says `cannot find value greet in module vault_program`. That is the harness working as intended — it is the acceptance criteria written in Rust, and it is the only thing the build server can check.\n",
+        "src": "# Challenge: Add an Instruction\n\nTime to modify the program. Add a `greet` instruction that logs a greeting message.\n\n## Requirements\n\n1. Add a new function `greet` inside the `#[program]` module\n2. It should take `_ctx: Context<Greet>` as its parameter\n3. It should call `msg!(\"Hello, Solana!\")` and return `Ok(())`\n4. Add a corresponding `Greet` accounts struct (can be empty, like `Initialize`)\n\n## Tips\n\n- Follow the same pattern as the existing `initialize` function\n- The accounts struct name must match the `Context<T>` generic\n- Don't forget `#[derive(Accounts)]` on your new struct\n",
         "url": null,
         "language": null,
         "buildType": null,
@@ -919,32 +843,32 @@
         "language": "rust",
         "buildType": "buildable",
         "deployable": false,
-        "starter": "// Anatomy of an Anchor program — the same vault program, reduced to its four\n// parts and nothing else. Each part is labeled below.\n//\n// Parts 1 and 4 are complete. Parts 2 and 3 each already contain one worked\n// example, `version` and `Version`. Your job is the second pair: `greet` and\n// `Greet`, following the pattern that is already there.\n//\n// This file does NOT compile as shipped. The harness at the bottom names both\n// items you owe, and every error you see comes from one of them.\n\nuse anchor_lang::prelude::*;\n\n// ─────────────────────────────────────────────────────────────────────────────\n// PART 1 of 4 — `declare_id!`: the program's address.  (done)\n//\n// One address per program, baked into the binary. At deploy time the runtime\n// compares this value against the address it is deploying to.\n// ─────────────────────────────────────────────────────────────────────────────\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n// ─────────────────────────────────────────────────────────────────────────────\n// PART 2 of 4 — `#[program]`: the instruction handlers.\n//\n// Every `pub fn` in here becomes a callable instruction. First parameter is\n// always `Context<T>`; return type is always `Result<()>`.\n//\n// TODO (part 2): add a second handler, `greet`, that logs \"Hello, Solana!\"\n//                and returns `Ok(())`. Copy the shape of `version`.\n// ─────────────────────────────────────────────────────────────────────────────\n#[program]\npub mod vault_program {\n    use super::*;\n\n    pub fn version(_ctx: Context<Version>) -> Result<()> {\n        msg!(\"vault program, id {}\", ID);\n        Ok(())\n    }\n}\n\n// ─────────────────────────────────────────────────────────────────────────────\n// PART 3 of 4 — `#[derive(Accounts)]`: one account list per handler.\n//\n// The struct name must match the `Context<T>` generic exactly. `Version`\n// declares no fields, because `version` reads and writes no accounts.\n//\n// TODO (part 3): add the `Greet` accounts struct. `greet` only logs, so it too\n//                needs no fields — but it does need the derive.\n// ─────────────────────────────────────────────────────────────────────────────\n#[derive(Accounts)]\npub struct Version {}\n\n// ─────────────────────────────────────────────────────────────────────────────\n// PART 4 of 4 — `#[account]`: the state.  (done — this is your Course 2 struct)\n//\n// `#[account]` marks a struct as the contents of a program-owned account: it\n// generates the serialization and the 8-byte discriminator that identifies the\n// type on-chain. Nothing here creates an account. Module 2 does that.\n// ─────────────────────────────────────────────────────────────────────────────\n#[account]\n#[derive(InitSpace)]\npub struct VaultState {\n    pub owner: Pubkey,\n    pub balance: u64,\n    pub bump: u8,\n}\n\n// ─────────────────────────────────────────────────────────────────────────────\n// VERIFICATION HARNESS — DO NOT EDIT ANYTHING BELOW THIS LINE.\n//\n// It compiles only if both items exist with the exact names and signatures the\n// lesson asks for. This is a TYPE check, not a behaviour check: it cannot see\n// what your `msg!` string says, and it cannot see whether the handler does\n// anything at all.\n// ─────────────────────────────────────────────────────────────────────────────\n#[doc(hidden)]\n#[allow(dead_code)]\nmod verify {\n    use super::*;\n\n    // Part 3: `Greet` exists, has no fields, and carries `#[derive(Accounts)]`\n    // — the derive is what supplies the `Bumps` impl `Context` requires below.\n    fn accounts() -> Greet {\n        Greet {}\n    }\n\n    // Part 2: a handler named `greet` exists inside the `#[program]` module,\n    // takes `Context<Greet>` and returns `Result<()>`.\n    const GREET: for<'info> fn(Context<'info, Greet>) -> Result<()> = vault_program::greet;\n\n    // Part 4 is unchanged from Course 2: three fields, 41 bytes of data.\n    const _: () = assert!(VaultState::INIT_SPACE == 41);\n}\n",
-        "solution": "// Anatomy of an Anchor program — the four parts, with the second handler and\n// its account list filled in.\n//\n// The `msg!` string is yours; nothing checks it. What is fixed is the pair of\n// names: the handler is `greet` and the accounts struct is `Greet`, because\n// `Context<Greet>` in the signature is what ties them together.\n\nuse anchor_lang::prelude::*;\n\n// ─────────────────────────────────────────────────────────────────────────────\n// PART 1 of 4 — `declare_id!`: the program's address.\n// ─────────────────────────────────────────────────────────────────────────────\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n// ─────────────────────────────────────────────────────────────────────────────\n// PART 2 of 4 — `#[program]`: the instruction handlers.\n// ─────────────────────────────────────────────────────────────────────────────\n#[program]\npub mod vault_program {\n    use super::*;\n\n    pub fn version(_ctx: Context<Version>) -> Result<()> {\n        msg!(\"vault program, id {}\", ID);\n        Ok(())\n    }\n\n    pub fn greet(_ctx: Context<Greet>) -> Result<()> {\n        msg!(\"Hello, Solana!\");\n        Ok(())\n    }\n}\n\n// ─────────────────────────────────────────────────────────────────────────────\n// PART 3 of 4 — `#[derive(Accounts)]`: one account list per handler.\n//\n// Both are empty because neither handler touches an account. Empty is a claim,\n// not an omission: it says \"this instruction may read and write nothing\".\n// ─────────────────────────────────────────────────────────────────────────────\n#[derive(Accounts)]\npub struct Version {}\n\n#[derive(Accounts)]\npub struct Greet {}\n\n// ─────────────────────────────────────────────────────────────────────────────\n// PART 4 of 4 — `#[account]`: the state, unchanged from Course 2.\n// ─────────────────────────────────────────────────────────────────────────────\n#[account]\n#[derive(InitSpace)]\npub struct VaultState {\n    pub owner: Pubkey,\n    pub balance: u64,\n    pub bump: u8,\n}\n\n// ─────────────────────────────────────────────────────────────────────────────\n// VERIFICATION HARNESS — DO NOT EDIT ANYTHING BELOW THIS LINE.\n//\n// It compiles only if both items exist with the exact names and signatures the\n// lesson asks for. This is a TYPE check, not a behaviour check: it cannot see\n// what your `msg!` string says, and it cannot see whether the handler does\n// anything at all.\n// ─────────────────────────────────────────────────────────────────────────────\n#[doc(hidden)]\n#[allow(dead_code)]\nmod verify {\n    use super::*;\n\n    // Part 3: `Greet` exists, has no fields, and carries `#[derive(Accounts)]`\n    // — the derive is what supplies the `Bumps` impl `Context` requires below.\n    fn accounts() -> Greet {\n        Greet {}\n    }\n\n    // Part 2: a handler named `greet` exists inside the `#[program]` module,\n    // takes `Context<Greet>` and returns `Result<()>`.\n    const GREET: for<'info> fn(Context<'info, Greet>) -> Result<()> = vault_program::greet;\n\n    // Part 4 is unchanged from Course 2: three fields, 41 bytes of data.\n    const _: () = assert!(VaultState::INIT_SPACE == 41);\n}\n",
+        "starter": "use anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n#[program]\npub mod academy_program {\n    use super::*;\n\n    pub fn initialize(_ctx: Context<Initialize>) -> Result<()> {\n        msg!(\"Superteam Academy default program\");\n        Ok(())\n    }\n\n    // TODO: Add a greet instruction here\n}\n\n#[derive(Accounts)]\npub struct Initialize {}\n\n// TODO: Add a Greet accounts struct here\n",
+        "solution": "use anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n#[program]\npub mod academy_program {\n    use super::*;\n\n    pub fn initialize(_ctx: Context<Initialize>) -> Result<()> {\n        msg!(\"Superteam Academy default program\");\n        Ok(())\n    }\n\n    pub fn greet(_ctx: Context<Greet>) -> Result<()> {\n        msg!(\"Hello, Solana!\");\n        Ok(())\n    }\n}\n\n#[derive(Accounts)]\npub struct Initialize {}\n\n#[derive(Accounts)]\npub struct Greet {}\n",
         "tests": [
           {
-            "id": "t1",
-            "description": "The file compiles on the build server against anchor-lang 1.1.2",
+            "id": "test-1",
+            "description": "Program compiles successfully",
             "input": "",
             "expectedOutput": "true"
           },
           {
-            "id": "t2",
-            "description": "Compiles ⇒ a handler named greet exists inside #[program], taking Context<Greet> and returning Result<()>",
+            "id": "test-2",
+            "description": "Code contains a greet function",
             "input": "",
             "expectedOutput": "true"
           },
           {
-            "id": "t3",
-            "description": "Compiles ⇒ Greet exists, has no fields, and carries #[derive(Accounts)]",
+            "id": "test-3",
+            "description": "Code contains a Greet accounts struct",
             "input": "",
             "expectedOutput": "true"
           }
         ],
         "hints": [
-          "Build before you write anything. Four errors come back and all four are raised by the harness at the bottom, which is the only code referencing the two items you owe: three of them name `Greet` and one names `greet`.",
-          "The greet function follows the exact same pattern as version — just change the name and the log message. It goes inside the `#[program]` module under part 2, and its accounts struct goes under part 3, where `#[derive(Accounts)]` is not optional: without the derive the struct exists but `Context<Greet>` still fails, because the derive is what supplies the trait `Context` requires.",
-          "Both signatures in full. Inside `#[program]`: `pub fn greet(_ctx: Context<Greet>) -> Result<()>`, with a `msg!` and `Ok(())` in the body. At the top level, next to `Version`: `#[derive(Accounts)]` on the line above `pub struct Greet {}`."
+          "The greet function follows the exact same pattern as initialize — just change the name and the log message",
+          "Don't forget to add `#[derive(Accounts)]` before `pub struct Greet {}`",
+          "The full signature is: `pub fn greet(_ctx: Context<Greet>) -> Result<()>`"
         ],
         "questions": null,
         "prompt": null,
@@ -996,7 +920,7 @@
           },
           {
             "id": "q2",
-            "prompt": "The `Greet` accounts struct can be empty (`pub struct Greet {}`). Why is that valid, when module 2's `InitializeVault` will not be?",
+            "prompt": "The `Greet` accounts struct can be empty (`pub struct Greet {}`). Why is that valid when `Initialize`'s struct is not?",
             "multiSelect": false,
             "options": [
               {
@@ -1009,7 +933,7 @@
                 "id": "b",
                 "label": "Empty structs are required for every instruction",
                 "correct": false,
-                "feedback": "Not required — the struct lists exactly the accounts an instruction touches. greet touches none; creating a vault touches three, so its struct cannot be empty."
+                "feedback": "Not required — the struct lists exactly the accounts an instruction touches. greet touches none; Initialize creates an account, so its struct is non-empty."
               },
               {
                 "id": "c",
@@ -1018,39 +942,7 @@
                 "feedback": "Programs are stateless and store nothing internally. greet simply has no state to touch, which is why its accounts struct is empty."
               }
             ],
-            "explanation": "An accounts struct declares exactly the accounts an instruction reads or writes. `greet` only calls `msg!`, touching none, so its struct is legitimately empty — whereas creating the vault must declare the account being created, the payer who funds it, and the System Program that does the creating."
-          },
-          {
-            "id": "q3",
-            "prompt": "You copy a handler signature out of an older Anchor tutorial and end up with `pub fn greet(_ctx: Context<Greet>) -> ProgramResult {`. Predict what the build server reports.",
-            "multiSelect": false,
-            "options": [
-              {
-                "id": "a",
-                "label": "`error[E0412]: cannot find type ProgramResult in this scope` — the type was removed from Anchor years ago; 1.x handlers return `Result<()>`.",
-                "correct": true,
-                "feedback": null
-              },
-              {
-                "id": "b",
-                "label": "It compiles. `ProgramResult` and `Result<()>` are aliases for the same type.",
-                "correct": false,
-                "feedback": "They were never aliases — `ProgramResult` carried a `ProgramError`, which is why Anchor replaced it with its own `Result` and richer error type. And it is not in the prelude at all any more, so the name does not resolve."
-              },
-              {
-                "id": "c",
-                "label": "It compiles with a deprecation warning, since Anchor keeps the old return type for compatibility.",
-                "correct": false,
-                "feedback": "There is no deprecation shim. The removal is old enough that the type is simply gone; you get a hard error on an unresolved name."
-              },
-              {
-                "id": "d",
-                "label": "It fails inside the `#[program]` macro with an unhelpful error about the dispatcher.",
-                "correct": false,
-                "feedback": "The macro expansion is fine — the failure is ordinary name resolution on your own signature, and the error points at the exact column of `ProgramResult`."
-              }
-            ],
-            "explanation": "Worth recognising by sight, because it is the cheapest possible age-detector for a snippet. An unresolved name in a signature you copied almost always means the material predates a breaking release rather than that you mistyped. Anchor 1.x: the return type is `Result<()>`."
+            "explanation": "An accounts struct declares exactly the accounts an instruction reads or writes. `greet` only calls `msg!`, touching no accounts, so its struct is legitimately empty — whereas `Initialize` creates a Counter and must declare it, the payer, and the System Program."
           }
         ],
         "prompt": null,
@@ -1063,15 +955,15 @@
   },
   {
     "_id": "lesson-bfsp-adding-instructions",
-    "title": "Add an Instruction",
-    "slug": "add-an-instruction",
+    "title": "Adding Instructions",
+    "slug": "adding-instructions",
     "blocks": [
       {
         "key": "intro",
         "_type": "prose",
         "produces": null,
         "consumes": null,
-        "src": "# Add an Instruction\n\n> **Version stamp — checked 2026-07-26.** `anchor-lang 1.1.2` (published 2026-06-26) · `cargo-build-sbf` with platform-tools v1.54 (rustc 1.89) · `borsh` resolves to **1.8.0** · edition 2021. Every compiler message quoted below was produced by compiling this lesson's starter on that toolchain.\n\nYou have named the four parts. Now add an instruction without being shown where each line goes.\n\nAdding one is always the same three steps:\n\n1. a `pub fn` inside `#[program]`;\n2. an accounts struct with `#[derive(Accounts)]`, named exactly what the handler's `Context<T>` says;\n3. inside that struct, the accounts the instruction needs — and the constraints they must satisfy.\n\nStep 3 is module 2, and it is most of the rest of the course. This lesson is steps 1 and 2, on a handler that reads nothing, so that the mechanics are the only thing in front of you: `vault_info`, which logs the program's own id and returns.\n\n## What adding an instruction does to your program's API\n\nAn instruction is selected by the 8-byte discriminator Anchor derives from its name, so adding a handler is a purely **additive** change: every existing caller keeps working, because their discriminators still resolve. Renaming or removing one is a **breaking** change for exactly the same reason. Program upgrades on Solana are in-place — the address does not change and clients do not get told — so this is the version-compatibility surface you actually have. `vault_info` is safe to add today and expensive to rename tomorrow.\n\n## The exercise is a completion, not a blank page\n\nEvery line you need is already in the file, commented out and shuffled into two pools. Your job is discrimination and order, not invention:\n\n- **Pool A**, inside `#[program]`: five lines, four of which make one complete handler. Rust is whitespace-insensitive, so indentation is not what you are being asked about — the sequence is. One line opens the block, one closes it, one is the body, one is the return value.\n- **Pool B**, at the top level: four lines, two of which belong. This is where the exercise gets interesting.\n\nThree of the nine lines belong nowhere. **Two of the three are caught by the compiler; one is not**, and knowing which one slips through is the actual content of this lesson.\n\n### `#[account]` is not `#[derive(Accounts)]`\n\nPool B offers you both. They are one letter apart in conversation and unrelated in function:\n\n| | Goes on | Means |\n| --- | --- | --- |\n| `#[account]` | a **state struct** | \"these are the bytes stored inside a program-owned account\" — generates the serialization and the 8-byte type discriminator |\n| `#[derive(Accounts)]` | an **account list** | \"these are the accounts one instruction may touch\" — generates the deserialization and every validation check |\n\n`VaultState` in this file has the first. `VaultInfo` needs the second. Choose `#[account]` for `VaultInfo` and the build fails on `the trait bound VaultInfo: Bumps is not satisfied` — `Bumps` is one of the traits the `Accounts` derive generates, and `Context<T>` requires it. That error message names the missing trait rather than the missing attribute, which is why it is worth meeting once deliberately.\n\n### The line the compiler will not save you from\n\nPool B also offers a second error enum:\n\n```rust\n#[error_code] pub enum InfoError { #[msg(\"no vault at that address\")] NoVault }\n```\n\n**A program should carry exactly one `#[error_code]` enum, and nothing enforces it.** You already have yours — `VaultError`, from Course 2, sitting at the bottom of this file.\n\nHere is the part that matters. Paste that line in and **the build is green.** Not because our grader is lenient — a second enum is legal Anchor, and the Anchor CLI would accept it too. There is no rule being skipped here. What you get instead of an error is silent and worse.\n\n`#[error_code]` generates `impl From<YourEnum> for u32` as `variant_index + ERROR_CODE_OFFSET`, and `ERROR_CODE_OFFSET` is `6000`. Two enums, neither given an explicit offset, both start numbering at 6000. So `VaultError::Overflow` and `InfoError::NoVault` are **both error code 6000**, and a client that catches 6000 cannot tell which failure it is looking at. Your error messages stop being diagnostic at the exact moment you need them.\n\nTwo correct moves, in order of preference:\n\n1. Add a variant to `VaultError`. One namespace, monotonic numbering, no collision. This is what module 3 does when `withdraw` needs `InsufficientFunds`.\n2. If you genuinely need a separate enum, `#[error_code(offset = 7000)]` moves its base. You will almost never need this, and reaching for it is usually a sign the first option was right.\n\nTake the general lesson too: a green build here proves your file compiles against the real Anchor 1.x toolchain and nothing more. It does not prove the file is correct, and this lesson contains a live example of the gap.\n\n## Your job\n\nAssemble `vault_info` from pool A and `VaultInfo` from pool B. Leave the lines that belong nowhere commented out. The verification harness at the bottom of the file names both items by signature — build first, and the errors will tell you exactly what is still missing.\n",
+        "src": "# Adding Instructions\n\nA program with just `initialize` isn't very useful. Real programs have multiple instructions that modify state.\n\n## The Pattern\n\nEvery new instruction follows the same pattern:\n\n1. Add a `pub fn` inside `#[program]`\n2. Create a corresponding accounts struct with `#[derive(Accounts)]`\n3. Define which accounts the instruction needs and their constraints\n\n## Increment: Modifying State\n\nTo increment a counter, we need:\n\n```rust\npub fn increment(ctx: Context<Increment>) -> Result<()> {\n    let counter = &mut ctx.accounts.counter;\n    counter.count += 1;\n    Ok(())\n}\n```\n\nThe `Increment` accounts struct needs the counter PDA and the user (to derive the PDA seeds):\n\n```rust\n#[derive(Accounts)]\npub struct Increment<'info> {\n    #[account(\n        mut,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    pub user: Signer<'info>,\n}\n```\n\nNote: `mut` is required because we're modifying `count`. The `seeds` and `bump` tell Anchor to verify the PDA address matches. The `user` provides the wallet pubkey used in the seeds.\n\n## Decrement with Safety\n\nWhat happens if someone tries to decrement a counter that's already at 0? With `u64`, subtraction would underflow and panic.\n\nAnchor provides `require!` for safe checks:\n\n```rust\npub fn decrement(ctx: Context<Decrement>) -> Result<()> {\n    let counter = &mut ctx.accounts.counter;\n    require!(counter.count > 0, ErrorCode::Underflow);\n    counter.count -= 1;\n    Ok(())\n}\n```\n\n## Custom Errors\n\nThe `ErrorCode::Underflow` needs to be defined:\n\n```rust\n#[error_code]\npub enum ErrorCode {\n    #[msg(\"Cannot decrement below zero\")]\n    Underflow,\n}\n```\n\n`#[error_code]` generates Anchor-compatible error types. The `#[msg]` attribute provides a human-readable error message visible in transaction logs.\n\n## Coming Up\n\nYou'll build the increment instruction first, then combine everything into the complete counter program with error handling.\n",
         "url": null,
         "language": null,
         "buildType": null,
@@ -1080,50 +972,6 @@
         "solution": null,
         "tests": null,
         "hints": null,
-        "questions": null,
-        "prompt": null,
-        "maxWords": null,
-        "amount": null,
-        "network": null,
-        "idl": null
-      },
-      {
-        "key": "exercise",
-        "_type": "code",
-        "produces": null,
-        "consumes": null,
-        "src": null,
-        "url": null,
-        "language": "rust",
-        "buildType": "buildable",
-        "deployable": false,
-        "starter": "// Add an instruction — assemble it from the fragments below.\n//\n// Nothing here is for you to invent. Every line you need is already in this\n// file, commented out and out of order, in two pools. Uncomment the ones that\n// belong, put them in the right place in the right order, and leave the rest\n// commented.\n//\n// THREE of the nine pool lines belong nowhere. All three are mistakes people\n// actually make. TWO of them the compiler catches; ONE builds green and is\n// wrong anyway. Decide which is which before you build.\n//\n// Target, in full:\n//\n//     pub fn vault_info(_ctx: Context<VaultInfo>) -> Result<()>\n//     #[derive(Accounts)] pub struct VaultInfo {}\n//\n// This file does NOT compile as shipped.\n\nuse anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n#[program]\npub mod vault_program {\n    use super::*;\n\n    pub fn version(_ctx: Context<Version>) -> Result<()> {\n        msg!(\"vault program, id {}\", ID);\n        Ok(())\n    }\n\n    // ── POOL A — five lines. FOUR of them make one complete handler, here,\n    //    in some order. ONE belongs nowhere. Indentation is not graded; order\n    //    inside the block is the whole exercise.\n    //\n    // (a1)     Ok(())\n    // (a2) }\n    // (a3)     msg!(\"vault program id: {}\", ID);\n    // (a4) pub fn vault_info(_ctx: Context<VaultInfo>) -> ProgramResult {\n    // (a5) pub fn vault_info(_ctx: Context<VaultInfo>) -> Result<()> {\n}\n\n#[derive(Accounts)]\npub struct Version {}\n\n// ── POOL B — four lines. TWO of them belong here, in order. TWO belong nowhere.\n//\n// (b1) pub struct VaultInfo {}\n// (b2) #[derive(Accounts)]\n// (b3) #[account]\n// (b4) #[error_code] pub enum InfoError { #[msg(\"no vault at that address\")] NoVault }\n\n#[account]\n#[derive(InitSpace)]\npub struct VaultState {\n    pub owner: Pubkey,\n    pub balance: u64,\n    pub bump: u8,\n}\n\n#[error_code]\npub enum VaultError {\n    #[msg(\"Deposit would overflow the vault balance\")]\n    Overflow,\n    #[msg(\"Withdrawal is larger than the vault balance\")]\n    InsufficientFunds,\n    #[msg(\"Amount must be greater than zero\")]\n    ZeroAmount,\n    #[msg(\"Signer is not the vault owner\")]\n    NotOwner,\n}\n\n// ─────────────────────────────────────────────────────────────────────────────\n// VERIFICATION HARNESS — DO NOT EDIT ANYTHING BELOW THIS LINE.\n//\n// It compiles only if `vault_info` and `VaultInfo` exist with exactly the names\n// and signatures the lesson asks for. It is a TYPE check and nothing more: it\n// cannot see the body of your handler, and it cannot see a second `#[error_code]`\n// enum sitting above it.\n// ─────────────────────────────────────────────────────────────────────────────\n#[doc(hidden)]\n#[allow(dead_code)]\nmod verify {\n    use super::*;\n\n    // Pool B: `VaultInfo` exists, has no fields, and carries\n    // `#[derive(Accounts)]` — the derive is what supplies the `Bumps` impl that\n    // `Context` demands on the next line.\n    fn accounts() -> VaultInfo {\n        VaultInfo {}\n    }\n\n    // Pool A: a handler named `vault_info` exists inside the `#[program]`\n    // module, takes `Context<VaultInfo>` and returns `Result<()>`.\n    const VAULT_INFO: for<'info> fn(Context<'info, VaultInfo>) -> Result<()> =\n        vault_program::vault_info;\n}\n",
-        "solution": "// Add an instruction — assembled.\n//\n// Pool A, in order: (a5) opens the handler, (a3) is the body, (a1) returns, (a2)\n// closes the block. (a4) is the same signature with `ProgramResult` as its return\n// type; that type was removed from Anchor years ago, so it does not resolve.\n//\n// Pool B, in order: (b2) then (b1). (b3) is `#[account]`, which marks the\n// *contents of an account*, not an account list — pick it and `Context<VaultInfo>`\n// fails with `the trait bound VaultInfo: Bumps is not satisfied`, because the\n// `Accounts` derive is the only thing that supplies that impl. (b4) is the one\n// wrong line the compiler does not catch; see the lesson prose.\n\nuse anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n#[program]\npub mod vault_program {\n    use super::*;\n\n    pub fn version(_ctx: Context<Version>) -> Result<()> {\n        msg!(\"vault program, id {}\", ID);\n        Ok(())\n    }\n\n    pub fn vault_info(_ctx: Context<VaultInfo>) -> Result<()> {\n        msg!(\"vault program id: {}\", ID);\n        Ok(())\n    }\n}\n\n#[derive(Accounts)]\npub struct Version {}\n\n#[derive(Accounts)]\npub struct VaultInfo {}\n\n#[account]\n#[derive(InitSpace)]\npub struct VaultState {\n    pub owner: Pubkey,\n    pub balance: u64,\n    pub bump: u8,\n}\n\n#[error_code]\npub enum VaultError {\n    #[msg(\"Deposit would overflow the vault balance\")]\n    Overflow,\n    #[msg(\"Withdrawal is larger than the vault balance\")]\n    InsufficientFunds,\n    #[msg(\"Amount must be greater than zero\")]\n    ZeroAmount,\n    #[msg(\"Signer is not the vault owner\")]\n    NotOwner,\n}\n\n// ─────────────────────────────────────────────────────────────────────────────\n// VERIFICATION HARNESS — DO NOT EDIT ANYTHING BELOW THIS LINE.\n//\n// It compiles only if `vault_info` and `VaultInfo` exist with exactly the names\n// and signatures the lesson asks for. It is a TYPE check and nothing more: it\n// cannot see the body of your handler, and it cannot see a second `#[error_code]`\n// enum sitting above it.\n// ─────────────────────────────────────────────────────────────────────────────\n#[doc(hidden)]\n#[allow(dead_code)]\nmod verify {\n    use super::*;\n\n    // Pool B: `VaultInfo` exists, has no fields, and carries\n    // `#[derive(Accounts)]` — the derive is what supplies the `Bumps` impl that\n    // `Context` demands on the next line.\n    fn accounts() -> VaultInfo {\n        VaultInfo {}\n    }\n\n    // Pool A: a handler named `vault_info` exists inside the `#[program]`\n    // module, takes `Context<VaultInfo>` and returns `Result<()>`.\n    const VAULT_INFO: for<'info> fn(Context<'info, VaultInfo>) -> Result<()> =\n        vault_program::vault_info;\n}\n",
-        "tests": [
-          {
-            "id": "t1",
-            "description": "The file compiles on the build server against anchor-lang 1.1.2",
-            "input": "",
-            "expectedOutput": "true"
-          },
-          {
-            "id": "t2",
-            "description": "Compiles ⇒ a handler named vault_info exists inside #[program], taking Context<VaultInfo> and returning Result<()>",
-            "input": "",
-            "expectedOutput": "true"
-          },
-          {
-            "id": "t3",
-            "description": "Compiles ⇒ VaultInfo exists, has no fields, and carries #[derive(Accounts)] rather than #[account]",
-            "input": "",
-            "expectedOutput": "true"
-          }
-        ],
-        "hints": [
-          "Build before you place anything. Four errors come back and all four are raised by the harness, which is the only code in the file referencing what you have not placed yet: three name `VaultInfo` and one names `vault_info`. Neither pool is mentioned, because a commented-out line is invisible to the compiler.",
-          "Pool A, mechanically: the line that opens a block ends in `{`, the line that closes one is `}`, and between them the body runs top to bottom with the returned value last. That fixes the order completely. Then look at the two candidate signatures — only one names a return type that exists in Anchor 1.x, and you met the other one in the previous lesson's quiz.",
-          "Pool B is `(b2)` then `(b1)`. `#[account]` describes the bytes inside an account and `#[derive(Accounts)]` describes a list of accounts an instruction may touch; `Context<VaultInfo>` needs the second, and picking the first fails on `the trait bound VaultInfo: Bumps is not satisfied`. `(b4)` compiles cleanly and is still wrong — re-read the prose on error code 6000 before deciding it is harmless."
-        ],
         "questions": null,
         "prompt": null,
         "maxWords": null,
@@ -1134,16 +982,118 @@
     ]
   },
   {
-    "_id": "lesson-bfsp-build-increment",
-    "title": "Write the Deposit",
-    "slug": "write-the-deposit",
+    "_id": "lesson-bfsp-anatomy-anchor-program",
+    "title": "Anatomy of an Anchor Program",
+    "slug": "anatomy-anchor-program",
     "blocks": [
       {
         "key": "intro",
         "_type": "prose",
         "produces": null,
         "consumes": null,
-        "src": "# Write the Deposit\n\n> **Version stamp — checked 2026-07-26.** `anchor-lang 1.1.2` (published 2026-06-26) · `cargo-build-sbf` with platform-tools v1.54 (rustc 1.89) · edition 2021. Every compiler message quoted below was produced by compiling this lesson's file.\n\nYou read a working `deposit` in the last lesson. Now write one.\n\nThe starter has the vault program with `deposit` and its accounts struct removed, and three numbered subgoals in their place. The previous lesson is still open in another tab; that is deliberate. At this rung the work is not recall, it is knowing which piece goes where and why each line is there — and subgoal 3 asks for something no tutorial can hand you: a call into a file *you* wrote.\n\n## Subgoal 1 — `Deposit<'info>`\n\nThree accounts. `system_program` is pre-filled, because you already know why it stays even though `CpiContext::new` no longer takes it. The other two you write:\n\n- **the vault** — mutable, and re-derived from its seeds so Anchor can prove the account passed in really is *this* caller's vault.\n- **the user** — a signer, and mutable.\n\n`user` being `mut` is the one that catches people. In Module 2's `initialize_vault` the user was `mut` because they paid rent. Here nobody pays rent — the account already exists — but lamports still leave the user's wallet, and any account whose lamports change must be declared mutable. Same constraint, different reason.\n\n### `bump = vault.bump`, not bare `bump`\n\nBoth are legal. They do different amounts of work:\n\n| Written | What Anchor does |\n| --- | --- |\n| `bump` | searches from 255 downwards for the canonical bump, hashing at each step |\n| `bump = vault.bump` | one hash, using the byte you stored at initialize time |\n\nThe stored bump is *why* you spent a byte on it in Module 2. Use it. A bare `bump` here would be paying compute units to recompute an answer the account is already carrying.\n\n## Subgoal 2 — the CPI\n\nAsk the System Program to move `amount` lamports from the user to the vault. The shape from the last lesson, with the Anchor 1.0 first argument:\n\n```\ntransfer( CpiContext::new( <program id>, Transfer { from, to } ), amount )?\n```\n\n`Transfer`'s two fields are `AccountInfo`s, so both accounts need `.to_account_info()`. Get the direction right: the user is the source.\n\n## Subgoal 3 — call your own code\n\n```rust\nctx.accounts.vault.deposit(amount)?;\n```\n\nOne line. That line is the whole reason Course 2 exists.\n\nEverything it does — reject a zero amount, add with `checked_add`, return `VaultError::Overflow` instead of wrapping — is already written, already reasoned about, and lives in a module with no accounts in it. You are not going to retype `checked_add` here, and if you find yourself writing `ctx.accounts.vault.balance += amount` then stop: that is a fresh, unchecked, untested copy of a function you already own, and the version you already own is better.\n\nThis is what \"import, don't retype\" means as a mechanical fact rather than a slogan. Look at your finished file afterwards and note that the arithmetic appears exactly once in it.\n\n## Does the order matter?\n\nYou have two statements — the CPI and the bookkeeping — and you may be wondering which goes first.\n\nIt does not matter, and the reason is worth knowing: **a transaction either completes or is entirely rolled back.** If `vault.deposit(amount)` returns `Err` after the CPI has already moved lamports, the transfer is undone along with everything else. There is no state where the lamports moved and the balance did not.\n\nThat guarantee is what lets you write the happy path in the order that reads best.\n\n## What the build server can and cannot tell you\n\nAt the bottom of the starter is a `mod verify` block marked do-not-edit. It compiles only if `deposit` exists with exactly the right signature and `Deposit` has all three fields with the right types. Get a name or a type wrong and you get a compile error naming it.\n\nIt is a **type** check, not a behaviour check. It cannot see whether your CPI moves lamports in the right direction, and it cannot see whether you called `vault.deposit` at all — an empty handler body with a correct signature compiles. The harness comment lists exactly which mistakes it is blind to. Read that list; it is more useful than the part it does catch.\n",
+        "src": "# Anatomy of an Anchor Program\n\nBefore we start adding features, let's break down every line of the program you just compiled.\n\n## The Import\n\n```rust\nuse anchor_lang::prelude::*;\n```\n\nThis single import brings in everything Anchor needs: the `#[program]` macro, `Context`, `Account`, `Signer`, `Result`, error types, and more.\n\n## Program ID\n\n```rust\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n```\n\nEvery Solana program has a unique address (public key). The `declare_id!` macro hardcodes this address into the binary. When you deploy, Solana verifies the binary matches this ID.\n\nFor development, you can use any valid base58 public key. For production, you'd generate one with `solana-keygen grind`.\n\n## The Program Module\n\n```rust\n#[program]\npub mod academy_program {\n    use super::*;\n\n    pub fn initialize(_ctx: Context<Initialize>) -> Result<()> {\n        msg!(\"Superteam Academy default program\");\n        Ok(())\n    }\n}\n```\n\nThe `#[program]` attribute tells Anchor this module contains your instruction handlers. Each `pub fn` inside becomes a callable instruction on-chain.\n\n**Key rules:**\n- First parameter is always `Context<T>` where `T` is an accounts struct\n- Return type is always `Result<()>`\n- `msg!()` logs to the transaction log (visible in explorers)\n\n## Accounts Structs\n\n```rust\n#[derive(Accounts)]\npub struct Initialize {}\n```\n\nEvery instruction needs an accounts struct that defines which accounts the instruction reads/writes. This empty struct means `initialize` doesn't need any accounts.\n\nIn the next lesson, you'll add your first real instruction with a non-empty accounts struct.\n\n## What the Compiler Checks\n\nWhen you hit Build, `cargo-build-sbf` validates:\n- Rust syntax and type safety\n- Anchor macro expansion (accounts, constraints, errors)\n- SBF compatibility (no system calls, no heap abuse)\n\nIf any of these fail, you get a compiler error with the exact line number.\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "retrieval-close",
+        "_type": "quiz",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": [
+          {
+            "id": "q1",
+            "prompt": "`declare_id!(...)` hardcodes an address into your binary. What does Solana do with it at deploy time?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "It verifies the deployed program's account address matches the declared id",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "It generates a fresh keypair for the program",
+                "correct": false,
+                "feedback": "declare_id! generates no keys — it states the expected address. Solana checks the deployed program matches it; a mismatch is an error."
+              },
+              {
+                "id": "c",
+                "label": "It reserves the address so no one else can use it before you deploy",
+                "correct": false,
+                "feedback": "The macro reserves nothing on its own. It is a claim that Solana validates against the actual deploy address."
+              }
+            ],
+            "explanation": "declare_id! embeds the program's expected public key into the binary. On deploy, Solana checks the program account address against it — a guard against deploying a binary under the wrong id, which would break every client that derives PDAs from that id."
+          },
+          {
+            "id": "q2",
+            "prompt": "You add a new `pub fn withdraw(...)` inside the `#[program]` module. What must be true of its signature?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "Its first parameter is `Context<T>` for some `#[derive(Accounts)]` struct T, and it returns `Result<()>`",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "It can take any parameters and return any type",
+                "correct": false,
+                "feedback": "The `#[program]` contract is fixed: every handler takes a `Context<T>` first and returns `Result<()>`. Anchor's macro expansion depends on it."
+              },
+              {
+                "id": "c",
+                "label": "It must take each account as a separate argument, not a Context",
+                "correct": false,
+                "feedback": "Accounts are always bundled in `Context<T>`, never passed individually. The struct T is where accounts and their constraints live."
+              }
+            ],
+            "explanation": "Every `#[program]` handler has the same shape: `Context<T>` first (T being the accounts struct that declares and validates accounts), then optional instruction args, returning `Result<()>`. Anchor generates the on-chain dispatch from exactly this signature."
+          }
+        ],
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      }
+    ]
+  },
+  {
+    "_id": "lesson-bfsp-build-increment",
+    "title": "Build the Increment",
+    "slug": "build-increment",
+    "blocks": [
+      {
+        "key": "intro",
+        "_type": "prose",
+        "produces": null,
+        "consumes": null,
+        "src": "# Challenge: Build the Increment\n\nAdd an `increment` instruction to the counter program.\n\n## Requirements\n\n1. Add a `pub fn increment` inside the `#[program]` module\n2. It should take `ctx: Context<Increment>` and return `Result<()>`\n3. Get a mutable reference to `ctx.accounts.counter` and add 1 to `count`\n4. Add an `Increment` accounts struct with `counter` (PDA, `mut`, same seeds as Initialize) and `user` (`Signer`)\n\n## Why `user` is needed in Increment\n\nThe counter is a PDA derived from `[b\"counter\", user.key()]`. To verify the PDA matches, Anchor needs the `user` account to re-derive the seeds. This also acts as authorization — only the wallet that matches the seeds can modify this counter.\n\n## Tips\n\n- The `Increment` struct needs the `<'info>` lifetime, just like `Initialize`\n- The counter field needs `seeds` and `bump` (same seeds as Initialize, but no `init`)\n- The `user` field is `Signer<'info>` (not mut — they don't pay anything here)\n- Don't change the existing `initialize` or `greet` instructions\n",
         "url": null,
         "language": null,
         "buildType": null,
@@ -1169,20 +1119,32 @@
         "language": "rust",
         "buildType": "buildable",
         "deployable": false,
-        "starter": "use anchor_lang::prelude::*;\nuse anchor_lang::system_program::{transfer, Transfer};\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n// ─── Your Course 2 core, imported unchanged. Do not edit it. ─────────────────\npub mod vault {\n    use super::*;\n\n    #[account]\n    #[derive(InitSpace)]\n    pub struct VaultState {\n        pub owner: Pubkey,\n        pub balance: u64,\n        pub bump: u8,\n    }\n\n    #[error_code]\n    pub enum VaultError {\n        #[msg(\"Deposit would overflow the vault balance\")]\n        Overflow,\n        #[msg(\"Withdrawal is larger than the vault balance\")]\n        InsufficientFunds,\n        #[msg(\"Amount must be greater than zero\")]\n        ZeroAmount,\n        #[msg(\"Signer is not the vault owner\")]\n        NotOwner,\n    }\n\n    impl VaultState {\n        pub fn deposit(&mut self, amount: u64) -> Result<()> {\n            require!(amount > 0, VaultError::ZeroAmount);\n            self.balance = self\n                .balance\n                .checked_add(amount)\n                .ok_or(VaultError::Overflow)?;\n            Ok(())\n        }\n\n        pub fn withdraw(&mut self, amount: u64) -> Result<()> {\n            require!(amount > 0, VaultError::ZeroAmount);\n            self.balance = self\n                .balance\n                .checked_sub(amount)\n                .ok_or(VaultError::InsufficientFunds)?;\n            Ok(())\n        }\n    }\n}\n\npub use vault::{VaultError, VaultState};\n\n#[program]\npub mod vault_program {\n    use super::*;\n\n    // Finished in Module 2. Leave it alone.\n    pub fn initialize_vault(ctx: Context<InitializeVault>) -> Result<()> {\n        let vault = &mut ctx.accounts.vault;\n        vault.owner = ctx.accounts.user.key();\n        vault.balance = 0;\n        vault.bump = ctx.bumps.vault;\n        Ok(())\n    }\n\n    pub fn deposit(ctx: Context<Deposit>, amount: u64) -> Result<()> {\n        // ── SUBGOAL 2: move the lamports ────────────────────────────────────\n        //\n        // Ask the System Program to transfer `amount` from the user to the\n        // vault. Two things to get right:\n        //\n        //   * the first argument to `CpiContext::new` is a program id — a\n        //     `Pubkey`. Pass an `AccountInfo` and you get\n        //     `error[E0308]: expected Pubkey, found AccountInfo<'_>`.\n        //   * `Transfer { from, to }` takes `AccountInfo`s, so both accounts\n        //     need `.to_account_info()`. The user is the source.\n        //\n        // Propagate failure with `?` — never `.unwrap()`.\n\n        // ── SUBGOAL 3: update the balance using YOUR Course 2 method ────────\n        //\n        // One line. `ctx.accounts.vault` derefs to your `VaultState`, so the\n        // method you wrote and reasoned about in Course 2 is callable on it directly.\n        //\n        // Do NOT retype the arithmetic. If you are writing `checked_add` or\n        // `+= amount` in this file, you are shipping a second copy of a function\n        // you already own — one more place for the guard to go missing.\n\n        Ok(())\n    }\n}\n\n#[derive(Accounts)]\npub struct InitializeVault<'info> {\n    #[account(\n        init,\n        payer = user,\n        space = 8 + 32 + 8 + 1,\n        seeds = [b\"vault\", user.key().as_ref()],\n        bump\n    )]\n    pub vault: Account<'info, VaultState>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n    pub system_program: Program<'info, System>,\n}\n\n// ── SUBGOAL 1: the accounts struct ──────────────────────────────────────────\n//\n// Three accounts. One is pre-filled. Add the other two, in this order:\n//\n//   1a. `vault` — `Account<'info, VaultState>`. Mutable (both its lamports and\n//       its data change), re-derived from `[b\"vault\", user.key().as_ref()]`,\n//       and using the bump you STORED rather than searching for it again.\n//\n//   1b. `user`  — `Signer<'info>`. Mutable: no rent is paid here, but lamports\n//       leave this wallet, and any account whose lamports change must be `mut`.\n//\n#[derive(Accounts)]\npub struct Deposit<'info> {\n    // Still required even though `CpiContext::new` no longer takes it: the\n    // runtime must have the callee's program account loaded, and declaring it\n    // here is what makes the client include it in the transaction.\n    pub system_program: Program<'info, System>,\n}\n\n// ─────────────────────────────────────────────────────────────────────────────\n// VERIFICATION HARNESS — DO NOT EDIT ANYTHING BELOW THIS LINE.\n//\n// This compiles only if `deposit` and `Deposit` exist with exactly the names,\n// field names and types the subgoals ask for. A missing field is\n// `error[E0609]: no field ... on type &Deposit<'_>`; a wrong type is\n// `error[E0308]: mismatched types`; a missing item is `error[E0433]`.\n//\n// It is a TYPE check, not a behaviour check. Ways to be wrong and still be\n// green, each one confirmed by compiling it:\n//   * an empty `deposit` body — only the signature is pinned\n//   * `from` and `to` swapped, so the vault pays the user\n//   * `ctx.accounts.vault.balance += amount` instead of the Course 2 method\n//   * a bare `bump` instead of `bump = vault.bump`, which costs compute units\n// The build server compiles; it does not run, and neither does anything else in\n// this course. Module 4 shows you the LiteSVM test that would catch these three,\n// and why compiling cannot.\n// ─────────────────────────────────────────────────────────────────────────────\n#[doc(hidden)]\n#[allow(dead_code)]\nmod verify {\n    use super::*;\n\n    // `deposit` takes a `Deposit` context plus a `u64` and returns `Result<()>`.\n    const DEPOSIT: for<'info> fn(Context<'info, Deposit<'info>>, u64) -> Result<()> =\n        vault_program::deposit;\n\n    // `Deposit` carries all three accounts, each with the right type.\n    fn pin_deposit_accounts(a: &Deposit) {\n        let _: &Account<VaultState> = &a.vault;\n        let _: &Signer = &a.user;\n        let _: &Program<System> = &a.system_program;\n    }\n\n    // The Course 2 core is intact and still has the method subgoal 3 calls.\n    const CORE_DEPOSIT: fn(&mut VaultState, u64) -> Result<()> = VaultState::deposit;\n    const _: () = assert!(VaultState::INIT_SPACE == 41);\n}\n",
-        "solution": "use anchor_lang::prelude::*;\nuse anchor_lang::system_program::{transfer, Transfer};\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n// ─── Your Course 2 core, imported unchanged. Do not edit it. ─────────────────\npub mod vault {\n    use super::*;\n\n    #[account]\n    #[derive(InitSpace)]\n    pub struct VaultState {\n        pub owner: Pubkey,\n        pub balance: u64,\n        pub bump: u8,\n    }\n\n    #[error_code]\n    pub enum VaultError {\n        #[msg(\"Deposit would overflow the vault balance\")]\n        Overflow,\n        #[msg(\"Withdrawal is larger than the vault balance\")]\n        InsufficientFunds,\n        #[msg(\"Amount must be greater than zero\")]\n        ZeroAmount,\n        #[msg(\"Signer is not the vault owner\")]\n        NotOwner,\n    }\n\n    impl VaultState {\n        pub fn deposit(&mut self, amount: u64) -> Result<()> {\n            require!(amount > 0, VaultError::ZeroAmount);\n            self.balance = self\n                .balance\n                .checked_add(amount)\n                .ok_or(VaultError::Overflow)?;\n            Ok(())\n        }\n\n        pub fn withdraw(&mut self, amount: u64) -> Result<()> {\n            require!(amount > 0, VaultError::ZeroAmount);\n            self.balance = self\n                .balance\n                .checked_sub(amount)\n                .ok_or(VaultError::InsufficientFunds)?;\n            Ok(())\n        }\n    }\n}\n\npub use vault::{VaultError, VaultState};\n\n#[program]\npub mod vault_program {\n    use super::*;\n\n    pub fn initialize_vault(ctx: Context<InitializeVault>) -> Result<()> {\n        let vault = &mut ctx.accounts.vault;\n        vault.owner = ctx.accounts.user.key();\n        vault.balance = 0;\n        vault.bump = ctx.bumps.vault;\n        Ok(())\n    }\n\n    pub fn deposit(ctx: Context<Deposit>, amount: u64) -> Result<()> {\n        // SUBGOAL 2 — the lamports. Program id first (a `Pubkey`), accounts\n        // second, amount last. The user's transaction signature is what the\n        // System Program checks; this program signs nothing.\n        transfer(\n            CpiContext::new(\n                System::id(),\n                Transfer {\n                    from: ctx.accounts.user.to_account_info(),\n                    to: ctx.accounts.vault.to_account_info(),\n                },\n            ),\n            amount,\n        )?;\n\n        // SUBGOAL 3 — the bookkeeping, in one line, by calling Course 2.\n        // The zero-amount guard, the `checked_add` and `VaultError::Overflow`\n        // all live inside this method. Nothing is retyped here.\n        ctx.accounts.vault.deposit(amount)?;\n\n        Ok(())\n    }\n}\n\n#[derive(Accounts)]\npub struct InitializeVault<'info> {\n    #[account(\n        init,\n        payer = user,\n        space = 8 + 32 + 8 + 1,\n        seeds = [b\"vault\", user.key().as_ref()],\n        bump\n    )]\n    pub vault: Account<'info, VaultState>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n    pub system_program: Program<'info, System>,\n}\n\n// SUBGOAL 1 — the accounts struct.\n#[derive(Accounts)]\npub struct Deposit<'info> {\n    // `mut`: both the lamports and the data change.\n    // `bump = vault.bump`: one hash, using the byte stored at initialize time,\n    // instead of searching from 255 down for a canonical bump we already have.\n    #[account(\n        mut,\n        seeds = [b\"vault\", user.key().as_ref()],\n        bump = vault.bump\n    )]\n    pub vault: Account<'info, VaultState>,\n\n    // `mut` because lamports leave this wallet — not because rent is paid.\n    // `Signer` because the System Program will not debit an account that did\n    // not sign, and that signature is the only authorisation in the instruction.\n    #[account(mut)]\n    pub user: Signer<'info>,\n\n    pub system_program: Program<'info, System>,\n}\n\n// ─────────────────────────────────────────────────────────────────────────────\n// VERIFICATION HARNESS — DO NOT EDIT ANYTHING BELOW THIS LINE.\n//\n// A TYPE check, not a behaviour check. Ways to be wrong and still be green,\n// each one confirmed by compiling it: an empty `deposit` body; `from` and `to`\n// swapped; `balance += amount` instead of the Course 2 method; a bare `bump`\n// instead of `bump = vault.bump`. The build server compiles, it does not run.\n// ─────────────────────────────────────────────────────────────────────────────\n#[doc(hidden)]\n#[allow(dead_code)]\nmod verify {\n    use super::*;\n\n    const DEPOSIT: for<'info> fn(Context<'info, Deposit<'info>>, u64) -> Result<()> =\n        vault_program::deposit;\n\n    fn pin_deposit_accounts(a: &Deposit) {\n        let _: &Account<VaultState> = &a.vault;\n        let _: &Signer = &a.user;\n        let _: &Program<System> = &a.system_program;\n    }\n\n    const CORE_DEPOSIT: fn(&mut VaultState, u64) -> Result<()> = VaultState::deposit;\n    const _: () = assert!(VaultState::INIT_SPACE == 41);\n}\n",
+        "starter": "use anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n#[program]\npub mod academy_program {\n    use super::*;\n\n    pub fn initialize(ctx: Context<Initialize>) -> Result<()> {\n        let counter = &mut ctx.accounts.counter;\n        counter.count = 0;\n        counter.authority = ctx.accounts.user.key();\n        msg!(\"Counter initialized!\");\n        Ok(())\n    }\n\n    pub fn greet(_ctx: Context<Greet>) -> Result<()> {\n        msg!(\"Hello, Solana!\");\n        Ok(())\n    }\n\n    // TODO: Add an increment instruction\n}\n\n#[derive(Accounts)]\npub struct Initialize<'info> {\n    #[account(\n        init,\n        payer = user,\n        space = 8 + 8 + 32,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n    pub system_program: Program<'info, System>,\n}\n\n#[derive(Accounts)]\npub struct Greet {}\n\n// TODO: Add an Increment accounts struct with counter (PDA) and user (Signer)\n\n#[account]\npub struct Counter {\n    pub count: u64,\n    pub authority: Pubkey,\n}\n",
+        "solution": "use anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n#[program]\npub mod academy_program {\n    use super::*;\n\n    pub fn initialize(ctx: Context<Initialize>) -> Result<()> {\n        let counter = &mut ctx.accounts.counter;\n        counter.count = 0;\n        counter.authority = ctx.accounts.user.key();\n        msg!(\"Counter initialized!\");\n        Ok(())\n    }\n\n    pub fn greet(_ctx: Context<Greet>) -> Result<()> {\n        msg!(\"Hello, Solana!\");\n        Ok(())\n    }\n\n    pub fn increment(ctx: Context<Increment>) -> Result<()> {\n        let counter = &mut ctx.accounts.counter;\n        counter.count += 1;\n        Ok(())\n    }\n}\n\n#[derive(Accounts)]\npub struct Initialize<'info> {\n    #[account(\n        init,\n        payer = user,\n        space = 8 + 8 + 32,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n    pub system_program: Program<'info, System>,\n}\n\n#[derive(Accounts)]\npub struct Greet {}\n\n#[derive(Accounts)]\npub struct Increment<'info> {\n    #[account(\n        mut,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    pub user: Signer<'info>,\n}\n\n#[account]\npub struct Counter {\n    pub count: u64,\n    pub authority: Pubkey,\n}\n",
         "tests": [
           {
-            "id": "compiles",
-            "description": "The program compiles against the Anchor 1.x toolchain, with the verification harness intact",
+            "id": "test-1",
+            "description": "Program compiles successfully",
+            "input": "",
+            "expectedOutput": "true"
+          },
+          {
+            "id": "test-2",
+            "description": "Code contains an increment function",
+            "input": "",
+            "expectedOutput": "true"
+          },
+          {
+            "id": "test-3",
+            "description": "Increment struct has mut counter",
             "input": "",
             "expectedOutput": "true"
           }
         ],
         "hints": [
-          "Build the unfinished file first. It fails with `error[E0609]: no field 'vault' on type '&Deposit<'_>'` and the same for `user` — that is the do-not-edit harness at the bottom telling you subgoal 1 is not done yet. Errors that name the missing thing are the cheapest feedback you will get all lesson.",
-          "The `deposit` body is two statements: `transfer(CpiContext::new(System::id(), Transfer { from, to }), amount)?` and then one call on `ctx.accounts.vault`. `Transfer`'s fields are `AccountInfo`s, so both accounts need `.to_account_info()`, and the user is the `from`.",
-          "`Deposit<'info>` needs the lifetime, `vault` needs `mut` + `seeds = [b\"vault\", user.key().as_ref()]` + `bump = vault.bump` (the stored byte, not a bare `bump`), and `user` needs `mut` as well as `Signer<'info>` — lamports leave that wallet even though no rent is paid. Then make sure the handler still ends in `Ok(())`."
+          "The increment function body is just two lines: get `&mut ctx.accounts.counter` and then `counter.count += 1`",
+          "The Increment struct needs `<'info>` lifetime, a `counter` field with `#[account(mut, seeds = [b\"counter\", user.key().as_ref()], bump)]`, and a `user: Signer<'info>` field",
+          "Make sure increment returns `Ok(())` at the end"
         ],
         "questions": null,
         "prompt": null,
@@ -1191,12 +1153,11 @@
         "network": null,
         "idl": null,
         "tutorNotes": [
-          "Learners re-use `init` on the vault in the Deposit accounts struct; the account already exists at this point and only needs `mut`.",
-          "They leave `user` as a bare `Signer` without `mut`, carrying over the habit that a non-payer is not mutable — but lamports leave the wallet here, so it must be `mut`.",
-          "They forget `mut` on the vault, so Anchor rejects the instruction at runtime on the mut constraint even though the file compiled.",
-          "They copy a pre-1.0 CPI and pass `system_program.to_account_info()` as the first argument to `CpiContext::new`, which is `error[E0308]: expected Pubkey, found AccountInfo<'_>` — that argument is a program id now.",
-          "They swap `from` and `to` in `Transfer`, which compiles and makes the vault pay the depositor; nothing in a compile-only grader can see it.",
-          "They retype the arithmetic as `vault.balance += amount` instead of calling the Course 2 `vault.deposit(amount)?`, discarding the zero guard, the `checked_add` and the typed `Overflow` error in one line."
+          "Learners re-use `init` on the counter in the Increment accounts struct; the account already exists at this point and only needs `mut`.",
+          "They forget `mut` on the counter, so the compiler rejects `counter.count += 1` or the write never persists.",
+          "They drop the `seeds` + `bump` from the Increment struct, so Anchor stops verifying the account is the caller's own counter PDA.",
+          "They add `system_program` to Increment out of habit — it is only needed when an account is being created, not mutated.",
+          "They borrow the counter immutably with `&ctx.accounts.counter` and then try to mutate it."
         ]
       },
       {
@@ -1216,67 +1177,55 @@
         "questions": [
           {
             "id": "q1",
-            "prompt": "`Deposit` includes `user` and the same PDA seeds as `InitializeVault`, but no `init`. Why is `user` needed at all, and why is it `mut` here when nothing is being created?",
+            "prompt": "`Increment` includes the `user: Signer` and the same PDA seeds as `Initialize`, but no `init`. Why is `user` needed here at all?",
             "multiSelect": false,
             "options": [
               {
                 "id": "a",
-                "label": "Anchor re-derives the vault PDA from the user's key to prove the passed account is that wallet's vault — which also authorises only that wallet — and `mut` is required because lamports leave the user's account.",
+                "label": "Anchor re-derives the counter PDA from the user's key to verify the passed account is the right one, which also authorizes only that wallet",
                 "correct": true,
                 "feedback": null
               },
               {
                 "id": "b",
-                "label": "`user` is `mut` because it pays rent for the deposit.",
+                "label": "To pay rent for the increment",
                 "correct": false,
-                "feedback": "No rent is paid on a deposit — the vault already exists and its size never changes. The lamports leaving the wallet are the deposit itself, and that is what makes `mut` necessary."
+                "feedback": "No rent is paid on increment — the account already exists, so `user` is not `mut`. It is present so Anchor can re-derive and check the PDA seeds."
               },
               {
                 "id": "c",
-                "label": "Because every instruction must include a mutable signer.",
+                "label": "Because every instruction must have a signer",
                 "correct": false,
-                "feedback": "Neither half is a rule. Plenty of instructions have no signer at all, and plenty of signers are immutable. `user` is here to re-derive the seeds and to be debited."
-              },
-              {
-                "id": "d",
-                "label": "`user` is only needed as a seed; the `mut` is copied from `InitializeVault` and is harmless.",
-                "correct": false,
-                "feedback": "It is needed as a seed *and* as the debited account, and `mut` is load-bearing rather than harmless — drop it and Anchor rejects the instruction at runtime on the mut constraint."
+                "feedback": "Not every instruction needs a signer. Here `user` is required specifically to re-derive the PDA seeds and gate who may modify this counter."
               }
             ],
-            "explanation": "The vault's address is derived from the user's key, so Anchor needs `user` to recompute the seeds and confirm the passed account is that wallet's vault. That check doubles as authorisation. On top of it, `#[account(mut)]` is required of any account whose lamports or data change — and a deposit is lamports leaving this wallet. Same constraint as in `initialize_vault`, different reason for it."
+            "explanation": "The counter's address is derived from the user's key, so Anchor needs `user` to recompute the seeds and confirm the passed counter is that wallet's PDA. That check doubles as authorization: only the wallet in the seeds can modify its own counter. No lamports move, so `user` is not `mut`."
           },
           {
             "id": "q2",
-            "prompt": "A submission copies the whole constraint block over from `InitializeVault` — `init, payer = user, space = 8 + 32 + 8 + 1, seeds = [...], bump` — onto the vault in `Deposit`. It builds green. Predict what happens when the instruction is called on an existing vault.",
+            "prompt": "`Increment` uses `#[account(mut, seeds = [...], bump)]` on the counter but drops `init`. What would happen if you left `init` on it?",
             "multiSelect": false,
             "options": [
               {
                 "id": "a",
-                "label": "It tries to create the account a second time and fails, because the PDA already exists at that address.",
+                "label": "It would try to create the account again and fail, because the PDA already exists",
                 "correct": true,
                 "feedback": null
               },
               {
                 "id": "b",
-                "label": "It resets the vault's balance to zero.",
+                "label": "It would reset the counter to zero",
                 "correct": false,
-                "feedback": "`init` does not reset anything — it allocates and assigns a new account. On an address already in use it fails outright rather than silently zeroing your balance."
+                "feedback": "`init` does not reset — it allocates a new account. On an existing PDA it fails outright ('already in use'), rather than silently zeroing."
               },
               {
                 "id": "c",
-                "label": "Nothing changes; `init` is idempotent once the account exists.",
+                "label": "Nothing — `init` is idempotent",
                 "correct": false,
-                "feedback": "`init_if_needed` is the idempotent one, and it carries its own re-initialisation hazards. Plain `init` on an existing address is an error."
-              },
-              {
-                "id": "d",
-                "label": "The deposit succeeds but writes to a fresh account, leaving the old vault untouched.",
-                "correct": false,
-                "feedback": "There is no fresh account to write to. The seeds are the same, so the derived address is the same address that is already in use — a PDA cannot be created twice."
+                "feedback": "`init` is not idempotent (that is `init_if_needed`). Re-running `init` on an existing address errors."
               }
             ],
-            "explanation": "`init` allocates, funds and assigns a fresh account; you use it exactly once, in `initialize_vault`. Every later instruction operates on the account that already exists, so it uses `mut` plus `seeds` plus `bump = vault.bump` to locate and validate it. Adding `init` back is an attempt to create something at an address already in use. Note also that `init` and `bump = vault.bump` cannot coexist — you cannot read a bump off an account that does not exist yet."
+            "explanation": "`init` allocates and owns a fresh account; you use it once, in `Initialize`. `increment` operates on the already-created PDA, so it uses `mut` + `seeds` + `bump` to locate and mutate it. Leaving `init` on would attempt a second creation at an address already in use and fail."
           }
         ],
         "prompt": null,
@@ -1289,15 +1238,15 @@
   },
   {
     "_id": "lesson-bfsp-complete-counter",
-    "title": "Withdraw With a PDA Signer",
-    "slug": "withdraw-with-a-pda-signer",
+    "title": "Complete Counter Program",
+    "slug": "complete-counter-program",
     "blocks": [
       {
         "key": "intro",
         "_type": "prose",
         "produces": null,
         "consumes": null,
-        "src": "# Withdraw With a PDA Signer\n\n> **Version stamp — checked 2026-07-26.** `anchor-lang 1.1.2` (published 2026-06-26) · `cargo-build-sbf` with platform-tools v1.54 (rustc 1.89) · edition 2021 · System Program and rent behaviour read out of Agave `solana-system-program` 3.1.14 / 4.1.2 and `solana-svm-rent-collector`. Every compiler message quoted below was produced by that toolchain — either by compiling this lesson's file or, where a counter-example is shown, by compiling that counter-example; every runtime message was read from that Agave source, not from memory.\n\nThis lesson is named after the thing everyone reaches for. By the end you will know why the vault does not, in fact, sign its own withdrawal — and exactly where that signature *is* required, because it is a mechanism you will need constantly.\n\nDeposit was easy: the user signed the transaction, and that signature was still valid when the System Program looked at it. Withdrawal has no such luck. The lamports are leaving the *vault*, and the vault has no private key. It is an address that was chosen precisely because no key can produce it.\n\n## The shape you would write\n\nAnchor has an answer for exactly this, and it is real:\n\n```rust\nlet user_key = ctx.accounts.user.key();\nlet signer_seeds: &[&[&[u8]]] = &[&[b\"vault\", user_key.as_ref(), &[ctx.accounts.vault.bump]]];\n\ntransfer(\n    CpiContext::new_with_signer(\n        System::id(),\n        Transfer { from: vault_info, to: user_info },\n        signer_seeds,\n    ),\n    amount,\n)?;\n```\n\n`new_with_signer` takes the seeds and, at the moment of the nested call, the runtime re-derives an address from them **under your program id**. If the result matches the account you are claiming signed, the signature is accepted. No key exists, and none is needed: the derivation *is* the proof, and only your program can produce it because your program id is one of the inputs.\n\nThat is one of the most important primitives on Solana. Learn the shape.\n\nNote the `let user_key = ...` on the first line. `key()` returns a `Pubkey` **by value** and `as_ref()` only borrows it, so the seeds array holds a reference to a temporary. In the exact form above you get away with it even without the binding: the initializer starts with `&`, which triggers temporary lifetime extension, and the `Pubkey` is promoted to live as long as the enclosing block. It compiles either way.\n\nThe moment you split the seeds out into their own array, the extension no longer applies and the temporary dies at the semicolon:\n\n```rust\n// Does NOT compile — no leading `&`, so no lifetime extension.\nlet seeds: [&[u8]; 3] = [b\"vault\", ctx.accounts.user.key().as_ref(), &[ctx.accounts.vault.bump]];\n```\n\n```\nerror[E0716]: temporary value dropped while borrowed\n  |\n  |     let seeds: [&[u8]; 3] = [b\"vault\", ctx.accounts.user.key().as_ref(), ...];\n  |                                        ^^^^^^^^^^^^^^^^^^^^^^^ creates a temporary value\n  |                                        which is freed while still in use\n```\n\nThat refactor is extremely common — two-line seeds are easier to read — so bind the key to a named variable regardless. It costs one line and it is correct in both shapes.\n\n## Why it does not work here\n\nNow the part almost no tutorial tells you. From Agave's System Program, `transfer_verified`:\n\n```rust\nlet mut from = instruction_context.try_borrow_instruction_account(from_account_index)?;\nif !from.get_data().is_empty() {\n    ic_msg!(invoke_context, \"Transfer: `from` must not carry data\");\n    return Err(InstructionError::InvalidArgument);\n}\n```\n\nThe System Program will not send lamports **out of** any account that carries data. Your vault carries 49 bytes of `VaultState`. There is a second, independent reason as well: only the program that *owns* an account may debit it, and your vault is owned by your program, not by the System Program.\n\nSo the code above compiles, passes this course's grading, deploys cleanly, and fails the first time a learner calls it:\n\n```\nTransfer: `from` must not carry data\n```\n\nAuthorisation was never the obstacle. Ownership was. The seeds were solving a problem you did not have.\n\n> Read that sequence again, because it is the most expensive shape of bug in this ecosystem: **compiles, deploys, then fails.** Our own course catalogue specified the broken version of this instruction until it was compiled and checked against the runtime source. Anything you read about Solana — including this — is a claim until you have watched it run.\n\n## What actually moves lamports out\n\nYour program owns the vault. Owners may debit their own accounts directly, with no CPI and nothing to sign:\n\n```rust\n**vault_info.try_borrow_mut_lamports()? = remaining;\n**user_info.try_borrow_mut_lamports()? = credited;\n```\n\nTwo mutable borrows of the runtime's lamport fields, and the runtime reconciles the totals when the instruction ends. If the sums do not balance, the transaction fails — you cannot create lamports this way, only move them between accounts already in the instruction.\n\nThis is not a workaround. It is what Anchor's own `close = destination` constraint does internally, and what every escrow that holds native SOL in a stateful PDA does. `Withdraw` therefore needs no `system_program` in its accounts struct at all: there is no CPI to make.\n\n## The floor you cannot go below\n\nOne more rule, and it is the one people discover in production. Rent collection is gone, but rent *exemption* is enforced at the end of every transaction. From the runtime's rent check, a transition to `RentPaying` is allowed only from `RentPaying`:\n\n```rust\nmatch post_rent_state {\n    RentState::Uninitialized | RentState::RentExempt => true,\n    RentState::RentPaying { .. } => match pre_rent_state {\n        RentState::Uninitialized | RentState::RentExempt => false,\n        // ...\n    }\n}\n```\n\nYour vault starts rent-exempt. Take it below the minimum balance for its 49 bytes and the transition is refused with `TransactionError::InsufficientFundsForRent` — the whole transaction, not just your instruction.\n\nWhich means a vault holding exactly its rent-exempt minimum plus 1 SOL cannot pay out 1 SOL *and* stay alive at the same lamport count. You have to know the floor and check against it:\n\n```rust\nlet rent_floor = Rent::get()?.minimum_balance(vault_info.data_len());\n```\n\n`data_len()` reads the account's real allocated size, so this number stays correct even if the struct grows later. Do not hardcode 49.\n\n## The error, and the one-enum question\n\nThe guard returns `VaultError::InsufficientFunds` — the variant you already wrote in Course 2. Do not add a new error enum for this.\n\nThat advice is usually given as \"Anchor 1.0 allows only one `#[error_code]` per program.\" **That is not true, and it matters that you know why the real reason is worse.** Two `#[error_code]` enums in one program compile without complaint — this was verified on the same toolchain that grades you. What happens instead is silent:\n\n```rust\nimpl From<VaultError> for u32 {\n    fn from(e: VaultError) -> u32 { e as u32 + ERROR_CODE_OFFSET }   // 6000\n}\n```\n\nEvery `#[error_code]` enum starts counting at the same `ERROR_CODE_OFFSET` of 6000 unless you pass an explicit offset. So a second enum's first variant is *also* error code 6000, and a client that receives 6000 has no way to tell `VaultError::Overflow` from `SomeOtherError::Whatever`. You have not gained a type; you have gained a collision, and the compiler is happy about it.\n\nOne enum, four variants, already written, already carrying `InsufficientFunds`. Use it.\n\n## The exercise\n\nCompletion, not a blank page. The accounts struct is given, the two `AccountInfo` bindings are given, and ten candidate lines sit in a comment block at the top. Eight belong in the file. Two do not, and one of those two is the CPI you just read about — present on purpose, because reaching for it is the correct instinct and rejecting it is the lesson.\n",
+        "src": "# Capstone: Complete Counter Program\n\nThis is the capstone challenge. Build the complete counter program with:\n- `initialize` — create the counter PDA, set to 0\n- `increment` — add 1\n- `decrement` — subtract 1, with underflow protection\n\n## Requirements\n\n1. Add a `decrement` instruction that subtracts 1 from `counter.count`\n2. Use `require!(counter.count > 0, ErrorCode::Underflow)` to prevent underflow\n3. Add a `Decrement` accounts struct (same shape as `Increment` — PDA counter + user Signer)\n4. Define a custom `ErrorCode` enum with an `Underflow` variant\n\n## Custom Error Enum\n\nAnchor uses `#[error_code]` to define program-specific errors:\n\n```rust\n#[error_code]\npub enum ErrorCode {\n    #[msg(\"Cannot decrement below zero\")]\n    Underflow,\n}\n```\n\nThe `#[msg]` attribute provides the human-readable error message.\n\n## This Is It\n\nWhen this compiles, you've built a real Solana program from scratch using PDAs — the production-standard pattern. The next lesson covers deployment.\n",
         "url": null,
         "language": null,
         "buildType": null,
@@ -1323,20 +1272,32 @@
         "language": "rust",
         "buildType": "buildable",
         "deployable": false,
-        "starter": "// Complete `withdraw`.\n//\n// The accounts struct is written. The two `AccountInfo` bindings are written.\n// Below are ten candidate lines. EIGHT of them belong in this file, in an order\n// you have to work out. The other two compile — or all but compile — and are\n// still wrong, and a compile-only grader cannot tell the difference. That is the\n// point of asking you.\n//\n//   (1)  ctx.accounts.vault.withdraw(amount)?;\n//   (2)  let rent_floor = Rent::get()?.minimum_balance(vault_info.data_len());\n//   (3)  let remaining = vault_info.lamports().checked_sub(amount).ok_or(VaultError::InsufficientFunds)?;\n//   (4)  require!(remaining >= rent_floor, VaultError::InsufficientFunds);\n//   (5)  **vault_info.try_borrow_mut_lamports()? = remaining;\n//   (6)  let credited = user_info.lamports().checked_add(amount).ok_or(VaultError::Overflow)?;\n//   (7)  **user_info.try_borrow_mut_lamports()? = credited;\n//   (8)  Ok(())\n//   (9)  transfer(CpiContext::new_with_signer(System::id(), Transfer { from: vault_info.clone(), to: user_info.clone() }, signer_seeds), amount)?;\n//  (10)  **vault_info.try_borrow_mut_lamports()? -= amount;\n//\n// Order matters. Three of the eight read a value another one of them has to have\n// produced first, and the guard has to run before any lamport is touched.\n//\n// This file does NOT compile as shipped. Build it first — an empty body\n// evaluates to `()`, and the signature promises `Result<()>`.\n\nuse anchor_lang::prelude::*;\nuse anchor_lang::system_program::{transfer, Transfer};\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n// ─── Your Course 2 core, imported unchanged. Do not edit it. ─────────────────\npub mod vault {\n    use super::*;\n\n    #[account]\n    #[derive(InitSpace)]\n    pub struct VaultState {\n        pub owner: Pubkey,\n        pub balance: u64,\n        pub bump: u8,\n    }\n\n    #[error_code]\n    pub enum VaultError {\n        #[msg(\"Deposit would overflow the vault balance\")]\n        Overflow,\n        #[msg(\"Withdrawal is larger than the vault balance\")]\n        InsufficientFunds,\n        #[msg(\"Amount must be greater than zero\")]\n        ZeroAmount,\n        #[msg(\"Signer is not the vault owner\")]\n        NotOwner,\n    }\n\n    impl VaultState {\n        pub fn deposit(&mut self, amount: u64) -> Result<()> {\n            require!(amount > 0, VaultError::ZeroAmount);\n            self.balance = self\n                .balance\n                .checked_add(amount)\n                .ok_or(VaultError::Overflow)?;\n            Ok(())\n        }\n\n        pub fn withdraw(&mut self, amount: u64) -> Result<()> {\n            require!(amount > 0, VaultError::ZeroAmount);\n            self.balance = self\n                .balance\n                .checked_sub(amount)\n                .ok_or(VaultError::InsufficientFunds)?;\n            Ok(())\n        }\n    }\n}\n\npub use vault::{VaultError, VaultState};\n\n#[program]\npub mod vault_program {\n    use super::*;\n\n    pub fn initialize_vault(ctx: Context<InitializeVault>) -> Result<()> {\n        let vault = &mut ctx.accounts.vault;\n        vault.owner = ctx.accounts.user.key();\n        vault.balance = 0;\n        vault.bump = ctx.bumps.vault;\n        Ok(())\n    }\n\n    pub fn deposit(ctx: Context<Deposit>, amount: u64) -> Result<()> {\n        transfer(\n            CpiContext::new(\n                System::id(),\n                Transfer {\n                    from: ctx.accounts.user.to_account_info(),\n                    to: ctx.accounts.vault.to_account_info(),\n                },\n            ),\n            amount,\n        )?;\n        ctx.accounts.vault.deposit(amount)?;\n        Ok(())\n    }\n\n    pub fn withdraw(ctx: Context<Withdraw>, amount: u64) -> Result<()> {\n        let vault_info = ctx.accounts.vault.to_account_info();\n        let user_info = ctx.accounts.user.to_account_info();\n\n        // Eight lines from the pool, in order.\n    }\n}\n\n#[derive(Accounts)]\npub struct InitializeVault<'info> {\n    #[account(\n        init,\n        payer = user,\n        space = 8 + 32 + 8 + 1,\n        seeds = [b\"vault\", user.key().as_ref()],\n        bump\n    )]\n    pub vault: Account<'info, VaultState>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n    pub system_program: Program<'info, System>,\n}\n\n#[derive(Accounts)]\npub struct Deposit<'info> {\n    #[account(\n        mut,\n        seeds = [b\"vault\", user.key().as_ref()],\n        bump = vault.bump\n    )]\n    pub vault: Account<'info, VaultState>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n    pub system_program: Program<'info, System>,\n}\n\n// GIVEN. Two things to notice before you start.\n//\n//   * `constraint = vault.owner == user.key()` is what finally spends the\n//     `owner` field you have been carrying since Course 2, and it returns\n//     `NotOwner` — the fourth variant, previously unused.\n//   * there is no `system_program` here. `Withdraw` makes no CPI, so there is no\n//     callee program for the runtime to load. If your answer needs it, your\n//     answer is the wrong one.\n#[derive(Accounts)]\npub struct Withdraw<'info> {\n    #[account(\n        mut,\n        seeds = [b\"vault\", user.key().as_ref()],\n        bump = vault.bump,\n        constraint = vault.owner == user.key() @ VaultError::NotOwner\n    )]\n    pub vault: Account<'info, VaultState>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n}\n\n// ─────────────────────────────────────────────────────────────────────────────\n// VERIFICATION HARNESS — DO NOT EDIT ANYTHING BELOW THIS LINE.\n//\n// It pins the signature of `withdraw` and the fields of `Withdraw`, and nothing\n// else. It is a TYPE check, not a behaviour check. Ways to be wrong and still be\n// green, each one confirmed by compiling it:\n//   * pool line (9), which needs no more than a `signer_seeds` binding to\n//     compile, deploys fine, and returns `Transfer: 'from' must not carry data`\n//     the first time anyone calls it\n//   * pool line (10), which drops the rent floor and panics under\n//     `overflow-checks = true` instead of returning `InsufficientFunds`\n//   * crediting the user without debiting the vault, which the runtime catches\n//     at the end of the instruction — but not until it runs\n// The build server compiles; it does not run. Module 4 shows you the LiteSVM\n// test that would execute this program and catch the above, and why compiling\n// cannot — read it before any devnet SOL is spent.\n// ─────────────────────────────────────────────────────────────────────────────\n#[doc(hidden)]\n#[allow(dead_code)]\nmod verify {\n    use super::*;\n\n    const WITHDRAW: for<'info> fn(Context<'info, Withdraw<'info>>, u64) -> Result<()> =\n        vault_program::withdraw;\n\n    fn pin_withdraw_accounts(a: &Withdraw) {\n        let _: &Account<VaultState> = &a.vault;\n        let _: &Signer = &a.user;\n    }\n\n    // The Course 2 core is intact and still owns the arithmetic.\n    const CORE_WITHDRAW: fn(&mut VaultState, u64) -> Result<()> = VaultState::withdraw;\n\n    // All four variants still exist, including the one this lesson finally uses.\n    fn errors() -> [anchor_lang::error::Error; 4] {\n        [\n            VaultError::Overflow.into(),\n            VaultError::InsufficientFunds.into(),\n            VaultError::ZeroAmount.into(),\n            VaultError::NotOwner.into(),\n        ]\n    }\n}\n",
-        "solution": "// Exercise complete.\n//\n// Pool order is (1), (2), (3), (4), (5), (6), (7), (8). Lines (9) and (10)\n// belong nowhere:\n//\n//   (9)  is the CPI everyone reaches for. Give it a `signer_seeds` binding and\n//        it compiles, deploys, and then returns `Transfer: 'from' must not carry\n//        data` — the System Program refuses to debit any account with a\n//        non-empty data field, and it does not own our vault anyway. Signer\n//        seeds solve authorisation; authorisation was never the obstacle.\n//\n//  (10)  drops the rent floor and does bare subtraction. Under this crate's\n//        `overflow-checks = true` it panics instead of returning\n//        `InsufficientFunds`, and even when it does not underflow it will happily\n//        take the vault below its rent-exempt minimum, failing the entire\n//        transaction with `InsufficientFundsForRent`.\n//\n// Note what is NOT in this file: no `checked_sub` on `balance` (that is the\n// Course 2 method), no second `#[error_code]` enum, and no `system_program` in\n// `Withdraw`, because there is no CPI to make.\n\nuse anchor_lang::prelude::*;\nuse anchor_lang::system_program::{transfer, Transfer};\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n// ─── Your Course 2 core, imported unchanged. Do not edit it. ─────────────────\npub mod vault {\n    use super::*;\n\n    #[account]\n    #[derive(InitSpace)]\n    pub struct VaultState {\n        pub owner: Pubkey,\n        pub balance: u64,\n        pub bump: u8,\n    }\n\n    #[error_code]\n    pub enum VaultError {\n        #[msg(\"Deposit would overflow the vault balance\")]\n        Overflow,\n        #[msg(\"Withdrawal is larger than the vault balance\")]\n        InsufficientFunds,\n        #[msg(\"Amount must be greater than zero\")]\n        ZeroAmount,\n        #[msg(\"Signer is not the vault owner\")]\n        NotOwner,\n    }\n\n    impl VaultState {\n        pub fn deposit(&mut self, amount: u64) -> Result<()> {\n            require!(amount > 0, VaultError::ZeroAmount);\n            self.balance = self\n                .balance\n                .checked_add(amount)\n                .ok_or(VaultError::Overflow)?;\n            Ok(())\n        }\n\n        pub fn withdraw(&mut self, amount: u64) -> Result<()> {\n            require!(amount > 0, VaultError::ZeroAmount);\n            self.balance = self\n                .balance\n                .checked_sub(amount)\n                .ok_or(VaultError::InsufficientFunds)?;\n            Ok(())\n        }\n    }\n}\n\npub use vault::{VaultError, VaultState};\n\n#[program]\npub mod vault_program {\n    use super::*;\n\n    pub fn initialize_vault(ctx: Context<InitializeVault>) -> Result<()> {\n        let vault = &mut ctx.accounts.vault;\n        vault.owner = ctx.accounts.user.key();\n        vault.balance = 0;\n        vault.bump = ctx.bumps.vault;\n        Ok(())\n    }\n\n    pub fn deposit(ctx: Context<Deposit>, amount: u64) -> Result<()> {\n        transfer(\n            CpiContext::new(\n                System::id(),\n                Transfer {\n                    from: ctx.accounts.user.to_account_info(),\n                    to: ctx.accounts.vault.to_account_info(),\n                },\n            ),\n            amount,\n        )?;\n        ctx.accounts.vault.deposit(amount)?;\n        Ok(())\n    }\n\n    pub fn withdraw(ctx: Context<Withdraw>, amount: u64) -> Result<()> {\n        let vault_info = ctx.accounts.vault.to_account_info();\n        let user_info = ctx.accounts.user.to_account_info();\n\n        // (1) Bookkeeping first, and it is the Course 2 method — the zero guard,\n        // the `checked_sub` and `InsufficientFunds` all live inside it. If the\n        // vault's recorded balance cannot cover `amount`, nothing below runs.\n        ctx.accounts.vault.withdraw(amount)?;\n\n        // (2) The floor. `data_len()` reads the account's real allocated size,\n        // so this stays correct if `VaultState` ever grows. Never hardcode 49.\n        let rent_floor = Rent::get()?.minimum_balance(vault_info.data_len());\n\n        // (3) What the vault would hold afterwards, computed without trusting\n        // subtraction not to underflow.\n        let remaining = vault_info\n            .lamports()\n            .checked_sub(amount)\n            .ok_or(VaultError::InsufficientFunds)?;\n\n        // (4) The guard, before a single lamport moves. Below the floor, the\n        // runtime refuses the whole transaction with `InsufficientFundsForRent`\n        // — so we refuse it first, with an error the caller can read.\n        require!(remaining >= rent_floor, VaultError::InsufficientFunds);\n\n        // (5) Our program owns the vault, so our program may debit it. No CPI,\n        // nothing to sign.\n        **vault_info.try_borrow_mut_lamports()? = remaining;\n\n        // (6) and (7) The credit, also checked.\n        let credited = user_info\n            .lamports()\n            .checked_add(amount)\n            .ok_or(VaultError::Overflow)?;\n        **user_info.try_borrow_mut_lamports()? = credited;\n\n        // (8)\n        Ok(())\n    }\n}\n\n#[derive(Accounts)]\npub struct InitializeVault<'info> {\n    #[account(\n        init,\n        payer = user,\n        space = 8 + 32 + 8 + 1,\n        seeds = [b\"vault\", user.key().as_ref()],\n        bump\n    )]\n    pub vault: Account<'info, VaultState>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n    pub system_program: Program<'info, System>,\n}\n\n#[derive(Accounts)]\npub struct Deposit<'info> {\n    #[account(\n        mut,\n        seeds = [b\"vault\", user.key().as_ref()],\n        bump = vault.bump\n    )]\n    pub vault: Account<'info, VaultState>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n    pub system_program: Program<'info, System>,\n}\n\n// GIVEN. Two things to notice before you start.\n//\n//   * `constraint = vault.owner == user.key()` is what finally spends the\n//     `owner` field you have been carrying since Course 2, and it returns\n//     `NotOwner` — the fourth variant, previously unused.\n//   * there is no `system_program` here. `Withdraw` makes no CPI, so there is no\n//     callee program for the runtime to load. If your answer needs it, your\n//     answer is the wrong one.\n#[derive(Accounts)]\npub struct Withdraw<'info> {\n    #[account(\n        mut,\n        seeds = [b\"vault\", user.key().as_ref()],\n        bump = vault.bump,\n        constraint = vault.owner == user.key() @ VaultError::NotOwner\n    )]\n    pub vault: Account<'info, VaultState>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n}\n\n// ─────────────────────────────────────────────────────────────────────────────\n// VERIFICATION HARNESS — DO NOT EDIT ANYTHING BELOW THIS LINE.\n//\n// It pins the signature of `withdraw` and the fields of `Withdraw`, and nothing\n// else. It is a TYPE check, not a behaviour check. Ways to be wrong and still be\n// green, each one confirmed by compiling it:\n//   * pool line (9), which needs no more than a `signer_seeds` binding to\n//     compile, deploys fine, and returns `Transfer: 'from' must not carry data`\n//     the first time anyone calls it\n//   * pool line (10), which drops the rent floor and panics under\n//     `overflow-checks = true` instead of returning `InsufficientFunds`\n//   * crediting the user without debiting the vault, which the runtime catches\n//     at the end of the instruction — but not until it runs\n// The build server compiles; it does not run. Module 4 shows you the LiteSVM\n// test that would execute this program and catch the above, and why compiling\n// cannot — read it before any devnet SOL is spent.\n// ─────────────────────────────────────────────────────────────────────────────\n#[doc(hidden)]\n#[allow(dead_code)]\nmod verify {\n    use super::*;\n\n    const WITHDRAW: for<'info> fn(Context<'info, Withdraw<'info>>, u64) -> Result<()> =\n        vault_program::withdraw;\n\n    fn pin_withdraw_accounts(a: &Withdraw) {\n        let _: &Account<VaultState> = &a.vault;\n        let _: &Signer = &a.user;\n    }\n\n    // The Course 2 core is intact and still owns the arithmetic.\n    const CORE_WITHDRAW: fn(&mut VaultState, u64) -> Result<()> = VaultState::withdraw;\n\n    // All four variants still exist, including the one this lesson finally uses.\n    fn errors() -> [anchor_lang::error::Error; 4] {\n        [\n            VaultError::Overflow.into(),\n            VaultError::InsufficientFunds.into(),\n            VaultError::ZeroAmount.into(),\n            VaultError::NotOwner.into(),\n        ]\n    }\n}\n",
+        "starter": "use anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n#[program]\npub mod academy_program {\n    use super::*;\n\n    pub fn initialize(ctx: Context<Initialize>) -> Result<()> {\n        let counter = &mut ctx.accounts.counter;\n        counter.count = 0;\n        counter.authority = ctx.accounts.user.key();\n        msg!(\"Counter initialized!\");\n        Ok(())\n    }\n\n    pub fn greet(_ctx: Context<Greet>) -> Result<()> {\n        msg!(\"Hello, Solana!\");\n        Ok(())\n    }\n\n    pub fn increment(ctx: Context<Increment>) -> Result<()> {\n        let counter = &mut ctx.accounts.counter;\n        counter.count += 1;\n        Ok(())\n    }\n\n    // TODO: Add a decrement instruction with underflow protection\n}\n\n#[derive(Accounts)]\npub struct Initialize<'info> {\n    #[account(\n        init,\n        payer = user,\n        space = 8 + 8 + 32,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n    pub system_program: Program<'info, System>,\n}\n\n#[derive(Accounts)]\npub struct Greet {}\n\n#[derive(Accounts)]\npub struct Increment<'info> {\n    #[account(\n        mut,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    pub user: Signer<'info>,\n}\n\n// TODO: Add a Decrement accounts struct (same as Increment)\n\n#[account]\npub struct Counter {\n    pub count: u64,\n    pub authority: Pubkey,\n}\n\n// TODO: Add a custom ErrorCode enum with Underflow variant\n",
+        "solution": "use anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n#[program]\npub mod academy_program {\n    use super::*;\n\n    pub fn initialize(ctx: Context<Initialize>) -> Result<()> {\n        let counter = &mut ctx.accounts.counter;\n        counter.count = 0;\n        counter.authority = ctx.accounts.user.key();\n        msg!(\"Counter initialized!\");\n        Ok(())\n    }\n\n    pub fn greet(_ctx: Context<Greet>) -> Result<()> {\n        msg!(\"Hello, Solana!\");\n        Ok(())\n    }\n\n    pub fn increment(ctx: Context<Increment>) -> Result<()> {\n        let counter = &mut ctx.accounts.counter;\n        counter.count += 1;\n        Ok(())\n    }\n\n    pub fn decrement(ctx: Context<Decrement>) -> Result<()> {\n        let counter = &mut ctx.accounts.counter;\n        require!(counter.count > 0, ErrorCode::Underflow);\n        counter.count -= 1;\n        Ok(())\n    }\n}\n\n#[derive(Accounts)]\npub struct Initialize<'info> {\n    #[account(\n        init,\n        payer = user,\n        space = 8 + 8 + 32,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n    pub system_program: Program<'info, System>,\n}\n\n#[derive(Accounts)]\npub struct Greet {}\n\n#[derive(Accounts)]\npub struct Increment<'info> {\n    #[account(\n        mut,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    pub user: Signer<'info>,\n}\n\n#[derive(Accounts)]\npub struct Decrement<'info> {\n    #[account(\n        mut,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    pub user: Signer<'info>,\n}\n\n#[account]\npub struct Counter {\n    pub count: u64,\n    pub authority: Pubkey,\n}\n\n#[error_code]\npub enum ErrorCode {\n    #[msg(\"Cannot decrement below zero\")]\n    Underflow,\n}\n",
         "tests": [
           {
-            "id": "compiles",
-            "description": "The program compiles against the Anchor 1.x toolchain, with the verification harness intact",
+            "id": "test-1",
+            "description": "Program compiles successfully",
+            "input": "",
+            "expectedOutput": "true"
+          },
+          {
+            "id": "test-2",
+            "description": "Code contains decrement function with underflow check",
+            "input": "",
+            "expectedOutput": "true"
+          },
+          {
+            "id": "test-3",
+            "description": "Custom ErrorCode enum is defined",
             "input": "",
             "expectedOutput": "true"
           }
         ],
         "hints": [
-          "Build before you change anything. One error comes back: `error[E0308]: mismatched types — expected Result<(), Error>, found ()`, pointing at `withdraw`'s return type with the note `implicitly returns () as its body has no tail`. An empty body evaluates to `()`, so one of the ten pool lines is simply `Ok(())` and it goes last.",
-          "Work out the dependencies before the order. `rent_floor` and `remaining` are both `let` bindings that a later line reads, and `remaining` has to exist before the guard that compares it. The guard has to run before any lamport is touched, and the Course 2 method has to run before anything at all — if the recorded balance cannot cover the amount, nothing else should happen.",
-          "Two lines belong nowhere. (9) is the `new_with_signer` CPI: add a `signer_seeds` binding and it compiles, deploys, and returns `Transfer: 'from' must not carry data`, because the System Program will not debit a data-carrying account and does not own your vault. (10) does bare subtraction with no floor check — under `overflow-checks = true` it panics instead of returning `InsufficientFunds`."
+          "The decrement function is almost identical to increment, but starts with `require!(counter.count > 0, ErrorCode::Underflow);`",
+          "The Decrement accounts struct is the same shape as Increment — counter with PDA seeds and user as Signer",
+          "Don't forget `#[error_code]` on the enum and `#[msg(\"Cannot decrement below zero\")]` on the Underflow variant"
         ],
         "questions": null,
         "prompt": null,
@@ -1345,12 +1306,11 @@
         "network": null,
         "idl": null,
         "tutorNotes": [
-          "Learners reach for `CpiContext::new_with_signer` and a System `transfer` out of the vault. It compiles and deploys; on-chain it returns `Transfer: 'from' must not carry data`. The vault is owned by their program and holds 49 bytes, so the System Program will not debit it.",
-          "They debit the vault with no rent-floor check. It works while the vault is well funded and then fails the whole transaction with `InsufficientFundsForRent` once the balance nears the minimum for 49 bytes.",
-          "They hardcode 49 in `minimum_balance(...)` instead of `vault_info.data_len()`, which silently goes wrong the moment `VaultState` gains a field.",
-          "They retype `checked_sub` on `vault.balance` instead of calling the Course 2 `vault.withdraw(amount)?`, so the zero guard and the typed error are quietly dropped.",
-          "They add a second `#[error_code]` enum for the rent case. It compiles — both enums start at `ERROR_CODE_OFFSET` 6000, so the two first variants share error code 6000 and the client cannot tell them apart.",
-          "They add `system_program` to the Withdraw accounts struct out of habit. There is no CPI in this instruction, so there is no callee program for the runtime to load."
+          "Learners subtract before checking, so a decrement at zero underflows the `u64` and panics instead of returning the custom error.",
+          "They guard with `count >= 0`, which is always true for an unsigned integer and stops nothing — the meaningful check is strictly greater than zero.",
+          "They define the error enum but omit the `#[error_code]` attribute, so `require!` will not accept the variant.",
+          "They give the Decrement accounts struct different PDA seeds than Increment, so it resolves a different account than the one they initialized.",
+          "They handle the zero case by returning `Ok(())` and doing nothing, silently swallowing the error instead of surfacing it to the caller."
         ]
       },
       {
@@ -1370,99 +1330,55 @@
         "questions": [
           {
             "id": "q1",
-            "prompt": "A submission drops the `require!(remaining >= rent_floor, ...)` guard and debits the vault directly. A user then withdraws an amount that would leave the vault with fewer lamports than the rent-exempt minimum for its 49 bytes. Predict the outcome.",
+            "prompt": "`decrement` guards with `require!(counter.count > 0, ErrorCode::Underflow)`. What happens when a user calls decrement while count is 0?",
             "multiSelect": false,
             "options": [
               {
                 "id": "a",
-                "label": "The whole transaction fails with `TransactionError::InsufficientFundsForRent` — nothing moves, and the caller gets a runtime error instead of your typed `InsufficientFunds`.",
+                "label": "The instruction returns the Underflow error, the transaction fails, and no state changes",
                 "correct": true,
                 "feedback": null
               },
               {
                 "id": "b",
-                "label": "It succeeds. Rent collection was removed from Solana, so a low balance no longer matters.",
+                "label": "count wraps around to a huge u64 value",
                 "correct": false,
-                "feedback": "Rent *collection* is gone; rent *exemption* is still enforced at the end of every transaction. A rent-exempt account is not allowed to become rent-paying, which is exactly the transition this attempts."
+                "feedback": "That is exactly what the guard prevents. Without `require!`, subtracting 1 from 0 on a u64 would underflow-wrap; with it, the instruction fails cleanly and count stays 0."
               },
               {
                 "id": "c",
-                "label": "It succeeds, and the account is closed automatically once it drops below the minimum.",
+                "label": "count goes to -1",
                 "correct": false,
-                "feedback": "Nothing closes accounts implicitly. Closing is a deliberate act — zero the lamports and hand back the data — and a partial drop below the minimum is refused rather than converted into one."
-              },
-              {
-                "id": "d",
-                "label": "The instruction returns `VaultError::InsufficientFunds`, since the runtime maps the rent failure onto your error enum.",
-                "correct": false,
-                "feedback": "The runtime knows nothing about your enum. That mapping is the guard you just deleted — its whole job is to convert a runtime rejection you cannot label into an error the caller can read."
+                "feedback": "A `u64` cannot hold -1. Unguarded subtraction would wrap to a huge number; the `require!` guard rejects the call instead."
               }
             ],
-            "explanation": "The rent check compares an account's state before and after the transaction, and a transition from `RentExempt` to `RentPaying` is refused. So the failure is real, it is transaction-wide, and it arrives as an opaque runtime error. Checking the floor yourself with `Rent::get()?.minimum_balance(vault_info.data_len())` is how the caller finds out what they actually did wrong."
+            "explanation": "`require!` returns the custom error and aborts the instruction when the condition is false, so a decrement at zero fails and leaves state untouched. This is the on-chain defense against u64 underflow wrapping 0 into a near-limitless value — a real class of bug."
           },
           {
             "id": "q2",
-            "prompt": "Wanting a clearer message for the rent case, a submission adds `#[error_code] pub enum WithdrawError { #[msg(\"Would break rent exemption\")] BelowRentFloor }` alongside the Course 2 `VaultError`. Predict the outcome.",
+            "prompt": "What does `#[error_code]` on the `ErrorCode` enum plus `#[msg]` on the `Underflow` variant give you?",
             "multiSelect": false,
             "options": [
               {
                 "id": "a",
-                "label": "It compiles — and both enums start at `ERROR_CODE_OFFSET`, so `BelowRentFloor` and `VaultError::Overflow` are both error code 6000 and no client can tell them apart.",
+                "label": "A program-specific error whose human-readable message is surfaced to clients when the instruction fails",
                 "correct": true,
                 "feedback": null
               },
               {
                 "id": "b",
-                "label": "It fails to compile. Anchor 1.0 permits only one `#[error_code]` enum per program.",
+                "label": "A compile-time check that count never underflows",
                 "correct": false,
-                "feedback": "This is the version of the rule you will read almost everywhere, and it is wrong — verified on the toolchain that grades you. Lessons 2 and 3 told you to keep one enum, and that advice stands; what they were careful not to say is that the compiler enforces it. It does not. Two enums compile silently, which is worse than a compile error, because the collision only shows up in a client trying to interpret code 6000."
+                "feedback": "The compiler does not prove that — the runtime `require!` does. `#[error_code]` and `#[msg]` just define the error and the message clients see."
               },
               {
                 "id": "c",
-                "label": "It compiles, and Anchor offsets the second enum automatically so the codes stay distinct.",
+                "label": "Automatic retry of the failed instruction",
                 "correct": false,
-                "feedback": "There is no automatic offsetting. `impl From<E> for u32` adds the same `ERROR_CODE_OFFSET` for every enum; you have to pass an offset yourself with `#[error_code(offset = ...)]` if you really want two."
-              },
-              {
-                "id": "d",
-                "label": "It compiles but the second enum is stripped from the IDL, so clients see nothing at all.",
-                "correct": false,
-                "feedback": "Both enums are emitted. The problem is not absence, it is ambiguity — two different names claiming the same number."
+                "feedback": "There is no automatic retry. The macros define a typed error and message; the transaction simply fails and the client reads the message."
               }
             ],
-            "explanation": "One enum per program is the right *practice*, but not for the reason usually given. `#[error_code]` generates `impl From<Enum> for u32 { e as u32 + ERROR_CODE_OFFSET }`, and `ERROR_CODE_OFFSET` is 6000 for every enum, so a second enum's variants shadow the first enum's codes one for one. Course 2's `VaultError` already has `InsufficientFunds`; reuse it."
-          },
-          {
-            "id": "q3",
-            "prompt": "`Deposit` declares `system_program: Program<'info, System>` and `Withdraw` does not. Why is the asymmetry correct?",
-            "multiSelect": false,
-            "options": [
-              {
-                "id": "a",
-                "label": "`deposit` makes a CPI and the runtime must have the callee's program account loaded; `withdraw` makes no CPI, because a program may debit an account it owns directly.",
-                "correct": true,
-                "feedback": null
-              },
-              {
-                "id": "b",
-                "label": "Because `withdraw` is a read-only instruction and read-only instructions never need the System Program.",
-                "correct": false,
-                "feedback": "`withdraw` mutates two lamport balances and the vault's data — it is about as far from read-only as an instruction gets. The reason is the absence of a CPI, not the absence of writes."
-              },
-              {
-                "id": "c",
-                "label": "Anchor injects the System Program automatically for instructions that only move lamports.",
-                "correct": false,
-                "feedback": "Anchor never injects accounts. Anything the instruction needs must be declared, which is why omitting it from an `init` instruction gives you a trait-bound error rather than working silently."
-              },
-              {
-                "id": "d",
-                "label": "Because the vault signs for itself in `withdraw`, replacing the need for the System Program.",
-                "correct": false,
-                "feedback": "Nothing signs in `withdraw`. That is the lesson: the seeds would have proved authorisation, and authorisation was never what was missing."
-              }
-            ],
-            "explanation": "A CPI needs its callee present in the transaction, so `deposit` declares the System Program. `withdraw` asks no other program for anything — your program owns the vault, and owners may move their own accounts' lamports with `try_borrow_mut_lamports`. If your answer to `withdraw` needed the System Program, it was the wrong answer."
+            "explanation": "`#[error_code]` turns the enum into Anchor program errors with stable codes, and `#[msg]` attaches the readable string returned to clients on failure. Combined with `require!`, your program enforces its own rules and explains violations to the caller."
           }
         ],
         "prompt": null,
@@ -1475,15 +1391,15 @@
   },
   {
     "_id": "lesson-bfsp-define-counter",
-    "title": "Define the Vault Account",
-    "slug": "define-the-vault-account",
+    "title": "Define a Counter Account",
+    "slug": "define-counter-account",
     "blocks": [
       {
         "key": "intro",
         "_type": "prose",
         "produces": null,
         "consumes": null,
-        "src": "# Define the Vault Account\n\n> **Version stamp — checked 2026-07-26.** `anchor-lang 1.1.2` (published 2026-06-26) · `cargo-build-sbf` with platform-tools v1.54 (rustc 1.89) · `borsh` resolves to **1.8.0** · edition 2021. Every compiler message quoted below was produced by compiling this lesson's file on that toolchain. Scope of the harness: it pins the field names, their types and the `bump` constraint. It cannot see whether your `space =` expression is the right number — see \"The one thing the build cannot check\".\n\nYou have derived the size. You have derived the address. What you have not done is write the whole\naccounts struct yourself, in one piece, and that is this lesson.\n\nEvery line you need is in the file, commented out and out of order. Two of them belong nowhere. Your\njob is to pick, order and uncomment — not to invent.\n\n## What an accounts struct is for\n\n`#[derive(Accounts)]` is not a parameter list. It is a **validation contract**, checked by generated\ncode before your handler body runs. Each field says \"an account of this type, satisfying these\nconstraints, or the instruction fails.\"\n\n`InitializeVault` needs three accounts, each for a different reason:\n\n```\nvault           the account being created. Program-owned, PDA-addressed, 49 bytes\nuser            who is paying, and who the vault will belong to\nsystem_program  the program that actually allocates the bytes\n```\n\n## The five constraints on the vault\n\n```rust\ninit                                          // create it\npayer = user                                  // this account funds the rent deposit\nspace = 8 + 32 + 8 + 1                        // 49 bytes, derived not copied\nseeds = [b\"vault\", user.key().as_ref()]       // one vault per wallet\nbump                                          // at the canonical address, checked\n```\n\n`init` is the one that does the work, and it does more than it looks like:\n\n- allocates `space` bytes,\n- assigns the account's **owner** to your program id,\n- moves the rent-exempt deposit from `payer`,\n- writes `VaultState`'s 8-byte discriminator into the front,\n- and does all of that by **calling the System Program** — which is why `system_program` has to be in\n  the struct.\n\nThat last point is not a detail. Anchor does not inject accounts. If `init` needs the System Program,\nyou declare the System Program.\n\n## Why `user` needs both `mut` and `Signer`\n\nTwo separate facts about the same account, enforced separately.\n\n`Signer<'info>` says the transaction carries this account's signature. `#[account(mut)]` says this\ninstruction changes the account — and it does, because `payer = user` debits about 0.00123 SOL of rent\ndeposit from it.\n\nMiss the `mut` and Anchor rejects the instruction rather than silently spending someone's lamports. The\nruntime's rule is the broader one: **any account whose lamports or data change must be declared\nwritable**, all the way up at the transaction level. `mut` is how you declare it here.\n\n## The two lines that belong nowhere\n\nOne pool entry is `rent = rent`. That constraint was **removed in Anchor 0.31** — Anchor reads the rent\nparameters itself and derives the deposit from `space`. Use it and the build stops.\n\nThe other is `mut,` sitting among the vault's constraints. It is the line people reach for out of\nreflex, because the vault is obviously about to be written to. But the vault does not exist yet, and\n`mut` means \"this existing account will be modified.\" `init` is the request to bring an account into\nbeing, and it implies the write. Ask for both, or for `mut` alone with `space` and `payer` beside it,\nand Anchor tells you the combination is wrong.\n\nBoth traps compile-fail, which is the mercy of this rung. The one that does *not* compile-fail is\n`space`.\n\n## The one thing the build cannot check\n\n`space = 8 + 32 + 8 + 1` and `space = 8 + 999` compile identically. Nothing in Rust, nothing in Anchor\nand nothing in the grader compares your `space` to your struct. An account sized 8 bytes short deploys\nfine and fails on first write; an account sized 1024 bytes deploys fine and quietly locks twenty times\nthe rent deposit, per vault, for as long as it exists.\n\nThat is why lesson 1 walked the arithmetic instead of handing you the number, and why\n`8 + VaultState::INIT_SPACE` is what you would reach for in production. Here you write the sum, because\nhere the point is knowing what it is made of.\n\n## Requirements\n\n1. Replace `pub struct InitializeVault {}` with pool line (1). Note what is different about it, and why\n   an empty struct did not need it.\n2. Give the `vault` field its five constraints, inside one `#[account( ... )]`.\n3. Add the `user` field, as a mutable `Signer`.\n4. Add the `system_program` field.\n5. Leave the two dead pool lines alone.\n\nThe verification harness at the bottom of the file names every field and type a passing answer must\nhave. Read it — it is the acceptance criteria, written in Rust.\n",
+        "src": "# Challenge: Define a Counter Account (PDA)\n\nAdd a `Counter` account struct and update the `Initialize` accounts to create it as a **Program Derived Address** (PDA).\n\n## What is a PDA?\n\nA PDA is an account address derived deterministically from **seeds** and the **program ID**. Unlike keypair accounts, PDAs don't have a private key — the program itself controls them. The same seeds always produce the same address.\n\nFor our counter: `seeds = [\"counter\", user_wallet_pubkey]` means each wallet gets exactly one counter per program.\n\n## Requirements\n\n1. Add a `Counter` struct with `#[account]` attribute containing `pub count: u64` and `pub authority: Pubkey`\n2. Add lifetime `<'info>` to the `Initialize` struct\n3. Add a `counter` field with `#[account(init, payer = user, space = 8 + 8 + 32, seeds = [b\"counter\", user.key().as_ref()], bump)]`\n4. Add a `user` field as `Signer<'info>` with `#[account(mut)]`\n5. Add `system_program` as `Program<'info, System>`\n\n## What Each Constraint Does\n\n- `init` — creates the account (allocates space, assigns owner)\n- `payer = user` — the `user` account pays the rent deposit\n- `space = 8 + 8 + 32` — 8 bytes discriminator + 8 bytes `u64` + 32 bytes `Pubkey`\n- `seeds` — the byte arrays used to derive the PDA address\n- `bump` — Anchor finds the valid bump seed automatically\n- `mut` on `user` — required because their lamport balance changes (pays rent)\n\n## Tips\n\n- The `Counter` struct goes outside the `#[program]` module\n- The `Initialize` struct needs a lifetime parameter: `pub struct Initialize<'info>`\n- Make sure `counter` has type `Account<'info, Counter>`\n- The `authority` field records who created the counter (useful for access control later)\n",
         "url": null,
         "language": null,
         "buildType": null,
@@ -1509,44 +1425,32 @@
         "language": "rust",
         "buildType": "buildable",
         "deployable": false,
-        "starter": "use anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n// ─────────────────────────────────────────────────────────────────────────────\n// Your Course 2 vault core, imported and not retyped. Nothing in here changes.\n// ─────────────────────────────────────────────────────────────────────────────\npub mod vault {\n    use super::*;\n\n    #[account]\n    #[derive(InitSpace)]\n    pub struct VaultState {\n        pub owner: Pubkey,\n        pub balance: u64,\n        pub bump: u8,\n    }\n\n    #[error_code]\n    pub enum VaultError {\n        #[msg(\"Deposit would overflow the vault balance\")]\n        Overflow,\n        #[msg(\"Withdrawal is larger than the vault balance\")]\n        InsufficientFunds,\n        #[msg(\"Amount must be greater than zero\")]\n        ZeroAmount,\n        #[msg(\"Signer is not the vault owner\")]\n        NotOwner,\n    }\n\n    impl VaultState {\n        pub fn deposit(&mut self, amount: u64) -> Result<()> {\n            require!(amount > 0, VaultError::ZeroAmount);\n            self.balance = self\n                .balance\n                .checked_add(amount)\n                .ok_or(VaultError::Overflow)?;\n            Ok(())\n        }\n\n        pub fn withdraw(&mut self, amount: u64) -> Result<()> {\n            require!(amount > 0, VaultError::ZeroAmount);\n            self.balance = self\n                .balance\n                .checked_sub(amount)\n                .ok_or(VaultError::InsufficientFunds)?;\n            Ok(())\n        }\n    }\n}\n\npub use vault::{VaultError, VaultState};\n\n#[program]\npub mod vault_program {\n    use super::*;\n\n    pub fn initialize_vault(ctx: Context<InitializeVault>) -> Result<()> {\n        let vault = &mut ctx.accounts.vault;\n        vault.owner = ctx.accounts.user.key();\n        vault.balance = 0;\n        vault.bump = ctx.bumps.vault;\n        msg!(\"Vault initialized for {}\", vault.owner);\n        Ok(())\n    }\n\n    pub fn vault_info(_ctx: Context<VaultInfo>) -> Result<()> {\n        msg!(\"Vault program online\");\n        Ok(())\n    }\n}\n\n// ─────────────────────────────────────────────────────────────────────────────\n// THE FRAGMENT POOL\n//\n// Every line `InitializeVault` needs is here, out of order. Two of them belong\n// nowhere at all. Assemble the struct below from the ones you want; leave the\n// rest where they are.\n//\n//   (1)   pub struct InitializeVault<'info> {\n//   (2)       pub system_program: Program<'info, System>,\n//   (3)           space = 8 + 32 + 8 + 1,\n//   (4)       pub vault: Account<'info, VaultState>,\n//   (5)           rent = rent,\n//   (6)       #[account(mut)]\n//   (7)           seeds = [b\"vault\", user.key().as_ref()],\n//   (8)           init,\n//   (9)       pub user: Signer<'info>,\n//  (10)           bump\n//  (11)           payer = user,\n//  (12)           mut,\n//\n// The two indent levels are a hint: the ones indented further are constraints\n// and go inside `#[account( ... )]`. The others are fields of the struct.\n//\n// On the two lines that belong nowhere:\n//   · One is a constraint Anchor deleted. The build refuses it with a bare\n//     `error: Invalid attribute` pointing at the line — it will not tell you\n//     why, which is the point of knowing before you press the button.\n//   · The other is the constraint people reach for out of habit when an account\n//     is about to be written to. It is the wrong one here, because this account\n//     does not exist yet, and \"write to it\" and \"bring it into existence\" are\n//     different requests.\n//\n// One thing is not in the pool and is not optional: line (1) replaces the\n// `InitializeVault` below, and the difference between them is the part that\n// matters.\n// ─────────────────────────────────────────────────────────────────────────────\n\n// TODO: assemble InitializeVault from the pool above, replacing this.\n#[derive(Accounts)]\npub struct InitializeVault {}\n\n#[derive(Accounts)]\npub struct VaultInfo {}\n\n// ─────────────────────────────────────────────────────────────────────────────\n// VERIFICATION HARNESS — DO NOT EDIT ANYTHING BELOW THIS LINE.\n//\n// A TYPE check, not a behaviour check. Grading is compile-success: the build\n// server compiles the file and reports whether it built. Nothing reads your\n// source and there are no hidden tests on the Rust path — so the harness names,\n// in Rust, every item a passing file must have, and an absent or wrongly-typed\n// one becomes a compile error the grader already catches.\n//\n// It reaches: the three field names and their exact types, the lifetime on the\n// struct, and that `vault` carries a `bump` constraint (which Anchor accepts\n// only alongside `seeds`).\n//\n// It cannot reach: whether `space` is the right number. `8 + 32 + 8 + 1` and\n// `8 + 999` compile identically. That one is on you — which is why you derived\n// it two lessons ago instead of copying it.\n// ─────────────────────────────────────────────────────────────────────────────\n#[doc(hidden)]\n#[allow(dead_code)]\nmod verify {\n    use super::*;\n\n    const _: () = assert!(VaultState::DISCRIMINATOR.len() == 8);\n    const _: () = assert!(VaultState::INIT_SPACE == 41);\n\n    fn pin_bump(bumps: &InitializeVaultBumps) -> u8 {\n        bumps.vault\n    }\n\n    fn pin_vault<'info>(a: &'info InitializeVault<'info>) -> &'info Account<'info, VaultState> {\n        &a.vault\n    }\n    fn pin_user<'info>(a: &'info InitializeVault<'info>) -> &'info Signer<'info> {\n        &a.user\n    }\n    fn pin_system<'info>(a: &'info InitializeVault<'info>) -> &'info Program<'info, System> {\n        &a.system_program\n    }\n}\n",
-        "solution": "use anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n// ─────────────────────────────────────────────────────────────────────────────\n// Your Course 2 vault core, imported and not retyped.\n// ─────────────────────────────────────────────────────────────────────────────\npub mod vault {\n    use super::*;\n\n    #[account]\n    #[derive(InitSpace)]\n    pub struct VaultState {\n        pub owner: Pubkey,\n        pub balance: u64,\n        pub bump: u8,\n    }\n\n    #[error_code]\n    pub enum VaultError {\n        #[msg(\"Deposit would overflow the vault balance\")]\n        Overflow,\n        #[msg(\"Withdrawal is larger than the vault balance\")]\n        InsufficientFunds,\n        #[msg(\"Amount must be greater than zero\")]\n        ZeroAmount,\n        #[msg(\"Signer is not the vault owner\")]\n        NotOwner,\n    }\n\n    impl VaultState {\n        pub fn deposit(&mut self, amount: u64) -> Result<()> {\n            require!(amount > 0, VaultError::ZeroAmount);\n            self.balance = self\n                .balance\n                .checked_add(amount)\n                .ok_or(VaultError::Overflow)?;\n            Ok(())\n        }\n\n        pub fn withdraw(&mut self, amount: u64) -> Result<()> {\n            require!(amount > 0, VaultError::ZeroAmount);\n            self.balance = self\n                .balance\n                .checked_sub(amount)\n                .ok_or(VaultError::InsufficientFunds)?;\n            Ok(())\n        }\n    }\n}\n\npub use vault::{VaultError, VaultState};\n\n#[program]\npub mod vault_program {\n    use super::*;\n\n    pub fn initialize_vault(ctx: Context<InitializeVault>) -> Result<()> {\n        let vault = &mut ctx.accounts.vault;\n        vault.owner = ctx.accounts.user.key();\n        vault.balance = 0;\n        vault.bump = ctx.bumps.vault;\n        msg!(\"Vault initialized for {}\", vault.owner);\n        Ok(())\n    }\n\n    pub fn vault_info(_ctx: Context<VaultInfo>) -> Result<()> {\n        msg!(\"Vault program online\");\n        Ok(())\n    }\n}\n\n// One correct assembly. The three fields may be declared in any order, and the\n// constraints inside `#[account(...)]` in any order too. What is fixed is which\n// lines are here at all.\n//\n// Pool lines (5) `rent = rent` and (12) `mut,` are not used:\n//   · `rent = rent` was removed in Anchor 0.31. Anchor reads the rent parameters\n//     itself and derives the deposit from `space`.\n//   · `mut` on the vault would be asking to write an account that already\n//     exists. `init` is the request to create it — allocate `space` bytes, set\n//     the owner to this program, and fund the rent-exempt deposit from `payer`.\n//     `init` implies the write.\n#[derive(Accounts)]\npub struct InitializeVault<'info> {\n    #[account(\n        init,\n        payer = user,\n        space = 8 + 32 + 8 + 1,\n        seeds = [b\"vault\", user.key().as_ref()],\n        bump\n    )]\n    pub vault: Account<'info, VaultState>,\n    // `mut` because `payer = user` debits this account's lamports for the rent\n    // deposit. `Signer` because someone has to authorize spending them. Two\n    // separate facts, two separate pieces of syntax.\n    #[account(mut)]\n    pub user: Signer<'info>,\n    // `init` creates the account by calling the System Program, so the System\n    // Program has to be in the account list. Anchor does not add it for you.\n    pub system_program: Program<'info, System>,\n}\n\n#[derive(Accounts)]\npub struct VaultInfo {}\n\n// ─────────────────────────────────────────────────────────────────────────────\n// VERIFICATION HARNESS — DO NOT EDIT ANYTHING BELOW THIS LINE.\n// A type check, not a behaviour check. See the starter for its exact reach.\n// ─────────────────────────────────────────────────────────────────────────────\n#[doc(hidden)]\n#[allow(dead_code)]\nmod verify {\n    use super::*;\n\n    const _: () = assert!(VaultState::DISCRIMINATOR.len() == 8);\n    const _: () = assert!(VaultState::INIT_SPACE == 41);\n\n    fn pin_bump(bumps: &InitializeVaultBumps) -> u8 {\n        bumps.vault\n    }\n\n    fn pin_vault<'info>(a: &'info InitializeVault<'info>) -> &'info Account<'info, VaultState> {\n        &a.vault\n    }\n    fn pin_user<'info>(a: &'info InitializeVault<'info>) -> &'info Signer<'info> {\n        &a.user\n    }\n    fn pin_system<'info>(a: &'info InitializeVault<'info>) -> &'info Program<'info, System> {\n        &a.system_program\n    }\n}\n",
+        "starter": "use anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n#[program]\npub mod academy_program {\n    use super::*;\n\n    pub fn initialize(_ctx: Context<Initialize>) -> Result<()> {\n        msg!(\"Superteam Academy default program\");\n        Ok(())\n    }\n\n    pub fn greet(_ctx: Context<Greet>) -> Result<()> {\n        msg!(\"Hello, Solana!\");\n        Ok(())\n    }\n}\n\n// TODO: Update Initialize to create a Counter PDA account\n// Use seeds = [b\"counter\", user.key().as_ref()] and bump\n#[derive(Accounts)]\npub struct Initialize {}\n\n#[derive(Accounts)]\npub struct Greet {}\n\n// TODO: Add a Counter account struct with count: u64 and authority: Pubkey\n",
+        "solution": "use anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n#[program]\npub mod academy_program {\n    use super::*;\n\n    pub fn initialize(_ctx: Context<Initialize>) -> Result<()> {\n        msg!(\"Superteam Academy default program\");\n        Ok(())\n    }\n\n    pub fn greet(_ctx: Context<Greet>) -> Result<()> {\n        msg!(\"Hello, Solana!\");\n        Ok(())\n    }\n}\n\n#[derive(Accounts)]\npub struct Initialize<'info> {\n    #[account(\n        init,\n        payer = user,\n        space = 8 + 8 + 32,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n    pub system_program: Program<'info, System>,\n}\n\n#[derive(Accounts)]\npub struct Greet {}\n\n#[account]\npub struct Counter {\n    pub count: u64,\n    pub authority: Pubkey,\n}\n",
         "tests": [
           {
-            "id": "t1",
-            "description": "The file compiles on the build server against anchor-lang 1.1.2",
+            "id": "test-1",
+            "description": "Program compiles successfully",
             "input": "",
             "expectedOutput": "true"
           },
           {
-            "id": "t2",
-            "description": "Compiles ⇒ InitializeVault carries the <'info> lifetime and holds account references",
+            "id": "test-2",
+            "description": "Counter struct is defined",
             "input": "",
             "expectedOutput": "true"
           },
           {
-            "id": "t3",
-            "description": "Compiles ⇒ vault is Account<'info, VaultState>, user is a mutable Signer, system_program is Program<'info, System>",
-            "input": "",
-            "expectedOutput": "true"
-          },
-          {
-            "id": "t4",
-            "description": "Compiles ⇒ the vault carries seeds + bump, so ctx.bumps.vault exists",
-            "input": "",
-            "expectedOutput": "true"
-          },
-          {
-            "id": "t5",
-            "description": "Compiles ⇒ neither dead pool line was used — rent was removed in 0.31, and mut cannot create an account",
+            "id": "test-3",
+            "description": "Initialize struct has account constraints",
             "input": "",
             "expectedOutput": "true"
           }
         ],
         "hints": [
-          "Start with pool line (1). The struct in the file is `pub struct InitializeVault {}` and the pool's version is `pub struct InitializeVault<'info> {`. An empty struct holds nothing, so it needs no lifetime; the moment it holds borrowed account references it needs one, and every field type in the pool mentions `'info` to prove it. Get this wrong and the errors talk about lifetimes rather than fields, and you will edit the wrong line for ten minutes.",
-          "The vault takes five constraint lines inside one `#[account( ... )]` — pool (8), (11), (3), (7), (10) — and pool (4) is the field itself. Note that (10) `bump` is the only one with no trailing comma, because it comes last. Then two more fields: (6) above (9) for the user, and (2) for the System Program.",
-          "Pool (5) `rent = rent` and (12) `mut,` are the two that belong nowhere. `rent` was removed in Anchor 0.31 and the build refuses it outright. `mut` on the vault is the subtler one: it asks to modify an account that does not exist yet, and `init` is the request that brings it into existence — `init` already implies the write."
+          "Start by adding the Counter struct at the bottom: `#[account]\\npub struct Counter { pub count: u64, pub authority: Pubkey }`",
+          "The Initialize struct needs a lifetime: `pub struct Initialize<'info>` with three fields: counter, user, and system_program",
+          "The counter field needs PDA constraints: `#[account(init, payer = user, space = 8 + 8 + 32, seeds = [b\"counter\", user.key().as_ref()], bump)]`"
         ],
         "questions": null,
         "prompt": null,
@@ -1555,12 +1459,11 @@
         "network": null,
         "idl": null,
         "tutorNotes": [
-          "Learners size `space` by adding up only the fields and forget the 8-byte discriminator Anchor prepends to every `#[account]`, so the account is under-allocated and the first write past the field boundary fails.",
-          "They omit the `<'info>` lifetime on `InitializeVault` once it holds account references, then get opaque lifetime errors and start editing field types instead of the struct header.",
-          "They leave `user` without `#[account(mut)]`; the payer that funds an `init` has its lamports changed and must be declared writable, and this one survives the build and fails at runtime.",
-          "They reach for `mut` on the vault, but the account is being created here for the first time, which needs `init` — `mut` is for an account that already exists.",
-          "They write the PDA seed as the string `\"vault\"` instead of the byte literal `b\"vault\"`, or drop `bump`, and then read the resulting error cascade as a lifetime problem.",
-          "They copy `rent = rent` from a pre-0.31 tutorial and conclude their Anchor install is broken, rather than that the constraint was deleted."
+          "Learners size `space` by adding up only the fields and forget the 8-byte discriminator Anchor prepends to every `#[account]`, so the account is under-allocated.",
+          "They omit the `<'info>` lifetime on the `Initialize` struct once it holds account references, then get opaque lifetime errors and edit the wrong line.",
+          "They leave `user` without `#[account(mut)]`; the payer that funds an `init` has its lamports changed and must be mutable.",
+          "They reach for `#[account(mut)]` on the counter, but the account is being created here for the first time, which needs `init`, not `mut`.",
+          "They write the PDA seed as a plain text string instead of a byte literal, or leave off `bump`, so the constraints do not compile."
         ]
       },
       {
@@ -1580,99 +1483,217 @@
         "questions": [
           {
             "id": "q1",
-            "prompt": "The vault is a PDA seeded on `b\"vault\"` plus the user's key. What does that seed choice actually guarantee?",
+            "prompt": "The counter is a PDA seeded on the counter label plus the user's public key. What does this seed choice guarantee?",
             "multiSelect": false,
             "options": [
               {
                 "id": "a",
-                "label": "One vault per wallet for this program, at an address any client can re-derive from the wallet alone",
+                "label": "Each wallet gets exactly one counter for this program, at a deterministic address anyone can re-derive",
                 "correct": true,
                 "feedback": null
               },
               {
                 "id": "b",
-                "label": "Each wallet can create as many vaults as it likes",
+                "label": "Each wallet can create unlimited counters",
                 "correct": false,
-                "feedback": "The seeds fix the address: for a given user those seeds derive exactly one. A second `init` there fails, because the account already exists. Multiple vaults per wallet would need a third seed in the list — an index, or a mint."
+                "feedback": "The seeds fix the address: for a given user those seeds derive one address. A second init there fails — one counter per wallet."
               },
               {
                 "id": "c",
-                "label": "The vault has a private key that the user controls",
+                "label": "The counter has a private key the user controls",
                 "correct": false,
-                "feedback": "PDAs have no private key; that is the point of deriving off the curve. The program authorizes the address by presenting its seeds, and the user's key is an *input* to the derivation, not a key for the result."
-              },
-              {
-                "id": "d",
-                "label": "Only the user can pass the vault into an instruction",
-                "correct": false,
-                "feedback": "Anyone can put any address into an instruction's account list. What the seeds guarantee is that the address is derivable from the user's key, so someone else's vault fails the seeds check instead of being quietly accepted."
+                "feedback": "PDAs have no private key — that is the point. The program controls the PDA; the seeds just make its address deterministic."
               }
             ],
-            "explanation": "A PDA's address is a pure function of its seeds and the program id. Seeding with the user's pubkey gives one deterministic vault per wallet, re-derivable by any client with no lookup table and no private key — and the `bump` constraint is what turns \"derivable\" into \"checked on every call.\""
+            "explanation": "A PDA address is a pure function of its seeds and the program id. Seeding with the user's pubkey means one deterministic counter per wallet, re-derivable by any client, with no private key — the program signs for it via the bump."
           },
           {
             "id": "q2",
-            "prompt": "You forget `#[account(mut)]` on `user` but keep `payer = user`. Everything else is right. Predict what happens.",
+            "prompt": "Why does the `user` field need `#[account(mut)]` in `Initialize`?",
             "multiSelect": false,
             "options": [
               {
                 "id": "a",
-                "label": "It compiles, and every call fails at runtime — the payer's lamports change, so the account has to be declared writable",
+                "label": "Creating the counter with `init` debits rent from the user, changing their lamport balance — a mutation",
                 "correct": true,
                 "feedback": null
               },
               {
                 "id": "b",
-                "label": "It fails to compile — `payer` requires `mut` on the field it names",
+                "label": "Because the user signs the transaction",
                 "correct": false,
-                "feedback": "Anchor does not couple them at compile time. The constraint is checked when the instruction runs, which is exactly why this one gets deployed and then breaks on first use."
+                "feedback": "Signing is `Signer`, a separate thing. `mut` is required because the payer's lamports decrease to fund the new account's rent."
               },
               {
                 "id": "c",
-                "label": "It works — `Signer` implies writability, because signing is what authorizes spending",
+                "label": "Because the user's data is written into the counter",
                 "correct": false,
-                "feedback": "Signing and writing are separate declarations. A read-only `Signer` is perfectly normal: an authority that approves an action without paying for it. Paying is what needs `mut`."
-              },
-              {
-                "id": "d",
-                "label": "It works, and the rent deposit comes from the vault instead",
-                "correct": false,
-                "feedback": "The vault has no lamports yet — it is the account being created. `payer = user` names where the deposit comes from and there is no fallback."
+                "feedback": "The user account's own data is not modified. What changes is its lamport balance, since `payer = user` funds the rent — that is why it must be `mut`."
               }
             ],
-            "explanation": "`Signer` is about authorization, `mut` is about mutation, and the payer of an `init` is both. The runtime requires every account whose lamports or data change to be writable at the transaction level, so a missing `mut` is a runtime rejection — after a successful build and a successful deploy. Failures only reachable by running are exactly what module 4's LiteSVM lesson is about — it shows you the test that would catch this one."
+            "explanation": "`init` allocates the counter and `payer = user` funds its rent-exempt deposit, so the user's lamport balance decreases. Any account whose lamports or data change must be declared `mut`, or Anchor rejects the instruction."
+          }
+        ],
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      }
+    ]
+  },
+  {
+    "_id": "lesson-bfsp-deploy-to-devnet",
+    "title": "Deploy to Devnet",
+    "slug": "deploy-to-devnet",
+    "blocks": [
+      {
+        "key": "intro",
+        "_type": "prose",
+        "produces": null,
+        "consumes": null,
+        "src": "# Deploy to Devnet\n\nYou've built the complete counter program. Now compile it one final time and learn how to deploy it.\n\n## Final Build\n\nThe starter code is your complete counter program. Hit **Build** to compile it. When it succeeds, you'll see a **Build UUID** in the output — this is the identifier for your compiled `.so` binary.\n\n## What Happens After Build\n\nThe build server compiled your Rust code into a Solana program binary (`.so` file). To deploy it to Devnet, you'd run:\n\n```bash\n# Download the compiled binary\ncurl -H 'X-API-Key: YOUR_KEY' \\\n  https://build-server-url/deploy/YOUR_UUID \\\n  -o program.so\n\n# Deploy to Devnet\nsolana program deploy program.so --url devnet\n```\n\nThe `solana program deploy` command:\n1. Uploads the binary to a buffer account\n2. Creates the program account\n3. Sets the program as executable\n4. Returns the **Program ID** — the on-chain address of your program\n\n## Interacting with Your Program\n\nOnce deployed, anyone can call your program's instructions:\n\n```typescript\n// TypeScript client using Anchor\nconst program = new Program(idl, programId, provider);\n\n// Initialize a counter\nawait program.methods\n  .initialize()\n  .accounts({ counter: counterKeypair.publicKey })\n  .signers([counterKeypair])\n  .rpc();\n\n// Increment\nawait program.methods\n  .increment()\n  .accounts({ counter: counterKeypair.publicKey })\n  .rpc();\n```\n\n## What You've Accomplished\n\nYou wrote a Solana program from scratch:\n- **4 instructions**: initialize, greet, increment, decrement\n- **Account management**: init with payer, mutable state, space calculation\n- **Error handling**: Custom error enum with underflow protection\n- **Compilation**: cargo-build-sbf via the build server\n\nThis counter program follows the same patterns used by every production Anchor program on Solana. The complexity scales, but the fundamentals are the same.\n\n## Next Steps\n\n- **DeFi on Solana** course — build a token vault with PDAs and CPIs\n- **Deploy locally** — install the Solana CLI and Anchor to build on your machine\n- **Read the Anchor Book** — [book.anchor-lang.com](https://book.anchor-lang.com)\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "exercise",
+        "_type": "code",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": "rust",
+        "buildType": "buildable",
+        "deployable": false,
+        "starter": "use anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n#[program]\npub mod academy_program {\n    use super::*;\n\n    pub fn initialize(ctx: Context<Initialize>) -> Result<()> {\n        let counter = &mut ctx.accounts.counter;\n        counter.count = 0;\n        counter.authority = ctx.accounts.user.key();\n        msg!(\"Counter initialized!\");\n        Ok(())\n    }\n\n    pub fn greet(_ctx: Context<Greet>) -> Result<()> {\n        msg!(\"Hello, Solana!\");\n        Ok(())\n    }\n\n    pub fn increment(ctx: Context<Increment>) -> Result<()> {\n        let counter = &mut ctx.accounts.counter;\n        counter.count += 1;\n        Ok(())\n    }\n\n    pub fn decrement(ctx: Context<Decrement>) -> Result<()> {\n        let counter = &mut ctx.accounts.counter;\n        require!(counter.count > 0, ErrorCode::Underflow);\n        counter.count -= 1;\n        Ok(())\n    }\n}\n\n#[derive(Accounts)]\npub struct Initialize<'info> {\n    #[account(\n        init,\n        payer = user,\n        space = 8 + 8 + 32,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n    pub system_program: Program<'info, System>,\n}\n\n#[derive(Accounts)]\npub struct Greet {}\n\n#[derive(Accounts)]\npub struct Increment<'info> {\n    #[account(\n        mut,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    pub user: Signer<'info>,\n}\n\n#[derive(Accounts)]\npub struct Decrement<'info> {\n    #[account(\n        mut,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    pub user: Signer<'info>,\n}\n\n#[account]\npub struct Counter {\n    pub count: u64,\n    pub authority: Pubkey,\n}\n\n#[error_code]\npub enum ErrorCode {\n    #[msg(\"Cannot decrement below zero\")]\n    Underflow,\n}\n",
+        "solution": "use anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n#[program]\npub mod academy_program {\n    use super::*;\n\n    pub fn initialize(ctx: Context<Initialize>) -> Result<()> {\n        let counter = &mut ctx.accounts.counter;\n        counter.count = 0;\n        counter.authority = ctx.accounts.user.key();\n        msg!(\"Counter initialized!\");\n        Ok(())\n    }\n\n    pub fn greet(_ctx: Context<Greet>) -> Result<()> {\n        msg!(\"Hello, Solana!\");\n        Ok(())\n    }\n\n    pub fn increment(ctx: Context<Increment>) -> Result<()> {\n        let counter = &mut ctx.accounts.counter;\n        counter.count += 1;\n        Ok(())\n    }\n\n    pub fn decrement(ctx: Context<Decrement>) -> Result<()> {\n        let counter = &mut ctx.accounts.counter;\n        require!(counter.count > 0, ErrorCode::Underflow);\n        counter.count -= 1;\n        Ok(())\n    }\n}\n\n#[derive(Accounts)]\npub struct Initialize<'info> {\n    #[account(\n        init,\n        payer = user,\n        space = 8 + 8 + 32,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n    pub system_program: Program<'info, System>,\n}\n\n#[derive(Accounts)]\npub struct Greet {}\n\n#[derive(Accounts)]\npub struct Increment<'info> {\n    #[account(\n        mut,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    pub user: Signer<'info>,\n}\n\n#[derive(Accounts)]\npub struct Decrement<'info> {\n    #[account(\n        mut,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    pub user: Signer<'info>,\n}\n\n#[account]\npub struct Counter {\n    pub count: u64,\n    pub authority: Pubkey,\n}\n\n#[error_code]\npub enum ErrorCode {\n    #[msg(\"Cannot decrement below zero\")]\n    Underflow,\n}\n",
+        "tests": [
+          {
+            "id": "test-1",
+            "description": "Complete counter program compiles successfully",
+            "input": "",
+            "expectedOutput": "true"
+          }
+        ],
+        "hints": [
+          "This is the complete program from the previous challenge. Just click Build to compile it.",
+          "If you see errors, make sure you haven't accidentally modified the code. Click Reset Code to restore.",
+          "The build UUID in the output panel is your program's compiled binary identifier."
+        ],
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      }
+    ]
+  },
+  {
+    "_id": "lesson-bfsp-from-code-to-chain",
+    "title": "From Code to Chain",
+    "slug": "from-code-to-chain",
+    "blocks": [
+      {
+        "key": "intro",
+        "_type": "prose",
+        "produces": null,
+        "consumes": null,
+        "src": "# From Code to Chain\n\nYou've written Anchor programs in the previous courses. Now it's time to compile and deploy them for real.\n\n## The Build Pipeline\n\nWhen you write an Anchor program, it goes through several stages before it reaches the Solana blockchain:\n\n1. **Rust source code** — what you write in your editor\n2. **`cargo-build-sbf`** — the Solana compiler that transforms Rust into Solana Bytecode Format (SBF)\n3. **`.so` binary** — the compiled program, an ELF shared object file\n4. **`solana program deploy`** — uploads the binary to a Solana cluster\n\n## What is SBF?\n\nSolana Bytecode Format (SBF) is a variant of eBPF (extended Berkeley Packet Filter) adapted for the Solana runtime. It's a register-based instruction set designed for:\n\n- **Safety**: Programs run in a sandboxed VM with no access to the host system\n- **Performance**: Near-native execution speed\n- **Determinism**: Same inputs always produce the same outputs\n\n## The Build Server\n\nIn this course, you won't need a local Rust toolchain. The **Superteam Academy Build Server** handles compilation in the cloud:\n\n1. You write Anchor code in the browser editor\n2. Click **Build** to submit your code\n3. The build server runs `cargo-build-sbf` on your code\n4. You get back either compiler errors or a compiled binary UUID\n\nThe build server uses the same Anchor 0.32 and Solana SDK that you'd use locally. Think of it as a cloud-hosted `anchor build`.\n\n## What Gets Compiled\n\nYour `lib.rs` file is placed into a pre-configured Anchor project with:\n- `anchor-lang` 0.32.1 (with `init-if-needed` feature)\n- `anchor-spl` 0.32.1\n- `solana-program` via the Agave 3.0 toolchain\n\nThe build server rejects dangerous patterns (`std::process`, `std::fs`, `std::net`) to keep the sandbox secure.\n\n## Ready to Build?\n\nIn the next lesson, you'll hit the **Build** button for the first time. Your only job: see the green checkmark.\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "retrieval-close",
+        "_type": "quiz",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": [
+          {
+            "id": "q1",
+            "prompt": "The build server rejects programs that use `std::fs`, `std::net`, or `std::process`. Why would those never work in a deployed Solana program anyway?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "SBF programs run in a sandboxed VM with no access to the host's filesystem, network, or OS, so those calls have no meaning on-chain",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "They compile fine on-chain but slow the validator down",
+                "correct": false,
+                "feedback": "They cannot run at all — the SBF VM has no host access. The build server rejects them early rather than shipping a program that could never execute."
+              },
+              {
+                "id": "c",
+                "label": "They are blocked only to protect the build server, not the runtime",
+                "correct": false,
+                "feedback": "The sandbox is fundamental to the runtime too: an on-chain program has no OS to call. The build-server block just surfaces that constraint sooner."
+              }
+            ],
+            "explanation": "Solana programs compile to SBF and run in a deterministic, sandboxed VM. There is no filesystem, network, or process table on-chain, so those calls are meaningless — and determinism requires the same input to always yield the same output, which host I/O would break."
           },
           {
-            "id": "q3",
-            "prompt": "Why does `space` deserve more care than the other four constraints on the vault?",
+            "id": "q2",
+            "prompt": "What artifact does `cargo-build-sbf` produce, and what does `solana program deploy` do with it?",
             "multiSelect": false,
             "options": [
               {
                 "id": "a",
-                "label": "It is the only one whose wrong value still compiles and still deploys — the other four fail loudly",
+                "label": "A `.so` ELF binary of SBF bytecode; deploy uploads that binary to a cluster",
                 "correct": true,
                 "feedback": null
               },
               {
                 "id": "b",
-                "label": "It is the only one that costs compute units",
+                "label": "A JSON IDL; deploy registers it with the RPC",
                 "correct": false,
-                "feedback": "`space` costs nothing at runtime; it is a number baked into the account-creation call. Bare `bump` is the constraint with a per-call compute cost, because it re-runs the derivation search."
+                "feedback": "The IDL is separate metadata. The compiler output that gets deployed is the `.so` SBF binary — the executable itself."
               },
               {
                 "id": "c",
-                "label": "It can be changed later, unlike the others",
+                "label": "Raw Rust source; deploy compiles it on the validator",
                 "correct": false,
-                "feedback": "It is the least changeable of the five. The allocation is fixed at creation, and growing an account afterwards is a separate deliberate operation with its own payer. Seeds and bump, by contrast, are checks that simply re-run per instruction."
-              },
-              {
-                "id": "d",
-                "label": "Anchor validates the others against the struct but not `space`",
-                "correct": false,
-                "feedback": "Anchor validates none of them against `VaultState`. What makes the other four safe is that a wrong value is malformed syntax or a failed runtime check. A wrong `space` is a well-formed number."
+                "feedback": "Validators never compile source. Compilation to `.so` happens off-chain (here, on the build server); only the finished bytecode is uploaded."
               }
             ],
-            "explanation": "`init`, `payer`, `seeds` and `bump` all fail loudly — at build time for bad syntax, at runtime for a wrong address or an unsigned payer. `space` is a plain integer expression: too small and the account deploys and then fails on write, too large and it deploys and quietly locks extra rent deposit per vault for as long as it exists. Nothing anywhere reports it, which is why you derived it instead of copying it."
+            "explanation": "The pipeline is Rust source, then `cargo-build-sbf`, then a `.so` ELF containing SBF bytecode, then `solana program deploy` uploads that binary. Validators execute bytecode, never source — which is why the compile step happens before deployment."
           }
         ],
         "prompt": null,
@@ -1685,15 +1706,15 @@
   },
   {
     "_id": "lesson-bfsp-m4-airdrop",
-    "title": "Fund Your Wallet",
-    "slug": "fund-your-wallet",
+    "title": "Airdrop & Fund Your Wallet",
+    "slug": "airdrop-fund-wallet",
     "blocks": [
       {
         "key": "intro",
         "_type": "prose",
         "produces": null,
         "consumes": null,
-        "src": "# Fund Your Wallet\n\n> **Version stamp — checked 2026-07-26.** Rent constants from `solana-rent`; account-size constants from `solana-loader-v3-interface` (`size_of_program() = 36`, `size_of_programdata_metadata() = 45`, `size_of_buffer_metadata() = 37`). The 234,040-byte binary is this course's finished vault, compiled with `cargo-build-sbf --tools-version v1.54`. Faucet limits are policy, not protocol, and move without notice — treat the SOL figures as exact and the faucet rules as approximate.\n\nBefore deploying your program, you need devnet SOL to pay for the on-chain storage (called \"rent\").\n\n## You may already have some\n\nIf you came through Course 1 you funded this same wallet there, and it is very likely still holding SOL — devnet balances do not expire, and nothing in Courses 2 or 3 spent any. So check the balance in the widget below **before** you airdrop: if you are already at 4-5 SOL, you are done and the next lesson is waiting.\n\nIf Course 3 is your entry point, or the balance has drained, read on.\n\n## How Much SOL Do You Need?\n\nDeploying an Anchor program requires approximately **2 SOL** on devnet:\n- **~1.63 SOL** for the buffer account (temporary storage during upload)\n- **~1.63 SOL** for the **programdata** account, which holds your bytecode for the life of the program\n- **~0.00114 SOL** for the program account itself (it is only 36 bytes — a pointer, not the code)\n- **~0.3 SOL** for transaction fees (200+ transactions)\n\nThose figures are for a compiled Anchor program of roughly **229 KB**, which is what your vault actually comes out to. Most of that size is the framework's account-validation and error machinery, so it barely moves with the number of instructions you wrote — three instructions and thirty cost close to the same.\n\nRead that list again, because the two big numbers do not both stay spent. The buffer's deposit is **refunded automatically**: the deploy instruction drains the buffer back to your wallet in the same instruction that funds programdata. So you need ~2 SOL *on hand* to deploy, but you end up down roughly **1.63 SOL plus fees** — and that 1.63 stays locked as long as the program exists. Getting it back means `solana program close`, which permanently retires the program id.\n\n## The Devnet Faucet\n\nSolana provides a free faucet on devnet. The web faucet at [faucet.solana.com](https://faucet.solana.com) is the reliable path — airdrops through the public RPC (`solana airdrop`) are throttled more aggressively. The web faucet is rate-limited by **request frequency** (a maximum of 2 requests every 8 hours, as of mid-2026); signing in with GitHub raises that limit.\n\nUse the widget below to fund your wallet. You'll need at least 4-5 SOL to comfortably deploy — because of the request-frequency limit, that may take more than one faucet visit, which is expected, not a failure.\n\n> **Tip**: The faucet can be slow during peak hours. If you see \"faucet is busy,\" just wait 30-60 seconds and try again. This is normal — devnet is a shared resource.\n\n## The same rent, at a different scale\n\nThis is the rent-exempt deposit you already sized for the vault account in module 2 — `(128 + space) × 3480 × 2` — applied to something four thousand times larger. Nothing about the rule changed; only `space` did.\n\nRun it on the deploy accounts and the numbers above fall out:\n\n```\nprogramdata: (128 + 45 + 234,040) × 6,960  =  1,630,122,480 lamports  ≈  1.63 SOL\nprogram:     (128 +          36) × 6,960  =      1,141,440 lamports  ≈  0.00114 SOL\n```\n\nThe 45 and the 36 are the loader's own metadata headers, and 234,040 is your compiled `.so` in bytes. Note which account is expensive: the program account is a 36-byte pointer, and the bytecode lives in programdata.\n\nOne correction worth carrying forward from module 2: rent is a **deposit, not a meter**, and the buffer's deposit comes back to you automatically as part of deploying. The programdata deposit does not — that one is the real price of having a program on-chain.\n",
+        "src": "# Airdrop & Fund Your Wallet\n\nBefore deploying your program, you need devnet SOL to pay for the on-chain storage (called \"rent\").\n\n## How Much SOL Do You Need?\n\nDeploying an Anchor program requires approximately **2 SOL** on devnet:\n- **~1.4 SOL** for the buffer account (temporary storage during upload)\n- **~0.1 SOL** for the program account\n- **~0.3 SOL** for transaction fees (200+ transactions)\n\nThe good news: most of this rent is **reclaimable** after deployment.\n\n## The Devnet Faucet\n\nSolana provides a free faucet on devnet. The web faucet at [faucet.solana.com](https://faucet.solana.com) is the reliable path — airdrops through the public RPC (`solana airdrop`) are throttled more aggressively. The web faucet is rate-limited by **request frequency** (a maximum of 2 requests every 8 hours, as of mid-2026); signing in with GitHub raises that limit.\n\nUse the widget below to fund your wallet. You'll need at least 4-5 SOL to comfortably deploy — because of the request-frequency limit, that may take more than one faucet visit, which is expected, not a failure.\n\n> **Tip**: The faucet can be slow during peak hours. If you see \"faucet is busy,\" just wait 30-60 seconds and try again. This is normal — devnet is a shared resource.\n\n## What is Rent?\n\nOn Solana, every account must maintain a minimum balance called **rent**. This prevents spam accounts from filling up validator storage.\n\nThe rent amount depends on the account's data size:\n\n```\nrent = base_rent + (data_size * rent_per_byte)\n```\n\nFor a 200KB program binary, the buffer account rent is ~1.4 SOL.\n\nAccounts that maintain the minimum balance are **rent-exempt** — they won't be garbage collected.\n",
         "url": null,
         "language": null,
         "buildType": null,
@@ -1747,7 +1768,7 @@
         "questions": [
           {
             "id": "q1",
-            "prompt": "Deploying a ~229KB program needs ~1.63 SOL just for the buffer account. Why does the buffer cost scale with the program's size?",
+            "prompt": "Deploying a ~200KB program needs ~1.4 SOL just for the buffer account. Why does the buffer cost scale with the program's size?",
             "multiSelect": false,
             "options": [
               {
@@ -1766,10 +1787,10 @@
                 "id": "c",
                 "label": "The validator charges per instruction, and big programs have more instructions",
                 "correct": false,
-                "feedback": "The ~1.63 SOL is buffer-account rent, sized by the binary's byte length, not a per-instruction charge."
+                "feedback": "The ~1.4 SOL is buffer-account rent, sized by the binary's byte length, not a per-instruction charge."
               }
             ],
-            "explanation": "Deployment first uploads the binary into a temporary buffer account whose rent follows (128 + space) * 3480 * 2 — the same formula you used on the vault in module 2. A 229KB binary needs a 229KB buffer, hence ~1.63 SOL. That specific deposit does come back: the deploy instruction drains the buffer to your wallet as it funds programdata. What stays locked is the ~1.63 SOL on the programdata account, for as long as the program exists."
+            "explanation": "Deployment first uploads the binary into a temporary buffer account whose rent follows base + data_size * rent_per_byte. A 200KB binary needs a 200KB buffer, hence ~1.4 SOL — and because most of that rent is reclaimable, you get much of it back after finalizing."
           },
           {
             "id": "q2",
@@ -1786,16 +1807,16 @@
                 "id": "b",
                 "label": "Because half of every airdrop is burned",
                 "correct": false,
-                "feedback": "Airdrops are not burned. The buffer alone is ~1.63 SOL and fees ~0.3, so 2 SOL leaves no cushion; 4-5 gives comfortable margin."
+                "feedback": "Airdrops are not burned. The buffer alone can be ~1.4 SOL and fees ~0.3, so 2 SOL leaves no cushion; 4-5 gives comfortable margin."
               },
               {
                 "id": "c",
                 "label": "Because programs require a minimum 4 SOL balance to deploy",
                 "correct": false,
-                "feedback": "There is no fixed 4 SOL minimum — you need ~2 SOL on hand. You aim for 4-5 to absorb retries, fee spikes, and the 200+ transactions."
+                "feedback": "There is no fixed 4 SOL minimum — actual cost is ~2 SOL. You aim for 4-5 to absorb retries, fee spikes, and the 200+ transactions."
               }
             ],
-            "explanation": "You need ~2 SOL on hand (buffer ~1.63 refunded on deploy, programdata ~1.63 locked, program account ~0.00114, fees ~0.3 across 200+ transactions). Airdropping only 2 leaves zero room for a failed-and-resumed upload or fee variance, so the lesson buffers you to 4-5 SOL."
+            "explanation": "Real deployment cost is ~2 SOL (buffer ~1.4, program ~0.1, fees ~0.3 across 200+ transactions). Airdropping only 2 leaves zero room for a failed-and-resumed upload or fee variance, so the lesson buffers you to 4-5 SOL."
           }
         ],
         "prompt": null,
@@ -1808,7 +1829,7 @@
   },
   {
     "_id": "lesson-bfsp-m4-capstone",
-    "title": "What You've Built — and Writing It Up",
+    "title": "What You've Built",
     "slug": "what-you-built",
     "blocks": [
       {
@@ -1816,7 +1837,7 @@
         "_type": "prose",
         "produces": null,
         "consumes": null,
-        "src": "# What You've Built — and Writing It Up\n\n> **Version stamp — checked 2026-07-26.** `anchor-lang 1.1.2` · `cargo-build-sbf` with platform-tools v1.54 (rustc 1.89) · edition 2021 · on-chain IDL via the **Program Metadata Program** (`@solana-program/program-metadata`), not the removed `anchor idl init`. Every claim this lesson tells you to make about your own build is one that is true of the artifact you actually shipped.\n\nYou have a program id. It is live on a public network, anyone can look it up without asking you, and it did not exist eleven lessons ago.\n\n## Name the pieces\n\nVague recaps are worth nothing, so here is the specific list. Every item is something you can point at.\n\n| What you shipped                | Where it came from                                                                                                       |\n| ------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |\n| **The Course 2 vault core**     | `VaultState`, `VaultError`, `deposit`, `withdraw` — imported into module 1 unchanged, not retyped. The half of a program that has no runtime dependency |\n| **The vault PDA**               | A per-user, program-owned account at `[b\"vault\", your_key]` — 49 bytes, space derived rather than guessed, canonical bump stored at init |\n| **A System Program CPI**        | `transfer(CpiContext::new(System::id(), Transfer { … }), amount)` on deposit — the Anchor 1.0 shape, where `new` takes the program's ID rather than its `AccountInfo` |\n| **The instruction with no CPI** | `withdraw`, which debits the vault directly because your program owns it — and which therefore has no `system_program` in its accounts struct at all |\n| **A rent floor you enforced**   | `Rent::get()?.minimum_balance(data_len())`, checked before a lamport moves, so a too-large withdrawal returns your `InsufficientFunds` instead of the runtime's `InsufficientFundsForRent` |\n| **Account constraints**         | `seeds` + `bump = vault.bump` binding the vault to its signer, `Account<'info, VaultState>` enforcing the discriminator, an ownership `constraint` raising `NotOwner`, and a decision about `dup` |\n| **A tested-by-reading pre-flight** | The LiteSVM tier: what a test that actually runs `withdraw` asserts, and why compile-success cannot assert it            |\n| **A program id**                | Yours, on devnet, under the BPF Loader Upgradeable, with your wallet as upgrade authority                                 |\n| **An on-chain IDL**             | Published through the Program Metadata Program, reachable from the program id alone                                       |\n\nThe distinction worth keeping: **Anchor generated the boilerplate; you made every decision.** The discriminator, the deserialization, the create-account CPI, the error-code plumbing — macros wrote those. Which seeds. How much space. Where the bump lives. Which error names which failure. Which constraint stops which attack. Those were yours, and they are the part that transfers to the next program you write, in any framework.\n\n## Two concrete next steps\n\n### 1. Course 4 starts from what you just made\n\n**`dapp-and-sdk-with-kit`** takes the program id and the IDL from the last lesson, runs Codama over the IDL to generate a typed client, and puts a real interface on your vault. That is why publishing the IDL was a step rather than a footnote: the next course is told nothing about your program except its address.\n\nBring the id. Nothing else is needed.\n\n### 2. Turbin3, and paid work on Earn\n\n**Turbin3's** admission process includes a Rust prerequisite task that requires executing a transaction on-chain. You have done exactly that, with a program you wrote, and you can point at the signature.\n\n**Superteam Earn** lists bounties judged on submissions rather than résumés, and the shape of your artifact matches two categories of listing well:\n\n- **Program work.** Chapter listings for Anchor vaults, escrows and security templates have run in the **$300–$4,000 USDG** range, at roughly **7–62 submissions** each. Your vault is a smaller version of exactly that brief. Start with the [development listings](https://superteam.fun/earn/category/development/) and prefer small, tightly-scoped deliverables for a first submission.\n- **Writing about program work.** Educational modules and technical deep dives have paid **$1,500–$3,000** at roughly **10–50 competitors** — noticeably fewer people per dollar than the development side. That asymmetry is the single best-odds thing on the board for someone who has just built something and can explain it. It is also why the write-up below is a deliverable and not homework.\n\nTreat those ranges as the historical shape of the board, not a forecast, and never read one day's submission count as a competition rate.\n\nIf you have a larger idea, [Superteam grants](https://superteam.fun/earn/grants/) fund builders directly. A live devnet program is the strongest artifact a first application can carry.\n\n## The write-up\n\nThis is the second deliverable of the course, and the block below is where you draft it. It is never graded, awards no XP and gates nothing — it exists because the version of you that just finished this has information that disappears within a week.\n\nA structure that works, and roughly what belongs in each part:\n\n1. **What it is, in two sentences.** \"A per-user SOL vault on Solana devnet: an Anchor program with `initialize_vault`, `deposit` and `withdraw`, where the vault is a program-owned PDA that the program debits directly, above an enforced rent floor.\" Then the program id, as a link with `?cluster=devnet`.\n2. **One design decision, defended.** Not a tour — one choice. Why the canonical bump is stored in the account instead of re-derived, and what re-deriving costs. Or why `checked_sub` and a named error beat bare subtraction even with `overflow-checks = true`. One paragraph on a real decision beats five paragraphs of narration, and it is the paragraph a reviewer reads to decide whether you understood what you built.\n3. **The thing that broke, and how you found it.** Everyone's write-up has the happy path. Almost none have this. If you hit the deliberate compile error in module 2, or a transaction that failed with a custom error code you had to look up, that is the most useful paragraph you can write — for a reader and for a sponsor assessing whether you can debug.\n4. **What you would do differently.** Short, specific, no false modesty.\n\nTwo rules about claims, because they are the kind of thing that costs credibility:\n\n- Say **\"compiled against the real Anchor 1.1 toolchain.\"** Do not say \"unit tested\" — grading here is compile-only, and the LiteSVM tier is something you read rather than ran. The precise claim is more impressive than the loose one to anyone who knows the difference, and the loose one is checkable.\n- Link the program id rather than describing it. It is on a public network; a reader can verify every claim you make about it in about ten seconds. That verifiability is worth more than any certificate screenshot, and it is the actual asset this course produced.\n\nYour deployed program stays on devnet. Nothing expires, nothing is collected, and the id keeps resolving.\n",
+        "src": "# What You've Built\n\nCongratulations! You've completed the full Solana developer lifecycle:\n\n## Your Journey\n\n1. **Write Code** — You wrote a counter program in Rust using the Anchor framework\n2. **Compile** — The Superteam Academy Build Server compiled it to a Solana program binary\n3. **Deploy** — You deployed it to Solana Devnet using the BPF Loader Upgradeable\n4. **Interact** — You called instructions and watched on-chain state change in real time\n\n## What You Learned\n\n### Anchor Framework\n- `#[program]` — defines your instruction handlers\n- `#[derive(Accounts)]` — specifies account constraints\n- `#[account]` — defines on-chain data structures\n- `#[error_code]` — custom errors enforced by the runtime\n\n### On-Chain Concepts\n- **Accounts** are Solana's storage primitive (not key-value pairs)\n- **Discriminators** identify account types (first 8 bytes)\n- **Rent** prevents spam (accounts must maintain minimum balance)\n- **Transactions** are batches of instructions signed by wallets\n\n### Deployment Protocol\n- Programs are uploaded in **~1000-byte chunks** via the BPF Loader\n- A **buffer account** holds the binary during upload\n- The **program account** is a pointer to the executable data\n- Upgradeable programs can be updated by the upgrade authority\n\n## Ship It: Your First Paid Solana Work\n\nYou now have something most applicants don't: a program you wrote, compiled, and deployed yourself, live on a public network. The next step isn't another course — it's putting that skill in front of teams that pay for it.\n\n**Superteam Earn** lists bounties and projects from real Solana teams, judged on submissions, not resumes. This is where deployed-a-program skills convert into your first $500–$5,000 of paid Solana work:\n\n1. **Browse open development work** — start with the [development bounties on Superteam Earn](https://superteam.fun/earn/category/development/). Look for small, scoped bounties with a defined deliverable: they are the fastest way to a first paid submission.\n2. **Write about what you built** — [content bounties](https://superteam.fun/earn/category/content/) pay for technical writing. A walkthrough of the counter program you just deployed — what confused you, and how you worked through it — is exactly the material sponsors ask for.\n3. **Have a bigger idea? Apply for a grant** — [Superteam grants](https://superteam.fun/earn/grants/) fund builders directly (avg $5.5k Brazil grants). A live Devnet program is the strongest artifact a first grant application can include.\n\nWhatever you submit, link your deployed program. It is live on a public network — anyone can verify it, and that proof is worth more than any certificate screenshot.\n\n## Keep Building\n\n- **Install locally** — Set up the Anchor CLI on your machine for faster iteration\n- **Solana Frontend Development** — Put a UI on your program: wallet integration, reading on-chain state, sending transactions from the browser\n\nYour deployed program will continue to live on Devnet. You can interact with it anytime using the Solana CLI or any Anchor client.\n",
         "url": null,
         "language": null,
         "buildType": null,
@@ -1898,7 +1919,7 @@
           },
           {
             "id": "q2",
-            "prompt": "You want to fix a bug in your deployed vault. Which statement about the program account and its data is true?",
+            "prompt": "You want to fix a bug in your deployed counter. Which statement about the program account and its data is true?",
             "multiSelect": false,
             "options": [
               {
@@ -1915,323 +1936,16 @@
               },
               {
                 "id": "c",
-                "label": "Editing the program automatically wipes existing vault accounts",
+                "label": "Editing the program automatically wipes existing counter accounts",
                 "correct": false,
-                "feedback": "Vault accounts are separate state and survive an upgrade. Upgrading changes code, not the accounts your program created."
+                "feedback": "Counter accounts are separate state and survive an upgrade. Upgrading changes code, not the accounts your program created."
               }
             ],
-            "explanation": "An upgradeable program account references executable data that the upgrade authority can swap, so bug fixes reuse the same program id. Because state is stored in separate accounts, existing vaults persist across the upgrade — code and data are decoupled by design. That also means a change to `VaultState`'s layout is a data-migration problem, not a redeploy problem."
-          },
-          {
-            "id": "q3",
-            "prompt": "The build server reported a green build before you deployed. Precisely what did that prove?",
-            "multiSelect": false,
-            "options": [
-              {
-                "id": "a",
-                "label": "That the file compiles to an SBF binary against the real Anchor 1.1 toolchain — nothing about whether the instructions behave correctly",
-                "correct": true,
-                "feedback": null
-              },
-              {
-                "id": "b",
-                "label": "That the program compiles and its instructions produce the expected account state",
-                "correct": false,
-                "feedback": "Nothing ran. Grading on this path is compile-success only; the grader never executes an instruction and never reads your code. Behaviour is exactly what a green build cannot speak to."
-              },
-              {
-                "id": "c",
-                "label": "That the program compiles and passes the hidden tests attached to the lesson",
-                "correct": false,
-                "feedback": "There are no hidden tests on the Rust path — no `cargo test` step exists here. The single bit the server returns is whether compilation succeeded."
-              }
-            ],
-            "explanation": "A green build is one bit: it compiled. That bit is worth having, because Anchor's macros turn a large class of account-wiring mistakes into compile errors, and an uncompilable program cannot be deployed at all. It is also the whole of what was verified, which is why the pre-flight lesson listed eight ways to be green and wrong, and why the write-up should say \"compiled against the real Anchor 1.1 toolchain\" rather than \"tested\"."
-          },
-          {
-            "id": "q4",
-            "prompt": "Your vault account was created with `space = 8 + 32 + 8 + 1`. You now want to add a `deposit_count: u64` field. What does that cost you?",
-            "multiSelect": false,
-            "options": [
-              {
-                "id": "a",
-                "label": "A larger `space` for newly created vaults plus a migration for existing ones — an account's data length is fixed at creation and does not grow because the struct did",
-                "correct": true,
-                "feedback": null
-              },
-              {
-                "id": "b",
-                "label": "Nothing — you widen `space` and existing accounts resize on the next write",
-                "correct": false,
-                "feedback": "A wider `space` applies only to accounts created AFTER the upgrade. Existing accounts keep the 49 bytes they were allocated; nothing resizes them implicitly."
-              },
-              {
-                "id": "c",
-                "label": "Only more rent, charged automatically as the account grows",
-                "correct": false,
-                "feedback": "Two things wrong: accounts do not grow on their own, and rent is a one-time deposit rather than a running charge. A bigger account needs a bigger deposit at the moment it is allocated or reallocated."
-              }
-            ],
-            "explanation": "Space is allocated once, at creation, and the rent deposit is sized to it then. Add a field and new vaults get the larger layout while old ones still hold 49 bytes with no room for it — so deserializing an old account against the new struct fails. This is why module 2 made you derive the sum aloud rather than copy someone else's `8 + 8 + 32`: a number you derived stays honest when the struct changes. The migration problem is yours either way."
-          },
-          {
-            "id": "q5",
-            "prompt": "Three addresses are involved in your deployment: your wallet, the vault PDA, and the program account. Which of them has a private key?",
-            "multiSelect": false,
-            "options": [
-              {
-                "id": "a",
-                "label": "Only your wallet. The vault PDA is off-curve by construction, and the program account's address came from a keypair that is irrelevant after deployment",
-                "correct": true,
-                "feedback": null
-              },
-              {
-                "id": "b",
-                "label": "Your wallet and the program account — the program's keypair is what authorises upgrades",
-                "correct": false,
-                "feedback": "Upgrades are authorised by the UPGRADE AUTHORITY, which is your wallet, not by the program's own keypair. That keypair's only job was to fix the address at deploy time."
-              },
-              {
-                "id": "c",
-                "label": "All three — every Solana address is a public key with a matching private key somewhere",
-                "correct": false,
-                "feedback": "This is the assumption PDAs exist to break. Derivation deliberately retries until the digest is NOT a valid curve point, so for a PDA no private key exists at all."
-              }
-            ],
-            "explanation": "\"Address\" and \"public key\" are not synonyms on Solana. Your wallet is a keypair. The program account's address came from a keypair, but authority over the program is held by the upgrade authority, not that key. The vault PDA has no key by design — it is off the ed25519 curve, and the only way to authorise it is a program the runtime can check. Sorting these three apart is most of the account model."
-          },
-          {
-            "id": "q6",
-            "prompt": "`Deposit` declares `pub system_program: Program<'info, System>`. `Withdraw` does not. What single rule explains both?",
-            "multiSelect": false,
-            "options": [
-              {
-                "id": "a",
-                "label": "A program may only debit accounts it owns, and a CPI's callee must appear in the account list. Deposit debits a System-owned wallet so it needs System present; withdraw debits your own vault, needs no CPI, so there is no callee to load",
-                "correct": true,
-                "feedback": null
-              },
-              {
-                "id": "b",
-                "label": "Withdraw omits it as an optimisation — one fewer account keeps the transaction under the size limit",
-                "correct": false,
-                "feedback": "It is not a size optimisation. There is genuinely no CPI in `withdraw`, so there is no callee program for the runtime to load; declaring System would be an account that goes unused."
-              },
-              {
-                "id": "c",
-                "label": "Anchor injects the System Program automatically for instructions that only move lamports",
-                "correct": false,
-                "feedback": "Anchor never injects accounts. Every account a program touches — including a callee program — must be in the instruction's account list, which is why `Deposit` names it explicitly and `Withdraw` has nothing to name."
-              }
-            ],
-            "explanation": "Two rules doing one job. First, ownership: the executing program may debit only accounts assigned to it, so lamports leaving a wallet must go through System while lamports leaving your vault must not. Second, explicitness: Solana transactions declare every account up front and a program receives exactly that set — nothing is reached out to mid-instruction, which is what lets a wallet simulate a transaction before you sign it. Put together, the presence or absence of `system_program` in an accounts struct tells you whether that instruction calls out to anyone, and the empty account list on `Withdraw` is the visible consequence of your program owning the vault."
-          },
-          {
-            "id": "q7",
-            "prompt": "Course 2 recall. Your `withdraw` uses `checked_sub(amount).ok_or(VaultError::InsufficientFunds)?`. What does a caller actually receive when the vault is short?",
-            "multiSelect": false,
-            "options": [
-              {
-                "id": "a",
-                "label": "A failed transaction carrying custom error 6001 and the `#[msg]` string you wrote, which any client can render without knowing your program",
-                "correct": true,
-                "feedback": null
-              },
-              {
-                "id": "b",
-                "label": "A failed transaction with no error code — the instruction simply aborts",
-                "correct": false,
-                "feedback": "That is what a PANIC gives you, from `unwrap()` or bare subtraction. `checked_sub` + `ok_or` + `?` is the path that produces a code and a message instead."
-              },
-              {
-                "id": "c",
-                "label": "A successful transaction that leaves `balance` unchanged",
-                "correct": false,
-                "feedback": "`?` propagates the error out of the handler, so the instruction fails and the whole transaction's account writes are discarded. Nothing partial is committed."
-              }
-            ],
-            "explanation": "`checked_sub` returns `None`, `ok_or` names it, `?` carries it up, and Anchor maps your variant to 6000 + its index — 6001 for `InsufficientFunds`. The caller gets a code and a sentence you authored. The alternative, a panic, gives them an aborted instruction and nothing to display, which is why Course 2 refused `unwrap()` in program code even with `overflow-checks = true` turning wraps into panics."
-          },
-          {
-            "id": "q8",
-            "prompt": "You add a `transfer_between_vaults` instruction taking two mutable vault accounts. Under Anchor 1.0, what happens if a caller passes the same vault for both?",
-            "multiSelect": false,
-            "options": [
-              {
-                "id": "a",
-                "label": "It fails by default with `ConstraintDuplicateMutableAccount`; allowing it requires opting that account out with `#[account(mut, dup)]`",
-                "correct": true,
-                "feedback": null
-              },
-              {
-                "id": "b",
-                "label": "It succeeds, and the two writes are merged safely because they target one account",
-                "correct": false,
-                "feedback": "There is no merge. Two mutable views of one account means one write can be overwritten by the other from stale data — which is precisely why Anchor 1.0 made the default an error."
-              },
-              {
-                "id": "c",
-                "label": "It fails, and the fix is `#[account(mut, unsafe(dup))]`",
-                "correct": false,
-                "feedback": "Right diagnosis, wrong syntax: `unsafe(dup)` is Anchor v2-alpha (Pinocchio, `no_std`). On v1 the opt-out is plain `dup`."
-              }
-            ],
-            "explanation": "Aliased mutable accounts are a classic source of silent double-credits and vanishing writes: you deserialize twice, modify one copy, and the second copy's serialization overwrites it. Anchor 1.0 flipped this to error-by-default and gave you `dup` for the rare instruction where aliasing is legitimate. The general lesson is the one running through module 3 — most account-level exploits are stopped by a constraint you either wrote or forgot, and the framework's defaults decide which mistakes are even reachable."
-          },
-          {
-            "id": "q9",
-            "prompt": "You mistype a constraint inside `#[derive(Accounts)] pub struct Deposit`. The compiler reports the error on the `#[derive(Accounts)]` line, not on the constraint you edited. Why, and what do you do with that?",
-            "multiSelect": false,
-            "options": [
-              {
-                "id": "a",
-                "label": "The failing code is macro-generated, so it is reported where the macro expanded — read the FIRST error and treat the struct as the neighbourhood, not the line",
-                "correct": true,
-                "feedback": null
-              },
-              {
-                "id": "b",
-                "label": "The compiler is confused by proc macros and the reported line is meaningless",
-                "correct": false,
-                "feedback": "The location is accurate — that genuinely is where the failing code exists after expansion. It is just not where you typed the mistake, which is a different problem and one you can plan around."
-              },
-              {
-                "id": "c",
-                "label": "Anchor validates constraints at runtime, so this must be an unrelated error",
-                "correct": false,
-                "feedback": "Constraints expand into code at compile time; that is most of the point of Anchor. Runtime is where the generated checks RUN, not where they are written."
-              }
-            ],
-            "explanation": "This is the single most useful debugging habit for macro-heavy Rust. `#[derive(Accounts)]` writes a validation function from your attributes, and if that function does not compile, the error lands at the expansion site. So the reported line tells you which struct, and the message tells you what the generated code needed — a field that does not exist, a type that does not match. Deleting `system_program` from `InitializeVault` fails this same way, and Cargo's error ordering matters: the first error is usually the cause and the rest are its consequences."
-          },
-          {
-            "id": "q10",
-            "prompt": "A friend opens your program id on Solana Explorer and reports that the address does not exist. Both of you are looking at the same 32 bytes. What is the most likely explanation?",
-            "multiSelect": false,
-            "options": [
-              {
-                "id": "a",
-                "label": "Their URL is missing `?cluster=devnet`, so the explorer is searching mainnet, where your program was never deployed",
-                "correct": true,
-                "feedback": null
-              },
-              {
-                "id": "b",
-                "label": "Devnet programs are only visible to the wallet that deployed them",
-                "correct": false,
-                "feedback": "Nothing on a public cluster is wallet-scoped. Anyone can read any account; only WRITING is gated, and only by signatures and program logic."
-              },
-              {
-                "id": "c",
-                "label": "The program needs its IDL published before the explorer can find the account",
-                "correct": false,
-                "feedback": "The IDL affects how nicely a program is RENDERED, never whether the account is found. An account with no IDL still shows up with its owner, lamports and raw data."
-              }
-            ],
-            "explanation": "Clusters are separate chains that share an address space, so the same 32 bytes name nothing on mainnet and your program on devnet. Solana Explorer defaults to mainnet, which makes a missing `?cluster=devnet` the most common false alarm in this whole course — and the reason every explorer link you share should carry the query parameter. Reading is permissionless on every cluster; the upgrade authority is what is scoped to your wallet."
-          },
-          {
-            "id": "q11",
-            "prompt": "You publish your IDL through the Program Metadata Program. Someone is handed only your program id. What can they now do that they could not before?",
-            "multiSelect": false,
-            "options": [
-              {
-                "id": "a",
-                "label": "Fetch the interface description from the chain using the id alone and generate a typed client from it, with nothing else from you",
-                "correct": true,
-                "feedback": null
-              },
-              {
-                "id": "b",
-                "label": "Read your Rust source, since the IDL is compiled from it",
-                "correct": false,
-                "feedback": "The IDL describes the interface — instruction names, discriminators, account lists, PDA seeds, layouts, error codes. Your source is not on-chain; the binary and this metadata are."
-              },
-              {
-                "id": "c",
-                "label": "Upgrade the program, since the metadata records the upgrade authority",
-                "correct": false,
-                "feedback": "Publishing metadata REQUIRES the upgrade authority; it does not grant it. Only your wallet can upgrade the program or rewrite its metadata."
-              }
-            ],
-            "explanation": "This is what makes the program id a complete handoff. Anchor 1.0 removed the legacy on-chain IDL instructions your program used to carry, and moved the job to a separate Program Metadata Program keyed by program id — so the description travels with the address rather than with your repo. Course 4 depends on exactly this: it fetches your IDL, runs Codama over it, and produces a typed client for a program it knows nothing else about."
-          },
-          {
-            "id": "q12",
-            "prompt": "You are writing up this build for a technical audience. Which sentence can you defend?",
-            "multiSelect": false,
-            "options": [
-              {
-                "id": "a",
-                "label": "\"Compiled against the real Anchor 1.1 toolchain and deployed to devnet; behaviour is verified by reading, not by an automated test suite.\"",
-                "correct": true,
-                "feedback": null
-              },
-              {
-                "id": "b",
-                "label": "\"Unit tested and deployed to devnet.\"",
-                "correct": false,
-                "feedback": "There is no test run anywhere in this course. Grading is compile-only and the LiteSVM file was reading material. This is the claim a reviewer can falsify in one question, which costs more than the sentence buys."
-              },
-              {
-                "id": "c",
-                "label": "\"Audited against the standard Anchor security constraints.\"",
-                "correct": false,
-                "feedback": "You applied constraints deliberately and can say so. \"Audited\" implies an adversarial review by someone other than the author, which did not happen."
-              }
-            ],
-            "explanation": "Precision is the cheapest credibility available to a developer writing about their own work, and overclaiming is the fastest way to lose it. Name the toolchain and the network, say what was and was not verified, and link the program id so every claim is checkable in ten seconds. The narrow, honest sentence is also more impressive to the audience you want, because it demonstrates you know the difference between compiling and testing — which is exactly what the pre-flight lesson was about."
-          },
-          {
-            "id": "q13",
-            "prompt": "Course 2 recall. Your program has a `pub mod vault` and a `#[program] pub mod vault_program`. What separates them?",
-            "multiSelect": false,
-            "options": [
-              {
-                "id": "a",
-                "label": "`vault` is the half with no runtime dependency — pure state and arithmetic, checkable by reading. `vault_program` is the half that needs accounts, the runtime and a CPI",
-                "correct": true,
-                "feedback": null
-              },
-              {
-                "id": "b",
-                "label": "`vault` holds private helpers and `vault_program` holds the public API",
-                "correct": false,
-                "feedback": "`vault`'s items are public and re-exported at the crate root — the harness and the program module both depend on it. The split is by runtime dependency, not visibility."
-              },
-              {
-                "id": "c",
-                "label": "`vault` is a legacy layout kept for compatibility with Course 2's grader",
-                "correct": false,
-                "feedback": "It is the deliberate architecture, not a leftover. Keeping the state machine free of runtime types is what let Course 2 grade it standalone and what lets Course 3 wrap it without editing a line."
-              }
-            ],
-            "explanation": "This split is the most portable idea in the two courses. `VaultState`, `VaultError` and the two methods know nothing about accounts, signers, the clock or CPIs, which is why they could be written and checked in Course 2 and imported here unchanged. Everything the runtime forced on you — `Context`, `#[derive(Accounts)]`, the System Program CPI, the PDA signer — lives on the other side of the boundary. Programs written this way are the ones you can reason about, test in isolation, and port to another framework without a rewrite."
+            "explanation": "An upgradeable program account references executable data that the upgrade authority can swap, so bug fixes reuse the same program id. Because state is stored in separate accounts, existing counters persist across the upgrade — code and data are decoupled by design."
           }
         ],
         "prompt": null,
         "maxWords": null,
-        "amount": null,
-        "network": null,
-        "idl": null
-      },
-      {
-        "key": "writeup",
-        "_type": "openEnded",
-        "produces": null,
-        "consumes": null,
-        "src": null,
-        "url": null,
-        "language": null,
-        "buildType": null,
-        "deployable": null,
-        "starter": null,
-        "solution": null,
-        "tests": null,
-        "hints": null,
-        "questions": null,
-        "prompt": "Draft your build write-up here, following the four-part structure above: what it is (two sentences plus your program id as a `?cluster=devnet` link), one design decision defended, the thing that broke and how you found it, and what you would do differently. Nothing here is graded, no XP depends on it, and it gates nothing — it exists so the version of you that just finished still remembers what was hard. Keep the claims narrow: \"compiled against the real Anchor 1.1 toolchain\", never \"unit tested\".",
-        "maxWords": 300,
         "amount": null,
         "network": null,
         "idl": null
@@ -2240,15 +1954,15 @@
   },
   {
     "_id": "lesson-bfsp-m4-deploy",
-    "title": "Deploy and Publish the IDL",
-    "slug": "deploy-and-publish-the-idl",
+    "title": "Deploy Your Program to Devnet",
+    "slug": "deploy-program-devnet",
     "blocks": [
       {
         "key": "intro",
         "_type": "prose",
         "produces": null,
         "consumes": null,
-        "src": "# Deploy and Publish the IDL\n\n> **Version stamp — checked 2026-07-26.** `anchor-lang 1.1.2` · `borsh` resolves to **1.8.0** · Agave ≥ 3.1.10 · rustc 1.89+ · IDL spec 0.1.0 (Anchor 0.30+ shape).\n\nThis is it. The code block below is your vault as a deploy artifact: the Course 2 core, plus the three instructions that move lamports or create state — `initialize_vault`, `deposit`, `withdraw` — assembled into one file. (`transfer_between_vaults` from the last lesson is not in it, and the header comment says why.) Build it, then put it on a public network.\n\nTwo things come out of this lesson, and both of them are artifacts you keep:\n\n1. **A program id.** A 32-byte address that anyone, anywhere, can look up without your permission and without asking you for anything.\n2. **An IDL published on-chain at that id.** The machine-readable description of your instructions and accounts — which is what lets a client call your program having been told nothing but the id.\n\nCourse 4 consumes exactly those two. Keep the id somewhere you will find it again.\n\n## The Deployment Process\n\nDeploying a Solana program involves 4 steps:\n\n1. **Compile**: Your Rust code → `.so` binary (done by the build server)\n2. **Create Buffer**: A temporary on-chain account to hold the binary during upload\n3. **Upload Chunks**: The binary is uploaded in ~1000-byte chunks (200+ transactions for a typical program)\n4. **Finalize**: Link the buffer to a new program account, making it executable\n\nThis follows the **BPF Loader Upgradeable** protocol — the standard way all Anchor programs are deployed.\n\nYour vault compiles to roughly 229 KB, so expect the full 200-plus transactions. The chunking is not a platform quirk: a Solana transaction is capped near 1232 bytes, which is three orders of magnitude smaller than the binary, so a large upload has no other shape available to it.\n\n## What You'll See\n\n- **1 wallet popup** to create the buffer account\n- **Batch signing** every ~30 chunks (to avoid blockhash expiry)\n- **A real-time transaction log** showing each chunk being confirmed\n- **Your Program ID** when deployment completes\n\n## Instructions\n\n1. Click **Build** to compile the program\n2. When the build succeeds, click **Deploy to Devnet**\n3. Approve the transactions in your wallet\n4. Watch the deployment progress in real time!\n\n> **If deployment fails**: Don't worry! The system saves your progress. Click **Resume** to pick up where you left off — you won't re-upload chunks that already succeeded.\n\n## Publishing the IDL: what changed in Anchor 1.0\n\nYour program is on-chain. Nothing yet knows what its instructions are called.\n\nAn IDL is a JSON document describing every instruction, its 8-byte discriminator, the accounts it expects, the seeds of any PDA among them, your account layouts, and your error codes. It is the difference between an address a client can *see* and an address a client can *use*.\n\nFor years Anchor put that JSON on-chain through instructions built into your own program — the mechanism behind `anchor idl init`. **Anchor 1.0 removed those instructions.** Every tutorial that tells you to run `anchor idl init <PROGRAM_ID>` is describing a mechanism that no longer exists, and there are a great many of them.\n\nThe replacement is the **Program Metadata Program**, a separate on-chain program that stores metadata for *any* program, keyed by program id. It is not Anchor-specific and it is not part of your binary — which is the improvement: your program no longer carries instructions whose only purpose is to describe itself.\n\nPublishing to it is one command:\n\n```bash\nnpx @solana-program/program-metadata write idl <program-id> ./idl.json\n```\n\nIn a local Anchor repo `anchor deploy` does this for you as part of deploying, and `--no-idl` opts out. Deployment here happens in the browser and does not, so publishing is the separate step above — run against the id the panel just gave you, with the IDL from this lesson.\n\nTwo honest notes:\n\n- **The authority matters.** Writing metadata for a program id requires the program's upgrade authority, which is your wallet. Nobody else can publish an IDL for your program, and you cannot publish one for someone else's.\n- **Explorer support is uneven.** Not every explorer resolves and renders Program Metadata IDLs yet; several still look only for the legacy account that Anchor 1.0 stopped writing. If an explorer shows your program without an IDL, that is a gap in the explorer, not a failed publish. Clients that read the metadata PDA directly — Codama among them, which is what Course 4 uses — get it either way.\n\nThe property worth internalising: **once published, the IDL is reachable from the program id alone.** No repo, no npm package, no README. Hand someone 32 bytes and they can generate a typed client. That is the whole reason the next course can start from your program instead of its own.\n\n## Interacting with your live program\n\nThe panel below reads the IDL, derives every account it can, and builds real transactions against **your** deployed program. Work through it in order:\n\n1. **`initialize_vault`** — no arguments. Watch the account list: `vault` resolves as a PDA, derived from `[b\"vault\", your_wallet]` under your program id, and `user` resolves to your wallet. Nothing was typed in; the seeds in the IDL were enough. After it confirms, the account view shows `owner` (your address), `balance` (0) and `bump` (probably 255, occasionally lower).\n2. **`deposit`** — pass an amount in lamports. `1000000000` is 1 SOL; start smaller. Two things change and you should check both: the vault account's lamport balance on the explorer, and the `balance` field in the account view. They are separate writes — the System Program moved the lamports, your Course 2 `deposit` method recorded the number — and a program where they disagree is a program with a bug.\n3. **`withdraw`** — pass a smaller amount than you deposited. Look at the account list before you send: there are **two** accounts, not three. No `system_program`, because `withdraw` makes no CPI — the account being debited is the vault, your program owns it, and a program may move lamports out of an account it owns without asking anyone. That absence in the account list is module 3's hardest finding made visible.\n4. **Read the bytes.** Open the vault address on [Solana Explorer](https://explorer.solana.com) with `?cluster=devnet` and look at the raw account data. The first 8 bytes are the discriminator; then 32 bytes of `owner`; then `balance` as a little-endian `u64`, least significant byte first; then one byte of `bump`. 49 bytes, exactly the arithmetic you did in module 2, in front of you.\n\nThen try two errors on purpose, because a live program is the only place you can watch your own error strings travel.\n\n**Call `deposit` with `0`.** The transaction fails with custom error `6002`, and the message attached is the `#[msg(\"Amount must be greater than zero\")]` string you wrote — travelling from your `require!` through the runtime into a UI that had never heard of your program before this lesson. That is what a named error buys you, and it is why Course 2 refused to let you `unwrap`.\n\n**Then call `withdraw` for more than the vault holds** — or for an amount that would drop it below its rent floor. You get `6001`, `InsufficientFunds`, from your own guard, rather than the runtime's `InsufficientFundsForRent`. Both stop the transaction. Only one of them tells the caller what to do about it, and the difference is the rent-floor check you wrote instead of letting the runtime find out the hard way.\n",
+        "src": "# Deploy Your Program to Devnet\n\nThis is it — you're about to deploy your counter program to the Solana blockchain.\n\n## The Deployment Process\n\nDeploying a Solana program involves 4 steps:\n\n1. **Compile**: Your Rust code → `.so` binary (already done by the build server)\n2. **Create Buffer**: A temporary on-chain account to hold the binary during upload\n3. **Upload Chunks**: The binary is uploaded in ~1000-byte chunks (200+ transactions for a typical program)\n4. **Finalize**: Link the buffer to a new program account, making it executable\n\nThis follows the **BPF Loader Upgradeable** protocol — the standard way all Anchor programs are deployed.\n\n## What You'll See\n\n- **1 wallet popup** to create the buffer account\n- **Batch signing** every ~30 chunks (to avoid blockhash expiry)\n- **A real-time transaction log** showing each chunk being confirmed\n- **Your Program ID** when deployment completes\n\n## Instructions\n\n1. Click **Build** to compile your counter program\n2. When the build succeeds, click **Deploy to Devnet**\n3. Approve the transactions in your wallet\n4. Watch the deployment progress in real time!\n\n> **If deployment fails**: Don't worry! The system saves your progress. Click **Resume** to pick up where you left off — you won't re-upload chunks that already succeeded.\n",
         "url": null,
         "language": null,
         "buildType": null,
@@ -2276,19 +1990,18 @@
         "language": "rust",
         "buildType": "buildable",
         "deployable": true,
-        "starter": "// The finished vault — the deploy artifact, in one file. Nothing here is new.\n// Read it once to confirm you recognise all of it, then click Build, then\n// Deploy to Devnet.\n//\n// WHAT SHIPS, AND WHAT DOES NOT. Three instructions go on-chain:\n// `initialize_vault`, `deposit` and `withdraw` — the three that move lamports\n// or create state, and the three Course 4 calls against this program id. Your\n// `transfer_between_vaults` from `harden-the-vault` is deliberately NOT here:\n// it moves recorded balance between two vaults and touches no lamports, so it\n// adds nothing to the artifact the next course consumes. It was an exercise in\n// writing constraints, not a feature of the vault. If you want it deployed,\n// add it back along with its entry in the IDL — nothing stops you.\n//\n// Version stamp — checked 2026-07-26: anchor-lang 1.1.2, borsh resolves to\n// 1.8.0, edition 2021, Agave >= 3.1.10, rustc 1.89+.\n\nuse anchor_lang::prelude::*;\nuse anchor_lang::system_program::{transfer, Transfer};\n\n// The one line that looks optional and is not: `#[account]` expands to an\n// `impl Owner for VaultState` whose body reads `crate::ID`, and this is what\n// defines `ID`. Deploying replaces this placeholder with your own program id.\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n// ─────────────────────────────────────────────────────────────────────────────\n// YOUR COURSE 2 CORE — imported, not retyped.\n//\n// This module is the file you wrote in Course 2, unchanged. It has no accounts,\n// no signers, no CPI: it is the half of a program that does not depend on the\n// runtime. Every checked_add / checked_sub / named-error decision in it is one\n// you already made and already defended.\n// ─────────────────────────────────────────────────────────────────────────────\npub mod vault {\n    use super::*;\n\n    #[account]\n    #[derive(InitSpace)]\n    pub struct VaultState {\n        pub owner: Pubkey,\n        pub balance: u64,\n        pub bump: u8,\n    }\n\n    // Exactly ONE `#[error_code]` enum per program — Anchor 1.0 permits no more\n    // than one, and this is it. Module 3 added no new error type; it added a\n    // constraint that raises `NotOwner`, which Course 2 declared and left unused\n    // for precisely that reason.\n    #[error_code]\n    pub enum VaultError {\n        #[msg(\"Deposit would overflow the vault balance\")]\n        Overflow,\n        #[msg(\"Withdrawal is larger than the vault balance\")]\n        InsufficientFunds,\n        #[msg(\"Amount must be greater than zero\")]\n        ZeroAmount,\n        #[msg(\"Signer is not the vault owner\")]\n        NotOwner,\n    }\n\n    impl VaultState {\n        pub fn deposit(&mut self, amount: u64) -> Result<()> {\n            require!(amount > 0, VaultError::ZeroAmount);\n            self.balance = self\n                .balance\n                .checked_add(amount)\n                .ok_or(VaultError::Overflow)?;\n            Ok(())\n        }\n\n        pub fn withdraw(&mut self, amount: u64) -> Result<()> {\n            require!(amount > 0, VaultError::ZeroAmount);\n            self.balance = self\n                .balance\n                .checked_sub(amount)\n                .ok_or(VaultError::InsufficientFunds)?;\n            Ok(())\n        }\n    }\n}\n\npub use vault::{VaultError, VaultState};\n\n// ─────────────────────────────────────────────────────────────────────────────\n// THE HALF COURSE 3 ADDED: the runtime-facing program.\n// ─────────────────────────────────────────────────────────────────────────────\n#[program]\npub mod vault_program {\n    use super::*;\n\n    /// Module 2. Creates the per-user vault PDA and stores the canonical bump.\n    pub fn initialize_vault(ctx: Context<InitializeVault>) -> Result<()> {\n        let vault = &mut ctx.accounts.vault;\n        vault.owner = ctx.accounts.user.key();\n        vault.balance = 0;\n        // `ctx.bumps` is keyed by the FIELD name in the accounts struct, not by\n        // the seed prefix. Store it now so no later instruction has to search.\n        vault.bump = ctx.bumps.vault;\n        msg!(\"Vault initialized for {}\", vault.owner);\n        Ok(())\n    }\n\n    /// Module 3. Lamports IN move via a System Program CPI, because the debited\n    /// account is the user's wallet and System owns that. The recorded balance\n    /// moves via your Course 2 method. Two writes that have to agree.\n    pub fn deposit(ctx: Context<Deposit>, amount: u64) -> Result<()> {\n        // Anchor 1.0: `CpiContext::new` takes the program's ID, not its\n        // AccountInfo. Every pre-1.0 CPI tutorial online has the old shape.\n        transfer(\n            CpiContext::new(\n                System::id(),\n                Transfer {\n                    from: ctx.accounts.user.to_account_info(),\n                    to: ctx.accounts.vault.to_account_info(),\n                },\n            ),\n            amount,\n        )?;\n        ctx.accounts.vault.deposit(amount)?;\n        Ok(())\n    }\n\n    /// Module 3, and the instruction with no CPI in it. The debited account is\n    /// the vault, which OUR program owns — so our program may move its lamports\n    /// directly. The System Program could not do it for us at any price: it\n    /// refuses to debit an account carrying data, and it does not own this one.\n    pub fn withdraw(ctx: Context<Withdraw>, amount: u64) -> Result<()> {\n        let vault_info = ctx.accounts.vault.to_account_info();\n        let user_info = ctx.accounts.user.to_account_info();\n\n        // Bookkeeping first, through the Course 2 method: the zero guard, the\n        // `checked_sub` and `InsufficientFunds` all live inside it.\n        ctx.accounts.vault.withdraw(amount)?;\n\n        // The rent floor, read from the account's real allocated size so it stays\n        // correct if `VaultState` ever grows. Never hardcode 49.\n        let rent_floor = Rent::get()?.minimum_balance(vault_info.data_len());\n        let remaining = vault_info\n            .lamports()\n            .checked_sub(amount)\n            .ok_or(VaultError::InsufficientFunds)?;\n        require!(remaining >= rent_floor, VaultError::InsufficientFunds);\n\n        **vault_info.try_borrow_mut_lamports()? = remaining;\n        let credited = user_info\n            .lamports()\n            .checked_add(amount)\n            .ok_or(VaultError::Overflow)?;\n        **user_info.try_borrow_mut_lamports()? = credited;\n\n        Ok(())\n    }\n}\n\n#[derive(Accounts)]\npub struct InitializeVault<'info> {\n    // 8 (discriminator) + 32 (owner) + 8 (balance) + 1 (bump) = 49, derived in\n    // module 2 rather than copied. No `rent` constraint — removed in 0.31.\n    #[account(\n        init,\n        payer = user,\n        space = 8 + 32 + 8 + 1,\n        seeds = [b\"vault\", user.key().as_ref()],\n        bump\n    )]\n    pub vault: Account<'info, VaultState>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n    pub system_program: Program<'info, System>,\n}\n\n#[derive(Accounts)]\npub struct Deposit<'info> {\n    // `bump = vault.bump` uses the stored canonical bump: one hash instead of a\n    // search from 255 down for a value you already wrote to the account.\n    #[account(\n        mut,\n        seeds = [b\"vault\", user.key().as_ref()],\n        bump = vault.bump\n    )]\n    pub vault: Account<'info, VaultState>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n    pub system_program: Program<'info, System>,\n}\n\n#[derive(Accounts)]\npub struct Withdraw<'info> {\n    // The `constraint` is what finally spends the `owner` field carried since\n    // Course 2, and it raises `NotOwner` — the fourth variant, previously unused.\n    // Note what is absent: no `system_program`, because `withdraw` makes no CPI\n    // and there is no callee program for the runtime to load.\n    #[account(\n        mut,\n        seeds = [b\"vault\", user.key().as_ref()],\n        bump = vault.bump,\n        constraint = vault.owner == user.key() @ VaultError::NotOwner\n    )]\n    pub vault: Account<'info, VaultState>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n}\n",
-        "solution": "// The finished vault — the deploy artifact, in one file. Nothing here is new.\n// Read it once to confirm you recognise all of it, then click Build, then\n// Deploy to Devnet.\n//\n// WHAT SHIPS, AND WHAT DOES NOT. Three instructions go on-chain:\n// `initialize_vault`, `deposit` and `withdraw` — the three that move lamports\n// or create state, and the three Course 4 calls against this program id. Your\n// `transfer_between_vaults` from `harden-the-vault` is deliberately NOT here:\n// it moves recorded balance between two vaults and touches no lamports, so it\n// adds nothing to the artifact the next course consumes. It was an exercise in\n// writing constraints, not a feature of the vault. If you want it deployed,\n// add it back along with its entry in the IDL — nothing stops you.\n//\n// Version stamp — checked 2026-07-26: anchor-lang 1.1.2, borsh resolves to\n// 1.8.0, edition 2021, Agave >= 3.1.10, rustc 1.89+.\n\nuse anchor_lang::prelude::*;\nuse anchor_lang::system_program::{transfer, Transfer};\n\n// The one line that looks optional and is not: `#[account]` expands to an\n// `impl Owner for VaultState` whose body reads `crate::ID`, and this is what\n// defines `ID`. Deploying replaces this placeholder with your own program id.\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n// ─────────────────────────────────────────────────────────────────────────────\n// YOUR COURSE 2 CORE — imported, not retyped.\n//\n// This module is the file you wrote in Course 2, unchanged. It has no accounts,\n// no signers, no CPI: it is the half of a program that does not depend on the\n// runtime. Every checked_add / checked_sub / named-error decision in it is one\n// you already made and already defended.\n// ─────────────────────────────────────────────────────────────────────────────\npub mod vault {\n    use super::*;\n\n    #[account]\n    #[derive(InitSpace)]\n    pub struct VaultState {\n        pub owner: Pubkey,\n        pub balance: u64,\n        pub bump: u8,\n    }\n\n    // Exactly ONE `#[error_code]` enum per program — Anchor 1.0 permits no more\n    // than one, and this is it. Module 3 added no new error type; it added a\n    // constraint that raises `NotOwner`, which Course 2 declared and left unused\n    // for precisely that reason.\n    #[error_code]\n    pub enum VaultError {\n        #[msg(\"Deposit would overflow the vault balance\")]\n        Overflow,\n        #[msg(\"Withdrawal is larger than the vault balance\")]\n        InsufficientFunds,\n        #[msg(\"Amount must be greater than zero\")]\n        ZeroAmount,\n        #[msg(\"Signer is not the vault owner\")]\n        NotOwner,\n    }\n\n    impl VaultState {\n        pub fn deposit(&mut self, amount: u64) -> Result<()> {\n            require!(amount > 0, VaultError::ZeroAmount);\n            self.balance = self\n                .balance\n                .checked_add(amount)\n                .ok_or(VaultError::Overflow)?;\n            Ok(())\n        }\n\n        pub fn withdraw(&mut self, amount: u64) -> Result<()> {\n            require!(amount > 0, VaultError::ZeroAmount);\n            self.balance = self\n                .balance\n                .checked_sub(amount)\n                .ok_or(VaultError::InsufficientFunds)?;\n            Ok(())\n        }\n    }\n}\n\npub use vault::{VaultError, VaultState};\n\n// ─────────────────────────────────────────────────────────────────────────────\n// THE HALF COURSE 3 ADDED: the runtime-facing program.\n// ─────────────────────────────────────────────────────────────────────────────\n#[program]\npub mod vault_program {\n    use super::*;\n\n    /// Module 2. Creates the per-user vault PDA and stores the canonical bump.\n    pub fn initialize_vault(ctx: Context<InitializeVault>) -> Result<()> {\n        let vault = &mut ctx.accounts.vault;\n        vault.owner = ctx.accounts.user.key();\n        vault.balance = 0;\n        // `ctx.bumps` is keyed by the FIELD name in the accounts struct, not by\n        // the seed prefix. Store it now so no later instruction has to search.\n        vault.bump = ctx.bumps.vault;\n        msg!(\"Vault initialized for {}\", vault.owner);\n        Ok(())\n    }\n\n    /// Module 3. Lamports IN move via a System Program CPI, because the debited\n    /// account is the user's wallet and System owns that. The recorded balance\n    /// moves via your Course 2 method. Two writes that have to agree.\n    pub fn deposit(ctx: Context<Deposit>, amount: u64) -> Result<()> {\n        // Anchor 1.0: `CpiContext::new` takes the program's ID, not its\n        // AccountInfo. Every pre-1.0 CPI tutorial online has the old shape.\n        transfer(\n            CpiContext::new(\n                System::id(),\n                Transfer {\n                    from: ctx.accounts.user.to_account_info(),\n                    to: ctx.accounts.vault.to_account_info(),\n                },\n            ),\n            amount,\n        )?;\n        ctx.accounts.vault.deposit(amount)?;\n        Ok(())\n    }\n\n    /// Module 3, and the instruction with no CPI in it. The debited account is\n    /// the vault, which OUR program owns — so our program may move its lamports\n    /// directly. The System Program could not do it for us at any price: it\n    /// refuses to debit an account carrying data, and it does not own this one.\n    pub fn withdraw(ctx: Context<Withdraw>, amount: u64) -> Result<()> {\n        let vault_info = ctx.accounts.vault.to_account_info();\n        let user_info = ctx.accounts.user.to_account_info();\n\n        // Bookkeeping first, through the Course 2 method: the zero guard, the\n        // `checked_sub` and `InsufficientFunds` all live inside it.\n        ctx.accounts.vault.withdraw(amount)?;\n\n        // The rent floor, read from the account's real allocated size so it stays\n        // correct if `VaultState` ever grows. Never hardcode 49.\n        let rent_floor = Rent::get()?.minimum_balance(vault_info.data_len());\n        let remaining = vault_info\n            .lamports()\n            .checked_sub(amount)\n            .ok_or(VaultError::InsufficientFunds)?;\n        require!(remaining >= rent_floor, VaultError::InsufficientFunds);\n\n        **vault_info.try_borrow_mut_lamports()? = remaining;\n        let credited = user_info\n            .lamports()\n            .checked_add(amount)\n            .ok_or(VaultError::Overflow)?;\n        **user_info.try_borrow_mut_lamports()? = credited;\n\n        Ok(())\n    }\n}\n\n#[derive(Accounts)]\npub struct InitializeVault<'info> {\n    // 8 (discriminator) + 32 (owner) + 8 (balance) + 1 (bump) = 49, derived in\n    // module 2 rather than copied. No `rent` constraint — removed in 0.31.\n    #[account(\n        init,\n        payer = user,\n        space = 8 + 32 + 8 + 1,\n        seeds = [b\"vault\", user.key().as_ref()],\n        bump\n    )]\n    pub vault: Account<'info, VaultState>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n    pub system_program: Program<'info, System>,\n}\n\n#[derive(Accounts)]\npub struct Deposit<'info> {\n    // `bump = vault.bump` uses the stored canonical bump: one hash instead of a\n    // search from 255 down for a value you already wrote to the account.\n    #[account(\n        mut,\n        seeds = [b\"vault\", user.key().as_ref()],\n        bump = vault.bump\n    )]\n    pub vault: Account<'info, VaultState>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n    pub system_program: Program<'info, System>,\n}\n\n#[derive(Accounts)]\npub struct Withdraw<'info> {\n    // The `constraint` is what finally spends the `owner` field carried since\n    // Course 2, and it raises `NotOwner` — the fourth variant, previously unused.\n    // Note what is absent: no `system_program`, because `withdraw` makes no CPI\n    // and there is no callee program for the runtime to load.\n    #[account(\n        mut,\n        seeds = [b\"vault\", user.key().as_ref()],\n        bump = vault.bump,\n        constraint = vault.owner == user.key() @ VaultError::NotOwner\n    )]\n    pub vault: Account<'info, VaultState>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n}\n",
+        "starter": "use anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n#[program]\npub mod academy_program {\n    use super::*;\n\n    pub fn initialize(ctx: Context<Initialize>) -> Result<()> {\n        let counter = &mut ctx.accounts.counter;\n        counter.count = 0;\n        counter.authority = ctx.accounts.user.key();\n        msg!(\"Counter initialized!\");\n        Ok(())\n    }\n\n    pub fn greet(_ctx: Context<Greet>) -> Result<()> {\n        msg!(\"Hello, Solana!\");\n        Ok(())\n    }\n\n    pub fn increment(ctx: Context<Increment>) -> Result<()> {\n        let counter = &mut ctx.accounts.counter;\n        counter.count += 1;\n        Ok(())\n    }\n\n    pub fn decrement(ctx: Context<Decrement>) -> Result<()> {\n        let counter = &mut ctx.accounts.counter;\n        require!(counter.count > 0, ErrorCode::Underflow);\n        counter.count -= 1;\n        Ok(())\n    }\n}\n\n#[derive(Accounts)]\npub struct Initialize<'info> {\n    #[account(\n        init,\n        payer = user,\n        space = 8 + 8 + 32,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n    pub system_program: Program<'info, System>,\n}\n\n#[derive(Accounts)]\npub struct Greet {}\n\n#[derive(Accounts)]\npub struct Increment<'info> {\n    #[account(\n        mut,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    pub user: Signer<'info>,\n}\n\n#[derive(Accounts)]\npub struct Decrement<'info> {\n    #[account(\n        mut,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    pub user: Signer<'info>,\n}\n\n#[account]\npub struct Counter {\n    pub count: u64,\n    pub authority: Pubkey,\n}\n\n#[error_code]\npub enum ErrorCode {\n    #[msg(\"Cannot decrement below zero\")]\n    Underflow,\n}\n",
+        "solution": "use anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n#[program]\npub mod academy_program {\n    use super::*;\n\n    pub fn initialize(ctx: Context<Initialize>) -> Result<()> {\n        let counter = &mut ctx.accounts.counter;\n        counter.count = 0;\n        counter.authority = ctx.accounts.user.key();\n        msg!(\"Counter initialized!\");\n        Ok(())\n    }\n\n    pub fn greet(_ctx: Context<Greet>) -> Result<()> {\n        msg!(\"Hello, Solana!\");\n        Ok(())\n    }\n\n    pub fn increment(ctx: Context<Increment>) -> Result<()> {\n        let counter = &mut ctx.accounts.counter;\n        counter.count += 1;\n        Ok(())\n    }\n\n    pub fn decrement(ctx: Context<Decrement>) -> Result<()> {\n        let counter = &mut ctx.accounts.counter;\n        require!(counter.count > 0, ErrorCode::Underflow);\n        counter.count -= 1;\n        Ok(())\n    }\n}\n\n#[derive(Accounts)]\npub struct Initialize<'info> {\n    #[account(\n        init,\n        payer = user,\n        space = 8 + 8 + 32,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n    pub system_program: Program<'info, System>,\n}\n\n#[derive(Accounts)]\npub struct Greet {}\n\n#[derive(Accounts)]\npub struct Increment<'info> {\n    #[account(\n        mut,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    pub user: Signer<'info>,\n}\n\n#[derive(Accounts)]\npub struct Decrement<'info> {\n    #[account(\n        mut,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    pub user: Signer<'info>,\n}\n\n#[account]\npub struct Counter {\n    pub count: u64,\n    pub authority: Pubkey,\n}\n\n#[error_code]\npub enum ErrorCode {\n    #[msg(\"Cannot decrement below zero\")]\n    Underflow,\n}\n",
         "tests": [
           {
             "id": "test-deploy-1",
-            "description": "The assembled vault program compiles successfully",
+            "description": "Complete counter program compiles successfully",
             "input": "",
-            "expectedOutput": "true",
-            "failureMessage": "The build server rejected the file, so there is nothing to deploy yet. Read the FIRST error, not the last: a failure inside #[program] or #[derive(Accounts)] is reported where the macro expanded, which is usually several lines above the edit that caused it."
+            "expectedOutput": "true"
           }
         ],
         "hints": [
-          "This is the vault you assembled across modules 1-3, unchanged. Click Build to compile it, then Deploy to Devnet.",
+          "This is the same counter program from Module 3. Click Build to compile it, then Deploy to Devnet.",
           "Make sure you have at least 2 SOL in your wallet. Use the previous lesson to airdrop if needed.",
           "If deployment fails mid-way, click Resume — it will pick up where it left off."
         ],
@@ -2299,36 +2012,13 @@
         "network": null,
         "idl": null,
         "tutorNotes": [
-          "`declare_id!` is not the lever they think it is. The platform generates a program keypair and rewrites `declare_id!` with it before compiling, so the placeholder in the starter is irrelevant. A learner who pastes their previous program id in gets no effect at all — not an error, just nothing. If they ask how the program knows its own id, the answer is build-time injection, plus Anchor's runtime check that the invoked address equals `ID` (error 4100, DeclaredProgramIdMismatch).",
-          "Every Build mints a NEW program keypair, so a rebuild after a successful deploy produces a DIFFERENT program id. Learners who rebuild 'to be safe' then cannot tell which of two ids Course 4 wants. The id that counts is the one the panel reported after the Deploy that finished. Do not suggest rebuilding as a fix for anything except an actual compile error.",
-          "A deploy that dies partway usually died of money, not network. The upload is 200-plus transactions; a wallet holding exactly 2 SOL can run dry around chunk 150 and the symptom looks identical to a dropped connection. Check the balance before theorising about RPC. The recovery is fund-then-Resume; restarting from zero re-pays for chunks already on-chain.",
-          "Chunks are batch-signed roughly 30 at a time. Rejecting or dismissing one wallet popup aborts that whole batch, which reads as a mysterious stall. Resume is the correct next action — the confirmed chunks are already in the buffer, so nothing is lost, and re-deploying from scratch is the expensive mistake here.",
-          "`?cluster=devnet` is missing from their explorer URL. Solana Explorer defaults to mainnet, where their address does not exist, so it reports the account as not found and the learner concludes the deploy failed. Have them check the URL before they check anything else.",
-          "For the IDL step: `anchor idl init <PROGRAM_ID>` no longer exists — Anchor 1.0 removed the legacy on-chain IDL instructions, and most tutorials still teach it. The mechanism is the Program Metadata Program. Also, writing metadata requires the program's UPGRADE AUTHORITY, so a wallet switch between deploying and publishing fails with an authority error that looks nothing like an IDL problem."
+          "Learners hit a mid-deploy failure and restart from zero, re-uploading chunks that already landed, instead of clicking Resume, which skips the confirmed ones.",
+          "They run out of devnet SOL partway through the 200+ upload transactions and read the abort as a code bug; the buffer and fees simply drained the wallet — fund it and Resume.",
+          "They deploy with the wallet or CLI pointed at the wrong cluster, so a devnet program seems to vanish when they look for it on mainnet, or the deploy fails against an unfunded network.",
+          "They rebuild after a failed deploy and expect the same Program ID; a fresh program keypair yields a new id, so they then search the explorer for the old one and find nothing.",
+          "They reject or ignore one of the batch-signing popups and treat the stalled upload as a crash, rather than approving the next batch so the chunks keep confirming.",
+          "They read the green build check as a finished deploy — building only produced the `.so`; the on-chain upload is the separate step happening here."
         ]
-      },
-      {
-        "key": "explore",
-        "_type": "program-explorer",
-        "produces": null,
-        "consumes": [
-          "deployed-program"
-        ],
-        "src": null,
-        "url": null,
-        "language": null,
-        "buildType": null,
-        "deployable": null,
-        "starter": null,
-        "solution": null,
-        "tests": null,
-        "hints": null,
-        "questions": null,
-        "prompt": null,
-        "maxWords": null,
-        "amount": null,
-        "network": null,
-        "idl": "{\n  \"address\": \"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\",\n  \"metadata\": {\n    \"name\": \"vault_program\",\n    \"version\": \"0.1.0\",\n    \"spec\": \"0.1.0\",\n    \"description\": \"Per-user SOL vault — Superteam Academy Course 3\"\n  },\n  \"instructions\": [\n    {\n      \"name\": \"initialize_vault\",\n      \"discriminator\": [48, 191, 163, 44, 71, 129, 63, 164],\n      \"accounts\": [\n        {\n          \"name\": \"vault\",\n          \"writable\": true,\n          \"pda\": {\n            \"seeds\": [\n              {\n                \"kind\": \"const\",\n                \"value\": [118, 97, 117, 108, 116]\n              },\n              {\n                \"kind\": \"account\",\n                \"path\": \"user\"\n              }\n            ]\n          }\n        },\n        {\n          \"name\": \"user\",\n          \"writable\": true,\n          \"signer\": true\n        },\n        {\n          \"name\": \"system_program\",\n          \"address\": \"11111111111111111111111111111111\"\n        }\n      ],\n      \"args\": []\n    },\n    {\n      \"name\": \"deposit\",\n      \"discriminator\": [242, 35, 198, 137, 82, 225, 242, 182],\n      \"accounts\": [\n        {\n          \"name\": \"vault\",\n          \"writable\": true,\n          \"pda\": {\n            \"seeds\": [\n              {\n                \"kind\": \"const\",\n                \"value\": [118, 97, 117, 108, 116]\n              },\n              {\n                \"kind\": \"account\",\n                \"path\": \"user\"\n              }\n            ]\n          }\n        },\n        {\n          \"name\": \"user\",\n          \"writable\": true,\n          \"signer\": true\n        },\n        {\n          \"name\": \"system_program\",\n          \"address\": \"11111111111111111111111111111111\"\n        }\n      ],\n      \"args\": [\n        {\n          \"name\": \"amount\",\n          \"type\": \"u64\"\n        }\n      ]\n    },\n    {\n      \"name\": \"withdraw\",\n      \"discriminator\": [183, 18, 70, 156, 148, 109, 161, 34],\n      \"accounts\": [\n        {\n          \"name\": \"vault\",\n          \"writable\": true,\n          \"pda\": {\n            \"seeds\": [\n              {\n                \"kind\": \"const\",\n                \"value\": [118, 97, 117, 108, 116]\n              },\n              {\n                \"kind\": \"account\",\n                \"path\": \"user\"\n              }\n            ]\n          }\n        },\n        {\n          \"name\": \"user\",\n          \"writable\": true,\n          \"signer\": true\n        }\n      ],\n      \"args\": [\n        {\n          \"name\": \"amount\",\n          \"type\": \"u64\"\n        }\n      ]\n    }\n  ],\n  \"accounts\": [\n    {\n      \"name\": \"VaultState\",\n      \"discriminator\": [228, 196, 82, 165, 98, 210, 235, 152]\n    }\n  ],\n  \"errors\": [\n    {\n      \"code\": 6000,\n      \"name\": \"Overflow\",\n      \"msg\": \"Deposit would overflow the vault balance\"\n    },\n    {\n      \"code\": 6001,\n      \"name\": \"InsufficientFunds\",\n      \"msg\": \"Withdrawal is larger than the vault balance\"\n    },\n    {\n      \"code\": 6002,\n      \"name\": \"ZeroAmount\",\n      \"msg\": \"Amount must be greater than zero\"\n    },\n    {\n      \"code\": 6003,\n      \"name\": \"NotOwner\",\n      \"msg\": \"Signer is not the vault owner\"\n    }\n  ],\n  \"types\": [\n    {\n      \"name\": \"VaultState\",\n      \"type\": {\n        \"kind\": \"struct\",\n        \"fields\": [\n          {\n            \"name\": \"owner\",\n            \"type\": \"pubkey\"\n          },\n          {\n            \"name\": \"balance\",\n            \"type\": \"u64\"\n          },\n          {\n            \"name\": \"bump\",\n            \"type\": \"u8\"\n          }\n        ]\n      }\n    }\n  ]\n}\n"
       },
       {
         "key": "retrieval-close",
@@ -2360,7 +2050,7 @@
                 "id": "b",
                 "label": "Chunking makes the upload faster than a single transaction",
                 "correct": false,
-                "feedback": "It is about size limits, not speed. A whole 229KB binary cannot fit in one ~1232-byte transaction, so it is split into many."
+                "feedback": "It is about size limits, not speed. A whole 200KB binary cannot fit in one ~1232-byte transaction, so it is split into many."
               },
               {
                 "id": "c",
@@ -2396,84 +2086,131 @@
               }
             ],
             "explanation": "Confirmed chunks are already written to the on-chain buffer, so Resume checks what has landed and uploads only the remainder. This is why a flaky connection mid-deploy costs seconds, not a full re-upload of 200+ transactions."
-          },
+          }
+        ],
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      }
+    ]
+  },
+  {
+    "_id": "lesson-bfsp-m4-interact",
+    "title": "Interact with Your Program",
+    "slug": "interact-with-program",
+    "blocks": [
+      {
+        "key": "intro",
+        "_type": "prose",
+        "produces": null,
+        "consumes": null,
+        "src": "# Interact with Your Program\n\nYour counter program is live on Solana Devnet. Now let's call its instructions and watch the on-chain state change in real time.\n\n## What You'll Do\n\n1. **Initialize** a counter account — creates a new account owned by your program\n2. **Increment** the counter — modifies the on-chain state\n3. **Decrement** the counter — see your custom error handling in action\n\n## Understanding the Data\n\nThe Program Explorer below shows two views of your counter account:\n\n### Parsed Data\nThe human-readable version: `count: 3`\n\n### Raw Data (Hex)\nWhat's actually stored on-chain:\n```\n[a8 fc 0b 1f 05 77 32 45 | 03 00 00 00 00 00 00 00]\n ^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^^^^^^^^^^\n discriminator (8 bytes)    count: 3 (u64 LE)\n```\n\nThe **discriminator** is Anchor's way of identifying account types. It's the first 8 bytes of `sha256(\"account:Counter\")`. Every Anchor account starts with this — it's how the runtime knows it's looking at a `Counter` struct and not random data.\n\nThe **count** is stored as a `u64` in **little-endian** byte order. The value `3` is `03 00 00 00 00 00 00 00` because the least significant byte comes first.\n\n## Try This\n\n1. Click **Initialize** — watch the discriminator bytes appear\n2. Click **Increment** 3 times — watch `count` change from `00` to `03`\n3. Click **Decrement** down to 0, then try decrementing again\n4. See your `#[error_code] Underflow` in action!\n\n> **Teaching moment**: When you decrement below zero, your custom error `Cannot decrement below zero` is enforced by the Solana runtime. This is your code running on a real blockchain, enforcing rules you defined.\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "explore",
+        "_type": "program-explorer",
+        "produces": null,
+        "consumes": [
+          "deployed-program"
+        ],
+        "src": null,
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": "{\"address\":\"11111111111111111111111111111111\",\"metadata\":{\"name\":\"counter\",\"version\":\"0.1.0\",\"spec\":\"0.1.0\"},\"instructions\":[{\"name\":\"initialize\",\"discriminator\":[175,175,109,31,13,152,155,237],\"accounts\":[{\"name\":\"counter\",\"writable\":true,\"pda\":{\"seeds\":[{\"kind\":\"const\",\"value\":[99,111,117,110,116,101,114]},{\"kind\":\"account\",\"path\":\"user\"}]}},{\"name\":\"user\",\"writable\":true,\"signer\":true},{\"name\":\"system_program\",\"address\":\"11111111111111111111111111111111\"}],\"args\":[]},{\"name\":\"increment\",\"discriminator\":[11,18,104,9,104,174,59,33],\"accounts\":[{\"name\":\"counter\",\"writable\":true,\"pda\":{\"seeds\":[{\"kind\":\"const\",\"value\":[99,111,117,110,116,101,114]},{\"kind\":\"account\",\"path\":\"user\"}]}},{\"name\":\"user\",\"signer\":true}],\"args\":[]},{\"name\":\"decrement\",\"discriminator\":[106,227,168,59,248,27,150,101],\"accounts\":[{\"name\":\"counter\",\"writable\":true,\"pda\":{\"seeds\":[{\"kind\":\"const\",\"value\":[99,111,117,110,116,101,114]},{\"kind\":\"account\",\"path\":\"user\"}]}},{\"name\":\"user\",\"signer\":true}],\"args\":[]}],\"accounts\":[{\"name\":\"Counter\",\"discriminator\":[255,176,4,245,188,253,124,25]}],\"types\":[{\"name\":\"Counter\",\"type\":{\"kind\":\"struct\",\"fields\":[{\"name\":\"count\",\"type\":\"u64\"},{\"name\":\"authority\",\"type\":\"publicKey\"}]}}],\"errors\":[{\"code\":6000,\"name\":\"Underflow\",\"msg\":\"Cannot decrement below zero\"}]}\n"
+      },
+      {
+        "key": "retrieval-close",
+        "_type": "quiz",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": [
           {
-            "id": "q3",
-            "prompt": "You deposit 1 SOL and open the vault account on the explorer. Bytes 40 through 47 of the raw data read `00 ca 9a 3b 00 00 00 00`. What is `balance`, and why is the layout that way round?",
+            "id": "q1",
+            "prompt": "The raw hex for the counter reads (after the discriminator) `03 00 00 00 00 00 00 00`. What is the value, and why is `03` first?",
             "multiSelect": false,
             "options": [
               {
                 "id": "a",
-                "label": "1,000,000,000 — a u64 is stored little-endian, least significant byte first, and the field starts at offset 40 because 8 (discriminator) + 32 (owner) come before it",
+                "label": "3 — the u64 is stored little-endian, so the least significant byte comes first",
                 "correct": true,
                 "feedback": null
               },
               {
                 "id": "b",
-                "label": "An enormous number — read the bytes left to right as a big-endian integer",
+                "label": "A very large number — the bytes read left to right as big-endian",
                 "correct": false,
-                "feedback": "Solana stores integers little-endian. Read as big-endian those bytes would be astronomically large; read correctly, least significant byte first, they are exactly 1,000,000,000 lamports."
+                "feedback": "Solana stores integers little-endian, so `03 00 ...` is 3, not a huge big-endian value. The least significant byte leads."
               },
               {
                 "id": "c",
-                "label": "1,000,000,000 — but little-endian would have written it as `00 00 00 00 3b 9a ca 00`",
+                "label": "3, but little-endian would write it as `00 00 00 00 00 00 00 03`",
                 "correct": false,
-                "feedback": "That byte order is big-endian. Little-endian puts the least significant byte first, which is why the `00 ca 9a 3b` end comes before the padding zeros."
+                "feedback": "Little-endian puts the least significant byte first, so 3 is `03 00 00 00 00 00 00 00`. The `00 ... 03` layout is big-endian."
               }
             ],
-            "explanation": "Two things have to be right to read an account by hand: the offset and the byte order. The offset comes from the layout you derived in module 2 — 8 for the discriminator, 32 for `owner`, so `balance` begins at 40. The byte order is little-endian, which Solana uses throughout, so `00 ca 9a 3b 00 00 00 00` is 0x3B9ACA00 = 1,000,000,000. A client that gets either wrong reads plausible-looking garbage rather than failing loudly, which is why decoding is worth doing once by hand."
+            "explanation": "A `u64` equal to 3 is `03 00 00 00 00 00 00 00` in little-endian, the byte order Solana uses. Reading raw account data means accounting for both the leading 8-byte discriminator and little-endian integer layout — exactly what a manual byte decoder must handle."
           },
           {
-            "id": "q4",
-            "prompt": "You call `deposit` with `0` from the explorer panel and the transaction fails with custom error `6002` and the message \"Amount must be greater than zero\". Where is that rule actually enforced?",
+            "id": "q2",
+            "prompt": "When you decrement below zero, the error `Cannot decrement below zero` appears. Where is that rule actually enforced?",
             "multiSelect": false,
             "options": [
               {
                 "id": "a",
-                "label": "By the Solana runtime executing your deployed program's `require!` — the check is in your on-chain code, so it holds against any caller",
+                "label": "By the Solana runtime executing your deployed program's `require!` check — your own on-chain code",
                 "correct": true,
                 "feedback": null
               },
               {
                 "id": "b",
-                "label": "By the explorer panel, which validates the amount before building the transaction",
+                "label": "By the browser UI before the transaction is sent",
                 "correct": false,
-                "feedback": "The panel is a client, and any client can be bypassed or replaced. The guard lives in your program, which is why it holds for a caller you never wrote and cannot see."
+                "feedback": "The UI is not the enforcer; a client could bypass it. The rule lives in your deployed program and the runtime enforces it, which is why it holds against any caller."
               },
               {
                 "id": "c",
-                "label": "By the RPC node, which rejects instructions with zero-value arguments",
+                "label": "By the RPC node validating the request",
                 "correct": false,
-                "feedback": "RPC nodes forward transactions; they do not know your business rules. The `require!` executes inside your program on the validator, and 6002 is your enum's third variant."
+                "feedback": "RPC nodes forward transactions; they do not run your business rules. The `require!` guard executes inside your program on the validator."
               }
             ],
-            "explanation": "This is the difference between a UI check and a rule. `require!(amount > 0, VaultError::ZeroAmount)` compiles into your program, so the validator runs it for every caller — the explorer panel, a script, a stranger's bot. The 6002 is Anchor's offset (6000) plus your variant's index, and the string is the `#[msg]` you wrote in Course 2, which is how a client that has never heard of your program can still render something a human can act on."
-          },
-          {
-            "id": "q5",
-            "prompt": "You publish your IDL with `npx @solana-program/program-metadata write idl <program-id> ./idl.json`. What does that actually buy someone who has only your program id?",
-            "multiSelect": false,
-            "options": [
-              {
-                "id": "a",
-                "label": "They can fetch the IDL from the chain using the id alone, and generate a typed client from it — no repo, no npm package, nothing from you",
-                "correct": true,
-                "feedback": null
-              },
-              {
-                "id": "b",
-                "label": "They can read your program's source code on-chain",
-                "correct": false,
-                "feedback": "The IDL is an interface description — instruction names, discriminators, account lists, PDA seeds, layouts, error codes. Your Rust source is not on-chain; only the compiled binary and this metadata are."
-              },
-              {
-                "id": "c",
-                "label": "Nothing extra — they could already derive the instruction discriminators from the deployed binary",
-                "correct": false,
-                "feedback": "In principle a discriminator can be recovered by disassembly; in practice nobody does that. Names, argument types, account ordering and PDA seeds are not recoverable from the binary, and those are what an IDL supplies."
-              }
-            ],
-            "explanation": "The IDL is what turns an address into an interface. Published on-chain via the Program Metadata Program it is reachable from the program id alone, which is exactly what makes the next course possible: Course 4 fetches your IDL, runs Codama over it, and generates a typed client for a program it was told nothing else about. Note that Anchor 1.0 REMOVED the legacy on-chain IDL instructions — `anchor idl init` is no longer the mechanism, however many tutorials still say it is."
+            "explanation": "The `#[error_code]` Underflow and its `require!` guard run inside your program on-chain, so the Solana runtime enforces them regardless of which client sends the transaction. That is the difference between a UI check anyone can skip and a rule that actually holds on a public network."
           }
         ],
         "prompt": null,
@@ -2486,15 +2223,15 @@
   },
   {
     "_id": "lesson-bfsp-on-chain-state",
-    "title": "Accounts Are Just Bytes",
-    "slug": "accounts-are-just-bytes",
+    "title": "On-Chain State",
+    "slug": "on-chain-state",
     "blocks": [
       {
         "key": "intro",
         "_type": "prose",
         "produces": null,
         "consumes": null,
-        "src": "# Accounts Are Just Bytes\n\n> **Version stamp — checked 2026-07-26.** `anchor-lang 1.1.2` (published 2026-06-26) · `cargo-build-sbf` with platform-tools v1.54 (rustc 1.89) · `borsh` resolves to **1.8.0** · edition 2021. The three rent constants below — `ACCOUNT_STORAGE_OVERHEAD = 128`, `DEFAULT_LAMPORTS_PER_BYTE_YEAR = 3480`, `DEFAULT_EXEMPTION_THRESHOLD = 2.0` — were read out of `solana-rent`. The byte sizes were verified as `const` assertions compiled on the toolchain above.\n\nYour program so far has no memory. Every instruction logs a line and exits. Call it a thousand times\nand nothing about the chain is different afterwards.\n\nTo fix that you need an **account** — and an account is not an object, a row, or a document. It is a\nbyte buffer whose length you choose once, at creation, and can never change.\n\nThat single sentence is why this lesson comes before you write any code. The size decision is\nirreversible, it costs the payer money for as long as the account exists, and Anchor will not compute\nit for you unless you ask.\n\n## What the runtime actually stores\n\nEvery account on Solana carries exactly four things the runtime cares about:\n\n| Field    | What it is                                                    |\n| -------- | ------------------------------------------------------------- |\n| address  | 32 bytes. How anything finds the account                      |\n| owner    | 32 bytes. The **program id** allowed to write the data        |\n| lamports | The balance — and the rent-exemption deposit                  |\n| data     | A flat `[u8]` of fixed length. This is the part you design    |\n\nNote what is missing: no type, no schema, no column names. `data` is bytes. The only reason\n`[0, 0, 0, 0, 0, 0, 0, 0, 82, 12, …]` means anything at all is that a program agrees to read it a\nparticular way.\n\n\"Owner\" is the word people trip on. The **owner is a program**, not a person. Your vault's owner will\nbe your program id — that is what makes it program-controlled state rather than data sitting under\nsomebody's wallet. Your own `VaultState` has a field called `owner` too, and that one holds the\n*user's* wallet. Two different meanings, one word, both correct, and you will read code that uses\neach. The runtime's owner is enforced by the runtime. Yours is enforced only by the constraints you\nwrite in module 3.\n\n## The eight bytes you did not write\n\nAnchor puts an 8-byte **discriminator** at the front of every `#[account]` buffer. It is derived from\nthe account's type name, so `VaultState`'s eight bytes are not `Config`'s eight bytes.\n\n```\nbyte 0               8                                                          49\n  │  discriminator   │  your fields, Borsh-serialized in declaration order      │\n  └──────────────────┴──────────────────────────────────────────────────────────┘\n```\n\nEvery deserialize checks those eight bytes first. Hand your program some other program's account — or\nyour own `Config` where a `VaultState` is expected — and it fails on the discriminator instead of\nreading foreign bytes as if they were your struct. This is the cheapest security property in Anchor,\nand you get it by typing `#[account]`.\n\nYou never read or write those eight bytes yourself. You do have to **pay for them**.\n\n## Deriving the vault's size, out loud\n\nHere is the struct you wrote in Course 2, unchanged:\n\n```rust\n#[account]\n#[derive(InitSpace)]\npub struct VaultState {\n    pub owner: Pubkey,   // 32\n    pub balance: u64,    //  8\n    pub bump: u8,        //  1\n}\n```\n\nBorsh writes fields in declaration order, back to back, with no padding and no type information. So:\n\n```\n  8   discriminator   (Anchor, on every #[account])\n 32   owner: Pubkey   (32 raw bytes, no length prefix)\n  8   balance: u64    (little-endian, 8 bytes, fixed)\n  1   bump: u8        (one byte, values 0..=255)\n───\n 49   bytes total\n```\n\n**49.** Not \"about 48\", not \"round it to 64\". Forty-nine. You will type that as\n`space = 8 + 32 + 8 + 1` in the next two lessons — written as a sum rather than as `49`, so the reason\nfor every term stays visible in the code.\n\nThe sizes you need for anything else:\n\n| Type               | Bytes                                   |\n| ------------------ | --------------------------------------- |\n| `bool`, `u8`, `i8` | 1                                       |\n| `u16` / `i16`      | 2                                       |\n| `u32` / `i32`      | 4                                       |\n| `u64` / `i64`      | 8                                       |\n| `u128` / `i128`    | 16                                      |\n| `Pubkey`           | 32                                      |\n| `Option<T>`        | 1 + size of `T`                         |\n| `String`           | 4 (length prefix) + bytes of content    |\n| `Vec<T>`           | 4 (length prefix) + count × size of `T` |\n\nThe last two are where fixed-size accounts and variable-length data collide: you must allocate for the\n**maximum** length you will ever accept, and then enforce that maximum in code. A `String` field with\nno length cap is an account you cannot size.\n\n## Two ways to get 49 wrong\n\n**`std::mem::size_of::<VaultState>()` is not the answer.** Rust aligns struct fields for CPU access;\nBorsh does not. `size_of::<VaultState>()` is **48** — 41 bytes of fields rounded up to the struct's\n8-byte alignment — while Borsh writes **41**. Size with `size_of` and you allocate 56 bytes for a\n49-byte account, and overpay rent on every vault for as long as it exists, for no benefit. Rust's\nmemory layout and Borsh's wire layout are different problems that happen to be about the same struct.\n\n**Counting the discriminator twice, or not at all,** is the other one. `8 + 32 + 8 + 1` counts it\nonce. If you ever see a `space` that equals exactly the sum of the field sizes, that account is 8\nbytes short, and the first write past the field boundary fails.\n\nThe maintainable form is the one your Course 2 file already set up:\n\n```rust\nspace = 8 + VaultState::INIT_SPACE   // 8 + 41 = 49\n```\n\n`#[derive(InitSpace)]` generates `INIT_SPACE` as the sum of the field sizes — **without** the\ndiscriminator, which is why the `8 +` is still yours to write. Add a field later and the constant\nfollows; a literal sum does not. Ship `INIT_SPACE`. We write the sum in this course because you are\nlearning what it is made of.\n\n## Why the size is fixed, and what it costs\n\nThe runtime allocates `space` bytes at creation, and that is the account's size for life. There is a\nseparate `realloc` mechanism for growing an account later — a deliberate operation with its own payer\nand its own constraints, not something that happens because your struct grew.\n\nThe account also has to be **rent-exempt** to survive, which means holding a lamport balance above a\nminimum that scales with size:\n\n```\nminimum = (128 + space) × 3480 × 2 lamports\n```\n\n128 bytes is the per-account storage overhead the runtime charges regardless of your data, 3,480\nlamports is the per-byte-year price, and 2 is the exemption threshold in years. For the vault:\n\n```\n(128 + 49) × 3480 × 2  =  177 × 6960  =  1,231,920 lamports  ≈  0.00123 SOL\n```\n\nThat deposit is not a fee. It sits in the account and comes back if the account is ever closed. But it\nis the payer's SOL, locked, for as long as the account exists — which is why over-allocating has a\nprice tag and \"just make it 1024 bytes to be safe\" is a decision, not a precaution. Those three\nnumbers are protocol parameters, so the way to read the current value rather than trust a number in a\ntutorial is the `getMinimumBalanceForRentExemption` RPC method.\n\nOne thing that is **not** a cost: ongoing rent collection. It is gone. An account's `rent_epoch` field\nis vestigial — if you find prose describing it as \"when rent is next due\", that prose is describing a\nmechanism that no longer runs.\n\n## What Anchor stopped asking for\n\nSearch for account-creation examples and you will find this shape:\n\n```rust\n#[account(init, payer = user, space = 49, rent = rent)]\n```\n\n`rent = rent` was **removed in Anchor 0.31**. There is no `rent` constraint, and no\n`rent: Sysvar<'info, Rent>` field to add alongside it. Anchor reads the rent parameters itself and\ncomputes the deposit from `space`. Any tutorial still passing it predates 0.31 by definition — which\nis a useful dating signal for everything else on that page.\n\nWhat you do still supply, every time, is `space`. And now you know what each term in it pays for.\n",
+        "src": "# On-Chain State\n\nSo far, our program doesn't store any data. Every instruction just logs a message and exits. To build anything useful, you need **on-chain state** — data that persists between transactions.\n\n## Accounts = Storage\n\nOn Solana, all state lives in **accounts**. An account is a buffer of bytes owned by a program. Think of it like a row in a database, but on-chain.\n\nEvery account has:\n- **Address** (public key) — how you find it\n- **Owner** (program ID) — which program can modify it\n- **Data** (byte array) — the actual state\n- **Lamports** (balance) — rent deposit to keep it alive\n\n## The Discriminator\n\nAnchor adds an 8-byte **discriminator** at the start of every account's data. This is a hash of the account type name, used to prevent account type confusion attacks.\n\n```\n[8 bytes discriminator][...your data...]\n```\n\nYou never read or write the discriminator directly — Anchor handles it.\n\n## Space Calculation\n\nWhen you create an account, you must specify its size upfront (accounts can't be resized after creation). The formula:\n\n```\nspace = 8 (discriminator) + sum of field sizes\n```\n\nCommon field sizes:\n- `u8` / `i8` / `bool` = 1 byte\n- `u16` / `i16` = 2 bytes\n- `u32` / `i32` = 4 bytes\n- `u64` / `i64` = 8 bytes\n- `u128` / `i128` = 16 bytes\n- `Pubkey` = 32 bytes\n- `String` = 4 (length prefix) + content bytes\n- `Vec<T>` = 4 (length prefix) + (count * size_of::<T>())\n\n## Example: A Counter\n\nA simple counter needs one `u64` field:\n\n```rust\n#[account]\npub struct Counter {\n    pub count: u64,  // 8 bytes\n}\n// Total space = 8 (discriminator) + 8 (u64) = 16 bytes\n```\n\nThe `#[account]` attribute tells Anchor to:\n1. Add serialization/deserialization (Borsh)\n2. Add the 8-byte discriminator\n3. Implement account validation traits\n\nIn the next challenge, you'll define this Counter account and wire it into your program.\n",
         "url": null,
         "language": null,
         "buildType": null,
@@ -2527,131 +2264,55 @@
         "questions": [
           {
             "id": "q1",
-            "prompt": "Your `VaultState` is `owner: Pubkey`, `balance: u64`, `bump: u8`. You are writing the `space` for its `init` constraint. What number does it have to come to, and why that number?",
+            "prompt": "A `Counter` holds one `u64`. What `space` must you allocate, and why that number?",
             "multiSelect": false,
             "options": [
               {
                 "id": "a",
-                "label": "49 — 8 discriminator + 32 + 8 + 1",
+                "label": "16 bytes — 8 for the discriminator plus 8 for the u64",
                 "correct": true,
                 "feedback": null
               },
               {
                 "id": "b",
-                "label": "41 — 32 + 8 + 1, the three fields",
+                "label": "8 bytes — just the u64",
                 "correct": false,
-                "feedback": "41 is `VaultState::INIT_SPACE`, which is deliberately the fields only. `space` also has to pay for the 8-byte discriminator Anchor writes in front of them, so it is `8 + INIT_SPACE` = 49. An account sized 41 is 8 bytes short, and the first write past the field boundary fails."
+                "feedback": "You forgot the discriminator. Every Anchor account starts with an 8-byte type discriminator, so a single u64 account needs 8 + 8 = 16."
               },
               {
                 "id": "c",
-                "label": "48 — that is what `std::mem::size_of::<VaultState>()` reports",
+                "label": "24 bytes — 8 discriminator + 8 length prefix + 8 u64",
                 "correct": false,
-                "feedback": "48 is Rust's in-memory size: 41 bytes of fields rounded up to the struct's 8-byte alignment. Borsh writes 41, with no padding at all. Sizing from `size_of` allocates for a layout that never reaches the account."
-              },
-              {
-                "id": "d",
-                "label": "57 — 8 discriminator + 8 length prefix + 32 + 8 + 1",
-                "correct": false,
-                "feedback": "Only variable-length types carry a length prefix — `String` and `Vec<T>` — and it is 4 bytes, not 8. Every field here is fixed-size, so there is no prefix to pay for."
+                "feedback": "A fixed-size `u64` has no length prefix; only dynamic types like String and Vec add one. The total is 8 + 8 = 16."
               }
             ],
-            "explanation": "`space` = 8 (discriminator) + the Borsh size of every field, in declaration order, with no padding: 8 + 32 + 8 + 1 = 49. Write it as that sum rather than as `49` so each term stays traceable, and reach for `8 + VaultState::INIT_SPACE` in production code so that adding a field cannot silently under-allocate."
+            "explanation": "space = 8 (discriminator) + sum of field sizes. A `u64` is 8 bytes, so a Counter is 8 + 8 = 16. This matters because accounts cannot be resized after creation — too small and writes fail, too large and the payer overpays rent."
           },
           {
             "id": "q2",
-            "prompt": "A teammate writes `space = 8 + std::mem::size_of::<VaultState>()`. It compiles and the program deploys. Predict what actually happens.",
+            "prompt": "Anchor prepends an 8-byte discriminator (a hash of the account type name) to every account. What attack does this prevent?",
             "multiSelect": false,
             "options": [
               {
                 "id": "a",
-                "label": "It works, and silently over-allocates — 56 bytes for a 49-byte account, so every vault locks more rent deposit than it needs",
+                "label": "Account type confusion — passing a different account type where a Counter is expected, since its discriminator will not match",
                 "correct": true,
                 "feedback": null
               },
               {
                 "id": "b",
-                "label": "It fails to compile — `size_of` is not const-evaluable in a constraint",
+                "label": "Double-spending of lamports",
                 "correct": false,
-                "feedback": "`size_of` is a `const fn`, so the expression evaluates fine at compile time. Nothing stops it, and that is exactly what makes this bug expensive: there is no error anywhere to point at it."
+                "feedback": "The discriminator is about type identity, not balances. It stops a program from mistaking one account type for another."
               },
               {
                 "id": "c",
-                "label": "Writes past byte 49 fail, because Borsh needs more room than `size_of` reports",
+                "label": "Replaying an old transaction",
                 "correct": false,
-                "feedback": "It goes the other way. Rust's `size_of` is 48 because of alignment padding; Borsh writes 41. The account ends up too big, never too small — so nothing fails, it just costs more."
-              },
-              {
-                "id": "d",
-                "label": "The account is created at 49 bytes anyway — Anchor recomputes `space` from the struct",
-                "correct": false,
-                "feedback": "Anchor allocates exactly the `space` you give it and does not second-guess the number. `#[derive(InitSpace)]` offers you a correct one in `INIT_SPACE`, but only if you use it."
+                "feedback": "Replay is handled by the recent blockhash, not the discriminator. The discriminator guards account type identity on deserialize."
               }
             ],
-            "explanation": "Rust's memory layout and Borsh's wire layout are different problems. `size_of::<VaultState>()` is 48 — 41 bytes rounded up to 8-byte alignment — so `8 + size_of` is 56 for an account that needs 49. Seven wasted bytes is roughly 48,700 lamports of deposit locked per vault (7 x 6,960), with nothing anywhere reporting it. `8 + VaultState::INIT_SPACE` is the form that stays correct."
-          },
-          {
-            "id": "q3",
-            "prompt": "Your `withdraw` expects `Account<'info, VaultState>`. Someone passes an account of a different type that happens to be 49 bytes and owned by your program. Where does this stop, and how?",
-            "multiSelect": false,
-            "options": [
-              {
-                "id": "a",
-                "label": "At deserialize, at runtime — the leading 8 bytes are that other type's discriminator, so they do not match `VaultState`'s",
-                "correct": true,
-                "feedback": null
-              },
-              {
-                "id": "b",
-                "label": "At compile time — `Account<'info, VaultState>` is a type, so the wrong type cannot be passed",
-                "correct": false,
-                "feedback": "The type only constrains your Rust. What arrives on the wire is a 32-byte address and a buffer; nothing about a transaction is type-checked by rustc. The check has to happen at runtime, and the discriminator is what makes it possible."
-              },
-              {
-                "id": "c",
-                "label": "It does not stop — the sizes match, so the bytes deserialize into a valid-looking `VaultState`",
-                "correct": false,
-                "feedback": "That is precisely what the discriminator exists to prevent, and what would happen without it. The first 8 bytes are checked before any field is read, and a mismatch is an error rather than a reinterpretation."
-              },
-              {
-                "id": "d",
-                "label": "The runtime rejects it, because only your program may pass its own accounts",
-                "correct": false,
-                "feedback": "The runtime enforces who may *write* an account, not who may pass one in. Anyone can put any address in an instruction's account list. Filtering what arrives is your program's job."
-              }
-            ],
-            "explanation": "Type confusion is a runtime problem because account data arrives as bytes. Anchor's 8-byte discriminator is derived from the account type's name, so it is checked on every deserialize and a mismatch is an error instead of a reinterpretation of foreign bytes as your struct. You buy this by typing `#[account]`, and you pay for it with 8 bytes of `space`."
-          },
-          {
-            "id": "q4",
-            "prompt": "You copy an `init` constraint from a blog post and it includes `rent = rent`. What does that tell you?",
-            "multiSelect": false,
-            "options": [
-              {
-                "id": "a",
-                "label": "It will not compile — the `rent` constraint was removed in Anchor 0.31, which also dates the rest of that post as pre-0.31",
-                "correct": true,
-                "feedback": null
-              },
-              {
-                "id": "b",
-                "label": "Nothing — it is optional, and harmless to keep for clarity",
-                "correct": false,
-                "feedback": "It is not optional, because it no longer exists. Anchor reads the rent parameters itself and derives the deposit from `space`. Leaving the constraint in is a build failure, not a stylistic choice."
-              },
-              {
-                "id": "c",
-                "label": "It is required whenever `payer` is present, to prove the payer can cover the deposit",
-                "correct": false,
-                "feedback": "`payer` is all Anchor needs. The deposit is computed from `space` and debited from the payer; there was never a version where `rent` proved anything about the payer's balance."
-              },
-              {
-                "id": "d",
-                "label": "Rent is still collected periodically, so the sysvar has to be passed to schedule it",
-                "correct": false,
-                "feedback": "Ongoing rent collection is gone, and an account's `rent_epoch` is vestigial. What remains is the one-time rent-exemption deposit, which scales with `space` and comes back if the account is closed."
-              }
-            ],
-            "explanation": "`rent = rent` and its companion `rent: Sysvar<'info, Rent>` field were both removed in Anchor 0.31; Anchor computes the rent-exempt minimum from `space` on its own. The useful part is the dating signal — a page still passing `rent` predates 0.31, so treat everything else it tells you about Anchor as equally old."
+            "explanation": "The 8-byte discriminator is derived from the account's type name, so Anchor rejects an account whose leading bytes do not match the expected `Counter` type. Without it, an attacker could pass a look-alike account and trick the program into interpreting foreign bytes as your struct."
           }
         ],
         "prompt": null,
@@ -2672,7 +2333,7 @@
         "_type": "prose",
         "produces": null,
         "consumes": null,
-        "src": "# Wire Up Initialize\n\n> **Version stamp — checked 2026-07-26.** `anchor-lang 1.1.2` (published 2026-06-26) · `cargo-build-sbf` with platform-tools v1.54 (rustc 1.89) · `borsh` resolves to **1.8.0** · edition 2021. Every compiler message quoted below — including the error count and the order they arrive in — was produced by compiling this lesson's deliberately-broken starter on that toolchain.\n\nThis lesson is different. The starter **does not compile**, on purpose, and the first thing you do is\npress Build and read what comes back.\n\nThat is not a warm-up. Reading Anchor's build output is a distinct skill from writing Anchor, most\npeople never practise it deliberately, and it is the difference between a five-second fix and an\nafternoon.\n\n## Task 1 — diagnose the bug\n\n1. Click **Build** before you change anything.\n2. Read the output **from the top**.\n3. Fix one thing.\n4. Build again.\n\nThe `InitializeVault` struct uses `#[account(init, ...)]` to create the vault PDA, and it is missing a\nrequired account. There is a comment where it should be.\n\n### What the output will look like\n\nYou will get ten errors. Nine of them are noise, and knowing that is most of the skill.\n\nThe **first** line is Anchor's own, and in Anchor 1.x it is unusually direct:\n\n```\nerror: a non-optional init constraint requires a non-optional system_program field\nto exist in the account validation struct. Use the Program type to add the\nsystem_program field to your validation struct.\n```\n\nEverything after it is fallout. `#[derive(Accounts)]` gave up, so the items it was going to generate\nnever appeared, and rustc reports each absence separately:\n\n```\nerror[E0432]: unresolved import `crate`\nerror[E0277]: the trait bound `InitializeVault<'_>: Bumps` is not satisfied\nerror[E0599]: no function or associated item named `try_accounts` found for struct `InitializeVault`\nerror[E0277]: the trait bound `InitializeVault<'_>: anchor_lang::Accounts<'_, _>` is not satisfied\n```\n\nNone of those is a real problem. There is one problem, stated once, at the top.\n\nOlder Anchor versions did not print that first line at all — you got the trait-bound cascade and\nnothing else, which is why \"the trait bound `Accounts` is not satisfied\" is still the most-searched\nAnchor error on the internet and why so many answers to it are guesswork. Anchor 1.x tells you the\nanswer plainly and then buries it under nine more lines. **Read from the top, fix one thing, build\nagain.**\n\nOne of those nine is the verification harness at the bottom of the file also noticing the missing\nfield. It lands last, long after Anchor has already told you.\n\n### Why `init` needs the System Program at all\n\nYour program cannot create accounts. Nothing can, except the System Program — allocation and ownership\nassignment are its instructions, and every account on Solana was created by a call to it.\n\nSo `init` is not a local operation. It expands into a **cross-program invocation**: your program calls\nthe System Program's `create_account`, which allocates `space` bytes, assigns the new account's owner to\nyour program id, and moves the rent-exempt deposit from `payer`. A CPI needs the callee in the\ntransaction's account list, so `system_program` has to be a field on the struct. Anchor will not add it\nfor you, and it is telling you so.\n\nModule 3 makes CPIs explicit, with transfers you write yourself. This one you have been making since\nlesson 3 without seeing it.\n\n### One thing not to do\n\nThere is a way to make the build pass that is worse than the bug. Deleting `init` — or replacing it\nwith `mut` — removes the constraint that needed the System Program, and the file compiles. It also no\nlonger creates anything.\n\nThe verification harness at the bottom of the file names `system_program` as a required field, so that\nparticular escape is closed: drop `init` and stop there, and the harness fails you. Be precise about\nhow far that goes, though — drop `init` *and* add `system_program` anyway, and the build is green on a\nprogram that creates nothing. `init` is not something a compiler can check for. Take it as the general\nwarning: on this platform a green build means *the file compiled*, and \"make the error go away\" and\n\"make the program correct\" are different goals that occasionally point in opposite directions.\n\n## Task 2 — write the body\n\nOnce it builds, the handler is yours to write. No scaffolding this time.\n\nBy the time `initialize_vault` runs, the account exists: 49 bytes allocated, owner set to your program,\ndiscriminator written, every field zero. What it does not have is meaning. Three assignments give it\nsome:\n\n1. **`owner`** — the wallet this vault belongs to. Module 3's `has_one = owner` check reads exactly this\n   field to reject a withdrawal signed by somebody else. Get it from the accounts struct.\n2. **`balance`** — zero. The bytes are already zero, so the line changes nothing; write it anyway,\n   because the next person to read the handler should not have to know that in order to trust it.\n3. **`bump`** — the canonical bump Anchor derived a moment ago, so `deposit` and `withdraw` can use\n   `bump = vault.bump` instead of re-running the search on every call. Anchor hands it to you on\n   `ctx.bumps`, under this account's own field name.\n\n### What the grader can and cannot see\n\nCompile-only grading means the harness can prove your struct holds the right three accounts, and can\nprove `ctx.bumps.vault` is reachable. It cannot see the body. A handler that assigns nothing at all\ncompiles exactly as well as a correct one.\n\nSo this rung is graded on the bug and trusted on the body — and the untrusted half is exactly what\nmodule 4's LiteSVM lesson shows you how to check, before you spend a lamport of devnet SOL on it.\nReading that test and knowing why compiling could not replace it is the point.\n",
+        "src": "# Challenge: Wire Up Initialize\n\nThis challenge is different. The starter code has a **deliberate bug** — it won't compile.\n\nYour job:\n1. Click **Build** to see the compiler error\n2. Read the error message carefully\n3. Fix the code\n4. Build again until it compiles\n\n## The Bug\n\nThe `Initialize` struct uses `#[account(init, ...)]` to create a `Counter` PDA, but it's missing a required account. When Anchor generates the account creation code, it needs the System Program to execute the `create_account` instruction.\n\n## What You'll Learn\n\nThis is the most common Anchor compile error you'll encounter in the wild. Learning to diagnose it now saves you hours of debugging later.\n\n## Requirements\n\n1. Read the compiler error output\n2. Add the missing account to `Initialize`\n3. Make sure `initialize` sets `counter.count = 0` and `counter.authority = ctx.accounts.user.key()`\n",
         "url": null,
         "language": null,
         "buildType": null,
@@ -2698,39 +2359,32 @@
         "language": "rust",
         "buildType": "buildable",
         "deployable": false,
-        "starter": "use anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n// ─────────────────────────────────────────────────────────────────────────────\n// Your Course 2 vault core, imported and not retyped. Nothing in here is broken.\n// ─────────────────────────────────────────────────────────────────────────────\npub mod vault {\n    use super::*;\n\n    #[account]\n    #[derive(InitSpace)]\n    pub struct VaultState {\n        pub owner: Pubkey,\n        pub balance: u64,\n        pub bump: u8,\n    }\n\n    #[error_code]\n    pub enum VaultError {\n        #[msg(\"Deposit would overflow the vault balance\")]\n        Overflow,\n        #[msg(\"Withdrawal is larger than the vault balance\")]\n        InsufficientFunds,\n        #[msg(\"Amount must be greater than zero\")]\n        ZeroAmount,\n        #[msg(\"Signer is not the vault owner\")]\n        NotOwner,\n    }\n\n    impl VaultState {\n        pub fn deposit(&mut self, amount: u64) -> Result<()> {\n            require!(amount > 0, VaultError::ZeroAmount);\n            self.balance = self\n                .balance\n                .checked_add(amount)\n                .ok_or(VaultError::Overflow)?;\n            Ok(())\n        }\n\n        pub fn withdraw(&mut self, amount: u64) -> Result<()> {\n            require!(amount > 0, VaultError::ZeroAmount);\n            self.balance = self\n                .balance\n                .checked_sub(amount)\n                .ok_or(VaultError::InsufficientFunds)?;\n            Ok(())\n        }\n    }\n}\n\npub use vault::{VaultError, VaultState};\n\n#[program]\npub mod vault_program {\n    use super::*;\n\n    pub fn initialize_vault(ctx: Context<InitializeVault>) -> Result<()> {\n        let vault = &mut ctx.accounts.vault;\n\n        // TASK 2 — the handler body. Three lines, no scaffolding this time.\n        //\n        // By the time this runs the account exists: allocated, program-owned,\n        // discriminator written, every field zero. What it does not have is\n        // meaning. Give it the three things `deposit` and `withdraw` will need —\n        // who it belongs to, what it holds, and the bump that proves its address.\n        //\n        // Names and types are in `VaultState` above. The bump Anchor just derived\n        // is on `ctx.bumps`, under this account's own field name.\n\n        msg!(\"Vault initialized for {}\", vault.owner);\n        Ok(())\n    }\n\n    pub fn vault_info(_ctx: Context<VaultInfo>) -> Result<()> {\n        msg!(\"Vault program online\");\n        Ok(())\n    }\n}\n\n#[derive(Accounts)]\npub struct InitializeVault<'info> {\n    #[account(\n        init,\n        payer = user,\n        space = 8 + 32 + 8 + 1,\n        seeds = [b\"vault\", user.key().as_ref()],\n        bump\n    )]\n    pub vault: Account<'info, VaultState>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n    // BUG: Something is missing here...\n}\n\n#[derive(Accounts)]\npub struct VaultInfo {}\n\n// ─────────────────────────────────────────────────────────────────────────────\n// VERIFICATION HARNESS — DO NOT EDIT ANYTHING BELOW THIS LINE.\n//\n// A TYPE check, not a behaviour check. It names the three accounts the struct\n// must hold, so that \"make the build pass\" cannot be satisfied by deleting the\n// constraint that caused the failure.\n//\n// It cannot see the handler body at all. Whether you assigned the three fields,\n// and whether you assigned them the right values, is invisible to a compile-only\n// grader — there are no hidden tests on the Rust path. Module 4 proves that part\n// against a real runtime.\n// ─────────────────────────────────────────────────────────────────────────────\n#[doc(hidden)]\n#[allow(dead_code)]\nmod verify {\n    use super::*;\n\n    const _: () = assert!(VaultState::DISCRIMINATOR.len() == 8);\n    const _: () = assert!(VaultState::INIT_SPACE == 41);\n\n    fn pin_bump(bumps: &InitializeVaultBumps) -> u8 {\n        bumps.vault\n    }\n\n    fn pin_vault<'info>(a: &'info InitializeVault<'info>) -> &'info Account<'info, VaultState> {\n        &a.vault\n    }\n    fn pin_user<'info>(a: &'info InitializeVault<'info>) -> &'info Signer<'info> {\n        &a.user\n    }\n    fn pin_system<'info>(a: &'info InitializeVault<'info>) -> &'info Program<'info, System> {\n        &a.system_program\n    }\n}\n",
-        "solution": "use anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n// ─────────────────────────────────────────────────────────────────────────────\n// Your Course 2 vault core, imported and not retyped.\n// ─────────────────────────────────────────────────────────────────────────────\npub mod vault {\n    use super::*;\n\n    #[account]\n    #[derive(InitSpace)]\n    pub struct VaultState {\n        pub owner: Pubkey,\n        pub balance: u64,\n        pub bump: u8,\n    }\n\n    #[error_code]\n    pub enum VaultError {\n        #[msg(\"Deposit would overflow the vault balance\")]\n        Overflow,\n        #[msg(\"Withdrawal is larger than the vault balance\")]\n        InsufficientFunds,\n        #[msg(\"Amount must be greater than zero\")]\n        ZeroAmount,\n        #[msg(\"Signer is not the vault owner\")]\n        NotOwner,\n    }\n\n    impl VaultState {\n        pub fn deposit(&mut self, amount: u64) -> Result<()> {\n            require!(amount > 0, VaultError::ZeroAmount);\n            self.balance = self\n                .balance\n                .checked_add(amount)\n                .ok_or(VaultError::Overflow)?;\n            Ok(())\n        }\n\n        pub fn withdraw(&mut self, amount: u64) -> Result<()> {\n            require!(amount > 0, VaultError::ZeroAmount);\n            self.balance = self\n                .balance\n                .checked_sub(amount)\n                .ok_or(VaultError::InsufficientFunds)?;\n            Ok(())\n        }\n    }\n}\n\npub use vault::{VaultError, VaultState};\n\n#[program]\npub mod vault_program {\n    use super::*;\n\n    pub fn initialize_vault(ctx: Context<InitializeVault>) -> Result<()> {\n        let vault = &mut ctx.accounts.vault;\n\n        // TASK 2. Three assignments, and every one of them is load-bearing later:\n        //   · `owner` is what module 3's `has_one = owner` check reads to reject\n        //     somebody else's withdrawal.\n        //   · `balance` starts at zero explicitly. The bytes are already zero, so\n        //     this line changes nothing — and it is still worth writing, because\n        //     the next person to read the handler should not have to know that.\n        //   · `bump` is stored once here so that `deposit` and `withdraw` can use\n        //     `bump = vault.bump` instead of re-running the derivation search.\n        vault.owner = ctx.accounts.user.key();\n        vault.balance = 0;\n        vault.bump = ctx.bumps.vault;\n\n        msg!(\"Vault initialized for {}\", vault.owner);\n        Ok(())\n    }\n\n    pub fn vault_info(_ctx: Context<VaultInfo>) -> Result<()> {\n        msg!(\"Vault program online\");\n        Ok(())\n    }\n}\n\n#[derive(Accounts)]\npub struct InitializeVault<'info> {\n    #[account(\n        init,\n        payer = user,\n        space = 8 + 32 + 8 + 1,\n        seeds = [b\"vault\", user.key().as_ref()],\n        bump\n    )]\n    pub vault: Account<'info, VaultState>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n    // TASK 1. `init` creates the account by calling the System Program, so the\n    // System Program has to be in the account list. Anchor never injects it.\n    pub system_program: Program<'info, System>,\n}\n\n#[derive(Accounts)]\npub struct VaultInfo {}\n\n// ─────────────────────────────────────────────────────────────────────────────\n// VERIFICATION HARNESS — DO NOT EDIT ANYTHING BELOW THIS LINE.\n// A type check, not a behaviour check. See the starter for its exact reach.\n// ─────────────────────────────────────────────────────────────────────────────\n#[doc(hidden)]\n#[allow(dead_code)]\nmod verify {\n    use super::*;\n\n    const _: () = assert!(VaultState::DISCRIMINATOR.len() == 8);\n    const _: () = assert!(VaultState::INIT_SPACE == 41);\n\n    fn pin_bump(bumps: &InitializeVaultBumps) -> u8 {\n        bumps.vault\n    }\n\n    fn pin_vault<'info>(a: &'info InitializeVault<'info>) -> &'info Account<'info, VaultState> {\n        &a.vault\n    }\n    fn pin_user<'info>(a: &'info InitializeVault<'info>) -> &'info Signer<'info> {\n        &a.user\n    }\n    fn pin_system<'info>(a: &'info InitializeVault<'info>) -> &'info Program<'info, System> {\n        &a.system_program\n    }\n}\n",
+        "starter": "use anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n#[program]\npub mod academy_program {\n    use super::*;\n\n    pub fn initialize(ctx: Context<Initialize>) -> Result<()> {\n        let counter = &mut ctx.accounts.counter;\n        counter.count = 0;\n        counter.authority = ctx.accounts.user.key();\n        msg!(\"Counter initialized!\");\n        Ok(())\n    }\n\n    pub fn greet(_ctx: Context<Greet>) -> Result<()> {\n        msg!(\"Hello, Solana!\");\n        Ok(())\n    }\n}\n\n#[derive(Accounts)]\npub struct Initialize<'info> {\n    #[account(\n        init,\n        payer = user,\n        space = 8 + 8 + 32,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n    // BUG: Something is missing here...\n}\n\n#[derive(Accounts)]\npub struct Greet {}\n\n#[account]\npub struct Counter {\n    pub count: u64,\n    pub authority: Pubkey,\n}\n",
+        "solution": "use anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n#[program]\npub mod academy_program {\n    use super::*;\n\n    pub fn initialize(ctx: Context<Initialize>) -> Result<()> {\n        let counter = &mut ctx.accounts.counter;\n        counter.count = 0;\n        counter.authority = ctx.accounts.user.key();\n        msg!(\"Counter initialized!\");\n        Ok(())\n    }\n\n    pub fn greet(_ctx: Context<Greet>) -> Result<()> {\n        msg!(\"Hello, Solana!\");\n        Ok(())\n    }\n}\n\n#[derive(Accounts)]\npub struct Initialize<'info> {\n    #[account(\n        init,\n        payer = user,\n        space = 8 + 8 + 32,\n        seeds = [b\"counter\", user.key().as_ref()],\n        bump\n    )]\n    pub counter: Account<'info, Counter>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n    pub system_program: Program<'info, System>,\n}\n\n#[derive(Accounts)]\npub struct Greet {}\n\n#[account]\npub struct Counter {\n    pub count: u64,\n    pub authority: Pubkey,\n}\n",
         "tests": [
           {
-            "id": "t1",
-            "description": "The file compiles on the build server against anchor-lang 1.1.2 — the deliberate bug is fixed",
+            "id": "test-1",
+            "description": "Program compiles successfully",
             "input": "",
             "expectedOutput": "true"
           },
           {
-            "id": "t2",
-            "description": "Compiles ⇒ InitializeVault holds system_program: Program<'info, System>, which init requires",
+            "id": "test-2",
+            "description": "Initialize struct includes system_program",
             "input": "",
             "expectedOutput": "true"
           },
           {
-            "id": "t3",
-            "description": "Compiles ⇒ the vault still carries seeds + bump: the build was fixed by adding an account, not by dropping the PDA derivation. (init itself is not compile-visible — the harness cannot see it.)",
-            "input": "",
-            "expectedOutput": "true"
-          },
-          {
-            "id": "t4",
-            "description": "Compiles ⇒ VaultState still has owner: Pubkey, balance: u64, bump: u8 — INIT_SPACE is 41",
+            "id": "test-3",
+            "description": "Counter is initialized to zero",
             "input": "",
             "expectedOutput": "true"
           }
         ],
         "hints": [
           "Click Build first to see the error. The compiler will tell you what's missing.",
-          "Read the output from the top. The first line is Anchor's own and it names the fix outright — everything after it is a cascade of trait-bound errors on `InitializeVault` caused by `#[derive(Accounts)]` having aborted. Ten errors, one problem, stated once, at the top.",
-          "Add `pub system_program: Program<'info, System>,` to the `InitializeVault` struct. The System Program is required whenever you use `#[account(init)]`, because creating an account is a CPI to it.",
-          "For task 2: the handler has to persist three things, and `ctx` carries all of them. Two are values you already know at call time — who the owner is, and what a brand-new balance should be. The third is the bump Anchor just computed while deriving the address, which it hands back on `ctx.bumps`, named after the field. Do not hardcode it."
+          "The error mentions a trait bound related to Accounts. This happens when a required account is missing from the struct.",
+          "Add `pub system_program: Program<'info, System>,` to the Initialize struct. The System Program is required whenever you use `#[account(init)]`."
         ],
         "questions": null,
         "prompt": null,
@@ -2739,12 +2393,10 @@
         "network": null,
         "idl": null,
         "tutorNotes": [
-          "Learners try to satisfy the failing build by deleting or loosening the `init` constraint, instead of supplying the account that `init` requires. The harness only half-closes this: drop `seeds`/`bump` and it fails, but drop `init` alone and the build goes green on a program that creates nothing. Name the instinct — the compiler will not.",
-          "They scroll to the *last* error, or the loudest, rather than the first. Anchor 1.x prints the real diagnosis on line one and then nine consequences of the derive macro aborting.",
-          "They guess at a fix without clicking Build first, so they never read what the compiler is actually asking for — and hint 1 exists only to make them read it.",
-          "When they do add the missing account they give it a bare `AccountInfo` or `UncheckedAccount` type instead of `Program<'info, System>`, which loses the check that this is really the System Program.",
-          "On task 2 they write `vault.bump = 255`, having read that the search starts at 255. Which bump is canonical depends on the seeds and the program id, so a hardcoded 255 is wrong for roughly half of all vaults — and compiles.",
-          "Task 2 is invisible to the grader. A learner who fixes the bug and writes no body at all gets a green build, so say plainly that the body is trusted here, and that module 4 shows the test that would prove it."
+          "Learners try to satisfy the failing build by deleting or loosening the `init` constraint, instead of supplying the account that `init` requires.",
+          "They read only the surface of the trait-bound error, which names `Accounts` rather than a field, and start editing the wrong struct.",
+          "They guess at a fix without clicking Build first, so they never read what the compiler is actually asking for.",
+          "When they do add the missing account they give it a bare `AccountInfo` or `UncheckedAccount` type instead of the typed program wrapper Anchor expects."
         ]
       },
       {
@@ -2764,44 +2416,38 @@
         "questions": [
           {
             "id": "q1",
-            "prompt": "An `InitializeVault` struct uses `#[account(init, ...)]` and omits the System Program. Predict the build output on Anchor 1.x.",
+            "prompt": "An `Initialize` struct uses `#[account(init, ...)]` but omits the System Program. What does the compiler tell you, and why?",
             "multiSelect": false,
             "options": [
               {
                 "id": "a",
-                "label": "One Anchor error naming `system_program` outright, followed by nine more errors on `InitializeVault` — all consequences of the derive macro aborting",
+                "label": "A trait-bound error on `Accounts` — `init` generates a `create_account` CPI that needs the System Program present",
                 "correct": true,
                 "feedback": null
               },
               {
                 "id": "b",
-                "label": "Only the trait-bound errors, with nothing naming the missing field",
+                "label": "A runtime 'account not found' error, only when the instruction is called",
                 "correct": false,
-                "feedback": "That was the pre-1.x experience, and it is why \"the trait bound `Accounts` is not satisfied\" is still the most-searched Anchor error on the internet. Anchor 1.x prints an explicit diagnosis first — you just have to read from the top to find it."
+                "feedback": "It fails at compile time, not runtime. Anchor cannot generate valid account-creation code without the System Program, so the build breaks."
               },
               {
                 "id": "c",
-                "label": "A runtime \"account not found\" error, only when the instruction is called",
-                "correct": false,
-                "feedback": "It fails at compile time. Anchor cannot generate the account-creation code without knowing which program to call, so the build breaks before anything is deployable."
-              },
-              {
-                "id": "d",
                 "label": "No error — Anchor injects the System Program automatically",
                 "correct": false,
-                "feedback": "Anchor never injects accounts. `init` requires you to declare `system_program: Program<'info, System>` explicitly, and the whole point of the message is to say so."
+                "feedback": "Anchor does not inject it. `init` requires you to declare `system_program: Program<'info, System>` explicitly, or the generated code fails the Accounts trait."
               }
             ],
-            "explanation": "Creating an account is a CPI to the System Program, so `init` compiles only when that program is in the accounts struct. Anchor 1.x reports it directly — \"a non-optional init constraint requires a non-optional system_program field\" — and then `#[derive(Accounts)]` aborts, so the `Bumps`, `Accounts` and `try_accounts` items it was going to generate all come back missing. One problem, ten errors, and the real one is first."
+            "explanation": "Account creation is a CPI to the System Program, so `init` only compiles when that program is in the accounts struct. Omitting it makes Anchor's generated code fail the `Accounts` trait bound — a cryptic-looking error whose fix is always to add the missing account."
           },
           {
             "id": "q2",
-            "prompt": "Why is learning to read this particular build output worth a whole lesson?",
+            "prompt": "Why is learning to read this trait-bound error worth a whole lesson?",
             "multiSelect": false,
             "options": [
               {
                 "id": "a",
-                "label": "Because macro-generated code fails in cascades — one mistake produces ten errors — and the habit of reading the first one is what makes Anchor tractable",
+                "label": "It is the most common Anchor compile error, and its message points at a trait rather than the real cause: a missing account",
                 "correct": true,
                 "feedback": null
               },
@@ -2809,54 +2455,16 @@
                 "id": "b",
                 "label": "Because it only appears on devnet, never locally",
                 "correct": false,
-                "feedback": "It is a compile-time error, identical everywhere. The lesson exists because the output is *shaped* confusingly, not because it is environment-specific."
+                "feedback": "It is a compile-time error, identical everywhere. The lesson exists because the message is indirect, not because it is environment-specific."
               },
               {
                 "id": "c",
                 "label": "Because it means your program is unsafe to deploy",
                 "correct": false,
-                "feedback": "It is not a safety warning; it is a missing-account compile error. The transferable part is the reading habit, not this one fix."
-              },
-              {
-                "id": "d",
-                "label": "Because the fix differs between Anchor versions",
-                "correct": false,
-                "feedback": "The fix has been the same since Anchor learned the constraint: declare the System Program. What changed in 1.x is the quality of the message, not the answer."
+                "feedback": "It is not a safety warning — it is a missing-account compile error. The point is recognizing the indirect message and knowing the fix."
               }
             ],
-            "explanation": "Anchor generates account validation through macros, so a single missing field takes every generated item down with it and rustc reports each absence separately. Every constraint mistake you make from here on will look like this: one honest line, then a wall. Read the top, fix one thing, build again — that loop is the actual deliverable of this lesson."
-          },
-          {
-            "id": "q3",
-            "prompt": "You fix the bug, then write `vault.bump = 255;` in the handler because the derivation search starts at 255. Predict what happens.",
-            "multiSelect": false,
-            "options": [
-              {
-                "id": "a",
-                "label": "It compiles and deploys, and roughly half of all vaults store the wrong bump — every later `bump = vault.bump` check on those fails",
-                "correct": true,
-                "feedback": null
-              },
-              {
-                "id": "b",
-                "label": "It fails to compile — Anchor knows the canonical bump and rejects a literal",
-                "correct": false,
-                "feedback": "`vault.bump` is a plain `u8` field and `255` is a plain `u8`. Nothing in the type system connects that assignment to the bump Anchor derived. This is exactly the class of bug compile-only grading cannot see."
-              },
-              {
-                "id": "c",
-                "label": "It works — 255 is always the canonical bump",
-                "correct": false,
-                "feedback": "255 is where the search *starts*. About half of all candidates land off the curve, so 255 works about half the time and the answer depends entirely on the seeds and the program id. That is precisely why the derivation returns the bump rather than assuming it."
-              },
-              {
-                "id": "d",
-                "label": "It works, because Anchor overwrites the field with the real bump on deserialize",
-                "correct": false,
-                "feedback": "Anchor deserializes what is in the account's bytes and never rewrites your fields. Whatever you store is what every later instruction reads."
-              }
-            ],
-            "explanation": "The canonical bump is the first value counting down from 255 whose derived address lands off the Ed25519 curve, and which value that is depends on the seeds and the program id. `ctx.bumps.vault` is the one Anchor just computed for this exact account; a hardcoded 255 is a guess that compiles, deploys, and then makes `bump = vault.bump` fail in `deposit` for every vault where the guess was wrong. A build server that only compiles cannot catch this — module 4 shows you the LiteSVM test that would, on the first call."
+            "explanation": "Because Anchor generates account-validation code via macros, a missing account surfaces as a trait-bound error on `Accounts`, not a plain 'you forgot system_program.' Recognizing that pattern turns hours of confusion into a one-line fix."
           }
         ],
         "prompt": null,
@@ -2869,15 +2477,15 @@
   },
   {
     "_id": "lesson-bfsp-your-first-build",
-    "title": "From Rust Core to Anchor",
-    "slug": "from-rust-core-to-anchor",
+    "title": "Your First Build",
+    "slug": "your-first-build",
     "blocks": [
       {
         "key": "intro",
         "_type": "prose",
         "produces": null,
         "consumes": null,
-        "src": "# From Rust Core to Anchor\n\n> **Version stamp — checked 2026-07-26.** `anchor-lang 1.1.2` (published 2026-06-26) · `cargo-build-sbf` with platform-tools v1.54 (rustc 1.89) · `borsh` resolves to **1.8.0** · edition 2021. This lesson's starter and solution were both compiled against that toolchain; the build is green with no edits.\n\nYou have a file that compiles. It is called `vault_core.rs`, you wrote it at the end of Course 2, and it holds a `VaultState` struct, a `VaultError` enum, and two methods that do checked arithmetic and return named errors instead of panicking.\n\nIt is not a Solana program. It has no `#[program]` module and no `#[derive(Accounts)]` struct — **that is what this course adds.**\n\nThat distinction is the shape of all fifteen lessons in this course, so be precise about it. Nothing in Course 2 was a program: `#[account]` and `#[error_code]` are Anchor attributes and you used both, but neither one makes a crate into something the runtime can call. A program needs an entrypoint and a dispatcher. You have not written one yet. You are about to compile one.\n\n## The two halves, side by side\n\nThe starter below is your Course 2 file with the wrapper added underneath it, separated by a labeled line. Here is the same split as a table.\n\n| Your Course 2 file                                   | What Course 3 adds                                                             |\n| ---------------------------------------------------- | ------------------------------------------------------------------------------ |\n| `pub mod vault { … }` — an ordinary Rust module       | `#[program] pub mod vault_program { … }` — instruction handlers                 |\n| `#[account] pub struct VaultState` — a *shape*        | `#[derive(Accounts)] pub struct DryRun` — an *account list*                     |\n| `#[error_code] pub enum VaultError` — named failures  | nothing: one per program is the practice, and you already have yours            |\n| `impl VaultState { deposit, withdraw }` — the logic   | handler bodies that **call** `deposit` and `withdraw`                           |\n| Callable only from other Rust                        | Callable from a transaction, by address                                        |\n\nTwo attributes doing two different jobs:\n\n**`#[program]`** expands the module into a dispatcher and a program entrypoint. Every `pub fn` inside becomes a callable instruction, selected by an 8-byte discriminator derived from its name. This is the line that turns a library into a program.\n\n**`#[derive(Accounts)]`** generates the deserialization and validation code for one instruction's account list. `DryRun` is empty, so `dry_run` may touch no accounts at all — which is exactly why nothing it does survives the transaction. Read the handler and notice what is absent: there is no account, so `VaultState` is a value on the stack, `deposit` mutates it, and it is gone when the instruction returns. Module 2 is where the vault stops being a local variable.\n\nWhat the body *does* show is the division of labour for the rest of the course. It calls `vault.deposit(1_000)?` — your method, imported, not retyped. Handlers validate accounts and delegate; the arithmetic stays in the core you already reasoned through line by line.\n\n## What happens when you press Build\n\nFour stages, none of them on your machine:\n\n1. **Rust source** — the single file in the editor. It becomes `src/lib.rs` of a fixed crate, the one whose `Cargo.toml` you read at the end of Course 2.\n2. **`cargo-build-sbf`** — the Solana compiler driver. It compiles the crate to Solana Bytecode Format, a register-based instruction set derived from eBPF and executed by the runtime's VM: sandboxed, with no host filesystem and no sockets, and deterministic, because the same inputs must produce the same result on every validator.\n3. **A `.so` binary** — an ELF shared object. The build response carries its identifier; in module 4 one of these gets uploaded to devnet.\n4. **A green check, or compiler output** — back in the browser tab.\n\nThe toolchain the build server pins, which is the version stamp for every code block in this course:\n\n| Layer          | Version                                             |\n| -------------- | --------------------------------------------------- |\n| `anchor-lang`  | **1.1.2**                                           |\n| platform-tools | **v1.54** — rustc 1.89, Anchor 1.x's minimum        |\n| Rust edition   | 2021                                                |\n| `borsh`        | `1.5.7`, a range — so 1.8.0 is what actually resolves |\n\nTwo consequences worth internalising now. **Warnings are not failures:** this starter returns six of them, every one from inside the `#[program]` expansion, and the build is green. And **the sandbox is real:** the server rejects a submission containing `std::process`, `std::fs::`, `std::net::`, `std::env::`, `Command::new`, `include_bytes!`, `include_str!`, `env!(`, `option_env!` or `proc_macro` before the compiler ever sees it. None of those belongs in a program anyway.\n\nBe exact about what a green check proves: **your code compiled against the real Anchor 1.x toolchain.** No test ran. Nothing executed. A `withdraw` that calls `checked_add` compiles perfectly, and nothing in this course will catch it — module 4 shows you the LiteSVM test that would, and why no compiler can.\n\n## The seam: two things called \"Anchor\"\n\nSearch for Anchor documentation today and you will land on material for a different version of a differently-named package. Three facts save you an afternoon.\n\n- **The Rust crate is `anchor-lang`, at `1.1`.** Anchor 1.0 was a breaking release and the internet has not caught up. When a snippet does not compile here, suspect its age before you suspect yourself; the specific breakages are called out in the lessons where they bite.\n- **The TypeScript package is `@anchor-lang/core`.** The old one, `@coral-xyz/anchor`, is frozen at 0.32.1 and still pulls roughly 659k weekly downloads against `@anchor-lang/core`'s 16k. Popularity is not currency — that ratio measures how much stale tutorial code is in circulation. You need the TS side in Course 4, not here, but you will meet the wrong package name long before then.\n- **The version manager installs from `otter-sec/anchor`,** not `coral-xyz/anchor`. Maintenance moved. A `cargo install --git …/coral-xyz/anchor avm` line dates a blog post on its own.\n\nNone of this is your problem in this lesson, because you are installing nothing. That is what the build server is for: no toolchain, no version manager, no `PATH`. Browser builds are not new — Solana Playground has offered them for years and the Foundation's own quickstart uses one. What is different here is that this path is **graded, sequenced and credentialed**, and the program you deploy in module 4 is an artifact that three later things consume.\n\n## Your job\n\nPress **Build**. Change nothing. Read the output.\n",
+        "src": "# Your First Build\n\nThis is the simplest challenge in the entire course. Your goal: **hit the Build button and see it succeed.**\n\nThe starter code is a minimal Anchor program that compiles with zero changes. Don't modify anything — just click **Build** and watch the build server compile your first Solana program.\n\n## What to Expect\n\n- The build takes 30-60 seconds on first run (dependencies are cached after that)\n- You'll see compiler output in the panel below\n- A green checkmark means your program compiled to a `.so` binary\n- The build UUID is your compiled program's identifier\n\n## Why This Matters\n\nThis proves the pipeline works end-to-end: your code leaves the browser, reaches the build server, gets compiled by `cargo-build-sbf`, and the result comes back. Every lesson after this builds on this foundation.\n",
         "url": null,
         "language": null,
         "buildType": null,
@@ -2903,18 +2511,12 @@
         "language": "rust",
         "buildType": "buildable",
         "deployable": false,
-        "starter": "// From Rust core to Anchor — nothing to write. Click Build.\n//\n// This file is your Course 2 `vault_core.rs`, unchanged, with the Anchor wrapper\n// added underneath it. The two halves are separated by a labeled line so you can\n// see exactly where your code stops and this course's material starts.\n//\n// If you did not take Course 2, this is the reference version — it is a correct\n// vault core, and starting here is a supported path.\n\n// ─────────────────────────────────────────────────────────────────────────────\n// YOUR COURSE 2 FILE — copied in verbatim, from the `use` line to the re-export.\n// Not one character of it changes in this course.\n// ─────────────────────────────────────────────────────────────────────────────\nuse anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\npub mod vault {\n    use super::*;\n\n    #[account]\n    #[derive(InitSpace)]\n    pub struct VaultState {\n        pub owner: Pubkey,\n        pub balance: u64,\n        pub bump: u8,\n    }\n\n    #[error_code]\n    pub enum VaultError {\n        #[msg(\"Deposit would overflow the vault balance\")]\n        Overflow,\n        #[msg(\"Withdrawal is larger than the vault balance\")]\n        InsufficientFunds,\n        #[msg(\"Amount must be greater than zero\")]\n        ZeroAmount,\n        #[msg(\"Signer is not the vault owner\")]\n        NotOwner,\n    }\n\n    impl VaultState {\n        pub fn deposit(&mut self, amount: u64) -> Result<()> {\n            require!(amount > 0, VaultError::ZeroAmount);\n            self.balance = self\n                .balance\n                .checked_add(amount)\n                .ok_or(VaultError::Overflow)?;\n            Ok(())\n        }\n\n        pub fn withdraw(&mut self, amount: u64) -> Result<()> {\n            require!(amount > 0, VaultError::ZeroAmount);\n            self.balance = self\n                .balance\n                .checked_sub(amount)\n                .ok_or(VaultError::InsufficientFunds)?;\n            Ok(())\n        }\n    }\n}\n\npub use vault::{VaultError, VaultState};\n\n// ─────────────────────────────────────────────────────────────────────────────\n// EVERYTHING BELOW THIS LINE IS WHAT COURSE 3 ADDS.\n//\n// Two items, and they are the two your Course 2 file was missing:\n//\n//   #[program]          — turns a plain Rust module into a set of instructions\n//                         the Solana runtime can dispatch to. This is what makes\n//                         the crate a *program* and not a library.\n//   #[derive(Accounts)] — declares which accounts an instruction may touch.\n//                         `DryRun` declares none, and that is the entire reason\n//                         nothing below persists.\n//\n// Read the body of `dry_run`: it builds a `VaultState`, calls the `deposit` you\n// wrote in Course 2, and logs the result. The method is imported, not retyped.\n// That is the pattern for the rest of the course — a handler validates accounts\n// and then calls core logic that was already correct.\n// ─────────────────────────────────────────────────────────────────────────────\n#[program]\npub mod vault_program {\n    use super::*;\n\n    pub fn dry_run(_ctx: Context<DryRun>) -> Result<()> {\n        // Not an account — a value on this handler's stack, alive for exactly\n        // as long as this instruction runs.\n        let mut vault = VaultState {\n            owner: Pubkey::default(),\n            balance: 0,\n            bump: 0,\n        };\n\n        // Your Course 2 method, called unmodified. `?` needs no conversion here\n        // because `deposit` already returns `anchor_lang::Result<()>`.\n        vault.deposit(1_000)?;\n\n        msg!(\"program id: {}\", ID);\n        msg!(\"balance after deposit: {}\", vault.balance);\n        Ok(())\n    }\n}\n\n#[derive(Accounts)]\npub struct DryRun {}\n",
-        "solution": "// From Rust core to Anchor — the solution is the starter, unchanged.\n//\n// This is a no-edit lesson: the starter already compiles, and \"solving\" it means\n// pressing Build. The two files are identical on purpose, so that Reset Code and\n// Show Solution land you in exactly the same place.\n//\n// This file is your Course 2 `vault_core.rs`, unchanged, with the Anchor wrapper\n// added underneath it. The two halves are separated by a labeled line so you can\n// see exactly where your code stops and this course's material starts.\n//\n// If you did not take Course 2, this is the reference version — it is a correct\n// vault core, and starting here is a supported path.\n\n// ─────────────────────────────────────────────────────────────────────────────\n// YOUR COURSE 2 FILE — copied in verbatim, from the `use` line to the re-export.\n// Not one character of it changes in this course.\n// ─────────────────────────────────────────────────────────────────────────────\nuse anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\npub mod vault {\n    use super::*;\n\n    #[account]\n    #[derive(InitSpace)]\n    pub struct VaultState {\n        pub owner: Pubkey,\n        pub balance: u64,\n        pub bump: u8,\n    }\n\n    #[error_code]\n    pub enum VaultError {\n        #[msg(\"Deposit would overflow the vault balance\")]\n        Overflow,\n        #[msg(\"Withdrawal is larger than the vault balance\")]\n        InsufficientFunds,\n        #[msg(\"Amount must be greater than zero\")]\n        ZeroAmount,\n        #[msg(\"Signer is not the vault owner\")]\n        NotOwner,\n    }\n\n    impl VaultState {\n        pub fn deposit(&mut self, amount: u64) -> Result<()> {\n            require!(amount > 0, VaultError::ZeroAmount);\n            self.balance = self\n                .balance\n                .checked_add(amount)\n                .ok_or(VaultError::Overflow)?;\n            Ok(())\n        }\n\n        pub fn withdraw(&mut self, amount: u64) -> Result<()> {\n            require!(amount > 0, VaultError::ZeroAmount);\n            self.balance = self\n                .balance\n                .checked_sub(amount)\n                .ok_or(VaultError::InsufficientFunds)?;\n            Ok(())\n        }\n    }\n}\n\npub use vault::{VaultError, VaultState};\n\n// ─────────────────────────────────────────────────────────────────────────────\n// EVERYTHING BELOW THIS LINE IS WHAT COURSE 3 ADDS.\n//\n// Two items, and they are the two your Course 2 file was missing:\n//\n//   #[program]          — turns a plain Rust module into a set of instructions\n//                         the Solana runtime can dispatch to. This is what makes\n//                         the crate a *program* and not a library.\n//   #[derive(Accounts)] — declares which accounts an instruction may touch.\n//                         `DryRun` declares none, and that is the entire reason\n//                         nothing below persists.\n//\n// Read the body of `dry_run`: it builds a `VaultState`, calls the `deposit` you\n// wrote in Course 2, and logs the result. The method is imported, not retyped.\n// That is the pattern for the rest of the course — a handler validates accounts\n// and then calls core logic that was already correct.\n// ─────────────────────────────────────────────────────────────────────────────\n#[program]\npub mod vault_program {\n    use super::*;\n\n    pub fn dry_run(_ctx: Context<DryRun>) -> Result<()> {\n        // Not an account — a value on this handler's stack, alive for exactly\n        // as long as this instruction runs.\n        let mut vault = VaultState {\n            owner: Pubkey::default(),\n            balance: 0,\n            bump: 0,\n        };\n\n        // Your Course 2 method, called unmodified. `?` needs no conversion here\n        // because `deposit` already returns `anchor_lang::Result<()>`.\n        vault.deposit(1_000)?;\n\n        msg!(\"program id: {}\", ID);\n        msg!(\"balance after deposit: {}\", vault.balance);\n        Ok(())\n    }\n}\n\n#[derive(Accounts)]\npub struct DryRun {}\n",
+        "starter": "use anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n#[program]\npub mod academy_program {\n    use super::*;\n\n    pub fn initialize(_ctx: Context<Initialize>) -> Result<()> {\n        msg!(\"Superteam Academy default program\");\n        Ok(())\n    }\n}\n\n#[derive(Accounts)]\npub struct Initialize {}\n",
+        "solution": "use anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n#[program]\npub mod academy_program {\n    use super::*;\n\n    pub fn initialize(_ctx: Context<Initialize>) -> Result<()> {\n        msg!(\"Superteam Academy default program\");\n        Ok(())\n    }\n}\n\n#[derive(Accounts)]\npub struct Initialize {}\n",
         "tests": [
           {
-            "id": "t1",
-            "description": "The file compiles on the build server against anchor-lang 1.1.2",
-            "input": "",
-            "expectedOutput": "true"
-          },
-          {
-            "id": "t2",
-            "description": "Compiles ⇒ the Course 2 vault core and the #[program] wrapper coexist in one crate",
+            "id": "test-1",
+            "description": "Program compiles successfully",
             "input": "",
             "expectedOutput": "true"
           }
@@ -2931,12 +2533,11 @@
         "network": null,
         "idl": null,
         "tutorNotes": [
-          "Six `unexpected cfg condition value` warnings come back from inside the `#[program]` expansion on a correct build. They are warnings, the build is green, and a learner reading the first `warning:` as the reason it \"failed\" is the single most common confusion on this lesson. Point at the final line, not the first one.",
-          "The editor shows one file and the build server compiles it as `src/lib.rs` of a fixed crate. The manifest, the lockfile and the dependency versions are not editable. Requests to \"add a dependency\", \"split this into modules\" or \"put the vault in its own file\" cannot be satisfied by this pipeline — the inline `pub mod vault` is the workaround, not a style preference.",
-          "The build cache is keyed on the dependency graph, not on the learner's source, so the slow build is once per session and every later lesson in the course is fast even though the file changed. A learner who edits and waits 40 seconds again usually hit a cold worker, not their own code.",
-          "`declare_id!` is a placeholder until module 4. Pasting a different pubkey into it still builds green — nothing checks the value at compile time. The mismatch only surfaces at deploy, as `DeclaredProgramIdMismatch`, which is why the id is not worth changing here.",
-          "Nothing in this lesson executes. Grading is compile-success only: the server shells `cargo-build-sbf` and reports whether a `.so` came back. If asked whether `deposit` \"passed\", the honest answer is that no test ran — behaviour is not checked anywhere in this course — module 4 shows you the LiteSVM test that would check it, and why compiling cannot.",
-          "`dry_run` builds a `VaultState` on the stack, so its `balance` is discarded when the instruction returns. Learners often read the log line as proof that state was saved. Nothing was saved: `DryRun` declares no accounts, and `#[account]` describes a shape rather than creating storage."
+          "Learners edit the starter to feel productive, but it already compiles unchanged; a broken build here is almost always a self-inflicted edit, and the fix is Reset Code, not a new one.",
+          "They read the slow first build (dependencies downloading) or a timeout as a real failure and give up, instead of simply clicking Build again as the hints say.",
+          "They expect a local `cargo build` on their own machine and are thrown that compilation runs on the build server through the sbf toolchain, not their terminal.",
+          "They treat a compiler warning as the error and chase it, missing that the build actually succeeded — a green check means the `.so` compiled and there is nothing to fix.",
+          "They take the green check to mean the program is deployed and live on devnet, and go hunting for it on-chain; building only produced a binary — deployment is a later lesson."
         ]
       },
       {
@@ -3005,38 +2606,6 @@
               }
             ],
             "explanation": "The green check means `cargo-build-sbf` turned your source into a `.so` binary and returned it, proving the pipeline works. Deployment and on-chain execution are later, separate steps."
-          },
-          {
-            "id": "q3",
-            "prompt": "`dry_run` builds a `VaultState`, calls your Course 2 `deposit(1_000)`, logs `balance after deposit: 1000` and returns `Ok(())` — green build, successful transaction. Predict what exists on-chain afterwards.",
-            "multiSelect": false,
-            "options": [
-              {
-                "id": "a",
-                "label": "Nothing new. The `VaultState` was a value on the handler's stack; `DryRun` declares no accounts, so nothing was created or written and the balance is gone the moment the instruction returns.",
-                "correct": true,
-                "feedback": null
-              },
-              {
-                "id": "b",
-                "label": "An account owned by your program holding `balance: 1000` — `#[account]` on `VaultState` is what creates it.",
-                "correct": false,
-                "feedback": "`#[account]` supplies serialization and the 8-byte discriminator for a struct that is *stored in* an account. It does not create one. Creation is an `init` constraint on an accounts struct, and this instruction has no accounts struct fields at all."
-              },
-              {
-                "id": "c",
-                "label": "Nothing persists, and the transaction fails — the runtime rejects an instruction that writes no account.",
-                "correct": false,
-                "feedback": "A handler that only computes and logs is perfectly legal and succeeds. Every Anchor quickstart's first instruction does exactly this."
-              },
-              {
-                "id": "d",
-                "label": "The values persist inside the program binary, because `#[program]` gives the module somewhere to keep them.",
-                "correct": false,
-                "feedback": "Programs are stateless. `#[program]` generates an entrypoint and a dispatcher — code, not storage. All mutable state on Solana lives in accounts that are passed in."
-              }
-            ],
-            "explanation": "This is the seam the course closes. `#[program]` gave you an entrypoint, `#[derive(Accounts)]` gave you a place to declare accounts, and your Course 2 methods gave you correct arithmetic — but no one gave you an account. Module 2 is where the vault becomes something that exists between transactions."
           }
         ],
         "prompt": null,
@@ -9202,7 +8771,7 @@
                 "feedback": "Close but a different failure. `E0596` is what you get when you try to take `&mut` of a binding declared without `let mut`. Here nothing is being borrowed — an assignment is being attempted through a reference that forbids it."
               }
             ],
-            "explanation": "`&T` grants read access and nothing else, all the way down and regardless of the field's type, so assigning to `v.balance` through `&VaultLike` is `E0594`. A call site cannot upgrade a shared borrow to an exclusive one — the signature is the promise — which also sets it apart from `E0596`, taking `&mut` of a binding declared without `let mut`."
+            "explanation": null
           },
           {
             "id": "q3",
@@ -9266,7 +8835,7 @@
                 "feedback": "There is no hidden copy. That is JavaScript's pass-a-primitive behaviour; a Rust `&mut` points at the caller's own value, and silently copying instead would be a language bug."
               }
             ],
-            "explanation": "You cannot lend out write access you were never granted: `let vault = ...` binds immutably, so `&mut vault` is `E0596` even though the call site asks for `&mut`. `let mut` on the binding grants the write; `&mut` at the call site only passes it on. A mutable borrow is a loan, not a move, which is why it is never `E0382`."
+            "explanation": null
           }
         ],
         "prompt": null,
@@ -9501,7 +9070,7 @@
                 "feedback": "`use super::*` always resolves; the crate root exists and is a valid module. The failure lands on the names the harness then tries to use."
               }
             ],
-            "explanation": "`use super::*` pulls in exactly what is in scope one level up — the crate root, where `mod verify` is a sibling of `mod vault` — and never searches downward into sibling modules, so the harness cannot see `VaultState` and fails with \"cannot find type\". A crate-root re-export is what bridges a sibling module; the items are already `pub`, so visibility is not the problem."
+            "explanation": null
           },
           {
             "id": "q3",
@@ -9533,7 +9102,7 @@
                 "feedback": "Nothing converts a panic into a named error. That conversion is the thing you write by hand, with `checked_sub(...).ok_or(...)?`."
               }
             ],
-            "explanation": "With `overflow-checks = true` in the release profile, `self.balance - amount` when `amount` exceeds the balance panics at runtime and aborts the instruction — no `VaultError`, no message for the caller. The compiler only rejects overflow it can evaluate on constants; runtime values need `checked_sub(...).ok_or(...)?` to convert the panic into a named error, the lesson-4 rule."
+            "explanation": null
           }
         ],
         "prompt": null,
@@ -9659,7 +9228,7 @@
                 "feedback": "With literal constants the compiler does catch it. With runtime values it cannot possibly know, which is the entire situation your program is in — the amount came from an instruction someone else wrote."
               }
             ],
-            "explanation": "`-` on `u64` always returns `u64`, never an `Option`, so with `overflow-checks = true` an underflow panics and the transaction aborts — the caller gets a crash, not an error it can distinguish. The flag lives in `Cargo.toml`, not your code, so correctness that leans on it is one profile change from wrong; call `checked_sub` to get an `Option` you handle."
+            "explanation": null
           },
           {
             "id": "q2",
@@ -9691,7 +9260,7 @@
                 "feedback": "`Some(x?)` on an `Option` is genuinely redundant — the value is already the right type — but Rust does not lint for it, and in a `const fn` you never get that far."
               }
             ],
-            "explanation": "`?` on `Option` is still unstable in const context, so it fails with `E0015` inside a `const fn` — which is why the spec asks for `match`. Dropping `const fn` to reach for `?` would disable the assertions that grade the lesson; `?` on `Result`, in a non-const function, arrives in lesson 12."
+            "explanation": null
           },
           {
             "id": "q3",
@@ -9723,7 +9292,7 @@
                 "feedback": "A tail expression is defined by the *absence* of the semicolon. Adding one is what turns it from the body's value into a discarded statement — the same rule that broke `if a < b { a; } else { b; }` in lesson 3."
               }
             ],
-            "explanation": "A trailing semicolon turns `checked_sub`'s result into a discarded statement, so the body evaluates to `()` and fails a `-> Option<u64>` signature with `E0308` — there is no implicit `None`. This is the same tail-expression rule that broke `if a < b { a; } else { b; }` in lesson 3: the semicolon, not the value, decides what a body returns."
+            "explanation": null
           }
         ],
         "prompt": null,
@@ -10261,7 +9830,7 @@
                 "feedback": "Reborrowing a `&mut` is completely legal and you do it every time you pass `v` to another function. The problem is doing it twice and keeping both."
               }
             ],
-            "explanation": "Swapping the shared borrow for `&mut v.balance` trades one rule for another: `&mut` is exclusive, so holding it across the `credit(v, ...)` call is a second mutable borrow and fails with `E0499`, not the shared-then-mutable `E0502`. Telling the two apart is how you know whether to drop a borrow or reorder the calls."
+            "explanation": null
           },
           {
             "id": "q2",
@@ -10293,7 +9862,7 @@
                 "feedback": "Reading freed memory is precisely what does not happen. This is the whole reason the error exists, and it is caught at compile time, so there is no observable garbage to read."
               }
             ],
-            "explanation": "`data.to_vec()` creates a `Vec` that is dropped at the end of the statement, so returning `&...[..8]` into it is `E0515` — a reference outliving the value it points at. The fix is not to bind the `Vec` with `let` (that is the two-line original bug) but to avoid creating an owned `Vec` at all; the freed memory is never read because the error is caught at compile time."
+            "explanation": null
           },
           {
             "id": "q3",
@@ -10451,7 +10020,7 @@
                 "feedback": "`()` does not coerce to anything. It is a distinct type with one value, and Rust has no implicit conversions to paper over the gap — the same rule you met with `u8` and `u64` in lesson 2."
               }
             ],
-            "explanation": "A semicolon is an operation, not punctuation: it discards its expression's value and yields `()`, so both arms become `()` and the body fails its `u64` return with `E0308`, once per arm. `()` coerces to nothing — the same no-implicit-conversion rule you met with `u8` and `u64` — and the `help:` line offers to remove the semicolon."
+            "explanation": null
           },
           {
             "id": "q2",
@@ -10483,7 +10052,7 @@
                 "feedback": "Pattern *kind* has no bearing on order either. Source order is the whole rule."
               }
             ],
-            "explanation": "`match` is strictly source order, first match wins — there is no specificity ranking and no literal-before-range rule — so a `0..=999_999` arm above `0` claims 0 and returns \"dust\". The shadowed arm is only a warn-level `unreachable pattern` lint, so a compile-graded lesson passes it and the log is discarded on success; nothing but reading the arms catches a wrong order."
+            "explanation": null
           },
           {
             "id": "q3",
@@ -10515,7 +10084,7 @@
                 "feedback": "Nothing about integer behaviour in Rust is implementation-defined, and this particular lint denies rather than warns."
               }
             ],
-            "explanation": "A literal that does not fit its annotated type is caught at compile time by a deny-by-default lint, so `let bump: u8 = 300` stops the build rather than wrapping to 44 or clamping to 255. Wrapping is what `300u32 as u8` would do — exactly why this course avoids `as` on numbers, the rule from lesson 2."
+            "explanation": null
           }
         ],
         "prompt": null,
@@ -10857,7 +10426,7 @@
                 "feedback": "32 bytes on the stack, no allocator involved. Heap allocation is what `Vec` and `String` do, and it is exactly why those two are not `Copy`."
               }
             ],
-            "explanation": "`Pubkey` derives `Copy`, so `let a = v.owner` copies 32 bytes out of the shared borrow rather than moving the field, and a `Copy` field is never moved by a read — both lines compile. Reading is exactly what `&T` is for, and the copy is 32 stack bytes with no allocator, which is why the heap types `Vec` and `String` are not `Copy`."
+            "explanation": null
           },
           {
             "id": "q3",
@@ -10889,7 +10458,7 @@
                 "feedback": "Nothing was borrowed. The parameter is `Vec<u8>`, not `&mut Vec<u8>`, so this is a move, not a borrow, and moves report `E0382`."
               }
             ],
-            "explanation": "Ownership follows the signature, not the body: `consume_bytes(bytes: Vec<u8>)` takes the buffer by value, so the first call moves `data` and drops it and the second is `E0382`. A `Vec` can never be `Copy`, and the compiler refuses to build the second call rather than let you observe a moved-from or \"emptied\" value."
+            "explanation": null
           },
           {
             "id": "q4",
@@ -10982,7 +10551,7 @@
                 "feedback": "Nothing borrowed it first. `E0507` is for moving out of something you only have a reference to. Here you owned the `Vec` outright and gave it away."
               }
             ],
-            "explanation": "`for v in vaults` desugars to `vaults.into_iter()`, which takes the `Vec` by value, so `vaults` is gone by the time `vaults.len()` runs and the read is `E0382`. `for v in &vaults` borrows instead — the compiler's own suggestion — because a read is a borrow and you cannot borrow what you no longer own."
+            "explanation": null
           },
           {
             "id": "q2",
@@ -11110,7 +10679,7 @@
                 "feedback": "`usize::from` does not exist for `u32` — `impl From<u32> for usize` is not in the standard library, because `usize` is 16 bits on some targets and the conversion is therefore not universally lossless. `impl From<u16> for usize` does exist. `TryFrom` is what you get for `u32`, and it hands you a `Result` rather than a promise."
               }
             ],
-            "explanation": "The literal `8` infers `u32` from `field_count`, so the sum stays `u32` and fails a `-> usize` return with `E0308` — Rust has no implicit numeric widening. The compiler's diagnostics are authoritative but its suggestions are not: `.try_into().unwrap()` compiles and panics on the input that overflows, so keep `usize::try_from(field_count)` and handle the `Err`. (`usize::from` does not exist for `u32`; that conversion is only `TryFrom`.)"
+            "explanation": null
           },
           {
             "id": "q6",
@@ -11590,7 +11159,7 @@
                 "feedback": "E0605 is for `as` between types where it makes no sense. Both of these are primitive integers, so `as` would compile — it is just the wrong tool, because `as` silently truncates when the widths go the other way."
               }
             ],
-            "explanation": "Rust performs no implicit numeric conversion in either direction, lossless widenings included, so a `u8` where `u64` is expected is a hard `E0308` — not a warning and not an `as`-cast. Convert explicitly with `u64::from(bump)`, which is infallible precisely because every `u8` fits."
+            "explanation": null
           },
           {
             "id": "q2",
@@ -11622,7 +11191,7 @@
                 "feedback": "Severity is a property of the diagnostic, not of its position. Four type errors are four errors."
               }
             ],
-            "explanation": "`rustc` finishes the whole pass before reporting, so four independent mistakes come back as four errors, each with its own code and span — not one at a time the way a runtime halts on the first exception. The first build of a broken file is a complete to-do list; a real cascade only comes from a mistake that leaves the compiler guessing at a type other code depends on."
+            "explanation": null
           },
           {
             "id": "q3",
@@ -11654,7 +11223,7 @@
                 "feedback": "E0384 is the *binding* case — reassigning a `let` without `mut`. This is the *reference* case, E0594. Both are fixed by the word `mut`, in two different positions, and telling them apart tells you which position."
               }
             ],
-            "explanation": "A parameter typed `&VaultLike` is a promise not to write, and nothing overrides it: `pub` only controls who may name the field, and the caller's ownership stays on the caller's side of the signature. Assigning through it is `E0594`, fixed by `&mut` in the signature — distinct from `E0384`, the immutable-binding case."
+            "explanation": null
           },
           {
             "id": "q4",
@@ -11686,7 +11255,7 @@
                 "feedback": "Both are 64 bits, but a double spends 11 of them on an exponent and one on a sign, leaving 53 bits of integer precision. Every integer above 2^53 - 1 is representable only approximately, which is why Solana clients read `u64` fields as `BigInt`."
               }
             ],
-            "explanation": "`Number` is a 64-bit double with only 53 bits of integer precision, so any `u64` above 2^53 - 1 is silently rounded to a nearby value — no error, no warning, and `Number.MAX_SAFE_INTEGER` is documentation, not a guard. That silent rounding is why Solana clients read `u64` fields as `BigInt`."
+            "explanation": null
           }
         ],
         "prompt": null,
@@ -11789,7 +11358,7 @@
                 "feedback": "`space` is computed from the same const, so it grows with the struct. Under-allocation is what happens when you hardcode the number instead of deriving it."
               }
             ],
-            "explanation": "`INIT_SPACE` is an associated const the `InitSpace` derive computes at compile time, so widening `bump` to `u64` makes it 48 and the `const _: () = assert!(... == 41)` fails the build — a `u64` field is perfectly legal, the size is the problem. Deriving `space = 8 + INIT_SPACE` from the same const keeps allocation correct; hardcoding the number is what under-allocates."
+            "explanation": null
           },
           {
             "id": "q2",
@@ -11853,7 +11422,7 @@
                 "feedback": "Anchor hands you `Account<'info, VaultState>` and you reach the data through a mutable deref. A method that consumes `self` cannot be called through a borrow."
               }
             ],
-            "explanation": "`&mut self` and `mut self` both let you write, but they differ in ownership: `mut self` consumes the value while `&mut self` borrows it, and that difference is in the type the harness binds — `fn(VaultState, ...)` versus `fn(&mut VaultState, ...)`. Taking `self` by value is legal Rust (`into_parts(self)`) but wrong here, because Anchor reaches account data through a mutable deref, not by value."
+            "explanation": null
           },
           {
             "id": "q4",
@@ -11885,7 +11454,7 @@
                 "feedback": "The bump is one byte and it is inside the 41. Anchor adds no padding — the layout is the fields, back to back, after the discriminator."
               }
             ],
-            "explanation": "The 8 bytes are the Anchor discriminator — a hash of the account type's name written at offset 0 — the same first 8 bytes your Course 1 decoder sliced off before reading `owner`. They are not lamports (those live in the account's metadata), not a borsh length prefix (4 bytes, and only on variable-length types), and not padding, since Anchor lays fields back to back after the discriminator."
+            "explanation": null
           },
           {
             "id": "q5",
@@ -11917,7 +11486,7 @@
                 "feedback": "Hashing is order-sensitive. Reorder the seeds and you get a different address — you proved that to yourself in Course 1 by deriving it both ways."
               }
             ],
-            "explanation": "The bump is what the derivation counted down from 255 until the address left the ed25519 curve, and storing it lets a later instruction re-validate the PDA without paying to re-run that search. Hardcoding 254 is not safe — a mock SDK's hardcoded 254 was exactly the Course 1 bug; the canonical bump is whatever the search found for those seeds, and seed order changes the address because hashing is order-sensitive."
+            "explanation": null
           },
           {
             "id": "q6",
@@ -12137,7 +11706,7 @@
                 "feedback": "There is no partial credit on a buildable lesson. The signal the grader has is one bit: did it compile."
               }
             ],
-            "explanation": "A buildable lesson is graded on one bit — did it compile — and `rustc` treats warnings as advice and exits successfully, so an unreachable-pattern warning still passes. The trap is that this platform discards the build log on success, so the warning never reaches you; that matters when a later lesson tells you a mistake \"only warns\"."
+            "explanation": null
           },
           {
             "id": "q2",
@@ -12169,7 +11738,7 @@
                 "feedback": "A missing name is caught during compilation. Rust does not resolve names at run time, so there is no \"later\" for this class of mistake."
               }
             ],
-            "explanation": "`declare_id!` generates the compile-time constant `ID`, and the `msg!` on the next line uses it, so deleting the macro makes the name absent and the build fails during compilation. It is not deploy metadata and there is no all-zeros fallback — Rust resolves names at compile time, so there is no \"later\" for this class of mistake."
+            "explanation": null
           },
           {
             "id": "q3",
@@ -12201,683 +11770,7 @@
                 "feedback": "A compiler cannot warn about syntax it does not understand. You get an error — often an unhelpful parse error rather than a polite \"this needs a newer Rust\"."
               }
             ],
-            "explanation": "The toolchain is pinned by the `--tools-version` the build server passes to `cargo-build-sbf`, and nothing in a submission can raise it, so a feature stabilised after that version fails to compile here even though it is valid Rust on a newer toolchain. The server's compiler is the ceiling, which is why every lesson carries a version stamp at the top."
-          }
-        ],
-        "prompt": null,
-        "maxWords": null,
-        "amount": null,
-        "network": null,
-        "idl": null
-      }
-    ]
-  },
-  {
-    "_id": "lesson-bfsp-cpi-lamports",
-    "title": "CPI: Moving Real Lamports",
-    "slug": "cpi-moving-real-lamports",
-    "blocks": [
-      {
-        "key": "intro",
-        "_type": "prose",
-        "produces": null,
-        "consumes": null,
-        "src": "# CPI: Moving Real Lamports\n\n> **Version stamp — checked 2026-07-26.** `anchor-lang 1.1.2` (published 2026-06-26) · `cargo-build-sbf` with platform-tools v1.54 (rustc 1.89) · edition 2021 · System Program behaviour read out of Agave `solana-system-program` 3.1.14 and 4.1.2. Every compiler message and every runtime log quoted below was produced by compiling this lesson's file, or read verbatim from that Agave source.\n\nYour vault has a `balance` field. So far that field is a claim: it says how much the vault holds, and nothing enforces it. Nobody has moved a lamport.\n\nThis lesson is the one where the claim becomes true. You will read a finished `deposit` — not write it — and by the end you should be able to say exactly which program moved the money, who authorised it, and why the code looks the way it does rather than the way every tutorial written before Anchor 1.0 says it should.\n\n## Your program cannot move lamports\n\nNot the user's, anyway. An account's lamports may only be **debited by the program that owns the account**. The user's wallet is owned by the System Program, so the System Program is the only thing on the chain that can take lamports out of it.\n\nThat is not a limitation to work around. It is the whole security model: if any program could debit any account, a signature would mean nothing.\n\nSo `deposit` does not move lamports. It **asks** the System Program to. That request is a **cross-program invocation** — a CPI.\n\n## What composability actually buys you\n\nThe reason this matters beyond your vault: almost nothing on Solana is self-contained. A program that wants to move SOL calls the System Program. One that wants to move tokens calls the Token program. One that wants to price a swap calls an AMM, which calls the Token program twice. Each of those programs was audited once and is now reused by everyone, which is why a 200-line program can do something a 20,000-line program would otherwise have to.\n\nYour vault is the smallest honest example of that: about six lines of CPI, and it inherits every lamport-accounting guarantee the System Program has.\n\n## The call stack, and how far down it goes\n\nA CPI is a nested instruction. The runtime keeps a stack:\n\n```\ntransaction\n  └─ instruction 1: deposit          ← your program, stack depth 1\n       └─ CPI: System Program transfer  ← stack depth 2\n```\n\nThe ceiling is a constant in the runtime, `MAX_INSTRUCTION_STACK_DEPTH = 5`. Your top-level instruction occupies the first slot, so you get **four levels of nesting below you**. Deep call chains are a real constraint in composed DeFi; for a vault it is not close to a concern. Worth knowing the constant's name so you can check it yourself rather than trusting a blog post — the number has been proposed for a raise more than once.\n\n## Signer propagation: nobody signs twice\n\nHere is the part that surprises people. `transfer` needs the source account to have signed. The user signed the *transaction*. Does the signature reach the CPI?\n\nYes. Signatures established at the top of the transaction stay valid all the way down the stack. Your program does not re-sign, cannot re-sign, and does not need to. It hands the System Program a `from` account that is already marked as a signer, and the System Program sees a signer.\n\nThat single fact is why `deposit` is easy and why the next lesson is hard. Withdrawal needs *the vault* to authorise something, and the vault never signed anything — it has no private key to sign with.\n\n## The Anchor 1.0 `CpiContext`, and the one line the internet gets wrong\n\nA CPI in Anchor is two values: which accounts, and which program.\n\n```rust\ntransfer(\n    CpiContext::new(\n        System::id(),\n        Transfer {\n            from: ctx.accounts.user.to_account_info(),\n            to: ctx.accounts.vault.to_account_info(),\n        },\n    ),\n    amount,\n)?;\n```\n\nLook at the first argument to `CpiContext::new`. It is a **program id** — a `Pubkey`. In `anchor-lang` 1.1.2 the signature is:\n\n```rust\npub fn new(program_id: Pubkey, accounts: T) -> Self\n```\n\nEvery CPI tutorial published before Anchor 1.0 — including the earlier version of this course — passes an `AccountInfo` instead:\n\n```rust\n// pre-1.0. Does not compile against anchor-lang 1.x.\nCpiContext::new(ctx.accounts.system_program.to_account_info(), cpi_accounts)\n```\n\nPaste that into this lesson's file and the build server says:\n\n```\nerror[E0308]: mismatched types\n   |\n   |                 ctx.accounts.system_program.to_account_info(),\n   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Pubkey`, found `AccountInfo<'_>`\n```\n\nThis is the single most common stale snippet in Solana material, and it is a *good* break: it fails loudly at compile time instead of quietly at runtime. When your copy-paste from a 2024 blog post fails this way, you now know why.\n\nTwo details that follow from the new shape:\n\n- `System::id()` is a compile-time constant. Nothing is looked up, nothing is borrowed, and the context no longer depends on an account being present in order to be *built*.\n- You still declare `pub system_program: Program<'info, System>` in the accounts struct. The runtime has to have the callee's program account loaded to execute the nested instruction, and that field is what makes the client include it. What changed in 1.0 is only how `CpiContext` is told which program to call — not whether the program account travels with the transaction.\n\n## The direction rule: why deposit is a CPI and withdraw will not be\n\nRead this from the Agave System Program, `transfer_verified`:\n\n```rust\nlet mut from = instruction_context.try_borrow_instruction_account(from_account_index)?;\nif !from.get_data().is_empty() {\n    ic_msg!(invoke_context, \"Transfer: `from` must not carry data\");\n    return Err(InstructionError::InvalidArgument);\n}\n```\n\nThe System Program refuses to send lamports **out of** any account that carries data. Not \"out of a PDA\" — out of *anything with a non-empty data field*.\n\nYour vault carries 49 bytes. So:\n\n| Direction | Source | Data on the source? | System `transfer` CPI |\n| --- | --- | --- | --- |\n| deposit | user's wallet | no — wallets hold no data | ✅ works, and is what you read below |\n| withdraw | vault PDA | yes, 49 bytes of `VaultState` | ❌ `Transfer: 'from' must not carry data` |\n\nNote where that failure lands: **at runtime, on devnet, after a green build.** The compiler has no opinion about it. Hold that thought until the next lesson.\n\n## Where `new_with_signer` is genuinely required\n\nYou will meet `CpiContext::new_with_signer(program_id, accounts, signer_seeds)`. It exists so a PDA can authorise a call it has no key to sign for: the runtime accepts the signature if the seeds you pass re-derive the PDA under *your* program id. That is real, it is central, and it is used constantly — for a PDA that is the **authority** on a token account, or for a **dataless** PDA (allocated with zero bytes) used purely to hold SOL in escrow.\n\nIt is not what gets lamports out of a data-carrying vault. Anyone who tells you otherwise has written code that compiles.\n\n## What you are reading in the exercise\n\nThe file below is complete and correct. Build it — do not edit it — and read for four things:\n\n1. `Deposit<'info>` re-derives the vault from `bump = vault.bump` rather than re-searching for the canonical bump.\n2. The CPI moves the lamports. It is the only thing in the file that touches a balance the program does not own.\n3. `ctx.accounts.vault.deposit(amount)?` is your own Course 2 method, imported and called. The `checked_add` and the `ZeroAmount` guard are not retyped here; they are the same lines you already wrote and reasoned about.\n4. The two are separate on purpose. Lamports are the runtime's bookkeeping; `vault.balance` is yours. Every real audit finding in a vault lives in the gap between those two numbers, and you cannot inspect a gap whose sides are the same statement.\n\nOne honest note about grading, true for every Rust exercise in this course: **the build server grades by compiling.** A green check means the Anchor 1.x toolchain accepted your program. It does not mean the program behaves. That is not a gap we are hiding — it is the reason Module 4 opens by walking you through the LiteSVM test that *would* run the finished vault, and showing exactly which of these mistakes compiling can never catch.\n",
-        "url": null,
-        "language": null,
-        "buildType": null,
-        "deployable": null,
-        "starter": null,
-        "solution": null,
-        "tests": null,
-        "hints": null,
-        "questions": null,
-        "prompt": null,
-        "maxWords": null,
-        "amount": null,
-        "network": null,
-        "idl": null
-      },
-      {
-        "key": "exercise",
-        "_type": "code",
-        "produces": null,
-        "consumes": null,
-        "src": null,
-        "url": null,
-        "language": "rust",
-        "buildType": "buildable",
-        "deployable": false,
-        "starter": "// ─────────────────────────────────────────────────────────────────────────────\n// WORKED EXAMPLE — nothing to fix. Build it, then read it.\n//\n// This is your vault after Module 2, plus one new instruction: `deposit`.\n// It compiles as shipped. The point of the exercise is the reading, so if you\n// change something and it breaks, `git`-less as you are, just reload the lesson.\n// ─────────────────────────────────────────────────────────────────────────────\n\nuse anchor_lang::prelude::*;\nuse anchor_lang::system_program::{transfer, Transfer};\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n// ─── Your Course 2 core, imported unchanged ──────────────────────────────────\n// Not one line of this module is new. It is the file you finished Course 2 with:\n// a struct that knows its own size, two methods that cannot silently overflow,\n// and one error enum. Nothing in it knows what an account is.\npub mod vault {\n    use super::*;\n\n    #[account]\n    #[derive(InitSpace)]\n    pub struct VaultState {\n        pub owner: Pubkey,\n        pub balance: u64,\n        pub bump: u8,\n    }\n\n    #[error_code]\n    pub enum VaultError {\n        #[msg(\"Deposit would overflow the vault balance\")]\n        Overflow,\n        #[msg(\"Withdrawal is larger than the vault balance\")]\n        InsufficientFunds,\n        #[msg(\"Amount must be greater than zero\")]\n        ZeroAmount,\n        #[msg(\"Signer is not the vault owner\")]\n        NotOwner,\n    }\n\n    impl VaultState {\n        pub fn deposit(&mut self, amount: u64) -> Result<()> {\n            require!(amount > 0, VaultError::ZeroAmount);\n            self.balance = self\n                .balance\n                .checked_add(amount)\n                .ok_or(VaultError::Overflow)?;\n            Ok(())\n        }\n\n        pub fn withdraw(&mut self, amount: u64) -> Result<()> {\n            require!(amount > 0, VaultError::ZeroAmount);\n            self.balance = self\n                .balance\n                .checked_sub(amount)\n                .ok_or(VaultError::InsufficientFunds)?;\n            Ok(())\n        }\n    }\n}\n\npub use vault::{VaultError, VaultState};\n\n#[program]\npub mod vault_program {\n    use super::*;\n\n    pub fn initialize_vault(ctx: Context<InitializeVault>) -> Result<()> {\n        let vault = &mut ctx.accounts.vault;\n        vault.owner = ctx.accounts.user.key();\n        vault.balance = 0;\n        vault.bump = ctx.bumps.vault;\n        Ok(())\n    }\n\n    pub fn deposit(ctx: Context<Deposit>, amount: u64) -> Result<()> {\n        // ── 1. The lamports. This is the CPI. ────────────────────────────────\n        //\n        // `transfer` here is `anchor_lang::system_program::transfer` — a thin\n        // wrapper that builds a System Program instruction and invokes it.\n        //\n        // First argument to `CpiContext::new` is a `Pubkey`: WHICH program.\n        // `System::id()` is a compile-time constant, so no account is read to\n        // build this. Anchor 1.0 changed this argument from an `AccountInfo`;\n        // passing one now is `error[E0308]: expected Pubkey, found AccountInfo`.\n        //\n        // The user signed the transaction, and that signature is still valid\n        // this far down the call stack. Our program signs nothing.\n        transfer(\n            CpiContext::new(\n                System::id(),\n                Transfer {\n                    from: ctx.accounts.user.to_account_info(),\n                    to: ctx.accounts.vault.to_account_info(),\n                },\n            ),\n            amount,\n        )?;\n\n        // ── 2. The bookkeeping. This is your Course 2 method. ────────────────\n        //\n        // Imported, not retyped. `checked_add`, the `ZeroAmount` guard and the\n        // `Overflow` error all live in `vault::VaultState`, already written and\n        // already reasoned about. If `amount` is 0 this returns before the\n        // balance changes — and because the CPI above already ran, the whole\n        // transaction is rolled back. Failure is all-or-nothing per instruction.\n        ctx.accounts.vault.deposit(amount)?;\n\n        Ok(())\n    }\n}\n\n#[derive(Accounts)]\npub struct InitializeVault<'info> {\n    #[account(\n        init,\n        payer = user,\n        space = 8 + 32 + 8 + 1,\n        seeds = [b\"vault\", user.key().as_ref()],\n        bump\n    )]\n    pub vault: Account<'info, VaultState>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n    pub system_program: Program<'info, System>,\n}\n\n#[derive(Accounts)]\npub struct Deposit<'info> {\n    // `mut` because the lamports AND the data both change.\n    //\n    // `bump = vault.bump` re-derives the address using the bump you stored at\n    // initialize time — one hash. A bare `bump` would make Anchor search from\n    // 255 downwards for the canonical bump, which costs compute units for an\n    // answer the account is already carrying.\n    #[account(\n        mut,\n        seeds = [b\"vault\", user.key().as_ref()],\n        bump = vault.bump\n    )]\n    pub vault: Account<'info, VaultState>,\n\n    // `mut` because lamports leave this account. `Signer` because the System\n    // Program will not debit an account that did not sign — and that signature\n    // is the only authorisation in the whole instruction.\n    #[account(mut)]\n    pub user: Signer<'info>,\n\n    // Required even though `CpiContext::new` no longer takes it. The runtime\n    // must have the callee's program account loaded; declaring it here is what\n    // makes the client include it in the transaction.\n    pub system_program: Program<'info, System>,\n}\n",
-        "solution": "// ─────────────────────────────────────────────────────────────────────────────\n// WORKED EXAMPLE — nothing to fix. Build it, then read it.\n//\n// This is your vault after Module 2, plus one new instruction: `deposit`.\n// It compiles as shipped. The point of the exercise is the reading, so if you\n// change something and it breaks, `git`-less as you are, just reload the lesson.\n// ─────────────────────────────────────────────────────────────────────────────\n\nuse anchor_lang::prelude::*;\nuse anchor_lang::system_program::{transfer, Transfer};\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n// ─── Your Course 2 core, imported unchanged ──────────────────────────────────\n// Not one line of this module is new. It is the file you finished Course 2 with:\n// a struct that knows its own size, two methods that cannot silently overflow,\n// and one error enum. Nothing in it knows what an account is.\npub mod vault {\n    use super::*;\n\n    #[account]\n    #[derive(InitSpace)]\n    pub struct VaultState {\n        pub owner: Pubkey,\n        pub balance: u64,\n        pub bump: u8,\n    }\n\n    #[error_code]\n    pub enum VaultError {\n        #[msg(\"Deposit would overflow the vault balance\")]\n        Overflow,\n        #[msg(\"Withdrawal is larger than the vault balance\")]\n        InsufficientFunds,\n        #[msg(\"Amount must be greater than zero\")]\n        ZeroAmount,\n        #[msg(\"Signer is not the vault owner\")]\n        NotOwner,\n    }\n\n    impl VaultState {\n        pub fn deposit(&mut self, amount: u64) -> Result<()> {\n            require!(amount > 0, VaultError::ZeroAmount);\n            self.balance = self\n                .balance\n                .checked_add(amount)\n                .ok_or(VaultError::Overflow)?;\n            Ok(())\n        }\n\n        pub fn withdraw(&mut self, amount: u64) -> Result<()> {\n            require!(amount > 0, VaultError::ZeroAmount);\n            self.balance = self\n                .balance\n                .checked_sub(amount)\n                .ok_or(VaultError::InsufficientFunds)?;\n            Ok(())\n        }\n    }\n}\n\npub use vault::{VaultError, VaultState};\n\n#[program]\npub mod vault_program {\n    use super::*;\n\n    pub fn initialize_vault(ctx: Context<InitializeVault>) -> Result<()> {\n        let vault = &mut ctx.accounts.vault;\n        vault.owner = ctx.accounts.user.key();\n        vault.balance = 0;\n        vault.bump = ctx.bumps.vault;\n        Ok(())\n    }\n\n    pub fn deposit(ctx: Context<Deposit>, amount: u64) -> Result<()> {\n        // ── 1. The lamports. This is the CPI. ────────────────────────────────\n        //\n        // `transfer` here is `anchor_lang::system_program::transfer` — a thin\n        // wrapper that builds a System Program instruction and invokes it.\n        //\n        // First argument to `CpiContext::new` is a `Pubkey`: WHICH program.\n        // `System::id()` is a compile-time constant, so no account is read to\n        // build this. Anchor 1.0 changed this argument from an `AccountInfo`;\n        // passing one now is `error[E0308]: expected Pubkey, found AccountInfo`.\n        //\n        // The user signed the transaction, and that signature is still valid\n        // this far down the call stack. Our program signs nothing.\n        transfer(\n            CpiContext::new(\n                System::id(),\n                Transfer {\n                    from: ctx.accounts.user.to_account_info(),\n                    to: ctx.accounts.vault.to_account_info(),\n                },\n            ),\n            amount,\n        )?;\n\n        // ── 2. The bookkeeping. This is your Course 2 method. ────────────────\n        //\n        // Imported, not retyped. `checked_add`, the `ZeroAmount` guard and the\n        // `Overflow` error all live in `vault::VaultState`, already written and\n        // already reasoned about. If `amount` is 0 this returns before the\n        // balance changes — and because the CPI above already ran, the whole\n        // transaction is rolled back. Failure is all-or-nothing per instruction.\n        ctx.accounts.vault.deposit(amount)?;\n\n        Ok(())\n    }\n}\n\n#[derive(Accounts)]\npub struct InitializeVault<'info> {\n    #[account(\n        init,\n        payer = user,\n        space = 8 + 32 + 8 + 1,\n        seeds = [b\"vault\", user.key().as_ref()],\n        bump\n    )]\n    pub vault: Account<'info, VaultState>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n    pub system_program: Program<'info, System>,\n}\n\n#[derive(Accounts)]\npub struct Deposit<'info> {\n    // `mut` because the lamports AND the data both change.\n    //\n    // `bump = vault.bump` re-derives the address using the bump you stored at\n    // initialize time — one hash. A bare `bump` would make Anchor search from\n    // 255 downwards for the canonical bump, which costs compute units for an\n    // answer the account is already carrying.\n    #[account(\n        mut,\n        seeds = [b\"vault\", user.key().as_ref()],\n        bump = vault.bump\n    )]\n    pub vault: Account<'info, VaultState>,\n\n    // `mut` because lamports leave this account. `Signer` because the System\n    // Program will not debit an account that did not sign — and that signature\n    // is the only authorisation in the whole instruction.\n    #[account(mut)]\n    pub user: Signer<'info>,\n\n    // Required even though `CpiContext::new` no longer takes it. The runtime\n    // must have the callee's program account loaded; declaring it here is what\n    // makes the client include it in the transaction.\n    pub system_program: Program<'info, System>,\n}\n",
-        "tests": [
-          {
-            "id": "compiles",
-            "description": "The program compiles against the Anchor 1.x toolchain",
-            "input": "",
-            "expectedOutput": "true"
-          }
-        ],
-        "hints": [
-          "Nothing is broken. This file compiles exactly as shipped — click Build and read it while it runs. The first build of a session pulls and compiles the Anchor crates, so it is the slow one; later builds in the same lesson are seconds.",
-          "While it builds, find the two statements in `deposit` that do completely different jobs: one asks another program to move lamports, one updates a number your own program owns. Everything in this module hangs off the fact that those are separate.",
-          "Then find the three reasons `user` is `#[account(mut)]` and a `Signer`: lamports leave it, the System Program refuses to debit a non-signer, and that signature is the only authorisation anywhere in the instruction."
-        ],
-        "questions": null,
-        "prompt": null,
-        "maxWords": null,
-        "amount": null,
-        "network": null,
-        "idl": null
-      },
-      {
-        "key": "retrieval-close",
-        "_type": "quiz",
-        "produces": null,
-        "consumes": null,
-        "src": null,
-        "url": null,
-        "language": null,
-        "buildType": null,
-        "deployable": null,
-        "starter": null,
-        "solution": null,
-        "tests": null,
-        "hints": null,
-        "questions": [
-          {
-            "id": "q1",
-            "prompt": "You copy a CPI snippet from a 2024 tutorial and it reads `CpiContext::new(ctx.accounts.system_program.to_account_info(), cpi_accounts)`. Predict the outcome when the build server compiles it.",
-            "multiSelect": false,
-            "options": [
-              {
-                "id": "a",
-                "label": "`error[E0308]: mismatched types` — expected `Pubkey`, found `AccountInfo<'_>`. In Anchor 1.x the first argument is the program id, so `System::id()` belongs there.",
-                "correct": true,
-                "feedback": null
-              },
-              {
-                "id": "b",
-                "label": "It compiles. Anchor accepts either an `AccountInfo` or a `Pubkey` and figures out which you meant.",
-                "correct": false,
-                "feedback": "There is no overload. `CpiContext::new` in `anchor-lang` 1.1.2 is `pub fn new(program_id: Pubkey, accounts: T) -> Self` — one signature, and an `AccountInfo` is not a `Pubkey`."
-              },
-              {
-                "id": "c",
-                "label": "It compiles and then fails on-chain, because the account info is stale by the time the CPI runs.",
-                "correct": false,
-                "feedback": "It never gets as far as running. This is a type error the compiler catches, which is the good case — a stale API that breaks loudly is far cheaper than one that breaks quietly."
-              },
-              {
-                "id": "d",
-                "label": "It compiles with a deprecation warning naming the 1.0 form.",
-                "correct": false,
-                "feedback": "The old argument type was removed, not deprecated, so there is no warning to emit — just a hard mismatch. Deprecation would have been kinder; assume nothing in a major version bump."
-              }
-            ],
-            "explanation": "`CpiContext::new(program_id: Pubkey, accounts: T)` is the Anchor 1.0 shape, and the pre-1.0 shape passed the callee's `AccountInfo` instead. Because a `Pubkey` is a compile-time value, the context no longer needs an account read in order to be built. You still declare `system_program: Program<'info, System>` in the accounts struct — the runtime needs the callee's program account loaded — but the context is told which program to call by id."
-          },
-          {
-            "id": "q2",
-            "prompt": "Someone writes `withdraw` by mirroring `deposit`: the same `system_program::transfer` CPI, with `from` set to the vault PDA and `to` set to the user, signed with the vault's seeds. Predict the outcome.",
-            "multiSelect": false,
-            "options": [
-              {
-                "id": "a",
-                "label": "It compiles, passes this course's grading, and fails on devnet with `Transfer: 'from' must not carry data` — the System Program refuses to debit any account with a non-empty data field.",
-                "correct": true,
-                "feedback": null
-              },
-              {
-                "id": "b",
-                "label": "It works. Signer seeds are exactly the mechanism for letting a PDA spend from itself.",
-                "correct": false,
-                "feedback": "Signer seeds solve authorisation, and authorisation was never the obstacle. The obstacle is that the vault carries 49 bytes of `VaultState`, and the System Program checks `from.get_data()` is empty before it debits anything."
-              },
-              {
-                "id": "c",
-                "label": "It fails to compile, because a PDA cannot be the `from` of a `Transfer`.",
-                "correct": false,
-                "feedback": "`Transfer`'s fields are plain `AccountInfo`s, so any account fits and the types are satisfied. That is what makes this failure expensive: compile-time silence, runtime rejection."
-              },
-              {
-                "id": "d",
-                "label": "It works but silently transfers zero, because the PDA's signature is not recognised.",
-                "correct": false,
-                "feedback": "Solana instructions do not partially succeed. The nested instruction returns `InvalidArgument` and the whole transaction is rolled back — nothing transfers, silently or otherwise."
-              }
-            ],
-            "explanation": "Agave's `transfer_verified` opens with `if !from.get_data().is_empty() { ... return Err(InstructionError::InvalidArgument) }`. Deposit works because a wallet holds no data; withdraw cannot, because the vault does. Note exactly where that lands — a green build, then a runtime rejection — which is the reason Module 4 walks you through the LiteSVM test that would surface it before you spend devnet SOL."
-          },
-          {
-            "id": "q3",
-            "prompt": "During `deposit`, the System Program requires that `from` signed. Who provided that signature, and at what point?",
-            "multiSelect": false,
-            "options": [
-              {
-                "id": "a",
-                "label": "The user, on the outer transaction. Signatures established at the top of the stack stay valid in nested instructions, so the program signs nothing.",
-                "correct": true,
-                "feedback": null
-              },
-              {
-                "id": "b",
-                "label": "The program signs on the user's behalf, using its program id as the signing authority.",
-                "correct": false,
-                "feedback": "A program id can only ever authorise PDAs derived from it, and a user's wallet is not one. If a program could sign for a wallet it did not own, no balance on Solana would be safe."
-              },
-              {
-                "id": "c",
-                "label": "The vault PDA signs, since it is the destination of the transfer.",
-                "correct": false,
-                "feedback": "Destinations are never asked to sign — receiving lamports needs no permission. And the vault has no key to sign with; that is what the next lesson is about."
-              },
-              {
-                "id": "d",
-                "label": "Nobody. `transfer` only needs a signature when the amount exceeds the rent-exempt minimum.",
-                "correct": false,
-                "feedback": "Debiting an account always requires its signature, whatever the amount. Rent-exemption governs how *low* a balance may fall, not who may authorise the move."
-              }
-            ],
-            "explanation": "The transaction carries the user's signature; the runtime keeps that fact as the call stack deepens, so the System Program sees a signed `from` without your program doing anything. That is also why the withdrawal direction is the hard one: it needs the *vault* to authorise, and the vault never signed — it has no private key to sign with."
-          }
-        ],
-        "prompt": null,
-        "maxWords": null,
-        "amount": null,
-        "network": null,
-        "idl": null
-      }
-    ]
-  },
-  {
-    "_id": "lesson-bfsp-pdas-vault",
-    "title": "PDAs: An Address With No Key",
-    "slug": "pdas-an-address-with-no-key",
-    "blocks": [
-      {
-        "key": "intro",
-        "_type": "prose",
-        "produces": null,
-        "consumes": null,
-        "src": "# PDAs: An Address With No Key\n\n> **Version stamp — checked 2026-07-26.** `anchor-lang 1.1.2` (published 2026-06-26) · `cargo-build-sbf` with platform-tools v1.54 (rustc 1.89) · `borsh` resolves to **1.8.0** · edition 2021. Every compiler message quoted below was produced by compiling this lesson's starter on that toolchain.\n\nYou know how to size the vault. You do not yet know **where it lives**, and the answer is stranger than\nit looks: at an address that nobody can sign for.\n\n## The problem a PDA solves\n\nRight now your `initialize_vault` creates an account at whatever address the client hands it. That has\ntwo failures, and the compiler can see neither of them.\n\nThe first is that nothing ties the account to the user. Any address will do. There is no rule that\nAlice gets one vault, or that Alice's vault is Alice's.\n\nThe second is worse. A normal account's address **is** a public key, and somewhere there is a private\nkey that matches it. Whoever holds that private key can sign for the account. An account your program\nis supposed to control, sitting at an address someone can sign for, is not controlled by your program.\n\nA **Program Derived Address** fixes both at once. It is an address computed from inputs you choose, and\nit is deliberately an address for which no private key exists.\n\n## Why no private key exists\n\nSolana signatures are Ed25519, and every Ed25519 public key is a point on a particular elliptic curve.\nNot every 32-byte string is such a point — most are not. A byte string that is not on the curve cannot\nbe a public key, so no private key can correspond to it, so nothing can ever produce a signature for\nit.\n\nPDA derivation exploits exactly that. It searches for a 32-byte result that is **off** the curve:\n\n```\nfor bump in (0..=255).rev() {\n    candidate = sha256(seeds || [bump] || program_id || \"ProgramDerivedAddress\")\n    if !is_on_curve(candidate) {\n        return (candidate, bump)\n    }\n}\n```\n\nThree things to take from that loop.\n\n**The search runs downward from 255.** The first bump that yields an off-curve result is the\n**canonical bump** for those seeds. Roughly half of all candidates are off-curve, so it is usually 255\nand almost always found within the first few tries — but \"usually\" is not \"always\", which is why the\nbump is an output of the derivation and not a constant you can assume.\n\n**The program id is part of the hash.** The same seeds under a different program id give a different\naddress. A PDA belongs to one program by construction, and no other program can derive into your\naddress space.\n\n**The literal `\"ProgramDerivedAddress\"` marker is in there too.** It is what keeps PDA derivation from\ncolliding with the other ways addresses get derived on Solana.\n\nThe output is an address your program can *authorize* — not by signing, but by presenting the seeds\nduring a cross-program invocation and letting the runtime re-derive and check them. That is module 3's\nlesson. What matters here is the consequence: **the seeds are the credential**. Knowing them is what\nlets your program act for the address, and no key theft can substitute for them.\n\n## In Anchor, you do not run the loop\n\n`Pubkey::find_program_address` and `Pubkey::try_find_program_address` are the primitives, and you will\nsee them in client code and in native programs. Inside an Anchor accounts struct you almost never call\nthem, because two constraints do it declaratively:\n\n```rust\n#[account(\n    init,\n    payer = user,\n    space = 8 + 32 + 8 + 1,\n    seeds = [b\"vault\", user.key().as_ref()],\n    bump\n)]\npub vault: Account<'info, VaultState>,\n```\n\n`seeds` says what the address is derived from. Bare `bump` says \"derive the canonical bump and check\nthat the account you were handed is at that exact address.\" If the client passes anything else, the\ninstruction fails before your handler body runs — you do not write that check, and you cannot forget\nto.\n\nThe two constraints are a pair, and Anchor refuses either one alone — with a different\nmessage for each direction, which is a free hint about which half you forgot.\n`seeds` without `bump` reports `bump must be provided with seeds`. `bump` without\n`seeds` reports `seeds must be provided before bump`, because there is nothing to bump.\n\nAnchor also hands you the bump it just computed, on `ctx.bumps`, named after the field:\n\n```rust\nvault.bump = ctx.bumps.vault;\n```\n\n`ctx.bumps.vault` exists **only** if that account carries a `bump` constraint. Reference it without\none and the compiler says `no field 'vault' on type 'InitializeVaultBumps'`. That is a useful property:\nit makes one of this lesson's subgoals something the build can actually check.\n\n## Store the bump. Always store the bump.\n\nYou already have `bump: u8` in `VaultState`. This is the lesson where the reason lands.\n\nEvery later instruction — `deposit`, `withdraw`, anything that touches the vault — has to prove the\naccount it was given is the right PDA. It can do that two ways:\n\n```rust\n// re-derives: runs the search loop again, on-chain, every call\n#[account(mut, seeds = [b\"vault\", user.key().as_ref()], bump)]\n\n// reads the byte you stored, then verifies that one candidate\n#[account(mut, seeds = [b\"vault\", user.key().as_ref()], bump = vault.bump)]\n```\n\nThe first form pays for the search in compute units. Each candidate is a SHA-256 over the seeds plus\nthe program id plus the marker, followed by a curve check, and the loop stops at the first off-curve\nresult — typically after one round, occasionally after several. The second form does one hash with a\nknown bump and compares. It is strictly cheaper, and the difference is unbounded in the bad case\nwhereas the stored form is constant.\n\nThere is a correctness argument too, and it is the more important one. `bump = vault.bump` pins the\naccount to the bump that was canonical **when the vault was created**, which is the only bump that\naddress should ever be reachable by. Accepting a bump the caller supplies, without checking it against\na stored value, is how programs end up with several valid addresses for what was meant to be one\naccount. The stored byte is a one-byte commitment that removes the question.\n\nOne byte of `space`, about 0.000014 SOL of deposit, for a cheaper and tighter check on every future\ninstruction. That is the trade, and it is not close.\n\n## Designing seeds\n\nSeeds are an ordered list of byte slices. Up to 16 of them, each at most 32 bytes, and the bump counts\nas one — so 15 is your practical ceiling, which is far more than you will want.\n\n**One per user** — what the vault uses:\n\n```rust\nseeds = [b\"vault\", user.key().as_ref()]\n```\n\nThe `b\"vault\"` prefix is a namespace. Without it, a second per-user account in the same program would\nderive to the same address as the first.\n\n**One per user per resource** — the shape for orders, escrows, positions:\n\n```rust\nseeds = [b\"order\", user.key().as_ref(), &order_id.to_le_bytes()]\n```\n\nNote `to_le_bytes()`. Numbers go into seeds as their fixed-width little-endian bytes, never as decimal\ntext, because a fixed width is what keeps them from running into the next seed.\n\n**One per program** — config and authority singletons:\n\n```rust\nseeds = [b\"config\"]\n```\n\nThe hazard to actually avoid is **ambiguity between adjacent variable-length seeds**. If you derive\nfrom two user-supplied strings back to back, `[\"alice\", \"bob\"]` and `[\"alic\", \"ebob\"]` are different\nseed lists — but a design that lets a caller choose where the boundary falls is a design where two\ndifferent logical keys can land on one address. Fixed-width seeds (a `Pubkey` is always 32 bytes, a\n`u64` is always 8) do not have this problem, which is why almost every PDA in production is a constant\nprefix plus fixed-width parts.\n\n## What the build can and cannot see\n\nThe compiler will catch a `bump` with no `seeds`, and it will catch `ctx.bumps.vault` when no `bump`\nconstraint exists. It will not catch seeds that are simply *wrong* — `b\"vaults\"`, or the user's key\nwhere the mint's belongs. Those derive a perfectly valid PDA at an address your client never looks at,\nand the failure shows up as a puzzling `ConstraintSeeds` error at runtime, or as an account that\ninitializes fine and is then unreachable.\n\nThe check for that is the derivation you already wrote on the client side in Course 1: derive the\naddress off-chain, derive it on-chain, and require that they match. Module 4 shows you exactly that assertion written as a\nLiteSVM test — read it before you spend a lamport on devnet.\n\n---\n\n## Your task\n\nBuild the starter before you change anything. It reports **one** error, and the error is not in your\nprogram:\n\n```\nerror[E0609]: no field `vault` on type `&InitializeVaultBumps`\n```\n\nThat comes from the verification harness at the bottom of the file. Your `initialize_vault` compiles\nperfectly well as it stands — it creates a 49-byte account at whatever address the client passes, with\nno seeds, no bump, and no relationship to the user whatsoever. That is a legal Anchor program and a\nbroken vault, and nothing except the harness can tell the difference. Which is the whole reason the\nharness is there.\n\nThree labeled subgoals turn it into a PDA. Do them in order; each one is what makes the next one\npossible.\n",
-        "url": null,
-        "language": null,
-        "buildType": null,
-        "deployable": null,
-        "starter": null,
-        "solution": null,
-        "tests": null,
-        "hints": null,
-        "questions": null,
-        "prompt": null,
-        "maxWords": null,
-        "amount": null,
-        "network": null,
-        "idl": null
-      },
-      {
-        "key": "exercise",
-        "_type": "code",
-        "produces": null,
-        "consumes": null,
-        "src": null,
-        "url": null,
-        "language": "rust",
-        "buildType": "buildable",
-        "deployable": false,
-        "starter": "use anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n// ─────────────────────────────────────────────────────────────────────────────\n// Your Course 2 vault core, imported and not retyped. Nothing in this module\n// needs to change in this lesson — `bump: u8` is already here, waiting for a\n// reason.\n// ─────────────────────────────────────────────────────────────────────────────\npub mod vault {\n    use super::*;\n\n    #[account]\n    #[derive(InitSpace)]\n    pub struct VaultState {\n        pub owner: Pubkey,\n        pub balance: u64,\n        pub bump: u8,\n    }\n\n    #[error_code]\n    pub enum VaultError {\n        #[msg(\"Deposit would overflow the vault balance\")]\n        Overflow,\n        #[msg(\"Withdrawal is larger than the vault balance\")]\n        InsufficientFunds,\n        #[msg(\"Amount must be greater than zero\")]\n        ZeroAmount,\n        #[msg(\"Signer is not the vault owner\")]\n        NotOwner,\n    }\n\n    impl VaultState {\n        pub fn deposit(&mut self, amount: u64) -> Result<()> {\n            require!(amount > 0, VaultError::ZeroAmount);\n            self.balance = self\n                .balance\n                .checked_add(amount)\n                .ok_or(VaultError::Overflow)?;\n            Ok(())\n        }\n\n        pub fn withdraw(&mut self, amount: u64) -> Result<()> {\n            require!(amount > 0, VaultError::ZeroAmount);\n            self.balance = self\n                .balance\n                .checked_sub(amount)\n                .ok_or(VaultError::InsufficientFunds)?;\n            Ok(())\n        }\n    }\n}\n\npub use vault::{VaultError, VaultState};\n\n#[program]\npub mod vault_program {\n    use super::*;\n\n    pub fn initialize_vault(ctx: Context<InitializeVault>) -> Result<()> {\n        let vault = &mut ctx.accounts.vault;\n        vault.owner = ctx.accounts.user.key();\n        vault.balance = 0;\n\n        // ── SUBGOAL 3 ────────────────────────────────────────────────────────\n        // Store the canonical bump, so that no later instruction has to run the\n        // derivation search again. Anchor hands you the bump it just computed on\n        // `ctx.bumps`, under the field's own name.\n        //\n        // One line, right here. It only compiles once subgoal 2 is done.\n\n        msg!(\"Vault initialized for {}\", vault.owner);\n        Ok(())\n    }\n\n    pub fn vault_info(_ctx: Context<VaultInfo>) -> Result<()> {\n        msg!(\"Vault program online\");\n        Ok(())\n    }\n}\n\n#[derive(Accounts)]\npub struct InitializeVault<'info> {\n    #[account(\n        init,\n        payer = user,\n        space = 8 + 32 + 8 + 1\n        // ── SUBGOAL 1 ────────────────────────────────────────────────────────\n        // Derive this account's address instead of accepting whatever the client\n        // passed. Add a `seeds` constraint: a `b\"vault\"` namespace prefix, then\n        // the user's key as raw bytes.\n        //\n        // Remember the trailing comma on the line above once you add a line\n        // below it.\n        //\n        // ── SUBGOAL 2 ────────────────────────────────────────────────────────\n        // Ask Anchor for the canonical bump and check that the account handed in\n        // really is at that address. One bare word. `seeds` without it does not\n        // compile, and neither does it without `seeds`.\n    )]\n    pub vault: Account<'info, VaultState>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n    pub system_program: Program<'info, System>,\n}\n\n#[derive(Accounts)]\npub struct VaultInfo {}\n\n// ─────────────────────────────────────────────────────────────────────────────\n// VERIFICATION HARNESS — DO NOT EDIT ANYTHING BELOW THIS LINE.\n//\n// This is a TYPE check, not a behaviour check. Grading on this platform is\n// compile-success: the build server compiles your file and reports whether it\n// built. Nothing inspects your source, and there are no hidden tests on the Rust\n// path. So the harness names, in Rust, the things a passing file must have —\n// and an absent or wrongly-typed item becomes a compile error the grader\n// already catches.\n//\n// What it reaches: subgoals 1 and 2, via `InitializeVaultBumps`. `ctx.bumps`\n// only grows a field for an account that carries a `bump` constraint, and\n// Anchor only accepts `bump` alongside `seeds`.\n//\n// What it cannot reach: whether your seeds are the *right* seeds, and whether\n// you actually stored the bump in subgoal 3. Those are proven in module 4,\n// against a real runtime.\n// ─────────────────────────────────────────────────────────────────────────────\n#[doc(hidden)]\n#[allow(dead_code)]\nmod verify {\n    use super::*;\n\n    // `#[account]` is present: 8 bytes of discriminator.\n    const _: () = assert!(VaultState::DISCRIMINATOR.len() == 8);\n\n    // `#[derive(InitSpace)]` is present and the fields are still exactly\n    // Pubkey (32) + u64 (8) + u8 (1) = 41. `space` is 8 + this.\n    const _: () = assert!(VaultState::INIT_SPACE == 41);\n\n    // The vault account is a PDA: this field exists only when `vault` carries a\n    // `bump` constraint, which Anchor accepts only alongside `seeds`.\n    fn pin_bump(bumps: &InitializeVaultBumps) -> u8 {\n        bumps.vault\n    }\n\n    fn pin_vault<'info>(a: &'info InitializeVault<'info>) -> &'info Account<'info, VaultState> {\n        &a.vault\n    }\n    fn pin_user<'info>(a: &'info InitializeVault<'info>) -> &'info Signer<'info> {\n        &a.user\n    }\n    fn pin_system<'info>(a: &'info InitializeVault<'info>) -> &'info Program<'info, System> {\n        &a.system_program\n    }\n}\n",
-        "solution": "use anchor_lang::prelude::*;\n\ndeclare_id!(\"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\");\n\n// ─────────────────────────────────────────────────────────────────────────────\n// Your Course 2 vault core, imported and not retyped. Untouched by this lesson.\n// ─────────────────────────────────────────────────────────────────────────────\npub mod vault {\n    use super::*;\n\n    #[account]\n    #[derive(InitSpace)]\n    pub struct VaultState {\n        pub owner: Pubkey,\n        pub balance: u64,\n        pub bump: u8,\n    }\n\n    #[error_code]\n    pub enum VaultError {\n        #[msg(\"Deposit would overflow the vault balance\")]\n        Overflow,\n        #[msg(\"Withdrawal is larger than the vault balance\")]\n        InsufficientFunds,\n        #[msg(\"Amount must be greater than zero\")]\n        ZeroAmount,\n        #[msg(\"Signer is not the vault owner\")]\n        NotOwner,\n    }\n\n    impl VaultState {\n        pub fn deposit(&mut self, amount: u64) -> Result<()> {\n            require!(amount > 0, VaultError::ZeroAmount);\n            self.balance = self\n                .balance\n                .checked_add(amount)\n                .ok_or(VaultError::Overflow)?;\n            Ok(())\n        }\n\n        pub fn withdraw(&mut self, amount: u64) -> Result<()> {\n            require!(amount > 0, VaultError::ZeroAmount);\n            self.balance = self\n                .balance\n                .checked_sub(amount)\n                .ok_or(VaultError::InsufficientFunds)?;\n            Ok(())\n        }\n    }\n}\n\npub use vault::{VaultError, VaultState};\n\n#[program]\npub mod vault_program {\n    use super::*;\n\n    pub fn initialize_vault(ctx: Context<InitializeVault>) -> Result<()> {\n        let vault = &mut ctx.accounts.vault;\n        vault.owner = ctx.accounts.user.key();\n        vault.balance = 0;\n\n        // SUBGOAL 3. One byte, written once, so that `deposit` and `withdraw` can\n        // use `bump = vault.bump` instead of re-running the derivation search on\n        // every call.\n        vault.bump = ctx.bumps.vault;\n\n        msg!(\"Vault initialized for {}\", vault.owner);\n        Ok(())\n    }\n\n    pub fn vault_info(_ctx: Context<VaultInfo>) -> Result<()> {\n        msg!(\"Vault program online\");\n        Ok(())\n    }\n}\n\n#[derive(Accounts)]\npub struct InitializeVault<'info> {\n    #[account(\n        init,\n        payer = user,\n        space = 8 + 32 + 8 + 1,\n        // SUBGOAL 1. A namespace prefix, then the user's key as raw bytes. One\n        // vault per wallet, at an address any client can re-derive without\n        // being told it.\n        seeds = [b\"vault\", user.key().as_ref()],\n        // SUBGOAL 2. Derive the canonical bump and require that the account\n        // handed in is at that exact address. This is the check you would\n        // otherwise have to write by hand, and forget.\n        bump\n    )]\n    pub vault: Account<'info, VaultState>,\n    #[account(mut)]\n    pub user: Signer<'info>,\n    pub system_program: Program<'info, System>,\n}\n\n#[derive(Accounts)]\npub struct VaultInfo {}\n\n// ─────────────────────────────────────────────────────────────────────────────\n// VERIFICATION HARNESS — DO NOT EDIT ANYTHING BELOW THIS LINE.\n// A type check, not a behaviour check. See the starter for what it does and\n// does not reach.\n// ─────────────────────────────────────────────────────────────────────────────\n#[doc(hidden)]\n#[allow(dead_code)]\nmod verify {\n    use super::*;\n\n    const _: () = assert!(VaultState::DISCRIMINATOR.len() == 8);\n    const _: () = assert!(VaultState::INIT_SPACE == 41);\n\n    fn pin_bump(bumps: &InitializeVaultBumps) -> u8 {\n        bumps.vault\n    }\n\n    fn pin_vault<'info>(a: &'info InitializeVault<'info>) -> &'info Account<'info, VaultState> {\n        &a.vault\n    }\n    fn pin_user<'info>(a: &'info InitializeVault<'info>) -> &'info Signer<'info> {\n        &a.user\n    }\n    fn pin_system<'info>(a: &'info InitializeVault<'info>) -> &'info Program<'info, System> {\n        &a.system_program\n    }\n}\n",
-        "tests": [
-          {
-            "id": "t1",
-            "description": "The file compiles on the build server against anchor-lang 1.1.2",
-            "input": "",
-            "expectedOutput": "true"
-          },
-          {
-            "id": "t2",
-            "description": "Compiles ⇒ the vault account carries a bump constraint, so ctx.bumps.vault exists",
-            "input": "",
-            "expectedOutput": "true"
-          },
-          {
-            "id": "t3",
-            "description": "Compiles ⇒ that bump constraint sits alongside seeds — Anchor rejects one without the other",
-            "input": "",
-            "expectedOutput": "true"
-          },
-          {
-            "id": "t4",
-            "description": "Compiles ⇒ VaultState still has owner: Pubkey, balance: u64, bump: u8 — INIT_SPACE is 41",
-            "input": "",
-            "expectedOutput": "true"
-          },
-          {
-            "id": "t5",
-            "description": "Compiles ⇒ InitializeVault holds vault, a mutable user Signer, and the System Program",
-            "input": "",
-            "expectedOutput": "true"
-          }
-        ],
-        "hints": [
-          "Build before you type anything. One error comes back, from the harness rather than from your program: `no field 'vault' on type '&InitializeVaultBumps'`. Anchor grows that struct a field per account that carries a `bump` constraint, and yours carries none yet — so the error is telling you the vault is not a PDA. Subgoals 1 and 2 are what make the field appear.",
-          "Subgoal 1 is one line inside the `#[account(...)]` parentheses: `seeds = [b\"vault\", user.key().as_ref()],`. Two easy misses — the `space = 8 + 32 + 8 + 1` line above it now needs a trailing comma, and the prefix is the byte literal `b\"vault\"`, not the string `\"vault\"`. Subgoal 2 is the bare word `bump` on the next line. They are a pair, and the message names the missing half: add only `seeds` and Anchor answers `bump must be provided with seeds`; add only `bump` and it answers `seeds must be provided before bump`.",
-          "Subgoal 3 is `vault.bump = ctx.bumps.vault;` in the handler, above the `msg!`. It compiles only once subgoal 2 exists, which is the point — and note that the build cannot tell whether you wrote it, only whether it *could* be written. Skipping it leaves a vault whose stored bump is 0, and every `bump = vault.bump` check in module 3 fails against it."
-        ],
-        "questions": null,
-        "prompt": null,
-        "maxWords": null,
-        "amount": null,
-        "network": null,
-        "idl": null
-      },
-      {
-        "key": "retrieval-close",
-        "_type": "quiz",
-        "produces": null,
-        "consumes": null,
-        "src": null,
-        "url": null,
-        "language": null,
-        "buildType": null,
-        "deployable": null,
-        "starter": null,
-        "solution": null,
-        "tests": null,
-        "hints": null,
-        "questions": [
-          {
-            "id": "q1",
-            "prompt": "Why is there no private key for the vault PDA, and what follows from that?",
-            "multiSelect": false,
-            "options": [
-              {
-                "id": "a",
-                "label": "Derivation searches for a result that is **off** the Ed25519 curve, and only curve points can be public keys — so nothing can ever sign for it, and the seeds become the credential instead",
-                "correct": true,
-                "feedback": null
-              },
-              {
-                "id": "b",
-                "label": "The private key exists but is held by the program, which keeps it in its own account data",
-                "correct": false,
-                "feedback": "A program has no secrets. Its bytecode is public, its accounts are public, and anything it stored would be readable by everyone. PDA authority works precisely because there is no key to hold — the runtime re-derives from seeds instead."
-              },
-              {
-                "id": "c",
-                "label": "The private key is discarded after derivation, so nobody has a copy",
-                "correct": false,
-                "feedback": "There is nothing to discard. The derivation never produces a keypair; it hashes seeds and keeps going until the 32-byte result is not a valid curve point, which means no matching private key can exist at all."
-              },
-              {
-                "id": "d",
-                "label": "It has one, but the runtime refuses signatures for accounts owned by a program",
-                "correct": false,
-                "feedback": "The runtime does not need such a rule, and account ownership is a separate matter — a plain keypair account can be owned by a program too. The guarantee here is mathematical, not a policy check."
-              }
-            ],
-            "explanation": "Ed25519 public keys are points on a curve, and most 32-byte strings are not points. PDA derivation hashes `seeds || bump || program_id || \"ProgramDerivedAddress\"`, counting the bump down from 255, and returns the first result that is off the curve. No key exists, so no key can be stolen — and what authorizes the address is knowledge of its seeds, which only the deriving program can present."
-          },
-          {
-            "id": "q2",
-            "prompt": "`deposit` needs to verify its vault account. Compare `bump = vault.bump` with a bare `bump`. What is the difference at runtime?",
-            "multiSelect": false,
-            "options": [
-              {
-                "id": "a",
-                "label": "Bare `bump` re-runs the derivation search on-chain; `bump = vault.bump` verifies the one stored byte — cheaper in compute units, and pinned to the bump the vault was created with",
-                "correct": true,
-                "feedback": null
-              },
-              {
-                "id": "b",
-                "label": "No difference — both compile to the same check, and `vault.bump` is only documentation",
-                "correct": false,
-                "feedback": "They generate different code. Bare `bump` derives the canonical bump from scratch, hashing candidates until one lands off the curve. `bump = vault.bump` reads your stored byte and verifies that single candidate."
-              },
-              {
-                "id": "c",
-                "label": "`bump = vault.bump` is less safe, because it trusts a value from account data instead of deriving it",
-                "correct": false,
-                "feedback": "It is not trusted blindly — Anchor still derives the address from the seeds plus that bump and requires the account to be at it. Storing the bump is what pins the vault to the bump that was canonical at creation, which is tighter than accepting whatever a caller offers."
-              },
-              {
-                "id": "d",
-                "label": "Bare `bump` is cheaper, because Anchor caches the canonical bump between instructions",
-                "correct": false,
-                "feedback": "Nothing is cached between instructions — each one is a fresh execution with no memory of the last. Any derivation it performs, it performs from scratch."
-              }
-            ],
-            "explanation": "Bare `bump` runs the search: SHA-256 over the seeds plus program id plus marker, then a curve check, repeated until a candidate is off-curve. Usually that is one round; the worst case is unbounded. `bump = vault.bump` does one hash with a known bump and compares. One byte of `space` buys a constant-cost check on every future instruction, and pins the account to a single canonical bump instead of whichever one a caller supplies."
-          },
-          {
-            "id": "q3",
-            "prompt": "You add the `seeds` line to the vault's constraint and forget the bare `bump` under it. Predict the build output.",
-            "multiSelect": false,
-            "options": [
-              {
-                "id": "a",
-                "label": "\"`error: bump must be provided with seeds` first, then a cascade of trait-bound errors on `InitializeVault` — the first line is the real one, the rest are debris from the accounts struct failing to generate\"",
-                "correct": true,
-                "feedback": null
-              },
-              {
-                "id": "b",
-                "label": "One error, pointing at the `seeds` line, and nothing else",
-                "correct": false,
-                "feedback": "Anchor's own message does come first and does name the fix, but a `#[derive(Accounts)]` that aborts takes the generated `Bumps`, `Accounts` and `try_accounts` items with it — so you get ten or more errors. Learning to read only the top one is most of the skill."
-              },
-              {
-                "id": "c",
-                "label": "It compiles, and Anchor treats the bump as 255",
-                "correct": false,
-                "feedback": "There is no such default. 255 is only where the search *starts*; which bump is canonical depends on the seeds and the program id, so assuming it would be wrong roughly half the time. The macro rejects the constraint instead."
-              },
-              {
-                "id": "d",
-                "label": "It compiles, and fails at runtime with `ConstraintSeeds`",
-                "correct": false,
-                "feedback": "`ConstraintSeeds` is a real runtime error — you get it for seeds that derive to an address other than the account passed in. This one never builds at all."
-              }
-            ],
-            "explanation": "`seeds` and `bump` are a pair, and Anchor says so in as many words: `bump must be provided with seeds`. Everything after it — `the trait bound InitializeVault: Bumps is not satisfied`, `no function named try_accounts`, `unresolved import crate` — is fallout from the derive macro having given up. That shape recurs throughout Anchor: the first error is the real one and the rest are debris. Read from the top, fix one thing, build again."
-          }
-        ],
-        "prompt": null,
-        "maxWords": null,
-        "amount": null,
-        "network": null,
-        "idl": null
-      }
-    ]
-  },
-  {
-    "_id": "lesson-bfsp-pre-flight-check",
-    "title": "Pre-Flight Check",
-    "slug": "pre-flight-check",
-    "blocks": [
-      {
-        "key": "intro",
-        "_type": "prose",
-        "produces": null,
-        "consumes": null,
-        "src": "# Pre-Flight Check\n\n> **Version stamp — checked 2026-07-26.** `anchor-lang 1.1.2` · `borsh` resolves to **1.8.0** · `litesvm 0.15.x` (minor pinned; patch moves weekly) · Agave ≥ 3.1.10 · rustc 1.89+ · edition 2021.\n\nEverything after this page costs something. The next lesson puts real devnet SOL in your wallet, the one after that spends it on 200-odd transactions, and the program id that comes out is the artifact your credential is keyed to. This is the last page where being wrong is free.\n\nSo before you spend a lamport: what do you actually know, and what have you only compiled?\n\n## A green build is one bit of information\n\nThe build server compiles your file and grades on exactly that: **did it compile.** There is no test step on the Rust path. The grader never reads your code.\n\nThat bit is worth having — a program that does not compile cannot be deployed, and Anchor's macros catch a large class of account-wiring mistakes at compile time, which is most of why this course uses Anchor at all. But it is one bit, and Course 2 already showed you four ways to spend it on a vault that does not work:\n\n| What you wrote                                       | Build | What happens on-chain                              |\n| ---------------------------------------------------- | ----- | -------------------------------------------------- |\n| `withdraw` calling `checked_add`                     | green | the vault pays you for withdrawing                 |\n| the `require!(amount > 0, …)` guard dropped          | green | zero-amount instructions succeed and write nothing |\n| `.unwrap()` where `.ok_or(…)?` belongs               | green | a panic — aborted instruction, no error code       |\n| `self.balance = self.balance - amount`               | green | a panic, for the same reason                       |\n\nNone of those changes a type, and nothing type-level can see them.\n\nCourse 3 adds four more of its own:\n\n- **`deposit` that moves the lamports but forgets `vault.deposit(amount)`.** The CPI lands; the stored `balance` stays at zero. Two numbers that are supposed to agree, and only one of them got written.\n- **`withdraw` written as a System Program CPI with signer seeds.** It compiles. It deploys. It fails the first time anyone calls it, with `Transfer: 'from' must not carry data` — because System will not debit an account that carries data, and does not own your vault in any case. Signer seeds solve authorisation, and authorisation was never the obstacle.\n- **A dropped rent floor.** Debit the vault below its rent-exempt minimum and the runtime kills the whole transaction with `InsufficientFundsForRent` — a failure your caller cannot act on, in place of the `InsufficientFunds` you would have returned.\n- **A bump that is re-derived instead of read.** `bump` (bare) and `bump = vault.bump` both compile and both usually resolve to the same address. They diverge in compute units, and they diverge in intent: one trusts what you stored, the other recomputes it every call.\n\nThe compiler is indifferent to all eight. So is the grader.\n\n## The tool that is not indifferent: LiteSVM\n\n**LiteSVM** is the SVM — the same runtime a validator executes your program in — as a Rust library you construct in-process. No validator to boot, no RPC, no ports, no keypair files. You build a machine, load your `.so` into it, fund an address, send a transaction, and read the account back. Milliseconds, not tens of seconds.\n\nThat is the whole reason it matters here: the thing that catches a swapped operator is a test that **runs** `withdraw` and looks at the number afterwards. Nothing else does.\n\n```rust\n// litesvm 0.15.x — reading material, not a graded exercise.\nlet mut svm = LiteSVM::new();\nsvm.add_program_from_file(program_id, \"target/deploy/academy_program.so\")\n    .unwrap();\nsvm.airdrop(&user.pubkey(), 10 * LAMPORTS_PER_SOL).unwrap();\n\n// initialize → deposit 2 SOL → withdraw 1 SOL\nsvm.send_transaction(initialize_vault_tx(&svm, &user)).unwrap();\nsvm.send_transaction(deposit_tx(&svm, &user, 2 * LAMPORTS_PER_SOL)).unwrap();\nsvm.send_transaction(withdraw_tx(&svm, &user, 1 * LAMPORTS_PER_SOL)).unwrap();\n\n// The assertion the compiler cannot make.\nlet raw = svm.get_account(&vault_pda).unwrap().data;\nlet state = VaultState::try_deserialize(&mut raw.as_slice()).unwrap();\nassert_eq!(state.balance, 1 * LAMPORTS_PER_SOL);\n```\n\nThree things to notice, because they are the point rather than the syntax.\n\n**The `unwrap()`s are fine here.** Course 2 spent a lesson on why a panic inside a program is unacceptable: the caller gets an aborted instruction with no code and no message. A test is the opposite situation — a panic *is* the failure report, and it is the shortest one available. The rule was never \"never `unwrap`\"; it was \"never `unwrap` where someone else has to read the error.\"\n\n**`assert_eq!(state.balance, …)` is the assertion nothing else in this course can make.** It compares a number the runtime produced against a number you predicted. Every green build up to now has compared a shape against a shape.\n\n**The last line reads the account back rather than trusting the return value.** `send_transaction` succeeding means the instruction did not error. It does not mean it wrote what you meant. Those are different claims and the second one is the one you care about.\n\nLiteSVM is Apache-2.0, which makes it the one major testing corpus in this ecosystem whose examples you can adapt into your own repo with attribution rather than reimplement from scratch. Pin the minor — it ships roughly weekly, and `0.15.x` is what the snippet above was written against.\n\n## What this platform runs, stated plainly\n\nThe code block on a lesson has two modes, `standard` and `buildable`. `buildable` shells out to the Anchor toolchain and compiles. **There is no test mode.** Adding one is a two-stage build-then-run pipeline on the build server, not a flag, and it is tracked separately.\n\nWhich means: the LiteSVM file above is not something you submit here today. It is something you read, and then write for real the first time you have a repo of your own — which, if you follow this path, is Course 4.\n\nIt also means the honest description of what you are about to deploy is *\"compiled against the real Anchor 1.1 toolchain,\"* and never *\"unit tested.\"* If you write up this build — and the last lesson asks you to — use the first one. The distinction is the kind of thing a reviewer notices.\n\n## So the pre-flight check is you\n\nNo new material below. The checkpoint asks about decisions you made across the last eleven lessons, cold, out of the order you made them in, plus two from Course 2 that Course 3 has been quietly leaning on the whole time.\n\nGetting one wrong here costs nothing. Getting it wrong after the deploy costs an upgrade transaction and the walk back through this module to find out which of the eight silent failures you shipped.\n",
-        "url": null,
-        "language": null,
-        "buildType": null,
-        "deployable": null,
-        "starter": null,
-        "solution": null,
-        "tests": null,
-        "hints": null,
-        "questions": null,
-        "prompt": null,
-        "maxWords": null,
-        "amount": null,
-        "network": null,
-        "idl": null
-      },
-      {
-        "key": "checkpoint",
-        "_type": "quiz",
-        "produces": null,
-        "consumes": null,
-        "src": null,
-        "url": null,
-        "language": null,
-        "buildType": null,
-        "deployable": null,
-        "starter": null,
-        "solution": null,
-        "tests": null,
-        "hints": null,
-        "questions": [
-          {
-            "id": "q1",
-            "prompt": "Your vault account is created with `space = 8 + 32 + 8 + 1`, where `VaultState` is `{ owner: Pubkey, balance: u64, bump: u8 }`. How many bytes is the account, and what is the leading 8 for?",
-            "multiSelect": false,
-            "options": [
-              {
-                "id": "a",
-                "label": "49 bytes — 8 for the discriminator Anchor writes at offset 0, then 32 + 8 + 1 for the fields",
-                "correct": true,
-                "feedback": null
-              },
-              {
-                "id": "b",
-                "label": "41 bytes — 32 + 8 + 1; the 8 is the u64 `balance`, already counted",
-                "correct": false,
-                "feedback": "41 is `INIT_SPACE`, the fields alone. The extra 8 is the account discriminator, which sits ahead of every field — total 49."
-              },
-              {
-                "id": "c",
-                "label": "49 bytes — 8 reserved for future fields, then 32 + 8 + 1",
-                "correct": false,
-                "feedback": "The 8 is not padding you could grow into. It is the discriminator: the first 8 bytes of sha256 of the type name, which is how the runtime knows this account is a `VaultState` and not some other struct of the same length."
-              }
-            ],
-            "explanation": "`INIT_SPACE` (41) counts the fields; the `8 +` is Anchor's account discriminator, written at offset 0 and checked on every deserialize. 8 + 32 + 8 + 1 = 49, and that number is fixed at creation — an account's data length cannot grow later without a realloc, which is why you derive it rather than guess it."
-          },
-          {
-            "id": "q2",
-            "prompt": "`deposit` makes a System Program CPI — `transfer(CpiContext::new(System::id(), Transfer { from: user, to: vault }), amount)`. `withdraw` makes no CPI at all. Why the asymmetry?",
-            "multiSelect": false,
-            "options": [
-              {
-                "id": "a",
-                "label": "A program may only debit accounts it owns. Deposit debits the user's wallet, owned by System, so System must do it; withdraw debits the vault, owned by your program, so your program does it directly",
-                "correct": true,
-                "feedback": null
-              },
-              {
-                "id": "b",
-                "label": "Withdraw could use a System CPI with `new_with_signer`, but direct lamport arithmetic costs fewer compute units",
-                "correct": false,
-                "feedback": "The System CPI is not a slower alternative — it does not work at all. System refuses to debit an account carrying data (`Transfer: 'from' must not carry data`) and does not own the vault regardless. Signer seeds solve authorisation, and authorisation was never the obstacle."
-              },
-              {
-                "id": "c",
-                "label": "Withdraw skips the CPI because the vault is a PDA, and PDAs cannot be the source of a transfer",
-                "correct": false,
-                "feedback": "Being a PDA is not the blocker — a dataless PDA can absolutely be the `from` of a System transfer when its program signs with seeds. What blocks it here is that this PDA carries 49 bytes of data and is owned by your program."
-              }
-            ],
-            "explanation": "The rule is ownership: whichever program is executing may debit only accounts assigned to it. Lamports IN move through System because the source is a wallet System owns. Lamports OUT do not, because the source is your vault — so your program writes `try_borrow_mut_lamports` itself, and a System CPI would fail whatever seeds you attached. This is why `Withdraw` has no `system_program` field: there is no callee program to load. Getting this backwards is the single most common PDA mistake on Solana, which is why module 3 shipped it as a decoy rather than a footnote."
-          },
-          {
-            "id": "q3",
-            "prompt": "Why does the vault PDA have no private key, and what would break if it did?",
-            "multiSelect": false,
-            "options": [
-              {
-                "id": "a",
-                "label": "Its address is found by hashing seeds until the result falls OFF the ed25519 curve, so no key can correspond to it — and if one could, its holder could move the vault's lamports without the program",
-                "correct": true,
-                "feedback": null
-              },
-              {
-                "id": "b",
-                "label": "The key exists but is held by the program, which keeps it secret",
-                "correct": false,
-                "feedback": "There is no key anywhere. Derivation deliberately retries with a decreasing bump until it lands off the curve, precisely so no keypair can exist for the address."
-              },
-              {
-                "id": "c",
-                "label": "The key is derived from the program id, so only the program can reconstruct it",
-                "correct": false,
-                "feedback": "Nothing is reconstructed. A PDA is off-curve by construction; the program's authority over it comes from the runtime checking seeds, not from possessing anything."
-              }
-            ],
-            "explanation": "PDA derivation hashes the seeds, the program id and a marker, and retries with bump 255, 254, … until the digest is not a valid curve point. Off-curve means no keypair exists, which is exactly the property you want for an account holding value: the only path to authorising it is a program the runtime can check, not a secret someone can leak."
-          },
-          {
-            "id": "q4",
-            "prompt": "An attacker calls your `withdraw` and passes someone else's vault account, hoping to drain it into their own wallet. Which single piece of the accounts struct stops that?",
-            "multiSelect": false,
-            "options": [
-              {
-                "id": "a",
-                "label": "`seeds = [b\"vault\", user.key().as_ref()]` — the vault's address is a function of the signer's key, so a different vault simply is not the account at that address and the constraint fails",
-                "correct": true,
-                "feedback": null
-              },
-              {
-                "id": "b",
-                "label": "`Account<'info, VaultState>`, because it verifies the discriminator",
-                "correct": false,
-                "feedback": "The discriminator check stops a wrong TYPE (or an uninitialised account) being passed, which is a different attack. It happily accepts a correctly-typed vault belonging to somebody else. The seeds are what bind the account to the signer."
-              },
-              {
-                "id": "c",
-                "label": "`#[account(mut)]` on `user`, because only a mutable signer can receive lamports",
-                "correct": false,
-                "feedback": "`mut` marks the account writable; it says nothing about whose vault was supplied. The binding comes from deriving the vault address from `user.key()`."
-              }
-            ],
-            "explanation": "Seeds are the cheapest and strongest account-substitution defence available: `[b\"vault\", user.key().as_ref()]` makes the address itself a function of the signer, so there is exactly one vault the transaction can name for a given signer. The discriminator check and `mut` guard other things — wrong type, and writability — and all three are needed for different reasons."
-          },
-          {
-            "id": "q5",
-            "prompt": "Anchor 1.0 changed the default for duplicate mutable accounts. What is the default now, and what does `#[account(mut, dup)]` do?",
-            "multiSelect": false,
-            "options": [
-              {
-                "id": "a",
-                "label": "Passing the same account twice as two mutable inputs now fails with `ConstraintDuplicateMutableAccount`; `dup` opts a specific account out, for instructions where aliasing is legitimate",
-                "correct": true,
-                "feedback": null
-              },
-              {
-                "id": "b",
-                "label": "Duplicates are allowed by default; `dup` turns on the check for accounts where aliasing would be a bug",
-                "correct": false,
-                "feedback": "It is the reverse, and that reversal is the 1.0 change. The check is on by default and errors; `dup` is the opt-OUT for the rare instruction that genuinely wants the same account in two slots."
-              },
-              {
-                "id": "c",
-                "label": "`dup` deduplicates the account list before the instruction runs",
-                "correct": false,
-                "feedback": "Nothing is removed. `dup` only suppresses the duplicate-mutable-account error for that field; the account still appears in both positions and both borrows are yours to reason about."
-              }
-            ],
-            "explanation": "Two mutable handles to one account is how a `transfer_between_vaults` silently becomes a no-op or a double-credit: you write through one view, then the second view overwrites it from stale data. Anchor 1.0 makes that an error by default and gives you `#[account(mut, dup)]` to say \"yes, I meant it here.\" Write `dup`, never `unsafe(dup)` — that is v2-alpha syntax for a different framework generation."
-          },
-          {
-            "id": "q6",
-            "prompt": "You delete `pub system_program: Program<'info, System>` from `InitializeVault` and click Build. What happens?",
-            "multiSelect": false,
-            "options": [
-              {
-                "id": "a",
-                "label": "The build fails: `init` expands into a CPI that creates the account, and that expansion needs a System Program account in the struct to call — there is no field left to reference",
-                "correct": true,
-                "feedback": null
-              },
-              {
-                "id": "b",
-                "label": "The build succeeds; the instruction fails at runtime when it tries to create the account",
-                "correct": false,
-                "feedback": "It never gets that far. `init` is a macro that writes the create-account CPI for you, and the code it writes names `system_program`. Remove the field and the generated code refers to something that does not exist."
-              },
-              {
-                "id": "c",
-                "label": "The build succeeds and Anchor supplies the System Program automatically, since its address is a constant",
-                "correct": false,
-                "feedback": "The address is a constant, but the ACCOUNT still has to be in the instruction's account list — the runtime only lends a program the accounts it was passed. Anchor requires you to declare it."
-              }
-            ],
-            "explanation": "Creating an account is not something your program can do alone; only the System Program can allocate and assign. `init` hides that CPI, but hiding is not removing, and the generated call names the field. This is also why the error lands on your accounts struct rather than on the line you deleted: macro-generated code fails where it was expanded."
-          },
-          {
-            "id": "q7",
-            "prompt": "`bump` (bare) and `bump = vault.bump` on the same account both compile and usually resolve to the same address. What is the actual difference?",
-            "multiSelect": false,
-            "options": [
-              {
-                "id": "a",
-                "label": "Bare `bump` re-runs the derivation search, hashing once per candidate bump until it finds the canonical one; `bump = vault.bump` hashes once with the bump you stored at init",
-                "correct": true,
-                "feedback": null
-              },
-              {
-                "id": "b",
-                "label": "Bare `bump` accepts any valid bump, so a caller could supply a non-canonical one",
-                "correct": false,
-                "feedback": "Bare `bump` finds and requires the CANONICAL bump — it is not permissive. The cost is that finding it means repeating the search on every call."
-              },
-              {
-                "id": "c",
-                "label": "`bump = vault.bump` skips PDA verification entirely and trusts the account",
-                "correct": false,
-                "feedback": "Verification still happens: Anchor derives the address from your seeds plus that bump and compares it to the account passed in. It just does one hash instead of a search."
-              }
-            ],
-            "explanation": "This is why `VaultState` carries a `bump: u8` field at all. The canonical bump is found by trying 255, 254, … until the result is off-curve, and that search costs compute units every single call. Store it once at init, then hand it back with `bump = vault.bump` — one hash, same guarantee. It is the clearest instance in the course of paying 1 byte of rent to stop paying compute forever."
-          },
-          {
-            "id": "q8",
-            "prompt": "Course 2 recall. Your `withdraw` does `self.balance.checked_sub(amount).ok_or(VaultError::InsufficientFunds)?`. Someone suggests `self.balance - amount` instead, noting that the release profile sets `overflow-checks = true` so it will panic rather than wrap. Why is that still worse?",
-            "multiSelect": false,
-            "options": [
-              {
-                "id": "a",
-                "label": "A panic aborts the instruction with no error code and no message, so the caller learns only that something failed; `checked_sub` + `ok_or` returns a named variant with the `#[msg]` string you wrote",
-                "correct": true,
-                "feedback": null
-              },
-              {
-                "id": "b",
-                "label": "It is not worse — with `overflow-checks = true` the two are equivalent",
-                "correct": false,
-                "feedback": "They stop the same bad write, but they report it completely differently. One gives the caller a code and a sentence; the other gives them a failed transaction and nothing to act on."
-              },
-              {
-                "id": "c",
-                "label": "Bare subtraction would silently wrap to a huge number even with `overflow-checks = true`",
-                "correct": false,
-                "feedback": "That line is exactly what `overflow-checks = true` prevents — it panics instead of wrapping. The problem is the panic itself, not a wrap."
-              },
-              {
-                "id": "d",
-                "label": "`checked_sub` is faster, so the checked version costs fewer compute units",
-                "correct": false,
-                "feedback": "Compute cost is not the argument, and the difference is negligible. The argument is the quality of the failure your caller receives."
-              }
-            ],
-            "explanation": "`overflow-checks = true` turns a wrap into a panic, which is strictly better than a wrap and still the wrong shape for a program. A panic is an aborted instruction carrying no error code, so a client can render nothing useful. `checked_sub` returns `None`, `ok_or` names it `InsufficientFunds`, and `?` carries it up — the caller gets 6001 and a string you authored. Turning `None` into a named variant was the whole point of Course 2's last five lessons, and it is what makes an error a feature rather than a crash."
-          },
-          {
-            "id": "q9",
-            "prompt": "Course 2 recall. Course 2's `mod verify` harness binds `VaultState::withdraw` to `fn(&mut VaultState, u64) -> Result<()>` and asserts `INIT_SPACE == 41`. Which of these would the harness let through?",
-            "multiSelect": false,
-            "options": [
-              {
-                "id": "a",
-                "label": "A `withdraw` whose body calls `checked_add` instead of `checked_sub`",
-                "correct": true,
-                "feedback": null
-              },
-              {
-                "id": "b",
-                "label": "Renaming `balance` to `amount_held`",
-                "correct": false,
-                "feedback": "The harness constructs `VaultState { owner, balance, bump }` by field name, so a rename is a compile error. That is the class of mistake a type-level check does catch."
-              },
-              {
-                "id": "c",
-                "label": "Widening `bump` from `u8` to `u64`",
-                "correct": false,
-                "feedback": "That moves `INIT_SPACE` from 41 to 48 and trips `const _: () = assert!(VaultState::INIT_SPACE == 41)` at compile time."
-              },
-              {
-                "id": "d",
-                "label": "Deleting the `#[account]` attribute",
-                "correct": false,
-                "feedback": "`#[account]` is what supplies the discriminator the harness measures with `assert!(VaultState::DISCRIMINATOR.len() == 8)`, so removing it fails the build."
-              }
-            ],
-            "explanation": "A verification harness is a TYPE check, and an operator is not a type. `checked_add` and `checked_sub` have identical signatures, so every binding in the harness still matches and the build goes green on a vault that credits you for withdrawing. That gap is not a flaw in the harness — it is the boundary of what compilation can observe, and it is exactly the boundary a LiteSVM test crosses by running the instruction and reading the number back."
+            "explanation": null
           }
         ],
         "prompt": null,

--- a/apps/web/src/lib/content/__tests__/fixtures/golden/paths.json
+++ b/apps/web/src/lib/content/__tests__/fixtures/golden/paths.json
@@ -1,160 +1,228 @@
 [
   {
     "_id": "path-solana-core",
-    "title": "Solana Core",
-    "description": "The complete path from zero to Solana developer. Start with the fundamentals, understand how the network works, and build your first on-chain program.",
-    "slug": null,
-    "tag": "Foundation",
-    "order": 1,
-    "difficulty": "beginner",
     "courses": [
       {
         "_id": "course-building-first-program",
-        "title": "Building Your First Solana Program",
-        "slug": "building-your-first-solana-program",
-        "description": "You arrive holding `vault_core.rs` — a `VaultState` and checked `deposit`/`withdraw` that compile, with no `#[program]` and no `#[derive(Accounts)]`. This course adds exactly that. You wrap your own Rust core in Anchor 1.x, create a per-user vault PDA with the space arithmetic derived rather than copied, and move real lamports: deposit through a System Program CPI, withdraw by debiting the program-owned vault directly above an enforced rent floor — and you learn why signer seeds are not the answer there. Then you write the account constraints that stop three named attacks, read the LiteSVM test that would catch what compiling cannot, deploy from a browser tab, publish the IDL on-chain, and call your own live program. Nothing is installed locally. You finish with a devnet program id, a fetchable IDL, and a build write-up.",
+        "creator": "B7o8NfV81HzjuZFWQTTx3Xdvh77Dqoajwib3kWEnvzJF",
+        "description": "Take your Anchor knowledge from theory to practice. Write, compile, and deploy real Solana programs using the Superteam Academy Build Server — no local toolchain setup required. By the end, you'll have a working counter program deployed to Devnet.",
         "difficulty": "intermediate",
         "duration": 12,
-        "thumbnail": null,
-        "creator": "B7o8NfV81HzjuZFWQTTx3Xdvh77Dqoajwib3kWEnvzJF",
-        "tags": [
-          "account-model",
-          "anchor",
-          "checked-arithmetic",
-          "cpi",
-          "debugging",
-          "idl",
-          "keypairs-wallets",
-          "pdas",
-          "program-build",
-          "program-deployment",
-          "program-errors",
-          "program-security",
-          "program-testing",
-          "rent-and-space",
-          "solana-explorer",
-          "solana-programs",
-          "technical-writing",
-          "transactions"
-        ],
-        "xpReward": 850,
-        "trackId": 1,
-        "trackLevel": 3,
         "modules": [
           {
+            "description": "Understand how Solana programs get compiled and get your first successful build through the Superteam Academy Build Server.",
             "key": "bfsp-build-pipeline",
-            "title": "The Build Pipeline",
-            "description": "Wrap your own C2 vault core in Anchor, name the four parts of every Anchor program, and extend it yourself — a green build from a browser tab.",
             "lessons": [
               {
+                "_id": "lesson-bfsp-from-code-to-chain",
+                "slug": "from-code-to-chain",
+                "title": "From Code to Chain"
+              },
+              {
                 "_id": "lesson-bfsp-your-first-build",
-                "title": "From Rust Core to Anchor",
-                "slug": "from-rust-core-to-anchor"
+                "slug": "your-first-build",
+                "title": "Your First Build"
+              },
+              {
+                "_id": "lesson-bfsp-anatomy-anchor-program",
+                "slug": "anatomy-anchor-program",
+                "title": "Anatomy of an Anchor Program"
               },
               {
                 "_id": "lesson-bfsp-add-instruction",
-                "title": "Anatomy of an Anchor Program",
-                "slug": "anatomy-of-an-anchor-program"
-              },
-              {
-                "_id": "lesson-bfsp-adding-instructions",
-                "title": "Add an Instruction",
-                "slug": "add-an-instruction"
+                "slug": "add-instruction",
+                "title": "Add an Instruction"
               }
-            ]
+            ],
+            "title": "The Build Pipeline"
           },
           {
-            "key": "bfsp-state-vault-pda",
-            "title": "State and the Vault PDA",
-            "description": "Derive the byte size of the vault account, derive its address from seeds, store the canonical bump, and wire up initialize by reading a real compile error.",
+            "description": "Define on-chain state with account structs, learn account constraints, and debug compiler errors.",
+            "key": "bfsp-state-accounts",
             "lessons": [
               {
                 "_id": "lesson-bfsp-on-chain-state",
-                "title": "Accounts Are Just Bytes",
-                "slug": "accounts-are-just-bytes"
-              },
-              {
-                "_id": "lesson-bfsp-pdas-vault",
-                "title": "PDAs: An Address With No Key",
-                "slug": "pdas-an-address-with-no-key"
+                "slug": "on-chain-state",
+                "title": "On-Chain State"
               },
               {
                 "_id": "lesson-bfsp-define-counter",
-                "title": "Define the Vault Account",
-                "slug": "define-the-vault-account"
-              },
-              {
-                "_id": "lesson-bfsp-wire-up-initialize",
-                "title": "Wire Up Initialize",
-                "slug": "wire-up-initialize"
-              }
-            ]
-          },
-          {
-            "key": "bfsp-deposit-withdraw-harden",
-            "title": "Deposit, Withdraw, Harden",
-            "description": "Move real lamports — deposit through a System Program CPI, withdraw by debiting the program-owned vault directly above a rent floor — find out why the PDA does not sign its own withdrawal, surface your checked arithmetic as typed Anchor errors, and write the constraints that stop the obvious attacks.",
-            "lessons": [
-              {
-                "_id": "lesson-bfsp-cpi-lamports",
-                "title": "CPI: Moving Real Lamports",
-                "slug": "cpi-moving-real-lamports"
-              },
-              {
-                "_id": "lesson-bfsp-build-increment",
-                "title": "Write the Deposit",
-                "slug": "write-the-deposit"
-              },
-              {
-                "_id": "lesson-bfsp-complete-counter",
-                "title": "Withdraw With a PDA Signer",
-                "slug": "withdraw-with-a-pda-signer"
+                "slug": "define-counter-account",
+                "title": "Define a Counter Account"
               },
               {
                 "_id": "lesson-bfsp-account-constraints",
-                "title": "Harden the Vault",
-                "slug": "harden-the-vault"
-              }
-            ]
-          },
-          {
-            "key": "bfsp-ship-it",
-            "title": "Ship It",
-            "description": "Prove the program behaves before you spend devnet SOL, fund the deploy wallet, deploy from the browser, publish the IDL on-chain, and write up what you built.",
-            "lessons": [
-              {
-                "_id": "lesson-bfsp-pre-flight-check",
-                "title": "Pre-Flight Check",
-                "slug": "pre-flight-check"
+                "slug": "account-constraints-deep-dive",
+                "title": "Account Constraints Deep Dive"
               },
               {
+                "_id": "lesson-bfsp-wire-up-initialize",
+                "slug": "wire-up-initialize",
+                "title": "Wire Up Initialize"
+              }
+            ],
+            "title": "State & Accounts"
+          },
+          {
+            "description": "Build the complete counter program with multiple instructions, error handling, and deploy it to Devnet.",
+            "key": "bfsp-full-counter",
+            "lessons": [
+              {
+                "_id": "lesson-bfsp-adding-instructions",
+                "slug": "adding-instructions",
+                "title": "Adding Instructions"
+              },
+              {
+                "_id": "lesson-bfsp-build-increment",
+                "slug": "build-increment",
+                "title": "Build the Increment"
+              },
+              {
+                "_id": "lesson-bfsp-complete-counter",
+                "slug": "complete-counter-program",
+                "title": "Complete Counter Program"
+              },
+              {
+                "_id": "lesson-bfsp-deploy-to-devnet",
+                "slug": "deploy-to-devnet",
+                "title": "Deploy to Devnet"
+              }
+            ],
+            "title": "The Full Counter"
+          },
+          {
+            "description": "Deploy your counter program to Solana Devnet and interact with it on-chain. Fund your wallet, deploy your binary, and call your program's instructions.",
+            "key": "bfsp-deploy-interact",
+            "lessons": [
+              {
                 "_id": "lesson-bfsp-m4-airdrop",
-                "title": "Fund Your Wallet",
-                "slug": "fund-your-wallet"
+                "slug": "airdrop-fund-wallet",
+                "title": "Airdrop & Fund Your Wallet"
               },
               {
                 "_id": "lesson-bfsp-m4-deploy",
-                "title": "Deploy and Publish the IDL",
-                "slug": "deploy-and-publish-the-idl"
+                "slug": "deploy-program-devnet",
+                "title": "Deploy Your Program to Devnet"
+              },
+              {
+                "_id": "lesson-bfsp-m4-interact",
+                "slug": "interact-with-program",
+                "title": "Interact with Your Program"
               },
               {
                 "_id": "lesson-bfsp-m4-capstone",
-                "title": "What You've Built — and Writing It Up",
-                "slug": "what-you-built"
+                "slug": "what-you-built",
+                "title": "What You've Built"
               }
-            ]
+            ],
+            "title": "Deploy & Interact"
           }
-        ]
+        ],
+        "slug": "building-your-first-solana-program",
+        "tags": [
+          "account-model",
+          "anchor",
+          "keypairs-wallets",
+          "program-deployment",
+          "solana-programs",
+          "transactions"
+        ],
+        "thumbnail": null,
+        "title": "Building Your First Solana Program",
+        "trackId": 1,
+        "trackLevel": 2,
+        "xpReward": 850
       },
       {
         "_id": "course-solana-fundamentals",
-        "title": "Solana Fundamentals",
-        "slug": "solana-fundamentals",
+        "creator": "B7o8NfV81HzjuZFWQTTx3Xdvh77Dqoajwib3kWEnvzJF",
         "description": "A comprehensive beginner course covering the fundamentals of Solana blockchain development. Learn to set up your environment, create wallets, send transactions, and work with SPL tokens. Perfect for developers new to Solana who want to start building decentralized applications.",
         "difficulty": "beginner",
         "duration": 10,
-        "thumbnail": null,
-        "creator": "B7o8NfV81HzjuZFWQTTx3Xdvh77Dqoajwib3kWEnvzJF",
+        "modules": [
+          {
+            "description": "Learn the fundamentals of Solana blockchain, set up your development environment, and configure your first wallet.",
+            "key": "getting-started",
+            "lessons": [
+              {
+                "_id": "lesson-intro-solana",
+                "slug": "what-is-solana",
+                "title": "What is Solana?"
+              },
+              {
+                "_id": "lesson-setup-environment",
+                "slug": "setup-environment",
+                "title": "Setting Up Your Development Environment"
+              },
+              {
+                "_id": "lesson-wallet-setup",
+                "slug": "wallet-setup",
+                "title": "Setting Up a Solana Wallet"
+              },
+              {
+                "_id": "lesson-keypair-challenge",
+                "slug": "keypair-challenge",
+                "title": "Challenge: Generate a Keypair"
+              }
+            ],
+            "title": "Getting Started with Solana"
+          },
+          {
+            "description": "Master Solana transactions, learn about SPL tokens, and build your first on-chain programs.",
+            "key": "transactions-tokens",
+            "lessons": [
+              {
+                "_id": "lesson-first-transaction",
+                "slug": "first-transaction",
+                "title": "Your First Transaction"
+              },
+              {
+                "_id": "lesson-transfer-challenge",
+                "slug": "transfer-challenge",
+                "title": "Challenge: Build a Transfer Function"
+              },
+              {
+                "_id": "lesson-token-overview",
+                "slug": "token-overview",
+                "title": "Understanding SPL Tokens"
+              },
+              {
+                "_id": "lesson-create-token-challenge",
+                "slug": "create-token-challenge",
+                "title": "Challenge: Create a Token Mint"
+              }
+            ],
+            "title": "Transactions & Tokens"
+          },
+          {
+            "description": "Deep dive into Solana's account model and program architecture. Learn how programs interact with accounts and build custom instructions.",
+            "key": "accounts-programs",
+            "lessons": [
+              {
+                "_id": "lesson-account-model",
+                "slug": "account-model",
+                "title": "Understanding Solana's Account Model"
+              },
+              {
+                "_id": "lesson-account-challenge",
+                "slug": "account-challenge",
+                "title": "Challenge: Explore the Account Model"
+              },
+              {
+                "_id": "lesson-programs-overview",
+                "slug": "programs-overview",
+                "title": "Introduction to Solana Programs"
+              },
+              {
+                "_id": "lesson-program-challenge",
+                "slug": "program-challenge",
+                "title": "Challenge: Build a Custom Instruction"
+              }
+            ],
+            "title": "Accounts & Programs"
+          }
+        ],
+        "slug": "solana-fundamentals",
         "tags": [
           "account-model",
           "keypairs-wallets",
@@ -163,113 +231,113 @@
           "spl-tokens",
           "transactions"
         ],
-        "xpReward": 600,
+        "thumbnail": null,
+        "title": "Solana Fundamentals",
         "trackId": 1,
         "trackLevel": 1,
-        "modules": [
-          {
-            "key": "getting-started",
-            "title": "Getting Started with Solana",
-            "description": "Learn the fundamentals of Solana blockchain, set up your development environment, and configure your first wallet.",
-            "lessons": [
-              {
-                "_id": "lesson-intro-solana",
-                "title": "What is Solana?",
-                "slug": "what-is-solana"
-              },
-              {
-                "_id": "lesson-setup-environment",
-                "title": "Setting Up Your Development Environment",
-                "slug": "setup-environment"
-              },
-              {
-                "_id": "lesson-wallet-setup",
-                "title": "Setting Up a Solana Wallet",
-                "slug": "wallet-setup"
-              },
-              {
-                "_id": "lesson-keypair-challenge",
-                "title": "Challenge: Generate a Keypair",
-                "slug": "keypair-challenge"
-              }
-            ]
-          },
-          {
-            "key": "transactions-tokens",
-            "title": "Transactions & Tokens",
-            "description": "Master Solana transactions, learn about SPL tokens, and build your first on-chain programs.",
-            "lessons": [
-              {
-                "_id": "lesson-first-transaction",
-                "title": "Your First Transaction",
-                "slug": "first-transaction"
-              },
-              {
-                "_id": "lesson-transfer-challenge",
-                "title": "Challenge: Build a Transfer Function",
-                "slug": "transfer-challenge"
-              },
-              {
-                "_id": "lesson-token-overview",
-                "title": "Understanding SPL Tokens",
-                "slug": "token-overview"
-              },
-              {
-                "_id": "lesson-create-token-challenge",
-                "title": "Challenge: Create a Token Mint",
-                "slug": "create-token-challenge"
-              }
-            ]
-          },
-          {
-            "key": "accounts-programs",
-            "title": "Accounts & Programs",
-            "description": "Deep dive into Solana's account model and program architecture. Learn how programs interact with accounts and build custom instructions.",
-            "lessons": [
-              {
-                "_id": "lesson-account-model",
-                "title": "Understanding Solana's Account Model",
-                "slug": "account-model"
-              },
-              {
-                "_id": "lesson-account-challenge",
-                "title": "Challenge: Explore the Account Model",
-                "slug": "account-challenge"
-              },
-              {
-                "_id": "lesson-programs-overview",
-                "title": "Introduction to Solana Programs",
-                "slug": "programs-overview"
-              },
-              {
-                "_id": "lesson-program-challenge",
-                "title": "Challenge: Build a Custom Instruction",
-                "slug": "program-challenge"
-              }
-            ]
-          }
-        ]
+        "xpReward": 600
       }
-    ]
+    ],
+    "description": "The complete path from zero to Solana developer. Start with the fundamentals, understand how the network works, and build your first on-chain program.",
+    "difficulty": "beginner",
+    "order": 1,
+    "slug": null,
+    "tag": "Foundation",
+    "title": "Solana Core"
   },
   {
     "_id": "path-rust-programs",
-    "title": "Rust & Programs",
-    "description": "Master Rust for blockchain and the Anchor framework. Write, test, and deploy production-ready Solana programs.",
-    "slug": null,
-    "tag": "Builder",
-    "order": 2,
-    "difficulty": "intermediate",
     "courses": [
       {
         "_id": "course-anchor-framework",
-        "title": "Anchor Framework Mastery",
-        "slug": "anchor-framework",
+        "creator": "B7o8NfV81HzjuZFWQTTx3Xdvh77Dqoajwib3kWEnvzJF",
         "description": "Master the Anchor framework for Solana smart contract development. From account constraints to PDAs, CPIs, testing, and deployment — build production-ready programs with confidence.",
         "difficulty": "intermediate",
         "duration": 14,
-        "thumbnail": null,
-        "creator": "B7o8NfV81HzjuZFWQTTx3Xdvh77Dqoajwib3kWEnvzJF",
+        "modules": [
+          {
+            "description": "Learn the fundamentals of the Anchor framework, program structure, and account constraints.",
+            "key": "anchor-basics",
+            "lessons": [
+              {
+                "_id": "lesson-anchor-intro",
+                "slug": "anchor-intro",
+                "title": "What is the Anchor Framework?"
+              },
+              {
+                "_id": "lesson-anchor-setup-challenge",
+                "slug": "anchor-setup-challenge",
+                "title": "Challenge: Anchor Program Structure"
+              },
+              {
+                "_id": "lesson-anchor-accounts",
+                "slug": "anchor-accounts",
+                "title": "Anchor Account Constraints"
+              },
+              {
+                "_id": "lesson-anchor-accounts-challenge",
+                "slug": "anchor-accounts-challenge",
+                "title": "Challenge: Account Validation"
+              }
+            ],
+            "title": "Anchor Basics"
+          },
+          {
+            "description": "Master Program Derived Addresses and Cross-Program Invocations for building composable programs.",
+            "key": "pdas-cpis",
+            "lessons": [
+              {
+                "_id": "lesson-pda-deep-dive",
+                "slug": "pda-deep-dive",
+                "title": "PDA Deep Dive"
+              },
+              {
+                "_id": "lesson-pda-advanced-challenge",
+                "slug": "pda-advanced-challenge",
+                "title": "Challenge: Multi-PDA Derivation"
+              },
+              {
+                "_id": "lesson-cpi-overview",
+                "slug": "cpi-overview",
+                "title": "Cross-Program Invocations"
+              },
+              {
+                "_id": "lesson-cpi-challenge",
+                "slug": "cpi-challenge",
+                "title": "Challenge: Simulate a CPI Vault Transfer"
+              }
+            ],
+            "title": "PDAs & CPIs"
+          },
+          {
+            "description": "Learn to test, debug, and deploy production-ready Anchor programs.",
+            "key": "anchor-testing",
+            "lessons": [
+              {
+                "_id": "lesson-anchor-testing",
+                "slug": "anchor-testing",
+                "title": "Testing Anchor Programs"
+              },
+              {
+                "_id": "lesson-anchor-errors",
+                "slug": "anchor-errors",
+                "title": "Custom Errors in Anchor"
+              },
+              {
+                "_id": "lesson-deployment",
+                "slug": "deployment",
+                "title": "Deploying Solana Programs"
+              },
+              {
+                "_id": "lesson-testing-challenge",
+                "slug": "testing-challenge",
+                "title": "Challenge: Test a Transfer Program"
+              }
+            ],
+            "title": "Testing & Deployment"
+          }
+        ],
+        "slug": "anchor-framework",
         "tags": [
           "account-model",
           "anchor",
@@ -279,215 +347,210 @@
           "program-testing",
           "solana-programs"
         ],
-        "xpReward": 900,
+        "thumbnail": null,
+        "title": "Anchor Framework Mastery",
         "trackId": 3,
         "trackLevel": 1,
-        "modules": [
-          {
-            "key": "anchor-basics",
-            "title": "Anchor Basics",
-            "description": "Learn the fundamentals of the Anchor framework, program structure, and account constraints.",
-            "lessons": [
-              {
-                "_id": "lesson-anchor-intro",
-                "title": "What is the Anchor Framework?",
-                "slug": "anchor-intro"
-              },
-              {
-                "_id": "lesson-anchor-setup-challenge",
-                "title": "Challenge: Anchor Program Structure",
-                "slug": "anchor-setup-challenge"
-              },
-              {
-                "_id": "lesson-anchor-accounts",
-                "title": "Anchor Account Constraints",
-                "slug": "anchor-accounts"
-              },
-              {
-                "_id": "lesson-anchor-accounts-challenge",
-                "title": "Challenge: Account Validation",
-                "slug": "anchor-accounts-challenge"
-              }
-            ]
-          },
-          {
-            "key": "pdas-cpis",
-            "title": "PDAs & CPIs",
-            "description": "Master Program Derived Addresses and Cross-Program Invocations for building composable programs.",
-            "lessons": [
-              {
-                "_id": "lesson-pda-deep-dive",
-                "title": "PDA Deep Dive",
-                "slug": "pda-deep-dive"
-              },
-              {
-                "_id": "lesson-pda-advanced-challenge",
-                "title": "Challenge: Multi-PDA Derivation",
-                "slug": "pda-advanced-challenge"
-              },
-              {
-                "_id": "lesson-cpi-overview",
-                "title": "Cross-Program Invocations",
-                "slug": "cpi-overview"
-              },
-              {
-                "_id": "lesson-cpi-challenge",
-                "title": "Challenge: Simulate a CPI Vault Transfer",
-                "slug": "cpi-challenge"
-              }
-            ]
-          },
-          {
-            "key": "anchor-testing",
-            "title": "Testing & Deployment",
-            "description": "Learn to test, debug, and deploy production-ready Anchor programs.",
-            "lessons": [
-              {
-                "_id": "lesson-anchor-testing",
-                "title": "Testing Anchor Programs",
-                "slug": "anchor-testing"
-              },
-              {
-                "_id": "lesson-anchor-errors",
-                "title": "Custom Errors in Anchor",
-                "slug": "anchor-errors"
-              },
-              {
-                "_id": "lesson-deployment",
-                "title": "Deploying Solana Programs",
-                "slug": "deployment"
-              },
-              {
-                "_id": "lesson-testing-challenge",
-                "title": "Challenge: Test a Transfer Program",
-                "slug": "testing-challenge"
-              }
-            ]
-          }
-        ]
+        "xpReward": 900
       },
       {
         "_id": "course-rust-for-solana",
-        "title": "Rust for Solana Developers",
-        "slug": "rust-for-solana",
+        "creator": "B7o8NfV81HzjuZFWQTTx3Xdvh77Dqoajwib3kWEnvzJF",
         "description": "Master Rust fundamentals tailored for Solana smart contract development. From ownership and borrowing to serialization, error handling, PDAs, and program architecture — build the skills to write native Solana programs.",
         "difficulty": "intermediate",
         "duration": 12,
-        "thumbnail": null,
-        "creator": "B7o8NfV81HzjuZFWQTTx3Xdvh77Dqoajwib3kWEnvzJF",
-        "tags": [
-          "borsh-serialization",
-          "pdas",
-          "rust",
-          "solana-programs"
-        ],
-        "xpReward": 800,
-        "trackId": 2,
-        "trackLevel": 1,
         "modules": [
           {
-            "key": "rust-basics",
-            "title": "Rust Basics",
             "description": "Learn Rust fundamentals essential for Solana development: ownership, borrowing, structs, enums, and pattern matching.",
+            "key": "rust-basics",
             "lessons": [
               {
                 "_id": "lesson-why-rust",
-                "title": "Why Rust for Solana",
-                "slug": "why-rust"
+                "slug": "why-rust",
+                "title": "Why Rust for Solana"
               },
               {
                 "_id": "lesson-ownership-borrowing",
-                "title": "Ownership and Borrowing",
-                "slug": "ownership-borrowing"
+                "slug": "ownership-borrowing",
+                "title": "Ownership and Borrowing"
               },
               {
                 "_id": "lesson-structs-enums",
-                "title": "Structs and Enums for Solana",
-                "slug": "structs-enums"
+                "slug": "structs-enums",
+                "title": "Structs and Enums for Solana"
               },
               {
                 "_id": "lesson-rust-basics-challenge",
-                "title": "Challenge: Rust Structs & Methods",
-                "slug": "rust-basics-challenge"
+                "slug": "rust-basics-challenge",
+                "title": "Challenge: Rust Structs & Methods"
               }
-            ]
+            ],
+            "title": "Rust Basics"
           },
           {
-            "key": "rust-blockchain",
-            "title": "Rust for Blockchain",
             "description": "Apply Rust skills to blockchain concepts: serialization with Borsh, error handling patterns, and on-chain data management.",
+            "key": "rust-blockchain",
             "lessons": [
               {
                 "_id": "lesson-serialization",
-                "title": "Borsh Serialization for Solana",
-                "slug": "serialization"
+                "slug": "serialization",
+                "title": "Borsh Serialization for Solana"
               },
               {
                 "_id": "lesson-serialization-challenge",
-                "title": "Challenge: Serialize Account Data",
-                "slug": "serialization-challenge"
+                "slug": "serialization-challenge",
+                "title": "Challenge: Serialize Account Data"
               },
               {
                 "_id": "lesson-error-handling",
-                "title": "Error Handling in Solana Programs",
-                "slug": "error-handling"
+                "slug": "error-handling",
+                "title": "Error Handling in Solana Programs"
               },
               {
                 "_id": "lesson-error-challenge",
-                "title": "Challenge: Transaction Validator",
-                "slug": "error-challenge"
+                "slug": "error-challenge",
+                "title": "Challenge: Transaction Validator"
               }
-            ]
+            ],
+            "title": "Rust for Blockchain"
           },
           {
-            "key": "rust-programs",
-            "title": "Building Solana Programs",
             "description": "Build native Solana programs: program structure, instruction processing, PDAs, and state management.",
+            "key": "rust-programs",
             "lessons": [
               {
                 "_id": "lesson-program-structure",
-                "title": "Solana Program Structure",
-                "slug": "program-structure"
+                "slug": "program-structure",
+                "title": "Solana Program Structure"
               },
               {
                 "_id": "lesson-rust-program-challenge",
-                "title": "Challenge: Process Transfer Instruction",
-                "slug": "rust-program-challenge"
+                "slug": "rust-program-challenge",
+                "title": "Challenge: Process Transfer Instruction"
               },
               {
                 "_id": "lesson-state-management",
-                "title": "PDAs and State Management",
-                "slug": "state-management"
+                "slug": "state-management",
+                "title": "PDAs and State Management"
               },
               {
                 "_id": "lesson-pda-challenge",
-                "title": "Challenge: Derive PDAs",
-                "slug": "pda-challenge"
+                "slug": "pda-challenge",
+                "title": "Challenge: Derive PDAs"
               }
-            ]
+            ],
+            "title": "Building Solana Programs"
           }
-        ]
+        ],
+        "slug": "rust-for-solana",
+        "tags": ["borsh-serialization", "pdas", "rust", "solana-programs"],
+        "thumbnail": null,
+        "title": "Rust for Solana Developers",
+        "trackId": 2,
+        "trackLevel": 1,
+        "xpReward": 800
       }
-    ]
+    ],
+    "description": "Master Rust for blockchain and the Anchor framework. Write, test, and deploy production-ready Solana programs.",
+    "difficulty": "intermediate",
+    "order": 2,
+    "slug": null,
+    "tag": "Builder",
+    "title": "Rust & Programs"
   },
   {
     "_id": "path-frontend",
-    "title": "Frontend",
-    "description": "Build production-ready Solana dApp frontends. Master wallet integration, on-chain data reading, and interactive transaction UIs.",
-    "slug": null,
-    "tag": "UI/UX",
-    "order": 3,
-    "difficulty": "intermediate",
     "courses": [
       {
         "_id": "course-solana-frontend",
-        "title": "Solana Frontend Development",
-        "slug": "solana-frontend",
+        "creator": "B7o8NfV81HzjuZFWQTTx3Xdvh77Dqoajwib3kWEnvzJF",
         "description": "Build production-ready Solana dApp frontends. Master wallet integration, on-chain data reading, and interactive transaction UIs using React and the Solana Wallet Adapter.",
         "difficulty": "intermediate",
         "duration": 10,
-        "thumbnail": null,
-        "creator": "B7o8NfV81HzjuZFWQTTx3Xdvh77Dqoajwib3kWEnvzJF",
+        "modules": [
+          {
+            "description": "Master Solana wallet integration using the Wallet Adapter. Learn to connect wallets, sign messages, and implement Sign-In With Solana (SIWS) authentication.",
+            "key": "wallet-integration",
+            "lessons": [
+              {
+                "_id": "lesson-wallet-adapter-intro",
+                "slug": "wallet-adapter-intro",
+                "title": "Solana Wallet Adapter Architecture"
+              },
+              {
+                "_id": "lesson-connect-wallet-challenge",
+                "slug": "connect-wallet-challenge",
+                "title": "Challenge: Wallet Connection Flow"
+              },
+              {
+                "_id": "lesson-signing-messages",
+                "slug": "signing-messages",
+                "title": "Sign-In With Solana (SIWS)"
+              },
+              {
+                "_id": "lesson-sign-message-challenge",
+                "slug": "sign-message-challenge",
+                "title": "Challenge: Build a SIWS Message"
+              }
+            ],
+            "title": "Wallet Integration"
+          },
+          {
+            "description": "Learn to read and parse on-chain data using Solana's RPC methods. Master account data deserialization and binary encoding patterns.",
+            "key": "reading-onchain",
+            "lessons": [
+              {
+                "_id": "lesson-rpc-methods",
+                "slug": "rpc-methods",
+                "title": "Solana RPC Methods"
+              },
+              {
+                "_id": "lesson-balance-checker-challenge",
+                "slug": "balance-checker-challenge",
+                "title": "Challenge: Multi-Wallet Balance Checker"
+              },
+              {
+                "_id": "lesson-parsing-data",
+                "slug": "parsing-data",
+                "title": "Parsing Account Data"
+              },
+              {
+                "_id": "lesson-parse-data-challenge",
+                "slug": "parse-data-challenge",
+                "title": "Challenge: Parse Account Data Buffer"
+              }
+            ],
+            "title": "Reading On-Chain Data"
+          },
+          {
+            "description": "Build production-ready dApp user interfaces. Master React patterns, transaction flows, and real-time notifications for Solana applications.",
+            "key": "dapp-ui",
+            "lessons": [
+              {
+                "_id": "lesson-react-patterns",
+                "slug": "react-patterns",
+                "title": "React Patterns for Solana dApps"
+              },
+              {
+                "_id": "lesson-transaction-ui",
+                "slug": "transaction-ui",
+                "title": "Transaction UI Patterns"
+              },
+              {
+                "_id": "lesson-notifications",
+                "slug": "notifications",
+                "title": "Transaction Notifications"
+              },
+              {
+                "_id": "lesson-dapp-challenge",
+                "slug": "dapp-challenge",
+                "title": "Challenge: SOL Transfer Form"
+              }
+            ],
+            "title": "Building dApp UIs"
+          }
+        ],
+        "slug": "solana-frontend",
         "tags": [
           "account-model",
           "borsh-serialization",
@@ -499,238 +562,156 @@
           "wallet-adapter",
           "web3-frontend"
         ],
-        "xpReward": 700,
+        "thumbnail": null,
+        "title": "Solana Frontend Development",
         "trackId": 4,
         "trackLevel": 1,
-        "modules": [
-          {
-            "key": "wallet-integration",
-            "title": "Wallet Integration",
-            "description": "Master Solana wallet integration using the Wallet Adapter. Learn to connect wallets, sign messages, and implement Sign-In With Solana (SIWS) authentication.",
-            "lessons": [
-              {
-                "_id": "lesson-wallet-adapter-intro",
-                "title": "Solana Wallet Adapter Architecture",
-                "slug": "wallet-adapter-intro"
-              },
-              {
-                "_id": "lesson-connect-wallet-challenge",
-                "title": "Challenge: Wallet Connection Flow",
-                "slug": "connect-wallet-challenge"
-              },
-              {
-                "_id": "lesson-signing-messages",
-                "title": "Sign-In With Solana (SIWS)",
-                "slug": "signing-messages"
-              },
-              {
-                "_id": "lesson-sign-message-challenge",
-                "title": "Challenge: Build a SIWS Message",
-                "slug": "sign-message-challenge"
-              }
-            ]
-          },
-          {
-            "key": "reading-onchain",
-            "title": "Reading On-Chain Data",
-            "description": "Learn to read and parse on-chain data using Solana's RPC methods. Master account data deserialization and binary encoding patterns.",
-            "lessons": [
-              {
-                "_id": "lesson-rpc-methods",
-                "title": "Solana RPC Methods",
-                "slug": "rpc-methods"
-              },
-              {
-                "_id": "lesson-balance-checker-challenge",
-                "title": "Challenge: Multi-Wallet Balance Checker",
-                "slug": "balance-checker-challenge"
-              },
-              {
-                "_id": "lesson-parsing-data",
-                "title": "Parsing Account Data",
-                "slug": "parsing-data"
-              },
-              {
-                "_id": "lesson-parse-data-challenge",
-                "title": "Challenge: Parse Account Data Buffer",
-                "slug": "parse-data-challenge"
-              }
-            ]
-          },
-          {
-            "key": "dapp-ui",
-            "title": "Building dApp UIs",
-            "description": "Build production-ready dApp user interfaces. Master React patterns, transaction flows, and real-time notifications for Solana applications.",
-            "lessons": [
-              {
-                "_id": "lesson-react-patterns",
-                "title": "React Patterns for Solana dApps",
-                "slug": "react-patterns"
-              },
-              {
-                "_id": "lesson-transaction-ui",
-                "title": "Transaction UI Patterns",
-                "slug": "transaction-ui"
-              },
-              {
-                "_id": "lesson-notifications",
-                "title": "Transaction Notifications",
-                "slug": "notifications"
-              },
-              {
-                "_id": "lesson-dapp-challenge",
-                "title": "Challenge: SOL Transfer Form",
-                "slug": "dapp-challenge"
-              }
-            ]
-          }
-        ]
+        "xpReward": 700
       }
-    ]
+    ],
+    "description": "Build production-ready Solana dApp frontends. Master wallet integration, on-chain data reading, and interactive transaction UIs.",
+    "difficulty": "intermediate",
+    "order": 3,
+    "slug": null,
+    "tag": "UI/UX",
+    "title": "Frontend"
   },
   {
     "_id": "path-defi",
-    "title": "DeFi",
-    "description": "Specialize in decentralized finance on Solana. Understand AMMs, lending protocols, token mechanics, and create DeFi primitives.",
-    "slug": null,
-    "tag": "DeFi",
-    "order": 4,
-    "difficulty": "advanced",
     "courses": [
       {
         "_id": "course-defi-on-solana",
-        "title": "DeFi on Solana",
-        "slug": "defi-on-solana",
+        "creator": "B7o8NfV81HzjuZFWQTTx3Xdvh77Dqoajwib3kWEnvzJF",
         "description": "Dive deep into decentralized finance on Solana. Understand AMMs, lending protocols, token mechanics, staking, and build DeFi primitives from vaults to liquidation engines.",
         "difficulty": "advanced",
         "duration": 16,
-        "thumbnail": null,
-        "creator": "B7o8NfV81HzjuZFWQTTx3Xdvh77Dqoajwib3kWEnvzJF",
-        "tags": [
-          "amm",
-          "defi",
-          "lending",
-          "oracles",
-          "spl-tokens",
-          "staking"
-        ],
-        "xpReward": 1000,
-        "trackId": 5,
-        "trackLevel": 1,
         "modules": [
           {
-            "key": "defi-primitives",
-            "title": "DeFi Primitives",
             "description": "Understand the core concepts of decentralized finance on Solana: AMMs, lending, and market mechanics.",
+            "key": "defi-primitives",
             "lessons": [
               {
                 "_id": "lesson-defi-overview",
-                "title": "DeFi on Solana Overview",
-                "slug": "defi-overview"
+                "slug": "defi-overview",
+                "title": "DeFi on Solana Overview"
               },
               {
                 "_id": "lesson-amm-concepts",
-                "title": "Automated Market Makers",
-                "slug": "amm-concepts"
+                "slug": "amm-concepts",
+                "title": "Automated Market Makers"
               },
               {
                 "_id": "lesson-lending-concepts",
-                "title": "Lending & Borrowing Protocols",
-                "slug": "lending-concepts"
+                "slug": "lending-concepts",
+                "title": "Lending & Borrowing Protocols"
               },
               {
                 "_id": "lesson-amm-challenge",
-                "title": "Challenge: Constant Product AMM",
-                "slug": "amm-challenge"
+                "slug": "amm-challenge",
+                "title": "Challenge: Constant Product AMM"
               }
-            ]
+            ],
+            "title": "DeFi Primitives"
           },
           {
-            "key": "token-mechanics",
-            "title": "Token Mechanics",
             "description": "Deep dive into SPL Token standards, token math, and staking mechanisms on Solana.",
+            "key": "token-mechanics",
             "lessons": [
               {
                 "_id": "lesson-token-standards",
-                "title": "Solana Token Standards",
-                "slug": "token-standards"
+                "slug": "token-standards",
+                "title": "Solana Token Standards"
               },
               {
                 "_id": "lesson-token-math-challenge",
-                "title": "Token Math Challenge",
-                "slug": "token-math-challenge"
+                "slug": "token-math-challenge",
+                "title": "Token Math Challenge"
               },
               {
                 "_id": "lesson-staking-mechanisms",
-                "title": "Staking Mechanisms on Solana",
-                "slug": "staking-mechanisms"
+                "slug": "staking-mechanisms",
+                "title": "Staking Mechanisms on Solana"
               },
               {
                 "_id": "lesson-staking-challenge",
-                "title": "Staking Rewards Calculator",
-                "slug": "staking-challenge"
+                "slug": "staking-challenge",
+                "title": "Staking Rewards Calculator"
               }
-            ]
+            ],
+            "title": "Token Mechanics"
           },
           {
-            "key": "building-defi",
-            "title": "Building DeFi Protocols",
             "description": "Learn advanced DeFi architecture: orderbooks, oracles, vaults, and liquidation systems.",
+            "key": "building-defi",
             "lessons": [
               {
                 "_id": "lesson-orderbook-design",
-                "title": "On-Chain Orderbooks on Solana",
-                "slug": "orderbook-design"
+                "slug": "orderbook-design",
+                "title": "On-Chain Orderbooks on Solana"
               },
               {
                 "_id": "lesson-oracle-design",
-                "title": "Price Oracles for DeFi",
-                "slug": "oracle-design"
+                "slug": "oracle-design",
+                "title": "Price Oracles for DeFi"
               },
               {
                 "_id": "lesson-vault-challenge",
-                "title": "DeFi Vault Simulator",
-                "slug": "vault-challenge"
+                "slug": "vault-challenge",
+                "title": "DeFi Vault Simulator"
               },
               {
                 "_id": "lesson-liquidation-challenge",
-                "title": "Liquidation Engine",
-                "slug": "liquidation-challenge"
+                "slug": "liquidation-challenge",
+                "title": "Liquidation Engine"
               }
-            ]
+            ],
+            "title": "Building DeFi Protocols"
           }
-        ]
+        ],
+        "slug": "defi-on-solana",
+        "tags": ["amm", "defi", "lending", "oracles", "spl-tokens", "staking"],
+        "thumbnail": null,
+        "title": "DeFi on Solana",
+        "trackId": 5,
+        "trackLevel": 1,
+        "xpReward": 1000
       }
-    ]
+    ],
+    "description": "Specialize in decentralized finance on Solana. Understand AMMs, lending protocols, token mechanics, and create DeFi primitives.",
+    "difficulty": "advanced",
+    "order": 4,
+    "slug": null,
+    "tag": "DeFi",
+    "title": "DeFi"
   },
   {
     "_id": "path-infrastructure",
-    "title": "Infrastructure",
+    "courses": [],
     "description": "Learn to build and maintain Solana infrastructure — validators, RPCs, indexers, and developer tooling.",
+    "difficulty": "advanced",
+    "order": 5,
     "slug": null,
     "tag": "Infra",
-    "order": 5,
-    "difficulty": "advanced",
-    "courses": []
+    "title": "Infrastructure"
   },
   {
     "_id": "path-ai-solana",
-    "title": "AI x Solana",
+    "courses": [],
     "description": "Explore the intersection of artificial intelligence and Solana. Build AI agents that interact with on-chain data and execute transactions.",
+    "difficulty": "intermediate",
+    "order": 6,
     "slug": null,
     "tag": "AI Agents",
-    "order": 6,
-    "difficulty": "intermediate",
-    "courses": []
+    "title": "AI x Solana"
   },
   {
     "_id": "path-security",
-    "title": "Security & Auditing",
+    "courses": [],
     "description": "Learn to audit Solana programs for vulnerabilities. Understand common exploit patterns, best practices, and security testing methodologies.",
+    "difficulty": "advanced",
+    "order": 7,
     "slug": null,
     "tag": "Security",
-    "order": 7,
-    "difficulty": "advanced",
-    "courses": []
+    "title": "Security & Auditing"
   }
 ]

--- a/apps/web/src/lib/content/__tests__/fixtures/golden/quests-raw.json
+++ b/apps/web/src/lib/content/__tests__/fixtures/golden/quests-raw.json
@@ -5,15 +5,12 @@
     "lesson-anchor-accounts-challenge",
     "lesson-anchor-setup-challenge",
     "lesson-balance-checker-challenge",
-    "lesson-bfsp-account-constraints",
     "lesson-bfsp-add-instruction",
-    "lesson-bfsp-adding-instructions",
     "lesson-bfsp-build-increment",
     "lesson-bfsp-complete-counter",
-    "lesson-bfsp-cpi-lamports",
     "lesson-bfsp-define-counter",
+    "lesson-bfsp-deploy-to-devnet",
     "lesson-bfsp-m4-deploy",
-    "lesson-bfsp-pdas-vault",
     "lesson-bfsp-wire-up-initialize",
     "lesson-bfsp-your-first-build",
     "lesson-connect-wallet-challenge",
@@ -87,35 +84,36 @@
     {
       "_id": "course-building-first-program:bfsp-build-pipeline",
       "lessonIds": [
+        "lesson-bfsp-from-code-to-chain",
         "lesson-bfsp-your-first-build",
-        "lesson-bfsp-add-instruction",
-        "lesson-bfsp-adding-instructions"
+        "lesson-bfsp-anatomy-anchor-program",
+        "lesson-bfsp-add-instruction"
       ]
     },
     {
-      "_id": "course-building-first-program:bfsp-state-vault-pda",
+      "_id": "course-building-first-program:bfsp-state-accounts",
       "lessonIds": [
         "lesson-bfsp-on-chain-state",
-        "lesson-bfsp-pdas-vault",
         "lesson-bfsp-define-counter",
+        "lesson-bfsp-account-constraints",
         "lesson-bfsp-wire-up-initialize"
       ]
     },
     {
-      "_id": "course-building-first-program:bfsp-deposit-withdraw-harden",
+      "_id": "course-building-first-program:bfsp-full-counter",
       "lessonIds": [
-        "lesson-bfsp-cpi-lamports",
+        "lesson-bfsp-adding-instructions",
         "lesson-bfsp-build-increment",
         "lesson-bfsp-complete-counter",
-        "lesson-bfsp-account-constraints"
+        "lesson-bfsp-deploy-to-devnet"
       ]
     },
     {
-      "_id": "course-building-first-program:bfsp-ship-it",
+      "_id": "course-building-first-program:bfsp-deploy-interact",
       "lessonIds": [
-        "lesson-bfsp-pre-flight-check",
         "lesson-bfsp-m4-airdrop",
         "lesson-bfsp-m4-deploy",
+        "lesson-bfsp-m4-interact",
         "lesson-bfsp-m4-capstone"
       ]
     },

--- a/apps/web/src/lib/content/__tests__/project.golden.test.ts
+++ b/apps/web/src/lib/content/__tests__/project.golden.test.ts
@@ -65,13 +65,6 @@ vi.mock("server-only", () => ({}));
 //    quiz explanations (#15). courses.json, lessons.json and quests-raw.json's
 //    challengeLessonIds/moduleLessonMap regenerated from the bundle through
 //    the real projectors (order preserved, raw quest docs untouched).
-//  - launch-content wave 4 (bump to courses-academy @7a49747): C3 transform of
-//    the LIVE `building-your-first-solana-program` (16 → 15 lessons: 4 retired,
-//    3 added, 0 surviving lessons renumbered — slot-keyed progress bitmaps for
-//    the 38 live enrollments are untouched by construction; capstone lesson id
-//    unchanged, #721 gate constants still hold). courses.json, lessons.json,
-//    quests-raw derived fields, paths.json and course-summaries.json
-//    regenerated from the bundle through the real projectors.
 const deps = { lessonsById };
 
 function bundleCourse(id: string): CourseDoc {


### PR DESCRIPTION
## Revert #740 — it merged 3 minutes before the gate block landed

#740 merged at 22:52:55Z; my blocking review posted at 22:55. Main auto-deploys, so the bump is live. This restores the previous bundle (`content.lock` → `1b74e4a`, 99 lessons, `course-building-first-program` back to 16 dense slots) while **#741** is fixed.

## Why it can't stay live

#740's premise — *"slot-keyed ids are stable, so the on-chain progress bitmaps are untouched by construction"* — is right about ids and wrong about the bitmap. The bitmap index is **not** the slot. `/api/lessons/complete` derives it via `findLessonIndex` ([lesson-index.ts:14](apps/web/src/lib/courses/lesson-index.ts:14)), which returns the lesson's position in the flattened module array. `slots.json` is read by exactly two files, both admin-only. Full analysis in **#741**.

With the transform applied, **9 of 12 surviving lessons change their bitmap index** — including `m4-capstone` 15→14.

**This is not hypothetical on prod data.** `lesson-bfsp-m4-interact` — retired by C3 — is completed with a real on-chain tx at **bit 14**. With #740 live, the capstone maps to index 14, so the idempotency check reads that already-set bit and marks the capstone complete without the learner doing it (no XP, no tx). The capstone is the credential gate (#721). Any other completion on this course in the meantime writes the wrong on-chain bit.

Exposure is small — 1 enrollment, 5 completed rows, 2 learners, 0 certificates — and the corruption only triggers on a completion request, so reverting now most likely avoids it entirely rather than cleaning it up after.

## Sequence

1. This revert (restores known-good).
2. #741 — completion path resolves `lessonId → slot` from the committed `slots.json`; the `lessonIndex >= liveLessonCount` guard becomes a bit test against `activeLessons`; decide the `user_progress.lesson_index` backfill.
3. Re-land #740 unchanged. **The content is good** — nothing needs re-authoring, this is purely an ordering dependency.
