### PR TITLE
fix(content-lint): fail closed on unresolvable base ref; restore-not-regenerate deleted deployed lock (#737 follow-up)

### DIFF
--- a/packages/content-lint/src/__tests__/gate2.test.ts
+++ b/packages/content-lint/src/__tests__/gate2.test.ts
@@ -106,6 +106,31 @@ describe("gate 2 — ids", () => {
     ).toBe(false);
   });
 
+  it("fails CLOSED when an explicit base ref is set but unresolvable — #737 (no fail-open)", async () => {
+    // LINT_BASE_REF points at a ref that was never fetched. Id immutability cannot
+    // be checked; a silent skip would fail OPEN. It must ERROR.
+    const root = makeTempRepo({
+      "courses/a/course.yaml": course("course-x"),
+    });
+    const git = (...args: string[]) => execFileSync("git", args, { cwd: root });
+    git("init", "-q");
+    git("config", "user.email", "t@t.t");
+    git("config", "user.name", "t");
+    git("add", "-A");
+    git("commit", "-qm", "c1");
+    git("branch", "-M", "main");
+
+    const r = await runLint(root, { baseRef: "origin/does-not-exist" });
+    expect(
+      r.diagnostics.some(
+        (d) =>
+          d.gate === "gate-2" &&
+          d.severity === "error" &&
+          /misconfiguration/i.test(d.message)
+      )
+    ).toBe(true);
+  });
+
   it("emits a warning (never silent) when no exact merge-base exists", async () => {
     // An orphan base branch shares NO history with HEAD, so `git merge-base`
     // fails and the check degrades to the base tip — which must be surfaced.

--- a/packages/content-lint/src/__tests__/gate3.test.ts
+++ b/packages/content-lint/src/__tests__/gate3.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { execFileSync } from "node:child_process";
-import { writeFileSync } from "node:fs";
+import { writeFileSync, unlinkSync } from "node:fs";
 import { join } from "node:path";
 import { runLint } from "../lint";
 import "../checks/gate1-schema";
@@ -159,6 +159,53 @@ describe("gate 3 — slots", () => {
           /missing slots\.lock\.json/i.test(d.message)
       )
     ).toBe(true);
+  });
+
+  it("fails CLOSED when an explicit base ref is set but unresolvable — #737 (no fail-open)", async () => {
+    // CI sets LINT_BASE_REF but the ref was never fetched (e.g. a shallow/no fetch).
+    // Slot immutability cannot be checked, and a skip here would fail OPEN, silently
+    // disabling the hard gate. It must ERROR, not warn.
+    const { root } = gitRepo(correctLock);
+    // Renumber a slot to prove the gate would otherwise have work to do.
+    writeFileSync(
+      join(root, "courses/x/slots.lock.json"),
+      JSON.stringify({
+        version: 1,
+        slots: { "lesson-a": 9, "lesson-b": 1 },
+        retired: [],
+        next: 10,
+      }),
+      "utf8"
+    );
+    const r = await runLint(root, { baseRef: "origin/does-not-exist" });
+    expect(
+      r.diagnostics.some(
+        (d) =>
+          d.gate === "gate-3" &&
+          d.severity === "error" &&
+          /misconfiguration/i.test(d.message)
+      )
+    ).toBe(true);
+    // Never a soft warning-skip for an explicitly-requested-but-missing base.
+    expect(
+      r.diagnostics.some((d) => d.gate === "gate-3" && d.severity === "warning")
+    ).toBe(false);
+  });
+
+  it("tells you to RESTORE a deleted deployed lock, never regenerate it — #737", async () => {
+    // Base (main) has the lock; the working tree deletes it. This is an
+    // accidentally-deleted deployed course, not a new one.
+    const { root } = gitRepo(correctLock);
+    unlinkSync(join(root, "courses/x/slots.lock.json"));
+    const r = await runLint(root, { baseRef: "main" });
+    const msg = r.diagnostics.find(
+      (d) => d.gate === "gate-3" && d.severity === "error"
+    )?.message;
+    expect(msg).toBeDefined();
+    expect(msg).toMatch(/deleted/i);
+    expect(msg).toMatch(/restore/i);
+    // Must NOT suggest generating a fresh lock for a course that was deployed.
+    expect(msg).not.toMatch(/generated from its lesson order/i);
   });
 
   it("resolves origin/main locally so a correct lock passes with no explicit base ref", async () => {

--- a/packages/content-lint/src/__tests__/gate3.test.ts
+++ b/packages/content-lint/src/__tests__/gate3.test.ts
@@ -117,6 +117,11 @@ describe("gate 3 — slots", () => {
     expect(msg).toMatch(/DANGER/);
     expect(msg).toMatch(/invariant/i);
     expect(msg).toMatch(/by hand/i);
+    // The DANGER note states the generic truth, not a fabricated enrollment count —
+    // it fires for every mismatching course, including a zero-enrollment new one.
+    // (Digits still legitimately appear in the trailing Expected-lock JSON.)
+    expect(msg).toMatch(/every already-enrolled learner/i);
+    expect(msg).not.toMatch(/\d+\+?\s*(?:live\s+)?learner/i); // no hardcoded count e.g. "38+ learners"
   });
 
   it("skips (warning, never error) when no base ref is resolvable — #737", async () => {

--- a/packages/content-lint/src/checks/gate2-ids.ts
+++ b/packages/content-lint/src/checks/gate2-ids.ts
@@ -74,7 +74,19 @@ export function gate2Check(model: RepoModel, ctx: LintContext): Diagnostic[] {
   // Immutability vs the PR base: an id present at base whose value changed is a hard fail.
   if (ctx.baseRef) {
     const base = mergeBase(ctx.root, ctx.baseRef);
-    if (base) {
+    if (!base) {
+      // A base ref was EXPLICITLY requested (CI sets LINT_BASE_REF) but it does not
+      // resolve — the base was not fetched, or the ref name is wrong. Fail CLOSED:
+      // silently skipping here would fail OPEN and disable the id-immutability gate.
+      out.push(
+        diag(
+          "gate-2",
+          "error",
+          "",
+          `CI misconfiguration: told to diff id immutability against "${ctx.baseRef}" but it is not resolvable — fetch it (fetch-depth: 0) or fix LINT_BASE_REF. Id immutability was NOT verified.`
+        )
+      );
+    } else {
       if (!base.exact) {
         // Degraded to the base tip (e.g. a shallow --depth=1 base fetch). The tip
         // is not the fork point on a diverged base, so the immutability comparison

--- a/packages/content-lint/src/checks/gate3-slots.ts
+++ b/packages/content-lint/src/checks/gate3-slots.ts
@@ -162,7 +162,7 @@ export function gate3Check(model: RepoModel, ctx: LintContext): Diagnostic[] {
           // learner progress (#737).
           `slots.lock.json violates the slot invariant — surviving lessons must keep their assigned slot, retired slots are never reused, and \`next\` only grows. ` +
             `Fix the lock BY HAND to preserve every slot already assigned in the base ref (diff it: \`git show <base>:${file}\`). ` +
-            `DANGER: do NOT run any regenerate-from-scratch command on a deployed course — it renumbers slots and re-points 38+ learners' completed-lesson bitmaps. Regeneration is ONLY for a brand-new course that has never been deployed. ` +
+            `DANGER: do NOT run any regenerate-from-scratch command on a deployed course — it renumbers slots and re-points every already-enrolled learner's completed-lesson bitmap. Regeneration is ONLY for a brand-new course that has never been deployed. ` +
             `Expected ${JSON.stringify(expected)}`
         )
       );

--- a/packages/content-lint/src/checks/gate3-slots.ts
+++ b/packages/content-lint/src/checks/gate3-slots.ts
@@ -33,17 +33,34 @@ function baseLock(
   return parsed.success ? parsed.data : null;
 }
 
-/** Emitted once when no base ref is resolvable — the check is skipped, not failed. */
-function missingLockDiag(course: CourseEntry): Diagnostic {
+/**
+ * Diagnostic for a course whose lock is missing or unparseable. Uses the base ref
+ * (when one is resolved) to tell a brand-new course — safe to generate a fresh
+ * lock — apart from an accidentally-deleted DEPLOYED lock, where the only safe
+ * remedy is to restore the base copy, never regenerate (that renumbers live slots).
+ */
+function missingLockDiag(
+  course: CourseEntry,
+  ctx: LintContext,
+  baseRef: string | null
+): Diagnostic {
   const file = course.slotsPath ?? `${course.dir}/slots.lock.json`;
-  // A brand-new course with no lock file yet is the ONLY safe place to generate a
-  // fresh 0-N assignment. A present-but-unparseable lock is different: the course
-  // may already be deployed, so we flag it for a human instead of inviting a
-  // from-scratch regeneration that would renumber live slots.
-  const message =
-    course.slotsPath === null
-      ? "missing slots.lock.json — a new course needs one generated from its lesson order"
-      : "slots.lock.json is present but does not parse against the schema — fix it by hand; do NOT regenerate a deployed course's lock from scratch (that renumbers live slots)";
+  if (course.slotsPath !== null) {
+    // File is present but does not parse — the course may already be deployed.
+    return diag(
+      "gate-3",
+      "error",
+      file,
+      "slots.lock.json is present but does not parse against the schema — fix it by hand; do NOT regenerate a deployed course's lock from scratch (that renumbers live slots)"
+    );
+  }
+  // File is absent from the working tree. If the base ref HAS a lock here, it was a
+  // deployed course whose lock was deleted — restore it, don't generate a new one.
+  const baseHadLock =
+    baseRef !== null && gitShow(ctx.root, baseRef, file) !== null;
+  const message = baseHadLock
+    ? `slots.lock.json was deleted for a deployed course — restore it from the base ref (\`git show <base>:${file}\`); do NOT regenerate it (that renumbers live slots)`
+    : "missing slots.lock.json — a new course needs one generated from its lesson order";
   return diag("gate-3", "error", file, message);
 }
 
@@ -53,18 +70,34 @@ export function gate3Check(model: RepoModel, ctx: LintContext): Diagnostic[] {
   // CI sets ctx.baseRef; a bare local run does not. Fall back to a remote-tracking
   // default (origin/HEAD → origin/main) so a correct lock validates locally too,
   // instead of being regenerated from scratch and reported as a false mismatch (#737).
-  const resolvedRef = ctx.baseRef ?? resolveLocalBase(ctx.root);
+  const explicitBase = ctx.baseRef;
+  const resolvedRef = explicitBase ?? resolveLocalBase(ctx.root);
 
   // Resolve the fork point ONCE (same baseRef for every course). A degrade to the
   // base tip (e.g. a shallow --depth=1 fetch) makes the slots-lock immutability
   // comparison inexact, so surface it — never silently — exactly once.
   const base = resolvedRef ? mergeBase(ctx.root, resolvedRef) : null;
 
-  // No base ref at all (no CI ref, no origin remote): slot immutability CANNOT be
-  // verified — the base state to diff against is unknown. Never regenerate a fresh
-  // 0-N lock and assert a mismatch against a correct one (#737); say the check was
-  // skipped and only catch a genuinely missing lock, which needs no base ref.
   if (!base) {
+    if (explicitBase) {
+      // A base ref was EXPLICITLY requested (CI sets LINT_BASE_REF) but it does not
+      // resolve — the base was not fetched, or the ref name is wrong. This is a hard
+      // failure, NOT a skip: silently passing here would fail OPEN and disable the
+      // slot-immutability gate. Fail CLOSED so a misconfigured workflow is caught.
+      out.push(
+        diag(
+          "gate-3",
+          "error",
+          "",
+          `CI misconfiguration: told to diff slot immutability against "${explicitBase}" but it is not resolvable — fetch it (fetch-depth: 0) or fix LINT_BASE_REF. Slot immutability was NOT verified.`
+        )
+      );
+      return out;
+    }
+    // Bare local run with no base ref at all (no CI ref, no origin remote): slot
+    // immutability CANNOT be verified — the base state is unknown. Never regenerate a
+    // fresh 0-N lock and assert a mismatch against a correct one (#737); say the check
+    // was skipped and only catch a genuinely missing lock, which needs no base ref.
     out.push(
       diag(
         "gate-3",
@@ -74,7 +107,7 @@ export function gate3Check(model: RepoModel, ctx: LintContext): Diagnostic[] {
       )
     );
     for (const course of model.courses) {
-      if (!course.slotsLock) out.push(missingLockDiag(course));
+      if (!course.slotsLock) out.push(missingLockDiag(course, ctx, null));
     }
     return out;
   }
@@ -94,7 +127,7 @@ export function gate3Check(model: RepoModel, ctx: LintContext): Diagnostic[] {
   for (const course of model.courses) {
     const file = course.slotsPath ?? `${course.dir}/slots.lock.json`;
     if (!course.slotsLock) {
-      out.push(missingLockDiag(course));
+      out.push(missingLockDiag(course, ctx, baseRef));
       continue;
     }
     const displayOrder = course.course.modules.flatMap((m) => m.lessons);


### PR DESCRIPTION
Follow-up to #742 (already squash-merged). Adversarial review of that PR found two latent holes in the base-ref handling shared by gate-2 (id immutability) and gate-3 (slots immutability). Both are fixed here.

## 1. MAJOR — fail-open on an explicit-but-unresolvable base ref
#742 collapsed two distinct states into one warning-and-skip:
- **bare local, no base ref** — warning + skip is correct (nothing to diff against).
- **base ref EXPLICITLY set (CI's `LINT_BASE_REF`) but unresolvable** — e.g. the ref was never fetched. `mergeBase` returns null → warning + skip + **exit 0**.

The second case regressed the hard gate to **fail OPEN**: a future workflow that stopped doing `fetch-depth: 0` would silently disable slot/id immutability, and gate-2 skipped on a null base too, so nothing backstops. Reproduced: baseRef set, `origin/main` absent, slot renumbered → lint green.

**Fix:** distinguish the two. No baseRef at all (bare local) stays a warning-skip. A baseRef that was *provided* but does not resolve is now a hard **ERROR** — `CI misconfiguration: told to diff … against "<ref>" but it is not resolvable — fetch it (fetch-depth: 0) or fix LINT_BASE_REF`. Applied identically to `gate2-ids.ts` and `gate3-slots.ts`.

## 2. MINOR — destructive advice for a deleted deployed lock
`missingLockDiag` branched only on working-tree absence, so deleting a **deployed** course's `slots.lock.json` errored with *"a new course needs one generated from its lesson order"* — reintroducing the renumber-and-corrupt class for the accidental-deletion case.

**Fix:** gate-3 now consults the base ref. If the base HAD a lock at that path, the message is *"slots.lock.json was deleted for a deployed course — restore it from the base ref (`git show <base>:<path>`); do NOT regenerate it"*. New-course guidance is kept only when the base has no lock either. A present-but-unparseable lock keeps its existing fix-by-hand message.

## Tests
`pnpm --filter @superteam-lms/content-lint test` → **88 passed** (gate2: 5, gate3: 10). `content-schema` → 170. `typecheck` clean on both touched packages. New coverage: explicit-but-unresolvable base → ERROR (both gate-2 and gate-3), no warning; deleted-deployed-lock → restore message with no "generate" text; the bare-no-base warning path is unchanged.

## courses-academy blast matrix (linter @ this branch vs courses-academy@main, read-only)
| invocation | result |
|---|---|
| bare, `origin/main` present | exit 0, no gate-2/gate-3 diagnostics (resolves origin/main) |
| CI-sim `GITHUB_BASE_REF=main` | exit 0 (byte-identical to prod) |
| bare, no `origin` remote | exit 0, gate-3 **warning** "no base ref" |
| **`LINT_BASE_REF=origin/does-not-exist`** (explicit but unresolvable) | **exit 1**, gate-2 AND gate-3 **error** "CI misconfiguration" (fail closed) |

**Do not merge** — SENSITIVE (ci/lint semantics). Needs adversarial + gate.
