### PR TITLE
fix(content-lint): drop fabricated learner count + stop gate-2 skipping silently

### DIFF
--- a/apps/web/src/app/api/CLAUDE.md
+++ b/apps/web/src/app/api/CLAUDE.md
@@ -91,6 +91,7 @@ the boundary (never the full `Lesson` `blocks[]`, which carries solutions/tests)
 | `/api/admin/flags`                      | GET      | ADMIN_SECRET | Pending community flags for the moderation queue                   |
 | `/api/admin/freeze`                     | GET/POST | ADMIN_SECRET | Read/set the global deploy-window freeze (reset wave B2)           |
 | `/api/admin/publish/pin`                | GET      | ADMIN_SECRET | Content pin: pinned bundle SHA + counts vs courses-academy HEAD    |
+| `/api/admin/capstone-funnel`            | GET      | ADMIN_SECRET | Capstone credential funnel counters (#725)                         |
 
 Content drift (bundle SHA vs `courses-academy` HEAD) and chain drift are folded
 into `/api/admin/status`; the publish card reads `/api/admin/publish/pin`. There

--- a/packages/content-lint/src/__tests__/gate2.test.ts
+++ b/packages/content-lint/src/__tests__/gate2.test.ts
@@ -138,4 +138,54 @@ describe("gate 2 — ids", () => {
       )
     ).toBe(true);
   });
+
+  it("warns (never silently skips) when no base ref is resolvable", async () => {
+    // Previously `if (ctx.baseRef)` with no else: outside CI the id-immutability
+    // comparison vanished with no diagnostic at all, so a bare run looked clean
+    // whether or not the check had actually run. It must say it was skipped.
+    const root = makeTempRepo({
+      "courses/a/course.yaml": course("course-a"),
+    });
+    const r = await runLint(root); // no baseRef, not a git repo
+    expect(
+      r.diagnostics.filter((d) => d.gate === "gate-2" && d.severity === "error")
+    ).toEqual([]);
+    expect(
+      r.diagnostics.some(
+        (d) =>
+          d.gate === "gate-2" &&
+          d.severity === "warning" &&
+          /no base ref/i.test(d.message)
+      )
+    ).toBe(true);
+  });
+
+  it("resolves origin/main locally so immutability is still checked with no explicit base ref", async () => {
+    const root = makeTempRepo({
+      "courses/a/course.yaml": course("course-original"),
+    });
+    const git = (...args: string[]) => execFileSync("git", args, { cwd: root });
+    git("init", "-q");
+    git("config", "user.email", "t@t.t");
+    git("config", "user.name", "t");
+    git("add", "-A");
+    git("commit", "-qm", "base");
+    git("update-ref", "refs/remotes/origin/main", "HEAD");
+    git("symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/main");
+    // Mutate the id AFTER origin/main was pinned — a bare run must still catch it.
+    writeFileSync(
+      join(root, "courses/a/course.yaml"),
+      course("course-renamed"),
+      "utf8"
+    );
+    const r = await runLint(root); // no explicit baseRef
+    expect(
+      r.diagnostics.some(
+        (d) =>
+          d.gate === "gate-2" &&
+          d.severity === "error" &&
+          /immutable|changed/i.test(d.message)
+      )
+    ).toBe(true);
+  });
 });

--- a/packages/content-lint/src/checks/gate2-ids.ts
+++ b/packages/content-lint/src/checks/gate2-ids.ts
@@ -3,7 +3,7 @@ import { byteLength } from "@superteam-lms/content-schema";
 import { registerCheck, type LintContext } from "../lint";
 import { type RepoModel } from "../model";
 import { diag, type Diagnostic } from "../diagnostics";
-import { mergeBase, gitShow } from "../git";
+import { mergeBase, gitShow, resolveLocalBase } from "../git";
 
 const BYTE_CAP: Record<string, number> = { course: 32, achievement: 32 };
 
@@ -72,38 +72,55 @@ export function gate2Check(model: RepoModel, ctx: LintContext): Diagnostic[] {
   }
 
   // Immutability vs the PR base: an id present at base whose value changed is a hard fail.
-  if (ctx.baseRef) {
-    const base = mergeBase(ctx.root, ctx.baseRef);
-    if (base) {
-      if (!base.exact) {
-        // Degraded to the base tip (e.g. a shallow --depth=1 base fetch). The tip
-        // is not the fork point on a diverged base, so the immutability comparison
-        // below may be wrong — never let that be silent (fetch base with full
-        // history, `fetch-depth: 0`, to restore an exact merge-base).
-        out.push(
-          diag(
-            "gate-2",
-            "warning",
-            "",
-            `could not compute an exact merge-base with "${ctx.baseRef}" (shallow base?) — comparing id immutability against the base TIP instead of the fork point; results may be inaccurate. Fetch the base with full history (fetch-depth: 0).`
-          )
-        );
-      }
-      for (const { kind, id, file } of all) {
-        const baseText = gitShow(ctx.root, base.ref, file);
-        if (baseText === null) continue; // file is new at head — nothing to compare
-        const baseId = idFrom(baseText);
-        if (baseId !== undefined && baseId !== id) {
-          out.push(
-            diag(
-              "gate-2",
-              "error",
-              file,
-              `${kind} id changed from "${baseId}" to "${id}" — ids are immutable (spec §4.7)`
-            )
-          );
-        }
-      }
+  // Base resolution mirrors gate-3 (#737): CI supplies ctx.baseRef; a bare local run
+  // falls back to a remote-tracking default so the check still runs outside CI.
+  const resolvedRef = ctx.baseRef ?? resolveLocalBase(ctx.root);
+  const base = resolvedRef ? mergeBase(ctx.root, resolvedRef) : null;
+
+  // No base ref at all: id immutability CANNOT be verified. Previously this branch
+  // was `if (ctx.baseRef)` with no else, so the check vanished with NO diagnostic —
+  // a check that cannot run must not report a failure, but must not silently
+  // disappear either (#614/#694, and the gate-3 half of #737).
+  if (!base) {
+    out.push(
+      diag(
+        "gate-2",
+        "warning",
+        "",
+        "id immutability not checked — no base ref (set GITHUB_BASE_REF, or fetch origin/main with full history). Id invariants are verified in CI."
+      )
+    );
+    return out;
+  }
+
+  if (!base.exact) {
+    // Degraded to the base tip (e.g. a shallow --depth=1 base fetch). The tip
+    // is not the fork point on a diverged base, so the immutability comparison
+    // below may be wrong — never let that be silent (fetch base with full
+    // history, `fetch-depth: 0`, to restore an exact merge-base).
+    out.push(
+      diag(
+        "gate-2",
+        "warning",
+        "",
+        `could not compute an exact merge-base with "${resolvedRef}" (shallow base?) — comparing id immutability against the base TIP instead of the fork point; results may be inaccurate. Fetch the base with full history (fetch-depth: 0).`
+      )
+    );
+  }
+
+  for (const { kind, id, file } of all) {
+    const baseText = gitShow(ctx.root, base.ref, file);
+    if (baseText === null) continue; // file is new at head — nothing to compare
+    const baseId = idFrom(baseText);
+    if (baseId !== undefined && baseId !== id) {
+      out.push(
+        diag(
+          "gate-2",
+          "error",
+          file,
+          `${kind} id changed from "${baseId}" to "${id}" — ids are immutable (spec §4.7)`
+        )
+      );
     }
   }
 

--- a/packages/content-lint/src/checks/gate3-slots.ts
+++ b/packages/content-lint/src/checks/gate3-slots.ts
@@ -129,7 +129,7 @@ export function gate3Check(model: RepoModel, ctx: LintContext): Diagnostic[] {
           // learner progress (#737).
           `slots.lock.json violates the slot invariant — surviving lessons must keep their assigned slot, retired slots are never reused, and \`next\` only grows. ` +
             `Fix the lock BY HAND to preserve every slot already assigned in the base ref (diff it: \`git show <base>:${file}\`). ` +
-            `DANGER: do NOT run any regenerate-from-scratch command on a deployed course — it renumbers slots and re-points 38+ learners' completed-lesson bitmaps. Regeneration is ONLY for a brand-new course that has never been deployed. ` +
+            `DANGER: do NOT run any regenerate-from-scratch command on a deployed course — it renumbers slots and re-points every already-enrolled learner's completed-lesson bitmap. Regeneration is ONLY for a brand-new course that has never been deployed. ` +
             `Expected ${JSON.stringify(expected)}`
         )
       );


### PR DESCRIPTION
Follow-ups from `claude-review` findings on #742 and #743 that I merged past. Two of the three are the bot's; the third is its non-blocking doc note.

## 1. gate-3's DANGER string cited a fabricated count (bot flagged this as **blocking** on #742)

The message hardcoded *"re-points 38+ learners' completed-lesson bitmaps"* but fires from the generic per-course loop in `gate3Check` — so a brand-new course with zero enrollments is told 38+ learners are at risk. There is no per-course enrollment data plumbed into that string.

The number is independently wrong for production: `enrollments` holds **7 rows across all six courses** (1 on `course-building-first-program`). The 38 is the devnet on-chain count from the reset wave.

This matters more than a typo because the entire purpose of #742 was to make that warning trustworthy enough that a human or agent doesn't reach for a destructive regenerate. A reader who notices the count is obviously canned discounts the DANGER note along with it. Now phrased without a number — the invariant argument never needed one.

## 2. gate-2 skips silently with no base ref (bot's non-blocking note, same class as #737)

`gate2-ids.ts` had `if (ctx.baseRef) { … }` with no `else`. With no base ref the id-immutability comparison vanished — **no error, no warning, nothing** — so a bare local run looked clean whether or not the check had actually run. After #742 the two gates disagreed: gate-3 warns and falls back to `origin/main`, gate-2 stayed silent.

Now shares gate-3's `resolveLocalBase` fallback and emits `id immutability not checked — no base ref` when it genuinely cannot run. Same principle as #614/#694: a check that cannot run must not report a failure, and must not disappear either.

CI is unchanged — `ctx.baseRef ?? resolveLocalBase(...)` short-circuits whenever GitHub supplies `github.base_ref`.

## 3. Missing route-table row (#743)

`GET /api/admin/capstone-funnel` wasn't added to the Admin table in `apps/web/src/app/api/CLAUDE.md`.

## Verification

`content-lint` **87 passed** (was 85). Both new gate-2 tests were confirmed to **fail against the previous implementation** — stashed the fix, re-ran, watched exactly those two go red, restored. `tsc --noEmit` exit 0.