### PR TITLE
fix(content-lint): fail closed on explicit-but-unresolvable base ref (rebase of #745 over #746)

### DIFF
--- a/packages/content-lint/src/__tests__/gate2.test.ts
+++ b/packages/content-lint/src/__tests__/gate2.test.ts
@@ -106,6 +106,31 @@ describe("gate 2 — ids", () => {
     ).toBe(false);
   });
 
+  it("fails CLOSED when an explicit base ref is set but unresolvable — #737 (no fail-open)", async () => {
+    // LINT_BASE_REF points at a ref that was never fetched. Id immutability cannot
+    // be checked; a silent skip would fail OPEN. It must ERROR.
+    const root = makeTempRepo({
+      "courses/a/course.yaml": course("course-x"),
+    });
+    const git = (...args: string[]) => execFileSync("git", args, { cwd: root });
+    git("init", "-q");
+    git("config", "user.email", "t@t.t");
+    git("config", "user.name", "t");
+    git("add", "-A");
+    git("commit", "-qm", "c1");
+    git("branch", "-M", "main");
+
+    const r = await runLint(root, { baseRef: "origin/does-not-exist" });
+    expect(
+      r.diagnostics.some(
+        (d) =>
+          d.gate === "gate-2" &&
+          d.severity === "error" &&
+          /misconfiguration/i.test(d.message)
+      )
+    ).toBe(true);
+  });
+
   it("emits a warning (never silent) when no exact merge-base exists", async () => {
     // An orphan base branch shares NO history with HEAD, so `git merge-base`
     // fails and the check degrades to the base tip — which must be surfaced.

--- a/packages/content-lint/src/__tests__/gate3.test.ts
+++ b/packages/content-lint/src/__tests__/gate3.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { execFileSync } from "node:child_process";
-import { writeFileSync } from "node:fs";
+import { writeFileSync, unlinkSync } from "node:fs";
 import { join } from "node:path";
 import { runLint } from "../lint";
 import "../checks/gate1-schema";
@@ -159,6 +159,53 @@ describe("gate 3 — slots", () => {
           /missing slots\.lock\.json/i.test(d.message)
       )
     ).toBe(true);
+  });
+
+  it("fails CLOSED when an explicit base ref is set but unresolvable — #737 (no fail-open)", async () => {
+    // CI sets LINT_BASE_REF but the ref was never fetched (e.g. a shallow/no fetch).
+    // Slot immutability cannot be checked, and a skip here would fail OPEN, silently
+    // disabling the hard gate. It must ERROR, not warn.
+    const { root } = gitRepo(correctLock);
+    // Renumber a slot to prove the gate would otherwise have work to do.
+    writeFileSync(
+      join(root, "courses/x/slots.lock.json"),
+      JSON.stringify({
+        version: 1,
+        slots: { "lesson-a": 9, "lesson-b": 1 },
+        retired: [],
+        next: 10,
+      }),
+      "utf8"
+    );
+    const r = await runLint(root, { baseRef: "origin/does-not-exist" });
+    expect(
+      r.diagnostics.some(
+        (d) =>
+          d.gate === "gate-3" &&
+          d.severity === "error" &&
+          /misconfiguration/i.test(d.message)
+      )
+    ).toBe(true);
+    // Never a soft warning-skip for an explicitly-requested-but-missing base.
+    expect(
+      r.diagnostics.some((d) => d.gate === "gate-3" && d.severity === "warning")
+    ).toBe(false);
+  });
+
+  it("tells you to RESTORE a deleted deployed lock, never regenerate it — #737", async () => {
+    // Base (main) has the lock; the working tree deletes it. This is an
+    // accidentally-deleted deployed course, not a new one.
+    const { root } = gitRepo(correctLock);
+    unlinkSync(join(root, "courses/x/slots.lock.json"));
+    const r = await runLint(root, { baseRef: "main" });
+    const msg = r.diagnostics.find(
+      (d) => d.gate === "gate-3" && d.severity === "error"
+    )?.message;
+    expect(msg).toBeDefined();
+    expect(msg).toMatch(/deleted/i);
+    expect(msg).toMatch(/restore/i);
+    // Must NOT suggest generating a fresh lock for a course that was deployed.
+    expect(msg).not.toMatch(/generated from its lesson order/i);
   });
 
   it("resolves origin/main locally so a correct lock passes with no explicit base ref", async () => {

--- a/packages/content-lint/src/__tests__/gate3.test.ts
+++ b/packages/content-lint/src/__tests__/gate3.test.ts
@@ -117,6 +117,11 @@ describe("gate 3 — slots", () => {
     expect(msg).toMatch(/DANGER/);
     expect(msg).toMatch(/invariant/i);
     expect(msg).toMatch(/by hand/i);
+    // The DANGER note states the generic truth, not a fabricated enrollment count —
+    // it fires for every mismatching course, including a zero-enrollment new one.
+    // (Digits still legitimately appear in the trailing Expected-lock JSON.)
+    expect(msg).toMatch(/every already-enrolled learner/i);
+    expect(msg).not.toMatch(/\d+\+?\s*(?:live\s+)?learner/i); // no hardcoded count e.g. "38+ learners"
   });
 
   it("skips (warning, never error) when no base ref is resolvable — #737", async () => {

--- a/packages/content-lint/src/checks/gate2-ids.ts
+++ b/packages/content-lint/src/checks/gate2-ids.ts
@@ -77,19 +77,32 @@ export function gate2Check(model: RepoModel, ctx: LintContext): Diagnostic[] {
   const resolvedRef = ctx.baseRef ?? resolveLocalBase(ctx.root);
   const base = resolvedRef ? mergeBase(ctx.root, resolvedRef) : null;
 
-  // No base ref at all: id immutability CANNOT be verified. Previously this branch
-  // was `if (ctx.baseRef)` with no else, so the check vanished with NO diagnostic —
-  // a check that cannot run must not report a failure, but must not silently
-  // disappear either (#614/#694, and the gate-3 half of #737).
   if (!base) {
-    out.push(
-      diag(
-        "gate-2",
-        "warning",
-        "",
-        "id immutability not checked — no base ref (set GITHUB_BASE_REF, or fetch origin/main with full history). Id invariants are verified in CI."
-      )
-    );
+    if (ctx.baseRef) {
+      // A base ref was EXPLICITLY requested (CI sets LINT_BASE_REF) but does not
+      // resolve — never fetched, or the ref name is wrong. Fail CLOSED: warning-and-
+      // skip here would silently disable the id-immutability gate on a green run.
+      out.push(
+        diag(
+          "gate-2",
+          "error",
+          "",
+          `CI misconfiguration: told to diff id immutability against "${ctx.baseRef}" but it is not resolvable — fetch it (fetch-depth: 0) or fix LINT_BASE_REF. Id immutability was NOT verified.`
+        )
+      );
+    } else {
+      // No base ref at all (bare local, no origin remote): there is genuinely
+      // nothing to diff against. Say the check was skipped rather than fabricating
+      // a verdict — but never vanish silently (#614/#694).
+      out.push(
+        diag(
+          "gate-2",
+          "warning",
+          "",
+          "id immutability not checked — no base ref (set GITHUB_BASE_REF, or fetch origin/main with full history). Id invariants are verified in CI."
+        )
+      );
+    }
     return out;
   }
 

--- a/packages/content-lint/src/checks/gate3-slots.ts
+++ b/packages/content-lint/src/checks/gate3-slots.ts
@@ -33,17 +33,34 @@ function baseLock(
   return parsed.success ? parsed.data : null;
 }
 
-/** Emitted once when no base ref is resolvable — the check is skipped, not failed. */
-function missingLockDiag(course: CourseEntry): Diagnostic {
+/**
+ * Diagnostic for a course whose lock is missing or unparseable. Uses the base ref
+ * (when one is resolved) to tell a brand-new course — safe to generate a fresh
+ * lock — apart from an accidentally-deleted DEPLOYED lock, where the only safe
+ * remedy is to restore the base copy, never regenerate (that renumbers live slots).
+ */
+function missingLockDiag(
+  course: CourseEntry,
+  ctx: LintContext,
+  baseRef: string | null
+): Diagnostic {
   const file = course.slotsPath ?? `${course.dir}/slots.lock.json`;
-  // A brand-new course with no lock file yet is the ONLY safe place to generate a
-  // fresh 0-N assignment. A present-but-unparseable lock is different: the course
-  // may already be deployed, so we flag it for a human instead of inviting a
-  // from-scratch regeneration that would renumber live slots.
-  const message =
-    course.slotsPath === null
-      ? "missing slots.lock.json — a new course needs one generated from its lesson order"
-      : "slots.lock.json is present but does not parse against the schema — fix it by hand; do NOT regenerate a deployed course's lock from scratch (that renumbers live slots)";
+  if (course.slotsPath !== null) {
+    // File is present but does not parse — the course may already be deployed.
+    return diag(
+      "gate-3",
+      "error",
+      file,
+      "slots.lock.json is present but does not parse against the schema — fix it by hand; do NOT regenerate a deployed course's lock from scratch (that renumbers live slots)"
+    );
+  }
+  // File is absent from the working tree. If the base ref HAS a lock here, it was a
+  // deployed course whose lock was deleted — restore it, don't generate a new one.
+  const baseHadLock =
+    baseRef !== null && gitShow(ctx.root, baseRef, file) !== null;
+  const message = baseHadLock
+    ? `slots.lock.json was deleted for a deployed course — restore it from the base ref (\`git show <base>:${file}\`); do NOT regenerate it (that renumbers live slots)`
+    : "missing slots.lock.json — a new course needs one generated from its lesson order";
   return diag("gate-3", "error", file, message);
 }
 
@@ -53,18 +70,34 @@ export function gate3Check(model: RepoModel, ctx: LintContext): Diagnostic[] {
   // CI sets ctx.baseRef; a bare local run does not. Fall back to a remote-tracking
   // default (origin/HEAD → origin/main) so a correct lock validates locally too,
   // instead of being regenerated from scratch and reported as a false mismatch (#737).
-  const resolvedRef = ctx.baseRef ?? resolveLocalBase(ctx.root);
+  const explicitBase = ctx.baseRef;
+  const resolvedRef = explicitBase ?? resolveLocalBase(ctx.root);
 
   // Resolve the fork point ONCE (same baseRef for every course). A degrade to the
   // base tip (e.g. a shallow --depth=1 fetch) makes the slots-lock immutability
   // comparison inexact, so surface it — never silently — exactly once.
   const base = resolvedRef ? mergeBase(ctx.root, resolvedRef) : null;
 
-  // No base ref at all (no CI ref, no origin remote): slot immutability CANNOT be
-  // verified — the base state to diff against is unknown. Never regenerate a fresh
-  // 0-N lock and assert a mismatch against a correct one (#737); say the check was
-  // skipped and only catch a genuinely missing lock, which needs no base ref.
   if (!base) {
+    if (explicitBase) {
+      // A base ref was EXPLICITLY requested (CI sets LINT_BASE_REF) but it does not
+      // resolve — the base was not fetched, or the ref name is wrong. This is a hard
+      // failure, NOT a skip: silently passing here would fail OPEN and disable the
+      // slot-immutability gate. Fail CLOSED so a misconfigured workflow is caught.
+      out.push(
+        diag(
+          "gate-3",
+          "error",
+          "",
+          `CI misconfiguration: told to diff slot immutability against "${explicitBase}" but it is not resolvable — fetch it (fetch-depth: 0) or fix LINT_BASE_REF. Slot immutability was NOT verified.`
+        )
+      );
+      return out;
+    }
+    // Bare local run with no base ref at all (no CI ref, no origin remote): slot
+    // immutability CANNOT be verified — the base state is unknown. Never regenerate a
+    // fresh 0-N lock and assert a mismatch against a correct one (#737); say the check
+    // was skipped and only catch a genuinely missing lock, which needs no base ref.
     out.push(
       diag(
         "gate-3",
@@ -74,7 +107,7 @@ export function gate3Check(model: RepoModel, ctx: LintContext): Diagnostic[] {
       )
     );
     for (const course of model.courses) {
-      if (!course.slotsLock) out.push(missingLockDiag(course));
+      if (!course.slotsLock) out.push(missingLockDiag(course, ctx, null));
     }
     return out;
   }
@@ -94,7 +127,7 @@ export function gate3Check(model: RepoModel, ctx: LintContext): Diagnostic[] {
   for (const course of model.courses) {
     const file = course.slotsPath ?? `${course.dir}/slots.lock.json`;
     if (!course.slotsLock) {
-      out.push(missingLockDiag(course));
+      out.push(missingLockDiag(course, ctx, baseRef));
       continue;
     }
     const displayOrder = course.course.modules.flatMap((m) => m.lessons);


### PR DESCRIPTION
**Supersedes #745** — same work, rebased over #746. Original commits and authorship preserved; I resolved the conflict because **I caused it** by merging #746 into `gate2-ids.ts` while #745 was in flight. Force-pushing to the original branch was blocked by a permission classifier, hence a new branch rather than an update in place.

## The finding is real — verified independently

#745's MAJOR claim checks out. `summarize()` computes `ok: !diagnostics.some(d => d.severity === "error")` ([diagnostics.ts:28](packages/content-lint/src/diagnostics.ts:28)) and the CLI exits on that `ok`. So a **warning exits 0**. After #742, `LINT_BASE_REF` set-but-unresolvable produced exactly a warning → the slots/id immutability gate passed green without having run. That is a hard gate failing **open**.

Pre-#742 the same case was *silently* skipped (`if (base)` with no else), so this isn't a regression #742 introduced so much as one it made visible and left in place. Either way it has to fail closed: a gate told to diff against a ref it cannot resolve knows it didn't do its job.

**#746 propagated the hole to gate-2**, since I mirrored the warn-and-skip pattern there. So this PR is fixing something I widened a few minutes earlier.

## Conflict resolution — three distinct states, not two

The merge keeps both semantics rather than letting one win:

| state | behavior | whose |
|---|---|---|
| `ctx.baseRef` set, unresolvable | **ERROR** — "CI misconfiguration… NOT verified" (fail closed) | #745 |
| no `ctx.baseRef`, no resolvable local base | **warning** + skip (nothing to diff against) | #746 |
| no `ctx.baseRef`, `origin/main` resolvable | runs the real check | #746 |
| base resolved but inexact | warning + degrade-to-tip | pre-existing |

Applied identically to `gate2-ids.ts` and `gate3-slots.ts`.

Also carried through: gate-3's **restore-don't-regenerate** message for a *deleted* deployed lock (`missingLockDiag` now consults the base ref — if the base had a lock at that path, it says restore it via `git show <base>:<path>` instead of offering new-course generation, which would reintroduce the renumber-and-corrupt class).

#745's second commit reduces to its regression test here — #746 already removed the fabricated `38+ learners` string from the code, and this pins it with `expect(msg).not.toMatch(/\d+\+?\s*(?:live\s+)?learner/i)` so it can't come back.

## Verification

`content-lint` **90 passed** (was 87 on main). All four base-ref behaviors assert individually by name — confirmed in verbose output that both the fail-closed and the warn-on-no-ref tests pass in the same run, so the merge didn't let one semantic quietly overwrite the other:

```
gate 2 — ids > fails CLOSED when an explicit base ref is set but unresolvable — #737 (no fail-open)
gate 2 — ids > warns (never silently skips) when no base ref is resolvable
gate 2 — ids > resolves origin/main locally so immutability is still checked with no explicit base ref
gate 3 — slots > fails CLOSED when an explicit base ref is set but unresolvable — #737 (no fail-open)
gate 3 — slots > tells you to RESTORE a deleted deployed lock, never regenerate it — #737
```

`tsc --noEmit` exit 0. CI path unchanged: `ctx.baseRef ?? resolveLocalBase(...)` short-circuits whenever GitHub supplies `github.base_ref`.
