### PR TITLE
feat(content-lint): gate-4a — verify achievement award refs resolve to earnable content (#627)

### DIFF
--- a/packages/content-lint/src/__tests__/gate4a.test.ts
+++ b/packages/content-lint/src/__tests__/gate4a.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect } from "vitest";
+import { runLint } from "../lint";
+import "../checks/gate1-schema";
+import "../checks/gate4a-award-refs";
+import { makeTempRepo } from "./helpers";
+
+const course = (id: string) => `id: ${id}
+slug: ${id.replace("course-", "")}
+title: ${id}
+difficulty: beginner
+duration: 1
+xpPerLesson: 10
+xpReward: 100
+modules: [{ key: m, title: M, lessons: [lesson-a] }]
+`;
+
+const path = (id: string, courses: string[]) => `id: ${id}
+slug: ${id.replace("path-", "")}
+title: ${id}
+difficulty: beginner
+courses: [${courses.join(", ")}]
+`;
+
+/** A schema-valid empty path — allowed only as an explicit draft. */
+const draftEmptyPath = (id: string) => `id: ${id}
+slug: ${id.replace("path-", "")}
+title: ${id}
+difficulty: beginner
+draft: true
+`;
+
+const achievement = (id: string, award: string) => `id: ${id}
+name: ${id}
+category: progress
+xpReward: 50
+award: ${award}
+`;
+
+const g4a = (
+  r: Awaited<ReturnType<typeof runLint>>
+): { severity: string; message: string }[] =>
+  r.diagnostics.filter((d) => d.gate === "gate-4a");
+
+describe("gate 4a — achievement award refs", () => {
+  it("passes when course-completed names an existing course", async () => {
+    const root = makeTempRepo({
+      "courses/x/course.yaml": course("course-x"),
+      "achievements/a.yaml": achievement(
+        "achievement-a",
+        "{ kind: course-completed, course: course-x }"
+      ),
+    });
+    expect(g4a(await runLint(root))).toEqual([]);
+  });
+
+  it("errors when course-completed names a missing course", async () => {
+    const root = makeTempRepo({
+      "achievements/a.yaml": achievement(
+        "achievement-a",
+        "{ kind: course-completed, course: course-ghost }"
+      ),
+    });
+    const d = g4a(await runLint(root));
+    expect(
+      d.some((x) => x.severity === "error" && /course-ghost/.test(x.message))
+    ).toBe(true);
+  });
+
+  it("errors when lessons-completed-in-course names a missing course", async () => {
+    const root = makeTempRepo({
+      "achievements/a.yaml": achievement(
+        "achievement-a",
+        "{ kind: lessons-completed-in-course, course: course-ghost, gte: 3 }"
+      ),
+    });
+    const d = g4a(await runLint(root));
+    expect(
+      d.some((x) => x.severity === "error" && /course-ghost/.test(x.message))
+    ).toBe(true);
+  });
+
+  it("passes when path-completed names an existing non-empty path", async () => {
+    const root = makeTempRepo({
+      "courses/x/course.yaml": course("course-x"),
+      "paths/p.yaml": path("path-p", ["course-x"]),
+      "achievements/a.yaml": achievement(
+        "achievement-a",
+        "{ kind: path-completed, path: path-p }"
+      ),
+    });
+    expect(g4a(await runLint(root))).toEqual([]);
+  });
+
+  it("errors when path-completed names a missing path", async () => {
+    const root = makeTempRepo({
+      "achievements/a.yaml": achievement(
+        "achievement-a",
+        "{ kind: path-completed, path: path-ghost }"
+      ),
+    });
+    const d = g4a(await runLint(root));
+    expect(
+      d.some((x) => x.severity === "error" && /path-ghost/.test(x.message))
+    ).toBe(true);
+  });
+
+  it("errors when path-completed names an existing but EMPTY path — the #559 unearnable case", async () => {
+    // A drafted / emptied path is schema-valid but buildUserState never completes
+    // it (courseIds.length > 0 is required), so the award can never fire.
+    const root = makeTempRepo({
+      "paths/p.yaml": draftEmptyPath("path-empty"),
+      "achievements/a.yaml": achievement(
+        "achievement-a",
+        "{ kind: path-completed, path: path-empty }"
+      ),
+    });
+    const d = g4a(await runLint(root));
+    expect(
+      d.some(
+        (x) =>
+          x.severity === "error" &&
+          /path-empty/.test(x.message) &&
+          /no courses|never be unlocked/.test(x.message)
+      )
+    ).toBe(true);
+  });
+
+  it("ignores award kinds that reference no content id", async () => {
+    const root = makeTempRepo({
+      "achievements/lc.yaml": achievement(
+        "achievement-lc",
+        "{ kind: lessons-completed, gte: 5 }"
+      ),
+      "achievements/st.yaml": achievement(
+        "achievement-st",
+        "{ kind: streak, days: 7 }"
+      ),
+      "achievements/un.yaml": achievement(
+        "achievement-un",
+        "{ kind: user-number, lte: 100 }"
+      ),
+      "achievements/mn.yaml": achievement("achievement-mn", "{ kind: manual }"),
+    });
+    expect(g4a(await runLint(root))).toEqual([]);
+  });
+});

--- a/packages/content-lint/src/checks/gate4a-award-refs.ts
+++ b/packages/content-lint/src/checks/gate4a-award-refs.ts
@@ -69,6 +69,20 @@ export function gate4aCheck(model: RepoModel): Diagnostic[] {
         }
         break;
       }
+      // Non-ref kinds: nothing to resolve. Enumerated explicitly (not a bare
+      // fall-through) so a NEW award kind added to the schema union fails this
+      // build via the `never` default — a future ref-bearing kind must not be
+      // silently skipped by this gate (fail-open class, #749 review).
+      case "lessons-completed":
+      case "streak":
+      case "user-number":
+      case "community-stat":
+      case "manual":
+        break;
+      default: {
+        const _exhaustive: never = award;
+        void _exhaustive;
+      }
     }
   }
 

--- a/packages/content-lint/src/checks/gate4a-award-refs.ts
+++ b/packages/content-lint/src/checks/gate4a-award-refs.ts
@@ -1,0 +1,78 @@
+import { registerCheck } from "../lint";
+import { type RepoModel } from "../model";
+import { diag, type Diagnostic } from "../diagnostics";
+
+/**
+ * Gate 4a — achievement award refs must resolve to earnable content.
+ *
+ * An achievement's `award` rule is its ONLY unlock path. When the rule names a
+ * course or path id, that id must resolve against the bundle to something a
+ * learner can actually complete — otherwise the achievement is silently minted
+ * but permanently un-unlockable, and nothing downstream catches it (the doc is
+ * schema-valid, the ref is just dead). This mirrors the runtime consumer,
+ * `buildUserState` in lib/gamification/achievements.ts:
+ *   - `course-completed` / `lessons-completed-in-course` credit a course only if
+ *     it exists (completedCourseIds is keyed by real course ids).
+ *   - `path-completed` credits a path only when `path.courseIds.length > 0`
+ *     (achievements.ts:164-171) — an empty path is never marked complete, so an
+ *     award pointing at one can never fire. Retiring the last course from a path
+ *     is exactly how #559 nearly shipped an unearnable achievement.
+ *
+ * Courses cannot be empty (course schema requires modules.min(1) / lessons.min(1)),
+ * so course refs only need existence. Only paths carry the empty-but-present case.
+ *
+ * The remaining award kinds — lessons-completed, streak, user-number,
+ * community-stat, manual — reference no content id and need no resolution here.
+ */
+export function gate4aCheck(model: RepoModel): Diagnostic[] {
+  const out: Diagnostic[] = [];
+  const courseIds = new Set(model.courses.map((c) => c.id));
+  const pathsById = new Map(model.paths.map((p) => [p.path.id, p.path]));
+
+  for (const { file, achievement } of model.achievements) {
+    const award = achievement.award;
+    switch (award.kind) {
+      case "course-completed":
+      case "lessons-completed-in-course": {
+        if (!courseIds.has(award.course)) {
+          out.push(
+            diag(
+              "gate-4a",
+              "error",
+              file,
+              `achievement "${achievement.id}" award (${award.kind}) references missing course "${award.course}" — it can never be unlocked`
+            )
+          );
+        }
+        break;
+      }
+      case "path-completed": {
+        const path = pathsById.get(award.path);
+        if (!path) {
+          out.push(
+            diag(
+              "gate-4a",
+              "error",
+              file,
+              `achievement "${achievement.id}" award (path-completed) references missing path "${award.path}" — it can never be unlocked`
+            )
+          );
+        } else if (path.courses.length === 0) {
+          out.push(
+            diag(
+              "gate-4a",
+              "error",
+              file,
+              `achievement "${achievement.id}" award (path-completed) references path "${award.path}", which has no courses — buildUserState only completes a path when courseIds.length > 0, so this achievement can never be unlocked`
+            )
+          );
+        }
+        break;
+      }
+    }
+  }
+
+  return out;
+}
+
+registerCheck(gate4aCheck);

--- a/packages/content-lint/src/index.ts
+++ b/packages/content-lint/src/index.ts
@@ -6,6 +6,7 @@ export * from "./checks/gate1-schema";
 export * from "./checks/gate2-ids";
 export * from "./checks/gate3-slots";
 export * from "./checks/gate4-refs";
+export * from "./checks/gate4a-award-refs";
 export * from "./checks/gate5-orphans";
 export * from "./checks/gate5a-xp";
 export * from "./checks/gate6-executor";


### PR DESCRIPTION
Implements the **first** half of #627: content-lint verification that achievement `award` refs resolve to earnable content. The second half (the dead `path draft:true` flag ruling) is deliberately left open — see below.

## Problem
An achievement's `award` rule is its **only** unlock path. If the rule names a course/path id that doesn't resolve — or a `path-completed` rule points at an **empty** path — the achievement is minted but can **never** be unlocked, and nothing downstream catches it: the doc is schema-valid, the ref is just dead. This is the class that nearly shipped `full-stack-solana` permanently unearnable in #559 (courses-academy#7) when `path-solana-core` was emptied; only a manual catch saved it.

## Gate 4a (new, `checks/gate4a-award-refs.ts`, error tier)
Mirrors the runtime consumer `buildUserState` (`apps/web/src/lib/gamification/achievements.ts`) exactly:

| award kind | check |
|---|---|
| `course-completed`, `lessons-completed-in-course` | course must exist (courses always have ≥1 lesson per schema `modules.min(1)`/`lessons.min(1)`, so existence is sufficient — `completedCourseIds` is keyed by real course ids) |
| `path-completed` | path must exist **and be non-empty** — `buildUserState` only adds a path to `completedPathIds` when `courseIds.length > 0` (achievements.ts:164-171), so an award on an empty path can never fire |
| `lessons-completed`, `streak`, `user-number`, `community-stat`, `manual` | reference no content id — ignored |

Error tier because a dangling ref is authoring breakage, not style. Registered via the existing `registerCheck` convention and exported from `index.ts`.

## Tests (`__tests__/gate4a.test.ts`, both directions)
- pass: `course-completed` / `lessons-completed-in-course` / `path-completed` naming existing (and non-empty) content
- error: missing course; missing path
- error: **existing but empty path** — the #559 unearnable case (drafted/emptied path)
- pass: the five non-ref award kinds are ignored

`pnpm --filter @superteam-lms/content-lint test` → 94 passed (gate4a: 7). `content-schema` → 170. `typecheck` clean.

## courses-academy blast check — GREEN
Ran the linter (this branch) against `courses-academy@main`, bare and CI-simulated — **0 gate-4a diagnostics** both ways (gate-4a is git-independent, so the two are identical). The gate is **not** vacuously green: it actively resolves 4 real refs and all pass —

| achievement | award | resolves to | ok |
|---|---|---|---|
| anchor-expert | course-completed | course-anchor-framework | ✓ |
| course-completer | course-completed | course-solana-fundamentals | ✓ |
| rust-rookie | lessons-completed-in-course | course-rust-for-solana | ✓ |
| full-stack-solana | path-completed | path-zero-to-deployed (4 courses) | ✓ |

Notably `path-solana-core` in that repo is `draft: true, courses: []` (the emptied path from #559). `full-stack-solana` was retargeted off it to the non-empty `path-zero-to-deployed`, so the gate is green — had that retarget not happened, gate-4a would have flagged it. So the gate reproduces the #627 protection on the exact content that motivated it.

## Out of scope (stays open on #627)
The second half — **ruling on the dead `path draft:true` flag** (compiler carries it into the bundle but no runtime reads it; a drafted-but-populated path leaks its courses into All Courses/search) — is a design decision entangled with #711 / D-1 (owner) and is intentionally **not** addressed here. #627 should remain open for it.

Related: #596 (skills-tag gate) is the same registry-resolution family.

**Do not merge** — SENSITIVE (ci/lint semantics). Needs adversarial + gate.
