### PR TITLE
fix(lessons): derive on-chain bitmap index from slot lock, not array position (#741)

### DIFF
--- a/apps/web/src/app/api/admin/resync/route.ts
+++ b/apps/web/src/app/api/admin/resync/route.ts
@@ -18,7 +18,8 @@ import {
   fetchEnrollment,
   fetchAchievementReceiptData,
 } from "@/lib/solana/academy-reads";
-import { decodeLessonBitmap } from "@/lib/solana/bitmap";
+import { isLessonComplete } from "@/lib/solana/bitmap";
+import { slotToLiveLessonId } from "@/lib/courses/lesson-slot";
 import { getAllCourses, getAllAchievements } from "@/lib/content/queries";
 import { calculateLevel } from "@/lib/gamification/xp";
 
@@ -149,32 +150,28 @@ export async function POST(req: NextRequest) {
       );
       results.enrollments++;
 
-      // Decode lesson bitmap → sync individual lesson progress. Display order is
-      // the array position now (spec §10.1), so the flattened order IS the
-      // on-chain bitmap order — matching findLessonIndex.
-      const allLessons = (course.modules ?? []).flatMap((m) => m.lessons ?? []);
-
-      const lessonCount = enrollment.lesson_count
-        ? Number(enrollment.lesson_count)
-        : allLessons.length;
-
-      if (enrollment.lesson_flags && lessonCount > 0) {
-        const bitmap = decodeLessonBitmap(enrollment.lesson_flags, lessonCount);
-
-        for (let i = 0; i < bitmap.length && i < allLessons.length; i++) {
-          const lesson = allLessons[i];
-          if (bitmap[i] && lesson) {
+      // Reconstruct lesson progress from the on-chain bitmap by SLOT, not array
+      // position (#741). A bit at index N means "slot N is complete"; slot N maps
+      // to a lessonId via the committed slot lock, which is stable across
+      // restructures. Iterating array position instead would mis-map every live
+      // lesson once a course is sparse (retire/insert), and would resurrect a
+      // retired slot's stale bit onto whichever lesson now sits at that array
+      // index. A retired slot has no entry in the live map, so its bit is ignored.
+      if (enrollment.lesson_flags) {
+        for (const [slot, lessonId] of slotToLiveLessonId(course._id)) {
+          if (isLessonComplete(enrollment.lesson_flags, slot)) {
             await supabase.from("user_progress").upsert(
               {
                 user_id: profile.id,
                 course_id: course._id,
-                lesson_id: lesson._id,
+                lesson_id: lessonId,
                 completed: true,
                 completed_at: enrollment.enrolled_at
                   ? new Date(
                       Number(enrollment.enrolled_at) * 1000
                     ).toISOString()
                   : new Date().toISOString(),
+                lesson_index: slot,
               },
               { onConflict: "user_id,lesson_id", ignoreDuplicates: true }
             );

--- a/apps/web/src/app/api/lessons/complete/__tests__/deny-reasons.test.ts
+++ b/apps/web/src/app/api/lessons/complete/__tests__/deny-reasons.test.ts
@@ -88,7 +88,7 @@ vi.mock("@/lib/solana/academy-reads", () => ({
   fetchCourse: vi.fn(),
 }));
 vi.mock("@/lib/solana/bitmap", () => ({ isLessonComplete: vi.fn() }));
-vi.mock("@/lib/courses/lesson-index", () => ({ findLessonIndex: () => 0 }));
+vi.mock("@/lib/courses/lesson-slot", () => ({ getLessonSlot: () => 0 }));
 vi.mock("@/lib/logging", () => ({ logError: vi.fn() }));
 vi.mock("@/lib/content/deployments", () => ({ isCourseInMaintenance }));
 vi.mock("@/lib/platform/freeze", () => ({ isPlatformFrozen }));

--- a/apps/web/src/app/api/lessons/complete/__tests__/gate.test.ts
+++ b/apps/web/src/app/api/lessons/complete/__tests__/gate.test.ts
@@ -77,7 +77,7 @@ vi.mock("@/lib/solana/academy-reads", () => ({
   fetchCourse: vi.fn(),
 }));
 vi.mock("@/lib/solana/bitmap", () => ({ isLessonComplete: vi.fn() }));
-vi.mock("@/lib/courses/lesson-index", () => ({ findLessonIndex: () => 0 }));
+vi.mock("@/lib/courses/lesson-slot", () => ({ getLessonSlot: () => 0 }));
 vi.mock("@/lib/logging", () => ({ logError: vi.fn() }));
 vi.mock("@/lib/content/deployments", () => ({ isCourseInMaintenance }));
 vi.mock("@/lib/platform/freeze", () => ({ isPlatformFrozen }));

--- a/apps/web/src/app/api/lessons/complete/__tests__/grading-dedup.test.ts
+++ b/apps/web/src/app/api/lessons/complete/__tests__/grading-dedup.test.ts
@@ -87,7 +87,7 @@ vi.mock("@/lib/solana/academy-program", () => ({
 }));
 vi.mock("@/lib/solana/academy-reads", () => ({ fetchEnrollment, fetchCourse }));
 vi.mock("@/lib/solana/bitmap", () => ({ isLessonComplete }));
-vi.mock("@/lib/courses/lesson-index", () => ({ findLessonIndex: () => 0 }));
+vi.mock("@/lib/courses/lesson-slot", () => ({ getLessonSlot: () => 0 }));
 vi.mock("@/lib/logging", () => ({ logError: vi.fn() }));
 vi.mock("@/lib/content/deployments", () => ({ isCourseInMaintenance }));
 vi.mock("@/lib/platform/freeze", () => ({ isPlatformFrozen }));

--- a/apps/web/src/app/api/lessons/complete/__tests__/inflight-guard.test.ts
+++ b/apps/web/src/app/api/lessons/complete/__tests__/inflight-guard.test.ts
@@ -78,7 +78,7 @@ vi.mock("@/lib/solana/academy-program", () => ({
 }));
 vi.mock("@/lib/solana/academy-reads", () => ({ fetchEnrollment, fetchCourse }));
 vi.mock("@/lib/solana/bitmap", () => ({ isLessonComplete }));
-vi.mock("@/lib/courses/lesson-index", () => ({ findLessonIndex: () => 0 }));
+vi.mock("@/lib/courses/lesson-slot", () => ({ getLessonSlot: () => 0 }));
 vi.mock("@/lib/logging", () => ({ logError: vi.fn() }));
 vi.mock("@/lib/content/deployments", () => ({ isCourseInMaintenance }));
 vi.mock("@/lib/platform/freeze", () => ({ isPlatformFrozen }));

--- a/apps/web/src/app/api/lessons/complete/__tests__/review-capture.test.ts
+++ b/apps/web/src/app/api/lessons/complete/__tests__/review-capture.test.ts
@@ -75,7 +75,7 @@ vi.mock("@/lib/solana/academy-reads", () => ({
   fetchCourse: vi.fn(),
 }));
 vi.mock("@/lib/solana/bitmap", () => ({ isLessonComplete: vi.fn() }));
-vi.mock("@/lib/courses/lesson-index", () => ({ findLessonIndex: () => 0 }));
+vi.mock("@/lib/courses/lesson-slot", () => ({ getLessonSlot: () => 0 }));
 vi.mock("@/lib/logging", () => ({ logError: vi.fn() }));
 vi.mock("@/lib/content/deployments", () => ({ isCourseInMaintenance }));
 vi.mock("@/lib/platform/freeze", () => ({ isPlatformFrozen }));

--- a/apps/web/src/app/api/lessons/complete/__tests__/slot-aware.test.ts
+++ b/apps/web/src/app/api/lessons/complete/__tests__/slot-aware.test.ts
@@ -1,0 +1,211 @@
+/* eslint-disable import/order -- vi.mock calls must precede importing the route. */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("server-only", () => ({}));
+
+// Slot-aware completion path (#741). These tests drive the route through to the
+// on-chain submit with a C3-shaped sparse course: the target lesson's SLOT (15,
+// the capstone) differs from what its array position would be, and slot 14 is a
+// retired lesson whose bit may still be set on an old enrollment. They assert
+// the SLOT — not array position — is what reaches the bitmap read, the count
+// guard, and completeLesson. The bitmap helpers are REAL (not mocked) so the
+// slot arithmetic is exercised end-to-end.
+
+const {
+  getUser,
+  singleProfile,
+  upsertProgress,
+  getLessonByIdForGrading,
+  isOnChainProgramLive,
+  isRateLimited,
+  isCourseInMaintenance,
+  isPlatformFrozen,
+  completeLesson,
+  fetchEnrollment,
+  fetchCourse,
+  getLessonSlot,
+} = vi.hoisted(() => ({
+  getUser: vi.fn<() => Promise<unknown>>(),
+  singleProfile: vi.fn<() => Promise<unknown>>(),
+  upsertProgress: vi.fn<(row?: unknown) => Promise<unknown>>(),
+  getLessonByIdForGrading: vi.fn(),
+  isOnChainProgramLive: vi.fn<() => Promise<boolean>>(),
+  isRateLimited: vi.fn<() => Promise<boolean>>(),
+  isCourseInMaintenance: vi.fn<() => Promise<boolean>>(),
+  isPlatformFrozen: vi.fn<() => Promise<boolean>>(),
+  completeLesson: vi.fn<() => Promise<string>>(),
+  fetchEnrollment: vi.fn<() => Promise<unknown>>(),
+  fetchCourse: vi.fn<() => Promise<unknown>>(),
+  getLessonSlot: vi.fn<() => number>(),
+}));
+
+vi.mock("@/lib/rate-limit", () => ({
+  isRateLimited: () => isRateLimited(),
+  releaseRateLimit: () => Promise.resolve(),
+  getClientIp: () => "203.0.113.7",
+}));
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: async () => ({ auth: { getUser } }),
+}));
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: () => ({
+    from: () => ({
+      select: () => ({ eq: () => ({ single: singleProfile }) }),
+      upsert: upsertProgress,
+    }),
+  }),
+}));
+vi.mock("@/lib/content/queries", () => ({ getLessonByIdForGrading }));
+vi.mock("@/lib/grading/graders", () => ({ GRADERS: {} }));
+vi.mock("@/lib/review/schedule-review", () => ({
+  captureReviewFailure: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("@/lib/ai/check-seal", () => ({ openAttestation: () => true }));
+vi.mock("@/lib/solana/academy-program", () => ({
+  isOnChainProgramLive,
+  completeLesson,
+  getConnection: vi.fn(),
+  getProgramId: vi.fn(),
+}));
+vi.mock("@/lib/solana/academy-reads", () => ({ fetchEnrollment, fetchCourse }));
+// NOTE: bitmap.ts is intentionally NOT mocked — isLessonComplete runs for real.
+vi.mock("@/lib/courses/lesson-slot", () => ({ getLessonSlot }));
+vi.mock("@/lib/logging", () => ({ logError: vi.fn() }));
+vi.mock("@/lib/content/deployments", () => ({ isCourseInMaintenance }));
+vi.mock("@/lib/platform/freeze", () => ({ isPlatformFrozen }));
+
+import { POST } from "../route";
+
+// Prose-only lesson sails through grading, isolating the slot/bitmap path.
+const PROSE_LESSON = { blocks: [{ _type: "prose", key: "p1", src: "hi" }] };
+const CAPSTONE_SLOT = 15;
+const RETIRED_SLOT = 14;
+
+// Build a 4-word [u64;4] mask (as bigints) with the given bits set.
+function mask(...bits: number[]): bigint[] {
+  const words: [bigint, bigint, bigint, bigint] = [0n, 0n, 0n, 0n];
+  for (const b of bits) {
+    const w = Math.floor(b / 64) as 0 | 1 | 2 | 3;
+    words[w] |= 1n << BigInt(b % 64);
+  }
+  return words;
+}
+
+// Live mask for the C3 course: slots 0..13 and 15 live, 14 retired.
+const LIVE_MASK = mask(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 15);
+
+function req(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/lessons/complete", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "content-type": "application/json" },
+  });
+}
+const call = () =>
+  POST(req({ lessonId: "lesson-capstone", courseId: "course-c3", proofs: {} }));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  process.env.NEXT_PUBLIC_SUPABASE_URL = "http://localhost";
+  process.env.SUPABASE_SERVICE_ROLE_KEY = "srk";
+  getUser.mockResolvedValue({ data: { user: { id: "user-1" } }, error: null });
+  singleProfile.mockResolvedValue({
+    data: { wallet_address: "11111111111111111111111111111111" },
+  });
+  upsertProgress.mockResolvedValue({ error: null });
+  getLessonByIdForGrading.mockResolvedValue(PROSE_LESSON);
+  isOnChainProgramLive.mockResolvedValue(true);
+  isCourseInMaintenance.mockResolvedValue(false);
+  isPlatformFrozen.mockResolvedValue(false);
+  isRateLimited.mockResolvedValue(false);
+  completeLesson.mockResolvedValue("sig-capstone");
+  getLessonSlot.mockReturnValue(CAPSTONE_SLOT);
+  // Default: capstone slot live in the on-chain mask; bitmap all-zero.
+  fetchCourse.mockResolvedValue({ activeLessons: LIVE_MASK });
+  fetchEnrollment.mockResolvedValue({ lesson_flags: mask() });
+});
+
+describe("slot-aware completion (#741)", () => {
+  it("sends the SLOT (15), not the array position, to completeLesson", async () => {
+    const res = await call();
+
+    expect(res.status).toBe(200);
+    expect(completeLesson).toHaveBeenCalledWith(
+      "course-c3",
+      expect.anything(),
+      CAPSTONE_SLOT
+    );
+    // And user_progress records the slot, not array order.
+    const row = upsertProgress.mock.calls.at(-1)?.[0] as
+      | { lesson_index?: number }
+      | undefined;
+    expect(row?.lesson_index).toBe(CAPSTONE_SLOT);
+  });
+
+  it("a retired slot's stale set bit never makes a live lesson read as already-complete", async () => {
+    // Old enrollment has slot 14 (retired lesson m4-interact) completed on-chain.
+    // The capstone is slot 15 — its bit is unset — so completion must proceed and
+    // fire the tx, NOT short-circuit as already-done on the neighbouring bit.
+    fetchEnrollment.mockResolvedValue({ lesson_flags: mask(RETIRED_SLOT) });
+
+    const res = await call();
+    const body = (await res.json()) as { alreadyCompleted?: boolean };
+
+    expect(res.status).toBe(200);
+    expect(body.alreadyCompleted).toBeUndefined();
+    expect(completeLesson).toHaveBeenCalledWith(
+      "course-c3",
+      expect.anything(),
+      CAPSTONE_SLOT
+    );
+  });
+
+  it("is idempotent on the SLOT bit: capstone already set → no tx, alreadyCompleted", async () => {
+    fetchEnrollment.mockResolvedValue({ lesson_flags: mask(CAPSTONE_SLOT) });
+
+    const res = await call();
+    const body = (await res.json()) as { alreadyCompleted?: boolean };
+
+    expect(res.status).toBe(200);
+    expect(body.alreadyCompleted).toBe(true);
+    expect(completeLesson).not.toHaveBeenCalled();
+  });
+
+  it("count guard is a per-slot bit test: slot not live in the mask → 409, no tx", async () => {
+    // Mask does NOT include slot 15 (admin re-sync of active_lessons pending).
+    // A count/popcount compare would let a high slot through or wrongly gate a
+    // low one; the bit test correctly refuses this un-synced slot.
+    fetchCourse.mockResolvedValue({ activeLessons: mask(0, 1, 2, 3, 4) });
+
+    const res = await call();
+
+    expect(res.status).toBe(409);
+    expect(completeLesson).not.toHaveBeenCalled();
+  });
+
+  it("a capstone at slot 15 is NOT 409'd when popcount(active) == 15 (the C3 trap)", async () => {
+    // LIVE_MASK has popcount 15 (slots 0..13 + 15) but slot 15 IS live. The old
+    // count guard (`slot >= popcount`) would 409 this valid capstone; the bit
+    // test lets it through.
+    const res = await call();
+
+    expect(res.status).toBe(200);
+    expect(completeLesson).toHaveBeenCalledWith(
+      "course-c3",
+      expect.anything(),
+      CAPSTONE_SLOT
+    );
+  });
+
+  it("fails CLOSED when the lesson has no slot — 500, never an array-index tx", async () => {
+    getLessonSlot.mockImplementation(() => {
+      throw new Error("Lesson has no slot in course (retired or unknown)");
+    });
+
+    const res = await call();
+
+    expect(res.status).toBe(500);
+    expect(completeLesson).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/api/lessons/complete/route.ts
+++ b/apps/web/src/app/api/lessons/complete/route.ts
@@ -4,7 +4,7 @@ import { PublicKey } from "@solana/web3.js";
 import { BLOCK_REGISTRY, type BlockType } from "@superteam-lms/content-schema";
 import { createClient } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin";
-import { getCourseById, getLessonByIdForGrading } from "@/lib/content/queries";
+import { getLessonByIdForGrading } from "@/lib/content/queries";
 import type { CompletionDenyReason } from "@/lib/lessons/completion-error";
 import { GRADERS, type GradedBlockType } from "@/lib/grading/graders";
 import { DENY_REASONS } from "@/lib/grading/deny-reason";
@@ -21,7 +21,7 @@ import {
 } from "@/lib/solana/academy-program";
 import { fetchEnrollment, fetchCourse } from "@/lib/solana/academy-reads";
 import { isLessonComplete } from "@/lib/solana/bitmap";
-import { findLessonIndex } from "@/lib/courses/lesson-index";
+import { getLessonSlot } from "@/lib/courses/lesson-slot";
 import { serverEnv } from "@/lib/env.server";
 import { isCourseInMaintenance } from "@/lib/content/deployments";
 import { isPlatformFrozen } from "@/lib/platform/freeze";
@@ -43,21 +43,6 @@ interface LessonCompleteRequest {
    * gate below and NOTHING else — see the gate comment for why that is safe.
    */
   replay?: boolean;
-}
-
-/**
- * Derive the 0-based lesson index within a course from content-bundle lesson order.
- * Modules and lessons are flattened in order; the index matches the on-chain bitmap position.
- */
-async function deriveLessonIndex(
-  courseId: string,
-  lessonId: string
-): Promise<number> {
-  const course = await getCourseById(courseId);
-  if (!course) throw new Error(`Course not found: ${courseId}`);
-  const index = findLessonIndex(course, lessonId);
-  if (index === -1) throw new Error(`Lesson not found in course: ${lessonId}`);
-  return index;
 }
 
 /**
@@ -445,36 +430,45 @@ export async function POST(request: NextRequest) {
         );
       }
 
-      // Derive lesson index from content-bundle lesson order
-      const lessonIndex = await deriveLessonIndex(courseId, lessonId);
+      // Resolve the lesson's permanent on-chain bitmap SLOT from the committed
+      // slot lock — NEVER its position in the flattened module array. Array
+      // position shifts whenever the course is restructured (reorder/retire/
+      // insert), so the same lessonId would map to a different bit and silently
+      // complete a different (possibly retired) lesson (#741). Fail-closed: an
+      // unslotted lesson throws → outer catch → 500 (no wrong-slot completion).
+      const lessonSlot = getLessonSlot(courseId, lessonId);
 
-      // Guard: the on-chain complete_lesson reverts when lessonIndex >=
-      // course.lesson_count. That happens when a teacher appended lessons to an
-      // already-deployed course but the Course PDA's lesson_count has not yet been
-      // raised by an admin re-sync (update_course.new_lesson_count). Detect it here
-      // and return a clear 409 instead of letting the on-chain TX throw a generic
-      // 500. fetchCourse returns the normalised `liveLessonCount`.
-      // Count-based and only correct while masks are dense (today). Once a
-      // sparse-mask course can exist, this must become a per-slot bit test
-      // against `activeLessons` instead of a count comparison.
-      const onChainLessonCount = onChainCourse?.liveLessonCount;
-      if (
-        typeof onChainLessonCount === "number" &&
-        lessonIndex >= onChainLessonCount
-      ) {
-        return NextResponse.json(
-          {
-            error:
-              "This course was recently extended and is pending an admin re-sync — try again shortly.",
-          },
-          { status: 409 }
-        );
+      // Guard: the on-chain complete_lesson reverts when the target slot is not
+      // a LIVE bit in the Course PDA's `active_lessons` mask. That happens when a
+      // teacher added a lesson (new slot) but the admin mask re-sync
+      // (update_course.new_active_lessons) hasn't landed yet. Detect it here and
+      // return a clear 409 instead of letting the on-chain TX throw a generic
+      // 500. This is a per-SLOT bit test, not a count comparison: once a mask is
+      // sparse, popcount(active_lessons) (== liveLessonCount) no longer equals
+      // the highest live slot, so a count compare would wrongly 409 valid high
+      // slots (e.g. a capstone at slot 15 when popcount is 15).
+      const activeLessons = onChainCourse?.activeLessons;
+      if (activeLessons) {
+        const word = Math.floor(lessonSlot / 64);
+        const bit = BigInt(lessonSlot % 64);
+        const slotIsLive = ((activeLessons[word] ?? 0n) & (1n << bit)) !== 0n;
+        if (!slotIsLive) {
+          return NextResponse.json(
+            {
+              error:
+                "This course was recently extended and is pending an admin re-sync — try again shortly.",
+            },
+            { status: 409 }
+          );
+        }
       }
 
-      // Idempotency: skip on-chain TX if lesson already completed in bitmap
+      // Idempotency: skip on-chain TX if this SLOT's bit is already set. Tested
+      // against the slot (not array position) so a retired lesson's stale set bit
+      // can never make a different, live lesson read as already complete (#741).
       const alreadyOnChain = isLessonComplete(
         onChainEnrollment.lesson_flags as (bigint | number)[],
-        lessonIndex
+        lessonSlot
       );
 
       if (alreadyOnChain) {
@@ -490,7 +484,11 @@ export async function POST(request: NextRequest) {
               completed: true,
               completed_at: new Date().toISOString(),
               tx_signature: null,
-              lesson_index: lessonIndex,
+              // Stores the on-chain SLOT (the true bitmap position), not array
+              // order — see getLessonSlot. Historical rows written pre-#741 may
+              // hold old array-space values; they are left as a historical record
+              // (no live-DB backfill), and every new write here is slot-space.
+              lesson_index: lessonSlot,
             },
             { onConflict: "user_id,lesson_id", ignoreDuplicates: true }
           );
@@ -567,7 +565,7 @@ export async function POST(request: NextRequest) {
       const signature = await onChainCompleteLesson(
         courseId,
         walletPubkey,
-        lessonIndex
+        lessonSlot
       );
 
       // Write directly to Supabase so progress is visible on the dashboard
@@ -583,7 +581,7 @@ export async function POST(request: NextRequest) {
             completed: true,
             completed_at: new Date().toISOString(),
             tx_signature: signature,
-            lesson_index: lessonIndex,
+            lesson_index: lessonSlot, // on-chain slot (see getLessonSlot / #741)
           },
           { onConflict: "user_id,lesson_id" }
         );

--- a/apps/web/src/lib/courses/__tests__/lesson-slot-equivalence.test.ts
+++ b/apps/web/src/lib/courses/__tests__/lesson-slot-equivalence.test.ts
@@ -1,0 +1,75 @@
+/* eslint-disable import/order -- vi.mock must precede the store/query imports. */
+import { describe, it, expect, beforeAll, vi } from "vitest";
+import type { SlotsLockT } from "@superteam-lms/content-schema";
+
+vi.mock("server-only", () => ({}));
+
+// getCourseById → getDeploymentById → a service-role Supabase read. Stub it to
+// "no deployment" so the course projection runs purely against the in-memory
+// content bundle (the deployment only supplies a track-collection address, which
+// does not affect module/lesson ORDER — the only thing this test inspects).
+vi.mock("@supabase/supabase-js", () => ({
+  createClient: () => ({
+    from: () => ({
+      select: () => ({
+        eq: () => ({
+          maybeSingle: async () => ({ data: null, error: null }),
+        }),
+      }),
+    }),
+  }),
+}));
+
+import { slotsByCourseId } from "@/lib/content/store";
+import { getCourseById } from "@/lib/content/queries";
+import { findLessonIndex } from "@/lib/courses/lesson-index";
+
+/** A course is dense when no slot is retired and the live slots are 0..n-1. */
+function isDense(lock: SlotsLockT): boolean {
+  const slots = Object.values(lock.slots).sort((a, b) => a - b);
+  return lock.retired.length === 0 && slots.every((s, i) => s === i);
+}
+
+beforeAll(() => {
+  process.env.NEXT_PUBLIC_SUPABASE_URL = "http://localhost";
+  process.env.SUPABASE_SERVICE_ROLE_KEY = "srk";
+});
+
+// The safety claim for shipping #741 BEFORE any restructure bump: for the
+// current committed bundle, the slot the new code sends on-chain equals the
+// array index the old code sent — byte-identical behaviour.
+describe("slot lock ↔ array-index equivalence (current bundle) — #741", () => {
+  it("every DENSE course has slot == findLessonIndex for every lesson", async () => {
+    let checkedLessons = 0;
+    for (const [courseId, lock] of slotsByCourseId) {
+      if (!isDense(lock)) continue;
+      const course = await getCourseById(courseId);
+      expect(
+        course,
+        `getCourseById(${courseId}) should resolve`
+      ).not.toBeNull();
+      for (const [lessonId, slot] of Object.entries(lock.slots)) {
+        expect(
+          findLessonIndex(course!, lessonId),
+          `${courseId}/${lessonId}: slot ${slot} must equal array index`
+        ).toBe(slot);
+        checkedLessons++;
+      }
+    }
+    // Guard against a vacuous pass (e.g. all courses filtered out as sparse).
+    expect(checkedLessons).toBeGreaterThan(0);
+  });
+
+  // LANDMINE BY DESIGN. This documents that the CURRENT committed bundle is
+  // entirely dense, which is exactly what makes #741 byte-identical today. When
+  // a restructure bump (e.g. #740) lands and a course becomes sparse, RELAX THIS
+  // ONE TEST — the dense⟹equivalence test above and the sparse-fixture tests in
+  // slot-aware.test.ts / lesson-slot.test.ts remain the real guarantees, and the
+  // slot-aware route is precisely what makes the now-sparse course correct.
+  it("the current bundle is entirely dense (slot-space == array-space today)", () => {
+    const sparse = [...slotsByCourseId.entries()]
+      .filter(([, lock]) => !isDense(lock))
+      .map(([id]) => id);
+    expect(sparse).toEqual([]);
+  });
+});

--- a/apps/web/src/lib/courses/__tests__/lesson-slot.test.ts
+++ b/apps/web/src/lib/courses/__tests__/lesson-slot.test.ts
@@ -1,0 +1,75 @@
+/* eslint-disable import/order -- vi.mock must precede importing the module under test. */
+import { describe, it, expect, vi } from "vitest";
+import type { SlotsLockT } from "@superteam-lms/content-schema";
+
+vi.mock("server-only", () => ({}));
+
+// The helper reads the committed slot lock via the content store. Inject a
+// synthetic lock whose slots DELIBERATELY disagree with insertion/array order —
+// a C3-shaped course where the capstone keeps slot 15 while later-authored
+// lessons sit at low slots and slot 14 is retired. Hoisted so the vi.mock
+// factory (also hoisted) can close over it.
+const { slotsByCourseId } = vi.hoisted(() => ({
+  slotsByCourseId: new Map<string, SlotsLockT>([
+    [
+      "course-c3",
+      {
+        version: 1,
+        slots: {
+          // insertion order here is NOT slot order — proves the helper reads the
+          // slot value, not the position.
+          "lesson-capstone": 15,
+          "lesson-intro": 0,
+          "lesson-moved-late": 2,
+          "lesson-mid": 10,
+        },
+        retired: [14],
+        next: 16,
+      },
+    ],
+  ]),
+}));
+
+vi.mock("@/lib/content/store", () => ({ slotsByCourseId }));
+
+import { getLessonSlot, slotToLiveLessonId } from "../lesson-slot";
+
+describe("getLessonSlot — slot lock is the on-chain bitmap index (#741)", () => {
+  it("returns the lesson's committed slot, not its array/insertion position", () => {
+    expect(getLessonSlot("course-c3", "lesson-capstone")).toBe(15);
+    expect(getLessonSlot("course-c3", "lesson-intro")).toBe(0);
+    // Authored later, appears third, but its slot is 2 — array order disagrees.
+    expect(getLessonSlot("course-c3", "lesson-moved-late")).toBe(2);
+    expect(getLessonSlot("course-c3", "lesson-mid")).toBe(10);
+  });
+
+  it("throws (fail-closed) for an unknown course — never falls back to an index", () => {
+    expect(() => getLessonSlot("course-missing", "lesson-intro")).toThrow(
+      /no slot lock/i
+    );
+  });
+
+  it("throws (fail-closed) for a lesson with no slot (retired/unknown)", () => {
+    expect(() => getLessonSlot("course-c3", "lesson-retired")).toThrow(
+      /no slot/i
+    );
+  });
+});
+
+describe("slotToLiveLessonId — reverse map for bitmap→progress sync (#741)", () => {
+  it("maps every live slot to its lessonId; retired slots are absent", () => {
+    const map = slotToLiveLessonId("course-c3");
+    expect(map.get(15)).toBe("lesson-capstone");
+    expect(map.get(0)).toBe("lesson-intro");
+    expect(map.get(2)).toBe("lesson-moved-late");
+    expect(map.get(10)).toBe("lesson-mid");
+    expect(map.size).toBe(4);
+    // Retired slot 14 has no live lesson → correctly absent, so a stray set bit
+    // at 14 is ignored rather than resurrected onto some other lesson.
+    expect(map.has(14)).toBe(false);
+  });
+
+  it("returns an empty map for an unknown course (degrade, don't throw mid-batch)", () => {
+    expect(slotToLiveLessonId("course-missing").size).toBe(0);
+  });
+});

--- a/apps/web/src/lib/courses/lesson-index.ts
+++ b/apps/web/src/lib/courses/lesson-index.ts
@@ -8,8 +8,14 @@ interface CourseLike {
 
 /**
  * Flatten a course's modules into a single ordered lesson list and return the
- * zero-based index of `lessonId`, or -1 if absent. This index is the lesson's
- * on-chain bitmap position, so its ordering must match the course structure.
+ * zero-based DISPLAY index of `lessonId`, or -1 if absent.
+ *
+ * DISPLAY-ONLY. This is the lesson's position in the authored structure and
+ * shifts whenever the course is reordered/retired/inserted. It is NOT the
+ * on-chain bitmap position — for anything that touches `lesson_flags`,
+ * `complete_lesson`, or `user_progress.lesson_index`, use `getLessonSlot`
+ * (lesson-slot.ts), which reads the stable slot lock. Conflating the two was the
+ * #741 bug: a restructure remapped the array index while the slot stayed put.
  */
 export function findLessonIndex(course: CourseLike, lessonId: string): number {
   const allLessons = (course.modules ?? []).flatMap((m) => m.lessons ?? []);

--- a/apps/web/src/lib/courses/lesson-slot.ts
+++ b/apps/web/src/lib/courses/lesson-slot.ts
@@ -1,0 +1,58 @@
+import "server-only";
+
+import { slotsByCourseId } from "@/lib/content/store";
+
+/**
+ * Resolve a lesson's permanent on-chain bitmap SLOT from the committed
+ * `slots.lock.json` (exposed as `slotsByCourseId`).
+ *
+ * A slot is "assigned once, never renumbered, never reused" — the whole point of
+ * the slot lock is to keep an enrollment's `lesson_flags` bit stable across
+ * reorders/retirements. This is therefore the ONLY correct index to send to
+ * `complete_lesson`, to test against the enrollment bitmap, or to record as
+ * `user_progress.lesson_index`. It is NOT the same as `findLessonIndex` (the
+ * lesson's position in the flattened module array), which shifts whenever the
+ * course is restructured — using array position was the #741 bug: after a
+ * restructure the same lessonId maps to a different bit, silently completing a
+ * different (possibly retired) lesson.
+ *
+ * FAIL-CLOSED: a missing course lock or an unslotted lessonId throws. There is
+ * deliberately NO array-index fallback — a wrong slot corrupts on-chain state
+ * (double XP, wrong bit set) or bricks a credential, so refusing is the only
+ * safe answer. Every deployed course has a slot lock generated at compile time
+ * (`pnpm content:slots`); a miss here means a course/bundle mismatch, i.e. a
+ * genuine server fault, not a learner error.
+ */
+export function getLessonSlot(courseId: string, lessonId: string): number {
+  const lock = slotsByCourseId.get(courseId);
+  if (!lock) {
+    throw new Error(`No slot lock for course: ${courseId}`);
+  }
+  const slot = lock.slots[lessonId];
+  if (slot === undefined) {
+    throw new Error(
+      `Lesson ${lessonId} has no slot in course ${courseId} (retired or unknown)`
+    );
+  }
+  return slot;
+}
+
+/**
+ * Reverse map slot → lessonId for a course's LIVE lessons only (the `slots` map
+ * never contains retired lessons — they move to `retired`). Used to reconstruct
+ * `user_progress` from an on-chain bitmap (admin resync): iterate live slots and
+ * test each bit, rather than assuming bit position equals array position. A
+ * retired slot's set bit has no entry here, so it is correctly ignored.
+ *
+ * Returns an empty map when the course has no lock, so callers degrade to
+ * "nothing to sync" rather than throwing mid-batch.
+ */
+export function slotToLiveLessonId(courseId: string): Map<number, string> {
+  const map = new Map<number, string>();
+  const lock = slotsByCourseId.get(courseId);
+  if (!lock) return map;
+  for (const [lessonId, slot] of Object.entries(lock.slots)) {
+    map.set(slot, lessonId);
+  }
+  return map;
+}

--- a/apps/web/src/lib/helius/__tests__/resolvers.test.ts
+++ b/apps/web/src/lib/helius/__tests__/resolvers.test.ts
@@ -1,0 +1,51 @@
+/* eslint-disable import/order -- vi.mock calls must precede importing the module. */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+// resolveLessonId maps an on-chain LessonCompleted event index → lessonId. That
+// index IS the permanent slot (#741), so resolution must go through the slot
+// lock, not array position. resolveLessonId dynamically imports lesson-slot, so
+// mocking that module intercepts the resolution.
+const { slotToLiveLessonId } = vi.hoisted(() => ({
+  slotToLiveLessonId: vi.fn<(courseId: string) => Map<number, string>>(),
+}));
+vi.mock("@/lib/courses/lesson-slot", () => ({ slotToLiveLessonId }));
+
+import { resolveLessonId } from "../resolvers";
+
+// C3-shaped: a later-authored lesson keeps slot 5 while sitting at array pos 4
+// (an earlier lesson was retired), and slot 14 is retired entirely.
+const LIVE = new Map<number, string>([
+  [0, "lesson-intro"],
+  [5, "lesson-keeps-slot-5"], // array pos 4, slot 5 — the repro
+  [15, "lesson-capstone"],
+]);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  slotToLiveLessonId.mockReturnValue(LIVE);
+});
+
+describe("resolveLessonId — event index is the slot, not array position (#741)", () => {
+  it("resolves the slot to the correct lesson even when array order disagrees", async () => {
+    // The event carries slot 5 → must resolve lesson-keeps-slot-5, NOT whatever
+    // sits at array index 5 (which array-position resolution would have picked).
+    expect(await resolveLessonId("course-c3", 5)).toBe("lesson-keeps-slot-5");
+    expect(await resolveLessonId("course-c3", 15)).toBe("lesson-capstone");
+  });
+
+  it("returns null for a retired/unknown slot (caller skips gracefully, no throw)", async () => {
+    // Slot 14 is retired — no live lesson. Must return null (the handler then
+    // skips the upsert and falls the XP reason back to the raw index), never
+    // throw the webhook into a retry loop.
+    await expect(resolveLessonId("course-c3", 14)).resolves.toBeNull();
+  });
+
+  it("returns null (never throws) if slot resolution itself errors", async () => {
+    slotToLiveLessonId.mockImplementation(() => {
+      throw new Error("store unavailable");
+    });
+    await expect(resolveLessonId("course-c3", 5)).resolves.toBeNull();
+  });
+});

--- a/apps/web/src/lib/helius/resolvers.ts
+++ b/apps/web/src/lib/helius/resolvers.ts
@@ -76,34 +76,36 @@ export async function resolveCourseId(
 }
 
 /**
- * Resolve lesson_index to lesson_id using Sanity course structure.
- * Flattens modules → lessons and returns the lesson at the given index.
+ * Resolve an on-chain LessonCompleted event's index to a lesson_id.
+ *
+ * The event index IS the permanent on-chain SLOT (that is what the program sets
+ * and what our completion route now sends — #741), NOT the lesson's position in
+ * the flattened module array. Resolving it via array position (the old
+ * `allLessons[index]`) would, on any sparse/reordered course, name the WRONG
+ * lesson — writing a phantom `user_progress` row and an XP reason for a lesson
+ * the learner never did. Resolve slot → lessonId through the committed slot lock.
+ *
+ * A retired or not-yet-synced slot has no live lesson → returns null, which the
+ * caller (`handleLessonCompleted`) already handles gracefully: it skips the
+ * progress upsert and falls the XP reason back to the raw index. Never throws —
+ * a webhook that throws is retried into a loop.
  */
 export async function resolveLessonId(
   courseId: string,
   lessonIndex: number
 ): Promise<string | null> {
-  // Dynamic import to avoid pulling Sanity client into non-page contexts
-  const { getCourseById } = await import("@/lib/content/queries");
   try {
-    const course = await getCourseById(courseId);
-    if (!course) {
-      console.warn(`[resolver] No course found for ${courseId}`);
-      return null;
-    }
-    const allLessons = (course.modules ?? []).flatMap(
-      (m: { lessons?: { _id: string }[] }) => m.lessons ?? []
-    );
-    const lessonId = allLessons[lessonIndex]?._id ?? null;
+    const { slotToLiveLessonId } = await import("@/lib/courses/lesson-slot");
+    const lessonId = slotToLiveLessonId(courseId).get(lessonIndex) ?? null;
     if (!lessonId) {
       console.warn(
-        `[resolver] No lesson at index ${lessonIndex} for course ${courseId} (total: ${allLessons.length})`
+        `[resolver] No live lesson at slot ${lessonIndex} for course ${courseId} (retired or re-sync pending)`
       );
     }
     return lessonId;
   } catch (err) {
     console.error(
-      `[resolver] resolveLessonId failed for course=${courseId} index=${lessonIndex}:`,
+      `[resolver] resolveLessonId failed for course=${courseId} slot=${lessonIndex}:`,
       err
     );
     return null;

--- a/apps/web/src/lib/lessons/__tests__/batch-complete.test.ts
+++ b/apps/web/src/lib/lessons/__tests__/batch-complete.test.ts
@@ -12,6 +12,7 @@ const h = vi.hoisted(() => ({
   fetchCourse: vi.fn(),
   upsert: vi.fn(async () => ({ error: null })),
   logError: vi.fn(),
+  getLessonSlot: vi.fn<(courseId: string, lessonId: string) => number>(),
 }));
 
 vi.mock("@/lib/content/queries", () => ({ getCourseById: h.getCourseById }));
@@ -28,6 +29,9 @@ vi.mock("@/lib/supabase/admin", () => ({
   createAdminClient: () => ({ from: () => ({ upsert: h.upsert }) }),
 }));
 vi.mock("@/lib/logging", () => ({ logError: h.logError }));
+vi.mock("@/lib/courses/lesson-slot", () => ({
+  getLessonSlot: h.getLessonSlot,
+}));
 
 import { batchCompleteCourse, BatchCompleteError } from "../batch-complete";
 
@@ -46,12 +50,27 @@ function courseWithLessons(n: number) {
   };
 }
 
+/** Build a 4-word [u64;4] mask (bigints) with the given bit positions set. */
+function mask(...bits: number[]): bigint[] {
+  const words: [bigint, bigint, bigint, bigint] = [0n, 0n, 0n, 0n];
+  for (const b of bits) {
+    const w = Math.floor(b / 64) as 0 | 1 | 2 | 3;
+    words[w] |= 1n << BigInt(b % 64);
+  }
+  return words;
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
   h.getCourseById.mockResolvedValue(courseWithLessons(4));
   h.fetchCourse.mockResolvedValue({ liveLessonCount: 4, xp_per_lesson: 100 });
   h.completeLesson.mockResolvedValue("sig");
   h.upsert.mockResolvedValue({ error: null });
+  // Default dense mapping: lesson `lN` → slot N (slot == array index). Existing
+  // dense cases stay byte-identical; sparse cases override this per test.
+  h.getLessonSlot.mockImplementation((_courseId, lessonId) =>
+    Number(String(lessonId).replace("l", ""))
+  );
 });
 
 describe("batchCompleteCourse", () => {
@@ -96,9 +115,16 @@ describe("batchCompleteCourse", () => {
     expect(h.completeLesson).not.toHaveBeenCalled();
   });
 
-  it("clamps to the on-chain live lesson count (content/chain drift)", async () => {
-    h.getCourseById.mockResolvedValue(courseWithLessons(6)); // content has 6
-    h.fetchCourse.mockResolvedValue({ liveLessonCount: 4, xp_per_lesson: 100 }); // chain has 4
+  it("skips slots not live in the on-chain mask, per-slot (sparse/drift)", async () => {
+    // Content has 6 lessons (slots 0..5) but the on-chain mask only activates
+    // 0..3. The two un-activated slots are isolated into `pending` — via the
+    // per-SLOT bit test, NOT a count truncation — and no revert-bound tx fires
+    // for them (#741).
+    h.getCourseById.mockResolvedValue(courseWithLessons(6));
+    h.fetchCourse.mockResolvedValue({
+      activeLessons: mask(0, 1, 2, 3),
+      xp_per_lesson: 100,
+    });
     h.fetchEnrollment.mockResolvedValue({ lesson_flags: [0n] });
 
     const result = await batchCompleteCourse({
@@ -107,10 +133,73 @@ describe("batchCompleteCourse", () => {
       wallet: WALLET,
     });
 
-    expect(result.total).toBe(4);
-    expect(result.newlyCompleted).toBe(4);
+    expect(result).toEqual({
+      total: 6,
+      newlyCompleted: 4,
+      alreadyComplete: 0,
+      pending: 2, // slots 4 and 5 not live → skipped, no tx
+    });
     const maxIndex = Math.max(...h.completeLesson.mock.calls.map((c) => c[2]));
-    expect(maxIndex).toBe(3); // never touches slots 4 or 5
+    expect(maxIndex).toBe(3); // never attempts slots 4 or 5
+  });
+
+  it("sends the SLOT to completeLesson, not array position (C3 capstone at 15)", async () => {
+    // A 2-lesson course whose second lesson keeps slot 15 (capstone) while a
+    // retired slot 14 sits between; array position would send 1, the slot is 15.
+    h.getCourseById.mockResolvedValue(courseWithLessons(2));
+    h.getLessonSlot.mockImplementation((_c, id) => (id === "l0" ? 0 : 15));
+    h.fetchCourse.mockResolvedValue({
+      activeLessons: mask(0, 15), // 14 retired, 15 (capstone) live
+      xp_per_lesson: 100,
+    });
+    // Old enrollment carries a stale retired-slot-14 bit; it must NOT read as the
+    // capstone being complete.
+    h.fetchEnrollment.mockResolvedValue({ lesson_flags: mask(14) });
+
+    const result = await batchCompleteCourse({
+      userId: "u",
+      courseId: "course-x",
+      wallet: WALLET,
+    });
+
+    expect(result).toEqual({
+      total: 2,
+      newlyCompleted: 2,
+      alreadyComplete: 0,
+      pending: 0,
+    });
+    const slots = h.completeLesson.mock.calls
+      .map((c) => c[2])
+      .sort((a, b) => a - b);
+    expect(slots).toEqual([0, 15]); // capstone sent as slot 15, never 1 or 14
+  });
+
+  it("isolates an unslotted lesson into `pending` (fail-closed, batch continues)", async () => {
+    // Middle lesson has no slot → must NOT fall back to array position; it lands
+    // in `pending` with a logged reason and the rest of the batch proceeds.
+    h.getCourseById.mockResolvedValue(courseWithLessons(3));
+    h.getLessonSlot.mockImplementation((_c, id) => {
+      if (id === "l1") throw new Error("Lesson l1 has no slot in course");
+      return Number(String(id).replace("l", ""));
+    });
+    h.fetchEnrollment.mockResolvedValue({ lesson_flags: [0n] });
+
+    const result = await batchCompleteCourse({
+      userId: "u",
+      courseId: "course-x",
+      wallet: WALLET,
+    });
+
+    expect(result).toEqual({
+      total: 3,
+      newlyCompleted: 2, // l0, l2
+      alreadyComplete: 0,
+      pending: 1, // l1 unslotted
+    });
+    const slots = h.completeLesson.mock.calls
+      .map((c) => c[2])
+      .sort((a, b) => a - b);
+    expect(slots).toEqual([0, 2]); // never attempted l1 at any index
   });
 
   it("isolates a single lesson's on-chain failure into `pending`", async () => {

--- a/apps/web/src/lib/lessons/batch-complete.ts
+++ b/apps/web/src/lib/lessons/batch-complete.ts
@@ -8,6 +8,7 @@ import {
 } from "@/lib/solana/academy-program";
 import { fetchEnrollment, fetchCourse } from "@/lib/solana/academy-reads";
 import { isLessonComplete } from "@/lib/solana/bitmap";
+import { getLessonSlot } from "@/lib/courses/lesson-slot";
 import { logError } from "@/lib/logging";
 import { ERROR_IDS } from "@/constants/errorIds";
 import { TEST_OUT_MAX_XP } from "@/lib/courses/test-out";
@@ -94,15 +95,14 @@ export async function batchCompleteCourse(params: {
     );
   }
 
-  // Only complete slots the program will accept: indices < the live lesson
-  // count. A content-vs-chain drift (content has more lessons than the chain has
-  // activated) would otherwise revert on `is_active_slot`. Count-based, correct
-  // while masks are dense (today) — mirrors the complete route's guard.
-  const liveLessonCount =
-    typeof onChainCourse?.liveLessonCount === "number"
-      ? onChainCourse.liveLessonCount
-      : lessons.length;
-  const total = Math.min(lessons.length, liveLessonCount);
+  // Every live lesson is a candidate; `total` (the XP-cap basis and result
+  // denominator) is the live-lesson count. Whether the program will ACCEPT a
+  // given lesson is a per-SLOT decision (`is_active_slot`), tested inside the
+  // loop against `activeLessons` — NOT a count truncation. A count bound would,
+  // on a sparse mask, attempt the wrong lessons (array positions 0..popcount-1)
+  // and skip live high slots such as a capstone at slot 15 (#741).
+  const total = lessons.length;
+  const activeLessons = onChainCourse?.activeLessons;
 
   // Spec cap: refuse a course whose retroactive XP would exceed the ceiling
   // rather than driving an absurd batch mint (xpPerLesson × lessonCount ≤ 10000).
@@ -133,17 +133,63 @@ export async function batchCompleteCourse(params: {
 
   // Sequential: the backend keypair is payer on every tx, and serialising keeps
   // the recent-blockhash / nonce path simple and the RPC load bounded.
-  for (let index = 0; index < total; index++) {
-    const lesson = lessons[index];
+  for (const lesson of lessons) {
     if (!lesson) continue;
 
-    if (isLessonComplete(flags, index)) {
+    // Resolve the permanent on-chain SLOT — never array position (#741).
+    // Fail-CLOSED per lesson: an unslotted lesson is isolated into `pending`
+    // with a logged reason and the batch continues; it never falls back to an
+    // index, which would complete the wrong bit.
+    let slot: number;
+    try {
+      slot = getLessonSlot(courseId, lesson._id);
+    } catch (err: unknown) {
+      pending++;
+      logError({
+        errorId: ERROR_IDS.TEST_OUT_FAILED,
+        error: err instanceof Error ? err : new Error(String(err)),
+        context: {
+          step: "resolve_slot",
+          userId,
+          courseId,
+          lessonId: lesson._id,
+        },
+      });
+      continue;
+    }
+
+    // Skip slots the program has not activated — `complete_lesson` reverts on
+    // `is_active_slot`, so attempting would only burn a reverted-tx fee. Per-SLOT
+    // bit test against the mask (the slot-space replacement for the old count
+    // bound). Counted as `pending`: a re-run after the admin mask re-sync lands
+    // it.
+    if (activeLessons) {
+      const word = Math.floor(slot / 64);
+      const bit = BigInt(slot % 64);
+      const slotLive = ((activeLessons[word] ?? 0n) & (1n << bit)) !== 0n;
+      if (!slotLive) {
+        pending++;
+        logError({
+          errorId: ERROR_IDS.TEST_OUT_FAILED,
+          error: new Error(`slot ${slot} not live on-chain (re-sync pending)`),
+          context: {
+            step: "slot_not_live",
+            userId,
+            courseId,
+            lessonId: lesson._id,
+          },
+        });
+        continue;
+      }
+    }
+
+    if (isLessonComplete(flags, slot)) {
       alreadyComplete++;
       continue;
     }
 
     try {
-      const signature = await completeLesson(courseId, wallet, index);
+      const signature = await completeLesson(courseId, wallet, slot);
       const { error } = await admin.from("user_progress").upsert(
         {
           user_id: userId,
@@ -152,7 +198,7 @@ export async function batchCompleteCourse(params: {
           completed: true,
           completed_at: new Date().toISOString(),
           tx_signature: signature,
-          lesson_index: index,
+          lesson_index: slot,
         },
         { onConflict: "user_id,lesson_id" }
       );
@@ -185,7 +231,7 @@ export async function batchCompleteCourse(params: {
           userId,
           courseId,
           lessonId: lesson._id,
-          lessonIndex: index,
+          lessonIndex: slot,
         },
       });
     }

--- a/apps/web/src/lib/solana/__tests__/bitmap.test.ts
+++ b/apps/web/src/lib/solana/__tests__/bitmap.test.ts
@@ -2,6 +2,16 @@ import { describe, it, expect } from "vitest";
 import BN from "bn.js";
 import { decodeLessonBitmap, isCourseComplete } from "../bitmap";
 
+/** Build a 4-word [u64;4] mask (bigints) with the given bit positions set. */
+function mask(...bits: number[]): bigint[] {
+  const words: [bigint, bigint, bigint, bigint] = [0n, 0n, 0n, 0n];
+  for (const b of bits) {
+    const w = Math.floor(b / 64) as 0 | 1 | 2 | 3;
+    words[w] |= 1n << BigInt(b % 64);
+  }
+  return words;
+}
+
 describe("decodeLessonBitmap", () => {
   it("empty bitmap returns all false", () => {
     expect(
@@ -116,6 +126,23 @@ describe("isCourseComplete", () => {
         [0n, 0n, 0n, 0n]
       )
     ).toBe(true);
+  });
+
+  // C3-shaped (#741): capstone lives at slot 15 while slot 14 (m4-interact) is
+  // retired. A real learner carries a stale bit-14 completion. Finalize must
+  // require slot 15 (the capstone) and ignore the burned bit 14.
+  const c3Active = mask(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 15);
+
+  it("C3: capstone slot 15 set + retired slot 14 stale bit -> complete", () => {
+    const flags = mask(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
+    expect(isCourseComplete(flags, c3Active)).toBe(true);
+  });
+
+  it("C3: every live slot but the capstone (15) -> incomplete", () => {
+    // The stale retired bit 14 is set but slot 15 is not — must NOT pass, which
+    // is the credential-gating property (#721): the capstone really is required.
+    const flags = mask(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14);
+    expect(isCourseComplete(flags, c3Active)).toBe(false);
   });
 
   it("treats a missing/short lessonFlags word as 0", () => {


### PR DESCRIPTION
Closes #741. Prerequisite for re-landing #740 (reverted in #744).

## What was wrong

The on-chain bitmap index (sent to `complete_lesson`, tested against `lesson_flags`, written to `lesson_index`) was derived from a lesson's **position in the flattened module array**, not its **slot** in `slots.lock.json`. The slot lock exists precisely to keep that bit stable across reorders/retirements, but **no learner-facing code read it**. Dense courses made `arrayIndex == slot` by accident; a restructure (#740 C3) remaps 9 of 12 survivors → a `lessonId` lands on a different (possibly retired) bit: silent false-completion, double XP, or an unreachable credential.

## Fix — every on-chain index consumer is now slot-aware

New `lib/courses/lesson-slot.ts`:
- `getLessonSlot(courseId, lessonId)` — reads the committed slot lock (`slotsByCourseId`). **FAIL-CLOSED**: throws on a missing lock or unslotted lesson; no array-index fallback.
- `slotToLiveLessonId(courseId)` — reverse map slot→lessonId over live slots (retired absent), for reconstructing progress from a bitmap.

Consumers converted:
- **`lessons/complete/route.ts`** — slot → `complete_lesson`, slot-bit idempotency, slot → `lesson_index`. Count guard rewritten from `slot >= popcount(active_lessons)` to a **per-slot bit test** against `activeLessons` (a sparse mask makes popcount != highest live slot, so the count compare would 409 a valid capstone at slot 15).
- **`admin/resync/route.ts`** — reconstructs `user_progress` by iterating live slots + `isLessonComplete(flags, slot)` instead of `bit i → allLessons[i]`.
- **`lib/helius/resolvers.ts` (`resolveLessonId`)** — *found by the adversarial reviewer.* The Helius webhook mapped the event index via `allLessons[index]`; the event index IS the slot, so on a sparse course it wrote a phantom `user_progress` row for the WRONG lesson + an XP reason naming it, on **every** webhook-mirrored completion. Now `slotToLiveLessonId(courseId).get(index)`; a retired/unsynced slot → null, which `handleLessonCompleted` already handles gracefully (skips upsert, XP reason falls back to the index). Never throws.
- **`lib/lessons/batch-complete.ts` (test-out, #730)** — *found by the adversarial reviewer.* Loop index over `flatMap` was sent to `completeLesson`, tested against the bitmap, and written to `lesson_index`. All three now use `getLessonSlot` (fail-closed → the lesson is isolated into `pending` with a logged reason, batch continues). The count-based `total = min(len, popcount)` bound is replaced by a **per-slot `is_active_slot` bit test** so a live high slot is attempted and an un-activated slot is skipped without a reverted-tx fee.
- **`lib/courses/lesson-index.ts`** — `findLessonIndex` docstring corrected to DISPLAY-ONLY; no non-test callers remain.

## Call-site disposition (full sweep)

| Call site | Path | Disposition |
|---|---|---|
| `api/lessons/complete/route.ts` | learner on-chain completion | **FIXED → slot**; count guard → per-slot bit test |
| `api/admin/resync/route.ts` | admin progress reconstruction from bitmap | **FIXED → slot** (reverse map) |
| `lib/helius/resolvers.ts` `resolveLessonId` | **Helius webhook** → progress + XP attribution | **FIXED → slot** (reviewer-found); retired slot → null, graceful skip |
| `lib/lessons/batch-complete.ts` | **test-out batch** (#730) | **FIXED → slot** ×3 (reviewer-found); count bound → per-slot `is_active_slot` gate |
| `lib/courses/lesson-index.ts` `findLessonIndex` | pure helper | **docstring → display-only**; no non-test callers |
| `api/admin/courses/sync/route.ts`, `lib/solana/admin-signer.ts` | admin `active_lessons` mask derivation | **no change** — already read slots.lock |
| `lesson-client.tsx` prev/next, `continue-learning.ts` `findNextIncompleteLesson` | display navigation | **no change** — lessonId-keyed, order-safe display |
| `lib/solana/academy-program.ts` `completeLesson(lessonIndex)` | instruction sink | **no change** — forwards the number it's given (now the slot) |

Credit to the adversarial reviewer for catching the webhook + batch consumers that the first pass missed.

## Re-grep evidence (no other consumers)

`grep -rn "allLessons\[" src` → only `lesson-client.tsx` prev/next nav (display) + a comment in `resolvers.ts`.
`grep -rn "completeLesson(" src` → sink builder (`academy-program.ts`), `batch-complete.ts` (now slot), `continue-learning`/`hybrid-progress-service` (unrelated: nav / throwing stub).
`grep -rn "resolveLessonId" src` → single caller `event-handlers.ts:161` passing `event.lessonIndex` (already the slot; `lesson_index: event.lessonIndex` write is correct).
`grep -rn "lesson_index:|lessonIndex" src` → remaining hits are the bitmap helper (sink), the event decoder (reads the on-chain field), generated DB types, and the fixed files.

## Backfill

New `user_progress.lesson_index` writes are slot-space; historical rows left as a record (no live-DB backfill — self-correct on next completion/resync).

## Why safe to ship before #740 re-lands

Every current course is dense (slot == arrayIndex), proven by `lesson-slot-equivalence.test.ts` over the committed bundle. One deliberately-landmined sub-test asserts the bundle is all-dense today; #740's re-land relaxes that one test while the dense⟹equivalence and sparse-fixture tests remain the guarantees.

## Tests

- `lesson-slot.test.ts`, `lesson-slot-equivalence.test.ts` — slot resolution + bundle-wide equivalence.
- `slot-aware.test.ts` (route, real bitmap) — slot (not array pos) reaches `completeLesson`; retired bit-14 never false-completes the capstone; per-slot count guard 409s only when the slot isn't live and does NOT 409 the capstone at popcount==15; missing slot → 500, no tx.
- `resolvers.test.ts` — event slot → correct lesson when array order disagrees; retired slot → null; never throws.
- `batch-complete.test.ts` — capstone sent as slot 15 (not array pos); not-live slots skipped as `pending`; unslotted lesson isolated as `pending`, batch continues.
- `bitmap.test.ts` — C3 `isCourseComplete` cases (capstone slot 15 required; retired slot-14 burned bit ignored).

## Verification

- `pnpm typecheck` — 6/6 packages pass
- `pnpm --filter web test` — **1890 passed** (208 files)
- eslint clean on all changed files; zero `any`, strict TS.

Does NOT merge — SENSITIVE (on-chain trust path) → adversarial + gate.
