### PR TITLE
feat(courses): changelog for reactivate / deactivate / recreate mutators (#738)

### DIFF
--- a/apps/web/src/app/api/admin/courses/deactivate/route.ts
+++ b/apps/web/src/app/api/admin/courses/deactivate/route.ts
@@ -2,6 +2,7 @@ import "server-only";
 
 import { revalidateTag } from "next/cache";
 import { NextRequest, NextResponse } from "next/server";
+import { Connection } from "@solana/web3.js";
 import {
   requireAdminAuth,
   adminUnauthorizedResponse,
@@ -9,8 +10,12 @@ import {
 } from "@/lib/admin/auth";
 import { isPlatformFrozen } from "@/lib/platform/freeze";
 import { platformFrozenResponse } from "@/lib/platform/freeze-http";
+import { serverEnv } from "@/lib/env.server";
 import { deactivateCoursePda } from "@/lib/solana/admin-signer";
 import { writeCourseActive } from "@/lib/content/deployment-writes";
+import { recordCourseDeactivated } from "@/lib/content/changelog-writes";
+import { fetchCourse } from "@/lib/solana/academy-reads";
+import { getProgramId } from "@/lib/solana/pda";
 import { COURSES_CACHE_TAG } from "@/lib/content/queries";
 
 export async function POST(req: NextRequest): Promise<NextResponse> {
@@ -64,6 +69,31 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     );
     warning =
       "Deactivated on-chain, but the catalog flag didn't update — the course may still show until re-synced.";
+  }
+
+  // Course changelog (#738): record the deactivation — the path #713 retires the
+  // superseded courses with. Non-fatal. deactivate does not close the account or
+  // bump version, so the course is still readable on-chain; record its current
+  // version. NOTE: under the #654 RLS (synced+active only) this entry is not
+  // publicly readable while the course is inactive — it becomes visible if the
+  // course is later reactivated. See #738 on deferring the retired-course surface.
+  if (result.signature) {
+    try {
+      const connection = new Connection(serverEnv.SOLANA_RPC_URL, "confirmed");
+      const onChain = await fetchCourse(courseId, connection, getProgramId());
+      if (onChain) {
+        await recordCourseDeactivated({
+          courseId,
+          txSignature: result.signature,
+          version: onChain.version,
+        });
+      }
+    } catch (changelogErr) {
+      console.error(
+        "[admin/courses/deactivate] changelog write failed:",
+        changelogErr
+      );
+    }
   }
 
   return NextResponse.json({

--- a/apps/web/src/app/api/admin/courses/reactivate/route.ts
+++ b/apps/web/src/app/api/admin/courses/reactivate/route.ts
@@ -2,6 +2,7 @@ import "server-only";
 
 import { revalidateTag } from "next/cache";
 import { NextRequest, NextResponse } from "next/server";
+import { Connection } from "@solana/web3.js";
 import {
   requireAdminAuth,
   adminUnauthorizedResponse,
@@ -9,8 +10,12 @@ import {
 } from "@/lib/admin/auth";
 import { isPlatformFrozen } from "@/lib/platform/freeze";
 import { platformFrozenResponse } from "@/lib/platform/freeze-http";
+import { serverEnv } from "@/lib/env.server";
 import { updateCoursePda } from "@/lib/solana/admin-signer";
 import { writeCourseActive } from "@/lib/content/deployment-writes";
+import { recordCourseReactivated } from "@/lib/content/changelog-writes";
+import { fetchCourse } from "@/lib/solana/academy-reads";
+import { getProgramId } from "@/lib/solana/pda";
 import { COURSES_CACHE_TAG } from "@/lib/content/queries";
 
 export async function POST(req: NextRequest): Promise<NextResponse> {
@@ -62,6 +67,29 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     );
     warning =
       "Reactivated on-chain, but the catalog flag didn't update — the course may stay hidden until re-synced.";
+  }
+
+  // Course changelog (#738): record the reactivation. Non-fatal — the on-chain
+  // flip already landed; a missing log entry must not fail the operation.
+  // reactivate does not bump version, so record the current on-chain version;
+  // if it can't be read, skip the entry rather than logging a wrong version.
+  if (result.signature) {
+    try {
+      const connection = new Connection(serverEnv.SOLANA_RPC_URL, "confirmed");
+      const onChain = await fetchCourse(courseId, connection, getProgramId());
+      if (onChain) {
+        await recordCourseReactivated({
+          courseId,
+          txSignature: result.signature,
+          version: onChain.version,
+        });
+      }
+    } catch (changelogErr) {
+      console.error(
+        "[admin/courses/reactivate] changelog write failed:",
+        changelogErr
+      );
+    }
   }
 
   return NextResponse.json({

--- a/apps/web/src/components/course/__tests__/course-changelog.test.tsx
+++ b/apps/web/src/components/course/__tests__/course-changelog.test.tsx
@@ -106,4 +106,43 @@ describe("CourseChangelog", () => {
     expect(screen.queryByText(/since you enrolled/i)).not.toBeInTheDocument();
     expect(screen.queryByText("New")).not.toBeInTheDocument();
   });
+
+  it("renders the #738 status + recreate kinds", () => {
+    renderWithIntl(
+      <CourseChangelog
+        entries={[
+          {
+            id: 12,
+            kind: "reactivated",
+            version: 4,
+            txSignature: "S12",
+            createdAt: "2026-07-26T03:00:00Z",
+            detail: {},
+          },
+          {
+            id: 11,
+            kind: "recreated",
+            version: 1,
+            txSignature: "S11",
+            createdAt: "2026-07-26T02:00:00Z",
+            detail: { lessonCount: 7 },
+          },
+          {
+            id: 10,
+            kind: "deactivated",
+            version: 4,
+            txSignature: "S10",
+            createdAt: "2026-07-26T01:00:00Z",
+            detail: {},
+          },
+        ]}
+      />
+    );
+    expect(screen.getByText("Course deactivated")).toBeInTheDocument();
+    expect(screen.getByText("Course reactivated")).toBeInTheDocument();
+    expect(screen.getByText("Course rebuilt on-chain")).toBeInTheDocument();
+    expect(
+      screen.getByText(/on-chain course account was recreated/i)
+    ).toBeInTheDocument();
+  });
 });

--- a/apps/web/src/components/course/course-changelog.tsx
+++ b/apps/web/src/components/course/course-changelog.tsx
@@ -9,6 +9,9 @@ import {
   MinusCircle,
   Lightning,
   ArrowsClockwise,
+  ArrowsCounterClockwise,
+  EyeSlash,
+  Eye,
 } from "@phosphor-icons/react";
 import type {
   CourseChangelogEntry,
@@ -37,6 +40,12 @@ function iconFor(kind: CourseChangelogEntry["kind"]) {
       return Lightning;
     case "content_updated":
       return ArrowsClockwise;
+    case "deactivated":
+      return EyeSlash;
+    case "reactivated":
+      return Eye;
+    case "recreated":
+      return ArrowsCounterClockwise;
   }
 }
 
@@ -170,6 +179,12 @@ function ChangelogTitle({
       return <>{t("changelogXpChanged")}</>;
     case "content_updated":
       return <>{t("changelogContentUpdated")}</>;
+    case "deactivated":
+      return <>{t("changelogDeactivated")}</>;
+    case "reactivated":
+      return <>{t("changelogReactivated")}</>;
+    case "recreated":
+      return <>{t("changelogRecreated")}</>;
   }
 }
 
@@ -219,6 +234,18 @@ function ChangelogBody({
         <p className="text-sm text-text-2">
           {t("changelogContentUpdatedDetail")}
         </p>
+      );
+    case "deactivated":
+      return (
+        <p className="text-sm text-text-2">{t("changelogDeactivatedDetail")}</p>
+      );
+    case "reactivated":
+      return (
+        <p className="text-sm text-text-2">{t("changelogReactivatedDetail")}</p>
+      );
+    case "recreated":
+      return (
+        <p className="text-sm text-text-2">{t("changelogRecreatedDetail")}</p>
       );
   }
 }

--- a/apps/web/src/lib/admin/__tests__/recreate-course.test.ts
+++ b/apps/web/src/lib/admin/__tests__/recreate-course.test.ts
@@ -102,6 +102,15 @@ vi.mock("@/lib/content/deployment-writes", () => ({
   }),
 }));
 
+// #738 — the recreate now records a `recreated` changelog entry (non-fatal,
+// last). Mock it so the test stays hermetic (no real supabase) and so we can
+// assert it fires on the happy path and its ordering (after synced + gate off).
+vi.mock("@/lib/content/changelog-writes", () => ({
+  recordCourseRecreated: vi.fn(async () => {
+    calls.push("changelog:recreated");
+  }),
+}));
+
 vi.mock("@solana/web3.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@solana/web3.js")>();
   return {
@@ -553,6 +562,9 @@ describe("rail 3 — the maintenance gate", () => {
       "bind",
       "db:synced",
       "gate:off",
+      // #738 — the changelog entry is recorded LAST (non-fatal), after the
+      // course is fully up, restored, and the gate is cleared.
+      "changelog:recreated",
     ]);
   });
 
@@ -680,6 +692,7 @@ describe("rail 3 — the maintenance gate", () => {
       "bind",
       "db:synced",
       "gate:off",
+      "changelog:recreated",
     ]);
   });
 });
@@ -700,6 +713,7 @@ describe("close → create happy path", () => {
       "bind",
       "db:synced",
       "gate:off",
+      "changelog:recreated",
     ]);
 
     expect(result.action).toBe("recreated");
@@ -751,6 +765,7 @@ describe("close → create happy path", () => {
       "deactivate",
       "db:synced",
       "gate:off",
+      "changelog:recreated",
     ]);
     expect(result.warnings.join(" ")).not.toMatch(/currently LIVE/);
   });
@@ -837,6 +852,7 @@ describe("create fails after close — the course is DOWN", () => {
       "bind",
       "db:synced",
       "gate:off",
+      "changelog:recreated",
     ]);
   });
 

--- a/apps/web/src/lib/admin/recreate-course.ts
+++ b/apps/web/src/lib/admin/recreate-course.ts
@@ -1,11 +1,6 @@
 import "server-only";
 
 import { Connection, PublicKey } from "@solana/web3.js";
-import {
-  difficultyToNumber,
-  getMissingCourseFields,
-  isDraftId,
-} from "./sync-diff";
 import { serverEnv } from "@/lib/env.server";
 import { getAllCoursesAdmin } from "@/lib/content/queries";
 import {
@@ -13,6 +8,7 @@ import {
   writeCourseMaintenanceFlag,
   acquireCourseMaintenanceGate,
 } from "@/lib/content/deployment-writes";
+import { recordCourseRecreated } from "@/lib/content/changelog-writes";
 import { fetchCourse } from "@/lib/solana/academy-reads";
 import { findCoursePDA, getProgramId } from "@/lib/solana/pda";
 import {
@@ -24,6 +20,11 @@ import {
   updateCoursePda,
   type CreateCourseAdminParams,
 } from "@/lib/solana/admin-signer";
+import {
+  difficultyToNumber,
+  getMissingCourseFields,
+  isDraftId,
+} from "./sync-diff";
 
 /**
  * Close + recreate a Course PDA (issue #440).
@@ -667,6 +668,24 @@ export async function recreateCourse(
   //    paths can resume immediately rather than waiting for the operator to do
   //    it manually. Unconditionally reached even if step 6 threw (see above).
   await clearMaintenanceGate(courseId);
+
+  // 8. CHANGELOG (#738). Record the recreate — the most dramatic on-chain
+  //    mutation, and previously silent. Non-fatal and last: the course is
+  //    already up, restored, and the gate is cleared, so a changelog blip must
+  //    not affect any of that. create_course reset version to 1; lessonCount is
+  //    the live count preserved through the recreate (H3 never widens it).
+  try {
+    await recordCourseRecreated({
+      courseId,
+      txSignature: createSignature,
+      lessonCount: plan.createParams.lessonCount,
+    });
+  } catch (changelogErr) {
+    console.error(
+      `[recreate-course] ${courseId}: changelog write failed:`,
+      changelogErr
+    );
+  }
 
   return {
     action: "recreated",

--- a/apps/web/src/lib/content/__tests__/changelog-writes.test.ts
+++ b/apps/web/src/lib/content/__tests__/changelog-writes.test.ts
@@ -49,7 +49,14 @@ vi.mock("@/lib/content/store", () => ({
   ]),
 }));
 
-import { recordCourseDeployed, recordCourseUpdate } from "../changelog-writes";
+import {
+  recordCourseDeployed,
+  recordCourseUpdate,
+  recordCourseChange,
+  recordCourseDeactivated,
+  recordCourseReactivated,
+  recordCourseRecreated,
+} from "../changelog-writes";
 
 /** Build a single-word mask from a list of slot indices (all < 64). */
 function mask(...slots: number[]): bigint[] {
@@ -215,6 +222,85 @@ describe("recordCourseUpdate", () => {
         ...baseUpdate,
         oldMask: mask(0),
         newMask: mask(0, 1),
+      })
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe("#738 status + recreate recorders", () => {
+  it("recordCourseChange writes one row through the shared low-level seam", async () => {
+    await recordCourseChange({
+      courseId: "course-x",
+      kind: "deactivated",
+      version: 3,
+      txSignature: "SIG",
+    });
+    expect(lastTable).toBe("course_changelog");
+    expect(lastRows).toHaveLength(1);
+    expect(lastRows?.[0]).toMatchObject({
+      course_id: "course-x",
+      kind: "deactivated",
+      version: 3,
+      tx_signature: "SIG",
+      detail: {},
+    });
+    // Same idempotency contract as every other recorder.
+    expect(lastOptions).toEqual({
+      onConflict: "course_id,kind,tx_signature",
+      ignoreDuplicates: true,
+    });
+  });
+
+  it("recordCourseDeactivated logs a deactivated row at the current version", async () => {
+    await recordCourseDeactivated({
+      courseId: "course-x",
+      txSignature: "SIG_D",
+      version: 5,
+    });
+    expect(lastRows?.[0]).toMatchObject({
+      kind: "deactivated",
+      version: 5,
+      tx_signature: "SIG_D",
+      detail: {},
+    });
+  });
+
+  it("recordCourseReactivated logs a reactivated row at the current version", async () => {
+    await recordCourseReactivated({
+      courseId: "course-x",
+      txSignature: "SIG_R",
+      version: 5,
+    });
+    expect(lastRows?.[0]).toMatchObject({
+      kind: "reactivated",
+      version: 5,
+      tx_signature: "SIG_R",
+      detail: {},
+    });
+  });
+
+  it("recordCourseRecreated logs at version 1 with the preserved lesson count", async () => {
+    // create_course resets version to 1; lessonCount is the H3-preserved live count.
+    await recordCourseRecreated({
+      courseId: "course-x",
+      txSignature: "SIG_CREATE",
+      lessonCount: 7,
+    });
+    expect(lastRows?.[0]).toMatchObject({
+      kind: "recreated",
+      version: 1,
+      tx_signature: "SIG_CREATE",
+      detail: { lessonCount: 7 },
+    });
+  });
+
+  it("status recorders are non-fatal when the upsert errors", async () => {
+    upsertError = { message: "boom" };
+    await expect(
+      recordCourseDeactivated({
+        courseId: "course-x",
+        txSignature: "SIG",
+        version: 1,
       })
     ).resolves.toBeUndefined();
   });

--- a/apps/web/src/lib/content/changelog-writes.ts
+++ b/apps/web/src/lib/content/changelog-writes.ts
@@ -4,23 +4,37 @@ import { createAdminClient } from "@/lib/supabase/admin";
 import { lessonsById, slotsByCourseId } from "@/lib/content/store";
 import { diffMasks } from "@/lib/courses/changelog-diff";
 import type {
+  ChangelogKind,
   ChangelogLessonRef,
   DeployedDetail,
   LessonsDetail,
   XpChangedDetail,
   ContentUpdatedDetail,
+  RecreatedDetail,
 } from "@/lib/courses/changelog-types";
 import type { Json } from "@/lib/supabase/types";
 
 /**
  * Course changelog (#654) — WRITE seam.
  *
- * The admin sync route (`api/admin/courses/sync`) is the sole mutator of a
- * course's on-chain state, and at mutation time it already holds BOTH the prior
- * on-chain state (via `fetchCourse`) and the intended new state (the committed
- * slots.lock mask + xp). So the changelog is captured HERE, at mutation time,
- * not replayed from `CourseUpdated` events — the event carries only
- * version/collection/timestamp and cannot say which lesson slots moved.
+ * Every route that mutates a course's on-chain state records HERE, at mutation
+ * time — not replayed from `CourseUpdated` events (the event carries only
+ * version/collection/timestamp and cannot say which lesson slots moved). Each
+ * mutator holds both the prior on-chain state and the intended new state in the
+ * same call, which is what makes a meaningful diff possible. Coverage (#654 +
+ * #738):
+ *   - `api/admin/courses/sync`      → deployed / lessons_* / xp_changed /
+ *                                     content_updated   (recordCourseDeployed,
+ *                                     recordCourseUpdate)
+ *   - `api/admin/courses/deactivate`→ deactivated       (recordCourseDeactivated)
+ *   - `api/admin/courses/reactivate`→ reactivated       (recordCourseReactivated)
+ *   - `lib/admin/recreate-course`   → recreated         (recordCourseRecreated)
+ * All four go through {@link recordCourseChange} (the single low-level writer),
+ * so the fifth mutator added later has one obvious seam to call rather than a
+ * fresh inline supabase write. NOT logged, by design: the collection re-bind
+ * (`setCourseCollectionPda`) and recreate's internal `restoreAfterCreate`
+ * is_active restore — both are metadata plumbing / sub-steps of an operation
+ * already captured by its own entry, not independent learner-facing changes.
  *
  * Lesson titles are SNAPSHOTTED into `detail` at capture time (a changelog is an
  * immutable historical record; a retired lesson may later vanish from the
@@ -35,12 +49,7 @@ import type { Json } from "@/lib/supabase/types";
 
 type ChangelogInsert = {
   course_id: string;
-  kind:
-    | "deployed"
-    | "lessons_added"
-    | "lessons_removed"
-    | "xp_changed"
-    | "content_updated";
+  kind: ChangelogKind;
   version: number;
   detail: Json;
   tx_signature: string;
@@ -84,6 +93,32 @@ async function insertEntries(rows: ChangelogInsert[]): Promise<void> {
       `[changelog] insert failed for ${rows[0]?.course_id}: ${error.message}`
     );
   }
+}
+
+/**
+ * The single low-level writer every mutator records through (#738). One
+ * `(course, kind, tx)` row, idempotent, non-fatal. `recordCourseDeployed` /
+ * `recordCourseUpdate` build multiple rows in one call so they use
+ * `insertEntries` directly; the single-row status/recreate recorders below
+ * delegate here. Any future course mutator should call THIS rather than open a
+ * fresh inline supabase write — that is the invariant #738 is enforcing.
+ */
+export async function recordCourseChange(params: {
+  courseId: string;
+  kind: ChangelogKind;
+  version: number;
+  txSignature: string;
+  detail?: Json;
+}): Promise<void> {
+  await insertEntries([
+    {
+      course_id: params.courseId,
+      kind: params.kind,
+      version: params.version,
+      detail: params.detail ?? {},
+      tx_signature: params.txSignature,
+    },
+  ]);
 }
 
 /** Record a course's first on-chain deploy (create_course sets version = 1). */
@@ -186,4 +221,72 @@ export async function recordCourseUpdate(params: {
   }
 
   await insertEntries(rows);
+}
+
+/**
+ * Record a course deactivation (#738 — `api/admin/courses/deactivate`, the
+ * path #713 retires the five superseded courses with). Deactivate does not
+ * touch `content_tx_id`, so `version` is the course's CURRENT on-chain version,
+ * unchanged — the caller reads it and passes it in.
+ *
+ * VISIBILITY: this entry is written while the course is (about to be) inactive,
+ * and the #654 RLS policy scopes reads to synced+active courses — so it is
+ * recorded but not publicly readable until the course is reactivated (at which
+ * point the full deactivate→reactivate history becomes visible together). See
+ * the PR/issue #738 note on why surfacing a retired course's log to enrolled
+ * learners is deferred (it needs un-gating the course page, not just RLS).
+ */
+export async function recordCourseDeactivated(params: {
+  courseId: string;
+  txSignature: string;
+  version: number;
+}): Promise<void> {
+  await recordCourseChange({
+    courseId: params.courseId,
+    kind: "deactivated",
+    version: params.version,
+    txSignature: params.txSignature,
+  });
+}
+
+/**
+ * Record a course reactivation (#738 — `api/admin/courses/reactivate`). Mirror
+ * of {@link recordCourseDeactivated}; `version` is the current on-chain version
+ * (reactivate does not bump it). The course is synced+active afterward, so this
+ * entry — and any earlier `deactivated` one — is immediately readable.
+ */
+export async function recordCourseReactivated(params: {
+  courseId: string;
+  txSignature: string;
+  version: number;
+}): Promise<void> {
+  await recordCourseChange({
+    courseId: params.courseId,
+    kind: "reactivated",
+    version: params.version,
+    txSignature: params.txSignature,
+  });
+}
+
+/**
+ * Record a close+recreate (#738 — `lib/admin/recreate-course.ts`, WS-2). This
+ * is the most dramatic on-chain mutation: the Course PDA is closed and a fresh
+ * one created. `create_course` resets `version` to 1, so that is the post-
+ * recreate version. `lessonCount` is the live count preserved through the
+ * recreate (H3 never widens it). The entry is keyed on the CREATE signature.
+ * The course is synced+active afterward, so it is immediately readable.
+ */
+export async function recordCourseRecreated(params: {
+  courseId: string;
+  txSignature: string;
+  lessonCount: number;
+}): Promise<void> {
+  const detail: RecreatedDetail = { lessonCount: params.lessonCount };
+  await recordCourseChange({
+    courseId: params.courseId,
+    kind: "recreated",
+    version: 1,
+    txSignature: params.txSignature,
+    detail: detail as unknown as Json,
+  });
 }

--- a/apps/web/src/lib/courses/__tests__/changelog-read.test.ts
+++ b/apps/web/src/lib/courses/__tests__/changelog-read.test.ts
@@ -120,4 +120,41 @@ describe("getCourseChangelog", () => {
     rows = [];
     expect(await getCourseChangelog("course-x")).toEqual([]);
   });
+
+  it("decodes the #738 status + recreate kinds", async () => {
+    rows = [
+      {
+        id: 3,
+        kind: "reactivated",
+        version: 4,
+        detail: {},
+        tx_signature: "S3",
+        created_at: "2026-07-26T03:00:00Z",
+      },
+      {
+        id: 2,
+        kind: "recreated",
+        version: 1,
+        detail: { lessonCount: 7 },
+        tx_signature: "S2",
+        created_at: "2026-07-26T02:00:00Z",
+      },
+      {
+        id: 1,
+        kind: "deactivated",
+        version: 4,
+        detail: {},
+        tx_signature: "S1",
+        created_at: "2026-07-26T01:00:00Z",
+      },
+    ];
+    const entries = await getCourseChangelog("course-x");
+    expect(entries.map((e) => e.kind)).toEqual([
+      "reactivated",
+      "recreated",
+      "deactivated",
+    ]);
+    const recreated = entries.find((e) => e.kind === "recreated");
+    expect(recreated?.detail).toEqual({ lessonCount: 7 });
+  });
 });

--- a/apps/web/src/lib/courses/changelog-types.ts
+++ b/apps/web/src/lib/courses/changelog-types.ts
@@ -14,7 +14,11 @@ export type ChangelogKind =
   | "lessons_added"
   | "lessons_removed"
   | "xp_changed"
-  | "content_updated";
+  | "content_updated"
+  // #738 — the other on-chain course mutators, previously silent:
+  | "deactivated" // deactivate route (is_active → false; #713 retirement path)
+  | "reactivated" // reactivate route (is_active → true)
+  | "recreated"; // close + recreate (WS-2), the account rebuild
 
 /**
  * A lesson referenced by a changelog entry. `slot` is the permanent bit index
@@ -44,6 +48,12 @@ export interface ContentUpdatedDetail {
   /** The content bundle git SHA this re-sync pinned. */
   sha: string;
 }
+export interface RecreatedDetail {
+  /** Live lesson count preserved through the recreate (never widened — H3). */
+  lessonCount: number;
+}
+/** Status flips carry no payload — the kind + version + timestamp say it all. */
+export type StatusChangeDetail = Record<string, never>;
 
 interface EntryBase {
   id: number;
@@ -64,4 +74,7 @@ export type CourseChangelogEntry =
   | (EntryBase & { kind: "lessons_added"; detail: LessonsDetail })
   | (EntryBase & { kind: "lessons_removed"; detail: LessonsDetail })
   | (EntryBase & { kind: "xp_changed"; detail: XpChangedDetail })
-  | (EntryBase & { kind: "content_updated"; detail: ContentUpdatedDetail });
+  | (EntryBase & { kind: "content_updated"; detail: ContentUpdatedDetail })
+  | (EntryBase & { kind: "deactivated"; detail: StatusChangeDetail })
+  | (EntryBase & { kind: "reactivated"; detail: StatusChangeDetail })
+  | (EntryBase & { kind: "recreated"; detail: RecreatedDetail });

--- a/apps/web/src/lib/courses/changelog.ts
+++ b/apps/web/src/lib/courses/changelog.ts
@@ -79,6 +79,16 @@ function decodeEntry(row: {
         detail: { from: d.from, to: d.to },
       };
     }
+    case "deactivated":
+    case "reactivated": {
+      // Status flips carry no payload — the kind + version + timestamp say it all.
+      return { ...base, kind: row.kind, detail: {} };
+    }
+    case "recreated": {
+      const lessonCount =
+        isRecord(d) && typeof d.lessonCount === "number" ? d.lessonCount : 0;
+      return { ...base, kind: "recreated", detail: { lessonCount } };
+    }
     case "content_updated": {
       const sha = isRecord(d) && typeof d.sha === "string" ? d.sha : "";
       return { ...base, kind: "content_updated", detail: { sha } };

--- a/apps/web/src/lib/supabase/__tests__/course-changelog-status-kinds-guard.test.ts
+++ b/apps/web/src/lib/supabase/__tests__/course-changelog-status-kinds-guard.test.ts
@@ -1,0 +1,89 @@
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, it, expect } from "vitest";
+
+// #738: the status/recreate kinds migration widens course_changelog.kind's CHECK
+// so deactivate/reactivate/recreate can record. RLS can't be exercised in unit
+// tests, so pin the SQL invariants in BOTH the migration (what gets applied) and
+// the schema.sql mirror (the snapshot new environments are built from).
+
+function findRepoRoot(): string {
+  let dir = dirname(fileURLToPath(import.meta.url));
+  while (!existsSync(resolve(dir, "supabase/schema.sql"))) {
+    const parent = dirname(dir);
+    if (parent === dir)
+      throw new Error("repo root (supabase/schema.sql) not found");
+    dir = parent;
+  }
+  return dir;
+}
+
+const repoRoot = findRepoRoot();
+const migration = readFileSync(
+  resolve(
+    repoRoot,
+    "supabase/migrations/20260726220000_course_changelog_status_kinds.sql"
+  ),
+  "utf8"
+);
+const schema = readFileSync(resolve(repoRoot, "supabase/schema.sql"), "utf8");
+
+const NEW_KINDS = ["deactivated", "reactivated", "recreated"] as const;
+const ALL_KINDS = [
+  "deployed",
+  "lessons_added",
+  "lessons_removed",
+  "xp_changed",
+  "content_updated",
+  "deactivated",
+  "reactivated",
+  "recreated",
+] as const;
+
+describe("#738 course_changelog status kinds — migration", () => {
+  it("swaps the kind CHECK constraint idempotently (DROP IF EXISTS then ADD)", () => {
+    expect(migration).toContain(
+      "DROP CONSTRAINT IF EXISTS course_changelog_kind_check"
+    );
+    expect(migration).toContain(
+      "ADD CONSTRAINT course_changelog_kind_check CHECK (kind IN ("
+    );
+  });
+
+  it("lists all eight kinds in the new CHECK", () => {
+    for (const kind of ALL_KINDS) {
+      expect(migration).toContain(`'${kind}'`);
+    }
+  });
+
+  it("runs in one explicit transaction", () => {
+    expect(migration).toContain("BEGIN;");
+    expect(migration).toContain("COMMIT;");
+  });
+
+  it("ships a rollback that restores the five-kind CHECK", () => {
+    // The rollback block (commented) must re-add the constraint WITHOUT the new
+    // kinds — i.e. it drops the same constraint and re-adds the #654 five.
+    const rollback = migration.slice(migration.indexOf("-- ROLLBACK ("));
+    expect(rollback).toContain("course_changelog_kind_check");
+    for (const kind of NEW_KINDS) {
+      // The new kinds must NOT appear in the rollback's re-added CHECK.
+      expect(rollback).not.toContain(`'${kind}'`);
+    }
+  });
+});
+
+describe("#738 course_changelog status kinds — schema.sql mirror", () => {
+  it("the inline kind CHECK lists all eight kinds", () => {
+    // The snapshot table definition carries the final CHECK directly (no ALTER).
+    const start = schema.indexOf(
+      "CREATE TABLE IF NOT EXISTS public.course_changelog"
+    );
+    expect(start).toBeGreaterThan(-1);
+    const table = schema.slice(start, schema.indexOf(");", start));
+    for (const kind of ALL_KINDS) {
+      expect(table).toContain(`'${kind}'`);
+    }
+  });
+});

--- a/apps/web/src/lib/supabase/types.ts
+++ b/apps/web/src/lib/supabase/types.ts
@@ -1092,7 +1092,10 @@ export type Database = {
             | "lessons_added"
             | "lessons_removed"
             | "xp_changed"
-            | "content_updated";
+            | "content_updated"
+            | "deactivated"
+            | "reactivated"
+            | "recreated";
           version: number;
           detail: Json;
           tx_signature: string;
@@ -1106,7 +1109,10 @@ export type Database = {
             | "lessons_added"
             | "lessons_removed"
             | "xp_changed"
-            | "content_updated";
+            | "content_updated"
+            | "deactivated"
+            | "reactivated"
+            | "recreated";
           version: number;
           detail?: Json;
           tx_signature: string;
@@ -1120,7 +1126,10 @@ export type Database = {
             | "lessons_added"
             | "lessons_removed"
             | "xp_changed"
-            | "content_updated";
+            | "content_updated"
+            | "deactivated"
+            | "reactivated"
+            | "recreated";
           version?: number;
           detail?: Json;
           tx_signature?: string;

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -208,7 +208,13 @@
     "changelogXpChangedDetail": "XP per lesson changed from {from} to {to}.",
     "changelogContentUpdated": "Content updated",
     "changelogContentUpdatedDetail": "Lesson content was refreshed.",
-    "changelogLessonSlot": "Lesson slot {slot}"
+    "changelogLessonSlot": "Lesson slot {slot}",
+    "changelogDeactivated": "Course deactivated",
+    "changelogDeactivatedDetail": "This course was removed from the catalog.",
+    "changelogReactivated": "Course reactivated",
+    "changelogReactivatedDetail": "This course is available again.",
+    "changelogRecreated": "Course rebuilt on-chain",
+    "changelogRecreatedDetail": "The on-chain course account was recreated. Your progress and XP were preserved."
   },
   "lesson": {
     "content": "Content",

--- a/apps/web/src/messages/es.json
+++ b/apps/web/src/messages/es.json
@@ -208,7 +208,13 @@
     "changelogXpChangedDetail": "El XP por lección cambió de {from} a {to}.",
     "changelogContentUpdated": "Contenido actualizado",
     "changelogContentUpdatedDetail": "Se actualizó el contenido de las lecciones.",
-    "changelogLessonSlot": "Lección posición {slot}"
+    "changelogLessonSlot": "Lección posición {slot}",
+    "changelogDeactivated": "Curso desactivado",
+    "changelogDeactivatedDetail": "Este curso se retiró del catálogo.",
+    "changelogReactivated": "Curso reactivado",
+    "changelogReactivatedDetail": "Este curso vuelve a estar disponible.",
+    "changelogRecreated": "Curso reconstruido on-chain",
+    "changelogRecreatedDetail": "La cuenta on-chain del curso se recreó. Tu progreso y XP se conservaron."
   },
   "lesson": {
     "content": "Contenido",

--- a/apps/web/src/messages/pt-BR.json
+++ b/apps/web/src/messages/pt-BR.json
@@ -208,7 +208,13 @@
     "changelogXpChangedDetail": "O XP por lição mudou de {from} para {to}.",
     "changelogContentUpdated": "Conteúdo atualizado",
     "changelogContentUpdatedDetail": "O conteúdo das lições foi atualizado.",
-    "changelogLessonSlot": "Lição posição {slot}"
+    "changelogLessonSlot": "Lição posição {slot}",
+    "changelogDeactivated": "Curso desativado",
+    "changelogDeactivatedDetail": "Este curso foi removido do catálogo.",
+    "changelogReactivated": "Curso reativado",
+    "changelogReactivatedDetail": "Este curso está disponível novamente.",
+    "changelogRecreated": "Curso reconstruído on-chain",
+    "changelogRecreatedDetail": "A conta on-chain do curso foi recriada. Seu progresso e XP foram preservados."
   },
   "lesson": {
     "content": "Conteúdo",

--- a/supabase/migrations/20260726220000_course_changelog_status_kinds.sql
+++ b/supabase/migrations/20260726220000_course_changelog_status_kinds.sql
@@ -1,0 +1,62 @@
+-- ============================================================================
+-- Migration: course_changelog status/recreate kinds (#738)
+--
+-- #654 (20260726210000_course_changelog.sql) captured changelog entries only in
+-- the admin sync route, on the premise that it was "the sole mutator of a
+-- course's on-chain state". It was not: `api/admin/courses/deactivate`,
+-- `api/admin/courses/reactivate`, and the close+recreate
+-- (`lib/admin/recreate-course.ts`) also mutate on-chain course state and wrote
+-- nothing. This migration widens the `kind` CHECK so those mutators can record:
+--   * deactivated — is_active → false (the path #713 retires 5 courses with)
+--   * reactivated — is_active → true
+--   * recreated   — close_course + create_course (the account rebuild, WS-2)
+--
+-- The original CHECK was an inline column constraint, so Postgres named it
+-- `course_changelog_kind_check`. We DROP that (IF EXISTS) and re-ADD a
+-- same-named constraint listing all eight kinds — idempotent: re-running drops
+-- the constraint we just added and re-creates it identically.
+--
+-- No new columns, indexes, RLS, or policies: the #654 table shape, the
+-- fail-closed SELECT policy (synced+active only), and the service_role-only
+-- write model all stay exactly as they are. Deactivated entries are therefore
+-- written but not publicly readable until the course is reactivated — see the
+-- #738 discussion on why surfacing a retired course's log to enrolled learners
+-- is deferred (it needs un-gating the course page, not just the RLS).
+--
+-- Idempotent; explicit BEGIN/COMMIT. Tested ROLLBACK block at the bottom.
+-- Mirrored into supabase/schema.sql (the inline CHECK there now lists all eight).
+-- ============================================================================
+
+BEGIN;
+
+ALTER TABLE public.course_changelog
+  DROP CONSTRAINT IF EXISTS course_changelog_kind_check;
+
+ALTER TABLE public.course_changelog
+  ADD CONSTRAINT course_changelog_kind_check CHECK (kind IN (
+    'deployed',
+    'lessons_added',
+    'lessons_removed',
+    'xp_changed',
+    'content_updated',
+    'deactivated',
+    'reactivated',
+    'recreated'
+  ));
+
+COMMIT;
+
+-- ============================================================================
+-- ROLLBACK (tested; not executed by the migration runner)
+-- ----------------------------------------------------------------------------
+-- Reverts to the #654 five-kind CHECK. Safe only if no row uses a new kind.
+-- BEGIN;
+--   ALTER TABLE public.course_changelog
+--     DROP CONSTRAINT IF EXISTS course_changelog_kind_check;
+--   ALTER TABLE public.course_changelog
+--     ADD CONSTRAINT course_changelog_kind_check CHECK (kind IN (
+--       'deployed', 'lessons_added', 'lessons_removed', 'xp_changed',
+--       'content_updated'
+--     ));
+-- COMMIT;
+-- ============================================================================

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -2622,7 +2622,10 @@ CREATE TABLE IF NOT EXISTS public.course_changelog (
                  'lessons_added',
                  'lessons_removed',
                  'xp_changed',
-                 'content_updated'
+                 'content_updated',
+                 'deactivated',
+                 'reactivated',
+                 'recreated'
                )),
   version      INTEGER NOT NULL,
   detail       JSONB NOT NULL DEFAULT '{}'::jsonb,


### PR DESCRIPTION
Closes #738.

## What

#654 captured changelog entries only in `api/admin/courses/sync`, on the premise that it was "the sole mutator of a course's on-chain state". It was not. This PR extends the changelog to **every** on-chain course mutator, so post-deployment mutation is genuinely no longer silent.

## Mutator enumeration (every caller of the course-mutating signer fns)

| path | signer call | changelog |
|---|---|---|
| `api/admin/courses/sync` (deploy) | `deployCoursePda` | `deployed` (already, #654) |
| `api/admin/courses/sync` (update) | `updateCoursePda` | `lessons_added` / `lessons_removed` / `xp_changed` / `content_updated` (already, #654) |
| `api/admin/courses/deactivate` | `deactivateCoursePda` | **`deactivated` (NEW)** |
| `api/admin/courses/reactivate` | `updateCoursePda({newIsActive:true})` | **`reactivated` (NEW)** |
| `lib/admin/recreate-course` (via `api/admin/courses/recreate`) | `closeCoursePda` + `deployCoursePda` | **`recreated` (NEW)** |
| `sync` / `recreate` collection bind | `setCourseCollectionPda` | none — **by design** (Metaplex collection pointer plumbing, not a learner-facing course change) |
| `recreate` internal `restoreAfterCreate` | `updateCoursePda({newIsActive:false})` | none — **by design** (restores pre-close state as a sub-step of the recreate, already captured by the `recreated` entry) |

`api/lessons/complete` is not a mutator (the grep hit is a comment about `update_course.new_lesson_count`).

## Design — extends #654, does not replace it

- **Shared `recordCourseChange` seam.** All recorders delegate to one low-level writer, so the next mutator added has one obvious call site rather than a fresh inline supabase write (the exact repeat the issue warns about).
- **Three new kinds** via migration `20260726220000_course_changelog_status_kinds.sql`: an idempotent CHECK-constraint swap (DROP IF EXISTS + ADD, BEGIN/COMMIT, tested rollback), the `schema.sql` inline CHECK now lists all eight, plus supabase types + a guard test.
- **Non-fatal service_role write-back** in each mutator, matching #654. Status flips don't bump `version`, so the routes read the current on-chain version and skip the entry if it can't be read (never log a wrong version). Recreate records `version = 1` (create resets it) with the H3-preserved `lessonCount`, keyed on the create signature, recorded **last** — after the course is up, restored, and the maintenance gate is cleared.
- **i18n** en/es/pt-BR + component rendering (icons/title/body) for all three new kinds.

## RLS / surfacing decision (the issue's "Also worth deciding")

The #654 fail-closed policy (`status='synced' AND COALESCE(is_active,true)`) is **unchanged**. Consequence: a `deactivated` entry is written but not publicly readable while the course is inactive — it becomes visible again if the course is reactivated (the deactivate→reactivate history then shows together). `reactivated` and `recreated` land on synced+active courses, so they are immediately visible (the high-value cases).

Surfacing a **retired** course's log to enrolled learners is **intentionally deferred**: it requires un-gating the deactivated-course *page* (which 404s today via the catalog `isSynced` gate), not just the RLS. An RLS carve-out alone would be dead code — there is no surface to render it on. That un-gating is #713 / visibility-policy scope. The write side is complete regardless (full audit trail; visible on reactivation).

## Verification

`pnpm install --frozen-lockfile && pnpm typecheck && pnpm --filter web test` — all green.
- typecheck: 6/6 packages
- **web suite: 205 files, 1882 tests pass**

New/updated tests: shared-seam + three recorders (incl. non-fatal), read-decode of the new kinds, component rendering, the new migration guard (CHECK swap + rollback + 8-kind schema mirror), and recreate wiring (records **last**, full call-ordering assertion).

Do not merge — for review.
