### PR TITLE
fix(courses): log the changelog version-unreadable skip (#752 review MINOR)

### DIFF
--- a/apps/web/src/app/api/admin/courses/deactivate/route.ts
+++ b/apps/web/src/app/api/admin/courses/deactivate/route.ts
@@ -87,6 +87,12 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
           txSignature: result.signature,
           version: onChain.version,
         });
+      } else {
+        // #731 honesty standard: skipping (to avoid logging a wrong version)
+        // must itself be visible — a silent miss is an invisible audit gap.
+        console.warn(
+          `[course-changelog] ${courseId}: 'deactivated' entry SKIPPED — on-chain course unreadable after mutation (tx ${result.signature})`
+        );
       }
     } catch (changelogErr) {
       console.error(

--- a/apps/web/src/app/api/admin/courses/reactivate/route.ts
+++ b/apps/web/src/app/api/admin/courses/reactivate/route.ts
@@ -83,6 +83,12 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
           txSignature: result.signature,
           version: onChain.version,
         });
+      } else {
+        // #731 honesty standard: skipping (to avoid logging a wrong version)
+        // must itself be visible — a silent miss is an invisible audit gap.
+        console.warn(
+          `[course-changelog] ${courseId}: 'reactivated' entry SKIPPED — on-chain course unreadable after mutation (tx ${result.signature})`
+        );
       }
     } catch (changelogErr) {
       console.error(


### PR DESCRIPTION
Post-merge follow-up to #752 (the gate merged before the adversarial round-trip completed — findings land here per the branch-lifecycle rule).

**Adversarial review of #752 was PASS** with one MINOR: in the deactivate/reactivate routes, when `fetchCourse` returns null after a landed mutation, the changelog entry is skipped to avoid recording a wrong version (correct call) — but the skip itself was SILENT: no changelog row AND no trace. Per the #731 honesty standard (a silent miss is an invisible audit gap), the `else` now emits a `console.warn` naming the course, the skipped kind, and the tx signature. `recreate-course` already logged its failures loudly — these two routes now match.

Two-line-per-route change, no behavior delta on the happy path. Verified: typecheck exit 0, admin route tests 51/51.

Full #752 adversarial record (enumeration exhaustiveness verified independently, migration CHECK-swap proven atomic under ACCESS EXCLUSIVE, RLS invisibility semantics confirmed live-evaluated, guard mutation-tested) is on the #752 thread.