### PR TITLE
ci(review): re-run claude-review on push/label for needs-gate PRs (#710)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,18 +2,36 @@ name: Claude Code Review
 
 on:
   pull_request:
-    # Cost: review on open / ready / reopen — NOT on every `synchronize` (every push),
-    # which re-reviews a PR on each commit and burns the OAuth-token budget. Re-trigger a
-    # fresh review by commenting `@claude review` (claude.yml) or reopening.
-    types: [opened, ready_for_review, reopened]
+    # Every PR is reviewed on open / ready / reopen. Additionally — and ONLY for PRs
+    # carrying `needs-gate` — re-review on every push (`synchronize`) and when the
+    # label is first applied (`labeled`). This closes the #710 race: the orchestrator
+    # pushes hardening commits after the review has started, so the review reported on
+    # a head that no longer existed (and 3 of 5 stale reviews missed the security-
+    # relevant commit). Scoping the push re-review to needs-gate keeps the OAuth-token
+    # cost off every ordinary PR push; the `if:` below enforces the scope, and the
+    # concurrency group cancels an in-flight review the moment a newer head arrives so
+    # a stale verdict can never post.
+    types: [opened, ready_for_review, reopened, synchronize, labeled]
+
+# One review per PR at a time; a newer head cancels the older review in flight (the
+# mechanical core of the #710 fix — the pre-fix head's review is superseded, never
+# posted as if current). Keyed on PR number so PRs don't cancel each other.
+concurrency:
+  group: claude-code-review-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # opened/ready/reopened review any PR (unchanged). synchronize + labeled fire for
+    # every PR but are admitted here only for needs-gate, so a fresh-head review is
+    # guaranteed both when the PR is queued (label added) and on each subsequent push,
+    # without re-reviewing every push of every PR.
+    if: >-
+      github.event.action == 'opened' ||
+      github.event.action == 'ready_for_review' ||
+      github.event.action == 'reopened' ||
+      (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'needs-gate')) ||
+      (github.event.action == 'labeled' && github.event.label.name == 'needs-gate')
 
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
Closes #710 (mechanical half).

## Problem

The `claude[bot]` review fires on open/ready/reopen and takes 2–4 min. The orchestrator pushes hardening commits inside that window, so the review reports on a head that no longer exists — **5 stale reviews in one night, 3 of them missing the security-relevant commit** (#710). GitHub still shows a green `claude-review` check, because the check means "the action ran", not "the action reviewed this head".

The behavioral half (re-request via `@claude` after a fix push) is already adopted per the orchestrator's ack on the issue. This PR is the **mechanical** half the maintainer offered there.

## Change (one file: `.github/workflows/claude-code-review.yml`)

1. **Trigger on `synchronize` + `labeled`**, in addition to `opened/ready_for_review/reopened`.
2. **Job-level `if:` scopes the two new events to `needs-gate` PRs only** — `synchronize` re-reviews only when the PR carries `needs-gate`; `labeled` fires only when the label added *is* `needs-gate`. Ordinary PR pushes still don't trigger a review, so the OAuth-token budget is unaffected. Open/ready/reopen behavior is unchanged for every PR.
3. **Per-PR `concurrency` group with `cancel-in-progress: true`.** This is the core: when a newer head arrives mid-review, the in-flight review of the stale head is cancelled and superseded, so a verdict for a superseded commit can never post. Keyed on `github.event.pull_request.number` so PRs don't cancel each other.

### Resulting flow for a gated PR
Queue it (`needs-gate` added) → `labeled` fires a fresh review at the current head. Push a hardening commit → `synchronize` cancels any in-flight review and reviews the new head. The review a human reads always describes the head they're about to merge.

## Why this is safe / minimally scoped

- **No cost storm:** the push re-review is gated to `needs-gate`; non-gated PRs are untouched.
- **Cancelled runs don't block merges:** `claude-review` is advisory, not a required status check. I verified the required checks on `main` are `Frontend (lint · typecheck · test)`, `On-chain (fmt · clippy · cargo test)`, and `SHA-pin guard` — `claude-review` is not among them.
- **No new/changed actions:** both `actions/checkout` and `anthropics/claude-code-action` remain SHA-pinned (the SHA-pin guard passes on this branch).

## Verification (what I actually ran; workflow behavior itself cannot be exercised locally — stated honestly)

- **`actionlint .github/workflows/claude-code-review.yml` → clean.** Validates the `on:` filter, the `if:` expression (including `contains(github.event.pull_request.labels.*.name, …)`), and the `concurrency` block.
- **`scripts/check-action-pins.sh` → green** (8 files) — all `uses:` still SHA-pinned.
- **`python3 yaml.safe_load` → parses**, and the folded `if:` resolves to a single clean expression line.
- Confirmed `needs-gate` label exists in the repo (`gh label list`).
- The runtime trigger/cancel semantics (does `synchronize` actually cancel the stale run, does the `labeled` filter admit only `needs-gate`) can only be observed on live PR events on `main` — cannot be simulated locally.

> SENSITIVE (`.github/workflows/**`) — do not merge without adversarial review + gate.
