### PR TITLE
fix(onchain): map program error codes 6031-6036 + i18n (#607, code half)

### DIFF
--- a/apps/web/src/lib/solana/__tests__/program-errors.test.ts
+++ b/apps/web/src/lib/solana/__tests__/program-errors.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from "vitest";
+import { parseProgramError } from "../program-errors";
+import idl from "../idl/superteam_academy.json";
+import en from "../../../messages/en.json";
+import ptBR from "../../../messages/pt-BR.json";
+import es from "../../../messages/es.json";
+
+const idlErrors = (idl as { errors: { code: number; name: string }[] }).errors;
+const locales = { en, "pt-BR": ptBR, es } as const;
+
+/** Format a custom program error string the way RPC simulation surfaces it. */
+const hex = (code: number) => `custom program error: 0x${code.toString(16)}`;
+
+describe("parseProgramError — newly added codes (6031–6036)", () => {
+  const added: [number, string, string][] = [
+    [6031, "MintingPaused", "mintingPaused"],
+    [6032, "WrongXpMint", "wrongXpMint"],
+    [6033, "XpAmountExceedsMax", "xpAmountExceedsMax"],
+    [6034, "StaleEnrollment", "staleEnrollment"],
+    [6035, "OldMinterRoleMissing", "oldMinterRoleMissing"],
+    [6036, "EnrollmentInProgress", "enrollmentInProgress"],
+  ];
+
+  it.each(added)("maps hex code for %i → %s", (code, name, i18nKey) => {
+    const parsed = parseProgramError(new Error(hex(code)));
+    expect(parsed.code).toBe(code);
+    expect(parsed.name).toBe(name);
+    expect(parsed.i18nKey).toBe(i18nKey);
+    expect(parsed.fallback.length).toBeGreaterThan(0);
+    expect(parsed.fallback).not.toContain("0x");
+  });
+
+  it.each(added)("maps error name for %i (%s)", (_code, name, i18nKey) => {
+    const parsed = parseProgramError(new Error(`Something failed: ${name}`));
+    expect(parsed.name).toBe(name);
+    expect(parsed.i18nKey).toBe(i18nKey);
+  });
+});
+
+describe("parseProgramError — unknown-code fallback", () => {
+  it("preserves an unmapped custom code and returns the raw message", () => {
+    const parsed = parseProgramError(new Error("custom program error: 0x270f")); // 9999
+    expect(parsed.code).toBe(9999);
+    expect(parsed.name).toBeNull();
+    expect(parsed.i18nKey).toBeNull();
+    expect(parsed.fallback).toContain("0x270f");
+  });
+
+  it("returns the raw message when nothing matches", () => {
+    const parsed = parseProgramError(new Error("blockhash not found"));
+    expect(parsed.code).toBeNull();
+    expect(parsed.name).toBeNull();
+    expect(parsed.i18nKey).toBeNull();
+    expect(parsed.fallback).toBe("blockhash not found");
+  });
+});
+
+describe("parseProgramError — existing mappings unchanged", () => {
+  it.each([
+    [6008, "UnenrollCooldown", "unenrollCooldown"],
+    [6000, "Unauthorized", "unauthorized"],
+    [6030, "InvalidCourseAccount", "invalidCourseAccount"],
+  ])("code %i still maps to %s", (code, name, i18nKey) => {
+    const parsed = parseProgramError(new Error(hex(code)));
+    expect(parsed.name).toBe(name);
+    expect(parsed.i18nKey).toBe(i18nKey);
+  });
+});
+
+describe("program-errors ↔ IDL ↔ i18n parity", () => {
+  it("every IDL error code resolves to a mapped entry", () => {
+    for (const { code, name } of idlErrors) {
+      const parsed = parseProgramError(new Error(hex(code)));
+      expect(parsed.name, `code ${code} (${name}) is unmapped`).toBe(name);
+      expect(
+        parsed.i18nKey,
+        `code ${code} (${name}) has no i18nKey`
+      ).not.toBeNull();
+    }
+  });
+
+  it("every mapped i18nKey has a string in all three locales", () => {
+    for (const { code } of idlErrors) {
+      const { i18nKey } = parseProgramError(new Error(hex(code)));
+      if (!i18nKey) continue;
+      for (const [name, msgs] of Object.entries(locales)) {
+        const value = (msgs as { programErrors: Record<string, string> })
+          .programErrors[i18nKey];
+        expect(
+          typeof value === "string" && value.length > 0,
+          `${name} is missing programErrors.${i18nKey}`
+        ).toBe(true);
+      }
+    }
+  });
+});

--- a/apps/web/src/lib/solana/program-errors.ts
+++ b/apps/web/src/lib/solana/program-errors.ts
@@ -4,8 +4,10 @@ import type { PublicKey } from "@solana/web3.js";
 /**
  * Centralized map of on-chain AcademyError codes → i18n keys.
  *
- * Anchor assigns codes starting at 6000 + enum index.
- * See: onchain-academy/programs/onchain-academy/src/errors.rs
+ * Codes start at 6000 + enum index (Anchor convention; the live Pinocchio
+ * program emits wire-compatible custom errors and log lines).
+ * See: onchain-academy/programs/onchain-academy-pinocchio/src/errors.rs
+ * and the `errors` table in idl/superteam_academy.json (kept in sync).
  *
  * Each entry maps to a key under the "programErrors" i18n namespace.
  * Components with `t()` use `t("programErrors.<key>")`;
@@ -174,6 +176,38 @@ const ERROR_MAP: Record<number, ProgramErrorEntry> = {
     name: "InvalidCourseAccount",
     i18nKey: "invalidCourseAccount",
     fallback: "Account is not a valid course.",
+  },
+  6031: {
+    name: "MintingPaused",
+    i18nKey: "mintingPaused",
+    fallback: "XP minting is currently paused. Please try again later.",
+  },
+  6032: {
+    name: "WrongXpMint",
+    i18nKey: "wrongXpMint",
+    fallback: "Your token account does not match the current XP mint.",
+  },
+  6033: {
+    name: "XpAmountExceedsMax",
+    i18nKey: "xpAmountExceedsMax",
+    fallback: "XP amount exceeds the per-mint ceiling.",
+  },
+  6034: {
+    name: "StaleEnrollment",
+    i18nKey: "staleEnrollment",
+    fallback:
+      "This enrollment belongs to an older version of the course. Please re-enroll to continue.",
+  },
+  6035: {
+    name: "OldMinterRoleMissing",
+    i18nKey: "oldMinterRoleMissing",
+    fallback:
+      "Backend rotation requires the previous backend minter role account.",
+  },
+  6036: {
+    name: "EnrollmentInProgress",
+    i18nKey: "enrollmentInProgress",
+    fallback: "An enrollment with completed lessons cannot be closed.",
   },
 };
 

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -820,6 +820,12 @@
     "invalidXpReward": "XP reward must be greater than zero.",
     "enrollmentFinalized": "This enrollment is finalized and can no longer be unenrolled or closed.",
     "invalidCourseAccount": "Account is not a valid course.",
+    "mintingPaused": "XP minting is currently paused. Please try again later.",
+    "wrongXpMint": "Your token account does not match the current XP mint.",
+    "xpAmountExceedsMax": "XP amount exceeds the per-mint ceiling.",
+    "staleEnrollment": "This enrollment belongs to an older version of the course. Please re-enroll to continue.",
+    "oldMinterRoleMissing": "Backend rotation requires the previous backend minter role account.",
+    "enrollmentInProgress": "An enrollment with completed lessons cannot be closed.",
     "unknown": "Transaction failed. Please try again."
   },
   "community": {

--- a/apps/web/src/messages/es.json
+++ b/apps/web/src/messages/es.json
@@ -820,6 +820,12 @@
     "invalidXpReward": "La recompensa de XP debe ser mayor que cero.",
     "enrollmentFinalized": "Esta inscripción está finalizada y ya no se puede cancelar ni cerrar.",
     "invalidCourseAccount": "La cuenta no es un curso válido.",
+    "mintingPaused": "La emisión de XP está pausada actualmente. Inténtalo de nuevo más tarde.",
+    "wrongXpMint": "Tu cuenta de token no coincide con el mint de XP actual.",
+    "xpAmountExceedsMax": "La cantidad de XP excede el límite máximo por emisión.",
+    "staleEnrollment": "Esta inscripción pertenece a una versión anterior del curso. Vuelve a inscribirte para continuar.",
+    "oldMinterRoleMissing": "La rotación de backend requiere la cuenta anterior del rol de minter del backend.",
+    "enrollmentInProgress": "Una inscripción con lecciones completadas no se puede cerrar.",
     "unknown": "La transacción falló. Inténtalo de nuevo."
   },
   "community": {

--- a/apps/web/src/messages/pt-BR.json
+++ b/apps/web/src/messages/pt-BR.json
@@ -820,6 +820,12 @@
     "invalidXpReward": "A recompensa de XP deve ser maior que zero.",
     "enrollmentFinalized": "Esta inscrição foi finalizada e não pode mais ser cancelada ou encerrada.",
     "invalidCourseAccount": "A conta não é um curso válido.",
+    "mintingPaused": "A emissão de XP está pausada no momento. Tente novamente mais tarde.",
+    "wrongXpMint": "Sua conta de token não corresponde ao mint de XP atual.",
+    "xpAmountExceedsMax": "A quantidade de XP excede o limite máximo por emissão.",
+    "staleEnrollment": "Esta matrícula pertence a uma versão anterior do curso. Matricule-se novamente para continuar.",
+    "oldMinterRoleMissing": "A rotação de backend requer a conta anterior de papel de minter do backend.",
+    "enrollmentInProgress": "Uma matrícula com aulas concluídas não pode ser encerrada.",
     "unknown": "Transação falhou. Tente novamente."
   },
   "community": {


### PR DESCRIPTION
Closes the **code half** of #607 (P0). The migration half is deliberately deferred until dry-run counts are posted on the issue.

## What
`apps/web/src/lib/solana/program-errors.ts` stopped at code **6030** (31 entries), but the live Pinocchio program and the IDL define codes through **6036**. Any learner hitting 6031–6036 saw a raw unmapped `custom program error: 0x…` instead of a localized message. The most launch-relevant is **6034 `StaleEnrollment`** — the exact error a learner on the stranded `7NeJa` instance hits after the move to `Dsro2Cd9`.

Adds the six missing entries + en/pt-BR/es i18n strings:

| Code | Name | i18nKey |
|------|------|---------|
| 6031 | MintingPaused | `mintingPaused` |
| 6032 | WrongXpMint | `wrongXpMint` |
| 6033 | XpAmountExceedsMax | `xpAmountExceedsMax` |
| 6034 | StaleEnrollment | `staleEnrollment` |
| 6035 | OldMinterRoleMissing | `oldMinterRoleMissing` |
| 6036 | EnrollmentInProgress | `enrollmentInProgress` |

## Scope correction vs. the issue
The issue says "33 entries spanning 6000-6032, missing 6034/6035/6036." The file on `main` actually has **31** entries (6000-6030) and is missing **six** codes (6031-6036), not three. 6031/6032/6033 (`MintingPaused`, `WrongXpMint`, `XpAmountExceedsMax`) were also unmapped, so fixing only 6034-6036 would still leave those surfacing raw errors. This PR maps all six for full IDL parity.

## Source-of-truth trace
No drift found between the three definitions — the fix only re-syncs the stale **client** map:
- **Program enum:** `onchain-academy/programs/onchain-academy-pinocchio/src/errors.rs` — `AcademyError` variants 31–36 (`MintingPaused`…`EnrollmentInProgress`), custom code = `6000 + ordinal`.
- **`ACADEMY_LOGS` table** (same file) — pre-baked `Error Number: 603x` log lines, names/numbers/messages "match the IDL errors table verbatim."
- **IDL:** `apps/web/src/lib/solana/idl/superteam_academy.json` `errors[]` — already contains all 37 codes (6000-6036). **The IDL was not stale and was not touched** (respecting #449: no account layouts modified; the `errors` table is independent of the decoder's layout concern anyway).

English fallbacks are user-friendly paraphrases of the IDL `msg`, matching the existing entry style; i18nKeys follow the existing camelCase convention. Consumers use `parsed.i18nKey ? t(parsed.i18nKey) : parsed.fallback`, so both surfaces are covered.

## Tests
New `apps/web/src/lib/solana/__tests__/program-errors.test.ts` (19 tests):
- the six new codes map (hex + error-name paths)
- unknown-code fallback still returns the raw message with the code preserved
- existing mappings (6000, 6008, 6030) unchanged
- **parity guard:** every IDL error code resolves to a mapped entry **and** has a non-empty string in all three locales — this fails CI if the map drifts from the IDL again.

## Verification
```
pnpm install --frozen-lockfile   # ok
pnpm typecheck                    # 6 successful, 6 total
pnpm --filter web test            # Test Files 210 passed (210) · Tests 1922 passed (1922)
```

Code half of #607; migration half follows the posted dry-run counts.
