### PR TITLE
fix(content-lint): resolve a slashed base branch instead of hard-failing CI (#748)

### DIFF
--- a/packages/content-lint/src/__tests__/base-ref.test.ts
+++ b/packages/content-lint/src/__tests__/base-ref.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from "vitest";
+import { execFileSync } from "node:child_process";
+import { runLint } from "../lint";
+import "../checks/gate1-schema";
+import "../checks/gate3-slots";
+import { normalizeBaseRef } from "../base-ref";
+import { makeTempRepo } from "./helpers";
+
+const course = `id: course-x
+slug: x
+title: X
+difficulty: beginner
+duration: 1
+xpPerLesson: 10
+xpReward: 100
+modules: [{ key: m, title: M, lessons: [lesson-a, lesson-b] }]
+`;
+const lesson = (id: string) => `id: ${id}
+slug: ${id.replace("lesson-", "")}
+title: ${id}
+blocks: [{ type: prose, key: intro, src: intro.md }]
+`;
+const lock = JSON.stringify({
+  version: 1,
+  slots: { "lesson-a": 0, "lesson-b": 1 },
+  retired: [],
+  next: 2,
+});
+
+/**
+ * A committed repo whose base branch is reachable both as a bare-named remote
+ * branch (`origin/release/1.0`) and as the default `origin/main`.
+ */
+function repoWithBranches(): string {
+  const root = makeTempRepo({
+    "courses/x/course.yaml": course,
+    "courses/x/slots.lock.json": lock,
+    "courses/x/lessons/a/lesson.yaml": lesson("lesson-a"),
+    "courses/x/lessons/a/intro.md": "# a",
+    "courses/x/lessons/b/lesson.yaml": lesson("lesson-b"),
+    "courses/x/lessons/b/intro.md": "# b",
+  });
+  const git = (...args: string[]) =>
+    execFileSync("git", args, { cwd: root, stdio: "ignore" });
+  git("init", "-q");
+  git("config", "user.email", "t@t.t");
+  git("config", "user.name", "t");
+  git("add", "-A");
+  git("commit", "-qm", "c1");
+  git("branch", "-M", "main");
+  // Remote-tracking refs, as a fetch-depth:0 checkout would have.
+  git("update-ref", "refs/remotes/origin/main", "main");
+  git("update-ref", "refs/remotes/origin/release/1.0", "main");
+  return root;
+}
+
+describe("normalizeBaseRef (#748)", () => {
+  it("prefixes origin/ onto a bare branch name WITH a slash", () => {
+    const root = repoWithBranches();
+    expect(normalizeBaseRef("release/1.0", root)).toBe("origin/release/1.0");
+  });
+
+  it("prefixes origin/ onto a plain bare branch name (unchanged behavior)", () => {
+    const root = repoWithBranches();
+    expect(normalizeBaseRef("main", root)).toBe("origin/main");
+  });
+
+  it("passes an already origin-qualified ref through verbatim", () => {
+    const root = repoWithBranches();
+    expect(normalizeBaseRef("origin/main", root)).toBe("origin/main");
+  });
+
+  it("passes a full-SHA base through verbatim", () => {
+    const root = repoWithBranches();
+    const sha = execFileSync("git", ["rev-parse", "HEAD"], { cwd: root })
+      .toString()
+      .trim();
+    expect(normalizeBaseRef(sha, root)).toBe(sha);
+  });
+
+  it("returns undefined for no ref (bare local run)", () => {
+    const root = repoWithBranches();
+    expect(normalizeBaseRef(undefined, root)).toBeUndefined();
+  });
+
+  it("keeps #747 fail-closed for a genuinely unresolvable slashed ref", () => {
+    const root = repoWithBranches();
+    // origin/release/9.9 does not exist; must NOT silently pass — it stays
+    // origin-qualified so the gate's hard error names it (never bare/verbatim).
+    expect(normalizeBaseRef("release/9.9", root)).toBe("origin/release/9.9");
+  });
+
+  it("resolves a slashed base end-to-end: gate-3 runs (no misconfiguration error)", async () => {
+    const root = repoWithBranches();
+    const baseRef = normalizeBaseRef("release/1.0", root);
+    const r = await runLint(root, { baseRef });
+    expect(
+      r.diagnostics.filter((d) => d.gate === "gate-3" && d.severity === "error")
+    ).toEqual([]);
+  });
+
+  it("a genuinely unresolvable base still fails CLOSED end-to-end (#747 message)", async () => {
+    const root = repoWithBranches();
+    const baseRef = normalizeBaseRef("release/9.9", root); // origin/release/9.9
+    const r = await runLint(root, { baseRef });
+    expect(
+      r.diagnostics.some(
+        (d) =>
+          d.gate === "gate-3" &&
+          d.severity === "error" &&
+          /misconfiguration/i.test(d.message)
+      )
+    ).toBe(true);
+  });
+});

--- a/packages/content-lint/src/base-ref.ts
+++ b/packages/content-lint/src/base-ref.ts
@@ -1,0 +1,37 @@
+import { resolvesRef } from "./git";
+
+/**
+ * Map a raw base ref (`GITHUB_BASE_REF` / `LINT_BASE_REF`) to a ref that resolves
+ * in the linter's checkout.
+ *
+ * `github.base_ref` is a BARE branch name — usually "main", but also "release/1.0"
+ * or "hotfix/x". In the content-lint checkout the base branch lives under
+ * `origin/`, so a bare name must be prefixed with `origin/` REGARDLESS of any slash
+ * it contains. The previous `raw.includes("/")` proxy for "already qualified" left
+ * a slashed branch name verbatim, so it never resolved — and post-#747 an
+ * explicit-but-unresolvable base is a HARD CI failure, so every content PR against
+ * a slashed base branch would red-wall (#748).
+ *
+ * Resolution order:
+ *   1. Already remote-/fully-qualified (`origin/…`, `refs/…`) → verbatim.
+ *   2. Bare branch name → `origin/<raw>` when that resolves (the #748 fix; also
+ *      preserves the old "main" → "origin/main" target for the no-slash case).
+ *   3. Otherwise a SHA or local ref that resolves as-is → verbatim.
+ *   4. Nothing resolves → return the `origin/`-qualified form so the downstream
+ *      gate's #747 hard error names the ref CI meant to fetch. A genuinely bogus
+ *      ref still ERRORs; this never silently fails open.
+ *
+ * Only two candidates are ever tried (`origin/<raw>`, then `<raw>`), so an
+ * unresolvable ref cannot accidentally match some unrelated object.
+ */
+export function normalizeBaseRef(
+  raw: string | undefined,
+  root: string
+): string | undefined {
+  if (!raw) return undefined;
+  if (raw.startsWith("origin/") || raw.startsWith("refs/")) return raw;
+  const prefixed = `origin/${raw}`;
+  if (resolvesRef(root, prefixed)) return prefixed;
+  if (resolvesRef(root, raw)) return raw;
+  return prefixed;
+}

--- a/packages/content-lint/src/cli.ts
+++ b/packages/content-lint/src/cli.ts
@@ -1,15 +1,10 @@
 import { runLint } from "./lint";
+import { normalizeBaseRef } from "./base-ref";
 import type { Diagnostic } from "./diagnostics";
 // Side-effect import: running `./index` executes every check module's top-level
 // `registerCheck` / `registerSchemaCheck`, so the CLI lints with all gates
 // registered (without it, no gate runs and every repo trivially "passes").
 import "./index";
-
-function normalizeBaseRef(raw: string | undefined): string | undefined {
-  if (!raw) return undefined;
-  // GITHUB_BASE_REF is a bare branch name ("main"); a full ref is used verbatim.
-  return raw.includes("/") ? raw : `origin/${raw}`;
-}
 
 function format(d: Diagnostic): string {
   const where = d.file ? ` ${d.file}` : "";
@@ -19,7 +14,8 @@ function format(d: Diagnostic): string {
 async function main(): Promise<void> {
   const root = process.argv[2] ?? process.cwd();
   const baseRef = normalizeBaseRef(
-    process.env.LINT_BASE_REF ?? process.env.GITHUB_BASE_REF
+    process.env.LINT_BASE_REF ?? process.env.GITHUB_BASE_REF,
+    root
   );
   const { diagnostics, ok } = await runLint(root, { baseRef });
 

--- a/packages/content-lint/src/git.ts
+++ b/packages/content-lint/src/git.ts
@@ -63,6 +63,13 @@ export function resolveLocalBase(root: string): string | null {
   return null;
 }
 
+/** True when `ref` resolves to a commit object in `root`. */
+export function resolvesRef(root: string, ref: string): boolean {
+  return (
+    git(root, ["rev-parse", "--verify", "--quiet", `${ref}^{commit}`]) !== null
+  );
+}
+
 /** File contents at `ref`, or null when the path did not exist there. */
 export function gitShow(
   root: string,


### PR DESCRIPTION
Fixes #748.

## Problem
`packages/content-lint/src/cli.ts` `normalizeBaseRef` added the `origin/` prefix only when the raw ref had **no** slash:
```ts
return raw.includes("/") ? raw : `origin/${raw}`;
```
`github.base_ref` is a **bare branch name**. For `main` that becomes `origin/main` and resolves. But a base branch whose own name contains a slash — `release/1.0`, `hotfix/x` — arrives verbatim and is used as-is, so it never resolves in the linter's checkout. **#747 raised the stakes:** an explicit-but-unresolvable base is now a HARD CI failure (fail-closed), so the first content PR targeting a slashed base branch would red-wall outright. Not live today (default branch is `main`) but latent.

## Fix
Decide "already qualified" by a leading `origin/` / `refs/` (or by actual resolution), not by the presence of any slash. `normalizeBaseRef` now:
1. `origin/…` / `refs/…` → verbatim (already qualified).
2. bare branch name → `origin/<raw>` when that resolves — **regardless of embedded slashes** (the fix); this also preserves the old `main` → `origin/main` target.
3. otherwise a SHA / local ref that resolves as-is → verbatim (the old code actually mis-prefixed a no-slash SHA to `origin/<sha>`; now handled correctly).
4. nothing resolves → return the `origin/`-qualified form so #747's hard error names the ref CI meant to fetch.

**#747 fail-closed is intact:** only two candidates are ever tried (`origin/<raw>`, then `<raw>`), so a genuinely bogus ref matches neither and still ERRORs — it never silently passes.

`normalizeBaseRef` was extracted into `base-ref.ts` (cli.ts self-runs `main()` on import, so it can't be imported for unit tests) and a small `resolvesRef` helper added to `git.ts`.

## Tests (`__tests__/base-ref.test.ts`, 8)
- slashed bare branch `release/1.0` → `origin/release/1.0`
- plain bare `main` → `origin/main` (unchanged)
- already-qualified `origin/main` → verbatim
- full SHA → verbatim
- `undefined` → `undefined`
- genuinely unresolvable `release/9.9` → stays `origin/release/9.9` (never bare) — fail-closed
- end-to-end: a slashed base resolves and gate-3 runs with no misconfiguration error
- end-to-end: an unresolvable base still fails CLOSED with #747's `misconfiguration` error

`pnpm --filter @superteam-lms/content-lint test` → 105 passed (base-ref: 8). `content-schema` → 170. `typecheck` clean.

## courses-academy blast — GREEN
| invocation | exit |
|---|---|
| bare | 0 |
| CI-sim `GITHUB_BASE_REF=main` | 0 |
| **slashed base** `LINT_BASE_REF=release/1.0` (created `origin/release/1.0`) | **0** — resolves; before this PR it would hard-fail |

**Do not merge** — SENSITIVE (ci/lint semantics). Needs adversarial + gate.
