### PR TITLE
fix(review): scope claude-review concurrency to job level (#710 regression on main)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -13,25 +13,36 @@ on:
     # a stale verdict can never post.
     types: [opened, ready_for_review, reopened, synchronize, labeled]
 
-# One review per PR at a time; a newer head cancels the older review in flight (the
-# mechanical core of the #710 fix — the pre-fix head's review is superseded, never
-# posted as if current). Keyed on PR number so PRs don't cancel each other.
-concurrency:
-  group: claude-code-review-pr-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
-
 jobs:
   claude-review:
     # opened/ready/reopened review any PR (unchanged). synchronize + labeled fire for
     # every PR but are admitted here only for needs-gate, so a fresh-head review is
     # guaranteed both when the PR is queued (label added) and on each subsequent push,
     # without re-reviewing every push of every PR.
+    #
+    # No draft-PR guard is intentional: a needs-gate draft's pushes still review, which
+    # is what we want — a PR is queued for the gate precisely to be reviewed at head.
     if: >-
       github.event.action == 'opened' ||
       github.event.action == 'ready_for_review' ||
       github.event.action == 'reopened' ||
       (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'needs-gate')) ||
       (github.event.action == 'labeled' && github.event.label.name == 'needs-gate')
+
+    # One review per PR at a time; a newer head cancels the older review in flight (the
+    # mechanical core of the #710 fix — the pre-fix head's review is superseded, never
+    # posted as if current). Keyed on PR number so PRs don't cancel each other.
+    #
+    # MUST stay job-level, NOT workflow-level. A skipped job (the `if` above is false)
+    # never enters the concurrency group, so it can't cancel anything. Workflow-level
+    # concurrency is claimed the moment the run is created, BEFORE the `if` is
+    # evaluated — so an ordinary (non-needs-gate) PR that gets a quick push after open
+    # would create a synchronize run that cancels the in-flight open review and then
+    # skips its own job, silently killing the only review. Keeping this at job level is
+    # what confines cancellation to runs that will actually post a replacement review.
+    concurrency:
+      group: claude-code-review-pr-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
 
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
Follow-up to #759 (merged) — fixes the MAJOR its adversarial review caught, which landed on `main` anyway.

## What happened

#759 added the #710 re-review triggers with a **workflow-level** `concurrency` block. The adversarial review FAILED it for a silent-cancel regression, and a job-level fix was pushed to the branch — but **#759 was merged at the pre-fix head (`4bab69c`) before that fix synced to the PR**, so the buggy version is now on `main`. (Ironically, the exact #710 pathology: a stale head merged.) This PR ports the fix onto `main`.

## The bug now on main

Workflow-level `concurrency` is claimed when the run is **created**, before the job `if` is evaluated. On an ordinary (non-`needs-gate`) PR:
1. PR opens → run A starts reviewing.
2. Author pushes within the 2–4 min window → `synchronize` creates run B → run B claims the per-PR group and `cancel-in-progress` **kills run A**.
3. Run B's job `if` is false (no `needs-gate` label) → job skipped → **no replacement review**.

Net: the only review is silently cancelled — a regression versus today, where `synchronize` doesn't trigger at all so run A always completes. Same mechanism bites a non-`needs-gate` `labeled` event and `synchronize`-before-the-label-lands.

## Fix

Move `concurrency` from workflow-level into the `claude-review` job. A job skipped by its `if` never enters the concurrency group, so only runs that will actually post a replacement review participate in cancellation. Needs-gate re-review + supersede-stale-head behavior is unchanged. A comment records why it must stay job-level (so it isn't "simplified" back), and notes the accepted residual (no draft-PR guard — a gated draft's pushes reviewing is intended).

Diff is one file, `+18 / -7`.

## Verification (what I ran)

- `python3 yaml.safe_load`: confirmed **no top-level `concurrency`**; it now lives under `jobs.claude-review`.
- `actionlint .github/workflows/claude-code-review.yml` → **clean**.
- `scripts/check-action-pins.sh` → **green** (no action changes; all `uses:` SHA-pinned).
- Runtime trigger/cancel semantics can't be exercised locally (stated honestly): rests on the established Actions behavior that a job skipped by `if` never acquires job-level concurrency — which is the whole basis of the fix.

> SENSITIVE (`.github/workflows/**`) — do not merge without adversarial review + gate. This is the remediation of a FAILED finding already on `main`, so please re-gate against **this** head.
