### PR TITLE
fix(courses): changelog lessons_removed — recover id/title from prior content revision (#757)

### DIFF
--- a/apps/web/src/app/api/admin/courses/sync/route.ts
+++ b/apps/web/src/app/api/admin/courses/sync/route.ts
@@ -38,6 +38,11 @@ import {
   recordCourseDeployed,
   recordCourseUpdate,
 } from "@/lib/content/changelog-writes";
+import {
+  contentShaFromTxId,
+  resolvePriorRemovedLessons,
+} from "@/lib/content/prior-content";
+import { diffMasks } from "@/lib/courses/changelog-diff";
 import { slotsByCourseId } from "@/lib/content/store";
 import { SYNCED_SHA } from "@/lib/content/meta";
 import { MaskMismatchError } from "@/lib/github/types";
@@ -582,6 +587,31 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   if (onChainCourse && result.signature) {
     try {
       const contentCommitted = updateParams.contentTxId !== undefined;
+      // #757 — a removed lesson is gone from the CURRENT bundle, so its id/title
+      // can only come from the PRIOR content revision. Resolve those from the
+      // pre-update on-chain content_tx_id (a padded courses-academy sha) ONLY
+      // when this update actually retires a slot. Best-effort: any failure
+      // leaves `priorRemoved` empty and the removed entry records slot-only.
+      let priorRemoved:
+        | ReadonlyMap<number, { id: string; title: string | null }>
+        | undefined;
+      if (updateParams.newActiveLessons) {
+        const { removedSlots } = diffMasks(
+          onChainCourse.activeLessons,
+          updateParams.newActiveLessons
+        );
+        const priorSha =
+          removedSlots.length > 0
+            ? contentShaFromTxId(onChainCourse.content_tx_id)
+            : null;
+        if (priorSha) {
+          priorRemoved = await resolvePriorRemovedLessons({
+            courseId,
+            priorSha,
+            removedSlots,
+          });
+        }
+      }
       await recordCourseUpdate({
         courseId,
         txSignature: result.signature,
@@ -592,6 +622,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
         contentCommitted,
         newVersion: onChainCourse.version + (contentCommitted ? 1 : 0),
         contentSha: SYNCED_SHA,
+        priorRemoved,
       });
     } catch (changelogErr) {
       console.error(

--- a/apps/web/src/lib/content/__tests__/changelog-writes.test.ts
+++ b/apps/web/src/lib/content/__tests__/changelog-writes.test.ts
@@ -305,3 +305,99 @@ describe("#738 status + recreate recorders", () => {
     ).resolves.toBeUndefined();
   });
 });
+
+describe("#757 removed-lesson id/title from prior state", () => {
+  const baseUpdate = {
+    courseId: "course-x",
+    txSignature: "SIG_UPDATE",
+    oldXp: 10,
+    contentCommitted: true,
+    newVersion: 4,
+    contentSha: "abc123",
+  };
+
+  it("uses priorRemoved for removed slots (id + title), overriding the null bundle miss", async () => {
+    const priorRemoved = new Map([
+      [3, { id: "lesson-gone", title: "A Retired Lesson" }],
+    ]);
+    await recordCourseUpdate({
+      ...baseUpdate,
+      oldMask: mask(0, 1, 3),
+      newMask: mask(0, 1), // slot 3 removed; absent from the current bundle
+      priorRemoved,
+    });
+    const removed = lastRows?.find((r) => r.kind === "lessons_removed");
+    expect(removed?.detail).toEqual({
+      lessons: [{ slot: 3, id: "lesson-gone", title: "A Retired Lesson" }],
+    });
+  });
+
+  it("still records slot-only when priorRemoved lacks the slot (never fabricates)", async () => {
+    await recordCourseUpdate({
+      ...baseUpdate,
+      oldMask: mask(0, 1, 3),
+      newMask: mask(0, 1),
+      priorRemoved: new Map(), // resolver degraded / slot unresolved
+    });
+    const removed = lastRows?.find((r) => r.kind === "lessons_removed");
+    expect(removed?.detail).toEqual({
+      lessons: [{ slot: 3, id: null, title: null }],
+    });
+  });
+
+  it("reproduces the exact C3 prod case (tx 5T1jeJ68) — full removed entries, no nulls", async () => {
+    // Live-before: slots 0..15. Live-now: remove {0,2,11,14}, add {16,17,18}.
+    const priorRemoved = new Map([
+      [
+        0,
+        { id: "lesson-bfsp-from-code-to-chain", title: "From Code to Chain" },
+      ],
+      [
+        2,
+        {
+          id: "lesson-bfsp-anatomy-anchor-program",
+          title: "Anatomy of an Anchor Program",
+        },
+      ],
+      [11, { id: "lesson-bfsp-deploy-to-devnet", title: "Deploy to Devnet" }],
+      [
+        14,
+        { id: "lesson-bfsp-m4-interact", title: "Interact with Your Program" },
+      ],
+    ]);
+    await recordCourseUpdate({
+      ...baseUpdate,
+      oldMask: mask(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15),
+      newMask: mask(1, 3, 4, 5, 6, 7, 8, 9, 10, 12, 13, 15, 16, 17, 18),
+      priorRemoved,
+    });
+    const removed = lastRows?.find((r) => r.kind === "lessons_removed");
+    const lessons = (
+      removed?.detail as { lessons: Array<Record<string, unknown>> }
+    ).lessons;
+    // The exact prod regression (all id:null/title:null) is gone.
+    expect(lessons.every((l) => l.id !== null && l.title !== null)).toBe(true);
+    expect(lessons).toEqual([
+      {
+        slot: 0,
+        id: "lesson-bfsp-from-code-to-chain",
+        title: "From Code to Chain",
+      },
+      {
+        slot: 2,
+        id: "lesson-bfsp-anatomy-anchor-program",
+        title: "Anatomy of an Anchor Program",
+      },
+      {
+        slot: 11,
+        id: "lesson-bfsp-deploy-to-devnet",
+        title: "Deploy to Devnet",
+      },
+      {
+        slot: 14,
+        id: "lesson-bfsp-m4-interact",
+        title: "Interact with Your Program",
+      },
+    ]);
+  });
+});

--- a/apps/web/src/lib/content/__tests__/changelog-writes.test.ts
+++ b/apps/web/src/lib/content/__tests__/changelog-writes.test.ts
@@ -399,5 +399,17 @@ describe("#757 removed-lesson id/title from prior state", () => {
         title: "Interact with Your Program",
       },
     ]);
+
+    // Cross-contamination pin: added lessons resolve from the CURRENT bundle
+    // ONLY — priorRemoved (slots 0/2/11/14) must never bleed into the added
+    // row. Slots 16/17/18 aren't in the test bundle, so they stay slot-only.
+    const added = lastRows?.find((r) => r.kind === "lessons_added");
+    expect(added?.detail).toEqual({
+      lessons: [
+        { slot: 16, id: null, title: null },
+        { slot: 17, id: null, title: null },
+        { slot: 18, id: null, title: null },
+      ],
+    });
   });
 });

--- a/apps/web/src/lib/content/__tests__/prior-content.test.ts
+++ b/apps/web/src/lib/content/__tests__/prior-content.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// #757: resolve removed-lesson id/title from the PRIOR content revision. Mock
+// the GitHub tarball fetch + extractTarball so we can feed a canned repo tree;
+// the yaml/JSON parsing under test runs for real.
+
+vi.mock("server-only", () => ({}));
+
+let fetchTarballImpl: () => Promise<Uint8Array>;
+let extractImpl: () => Promise<Map<string, Uint8Array>>;
+
+vi.mock("@/lib/github/github", () => ({
+  createGitHubClient: () => ({
+    fetchTarball: () => fetchTarballImpl(),
+  }),
+}));
+vi.mock("@/lib/content/compile/tarball", () => ({
+  extractTarball: () => extractImpl(),
+}));
+
+import {
+  contentShaFromTxId,
+  resolvePriorRemovedLessons,
+} from "../prior-content";
+
+const enc = (s: string) => new TextEncoder().encode(s);
+
+/** A prior repo tree: the target course + a decoy, in courses-academy layout. */
+function priorTree(): Map<string, Uint8Array> {
+  return new Map<string, Uint8Array>([
+    // Decoy course — must NOT be matched (proves id-match, not path-guess).
+    [
+      "courses/other-course/course.yaml",
+      enc("id: course-other\nslug: other\n"),
+    ],
+    [
+      "courses/other-course/slots.lock.json",
+      enc('{"slots":{"lesson-z":0},"retired":[],"next":1,"version":1}'),
+    ],
+    // Target course — dir name deliberately unlike the id/slug (#757: dir != slug).
+    [
+      "courses/building-your-first-solana-program/course.yaml",
+      enc("id: course-building-first-program\nslug: building-first-program\n"),
+    ],
+    [
+      "courses/building-your-first-solana-program/slots.lock.json",
+      enc(
+        '{"slots":{"lesson-bfsp-from-code-to-chain":0,"lesson-bfsp-anatomy-anchor-program":2,"lesson-bfsp-live":5},"retired":[],"next":6,"version":1}'
+      ),
+    ],
+    [
+      "courses/building-your-first-solana-program/lessons/intro/lesson.yaml",
+      enc("id: lesson-bfsp-from-code-to-chain\ntitle: From Code to Chain\n"),
+    ],
+    [
+      "courses/building-your-first-solana-program/lessons/anatomy/lesson.yaml",
+      enc(
+        "id: lesson-bfsp-anatomy-anchor-program\ntitle: Anatomy of an Anchor Program\n"
+      ),
+    ],
+  ]);
+}
+
+beforeEach(() => {
+  fetchTarballImpl = () => Promise.resolve(new Uint8Array([1, 2, 3]));
+  extractImpl = () => Promise.resolve(priorTree());
+});
+
+describe("contentShaFromTxId", () => {
+  const pad = (sha: string): number[] => {
+    const bytes: number[] = [];
+    for (let i = 0; i < 40; i += 2)
+      bytes.push(parseInt(sha.slice(i, i + 2), 16));
+    return [...Array(12).fill(0), ...bytes];
+  };
+
+  it("decodes a padded 20-byte sha back to 40-hex", () => {
+    const sha = "1b74e4a60f8813374219451b60436af832df2d91";
+    expect(contentShaFromTxId(pad(sha))).toBe(sha);
+  });
+
+  it("returns null for an all-zero content_tx_id (never committed content)", () => {
+    expect(contentShaFromTxId(new Array(32).fill(0))).toBeNull();
+  });
+
+  it("returns null when the 12-byte pad is not all zero", () => {
+    const b = pad("1b74e4a60f8813374219451b60436af832df2d91");
+    b[3] = 9;
+    expect(contentShaFromTxId(b)).toBeNull();
+  });
+
+  it("returns null for a wrong-length input", () => {
+    expect(contentShaFromTxId([0, 1, 2])).toBeNull();
+  });
+});
+
+describe("resolvePriorRemovedLessons", () => {
+  it("resolves removed slots to id + title from the prior revision", async () => {
+    const map = await resolvePriorRemovedLessons({
+      courseId: "course-building-first-program",
+      priorSha: "deadbeef",
+      removedSlots: [0, 2],
+    });
+    expect(map.get(0)).toEqual({
+      id: "lesson-bfsp-from-code-to-chain",
+      title: "From Code to Chain",
+    });
+    expect(map.get(2)).toEqual({
+      id: "lesson-bfsp-anatomy-anchor-program",
+      title: "Anatomy of an Anchor Program",
+    });
+  });
+
+  it("matches the course by id, not by a path guess (dir != slug)", async () => {
+    // slug is building-first-program; the dir is building-your-first-solana-program.
+    const map = await resolvePriorRemovedLessons({
+      courseId: "course-building-first-program",
+      priorSha: "x",
+      removedSlots: [0],
+    });
+    expect(map.get(0)?.id).toBe("lesson-bfsp-from-code-to-chain");
+  });
+
+  it("records the id with a null title when the prior title is unavailable", async () => {
+    // slot 5's lesson is in the prior lock but has no lesson.yaml in the tree.
+    const map = await resolvePriorRemovedLessons({
+      courseId: "course-building-first-program",
+      priorSha: "x",
+      removedSlots: [5],
+    });
+    expect(map.get(5)).toEqual({ id: "lesson-bfsp-live", title: null });
+  });
+
+  it("omits a slot absent from the prior lock (keeps the slot-only fallback)", async () => {
+    const map = await resolvePriorRemovedLessons({
+      courseId: "course-building-first-program",
+      priorSha: "x",
+      removedSlots: [99],
+    });
+    expect(map.has(99)).toBe(false);
+  });
+
+  it("degrades to empty when the course id is not found in the prior tree", async () => {
+    const map = await resolvePriorRemovedLessons({
+      courseId: "course-does-not-exist",
+      priorSha: "x",
+      removedSlots: [0],
+    });
+    expect(map.size).toBe(0);
+  });
+
+  it("degrades to empty (never throws) when the tarball fetch fails", async () => {
+    fetchTarballImpl = () => Promise.reject(new Error("GITHUB_TOKEN not set"));
+    const map = await resolvePriorRemovedLessons({
+      courseId: "course-building-first-program",
+      priorSha: "x",
+      removedSlots: [0, 2],
+    });
+    expect(map.size).toBe(0);
+  });
+
+  it("short-circuits with no removed slots", async () => {
+    let fetched = false;
+    fetchTarballImpl = () => {
+      fetched = true;
+      return Promise.resolve(new Uint8Array());
+    };
+    const map = await resolvePriorRemovedLessons({
+      courseId: "course-building-first-program",
+      priorSha: "x",
+      removedSlots: [],
+    });
+    expect(map.size).toBe(0);
+    expect(fetched).toBe(false);
+  });
+});

--- a/apps/web/src/lib/content/__tests__/prior-content.test.ts
+++ b/apps/web/src/lib/content/__tests__/prior-content.test.ts
@@ -140,16 +140,24 @@ describe("resolvePriorRemovedLessons", () => {
     expect(map.has(99)).toBe(false);
   });
 
-  it("degrades to empty when the course id is not found in the prior tree", async () => {
+  it("degrades to empty (and WARNS) when the course id is not found", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const map = await resolvePriorRemovedLessons({
       courseId: "course-does-not-exist",
       priorSha: "x",
       removedSlots: [0],
     });
     expect(map.size).toBe(0);
+    // #731 bar: the degrade is not silent — it names the course and the reason.
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("course-does-not-exist")
+    );
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("slot-only"));
+    warn.mockRestore();
   });
 
-  it("degrades to empty (never throws) when the tarball fetch fails", async () => {
+  it("degrades to empty (never throws, and WARNS) when the tarball fetch fails", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     fetchTarballImpl = () => Promise.reject(new Error("GITHUB_TOKEN not set"));
     const map = await resolvePriorRemovedLessons({
       courseId: "course-building-first-program",
@@ -157,6 +165,10 @@ describe("resolvePriorRemovedLessons", () => {
       removedSlots: [0, 2],
     });
     expect(map.size).toBe(0);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("GITHUB_TOKEN not set")
+    );
+    warn.mockRestore();
   });
 
   it("short-circuits with no removed slots", async () => {

--- a/apps/web/src/lib/content/changelog-writes.ts
+++ b/apps/web/src/lib/content/changelog-writes.ts
@@ -56,13 +56,22 @@ type ChangelogInsert = {
 };
 
 /**
- * Resolve a slot (bit index) to a lesson id + title snapshot from the committed
- * bundle. Inverts the course's `slots` map (lessonId → slot) once per call set.
- * Returns `{ slot, id: null, title: null }` when the slot is unknown to the
- * bundle (e.g. a slot retired before its lesson was tracked) so the entry still
- * records the slot number.
+ * Resolve a slot (bit index) to a lesson id + title snapshot. Inverts the
+ * course's CURRENT `slots` map (lessonId → slot) once per call set.
+ *
+ * `prior` (#757) is an override for slots whose lesson is no longer in the
+ * current bundle — i.e. REMOVED lessons, which are by definition absent from
+ * the current `slots`/`lessonsById` and would otherwise resolve to
+ * `{id:null,title:null}`. It is resolved from the prior content revision
+ * (see {@link file://./prior-content.ts}) and takes precedence when present.
+ * A slot with neither a prior entry nor a current-bundle hit still records the
+ * slot number (`{id:null,title:null}`) so the entry is never dropped.
  */
-function resolveSlots(courseId: string, slots: number[]): ChangelogLessonRef[] {
+function resolveSlots(
+  courseId: string,
+  slots: number[],
+  prior?: ReadonlyMap<number, { id: string; title: string | null }>
+): ChangelogLessonRef[] {
   const lock = slotsByCourseId.get(courseId);
   const slotToLessonId = new Map<number, string>();
   if (lock) {
@@ -71,6 +80,8 @@ function resolveSlots(courseId: string, slots: number[]): ChangelogLessonRef[] {
     }
   }
   return slots.map((slot) => {
+    const priorRef = prior?.get(slot);
+    if (priorRef) return { slot, id: priorRef.id, title: priorRef.title };
     const id = slotToLessonId.get(slot) ?? null;
     const rawTitle = id ? lessonsById.get(id)?.title : undefined;
     const title = typeof rawTitle === "string" ? rawTitle : null;
@@ -160,6 +171,13 @@ export async function recordCourseUpdate(params: {
   newVersion: number;
   /** The content bundle SHA pinned by this re-sync (for `content_updated`). */
   contentSha: string;
+  /**
+   * #757 — id/title for REMOVED slots, resolved from the prior content revision
+   * (the current bundle no longer has them). Keyed by slot. Absent/empty ⇒ the
+   * removed lessons record slot-only, exactly as before. Never applies to added
+   * lessons, which resolve from the current bundle.
+   */
+  priorRemoved?: ReadonlyMap<number, { id: string; title: string | null }>;
 }): Promise<void> {
   const rows: ChangelogInsert[] = [];
   const base = {
@@ -188,7 +206,11 @@ export async function recordCourseUpdate(params: {
     if (removedSlots.length > 0) {
       liveSetChanged = true;
       const detail: LessonsDetail = {
-        lessons: resolveSlots(params.courseId, removedSlots),
+        lessons: resolveSlots(
+          params.courseId,
+          removedSlots,
+          params.priorRemoved
+        ),
       };
       rows.push({
         ...base,

--- a/apps/web/src/lib/content/prior-content.ts
+++ b/apps/web/src/lib/content/prior-content.ts
@@ -31,6 +31,17 @@ import { extractTarball } from "@/lib/content/compile/tarball";
 const decoder = new TextDecoder();
 
 /**
+ * Bound the whole prior-content fetch (redirect + tarball body read). A hung
+ * GitHub response must not stall the admin sync; on timeout the AbortController
+ * aborts the fetch and we degrade to slot-only. 30s is generous for a
+ * small-repo tarball while still failing a truly stuck request.
+ */
+const TARBALL_TIMEOUT_MS = 30_000;
+
+/** Prefix every prior-content degrade log so an operator can grep the cause. */
+const LOG = "[changelog:prior-content]";
+
+/**
  * Decode `Course.content_tx_id` (§11.0: 12 leading zero bytes + a 20-byte git
  * SHA-1) back to the 40-hex sha. Returns `null` when the bytes are not a padded
  * sha — e.g. all-zero (a course that never committed content) or non-zero in
@@ -79,12 +90,25 @@ export async function resolvePriorRemovedLessons(params: {
   if (params.removedSlots.length === 0) return out;
 
   let tree: Map<string, Uint8Array>;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TARBALL_TIMEOUT_MS);
   try {
-    const tarball = await createGitHubClient().fetchTarball(params.priorSha);
+    const tarball = await createGitHubClient().fetchTarball(
+      params.priorSha,
+      controller.signal
+    );
     tree = await extractTarball(tarball);
-  } catch {
-    // No GITHUB_TOKEN, network/HTTP error, or a tarball too large/corrupt.
+  } catch (err) {
+    // No GITHUB_TOKEN, network/HTTP error, timeout, or a tarball too large/
+    // corrupt. Log loudly (#731 bar) so an admin retiring lessons with, e.g.,
+    // an expired token sees WHY enrichment degraded rather than silent nulls.
+    const reason = err instanceof Error ? err.message : String(err);
+    console.warn(
+      `${LOG} ${params.courseId}: could not fetch/extract prior content at ${params.priorSha} — removed lessons will record slot-only (${reason})`
+    );
     return out;
+  } finally {
+    clearTimeout(timer);
   }
 
   // 1. Locate the course by matching each course.yaml's `id` (dir != slug).
@@ -97,11 +121,21 @@ export async function resolvePriorRemovedLessons(params: {
       break;
     }
   }
-  if (!courseDir) return out;
+  if (!courseDir) {
+    console.warn(
+      `${LOG} ${params.courseId}: not found in prior content at ${params.priorSha} — removed lessons will record slot-only`
+    );
+    return out;
+  }
 
   // 2. Reverse the prior slots.lock.json (lessonId→slot) for the removed slots.
   const lockBytes = tree.get(`${courseDir}/slots.lock.json`);
-  if (!lockBytes) return out;
+  if (!lockBytes) {
+    console.warn(
+      `${LOG} ${params.courseId}: ${courseDir}/slots.lock.json missing at ${params.priorSha} — removed lessons will record slot-only`
+    );
+    return out;
+  }
   const slotToId = new Map<number, string>();
   try {
     const lock = JSON.parse(decoder.decode(lockBytes)) as {
@@ -110,7 +144,11 @@ export async function resolvePriorRemovedLessons(params: {
     for (const [lessonId, slot] of Object.entries(lock.slots ?? {})) {
       slotToId.set(Number(slot), lessonId);
     }
-  } catch {
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    console.warn(
+      `${LOG} ${params.courseId}: ${courseDir}/slots.lock.json unparseable at ${params.priorSha} — removed lessons will record slot-only (${reason})`
+    );
     return out;
   }
 

--- a/apps/web/src/lib/content/prior-content.ts
+++ b/apps/web/src/lib/content/prior-content.ts
@@ -1,0 +1,136 @@
+import "server-only";
+
+import { parse as parseYaml } from "yaml";
+import { createGitHubClient } from "@/lib/github/github";
+import { extractTarball } from "@/lib/content/compile/tarball";
+
+/**
+ * Prior-content resolver for the course changelog (#757).
+ *
+ * A `lessons_removed` changelog entry needs the id + title of each retired
+ * lesson, but a removed lesson is BY DEFINITION gone from the CURRENT content
+ * bundle — resolving it against the current bundle yields `{id:null,title:null}`
+ * (the observed prod bug on the C3 sync, tx 5T1jeJ68GF3D). The faithful source
+ * is the PRIOR content revision: `Course.content_tx_id` (read off-chain before
+ * the update) is a padded courses-academy git SHA, and at that SHA the removed
+ * lessons were still live — their `courses/<dir>/slots.lock.json` still maps
+ * their id→slot, and their `lesson.yaml` still carries the title.
+ *
+ * This is issue #757's Option 1 ("resolve from the previous bundle ... the
+ * faithful answer, at the cost of a git read in the write path"). It runs ONLY
+ * on the rare retire-a-live-lesson sync, and is BEST-EFFORT: any failure (no
+ * GITHUB_TOKEN, network/tarball error, prior content unparseable, course not
+ * found) returns an empty map and the caller degrades to slot-only — never
+ * worse than today, never a fabricated name.
+ *
+ * The course dir is NOT the slug (e.g. slug `building-first-program` lives in
+ * `courses/building-your-first-solana-program/`), so the course is located by
+ * scanning each `course.yaml`'s `id`, not by constructing a path.
+ */
+
+const decoder = new TextDecoder();
+
+/**
+ * Decode `Course.content_tx_id` (§11.0: 12 leading zero bytes + a 20-byte git
+ * SHA-1) back to the 40-hex sha. Returns `null` when the bytes are not a padded
+ * sha — e.g. all-zero (a course that never committed content) or non-zero in
+ * the pad — so the caller simply skips the prior read.
+ */
+export function contentShaFromTxId(
+  txId: readonly number[] | Uint8Array
+): string | null {
+  const bytes = Array.from(txId);
+  if (bytes.length !== 32) return null;
+  if (bytes.some((b) => !Number.isInteger(b) || b < 0 || b > 255)) return null;
+  for (let i = 0; i < 12; i++) if (bytes[i] !== 0) return null;
+  const sha = bytes
+    .slice(12)
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+  if (!/^[0-9a-f]{40}$/.test(sha) || /^0{40}$/.test(sha)) return null;
+  return sha;
+}
+
+type PriorRef = { id: string; title: string | null };
+
+function parseYamlDoc(bytes: Uint8Array): Record<string, unknown> | null {
+  try {
+    const doc = parseYaml(decoder.decode(bytes));
+    return doc && typeof doc === "object"
+      ? (doc as Record<string, unknown>)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve removed slots → `{id, title}` from the prior courses-academy revision
+ * at `priorSha`. Best-effort: returns an empty map on any failure, and omits any
+ * individual slot it can't resolve (the caller keeps the slot-only fallback for
+ * those). Never throws.
+ */
+export async function resolvePriorRemovedLessons(params: {
+  courseId: string;
+  priorSha: string;
+  removedSlots: number[];
+}): Promise<Map<number, PriorRef>> {
+  const out = new Map<number, PriorRef>();
+  if (params.removedSlots.length === 0) return out;
+
+  let tree: Map<string, Uint8Array>;
+  try {
+    const tarball = await createGitHubClient().fetchTarball(params.priorSha);
+    tree = await extractTarball(tarball);
+  } catch {
+    // No GITHUB_TOKEN, network/HTTP error, or a tarball too large/corrupt.
+    return out;
+  }
+
+  // 1. Locate the course by matching each course.yaml's `id` (dir != slug).
+  let courseDir: string | null = null;
+  for (const [path, bytes] of tree) {
+    if (!/^courses\/[^/]+\/course\.ya?ml$/.test(path)) continue;
+    const doc = parseYamlDoc(bytes);
+    if (doc?.id === params.courseId) {
+      courseDir = path.slice(0, path.lastIndexOf("/"));
+      break;
+    }
+  }
+  if (!courseDir) return out;
+
+  // 2. Reverse the prior slots.lock.json (lessonId→slot) for the removed slots.
+  const lockBytes = tree.get(`${courseDir}/slots.lock.json`);
+  if (!lockBytes) return out;
+  const slotToId = new Map<number, string>();
+  try {
+    const lock = JSON.parse(decoder.decode(lockBytes)) as {
+      slots?: Record<string, number>;
+    };
+    for (const [lessonId, slot] of Object.entries(lock.slots ?? {})) {
+      slotToId.set(Number(slot), lessonId);
+    }
+  } catch {
+    return out;
+  }
+
+  // 3. Snapshot titles from the prior lesson.yaml docs under this course.
+  const titleById = new Map<string, string>();
+  const lessonsPrefix = `${courseDir}/lessons/`;
+  for (const [path, bytes] of tree) {
+    if (!path.startsWith(lessonsPrefix) || !/\/lesson\.ya?ml$/.test(path)) {
+      continue;
+    }
+    const doc = parseYamlDoc(bytes);
+    if (typeof doc?.id === "string" && typeof doc?.title === "string") {
+      titleById.set(doc.id, doc.title);
+    }
+  }
+
+  for (const slot of params.removedSlots) {
+    const id = slotToId.get(slot);
+    if (!id) continue; // not in the prior lock either → leave slot-only
+    out.set(slot, { id, title: titleById.get(id) ?? null });
+  }
+  return out;
+}

--- a/apps/web/src/lib/github/github.ts
+++ b/apps/web/src/lib/github/github.ts
@@ -1,13 +1,18 @@
 import "server-only";
-import { type ChecksState, GitHubUnavailableError } from "./types";
 import { serverEnv } from "@/lib/env.server";
+import { type ChecksState, GitHubUnavailableError } from "./types";
 
 const REPO = "solanabr/courses-academy";
 const BRANCH = "main";
 const API = "https://api.github.com";
 
 export interface GitHubClient {
-  fetchTarball(sha: string): Promise<Uint8Array>;
+  /**
+   * Download a repo tarball at `sha`. `signal` lets the caller bound the whole
+   * fetch (redirect + body read) with a timeout — aborting the fetch aborts the
+   * response stream too. Existing callers pass none (unbounded, unchanged).
+   */
+  fetchTarball(sha: string, signal?: AbortSignal): Promise<Uint8Array>;
   fetchHeadSha(): Promise<string>;
   fetchChecksState(sha: string): Promise<ChecksState>;
   /** Commits `head` is ahead of `base` (compare API `ahead_by`). */
@@ -23,7 +28,11 @@ export function createGitHubClient(opts: Opts = {}): GitHubClient {
   const token = "token" in opts ? opts.token : serverEnv.GITHUB_TOKEN;
   const doFetch = opts.fetchImpl ?? fetch;
 
-  async function call(path: string, accept: string): Promise<Response> {
+  async function call(
+    path: string,
+    accept: string,
+    signal?: AbortSignal
+  ): Promise<Response> {
     if (!token) {
       throw new GitHubUnavailableError("GITHUB_TOKEN is not configured");
     }
@@ -35,6 +44,7 @@ export function createGitHubClient(opts: Opts = {}): GitHubClient {
           Accept: accept,
           "X-GitHub-Api-Version": "2022-11-28",
         },
+        signal,
       });
     } catch (e) {
       throw new GitHubUnavailableError(
@@ -48,11 +58,12 @@ export function createGitHubClient(opts: Opts = {}): GitHubClient {
   }
 
   return {
-    async fetchTarball(sha) {
+    async fetchTarball(sha, signal) {
       // `tarball/<sha>` 302-redirects to codeload; fetch follows redirects by default.
       const res = await call(
         `/repos/${REPO}/tarball/${sha}`,
-        "application/vnd.github+json"
+        "application/vnd.github+json",
+        signal
       );
       return new Uint8Array(await res.arrayBuffer());
     },


### PR DESCRIPTION
Closes #757.

## What

The first real changelog write in production (the C3 mask sync, tx `5T1jeJ68…`, version 4) recorded `lessons_removed` as `{"id":null,"slot":N,"title":null}` — the audit entry couldn't say *what* was removed. A removed lesson is by definition gone from the **current** content bundle, so resolving its id/title against that bundle misses. (The `lessons_added` path works because those lessons *are* present.)

## Fix — resolve from the previous bundle (issue Option 1)

The pre-update on-chain `Course.content_tx_id` is a padded courses-academy git SHA, and at that SHA the removed lessons were still live — their `slots.lock.json` still maps id→slot and their `lesson.yaml` still carries the title.

- **`lib/content/prior-content.ts`** (new): `contentShaFromTxId` decodes `content_tx_id` (12 zero bytes + 20-byte sha) back to the sha; `resolvePriorRemovedLessons` fetches that revision's tarball (reusing `github.fetchTarball` + `extractTarball`), locates the course by matching each `course.yaml`'s `id`, reverses its `slots.lock.json` for the removed slots → ids, and snapshots titles from the prior `lesson.yaml` docs.
- **The course dir is NOT the slug** — a real gotcha this fix handles: slug `building-first-program` lives in `courses/building-your-first-solana-program/`. The course is found by `id` match, never a path guess.
- **`changelog-writes`**: `resolveSlots` takes a prior-override (removed slots only); `recordCourseUpdate` accepts `priorRemoved`. Added lessons still resolve from the current bundle. The sync route resolves `priorRemoved` **only** when a slot is actually retired.
- **Best-effort, non-fatal, rare path**: no `GITHUB_TOKEN`, network/tarball error, unparseable prior content, or a slot absent from the prior lock all degrade to slot-only (`id/title:null`) — never worse than today, never a fabricated name. Runs only on the uncommon retire-a-live-lesson sync.

### Verified against real data

Reversing the prior `slots.lock.json` at content sha `1b74e4a6` (the version-3 `content_tx_id`) yields exactly the ids the issue names from git history:

| slot | id | title |
|---|---|---|
| 0 | `lesson-bfsp-from-code-to-chain` | From Code to Chain |
| 2 | `lesson-bfsp-anatomy-anchor-program` | Anatomy of an Anchor Program |
| 11 | `lesson-bfsp-deploy-to-devnet` | Deploy to Devnet |
| 14 | `lesson-bfsp-m4-interact` | Interact with Your Program |

## Backfill the one affected prod row (for the gate to apply)

No migration for a single row (per the issue). The gate should run this against prod with `service_role`. Verify first, then update — the `WHERE` is idempotent (only touches the still-null row):

```sql
-- 1. Verify the target row (expect one lessons_removed row, currently all-null ids)
SELECT id, course_id, version, tx_signature, detail
FROM public.course_changelog
WHERE course_id = 'course-building-first-program'
  AND kind = 'lessons_removed'
  AND tx_signature LIKE '5T1jeJ68%';

-- 2. Backfill the ids/titles recovered from content sha 1b74e4a6
UPDATE public.course_changelog
SET detail = '{"lessons":[
  {"slot":0,"id":"lesson-bfsp-from-code-to-chain","title":"From Code to Chain"},
  {"slot":2,"id":"lesson-bfsp-anatomy-anchor-program","title":"Anatomy of an Anchor Program"},
  {"slot":11,"id":"lesson-bfsp-deploy-to-devnet","title":"Deploy to Devnet"},
  {"slot":14,"id":"lesson-bfsp-m4-interact","title":"Interact with Your Program"}
]}'::jsonb
WHERE course_id = 'course-building-first-program'
  AND kind = 'lessons_removed'
  AND tx_signature LIKE '5T1jeJ68%'
  AND detail->'lessons' @> '[{"id":null}]'::jsonb;
```

## Verification

`pnpm install --frozen-lockfile && pnpm typecheck && pnpm --filter web test` — all green.
- typecheck: 6/6 packages
- **web suite: 210 files, 1917 tests pass**

New tests: `prior-content` resolver (id+title, `dir != slug` id-match, null-title fallback, and every degrade path — fetch failure, course-not-found, slot-not-in-lock, empty removed set); `recordCourseUpdate` `priorRemoved` override + slot-only fallback (never fabricates); and an **exact C3-shaped reproduction** (remove slots 0/2/11/14, add 16/17/18) that now yields full entries with **no nulls**.

Do not merge — for review.
