### PR TITLE
fix(content-lint): SHA-shape base-ref passthrough so fail-closed is unconditional (#748 review follow-up)

### DIFF
--- a/packages/content-lint/src/__tests__/base-ref.test.ts
+++ b/packages/content-lint/src/__tests__/base-ref.test.ts
@@ -90,6 +90,29 @@ describe("normalizeBaseRef (#748)", () => {
     expect(normalizeBaseRef("release/9.9", root)).toBe("origin/release/9.9");
   });
 
+  it("never falls through to a LOCAL branch shadowing the base name — stays fail-closed (#761 review)", () => {
+    const root = repoWithBranches();
+    // A local branch named "release" exists, but there is NO origin/release. A bare
+    // branch name must not resolve against the (possibly stale) local branch.
+    execFileSync("git", ["branch", "release"], { cwd: root, stdio: "ignore" });
+    expect(normalizeBaseRef("release", root)).toBe("origin/release");
+  });
+
+  it("a base shadowed only by a local branch still fails CLOSED end-to-end (#747)", async () => {
+    const root = repoWithBranches();
+    execFileSync("git", ["branch", "release"], { cwd: root, stdio: "ignore" });
+    const baseRef = normalizeBaseRef("release", root); // origin/release, unresolvable
+    const r = await runLint(root, { baseRef });
+    expect(
+      r.diagnostics.some(
+        (d) =>
+          d.gate === "gate-3" &&
+          d.severity === "error" &&
+          /misconfiguration/i.test(d.message)
+      )
+    ).toBe(true);
+  });
+
   it("resolves a slashed base end-to-end: gate-3 runs (no misconfiguration error)", async () => {
     const root = repoWithBranches();
     const baseRef = normalizeBaseRef("release/1.0", root);

--- a/packages/content-lint/src/base-ref.ts
+++ b/packages/content-lint/src/base-ref.ts
@@ -16,14 +16,22 @@ import { resolvesRef } from "./git";
  *   1. Already remote-/fully-qualified (`origin/…`, `refs/…`) → verbatim.
  *   2. Bare branch name → `origin/<raw>` when that resolves (the #748 fix; also
  *      preserves the old "main" → "origin/main" target for the no-slash case).
- *   3. Otherwise a SHA or local ref that resolves as-is → verbatim.
+ *   3. A SHA-shaped `raw` that resolves → verbatim (a full/abbrev commit id passed
+ *      as an explicit base). Restricted to SHA shape ON PURPOSE: a bare *branch*
+ *      name must resolve ONLY via `origin/` in CI, so it can never fall through to
+ *      a possibly-stale LOCAL branch of the same name — which would make #747's
+ *      fail-closed conditional on the absence of a shadowing local branch (#761
+ *      review). CI checks out a detached HEAD with no local branches today, but a
+ *      future checkout change must not silently re-open a stale-base diff.
  *   4. Nothing resolves → return the `origin/`-qualified form so the downstream
  *      gate's #747 hard error names the ref CI meant to fetch. A genuinely bogus
  *      ref still ERRORs; this never silently fails open.
  *
- * Only two candidates are ever tried (`origin/<raw>`, then `<raw>`), so an
- * unresolvable ref cannot accidentally match some unrelated object.
+ * At most two candidates are ever tried (`origin/<raw>`, then a SHA-shaped
+ * `<raw>`), so an unresolvable ref cannot accidentally match some unrelated object.
  */
+const SHA_SHAPE = /^[0-9a-f]{7,40}$/i;
+
 export function normalizeBaseRef(
   raw: string | undefined,
   root: string
@@ -32,6 +40,6 @@ export function normalizeBaseRef(
   if (raw.startsWith("origin/") || raw.startsWith("refs/")) return raw;
   const prefixed = `origin/${raw}`;
   if (resolvesRef(root, prefixed)) return prefixed;
-  if (resolvesRef(root, raw)) return raw;
+  if (SHA_SHAPE.test(raw) && resolvesRef(root, raw)) return raw;
   return prefixed;
 }


### PR DESCRIPTION
Follow-up to #761 (already squash-merged). Adversarial review of that PR PASSed but flagged one MINOR against the team's fail-closed bar; this addresses it.

## The hole
#761's `normalizeBaseRef` step 3 used a verbatim fallback that resolved **any** ref `rev-parse` could resolve — including a **local branch** shadowing the base name. So when `origin/<base>` is missing (the exact misconfiguration #747 is meant to catch) **and** the checkout has a local branch of that name, the run silently diffed against the possibly-stale local branch instead of erroring. That makes #747's fail-closed *conditional* on the absence of a shadowing local branch. Not reachable in current CI (`actions/checkout` leaves a detached HEAD with no local branches), but a future checkout change would silently re-open a stale-base diff.

## Fix
Restrict the verbatim passthrough to **SHA-shaped** `raw` (`/^[0-9a-f]{7,40}$/i`). A bare branch name now resolves **only** via `origin/`, so a shadowing local branch can never satisfy it and the run fail-closes with #747's error. Genuine full/abbrev-SHA base passthrough (the intended #748 behavior) is unaffected. At most two candidates are ever tried: `origin/<raw>`, then a SHA-shaped `<raw>`.

## Tests (`base-ref.test.ts`, +2 → 10)
- **new:** a LOCAL branch `release` with no `origin/release` → `normalizeBaseRef("release")` returns `origin/release` (never the local branch)
- **new, end-to-end:** that same shadowed base still fails CLOSED with #747's `misconfiguration` error
- all prior cases unchanged (slashed→origin/, plain bare, already-qualified verbatim, full-SHA verbatim, undefined, unresolvable-slashed fail-closed, slashed resolves e2e, unresolvable fail-closed e2e)

`pnpm --filter @superteam-lms/content-lint test` → 107 passed (base-ref: 10). `typecheck` clean.

## courses-academy blast — GREEN
bare = exit 0; CI-sim `GITHUB_BASE_REF=main` = exit 0; slashed base `LINT_BASE_REF=release/1.0` = exit 0.

**Do not merge** — SENSITIVE (ci/lint semantics). Needs adversarial + gate.
