### PR TITLE
fix(db): positive xp_transactions.source at the award_xp call sites (#736)

### DIFF
--- a/apps/web/src/app/api/admin/resync/route.ts
+++ b/apps/web/src/app/api/admin/resync/route.ts
@@ -257,6 +257,7 @@ export async function POST(req: NextRequest) {
           p_reason: `Achievement reward: ${achievement.id}`,
           p_idempotency_key: `resync:${assetAddr}:xp`,
           p_tx_signature: `resync:${assetAddr}`,
+          p_source: "achievement", // #736
         });
       }
 

--- a/apps/web/src/lib/gamification/__tests__/surprise-bonus.test.ts
+++ b/apps/web/src/lib/gamification/__tests__/surprise-bonus.test.ts
@@ -118,6 +118,8 @@ describe("maybeAwardSurpriseBonus", () => {
       p_reason: `${SURPRISE_BONUS_REASON_PREFIX}lesson-pdas-1`,
       p_idempotency_key: "sig-abc:SurpriseBonus",
       p_tx_signature: "sig-abc",
+      // #736: source stated positively (a surprise bonus is a platform grant).
+      p_source: "platform",
     });
   });
 

--- a/apps/web/src/lib/gamification/surprise-bonus.ts
+++ b/apps/web/src/lib/gamification/surprise-bonus.ts
@@ -105,6 +105,10 @@ export async function maybeAwardSurpriseBonus(
     p_reason: surpriseBonusReason(lessonId),
     p_idempotency_key: `${txSignature}:SurpriseBonus`,
     p_tx_signature: txSignature,
+    // #736: a surprise bonus is a platform grant, not learning XP — pin the
+    // source (its 'surprise_bonus:' reason already derived to 'platform', but
+    // state it positively so it can never drift).
+    p_source: "platform",
   });
 
   if (error) throw new Error(error.message);

--- a/apps/web/src/lib/helius/__tests__/award-xp-source.test.ts
+++ b/apps/web/src/lib/helius/__tests__/award-xp-source.test.ts
@@ -1,0 +1,188 @@
+/* eslint-disable import/order -- vi.mock('server-only') must be hoisted above
+   the module imports so the `server-only` graph loads under vitest. */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Keypair } from "@solana/web3.js";
+
+// #736 (adversarial-review MINOR): the SECURITY-critical part of #736 is the
+// EXPLICIT p_source each award_xp call site passes — especially handleXpRewarded,
+// which pins 'platform' so an arbitrary authority memo can't reverse-derive into
+// a league-eligible source. That value is convention, not structure, so it must
+// be pinned by a test: a future edit (or the reviewer's mutation flipping
+// 'platform' → 'lesson') must fail CI here.
+
+vi.mock("server-only", () => ({}));
+
+const { resolveUserId, resolveCourseId, resolveLessonId, awardXpCalls, rpc } =
+  vi.hoisted(() => {
+    const awardXpCalls: Array<Record<string, unknown>> = [];
+    return {
+      resolveUserId: vi.fn<(addr: string) => Promise<string | null>>(),
+      resolveCourseId: vi.fn<() => Promise<string | null>>(),
+      resolveLessonId: vi.fn<() => Promise<string | null>>(),
+      awardXpCalls,
+      rpc: vi.fn((fn: string, params: Record<string, unknown>) => {
+        if (fn === "award_xp") awardXpCalls.push(params);
+        return Promise.resolve({ data: 10, error: null });
+      }),
+    };
+  });
+
+// A chainable admin-client stub: every query-builder method returns the same
+// chain, and awaiting it (or .single()) resolves a benign empty result — so the
+// non-target work in each handler (progress upsert, enrollment update, credential
+// / achievement / finalize side-paths) runs without throwing, and only the
+// award_xp rpc calls are captured.
+vi.mock("@/lib/supabase/admin", () => {
+  const chain: Record<string, unknown> = {};
+  const result = { data: null, error: null };
+  for (const m of [
+    "select",
+    "insert",
+    "upsert",
+    "update",
+    "delete",
+    "eq",
+    "in",
+    "order",
+    "limit",
+  ]) {
+    chain[m] = () => chain;
+  }
+  chain.single = () => Promise.resolve(result);
+  chain.maybeSingle = () => Promise.resolve(result);
+  chain.then = (onF: (v: typeof result) => unknown) =>
+    Promise.resolve(result).then(onF);
+  return {
+    createAdminClient: () => ({ from: () => chain, rpc }),
+  };
+});
+
+// Non-target collaborators → inert (they must not fire their own award_xp).
+vi.mock("@/lib/helius/resolvers", () => ({
+  resolveUserId,
+  resolveCourseId,
+  resolveLessonId,
+}));
+vi.mock("@/lib/gamification/surprise-bonus", () => ({
+  maybeAwardSurpriseBonus: vi.fn(async () => undefined),
+}));
+vi.mock("@/lib/solana/pda", () => ({ getProgramId: () => "program-id" }));
+vi.mock("@/lib/solana/academy-program", () => ({
+  getConnection: () => ({}),
+  finalizeCourse: vi.fn(),
+  issueCredential: vi.fn(),
+  awardAchievement: vi.fn(),
+}));
+vi.mock("@/lib/solana/academy-reads", () => ({
+  fetchEnrollment: vi.fn(async () => null),
+  fetchCourse: vi.fn(async () => null),
+}));
+vi.mock("@/lib/solana/bitmap", () => ({ isCourseComplete: () => false }));
+vi.mock("@/lib/content/deployments", () => ({
+  isCourseInMaintenance: vi.fn(async () => false),
+}));
+vi.mock("@/lib/platform/freeze", () => ({
+  isPlatformFrozen: vi.fn(async () => false),
+}));
+vi.mock("@/lib/content/queries", () => ({
+  getCourseById: vi.fn(async () => null),
+  getDeployedAchievements: vi.fn(async () => []),
+}));
+vi.mock("@/lib/gamification/achievements", () => ({
+  checkNewAchievements: vi.fn(() => []),
+  buildUserState: vi.fn(),
+}));
+vi.mock("@/lib/solana/arweave", () => ({ uploadCertificateMetadata: vi.fn() }));
+vi.mock("@/lib/logging", () => ({ logError: vi.fn() }));
+
+import {
+  handleLessonCompleted,
+  handleCourseFinalized,
+  handleAchievementAwarded,
+  handleXpRewarded,
+} from "../event-handlers";
+
+const SIG = "sig-1";
+// The handlers construct real PublicKeys from these addresses (credential /
+// finalize side-paths), so they must be valid base58.
+const LEARNER = Keypair.generate().publicKey.toBase58();
+const COURSE = Keypair.generate().publicKey.toBase58();
+const CREATOR = Keypair.generate().publicKey.toBase58();
+const ASSET = Keypair.generate().publicKey.toBase58();
+
+/** The p_source of the captured award_xp call whose idempotency key ends `key`. */
+function sourceForKey(key: string): unknown {
+  const call = awardXpCalls.find((c) =>
+    String(c.p_idempotency_key ?? "").endsWith(key)
+  );
+  expect(call, `award_xp call for ${key}`).toBeDefined();
+  return call?.p_source;
+}
+
+beforeEach(() => {
+  awardXpCalls.length = 0;
+  vi.clearAllMocks();
+  resolveUserId.mockImplementation(async (addr: string) =>
+    addr === CREATOR ? "creator-1" : "user-1"
+  );
+  resolveCourseId.mockResolvedValue("course-1");
+  resolveLessonId.mockResolvedValue("lesson-1");
+});
+
+describe("#736 award_xp call-site sources are explicit (not reverse-derived)", () => {
+  it("handleXpRewarded pins 'platform' — an arbitrary memo can NEVER launder into eligibility", async () => {
+    // THE fix. Note the memo is shaped like an eligible source on purpose.
+    await handleXpRewarded(
+      {
+        recipient: LEARNER,
+        amount: 500n,
+        memo: "Completed lesson: totally-legit",
+      } as never,
+      SIG
+    );
+    expect(sourceForKey("XpRewarded")).toBe("platform");
+  });
+
+  it("handleLessonCompleted passes 'lesson'", async () => {
+    await handleLessonCompleted(
+      {
+        learner: LEARNER,
+        course: COURSE,
+        lessonIndex: 0,
+        xpEarned: 25,
+        timestamp: 1_700_000_000,
+      } as never,
+      SIG
+    );
+    expect(sourceForKey("LessonCompleted")).toBe("lesson");
+  });
+
+  it("handleCourseFinalized passes 'course_completion' (bonus) and 'creator_reward' (creator)", async () => {
+    await handleCourseFinalized(
+      {
+        learner: LEARNER,
+        course: COURSE,
+        creator: CREATOR,
+        bonusXp: 200,
+        creatorXp: 30,
+        timestamp: 1_700_000_000,
+      } as never,
+      SIG
+    );
+    expect(sourceForKey("CourseFinalized:bonus")).toBe("course_completion");
+    expect(sourceForKey("CourseFinalized:creator")).toBe("creator_reward");
+  });
+
+  it("handleAchievementAwarded passes 'achievement'", async () => {
+    await handleAchievementAwarded(
+      {
+        recipient: LEARNER,
+        achievementId: "first-steps",
+        asset: ASSET,
+        xpReward: 50,
+      } as never,
+      SIG
+    );
+    expect(sourceForKey("AchievementAwarded:xp")).toBe("achievement");
+  });
+});

--- a/apps/web/src/lib/helius/event-handlers.ts
+++ b/apps/web/src/lib/helius/event-handlers.ts
@@ -201,6 +201,8 @@ export async function handleLessonCompleted(
     p_reason: `Completed lesson: ${lessonId ?? `index:${event.lessonIndex}`}`,
     p_idempotency_key: `${txSignature}:LessonCompleted`,
     p_tx_signature: txSignature,
+    // #736: state the source positively rather than let it be reverse-derived.
+    p_source: "lesson",
   });
 
   if (xpError) {
@@ -294,6 +296,7 @@ export async function handleCourseFinalized(
       p_reason: `Course completion bonus: ${courseId}`,
       p_idempotency_key: `${txSignature}:CourseFinalized:bonus`,
       p_tx_signature: txSignature,
+      p_source: "course_completion", // #736
     });
 
     if (xpError) {
@@ -320,6 +323,7 @@ export async function handleCourseFinalized(
         p_reason: `Creator reward: ${courseId}`,
         p_idempotency_key: `${txSignature}:CourseFinalized:creator`,
         p_tx_signature: txSignature,
+        p_source: "creator_reward", // #736 — not league-eligible
       });
 
       if (creatorXpError) {
@@ -399,6 +403,7 @@ export async function handleAchievementAwarded(
       p_reason: `Achievement reward: ${event.achievementId}`,
       p_idempotency_key: `${txSignature}:AchievementAwarded:xp`,
       p_tx_signature: txSignature,
+      p_source: "achievement", // #736
     });
 
     if (xpError) {
@@ -435,6 +440,11 @@ export async function handleXpRewarded(
     p_reason: event.memo || "XP reward",
     p_idempotency_key: `${txSignature}:XpRewarded`,
     p_tx_signature: txSignature,
+    // #736 (the fix's core): XpRewarded carries an ARBITRARY authority-supplied
+    // memo. Without an explicit source, a promo shaped as "Completed lesson: …"
+    // would reverse-derive to a league-eligible source. Pin it to 'platform'
+    // (never league-eligible) so the memo can never launder into eligibility.
+    p_source: "platform",
   });
 
   if (error) {

--- a/apps/web/src/lib/solana/__tests__/onchain-queue.test.ts
+++ b/apps/web/src/lib/solana/__tests__/onchain-queue.test.ts
@@ -288,7 +288,11 @@ describe("retryPendingOnchainActions — xp credit-loss (#372)", () => {
     await retryPendingOnchainActions(USER_ID);
 
     expect(h.awardXp).toHaveBeenCalledWith(
-      expect.objectContaining({ p_idempotency_key: "lesson-4", p_amount: 40 })
+      expect.objectContaining({
+        p_idempotency_key: "lesson-4",
+        p_amount: 40,
+        p_source: "lesson", // #736 — the "xp" thread credits lesson XP
+      })
     );
   });
 });
@@ -379,7 +383,11 @@ describe("retryPendingOnchainActions — course_finalize credit-loss (#372)", ()
     const patch = patchFor("r-cf-ok");
     expect(typeof patch?.resolved_at).toBe("string");
     expect(h.awardXp).toHaveBeenCalledWith(
-      expect.objectContaining({ p_idempotency_key: "course-3", p_amount: 1500 })
+      expect.objectContaining({
+        p_idempotency_key: "course-3",
+        p_amount: 1500,
+        p_source: "course_completion", // #736
+      })
     );
   });
 });
@@ -601,7 +609,10 @@ describe("retryPendingOnchainActions — global freeze deferral (reset wave B2)"
 
     // quest_xp credited + resolved (DB-only, never frozen).
     expect(h.awardXp).toHaveBeenCalledWith(
-      expect.objectContaining({ p_idempotency_key: "quest-daily-1" })
+      expect.objectContaining({
+        p_idempotency_key: "quest-daily-1",
+        p_source: "quest", // #736 — Pass 1 credits daily-quest XP
+      })
     );
     expect(typeof patchFor("r-quest")?.resolved_at).toBe("string");
     // The on-chain achievement row is deferred.

--- a/apps/web/src/lib/solana/onchain-queue.ts
+++ b/apps/web/src/lib/solana/onchain-queue.ts
@@ -376,7 +376,8 @@ export async function retryPendingOnchainActions(
               row,
               xpAmount,
               reason,
-              row.reference_id
+              row.reference_id,
+              "course_completion" // #736
             );
             continue; // settlement (resolve / cap-defer / retry) handled inside
           }
@@ -409,7 +410,8 @@ export async function retryPendingOnchainActions(
             row,
             xpAmount,
             reason,
-            row.reference_id
+            row.reference_id,
+            "lesson" // #736 — the "xp" action credits lesson-completion XP
           );
           continue; // settlement (resolve / cap-defer / retry) handled inside
         }
@@ -542,7 +544,8 @@ async function creditQuestXpRows(
       row,
       xpAmount,
       reason,
-      row.reference_id
+      row.reference_id,
+      "quest" // #736 — Pass 1 credits daily-quest XP
     );
   }
 }
@@ -569,7 +572,11 @@ async function creditXpAndSettle(
   row: PendingActionRow,
   amount: number,
   reason: string,
-  idempotencyKey: string
+  idempotencyKey: string,
+  // #736: the true source of this credit, stated positively by the caller (the
+  // queue payload's reason may be authority-influenced, so it is not trusted to
+  // reverse-derive the league-eligibility-bearing source).
+  source: string
 ): Promise<void> {
   try {
     const { data: credited, error: xpRpcError } = await adminClient.rpc(
@@ -579,6 +586,7 @@ async function creditXpAndSettle(
         p_amount: amount,
         p_reason: reason,
         p_idempotency_key: idempotencyKey,
+        p_source: source,
       }
     );
     if (xpRpcError) throw new Error(xpRpcError.message);

--- a/apps/web/src/lib/supabase/__tests__/xp-source-positive-writes-guard.test.ts
+++ b/apps/web/src/lib/supabase/__tests__/xp-source-positive-writes-guard.test.ts
@@ -1,0 +1,104 @@
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, it, expect } from "vitest";
+
+// #736: xp_transactions.source must be written POSITIVELY by award_xp's callers,
+// not reverse-derived from the memo prefix (an authority-supplied XpRewarded memo
+// shaped as "Completed lesson: …" would otherwise launder into a league-eligible
+// source). PL/pgSQL can't run in unit tests, so pin the SQL invariants in both
+// the migration (what applies) and the schema.sql mirror.
+
+function findRepoRoot(): string {
+  let dir = dirname(fileURLToPath(import.meta.url));
+  while (!existsSync(resolve(dir, "supabase/schema.sql"))) {
+    const parent = dirname(dir);
+    if (parent === dir)
+      throw new Error("repo root (supabase/schema.sql) not found");
+    dir = parent;
+  }
+  return dir;
+}
+
+const repoRoot = findRepoRoot();
+const migration = readFileSync(
+  resolve(
+    repoRoot,
+    "supabase/migrations/20260727120000_xp_source_positive_writes.sql"
+  ),
+  "utf8"
+);
+const schema = readFileSync(resolve(repoRoot, "supabase/schema.sql"), "utf8");
+
+function awardXpDef(sql: string): string {
+  const start = sql.indexOf("CREATE OR REPLACE FUNCTION award_xp(");
+  expect(start, "award_xp defined").toBeGreaterThan(-1);
+  return sql.slice(start, sql.indexOf("$$;", start));
+}
+
+for (const [label, sql] of [
+  ["migration", migration] as const,
+  ["schema.sql", schema] as const,
+]) {
+  describe(`#736 positive source — ${label}`, () => {
+    it("award_xp takes an explicit p_source parameter (defaulting to NULL)", () => {
+      const def = awardXpDef(sql);
+      expect(def).toMatch(/p_source TEXT DEFAULT NULL/);
+    });
+
+    it("source is positive-with-fallback: COALESCE(p_source, derivation)", () => {
+      const def = awardXpDef(sql);
+      expect(def).toContain(
+        "COALESCE(p_source, public.xp_source_for_reason(p_reason))"
+      );
+      // The bare reverse-derivation must be gone from the go-forward body.
+      expect(def).not.toMatch(
+        /v_source\s*:=\s*public\.xp_source_for_reason\(p_reason\)\s*;/
+      );
+    });
+  });
+}
+
+describe("#736 positive source — migration hygiene", () => {
+  it("runs in one explicit transaction", () => {
+    expect(migration).toContain("BEGIN;");
+    expect(migration).toContain("COMMIT;");
+  });
+
+  it("drops the 5-arg signature before creating the 6-arg one (no overload)", () => {
+    expect(migration).toContain(
+      "DROP FUNCTION IF EXISTS award_xp(UUID, INTEGER, TEXT, TEXT, TEXT);"
+    );
+    // The applied CREATE carries the new 6th parameter.
+    const applied = migration.slice(0, migration.indexOf("COMMIT;"));
+    expect(applied).toMatch(/p_source TEXT DEFAULT NULL/);
+  });
+
+  it("documents the HARD dependency on 190000's bodies (next_streak_value)", () => {
+    // award_xp's body calls next_streak_value (added by 190000); applying this
+    // before those bodies breaks every award. The header must say so.
+    expect(migration).toMatch(/APPLY AFTER 20260726190000_streak_forgiveness/);
+    expect(migration).toContain("next_streak_value");
+  });
+
+  it("ships a SELF-CONTAINED rollback (inline body, no cross-file re-apply)", () => {
+    expect(migration).toContain(
+      "DROP FUNCTION IF EXISTS award_xp(UUID, INTEGER, TEXT, TEXT, TEXT, TEXT);"
+    );
+    // The rollback restores the prior 5-arg body inline (commented), with the
+    // bare reverse-derivation — proof it is the pre-#736 body, not a reference.
+    expect(migration).toMatch(
+      /--\s+v_source := public\.xp_source_for_reason\(p_reason\);/
+    );
+    expect(migration).not.toMatch(/re-apply .*migration/i);
+  });
+
+  it("re-hardens grants on the recreated function", () => {
+    expect(migration).toContain(
+      "REVOKE EXECUTE ON FUNCTION award_xp FROM authenticated, anon, public;"
+    );
+    expect(migration).toContain(
+      "GRANT EXECUTE ON FUNCTION award_xp TO service_role;"
+    );
+  });
+});

--- a/apps/web/src/lib/supabase/types.ts
+++ b/apps/web/src/lib/supabase/types.ts
@@ -1311,6 +1311,7 @@ export type Database = {
           p_amount: number;
           p_idempotency_key?: string;
           p_reason: string;
+          p_source?: string;
           p_tx_signature?: string;
           p_user_id: string;
         };

--- a/supabase/migrations/20260727120000_xp_source_positive_writes.sql
+++ b/supabase/migrations/20260727120000_xp_source_positive_writes.sql
@@ -1,0 +1,246 @@
+-- ============================================================================
+-- Migration: write xp_transactions.source POSITIVELY at the award_xp call site
+-- (#736).
+--
+-- THE PROBLEM: xp_transactions.source (the column the cohort-league anti-gaming
+-- allowlist filters on, LX-B9a / #574) is REVERSE-DERIVED from the free-text
+-- reason prefix by xp_source_for_reason(), whose ELSE -> 'platform' is the only
+-- thing excluding an arbitrary award. The on-chain XpRewarded instruction takes
+-- an authority-supplied memo; a promo shaped as 'Completed lesson: ...' would
+-- derive to 'lesson' and score as league-eligible. Not urgent (memos are
+-- authority-only; leagues are display-only; the 5000/day cap bounds volume) —
+-- but source should be a POSITIVE FACT each writer states, not an inference.
+--
+-- THE FIX: award_xp gains a `p_source TEXT` parameter. When the caller passes a
+-- source it is used verbatim; when NULL it falls back to xp_source_for_reason()
+-- (unchanged) so any un-migrated caller keeps its current behaviour. The call
+-- sites now pass their true source explicitly — critically, the XpRewarded
+-- arbitrary-memo path passes 'platform', so a promo can never masquerade as
+-- league-eligible regardless of its memo. xp_source_for_reason() is demoted to
+-- the default/backfill helper it always should have been.
+--
+-- award_community_xp already writes 'community' positively (hardcoded) — it is
+-- not reverse-derived, so it is unchanged.
+--
+-- ⚠ HARD DEPENDENCY — APPLY AFTER 20260726190000_streak_forgiveness (its bodies,
+-- not just its schema half). This migration's award_xp body is the CURRENT
+-- in-tree body, which calls public.next_streak_value() (added by 190000). On a
+-- database where 190000's FUNCTION BODIES are not yet applied (e.g. prod as of
+-- 2026-07-27 — its schema half is applied, its bodies are blocked on #750/#758,
+-- see docs/DB-MIGRATION-LEDGER.md), award_xp would reference an undefined
+-- function and every XP award would error at runtime. Sequence: land #758 →
+-- apply 190000 bodies → apply this. This is the #750 "which prod state does it
+-- assume" discipline made explicit. Snapshot pg_get_functiondef for award_xp
+-- before applying (CREATE OR REPLACE is only reversible if the prior body was
+-- captured); the self-contained rollback below also restores it verbatim.
+--
+-- Signature change (5 -> 6 args) means CREATE OR REPLACE cannot edit in place:
+-- DROP the 5-arg function, CREATE the 6-arg one. award_xp is called only from
+-- service_role TS (no SQL object depends on it), so the drop has no cascade.
+-- Idempotent: DROP IF EXISTS + CREATE OR REPLACE. Explicit BEGIN/COMMIT.
+-- Mirrored into supabase/schema.sql.
+-- ============================================================================
+
+BEGIN;
+
+-- Drop the 5-arg signature so the 6-arg definition below is unambiguous (a
+-- lingering 5-arg overload would make named-arg calls resolve non-deterministically).
+DROP FUNCTION IF EXISTS award_xp(UUID, INTEGER, TEXT, TEXT, TEXT);
+
+CREATE OR REPLACE FUNCTION award_xp(
+  p_user_id UUID,
+  p_amount INTEGER,
+  p_reason TEXT,
+  p_idempotency_key TEXT DEFAULT NULL,
+  p_tx_signature TEXT DEFAULT NULL,
+  p_source TEXT DEFAULT NULL
+) RETURNS INTEGER
+-- Returns the amount actually credited (after per-award + daily-cap clamps).
+--   > 0 → XP landed (or, for an idempotency-key duplicate, had already landed —
+--         the previously-credited amount is returned so callers can treat
+--         "already delivered" as delivered).
+--   = 0 → nothing was credited (invalid amount, or the daily cap consumed the
+--         whole award). Queue-style callers MUST NOT mark delivery resolved
+--         on 0 — the credit was dropped, not delivered.
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_last_activity DATE;
+  v_current_streak INTEGER;
+  v_longest_streak INTEGER;
+  v_new_streak INTEGER;
+  v_new_longest INTEGER;
+  v_daily_total INTEGER;
+  v_prev_amount INTEGER;
+  -- Typed source (LX-B9a / #736). POSITIVE by default: the caller states it via
+  -- p_source. Falls back to the reason-prefix derivation (xp_source_for_reason)
+  -- only when the caller passes NULL, so un-migrated callers are unaffected and
+  -- old-row backfill still shares one mapping.
+  v_source TEXT;
+  c_max_award_xp CONSTANT INTEGER := 2000;
+  c_max_daily_award_xp CONSTANT INTEGER := 5000;
+BEGIN
+  IF p_amount IS NULL OR p_amount <= 0 THEN
+    RETURN 0;
+  END IF;
+
+  IF p_amount > c_max_award_xp THEN
+    p_amount := c_max_award_xp;
+  END IF;
+
+  PERFORM pg_advisory_xact_lock(hashtext('award_xp:' || p_user_id::text)::bigint);
+
+  SELECT COALESCE(SUM(amount), 0) INTO v_daily_total
+  FROM public.xp_transactions
+  WHERE user_id = p_user_id
+    AND created_at >= date_trunc('day', now() AT TIME ZONE 'UTC') AT TIME ZONE 'UTC'
+    AND reason NOT LIKE 'community:%';
+
+  IF v_daily_total >= c_max_daily_award_xp THEN
+    RETURN 0;
+  END IF;
+
+  IF v_daily_total + p_amount > c_max_daily_award_xp THEN
+    p_amount := c_max_daily_award_xp - v_daily_total;
+  END IF;
+
+  IF p_amount <= 0 THEN
+    RETURN 0;
+  END IF;
+
+  -- Positive source wins; derivation is the fallback for NULL (#736).
+  v_source := COALESCE(p_source, public.xp_source_for_reason(p_reason));
+
+  IF p_idempotency_key IS NOT NULL THEN
+    INSERT INTO public.xp_transactions (user_id, amount, reason, source, idempotency_key, tx_signature)
+    VALUES (p_user_id, p_amount, p_reason, v_source, p_idempotency_key, p_tx_signature)
+    ON CONFLICT (user_id, idempotency_key) WHERE idempotency_key IS NOT NULL DO NOTHING;
+
+    IF NOT FOUND THEN
+      SELECT amount INTO v_prev_amount
+      FROM public.xp_transactions
+      WHERE user_id = p_user_id
+        AND idempotency_key = p_idempotency_key;
+      RETURN COALESCE(v_prev_amount, 0);
+    END IF;
+  ELSE
+    INSERT INTO public.xp_transactions (user_id, amount, reason, source, tx_signature)
+    VALUES (p_user_id, p_amount, p_reason, v_source, p_tx_signature);
+  END IF;
+
+  -- Get current streak state, then apply the shared forgiveness-aware decision.
+  -- next_streak_value consumes freezes (and logs frozen days) on a forgiven gap
+  -- BEFORE the upsert below writes the surviving streak — same row, one txn.
+  SELECT last_activity_date, current_streak, longest_streak
+  INTO v_last_activity, v_current_streak, v_longest_streak
+  FROM public.user_xp
+  WHERE user_id = p_user_id;
+
+  v_new_streak := public.next_streak_value(p_user_id, v_last_activity, v_current_streak, CURRENT_DATE);
+  v_new_longest := GREATEST(COALESCE(v_longest_streak, 0), v_new_streak);
+
+  INSERT INTO public.user_xp (user_id, total_xp, level, last_activity_date, current_streak, longest_streak)
+  VALUES (
+    p_user_id,
+    p_amount,
+    floor(sqrt(p_amount / 100.0))::int,
+    CURRENT_DATE,
+    v_new_streak,
+    v_new_longest
+  )
+  ON CONFLICT (user_id) DO UPDATE SET
+    total_xp = user_xp.total_xp + p_amount,
+    level = floor(sqrt((user_xp.total_xp + p_amount) / 100.0))::int,
+    last_activity_date = CURRENT_DATE,
+    current_streak = v_new_streak,
+    longest_streak = v_new_longest;
+
+  RETURN p_amount;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION award_xp FROM authenticated, anon, public;
+GRANT EXECUTE ON FUNCTION award_xp TO service_role;
+
+COMMIT;
+
+-- ============================================================================
+-- ROLLBACK (self-contained) — restores the pre-#736 award_xp (5-arg, source
+-- reverse-derived). Inlines the prior body verbatim; no cross-file reference
+-- (the #750 lesson). ASSUMES the same prod state this migration assumes —
+-- 190000's bodies applied — because the restored body also calls
+-- next_streak_value; on a DB without it, restore from your pre-apply
+-- pg_get_functiondef snapshot instead. Run as one transaction:
+-- ----------------------------------------------------------------------------
+-- BEGIN;
+-- DROP FUNCTION IF EXISTS award_xp(UUID, INTEGER, TEXT, TEXT, TEXT, TEXT);
+-- CREATE OR REPLACE FUNCTION award_xp(
+--   p_user_id UUID,
+--   p_amount INTEGER,
+--   p_reason TEXT,
+--   p_idempotency_key TEXT DEFAULT NULL,
+--   p_tx_signature TEXT DEFAULT NULL
+-- ) RETURNS INTEGER
+-- LANGUAGE plpgsql
+-- SECURITY DEFINER
+-- SET search_path = ''
+-- AS $$
+-- DECLARE
+--   v_last_activity DATE;
+--   v_current_streak INTEGER;
+--   v_longest_streak INTEGER;
+--   v_new_streak INTEGER;
+--   v_new_longest INTEGER;
+--   v_daily_total INTEGER;
+--   v_prev_amount INTEGER;
+--   v_source TEXT;
+--   c_max_award_xp CONSTANT INTEGER := 2000;
+--   c_max_daily_award_xp CONSTANT INTEGER := 5000;
+-- BEGIN
+--   IF p_amount IS NULL OR p_amount <= 0 THEN RETURN 0; END IF;
+--   IF p_amount > c_max_award_xp THEN p_amount := c_max_award_xp; END IF;
+--   PERFORM pg_advisory_xact_lock(hashtext('award_xp:' || p_user_id::text)::bigint);
+--   SELECT COALESCE(SUM(amount), 0) INTO v_daily_total
+--   FROM public.xp_transactions
+--   WHERE user_id = p_user_id
+--     AND created_at >= date_trunc('day', now() AT TIME ZONE 'UTC') AT TIME ZONE 'UTC'
+--     AND reason NOT LIKE 'community:%';
+--   IF v_daily_total >= c_max_daily_award_xp THEN RETURN 0; END IF;
+--   IF v_daily_total + p_amount > c_max_daily_award_xp THEN p_amount := c_max_daily_award_xp - v_daily_total; END IF;
+--   IF p_amount <= 0 THEN RETURN 0; END IF;
+--   v_source := public.xp_source_for_reason(p_reason);
+--   IF p_idempotency_key IS NOT NULL THEN
+--     INSERT INTO public.xp_transactions (user_id, amount, reason, source, idempotency_key, tx_signature)
+--     VALUES (p_user_id, p_amount, p_reason, v_source, p_idempotency_key, p_tx_signature)
+--     ON CONFLICT (user_id, idempotency_key) WHERE idempotency_key IS NOT NULL DO NOTHING;
+--     IF NOT FOUND THEN
+--       SELECT amount INTO v_prev_amount FROM public.xp_transactions
+--       WHERE user_id = p_user_id AND idempotency_key = p_idempotency_key;
+--       RETURN COALESCE(v_prev_amount, 0);
+--     END IF;
+--   ELSE
+--     INSERT INTO public.xp_transactions (user_id, amount, reason, source, tx_signature)
+--     VALUES (p_user_id, p_amount, p_reason, v_source, p_tx_signature);
+--   END IF;
+--   SELECT last_activity_date, current_streak, longest_streak
+--   INTO v_last_activity, v_current_streak, v_longest_streak
+--   FROM public.user_xp WHERE user_id = p_user_id;
+--   v_new_streak := public.next_streak_value(p_user_id, v_last_activity, v_current_streak, CURRENT_DATE);
+--   v_new_longest := GREATEST(COALESCE(v_longest_streak, 0), v_new_streak);
+--   INSERT INTO public.user_xp (user_id, total_xp, level, last_activity_date, current_streak, longest_streak)
+--   VALUES (p_user_id, p_amount, floor(sqrt(p_amount / 100.0))::int, CURRENT_DATE, v_new_streak, v_new_longest)
+--   ON CONFLICT (user_id) DO UPDATE SET
+--     total_xp = user_xp.total_xp + p_amount,
+--     level = floor(sqrt((user_xp.total_xp + p_amount) / 100.0))::int,
+--     last_activity_date = CURRENT_DATE,
+--     current_streak = v_new_streak,
+--     longest_streak = v_new_longest;
+--   RETURN p_amount;
+-- END;
+-- $$;
+-- REVOKE EXECUTE ON FUNCTION award_xp FROM authenticated, anon, public;
+-- GRANT EXECUTE ON FUNCTION award_xp TO service_role;
+-- COMMIT;
+-- ============================================================================

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -397,11 +397,12 @@ CREATE POLICY "Anyone can read nft metadata"
 -- ─────────────────────────────────────────────
 
 -- Reason→source derivation for xp_transactions.source (LX-B9a, #557).
--- Single source of truth for the go-forward writes in award_xp AND the
--- backfill in 20260726120000_add_xp_transactions_source.sql — old and new
--- rows can never disagree. Source is DERIVED from the reason prefix (not a
--- new award_xp parameter) because reason prefixes are already load-bearing
--- machine-readable convention here: award_xp's daily cap counts
+-- DEMOTED by #736 to a DEFAULT/BACKFILL helper: award_xp now takes an explicit
+-- p_source and only falls back to this derivation when the caller passes NULL.
+-- Still the single mapping shared by that fallback AND the old-row backfill in
+-- 20260726120000_add_xp_transactions_source.sql, so derived rows never disagree.
+-- Kept because reason prefixes remain load-bearing elsewhere: award_xp's daily
+-- cap counts
 -- `NOT LIKE 'community:%'`, award_community_xp's cap counts
 -- `LIKE 'community:%'`, and durable pending_onchain_actions payloads carry
 -- reasons that may be swept long after deploy. Each prefix below is verified
@@ -577,7 +578,8 @@ CREATE OR REPLACE FUNCTION award_xp(
   p_amount INTEGER,
   p_reason TEXT,
   p_idempotency_key TEXT DEFAULT NULL,
-  p_tx_signature TEXT DEFAULT NULL
+  p_tx_signature TEXT DEFAULT NULL,
+  p_source TEXT DEFAULT NULL
 ) RETURNS INTEGER
 -- Returns the amount actually credited (after per-award + daily-cap clamps).
 --   > 0 → XP landed (or, for an idempotency-key duplicate, had already landed —
@@ -598,8 +600,10 @@ DECLARE
   v_new_longest INTEGER;
   v_daily_total INTEGER;
   v_prev_amount INTEGER;
-  -- Typed source derived from the reason prefix (LX-B9a) — see
-  -- xp_source_for_reason for the mapping and the derivation rationale.
+  -- Typed source (LX-B9a / #736). POSITIVE by default: the caller states it via
+  -- p_source. Falls back to the reason-prefix derivation (xp_source_for_reason)
+  -- only when the caller passes NULL, so un-migrated callers are unaffected and
+  -- old-row backfill still shares one mapping.
   v_source TEXT;
   -- Hard per-award ceiling. Matches the documented "max 2000 XP per award"
   -- (the largest legitimate single award is a course-completion bonus).
@@ -646,7 +650,8 @@ BEGIN
     RETURN 0;
   END IF;
 
-  v_source := public.xp_source_for_reason(p_reason);
+  -- Positive source wins; derivation is the fallback for NULL (#736).
+  v_source := COALESCE(p_source, public.xp_source_for_reason(p_reason));
 
   IF p_idempotency_key IS NOT NULL THEN
     INSERT INTO public.xp_transactions (user_id, amount, reason, source, idempotency_key, tx_signature)


### PR DESCRIPTION
Closes #736. Makes `xp_transactions.source` — the column the cohort-league anti-gaming allowlist filters on — a **positive fact** each writer states, instead of a value reverse-derived from the free-text memo prefix.

**This PR touches the XP writers — please give it its own adversarial review** (per the routing note). No live-DB action.

## The vulnerability
`source` was set by `xp_source_for_reason(reason)`, whose `ELSE → 'platform'` is the only thing excluding an arbitrary award. The on-chain `XpRewarded` instruction takes an **authority-supplied memo**; a promo shaped as `"Completed lesson: …"` derives to `'lesson'` → scores as league-eligible. (Not urgent: memos are authority-only, leagues are display-only, the 5000/day cap bounds volume — but it should be positive.)

## The fix
- **`award_xp` gains `p_source TEXT DEFAULT NULL`**; `v_source := COALESCE(p_source, xp_source_for_reason(p_reason))`. Explicit source wins; the derivation is the NULL fallback (un-migrated callers unaffected, backfill still shares one mapping). `xp_source_for_reason` demoted to the default/backfill helper. Signature 5→6 args, so the migration **DROPs the 5-arg then CREATEs the 6-arg** (award_xp has no SQL dependents). Byte-mirrored into `schema.sql`.
- **Call sites pass their true source** (all 8): lesson / course_completion / creator_reward / achievement / quest — and, the **core fix**, the `XpRewarded` arbitrary-memo path passes **`'platform'`** (never league-eligible), so a memo can't launder into eligibility. Threaded a `source` arg through `onchain-queue`'s `creditXpAndSettle` (its 3 callers). `award_community_xp` already writes `'community'` positively — unchanged.

## ⚠ Hard apply-ordering dependency (the #750 discipline)
`award_xp`'s body calls `next_streak_value()` (added by `20260726190000_streak_forgiveness`). Prod has 190000's **schema half** applied but its **function bodies are not** (blocked on #750/#758, see `docs/DB-MIGRATION-LEDGER.md`). **This migration MUST apply after 190000's bodies** — applying it earlier makes `award_xp` reference an undefined function and every award errors. Documented prominently in the migration header and pinned by the guard test. Sequence: land #758 → apply 190000 bodies → apply this. The **self-contained rollback** inlines the prior 5-arg body verbatim (no cross-file re-apply); snapshot `pg_get_functiondef` before applying.

## Verify
- `pnpm typecheck` — green (6/6)
- `pnpm --filter web test` — 210 files / 1912 tests pass (new guard test: source is positive-with-fallback; migration DROP-then-CREATE; hard-dep documented; self-contained rollback; grants re-hardened)
