### PR TITLE
db(#607): reset chain-mirrored state stranded by the program move (migration half)

### DIFF
--- a/apps/web/src/lib/supabase/__tests__/stranded-instance-cleanup-guard.test.ts
+++ b/apps/web/src/lib/supabase/__tests__/stranded-instance-cleanup-guard.test.ts
@@ -1,0 +1,139 @@
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, it, expect } from "vitest";
+
+// #607: reset the chain-mirrored learner state stranded by the program move
+// (Dsro2Cd9 live; the DB still mirrors the superseded 7NeJa instance). This is a
+// DATA-only migration (DML, no DDL) — it is NOT mirrored into schema.sql, so
+// there is no snapshot to cross-check. Instead these tests pin the two
+// invariants a careless edit could break and this issue exists to protect:
+//   1. user_xp is UPDATED to zero, NEVER deleted (it is 1:1 with profiles; a
+//      DELETE would blast the 73 pristine event-cohort rows).
+//   2. profiles and auth.users are NEVER written (only read for assertions);
+//      certificates is EXCLUDED from the reset.
+// PL/pgSQL execution can't run in this repo (no DB harness — see the sibling
+// *-guard tests), so we assert against the migration SQL text directly.
+
+function findRepoRoot(): string {
+  let dir = dirname(fileURLToPath(import.meta.url));
+  while (!existsSync(resolve(dir, "supabase/schema.sql"))) {
+    const parent = dirname(dir);
+    if (parent === dir)
+      throw new Error("repo root (supabase/schema.sql) not found");
+    dir = parent;
+  }
+  return dir;
+}
+
+const repoRoot = findRepoRoot();
+const migration = readFileSync(
+  resolve(
+    repoRoot,
+    "supabase/migrations/20260727140000_stranded_instance_state_cleanup.sql"
+  ),
+  "utf8"
+);
+
+// Executable SQL only: strip `--` line comments so the "never write X" checks
+// test statements, not the header/ROLLBACK prose (which legitimately DISCUSSES
+// `DELETE FROM user_xp` as the mistake to avoid). No string literal in this file
+// contains `--`, so a line-level strip is sufficient.
+const code = migration.replace(/--[^\n]*/g, "");
+
+describe("#607 stranded-instance cleanup — transaction + shape", () => {
+  it("runs in one explicit transaction", () => {
+    expect(migration).toContain("BEGIN;");
+    expect(migration).toContain("COMMIT;");
+  });
+
+  it("resets the four chain-mirrored tables with straight DELETEs", () => {
+    for (const t of [
+      "enrollments",
+      "user_progress",
+      "xp_transactions",
+      "user_achievements",
+    ]) {
+      expect(migration).toContain(`DELETE FROM public.${t};`);
+    }
+  });
+});
+
+describe("#607 stranded-instance cleanup — user_xp is UPDATE, never DELETE", () => {
+  it("UPDATEs user_xp to zero", () => {
+    expect(migration).toMatch(/UPDATE\s+public\.user_xp\s+SET/);
+    expect(migration).toContain("total_xp           = 0");
+  });
+
+  it("never issues a DELETE or TRUNCATE against user_xp", () => {
+    // The whole point of the 🔴 note: a DELETE here would remove the 73 pristine
+    // signup rows (37x the target). This must never regress. Checked against
+    // executable SQL only (the header prose names the mistake on purpose).
+    expect(code).not.toMatch(/DELETE\s+FROM\s+(public\.)?user_xp/i);
+    expect(code).not.toMatch(/TRUNCATE\s+(TABLE\s+)?(public\.)?user_xp/i);
+  });
+
+  it("scopes the UPDATE so it can only touch rows with state (idempotent)", () => {
+    // WHERE must gate on the state columns so it hits exactly the 2 active rows
+    // now and 0 rows on re-apply — never the 73 pristine zeros.
+    expect(migration).toMatch(
+      /WHERE\s+total_xp\s*>\s*0[\s\S]*last_activity_date\s+IS\s+NOT\s+NULL/
+    );
+  });
+
+  it("preserves streak_freezes (not in the SET list)", () => {
+    // Owner decision: streak_freezes is the earned freeze inventory (0 today),
+    // preserved as-is. It must not appear on the left of an assignment.
+    expect(code).not.toMatch(/streak_freezes\s*=/);
+  });
+
+  it("asserts user_xp row count is unchanged after the reset", () => {
+    expect(migration).toMatch(/user_xp must be UPDATED to zero, NEVER deleted/);
+  });
+});
+
+describe("#607 stranded-instance cleanup — never-touch + excluded tables", () => {
+  it("never writes profiles or auth.users (reads for assertions only)", () => {
+    for (const t of ["profiles", "auth\\.users"]) {
+      expect(code).not.toMatch(
+        new RegExp(`DELETE\\s+FROM\\s+(public\\.)?${t}`, "i")
+      );
+      expect(code).not.toMatch(
+        new RegExp(`UPDATE\\s+(public\\.)?${t}\\s+SET`, "i")
+      );
+      expect(code).not.toMatch(
+        new RegExp(`INSERT\\s+INTO\\s+(public\\.)?${t}`, "i")
+      );
+      expect(code).not.toMatch(
+        new RegExp(`TRUNCATE\\s+(TABLE\\s+)?(public\\.)?${t}`, "i")
+      );
+    }
+  });
+
+  it("never writes the EXCLUDED certificates table", () => {
+    expect(code).not.toMatch(/DELETE\s+FROM\s+(public\.)?certificates/i);
+    expect(code).not.toMatch(/UPDATE\s+(public\.)?certificates\s+SET/i);
+    expect(code).not.toMatch(/TRUNCATE\s+(TABLE\s+)?(public\.)?certificates/i);
+  });
+
+  it("asserts profiles, auth.users and certificates are unchanged at COMMIT", () => {
+    expect(migration).toMatch(/this migration must never touch profiles/);
+    expect(migration).toMatch(/must never touch auth users/);
+    expect(migration).toMatch(/certificates is EXCLUDED from this cleanup/);
+  });
+
+  it("pins the posted dry-run baseline so it fails on drift", () => {
+    expect(migration).toContain("b.profiles <> 75");
+    expect(migration).toContain("b.user_xp <> 75");
+    expect(migration).toContain("b.certificates <> 4");
+  });
+});
+
+describe("#607 stranded-instance cleanup — honesty about reversibility", () => {
+  it("declares itself NOT rollback-able rather than shipping a fake rollback", () => {
+    expect(migration).toMatch(/ROLLBACK — NONE/);
+    expect(migration).toMatch(/DESTRUCTIVE and NOT reversible/);
+    // #750 lesson: must not tell the operator to "re-apply" anything to recover.
+    expect(migration).not.toMatch(/re-apply the migration/i);
+  });
+});

--- a/apps/web/src/lib/supabase/__tests__/stranded-instance-cleanup-guard.test.ts
+++ b/apps/web/src/lib/supabase/__tests__/stranded-instance-cleanup-guard.test.ts
@@ -87,6 +87,25 @@ describe("#607 stranded-instance cleanup — transaction + shape", () => {
     // Post-DELETE: no pre-move row survives in any reset table.
     expect(migration).toMatch(/pre-move rows survived the reset/);
   });
+
+  it("aborts on a NULL anchor in any reset table (invisible to the era filter)", () => {
+    // A NULL timestamp is invisible to `< '2026-07-21'`, so a NULL-anchored row
+    // would silently survive the wipe. None of the four columns is NOT NULL, so
+    // each gets an explicit IS NULL count that must be 0. Mutation: removing any
+    // one of these four asserts fails this test.
+    expect(migration).toContain("b.enr_null <> 0");
+    expect(migration).toContain("b.up_null <> 0");
+    expect(migration).toContain("b.xp_null <> 0");
+    expect(migration).toContain("b.ach_null <> 0");
+    for (const [ts] of [
+      ["enrolled_at"],
+      ["completed_at"],
+      ["created_at"],
+      ["unlocked_at"],
+    ] as const) {
+      expect(code).toMatch(new RegExp(`WHERE ${ts}\\s+IS NULL`));
+    }
+  });
 });
 
 describe("#607 stranded-instance cleanup — user_xp is UPDATE, never DELETE", () => {

--- a/apps/web/src/lib/supabase/__tests__/stranded-instance-cleanup-guard.test.ts
+++ b/apps/web/src/lib/supabase/__tests__/stranded-instance-cleanup-guard.test.ts
@@ -47,15 +47,45 @@ describe("#607 stranded-instance cleanup — transaction + shape", () => {
     expect(migration).toContain("COMMIT;");
   });
 
-  it("resets the four chain-mirrored tables with straight DELETEs", () => {
-    for (const t of [
-      "enrollments",
-      "user_progress",
-      "xp_transactions",
-      "user_achievements",
-    ]) {
-      expect(migration).toContain(`DELETE FROM public.${t};`);
+  // The four reset tables are ERA-SCOPED, each on its own creation timestamp,
+  // so live post-move rows (e.g. the #725 e2e completions, or any completion
+  // written directly by lessons/complete) survive. A missing WHERE would make
+  // the DELETE unbounded — the exact bug the review caught — so pin the shape.
+  const ERA_DELETES: ReadonlyArray<[string, string]> = [
+    ["enrollments", "enrolled_at"],
+    ["user_progress", "completed_at"],
+    ["xp_transactions", "created_at"],
+    ["user_achievements", "unlocked_at"],
+  ];
+
+  it("era-scopes every DELETE (WHERE <ts> < '2026-07-21')", () => {
+    for (const [table, ts] of ERA_DELETES) {
+      expect(code).toMatch(
+        new RegExp(
+          `DELETE FROM public\\.${table}\\s+WHERE ${ts}\\s*<\\s*'2026-07-21'`
+        )
+      );
     }
+  });
+
+  it("never issues an UNBOUNDED delete against a reset table (mutation guard)", () => {
+    // Removing the WHERE must fail this: a bare `DELETE FROM public.<t>;` would
+    // destroy live post-move rows.
+    for (const [table] of ERA_DELETES) {
+      expect(code).not.toMatch(
+        new RegExp(`DELETE FROM public\\.${table}\\s*;`)
+      );
+    }
+  });
+
+  it("guards the era counts before AND after deleting", () => {
+    // Pre-DELETE: each era count must equal the posted value OR 0 (idempotent).
+    expect(migration).toContain("b.enr_era NOT IN (0, 7)");
+    expect(migration).toContain("b.up_era NOT IN (0, 63)");
+    expect(migration).toContain("b.xp_era NOT IN (0, 16)");
+    expect(migration).toContain("b.ach_era NOT IN (0, 7)");
+    // Post-DELETE: no pre-move row survives in any reset table.
+    expect(migration).toMatch(/pre-move rows survived the reset/);
   });
 });
 

--- a/apps/web/src/lib/supabase/__tests__/stranded-instance-cleanup-guard.test.ts
+++ b/apps/web/src/lib/supabase/__tests__/stranded-instance-cleanup-guard.test.ts
@@ -122,12 +122,23 @@ describe("#607 stranded-instance cleanup — user_xp is UPDATE, never DELETE", (
     expect(code).not.toMatch(/TRUNCATE\s+(TABLE\s+)?(public\.)?user_xp/i);
   });
 
-  it("scopes the UPDATE so it can only touch rows with state (idempotent)", () => {
-    // WHERE must gate on the state columns so it hits exactly the 2 active rows
-    // now and 0 rows on re-apply — never the 73 pristine zeros.
-    expect(migration).toMatch(
-      /WHERE\s+total_xp\s*>\s*0[\s\S]*last_activity_date\s+IS\s+NOT\s+NULL/
+  it("ERA-scopes the UPDATE so it can never zero a post-move learner", () => {
+    // Round-3 gate catch: the WHERE must gate on the state columns AND carry the
+    // era clause. The state chain alone matched EVERY active learner — including
+    // valid post-move ones (e.g. the #725 test learner's 1070 XP). The era
+    // clause (last_activity_date < 2026-07-21) confines it to stranded rows.
+    expect(code).toMatch(/last_activity_date\s+IS\s+NOT\s+NULL/); // state chain
+    expect(code).toMatch(
+      /UPDATE public\.user_xp[\s\S]*?AND last_activity_date < '2026-07-21'/
     );
+  });
+
+  it("verifies no state-bearing row has a NULL activity date (era clause is NULL-blind)", () => {
+    // award_xp always stamps last_activity_date, so total_xp>0 with a NULL date
+    // is impossible by construction — but the era clause cannot see a NULL, so
+    // the migration verifies the claim and aborts if ever violated (else a
+    // silent survivor of an irreversible reset). Expect 0.
+    expect(migration).toContain("uxp_null_state");
   });
 
   it("preserves streak_freezes (not in the SET list)", () => {
@@ -138,6 +149,16 @@ describe("#607 stranded-instance cleanup — user_xp is UPDATE, never DELETE", (
 
   it("asserts user_xp row count is unchanged after the reset", () => {
     expect(migration).toMatch(/user_xp must be UPDATED to zero, NEVER deleted/);
+  });
+
+  it("ERA-scopes the post-reset assert (live learners may keep state)", () => {
+    // Round-3 gate catch: the post-assert must NOT demand universal zeroing (a
+    // valid post-move learner would abort the txn). It asserts only that no
+    // STRANDED-ERA row (last_activity_date < 2026-07-21) still carries state.
+    expect(migration).toMatch(/stranded-era row\(s\) still carry state/);
+    expect(migration).not.toMatch(
+      /user_xp still has % row\(s\) with non-zero state/
+    );
   });
 });
 
@@ -165,16 +186,28 @@ describe("#607 stranded-instance cleanup — never-touch + excluded tables", () 
     expect(code).not.toMatch(/TRUNCATE\s+(TABLE\s+)?(public\.)?certificates/i);
   });
 
-  it("asserts profiles, auth.users and certificates are unchanged at COMMIT", () => {
+  it("never writes deployed_programs (holds the #725 proof row) and asserts it unchanged", () => {
+    // Gate ask: deployed_programs now has its first real row; assert untouched.
+    expect(code).not.toMatch(/DELETE\s+FROM\s+(public\.)?deployed_programs/i);
+    expect(code).not.toMatch(/UPDATE\s+(public\.)?deployed_programs\s+SET/i);
+    expect(migration).toMatch(/must never touch deployed_programs/);
+  });
+
+  it("asserts profiles, auth.users, certificates and deployed_programs unchanged at COMMIT", () => {
     expect(migration).toMatch(/this migration must never touch profiles/);
     expect(migration).toMatch(/must never touch auth users/);
     expect(migration).toMatch(/certificates is EXCLUDED from this cleanup/);
+    expect(migration).toMatch(/must never touch deployed_programs/);
   });
 
-  it("pins the posted dry-run baseline so it fails on drift", () => {
-    expect(migration).toContain("b.profiles <> 75");
-    expect(migration).toContain("b.user_xp <> 75");
-    expect(migration).toContain("b.certificates <> 4");
+  it("drops the absolute live-count pins (drift-immune before==after only)", () => {
+    // Round-3 gate catch: absolute pins on LIVE counts go stale the moment
+    // anyone signs up (profiles/user_xp were already 76/76). They reintroduce
+    // the race era-scoping removes. Only the frozen ERA counts deserve pins; the
+    // never-touch tables are guarded by before==after (see the asserts above).
+    expect(migration).not.toContain("b.profiles <> 75");
+    expect(migration).not.toContain("b.user_xp <> 75");
+    expect(migration).not.toContain("b.certificates <> 4");
   });
 });
 

--- a/supabase/migrations/20260727140000_stranded_instance_state_cleanup.sql
+++ b/supabase/migrations/20260727140000_stranded_instance_state_cleanup.sql
@@ -1,0 +1,200 @@
+-- ============================================================================
+-- Migration: reset the chain-mirrored learner state stranded by the program
+-- move (Dsro2Cd9 is live; the DB still mirrors the superseded 7NeJa instance).
+-- Task: #607 (P0)  [area:onchain][area:db]  — reset-wave pattern (cf. #356)
+-- ----------------------------------------------------------------------------
+-- ⚠️  certificates IS EXCLUDED. It is NOT reset here (owner decision:
+--     "investigate separately"). Its 4 rows are Metaplex Core assets that may
+--     still exist in a wallet, so the DB row can be the only surviving record
+--     of a real credential. This migration never writes certificates and
+--     asserts its row count is unchanged. profiles and auth.users are likewise
+--     NEVER TOUCHED — asserted unchanged at COMMIT.
+--
+-- WHAT HAPPENED. The app now writes to program Dsro2Cd9…; the prior instance
+-- 7NeJa… holds the only on-chain counterparts of the learner state below.
+-- Enrollment PDAs are program-derived, so that state is unreachable from the
+-- new id and cannot be migrated. The 5 stranded-era courses were also
+-- deactivated in the on-chain window (#713/#606), so these rows are
+-- doubly-orphaned. Owner decision (2026-07-25): do NOT re-mint XP — start from
+-- zero and clean up the DB. Nothing has been awarded since the move (the Helius
+-- webhook still points at the old program — see #607), so this touches pre-move
+-- history only; no live learner activity is discarded.
+--
+-- WHAT THIS DOES. Reset ONLY chain-mirrored state:
+--   • enrollments, user_progress, xp_transactions, user_achievements — straight
+--     DELETE (every row is stranded-era; the counts below are all 2 users).
+--   • user_xp — UPDATE-to-zero, NEVER DELETE (see the 🔴 note).
+--
+-- 🔴 user_xp IS 1:1 WITH profiles — UPDATE, NEVER DELETE. Unlike the other four
+-- tables (rows for 2 users), user_xp has a row for ALL 75 learners: a row is
+-- created at signup regardless of activity. 73 of those are pristine zeros
+-- belonging to last week's event cohort. A `DELETE FROM user_xp` — the shape
+-- that is correct for the other four — would remove 73 rows with nothing to
+-- reset, a blast radius 37× the real target, adjacent to the exact constraint
+-- this issue protects. So user_xp gets a WHERE-scoped UPDATE that touches
+-- EXACTLY the 2 rows carrying state and cannot reach the 73 pristine ones. The
+-- post-apply assert pins user_xp's row count unchanged (== profiles), enforcing
+-- "never deleted from" structurally.
+--
+-- DRY-RUN COUNTS (gate, prod pywhtmidcrptomrabbrw, posted on #607 2026-07-27).
+-- RE-VERIFY these against the live DB BEFORE applying — the assert block below
+-- hard-pins profiles=75 / user_xp=75 / certificates=4, so a drift (e.g. new
+-- signups grew the cohort) fails the migration and forces reconciliation rather
+-- than running against stale evidence. Re-run:
+--
+--   select 'enrollments' t, count(*) rows, count(distinct user_id) users from enrollments
+--   union all select 'user_progress', count(*), count(distinct user_id) from user_progress
+--   union all select 'user_xp', count(*), count(distinct user_id) from user_xp
+--   union all select 'xp_transactions', count(*), count(distinct user_id) from xp_transactions
+--   union all select 'user_achievements', count(*), count(distinct user_id) from user_achievements;
+--   -- expected: enrollments 7/2 · user_progress 63/2 · xp_transactions 16/2
+--   --           user_achievements 7/2 · user_xp 75/75
+--
+--   select count(*) filter (where total_xp > 0 OR current_streak > 0
+--       OR longest_streak > 0 OR last_activity_date IS NOT NULL) as active_rows
+--   from user_xp;   -- expected: 2 (the only rows the UPDATE may touch)
+--
+--   select 'profiles' t, count(*) from profiles           -- expected 75 (NEVER TOUCH)
+--   union all select 'auth.users', count(*) from auth.users;
+--   select count(*) from certificates;                    -- expected 4 (EXCLUDED)
+--
+-- Idempotent: the DELETEs re-run to 0 rows; the UPDATE's WHERE matches 0 rows
+-- once state is zeroed. Safe to re-apply (re-apply is a no-op). One explicit
+-- BEGIN/COMMIT so the whole file is a single transaction under a manual apply
+-- and every assert can roll the batch back atomically.
+--
+-- schema.sql is NOT touched: this is a DATA-only migration (DML, no DDL). The
+-- schema.sql snapshot carries structure, not rows, so there is nothing to
+-- mirror (cf. the data-only precedents 20260630165536 / 20260703150000). The
+-- guard test pins the UPDATE-not-DELETE and never-touch invariants against this
+-- file directly.
+--
+-- ⚠️  NOT ROLLBACK-ABLE — this is destructive and the ROLLBACK section at the
+-- bottom says so honestly (the #750 lesson: a rollback that cannot restore the
+-- data must not pretend to). Deleted rows and overwritten XP are gone. Per the
+-- owner decision, recovery is by design "progress is recoverable": learners
+-- redo the affected activity against the live program, and XP re-accrues once
+-- the reward loop is repointed (the #607 webhook fix). Certificates are
+-- untouched, so no credential is lost.
+-- ============================================================================
+
+BEGIN;
+
+-- Snapshot the must-not-touch / excluded baselines inside the transaction so the
+-- post-apply asserts can prove they did not move (ON COMMIT DROP: temp, no
+-- residue). Captured BEFORE any DML.
+CREATE TEMP TABLE _cleanup_baseline ON COMMIT DROP AS
+SELECT
+  (SELECT count(*) FROM public.profiles)     AS profiles,
+  (SELECT count(*) FROM auth.users)          AS auth_users,
+  (SELECT count(*) FROM public.user_xp)      AS user_xp,
+  (SELECT count(*) FROM public.certificates) AS certificates;
+
+-- ── Reset chain-mirrored state (straight DELETEs; every row is stranded-era) ──
+-- Maps to the dry-run counts: enrollments 7 · user_progress 63 ·
+-- xp_transactions 16 · user_achievements 7 (all 2 users). Idempotent: a re-run
+-- finds no rows and deletes 0.
+DELETE FROM public.enrollments;
+DELETE FROM public.user_progress;
+DELETE FROM public.xp_transactions;
+DELETE FROM public.user_achievements;
+
+-- ── user_xp: UPDATE-to-zero, scoped to the rows that actually carry state ──
+-- The WHERE self-limits to the 2 active rows and can NEVER reach the 73 pristine
+-- signup rows, and it makes the statement idempotent (once zeroed, it matches 0
+-- rows on re-apply). streak_freezes is INTENTIONALLY preserved as-is (0 for
+-- every row today; it is the earned freeze inventory, not chain-mirrored XP —
+-- owner decision to leave it untouched). Setting current_streak and
+-- longest_streak together to 0 satisfies chk_user_xp_longest_gte_current.
+UPDATE public.user_xp
+SET total_xp           = 0,
+    level              = 0,
+    current_streak     = 0,
+    longest_streak     = 0,
+    last_activity_date = NULL
+WHERE total_xp > 0
+   OR level > 0
+   OR current_streak > 0
+   OR longest_streak > 0
+   OR last_activity_date IS NOT NULL;
+
+-- ── Assertions — roll the whole batch back if any invariant is violated ──
+DO $$
+DECLARE
+  b            RECORD;
+  v_active     INTEGER;
+  v_profiles   INTEGER;
+  v_auth       INTEGER;
+  v_user_xp    INTEGER;
+  v_certs      INTEGER;
+BEGIN
+  SELECT * INTO b FROM _cleanup_baseline;
+
+  -- Baseline guard: the posted dry-run evidence this migration was written
+  -- against. A mismatch means the DB drifted (e.g. new signups) — STOP and
+  -- reconcile against fresh counts rather than run on stale assumptions.
+  IF b.profiles <> 75 THEN
+    RAISE EXCEPTION 'profiles baseline drifted: expected 75 (posted #607), got %. Re-run the DRY-RUN counts and reconcile before applying.', b.profiles;
+  END IF;
+  IF b.user_xp <> 75 THEN
+    RAISE EXCEPTION 'user_xp baseline drifted: expected 75 (== profiles), got %. Re-run the DRY-RUN counts before applying.', b.user_xp;
+  END IF;
+  IF b.certificates <> 4 THEN
+    RAISE EXCEPTION 'certificates baseline drifted: expected 4 (posted #607), got %. certificates is EXCLUDED — investigate before applying.', b.certificates;
+  END IF;
+
+  -- NEVER-TOUCH invariant: profiles and auth.users unchanged across the batch.
+  SELECT count(*) INTO v_profiles FROM public.profiles;
+  SELECT count(*) INTO v_auth     FROM auth.users;
+  IF v_profiles <> b.profiles THEN
+    RAISE EXCEPTION 'profiles row count changed (% -> %): this migration must never touch profiles', b.profiles, v_profiles;
+  END IF;
+  IF v_auth <> b.auth_users THEN
+    RAISE EXCEPTION 'auth.users row count changed (% -> %): this migration must never touch auth users', b.auth_users, v_auth;
+  END IF;
+
+  -- EXCLUDED invariant: certificates untouched.
+  SELECT count(*) INTO v_certs FROM public.certificates;
+  IF v_certs <> b.certificates THEN
+    RAISE EXCEPTION 'certificates row count changed (% -> %): certificates is EXCLUDED from this cleanup', b.certificates, v_certs;
+  END IF;
+
+  -- UPDATE-not-DELETE invariant: user_xp keeps every row (still 1:1 with
+  -- profiles). If this fired, a DELETE reached user_xp — the exact mistake the
+  -- 🔴 note exists to prevent.
+  SELECT count(*) INTO v_user_xp FROM public.user_xp;
+  IF v_user_xp <> b.user_xp THEN
+    RAISE EXCEPTION 'user_xp row count changed (% -> %): user_xp must be UPDATED to zero, NEVER deleted', b.user_xp, v_user_xp;
+  END IF;
+
+  -- Reset invariant: no user_xp row carries state after the UPDATE (proves the
+  -- 2 active rows were zeroed; also confirms idempotent re-runs are no-ops).
+  SELECT count(*) INTO v_active FROM public.user_xp
+  WHERE total_xp > 0 OR level > 0 OR current_streak > 0
+     OR longest_streak > 0 OR last_activity_date IS NOT NULL;
+  IF v_active <> 0 THEN
+    RAISE EXCEPTION 'user_xp still has % row(s) with non-zero state after reset', v_active;
+  END IF;
+
+  RAISE NOTICE 'stranded-instance cleanup OK: profiles=% (untouched), auth.users=% (untouched), certificates=% (excluded, untouched), user_xp=% rows all zeroed', v_profiles, v_auth, v_certs, v_user_xp;
+END $$;
+
+COMMIT;
+
+-- ============================================================================
+-- ROLLBACK — NONE. This migration is DESTRUCTIVE and NOT reversible.
+-- ----------------------------------------------------------------------------
+-- There is deliberately no rollback block. The deleted enrollments /
+-- user_progress / xp_transactions / user_achievements rows and the overwritten
+-- user_xp XP/streak values are GONE at COMMIT; nothing in the repo or this file
+-- can restore them (the #750 lesson: a rollback that cannot reproduce the prior
+-- state must not pretend to). If a restore is ever required, it must come from a
+-- point-in-time / PITR database backup taken BEFORE this migration — capture one
+-- first if that possibility matters to the operator.
+--
+-- Recovery is by the owner's design decision (2026-07-25): "resetting progress
+-- is recoverable." Learners simply redo the affected activity against the live
+-- program (Dsro2Cd9), and XP/streaks re-accrue once the reward loop is repointed
+-- (the Helius webhook fix on #607). No identity is lost (profiles / auth.users
+-- untouched) and no credential is lost (certificates excluded).
+-- ============================================================================

--- a/supabase/migrations/20260727140000_stranded_instance_state_cleanup.sql
+++ b/supabase/migrations/20260727140000_stranded_instance_state_cleanup.sql
@@ -16,13 +16,44 @@
 -- new id and cannot be migrated. The 5 stranded-era courses were also
 -- deactivated in the on-chain window (#713/#606), so these rows are
 -- doubly-orphaned. Owner decision (2026-07-25): do NOT re-mint XP — start from
--- zero and clean up the DB. Nothing has been awarded since the move (the Helius
--- webhook still points at the old program — see #607), so this touches pre-move
--- history only; no live learner activity is discarded.
+-- zero and clean up the DB.
 --
--- WHAT THIS DOES. Reset ONLY chain-mirrored state:
---   • enrollments, user_progress, xp_transactions, user_achievements — straight
---     DELETE (every row is stranded-era; the counts below are all 2 users).
+-- 🟠 SAFETY IS BY ERA BOUNDARY, NOT "the webhook is dark". An earlier draft of
+-- this migration argued the reset was safe because XP/achievements are
+-- webhook-driven and the Helius webhook still points at the old program. That
+-- argument is FALSE for user_progress: /api/lessons/complete
+-- (lessons/complete/route.ts) upserts user_progress DIRECTLY, independent of the
+-- webhook, so a live completion after the move lands a real post-move row. The
+-- gate's #725 end-to-end test created exactly such rows (enroll → completions →
+-- XP on Dsro2Cd9) AFTER the dry-run counts were posted. A full-table
+-- `DELETE FROM user_progress` would have destroyed them.
+--
+-- So every DELETE is ERA-SCOPED to rows created BEFORE the move, and no reset is
+-- justified by the webhook being dark. Anything at/after the boundary is live
+-- and survives untouched.
+--
+-- 🔵 ERA BOUNDARY = '2026-07-21' (the Dsro2Cd9 deploy date, a fresh Pinocchio
+-- instance). PROVENANCE: the gate's #607 dry-run cross-check counted
+-- `xp_transactions where created_at < '2026-07-21'` and it reproduced the posted
+-- xp_transactions total — so this boundary cleanly separates stranded (pre-move)
+-- rows from live (post-move) rows. Each of the four tables is scoped on its own
+-- creation timestamp (all reliable — see below); the pre-DELETE assert re-checks
+-- that the era-scoped count still equals the posted value, so a wrong boundary
+-- or a live row inside the window ABORTS rather than deletes the wrong rows.
+--
+--   table              scope column     why it is a reliable creation anchor
+--   enrollments        enrolled_at      TIMESTAMPTZ DEFAULT NOW(), non-null
+--   user_progress      completed_at     every writer (route:575, batch-complete,
+--                                        resync, webhook) sets completed:true +
+--                                        completed_at; no path inserts a NULL
+--   xp_transactions    created_at       TIMESTAMPTZ DEFAULT NOW(); the exact
+--                                        column the gate's cross-check used
+--   user_achievements  unlocked_at      TIMESTAMPTZ DEFAULT NOW(), non-null
+--
+-- WHAT THIS DOES. Reset ONLY chain-mirrored, pre-move state:
+--   • enrollments, user_progress, xp_transactions, user_achievements —
+--     ERA-SCOPED DELETE (WHERE <ts> < '2026-07-21'); the posted counts are all
+--     2 users / 7·63·16·7 rows, all pre-move.
 --   • user_xp — UPDATE-to-zero, NEVER DELETE (see the 🔴 note).
 --
 -- 🔴 user_xp IS 1:1 WITH profiles — UPDATE, NEVER DELETE. Unlike the other four
@@ -32,23 +63,29 @@
 -- that is correct for the other four — would remove 73 rows with nothing to
 -- reset, a blast radius 37× the real target, adjacent to the exact constraint
 -- this issue protects. So user_xp gets a WHERE-scoped UPDATE that touches
--- EXACTLY the 2 rows carrying state and cannot reach the 73 pristine ones. The
--- post-apply assert pins user_xp's row count unchanged (== profiles), enforcing
--- "never deleted from" structurally.
+-- EXACTLY the 2 rows carrying state and cannot reach the 73 pristine ones. It
+-- is NOT era-scoped: user_xp is cumulative, not per-event, so "zero the active
+-- rows" is the reset — and the 2 active rows are the same stranded learners
+-- (no XP has been awarded on the new instance to anyone else). The post-apply
+-- assert pins user_xp's row count unchanged (== profiles), enforcing "never
+-- deleted from" structurally.
 --
 -- DRY-RUN COUNTS (gate, prod pywhtmidcrptomrabbrw, posted on #607 2026-07-27).
--- RE-VERIFY these against the live DB BEFORE applying — the assert block below
--- hard-pins profiles=75 / user_xp=75 / certificates=4, so a drift (e.g. new
--- signups grew the cohort) fails the migration and forces reconciliation rather
--- than running against stale evidence. Re-run:
+-- RE-VERIFY these against the live DB BEFORE applying — the assert blocks pin
+-- the era-scoped delete counts (7/63/16/7) and profiles=75 / user_xp=75 /
+-- certificates=4, so a drift fails the migration and forces reconciliation
+-- rather than running against stale evidence. Re-run:
 --
---   select 'enrollments' t, count(*) rows, count(distinct user_id) users from enrollments
---   union all select 'user_progress', count(*), count(distinct user_id) from user_progress
---   union all select 'user_xp', count(*), count(distinct user_id) from user_xp
---   union all select 'xp_transactions', count(*), count(distinct user_id) from xp_transactions
---   union all select 'user_achievements', count(*), count(distinct user_id) from user_achievements;
---   -- expected: enrollments 7/2 · user_progress 63/2 · xp_transactions 16/2
---   --           user_achievements 7/2 · user_xp 75/75
+--   -- era-scoped delete targets (must match the DELETE WHERE clauses below):
+--   select 'enrollments' t, count(*) from enrollments       where enrolled_at  < '2026-07-21'
+--   union all select 'user_progress', count(*) from user_progress   where completed_at < '2026-07-21'
+--   union all select 'xp_transactions', count(*) from xp_transactions where created_at   < '2026-07-21'
+--   union all select 'user_achievements', count(*) from user_achievements where unlocked_at < '2026-07-21';
+--   -- expected: enrollments 7 · user_progress 63 · xp_transactions 16 · user_achievements 7
+--
+--   -- sanity: the posted UNCONDITIONAL counts were the same before #725 ran;
+--   -- after #725 the unconditional counts may be HIGHER (live rows) but the
+--   -- era-scoped counts above must be unchanged.
 --
 --   select count(*) filter (where total_xp > 0 OR current_streak > 0
 --       OR longest_streak > 0 OR last_activity_date IS NOT NULL) as active_rows
@@ -58,16 +95,17 @@
 --   union all select 'auth.users', count(*) from auth.users;
 --   select count(*) from certificates;                    -- expected 4 (EXCLUDED)
 --
--- Idempotent: the DELETEs re-run to 0 rows; the UPDATE's WHERE matches 0 rows
--- once state is zeroed. Safe to re-apply (re-apply is a no-op). One explicit
--- BEGIN/COMMIT so the whole file is a single transaction under a manual apply
--- and every assert can roll the batch back atomically.
+-- Idempotent: the era-scoped DELETEs re-run to 0 rows (nothing pre-move
+-- remains); the UPDATE's WHERE matches 0 rows once state is zeroed. Safe to
+-- re-apply (re-apply is a no-op). One explicit BEGIN/COMMIT so the whole file
+-- is a single transaction under a manual apply and every assert can roll the
+-- batch back atomically.
 --
 -- schema.sql is NOT touched: this is a DATA-only migration (DML, no DDL). The
 -- schema.sql snapshot carries structure, not rows, so there is nothing to
 -- mirror (cf. the data-only precedents 20260630165536 / 20260703150000). The
--- guard test pins the UPDATE-not-DELETE and never-touch invariants against this
--- file directly.
+-- guard test pins the era-scoped-DELETE, UPDATE-not-DELETE and never-touch
+-- invariants against this file directly.
 --
 -- ⚠️  NOT ROLLBACK-ABLE — this is destructive and the ROLLBACK section at the
 -- bottom says so honestly (the #750 lesson: a rollback that cannot restore the
@@ -80,24 +118,51 @@
 
 BEGIN;
 
--- Snapshot the must-not-touch / excluded baselines inside the transaction so the
--- post-apply asserts can prove they did not move (ON COMMIT DROP: temp, no
--- residue). Captured BEFORE any DML.
+-- Snapshot the must-not-touch / excluded baselines AND the era-scoped delete
+-- counts inside the transaction so the asserts can prove exactly what moved (ON
+-- COMMIT DROP: temp, no residue). Captured BEFORE any DML.
 CREATE TEMP TABLE _cleanup_baseline ON COMMIT DROP AS
 SELECT
   (SELECT count(*) FROM public.profiles)     AS profiles,
   (SELECT count(*) FROM auth.users)          AS auth_users,
   (SELECT count(*) FROM public.user_xp)      AS user_xp,
-  (SELECT count(*) FROM public.certificates) AS certificates;
+  (SELECT count(*) FROM public.certificates) AS certificates,
+  (SELECT count(*) FROM public.enrollments       WHERE enrolled_at  < '2026-07-21') AS enr_era,
+  (SELECT count(*) FROM public.user_progress     WHERE completed_at < '2026-07-21') AS up_era,
+  (SELECT count(*) FROM public.xp_transactions   WHERE created_at   < '2026-07-21') AS xp_era,
+  (SELECT count(*) FROM public.user_achievements WHERE unlocked_at  < '2026-07-21') AS ach_era;
 
--- ── Reset chain-mirrored state (straight DELETEs; every row is stranded-era) ──
+-- ── Pre-DELETE structural guard ──
+-- Each era-scoped count must equal its posted value (first apply) OR 0 (already
+-- applied) — this preserves idempotency AND aborts on any drift: a live row
+-- that fell inside the era window, or a boundary that no longer reproduces the
+-- posted count, stops the batch before a single row is deleted.
+DO $$
+DECLARE b RECORD;
+BEGIN
+  SELECT * INTO b FROM _cleanup_baseline;
+  IF b.enr_era NOT IN (0, 7) THEN
+    RAISE EXCEPTION 'enrollments era-count (enrolled_at < 2026-07-21) = % — expected 7 (first apply) or 0 (re-apply). Re-run the DRY-RUN counts and reconcile the boundary before applying.', b.enr_era;
+  END IF;
+  IF b.up_era NOT IN (0, 63) THEN
+    RAISE EXCEPTION 'user_progress era-count (completed_at < 2026-07-21) = % — expected 63 or 0. A live post-move row must NOT fall in this window; re-verify before applying.', b.up_era;
+  END IF;
+  IF b.xp_era NOT IN (0, 16) THEN
+    RAISE EXCEPTION 'xp_transactions era-count (created_at < 2026-07-21) = % — expected 16 or 0. Re-verify before applying.', b.xp_era;
+  END IF;
+  IF b.ach_era NOT IN (0, 7) THEN
+    RAISE EXCEPTION 'user_achievements era-count (unlocked_at < 2026-07-21) = % — expected 7 or 0. Re-verify before applying.', b.ach_era;
+  END IF;
+END $$;
+
+-- ── Reset chain-mirrored state (ERA-SCOPED DELETEs — post-move rows survive) ──
 -- Maps to the dry-run counts: enrollments 7 · user_progress 63 ·
--- xp_transactions 16 · user_achievements 7 (all 2 users). Idempotent: a re-run
--- finds no rows and deletes 0.
-DELETE FROM public.enrollments;
-DELETE FROM public.user_progress;
-DELETE FROM public.xp_transactions;
-DELETE FROM public.user_achievements;
+-- xp_transactions 16 · user_achievements 7 (all 2 users, all pre-move).
+-- Idempotent: a re-run finds no pre-move rows and deletes 0.
+DELETE FROM public.enrollments       WHERE enrolled_at  < '2026-07-21';
+DELETE FROM public.user_progress     WHERE completed_at < '2026-07-21';
+DELETE FROM public.xp_transactions   WHERE created_at   < '2026-07-21';
+DELETE FROM public.user_achievements WHERE unlocked_at  < '2026-07-21';
 
 -- ── user_xp: UPDATE-to-zero, scoped to the rows that actually carry state ──
 -- The WHERE self-limits to the 2 active rows and can NEVER reach the 73 pristine
@@ -118,7 +183,7 @@ WHERE total_xp > 0
    OR longest_streak > 0
    OR last_activity_date IS NOT NULL;
 
--- ── Assertions — roll the whole batch back if any invariant is violated ──
+-- ── Post-apply assertions — roll the whole batch back if any invariant fails ──
 DO $$
 DECLARE
   b            RECORD;
@@ -127,6 +192,10 @@ DECLARE
   v_auth       INTEGER;
   v_user_xp    INTEGER;
   v_certs      INTEGER;
+  v_enr        INTEGER;
+  v_up         INTEGER;
+  v_xp         INTEGER;
+  v_ach        INTEGER;
 BEGIN
   SELECT * INTO b FROM _cleanup_baseline;
 
@@ -176,7 +245,18 @@ BEGIN
     RAISE EXCEPTION 'user_xp still has % row(s) with non-zero state after reset', v_active;
   END IF;
 
-  RAISE NOTICE 'stranded-instance cleanup OK: profiles=% (untouched), auth.users=% (untouched), certificates=% (excluded, untouched), user_xp=% rows all zeroed', v_profiles, v_auth, v_certs, v_user_xp;
+  -- Era-clean invariant: no pre-move row survives in any of the four reset
+  -- tables (proves the era-scoped DELETEs ran). Post-move (live) rows, which are
+  -- OUTSIDE this window, are deliberately not counted here and are preserved.
+  SELECT count(*) INTO v_enr FROM public.enrollments       WHERE enrolled_at  < '2026-07-21';
+  SELECT count(*) INTO v_up  FROM public.user_progress     WHERE completed_at < '2026-07-21';
+  SELECT count(*) INTO v_xp  FROM public.xp_transactions   WHERE created_at   < '2026-07-21';
+  SELECT count(*) INTO v_ach FROM public.user_achievements WHERE unlocked_at  < '2026-07-21';
+  IF v_enr <> 0 OR v_up <> 0 OR v_xp <> 0 OR v_ach <> 0 THEN
+    RAISE EXCEPTION 'pre-move rows survived the reset: enrollments=%, user_progress=%, xp_transactions=%, user_achievements=%', v_enr, v_up, v_xp, v_ach;
+  END IF;
+
+  RAISE NOTICE 'stranded-instance cleanup OK: deleted pre-move rows (enr % / up % / xp % / ach %); profiles=% (untouched), auth.users=% (untouched), certificates=% (excluded, untouched), user_xp=% rows all zeroed', b.enr_era, b.up_era, b.xp_era, b.ach_era, v_profiles, v_auth, v_certs, v_user_xp;
 END $$;
 
 COMMIT;

--- a/supabase/migrations/20260727140000_stranded_instance_state_cleanup.sql
+++ b/supabase/migrations/20260727140000_stranded_instance_state_cleanup.sql
@@ -130,7 +130,16 @@ SELECT
   (SELECT count(*) FROM public.enrollments       WHERE enrolled_at  < '2026-07-21') AS enr_era,
   (SELECT count(*) FROM public.user_progress     WHERE completed_at < '2026-07-21') AS up_era,
   (SELECT count(*) FROM public.xp_transactions   WHERE created_at   < '2026-07-21') AS xp_era,
-  (SELECT count(*) FROM public.user_achievements WHERE unlocked_at  < '2026-07-21') AS ach_era;
+  (SELECT count(*) FROM public.user_achievements WHERE unlocked_at  < '2026-07-21') AS ach_era,
+  -- NULL-anchor counts: none of the four timestamp columns is NOT NULL, so a
+  -- NULL anchor would slip past the era predicate (NULL < date → UNKNOWN) and
+  -- survive as a silent orphan. Verified unreachable via every current writer,
+  -- but this migration is an irreversible wipe, so a NULL is an ABORT-for-
+  -- inspection signal, not a silent skip.
+  (SELECT count(*) FROM public.enrollments       WHERE enrolled_at  IS NULL) AS enr_null,
+  (SELECT count(*) FROM public.user_progress     WHERE completed_at IS NULL) AS up_null,
+  (SELECT count(*) FROM public.xp_transactions   WHERE created_at   IS NULL) AS xp_null,
+  (SELECT count(*) FROM public.user_achievements WHERE unlocked_at  IS NULL) AS ach_null;
 
 -- ── Pre-DELETE structural guard ──
 -- Each era-scoped count must equal its posted value (first apply) OR 0 (already
@@ -152,6 +161,23 @@ BEGIN
   END IF;
   IF b.ach_era NOT IN (0, 7) THEN
     RAISE EXCEPTION 'user_achievements era-count (unlocked_at < 2026-07-21) = % — expected 7 or 0. Re-verify before applying.', b.ach_era;
+  END IF;
+
+  -- NULL-anchor guard: a NULL timestamp is invisible to the era predicate, so a
+  -- NULL-anchored row (should be impossible via every current writer) would
+  -- silently survive this irreversible wipe as an orphan. Expect 0; ABORT for
+  -- operator inspection otherwise — never a silent skip.
+  IF b.enr_null <> 0 THEN
+    RAISE EXCEPTION 'enrollments has % row(s) with NULL enrolled_at — invisible to the era filter. Inspect and reconcile before applying.', b.enr_null;
+  END IF;
+  IF b.up_null <> 0 THEN
+    RAISE EXCEPTION 'user_progress has % row(s) with NULL completed_at — invisible to the era filter. Inspect and reconcile before applying.', b.up_null;
+  END IF;
+  IF b.xp_null <> 0 THEN
+    RAISE EXCEPTION 'xp_transactions has % row(s) with NULL created_at — invisible to the era filter. Inspect and reconcile before applying.', b.xp_null;
+  END IF;
+  IF b.ach_null <> 0 THEN
+    RAISE EXCEPTION 'user_achievements has % row(s) with NULL unlocked_at — invisible to the era filter. Inspect and reconcile before applying.', b.ach_null;
   END IF;
 END $$;
 

--- a/supabase/migrations/20260727140000_stranded_instance_state_cleanup.sql
+++ b/supabase/migrations/20260727140000_stranded_instance_state_cleanup.sql
@@ -7,8 +7,14 @@
 --     "investigate separately"). Its 4 rows are Metaplex Core assets that may
 --     still exist in a wallet, so the DB row can be the only surviving record
 --     of a real credential. This migration never writes certificates and
---     asserts its row count is unchanged. profiles and auth.users are likewise
---     NEVER TOUCHED — asserted unchanged at COMMIT.
+--     asserts its row count is unchanged. profiles, auth.users and
+--     deployed_programs are likewise NEVER TOUCHED — each asserted unchanged at
+--     COMMIT (deployed_programs now holds its first real row, the #725 proof).
+--
+-- OUT OF SCOPE (considered, intentionally not touched): streak_freezes_used
+-- (the per-day freeze calendar log, keyed (user_id, frozen_date)). It is not
+-- chain-mirrored XP, and a stale stranded-era row cannot collide with a future
+-- date, so leaving it is harmless; user_xp.streak_freezes is likewise preserved.
 --
 -- WHAT HAPPENED. The app now writes to program Dsro2Cd9…; the prior instance
 -- 7NeJa… holds the only on-chain counterparts of the learner state below.
@@ -35,11 +41,13 @@
 -- 🔵 ERA BOUNDARY = '2026-07-21' (the Dsro2Cd9 deploy date, a fresh Pinocchio
 -- instance). PROVENANCE: the gate's #607 dry-run cross-check counted
 -- `xp_transactions where created_at < '2026-07-21'` and it reproduced the posted
--- xp_transactions total — so this boundary cleanly separates stranded (pre-move)
--- rows from live (post-move) rows. Each of the four tables is scoped on its own
--- creation timestamp (all reliable — see below); the pre-DELETE assert re-checks
--- that the era-scoped count still equals the posted value, so a wrong boundary
--- or a live row inside the window ABORTS rather than deletes the wrong rows.
+-- xp_transactions total; the LATEST stranded row is 2026-07-16, giving ~5 days
+-- of margin below the boundary. So it cleanly separates stranded (pre-move) rows
+-- from live (post-move) rows. Each of the five statements (four DELETEs + the
+-- user_xp UPDATE) carries the era predicate, scoped on its own creation
+-- timestamp (all reliable — see below); the pre-DELETE assert re-checks that the
+-- era-scoped count still equals the posted value, so a wrong boundary or a live
+-- row inside the window ABORTS rather than deletes/zeroes the wrong rows.
 --
 --   table              scope column     why it is a reliable creation anchor
 --   enrollments        enrolled_at      TIMESTAMPTZ DEFAULT NOW(), non-null
@@ -56,25 +64,29 @@
 --     2 users / 7·63·16·7 rows, all pre-move.
 --   • user_xp — UPDATE-to-zero, NEVER DELETE (see the 🔴 note).
 --
--- 🔴 user_xp IS 1:1 WITH profiles — UPDATE, NEVER DELETE. Unlike the other four
--- tables (rows for 2 users), user_xp has a row for ALL 75 learners: a row is
--- created at signup regardless of activity. 73 of those are pristine zeros
+-- 🔴 user_xp IS 1:1 WITH profiles — UPDATE (era-scoped), NEVER DELETE. Unlike
+-- the other four tables (rows for 2 users), user_xp has a row for EVERY learner:
+-- a row is created at signup regardless of activity, most of them pristine zeros
 -- belonging to last week's event cohort. A `DELETE FROM user_xp` — the shape
--- that is correct for the other four — would remove 73 rows with nothing to
--- reset, a blast radius 37× the real target, adjacent to the exact constraint
--- this issue protects. So user_xp gets a WHERE-scoped UPDATE that touches
--- EXACTLY the 2 rows carrying state and cannot reach the 73 pristine ones. It
--- is NOT era-scoped: user_xp is cumulative, not per-event, so "zero the active
--- rows" is the reset — and the 2 active rows are the same stranded learners
--- (no XP has been awarded on the new instance to anyone else). The post-apply
--- assert pins user_xp's row count unchanged (== profiles), enforcing "never
--- deleted from" structurally.
+-- that is correct for the other four — would remove all those pristine rows,
+-- adjacent to the exact constraint this issue protects. So user_xp gets a
+-- WHERE-scoped UPDATE, and the WHERE carries BOTH the state chain (keeps it off
+-- the pristine rows) AND the era clause `last_activity_date < '2026-07-21'`
+-- (keeps it off VALID POST-MOVE learners — since the move, real learners have
+-- earned XP on the new instance, e.g. the #725 test learner's 1070 XP dated
+-- 2026-07-27; without the era clause the state chain alone would zero them).
+-- The stranded-active rows are frozen (≤ 2026-07-16), so this targets IN (0, 2)
+-- rows, asserted pre-flight. The post-apply assert pins user_xp's row count
+-- unchanged (== before), enforcing "never deleted from" structurally.
 --
--- DRY-RUN COUNTS (gate, prod pywhtmidcrptomrabbrw, posted on #607 2026-07-27).
--- RE-VERIFY these against the live DB BEFORE applying — the assert blocks pin
--- the era-scoped delete counts (7/63/16/7) and profiles=75 / user_xp=75 /
--- certificates=4, so a drift fails the migration and forces reconciliation
--- rather than running against stale evidence. Re-run:
+-- DRY-RUN COUNTS (gate, prod pywhtmidcrptomrabbrw; posted #607 2026-07-27, and
+-- already drifted to 76/76 by 2026-07-27 evening as signups + the #725 test
+-- landed). This is why NO absolute live-count pin is used: the assert blocks pin
+-- only the FROZEN era counts (7/63/16/7 delete targets, 2 stranded-active
+-- user_xp rows) and the drift-immune before==after never-touch invariants — so
+-- concurrent signups can't spuriously abort. RE-VERIFY the era counts against
+-- the live DB BEFORE applying; a drift there fails the migration and forces
+-- reconciliation. Re-run:
 --
 --   -- era-scoped delete targets (must match the DELETE WHERE clauses below):
 --   select 'enrollments' t, count(*) from enrollments       where enrolled_at  < '2026-07-21'
@@ -84,16 +96,26 @@
 --   -- expected: enrollments 7 · user_progress 63 · xp_transactions 16 · user_achievements 7
 --
 --   -- sanity: the posted UNCONDITIONAL counts were the same before #725 ran;
---   -- after #725 the unconditional counts may be HIGHER (live rows) but the
---   -- era-scoped counts above must be unchanged.
+--   -- after #725/new signups the unconditional counts are HIGHER (live rows),
+--   -- but the era-scoped counts above must be unchanged.
 --
---   select count(*) filter (where total_xp > 0 OR current_streak > 0
---       OR longest_streak > 0 OR last_activity_date IS NOT NULL) as active_rows
---   from user_xp;   -- expected: 2 (the only rows the UPDATE may touch)
+--   -- stranded-active user_xp (the ONLY rows the era-scoped UPDATE may zero):
+--   select count(*) from user_xp
+--   where last_activity_date < '2026-07-21'
+--     and (total_xp > 0 OR level > 0 OR current_streak > 0 OR longest_streak > 0);
+--   -- expected: 2 (frozen). A NULL-dated row with state must NOT exist:
+--   select count(*) from user_xp
+--   where last_activity_date IS NULL
+--     and (total_xp > 0 OR level > 0 OR current_streak > 0 OR longest_streak > 0);
+--   -- expected: 0.
 --
---   select 'profiles' t, count(*) from profiles           -- expected 75 (NEVER TOUCH)
---   union all select 'auth.users', count(*) from auth.users;
---   select count(*) from certificates;                    -- expected 4 (EXCLUDED)
+--   -- never-touch / excluded tables (asserted before==after, NOT pinned to an
+--   -- absolute value — they drift with signups): note the live totals so you can
+--   -- confirm they are unchanged post-apply.
+--   select 'profiles' t, count(*) from profiles
+--   union all select 'auth.users', count(*) from auth.users
+--   union all select 'certificates', count(*) from certificates
+--   union all select 'deployed_programs', count(*) from deployed_programs;
 --
 -- Idempotent: the era-scoped DELETEs re-run to 0 rows (nothing pre-move
 -- remains); the UPDATE's WHERE matches 0 rows once state is zeroed. Safe to
@@ -139,7 +161,22 @@ SELECT
   (SELECT count(*) FROM public.enrollments       WHERE enrolled_at  IS NULL) AS enr_null,
   (SELECT count(*) FROM public.user_progress     WHERE completed_at IS NULL) AS up_null,
   (SELECT count(*) FROM public.xp_transactions   WHERE created_at   IS NULL) AS xp_null,
-  (SELECT count(*) FROM public.user_achievements WHERE unlocked_at  IS NULL) AS ach_null;
+  (SELECT count(*) FROM public.user_achievements WHERE unlocked_at  IS NULL) AS ach_null,
+  -- deployed_programs: a NEVER-TOUCH table like profiles/auth.users. It now
+  -- holds its first real row (the #725 proof); this migration never writes it
+  -- and asserts the count is unchanged across the batch.
+  (SELECT count(*) FROM public.deployed_programs) AS deployed_programs,
+  -- user_xp era counts. uxp_active_era = stranded-era rows still carrying state
+  -- (the era-scoped UPDATE's exact targets: frozen at ≤ 2026-07-16, so IN(0,2)).
+  -- uxp_null_state = rows with state but a NULL activity date — impossible by
+  -- construction (award_xp always stamps last_activity_date), verified because
+  -- the era clause is NULL-blind and this is an irreversible reset.
+  (SELECT count(*) FROM public.user_xp
+     WHERE last_activity_date < '2026-07-21'
+       AND (total_xp > 0 OR level > 0 OR current_streak > 0 OR longest_streak > 0)) AS uxp_active_era,
+  (SELECT count(*) FROM public.user_xp
+     WHERE last_activity_date IS NULL
+       AND (total_xp > 0 OR level > 0 OR current_streak > 0 OR longest_streak > 0)) AS uxp_null_state;
 
 -- ── Pre-DELETE structural guard ──
 -- Each era-scoped count must equal its posted value (first apply) OR 0 (already
@@ -179,6 +216,20 @@ BEGIN
   IF b.ach_null <> 0 THEN
     RAISE EXCEPTION 'user_achievements has % row(s) with NULL unlocked_at — invisible to the era filter. Inspect and reconcile before applying.', b.ach_null;
   END IF;
+
+  -- user_xp pre-flight (same discipline as the DELETE tables):
+  -- • stranded-active rows are frozen (≤ 2026-07-16) so the era-scoped UPDATE
+  --   targets exactly IN (0, 2) rows; anything else means a post-move learner
+  --   fell inside the window or the boundary drifted — ABORT.
+  -- • a state-bearing row with a NULL activity date cannot exist (award_xp
+  --   always stamps last_activity_date), but the era clause is NULL-blind, so
+  --   verify it and ABORT rather than silently skip on an irreversible reset.
+  IF b.uxp_active_era NOT IN (0, 2) THEN
+    RAISE EXCEPTION 'user_xp stranded-active count (state AND last_activity_date < 2026-07-21) = % — expected 2 (first apply) or 0 (re-apply). A post-move learner must NOT fall in this window; re-verify before applying.', b.uxp_active_era;
+  END IF;
+  IF b.uxp_null_state <> 0 THEN
+    RAISE EXCEPTION 'user_xp has % row(s) with state but NULL last_activity_date — invisible to the era clause. Inspect before applying (award_xp should make this impossible).', b.uxp_null_state;
+  END IF;
 END $$;
 
 -- ── Reset chain-mirrored state (ERA-SCOPED DELETEs — post-move rows survive) ──
@@ -190,12 +241,22 @@ DELETE FROM public.user_progress     WHERE completed_at < '2026-07-21';
 DELETE FROM public.xp_transactions   WHERE created_at   < '2026-07-21';
 DELETE FROM public.user_achievements WHERE unlocked_at  < '2026-07-21';
 
--- ── user_xp: UPDATE-to-zero, scoped to the rows that actually carry state ──
--- The WHERE self-limits to the 2 active rows and can NEVER reach the 73 pristine
--- signup rows, and it makes the statement idempotent (once zeroed, it matches 0
--- rows on re-apply). streak_freezes is INTENTIONALLY preserved as-is (0 for
--- every row today; it is the earned freeze inventory, not chain-mirrored XP —
--- owner decision to leave it untouched). Setting current_streak and
+-- ── user_xp: UPDATE-to-zero, ERA-SCOPED to stranded-active rows ──
+-- Two clauses, both load-bearing:
+--   • the state chain (total_xp > 0 OR …) keeps the UPDATE off the 73 pristine
+--     signup rows and makes it idempotent (once zeroed it matches 0 rows);
+--   • AND last_activity_date < '2026-07-21' confines it to STRANDED-era rows, so
+--     it can NEVER zero a valid post-move learner (e.g. the #725 test learner's
+--     1070 XP, activity 2026-07-27). This is the same era discipline as the
+--     DELETEs — user_xp was the last statement still living in the pre-drift
+--     world (round-3 gate catch).
+-- NULL reasoning: pristine rows have last_activity_date IS NULL → the era clause
+-- (NULL < date → UNKNOWN) excludes them → correct, they need no reset. And a
+-- state-bearing row with a NULL date cannot exist (award_xp always stamps
+-- last_activity_date on award) — verified by the pre-flight uxp_null_state
+-- assert above, so the era clause being the sole anchor is safe by construction.
+-- streak_freezes is INTENTIONALLY preserved as-is (0 for every row; the earned
+-- freeze inventory, not chain-mirrored XP). Setting current_streak and
 -- longest_streak together to 0 satisfies chk_user_xp_longest_gte_current.
 UPDATE public.user_xp
 SET total_xp           = 0,
@@ -203,11 +264,14 @@ SET total_xp           = 0,
     current_streak     = 0,
     longest_streak     = 0,
     last_activity_date = NULL
-WHERE total_xp > 0
-   OR level > 0
-   OR current_streak > 0
-   OR longest_streak > 0
-   OR last_activity_date IS NOT NULL;
+WHERE (
+       total_xp > 0
+    OR level > 0
+    OR current_streak > 0
+    OR longest_streak > 0
+    OR last_activity_date IS NOT NULL
+  )
+  AND last_activity_date < '2026-07-21';
 
 -- ── Post-apply assertions — roll the whole batch back if any invariant fails ──
 DO $$
@@ -218,6 +282,7 @@ DECLARE
   v_auth       INTEGER;
   v_user_xp    INTEGER;
   v_certs      INTEGER;
+  v_deployed   INTEGER;
   v_enr        INTEGER;
   v_up         INTEGER;
   v_xp         INTEGER;
@@ -225,18 +290,13 @@ DECLARE
 BEGIN
   SELECT * INTO b FROM _cleanup_baseline;
 
-  -- Baseline guard: the posted dry-run evidence this migration was written
-  -- against. A mismatch means the DB drifted (e.g. new signups) — STOP and
-  -- reconcile against fresh counts rather than run on stale assumptions.
-  IF b.profiles <> 75 THEN
-    RAISE EXCEPTION 'profiles baseline drifted: expected 75 (posted #607), got %. Re-run the DRY-RUN counts and reconcile before applying.', b.profiles;
-  END IF;
-  IF b.user_xp <> 75 THEN
-    RAISE EXCEPTION 'user_xp baseline drifted: expected 75 (== profiles), got %. Re-run the DRY-RUN counts before applying.', b.user_xp;
-  END IF;
-  IF b.certificates <> 4 THEN
-    RAISE EXCEPTION 'certificates baseline drifted: expected 4 (posted #607), got %. certificates is EXCLUDED — investigate before applying.', b.certificates;
-  END IF;
+  -- No absolute live-count pins here (round-3 gate). profiles/user_xp/
+  -- certificates are LIVE counts that grow with every signup (already 76/76 by
+  -- apply time), so pinning them to the 2026-07-27 dry-run values would make the
+  -- migration go stale the moment anyone signs up — reintroducing the very race
+  -- era-scoping removes. The frozen numbers that DO deserve pins are the era
+  -- counts (asserted pre-DELETE). The never-touch tables are proved by the
+  -- before==after invariants below, which are drift-immune.
 
   -- NEVER-TOUCH invariant: profiles and auth.users unchanged across the batch.
   SELECT count(*) INTO v_profiles FROM public.profiles;
@@ -254,6 +314,13 @@ BEGIN
     RAISE EXCEPTION 'certificates row count changed (% -> %): certificates is EXCLUDED from this cleanup', b.certificates, v_certs;
   END IF;
 
+  -- NEVER-TOUCH invariant: deployed_programs unchanged (it now holds the #725
+  -- proof row; this migration never writes it). Gate ask.
+  SELECT count(*) INTO v_deployed FROM public.deployed_programs;
+  IF v_deployed <> b.deployed_programs THEN
+    RAISE EXCEPTION 'deployed_programs row count changed (% -> %): this migration must never touch deployed_programs', b.deployed_programs, v_deployed;
+  END IF;
+
   -- UPDATE-not-DELETE invariant: user_xp keeps every row (still 1:1 with
   -- profiles). If this fired, a DELETE reached user_xp — the exact mistake the
   -- 🔴 note exists to prevent.
@@ -262,13 +329,17 @@ BEGIN
     RAISE EXCEPTION 'user_xp row count changed (% -> %): user_xp must be UPDATED to zero, NEVER deleted', b.user_xp, v_user_xp;
   END IF;
 
-  -- Reset invariant: no user_xp row carries state after the UPDATE (proves the
-  -- 2 active rows were zeroed; also confirms idempotent re-runs are no-ops).
+  -- Reset invariant (ERA-SCOPED): no STRANDED-ERA row still carries state after
+  -- the UPDATE. It must NOT demand universal zeroing — a valid post-move learner
+  -- legitimately keeps state, and pinning "0 rows carry state" would abort the
+  -- txn the moment one exists (round-3 gate catch). The reset rows now have
+  -- last_activity_date = NULL, so they fall outside this window too; a stranded
+  -- row the UPDATE somehow missed would still be < boundary AND carry state.
   SELECT count(*) INTO v_active FROM public.user_xp
-  WHERE total_xp > 0 OR level > 0 OR current_streak > 0
-     OR longest_streak > 0 OR last_activity_date IS NOT NULL;
+  WHERE last_activity_date < '2026-07-21'
+    AND (total_xp > 0 OR level > 0 OR current_streak > 0 OR longest_streak > 0);
   IF v_active <> 0 THEN
-    RAISE EXCEPTION 'user_xp still has % row(s) with non-zero state after reset', v_active;
+    RAISE EXCEPTION 'user_xp: % stranded-era row(s) still carry state after reset', v_active;
   END IF;
 
   -- Era-clean invariant: no pre-move row survives in any of the four reset
@@ -282,7 +353,7 @@ BEGIN
     RAISE EXCEPTION 'pre-move rows survived the reset: enrollments=%, user_progress=%, xp_transactions=%, user_achievements=%', v_enr, v_up, v_xp, v_ach;
   END IF;
 
-  RAISE NOTICE 'stranded-instance cleanup OK: deleted pre-move rows (enr % / up % / xp % / ach %); profiles=% (untouched), auth.users=% (untouched), certificates=% (excluded, untouched), user_xp=% rows all zeroed', b.enr_era, b.up_era, b.xp_era, b.ach_era, v_profiles, v_auth, v_certs, v_user_xp;
+  RAISE NOTICE 'stranded-instance cleanup OK: deleted pre-move rows (enr % / up % / xp % / ach %), zeroed % stranded-active user_xp row(s); untouched: profiles=%, auth.users=%, certificates=%, deployed_programs=%, user_xp rowcount=%', b.enr_era, b.up_era, b.xp_era, b.ach_era, b.uxp_active_era, v_profiles, v_auth, v_certs, v_deployed, v_user_xp;
 END $$;
 
 COMMIT;


### PR DESCRIPTION
**Migration half of #607 (P0).** The code half (program-errors 6031-6036 gap) is PR #760. Written against the gate's dry-run counts posted on #607 (prod `pywhtmidcrptomrabbrw`, 2026-07-27). Data-only, do NOT merge without the gate/owner sign-off.

## What & why
The app moved to program `Dsro2Cd9…`; the DB still mirrors the superseded `7NeJa…` instance. Enrollment PDAs are program-derived, so that state is unreachable from the new id and cannot be migrated; the 5 stranded-era courses were also deactivated on-chain (#713/#606), making the rows doubly-orphaned. Owner decision (2026-07-25): do not re-mint XP — reset from zero, keep identities and credentials. Nothing has been awarded since the move (the Helius webhook still points at the old program), so this is pre-move history only.

## How each posted count maps to a statement

| posted count (#607) | migration statement |
|---|---|
| `enrollments` 7 rows / 2 users | `DELETE FROM public.enrollments;` |
| `user_progress` 63 / 2 | `DELETE FROM public.user_progress;` |
| `xp_transactions` 16 / 2 | `DELETE FROM public.xp_transactions;` |
| `user_achievements` 7 / 2 | `DELETE FROM public.user_achievements;` |
| `user_xp` **75 / 75** (2 active, 73 pristine) | `UPDATE public.user_xp SET …=0 WHERE total_xp>0 OR level>0 OR current_streak>0 OR longest_streak>0 OR last_activity_date IS NOT NULL` — touches exactly the 2 rows with state |
| `profiles` 75 (NEVER TOUCH) | not written; asserted `= 75` and unchanged at COMMIT |
| `auth.users` (NEVER TOUCH) | not written; asserted unchanged at COMMIT |
| `certificates` 4 / 1 (EXCLUDED) | not written; asserted `= 4` and unchanged at COMMIT |

## The one shape change from the naive reset
`user_xp` is **1:1 with `profiles`** (a row per learner at signup), so a `DELETE` — correct for the other four tables — would wipe **73** pristine event-cohort rows, a blast radius **37× the 2-row target** and adjacent to the exact constraint this issue protects. So `user_xp` is an **UPDATE-to-zero** scoped by `WHERE`, which self-limits to the 2 active rows and can never reach the 73 pristine ones. `streak_freezes` is preserved as-is (0 for every row today; it's the earned freeze inventory, per owner decision). Setting both streak columns to 0 together satisfies `chk_user_xp_longest_gte_current`.

## Safety / conventions
- **One `BEGIN;`/`COMMIT;`.** A trailing `DO $$` assert block rolls the whole batch back unless: `profiles=75` / `user_xp=75` / `certificates=4` (posted baseline) hold; profiles, auth.users, certificates are unchanged; and `user_xp` kept every row (UPDATE-not-DELETE, enforced structurally). A drift (e.g. new signups) fails the migration and forces re-verification against fresh counts — the DRY-RUN queries are inlined as comments at the top for exactly that.
- **Idempotent:** DELETEs re-run to 0 rows; the UPDATE's WHERE matches 0 rows once zeroed. Re-apply is a no-op.
- **`schema.sql` untouched** — data-only (DML, no DDL), following the data-only precedents `20260630165536` / `20260703150000`. schema.sql is a structure snapshot; there are no rows to mirror.
- **NOT rollback-able, stated honestly** (the #750 lesson): no fake rollback block. Deleted rows / overwritten XP are gone at COMMIT; recovery is by the owner's "progress is recoverable" decision — learners redo activity against the live program and XP re-accrues once the webhook is repointed. No identity or credential is lost.
- **Timestamp** `20260727140000` — unique vs the migrations dir (max was `20260727120000`) and vs open PRs (none touch migrations).

## Guard test
`apps/web/src/lib/supabase/__tests__/stranded-instance-cleanup-guard.test.ts` (12 tests) pins the load-bearing invariants against the migration SQL (comment-stripped for the executable-statement checks, since the header prose intentionally names `DELETE FROM user_xp` as the mistake to avoid): user_xp is UPDATE-not-DELETE and WHERE-scoped; profiles / auth.users / certificates are never written; the posted baseline is pinned; the ROLLBACK-NONE honesty note is present.

## Verification
```
pnpm install --frozen-lockfile   # ok
pnpm typecheck                    # 6 successful, 6 total
pnpm --filter web test            # Test Files 214 passed (214) · Tests 1961 passed (1961)
```

Apply is a prod action held by the gate (this repo ships SQL/docs, never touches prod). Post-apply, the gate should stamp the ledger (`docs/DB-MIGRATION-LEDGER.md`) with the MCP-assigned version per the going-forward rule.


---

## Round 3 update (head `5485de1`) — era-scope the `user_xp` UPDATE

Gate round-2 approved the DELETE half; the `user_xp` half still lived in the pre-drift world. Live counts drifted to 76/76 (organic signups + the #725 e2e learner carrying 1070 XP dated 2026-07-27). Changes:

- **`user_xp` UPDATE era-scoped**: `WHERE (state chain) AND last_activity_date < '2026-07-21'`. The state chain alone matched every active learner including valid post-move ones; the era clause confines it to stranded rows. NULL reasoning: pristine rows (NULL date) are correctly excluded; a state-bearing NULL-dated row can't exist (`award_xp` always stamps the date) and is verified by a pre-flight `uxp_null_state = 0` assert.
- **Post-reset assert era-scoped**: asserts no *stranded-era* row carries state, not universal zeroing (which would abort once a valid learner exists).
- **Pre-flight adds** `uxp_active_era IN (0,2)` and `uxp_null_state = 0`.
- **Dropped the absolute live-count pins** (`profiles=75`/`user_xp=75`/`certificates=4`) — they go stale on any signup and reintroduce the race era-scoping removes. Kept the drift-immune before==after never-touch invariants.
- **`deployed_programs`** added as a never-touch table (holds the #725 proof row; gate ask), asserted unchanged.
- Header: `user_xp` note rewritten (now era-scoped), 5-day boundary margin (latest stranded row 2026-07-16), `streak_freezes_used` out-of-scope note.

**Red-proof (loop contract):** regression test `apps/web/src/lib/supabase/__tests__/stranded-instance-cleanup-guard.test.ts` verified failing at `e4f4b696` — 6 flipped/new guards (era-scoped UPDATE, `uxp_null_state`, era-scoped post-assert, `deployed_programs` untouched, dropped absolute pins) failed against the pre-fix migration; all 18 pass after the fix.

**Verification:** `pnpm typecheck` 6/6 · `pnpm --filter web test` 214 files / 1967 tests · guard 18/18.

**Timestamp note:** `20260727140000` collides with open PR #779 (`on-hold-david`), which is moot for merge order; keeping this at `140000` and letting #779 renumber if it ever revives, per the gate.
