### PR TITLE
docs(loop): trim issue-number citations from the ship-loop rules (#780 follow-up)

### DIFF
--- a/docs/HANDOFF-LOOP-2026-07-25.md
+++ b/docs/HANDOFF-LOOP-2026-07-25.md
@@ -63,26 +63,21 @@ Bounced PRs get `needs-gate` removed and a comment; the orchestrator picks them 
 
 ### Ship-loop upgrades (added 2026-07-27, owner-approved)
 
-Three rules imported from red-first/BDD practice, each patching a failure this loop actually had:
-
 1. **A bounce comes back as a failing test, not prose.** When the gate bounces a PR for a defect,
-   the fix push MUST include a regression test that **fails at the bounced head** and passes at the
-   new one. The gate verifies red-first the way it verifies md5s (stash/checkout the old head, run
-   exactly that test, watch it fail). Rationale: green-while-guarding-nothing tests are how #699's
-   hollow guards happened; prose bounces are how #738/#748 stayed unfixed for hours.
+   the fix push includes a regression test that **fails at the bounced head** and passes at the new
+   one. The gate verifies red-first (check out the old head, run exactly that test, watch it fail).
+   A test that was never seen red proves nothing.
 2. **PR bodies claim red-proof explicitly.** Any PR whose point is "this can never happen again"
-   states: `regression test <file> verified failing at <sha>`. A checkable claim, not a vibe.
-   (First done ad hoc on #746 — now the convention.)
-3. **The critical learner paths get Playwright, in CI** (tracked in its own issue): enroll →
-   complete → XP; catalog gate (active courses render, deactivated don't); unsubscribe. The gate's
-   manual runtime smokes caught #711 and validated the Next 15 upgrade, but they die with the
-   session — 04-layer coverage must outlive the operator.
+   states: `regression test <file> verified failing at <sha>` — a checkable claim the gate can
+   replay.
+3. **The critical learner paths get Playwright, in CI**: enroll → complete → XP; the catalog gate
+   (active courses render, deactivated ones don't); unsubscribe. Manual runtime smokes die with the
+   operator's session — end-to-end coverage must not.
 
-What we deliberately did NOT import: full Gherkin/BDD ceremony (two-agent loop, launch week), and
-collapsing the gate into a pipeline stage. The gate's value is that it is a **different agent
-verifying claims against reality** (prod DB, chain, live renders) — not the same author's context
-checking rule-compliance. Records-vs-reality was our biggest bug class (6 instances); no in-pipeline
-gate catches those.
+Deliberately not imported: Gherkin/BDD ceremony, and collapsing the gate into a pipeline stage. The
+gate's value is a **different agent verifying claims against reality** (prod DB, chain, live
+renders) — not the same author's context checking rule-compliance. Our biggest bug class has been
+records that disagree with production; no in-pipeline gate catches those.
 
 ### Branch lifecycle — the collision that already happened once
 


### PR DESCRIPTION
Owner feedback on #780: the contract doc referenced specific PR/issue numbers as rationale. Rules are permanent; case numbers are ephemeral noise for future readers. This keeps the three rules and the not-imported note verbatim in substance, drops the citations. Docs-only.