### PR TITLE
perf(build-proxy): raise build-program proxy timeout to cover Cloud Run's 300s (#776 item 5)

### DIFF
--- a/apps/web/src/app/api/build-program/route.ts
+++ b/apps/web/src/app/api/build-program/route.ts
@@ -35,9 +35,24 @@ interface BuildProgramResponse {
 
 // --- Config ------------------------------------------------------------------
 
+// Let the serverless function run long enough to cover the build server's full
+// window. Cloud Run allows 300s (deploy/deploy.sh `--timeout 300`), so a cold
+// build (fat-LTO codegen; #776 item 1) can legitimately take minutes. 300 is
+// the Vercel plan's hard ceiling for maxDuration on this project (the same value
+// api/courses/test-out already uses) — the platform kills the function at 300s
+// regardless of any larger number here, so the upstream abort below sits just
+// UNDER it to return a clean 504 before that hard kill. See the PR/#776 item 5
+// for the residual (a build using the entire 300s can still 504 in the last
+// headroom window) and the owner-side `--min-instances 1` mitigation.
+export const maxDuration = 300;
+
 const BUILD_SERVER_URL = serverEnv.BUILD_SERVER_URL;
 const BUILD_SERVER_API_KEY = serverEnv.BUILD_SERVER_API_KEY;
-const UPSTREAM_TIMEOUT_MS = 130_000; // slightly above the 120s build timeout
+// Was 130s — it 504'd cold builds the build server (Cloud Run, 300s) was still
+// finishing, wasting the compile and showing a confusing failure (#776 item 5).
+// Sits ~5s under maxDuration so the abort's own 504 is returned before Vercel
+// hard-kills the function at 300s.
+const UPSTREAM_TIMEOUT_MS = 295_000;
 const MAX_TOTAL_SIZE = 500 * 1024; // 500KB, matches build server limit
 
 // --- Route Handler -----------------------------------------------------------
@@ -156,7 +171,7 @@ export async function POST(
           stderr: "",
           uuid: null,
           error: isAbort
-            ? "Build timed out (130s limit)"
+            ? `Build timed out (${UPSTREAM_TIMEOUT_MS / 1000}s limit)`
             : "Failed to reach build server",
         },
         { status: 504 }


### PR DESCRIPTION
#776 PR C (item 5). Fixes the proxy↔server timeout mismatch: the Vercel `POST /api/build-program` route aborted the upstream build at **130s** while the build server (Cloud Run, `deploy/deploy.sh --timeout 300`) keeps compiling to **300s**. A cold fat-LTO build 504'd the learner while the server finished anyway — wasted compile, confusing failure.

## Change (route constant + a deploy flag, exactly as scoped)
- `UPSTREAM_TIMEOUT_MS` **130s → 295s** — the proxy now waits out the server's full window.
- Added **`export const maxDuration = 300`**. Without it the function can't legitimately run that long; the abort is meaningless if the platform kills the function first.
- The timeout error message now derives from the constant (`${UPSTREAM_TIMEOUT_MS/1000}s`) instead of a hardcoded "130s" — kills the stale-text class.

## maxDuration decision (the constraint the task asked me to check)
**Vercel caps `maxDuration` at 300s on this project's plan** — confirmed by `api/courses/test-out/route.ts:82` which already sets `maxDuration = 300`. So the issue's literal "raise above 300s" is **not achievable**: the platform hard-kills the function at 300s regardless of any larger number. I picked the **maximum possible (300)** and set the abort to **295s** (~5s headroom) so the abort returns a clean 504 with a useful body *before* Vercel's hard kill (a hard kill yields a generic 504 with no body).

**Residual (documented, per instruction):** a build that consumes the entire 300s Cloud Run budget can still 504 in that last ~5s headroom window. It's bounded, and shrinks further with **#776 item 1** (relaxed compile profile → shorter builds) and the owner-side **`--min-instances 1`** during launch hours (fewer cold starts). Per the task, `--min-instances 1` is an **owner cost call — noted here, not acted on**.

## Notes
- No test exists for this route, so there's no red-proof to run; the change is a proxy constant + a Next.js route segment config.
- Sibling for a follow-up (out of scope here): `lib/challenge/buildable-executor.ts:79` carries the same `130_000` against the same build server — worth the identical bump in a separate change if that path also cold-builds.
- This branch is off `main` and contains **only** `route.ts` (items 1/6/3/4/7 are the other #776 PRs).

## Verify
- `pnpm typecheck` — green (6/6)
- `pnpm --filter web test` — 213 files / 1949 tests pass
