### PR TITLE
perf(build-server): relax compile profile + fail-closed build success (#776 items 1+6)

### DIFF
--- a/apps/build-server/programs/Cargo.toml
+++ b/apps/build-server/programs/Cargo.toml
@@ -7,11 +7,19 @@ edition = "2021"
 crate-type = ["cdylib", "lib"]
 path = "src/lib.rs"
 
+# Per-request learner builds optimise for COMPILE TIME, not binary size: the fat
+# LTO merge + single-codegen-unit codegen of the leaf cdylib reran on every Run
+# click (30-120s per the metrics buckets) even though the warm target/ caches
+# dependencies (#776 item 1). overflow-checks stays ON — it is load-bearing for the
+# C2 curriculum, where a bare `-` must still panic. NOTE: changing this profile
+# invalidates the pre-warmed programs/target/ baked by the Dockerfile; it is
+# re-warmed automatically on the next image build (Dockerfile `cargo-build-sbf
+# --manifest-path programs/Cargo.toml`), no separate step.
 [profile.release]
 overflow-checks = true
-lto = true
-codegen-units = 1
-opt-level = "z"
+lto = false
+codegen-units = 16
+opt-level = 1
 
 [dependencies]
 # Anchor 1.1.2 re-exports solana-program — no direct dep needed

--- a/apps/build-server/src/build.rs
+++ b/apps/build-server/src/build.rs
@@ -22,6 +22,21 @@ const MAX_FILE_SIZE: usize = 100 * 1024; // 100KB
 const MAX_TOTAL_SIZE: usize = 500 * 1024; // 500KB
 const MAX_PATH_LENGTH: usize = 128;
 
+/// The cdylib artifact cargo-build-sbf emits for `academy-program` (dashes →
+/// underscores). Written to `--sbf-out-dir` (the build dir) and read back for the
+/// inline deploy response.
+const SO_FILENAME: &str = "academy_program.so";
+
+/// A build succeeded only when the compiler exited zero AND left the `.so` behind.
+///
+/// Fail-closed (#776 item 6): success was previously inferred from stderr
+/// substrings, so a linker crash / OOM whose output matched neither pattern was
+/// reported as `success: true` with no binary. The exit status plus the artifact's
+/// existence are the ground truth; stderr text is not.
+fn build_succeeded(exit_success: bool, so_path: &Path) -> bool {
+    exit_success && so_path.exists()
+}
+
 const BLOCKED_PATTERNS: &[&str] = &[
     "std::process",
     "std::fs::",
@@ -176,8 +191,11 @@ impl BuildService {
 
         // Copy pre-built target/ from the template so dependency crates are
         // already compiled. Uses --reflink=auto for CoW on supported FS,
-        // falling back to regular copy on tmpfs. This turns a ~180s full
-        // rebuild into a ~10-15s incremental compile of just the student crate.
+        // falling back to regular copy on tmpfs. Dependencies are then warm and
+        // only the student's leaf crate is (re)compiled per request; that cost is
+        // dominated by [profile.release] in programs/Cargo.toml (relaxed in #776).
+        // Measure it via academy_build_duration_seconds on /metrics — do not
+        // assume a fixed figure.
         let template_target = Path::new(&config.programs_dir).join("target");
         if template_target.is_dir() {
             let build_target = build_dir.join("target");
@@ -253,11 +271,13 @@ impl BuildService {
         let timeout_duration = Duration::from_secs(config.build_timeout_secs);
 
         match tokio::time::timeout(timeout_duration, child.wait()).await {
-            Ok(Ok(_status)) => {
+            Ok(Ok(status)) => {
                 let stderr = stderr_task.await.unwrap_or_default();
-                let has_error =
-                    stderr.contains("error: could not compile") || stderr.contains("error[");
-                (!has_error, stderr)
+                // Trust the compiler's exit status AND require the artifact — never
+                // infer success from stderr text, which fails OPEN on a linker
+                // crash / OOM that matches no known pattern (#776 item 6).
+                let so_path = build_dir.join(SO_FILENAME);
+                (build_succeeded(status.success(), &so_path), stderr)
             }
             Ok(Err(e)) => (false, format!("Error waiting for build: {e}")),
             Err(_) => {
@@ -294,7 +314,7 @@ impl BuildService {
             let binary_b64 = if cached.success {
                 let so_path = Path::new(&self.config.builds_dir)
                     .join(&cached.uuid)
-                    .join("academy_program.so");
+                    .join(SO_FILENAME);
                 tokio::fs::read(&so_path)
                     .await
                     .ok()
@@ -368,7 +388,7 @@ impl BuildService {
 
         // 8. Read binary before any cleanup (same instance has the file)
         let binary_b64 = if success {
-            let so_path = build_dir.join("academy_program.so");
+            let so_path = build_dir.join(SO_FILENAME);
             match tokio::fs::read(&so_path).await {
                 Ok(bytes) => Some(STANDARD.encode(&bytes)),
                 Err(e) => {
@@ -412,7 +432,7 @@ impl BuildService {
 
         let binary_path = Path::new(&self.config.builds_dir)
             .join(uuid)
-            .join("academy_program.so");
+            .join(SO_FILENAME);
 
         tokio::fs::read(&binary_path)
             .await
@@ -505,5 +525,39 @@ mod tests {
             "use anchor_lang::prelude::*;\ndeclare_id!(\"...\");",
         )]);
         assert!(BuildService::check_blocked_patterns(&files).is_ok());
+    }
+
+    // --- #776 item 6: success is exit-status + artifact, never stderr inference ---
+
+    /// A path guaranteed to exist during the test (this crate's own manifest).
+    fn existing_path() -> PathBuf {
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("Cargo.toml")
+    }
+
+    #[test]
+    fn build_succeeds_only_on_zero_exit_with_artifact() {
+        assert!(build_succeeded(true, &existing_path()));
+    }
+
+    #[test]
+    fn build_fails_closed_on_nonzero_exit_even_with_artifact() {
+        // The exact regression: a failing build whose stderr matched no known
+        // pattern used to report success. A non-zero exit is now always a failure,
+        // regardless of any leftover .so.
+        assert!(!build_succeeded(false, &existing_path()));
+    }
+
+    #[test]
+    fn build_fails_closed_on_zero_exit_without_artifact() {
+        // A "clean" exit that produced no binary (e.g. a silent linker/OOM abort)
+        // is a failure — we never report success without the .so.
+        let missing = Path::new("/nonexistent/academy_program.so");
+        assert!(!build_succeeded(true, missing));
+    }
+
+    #[test]
+    fn build_fails_closed_on_nonzero_exit_without_artifact() {
+        let missing = Path::new("/nonexistent/academy_program.so");
+        assert!(!build_succeeded(false, missing));
     }
 }


### PR DESCRIPTION
PR A of #776 (build server — items 1 + 6). Scope: `apps/build-server` only.

## Item 1 — relax the per-request compile profile
`programs/Cargo.toml` `[profile.release]` is copied verbatim into every learner build dir (`build.rs` `setup_build_dir`). It shipped `lto = true, codegen-units = 1, opt-level = "z"` — size-optimised, so the whole-program fat-LTO merge + single-threaded codegen of the leaf cdylib reran on **every Run click** (30–120s per the metrics histogram buckets) even though the warm `target/` already caches dependencies.

Changed to `lto = false, codegen-units = 16, opt-level = 1`. **`overflow-checks = true` kept** — it is load-bearing for the C2 curriculum (a bare `-` must still panic).

**Re-warm question (asked in the task):** the pre-warmed `programs/target/` is baked by the Dockerfile at image-build time (`RUN cargo-build-sbf --tools-version v1.54 --manifest-path programs/Cargo.toml`, right after `COPY programs/`). Changing the profile invalidates that cache, but it is **re-warmed automatically on the next image build** — the `COPY programs/` layer busts on the manifest change and the `cargo-build-sbf` step recompiles `target/` under the new profile. **No separate step, no runtime action.** (There is no runtime warm-cache generation — the runtime FS is read-only; `/tmp` is the only writable path.)

**Measurement:** before/after belongs on `academy_build_duration_seconds` (`/metrics`) in the real Cloud Run image — it needs the sbf toolchain and a warm image, so it is **not measurable on this macOS dev box**. Flagging for whoever has the deployed image; the profile change is the lever, the metric is already wired.

## Item 6 — fail-closed build success
`build.rs` `run_cargo_build_sbf` inferred success from stderr substrings (`error: could not compile` / `error[`) and **ignored the exit status**. A linker crash / OOM whose stderr matched neither pattern reported `success: true` with no `.so`.

Now: `success = status.success() && <.so exists>`, via a small pure `build_succeeded(exit_success, so_path)` helper. Fail-closed on both a non-zero exit and a zero-exit-without-artifact.

### Red-proof (new contract rule)
There is **no unit harness for the subprocess path** — `run_cargo_build_sbf` hard-codes `Command::new("cargo-build-sbf")` and needs the sbf toolchain (the existing `#[cfg(test)]` tests cover only the pure validators; `tests/integration_test.rs` is all `#[ignore]`d and runs against a live server). So per the rule, stating that and showing the **manual repro** — a forced non-zero exit whose stderr matches neither pattern:
```
process exit_success=false  stderr="linker: out of memory, killed"
OLD reports success = true   <-- FAIL-OPEN bug (build failed, no .so)
NEW reports success = false   <-- fail-closed (correct)
```
(exit 137 = OOM-kill.) The decision is now locked by 4 unit tests on `build_succeeded` (the fail-closed truth table).

## Also
- Fixed the stale `~10-15s incremental compile` comment (`setup_build_dir`) — the LTO merge made real builds 30–120s; the comment now points at the profile + the metric instead of a fabricated figure.
- De-duplicated the `academy_program.so` literal into a `SO_FILENAME` const (4 sites).

## What ran locally (macOS; sbf builds not runnable here — compile-only verification, as expected)
- `cargo build` (server) → clean
- `cargo test` → **19 unit passed** (15 existing + 4 new fail-closed), 11 integration `#[ignore]`d
- manual repro above (standalone `rustc`)
- `programs/Cargo.toml` re-parsed to confirm the profile table

**Do not merge** — SENSITIVE (build/deploy correctness). Needs adversarial + gate.
