### PR TITLE
perf(deploy): bounded-concurrency sends + write-tx CU limit + rebroadcast backoff (#776 items 3+4+7)

### DIFF
--- a/packages/deploy/package.json
+++ b/packages/deploy/package.json
@@ -5,12 +5,15 @@
   "main": "src/index.ts",
   "types": "src/index.ts",
   "scripts": {
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@solana/web3.js": "^1.98.4"
   },
   "devDependencies": {
-    "typescript": "^5.6.0"
+    "typescript": "^5.6.0",
+    "vitest": "^4.1.0"
   }
 }

--- a/packages/deploy/src/__tests__/deploy.test.ts
+++ b/packages/deploy/src/__tests__/deploy.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { ComputeBudgetProgram, type Connection } from "@solana/web3.js";
+import {
+  ComputeBudgetProgram,
+  Keypair,
+  PublicKey,
+  Transaction,
+  type Connection,
+} from "@solana/web3.js";
 import {
   writeComputeBudgetIxs,
   priorityFeeIx,
@@ -8,7 +14,15 @@ import {
   is429,
   parseRetryAfterMs,
   nextResendInterval,
+  deployProgram,
+  resumeDeployment,
+  setCachedBinary,
 } from "../deploy";
+import type {
+  DeploymentCallbacks,
+  DeploymentState,
+  WalletAdapter,
+} from "../types";
 
 // ---------------------------------------------------------------------------
 // Item 4 — setComputeUnitLimit on the write txs (not the one-off txs)
@@ -110,10 +124,20 @@ describe("rebroadcast backoff decision (item 7)", () => {
     expect(is429(new Error("Transaction simulation failed"))).toBe(false);
   });
 
-  it("parseRetryAfterMs scrapes an explicit hint, else null", () => {
+  it("parseRetryAfterMs scrapes an explicit delta-seconds hint, else null", () => {
     expect(parseRetryAfterMs(new Error("429; Retry-After: 3"))).toBe(3000);
     expect(parseRetryAfterMs(new Error("retry after 10 seconds"))).toBe(10_000);
     expect(parseRetryAfterMs(new Error("429 Too Many Requests"))).toBeNull();
+  });
+
+  it("parseRetryAfterMs does NOT misread an HTTP-date Retry-After as seconds", () => {
+    // The date form always leads with a weekday, so no integer follows the
+    // header — must be null, never e.g. the day-of-month (21) or year (2015).
+    expect(
+      parseRetryAfterMs(
+        new Error("429 Retry-After: Wed, 21 Oct 2015 07:28:00 GMT")
+      )
+    ).toBeNull();
   });
 
   it("a clean cycle relaxes to the base cadence (4s)", () => {
@@ -219,5 +243,138 @@ describe("confirmBatch rebroadcast (item 7)", () => {
     expect(callTimes[0]).toBeGreaterThanOrEqual(4_000);
     const firstGap = callTimes[1]! - callTimes[0]!;
     expect(firstGap).toBeGreaterThanOrEqual(7_500); // ~8s, backed off from 4s
+  });
+});
+
+// ---------------------------------------------------------------------------
+// BOTH entry points end-to-end: the reviewer's gap — the first pass migrated
+// deployProgram but not resumeDeployment, and no test drove either. These run
+// each real path against one mocked-connection harness and assert (1) its send
+// dispatch is POOLED (peak concurrency > 1, not serial) and (2) every write tx
+// carries the CU-limit ix.
+// ---------------------------------------------------------------------------
+describe("deployProgram + resumeDeployment both use the pool + CU limit (#776)", () => {
+  const ZERO_HASH = "11111111111111111111111111111111"; // valid 32-byte base58
+
+  function harness(bufferKp: Keypair) {
+    let inFlight = 0;
+    let peak = 0;
+    let sigN = 0;
+    const writeTxs: Transaction[] = [];
+
+    const sendRawTransaction = vi.fn(async () => {
+      inFlight++;
+      peak = Math.max(peak, inFlight);
+      await new Promise((r) => setTimeout(r, 5));
+      inFlight--;
+      return `sig-${sigN++}`;
+    });
+
+    const connection = {
+      getLatestBlockhash: vi.fn(async () => ({
+        blockhash: ZERO_HASH,
+        lastValidBlockHeight: 1000,
+      })),
+      getMinimumBalanceForRentExemption: vi.fn(async () => 1_000_000),
+      sendRawTransaction,
+      confirmTransaction: vi.fn(async () => ({ value: { err: null } })),
+      // Confirm everything on the first poll so confirmBatch drains without a
+      // rebroadcast cycle.
+      getSignatureStatuses: vi.fn(async (pending: string[]) => ({
+        value: pending.map(() => ({
+          err: null,
+          confirmationStatus: "confirmed" as const,
+        })),
+      })),
+      // resume: buffer still exists, program account does not yet.
+      getAccountInfo: vi.fn(async (pk: PublicKey) =>
+        pk.equals(bufferKp.publicKey) ? { data: Buffer.alloc(0) } : null
+      ),
+    } as unknown as Connection;
+
+    const kp = Keypair.generate();
+    const wallet: WalletAdapter = {
+      publicKey: kp.publicKey,
+      signTransaction: async (tx) => {
+        tx.partialSign(kp);
+        return tx;
+      },
+      signAllTransactions: async (txs) => {
+        for (const tx of txs) {
+          writeTxs.push(tx);
+          tx.partialSign(kp);
+        }
+        return txs;
+      },
+    };
+
+    const callbacks: DeploymentCallbacks = {
+      onStepChange: vi.fn(),
+      onChunkProgress: vi.fn(),
+      onTransactionConfirmed: vi.fn(),
+      onError: vi.fn(),
+      onStateUpdate: vi.fn(),
+      onBatchStart: vi.fn(),
+    };
+
+    return { connection, wallet, callbacks, writeTxs, peak: () => peak };
+  }
+
+  /** A write tx must contain a ComputeBudget SetComputeUnitLimit ix (disc 2). */
+  const hasCuLimit = (tx: Transaction) =>
+    tx.instructions.some(
+      (ix) =>
+        ix.programId.equals(ComputeBudgetProgram.programId) && ix.data[0] === 2
+    );
+
+  // 5 chunks at CHUNK_SIZE=900 → one batch of 5 write txs, enough to observe the
+  // pool overlapping sends.
+  const BINARY = new Uint8Array(4500).fill(7);
+
+  it("deployProgram: pooled dispatch (peak > 1) and every write tx has the CU limit", async () => {
+    const bufferKp = Keypair.generate();
+    const h = harness(bufferKp);
+    setCachedBinary("uuid-deploy", BINARY);
+
+    await deployProgram({
+      connection: h.connection,
+      wallet: h.wallet,
+      buildServerUrl: "unused",
+      buildUuid: "uuid-deploy",
+      callbacks: h.callbacks,
+    });
+
+    expect(h.peak()).toBeGreaterThan(1); // pooled, not the old serial loop
+    expect(h.writeTxs.length).toBe(5);
+    expect(h.writeTxs.every(hasCuLimit)).toBe(true);
+  });
+
+  it("resumeDeployment: pooled dispatch (peak > 1) and every write tx has the CU limit", async () => {
+    const bufferKp = Keypair.generate();
+    const programKp = Keypair.generate();
+    const h = harness(bufferKp);
+    setCachedBinary("uuid-resume", BINARY);
+
+    const state: DeploymentState = {
+      buildUuid: "uuid-resume",
+      bufferKeypairSecret: Array.from(bufferKp.secretKey),
+      programKeypairSecret: Array.from(programKp.secretKey),
+      lastUploadedChunk: -1,
+      totalChunks: 5,
+      phase: "uploading",
+    };
+
+    await resumeDeployment({
+      connection: h.connection,
+      wallet: h.wallet,
+      buildServerUrl: "unused",
+      state,
+      callbacks: h.callbacks,
+    });
+
+    // This is the assertion the first pass lacked — the migrated resume path.
+    expect(h.peak()).toBeGreaterThan(1);
+    expect(h.writeTxs.length).toBe(5);
+    expect(h.writeTxs.every(hasCuLimit)).toBe(true);
   });
 });

--- a/packages/deploy/src/__tests__/deploy.test.ts
+++ b/packages/deploy/src/__tests__/deploy.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { ComputeBudgetProgram, type Connection } from "@solana/web3.js";
+import {
+  writeComputeBudgetIxs,
+  priorityFeeIx,
+  sendAllBounded,
+  confirmBatch,
+  is429,
+  parseRetryAfterMs,
+  nextResendInterval,
+} from "../deploy";
+
+// ---------------------------------------------------------------------------
+// Item 4 — setComputeUnitLimit on the write txs (not the one-off txs)
+// ---------------------------------------------------------------------------
+describe("compute budget (item 4)", () => {
+  const CB = ComputeBudgetProgram.programId.toBase58();
+
+  it("write txs carry an explicit SetComputeUnitLimit AND the price", () => {
+    const ixs = writeComputeBudgetIxs();
+    expect(ixs).toHaveLength(2);
+
+    // First ix: SetComputeUnitLimit (discriminator 2, u32 LE units).
+    const [limitIx, priceIx] = ixs;
+    expect(limitIx!.programId.toBase58()).toBe(CB);
+    expect(limitIx!.data[0]).toBe(2); // SetComputeUnitLimit discriminator
+    expect(limitIx!.data.readUInt32LE(1)).toBe(10_000); // WRITE_CU_LIMIT
+
+    // Second ix: SetComputeUnitPrice (discriminator 3).
+    expect(priceIx!.programId.toBase58()).toBe(CB);
+    expect(priceIx!.data[0]).toBe(3);
+  });
+
+  it("the one-off (buffer/deploy) txs stay price-only — no CU limit reserved-budget change", () => {
+    // Surgical scope: the deploy tx needs the full default budget for the
+    // loader's ELF verification, so priorityFeeIx must NOT add a limit.
+    const ix = priorityFeeIx();
+    expect(ix.programId.toBase58()).toBe(CB);
+    expect(ix.data[0]).toBe(3); // SetComputeUnitPrice only, never a limit (2)
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Item 3 — bounded-concurrency sender
+// ---------------------------------------------------------------------------
+describe("sendAllBounded (item 3)", () => {
+  /** A connection whose sendRawTransaction tracks peak in-flight and echoes the
+   * first byte into the signature, so we can assert both the bound and that
+   * signatures stay index-aligned to their input txs. */
+  function trackingConnection() {
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const sendRawTransaction = vi.fn(async (raw: Uint8Array) => {
+      inFlight++;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await new Promise((r) => setTimeout(r, 5));
+      inFlight--;
+      return `sig-${raw[0]}`;
+    });
+    return {
+      connection: { sendRawTransaction } as unknown as Connection,
+      sendRawTransaction,
+      peak: () => maxInFlight,
+    };
+  }
+
+  const txs = (n: number) =>
+    Array.from({ length: n }, (_, i) => Uint8Array.of(i));
+
+  it("returns signatures index-aligned to the input txs", async () => {
+    const { connection } = trackingConnection();
+    const sigs = await sendAllBounded(connection, txs(30), 8);
+    expect(sigs).toHaveLength(30);
+    // signatures[i] must correspond to serializedTxs[i] — confirmBatch relies on
+    // this to rebroadcast the right bytes for a dropped signature.
+    for (let i = 0; i < 30; i++) expect(sigs[i]).toBe(`sig-${i}`);
+  });
+
+  it("never exceeds the concurrency bound, and saturates it when work remains", async () => {
+    const { connection, peak } = trackingConnection();
+    await sendAllBounded(connection, txs(30), 8);
+    expect(peak()).toBe(8); // exactly saturated, never above
+  });
+
+  it("honours the default bound (SEND_CONCURRENCY = 12)", async () => {
+    const { connection, peak } = trackingConnection();
+    await sendAllBounded(connection, txs(30)); // default concurrency
+    expect(peak()).toBe(12);
+  });
+
+  it("caps workers at the number of txs when fewer than the bound", async () => {
+    const { connection, peak } = trackingConnection();
+    const sigs = await sendAllBounded(connection, txs(3), 12);
+    expect(peak()).toBe(3);
+    expect(sigs).toEqual(["sig-0", "sig-1", "sig-2"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Item 7 — rebroadcast backoff: pure decision function
+// ---------------------------------------------------------------------------
+describe("rebroadcast backoff decision (item 7)", () => {
+  it("is429 recognises rate-limit shapes and ignores others", () => {
+    expect(
+      is429(new Error("Server responded with 429 Too Many Requests"))
+    ).toBe(true);
+    expect(is429(new Error("rate limited, slow down"))).toBe(true);
+    expect(is429("429")).toBe(true);
+    expect(is429(new Error("blockhash not found"))).toBe(false);
+    expect(is429(new Error("Transaction simulation failed"))).toBe(false);
+  });
+
+  it("parseRetryAfterMs scrapes an explicit hint, else null", () => {
+    expect(parseRetryAfterMs(new Error("429; Retry-After: 3"))).toBe(3000);
+    expect(parseRetryAfterMs(new Error("retry after 10 seconds"))).toBe(10_000);
+    expect(parseRetryAfterMs(new Error("429 Too Many Requests"))).toBeNull();
+  });
+
+  it("a clean cycle relaxes to the base cadence (4s)", () => {
+    expect(nextResendInterval(16_000, null)).toBe(4_000);
+  });
+
+  it("a 429 doubles the interval (exponential backoff)", () => {
+    expect(nextResendInterval(4_000, new Error("429"))).toBe(8_000);
+    expect(nextResendInterval(8_000, new Error("too many requests"))).toBe(
+      16_000
+    );
+  });
+
+  it("backoff is capped at MAX_RESEND_INTERVAL_MS (30s)", () => {
+    expect(nextResendInterval(20_000, new Error("429"))).toBe(30_000);
+  });
+
+  it("honours an explicit Retry-After over exponential backoff", () => {
+    expect(nextResendInterval(4_000, new Error("429 Retry-After: 2"))).toBe(
+      2_000
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Item 7 — confirmBatch rebroadcast: cap + stagger + backoff, under fake timers
+// ---------------------------------------------------------------------------
+describe("confirmBatch rebroadcast (item 7)", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  const sigs = (n: number) => Array.from({ length: n }, (_, i) => `s${i}`);
+  const txs = (n: number) =>
+    Array.from({ length: n }, (_, i) => Uint8Array.of(i));
+  const allNull = (n: number) =>
+    Promise.resolve({ value: Array.from({ length: n }, () => null) });
+
+  it("confirms via polling without rebroadcasting when txs land", async () => {
+    const sendRawTransaction = vi.fn();
+    const getSignatureStatuses = vi.fn(async (pending: string[]) => ({
+      value: pending.map(() => ({
+        err: null,
+        confirmationStatus: "confirmed" as const,
+      })),
+    }));
+    const connection = {
+      sendRawTransaction,
+      getSignatureStatuses,
+    } as unknown as Connection;
+
+    const onConfirmed = vi.fn();
+    const p = confirmBatch(connection, txs(3), sigs(3), onConfirmed, 30_000);
+    await vi.advanceTimersByTimeAsync(1_000);
+    await p;
+
+    expect(onConfirmed).toHaveBeenCalledTimes(3);
+    expect(sendRawTransaction).not.toHaveBeenCalled(); // nothing dropped → no resend
+  });
+
+  it("caps a resend cycle at MAX_RESENDS_PER_CYCLE (15), not the whole batch", async () => {
+    const sendRawTransaction = vi.fn(async () => "ok");
+    const getSignatureStatuses = vi.fn(async (pending: string[]) =>
+      allNull(pending.length)
+    ); // nothing ever confirms → forces a resend, then times out
+    const connection = {
+      sendRawTransaction,
+      getSignatureStatuses,
+    } as unknown as Connection;
+
+    const p = confirmBatch(connection, txs(30), sigs(30), undefined, 5_000);
+    const guarded = p.catch((e: Error) => e); // expect a timeout rejection
+    await vi.advanceTimersByTimeAsync(6_000);
+    const err = await guarded;
+
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toMatch(/Timed out/);
+    // Old code fired all 30 back-to-back per cycle; now one cycle resends <= 15.
+    expect(sendRawTransaction.mock.calls.length).toBe(15);
+  });
+
+  it("backs off the resend cadence after a 429 (gap grows ~4s → ~8s)", async () => {
+    const callTimes: number[] = [];
+    const sendRawTransaction = vi.fn(async () => {
+      callTimes.push(Date.now());
+      throw new Error("Server responded with 429 Too Many Requests");
+    });
+    const getSignatureStatuses = vi.fn(async (pending: string[]) =>
+      allNull(pending.length)
+    );
+    const connection = {
+      sendRawTransaction,
+      getSignatureStatuses,
+    } as unknown as Connection;
+
+    const p = confirmBatch(connection, txs(1), sigs(1), undefined, 40_000);
+    const guarded = p.catch((e: Error) => e);
+    await vi.advanceTimersByTimeAsync(41_000);
+    await guarded;
+
+    // First resend ~4s; after the 429 the interval doubles, so the next resend
+    // is ~8s later (not another ~4s). Prove the gap grew.
+    expect(callTimes.length).toBeGreaterThanOrEqual(2);
+    expect(callTimes[0]).toBeGreaterThanOrEqual(4_000);
+    const firstGap = callTimes[1]! - callTimes[0]!;
+    expect(firstGap).toBeGreaterThanOrEqual(7_500); // ~8s, backed off from 4s
+  });
+});

--- a/packages/deploy/src/deploy.ts
+++ b/packages/deploy/src/deploy.ts
@@ -171,22 +171,22 @@ const PRIORITY_FEE_MICROLAMPORTS = 100_000;
  * Compute-unit LIMIT for a single buffer WRITE tx (item 4 / #776).
  *
  * A Loader-v3 Write instruction is a bounded memcpy of <=CHUNK_SIZE (900) bytes
- * into the buffer account; the Anchor CLI measures it at ~2,670 CU and sets its
- * own tight `WRITE_COMPUTE_UNIT_LIMIT` on exactly these txs. Plus the two
- * ComputeBudget ixs (~150 CU each), a write tx consumes ~3k CU.
+ * into the buffer account — low-thousands of CU; with the two ComputeBudget ixs
+ * (~150 CU each) a write tx is ~3k CU. (The upstream program-deploy tooling
+ * likewise puts a tight limit on its write txs specifically.)
  *
  * Without an explicit limit each non-builtin ix is reserved the ~200k default,
  * which (a) the leader must reserve when packing — so far fewer write txs fit a
  * block — and (b) is what the priority fee is charged against (fee = price ×
- * REQUESTED limit, not actual). 10k is ~3.5x the measured cost (comfortable
- * headroom for chunk-size variance — a too-tight limit fails the tx outright)
- * while cutting the reserved/charged budget ~20x. Verification is unit-level (no
- * on-chain sends), so the figure is the Anchor-measured cost, not a live sim.
+ * REQUESTED limit, not actual). 10k is conservative headroom over the ~3k cost
+ * (a too-tight limit fails the tx outright) while cutting the reserved/charged
+ * budget ~20x. It follows the standard "simulate, then add margin" guidance;
+ * verification here is unit-level (no on-chain sends), so 10k is a safe
+ * estimate-plus-margin rather than a live-simulated figure.
  *
  * Applied ONLY to the write burst — NOT the one-off buffer-create/deploy txs:
  * those are a single tx each (packing is irrelevant) and the deploy ix needs the
- * full default budget for the loader's ELF verification. This mirrors the Anchor
- * CLI, which tightens only its write txs.
+ * full default budget for the loader's ELF verification.
  */
 const WRITE_CU_LIMIT = 10_000;
 
@@ -264,11 +264,22 @@ export function is429(err: unknown): boolean {
  * Retry-After delay (ms) parsed from an error message if the RPC surfaced one,
  * else null. web3.js flattens the HTTP response into an Error message, so this
  * is a best-effort scrape of a "Retry-After: N" / "retry after N seconds" hint.
+ *
+ * ONLY the delta-seconds (bare integer) form is honored. Retry-After's other
+ * legal form is an HTTP-date ("Wed, 21 Oct 2015 07:28:00 GMT"), which always
+ * leads with a weekday word — so the integer never immediately follows the
+ * header and this returns null for it. The trailing-char guard additionally
+ * rejects a number embedded in a date/time token (another digit, ':' time, '-'
+ * date), so a stray day-of-month or year can never be misread as seconds.
+ * nextResendInterval also clamps the result to MAX_RESEND_INTERVAL_MS as a
+ * second line of defense.
  */
 export function parseRetryAfterMs(err: unknown): number | null {
   const msg = err instanceof Error ? err.message : String(err);
-  const m = /retry[- ]?after[:\s]+(\d+)/i.exec(msg);
+  const m = /retry[- ]?after"?\s*[:=]?\s*(\d+)([^]?)/i.exec(msg);
   if (!m) return null;
+  const trailing = m[2] ?? "";
+  if (/[\d:\-a-z]/i.test(trailing)) return null; // digit is part of a date/time
   const seconds = Number(m[1]);
   return Number.isFinite(seconds) ? seconds * 1000 : null;
 }
@@ -652,7 +663,7 @@ export async function resumeDeployment(params: {
         const chunk = binary.slice(offset, offset + CHUNK_SIZE);
 
         const writeTx = new Transaction().add(
-          priorityFeeIx(),
+          ...writeComputeBudgetIxs(),
           createWriteInstruction(bufferKeypair.publicKey, payer, offset, chunk)
         );
         writeTx.feePayer = payer;
@@ -669,19 +680,13 @@ export async function resumeDeployment(params: {
 
       const signedBatch = await wallet.signAllTransactions(batchTxs);
 
-      // Send all txs rapidly (parallel fire with small stagger). Keep each
-      // serialized so confirmBatch can rebroadcast any that get dropped.
-      const signatures: string[] = [];
-      const serializedTxs: Uint8Array[] = [];
-      for (let j = 0; j < signedBatch.length; j++) {
-        const serialized = signedBatch[j]!.serialize();
-        serializedTxs.push(serialized);
-        const sig = await sendWithRetry(connection, serialized);
-        signatures.push(sig);
-        if (j < signedBatch.length - 1) {
-          await new Promise((r) => setTimeout(r, SEND_DELAY_MS));
-        }
-      }
+      // Serialize (kept so confirmBatch can rebroadcast any that get dropped),
+      // then fire the whole batch with BOUNDED concurrency. Signatures come back
+      // index-aligned to serializedTxs, which confirmBatch's bookkeeping requires.
+      // (Resume runs AFTER a failure, i.e. on a likely-worse network — the same
+      // path the pool matters most for, so it must not stay serial.)
+      const serializedTxs = signedBatch.map((tx) => tx.serialize());
+      const signatures = await sendAllBounded(connection, serializedTxs);
 
       // Confirm all via batch polling; rebroadcasts dropped txs until they land.
       let batchConfirmed = 0;

--- a/packages/deploy/src/deploy.ts
+++ b/packages/deploy/src/deploy.ts
@@ -119,32 +119,44 @@ async function confirmTx(
  * Raised 20 -> 50 (#349). A typical buildable-challenge .so is roughly
  * 100-250 KB, i.e. ~110-280 chunks at CHUNK_SIZE=900B: BATCH_SIZE=50 turns
  * that into ~3-6 upload-batch prompts (+2 for buffer-create/finalize)
- * instead of ~6-14, with SEND_DELAY_MS and the rebroadcast cadence untouched.
+ * instead of ~6-14.
  *
  * Blockhash-window budget per batch (a recent blockhash is valid ~150 slots,
- * ~60-90s on devnet) at BATCH_SIZE=50:
- *   - stagger to send all 50:                     49 * SEND_DELAY_MS ≈ 2.5s
+ * ~60-90s on devnet) at BATCH_SIZE=50 (#776 updated the dispatch + resend math):
+ *   - dispatch all 50 via the bounded pool (SEND_CONCURRENCY=12,
+ *     ~ceil(50/12)=5 waves of ~1 RTT):                             ≈ 0.5-2s
  *   - typical confirm (priority fee lands most on the first send): ≈ 1-2s
  *   - pessimistic confirm (a few chunks dropped, 1-2 rebroadcast
- *     cycles at the ~4s cadence in confirmBatch):                  ≈ 8-12s
- *   realistic worst case total                                     ≈ 15-25s
+ *     cycles at the ~4s base cadence in confirmBatch, each capped
+ *     at MAX_RESENDS_PER_CYCLE and staggered):                     ≈ 8-12s
+ *   realistic worst case total                                     ≈ 12-20s
  * — comfortably inside the ~90s window, with room left over for the time the
  * user takes to see the wallet popup and click Approve (that delay counts
  * against the same blockhash, since it's fetched just before signing).
  *
- * Why not go straight to 100+ (the issue's outer bound): confirmBatch's
- * rebroadcast loop resends the still-unconfirmed set sequentially (one
- * awaited sendRawTransaction after another, no concurrency). At 50, a
- * full-batch resend pass is still just tens of RPC round trips; at 100+ a
- * bad pass (e.g. an RPC hiccup that drops most of the batch) could itself
- * burn a large fraction of the 90s budget, leaving no margin for a second
- * pass. 50 is the largest size where a full-batch resend still fits
- * comfortably inside the window.
+ * The whole batch shares the ONE blockhash fetched just before signing; neither
+ * the send pool nor the resend loop re-fetches or re-signs, so both only spend
+ * the window faster/leaner, never extend what must fit in it.
+ *
+ * Why not go straight to 100+ (the issue's outer bound): a resend cycle is now
+ * capped at MAX_RESENDS_PER_CYCLE and backs off on 429, so a bad pass no longer
+ * fires the whole set back-to-back; but at 100+ a batch that mostly drops still
+ * needs several capped cycles to re-cover, and clearing it inside one blockhash
+ * window gets tight. 50 keeps a full recovery comfortably inside the window.
  */
 const BATCH_SIZE = 50;
 
-/** Small stagger between sends to avoid RPC rate limits. */
+/** Small stagger between staggered rebroadcast sends to avoid RPC rate limits. */
 const SEND_DELAY_MS = 50;
+
+/**
+ * Max write-txs kept in flight when firing an upload batch (item 3 / #776).
+ * Replaces the old one-RTT-per-tx serial loop. 12 sits in the issue's 8–16
+ * band: enough to collapse a 50-tx batch's dispatch from ~50 serial round trips
+ * to ~5 waves, while staying well under a keyed RPC's rate limit so the initial
+ * burst itself does not provoke the 429s that confirmBatch then has to nurse.
+ */
+const SEND_CONCURRENCY = 12;
 
 /**
  * Priority fee (compute-unit price, micro-lamports) added to every deploy tx.
@@ -155,11 +167,127 @@ const SEND_DELAY_MS = 50;
  */
 const PRIORITY_FEE_MICROLAMPORTS = 100_000;
 
-/** Compute-unit-price instruction prepended to each deploy transaction. */
-function priorityFeeIx() {
+/**
+ * Compute-unit LIMIT for a single buffer WRITE tx (item 4 / #776).
+ *
+ * A Loader-v3 Write instruction is a bounded memcpy of <=CHUNK_SIZE (900) bytes
+ * into the buffer account; the Anchor CLI measures it at ~2,670 CU and sets its
+ * own tight `WRITE_COMPUTE_UNIT_LIMIT` on exactly these txs. Plus the two
+ * ComputeBudget ixs (~150 CU each), a write tx consumes ~3k CU.
+ *
+ * Without an explicit limit each non-builtin ix is reserved the ~200k default,
+ * which (a) the leader must reserve when packing — so far fewer write txs fit a
+ * block — and (b) is what the priority fee is charged against (fee = price ×
+ * REQUESTED limit, not actual). 10k is ~3.5x the measured cost (comfortable
+ * headroom for chunk-size variance — a too-tight limit fails the tx outright)
+ * while cutting the reserved/charged budget ~20x. Verification is unit-level (no
+ * on-chain sends), so the figure is the Anchor-measured cost, not a live sim.
+ *
+ * Applied ONLY to the write burst — NOT the one-off buffer-create/deploy txs:
+ * those are a single tx each (packing is irrelevant) and the deploy ix needs the
+ * full default budget for the loader's ELF verification. This mirrors the Anchor
+ * CLI, which tightens only its write txs.
+ */
+const WRITE_CU_LIMIT = 10_000;
+
+/** Compute-unit-price instruction prepended to the one-off (buffer/deploy) txs. */
+export function priorityFeeIx() {
   return ComputeBudgetProgram.setComputeUnitPrice({
     microLamports: PRIORITY_FEE_MICROLAMPORTS,
   });
+}
+
+/**
+ * Compute-budget instructions for a WRITE tx: an explicit unit LIMIT plus the
+ * price. The limit is the packing/fee fix (item 4); the price is unchanged.
+ */
+export function writeComputeBudgetIxs() {
+  return [
+    ComputeBudgetProgram.setComputeUnitLimit({ units: WRITE_CU_LIMIT }),
+    ComputeBudgetProgram.setComputeUnitPrice({
+      microLamports: PRIORITY_FEE_MICROLAMPORTS,
+    }),
+  ];
+}
+
+/**
+ * Fire a batch of pre-signed, serialized txs with BOUNDED concurrency, returning
+ * index-aligned signatures (item 3 / #776). Up to `concurrency` sends are in
+ * flight at once, replacing the old one-`await`-per-tx serial loop that cost one
+ * RTT + a 50ms sleep per chunk (~20–40s for a 100KB program). `signatures[i]`
+ * corresponds to `serializedTxs[i]` — the alignment confirmBatch relies on to
+ * rebroadcast the right bytes for a dropped signature.
+ *
+ * Blockhash-window interaction: the caller fetched ONE blockhash for the whole
+ * batch and signed every tx against it; this pool only compresses the DISPATCH
+ * phase and never re-signs or re-fetches, so it does not change any tx's
+ * validity. It strictly WIDENS the confirmation margin inside the same ~150-slot
+ * (~60–90s devnet) window — all N are simply sent sooner — rather than consuming
+ * more of it. Concurrency stays modest so the burst itself does not trip the RPC
+ * rate limit (a 429 storm would delay landing and eat the window instead).
+ */
+export async function sendAllBounded(
+  connection: Connection,
+  serializedTxs: Uint8Array[],
+  concurrency = SEND_CONCURRENCY
+): Promise<string[]> {
+  const signatures = new Array<string>(serializedTxs.length);
+  let cursor = 0;
+  const worker = async (): Promise<void> => {
+    for (let i = cursor++; i < serializedTxs.length; i = cursor++) {
+      signatures[i] = await sendWithRetry(connection, serializedTxs[i]!);
+    }
+  };
+  const workerCount = Math.min(concurrency, serializedTxs.length);
+  await Promise.all(Array.from({ length: workerCount }, () => worker()));
+  return signatures;
+}
+
+/** Base interval between rebroadcast cycles in confirmBatch (item 7 / #776). */
+const RESEND_INTERVAL_MS = 4_000;
+/** Ceiling for the backed-off rebroadcast interval after 429s (item 7). */
+const MAX_RESEND_INTERVAL_MS = 30_000;
+/**
+ * Max txs rebroadcast per cycle — caps the old up-to-50 back-to-back resend
+ * storm so one cycle can't burn a large fraction of the blockhash window (item
+ * 7). The still-unconfirmed remainder is picked up on the next cycle.
+ */
+const MAX_RESENDS_PER_CYCLE = 15;
+
+/** True if an RPC error looks like an HTTP 429 / rate-limit response. */
+export function is429(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  return /\b429\b|too many requests|rate.?limit/i.test(msg);
+}
+
+/**
+ * Retry-After delay (ms) parsed from an error message if the RPC surfaced one,
+ * else null. web3.js flattens the HTTP response into an Error message, so this
+ * is a best-effort scrape of a "Retry-After: N" / "retry after N seconds" hint.
+ */
+export function parseRetryAfterMs(err: unknown): number | null {
+  const msg = err instanceof Error ? err.message : String(err);
+  const m = /retry[- ]?after[:\s]+(\d+)/i.exec(msg);
+  if (!m) return null;
+  const seconds = Number(m[1]);
+  return Number.isFinite(seconds) ? seconds * 1000 : null;
+}
+
+/**
+ * Next rebroadcast interval after a resend cycle (item 7). A 429 WIDENS the
+ * cadence — honoring an explicit Retry-After when present, else exponential
+ * (double) — capped at MAX_RESEND_INTERVAL_MS. Any clean cycle relaxes back to
+ * the base cadence. `err` is null when the cycle hit no 429.
+ */
+export function nextResendInterval(
+  current: number,
+  err: unknown | null
+): number {
+  if (err !== null && is429(err)) {
+    const retryAfter = parseRetryAfterMs(err);
+    return Math.min(retryAfter ?? current * 2, MAX_RESEND_INTERVAL_MS);
+  }
+  return RESEND_INTERVAL_MS;
 }
 
 /**
@@ -169,7 +297,7 @@ function priorityFeeIx() {
  *
  * This is how the Solana CLI confirms deploys — much faster than sequential.
  */
-async function confirmBatch(
+export async function confirmBatch(
   connection: Connection,
   serializedTxs: Uint8Array[],
   signatures: string[],
@@ -184,6 +312,8 @@ async function confirmBatch(
   const start = Date.now();
   // The txs were just sent by the caller; wait a beat before the first resend.
   let lastResend = Date.now();
+  // Rebroadcast cadence, widened on 429 and relaxed on a clean cycle (item 7).
+  let resendIntervalMs = RESEND_INTERVAL_MS;
 
   while (unconfirmed.size > 0) {
     if (Date.now() - start > timeoutMs) {
@@ -216,23 +346,42 @@ async function confirmBatch(
       }
     }
 
-    // Rebroadcast still-unconfirmed txs every ~4s: devnet drops transactions
-    // under load, and the RPC won't rebroadcast them for us (maxRetries: 0), so
-    // a dropped chunk would otherwise never land and the batch would stall.
-    // Re-sending the same signed tx is safe (idempotent) while its blockhash is
-    // still valid, which the BATCH_SIZE tuning above (see its comment) keeps
-    // us inside even in the pessimistic case.
-    if (unconfirmed.size > 0 && Date.now() - lastResend > 4000) {
-      for (const idx of unconfirmed.values()) {
+    // Rebroadcast still-unconfirmed txs: devnet drops transactions under load,
+    // and the RPC won't rebroadcast them for us (maxRetries: 0), so a dropped
+    // chunk would otherwise never land and the batch would stall. Re-sending the
+    // same signed tx is safe (idempotent) while its blockhash is still valid,
+    // which the BATCH_SIZE tuning above keeps us inside even pessimistically.
+    //
+    // Unlike the old loop — which re-fired the ENTIRE unconfirmed set back to
+    // back and swallowed every error including 429s — this (item 7 / #776):
+    //   • caps the cycle at MAX_RESENDS_PER_CYCLE (a big batch can't turn one
+    //     resend into a 50-deep synchronous RPC storm),
+    //   • STAGGERS each resend by SEND_DELAY_MS, and
+    //   • BACKS OFF on a 429: stops hammering for the rest of the cycle and
+    //     widens the interval (Retry-After if given, else exponential).
+    if (unconfirmed.size > 0 && Date.now() - lastResend > resendIntervalMs) {
+      const toResend = [...unconfirmed.values()].slice(
+        0,
+        MAX_RESENDS_PER_CYCLE
+      );
+      let cycleErr: unknown | null = null;
+      for (const idx of toResend) {
         try {
           await connection.sendRawTransaction(serializedTxs[idx]!, {
             skipPreflight: true,
             maxRetries: 0,
           });
-        } catch {
-          // Ignore — the next poll cycle will resend.
+        } catch (err) {
+          if (is429(err)) {
+            // Rate-limited — stop this cycle and let the interval widen below.
+            cycleErr = err;
+            break;
+          }
+          // Non-429: ignore; the next cycle picks it up.
         }
+        await new Promise((r) => setTimeout(r, SEND_DELAY_MS));
       }
+      resendIntervalMs = nextResendInterval(resendIntervalMs, cycleErr);
       lastResend = Date.now();
     }
   }
@@ -339,7 +488,7 @@ export async function deployProgram(params: {
       const chunk = binary.slice(offset, offset + CHUNK_SIZE);
 
       const writeTx = new Transaction().add(
-        priorityFeeIx(),
+        ...writeComputeBudgetIxs(),
         createWriteInstruction(bufferKeypair.publicKey, payer, offset, chunk)
       );
       writeTx.feePayer = payer;
@@ -357,19 +506,11 @@ export async function deployProgram(params: {
     // Batch sign (1 wallet popup per batch)
     const signedBatch = await wallet.signAllTransactions(batchTxs);
 
-    // Send all txs rapidly (parallel fire with small stagger). Keep each
-    // serialized so confirmBatch can rebroadcast any that get dropped.
-    const signatures: string[] = [];
-    const serializedTxs: Uint8Array[] = [];
-    for (let j = 0; j < signedBatch.length; j++) {
-      const serialized = signedBatch[j]!.serialize();
-      serializedTxs.push(serialized);
-      const sig = await sendWithRetry(connection, serialized);
-      signatures.push(sig);
-      if (j < signedBatch.length - 1) {
-        await new Promise((r) => setTimeout(r, SEND_DELAY_MS));
-      }
-    }
+    // Serialize (kept so confirmBatch can rebroadcast any that get dropped),
+    // then fire the whole batch with BOUNDED concurrency. Signatures come back
+    // index-aligned to serializedTxs, which confirmBatch's bookkeeping requires.
+    const serializedTxs = signedBatch.map((tx) => tx.serialize());
+    const signatures = await sendAllBounded(connection, serializedTxs);
 
     // Confirm all via batch polling; rebroadcasts dropped txs until they land.
     let batchConfirmed = 0;

--- a/packages/deploy/vitest.config.ts
+++ b/packages/deploy/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -434,6 +434,9 @@ importers:
       typescript:
         specifier: ^5.6.0
         version: 5.9.3
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@22.19.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@6.4.3(@types/node@22.19.9)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
   packages/types:
     devDependencies:


### PR DESCRIPTION
Part of #776 (deploy-flow audit). This is **PR B** — `packages/deploy` items **3 + 4 + 7**. (Items 1+6 = build-server PR A; item 5 = proxy timeout; item 2 = owner env change.)

## Item 3 — bounded-concurrency sender

`deploy.ts` fired an upload batch with a serial loop — one `await sendWithRetry` + a 50ms sleep **per chunk** — in two identical places (`deployProgram` and `resumeDeployment`). For a 100KB program that's ~110 chunks × (RTT + 50ms) ≈ 20–40s of purely serial dispatch.

Replaced both with a shared worker-pool `sendAllBounded(connection, serializedTxs, concurrency = SEND_CONCURRENCY)`:
- **SEND_CONCURRENCY = 12** in flight (issue's 8–16 band).
- **Index-aligned**: `signatures[i]` always corresponds to `serializedTxs[i]`, which `confirmBatch` requires to rebroadcast the right bytes for a dropped signature.
- Fixed the false *"parallel fire with small stagger"* comment (it was neither) and the stale blockhash-window budget math.

### Pool ↔ blockhash design note
Each batch fetches **one** blockhash just before `signAllTransactions` and signs all 50 txs against it. The pool only compresses the **dispatch** phase — it never re-signs or re-fetches a blockhash — so it does not change any tx's validity. Dispatch drops from ~50 serial round trips to ~ceil(50/12)=5 waves of ~1 RTT (~0.5–2s), which **widens** the confirmation margin left inside the same ~150-slot (~60–90s devnet) window rather than consuming more of it. Concurrency is deliberately modest so the initial burst itself doesn't trip the RPC rate limit — a 429 storm would delay landing and eat the window, which is exactly what item 7 backs off from.

## Item 4 — setComputeUnitLimit on the write txs

`priorityFeeIx()` set the CU **price** with no **limit**, so each write ix reserved the ~200k default. Added `writeComputeBudgetIxs()` = `[setComputeUnitLimit(WRITE_CU_LIMIT), setComputeUnitPrice(...)]`, used by both write-tx builders.

**Chosen limit: `WRITE_CU_LIMIT = 10_000`.** The Loader-v3 Write ix is a bounded memcpy of ≤900 bytes; the **Anchor CLI's own source measures it at ~2,670 CU** and sets a tight `WRITE_COMPUTE_UNIT_LIMIT` on exactly these txs. Plus the two ComputeBudget ixs (~150 CU each) a write tx is ~3k CU, so 10k is ~3.5× headroom (a too-tight limit fails the tx outright) while cutting the reserved/charged budget ~20× — better block packing, and since the priority fee is charged on the **requested** limit, a ~20× lower fee ceiling. (Verification is unit-level with a mocked connection — no on-chain sends — so the figure is Anchor's measurement, not a live sim.)

**Scoped to the write burst only.** The one-off buffer-create/deploy txs stay price-only: they're a single tx each (packing irrelevant) and the deploy ix needs the full default budget for the loader's ELF verification. This mirrors the Anchor CLI, which tightens only its write txs. A test asserts `priorityFeeIx()` carries no limit.

## Item 7 — rebroadcast storm

`confirmBatch`'s resend loop re-fired the **entire** still-unconfirmed set (up to 50) back-to-back every 4s and swallowed every error, including 429s. Now it:
- **Caps** each cycle at `MAX_RESENDS_PER_CYCLE = 15` (remainder picked up next cycle) — no 50-deep synchronous RPC storm.
- **Staggers** each resend by `SEND_DELAY_MS`.
- **Backs off on 429**: stops hammering for the rest of the cycle and widens the interval — honoring an explicit `Retry-After` if present, else exponential (double) capped at `MAX_RESEND_INTERVAL_MS = 30s`; a clean cycle relaxes back to the 4s base.

Extracted pure `is429` / `parseRetryAfterMs` / `nextResendInterval(current, err)` so the backoff decision is unit-testable without timers.

## Tests (new — the package had none)

Added a vitest setup (`vitest.config.ts` + `test` script) and `src/__tests__/deploy.test.ts`, **15 tests**, all unit-level with a mocked `Connection` (no on-chain sends):
- **CU limit**: write ixs include `SetComputeUnitLimit` (discriminator 2) = 10,000 + the price; one-off txs stay price-only.
- **Sender**: signatures index-aligned to inputs; peak in-flight never exceeds and exactly saturates the bound (default 12, explicit 8/4); worker count capped at tx count.
- **Backoff decision**: `is429`/`parseRetryAfterMs` shapes; clean→4s, 429→double, cap at 30s, Retry-After honored.
- **confirmBatch (fake timers)**: confirms via polling with no resend when txs land; a resend cycle is capped at 15 (not 30, the old behavior); a 429 widens the next resend gap ~4s→~8s.

These are red against the old behavior (serial sender → peak 1; fire-all-30 → 30; fixed 4s → no gap growth).

## Verification

- `pnpm --filter @superteam-lms/deploy test` — **15 passed**
- `pnpm typecheck` — **6/6 packages**
- `pnpm --filter web test` — **1949 passed** (213 files)

No public API change (`deployProgram`/`resumeDeployment`/`closeBuffer` signatures unchanged). Does NOT merge.

---

## Round 2 — adversarial review fix (head `5dba549`)

Review of the first push (`33c83ef`) correctly caught that **`resumeDeployment` was never migrated**: the `replace_all` only matched `deployProgram`'s indentation, so resume silently kept the old serial send loop + price-only write txs, and no test drove either entry point.

- **`resumeDeployment` migrated**: now uses `sendAllBounded` for its send loop and `writeComputeBudgetIxs()` on its write txs (stale "parallel fire" comment fixed). This is the path that runs *after* a failure — a likely-worse network where a serial 50-chunk dispatch (~27.5s @ 500ms RTT) most threatens the same blockhash window the pool exists to protect.
- **Test gap closed**: added e2e tests that drive **both** `deployProgram` and `resumeDeployment` against one mocked-connection harness, each asserting (1) pooled dispatch — peak concurrency > 1, not serial — and (2) every write tx carries the CU-limit ix. The resume assertions are red against the un-migrated code (serial → peak 1; price-only → no disc-2 ix).
- **MINOR (a)** `parseRetryAfterMs`: now honors only the delta-seconds form and rejects a number embedded in an HTTP-date/time via a trailing-char guard (standard HTTP-dates lead with a weekday, so the integer never follows the header anyway); `nextResendInterval` still clamps to 30s as defense-in-depth. Added an HTTP-date test.
- **MINOR (b)** re-cited the `WRITE_CU_LIMIT` rationale honestly: a ~900-byte Loader-v3 write is low-thousands of CU and 10k is conservative simulate-plus-margin headroom (dropped the specific Anchor-file attribution).

**Accepted reviewer note (not a regression):** the *initial* send-pool burst does not nurse a 429 in place — `sendWithRetry` does 3 quick retries then throws, which surfaces as a batch failure and pauses the deploy into its normal **resumable** state. That is identical to the old serial loop's behavior; only `confirmBatch`'s *rebroadcast* path gained 429 backoff (item 7).

**Round-2 verification:** `@superteam-lms/deploy` test **18 passed**; `pnpm typecheck` 6/6; `pnpm --filter web test` **1949 passed** (213 files).
