### PR TITLE
test(e2e): Playwright for the 3 critical learner paths (#781)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,6 +155,71 @@ jobs:
           NEXT_PUBLIC_SUPABASE_ANON_KEY: test-anon-key
         run: pnpm -r test
 
+  # ── E2E: Playwright, the 3 critical learner paths (#781) ────────────────────
+  # Runs the learner-path specs against a PRODUCTION build (`next build &&
+  # next start`) fronted by a mock Supabase — the runtime coverage the gate's
+  # manual smokes used to give, now permanent. Change-gated on `frontend` (same
+  # as the frontend job) so it does NOT run on every push of every PR — only when
+  # apps/web (or the shared deps that reach it) change, or on manual dispatch.
+  # See apps/web/e2e/README.md for the harness + mock-boundary map.
+  e2e:
+    name: E2E (Playwright · learner paths)
+    runs-on: ubuntu-latest
+    needs: changes
+    timeout-minutes: 15
+    if: >-
+      github.event.action != 'labeled' &&
+      (needs.changes.outputs.frontend == 'true' || github.event_name == 'workflow_dispatch')
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+
+      - name: Setup Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # Cache the Next build cache so the `next build` inside the harness stays
+      # incremental across runs (keeps the E2E wall-clock down — the specs
+      # themselves are seconds; the cold build is the bulk).
+      - name: Cache Next build
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: apps/web/.next/cache
+          key: nextcache-e2e-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ hashFiles('apps/web/src/**') }}
+          restore-keys: |
+            nextcache-e2e-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-
+            nextcache-e2e-${{ runner.os }}-
+
+      # Pinned via package.json (@playwright/test 1.59.1); --with-deps pulls the
+      # OS libs the browser needs on the runner. openssl (for the mock cert) is
+      # pre-installed on ubuntu-latest.
+      - name: Install Playwright browser
+        run: pnpm --filter web exec playwright install --with-deps chromium
+
+      - name: Run E2E (build + start + specs)
+        # The harness (apps/web/e2e/harness/serve.mjs) generates the cert, starts
+        # the mock, runs `next build`, then `next start`. Single source of the
+        # E2E env, so build-time NEXT_PUBLIC_* and runtime agree.
+        run: pnpm --filter web e2e
+
+      - name: Upload Playwright report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: playwright-report
+          path: |
+            apps/web/playwright-report
+            apps/web/test-results
+          if-no-files-found: ignore
+          retention-days: 7
+
   # ── On-chain program: fmt, clippy, Rust unit tests ──────────────────────────
   onchain-rust:
     name: On-chain (fmt · clippy · cargo test)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,13 +185,17 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      # Cache the Next build cache so the `next build` inside the harness stays
-      # incremental across runs (keeps the E2E wall-clock down — the specs
-      # themselves are seconds; the cold build is the bulk).
-      - name: Cache Next build
+      # Cache ONLY the webpack BUILD cache so `next build` inside the harness
+      # stays incremental (the cold build is the bulk of the E2E wall-clock; the
+      # specs are seconds). Deliberately NOT `.next/cache` wholesale: that would
+      # restore `.next/cache/fetch-cache` — the `unstable_cache` DATA cache — and
+      # a restored stale deployment snapshot would let the catalog spec no-op on
+      # last-run's data (the gate's finding). The harness also purges fetch-cache
+      # before `next start`; this narrower path is the belt to that suspenders.
+      - name: Cache Next build (webpack only, never fetch-cache)
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
-          path: apps/web/.next/cache
+          path: apps/web/.next/cache/webpack
           key: nextcache-e2e-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ hashFiles('apps/web/src/**') }}
           restore-keys: |
             nextcache-e2e-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-

--- a/.gitignore
+++ b/.gitignore
@@ -99,6 +99,11 @@ docs/FLOW_AUDIT.md
 docs/DEEP_AUDIT_REPORT.md
 audit/
 
+# Playwright (E2E — #781)
+playwright-report/
+test-results/
+/apps/web/playwright/.cache/
+
 # Misc
 *.log
 *.tmp

--- a/apps/web/e2e/README.md
+++ b/apps/web/e2e/README.md
@@ -1,0 +1,69 @@
+# E2E — critical learner paths (#781)
+
+Playwright end-to-end coverage for the three learner paths the gate's manual
+runtime smokes used to cover by hand (and which died with the gate's session).
+Runs against a **production build** (`next build && next start`), not `next dev`.
+
+## Run locally
+
+```bash
+pnpm --filter web e2e            # headless, builds + starts everything
+pnpm --filter web e2e:ui         # Playwright UI mode
+pnpm --filter web e2e:report     # open the last HTML report
+```
+
+`playwright.config.ts`'s `webServer` runs `e2e/harness/serve.mjs`, which owns the
+whole harness so ordering is deterministic:
+
+1. generate a fresh self-signed cert for `127.0.0.1` (openssl — nothing committed);
+2. start the **mock Supabase** server (`e2e/harness/mock-supabase.mjs`) over HTTPS
+   and wait for `/health`;
+3. `next build` with the E2E env (skipped when `E2E_NO_BUILD=1`);
+4. `next start` on `:3100` with `NODE_EXTRA_CA_CERTS` pointing at the cert.
+
+Prereqs: `pnpm --filter web exec playwright install chromium` once, and `openssl`
+on `PATH` (present on macOS and GitHub `ubuntu-latest`).
+
+## Why a mock Supabase (and why HTTPS)
+
+The catalog's active-course set is resolved **server-side**
+(`lib/content/deployments.ts` reads the `public_onchain_deployments` view), so it
+cannot be mocked from the browser. A real endpoint returning a fixed fixture is
+the only way to make the catalog deterministic under `next start`. The same
+server answers the browser-side profile/enrollment/progress reads for the learn
+loop.
+
+`env.ts` requires `NEXT_PUBLIC_SUPABASE_URL` to be `https://` in production (and
+`next start` is production), so the mock speaks TLS with the per-run self-signed
+cert. The app's Node process trusts it via `NODE_EXTRA_CA_CERTS`; the browser via
+`ignoreHTTPSErrors`.
+
+Everything is fake by construction — no real keys, no real JWT, no real wallet,
+no network, no on-chain tx. The learner "session" is a locally-minted cookie
+(`harness/session.ts`) the specs attach; the mock signs and verifies nothing.
+
+## The three specs
+
+| Spec         | File                  | Auth           | What it locks in                                                                                                      |
+| ------------ | --------------------- | -------------- | --------------------------------------------------------------------------------------------------------------------- |
+| Catalog gate | `catalog.spec.ts`     | none           | Anonymous `/en/courses` renders **only** active courses; a deactivated course is absent (#711 regression, permanent). |
+| Learn loop   | `learn-loop.spec.ts`  | mocked session | Signed-in, enrolled learner works a quiz-only lesson and reaches the completed state.                                 |
+| Unsubscribe  | `unsubscribe.spec.ts` | none           | **Skipped until #769** (email feature). GET bad token → failure page; POST always-200.                                |
+
+## Mock-boundary map
+
+| Seam                                      | Who owns it | How it's mocked                                                                                                                        |
+| ----------------------------------------- | ----------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| Catalog active set (SSR)                  | mock server | `GET /rest/v1/public_onchain_deployments` → fixed `DEPLOYMENTS` fixture                                                                |
+| Browser session                           | test        | locally-minted `sb-127-auth-token` cookie (no network)                                                                                 |
+| Profile / enrollment / progress (browser) | mock server | `GET /rest/v1/{profiles,enrollments,user_progress}` fixtures                                                                           |
+| `getUser` (middleware, SSR)               | mock server | `POST /auth/v1/user`                                                                                                                   |
+| On-chain completion (`completeLesson`)    | test        | `page.route` fulfils `POST /api/lessons/complete` — the E2E owns the browser↔route seam; the chain seam is the unit suites' job (#751) |
+
+## Determinism
+
+- No `waitForTimeout`; only Playwright auto-waiting + explicit assertions.
+- The catalog spec asserts active courses are present **before** asserting the
+  deactivated one is absent, so the absence check can't pass on an empty page.
+- Fixtures (`harness/fixtures.mjs`) are the single source of truth shared by the
+  mock server and the specs.

--- a/apps/web/e2e/catalog.spec.ts
+++ b/apps/web/e2e/catalog.spec.ts
@@ -1,0 +1,40 @@
+import { test, expect } from "@playwright/test";
+import {
+  ACTIVE_COURSE_SLUGS,
+  DEACTIVATED_COURSE_SLUG,
+} from "./harness/fixtures.mjs";
+
+// Spec 2 — Catalog gate (#711 regression, permanent).
+//
+// Anonymous `/en/courses` must render EXACTLY the active-course set. The gate
+// (lib/content/deployments.isSynced) is fed by the mock's fixed
+// `public_onchain_deployments` fixture: three courses synced+active, one
+// synced+is_active:false. This spec is the standing proof that a DEACTIVATED
+// course can never leak back into the catalog — the shape of the #711 bug.
+//
+// No auth: this path needs none, which is why the issue says it can ship alone.
+
+test.describe("catalog gate", () => {
+  test("anonymous catalog renders only active courses; a deactivated course is absent", async ({
+    page,
+  }) => {
+    await page.goto("/en/courses");
+
+    // Prove the catalog rendered WITH data first, so the absence assertion below
+    // can never pass trivially on an empty/failed page. Each active course's card
+    // links to /<locale>/courses/<slug>.
+    for (const slug of ACTIVE_COURSE_SLUGS) {
+      await expect(
+        page.locator(`a[href$="/courses/${slug}"]`).first(),
+        `active course "${slug}" should be listed`
+      ).toBeVisible();
+    }
+
+    // The #711 assertion: the deactivated course is nowhere in the catalog —
+    // neither a visible card nor a stray link.
+    await expect(
+      page.locator(`a[href$="/courses/${DEACTIVATED_COURSE_SLUG}"]`),
+      `deactivated course "${DEACTIVATED_COURSE_SLUG}" must NOT be listed`
+    ).toHaveCount(0);
+  });
+});

--- a/apps/web/e2e/harness/fixtures.d.mts
+++ b/apps/web/e2e/harness/fixtures.d.mts
@@ -1,0 +1,27 @@
+// Types for the plain-ESM fixtures shared with the Node harness (fixtures.mjs).
+export const MOCK_PORT: number;
+export const APP_PORT: number;
+export const MOCK_SUPABASE_URL: string;
+export const APP_BASE_URL: string;
+export const ANON_KEY: string;
+export const LEARNER: {
+  id: string;
+  email: string;
+  username: string;
+  walletAddress: string;
+};
+export const DEPLOYMENTS: ReadonlyArray<{
+  content_id: string;
+  kind: string;
+  status: string;
+  is_active: boolean;
+  achievement_pda: string | null;
+}>;
+export const ACTIVE_COURSE_SLUGS: readonly string[];
+export const DEACTIVATED_COURSE_SLUG: string;
+export const LEARN_LOOP: {
+  courseId: string;
+  courseSlug: string;
+  lessonId: string;
+  lessonSlug: string;
+};

--- a/apps/web/e2e/harness/fixtures.mjs
+++ b/apps/web/e2e/harness/fixtures.mjs
@@ -1,0 +1,85 @@
+// Deterministic E2E fixtures — the single source of truth shared by the mock
+// Supabase server (harness) and the specs. Plain `.mjs` with no imports so both
+// the Node harness and the Playwright specs (via a thin re-export) can read it.
+//
+// Everything here is fake by construction: no real keys, no real wallet, no real
+// JWT. The learner "session" is a locally-minted cookie the specs attach; the
+// mock server signs nothing and verifies nothing. See e2e/README.md.
+
+// Fixed ports so the build-time-inlined NEXT_PUBLIC_SUPABASE_URL and the runtime
+// server agree. 54329 for the mock, 3100 for the app under `next start`.
+export const MOCK_PORT = 54329;
+export const APP_PORT = 3100;
+export const MOCK_SUPABASE_URL = `https://127.0.0.1:${MOCK_PORT}`;
+export const APP_BASE_URL = `http://127.0.0.1:${APP_PORT}`;
+
+// A shape-valid anon key. Not a JWT and not verified anywhere in the harness.
+export const ANON_KEY = "e2e-anon-key-not-a-secret";
+
+// The mocked learner. `id` is a fixed UUID; `walletAddress` only needs to be a
+// non-empty string — it is read client-side to flip `hasLinkedWallet` true and
+// is never parsed as a PublicKey (the on-chain seam is mocked at the route).
+export const LEARNER = {
+  id: "00000000-0000-0000-0000-0000000000e2",
+  email: "e2e-learner@example.com",
+  username: "e2e-learner",
+  walletAddress: "E2ELearnerWa11etAddreSSxxxxxxxxxxxxxxxxxxxxxx",
+};
+
+// ── The catalog gate fixture (#711 regression, spec 2) ──────────────────────
+// Rows shaped like the `public_onchain_deployments` view. `isSynced` (one place,
+// lib/content/deployments.ts) makes a course visible iff status === "synced" AND
+// is_active !== false. So:
+//   • synced + active           → PRESENT in /courses
+//   • synced + is_active:false  → ABSENT  (a DEACTIVATED course — the #711 leak)
+//   • no row                    → ABSENT  (fail-closed)
+// content_id values are real bundle course ids; the catalog renders their slugs.
+export const DEPLOYMENTS = [
+  {
+    content_id: "course-building-first-program",
+    kind: "course",
+    status: "synced",
+    is_active: true,
+    achievement_pda: null,
+  },
+  {
+    content_id: "course-solana-fundamentals",
+    kind: "course",
+    status: "synced",
+    is_active: true,
+    achievement_pda: null,
+  },
+  {
+    content_id: "course-rust-for-solana",
+    kind: "course",
+    status: "synced",
+    is_active: true,
+    achievement_pda: null,
+  },
+  // The deactivated course. Must NOT appear in the catalog — this row is the
+  // permanent guard that a deactivated course can never leak back in.
+  {
+    content_id: "course-anchor-framework",
+    kind: "course",
+    status: "synced",
+    is_active: false,
+    achievement_pda: null,
+  },
+];
+
+// Slugs the specs assert on (kept next to the ids they map to, so a bundle rename
+// is caught here rather than silently passing).
+export const ACTIVE_COURSE_SLUGS = [
+  "building-your-first-solana-program",
+  "solana-fundamentals",
+  "rust-for-solana",
+];
+export const DEACTIVATED_COURSE_SLUG = "anchor-framework";
+
+// The learn-loop target (spec 1): a quiz-only lesson with a known answer key.
+export const LEARN_LOOP = {
+  courseId: "course-building-first-program",
+  courseSlug: "building-your-first-solana-program",
+  lessonId: "lesson-bfsp-on-chain-state",
+  lessonSlug: "accounts-are-just-bytes",
+};

--- a/apps/web/e2e/harness/mock-supabase.mjs
+++ b/apps/web/e2e/harness/mock-supabase.mjs
@@ -1,0 +1,164 @@
+// A tiny, self-contained stand-in for the Supabase REST + Auth surface the app
+// touches during the E2E. It is NOT a general Supabase emulator — it answers
+// exactly the handful of requests the three specs' code paths make, with the
+// exact response shapes postgrest-js / auth-js expect, and nothing else.
+//
+// Why it exists: the catalog's active-course set is resolved SERVER-SIDE
+// (lib/content/deployments.ts reads the `public_onchain_deployments` view), so
+// it cannot be mocked from the browser. A real endpoint returning a fixed
+// fixture is the only way to make spec 2 deterministic under `next start`.
+//
+// HTTPS: env.ts requires NEXT_PUBLIC_SUPABASE_URL to be https:// in production
+// (`next start` runs in production mode), so the mock must speak TLS. The cert
+// is generated fresh per run by serve.mjs (no committed key). The app's Node
+// process trusts it via NODE_EXTRA_CA_CERTS; the browser via ignoreHTTPSErrors.
+
+import https from "node:https";
+import { readFileSync } from "node:fs";
+import { MOCK_PORT, DEPLOYMENTS, LEARNER } from "./fixtures.mjs";
+
+const CERT = process.env.E2E_SSL_CERT;
+const KEY = process.env.E2E_SSL_KEY;
+if (!CERT || !KEY) {
+  console.error("[mock-supabase] E2E_SSL_CERT / E2E_SSL_KEY not set");
+  process.exit(1);
+}
+
+const VIEW_COLUMNS = new Set([
+  "content_id",
+  "kind",
+  "status",
+  "is_active",
+  "achievement_pda",
+]);
+
+// PostgREST returns a single OBJECT when the client sets
+// `Accept: application/vnd.pgrst.object+json` (`.single()`), and an ARRAY
+// otherwise — including for `.maybeSingle()` on a GET, which asks for
+// `application/json` and picks `data[0]` itself. Reproduce that contract exactly
+// (see postgrest-js PostgrestBuilder): returning the wrong container silently
+// breaks `.single()`/`.maybeSingle()` and the UI never leaves its loading state.
+function wantsObject(req) {
+  return (req.headers["accept"] || "").includes("pgrst.object");
+}
+
+function sendJson(res, status, body, extraHeaders = {}) {
+  const payload = body === undefined ? "" : JSON.stringify(body);
+  res.writeHead(status, {
+    "content-type": "application/json; charset=utf-8",
+    ...cors(),
+    ...extraHeaders,
+  });
+  res.end(payload);
+}
+
+// The app runs on a different origin (http://127.0.0.1:3100) than the mock
+// (https://127.0.0.1:54329), so every browser call is cross-origin and
+// supabase-js's custom headers (apikey, x-client-info, …) trigger a preflight.
+function cors() {
+  return {
+    "access-control-allow-origin": "*",
+    "access-control-allow-methods": "GET, POST, OPTIONS, PATCH, DELETE",
+    "access-control-allow-headers":
+      "authorization, apikey, content-type, accept, accept-profile, content-profile, x-client-info, prefer, range, x-supabase-api-version",
+    "access-control-expose-headers": "content-range, content-profile",
+    "access-control-max-age": "86400",
+  };
+}
+
+// A course row read back through the profiles/enrollments/user_progress tables.
+// The learner is always enrolled in the learn-loop course and has never
+// completed the target lesson, so spec 1 starts from "enrolled, not complete".
+function handleRest(table, req, res) {
+  switch (table) {
+    case "public_onchain_deployments":
+      // The catalog gate (spec 2). Always an array.
+      return sendJson(
+        res,
+        200,
+        DEPLOYMENTS.map((r) =>
+          Object.fromEntries(
+            Object.entries(r).filter(([k]) => VIEW_COLUMNS.has(k))
+          )
+        )
+      );
+
+    case "profiles": {
+      // auth-provider reads this with `.single()` (object accept). Hand back a
+      // profile WITH a wallet so `hasLinkedWallet` is true and the complete
+      // button is enabled.
+      const row = {
+        username: LEARNER.username,
+        avatar_url: null,
+        wallet_address: LEARNER.walletAddress,
+      };
+      return sendJson(res, 200, wantsObject(req) ? row : [row]);
+    }
+
+    case "enrollments":
+      // `.maybeSingle()` GET → array; one row makes `isEnrolled` true.
+      return sendJson(res, 200, [{ id: "e2e-enrollment-1" }]);
+
+    case "user_progress":
+      // `.maybeSingle()` GET → empty array → not yet completed.
+      return sendJson(res, 200, []);
+
+    default:
+      // Any other table: behave like an empty result rather than erroring, so an
+      // incidental read never fails a spec on something it isn't testing.
+      return sendJson(res, 200, wantsObject(req) ? null : []);
+  }
+}
+
+// auth-js calls POST /auth/v1/user (getUser, server-side in middleware) with the
+// session's bearer token. Return the learner for the fake token, else 401 — both
+// are handled gracefully by the middleware for the public routes the specs hit.
+function handleAuthUser(req, res) {
+  const auth = req.headers["authorization"] || "";
+  if (auth.includes(`Bearer ${LEARNER.id}.fake`)) {
+    return sendJson(res, 200, {
+      id: LEARNER.id,
+      aud: "authenticated",
+      role: "authenticated",
+      email: LEARNER.email,
+      app_metadata: { provider: "email" },
+      user_metadata: {},
+      created_at: new Date(0).toISOString(),
+    });
+  }
+  return sendJson(res, 401, {
+    code: 401,
+    msg: "invalid claim: missing sub claim",
+  });
+}
+
+const server = https.createServer(
+  { cert: readFileSync(CERT), key: readFileSync(KEY) },
+  (req, res) => {
+    const { pathname } = new URL(req.url, "https://127.0.0.1");
+
+    if (req.method === "OPTIONS") {
+      res.writeHead(204, cors());
+      return res.end();
+    }
+
+    if (pathname === "/health") return sendJson(res, 200, { ok: true });
+
+    // /auth/v1/user — the only auth endpoint reached (getSession is cookie-local
+    // and needs no network; the session never nears expiry so no token refresh).
+    if (pathname === "/auth/v1/user") return handleAuthUser(req, res);
+
+    // Drain and ignore any other auth POST (e.g. logout) with a clean 200 so it
+    // never throws in the client.
+    if (pathname.startsWith("/auth/v1/")) return sendJson(res, 200, {});
+
+    const rest = pathname.match(/^\/rest\/v1\/([^/?]+)/);
+    if (rest) return handleRest(rest[1], req, res);
+
+    return sendJson(res, 404, { message: "not found" });
+  }
+);
+
+server.listen(MOCK_PORT, "127.0.0.1", () => {
+  console.log(`[mock-supabase] listening on https://127.0.0.1:${MOCK_PORT}`);
+});

--- a/apps/web/e2e/harness/serve.mjs
+++ b/apps/web/e2e/harness/serve.mjs
@@ -1,0 +1,164 @@
+// E2E web-server entrypoint, launched by Playwright's `webServer.command`.
+//
+// Ordering matters and is controlled here (not left to Playwright's webServer
+// array): a self-signed cert must exist before `next start` boots so its Node
+// process can trust the mock over NODE_EXTRA_CA_CERTS. Sequence:
+//   1. generate a fresh self-signed cert for 127.0.0.1 (openssl; no committed key)
+//   2. start the mock Supabase server (HTTPS) and wait for it to accept connections
+//   3. `next build` with the E2E env (unless E2E_NO_BUILD=1) — NEXT_PUBLIC_* are
+//      inlined at build time, so the build MUST use the mock URL
+//   4. `next start` with the same env + NODE_EXTRA_CA_CERTS
+// Playwright then polls APP_BASE_URL. SIGTERM/SIGINT tears both children down.
+
+import { spawn, spawnSync } from "node:child_process";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import net from "node:net";
+import {
+  APP_PORT,
+  MOCK_PORT,
+  MOCK_SUPABASE_URL,
+  ANON_KEY,
+} from "./fixtures.mjs";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const webRoot = join(here, "..", "..");
+
+// ── 1. Cert ─────────────────────────────────────────────────────────────────
+const certDir = mkdtempSync(join(tmpdir(), "e2e-supabase-cert-"));
+const keyPath = join(certDir, "key.pem");
+const certPath = join(certDir, "cert.pem");
+const openssl = spawnSync(
+  "openssl",
+  [
+    "req",
+    "-x509",
+    "-newkey",
+    "rsa:2048",
+    "-nodes",
+    "-keyout",
+    keyPath,
+    "-out",
+    certPath,
+    "-days",
+    "1",
+    "-subj",
+    "/CN=127.0.0.1",
+    "-addext",
+    "subjectAltName=IP:127.0.0.1,DNS:localhost",
+  ],
+  { stdio: "inherit" }
+);
+if (openssl.status !== 0) {
+  console.error("[serve] openssl cert generation failed");
+  process.exit(1);
+}
+
+// ── Shared env for build + start ─────────────────────────────────────────────
+const appEnv = {
+  ...process.env,
+  NODE_ENV: "production",
+  PORT: String(APP_PORT),
+  NEXT_TELEMETRY_DISABLED: "1",
+  NEXT_PUBLIC_SUPABASE_URL: MOCK_SUPABASE_URL,
+  NEXT_PUBLIC_SUPABASE_ANON_KEY: ANON_KEY,
+  NEXT_PUBLIC_SOLANA_RPC_URL: "https://api.devnet.solana.com",
+  // Mirror the CI unit-test env (ci.yml frontend job) so build-time page-data
+  // collection has the public vars the app requires (event-decoder, etc.). A
+  // shape-valid devnet program id — never used to send a real tx here.
+  NEXT_PUBLIC_PROGRAM_ID: "7NeJaSRyb4Wxay3Tcd9bdpD7T3GWYUQSFyrhG8SgwE8V",
+  NEXT_PUBLIC_SOLANA_NETWORK: "devnet",
+  SUPABASE_SERVICE_ROLE_KEY: "e2e-service-role-not-a-secret",
+  SOLANA_RPC_URL: "https://api.devnet.solana.com",
+  // Trust the mock's self-signed cert for server-side (undici) fetches.
+  NODE_EXTRA_CA_CERTS: certPath,
+};
+
+const children = [];
+function shutdown(code = 0) {
+  for (const c of children) {
+    try {
+      c.kill("SIGTERM");
+    } catch {
+      /* already gone */
+    }
+  }
+  process.exit(code);
+}
+process.on("SIGTERM", () => shutdown(0));
+process.on("SIGINT", () => shutdown(0));
+
+function run(cmd, args, opts) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(cmd, args, { stdio: "inherit", ...opts });
+    child.on("exit", (code) =>
+      code === 0 ? resolve() : reject(new Error(`${cmd} exited ${code}`))
+    );
+    child.on("error", reject);
+  });
+}
+
+// Readiness by TCP connect, not HTTPS fetch: the mock's cert is self-signed and
+// NODE_EXTRA_CA_CERTS is only honored at process start (too late to help a probe
+// in THIS already-running process). A successful TCP connect proves the server
+// is listening, which is all the ordering guarantee we need.
+function waitForPort(port, host, label, timeoutMs = 60_000) {
+  const deadline = Date.now() + timeoutMs;
+  return new Promise((resolve, reject) => {
+    const attempt = () => {
+      const socket = net.connect({ port, host });
+      socket.once("connect", () => {
+        socket.destroy();
+        resolve();
+      });
+      socket.once("error", () => {
+        socket.destroy();
+        if (Date.now() > deadline) {
+          reject(new Error(`[serve] ${label} not ready after ${timeoutMs}ms`));
+        } else {
+          setTimeout(attempt, 300);
+        }
+      });
+    };
+    attempt();
+  });
+}
+
+async function main() {
+  // ── 2. Mock Supabase ────────────────────────────────────────────────────
+  const mock = spawn(process.execPath, [join(here, "mock-supabase.mjs")], {
+    stdio: "inherit",
+    env: {
+      ...process.env,
+      E2E_SSL_CERT: certPath,
+      E2E_SSL_KEY: keyPath,
+      // The probe below runs in THIS process; trust the cert here too.
+      NODE_EXTRA_CA_CERTS: certPath,
+    },
+  });
+  children.push(mock);
+  await waitForPort(MOCK_PORT, "127.0.0.1", "mock supabase");
+
+  // ── 3. Build (skippable in CI, which builds in its own cached step) ───────
+  if (process.env.E2E_NO_BUILD !== "1") {
+    console.log("[serve] next build (E2E env)…");
+    await run("pnpm", ["exec", "next", "build"], { cwd: webRoot, env: appEnv });
+  }
+
+  // ── 4. Start ──────────────────────────────────────────────────────────────
+  console.log(`[serve] next start on :${APP_PORT}…`);
+  const app = spawn("pnpm", ["exec", "next", "start", "-p", String(APP_PORT)], {
+    stdio: "inherit",
+    cwd: webRoot,
+    env: appEnv,
+  });
+  children.push(app);
+  app.on("exit", (code) => shutdown(code ?? 0));
+}
+
+main().catch((err) => {
+  console.error(err);
+  shutdown(1);
+});

--- a/apps/web/e2e/harness/serve.mjs
+++ b/apps/web/e2e/harness/serve.mjs
@@ -11,7 +11,7 @@
 // Playwright then polls APP_BASE_URL. SIGTERM/SIGINT tears both children down.
 
 import { spawn, spawnSync } from "node:child_process";
-import { mkdtempSync } from "node:fs";
+import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -141,11 +141,25 @@ async function main() {
   children.push(mock);
   await waitForPort(MOCK_PORT, "127.0.0.1", "mock supabase");
 
-  // ── 3. Build (skippable in CI, which builds in its own cached step) ───────
+  // ── 3. Build (skippable via E2E_NO_BUILD=1 to reuse an existing .next) ─────
   if (process.env.E2E_NO_BUILD !== "1") {
     console.log("[serve] next build (E2E env)…");
     await run("pnpm", ["exec", "next", "build"], { cwd: webRoot, env: appEnv });
   }
+
+  // ── 3b. Purge the Next DATA cache (unstable_cache / fetch-cache) ──────────
+  // getActiveDeployments() is wrapped in `unstable_cache` (revalidate 3600),
+  // whose result persists to .next/cache/fetch-cache ACROSS process restarts.
+  // Without this purge, a rerun on a reused .next (or a CI cache restore) serves
+  // the PREVIOUS run's deployment snapshot, so the catalog spec silently no-ops
+  // on stale data instead of reading the current fixture. Deleting it here makes
+  // every run start with a cold data cache that re-reads the mock. The webpack
+  // BUILD cache under .next/cache/webpack is left intact (that is the safe,
+  // fixture-independent speedup CI restores).
+  rmSync(join(webRoot, ".next", "cache", "fetch-cache"), {
+    recursive: true,
+    force: true,
+  });
 
   // ── 4. Start ──────────────────────────────────────────────────────────────
   console.log(`[serve] next start on :${APP_PORT}…`);

--- a/apps/web/e2e/harness/session.ts
+++ b/apps/web/e2e/harness/session.ts
@@ -1,0 +1,73 @@
+import type { BrowserContext } from "@playwright/test";
+// The harness fixtures are plain ESM so the Node servers can read them without a
+// TS toolchain; fixtures.d.ts types them, and Playwright's esbuild transform
+// resolves the .mjs at runtime.
+import { MOCK_SUPABASE_URL, APP_BASE_URL, LEARNER } from "./fixtures.mjs";
+
+const SUPABASE_URL = MOCK_SUPABASE_URL;
+const APP_URL = APP_BASE_URL;
+const LEARNER_ID = LEARNER.id;
+
+/**
+ * The cookie name the @supabase/ssr browser client reads its session from:
+ * `sb-${firstUrlLabel}-auth-token`, where the label is the Supabase URL's
+ * hostname up to the first dot (see supabase-js defaultStorageKey). For
+ * `https://127.0.0.1:<port>` that is `sb-127-auth-token`. Derived, not
+ * hard-coded, so it tracks the fixture URL.
+ */
+const STORAGE_KEY = `sb-${new URL(SUPABASE_URL).hostname.split(".")[0]}-auth-token`;
+
+/**
+ * Mint the cookie the browser Supabase client would have written on a real
+ * sign-in. `getSession()` reads this locally (no network) and trusts the
+ * embedded `expires_at`, so a non-JWT access_token with a future expiry is a
+ * fully-working session for the client — no secret, no signing. The value is
+ * `base64-` + base64url(JSON(session)), exactly the @supabase/ssr encoding.
+ */
+function buildSessionCookieValue(): string {
+  const nowSec = Math.floor(Date.now() / 1000);
+  const session = {
+    // The mock's /auth/v1/user matches on `Bearer <id>.fake`; keep in sync.
+    access_token: `${LEARNER_ID}.fake.jwt`,
+    refresh_token: "e2e-refresh-token",
+    token_type: "bearer",
+    expires_in: 3600,
+    expires_at: nowSec + 3600,
+    user: {
+      id: LEARNER_ID,
+      aud: "authenticated",
+      role: "authenticated",
+      email: LEARNER.email,
+      app_metadata: { provider: "email", providers: ["email"] },
+      user_metadata: {},
+      identities: [],
+      created_at: new Date(0).toISOString(),
+      updated_at: new Date(0).toISOString(),
+    },
+  };
+  const base64url = Buffer.from(JSON.stringify(session), "utf8").toString(
+    "base64url"
+  );
+  return `base64-${base64url}`;
+}
+
+/**
+ * Attach the mocked learner session to a browser context. Call before the first
+ * navigation. The cookie lives on the APP origin (that is where the browser
+ * client's document.cookie storage lives), even though its name derives from the
+ * Supabase host.
+ */
+export async function signInAsLearner(context: BrowserContext): Promise<void> {
+  const appUrl = new URL(APP_URL);
+  await context.addCookies([
+    {
+      name: STORAGE_KEY,
+      value: buildSessionCookieValue(),
+      domain: appUrl.hostname,
+      path: "/",
+      httpOnly: false,
+      secure: false,
+      sameSite: "Lax",
+    },
+  ]);
+}

--- a/apps/web/e2e/learn-loop.spec.ts
+++ b/apps/web/e2e/learn-loop.spec.ts
@@ -1,0 +1,80 @@
+import { test, expect } from "@playwright/test";
+import { signInAsLearner } from "./harness/session";
+import { LEARN_LOOP } from "./harness/fixtures.mjs";
+
+// Spec 1 — Learn loop.
+//
+// Signed-in learner opens an enrolled course, works a quiz-only lesson
+// (`lesson-bfsp-on-chain-state`, answer key: option "a" for every question),
+// clicks Mark as Complete, and the UI reaches the completed state.
+//
+// Mock boundaries (see e2e/README.md for the full map):
+//   • Session: a locally-minted Supabase cookie (no network, no secret).
+//   • Supabase reads (profile/enrollment/progress): the mock server — the
+//     learner is enrolled and has NOT completed this lesson.
+//   • The on-chain send: mocked at the route boundary. Playwright owns the
+//     browser↔route seam and fulfils POST /api/lessons/complete; the chain seam
+//     inside the route is the unit suites' job (#751). This asserts the browser
+//     posts the right body and renders completion on success.
+
+test.describe("learn loop", () => {
+  test("signed-in learner completes a quiz-only lesson and sees the completed state", async ({
+    page,
+    context,
+  }) => {
+    await signInAsLearner(context);
+
+    // Own the browser↔route seam: capture the completion POST and return the
+    // success the route would return once the on-chain tx lands.
+    let completionBody: { lessonId?: string; courseId?: string } | null = null;
+    await page.route("**/api/lessons/complete", async (route) => {
+      completionBody = route.request().postDataJSON();
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          success: true,
+          signature: "e2e-mock-signature",
+        }),
+      });
+    });
+
+    await page.goto(
+      `/en/courses/${LEARN_LOOP.courseSlug}/lessons/${LEARN_LOOP.lessonSlug}`
+    );
+
+    // Work the retrieval quiz: option "a" is correct for every question. Grading
+    // is server-side (mocked here); answering exercises the real quiz UI so the
+    // "learn loop" is faithful, not a bare button click.
+    for (const qid of ["q1", "q2", "q3", "q4"]) {
+      await page.locator(`input[name="${qid}"][value="a"]`).check();
+    }
+    const checkButtons = page.getByRole("button", { name: "Check answer" });
+    const count = await checkButtons.count();
+    expect(count).toBeGreaterThan(0);
+    for (let i = 0; i < count; i++) {
+      await checkButtons.nth(i).click();
+    }
+
+    // The complete button only renders for a signed-in, enrolled learner — its
+    // presence is itself the "enrolled course" assertion. Auto-waits for the
+    // enrollment effect to resolve against the mock.
+    const completeButton = page.getByRole("button", {
+      name: "Mark as Complete",
+    });
+    await expect(completeButton).toBeEnabled();
+    await completeButton.click();
+
+    // Completed state: the button flips to "Lesson Complete!". This is the
+    // durable UI signal handleComplete sets on a successful POST.
+    await expect(
+      page.getByRole("button", { name: "Lesson Complete!" })
+    ).toBeVisible();
+
+    // And the browser sent the right request across the seam we own.
+    expect(completionBody).toMatchObject({
+      lessonId: LEARN_LOOP.lessonId,
+      courseId: LEARN_LOOP.courseId,
+    });
+  });
+});

--- a/apps/web/e2e/unsubscribe.spec.ts
+++ b/apps/web/e2e/unsubscribe.spec.ts
@@ -1,0 +1,37 @@
+import { test, expect } from "@playwright/test";
+
+// Spec 3 — Unsubscribe (SKIPPED until the email feature lands: David's #769).
+//
+// The issue scopes this spec now but ships it disabled until there is a route to
+// exercise. Authored against the contract so enabling it is a one-line change
+// (remove `.skip`) plus confirming the final route path:
+//   • GET with a bad/forged token → the failure page (never a silent success).
+//   • POST is ALWAYS 200 (list-unsubscribe one-click must not leak validity or
+//     let a prefetch/scanner error out) — the token is validated on GET.
+//
+// When #769 merges: set UNSUBSCRIBE_PATH to the real route, drop `.skip`, and
+// adjust the failure-page assertion to match the shipped copy/testid.
+const UNSUBSCRIBE_PATH = "/en/unsubscribe"; // TODO(#769): confirm final path.
+
+test.describe.skip("unsubscribe (pending email feature #769)", () => {
+  test("GET with a bad token shows the failure page", async ({ page }) => {
+    const res = await page.goto(`${UNSUBSCRIBE_PATH}?token=not-a-real-token`);
+    // The page renders (200) but communicates failure — it does not 500 or
+    // silently claim success.
+    expect(res?.status()).toBe(200);
+    await expect(
+      page.getByRole("heading", {
+        name: /couldn.t unsubscribe|invalid|expired/i,
+      })
+    ).toBeVisible();
+  });
+
+  test("POST is always 200 regardless of token validity", async ({
+    request,
+  }) => {
+    const res = await request.post(`${UNSUBSCRIBE_PATH}`, {
+      form: { token: "not-a-real-token" },
+    });
+    expect(res.status()).toBe(200);
+  });
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,7 +12,10 @@
     "reset-verify": "tsx scripts/reset-verify.ts",
     "reset-vnext": "tsx --tsconfig scripts/tsconfig.reset.json scripts/reset-vnext.ts",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "e2e": "playwright test",
+    "e2e:ui": "playwright test --ui",
+    "e2e:report": "playwright show-report"
   },
   "dependencies": {
     "@coral-xyz/anchor": "^0.32.1",
@@ -76,6 +79,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@playwright/test": "1.59.1",
     "@tailwindcss/typography": "^0.5.19",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^14.3.1",

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -1,0 +1,48 @@
+import { defineConfig, devices } from "@playwright/test";
+import { APP_BASE_URL } from "./e2e/harness/fixtures.mjs";
+
+// E2E for the critical learner paths (#781). Runs against a production build
+// (`next build && next start`) fronted by a mock Supabase — see e2e/README.md.
+// The whole harness (cert, mock, build, start) is orchestrated by serve.mjs so
+// ordering is deterministic; Playwright only polls the app URL below.
+
+const CI = !!process.env.CI;
+
+export default defineConfig({
+  testDir: "./e2e",
+  // Only Playwright specs live here; the mock/harness are .mjs and excluded.
+  testMatch: /.*\.spec\.ts$/,
+  fullyParallel: true,
+  forbidOnly: CI,
+  // Deterministic-by-construction (mocked seams, auto-waiting assertions). One
+  // retry in CI absorbs cold-start jitter only; a real failure still fails.
+  retries: CI ? 1 : 0,
+  workers: CI ? 2 : undefined,
+  reporter: CI
+    ? [["github"], ["html", { open: "never" }], ["list"]]
+    : [["html", { open: "never" }], ["list"]],
+  // Fail fast on a hung server rather than burning the CI budget.
+  timeout: 30_000,
+  expect: { timeout: 10_000 },
+  use: {
+    baseURL: APP_BASE_URL,
+    // The mock Supabase serves a per-run self-signed cert.
+    ignoreHTTPSErrors: true,
+    trace: "on-first-retry",
+    screenshot: "only-on-failure",
+    video: CI ? "on-first-retry" : "off",
+  },
+  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+  webServer: {
+    command: "node e2e/harness/serve.mjs",
+    url: `${APP_BASE_URL}/en/courses`,
+    reuseExistingServer: !CI,
+    // The harness runs `next build` (cold on a fresh tree) + boots the mock +
+    // `next start`. CI restores apps/web/.next/cache so the build stays
+    // incremental; the specs themselves are seconds. Generous timeout covers a
+    // cold cache.
+    timeout: 240_000,
+    stdout: "pipe",
+    stderr: "pipe",
+  },
+});

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,5 +1,5 @@
 import path from "path";
-import { defineConfig } from "vitest/config";
+import { defineConfig, configDefaults } from "vitest/config";
 
 export default defineConfig({
   // tsconfig.json sets "jsx": "preserve" (Next.js compiles JSX at build
@@ -14,6 +14,10 @@ export default defineConfig({
     globals: true,
     environment: "node",
     setupFiles: ["./vitest.setup.ts"],
+    // The Playwright E2E specs share the `*.spec.ts` glob but must NOT be
+    // collected by vitest (they import `@playwright/test`, not the vitest
+    // runner). They run via `pnpm --filter web e2e`. Keep vitest's own defaults.
+    exclude: [...configDefaults.exclude, "e2e/**"],
   },
   resolve: {
     alias: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,7 +110,7 @@ importers:
         version: 1.2.8(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@sentry/nextjs':
         specifier: ^10.38.0
-        version: 10.38.0(@opentelemetry/context-async-hooks@2.5.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(next@15.5.22(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(webpack@5.105.2)
+        version: 10.38.0(@opentelemetry/context-async-hooks@2.5.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(next@15.5.22(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(webpack@5.105.2)
       '@solana/spl-token':
         specifier: ^0.4.14
         version: 0.4.14(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
@@ -173,10 +173,10 @@ importers:
         version: 2.36.0(@noble/hashes@1.8.0)
       next:
         specifier: ^15.5.22
-        version: 15.5.22(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 15.5.22(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       next-intl:
         specifier: ^4.13.4
-        version: 4.13.4(@swc/helpers@0.5.18)(next@15.5.22(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+        version: 4.13.4(@swc/helpers@0.5.18)(next@15.5.22(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
       next-themes:
         specifier: ^0.4.0
         version: 0.4.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -229,6 +229,9 @@ importers:
         specifier: ^4.4.3
         version: 4.4.3
     devDependencies:
+      '@playwright/test':
+        specifier: 1.59.1
+        version: 1.59.1
       '@tailwindcss/typography':
         specifier: ^0.5.19
         version: 0.5.19(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.2))
@@ -2082,6 +2085,11 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@playwright/test@1.59.1':
+    resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@posthog/core@1.22.0':
     resolution: {integrity: sha512-WkmOnq95aAOu6yk6r5LWr5cfXsQdpVbWDCwOxQwxSne8YV6GuZET1ziO5toSQXgrgbdcjrSz2/GopAfiL6iiAA==}
@@ -4904,6 +4912,11 @@ packages:
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -6330,6 +6343,16 @@ packages:
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
+
+  playwright-core@1.59.1:
+    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.59.1:
+    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   pngjs@5.0.0:
     resolution: {integrity: sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==}
@@ -9686,6 +9709,10 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
+  '@playwright/test@1.59.1':
+    dependencies:
+      playwright: 1.59.1
+
   '@posthog/core@1.22.0':
     dependencies:
       cross-spawn: 7.0.6
@@ -10355,7 +10382,7 @@ snapshots:
 
   '@sentry/core@10.38.0': {}
 
-  '@sentry/nextjs@10.38.0(@opentelemetry/context-async-hooks@2.5.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(next@15.5.22(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(webpack@5.105.2)':
+  '@sentry/nextjs@10.38.0(@opentelemetry/context-async-hooks@2.5.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(next@15.5.22(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(webpack@5.105.2)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/semantic-conventions': 1.39.0
@@ -10368,7 +10395,7 @@ snapshots:
       '@sentry/react': 10.38.0(react@18.3.1)
       '@sentry/vercel-edge': 10.38.0
       '@sentry/webpack-plugin': 4.9.1(webpack@5.105.2)
-      next: 15.5.22(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next: 15.5.22(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       rollup: 4.57.1
       stacktrace-parser: 0.1.11
     transitivePeerDependencies:
@@ -12979,6 +13006,9 @@ snapshots:
 
   fs.realpath@1.0.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -14619,14 +14649,14 @@ snapshots:
 
   next-intl-swc-plugin-extractor@4.13.4: {}
 
-  next-intl@4.13.4(@swc/helpers@0.5.18)(next@15.5.22(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(typescript@5.9.3):
+  next-intl@4.13.4(@swc/helpers@0.5.18)(next@15.5.22(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(typescript@5.9.3):
     dependencies:
       '@formatjs/intl-localematcher': 0.8.13
       '@parcel/watcher': 2.6.0
       '@swc/core': 1.15.46(@swc/helpers@0.5.18)
       icu-minify: 4.13.4
       negotiator: 1.0.0
-      next: 15.5.22(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next: 15.5.22(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       next-intl-swc-plugin-extractor: 4.13.4
       po-parser: 2.1.1
       react: 18.3.1
@@ -14641,7 +14671,7 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  next@15.5.22(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  next@15.5.22(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@next/env': 15.5.22
       '@swc/helpers': 0.5.15
@@ -14660,6 +14690,7 @@ snapshots:
       '@next/swc-win32-arm64-msvc': 15.5.22
       '@next/swc-win32-x64-msvc': 15.5.22
       '@opentelemetry/api': 1.9.0
+      '@playwright/test': 1.59.1
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -14892,6 +14923,14 @@ snapshots:
   pify@2.3.0: {}
 
   pirates@4.0.7: {}
+
+  playwright-core@1.59.1: {}
+
+  playwright@1.59.1:
+    dependencies:
+      playwright-core: 1.59.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   pngjs@5.0.0: {}
 


### PR DESCRIPTION
Closes #781.

## What

Playwright E2E for the three critical learner paths — the runtime coverage the gate's manual smokes gave (they caught #711 and validated the Next 15 migration) but which died with the gate's session. Now permanent, in CI, against a **production build** (`next build && next start`), fronted by a self-contained mock Supabase.

Run locally: `pnpm --filter web e2e`. Harness + boundaries documented in `apps/web/e2e/README.md`.

## Why a mock Supabase (and HTTPS)

The catalog's active-course set is resolved **server-side** (`lib/content/deployments.ts` reads the `public_onchain_deployments` view), so it can't be mocked from the browser — a real endpoint returning a fixed fixture is the only way to make the catalog deterministic under `next start`. `env.ts` requires `NEXT_PUBLIC_SUPABASE_URL` to be `https://` in production, so the mock speaks TLS with a **per-run self-signed cert** (openssl; nothing committed — sidesteps the no-secrets rule). The app's Node process trusts it via `NODE_EXTRA_CA_CERTS`; the browser via `ignoreHTTPSErrors`. Everything is fake by construction: no real keys, no real JWT, no real wallet, no network, no on-chain tx.

## Coverage — the three specs

| Spec | File | Auth | What it locks in |
| --- | --- | --- | --- |
| Catalog gate | `catalog.spec.ts` | none | Anonymous `/en/courses` renders **only** active courses; a deactivated course's slug is absent (#711 regression, permanent). Asserts the active set is present **before** the absence check, so it can't pass on an empty page. |
| Learn loop | `learn-loop.spec.ts` | mocked session | Signed-in, enrolled learner works the quiz-only lesson `lesson-bfsp-on-chain-state` (answer key: option "a"), clicks Mark as Complete, reaches the completed state. Also asserts the POST body across the seam. |
| Unsubscribe | `unsubscribe.spec.ts` | none | Authored but **`test.describe.skip` until #769** (email feature). GET bad token → failure page; POST always-200. Enabling it is removing `.skip` + confirming the route path. |

## Mock-boundary map

| Seam | Owner | How |
| --- | --- | --- |
| Catalog active set (SSR) | mock server | `GET /rest/v1/public_onchain_deployments` → fixed `DEPLOYMENTS` fixture (3 synced+active, 1 synced+`is_active:false`) |
| Browser session | test | locally-minted `sb-127-auth-token` cookie (no network, no secret) |
| Profile / enrollment / progress (browser) | mock server | `GET /rest/v1/{profiles,enrollments,user_progress}` fixtures, in the exact shapes postgrest-js `.single()`/`.maybeSingle()` expect |
| `getUser` (middleware, SSR) | mock server | `POST /auth/v1/user` |
| On-chain completion (`completeLesson`) | test | `page.route` fulfils `POST /api/lessons/complete` — **the E2E owns the browser↔route seam; the chain seam is the unit suites' job (#751)** |

## Local run (production build)

Two consecutive clean runs against `next build && next start`:

```
✓  e2e/catalog.spec.ts    › catalog gate › anonymous catalog renders only active courses; a deactivated course is absent (1.2s)
✓  e2e/learn-loop.spec.ts › learn loop › signed-in learner completes a quiz-only lesson and sees the completed state (1.6s)
2 skipped
2 passed (1.1m)
```

(The 1.1m is dominated by the cold `next build`; the specs themselves run in ~3s combined. The 2 skipped are the unsubscribe pair.)

## CI

New change-gated `e2e` job in `ci.yml` (gated on `frontend`, same as the frontend job — it does **not** run on every push of every PR, only when `apps/web`/shared deps change or on `workflow_dispatch`). SHA-pinned actions only (pin guard passes locally); `@playwright/test` pinned to exact `1.59.1`. Restores `apps/web/.next/cache` so the build stays incremental. Uploads the Playwright report + traces on failure. `vitest` excludes `e2e/` from its `*.spec.ts` glob so the two runners don't collide.

**CI cost:** one extra `ubuntu-latest` job on frontend PRs — cold `next build` (~30-70s) + browser install (~20s) + the specs (~3s). Bounded by a 15-min timeout.

## Do not merge

Touches workflows → adversarial + gate + owner sign-off.
