### PR TITLE
fix(leaderboard): frame league XP as weekly + scoring info tooltip (#789)

### DIFF
--- a/apps/web/src/app/[locale]/(platform)/leaderboard/__tests__/leaderboard-client.test.tsx
+++ b/apps/web/src/app/[locale]/(platform)/leaderboard/__tests__/leaderboard-client.test.tsx
@@ -1,0 +1,84 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import type { CohortLeague } from "@superteam-lms/types";
+import messages from "@/messages/en.json";
+import { LeaderboardClient } from "../leaderboard-client";
+
+const cohort: CohortLeague = {
+  tier: 1,
+  weekStart: "2026-07-27",
+  memberCount: 2,
+  entries: [
+    {
+      userId: "u1",
+      username: "alice",
+      avatarUrl: null,
+      score: 1275,
+      rank: 1,
+      isYou: true,
+    },
+    {
+      userId: "u2",
+      username: "bob",
+      avatarUrl: null,
+      score: 300,
+      rank: 2,
+      isYou: false,
+    },
+  ],
+};
+
+function renderClient(initialCohort: CohortLeague | null) {
+  return render(
+    <NextIntlClientProvider locale="en" messages={messages}>
+      <LeaderboardClient
+        initialGlobalEntries={[]}
+        initialCohort={initialCohort}
+        currentUserId="u1"
+      />
+    </NextIntlClientProvider>
+  );
+}
+
+describe("LeaderboardClient — league framing + scoring info (#789)", () => {
+  it("defaults to the League board and leads the subtitle with 'This week'", () => {
+    renderClient(cohort);
+    // "This week · 2 learners · resets Monday" — the weekly qualifier is present.
+    expect(screen.getByText(/This week/)).toBeInTheDocument();
+    expect(screen.getByText(/2 learners/)).toBeInTheDocument();
+  });
+
+  it("renders league scores with the weekly '+X XP' framing", () => {
+    renderClient(cohort);
+    expect(screen.getByText("+1,275 XP")).toBeInTheDocument();
+    expect(screen.getByText("+300 XP")).toBeInTheDocument();
+  });
+
+  it("exposes the league-scoring info affordance with an accessible label", () => {
+    renderClient(cohort);
+    expect(
+      screen.getByRole("button", { name: "About league scoring" })
+    ).toBeInTheDocument();
+  });
+
+  it("has honest scoring copy: weekly + eligible-sources-only, bonuses excluded", () => {
+    // The tooltip content is portalled on open; pin the copy at the message
+    // layer so the honest framing (weekly, learning-only, bonuses excluded)
+    // can't silently drift.
+    const copy = messages.gamification.leagueScoringInfo;
+    expect(copy).toMatch(/this week/i);
+    expect(copy).toMatch(/lessons/i);
+    expect(copy).toMatch(/[Bb]onuses.*(don't|do not) count/);
+  });
+
+  it("does not show the League board for anon visitors with no cohort", () => {
+    renderClient(null);
+    // Falls back to the global board; the sign-in prompt is the league empty
+    // state and must not appear as a default.
+    expect(
+      screen.queryByRole("button", { name: "About league scoring" })
+    ).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/[locale]/(platform)/leaderboard/leaderboard-client.tsx
+++ b/apps/web/src/app/[locale]/(platform)/leaderboard/leaderboard-client.tsx
@@ -10,7 +10,9 @@ import {
   Lightning,
   Medal,
   UsersThree,
+  Info,
 } from "@phosphor-icons/react";
+import * as Tooltip from "@radix-ui/react-tooltip";
 import type { LeaderboardEntry, CohortLeague } from "@superteam-lms/types";
 import { LevelBadge } from "@/components/gamification/level-badge";
 import { CohortRow } from "@/components/leaderboard/cohort-row";
@@ -184,13 +186,17 @@ function LeagueBoard({ cohort }: { cohort: CohortLeague | null }) {
         <span className="lb-league-icon" aria-hidden="true">
           <UsersThree size={22} weight="fill" />
         </span>
-        <div className="min-w-0">
+        <div className="min-w-0 flex-1">
           <p className="lb-league-tier">{tierName(t, cohort.tier)}</p>
+          {/* "This week" leads the subtitle so the league values read as weekly,
+              not lifetime (#789). */}
           <p className="lb-league-sub">
+            {t("leagueThisWeek")} ·{" "}
             {t("cohortMembers", { count: cohort.memberCount })} ·{" "}
             {t("leagueResets")}
           </p>
         </div>
+        <LeagueScoringInfo />
       </div>
 
       <div className="lb-list">
@@ -203,6 +209,38 @@ function LeagueBoard({ cohort }: { cohort: CohortLeague | null }) {
         ))}
       </div>
     </>
+  );
+}
+
+/* ── Info affordance explaining league scoring (weekly, eligible sources) ── */
+function LeagueScoringInfo() {
+  const t = useTranslations("gamification");
+  return (
+    <Tooltip.Provider delayDuration={0} skipDelayDuration={150}>
+      <Tooltip.Root>
+        <Tooltip.Trigger asChild>
+          <button
+            type="button"
+            className="lb-league-info"
+            aria-label={t("leagueScoringInfoLabel")}
+          >
+            <Info size={18} weight="bold" aria-hidden="true" />
+          </button>
+        </Tooltip.Trigger>
+        <Tooltip.Portal>
+          <Tooltip.Content
+            className="lb-tooltip"
+            sideOffset={6}
+            side="bottom"
+            align="end"
+            collisionPadding={12}
+          >
+            {t("leagueScoringInfo")}
+            <Tooltip.Arrow className="fill-[var(--card)]" />
+          </Tooltip.Content>
+        </Tooltip.Portal>
+      </Tooltip.Root>
+    </Tooltip.Provider>
   );
 }
 

--- a/apps/web/src/components/dashboard/cohort-strip.tsx
+++ b/apps/web/src/components/dashboard/cohort-strip.tsx
@@ -69,8 +69,10 @@ export function CohortStrip({ userId }: CohortStripProps) {
           <p className="font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-primary">
             {t("cohortStripTitle")}
           </p>
+          {/* Weekly qualifier so the card's "+X XP" rows read as this week's
+              league score, not the lifetime header total (#789). */}
           <p className="truncate text-sm font-semibold text-text-2">
-            {tierName(t, league.tier)}
+            {tierName(t, league.tier)} · {t("leagueThisWeek")}
           </p>
         </div>
         <Link

--- a/apps/web/src/components/leaderboard/__tests__/cohort-row.test.tsx
+++ b/apps/web/src/components/leaderboard/__tests__/cohort-row.test.tsx
@@ -1,0 +1,59 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import type { CohortLeaderboardEntry } from "@superteam-lms/types";
+import messages from "@/messages/en.json";
+import { CohortRow } from "../cohort-row";
+
+function renderRow(entry: CohortLeaderboardEntry) {
+  return render(
+    <NextIntlClientProvider locale="en" messages={messages}>
+      <CohortRow entry={entry} />
+    </NextIntlClientProvider>
+  );
+}
+
+const base: CohortLeaderboardEntry = {
+  userId: "u1",
+  username: "alice",
+  avatarUrl: null,
+  score: 1275,
+  rank: 3,
+  isYou: false,
+};
+
+describe("CohortRow — weekly XP framing (#789)", () => {
+  it("frames the league score as earned-this-week with a '+' prefix", () => {
+    renderRow(base);
+    // Visible value carries the '+' so it reads as points earned this period,
+    // not the lifetime header total.
+    expect(screen.getByText("+1,275 XP")).toBeInTheDocument();
+  });
+
+  it("gives the score an accessible 'earned this week' label", () => {
+    renderRow(base);
+    expect(
+      screen.getByLabelText("1,275 XP earned this week")
+    ).toBeInTheDocument();
+  });
+
+  it("still frames a zero-eligible score as weekly (not a bare lifetime-looking 0)", () => {
+    renderRow({ ...base, score: 0 });
+    expect(screen.getByText("+0 XP")).toBeInTheDocument();
+    expect(screen.getByLabelText("0 XP earned this week")).toBeInTheDocument();
+  });
+
+  it("renders an anonymized private member without leaking identity", () => {
+    renderRow({ ...base, username: null, userId: null });
+    expect(screen.getByText("Anonymous learner")).toBeInTheDocument();
+    // Anonymized rows are not linkable.
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+  });
+
+  it("labels the viewer's own row 'You' while keeping the weekly framing", () => {
+    renderRow({ ...base, isYou: true });
+    expect(screen.getByText("You")).toBeInTheDocument();
+    expect(screen.getByText("+1,275 XP")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/leaderboard/cohort-row.tsx
+++ b/apps/web/src/components/leaderboard/cohort-row.tsx
@@ -61,7 +61,17 @@ export function CohortRow({ entry, style }: CohortRowProps) {
       </div>
 
       <div className="lb-right">
-        <span className="lb-xp">{entry.score.toLocaleString()} XP</span>
+        {/* League score is WEEKLY league-eligible XP (#789) — the '+' frames it
+            as points earned this period, distinct from the lifetime header
+            total; the surface subtitle + this aria-label carry "this week". */}
+        <span
+          className="lb-xp"
+          aria-label={t("leagueScoreAria", {
+            score: entry.score.toLocaleString(),
+          })}
+        >
+          +{entry.score.toLocaleString()} XP
+        </span>
       </div>
     </div>
   );

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -440,7 +440,11 @@
     "leagueSignIn": "Sign in to join this week's league.",
     "cohortStripTitle": "Your league",
     "cohortStripAria": "Your league standing",
-    "cohortViewAll": "View league"
+    "cohortViewAll": "View league",
+    "leagueThisWeek": "This week",
+    "leagueScoreAria": "{score} XP earned this week",
+    "leagueScoringInfoLabel": "About league scoring",
+    "leagueScoringInfo": "League scores count learning XP earned this week — lessons, challenges, quests, and achievements. Bonuses and community XP don't count."
   },
   "certificates": {
     "title": "Certificate of Completion",

--- a/apps/web/src/messages/es.json
+++ b/apps/web/src/messages/es.json
@@ -440,7 +440,11 @@
     "leagueSignIn": "Inicia sesión para unirte a la liga de esta semana.",
     "cohortStripTitle": "Tu liga",
     "cohortStripAria": "Tu posición en la liga",
-    "cohortViewAll": "Ver liga"
+    "cohortViewAll": "Ver liga",
+    "leagueThisWeek": "Esta semana",
+    "leagueScoreAria": "{score} XP ganados esta semana",
+    "leagueScoringInfoLabel": "Sobre la puntuación de la liga",
+    "leagueScoringInfo": "La puntuación de la liga cuenta el XP de aprendizaje ganado esta semana — lecciones, desafíos, misiones y logros. Las bonificaciones y el XP de la comunidad no cuentan."
   },
   "certificates": {
     "title": "Certificado de Finalización",

--- a/apps/web/src/messages/pt-BR.json
+++ b/apps/web/src/messages/pt-BR.json
@@ -440,7 +440,11 @@
     "leagueSignIn": "Entre para participar da liga desta semana.",
     "cohortStripTitle": "Sua liga",
     "cohortStripAria": "Sua posição na liga",
-    "cohortViewAll": "Ver liga"
+    "cohortViewAll": "Ver liga",
+    "leagueThisWeek": "Esta semana",
+    "leagueScoreAria": "{score} XP ganhos esta semana",
+    "leagueScoringInfoLabel": "Sobre a pontuação da liga",
+    "leagueScoringInfo": "A pontuação da liga conta o XP de aprendizado ganho esta semana — aulas, desafios, missões e conquistas. Bônus e XP da comunidade não contam."
   },
   "certificates": {
     "title": "Certificado de Conclusão",

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -3109,6 +3109,43 @@ a.path-step-card:hover .path-step-badge.skip {
   color: var(--text-3);
 }
 
+/* ── Info affordance explaining league scoring (#789) ── */
+.lb-league-info {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  flex-shrink: 0;
+  border-radius: 999px;
+  border: none;
+  background: none;
+  color: var(--text-3);
+  cursor: pointer;
+  transition: color 0.15s;
+}
+.lb-league-info:hover {
+  color: var(--primary);
+}
+.lb-league-info:focus-visible {
+  outline: 2px solid var(--primary);
+  outline-offset: 2px;
+}
+/* Multi-line tooltip content (heatmap-tooltip is nowrap; league copy wraps). */
+.lb-tooltip {
+  max-width: 264px;
+  padding: 10px 12px;
+  background: var(--card);
+  color: var(--text);
+  border: 1px solid var(--border-default);
+  font-size: 12px;
+  line-height: 1.45;
+  border-radius: var(--r-sm);
+  z-index: 210;
+  box-shadow: var(--shadow);
+  animation: tooltip-in 0.12s ease-out;
+}
+
 /* ── Compact list variant — dashboard you-±3 strip ── */
 .lb-list-compact {
   gap: 4px;


### PR DESCRIPTION
Closes #789.

## What & why
Owner screenshots (2026-07-27, live app) showed the league card presenting **1,275 XP** unlabeled next to the **1,315 XP** lifetime header total. Both are correct: the 40-XP gap is the `platform`-source Surprise bonus that `is_league_eligible_source()` **deliberately excludes** from cohort scores (#574 anti-gaming — random awards must not rank), and 1,275 is the **weekly** eligible sum. The bug was the presentation — a learner saw two different XP figures for themselves with nothing explaining why.

**Presentation-only. No RPC/schema/query change; the anti-gaming exclusion stays by design.**

## Changes (the issue's numbered fix shape)
1. **Weekly framing on league values.** `CohortRow` renders `+{score} XP` (the `+` reads as points *earned this period*, visually distinct from the bare lifetime total) with an accessible `"{score} XP earned this week"` label. The leaderboard **League** board subtitle now leads with **"This week"**, and the dashboard **league card** carries the same "This week" qualifier — so every surface that shows a league score says it's weekly.
2. **Scoring info affordance.** A keyboard-focusable, labeled Radix tooltip on the League board header explains scoring honestly: _"League scores count learning XP earned this week — lessons, challenges, quests, and achievements. Bonuses and community XP don't count."_
3. **Canonical-source audit.** Confirmed one source per surface: header / sidebar / dashboard identity panel = **lifetime** `total_xp`; the **only** league-score render site is `CohortRow` (weekly `get_cohort_leaderboard` snapshot). No third variant.

## i18n / a11y
- New `gamification` keys (`leagueThisWeek`, `leagueScoreAria`, `leagueScoringInfoLabel`, `leagueScoringInfo`) in **en / pt-BR / es**.
- Tooltip trigger is a real `<button>` with an `aria-label`; score values carry an `aria-label` that spells out "earned this week"; tooltip copy wraps (dedicated `.lb-tooltip`, not the `nowrap` heatmap style).

## Tests
- `cohort-row.test.tsx` — `+X XP` framing, the `earned this week` aria label, zero-score still framed weekly, anonymized row unchanged, "You" label preserved.
- `leaderboard-client.test.tsx` — League board default, "This week" subtitle, `+X XP` scores, the info affordance's accessible label, honest scoring copy (weekly + learning-only + bonuses excluded), and no league affordance for anon/no-cohort.

## Verification
`pnpm install --frozen-lockfile && pnpm typecheck` green; `pnpm --filter web test` → **1978 passed / 1978** (216 files, +10 new); `pnpm --filter web lint` clean.

Do not merge — awaiting review + owner sign-off.
