### PR TITLE
fix(start): route learner segments to the live ladder, not deactivated courses

### DIFF
--- a/apps/web/src/app/[locale]/(marketing)/start/__tests__/routes.test.ts
+++ b/apps/web/src/app/[locale]/(marketing)/start/__tests__/routes.test.ts
@@ -12,8 +12,8 @@ const byId = vi.mocked(getCourseById);
 const lessonsOf = vi.mocked(getCourseLessons);
 
 // Use each entry course's id as its slug for the fixtures (1:1, arbitrary).
-const FUNDAMENTALS = SEGMENT_ENTRY_COURSE[1];
-const ANCHOR = SEGMENT_ENTRY_COURSE[2];
+const SEG1_ENTRY = SEGMENT_ENTRY_COURSE[1];
+const SEG2_ENTRY = SEGMENT_ENTRY_COURSE[2];
 
 beforeEach(() => {
   byId.mockReset();
@@ -33,20 +33,20 @@ describe("resolveSegmentRoutes — F1 sync gating (funnel must never 404)", () =
   it("deep-links to the first lesson when the entry course is synced", async () => {
     lessonsOf.mockResolvedValue([lesson("intro"), lesson("second")]);
     const routes = await resolveSegmentRoutes("en");
-    expect(routes[1].href).toBe(`/en/courses/${FUNDAMENTALS}/lessons/intro`);
-    expect(routes[2].href).toBe(`/en/courses/${ANCHOR}/lessons/intro`);
-    expect(routes[1].courseId).toBe(FUNDAMENTALS);
+    expect(routes[1].href).toBe(`/en/courses/${SEG1_ENTRY}/lessons/intro`);
+    expect(routes[2].href).toBe(`/en/courses/${SEG2_ENTRY}/lessons/intro`);
+    expect(routes[1].courseId).toBe(SEG1_ENTRY);
   });
 
   it("falls back to /courses when the entry course is present but UNSYNCED", async () => {
     // getCourseLessons returns [] for an unsynced course (or a DB-degraded
     // empty deployment map) — the realistic launch state. Must NOT deep-link.
     lessonsOf.mockImplementation(async (slug: string) =>
-      slug === ANCHOR ? [] : [lesson("intro")]
+      slug === SEG2_ENTRY ? [] : [lesson("intro")]
     );
     const routes = await resolveSegmentRoutes("en");
-    expect(routes[2].href).toBe("/en/courses"); // unsynced anchor → catalog
-    expect(routes[1].href).toBe(`/en/courses/${FUNDAMENTALS}/lessons/intro`);
+    expect(routes[2].href).toBe("/en/courses"); // unsynced seg-2 entry → catalog
+    expect(routes[1].href).toBe(`/en/courses/${SEG1_ENTRY}/lessons/intro`);
   });
 
   it("falls back to /courses when the entry course is absent from the bundle", async () => {

--- a/apps/web/src/app/api/content/params.ts
+++ b/apps/web/src/app/api/content/params.ts
@@ -9,7 +9,7 @@ import { NextResponse } from "next/server";
  * All params are bounded and shape-checked — no unbounded fan-out.
  */
 
-/** Sanity `_id`s are slug-like (`course-anchor-framework`). */
+/** Sanity `_id`s are slug-like (`course-rust-for-program-devs`). */
 const ID_PATTERN = /^[A-Za-z0-9._-]{1,128}$/;
 
 /** Base58 Solana pubkey. */

--- a/apps/web/src/lib/courses/__tests__/entry-course-live.test.ts
+++ b/apps/web/src/lib/courses/__tests__/entry-course-live.test.ts
@@ -1,0 +1,99 @@
+/* eslint-disable import/order -- vi.mock('server-only') must be hoisted above
+   the queries graph so the `server-only` module loads under vitest. */
+import { describe, it, expect, vi } from "vitest";
+vi.mock("server-only", () => ({}));
+import type { DeploymentStatus } from "@/lib/content/deployments";
+import {
+  entryCourseForSegment,
+  type LearnerSegment,
+} from "@/lib/courses/learner-segment";
+import {
+  resolveEntryLessonHref,
+  resolveFlagshipLessonHref,
+} from "../entry-lesson";
+
+/**
+ * Regression guard for the entry-course routing table (companion to
+ * entry-lesson.test.ts). That suite mocks `@/lib/content/queries` wholesale and
+ * routes a synthetic `course-x`, so it passes no matter what real id
+ * SEGMENT_ENTRY_COURSE holds — which is exactly how a table pointing at a
+ * deactivated course (`solana-fundamentals` / `anchor-framework`, retired per
+ * courses-academy CATALOG §3) shipped while every existing test stayed green.
+ *
+ * This suite instead runs the REAL resolver against the REAL committed content
+ * bundle, mocking ONLY the on-chain sync gate so the courses read as
+ * synced+active. If an entry id is absent from the bundle or has no lessons,
+ * `resolveEntryLessonHref` yields the `/courses` fallback and these assertions
+ * fail — the deep-link-is-dead signal the /start funnel needs.
+ */
+
+// Mark every course synced+active (the resolver only ever queries the entry
+// courses) and leave the on-chain read inert so getCourseById needs no Supabase.
+// A map-like with a `.get()` avoids referencing any hoisted import in the
+// factory — isSynced only calls `.get()`.
+vi.mock("@/lib/content/deployments", async (importActual) => {
+  const actual =
+    await importActual<typeof import("@/lib/content/deployments")>();
+  const synced = (id: string): DeploymentStatus =>
+    ({
+      content_id: id,
+      kind: "course",
+      status: "synced",
+      is_active: true,
+      achievement_pda: null,
+    }) as DeploymentStatus;
+  return {
+    ...actual,
+    getActiveDeployments: vi.fn(
+      async () =>
+        ({ get: (id: string) => synced(id) }) as unknown as ReadonlyMap<
+          string,
+          DeploymentStatus
+        >
+    ),
+    getDeploymentById: vi.fn(async () => null),
+    getDeploymentByIdSafe: vi.fn(async () => null),
+  };
+});
+
+const SEGMENTS: LearnerSegment[] = [1, 2, 3];
+const LESSON_HREF = /^\/en\/courses\/[^/]+\/lessons\/[^/]+$/;
+
+// The 5 courses CATALOG §3 retires (deactivated on-chain). No segment may enter
+// at one of these — this is the exact class that broke the /start deep-link.
+const RETIRED_COURSE_IDS = new Set([
+  "course-solana-fundamentals",
+  "course-rust-for-solana",
+  "course-anchor-framework",
+  "course-solana-frontend",
+  "course-defi-on-solana",
+]);
+
+describe("SEGMENT_ENTRY_COURSE — live-ladder routing", () => {
+  it("no segment enters at a retired course", () => {
+    for (const segment of SEGMENTS) {
+      const id = entryCourseForSegment(segment);
+      expect(
+        RETIRED_COURSE_IDS.has(id),
+        `segment ${segment} entry "${id}" is a retired course`
+      ).toBe(false);
+    }
+  });
+
+  it("every segment entry deep-links to a real bundle lesson (not the catalog fallback)", async () => {
+    for (const segment of SEGMENTS) {
+      const id = entryCourseForSegment(segment);
+      const href = await resolveEntryLessonHref("en", id);
+      expect(
+        href,
+        `segment ${segment} → "${id}" fell back to the catalog`
+      ).toMatch(LESSON_HREF);
+    }
+  });
+
+  it("the flagship landing deep-link (segment 1) resolves to a real lesson", async () => {
+    const href = await resolveFlagshipLessonHref("en");
+    expect(href).not.toBe("/en/courses");
+    expect(href).toMatch(LESSON_HREF);
+  });
+});

--- a/apps/web/src/lib/courses/learner-segment.ts
+++ b/apps/web/src/lib/courses/learner-segment.ts
@@ -51,22 +51,34 @@ export const SEGMENT_PATH_MODALITY: Record<
  * path-schema metadata to avoid the two-repo content-staging cycle, so routing
  * changes ship with a code deploy, not a content.lock bump.
  *
- * Grounded in the "Zero to Deployed" flagship path ordering
- * (fundamentals → rust → anchor → building-first-program):
+ * Grounded in the new 5-course "Zero to Deployed" ladder (courses-academy
+ * CATALOG.md §2, one sequential path — trackId 1, trackLevel 1→5):
  *
- *   1 — CORE web2 (ships JS/TS, new to Solana) → Solana Fundamentals (path course 1)
- *   2 — web3 dev (already ships on-chain)       → Anchor Framework (skips fundamentals)
- *   3 — beginner (new to programming)           → Solana Fundamentals (most foundational)
+ *   C1 solana-for-web-devs → C2 rust-for-program-devs →
+ *   C3 building-your-first-solana-program → C4 dapp-and-sdk-with-kit →
+ *   C5 stablecoin-agentic-payments
  *
- * Segment 3 shares the fundamentals entry until the dedicated JS/TS entry-rung
- * course (LX-D3, P2 fast-follow) exists; when it lands, only this line moves.
- * The acknowledged §3.5 deferral applies: launch segmentation is topic-routing,
- * not guidance-level differentiation.
+ * The previous entries (solana-fundamentals, anchor-framework) are RETIRED
+ * (CATALOG §3) and deactivated on-chain. Routing to a deactivated course sends
+ * the /start funnel + landing deep-link to the catalog fallback: the
+ * `resolveEntryLessonHref` sync gate keeps that from 404-ing, but the deep-link
+ * into flagship lesson 1 goes dead — the regression this table fixes.
+ *
+ *   1 — CORE web2 (ships JS/TS, new to Solana) → C2 rust-for-program-devs (†)
+ *   2 — web3 dev (already ships on-chain)       → C3 building-your-first-solana-program (segment 2 "enters here", skips the on-ramp)
+ *   3 — beginner (new to programming)           → C2 rust-for-program-devs (†) (shares segment 1's entry)
+ *
+ * (†) TODO(#599/#673): segments 1 and 3 should enter at C1
+ * `course-solana-for-web-devs` (the JS/TS on-ramp) once it lands on-chain — it
+ * is not in the committed bundle yet, so today they enter at the live entry
+ * rung C2. When C1 lands, only these two lines move. Segment 3 stays out of
+ * scope this wave (CATALOG §1) but still routes to the live on-ramp rather than
+ * a dead course.
  */
 export const SEGMENT_ENTRY_COURSE: Record<LearnerSegment, string> = {
-  1: "course-solana-fundamentals",
-  2: "course-anchor-framework",
-  3: "course-solana-fundamentals",
+  1: "course-rust-for-program-devs",
+  2: "course-building-first-program",
+  3: "course-rust-for-program-devs",
 };
 
 export function entryCourseForSegment(segment: LearnerSegment): string {


### PR DESCRIPTION
## What

`SEGMENT_ENTRY_COURSE` (`apps/web/src/lib/courses/learner-segment.ts`) routed learner segments to courses that were **retired and deactivated on-chain**:

| Segment | Old target (dead) | New target (live) |
| --- | --- | --- |
| 1 — CORE web2 | `course-solana-fundamentals` | **C2** `course-rust-for-program-devs` (live entry rung) |
| 2 — web3 dev | `course-anchor-framework` | **C3** `course-building-first-program` (segment 2 "enters here") |
| 3 — beginner | `course-solana-fundamentals` | **C2** `course-rust-for-program-devs` (shares segment 1's entry) |

## Why it's a live UX regression

Since tonight's on-chain deactivation, the landing CTA + `/start` funnel deep-links pointed at deactivated courses. The `#717` resolver's sync gate (`resolveEntryLessonHref`) saved us from 404s by falling back to `/courses` — but the deep-link **into flagship lesson 1 was dead**; every segment dumped to the catalog instead.

Remapped to the live "Zero to Deployed" ladder (courses-academy `CATALOG.md` §2, trackId 1 / trackLevel 1→5). C1 `course-solana-for-web-devs` is the intended segment-1/3 on-ramp but is **not in the committed bundle yet**, so segments 1 & 3 enter at the live rung C2 today — `TODO(#599/#673)` in the constant names the one-line move for when C1 lands.

## The regression test this class needed

`entry-course-live.test.ts` (new) runs the **real** resolver against the **real committed bundle**, mocking only the on-chain sync gate. It asserts (a) no segment enters a retired course, and (b) every segment entry deep-links to a real lesson (not the `/courses` fallback). The existing `entry-lesson`/`start/routes` suites mock the bundle away and route a synthetic `course-x` — which is exactly why a dead-course table shipped green.

Verified it goes **red** on the old values:
```
× no segment enters at a retired course
  AssertionError: segment 1 entry "course-solana-fundamentals" is a retired course
```

## Also

- `start/routes.test.ts`: renamed stale `FUNDAMENTALS`/`ANCHOR` locals → `SEG1_ENTRY`/`SEG2_ENTRY` (they read from the constant, so behaviour is unchanged — the names were just misleading now).
- `api/content/params.ts`: freshened an **inert** `ID_PATTERN` doc example that cited the retired `course-anchor-framework` (comment only — checked, it is not a live reference; the route validates shape, not membership).

## Checks
- `tsc --noEmit` clean · full web vitest suite **1971 passed** (incl. the new 3) · eslint + prettier clean on changed files.

## Notes
- Companion work — courses-academy path rewiring + course retirement — is in flight. This app-side constant fix is **independently safe** because C2 (`rust-for-program-devs`) is already live; if C3 weren't yet synced, segment 2 would degrade to the catalog fallback (never a 404), still strictly better than a deactivated target.
- **Do not merge** — hand to the gate.
