### PR TITLE
feat(gamification): toast server-granted XP — daily quests + surprise bonus (#790)

### DIFF
--- a/apps/web/src/app/api/quests/daily/route.ts
+++ b/apps/web/src/app/api/quests/daily/route.ts
@@ -89,12 +89,14 @@ export async function GET() {
 
     const progressMap = new Map<
       string,
-      { currentValue: number; completed: boolean }
+      { currentValue: number; completed: boolean; justAwarded: boolean }
     >();
     for (const row of progressRows) {
       progressMap.set(row.questId, {
         currentValue: row.currentValue,
         completed: row.completed,
+        // #790: surface the one-shot award signal so the client can toast it.
+        justAwarded: row.justAwarded,
       });
     }
 
@@ -111,6 +113,7 @@ export async function GET() {
         currentValue: progress?.currentValue ?? 0,
         completed: progress?.completed ?? false,
         resetType: q.resetType,
+        justAwarded: progress?.justAwarded ?? false,
       };
     });
 

--- a/apps/web/src/hooks/__tests__/use-dashboard-data.test.tsx
+++ b/apps/web/src/hooks/__tests__/use-dashboard-data.test.tsx
@@ -1,0 +1,155 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import {
+  __resetServerXpFeedbackForTests,
+  pickSurpriseBonusToasts,
+} from "@/lib/gamification/server-xp-feedback";
+
+// Real server-xp-feedback pickers between the hook and the toast facade — the
+// point of this test is the HOOK's wiring of a poll-detected surprise bonus, so
+// the picker stays real and only the dispatch surface is spied.
+const h = vi.hoisted(() => ({
+  dispatchXpGain: vi.fn(),
+  dispatchSurpriseBonus: vi.fn(),
+  dispatchToast: vi.fn(),
+  celebrate: vi.fn(),
+  transactions: [] as unknown[],
+}));
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+vi.mock("@/hooks/use-gamification-events", () => ({
+  dispatchXpGain: h.dispatchXpGain,
+}));
+vi.mock("@/components/gamification/surprise-bonus-toast", () => ({
+  dispatchSurpriseBonus: h.dispatchSurpriseBonus,
+}));
+vi.mock("@/components/ui/toast-container", () => ({
+  dispatchToast: h.dispatchToast,
+}));
+vi.mock("@/lib/gamification/celebration", () => ({
+  celebrate: h.celebrate,
+}));
+
+// Content bundle queries — never reached before the surprise-bonus loop, but
+// stubbed so the poll runs clean instead of hitting the network.
+vi.mock("@/lib/content/client-queries", () => ({
+  getCourseLessonOrders: vi.fn(async () => []),
+  getCoursesByIds: vi.fn(async () => []),
+  getLessonsByIds: vi.fn(async () => []),
+  getRecommendedCourses: vi.fn(async () => []),
+  getAllAchievements: vi.fn(async () => []),
+  getAllLessonSkills: vi.fn(async () => []),
+}));
+
+vi.mock("@/lib/services", () => ({
+  getProgressService: () => ({
+    getXP: async () => 0,
+    getStreak: async () => ({
+      available: true,
+      currentStreak: 0,
+      longestStreak: 0,
+      lastActivityDate: "",
+      streakHistory: {},
+      frozenDays: [],
+      freezesRemaining: 0,
+    }),
+  }),
+}));
+
+// Chainable Supabase stub. Terminal shape depends on the table + whether the
+// query is a head/count read: profiles resolve a single row, the recent
+// xp_transactions scan resolves the seeded surprise-bonus row, everything else
+// resolves an empty set.
+vi.mock("@/lib/supabase/client", () => ({
+  createClient: () => ({
+    from(table: string) {
+      let columns = "";
+      let head = false;
+      const builder: Record<string, unknown> = {
+        select(cols: string, opts?: { head?: boolean }) {
+          columns = cols;
+          head = Boolean(opts?.head);
+          return builder;
+        },
+        eq: () => builder,
+        gte: () => builder,
+        order: () => builder,
+        limit: () => builder,
+        single: () =>
+          Promise.resolve({
+            data: { username: "Builder", name_rerolls_used: 0 },
+          }),
+        then(
+          resolve: (v: unknown) => unknown,
+          reject?: (e: unknown) => unknown
+        ) {
+          const value = head
+            ? { count: 0 }
+            : table === "xp_transactions" && columns.includes("amount")
+              ? { data: h.transactions }
+              : { data: [] };
+          return Promise.resolve(value).then(resolve, reject);
+        },
+      };
+      return builder;
+    },
+  }),
+}));
+
+import { useDashboardData } from "../use-dashboard-data";
+
+beforeEach(() => {
+  h.dispatchXpGain.mockClear();
+  h.dispatchSurpriseBonus.mockClear();
+  h.dispatchToast.mockClear();
+  h.celebrate.mockClear();
+  h.transactions = [];
+  __resetServerXpFeedbackForTests();
+  // /api/quests/daily poll — no quest rewards, isolate the surprise-bonus path.
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ quests: [], nextResetTime: "" }),
+    }))
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("useDashboardData — poll-detected surprise bonus", () => {
+  it("dispatches an xp-gain for a surprise bonus the poll newly detects", async () => {
+    // Seed the tab: the first observation silently marks existing history seen,
+    // so a bonus that appears on a LATER poll is the one that toasts (#790).
+    pickSurpriseBonusToasts([]);
+
+    const AMOUNT = 25;
+    h.transactions = [
+      {
+        amount: AMOUNT,
+        reason: "surprise_bonus:lesson-what-is-a-pda",
+        created_at: new Date().toISOString(),
+        tx_signature: "5igNaTure",
+        idempotency_key: "surprise-bonus-key-1",
+      },
+    ];
+
+    renderHook(() => useDashboardData("user-1", false));
+
+    // The surprise-bonus toast fires in both the buggy and fixed builds; wait on
+    // it so the xp-gain assertion below is a clean failure at the unfixed head
+    // rather than a timeout.
+    await waitFor(() =>
+      expect(h.dispatchSurpriseBonus).toHaveBeenCalledWith(AMOUNT)
+    );
+
+    // #796 regression: the poll path must also move the header XP counter.
+    expect(h.dispatchXpGain).toHaveBeenCalledWith(AMOUNT);
+  });
+});

--- a/apps/web/src/hooks/__tests__/use-dashboard-data.test.tsx
+++ b/apps/web/src/hooks/__tests__/use-dashboard-data.test.tsx
@@ -125,9 +125,10 @@ afterEach(() => {
 
 describe("useDashboardData — poll-detected surprise bonus", () => {
   it("dispatches an xp-gain for a surprise bonus the poll newly detects", async () => {
-    // Seed the tab: the first observation silently marks existing history seen,
-    // so a bonus that appears on a LATER poll is the one that toasts (#790).
-    pickSurpriseBonusToasts([]);
+    // Seed the tab for this user: the first observation silently marks existing
+    // history seen, so a bonus that appears on a LATER poll is the one that
+    // toasts (#790). Keyed by the same user id the hook polls under (#796).
+    pickSurpriseBonusToasts([], "user-1");
 
     const AMOUNT = 25;
     h.transactions = [
@@ -151,5 +152,43 @@ describe("useDashboardData — poll-detected surprise bonus", () => {
 
     // #796 regression: the poll path must also move the header XP counter.
     expect(h.dispatchXpGain).toHaveBeenCalledWith(AMOUNT);
+  });
+
+  it("re-seeds silently for a new user — never storms user B with their own history", async () => {
+    // #796 round-3: sign-out hard-navigates without clearing sessionStorage, so
+    // a same-tab account switch must NOT let user B inherit user A's init flag —
+    // otherwise B's ENTIRE surprise-bonus history toasts at once on first poll.
+
+    // User A initialised earlier in this tab (their init flag is now set).
+    pickSurpriseBonusToasts([], "user-A");
+
+    // User B signs in on the same tab with pre-existing surprise-bonus history.
+    h.transactions = [
+      {
+        amount: 20,
+        reason: "surprise_bonus:lesson-one",
+        created_at: "2026-07-20T00:00:00.000Z",
+        tx_signature: "sigB1",
+        idempotency_key: "user-B-bonus-1",
+      },
+      {
+        amount: 35,
+        reason: "surprise_bonus:lesson-two",
+        created_at: "2026-07-21T00:00:00.000Z",
+        tx_signature: "sigB2",
+        idempotency_key: "user-B-bonus-2",
+      },
+    ];
+
+    const { result } = renderHook(() => useDashboardData("user-B", false));
+
+    // Wait for the poll to finish (isLoading flips false once the surprise-bonus
+    // loop has run) so the "nothing toasted" assertions aren't racing the fetch.
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    // B's history is theirs from before this session — seed it silently, toast
+    // nothing, move no counter.
+    expect(h.dispatchSurpriseBonus).not.toHaveBeenCalled();
+    expect(h.dispatchXpGain).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/hooks/use-dashboard-data.ts
+++ b/apps/web/src/hooks/use-dashboard-data.ts
@@ -23,6 +23,14 @@ import {
   deriveContinueTarget,
   type ContinueTarget,
 } from "@/lib/courses/continue-learning";
+import {
+  pickQuestRewardToasts,
+  pickSurpriseBonusToasts,
+} from "@/lib/gamification/server-xp-feedback";
+import { dispatchXpGain } from "@/hooks/use-gamification-events";
+import { dispatchSurpriseBonus } from "@/components/gamification/surprise-bonus-toast";
+import { dispatchToast } from "@/components/ui/toast-container";
+import { celebrate } from "@/lib/gamification/celebration";
 
 // Default streak for unauthenticated or on error
 const defaultStreak: StreakData = {
@@ -95,6 +103,7 @@ export function useDashboardData(
   authLoading: boolean
 ): DashboardData {
   const tDash = useTranslations("dashboard");
+  const tGam = useTranslations("gamification");
   const [data, setData] = useState<DashboardData>({
     xp: 0,
     level: 0,
@@ -169,10 +178,32 @@ export function useDashboardData(
         // every lesson a user ever completed.
         const { data: transactions } = await supabase
           .from("xp_transactions")
-          .select("amount, reason, created_at, tx_signature")
+          .select("amount, reason, created_at, tx_signature, idempotency_key")
           .eq("user_id", authUserId)
           .order("created_at", { ascending: false })
           .limit(100);
+
+        // #790: server-granted XP (daily-quest rewards + surprise bonuses) has
+        // no synchronous UI cause. Toast it ONCE from the poll the dashboard
+        // already makes — quest rewards from /api/quests/daily's justAwarded,
+        // surprise bonuses from the transactions above. Both are deduped
+        // session-wide (see server-xp-feedback), so a re-poll never re-toasts,
+        // and the surprise-bonus dedupe is shared with the Realtime path.
+        const questPeriod = new Date().toISOString().split("T")[0] as string;
+        for (const reward of pickQuestRewardToasts(
+          (questsResult.quests ?? []) as DailyQuest[],
+          questPeriod
+        )) {
+          dispatchXpGain(reward.xpReward);
+          dispatchToast(
+            tGam("questReward", { name: reward.name, amount: reward.xpReward }),
+            "success"
+          );
+        }
+        for (const amount of pickSurpriseBonusToasts(transactions ?? [])) {
+          celebrate("surprise-bonus");
+          dispatchSurpriseBonus(amount);
+        }
 
         // Fetch activity dates for streak heatmap (last 270 days)
         const oneYearAgo = new Date();
@@ -609,7 +640,7 @@ export function useDashboardData(
     }
 
     fetchData();
-  }, [authUserId, authLoading, tDash]);
+  }, [authUserId, authLoading, tDash, tGam]);
 
   return data;
 }

--- a/apps/web/src/hooks/use-dashboard-data.ts
+++ b/apps/web/src/hooks/use-dashboard-data.ts
@@ -201,6 +201,7 @@ export function useDashboardData(
           );
         }
         for (const amount of pickSurpriseBonusToasts(transactions ?? [])) {
+          dispatchXpGain(amount);
           celebrate("surprise-bonus");
           dispatchSurpriseBonus(amount);
         }

--- a/apps/web/src/hooks/use-dashboard-data.ts
+++ b/apps/web/src/hooks/use-dashboard-data.ts
@@ -192,7 +192,8 @@ export function useDashboardData(
         const questPeriod = new Date().toISOString().split("T")[0] as string;
         for (const reward of pickQuestRewardToasts(
           (questsResult.quests ?? []) as DailyQuest[],
-          questPeriod
+          questPeriod,
+          authUserId
         )) {
           dispatchXpGain(reward.xpReward);
           dispatchToast(
@@ -200,7 +201,10 @@ export function useDashboardData(
             "success"
           );
         }
-        for (const amount of pickSurpriseBonusToasts(transactions ?? [])) {
+        for (const amount of pickSurpriseBonusToasts(
+          transactions ?? [],
+          authUserId
+        )) {
           dispatchXpGain(amount);
           celebrate("surprise-bonus");
           dispatchSurpriseBonus(amount);

--- a/apps/web/src/hooks/use-gamification-events.ts
+++ b/apps/web/src/hooks/use-gamification-events.ts
@@ -139,7 +139,8 @@ export function useGamificationEvents(userId: string | undefined) {
             // aligned or a bonus would toast twice (once per path).
             if (
               claimSurpriseBonus(
-                row.idempotency_key ?? row.id ?? row.tx_signature ?? ""
+                row.idempotency_key ?? row.id ?? row.tx_signature ?? "",
+                userId
               )
             ) {
               celebrate("surprise-bonus");

--- a/apps/web/src/hooks/use-gamification-events.ts
+++ b/apps/web/src/hooks/use-gamification-events.ts
@@ -5,6 +5,7 @@ import { trackCredentialMinted } from "@/lib/analytics/events";
 import { createClient } from "@/lib/supabase/client";
 import { celebrate } from "@/lib/gamification/celebration";
 import { isSurpriseBonusReason } from "@/lib/gamification/surprise-bonus";
+import { claimSurpriseBonus } from "@/lib/gamification/server-xp-feedback";
 import {
   dispatchAchievementUnlock,
   dispatchAchievementXp,
@@ -94,6 +95,7 @@ export function useGamificationEvents(userId: string | undefined) {
             amount?: number;
             reason?: string;
             tx_signature?: string;
+            idempotency_key?: string;
           };
 
           // Deduplicate by row id (primary defence) or tx_signature (fallback)
@@ -124,9 +126,19 @@ export function useGamificationEvents(userId: string | undefined) {
           // reward only surfaces here, AFTER it is granted server-side — there
           // is no pre-announcement anywhere in the UI. Localization happens in
           // the mounted SurpriseBonusToastListener (inside the intl provider).
+          // #790: the dashboard poll also detects surprise bonuses (for sessions
+          // where Realtime isn't delivering); claimSurpriseBonus is a session
+          // dedupe SHARED with that path, so whichever fires first wins and the
+          // other is a no-op — never a double toast.
           if (row.reason && isSurpriseBonusReason(row.reason)) {
-            celebrate("surprise-bonus");
-            dispatchSurpriseBonus(amount);
+            if (
+              claimSurpriseBonus(
+                row.idempotency_key ?? row.id ?? row.tx_signature ?? ""
+              )
+            ) {
+              celebrate("surprise-bonus");
+              dispatchSurpriseBonus(amount);
+            }
             dispatchXpGain(amount);
             return;
           }

--- a/apps/web/src/hooks/use-gamification-events.ts
+++ b/apps/web/src/hooks/use-gamification-events.ts
@@ -131,6 +131,12 @@ export function useGamificationEvents(userId: string | undefined) {
           // dedupe SHARED with that path, so whichever fires first wins and the
           // other is a no-op — never a double toast.
           if (row.reason && isSurpriseBonusReason(row.reason)) {
+            // KEEP IN SYNC with surpriseKey() in server-xp-feedback.ts: both
+            // channels share claimSurpriseBonus's seen-set, so they must derive
+            // the SAME key for the same award. maybeAwardSurpriseBonus always
+            // sets idempotency_key, so the fallbacks below are dead today — but
+            // if it ever becomes optional, both sites' fallbacks must stay
+            // aligned or a bonus would toast twice (once per path).
             if (
               claimSurpriseBonus(
                 row.idempotency_key ?? row.id ?? row.tx_signature ?? ""

--- a/apps/web/src/lib/gamification/__tests__/server-xp-feedback.test.ts
+++ b/apps/web/src/lib/gamification/__tests__/server-xp-feedback.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import type { DailyQuest } from "@superteam-lms/types";
+import {
+  pickQuestRewardToasts,
+  pickSurpriseBonusToasts,
+  claimSurpriseBonus,
+  __resetServerXpFeedbackForTests,
+} from "../server-xp-feedback";
+
+// #790: server-granted XP must toast exactly ONCE. These pin the dedupe: a
+// just-awarded quest / a surprise-bonus row is picked the first time and never
+// again this session (re-poll safe), and nothing is picked without an award.
+
+const PERIOD = "2026-07-27";
+
+function quest(overrides: Partial<DailyQuest>): DailyQuest {
+  return {
+    id: "quest-complete-lesson",
+    type: "lesson",
+    name: "Complete a Lesson",
+    description: "",
+    icon: "BookOpen",
+    xpReward: 25,
+    targetValue: 1,
+    currentValue: 1,
+    completed: true,
+    resetType: "daily",
+    ...overrides,
+  };
+}
+
+beforeEach(() => __resetServerXpFeedbackForTests());
+
+describe("pickQuestRewardToasts (#790)", () => {
+  it("returns a just-awarded quest ONCE, then nothing on a re-poll", () => {
+    const quests = [quest({ id: "q1", justAwarded: true, xpReward: 35 })];
+    const first = pickQuestRewardToasts(quests, PERIOD);
+    expect(first).toEqual([
+      { questId: "q1", name: "Complete a Lesson", xpReward: 35 },
+    ]);
+    // Same quest, still flagged (e.g. a stale response) → already claimed → nothing.
+    expect(pickQuestRewardToasts(quests, PERIOD)).toEqual([]);
+  });
+
+  it("ignores quests that were not just awarded", () => {
+    expect(
+      pickQuestRewardToasts(
+        [
+          quest({ id: "a", justAwarded: false }),
+          quest({ id: "b", completed: true }), // justAwarded undefined
+        ],
+        PERIOD
+      )
+    ).toEqual([]);
+  });
+
+  it("keys the dedupe on quest + period — a new day re-toasts", () => {
+    const q = [quest({ id: "q1", justAwarded: true })];
+    expect(pickQuestRewardToasts(q, "2026-07-27")).toHaveLength(1);
+    expect(pickQuestRewardToasts(q, "2026-07-27")).toHaveLength(0);
+    expect(pickQuestRewardToasts(q, "2026-07-28")).toHaveLength(1);
+  });
+});
+
+describe("pickSurpriseBonusToasts (#790)", () => {
+  const rowA = {
+    reason: "surprise_bonus:lesson-1",
+    amount: 40,
+    idempotency_key: "sigA:SurpriseBonus",
+  };
+  const rowB = {
+    reason: "surprise_bonus:lesson-2",
+    amount: 15,
+    idempotency_key: "sigB:SurpriseBonus",
+  };
+
+  it("seeds existing bonuses SILENTLY on first observation (no stale toast storm)", () => {
+    // A fresh tab's first dashboard poll sees historical bonuses — it must not
+    // toast them; the learner didn't just earn them.
+    expect(pickSurpriseBonusToasts([rowA, rowB])).toEqual([]);
+  });
+
+  it("toasts a newly-appeared bonus ONCE, then nothing on a re-poll", () => {
+    pickSurpriseBonusToasts([rowA]); // first poll → seed rowA silently
+    // rowB appears on a later poll → toast it once.
+    expect(pickSurpriseBonusToasts([rowA, rowB])).toEqual([15]);
+    // Re-poll (reload-equivalent): both seen → nothing.
+    expect(pickSurpriseBonusToasts([rowA, rowB])).toEqual([]);
+  });
+
+  it("ignores non-surprise and non-positive rows", () => {
+    pickSurpriseBonusToasts([]); // init
+    expect(
+      pickSurpriseBonusToasts([
+        { reason: "Completed lesson: x", amount: 25, idempotency_key: "a" },
+        { reason: "surprise_bonus:y", amount: 0, idempotency_key: "b" },
+        { reason: null, amount: 40, idempotency_key: "c" },
+      ])
+    ).toEqual([]);
+  });
+
+  it("shares its dedupe with the Realtime path (claimSurpriseBonus)", () => {
+    pickSurpriseBonusToasts([]); // init (empty → nothing seeded)
+    // Realtime saw the award first and claimed its key → the poll must not re-toast.
+    expect(claimSurpriseBonus("sigA:SurpriseBonus")).toBe(true);
+    expect(pickSurpriseBonusToasts([rowA])).toEqual([]);
+  });
+
+  it("falls back to sig+timestamp when idempotency_key is absent", () => {
+    pickSurpriseBonusToasts([]); // init
+    const rows = [
+      {
+        reason: "surprise_bonus:z",
+        amount: 15,
+        tx_signature: "txA",
+        created_at: "2026-07-27T10:00:00Z",
+      },
+    ];
+    expect(pickSurpriseBonusToasts(rows)).toEqual([15]);
+    expect(pickSurpriseBonusToasts(rows)).toEqual([]);
+  });
+});

--- a/apps/web/src/lib/gamification/server-xp-feedback.ts
+++ b/apps/web/src/lib/gamification/server-xp-feedback.ts
@@ -28,9 +28,17 @@ import { isSurpriseBonusReason } from "@/lib/gamification/surprise-bonus";
 
 const firedQuestKeys = new Set<string>();
 
-/** True the first time (questId, period) is claimed this session; marks it seen. */
-export function claimQuestReward(questId: string, period: string): boolean {
-  const key = `${questId}:${period}`;
+/**
+ * True the first time (questId, period) is claimed this session; marks it seen.
+ * Namespaced by the authenticated user id so a same-tab account switch never
+ * lets a new user inherit the previous user's fired keys.
+ */
+export function claimQuestReward(
+  questId: string,
+  period: string,
+  userId?: string
+): boolean {
+  const key = `${ns(userId)}:${questId}:${period}`;
   if (firedQuestKeys.has(key)) return false;
   firedQuestKeys.add(key);
   return true;
@@ -49,11 +57,12 @@ export interface QuestRewardToast {
  */
 export function pickQuestRewardToasts(
   quests: readonly DailyQuest[],
-  period: string
+  period: string,
+  userId?: string
 ): QuestRewardToast[] {
   const out: QuestRewardToast[] = [];
   for (const q of quests) {
-    if (q.justAwarded && claimQuestReward(q.id, period)) {
+    if (q.justAwarded && claimQuestReward(q.id, period, userId)) {
       out.push({ questId: q.id, name: q.name, xpReward: q.xpReward });
     }
   }
@@ -65,9 +74,36 @@ export function pickQuestRewardToasts(
 const SURPRISE_SEEN_KEY = "stbr:surprise-bonus-seen";
 const SURPRISE_INIT_KEY = "stbr:surprise-bonus-init";
 
-// In-memory fallback for SSR / non-DOM test env (sessionStorage absent).
-const memSeen = new Set<string>();
-let memInit = false;
+// The seen-set and init flag are keyed by the authenticated user id. Sign-out
+// hard-navigates without clearing sessionStorage, so a same-tab account switch
+// would otherwise let the new user inherit the previous user's init flag and
+// storm them with their OWN entire surprise-bonus history. A per-user namespace
+// means an unseen user id has no init flag → it seeds silently, exactly like a
+// fresh tab. An absent id (SSR / anonymous) collapses to a single "" namespace,
+// preserving the original single-user behaviour byte-for-byte.
+function ns(userId?: string): string {
+  return userId ?? "";
+}
+function seenStorageKey(userId?: string): string {
+  return `${SURPRISE_SEEN_KEY}:${ns(userId)}`;
+}
+function initStorageKey(userId?: string): string {
+  return `${SURPRISE_INIT_KEY}:${ns(userId)}`;
+}
+
+// In-memory fallback for SSR / non-DOM test env (sessionStorage absent), also
+// namespaced per user id.
+const memSeen = new Map<string, Set<string>>();
+const memInit = new Set<string>();
+
+function memSeenSet(userId?: string): Set<string> {
+  let set = memSeen.get(ns(userId));
+  if (!set) {
+    set = new Set<string>();
+    memSeen.set(ns(userId), set);
+  }
+  return set;
+}
 
 function store(): Storage | null {
   try {
@@ -79,55 +115,59 @@ function store(): Storage | null {
   }
 }
 
-function readSeen(): Set<string> {
+function readSeen(userId?: string): Set<string> {
   const s = store();
-  if (!s) return memSeen;
+  if (!s) return memSeenSet(userId);
   try {
-    const raw = s.getItem(SURPRISE_SEEN_KEY);
+    const raw = s.getItem(seenStorageKey(userId));
     return new Set(raw ? (JSON.parse(raw) as string[]) : []);
   } catch {
-    return memSeen;
+    return memSeenSet(userId);
   }
 }
 
-function writeSeen(seen: Set<string>): void {
+function writeSeen(seen: Set<string>, userId?: string): void {
   const s = store();
   if (!s) return;
   try {
     // Cap so the store can't grow without bound over a long session.
-    s.setItem(SURPRISE_SEEN_KEY, JSON.stringify([...seen].slice(-200)));
+    s.setItem(seenStorageKey(userId), JSON.stringify([...seen].slice(-200)));
   } catch {
     // Storage full / disabled — the in-memory set still dedupes this session.
   }
 }
 
-function hasInitialized(): boolean {
+function hasInitialized(userId?: string): boolean {
   const s = store();
-  if (!s) return memInit;
-  return s.getItem(SURPRISE_INIT_KEY) === "1";
+  if (!s) return memInit.has(ns(userId));
+  return s.getItem(initStorageKey(userId)) === "1";
 }
 
-function markInitialized(seen: Set<string>): void {
+function markInitialized(seen: Set<string>, userId?: string): void {
   const s = store();
   if (!s) {
-    memInit = true;
+    memInit.add(ns(userId));
     return;
   }
-  writeSeen(seen);
+  writeSeen(seen, userId);
   try {
-    s.setItem(SURPRISE_INIT_KEY, "1");
+    s.setItem(initStorageKey(userId), "1");
   } catch {
-    memInit = true;
+    memInit.add(ns(userId));
   }
 }
 
-/** True the first time this surprise-bonus award key is claimed; marks it seen. */
-export function claimSurpriseBonus(key: string): boolean {
+/**
+ * True the first time this surprise-bonus award key is claimed; marks it seen.
+ * Namespaced by user id so the seen-set is never shared across a same-tab
+ * account switch.
+ */
+export function claimSurpriseBonus(key: string, userId?: string): boolean {
   if (!key) return false;
-  const seen = readSeen();
+  const seen = readSeen(userId);
   if (seen.has(key)) return false;
   seen.add(key);
-  writeSeen(seen);
+  writeSeen(seen, userId);
   return true;
 }
 
@@ -158,7 +198,8 @@ function surpriseKey(r: XpTransactionRow): string {
  * Realtime path via claimSurpriseBonus.
  */
 export function pickSurpriseBonusToasts(
-  rows: readonly XpTransactionRow[]
+  rows: readonly XpTransactionRow[],
+  userId?: string
 ): number[] {
   const bonuses = rows.filter(
     (r) =>
@@ -168,16 +209,17 @@ export function pickSurpriseBonusToasts(
       r.amount > 0
   );
 
-  if (!hasInitialized()) {
-    const seen = readSeen();
+  if (!hasInitialized(userId)) {
+    const seen = readSeen(userId);
     for (const r of bonuses) seen.add(surpriseKey(r));
-    markInitialized(seen);
+    markInitialized(seen, userId);
     return [];
   }
 
   const out: number[] = [];
   for (const r of bonuses) {
-    if (claimSurpriseBonus(surpriseKey(r))) out.push(r.amount as number);
+    if (claimSurpriseBonus(surpriseKey(r), userId))
+      out.push(r.amount as number);
   }
   return out;
 }
@@ -186,12 +228,22 @@ export function pickSurpriseBonusToasts(
 export function __resetServerXpFeedbackForTests(): void {
   firedQuestKeys.clear();
   memSeen.clear();
-  memInit = false;
+  memInit.clear();
   const s = store();
   if (s) {
     try {
-      s.removeItem(SURPRISE_SEEN_KEY);
-      s.removeItem(SURPRISE_INIT_KEY);
+      // Keys are per-user namespaced, so remove every surprise-bonus entry.
+      const doomed: string[] = [];
+      for (let i = 0; i < s.length; i++) {
+        const k = s.key(i);
+        if (
+          k &&
+          (k.startsWith(SURPRISE_SEEN_KEY) || k.startsWith(SURPRISE_INIT_KEY))
+        ) {
+          doomed.push(k);
+        }
+      }
+      for (const k of doomed) s.removeItem(k);
     } catch {
       // ignore
     }

--- a/apps/web/src/lib/gamification/server-xp-feedback.ts
+++ b/apps/web/src/lib/gamification/server-xp-feedback.ts
@@ -1,0 +1,193 @@
+import type { DailyQuest } from "@superteam-lms/types";
+import { isSurpriseBonusReason } from "@/lib/gamification/surprise-bonus";
+
+// #790: server-granted XP (daily-quest rewards, surprise bonuses) lands with no
+// synchronous UI cause — the owner couldn't tell why the numbers moved. These
+// helpers decide, from the data the dashboard ALREADY polls (/api/quests/daily's
+// justAwarded + the recent xp_transactions), which rewards to toast, exactly
+// once.
+//
+// Two different server semantics ⇒ two dedupe strategies:
+//
+//   * QUESTS use `justAwarded`, which the server flips false after the first
+//     poll (get_daily_quest_state). So a plain in-memory Set keyed on
+//     questId+period is enough — a reload re-polls and simply gets justAwarded
+//     false, never re-toasting.
+//
+//   * SURPRISE BONUSES are permanent xp_transactions rows with no one-shot
+//     flag, so a poll that re-scans recent transactions would re-toast them on
+//     every reload. Their seen-set is therefore persisted in sessionStorage
+//     (survives reload within the tab) and SEEDED SILENTLY on the first
+//     observation in a tab: existing bonuses are marked seen without toasting
+//     (they are history the learner didn't just earn); only bonuses that appear
+//     on a LATER poll toast. The same set is SHARED with the Realtime path
+//     (use-gamification-events) via claimSurpriseBonus, so whichever channel
+//     sees an award first fires the toast and the other is a no-op.
+
+// ── Quests ──────────────────────────────────────────────────────────────────
+
+const firedQuestKeys = new Set<string>();
+
+/** True the first time (questId, period) is claimed this session; marks it seen. */
+export function claimQuestReward(questId: string, period: string): boolean {
+  const key = `${questId}:${period}`;
+  if (firedQuestKeys.has(key)) return false;
+  firedQuestKeys.add(key);
+  return true;
+}
+
+export interface QuestRewardToast {
+  questId: string;
+  name: string;
+  xpReward: number;
+}
+
+/**
+ * The quests whose XP was just awarded on THIS poll and not yet toasted this
+ * session. A re-poll (justAwarded already false, or the key already claimed)
+ * yields nothing.
+ */
+export function pickQuestRewardToasts(
+  quests: readonly DailyQuest[],
+  period: string
+): QuestRewardToast[] {
+  const out: QuestRewardToast[] = [];
+  for (const q of quests) {
+    if (q.justAwarded && claimQuestReward(q.id, period)) {
+      out.push({ questId: q.id, name: q.name, xpReward: q.xpReward });
+    }
+  }
+  return out;
+}
+
+// ── Surprise bonuses (sessionStorage-backed, seeded silently) ─────────────────
+
+const SURPRISE_SEEN_KEY = "stbr:surprise-bonus-seen";
+const SURPRISE_INIT_KEY = "stbr:surprise-bonus-init";
+
+// In-memory fallback for SSR / non-DOM test env (sessionStorage absent).
+const memSeen = new Set<string>();
+let memInit = false;
+
+function store(): Storage | null {
+  try {
+    return typeof window !== "undefined" && window.sessionStorage
+      ? window.sessionStorage
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function readSeen(): Set<string> {
+  const s = store();
+  if (!s) return memSeen;
+  try {
+    const raw = s.getItem(SURPRISE_SEEN_KEY);
+    return new Set(raw ? (JSON.parse(raw) as string[]) : []);
+  } catch {
+    return memSeen;
+  }
+}
+
+function writeSeen(seen: Set<string>): void {
+  const s = store();
+  if (!s) return;
+  try {
+    // Cap so the store can't grow without bound over a long session.
+    s.setItem(SURPRISE_SEEN_KEY, JSON.stringify([...seen].slice(-200)));
+  } catch {
+    // Storage full / disabled — the in-memory set still dedupes this session.
+  }
+}
+
+function hasInitialized(): boolean {
+  const s = store();
+  if (!s) return memInit;
+  return s.getItem(SURPRISE_INIT_KEY) === "1";
+}
+
+function markInitialized(seen: Set<string>): void {
+  const s = store();
+  if (!s) {
+    memInit = true;
+    return;
+  }
+  writeSeen(seen);
+  try {
+    s.setItem(SURPRISE_INIT_KEY, "1");
+  } catch {
+    memInit = true;
+  }
+}
+
+/** True the first time this surprise-bonus award key is claimed; marks it seen. */
+export function claimSurpriseBonus(key: string): boolean {
+  if (!key) return false;
+  const seen = readSeen();
+  if (seen.has(key)) return false;
+  seen.add(key);
+  writeSeen(seen);
+  return true;
+}
+
+/** A recent xp_transactions row, as the dashboard poll selects it. */
+export interface XpTransactionRow {
+  reason: string | null;
+  amount: number | null;
+  idempotency_key?: string | null;
+  tx_signature?: string | null;
+  created_at?: string | null;
+}
+
+function surpriseKey(r: XpTransactionRow): string {
+  return r.idempotency_key ?? `${r.tx_signature ?? ""}:${r.created_at ?? ""}`;
+}
+
+/**
+ * The surprise-bonus amounts to toast from a recent-transactions scan. On the
+ * FIRST observation in a tab, seeds existing bonuses as seen and toasts nothing
+ * (they are history); on later polls, toasts each newly-appeared bonus once.
+ * Deduped (sessionStorage) so a reload never re-toasts, and shared with the
+ * Realtime path via claimSurpriseBonus.
+ */
+export function pickSurpriseBonusToasts(
+  rows: readonly XpTransactionRow[]
+): number[] {
+  const bonuses = rows.filter(
+    (r) =>
+      r.reason != null &&
+      isSurpriseBonusReason(r.reason) &&
+      r.amount != null &&
+      r.amount > 0
+  );
+
+  if (!hasInitialized()) {
+    const seen = readSeen();
+    for (const r of bonuses) seen.add(surpriseKey(r));
+    markInitialized(seen);
+    return [];
+  }
+
+  const out: number[] = [];
+  for (const r of bonuses) {
+    if (claimSurpriseBonus(surpriseKey(r))) out.push(r.amount as number);
+  }
+  return out;
+}
+
+/** Test-only: clear both the quest and surprise session dedupe state. */
+export function __resetServerXpFeedbackForTests(): void {
+  firedQuestKeys.clear();
+  memSeen.clear();
+  memInit = false;
+  const s = store();
+  if (s) {
+    try {
+      s.removeItem(SURPRISE_SEEN_KEY);
+      s.removeItem(SURPRISE_INIT_KEY);
+    } catch {
+      // ignore
+    }
+  }
+}

--- a/apps/web/src/lib/gamification/server-xp-feedback.ts
+++ b/apps/web/src/lib/gamification/server-xp-feedback.ts
@@ -141,6 +141,12 @@ export interface XpTransactionRow {
 }
 
 function surpriseKey(r: XpTransactionRow): string {
+  // KEEP IN SYNC with the inline key in use-gamification-events.ts: both
+  // channels share claimSurpriseBonus's seen-set, so they must derive the SAME
+  // key for the same award. maybeAwardSurpriseBonus always sets
+  // idempotency_key, so the fallback below is dead today — but if it ever
+  // becomes optional, both sites' fallbacks must stay aligned or a bonus would
+  // toast twice (once per path).
   return r.idempotency_key ?? `${r.tx_signature ?? ""}:${r.created_at ?? ""}`;
 }
 

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -426,6 +426,7 @@
     "xpRemaining": "<em>{xp} {xpLabel}</em> to {levelLabel} {level}",
     "xpTooltip": "{xp} {xpLabel} to {levelLabel} {level}",
     "surpriseBonus": "Surprise bonus! +{amount} XP",
+    "questReward": "Quest complete: {name} +{amount} XP",
     "league": "League",
     "global": "Global",
     "leagueSubtitle": "Your weekly cohort — this week's standings",

--- a/apps/web/src/messages/es.json
+++ b/apps/web/src/messages/es.json
@@ -426,6 +426,7 @@
     "xpRemaining": "<em>{xp} {xpLabel}</em> para {levelLabel} {level}",
     "xpTooltip": "{xp} {xpLabel} para {levelLabel} {level}",
     "surpriseBonus": "¡Bono sorpresa! +{amount} XP",
+    "questReward": "Misión completada: {name} +{amount} XP",
     "league": "Liga",
     "global": "Global",
     "leagueSubtitle": "Tu grupo de la semana — la clasificación de esta semana",

--- a/apps/web/src/messages/pt-BR.json
+++ b/apps/web/src/messages/pt-BR.json
@@ -426,6 +426,7 @@
     "xpRemaining": "<em>{xp} {xpLabel}</em> para {levelLabel} {level}",
     "xpTooltip": "{xp} {xpLabel} para {levelLabel} {level}",
     "surpriseBonus": "Bônus surpresa! +{amount} XP",
+    "questReward": "Missão concluída: {name} +{amount} XP",
     "league": "Liga",
     "global": "Global",
     "leagueSubtitle": "Seu grupo da semana — a classificação desta semana",

--- a/packages/types/src/progress.ts
+++ b/packages/types/src/progress.ts
@@ -113,6 +113,14 @@ export interface DailyQuest {
   currentValue: number;
   completed: boolean;
   resetType: "daily" | "multi_day";
+  /**
+   * True on the SINGLE poll of /api/quests/daily where this quest's XP was just
+   * granted (mirrors `v_just_awarded` in get_daily_quest_state — the server
+   * flips it once, when xp_granted goes false→true). Drives the one-time XP
+   * toast (#790); every later poll returns false. Absent on quests fetched
+   * outside that endpoint.
+   */
+  justAwarded?: boolean;
 }
 
 export interface LearningProgressService {


### PR DESCRIPTION
Closes #790. Server-granted XP landed silently — daily-quest rewards (+25/+35) and surprise bonuses (+40) moved the header number with no toast/confetti, so the owner couldn't tell why. This wires both into the **existing** toast/celebration machinery, riding the responses the dashboard **already polls** — no new push channel, no new XP paths.

## Daily quests
`/api/quests/daily` already computes `justAwarded` per quest (`v_just_awarded`, flipped true on the single poll where `xp_granted` goes false→true) but **dropped it**. Now it's surfaced (`DailyQuest.justAwarded`), and the dashboard poll fires the XP counter (`dispatchXpGain`) + a success toast (new `gamification.questReward`, ×3 locales) on that poll.

**Dedupe:** in-memory `Set` keyed on `questId + period`. Safe by construction — the server flips `justAwarded` **false** after that first poll, so a reload re-polls and simply gets `false`; the client Set is belt-and-suspenders against same-session re-processing.

## Surprise bonus
Detected from the recent `xp_transactions` the dashboard already fetches, firing the **existing** surprise-bonus toast + `celebrate("surprise-bonus")` (its i18n string + "none" confetti tier already existed).

The tricky part, handled: surprise rows are **permanent** (no one-shot flag like `justAwarded`), so a naive re-scan would re-toast on every reload. The seen-set is therefore **sessionStorage-backed** and **seeded silently on first observation per tab** — existing bonuses are marked seen without toasting (no stale storm on load); only bonuses that appear on a **later** poll toast. The set is **shared with the Realtime path** (`use-gamification-events`) via `claimSurpriseBonus`, so whichever channel sees an award first toasts and the other is a no-op — **never a double toast** when both are live.

## Dedupe design (summary)
| signal | source | dedupe | why |
|---|---|---|---|
| quest reward | `/api/quests/daily` `justAwarded` | in-memory Set, `questId:period` | server is one-shot (justAwarded→false) |
| surprise bonus | recent `xp_transactions` scan | **sessionStorage** set + seed-silent-on-init, shared with Realtime | rows are permanent ⇒ must survive reload + not storm on first load |

## a11y & i18n
- Toasts announce via the existing `aria-live="polite"` ToastContainer.
- New `questReward` string in en / pt-BR / es.

## Tests (`server-xp-feedback.test.ts`, 8)
justAwarded → toast once; re-poll → no dup; no-award → nothing; new-day re-toasts; surprise **seeds silently** then toasts a newly-appeared bonus once; shared-dedupe with the Realtime `claimSurpriseBonus`; idempotency_key fallback.

## Verify
- `pnpm typecheck` — green (6/6)
- `pnpm --filter web test` — 215 files / 1976 tests pass
- `pnpm --filter web lint` — clean

## Note for the gate
The surprise-bonus toast was **already** wired via Supabase Realtime (`use-gamification-events`); its prod silence most likely means the `20260630120000_enable_realtime_gamification` publication migration isn't applied there (the #708/#750 ledger-divergence family). This PR makes both feedbacks work **regardless** of Realtime by also riding the deterministic poll — worth verifying that migration's application separately.


---

## Round 2 (gate bounce fix) — head 0b74a13

**Fix:** `dispatchXpGain(amount)` added inside the poll-detected surprise-bonus loop in `use-dashboard-data.ts`, symmetric with the quest-reward loop and the Realtime handler — the header XP counter now animates on the poll path (the only live channel today per #797).

**Red-proof (rule 2), independently replayed by the orchestrator:** new regression test `use-dashboard-data.test.tsx > useDashboardData — poll-detected surprise bonus > dispatches an xp-gain for a surprise bonus the poll newly detects` run against **bfe038b** (pre-fix) fails with `AssertionError: expected "vi.fn()" to be called with arguments: [ 25 ] — Number of calls: 0` (the test first awaits `dispatchSurpriseBonus(25)`, proving the poll path executed in the buggy build). Green at this head.

**Also (reviewer non-blocking):** keep-in-sync comments added at BOTH divergent dedupe-key fallback sites (`surpriseKey()` in `server-xp-feedback.ts` and the inline key in `use-gamification-events.ts`).

**Verified at 0b74a13 (agent + orchestrator re-run in clean clone):** typecheck 6/6 workspaces; web suite **216 files / 1977 tests** (+1 file/+1 test = the regression test); content-schema 170, content-lint 107, deploy 18.

**#797 update superseding the "Note for the gate" above:** publication-missing theory ruled out by gate prod SQL; root cause diagnosed as anon Realtime socket + own-row RLS — see the diagnosis on #797.


---

## Round 3 (gate bounce fix) — head 852f705

**Fix:** the sessionStorage dedupe keys (surprise-bonus seen-set + init flag, AND `firedQuestKeys`) are now namespaced by the authenticated user id (`${KEY}:${userId ?? ""}`). A user id with no init flag seeds silently exactly like a fresh tab — that IS the re-seed-on-account-switch, with no explicit change detection to get wrong. Absent id (SSR/anon) collapses to the single `""` namespace, so single-user behavior is byte-identical; all round-1/2 helper tests unchanged and green. `userId` is an optional trailing param threaded from both the poll path (`use-dashboard-data.ts`) and the Realtime path (`use-gamification-events.ts`).

**Red-proof (rule 2), independently replayed by the orchestrator:** regression test `use-dashboard-data.test.tsx > … > re-seeds silently for a new user — never storms user B with their own history` run against **0b74a13** (pre-fix) fails with `AssertionError: expected "vi.fn()" to not be called at all, but actually been called 2 times` (calls: [20], [35] — user B inheriting user A's global init flag toasts B's entire history). Green at this head.

**Verified at 852f705 (agent + orchestrator re-run in clean clone):** typecheck 6/6; web suite **216 files / 1978 tests** (+1 test vs round 2).
