### PR TITLE
fix(leaderboard): dedupe 'this week' + enumerate course completions in scoring tooltip (#793)

### DIFF
--- a/apps/web/src/app/[locale]/(platform)/leaderboard/__tests__/leaderboard-client.test.tsx
+++ b/apps/web/src/app/[locale]/(platform)/leaderboard/__tests__/leaderboard-client.test.tsx
@@ -70,6 +70,9 @@ describe("LeaderboardClient — league framing + scoring info (#789)", () => {
     const copy = messages.gamification.leagueScoringInfo;
     expect(copy).toMatch(/this week/i);
     expect(copy).toMatch(/lessons/i);
+    // course_completion is an is_league_eligible_source — the enumeration must
+    // name every eligible source, not silently omit one (#793).
+    expect(copy).toMatch(/course completions/i);
     expect(copy).toMatch(/[Bb]onuses.*(don't|do not) count/);
   });
 

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -428,7 +428,7 @@
     "surpriseBonus": "Surprise bonus! +{amount} XP",
     "league": "League",
     "global": "Global",
-    "leagueSubtitle": "Your weekly cohort — this week's standings",
+    "leagueSubtitle": "Your weekly cohort — live standings",
     "globalSubtitle": "All-time XP across everyone",
     "leagueTier1": "Seed League",
     "leagueTier2": "Sprout League",
@@ -444,7 +444,7 @@
     "leagueThisWeek": "This week",
     "leagueScoreAria": "{score} XP earned this week",
     "leagueScoringInfoLabel": "About league scoring",
-    "leagueScoringInfo": "League scores count learning XP earned this week — lessons, challenges, quests, and achievements. Bonuses and community XP don't count."
+    "leagueScoringInfo": "League scores count learning XP earned this week — lessons, challenges, course completions, quests, and achievements. Bonuses and community XP don't count."
   },
   "certificates": {
     "title": "Certificate of Completion",

--- a/apps/web/src/messages/es.json
+++ b/apps/web/src/messages/es.json
@@ -428,7 +428,7 @@
     "surpriseBonus": "¡Bono sorpresa! +{amount} XP",
     "league": "Liga",
     "global": "Global",
-    "leagueSubtitle": "Tu grupo de la semana — la clasificación de esta semana",
+    "leagueSubtitle": "Tu grupo de la semana — la clasificación actual",
     "globalSubtitle": "XP de todos los tiempos entre todos",
     "leagueTier1": "Liga Semilla",
     "leagueTier2": "Liga Brote",
@@ -444,7 +444,7 @@
     "leagueThisWeek": "Esta semana",
     "leagueScoreAria": "{score} XP ganados esta semana",
     "leagueScoringInfoLabel": "Sobre la puntuación de la liga",
-    "leagueScoringInfo": "La puntuación de la liga cuenta el XP de aprendizaje ganado esta semana — lecciones, desafíos, misiones y logros. Las bonificaciones y el XP de la comunidad no cuentan."
+    "leagueScoringInfo": "La puntuación de la liga cuenta el XP de aprendizaje ganado esta semana — lecciones, desafíos, cursos completados, misiones y logros. Las bonificaciones y el XP de la comunidad no cuentan."
   },
   "certificates": {
     "title": "Certificado de Finalización",

--- a/apps/web/src/messages/pt-BR.json
+++ b/apps/web/src/messages/pt-BR.json
@@ -428,7 +428,7 @@
     "surpriseBonus": "Bônus surpresa! +{amount} XP",
     "league": "Liga",
     "global": "Global",
-    "leagueSubtitle": "Seu grupo da semana — a classificação desta semana",
+    "leagueSubtitle": "Seu grupo da semana — a classificação atual",
     "globalSubtitle": "XP de todos os tempos entre todos",
     "leagueTier1": "Liga Semente",
     "leagueTier2": "Liga Broto",
@@ -444,7 +444,7 @@
     "leagueThisWeek": "Esta semana",
     "leagueScoreAria": "{score} XP ganhos esta semana",
     "leagueScoringInfoLabel": "Sobre a pontuação da liga",
-    "leagueScoringInfo": "A pontuação da liga conta o XP de aprendizado ganho esta semana — aulas, desafios, missões e conquistas. Bônus e XP da comunidade não contam."
+    "leagueScoringInfo": "A pontuação da liga conta o XP de aprendizado ganho esta semana — aulas, desafios, cursos concluídos, missões e conquistas. Bônus e XP da comunidade não contam."
   },
   "certificates": {
     "title": "Certificado de Conclusão",


### PR DESCRIPTION
Closes #793 (gate-filed follow-up to #792; presentation-only).

## Changes
1. **Dedupe "this week"** — kept the info-bearing dynamic `lb-league-sub` line ("This week · N learners · resets Monday"); reworded `leagueSubtitle` to drop the duplicate: en "Your weekly cohort — live standings", es "…la clasificación actual", pt-BR "…a classificação atual".
2. **Scoring tooltip enumerates all eligible sources** — `leagueScoringInfo` now lists lessons, challenges, **course completions**, quests, achievements (all 3 locales). Cross-checked against `is_league_eligible_source()` (20260726200000_cohort_leagues.sql:97): allowlist is exactly `('lesson','course_completion','quest','achievement')` — `course_completion` was the only omission. "Challenges" deliberately KEPT in copy though not a distinct source: there is no `'challenge'` source (20260726120000:53-55); challenges complete as lessons via on-chain `complete_lesson`, so they score under `lesson` — user-facing detail, not a scoring claim error.
3. Drift-guard assertion added to the existing #789 leaderboard test (tooltip must mention course completions), matching that test's can't-silently-drift intent.

## Verification (agent + orchestrator re-run at head in clean worktree)
- typecheck 6/6 workspaces
- web suite **217 files / 1981 tests** green (includes updated leaderboard test)
- No schema/query changes; messages + one test file only.
