### PR TITLE
test: fix stale deleted-course refs in achievements-raw 'deployed' array (#801)

### DIFF
--- a/apps/web/src/lib/content/__tests__/fixtures/golden/achievements-raw.json
+++ b/apps/web/src/lib/content/__tests__/fixtures/golden/achievements-raw.json
@@ -217,7 +217,7 @@
     {
       "_id": "achievement-anchor-expert",
       "award": {
-        "course": "course-anchor-framework",
+        "course": "course-building-first-program",
         "days": null,
         "gte": null,
         "kind": "course-completed",
@@ -274,7 +274,7 @@
     {
       "_id": "achievement-course-completer",
       "award": {
-        "course": "course-solana-fundamentals",
+        "course": "course-rust-for-program-devs",
         "days": null,
         "gte": null,
         "kind": "course-completed",
@@ -380,7 +380,7 @@
     {
       "_id": "achievement-rust-rookie",
       "award": {
-        "course": "course-rust-for-solana",
+        "course": "course-rust-for-program-devs",
         "days": null,
         "gte": 1,
         "kind": "lessons-completed-in-course",


### PR DESCRIPTION
Closes #801 (deferred non-blocking finding from #798's review).

Retargets the 3 stale `award.course` refs in the consumer-less `deployed` array to match the already-patched `all` array (anchor-expert → course-building-first-program; course-completer + rust-rookie → course-rust-for-program-devs), making the fixture internally consistent. Node-verified: `all` and `deployed` now agree for all 3 ids; `project.golden.test.ts` 19/19 at head. 3-line diff, fixture only.