### PR TITLE
fix(gamification): authenticate the Realtime socket before subscribe (#800)

### DIFF
--- a/apps/web/src/hooks/__tests__/use-gamification-events.test.tsx
+++ b/apps/web/src/hooks/__tests__/use-gamification-events.test.tsx
@@ -1,18 +1,32 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { renderHook, act } from "@testing-library/react";
-import { useGamificationEvents } from "../use-gamification-events";
+import { renderHook, act, waitFor } from "@testing-library/react";
 import {
   resetAnalyticsEventDedupeForTests,
   trackCredentialMinted,
 } from "@/lib/analytics/events";
+import {
+  pickSurpriseBonusToasts,
+  __resetServerXpFeedbackForTests,
+} from "@/lib/gamification/server-xp-feedback";
+import { useGamificationEvents } from "../use-gamification-events";
 
-// Real events module between hook and facade — asserts the wire format AND
-// the cross-path dedupe with the manual-mint observation.
+// Real events + server-xp-feedback modules between hook and facades — asserts
+// the wire format, the cross-path dedupe with the manual-mint observation, AND
+// the shared surprise-bonus dedupe with the #796 dashboard poll.
 const h = vi.hoisted(() => ({
   trackEvent: vi.fn(),
   dispatchCertificateMinted: vi.fn(),
+  dispatchSurpriseBonus: vi.fn(),
   handlers: new Map<string, (payload: unknown) => void>(),
+  // Realtime auth plumbing (#800)
+  getSession: vi.fn(),
+  setAuth: vi.fn(async (_token?: string | null) => {}),
+  authCallback: null as ((event: string, session: unknown) => void) | null,
+  authUnsubscribe: vi.fn(),
+  // Ordered log of auth/subscribe operations so tests can assert setAuth
+  // happens BEFORE subscribe.
+  order: [] as string[],
 }));
 
 vi.mock("@/lib/analytics", () => ({ trackEvent: h.trackEvent }));
@@ -27,6 +41,9 @@ vi.mock("@/components/gamification/certificate-popup", () => ({
 vi.mock("@/components/gamification/level-up-popup", () => ({
   dispatchLevelUp: vi.fn(),
 }));
+vi.mock("@/components/gamification/surprise-bonus-toast", () => ({
+  dispatchSurpriseBonus: h.dispatchSurpriseBonus,
+}));
 
 vi.mock("@/lib/supabase/client", () => ({
   createClient: () => {
@@ -39,7 +56,10 @@ vi.mock("@/lib/supabase/client", () => ({
         h.handlers.set(`${filter.table}:${filter.event}`, callback);
         return channel;
       },
-      subscribe: () => channel,
+      subscribe: () => {
+        h.order.push("subscribe");
+        return channel;
+      },
     };
     return {
       from: () => ({
@@ -51,28 +71,131 @@ vi.mock("@/lib/supabase/client", () => ({
       }),
       channel: () => channel,
       removeChannel: vi.fn(),
+      auth: {
+        getSession: h.getSession,
+        onAuthStateChange: (cb: (event: string, session: unknown) => void) => {
+          h.authCallback = cb;
+          return {
+            data: { subscription: { unsubscribe: h.authUnsubscribe } },
+          };
+        },
+      },
+      realtime: {
+        setAuth: (token?: string | null) => {
+          h.order.push(`setAuth:${token}`);
+          return h.setAuth(token);
+        },
+      },
     };
   },
 }));
+
+const SESSION = {
+  data: { session: { access_token: "tok-1", user: { id: "user-1" } } },
+};
 
 function certInsert(id: string, courseId: string): unknown {
   return { new: { id, course_id: courseId, user_id: "user-1" } };
 }
 
+async function mountHook(userId = "user-1") {
+  const utils = renderHook(() => useGamificationEvents(userId));
+  // The effect is now async (getSession → setAuth → subscribe); flush the
+  // microtask chain so the channel is subscribed and handlers registered.
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+  return utils;
+}
+
+async function waitForHandler(
+  key: string
+): Promise<(payload: unknown) => void> {
+  let cb: ((payload: unknown) => void) | undefined;
+  await waitFor(() => {
+    cb = h.handlers.get(key);
+    expect(cb).toBeDefined();
+  });
+  return cb as (payload: unknown) => void;
+}
+
 beforeEach(() => {
   h.trackEvent.mockClear();
   h.dispatchCertificateMinted.mockClear();
+  h.dispatchSurpriseBonus.mockClear();
+  h.setAuth.mockClear();
+  h.authUnsubscribe.mockClear();
+  h.getSession.mockReset();
+  h.getSession.mockResolvedValue(SESSION);
+  h.authCallback = null;
   h.handlers.clear();
+  h.order.length = 0;
   resetAnalyticsEventDedupeForTests();
+  __resetServerXpFeedbackForTests();
+});
+
+describe("useGamificationEvents — Realtime socket auth (#800)", () => {
+  it("calls realtime.setAuth with the session token BEFORE subscribing", async () => {
+    await mountHook();
+    await waitFor(() => expect(h.order).toContain("subscribe"));
+
+    expect(h.setAuth).toHaveBeenCalledWith("tok-1");
+    const setAuthIdx = h.order.indexOf("setAuth:tok-1");
+    const subscribeIdx = h.order.indexOf("subscribe");
+    expect(setAuthIdx).toBeGreaterThanOrEqual(0);
+    expect(subscribeIdx).toBeGreaterThan(setAuthIdx);
+  });
+
+  it("re-authenticates the socket on TOKEN_REFRESHED and SIGNED_IN", async () => {
+    await mountHook();
+    await waitFor(() => expect(h.authCallback).toBeTypeOf("function"));
+    h.setAuth.mockClear();
+
+    act(() =>
+      h.authCallback?.("TOKEN_REFRESHED", {
+        access_token: "tok-2",
+        user: { id: "user-1" },
+      })
+    );
+    expect(h.setAuth).toHaveBeenCalledWith("tok-2");
+
+    act(() =>
+      h.authCallback?.("SIGNED_IN", {
+        access_token: "tok-3",
+        user: { id: "user-1" },
+      })
+    );
+    expect(h.setAuth).toHaveBeenCalledWith("tok-3");
+
+    // Unrelated events (e.g. SIGNED_OUT) must not re-set the socket token.
+    h.setAuth.mockClear();
+    act(() => h.authCallback?.("SIGNED_OUT", null));
+    expect(h.setAuth).not.toHaveBeenCalled();
+  });
+
+  it("unsubscribes the auth listener on cleanup", async () => {
+    const { unmount } = await mountHook();
+    await waitFor(() => expect(h.authCallback).toBeTypeOf("function"));
+    unmount();
+    expect(h.authUnsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it("degrades gracefully with no session: no setAuth, still subscribes", async () => {
+    h.getSession.mockResolvedValue({ data: { session: null } });
+    await mountHook();
+    await waitFor(() => expect(h.order).toContain("subscribe"));
+    expect(h.setAuth).not.toHaveBeenCalled();
+  });
 });
 
 describe("useGamificationEvents — credential_minted (Realtime INSERT path)", () => {
-  it("fires credential_minted with the row's course id on a certificates INSERT", () => {
-    renderHook(() => useGamificationEvents("user-1"));
-    const onCertInsert = h.handlers.get("certificates:INSERT");
-    expect(onCertInsert).toBeDefined();
+  it("fires credential_minted with the row's course id on a certificates INSERT", async () => {
+    await mountHook();
+    const onCertInsert = await waitForHandler("certificates:INSERT");
 
-    act(() => onCertInsert?.(certInsert("cert-1", "course-solana-101")));
+    act(() => onCertInsert(certInsert("cert-1", "course-solana-101")));
 
     expect(h.trackEvent).toHaveBeenCalledTimes(1);
     expect(h.trackEvent).toHaveBeenCalledWith("credential_minted", {
@@ -82,24 +205,24 @@ describe("useGamificationEvents — credential_minted (Realtime INSERT path)", (
     expect(h.dispatchCertificateMinted).toHaveBeenCalledWith("cert-1");
   });
 
-  it("ignores Realtime replays of the same row", () => {
-    renderHook(() => useGamificationEvents("user-1"));
-    const onCertInsert = h.handlers.get("certificates:INSERT");
+  it("ignores Realtime replays of the same row", async () => {
+    await mountHook();
+    const onCertInsert = await waitForHandler("certificates:INSERT");
 
-    act(() => onCertInsert?.(certInsert("cert-1", "course-solana-101")));
-    act(() => onCertInsert?.(certInsert("cert-1", "course-solana-101")));
+    act(() => onCertInsert(certInsert("cert-1", "course-solana-101")));
+    act(() => onCertInsert(certInsert("cert-1", "course-solana-101")));
 
     expect(h.trackEvent).toHaveBeenCalledTimes(1);
     expect(h.dispatchCertificateMinted).toHaveBeenCalledTimes(1);
   });
 
-  it("does not double-fire when the manual mint already observed this mint", () => {
-    renderHook(() => useGamificationEvents("user-1"));
-    const onCertInsert = h.handlers.get("certificates:INSERT");
+  it("does not double-fire when the manual mint already observed this mint", async () => {
+    await mountHook();
+    const onCertInsert = await waitForHandler("certificates:INSERT");
 
     // Manual-mint success (course-completion-mint.tsx) fired moments earlier.
     trackCredentialMinted("course-solana-101", "manual_mint");
-    act(() => onCertInsert?.(certInsert("cert-1", "course-solana-101")));
+    act(() => onCertInsert(certInsert("cert-1", "course-solana-101")));
 
     const mintEvents = h.trackEvent.mock.calls.filter(
       (call) => call[0] === "credential_minted"
@@ -111,5 +234,51 @@ describe("useGamificationEvents — credential_minted (Realtime INSERT path)", (
     });
     // The popup still shows — only the analytics event is deduped.
     expect(h.dispatchCertificateMinted).toHaveBeenCalledWith("cert-1");
+  });
+});
+
+describe("useGamificationEvents — surprise bonus no-double-toast invariant", () => {
+  it("fires only ONE toast when the authed Realtime path and the #796 poll see the same award", async () => {
+    // Seed the tab: the first poll observation silently marks existing history
+    // seen, so subsequent claims of a NEW award are the ones that would toast.
+    // Same userId the hook uses so both paths share the per-user dedupe (#796).
+    pickSurpriseBonusToasts([], "user-1");
+
+    await mountHook();
+    const onXpInsert = await waitForHandler("xp_transactions:INSERT");
+
+    // Authed Realtime delivers the surprise bonus first → toasts once and
+    // claims the shared key.
+    act(() =>
+      onXpInsert({
+        new: {
+          id: "xtx-1",
+          amount: 25,
+          reason: "surprise_bonus:lesson-what-is-a-pda",
+          tx_signature: "sig-1",
+          idempotency_key: "sb-1",
+        },
+      })
+    );
+    expect(h.dispatchSurpriseBonus).toHaveBeenCalledTimes(1);
+    expect(h.dispatchSurpriseBonus).toHaveBeenCalledWith(25);
+
+    // #796 dashboard poll then re-scans recent transactions and sees the SAME
+    // award (same idempotency_key). The shared claimSurpriseBonus dedupe must
+    // make it a no-op — no second toast amount.
+    const pollToasts = pickSurpriseBonusToasts(
+      [
+        {
+          reason: "surprise_bonus:lesson-what-is-a-pda",
+          amount: 25,
+          tx_signature: "sig-1",
+          idempotency_key: "sb-1",
+          created_at: new Date().toISOString(),
+        },
+      ],
+      "user-1"
+    );
+    expect(pollToasts).toEqual([]);
+    expect(h.dispatchSurpriseBonus).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/src/hooks/use-gamification-events.ts
+++ b/apps/web/src/hooks/use-gamification-events.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef } from "react";
+import type { RealtimeChannel } from "@supabase/supabase-js";
 import { trackCredentialMinted } from "@/lib/analytics/events";
 import { createClient } from "@/lib/supabase/client";
 import { celebrate } from "@/lib/gamification/celebration";
@@ -43,6 +44,12 @@ export function useGamificationEvents(userId: string | undefined) {
     if (!userId) return;
 
     const supabase = createClient();
+    // The effect is async now (we await the session before subscribing), so a
+    // component that unmounts mid-await must not leave a dangling channel or
+    // subscribe after teardown. `cancelled` guards the await points; `channel`
+    // is assigned only once the socket is authed and subscribed.
+    let cancelled = false;
+    let channel: RealtimeChannel | null = null;
 
     // Seed the ref with the current level so the first UPDATE doesn't false-trigger.
     // Guard: only write the seed if no Realtime event has already set the ref —
@@ -58,159 +65,196 @@ export function useGamificationEvents(userId: string | undefined) {
         }
       });
 
-    const channel = supabase
-      .channel(`gamification:${userId}`)
-      // XP changes → detect level-up via local ref comparison
-      .on(
-        "postgres_changes",
-        {
-          event: "UPDATE",
-          schema: "public",
-          table: "user_xp",
-          filter: `user_id=eq.${userId}`,
-        },
-        (payload) => {
-          const newLevel = (payload.new as { level?: number }).level ?? 0;
-          const previousLevel = lastKnownLevelRef.current;
-          // Only celebrate a genuine increase — the ref starts null until the
-          // seed query resolves, so the first UPDATE can't false-trigger.
-          if (previousLevel !== null && newLevel > previousLevel) {
-            dispatchLevelUp(newLevel);
-          }
-          lastKnownLevelRef.current = newLevel;
-        }
-      )
-      // New XP transactions → XP popup (or enrich achievement popup)
-      .on(
-        "postgres_changes",
-        {
-          event: "INSERT",
-          schema: "public",
-          table: "xp_transactions",
-          filter: `user_id=eq.${userId}`,
-        },
-        (payload) => {
-          const row = payload.new as {
-            id?: string;
-            amount?: number;
-            reason?: string;
-            tx_signature?: string;
-            idempotency_key?: string;
-          };
+    // Authenticate the Realtime socket BEFORE subscribing. The browser client's
+    // socket otherwise joins as `anon`, and own-row RLS on xp_transactions (and
+    // the other gamification tables) then filters every event server-side while
+    // the channel still reports SUBSCRIBED — so no popup ever fires. Awaiting
+    // the session here also closes a hydration race: the subscribe used to run
+    // synchronously on mount, before the cookie session had been recovered.
+    async function connect() {
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
+      if (cancelled) return;
+      // No session → leave the socket anon (graceful degrade); own-row RLS
+      // yields nothing but the hook still subscribes without erroring.
+      if (session?.access_token) {
+        await supabase.realtime.setAuth(session.access_token);
+        if (cancelled) return;
+      }
 
-          // Deduplicate by row id (primary defence) or tx_signature (fallback)
-          const dedupeKey = row.id ?? row.tx_signature;
-          if (dedupeKey) {
-            if (seenIdsRef.current.has(dedupeKey)) return;
-            seenIdsRef.current.add(dedupeKey);
-            setTimeout(() => seenIdsRef.current.delete(dedupeKey), 15_000);
-          }
-
-          const amount = row.amount;
-          if (!amount || amount <= 0) return;
-
-          // Achievement XP → enrich the achievement popup instead of separate XP popup
-          const achievementMatch = row.reason?.match(
-            /^Achievement reward: (.+)$/
-          );
-          if (achievementMatch?.[1]) {
-            dispatchAchievementXp(achievementMatch[1], amount);
-            dispatchXpGain(amount);
-            return;
-          }
-
-          // Daily quest XP → suppress popup (quests panel already shows the reward)
-          if (row.reason?.startsWith("daily_quest:")) return;
-
-          // Surprise bonus (LX-B15) → informational toast (never confetti). The
-          // reward only surfaces here, AFTER it is granted server-side — there
-          // is no pre-announcement anywhere in the UI. Localization happens in
-          // the mounted SurpriseBonusToastListener (inside the intl provider).
-          // #790: the dashboard poll also detects surprise bonuses (for sessions
-          // where Realtime isn't delivering); claimSurpriseBonus is a session
-          // dedupe SHARED with that path, so whichever fires first wins and the
-          // other is a no-op — never a double toast.
-          if (row.reason && isSurpriseBonusReason(row.reason)) {
-            // KEEP IN SYNC with surpriseKey() in server-xp-feedback.ts: both
-            // channels share claimSurpriseBonus's seen-set, so they must derive
-            // the SAME key for the same award. maybeAwardSurpriseBonus always
-            // sets idempotency_key, so the fallbacks below are dead today — but
-            // if it ever becomes optional, both sites' fallbacks must stay
-            // aligned or a bonus would toast twice (once per path).
-            if (
-              claimSurpriseBonus(
-                row.idempotency_key ?? row.id ?? row.tx_signature ?? "",
-                userId
-              )
-            ) {
-              celebrate("surprise-bonus");
-              dispatchSurpriseBonus(amount);
+      channel = supabase
+        .channel(`gamification:${userId}`)
+        // XP changes → detect level-up via local ref comparison
+        .on(
+          "postgres_changes",
+          {
+            event: "UPDATE",
+            schema: "public",
+            table: "user_xp",
+            filter: `user_id=eq.${userId}`,
+          },
+          (payload) => {
+            const newLevel = (payload.new as { level?: number }).level ?? 0;
+            const previousLevel = lastKnownLevelRef.current;
+            // Only celebrate a genuine increase — the ref starts null until the
+            // seed query resolves, so the first UPDATE can't false-trigger.
+            if (previousLevel !== null && newLevel > previousLevel) {
+              dispatchLevelUp(newLevel);
             }
-            dispatchXpGain(amount);
-            return;
+            lastKnownLevelRef.current = newLevel;
           }
+        )
+        // New XP transactions → XP popup (or enrich achievement popup)
+        .on(
+          "postgres_changes",
+          {
+            event: "INSERT",
+            schema: "public",
+            table: "xp_transactions",
+            filter: `user_id=eq.${userId}`,
+          },
+          (payload) => {
+            const row = payload.new as {
+              id?: string;
+              amount?: number;
+              reason?: string;
+              tx_signature?: string;
+              idempotency_key?: string;
+            };
 
-          dispatchXpGain(amount);
-        }
-      )
-      // New achievements → achievement popup
-      .on(
-        "postgres_changes",
-        {
-          event: "INSERT",
-          schema: "public",
-          table: "user_achievements",
-          filter: `user_id=eq.${userId}`,
-        },
-        (payload) => {
-          const row = payload.new as {
-            id?: string;
-            achievement_id?: string;
-          };
-          const key = row.id ?? row.achievement_id;
-          if (key) {
-            if (seenIdsRef.current.has(key)) return;
-            seenIdsRef.current.add(key);
-            setTimeout(() => seenIdsRef.current.delete(key), 15_000);
+            // Deduplicate by row id (primary defence) or tx_signature (fallback)
+            const dedupeKey = row.id ?? row.tx_signature;
+            if (dedupeKey) {
+              if (seenIdsRef.current.has(dedupeKey)) return;
+              seenIdsRef.current.add(dedupeKey);
+              setTimeout(() => seenIdsRef.current.delete(dedupeKey), 15_000);
+            }
+
+            const amount = row.amount;
+            if (!amount || amount <= 0) return;
+
+            // Achievement XP → enrich the achievement popup instead of separate XP popup
+            const achievementMatch = row.reason?.match(
+              /^Achievement reward: (.+)$/
+            );
+            if (achievementMatch?.[1]) {
+              dispatchAchievementXp(achievementMatch[1], amount);
+              dispatchXpGain(amount);
+              return;
+            }
+
+            // Daily quest XP → suppress popup (quests panel already shows the reward)
+            if (row.reason?.startsWith("daily_quest:")) return;
+
+            // Surprise bonus (LX-B15) → informational toast (never confetti). The
+            // reward only surfaces here, AFTER it is granted server-side — there
+            // is no pre-announcement anywhere in the UI. Localization happens in
+            // the mounted SurpriseBonusToastListener (inside the intl provider).
+            // #790: the dashboard poll also detects surprise bonuses (for sessions
+            // where Realtime isn't delivering); claimSurpriseBonus is a session
+            // dedupe SHARED with that path, so whichever fires first wins and the
+            // other is a no-op — never a double toast.
+            if (row.reason && isSurpriseBonusReason(row.reason)) {
+              // KEEP IN SYNC with surpriseKey() in server-xp-feedback.ts: both
+              // channels share claimSurpriseBonus's seen-set, so they must derive
+              // the SAME key for the same award. maybeAwardSurpriseBonus always
+              // sets idempotency_key, so the fallbacks below are dead today — but
+              // if it ever becomes optional, both sites' fallbacks must stay
+              // aligned or a bonus would toast twice (once per path).
+              if (
+                claimSurpriseBonus(
+                  row.idempotency_key ?? row.id ?? row.tx_signature ?? "",
+                  userId
+                )
+              ) {
+                celebrate("surprise-bonus");
+                dispatchSurpriseBonus(amount);
+              }
+              dispatchXpGain(amount);
+              return;
+            }
+
+            dispatchXpGain(amount);
           }
-          if (row.achievement_id) {
-            const displayName = row.achievement_id
-              .replace(/_/g, " ")
-              .replace(/\b\w/g, (c) => c.toUpperCase());
-            dispatchAchievementUnlock(row.achievement_id, displayName);
+        )
+        // New achievements → achievement popup
+        .on(
+          "postgres_changes",
+          {
+            event: "INSERT",
+            schema: "public",
+            table: "user_achievements",
+            filter: `user_id=eq.${userId}`,
+          },
+          (payload) => {
+            const row = payload.new as {
+              id?: string;
+              achievement_id?: string;
+            };
+            const key = row.id ?? row.achievement_id;
+            if (key) {
+              if (seenIdsRef.current.has(key)) return;
+              seenIdsRef.current.add(key);
+              setTimeout(() => seenIdsRef.current.delete(key), 15_000);
+            }
+            if (row.achievement_id) {
+              const displayName = row.achievement_id
+                .replace(/_/g, " ")
+                .replace(/\b\w/g, (c) => c.toUpperCase());
+              dispatchAchievementUnlock(row.achievement_id, displayName);
+            }
           }
-        }
-      )
-      // New certificates → certificate popup
-      .on(
-        "postgres_changes",
-        {
-          event: "INSERT",
-          schema: "public",
-          table: "certificates",
-          filter: `user_id=eq.${userId}`,
-        },
-        (payload) => {
-          const row = payload.new as { id?: string; course_id?: string };
-          if (!row.id) return;
-          if (seenIdsRef.current.has(row.id)) return;
-          seenIdsRef.current.add(row.id);
-          const certId = row.id;
-          setTimeout(() => seenIdsRef.current.delete(certId), 15_000);
-          // credential_minted baseline (LX-F1) — the helper dedupes per
-          // course, so the manual-mint success firing moments earlier (or
-          // later) never double-counts the same mint.
-          if (row.course_id) {
-            trackCredentialMinted(row.course_id, "realtime");
+        )
+        // New certificates → certificate popup
+        .on(
+          "postgres_changes",
+          {
+            event: "INSERT",
+            schema: "public",
+            table: "certificates",
+            filter: `user_id=eq.${userId}`,
+          },
+          (payload) => {
+            const row = payload.new as { id?: string; course_id?: string };
+            if (!row.id) return;
+            if (seenIdsRef.current.has(row.id)) return;
+            seenIdsRef.current.add(row.id);
+            const certId = row.id;
+            setTimeout(() => seenIdsRef.current.delete(certId), 15_000);
+            // credential_minted baseline (LX-F1) — the helper dedupes per
+            // course, so the manual-mint success firing moments earlier (or
+            // later) never double-counts the same mint.
+            if (row.course_id) {
+              trackCredentialMinted(row.course_id, "realtime");
+            }
+            dispatchCertificateMinted(certId);
           }
-          dispatchCertificateMinted(certId);
-        }
-      )
-      .subscribe();
+        )
+        .subscribe();
+    }
+    void connect();
+
+    // Keep the socket authed across the page's lifetime. When GoTrue rotates
+    // the JWT (TOKEN_REFRESHED) or a sign-in completes on this page (SIGNED_IN),
+    // re-set the Realtime token so the connection doesn't silently fall back to
+    // filtering everything. This callback must stay synchronous — GoTrue awaits
+    // onAuthStateChange callbacks during init, and an async body that reached
+    // getSession would deadlock; setAuth takes the token straight off the event.
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((event, session) => {
+      if (event !== "TOKEN_REFRESHED" && event !== "SIGNED_IN") return;
+      if (session?.access_token) {
+        void supabase.realtime.setAuth(session.access_token);
+      }
+    });
 
     const seenIds = seenIdsRef.current;
     return () => {
-      supabase.removeChannel(channel);
+      cancelled = true;
+      subscription.unsubscribe();
+      if (channel) supabase.removeChannel(channel);
       seenIds.clear();
     };
   }, [userId]);


### PR DESCRIPTION
Closes #800. Originally stacked on #796; the gate merged #796 (squash 07547d5) while this was in verification, so the branch is now a single commit rebased directly onto main — same delta, verified at the rebased head.

## Fix (client-side only — RLS stays as-is, per #797's gate-confirmed root cause)
`use-gamification-events.ts`:
1. `connect()` is now async: `getSession()` → if a session exists, `await supabase.realtime.setAuth(session.access_token)` **before** building/subscribing the channel. Also closes the #797 hydration race (subscribe used to fire synchronously before the cookie session recovered).
2. `onAuthStateChange` re-calls `setAuth` on `TOKEN_REFRESHED` and `SIGNED_IN`; callback kept synchronous (GoTrue awaits these callbacks during init — reading the token off the event avoids a `getSession` deadlock).
3. Async-effect lifecycle: `cancelled` flag guards both await points; `channel` assigned only after auth+subscribe; cleanup cancels, unsubscribes the auth listener, and `removeChannel`s only if assigned. Event-handler bodies unchanged (re-indented only).
4. Anon path unchanged: no session → no `setAuth`, still subscribes, no errors.

**Placement**: in the hook, not the client factory — grep-confirmed this hook is the ONLY Realtime channel subscriber in `apps/web/src`; `createClient()` is a synchronous singleton used broadly by non-Realtime consumers.

## Red-proof (rule 2), independently replayed by the orchestrator
New tests run against pre-fix base **852f705** (= #796 round-3 content, now squashed into main as 07547d5): **3 failed | 5 passed** —
- `calls realtime.setAuth with the session token BEFORE subscribing` → `AssertionError: expected "vi.fn()" to be called with arguments: [ 'tok-1' ]`
- `re-authenticates the socket on TOKEN_REFRESHED and SIGNED_IN` → `expected null to be type of 'function'`
- `unsubscribes the auth listener on cleanup` → `expected null to be type of 'function'`
Green 8/8 at this head.

## No-double-toast invariant (interaction guard with #796, now on main)
Same user on both channels: Realtime INSERT with `idempotency_key "sb-1"` claims first → the poll path's `pickSurpriseBonusToasts` returns `[]` via the shared per-user seen-set; asserts exactly one `dispatchSurpriseBonus`. Mismatched userIds would fail it, so it genuinely guards the namespaced dedupe.

## Verified at ee8fa4b (orchestrator re-run in clean clone, post-rebase)
typecheck 6/6; web suite **219 files / 1996 tests**; target file 8/8.
