### PR TITLE
fix(challenge): cap the AI think-first lock against clock skew + test the lock (#770)

### DIFF
--- a/apps/web/src/components/editor/__tests__/challenge-interface.ai-lock.test.tsx
+++ b/apps/web/src/components/editor/__tests__/challenge-interface.ai-lock.test.tsx
@@ -1,0 +1,153 @@
+// @vitest-environment jsdom
+// AI Partner think-first lock wiring (#770): ChallengeInterface computes the
+// per-lesson unlock moment and hands it to the AiPartnerPane as `unlockAt`. The
+// open timestamp is persisted in localStorage so a reload cannot reset the
+// timer, already-complete lessons are exempt (unlockAt === null), and a stored
+// timestamp in the FUTURE (clock skew / tampering) is clamped so the lock can
+// never outlast the 3-minute window. The pane's rendering of the countdown is
+// covered in ai-partner/__tests__/ai-partner-pane.test.tsx; here we assert the
+// timestamp math + persistence by capturing the prop the pane receives.
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import messages from "@/messages/en.json";
+import { ChallengeInterface } from "../challenge-interface";
+
+const AI_LOCK_MS = 3 * 60 * 1000;
+
+vi.mock("../code-editor", async () => {
+  const { forwardRef } = await import("react");
+  return {
+    CodeEditor: forwardRef(function CodeEditorMock() {
+      return null;
+    }),
+    resetEditorStorage: vi.fn(),
+  };
+});
+
+vi.mock("../output-panel", () => ({ OutputPanel: () => null }));
+vi.mock("../challenge-runner", () => ({ ChallengeRunner: () => null }));
+
+// Capture the unlockAt the pane is handed, instead of rendering the real pane.
+vi.mock("../ai-partner/ai-partner-pane", async () => {
+  const { createElement } = await import("react");
+  return {
+    AiPartnerPane: (props: { unlockAt?: number | null }) =>
+      createElement("div", {
+        "data-testid": "ai-pane",
+        "data-unlockat": String(props.unlockAt),
+      }),
+  };
+});
+
+beforeEach(() => {
+  window.localStorage.clear();
+  // Sentinel observer that intersects immediately so the AI pane mounts on
+  // render (the reveal-on-scroll is not what these tests exercise).
+  vi.stubGlobal(
+    "IntersectionObserver",
+    class {
+      readonly root = null;
+      readonly rootMargin = "";
+      readonly thresholds: readonly number[] = [];
+      constructor(private readonly cb: IntersectionObserverCallback) {}
+      observe(): void {
+        this.cb(
+          [{ isIntersecting: true } as IntersectionObserverEntry],
+          this as unknown as IntersectionObserver
+        );
+      }
+      unobserve(): void {}
+      disconnect(): void {}
+      takeRecords(): IntersectionObserverEntry[] {
+        return [];
+      }
+    }
+  );
+});
+
+const LESSON_ID = "lesson-1";
+const STORAGE_KEY = `challenge:ai-open:${LESSON_ID}`;
+
+function renderInterface(props: { isAlreadyCompleted?: boolean } = {}) {
+  return render(
+    <NextIntlClientProvider locale="en" messages={messages}>
+      <ChallengeInterface
+        lessonId={LESSON_ID}
+        courseSlug="course"
+        lessonSlug="lesson"
+        initialCode=""
+        language="typescript"
+        tests={[]}
+        hints={[]}
+        xpReward={30}
+        {...props}
+      />
+    </NextIntlClientProvider>
+  );
+}
+
+function readUnlockAt(): number | null {
+  const raw = screen.getByTestId("ai-pane").getAttribute("data-unlockat");
+  return raw === "null" ? null : Number(raw);
+}
+
+describe("ChallengeInterface — AI think-first lock (#770)", () => {
+  it("locks a fresh challenge for 3 minutes and persists the open moment", () => {
+    const before = Date.now();
+    renderInterface();
+    const after = Date.now();
+
+    const unlockAt = readUnlockAt();
+    expect(unlockAt).not.toBeNull();
+    // Opened ~now, so it unlocks ~now + 3 min.
+    expect(unlockAt).toBeGreaterThanOrEqual(before + AI_LOCK_MS);
+    expect(unlockAt).toBeLessThanOrEqual(after + AI_LOCK_MS);
+
+    // The open moment was written so a reload can recover it.
+    const stored = Number(window.localStorage.getItem(STORAGE_KEY));
+    expect(stored).toBeGreaterThanOrEqual(before);
+    expect(stored).toBeLessThanOrEqual(after);
+  });
+
+  it("resumes from the stored open moment across a reload (no reset)", () => {
+    // Simulate a reload one minute into the lock: the timer must continue from
+    // the stored timestamp, not restart, so ~2 minutes remain.
+    const openedAt = Date.now() - 60 * 1000;
+    window.localStorage.setItem(STORAGE_KEY, String(openedAt));
+
+    renderInterface();
+
+    // Exactly stored + 3 min — proves the stored value drove the math.
+    expect(readUnlockAt()).toBe(openedAt + AI_LOCK_MS);
+    // Unchanged: a valid past timestamp is not rewritten.
+    expect(Number(window.localStorage.getItem(STORAGE_KEY))).toBe(openedAt);
+  });
+
+  it("exempts an already-completed lesson (no lock)", () => {
+    renderInterface({ isAlreadyCompleted: true });
+    expect(readUnlockAt()).toBeNull();
+  });
+
+  it("clamps a future stored timestamp so the lock cannot outlast 3 minutes", () => {
+    // A clock-skewed / tampered future value must not lock the tutor forever.
+    const future = Date.now() + 10 * 60 * 1000;
+    window.localStorage.setItem(STORAGE_KEY, String(future));
+
+    const before = Date.now();
+    renderInterface();
+    const after = Date.now();
+
+    const unlockAt = readUnlockAt();
+    expect(unlockAt).not.toBeNull();
+    // Capped at now + 3 min — never future + 3 min.
+    expect(unlockAt).toBeLessThanOrEqual(after + AI_LOCK_MS);
+    expect(unlockAt).toBeGreaterThanOrEqual(before + AI_LOCK_MS);
+    expect(unlockAt).toBeLessThan(future);
+
+    // The bogus future value is self-healed back to ~now.
+    const stored = Number(window.localStorage.getItem(STORAGE_KEY));
+    expect(stored).toBeLessThanOrEqual(after);
+    expect(stored).toBeGreaterThanOrEqual(before);
+  });
+});

--- a/apps/web/src/components/editor/ai-partner/__tests__/ai-partner-pane.test.tsx
+++ b/apps/web/src/components/editor/ai-partner/__tests__/ai-partner-pane.test.tsx
@@ -5,8 +5,8 @@
 // enforced one level up in ChallengeInterface, which does not mount this pane
 // at all while suppressed (see challenge-interface-ai-gate.test.tsx), so a
 // suppressed lesson can never surface this button.
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
 import { NextIntlClientProvider } from "next-intl";
 import messages from "@/messages/en.json";
 import { AiPartnerPane } from "../ai-partner-pane";
@@ -33,7 +33,11 @@ vi.mock("@/lib/ai/use-ai-partner", () => ({
 }));
 
 function renderPane(
-  props: { solutionPassed?: boolean; disabled?: boolean } = {}
+  props: {
+    solutionPassed?: boolean;
+    disabled?: boolean;
+    unlockAt?: number | null;
+  } = {}
 ) {
   return render(
     <NextIntlClientProvider locale="en" messages={messages}>
@@ -107,5 +111,51 @@ describe("AiPartnerPane — post-pass review button (LX-C9)", () => {
     hookState.budgetExhausted = true;
     renderPane({ solutionPassed: true });
     expect(screen.getByRole("button", { name: reviewLabel })).toBeDisabled();
+  });
+});
+
+describe("AiPartnerPane — think-first lock (#770)", () => {
+  const lockTitle = messages.aiPartner.lock.title;
+  const hintLabel = messages.aiPartner.actions.hint;
+  const THREE_MIN = 3 * 60 * 1000;
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("shows the lock banner with a live countdown and disables the actions while locked", () => {
+    // A fresh 3-minute lock renders a m:ss countdown in the localized body
+    // (~2:59/3:00 depending on the sub-ms gap to the pane's own Date.now()).
+    renderPane({ unlockAt: Date.now() + THREE_MIN });
+    expect(screen.getByText(lockTitle)).toBeInTheDocument();
+    expect(screen.getByText(/unlocks in \d:\d\d/)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: hintLabel })).toBeDisabled();
+  });
+
+  it("does not lock when unlockAt is null (completed lesson / no lock)", () => {
+    renderPane({ unlockAt: null });
+    expect(screen.queryByText(lockTitle)).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: hintLabel })).toBeEnabled();
+  });
+
+  it("does not lock when unlockAt is already in the past", () => {
+    renderPane({ unlockAt: Date.now() - 1000 });
+    expect(screen.queryByText(lockTitle)).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: hintLabel })).toBeEnabled();
+  });
+
+  it("counts down and unlocks once the window elapses", () => {
+    vi.useFakeTimers();
+    const start = Date.now();
+    renderPane({ unlockAt: start + 2000 });
+    expect(screen.getByText(lockTitle)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: hintLabel })).toBeDisabled();
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    expect(screen.queryByText(lockTitle)).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: hintLabel })).toBeEnabled();
   });
 });

--- a/apps/web/src/components/editor/challenge-interface.tsx
+++ b/apps/web/src/components/editor/challenge-interface.tsx
@@ -205,8 +205,13 @@ export function ChallengeInterface({
     }
     const key = `challenge:ai-open:${lessonId}`;
     const stored = Number(window.localStorage.getItem(key));
+    // A valid past timestamp is the real open moment. But a stored value in the
+    // FUTURE (a wrong device clock when it was written, or tampering) must never
+    // lock the tutor beyond the 3-min window, so clamp to now — remaining stays
+    // ≤ AI_LOCK_MS. The clamp also self-heals the stored value below.
+    const now = Date.now();
     const openedAt =
-      Number.isFinite(stored) && stored > 0 ? stored : Date.now();
+      Number.isFinite(stored) && stored > 0 ? Math.min(stored, now) : now;
     if (openedAt !== stored) {
       try {
         window.localStorage.setItem(key, String(openedAt));


### PR DESCRIPTION
Closes #770.

## Scope note (honest accounting)
Items 1, 2, 3, and 4 of the issue were implemented by David directly on main earlier today (`410e2ff` horizontal-scrollbar root cause = 100vw full-bleed incl. scrollbar gutter → `overflow-x-clip` on body; `dda1b19`+`6755558` viewport-fit layout; `b0b5adc` 3-min think-first lock + post-completion reference solution). This PR ships the two genuine gaps the loop's already-done check found in the lock:

1. **Clock-skew bug (source change, `challenge-interface.tsx`)**: the stored `challenge:ai-open:<lessonId>` timestamp fed `openedAt` unclamped, so a FUTURE stored value (bad device clock / tampering) yielded `unlockAt = future + 3min` — locking the tutor far beyond the intended window. Fix: `openedAt = Number.isFinite(stored) && stored > 0 ? Math.min(stored, now) : now`; the existing `openedAt !== stored` write self-heals the bad value. Remaining lock time can now never exceed 3 minutes.
2. **Zero unit coverage for the lock** — 9 tests added across `ai-partner-pane.test.tsx` (lock banner + live countdown + action disabling; null/past unlockAt no-lock; elapse-and-unlock with fake timers) and new `challenge-interface.ai-lock.test.tsx` (fresh challenge locks 3min + persists open moment; reload resumes from stored timestamp — no reset; completed-lesson exemption; future-timestamp clamp).

## Red-proof, independently replayed by the orchestrator
Both test files run against **main (bbfbb1b)**: `clamps a future stored timestamp so the lock cannot outlast 3 minutes` FAILS; the other 13 pass (they pin the already-merged behavior). Green 14/14 at this head — the clamp is the one genuine source change and its test was seen red.

## Verified at ee8bdc7 (agent + orchestrator re-run in clean clone)
typecheck 6/6; web suite **218 files / 1989 tests**. `pnpm build` compiles clean (page-data collection then stops at the documented local-env secret requirements — unrelated to this change). No visual claims made: no layout code touched.
