### PR TITLE
fix(gamification): harden Realtime setAuth — catch rejections, stale-token race guard, decouple test ticks (#806)

### DIFF
--- a/apps/web/src/hooks/__tests__/use-gamification-events.test.tsx
+++ b/apps/web/src/hooks/__tests__/use-gamification-events.test.tsx
@@ -100,13 +100,11 @@ function certInsert(id: string, courseId: string): unknown {
 
 async function mountHook(userId = "user-1") {
   const utils = renderHook(() => useGamificationEvents(userId));
-  // The effect is now async (getSession → setAuth → subscribe); flush the
-  // microtask chain so the channel is subscribed and handlers registered.
-  await act(async () => {
-    await Promise.resolve();
-    await Promise.resolve();
-    await Promise.resolve();
-  });
+  // The effect is async (getSession → setAuth → subscribe). Wait on the
+  // observable end-state (the channel subscribed) rather than a fixed number of
+  // microtask ticks — that way an added await in connect() fails loudly here
+  // (subscribe never observed → timeout) instead of silently under-flushing.
+  await waitFor(() => expect(h.order).toContain("subscribe"));
   return utils;
 }
 
@@ -187,6 +185,51 @@ describe("useGamificationEvents — Realtime socket auth (#800)", () => {
     await mountHook();
     await waitFor(() => expect(h.order).toContain("subscribe"));
     expect(h.setAuth).not.toHaveBeenCalled();
+  });
+
+  it("does not revert the socket to a stale token when a refresh races a slow getSession", async () => {
+    // Hold getSession() open so connect() is suspended mid-await, then land a
+    // TOKEN_REFRESHED before it resolves. connect() must not overwrite the
+    // fresher token with the pre-refresh one it captured (#806 stale-token race).
+    let resolveSession!: (value: unknown) => void;
+    h.getSession.mockReturnValue(
+      new Promise((resolve) => {
+        resolveSession = resolve;
+      })
+    );
+
+    renderHook(() => useGamificationEvents("user-1"));
+    // The auth listener registers synchronously while connect() awaits getSession.
+    await waitFor(() => expect(h.authCallback).toBeTypeOf("function"));
+
+    // Refresh lands while getSession is still in flight → newer token applied.
+    act(() =>
+      h.authCallback?.("TOKEN_REFRESHED", {
+        access_token: "tok-new",
+        user: { id: "user-1" },
+      })
+    );
+    expect(h.setAuth).toHaveBeenCalledWith("tok-new");
+
+    // getSession finally resolves with the PRE-refresh (now stale) token.
+    await act(async () => {
+      resolveSession({
+        data: {
+          session: { access_token: "tok-stale", user: { id: "user-1" } },
+        },
+      });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(h.order).toContain("subscribe"));
+
+    // The socket must remain on the newer token: the stale one is never pushed,
+    // and the last token applied is the refreshed one.
+    expect(h.setAuth).not.toHaveBeenCalledWith("tok-stale");
+    const appliedTokens = h.order
+      .filter((entry) => entry.startsWith("setAuth:"))
+      .map((entry) => entry.slice("setAuth:".length));
+    expect(appliedTokens.at(-1)).toBe("tok-new");
   });
 });
 

--- a/apps/web/src/hooks/use-gamification-events.ts
+++ b/apps/web/src/hooks/use-gamification-events.ts
@@ -65,6 +65,21 @@ export function useGamificationEvents(userId: string | undefined) {
         }
       });
 
+    // Monotonic guard against a stale-token race: bumped every time a token is
+    // pushed to the socket. If a TOKEN_REFRESHED lands while connect()'s
+    // getSession() is in flight, the auth listener pushes the newer token and
+    // bumps this; connect() then sees the generation moved and must NOT
+    // overwrite the socket with the older token it captured before the refresh.
+    let authGeneration = 0;
+
+    // Push a JWT to the Realtime socket. setAuth's rejection contract isn't
+    // guaranteed across supabase-js versions, so swallow rejections — a failed
+    // re-auth must never surface as unhandled-rejection noise.
+    function pushRealtimeAuth(token: string): Promise<void> {
+      authGeneration += 1;
+      return supabase.realtime.setAuth(token).catch(() => {});
+    }
+
     // Authenticate the Realtime socket BEFORE subscribing. The browser client's
     // socket otherwise joins as `anon`, and own-row RLS on xp_transactions (and
     // the other gamification tables) then filters every event server-side while
@@ -72,14 +87,18 @@ export function useGamificationEvents(userId: string | undefined) {
     // the session here also closes a hydration race: the subscribe used to run
     // synchronously on mount, before the cookie session had been recovered.
     async function connect() {
+      const generationBefore = authGeneration;
       const {
         data: { session },
       } = await supabase.auth.getSession();
       if (cancelled) return;
       // No session → leave the socket anon (graceful degrade); own-row RLS
-      // yields nothing but the hook still subscribes without erroring.
-      if (session?.access_token) {
-        await supabase.realtime.setAuth(session.access_token);
+      // yields nothing but the hook still subscribes without erroring. Skip the
+      // push if a fresher token was applied by the auth listener while
+      // getSession() was in flight — reverting to this now-stale token would
+      // silently de-auth the socket until the next refresh.
+      if (session?.access_token && authGeneration === generationBefore) {
+        await pushRealtimeAuth(session.access_token);
         if (cancelled) return;
       }
 
@@ -233,7 +252,9 @@ export function useGamificationEvents(userId: string | undefined) {
         )
         .subscribe();
     }
-    void connect();
+    // getSession() can reject; swallow so the initial connect can't surface as
+    // unhandled-rejection noise (the setAuth push inside is already guarded).
+    connect().catch(() => {});
 
     // Keep the socket authed across the page's lifetime. When GoTrue rotates
     // the JWT (TOKEN_REFRESHED) or a sign-in completes on this page (SIGNED_IN),
@@ -246,7 +267,9 @@ export function useGamificationEvents(userId: string | undefined) {
     } = supabase.auth.onAuthStateChange((event, session) => {
       if (event !== "TOKEN_REFRESHED" && event !== "SIGNED_IN") return;
       if (session?.access_token) {
-        void supabase.realtime.setAuth(session.access_token);
+        // pushRealtimeAuth swallows rejections internally, so the floating
+        // promise here can never become unhandled-rejection noise.
+        void pushRealtimeAuth(session.access_token);
       }
     });
 


### PR DESCRIPTION
Closes #806 (the three non-blocking hardening items the gate filed from #804's review).

## Changes (`use-gamification-events.ts` + its test file only)
1. **Defensive `.catch()`**: new `pushRealtimeAuth(token)` centralizes every socket auth push — bumps the race guard and returns `supabase.realtime.setAuth(token).catch(() => {})`, so a rejected `setAuth` can never surface as unhandled-rejection noise regardless of supabase-js version. `connect()` itself is invoked as `connect().catch(() => {})` covering a `getSession()` rejection too.
2. **Monotonic stale-token guard**: closure-scoped `authGeneration`, snapshotted at `connect()` entry before the `getSession()` await and bumped on every push. If `TOKEN_REFRESHED` lands during the await, the listener has already pushed the newer token (bumping the generation), so `connect()` skips its now-stale token instead of momentarily reverting the socket.
3. **Test decoupling**: `mountHook()` no longer flushes a hardcoded 3 microtask ticks (coupled to `connect()`'s await count) — replaced with `waitFor(() => expect(order).toContain("subscribe"))` on the observable end-state. A future added await fails loudly (waitFor timeout) instead of silently under-flushing; subscribe-never-happens still fails everything.

## Red-proof (rule 2), independently replayed by the orchestrator
New race test run against **main (520d67b)** with the unmodified hook source: `does not revert the socket to a stale token when a refresh races a slow getSession` FAILS with `AssertionError: expected "vi.fn()" to not be called with arguments: [ 'tok-stale' ]` — the other 8 tests pass under the rewritten waitFor harness, proving item 3 kept them meaningful. Green 9/9 at this head.

## Verified at fb08ad1 (agent + orchestrator re-run in clean clone)
typecheck 6/6; web suite **220 files / 2005 tests**; target file 9/9; eslint clean.
