### PR TITLE
ci(onchain): durably record the verifiable-build program hash (feeds #140 / G-3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,11 @@ name: CI
 
 on:
   push:
-    branches: ["**"] # every branch — gives fork branches CI before the upstream PR
+    # `**` = every branch (gives fork branches CI before the upstream PR).
+    # `!program-hash` excludes the CI-owned hash-record branch so pushes there
+    # never spin up CI — defense-in-depth vs a future PAT swap (GITHUB_TOKEN
+    # pushes already don't trigger workflows). Negation MUST follow `**` to win.
+    branches: ["**", "!program-hash"]
   pull_request:
     branches: [main]
     # `labeled` lets the verifiable-build job (gated on the `verifiable-build`
@@ -499,14 +503,13 @@ jobs:
   verifiable-build:
     name: Verifiable build (program hash)
     runs-on: ubuntu-latest
-    # Job-level override of the workflow's `contents: read`. Needed ONLY by the
-    # "Publish program hash" step, which commits the hash record to the CI-owned
-    # `program-hash` branch (feeds #140 / G-3). Scoped to this job so no other
-    # job gains write. The default GITHUB_TOKEN cannot push to `main` (branch
-    # protection requires a PR), which is why the record lands on a dedicated
-    # branch — see docs/PROGRAM-HASH.md.
-    permissions:
-      contents: write
+    # No job-level `permissions:` here on purpose. This job runs PR-controlled
+    # build code — `cargo build-sbf` executes the crate's build.rs / proc-macros
+    # — on same-repo PRs carrying the `verifiable-build` label. It therefore
+    # inherits the workflow's read-only `contents: read` and NEVER holds a
+    # write-capable token in a job that runs untrusted code. The durable publish
+    # (which needs write) is a SEPARATE job, `publish-hash`, that runs only on
+    # trusted `main` and never checks out PR code. See #140 / G-3.
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
@@ -517,7 +520,12 @@ jobs:
       # pinned platform-tools (v1.54 = rustc 1.89).
       SOLANA_VERSION: "3.1.10"
     outputs:
-      program_sha256: ${{ steps.hash.outputs.sha256 }}
+      # Non-secret record fields consumed by the `publish-hash` job — plain
+      # strings (hash, byte size, toolchain versions), no artifact plumbing.
+      sha256: ${{ steps.hash.outputs.sha256 }}
+      size: ${{ steps.hash.outputs.size }}
+      solana: ${{ steps.hash.outputs.solana }}
+      platform_tools: ${{ steps.hash.outputs.platform_tools }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -565,7 +573,13 @@ jobs:
           fi
           SHA="$(sha256sum "$SO_PATH" | awk '{print $1}')"
           SIZE="$(wc -c < "$SO_PATH" | tr -d ' ')"
-          echo "sha256=$SHA" >> "$GITHUB_OUTPUT"
+          # Expose the record fields as job outputs for the `publish-hash` job.
+          {
+            echo "sha256=$SHA"
+            echo "size=$SIZE"
+            echo "solana=$SOLANA_VERSION"
+            echo "platform_tools=v1.54"
+          } >> "$GITHUB_OUTPUT"
           # Plain artifact for downstream comparison / scripting.
           printf '%s  %s\n' "$SHA" "onchain_academy_pinocchio.so" > program-hash.txt
           {
@@ -598,30 +612,48 @@ jobs:
             onchain-academy/program-hash.txt
           if-no-files-found: error
 
-      # ── Durable hash record (feeds #140 / G-3) ──────────────────────────────
-      # The step above (upload-artifact) is EPHEMERAL — the artifact expires. This
-      # step makes the hash durable: on every push to main, it publishes the
-      # verified hash to the CI-owned `program-hash` branch (see docs/PROGRAM-HASH.md
-      # for why a branch and not a commit to `main`: branch protection requires a
-      # PR, so the bot cannot push to `main`).
-      #
-      # Loop / spam safety (verifiable-build runs on EVERY main push, path-filter
-      # free, so this must not rebuild-and-commit forever):
-      #   1. Idempotence (primary): publish only when the hash CHANGED. A doc-only
-      #      or any hash-unchanged main push short-circuits with no commit.
-      #   2. Structural: the push targets `program-hash`, not `main` — it can never
-      #      re-trigger this main-gated job regardless of anything else.
-      #   3. GITHUB_TOKEN pushes never trigger workflow runs (GitHub's built-in
-      #      recursion guard; cf. claude-code-review.yml).
-      #   4. `[skip ci]` in the bot commit message — a belt for a future PAT swap.
-      - name: Publish program hash (main only)
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        env:
-          NEW_SHA: ${{ steps.hash.outputs.sha256 }}
-          PUBLISH_BRANCH: program-hash
-          RECORD_PATH: docs/PROGRAM-HASH.md
-          SO_PATH: onchain-academy/target/deploy/onchain_academy_pinocchio.so
-          PROGRAM_ID: 7NeJaSRyb4Wxay3Tcd9bdpD7T3GWYUQSFyrhG8SgwE8V
+  # ── Durable hash record (feeds #140 / G-3) ──────────────────────────────────
+  # SEPARATE job from verifiable-build so the write-capable token is never present
+  # while PR-controlled build code runs. verifiable-build (which runs cargo
+  # build-sbf, i.e. PR build.rs / proc-macros on labeled same-repo PRs) stays
+  # read-only; ONLY this job holds `contents: write`, it runs ONLY on trusted
+  # `main`, and it never checks out PR code. It renders the record purely from
+  # verifiable-build's non-secret string outputs plus git facts re-derived from
+  # its OWN clean `main` checkout.
+  #
+  # The upload-artifact in verifiable-build is EPHEMERAL; this makes the hash
+  # durable by publishing it to the CI-owned `program-hash` branch (see
+  # docs/PROGRAM-HASH.md for why a branch, not a commit to protected `main`).
+  #
+  # Loop / spam safety (verifiable-build runs on EVERY main push, path-filter free):
+  #   1. Idempotence (primary): publish only when the hash CHANGED — a doc-only or
+  #      any hash-unchanged main push short-circuits with no commit.
+  #   2. Structural: the push targets `program-hash` (excluded from `on.push`,
+  #      never `main`), so it cannot re-trigger this main-gated job.
+  #   3. GITHUB_TOKEN pushes never trigger workflow runs (GitHub recursion guard;
+  #      cf. claude-code-review.yml).
+  #   4. `[skip ci]` in the bot commit message — a belt for a future PAT swap.
+  publish-hash:
+    name: Publish program hash
+    needs: verifiable-build
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      NEW_SHA: ${{ needs.verifiable-build.outputs.sha256 }}
+      SIZE: ${{ needs.verifiable-build.outputs.size }}
+      SOLANA_VERSION: ${{ needs.verifiable-build.outputs.solana }}
+      PLATFORM_TOOLS: ${{ needs.verifiable-build.outputs.platform_tools }}
+      PUBLISH_BRANCH: program-hash
+      RECORD_PATH: docs/PROGRAM-HASH.md
+      PROGRAM_ID: 7NeJaSRyb4Wxay3Tcd9bdpD7T3GWYUQSFyrhG8SgwE8V
+    steps:
+      # Clean checkout of the TRUSTED main ref (the push's own commit) — never PR
+      # code. persist-credentials (default true) supplies the push credential.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Publish record to the program-hash branch
         run: |
           set -euo pipefail
 
@@ -638,17 +670,17 @@ jobs:
             exit 0
           fi
 
-          SIZE="$(wc -c < "$SO_PATH" | tr -d ' ')"
+          # Git facts re-derived from THIS job's clean main checkout (HEAD == the
+          # pushed main commit) — nothing sourced from PR-controlled state.
           SRC_COMMIT="$(git rev-parse HEAD)"
-          # Deterministic build date = source commit's committer date, not wall clock.
-          BUILD_DATE="$(git show -s --format=%cI HEAD)"
+          BUILD_DATE="$(git show -s --format=%cI HEAD)"  # committer date, not wall clock
 
-          # --- Render the record (echo-group style, matching the hash step above) ---
+          # --- Render the record (echo-group style, matching the hash step) ---
           RECORD="$(mktemp)"
           {
             echo "<!--"
             echo "  CI-MAINTAINED — DO NOT EDIT BY HAND. Published by .github/workflows/ci.yml"
-            echo "  (verifiable-build job) on every push to main whose program hash changed."
+            echo "  (publish-hash job) on every push to main whose program hash changed."
             echo "  The human-readable spec + reproduction guide lives on main at"
             echo "  docs/PROGRAM-HASH.md."
             echo "-->"
@@ -669,14 +701,14 @@ jobs:
             echo "| SHA-256 | \`${NEW_SHA}\` |"
             echo "| Program ID | \`${PROGRAM_ID}\` |"
             echo "| Solana | \`${SOLANA_VERSION}\` |"
-            echo "| platform-tools | \`v1.54\` |"
+            echo "| platform-tools | \`${PLATFORM_TOOLS}\` |"
             echo "| Source commit | \`${SRC_COMMIT}\` |"
             echo "| Build date | \`${BUILD_DATE}\` |"
             echo ""
             echo "## Reproduce"
             echo ""
             echo '```bash'
-            echo "cargo build-sbf --manifest-path onchain-academy/programs/onchain-academy-pinocchio/Cargo.toml --tools-version v1.54"
+            echo "cargo build-sbf --manifest-path onchain-academy/programs/onchain-academy-pinocchio/Cargo.toml --tools-version ${PLATFORM_TOOLS}"
             echo "sha256sum onchain-academy/target/deploy/onchain_academy_pinocchio.so"
             echo '```'
             echo ""
@@ -688,11 +720,17 @@ jobs:
             echo '```'
           } > "$RECORD"
 
-          # --- Commit + push in an isolated worktree (never touches the build tree) ---
+          # --- Commit + push in an isolated worktree (never touches the checkout) ---
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
           WT="$(mktemp -d)"
+          cleanup() {
+            git worktree remove --force "$WT" >/dev/null 2>&1 || true
+            rm -rf "$WT" >/dev/null 2>&1 || true
+          }
+          trap cleanup EXIT
+
           if [ -n "$OLD_SHA" ] || git ls-remote --exit-code --heads origin "$PUBLISH_BRANCH" >/dev/null 2>&1; then
             git worktree add "$WT" "refs/remotes/origin/${PUBLISH_BRANCH}"
             git -C "$WT" checkout -B "$PUBLISH_BRANCH"
@@ -712,4 +750,3 @@ jobs:
             git -C "$WT" push origin "HEAD:refs/heads/${PUBLISH_BRANCH}"
             echo "Published program hash ${NEW_SHA} to ${PUBLISH_BRANCH}."
           fi
-          git worktree remove --force "$WT" 2>/dev/null || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -499,6 +499,14 @@ jobs:
   verifiable-build:
     name: Verifiable build (program hash)
     runs-on: ubuntu-latest
+    # Job-level override of the workflow's `contents: read`. Needed ONLY by the
+    # "Publish program hash" step, which commits the hash record to the CI-owned
+    # `program-hash` branch (feeds #140 / G-3). Scoped to this job so no other
+    # job gains write. The default GITHUB_TOKEN cannot push to `main` (branch
+    # protection requires a PR), which is why the record lands on a dedicated
+    # branch — see docs/PROGRAM-HASH.md.
+    permissions:
+      contents: write
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
@@ -589,3 +597,119 @@ jobs:
             onchain-academy/idl/*.json
             onchain-academy/program-hash.txt
           if-no-files-found: error
+
+      # ── Durable hash record (feeds #140 / G-3) ──────────────────────────────
+      # The step above (upload-artifact) is EPHEMERAL — the artifact expires. This
+      # step makes the hash durable: on every push to main, it publishes the
+      # verified hash to the CI-owned `program-hash` branch (see docs/PROGRAM-HASH.md
+      # for why a branch and not a commit to `main`: branch protection requires a
+      # PR, so the bot cannot push to `main`).
+      #
+      # Loop / spam safety (verifiable-build runs on EVERY main push, path-filter
+      # free, so this must not rebuild-and-commit forever):
+      #   1. Idempotence (primary): publish only when the hash CHANGED. A doc-only
+      #      or any hash-unchanged main push short-circuits with no commit.
+      #   2. Structural: the push targets `program-hash`, not `main` — it can never
+      #      re-trigger this main-gated job regardless of anything else.
+      #   3. GITHUB_TOKEN pushes never trigger workflow runs (GitHub's built-in
+      #      recursion guard; cf. claude-code-review.yml).
+      #   4. `[skip ci]` in the bot commit message — a belt for a future PAT swap.
+      - name: Publish program hash (main only)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        env:
+          NEW_SHA: ${{ steps.hash.outputs.sha256 }}
+          PUBLISH_BRANCH: program-hash
+          RECORD_PATH: docs/PROGRAM-HASH.md
+          SO_PATH: onchain-academy/target/deploy/onchain_academy_pinocchio.so
+          PROGRAM_ID: 7NeJaSRyb4Wxay3Tcd9bdpD7T3GWYUQSFyrhG8SgwE8V
+        run: |
+          set -euo pipefail
+
+          # --- Idempotence guard: compare against the currently published hash ---
+          OLD_SHA=""
+          if git ls-remote --exit-code --heads origin "$PUBLISH_BRANCH" >/dev/null 2>&1; then
+            git fetch --no-tags --depth=1 origin \
+              "+refs/heads/${PUBLISH_BRANCH}:refs/remotes/origin/${PUBLISH_BRANCH}"
+            OLD_SHA="$(git show "refs/remotes/origin/${PUBLISH_BRANCH}:${RECORD_PATH}" 2>/dev/null \
+                        | grep -oiE '^[0-9a-f]{64}' | head -1 || true)"
+          fi
+          if [ -n "$OLD_SHA" ] && [ "$OLD_SHA" = "$NEW_SHA" ]; then
+            echo "Program hash unchanged ($NEW_SHA); nothing to publish."
+            exit 0
+          fi
+
+          SIZE="$(wc -c < "$SO_PATH" | tr -d ' ')"
+          SRC_COMMIT="$(git rev-parse HEAD)"
+          # Deterministic build date = source commit's committer date, not wall clock.
+          BUILD_DATE="$(git show -s --format=%cI HEAD)"
+
+          # --- Render the record (echo-group style, matching the hash step above) ---
+          RECORD="$(mktemp)"
+          {
+            echo "<!--"
+            echo "  CI-MAINTAINED — DO NOT EDIT BY HAND. Published by .github/workflows/ci.yml"
+            echo "  (verifiable-build job) on every push to main whose program hash changed."
+            echo "  The human-readable spec + reproduction guide lives on main at"
+            echo "  docs/PROGRAM-HASH.md."
+            echo "-->"
+            echo ""
+            echo "# Verifiable build — program hash (feeds #140 / G-3)"
+            echo ""
+            echo "SHA-256 of the toolchain-reproducible \`onchain_academy_pinocchio.so\`,"
+            echo "published by CI so the deployed bytes can be independently verified."
+            echo ""
+            echo '```'
+            echo "${NEW_SHA}  onchain_academy_pinocchio.so"
+            echo '```'
+            echo ""
+            echo "| Field | Value |"
+            echo "| --- | --- |"
+            echo "| Artifact | \`onchain_academy_pinocchio.so\` |"
+            echo "| Size (bytes) | \`${SIZE}\` |"
+            echo "| SHA-256 | \`${NEW_SHA}\` |"
+            echo "| Program ID | \`${PROGRAM_ID}\` |"
+            echo "| Solana | \`${SOLANA_VERSION}\` |"
+            echo "| platform-tools | \`v1.54\` |"
+            echo "| Source commit | \`${SRC_COMMIT}\` |"
+            echo "| Build date | \`${BUILD_DATE}\` |"
+            echo ""
+            echo "## Reproduce"
+            echo ""
+            echo '```bash'
+            echo "cargo build-sbf --manifest-path onchain-academy/programs/onchain-academy-pinocchio/Cargo.toml --tools-version v1.54"
+            echo "sha256sum onchain-academy/target/deploy/onchain_academy_pinocchio.so"
+            echo '```'
+            echo ""
+            echo "## Verify against the deployed program"
+            echo ""
+            echo '```bash'
+            echo "solana program dump ${PROGRAM_ID} onchain.so"
+            echo "sha256sum onchain.so   # must equal the SHA-256 above"
+            echo '```'
+          } > "$RECORD"
+
+          # --- Commit + push in an isolated worktree (never touches the build tree) ---
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          WT="$(mktemp -d)"
+          if [ -n "$OLD_SHA" ] || git ls-remote --exit-code --heads origin "$PUBLISH_BRANCH" >/dev/null 2>&1; then
+            git worktree add "$WT" "refs/remotes/origin/${PUBLISH_BRANCH}"
+            git -C "$WT" checkout -B "$PUBLISH_BRANCH"
+          else
+            # First ever run: start the branch as an orphan (no repo history baggage).
+            git worktree add --detach "$WT"
+            git -C "$WT" checkout --orphan "$PUBLISH_BRANCH"
+            git -C "$WT" rm -rf --quiet . 2>/dev/null || true
+          fi
+
+          install -D -m 0644 "$RECORD" "$WT/${RECORD_PATH}"
+          git -C "$WT" add "$RECORD_PATH"
+          if git -C "$WT" diff --cached --quiet; then
+            echo "docs/PROGRAM-HASH.md unchanged; skipping commit."
+          else
+            git -C "$WT" commit -q -m "chore(ci): record program hash ${NEW_SHA} [skip ci]"
+            git -C "$WT" push origin "HEAD:refs/heads/${PUBLISH_BRANCH}"
+            echo "Published program hash ${NEW_SHA} to ${PUBLISH_BRANCH}."
+          fi
+          git worktree remove --force "$WT" 2>/dev/null || true

--- a/docs/PROGRAM-HASH.md
+++ b/docs/PROGRAM-HASH.md
@@ -1,0 +1,83 @@
+<!--
+  CI-MAINTAINED — DO NOT EDIT BY HAND.
+  The live, machine-updated copy of this file is published by the `verifiable-build`
+  job in .github/workflows/ci.yml to the dedicated `program-hash` branch, once per
+  push to `main` (only when the program hash actually changes). See "Where the live
+  record lives" below.
+  This copy on `main` is the human-readable spec + entry point; it is intentionally
+  NOT updated by CI, because branch protection on `main` ("Require a pull request
+  before merging") forbids the github-actions bot from pushing to `main`.
+-->
+
+# Verifiable build — program hash (feeds #140 / G-3)
+
+This file records the SHA-256 of the toolchain-reproducible build of the on-chain
+program `onchain_academy_pinocchio.so`, so that anyone can independently verify the
+bytes deployed on-chain match the audited source at a known commit.
+
+The **build** is the guarantee; the **hash** is the comparable artifact.
+
+## Current record
+
+> **PENDING FIRST CI RUN.** No canonical hash has been published yet. This seed
+> was committed with a placeholder rather than a locally-produced hash on purpose:
+> a hash is only meaningful if it comes from the *pinned* toolchain the CI job uses
+> (Solana `3.1.10` + platform-tools `v1.54` on Ubuntu). A build from any other
+> toolchain would not match the deployed program and must not be recorded here.
+> The first push to `main` after this lands publishes the real values to the
+> `program-hash` branch (see below).
+
+<!-- The line below is the machine-readable checksum, in `sha256sum` format
+     (`<64-hex>  <filename>`). CI regenerates it; tooling greps `^[0-9a-f]{64}`. -->
+```
+0000000000000000000000000000000000000000000000000000000000000000  onchain_academy_pinocchio.so
+```
+
+| Field | Value |
+| --- | --- |
+| Artifact | `onchain_academy_pinocchio.so` |
+| Size (bytes) | _pending first CI run_ |
+| SHA-256 | _pending first CI run_ |
+| Program ID | `7NeJaSRyb4Wxay3Tcd9bdpD7T3GWYUQSFyrhG8SgwE8V` |
+| Solana | `3.1.10` |
+| platform-tools | `v1.54` |
+| Source commit | _pending first CI run_ |
+| Build date | _pending first CI run_ |
+
+## Where the live record lives
+
+Branch protection on `main` requires every change to go through a pull request, so
+CI cannot commit an updated hash back to `main`. Instead, the `verifiable-build` CI
+job publishes the live record to a dedicated **`program-hash`** branch (unprotected,
+CI-owned — analogous to a `gh-pages` branch). Every distinct program hash ever built
+from `main` is one commit on that branch, giving a tamper-evident audit trail.
+
+Read the current published record:
+
+```bash
+git fetch origin program-hash
+git show origin/program-hash:docs/PROGRAM-HASH.md
+```
+
+Or via the raw URL:
+`https://raw.githubusercontent.com/solanabr/superteam-academy/program-hash/docs/PROGRAM-HASH.md`
+
+## Reproduce the build
+
+The hash is reproducible from source with the pinned toolchain the CI job uses:
+
+```bash
+# Solana CLI 3.1.10 (Agave); platform-tools v1.54 is fetched by --tools-version.
+cargo build-sbf \
+  --manifest-path onchain-academy/programs/onchain-academy-pinocchio/Cargo.toml \
+  --tools-version v1.54
+sha256sum onchain-academy/target/deploy/onchain_academy_pinocchio.so
+# must equal the SHA-256 recorded on the program-hash branch
+```
+
+## Verify against the deployed program
+
+```bash
+solana program dump 7NeJaSRyb4Wxay3Tcd9bdpD7T3GWYUQSFyrhG8SgwE8V onchain.so
+sha256sum onchain.so   # must equal the recorded SHA-256
+```

--- a/docs/PROGRAM-HASH.md
+++ b/docs/PROGRAM-HASH.md
@@ -1,6 +1,6 @@
 <!--
   CI-MAINTAINED — DO NOT EDIT BY HAND.
-  The live, machine-updated copy of this file is published by the `verifiable-build`
+  The live, machine-updated copy of this file is published by the `publish-hash`
   job in .github/workflows/ci.yml to the dedicated `program-hash` branch, once per
   push to `main` (only when the program hash actually changes). See "Where the live
   record lives" below.
@@ -47,8 +47,10 @@ The **build** is the guarantee; the **hash** is the comparable artifact.
 ## Where the live record lives
 
 Branch protection on `main` requires every change to go through a pull request, so
-CI cannot commit an updated hash back to `main`. Instead, the `verifiable-build` CI
-job publishes the live record to a dedicated **`program-hash`** branch (unprotected,
+CI cannot commit an updated hash back to `main`. Instead, the `publish-hash` CI job
+(a separate job from the build, holding the only `contents: write` token and running
+only on trusted main) publishes the live record to a dedicated **`program-hash`**
+branch (unprotected,
 CI-owned — analogous to a `gh-pages` branch). Every distinct program hash ever built
 from `main` is one commit on that branch, giving a tamper-evident audit trail.
 


### PR DESCRIPTION
Feeds #140 "[G-3] Verifiable build published + hash recorded" (does NOT close it — the gate flip and the deployed-bytes reconciliation are the owner's, at deploy time).

## What this is
The `verifiable-build` CI job already computes a reproducible sha256 of `onchain_academy_pinocchio.so` (pinned platform-tools v1.54 + committed Cargo.lock) — but published it only ephemerally ($GITHUB_STEP_SUMMARY + expiring artifact). This PR makes the record durable:

1. **New "Publish program hash (main only)" step** in the existing `verifiable-build` job — gated `push && refs/heads/main` only (PRs/dispatch still build+summary+artifact, never publish).
2. **Publishes to a dedicated CI-owned `program-hash` branch** (one commit per distinct hash = tamper-evident audit trail), NOT to main — **verified**: main's branch protection has require-a-PR ON, so a GITHUB_TOKEN bot push to main is impossible; the stated fallback design was used. `docs/PROGRAM-HASH.md` on main (this PR's second file) is the static human-readable spec + reproduction guide pointing at `git show origin/program-hash:docs/PROGRAM-HASH.md`; it seeds with an explicit zeros placeholder — no fabricated hash (the implementer's local toolchain is non-canonical v1.51).

## Loop/spam guard (4 layers — the job has no path filter, so it rebuilds on every main push)
1. **Idempotence (primary)**: current published hash is read back from `origin/program-hash`; `OLD==NEW → exit 0` before any commit (round-trip of the render→grep extraction unit-tested), plus a `git diff --cached --quiet` backstop.
2. **Structural**: the push target is `program-hash`, never main — a publish cannot re-trigger the main-gated step.
3. GITHUB_TOKEN pushes don't trigger workflows (GitHub recursion guard; precedent in claude-code-review.yml).
4. `[skip ci]` in the bot commit message as a belt for any future PAT swap.

## Permissions + policy
Workflow-level stays `contents: read`; `contents: write` added at **job level on verifiable-build only**. Zero new `uses:` (pure `run:` git/gh) — no SHA-pin surface; the repo's pin guard passes.

## Verified (agent + orchestrator re-runs)
actionlint exit 0 (shellcheck-backed), extracted publish script shellcheck-clean + `bash -n` OK, YAML parses, pin-guard green across all 8 workflow files, diff is exactly 2 files / +207 with zero TS/Rust source (hence no app test lanes to exercise). Commit mechanics use an isolated `git worktree`; build date = source commit committer-date (reproducible, no wall-clock).

## ⚠ First-run risk
The first main build after merge creates the orphan `program-hash` branch via a live bot push — unverifiable before merge. Rollback: delete the `program-hash` branch + revert this commit; nothing on main or on-chain is touched.


---

## Round 2 — adversarial findings fixed (head 7c9d8c0)

Independent adversarial review (area:ci protocol) verdict: **PASS** with 1 MEDIUM + 4 LOW. The MEDIUM and both cheap LOWs are fixed in this round; two LOWs accepted:

**MEDIUM fixed — pwn-request token isolation (job split):** `verifiable-build` no longer holds any write permission (inherits workflow-level `contents: read`) — the job that executes PR-controlled `build.rs`/proc-macros on labeled PRs never sees a write token. Publishing moved to a new `publish-hash` job: `needs: verifiable-build`, main-push-only `if`, its own `permissions: {contents: write}`, clean checkout of the trusted main ref, record rendered from job outputs (`sha256`/`size`/`solana`/`platform_tools` — plain build-fact strings; `SRC_COMMIT`/`BUILD_DATE` re-derived in the publish job's own main checkout, nothing PR-controlled crosses the boundary).

**LOWs fixed:** `on.push.branches` now `["**", "!program-hash"]` (a future PAT swap can't CI-storm the record branch); `trap`-based worktree cleanup on failure.

**LOWs accepted (acknowledged):** concurrent main pushes → rare non-ff push fails visibly, non-destructively (workflow `concurrency` serializes; no force-push); the main-side seed doc keeps a zeroed placeholder under an explicit "pending first CI run" banner rather than a fabricated hash.

**Honest delta:** this round adds exactly one `uses:` — `actions/checkout` at the SAME SHA already pinned 8× in the repo (needed for the publish job's trusted-main checkout). Pin guard green.

**Re-verified (agent + orchestrator):** actionlint exit 0, shellcheck clean, YAML job graph confirmed (outputs/needs/if/permissions exactly as designed), pin guard green, `uses:` diff vs main = exactly the one pinned checkout, two-job first-run bootstrap re-walked (orphan create → idempotent no-op → changed-hash update; labeled PR → build read-only, publish skipped).
