### PR TITLE
fix(email): subject CRLF scrub, announce-route maxDuration, route-table docs (#807)

### DIFF
--- a/apps/web/src/app/api/CLAUDE.md
+++ b/apps/web/src/app/api/CLAUDE.md
@@ -77,26 +77,36 @@ the boundary (never the full `Lesson` `blocks[]`, which carries solutions/tests)
 
 ## Admin
 
-| Route                                   | Method   | Auth         | Purpose                                                            |
-| --------------------------------------- | -------- | ------------ | ------------------------------------------------------------------ |
-| `/api/admin/auth`                       | POST     | ADMIN_SECRET | Admin authentication                                               |
-| `/api/admin/status`                     | GET      | ADMIN_SECRET | Platform status (program liveness, authority match)                |
-| `/api/admin/courses/sync`               | POST     | ADMIN_SECRET | Deploy course PDA + collection on-chain                            |
-| `/api/admin/courses/deactivate`         | POST     | ADMIN_SECRET | Set course `is_active = false`                                     |
-| `/api/admin/courses/reactivate`         | POST     | ADMIN_SECRET | Set course `is_active = true`                                      |
-| `/api/admin/courses/recreate`           | POST     | ADMIN_SECRET | **DESTRUCTIVE** — close + recreate course PDA (create-only fields) |
-| `/api/admin/courses/recreate/preflight` | GET      | ADMIN_SECRET | Read-only preflight validation for the recreate execute route      |
-| `/api/admin/achievements/sync`          | POST     | ADMIN_SECRET | Deploy achievement type + collection on-chain                      |
-| `/api/admin/resync`                     | POST     | ADMIN_SECRET | Resync on-chain state to Supabase                                  |
-| `/api/admin/flags`                      | GET      | ADMIN_SECRET | Pending community flags for the moderation queue                   |
-| `/api/admin/freeze`                     | GET/POST | ADMIN_SECRET | Read/set the global deploy-window freeze (reset wave B2)           |
-| `/api/admin/publish/pin`                | GET      | ADMIN_SECRET | Content pin: pinned bundle SHA + counts vs courses-academy HEAD    |
-| `/api/admin/capstone-funnel`            | GET      | ADMIN_SECRET | Capstone credential funnel counters (#725)                         |
+| Route                                   | Method   | Auth         | Purpose                                                              |
+| --------------------------------------- | -------- | ------------ | -------------------------------------------------------------------- |
+| `/api/admin/auth`                       | POST     | ADMIN_SECRET | Admin authentication                                                 |
+| `/api/admin/status`                     | GET      | ADMIN_SECRET | Platform status (program liveness, authority match)                  |
+| `/api/admin/courses/sync`               | POST     | ADMIN_SECRET | Deploy course PDA + collection on-chain                              |
+| `/api/admin/courses/deactivate`         | POST     | ADMIN_SECRET | Set course `is_active = false`                                       |
+| `/api/admin/courses/reactivate`         | POST     | ADMIN_SECRET | Set course `is_active = true`                                        |
+| `/api/admin/courses/recreate`           | POST     | ADMIN_SECRET | **DESTRUCTIVE** — close + recreate course PDA (create-only fields)   |
+| `/api/admin/courses/recreate/preflight` | GET      | ADMIN_SECRET | Read-only preflight validation for the recreate execute route        |
+| `/api/admin/achievements/sync`          | POST     | ADMIN_SECRET | Deploy achievement type + collection on-chain                        |
+| `/api/admin/resync`                     | POST     | ADMIN_SECRET | Resync on-chain state to Supabase                                    |
+| `/api/admin/flags`                      | GET      | ADMIN_SECRET | Pending community flags for the moderation queue                     |
+| `/api/admin/freeze`                     | GET/POST | ADMIN_SECRET | Read/set the global deploy-window freeze (reset wave B2)             |
+| `/api/admin/publish/pin`                | GET      | ADMIN_SECRET | Content pin: pinned bundle SHA + counts vs courses-academy HEAD      |
+| `/api/admin/capstone-funnel`            | GET      | ADMIN_SECRET | Capstone credential funnel counters (#725)                           |
+| `/api/admin/email/announce-course`      | POST     | ADMIN_SECRET | Send "new course available" email to marketing-opted-in users (#769) |
 
 Content drift (bundle SHA vs `courses-academy` HEAD) and chain drift are folded
 into `/api/admin/status`; the publish card reads `/api/admin/publish/pin`. There
 is no separate drift route — one existed, was never wired to a UI, and was
 deleted in #444.
+
+## Email (#769)
+
+Marketing-consent model (opt-in defaults OFF; LGPD/GDPR/CAN-SPAM). The admin
+send trigger lives in the Admin table (`/api/admin/email/announce-course`).
+
+| Route                    | Method   | Auth  | Purpose                                                                                                                                                   |
+| ------------------------ | -------- | ----- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `/api/email/unsubscribe` | GET/POST | Token | One-click List-Unsubscribe by per-user token (GET renders a confirmation page; POST is the RFC 8058 one-click). No session — the email link carries none. |
 
 ## Health
 

--- a/apps/web/src/app/api/admin/email/announce-course/route.ts
+++ b/apps/web/src/app/api/admin/email/announce-course/route.ts
@@ -13,6 +13,17 @@ import { defaultLocale } from "@/lib/i18n/config";
 // Reads the admin cookie + service-role DB (recipient list) — never prerender.
 export const dynamic = "force-dynamic";
 
+// The campaign sends SERIALLY: recipients are chunked to Resend's 100/batch
+// limit and each batch is followed by a 600ms courtesy delay
+// (DELAY_BETWEEN_BATCHES_MS in lib/email/campaign.ts) plus the batch's own
+// Resend round-trip. At the default serverless limit that outgrows the window
+// after only a few thousand recipients, truncating a send mid-campaign. 300s is
+// the Vercel plan's hard ceiling on this project (same value api/build-program
+// and api/courses/test-out already use); at ~600ms + round-trip per 100-address
+// batch it covers well over ten thousand opted-in recipients — beyond any near-
+// term list — and the platform hard-kills at 300s regardless of a larger value.
+export const maxDuration = 300;
+
 /**
  * POST /api/admin/email/announce-course — admin-triggered "new course available"
  * announcement to marketing-opted-in users (#769). NO automatic sends: this is

--- a/apps/web/src/lib/email/__tests__/templates.test.ts
+++ b/apps/web/src/lib/email/__tests__/templates.test.ts
@@ -34,4 +34,17 @@ describe("newCourseAnnouncementEmail", () => {
     expect(r.html).not.toContain("<script>alert(1)</script>");
     expect(r.html).toContain("&lt;script&gt;");
   });
+
+  it("scrubs CR/LF from the subject (header-injection defense, #807)", () => {
+    const r = newCourseAnnouncementEmail({
+      courseTitle: "Legit Title\r\nBcc: victim@example.com",
+      courseUrl: "https://x/c",
+      unsubscribeUrl: "https://x/u",
+    });
+    // A mail subject is a header line — a raw newline could split it or smuggle
+    // another header. The title's visible text survives; only the CR/LF go.
+    expect(r.subject).not.toMatch(/[\r\n]/);
+    expect(r.subject).toContain("Legit Title");
+    expect(r.subject).toContain("Bcc: victim@example.com");
+  });
 });

--- a/apps/web/src/lib/email/templates.ts
+++ b/apps/web/src/lib/email/templates.ts
@@ -17,6 +17,17 @@ function escapeHtml(s: string): string {
     .replace(/'/g, "&#39;");
 }
 
+/**
+ * Strip CR/LF from a value bound into an email SUBJECT (a mail header line).
+ * Resend's JSON API already blocks raw header injection, but the subject
+ * interpolates a user-controlled course title, so we neutralize newlines at the
+ * boundary as defense-in-depth (#807): they can never split the header line or
+ * smuggle an extra one, regardless of the transport underneath.
+ */
+function scrubHeaderValue(s: string): string {
+  return s.replace(/[\r\n]/g, " ");
+}
+
 export interface RenderedEmail {
   subject: string;
   html: string;
@@ -40,7 +51,9 @@ export function newCourseAnnouncementEmail(
   const title = escapeHtml(params.courseTitle);
   const courseUrl = escapeHtml(params.courseUrl);
   const unsubscribeUrl = escapeHtml(params.unsubscribeUrl);
-  const subject = `New course on Superteam Academy: ${params.courseTitle}`;
+  const subject = scrubHeaderValue(
+    `New course on Superteam Academy: ${params.courseTitle}`
+  );
 
   const html = `<!doctype html>
 <html>


### PR DESCRIPTION
Closes #807 (the gate's follow-ups from its #779 review).

## Changes
1. **Subject CRLF scrub** (`templates.ts`): the subject interpolated the raw course title while the body escaped it. New `scrubHeaderValue()` (`replace(/[\r\n]/g, " ")`, the issue's exact regex) wraps the assembled subject — defense-in-depth on top of Resend's JSON API, so a newline in a title can't split or smuggle a header line.
2. **Announce-route `maxDuration = 300`** (`announce-course/route.ts`): the campaign sends serially (100-address Resend batches + 600ms courtesy delay + round-trips), so a real list truncates mid-send at the default serverless limit. 300 is the plan's hard ceiling, matching `api/build-program` and `api/courses/test-out` (cross-referenced in the comment); covers >10k recipients.
3. **API route table** (`api/CLAUDE.md`): `POST /api/admin/email/announce-course` added to the Admin table (preserving the "all /api/admin/* live in Admin" invariant) + new Email section for `GET/POST /api/email/unsubscribe` (token auth, RFC 8058 one-click), matching the file's group-by-area style.

## Red-proof (rule 2), independently replayed by the orchestrator
New test `scrubs CR/LF from the subject (header-injection defense, #807)` run against **main (069c095)**: FAILS with the subject carrying the raw injected line — `Received: "New course on Superteam Academy: Legit Title\nBcc: victim@example.com"`. This was a genuine gap, not a JSON-API-already-safe case. Green 4/4 at this head.

## Verified at dd719cd (agent + orchestrator re-run in clean clone)
typecheck 6/6; web suite **227 files / 2058 tests**; lint clean.
