### PR TITLE
docs(onchain): supersede banner on stale VERIFIABLE_BUILD.md (#813)

### DIFF
--- a/onchain-academy/VERIFIABLE_BUILD.md
+++ b/onchain-academy/VERIFIABLE_BUILD.md
@@ -4,7 +4,8 @@
 > `anchor build --verifiable` era (the program has since been rewritten in Pinocchio;
 > same Program ID). The authoritative, CI-maintained record is
 > [`docs/PROGRAM-HASH.md`](../docs/PROGRAM-HASH.md) — the live hash lives on the
-> CI-owned `program-hash` branch (`git show origin/program-hash:docs/PROGRAM-HASH.md`),
+> CI-owned `program-hash` branch
+> (`git fetch origin program-hash && git show origin/program-hash:docs/PROGRAM-HASH.md`),
 > published by the `publish-hash` job on every main-branch build. This file is kept
 > only as a historical record of the 2026-07-13 attempt.
 

--- a/onchain-academy/VERIFIABLE_BUILD.md
+++ b/onchain-academy/VERIFIABLE_BUILD.md
@@ -1,5 +1,13 @@
 # Verifiable Build Record (#140)
 
+> **⚠️ SUPERSEDED (2026-07-27).** This is a stale manual record from the pre-Pinocchio
+> `anchor build --verifiable` era (the program has since been rewritten in Pinocchio;
+> same Program ID). The authoritative, CI-maintained record is
+> [`docs/PROGRAM-HASH.md`](../docs/PROGRAM-HASH.md) — the live hash lives on the
+> CI-owned `program-hash` branch (`git show origin/program-hash:docs/PROGRAM-HASH.md`),
+> published by the `publish-hash` job on every main-branch build. This file is kept
+> only as a historical record of the 2026-07-13 attempt.
+
 **Date:** 2026-07-13
 **Program:** `onchain-academy`
 **Program ID:** `7NeJaSRyb4Wxay3Tcd9bdpD7T3GWYUQSFyrhG8SgwE8V`


### PR DESCRIPTION
Closes #813 (non-blocking carry from #811's review). Adds a superseded banner atop the stale 2026-07-13 pre-Pinocchio manual record, pointing readers at the CI-maintained `docs/PROGRAM-HASH.md` + the `program-hash` branch (the #811 machinery). Kept as a historical record rather than deleted — the banner makes the supersession explicit. Docs-only, one file.