### PR TITLE
onchain: record the frozen devnet reference vault (#599 / PB-4)

### DIFF
--- a/onchain-academy/reference-vault/README.md
+++ b/onchain-academy/reference-vault/README.md
@@ -1,0 +1,55 @@
+# Devnet Reference Vault — frozen curriculum artifact (#599 / spec item 10, PB-4)
+
+A minimal, **frozen** (upgrade authority = none) devnet deployment of the canonical
+`VaultState` program that C2 (struct/bytes lessons) and C3 (PDA lessons) teach and C4
+reads. Its account layout is a **curriculum-wide decision** — courses may rely on these
+exact bytes and this fixed address. Deployed and frozen 2026-07-27.
+
+## Coordinates
+
+| Field                   | Value                                                                                           |
+| ----------------------- | ----------------------------------------------------------------------------------------------- |
+| Program ID (fixed)      | `D7ZFoWvEG5NBnkJy6iC98rhwj2qhgq8xhSD42cdTRAQd`                                                  |
+| Network                 | devnet                                                                                          |
+| Deployed `.so` sha256   | `486367e21cbaa88b254e0ea78ed427070569cb25f1237f72210359d660b62ca8`                              |
+| Upgrade authority       | **none (frozen, irreversible)**                                                                 |
+| Reference vault PDA     | `FY86s1fAwUiFQTjVFYprsiV6fwNH7e955MSUBo73FP4j`                                                  |
+| Vault `owner` field     | `6JFH1dxqiw6Dc81CbWdx4TUT8CvAfgwZg33wQrSytZsU`                                                  |
+| Vault `balance`         | `100000000` (0.1 SOL, recorded)                                                                 |
+| On-chain IDL (metadata) | `AUAPj7TdS9LXfdkLQC7eaW4aSXLLPScSqEF6Zn325PQX` (seed `idl`)                                     |
+| IDL (this repo)         | [`vault_program.idl.json`](./vault_program.idl.json) — field-identical to the on-chain metadata |
+
+## Account layout (`VaultState`, 49 bytes)
+
+```
+offset 0  len 8  : discriminator = [228,196,82,165,98,210,235,152] = sha256("account:VaultState")[..8]
+offset 8  len 32 : owner   (Pubkey)
+offset 40 len 8  : balance (u64 LE)
+offset 48 len 1  : bump    (u8, canonical)
+```
+
+`INIT_SPACE == 41` (data, no discriminator); `space == 49`. PDA seeds:
+`[b"vault", owner_pubkey]`.
+
+## Instructions
+
+`initialize_vault()`, `deposit(amount: u64)`, `withdraw(amount: u64)` — accounts in IDL
+order `[vault, user, system_program]` (**vault first**). Errors: `6000 Overflow`,
+`6001 InsufficientFunds`, `6002 ZeroAmount`, `6003 NotOwner`.
+
+> **Client authors:** honor the IDL account order (`[vault, user, system_program]`).
+> See #821 for a C4 mock stand-in that had this inverted.
+
+## Provenance / verification (all before freeze)
+
+- Program source byte-identical to C3's canonical `deploy-and-publish-the-idl` solution;
+  independent adversarial review verdict **FREEZE-SAFE** (layout fidelity, financial
+  safety of the direct-PDA-debit withdraw, init safety, exclusions all verified).
+- On-chain program dump sha256 **matched** the local build byte-for-byte.
+- Vault account decoded field-for-field against this IDL (owner/balance/bump).
+- Behavioral: `deposit(0)` returns `6002` (ZeroAmount) on-chain.
+- Deployed via the Helius devnet RPC only. Then upgrade authority set `--final`.
+
+Transactions: deploy `49AVAMkWNvu351R15qgrrrpsxmEMdagWdkQDQEfFb613fDFb9XY4sNoeM1TTkWGMqA3TPjrUtXZ4RxSsSqHEWeqS`,
+init+deposit `3EhspCQr1UiamUn6UbpXnk1VP1KLQTSzXmd8Mu99m5m4bzMU2kNvVnMVvgtBz1zCwaF26fPbwa388oiBtZEXDHwm`,
+freeze `cE2s7WGb3EvXj2Jw3BukBKoeLpSANk49ztBz9g7UDoitESeQLY6ehgPLC6cBic2hmQDt7cXBiHAxC9CfUiz1FYa`.

--- a/onchain-academy/reference-vault/vault_program.idl.json
+++ b/onchain-academy/reference-vault/vault_program.idl.json
@@ -1,0 +1,176 @@
+{
+  "address": "D7ZFoWvEG5NBnkJy6iC98rhwj2qhgq8xhSD42cdTRAQd",
+  "metadata": {
+    "name": "vault_program",
+    "version": "0.1.0",
+    "spec": "0.1.0"
+  },
+  "instructions": [
+    {
+      "name": "deposit",
+      "docs": [
+        "Module 3. Lamports IN move via a System Program CPI, because the debited",
+        "account is the user's wallet and System owns that. The recorded balance",
+        "moves via your Course 2 method. Two writes that have to agree."
+      ],
+      "discriminator": [242, 35, 198, 137, 82, 225, 242, 182],
+      "accounts": [
+        {
+          "name": "vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [118, 97, 117, 108, 116]
+              },
+              {
+                "kind": "account",
+                "path": "user"
+              }
+            ]
+          }
+        },
+        {
+          "name": "user",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "amount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "initialize_vault",
+      "docs": [
+        "Module 2. Creates the per-user vault PDA and stores the canonical bump."
+      ],
+      "discriminator": [48, 191, 163, 44, 71, 129, 63, 164],
+      "accounts": [
+        {
+          "name": "vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [118, 97, 117, 108, 116]
+              },
+              {
+                "kind": "account",
+                "path": "user"
+              }
+            ]
+          }
+        },
+        {
+          "name": "user",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "withdraw",
+      "docs": [
+        "Module 3, and the instruction with no CPI in it. The debited account is",
+        "the vault, which OUR program owns — so our program may move its lamports",
+        "directly. The System Program could not do it for us at any price: it",
+        "refuses to debit an account carrying data, and it does not own this one."
+      ],
+      "discriminator": [183, 18, 70, 156, 148, 109, 161, 34],
+      "accounts": [
+        {
+          "name": "vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [118, 97, 117, 108, 116]
+              },
+              {
+                "kind": "account",
+                "path": "user"
+              }
+            ]
+          }
+        },
+        {
+          "name": "user",
+          "writable": true,
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "amount",
+          "type": "u64"
+        }
+      ]
+    }
+  ],
+  "accounts": [
+    {
+      "name": "VaultState",
+      "discriminator": [228, 196, 82, 165, 98, 210, 235, 152]
+    }
+  ],
+  "errors": [
+    {
+      "code": 6000,
+      "name": "Overflow",
+      "msg": "Deposit would overflow the vault balance"
+    },
+    {
+      "code": 6001,
+      "name": "InsufficientFunds",
+      "msg": "Withdrawal is larger than the vault balance"
+    },
+    {
+      "code": 6002,
+      "name": "ZeroAmount",
+      "msg": "Amount must be greater than zero"
+    },
+    {
+      "code": 6003,
+      "name": "NotOwner",
+      "msg": "Signer is not the vault owner"
+    }
+  ],
+  "types": [
+    {
+      "name": "VaultState",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "balance",
+            "type": "u64"
+          },
+          {
+            "name": "bump",
+            "type": "u8"
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Records the fixed address + committed IDL for the frozen devnet reference vault (spec item 10 / PB-4), the acceptance-criteria deliverable for #599.

**This is a record-only commit** — 2 files under `onchain-academy/reference-vault/` (the frozen program's IDL + a README of coordinates/layout/provenance). No program source, no deploy code, no runtime path. The program itself is already deployed and **frozen (upgrade authority = none, irreversible)** on devnet.

- Program ID: `D7ZFoWvEG5NBnkJy6iC98rhwj2qhgq8xhSD42cdTRAQd`
- Deployed .so sha256: `486367e2…` (on-chain dump byte-matched local before freeze)
- Vault PDA `FY86s1f…`, owner `6JFH…tZsU`, balance 100000000
- Independent adversarial review: **FREEZE-SAFE**; behavioral `deposit(0)→6002` confirmed on-chain.

Unblocks C1 (#673) and the C4 dead-end fallback. Client authors: honor the IDL account order `[vault, user, system_program]` (see #821).