### PR TITLE
test(e2e): O-4 journey — anonymous bank → sign-in replay + #459 exemption (#819)

### DIFF
--- a/apps/web/e2e/o4-journey.spec.ts
+++ b/apps/web/e2e/o4-journey.spec.ts
@@ -1,0 +1,213 @@
+import { test, expect } from "@playwright/test";
+import { signInAsLearner } from "./harness/session";
+import { LEARN_LOOP } from "./harness/fixtures.mjs";
+
+// Spec 4 — The O-4 journey (#819): anonymous deep-link → do the work → claim
+// moment → sign in → banked progress replays and the completion is recorded.
+//
+// This is the launch-critical funnel (LX-A4c): a visitor who lands mid-lesson
+// from a share/deep-link can do the graded work while signed OUT, and must never
+// lose it at the sign-in wall. The work is banked in localStorage and replayed
+// server-side the moment they have an account.
+//
+// ── What this spec drives END-TO-END (the real implementation, not a mock of
+//    it) ──────────────────────────────────────────────────────────────────────
+//   • Anonymous access to a lesson deep-link (the route is public — not in
+//     middleware's protectedPaths).
+//   • The real QuizBlock reports its proof upward via ctx.setProof on selection.
+//   • The real anonymous claim path: lesson-client's "Sign In to Track Progress"
+//     button → openClaimAuth → bankCurrentLesson writes the EXACT proofs the
+//     completion POST would carry into localStorage under the real bank key.
+//   • The real "Later" affordance (auth-modal showLater/onLater) — the escape
+//     that dismisses WITHOUT discarding the banked work (F4).
+//   • The real replay: on sign-in, the globally-mounted BankedProgressReplay
+//     (GamificationOverlays) sees the bank and POSTs /api/lessons/complete with
+//     `replay: true` and the banked proofs; on success it clears the bank and
+//     surfaces the "progress restored" toast.
+//
+// ── Where a leg falls back, and why (documented per the #819 brief) ───────────
+//   • SIGN-IN itself: the harness has no real OAuth/SIWS provider (README:
+//     "no real keys, no real JWT, no real wallet"). Every other e2e spec that
+//     needs an authed session mints the @supabase/ssr session cookie directly
+//     (harness/session.signInAsLearner) — getSession() reads it locally with no
+//     network. We do the same to model the post-OAuth return: the learner banks
+//     while anonymous, then the session appears and the page reloads, exactly as
+//     the OAuth callback redirect back into the lesson would leave things. The
+//     transition we assert on is the one we CAN own end-to-end: bank-while-anon
+//     → session-present → replay-fires-with-the-banked-work.
+//   • The CHAIN/route seam: as in learn-loop.spec, Playwright owns the
+//     browser↔route seam and fulfils POST /api/lessons/complete. So this spec
+//     asserts the CLIENT emits a correct replay request (marker + banked
+//     proofs) and honours the response (bank cleared, toast). Whether the SERVER
+//     honours the `replay: true` marker — the #459 volume-gate exemption — runs
+//     server-side and cannot be observed through this mocked seam; it is covered,
+//     observably, at the integration layer in
+//     app/api/lessons/complete/__tests__/{gate,o4-replay-exemption}.test.ts.
+//     Together the two layers close the loop: client SENDS replay:true (here),
+//     server EXEMPTS on replay:true (integration).
+
+const BANK_KEY = "superteam:progress-bank:v1";
+
+interface BankedEntry {
+  courseId: string;
+  lessonId: string;
+  proofs: Record<string, unknown>;
+}
+
+const readBank = (page: import("@playwright/test").Page) =>
+  page.evaluate((key) => {
+    const raw = window.localStorage.getItem(key);
+    return raw ? (JSON.parse(raw) as unknown[]) : [];
+  }, BANK_KEY);
+
+test.describe("O-4 journey (anonymous → sign in → banked replay)", () => {
+  test("anonymous work banks, survives the sign-in wall, and replays with replay:true", async ({
+    page,
+    context,
+  }) => {
+    // Own the browser↔route seam for the WHOLE test. Nothing should POST here
+    // while anonymous (the anon path banks locally, never calls the route); the
+    // only completion POST is the replay after sign-in. Capture every body so an
+    // unexpected anonymous POST would be caught, and fulfil the success the route
+    // would return once the on-chain tx lands.
+    const completionBodies: Array<{
+      lessonId?: string;
+      courseId?: string;
+      replay?: boolean;
+      proofs?: Record<string, unknown>;
+    }> = [];
+    await page.route("**/api/lessons/complete", async (route) => {
+      completionBodies.push(route.request().postDataJSON());
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          success: true,
+          alreadyCompleted: false,
+          signature: "e2e-mock-replay-signature",
+        }),
+      });
+    });
+
+    // ── 1. Anonymous deep-link into the flagship lesson ──────────────────────
+    // No session cookie is attached — this is a cold, signed-out visitor landing
+    // mid-course, the O-4 entry condition.
+    await page.goto(
+      `/en/courses/${LEARN_LOOP.courseSlug}/lessons/${LEARN_LOOP.lessonSlug}`
+    );
+
+    // ── 2. Do the graded work while signed out ───────────────────────────────
+    // Answer the retrieval quiz (option "a" is the key for every question) and
+    // check each one, exercising the real QuizBlock. Selecting the options is
+    // what drives ctx.setProof → the proofs the bank will carry.
+    for (const qid of ["q1", "q2", "q3", "q4"]) {
+      await page.locator(`input[name="${qid}"][value="a"]`).check();
+    }
+    const checkButtons = page.getByRole("button", { name: "Check answer" });
+    const checkCount = await checkButtons.count();
+    expect(checkCount).toBeGreaterThan(0);
+    for (let i = 0; i < checkCount; i++) await checkButtons.nth(i).click();
+
+    // Nothing has hit the completion route yet — an anonymous learner cannot
+    // complete on-chain; the work only lives locally at this point.
+    expect(completionBodies).toHaveLength(0);
+
+    // ── 3. Claim moment: "Sign In to Track Progress" banks, then prompts ──────
+    // This is the anonymous CTA (lesson-client, userId falsy). Clicking it runs
+    // bankCurrentLesson BEFORE opening the modal — the modal's Later escape
+    // relies on the work already being saved.
+    await page
+      .getByRole("button", { name: "Sign In to Track Progress" })
+      .click();
+
+    // The claim-moment modal is open with its "keep your progress" framing.
+    await expect(
+      page.getByRole("heading", { name: "Save your progress" })
+    ).toBeVisible();
+
+    // ── 4. Assert the work is BANKED (the real key, the real proofs) ─────────
+    const banked = (await readBank(page)) as BankedEntry[];
+    expect(banked).toHaveLength(1);
+    const entry = banked[0]!;
+    expect(entry).toMatchObject({
+      courseId: LEARN_LOOP.courseId,
+      lessonId: LEARN_LOOP.lessonId,
+    });
+    // The banked proofs are the real quiz submission, not an empty placeholder:
+    // the QuizBlock's proof is `{ selections: { q1: ["a"], … } }`, keyed by the
+    // block key. Assert the shape survived into storage.
+    const proofsJson = JSON.stringify(entry.proofs);
+    expect(Object.keys(entry.proofs).length).toBeGreaterThan(0);
+    expect(proofsJson).toContain("selections");
+    expect(proofsJson).toContain("q1");
+
+    // ── 5. The "Later" affordance is present and non-destructive ─────────────
+    // F4: the escape never implies the work is lost — it reassures it is kept.
+    const laterButton = page.getByRole("button", { name: "Later" });
+    await expect(laterButton).toBeVisible();
+    await expect(
+      page.getByText("No rush — your progress stays saved on this device.")
+    ).toBeVisible();
+
+    // Take the Later escape (the learner defers sign-in) and confirm the bank is
+    // UNTOUCHED — dismissing must not discard.
+    await laterButton.click();
+    await expect(laterButton).toBeHidden();
+    expect(await readBank(page)).toHaveLength(1);
+
+    // ── 6. Sign in ───────────────────────────────────────────────────────────
+    // The learner comes back and authenticates. The harness cannot run real
+    // OAuth, so we mint the session the OAuth callback would have left (see the
+    // header note) and reload into the lesson — the callback's own redirect
+    // target. localStorage (the bank) survives the reload; the session now
+    // exists, so the globally-mounted BankedProgressReplay will fire.
+    await signInAsLearner(context);
+
+    // Arm the assertion BEFORE the reload that triggers the replay: wait for the
+    // completion POST that carries the replay marker.
+    const replayRequest = page.waitForRequest((req) => {
+      if (!req.url().includes("/api/lessons/complete")) return false;
+      if (req.method() !== "POST") return false;
+      try {
+        return req.postDataJSON()?.replay === true;
+      } catch {
+        return false;
+      }
+    });
+
+    await page.reload();
+
+    // ── 7. The replay fires with `replay: true` and the banked work ──────────
+    const replay = await replayRequest;
+    const replayBody = replay.postDataJSON() as {
+      lessonId: string;
+      courseId: string;
+      replay: boolean;
+      proofs: Record<string, unknown>;
+    };
+    expect(replayBody).toMatchObject({
+      lessonId: LEARN_LOOP.lessonId,
+      courseId: LEARN_LOOP.courseId,
+      replay: true,
+    });
+    // The replayed proofs are the ones banked while anonymous — the server
+    // re-grades exactly what the learner produced, so replay grants nothing a
+    // live completion wouldn't.
+    expect(JSON.stringify(replayBody.proofs)).toContain("selections");
+
+    // Exactly one completion POST happened, and it was the replay (marked). The
+    // route handler pushes asynchronously (it can lag the waitForRequest above,
+    // which resolves at request ISSUANCE), so poll for it — the assertion is the
+    // steady state, never a race on handler timing.
+    await expect.poll(() => completionBodies.length).toBe(1);
+    expect(completionBodies[0]?.replay).toBe(true);
+
+    // ── 8. Completion recorded → bank cleared + progress-restored surfaced ────
+    // On the route's 200, replayBankedCompletions removes the entry (a success
+    // never re-replays) and BankedProgressReplay raises the restore toast. The
+    // cleared bank is the durable "recorded" signal; the toast is the learner-
+    // facing confirmation their earned progress (and its XP) landed.
+    await expect.poll(async () => (await readBank(page)).length).toBe(0);
+    await expect(page.getByText("Restored 1 completed lesson")).toBeVisible();
+  });
+});

--- a/apps/web/src/app/api/lessons/complete/__tests__/o4-replay-exemption.test.ts
+++ b/apps/web/src/app/api/lessons/complete/__tests__/o4-replay-exemption.test.ts
@@ -1,0 +1,193 @@
+/* eslint-disable import/order -- vi.mock calls must precede importing the route. */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+import type { GradeResult } from "@/lib/grading/types";
+
+vi.mock("server-only", () => ({}));
+
+// The server half of the O-4 journey (#819). The E2E (e2e/o4-journey.spec.ts)
+// proves the CLIENT sends `replay: true` with the banked proofs; it cannot reach
+// the server-side #459 volume gate through its mocked route seam. This test is
+// that other half, made OBSERVABLE (not assumed): under a REAL per-user token
+// bucket, a NON-replay burst trips the gate exactly at exhaustion while an equal
+// replay burst never does — the LX-A4c exemption is the counter arithmetic, not
+// just a branch that runs.
+//
+// It complements gate.test.ts's replay cases (which use a boolean mock to show
+// the per-user key is/ isn't queried): here the bucket actually depletes across
+// a burst, so the assertion is the OBSERVED divergence in 429 counts.
+
+const {
+  getUser,
+  singleProfile,
+  getLessonByIdForGrading,
+  codeGrader,
+  isOnChainProgramLive,
+  isCourseInMaintenance,
+  isPlatformFrozen,
+} = vi.hoisted(() => ({
+  getUser: vi.fn<() => Promise<unknown>>(),
+  singleProfile: vi.fn<() => Promise<unknown>>(),
+  getLessonByIdForGrading: vi.fn(),
+  codeGrader: vi.fn<() => Promise<GradeResult>>(),
+  isOnChainProgramLive: vi.fn<() => Promise<boolean>>(),
+  isCourseInMaintenance: vi.fn<() => Promise<boolean>>(),
+  isPlatformFrozen: vi.fn<() => Promise<boolean>>(),
+}));
+
+// A REAL, stateful fixed-window bucket per namespace:key — the point of this
+// test. Returns true (limited) once a key has been queried maxTokens times.
+// The route only passes maxTokens for the two completion namespaces, so we model
+// those: per-user 40, per-IP 1200 (the production sizes). Keyed by namespace+key
+// so per-user (user id) and per-IP (client ip) count independently.
+const buckets = new Map<string, number>();
+const CAPS: Record<string, number> = {
+  "lessons:complete": 40,
+  "lessons:complete:ip": 1200,
+};
+function bucketLimited(namespace: string, key: string): boolean {
+  const cap = CAPS[namespace];
+  if (cap === undefined) return false;
+  const id = `${namespace}:${key}`;
+  const used = buckets.get(id) ?? 0;
+  if (used >= cap) return true; // exhausted → limited
+  buckets.set(id, used + 1);
+  return false;
+}
+
+vi.mock("@/lib/rate-limit", () => ({
+  isRateLimited: (namespace: string, key: string) =>
+    Promise.resolve(bucketLimited(namespace, key)),
+  releaseRateLimit: () => Promise.resolve(),
+  getClientIp: () => "203.0.113.7",
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: async () => ({ auth: { getUser } }),
+}));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: () => ({
+    from: () => ({
+      select: () => ({ eq: () => ({ single: singleProfile }) }),
+    }),
+  }),
+}));
+
+vi.mock("@/lib/content/queries", () => ({
+  getLessonByIdForGrading,
+  getCourseById: vi.fn(),
+}));
+
+vi.mock("@/lib/grading/graders", () => ({
+  GRADERS: { code: () => codeGrader() },
+}));
+
+vi.mock("@/lib/review/schedule-review", () => ({
+  captureReviewFailure: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/lib/ai/check-seal", () => ({ openAttestation: () => true }));
+
+vi.mock("@/lib/solana/academy-program", () => ({
+  isOnChainProgramLive,
+  completeLesson: vi.fn(),
+  getConnection: vi.fn(),
+  getProgramId: vi.fn(),
+}));
+vi.mock("@/lib/solana/academy-reads", () => ({
+  fetchEnrollment: vi.fn(),
+  fetchCourse: vi.fn(),
+}));
+vi.mock("@/lib/solana/bitmap", () => ({ isLessonComplete: vi.fn() }));
+vi.mock("@/lib/courses/lesson-slot", () => ({ getLessonSlot: () => 0 }));
+vi.mock("@/lib/logging", () => ({ logError: vi.fn() }));
+vi.mock("@/lib/content/deployments", () => ({ isCourseInMaintenance }));
+vi.mock("@/lib/platform/freeze", () => ({ isPlatformFrozen }));
+
+import { POST } from "../route";
+
+// A wrong-answer proof: the request runs the whole gate — freeze, volume,
+// grading — and stops at grading (403) WITHOUT touching the chain. That keeps
+// each call cheap and isolates what we are measuring: whether the VOLUME gate
+// let the request through to grading (403) or throttled it (429).
+function post(replay: boolean): Promise<Response> {
+  return POST(
+    new NextRequest("http://localhost/api/lessons/complete", {
+      method: "POST",
+      body: JSON.stringify({
+        lessonId: "lesson-1",
+        courseId: "course-1",
+        proofs: { c1: { code: "wrong" } },
+        ...(replay ? { replay: true } : {}),
+      }),
+      headers: { "content-type": "application/json" },
+    })
+  );
+}
+
+async function burst(n: number, replay: boolean): Promise<number[]> {
+  const statuses: number[] = [];
+  // Sequential — a fixed-window counter must see ordered pressure, and the route
+  // replays the bank sequentially too (replay-banked.ts).
+  for (let i = 0; i < n; i++) statuses.push((await post(replay)).status);
+  return statuses;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  buckets.clear();
+  process.env.NEXT_PUBLIC_SUPABASE_URL = "http://localhost";
+  process.env.SUPABASE_SERVICE_ROLE_KEY = "srk";
+  getUser.mockResolvedValue({ data: { user: { id: "user-1" } }, error: null });
+  singleProfile.mockResolvedValue({ data: { wallet_address: "wallet-1" } });
+  getLessonByIdForGrading.mockResolvedValue({
+    blocks: [{ _type: "code", key: "c1" }],
+  });
+  codeGrader.mockResolvedValue({ ok: false, status: 403 });
+  isOnChainProgramLive.mockResolvedValue(false);
+  isCourseInMaintenance.mockResolvedValue(false);
+  isPlatformFrozen.mockResolvedValue(false);
+});
+
+describe("O-4 replay exemption is observable under a real burst (#819 / LX-A4c)", () => {
+  const OVER_USER_CAP = 45; // > the 40/hr per-user bucket
+
+  it("a NON-replay burst trips the per-user volume gate at exhaustion", async () => {
+    const statuses = await burst(OVER_USER_CAP, /* replay */ false);
+
+    const throttled = statuses.filter((s) => s === 429).length;
+    const reachedGrading = statuses.filter((s) => s === 403).length;
+
+    // First 40 pass the per-user gate and reach grading; 41..45 are throttled.
+    expect(reachedGrading).toBe(40);
+    expect(throttled).toBe(OVER_USER_CAP - 40);
+    // The per-user bucket is the one that tripped (it hit its 40 cap); per-IP
+    // (1200) is nowhere near, so this 429 is the per-USER limit, as designed.
+    expect(buckets.get("lessons:complete:user-1")).toBe(40);
+  });
+
+  it("an equal REPLAY burst is NEVER throttled by the per-user gate", async () => {
+    const statuses = await burst(OVER_USER_CAP, /* replay */ true);
+
+    const throttled = statuses.filter((s) => s === 429).length;
+    const reachedGrading = statuses.filter((s) => s === 403).length;
+
+    // Every replayed completion reaches grading — the learner banks their whole
+    // anonymous session in one burst without their own history throttling them.
+    expect(throttled).toBe(0);
+    expect(reachedGrading).toBe(OVER_USER_CAP);
+    // Observable proof of "by construction": the per-user bucket was never even
+    // queried for a replay (the route skips it when replay === true), so it
+    // stays absent — not merely under-cap.
+    expect(buckets.has("lessons:complete:user-1")).toBe(false);
+  });
+
+  it("the per-IP burn-rate gate is NOT loosened by replay — it still counts every replay", async () => {
+    await burst(OVER_USER_CAP, /* replay */ true);
+
+    // Replay skips ONLY the per-user key; the per-IP key (the one that bounds a
+    // Sybil farm's burn rate) is charged on every request, replay or not.
+    expect(buckets.get("lessons:complete:ip:203.0.113.7")).toBe(OVER_USER_CAP);
+  });
+});


### PR DESCRIPTION
Closes #819 (P1). Adds coverage for the launch-critical O-4 funnel — the one journey the Playwright suite didn't cover. **Test-only: 2 new files, zero production code.**

## `e2e/o4-journey.spec.ts` (on the #787 mock-Supabase harness)
Drives the REAL implementation, leg by leg: anonymous deep-link renders flagship lesson 1 → real QuizBlock answered + checked (no completion POST while anon) → 'Sign In to Track Progress' opens the claim modal → **banked**: asserts the actual `superteam:progress-bank:v1` key holds one entry with the real quiz proofs (not a placeholder) → **Later** affordance visible, click dismisses without discarding the bank → sign in + reload → **replay**: catches `POST /api/lessons/complete` with `replay===true` carrying the banked proofs, exactly one completion POST → **recorded**: bank cleared + 'Restored 1 completed lesson' toast.

**Honest fallbacks (documented in the spec header, not faked):** sign-in is modeled by minting the @supabase/ssr session cookie the way every other authed spec does (the harness has no real OAuth/SIWS); the server-side #459 exemption can't be observed through the mocked route seam, so it's covered at the integration layer below.

## `api/lessons/complete/__tests__/o4-replay-exemption.test.ts` (the security-negative, observable not assumed)
Drives the real route under a stateful fixed-window counter (matching lib/rate-limit.ts semantics): a **non-replay** burst of 45 → 40 reach grading, 5×429, per-user bucket == 40; an equal **replay** burst → **0 throttled, all 45 reach grading, and the per-user counter key is never even created** (`.has()===false` — 'by construction' made observable); and the **per-IP burn-rate gate still charges every replay** (== 45) — proving the anti-Sybil bound is NOT loosened (guards the tempting wrong-fix). Stronger than the existing boolean-mock cases, which are left in place.

## Verification (agent + orchestrator re-run at head)
typecheck 6/6; web suite **228 files / 2062 tests** (+3 = the integration tests); o4-replay-exemption 3/3. E2E auto-runs in CI (Playwright globs `e2e/*.spec.ts`) — proves out on this PR's run. Ran locally twice (isolated + parallel) for determinism; a request-issuance race was caught and fixed (the replay-body assertion via waitForRequest remains authoritative).
