### PR TITLE
chore(challenge): retire the fabricated web3.js-v1 PDA mock — loud stubs both runners (#818)

### DIFF
--- a/apps/web/src/components/editor/challenge-runner.tsx
+++ b/apps/web/src/components/editor/challenge-runner.tsx
@@ -7,15 +7,15 @@ import { Play, CircleNotch } from "@phosphor-icons/react";
 import type { TestCase } from "@superteam-lms/types";
 import { Keypair } from "@solana/web3.js";
 import { setCachedBinary } from "@superteam-lms/deploy";
+import { executeRustCode } from "@/lib/rust/execute";
+import { buildProgram } from "@/lib/build-server/client";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
 import type {
   ChallengeRunnerProps,
   ExecutionResult,
   TestResult,
 } from "./types";
-import { executeRustCode } from "@/lib/rust/execute";
-import { buildProgram } from "@/lib/build-server/client";
-import { cn } from "@/lib/utils";
-import { Button } from "@/components/ui/button";
 
 // ---------------------------------------------------------------------------
 // Web Worker sandbox — all user code executes in a separate thread with no
@@ -62,16 +62,23 @@ class MockPublicKey {
     if (!other || !other._bytes) return false;
     return this.toBase58() === other.toBase58();
   }
-  static isOnCurve() { return true; }
-  static findProgramAddressSync(seeds, programId) {
-    void programId;
-    const combined = new Uint8Array(seeds.reduce(function(a,s){ return a+s.length; }, 0) + 1);
-    let offset = 0;
-    for (const s of seeds) { combined.set(s, offset); offset += s.length; }
-    combined[offset] = 254;
-    const hash = new Uint8Array(32);
-    for (let i = 0; i < 32; i++) hash[i] = (combined[i % combined.length] || 0) ^ 0x5a;
-    return [new MockPublicKey(hash), 254];
+  // CAT-21: the fabricated findProgramAddressSync / isOnCurve mock retired with
+  // the legacy web3.js-v1 exercises. Kept as loud stubs so browser grading stays
+  // identical to the server executor — a block reaching for them fails with an
+  // explicit message, never a silent fabricated "pass". See executor.ts.
+  static isOnCurve() {
+    throw new Error(
+      "PublicKey.isOnCurve is not available in the grading sandbox (CAT-21: the " +
+      "web3.js-v1 PDA mock was retired; PB-1 grades challenges as pure functions " +
+      "over injected fixtures).",
+    );
+  }
+  static findProgramAddressSync() {
+    throw new Error(
+      "PublicKey.findProgramAddressSync is not available in the grading sandbox " +
+      "(CAT-21: the web3.js-v1 PDA mock was retired; PB-1 grades challenges as " +
+      "pure functions over injected fixtures).",
+    );
   }
 }
 

--- a/apps/web/src/lib/challenge/__tests__/executor.test.ts
+++ b/apps/web/src/lib/challenge/__tests__/executor.test.ts
@@ -236,6 +236,43 @@ describe.skipIf(!EXECUTOR_AVAILABLE)(
       expect(run.results.find((r) => r.id === "no-process")?.passed).toBe(true);
       expect(run.results.find((r) => r.id === "no-require")?.passed).toBe(true);
     });
+
+    // CAT-21: the fabricated PublicKey.findProgramAddressSync / isOnCurve mock
+    // was retired with the legacy web3.js-v1 exercises (PB-1: graded blocks are
+    // pure functions over injected fixtures, no SDK imports). A future block that
+    // reaches for the removed function must FAIL LOUDLY with an explicit message,
+    // NOT an "undefined is not a function" mystery. This test is meaningful (not
+    // vacuous): it asserts the specific retirement message AND that the failure
+    // is not a generic TypeError — it regresses (fails) if the loud stub is
+    // replaced by a bare `undefined` or the message loses its CAT-21/PB-1 marker.
+    it("FAILS LOUDLY when a block calls the retired findProgramAddressSync mock (CAT-21)", async () => {
+      const pdaTests: AdminTestCase[] = [
+        {
+          id: "derive",
+          description: "derives a PDA via the retired v1 helper",
+          input: "",
+          expectedOutput: "typeof result === 'string'",
+        },
+      ];
+      const usesRetiredMock = `import { PublicKey } from "@solana/web3.js";
+function derive() {
+  const seed = new TextEncoder().encode("vault");
+  const [pda] = PublicKey.findProgramAddressSync([seed], new PublicKey("11111111111111111111111111111111"));
+  return pda.toBase58();
+}`;
+      const run = await runJsSubmission(usesRetiredMock, pdaTests);
+      expect(run.available).toBe(true);
+      if (!run.available) return;
+      expect(run.passed).toBe(false);
+      const detail = run.results.find((r) => r.id === "derive")?.detail ?? "";
+      // Explicit, actionable message — the retirement is named.
+      expect(detail).toContain("findProgramAddressSync");
+      expect(detail).toContain("not available in the grading sandbox");
+      expect(detail).toContain("CAT-21");
+      // Meaningful-ness guard: must NOT regress to the generic mystery error a
+      // bare `undefined` static would produce.
+      expect(detail).not.toMatch(/is not a function/);
+    });
   }
 );
 

--- a/packages/challenge-executor/src/executor.ts
+++ b/packages/challenge-executor/src/executor.ts
@@ -242,19 +242,28 @@ MockPublicKey.prototype.equals = function (other) {
   if (!other || !other._bytes) return false;
   return this.toBase58() === other.toBase58();
 };
-MockPublicKey.isOnCurve = function () { return true; };
-MockPublicKey.findProgramAddressSync = function (seeds, programId) {
-  void programId;
-  var total = 1;
-  for (var i = 0; i < seeds.length; i++) total += seeds[i].length;
-  var combined = new Uint8Array(total);
-  var offset = 0;
-  for (var j = 0; j < seeds.length; j++) { combined.set(seeds[j], offset); offset += seeds[j].length; }
-  combined[offset] = 254;
-  var hash = new Uint8Array(32);
-  for (var k = 0; k < 32; k++) hash[k] = (combined[k % combined.length] || 0) ^ 0x5a;
-  return [new MockPublicKey(hash), 254];
-};
+/* CAT-21: the fabricated PublicKey.findProgramAddressSync / isOnCurve mock — a
+ * web3.js-v1 shim whose findProgramAddressSync returned a hand-rolled hash with
+ * the bump hardcoded to 254 (no curve check, no retry loop) and whose isOnCurve
+ * always returned true — was RETIRED with the legacy web3.js-v1 exercises. It is
+ * the JavaScript twin of the DefaultHasher PDA model the Rust syllabi delete,
+ * and it is the documented root cause of the old keypair-challenge grading
+ * isValid:true unconditionally. Grading is now pure functions over injected
+ * fixtures (PB-1), so no live block imports these. They stay as LOUD stubs so a
+ * future block reaching for them fails with an explicit message rather than an
+ * "undefined is not a function" mystery. */
+function __retiredPdaShim__(name) {
+  return function () {
+    /* Markers front-loaded so they survive the 200-char detail slice. */
+    throw new Error(
+      name + " is not available in the grading sandbox (CAT-21: the web3.js-v1 " +
+      "PDA mock was retired; PB-1 grades challenges as pure functions over " +
+      "injected fixtures)."
+    );
+  };
+}
+MockPublicKey.isOnCurve = __retiredPdaShim__("PublicKey.isOnCurve");
+MockPublicKey.findProgramAddressSync = __retiredPdaShim__("PublicKey.findProgramAddressSync");
 
 function MockKeypair() {
   this.secretKey = randomBytes(64);


### PR DESCRIPTION
Closes #818 (CAT-21, licensed by the PB-1 decision in #600).

## What the mock was
The challenge executor's in-isolate `__modules__["@solana/web3.js"]` shim carried a fabricated `MockPublicKey.findProgramAddressSync` (XOR-of-seeds "hash", bump hardcoded 254, no curve check) and `isOnCurve` (always `true` — the documented root cause of the old keypair-challenge grading bug). The same mock was duplicated in the browser Web-Worker runner (`challenge-runner.tsx`).

## Live-content dependency check (the go/no-go): CLEAN
Three independent vectors, all zero: (1) a walk over every graded code block in the committed bundle (40 blocks — no `findProgramAddressSync`/`isOnCurve`/imports; the lone `@solana/web3.js` hit is narrative prose in the C4 "legacy seam" lesson); (2) grep across all courses-academy exercise files (hits only in CATALOG.md docs); (3) the strongest signal — content-lint runs the REAL executor oracle over the bundle and stays green. The 4 live courses are Kit-era, exactly as PB-1 predicted.

## The change (3 files, +80/−27)
Both mock functions become **loud stubs** in BOTH the server executor and the browser twin (kept identical to preserve client/server grading parity): they throw `"…not available in the grading sandbox (CAT-21: the web3.js-v1 PDA mock was retired; PB-1 grades challenges as pure functions over injected fixtures)"` — message engineered so the CAT-21/PB-1 markers survive `runCase`'s 200-char `detail` truncation. Replaces the undefined-is-not-a-function mystery with an actionable error. No orphaned v1 exercise fixtures existed to remove.

## Guard test — proven meaningful
New executor test asserts `passed === false`, the detail contains the marker strings, AND `.not.toMatch(/is not a function/)`. Deliberately regressing the stub to a bare `undefined` made it FAIL — so it pins the loud message, not just "something threw".

## Verified at 6c58f4ce (agent + orchestrator re-runs in clean clone)
typecheck 6/6; executor suite 21/21; web suite **228 files / 2063 tests**; content-lint **107/107** (real oracle over the bundle); lint clean.
