### PR TITLE
fix(ui): AI countdown chip readability + name-reveal modal recurrence (#842, #843)

### DIFF
--- a/apps/web/src/components/dashboard/__tests__/name-reveal-dialog.test.tsx
+++ b/apps/web/src/components/dashboard/__tests__/name-reveal-dialog.test.tsx
@@ -1,0 +1,123 @@
+// @vitest-environment jsdom
+/* eslint-disable import/order -- vi.mock calls must precede importing the component. */
+// #843 — the name-reveal modal must be gated on the DURABLE record
+// (profiles.prefs.nameRevealSeen), not on localStorage or name_rerolls_used:
+// a learner who accepts the first generated name leaves rerolls at 0 forever,
+// and localStorage is per-browser, so the old gate re-prompted on every new
+// device/cleared profile.
+import type { ReactElement } from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import messages from "@/messages/en.json";
+
+const { maybeSingle, updatePayloads } = vi.hoisted(() => ({
+  maybeSingle: vi.fn(),
+  updatePayloads: [] as Array<Record<string, unknown>>,
+}));
+
+vi.mock("@/lib/supabase/client", () => ({
+  createClient: () => ({
+    from: () => ({
+      select: () => ({ eq: () => ({ maybeSingle }) }),
+      update: (payload: Record<string, unknown>) => {
+        updatePayloads.push(payload);
+        return { eq: () => Promise.resolve({ error: null }) };
+      },
+    }),
+  }),
+}));
+
+import { NameRevealDialog } from "../name-reveal-dialog";
+
+function renderDialog(props: { nameRerollsUsed?: number } = {}): ReactElement {
+  const ui = (
+    <NextIntlClientProvider locale="en" messages={messages}>
+      <NameRevealDialog
+        isLoading={false}
+        userId="user-1"
+        username="brave-anchor-9000"
+        nameRerollsUsed={props.nameRerollsUsed ?? 0}
+      />
+    </NextIntlClientProvider>
+  );
+  render(ui);
+  return ui;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  updatePayloads.length = 0;
+  localStorage.clear();
+});
+
+describe("NameRevealDialog — durable already-seen gate (#843)", () => {
+  it("never re-shows for a learner who confirmed on another device (prefs.nameRevealSeen set, localStorage empty)", async () => {
+    // The accept-without-reroll path: rerolls stayed 0, this browser has no
+    // localStorage record, but the profiles row says the reveal was confirmed.
+    maybeSingle.mockResolvedValue({
+      data: { prefs: { nameRevealSeen: true } },
+      error: null,
+    });
+
+    renderDialog({ nameRerollsUsed: 0 });
+
+    // The component must consult the profiles row before deciding to prompt.
+    await waitFor(() => expect(maybeSingle).toHaveBeenCalled());
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("still shows once for a genuinely new learner (prefs empty)", async () => {
+    maybeSingle.mockResolvedValue({ data: { prefs: null }, error: null });
+
+    renderDialog({ nameRerollsUsed: 0 });
+
+    expect(await screen.findByRole("dialog")).toBeInTheDocument();
+  });
+
+  it("persists nameRevealSeen to profiles.prefs on confirm, merging other prefs keys", async () => {
+    const existingPrefs = { nextLesson: { day: "tue", time: "19:00" } };
+    maybeSingle.mockResolvedValue({
+      data: { prefs: existingPrefs },
+      error: null,
+    });
+    // The gate read sees no seen-flag → show; force that for the first read.
+    maybeSingle.mockResolvedValueOnce({
+      data: { prefs: existingPrefs },
+      error: null,
+    });
+
+    renderDialog({ nameRerollsUsed: 0 });
+    await screen.findByRole("dialog");
+
+    screen.getByRole("button", { name: /ship it/i }).click();
+
+    await waitFor(() => expect(updatePayloads.length).toBeGreaterThan(0));
+    const written = updatePayloads[updatePayloads.length - 1]?.prefs as Record<
+      string,
+      unknown
+    >;
+    expect(written.nameRevealSeen).toBe(true);
+    // Merge, don't clobber: sibling prefs keys survive the confirm write.
+    expect(written.nextLesson).toEqual(existingPrefs.nextLesson);
+    expect(localStorage.getItem("nameRevealSeen")).toBe("1");
+    await waitFor(() =>
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+    );
+  });
+
+  it("keeps localStorage as an offline fast path — no prompt, no fetch, when already recorded locally", () => {
+    localStorage.setItem("nameRevealSeen", "1");
+
+    renderDialog({ nameRerollsUsed: 0 });
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(maybeSingle).not.toHaveBeenCalled();
+  });
+
+  it("does not prompt learners who already rerolled (rerolls > 0 proves they saw it)", () => {
+    renderDialog({ nameRerollsUsed: 2 });
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/dashboard/__tests__/name-reveal-dialog.test.tsx
+++ b/apps/web/src/components/dashboard/__tests__/name-reveal-dialog.test.tsx
@@ -106,6 +106,52 @@ describe("NameRevealDialog — durable already-seen gate (#843)", () => {
     );
   });
 
+  it("skips the durable write when the confirm-time prefs read fails — never clobber on a blind merge", async () => {
+    // Gate read succeeds (new learner) → dialog shows.
+    maybeSingle.mockResolvedValueOnce({ data: { prefs: null }, error: null });
+    // Confirm-time re-read fails: merging is impossible, so writing anyway
+    // would clobber sibling prefs keys (e.g. nextLesson) with a bare
+    // { nameRevealSeen: true } object.
+    maybeSingle.mockResolvedValue({
+      data: null,
+      error: { message: "read failed" },
+    });
+
+    renderDialog({ nameRerollsUsed: 0 });
+    await screen.findByRole("dialog");
+
+    screen.getByRole("button", { name: /ship it/i }).click();
+
+    // Both reads settled (gate + confirm re-read) …
+    await waitFor(() => expect(maybeSingle).toHaveBeenCalledTimes(2));
+    // … but no prefs UPDATE happened; the localStorage fast path still covers
+    // this browser and the dialog still closes.
+    expect(updatePayloads).toHaveLength(0);
+    expect(localStorage.getItem("nameRevealSeen")).toBe("1");
+    await waitFor(() =>
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+    );
+  });
+
+  it("does NOT write prefs on bare dismissal (Escape/overlay/X) — only per-browser localStorage", async () => {
+    maybeSingle.mockResolvedValue({ data: { prefs: null }, error: null });
+
+    renderDialog({ nameRerollsUsed: 0 });
+    const dialog = await screen.findByRole("dialog");
+
+    // The X close button drives Radix onOpenChange(false), same path as
+    // Escape and overlay taps.
+    screen.getByRole("button", { name: /close/i }).click();
+
+    await waitFor(() => expect(dialog).not.toBeInTheDocument());
+    // Accidental dismissal must not durably bury the reveal cross-device:
+    // no prefs write, no confirm-time re-read — only the gate read ran.
+    expect(updatePayloads).toHaveLength(0);
+    expect(maybeSingle).toHaveBeenCalledTimes(1);
+    // Pre-#843 per-browser behavior is kept: this browser stops nagging.
+    expect(localStorage.getItem("nameRevealSeen")).toBe("1");
+  });
+
   it("keeps localStorage as an offline fast path — no prompt, no fetch, when already recorded locally", () => {
     localStorage.setItem("nameRevealSeen", "1");
 

--- a/apps/web/src/components/dashboard/name-reveal-dialog.tsx
+++ b/apps/web/src/components/dashboard/name-reveal-dialog.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { createClient } from "@/lib/supabase/client";
+import type { Json } from "@/lib/supabase/types";
 import { Dialog, DialogContent } from "@/components/ui/dialog";
 import { WalletNameGenerator } from "@/components/profile/wallet-name-generator";
 
@@ -12,10 +13,21 @@ interface NameRevealDialogProps {
   nameRerollsUsed: number;
 }
 
+/** Narrows the untyped prefs blob to a plain object for reading/merging. */
+function toPrefsObject(prefs: unknown): Record<string, unknown> {
+  return prefs && typeof prefs === "object" && !Array.isArray(prefs)
+    ? (prefs as Record<string, unknown>)
+    : {};
+}
+
 /**
- * Name reveal modal — shown on first login (rerolls === 0 means never seen),
- * persisting the "seen" flag in localStorage and username changes in
- * Supabase.
+ * Name reveal modal — shown once per learner, on first login.
+ *
+ * "Already seen" is decided by `profiles.prefs.nameRevealSeen` (#843) — the
+ * durable, cross-device record (learner-owned JSONB, same store as
+ * `prefs.nextLesson`). localStorage is only an offline fast path, and
+ * `name_rerolls_used === 0` alone proves nothing: accepting the first
+ * generated name leaves rerolls at 0 forever.
  */
 export function NameRevealDialog({
   isLoading,
@@ -26,17 +38,35 @@ export function NameRevealDialog({
   const [showNameReveal, setShowNameReveal] = useState(false);
   const [dashboardUsername, setDashboardUsername] = useState(username);
 
-  // Show name reveal modal on first visit (rerolls === 0 means never seen)
   useEffect(() => {
-    if (
-      !isLoading &&
-      nameRerollsUsed === 0 &&
-      userId &&
-      !localStorage.getItem("nameRevealSeen")
-    ) {
+    // rerolls > 0 means the learner has been through the reveal already.
+    if (isLoading || !userId || nameRerollsUsed !== 0) return;
+    // Fast path: this browser already recorded a confirmation.
+    if (localStorage.getItem("nameRevealSeen")) return;
+
+    let cancelled = false;
+    (async () => {
+      const supabase = createClient();
+      const { data, error } = await supabase
+        .from("profiles")
+        .select("prefs")
+        .eq("id", userId)
+        .maybeSingle();
+      if (cancelled) return;
+      // Fail closed: if the prefs read errors we cannot prove "never seen",
+      // so don't prompt — a genuinely new learner just sees it next visit.
+      if (error || !data) return;
+      if (toPrefsObject(data.prefs).nameRevealSeen) {
+        // Confirmed on another device — backfill the local fast path.
+        localStorage.setItem("nameRevealSeen", "1");
+        return;
+      }
       setShowNameReveal(true);
-    }
-  }, [isLoading, nameRerollsUsed, userId]);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [isLoading, userId, nameRerollsUsed]);
 
   // Keep username in sync
   useEffect(() => {
@@ -59,6 +89,24 @@ export function NameRevealDialog({
   const handleNameConfirm = () => {
     localStorage.setItem("nameRevealSeen", "1");
     setShowNameReveal(false);
+    // Durable record (#843): re-read prefs and merge so sibling keys (e.g.
+    // prefs.nextLesson) are not clobbered. Best-effort — localStorage already
+    // covers this browser if the write fails.
+    void (async () => {
+      const supabase = createClient();
+      const { data } = await supabase
+        .from("profiles")
+        .select("prefs")
+        .eq("id", userId)
+        .maybeSingle();
+      const prefs = { ...toPrefsObject(data?.prefs), nameRevealSeen: true };
+      await supabase
+        .from("profiles")
+        // A plain JSON object; the merged record lacks the index signature the
+        // generated Json type wants, so cast at the boundary.
+        .update({ prefs: prefs as unknown as Json })
+        .eq("id", userId);
+    })();
   };
 
   return (

--- a/apps/web/src/components/dashboard/name-reveal-dialog.tsx
+++ b/apps/web/src/components/dashboard/name-reveal-dialog.tsx
@@ -86,6 +86,7 @@ export function NameRevealDialog({
     return !error;
   };
 
+  /** Real confirmation ("Ship it!") — record it durably, cross-device. */
   const handleNameConfirm = () => {
     localStorage.setItem("nameRevealSeen", "1");
     setShowNameReveal(false);
@@ -94,11 +95,16 @@ export function NameRevealDialog({
     // covers this browser if the write fails.
     void (async () => {
       const supabase = createClient();
-      const { data } = await supabase
+      const { data, error } = await supabase
         .from("profiles")
         .select("prefs")
         .eq("id", userId)
         .maybeSingle();
+      // Fail closed, mirroring the gating read: without a good read we cannot
+      // merge, and writing anyway would clobber sibling prefs keys. Skip the
+      // durable write — the localStorage fast path already covers this
+      // browser, and another device simply re-prompts.
+      if (error) return;
       const prefs = { ...toPrefsObject(data?.prefs), nameRevealSeen: true };
       await supabase
         .from("profiles")
@@ -109,8 +115,20 @@ export function NameRevealDialog({
     })();
   };
 
+  /**
+   * Bare dismissal (Escape / overlay / X) — NOT a confirmation. Keep only the
+   * pre-#843 per-browser localStorage record so this browser stops nagging,
+   * but skip the durable write: an accidental Escape must not permanently
+   * bury the reveal on every other device.
+   */
+  const handleDismiss = (open: boolean) => {
+    if (open) return;
+    localStorage.setItem("nameRevealSeen", "1");
+    setShowNameReveal(false);
+  };
+
   return (
-    <Dialog open={showNameReveal} onOpenChange={handleNameConfirm}>
+    <Dialog open={showNameReveal} onOpenChange={handleDismiss}>
       <DialogContent className="sm:max-w-md">
         <div className="py-4">
           <WalletNameGenerator

--- a/apps/web/src/components/editor/ai-partner/__tests__/ai-partner-pane.test.tsx
+++ b/apps/web/src/components/editor/ai-partner/__tests__/ai-partner-pane.test.tsx
@@ -160,6 +160,33 @@ describe("AiPartnerPane — think-first lock (#770)", () => {
     expect(screen.getByRole("button", { name: hintLabel })).toBeEnabled();
   });
 
+  it("renders the countdown chip OUTSIDE the collapse toggle; clicking it does not toggle (#842)", () => {
+    renderPane({ unlockAt: Date.now() + THREE_MIN });
+
+    const chip = screen.getByRole("status");
+    const toggle = screen.getByRole("button", { expanded: true });
+
+    // The chip must not live inside the toggle: nested, its clicks bubbled to
+    // the toggle and the pane collapsed out from under the tooltip (#842).
+    expect(toggle.contains(chip)).toBe(false);
+
+    // Clicking the countdown does nothing — pane stays open.
+    fireEvent.click(chip);
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByRole("button", { name: hintLabel })).toBeInTheDocument();
+
+    // The toggle itself still collapses and re-expands the pane.
+    fireEvent.click(toggle);
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+    expect(
+      screen.queryByRole("button", { name: hintLabel })
+    ).not.toBeInTheDocument();
+    // The chip survives the collapse — the wait stays visible in the header.
+    expect(screen.getByRole("status")).toBeInTheDocument();
+    fireEvent.click(toggle);
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
+  });
+
   it("counts down and unlocks once the window elapses", () => {
     vi.useFakeTimers();
     const start = Date.now();

--- a/apps/web/src/components/editor/ai-partner/ai-partner-pane.tsx
+++ b/apps/web/src/components/editor/ai-partner/ai-partner-pane.tsx
@@ -96,60 +96,70 @@ export function AiPartnerPane({
       )}
     >
       {/* Collapsible (#770): the whole pane folds to its header so the reading
-          column can be reclaimed. Starts open. */}
-      <button
-        type="button"
-        onClick={() => setOpen((v) => !v)}
-        aria-expanded={open}
-        aria-controls="ai-partner-body"
-        className="flex shrink-0 flex-col gap-2 border-b border-border px-4 py-3 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-      >
-        <div className="flex items-center gap-2">
-          <Robot
-            size={18}
-            weight="duotone"
-            className="text-primary"
-            aria-hidden="true"
-          />
-          <h2 className="font-display text-sm font-extrabold text-text">
-            {t("title")}
-          </h2>
+          column can be reclaimed. Starts open. The countdown chip is a SIBLING
+          of the toggle, not a child (#842): nested inside the button, every
+          chip click toggled the pane out from under the pointer and dismissed
+          the tooltip before it could be read. */}
+      <div className="flex shrink-0 items-start border-b border-border">
+        <button
+          type="button"
+          onClick={() => setOpen((v) => !v)}
+          aria-expanded={open}
+          aria-controls="ai-partner-body"
+          className="flex min-w-0 flex-1 flex-col gap-2 px-4 py-3 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          <div className="flex w-full items-center gap-2">
+            <Robot
+              size={18}
+              weight="duotone"
+              className="text-primary"
+              aria-hidden="true"
+            />
+            <h2 className="font-display text-sm font-extrabold text-text">
+              {t("title")}
+            </h2>
+            <CaretDown
+              size={14}
+              weight="bold"
+              aria-hidden="true"
+              className={cn(
+                "ml-auto text-text-3 transition-transform",
+                !open && "-rotate-90"
+              )}
+            />
+            <span className="sr-only">{tLesson("toggleSection")}</span>
+          </div>
+          <p className="text-xs text-text-3">
+            {disabled
+              ? t("completed")
+              : locked
+                ? t("lock.title")
+                : t("subtitle")}
+          </p>
+          <AssistMeter freeHintsUsed={freeHintsUsed} paidUsed={paidUsed} />
+        </button>
 
-          {/* Think-first countdown (#770): prominent, in the header's right
-              rail, so the wait is the first thing read — not a footnote. */}
-          {locked && (
-            <span
-              role="status"
-              title={t("lock.tooltip")}
-              aria-label={`${countdown} — ${t("lock.tooltip")}`}
-              className="ml-auto flex cursor-help items-center gap-1.5 rounded-full px-2.5 py-1 text-sm font-bold tabular-nums text-text [background:var(--input)]"
-            >
-              <Lock
-                size={16}
-                weight="duotone"
-                className="shrink-0 text-text-3"
-                aria-hidden="true"
-              />
-              {countdown}
-            </span>
-          )}
-          <CaretDown
-            size={14}
-            weight="bold"
-            aria-hidden="true"
-            className={cn(
-              "text-text-3 transition-transform",
-              !locked && "ml-auto",
-              !open && "-rotate-90"
-            )}
-          />
-          <span className="sr-only">{tLesson("toggleSection")}</span>
-        </div>
-        <p className="text-xs text-text-3">
-          {disabled ? t("completed") : locked ? t("lock.title") : t("subtitle")}
-        </p>
-        <AssistMeter freeHintsUsed={freeHintsUsed} paidUsed={paidUsed} />
-      </button>
+        {/* Think-first countdown (#770): prominent, in the header's right
+            rail, so the wait is the first thing read — not a footnote.
+            Outside the toggle's hit area (#842), so hovering it holds the
+            tooltip and clicking it does nothing. */}
+        {locked && (
+          <span
+            role="status"
+            title={t("lock.tooltip")}
+            aria-label={`${countdown} — ${t("lock.tooltip")}`}
+            className="mr-4 mt-3 flex shrink-0 cursor-help items-center gap-1.5 rounded-full px-2.5 py-1 text-sm font-bold tabular-nums text-text [background:var(--input)]"
+          >
+            <Lock
+              size={16}
+              weight="duotone"
+              className="shrink-0 text-text-3"
+              aria-hidden="true"
+            />
+            {countdown}
+          </span>
+        )}
+      </div>
 
       {/* Empty state stays COMPACT (#770): the prompt and the Hint button sit
           together in a short block — no reserved conversation area. The pane


### PR DESCRIPTION
Closes #842
Closes #843

## #842 — AI countdown chip unreadable

**Root cause**: the think-first countdown chip (`role="status"`, added by #791/#805/#817) was rendered as a child of the AI Partner header's collapse-toggle `<button>` in `ai-partner-pane.tsx`. Any click on the chip bubbled to the toggle, collapsing the pane out from under the pointer and dismissing the `title` tooltip before it could be read — two controls occupied the same pixels.

**Fix**: the header is now a flex row of **[toggle button][countdown chip]** — the chip is a sibling of the toggle, not a child (as the issue prefers over `stopPropagation`, which would only mask the collision). Preserved unchanged: `role="status"`, `title` + `aria-label` carrying the tooltip copy, tabular `m:ss` countdown, keyboard access to the toggle (`aria-expanded`/`aria-controls`, focus-visible ring), and the collapse behavior everywhere else in the header. The chip stays visible while the pane is collapsed.

New test: *renders the countdown chip OUTSIDE the collapse toggle; clicking it does not toggle (#842)* — asserts `toggle.contains(chip) === false`, that clicking the chip leaves the pane open, and that the toggle still collapses/expands. No existing #817 assertions weakened (all 11 pane tests pass).

## #843 — name-reveal modal reappears

**Root cause**: "already seen" was decided by `name_rerolls_used === 0` plus `localStorage.getItem("nameRevealSeen")`. A learner who accepts the first generated name never increments rerolls, and localStorage is per-browser — so the common path (accept first name, sign in on another device / cleared profile) reliably re-prompted. Nothing durable recorded completion.

**Fix**: confirmation is persisted to `profiles.prefs.nameRevealSeen` (the learner-owned JSONB store already used for `prefs.nextLesson`), via a read-merge-write so sibling prefs keys are never clobbered. The dialog is gated on that row: localStorage is only an offline fast path, and is backfilled when the row says seen. Prefs read errors fail closed (no spurious prompt). `name_rerolls_used` is untouched — using it as the marker would silently spend a reroll (per the issue).

### Red-proof (bug 2)

At main sha `4172d5c47a4296182aaf49d2aee0ebc5044ddeb3` (the branch point, component unmodified), the new test file `apps/web/src/components/dashboard/__tests__/name-reveal-dialog.test.tsx` fails:

- **`never re-shows for a learner who confirmed on another device (prefs.nameRevealSeen set, localStorage empty)`** — fails with `AssertionError: expected "vi.fn()" to be called at least once`: the component never reads `profiles.prefs` before prompting (and the dialog opens anyway).
- `persists nameRevealSeen to profiles.prefs on confirm, merging other prefs keys` — fails with `AssertionError: expected 0 to be greater than 0` (no prefs write ever happens).

Both pass with the fix; 3 companion tests (new-learner still sees it once, localStorage fast path, rerolls > 0 gate) also pass.

## Verification

- `pnpm typecheck` (root): 6/6 tasks pass
- `pnpm --filter web test` (full): **234 files / 2102 tests pass** (baseline at branch point: 2090)
- ESLint + Prettier clean on all 4 changed files (also enforced by the pre-commit hook)