### PR TITLE
feat(quiz): stepper UX — one question per card with navigation (#849)

### DIFF
--- a/apps/web/e2e/harness/quiz.ts
+++ b/apps/web/e2e/harness/quiz.ts
@@ -1,0 +1,30 @@
+import type { Page } from "@playwright/test";
+// Accessible names come from the real locale bundle — the specs must track the
+// i18n keys (lesson.quizCheck / lesson.quizNext), not drift on raw strings.
+import messages from "../../src/messages/en.json";
+
+const { quizCheck, quizNext } = messages.lesson;
+
+/**
+ * Work the quiz block the way a learner does since the stepper redesign
+ * (#849): one question is mounted at a time, so for each question — select
+ * the answer, click Check, then advance with Next (no Next after the last).
+ * Exercises the real QuizBlock: selection drives ctx.setProof, Check drives
+ * the per-question verdict, and checking every question flips the block's
+ * answered gate.
+ */
+export async function answerQuizStepper(
+  page: Page,
+  questionIds: readonly string[],
+  optionValue = "a"
+): Promise<void> {
+  for (let i = 0; i < questionIds.length; i++) {
+    await page
+      .locator(`input[name="${questionIds[i]}"][value="${optionValue}"]`)
+      .check();
+    await page.getByRole("button", { name: quizCheck }).click();
+    if (i < questionIds.length - 1) {
+      await page.getByRole("button", { name: quizNext }).click();
+    }
+  }
+}

--- a/apps/web/e2e/learn-loop.spec.ts
+++ b/apps/web/e2e/learn-loop.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from "@playwright/test";
 import { signInAsLearner } from "./harness/session";
 import { LEARN_LOOP } from "./harness/fixtures.mjs";
+import { answerQuizStepper } from "./harness/quiz";
 
 // Spec 1 — Learn loop.
 //
@@ -45,16 +46,9 @@ test.describe("learn loop", () => {
 
     // Work the retrieval quiz: option "a" is correct for every question. Grading
     // is server-side (mocked here); answering exercises the real quiz UI so the
-    // "learn loop" is faithful, not a bare button click.
-    for (const qid of ["q1", "q2", "q3", "q4"]) {
-      await page.locator(`input[name="${qid}"][value="a"]`).check();
-    }
-    const checkButtons = page.getByRole("button", { name: "Check answer" });
-    const count = await checkButtons.count();
-    expect(count).toBeGreaterThan(0);
-    for (let i = 0; i < count; i++) {
-      await checkButtons.nth(i).click();
-    }
+    // "learn loop" is faithful, not a bare button click. Since #849 the quiz is
+    // a stepper — answer → check → next, one question at a time.
+    await answerQuizStepper(page, ["q1", "q2", "q3", "q4"]);
 
     // The complete button only renders for a signed-in, enrolled learner — its
     // presence is itself the "enrolled course" assertion. Auto-waits for the

--- a/apps/web/e2e/o4-journey.spec.ts
+++ b/apps/web/e2e/o4-journey.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from "@playwright/test";
 import { signInAsLearner } from "./harness/session";
 import { LEARN_LOOP } from "./harness/fixtures.mjs";
+import { answerQuizStepper } from "./harness/quiz";
 
 // Spec 4 — The O-4 journey (#819): anonymous deep-link → do the work → claim
 // moment → sign in → banked progress replays and the completion is recorded.
@@ -98,15 +99,10 @@ test.describe("O-4 journey (anonymous → sign in → banked replay)", () => {
 
     // ── 2. Do the graded work while signed out ───────────────────────────────
     // Answer the retrieval quiz (option "a" is the key for every question) and
-    // check each one, exercising the real QuizBlock. Selecting the options is
+    // check each one, exercising the real QuizBlock — since #849 a stepper:
+    // answer → check → next, one question at a time. Selecting the options is
     // what drives ctx.setProof → the proofs the bank will carry.
-    for (const qid of ["q1", "q2", "q3", "q4"]) {
-      await page.locator(`input[name="${qid}"][value="a"]`).check();
-    }
-    const checkButtons = page.getByRole("button", { name: "Check answer" });
-    const checkCount = await checkButtons.count();
-    expect(checkCount).toBeGreaterThan(0);
-    for (let i = 0; i < checkCount; i++) await checkButtons.nth(i).click();
+    await answerQuizStepper(page, ["q1", "q2", "q3", "q4"]);
 
     // Nothing has hit the completion route yet — an anonymous learner cannot
     // complete on-chain; the work only lives locally at this point.

--- a/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/blocks/__tests__/quiz-block.test.tsx
+++ b/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/blocks/__tests__/quiz-block.test.tsx
@@ -4,9 +4,9 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { NextIntlClientProvider } from "next-intl";
 import type { Lesson, QuizBlockData } from "@superteam-lms/types";
+import messages from "@/messages/en.json";
 import { QuizBlock } from "../quiz-block";
 import type { BlockContext } from "../types";
-import messages from "@/messages/en.json";
 
 const quizBlock: QuizBlockData = {
   _type: "quiz",
@@ -45,6 +45,12 @@ const quizBlock: QuizBlockData = {
   ],
 };
 
+const singleQuestionBlock: QuizBlockData = {
+  _type: "quiz",
+  key: "q-single",
+  questions: [quizBlock.questions[0]!],
+};
+
 const lesson: Lesson = {
   _id: "lesson-1",
   title: "Lesson",
@@ -81,11 +87,17 @@ function renderWithIntl(ui: ReactElement) {
   );
 }
 
-/** The per-question Check button (question order = render order). */
-function checkButton(index: number): HTMLElement {
-  const button = screen.getAllByRole("button", { name: "Check answer" })[index];
-  if (!button) throw new Error(`No Check button at index ${index}`);
-  return button;
+/** The Check button of the CURRENT card (stepper shows one question at a time). */
+function checkButton(): HTMLElement {
+  return screen.getByRole("button", { name: "Check answer" });
+}
+
+function nextButton(): HTMLElement {
+  return screen.getByRole("button", { name: "Next question" });
+}
+
+function prevButton(): HTMLElement {
+  return screen.getByRole("button", { name: "Previous question" });
 }
 
 beforeEach(() => {
@@ -95,16 +107,16 @@ beforeEach(() => {
 describe("QuizBlock — Check interaction (LX-C1)", () => {
   it("disables Check until an option is selected", () => {
     renderWithIntl(<QuizBlock block={quizBlock} ctx={makeCtx()} />);
-    expect(checkButton(0)).toBeDisabled();
+    expect(checkButton()).toBeDisabled();
 
     fireEvent.click(screen.getByLabelText("A private key"));
-    expect(checkButton(0)).toBeEnabled();
+    expect(checkButton()).toBeEnabled();
   });
 
   it("wrong answer → authored per-option feedback + explanation inline", () => {
     renderWithIntl(<QuizBlock block={quizBlock} ctx={makeCtx()} />);
     fireEvent.click(screen.getByLabelText("A private key"));
-    fireEvent.click(checkButton(0));
+    fireEvent.click(checkButton());
 
     expect(
       screen.getByText("Not quite — review your answer and try again.")
@@ -125,7 +137,7 @@ describe("QuizBlock — Check interaction (LX-C1)", () => {
   it("correct answer → correct status + that option's feedback + explanation", () => {
     renderWithIntl(<QuizBlock block={quizBlock} ctx={makeCtx()} />);
     fireEvent.click(screen.getByLabelText("A program-derived address"));
-    fireEvent.click(checkButton(0));
+    fireEvent.click(checkButton());
 
     expect(screen.getByText("Correct!")).toBeInTheDocument();
     expect(
@@ -138,23 +150,25 @@ describe("QuizBlock — Check interaction (LX-C1)", () => {
 
   it("multi-select correctness is set equality, not subset", () => {
     renderWithIntl(<QuizBlock block={quizBlock} ctx={makeCtx()} />);
+    fireEvent.click(nextButton()); // q2 is the multi-select question
+
     // Subset of the correct set → incorrect.
     fireEvent.click(screen.getByLabelText("XP tokens"));
-    fireEvent.click(checkButton(1));
+    fireEvent.click(checkButton());
     expect(
       screen.getByText("Not quite — review your answer and try again.")
     ).toBeInTheDocument();
 
     // Completing the set → correct.
     fireEvent.click(screen.getByLabelText("Credentials"));
-    fireEvent.click(checkButton(1));
+    fireEvent.click(checkButton());
     expect(screen.getByText("Correct!")).toBeInTheDocument();
   });
 
   it("changing the selection retires the previous verdict", () => {
     renderWithIntl(<QuizBlock block={quizBlock} ctx={makeCtx()} />);
     fireEvent.click(screen.getByLabelText("A private key"));
-    fireEvent.click(checkButton(0));
+    fireEvent.click(checkButton());
     expect(
       screen.getByText("Not quite — review your answer and try again.")
     ).toBeInTheDocument();
@@ -165,18 +179,21 @@ describe("QuizBlock — Check interaction (LX-C1)", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("renders feedback inside an aria-live region", () => {
+  it("renders feedback inside an always-mounted aria-live region", () => {
     const { container } = renderWithIntl(
       <QuizBlock block={quizBlock} ctx={makeCtx()} />
     );
-    const liveRegions = container.querySelectorAll('[aria-live="polite"]');
-    // One always-mounted live region per question, so announcements fire when
-    // the verdict appears inside it.
-    expect(liveRegions).toHaveLength(2);
+    // The feedback region lives inside the question fieldset and is mounted
+    // BEFORE the check, so the verdict is announced when it appears.
+    const feedbackRegion = container.querySelector(
+      'fieldset [aria-live="polite"]'
+    );
+    expect(feedbackRegion).not.toBeNull();
+    expect(feedbackRegion?.textContent).toBe("");
 
     fireEvent.click(screen.getByLabelText("A private key"));
-    fireEvent.click(checkButton(0));
-    expect(liveRegions[0]?.textContent).toContain(
+    fireEvent.click(checkButton());
+    expect(feedbackRegion?.textContent).toContain(
       "Not quite — review your answer and try again."
     );
   });
@@ -198,11 +215,12 @@ describe("QuizBlock — proofs and answered reporting", () => {
     expect(ctx.setQuizAnswered).toHaveBeenLastCalledWith("q-block", false);
 
     fireEvent.click(screen.getByLabelText("A private key")); // wrong on purpose
-    fireEvent.click(checkButton(0));
+    fireEvent.click(checkButton());
     expect(ctx.setQuizAnswered).toHaveBeenLastCalledWith("q-block", false);
 
+    fireEvent.click(nextButton());
     fireEvent.click(screen.getByLabelText("SOL")); // wrong on purpose
-    fireEvent.click(checkButton(1));
+    fireEvent.click(checkButton());
     // Checked (attempted) — feedback + explanation already revealed, so the
     // AI gate has nothing left to protect. Correctness is NOT required here;
     // the server still gates completion.
@@ -213,13 +231,138 @@ describe("QuizBlock — proofs and answered reporting", () => {
     const ctx = makeCtx();
     renderWithIntl(<QuizBlock block={quizBlock} ctx={ctx} />);
     fireEvent.click(screen.getByLabelText("A private key"));
-    fireEvent.click(checkButton(0));
+    fireEvent.click(checkButton());
+    fireEvent.click(nextButton());
     fireEvent.click(screen.getByLabelText("SOL"));
-    fireEvent.click(checkButton(1));
+    fireEvent.click(checkButton());
     expect(ctx.setQuizAnswered).toHaveBeenLastCalledWith("q-block", true);
 
     // Changing an answer clears its verdict but must not re-suppress the AI.
+    fireEvent.click(prevButton());
     fireEvent.click(screen.getByLabelText("A program-derived address"));
     expect(ctx.setQuizAnswered).toHaveBeenLastCalledWith("q-block", true);
+  });
+});
+
+describe("QuizBlock — stepper (#849)", () => {
+  it("shows one question per card and navigates with next/prev", () => {
+    renderWithIntl(<QuizBlock block={quizBlock} ctx={makeCtx()} />);
+    expect(screen.getByText("What is a PDA?")).toBeInTheDocument();
+    expect(screen.queryByText("Which are soulbound?")).not.toBeInTheDocument();
+    expect(prevButton()).toBeDisabled();
+    expect(nextButton()).toBeEnabled();
+
+    fireEvent.click(nextButton());
+    expect(screen.getByText("Which are soulbound?")).toBeInTheDocument();
+    expect(screen.queryByText("What is a PDA?")).not.toBeInTheDocument();
+    expect(prevButton()).toBeEnabled();
+    expect(nextButton()).toBeDisabled();
+
+    fireEvent.click(prevButton());
+    expect(screen.getByText("What is a PDA?")).toBeInTheDocument();
+  });
+
+  it("displays the position alongside the correct-count and announces it via aria-live", () => {
+    renderWithIntl(<QuizBlock block={quizBlock} ctx={makeCtx()} />);
+    // Twice: the visible header chip + the sr-only live announcer.
+    expect(screen.getAllByText("Question 1 of 2")).toHaveLength(2);
+    expect(screen.getByText("0/2 correct")).toBeInTheDocument();
+
+    fireEvent.click(nextButton());
+    const announcements = screen.getAllByText("Question 2 of 2");
+    expect(announcements).toHaveLength(2);
+    expect(
+      announcements.some((el) => el.getAttribute("aria-live") === "polite")
+    ).toBe(true);
+  });
+
+  it("preserves answered state and feedback across navigation", () => {
+    renderWithIntl(<QuizBlock block={quizBlock} ctx={makeCtx()} />);
+    fireEvent.click(screen.getByLabelText("A program-derived address"));
+    fireEvent.click(checkButton());
+    expect(screen.getByText("Correct!")).toBeInTheDocument();
+    expect(screen.getByText("1/2 correct")).toBeInTheDocument();
+
+    fireEvent.click(nextButton());
+    expect(screen.queryByText("Correct!")).not.toBeInTheDocument();
+
+    fireEvent.click(prevButton());
+    // Selection, verdict, feedback, and explanation all survived the round trip.
+    expect(screen.getByLabelText("A program-derived address")).toBeChecked();
+    expect(screen.getByText("Correct!")).toBeInTheDocument();
+    expect(
+      screen.getByText("Right — derived from seeds, off the ed25519 curve.")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("PDAs are derived from seeds and the program id.")
+    ).toBeInTheDocument();
+    expect(screen.getByText("1/2 correct")).toBeInTheDocument();
+  });
+
+  it("renders single-question quizzes without stepper chrome", () => {
+    renderWithIntl(<QuizBlock block={singleQuestionBlock} ctx={makeCtx()} />);
+    expect(screen.getByText("What is a PDA?")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Next question" })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Previous question" })
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText(/Question 1 of 1/)).not.toBeInTheDocument();
+    // The check flow itself is untouched.
+    fireEvent.click(screen.getByLabelText("A program-derived address"));
+    fireEvent.click(checkButton());
+    expect(screen.getByText("Correct!")).toBeInTheDocument();
+  });
+
+  it("navigates with arrow keys when focus is within the block", () => {
+    renderWithIntl(<QuizBlock block={quizBlock} ctx={makeCtx()} />);
+    fireEvent.keyDown(screen.getByText("What is a PDA?"), {
+      key: "ArrowRight",
+    });
+    expect(screen.getByText("Which are soulbound?")).toBeInTheDocument();
+
+    fireEvent.keyDown(screen.getByText("Which are soulbound?"), {
+      key: "ArrowLeft",
+    });
+    expect(screen.getByText("What is a PDA?")).toBeInTheDocument();
+  });
+
+  it("does NOT hijack arrow keys inside the radio/checkbox group", () => {
+    renderWithIntl(<QuizBlock block={quizBlock} ctx={makeCtx()} />);
+    // Arrows on an option input move the native selection, never the card.
+    fireEvent.keyDown(screen.getByLabelText("A private key"), {
+      key: "ArrowRight",
+    });
+    expect(screen.getByText("What is a PDA?")).toBeInTheDocument();
+    expect(screen.queryByText("Which are soulbound?")).not.toBeInTheDocument();
+  });
+
+  it("checks the current question on Enter", () => {
+    renderWithIntl(<QuizBlock block={quizBlock} ctx={makeCtx()} />);
+    const option = screen.getByLabelText("A program-derived address");
+    fireEvent.click(option);
+    fireEvent.keyDown(option, { key: "Enter" });
+    expect(screen.getByText("Correct!")).toBeInTheDocument();
+  });
+
+  it("ignores Enter when nothing is selected", () => {
+    renderWithIntl(<QuizBlock block={quizBlock} ctx={makeCtx()} />);
+    fireEvent.keyDown(screen.getByText("What is a PDA?"), { key: "Enter" });
+    expect(screen.queryByText("Correct!")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Not quite — review your answer and try again.")
+    ).not.toBeInTheDocument();
+  });
+
+  it("moves focus to the question heading when the card changes", () => {
+    renderWithIntl(<QuizBlock block={quizBlock} ctx={makeCtx()} />);
+    fireEvent.click(nextButton());
+    expect(document.activeElement).toBe(
+      screen.getByText("Which are soulbound?")
+    );
+
+    fireEvent.click(prevButton());
+    expect(document.activeElement).toBe(screen.getByText("What is a PDA?"));
   });
 });

--- a/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/blocks/quiz-block.tsx
+++ b/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/blocks/quiz-block.tsx
@@ -1,8 +1,15 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslations } from "next-intl";
-import { CaretDown, CheckCircle, Robot, XCircle } from "@phosphor-icons/react";
+import {
+  CaretDown,
+  CaretLeft,
+  CaretRight,
+  CheckCircle,
+  Robot,
+  XCircle,
+} from "@phosphor-icons/react";
 import type { QuizBlockData, QuizQuestionData } from "@superteam-lms/types";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
@@ -38,6 +45,12 @@ function isChoiceCorrect(q: QuizQuestionData, chosen: string[]): boolean {
  * per-question Check below is instant formative feedback only (LX-C1): it
  * renders the authored per-option `feedback` for whatever the learner chose,
  * plus the question's `explanation` after any check.
+ *
+ * Presentation is a STEPPER (#849): one question per card with prev/next
+ * navigation (buttons + arrow keys), so long quizzes never render as a wall.
+ * All per-question state lives in maps keyed by question id, so answers,
+ * verdicts, and feedback survive navigating away and back. Single-question
+ * quizzes render without any stepper chrome.
  */
 export function QuizBlock({ block, ctx }: BlockRenderProps) {
   const b = block as QuizBlockData;
@@ -49,6 +62,11 @@ export function QuizBlock({ block, ctx }: BlockRenderProps) {
   const [checkedEver, setCheckedEver] = useState<Record<string, boolean>>({});
   // Section starts open (#770); collapsing leaves the score badge as the recap.
   const [open, setOpen] = useState(true);
+  const [index, setIndex] = useState(0);
+  const promptRef = useRef<HTMLLegendElement>(null);
+  // True only between a user-initiated navigation and the focus effect below —
+  // keeps mount (and unrelated re-renders) from stealing focus.
+  const navigatedRef = useRef(false);
 
   useEffect(() => {
     ctx.setProof(b.key, { selections });
@@ -103,11 +121,66 @@ export function QuizBlock({ block, ctx }: BlockRenderProps) {
     [ctx.lesson._id, ctx.courseId]
   );
 
+  const total = b.questions.length;
+  // Stepper chrome (position chip, prev/next, arrow-key nav) only exists when
+  // there is something to step through (#849).
+  const stepper = total > 1;
+  const current = Math.min(index, Math.max(total - 1, 0));
+  const q = b.questions[current];
+
+  const goTo = (target: number): void => {
+    if (target < 0 || target >= total || target === current) return;
+    navigatedRef.current = true;
+    setIndex(target);
+  };
+
+  // Card changed via prev/next/arrows — move focus to the question heading so
+  // keyboard and screen-reader users land on the new question, not in a void.
+  useEffect(() => {
+    if (!navigatedRef.current) return;
+    navigatedRef.current = false;
+    promptRef.current?.focus();
+  }, [current]);
+
+  const onBodyKeyDown = (event: React.KeyboardEvent<HTMLDivElement>): void => {
+    if (!q) return;
+    const tag = (event.target as HTMLElement).tagName;
+    if (event.key === "Enter") {
+      // Buttons handle Enter natively (prev/next/check/collapse) — anywhere
+      // else in the card, Enter checks the current question.
+      if (tag === "BUTTON" || tag === "A" || tag === "TEXTAREA") return;
+      const chosen = selections[q.id] ?? [];
+      if (chosen.length === 0) return;
+      event.preventDefault();
+      check(q, chosen);
+      return;
+    }
+    if (!stepper) return;
+    // Inside the radio/checkbox group the arrow keys move the SELECTION —
+    // native group behavior stays untouched; navigation arrows apply elsewhere.
+    if (tag === "INPUT") return;
+    if (event.key === "ArrowRight") {
+      event.preventDefault();
+      goTo(current + 1);
+    } else if (event.key === "ArrowLeft") {
+      event.preventDefault();
+      goTo(current - 1);
+    }
+  };
+
   // Collapsed summary (#770): how many questions are currently answered
   // correctly. Turns green only at a clean sweep, so the badge doubles as the
   // "done" signal when the section is folded away.
   const correctCount = b.questions.filter((q) => results[q.id]?.correct).length;
-  const allCorrect = correctCount === b.questions.length;
+  const allCorrect = correctCount === total;
+
+  const multi = q?.multiSelect ?? false;
+  const chosen = q ? (selections[q.id] ?? []) : [];
+  const result: CheckResult | undefined = q ? results[q.id] : undefined;
+  const chosenWithFeedback =
+    q && result
+      ? q.options.filter((o) => result.chosen.includes(o.id) && o.feedback)
+      : [];
 
   return (
     <div className="rounded-[var(--r-lg)] border-[2.5px] border-border bg-card shadow-card">
@@ -120,6 +193,11 @@ export function QuizBlock({ block, ctx }: BlockRenderProps) {
         <h3 className="font-display text-sm font-extrabold uppercase text-text-3">
           {t("quiz")}
         </h3>
+        {stepper && (
+          <span className="rounded-full px-2 py-0.5 text-xs font-bold tabular-nums text-text-3 [background:var(--input)]">
+            {t("quizPosition", { current: current + 1, total })}
+          </span>
+        )}
         <span
           className={cn(
             "rounded-full px-2 py-0.5 text-xs font-bold tabular-nums",
@@ -130,7 +208,7 @@ export function QuizBlock({ block, ctx }: BlockRenderProps) {
         >
           {t("quizScore", {
             correct: correctCount,
-            total: b.questions.length,
+            total,
           })}
         </span>
         <CaretDown
@@ -145,103 +223,128 @@ export function QuizBlock({ block, ctx }: BlockRenderProps) {
         <span className="sr-only">{t("toggleSection")}</span>
       </button>
 
-      <div className={cn("space-y-6 px-5 pb-5", !open && "hidden")}>
-        {b.questions.map((q) => {
-          const multi = q.multiSelect ?? false;
-          const chosen = selections[q.id] ?? [];
-          const result: CheckResult | undefined = results[q.id];
-          const chosenWithFeedback = result
-            ? q.options.filter(
-                (o) => result.chosen.includes(o.id) && o.feedback
-              )
-            : [];
-          return (
-            <fieldset key={q.id} className="space-y-2">
-              <legend className="font-display font-bold text-text">
-                {q.prompt}
-              </legend>
-              <div className="space-y-1.5">
-                {q.options.map((o) => {
-                  const judged = result?.chosen.includes(o.id) ?? false;
-                  return (
-                    <label
-                      key={o.id}
-                      className={`flex cursor-pointer items-center gap-2 rounded-md border p-2 text-sm transition-colors hover:bg-subtle ${
-                        judged
-                          ? o.correct
-                            ? "border-success"
-                            : "border-danger"
-                          : "border-border"
-                      }`}
-                    >
-                      <input
-                        type={multi ? "checkbox" : "radio"}
-                        name={q.id}
-                        value={o.id}
-                        checked={chosen.includes(o.id)}
-                        onChange={() => toggle(q.id, o.id, multi)}
-                        className="accent-primary"
-                      />
-                      <span>{o.label}</span>
-                    </label>
-                  );
-                })}
-              </div>
-              <div>
-                <Button
-                  variant="pushSuccess"
-                  size="sm"
-                  onClick={() => check(q, chosen)}
-                  disabled={chosen.length === 0}
-                  aria-disabled={chosen.length === 0}
-                >
-                  {t("quizCheck")}
-                </Button>
-              </div>
-              {/* Always-mounted live region: the verdict + authored feedback are
+      <div
+        className={cn("space-y-6 px-5 pb-5", !open && "hidden")}
+        onKeyDown={onBodyKeyDown}
+      >
+        {/* Always-mounted position announcer: navigation swaps the card, so a
+            separate live region tells screen readers where they landed. */}
+        {stepper && (
+          <p aria-live="polite" className="sr-only">
+            {t("quizPosition", { current: current + 1, total })}
+          </p>
+        )}
+        {q && (
+          <fieldset key={q.id} className="space-y-2">
+            <legend
+              ref={promptRef}
+              tabIndex={-1}
+              className="rounded-sm font-display font-bold text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              {q.prompt}
+            </legend>
+            <div className="space-y-1.5">
+              {q.options.map((o) => {
+                const judged = result?.chosen.includes(o.id) ?? false;
+                return (
+                  <label
+                    key={o.id}
+                    className={`flex cursor-pointer items-center gap-2 rounded-md border p-2 text-sm transition-colors hover:bg-subtle ${
+                      judged
+                        ? o.correct
+                          ? "border-success"
+                          : "border-danger"
+                        : "border-border"
+                    }`}
+                  >
+                    <input
+                      type={multi ? "checkbox" : "radio"}
+                      name={q.id}
+                      value={o.id}
+                      checked={chosen.includes(o.id)}
+                      onChange={() => toggle(q.id, o.id, multi)}
+                      className="accent-primary"
+                    />
+                    <span>{o.label}</span>
+                  </label>
+                );
+              })}
+            </div>
+            <div>
+              <Button
+                variant="pushSuccess"
+                size="sm"
+                onClick={() => check(q, chosen)}
+                disabled={chosen.length === 0}
+                aria-disabled={chosen.length === 0}
+              >
+                {t("quizCheck")}
+              </Button>
+            </div>
+            {/* Always-mounted live region: the verdict + authored feedback are
                 announced when they appear. Focus stays on the Check button —
                 nothing is unmounted from under the keyboard user. */}
-              <div aria-live="polite" className="space-y-2">
-                {result && (
-                  <>
-                    <p
-                      className={`flex items-center gap-1.5 text-sm font-medium ${
-                        result.correct ? "text-success" : "text-danger"
-                      }`}
-                    >
-                      {result.correct ? (
-                        <CheckCircle
-                          size={16}
-                          weight="bold"
-                          aria-hidden="true"
-                        />
-                      ) : (
-                        <XCircle size={16} weight="bold" aria-hidden="true" />
-                      )}
-                      {result.correct ? t("quizCorrect") : t("quizIncorrect")}
-                    </p>
-                    {chosenWithFeedback.map((o) => (
-                      <p key={o.id} className="text-sm text-text">
-                        {multi && (
-                          <span className="font-medium">{o.label}: </span>
-                        )}
-                        {o.feedback}
-                      </p>
-                    ))}
-                    {q.explanation && (
-                      <div className="space-y-1 rounded-md border border-border bg-subtle p-3">
-                        <p className="font-display text-xs font-bold uppercase tracking-wide text-text-3">
-                          {t("quizExplanationLabel")}
-                        </p>
-                        <p className="text-sm text-text">{q.explanation}</p>
-                      </div>
+            <div aria-live="polite" className="space-y-2">
+              {result && (
+                <>
+                  <p
+                    className={`flex items-center gap-1.5 text-sm font-medium ${
+                      result.correct ? "text-success" : "text-danger"
+                    }`}
+                  >
+                    {result.correct ? (
+                      <CheckCircle size={16} weight="bold" aria-hidden="true" />
+                    ) : (
+                      <XCircle size={16} weight="bold" aria-hidden="true" />
                     )}
-                  </>
-                )}
-              </div>
-            </fieldset>
-          );
-        })}
+                    {result.correct ? t("quizCorrect") : t("quizIncorrect")}
+                  </p>
+                  {chosenWithFeedback.map((o) => (
+                    <p key={o.id} className="text-sm text-text">
+                      {multi && (
+                        <span className="font-medium">{o.label}: </span>
+                      )}
+                      {o.feedback}
+                    </p>
+                  ))}
+                  {q.explanation && (
+                    <div className="space-y-1 rounded-md border border-border bg-subtle p-3">
+                      <p className="font-display text-xs font-bold uppercase tracking-wide text-text-3">
+                        {t("quizExplanationLabel")}
+                      </p>
+                      <p className="text-sm text-text">{q.explanation}</p>
+                    </div>
+                  )}
+                </>
+              )}
+            </div>
+          </fieldset>
+        )}
+
+        {stepper && (
+          <div className="flex items-center justify-between gap-2">
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={() => goTo(current - 1)}
+              disabled={current === 0}
+              aria-disabled={current === 0}
+            >
+              <CaretLeft size={14} weight="bold" aria-hidden="true" />
+              {t("quizPrev")}
+            </Button>
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={() => goTo(current + 1)}
+              disabled={current === total - 1}
+              aria-disabled={current === total - 1}
+            >
+              {t("quizNext")}
+              <CaretRight size={14} weight="bold" aria-hidden="true" />
+            </Button>
+          </div>
+        )}
 
         {/* The AI Partner is suppressed while any question is unchecked
             (LX-C1/F18) — retrieval stays AI-free. Say so, so its absence reads

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -314,6 +314,9 @@
     "quizScore": "{correct}/{total} correct",
     "toggleSection": "Toggle section",
     "quiz": "Quiz",
+    "quizPosition": "Question {current} of {total}",
+    "quizPrev": "Previous question",
+    "quizNext": "Next question",
     "quizUnlocksAssistant": "Answer every question to unlock the AI Partner for this lesson."
   },
   "dashboard": {

--- a/apps/web/src/messages/es.json
+++ b/apps/web/src/messages/es.json
@@ -314,6 +314,9 @@
     "quizScore": "{correct}/{total} correctas",
     "toggleSection": "Alternar sección",
     "quiz": "Cuestionario",
+    "quizPosition": "Pregunta {current} de {total}",
+    "quizPrev": "Pregunta anterior",
+    "quizNext": "Siguiente pregunta",
     "quizUnlocksAssistant": "Responde todas las preguntas para desbloquear el AI Partner en esta lección."
   },
   "dashboard": {

--- a/apps/web/src/messages/pt-BR.json
+++ b/apps/web/src/messages/pt-BR.json
@@ -314,6 +314,9 @@
     "quizScore": "{correct}/{total} corretas",
     "toggleSection": "Alternar seção",
     "quiz": "Quiz",
+    "quizPosition": "Pergunta {current} de {total}",
+    "quizPrev": "Pergunta anterior",
+    "quizNext": "Próxima pergunta",
     "quizUnlocksAssistant": "Responda todas as perguntas para desbloquear o AI Partner nesta lição."
   },
   "dashboard": {


### PR DESCRIPTION
Closes #849

## What changed

`quiz-block.tsx` no longer renders every question in a vertical stack (the owner's screenshot showed 17 stacked questions). It is now a **stepper**: one question per card, with navigation.

### Before
- All N questions rendered at once, each with its own Check button — a wall of 17 fieldsets on the C5 recap.

### After (presentation only — zero pipeline changes)
- **One question per card** with `Previous question` / `Next question` buttons (prev disabled on first, next disabled on last). Navigation is free-form — learners can go back any time to review; selection, verdict, feedback, and explanation are preserved per question (state was already in question-id-keyed maps).
- **Position indicator** — a `Question N of M` chip in the header next to the existing correct-count chip, plus an always-mounted `sr-only` `aria-live="polite"` announcer so screen readers hear where they landed after each navigation.
- **Keyboard**: ArrowLeft/ArrowRight navigate when focus is within the card body — except on the radio/checkbox inputs, where arrows keep their native move-the-selection behavior. Enter checks the current question (skipped on buttons so prev/next/check/collapse keep native Enter activation).
- **Focus management**: on card change, focus moves to the question heading (`legend`, `tabIndex={-1}`, repo focus-visible ring classes). A ref flag ensures only user-initiated navigation moves focus — mount never steals it.
- **Single-question quizzes** render with no stepper chrome at all (no chip, no nav buttons, no arrow-key handling).
- New next-intl keys `quizPosition` / `quizPrev` / `quizNext` in en, es, pt-BR.

### Unchanged (hard constraints)
- Same `QuizProof` via `ctx.setProof` (`{ selections }`), same D4 open-book client-side check (set equality), same per-question check→feedback→explanation cycle, same sticky `checkedEver` → `setQuizAnswered` AI-suppression gate, same correct-count chip semantics (green only on clean sweep), same `trackQuizChecked` analytics event. No API/pipeline changes.

## Tests

Existing assertions kept at full strength (check flow, proof assembly, feedback leak-prevention, aria-live feedback region, answered/suppression reporting) and rewired to the stepper (interacting with q2 now requires clicking Next). Added a stepper suite: next/prev navigation + disabled bounds, position display + aria-live announcement, answered-state persistence across a nav round trip, single-question no-chrome, arrow-key navigation, arrows NOT hijacked inside the option group, Enter-to-check, Enter ignored with no selection, focus moving to the heading on card change.

## Verification

- `pnpm typecheck` — 6/6 tasks pass
- `pnpm --filter web test` — **234 files / 2113 tests passed** (quiz-block: 18/18, was 9)
- ESLint on changed files: 0 errors (1 pre-existing `import/order` warning also present on main); Prettier clean
- Live check on `pnpm dev` against the real 17-question C5 recap quiz (`/en/courses/stablecoin-agentic-payments/lessons/submit-and-what-you-built`): renders `Question 1 of 17` + `0/17 correct`, one question mounted, Next → `Question 2 of 17` with focus on the new heading, ArrowLeft → back to question 1.
