### PR TITLE
fix(reflection): AI reply ON by default + one-round openEnded UI (#848)

### DIFF
--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -93,11 +93,11 @@ AI_SPEND_IP_SOFT_USD=              # Per-IP degrade                (default 2)
 AI_SPEND_IP_HARD_USD=              # Per-IP hard deny              (default 5)
 AI_SPEND_INPUT_USD_PER_MTOK=       # Gemini input price  $/1M tok  (default 0.3)
 AI_SPEND_OUTPUT_USD_PER_MTOK=      # Gemini output price $/1M tok  (default 2.5; thinking bills here)
-OPENENDED_AI_REPLY=                # Set to "1" to enable the best-effort AI reply on
-                                    # /api/lessons/reflect (openEnded reflections). Default OFF:
-                                    # the reflection SEAL is always returned regardless; the reply
-                                    # is enrichment only and is a metered cost path whose accounting
-                                    # is owned by #590. Requires GEMINI_API_KEY when enabled.
+OPENENDED_AI_REPLY=                # Best-effort AI reply on /api/lessons/reflect (openEnded
+                                    # reflections). Default ON since #848 — set to "0" to disable.
+                                    # The reflection SEAL is always returned regardless; the reply
+                                    # is enrichment only (rate-limited, #591 spend-ledger gated,
+                                    # never blocks). Requires GEMINI_API_KEY — unset key = no reply.
 
 # Optional — Teacher course preview (#828), server-only
 #                                  # Needs no GITHUB_TOKEN: courses-academy is public, so the

--- a/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/blocks/__tests__/open-ended-block.test.tsx
+++ b/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/blocks/__tests__/open-ended-block.test.tsx
@@ -1,0 +1,185 @@
+// @vitest-environment jsdom
+import type { ReactElement } from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import type { Lesson, OpenEndedBlockData } from "@superteam-lms/types";
+import messages from "@/messages/en.json";
+import { OpenEndedBlock } from "../open-ended-block";
+import type { BlockContext } from "../types";
+
+const block: OpenEndedBlockData = {
+  _type: "openEnded",
+  key: "reflect",
+  prompt: "What did you take away from this course?",
+  maxWords: 250,
+};
+
+const lesson: Lesson = {
+  _id: "lesson-1",
+  title: "Lesson",
+  slug: "lesson",
+  blocks: [block],
+};
+
+function makeCtx(overrides: Partial<BlockContext> = {}): BlockContext {
+  return {
+    lesson,
+    courseSlug: "course",
+    courseId: "course-1",
+    locale: "en",
+    isEnrolled: true,
+    isCompleted: false,
+    xpReward: 30,
+    earnedXp: null,
+    onEnroll: vi.fn(),
+    setProof: vi.fn(),
+    setQuizAnswered: vi.fn(),
+    aiSuppressed: true,
+    buildUuid: null,
+    programKeypairSecret: null,
+    resetBuild: vi.fn(),
+    ...overrides,
+  };
+}
+
+function renderWithIntl(ui: ReactElement) {
+  return render(
+    <NextIntlClientProvider locale="en" messages={messages}>
+      {ui}
+    </NextIntlClientProvider>
+  );
+}
+
+function textarea(): HTMLElement {
+  return screen.getByLabelText(block.prompt);
+}
+
+function submitButton(): HTMLElement {
+  return screen.getByRole("button");
+}
+
+function stubReflectFetch(reply: string | null, ok = true) {
+  const fetchMock = vi.fn(async () => ({
+    ok,
+    json: async () => ({ seal: "seal-abc", reply }),
+  }));
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("OpenEndedBlock — word limit (#848: maxWords counts words, not chars)", () => {
+  it("shows the block's word cap and counts words", () => {
+    renderWithIntl(<OpenEndedBlock block={block} ctx={makeCtx()} />);
+    expect(screen.getByText("0/250")).toBeInTheDocument();
+
+    fireEvent.change(textarea(), {
+      target: { value: "five words of long reflection" },
+    });
+    expect(screen.getByText("5/250")).toBeInTheDocument();
+  });
+
+  it("defaults to 200 words when the block sets no maxWords", () => {
+    const noCap: OpenEndedBlockData = { ...block, maxWords: null };
+    renderWithIntl(<OpenEndedBlock block={noCap} ctx={makeCtx()} />);
+    expect(screen.getByText("0/200")).toBeInTheDocument();
+  });
+
+  it("disables submit when empty or over the word cap — chars alone never trip it", () => {
+    const tiny: OpenEndedBlockData = { ...block, maxWords: 20 };
+    renderWithIntl(<OpenEndedBlock block={tiny} ctx={makeCtx()} />);
+    expect(submitButton()).toBeDisabled();
+
+    // One very long word: far over 200 CHARS, still 1/20 words → submittable.
+    fireEvent.change(textarea(), { target: { value: "x".repeat(400) } });
+    expect(screen.getByText("1/20")).toBeInTheDocument();
+    expect(submitButton()).toBeEnabled();
+
+    fireEvent.change(textarea(), {
+      target: { value: Array(21).fill("word").join(" ") },
+    });
+    expect(screen.getByText("21/20")).toBeInTheDocument();
+    expect(submitButton()).toBeDisabled();
+  });
+});
+
+describe("OpenEndedBlock — seal + one-round AI reply", () => {
+  it("records the seal as proof and renders the AI reply when present", async () => {
+    stubReflectFetch("Nice reflection — the rails distinction is exactly it.");
+    const setProof = vi.fn();
+    renderWithIntl(
+      <OpenEndedBlock block={block} ctx={makeCtx({ setProof })} />
+    );
+
+    fireEvent.change(textarea(), { target: { value: "my honest takeaway" } });
+    fireEvent.click(submitButton());
+
+    await waitFor(() =>
+      expect(screen.getByText("Reflection recorded")).toBeInTheDocument()
+    );
+    expect(setProof).toHaveBeenCalledWith("reflect", "seal-abc");
+    expect(screen.getByText("Feedback")).toBeInTheDocument();
+    expect(
+      screen.getByText("Nice reflection — the rails distinction is exactly it.")
+    ).toBeInTheDocument();
+  });
+
+  it("still seals with no reply block when the AI reply is null (degraded/disabled)", async () => {
+    stubReflectFetch(null);
+    const setProof = vi.fn();
+    renderWithIntl(
+      <OpenEndedBlock block={block} ctx={makeCtx({ setProof })} />
+    );
+
+    fireEvent.change(textarea(), { target: { value: "my honest takeaway" } });
+    fireEvent.click(submitButton());
+
+    await waitFor(() =>
+      expect(screen.getByText("Reflection recorded")).toBeInTheDocument()
+    );
+    expect(setProof).toHaveBeenCalledWith("reflect", "seal-abc");
+    expect(screen.queryByText("Feedback")).not.toBeInTheDocument();
+  });
+
+  it("is one round only: after a reply, submit is disabled (no second round)", async () => {
+    const fetchMock = stubReflectFetch("One round of feedback.");
+    renderWithIntl(<OpenEndedBlock block={block} ctx={makeCtx()} />);
+
+    fireEvent.change(textarea(), { target: { value: "my honest takeaway" } });
+    fireEvent.click(submitButton());
+
+    await waitFor(() =>
+      expect(screen.getByText("One round of feedback.")).toBeInTheDocument()
+    );
+    const done = screen.getByRole("button", { name: /Reflection recorded/ });
+    expect(done).toBeDisabled();
+    fireEvent.click(done);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows the error state without recording proof when the POST fails", async () => {
+    stubReflectFetch(null, false);
+    const setProof = vi.fn();
+    renderWithIntl(
+      <OpenEndedBlock block={block} ctx={makeCtx({ setProof })} />
+    );
+
+    fireEvent.change(textarea(), { target: { value: "my honest takeaway" } });
+    fireEvent.click(submitButton());
+
+    await waitFor(() =>
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        "We couldn't record your reflection. Please try again."
+      )
+    );
+    expect(setProof).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/blocks/open-ended-block.tsx
+++ b/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/blocks/open-ended-block.tsx
@@ -4,8 +4,8 @@ import { useState } from "react";
 import { useTranslations } from "next-intl";
 import { CheckCircle } from "@phosphor-icons/react";
 import type { OpenEndedBlockData } from "@superteam-lms/types";
-import type { BlockRenderProps } from "./types";
 import { Button } from "@/components/ui/button";
+import type { BlockRenderProps } from "./types";
 
 interface ReflectResponse {
   seal: string;
@@ -32,7 +32,11 @@ export function OpenEndedBlock({ block, ctx }: BlockRenderProps) {
   const words = text.trim() === "" ? 0 : text.trim().split(/\s+/).length;
   const maxWords = b.maxWords ?? 200;
   const overLimit = words > maxWords;
-  const canSubmit = words > 0 && !overLimit && status !== "submitting";
+  // One round only (#848): once the seal is recorded (status "done"), the
+  // submit affordance stays disabled — the AI reply is a single round of
+  // feedback, not a chat. Errors still allow a retry.
+  const canSubmit =
+    words > 0 && !overLimit && (status === "idle" || status === "error");
 
   const submit = async () => {
     if (!canSubmit) return;

--- a/apps/web/src/app/api/lessons/reflect/route.ts
+++ b/apps/web/src/app/api/lessons/reflect/route.ts
@@ -15,8 +15,9 @@ import { serverEnv } from "@/lib/env.server";
 // forever. This route is that caller.
 //
 // Receipt-first ruling: a valid submission returns the seal UNCONDITIONALLY. The
-// AI reply is best-effort enrichment (`maybeGenerateReflectionReply`, default
-// off) that may fail, be rate-limited, or be disabled without ever blocking the
+// AI reply is best-effort enrichment (`maybeGenerateReflectionReply`, ON by
+// default since #848; kill switch OPENENDED_AI_REPLY=0) that may fail, be
+// rate-limited, or be disabled without ever blocking the
 // seal. The lesson must always be completable (AIE-21 — degrade never block).
 
 const MAX_BODY_CHARS = 20_000;

--- a/apps/web/src/lib/ai/__tests__/reflection-reply.test.ts
+++ b/apps/web/src/lib/ai/__tests__/reflection-reply.test.ts
@@ -61,13 +61,21 @@ afterEach(() => {
 });
 
 describe("maybeGenerateReflectionReply", () => {
-  it("returns null and never calls the model when the flag is off", async () => {
-    delete process.env.OPENENDED_AI_REPLY;
+  it("returns null and never calls the model when explicitly disabled (=0)", async () => {
+    process.env.OPENENDED_AI_REPLY = "0";
     const fetchMock = stubGeminiFetch("should not run");
     const { maybeGenerateReflectionReply } =
       await import("../reflection-reply");
     expect(await maybeGenerateReflectionReply(INPUT)).toBeNull();
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("is ON by default — replies with the flag unset (#848)", async () => {
+    delete process.env.OPENENDED_AI_REPLY;
+    stubGeminiFetch("Default-on reply");
+    const { maybeGenerateReflectionReply } =
+      await import("../reflection-reply");
+    expect(await maybeGenerateReflectionReply(INPUT)).toBe("Default-on reply");
   });
 
   it("returns null when GEMINI_API_KEY is unset", async () => {

--- a/apps/web/src/lib/ai/reflection-reply.ts
+++ b/apps/web/src/lib/ai/reflection-reply.ts
@@ -14,7 +14,11 @@ import type { GeminiUsageMetadata } from "@/lib/ai/spend-ledger";
 // key, or spend-cap denial resolves to `null` and the seal is issued regardless
 // (spec §3 item 6 — "degrade never block", AIE-21).
 //
-// Default OFF behind OPENENDED_AI_REPLY. When enabled, this reply spends the
+// Default ON since #848 (opt out with OPENENDED_AI_REPLY=0): the reply is
+// fail-safe by design — ledger-gated, rate-limited, never blocks the seal —
+// and a dark default meant the comprehension-reflection feedback loop never
+// fired in prod. Still requires GEMINI_API_KEY; unset key keeps it dark.
+// When live, this reply spends the
 // SAME sponsored GEMINI_API_KEY as the AI Partner, so — per #724 — it now runs
 // UNDER the #591 spend ledger: the same fail-closed checkAiSpend gate and
 // recordAiSpend booking (account + IP + global caps), and a fail-CLOSED reply
@@ -71,7 +75,10 @@ export async function maybeGenerateReflectionReply({
   prompt,
   reflection,
 }: ReflectionReplyInput): Promise<string | null> {
-  if (process.env.OPENENDED_AI_REPLY !== "1") return null;
+  // Default ON (#848); "0" is the explicit kill switch. Any other value —
+  // unset, "1", garbage — leaves the reply enabled; GEMINI_API_KEY remains the
+  // hard prerequisite below.
+  if (process.env.OPENENDED_AI_REPLY === "0") return null;
 
   const apiKey = serverEnv.GEMINI_API_KEY;
   if (!apiKey) return null;


### PR DESCRIPTION
Frontend half of #848. Content half (prompt audit + rewrites): solanabr/academy-courses#26.

## Reflection-reply gating facts (as found)

- **Env var**: `OPENENDED_AI_REPLY`, read in `apps/web/src/lib/ai/reflection-reply.ts`.
- **Previous default**: OFF — the gate was `!== "1"`, so unless the owner had set `OPENENDED_AI_REPLY=1` in Vercel, the one-round AI feedback never fired in prod even though the whole pipeline (seal, ledger, limiter) was live.
- **Change**: default flipped **ON**; `OPENENDED_AI_REPLY=0` is now the explicit kill switch. Safe by design: fail-closed per-user rate limiter (10/min), #591/#724 spend-ledger gate (account+IP+global caps, fail-closed), 512-token output cap, 10s abort, and the seal is computed and returned independently — a skipped/failed reply never blocks completion. `GEMINI_API_KEY` remains the hard prerequisite: if it is unset in Vercel the reply stays dark (owner action if desired: confirm `GEMINI_API_KEY` is set — it already powers the AI partner — and remove any stale `OPENENDED_AI_REPLY` value, or set it to `0` to opt out).

## UI

- `open-ended-block.tsx`: one round enforced client-side — once the seal is recorded the submit button stays disabled (error state still allows retry), so one box can't farm repeated replies. The AI reply already rendered on arrival (`aria-live`, "Feedback" panel) — now covered by tests.
- **Limit finding**: the "0/200" in the owner screenshot is a **word** counter, not characters — `maxWords` (schema default 200, min 20, max 500; frontend default 200). No cap change needed frontend-side; the content PR sets the C5 finale to 250 words.

## Tests

- New `blocks/__tests__/open-ended-block.test.tsx` (8 tests): word-cap semantics (block cap, 200 default, a 400-char single word never trips it), seal proof recording, reply rendering, null-reply degrade, one-round disable, error state.
- `reflection-reply.test.ts`: default-on coverage + explicit `"0"` disable.

## Verification

- `pnpm typecheck` clean
- `pnpm test` (apps/web): 238 files, 2141 tests, all passing
- `pnpm lint`: 0 errors (pre-existing warnings only)

Closes #848 (with the content PR staged for the next content.lock bump).
