### PR TITLE
feat(ai): per-action Gemini model routing — Socratic/hint to flash-lite (#868)

### DIFF
--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -91,8 +91,25 @@ AI_SPEND_ACCOUNT_SOFT_USD=         # Per-account degrade           (default 0.5)
 AI_SPEND_ACCOUNT_HARD_USD=         # Per-account hard deny         (default 1.5)
 AI_SPEND_IP_SOFT_USD=              # Per-IP degrade                (default 2)
 AI_SPEND_IP_HARD_USD=              # Per-IP hard deny              (default 5)
-AI_SPEND_INPUT_USD_PER_MTOK=       # Gemini input price  $/1M tok  (default 0.3)
-AI_SPEND_OUTPUT_USD_PER_MTOK=      # Gemini output price $/1M tok  (default 2.5; thinking bills here)
+AI_SPEND_INPUT_USD_PER_MTOK=       # EMERGENCY all-models price override, $/1M tok input.
+AI_SPEND_OUTPUT_USD_PER_MTOK=      # …and output (thinking bills here). UNSET by default:
+                                    # since #868 the ledger prices each call at its ROUTED
+                                    # model's rates (MODEL_RATES in lib/ai/models). Set these
+                                    # only to answer a provider price move before a deploy.
+
+# Optional — per-action Gemini model routing (#868). Defaults live in code
+# (lib/ai/models): hint → gemini-3.5-flash-lite; ask/propose/review →
+# gemini-3.6-flash; any Socratic-tier hint/ask turn → gemini-3.5-flash-lite; the
+# openEnded reflection reply → gemini-3.5-flash-lite. These vars are an escape
+# hatch for a price move or a model deprecation. A value outside the priced model
+# set (gemini-3.6-flash | gemini-3.5-flash-lite | gemini-3.5-flash) is IGNORED
+# with a warning — routing to an unpriced model would break the ledger's billing.
+AI_MODEL_HINT=                     # Override the `hint` action's model
+AI_MODEL_ASK=                      # Override the `ask` action's model
+AI_MODEL_PROPOSE=                  # Override the `propose` action's model
+AI_MODEL_REVIEW=                   # Override the `review` action's model
+AI_MODEL_SOCRATIC=                 # Override the Socratic-tier hint/ask model
+AI_MODEL_REFLECTION=               # Override the openEnded reflection-reply model
 OPENENDED_AI_REPLY=                # Best-effort AI reply on /api/lessons/reflect (openEnded
                                     # reflections). Default ON since #848 — set to "0" to disable.
                                     # The reflection SEAL is always returned regardless; the reply

--- a/apps/web/src/app/api/ai/__tests__/partner-route.test.ts
+++ b/apps/web/src/app/api/ai/__tests__/partner-route.test.ts
@@ -1108,6 +1108,7 @@ describe("POST /api/ai/partner", () => {
     expect(recordAiSpend).toHaveBeenCalledWith(
       "user-1",
       "203.0.113.9",
+      "gemini-3.6-flash",
       {
         promptTokenCount: 1000,
         candidatesTokenCount: 500,
@@ -1144,6 +1145,7 @@ describe("POST /api/ai/partner", () => {
     expect(recordAiSpend).toHaveBeenCalledWith(
       "user-1",
       "203.0.113.9",
+      "gemini-3.6-flash",
       undefined,
       { promptTokens: 6000, outputTokens: 2048 }
     );
@@ -1321,6 +1323,43 @@ describe("POST /api/ai/partner — Socratic tier (#864)", () => {
     );
   });
 
+  it("a Socratic-tier hint/ask turn is routed to flash-lite, and its spend billed there (#868)", async () => {
+    socraticSpend();
+    const fetchSpy = captureGemini(HINT_TEXT);
+
+    const { POST } = await import("../partner/route");
+    await POST(makeRequest({ ...VALID_BODY, action: "hint" }));
+
+    expect(String(fetchSpy.mock.calls[0]![0])).toContain(
+      "models/gemini-3.5-flash-lite:generateContent"
+    );
+    expect(recordAiSpend).toHaveBeenCalledWith(
+      "user-1",
+      "203.0.113.9",
+      "gemini-3.5-flash-lite",
+      expect.anything(),
+      expect.anything()
+    );
+  });
+
+  it("Socratic OVERRIDES ask's 3.6-flash mapping, but not propose's (§4.2)", async () => {
+    socraticSpend();
+    const askSpy = captureGemini(
+      JSON.stringify({ type: "answer", text: "Consider the bound." })
+    );
+    const { POST } = await import("../partner/route");
+    await POST(makeRequest({ ...VALID_BODY, action: "ask", message: "why?" }));
+    expect(String(askSpy.mock.calls[0]![0])).toContain(
+      "models/gemini-3.5-flash-lite:"
+    );
+
+    const proposeSpy = captureGemini(PROPOSE_GEMINI_TEXT);
+    await POST(makeRequest(VALID_BODY)); // action: propose
+    expect(String(proposeSpy.mock.calls[0]![0])).toContain(
+      "models/gemini-3.6-flash:"
+    );
+  });
+
   it("a Socratic-tier refund hands back the Socratic turn (tier-aware)", async () => {
     socraticSpend();
     stubGeminiFetch("", { ok: false });
@@ -1334,5 +1373,96 @@ describe("POST /api/ai/partner — Socratic tier (#864)", () => {
       "lesson-1",
       "socratic"
     );
+  });
+});
+
+describe("POST /api/ai/partner — per-action model routing (#868)", () => {
+  function captureGemini(text: string) {
+    const fetchSpy = vi.fn(async (_url: string, init: { body: string }) => {
+      void init;
+      return {
+        ok: true,
+        text: async () => "",
+        json: async () => ({
+          candidates: [{ content: { parts: [{ text }] } }],
+          usageMetadata: { cachedContentTokenCount: 0 },
+        }),
+      };
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+    return fetchSpy;
+  }
+
+  const HINT_TEXT = JSON.stringify({ type: "hint", text: "Check the bound." });
+  const ANSWER_TEXT = JSON.stringify({ type: "answer", text: "Because." });
+
+  it("hint hits flash-lite and books its spend at flash-lite rates", async () => {
+    const fetchSpy = captureGemini(HINT_TEXT);
+    const { POST } = await import("../partner/route");
+    const res = await POST(makeRequest({ ...VALID_BODY, action: "hint" }));
+
+    expect(res.status).toBe(200);
+    expect(String(fetchSpy.mock.calls[0]![0])).toContain(
+      "models/gemini-3.5-flash-lite:generateContent"
+    );
+    expect(recordAiSpend).toHaveBeenCalledWith(
+      "user-1",
+      "203.0.113.9",
+      "gemini-3.5-flash-lite",
+      expect.anything(),
+      expect.anything()
+    );
+  });
+
+  it("ask and propose hit 3.6-flash", async () => {
+    const { POST } = await import("../partner/route");
+
+    const askSpy = captureGemini(ANSWER_TEXT);
+    await POST(makeRequest({ ...VALID_BODY, action: "ask", message: "why?" }));
+    expect(String(askSpy.mock.calls[0]![0])).toContain(
+      "models/gemini-3.6-flash:generateContent"
+    );
+
+    const proposeSpy = captureGemini(PROPOSE_GEMINI_TEXT);
+    await POST(makeRequest(VALID_BODY));
+    expect(String(proposeSpy.mock.calls[0]![0])).toContain(
+      "models/gemini-3.6-flash:generateContent"
+    );
+  });
+
+  it("no action still calls the old pinned gemini-3.5-flash URL", async () => {
+    const { POST } = await import("../partner/route");
+    for (const action of ["hint", "ask", "propose"] as const) {
+      const spy = captureGemini(
+        action === "propose"
+          ? PROPOSE_GEMINI_TEXT
+          : action === "hint"
+            ? HINT_TEXT
+            : ANSWER_TEXT
+      );
+      await POST(makeRequest({ ...VALID_BODY, action, message: "why?" }));
+      expect(String(spy.mock.calls[0]![0])).not.toContain(
+        "models/gemini-3.5-flash:generateContent"
+      );
+    }
+  });
+
+  it("a routed model that 404s FAILS CLOSED — no silent fallback model call", async () => {
+    const fetchSpy = vi.fn(async () => ({
+      ok: false,
+      status: 404,
+      text: async () => "model not found",
+      json: async () => ({}),
+    }));
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const { POST } = await import("../partner/route");
+    const res = await POST(makeRequest({ ...VALID_BODY, action: "hint" }));
+
+    expect(res.status).toBe(502);
+    // Exactly one upstream attempt: no retry against a different model.
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(recordAiSpend).not.toHaveBeenCalled();
+    expect(refundAssistTurn).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/src/app/api/ai/partner/route.ts
+++ b/apps/web/src/app/api/ai/partner/route.ts
@@ -16,6 +16,7 @@ import {
 } from "@/lib/ai/spend-ledger";
 import type { GeminiUsageMetadata } from "@/lib/ai/spend-ledger";
 import { sealCheck } from "@/lib/ai/check-seal";
+import { modelForAction, geminiUrl } from "@/lib/ai/models";
 import {
   buildStaticPrefix,
   buildDynamicSuffix,
@@ -66,14 +67,25 @@ interface GeminiEnvelope {
   usageMetadata?: GeminiUsageMetadata & { cachedContentTokenCount?: number };
 }
 
-// Model history: gemini-2.5-flash(-lite) are gated for new keys (404 "not
-// available to new users") and gemini-2.0-flash is now fully retired (404 "no
-// longer available"). gemini-3.5-flash is available and supports structured
-// output. NOTE it's a *thinking* model — thinking tokens draw from the
-// maxOutputTokens budget — so thinking is disabled in generationConfig
-// (thinkingBudget: 0) to keep the whole budget for the structured response.
-const GEMINI_URL =
-  "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.5-flash:generateContent";
+// Model selection is PER ACTION (#868) and lives in lib/ai/models — this route
+// no longer pins one URL. hint → gemini-3.5-flash-lite; ask/propose/review →
+// gemini-3.6-flash; any Socratic-tier hint/ask turn → flash-lite regardless of
+// the base mapping.
+//
+// The old comment here claimed the 2.5 family was gated for new keys ("not
+// available to new users"). That is STALE: the 2026-07-28 reachability curls on
+// the prod key (#838 comment, AIE-04) returned HTTP 200 for 3.5-flash,
+// 3.5-flash-lite and 3.6-flash, and 2.5-flash/-lite appear in this key's model
+// list; the 404s that produced the folklore were a first-connection artifact
+// (empty-bodied, gone on retry). Same record, AIE-05: `thinkingBudget: 0` is
+// verified honored — every routed model here is a thinking model whose thinking
+// tokens would draw from maxOutputTokens and bill at the output rate, so the
+// flag stays on for all of them.
+//
+// A model that 404s FAILS CLOSED: the !response.ok branch below refunds the
+// assist and 502s. There is deliberately no silent fallback to another model —
+// that would bill the learner's turn against a model the ledger wasn't told
+// about.
 
 const VALID_ACTIONS: readonly PartnerAction[] = [
   "hint",
@@ -386,6 +398,10 @@ export async function POST(request: NextRequest) {
   // and `review` is post-pass and unaffected.
   const socratic = spend.tier === "socratic";
 
+  // Resolve the model for THIS turn once: the same value drives the endpoint,
+  // the failure logs, and the ledger's pricing, so they can't disagree.
+  const model = modelForAction(action, { socratic });
+
   // Whether Gemini has BILLED us for this request. Flips true the instant the
   // model returns a 2xx (`response.ok`) — a non-2xx or a network throw means it
   // never ran. This gates the refund: we hand the assist back ONLY when we were
@@ -449,7 +465,7 @@ export async function POST(request: NextRequest) {
       { socratic }
     );
 
-    const response = await fetch(`${GEMINI_URL}?key=${GEMINI_API_KEY}`, {
+    const response = await fetch(`${geminiUrl(model)}?key=${GEMINI_API_KEY}`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -468,9 +484,10 @@ export async function POST(request: NextRequest) {
           maxOutputTokens: degraded
             ? degradedMaxTokens(maxTokensFor(action, { socratic }))
             : maxTokensFor(action, { socratic }),
-          // gemini-3.5-flash is a thinking model and thinking tokens share the
-          // maxOutputTokens budget; disable it so the full budget goes to the
-          // structured response (and to cut latency/cost).
+          // Every routed model is a thinking model and thinking tokens share the
+          // maxOutputTokens budget (and bill at the output rate); disable it so
+          // the full budget goes to the structured response (and to cut
+          // latency/cost). Verified honored per model — #838 AIE-05.
           thinkingConfig: { thinkingBudget: 0 },
           responseMimeType: "application/json",
           responseSchema: responseSchemaFor(action),
@@ -480,7 +497,12 @@ export async function POST(request: NextRequest) {
 
     if (!response.ok) {
       const errorText = await response.text();
-      console.error("Gemini partner API error:", response.status, errorText);
+      console.error(
+        "Gemini partner API error:",
+        model,
+        response.status,
+        errorText
+      );
       // A spend already happened above (spend.allowed was true to reach
       // here) but Gemini never ran — refund exactly the ladder tier the spend
       // landed in so a failed call doesn't burn one of the learner's turns.
@@ -524,7 +546,7 @@ export async function POST(request: NextRequest) {
     // + a generous input estimate — instead of $0, so an unmeasurable-but-billed
     // call is never under-reported. Awaited for the same Vercel-freeze reason as
     // recordBilledAssist. Never throws.
-    await recordAiSpend(user.id, clientIp, data?.usageMetadata, {
+    await recordAiSpend(user.id, clientIp, model, data?.usageMetadata, {
       promptTokens: SPEND_FALLBACK_PROMPT_TOKENS,
       outputTokens: maxTokensFor(action),
     });
@@ -547,7 +569,11 @@ export async function POST(request: NextRequest) {
       // spent before any visible output. NOT refunded: Gemini billed the tokens.
       // Log the reason so maxTokensFor(action) can be tuned; diff-propose +
       // MAX_CODE_CHARS 8k (item 3a, this change) is what makes this hard to hit.
-      console.error("[ai/partner] empty output", { action, finishReason });
+      console.error("[ai/partner] empty output", {
+        action,
+        model,
+        finishReason,
+      });
       return NextResponse.json(
         { error: "AI could not generate a response" },
         { status: 502 }

--- a/apps/web/src/lib/ai/__tests__/models.test.ts
+++ b/apps/web/src/lib/ai/__tests__/models.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import {
+  GEMINI_MODELS,
+  MODEL_RATES,
+  isGeminiModel,
+  modelForAction,
+  modelForReflectionReply,
+  geminiUrl,
+} from "../models";
+
+const MODEL_ENV_VARS = [
+  "AI_MODEL_HINT",
+  "AI_MODEL_ASK",
+  "AI_MODEL_PROPOSE",
+  "AI_MODEL_REVIEW",
+  "AI_MODEL_SOCRATIC",
+  "AI_MODEL_REFLECTION",
+] as const;
+
+afterEach(() => {
+  for (const name of MODEL_ENV_VARS) delete process.env[name];
+  vi.restoreAllMocks();
+});
+
+describe("per-action routing (#868)", () => {
+  it("routes hint to flash-lite and ask/propose to 3.6-flash", () => {
+    expect(modelForAction("hint")).toBe("gemini-3.5-flash-lite");
+    expect(modelForAction("ask")).toBe("gemini-3.6-flash");
+    expect(modelForAction("propose")).toBe("gemini-3.6-flash");
+  });
+
+  it("routes review with ask (same quality shape, not the cheap tier)", () => {
+    expect(modelForAction("review")).toBe("gemini-3.6-flash");
+  });
+
+  it("never routes to the old pinned model by default", () => {
+    for (const action of ["hint", "ask", "propose", "review"] as const) {
+      expect(modelForAction(action)).not.toBe("gemini-3.5-flash");
+    }
+  });
+});
+
+describe("Socratic override (#887 §4.4)", () => {
+  it("forces flash-lite for Socratic-tier hint AND ask turns", () => {
+    expect(modelForAction("hint", { socratic: true })).toBe(
+      "gemini-3.5-flash-lite"
+    );
+    // ask normally routes to 3.6-flash — the Socratic contract overrides it.
+    expect(modelForAction("ask", { socratic: true })).toBe(
+      "gemini-3.5-flash-lite"
+    );
+  });
+
+  it("leaves propose and review on the quality tier at every ladder tier", () => {
+    // §4.2: propose keeps its full diff contract in the Socratic tier; review is
+    // post-pass and unaffected.
+    expect(modelForAction("propose", { socratic: true })).toBe(
+      "gemini-3.6-flash"
+    );
+    expect(modelForAction("review", { socratic: true })).toBe(
+      "gemini-3.6-flash"
+    );
+  });
+
+  it("is a no-op when socratic is false/absent", () => {
+    expect(modelForAction("ask", { socratic: false })).toBe("gemini-3.6-flash");
+    expect(modelForAction("ask")).toBe("gemini-3.6-flash");
+  });
+});
+
+describe("reflection reply routing", () => {
+  it("routes the bounded 512-token reply to the cheap tier", () => {
+    expect(modelForReflectionReply()).toBe("gemini-3.5-flash-lite");
+  });
+});
+
+describe("env overrides", () => {
+  it("lets a per-action var override the coded default", () => {
+    process.env.AI_MODEL_HINT = "gemini-3.6-flash";
+    expect(modelForAction("hint")).toBe("gemini-3.6-flash");
+    // Other actions are untouched.
+    expect(modelForAction("propose")).toBe("gemini-3.6-flash");
+    expect(modelForAction("hint", { socratic: true })).toBe(
+      "gemini-3.5-flash-lite"
+    );
+  });
+
+  it("lets AI_MODEL_SOCRATIC override only the Socratic path", () => {
+    process.env.AI_MODEL_SOCRATIC = "gemini-3.5-flash";
+    expect(modelForAction("hint", { socratic: true })).toBe("gemini-3.5-flash");
+    expect(modelForAction("hint")).toBe("gemini-3.5-flash-lite");
+  });
+
+  it("lets AI_MODEL_REFLECTION override the reflection reply", () => {
+    process.env.AI_MODEL_REFLECTION = "gemini-3.6-flash";
+    expect(modelForReflectionReply()).toBe("gemini-3.6-flash");
+  });
+
+  it("IGNORES an unpriced/garbage model and warns (the ledger must stay honest)", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    process.env.AI_MODEL_ASK = "gemini-9.9-imaginary";
+    expect(modelForAction("ask")).toBe("gemini-3.6-flash");
+    expect(warn).toHaveBeenCalled();
+  });
+
+  it("treats a blank value as unset", () => {
+    process.env.AI_MODEL_ASK = "";
+    expect(modelForAction("ask")).toBe("gemini-3.6-flash");
+  });
+});
+
+describe("price sheet + url", () => {
+  it("prices every routable model (no model can be routed unpriced)", () => {
+    for (const model of GEMINI_MODELS) {
+      expect(MODEL_RATES[model].inputUsdPerMTok).toBeGreaterThan(0);
+      expect(MODEL_RATES[model].outputUsdPerMTok).toBeGreaterThan(0);
+    }
+  });
+
+  it("builds the generateContent endpoint for the routed model", () => {
+    expect(geminiUrl("gemini-3.5-flash-lite")).toBe(
+      "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.5-flash-lite:generateContent"
+    );
+  });
+
+  it("recognises exactly the priced models", () => {
+    expect(isGeminiModel("gemini-3.6-flash")).toBe(true);
+    expect(isGeminiModel("gemini-2.5-flash-lite")).toBe(false);
+  });
+});

--- a/apps/web/src/lib/ai/__tests__/reflection-reply.test.ts
+++ b/apps/web/src/lib/ai/__tests__/reflection-reply.test.ts
@@ -70,6 +70,28 @@ describe("maybeGenerateReflectionReply", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it("calls the CHEAP routed model, not the old 3.5-flash pin (#868)", async () => {
+    const fetchMock = stubGeminiFetch("Nice work");
+    const { maybeGenerateReflectionReply } =
+      await import("../reflection-reply");
+    await maybeGenerateReflectionReply(INPUT);
+    const url = String((fetchMock.mock.calls[0] as unknown[])[0]);
+    expect(url).toContain("models/gemini-3.5-flash-lite:generateContent");
+    expect(url).not.toContain("models/gemini-3.5-flash:");
+  });
+
+  it("honours AI_MODEL_REFLECTION when it names a priced model", async () => {
+    process.env.AI_MODEL_REFLECTION = "gemini-3.6-flash";
+    const fetchMock = stubGeminiFetch("Nice work");
+    const { maybeGenerateReflectionReply } =
+      await import("../reflection-reply");
+    await maybeGenerateReflectionReply(INPUT);
+    expect(String((fetchMock.mock.calls[0] as unknown[])[0])).toContain(
+      "models/gemini-3.6-flash:generateContent"
+    );
+    delete process.env.AI_MODEL_REFLECTION;
+  });
+
   it("is ON by default — replies with the flag unset (#848)", async () => {
     delete process.env.OPENENDED_AI_REPLY;
     stubGeminiFetch("Default-on reply");
@@ -195,6 +217,7 @@ describe("maybeGenerateReflectionReply", () => {
     expect(recordAiSpend).toHaveBeenCalledWith(
       "user-1",
       "203.0.113.7",
+      "gemini-3.5-flash-lite",
       usageMetadata,
       { promptTokens: 3000, outputTokens: 512 }
     );
@@ -210,6 +233,7 @@ describe("maybeGenerateReflectionReply", () => {
     expect(recordAiSpend).toHaveBeenCalledWith(
       "user-1",
       "203.0.113.7",
+      "gemini-3.5-flash-lite",
       undefined,
       { promptTokens: 3000, outputTokens: 512 }
     );

--- a/apps/web/src/lib/ai/__tests__/spend-ledger.test.ts
+++ b/apps/web/src/lib/ai/__tests__/spend-ledger.test.ts
@@ -13,12 +13,18 @@ import {
   degradedMaxTokens,
   checkAiSpend,
   recordAiSpend,
+  ratesFor,
   getAiSpendToday,
 } from "../spend-ledger";
+import { MODEL_RATES } from "../models";
 
-// The wrapper reads caps/rates from serverEnv, which in tests takes the
-// env.server defaults (O-1 numbers): account soft/hard $0.50/$1.50, IP $2/$5,
-// global $14/$25; rates $0.30 input, $2.50 output per Mtok. Micro-USD = USD×1e6.
+// The wrapper reads caps from serverEnv, which in tests takes the env.server
+// defaults (O-1 numbers): account soft/hard $0.50/$1.50, IP $2/$5, global
+// $14/$25. Micro-USD = USD×1e6. Rates are PER MODEL since #868; the pre-existing
+// cases below were written against $0.30/$2.50, which is exactly flash-lite's
+// sheet, so they pin the cheap tier explicitly.
+const LITE = "gemini-3.5-flash-lite" as const;
+const FLASH_36 = "gemini-3.6-flash" as const;
 const RATES = { inputUsdPerMTok: 0.3, outputUsdPerMTok: 2.5 };
 
 beforeEach(() => {
@@ -182,11 +188,70 @@ describe("checkAiSpend", () => {
   });
 });
 
+describe("ratesFor (per-model pricing, #868)", () => {
+  it("prices each routed model from its own sheet (economics doc §2.1)", () => {
+    expect(ratesFor("gemini-3.6-flash")).toEqual({
+      inputUsdPerMTok: 1.5,
+      outputUsdPerMTok: 7.5,
+    });
+    expect(ratesFor("gemini-3.5-flash-lite")).toEqual({
+      inputUsdPerMTok: 0.3,
+      outputUsdPerMTok: 2.5,
+    });
+    // Kept as the documented fallback pin — and what pre-#868 traffic cost.
+    expect(ratesFor("gemini-3.5-flash")).toEqual({
+      inputUsdPerMTok: 1.5,
+      outputUsdPerMTok: 9.0,
+    });
+  });
+
+  it("matches MODEL_RATES exactly when no env override is set", () => {
+    for (const [model, sheet] of Object.entries(MODEL_RATES)) {
+      expect(ratesFor(model as keyof typeof MODEL_RATES)).toEqual(sheet);
+    }
+  });
+});
+
 describe("recordAiSpend", () => {
+  it("bills the SAME usage differently per routed model", async () => {
+    // Red at main: `recordAiSpend` took no model there and priced every call at
+    // one global rate pair, so a 3.6-flash turn was booked at flash-lite prices
+    // (under-reporting the sponsor's burn ~3×).
+    rpc.mockResolvedValue({ data: null, error: null });
+    const usage = { promptTokenCount: 1000, candidatesTokenCount: 500 };
+
+    await recordAiSpend("u", "1.2.3.4", FLASH_36, usage);
+    // 1000×1.50 = 1500 input; 500×7.50 = 3750 output → 5250 micro-USD.
+    expect(rpc).toHaveBeenLastCalledWith(
+      "record_ai_spend",
+      expect.objectContaining({ p_micro_usd: 5250 })
+    );
+
+    await recordAiSpend("u", "1.2.3.4", LITE, usage);
+    // Same tokens on the cheap tier: 1000×0.30 + 500×2.50 = 1550.
+    expect(rpc).toHaveBeenLastCalledWith(
+      "record_ai_spend",
+      expect.objectContaining({ p_micro_usd: 1550 })
+    );
+  });
+
+  it("prices the conservative fallback at the routed model's rates too", async () => {
+    rpc.mockResolvedValue({ data: null, error: null });
+    // No usageMetadata on a billed 3.6-flash call: 3000×1.50 + 512×7.50 = 8340.
+    await recordAiSpend("u", "1.2.3.4", FLASH_36, undefined, {
+      promptTokens: 3000,
+      outputTokens: 512,
+    });
+    expect(rpc).toHaveBeenLastCalledWith(
+      "record_ai_spend",
+      expect.objectContaining({ p_micro_usd: 8340 })
+    );
+  });
+
   it("books the computed micro-USD via record_ai_spend", async () => {
     rpc.mockResolvedValue({ data: null, error: null });
 
-    await recordAiSpend("u", "1.2.3.4", {
+    await recordAiSpend("u", "1.2.3.4", LITE, {
       promptTokenCount: 1000,
       candidatesTokenCount: 500,
     });
@@ -201,14 +266,14 @@ describe("recordAiSpend", () => {
   it("never throws when the record RPC errors (best-effort audit)", async () => {
     rpc.mockResolvedValue({ data: null, error: { message: "down" } });
     await expect(
-      recordAiSpend("u", "1.2.3.4", { promptTokenCount: 10 })
+      recordAiSpend("u", "1.2.3.4", LITE, { promptTokenCount: 10 })
     ).resolves.toBeUndefined();
   });
 
   it("never throws when the record RPC rejects", async () => {
     rpc.mockRejectedValue(new Error("network"));
     await expect(
-      recordAiSpend("u", "1.2.3.4", { promptTokenCount: 10 })
+      recordAiSpend("u", "1.2.3.4", LITE, { promptTokenCount: 10 })
     ).resolves.toBeUndefined();
   });
 
@@ -216,7 +281,7 @@ describe("recordAiSpend", () => {
     rpc.mockResolvedValue({ data: null, error: null });
     // usage undefined → metered estimate is 0 → fall back to the caller's shape.
     // 3000 input × 0.30 = 900; 512 output × 2.50 = 1280; total 2180 micro.
-    await recordAiSpend("u", "1.2.3.4", undefined, {
+    await recordAiSpend("u", "1.2.3.4", LITE, undefined, {
       promptTokens: 3000,
       outputTokens: 512,
     });
@@ -233,6 +298,7 @@ describe("recordAiSpend", () => {
     await recordAiSpend(
       "u",
       "1.2.3.4",
+      LITE,
       { promptTokenCount: 1000, candidatesTokenCount: 500 },
       { promptTokens: 9999, outputTokens: 9999 }
     );
@@ -247,6 +313,7 @@ describe("recordAiSpend", () => {
     await recordAiSpend(
       "u",
       "1.2.3.4",
+      LITE,
       {},
       {
         promptTokens: 3000,

--- a/apps/web/src/lib/ai/models.ts
+++ b/apps/web/src/lib/ai/models.ts
@@ -1,0 +1,148 @@
+import type { PartnerAction } from "@/lib/ai/partner-types";
+
+// Per-action Gemini model routing (#868, unified-spec item 3b / economics doc
+// P1-1). Every Gemini caller in the app resolves its model HERE, so the routing
+// table, the price sheet the spend ledger bills against, and the URL builder
+// stay in one place and cannot drift apart.
+//
+// Model-history correction (supersedes the old route.ts folklore): the claim
+// that the 2.5 family 404s "for new keys" is STALE. The 2026-07-28 reachability
+// curls on the prod key (#838 comment, AIE-04) returned HTTP 200 on
+// generateContent for `gemini-3.5-flash`, `gemini-3.5-flash-lite` AND
+// `gemini-3.6-flash`, and 2.5-flash/-lite appear in this key's model list. The
+// same record notes a first-connection artifact: the very first attempts
+// produced spurious 404s with EMPTY bodies, and every retry returned a real 200
+// — so any future "this model 404s for our key" claim must be re-tested twice
+// before it is believed (or written down).
+//
+// AIE-05 from the same record: `thinkingConfig: { thinkingBudget: 0 }` is
+// VERIFIED HONORED (no `thoughtsTokenCount` under budget-0; 146 thinking tokens
+// on the no-config control). Callers keep sending it — thinking tokens bill at
+// the OUTPUT rate, so it is a real cost lever, not a formality.
+
+export const GEMINI_MODELS = [
+  "gemini-3.6-flash",
+  "gemini-3.5-flash-lite",
+  "gemini-3.5-flash",
+] as const;
+
+export type GeminiModel = (typeof GEMINI_MODELS)[number];
+
+export interface ModelRates {
+  inputUsdPerMTok: number;
+  outputUsdPerMTok: number;
+}
+
+/**
+ * Gemini price sheet, USD per 1M tokens — economics doc §2.1 table (source:
+ * https://ai.google.dev/gemini-api/docs/pricing). Thinking tokens bill at the
+ * OUTPUT rate (#591). This is the ledger's billing truth: a model with no entry
+ * here cannot be routed to, which is deliberate — routing to an unpriced model
+ * would make the #591 spend ledger under-report the sponsor's burn.
+ *
+ * `gemini-3.5-flash` is no longer routed by default; it stays in the table as
+ * the documented fallback pin (and because its rates are what the pre-#868
+ * traffic actually cost).
+ */
+export const MODEL_RATES: Record<GeminiModel, ModelRates> = {
+  "gemini-3.6-flash": { inputUsdPerMTok: 1.5, outputUsdPerMTok: 7.5 },
+  "gemini-3.5-flash-lite": { inputUsdPerMTok: 0.3, outputUsdPerMTok: 2.5 },
+  "gemini-3.5-flash": { inputUsdPerMTok: 1.5, outputUsdPerMTok: 9.0 },
+};
+
+/** The cheap tier: short, bounded, low-stakes generations. */
+export const FLASH_LITE_MODEL: GeminiModel = "gemini-3.5-flash-lite";
+
+/** The quality tier: multi-hundred-token reasoning-shaped generations. */
+export const FLASH_MODEL: GeminiModel = "gemini-3.6-flash";
+
+/**
+ * Socratic-tier turns (#887 §4.4) are ONE diagnostic question at a hint-sized
+ * output cap — the cheapest shape the tutor emits, and the highest-volume tier
+ * (per-lesson ceiling 10 → 30 turns, 60 with the self-reset). Routing them to
+ * flash-lite regardless of the base action mapping is the single biggest lever
+ * in this change: ~$0.004/turn on the old pin → ~$0.0007.
+ */
+export const SOCRATIC_MODEL: GeminiModel = FLASH_LITE_MODEL;
+
+/**
+ * The openEnded reflection reply (lib/ai/reflection-reply.ts) is a single
+ * unstructured note capped at 512 output tokens, best-effort, never blocking the
+ * seal. Low stakes + bounded output = the cheap tier is the right fit per the
+ * economics doc's classification; nothing about it needs 3.6-flash's headroom.
+ */
+export const REFLECTION_REPLY_MODEL: GeminiModel = FLASH_LITE_MODEL;
+
+/**
+ * Base action → model. `hint` is short and high-volume (flash-lite); `ask` and
+ * `propose` carry the quality-sensitive reasoning and diff contracts
+ * (3.6-flash, which dominates the old pin on output price and ties on input).
+ * `review` is not in the economics doc's table — it emits a summary plus notes
+ * over the learner's finished code, the same quality shape as `ask`, so it
+ * follows `ask` rather than the cheap tier.
+ */
+const DEFAULT_ACTION_MODEL: Record<PartnerAction, GeminiModel> = {
+  hint: FLASH_LITE_MODEL,
+  ask: FLASH_MODEL,
+  propose: FLASH_MODEL,
+  review: FLASH_MODEL,
+};
+
+// Optional per-action env overrides, so a price move or a model deprecation can
+// be answered from the dashboard without a deploy. Defaults live in code above;
+// these are an escape hatch, not configuration. A value outside GEMINI_MODELS is
+// IGNORED (warn + fall back to the coded default) — an unpriced model would
+// silently break the ledger's accounting, so the allowlist is the price table.
+const ACTION_MODEL_ENV: Record<PartnerAction, string> = {
+  hint: "AI_MODEL_HINT",
+  ask: "AI_MODEL_ASK",
+  propose: "AI_MODEL_PROPOSE",
+  review: "AI_MODEL_REVIEW",
+};
+
+const SOCRATIC_MODEL_ENV = "AI_MODEL_SOCRATIC";
+const REFLECTION_MODEL_ENV = "AI_MODEL_REFLECTION";
+
+export function isGeminiModel(value: string): value is GeminiModel {
+  return (GEMINI_MODELS as readonly string[]).includes(value);
+}
+
+function envModel(name: string): GeminiModel | undefined {
+  const raw = process.env[name];
+  if (!raw) return undefined;
+  if (!isGeminiModel(raw)) {
+    console.warn(
+      `[ai/models] ignoring ${name}="${raw}" — not a priced model (${GEMINI_MODELS.join(", ")})`
+    );
+    return undefined;
+  }
+  return raw;
+}
+
+/**
+ * Resolve the model for one AI Partner turn.
+ *
+ * The Socratic contract wins over the base mapping, but only where it APPLIES:
+ * §4.2 keeps `propose`'s full diff contract at every ladder tier, and `review`
+ * is post-pass and unaffected — so only `hint`/`ask` are re-routed when the turn
+ * lands in the Socratic tier.
+ */
+export function modelForAction(
+  action: PartnerAction,
+  opts?: { socratic?: boolean }
+): GeminiModel {
+  if (opts?.socratic && (action === "hint" || action === "ask")) {
+    return envModel(SOCRATIC_MODEL_ENV) ?? SOCRATIC_MODEL;
+  }
+  return envModel(ACTION_MODEL_ENV[action]) ?? DEFAULT_ACTION_MODEL[action];
+}
+
+/** Resolve the model for the openEnded reflection reply. */
+export function modelForReflectionReply(): GeminiModel {
+  return envModel(REFLECTION_MODEL_ENV) ?? REFLECTION_REPLY_MODEL;
+}
+
+/** The generateContent endpoint for a routed model. */
+export function geminiUrl(model: GeminiModel): string {
+  return `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent`;
+}

--- a/apps/web/src/lib/ai/reflection-reply.ts
+++ b/apps/web/src/lib/ai/reflection-reply.ts
@@ -7,6 +7,7 @@ import {
   degradedMaxTokens,
 } from "@/lib/ai/spend-ledger";
 import type { GeminiUsageMetadata } from "@/lib/ai/spend-ledger";
+import { modelForReflectionReply, geminiUrl } from "@/lib/ai/models";
 
 // Best-effort AI feedback for an `openEnded` reflection. NEVER blocks the seal:
 // the attestation route computes and returns the receipt independently, then
@@ -27,11 +28,16 @@ import type { GeminiUsageMetadata } from "@/lib/ai/spend-ledger";
 // (spendAssist/refundAssist): the reflection reply is not a code-challenge
 // assist and must not draw from that per-lesson quota.
 
-const GEMINI_URL =
-  "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.5-flash:generateContent";
+// Model: routed, not pinned (#868). This reply is the textbook cheap-tier case
+// — ONE unstructured note, hard-capped at 512 output tokens, best-effort, and
+// discarded entirely on any failure because the seal ships regardless. Nothing
+// here needs 3.6-flash's headroom, and the #724 constraints in the header
+// (capped, low-latency, ledger-gated) point the same way, so it routes to
+// gemini-3.5-flash-lite (economics doc §2.1: $0.30/$2.50 per M vs $1.50/$9.00
+// on the old pin — ~5× cheaper on output for the same 512-token ceiling).
 
 // A short feedback note, not an essay. Kept small so an enabled reply is cheap
-// and low-latency; gemini-3.5-flash is a thinking model, so thinking is disabled
+// and low-latency; the routed model is a thinking model, so thinking is disabled
 // to spend the whole budget on the visible response.
 const MAX_OUTPUT_TOKENS = 512;
 
@@ -114,10 +120,11 @@ export async function maybeGenerateReflectionReply({
     outputTokens = degradedMaxTokens(MAX_OUTPUT_TOKENS);
   }
 
+  const model = modelForReflectionReply();
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), REPLY_TIMEOUT_MS);
   try {
-    const response = await fetch(`${GEMINI_URL}?key=${apiKey}`, {
+    const response = await fetch(`${geminiUrl(model)}?key=${apiKey}`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       signal: controller.signal,
@@ -155,7 +162,7 @@ export async function maybeGenerateReflectionReply({
     } catch {
       data = undefined;
     }
-    await recordAiSpend(userId, ip, data?.usageMetadata, {
+    await recordAiSpend(userId, ip, model, data?.usageMetadata, {
       promptTokens: SPEND_FALLBACK_PROMPT_TOKENS,
       outputTokens: MAX_OUTPUT_TOKENS,
     });

--- a/apps/web/src/lib/ai/spend-ledger.ts
+++ b/apps/web/src/lib/ai/spend-ledger.ts
@@ -1,6 +1,8 @@
 import "server-only";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { serverEnv } from "@/lib/env.server";
+import { MODEL_RATES } from "@/lib/ai/models";
+import type { GeminiModel, ModelRates } from "@/lib/ai/models";
 
 // AI tutor spend ledger (#591). The AI Partner spends a Superteam-sponsored
 // Gemini key; `challenge_assists` counts turns, not cost. This module gates and
@@ -38,10 +40,10 @@ interface SpendCapsMicroUsd {
   globalHard: number;
 }
 
-interface SpendRates {
-  inputUsdPerMTok: number;
-  outputUsdPerMTok: number;
-}
+// Pricing is PER MODEL (#868): the route bills different models per action, so
+// one global rate pair would misprice every call that isn't the pinned model.
+// `ModelRates` is the shared shape; `MODEL_RATES` (lib/ai/models) is the sheet.
+export type SpendRates = ModelRates;
 
 // The Gemini token accounting we bill against. Thinking tokens
 // (`thoughtsTokenCount`) bill at the OUTPUT rate (#591), so they are summed with
@@ -68,10 +70,21 @@ function capsMicroUsd(): SpendCapsMicroUsd {
   };
 }
 
-function rates(): SpendRates {
+/**
+ * The rates one billed generation is priced at. Base is the per-model price
+ * sheet (economics doc §2.1). `AI_SPEND_{INPUT,OUTPUT}_USD_PER_MTOK` remain as
+ * an EMERGENCY override applied across all models — a provider price move can
+ * be answered from the dashboard before a deploy — but they are now unset by
+ * default, so the ledger prices each model correctly out of the box instead of
+ * billing every call at one model's rates.
+ */
+export function ratesFor(model: GeminiModel): SpendRates {
+  const base = MODEL_RATES[model];
   return {
-    inputUsdPerMTok: serverEnv.AI_SPEND_INPUT_USD_PER_MTOK,
-    outputUsdPerMTok: serverEnv.AI_SPEND_OUTPUT_USD_PER_MTOK,
+    inputUsdPerMTok:
+      serverEnv.AI_SPEND_INPUT_USD_PER_MTOK ?? base.inputUsdPerMTok,
+    outputUsdPerMTok:
+      serverEnv.AI_SPEND_OUTPUT_USD_PER_MTOK ?? base.outputUsdPerMTok,
   };
 }
 
@@ -102,10 +115,12 @@ export function estimateSpendMicroUsd(
 
 /**
  * The degraded output-token budget: half the normal budget, floored so the
- * reply stays usable. Degrade is a SHORTER OUTPUT (the dominant cost lever), not
- * a model swap — gemini's cheaper flash-lite tier is gated for new keys (the
- * route documents the 404), so shrinking the output budget is the real,
- * always-available degrade.
+ * reply stays usable. Degrade remains a SHORTER OUTPUT, not a model swap —
+ * per-action routing (#868) already spends each action on its cheapest adequate
+ * model, so there is no cheaper tier left to fall to at degrade time without
+ * changing what the action can do. (The old note here claimed flash-lite was
+ * gated for new keys; the 2026-07-28 curl record disproved that — flash-lite is
+ * now the *default* for hint and Socratic turns.)
  */
 export function degradedMaxTokens(base: number): number {
   return Math.max(256, Math.floor(base / 2));
@@ -167,7 +182,9 @@ export async function checkAiSpend(
 
 /**
  * Record the actual micro-USD cost of a billed generation into all three daily
- * buckets. Best-effort: called only after Gemini has billed us, on the paid
+ * buckets, priced at the ROUTED MODEL's rates (#868) — the caller passes the
+ * model it actually called, so a flash-lite Socratic turn is not billed at
+ * 3.6-flash prices (or vice versa). Best-effort: called only after Gemini has billed us, on the paid
  * path, and must never break the reply the learner is owed, so it never throws.
  * A recording failure loses one data point of audit, not correctness — the CAP
  * is enforced by `checkAiSpend`, which fails closed on its own.
@@ -182,10 +199,11 @@ export async function checkAiSpend(
 export async function recordAiSpend(
   userId: string,
   ip: string,
+  model: GeminiModel,
   usage: GeminiUsageMetadata | undefined,
   fallback?: { promptTokens: number; outputTokens: number }
 ): Promise<void> {
-  const r = rates();
+  const r = ratesFor(model);
   let microUsd = estimateSpendMicroUsd(usage, r);
   if (microUsd <= 0 && fallback) {
     microUsd = estimateSpendMicroUsd(

--- a/apps/web/src/lib/env.server.ts
+++ b/apps/web/src/lib/env.server.ts
@@ -24,6 +24,14 @@ const usdNum = (fallback: number) =>
     z.coerce.number().min(0)
   );
 
+// An OPTIONAL non-negative USD amount: unset or blank leaves it `undefined` so
+// the caller can fall back to a code-side default (the per-model price sheet),
+// while a set-to-garbage or negative value still fails loudly at boot.
+const usdNumOpt = z.preprocess(
+  (v) => (v === "" || v === undefined ? undefined : v),
+  z.coerce.number().min(0).optional()
+);
+
 // A HARD-cap dollar amount. Identical to usdNum but rejects 0: a hard cap of $0
 // denies every request (self-DoS). Fail-closed makes that "safe" but silent —
 // so reject it loudly at boot instead of letting a fat-fingered `=0` take the
@@ -119,11 +127,14 @@ const serverEnvSchema = z.object({
   AI_SPEND_ACCOUNT_HARD_USD: usdNumHard(1.5), // a single account ≤ ~9% of the envelope
   AI_SPEND_IP_SOFT_USD: usdNum(2), // survives a NAT'd classroom
   AI_SPEND_IP_HARD_USD: usdNumHard(5), // caps a single-IP farm at ~30% of the envelope
-  // Gemini price sheet (USD per 1M tokens) used to turn usageMetadata token
-  // counts into micro-USD. Thinking tokens bill at the OUTPUT rate (#591). These
-  // move with the provider's pricing, not the sponsor commitment.
-  AI_SPEND_INPUT_USD_PER_MTOK: usdNum(0.3),
-  AI_SPEND_OUTPUT_USD_PER_MTOK: usdNum(2.5),
+  // Gemini price sheet OVERRIDE (USD per 1M tokens). Since #868 the ledger
+  // prices each billed call at its ROUTED model's rates (MODEL_RATES in
+  // lib/ai/models) — a single global rate pair would misprice every action that
+  // isn't the pinned model. These two stay as an emergency, all-models override
+  // for a provider price move that can't wait for a deploy; UNSET by default so
+  // the per-model sheet is what bills. Thinking tokens bill at the OUTPUT rate.
+  AI_SPEND_INPUT_USD_PER_MTOK: usdNumOpt,
+  AI_SPEND_OUTPUT_USD_PER_MTOK: usdNumOpt,
 });
 
 const parsed = serverEnvSchema.safeParse({


### PR DESCRIPTION
Closes #868 (epic #838 item 3b / economics doc P1-1).

The AI Partner and the reflection reply each pinned their own `GEMINI_URL` to `gemini-3.5-flash`. This replaces both with one routing module (`apps/web/src/lib/ai/models.ts`) that owns the action→model table, the price sheet, and the URL builder — so routing and billing can't drift apart.

**Priority context:** the just-merged assist ladder (#887) runs Socratic turns — the cheapest shape the tutor emits and the highest-volume tier (10→30 turns per lesson, 60 with the self-reset) — on the expensive pinned model. That's what this lands to stop.

## Routing table

| Caller | Model | Why |
|---|---|---|
| `hint` | `gemini-3.5-flash-lite` | short, high-volume |
| `ask` | `gemini-3.6-flash` | quality-sensitive reasoning |
| `propose` | `gemini-3.6-flash` | diff contract + comprehension check |
| `review` | `gemini-3.6-flash` | not in the doc's table; same quality shape as `ask`, so it follows `ask`, not the cheap tier |
| **Socratic-tier `hint`/`ask`** | `gemini-3.5-flash-lite` | **overrides the base mapping** — one diagnostic question at a hint-sized cap |
| Socratic-tier `propose`/`review` | `gemini-3.6-flash` | §4.2 keeps propose's full diff contract at every tier; review is post-pass |
| `reflection-reply` | `gemini-3.5-flash-lite` | one unstructured note, hard-capped at 512 output tokens, best-effort, discarded on any failure — nothing needs 3.6-flash's headroom (reasoning is recorded in-file) |

Both target models were verified reachable on the prod key by the 2026-07-28 curls (#838, AIE-04), with `thinkingBudget: 0` verified honored (AIE-05).

Defaults live in code. Optional per-action env overrides (`AI_MODEL_HINT|ASK|PROPOSE|REVIEW|SOCRATIC|REFLECTION`) exist as an escape hatch for a price move or a deprecation; a value outside the priced model set is **ignored with a warning**, because routing to an unpriced model would silently break the ledger's accounting.

## Ledger pricing (this was single-model — it is now per-model)

`lib/ai/spend-ledger.ts` priced every billed call from one global rate pair (`AI_SPEND_{INPUT,OUTPUT}_USD_PER_MTOK`, defaults `$0.30`/`$2.50`). Two problems: (a) those defaults are flash-lite's sheet, so the pinned `gemini-3.5-flash` traffic was already **under-reported ~3× on output**; (b) with per-action routing, one rate pair mis-prices every action that isn't the routed default.

`recordAiSpend` now takes the model it actually called and prices it from `MODEL_RATES` (economics doc §2.1):

| Model | Input $/M | Output $/M |
|---|---|---|
| `gemini-3.6-flash` | 1.50 | 7.50 |
| `gemini-3.5-flash-lite` | 0.30 | 2.50 |
| `gemini-3.5-flash` (fallback pin, kept) | 1.50 | 9.00 |

The two env vars survive as an **emergency all-models override**, now unset by default (`usdNumOpt`) so the per-model sheet is what bills.

**Red-proof** (the pricing change is behaviour, not refactor): the new `spend-ledger.test.ts` was run against `origin/main`'s ledger in a detached worktree — **8 tests fail**, including `bills the SAME usage differently per routed model` (main books `p_micro_usd: 0` where the routed model should book `5250`). Green on this branch.

## Cost impact

Per the economics doc §2.1/§2.2 shapes (thinking off, verified):

- Socratic turn: ~$0.004 → **~$0.0007** (≈5×)
- `hint`: $0.0036 → **~$0.0010**
- `ask`: $0.0068 → **~$0.0060**
- `propose`: $0.0113 → **~$0.0098**
- reflection reply (512 tok ceiling): ~5× cheaper on output

The doc's headline is a ~32% blended cut; the ladder's Socratic volume makes the realized cut larger. The #591 fail-closed spend ledger remains the actual ceiling — this widens the headroom under it, it doesn't relax it.

## Failure semantics

A routed model that 404s **fails closed**: the existing `!response.ok` branch refunds the assist tier and 502s. There is deliberately no silent fallback to another model — that would bill a learner's turn against a model the ledger wasn't told about. Covered by a test asserting exactly one upstream attempt.

## Stale comments corrected

`route.ts:69-70` claimed the 2.5 family 404s "for new keys" and that 2.0-flash is retired. The 2026-07-28 curl record disproves the gating claim (2.5-flash/-lite appear in this key's model list; all three candidates returned HTTP 200) and attributes the original 404s to a first-connection artifact — empty-bodied, gone on retry. The corrected note carries that "re-test twice before believing a 404" rule forward. The same stale claim in `degradedMaxTokens`'s doc comment (flash-lite "gated for new keys") is fixed too — flash-lite is now the default for hint and Socratic.

## Not in scope

**Flex-tier spike is NOT built.** Owner decision **D-7** (spike owner + exit criterion, suggested p95 < 4s on `hint`) is unresolved, and the issue conditions the spike on that criterion being demonstrated and recorded. No Flex code ships here.

## Verification

- `pnpm typecheck` clean
- Full web suite: **240 files / 2202 tests passed**
- `pnpm lint`: no new warnings (109 → 109 pre-existing)
