### PR TITLE
feat(ai): capstone AI-off via the credential-gate constant (#867)

### DIFF
--- a/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/blocks/__tests__/open-ended-block.test.tsx
+++ b/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/blocks/__tests__/open-ended-block.test.tsx
@@ -36,6 +36,7 @@ function makeCtx(overrides: Partial<BlockContext> = {}): BlockContext {
     setProof: vi.fn(),
     setQuizAnswered: vi.fn(),
     aiSuppressed: true,
+    capstoneAiOff: false,
     buildUuid: null,
     programKeypairSecret: null,
     resetBuild: vi.fn(),

--- a/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/blocks/__tests__/parsons-block.test.tsx
+++ b/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/blocks/__tests__/parsons-block.test.tsx
@@ -43,6 +43,7 @@ function makeCtx(overrides: Partial<BlockContext> = {}): BlockContext {
     setProof: vi.fn(),
     setQuizAnswered: vi.fn(),
     aiSuppressed: true,
+    capstoneAiOff: false,
     buildUuid: null,
     programKeypairSecret: null,
     resetBuild: vi.fn(),

--- a/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/blocks/__tests__/quiz-block.test.tsx
+++ b/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/blocks/__tests__/quiz-block.test.tsx
@@ -72,6 +72,7 @@ function makeCtx(overrides: Partial<BlockContext> = {}): BlockContext {
     setProof: vi.fn(),
     setQuizAnswered: vi.fn(),
     aiSuppressed: true,
+    capstoneAiOff: false,
     buildUuid: null,
     programKeypairSecret: null,
     resetBuild: vi.fn(),

--- a/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/blocks/code-block.tsx
+++ b/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/blocks/code-block.tsx
@@ -56,6 +56,7 @@ export function CodeBlock({ block, ctx }: BlockRenderProps) {
           isEnrolled={ctx.isEnrolled}
           onEnroll={ctx.onEnroll}
           aiSuppressed={ctx.aiSuppressed}
+          capstoneAiOff={ctx.capstoneAiOff}
           className="h-full"
         />
       </div>

--- a/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/blocks/types.ts
+++ b/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/blocks/types.ts
@@ -30,6 +30,15 @@ export interface BlockContext {
    * block threads it to ChallengeInterface, which keeps the AI Partner hidden.
    */
   aiSuppressed: boolean;
+  /**
+   * True on THE graded capstone lesson (#867) — derived from
+   * `lib/credentials/capstone-identity`, the same constant the credential gate
+   * uses. Unlike `aiSuppressed` this is permanent and explained: the code block
+   * threads it to ChallengeInterface, which renders the AI-free rationale where
+   * the AI Partner would sit. The server refuses independently
+   * (`/api/ai/partner`) — this is presentation, not the enforcement.
+   */
+  capstoneAiOff: boolean;
   /** Latest successful build (for deployable code + the deployed-program card). */
   buildUuid: string | null;
   programKeypairSecret: number[] | null;

--- a/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/lesson-client.tsx
+++ b/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/lesson-client.tsx
@@ -18,6 +18,7 @@ import { AuthModal } from "@/components/auth/auth-modal";
 import { trackEvent } from "@/lib/analytics";
 import { completionErrorKey } from "@/lib/lessons/completion-error";
 import { createClient } from "@/lib/supabase/client";
+import { isCapstoneLesson } from "@/lib/credentials/capstone-identity";
 import { useAuth } from "@/lib/auth/auth-provider";
 import { useOnChainEnroll } from "@/hooks/use-on-chain-enroll";
 import { bankCompletion, removeBanked } from "@/lib/lessons/progress-bank";
@@ -223,6 +224,16 @@ export function LessonPageClient({
       prev[blockKey] === answered ? prev : { ...prev, [blockKey]: answered }
     );
   }, []);
+  // AI hard-off on the capstone (#867) — the CLIENT leg of the server refusal
+  // in /api/ai/partner, derived from the same `capstone-identity` constant as
+  // the credential gate (never a second hardcoded id). Distinct from
+  // `aiSuppressed`: quiz suppression is temporary (answer the quiz and the
+  // tutor returns) and simply HIDES the pane, whereas this is permanent and
+  // must be EXPLAINED — the pane renders the AI-free rationale in place of its
+  // actions, so a learner who expected a tutor learns why there isn't one
+  // rather than finding a blank column.
+  const capstoneAiOff = isCapstoneLesson(lesson._id);
+
   const aiSuppressed =
     hasQuizBlock &&
     !isCompleted &&
@@ -401,6 +412,7 @@ export function LessonPageClient({
       setProof,
       setQuizAnswered,
       aiSuppressed,
+      capstoneAiOff,
       buildUuid,
       programKeypairSecret,
       resetBuild,
@@ -418,6 +430,7 @@ export function LessonPageClient({
       setProof,
       setQuizAnswered,
       aiSuppressed,
+      capstoneAiOff,
       buildUuid,
       programKeypairSecret,
       resetBuild,

--- a/apps/web/src/app/api/ai/__tests__/partner-capstone-off.test.ts
+++ b/apps/web/src/app/api/ai/__tests__/partner-capstone-off.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// AI hard-off on the capstone (#867, unified spec item 33) — the SERVER leg.
+//
+// RED-PROOF (measured): with this file's route change reverted, 3 of these 4
+// tests fail — `expected 200 to be 403` and `spendAssistTurn … called 1 times`.
+// No capstone check exists at main, so the request falls straight through and
+// is SERVED, spending a turn and hitting Gemini.
+//
+// That 200 is the point. Today's capstone happens to carry no `code` block, so
+// the route 404s there by accident — the "structural absence" this issue
+// exists to replace. The fixtures below deliberately give the capstone a code
+// block, which is precisely the content edit that would silently re-enable AI
+// on the lesson the credential rests on.
+
+vi.mock("server-only", () => ({}));
+
+const getUser = vi.fn();
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: async () => ({ auth: { getUser } }),
+}));
+
+const spendAssistTurn = vi.fn();
+const refundAssistTurn = vi.fn();
+const recordBilledAssist = vi.fn();
+const appendAssistLog = vi.fn();
+vi.mock("@/lib/ai/assist-budget", () => ({
+  spendAssistTurn,
+  refundAssistTurn,
+  recordBilledAssist,
+  appendAssistLog,
+  MAX_PAID_ASSISTS: 4,
+}));
+
+const isRateLimited = vi.fn();
+const getClientIp = vi.fn(() => "203.0.113.9");
+vi.mock("@/lib/rate-limit", () => ({ isRateLimited, getClientIp }));
+
+const checkAiSpend = vi.fn();
+const recordAiSpend = vi.fn();
+vi.mock("@/lib/ai/spend-ledger", () => ({
+  checkAiSpend,
+  recordAiSpend,
+  degradedMaxTokens: (base: number) => Math.max(256, Math.floor(base / 2)),
+}));
+
+const getLessonBySlug = vi.fn();
+vi.mock("@/lib/content/queries", () => ({ getLessonBySlug }));
+
+// The REAL identity module — deliberately not mocked. These tests must break if
+// the constant moves or changes, which is half the point of the shared-constant
+// clause.
+import {
+  CAPSTONE_CREDENTIAL,
+  CAPSTONE_AI_OFF_CODE,
+} from "@/lib/credentials/capstone-identity";
+
+const CODE_BLOCK = {
+  _type: "code",
+  key: "c1",
+  language: "rust",
+  buildType: "standard",
+  starter: "fn solve() {}",
+  solution: "fn solve() { /* the answer */ }",
+  tests: [
+    { id: "v1", description: "visible test", input: "1", expectedOutput: "2" },
+  ],
+  hints: [],
+};
+
+// The capstone WITH a code block: the worst case this change defends against —
+// a future content edit that gives the capstone a challenge surface. Structural
+// absence would silently serve AI here; the constant-driven check must not.
+const CAPSTONE_LESSON = {
+  _id: CAPSTONE_CREDENTIAL.deployLessonId,
+  title: "Capstone",
+  slug: "capstone",
+  blocks: [{ _type: "prose", key: "p1", src: "Ship it." }, CODE_BLOCK],
+};
+
+const ORDINARY_LESSON = {
+  _id: "lesson-1",
+  title: "Solve it",
+  slug: "l-slug",
+  blocks: [{ _type: "prose", key: "p1", src: "Double it." }, CODE_BLOCK],
+};
+
+function makeRequest(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/ai/partner", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "content-type": "application/json" },
+  });
+}
+
+const BODY = {
+  lessonSlug: "capstone",
+  courseSlug: "c-slug",
+  action: "hint",
+  code: "let x = 1;",
+  testSummary: "1/2 passing",
+};
+
+const GEMINI_TEXT = JSON.stringify({
+  type: "hint",
+  text: "Try a smaller step.",
+});
+
+function stubGeminiFetch() {
+  const fetchMock = vi.fn(async () => {
+    return {
+      ok: true,
+      text: async () => "",
+      json: async () => ({
+        candidates: [{ content: { parts: [{ text: GEMINI_TEXT }] } }],
+        usageMetadata: {},
+      }),
+    } as unknown as Response;
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  process.env.GEMINI_API_KEY = "test-gemini-key";
+  process.env.AI_PARTNER_SEAL_SECRET = "test-seal-secret";
+  getUser.mockReset();
+  spendAssistTurn.mockReset();
+  refundAssistTurn.mockReset();
+  recordBilledAssist.mockReset();
+  appendAssistLog.mockReset();
+  isRateLimited.mockReset();
+  getLessonBySlug.mockReset();
+  checkAiSpend.mockReset();
+  recordAiSpend.mockReset();
+
+  getUser.mockResolvedValue({ data: { user: { id: "user-1" } }, error: null });
+  isRateLimited.mockResolvedValue(false);
+  spendAssistTurn.mockResolvedValue({
+    allowed: true,
+    tier: "free",
+    counts: { free: 1, metered: 0, socratic: 0 },
+  });
+  refundAssistTurn.mockResolvedValue(undefined);
+  recordBilledAssist.mockResolvedValue(undefined);
+  appendAssistLog.mockResolvedValue(undefined);
+  checkAiSpend.mockResolvedValue({ decision: "full" });
+  recordAiSpend.mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+  delete process.env.GEMINI_API_KEY;
+  delete process.env.AI_PARTNER_SEAL_SECRET;
+});
+
+describe("POST /api/ai/partner — capstone AI hard-off (#867)", () => {
+  it("refuses the capstone lesson with the typed capstone_ai_off code", async () => {
+    getLessonBySlug.mockResolvedValue(CAPSTONE_LESSON);
+    stubGeminiFetch();
+
+    const { POST } = await import("../partner/route");
+    const res = await POST(makeRequest(BODY));
+    const json = await res.json();
+
+    expect(res.status).toBe(403);
+    expect(json).toMatchObject({
+      code: CAPSTONE_AI_OFF_CODE,
+      capstoneAiOff: true,
+    });
+  });
+
+  it("spends nothing: no assist turn, no ledger write, no Gemini call", async () => {
+    getLessonBySlug.mockResolvedValue(CAPSTONE_LESSON);
+    const fetchMock = stubGeminiFetch();
+
+    const { POST } = await import("../partner/route");
+    await POST(makeRequest(BODY));
+
+    // The refusal is the design, not a failure — it must cost the learner
+    // nothing and must never reach the platform-funded key.
+    expect(spendAssistTurn).not.toHaveBeenCalled();
+    expect(recordBilledAssist).not.toHaveBeenCalled();
+    expect(recordAiSpend).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+    // Nothing was spent, so nothing may be refunded either (a refund would
+    // credit a turn that was never taken).
+    expect(refundAssistTurn).not.toHaveBeenCalled();
+  });
+
+  it("refuses every action, not just hint", async () => {
+    getLessonBySlug.mockResolvedValue(CAPSTONE_LESSON);
+    stubGeminiFetch();
+    const { POST } = await import("../partner/route");
+
+    for (const action of ["hint", "ask", "propose", "review"]) {
+      const res = await POST(makeRequest({ ...BODY, action }));
+      expect(res.status, `action=${action}`).toBe(403);
+    }
+  });
+
+  it("leaves a non-capstone lesson untouched", async () => {
+    getLessonBySlug.mockResolvedValue(ORDINARY_LESSON);
+    const fetchMock = stubGeminiFetch();
+
+    const { POST } = await import("../partner/route");
+    const res = await POST(
+      makeRequest({ ...BODY, lessonSlug: "l-slug", action: "hint" })
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json).toMatchObject({ type: "hint" });
+    expect(spendAssistTurn).toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/api/ai/partner/route.ts
+++ b/apps/web/src/app/api/ai/partner/route.ts
@@ -35,6 +35,10 @@ import type {
   ReviewResponse,
   CodeEdit,
 } from "@/lib/ai/partner-types";
+import {
+  isCapstoneLesson,
+  CAPSTONE_AI_OFF_CODE,
+} from "@/lib/credentials/capstone-identity";
 import { serverEnv } from "@/lib/env.server";
 
 const GEMINI_API_KEY = serverEnv.GEMINI_API_KEY;
@@ -340,6 +344,34 @@ export async function POST(request: NextRequest) {
   // §10.2). getLessonBySlug applies the normal catalog gate — a lesson not yet
   // live has no partner surface either.
   const lesson = await getLessonBySlug(courseSlug, lessonSlug);
+
+  // AI HARD-OFF ON THE CAPSTONE (#867, unified spec item 33). The capstone
+  // credential attests that the learner shipped the program themselves (the
+  // deploy gate, item 14) — so it certifies nothing if a tutor could have
+  // written it. This is the SERVER leg, keyed off the SAME constant as that
+  // gate (`lib/credentials/capstone-identity`), so the two can never drift:
+  // re-shaping the capstone lesson cannot silently re-open the AI path.
+  //
+  // Placement is load-bearing on two counts:
+  //   • BEFORE any spend — no assist turn, no ledger entry, no Gemini call. A
+  //     refusal here costs the learner nothing (it is not a failure, it is the
+  //     design), so it must not consume a turn.
+  //   • BEFORE the `codeBlock` 404 — the capstone hosts no `code` block today,
+  //     so a structural 404 is what happens by accident. This returns the
+  //     TYPED reason instead, which is the whole point of the issue: the
+  //     refusal must be intentional and observable, not incidental.
+  // The copy is neutral, not an error: this is a permanent, explained state.
+  if (lesson && isCapstoneLesson(lesson._id)) {
+    return NextResponse.json(
+      {
+        error: "AI Partner is off for the capstone",
+        code: CAPSTONE_AI_OFF_CODE,
+        capstoneAiOff: true,
+      },
+      { status: 403 }
+    );
+  }
+
   const codeBlock = lesson?.blocks.find(
     (b): b is CodeBlockData => b._type === "code"
   );

--- a/apps/web/src/app/api/lessons/__tests__/reflect-capstone-off.test.ts
+++ b/apps/web/src/app/api/lessons/__tests__/reflect-capstone-off.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// AI hard-off on the capstone (#867) — the reflection leg.
+//
+// RULING (implemented here): on the capstone lesson the AI reply is NOT
+// generated, while the submission seal is returned exactly as before. The
+// capstone credential attests unaided work, and "AI-free" is only checkable if
+// it means *no AI turn on that lesson*. Receipt-first (AIE-21) is preserved —
+// suppressing enrichment must never make the lesson uncompletable.
+
+vi.mock("server-only", () => ({}));
+
+const getUser = vi.fn();
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: async () => ({ auth: { getUser } }),
+}));
+
+const getLessonByIdForGrading = vi.fn();
+vi.mock("@/lib/content/queries", () => ({ getLessonByIdForGrading }));
+
+const isRateLimited = vi.fn();
+const getClientIp = vi.fn(() => "203.0.113.9");
+vi.mock("@/lib/rate-limit", () => ({ isRateLimited, getClientIp }));
+
+const maybeGenerateReflectionReply = vi.fn();
+vi.mock("@/lib/ai/reflection-reply", () => ({ maybeGenerateReflectionReply }));
+
+import { CAPSTONE_CREDENTIAL } from "@/lib/credentials/capstone-identity";
+
+const BLOCK = {
+  _type: "openEnded",
+  key: "r1",
+  prompt: "What did you build?",
+  maxWords: 200,
+};
+
+function lessonWithReflection(id: string) {
+  return { _id: id, slug: "s", title: "t", blocks: [BLOCK] };
+}
+
+function makeRequest(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/lessons/reflect", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "content-type": "application/json" },
+  });
+}
+
+const TEXT = "I deployed the vault program to devnet under my own authority.";
+
+beforeEach(() => {
+  vi.resetModules();
+  process.env.NEXT_PUBLIC_SUPABASE_URL = "http://localhost:54321";
+  process.env.SUPABASE_SERVICE_ROLE_KEY = "service-role-key";
+  process.env.AI_PARTNER_SEAL_SECRET = "test-seal-secret";
+  getUser.mockReset();
+  getLessonByIdForGrading.mockReset();
+  isRateLimited.mockReset();
+  maybeGenerateReflectionReply.mockReset();
+
+  getUser.mockResolvedValue({ data: { user: { id: "user-1" } }, error: null });
+  isRateLimited.mockResolvedValue(false);
+  maybeGenerateReflectionReply.mockResolvedValue("Nice write-up.");
+});
+
+describe("POST /api/lessons/reflect — capstone AI-free ruling (#867)", () => {
+  it("returns the seal but no AI reply on the capstone lesson", async () => {
+    const lessonId = CAPSTONE_CREDENTIAL.deployLessonId;
+    getLessonByIdForGrading.mockResolvedValue(lessonWithReflection(lessonId));
+
+    const { POST } = await import("../reflect/route");
+    const res = await POST(
+      makeRequest({
+        courseId: CAPSTONE_CREDENTIAL.courseId,
+        lessonId,
+        blockKey: "r1",
+        text: TEXT,
+      })
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    // Receipt-first is untouched: completion still works.
+    expect(typeof json.seal).toBe("string");
+    expect(json.seal.length).toBeGreaterThan(0);
+    expect(json.reply).toBeNull();
+    // The generator is never even invoked — no spend, no ledger entry.
+    expect(maybeGenerateReflectionReply).not.toHaveBeenCalled();
+  });
+
+  it("still generates the reply on a non-capstone lesson", async () => {
+    getLessonByIdForGrading.mockResolvedValue(
+      lessonWithReflection("lesson-ordinary")
+    );
+
+    const { POST } = await import("../reflect/route");
+    const res = await POST(
+      makeRequest({
+        courseId: "course-other",
+        lessonId: "lesson-ordinary",
+        blockKey: "r1",
+        text: TEXT,
+      })
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.reply).toBe("Nice write-up.");
+    expect(maybeGenerateReflectionReply).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/web/src/app/api/lessons/reflect/route.ts
+++ b/apps/web/src/app/api/lessons/reflect/route.ts
@@ -5,6 +5,7 @@ import { getLessonByIdForGrading } from "@/lib/content/queries";
 import { sealAttestation } from "@/lib/ai/check-seal";
 import { maybeGenerateReflectionReply } from "@/lib/ai/reflection-reply";
 import { isRateLimited, getClientIp } from "@/lib/rate-limit";
+import { isCapstoneLesson } from "@/lib/credentials/capstone-identity";
 import { logError } from "@/lib/logging";
 import { ERROR_IDS } from "@/constants/errorIds";
 import { serverEnv } from "@/lib/env.server";
@@ -168,18 +169,35 @@ export async function POST(request: NextRequest) {
     // and resolves to null on failure/disabled/rate-limit; the extra try/catch
     // keeps the receipt-first guarantee LOCAL — the seal is returned even if the
     // reply path ever throws, rather than relying on the helper's discipline.
+    //
+    // CAPSTONE RULING (#867, unified spec item 33): on the capstone lesson the
+    // reply is NOT generated. The capstone credential attests unaided work, and
+    // "AI-free" is only checkable if it means *no AI turn on that lesson* —
+    // not "no AI turn that I judged to be help". The capstone's `openEnded`
+    // block is a write-up of a deploy that already happened, so this reply is
+    // enrichment rather than assistance; suppressing it therefore costs the
+    // learner nothing and buys a flat, greppable invariant keyed off the same
+    // constant as the credential gate.
+    //
+    // Receipt-first is UNTOUCHED: the seal is already computed above and is
+    // returned unconditionally. Skipping the reply cannot block completion,
+    // XP, or the credential — only the optional paragraph of feedback.
+    const capstoneAiOff = isCapstoneLesson(lessonId);
+
     let reply: string | null = null;
-    try {
-      reply = await maybeGenerateReflectionReply({
-        userId: user.id,
-        // Per-IP spend dimension (#724): the reply is metered under the #591
-        // ledger, which needs the actor's IP, not just the user id.
-        ip: getClientIp(request.headers),
-        prompt: (block as OpenEndedBlockData).prompt,
-        reflection: text,
-      });
-    } catch {
-      reply = null;
+    if (!capstoneAiOff) {
+      try {
+        reply = await maybeGenerateReflectionReply({
+          userId: user.id,
+          // Per-IP spend dimension (#724): the reply is metered under the #591
+          // ledger, which needs the actor's IP, not just the user id.
+          ip: getClientIp(request.headers),
+          prompt: (block as OpenEndedBlockData).prompt,
+          reflection: text,
+        });
+      } catch {
+        reply = null;
+      }
     }
 
     return NextResponse.json({ seal, reply });

--- a/apps/web/src/components/editor/__tests__/challenge-interface-capstone-ai-off.test.tsx
+++ b/apps/web/src/components/editor/__tests__/challenge-interface-capstone-ai-off.test.tsx
@@ -1,0 +1,106 @@
+// @vitest-environment jsdom
+// AI hard-off on the capstone (#867) — the CLIENT leg. Unlike `aiSuppressed`
+// (temporary, silent), this state is permanent and must be EXPLAINED: the pane
+// is replaced by the AI-free rationale, so a learner who expected a tutor
+// learns why there isn't one instead of finding an empty column.
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import messages from "@/messages/en.json";
+import { ChallengeInterface } from "../challenge-interface";
+
+vi.mock("../code-editor", async () => {
+  const { forwardRef } = await import("react");
+  return {
+    CodeEditor: forwardRef(function CodeEditorMock() {
+      return null;
+    }),
+    resetEditorStorage: vi.fn(),
+  };
+});
+
+vi.mock("../output-panel", () => ({ OutputPanel: () => null }));
+vi.mock("../challenge-runner", () => ({ ChallengeRunner: () => null }));
+
+vi.mock("../ai-partner/ai-partner-pane", async () => {
+  const { createElement } = await import("react");
+  return {
+    AiPartnerPane: () => createElement("div", { "data-testid": "ai-pane" }),
+  };
+});
+
+beforeEach(() => {
+  vi.stubGlobal(
+    "IntersectionObserver",
+    class {
+      readonly root = null;
+      readonly rootMargin = "";
+      readonly thresholds: readonly number[] = [];
+      constructor(private readonly cb: IntersectionObserverCallback) {}
+      observe(): void {
+        this.cb(
+          [{ isIntersecting: true } as IntersectionObserverEntry],
+          this as unknown as IntersectionObserver
+        );
+      }
+      unobserve(): void {}
+      disconnect(): void {}
+      takeRecords(): IntersectionObserverEntry[] {
+        return [];
+      }
+    }
+  );
+});
+
+function renderInterface(props: { capstoneAiOff?: boolean } = {}) {
+  return render(
+    <NextIntlClientProvider locale="en" messages={messages}>
+      <ChallengeInterface
+        lessonId="lesson-1"
+        courseSlug="course"
+        lessonSlug="lesson"
+        initialCode=""
+        language="typescript"
+        tests={[]}
+        hints={[]}
+        xpReward={30}
+        {...props}
+      />
+    </NextIntlClientProvider>
+  );
+}
+
+describe("ChallengeInterface — capstone AI-free state (#867)", () => {
+  it("never mounts the AI pane on the capstone", () => {
+    renderInterface({ capstoneAiOff: true });
+    // Unmounted, not CSS-hidden: hidden controls would still be reachable by
+    // keyboard (WCAG 4.1.2) and would still POST to the route.
+    expect(screen.queryByTestId("ai-pane")).not.toBeInTheDocument();
+  });
+
+  it("renders the AI-free explanation in the pane's place", () => {
+    renderInterface({ capstoneAiOff: true });
+    expect(
+      screen.getByText(messages.lesson.capstoneAiOffBody)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(messages.lesson.capstoneAiOffTitle)
+    ).toBeInTheDocument();
+  });
+
+  it("shows no explanation and keeps the pane on an ordinary lesson", () => {
+    renderInterface({ capstoneAiOff: false });
+    expect(screen.getByTestId("ai-pane")).toBeInTheDocument();
+    expect(
+      screen.queryByText(messages.lesson.capstoneAiOffBody)
+    ).not.toBeInTheDocument();
+  });
+
+  it("defaults to off (ordinary lesson) when the prop is omitted", () => {
+    renderInterface();
+    expect(screen.getByTestId("ai-pane")).toBeInTheDocument();
+    expect(
+      screen.queryByText(messages.lesson.capstoneAiOffBody)
+    ).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/editor/challenge-interface.tsx
+++ b/apps/web/src/components/editor/challenge-interface.tsx
@@ -82,6 +82,7 @@ export function ChallengeInterface({
   onEnroll,
   onComplete,
   aiSuppressed = false,
+  capstoneAiOff = false,
   className,
 }: ChallengeInterfaceProps) {
   const t = useTranslations("lesson");
@@ -187,7 +188,10 @@ export function ChallengeInterface({
   // internally and that sentinel could never intersect — the tutor was simply
   // unreachable. `aiSuppressed` (an unanswered quiz block, LX-C1/F18) still
   // hides it.
-  const aiVisible = !aiSuppressed;
+  // `capstoneAiOff` (#867) beats `aiSuppressed`: the capstone never gets a
+  // tutor, so the pane is not mounted at all — and unlike quiz suppression the
+  // slot is not left empty, it carries the explanation rendered below.
+  const aiVisible = !aiSuppressed && !capstoneAiOff;
 
   // Attempt-gate signal (#865, replaces the #770 hard think-first lock): the
   // AI Partner is never locked, but until the learner has run the tests at
@@ -453,6 +457,26 @@ export function ChallengeInterface({
             and collapsible. Now it grows with the conversation and caps out,
             scrolling internally past the cap. Hidden outright when suppressed so
             no invisible controls sit in the tab order (WCAG 4.1.2). */}
+        {/* Capstone AI-free notice (#867) — replaces the pane, never sits
+            alongside it. Static text, no controls, so nothing enters the tab
+            order; role="note" announces it as context rather than a status
+            change or an error. */}
+        {capstoneAiOff && (
+          <div
+            role="note"
+            className="order-4 px-3 pb-4 pt-2 lg:order-none lg:shrink-0"
+          >
+            <div className="rounded-lg border border-border bg-card px-4 py-3">
+              <p className="text-sm font-bold text-text">
+                {t("capstoneAiOffTitle")}
+              </p>
+              <p className="mt-1 text-xs text-text-3">
+                {t("capstoneAiOffBody")}
+              </p>
+            </div>
+          </div>
+        )}
+
         <div
           className={cn(
             "order-4 px-3 pb-4 pt-2 lg:order-none lg:shrink-0",

--- a/apps/web/src/components/editor/types.ts
+++ b/apps/web/src/components/editor/types.ts
@@ -103,6 +103,15 @@ export interface ChallengeInterfaceProps {
    * close cannot be delegated to the tutor.
    */
   aiSuppressed?: boolean;
+  /**
+   * THE graded capstone (#867). Derived from `lib/credentials/capstone-identity`
+   * — the same constant that gates the credential — never a lesson id compared
+   * inline. The AI Partner is not merely hidden here: the pane's slot renders a
+   * short AI-free explanation, because this state is permanent and deliberate
+   * and the learner deserves the reason. Enforcement is server-side
+   * (`/api/ai/partner` refuses with `capstone_ai_off`); this is the honest UI.
+   */
+  capstoneAiOff?: boolean;
   className?: string;
 }
 

--- a/apps/web/src/lib/credentials/__tests__/capstone-identity.test.ts
+++ b/apps/web/src/lib/credentials/__tests__/capstone-identity.test.ts
@@ -1,0 +1,92 @@
+/* eslint-disable import/order -- vi.mock('server-only') must be hoisted above
+   the capstone-gate import so its module graph loads under vitest. */
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+import {
+  CAPSTONE_CREDENTIAL,
+  CAPSTONE_AI_OFF_CODE,
+  isCapstoneCourse,
+  isCapstoneLesson,
+} from "../capstone-identity";
+import * as gate from "../capstone-gate";
+
+// The shared-constant clause (#867 / unified spec items 14 + 33): the credential
+// gate and the AI hard-off must key off ONE definition of the capstone identity.
+// These tests are what breaks when someone forks it.
+
+describe("capstone identity — single definition site", () => {
+  it("capstone-gate re-exports the identity module's object, not a copy", () => {
+    // Reference equality, not deep equality: a second literal with the same
+    // values would pass `toEqual` and defeat the whole point.
+    expect(gate.CAPSTONE_CREDENTIAL).toBe(CAPSTONE_CREDENTIAL);
+    expect(gate.isCapstoneCourse).toBe(isCapstoneCourse);
+    expect(gate.isCapstoneLesson).toBe(isCapstoneLesson);
+  });
+
+  it("no other source file hardcodes the capstone ids", () => {
+    // Walk the app source and fail on any literal occurrence of either id
+    // outside this module. Tests and the generated content bundle are the two
+    // legitimate exceptions: tests assert against the ids by construction, and
+    // the bundle is where the ids actually come from.
+    const SRC = join(process.cwd(), "src");
+    const IDS = [
+      CAPSTONE_CREDENTIAL.courseId,
+      CAPSTONE_CREDENTIAL.deployLessonId,
+    ];
+    const ALLOWED = new Set([
+      join("lib", "credentials", "capstone-identity.ts"),
+      // Not a fork: the personalization entry-course table (#599/#673) names
+      // C3 as segment 2's entry rung. It happens to be the same course, but it
+      // is answering "where does this learner start?", not "is this the graded
+      // capstone?" — coupling it to CAPSTONE_CREDENTIAL would be the real bug.
+      join("lib", "courses", "learner-segment.ts"),
+    ]);
+
+    const offenders: string[] = [];
+    const walk = (dir: string) => {
+      for (const entry of readdirSync(dir)) {
+        const full = join(dir, entry);
+        if (statSync(full).isDirectory()) {
+          if (entry === "__tests__" || entry === "generated") continue;
+          walk(full);
+          continue;
+        }
+        if (!/\.(ts|tsx)$/.test(entry)) continue;
+        const rel = relative(SRC, full);
+        if (ALLOWED.has(rel)) continue;
+        const source = readFileSync(full, "utf8");
+        if (IDS.some((id) => source.includes(id))) offenders.push(rel);
+      }
+    };
+    walk(SRC);
+
+    expect(
+      offenders,
+      `the capstone ids must be defined once, in ${[...ALLOWED].join(
+        ", "
+      )} — found literals in: ${offenders.join(", ")}`
+    ).toEqual([]);
+  });
+});
+
+describe("capstone identity — predicates", () => {
+  it("isCapstoneLesson matches the credential gate's deploy lesson only", () => {
+    expect(isCapstoneLesson(CAPSTONE_CREDENTIAL.deployLessonId)).toBe(true);
+    expect(isCapstoneLesson("lesson-something-else")).toBe(false);
+    // The course id is not a lesson id — the two must not be interchangeable.
+    expect(isCapstoneLesson(CAPSTONE_CREDENTIAL.courseId)).toBe(false);
+  });
+
+  it("isCapstoneCourse matches the gated course only", () => {
+    expect(isCapstoneCourse(CAPSTONE_CREDENTIAL.courseId)).toBe(true);
+    expect(isCapstoneCourse("course-other")).toBe(false);
+  });
+
+  it("exposes a stable typed refusal code for the AI routes", () => {
+    expect(CAPSTONE_AI_OFF_CODE).toBe("capstone_ai_off");
+  });
+});

--- a/apps/web/src/lib/credentials/capstone-gate.ts
+++ b/apps/web/src/lib/credentials/capstone-gate.ts
@@ -1,8 +1,20 @@
 import "server-only";
 
 import type { createAdminClient } from "@/lib/supabase/admin";
+import { CAPSTONE_CREDENTIAL, isCapstoneCourse } from "./capstone-identity";
 
 type AdminClient = ReturnType<typeof createAdminClient>;
+
+// The capstone identity itself lives in `./capstone-identity` — a
+// non-`server-only` module, so the lesson client can render the AI hard-off
+// (#867) from the SAME constant instead of a forked string. Re-exported here so
+// every existing `@/lib/credentials/capstone-gate` importer is unchanged; this
+// file remains the home of the gate's database logic.
+export {
+  CAPSTONE_CREDENTIAL,
+  isCapstoneCourse,
+  isCapstoneLesson,
+} from "./capstone-identity";
 
 // ---------------------------------------------------------------------------
 // LX-E2 — Capstone-gated credential (owner decision O-2)
@@ -21,9 +33,9 @@ type AdminClient = ReturnType<typeof createAdminClient>;
 // linked wallet (#620 / LX-E1). A row therefore means a real, attributable
 // deploy — not a self-reported claim.
 //
-// Identity is an app-side constant for launch; a content-schema flag comes
-// later. The values below MUST match what the deploy panel writes to
-// `deployed_programs`:
+// Identity is an app-side constant for launch (see `./capstone-identity`); a
+// content-schema flag comes later. Those values MUST match what the deploy
+// panel writes to `deployed_programs`:
 //   - courseId       = the page-level course `_id`   (courseInfo._id)
 //   - deployLessonId = the lesson hosting the `deployed-program-card` block
 //                      (ctx.lesson._id)
@@ -36,16 +48,6 @@ type AdminClient = ReturnType<typeof createAdminClient>;
 // existing `certificates` row) BEFORE reaching the gate, so pre-gate devnet
 // certificates minted without a recorded deploy stay valid and are never
 // re-evaluated.
-
-export const CAPSTONE_CREDENTIAL = {
-  courseId: "course-building-first-program",
-  deployLessonId: "lesson-bfsp-m4-capstone",
-} as const;
-
-/** Whether a course's credential is subject to the capstone deploy gate. */
-export function isCapstoneCourse(courseId: string): boolean {
-  return courseId === CAPSTONE_CREDENTIAL.courseId;
-}
 
 export type CapstoneGateResult =
   // The course is not the capstone — the deploy gate does not apply; issue as usual.

--- a/apps/web/src/lib/credentials/capstone-identity.ts
+++ b/apps/web/src/lib/credentials/capstone-identity.ts
@@ -1,0 +1,62 @@
+// ---------------------------------------------------------------------------
+// Capstone identity — the ONE definition site (#867, unified spec item 33)
+// ---------------------------------------------------------------------------
+//
+// `CAPSTONE_CREDENTIAL` names the graded capstone: the course whose credential
+// is deploy-gated (item 14) and the lesson that hosts that graded deploy. Two
+// independent systems key off it and MUST NOT be able to drift:
+//
+//   1. the credential gate — `./capstone-gate` (server-only): withholds the
+//      credential until a verified `deployed_programs` row exists for this
+//      lesson;
+//   2. the AI hard-off — `/api/ai/partner`, `/api/lessons/reflect`, and the
+//      lesson client: no AI turn is served on this lesson at all.
+//
+// (2) exists BECAUSE of (1): the credential attests that the learner shipped
+// the program themselves, so it certifies nothing if a tutor could have written
+// it. Forking the identity string would silently re-enable AI on the very
+// lesson the credential rests on — so both legs import from here.
+//
+// This module is deliberately NOT `server-only`: the lesson client renders the
+// AI-free state from the same constant, and a client-importable definition is
+// what keeps that from becoming a second hardcoded id. It holds constants and
+// pure predicates only — no I/O, no secrets. The gate's database logic stays in
+// `./capstone-gate`, which re-exports these for its existing callers.
+//
+// SHAPE (single-valued, on purpose): exactly one course mints a deploy-gated
+// credential today (C3). The multi-course future (C1/EVM capstones) turns this
+// into a lookup — a readonly array of `{ courseId, deployLessonId }`, or a
+// content-schema flag on the lesson, with `isCapstoneCourse`/`isCapstoneLesson`
+// becoming membership tests. Every consumer already goes through those two
+// predicates rather than comparing the constant inline, so that change is local
+// to this file. Do NOT pre-build a registry for one entry.
+
+export const CAPSTONE_CREDENTIAL = {
+  courseId: "course-building-first-program",
+  deployLessonId: "lesson-bfsp-m4-capstone",
+} as const;
+
+/** Whether a course's credential is subject to the capstone deploy gate. */
+export function isCapstoneCourse(courseId: string): boolean {
+  return courseId === CAPSTONE_CREDENTIAL.courseId;
+}
+
+/**
+ * Whether a lesson is THE graded capstone — the AI hard-off predicate.
+ *
+ * Takes a lesson `_id` (the same value the deploy panel writes to
+ * `deployed_programs.lesson_id`), not a slug: slugs are display-layer and can
+ * be re-derived, ids are the on-chain/PDA-stable identity.
+ */
+export function isCapstoneLesson(lessonId: string): boolean {
+  return lessonId === CAPSTONE_CREDENTIAL.deployLessonId;
+}
+
+/**
+ * The typed reason an AI route refuses on the capstone. Shared so the route's
+ * response and the client's copy selection cannot drift, and so the refusal is
+ * distinguishable from a rate limit, a spend cap, or an outage — this one is
+ * permanent and intended, and the UI must say so honestly rather than showing
+ * an error shape.
+ */
+export const CAPSTONE_AI_OFF_CODE = "capstone_ai_off" as const;

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -280,6 +280,8 @@
     "encouragementBody": "Every failed run narrows things down. Peek at the hints or ask the AI partner for a nudge — you're closer than it feels.",
     "encouragementBodyHintsOnly": "Every failed run narrows things down. Reveal a hint below — you're closer than it feels.",
     "encouragementBodyNeutral": "Every failed run narrows things down. Re-read the task and try a smaller step — you're closer than it feels.",
+    "capstoneAiOffTitle": "This one's all you.",
+    "capstoneAiOffBody": "The capstone is completed without the AI Partner — that's what makes the credential yours.",
     "stuckNudgeAction": "Show a hint",
     "stuckNudgeNextAction": "Show another hint",
     "stuckNudgeHintLabel": "Hint {number}",

--- a/apps/web/src/messages/es.json
+++ b/apps/web/src/messages/es.json
@@ -280,6 +280,8 @@
     "encouragementBody": "Cada ejecución fallida descarta posibilidades. Revisa las pistas o pídele una mano al compañero de IA — estás más cerca de lo que parece.",
     "encouragementBodyHintsOnly": "Cada ejecución fallida descarta posibilidades. Muestra una pista abajo — estás más cerca de lo que parece.",
     "encouragementBodyNeutral": "Cada ejecución fallida descarta posibilidades. Relee el enunciado e intenta un paso más pequeño — estás más cerca de lo que parece.",
+    "capstoneAiOffTitle": "Esta parte es solo tuya.",
+    "capstoneAiOffBody": "El capstone se completa sin el AI Partner — eso es lo que hace que la credencial sea tuya.",
     "stuckNudgeAction": "Mostrar una pista",
     "stuckNudgeNextAction": "Mostrar otra pista",
     "stuckNudgeHintLabel": "Pista {number}",

--- a/apps/web/src/messages/pt-BR.json
+++ b/apps/web/src/messages/pt-BR.json
@@ -280,6 +280,8 @@
     "encouragementBody": "Cada execução que falha elimina possibilidades. Dê uma olhada nas dicas ou peça uma força ao parceiro de IA — você está mais perto do que parece.",
     "encouragementBodyHintsOnly": "Cada execução que falha elimina possibilidades. Revele uma dica abaixo — você está mais perto do que parece.",
     "encouragementBodyNeutral": "Cada execução que falha elimina possibilidades. Releia o enunciado e tente um passo menor — você está mais perto do que parece.",
+    "capstoneAiOffTitle": "Esta etapa é só sua.",
+    "capstoneAiOffBody": "O capstone é concluído sem o AI Partner — é isso que torna a credencial sua.",
     "stuckNudgeAction": "Ver uma dica",
     "stuckNudgeNextAction": "Ver outra dica",
     "stuckNudgeHintLabel": "Dica {number}",


### PR DESCRIPTION
Closes #867 — unified spec item 33 (epic #838, last open item), with item 14's shared-constant clause.

## Why

The capstone credential attests that the learner shipped the program **themselves** (the deploy gate, item 14). It certifies nothing if a tutor could have written it.

Before this PR the AI path had only **structural absence** — the capstone happens to carry no `code` block, so `/api/ai/partner` 404'd there by accident — plus quiz-level `aiSuppressed`. No code read a capstone constant in the AI path. A content edit adding a challenge surface to the capstone would have silently re-enabled the AI Partner on the one lesson the credential rests on.

## What

**One definition site.** `lib/credentials/capstone-identity.ts` now holds `CAPSTONE_CREDENTIAL` + `isCapstoneCourse` / `isCapstoneLesson` / `CAPSTONE_AI_OFF_CODE`. It is deliberately **not** `server-only` — the lesson client renders the AI-free state from the same constant, and a client-importable definition is what stops that becoming a second hardcoded id. `capstone-gate.ts` re-exports it and keeps the gate's database logic, so **every existing importer is unchanged**.

**Server enforcement (the leg that matters).** `/api/ai/partner` refuses a capstone lesson with `403 { code: "capstone_ai_off", capstoneAiOff: true }`. Placement is load-bearing on two counts:
- **before any spend** — no assist turn, no billed-assist record, no spend-ledger write, no Gemini call. The refusal is the design, not a failure, so it costs the learner nothing (and nothing is refunded, since nothing was taken).
- **before the `codeBlock` 404** — so the refusal is *typed and intentional*, not the incidental 404 this issue exists to replace.

**Client.** `ChallengeInterface` gains `capstoneAiOff`, derived in `lesson-client` from `isCapstoneLesson(lesson._id)` and threaded through `BlockContext` → `code-block`. Unlike `aiSuppressed` (temporary, silent) this state is permanent, so the pane is **replaced by an explanation** rather than left as an empty column: *"The capstone is completed without the AI Partner — that's what makes the credential yours."* The pane is unmounted, not CSS-hidden (no controls in the tab order, WCAG 4.1.2). Copy in `en` / `pt-BR` / `es`.

## Ruling: `/api/lessons/reflect`

The capstone **does** carry an `openEnded` block ("What You've Built — and Writing It Up"), and `maybeGenerateReflectionReply` is lesson-scoped, so this route was in scope.

**Ruling implemented: the reply is NOT generated on the capstone; the seal is.**

The argument for the other side is real — the reflection is a write-up of a deploy that already happened, so the reply is post-completion enrichment, not challenge help, and could defensibly stay on. It is suppressed anyway because *"AI-free"* is only checkable if it means **no AI turn on that lesson**, not "no AI turn that someone judged to be help". A per-surface judgement call is exactly the kind of thing that drifts; a flat invariant keyed off the credential constant does not.

The cost is zero: **receipt-first (AIE-21) is untouched** — the seal is computed and returned unconditionally, so the capstone lesson stays completable, XP and the credential path are unaffected, and the only thing lost is an optional paragraph of feedback. Covered by `reflect-capstone-off.test.ts` (seal present, `reply: null`, generator never invoked).

## Red-proof

Measured, not asserted. With only the `/api/ai/partner` change reverted (`git stash push` on that one file), `partner-capstone-off.test.ts` goes **3 of 4 red**:

```
× refuses the capstone lesson with the typed capstone_ai_off code
    AssertionError: expected 200 to be 403
× spends nothing: no assist turn, no ledger write, no Gemini call
    AssertionError: expected "vi.fn()" to not be called at all, but actually been called 1 times
× refuses every action, not just hint
    AssertionError: action=hint: expected 200 to be 403
```

A **200**, not a 404: the fixture deliberately gives the capstone a code block, which is precisely the content edit that would silently re-enable AI today. At main the request is served — a turn spent and Gemini called on the capstone.

## Tests

- `partner-capstone-off.test.ts` — typed 403 on the capstone; nothing spent (assist / billed / ledger / fetch / refund all untouched); all four actions refused; non-capstone lesson serves a normal 200.
- `reflect-capstone-off.test.ts` — the ruling above, both directions.
- `challenge-interface-capstone-ai-off.test.tsx` — pane unmounted, explanation rendered, ordinary lesson and omitted-prop default unaffected.
- `capstone-identity.test.ts` — **the anti-fork test**: reference equality between `capstone-gate`'s re-export and the identity module (a duplicate literal would pass `toEqual` and defeat the point), plus a source walk over `apps/web/src` that fails on any file hardcoding either id. One allow-listed exception, documented in the test: `lib/courses/learner-segment.ts` names C3 as segment 2's *entry rung* (#599/#673) — a personalization routing table answering a different question; coupling it to `CAPSTONE_CREDENTIAL` would be the actual bug.

## Shape note (EVM / C1 future)

`CAPSTONE_CREDENTIAL` stays **single-valued** — only C3 mints a deploy-gated credential today. The multi-course future is documented in the module: it becomes a readonly array or a content-schema flag, with the two predicates turning into membership tests. Every consumer already goes through `isCapstoneCourse` / `isCapstoneLesson` rather than comparing the constant inline, so that change is local to one file. No registry invented for one entry.

## Verification

- `pnpm typecheck` — 6/6 tasks pass
- `apps/web` full suite — **244 files, 2217 tests, all passing**
- `pnpm lint` — no errors (only the repo's pre-existing `import/order` warnings)