### PR TITLE
content: bump content.lock — C1 + EVM elective + reflection prompts + flip wave

### DIFF
--- a/apps/web/content.lock
+++ b/apps/web/content.lock
@@ -1,4 +1,4 @@
 {
   "repo": "solanabr/courses-academy",
-  "sha": "9b1f03e6ffd993c8a3f0bac7c79574dd8cbbf6a1"
+  "sha": "c5c625e03b23f6ce527da884456f7b2d36c26bed"
 }

--- a/apps/web/e2e/harness/fixtures.mjs
+++ b/apps/web/e2e/harness/fixtures.mjs
@@ -34,9 +34,13 @@ export const LEARNER = {
 //   • synced + is_active:false  → ABSENT  (a DEACTIVATED course — the #711 leak)
 //   • no row                    → ABSENT  (fail-closed)
 // content_id values are real bundle course ids; the catalog renders their slugs.
-// The bundle is the live 4-course ladder (C2/C3/C4/C5). Three rows are
-// synced+active; one live bundle course is marked is_active:false so the spec
-// keeps its two-directional assertion (present set AND a deactivated absentee).
+// The bundle carries 6 courses: the on-chain ladder (C2/C3/C4/C5) plus C1
+// `course-solana-for-web-devs` and the elective `course-solana-for-evm-devs`,
+// which are STAGED ONLY — no deployment row, so they fall in the "no row →
+// ABSENT" bucket and need no fixture entry until their on-chain create. Three
+// rows are synced+active; one live bundle course is marked is_active:false so
+// the spec keeps its two-directional assertion (present set AND a deactivated
+// absentee).
 export const DEPLOYMENTS = [
   {
     content_id: "course-building-first-program",

--- a/apps/web/src/content/generated/achievements.json
+++ b/apps/web/src/content/generated/achievements.json
@@ -53,7 +53,7 @@
     "_id": "achievement-course-completer",
     "_type": "achievement",
     "award": {
-      "course": "course-rust-for-program-devs",
+      "course": "course-solana-for-web-devs",
       "kind": "course-completed"
     },
     "category": "progress",
@@ -108,7 +108,7 @@
       "path": "path-zero-to-deployed"
     },
     "category": "skills",
-    "description": "Complete all courses in the Solana Developer Path",
+    "description": "Complete every course in the Zero to Deployed path",
     "glyph": "◎",
     "icon": "layers",
     "maxSupply": 0,

--- a/apps/web/src/content/generated/courses.json
+++ b/apps/web/src/content/generated/courses.json
@@ -474,6 +474,234 @@
     "xpReward": 800
   },
   {
+    "_id": "course-solana-for-evm-devs",
+    "_type": "course",
+    "creator": "B7o8NfV81HzjuZFWQTTx3Xdvh77Dqoajwib3kWEnvzJF",
+    "creatorRewardXp": 30,
+    "description": "You already ship on the EVM. You know why `msg.sender` is trustworthy, what a `mapping` costs you, and how a revert unwinds state. None of that knowledge is wasted here — but almost all of it is filed in the wrong drawer. This course re-files it. Storage becomes accounts you allocate and pay rent for. A `mapping` becomes a program-derived address you compute off-chain before you ever send a transaction. `msg.sender` becomes a list of signers the runtime verified before your code ran. Gas becomes a compute budget you can measure and a priority fee you set separately. `approve` becomes a delegate that can be revoked. You finish able to read a Solana transaction and say what it touches, what it costs, and who authorized it — without translating it back into Solidity first. Version stamp — `@solana/kit` 7.0.0 · `@solana-program/compute-budget` 0.17.0 · `@solana-program/token` 0.15.0 · `anchor-lang` 1.1.2 · authored 2026-07-30.",
+    "difficulty": "intermediate",
+    "duration": 6,
+    "minCompletionsForReward": 10,
+    "modules": [
+      {
+        "_key": "sfe-state",
+        "_type": "courseModule",
+        "description": "The single largest mental move: a Solana program owns no storage. Code and state are different accounts, state is allocated with a size you choose and paid for with rent, and the `mapping` you would have reached for becomes an address you derive. Get this module wrong and everything after it reads as arbitrary.",
+        "key": "sfe-state",
+        "lessons": [
+          {
+            "_key": "lesson-sfe-storage-to-accounts",
+            "_ref": "lesson-sfe-storage-to-accounts",
+            "_type": "reference",
+            "_weak": true
+          },
+          {
+            "_key": "lesson-sfe-rent-and-space",
+            "_ref": "lesson-sfe-rent-and-space",
+            "_type": "reference",
+            "_weak": true
+          },
+          {
+            "_key": "lesson-sfe-mappings-to-pdas",
+            "_ref": "lesson-sfe-mappings-to-pdas",
+            "_type": "reference",
+            "_weak": true
+          }
+        ],
+        "title": "State Lives in Accounts"
+      },
+      {
+        "_key": "sfe-execution",
+        "_type": "courseModule",
+        "description": "Who authorized this, what will it touch, and what does it cost — three questions the EVM answers implicitly and Solana makes you answer up front. `msg.sender` becomes a verified signer list, gas becomes a compute budget priced separately from priority, and the account list you must declare in advance is the reason transactions can run in parallel.",
+        "key": "sfe-execution",
+        "lessons": [
+          {
+            "_key": "lesson-sfe-msg-sender-to-signers",
+            "_ref": "lesson-sfe-msg-sender-to-signers",
+            "_type": "reference",
+            "_weak": true
+          },
+          {
+            "_key": "lesson-sfe-gas-to-compute-units",
+            "_ref": "lesson-sfe-gas-to-compute-units",
+            "_type": "reference",
+            "_weak": true
+          },
+          {
+            "_key": "lesson-sfe-declared-accounts",
+            "_ref": "lesson-sfe-declared-accounts",
+            "_type": "reference",
+            "_weak": true
+          }
+        ],
+        "title": "Execution, Signers, and Fees"
+      },
+      {
+        "_key": "sfe-tokens",
+        "_type": "courseModule",
+        "description": "ERC-20 is a contract you deploy; SPL Token is one program everybody shares, and your balance is an account it owns on your behalf. That inversion changes what a transfer is, where `approve` lives, and why composing two protocols is a CPI rather than an external call into unknown code.",
+        "key": "sfe-tokens",
+        "lessons": [
+          {
+            "_key": "lesson-sfe-erc20-to-spl",
+            "_ref": "lesson-sfe-erc20-to-spl",
+            "_type": "reference",
+            "_weak": true
+          },
+          {
+            "_key": "lesson-sfe-approve-to-delegate",
+            "_ref": "lesson-sfe-approve-to-delegate",
+            "_type": "reference",
+            "_weak": true
+          },
+          {
+            "_key": "lesson-sfe-what-changes",
+            "_ref": "lesson-sfe-what-changes",
+            "_type": "reference",
+            "_weak": true
+          }
+        ],
+        "title": "Tokens and Composability"
+      }
+    ],
+    "slug": {
+      "_type": "slug",
+      "current": "solana-for-evm-devs"
+    },
+    "tags": [
+      "account-layout",
+      "account-model",
+      "compute-budget",
+      "pdas",
+      "priority-fees",
+      "program-security",
+      "rent-and-space",
+      "signers",
+      "solana-fundamentals",
+      "spl-tokens",
+      "transaction-fees",
+      "transactions",
+      "typescript"
+    ],
+    "title": "Solana for EVM Developers",
+    "trackId": 0,
+    "trackLevel": 0,
+    "xpPerLesson": 20,
+    "xpReward": 500
+  },
+  {
+    "_id": "course-solana-for-web-devs",
+    "_type": "course",
+    "creator": "B7o8NfV81HzjuZFWQTTx3Xdvh77Dqoajwib3kWEnvzJF",
+    "creatorRewardXp": 30,
+    "description": "You already write JavaScript or TypeScript. That is the whole prerequisite — no blockchain, no cryptography, no Rust, nothing installed. This course runs entirely in your browser against a real, frozen program on Solana's devnet. You start by reading its live vault account in an explorer, then decode its 49 raw bytes by hand — discriminator, owner, balance, bump — then reproduce its address from seeds, so an on-chain account stops being a mystery and becomes a byte layout you own. Then you sign: transaction anatomy with the exact fee arithmetic, a funded devnet wallet of your own, and a real deposit into the vault, confirmed on-chain with the signature to prove it. You finish by assembling everything into a working account inspector — paste any devnet address, get type, SOL, owner, rent-exemption, and decoded vault fields with every failure path handled. Everything is taught against `@solana/kit` 7.0.0, the current stack; one lesson maps it against the legacy web3.js v1 code you will still meet in the wild, with dates and download counts, so you can read old codebases without writing like them. Version stamp — kit 7.0.0, devnet, authored 2026-07-28.",
+    "difficulty": "beginner",
+    "duration": 6,
+    "minCompletionsForReward": 10,
+    "modules": [
+      {
+        "_key": "sfwd-read-the-chain",
+        "_type": "courseModule",
+        "description": "Point at a real devnet program and take its state apart. You read the live vault in an explorer without writing a line of code, then fetch the same account over RPC and decode its 49 bytes by hand — 8-byte discriminator, 32-byte owner, little-endian u64 balance, bump — and then reproduce the vault's address from its seeds and watch a wrong seed order produce a different address. You end holding a working `decodeVault` you wrote yourself, over bytes recorded from the real account. That decoder is the core of the inspector you ship in module 3, and the exact layout that becomes a Rust struct in Course 2.",
+        "key": "sfwd-read-the-chain",
+        "lessons": [
+          {
+            "_key": "lesson-sfwd-see-a-live-vault",
+            "_ref": "lesson-sfwd-see-a-live-vault",
+            "_type": "reference",
+            "_weak": true
+          },
+          {
+            "_key": "lesson-sfwd-accounts-are-just-bytes",
+            "_ref": "lesson-sfwd-accounts-are-just-bytes",
+            "_type": "reference",
+            "_weak": true
+          },
+          {
+            "_key": "lesson-sfwd-derive-the-vault-pda",
+            "_ref": "lesson-sfwd-derive-the-vault-pda",
+            "_type": "reference",
+            "_weak": true
+          }
+        ],
+        "title": "Read the Chain"
+      },
+      {
+        "_key": "sfwd-sign-your-own-transaction",
+        "_type": "courseModule",
+        "description": "Stop reading and start writing. You take a complete Kit transaction apart and predict its exact cost before it runs — 5,000 lamports per signature plus price times the REQUESTED compute-unit limit — then map the current stack against the legacy web3.js v1 code that still floods npm and every old codebase, so you can read the wild without importing it. Then the real thing: connect a wallet through Wallet Standard, fund it on devnet, and sign a deposit into the very vault you spent module 1 decoding — accounts in IDL order, discriminator plus little-endian amount, confirmed on-chain with an explorer signature on your profile.",
+        "key": "sfwd-sign-your-own-transaction",
+        "lessons": [
+          {
+            "_key": "lesson-sfwd-anatomy-of-a-transaction",
+            "_ref": "lesson-sfwd-anatomy-of-a-transaction",
+            "_type": "reference",
+            "_weak": true
+          },
+          {
+            "_key": "lesson-sfwd-kit-or-legacy",
+            "_ref": "lesson-sfwd-kit-or-legacy",
+            "_type": "reference",
+            "_weak": true
+          },
+          {
+            "_key": "lesson-sfwd-connect-fund-and-send",
+            "_ref": "lesson-sfwd-connect-fund-and-send",
+            "_type": "reference",
+            "_weak": true
+          }
+        ],
+        "title": "Sign Your Own Transaction"
+      },
+      {
+        "_key": "sfwd-publish-the-inspector",
+        "_type": "courseModule",
+        "description": "Assemble RPC read, byte decode, and PDA derivation into one working inspector: give it any devnet address and it answers — account type, SOL, owner, rent-exemption, and decoded vault fields when the owner and discriminator check out. The grade lives in the failure paths: accounts that do not exist, accounts with no data, accounts that only look like vaults. Two graded rungs — first complete the branch table, then write the decode path unaided against fixtures recorded from real devnet accounts. Close by naming every artifact you built and exactly which one Course 2 picks up.",
+        "key": "sfwd-publish-the-inspector",
+        "lessons": [
+          {
+            "_key": "lesson-sfwd-ship-the-inspector",
+            "_ref": "lesson-sfwd-ship-the-inspector",
+            "_type": "reference",
+            "_weak": true
+          },
+          {
+            "_key": "lesson-sfwd-what-you-built",
+            "_ref": "lesson-sfwd-what-you-built",
+            "_type": "reference",
+            "_weak": true
+          }
+        ],
+        "title": "Publish the Inspector"
+      }
+    ],
+    "slug": {
+      "_type": "slug",
+      "current": "solana-for-web-devs"
+    },
+    "tags": [
+      "account-model",
+      "api-currency",
+      "borsh-serialization",
+      "compute-budget",
+      "confirmation",
+      "error-handling",
+      "explorer-reading",
+      "pdas",
+      "rpc",
+      "solana-kit",
+      "transaction-fees",
+      "transactions",
+      "wallet-standard"
+    ],
+    "title": "Solana for Web Devs",
+    "trackId": 1,
+    "trackLevel": 1,
+    "xpPerLesson": 10,
+    "xpReward": 500
+  },
+  {
     "_id": "course-stablecoin-payments",
     "_type": "course",
     "creator": "B7o8NfV81HzjuZFWQTTx3Xdvh77Dqoajwib3kWEnvzJF",

--- a/apps/web/src/content/generated/lessons.json
+++ b/apps/web/src/content/generated/lessons.json
@@ -2604,8 +2604,8 @@
           "Subgoal 4: leave `computeUnitLimitSet: false`. The overpay is deliberate — the next lesson measures and fixes it."
         ],
         "language": "typescript",
-        "solution": "/**\n * Assemble the deposit transaction message by hand, in four subgoals.\n */\nfunction assembleDeposit(\n  owner: string,\n  amountLamports: bigint,\n  blockhash: string\n): {\n  feePayer: string;\n  lifetimeBlockhash: string;\n  instructions: { programAddress: string; accounts: { address: string; role: string }[]; data: { amountLamports: bigint } }[];\n  computeUnitLimitSet: boolean;\n} {\n  // Subgoal 1 — set the fee payer to the owner (done for you).\n  const feePayer = owner;\n\n  // Subgoal 2 — set the transaction lifetime to the given blockhash.\n  const lifetimeBlockhash = blockhash;\n\n  // Subgoal 3 — append the deposit instruction built from your wrapper.\n  const instructions = [buildDepositInstruction(owner, amountLamports)];\n\n  // Subgoal 4 — return the message; leave computeUnitLimitSet as false.\n  return {\n    feePayer,\n    lifetimeBlockhash,\n    instructions,\n    computeUnitLimitSet: false,\n  };\n}\n\n// --- your published wrapper's instruction builder — treat as given -------\nfunction buildDepositInstruction(\n  owner: string,\n  amountLamports: bigint\n): { programAddress: string; accounts: { address: string; role: string }[]; data: { amountLamports: bigint } } {\n  return {\n    programAddress: \"VauLtPr0gram1111111111111111111111111111111\",\n    accounts: [\n      { address: owner, role: \"writable-signer\" },\n      { address: \"Vau1t\" + owner.slice(0, 38).padEnd(38, \"1\"), role: \"writable\" },\n      { address: \"11111111111111111111111111111111\", role: \"readonly\" },\n    ],\n    data: { amountLamports },\n  };\n}\n",
-        "starter": "/**\n * Assemble the deposit transaction message by hand, in four subgoals.\n *\n * `buildDepositInstruction` below is your published wrapper's output — treat it\n * as given. Build the message with the owner as fee payer, the given blockhash\n * as its lifetime, and the deposit instruction appended. Do NOT set a compute\n * unit limit — that overpay is the next lesson's exercise.\n */\nfunction assembleDeposit(\n  owner: string,\n  amountLamports: bigint,\n  blockhash: string\n): {\n  feePayer: string;\n  lifetimeBlockhash: string;\n  instructions: { programAddress: string; accounts: { address: string; role: string }[]; data: { amountLamports: bigint } }[];\n  computeUnitLimitSet: boolean;\n} {\n  // Subgoal 1 — set the fee payer to the owner (done for you).\n  const feePayer = owner;\n\n  // Subgoal 2 — set the transaction lifetime to the given blockhash.\n  // const lifetimeBlockhash = ...\n\n  // Subgoal 3 — append the deposit instruction built from your wrapper.\n  // const instructions = [ buildDepositInstruction(owner, amountLamports) ];\n\n  // Subgoal 4 — return the message; leave computeUnitLimitSet as false.\n  return {\n    feePayer,\n    lifetimeBlockhash: \"\",\n    instructions: [],\n    computeUnitLimitSet: false,\n  };\n}\n\n// --- your published wrapper's instruction builder — treat as given -------\nfunction buildDepositInstruction(\n  owner: string,\n  amountLamports: bigint\n): { programAddress: string; accounts: { address: string; role: string }[]; data: { amountLamports: bigint } } {\n  return {\n    programAddress: \"VauLtPr0gram1111111111111111111111111111111\",\n    accounts: [\n      { address: owner, role: \"writable-signer\" },\n      { address: \"Vau1t\" + owner.slice(0, 38).padEnd(38, \"1\"), role: \"writable\" },\n      { address: \"11111111111111111111111111111111\", role: \"readonly\" },\n    ],\n    data: { amountLamports },\n  };\n}\n",
+        "solution": "/**\n * Assemble the deposit transaction message by hand, in four subgoals.\n */\nfunction assembleDeposit(\n  owner: string,\n  amountLamports: bigint,\n  blockhash: string\n): {\n  feePayer: string;\n  lifetimeBlockhash: string;\n  instructions: { programAddress: string; accounts: { address: string; role: string }[]; data: { amountLamports: bigint } }[];\n  computeUnitLimitSet: boolean;\n} {\n  // Subgoal 1 — set the fee payer to the owner (done for you).\n  const feePayer = owner;\n\n  // Subgoal 2 — set the transaction lifetime to the given blockhash.\n  const lifetimeBlockhash = blockhash;\n\n  // Subgoal 3 — append the deposit instruction built from your wrapper.\n  const instructions = [buildDepositInstruction(owner, amountLamports)];\n\n  // Subgoal 4 — return the message; leave computeUnitLimitSet as false.\n  return {\n    feePayer,\n    lifetimeBlockhash,\n    instructions,\n    computeUnitLimitSet: false,\n  };\n}\n\n// --- your published wrapper's instruction builder — treat as given -------\nfunction buildDepositInstruction(\n  user: string,\n  amountLamports: bigint\n): { programAddress: string; accounts: { address: string; role: string }[]; data: { amountLamports: bigint } } {\n  return {\n    programAddress: \"VauLtPr0gram1111111111111111111111111111111\",\n    accounts: [\n      { address: \"Vau1t\" + user.slice(0, 38).padEnd(38, \"1\"), role: \"writable\" },\n      { address: user, role: \"writable-signer\" },\n      { address: \"11111111111111111111111111111111\", role: \"readonly\" },\n    ],\n    data: { amountLamports },\n  };\n}\n",
+        "starter": "/**\n * Assemble the deposit transaction message by hand, in four subgoals.\n *\n * `buildDepositInstruction` below is your published wrapper's output — treat it\n * as given. Build the message with the owner as fee payer, the given blockhash\n * as its lifetime, and the deposit instruction appended. Do NOT set a compute\n * unit limit — that overpay is the next lesson's exercise.\n */\nfunction assembleDeposit(\n  owner: string,\n  amountLamports: bigint,\n  blockhash: string\n): {\n  feePayer: string;\n  lifetimeBlockhash: string;\n  instructions: { programAddress: string; accounts: { address: string; role: string }[]; data: { amountLamports: bigint } }[];\n  computeUnitLimitSet: boolean;\n} {\n  // Subgoal 1 — set the fee payer to the owner (done for you).\n  const feePayer = owner;\n\n  // Subgoal 2 — set the transaction lifetime to the given blockhash.\n  // const lifetimeBlockhash = ...\n\n  // Subgoal 3 — append the deposit instruction built from your wrapper.\n  // const instructions = [ buildDepositInstruction(owner, amountLamports) ];\n\n  // Subgoal 4 — return the message; leave computeUnitLimitSet as false.\n  return {\n    feePayer,\n    lifetimeBlockhash: \"\",\n    instructions: [],\n    computeUnitLimitSet: false,\n  };\n}\n\n// --- your published wrapper's instruction builder — treat as given -------\nfunction buildDepositInstruction(\n  user: string,\n  amountLamports: bigint\n): { programAddress: string; accounts: { address: string; role: string }[]; data: { amountLamports: bigint } } {\n  return {\n    programAddress: \"VauLtPr0gram1111111111111111111111111111111\",\n    accounts: [\n      { address: \"Vau1t\" + user.slice(0, 38).padEnd(38, \"1\"), role: \"writable\" },\n      { address: user, role: \"writable-signer\" },\n      { address: \"11111111111111111111111111111111\", role: \"readonly\" },\n    ],\n    data: { amountLamports },\n  };\n}\n",
         "tests": [
           {
             "description": "Subgoal 1: the fee payer is the owner",
@@ -2620,8 +2620,8 @@
             "input": "'0wnerWa11etAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA', 1000000n, 'B1ockhash1111111111111111111111111111111111'"
           },
           {
-            "description": "Subgoal 3: exactly one instruction, the deposit, with the owner signing",
-            "expectedOutput": "result.instructions.length === 1 && result.instructions[0].accounts[0].address === '0wnerWa11etAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'",
+            "description": "Subgoal 3: exactly one instruction, the deposit, with the user signing",
+            "expectedOutput": "result.instructions.length === 1 && result.instructions[0].accounts[1].address === '0wnerWa11etAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'",
             "id": "t3",
             "input": "'0wnerWa11etAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA', 1000000n, 'B1ockhash1111111111111111111111111111111111'"
           },
@@ -2709,8 +2709,8 @@
       {
         "_key": "milestone",
         "_type": "openEnded",
-        "maxWords": 60,
-        "prompt": "Deploy the app and paste its public URL (e.g. https://your-vault-app.vercel.app). Confirm you sent one real devnet deposit from it. Self-reported — record the URL; module 3 keeps shipping to it."
+        "maxWords": 120,
+        "prompt": "Deploy the app and paste its public URL (e.g. https://your-vault-app.vercel.app). Confirm you sent one real devnet deposit from it. Self-reported — record the URL; module 3 keeps shipping to it. Then, in a sentence or two: which part of that deposit did your installed package do, and which part could only the wallet do — why does that split exist?"
       }
     ],
     "skills": [
@@ -2746,8 +2746,8 @@
           "Once it passes, read the returned object. Notice the account order and roles; the IDL fixes both, and the generated builder never lets you shuffle them."
         ],
         "language": "typescript",
-        "solution": "/**\n * WORKED EXAMPLE — a hand-written stand-in for one Codama-generated builder.\n *\n * This is what `getDepositInstruction(...)` assembles for you from the IDL:\n * a program address, an ORDERED account list where each entry carries a role,\n * and a data payload holding the 8-byte instruction discriminator plus the\n * argument. Run it, read the returned object, and try changing the amount.\n *\n * Note the Kit conventions the real generated code uses:\n *   - addresses are strings (Kit `Address`), never `PublicKey` objects\n *   - the amount is a `bigint`, never a `number`\n *   - the account order is fixed by the IDL and must not be shuffled\n */\nfunction buildDepositInstruction(\n  programAddress: string,\n  vaultPda: string,\n  owner: string,\n  amountLamports: bigint\n): {\n  programAddress: string;\n  accounts: { address: string; role: string }[];\n  data: { discriminator: number[]; amountLamports: bigint };\n} {\n  // The System Program — deposit moves lamports through a System CPI, so it\n  // must be present and read-only.\n  const SYSTEM_PROGRAM = \"11111111111111111111111111111111\";\n\n  // The first 8 bytes Anchor writes to identify the `deposit` instruction.\n  // The generated client carries this so you never hand-write it.\n  const DEPOSIT_DISCRIMINATOR = [242, 35, 198, 137, 82, 225, 242, 182];\n\n  return {\n    programAddress,\n    accounts: [\n      { address: owner, role: \"writable-signer\" }, // pays the lamports, signs\n      { address: vaultPda, role: \"writable\" }, // receives them\n      { address: SYSTEM_PROGRAM, role: \"readonly\" }, // the CPI target\n    ],\n    data: {\n      discriminator: DEPOSIT_DISCRIMINATOR,\n      amountLamports,\n    },\n  };\n}\n",
-        "starter": "/**\n * WORKED EXAMPLE — a hand-written stand-in for one Codama-generated builder.\n *\n * This is what `getDepositInstruction(...)` assembles for you from the IDL:\n * a program address, an ORDERED account list where each entry carries a role,\n * and a data payload holding the 8-byte instruction discriminator plus the\n * argument.\n *\n * It is complete except for ONE value: the data payload hardcodes `0n` instead\n * of passing the amount through. Wire the `amountLamports` parameter into the\n * payload, then run it and read the returned object.\n *\n * Note the Kit conventions the real generated code uses:\n *   - addresses are strings (Kit `Address`), never `PublicKey` objects\n *   - the amount is a `bigint`, never a `number`\n *   - the account order is fixed by the IDL and must not be shuffled\n */\nfunction buildDepositInstruction(\n  programAddress: string,\n  vaultPda: string,\n  owner: string,\n  amountLamports: bigint\n): {\n  programAddress: string;\n  accounts: { address: string; role: string }[];\n  data: { discriminator: number[]; amountLamports: bigint };\n} {\n  // The System Program — deposit moves lamports through a System CPI, so it\n  // must be present and read-only.\n  const SYSTEM_PROGRAM = \"11111111111111111111111111111111\";\n\n  // The first 8 bytes Anchor writes to identify the `deposit` instruction.\n  // The generated client carries this so you never hand-write it.\n  const DEPOSIT_DISCRIMINATOR = [242, 35, 198, 137, 82, 225, 242, 182];\n\n  return {\n    programAddress,\n    accounts: [\n      { address: owner, role: \"writable-signer\" }, // pays the lamports, signs\n      { address: vaultPda, role: \"writable\" }, // receives them\n      { address: SYSTEM_PROGRAM, role: \"readonly\" }, // the CPI target\n    ],\n    data: {\n      discriminator: DEPOSIT_DISCRIMINATOR,\n      amountLamports: 0n, // TODO: pass `amountLamports` through instead of 0n\n    },\n  };\n}\n",
+        "solution": "/**\n * WORKED EXAMPLE — a hand-written stand-in for one Codama-generated builder.\n *\n * This is what `getDepositInstruction(...)` assembles for you from the IDL:\n * a program address, an ORDERED account list where each entry carries a role,\n * and a data payload holding the 8-byte instruction discriminator plus the\n * argument. Run it, read the returned object, and try changing the amount.\n *\n * Note the Kit conventions the real generated code uses:\n *   - addresses are strings (Kit `Address`), never `PublicKey` objects\n *   - the amount is a `bigint`, never a `number`\n *   - the account order is fixed by the IDL and must not be shuffled\n */\nfunction buildDepositInstruction(\n  programAddress: string,\n  vaultPda: string,\n  user: string,\n  amountLamports: bigint\n): {\n  programAddress: string;\n  accounts: { address: string; role: string }[];\n  data: { discriminator: number[]; amountLamports: bigint };\n} {\n  // The System Program — deposit moves lamports through a System CPI, so it\n  // must be present and read-only.\n  const SYSTEM_PROGRAM = \"11111111111111111111111111111111\";\n\n  // The first 8 bytes Anchor writes to identify the `deposit` instruction.\n  // The generated client carries this so you never hand-write it.\n  const DEPOSIT_DISCRIMINATOR = [242, 35, 198, 137, 82, 225, 242, 182];\n\n  return {\n    programAddress,\n    accounts: [\n      { address: vaultPda, role: \"writable\" }, // the vault — receives the lamports\n      { address: user, role: \"writable-signer\" }, // the user — pays the lamports, signs\n      { address: SYSTEM_PROGRAM, role: \"readonly\" }, // the CPI target\n    ],\n    data: {\n      discriminator: DEPOSIT_DISCRIMINATOR,\n      amountLamports,\n    },\n  };\n}\n",
+        "starter": "/**\n * WORKED EXAMPLE — a hand-written stand-in for one Codama-generated builder.\n *\n * This is what `getDepositInstruction(...)` assembles for you from the IDL:\n * a program address, an ORDERED account list where each entry carries a role,\n * and a data payload holding the 8-byte instruction discriminator plus the\n * argument.\n *\n * It is complete except for ONE value: the data payload hardcodes `0n` instead\n * of passing the amount through. Wire the `amountLamports` parameter into the\n * payload, then run it and read the returned object.\n *\n * Note the Kit conventions the real generated code uses:\n *   - addresses are strings (Kit `Address`), never `PublicKey` objects\n *   - the amount is a `bigint`, never a `number`\n *   - the account order is fixed by the IDL and must not be shuffled\n */\nfunction buildDepositInstruction(\n  programAddress: string,\n  vaultPda: string,\n  user: string,\n  amountLamports: bigint\n): {\n  programAddress: string;\n  accounts: { address: string; role: string }[];\n  data: { discriminator: number[]; amountLamports: bigint };\n} {\n  // The System Program — deposit moves lamports through a System CPI, so it\n  // must be present and read-only.\n  const SYSTEM_PROGRAM = \"11111111111111111111111111111111\";\n\n  // The first 8 bytes Anchor writes to identify the `deposit` instruction.\n  // The generated client carries this so you never hand-write it.\n  const DEPOSIT_DISCRIMINATOR = [242, 35, 198, 137, 82, 225, 242, 182];\n\n  return {\n    programAddress,\n    accounts: [\n      { address: vaultPda, role: \"writable\" }, // the vault — receives the lamports\n      { address: user, role: \"writable-signer\" }, // the user — pays the lamports, signs\n      { address: SYSTEM_PROGRAM, role: \"readonly\" }, // the CPI target\n    ],\n    data: {\n      discriminator: DEPOSIT_DISCRIMINATOR,\n      amountLamports: 0n, // TODO: pass `amountLamports` through instead of 0n\n    },\n  };\n}\n",
         "tests": [
           {
             "description": "The builder returns the program address it was given",
@@ -2762,14 +2762,14 @@
             "input": "'VauLtPr0gram1111111111111111111111111111111', 'Vau1tPDA1111111111111111111111111111111111', '0wnerWa11et11111111111111111111111111111111', 1000000n"
           },
           {
-            "description": "The account order is owner, vault, system program",
-            "expectedOutput": "result.accounts[0].address === '0wnerWa11et11111111111111111111111111111111' && result.accounts[1].address === 'Vau1tPDA1111111111111111111111111111111111'",
+            "description": "The account order is vault, user, system program",
+            "expectedOutput": "result.accounts[0].address === 'Vau1tPDA1111111111111111111111111111111111' && result.accounts[1].address === '0wnerWa11et11111111111111111111111111111111'",
             "id": "t3",
             "input": "'VauLtPr0gram1111111111111111111111111111111', 'Vau1tPDA1111111111111111111111111111111111', '0wnerWa11et11111111111111111111111111111111', 1000000n"
           },
           {
-            "description": "The signer is the owner, and the vault is writable but not a signer",
-            "expectedOutput": "result.accounts[0].role === 'writable-signer' && result.accounts[1].role === 'writable'",
+            "description": "The vault is writable but not a signer, and the user signs",
+            "expectedOutput": "result.accounts[0].role === 'writable' && result.accounts[1].role === 'writable-signer'",
             "id": "t4",
             "input": "'VauLtPr0gram1111111111111111111111111111111', 'Vau1tPDA1111111111111111111111111111111111', '0wnerWa11et11111111111111111111111111111111', 1000000n"
           },
@@ -3299,8 +3299,8 @@
       {
         "_key": "milestone",
         "_type": "openEnded",
-        "maxWords": 60,
-        "prompt": "Publish the client and paste the public npm URL of your package (e.g. https://www.npmjs.com/package/@your-scope/vault-client). This is self-reported — record the URL you will install from in the next module."
+        "maxWords": 120,
+        "prompt": "Publish the client and paste the public npm URL of your package (e.g. https://www.npmjs.com/package/@your-scope/vault-client). This is self-reported — record the URL you will install from in the next module. Then, in a sentence or two: what does a consumer installing your package get that copying your app's source would not give them, and what does your semver policy promise them on the next publish?"
       }
     ],
     "skills": [
@@ -3875,8 +3875,8 @@
       {
         "_key": "milestone",
         "_type": "openEnded",
-        "maxWords": 60,
-        "prompt": "Ship the finished app and paste its public URL. Confirm deposit, withdraw, live vault state, a sized compute budget and a network-priced fee all work. Self-reported — this is one of the two artifacts you name in the recap."
+        "maxWords": 120,
+        "prompt": "Ship the finished app and paste its public URL. Confirm deposit, withdraw, live vault state, a sized compute budget and a network-priced fee all work. Self-reported — this is one of the two artifacts you name in the recap. Then, in a sentence or two: why does the app size its compute budget from a simulation instead of a hardcoded constant — what goes wrong with the constant?"
       }
     ],
     "skills": [
@@ -4142,13 +4142,13 @@
         "buildType": "standard",
         "deployable": false,
         "hints": [
-          "Subgoal 3: call the generated builder — `getDepositInstruction({ owner, vaultPda, amountLamports })` — and keep its result in a variable.",
+          "Subgoal 3: call the generated builder — `getDepositInstruction({ user: owner, vaultPda, amountLamports })` — and keep its result in a variable.",
           "Subgoal 4: return `{ ok: true, vaultPda, instruction }`. Reuse the `vaultPda` subgoal 1 already derived; do not derive it again.",
           "Do not touch `deriveVaultPda` or `getDepositInstruction` — they stand in for generated code that codegen overwrites. Compose them; never edit them."
         ],
         "language": "typescript",
-        "solution": "/**\n * The ergonomic wrapper around the generated client.\n *\n * `deriveVaultPda` and `getDepositInstruction` below are the GENERATED surface —\n * treat them as read-only (in a real package they live in `src/generated`, which\n * codegen overwrites). Your job is the wrapper `deposit`, in four subgoals.\n */\nfunction deposit(\n  owner: string,\n  amountLamports: bigint\n): {\n  ok: boolean;\n  vaultPda: string;\n  instruction: {\n    programAddress: string;\n    accounts: { address: string; role: string }[];\n    data: { discriminator: number[]; amountLamports: bigint };\n  } | null;\n} {\n  // Subgoal 1 — derive the vault PDA from the owner (done for you).\n  const vaultPda = deriveVaultPda(owner);\n\n  // Subgoal 2 — narrow the input: a deposit must be a positive bigint (done for you).\n  if (typeof amountLamports !== \"bigint\" || amountLamports <= 0n) {\n    return { ok: false, vaultPda, instruction: null };\n  }\n\n  // Subgoal 3 — build the instruction from the generated builder.\n  const instruction = getDepositInstruction({ owner, vaultPda, amountLamports });\n\n  // Subgoal 4 — return the ergonomic shape: { ok: true, vaultPda, instruction }.\n  return { ok: true, vaultPda, instruction };\n}\n\n// --- generated surface — do not edit -------------------------------------\nfunction deriveVaultPda(owner: string): string {\n  // Stands in for the generated `findVaultPda`. Deterministic in the owner:\n  // the same owner always yields the same vault address, a different owner a\n  // different one.\n  return \"Vau1t\" + owner.slice(0, 38).padEnd(38, \"1\");\n}\n\nfunction getDepositInstruction(args: {\n  owner: string;\n  vaultPda: string;\n  amountLamports: bigint;\n}): {\n  programAddress: string;\n  accounts: { address: string; role: string }[];\n  data: { discriminator: number[]; amountLamports: bigint };\n} {\n  return {\n    programAddress: \"VauLtPr0gram1111111111111111111111111111111\",\n    accounts: [\n      { address: args.owner, role: \"writable-signer\" },\n      { address: args.vaultPda, role: \"writable\" },\n      { address: \"11111111111111111111111111111111\", role: \"readonly\" },\n    ],\n    data: { discriminator: [242, 35, 198, 137, 82, 225, 242, 182], amountLamports: args.amountLamports },\n  };\n}\n",
-        "starter": "/**\n * The ergonomic wrapper around the generated client.\n *\n * `deriveVaultPda` and `getDepositInstruction` below are the GENERATED surface —\n * treat them as read-only (in a real package they live in `src/generated`, which\n * codegen overwrites). Your job is the wrapper `deposit`, in four subgoals.\n */\nfunction deposit(\n  owner: string,\n  amountLamports: bigint\n): {\n  ok: boolean;\n  vaultPda: string;\n  instruction: {\n    programAddress: string;\n    accounts: { address: string; role: string }[];\n    data: { discriminator: number[]; amountLamports: bigint };\n  } | null;\n} {\n  // Subgoal 1 — derive the vault PDA from the owner (done for you).\n  const vaultPda = deriveVaultPda(owner);\n\n  // Subgoal 2 — narrow the input: a deposit must be a positive bigint (done for you).\n  if (typeof amountLamports !== \"bigint\" || amountLamports <= 0n) {\n    return { ok: false, vaultPda, instruction: null };\n  }\n\n  // Subgoal 3 — build the instruction from the generated builder.\n  //   Call getDepositInstruction({ owner, vaultPda, amountLamports }).\n  // const instruction = ...\n\n  // Subgoal 4 — return the ergonomic shape: { ok: true, vaultPda, instruction }.\n  //   The caller should never see a discriminator or a seed.\n  return { ok: false, vaultPda, instruction: null }; // replace this line\n}\n\n// --- generated surface — do not edit -------------------------------------\nfunction deriveVaultPda(owner: string): string {\n  // Stands in for the generated `findVaultPda`. Deterministic in the owner:\n  // the same owner always yields the same vault address, a different owner a\n  // different one.\n  return \"Vau1t\" + owner.slice(0, 38).padEnd(38, \"1\");\n}\n\nfunction getDepositInstruction(args: {\n  owner: string;\n  vaultPda: string;\n  amountLamports: bigint;\n}): {\n  programAddress: string;\n  accounts: { address: string; role: string }[];\n  data: { discriminator: number[]; amountLamports: bigint };\n} {\n  return {\n    programAddress: \"VauLtPr0gram1111111111111111111111111111111\",\n    accounts: [\n      { address: args.owner, role: \"writable-signer\" },\n      { address: args.vaultPda, role: \"writable\" },\n      { address: \"11111111111111111111111111111111\", role: \"readonly\" },\n    ],\n    data: { discriminator: [242, 35, 198, 137, 82, 225, 242, 182], amountLamports: args.amountLamports },\n  };\n}\n",
+        "solution": "/**\n * The ergonomic wrapper around the generated client.\n *\n * `deriveVaultPda` and `getDepositInstruction` below are the GENERATED surface —\n * treat them as read-only (in a real package they live in `src/generated`, which\n * codegen overwrites). Your job is the wrapper `deposit`, in four subgoals.\n */\nfunction deposit(\n  owner: string,\n  amountLamports: bigint\n): {\n  ok: boolean;\n  vaultPda: string;\n  instruction: {\n    programAddress: string;\n    accounts: { address: string; role: string }[];\n    data: { discriminator: number[]; amountLamports: bigint };\n  } | null;\n} {\n  // Subgoal 1 — derive the vault PDA from the owner (done for you).\n  const vaultPda = deriveVaultPda(owner);\n\n  // Subgoal 2 — narrow the input: a deposit must be a positive bigint (done for you).\n  if (typeof amountLamports !== \"bigint\" || amountLamports <= 0n) {\n    return { ok: false, vaultPda, instruction: null };\n  }\n\n  // Subgoal 3 — build the instruction from the generated builder.\n  const instruction = getDepositInstruction({ user: owner, vaultPda, amountLamports });\n\n  // Subgoal 4 — return the ergonomic shape: { ok: true, vaultPda, instruction }.\n  return { ok: true, vaultPda, instruction };\n}\n\n// --- generated surface — do not edit -------------------------------------\nfunction deriveVaultPda(owner: string): string {\n  // Stands in for the generated `findVaultPda`. Deterministic in the owner:\n  // the same owner always yields the same vault address, a different owner a\n  // different one.\n  return \"Vau1t\" + owner.slice(0, 38).padEnd(38, \"1\");\n}\n\nfunction getDepositInstruction(args: {\n  user: string;\n  vaultPda: string;\n  amountLamports: bigint;\n}): {\n  programAddress: string;\n  accounts: { address: string; role: string }[];\n  data: { discriminator: number[]; amountLamports: bigint };\n} {\n  return {\n    programAddress: \"VauLtPr0gram1111111111111111111111111111111\",\n    accounts: [\n      { address: args.vaultPda, role: \"writable\" },\n      { address: args.user, role: \"writable-signer\" },\n      { address: \"11111111111111111111111111111111\", role: \"readonly\" },\n    ],\n    data: { discriminator: [242, 35, 198, 137, 82, 225, 242, 182], amountLamports: args.amountLamports },\n  };\n}\n",
+        "starter": "/**\n * The ergonomic wrapper around the generated client.\n *\n * `deriveVaultPda` and `getDepositInstruction` below are the GENERATED surface —\n * treat them as read-only (in a real package they live in `src/generated`, which\n * codegen overwrites). Your job is the wrapper `deposit`, in four subgoals.\n */\nfunction deposit(\n  owner: string,\n  amountLamports: bigint\n): {\n  ok: boolean;\n  vaultPda: string;\n  instruction: {\n    programAddress: string;\n    accounts: { address: string; role: string }[];\n    data: { discriminator: number[]; amountLamports: bigint };\n  } | null;\n} {\n  // Subgoal 1 — derive the vault PDA from the owner (done for you).\n  const vaultPda = deriveVaultPda(owner);\n\n  // Subgoal 2 — narrow the input: a deposit must be a positive bigint (done for you).\n  if (typeof amountLamports !== \"bigint\" || amountLamports <= 0n) {\n    return { ok: false, vaultPda, instruction: null };\n  }\n\n  // Subgoal 3 — build the instruction from the generated builder.\n  //   Call getDepositInstruction({ user: owner, vaultPda, amountLamports }).\n  // const instruction = ...\n\n  // Subgoal 4 — return the ergonomic shape: { ok: true, vaultPda, instruction }.\n  //   The caller should never see a discriminator or a seed.\n  return { ok: false, vaultPda, instruction: null }; // replace this line\n}\n\n// --- generated surface — do not edit -------------------------------------\nfunction deriveVaultPda(owner: string): string {\n  // Stands in for the generated `findVaultPda`. Deterministic in the owner:\n  // the same owner always yields the same vault address, a different owner a\n  // different one.\n  return \"Vau1t\" + owner.slice(0, 38).padEnd(38, \"1\");\n}\n\nfunction getDepositInstruction(args: {\n  user: string;\n  vaultPda: string;\n  amountLamports: bigint;\n}): {\n  programAddress: string;\n  accounts: { address: string; role: string }[];\n  data: { discriminator: number[]; amountLamports: bigint };\n} {\n  return {\n    programAddress: \"VauLtPr0gram1111111111111111111111111111111\",\n    accounts: [\n      { address: args.vaultPda, role: \"writable\" },\n      { address: args.user, role: \"writable-signer\" },\n      { address: \"11111111111111111111111111111111\", role: \"readonly\" },\n    ],\n    data: { discriminator: [242, 35, 198, 137, 82, 225, 242, 182], amountLamports: args.amountLamports },\n  };\n}\n",
         "tests": [
           {
             "description": "Subgoal 3+4: a valid deposit returns ok with an instruction",
@@ -4175,8 +4175,8 @@
             "input": "'0wnerWa11etAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA', 0n"
           },
           {
-            "description": "Subgoal 4: the returned instruction is well-formed — owner signs, vault is the derived PDA",
-            "expectedOutput": "result.instruction.accounts[0].role === 'writable-signer' && result.instruction.accounts[1].address === result.vaultPda",
+            "description": "Subgoal 4: the returned instruction is well-formed — the vault is the derived PDA, the user signs",
+            "expectedOutput": "result.instruction.accounts[0].address === result.vaultPda && result.instruction.accounts[1].role === 'writable-signer'",
             "id": "t5",
             "input": "'0wnerWa11etAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA', 2500000n"
           }
@@ -8031,10 +8031,10 @@
         "src": "# Submit It — and What You Built\n\nOne artifact. Five courses. Name every layer of it.\n\n## The through-line\n\nNothing you built restarted. Each course added a layer to the same object.\n\n**Course 1 — you signed something.** Your own transaction, built and sent from your own key, confirmed on devnet, and an account inspector that reads state back off the chain rather than off a screenshot. The first time the chain answered you specifically.\n\n**Course 2 — the vault got a core.** Rust that models the vault's state and its rules, compiled green against the real toolchain on the build server. No local install, no version roulette.\n\n**Course 3 — your program went live.** Deposit and withdraw, hardened, deployed to devnet. You own a program id, and a credential NFT that says you do.\n\n**Course 4 — it became something other people can use.** A typed client generated from your own IDL, wrapped in an API you would actually import, published to npm with a semver policy you wrote down — and a deployed app at a public URL that installs that package from the registry and signs a real deposit through it.\n\n**Course 5 — it started earning.** A Subscription Authority and a Recurring Delegation gave the app a paid tier that charges once per period and correctly refuses to charge twice. An x402 route returns a real 402 challenge naming the network, the asset and the payTo address. An agent calls that route on a loop, pays for each call out of a Fixed Delegation, and halts cleanly when the allowance says no.\n\nSay the sentence out loud, because it is true and you will need it in a proposal:\n\n> You started as a web2 JavaScript developer, and you now own a monetized on-chain product.\n\nIf you entered here — at C5 lesson 1, on the reference app, because you wanted payments and not Anchor — the same sentence applies to the payments layer you built. The credential still requires your own artifact, not the reference one.\n\n## What is in scope, and what is not\n\nThe rails you learned are the ones open to you. From 2026-10-01, BCB Resolution 561 forbids a regulated eFX provider from taking reais, converting to a stablecoin, and settling the obligation abroad on-chain. That is a live constraint on a business model, not on you personally: individuals may still buy, sell, hold and transfer through authorized VASPs.\n\nWhat this course built sits entirely inside what the resolution leaves open: **domestic merchant acceptance, contractor payouts, subscriptions, and agent budgets.** Every one of those is a real product surface, and every one of them is something an Earn listing has asked for. When you write a proposal, name the use case in those terms — a reviewer in Brazil reads the difference immediately, and it is a signal that you understand the market and not just the SDK.\n\n## Pick a rail before you pick a package\n\nThe decision you now make without looking it up:\n\n- **Fixed delegation** — a capped total that never refills. An allowance. This is what an autonomous agent holds, because the on-chain cap is what makes the autonomy safe.\n- **Recurring delegation** — a cap that resets each period. Payroll, contractors, subscriptions. Skipped periods are lost.\n- **Subscription plan** — a merchant publishes terms and approved pullers collect against them.\n- **Solana Pay** — a human paying once, at a checkout. A decision, not an install: `@solana/pay@1.0.23` peer-depends on `@solana/kit ^6.9.0`, which does not admit the `@solana/kit@7.0.0` this course pins everywhere else.\n- **x402** — stateless per-request metering. No delegation, no relationship, one call.\n\nThat list is the most portable thing you learned. Packages will move; the shape of the requirement will not.\n\n## Submit one listing\n\nNow the part most people skip.\n\n**The calibration, honestly.** What this path realistically opens is **your first $500 to $5,000** of paid on-chain work. It is not a job offer, and anyone telling you a course makes you hireable as a Solana developer is selling something. The $5,000 frontend listing drew 731 submissions. The odds live somewhere else.\n\n**Where they live.** Two termini this course specifically unlocks:\n\n1. **Payments technical demos** — around $100 of reward per competitor, second only to Rust listings on that measure. You have a metered endpoint and a paid tier already running.\n2. **Educational modules** — $2,500–$3,000, typically closing near 10 submissions. Your deep dive from the last lesson is most of one.\n\n**How to read a listing, which is a skill in itself.** Competition is a function of **time-to-deadline**, not of category. The Zeroclaw listing sat at twelve submissions or fewer for most of its run and closed at 52 as the deadline approached. A submission count you read today tells you where that listing is in its life, not how contested it is. So: **never quote a single-day count as a competition rate.** Filter for **newly-opened development listings** and compare medians across listings that have actually closed.\n\n**Then submit.** One listing, this week, with a real artifact attached. Not a plan to submit. The bar is lower than it looks — most listings are decided among a handful of complete, reproducible submissions, and you now have the two things most submissions lack: something that runs, and a write-up that says which versions it ran against.\n\n## One more door\n\nTurbin3 runs cohort-based Solana builder programs, and its prerequisites are the kind of thing C1–C4 already satisfy: your own deployed program, a published client, a deployed app. If you want structure and a cohort after this, that is where to look. Bring the program id and the package URL.\n\nThat is the course. Submit the listing.\n"
       },
       {
-        "_key": "submit",
+        "_key": "reflect",
         "_type": "openEnded",
-        "maxWords": 200,
-        "prompt": "Paste the URL of the Superteam Earn listing you submitted to, and the URL of what you submitted. Then, in three lines: which rail the work uses (fixed delegation, recurring delegation, subscription plan, Solana Pay or x402), which Brazilian use case it serves, and the one thing in your submission a reviewer can run themselves."
+        "maxWords": 250,
+        "prompt": "Without re-reading the recap: pick the two rails you would be most likely to confuse in a proposal (fixed delegation, recurring delegation, subscription plan, Solana Pay, x402) and explain the difference in one sentence each, the way you would to a reviewer. Then name the one idea from this course that most changed how you would design a paid product for the Brazilian market, and say why. This is not graded and awards no XP — the Earn submission itself happens through the handoff after your credential, not in this box."
       },
       {
         "_key": "check",
@@ -9336,5 +9336,2594 @@
       "current": "write-the-deep-dive"
     },
     "title": "Publish the Deep Dive"
+  },
+  {
+    "_id": "lesson-sfe-approve-to-delegate",
+    "_type": "lesson",
+    "blocks": [
+      {
+        "_key": "intro",
+        "_type": "prose",
+        "src": "# `approve` becomes a delegate on the account itself\n\nThe ERC-20 allowance pattern is two transactions and a well-known footgun. You\n`approve(spender, amount)`, the spender later calls `transferFrom`, and the\nallowance sits in a nested mapping inside the token contract. Everyone has seen\nthe infinite-approval problem, and everyone has seen a wallet drained through a\nstale one.\n\nSPL Token keeps the idea and moves where it lives. A token account has two extra\nfields:\n\n```text\ndelegate         Option<Pubkey>   who may move tokens from this account\ndelegated_amount u64              how much they may still move\n```\n\nThe approval is not in a mapping keyed by `(owner, spender)`. It is **on the\ntoken account being spent from**.\n\n## What changes as a result\n\n**One delegate at a time.** Approving a second spender overwrites the first. In\nERC-20 you can hold approvals for a dozen contracts simultaneously; here the\nfield is singular. That is a real constraint, and it pushes protocols toward PDAs\nthat own accounts outright rather than accumulating standing approvals.\n\n**Revocation is a single instruction with no amount.** `revoke` clears the\ndelegate and zeroes the delegated amount. There is no \"approve to 0\" dance and no\nrace between reading and resetting an allowance — the ERC-20 front-running hazard\nthat produced `increaseAllowance` does not arise, because you are not comparing\nagainst a previous value.\n\n**Delegation is visible where the tokens are.** Reading a token account tells you\nwhether something can move its balance and how much. In ERC-20 you would have to\nknow which spender to ask about; here, one account read answers it.\n\n## The pattern that mostly replaces it\n\nMuch of what ERC-20 uses `approve` for, Solana does with ownership instead. A\nprotocol derives a PDA, that PDA owns a token account, and the user transfers into\nit. Now the protocol does not need standing permission over the user's wallet —\nit controls an account it already owns, and the user's own account has no\noutstanding delegate at all.\n\nWhether that is *safer* depends on the protocol. It is certainly narrower: the\nblast radius is whatever the user deposited, not whatever remains in their wallet\nunder an old infinite approval. When you port an EVM protocol, look for approvals\nfirst, and ask whether ownership transfer models the intent better.\n\n## Where they still coincide\n\nBoth models share the core hazard: an approval you forgot about is authority\nsomeone still holds. The Solana version limits it — one delegate, a decrementing\namount, one-instruction revocation — but it does not eliminate it. Auditing your\ndelegates is still worth doing, and now it is a field you can read rather than a\nmapping you have to guess at.\n"
+      },
+      {
+        "_key": "check",
+        "_type": "quiz",
+        "questions": [
+          {
+            "explanation": "One delegate per token account. Ported EVM designs that assume several simultaneous approvals need rethinking, usually toward a PDA that owns a dedicated account.",
+            "id": "q1",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "B replaces A entirely — the account holds one delegate, and A's authority is gone"
+              },
+              {
+                "correct": false,
+                "feedback": "`delegate` is a single optional field on the account, not a map. There is no room for a second entry.",
+                "id": "b",
+                "label": "Both delegations coexist, as two ERC-20 allowances would"
+              },
+              {
+                "correct": false,
+                "feedback": "Nothing rejects it. It silently overwrites — which is convenient for revocation and surprising if you expected ERC-20 accumulation.",
+                "id": "c",
+                "label": "The second approval fails while a delegation is outstanding"
+              }
+            ],
+            "prompt": "A user has delegated 100 tokens to protocol A. They now approve protocol B for 50 on the same token account. Predict."
+          },
+          {
+            "explanation": "The ERC-20 race comes from replacing a non-zero allowance with another non-zero value, giving the spender a window to use the old one. `revoke` is a distinct instruction that clears the field, so there is no window to exploit.",
+            "id": "q2",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "Revocation clears the delegate outright rather than writing a new amount to compare against"
+              },
+              {
+                "correct": false,
+                "feedback": "Atomicity applies within a transaction. It does not stop a *separate* transaction from landing first — the ordering hazard would still exist if the mechanism were compare-and-set.",
+                "id": "b",
+                "label": "Solana transactions are atomic, so no other transaction can interleave"
+              },
+              {
+                "correct": false,
+                "feedback": "They can be re-approved at any time. The point is that revocation is not expressed as \"set the amount to zero\".",
+                "id": "c",
+                "label": "Delegated amounts cannot be changed once set, only revoked"
+              }
+            ],
+            "prompt": "Why does the ERC-20 approval front-running race — the one that motivated `increaseAllowance` — not arise here?"
+          },
+          {
+            "explanation": "Ownership replaces standing permission. The protocol controls an account it owns and the user's wallet carries no outstanding delegate, so the exposure is the deposit rather than the remaining balance.",
+            "id": "q3",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "A PDA the protocol owns holds a token account the user deposits into"
+              },
+              {
+                "correct": false,
+                "feedback": "Mechanically possible and it reproduces exactly the blast radius you were trying to escape — the whole wallet balance, indefinitely.",
+                "id": "b",
+                "label": "Delegate the maximum `u64` to the protocol's authority and leave it in place"
+              },
+              {
+                "correct": false,
+                "feedback": "Workable but it adds a transaction to every action and still leaves a live delegation between them.",
+                "id": "c",
+                "label": "Re-approve before every interaction from the client"
+              }
+            ],
+            "prompt": "You port a protocol that relies on a standing infinite approval. What is the idiomatic Solana design?"
+          }
+        ]
+      }
+    ],
+    "skills": [
+      "spl-tokens",
+      "program-security"
+    ],
+    "slug": {
+      "_type": "slug",
+      "current": "approve-to-delegate"
+    },
+    "title": "From `approve` to Delegates"
+  },
+  {
+    "_id": "lesson-sfe-declared-accounts",
+    "_type": "lesson",
+    "blocks": [
+      {
+        "_key": "intro",
+        "_type": "prose",
+        "src": "# Declaring accounts up front is what buys parallelism\n\nAn Ethereum transaction says: call this address with this calldata. What storage\ngets touched is discovered while executing, so the EVM cannot know in advance\nwhether two transactions conflict. It executes them one at a time. That is the\nwhole reason the EVM is single-threaded.\n\nA Solana transaction says something stronger: here is every account I will touch,\nand whether I need to write to it.\n\nBecause that list is complete and declared before execution, the scheduler can\nlook at two transactions and decide immediately whether they overlap. Two\ntransactions writing to different accounts run **in parallel**. Two writing the\nsame account are serialized. This is Sealevel, and it is the direct payoff for\nthe thing that annoys you most when you start: having to pass every account\nexplicitly.\n\n## What this changes about your code\n\n**Instructions cannot discover state mid-flight.** In Solidity you can read one\nmapping, and based on the result, read another contract. On Solana, if the\naccount was not in the list, you cannot touch it — full stop. Dynamic access\npatterns must become explicit lists computed by the client before sending.\n\n**Contention is per-account, not global.** A popular NFT mint contends on that\nmint's accounts. It does not slow down a lending protocol that touches entirely\ndifferent accounts. There is no shared global queue for unrelated work.\n\n**Write locks are the scarce resource.** Declaring an account writable when you\nonly read it is a real cost: it blocks every other transaction that wants to\nwrite it, for no benefit. Mark reads as reads.\n\n## Reading a transaction\n\nBecause the account list is explicit, you can read any Solana transaction and\nanswer \"what does this touch?\" without executing it or having the source. An\nEthereum transaction hides that behind an opaque calldata blob and whatever the\ncontract chooses to do. This is why Solana wallets can show you a meaningful\nsimulation, and it is a genuine security property, not just tooling polish.\n\n## The tradeoff, stated honestly\n\nYou are trading ergonomics for throughput. Building a transaction means knowing\nyour accounts in advance, which means deriving PDAs client-side (lesson 3) and\nsometimes making an extra RPC call to discover what to include. Anchor's IDL and\nits generated clients hide much of it, but the constraint is real and it is the\nfirst thing EVM developers describe as friction.\n\nIt buys you a chain where unrelated work does not queue behind unrelated work.\nWhether that is a good trade depends on what you are building — but it is a\ntrade, not an accident.\n"
+      },
+      {
+        "_key": "check",
+        "_type": "quiz",
+        "questions": [
+          {
+            "explanation": "Conflict is decided on accounts, not on programs or on senders. Declaring the account set up front is precisely what makes that decision possible before execution.",
+            "id": "q1",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "In parallel — their declared account sets do not overlap"
+              },
+              {
+                "correct": false,
+                "feedback": "Sequencing everything is exactly what the declared account list avoids. Non-overlapping transactions have no reason to wait.",
+                "id": "b",
+                "label": "Sequentially, in fee order, like any two Ethereum transactions"
+              },
+              {
+                "correct": false,
+                "feedback": "The program is irrelevant to conflict detection. Two calls into the *same* program run in parallel when they touch different accounts — which is how one SPL Token program serves the whole chain at once.",
+                "id": "c",
+                "label": "In parallel only if they call different programs"
+              }
+            ],
+            "prompt": "Two transactions are submitted in the same slot. A writes account X; B writes account Y. Predict how they are scheduled."
+          },
+          {
+            "explanation": "Write locks are the scarce resource in a parallel scheduler. Marking reads as writes is the Solana analogue of holding a database lock you did not need — invisible in a test, expensive under load.",
+            "id": "q2",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "It takes a write lock, serializing every other transaction that wants to write that account"
+              },
+              {
+                "correct": false,
+                "feedback": "It does gate your writes, but it is also the input to the scheduler. An unnecessary write lock creates real contention for everyone else.",
+                "id": "b",
+                "label": "Nothing — the flag only affects whether your program may write"
+              },
+              {
+                "correct": false,
+                "feedback": "The base fee is per signature. The cost of an over-broad write lock is contention, not fees.",
+                "id": "c",
+                "label": "A higher base fee, proportional to the number of writable accounts"
+              }
+            ],
+            "prompt": "You mark an account writable that your instruction only reads. What does it cost?"
+          },
+          {
+            "explanation": "Conditional access becomes unconditional inclusion. This is the concrete friction of the model: some transactions carry accounts they end up not using, and the client must know enough to include them.",
+            "id": "q3",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "B must be in the account list anyway — the client decides what to include before sending"
+              },
+              {
+                "correct": false,
+                "feedback": "There is no facility to fetch an account mid-instruction. The list is fixed when the transaction is built; that fixity is what the scheduler relies on.",
+                "id": "b",
+                "label": "The program can request B from the runtime once it has read A"
+              },
+              {
+                "correct": false,
+                "feedback": "Sometimes a reasonable design, but not a requirement — passing both and ignoring one is normal and cheap.",
+                "id": "c",
+                "label": "A and B must be merged into a single account"
+              }
+            ],
+            "prompt": "Your instruction wants to read account B only if account A holds a particular flag. Predict what that requires."
+          }
+        ]
+      }
+    ],
+    "skills": [
+      "transactions",
+      "account-model"
+    ],
+    "slug": {
+      "_type": "slug",
+      "current": "declared-accounts"
+    },
+    "title": "Why Transactions Declare Their Accounts"
+  },
+  {
+    "_id": "lesson-sfe-erc20-to-spl",
+    "_type": "lesson",
+    "blocks": [
+      {
+        "_key": "intro",
+        "_type": "prose",
+        "src": "# One token program, and your balance is an account\n\n> Version stamp — `@solana/kit` 7.0.0 · `@solana-program/token` 0.15.0 ·\n> authored 2026-07-30.\n\nEvery ERC-20 is a separate contract. Deploying a token means deploying code, and\n\"balance of X\" is a lookup inside that contract's own mapping. Two tokens are two\ncodebases, and each may behave differently — fee-on-transfer, rebasing, a\nnon-standard `approve` — which is why integrating an arbitrary ERC-20 is a small\naudit.\n\nSolana inverts this. There is **one** SPL Token program, deployed once, shared by\nevery token on the chain. Creating a token deploys nothing; it creates a **mint\naccount** that the token program owns.\n\n```text\nMint account          supply, decimals, mint authority, freeze authority\nToken account (ATA)   owner, mint, amount, delegate\n```\n\nA balance is not a row in a mapping. It is a **token account** — its own account,\nowned by the SPL Token program, holding one balance of one mint for one owner. In\npractice its address is an **associated token account**: exactly the derivation\nfrom lesson 3, applied to the wallet and the mint.\n\nGet the details right, because this is the one PDA everybody derives and it does\nnot derive the way you would guess. The seeds are **three**, in this order —\n`[owner, token_program, mint]` — and the derivation runs under the **Associated\nToken Account program**, not under the token program whose address sits in the\nmiddle of the seed list:\n\n```ts\nimport { findAssociatedTokenPda, TOKEN_PROGRAM_ADDRESS } from \"@solana-program/token\";\n\nconst [ata] = await findAssociatedTokenPda({\n  owner,\n  tokenProgram: TOKEN_PROGRAM_ADDRESS,\n  mint,\n});\n```\n\nThe token program appears as a seed because the same wallet can hold the same\nmint under classic SPL Token and under Token-2022, and those must be different\naddresses.\n\n## What this buys you\n\n**Uniform behavior.** Transfer semantics are the same for every SPL token,\nbecause it is the same program every time. The fee-on-transfer surprise cannot\nexist in the base token program — a token cannot override transfer, because it\nhas no code of its own. (Token-2022 adds opt-in extensions such as transfer\nhooks, and those are explicitly opt-in and visible on the mint.)\n\n**No approval to interact.** Reading a balance is reading an account. No view\nfunction, no RPC call into a contract, no ABI.\n\n## What it costs you\n\n**Token accounts must exist before they can receive.** There is no \"send to an\naddress and it just works\". If the recipient has no token account for that mint,\nsomeone must create it — and pay its rent. That is the single most common\nsurprise for EVM developers.\n\nThe pattern that answers it is **create-if-missing, then transfer**: derive the\nATA, and prepend `getCreateAssociatedTokenIdempotentInstruction({...})` to the\nsame transaction as your transfer. *Idempotent* is the load-bearing word — it\nsucceeds whether or not the account already exists, so you never have to read\nthe chain first to decide, and two clients racing to fund the same recipient do\nnot knock each other over. One transaction, still atomic.\n\n> **In the wild (checked 2026-07-30).** You will constantly read\n> `getOrCreateAssociatedTokenAccount(connection, payer, mint, owner)` from\n> `@solana/spl-token`, and its sibling `getAssociatedTokenAddress`. Both are the\n> superseded v1-era stack, and the first quietly sends its own transaction\n> before yours. Read them; write the derive-plus-idempotent-instruction pair.\n\n**A wallet holds many token accounts.** One per mint. Your SOL balance is the\n`lamports` field on your wallet account; every SPL token you hold is a separate\naccount keyed to that mint.\n\n## Decimals, and the arithmetic you must not get wrong\n\nLike ERC-20, amounts are integers and `decimals` is display metadata. Unlike\nERC-20's near-universal 18, Solana decimals vary widely — USDC uses 6, many NFTs\nuse 0, wrapped SOL uses 9.\n\nBecause the number is not conventional, hardcoding it is a live bug rather than a\nmostly-safe assumption. Converting a human amount to base units is\n`uiAmount × 10^decimals`, and that is what you will implement.\n"
+      },
+      {
+        "_key": "exercise",
+        "_type": "code",
+        "buildType": "standard",
+        "deployable": false,
+        "hints": [
+          "The starter hardcodes 18 — the ERC-20 habit. The exponent is the `decimals` argument, which varies per mint on Solana.",
+          "Wrap the multiplication in `Math.round`. `0.07 * 10 ** 2` is 7.000000000000001 in binary floating point, and an un-rounded return fails the last case."
+        ],
+        "language": "typescript",
+        "solution": "function toBaseUnits(uiAmount: number, decimals: number): number {\n  return Math.round(uiAmount * 10 ** decimals);\n}\n",
+        "starter": "/**\n * Convert a human-facing token amount into base units.\n *\n *   baseUnits = uiAmount * 10^decimals\n *\n * Decimals are NOT conventionally 18 on Solana: USDC uses 6, wrapped SOL uses 9,\n * and plenty of NFTs use 0. Always read `decimals` from the mint.\n *\n * Return a whole number of base units.\n *\n * Examples:\n *   toBaseUnits(1.5, 6) -> 1500000\n *   toBaseUnits(1, 0)   -> 1\n */\nfunction toBaseUnits(uiAmount: number, decimals: number): number {\n  return uiAmount * 10 ** 18;\n}\n",
+        "tests": [
+          {
+            "description": "1.5 USDC at 6 decimals is 1,500,000 base units",
+            "expectedOutput": "result === 1500000",
+            "id": "usdc-six-decimals",
+            "input": "1.5, 6"
+          },
+          {
+            "description": "A 0-decimal token (a typical NFT) converts 1 to 1 — decimals must be read, not assumed",
+            "expectedOutput": "result === 1",
+            "id": "zero-decimals",
+            "input": "1, 0"
+          },
+          {
+            "description": "0.5 wrapped SOL at 9 decimals is 500,000,000 lamports",
+            "expectedOutput": "result === 500000000",
+            "id": "wrapped-sol-nine-decimals",
+            "input": "0.5, 9"
+          },
+          {
+            "description": "0.07 at 2 decimals is exactly 7 — binary floating point makes this 7.000000000000001 without rounding",
+            "expectedOutput": "result === 7",
+            "id": "no-floating-point-dust",
+            "input": "0.07, 2"
+          }
+        ],
+        "tutorNotes": [
+          "The hardcoded 18 is the intended trap: it passes nothing and makes the ERC-20 assumption visible.",
+          "Learners who fix the exponent but skip rounding pass three cases and fail `no-floating-point-dust`; that case exists to teach that base units are integers.",
+          "Production code uses BigInt for real amounts — `number` loses precision past 2^53. Say so if it comes up; the exercise uses `number` to keep the harness simple.",
+          "\"Where does `decimals` actually come from?\" The mint account, read once — it is a field on the mint, not on the token account and not on the wallet. If they are about to hardcode 6 because \"everything is USDC\", that is the same bug as hardcoding 18, one chain over.",
+          "They ask why the ATA derivation in the intro has THREE seeds when lesson 3's vault had two. The token program address sits in the middle — `[owner, token_program, mint]` — because the same wallet can hold the same mint under classic SPL Token and under Token-2022, and those must be different accounts. It is also derived under the Associated Token Account program, not under the token program in its own seed list; people miss that and get an address that does not exist."
+        ]
+      },
+      {
+        "_key": "check",
+        "_type": "quiz",
+        "questions": [
+          {
+            "explanation": "\"Send and it just works\" is an ERC-20 assumption that does not survive the account model. The idiomatic answer is to prepend an idempotent create-ATA instruction to the same transaction as the transfer — creation is a funded step you author, not a side effect.",
+            "id": "q1",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "It fails unless the recipient's token account for that mint is created first — and someone pays its rent"
+              },
+              {
+                "correct": false,
+                "feedback": "Nothing is created implicitly, because creation costs rent and the runtime will not decide who pays it.",
+                "id": "b",
+                "label": "It succeeds; the token program creates the account on demand"
+              },
+              {
+                "correct": false,
+                "feedback": "Only SOL lives on the wallet account, as `lamports`. Every SPL token balance is a separate account.",
+                "id": "c",
+                "label": "It succeeds and the balance is held on the wallet account itself"
+              }
+            ],
+            "prompt": "You transfer an SPL token to a wallet that has never held it. Predict."
+          },
+          {
+            "explanation": "Creating a token deploys no code, so there is nothing to override. That is what makes integrating an arbitrary SPL token far less risky than integrating an arbitrary ERC-20 — with Token-2022 extensions as the explicit, inspectable exception.",
+            "id": "q2",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "It has no code of its own — a mint is data owned by the shared token program"
+              },
+              {
+                "correct": false,
+                "feedback": "There is no such check to reject; there is simply no place for per-token logic to live in the base program.",
+                "id": "b",
+                "label": "The token program rejects transfers whose amounts do not match exactly"
+              },
+              {
+                "correct": false,
+                "feedback": "Not in the base token program. Token-2022 adds a transfer-fee extension — opt-in, visible on the mint, and a deliberate exception rather than the default.",
+                "id": "c",
+                "label": "It can, by setting a fee field on the mint"
+              }
+            ],
+            "prompt": "Why can a base SPL token not implement fee-on-transfer the way an ERC-20 can?"
+          }
+        ]
+      }
+    ],
+    "skills": [
+      "spl-tokens",
+      "account-model",
+      "typescript"
+    ],
+    "slug": {
+      "_type": "slug",
+      "current": "erc20-to-spl"
+    },
+    "title": "From ERC-20 to SPL Token"
+  },
+  {
+    "_id": "lesson-sfe-gas-to-compute-units",
+    "_type": "lesson",
+    "blocks": [
+      {
+        "_key": "intro",
+        "_type": "prose",
+        "src": "# Gas splits into two separate things\n\n> Version stamp — `@solana/kit` 7.0.0 · `@solana-program/compute-budget` 0.17.0\n> · authored 2026-07-30.\n\nOn the EVM, one number does two jobs. Gas meters how much work you did *and*, via\ngas price, how badly you want to be included. Raise the price and you buy\npriority; run an expensive loop and you pay more for the same priority.\n\nSolana separates them.\n\n**Compute units (CU)** meter work. Every instruction has a budget — 200,000 CU by\ndefault per instruction, up to 1.4M for a transaction if you ask. Exceed it and\nthe transaction fails. Crucially, the CU limit is *not* priced per unit the way\ngas is: the base fee is a flat 5,000 lamports per signature, essentially\nindependent of how much computation you did.\n\n**Priority fees** buy ordering. You bid in micro-lamports per compute unit,\nseparately, and only that bid competes for block space when there is contention.\n\nTwo consequences that will surprise you:\n\n- **Compute is cheap; state is expensive.** The EVM's `SSTORE`-dominated cost\n  model taught you to minimize writes above all. On Solana the recurring cost is\n  rent for space, and computation inside your budget is close to free. An\n  optimization that saves 20,000 CU saves you approximately nothing in fees — it\n  buys headroom, not money.\n- **Running out of CU is a failure, not a fee increase.** There is no \"raise the\n  limit and it costs more\" gradient. You either fit in the budget or the\n  transaction fails, so requesting an appropriate limit is part of building the\n  transaction.\n\n## Setting them\n\nBoth are instructions from the Compute Budget program, added to your\ntransaction:\n\n```ts\nimport {\n  getSetComputeUnitLimitInstruction,\n  getSetComputeUnitPriceInstruction,\n} from \"@solana-program/compute-budget\";\n\ngetSetComputeUnitLimitInstruction({ units: 300_000 });\ngetSetComputeUnitPriceInstruction({ microLamports: 5_000 });\n```\n\nThe first says how much room you need. The second is your priority bid. They are\nplain instructions like any other — you append them to a transaction message and\nthey carry no accounts.\n\nTwo honest footnotes. Putting them first is a **convention, not a protocol\nrule**: the runtime finds them anywhere in the transaction. The real constraints\nare at most one of each kind (a duplicate fails with `DuplicateInstruction`) and\nthe 1.4M-CU clamp. And for *estimating* the limit rather than hardcoding it, the\ncurrent API lives in Kit itself — `estimateResourceLimitsFactory({ rpc })` and\n`estimateAndSetResourceLimitsFactory(estimator)` — not in this package.\n\n> **In the wild (checked 2026-07-30).** The snippet you will find in nearly\n> every tutorial is `ComputeBudgetProgram.setComputeUnitLimit({...})` from\n> `@solana/web3.js` v1, a static class method. Same two instructions, superseded\n> API. Read it; write the builders above.\n\n## The arithmetic worth internalizing\n\nThe priority fee is `computeUnits × microLamportsPerCu`, converted from\nmicro-lamports to lamports — a division by 1,000,000.\n\nA 200,000 CU transaction bidding 5,000 micro-lamports/CU pays\n`200,000 × 5,000 / 1,000,000 = 1,000` lamports of priority, on top of the 5,000\nlamport base signature fee.\n\nNotice what that means: **the limit you request affects what you pay.** Request\n1.4M CU \"just to be safe\" while bidding the same price and you have multiplied\nyour priority fee by seven for a transaction that uses a fraction of it. The\ncorrect move is to simulate the transaction, observe the units actually consumed,\nand request that plus a modest margin.\n\nYou will implement exactly that conversion next.\n"
+      },
+      {
+        "_key": "exercise",
+        "_type": "code",
+        "buildType": "standard",
+        "deployable": false,
+        "hints": [
+          "The starter never converts units — it returns micro-lamports. Divide by 1,000,000 to reach lamports.",
+          "`Math.ceil`, not `Math.round` or `Math.floor`. The `rounds-up` case is 1 CU at 1 micro-lamport: a true value of 0.000001 lamports must still be charged as 1."
+        ],
+        "language": "typescript",
+        "solution": "function priorityFeeLamports(\n  computeUnits: number,\n  microLamportsPerCu: number\n): number {\n  const MICRO_LAMPORTS_PER_LAMPORT = 1_000_000;\n  return Math.ceil((computeUnits * microLamportsPerCu) / MICRO_LAMPORTS_PER_LAMPORT);\n}\n",
+        "starter": "/**\n * Compute the priority fee, in lamports, for a transaction.\n *\n * The bid is expressed in MICRO-lamports per compute unit, so:\n *\n *   lamports = computeUnits * microLamportsPerCu / 1_000_000\n *\n * Round UP — a partial lamport is still charged as a whole one.\n *\n * Examples:\n *   priorityFeeLamports(200000, 5000) -> 1000\n *   priorityFeeLamports(200000, 0)    -> 0\n */\nfunction priorityFeeLamports(\n  computeUnits: number,\n  microLamportsPerCu: number\n): number {\n  return computeUnits * microLamportsPerCu;\n}\n",
+        "tests": [
+          {
+            "description": "200,000 CU at 5,000 micro-lamports/CU is 1,000 lamports",
+            "expectedOutput": "result === 1000",
+            "id": "typical-bid",
+            "input": "200000, 5000"
+          },
+          {
+            "description": "A zero bid costs nothing in priority — the base signature fee is separate",
+            "expectedOutput": "result === 0",
+            "id": "no-bid-is-free",
+            "input": "200000, 0"
+          },
+          {
+            "description": "A partial lamport rounds up: 1 CU at 1 micro-lamport is charged as 1 lamport, not 0",
+            "expectedOutput": "result === 1",
+            "id": "rounds-up",
+            "input": "1, 1"
+          },
+          {
+            "description": "Requesting 1.4M CU at the same bid costs seven times a 200k request — over-requesting is not free",
+            "expectedOutput": "result === 7000",
+            "id": "limit-drives-cost",
+            "input": "1400000, 5000"
+          }
+        ],
+        "tutorNotes": [
+          "Learners divide but use `Math.floor` or plain truncation, so the sub-lamport case returns 0. The network rounds against the payer, never in their favour.",
+          "Some divide by 1,000 (confusing micro- with milli-). The factor between micro-lamports and lamports is 10^6.",
+          "The big one: they conflate the LIMIT with the PRICE. Two instructions, two jobs — the limit is how much room you reserve (a hard ceiling; exceed it and the transaction fails), the price is your bid per unit reserved. Raising the limit does not make you go faster; raising the price does not give you more room. Ask a stuck learner which one fixes an out-of-CU failure: the limit — and it costs real money at the current price.",
+          "Follow-on from the same confusion: they expect the fee to scale with compute CONSUMED, as gas does. It scales with compute REQUESTED. This is why `limit-drives-cost` exists — 1.4M CU at the same bid costs seven times a 200k request even if the instruction burns 6,000 units. \"Request 1.4M to be safe\" is a real bill.",
+          "\"So does optimizing my program save users money?\" Mostly no, and that surprises people coming from `SSTORE` accounting. Base fee is flat per signature and priority is per unit REQUESTED, so the saving only lands if you also lower the requested limit. What optimization really buys is headroom — fitting under the ceiling — not fees.",
+          "If they ask where the number to request comes from: simulate the transaction, read the units actually consumed, add roughly 10% margin. Consumption varies slightly run to run, so a limit pinned at one observed value fails intermittently. Simulate-then-tighten is a normal part of the send path here, not a debugging step."
+        ]
+      },
+      {
+        "_key": "check",
+        "_type": "quiz",
+        "questions": [
+          {
+            "explanation": "Compute is nearly free in base fees but not in priority fees, which are priced per requested unit. This is why \"request 1.4M CU to be safe\" is a real cost, and why simulate-then-request is the standard practice.",
+            "id": "q1",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "The priority fee falls proportionally, because it is priced per compute unit requested"
+              },
+              {
+                "correct": false,
+                "feedback": "The base fee is indeed flat, but the priority fee is explicitly per compute unit. Requesting fewer units at the same bid is cheaper.",
+                "id": "b",
+                "label": "Nothing changes — the base fee is flat per signature and compute is not billed"
+              },
+              {
+                "correct": false,
+                "feedback": "Nothing auto-compensates. A tighter limit is cheaper; whether it is *safe* is a separate judgement you make from simulation.",
+                "id": "c",
+                "label": "It rises, since a tighter limit risks failure and must be compensated with a higher bid"
+              }
+            ],
+            "prompt": "You optimize an instruction from 180,000 CU to 120,000 CU and leave the priority bid unchanged. Predict the effect on what a user pays."
+          },
+          {
+            "explanation": "Unlike gas, where a higher limit simply risks spending more, the compute budget is a hard ceiling. Fitting is a build-time concern, which is why simulation is part of a normal send path rather than a debugging step.",
+            "id": "q2",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "The transaction fails once the budget is exhausted — there is no overage billing"
+              },
+              {
+                "correct": false,
+                "feedback": "There is no overage. The budget is a hard ceiling, not a soft spending limit that bills you for going over.",
+                "id": "b",
+                "label": "It succeeds and the extra compute is billed at the same rate"
+              },
+              {
+                "correct": false,
+                "feedback": "Nothing is raised for you. Requesting more is an explicit `getSetComputeUnitLimitInstruction` you add to the transaction.",
+                "id": "c",
+                "label": "The runtime raises the limit automatically up to the 1.4M maximum"
+              }
+            ],
+            "prompt": "Your instruction needs 250,000 CU and you request the default limit. Predict."
+          }
+        ]
+      }
+    ],
+    "skills": [
+      "compute-budget",
+      "priority-fees",
+      "transaction-fees",
+      "typescript"
+    ],
+    "slug": {
+      "_type": "slug",
+      "current": "gas-to-compute-units"
+    },
+    "title": "From Gas to Compute Units and Priority Fees"
+  },
+  {
+    "_id": "lesson-sfe-mappings-to-pdas",
+    "_type": "lesson",
+    "blocks": [
+      {
+        "_key": "intro",
+        "_type": "prose",
+        "src": "# A `mapping` becomes an address you can compute\n\n> Version stamp — `@solana/kit` 7.0.0 · authored 2026-07-30.\n\n`balances[user]` is a hash of the slot number and the key, resolved by the EVM at\nread time inside the contract's storage. You never see the location; you just\nindex.\n\nSolana has no mapping, because it has no per-program storage to index into. What\nit has instead is stranger and, once it clicks, more useful: you can *derive an\naddress* from a set of seeds, deterministically, off-chain, before you send\nanything.\n\nThat address is a **program-derived address** — a PDA.\n\n```ts\nimport {\n  getProgramDerivedAddress,\n  getUtf8Encoder,\n  getAddressEncoder,\n} from \"@solana/kit\";\n\nconst [vaultPda, bump] = await getProgramDerivedAddress({\n  programAddress: VAULT_PROGRAM,\n  seeds: [\n    getUtf8Encoder().encode(\"vault\"),\n    getAddressEncoder().encode(owner),\n  ],\n});\n```\n\nGiven the same seeds and the same program address, everyone computes the same\naddress — your frontend, your tests, another protocol integrating with you. The\nmapping key became part of the address itself.\n\nTwo things to notice in that snippet, because both bite EVM developers on day\none. Seeds are **encoded bytes**, never bare JavaScript strings — the encoders\nare how `\"vault\"` and a 32-byte address become the byte sequences that get\nhashed. And the call is **awaited**: the derivation searches (see below), so it\nis async, and a forgotten `await` hands you a `Promise` where an address should\nbe. That is the single most common porting mistake into this API.\n\n> **In the wild (checked 2026-07-30).** Almost every PDA snippet you will find\n> on Stack Overflow or in an existing repo reads\n> `PublicKey.findProgramAddressSync(seeds, programId)` from `@solana/web3.js`\n> v1 — synchronous, `Buffer`-based, and still holding npm's `latest` tag. It is\n> superseded. Read it fluently; write `getProgramDerivedAddress`.\n\n## The two properties that matter\n\n**No private key exists for a PDA.** These addresses are deliberately chosen to\nfall *off* the ed25519 curve, so no keypair can produce a signature for them.\nNobody can sign as your vault by holding a secret — instead, the owning program\ncan sign for it, by supplying the seeds. Authority comes from the derivation, not\nfrom a secret. There is no EVM equivalent, because in the EVM authority over a\ncontract's storage is simply \"being that contract\".\n\n**The bump is the search.** Most seed combinations land *on* the curve, which\nwould be a valid keypair address and therefore unusable. So the derivation\nappends a byte — the bump — and counts down from 255 until it finds an off-curve\nresult. `getProgramDerivedAddress` returns the first one it finds (the\n*canonical* bump). Programs store that bump so they never repeat the search, and so an\nattacker cannot supply a different, non-canonical bump to derive a second valid\naddress for the same logical key.\n\n## What you gain, and what you give up\n\nYou gain addressability. A Solidity `mapping` entry has no address you can hand\nto anyone; a PDA is a first-class account you can pass to another program, list\nin a transaction, or read directly from a client with no view function and no\nRPC call into your contract.\n\nYou give up enumeration. `balances` cannot be listed on the EVM either, but at\nleast the contract can maintain its own index. On Solana the accounts exist\nindependently of any registry, so if you need to enumerate holders you either\nmaintain that index yourself or lean on an indexer that scans accounts by owner.\n\n## In the exercise\n\nYou will build the seed list itself — the small, boring, easy-to-get-wrong piece\nthat determines every address your program will ever use. Order matters, the\nliteral prefix matters, and both are part of your program's public interface: a\nseed change is an address change, and an address change orphans every account\nthat existed before.\n"
+      },
+      {
+        "_key": "exercise",
+        "_type": "code",
+        "buildType": "standard",
+        "deployable": false,
+        "hints": [
+          "The starter returns `[owner]` — one seed. The convention in the prose is two: the literal namespace prefix, then the owner.",
+          "Return the prefix as a plain string literal in the array, in first position. `[\"vault\", owner]` — not `[owner, \"vault\"]`, which derives a different address entirely."
+        ],
+        "language": "typescript",
+        "solution": "function vaultSeeds(owner: string): string[] {\n  return [\"vault\", owner];\n}\n",
+        "starter": "/**\n * Build the seed list for a per-owner vault PDA.\n *\n * The convention this program uses is a literal namespace prefix followed by the\n * owner, so a vault seed list is exactly:\n *\n *   [\"vault\", <owner>]\n *\n * The prefix is what stops a \"vault\" PDA from colliding with a \"config\" PDA\n * derived from the same owner. Order is part of the derivation: swapping the two\n * produces a different address.\n *\n * Example:\n *   vaultSeeds(\"alice\") -> [\"vault\", \"alice\"]\n */\nfunction vaultSeeds(owner: string): string[] {\n  return [owner];\n}\n",
+        "tests": [
+          {
+            "description": "The namespace prefix comes first, then the owner",
+            "expectedOutput": "JSON.stringify(result) === JSON.stringify([\"vault\",\"alice\"])",
+            "id": "prefix-then-owner",
+            "input": "\"alice\""
+          },
+          {
+            "description": "A different owner produces a different seed list — the owner is threaded through, not baked in",
+            "expectedOutput": "JSON.stringify(result) === JSON.stringify([\"vault\",\"bob\"])",
+            "id": "owner-is-not-hardcoded",
+            "input": "\"bob\""
+          },
+          {
+            "description": "Two seeds, no more: an extra seed silently changes every derived address",
+            "expectedOutput": "result.length === 2",
+            "id": "exactly-two-seeds",
+            "input": "\"carol\""
+          }
+        ],
+        "tutorNotes": [
+          "Learners order the seeds owner-first; the derivation is order-sensitive, so that is a different (and unused) address. Stress that this does not throw — it returns a perfectly real address that simply is not the vault. Wrong seed order is a silent wrong address, never an error.",
+          "Some add a third seed such as a bump, and `exactly-two-seeds` catches it. This is the lesson's most common confusion, so name the two roles apart: the SEEDS are your program's public interface, chosen by you; the BUMP is the search result the derivation appends by itself to land off the curve. You author seeds, never a bump. (The exception — a program replaying its own stored canonical bump to sign — is a different call and comes later.)",
+          "\"Why store the bump at all, then?\" Two reasons, and the second is a security bug. The search costs real compute on-chain, and — more importantly — several bumps below the canonical one may also land off-curve, each deriving a DIFFERENT valid address for the same logical key. Storing and re-checking the canonical bump is what stops an attacker handing you a second vault for the same owner.",
+          "They ask why the exercise returns plain strings when the intro shows `getUtf8Encoder().encode(...)`. The exercise isolates ordering with no crypto in the sandbox; in production seeds are ENCODED bytes, never bare JS strings, and a string handed straight to the real API is a type error.",
+          "They forget the `await` when they later write real Kit code. `getProgramDerivedAddress` is async — the bump search is why — so a missing await yields a `Promise` where an address should be. It is the number one porting mistake from `findProgramAddressSync`, which was synchronous.",
+          "Someone will ask what happens if the seeds exceed the limit: a seed is at most 32 bytes and there are at most 16 of them. Hashing a long value down to 32 bytes yourself is the normal escape hatch, and it is why you see `hash(name)` as a seed rather than the name."
+        ]
+      },
+      {
+        "_key": "check",
+        "_type": "quiz",
+        "questions": [
+          {
+            "explanation": "Authority over a PDA comes from the derivation, not from a secret. The program proves it may act for the address by producing the seeds that generate it — which is why seeds are effectively an access-control policy written as data.",
+            "id": "q1",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "PDAs are chosen to lie off the ed25519 curve, so no private key exists for them"
+              },
+              {
+                "correct": false,
+                "feedback": "There is no list. The property is mathematical: the address is not a point on the curve, so it is not a public key any private key maps to.",
+                "id": "b",
+                "label": "The runtime maintains a blocklist of derived addresses and refuses their signatures"
+              },
+              {
+                "correct": false,
+                "feedback": "No key exists to hold. The owning program signs by supplying the seeds, which is a different mechanism from holding a secret.",
+                "id": "c",
+                "label": "Their private keys are held by the owning program and never exposed"
+              }
+            ],
+            "prompt": "Why can nobody produce a signature for a PDA the way they can for a normal wallet address?"
+          },
+          {
+            "explanation": "Seeds are part of your public interface, exactly like a function signature. Changing them does not migrate anything — it points at different accounts and strands the originals, still holding their rent.",
+            "id": "q2",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "Every existing vault is orphaned — the new derivation points at fresh, empty addresses"
+              },
+              {
+                "correct": false,
+                "feedback": "Nothing re-derives or migrates. An address is a function of its seeds; change the seeds and you are simply talking about a different account.",
+                "id": "b",
+                "label": "Existing accounts are re-derived to the new address automatically on next access"
+              },
+              {
+                "correct": false,
+                "feedback": "The bump search varies one appended byte to get off the curve. It does not explore alternative seed contents.",
+                "id": "c",
+                "label": "The old and new seeds both resolve, since the bump search covers nearby inputs"
+              }
+            ],
+            "prompt": "You ship v2 of a program and change a PDA seed prefix from `\"vault\"` to `\"vault_v2\"`. Predict the effect on existing users."
+          }
+        ]
+      }
+    ],
+    "skills": [
+      "pdas",
+      "account-model",
+      "typescript"
+    ],
+    "slug": {
+      "_type": "slug",
+      "current": "mappings-to-pdas"
+    },
+    "title": "From `mapping` to Program-Derived Addresses"
+  },
+  {
+    "_id": "lesson-sfe-msg-sender-to-signers",
+    "_type": "lesson",
+    "blocks": [
+      {
+        "_key": "intro",
+        "_type": "prose",
+        "src": "# `msg.sender` becomes a list the runtime already verified\n\n`msg.sender` is a single address, and its meaning shifts with context: at the top\nlevel it is an externally-owned account, and one `call` deeper it is the calling\ncontract. Half of Solidity's access-control folklore exists to manage that shift.\n\nSolana replaces it with something flatter. A transaction carries a list of\naccounts, and each one is flagged `is_signer` or not. Before your program runs,\nthe runtime has already verified every signature against every account marked as\na signer. By the time your code executes, `is_signer` is a fact, not a claim.\n\nSo the question is never \"who called me?\" It is \"which of the accounts I was\nhanded are signers, and is the right one among them?\"\n\n```rust\nrequire!(ctx.accounts.owner.is_signer, VaultError::NotOwner);\nrequire_keys_eq!(ctx.accounts.vault.owner, ctx.accounts.owner.key());\n```\n\nTwo separate checks, and both are load-bearing:\n\n- **Did they sign?** Proves the transaction was authorized by that keypair.\n- **Are they the right one?** Proves the signer is the account your state says\n  is allowed.\n\nA signature from *somebody* is worthless on its own. That is the Solana version\nof the bug where a Solidity function checks that a caller exists but not that it\nis the owner.\n\n## Multiple signers are ordinary\n\nA Solana transaction can carry several signers, all verified up front — a user\nand a fee payer, or two parties to an escrow, in a single atomic transaction. In\nSolidity, the equivalent means signature-verification plumbing you write yourself\n(`ecrecover`, EIP-712, replay nonces). Here it is a property of the transaction\nenvelope, and there is nothing to implement.\n\n## Where `tx.origin` went\n\nIt does not exist, and its absence is not a gap. `tx.origin` is dangerous in\nSolidity precisely because it collapses the call chain into one address that\nphishing can exploit. On Solana, when your program calls another program via CPI,\nthe runtime tracks which signatures propagate: the callee sees the original\nsigners, plus any PDA the caller signed for with its seeds. The chain stays\nexplicit instead of being flattened into a single ambient value.\n\n## The habit to build now\n\nComing from Solidity, the reflex is to ask what the current call context is.\nRetrain it into two questions you can answer by reading the account list:\n\n1. Which accounts are signers?\n2. Does my state say those specific keys are authorized?\n\nEverything else in access control on Solana is a variation on those two lines.\n"
+      },
+      {
+        "_key": "check",
+        "_type": "quiz",
+        "questions": [
+          {
+            "explanation": "\"Signed\" and \"authorized\" are different claims. The runtime proves the first; only a comparison against your own state proves the second. This is the single most common port of the Solidity missing-`onlyOwner` bug.",
+            "id": "q1",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "The withdrawal succeeds — a valid signature was proven, but never that this signer owns that vault"
+              },
+              {
+                "correct": false,
+                "feedback": "The runtime verifies signatures. It has no idea which vault a given key is allowed to touch — that relationship exists only in your state, so only your program can check it.",
+                "id": "b",
+                "label": "It fails; the runtime binds signers to the accounts they are authorized over"
+              },
+              {
+                "correct": false,
+                "feedback": "No such rule exists. Transactions routinely include accounts the signer has no authority over.",
+                "id": "c",
+                "label": "It fails, because a signer must own every account in the instruction"
+              }
+            ],
+            "prompt": "A withdraw instruction checks `ctx.accounts.owner.is_signer` and nothing else. An attacker signs with their own keypair and passes someone else's vault. Predict."
+          },
+          {
+            "explanation": "The phishing risk in `tx.origin` comes from flattening a call chain into one address. Solana keeps the chain explicit: a callee sees the original signers plus any PDA the caller signed for, and nothing pretends to be a single \"who started this\".",
+            "id": "q2",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "Nowhere — signer status propagates explicitly through CPI instead of collapsing into one ambient address"
+              },
+              {
+                "correct": false,
+                "feedback": "The first account is the fee payer — that position is fixed by the protocol, not a convention — but paying a fee is not authorizing anything, so it must never be read as an authorization signal.",
+                "id": "b",
+                "label": "It is exposed as the first account in every transaction's account list"
+              },
+              {
+                "correct": false,
+                "feedback": "There is no equivalent value to reach for. The design avoids the flattening that makes `tx.origin` exploitable.",
+                "id": "c",
+                "label": "It is available but discouraged, exactly as in Solidity"
+              }
+            ],
+            "prompt": "Where did `tx.origin` go?"
+          },
+          {
+            "explanation": "Multi-signer transactions are ordinary, not a protocol you implement. Whole categories of Solidity signature plumbing — recovery, replay nonces, deadline checks — simply have no counterpart.",
+            "id": "q3",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "One transaction carrying both signers; the runtime verifies both before execution"
+              },
+              {
+                "correct": false,
+                "feedback": "That is the Solidity workaround for a transaction envelope that only carries one sender. Solana's envelope carries many.",
+                "id": "b",
+                "label": "An EIP-712 style signature passed as calldata and recovered in-program"
+              },
+              {
+                "correct": false,
+                "feedback": "A valid pattern when the parties genuinely act at different times, but unnecessary here — and it gives up atomicity.",
+                "id": "c",
+                "label": "Two transactions and a state machine that pairs them"
+              }
+            ],
+            "prompt": "Two parties must both authorize an atomic swap. What does that take on Solana?"
+          }
+        ]
+      }
+    ],
+    "skills": [
+      "signers",
+      "program-security"
+    ],
+    "slug": {
+      "_type": "slug",
+      "current": "msg-sender-to-signers"
+    },
+    "title": "From `msg.sender` to Verified Signers"
+  },
+  {
+    "_id": "lesson-sfe-rent-and-space",
+    "_type": "lesson",
+    "blocks": [
+      {
+        "_key": "intro",
+        "_type": "prose",
+        "src": "# Storage costs rent, and the size is yours to choose\n\n> Version stamp — Anchor 1.1.2 (`@anchor-lang/core` 1.1.2) · authored\n> 2026-07-30.\n\nOn the EVM you pay for storage once, at write time, in gas. `SSTORE` is\nexpensive precisely because the network stores that word forever. There is no\nongoing cost and no size declaration — you write to slot 7 and slot 7 exists.\n\nSolana charges differently. An account occupies validator memory for as long as\nit exists, so it must hold a minimum lamport balance proportional to its size.\nThat balance is called **rent**, and an account holding it is **rent-exempt**.\n\nRead \"rent\" as a **deposit**, not a subscription. The name is historical: Solana\nonce did debit accounts periodically, and an account that ran dry was collected.\nThat mechanism is gone. Today rent-exemption is enforced by the runtime *at\ncreation* — an account that does not hold the minimum for its size is not\ncreated at all, the instruction fails, and there is no such thing as a\npartially-funded account slowly draining. Nothing is billed over time and\nnothing is erased for non-payment. Every account on the chain is rent-exempt,\nbecause the runtime accepts no other kind.\n\nThe deposit stays yours: close the account and it comes back in full.\n\nTwo things follow, and both are alien coming from Solidity.\n\n## You declare the size up front\n\nCreating an account means saying how many bytes it needs. Not \"roughly\"; exactly.\nThe runtime allocates that many bytes, zeroed, and charges you the rent-exempt\nminimum for that size.\n\nThere is no `mapping` that grows as you insert. There is no dynamic array that\njust gets longer. If you want to store more later, you either allocate for the\nworst case now or `realloc` the account and top up the rent difference.\n\nSizing is therefore a design decision you make before writing a line of logic.\nGet it too small and you cannot store what you need; too large and every user\noverpays to create their account.\n\n## Rent is refundable\n\nRent is a deposit, not a fee. Close the account and the lamports go back to\nwhoever you nominate. This is why Solana programs have a `close` instruction and\nSolidity contracts do not bother with `selfdestruct` for state — reclaiming\nspace is a normal, profitable operation rather than a curiosity.\n\n## Counting bytes\n\nAn Anchor account starts with an 8-byte **discriminator** — a hash of the account\ntype name, used to tell a `Vault` from a `Config` when both are just bytes owned\nby your program. After that you pay for exactly what you declare:\n\n```text\n8                discriminator (Anchor)\n32               Pubkey\n8                u64  (lamports, timestamps)\n1                u8   (a PDA bump)\n1                bool\n4 + len          String or Vec (4-byte length prefix, then contents)\n```\n\nA vault with an owner `Pubkey`, a `u64` balance and a `u8` bump is\n`8 + 32 + 8 + 1 = 49` bytes. That number is not trivia — it is an argument you\npass at creation, and getting it wrong is one of the most common first bugs for\ndevelopers arriving from the EVM.\n\nIn the exercise you will compute exactly that number.\n"
+      },
+      {
+        "_key": "exercise",
+        "_type": "code",
+        "buildType": "standard",
+        "deployable": false,
+        "hints": [
+          "The discriminator is unconditional — it is there even when the account has no fields at all. Start your total at 8 rather than at 0.",
+          "`hasBump` contributes 1 byte, not 8. A bump is a `u8`; there is no alignment padding to round it up."
+        ],
+        "language": "typescript",
+        "solution": "function accountSize(numU64Fields: number, hasBump: boolean): number {\n  const DISCRIMINATOR = 8;\n  const U64 = 8;\n  return DISCRIMINATOR + numU64Fields * U64 + (hasBump ? 1 : 0);\n}\n",
+        "starter": "/**\n * Anchor lays an account out as:\n *\n *   8 bytes   discriminator (always present on an Anchor account)\n *   8 bytes   per u64 field\n *   1 byte    for the PDA bump, when the account stores one\n *\n * Return the total number of bytes to request at creation.\n *\n * Examples:\n *   accountSize(3, true)  -> 8 + 24 + 1 = 33\n *   accountSize(0, false) -> 8\n */\nfunction accountSize(numU64Fields: number, hasBump: boolean): number {\n  return 0;\n}\n",
+        "tests": [
+          {
+            "description": "Three u64 fields plus a bump: 8 + 24 + 1 = 33",
+            "expectedOutput": "result === 33",
+            "id": "three-fields-with-bump",
+            "input": "3, true"
+          },
+          {
+            "description": "No fields and no bump is still 8 bytes — the discriminator is never free",
+            "expectedOutput": "result === 8",
+            "id": "empty-account",
+            "input": "0, false"
+          },
+          {
+            "description": "One u64 with a bump is 17, without it 16 — the bump is a u8, not padded",
+            "expectedOutput": "result === 17",
+            "id": "bump-costs-exactly-one-byte",
+            "input": "1, true"
+          }
+        ],
+        "tutorNotes": [
+          "Learners returning `numU64Fields * 8` forget the 8-byte discriminator; the `empty-account` case is what catches it.",
+          "Some add 8 for the bump by pattern-matching the u64 size. A bump is a u8 — exactly 1 byte.",
+          "They ask why they are counting bytes by hand when Anchor has `#[derive(InitSpace)]` and `Vault::INIT_SPACE`. The honest answer: in real code you use it, and you should. But `INIT_SPACE` does NOT include the 8-byte discriminator — the idiomatic constraint is `space = 8 + Vault::INIT_SPACE` — so the one number the macro leaves you to remember is exactly the one this exercise drills. A learner who never counted by hand writes `space = Vault::INIT_SPACE` and is eight bytes short.",
+          "They ask what happens if the number is too small. Not a silent truncation: the write fails and the transaction fails. Too LARGE is the quieter bug — it never errors, every user just overpays the rent deposit forever, and nobody notices until someone reads an account and finds a tail of zeros.",
+          "\"Then why not allocate 10 KB and stop worrying?\" Because the deposit scales with size and the payer is usually the user, and because 10 KB is the hard per-instruction allocation ceiling anyway. Sizing is a real design decision, which is the point of the lesson.",
+          "If they ask about `String` or `Vec`: the 4-byte length prefix in the table is the *header*, not the contents. A `Vec<Pubkey>` capped at 10 is `4 + 10 * 32`, and you must size for the cap because nothing grows on write."
+        ]
+      },
+      {
+        "_key": "check",
+        "_type": "quiz",
+        "questions": [
+          {
+            "explanation": "Size is declared, not discovered. Growing means `realloc` plus more rent — which is exactly why worst-case sizing up front is such a common pattern in production programs.",
+            "id": "q1",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "The account must be reallocated to a larger size and topped up with the rent difference"
+              },
+              {
+                "correct": false,
+                "feedback": "Nothing grows implicitly. The byte count was fixed when the account was created; writing past it is an error, not an extension.",
+                "id": "b",
+                "label": "Nothing — the account grows on write, like a Solidity dynamic array"
+              },
+              {
+                "correct": false,
+                "feedback": "Splitting state across accounts is a design you choose, never something the runtime does for you.",
+                "id": "c",
+                "label": "The `Vec` is stored in a separate account automatically"
+              }
+            ],
+            "prompt": "You size a vault account at 49 bytes and later want to add a `Vec<Pubkey>` of up to 10 delegates. Predict what has to happen."
+          },
+          {
+            "explanation": "Rent-exemption is a deposit held against space. Give the space back and you get the deposit back — the closest EVM analogue is the (much smaller) gas refund for zeroing storage.",
+            "id": "q2",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "They are returned to whichever account the close instruction nominates"
+              },
+              {
+                "correct": false,
+                "feedback": "Rent is a refundable deposit, not a consumed fee. That is precisely why closing accounts is a normal operation rather than a write-off.",
+                "id": "b",
+                "label": "They are burned, since they paid for storage already consumed"
+              },
+              {
+                "correct": false,
+                "feedback": "If that were true, every abandoned account would permanently lock SOL. Reclaiming the deposit is the point of closing.",
+                "id": "c",
+                "label": "They stay locked forever; only the data is cleared"
+              }
+            ],
+            "prompt": "A user closes their vault account. What happens to the lamports that made it rent-exempt?"
+          }
+        ]
+      }
+    ],
+    "skills": [
+      "rent-and-space",
+      "account-layout",
+      "typescript"
+    ],
+    "slug": {
+      "_type": "slug",
+      "current": "rent-and-space"
+    },
+    "title": "Rent, and Sizing an Account"
+  },
+  {
+    "_id": "lesson-sfe-storage-to-accounts",
+    "_type": "lesson",
+    "blocks": [
+      {
+        "_key": "intro",
+        "_type": "prose",
+        "src": "# Your program owns no storage\n\nIn Solidity, a contract and its state are the same deployed thing. `uint256\npublic totalDeposits;` lives at a slot inside the contract's own storage trie,\nand only that contract's code can write it. Deploy the contract, and the storage\ncomes with it — empty, but there.\n\nOn Solana a program is an account holding executable bytes, and that account is\n**immutable at runtime**. Your program cannot write to itself. There is no slot\n0. `totalDeposits` has to live in a *different* account, one that you create,\nsize, and pay for.\n\n## The ownership rule that replaces `private`\n\nSolidity gives you visibility keywords. Solana gives you one runtime rule, and\nit is stricter than anything in the EVM:\n\n> A program may only write to accounts it owns.\n\nEvery account carries an `owner` field — the public key of the program allowed\nto modify its data. When your program writes to an account it does not own, the\nwhole transaction fails. Not a revert your code chose; a refusal the runtime\nimposes on you.\n\nWorth being precise about *when*, because it is not what a Solidity developer\nexpects. The write itself is not trapped at the moment it happens — your program\nis handed a mutable buffer and the store lands in memory. The runtime verifies\nownership **after your instruction returns**, comparing the account against what\nit looked like going in; an illegal change fails the transaction and every\neffect is discarded. So your code can appear to \"succeed\" right up until it\ndoes not. The guarantee is on the committed result, not on the individual\ninstruction that produced it.\n\nThis is why you will see Solana developers say \"the program owns the account\"\nwhere you would say \"the contract holds the state\". The account exists\nindependently. Your program is merely the only thing permitted to change it.\n\n## Three consequences you will feel immediately\n\n**State is passed in, not looked up.** Solidity reads `totalDeposits` from\nambient storage. A Solana instruction receives the accounts it may touch as\nexplicit arguments. If the caller does not pass the account, your program cannot\nread it — there is no ambient anything.\n\n**One program, many state accounts.** An ERC-20 is one contract per token, with\nbalances in an internal mapping. SPL Token is *one* program, deployed once, and\nevery mint and every balance is a separate account it owns. You will meet this\ninversion again in module 3; it is the same rule you are reading now.\n\n**Upgrades do not migrate state.** Upgrading a Solidity contract means proxies,\nbecause state and code are welded together. On Solana you replace the\nexecutable bytes of the program account, and the state accounts are untouched —\nthey were never inside the program to begin with. The flip side: if your new\ncode reads the old layout differently, nothing stops it. Nobody migrated\nanything, because nobody moved anything.\n\n## Reading an account\n\nEvery account, whoever owns it, has the same envelope:\n\n```text\nlamports    u64      balance in the base unit of SOL\nowner       Pubkey   the program allowed to write `data`\nexecutable  bool     is this account a program?\ndata        bytes    opaque to the runtime; meaningful only to `owner`\n```\n\n`data` is bytes. The runtime does not know or care what is in there — no types,\nno ABI, no storage layout. Interpreting those bytes is entirely your program's\njob, which is why Solana programs spend real effort on serialization in a way\nSolidity developers never have to think about.\n\nHold on to the envelope. `lamports` and `owner` come back in the next lesson, in\na way that has no EVM analogue at all: on Solana an account must hold a minimum\nlamport balance for its size before the runtime will let it exist at all. That\nbalance is a **refundable deposit**, not a meter — nothing is ever billed\nagainst it over time, and no account is erased for non-payment.\n"
+      },
+      {
+        "_key": "check",
+        "_type": "quiz",
+        "questions": [
+          {
+            "explanation": "Code and state are different accounts. The program is executable and immutable while running; state lives in accounts it owns, and each instruction receives exactly the ones it may touch.",
+            "id": "q1",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "In separate accounts your program owns, passed into each instruction"
+              },
+              {
+                "correct": false,
+                "feedback": "The program account is immutable at runtime — your own code cannot write to it. There is nowhere inside it to put a balance.",
+                "id": "b",
+                "label": "Inside the program account, after the executable bytes"
+              },
+              {
+                "correct": false,
+                "feedback": "There is no ambient storage on Solana. If an instruction did not receive an account, that account does not exist as far as the instruction is concerned.",
+                "id": "c",
+                "label": "In a runtime-provided storage map keyed by program id"
+              }
+            ],
+            "prompt": "You port a Solidity contract that keeps `mapping(address => uint256) balances` in its own storage. On Solana, where does that state live?"
+          },
+          {
+            "explanation": "\"Only the owner may write\" is verified by the runtime after your instruction returns, and an illegal change fails the transaction rather than reverting inside your code. This is why `owner` checks are the first thing an auditor looks for on accounts you merely *read* — the runtime protects your writes, not your assumptions about someone else's data.",
+            "id": "q2",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "The runtime rejects the transaction — a program may only write to accounts it owns"
+              },
+              {
+                "correct": false,
+                "feedback": "Ownership governs writes. It is the core protection of the account model, not a bookkeeping field.",
+                "id": "b",
+                "label": "The write succeeds; ownership only governs who may close the account"
+              },
+              {
+                "correct": false,
+                "feedback": "Closer than it looks — the store does land in the buffer — but it is not ignored. The runtime compares the account after your instruction returns and fails the whole transaction, discarding every effect.",
+                "id": "c",
+                "label": "It compiles and silently no-ops, so you must check the owner yourself"
+              }
+            ],
+            "prompt": "Your program is passed an account owned by a different program, and it writes to it. Predict."
+          },
+          {
+            "explanation": "Because code and state were never welded together, replacing the code leaves the state exactly where it was. The hazard inverts too: no proxy gymnastics, but also nothing stopping new code from misreading an old layout.",
+            "id": "q3",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "State accounts are untouched, because they were never inside the program"
+              },
+              {
+                "correct": false,
+                "feedback": "Nothing migrates anything. The runtime has no idea what your `data` bytes mean — that interpretation lives only in your program.",
+                "id": "b",
+                "label": "State is automatically migrated to the new layout by the runtime"
+              },
+              {
+                "correct": false,
+                "feedback": "A program account can be upgraded by its upgrade authority (or made truly immutable by revoking it). \"Immutable at runtime\" means the program cannot write to *itself* while executing.",
+                "id": "c",
+                "label": "Upgrades are impossible; programs are immutable once deployed"
+              }
+            ],
+            "prompt": "Compared with upgrading a Solidity contract behind a proxy, what is different about upgrading a Solana program?"
+          }
+        ]
+      }
+    ],
+    "skills": [
+      "account-model",
+      "solana-fundamentals"
+    ],
+    "slug": {
+      "_type": "slug",
+      "current": "storage-to-accounts"
+    },
+    "title": "Your Program Owns No Storage"
+  },
+  {
+    "_id": "lesson-sfe-what-changes",
+    "_type": "lesson",
+    "blocks": [
+      {
+        "_key": "intro",
+        "_type": "prose",
+        "src": "# What actually changed\n\nYou arrived able to build on the EVM. Nine lessons later, here is the whole\ntranslation table in one place — and, more usefully, the parts that do not\ntranslate.\n\n## The table\n\n| EVM | Solana |\n| --- | --- |\n| Contract storage | Separate accounts the program owns |\n| `SSTORE`, paid once | Rent, a refundable deposit sized in bytes |\n| `mapping(k => v)` | A PDA derived from seeds, computable off-chain |\n| `msg.sender` | An account list with verified `is_signer` flags |\n| `tx.origin` | No equivalent; signer status propagates explicitly |\n| Gas | Compute units (work) plus priority fees (ordering), priced apart |\n| Implicit storage access | An account list declared before execution |\n| One ERC-20 contract per token | One shared token program; a mint is data |\n| `approve` / `allowance` | A `delegate` field on the token account |\n| External call | CPI, with signer propagation and explicit accounts |\n\n## The three that are not translations\n\n**Sizing is a design decision.** No EVM habit prepares you for declaring byte\ncounts up front. It surfaces early — usually as an account too small for what you\nwanted to store — and it shapes schemas more than anything else in the model.\n\n**Authority can come from derivation.** A PDA has no private key. A program signs\nfor it by producing seeds. There is no Solidity analogue, because in the EVM\n\"being the contract\" is the only authority a contract has over its own storage.\nOnce this lands, a lot of Solana design stops looking arbitrary.\n\n**The account list is a public interface.** Anyone can read what a transaction\ntouches without executing it. That is why parallel execution is possible, why\nwallets can simulate meaningfully, and why some patterns you would reach for —\ndiscovering state mid-execution — are simply unavailable.\n\n## What did not change\n\nChecked arithmetic still matters, and Rust's `checked_add` is your `SafeMath`\nwith better ergonomics. Access control is still the bug class that drains\nprotocols; it just moves from a missing `onlyOwner` to a missing \"is this signer\nthe owner my state names\". Upgrade authority is as sensitive as a proxy admin\nkey. Integrating unknown code is still where the risk lives.\n\nThe security instincts you already have are the ones worth keeping. It is the\nstorage instincts that need rebuilding.\n\n## Where to go next\n\nThe natural sequel is a Rust course, then the account-validation layer Anchor\ngives you — `#[derive(Accounts)]` is where every idea in module 1 becomes a\nconstraint the compiler checks for you. If you would rather stay on the client\nside, the SDK path covers building transactions, deriving PDAs from TypeScript,\nand simulating before you send.\n"
+      },
+      {
+        "_key": "check",
+        "_type": "quiz",
+        "questions": [
+          {
+            "explanation": "The security instincts survive the move; the storage-cost instincts do not. Keep the paranoia about who is authorized and about overflow, and rebuild the intuitions about what state costs.",
+            "id": "q1",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "Access control is the dominant bug class, and checked arithmetic is not optional"
+              },
+              {
+                "correct": false,
+                "feedback": "That is an `SSTORE` instinct. Solana's recurring cost is rent for space; compute inside your budget is close to free, so the optimization target moves.",
+                "id": "b",
+                "label": "Minimize writes above all, because storage writes dominate cost"
+              },
+              {
+                "correct": false,
+                "feedback": "A convention that does not hold here. USDC is 6, wrapped SOL is 9, many NFTs are 0 — read `decimals` from the mint.",
+                "id": "c",
+                "label": "Assume 18 decimals unless told otherwise"
+              }
+            ],
+            "prompt": "Which EVM instinct transfers to Solana essentially unchanged?"
+          },
+          {
+            "explanation": "The declared account list comes first; parallel scheduling is what that declaration makes possible. Nearly every ergonomic friction in this course pays for that one property.",
+            "id": "q2",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "Parallelism is a consequence of declaring accounts up front, not a feature added on top"
+              },
+              {
+                "correct": false,
+                "feedback": "The account model, PDAs and the shared token program are structural differences, not throughput tuning.",
+                "id": "b",
+                "label": "The models are the same; Solana is only faster hardware and bigger blocks"
+              },
+              {
+                "correct": false,
+                "feedback": "The expressive gaps are narrow. What changes is where state lives and how authority is proven, not what can be built.",
+                "id": "c",
+                "label": "Solana cannot express what the EVM can, so it trades capability for speed"
+              }
+            ],
+            "prompt": "A colleague says \"Solana is just Ethereum with parallel execution bolted on\". What is the most accurate correction?"
+          }
+        ]
+      },
+      {
+        "_key": "reflect",
+        "_type": "openEnded",
+        "maxWords": 180,
+        "prompt": "Pick one system you have built on the EVM. Which single part of it would change most under the account model — and would it come out simpler or more complicated? Be specific about the state."
+      }
+    ],
+    "skills": [
+      "solana-fundamentals",
+      "account-model"
+    ],
+    "slug": {
+      "_type": "slug",
+      "current": "what-changes"
+    },
+    "title": "What Actually Changed"
+  },
+  {
+    "_id": "lesson-sfwd-accounts-are-just-bytes",
+    "_type": "lesson",
+    "blocks": [
+      {
+        "_key": "intro",
+        "_type": "prose",
+        "src": "# Accounts Are Just Bytes\n\n> Version stamp — `@solana/kit` 7.0.0 · devnet · authored 2026-07-28.\n\nYesterday you read the vault in an explorer. Today you become the explorer: fetch the account over RPC and turn its 49 raw bytes into `{ owner, balance, bump }` yourself.\n\n## Fetching the bytes\n\nIn Kit, an RPC client is one function call, and a read is a request you build and then `.send()`:\n\n```ts\nimport { createSolanaRpc, address } from \"@solana/kit\";\n\nconst rpc = createSolanaRpc(\"https://api.devnet.solana.com\");\nconst vault = address(\"FY86s1fAwUiFQTjVFYprsiV6fwNH7e955MSUBo73FP4j\");\n\nconst { value } = await rpc\n  .getAccountInfo(vault, { encoding: \"base64\" })\n  .send();\n// value.data[0] is the base64 string; decode it and you hold 49 bytes.\n```\n\nThat is the whole read path. What comes back is not JSON, not an object, not a struct — a base64 string that decodes to 49 bytes. The chain stores bytes; **meaning is a layout you have to know**.\n\n## The layout\n\nThis vault program documents its account layout (and in Course 2 you will write the Rust struct that produces it):\n\n| offset | length | field | encoding |\n|---|---|---|---|\n| 0 | 8 | discriminator | fixed bytes `[228, 196, 82, 165, 98, 210, 235, 152]` |\n| 8 | 32 | owner | raw public key, base58-encoded for display |\n| 40 | 8 | balance | unsigned 64-bit integer, **little-endian** |\n| 48 | 1 | bump | single byte |\n\n- The **discriminator** is an 8-byte type tag stamped at offset 0 of every account this program family creates — it answers \"are these bytes actually a VaultState?\" before you read another field. In module 3 your inspector checks it before decoding anything.\n- The **owner** field is the human answer lesson 1 promised: the wallet that controls this vault, stored as 32 raw bytes.\n- The **balance** is the vault's own accounting of what its owner deposited — distinct from the account's lamports, which also carry the rent deposit.\n- The **bump** you will understand in the next lesson. For today: one byte at the end.\n\n## Little-endian, felt once\n\n`balance` is a u64 stored least-significant byte first. A `DataView` reads it in one call — the `true` is \"little-endian\", and forgetting it is the classic bug:\n\n```ts\nconst view = new DataView(data.buffer, data.byteOffset, data.byteLength);\nconst balance = view.getBigUint64(40, true); // true = little-endian\n```\n\nNote the type: **`BigInt`, not `Number`**. Lamport amounts are u64, and `Number` silently loses integer precision above 2^53 — real mainnet balances cross that line. Every lamport value in this course is a `bigint`.\n\n## The production form\n\nDecoding by hand teaches you what the bytes are. In production code you declare the layout once with Kit's codecs and get the whole struct back:\n\n```ts\nimport {\n  getStructDecoder,\n  getU64Decoder,\n  getU8Decoder,\n  getAddressDecoder,\n  getBytesDecoder,\n  fixDecoderSize,\n} from \"@solana/kit\";\n\nconst vaultDecoder = getStructDecoder([\n  [\"discriminator\", fixDecoderSize(getBytesDecoder(), 8)],\n  [\"owner\", getAddressDecoder()],\n  [\"balance\", getU64Decoder()],\n  [\"bump\", getU8Decoder()],\n]);\n\nconst state = vaultDecoder.decode(data); // { discriminator, owner, balance, bump }\n```\n\nSame 49 bytes, same offsets, same little-endian u64 — the codec just says it declaratively. Use codecs in real code; decode by hand today so the codec is never magic.\n\n## The exercise\n\nThe grader has no network, so the harness hands your function **bytes recorded from the real devnet account** — the exact 49 bytes you can re-fetch yourself with the snippet above. Write `decodeVault(data)` in four labeled subgoals; a real base58 helper is provided for the owner field. One of the test fixtures is a *different* vault with a different owner, balance, and bump — so decode the bytes in front of you, don't transcribe the explorer.\n"
+      },
+      {
+        "_key": "decode",
+        "_type": "code",
+        "buildType": "standard",
+        "deployable": false,
+        "hints": [
+          "Subgoal 2: `toBase58(data.slice(8, 40))` — slice end is exclusive, so 40 means \"up to and including byte 39\".",
+          "Subgoal 3: `view.getBigUint64(40, true)` — the `true` is little-endian, and the return type is already `bigint`.",
+          "Subgoal 4: `view.getUint8(48)` (or `data[48]`) — one byte, a plain number."
+        ],
+        "language": "typescript",
+        "solution": "// ─────────────────────────────────────────────────────────────────────────────\n// TEST HARNESS — do not edit. Grading calls runCase with a fixture name and\n// hands your decodeVault the pinned bytes of that fixture (the grader has no\n// network). Provenance of each fixture is stated where it is defined below.\n// ─────────────────────────────────────────────────────────────────────────────\nfunction runCase(fixtureName: string) {\n  const bytes = FIXTURES[fixtureName];\n  if (!bytes) throw new Error(\"unknown fixture: \" + fixtureName);\n  return decodeVault(new Uint8Array(bytes));\n}\n\n/**\n * Decode a 49-byte VaultState account.\n *\n * Layout (from the lesson):\n *   offset 0,  8 bytes  — discriminator (already checked by the caller here)\n *   offset 8,  32 bytes — owner, a raw public key; display form is base58\n *   offset 40, 8 bytes  — balance, u64 LITTLE-endian\n *   offset 48, 1 byte   — bump\n */\nfunction decodeVault(data: Uint8Array): {\n  owner: string;\n  balance: bigint;\n  bump: number;\n} {\n  // Subgoal 1 (done for you) — a DataView over exactly these bytes.\n  // data.byteOffset/byteLength matter: a Uint8Array can be a window into a\n  // larger buffer, and the view must cover the same window.\n  const view = new DataView(data.buffer, data.byteOffset, data.byteLength);\n\n  // Subgoal 2 — owner: slice the 32 bytes at offsets 8..39 and base58-encode\n  // them with the provided toBase58 helper.\n  const owner = toBase58(data.slice(8, 40));\n\n  // Subgoal 3 — balance: the unsigned 64-bit little-endian integer at\n  // offset 40. Use the view; keep it a bigint.\n  const balance = view.getBigUint64(40, true);\n\n  // Subgoal 4 — bump: the single byte at offset 48.\n  const bump = view.getUint8(48);\n\n  return { owner, balance, bump };\n}\n\n// ── PROVIDED — a real base58 encoder (the display encoding of public keys) ──\nconst BASE58_ALPHABET =\n  \"123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz\";\nfunction toBase58(bytes: Uint8Array): string {\n  let n = 0n;\n  for (const b of bytes) n = n * 256n + BigInt(b);\n  let out = \"\";\n  while (n > 0n) {\n    out = BASE58_ALPHABET[Number(n % 58n)] + out;\n    n /= 58n;\n  }\n  // Leading zero bytes encode as leading '1's.\n  for (const b of bytes) {\n    if (b !== 0) break;\n    out = \"1\" + out;\n  }\n  return out;\n}\n\n// ── PINNED FIXTURES ─────────────────────────────────────────────────────────\n// \"reference-vault\" is FY86s1fAwUiFQTjVFYprsiV6fwNH7e955MSUBo73FP4j — real\n// bytes captured over devnet RPC on 2026-07-28 (the balance field is as\n// recorded at capture time; the live value keeps moving, which is exactly why\n// the bytes are pinned here — re-fetch them yourself with the lesson snippet).\n// \"second-vault\" is constructed byte-for-byte to the frozen VaultState layout\n// for a real derived PDA of a different owner — different owner, different\n// balance, different bump; same 49-byte layout, which is all your decoder may\n// rely on.\nconst FIXTURES: Record<string, number[]> = {\n  \"reference-vault\": [\n    228, 196, 82, 165, 98, 210, 235, 152, 78, 181, 115, 75, 97, 15, 248, 39,\n    115, 50, 94, 194, 229, 144, 50, 163, 140, 21, 194, 79, 145, 31, 240, 203,\n    132, 30, 178, 177, 89, 213, 11, 199, 0, 225, 245, 5, 0, 0, 0, 0, 255,\n  ],\n  \"second-vault\": [\n    228, 196, 82, 165, 98, 210, 235, 152, 250, 81, 168, 175, 243, 7, 13, 139,\n    135, 233, 111, 129, 165, 52, 141, 25, 59, 70, 254, 154, 56, 95, 224, 164,\n    40, 67, 110, 98, 15, 29, 43, 19, 160, 37, 38, 0, 0, 0, 0, 0, 252,\n  ],\n};\n",
+        "starter": "// ─────────────────────────────────────────────────────────────────────────────\n// TEST HARNESS — do not edit. Grading calls runCase with a fixture name and\n// hands your decodeVault the pinned bytes of that fixture (the grader has no\n// network). Provenance of each fixture is stated where it is defined below.\n// ─────────────────────────────────────────────────────────────────────────────\nfunction runCase(fixtureName: string) {\n  const bytes = FIXTURES[fixtureName];\n  if (!bytes) throw new Error(\"unknown fixture: \" + fixtureName);\n  return decodeVault(new Uint8Array(bytes));\n}\n\n/**\n * Decode a 49-byte VaultState account.\n *\n * Layout (from the lesson):\n *   offset 0,  8 bytes  — discriminator (already checked by the caller here)\n *   offset 8,  32 bytes — owner, a raw public key; display form is base58\n *   offset 40, 8 bytes  — balance, u64 LITTLE-endian\n *   offset 48, 1 byte   — bump\n */\nfunction decodeVault(data: Uint8Array): {\n  owner: string;\n  balance: bigint;\n  bump: number;\n} {\n  // Subgoal 1 (done for you) — a DataView over exactly these bytes.\n  // data.byteOffset/byteLength matter: a Uint8Array can be a window into a\n  // larger buffer, and the view must cover the same window.\n  const view = new DataView(data.buffer, data.byteOffset, data.byteLength);\n\n  // Subgoal 2 — owner: slice the 32 bytes at offsets 8..39 and base58-encode\n  // them with the provided toBase58 helper.\n  const owner = \"\"; // ← replace\n\n  // Subgoal 3 — balance: the unsigned 64-bit little-endian integer at\n  // offset 40. Use the view; keep it a bigint.\n  const balance = 0n; // ← replace\n\n  // Subgoal 4 — bump: the single byte at offset 48.\n  const bump = -1; // ← replace\n\n  return { owner, balance, bump };\n}\n\n// ── PROVIDED — a real base58 encoder (the display encoding of public keys) ──\nconst BASE58_ALPHABET =\n  \"123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz\";\nfunction toBase58(bytes: Uint8Array): string {\n  let n = 0n;\n  for (const b of bytes) n = n * 256n + BigInt(b);\n  let out = \"\";\n  while (n > 0n) {\n    out = BASE58_ALPHABET[Number(n % 58n)] + out;\n    n /= 58n;\n  }\n  // Leading zero bytes encode as leading '1's.\n  for (const b of bytes) {\n    if (b !== 0) break;\n    out = \"1\" + out;\n  }\n  return out;\n}\n\n// ── PINNED FIXTURES ─────────────────────────────────────────────────────────\n// \"reference-vault\" is FY86s1fAwUiFQTjVFYprsiV6fwNH7e955MSUBo73FP4j — real\n// bytes captured over devnet RPC on 2026-07-28 (the balance field is as\n// recorded at capture time; the live value keeps moving, which is exactly why\n// the bytes are pinned here — re-fetch them yourself with the lesson snippet).\n// \"second-vault\" is constructed byte-for-byte to the frozen VaultState layout\n// for a real derived PDA of a different owner — different owner, different\n// balance, different bump; same 49-byte layout, which is all your decoder may\n// rely on.\nconst FIXTURES: Record<string, number[]> = {\n  \"reference-vault\": [\n    228, 196, 82, 165, 98, 210, 235, 152, 78, 181, 115, 75, 97, 15, 248, 39,\n    115, 50, 94, 194, 229, 144, 50, 163, 140, 21, 194, 79, 145, 31, 240, 203,\n    132, 30, 178, 177, 89, 213, 11, 199, 0, 225, 245, 5, 0, 0, 0, 0, 255,\n  ],\n  \"second-vault\": [\n    228, 196, 82, 165, 98, 210, 235, 152, 250, 81, 168, 175, 243, 7, 13, 139,\n    135, 233, 111, 129, 165, 52, 141, 25, 59, 70, 254, 154, 56, 95, 224, 164,\n    40, 67, 110, 98, 15, 29, 43, 19, 160, 37, 38, 0, 0, 0, 0, 0, 252,\n  ],\n};\n",
+        "tests": [
+          {
+            "description": "Subgoal 2: the reference vault's owner decodes to the wallet you saw in lesson 1",
+            "expectedOutput": "result.owner === '6JFH1dxqiw6Dc81CbWdx4TUT8CvAfgwZg33wQrSytZsU'",
+            "failureMessage": "Slice exactly bytes 8 through 39 (data.slice(8, 40)) and pass the slice to toBase58 — off-by-one on either end changes every character of the address.",
+            "id": "t1",
+            "input": "'reference-vault'"
+          },
+          {
+            "description": "Subgoal 3: the balance reads as a little-endian u64 bigint",
+            "expectedOutput": "result.balance === 100000000n",
+            "failureMessage": "getBigUint64(40, true) — the second argument must be true for little-endian. A big-endian read of these same bytes gives a 17-digit number.",
+            "id": "t2",
+            "input": "'reference-vault'"
+          },
+          {
+            "description": "Subgoal 4: the bump is the last byte",
+            "expectedOutput": "result.bump === 255",
+            "id": "t3",
+            "input": "'reference-vault'"
+          },
+          {
+            "description": "Anti-hardcode: a different vault instance decodes to ITS owner, not the reference one",
+            "expectedOutput": "result.owner === 'Hr99MUHbQksoGpkSagrhqzvTgCo1BVEHjnACTSsaEJh8'",
+            "failureMessage": "Decode the bytes you were handed. If this returns the 6JFH… owner, the function is transcribing the explorer instead of reading data.",
+            "id": "t4",
+            "input": "'second-vault'"
+          },
+          {
+            "description": "Anti-hardcode: the second vault's balance and bump come from its bytes",
+            "expectedOutput": "result.balance === 2500000n && result.bump === 252",
+            "id": "t5",
+            "input": "'second-vault'"
+          }
+        ],
+        "tutorNotes": [
+          "Learners pass `false` (or nothing) as getBigUint64's second argument and read the balance big-endian — the result is a huge 17-plus-digit number instead of 100000000n. The fix is the endianness flag, not the offset.",
+          "They slice the owner as data.slice(8, 39) reasoning 'bytes 8 to 39', but slice's end is exclusive — 31 bytes instead of 32, and every character of the base58 output changes. The correct call is slice(8, 40).",
+          "They convert the balance with Number() to 'make it easier to compare', which passes here but is the exact 2^53 precision bug the lesson warns about — keep it bigint; the tests compare against 100000000n with the n suffix.",
+          "They hardcode the reference vault's owner/balance/bump from the explorer or from t1–t3 and fail t4/t5, which decode a second vault with different bytes. Point them at the fixture actually passed in, not the values they remember.",
+          "They build the DataView as new DataView(data.buffer) without byteOffset/byteLength. It works on these fixtures (the array owns its whole buffer) but is a latent bug worth naming if they ask why the harness passes both.",
+          "If they ask why base58 and not hex: base58 is the display convention for Solana addresses (no 0/O/I/l ambiguity); the chain stores the raw 32 bytes and never the string."
+        ]
+      },
+      {
+        "_key": "predict",
+        "_type": "quiz",
+        "questions": [
+          {
+            "explanation": "Little-endian stores the least significant byte first. Reading LE bytes as BE reverses their significance and yields a wildly different value with no error — the bug announces itself only through a nonsense balance.",
+            "id": "q1",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "Produce a completely different, astronomically large number — the byte order is reversed, so 100,000,000 becomes about 6.3 × 10^16"
+              },
+              {
+                "correct": false,
+                "feedback": "Endianness is byte order, and it applies to every multi-byte integer, signed or not. Reading these eight bytes big-endian treats the 0 as the most significant byte and the value explodes.",
+                "id": "b",
+                "label": "Produce the same value — endianness only matters for signed integers"
+              },
+              {
+                "correct": false,
+                "feedback": "Bytes carry no self-describing order; DataView reads whatever you ask, silently. That silence is why the little-endian flag is the classic decode bug — nothing fails, the number is just wrong.",
+                "id": "c",
+                "label": "Throw an error — DataView validates the byte order against the account"
+              }
+            ],
+            "prompt": "The balance bytes at offset 40 are [0, 225, 245, 5, 0, 0, 0, 0]. Predict what a big-endian read would do to the decoded value."
+          },
+          {
+            "explanation": "A layout decode has no built-in validation — any 49 bytes produce an owner, a balance, and a bump. The 8-byte discriminator is the type check, and module 3's inspector refuses to decode unless it matches.",
+            "id": "q2",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "Garbage that looks plausible — the decode succeeds mechanically, which is exactly why the discriminator must be checked before decoding"
+              },
+              {
+                "correct": false,
+                "feedback": "Nothing fails: any 49 bytes slice into 32 + 8 + 1 just fine, and you get a well-formed wrong answer. The discriminator check is the only thing standing between your inspector and confidently misreading a foreign account.",
+                "id": "b",
+                "label": "An exception — the byte reads fail on non-vault data"
+              },
+              {
+                "correct": false,
+                "feedback": "There are no defaults in a byte read. The decoder returns whatever the foreign bytes happen to contain at those offsets — plausible-looking and wrong, which is worse than an error.",
+                "id": "c",
+                "label": "All-zero fields — unrecognized accounts decode to defaults"
+              }
+            ],
+            "prompt": "Your inspector later fetches an account that is 49 bytes long but its first 8 bytes are not [228, 196, 82, 165, 98, 210, 235, 152]. Predict what decodeVault on those bytes would give you."
+          },
+          {
+            "explanation": "Lamports are the account's actual funds: rent deposit plus deposits. The balance field is state the program maintains — its own record of what was deposited. Keeping program state and raw lamports straight matters in module 2, when your deposit moves both.",
+            "id": "q3",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "The account's lamports run higher than the balance field — they also carry the rent-exemption deposit"
+              },
+              {
+                "correct": false,
+                "feedback": "Close, but no: the lamports include the ~0.0012 SOL rent-exemption deposit the vault must hold for its 49 bytes, on top of what depositors put in. The balance field is the program's own ledger of deposits alone.",
+                "id": "b",
+                "label": "They are the same number read two ways"
+              },
+              {
+                "correct": false,
+                "feedback": "Both are lamports — everything on-chain is. 100,000,000 lamports is 0.1 SOL. The difference between the two numbers is what the account must hold for rent, not the unit.",
+                "id": "c",
+                "label": "The balance field is denominated in SOL, the lamports in lamports"
+              }
+            ],
+            "prompt": "Lesson 1 showed the ACCOUNT's lamports; today you decoded a `balance` FIELD of 100,000,000 (recorded). Predict how the two relate on the live account."
+          },
+          {
+            "explanation": "A u64's range exceeds Number's exact-integer range (2^53). Convert a large balance to Number and it silently rounds — no error, wrong money. bigint is exact across the whole u64 range, so every lamport value in this course keeps the n.",
+            "id": "q4",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "Balances are u64 and Number silently loses integer precision above 2^53 — real balances cross that line"
+              },
+              {
+                "correct": false,
+                "feedback": "It is usually slower. The reason is correctness: a u64 can hold values up to about 1.8 × 10^19, and Number is only exact to 2^53 ≈ 9 × 10^15. Above that, amounts silently round.",
+                "id": "b",
+                "label": "bigint arithmetic is faster"
+              },
+              {
+                "correct": false,
+                "feedback": "The RPC serializes fine either way — that is what makes the bug dangerous. Nothing errors; large amounts just quietly change in your own arithmetic. bigint keeps every lamport exact.",
+                "id": "c",
+                "label": "The RPC rejects requests containing plain numbers"
+              }
+            ],
+            "prompt": "Why does this course insist the balance stays a bigint instead of a JavaScript number?"
+          }
+        ]
+      }
+    ],
+    "skills": [
+      "solana-kit",
+      "rpc",
+      "account-model",
+      "borsh-serialization"
+    ],
+    "slug": {
+      "_type": "slug",
+      "current": "accounts-are-just-bytes"
+    },
+    "title": "Accounts Are Just Bytes"
+  },
+  {
+    "_id": "lesson-sfwd-anatomy-of-a-transaction",
+    "_type": "lesson",
+    "blocks": [
+      {
+        "_key": "intro",
+        "_type": "prose",
+        "src": "# Anatomy of a Transaction\n\n> Version stamp — `@solana/kit` 7.0.0 · devnet · authored 2026-07-28.\n\nYou have only read the chain. Writing to it takes a **transaction** — and before you send your first one in lesson 6, you are going to take a complete one apart and predict, to the lamport, what it costs.\n\n## A complete Kit transaction, end to end\n\nThis is the whole pipeline for a v0 transaction — a SOL transfer, built with `pipe` (Kit's left-to-right function composition):\n\n```ts\nimport {\n  createSolanaRpc,\n  generateKeyPairSigner,\n  createTransactionMessage,\n  setTransactionMessageFeePayerSigner,\n  setTransactionMessageLifetimeUsingBlockhash,\n  appendTransactionMessageInstructions,\n  signTransactionMessageWithSigners,\n  getBase64EncodedWireTransaction,\n  pipe,\n} from \"@solana/kit\";\nimport { getTransferSolInstruction } from \"@solana-program/system\";\n\nconst rpc = createSolanaRpc(\"https://api.devnet.solana.com\");\nconst signer = await generateKeyPairSigner();\nconst { value: latestBlockhash } = await rpc.getLatestBlockhash().send();\n\nconst message = pipe(\n  createTransactionMessage({ version: 0 }),\n  (m) => setTransactionMessageFeePayerSigner(signer, m),\n  (m) => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, m),\n  (m) =>\n    appendTransactionMessageInstructions(\n      [getTransferSolInstruction({ source: signer, destination, amount: 1_000_000n })],\n      m\n    )\n);\n\nconst signed = await signTransactionMessageWithSigners(message);\nconst wire = getBase64EncodedWireTransaction(signed);\nconst sim = await rpc.simulateTransaction(wire, { encoding: \"base64\" }).send();\n```\n\nRead it as four declarations, not four steps of ceremony:\n\n1. **Version** — `{ version: 0 }`. Say \"**v0 transactions**\", not \"the only version\": Kit also has v1 messages, with a different fee surface (`setTransactionMessagePriorityFeeLamports`, a total in lamports). Everything below — the `price × CU` arithmetic included — is **v0-specific**, and v0 is what this course and the current ecosystem run on.\n2. **Fee payer** — the signer whose lamports pay for this transaction.\n3. **Lifetime** — a recent blockhash. The network accepts the transaction only while that blockhash is recent (about a minute); after that it can never land, which is what makes retries safe.\n4. **Instructions** — the actual work, appended last.\n\nThen sign, encode, and — before ever sending — **simulate**. Simulation runs the transaction against current state without landing it and reports `unitsConsumed`: how much compute it actually used. We ran exactly this simulation against the reference vault's `deposit` on 2026-07-28 and recorded **6,697 compute units** (a bare SOL transfer: 150).\n\n## What it costs — the exact formula\n\nA v0 transaction's fee has two parts:\n\n```\nfee = 5000 lamports × signatures                    ← base fee (50% burned)\n    + priorityFeeMicroLamportsPerCU × requestedCUlimit ÷ 1,000,000   ← priority fee\n```\n\nThe word that costs people real money is **requested**. The priority fee is charged on the compute-unit limit your transaction *asks for* — not on what it consumes. And if you don't ask, each non-builtin instruction requests the **default 200,000 CU** (clamped at 1,400,000 per transaction). A deposit that consumes 6,697 CU but requests 200,000 pays the priority rate on all 200,000.\n\nThat is why the professional habit is **simulate, then tighten**: request `unitsConsumed` plus ~10% margin (compute varies slightly run to run; a limit set exactly at one observed value occasionally fails with an exceeded-CU error).\n\nYou request a limit (and a price) with two extra instructions from `@solana-program/compute-budget`: `getSetComputeUnitLimitInstruction({ units })` and `getSetComputeUnitPriceInstruction({ microLamports })`. Two honest footnotes on those:\n\n- Putting the compute-budget instructions **first is a convention, not a protocol rule**. The runtime finds them anywhere in the transaction. The real constraints are: at most one of each kind (a duplicate fails with `DuplicateInstruction`), and the 1,400,000-CU clamp.\n- For production estimation, Kit's current API family is `fillTransactionMessageProvisoryResourceLimits` at message construction, `estimateResourceLimitsFactory({ rpc })` to estimate, and `estimateAndSetResourceLimitsFactory(estimator)` to apply. The older compute-unit-named trio (`fillTransactionMessageProvisoryComputeUnitLimit`, `estimateComputeUnitLimitFactory`, `estimateAndSetComputeUnitLimitFactory`) is **deprecated** — you will see it in tutorials; don't build on it. Note the resource estimator returns `{ computeUnitLimit, loadedAccountsDataSizeLimit }` — an object, not a bare number.\n\n## The exercise\n\n`planBudget(sim, price)` is a **worked example with exactly one blank**. It takes a recorded simulation result and a priority-fee price and returns the full cost plan: the requested limit, the 5,000-lamport signature fee (one signer), the priority fee (rounded **up** — the network never rounds in your favor), and the total. Everything is written except one line: the requested limit, sized from `sim.unitsConsumed` plus a 10% margin, in integer bigint arithmetic (`consumed + consumed / 10n`).\n\nFill the blank, then run the quiz and predict the costs the way you now can: on paper, before anything runs.\n"
+      },
+      {
+        "_key": "budget",
+        "_type": "code",
+        "buildType": "standard",
+        "deployable": false,
+        "hints": [
+          "One line: `const computeUnitLimit = sim.unitsConsumed + sim.unitsConsumed / 10n;` — the simulated consumption plus a tenth of it, all bigint.",
+          "If t3 fails on the priority fee, check you did NOT change the provided rounding line — 1.65 lamports must charge as 2, never 1.",
+          "Keep every value bigint. Mixing in a Number (like `* 1.1`) throws a TypeError in bigint arithmetic — which is the guardrail working."
+        ],
+        "language": "typescript",
+        "solution": "// ─────────────────────────────────────────────────────────────────────────────\n// TEST HARNESS — do not edit. Grading calls runCase with the name of a\n// RECORDED simulation (run for real against devnet on 2026-07-28) and a\n// priority-fee price in micro-lamports per compute unit.\n// ─────────────────────────────────────────────────────────────────────────────\nfunction runCase(simName: string, microLamportsPerCu: bigint) {\n  const sim = SIMULATIONS[simName];\n  if (!sim) throw new Error(\"unknown simulation: \" + simName);\n  return planBudget(sim, microLamportsPerCu);\n}\n\n/**\n * WORKED EXAMPLE — complete except for ONE line.\n *\n * Given a simulation result and a priority-fee price, produce the full v0\n * cost plan:\n *   - computeUnitLimit — what the transaction will REQUEST: the simulated\n *     consumption plus a 10% margin (integer bigint math).\n *   - signatureFee     — 5,000 lamports per signature; this plan has one.\n *   - priorityFee      — price × requested limit ÷ 1,000,000, rounded UP.\n *   - totalFeeLamports — the sum.\n */\nfunction planBudget(\n  sim: { unitsConsumed: bigint },\n  microLamportsPerCu: bigint\n): {\n  computeUnitLimit: bigint;\n  signatureFee: bigint;\n  priorityFee: bigint;\n  totalFeeLamports: bigint;\n} {\n  // ── THE BLANK ──────────────────────────────────────────────────────────\n  // Size the requested limit from what simulation measured, plus a 10%\n  // margin: consumed + consumed / 10n. (Why request MORE than consumed?\n  // Compute varies slightly run to run. Why not just leave the default?\n  // Because the default is 200,000 and you pay the priority fee on it.)\n  const computeUnitLimit = sim.unitsConsumed + sim.unitsConsumed / 10n;\n\n  // One signer pays 5,000 lamports, fixed. (Half is burned.)\n  const signatureFee = 5_000n;\n\n  // The priority fee is charged on the REQUESTED limit, not on consumption.\n  // Micro-lamports → lamports is a ÷ 1,000,000, rounded up: the network\n  // never rounds in your favor.\n  const priorityFee =\n    (computeUnitLimit * microLamportsPerCu + 999_999n) / 1_000_000n;\n\n  const totalFeeLamports = signatureFee + priorityFee;\n  return { computeUnitLimit, signatureFee, priorityFee, totalFeeLamports };\n}\n\n// ── RECORDED SIMULATIONS — real devnet runs, 2026-07-28 ─────────────────────\n// \"vault-deposit\" is the reference vault's deposit instruction — the exact\n// transaction you assemble and send in lesson 6. \"sol-transfer\" is a bare\n// System Program transfer, for scale.\nconst SIMULATIONS: Record<string, { unitsConsumed: bigint }> = {\n  \"vault-deposit\": { unitsConsumed: 6_697n },\n  \"sol-transfer\": { unitsConsumed: 150n },\n};\n",
+        "starter": "// ─────────────────────────────────────────────────────────────────────────────\n// TEST HARNESS — do not edit. Grading calls runCase with the name of a\n// RECORDED simulation (run for real against devnet on 2026-07-28) and a\n// priority-fee price in micro-lamports per compute unit.\n// ─────────────────────────────────────────────────────────────────────────────\nfunction runCase(simName: string, microLamportsPerCu: bigint) {\n  const sim = SIMULATIONS[simName];\n  if (!sim) throw new Error(\"unknown simulation: \" + simName);\n  return planBudget(sim, microLamportsPerCu);\n}\n\n/**\n * WORKED EXAMPLE — complete except for ONE line.\n *\n * Given a simulation result and a priority-fee price, produce the full v0\n * cost plan:\n *   - computeUnitLimit — what the transaction will REQUEST: the simulated\n *     consumption plus a 10% margin (integer bigint math).\n *   - signatureFee     — 5,000 lamports per signature; this plan has one.\n *   - priorityFee      — price × requested limit ÷ 1,000,000, rounded UP.\n *   - totalFeeLamports — the sum.\n */\nfunction planBudget(\n  sim: { unitsConsumed: bigint },\n  microLamportsPerCu: bigint\n): {\n  computeUnitLimit: bigint;\n  signatureFee: bigint;\n  priorityFee: bigint;\n  totalFeeLamports: bigint;\n} {\n  // ── THE BLANK ──────────────────────────────────────────────────────────\n  // Size the requested limit from what simulation measured, plus a 10%\n  // margin: consumed + consumed / 10n. (Why request MORE than consumed?\n  // Compute varies slightly run to run. Why not just leave the default?\n  // Because the default is 200,000 and you pay the priority fee on it.)\n  const computeUnitLimit = 0n; // ← replace with the sized limit\n\n  // One signer pays 5,000 lamports, fixed. (Half is burned.)\n  const signatureFee = 5_000n;\n\n  // The priority fee is charged on the REQUESTED limit, not on consumption.\n  // Micro-lamports → lamports is a ÷ 1,000,000, rounded up: the network\n  // never rounds in your favor.\n  const priorityFee =\n    (computeUnitLimit * microLamportsPerCu + 999_999n) / 1_000_000n;\n\n  const totalFeeLamports = signatureFee + priorityFee;\n  return { computeUnitLimit, signatureFee, priorityFee, totalFeeLamports };\n}\n\n// ── RECORDED SIMULATIONS — real devnet runs, 2026-07-28 ─────────────────────\n// \"vault-deposit\" is the reference vault's deposit instruction — the exact\n// transaction you assemble and send in lesson 6. \"sol-transfer\" is a bare\n// System Program transfer, for scale.\nconst SIMULATIONS: Record<string, { unitsConsumed: bigint }> = {\n  \"vault-deposit\": { unitsConsumed: 6_697n },\n  \"sol-transfer\": { unitsConsumed: 150n },\n};\n",
+        "tests": [
+          {
+            "description": "The deposit's requested limit is its simulated 6,697 CU plus a 10% margin",
+            "expectedOutput": "result.computeUnitLimit === 7366n",
+            "failureMessage": "Integer bigint math: 6697n + 6697n / 10n = 6697 + 669 = 7366. No floats, no Math.round — bigint division already floors.",
+            "id": "t1",
+            "input": "'vault-deposit', 10000n"
+          },
+          {
+            "description": "At 10,000 micro-lamports/CU the deposit's priority fee rounds up to 74 lamports, total 5,074",
+            "expectedOutput": "result.priorityFee === 74n && result.totalFeeLamports === 5074n",
+            "id": "t2",
+            "input": "'vault-deposit', 10000n"
+          },
+          {
+            "description": "A bare transfer sizes to 165 CU and its priority fee still rounds UP (1.65 → 2 lamports)",
+            "expectedOutput": "result.computeUnitLimit === 165n && result.priorityFee === 2n && result.totalFeeLamports === 5002n",
+            "failureMessage": "150 + 150/10 = 165 requested CU; 165 × 10,000 = 1,650,000 micro-lamports = 1.65 lamports, and the network rounds against you: 2.",
+            "id": "t3",
+            "input": "'sol-transfer', 10000n"
+          },
+          {
+            "description": "With a zero priority price only the signature fee remains",
+            "expectedOutput": "result.priorityFee === 0n && result.totalFeeLamports === 5000n && result.signatureFee === 5000n",
+            "id": "t4",
+            "input": "'vault-deposit', 0n"
+          }
+        ],
+        "tutorNotes": [
+          "Learners write the margin as `sim.unitsConsumed * 1.1` and hit 'Cannot mix BigInt and other types'. The bigint form is consumed + consumed / 10n; the error is the precision guardrail from lesson 2, not a grader quirk.",
+          "They fill the blank with 200_000n 'because that is the default'. The default is the disease, not the cure — the whole plan exists to request LESS than 200,000. t1 expects 7366n.",
+          "They fill the blank with sim.unitsConsumed exactly, no margin, giving 6697n. Explain the margin's job: consumption varies slightly run to run, and a limit set at one observed value intermittently fails with exceeded-CU.",
+          "They 'fix' the provided priorityFee line to round down (plain division). t3 exists for this: 1.65 lamports charges as 2. The network rounds against the payer; the +999_999n before dividing is the ceiling.",
+          "They ask why signatureFee is fixed while priorityFee scales: the base fee is 5,000 lamports per signature regardless of work; the priority fee is the bid for compute, priced on the REQUESTED limit. Two different levers.",
+          "If they ask whether the compute-budget instructions must come first: no — that placement is convention. The real rules are one instruction per variant (DuplicateInstruction otherwise) and the 1,400,000-CU clamp."
+        ]
+      },
+      {
+        "_key": "predict",
+        "_type": "quiz",
+        "questions": [
+          {
+            "explanation": "Priority fee = price × requested limit ÷ 1e6, and an unset limit requests the 200,000-CU default. 200,000 × 10,000 ÷ 1e6 = 2,000 lamports, versus 74 with a simulate-and-tighten limit of 7,366 — same transaction, ~27× the priority fee.",
+            "id": "q1",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "2,000 lamports — the deposit requests the 200,000-CU default, and the fee is charged on that request, not on the 6,697 CU it consumes"
+              },
+              {
+                "correct": false,
+                "feedback": "That would be fair, and it is not what happens. The fee is charged on the REQUESTED limit, and with nothing requested, each non-builtin instruction defaults to 200,000 CU. You pay 200,000 × 10,000 ÷ 1e6 = 2,000 lamports — nearly 30× the consumption-based number.",
+                "id": "b",
+                "label": "About 67 lamports — 6,697 consumed × 10,000 ÷ 1,000,000"
+              },
+              {
+                "correct": false,
+                "feedback": "In this scenario a price applies; the question is what it multiplies. Answer: the requested limit, which defaulted to 200,000 CU. That gap between requested and consumed is the overpay this lesson teaches you to close.",
+                "id": "c",
+                "label": "Zero — priority fees only apply if you set a compute-unit price"
+              }
+            ],
+            "prompt": "You send the vault deposit with NO compute-budget instructions at a network moment when the effective price is 10,000 micro-lamports/CU. Predict the priority fee."
+          },
+          {
+            "explanation": "The real constraints on compute-budget instructions: one per variant (duplicates fail with DuplicateInstruction) and the 1,400,000-CU clamp. \"Put them first\" is style — worth following, but not what the runtime checks.",
+            "id": "q2",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "It fails with DuplicateInstruction — at most one of each compute-budget variant is allowed, wherever they sit"
+              },
+              {
+                "correct": false,
+                "feedback": "Placement is a convention, not a rule — the runtime finds compute-budget instructions anywhere. What it will not accept is two of the same kind: that is DuplicateInstruction, a hard failure.",
+                "id": "b",
+                "label": "The first one wins, because compute-budget instructions must come first"
+              },
+              {
+                "correct": false,
+                "feedback": "There is no merging of duplicates — the transaction fails outright with DuplicateInstruction. The 1,400,000 clamp applies to a single valid limit request, not to resolving two.",
+                "id": "c",
+                "label": "The larger limit wins, clamped to 1,400,000"
+              }
+            ],
+            "prompt": "A transaction carries TWO SetComputeUnitLimit instructions — one at the start, one at the end. Predict the outcome."
+          },
+          {
+            "explanation": "The blockhash lifetime bounds how long a signed transaction can land (~a minute). Expiry is what makes retries safe: an expired transaction can never sneak in later and double-spend your retry. Lesson 6 leans on exactly this when a wallet send goes stale.",
+            "id": "q3",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "The network refuses it — its blockhash lifetime (about a minute) has expired, so it can never land, and a retry needs a fresh blockhash and a re-sign"
+              },
+              {
+                "correct": false,
+                "feedback": "There is no surcharge tier — lifetime is binary. Past its blockhash window the transaction is simply invalid, which is a feature: you can safely rebuild and resend knowing the old one cannot also land.",
+                "id": "b",
+                "label": "It lands, but pays a staleness surcharge"
+              },
+              {
+                "correct": false,
+                "feedback": "Blockhashes never become recent again — the chain only moves forward. Expiry is permanent for that transaction, and the remedy is a new message with a fresh blockhash, re-signed.",
+                "id": "c",
+                "label": "It waits at the RPC until the blockhash becomes recent again"
+              }
+            ],
+            "prompt": "Your signed transaction sits in a queue for two minutes before sending. Predict what happens when it finally goes out."
+          },
+          {
+            "explanation": "Base fee = 5,000 lamports × signatures (half burned); priority fee = price × requested CU limit ÷ 1e6. Two independent terms — your lesson-6 deposit has one signer, so its floor is exactly 5,000.",
+            "id": "q4",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "10,000 lamports — the base fee is 5,000 per signature, and half of every base fee is burned"
+              },
+              {
+                "correct": false,
+                "feedback": "The base fee scales with signature count: 5,000 lamports each. One fee payer still pays it all, but two signatures cost 10,000 — which is why signature count is part of predicting cost.",
+                "id": "b",
+                "label": "Still 5,000 — the fee payer covers one flat fee per transaction"
+              },
+              {
+                "correct": false,
+                "feedback": "Signers do not add priority fee — that is priced purely on the requested compute limit. The extra signature adds another 5,000-lamport base fee, nothing more.",
+                "id": "c",
+                "label": "5,000 plus a priority fee for the extra signer"
+              }
+            ],
+            "prompt": "The plan's signature fee is 5,000 lamports for one signer. Add a second required signer to the same transaction and predict the base fee."
+          }
+        ]
+      }
+    ],
+    "skills": [
+      "transactions",
+      "solana-kit",
+      "transaction-fees",
+      "compute-budget"
+    ],
+    "slug": {
+      "_type": "slug",
+      "current": "anatomy-of-a-transaction"
+    },
+    "title": "Anatomy of a Transaction"
+  },
+  {
+    "_id": "lesson-sfwd-connect-fund-and-send",
+    "_type": "lesson",
+    "blocks": [
+      {
+        "_key": "intro",
+        "_type": "prose",
+        "src": "# Connect, Fund, and Send It\n\n> Version stamp — `@solana/kit` 7.0.0 · devnet · authored 2026-07-28.\n\nEverything so far was reading and rehearsal. Today: a real wallet, real devnet SOL, and a real deposit into the vault you have been decoding since lesson 1 — confirmed on-chain, with a signature you can hand anyone as proof.\n\n## Connecting: Wallet Standard, not wallet-adapter\n\nModern wallets (Phantom, Solflare, Backpack, …) implement **Wallet Standard** — a browser protocol in which the wallet announces itself to the page. Your app does not install a package per wallet; it *discovers* whatever the visitor already has:\n\n```ts\nimport { createClient } from \"@solana/kit\";\nimport { solanaDevnetRpc } from \"@solana/kit-plugin-rpc\";\nimport { walletSigner } from \"@solana/kit-plugin-wallet\";\n\nconst client = createClient()\n  // Wallet Standard discovery — no per-wallet adapters. The wallet signer is\n  // the client's payer, so this plugin comes FIRST; and the chain is a\n  // required part of its config — a connected account can refuse a chain it\n  // was not asked to sign for.\n  .use(walletSigner({ chain: \"solana:devnet\" }))\n  .use(solanaDevnetRpc());\n```\n\nIf a tutorial hands you `ConnectionProvider`, `WalletProvider`, or `PhantomWalletAdapter`, you are reading the legacy stack from lesson 5 — read it, don't copy it.\n\nWhen the wallet connects, your app gets an **account and a signer** — the wallet holds the private key and never gives it up. Your code's job is to *assemble* the transaction; the wallet's job is to *sign* it. That division is the whole security model, and it is why the exercise below builds everything **except** the signature.\n\n## Funding\n\nThe button below fetches devnet SOL to your connected wallet. Devnet SOL is free and worthless by design — it exists so you can do exactly this. The faucet rations amounts and can run dry at busy times; if it declines, wait a little and retry. What lands in your wallet funds today's deposit *and* stays with you: in Course 3, this same wallet pays your own program's deploy.\n\n## The deposit, precisely\n\nYou already know every ingredient:\n\n- **Which instruction**: the vault program's `deposit`, from lesson 1's IDL.\n- **Which accounts, in which order**: the IDL fixes it — **the vault PDA first**, then your wallet (writable, signer), then the System Program. The order is part of the program's interface: the program reads accounts by position, so a swapped order is not style, it is a different (failing) call.\n- **Which vault**: *your* wallet's vault, derived exactly as in lesson 3 — seeds `[\"vault\", yourAddress]`. First deposit? The program creates it — which is why the System Program is in the account list.\n- **What data**: 8 bytes of instruction discriminator — `[242, 35, 198, 137, 82, 225, 242, 182]`, the `deposit` tag from the IDL — followed by the amount as a **u64 little-endian**, the exact write-side of the read you did in lesson 2.\n- **What it costs**: you predicted it in lesson 4 — 5,000 lamports for your one signature, plus any priority fee on the *requested* limit.\n\nAmounts are **integer lamports as bigint**, always: `0.001 SOL` is `1_000_000n` lamports. No floats anywhere near money.\n\nThe graded exercise assembles this plan as a pure function in four labeled subgoals — the same shape Kit's `pipe` built in lesson 4, with the instruction now built byte by byte. The grader checks the account order the way the program would: vault first, or it fails.\n\nAfter it passes, read **Send, Watch, and Read the Failure** below, then send the real thing from the embedded runner: connect, fund, deposit. When the confirmation lands, open your transaction in the explorer (`?cluster=devnet`!) and look at the vault's balance move.\n"
+      },
+      {
+        "_key": "fund",
+        "_type": "wallet-funding",
+        "amount": 2,
+        "network": "devnet",
+        "produces": "funded-wallet"
+      },
+      {
+        "_key": "assemble",
+        "_type": "code",
+        "buildType": "standard",
+        "deployable": false,
+        "hints": [
+          "Subgoal 2: `const lifetimeBlockhash = blockhash;` — pass the argument through; a message with no lifetime is rejected on send.",
+          "Subgoal 3: three entries, in IDL order — `vaultFor(wallet)` as \"writable\", the wallet as \"writable-signer\", `SYSTEM_PROGRAM` as \"readonly\". Vault FIRST.",
+          "Subgoal 4: `[...DEPOSIT_DISCRIMINATOR, ...u64le(lamports)]` — tag first, then the amount's 8 little-endian bytes."
+        ],
+        "language": "typescript",
+        "solution": "/**\n * Assemble the deposit plan — four labeled subgoals.\n *\n * A pure function: the wallet's address, a recent blockhash, and an amount\n * in, a complete unsigned transaction plan out. The wallet signs it; your\n * code never touches a private key. Helpers and recorded constants are\n * provided BELOW the function — read them before you start.\n */\nfunction buildDepositPlan(\n  wallet: string,\n  blockhash: string,\n  lamports: bigint\n): {\n  feePayer: string;\n  lifetimeBlockhash: string;\n  instructions: {\n    programAddress: string;\n    accounts: { address: string; role: string }[];\n    data: number[];\n  }[];\n} {\n  // Subgoal 1 (done for you) — the connected wallet pays the fee.\n  const feePayer = wallet;\n\n  // Subgoal 2 — the transaction's lifetime is the given recent blockhash.\n  const lifetimeBlockhash = blockhash;\n\n  // Subgoal 3 — the account list, in the program's IDL order:\n  //   1. the wallet's vault PDA (use vaultFor(wallet)), role \"writable\"\n  //   2. the wallet itself,                      role \"writable-signer\"\n  //   3. SYSTEM_PROGRAM,                         role \"readonly\"\n  // The program reads accounts BY POSITION — the vault must be first.\n  const accounts: { address: string; role: string }[] = [\n    { address: vaultFor(wallet), role: \"writable\" },\n    { address: wallet, role: \"writable-signer\" },\n    { address: SYSTEM_PROGRAM, role: \"readonly\" },\n  ];\n\n  // Subgoal 4 — the instruction data: the 8-byte DEPOSIT_DISCRIMINATOR,\n  // then the amount as u64 little-endian (u64le(lamports) gives the 8\n  // bytes — the write-side of your lesson-2 read).\n  const data: number[] = [...DEPOSIT_DISCRIMINATOR, ...u64le(lamports)];\n\n  return {\n    feePayer,\n    lifetimeBlockhash,\n    instructions: [{ programAddress: VAULT_PROGRAM, accounts, data }],\n  };\n}\n\n// ── PROVIDED ────────────────────────────────────────────────────────────────\nconst VAULT_PROGRAM = \"D7ZFoWvEG5NBnkJy6iC98rhwj2qhgq8xhSD42cdTRAQd\";\nconst SYSTEM_PROGRAM = \"11111111111111111111111111111111\";\n// The `deposit` instruction's 8-byte tag, from the IDL you read in lesson 1.\nconst DEPOSIT_DISCRIMINATOR = [242, 35, 198, 137, 82, 225, 242, 182];\n\n/** The amount as 8 little-endian bytes — lesson 2's DataView, writing. */\nfunction u64le(value: bigint): number[] {\n  const bytes = new Uint8Array(8);\n  new DataView(bytes.buffer).setBigUint64(0, value, true);\n  return Array.from(bytes);\n}\n\n/**\n * The wallet's vault PDA — recorded real derivations (lesson 3's math;\n * captured 2026-07-28). In production this is\n * `await getProgramDerivedAddress({ programAddress, seeds })`.\n */\nfunction vaultFor(wallet: string): string {\n  const RECORDED: Record<string, string> = {\n    \"6JFH1dxqiw6Dc81CbWdx4TUT8CvAfgwZg33wQrSytZsU\":\n      \"FY86s1fAwUiFQTjVFYprsiV6fwNH7e955MSUBo73FP4j\",\n    Hr99MUHbQksoGpkSagrhqzvTgCo1BVEHjnACTSsaEJh8:\n      \"EMTqK9Cfac1X7c86GUYG5wwGkqR9HpeYkqUDvjLmhgKi\",\n  };\n  const vault = RECORDED[wallet];\n  if (!vault) throw new Error(\"no recorded vault derivation for \" + wallet);\n  return vault;\n}\n",
+        "starter": "/**\n * Assemble the deposit plan — four labeled subgoals.\n *\n * A pure function: the wallet's address, a recent blockhash, and an amount\n * in, a complete unsigned transaction plan out. The wallet signs it; your\n * code never touches a private key. Helpers and recorded constants are\n * provided BELOW the function — read them before you start.\n */\nfunction buildDepositPlan(\n  wallet: string,\n  blockhash: string,\n  lamports: bigint\n): {\n  feePayer: string;\n  lifetimeBlockhash: string;\n  instructions: {\n    programAddress: string;\n    accounts: { address: string; role: string }[];\n    data: number[];\n  }[];\n} {\n  // Subgoal 1 (done for you) — the connected wallet pays the fee.\n  const feePayer = wallet;\n\n  // Subgoal 2 — the transaction's lifetime is the given recent blockhash.\n  const lifetimeBlockhash = \"\"; // ← replace\n\n  // Subgoal 3 — the account list, in the program's IDL order:\n  //   1. the wallet's vault PDA (use vaultFor(wallet)), role \"writable\"\n  //   2. the wallet itself,                      role \"writable-signer\"\n  //   3. SYSTEM_PROGRAM,                         role \"readonly\"\n  // The program reads accounts BY POSITION — the vault must be first.\n  const accounts: { address: string; role: string }[] = []; // ← replace\n\n  // Subgoal 4 — the instruction data: the 8-byte DEPOSIT_DISCRIMINATOR,\n  // then the amount as u64 little-endian (u64le(lamports) gives the 8\n  // bytes — the write-side of your lesson-2 read).\n  const data: number[] = []; // ← replace\n\n  return {\n    feePayer,\n    lifetimeBlockhash,\n    instructions: [{ programAddress: VAULT_PROGRAM, accounts, data }],\n  };\n}\n\n// ── PROVIDED ────────────────────────────────────────────────────────────────\nconst VAULT_PROGRAM = \"D7ZFoWvEG5NBnkJy6iC98rhwj2qhgq8xhSD42cdTRAQd\";\nconst SYSTEM_PROGRAM = \"11111111111111111111111111111111\";\n// The `deposit` instruction's 8-byte tag, from the IDL you read in lesson 1.\nconst DEPOSIT_DISCRIMINATOR = [242, 35, 198, 137, 82, 225, 242, 182];\n\n/** The amount as 8 little-endian bytes — lesson 2's DataView, writing. */\nfunction u64le(value: bigint): number[] {\n  const bytes = new Uint8Array(8);\n  new DataView(bytes.buffer).setBigUint64(0, value, true);\n  return Array.from(bytes);\n}\n\n/**\n * The wallet's vault PDA — recorded real derivations (lesson 3's math;\n * captured 2026-07-28). In production this is\n * `await getProgramDerivedAddress({ programAddress, seeds })`.\n */\nfunction vaultFor(wallet: string): string {\n  const RECORDED: Record<string, string> = {\n    \"6JFH1dxqiw6Dc81CbWdx4TUT8CvAfgwZg33wQrSytZsU\":\n      \"FY86s1fAwUiFQTjVFYprsiV6fwNH7e955MSUBo73FP4j\",\n    Hr99MUHbQksoGpkSagrhqzvTgCo1BVEHjnACTSsaEJh8:\n      \"EMTqK9Cfac1X7c86GUYG5wwGkqR9HpeYkqUDvjLmhgKi\",\n  };\n  const vault = RECORDED[wallet];\n  if (!vault) throw new Error(\"no recorded vault derivation for \" + wallet);\n  return vault;\n}\n",
+        "tests": [
+          {
+            "description": "Subgoal 1+2: the wallet pays, and the plan carries the given blockhash as its lifetime",
+            "expectedOutput": "result.feePayer === '6JFH1dxqiw6Dc81CbWdx4TUT8CvAfgwZg33wQrSytZsU' && result.lifetimeBlockhash === 'GJRYBLa6XmfnUicWpkccesM9SsDDbKAFYPDVzWqXAX2h'",
+            "failureMessage": "A message without a recent-blockhash lifetime is rejected the moment it is sent — pass the blockhash argument through.",
+            "id": "t1",
+            "input": "'6JFH1dxqiw6Dc81CbWdx4TUT8CvAfgwZg33wQrSytZsU', 'GJRYBLa6XmfnUicWpkccesM9SsDDbKAFYPDVzWqXAX2h', 1000000n"
+          },
+          {
+            "description": "Subgoal 3: the FIRST account is the wallet's vault PDA, writable — IDL order is the program's interface",
+            "expectedOutput": "result.instructions[0].accounts[0].address === 'FY86s1fAwUiFQTjVFYprsiV6fwNH7e955MSUBo73FP4j' && result.instructions[0].accounts[0].role === 'writable'",
+            "failureMessage": "The IDL lists [vault, user, system_program] — vault FIRST. The program reads accounts by position; user-first is a different, failing call.",
+            "id": "t2",
+            "input": "'6JFH1dxqiw6Dc81CbWdx4TUT8CvAfgwZg33wQrSytZsU', 'GJRYBLa6XmfnUicWpkccesM9SsDDbKAFYPDVzWqXAX2h', 1000000n"
+          },
+          {
+            "description": "Subgoal 3: then the signing wallet, then the System Program — exactly three accounts",
+            "expectedOutput": "result.instructions[0].accounts.length === 3 && result.instructions[0].accounts[1].address === '6JFH1dxqiw6Dc81CbWdx4TUT8CvAfgwZg33wQrSytZsU' && result.instructions[0].accounts[1].role === 'writable-signer' && result.instructions[0].accounts[2].address === '11111111111111111111111111111111' && result.instructions[0].accounts[2].role === 'readonly'",
+            "id": "t3",
+            "input": "'6JFH1dxqiw6Dc81CbWdx4TUT8CvAfgwZg33wQrSytZsU', 'GJRYBLa6XmfnUicWpkccesM9SsDDbKAFYPDVzWqXAX2h', 1000000n"
+          },
+          {
+            "description": "Subgoal 4: data = 8-byte deposit discriminator, then the amount as u64 LE",
+            "expectedOutput": "result.instructions[0].data.join(',') === '242,35,198,137,82,225,242,182,64,66,15,0,0,0,0,0'",
+            "failureMessage": "Discriminator first, then u64le(lamports). 1,000,000 = 0x0F4240, little-endian bytes [64, 66, 15, 0, 0, 0, 0, 0].",
+            "id": "t4",
+            "input": "'6JFH1dxqiw6Dc81CbWdx4TUT8CvAfgwZg33wQrSytZsU', 'GJRYBLa6XmfnUicWpkccesM9SsDDbKAFYPDVzWqXAX2h', 1000000n"
+          },
+          {
+            "description": "Anti-hardcode: a different wallet deposits into ITS vault, with ITS amount encoded",
+            "expectedOutput": "result.instructions[0].accounts[0].address === 'EMTqK9Cfac1X7c86GUYG5wwGkqR9HpeYkqUDvjLmhgKi' && result.instructions[0].data.join(',') === '242,35,198,137,82,225,242,182,160,37,38,0,0,0,0,0' && result.feePayer === 'Hr99MUHbQksoGpkSagrhqzvTgCo1BVEHjnACTSsaEJh8'",
+            "failureMessage": "Both the vault (via vaultFor) and the encoded amount must flow from the arguments — nothing about the reference wallet may be hardcoded.",
+            "id": "t5",
+            "input": "'Hr99MUHbQksoGpkSagrhqzvTgCo1BVEHjnACTSsaEJh8', 'JCB6HzS1PGGBAxqCJKM48VVfaAdrqvPo9WBEDFEZbT2a', 2500000n"
+          }
+        ],
+        "tutorNotes": [
+          "The classic order bug: learners list the user account first 'because the user is doing the deposit'. The program reads accounts by POSITION — the IDL fixes [vault, user, system_program], vault first, and t2/t3 grade exactly that. Swapped order on-chain is not a warning; it is a wrong call.",
+          "They skip subgoal 2 and return the empty-string lifetime. Explain via lesson 4: the blockhash is the transaction's lifetime; without it the network rejects the message immediately — the field is not decorative.",
+          "They put the amount bytes BEFORE the discriminator, or encode the amount big-endian. The wire format is tag-then-args, and the u64 is little-endian — t4's exact byte string [242,…,182,64,66,15,0,0,0,0,0] is the check; u64le() already does the LE write for them.",
+          "They hardcode the FY86… vault or the reference wallet and fail t5, which plans a deposit for a different wallet. Both the vault (via vaultFor) and the encoded amount must flow from the arguments.",
+          "They ask why the plan has no signature anywhere. By design: the wallet holds the key and signs; the app only assembles. If their mental model has the app touching a private key, correct it now — that division is the security model of every dApp they will ever build.",
+          "They ask why the System Program is in a deposit into OUR program's vault. First deposit may need the vault account created, and account creation is the System Program's job — the program CPIs into it. Course 3 makes them write that call."
+        ]
+      },
+      {
+        "_key": "send",
+        "_type": "prose",
+        "src": "# Send, Watch, and Read the Failure\n\nAssembling was the pure part. Sending is where the network answers back — and the answer is not a boolean.\n\n## Confirmation is a ladder, not a light switch\n\nIn Kit you send-and-confirm with a factory bound once to your RPC and its websocket side:\n\n```ts\nimport {\n  createSolanaRpc,\n  createSolanaRpcSubscriptions,\n  sendAndConfirmTransactionFactory,\n  getSignatureFromTransaction,\n} from \"@solana/kit\";\n\nconst rpc = createSolanaRpc(\"https://api.devnet.solana.com\");\nconst rpcSubscriptions = createSolanaRpcSubscriptions(\n  \"wss://api.devnet.solana.com\"\n);\nconst sendAndConfirm = sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions });\n\nawait sendAndConfirm(signedTransaction, { commitment: \"confirmed\" });\nconst signature = getSignatureFromTransaction(signedTransaction);\n```\n\nWhat you are waiting for is a **commitment level**, and each rung means something different:\n\n- **`processed`** — one validator has executed it. Fast, and still reversible.\n- **`confirmed`** — a supermajority of the cluster has voted on its block. The practical default: what \"it went through\" honestly means for a UI.\n- **`finalized`** — locked in beyond rollback. What you wait for before acting on money you cannot claw back.\n\nAn honest UI shows the rung it has actually reached — \"sending\" is not \"confirmed\", and \"confirmed\" is not a guess made at the moment you hit send.\n\n## The failure taxonomy\n\nFive ways this deposit can not-happen, and they are not the same event:\n\n1. **You reject in the wallet.** Nothing reached the network. Not a failed transaction — the honest UI state is back-to-resting, not an error banner.\n2. **The faucet declines.** Also pre-network; your wallet simply is not funded yet. Retry after a wait.\n3. **The blockhash expires.** The transaction aged out (~a minute) before landing — lesson 4's lifetime rule. It can never land now, which is precisely what makes the fix safe: rebuild with a fresh blockhash, re-sign, resend.\n4. **Simulation rejects it pre-flight.** The RPC ran it before broadcast and it failed — insufficient lamports, a program error. Nothing was sent; read the message, fix the cause.\n5. **The program says no, on-chain.** The transaction landed and *failed*, fee paid. This program's refusals are named in the IDL you read in lesson 1 — depositing `0` fails with error `6002 ZeroAmount`. A landed failure has a signature and logs; that is where you look.\n\nThe through-line: **\"failed\" is only honest for 3, 4 and 5.** Rejecting a wallet prompt did not fail — nothing happened, and an app that shows a red X for it is lying to its user.\n\n## Your receipt\n\nOnce confirmed, your signature is a permanent public record. `https://explorer.solana.com/tx/<signature>?cluster=devnet` shows what you paid (compare it to your lesson-4 prediction — for real this time), the accounts your instruction touched — vault first — and the vault's balance change. That link is the first artifact of this course anyone else can verify. Keep it; the reflection below asks for it, and your profile keeps it after that.\n"
+      },
+      {
+        "_key": "predict",
+        "_type": "quiz",
+        "questions": [
+          {
+            "explanation": "The failure taxonomy's first rule: rejection is pre-network. Failed is only honest for things that were sent — expired, preflight-rejected, or landed-and-failed. A rejection is none of those.",
+            "id": "q1",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "Back to resting; no on-chain record at all — nothing was signed, so nothing reached the network"
+              },
+              {
+                "correct": false,
+                "feedback": "A failed transaction is one that went out and did not succeed. A rejection never left the wallet — there is no signature, no fee, no record. Showing a red failure for it is the dishonest UI this lesson warns about.",
+                "id": "b",
+                "label": "A failed transaction with your rejection as the error"
+              },
+              {
+                "correct": false,
+                "feedback": "Pending describes something in flight. Nothing is in flight — the transaction was never signed. The blockhash-expiry clock matters only for transactions that actually went out.",
+                "id": "c",
+                "label": "A pending transaction that expires after a minute"
+              }
+            ],
+            "prompt": "You click Deposit, the wallet pops up, and you hit Reject. Predict the honest UI state and the on-chain record."
+          },
+          {
+            "explanation": "fee = 5,000 × signatures + price × requested CU ÷ 1e6. Reading 5,000 off the explorer tells you: one signer, zero priority price. The reflection below asks you to make exactly this comparison on your own transaction.",
+            "id": "q2",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "One signature and no priority price — the base fee alone, exactly the floor your lesson-4 plan predicted"
+              },
+              {
+                "correct": false,
+                "feedback": "Fees never scale with the amount moved. 5,000 = 5,000 × 1 signature + 0 priority — you simply sent without a compute-unit price, so only the base fee applied.",
+                "id": "b",
+                "label": "The network waived the priority fee because the deposit was small"
+              },
+              {
+                "correct": false,
+                "feedback": "Devnet and mainnet share the fee rules; only the SOL is free. 5,000 lamports is the per-signature base fee — the lesson-4 formula with one signer and price zero.",
+                "id": "c",
+                "label": "A discounted devnet rate"
+              }
+            ],
+            "prompt": "Your deposit lands, and the explorer shows the transaction succeeded with a fee of 5,000 lamports. From lesson 4, what does that fee tell you about the transaction you sent?"
+          },
+          {
+            "explanation": "Case 5 of the taxonomy: an on-chain program refusal. The transaction has a signature, logs, and a named error (6002 ZeroAmount) — and the fee is paid, because validators did the work of executing it to its refusal.",
+            "id": "q3",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "A landed, FAILED transaction — custom program error 6002 (ZeroAmount), with the fee paid"
+              },
+              {
+                "correct": false,
+                "feedback": "The wallet checks signatures, not business rules. The transaction is perfectly well-formed; it is the PROGRAM that refuses it, on-chain, with the error its IDL names: 6002 ZeroAmount. Landed failures pay their fee.",
+                "id": "b",
+                "label": "Nothing — the wallet blocks zero-amount transactions"
+              },
+              {
+                "correct": false,
+                "feedback": "This program explicitly rejects zero — error 6002 in the IDL you read in lesson 1. It lands, fails, and charges the base fee: taxonomy case 5, the only kind of failure with a signature and logs.",
+                "id": "c",
+                "label": "A success that moved zero lamports"
+              }
+            ],
+            "prompt": "Curious, you send a second deposit with amount 0. Predict what the explorer shows."
+          }
+        ]
+      },
+      {
+        "_key": "milestone",
+        "_type": "openEnded",
+        "maxWords": 150,
+        "prompt": "Paste your deposit's explorer link (https://explorer.solana.com/tx/<signature>?cluster=devnet), then answer two things in a few sentences. One: what did the wallet do that your buildDepositPlan could not — why does that split exist? Two: open the transaction's fee in the explorer and compare it to the cost you predicted in lesson 4 — did the numbers match, and if not, which term of the formula explains the difference?"
+      }
+    ],
+    "skills": [
+      "wallet-standard",
+      "transactions",
+      "confirmation",
+      "error-handling",
+      "solana-kit"
+    ],
+    "slug": {
+      "_type": "slug",
+      "current": "connect-fund-and-send"
+    },
+    "title": "Connect, Fund, and Send It"
+  },
+  {
+    "_id": "lesson-sfwd-derive-the-vault-pda",
+    "_type": "lesson",
+    "blocks": [
+      {
+        "_key": "intro",
+        "_type": "prose",
+        "src": "# Derive the Vault PDA\n\n> Version stamp — `@solana/kit` 7.0.0 · devnet · authored 2026-07-28.\n\nThe vault's address — `FY86s1fAwUiFQTjVFYprsiV6fwNH7e955MSUBo73FP4j` — was never generated from a private key. Nobody holds a secret for it, and nobody ever will. It is a **Program Derived Address**: computed, deterministically, from ingredients you already have.\n\n## The recipe\n\nA PDA is derived from three inputs:\n\n1. **Seeds** — an ordered list of byte strings. For this vault: the UTF-8 bytes of `\"vault\"`, then the owner's 32-byte public key.\n2. **The program's address** — `D7ZF…`. The same seeds under a different program give a completely different address, so programs can never collide on each other's accounts.\n3. **A bump** — one byte, found by search (below).\n\nThe derivation is a SHA-256 hash over `seeds + bump + program address + a fixed marker string (\"ProgramDerivedAddress\")`. The marker keeps PDAs from ever colliding with hashes computed for any other purpose.\n\n## Why the bump exists\n\nRegular addresses are points **on** the ed25519 curve — that is what makes them signable by a private key. A PDA must be the opposite: an address **off** the curve, so that *no private key can ever exist for it*. Only the program itself (with the runtime's help) can authorize actions for it.\n\nBut a hash lands on the curve roughly half the time. So the derivation *searches*: try bump 255 — if the hash is on the curve, try 254, then 253… until the result falls off the curve. The first bump that works (searching downward) is the **canonical bump**.\n\nTwo facts follow, and both showed up in your decoder yesterday:\n\n- The reference vault's stored bump is **255** — the very first candidate was already off-curve.\n- The bump is stored in the account (byte 48) so the program never has to redo the search. Deriving is cheap for you; on-chain, re-searching every call would be wasted compute.\n\n## In Kit\n\n```ts\nimport {\n  getProgramDerivedAddress,\n  getUtf8Encoder,\n  getAddressEncoder,\n} from \"@solana/kit\";\n\nconst [address, bump] = await getProgramDerivedAddress({\n  programAddress: VAULT_PROGRAM,\n  seeds: [\n    getUtf8Encoder().encode(\"vault\"),\n    getAddressEncoder().encode(owner),\n  ],\n});\n```\n\nNote it is `await` — the function is async — and it returns a pair: the address *and* the canonical bump it found.\n\n**Seed order is part of the address.** `[\"vault\", owner]` and `[owner, \"vault\"]` hash to different byte sequences, so they derive different addresses — same ingredients, different meal. The program defined the order once (you saw it in the IDL yesterday: constant `\"vault\"` first, then the user account); every client must reproduce it exactly.\n\n## The exercise\n\nThe grader has no network and no crypto library, so `derive` is **injected**: a lookup over outputs recorded from real `getProgramDerivedAddress` runs on 2026-07-28 — the correct derivation for two different owners, plus the wrong-seed-order and wrong-program derivations, all real. Your job is the part that is yours in production too: assemble the seeds in the right order and hand the right program address to `derive`.\n\nThe parts bin holds five lines. Three belong. One flips the seed order — it will \"work\" and return a real address that is simply not the vault. One passes the owner as the *program* address — a category error the lookup refuses loudly. Choose and order the lines, then run the tests: one fixture owner is the reference wallet from lesson 1, the other is a different wallet whose vault you have never seen.\n"
+      },
+      {
+        "_key": "derive",
+        "_type": "code",
+        "buildType": "standard",
+        "deployable": false,
+        "hints": [
+          "Three lines, in this role order: build the seeds, call derive, return the pair. The bin labels (A)–(E) are shuffled — labels are not positions.",
+          "The seed order question is settled by the program, not by you: lesson 1's IDL showed the constant \"vault\" seed first, then the user's key. Pick the seeds line that matches.",
+          "`derive` wants the address of the PROGRAM doing the deriving. One decoy hands it the owner — a wallet. If your run ends with \"no recorded derivation\", read which value you passed as programAddress."
+        ],
+        "language": "typescript",
+        "solution": "// ─────────────────────────────────────────────────────────────────────────────\n// TEST HARNESS — do not edit. Grading calls runCase with an owner address and\n// injects `derive`: a lookup over REAL getProgramDerivedAddress outputs,\n// recorded on 2026-07-28 (kit 7.0.0). No hashing happens in the sandbox; the\n// recorded map holds the correct derivation for two owners, the wrong-seed-\n// order result, and the wrong-program result — all real.\n// ─────────────────────────────────────────────────────────────────────────────\nfunction runCase(ownerAddress: string) {\n  return deriveVaultPda(ownerAddress, derive);\n}\n\n/**\n * Reproduce the vault PDA for `owner`.\n *\n * The five candidate lines are in the PARTS BIN below, commented out and\n * shuffled. THREE belong, in the right order. Two are decoys:\n *   - one flips the seed order — it derives a real address that is not the\n *     vault (seed order is part of the address);\n *   - one passes the owner where the PROGRAM address belongs — a category\n *     error the lookup rejects loudly.\n * Uncomment the lines you want inside the function, in order. Do not write\n * lines that are not in the bin.\n *\n * ┌─ PARTS BIN ──────────────────────────────────────────────────────────┐\n * │ (A)  const seeds = [utf8(\"vault\"), addressBytes(owner)];             │\n * │ (B)  const [address, bump] = derive({ programAddress: owner, seeds });│\n * │ (C)  const seeds = [addressBytes(owner), utf8(\"vault\")];             │\n * │ (D)  return { address, bump };                                       │\n * │ (E)  const [address, bump] = derive({                                │\n * │        programAddress: VAULT_PROGRAM, seeds });                      │\n * └──────────────────────────────────────────────────────────────────────┘\n */\nfunction deriveVaultPda(\n  owner: string,\n  derive: (input: { programAddress: string; seeds: string[] }) => [\n    string,\n    number,\n  ]\n): { address: string; bump: number } {\n  // (A) — the program's seed order: the constant \"vault\" first, then the owner.\n  const seeds = [utf8(\"vault\"), addressBytes(owner)];\n  // (E) — derive under the PROGRAM's address. (B) was the decoy: the owner is\n  // a wallet, not a program, and the lookup rejects it as a category error.\n  // (C) was the other decoy: [owner, \"vault\"] derives a real address that is\n  // simply not the vault — seed order is part of the address.\n  const [address, bump] = derive({ programAddress: VAULT_PROGRAM, seeds });\n  // (D)\n  return { address, bump };\n}\n\n// ── PROVIDED — seed encoders (stand-ins for getUtf8Encoder/getAddressEncoder;\n// the real ones return byte arrays, these return tagged strings the recorded\n// lookup understands) ────────────────────────────────────────────────────────\nconst VAULT_PROGRAM = \"D7ZFoWvEG5NBnkJy6iC98rhwj2qhgq8xhSD42cdTRAQd\";\nfunction utf8(s: string): string {\n  return \"utf8:\" + s;\n}\nfunction addressBytes(addr: string): string {\n  return \"address:\" + addr;\n}\n\n// ── RECORDED DERIVATIONS — real getProgramDerivedAddress outputs ────────────\nconst DERIVATIONS: Record<string, [string, number]> = {\n  // correct: [\"vault\", owner] under the vault program\n  \"D7ZFoWvEG5NBnkJy6iC98rhwj2qhgq8xhSD42cdTRAQd|utf8:vault,address:6JFH1dxqiw6Dc81CbWdx4TUT8CvAfgwZg33wQrSytZsU\":\n    [\"FY86s1fAwUiFQTjVFYprsiV6fwNH7e955MSUBo73FP4j\", 255],\n  \"D7ZFoWvEG5NBnkJy6iC98rhwj2qhgq8xhSD42cdTRAQd|utf8:vault,address:Hr99MUHbQksoGpkSagrhqzvTgCo1BVEHjnACTSsaEJh8\":\n    [\"EMTqK9Cfac1X7c86GUYG5wwGkqR9HpeYkqUDvjLmhgKi\", 252],\n  // wrong seed order: [owner, \"vault\"] — a real address, just not the vault\n  \"D7ZFoWvEG5NBnkJy6iC98rhwj2qhgq8xhSD42cdTRAQd|address:6JFH1dxqiw6Dc81CbWdx4TUT8CvAfgwZg33wQrSytZsU,utf8:vault\":\n    [\"6jBWSvMq5a1qiS61uUajhmp1KQYYZWriHc2fo6S4jYjJ\", 254],\n  \"D7ZFoWvEG5NBnkJy6iC98rhwj2qhgq8xhSD42cdTRAQd|address:Hr99MUHbQksoGpkSagrhqzvTgCo1BVEHjnACTSsaEJh8,utf8:vault\":\n    [\"7dpNqGM87gD1cVfnmwjc12rpeNiDdJStK4Jo4rtPs9R4\", 254],\n  // wrong program: same seeds under the System Program — different address\n  \"11111111111111111111111111111111|utf8:vault,address:6JFH1dxqiw6Dc81CbWdx4TUT8CvAfgwZg33wQrSytZsU\":\n    [\"9tk79Wfc9fQZBo5pggDqEnTRyhRu2pajB9VcgGe6tH3m\", 255],\n};\n\nfunction derive(input: {\n  programAddress: string;\n  seeds: string[];\n}): [string, number] {\n  const key = input.programAddress + \"|\" + input.seeds.join(\",\");\n  const hit = DERIVATIONS[key];\n  if (!hit) {\n    throw new Error(\n      \"no recorded derivation for programAddress=\" +\n        input.programAddress +\n        \" seeds=[\" +\n        input.seeds.join(\", \") +\n        \"] — is the program address actually a program, and are the seeds the ones the program defined?\"\n    );\n  }\n  return [hit[0], hit[1]];\n}\n",
+        "starter": "// ─────────────────────────────────────────────────────────────────────────────\n// TEST HARNESS — do not edit. Grading calls runCase with an owner address and\n// injects `derive`: a lookup over REAL getProgramDerivedAddress outputs,\n// recorded on 2026-07-28 (kit 7.0.0). No hashing happens in the sandbox; the\n// recorded map holds the correct derivation for two owners, the wrong-seed-\n// order result, and the wrong-program result — all real.\n// ─────────────────────────────────────────────────────────────────────────────\nfunction runCase(ownerAddress: string) {\n  return deriveVaultPda(ownerAddress, derive);\n}\n\n/**\n * Reproduce the vault PDA for `owner`.\n *\n * The five candidate lines are in the PARTS BIN below, commented out and\n * shuffled. THREE belong, in the right order. Two are decoys:\n *   - one flips the seed order — it derives a real address that is not the\n *     vault (seed order is part of the address);\n *   - one passes the owner where the PROGRAM address belongs — a category\n *     error the lookup rejects loudly.\n * Uncomment the lines you want inside the function, in order. Do not write\n * lines that are not in the bin.\n *\n * ┌─ PARTS BIN ──────────────────────────────────────────────────────────┐\n * │ (A)  const seeds = [utf8(\"vault\"), addressBytes(owner)];             │\n * │ (B)  const [address, bump] = derive({ programAddress: owner, seeds });│\n * │ (C)  const seeds = [addressBytes(owner), utf8(\"vault\")];             │\n * │ (D)  return { address, bump };                                       │\n * │ (E)  const [address, bump] = derive({                                │\n * │        programAddress: VAULT_PROGRAM, seeds });                      │\n * └──────────────────────────────────────────────────────────────────────┘\n */\nfunction deriveVaultPda(\n  owner: string,\n  derive: (input: { programAddress: string; seeds: string[] }) => [\n    string,\n    number,\n  ]\n): { address: string; bump: number } {\n  // Assemble three lines from the parts bin here, then delete the throw.\n  throw new Error(\"assemble the derivation from the parts bin\");\n}\n\n// ── PROVIDED — seed encoders (stand-ins for getUtf8Encoder/getAddressEncoder;\n// the real ones return byte arrays, these return tagged strings the recorded\n// lookup understands) ────────────────────────────────────────────────────────\nconst VAULT_PROGRAM = \"D7ZFoWvEG5NBnkJy6iC98rhwj2qhgq8xhSD42cdTRAQd\";\nfunction utf8(s: string): string {\n  return \"utf8:\" + s;\n}\nfunction addressBytes(addr: string): string {\n  return \"address:\" + addr;\n}\n\n// ── RECORDED DERIVATIONS — real getProgramDerivedAddress outputs ────────────\nconst DERIVATIONS: Record<string, [string, number]> = {\n  // correct: [\"vault\", owner] under the vault program\n  \"D7ZFoWvEG5NBnkJy6iC98rhwj2qhgq8xhSD42cdTRAQd|utf8:vault,address:6JFH1dxqiw6Dc81CbWdx4TUT8CvAfgwZg33wQrSytZsU\":\n    [\"FY86s1fAwUiFQTjVFYprsiV6fwNH7e955MSUBo73FP4j\", 255],\n  \"D7ZFoWvEG5NBnkJy6iC98rhwj2qhgq8xhSD42cdTRAQd|utf8:vault,address:Hr99MUHbQksoGpkSagrhqzvTgCo1BVEHjnACTSsaEJh8\":\n    [\"EMTqK9Cfac1X7c86GUYG5wwGkqR9HpeYkqUDvjLmhgKi\", 252],\n  // wrong seed order: [owner, \"vault\"] — a real address, just not the vault\n  \"D7ZFoWvEG5NBnkJy6iC98rhwj2qhgq8xhSD42cdTRAQd|address:6JFH1dxqiw6Dc81CbWdx4TUT8CvAfgwZg33wQrSytZsU,utf8:vault\":\n    [\"6jBWSvMq5a1qiS61uUajhmp1KQYYZWriHc2fo6S4jYjJ\", 254],\n  \"D7ZFoWvEG5NBnkJy6iC98rhwj2qhgq8xhSD42cdTRAQd|address:Hr99MUHbQksoGpkSagrhqzvTgCo1BVEHjnACTSsaEJh8,utf8:vault\":\n    [\"7dpNqGM87gD1cVfnmwjc12rpeNiDdJStK4Jo4rtPs9R4\", 254],\n  // wrong program: same seeds under the System Program — different address\n  \"11111111111111111111111111111111|utf8:vault,address:6JFH1dxqiw6Dc81CbWdx4TUT8CvAfgwZg33wQrSytZsU\":\n    [\"9tk79Wfc9fQZBo5pggDqEnTRyhRu2pajB9VcgGe6tH3m\", 255],\n};\n\nfunction derive(input: {\n  programAddress: string;\n  seeds: string[];\n}): [string, number] {\n  const key = input.programAddress + \"|\" + input.seeds.join(\",\");\n  const hit = DERIVATIONS[key];\n  if (!hit) {\n    throw new Error(\n      \"no recorded derivation for programAddress=\" +\n        input.programAddress +\n        \" seeds=[\" +\n        input.seeds.join(\", \") +\n        \"] — is the program address actually a program, and are the seeds the ones the program defined?\"\n    );\n  }\n  return [hit[0], hit[1]];\n}\n",
+        "tests": [
+          {
+            "description": "The reference owner derives to the exact vault address read in lesson 1",
+            "expectedOutput": "result.address === 'FY86s1fAwUiFQTjVFYprsiV6fwNH7e955MSUBo73FP4j'",
+            "failureMessage": "If you derived 6jBW…jYjJ, your seed order is flipped — the program defined [\"vault\", owner], constant first. If the lookup threw, check which value you passed as programAddress.",
+            "id": "t1",
+            "input": "'6JFH1dxqiw6Dc81CbWdx4TUT8CvAfgwZg33wQrSytZsU'"
+          },
+          {
+            "description": "The canonical bump comes back with the address — the same 255 you decoded at byte 48",
+            "expectedOutput": "result.bump === 255",
+            "id": "t2",
+            "input": "'6JFH1dxqiw6Dc81CbWdx4TUT8CvAfgwZg33wQrSytZsU'"
+          },
+          {
+            "description": "Anti-hardcode: a different owner derives to ITS vault, with ITS bump",
+            "expectedOutput": "result.address === 'EMTqK9Cfac1X7c86GUYG5wwGkqR9HpeYkqUDvjLmhgKi' && result.bump === 252",
+            "failureMessage": "The derivation must flow from the owner argument — if this returns the FY86… address, the owner was hardcoded rather than passed through the seeds.",
+            "id": "t3",
+            "input": "'Hr99MUHbQksoGpkSagrhqzvTgCo1BVEHjnACTSsaEJh8'"
+          }
+        ],
+        "tutorNotes": [
+          "Learners pick line (C), the flipped seed order [owner, \"vault\"]. It does not throw — it returns the real recorded address 6jBW…jYjJ — and t1 fails by address mismatch. The teaching point is that wrong seed order is a silent wrong address, not an error; the program fixed the order as [\"vault\", owner] and the IDL says so.",
+          "They pick decoy (B), passing the owner as programAddress. The lookup throws 'no recorded derivation' with the key it built — have them read their own key in the error: the first segment should be the program D7ZF…, not a wallet.",
+          "They hardcode FY86… (visible in the fixtures) and fail t3, which derives for a second owner. The owner argument must flow into the seeds.",
+          "They ask why derive is synchronous here when the lesson says getProgramDerivedAddress is async — the sandbox lookup is recorded, so there is nothing to await; in real Kit code the call must be awaited, and forgetting the await hands you a Promise instead of a [address, bump] pair.",
+          "They expect the bump to always be 255. The second owner's vault records 252 — the search stepped down three times before falling off the curve. If they treat 255 as a constant, t3's bump assertion catches it.",
+          "If they invent their own string keys instead of using utf8()/addressBytes(), the lookup throws. The helpers mirror getUtf8Encoder/getAddressEncoder — seeds are ENCODED bytes in production, never bare JS strings."
+        ]
+      },
+      {
+        "_key": "check",
+        "_type": "quiz",
+        "questions": [
+          {
+            "explanation": "A PDA's guarantee is that no private key can ever sign for it, which requires an off-curve address. Since a hash lands on-curve about half the time, the derivation tries bump 255, 254, … until the result falls off the curve; the first success is the canonical bump.",
+            "id": "q1",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "The hash can land ON the ed25519 curve, where a private key could exist — the search walks the bump down until the result is off-curve and therefore unsignable by anyone"
+              },
+              {
+                "correct": false,
+                "feedback": "PDAs are not secret — anyone can derive them, which is the point. The retry exists because roughly half of hash outputs are valid curve points, and a PDA must not be one: an on-curve address could have a private key.",
+                "id": "b",
+                "label": "Retrying makes the address harder to guess"
+              },
+              {
+                "correct": false,
+                "feedback": "Derivation never touches the chain — it is pure computation. The check is geometric (is this point on the curve?), not a lookup for collisions.",
+                "id": "c",
+                "label": "Each retry checks whether the address is already taken by another account"
+              }
+            ],
+            "prompt": "Why does the derivation retry with a decreasing bump instead of using the hash directly?"
+          },
+          {
+            "explanation": "Deriving costs a search (hash, curve check, decrement, repeat). On-chain compute is metered, so well-written programs derive once at creation, store the canonical bump, and read one byte thereafter — which is exactly the byte your decoder extracts.",
+            "id": "q2",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "Re-deriving repeats the hash-and-check search on-chain — the stored canonical bump turns that into a single byte read"
+              },
+              {
+                "correct": false,
+                "feedback": "The derivation is deterministic — same seeds, same program, same bump, forever. Storage is purely an efficiency and safety habit: one read instead of a compute-burning search each call.",
+                "id": "b",
+                "label": "The bump changes over time, so the original must be preserved"
+              },
+              {
+                "correct": false,
+                "feedback": "The runtime does not demand a bump in transactions. Storing it is the program's own choice, so its checks can use the canonical bump cheaply every time.",
+                "id": "c",
+                "label": "Transactions must include the bump or they are rejected"
+              }
+            ],
+            "prompt": "The vault stores its bump (255) in byte 48. Predict why the program keeps it instead of re-deriving on every call."
+          },
+          {
+            "explanation": "The program address is baked into the derivation, giving every program its own address namespace. That is also why the exercise's wrong-program fixture (same seeds, System Program) lands on a completely different address.",
+            "id": "q3",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "Different — the program address is an ingredient of the hash, so identical seeds under different programs derive different PDAs"
+              },
+              {
+                "correct": false,
+                "feedback": "Seeds are only part of the recipe. The deriving program's address is hashed in too, precisely so two programs can never collide on each other's accounts.",
+                "id": "b",
+                "label": "Identical — the seeds fully determine the address"
+              },
+              {
+                "correct": false,
+                "feedback": "Deployment order is irrelevant — derivation is pure math over seeds + program address + bump. Different program, different address, regardless of history.",
+                "id": "c",
+                "label": "It depends on which program was deployed first"
+              }
+            ],
+            "prompt": "Another program copies this vault's code and a user with the same wallet initializes a vault there with the same seeds. Predict the two vault addresses."
+          }
+        ]
+      }
+    ],
+    "skills": [
+      "pdas",
+      "solana-kit",
+      "account-model"
+    ],
+    "slug": {
+      "_type": "slug",
+      "current": "derive-the-vault-pda"
+    },
+    "title": "Derive the Vault PDA"
+  },
+  {
+    "_id": "lesson-sfwd-kit-or-legacy",
+    "_type": "lesson",
+    "blocks": [
+      {
+        "_key": "intro",
+        "_type": "prose",
+        "src": "# Kit, or What You'll Find in the Wild\n\n> Version stamp — `@solana/kit` 7.0.0 · devnet · authored 2026-07-28.\n\nThis lesson adds no new machinery. It exists because the first real codebase you open will not look like this course — and you need to read it anyway.\n\n## The seam, with dates\n\nTwo stacks coexist right now, and pretending otherwise would set you up to fail:\n\n- **`@solana/kit`** — the current stack, what solana.com documents, what this course teaches. Weekly downloads around 1.65M (checked 2026-07-28).\n- **`@solana/web3.js` v1** — officially labeled superseded, yet it still holds the npm **`latest`** tag at 1.98.x with roughly 2.1M weekly downloads. `npm i @solana/web3.js` installs v1 **today**. Its companion `@solana/wallet-adapter-*` is likewise superseded and likewise everywhere.\n\nSo: every bounty codebase, most Stack Overflow answers, and most tutorials you will search speak v1. \"Canonical\" and \"what you will be paid to touch\" have diverged. The skill is **read v1 fluently, write Kit only** — this course never asks you to write a line of v1, and neither should you.\n\nOne more honesty note: the ecosystem also contains `@solana/client`, `@solana/react-hooks`, and `gill` — packages whose own documentation pages disagree about their status. This course pins **one** stack, `@solana/kit` 7.0.0, and says so, so that every line you learn has one current answer.\n\n## THE MAP\n\nLeft column: what you will read in the wild. Right column: what you write instead. The right-hand strings below are exactly the ones the drill grades against.\n\n| Legacy (read it) | Kit (write it) |\n| --- | --- |\n| `new Connection(endpoint)` | `createSolanaRpc(endpoint)` |\n| `clusterApiUrl('devnet')` | `an explicit endpoint string` |\n| `new PublicKey(base58)` | `address(base58)` |\n| `Keypair.generate()` | `generateKeyPairSigner()` |\n| `SystemProgram.transfer({...})` | `getTransferSolInstruction({...})` |\n| `sendAndConfirmTransaction(connection, tx, [payer])` | `sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions })` |\n| `connection.getAccountInfo(pubkey)` | `rpc.getAccountInfo(address).send()` |\n| `PublicKey.findProgramAddressSync(seeds, programId)` | `await getProgramDerivedAddress({ programAddress, seeds })` |\n| `useWallet() from @solana/wallet-adapter-react` | `@solana/kit-plugin-wallet (Wallet Standard)` |\n\nThe pattern behind the rows, so you can extend the map yourself:\n\n- **Classes become functions.** v1 wraps everything in `new` — `Connection`, `PublicKey`, `Transaction`. Kit is plain functions returning plain values.\n- **Magic endpoints become explicit.** `clusterApiUrl('devnet')` hid the URL; Kit asks you to write `\"https://api.devnet.solana.com\"` where everyone can see which chain you are on.\n- **Sync PDA derivation becomes async.** `findProgramAddressSync` blocked while it searched for the bump; `getProgramDerivedAddress` is awaited — the single most common porting mistake is a forgotten `await` handing you a `Promise` where an address should be.\n- **The confirm helper becomes a factory.** v1's `sendAndConfirmTransaction` took a connection each call. Kit's `sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions })` binds its dependencies once and returns the function you actually call — you will use it for real in the next lesson.\n- **Wallet plumbing becomes a protocol.** wallet-adapter needed a package per wallet; Wallet Standard is implemented by the wallets themselves, and `@solana/kit-plugin-wallet` just discovers them.\n\n## How this lesson runs\n\nFirst, a **cumulative check** — six questions reaching back through lessons 1–4, each framed against unfamiliar legacy code, because recall under new packaging is the thing interviews and codebases actually demand. Then the **translation drill**: you fill in THE MAP as a function and it is graded over legacy call sequences — a transfer flow you have seen, plus an account-read and a PDA flow you have not. Finally a short **spot-the-legacy** check on real-world tells.\n"
+      },
+      {
+        "_key": "cumulative",
+        "_type": "quiz",
+        "questions": [
+          {
+            "explanation": "The account model does not change with the SDK: owner is the owning program. Different clothes (`info.owner.toBase58()` vs the `ownerProgram` you will read in Kit), same fact from lesson 1.",
+            "id": "q1",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "The vault PROGRAM's address, D7ZF… — owner on an account is the owning program, in v1 and Kit alike"
+              },
+              {
+                "correct": false,
+                "feedback": "The wallet lives at bytes 8–39 of the account DATA and needs your decoder. `info.owner` is the account's owning program — same account model, older API.",
+                "id": "b",
+                "label": "The wallet address stored inside the vault's data"
+              },
+              {
+                "correct": false,
+                "feedback": "No API surfaces that. The account model is package-independent: owner means owning program, and the human owner is a field your lesson-2 decoder reads.",
+                "id": "c",
+                "label": "The fee payer of the last transaction to touch the account"
+              }
+            ],
+            "prompt": "In a v1 codebase you read `const info = await connection.getAccountInfo(new PublicKey(addr)); console.log(info.owner.toBase58());` For the vault account from lesson 1, what does that log?"
+          },
+          {
+            "explanation": "Layouts belong to programs, not SDKs. Whatever the reading code looks like — Buffer, DataView, or Kit codec — it must encode the same knowledge: u64, offset 40, little-endian.",
+            "id": "q2",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "The layout — a u64 at offset 40, little-endian — which belongs to the PROGRAM's account definition, not to any SDK"
+              },
+              {
+                "correct": false,
+                "feedback": "Byte order is a property of the stored bytes, decided by the program that wrote them. Node's readBigUInt64LE, your DataView's getBigUint64(40, true), and Kit's getU64Decoder all read the same little-endian bytes.",
+                "id": "b",
+                "label": "A v1-specific byte order that Kit later changed"
+              },
+              {
+                "correct": false,
+                "feedback": "There is no universal balance offset; each program defines its own layout. Offset 40 is specific to this vault's discriminator + owner + balance + bump arrangement.",
+                "id": "c",
+                "label": "Nothing — offset 40 is where balances live on all Solana accounts"
+              }
+            ],
+            "prompt": "A v1 snippet reads a vault balance with `data.readBigUInt64LE(40)` (Node Buffer API). Which lesson-2 fact is it depending on?"
+          },
+          {
+            "explanation": "v1's derivation was sync; Kit's is async. The seams where sync became async are exactly where ports break silently — the compiler is happy, and the value is a Promise fragment.",
+            "id": "q3",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "The await is missing — Kit's derivation is async, so addr holds a piece of a Promise, not an address"
+              },
+              {
+                "correct": false,
+                "feedback": "The order shown matches: constant first, then owner — the same order lesson 3 taught. The bug is the missing await; the v1 function was synchronous and the Kit one is not.",
+                "id": "b",
+                "label": "The seed order flipped during the port"
+              },
+              {
+                "correct": false,
+                "feedback": "Kit returns the [address, bump] pair too. What changed is the synchrony: forget the await and you destructure a Promise — the single most common porting mistake on this exact line.",
+                "id": "c",
+                "label": "Kit returns only the address, not a pair"
+              }
+            ],
+            "prompt": "You port `PublicKey.findProgramAddressSync([Buffer.from('vault'), owner.toBuffer()], programId)` to Kit and write `const [addr] = getProgramDerivedAddress({ programAddress, seeds })`. It compiles, then things break downstream. Why?"
+          },
+          {
+            "explanation": "Fee = 5,000 × signatures + price × requested CU ÷ 1e6. The old \"flat fee\" folklore is the price-zero special case — true in the tutorial, expensive on a network where priority fees decide inclusion.",
+            "id": "q4",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "Only when no compute-unit price applies — with any priority price, the unset limit means paying it on the 200,000-CU default per instruction"
+              },
+              {
+                "correct": false,
+                "feedback": "The base fee is 5,000 per signature, but the priority fee rides on top: price × REQUESTED limit ÷ 1e6, and unset means the 200,000 default. The tutorial's claim quietly assumes price zero.",
+                "id": "b",
+                "label": "Always — the 5,000 base fee is the whole fee on every chain"
+              },
+              {
+                "correct": false,
+                "feedback": "A zero-price transaction really does pay just the base fee — your lesson-4 t4 case computed exactly that. The claim is wrong only once a price applies, which on busy networks is whenever you want to land.",
+                "id": "c",
+                "label": "Never — every transaction pays a priority fee"
+              }
+            ],
+            "prompt": "A v1 tutorial sends with no compute-budget instructions and calls the fee \"5,000 lamports, flat\". From lesson 4, when is that claim actually right?"
+          },
+          {
+            "explanation": "\"Account not found\" from looking at the wrong chain is the same bug whether a URL helper hid it or an explorer default did. Explicit endpoints make the chain choice reviewable — one of the quiet quality-of-life reasons the stack moved.",
+            "id": "q5",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "Which chain the code targets becomes visible and searchable at every call site — no helper hiding a cluster choice you then debug for an hour, lesson 1's ?cluster lesson in code form"
+              },
+              {
+                "correct": false,
+                "feedback": "Rate limits attach to endpoints, not to how the URL string was produced. The gain is legibility: the chain your code talks to is written where you can read it, grep it, and diff it.",
+                "id": "b",
+                "label": "clusterApiUrl endpoints were rate-limited harder than literal strings"
+              },
+              {
+                "correct": false,
+                "feedback": "Kit accepts any string, computed or not. The design choice is to stop hiding the cluster decision inside a helper — the same class of confusion as the explorer's silent mainnet default.",
+                "id": "c",
+                "label": "Kit cannot construct URLs at runtime"
+              }
+            ],
+            "prompt": "Reading a v1 codebase you meet `clusterApiUrl('devnet')` in one file and a hardcoded mainnet URL in another. Kit's replacement is \"an explicit endpoint string\". What problem is that explicitness solving?"
+          },
+          {
+            "explanation": "The 2^53 boundary is the whole argument for bigint lamports. The legacy line works in demos and corrupts exactly when the money gets big — the worst possible failure profile.",
+            "id": "q6",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "When the value exceeds 2^53 — Number silently rounds large integers, so big balances change with no error"
+              },
+              {
+                "correct": false,
+                "feedback": "PDAs have nothing to do with it — the hazard is numeric range. Number is exact only to 2^53, and u64 lamport values can exceed it; past that line, silent rounding.",
+                "id": "b",
+                "label": "Whenever the account is a PDA"
+              },
+              {
+                "correct": false,
+                "feedback": "A u64 ranges to ~1.8 × 10^19 and Number is exact to ~9 × 10^15. Large treasuries and token amounts cross that line in production. bigint end to end is the rule this course keeps.",
+                "id": "c",
+                "label": "Never — lamports always fit in a JavaScript number"
+              }
+            ],
+            "prompt": "A legacy snippet stores a balance as `const bal = Number(info.lamports);` and a code reviewer flags it. From lesson 2, when exactly does this line corrupt data?"
+          }
+        ]
+      },
+      {
+        "_key": "drill",
+        "_type": "code",
+        "buildType": "standard",
+        "deployable": false,
+        "hints": [
+          "Every right-hand answer is written verbatim in THE MAP table in the lesson above — this drill is open book; the work is connecting each legacy call to its row.",
+          "Two of the graded sequences never appear in the transfer flow: the account-read and the PDA/wallet fragment. Fill the WHOLE map, not just the rows the first test touches.",
+          "Copy the strings exactly — `await getProgramDerivedAddress({ programAddress, seeds })` includes the await, because in Kit that call really is async."
+        ],
+        "language": "typescript",
+        "solution": "// ─────────────────────────────────────────────────────────────────────────────\n// TEST HARNESS — do not edit. Grading calls runCase with the name of a legacy\n// call sequence (below) and checks the Kit equivalent you produce for every\n// step. The right-hand strings are exactly the ones in THE MAP in the lesson —\n// this is open book by design.\n// ─────────────────────────────────────────────────────────────────────────────\nfunction runCase(planName: string) {\n  const plan = LEGACY_PLANS[planName];\n  if (!plan) throw new Error(\"unknown legacy plan: \" + planName);\n  return modernizePlan(plan);\n}\n\n/**\n * TRANSLATION DRILL — fill in THE MAP.\n *\n * `legacy` is a sequence of calls lifted from a v1 codebase. For each one,\n * answer with the Kit equivalent, exactly as written in the lesson's map.\n * Two rows are done for you.\n */\nfunction modernizePlan(\n  legacy: string[]\n): { legacy: string; kit: string }[] {\n  const MAP: Record<string, string> = {\n    // Done for you — classes become functions:\n    \"new Connection(endpoint)\": \"createSolanaRpc(endpoint)\",\n    // Done for you — magic endpoints become explicit:\n    \"clusterApiUrl('devnet')\": \"an explicit endpoint string\",\n    // Fill in the rest from THE MAP:\n    \"new PublicKey(base58)\": \"address(base58)\",\n    \"Keypair.generate()\": \"generateKeyPairSigner()\",\n    \"SystemProgram.transfer({...})\": \"getTransferSolInstruction({...})\",\n    \"sendAndConfirmTransaction(connection, tx, [payer])\": \"sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions })\",\n    \"connection.getAccountInfo(pubkey)\": \"rpc.getAccountInfo(address).send()\",\n    \"PublicKey.findProgramAddressSync(seeds, programId)\": \"await getProgramDerivedAddress({ programAddress, seeds })\",\n    \"useWallet() from @solana/wallet-adapter-react\": \"@solana/kit-plugin-wallet (Wallet Standard)\",\n  };\n\n  return legacy.map((call) => {\n    const kit = MAP[call];\n    if (kit === undefined || kit === \"\") {\n      throw new Error(\"no Kit equivalent recorded for: \" + call);\n    }\n    return { legacy: call, kit };\n  });\n}\n\n// ── LEGACY CALL SEQUENCES — what you will actually read in the wild ─────────\nconst LEGACY_PLANS: Record<string, string[]> = {\n  // A v1 transfer flow, top to bottom — the shape you studied in lesson 4.\n  transfer: [\n    \"new Connection(endpoint)\",\n    \"clusterApiUrl('devnet')\",\n    \"Keypair.generate()\",\n    \"SystemProgram.transfer({...})\",\n    \"sendAndConfirmTransaction(connection, tx, [payer])\",\n  ],\n  // A v1 account read — lesson 2's territory, in old clothes.\n  \"account-read\": [\n    \"new Connection(endpoint)\",\n    \"new PublicKey(base58)\",\n    \"connection.getAccountInfo(pubkey)\",\n  ],\n  // A v1 dApp fragment: derive a PDA, reach for the wallet — lessons 3 and 6.\n  \"pda-dapp\": [\n    \"new PublicKey(base58)\",\n    \"PublicKey.findProgramAddressSync(seeds, programId)\",\n    \"useWallet() from @solana/wallet-adapter-react\",\n  ],\n};\n",
+        "starter": "// ─────────────────────────────────────────────────────────────────────────────\n// TEST HARNESS — do not edit. Grading calls runCase with the name of a legacy\n// call sequence (below) and checks the Kit equivalent you produce for every\n// step. The right-hand strings are exactly the ones in THE MAP in the lesson —\n// this is open book by design.\n// ─────────────────────────────────────────────────────────────────────────────\nfunction runCase(planName: string) {\n  const plan = LEGACY_PLANS[planName];\n  if (!plan) throw new Error(\"unknown legacy plan: \" + planName);\n  return modernizePlan(plan);\n}\n\n/**\n * TRANSLATION DRILL — fill in THE MAP.\n *\n * `legacy` is a sequence of calls lifted from a v1 codebase. For each one,\n * answer with the Kit equivalent, exactly as written in the lesson's map.\n * Two rows are done for you.\n */\nfunction modernizePlan(\n  legacy: string[]\n): { legacy: string; kit: string }[] {\n  const MAP: Record<string, string> = {\n    // Done for you — classes become functions:\n    \"new Connection(endpoint)\": \"createSolanaRpc(endpoint)\",\n    // Done for you — magic endpoints become explicit:\n    \"clusterApiUrl('devnet')\": \"an explicit endpoint string\",\n    // Fill in the rest from THE MAP:\n    \"new PublicKey(base58)\": \"\",\n    \"Keypair.generate()\": \"\",\n    \"SystemProgram.transfer({...})\": \"\",\n    \"sendAndConfirmTransaction(connection, tx, [payer])\": \"\",\n    \"connection.getAccountInfo(pubkey)\": \"\",\n    \"PublicKey.findProgramAddressSync(seeds, programId)\": \"\",\n    \"useWallet() from @solana/wallet-adapter-react\": \"\",\n  };\n\n  return legacy.map((call) => {\n    const kit = MAP[call];\n    if (kit === undefined || kit === \"\") {\n      throw new Error(\"no Kit equivalent recorded for: \" + call);\n    }\n    return { legacy: call, kit };\n  });\n}\n\n// ── LEGACY CALL SEQUENCES — what you will actually read in the wild ─────────\nconst LEGACY_PLANS: Record<string, string[]> = {\n  // A v1 transfer flow, top to bottom — the shape you studied in lesson 4.\n  transfer: [\n    \"new Connection(endpoint)\",\n    \"clusterApiUrl('devnet')\",\n    \"Keypair.generate()\",\n    \"SystemProgram.transfer({...})\",\n    \"sendAndConfirmTransaction(connection, tx, [payer])\",\n  ],\n  // A v1 account read — lesson 2's territory, in old clothes.\n  \"account-read\": [\n    \"new Connection(endpoint)\",\n    \"new PublicKey(base58)\",\n    \"connection.getAccountInfo(pubkey)\",\n  ],\n  // A v1 dApp fragment: derive a PDA, reach for the wallet — lessons 3 and 6.\n  \"pda-dapp\": [\n    \"new PublicKey(base58)\",\n    \"PublicKey.findProgramAddressSync(seeds, programId)\",\n    \"useWallet() from @solana/wallet-adapter-react\",\n  ],\n};\n",
+        "tests": [
+          {
+            "description": "The transfer flow translates end to end (5 steps)",
+            "expectedOutput": "result.length === 5 && result[0].kit === 'createSolanaRpc(endpoint)' && result[3].kit === 'getTransferSolInstruction({...})'",
+            "id": "t1",
+            "input": "'transfer'"
+          },
+          {
+            "description": "The confirm helper maps to the factory form, bound to rpc + subscriptions",
+            "expectedOutput": "result[4].kit === 'sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions })' && result[2].kit === 'generateKeyPairSigner()'",
+            "id": "t2",
+            "input": "'transfer'"
+          },
+          {
+            "description": "Anti-hardcode: an account-read flow you have not seen translates too",
+            "expectedOutput": "result[1].kit === 'address(base58)' && result[2].kit === 'rpc.getAccountInfo(address).send()'",
+            "failureMessage": "Every row of THE MAP must be filled — this sequence exercises rows the transfer flow never touches.",
+            "id": "t3",
+            "input": "'account-read'"
+          },
+          {
+            "description": "Anti-hardcode: the PDA + wallet fragment — note the await on the Kit derivation",
+            "expectedOutput": "result[1].kit === 'await getProgramDerivedAddress({ programAddress, seeds })' && result[2].kit === '@solana/kit-plugin-wallet (Wallet Standard)'",
+            "failureMessage": "The Kit PDA derivation is async — the map entry includes the await. And wallet-adapter maps to a protocol (Wallet Standard via kit-plugin-wallet), not to another hook.",
+            "id": "t4",
+            "input": "'pda-dapp'"
+          }
+        ],
+        "tutorNotes": [
+          "Learners fill only the rows the visible transfer flow uses and fail t3/t4, which grade an account-read and a PDA/wallet sequence. The map is the deliverable; the three plans are just probes into it.",
+          "They paraphrase the right-hand strings ('use address()' instead of 'address(base58)') and fail on strict equality. The lesson table is the answer key verbatim — this is retrieval-and-transcription by design, not creative writing.",
+          "They map findProgramAddressSync to 'getProgramDerivedAddress(...)' WITHOUT the await. The map entry includes the await deliberately — the sync-to-async seam is the most common real porting bug, and the string encodes it.",
+          "They map useWallet() to another React hook name. The answer is a protocol shift, not a hook rename: '@solana/kit-plugin-wallet (Wallet Standard)' — wallets implement the standard themselves; no per-wallet adapter packages exist in the Kit world.",
+          "They edit LEGACY_PLANS to make tests pass instead of filling MAP. The harness section is marked do-not-edit; redirect them to the empty strings in MAP.",
+          "If they ask why v1 fluency matters when they will never write it: the npm latest tag still ships v1 and ~2.1M weekly downloads read as existing codebases — reading the wild is a paid skill; writing it is technical debt."
+        ]
+      },
+      {
+        "_key": "spot",
+        "_type": "quiz",
+        "questions": [
+          {
+            "explanation": "Package imports are the fastest codebase fingerprint. wallet-adapter means the v1 world; Kit-side it would be @solana/kit-plugin-wallet and Wallet Standard discovery. Neither is broken — but you should know which world you are in by line 1.",
+            "id": "q1",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "The codebase is on the legacy wallet stack — expect v1 patterns throughout; read fluently, and budget for the fact that new code you write in Kit will sit across a seam"
+              },
+              {
+                "correct": false,
+                "feedback": "The stacks travel together: wallet-adapter pairs with v1 web3.js in practice, and a codebase importing it will almost certainly speak Connection/PublicKey everywhere. One import line is a reliable fingerprint.",
+                "id": "b",
+                "label": "Nothing — wallet-adapter is wallet plumbing, unrelated to which SDK the codebase uses"
+              },
+              {
+                "correct": false,
+                "feedback": "It works fine and runs half the dApps you have used — superseded is not broken. The read is strategic: legacy stack throughout, plan your reading and your seam accordingly.",
+                "id": "c",
+                "label": "The codebase is broken — wallet-adapter no longer works"
+              }
+            ],
+            "prompt": "First file of a bounty codebase you are evaluating shows `import { useWallet } from '@solana/wallet-adapter-react'`. What have you learned?"
+          },
+          {
+            "explanation": "The seam, stated with dates: solana.com labels v1 superseded, yet npm's latest tag ships it and ~2.1M weekly downloads keep it alive. Both facts are true at once — which is exactly why this lesson teaches you to read one stack and write the other.",
+            "id": "q2",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "The install worked — @solana/web3.js's latest tag still ships v1, so the tutorial runs today even though the stack is officially superseded"
+              },
+              {
+                "correct": false,
+                "feedback": "npm never swaps packages on you. The name @solana/web3.js still resolves to v1 at the latest tag — which is precisely why so much of the wild is still written in it.",
+                "id": "b",
+                "label": "npm redirected the install to @solana/kit"
+              },
+              {
+                "correct": false,
+                "feedback": "v1 talks to devnet fine — the chain does not care which client library built the request. Superseded describes the maintenance status and direction of the ecosystem, not an on/off switch.",
+                "id": "c",
+                "label": "The tutorial cannot run on current devnet"
+              }
+            ],
+            "prompt": "A 2024 tutorial's code runs `npm i @solana/web3.js` and uses `new Connection(...)`. A colleague says \"that package is deprecated, the install must have failed\". What actually happened?"
+          }
+        ]
+      }
+    ],
+    "skills": [
+      "solana-kit",
+      "api-currency",
+      "transactions",
+      "account-model",
+      "pdas"
+    ],
+    "slug": {
+      "_type": "slug",
+      "current": "kit-or-legacy"
+    },
+    "title": "Kit, or What You'll Find in the Wild"
+  },
+  {
+    "_id": "lesson-sfwd-see-a-live-vault",
+    "_type": "lesson",
+    "blocks": [
+      {
+        "_key": "intro",
+        "_type": "prose",
+        "src": "# See a Live Vault\n\nBefore you write a line of code, you are going to read state off a real blockchain — a program deployed on Solana's devnet, frozen so it can never change, holding a real vault account you can inspect right now.\n\nNothing in this lesson is a simulation or a screenshot. Every number you see, you read live.\n\n## Two kinds of account\n\nSolana has exactly one container for everything: the **account**. An account has an address, a lamport balance, an owner, and a slab of data bytes. What people call \"programs\" and \"data\" are both accounts — the difference is one flag:\n\n- A **program account** is marked `executable`. Its bytes are compiled code. Ours lives at [`D7ZFoWvEG5NBnkJy6iC98rhwj2qhgq8xhSD42cdTRAQd`](https://explorer.solana.com/address/D7ZFoWvEG5NBnkJy6iC98rhwj2qhgq8xhSD42cdTRAQd?cluster=devnet) — open it and the explorer says **Program**, and its **Upgradeable** field says **No**. That is the freeze: the deploy authority was burned, so this exact code is what runs, forever.\n- A **data account** is not executable. Its bytes are state. The vault you will spend three courses with lives at [`FY86s1fAwUiFQTjVFYprsiV6fwNH7e955MSUBo73FP4j`](https://explorer.solana.com/address/FY86s1fAwUiFQTjVFYprsiV6fwNH7e955MSUBo73FP4j?cluster=devnet).\n\nOpen the vault link and read it like a table:\n\n- **Balance** — the account's lamports. A lamport is a billionth of a SOL, and it is the native unit everything on Solana is denominated in. Read the number off the page; it is live, and later in this course you will change it.\n- **Owner** — the program allowed to modify this account's data: `D7ZF…` — our vault program. On Solana *the owner of a data account is a program*, not a person. The person is recorded somewhere else, as you will see in the next lesson.\n- **Allocated Data Size** — 49 bytes. Small enough that in the next lesson you will decode every single one by hand.\n- **Executable** — No. State, not code.\n\nOne habit to build immediately: the `?cluster=devnet` at the end of those URLs. The explorer defaults to mainnet, where none of this exists — drop the parameter and it will tell you the account is not found, and you will waste an hour concluding the chain ate your work. It didn't. You were looking at the wrong chain.\n\n## Why the balance is a moving target\n\nThis lesson will not tell you the vault's balance, on purpose. Other learners are depositing into this same account while you read this. Any number printed here would be stale by tonight — so the rule of this course is: **numbers come from the chain, not from the lesson**. Read it yourself; that is the skill.\n\n## Rent: why accounts hold lamports at all\n\nEvery account must keep a minimum lamport balance proportional to its data size — called **rent-exemption**. It is a refundable deposit, not a fee: storage on every validator costs something, so the network requires accounts to lock roughly 0.00089 SOL plus a per-byte amount, and returns it when the account closes. An account below its minimum can be garbage-collected. In module 3 your inspector will compute this minimum for any account and report whether the account clears it.\n\n## The explorer below\n\nUnder this text is the same program, embedded — its three instructions (`initialize_vault`, `deposit`, `withdraw`) read from the program's published interface, the **IDL**. Don't call anything yet; you have no wallet and no funds, and that is fine. Just open each instruction and read what it wants: which accounts it touches, who must sign, what arguments it takes. Notice `deposit` lists the vault account **first**, then the user, then the System Program — that exact order matters in module 2, when you build this call yourself.\n\nThen take the quiz — it asks you to predict what the chain does, and every answer is checkable against the pages you just opened.\n"
+      },
+      {
+        "_key": "explore",
+        "_type": "program-explorer",
+        "idl": "{\n  \"address\": \"D7ZFoWvEG5NBnkJy6iC98rhwj2qhgq8xhSD42cdTRAQd\",\n  \"metadata\": {\n    \"name\": \"vault_program\",\n    \"version\": \"0.1.0\",\n    \"spec\": \"0.1.0\"\n  },\n  \"instructions\": [\n    {\n      \"name\": \"deposit\",\n      \"docs\": [\n        \"Module 3. Lamports IN move via a System Program CPI, because the debited\",\n        \"account is the user's wallet and System owns that. The recorded balance\",\n        \"moves via your Course 2 method. Two writes that have to agree.\"\n      ],\n      \"discriminator\": [242, 35, 198, 137, 82, 225, 242, 182],\n      \"accounts\": [\n        {\n          \"name\": \"vault\",\n          \"writable\": true,\n          \"pda\": {\n            \"seeds\": [\n              {\n                \"kind\": \"const\",\n                \"value\": [118, 97, 117, 108, 116]\n              },\n              {\n                \"kind\": \"account\",\n                \"path\": \"user\"\n              }\n            ]\n          }\n        },\n        {\n          \"name\": \"user\",\n          \"writable\": true,\n          \"signer\": true\n        },\n        {\n          \"name\": \"system_program\",\n          \"address\": \"11111111111111111111111111111111\"\n        }\n      ],\n      \"args\": [\n        {\n          \"name\": \"amount\",\n          \"type\": \"u64\"\n        }\n      ]\n    },\n    {\n      \"name\": \"initialize_vault\",\n      \"docs\": [\n        \"Module 2. Creates the per-user vault PDA and stores the canonical bump.\"\n      ],\n      \"discriminator\": [48, 191, 163, 44, 71, 129, 63, 164],\n      \"accounts\": [\n        {\n          \"name\": \"vault\",\n          \"writable\": true,\n          \"pda\": {\n            \"seeds\": [\n              {\n                \"kind\": \"const\",\n                \"value\": [118, 97, 117, 108, 116]\n              },\n              {\n                \"kind\": \"account\",\n                \"path\": \"user\"\n              }\n            ]\n          }\n        },\n        {\n          \"name\": \"user\",\n          \"writable\": true,\n          \"signer\": true\n        },\n        {\n          \"name\": \"system_program\",\n          \"address\": \"11111111111111111111111111111111\"\n        }\n      ],\n      \"args\": []\n    },\n    {\n      \"name\": \"withdraw\",\n      \"docs\": [\n        \"Module 3, and the instruction with no CPI in it. The debited account is\",\n        \"the vault, which OUR program owns — so our program may move its lamports\",\n        \"directly. The System Program could not do it for us at any price: it\",\n        \"refuses to debit an account carrying data, and it does not own this one.\"\n      ],\n      \"discriminator\": [183, 18, 70, 156, 148, 109, 161, 34],\n      \"accounts\": [\n        {\n          \"name\": \"vault\",\n          \"writable\": true,\n          \"pda\": {\n            \"seeds\": [\n              {\n                \"kind\": \"const\",\n                \"value\": [118, 97, 117, 108, 116]\n              },\n              {\n                \"kind\": \"account\",\n                \"path\": \"user\"\n              }\n            ]\n          }\n        },\n        {\n          \"name\": \"user\",\n          \"writable\": true,\n          \"signer\": true\n        }\n      ],\n      \"args\": [\n        {\n          \"name\": \"amount\",\n          \"type\": \"u64\"\n        }\n      ]\n    }\n  ],\n  \"accounts\": [\n    {\n      \"name\": \"VaultState\",\n      \"discriminator\": [228, 196, 82, 165, 98, 210, 235, 152]\n    }\n  ],\n  \"errors\": [\n    {\n      \"code\": 6000,\n      \"name\": \"Overflow\",\n      \"msg\": \"Deposit would overflow the vault balance\"\n    },\n    {\n      \"code\": 6001,\n      \"name\": \"InsufficientFunds\",\n      \"msg\": \"Withdrawal is larger than the vault balance\"\n    },\n    {\n      \"code\": 6002,\n      \"name\": \"ZeroAmount\",\n      \"msg\": \"Amount must be greater than zero\"\n    },\n    {\n      \"code\": 6003,\n      \"name\": \"NotOwner\",\n      \"msg\": \"Signer is not the vault owner\"\n    }\n  ],\n  \"types\": [\n    {\n      \"name\": \"VaultState\",\n      \"type\": {\n        \"kind\": \"struct\",\n        \"fields\": [\n          {\n            \"name\": \"owner\",\n            \"type\": \"pubkey\"\n          },\n          {\n            \"name\": \"balance\",\n            \"type\": \"u64\"\n          },\n          {\n            \"name\": \"bump\",\n            \"type\": \"u8\"\n          }\n        ]\n      }\n    }\n  ]\n}\n"
+      },
+      {
+        "_key": "predict",
+        "_type": "quiz",
+        "questions": [
+          {
+            "explanation": "Owner on a Solana account means the owning program — the only program permitted to modify the account's data (and debit its lamports). The human \"owner\" of the vault is a field inside those 49 data bytes, which is the next lesson's job.",
+            "id": "q1",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "Only the vault program may modify this account's data — on Solana, a data account's owner is a program, not a person"
+              },
+              {
+                "correct": false,
+                "feedback": "`D7ZF…` is the program, not a wallet. The person behind the vault is recorded inside the account's data bytes — you will decode that field in the next lesson. The explorer's Owner field is always the owning program.",
+                "id": "b",
+                "label": "The wallet that created the vault is `D7ZF…`, so that person controls it"
+              },
+              {
+                "correct": false,
+                "feedback": "Code lives in the program account, which is marked executable. This account's Executable field says No — its 49 bytes are state, and the Owner field names the one program allowed to change them.",
+                "id": "c",
+                "label": "The account holds the program's source code"
+              }
+            ],
+            "prompt": "You open the vault account `FY86…` in the explorer and its Owner field says `D7ZF…` — the vault program. Predict what that means."
+          },
+          {
+            "explanation": "Frozen means frozen: with the upgrade authority set to none, the deployed bytes are permanent. That immutability is why every lesson in this course can safely pin this program's address and behavior.",
+            "id": "q2",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "They cannot — the upgrade authority was removed, so this exact code runs forever; a change means deploying a new program at a new address"
+              },
+              {
+                "correct": false,
+                "feedback": "That is what an upgradeable program allows — and exactly what this one gave up. With the authority burned, nobody can write new code to this address, which is why this course can pin it.",
+                "id": "b",
+                "label": "They redeploy over the same address with a new version"
+              },
+              {
+                "correct": false,
+                "feedback": "Validators vote on protocol upgrades, not on individual programs. A program's code changes only through its upgrade authority, and this program no longer has one.",
+                "id": "c",
+                "label": "They ask the validators to vote on the change"
+              }
+            ],
+            "prompt": "The program account `D7ZF…` shows Upgradeable: No. Predict what happens if the original authors want to change its code."
+          },
+          {
+            "explanation": "The explorer defaults to mainnet. Same address, different chain, no account — so the report is \"not found\" even though the devnet account is untouched. Check the cluster parameter before concluding anything about your account.",
+            "id": "q3",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "Unchanged and fine — the explorer defaulted to mainnet, a different chain where this address holds nothing"
+              },
+              {
+                "correct": false,
+                "feedback": "Nothing was deleted; the wrong chain was queried. Mainnet and devnet are separate ledgers, and an address that holds an account on one holds nothing on the other. Re-add ?cluster=devnet and the vault is right where it was.",
+                "id": "b",
+                "label": "Deleted — devnet accounts are periodically wiped"
+              },
+              {
+                "correct": false,
+                "feedback": "The vault's balance is comfortably above the ~0.0012 SOL minimum for a 49-byte account — read it live and check. The \"not found\" here is the missing cluster parameter, the single most common explorer mistake.",
+                "id": "c",
+                "label": "Below its rent-exempt minimum, so it was garbage-collected"
+              }
+            ],
+            "prompt": "A friend opens your vault link without `?cluster=devnet` and the explorer reports \"Account not found\". Predict the actual state of the vault."
+          },
+          {
+            "explanation": "An account's lamports are part of the account itself and are fully public. This one carries its rent deposit plus every deposit learners have made — a moving number, which is why the course rule is to read values live, never quote them.",
+            "id": "q4",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "The rent-exemption deposit plus everything deposited into the vault — lamports live on the account itself, and the balance moves as learners deposit"
+              },
+              {
+                "correct": false,
+                "feedback": "It started near the minimum, but deposits land on this same account, so the live balance is minimum plus deposits — which is why this lesson refuses to print the number. Read it off the chain.",
+                "id": "b",
+                "label": "Exactly the rent-exemption minimum, fixed at creation"
+              },
+              {
+                "correct": false,
+                "feedback": "Everything on Solana is public. The explorer shows the exact live lamport balance of any account to anyone — that openness is what makes the inspector you build in module 3 possible.",
+                "id": "c",
+                "label": "A display estimate — real balances are only visible to the account's owner"
+              }
+            ],
+            "prompt": "The vault account is 49 bytes and rent-exemption for 49 bytes is about 0.0012 SOL. Predict what the account's lamport balance you read in the explorer represents."
+          }
+        ]
+      }
+    ],
+    "skills": [
+      "account-model",
+      "explorer-reading"
+    ],
+    "slug": {
+      "_type": "slug",
+      "current": "see-a-live-vault"
+    },
+    "title": "See a Live Vault"
+  },
+  {
+    "_id": "lesson-sfwd-ship-the-inspector",
+    "_type": "lesson",
+    "blocks": [
+      {
+        "_key": "intro",
+        "_type": "prose",
+        "src": "# Ship the Inspector\n\n> Version stamp — `@solana/kit` 7.0.0 · devnet · authored 2026-07-28.\n\nNo new API in this lesson. You have every part: the RPC read from lesson 2, the byte decode from lesson 2, the derivation from lesson 3, rent-exemption from lesson 1. Today you assemble them into the module's deliverable — an **account inspector** — and the assembly is where the engineering lives.\n\n## The spec\n\n`inspect(address)` answers, for **any** devnet address:\n\n- **type** — one of `missing`, `system-owned`, `program`, `vault`, `other`;\n- **lamports** and **sol** — the balance, exact (bigint) and human-readable;\n- **ownerProgram** — who may modify it;\n- **rentExempt** — does the balance clear `getMinimumBalanceForRentExemption(dataLength)`;\n- **vault** — the decoded `{ owner, balance, bump }`, **but only when it really is a vault**: owned by the vault program *and* carrying the `VaultState` discriminator with the exact 49-byte layout. Otherwise `null`.\n\n## Acceptance criteria: the failure paths\n\nPaste-any-address means the input is hostile by default. The inspector's grade lives in what it does when the account is *not* the happy path:\n\n1. **The address does not exist** — RPC returns `{ value: null }`. Report `missing`; never touch fields that are not there.\n2. **The account exists but has no data** — a plain wallet: zero-length data, system-owned. There is nothing to decode, and trying is a bug.\n3. **The account is a program** — `executable` is set; its bytes are code, not state.\n4. **The account is owned by some other program** — a sysvar, a token account, anything. Not yours to decode: `other`.\n5. **The account is owned by the vault program but is not a VaultState** — wrong length or wrong discriminator. This is the trap lesson 2's quiz warned about: a blind decode *succeeds mechanically* and returns confident garbage. The discriminator check is what stands between your inspector and lying.\n\nOrder matters: check existence before anything, executability and ownership before shape, shape before decode. A branch order that \"mostly works\" is how inspectors end up reporting a sysvar as a vault.\n\n## Two rungs\n\n**Rung 1 — the branch table.** `classifyAccount(acc)` returns just the type. The lines are in a parts bin, scrambled, with two decoys: one classifies any vault-program-owned account as a vault without checking its shape (criterion 5's bug, made flesh), and one declares zero-length accounts `missing` (an existing empty account is not missing — criterion 2 vs 1).\n\n**Rung 2 — the whole inspector.** `inspect(acc, minRentFor)` — written by you from the spec, no pattern shown, no scaffold. Your rung-1 logic is the spine; add the balance report, rent-exemption, and the guarded decode (your lesson-2 decoder, now with the discriminator check in front). Rent minimums are injected as a recorded-real lookup, and the fee fixtures include a vault-program-owned account that is **not** rent-exempt — the check must use the real minimum for *that* account's data length, not a constant.\n\nBoth rungs grade over **recorded real devnet accounts** — the reference vault, a second vault instance, a wallet, the frozen program itself, and a sysvar — plus one synthetic layout probe (a truncated vault-owned account; details in the fixture comments). The set is exactly the taxonomy above; when it passes, your inspector has handled every failure path this course knows how to produce.\n\nThen the quiz asks you to predict failure paths, and the reflection asks which one taught you something.\n"
+      },
+      {
+        "_key": "classify",
+        "_type": "code",
+        "buildType": "standard",
+        "deployable": false,
+        "hints": [
+          "Five branches, and the FIRST must be the null check — every other branch dereferences acc.value.",
+          "Two vault branches are in the bin; only one checks hasVaultShape. The truncated-vault fixture exists to catch the one that doesn't.",
+          "An account with data.length === 0 still exists — the wallet fixture proves it. 'missing' is reserved for { value: null }."
+        ],
+        "language": "typescript",
+        "solution": "// ─────────────────────────────────────────────────────────────────────────────\n// TEST HARNESS — do not edit. Grading calls runCase with a fixture name and\n// hands classifyAccount the recorded account, in the exact shape an RPC\n// getAccountInfo read returns: { value: null } for a missing account,\n// { value: { lamports, ownerProgram, executable, data } } otherwise.\n// ─────────────────────────────────────────────────────────────────────────────\nfunction runCase(fixtureName: string) {\n  const acc = ACCOUNTS[fixtureName];\n  if (acc === undefined) throw new Error(\"unknown fixture: \" + fixtureName);\n  return classifyAccount(acc);\n}\n\ntype AccountInfo = {\n  value: {\n    lamports: bigint;\n    ownerProgram: string;\n    executable: boolean;\n    data: number[];\n  } | null;\n};\n\n/**\n * RUNG 1 — the branch table. Return exactly one of:\n * \"missing\" | \"system-owned\" | \"program\" | \"vault\" | \"other\".\n *\n * The seven candidate branches are in the PARTS BIN, shuffled. FIVE belong,\n * in the right order. Two are decoys:\n *   - one trusts ownership alone and skips the shape check — the exact bug\n *     that makes an inspector report garbage as a vault;\n *   - one calls an existing empty account \"missing\" — an account with no\n *     data still exists.\n * Uncomment the branches you want, in order. Do not write branches that are\n * not in the bin.\n *\n * ┌─ PARTS BIN ──────────────────────────────────────────────────────────┐\n * │ (A)  if (acc.value.ownerProgram === VAULT_PROGRAM) return \"vault\";   │\n * │ (B)  if (acc.value === null) return \"missing\";                       │\n * │ (C)  return \"other\";                                                 │\n * │ (D)  if (acc.value.data.length === 0) return \"missing\";              │\n * │ (E)  if (acc.value.executable) return \"program\";                     │\n * │ (F)  if (acc.value.ownerProgram === SYSTEM_PROGRAM)                  │\n * │        return \"system-owned\";                                        │\n * │ (G)  if (acc.value.ownerProgram === VAULT_PROGRAM &&                 │\n * │          hasVaultShape(acc.value.data)) return \"vault\";              │\n * └──────────────────────────────────────────────────────────────────────┘\n */\nfunction classifyAccount(\n  acc: AccountInfo\n): \"missing\" | \"system-owned\" | \"program\" | \"vault\" | \"other\" {\n  // (B) — existence first: nothing else may touch acc.value before this.\n  if (acc.value === null) return \"missing\";\n  // (E) — executable means code; its bytes are not state to decode.\n  if (acc.value.executable) return \"program\";\n  // (F) — system-owned covers wallets, INCLUDING empty ones. (D) was the\n  // decoy here: an existing account with no data is not \"missing\".\n  if (acc.value.ownerProgram === SYSTEM_PROGRAM) return \"system-owned\";\n  // (G) — ownership AND shape. (A) was the other decoy: trusting ownership\n  // alone reports any vault-program-owned bytes as a vault — confident\n  // garbage, the criterion-5 bug.\n  if (acc.value.ownerProgram === VAULT_PROGRAM && hasVaultShape(acc.value.data))\n    return \"vault\";\n  // (C) — everything else is someone else's account.\n  return \"other\";\n}\n\n// ── PROVIDED ────────────────────────────────────────────────────────────────\nconst VAULT_PROGRAM = \"D7ZFoWvEG5NBnkJy6iC98rhwj2qhgq8xhSD42cdTRAQd\";\nconst SYSTEM_PROGRAM = \"11111111111111111111111111111111\";\nconst VAULT_DISCRIMINATOR = [228, 196, 82, 165, 98, 210, 235, 152];\n\n/** True iff the bytes have the exact VaultState shape: 49 bytes, tag first. */\nfunction hasVaultShape(data: number[]): boolean {\n  if (data.length !== 49) return false;\n  for (let i = 0; i < 8; i++) {\n    if (data[i] !== VAULT_DISCRIMINATOR[i]) return false;\n  }\n  return true;\n}\n\n// ── RECORDED FIXTURES — real devnet accounts, captured 2026-07-28, except\n// \"second-vault\" (constructed byte-for-byte to the frozen VaultState layout\n// for a real derived PDA) and \"truncated-vault\" (a synthetic layout probe:\n// vault-program-owned bytes that are NOT a VaultState) ──────────────────────\nconst ACCOUNTS: Record<string, AccountInfo> = {\n  // FY86s1fAwUiFQTjVFYprsiV6fwNH7e955MSUBo73FP4j — the reference vault.\n  \"reference-vault\": {\n    value: {\n      lamports: 101231920n,\n      ownerProgram: \"D7ZFoWvEG5NBnkJy6iC98rhwj2qhgq8xhSD42cdTRAQd\",\n      executable: false,\n      data: [\n        228, 196, 82, 165, 98, 210, 235, 152, 78, 181, 115, 75, 97, 15, 248,\n        39, 115, 50, 94, 194, 229, 144, 50, 163, 140, 21, 194, 79, 145, 31,\n        240, 203, 132, 30, 178, 177, 89, 213, 11, 199, 0, 225, 245, 5, 0, 0,\n        0, 0, 255,\n      ],\n    },\n  },\n  // EMTqK9Cfac1X7c86GUYG5wwGkqR9HpeYkqUDvjLmhgKi — a different vault.\n  \"second-vault\": {\n    value: {\n      lamports: 3731920n,\n      ownerProgram: \"D7ZFoWvEG5NBnkJy6iC98rhwj2qhgq8xhSD42cdTRAQd\",\n      executable: false,\n      data: [\n        228, 196, 82, 165, 98, 210, 235, 152, 250, 81, 168, 175, 243, 7, 13,\n        139, 135, 233, 111, 129, 165, 52, 141, 25, 59, 70, 254, 154, 56, 95,\n        224, 164, 40, 67, 110, 98, 15, 29, 43, 19, 160, 37, 38, 0, 0, 0, 0,\n        0, 252,\n      ],\n    },\n  },\n  // 6JFH1dxqiw6Dc81CbWdx4TUT8CvAfgwZg33wQrSytZsU — a plain wallet: exists,\n  // zero-length data, system-owned.\n  wallet: {\n    value: {\n      lamports: 3331870864n,\n      ownerProgram: \"11111111111111111111111111111111\",\n      executable: false,\n      data: [],\n    },\n  },\n  // D7ZFoWvEG5NBnkJy6iC98rhwj2qhgq8xhSD42cdTRAQd — the frozen program itself.\n  program: {\n    value: {\n      lamports: 1141440n,\n      ownerProgram: \"BPFLoaderUpgradeab1e11111111111111111111111\",\n      executable: true,\n      data: [\n        2, 0, 0, 0, 68, 241, 198, 255, 117, 99, 71, 101, 249, 222, 102, 97,\n        219, 215, 40, 216, 232, 31, 153, 137, 220, 115, 36, 234, 236, 38, 120,\n        161, 231, 188, 130, 216,\n      ],\n    },\n  },\n  // SysvarC1ock11111111111111111111111111111111 — the clock, a real account\n  // owned by a program that is neither System nor the vault program.\n  \"clock-sysvar\": {\n    value: {\n      lamports: 1169280n,\n      ownerProgram: \"Sysvar1111111111111111111111111111111111111\",\n      executable: false,\n      data: [\n        23, 157, 149, 28, 0, 0, 0, 0, 112, 187, 104, 106, 0, 0, 0, 0, 86, 4,\n        0, 0, 0, 0, 0, 0, 87, 4, 0, 0, 0, 0, 0, 0, 244, 254, 104, 106, 0, 0,\n        0, 0,\n      ],\n    },\n  },\n  // Synthetic: owned by the vault program, but 12 bytes — NOT a VaultState.\n  // The account your inspector must refuse to decode.\n  \"truncated-vault\": {\n    value: {\n      lamports: 900000n,\n      ownerProgram: \"D7ZFoWvEG5NBnkJy6iC98rhwj2qhgq8xhSD42cdTRAQd\",\n      executable: false,\n      data: [228, 196, 82, 165, 98, 210, 235, 152, 78, 181, 115, 75],\n    },\n  },\n  // An address nobody has ever funded: the RPC answer is { value: null }.\n  missing: { value: null },\n};\n",
+        "starter": "// ─────────────────────────────────────────────────────────────────────────────\n// TEST HARNESS — do not edit. Grading calls runCase with a fixture name and\n// hands classifyAccount the recorded account, in the exact shape an RPC\n// getAccountInfo read returns: { value: null } for a missing account,\n// { value: { lamports, ownerProgram, executable, data } } otherwise.\n// ─────────────────────────────────────────────────────────────────────────────\nfunction runCase(fixtureName: string) {\n  const acc = ACCOUNTS[fixtureName];\n  if (acc === undefined) throw new Error(\"unknown fixture: \" + fixtureName);\n  return classifyAccount(acc);\n}\n\ntype AccountInfo = {\n  value: {\n    lamports: bigint;\n    ownerProgram: string;\n    executable: boolean;\n    data: number[];\n  } | null;\n};\n\n/**\n * RUNG 1 — the branch table. Return exactly one of:\n * \"missing\" | \"system-owned\" | \"program\" | \"vault\" | \"other\".\n *\n * The seven candidate branches are in the PARTS BIN, shuffled. FIVE belong,\n * in the right order. Two are decoys:\n *   - one trusts ownership alone and skips the shape check — the exact bug\n *     that makes an inspector report garbage as a vault;\n *   - one calls an existing empty account \"missing\" — an account with no\n *     data still exists.\n * Uncomment the branches you want, in order. Do not write branches that are\n * not in the bin.\n *\n * ┌─ PARTS BIN ──────────────────────────────────────────────────────────┐\n * │ (A)  if (acc.value.ownerProgram === VAULT_PROGRAM) return \"vault\";   │\n * │ (B)  if (acc.value === null) return \"missing\";                       │\n * │ (C)  return \"other\";                                                 │\n * │ (D)  if (acc.value.data.length === 0) return \"missing\";              │\n * │ (E)  if (acc.value.executable) return \"program\";                     │\n * │ (F)  if (acc.value.ownerProgram === SYSTEM_PROGRAM)                  │\n * │        return \"system-owned\";                                        │\n * │ (G)  if (acc.value.ownerProgram === VAULT_PROGRAM &&                 │\n * │          hasVaultShape(acc.value.data)) return \"vault\";              │\n * └──────────────────────────────────────────────────────────────────────┘\n */\nfunction classifyAccount(\n  acc: AccountInfo\n): \"missing\" | \"system-owned\" | \"program\" | \"vault\" | \"other\" {\n  // Assemble five branches from the parts bin here, then delete the throw.\n  throw new Error(\"assemble the branch table from the parts bin\");\n}\n\n// ── PROVIDED ────────────────────────────────────────────────────────────────\nconst VAULT_PROGRAM = \"D7ZFoWvEG5NBnkJy6iC98rhwj2qhgq8xhSD42cdTRAQd\";\nconst SYSTEM_PROGRAM = \"11111111111111111111111111111111\";\nconst VAULT_DISCRIMINATOR = [228, 196, 82, 165, 98, 210, 235, 152];\n\n/** True iff the bytes have the exact VaultState shape: 49 bytes, tag first. */\nfunction hasVaultShape(data: number[]): boolean {\n  if (data.length !== 49) return false;\n  for (let i = 0; i < 8; i++) {\n    if (data[i] !== VAULT_DISCRIMINATOR[i]) return false;\n  }\n  return true;\n}\n\n// ── RECORDED FIXTURES — real devnet accounts, captured 2026-07-28, except\n// \"second-vault\" (constructed byte-for-byte to the frozen VaultState layout\n// for a real derived PDA) and \"truncated-vault\" (a synthetic layout probe:\n// vault-program-owned bytes that are NOT a VaultState) ──────────────────────\nconst ACCOUNTS: Record<string, AccountInfo> = {\n  // FY86s1fAwUiFQTjVFYprsiV6fwNH7e955MSUBo73FP4j — the reference vault.\n  \"reference-vault\": {\n    value: {\n      lamports: 101231920n,\n      ownerProgram: \"D7ZFoWvEG5NBnkJy6iC98rhwj2qhgq8xhSD42cdTRAQd\",\n      executable: false,\n      data: [\n        228, 196, 82, 165, 98, 210, 235, 152, 78, 181, 115, 75, 97, 15, 248,\n        39, 115, 50, 94, 194, 229, 144, 50, 163, 140, 21, 194, 79, 145, 31,\n        240, 203, 132, 30, 178, 177, 89, 213, 11, 199, 0, 225, 245, 5, 0, 0,\n        0, 0, 255,\n      ],\n    },\n  },\n  // EMTqK9Cfac1X7c86GUYG5wwGkqR9HpeYkqUDvjLmhgKi — a different vault.\n  \"second-vault\": {\n    value: {\n      lamports: 3731920n,\n      ownerProgram: \"D7ZFoWvEG5NBnkJy6iC98rhwj2qhgq8xhSD42cdTRAQd\",\n      executable: false,\n      data: [\n        228, 196, 82, 165, 98, 210, 235, 152, 250, 81, 168, 175, 243, 7, 13,\n        139, 135, 233, 111, 129, 165, 52, 141, 25, 59, 70, 254, 154, 56, 95,\n        224, 164, 40, 67, 110, 98, 15, 29, 43, 19, 160, 37, 38, 0, 0, 0, 0,\n        0, 252,\n      ],\n    },\n  },\n  // 6JFH1dxqiw6Dc81CbWdx4TUT8CvAfgwZg33wQrSytZsU — a plain wallet: exists,\n  // zero-length data, system-owned.\n  wallet: {\n    value: {\n      lamports: 3331870864n,\n      ownerProgram: \"11111111111111111111111111111111\",\n      executable: false,\n      data: [],\n    },\n  },\n  // D7ZFoWvEG5NBnkJy6iC98rhwj2qhgq8xhSD42cdTRAQd — the frozen program itself.\n  program: {\n    value: {\n      lamports: 1141440n,\n      ownerProgram: \"BPFLoaderUpgradeab1e11111111111111111111111\",\n      executable: true,\n      data: [\n        2, 0, 0, 0, 68, 241, 198, 255, 117, 99, 71, 101, 249, 222, 102, 97,\n        219, 215, 40, 216, 232, 31, 153, 137, 220, 115, 36, 234, 236, 38, 120,\n        161, 231, 188, 130, 216,\n      ],\n    },\n  },\n  // SysvarC1ock11111111111111111111111111111111 — the clock, a real account\n  // owned by a program that is neither System nor the vault program.\n  \"clock-sysvar\": {\n    value: {\n      lamports: 1169280n,\n      ownerProgram: \"Sysvar1111111111111111111111111111111111111\",\n      executable: false,\n      data: [\n        23, 157, 149, 28, 0, 0, 0, 0, 112, 187, 104, 106, 0, 0, 0, 0, 86, 4,\n        0, 0, 0, 0, 0, 0, 87, 4, 0, 0, 0, 0, 0, 0, 244, 254, 104, 106, 0, 0,\n        0, 0,\n      ],\n    },\n  },\n  // Synthetic: owned by the vault program, but 12 bytes — NOT a VaultState.\n  // The account your inspector must refuse to decode.\n  \"truncated-vault\": {\n    value: {\n      lamports: 900000n,\n      ownerProgram: \"D7ZFoWvEG5NBnkJy6iC98rhwj2qhgq8xhSD42cdTRAQd\",\n      executable: false,\n      data: [228, 196, 82, 165, 98, 210, 235, 152, 78, 181, 115, 75],\n    },\n  },\n  // An address nobody has ever funded: the RPC answer is { value: null }.\n  missing: { value: null },\n};\n",
+        "tests": [
+          {
+            "description": "The reference vault classifies as a vault",
+            "expectedOutput": "result === 'vault'",
+            "id": "t1",
+            "input": "'reference-vault'"
+          },
+          {
+            "description": "An existing wallet with zero-length data is system-owned — NOT missing",
+            "expectedOutput": "result === 'system-owned'",
+            "failureMessage": "Decoy (D) trips here: an account with no data still exists. Only { value: null } is missing.",
+            "id": "t2",
+            "input": "'wallet'"
+          },
+          {
+            "description": "A { value: null } RPC answer is the only 'missing'",
+            "expectedOutput": "result === 'missing'",
+            "failureMessage": "Existence must be the FIRST branch — every other check dereferences acc.value and throws on null.",
+            "id": "t3",
+            "input": "'missing'"
+          },
+          {
+            "description": "The frozen program itself classifies as a program",
+            "expectedOutput": "result === 'program'",
+            "id": "t4",
+            "input": "'program'"
+          },
+          {
+            "description": "Anti-hardcode: a different vault instance is still a vault",
+            "expectedOutput": "result === 'vault'",
+            "id": "t5",
+            "input": "'second-vault'"
+          },
+          {
+            "description": "A real account owned by a foreign program (the clock sysvar) is 'other'",
+            "expectedOutput": "result === 'other'",
+            "id": "t6",
+            "input": "'clock-sysvar'"
+          },
+          {
+            "description": "Vault-program-owned bytes WITHOUT the VaultState shape are 'other', never 'vault'",
+            "expectedOutput": "result === 'other'",
+            "failureMessage": "Decoy (A) trips here: ownership alone is not enough. The vault branch must also check hasVaultShape — 49 bytes and the discriminator.",
+            "id": "t7",
+            "input": "'truncated-vault'"
+          }
+        ],
+        "tutorNotes": [
+          "Learners order the null check late and t3 dies with a null dereference instead of returning 'missing'. Existence is the first branch by necessity, not style — every other branch reads acc.value.",
+          "They pick decoy (A), classifying by ownership alone, and t7 reports 'vault' for 12 truncated bytes. This is the criterion-5 bug the lesson names: a blind decode succeeds mechanically; the shape check (49 bytes + discriminator) is the only defense.",
+          "They pick decoy (D) and call the zero-data wallet 'missing' at t2. Distinguish the two absences: no ACCOUNT is { value: null }; no DATA is an existing account with an empty byte array — a plain wallet.",
+          "They put the system-owned check after the vault check and worry the order is wrong. Here either order passes — the conditions are mutually exclusive — but executable-before-ownership matters: a program's owner is a loader, and classifying by ownership first would bury 'program'.",
+          "They write branches from memory instead of the bin and drift the return strings ('wallet' instead of 'system-owned'). The five type strings are the contract rung 2 and the tests share — exact strings, from the bin."
+        ]
+      },
+      {
+        "_key": "inspect",
+        "_type": "code",
+        "buildType": "standard",
+        "deployable": false,
+        "hints": [
+          "Start with the missing case: return the all-null report before touching acc.value. Then reuse your rung-1 branch order for type.",
+          "rentExempt compares against minRentFor(v.data.length) — the length of THIS account's data. The truncated-vault fixture is deliberately below its minimum.",
+          "Decode only when type === 'vault': bytes 8..39 through toBase58, getBigUint64(40, true), byte 48 — your lesson-2 decoder, behind the shape check."
+        ],
+        "language": "typescript",
+        "solution": "// ─────────────────────────────────────────────────────────────────────────────\n// TEST HARNESS — do not edit. Grading calls runCase with a fixture name and\n// hands your inspect the recorded account plus minRentFor — the injected\n// rent-exemption lookup (getMinimumBalanceForRentExemption, recorded from\n// devnet 2026-07-28: 0 bytes → 890,880 lamports; 49 bytes → 1,231,920).\n// ─────────────────────────────────────────────────────────────────────────────\nfunction runCase(fixtureName: string) {\n  const acc = ACCOUNTS[fixtureName];\n  if (acc === undefined) throw new Error(\"unknown fixture: \" + fixtureName);\n  return inspect(acc, minRentFor);\n}\n\ntype AccountInfo = {\n  value: {\n    lamports: bigint;\n    ownerProgram: string;\n    executable: boolean;\n    data: number[];\n  } | null;\n};\n\ntype Report = {\n  type: \"missing\" | \"system-owned\" | \"program\" | \"vault\" | \"other\";\n  lamports: bigint | null;\n  sol: string | null;\n  ownerProgram: string | null;\n  rentExempt: boolean | null;\n  vault: { owner: string; balance: bigint; bump: number } | null;\n};\n\n/**\n * RUNG 2 — the whole inspector, written by you from the spec. No pattern\n * this time; the spec from the lesson is the contract:\n *\n *   - type: your rung-1 classification, same five values, same order of\n *     checks (existence → executable → system-owned → vault-with-shape →\n *     other).\n *   - For a MISSING account every other field is null.\n *   - lamports: the exact balance (bigint). sol: lamportsToSol(lamports).\n *   - ownerProgram: as recorded.\n *   - rentExempt: lamports >= minRentFor(data.length) — the minimum for\n *     THIS account's data length, not a constant.\n *   - vault: the decoded { owner, balance, bump } — your lesson-2 decoder —\n *     but ONLY when type is \"vault\". Everything else gets null, including\n *     accounts owned by the vault program whose bytes are not a VaultState.\n *\n * Helpers provided below: hasVaultShape, toBase58, lamportsToSol, and the\n * constants. The byte offsets are the ones you have known since lesson 2:\n * owner at 8..39, balance u64 LE at 40, bump at 48.\n */\nfunction inspect(\n  acc: AccountInfo,\n  minRentFor: (dataLength: number) => bigint\n): Report {\n  if (acc.value === null) {\n    return {\n      type: \"missing\",\n      lamports: null,\n      sol: null,\n      ownerProgram: null,\n      rentExempt: null,\n      vault: null,\n    };\n  }\n  const v = acc.value;\n\n  // The rung-1 branch table, existence already handled above.\n  let type: Report[\"type\"];\n  if (v.executable) type = \"program\";\n  else if (v.ownerProgram === SYSTEM_PROGRAM) type = \"system-owned\";\n  else if (v.ownerProgram === VAULT_PROGRAM && hasVaultShape(v.data))\n    type = \"vault\";\n  else type = \"other\";\n\n  // Rent-exemption against the minimum for THIS account's data length.\n  const rentExempt = v.lamports >= minRentFor(v.data.length);\n\n  // The guarded decode: only a shape-checked vault is decoded.\n  let vault: Report[\"vault\"] = null;\n  if (type === \"vault\") {\n    const bytes = new Uint8Array(v.data);\n    const view = new DataView(bytes.buffer);\n    vault = {\n      owner: toBase58(bytes.slice(8, 40)),\n      balance: view.getBigUint64(40, true),\n      bump: bytes[48],\n    };\n  }\n\n  return {\n    type,\n    lamports: v.lamports,\n    sol: lamportsToSol(v.lamports),\n    ownerProgram: v.ownerProgram,\n    rentExempt,\n    vault,\n  };\n}\n\n// ── PROVIDED ────────────────────────────────────────────────────────────────\nconst VAULT_PROGRAM = \"D7ZFoWvEG5NBnkJy6iC98rhwj2qhgq8xhSD42cdTRAQd\";\nconst SYSTEM_PROGRAM = \"11111111111111111111111111111111\";\nconst VAULT_DISCRIMINATOR = [228, 196, 82, 165, 98, 210, 235, 152];\n\n/** True iff the bytes have the exact VaultState shape: 49 bytes, tag first. */\nfunction hasVaultShape(data: number[]): boolean {\n  if (data.length !== 49) return false;\n  for (let i = 0; i < 8; i++) {\n    if (data[i] !== VAULT_DISCRIMINATOR[i]) return false;\n  }\n  return true;\n}\n\n/** Lamports → \"whole.fraction\" SOL string, all nine fractional digits. */\nfunction lamportsToSol(lamports: bigint): string {\n  const whole = lamports / 1_000_000_000n;\n  const frac = (lamports % 1_000_000_000n).toString().padStart(9, \"0\");\n  return whole.toString() + \".\" + frac;\n}\n\n/**\n * getMinimumBalanceForRentExemption, injected. The recorded devnet anchors\n * (0 → 890,880; 49 → 1,231,920) pin the live rent parameters this linear\n * formula reproduces: (128 + dataLength) × 6,960 lamports.\n */\nfunction minRentFor(dataLength: number): bigint {\n  return (128n + BigInt(dataLength)) * 6_960n;\n}\n\n/** A real base58 encoder — same helper you used in lesson 2. */\nconst BASE58_ALPHABET =\n  \"123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz\";\nfunction toBase58(bytes: Uint8Array): string {\n  let n = 0n;\n  for (const b of bytes) n = n * 256n + BigInt(b);\n  let out = \"\";\n  while (n > 0n) {\n    out = BASE58_ALPHABET[Number(n % 58n)] + out;\n    n /= 58n;\n  }\n  for (const b of bytes) {\n    if (b !== 0) break;\n    out = \"1\" + out;\n  }\n  return out;\n}\n\n// ── RECORDED FIXTURES — the same set rung 1 classified: real devnet\n// accounts captured 2026-07-28, except \"second-vault\" (constructed\n// byte-for-byte to the frozen VaultState layout for a real derived PDA) and\n// \"truncated-vault\" (a synthetic layout probe, deliberately NOT rent-exempt:\n// 900,000 lamports < minRentFor(12) = 974,400) ──────────────────────────────\nconst ACCOUNTS: Record<string, AccountInfo> = {\n  \"reference-vault\": {\n    value: {\n      lamports: 101231920n,\n      ownerProgram: \"D7ZFoWvEG5NBnkJy6iC98rhwj2qhgq8xhSD42cdTRAQd\",\n      executable: false,\n      data: [\n        228, 196, 82, 165, 98, 210, 235, 152, 78, 181, 115, 75, 97, 15, 248,\n        39, 115, 50, 94, 194, 229, 144, 50, 163, 140, 21, 194, 79, 145, 31,\n        240, 203, 132, 30, 178, 177, 89, 213, 11, 199, 0, 225, 245, 5, 0, 0,\n        0, 0, 255,\n      ],\n    },\n  },\n  \"second-vault\": {\n    value: {\n      lamports: 3731920n,\n      ownerProgram: \"D7ZFoWvEG5NBnkJy6iC98rhwj2qhgq8xhSD42cdTRAQd\",\n      executable: false,\n      data: [\n        228, 196, 82, 165, 98, 210, 235, 152, 250, 81, 168, 175, 243, 7, 13,\n        139, 135, 233, 111, 129, 165, 52, 141, 25, 59, 70, 254, 154, 56, 95,\n        224, 164, 40, 67, 110, 98, 15, 29, 43, 19, 160, 37, 38, 0, 0, 0, 0,\n        0, 252,\n      ],\n    },\n  },\n  wallet: {\n    value: {\n      lamports: 3331870864n,\n      ownerProgram: \"11111111111111111111111111111111\",\n      executable: false,\n      data: [],\n    },\n  },\n  program: {\n    value: {\n      lamports: 1141440n,\n      ownerProgram: \"BPFLoaderUpgradeab1e11111111111111111111111\",\n      executable: true,\n      data: [\n        2, 0, 0, 0, 68, 241, 198, 255, 117, 99, 71, 101, 249, 222, 102, 97,\n        219, 215, 40, 216, 232, 31, 153, 137, 220, 115, 36, 234, 236, 38, 120,\n        161, 231, 188, 130, 216,\n      ],\n    },\n  },\n  \"clock-sysvar\": {\n    value: {\n      lamports: 1169280n,\n      ownerProgram: \"Sysvar1111111111111111111111111111111111111\",\n      executable: false,\n      data: [\n        23, 157, 149, 28, 0, 0, 0, 0, 112, 187, 104, 106, 0, 0, 0, 0, 86, 4,\n        0, 0, 0, 0, 0, 0, 87, 4, 0, 0, 0, 0, 0, 0, 244, 254, 104, 106, 0, 0,\n        0, 0,\n      ],\n    },\n  },\n  \"truncated-vault\": {\n    value: {\n      lamports: 900000n,\n      ownerProgram: \"D7ZFoWvEG5NBnkJy6iC98rhwj2qhgq8xhSD42cdTRAQd\",\n      executable: false,\n      data: [228, 196, 82, 165, 98, 210, 235, 152, 78, 181, 115, 75],\n    },\n  },\n  missing: { value: null },\n};\n",
+        "starter": "// ─────────────────────────────────────────────────────────────────────────────\n// TEST HARNESS — do not edit. Grading calls runCase with a fixture name and\n// hands your inspect the recorded account plus minRentFor — the injected\n// rent-exemption lookup (getMinimumBalanceForRentExemption, recorded from\n// devnet 2026-07-28: 0 bytes → 890,880 lamports; 49 bytes → 1,231,920).\n// ─────────────────────────────────────────────────────────────────────────────\nfunction runCase(fixtureName: string) {\n  const acc = ACCOUNTS[fixtureName];\n  if (acc === undefined) throw new Error(\"unknown fixture: \" + fixtureName);\n  return inspect(acc, minRentFor);\n}\n\ntype AccountInfo = {\n  value: {\n    lamports: bigint;\n    ownerProgram: string;\n    executable: boolean;\n    data: number[];\n  } | null;\n};\n\ntype Report = {\n  type: \"missing\" | \"system-owned\" | \"program\" | \"vault\" | \"other\";\n  lamports: bigint | null;\n  sol: string | null;\n  ownerProgram: string | null;\n  rentExempt: boolean | null;\n  vault: { owner: string; balance: bigint; bump: number } | null;\n};\n\n/**\n * RUNG 2 — the whole inspector, written by you from the spec. No pattern\n * this time; the spec from the lesson is the contract:\n *\n *   - type: your rung-1 classification, same five values, same order of\n *     checks (existence → executable → system-owned → vault-with-shape →\n *     other).\n *   - For a MISSING account every other field is null.\n *   - lamports: the exact balance (bigint). sol: lamportsToSol(lamports).\n *   - ownerProgram: as recorded.\n *   - rentExempt: lamports >= minRentFor(data.length) — the minimum for\n *     THIS account's data length, not a constant.\n *   - vault: the decoded { owner, balance, bump } — your lesson-2 decoder —\n *     but ONLY when type is \"vault\". Everything else gets null, including\n *     accounts owned by the vault program whose bytes are not a VaultState.\n *\n * Helpers provided below: hasVaultShape, toBase58, lamportsToSol, and the\n * constants. The byte offsets are the ones you have known since lesson 2:\n * owner at 8..39, balance u64 LE at 40, bump at 48.\n */\nfunction inspect(\n  acc: AccountInfo,\n  minRentFor: (dataLength: number) => bigint\n): Report {\n  // Write the inspector from the spec, then delete the throw.\n  throw new Error(\"write inspect from the spec above\");\n}\n\n// ── PROVIDED ────────────────────────────────────────────────────────────────\nconst VAULT_PROGRAM = \"D7ZFoWvEG5NBnkJy6iC98rhwj2qhgq8xhSD42cdTRAQd\";\nconst SYSTEM_PROGRAM = \"11111111111111111111111111111111\";\nconst VAULT_DISCRIMINATOR = [228, 196, 82, 165, 98, 210, 235, 152];\n\n/** True iff the bytes have the exact VaultState shape: 49 bytes, tag first. */\nfunction hasVaultShape(data: number[]): boolean {\n  if (data.length !== 49) return false;\n  for (let i = 0; i < 8; i++) {\n    if (data[i] !== VAULT_DISCRIMINATOR[i]) return false;\n  }\n  return true;\n}\n\n/** Lamports → \"whole.fraction\" SOL string, all nine fractional digits. */\nfunction lamportsToSol(lamports: bigint): string {\n  const whole = lamports / 1_000_000_000n;\n  const frac = (lamports % 1_000_000_000n).toString().padStart(9, \"0\");\n  return whole.toString() + \".\" + frac;\n}\n\n/**\n * getMinimumBalanceForRentExemption, injected. The recorded devnet anchors\n * (0 → 890,880; 49 → 1,231,920) pin the live rent parameters this linear\n * formula reproduces: (128 + dataLength) × 6,960 lamports.\n */\nfunction minRentFor(dataLength: number): bigint {\n  return (128n + BigInt(dataLength)) * 6_960n;\n}\n\n/** A real base58 encoder — same helper you used in lesson 2. */\nconst BASE58_ALPHABET =\n  \"123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz\";\nfunction toBase58(bytes: Uint8Array): string {\n  let n = 0n;\n  for (const b of bytes) n = n * 256n + BigInt(b);\n  let out = \"\";\n  while (n > 0n) {\n    out = BASE58_ALPHABET[Number(n % 58n)] + out;\n    n /= 58n;\n  }\n  for (const b of bytes) {\n    if (b !== 0) break;\n    out = \"1\" + out;\n  }\n  return out;\n}\n\n// ── RECORDED FIXTURES — the same set rung 1 classified: real devnet\n// accounts captured 2026-07-28, except \"second-vault\" (constructed\n// byte-for-byte to the frozen VaultState layout for a real derived PDA) and\n// \"truncated-vault\" (a synthetic layout probe, deliberately NOT rent-exempt:\n// 900,000 lamports < minRentFor(12) = 974,400) ──────────────────────────────\nconst ACCOUNTS: Record<string, AccountInfo> = {\n  \"reference-vault\": {\n    value: {\n      lamports: 101231920n,\n      ownerProgram: \"D7ZFoWvEG5NBnkJy6iC98rhwj2qhgq8xhSD42cdTRAQd\",\n      executable: false,\n      data: [\n        228, 196, 82, 165, 98, 210, 235, 152, 78, 181, 115, 75, 97, 15, 248,\n        39, 115, 50, 94, 194, 229, 144, 50, 163, 140, 21, 194, 79, 145, 31,\n        240, 203, 132, 30, 178, 177, 89, 213, 11, 199, 0, 225, 245, 5, 0, 0,\n        0, 0, 255,\n      ],\n    },\n  },\n  \"second-vault\": {\n    value: {\n      lamports: 3731920n,\n      ownerProgram: \"D7ZFoWvEG5NBnkJy6iC98rhwj2qhgq8xhSD42cdTRAQd\",\n      executable: false,\n      data: [\n        228, 196, 82, 165, 98, 210, 235, 152, 250, 81, 168, 175, 243, 7, 13,\n        139, 135, 233, 111, 129, 165, 52, 141, 25, 59, 70, 254, 154, 56, 95,\n        224, 164, 40, 67, 110, 98, 15, 29, 43, 19, 160, 37, 38, 0, 0, 0, 0,\n        0, 252,\n      ],\n    },\n  },\n  wallet: {\n    value: {\n      lamports: 3331870864n,\n      ownerProgram: \"11111111111111111111111111111111\",\n      executable: false,\n      data: [],\n    },\n  },\n  program: {\n    value: {\n      lamports: 1141440n,\n      ownerProgram: \"BPFLoaderUpgradeab1e11111111111111111111111\",\n      executable: true,\n      data: [\n        2, 0, 0, 0, 68, 241, 198, 255, 117, 99, 71, 101, 249, 222, 102, 97,\n        219, 215, 40, 216, 232, 31, 153, 137, 220, 115, 36, 234, 236, 38, 120,\n        161, 231, 188, 130, 216,\n      ],\n    },\n  },\n  \"clock-sysvar\": {\n    value: {\n      lamports: 1169280n,\n      ownerProgram: \"Sysvar1111111111111111111111111111111111111\",\n      executable: false,\n      data: [\n        23, 157, 149, 28, 0, 0, 0, 0, 112, 187, 104, 106, 0, 0, 0, 0, 86, 4,\n        0, 0, 0, 0, 0, 0, 87, 4, 0, 0, 0, 0, 0, 0, 244, 254, 104, 106, 0, 0,\n        0, 0,\n      ],\n    },\n  },\n  \"truncated-vault\": {\n    value: {\n      lamports: 900000n,\n      ownerProgram: \"D7ZFoWvEG5NBnkJy6iC98rhwj2qhgq8xhSD42cdTRAQd\",\n      executable: false,\n      data: [228, 196, 82, 165, 98, 210, 235, 152, 78, 181, 115, 75],\n    },\n  },\n  missing: { value: null },\n};\n",
+        "tests": [
+          {
+            "description": "The reference vault: full report with decoded fields matching your lesson-2 decoder",
+            "expectedOutput": "result.type === 'vault' && result.vault.owner === '6JFH1dxqiw6Dc81CbWdx4TUT8CvAfgwZg33wQrSytZsU' && result.vault.balance === 100000000n && result.vault.bump === 255 && result.rentExempt === true && result.sol === '0.101231920' && result.ownerProgram === 'D7ZFoWvEG5NBnkJy6iC98rhwj2qhgq8xhSD42cdTRAQd'",
+            "id": "t1",
+            "input": "'reference-vault'"
+          },
+          {
+            "description": "A wallet: system-owned, rent-exempt, and vault stays null",
+            "expectedOutput": "result.type === 'system-owned' && result.vault === null && result.rentExempt === true && result.sol === '3.331870864' && result.lamports === 3331870864n",
+            "id": "t2",
+            "input": "'wallet'"
+          },
+          {
+            "description": "Missing account: type only, every other field null",
+            "expectedOutput": "result.type === 'missing' && result.lamports === null && result.sol === null && result.ownerProgram === null && result.rentExempt === null && result.vault === null",
+            "failureMessage": "For { value: null } nothing else may be read — every non-type field is null, and reaching into acc.value first throws.",
+            "id": "t3",
+            "input": "'missing'"
+          },
+          {
+            "description": "Anti-hardcode: a different vault instance decodes to ITS fields",
+            "expectedOutput": "result.type === 'vault' && result.vault.owner === 'Hr99MUHbQksoGpkSagrhqzvTgCo1BVEHjnACTSsaEJh8' && result.vault.balance === 2500000n && result.vault.bump === 252 && result.sol === '0.003731920'",
+            "id": "t4",
+            "input": "'second-vault'"
+          },
+          {
+            "description": "The program account: type program, never decoded",
+            "expectedOutput": "result.type === 'program' && result.vault === null && result.rentExempt === true && result.sol === '0.001141440'",
+            "id": "t5",
+            "input": "'program'"
+          },
+          {
+            "description": "Vault-program-owned bytes without the shape: 'other', vault null — and NOT rent-exempt",
+            "expectedOutput": "result.type === 'other' && result.vault === null && result.rentExempt === false && result.lamports === 900000n",
+            "failureMessage": "Two traps in one fixture: the guarded decode (no VaultState shape → no decode) and rent-exemption computed for THIS data length — minRentFor(12) is 974,400, above the 900,000 balance.",
+            "id": "t6",
+            "input": "'truncated-vault'"
+          },
+          {
+            "description": "A foreign-owned sysvar: 'other', with an honest rent report",
+            "expectedOutput": "result.type === 'other' && result.vault === null && result.rentExempt === true && result.ownerProgram === 'Sysvar1111111111111111111111111111111111111'",
+            "id": "t7",
+            "input": "'clock-sysvar'"
+          }
+        ],
+        "tutorNotes": [
+          "Learners decode whenever ownerProgram matches, skipping the shape gate, and t6 hands them 12 bytes — the decode then reads past the array (undefined bytes, NaN balance) or fabricates fields. The rule: vault decode happens ONLY when the classification said 'vault', which already includes hasVaultShape.",
+          "They compute rentExempt against a constant (the 49-byte minimum, or lesson 1's ~0.0012 SOL) instead of minRentFor(data.length). t6 (12 bytes, 900,000 lamports, minimum 974,400) and t2 (0 bytes) both break constants — rent scales with THIS account's size.",
+          "They return partial nulls for missing (keeping type plus, say, lamports: 0n). The spec is all-null except type: 0n is a real balance claim about an account that does not exist, and t3 checks every field.",
+          "They build the sol string with Number division (lamports / 1e9) and get float artifacts like '3.3318708639999998'. lamportsToSol is provided and pure-bigint; the 2^53 rule from lesson 2 applies to display code too.",
+          "They forget the wallet/zero-data path and index into an empty array. data.length === 0 is a legal, common account state — the decode must be unreachable for it via the type gate.",
+          "If they ask why inspect takes minRentFor as a parameter: the real getMinimumBalanceForRentExemption is an RPC call; injecting it keeps the inspector a pure, testable function — the same dependency-injection shape the whole course grades with."
+        ]
+      },
+      {
+        "_key": "predict",
+        "_type": "quiz",
+        "questions": [
+          {
+            "explanation": "'other' is a feature, not a shrug: report what is safely knowable (balance, owner, rent) and refuse what is not (a decode under someone else's layout). That refusal is what separates an inspector from a liar.",
+            "id": "q1",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "type 'other', vault null — foreign-owned accounts are reported, never decoded"
+              },
+              {
+                "correct": false,
+                "feedback": "Paste-any-address is the spec: unknown account kinds are a normal input, not an error. The branch table absorbs them as 'other' with an honest lamports/owner/rent report and no decode.",
+                "id": "b",
+                "label": "An exception — the inspector only supports vault accounts"
+              },
+              {
+                "correct": false,
+                "feedback": "Only if the shape gate were missing. The vault branch requires the vault program as owner AND the 49-byte discriminator shape; a vote account fails both and lands in 'other'.",
+                "id": "c",
+                "label": "type 'vault' with garbage fields — 3,762 bytes decode mechanically"
+              }
+            ],
+            "prompt": "A user pastes a validator's VOTE account into your inspector — owned by the Vote program, 3,762 bytes. Predict the report."
+          },
+          {
+            "explanation": "The minimum is (128 + dataLength) × 6,960 lamports, so even zero data costs 890,880. An account below its minimum is real and reportable — and flagging it is exactly the kind of honest detail that makes an inspector useful.",
+            "id": "q2",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "false — a zero-data account's minimum is 890,880 lamports, and 800,000 is below it"
+              },
+              {
+                "correct": false,
+                "feedback": "Even empty accounts pay for their metadata: minRentFor(0) is 890,880 lamports (the 128-byte overhead × 6,960). 800,000 falls short, so the honest report is rentExempt false.",
+                "id": "b",
+                "label": "true — accounts with no data owe no rent"
+              },
+              {
+                "correct": false,
+                "feedback": "Rent-exemption is universal — system-owned, program-owned, sysvars, everything. null is reserved for accounts that do not exist at all.",
+                "id": "c",
+                "label": "null — rent only applies to program-owned accounts"
+              }
+            ],
+            "prompt": "Someone funds a brand-new address with 800,000 lamports and never creates data on it. Your inspector reports it. Predict rentExempt."
+          },
+          {
+            "explanation": "{ value: null } means \"no account at this address ON THIS CLUSTER\". The endpoint your createSolanaRpc was built with decides which chain answered — the code-side twin of the explorer's ?cluster parameter.",
+            "id": "q3",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "Wrong cluster — the address may hold an account on mainnet while your inspector queried devnet"
+              },
+              {
+                "correct": false,
+                "feedback": "Possible in principle, rare in practice — and not the first check. The overwhelmingly common cause of \"it exists, you say null\" is a cluster mismatch, the same trap as lesson 1's ?cluster=devnet.",
+                "id": "b",
+                "label": "The account was garbage-collected for low rent"
+              },
+              {
+                "correct": false,
+                "feedback": "Start with the boring hypothesis: your query went to a different chain than their wallet is looking at. Lesson 1's explorer default and your RPC endpoint choice are the same bug wearing two hats.",
+                "id": "c",
+                "label": "The RPC node is lying"
+              }
+            ],
+            "prompt": "Your RPC read returns { value: null } for an address the user swears has SOL on it. From this course, what is the FIRST hypothesis to check?"
+          },
+          {
+            "explanation": "Owner tells you which program may write the account; the discriminator tells you what the bytes claim to be. Real programs own many types, so the pair — owner AND tag — is the minimum honest check before any decode. That is the shape gate you built.",
+            "id": "q4",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "Any program can own several account types (or versions), so owner alone never identifies a layout — the discriminator is the type tag that does"
+              },
+              {
+                "correct": false,
+                "feedback": "Most real programs own MANY account types — that is why Anchor stamps a discriminator on every one. Owner narrows it to a program; the 8-byte tag picks the type within it.",
+                "id": "b",
+                "label": "It cannot happen — a program's accounts always share one layout"
+              },
+              {
+                "correct": false,
+                "feedback": "The chain does not corrupt bytes. The realistic source is legitimate variety: multiple account types, layout versions, or a different program deployed at an address you assumed. The tag check handles all of them the same way.",
+                "id": "c",
+                "label": "Only if the chain corrupts the account's bytes"
+              }
+            ],
+            "prompt": "Why does the truncated-vault fixture exist at all — when would a real inspector meet vault-program-owned bytes that are not a VaultState?"
+          }
+        ]
+      },
+      {
+        "_key": "reflect",
+        "_type": "openEnded",
+        "maxWords": 120,
+        "prompt": "Your inspector handles five failure paths: missing account, zero-data account, program account, foreign-owned account, and vault-owned-but-not-a-vault. Which one surprised you most when you first got it wrong (or almost wrong), and what did the fix teach you about how Solana models accounts?"
+      }
+    ],
+    "skills": [
+      "solana-kit",
+      "rpc",
+      "borsh-serialization",
+      "pdas",
+      "error-handling"
+    ],
+    "slug": {
+      "_type": "slug",
+      "current": "ship-the-inspector"
+    },
+    "title": "Ship the Inspector"
+  },
+  {
+    "_id": "lesson-sfwd-what-you-built",
+    "_type": "lesson",
+    "blocks": [
+      {
+        "_key": "intro",
+        "_type": "prose",
+        "src": "# What You Built\n\nSix lessons ago the vault was a URL you could not read. Inventory what exists now — each item is a real artifact, not a feeling:\n\n- **A graded, working account inspector** — `classifyAccount` plus `inspect`, passing every fixture including the five failure paths. It reads any devnet address and answers with type, SOL, owner, rent-exemption, and — only when the owner and discriminator prove it — decoded vault fields. It lives in your completed lesson 7, and it is the through-line artifact of this whole track.\n- **Your confirmed devnet transaction** — the deposit you assembled byte-by-byte and a wallet signed in lesson 6. Its explorer signature is on your profile via the lesson-6 reflection: a public, permanent record anyone can verify, showing your fee, your account order (vault first), and the vault's balance moving.\n- **A funded devnet wallet** — connected through Wallet Standard, holding the SOL the faucet gave you minus your deposit and its base fee. Keep it: **in Course 3 this exact wallet pays your own program's deploy** — rent for the program account and 200+ transactions of upload fees. (Course 2 spends nothing — it is all compiling.)\n- **Your credential and XP** — the on-chain record that you completed these eight lessons, minted to the same wallet.\n\n## The handoff contract, byte for byte\n\nThe one thing Course 2 picks up is not code — it is **knowledge of a layout**. Your decoder reads:\n\n```\noffset 0   8 bytes   discriminator [228, 196, 82, 165, 98, 210, 235, 152]\noffset 8   32 bytes  owner\noffset 40  8 bytes   balance, u64 little-endian\noffset 48  1 byte    bump\n```\n\nIn Course 2 you write the Rust struct that *produces* those bytes — `owner: Pubkey`, `balance: u64`, `bump: u8`, in that order. It must match your decoder **byte for byte**, because there is no translation layer between them: the struct's memory layout, serialized, IS the account data your `DataView` read. Get a field order wrong, or a width wrong, and your own inspector reports garbage against your own program — the mistake announces itself in a tool you built.\n\nThe seeds you ordered in lesson 3 — `[\"vault\", owner]`, constant first — become the `seeds = [...]` constraint in Course 3's account validation, character for character. And the hand-written decoder itself? Course 4 replaces it with a generated client — which is the point: you will know exactly what the generator generates, because you wrote it once by hand.\n\nRun the cumulative check below — it draws on every lesson — then the closing reflection.\n"
+      },
+      {
+        "_key": "cumulative",
+        "_type": "quiz",
+        "questions": [
+          {
+            "explanation": "Serialization is positional. The struct's field order determines the account's byte layout, and every reader — your inspector, Course 4's generated client — depends on it. The layout is a contract, and this course taught you both sides of it.",
+            "id": "q1",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "It reports garbage — the serialized field order IS the byte layout, so your decoder's offsets (owner at 8, balance at 40) would now read the wrong bytes"
+              },
+              {
+                "correct": false,
+                "feedback": "There are no names in the 49 bytes — only positions. Your decoder reads offsets; the struct defines what lives at each offset. Reorder the struct and every offset shifts, silently.",
+                "id": "b",
+                "label": "Nothing — decoders match fields by name"
+              },
+              {
+                "correct": false,
+                "feedback": "Rust compiles any field order happily. The breakage is semantic and silent: two programs disagreeing about what byte 40 means. That is why the handoff contract is byte-for-byte.",
+                "id": "c",
+                "label": "The program would fail to compile"
+              }
+            ],
+            "prompt": "In Course 2 you will write `struct VaultState { owner: Pubkey, balance: u64, bump: u8 }`. A classmate proposes reordering it to put `balance` first \"since it changes most\". What happens to your lesson-7 inspector against vaults created by that program?"
+          },
+          {
+            "explanation": "Seed order is part of the address. The choice was arbitrary once, binding forever after — your lesson-3 drill derived the real wrong-order address (6jBW…) to make the silence of that failure mode visible.",
+            "id": "q2",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "Because the derivation hashes seeds in order — the program chose [\"vault\", owner] once, and every client must reproduce it or derive a different, wrong address"
+              },
+              {
+                "correct": false,
+                "feedback": "The runtime has no such rule — either order would derive AN address. What matters is agreement: the program fixed [\"vault\", owner], so that exact order is now part of its interface, forever.",
+                "id": "b",
+                "label": "Constant seeds are required to come first by the runtime"
+              },
+              {
+                "correct": false,
+                "feedback": "The bump search guarantees off-curve for any seed order. The reversed order derives a perfectly valid, off-curve — and WRONG — address, which is why your lesson-3 decoy \"worked\" and still failed.",
+                "id": "c",
+                "label": "Reversed seeds would put the address on the ed25519 curve"
+              }
+            ],
+            "prompt": "Course 3 will declare the vault's address with seeds = [b\"vault\", user.key()]. From lesson 3, why exactly that order and not the reverse?"
+          },
+          {
+            "explanation": "fee = 5,000 × signatures + price × requested CU ÷ 1e6, and the default request is 200,000 CU per non-builtin instruction. Sizing the limit from simulation (6,697 + margin → 7,366) cuts that term ~27× — the single most valuable habit lesson 4 taught.",
+            "id": "q3",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "50,000 × 200,000 ÷ 1e6 = 10,000 lamports — the unset limit requests the 200,000-CU default, and the fee charges the request, not the ~6,700 consumed"
+              },
+              {
+                "correct": false,
+                "feedback": "The formula charges the REQUESTED limit. Without a SetComputeUnitLimit, the request defaults to 200,000 CU — that is the ~30× overpay lesson 4's simulate-and-tighten exists to close.",
+                "id": "b",
+                "label": "50,000 × 6,697 ÷ 1e6 ≈ 335 lamports — fees charge actual consumption"
+              },
+              {
+                "correct": false,
+                "feedback": "A price was set, so the priority fee applies — and it multiplies the requested limit. Optional is the price; once present, the arithmetic is fixed.",
+                "id": "c",
+                "label": "Zero — priority fees are optional"
+              }
+            ],
+            "prompt": "Your lesson-6 deposit paid 5,000 lamports. A mainnet dApp sends the same instruction with a compute-unit price of 50,000 micro-lamports and no limit instruction. Its priority fee is?"
+          },
+          {
+            "explanation": "Apps assemble, wallets sign, nodes relay. Wallet Standard is how the app discovered the wallet without a per-wallet adapter, and the assembled-vs-signed split is why a dApp can be open source and still safe to use.",
+            "id": "q4",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "Your code assembled the full unsigned plan; the wallet — discovered via Wallet Standard — held the key and produced the signature"
+              },
+              {
+                "correct": false,
+                "feedback": "The wallet signs what the app assembles — it built nothing. Your buildDepositPlan produced every byte (accounts in IDL order, discriminator, LE amount); the wallet's only power is the signature, and that split is the security model.",
+                "id": "b",
+                "label": "The wallet built the transaction from the amount you typed"
+              },
+              {
+                "correct": false,
+                "feedback": "RPC nodes relay; they never hold keys. One signature exists on that transaction — your wallet's — which is also why its base fee was exactly 5,000 lamports.",
+                "id": "c",
+                "label": "The RPC node co-signed on your behalf"
+              }
+            ],
+            "prompt": "Your lesson-6 flow never touched a private key, yet the deposit got signed. Reconstruct who did what."
+          },
+          {
+            "explanation": "The commitment ladder is a risk dial, not a status bar. UIs and businesses choose the rung that matches what a rollback would cost them — the honest-UI principle from lesson 6, applied to money.",
+            "id": "q5",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "'confirmed' (supermajority vote) can in rare cases roll back; 'finalized' cannot — so they accept small risk on money coming in, none on money going out"
+              },
+              {
+                "correct": false,
+                "feedback": "Commitment is about observation, not payment — the transaction is the same. The ladder (processed → confirmed → finalized) trades latency for certainty, and the exchange picks a rung per direction of risk.",
+                "id": "b",
+                "label": "'finalized' transactions pay higher fees, which withdrawals justify"
+              },
+              {
+                "correct": false,
+                "feedback": "Signature count is unrelated to commitment. The asymmetry is pure risk accounting on the same ladder your lesson-6 send climbed: reversible-ish at confirmed, irreversible at finalized.",
+                "id": "c",
+                "label": "Withdrawals require more signatures, which take longer"
+              }
+            ],
+            "prompt": "An exchange credits your deposit at 'confirmed' but releases withdrawals only at 'finalized'. Why the asymmetry?"
+          },
+          {
+            "explanation": "Five ways to not-happen: rejection and faucet-decline are pre-network; expiry, preflight, and on-chain error are not. Triage starts with \"did anything reach the network?\" — and a rejection never did.",
+            "id": "q6",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "Nothing failed on-chain — the rejection is pre-network, there is no signature to look up, and the app should have returned to resting state"
+              },
+              {
+                "correct": false,
+                "feedback": "There is no signature — nothing was signed or sent. Logs exist only for taxonomy case 5 (landed and failed on-chain). A rejection leaves no trace anywhere but the UI.",
+                "id": "b",
+                "label": "Find the failed transaction's signature and read its logs"
+              },
+              {
+                "correct": false,
+                "feedback": "Blockhash expiry applies to transactions that went OUT and aged. A rejection went nowhere; the user can simply try again immediately. Matching symptom to taxonomy case is the whole triage skill.",
+                "id": "c",
+                "label": "Ask them to wait for the blockhash to expire and retry"
+              }
+            ],
+            "prompt": "A user reports \"my deposit failed\" with a screenshot of a wallet rejection popup. Using the lesson-6 taxonomy, what is the correct triage?"
+          },
+          {
+            "explanation": "The seam is a fact of the ecosystem (npm's latest tag still ships v1), so the professional skill is asymmetric fluency: read the old world, write the new one.",
+            "id": "q7",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "Read the v1 code fluently with THE MAP, write your addition in Kit, and keep the seam explicit — never write new v1"
+              },
+              {
+                "correct": false,
+                "feedback": "A full rewrite is rarely on offer, and fluent READING is what makes the incremental path viable — v1 still out-downloads Kit (~2.1M vs ~1.65M weekly), so the wild will look like this for years.",
+                "id": "b",
+                "label": "Rewrite the whole codebase to Kit first"
+              },
+              {
+                "correct": false,
+                "feedback": "Consistency with a superseded stack is how codebases calcify. The course rule: read v1 fluently, write Kit only — new code on the current stack, seam acknowledged.",
+                "id": "c",
+                "label": "Match the codebase and write the feature in v1 for consistency"
+              }
+            ],
+            "prompt": "You inherit a codebase importing @solana/web3.js v1 everywhere and are asked to add one new feature. Per this course, the sound approach is?"
+          },
+          {
+            "explanation": "The course's bookend bug: lesson 1's ?cluster=devnet and your RPC endpoint are the same decision expressed twice. Every \"it does not exist\" report is a claim about ONE chain — always know which one you asked.",
+            "id": "q8",
+            "multiSelect": false,
+            "options": [
+              {
+                "correct": true,
+                "id": "a",
+                "label": "They asked different clusters — the RPC endpoint your client was built with and the explorer's ?cluster parameter decide which chain answers"
+              },
+              {
+                "correct": false,
+                "feedback": "Both read live. When two correct tools disagree about existence, they are almost certainly not looking at the same chain — the endpoint in createSolanaRpc vs the cluster in the explorer URL.",
+                "id": "b",
+                "label": "The explorer caches accounts that were later deleted"
+              },
+              {
+                "correct": false,
+                "feedback": "All account reads are public and unsigned — that openness is what made this whole course possible in a browser. The mismatch is the cluster, the very first trap lesson 1 set.",
+                "id": "c",
+                "label": "getAccountInfo requires the account's owner to sign the request"
+              }
+            ],
+            "prompt": "Your inspector queries an address and gets { value: null }, but the explorer shows the account exists. Both tools are working correctly. What single difference between the two reads explains it?"
+          }
+        ]
+      },
+      {
+        "_key": "reflect",
+        "_type": "openEnded",
+        "maxWords": 150,
+        "prompt": "In at most 150 words: which single artifact from this course does Course 2 pick up, and why must the Rust struct you will write match your lesson-2 decoder byte for byte? Name the concrete failure you would see in your own inspector if it didn't."
+      },
+      {
+        "_key": "next",
+        "_type": "prose",
+        "src": "# What Happens Next\n\nCourse 2 — *Rust for Program Developers* — starts from the sentence this course ends on: the account bytes your inspector decoded came from a struct someone wrote in Rust, and next it is you writing it. You will compile real Rust on a build server (nothing installed, same as here), learn ownership and borrowing against account-shaped code rather than toy examples, and finish holding `vault_core.rs` — the `VaultState` struct whose serialized bytes are exactly the 49 your decoder reads, with checked arithmetic so a balance can never silently wrap. Your funded wallet rests until Course 3; your inspector waits to be pointed at a vault whose program you wrote yourself.\n"
+      }
+    ],
+    "skills": [
+      "account-model",
+      "pdas",
+      "transactions",
+      "solana-kit",
+      "transaction-fees",
+      "wallet-standard",
+      "explorer-reading",
+      "api-currency"
+    ],
+    "slug": {
+      "_type": "slug",
+      "current": "what-you-built"
+    },
+    "title": "What You Built"
   }
 ]

--- a/apps/web/src/content/generated/meta.json
+++ b/apps/web/src/content/generated/meta.json
@@ -1,11 +1,11 @@
 {
-  "compiledAt": "2026-07-27T18:36:00Z",
+  "compiledAt": "2026-07-30T22:44:02Z",
   "counts": {
     "achievements": 10,
-    "courses": 4,
+    "courses": 6,
     "learningPaths": 8,
-    "lessons": 49,
+    "lessons": 66,
     "quests": 5
   },
-  "sha": "9b1f03e6ffd993c8a3f0bac7c79574dd8cbbf6a1"
+  "sha": "c5c625e03b23f6ce527da884456f7b2d36c26bed"
 }

--- a/apps/web/src/content/generated/paths.json
+++ b/apps/web/src/content/generated/paths.json
@@ -78,7 +78,7 @@
     "description": "The complete path from zero to Solana developer. Start with the fundamentals, understand how the network works, and build your first on-chain program.",
     "difficulty": "beginner",
     "draft": true,
-    "order": 1,
+    "order": 8,
     "slug": "solana-core",
     "tag": "Foundation",
     "title": "Solana Core"
@@ -87,6 +87,12 @@
     "_id": "path-zero-to-deployed",
     "_type": "learningPath",
     "courses": [
+      {
+        "_key": "course-solana-for-web-devs",
+        "_ref": "course-solana-for-web-devs",
+        "_type": "reference",
+        "_weak": true
+      },
       {
         "_key": "course-rust-for-program-devs",
         "_ref": "course-rust-for-program-devs",

--- a/apps/web/src/content/generated/skills.json
+++ b/apps/web/src/content/generated/skills.json
@@ -324,5 +324,13 @@
   {
     "label": "Confirmation & Commitment",
     "slug": "confirmation"
+  },
+  {
+    "label": "Explorer Reading",
+    "slug": "explorer-reading"
+  },
+  {
+    "label": "API Currency",
+    "slug": "api-currency"
   }
 ]

--- a/apps/web/src/content/generated/slots.json
+++ b/apps/web/src/content/generated/slots.json
@@ -65,6 +65,37 @@
     },
     "version": 1
   },
+  "course-solana-for-evm-devs": {
+    "next": 9,
+    "retired": [],
+    "slots": {
+      "lesson-sfe-approve-to-delegate": 7,
+      "lesson-sfe-declared-accounts": 5,
+      "lesson-sfe-erc20-to-spl": 6,
+      "lesson-sfe-gas-to-compute-units": 4,
+      "lesson-sfe-mappings-to-pdas": 2,
+      "lesson-sfe-msg-sender-to-signers": 3,
+      "lesson-sfe-rent-and-space": 1,
+      "lesson-sfe-storage-to-accounts": 0,
+      "lesson-sfe-what-changes": 8
+    },
+    "version": 1
+  },
+  "course-solana-for-web-devs": {
+    "next": 8,
+    "retired": [],
+    "slots": {
+      "lesson-sfwd-accounts-are-just-bytes": 1,
+      "lesson-sfwd-anatomy-of-a-transaction": 3,
+      "lesson-sfwd-connect-fund-and-send": 5,
+      "lesson-sfwd-derive-the-vault-pda": 2,
+      "lesson-sfwd-kit-or-legacy": 4,
+      "lesson-sfwd-see-a-live-vault": 0,
+      "lesson-sfwd-ship-the-inspector": 6,
+      "lesson-sfwd-what-you-built": 7
+    },
+    "version": 1
+  },
   "course-stablecoin-payments": {
     "next": 9,
     "retired": [],

--- a/apps/web/src/lib/content/__tests__/fixtures/golden/achievements-raw.json
+++ b/apps/web/src/lib/content/__tests__/fixtures/golden/achievements-raw.json
@@ -60,7 +60,7 @@
     {
       "_id": "achievement-course-completer",
       "award": {
-        "course": "course-rust-for-program-devs",
+        "course": "course-solana-for-web-devs",
         "days": null,
         "gte": null,
         "kind": "course-completed",
@@ -126,7 +126,7 @@
         "stat": null
       },
       "category": "skills",
-      "description": "Complete all courses in the Solana Developer Path",
+      "description": "Complete every course in the Zero to Deployed path",
       "glyph": "◎",
       "icon": "layers",
       "name": "Full Stack Solana",
@@ -274,7 +274,7 @@
     {
       "_id": "achievement-course-completer",
       "award": {
-        "course": "course-rust-for-program-devs",
+        "course": "course-solana-for-web-devs",
         "days": null,
         "gte": null,
         "kind": "course-completed",
@@ -340,7 +340,7 @@
         "stat": null
       },
       "category": "skills",
-      "description": "Complete all courses in the Solana Developer Path",
+      "description": "Complete every course in the Zero to Deployed path",
       "glyph": "◎",
       "icon": "layers",
       "name": "Full Stack Solana",

--- a/apps/web/src/lib/content/__tests__/fixtures/golden/course-summaries.json
+++ b/apps/web/src/lib/content/__tests__/fixtures/golden/course-summaries.json
@@ -100,6 +100,54 @@
       "learningPath": "Zero to Deployed"
     },
     {
+      "_id": "course-solana-for-evm-devs",
+      "title": "Solana for EVM Developers",
+      "slug": "solana-for-evm-devs",
+      "thumbnail": null,
+      "tags": [
+        "account-layout",
+        "account-model",
+        "compute-budget",
+        "pdas",
+        "priority-fees",
+        "program-security",
+        "rent-and-space",
+        "signers",
+        "solana-fundamentals",
+        "spl-tokens",
+        "transaction-fees",
+        "transactions",
+        "typescript"
+      ],
+      "difficulty": "intermediate",
+      "totalLessons": 9,
+      "learningPath": null
+    },
+    {
+      "_id": "course-solana-for-web-devs",
+      "title": "Solana for Web Devs",
+      "slug": "solana-for-web-devs",
+      "thumbnail": null,
+      "tags": [
+        "account-model",
+        "api-currency",
+        "borsh-serialization",
+        "compute-budget",
+        "confirmation",
+        "error-handling",
+        "explorer-reading",
+        "pdas",
+        "rpc",
+        "solana-kit",
+        "transaction-fees",
+        "transactions",
+        "wallet-standard"
+      ],
+      "difficulty": "beginner",
+      "totalLessons": 8,
+      "learningPath": "Zero to Deployed"
+    },
+    {
       "_id": "course-stablecoin-payments",
       "title": "Getting Paid: Stablecoin & Agentic Payments",
       "slug": "stablecoin-agentic-payments",
@@ -250,6 +298,66 @@
       "learningPath": "Zero to Deployed"
     },
     {
+      "_id": "course-solana-for-evm-devs",
+      "title": "Solana for EVM Developers",
+      "slug": "solana-for-evm-devs",
+      "description": "You already ship on the EVM. You know why `msg.sender` is trustworthy, what a `mapping` costs you, and how a revert unwinds state. None of that knowledge is wasted here — but almost all of it is filed in the wrong drawer. This course re-files it. Storage becomes accounts you allocate and pay rent for. A `mapping` becomes a program-derived address you compute off-chain before you ever send a transaction. `msg.sender` becomes a list of signers the runtime verified before your code ran. Gas becomes a compute budget you can measure and a priority fee you set separately. `approve` becomes a delegate that can be revoked. You finish able to read a Solana transaction and say what it touches, what it costs, and who authorized it — without translating it back into Solidity first. Version stamp — `@solana/kit` 7.0.0 · `@solana-program/compute-budget` 0.17.0 · `@solana-program/token` 0.15.0 · `anchor-lang` 1.1.2 · authored 2026-07-30.",
+      "difficulty": "intermediate",
+      "duration": 6,
+      "thumbnail": null,
+      "creator": "B7o8NfV81HzjuZFWQTTx3Xdvh77Dqoajwib3kWEnvzJF",
+      "tags": [
+        "account-layout",
+        "account-model",
+        "compute-budget",
+        "pdas",
+        "priority-fees",
+        "program-security",
+        "rent-and-space",
+        "signers",
+        "solana-fundamentals",
+        "spl-tokens",
+        "transaction-fees",
+        "transactions",
+        "typescript"
+      ],
+      "xpReward": 500,
+      "totalLessons": 9,
+      "trackId": 0,
+      "trackLevel": 0,
+      "learningPath": null
+    },
+    {
+      "_id": "course-solana-for-web-devs",
+      "title": "Solana for Web Devs",
+      "slug": "solana-for-web-devs",
+      "description": "You already write JavaScript or TypeScript. That is the whole prerequisite — no blockchain, no cryptography, no Rust, nothing installed. This course runs entirely in your browser against a real, frozen program on Solana's devnet. You start by reading its live vault account in an explorer, then decode its 49 raw bytes by hand — discriminator, owner, balance, bump — then reproduce its address from seeds, so an on-chain account stops being a mystery and becomes a byte layout you own. Then you sign: transaction anatomy with the exact fee arithmetic, a funded devnet wallet of your own, and a real deposit into the vault, confirmed on-chain with the signature to prove it. You finish by assembling everything into a working account inspector — paste any devnet address, get type, SOL, owner, rent-exemption, and decoded vault fields with every failure path handled. Everything is taught against `@solana/kit` 7.0.0, the current stack; one lesson maps it against the legacy web3.js v1 code you will still meet in the wild, with dates and download counts, so you can read old codebases without writing like them. Version stamp — kit 7.0.0, devnet, authored 2026-07-28.",
+      "difficulty": "beginner",
+      "duration": 6,
+      "thumbnail": null,
+      "creator": "B7o8NfV81HzjuZFWQTTx3Xdvh77Dqoajwib3kWEnvzJF",
+      "tags": [
+        "account-model",
+        "api-currency",
+        "borsh-serialization",
+        "compute-budget",
+        "confirmation",
+        "error-handling",
+        "explorer-reading",
+        "pdas",
+        "rpc",
+        "solana-kit",
+        "transaction-fees",
+        "transactions",
+        "wallet-standard"
+      ],
+      "xpReward": 500,
+      "totalLessons": 8,
+      "trackId": 1,
+      "trackLevel": 1,
+      "learningPath": "Zero to Deployed"
+    },
+    {
       "_id": "course-stablecoin-payments",
       "title": "Getting Paid: Stablecoin & Agentic Payments",
       "slug": "stablecoin-agentic-payments",
@@ -299,6 +407,14 @@
     {
       "_id": "course-rust-for-program-devs",
       "totalLessons": 14
+    },
+    {
+      "_id": "course-solana-for-evm-devs",
+      "totalLessons": 9
+    },
+    {
+      "_id": "course-solana-for-web-devs",
+      "totalLessons": 8
     },
     {
       "_id": "course-stablecoin-payments",

--- a/apps/web/src/lib/content/__tests__/fixtures/golden/courses.json
+++ b/apps/web/src/lib/content/__tests__/fixtures/golden/courses.json
@@ -495,5 +495,192 @@
         ]
       }
     ]
+  },
+  {
+    "_id": "course-solana-for-evm-devs",
+    "title": "Solana for EVM Developers",
+    "slug": "solana-for-evm-devs",
+    "description": "You already ship on the EVM. You know why `msg.sender` is trustworthy, what a `mapping` costs you, and how a revert unwinds state. None of that knowledge is wasted here — but almost all of it is filed in the wrong drawer. This course re-files it. Storage becomes accounts you allocate and pay rent for. A `mapping` becomes a program-derived address you compute off-chain before you ever send a transaction. `msg.sender` becomes a list of signers the runtime verified before your code ran. Gas becomes a compute budget you can measure and a priority fee you set separately. `approve` becomes a delegate that can be revoked. You finish able to read a Solana transaction and say what it touches, what it costs, and who authorized it — without translating it back into Solidity first. Version stamp — `@solana/kit` 7.0.0 · `@solana-program/compute-budget` 0.17.0 · `@solana-program/token` 0.15.0 · `anchor-lang` 1.1.2 · authored 2026-07-30.",
+    "difficulty": "intermediate",
+    "duration": 6,
+    "thumbnail": null,
+    "creator": "B7o8NfV81HzjuZFWQTTx3Xdvh77Dqoajwib3kWEnvzJF",
+    "tags": [
+      "account-layout",
+      "account-model",
+      "compute-budget",
+      "pdas",
+      "priority-fees",
+      "program-security",
+      "rent-and-space",
+      "signers",
+      "solana-fundamentals",
+      "spl-tokens",
+      "transaction-fees",
+      "transactions",
+      "typescript"
+    ],
+    "xpReward": 500,
+    "trackId": 0,
+    "trackLevel": 0,
+    "modules": [
+      {
+        "key": "sfe-state",
+        "title": "State Lives in Accounts",
+        "description": "The single largest mental move: a Solana program owns no storage. Code and state are different accounts, state is allocated with a size you choose and paid for with rent, and the `mapping` you would have reached for becomes an address you derive. Get this module wrong and everything after it reads as arbitrary.",
+        "lessons": [
+          {
+            "_id": "lesson-sfe-storage-to-accounts",
+            "title": "Your Program Owns No Storage",
+            "slug": "storage-to-accounts"
+          },
+          {
+            "_id": "lesson-sfe-rent-and-space",
+            "title": "Rent, and Sizing an Account",
+            "slug": "rent-and-space"
+          },
+          {
+            "_id": "lesson-sfe-mappings-to-pdas",
+            "title": "From `mapping` to Program-Derived Addresses",
+            "slug": "mappings-to-pdas"
+          }
+        ]
+      },
+      {
+        "key": "sfe-execution",
+        "title": "Execution, Signers, and Fees",
+        "description": "Who authorized this, what will it touch, and what does it cost — three questions the EVM answers implicitly and Solana makes you answer up front. `msg.sender` becomes a verified signer list, gas becomes a compute budget priced separately from priority, and the account list you must declare in advance is the reason transactions can run in parallel.",
+        "lessons": [
+          {
+            "_id": "lesson-sfe-msg-sender-to-signers",
+            "title": "From `msg.sender` to Verified Signers",
+            "slug": "msg-sender-to-signers"
+          },
+          {
+            "_id": "lesson-sfe-gas-to-compute-units",
+            "title": "From Gas to Compute Units and Priority Fees",
+            "slug": "gas-to-compute-units"
+          },
+          {
+            "_id": "lesson-sfe-declared-accounts",
+            "title": "Why Transactions Declare Their Accounts",
+            "slug": "declared-accounts"
+          }
+        ]
+      },
+      {
+        "key": "sfe-tokens",
+        "title": "Tokens and Composability",
+        "description": "ERC-20 is a contract you deploy; SPL Token is one program everybody shares, and your balance is an account it owns on your behalf. That inversion changes what a transfer is, where `approve` lives, and why composing two protocols is a CPI rather than an external call into unknown code.",
+        "lessons": [
+          {
+            "_id": "lesson-sfe-erc20-to-spl",
+            "title": "From ERC-20 to SPL Token",
+            "slug": "erc20-to-spl"
+          },
+          {
+            "_id": "lesson-sfe-approve-to-delegate",
+            "title": "From `approve` to Delegates",
+            "slug": "approve-to-delegate"
+          },
+          {
+            "_id": "lesson-sfe-what-changes",
+            "title": "What Actually Changed",
+            "slug": "what-changes"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "_id": "course-solana-for-web-devs",
+    "title": "Solana for Web Devs",
+    "slug": "solana-for-web-devs",
+    "description": "You already write JavaScript or TypeScript. That is the whole prerequisite — no blockchain, no cryptography, no Rust, nothing installed. This course runs entirely in your browser against a real, frozen program on Solana's devnet. You start by reading its live vault account in an explorer, then decode its 49 raw bytes by hand — discriminator, owner, balance, bump — then reproduce its address from seeds, so an on-chain account stops being a mystery and becomes a byte layout you own. Then you sign: transaction anatomy with the exact fee arithmetic, a funded devnet wallet of your own, and a real deposit into the vault, confirmed on-chain with the signature to prove it. You finish by assembling everything into a working account inspector — paste any devnet address, get type, SOL, owner, rent-exemption, and decoded vault fields with every failure path handled. Everything is taught against `@solana/kit` 7.0.0, the current stack; one lesson maps it against the legacy web3.js v1 code you will still meet in the wild, with dates and download counts, so you can read old codebases without writing like them. Version stamp — kit 7.0.0, devnet, authored 2026-07-28.",
+    "difficulty": "beginner",
+    "duration": 6,
+    "thumbnail": null,
+    "creator": "B7o8NfV81HzjuZFWQTTx3Xdvh77Dqoajwib3kWEnvzJF",
+    "tags": [
+      "account-model",
+      "api-currency",
+      "borsh-serialization",
+      "compute-budget",
+      "confirmation",
+      "error-handling",
+      "explorer-reading",
+      "pdas",
+      "rpc",
+      "solana-kit",
+      "transaction-fees",
+      "transactions",
+      "wallet-standard"
+    ],
+    "xpReward": 500,
+    "trackId": 1,
+    "trackLevel": 1,
+    "modules": [
+      {
+        "key": "sfwd-read-the-chain",
+        "title": "Read the Chain",
+        "description": "Point at a real devnet program and take its state apart. You read the live vault in an explorer without writing a line of code, then fetch the same account over RPC and decode its 49 bytes by hand — 8-byte discriminator, 32-byte owner, little-endian u64 balance, bump — and then reproduce the vault's address from its seeds and watch a wrong seed order produce a different address. You end holding a working `decodeVault` you wrote yourself, over bytes recorded from the real account. That decoder is the core of the inspector you ship in module 3, and the exact layout that becomes a Rust struct in Course 2.",
+        "lessons": [
+          {
+            "_id": "lesson-sfwd-see-a-live-vault",
+            "title": "See a Live Vault",
+            "slug": "see-a-live-vault"
+          },
+          {
+            "_id": "lesson-sfwd-accounts-are-just-bytes",
+            "title": "Accounts Are Just Bytes",
+            "slug": "accounts-are-just-bytes"
+          },
+          {
+            "_id": "lesson-sfwd-derive-the-vault-pda",
+            "title": "Derive the Vault PDA",
+            "slug": "derive-the-vault-pda"
+          }
+        ]
+      },
+      {
+        "key": "sfwd-sign-your-own-transaction",
+        "title": "Sign Your Own Transaction",
+        "description": "Stop reading and start writing. You take a complete Kit transaction apart and predict its exact cost before it runs — 5,000 lamports per signature plus price times the REQUESTED compute-unit limit — then map the current stack against the legacy web3.js v1 code that still floods npm and every old codebase, so you can read the wild without importing it. Then the real thing: connect a wallet through Wallet Standard, fund it on devnet, and sign a deposit into the very vault you spent module 1 decoding — accounts in IDL order, discriminator plus little-endian amount, confirmed on-chain with an explorer signature on your profile.",
+        "lessons": [
+          {
+            "_id": "lesson-sfwd-anatomy-of-a-transaction",
+            "title": "Anatomy of a Transaction",
+            "slug": "anatomy-of-a-transaction"
+          },
+          {
+            "_id": "lesson-sfwd-kit-or-legacy",
+            "title": "Kit, or What You'll Find in the Wild",
+            "slug": "kit-or-legacy"
+          },
+          {
+            "_id": "lesson-sfwd-connect-fund-and-send",
+            "title": "Connect, Fund, and Send It",
+            "slug": "connect-fund-and-send"
+          }
+        ]
+      },
+      {
+        "key": "sfwd-publish-the-inspector",
+        "title": "Publish the Inspector",
+        "description": "Assemble RPC read, byte decode, and PDA derivation into one working inspector: give it any devnet address and it answers — account type, SOL, owner, rent-exemption, and decoded vault fields when the owner and discriminator check out. The grade lives in the failure paths: accounts that do not exist, accounts with no data, accounts that only look like vaults. Two graded rungs — first complete the branch table, then write the decode path unaided against fixtures recorded from real devnet accounts. Close by naming every artifact you built and exactly which one Course 2 picks up.",
+        "lessons": [
+          {
+            "_id": "lesson-sfwd-ship-the-inspector",
+            "title": "Ship the Inspector",
+            "slug": "ship-the-inspector"
+          },
+          {
+            "_id": "lesson-sfwd-what-you-built",
+            "title": "What You Built",
+            "slug": "what-you-built"
+          }
+        ]
+      }
+    ]
   }
 ]

--- a/apps/web/src/lib/content/__tests__/fixtures/golden/lessons.json
+++ b/apps/web/src/lib/content/__tests__/fixtures/golden/lessons.json
@@ -4555,7 +4555,7 @@
         "idl": null
       },
       {
-        "key": "submit",
+        "key": "reflect",
         "_type": "openEnded",
         "produces": null,
         "consumes": null,
@@ -4569,8 +4569,8 @@
         "tests": null,
         "hints": null,
         "questions": null,
-        "prompt": "Paste the URL of the Superteam Earn listing you submitted to, and the URL of what you submitted. Then, in three lines: which rail the work uses (fixed delegation, recurring delegation, subscription plan, Solana Pay or x402), which Brazilian use case it serves, and the one thing in your submission a reviewer can run themselves.",
-        "maxWords": 200,
+        "prompt": "Without re-reading the recap: pick the two rails you would be most likely to confuse in a proposal (fixed delegation, recurring delegation, subscription plan, Solana Pay, x402) and explain the difference in one sentence each, the way you would to a reviewer. Then name the one idea from this course that most changed how you would design a paid product for the Brazilian market, and say why. This is not graded and awards no XP — the Earn submission itself happens through the handoff after your credential, not in this box.",
+        "maxWords": 250,
         "amount": null,
         "network": null,
         "idl": null
@@ -9225,8 +9225,8 @@
         "language": "typescript",
         "buildType": "standard",
         "deployable": false,
-        "starter": "/**\n * Assemble the deposit transaction message by hand, in four subgoals.\n *\n * `buildDepositInstruction` below is your published wrapper's output — treat it\n * as given. Build the message with the owner as fee payer, the given blockhash\n * as its lifetime, and the deposit instruction appended. Do NOT set a compute\n * unit limit — that overpay is the next lesson's exercise.\n */\nfunction assembleDeposit(\n  owner: string,\n  amountLamports: bigint,\n  blockhash: string\n): {\n  feePayer: string;\n  lifetimeBlockhash: string;\n  instructions: { programAddress: string; accounts: { address: string; role: string }[]; data: { amountLamports: bigint } }[];\n  computeUnitLimitSet: boolean;\n} {\n  // Subgoal 1 — set the fee payer to the owner (done for you).\n  const feePayer = owner;\n\n  // Subgoal 2 — set the transaction lifetime to the given blockhash.\n  // const lifetimeBlockhash = ...\n\n  // Subgoal 3 — append the deposit instruction built from your wrapper.\n  // const instructions = [ buildDepositInstruction(owner, amountLamports) ];\n\n  // Subgoal 4 — return the message; leave computeUnitLimitSet as false.\n  return {\n    feePayer,\n    lifetimeBlockhash: \"\",\n    instructions: [],\n    computeUnitLimitSet: false,\n  };\n}\n\n// --- your published wrapper's instruction builder — treat as given -------\nfunction buildDepositInstruction(\n  owner: string,\n  amountLamports: bigint\n): { programAddress: string; accounts: { address: string; role: string }[]; data: { amountLamports: bigint } } {\n  return {\n    programAddress: \"VauLtPr0gram1111111111111111111111111111111\",\n    accounts: [\n      { address: owner, role: \"writable-signer\" },\n      { address: \"Vau1t\" + owner.slice(0, 38).padEnd(38, \"1\"), role: \"writable\" },\n      { address: \"11111111111111111111111111111111\", role: \"readonly\" },\n    ],\n    data: { amountLamports },\n  };\n}\n",
-        "solution": "/**\n * Assemble the deposit transaction message by hand, in four subgoals.\n */\nfunction assembleDeposit(\n  owner: string,\n  amountLamports: bigint,\n  blockhash: string\n): {\n  feePayer: string;\n  lifetimeBlockhash: string;\n  instructions: { programAddress: string; accounts: { address: string; role: string }[]; data: { amountLamports: bigint } }[];\n  computeUnitLimitSet: boolean;\n} {\n  // Subgoal 1 — set the fee payer to the owner (done for you).\n  const feePayer = owner;\n\n  // Subgoal 2 — set the transaction lifetime to the given blockhash.\n  const lifetimeBlockhash = blockhash;\n\n  // Subgoal 3 — append the deposit instruction built from your wrapper.\n  const instructions = [buildDepositInstruction(owner, amountLamports)];\n\n  // Subgoal 4 — return the message; leave computeUnitLimitSet as false.\n  return {\n    feePayer,\n    lifetimeBlockhash,\n    instructions,\n    computeUnitLimitSet: false,\n  };\n}\n\n// --- your published wrapper's instruction builder — treat as given -------\nfunction buildDepositInstruction(\n  owner: string,\n  amountLamports: bigint\n): { programAddress: string; accounts: { address: string; role: string }[]; data: { amountLamports: bigint } } {\n  return {\n    programAddress: \"VauLtPr0gram1111111111111111111111111111111\",\n    accounts: [\n      { address: owner, role: \"writable-signer\" },\n      { address: \"Vau1t\" + owner.slice(0, 38).padEnd(38, \"1\"), role: \"writable\" },\n      { address: \"11111111111111111111111111111111\", role: \"readonly\" },\n    ],\n    data: { amountLamports },\n  };\n}\n",
+        "starter": "/**\n * Assemble the deposit transaction message by hand, in four subgoals.\n *\n * `buildDepositInstruction` below is your published wrapper's output — treat it\n * as given. Build the message with the owner as fee payer, the given blockhash\n * as its lifetime, and the deposit instruction appended. Do NOT set a compute\n * unit limit — that overpay is the next lesson's exercise.\n */\nfunction assembleDeposit(\n  owner: string,\n  amountLamports: bigint,\n  blockhash: string\n): {\n  feePayer: string;\n  lifetimeBlockhash: string;\n  instructions: { programAddress: string; accounts: { address: string; role: string }[]; data: { amountLamports: bigint } }[];\n  computeUnitLimitSet: boolean;\n} {\n  // Subgoal 1 — set the fee payer to the owner (done for you).\n  const feePayer = owner;\n\n  // Subgoal 2 — set the transaction lifetime to the given blockhash.\n  // const lifetimeBlockhash = ...\n\n  // Subgoal 3 — append the deposit instruction built from your wrapper.\n  // const instructions = [ buildDepositInstruction(owner, amountLamports) ];\n\n  // Subgoal 4 — return the message; leave computeUnitLimitSet as false.\n  return {\n    feePayer,\n    lifetimeBlockhash: \"\",\n    instructions: [],\n    computeUnitLimitSet: false,\n  };\n}\n\n// --- your published wrapper's instruction builder — treat as given -------\nfunction buildDepositInstruction(\n  user: string,\n  amountLamports: bigint\n): { programAddress: string; accounts: { address: string; role: string }[]; data: { amountLamports: bigint } } {\n  return {\n    programAddress: \"VauLtPr0gram1111111111111111111111111111111\",\n    accounts: [\n      { address: \"Vau1t\" + user.slice(0, 38).padEnd(38, \"1\"), role: \"writable\" },\n      { address: user, role: \"writable-signer\" },\n      { address: \"11111111111111111111111111111111\", role: \"readonly\" },\n    ],\n    data: { amountLamports },\n  };\n}\n",
+        "solution": "/**\n * Assemble the deposit transaction message by hand, in four subgoals.\n */\nfunction assembleDeposit(\n  owner: string,\n  amountLamports: bigint,\n  blockhash: string\n): {\n  feePayer: string;\n  lifetimeBlockhash: string;\n  instructions: { programAddress: string; accounts: { address: string; role: string }[]; data: { amountLamports: bigint } }[];\n  computeUnitLimitSet: boolean;\n} {\n  // Subgoal 1 — set the fee payer to the owner (done for you).\n  const feePayer = owner;\n\n  // Subgoal 2 — set the transaction lifetime to the given blockhash.\n  const lifetimeBlockhash = blockhash;\n\n  // Subgoal 3 — append the deposit instruction built from your wrapper.\n  const instructions = [buildDepositInstruction(owner, amountLamports)];\n\n  // Subgoal 4 — return the message; leave computeUnitLimitSet as false.\n  return {\n    feePayer,\n    lifetimeBlockhash,\n    instructions,\n    computeUnitLimitSet: false,\n  };\n}\n\n// --- your published wrapper's instruction builder — treat as given -------\nfunction buildDepositInstruction(\n  user: string,\n  amountLamports: bigint\n): { programAddress: string; accounts: { address: string; role: string }[]; data: { amountLamports: bigint } } {\n  return {\n    programAddress: \"VauLtPr0gram1111111111111111111111111111111\",\n    accounts: [\n      { address: \"Vau1t\" + user.slice(0, 38).padEnd(38, \"1\"), role: \"writable\" },\n      { address: user, role: \"writable-signer\" },\n      { address: \"11111111111111111111111111111111\", role: \"readonly\" },\n    ],\n    data: { amountLamports },\n  };\n}\n",
         "tests": [
           {
             "id": "t1",
@@ -9242,9 +9242,9 @@
           },
           {
             "id": "t3",
-            "description": "Subgoal 3: exactly one instruction, the deposit, with the owner signing",
+            "description": "Subgoal 3: exactly one instruction, the deposit, with the user signing",
             "input": "'0wnerWa11etAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA', 1000000n, 'B1ockhash1111111111111111111111111111111111'",
-            "expectedOutput": "result.instructions.length === 1 && result.instructions[0].accounts[0].address === '0wnerWa11etAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'"
+            "expectedOutput": "result.instructions.length === 1 && result.instructions[0].accounts[1].address === '0wnerWa11etAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'"
           },
           {
             "id": "t4",
@@ -9387,8 +9387,8 @@
         "tests": null,
         "hints": null,
         "questions": null,
-        "prompt": "Deploy the app and paste its public URL (e.g. https://your-vault-app.vercel.app). Confirm you sent one real devnet deposit from it. Self-reported — record the URL; module 3 keeps shipping to it.",
-        "maxWords": 60,
+        "prompt": "Deploy the app and paste its public URL (e.g. https://your-vault-app.vercel.app). Confirm you sent one real devnet deposit from it. Self-reported — record the URL; module 3 keeps shipping to it. Then, in a sentence or two: which part of that deposit did your installed package do, and which part could only the wallet do — why does that split exist?",
+        "maxWords": 120,
         "amount": null,
         "network": null,
         "idl": null
@@ -9431,8 +9431,8 @@
         "language": "typescript",
         "buildType": "standard",
         "deployable": false,
-        "starter": "/**\n * WORKED EXAMPLE — a hand-written stand-in for one Codama-generated builder.\n *\n * This is what `getDepositInstruction(...)` assembles for you from the IDL:\n * a program address, an ORDERED account list where each entry carries a role,\n * and a data payload holding the 8-byte instruction discriminator plus the\n * argument.\n *\n * It is complete except for ONE value: the data payload hardcodes `0n` instead\n * of passing the amount through. Wire the `amountLamports` parameter into the\n * payload, then run it and read the returned object.\n *\n * Note the Kit conventions the real generated code uses:\n *   - addresses are strings (Kit `Address`), never `PublicKey` objects\n *   - the amount is a `bigint`, never a `number`\n *   - the account order is fixed by the IDL and must not be shuffled\n */\nfunction buildDepositInstruction(\n  programAddress: string,\n  vaultPda: string,\n  owner: string,\n  amountLamports: bigint\n): {\n  programAddress: string;\n  accounts: { address: string; role: string }[];\n  data: { discriminator: number[]; amountLamports: bigint };\n} {\n  // The System Program — deposit moves lamports through a System CPI, so it\n  // must be present and read-only.\n  const SYSTEM_PROGRAM = \"11111111111111111111111111111111\";\n\n  // The first 8 bytes Anchor writes to identify the `deposit` instruction.\n  // The generated client carries this so you never hand-write it.\n  const DEPOSIT_DISCRIMINATOR = [242, 35, 198, 137, 82, 225, 242, 182];\n\n  return {\n    programAddress,\n    accounts: [\n      { address: owner, role: \"writable-signer\" }, // pays the lamports, signs\n      { address: vaultPda, role: \"writable\" }, // receives them\n      { address: SYSTEM_PROGRAM, role: \"readonly\" }, // the CPI target\n    ],\n    data: {\n      discriminator: DEPOSIT_DISCRIMINATOR,\n      amountLamports: 0n, // TODO: pass `amountLamports` through instead of 0n\n    },\n  };\n}\n",
-        "solution": "/**\n * WORKED EXAMPLE — a hand-written stand-in for one Codama-generated builder.\n *\n * This is what `getDepositInstruction(...)` assembles for you from the IDL:\n * a program address, an ORDERED account list where each entry carries a role,\n * and a data payload holding the 8-byte instruction discriminator plus the\n * argument. Run it, read the returned object, and try changing the amount.\n *\n * Note the Kit conventions the real generated code uses:\n *   - addresses are strings (Kit `Address`), never `PublicKey` objects\n *   - the amount is a `bigint`, never a `number`\n *   - the account order is fixed by the IDL and must not be shuffled\n */\nfunction buildDepositInstruction(\n  programAddress: string,\n  vaultPda: string,\n  owner: string,\n  amountLamports: bigint\n): {\n  programAddress: string;\n  accounts: { address: string; role: string }[];\n  data: { discriminator: number[]; amountLamports: bigint };\n} {\n  // The System Program — deposit moves lamports through a System CPI, so it\n  // must be present and read-only.\n  const SYSTEM_PROGRAM = \"11111111111111111111111111111111\";\n\n  // The first 8 bytes Anchor writes to identify the `deposit` instruction.\n  // The generated client carries this so you never hand-write it.\n  const DEPOSIT_DISCRIMINATOR = [242, 35, 198, 137, 82, 225, 242, 182];\n\n  return {\n    programAddress,\n    accounts: [\n      { address: owner, role: \"writable-signer\" }, // pays the lamports, signs\n      { address: vaultPda, role: \"writable\" }, // receives them\n      { address: SYSTEM_PROGRAM, role: \"readonly\" }, // the CPI target\n    ],\n    data: {\n      discriminator: DEPOSIT_DISCRIMINATOR,\n      amountLamports,\n    },\n  };\n}\n",
+        "starter": "/**\n * WORKED EXAMPLE — a hand-written stand-in for one Codama-generated builder.\n *\n * This is what `getDepositInstruction(...)` assembles for you from the IDL:\n * a program address, an ORDERED account list where each entry carries a role,\n * and a data payload holding the 8-byte instruction discriminator plus the\n * argument.\n *\n * It is complete except for ONE value: the data payload hardcodes `0n` instead\n * of passing the amount through. Wire the `amountLamports` parameter into the\n * payload, then run it and read the returned object.\n *\n * Note the Kit conventions the real generated code uses:\n *   - addresses are strings (Kit `Address`), never `PublicKey` objects\n *   - the amount is a `bigint`, never a `number`\n *   - the account order is fixed by the IDL and must not be shuffled\n */\nfunction buildDepositInstruction(\n  programAddress: string,\n  vaultPda: string,\n  user: string,\n  amountLamports: bigint\n): {\n  programAddress: string;\n  accounts: { address: string; role: string }[];\n  data: { discriminator: number[]; amountLamports: bigint };\n} {\n  // The System Program — deposit moves lamports through a System CPI, so it\n  // must be present and read-only.\n  const SYSTEM_PROGRAM = \"11111111111111111111111111111111\";\n\n  // The first 8 bytes Anchor writes to identify the `deposit` instruction.\n  // The generated client carries this so you never hand-write it.\n  const DEPOSIT_DISCRIMINATOR = [242, 35, 198, 137, 82, 225, 242, 182];\n\n  return {\n    programAddress,\n    accounts: [\n      { address: vaultPda, role: \"writable\" }, // the vault — receives the lamports\n      { address: user, role: \"writable-signer\" }, // the user — pays the lamports, signs\n      { address: SYSTEM_PROGRAM, role: \"readonly\" }, // the CPI target\n    ],\n    data: {\n      discriminator: DEPOSIT_DISCRIMINATOR,\n      amountLamports: 0n, // TODO: pass `amountLamports` through instead of 0n\n    },\n  };\n}\n",
+        "solution": "/**\n * WORKED EXAMPLE — a hand-written stand-in for one Codama-generated builder.\n *\n * This is what `getDepositInstruction(...)` assembles for you from the IDL:\n * a program address, an ORDERED account list where each entry carries a role,\n * and a data payload holding the 8-byte instruction discriminator plus the\n * argument. Run it, read the returned object, and try changing the amount.\n *\n * Note the Kit conventions the real generated code uses:\n *   - addresses are strings (Kit `Address`), never `PublicKey` objects\n *   - the amount is a `bigint`, never a `number`\n *   - the account order is fixed by the IDL and must not be shuffled\n */\nfunction buildDepositInstruction(\n  programAddress: string,\n  vaultPda: string,\n  user: string,\n  amountLamports: bigint\n): {\n  programAddress: string;\n  accounts: { address: string; role: string }[];\n  data: { discriminator: number[]; amountLamports: bigint };\n} {\n  // The System Program — deposit moves lamports through a System CPI, so it\n  // must be present and read-only.\n  const SYSTEM_PROGRAM = \"11111111111111111111111111111111\";\n\n  // The first 8 bytes Anchor writes to identify the `deposit` instruction.\n  // The generated client carries this so you never hand-write it.\n  const DEPOSIT_DISCRIMINATOR = [242, 35, 198, 137, 82, 225, 242, 182];\n\n  return {\n    programAddress,\n    accounts: [\n      { address: vaultPda, role: \"writable\" }, // the vault — receives the lamports\n      { address: user, role: \"writable-signer\" }, // the user — pays the lamports, signs\n      { address: SYSTEM_PROGRAM, role: \"readonly\" }, // the CPI target\n    ],\n    data: {\n      discriminator: DEPOSIT_DISCRIMINATOR,\n      amountLamports,\n    },\n  };\n}\n",
         "tests": [
           {
             "id": "t1",
@@ -9448,15 +9448,15 @@
           },
           {
             "id": "t3",
-            "description": "The account order is owner, vault, system program",
+            "description": "The account order is vault, user, system program",
             "input": "'VauLtPr0gram1111111111111111111111111111111', 'Vau1tPDA1111111111111111111111111111111111', '0wnerWa11et11111111111111111111111111111111', 1000000n",
-            "expectedOutput": "result.accounts[0].address === '0wnerWa11et11111111111111111111111111111111' && result.accounts[1].address === 'Vau1tPDA1111111111111111111111111111111111'"
+            "expectedOutput": "result.accounts[0].address === 'Vau1tPDA1111111111111111111111111111111111' && result.accounts[1].address === '0wnerWa11et11111111111111111111111111111111'"
           },
           {
             "id": "t4",
-            "description": "The signer is the owner, and the vault is writable but not a signer",
+            "description": "The vault is writable but not a signer, and the user signs",
             "input": "'VauLtPr0gram1111111111111111111111111111111', 'Vau1tPDA1111111111111111111111111111111111', '0wnerWa11et11111111111111111111111111111111', 1000000n",
-            "expectedOutput": "result.accounts[0].role === 'writable-signer' && result.accounts[1].role === 'writable'"
+            "expectedOutput": "result.accounts[0].role === 'writable' && result.accounts[1].role === 'writable-signer'"
           },
           {
             "id": "t5",
@@ -10128,8 +10128,8 @@
         "tests": null,
         "hints": null,
         "questions": null,
-        "prompt": "Publish the client and paste the public npm URL of your package (e.g. https://www.npmjs.com/package/@your-scope/vault-client). This is self-reported — record the URL you will install from in the next module.",
-        "maxWords": 60,
+        "prompt": "Publish the client and paste the public npm URL of your package (e.g. https://www.npmjs.com/package/@your-scope/vault-client). This is self-reported — record the URL you will install from in the next module. Then, in a sentence or two: what does a consumer installing your package get that copying your app's source would not give them, and what does your semver policy promise them on the next publish?",
+        "maxWords": 120,
         "amount": null,
         "network": null,
         "idl": null
@@ -10842,8 +10842,8 @@
         "tests": null,
         "hints": null,
         "questions": null,
-        "prompt": "Ship the finished app and paste its public URL. Confirm deposit, withdraw, live vault state, a sized compute budget and a network-priced fee all work. Self-reported — this is one of the two artifacts you name in the recap.",
-        "maxWords": 60,
+        "prompt": "Ship the finished app and paste its public URL. Confirm deposit, withdraw, live vault state, a sized compute budget and a network-priced fee all work. Self-reported — this is one of the two artifacts you name in the recap. Then, in a sentence or two: why does the app size its compute budget from a simulation instead of a hardcoded constant — what goes wrong with the constant?",
+        "maxWords": 120,
         "amount": null,
         "network": null,
         "idl": null
@@ -11165,8 +11165,8 @@
         "language": "typescript",
         "buildType": "standard",
         "deployable": false,
-        "starter": "/**\n * The ergonomic wrapper around the generated client.\n *\n * `deriveVaultPda` and `getDepositInstruction` below are the GENERATED surface —\n * treat them as read-only (in a real package they live in `src/generated`, which\n * codegen overwrites). Your job is the wrapper `deposit`, in four subgoals.\n */\nfunction deposit(\n  owner: string,\n  amountLamports: bigint\n): {\n  ok: boolean;\n  vaultPda: string;\n  instruction: {\n    programAddress: string;\n    accounts: { address: string; role: string }[];\n    data: { discriminator: number[]; amountLamports: bigint };\n  } | null;\n} {\n  // Subgoal 1 — derive the vault PDA from the owner (done for you).\n  const vaultPda = deriveVaultPda(owner);\n\n  // Subgoal 2 — narrow the input: a deposit must be a positive bigint (done for you).\n  if (typeof amountLamports !== \"bigint\" || amountLamports <= 0n) {\n    return { ok: false, vaultPda, instruction: null };\n  }\n\n  // Subgoal 3 — build the instruction from the generated builder.\n  //   Call getDepositInstruction({ owner, vaultPda, amountLamports }).\n  // const instruction = ...\n\n  // Subgoal 4 — return the ergonomic shape: { ok: true, vaultPda, instruction }.\n  //   The caller should never see a discriminator or a seed.\n  return { ok: false, vaultPda, instruction: null }; // replace this line\n}\n\n// --- generated surface — do not edit -------------------------------------\nfunction deriveVaultPda(owner: string): string {\n  // Stands in for the generated `findVaultPda`. Deterministic in the owner:\n  // the same owner always yields the same vault address, a different owner a\n  // different one.\n  return \"Vau1t\" + owner.slice(0, 38).padEnd(38, \"1\");\n}\n\nfunction getDepositInstruction(args: {\n  owner: string;\n  vaultPda: string;\n  amountLamports: bigint;\n}): {\n  programAddress: string;\n  accounts: { address: string; role: string }[];\n  data: { discriminator: number[]; amountLamports: bigint };\n} {\n  return {\n    programAddress: \"VauLtPr0gram1111111111111111111111111111111\",\n    accounts: [\n      { address: args.owner, role: \"writable-signer\" },\n      { address: args.vaultPda, role: \"writable\" },\n      { address: \"11111111111111111111111111111111\", role: \"readonly\" },\n    ],\n    data: { discriminator: [242, 35, 198, 137, 82, 225, 242, 182], amountLamports: args.amountLamports },\n  };\n}\n",
-        "solution": "/**\n * The ergonomic wrapper around the generated client.\n *\n * `deriveVaultPda` and `getDepositInstruction` below are the GENERATED surface —\n * treat them as read-only (in a real package they live in `src/generated`, which\n * codegen overwrites). Your job is the wrapper `deposit`, in four subgoals.\n */\nfunction deposit(\n  owner: string,\n  amountLamports: bigint\n): {\n  ok: boolean;\n  vaultPda: string;\n  instruction: {\n    programAddress: string;\n    accounts: { address: string; role: string }[];\n    data: { discriminator: number[]; amountLamports: bigint };\n  } | null;\n} {\n  // Subgoal 1 — derive the vault PDA from the owner (done for you).\n  const vaultPda = deriveVaultPda(owner);\n\n  // Subgoal 2 — narrow the input: a deposit must be a positive bigint (done for you).\n  if (typeof amountLamports !== \"bigint\" || amountLamports <= 0n) {\n    return { ok: false, vaultPda, instruction: null };\n  }\n\n  // Subgoal 3 — build the instruction from the generated builder.\n  const instruction = getDepositInstruction({ owner, vaultPda, amountLamports });\n\n  // Subgoal 4 — return the ergonomic shape: { ok: true, vaultPda, instruction }.\n  return { ok: true, vaultPda, instruction };\n}\n\n// --- generated surface — do not edit -------------------------------------\nfunction deriveVaultPda(owner: string): string {\n  // Stands in for the generated `findVaultPda`. Deterministic in the owner:\n  // the same owner always yields the same vault address, a different owner a\n  // different one.\n  return \"Vau1t\" + owner.slice(0, 38).padEnd(38, \"1\");\n}\n\nfunction getDepositInstruction(args: {\n  owner: string;\n  vaultPda: string;\n  amountLamports: bigint;\n}): {\n  programAddress: string;\n  accounts: { address: string; role: string }[];\n  data: { discriminator: number[]; amountLamports: bigint };\n} {\n  return {\n    programAddress: \"VauLtPr0gram1111111111111111111111111111111\",\n    accounts: [\n      { address: args.owner, role: \"writable-signer\" },\n      { address: args.vaultPda, role: \"writable\" },\n      { address: \"11111111111111111111111111111111\", role: \"readonly\" },\n    ],\n    data: { discriminator: [242, 35, 198, 137, 82, 225, 242, 182], amountLamports: args.amountLamports },\n  };\n}\n",
+        "starter": "/**\n * The ergonomic wrapper around the generated client.\n *\n * `deriveVaultPda` and `getDepositInstruction` below are the GENERATED surface —\n * treat them as read-only (in a real package they live in `src/generated`, which\n * codegen overwrites). Your job is the wrapper `deposit`, in four subgoals.\n */\nfunction deposit(\n  owner: string,\n  amountLamports: bigint\n): {\n  ok: boolean;\n  vaultPda: string;\n  instruction: {\n    programAddress: string;\n    accounts: { address: string; role: string }[];\n    data: { discriminator: number[]; amountLamports: bigint };\n  } | null;\n} {\n  // Subgoal 1 — derive the vault PDA from the owner (done for you).\n  const vaultPda = deriveVaultPda(owner);\n\n  // Subgoal 2 — narrow the input: a deposit must be a positive bigint (done for you).\n  if (typeof amountLamports !== \"bigint\" || amountLamports <= 0n) {\n    return { ok: false, vaultPda, instruction: null };\n  }\n\n  // Subgoal 3 — build the instruction from the generated builder.\n  //   Call getDepositInstruction({ user: owner, vaultPda, amountLamports }).\n  // const instruction = ...\n\n  // Subgoal 4 — return the ergonomic shape: { ok: true, vaultPda, instruction }.\n  //   The caller should never see a discriminator or a seed.\n  return { ok: false, vaultPda, instruction: null }; // replace this line\n}\n\n// --- generated surface — do not edit -------------------------------------\nfunction deriveVaultPda(owner: string): string {\n  // Stands in for the generated `findVaultPda`. Deterministic in the owner:\n  // the same owner always yields the same vault address, a different owner a\n  // different one.\n  return \"Vau1t\" + owner.slice(0, 38).padEnd(38, \"1\");\n}\n\nfunction getDepositInstruction(args: {\n  user: string;\n  vaultPda: string;\n  amountLamports: bigint;\n}): {\n  programAddress: string;\n  accounts: { address: string; role: string }[];\n  data: { discriminator: number[]; amountLamports: bigint };\n} {\n  return {\n    programAddress: \"VauLtPr0gram1111111111111111111111111111111\",\n    accounts: [\n      { address: args.vaultPda, role: \"writable\" },\n      { address: args.user, role: \"writable-signer\" },\n      { address: \"11111111111111111111111111111111\", role: \"readonly\" },\n    ],\n    data: { discriminator: [242, 35, 198, 137, 82, 225, 242, 182], amountLamports: args.amountLamports },\n  };\n}\n",
+        "solution": "/**\n * The ergonomic wrapper around the generated client.\n *\n * `deriveVaultPda` and `getDepositInstruction` below are the GENERATED surface —\n * treat them as read-only (in a real package they live in `src/generated`, which\n * codegen overwrites). Your job is the wrapper `deposit`, in four subgoals.\n */\nfunction deposit(\n  owner: string,\n  amountLamports: bigint\n): {\n  ok: boolean;\n  vaultPda: string;\n  instruction: {\n    programAddress: string;\n    accounts: { address: string; role: string }[];\n    data: { discriminator: number[]; amountLamports: bigint };\n  } | null;\n} {\n  // Subgoal 1 — derive the vault PDA from the owner (done for you).\n  const vaultPda = deriveVaultPda(owner);\n\n  // Subgoal 2 — narrow the input: a deposit must be a positive bigint (done for you).\n  if (typeof amountLamports !== \"bigint\" || amountLamports <= 0n) {\n    return { ok: false, vaultPda, instruction: null };\n  }\n\n  // Subgoal 3 — build the instruction from the generated builder.\n  const instruction = getDepositInstruction({ user: owner, vaultPda, amountLamports });\n\n  // Subgoal 4 — return the ergonomic shape: { ok: true, vaultPda, instruction }.\n  return { ok: true, vaultPda, instruction };\n}\n\n// --- generated surface — do not edit -------------------------------------\nfunction deriveVaultPda(owner: string): string {\n  // Stands in for the generated `findVaultPda`. Deterministic in the owner:\n  // the same owner always yields the same vault address, a different owner a\n  // different one.\n  return \"Vau1t\" + owner.slice(0, 38).padEnd(38, \"1\");\n}\n\nfunction getDepositInstruction(args: {\n  user: string;\n  vaultPda: string;\n  amountLamports: bigint;\n}): {\n  programAddress: string;\n  accounts: { address: string; role: string }[];\n  data: { discriminator: number[]; amountLamports: bigint };\n} {\n  return {\n    programAddress: \"VauLtPr0gram1111111111111111111111111111111\",\n    accounts: [\n      { address: args.vaultPda, role: \"writable\" },\n      { address: args.user, role: \"writable-signer\" },\n      { address: \"11111111111111111111111111111111\", role: \"readonly\" },\n    ],\n    data: { discriminator: [242, 35, 198, 137, 82, 225, 242, 182], amountLamports: args.amountLamports },\n  };\n}\n",
         "tests": [
           {
             "id": "t1",
@@ -11194,13 +11194,13 @@
           },
           {
             "id": "t5",
-            "description": "Subgoal 4: the returned instruction is well-formed — owner signs, vault is the derived PDA",
+            "description": "Subgoal 4: the returned instruction is well-formed — the vault is the derived PDA, the user signs",
             "input": "'0wnerWa11etAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA', 2500000n",
-            "expectedOutput": "result.instruction.accounts[0].role === 'writable-signer' && result.instruction.accounts[1].address === result.vaultPda"
+            "expectedOutput": "result.instruction.accounts[0].address === result.vaultPda && result.instruction.accounts[1].role === 'writable-signer'"
           }
         ],
         "hints": [
-          "Subgoal 3: call the generated builder — `getDepositInstruction({ owner, vaultPda, amountLamports })` — and keep its result in a variable.",
+          "Subgoal 3: call the generated builder — `getDepositInstruction({ user: owner, vaultPda, amountLamports })` — and keep its result in a variable.",
           "Subgoal 4: return `{ ok: true, vaultPda, instruction }`. Reuse the `vaultPda` subgoal 1 already derived; do not derive it again.",
           "Do not touch `deriveVaultPda` or `getDepositInstruction` — they stand in for generated code that codegen overwrites. Compose them; never edit them."
         ],
@@ -11285,6 +11285,3286 @@
             "explanation": "This is the rule in one incident: generated code is regenerated output. The wrapper is where a fix lives if it is behavioural, and the IDL is where it lives if the interface is wrong — either survives regeneration, an edit to `src/generated` never does."
           }
         ],
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      }
+    ]
+  },
+  {
+    "_id": "lesson-sfe-approve-to-delegate",
+    "title": "From `approve` to Delegates",
+    "slug": "approve-to-delegate",
+    "blocks": [
+      {
+        "key": "intro",
+        "_type": "prose",
+        "produces": null,
+        "consumes": null,
+        "src": "# `approve` becomes a delegate on the account itself\n\nThe ERC-20 allowance pattern is two transactions and a well-known footgun. You\n`approve(spender, amount)`, the spender later calls `transferFrom`, and the\nallowance sits in a nested mapping inside the token contract. Everyone has seen\nthe infinite-approval problem, and everyone has seen a wallet drained through a\nstale one.\n\nSPL Token keeps the idea and moves where it lives. A token account has two extra\nfields:\n\n```text\ndelegate         Option<Pubkey>   who may move tokens from this account\ndelegated_amount u64              how much they may still move\n```\n\nThe approval is not in a mapping keyed by `(owner, spender)`. It is **on the\ntoken account being spent from**.\n\n## What changes as a result\n\n**One delegate at a time.** Approving a second spender overwrites the first. In\nERC-20 you can hold approvals for a dozen contracts simultaneously; here the\nfield is singular. That is a real constraint, and it pushes protocols toward PDAs\nthat own accounts outright rather than accumulating standing approvals.\n\n**Revocation is a single instruction with no amount.** `revoke` clears the\ndelegate and zeroes the delegated amount. There is no \"approve to 0\" dance and no\nrace between reading and resetting an allowance — the ERC-20 front-running hazard\nthat produced `increaseAllowance` does not arise, because you are not comparing\nagainst a previous value.\n\n**Delegation is visible where the tokens are.** Reading a token account tells you\nwhether something can move its balance and how much. In ERC-20 you would have to\nknow which spender to ask about; here, one account read answers it.\n\n## The pattern that mostly replaces it\n\nMuch of what ERC-20 uses `approve` for, Solana does with ownership instead. A\nprotocol derives a PDA, that PDA owns a token account, and the user transfers into\nit. Now the protocol does not need standing permission over the user's wallet —\nit controls an account it already owns, and the user's own account has no\noutstanding delegate at all.\n\nWhether that is *safer* depends on the protocol. It is certainly narrower: the\nblast radius is whatever the user deposited, not whatever remains in their wallet\nunder an old infinite approval. When you port an EVM protocol, look for approvals\nfirst, and ask whether ownership transfer models the intent better.\n\n## Where they still coincide\n\nBoth models share the core hazard: an approval you forgot about is authority\nsomeone still holds. The Solana version limits it — one delegate, a decrementing\namount, one-instruction revocation — but it does not eliminate it. Auditing your\ndelegates is still worth doing, and now it is a field you can read rather than a\nmapping you have to guess at.\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "check",
+        "_type": "quiz",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": [
+          {
+            "id": "q1",
+            "prompt": "A user has delegated 100 tokens to protocol A. They now approve protocol B for 50 on the same token account. Predict.",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "B replaces A entirely — the account holds one delegate, and A's authority is gone",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "Both delegations coexist, as two ERC-20 allowances would",
+                "correct": false,
+                "feedback": "`delegate` is a single optional field on the account, not a map. There is no room for a second entry."
+              },
+              {
+                "id": "c",
+                "label": "The second approval fails while a delegation is outstanding",
+                "correct": false,
+                "feedback": "Nothing rejects it. It silently overwrites — which is convenient for revocation and surprising if you expected ERC-20 accumulation."
+              }
+            ],
+            "explanation": "One delegate per token account. Ported EVM designs that assume several simultaneous approvals need rethinking, usually toward a PDA that owns a dedicated account."
+          },
+          {
+            "id": "q2",
+            "prompt": "Why does the ERC-20 approval front-running race — the one that motivated `increaseAllowance` — not arise here?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "Revocation clears the delegate outright rather than writing a new amount to compare against",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "Solana transactions are atomic, so no other transaction can interleave",
+                "correct": false,
+                "feedback": "Atomicity applies within a transaction. It does not stop a *separate* transaction from landing first — the ordering hazard would still exist if the mechanism were compare-and-set."
+              },
+              {
+                "id": "c",
+                "label": "Delegated amounts cannot be changed once set, only revoked",
+                "correct": false,
+                "feedback": "They can be re-approved at any time. The point is that revocation is not expressed as \"set the amount to zero\"."
+              }
+            ],
+            "explanation": "The ERC-20 race comes from replacing a non-zero allowance with another non-zero value, giving the spender a window to use the old one. `revoke` is a distinct instruction that clears the field, so there is no window to exploit."
+          },
+          {
+            "id": "q3",
+            "prompt": "You port a protocol that relies on a standing infinite approval. What is the idiomatic Solana design?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "A PDA the protocol owns holds a token account the user deposits into",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "Delegate the maximum `u64` to the protocol's authority and leave it in place",
+                "correct": false,
+                "feedback": "Mechanically possible and it reproduces exactly the blast radius you were trying to escape — the whole wallet balance, indefinitely."
+              },
+              {
+                "id": "c",
+                "label": "Re-approve before every interaction from the client",
+                "correct": false,
+                "feedback": "Workable but it adds a transaction to every action and still leaves a live delegation between them."
+              }
+            ],
+            "explanation": "Ownership replaces standing permission. The protocol controls an account it owns and the user's wallet carries no outstanding delegate, so the exposure is the deposit rather than the remaining balance."
+          }
+        ],
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      }
+    ]
+  },
+  {
+    "_id": "lesson-sfe-declared-accounts",
+    "title": "Why Transactions Declare Their Accounts",
+    "slug": "declared-accounts",
+    "blocks": [
+      {
+        "key": "intro",
+        "_type": "prose",
+        "produces": null,
+        "consumes": null,
+        "src": "# Declaring accounts up front is what buys parallelism\n\nAn Ethereum transaction says: call this address with this calldata. What storage\ngets touched is discovered while executing, so the EVM cannot know in advance\nwhether two transactions conflict. It executes them one at a time. That is the\nwhole reason the EVM is single-threaded.\n\nA Solana transaction says something stronger: here is every account I will touch,\nand whether I need to write to it.\n\nBecause that list is complete and declared before execution, the scheduler can\nlook at two transactions and decide immediately whether they overlap. Two\ntransactions writing to different accounts run **in parallel**. Two writing the\nsame account are serialized. This is Sealevel, and it is the direct payoff for\nthe thing that annoys you most when you start: having to pass every account\nexplicitly.\n\n## What this changes about your code\n\n**Instructions cannot discover state mid-flight.** In Solidity you can read one\nmapping, and based on the result, read another contract. On Solana, if the\naccount was not in the list, you cannot touch it — full stop. Dynamic access\npatterns must become explicit lists computed by the client before sending.\n\n**Contention is per-account, not global.** A popular NFT mint contends on that\nmint's accounts. It does not slow down a lending protocol that touches entirely\ndifferent accounts. There is no shared global queue for unrelated work.\n\n**Write locks are the scarce resource.** Declaring an account writable when you\nonly read it is a real cost: it blocks every other transaction that wants to\nwrite it, for no benefit. Mark reads as reads.\n\n## Reading a transaction\n\nBecause the account list is explicit, you can read any Solana transaction and\nanswer \"what does this touch?\" without executing it or having the source. An\nEthereum transaction hides that behind an opaque calldata blob and whatever the\ncontract chooses to do. This is why Solana wallets can show you a meaningful\nsimulation, and it is a genuine security property, not just tooling polish.\n\n## The tradeoff, stated honestly\n\nYou are trading ergonomics for throughput. Building a transaction means knowing\nyour accounts in advance, which means deriving PDAs client-side (lesson 3) and\nsometimes making an extra RPC call to discover what to include. Anchor's IDL and\nits generated clients hide much of it, but the constraint is real and it is the\nfirst thing EVM developers describe as friction.\n\nIt buys you a chain where unrelated work does not queue behind unrelated work.\nWhether that is a good trade depends on what you are building — but it is a\ntrade, not an accident.\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "check",
+        "_type": "quiz",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": [
+          {
+            "id": "q1",
+            "prompt": "Two transactions are submitted in the same slot. A writes account X; B writes account Y. Predict how they are scheduled.",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "In parallel — their declared account sets do not overlap",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "Sequentially, in fee order, like any two Ethereum transactions",
+                "correct": false,
+                "feedback": "Sequencing everything is exactly what the declared account list avoids. Non-overlapping transactions have no reason to wait."
+              },
+              {
+                "id": "c",
+                "label": "In parallel only if they call different programs",
+                "correct": false,
+                "feedback": "The program is irrelevant to conflict detection. Two calls into the *same* program run in parallel when they touch different accounts — which is how one SPL Token program serves the whole chain at once."
+              }
+            ],
+            "explanation": "Conflict is decided on accounts, not on programs or on senders. Declaring the account set up front is precisely what makes that decision possible before execution."
+          },
+          {
+            "id": "q2",
+            "prompt": "You mark an account writable that your instruction only reads. What does it cost?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "It takes a write lock, serializing every other transaction that wants to write that account",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "Nothing — the flag only affects whether your program may write",
+                "correct": false,
+                "feedback": "It does gate your writes, but it is also the input to the scheduler. An unnecessary write lock creates real contention for everyone else."
+              },
+              {
+                "id": "c",
+                "label": "A higher base fee, proportional to the number of writable accounts",
+                "correct": false,
+                "feedback": "The base fee is per signature. The cost of an over-broad write lock is contention, not fees."
+              }
+            ],
+            "explanation": "Write locks are the scarce resource in a parallel scheduler. Marking reads as writes is the Solana analogue of holding a database lock you did not need — invisible in a test, expensive under load."
+          },
+          {
+            "id": "q3",
+            "prompt": "Your instruction wants to read account B only if account A holds a particular flag. Predict what that requires.",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "B must be in the account list anyway — the client decides what to include before sending",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "The program can request B from the runtime once it has read A",
+                "correct": false,
+                "feedback": "There is no facility to fetch an account mid-instruction. The list is fixed when the transaction is built; that fixity is what the scheduler relies on."
+              },
+              {
+                "id": "c",
+                "label": "A and B must be merged into a single account",
+                "correct": false,
+                "feedback": "Sometimes a reasonable design, but not a requirement — passing both and ignoring one is normal and cheap."
+              }
+            ],
+            "explanation": "Conditional access becomes unconditional inclusion. This is the concrete friction of the model: some transactions carry accounts they end up not using, and the client must know enough to include them."
+          }
+        ],
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      }
+    ]
+  },
+  {
+    "_id": "lesson-sfe-erc20-to-spl",
+    "title": "From ERC-20 to SPL Token",
+    "slug": "erc20-to-spl",
+    "blocks": [
+      {
+        "key": "intro",
+        "_type": "prose",
+        "produces": null,
+        "consumes": null,
+        "src": "# One token program, and your balance is an account\n\n> Version stamp — `@solana/kit` 7.0.0 · `@solana-program/token` 0.15.0 ·\n> authored 2026-07-30.\n\nEvery ERC-20 is a separate contract. Deploying a token means deploying code, and\n\"balance of X\" is a lookup inside that contract's own mapping. Two tokens are two\ncodebases, and each may behave differently — fee-on-transfer, rebasing, a\nnon-standard `approve` — which is why integrating an arbitrary ERC-20 is a small\naudit.\n\nSolana inverts this. There is **one** SPL Token program, deployed once, shared by\nevery token on the chain. Creating a token deploys nothing; it creates a **mint\naccount** that the token program owns.\n\n```text\nMint account          supply, decimals, mint authority, freeze authority\nToken account (ATA)   owner, mint, amount, delegate\n```\n\nA balance is not a row in a mapping. It is a **token account** — its own account,\nowned by the SPL Token program, holding one balance of one mint for one owner. In\npractice its address is an **associated token account**: exactly the derivation\nfrom lesson 3, applied to the wallet and the mint.\n\nGet the details right, because this is the one PDA everybody derives and it does\nnot derive the way you would guess. The seeds are **three**, in this order —\n`[owner, token_program, mint]` — and the derivation runs under the **Associated\nToken Account program**, not under the token program whose address sits in the\nmiddle of the seed list:\n\n```ts\nimport { findAssociatedTokenPda, TOKEN_PROGRAM_ADDRESS } from \"@solana-program/token\";\n\nconst [ata] = await findAssociatedTokenPda({\n  owner,\n  tokenProgram: TOKEN_PROGRAM_ADDRESS,\n  mint,\n});\n```\n\nThe token program appears as a seed because the same wallet can hold the same\nmint under classic SPL Token and under Token-2022, and those must be different\naddresses.\n\n## What this buys you\n\n**Uniform behavior.** Transfer semantics are the same for every SPL token,\nbecause it is the same program every time. The fee-on-transfer surprise cannot\nexist in the base token program — a token cannot override transfer, because it\nhas no code of its own. (Token-2022 adds opt-in extensions such as transfer\nhooks, and those are explicitly opt-in and visible on the mint.)\n\n**No approval to interact.** Reading a balance is reading an account. No view\nfunction, no RPC call into a contract, no ABI.\n\n## What it costs you\n\n**Token accounts must exist before they can receive.** There is no \"send to an\naddress and it just works\". If the recipient has no token account for that mint,\nsomeone must create it — and pay its rent. That is the single most common\nsurprise for EVM developers.\n\nThe pattern that answers it is **create-if-missing, then transfer**: derive the\nATA, and prepend `getCreateAssociatedTokenIdempotentInstruction({...})` to the\nsame transaction as your transfer. *Idempotent* is the load-bearing word — it\nsucceeds whether or not the account already exists, so you never have to read\nthe chain first to decide, and two clients racing to fund the same recipient do\nnot knock each other over. One transaction, still atomic.\n\n> **In the wild (checked 2026-07-30).** You will constantly read\n> `getOrCreateAssociatedTokenAccount(connection, payer, mint, owner)` from\n> `@solana/spl-token`, and its sibling `getAssociatedTokenAddress`. Both are the\n> superseded v1-era stack, and the first quietly sends its own transaction\n> before yours. Read them; write the derive-plus-idempotent-instruction pair.\n\n**A wallet holds many token accounts.** One per mint. Your SOL balance is the\n`lamports` field on your wallet account; every SPL token you hold is a separate\naccount keyed to that mint.\n\n## Decimals, and the arithmetic you must not get wrong\n\nLike ERC-20, amounts are integers and `decimals` is display metadata. Unlike\nERC-20's near-universal 18, Solana decimals vary widely — USDC uses 6, many NFTs\nuse 0, wrapped SOL uses 9.\n\nBecause the number is not conventional, hardcoding it is a live bug rather than a\nmostly-safe assumption. Converting a human amount to base units is\n`uiAmount × 10^decimals`, and that is what you will implement.\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "exercise",
+        "_type": "code",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": "typescript",
+        "buildType": "standard",
+        "deployable": false,
+        "starter": "/**\n * Convert a human-facing token amount into base units.\n *\n *   baseUnits = uiAmount * 10^decimals\n *\n * Decimals are NOT conventionally 18 on Solana: USDC uses 6, wrapped SOL uses 9,\n * and plenty of NFTs use 0. Always read `decimals` from the mint.\n *\n * Return a whole number of base units.\n *\n * Examples:\n *   toBaseUnits(1.5, 6) -> 1500000\n *   toBaseUnits(1, 0)   -> 1\n */\nfunction toBaseUnits(uiAmount: number, decimals: number): number {\n  return uiAmount * 10 ** 18;\n}\n",
+        "solution": "function toBaseUnits(uiAmount: number, decimals: number): number {\n  return Math.round(uiAmount * 10 ** decimals);\n}\n",
+        "tests": [
+          {
+            "id": "usdc-six-decimals",
+            "description": "1.5 USDC at 6 decimals is 1,500,000 base units",
+            "input": "1.5, 6",
+            "expectedOutput": "result === 1500000"
+          },
+          {
+            "id": "zero-decimals",
+            "description": "A 0-decimal token (a typical NFT) converts 1 to 1 — decimals must be read, not assumed",
+            "input": "1, 0",
+            "expectedOutput": "result === 1"
+          },
+          {
+            "id": "wrapped-sol-nine-decimals",
+            "description": "0.5 wrapped SOL at 9 decimals is 500,000,000 lamports",
+            "input": "0.5, 9",
+            "expectedOutput": "result === 500000000"
+          },
+          {
+            "id": "no-floating-point-dust",
+            "description": "0.07 at 2 decimals is exactly 7 — binary floating point makes this 7.000000000000001 without rounding",
+            "input": "0.07, 2",
+            "expectedOutput": "result === 7"
+          }
+        ],
+        "hints": [
+          "The starter hardcodes 18 — the ERC-20 habit. The exponent is the `decimals` argument, which varies per mint on Solana.",
+          "Wrap the multiplication in `Math.round`. `0.07 * 10 ** 2` is 7.000000000000001 in binary floating point, and an un-rounded return fails the last case."
+        ],
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null,
+        "tutorNotes": [
+          "The hardcoded 18 is the intended trap: it passes nothing and makes the ERC-20 assumption visible.",
+          "Learners who fix the exponent but skip rounding pass three cases and fail `no-floating-point-dust`; that case exists to teach that base units are integers.",
+          "Production code uses BigInt for real amounts — `number` loses precision past 2^53. Say so if it comes up; the exercise uses `number` to keep the harness simple.",
+          "\"Where does `decimals` actually come from?\" The mint account, read once — it is a field on the mint, not on the token account and not on the wallet. If they are about to hardcode 6 because \"everything is USDC\", that is the same bug as hardcoding 18, one chain over.",
+          "They ask why the ATA derivation in the intro has THREE seeds when lesson 3's vault had two. The token program address sits in the middle — `[owner, token_program, mint]` — because the same wallet can hold the same mint under classic SPL Token and under Token-2022, and those must be different accounts. It is also derived under the Associated Token Account program, not under the token program in its own seed list; people miss that and get an address that does not exist."
+        ]
+      },
+      {
+        "key": "check",
+        "_type": "quiz",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": [
+          {
+            "id": "q1",
+            "prompt": "You transfer an SPL token to a wallet that has never held it. Predict.",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "It fails unless the recipient's token account for that mint is created first — and someone pays its rent",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "It succeeds; the token program creates the account on demand",
+                "correct": false,
+                "feedback": "Nothing is created implicitly, because creation costs rent and the runtime will not decide who pays it."
+              },
+              {
+                "id": "c",
+                "label": "It succeeds and the balance is held on the wallet account itself",
+                "correct": false,
+                "feedback": "Only SOL lives on the wallet account, as `lamports`. Every SPL token balance is a separate account."
+              }
+            ],
+            "explanation": "\"Send and it just works\" is an ERC-20 assumption that does not survive the account model. The idiomatic answer is to prepend an idempotent create-ATA instruction to the same transaction as the transfer — creation is a funded step you author, not a side effect."
+          },
+          {
+            "id": "q2",
+            "prompt": "Why can a base SPL token not implement fee-on-transfer the way an ERC-20 can?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "It has no code of its own — a mint is data owned by the shared token program",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "The token program rejects transfers whose amounts do not match exactly",
+                "correct": false,
+                "feedback": "There is no such check to reject; there is simply no place for per-token logic to live in the base program."
+              },
+              {
+                "id": "c",
+                "label": "It can, by setting a fee field on the mint",
+                "correct": false,
+                "feedback": "Not in the base token program. Token-2022 adds a transfer-fee extension — opt-in, visible on the mint, and a deliberate exception rather than the default."
+              }
+            ],
+            "explanation": "Creating a token deploys no code, so there is nothing to override. That is what makes integrating an arbitrary SPL token far less risky than integrating an arbitrary ERC-20 — with Token-2022 extensions as the explicit, inspectable exception."
+          }
+        ],
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      }
+    ]
+  },
+  {
+    "_id": "lesson-sfe-gas-to-compute-units",
+    "title": "From Gas to Compute Units and Priority Fees",
+    "slug": "gas-to-compute-units",
+    "blocks": [
+      {
+        "key": "intro",
+        "_type": "prose",
+        "produces": null,
+        "consumes": null,
+        "src": "# Gas splits into two separate things\n\n> Version stamp — `@solana/kit` 7.0.0 · `@solana-program/compute-budget` 0.17.0\n> · authored 2026-07-30.\n\nOn the EVM, one number does two jobs. Gas meters how much work you did *and*, via\ngas price, how badly you want to be included. Raise the price and you buy\npriority; run an expensive loop and you pay more for the same priority.\n\nSolana separates them.\n\n**Compute units (CU)** meter work. Every instruction has a budget — 200,000 CU by\ndefault per instruction, up to 1.4M for a transaction if you ask. Exceed it and\nthe transaction fails. Crucially, the CU limit is *not* priced per unit the way\ngas is: the base fee is a flat 5,000 lamports per signature, essentially\nindependent of how much computation you did.\n\n**Priority fees** buy ordering. You bid in micro-lamports per compute unit,\nseparately, and only that bid competes for block space when there is contention.\n\nTwo consequences that will surprise you:\n\n- **Compute is cheap; state is expensive.** The EVM's `SSTORE`-dominated cost\n  model taught you to minimize writes above all. On Solana the recurring cost is\n  rent for space, and computation inside your budget is close to free. An\n  optimization that saves 20,000 CU saves you approximately nothing in fees — it\n  buys headroom, not money.\n- **Running out of CU is a failure, not a fee increase.** There is no \"raise the\n  limit and it costs more\" gradient. You either fit in the budget or the\n  transaction fails, so requesting an appropriate limit is part of building the\n  transaction.\n\n## Setting them\n\nBoth are instructions from the Compute Budget program, added to your\ntransaction:\n\n```ts\nimport {\n  getSetComputeUnitLimitInstruction,\n  getSetComputeUnitPriceInstruction,\n} from \"@solana-program/compute-budget\";\n\ngetSetComputeUnitLimitInstruction({ units: 300_000 });\ngetSetComputeUnitPriceInstruction({ microLamports: 5_000 });\n```\n\nThe first says how much room you need. The second is your priority bid. They are\nplain instructions like any other — you append them to a transaction message and\nthey carry no accounts.\n\nTwo honest footnotes. Putting them first is a **convention, not a protocol\nrule**: the runtime finds them anywhere in the transaction. The real constraints\nare at most one of each kind (a duplicate fails with `DuplicateInstruction`) and\nthe 1.4M-CU clamp. And for *estimating* the limit rather than hardcoding it, the\ncurrent API lives in Kit itself — `estimateResourceLimitsFactory({ rpc })` and\n`estimateAndSetResourceLimitsFactory(estimator)` — not in this package.\n\n> **In the wild (checked 2026-07-30).** The snippet you will find in nearly\n> every tutorial is `ComputeBudgetProgram.setComputeUnitLimit({...})` from\n> `@solana/web3.js` v1, a static class method. Same two instructions, superseded\n> API. Read it; write the builders above.\n\n## The arithmetic worth internalizing\n\nThe priority fee is `computeUnits × microLamportsPerCu`, converted from\nmicro-lamports to lamports — a division by 1,000,000.\n\nA 200,000 CU transaction bidding 5,000 micro-lamports/CU pays\n`200,000 × 5,000 / 1,000,000 = 1,000` lamports of priority, on top of the 5,000\nlamport base signature fee.\n\nNotice what that means: **the limit you request affects what you pay.** Request\n1.4M CU \"just to be safe\" while bidding the same price and you have multiplied\nyour priority fee by seven for a transaction that uses a fraction of it. The\ncorrect move is to simulate the transaction, observe the units actually consumed,\nand request that plus a modest margin.\n\nYou will implement exactly that conversion next.\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "exercise",
+        "_type": "code",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": "typescript",
+        "buildType": "standard",
+        "deployable": false,
+        "starter": "/**\n * Compute the priority fee, in lamports, for a transaction.\n *\n * The bid is expressed in MICRO-lamports per compute unit, so:\n *\n *   lamports = computeUnits * microLamportsPerCu / 1_000_000\n *\n * Round UP — a partial lamport is still charged as a whole one.\n *\n * Examples:\n *   priorityFeeLamports(200000, 5000) -> 1000\n *   priorityFeeLamports(200000, 0)    -> 0\n */\nfunction priorityFeeLamports(\n  computeUnits: number,\n  microLamportsPerCu: number\n): number {\n  return computeUnits * microLamportsPerCu;\n}\n",
+        "solution": "function priorityFeeLamports(\n  computeUnits: number,\n  microLamportsPerCu: number\n): number {\n  const MICRO_LAMPORTS_PER_LAMPORT = 1_000_000;\n  return Math.ceil((computeUnits * microLamportsPerCu) / MICRO_LAMPORTS_PER_LAMPORT);\n}\n",
+        "tests": [
+          {
+            "id": "typical-bid",
+            "description": "200,000 CU at 5,000 micro-lamports/CU is 1,000 lamports",
+            "input": "200000, 5000",
+            "expectedOutput": "result === 1000"
+          },
+          {
+            "id": "no-bid-is-free",
+            "description": "A zero bid costs nothing in priority — the base signature fee is separate",
+            "input": "200000, 0",
+            "expectedOutput": "result === 0"
+          },
+          {
+            "id": "rounds-up",
+            "description": "A partial lamport rounds up: 1 CU at 1 micro-lamport is charged as 1 lamport, not 0",
+            "input": "1, 1",
+            "expectedOutput": "result === 1"
+          },
+          {
+            "id": "limit-drives-cost",
+            "description": "Requesting 1.4M CU at the same bid costs seven times a 200k request — over-requesting is not free",
+            "input": "1400000, 5000",
+            "expectedOutput": "result === 7000"
+          }
+        ],
+        "hints": [
+          "The starter never converts units — it returns micro-lamports. Divide by 1,000,000 to reach lamports.",
+          "`Math.ceil`, not `Math.round` or `Math.floor`. The `rounds-up` case is 1 CU at 1 micro-lamport: a true value of 0.000001 lamports must still be charged as 1."
+        ],
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null,
+        "tutorNotes": [
+          "Learners divide but use `Math.floor` or plain truncation, so the sub-lamport case returns 0. The network rounds against the payer, never in their favour.",
+          "Some divide by 1,000 (confusing micro- with milli-). The factor between micro-lamports and lamports is 10^6.",
+          "The big one: they conflate the LIMIT with the PRICE. Two instructions, two jobs — the limit is how much room you reserve (a hard ceiling; exceed it and the transaction fails), the price is your bid per unit reserved. Raising the limit does not make you go faster; raising the price does not give you more room. Ask a stuck learner which one fixes an out-of-CU failure: the limit — and it costs real money at the current price.",
+          "Follow-on from the same confusion: they expect the fee to scale with compute CONSUMED, as gas does. It scales with compute REQUESTED. This is why `limit-drives-cost` exists — 1.4M CU at the same bid costs seven times a 200k request even if the instruction burns 6,000 units. \"Request 1.4M to be safe\" is a real bill.",
+          "\"So does optimizing my program save users money?\" Mostly no, and that surprises people coming from `SSTORE` accounting. Base fee is flat per signature and priority is per unit REQUESTED, so the saving only lands if you also lower the requested limit. What optimization really buys is headroom — fitting under the ceiling — not fees.",
+          "If they ask where the number to request comes from: simulate the transaction, read the units actually consumed, add roughly 10% margin. Consumption varies slightly run to run, so a limit pinned at one observed value fails intermittently. Simulate-then-tighten is a normal part of the send path here, not a debugging step."
+        ]
+      },
+      {
+        "key": "check",
+        "_type": "quiz",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": [
+          {
+            "id": "q1",
+            "prompt": "You optimize an instruction from 180,000 CU to 120,000 CU and leave the priority bid unchanged. Predict the effect on what a user pays.",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "The priority fee falls proportionally, because it is priced per compute unit requested",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "Nothing changes — the base fee is flat per signature and compute is not billed",
+                "correct": false,
+                "feedback": "The base fee is indeed flat, but the priority fee is explicitly per compute unit. Requesting fewer units at the same bid is cheaper."
+              },
+              {
+                "id": "c",
+                "label": "It rises, since a tighter limit risks failure and must be compensated with a higher bid",
+                "correct": false,
+                "feedback": "Nothing auto-compensates. A tighter limit is cheaper; whether it is *safe* is a separate judgement you make from simulation."
+              }
+            ],
+            "explanation": "Compute is nearly free in base fees but not in priority fees, which are priced per requested unit. This is why \"request 1.4M CU to be safe\" is a real cost, and why simulate-then-request is the standard practice."
+          },
+          {
+            "id": "q2",
+            "prompt": "Your instruction needs 250,000 CU and you request the default limit. Predict.",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "The transaction fails once the budget is exhausted — there is no overage billing",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "It succeeds and the extra compute is billed at the same rate",
+                "correct": false,
+                "feedback": "There is no overage. The budget is a hard ceiling, not a soft spending limit that bills you for going over."
+              },
+              {
+                "id": "c",
+                "label": "The runtime raises the limit automatically up to the 1.4M maximum",
+                "correct": false,
+                "feedback": "Nothing is raised for you. Requesting more is an explicit `getSetComputeUnitLimitInstruction` you add to the transaction."
+              }
+            ],
+            "explanation": "Unlike gas, where a higher limit simply risks spending more, the compute budget is a hard ceiling. Fitting is a build-time concern, which is why simulation is part of a normal send path rather than a debugging step."
+          }
+        ],
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      }
+    ]
+  },
+  {
+    "_id": "lesson-sfe-mappings-to-pdas",
+    "title": "From `mapping` to Program-Derived Addresses",
+    "slug": "mappings-to-pdas",
+    "blocks": [
+      {
+        "key": "intro",
+        "_type": "prose",
+        "produces": null,
+        "consumes": null,
+        "src": "# A `mapping` becomes an address you can compute\n\n> Version stamp — `@solana/kit` 7.0.0 · authored 2026-07-30.\n\n`balances[user]` is a hash of the slot number and the key, resolved by the EVM at\nread time inside the contract's storage. You never see the location; you just\nindex.\n\nSolana has no mapping, because it has no per-program storage to index into. What\nit has instead is stranger and, once it clicks, more useful: you can *derive an\naddress* from a set of seeds, deterministically, off-chain, before you send\nanything.\n\nThat address is a **program-derived address** — a PDA.\n\n```ts\nimport {\n  getProgramDerivedAddress,\n  getUtf8Encoder,\n  getAddressEncoder,\n} from \"@solana/kit\";\n\nconst [vaultPda, bump] = await getProgramDerivedAddress({\n  programAddress: VAULT_PROGRAM,\n  seeds: [\n    getUtf8Encoder().encode(\"vault\"),\n    getAddressEncoder().encode(owner),\n  ],\n});\n```\n\nGiven the same seeds and the same program address, everyone computes the same\naddress — your frontend, your tests, another protocol integrating with you. The\nmapping key became part of the address itself.\n\nTwo things to notice in that snippet, because both bite EVM developers on day\none. Seeds are **encoded bytes**, never bare JavaScript strings — the encoders\nare how `\"vault\"` and a 32-byte address become the byte sequences that get\nhashed. And the call is **awaited**: the derivation searches (see below), so it\nis async, and a forgotten `await` hands you a `Promise` where an address should\nbe. That is the single most common porting mistake into this API.\n\n> **In the wild (checked 2026-07-30).** Almost every PDA snippet you will find\n> on Stack Overflow or in an existing repo reads\n> `PublicKey.findProgramAddressSync(seeds, programId)` from `@solana/web3.js`\n> v1 — synchronous, `Buffer`-based, and still holding npm's `latest` tag. It is\n> superseded. Read it fluently; write `getProgramDerivedAddress`.\n\n## The two properties that matter\n\n**No private key exists for a PDA.** These addresses are deliberately chosen to\nfall *off* the ed25519 curve, so no keypair can produce a signature for them.\nNobody can sign as your vault by holding a secret — instead, the owning program\ncan sign for it, by supplying the seeds. Authority comes from the derivation, not\nfrom a secret. There is no EVM equivalent, because in the EVM authority over a\ncontract's storage is simply \"being that contract\".\n\n**The bump is the search.** Most seed combinations land *on* the curve, which\nwould be a valid keypair address and therefore unusable. So the derivation\nappends a byte — the bump — and counts down from 255 until it finds an off-curve\nresult. `getProgramDerivedAddress` returns the first one it finds (the\n*canonical* bump). Programs store that bump so they never repeat the search, and so an\nattacker cannot supply a different, non-canonical bump to derive a second valid\naddress for the same logical key.\n\n## What you gain, and what you give up\n\nYou gain addressability. A Solidity `mapping` entry has no address you can hand\nto anyone; a PDA is a first-class account you can pass to another program, list\nin a transaction, or read directly from a client with no view function and no\nRPC call into your contract.\n\nYou give up enumeration. `balances` cannot be listed on the EVM either, but at\nleast the contract can maintain its own index. On Solana the accounts exist\nindependently of any registry, so if you need to enumerate holders you either\nmaintain that index yourself or lean on an indexer that scans accounts by owner.\n\n## In the exercise\n\nYou will build the seed list itself — the small, boring, easy-to-get-wrong piece\nthat determines every address your program will ever use. Order matters, the\nliteral prefix matters, and both are part of your program's public interface: a\nseed change is an address change, and an address change orphans every account\nthat existed before.\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "exercise",
+        "_type": "code",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": "typescript",
+        "buildType": "standard",
+        "deployable": false,
+        "starter": "/**\n * Build the seed list for a per-owner vault PDA.\n *\n * The convention this program uses is a literal namespace prefix followed by the\n * owner, so a vault seed list is exactly:\n *\n *   [\"vault\", <owner>]\n *\n * The prefix is what stops a \"vault\" PDA from colliding with a \"config\" PDA\n * derived from the same owner. Order is part of the derivation: swapping the two\n * produces a different address.\n *\n * Example:\n *   vaultSeeds(\"alice\") -> [\"vault\", \"alice\"]\n */\nfunction vaultSeeds(owner: string): string[] {\n  return [owner];\n}\n",
+        "solution": "function vaultSeeds(owner: string): string[] {\n  return [\"vault\", owner];\n}\n",
+        "tests": [
+          {
+            "id": "prefix-then-owner",
+            "description": "The namespace prefix comes first, then the owner",
+            "input": "\"alice\"",
+            "expectedOutput": "JSON.stringify(result) === JSON.stringify([\"vault\",\"alice\"])"
+          },
+          {
+            "id": "owner-is-not-hardcoded",
+            "description": "A different owner produces a different seed list — the owner is threaded through, not baked in",
+            "input": "\"bob\"",
+            "expectedOutput": "JSON.stringify(result) === JSON.stringify([\"vault\",\"bob\"])"
+          },
+          {
+            "id": "exactly-two-seeds",
+            "description": "Two seeds, no more: an extra seed silently changes every derived address",
+            "input": "\"carol\"",
+            "expectedOutput": "result.length === 2"
+          }
+        ],
+        "hints": [
+          "The starter returns `[owner]` — one seed. The convention in the prose is two: the literal namespace prefix, then the owner.",
+          "Return the prefix as a plain string literal in the array, in first position. `[\"vault\", owner]` — not `[owner, \"vault\"]`, which derives a different address entirely."
+        ],
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null,
+        "tutorNotes": [
+          "Learners order the seeds owner-first; the derivation is order-sensitive, so that is a different (and unused) address. Stress that this does not throw — it returns a perfectly real address that simply is not the vault. Wrong seed order is a silent wrong address, never an error.",
+          "Some add a third seed such as a bump, and `exactly-two-seeds` catches it. This is the lesson's most common confusion, so name the two roles apart: the SEEDS are your program's public interface, chosen by you; the BUMP is the search result the derivation appends by itself to land off the curve. You author seeds, never a bump. (The exception — a program replaying its own stored canonical bump to sign — is a different call and comes later.)",
+          "\"Why store the bump at all, then?\" Two reasons, and the second is a security bug. The search costs real compute on-chain, and — more importantly — several bumps below the canonical one may also land off-curve, each deriving a DIFFERENT valid address for the same logical key. Storing and re-checking the canonical bump is what stops an attacker handing you a second vault for the same owner.",
+          "They ask why the exercise returns plain strings when the intro shows `getUtf8Encoder().encode(...)`. The exercise isolates ordering with no crypto in the sandbox; in production seeds are ENCODED bytes, never bare JS strings, and a string handed straight to the real API is a type error.",
+          "They forget the `await` when they later write real Kit code. `getProgramDerivedAddress` is async — the bump search is why — so a missing await yields a `Promise` where an address should be. It is the number one porting mistake from `findProgramAddressSync`, which was synchronous.",
+          "Someone will ask what happens if the seeds exceed the limit: a seed is at most 32 bytes and there are at most 16 of them. Hashing a long value down to 32 bytes yourself is the normal escape hatch, and it is why you see `hash(name)` as a seed rather than the name."
+        ]
+      },
+      {
+        "key": "check",
+        "_type": "quiz",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": [
+          {
+            "id": "q1",
+            "prompt": "Why can nobody produce a signature for a PDA the way they can for a normal wallet address?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "PDAs are chosen to lie off the ed25519 curve, so no private key exists for them",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "The runtime maintains a blocklist of derived addresses and refuses their signatures",
+                "correct": false,
+                "feedback": "There is no list. The property is mathematical: the address is not a point on the curve, so it is not a public key any private key maps to."
+              },
+              {
+                "id": "c",
+                "label": "Their private keys are held by the owning program and never exposed",
+                "correct": false,
+                "feedback": "No key exists to hold. The owning program signs by supplying the seeds, which is a different mechanism from holding a secret."
+              }
+            ],
+            "explanation": "Authority over a PDA comes from the derivation, not from a secret. The program proves it may act for the address by producing the seeds that generate it — which is why seeds are effectively an access-control policy written as data."
+          },
+          {
+            "id": "q2",
+            "prompt": "You ship v2 of a program and change a PDA seed prefix from `\"vault\"` to `\"vault_v2\"`. Predict the effect on existing users.",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "Every existing vault is orphaned — the new derivation points at fresh, empty addresses",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "Existing accounts are re-derived to the new address automatically on next access",
+                "correct": false,
+                "feedback": "Nothing re-derives or migrates. An address is a function of its seeds; change the seeds and you are simply talking about a different account."
+              },
+              {
+                "id": "c",
+                "label": "The old and new seeds both resolve, since the bump search covers nearby inputs",
+                "correct": false,
+                "feedback": "The bump search varies one appended byte to get off the curve. It does not explore alternative seed contents."
+              }
+            ],
+            "explanation": "Seeds are part of your public interface, exactly like a function signature. Changing them does not migrate anything — it points at different accounts and strands the originals, still holding their rent."
+          }
+        ],
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      }
+    ]
+  },
+  {
+    "_id": "lesson-sfe-msg-sender-to-signers",
+    "title": "From `msg.sender` to Verified Signers",
+    "slug": "msg-sender-to-signers",
+    "blocks": [
+      {
+        "key": "intro",
+        "_type": "prose",
+        "produces": null,
+        "consumes": null,
+        "src": "# `msg.sender` becomes a list the runtime already verified\n\n`msg.sender` is a single address, and its meaning shifts with context: at the top\nlevel it is an externally-owned account, and one `call` deeper it is the calling\ncontract. Half of Solidity's access-control folklore exists to manage that shift.\n\nSolana replaces it with something flatter. A transaction carries a list of\naccounts, and each one is flagged `is_signer` or not. Before your program runs,\nthe runtime has already verified every signature against every account marked as\na signer. By the time your code executes, `is_signer` is a fact, not a claim.\n\nSo the question is never \"who called me?\" It is \"which of the accounts I was\nhanded are signers, and is the right one among them?\"\n\n```rust\nrequire!(ctx.accounts.owner.is_signer, VaultError::NotOwner);\nrequire_keys_eq!(ctx.accounts.vault.owner, ctx.accounts.owner.key());\n```\n\nTwo separate checks, and both are load-bearing:\n\n- **Did they sign?** Proves the transaction was authorized by that keypair.\n- **Are they the right one?** Proves the signer is the account your state says\n  is allowed.\n\nA signature from *somebody* is worthless on its own. That is the Solana version\nof the bug where a Solidity function checks that a caller exists but not that it\nis the owner.\n\n## Multiple signers are ordinary\n\nA Solana transaction can carry several signers, all verified up front — a user\nand a fee payer, or two parties to an escrow, in a single atomic transaction. In\nSolidity, the equivalent means signature-verification plumbing you write yourself\n(`ecrecover`, EIP-712, replay nonces). Here it is a property of the transaction\nenvelope, and there is nothing to implement.\n\n## Where `tx.origin` went\n\nIt does not exist, and its absence is not a gap. `tx.origin` is dangerous in\nSolidity precisely because it collapses the call chain into one address that\nphishing can exploit. On Solana, when your program calls another program via CPI,\nthe runtime tracks which signatures propagate: the callee sees the original\nsigners, plus any PDA the caller signed for with its seeds. The chain stays\nexplicit instead of being flattened into a single ambient value.\n\n## The habit to build now\n\nComing from Solidity, the reflex is to ask what the current call context is.\nRetrain it into two questions you can answer by reading the account list:\n\n1. Which accounts are signers?\n2. Does my state say those specific keys are authorized?\n\nEverything else in access control on Solana is a variation on those two lines.\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "check",
+        "_type": "quiz",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": [
+          {
+            "id": "q1",
+            "prompt": "A withdraw instruction checks `ctx.accounts.owner.is_signer` and nothing else. An attacker signs with their own keypair and passes someone else's vault. Predict.",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "The withdrawal succeeds — a valid signature was proven, but never that this signer owns that vault",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "It fails; the runtime binds signers to the accounts they are authorized over",
+                "correct": false,
+                "feedback": "The runtime verifies signatures. It has no idea which vault a given key is allowed to touch — that relationship exists only in your state, so only your program can check it."
+              },
+              {
+                "id": "c",
+                "label": "It fails, because a signer must own every account in the instruction",
+                "correct": false,
+                "feedback": "No such rule exists. Transactions routinely include accounts the signer has no authority over."
+              }
+            ],
+            "explanation": "\"Signed\" and \"authorized\" are different claims. The runtime proves the first; only a comparison against your own state proves the second. This is the single most common port of the Solidity missing-`onlyOwner` bug."
+          },
+          {
+            "id": "q2",
+            "prompt": "Where did `tx.origin` go?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "Nowhere — signer status propagates explicitly through CPI instead of collapsing into one ambient address",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "It is exposed as the first account in every transaction's account list",
+                "correct": false,
+                "feedback": "The first account is the fee payer — that position is fixed by the protocol, not a convention — but paying a fee is not authorizing anything, so it must never be read as an authorization signal."
+              },
+              {
+                "id": "c",
+                "label": "It is available but discouraged, exactly as in Solidity",
+                "correct": false,
+                "feedback": "There is no equivalent value to reach for. The design avoids the flattening that makes `tx.origin` exploitable."
+              }
+            ],
+            "explanation": "The phishing risk in `tx.origin` comes from flattening a call chain into one address. Solana keeps the chain explicit: a callee sees the original signers plus any PDA the caller signed for, and nothing pretends to be a single \"who started this\"."
+          },
+          {
+            "id": "q3",
+            "prompt": "Two parties must both authorize an atomic swap. What does that take on Solana?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "One transaction carrying both signers; the runtime verifies both before execution",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "An EIP-712 style signature passed as calldata and recovered in-program",
+                "correct": false,
+                "feedback": "That is the Solidity workaround for a transaction envelope that only carries one sender. Solana's envelope carries many."
+              },
+              {
+                "id": "c",
+                "label": "Two transactions and a state machine that pairs them",
+                "correct": false,
+                "feedback": "A valid pattern when the parties genuinely act at different times, but unnecessary here — and it gives up atomicity."
+              }
+            ],
+            "explanation": "Multi-signer transactions are ordinary, not a protocol you implement. Whole categories of Solidity signature plumbing — recovery, replay nonces, deadline checks — simply have no counterpart."
+          }
+        ],
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      }
+    ]
+  },
+  {
+    "_id": "lesson-sfe-rent-and-space",
+    "title": "Rent, and Sizing an Account",
+    "slug": "rent-and-space",
+    "blocks": [
+      {
+        "key": "intro",
+        "_type": "prose",
+        "produces": null,
+        "consumes": null,
+        "src": "# Storage costs rent, and the size is yours to choose\n\n> Version stamp — Anchor 1.1.2 (`@anchor-lang/core` 1.1.2) · authored\n> 2026-07-30.\n\nOn the EVM you pay for storage once, at write time, in gas. `SSTORE` is\nexpensive precisely because the network stores that word forever. There is no\nongoing cost and no size declaration — you write to slot 7 and slot 7 exists.\n\nSolana charges differently. An account occupies validator memory for as long as\nit exists, so it must hold a minimum lamport balance proportional to its size.\nThat balance is called **rent**, and an account holding it is **rent-exempt**.\n\nRead \"rent\" as a **deposit**, not a subscription. The name is historical: Solana\nonce did debit accounts periodically, and an account that ran dry was collected.\nThat mechanism is gone. Today rent-exemption is enforced by the runtime *at\ncreation* — an account that does not hold the minimum for its size is not\ncreated at all, the instruction fails, and there is no such thing as a\npartially-funded account slowly draining. Nothing is billed over time and\nnothing is erased for non-payment. Every account on the chain is rent-exempt,\nbecause the runtime accepts no other kind.\n\nThe deposit stays yours: close the account and it comes back in full.\n\nTwo things follow, and both are alien coming from Solidity.\n\n## You declare the size up front\n\nCreating an account means saying how many bytes it needs. Not \"roughly\"; exactly.\nThe runtime allocates that many bytes, zeroed, and charges you the rent-exempt\nminimum for that size.\n\nThere is no `mapping` that grows as you insert. There is no dynamic array that\njust gets longer. If you want to store more later, you either allocate for the\nworst case now or `realloc` the account and top up the rent difference.\n\nSizing is therefore a design decision you make before writing a line of logic.\nGet it too small and you cannot store what you need; too large and every user\noverpays to create their account.\n\n## Rent is refundable\n\nRent is a deposit, not a fee. Close the account and the lamports go back to\nwhoever you nominate. This is why Solana programs have a `close` instruction and\nSolidity contracts do not bother with `selfdestruct` for state — reclaiming\nspace is a normal, profitable operation rather than a curiosity.\n\n## Counting bytes\n\nAn Anchor account starts with an 8-byte **discriminator** — a hash of the account\ntype name, used to tell a `Vault` from a `Config` when both are just bytes owned\nby your program. After that you pay for exactly what you declare:\n\n```text\n8                discriminator (Anchor)\n32               Pubkey\n8                u64  (lamports, timestamps)\n1                u8   (a PDA bump)\n1                bool\n4 + len          String or Vec (4-byte length prefix, then contents)\n```\n\nA vault with an owner `Pubkey`, a `u64` balance and a `u8` bump is\n`8 + 32 + 8 + 1 = 49` bytes. That number is not trivia — it is an argument you\npass at creation, and getting it wrong is one of the most common first bugs for\ndevelopers arriving from the EVM.\n\nIn the exercise you will compute exactly that number.\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "exercise",
+        "_type": "code",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": "typescript",
+        "buildType": "standard",
+        "deployable": false,
+        "starter": "/**\n * Anchor lays an account out as:\n *\n *   8 bytes   discriminator (always present on an Anchor account)\n *   8 bytes   per u64 field\n *   1 byte    for the PDA bump, when the account stores one\n *\n * Return the total number of bytes to request at creation.\n *\n * Examples:\n *   accountSize(3, true)  -> 8 + 24 + 1 = 33\n *   accountSize(0, false) -> 8\n */\nfunction accountSize(numU64Fields: number, hasBump: boolean): number {\n  return 0;\n}\n",
+        "solution": "function accountSize(numU64Fields: number, hasBump: boolean): number {\n  const DISCRIMINATOR = 8;\n  const U64 = 8;\n  return DISCRIMINATOR + numU64Fields * U64 + (hasBump ? 1 : 0);\n}\n",
+        "tests": [
+          {
+            "id": "three-fields-with-bump",
+            "description": "Three u64 fields plus a bump: 8 + 24 + 1 = 33",
+            "input": "3, true",
+            "expectedOutput": "result === 33"
+          },
+          {
+            "id": "empty-account",
+            "description": "No fields and no bump is still 8 bytes — the discriminator is never free",
+            "input": "0, false",
+            "expectedOutput": "result === 8"
+          },
+          {
+            "id": "bump-costs-exactly-one-byte",
+            "description": "One u64 with a bump is 17, without it 16 — the bump is a u8, not padded",
+            "input": "1, true",
+            "expectedOutput": "result === 17"
+          }
+        ],
+        "hints": [
+          "The discriminator is unconditional — it is there even when the account has no fields at all. Start your total at 8 rather than at 0.",
+          "`hasBump` contributes 1 byte, not 8. A bump is a `u8`; there is no alignment padding to round it up."
+        ],
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null,
+        "tutorNotes": [
+          "Learners returning `numU64Fields * 8` forget the 8-byte discriminator; the `empty-account` case is what catches it.",
+          "Some add 8 for the bump by pattern-matching the u64 size. A bump is a u8 — exactly 1 byte.",
+          "They ask why they are counting bytes by hand when Anchor has `#[derive(InitSpace)]` and `Vault::INIT_SPACE`. The honest answer: in real code you use it, and you should. But `INIT_SPACE` does NOT include the 8-byte discriminator — the idiomatic constraint is `space = 8 + Vault::INIT_SPACE` — so the one number the macro leaves you to remember is exactly the one this exercise drills. A learner who never counted by hand writes `space = Vault::INIT_SPACE` and is eight bytes short.",
+          "They ask what happens if the number is too small. Not a silent truncation: the write fails and the transaction fails. Too LARGE is the quieter bug — it never errors, every user just overpays the rent deposit forever, and nobody notices until someone reads an account and finds a tail of zeros.",
+          "\"Then why not allocate 10 KB and stop worrying?\" Because the deposit scales with size and the payer is usually the user, and because 10 KB is the hard per-instruction allocation ceiling anyway. Sizing is a real design decision, which is the point of the lesson.",
+          "If they ask about `String` or `Vec`: the 4-byte length prefix in the table is the *header*, not the contents. A `Vec<Pubkey>` capped at 10 is `4 + 10 * 32`, and you must size for the cap because nothing grows on write."
+        ]
+      },
+      {
+        "key": "check",
+        "_type": "quiz",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": [
+          {
+            "id": "q1",
+            "prompt": "You size a vault account at 49 bytes and later want to add a `Vec<Pubkey>` of up to 10 delegates. Predict what has to happen.",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "The account must be reallocated to a larger size and topped up with the rent difference",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "Nothing — the account grows on write, like a Solidity dynamic array",
+                "correct": false,
+                "feedback": "Nothing grows implicitly. The byte count was fixed when the account was created; writing past it is an error, not an extension."
+              },
+              {
+                "id": "c",
+                "label": "The `Vec` is stored in a separate account automatically",
+                "correct": false,
+                "feedback": "Splitting state across accounts is a design you choose, never something the runtime does for you."
+              }
+            ],
+            "explanation": "Size is declared, not discovered. Growing means `realloc` plus more rent — which is exactly why worst-case sizing up front is such a common pattern in production programs."
+          },
+          {
+            "id": "q2",
+            "prompt": "A user closes their vault account. What happens to the lamports that made it rent-exempt?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "They are returned to whichever account the close instruction nominates",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "They are burned, since they paid for storage already consumed",
+                "correct": false,
+                "feedback": "Rent is a refundable deposit, not a consumed fee. That is precisely why closing accounts is a normal operation rather than a write-off."
+              },
+              {
+                "id": "c",
+                "label": "They stay locked forever; only the data is cleared",
+                "correct": false,
+                "feedback": "If that were true, every abandoned account would permanently lock SOL. Reclaiming the deposit is the point of closing."
+              }
+            ],
+            "explanation": "Rent-exemption is a deposit held against space. Give the space back and you get the deposit back — the closest EVM analogue is the (much smaller) gas refund for zeroing storage."
+          }
+        ],
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      }
+    ]
+  },
+  {
+    "_id": "lesson-sfe-storage-to-accounts",
+    "title": "Your Program Owns No Storage",
+    "slug": "storage-to-accounts",
+    "blocks": [
+      {
+        "key": "intro",
+        "_type": "prose",
+        "produces": null,
+        "consumes": null,
+        "src": "# Your program owns no storage\n\nIn Solidity, a contract and its state are the same deployed thing. `uint256\npublic totalDeposits;` lives at a slot inside the contract's own storage trie,\nand only that contract's code can write it. Deploy the contract, and the storage\ncomes with it — empty, but there.\n\nOn Solana a program is an account holding executable bytes, and that account is\n**immutable at runtime**. Your program cannot write to itself. There is no slot\n0. `totalDeposits` has to live in a *different* account, one that you create,\nsize, and pay for.\n\n## The ownership rule that replaces `private`\n\nSolidity gives you visibility keywords. Solana gives you one runtime rule, and\nit is stricter than anything in the EVM:\n\n> A program may only write to accounts it owns.\n\nEvery account carries an `owner` field — the public key of the program allowed\nto modify its data. When your program writes to an account it does not own, the\nwhole transaction fails. Not a revert your code chose; a refusal the runtime\nimposes on you.\n\nWorth being precise about *when*, because it is not what a Solidity developer\nexpects. The write itself is not trapped at the moment it happens — your program\nis handed a mutable buffer and the store lands in memory. The runtime verifies\nownership **after your instruction returns**, comparing the account against what\nit looked like going in; an illegal change fails the transaction and every\neffect is discarded. So your code can appear to \"succeed\" right up until it\ndoes not. The guarantee is on the committed result, not on the individual\ninstruction that produced it.\n\nThis is why you will see Solana developers say \"the program owns the account\"\nwhere you would say \"the contract holds the state\". The account exists\nindependently. Your program is merely the only thing permitted to change it.\n\n## Three consequences you will feel immediately\n\n**State is passed in, not looked up.** Solidity reads `totalDeposits` from\nambient storage. A Solana instruction receives the accounts it may touch as\nexplicit arguments. If the caller does not pass the account, your program cannot\nread it — there is no ambient anything.\n\n**One program, many state accounts.** An ERC-20 is one contract per token, with\nbalances in an internal mapping. SPL Token is *one* program, deployed once, and\nevery mint and every balance is a separate account it owns. You will meet this\ninversion again in module 3; it is the same rule you are reading now.\n\n**Upgrades do not migrate state.** Upgrading a Solidity contract means proxies,\nbecause state and code are welded together. On Solana you replace the\nexecutable bytes of the program account, and the state accounts are untouched —\nthey were never inside the program to begin with. The flip side: if your new\ncode reads the old layout differently, nothing stops it. Nobody migrated\nanything, because nobody moved anything.\n\n## Reading an account\n\nEvery account, whoever owns it, has the same envelope:\n\n```text\nlamports    u64      balance in the base unit of SOL\nowner       Pubkey   the program allowed to write `data`\nexecutable  bool     is this account a program?\ndata        bytes    opaque to the runtime; meaningful only to `owner`\n```\n\n`data` is bytes. The runtime does not know or care what is in there — no types,\nno ABI, no storage layout. Interpreting those bytes is entirely your program's\njob, which is why Solana programs spend real effort on serialization in a way\nSolidity developers never have to think about.\n\nHold on to the envelope. `lamports` and `owner` come back in the next lesson, in\na way that has no EVM analogue at all: on Solana an account must hold a minimum\nlamport balance for its size before the runtime will let it exist at all. That\nbalance is a **refundable deposit**, not a meter — nothing is ever billed\nagainst it over time, and no account is erased for non-payment.\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "check",
+        "_type": "quiz",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": [
+          {
+            "id": "q1",
+            "prompt": "You port a Solidity contract that keeps `mapping(address => uint256) balances` in its own storage. On Solana, where does that state live?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "In separate accounts your program owns, passed into each instruction",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "Inside the program account, after the executable bytes",
+                "correct": false,
+                "feedback": "The program account is immutable at runtime — your own code cannot write to it. There is nowhere inside it to put a balance."
+              },
+              {
+                "id": "c",
+                "label": "In a runtime-provided storage map keyed by program id",
+                "correct": false,
+                "feedback": "There is no ambient storage on Solana. If an instruction did not receive an account, that account does not exist as far as the instruction is concerned."
+              }
+            ],
+            "explanation": "Code and state are different accounts. The program is executable and immutable while running; state lives in accounts it owns, and each instruction receives exactly the ones it may touch."
+          },
+          {
+            "id": "q2",
+            "prompt": "Your program is passed an account owned by a different program, and it writes to it. Predict.",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "The runtime rejects the transaction — a program may only write to accounts it owns",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "The write succeeds; ownership only governs who may close the account",
+                "correct": false,
+                "feedback": "Ownership governs writes. It is the core protection of the account model, not a bookkeeping field."
+              },
+              {
+                "id": "c",
+                "label": "It compiles and silently no-ops, so you must check the owner yourself",
+                "correct": false,
+                "feedback": "Closer than it looks — the store does land in the buffer — but it is not ignored. The runtime compares the account after your instruction returns and fails the whole transaction, discarding every effect."
+              }
+            ],
+            "explanation": "\"Only the owner may write\" is verified by the runtime after your instruction returns, and an illegal change fails the transaction rather than reverting inside your code. This is why `owner` checks are the first thing an auditor looks for on accounts you merely *read* — the runtime protects your writes, not your assumptions about someone else's data."
+          },
+          {
+            "id": "q3",
+            "prompt": "Compared with upgrading a Solidity contract behind a proxy, what is different about upgrading a Solana program?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "State accounts are untouched, because they were never inside the program",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "State is automatically migrated to the new layout by the runtime",
+                "correct": false,
+                "feedback": "Nothing migrates anything. The runtime has no idea what your `data` bytes mean — that interpretation lives only in your program."
+              },
+              {
+                "id": "c",
+                "label": "Upgrades are impossible; programs are immutable once deployed",
+                "correct": false,
+                "feedback": "A program account can be upgraded by its upgrade authority (or made truly immutable by revoking it). \"Immutable at runtime\" means the program cannot write to *itself* while executing."
+              }
+            ],
+            "explanation": "Because code and state were never welded together, replacing the code leaves the state exactly where it was. The hazard inverts too: no proxy gymnastics, but also nothing stopping new code from misreading an old layout."
+          }
+        ],
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      }
+    ]
+  },
+  {
+    "_id": "lesson-sfe-what-changes",
+    "title": "What Actually Changed",
+    "slug": "what-changes",
+    "blocks": [
+      {
+        "key": "intro",
+        "_type": "prose",
+        "produces": null,
+        "consumes": null,
+        "src": "# What actually changed\n\nYou arrived able to build on the EVM. Nine lessons later, here is the whole\ntranslation table in one place — and, more usefully, the parts that do not\ntranslate.\n\n## The table\n\n| EVM | Solana |\n| --- | --- |\n| Contract storage | Separate accounts the program owns |\n| `SSTORE`, paid once | Rent, a refundable deposit sized in bytes |\n| `mapping(k => v)` | A PDA derived from seeds, computable off-chain |\n| `msg.sender` | An account list with verified `is_signer` flags |\n| `tx.origin` | No equivalent; signer status propagates explicitly |\n| Gas | Compute units (work) plus priority fees (ordering), priced apart |\n| Implicit storage access | An account list declared before execution |\n| One ERC-20 contract per token | One shared token program; a mint is data |\n| `approve` / `allowance` | A `delegate` field on the token account |\n| External call | CPI, with signer propagation and explicit accounts |\n\n## The three that are not translations\n\n**Sizing is a design decision.** No EVM habit prepares you for declaring byte\ncounts up front. It surfaces early — usually as an account too small for what you\nwanted to store — and it shapes schemas more than anything else in the model.\n\n**Authority can come from derivation.** A PDA has no private key. A program signs\nfor it by producing seeds. There is no Solidity analogue, because in the EVM\n\"being the contract\" is the only authority a contract has over its own storage.\nOnce this lands, a lot of Solana design stops looking arbitrary.\n\n**The account list is a public interface.** Anyone can read what a transaction\ntouches without executing it. That is why parallel execution is possible, why\nwallets can simulate meaningfully, and why some patterns you would reach for —\ndiscovering state mid-execution — are simply unavailable.\n\n## What did not change\n\nChecked arithmetic still matters, and Rust's `checked_add` is your `SafeMath`\nwith better ergonomics. Access control is still the bug class that drains\nprotocols; it just moves from a missing `onlyOwner` to a missing \"is this signer\nthe owner my state names\". Upgrade authority is as sensitive as a proxy admin\nkey. Integrating unknown code is still where the risk lives.\n\nThe security instincts you already have are the ones worth keeping. It is the\nstorage instincts that need rebuilding.\n\n## Where to go next\n\nThe natural sequel is a Rust course, then the account-validation layer Anchor\ngives you — `#[derive(Accounts)]` is where every idea in module 1 becomes a\nconstraint the compiler checks for you. If you would rather stay on the client\nside, the SDK path covers building transactions, deriving PDAs from TypeScript,\nand simulating before you send.\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "check",
+        "_type": "quiz",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": [
+          {
+            "id": "q1",
+            "prompt": "Which EVM instinct transfers to Solana essentially unchanged?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "Access control is the dominant bug class, and checked arithmetic is not optional",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "Minimize writes above all, because storage writes dominate cost",
+                "correct": false,
+                "feedback": "That is an `SSTORE` instinct. Solana's recurring cost is rent for space; compute inside your budget is close to free, so the optimization target moves."
+              },
+              {
+                "id": "c",
+                "label": "Assume 18 decimals unless told otherwise",
+                "correct": false,
+                "feedback": "A convention that does not hold here. USDC is 6, wrapped SOL is 9, many NFTs are 0 — read `decimals` from the mint."
+              }
+            ],
+            "explanation": "The security instincts survive the move; the storage-cost instincts do not. Keep the paranoia about who is authorized and about overflow, and rebuild the intuitions about what state costs."
+          },
+          {
+            "id": "q2",
+            "prompt": "A colleague says \"Solana is just Ethereum with parallel execution bolted on\". What is the most accurate correction?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "Parallelism is a consequence of declaring accounts up front, not a feature added on top",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "The models are the same; Solana is only faster hardware and bigger blocks",
+                "correct": false,
+                "feedback": "The account model, PDAs and the shared token program are structural differences, not throughput tuning."
+              },
+              {
+                "id": "c",
+                "label": "Solana cannot express what the EVM can, so it trades capability for speed",
+                "correct": false,
+                "feedback": "The expressive gaps are narrow. What changes is where state lives and how authority is proven, not what can be built."
+              }
+            ],
+            "explanation": "The declared account list comes first; parallel scheduling is what that declaration makes possible. Nearly every ergonomic friction in this course pays for that one property."
+          }
+        ],
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "reflect",
+        "_type": "openEnded",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": null,
+        "prompt": "Pick one system you have built on the EVM. Which single part of it would change most under the account model — and would it come out simpler or more complicated? Be specific about the state.",
+        "maxWords": 180,
+        "amount": null,
+        "network": null,
+        "idl": null
+      }
+    ]
+  },
+  {
+    "_id": "lesson-sfwd-accounts-are-just-bytes",
+    "title": "Accounts Are Just Bytes",
+    "slug": "accounts-are-just-bytes",
+    "blocks": [
+      {
+        "key": "intro",
+        "_type": "prose",
+        "produces": null,
+        "consumes": null,
+        "src": "# Accounts Are Just Bytes\n\n> Version stamp — `@solana/kit` 7.0.0 · devnet · authored 2026-07-28.\n\nYesterday you read the vault in an explorer. Today you become the explorer: fetch the account over RPC and turn its 49 raw bytes into `{ owner, balance, bump }` yourself.\n\n## Fetching the bytes\n\nIn Kit, an RPC client is one function call, and a read is a request you build and then `.send()`:\n\n```ts\nimport { createSolanaRpc, address } from \"@solana/kit\";\n\nconst rpc = createSolanaRpc(\"https://api.devnet.solana.com\");\nconst vault = address(\"FY86s1fAwUiFQTjVFYprsiV6fwNH7e955MSUBo73FP4j\");\n\nconst { value } = await rpc\n  .getAccountInfo(vault, { encoding: \"base64\" })\n  .send();\n// value.data[0] is the base64 string; decode it and you hold 49 bytes.\n```\n\nThat is the whole read path. What comes back is not JSON, not an object, not a struct — a base64 string that decodes to 49 bytes. The chain stores bytes; **meaning is a layout you have to know**.\n\n## The layout\n\nThis vault program documents its account layout (and in Course 2 you will write the Rust struct that produces it):\n\n| offset | length | field | encoding |\n|---|---|---|---|\n| 0 | 8 | discriminator | fixed bytes `[228, 196, 82, 165, 98, 210, 235, 152]` |\n| 8 | 32 | owner | raw public key, base58-encoded for display |\n| 40 | 8 | balance | unsigned 64-bit integer, **little-endian** |\n| 48 | 1 | bump | single byte |\n\n- The **discriminator** is an 8-byte type tag stamped at offset 0 of every account this program family creates — it answers \"are these bytes actually a VaultState?\" before you read another field. In module 3 your inspector checks it before decoding anything.\n- The **owner** field is the human answer lesson 1 promised: the wallet that controls this vault, stored as 32 raw bytes.\n- The **balance** is the vault's own accounting of what its owner deposited — distinct from the account's lamports, which also carry the rent deposit.\n- The **bump** you will understand in the next lesson. For today: one byte at the end.\n\n## Little-endian, felt once\n\n`balance` is a u64 stored least-significant byte first. A `DataView` reads it in one call — the `true` is \"little-endian\", and forgetting it is the classic bug:\n\n```ts\nconst view = new DataView(data.buffer, data.byteOffset, data.byteLength);\nconst balance = view.getBigUint64(40, true); // true = little-endian\n```\n\nNote the type: **`BigInt`, not `Number`**. Lamport amounts are u64, and `Number` silently loses integer precision above 2^53 — real mainnet balances cross that line. Every lamport value in this course is a `bigint`.\n\n## The production form\n\nDecoding by hand teaches you what the bytes are. In production code you declare the layout once with Kit's codecs and get the whole struct back:\n\n```ts\nimport {\n  getStructDecoder,\n  getU64Decoder,\n  getU8Decoder,\n  getAddressDecoder,\n  getBytesDecoder,\n  fixDecoderSize,\n} from \"@solana/kit\";\n\nconst vaultDecoder = getStructDecoder([\n  [\"discriminator\", fixDecoderSize(getBytesDecoder(), 8)],\n  [\"owner\", getAddressDecoder()],\n  [\"balance\", getU64Decoder()],\n  [\"bump\", getU8Decoder()],\n]);\n\nconst state = vaultDecoder.decode(data); // { discriminator, owner, balance, bump }\n```\n\nSame 49 bytes, same offsets, same little-endian u64 — the codec just says it declaratively. Use codecs in real code; decode by hand today so the codec is never magic.\n\n## The exercise\n\nThe grader has no network, so the harness hands your function **bytes recorded from the real devnet account** — the exact 49 bytes you can re-fetch yourself with the snippet above. Write `decodeVault(data)` in four labeled subgoals; a real base58 helper is provided for the owner field. One of the test fixtures is a *different* vault with a different owner, balance, and bump — so decode the bytes in front of you, don't transcribe the explorer.\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "decode",
+        "_type": "code",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": "typescript",
+        "buildType": "standard",
+        "deployable": false,
+        "starter": "// ─────────────────────────────────────────────────────────────────────────────\n// TEST HARNESS — do not edit. Grading calls runCase with a fixture name and\n// hands your decodeVault the pinned bytes of that fixture (the grader has no\n// network). Provenance of each fixture is stated where it is defined below.\n// ─────────────────────────────────────────────────────────────────────────────\nfunction runCase(fixtureName: string) {\n  const bytes = FIXTURES[fixtureName];\n  if (!bytes) throw new Error(\"unknown fixture: \" + fixtureName);\n  return decodeVault(new Uint8Array(bytes));\n}\n\n/**\n * Decode a 49-byte VaultState account.\n *\n * Layout (from the lesson):\n *   offset 0,  8 bytes  — discriminator (already checked by the caller here)\n *   offset 8,  32 bytes — owner, a raw public key; display form is base58\n *   offset 40, 8 bytes  — balance, u64 LITTLE-endian\n *   offset 48, 1 byte   — bump\n */\nfunction decodeVault(data: Uint8Array): {\n  owner: string;\n  balance: bigint;\n  bump: number;\n} {\n  // Subgoal 1 (done for you) — a DataView over exactly these bytes.\n  // data.byteOffset/byteLength matter: a Uint8Array can be a window into a\n  // larger buffer, and the view must cover the same window.\n  const view = new DataView(data.buffer, data.byteOffset, data.byteLength);\n\n  // Subgoal 2 — owner: slice the 32 bytes at offsets 8..39 and base58-encode\n  // them with the provided toBase58 helper.\n  const owner = \"\"; // ← replace\n\n  // Subgoal 3 — balance: the unsigned 64-bit little-endian integer at\n  // offset 40. Use the view; keep it a bigint.\n  const balance = 0n; // ← replace\n\n  // Subgoal 4 — bump: the single byte at offset 48.\n  const bump = -1; // ← replace\n\n  return { owner, balance, bump };\n}\n\n// ── PROVIDED — a real base58 encoder (the display encoding of public keys) ──\nconst BASE58_ALPHABET =\n  \"123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz\";\nfunction toBase58(bytes: Uint8Array): string {\n  let n = 0n;\n  for (const b of bytes) n = n * 256n + BigInt(b);\n  let out = \"\";\n  while (n > 0n) {\n    out = BASE58_ALPHABET[Number(n % 58n)] + out;\n    n /= 58n;\n  }\n  // Leading zero bytes encode as leading '1's.\n  for (const b of bytes) {\n    if (b !== 0) break;\n    out = \"1\" + out;\n  }\n  return out;\n}\n\n// ── PINNED FIXTURES ─────────────────────────────────────────────────────────\n// \"reference-vault\" is FY86s1fAwUiFQTjVFYprsiV6fwNH7e955MSUBo73FP4j — real\n// bytes captured over devnet RPC on 2026-07-28 (the balance field is as\n// recorded at capture time; the live value keeps moving, which is exactly why\n// the bytes are pinned here — re-fetch them yourself with the lesson snippet).\n// \"second-vault\" is constructed byte-for-byte to the frozen VaultState layout\n// for a real derived PDA of a different owner — different owner, different\n// balance, different bump; same 49-byte layout, which is all your decoder may\n// rely on.\nconst FIXTURES: Record<string, number[]> = {\n  \"reference-vault\": [\n    228, 196, 82, 165, 98, 210, 235, 152, 78, 181, 115, 75, 97, 15, 248, 39,\n    115, 50, 94, 194, 229, 144, 50, 163, 140, 21, 194, 79, 145, 31, 240, 203,\n    132, 30, 178, 177, 89, 213, 11, 199, 0, 225, 245, 5, 0, 0, 0, 0, 255,\n  ],\n  \"second-vault\": [\n    228, 196, 82, 165, 98, 210, 235, 152, 250, 81, 168, 175, 243, 7, 13, 139,\n    135, 233, 111, 129, 165, 52, 141, 25, 59, 70, 254, 154, 56, 95, 224, 164,\n    40, 67, 110, 98, 15, 29, 43, 19, 160, 37, 38, 0, 0, 0, 0, 0, 252,\n  ],\n};\n",
+        "solution": "// ─────────────────────────────────────────────────────────────────────────────\n// TEST HARNESS — do not edit. Grading calls runCase with a fixture name and\n// hands your decodeVault the pinned bytes of that fixture (the grader has no\n// network). Provenance of each fixture is stated where it is defined below.\n// ─────────────────────────────────────────────────────────────────────────────\nfunction runCase(fixtureName: string) {\n  const bytes = FIXTURES[fixtureName];\n  if (!bytes) throw new Error(\"unknown fixture: \" + fixtureName);\n  return decodeVault(new Uint8Array(bytes));\n}\n\n/**\n * Decode a 49-byte VaultState account.\n *\n * Layout (from the lesson):\n *   offset 0,  8 bytes  — discriminator (already checked by the caller here)\n *   offset 8,  32 bytes — owner, a raw public key; display form is base58\n *   offset 40, 8 bytes  — balance, u64 LITTLE-endian\n *   offset 48, 1 byte   — bump\n */\nfunction decodeVault(data: Uint8Array): {\n  owner: string;\n  balance: bigint;\n  bump: number;\n} {\n  // Subgoal 1 (done for you) — a DataView over exactly these bytes.\n  // data.byteOffset/byteLength matter: a Uint8Array can be a window into a\n  // larger buffer, and the view must cover the same window.\n  const view = new DataView(data.buffer, data.byteOffset, data.byteLength);\n\n  // Subgoal 2 — owner: slice the 32 bytes at offsets 8..39 and base58-encode\n  // them with the provided toBase58 helper.\n  const owner = toBase58(data.slice(8, 40));\n\n  // Subgoal 3 — balance: the unsigned 64-bit little-endian integer at\n  // offset 40. Use the view; keep it a bigint.\n  const balance = view.getBigUint64(40, true);\n\n  // Subgoal 4 — bump: the single byte at offset 48.\n  const bump = view.getUint8(48);\n\n  return { owner, balance, bump };\n}\n\n// ── PROVIDED — a real base58 encoder (the display encoding of public keys) ──\nconst BASE58_ALPHABET =\n  \"123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz\";\nfunction toBase58(bytes: Uint8Array): string {\n  let n = 0n;\n  for (const b of bytes) n = n * 256n + BigInt(b);\n  let out = \"\";\n  while (n > 0n) {\n    out = BASE58_ALPHABET[Number(n % 58n)] + out;\n    n /= 58n;\n  }\n  // Leading zero bytes encode as leading '1's.\n  for (const b of bytes) {\n    if (b !== 0) break;\n    out = \"1\" + out;\n  }\n  return out;\n}\n\n// ── PINNED FIXTURES ─────────────────────────────────────────────────────────\n// \"reference-vault\" is FY86s1fAwUiFQTjVFYprsiV6fwNH7e955MSUBo73FP4j — real\n// bytes captured over devnet RPC on 2026-07-28 (the balance field is as\n// recorded at capture time; the live value keeps moving, which is exactly why\n// the bytes are pinned here — re-fetch them yourself with the lesson snippet).\n// \"second-vault\" is constructed byte-for-byte to the frozen VaultState layout\n// for a real derived PDA of a different owner — different owner, different\n// balance, different bump; same 49-byte layout, which is all your decoder may\n// rely on.\nconst FIXTURES: Record<string, number[]> = {\n  \"reference-vault\": [\n    228, 196, 82, 165, 98, 210, 235, 152, 78, 181, 115, 75, 97, 15, 248, 39,\n    115, 50, 94, 194, 229, 144, 50, 163, 140, 21, 194, 79, 145, 31, 240, 203,\n    132, 30, 178, 177, 89, 213, 11, 199, 0, 225, 245, 5, 0, 0, 0, 0, 255,\n  ],\n  \"second-vault\": [\n    228, 196, 82, 165, 98, 210, 235, 152, 250, 81, 168, 175, 243, 7, 13, 139,\n    135, 233, 111, 129, 165, 52, 141, 25, 59, 70, 254, 154, 56, 95, 224, 164,\n    40, 67, 110, 98, 15, 29, 43, 19, 160, 37, 38, 0, 0, 0, 0, 0, 252,\n  ],\n};\n",
+        "tests": [
+          {
+            "id": "t1",
+            "description": "Subgoal 2: the reference vault's owner decodes to the wallet you saw in lesson 1",
+            "input": "'reference-vault'",
+            "expectedOutput": "result.owner === '6JFH1dxqiw6Dc81CbWdx4TUT8CvAfgwZg33wQrSytZsU'",
+            "failureMessage": "Slice exactly bytes 8 through 39 (data.slice(8, 40)) and pass the slice to toBase58 — off-by-one on either end changes every character of the address."
+          },
+          {
+            "id": "t2",
+            "description": "Subgoal 3: the balance reads as a little-endian u64 bigint",
+            "input": "'reference-vault'",
+            "expectedOutput": "result.balance === 100000000n",
+            "failureMessage": "getBigUint64(40, true) — the second argument must be true for little-endian. A big-endian read of these same bytes gives a 17-digit number."
+          },
+          {
+            "id": "t3",
+            "description": "Subgoal 4: the bump is the last byte",
+            "input": "'reference-vault'",
+            "expectedOutput": "result.bump === 255"
+          },
+          {
+            "id": "t4",
+            "description": "Anti-hardcode: a different vault instance decodes to ITS owner, not the reference one",
+            "input": "'second-vault'",
+            "expectedOutput": "result.owner === 'Hr99MUHbQksoGpkSagrhqzvTgCo1BVEHjnACTSsaEJh8'",
+            "failureMessage": "Decode the bytes you were handed. If this returns the 6JFH… owner, the function is transcribing the explorer instead of reading data."
+          },
+          {
+            "id": "t5",
+            "description": "Anti-hardcode: the second vault's balance and bump come from its bytes",
+            "input": "'second-vault'",
+            "expectedOutput": "result.balance === 2500000n && result.bump === 252"
+          }
+        ],
+        "hints": [
+          "Subgoal 2: `toBase58(data.slice(8, 40))` — slice end is exclusive, so 40 means \"up to and including byte 39\".",
+          "Subgoal 3: `view.getBigUint64(40, true)` — the `true` is little-endian, and the return type is already `bigint`.",
+          "Subgoal 4: `view.getUint8(48)` (or `data[48]`) — one byte, a plain number."
+        ],
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null,
+        "tutorNotes": [
+          "Learners pass `false` (or nothing) as getBigUint64's second argument and read the balance big-endian — the result is a huge 17-plus-digit number instead of 100000000n. The fix is the endianness flag, not the offset.",
+          "They slice the owner as data.slice(8, 39) reasoning 'bytes 8 to 39', but slice's end is exclusive — 31 bytes instead of 32, and every character of the base58 output changes. The correct call is slice(8, 40).",
+          "They convert the balance with Number() to 'make it easier to compare', which passes here but is the exact 2^53 precision bug the lesson warns about — keep it bigint; the tests compare against 100000000n with the n suffix.",
+          "They hardcode the reference vault's owner/balance/bump from the explorer or from t1–t3 and fail t4/t5, which decode a second vault with different bytes. Point them at the fixture actually passed in, not the values they remember.",
+          "They build the DataView as new DataView(data.buffer) without byteOffset/byteLength. It works on these fixtures (the array owns its whole buffer) but is a latent bug worth naming if they ask why the harness passes both.",
+          "If they ask why base58 and not hex: base58 is the display convention for Solana addresses (no 0/O/I/l ambiguity); the chain stores the raw 32 bytes and never the string."
+        ]
+      },
+      {
+        "key": "predict",
+        "_type": "quiz",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": [
+          {
+            "id": "q1",
+            "prompt": "The balance bytes at offset 40 are [0, 225, 245, 5, 0, 0, 0, 0]. Predict what a big-endian read would do to the decoded value.",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "Produce a completely different, astronomically large number — the byte order is reversed, so 100,000,000 becomes about 6.3 × 10^16",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "Produce the same value — endianness only matters for signed integers",
+                "correct": false,
+                "feedback": "Endianness is byte order, and it applies to every multi-byte integer, signed or not. Reading these eight bytes big-endian treats the 0 as the most significant byte and the value explodes."
+              },
+              {
+                "id": "c",
+                "label": "Throw an error — DataView validates the byte order against the account",
+                "correct": false,
+                "feedback": "Bytes carry no self-describing order; DataView reads whatever you ask, silently. That silence is why the little-endian flag is the classic decode bug — nothing fails, the number is just wrong."
+              }
+            ],
+            "explanation": "Little-endian stores the least significant byte first. Reading LE bytes as BE reverses their significance and yields a wildly different value with no error — the bug announces itself only through a nonsense balance."
+          },
+          {
+            "id": "q2",
+            "prompt": "Your inspector later fetches an account that is 49 bytes long but its first 8 bytes are not [228, 196, 82, 165, 98, 210, 235, 152]. Predict what decodeVault on those bytes would give you.",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "Garbage that looks plausible — the decode succeeds mechanically, which is exactly why the discriminator must be checked before decoding",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "An exception — the byte reads fail on non-vault data",
+                "correct": false,
+                "feedback": "Nothing fails: any 49 bytes slice into 32 + 8 + 1 just fine, and you get a well-formed wrong answer. The discriminator check is the only thing standing between your inspector and confidently misreading a foreign account."
+              },
+              {
+                "id": "c",
+                "label": "All-zero fields — unrecognized accounts decode to defaults",
+                "correct": false,
+                "feedback": "There are no defaults in a byte read. The decoder returns whatever the foreign bytes happen to contain at those offsets — plausible-looking and wrong, which is worse than an error."
+              }
+            ],
+            "explanation": "A layout decode has no built-in validation — any 49 bytes produce an owner, a balance, and a bump. The 8-byte discriminator is the type check, and module 3's inspector refuses to decode unless it matches."
+          },
+          {
+            "id": "q3",
+            "prompt": "Lesson 1 showed the ACCOUNT's lamports; today you decoded a `balance` FIELD of 100,000,000 (recorded). Predict how the two relate on the live account.",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "The account's lamports run higher than the balance field — they also carry the rent-exemption deposit",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "They are the same number read two ways",
+                "correct": false,
+                "feedback": "Close, but no: the lamports include the ~0.0012 SOL rent-exemption deposit the vault must hold for its 49 bytes, on top of what depositors put in. The balance field is the program's own ledger of deposits alone."
+              },
+              {
+                "id": "c",
+                "label": "The balance field is denominated in SOL, the lamports in lamports",
+                "correct": false,
+                "feedback": "Both are lamports — everything on-chain is. 100,000,000 lamports is 0.1 SOL. The difference between the two numbers is what the account must hold for rent, not the unit."
+              }
+            ],
+            "explanation": "Lamports are the account's actual funds: rent deposit plus deposits. The balance field is state the program maintains — its own record of what was deposited. Keeping program state and raw lamports straight matters in module 2, when your deposit moves both."
+          },
+          {
+            "id": "q4",
+            "prompt": "Why does this course insist the balance stays a bigint instead of a JavaScript number?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "Balances are u64 and Number silently loses integer precision above 2^53 — real balances cross that line",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "bigint arithmetic is faster",
+                "correct": false,
+                "feedback": "It is usually slower. The reason is correctness: a u64 can hold values up to about 1.8 × 10^19, and Number is only exact to 2^53 ≈ 9 × 10^15. Above that, amounts silently round."
+              },
+              {
+                "id": "c",
+                "label": "The RPC rejects requests containing plain numbers",
+                "correct": false,
+                "feedback": "The RPC serializes fine either way — that is what makes the bug dangerous. Nothing errors; large amounts just quietly change in your own arithmetic. bigint keeps every lamport exact."
+              }
+            ],
+            "explanation": "A u64's range exceeds Number's exact-integer range (2^53). Convert a large balance to Number and it silently rounds — no error, wrong money. bigint is exact across the whole u64 range, so every lamport value in this course keeps the n."
+          }
+        ],
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      }
+    ]
+  },
+  {
+    "_id": "lesson-sfwd-anatomy-of-a-transaction",
+    "title": "Anatomy of a Transaction",
+    "slug": "anatomy-of-a-transaction",
+    "blocks": [
+      {
+        "key": "intro",
+        "_type": "prose",
+        "produces": null,
+        "consumes": null,
+        "src": "# Anatomy of a Transaction\n\n> Version stamp — `@solana/kit` 7.0.0 · devnet · authored 2026-07-28.\n\nYou have only read the chain. Writing to it takes a **transaction** — and before you send your first one in lesson 6, you are going to take a complete one apart and predict, to the lamport, what it costs.\n\n## A complete Kit transaction, end to end\n\nThis is the whole pipeline for a v0 transaction — a SOL transfer, built with `pipe` (Kit's left-to-right function composition):\n\n```ts\nimport {\n  createSolanaRpc,\n  generateKeyPairSigner,\n  createTransactionMessage,\n  setTransactionMessageFeePayerSigner,\n  setTransactionMessageLifetimeUsingBlockhash,\n  appendTransactionMessageInstructions,\n  signTransactionMessageWithSigners,\n  getBase64EncodedWireTransaction,\n  pipe,\n} from \"@solana/kit\";\nimport { getTransferSolInstruction } from \"@solana-program/system\";\n\nconst rpc = createSolanaRpc(\"https://api.devnet.solana.com\");\nconst signer = await generateKeyPairSigner();\nconst { value: latestBlockhash } = await rpc.getLatestBlockhash().send();\n\nconst message = pipe(\n  createTransactionMessage({ version: 0 }),\n  (m) => setTransactionMessageFeePayerSigner(signer, m),\n  (m) => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, m),\n  (m) =>\n    appendTransactionMessageInstructions(\n      [getTransferSolInstruction({ source: signer, destination, amount: 1_000_000n })],\n      m\n    )\n);\n\nconst signed = await signTransactionMessageWithSigners(message);\nconst wire = getBase64EncodedWireTransaction(signed);\nconst sim = await rpc.simulateTransaction(wire, { encoding: \"base64\" }).send();\n```\n\nRead it as four declarations, not four steps of ceremony:\n\n1. **Version** — `{ version: 0 }`. Say \"**v0 transactions**\", not \"the only version\": Kit also has v1 messages, with a different fee surface (`setTransactionMessagePriorityFeeLamports`, a total in lamports). Everything below — the `price × CU` arithmetic included — is **v0-specific**, and v0 is what this course and the current ecosystem run on.\n2. **Fee payer** — the signer whose lamports pay for this transaction.\n3. **Lifetime** — a recent blockhash. The network accepts the transaction only while that blockhash is recent (about a minute); after that it can never land, which is what makes retries safe.\n4. **Instructions** — the actual work, appended last.\n\nThen sign, encode, and — before ever sending — **simulate**. Simulation runs the transaction against current state without landing it and reports `unitsConsumed`: how much compute it actually used. We ran exactly this simulation against the reference vault's `deposit` on 2026-07-28 and recorded **6,697 compute units** (a bare SOL transfer: 150).\n\n## What it costs — the exact formula\n\nA v0 transaction's fee has two parts:\n\n```\nfee = 5000 lamports × signatures                    ← base fee (50% burned)\n    + priorityFeeMicroLamportsPerCU × requestedCUlimit ÷ 1,000,000   ← priority fee\n```\n\nThe word that costs people real money is **requested**. The priority fee is charged on the compute-unit limit your transaction *asks for* — not on what it consumes. And if you don't ask, each non-builtin instruction requests the **default 200,000 CU** (clamped at 1,400,000 per transaction). A deposit that consumes 6,697 CU but requests 200,000 pays the priority rate on all 200,000.\n\nThat is why the professional habit is **simulate, then tighten**: request `unitsConsumed` plus ~10% margin (compute varies slightly run to run; a limit set exactly at one observed value occasionally fails with an exceeded-CU error).\n\nYou request a limit (and a price) with two extra instructions from `@solana-program/compute-budget`: `getSetComputeUnitLimitInstruction({ units })` and `getSetComputeUnitPriceInstruction({ microLamports })`. Two honest footnotes on those:\n\n- Putting the compute-budget instructions **first is a convention, not a protocol rule**. The runtime finds them anywhere in the transaction. The real constraints are: at most one of each kind (a duplicate fails with `DuplicateInstruction`), and the 1,400,000-CU clamp.\n- For production estimation, Kit's current API family is `fillTransactionMessageProvisoryResourceLimits` at message construction, `estimateResourceLimitsFactory({ rpc })` to estimate, and `estimateAndSetResourceLimitsFactory(estimator)` to apply. The older compute-unit-named trio (`fillTransactionMessageProvisoryComputeUnitLimit`, `estimateComputeUnitLimitFactory`, `estimateAndSetComputeUnitLimitFactory`) is **deprecated** — you will see it in tutorials; don't build on it. Note the resource estimator returns `{ computeUnitLimit, loadedAccountsDataSizeLimit }` — an object, not a bare number.\n\n## The exercise\n\n`planBudget(sim, price)` is a **worked example with exactly one blank**. It takes a recorded simulation result and a priority-fee price and returns the full cost plan: the requested limit, the 5,000-lamport signature fee (one signer), the priority fee (rounded **up** — the network never rounds in your favor), and the total. Everything is written except one line: the requested limit, sized from `sim.unitsConsumed` plus a 10% margin, in integer bigint arithmetic (`consumed + consumed / 10n`).\n\nFill the blank, then run the quiz and predict the costs the way you now can: on paper, before anything runs.\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "budget",
+        "_type": "code",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": "typescript",
+        "buildType": "standard",
+        "deployable": false,
+        "starter": "// ─────────────────────────────────────────────────────────────────────────────\n// TEST HARNESS — do not edit. Grading calls runCase with the name of a\n// RECORDED simulation (run for real against devnet on 2026-07-28) and a\n// priority-fee price in micro-lamports per compute unit.\n// ─────────────────────────────────────────────────────────────────────────────\nfunction runCase(simName: string, microLamportsPerCu: bigint) {\n  const sim = SIMULATIONS[simName];\n  if (!sim) throw new Error(\"unknown simulation: \" + simName);\n  return planBudget(sim, microLamportsPerCu);\n}\n\n/**\n * WORKED EXAMPLE — complete except for ONE line.\n *\n * Given a simulation result and a priority-fee price, produce the full v0\n * cost plan:\n *   - computeUnitLimit — what the transaction will REQUEST: the simulated\n *     consumption plus a 10% margin (integer bigint math).\n *   - signatureFee     — 5,000 lamports per signature; this plan has one.\n *   - priorityFee      — price × requested limit ÷ 1,000,000, rounded UP.\n *   - totalFeeLamports — the sum.\n */\nfunction planBudget(\n  sim: { unitsConsumed: bigint },\n  microLamportsPerCu: bigint\n): {\n  computeUnitLimit: bigint;\n  signatureFee: bigint;\n  priorityFee: bigint;\n  totalFeeLamports: bigint;\n} {\n  // ── THE BLANK ──────────────────────────────────────────────────────────\n  // Size the requested limit from what simulation measured, plus a 10%\n  // margin: consumed + consumed / 10n. (Why request MORE than consumed?\n  // Compute varies slightly run to run. Why not just leave the default?\n  // Because the default is 200,000 and you pay the priority fee on it.)\n  const computeUnitLimit = 0n; // ← replace with the sized limit\n\n  // One signer pays 5,000 lamports, fixed. (Half is burned.)\n  const signatureFee = 5_000n;\n\n  // The priority fee is charged on the REQUESTED limit, not on consumption.\n  // Micro-lamports → lamports is a ÷ 1,000,000, rounded up: the network\n  // never rounds in your favor.\n  const priorityFee =\n    (computeUnitLimit * microLamportsPerCu + 999_999n) / 1_000_000n;\n\n  const totalFeeLamports = signatureFee + priorityFee;\n  return { computeUnitLimit, signatureFee, priorityFee, totalFeeLamports };\n}\n\n// ── RECORDED SIMULATIONS — real devnet runs, 2026-07-28 ─────────────────────\n// \"vault-deposit\" is the reference vault's deposit instruction — the exact\n// transaction you assemble and send in lesson 6. \"sol-transfer\" is a bare\n// System Program transfer, for scale.\nconst SIMULATIONS: Record<string, { unitsConsumed: bigint }> = {\n  \"vault-deposit\": { unitsConsumed: 6_697n },\n  \"sol-transfer\": { unitsConsumed: 150n },\n};\n",
+        "solution": "// ─────────────────────────────────────────────────────────────────────────────\n// TEST HARNESS — do not edit. Grading calls runCase with the name of a\n// RECORDED simulation (run for real against devnet on 2026-07-28) and a\n// priority-fee price in micro-lamports per compute unit.\n// ─────────────────────────────────────────────────────────────────────────────\nfunction runCase(simName: string, microLamportsPerCu: bigint) {\n  const sim = SIMULATIONS[simName];\n  if (!sim) throw new Error(\"unknown simulation: \" + simName);\n  return planBudget(sim, microLamportsPerCu);\n}\n\n/**\n * WORKED EXAMPLE — complete except for ONE line.\n *\n * Given a simulation result and a priority-fee price, produce the full v0\n * cost plan:\n *   - computeUnitLimit — what the transaction will REQUEST: the simulated\n *     consumption plus a 10% margin (integer bigint math).\n *   - signatureFee     — 5,000 lamports per signature; this plan has one.\n *   - priorityFee      — price × requested limit ÷ 1,000,000, rounded UP.\n *   - totalFeeLamports — the sum.\n */\nfunction planBudget(\n  sim: { unitsConsumed: bigint },\n  microLamportsPerCu: bigint\n): {\n  computeUnitLimit: bigint;\n  signatureFee: bigint;\n  priorityFee: bigint;\n  totalFeeLamports: bigint;\n} {\n  // ── THE BLANK ──────────────────────────────────────────────────────────\n  // Size the requested limit from what simulation measured, plus a 10%\n  // margin: consumed + consumed / 10n. (Why request MORE than consumed?\n  // Compute varies slightly run to run. Why not just leave the default?\n  // Because the default is 200,000 and you pay the priority fee on it.)\n  const computeUnitLimit = sim.unitsConsumed + sim.unitsConsumed / 10n;\n\n  // One signer pays 5,000 lamports, fixed. (Half is burned.)\n  const signatureFee = 5_000n;\n\n  // The priority fee is charged on the REQUESTED limit, not on consumption.\n  // Micro-lamports → lamports is a ÷ 1,000,000, rounded up: the network\n  // never rounds in your favor.\n  const priorityFee =\n    (computeUnitLimit * microLamportsPerCu + 999_999n) / 1_000_000n;\n\n  const totalFeeLamports = signatureFee + priorityFee;\n  return { computeUnitLimit, signatureFee, priorityFee, totalFeeLamports };\n}\n\n// ── RECORDED SIMULATIONS — real devnet runs, 2026-07-28 ─────────────────────\n// \"vault-deposit\" is the reference vault's deposit instruction — the exact\n// transaction you assemble and send in lesson 6. \"sol-transfer\" is a bare\n// System Program transfer, for scale.\nconst SIMULATIONS: Record<string, { unitsConsumed: bigint }> = {\n  \"vault-deposit\": { unitsConsumed: 6_697n },\n  \"sol-transfer\": { unitsConsumed: 150n },\n};\n",
+        "tests": [
+          {
+            "id": "t1",
+            "description": "The deposit's requested limit is its simulated 6,697 CU plus a 10% margin",
+            "input": "'vault-deposit', 10000n",
+            "expectedOutput": "result.computeUnitLimit === 7366n",
+            "failureMessage": "Integer bigint math: 6697n + 6697n / 10n = 6697 + 669 = 7366. No floats, no Math.round — bigint division already floors."
+          },
+          {
+            "id": "t2",
+            "description": "At 10,000 micro-lamports/CU the deposit's priority fee rounds up to 74 lamports, total 5,074",
+            "input": "'vault-deposit', 10000n",
+            "expectedOutput": "result.priorityFee === 74n && result.totalFeeLamports === 5074n"
+          },
+          {
+            "id": "t3",
+            "description": "A bare transfer sizes to 165 CU and its priority fee still rounds UP (1.65 → 2 lamports)",
+            "input": "'sol-transfer', 10000n",
+            "expectedOutput": "result.computeUnitLimit === 165n && result.priorityFee === 2n && result.totalFeeLamports === 5002n",
+            "failureMessage": "150 + 150/10 = 165 requested CU; 165 × 10,000 = 1,650,000 micro-lamports = 1.65 lamports, and the network rounds against you: 2."
+          },
+          {
+            "id": "t4",
+            "description": "With a zero priority price only the signature fee remains",
+            "input": "'vault-deposit', 0n",
+            "expectedOutput": "result.priorityFee === 0n && result.totalFeeLamports === 5000n && result.signatureFee === 5000n"
+          }
+        ],
+        "hints": [
+          "One line: `const computeUnitLimit = sim.unitsConsumed + sim.unitsConsumed / 10n;` — the simulated consumption plus a tenth of it, all bigint.",
+          "If t3 fails on the priority fee, check you did NOT change the provided rounding line — 1.65 lamports must charge as 2, never 1.",
+          "Keep every value bigint. Mixing in a Number (like `* 1.1`) throws a TypeError in bigint arithmetic — which is the guardrail working."
+        ],
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null,
+        "tutorNotes": [
+          "Learners write the margin as `sim.unitsConsumed * 1.1` and hit 'Cannot mix BigInt and other types'. The bigint form is consumed + consumed / 10n; the error is the precision guardrail from lesson 2, not a grader quirk.",
+          "They fill the blank with 200_000n 'because that is the default'. The default is the disease, not the cure — the whole plan exists to request LESS than 200,000. t1 expects 7366n.",
+          "They fill the blank with sim.unitsConsumed exactly, no margin, giving 6697n. Explain the margin's job: consumption varies slightly run to run, and a limit set at one observed value intermittently fails with exceeded-CU.",
+          "They 'fix' the provided priorityFee line to round down (plain division). t3 exists for this: 1.65 lamports charges as 2. The network rounds against the payer; the +999_999n before dividing is the ceiling.",
+          "They ask why signatureFee is fixed while priorityFee scales: the base fee is 5,000 lamports per signature regardless of work; the priority fee is the bid for compute, priced on the REQUESTED limit. Two different levers.",
+          "If they ask whether the compute-budget instructions must come first: no — that placement is convention. The real rules are one instruction per variant (DuplicateInstruction otherwise) and the 1,400,000-CU clamp."
+        ]
+      },
+      {
+        "key": "predict",
+        "_type": "quiz",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": [
+          {
+            "id": "q1",
+            "prompt": "You send the vault deposit with NO compute-budget instructions at a network moment when the effective price is 10,000 micro-lamports/CU. Predict the priority fee.",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "2,000 lamports — the deposit requests the 200,000-CU default, and the fee is charged on that request, not on the 6,697 CU it consumes",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "About 67 lamports — 6,697 consumed × 10,000 ÷ 1,000,000",
+                "correct": false,
+                "feedback": "That would be fair, and it is not what happens. The fee is charged on the REQUESTED limit, and with nothing requested, each non-builtin instruction defaults to 200,000 CU. You pay 200,000 × 10,000 ÷ 1e6 = 2,000 lamports — nearly 30× the consumption-based number."
+              },
+              {
+                "id": "c",
+                "label": "Zero — priority fees only apply if you set a compute-unit price",
+                "correct": false,
+                "feedback": "In this scenario a price applies; the question is what it multiplies. Answer: the requested limit, which defaulted to 200,000 CU. That gap between requested and consumed is the overpay this lesson teaches you to close."
+              }
+            ],
+            "explanation": "Priority fee = price × requested limit ÷ 1e6, and an unset limit requests the 200,000-CU default. 200,000 × 10,000 ÷ 1e6 = 2,000 lamports, versus 74 with a simulate-and-tighten limit of 7,366 — same transaction, ~27× the priority fee."
+          },
+          {
+            "id": "q2",
+            "prompt": "A transaction carries TWO SetComputeUnitLimit instructions — one at the start, one at the end. Predict the outcome.",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "It fails with DuplicateInstruction — at most one of each compute-budget variant is allowed, wherever they sit",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "The first one wins, because compute-budget instructions must come first",
+                "correct": false,
+                "feedback": "Placement is a convention, not a rule — the runtime finds compute-budget instructions anywhere. What it will not accept is two of the same kind: that is DuplicateInstruction, a hard failure."
+              },
+              {
+                "id": "c",
+                "label": "The larger limit wins, clamped to 1,400,000",
+                "correct": false,
+                "feedback": "There is no merging of duplicates — the transaction fails outright with DuplicateInstruction. The 1,400,000 clamp applies to a single valid limit request, not to resolving two."
+              }
+            ],
+            "explanation": "The real constraints on compute-budget instructions: one per variant (duplicates fail with DuplicateInstruction) and the 1,400,000-CU clamp. \"Put them first\" is style — worth following, but not what the runtime checks."
+          },
+          {
+            "id": "q3",
+            "prompt": "Your signed transaction sits in a queue for two minutes before sending. Predict what happens when it finally goes out.",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "The network refuses it — its blockhash lifetime (about a minute) has expired, so it can never land, and a retry needs a fresh blockhash and a re-sign",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "It lands, but pays a staleness surcharge",
+                "correct": false,
+                "feedback": "There is no surcharge tier — lifetime is binary. Past its blockhash window the transaction is simply invalid, which is a feature: you can safely rebuild and resend knowing the old one cannot also land."
+              },
+              {
+                "id": "c",
+                "label": "It waits at the RPC until the blockhash becomes recent again",
+                "correct": false,
+                "feedback": "Blockhashes never become recent again — the chain only moves forward. Expiry is permanent for that transaction, and the remedy is a new message with a fresh blockhash, re-signed."
+              }
+            ],
+            "explanation": "The blockhash lifetime bounds how long a signed transaction can land (~a minute). Expiry is what makes retries safe: an expired transaction can never sneak in later and double-spend your retry. Lesson 6 leans on exactly this when a wallet send goes stale."
+          },
+          {
+            "id": "q4",
+            "prompt": "The plan's signature fee is 5,000 lamports for one signer. Add a second required signer to the same transaction and predict the base fee.",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "10,000 lamports — the base fee is 5,000 per signature, and half of every base fee is burned",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "Still 5,000 — the fee payer covers one flat fee per transaction",
+                "correct": false,
+                "feedback": "The base fee scales with signature count: 5,000 lamports each. One fee payer still pays it all, but two signatures cost 10,000 — which is why signature count is part of predicting cost."
+              },
+              {
+                "id": "c",
+                "label": "5,000 plus a priority fee for the extra signer",
+                "correct": false,
+                "feedback": "Signers do not add priority fee — that is priced purely on the requested compute limit. The extra signature adds another 5,000-lamport base fee, nothing more."
+              }
+            ],
+            "explanation": "Base fee = 5,000 lamports × signatures (half burned); priority fee = price × requested CU limit ÷ 1e6. Two independent terms — your lesson-6 deposit has one signer, so its floor is exactly 5,000."
+          }
+        ],
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      }
+    ]
+  },
+  {
+    "_id": "lesson-sfwd-connect-fund-and-send",
+    "title": "Connect, Fund, and Send It",
+    "slug": "connect-fund-and-send",
+    "blocks": [
+      {
+        "key": "intro",
+        "_type": "prose",
+        "produces": null,
+        "consumes": null,
+        "src": "# Connect, Fund, and Send It\n\n> Version stamp — `@solana/kit` 7.0.0 · devnet · authored 2026-07-28.\n\nEverything so far was reading and rehearsal. Today: a real wallet, real devnet SOL, and a real deposit into the vault you have been decoding since lesson 1 — confirmed on-chain, with a signature you can hand anyone as proof.\n\n## Connecting: Wallet Standard, not wallet-adapter\n\nModern wallets (Phantom, Solflare, Backpack, …) implement **Wallet Standard** — a browser protocol in which the wallet announces itself to the page. Your app does not install a package per wallet; it *discovers* whatever the visitor already has:\n\n```ts\nimport { createClient } from \"@solana/kit\";\nimport { solanaDevnetRpc } from \"@solana/kit-plugin-rpc\";\nimport { walletSigner } from \"@solana/kit-plugin-wallet\";\n\nconst client = createClient()\n  // Wallet Standard discovery — no per-wallet adapters. The wallet signer is\n  // the client's payer, so this plugin comes FIRST; and the chain is a\n  // required part of its config — a connected account can refuse a chain it\n  // was not asked to sign for.\n  .use(walletSigner({ chain: \"solana:devnet\" }))\n  .use(solanaDevnetRpc());\n```\n\nIf a tutorial hands you `ConnectionProvider`, `WalletProvider`, or `PhantomWalletAdapter`, you are reading the legacy stack from lesson 5 — read it, don't copy it.\n\nWhen the wallet connects, your app gets an **account and a signer** — the wallet holds the private key and never gives it up. Your code's job is to *assemble* the transaction; the wallet's job is to *sign* it. That division is the whole security model, and it is why the exercise below builds everything **except** the signature.\n\n## Funding\n\nThe button below fetches devnet SOL to your connected wallet. Devnet SOL is free and worthless by design — it exists so you can do exactly this. The faucet rations amounts and can run dry at busy times; if it declines, wait a little and retry. What lands in your wallet funds today's deposit *and* stays with you: in Course 3, this same wallet pays your own program's deploy.\n\n## The deposit, precisely\n\nYou already know every ingredient:\n\n- **Which instruction**: the vault program's `deposit`, from lesson 1's IDL.\n- **Which accounts, in which order**: the IDL fixes it — **the vault PDA first**, then your wallet (writable, signer), then the System Program. The order is part of the program's interface: the program reads accounts by position, so a swapped order is not style, it is a different (failing) call.\n- **Which vault**: *your* wallet's vault, derived exactly as in lesson 3 — seeds `[\"vault\", yourAddress]`. First deposit? The program creates it — which is why the System Program is in the account list.\n- **What data**: 8 bytes of instruction discriminator — `[242, 35, 198, 137, 82, 225, 242, 182]`, the `deposit` tag from the IDL — followed by the amount as a **u64 little-endian**, the exact write-side of the read you did in lesson 2.\n- **What it costs**: you predicted it in lesson 4 — 5,000 lamports for your one signature, plus any priority fee on the *requested* limit.\n\nAmounts are **integer lamports as bigint**, always: `0.001 SOL` is `1_000_000n` lamports. No floats anywhere near money.\n\nThe graded exercise assembles this plan as a pure function in four labeled subgoals — the same shape Kit's `pipe` built in lesson 4, with the instruction now built byte by byte. The grader checks the account order the way the program would: vault first, or it fails.\n\nAfter it passes, read **Send, Watch, and Read the Failure** below, then send the real thing from the embedded runner: connect, fund, deposit. When the confirmation lands, open your transaction in the explorer (`?cluster=devnet`!) and look at the vault's balance move.\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "fund",
+        "_type": "wallet-funding",
+        "produces": "funded-wallet",
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": 2,
+        "network": "devnet",
+        "idl": null
+      },
+      {
+        "key": "assemble",
+        "_type": "code",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": "typescript",
+        "buildType": "standard",
+        "deployable": false,
+        "starter": "/**\n * Assemble the deposit plan — four labeled subgoals.\n *\n * A pure function: the wallet's address, a recent blockhash, and an amount\n * in, a complete unsigned transaction plan out. The wallet signs it; your\n * code never touches a private key. Helpers and recorded constants are\n * provided BELOW the function — read them before you start.\n */\nfunction buildDepositPlan(\n  wallet: string,\n  blockhash: string,\n  lamports: bigint\n): {\n  feePayer: string;\n  lifetimeBlockhash: string;\n  instructions: {\n    programAddress: string;\n    accounts: { address: string; role: string }[];\n    data: number[];\n  }[];\n} {\n  // Subgoal 1 (done for you) — the connected wallet pays the fee.\n  const feePayer = wallet;\n\n  // Subgoal 2 — the transaction's lifetime is the given recent blockhash.\n  const lifetimeBlockhash = \"\"; // ← replace\n\n  // Subgoal 3 — the account list, in the program's IDL order:\n  //   1. the wallet's vault PDA (use vaultFor(wallet)), role \"writable\"\n  //   2. the wallet itself,                      role \"writable-signer\"\n  //   3. SYSTEM_PROGRAM,                         role \"readonly\"\n  // The program reads accounts BY POSITION — the vault must be first.\n  const accounts: { address: string; role: string }[] = []; // ← replace\n\n  // Subgoal 4 — the instruction data: the 8-byte DEPOSIT_DISCRIMINATOR,\n  // then the amount as u64 little-endian (u64le(lamports) gives the 8\n  // bytes — the write-side of your lesson-2 read).\n  const data: number[] = []; // ← replace\n\n  return {\n    feePayer,\n    lifetimeBlockhash,\n    instructions: [{ programAddress: VAULT_PROGRAM, accounts, data }],\n  };\n}\n\n// ── PROVIDED ────────────────────────────────────────────────────────────────\nconst VAULT_PROGRAM = \"D7ZFoWvEG5NBnkJy6iC98rhwj2qhgq8xhSD42cdTRAQd\";\nconst SYSTEM_PROGRAM = \"11111111111111111111111111111111\";\n// The `deposit` instruction's 8-byte tag, from the IDL you read in lesson 1.\nconst DEPOSIT_DISCRIMINATOR = [242, 35, 198, 137, 82, 225, 242, 182];\n\n/** The amount as 8 little-endian bytes — lesson 2's DataView, writing. */\nfunction u64le(value: bigint): number[] {\n  const bytes = new Uint8Array(8);\n  new DataView(bytes.buffer).setBigUint64(0, value, true);\n  return Array.from(bytes);\n}\n\n/**\n * The wallet's vault PDA — recorded real derivations (lesson 3's math;\n * captured 2026-07-28). In production this is\n * `await getProgramDerivedAddress({ programAddress, seeds })`.\n */\nfunction vaultFor(wallet: string): string {\n  const RECORDED: Record<string, string> = {\n    \"6JFH1dxqiw6Dc81CbWdx4TUT8CvAfgwZg33wQrSytZsU\":\n      \"FY86s1fAwUiFQTjVFYprsiV6fwNH7e955MSUBo73FP4j\",\n    Hr99MUHbQksoGpkSagrhqzvTgCo1BVEHjnACTSsaEJh8:\n      \"EMTqK9Cfac1X7c86GUYG5wwGkqR9HpeYkqUDvjLmhgKi\",\n  };\n  const vault = RECORDED[wallet];\n  if (!vault) throw new Error(\"no recorded vault derivation for \" + wallet);\n  return vault;\n}\n",
+        "solution": "/**\n * Assemble the deposit plan — four labeled subgoals.\n *\n * A pure function: the wallet's address, a recent blockhash, and an amount\n * in, a complete unsigned transaction plan out. The wallet signs it; your\n * code never touches a private key. Helpers and recorded constants are\n * provided BELOW the function — read them before you start.\n */\nfunction buildDepositPlan(\n  wallet: string,\n  blockhash: string,\n  lamports: bigint\n): {\n  feePayer: string;\n  lifetimeBlockhash: string;\n  instructions: {\n    programAddress: string;\n    accounts: { address: string; role: string }[];\n    data: number[];\n  }[];\n} {\n  // Subgoal 1 (done for you) — the connected wallet pays the fee.\n  const feePayer = wallet;\n\n  // Subgoal 2 — the transaction's lifetime is the given recent blockhash.\n  const lifetimeBlockhash = blockhash;\n\n  // Subgoal 3 — the account list, in the program's IDL order:\n  //   1. the wallet's vault PDA (use vaultFor(wallet)), role \"writable\"\n  //   2. the wallet itself,                      role \"writable-signer\"\n  //   3. SYSTEM_PROGRAM,                         role \"readonly\"\n  // The program reads accounts BY POSITION — the vault must be first.\n  const accounts: { address: string; role: string }[] = [\n    { address: vaultFor(wallet), role: \"writable\" },\n    { address: wallet, role: \"writable-signer\" },\n    { address: SYSTEM_PROGRAM, role: \"readonly\" },\n  ];\n\n  // Subgoal 4 — the instruction data: the 8-byte DEPOSIT_DISCRIMINATOR,\n  // then the amount as u64 little-endian (u64le(lamports) gives the 8\n  // bytes — the write-side of your lesson-2 read).\n  const data: number[] = [...DEPOSIT_DISCRIMINATOR, ...u64le(lamports)];\n\n  return {\n    feePayer,\n    lifetimeBlockhash,\n    instructions: [{ programAddress: VAULT_PROGRAM, accounts, data }],\n  };\n}\n\n// ── PROVIDED ────────────────────────────────────────────────────────────────\nconst VAULT_PROGRAM = \"D7ZFoWvEG5NBnkJy6iC98rhwj2qhgq8xhSD42cdTRAQd\";\nconst SYSTEM_PROGRAM = \"11111111111111111111111111111111\";\n// The `deposit` instruction's 8-byte tag, from the IDL you read in lesson 1.\nconst DEPOSIT_DISCRIMINATOR = [242, 35, 198, 137, 82, 225, 242, 182];\n\n/** The amount as 8 little-endian bytes — lesson 2's DataView, writing. */\nfunction u64le(value: bigint): number[] {\n  const bytes = new Uint8Array(8);\n  new DataView(bytes.buffer).setBigUint64(0, value, true);\n  return Array.from(bytes);\n}\n\n/**\n * The wallet's vault PDA — recorded real derivations (lesson 3's math;\n * captured 2026-07-28). In production this is\n * `await getProgramDerivedAddress({ programAddress, seeds })`.\n */\nfunction vaultFor(wallet: string): string {\n  const RECORDED: Record<string, string> = {\n    \"6JFH1dxqiw6Dc81CbWdx4TUT8CvAfgwZg33wQrSytZsU\":\n      \"FY86s1fAwUiFQTjVFYprsiV6fwNH7e955MSUBo73FP4j\",\n    Hr99MUHbQksoGpkSagrhqzvTgCo1BVEHjnACTSsaEJh8:\n      \"EMTqK9Cfac1X7c86GUYG5wwGkqR9HpeYkqUDvjLmhgKi\",\n  };\n  const vault = RECORDED[wallet];\n  if (!vault) throw new Error(\"no recorded vault derivation for \" + wallet);\n  return vault;\n}\n",
+        "tests": [
+          {
+            "id": "t1",
+            "description": "Subgoal 1+2: the wallet pays, and the plan carries the given blockhash as its lifetime",
+            "input": "'6JFH1dxqiw6Dc81CbWdx4TUT8CvAfgwZg33wQrSytZsU', 'GJRYBLa6XmfnUicWpkccesM9SsDDbKAFYPDVzWqXAX2h', 1000000n",
+            "expectedOutput": "result.feePayer === '6JFH1dxqiw6Dc81CbWdx4TUT8CvAfgwZg33wQrSytZsU' && result.lifetimeBlockhash === 'GJRYBLa6XmfnUicWpkccesM9SsDDbKAFYPDVzWqXAX2h'",
+            "failureMessage": "A message without a recent-blockhash lifetime is rejected the moment it is sent — pass the blockhash argument through."
+          },
+          {
+            "id": "t2",
+            "description": "Subgoal 3: the FIRST account is the wallet's vault PDA, writable — IDL order is the program's interface",
+            "input": "'6JFH1dxqiw6Dc81CbWdx4TUT8CvAfgwZg33wQrSytZsU', 'GJRYBLa6XmfnUicWpkccesM9SsDDbKAFYPDVzWqXAX2h', 1000000n",
+            "expectedOutput": "result.instructions[0].accounts[0].address === 'FY86s1fAwUiFQTjVFYprsiV6fwNH7e955MSUBo73FP4j' && result.instructions[0].accounts[0].role === 'writable'",
+            "failureMessage": "The IDL lists [vault, user, system_program] — vault FIRST. The program reads accounts by position; user-first is a different, failing call."
+          },
+          {
+            "id": "t3",
+            "description": "Subgoal 3: then the signing wallet, then the System Program — exactly three accounts",
+            "input": "'6JFH1dxqiw6Dc81CbWdx4TUT8CvAfgwZg33wQrSytZsU', 'GJRYBLa6XmfnUicWpkccesM9SsDDbKAFYPDVzWqXAX2h', 1000000n",
+            "expectedOutput": "result.instructions[0].accounts.length === 3 && result.instructions[0].accounts[1].address === '6JFH1dxqiw6Dc81CbWdx4TUT8CvAfgwZg33wQrSytZsU' && result.instructions[0].accounts[1].role === 'writable-signer' && result.instructions[0].accounts[2].address === '11111111111111111111111111111111' && result.instructions[0].accounts[2].role === 'readonly'"
+          },
+          {
+            "id": "t4",
+            "description": "Subgoal 4: data = 8-byte deposit discriminator, then the amount as u64 LE",
+            "input": "'6JFH1dxqiw6Dc81CbWdx4TUT8CvAfgwZg33wQrSytZsU', 'GJRYBLa6XmfnUicWpkccesM9SsDDbKAFYPDVzWqXAX2h', 1000000n",
+            "expectedOutput": "result.instructions[0].data.join(',') === '242,35,198,137,82,225,242,182,64,66,15,0,0,0,0,0'",
+            "failureMessage": "Discriminator first, then u64le(lamports). 1,000,000 = 0x0F4240, little-endian bytes [64, 66, 15, 0, 0, 0, 0, 0]."
+          },
+          {
+            "id": "t5",
+            "description": "Anti-hardcode: a different wallet deposits into ITS vault, with ITS amount encoded",
+            "input": "'Hr99MUHbQksoGpkSagrhqzvTgCo1BVEHjnACTSsaEJh8', 'JCB6HzS1PGGBAxqCJKM48VVfaAdrqvPo9WBEDFEZbT2a', 2500000n",
+            "expectedOutput": "result.instructions[0].accounts[0].address === 'EMTqK9Cfac1X7c86GUYG5wwGkqR9HpeYkqUDvjLmhgKi' && result.instructions[0].data.join(',') === '242,35,198,137,82,225,242,182,160,37,38,0,0,0,0,0' && result.feePayer === 'Hr99MUHbQksoGpkSagrhqzvTgCo1BVEHjnACTSsaEJh8'",
+            "failureMessage": "Both the vault (via vaultFor) and the encoded amount must flow from the arguments — nothing about the reference wallet may be hardcoded."
+          }
+        ],
+        "hints": [
+          "Subgoal 2: `const lifetimeBlockhash = blockhash;` — pass the argument through; a message with no lifetime is rejected on send.",
+          "Subgoal 3: three entries, in IDL order — `vaultFor(wallet)` as \"writable\", the wallet as \"writable-signer\", `SYSTEM_PROGRAM` as \"readonly\". Vault FIRST.",
+          "Subgoal 4: `[...DEPOSIT_DISCRIMINATOR, ...u64le(lamports)]` — tag first, then the amount's 8 little-endian bytes."
+        ],
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null,
+        "tutorNotes": [
+          "The classic order bug: learners list the user account first 'because the user is doing the deposit'. The program reads accounts by POSITION — the IDL fixes [vault, user, system_program], vault first, and t2/t3 grade exactly that. Swapped order on-chain is not a warning; it is a wrong call.",
+          "They skip subgoal 2 and return the empty-string lifetime. Explain via lesson 4: the blockhash is the transaction's lifetime; without it the network rejects the message immediately — the field is not decorative.",
+          "They put the amount bytes BEFORE the discriminator, or encode the amount big-endian. The wire format is tag-then-args, and the u64 is little-endian — t4's exact byte string [242,…,182,64,66,15,0,0,0,0,0] is the check; u64le() already does the LE write for them.",
+          "They hardcode the FY86… vault or the reference wallet and fail t5, which plans a deposit for a different wallet. Both the vault (via vaultFor) and the encoded amount must flow from the arguments.",
+          "They ask why the plan has no signature anywhere. By design: the wallet holds the key and signs; the app only assembles. If their mental model has the app touching a private key, correct it now — that division is the security model of every dApp they will ever build.",
+          "They ask why the System Program is in a deposit into OUR program's vault. First deposit may need the vault account created, and account creation is the System Program's job — the program CPIs into it. Course 3 makes them write that call."
+        ]
+      },
+      {
+        "key": "send",
+        "_type": "prose",
+        "produces": null,
+        "consumes": null,
+        "src": "# Send, Watch, and Read the Failure\n\nAssembling was the pure part. Sending is where the network answers back — and the answer is not a boolean.\n\n## Confirmation is a ladder, not a light switch\n\nIn Kit you send-and-confirm with a factory bound once to your RPC and its websocket side:\n\n```ts\nimport {\n  createSolanaRpc,\n  createSolanaRpcSubscriptions,\n  sendAndConfirmTransactionFactory,\n  getSignatureFromTransaction,\n} from \"@solana/kit\";\n\nconst rpc = createSolanaRpc(\"https://api.devnet.solana.com\");\nconst rpcSubscriptions = createSolanaRpcSubscriptions(\n  \"wss://api.devnet.solana.com\"\n);\nconst sendAndConfirm = sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions });\n\nawait sendAndConfirm(signedTransaction, { commitment: \"confirmed\" });\nconst signature = getSignatureFromTransaction(signedTransaction);\n```\n\nWhat you are waiting for is a **commitment level**, and each rung means something different:\n\n- **`processed`** — one validator has executed it. Fast, and still reversible.\n- **`confirmed`** — a supermajority of the cluster has voted on its block. The practical default: what \"it went through\" honestly means for a UI.\n- **`finalized`** — locked in beyond rollback. What you wait for before acting on money you cannot claw back.\n\nAn honest UI shows the rung it has actually reached — \"sending\" is not \"confirmed\", and \"confirmed\" is not a guess made at the moment you hit send.\n\n## The failure taxonomy\n\nFive ways this deposit can not-happen, and they are not the same event:\n\n1. **You reject in the wallet.** Nothing reached the network. Not a failed transaction — the honest UI state is back-to-resting, not an error banner.\n2. **The faucet declines.** Also pre-network; your wallet simply is not funded yet. Retry after a wait.\n3. **The blockhash expires.** The transaction aged out (~a minute) before landing — lesson 4's lifetime rule. It can never land now, which is precisely what makes the fix safe: rebuild with a fresh blockhash, re-sign, resend.\n4. **Simulation rejects it pre-flight.** The RPC ran it before broadcast and it failed — insufficient lamports, a program error. Nothing was sent; read the message, fix the cause.\n5. **The program says no, on-chain.** The transaction landed and *failed*, fee paid. This program's refusals are named in the IDL you read in lesson 1 — depositing `0` fails with error `6002 ZeroAmount`. A landed failure has a signature and logs; that is where you look.\n\nThe through-line: **\"failed\" is only honest for 3, 4 and 5.** Rejecting a wallet prompt did not fail — nothing happened, and an app that shows a red X for it is lying to its user.\n\n## Your receipt\n\nOnce confirmed, your signature is a permanent public record. `https://explorer.solana.com/tx/<signature>?cluster=devnet` shows what you paid (compare it to your lesson-4 prediction — for real this time), the accounts your instruction touched — vault first — and the vault's balance change. That link is the first artifact of this course anyone else can verify. Keep it; the reflection below asks for it, and your profile keeps it after that.\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "predict",
+        "_type": "quiz",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": [
+          {
+            "id": "q1",
+            "prompt": "You click Deposit, the wallet pops up, and you hit Reject. Predict the honest UI state and the on-chain record.",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "Back to resting; no on-chain record at all — nothing was signed, so nothing reached the network",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "A failed transaction with your rejection as the error",
+                "correct": false,
+                "feedback": "A failed transaction is one that went out and did not succeed. A rejection never left the wallet — there is no signature, no fee, no record. Showing a red failure for it is the dishonest UI this lesson warns about."
+              },
+              {
+                "id": "c",
+                "label": "A pending transaction that expires after a minute",
+                "correct": false,
+                "feedback": "Pending describes something in flight. Nothing is in flight — the transaction was never signed. The blockhash-expiry clock matters only for transactions that actually went out."
+              }
+            ],
+            "explanation": "The failure taxonomy's first rule: rejection is pre-network. Failed is only honest for things that were sent — expired, preflight-rejected, or landed-and-failed. A rejection is none of those."
+          },
+          {
+            "id": "q2",
+            "prompt": "Your deposit lands, and the explorer shows the transaction succeeded with a fee of 5,000 lamports. From lesson 4, what does that fee tell you about the transaction you sent?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "One signature and no priority price — the base fee alone, exactly the floor your lesson-4 plan predicted",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "The network waived the priority fee because the deposit was small",
+                "correct": false,
+                "feedback": "Fees never scale with the amount moved. 5,000 = 5,000 × 1 signature + 0 priority — you simply sent without a compute-unit price, so only the base fee applied."
+              },
+              {
+                "id": "c",
+                "label": "A discounted devnet rate",
+                "correct": false,
+                "feedback": "Devnet and mainnet share the fee rules; only the SOL is free. 5,000 lamports is the per-signature base fee — the lesson-4 formula with one signer and price zero."
+              }
+            ],
+            "explanation": "fee = 5,000 × signatures + price × requested CU ÷ 1e6. Reading 5,000 off the explorer tells you: one signer, zero priority price. The reflection below asks you to make exactly this comparison on your own transaction."
+          },
+          {
+            "id": "q3",
+            "prompt": "Curious, you send a second deposit with amount 0. Predict what the explorer shows.",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "A landed, FAILED transaction — custom program error 6002 (ZeroAmount), with the fee paid",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "Nothing — the wallet blocks zero-amount transactions",
+                "correct": false,
+                "feedback": "The wallet checks signatures, not business rules. The transaction is perfectly well-formed; it is the PROGRAM that refuses it, on-chain, with the error its IDL names: 6002 ZeroAmount. Landed failures pay their fee."
+              },
+              {
+                "id": "c",
+                "label": "A success that moved zero lamports",
+                "correct": false,
+                "feedback": "This program explicitly rejects zero — error 6002 in the IDL you read in lesson 1. It lands, fails, and charges the base fee: taxonomy case 5, the only kind of failure with a signature and logs."
+              }
+            ],
+            "explanation": "Case 5 of the taxonomy: an on-chain program refusal. The transaction has a signature, logs, and a named error (6002 ZeroAmount) — and the fee is paid, because validators did the work of executing it to its refusal."
+          }
+        ],
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "milestone",
+        "_type": "openEnded",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": null,
+        "prompt": "Paste your deposit's explorer link (https://explorer.solana.com/tx/<signature>?cluster=devnet), then answer two things in a few sentences. One: what did the wallet do that your buildDepositPlan could not — why does that split exist? Two: open the transaction's fee in the explorer and compare it to the cost you predicted in lesson 4 — did the numbers match, and if not, which term of the formula explains the difference?",
+        "maxWords": 150,
+        "amount": null,
+        "network": null,
+        "idl": null
+      }
+    ]
+  },
+  {
+    "_id": "lesson-sfwd-derive-the-vault-pda",
+    "title": "Derive the Vault PDA",
+    "slug": "derive-the-vault-pda",
+    "blocks": [
+      {
+        "key": "intro",
+        "_type": "prose",
+        "produces": null,
+        "consumes": null,
+        "src": "# Derive the Vault PDA\n\n> Version stamp — `@solana/kit` 7.0.0 · devnet · authored 2026-07-28.\n\nThe vault's address — `FY86s1fAwUiFQTjVFYprsiV6fwNH7e955MSUBo73FP4j` — was never generated from a private key. Nobody holds a secret for it, and nobody ever will. It is a **Program Derived Address**: computed, deterministically, from ingredients you already have.\n\n## The recipe\n\nA PDA is derived from three inputs:\n\n1. **Seeds** — an ordered list of byte strings. For this vault: the UTF-8 bytes of `\"vault\"`, then the owner's 32-byte public key.\n2. **The program's address** — `D7ZF…`. The same seeds under a different program give a completely different address, so programs can never collide on each other's accounts.\n3. **A bump** — one byte, found by search (below).\n\nThe derivation is a SHA-256 hash over `seeds + bump + program address + a fixed marker string (\"ProgramDerivedAddress\")`. The marker keeps PDAs from ever colliding with hashes computed for any other purpose.\n\n## Why the bump exists\n\nRegular addresses are points **on** the ed25519 curve — that is what makes them signable by a private key. A PDA must be the opposite: an address **off** the curve, so that *no private key can ever exist for it*. Only the program itself (with the runtime's help) can authorize actions for it.\n\nBut a hash lands on the curve roughly half the time. So the derivation *searches*: try bump 255 — if the hash is on the curve, try 254, then 253… until the result falls off the curve. The first bump that works (searching downward) is the **canonical bump**.\n\nTwo facts follow, and both showed up in your decoder yesterday:\n\n- The reference vault's stored bump is **255** — the very first candidate was already off-curve.\n- The bump is stored in the account (byte 48) so the program never has to redo the search. Deriving is cheap for you; on-chain, re-searching every call would be wasted compute.\n\n## In Kit\n\n```ts\nimport {\n  getProgramDerivedAddress,\n  getUtf8Encoder,\n  getAddressEncoder,\n} from \"@solana/kit\";\n\nconst [address, bump] = await getProgramDerivedAddress({\n  programAddress: VAULT_PROGRAM,\n  seeds: [\n    getUtf8Encoder().encode(\"vault\"),\n    getAddressEncoder().encode(owner),\n  ],\n});\n```\n\nNote it is `await` — the function is async — and it returns a pair: the address *and* the canonical bump it found.\n\n**Seed order is part of the address.** `[\"vault\", owner]` and `[owner, \"vault\"]` hash to different byte sequences, so they derive different addresses — same ingredients, different meal. The program defined the order once (you saw it in the IDL yesterday: constant `\"vault\"` first, then the user account); every client must reproduce it exactly.\n\n## The exercise\n\nThe grader has no network and no crypto library, so `derive` is **injected**: a lookup over outputs recorded from real `getProgramDerivedAddress` runs on 2026-07-28 — the correct derivation for two different owners, plus the wrong-seed-order and wrong-program derivations, all real. Your job is the part that is yours in production too: assemble the seeds in the right order and hand the right program address to `derive`.\n\nThe parts bin holds five lines. Three belong. One flips the seed order — it will \"work\" and return a real address that is simply not the vault. One passes the owner as the *program* address — a category error the lookup refuses loudly. Choose and order the lines, then run the tests: one fixture owner is the reference wallet from lesson 1, the other is a different wallet whose vault you have never seen.\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "derive",
+        "_type": "code",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": "typescript",
+        "buildType": "standard",
+        "deployable": false,
+        "starter": "// ─────────────────────────────────────────────────────────────────────────────\n// TEST HARNESS — do not edit. Grading calls runCase with an owner address and\n// injects `derive`: a lookup over REAL getProgramDerivedAddress outputs,\n// recorded on 2026-07-28 (kit 7.0.0). No hashing happens in the sandbox; the\n// recorded map holds the correct derivation for two owners, the wrong-seed-\n// order result, and the wrong-program result — all real.\n// ─────────────────────────────────────────────────────────────────────────────\nfunction runCase(ownerAddress: string) {\n  return deriveVaultPda(ownerAddress, derive);\n}\n\n/**\n * Reproduce the vault PDA for `owner`.\n *\n * The five candidate lines are in the PARTS BIN below, commented out and\n * shuffled. THREE belong, in the right order. Two are decoys:\n *   - one flips the seed order — it derives a real address that is not the\n *     vault (seed order is part of the address);\n *   - one passes the owner where the PROGRAM address belongs — a category\n *     error the lookup rejects loudly.\n * Uncomment the lines you want inside the function, in order. Do not write\n * lines that are not in the bin.\n *\n * ┌─ PARTS BIN ──────────────────────────────────────────────────────────┐\n * │ (A)  const seeds = [utf8(\"vault\"), addressBytes(owner)];             │\n * │ (B)  const [address, bump] = derive({ programAddress: owner, seeds });│\n * │ (C)  const seeds = [addressBytes(owner), utf8(\"vault\")];             │\n * │ (D)  return { address, bump };                                       │\n * │ (E)  const [address, bump] = derive({                                │\n * │        programAddress: VAULT_PROGRAM, seeds });                      │\n * └──────────────────────────────────────────────────────────────────────┘\n */\nfunction deriveVaultPda(\n  owner: string,\n  derive: (input: { programAddress: string; seeds: string[] }) => [\n    string,\n    number,\n  ]\n): { address: string; bump: number } {\n  // Assemble three lines from the parts bin here, then delete the throw.\n  throw new Error(\"assemble the derivation from the parts bin\");\n}\n\n// ── PROVIDED — seed encoders (stand-ins for getUtf8Encoder/getAddressEncoder;\n// the real ones return byte arrays, these return tagged strings the recorded\n// lookup understands) ────────────────────────────────────────────────────────\nconst VAULT_PROGRAM = \"D7ZFoWvEG5NBnkJy6iC98rhwj2qhgq8xhSD42cdTRAQd\";\nfunction utf8(s: string): string {\n  return \"utf8:\" + s;\n}\nfunction addressBytes(addr: string): string {\n  return \"address:\" + addr;\n}\n\n// ── RECORDED DERIVATIONS — real getProgramDerivedAddress outputs ────────────\nconst DERIVATIONS: Record<string, [string, number]> = {\n  // correct: [\"vault\", owner] under the vault program\n  \"D7ZFoWvEG5NBnkJy6iC98rhwj2qhgq8xhSD42cdTRAQd|utf8:vault,address:6JFH1dxqiw6Dc81CbWdx4TUT8CvAfgwZg33wQrSytZsU\":\n    [\"FY86s1fAwUiFQTjVFYprsiV6fwNH7e955MSUBo73FP4j\", 255],\n  \"D7ZFoWvEG5NBnkJy6iC98rhwj2qhgq8xhSD42cdTRAQd|utf8:vault,address:Hr99MUHbQksoGpkSagrhqzvTgCo1BVEHjnACTSsaEJh8\":\n    [\"EMTqK9Cfac1X7c86GUYG5wwGkqR9HpeYkqUDvjLmhgKi\", 252],\n  // wrong seed order: [owner, \"vault\"] — a real address, just not the vault\n  \"D7ZFoWvEG5NBnkJy6iC98rhwj2qhgq8xhSD42cdTRAQd|address:6JFH1dxqiw6Dc81CbWdx4TUT8CvAfgwZg33wQrSytZsU,utf8:vault\":\n    [\"6jBWSvMq5a1qiS61uUajhmp1KQYYZWriHc2fo6S4jYjJ\", 254],\n  \"D7ZFoWvEG5NBnkJy6iC98rhwj2qhgq8xhSD42cdTRAQd|address:Hr99MUHbQksoGpkSagrhqzvTgCo1BVEHjnACTSsaEJh8,utf8:vault\":\n    [\"7dpNqGM87gD1cVfnmwjc12rpeNiDdJStK4Jo4rtPs9R4\", 254],\n  // wrong program: same seeds under the System Program — different address\n  \"11111111111111111111111111111111|utf8:vault,address:6JFH1dxqiw6Dc81CbWdx4TUT8CvAfgwZg33wQrSytZsU\":\n    [\"9tk79Wfc9fQZBo5pggDqEnTRyhRu2pajB9VcgGe6tH3m\", 255],\n};\n\nfunction derive(input: {\n  programAddress: string;\n  seeds: string[];\n}): [string, number] {\n  const key = input.programAddress + \"|\" + input.seeds.join(\",\");\n  const hit = DERIVATIONS[key];\n  if (!hit) {\n    throw new Error(\n      \"no recorded derivation for programAddress=\" +\n        input.programAddress +\n        \" seeds=[\" +\n        input.seeds.join(\", \") +\n        \"] — is the program address actually a program, and are the seeds the ones the program defined?\"\n    );\n  }\n  return [hit[0], hit[1]];\n}\n",
+        "solution": "// ─────────────────────────────────────────────────────────────────────────────\n// TEST HARNESS — do not edit. Grading calls runCase with an owner address and\n// injects `derive`: a lookup over REAL getProgramDerivedAddress outputs,\n// recorded on 2026-07-28 (kit 7.0.0). No hashing happens in the sandbox; the\n// recorded map holds the correct derivation for two owners, the wrong-seed-\n// order result, and the wrong-program result — all real.\n// ─────────────────────────────────────────────────────────────────────────────\nfunction runCase(ownerAddress: string) {\n  return deriveVaultPda(ownerAddress, derive);\n}\n\n/**\n * Reproduce the vault PDA for `owner`.\n *\n * The five candidate lines are in the PARTS BIN below, commented out and\n * shuffled. THREE belong, in the right order. Two are decoys:\n *   - one flips the seed order — it derives a real address that is not the\n *     vault (seed order is part of the address);\n *   - one passes the owner where the PROGRAM address belongs — a category\n *     error the lookup rejects loudly.\n * Uncomment the lines you want inside the function, in order. Do not write\n * lines that are not in the bin.\n *\n * ┌─ PARTS BIN ──────────────────────────────────────────────────────────┐\n * │ (A)  const seeds = [utf8(\"vault\"), addressBytes(owner)];             │\n * │ (B)  const [address, bump] = derive({ programAddress: owner, seeds });│\n * │ (C)  const seeds = [addressBytes(owner), utf8(\"vault\")];             │\n * │ (D)  return { address, bump };                                       │\n * │ (E)  const [address, bump] = derive({                                │\n * │        programAddress: VAULT_PROGRAM, seeds });                      │\n * └──────────────────────────────────────────────────────────────────────┘\n */\nfunction deriveVaultPda(\n  owner: string,\n  derive: (input: { programAddress: string; seeds: string[] }) => [\n    string,\n    number,\n  ]\n): { address: string; bump: number } {\n  // (A) — the program's seed order: the constant \"vault\" first, then the owner.\n  const seeds = [utf8(\"vault\"), addressBytes(owner)];\n  // (E) — derive under the PROGRAM's address. (B) was the decoy: the owner is\n  // a wallet, not a program, and the lookup rejects it as a category error.\n  // (C) was the other decoy: [owner, \"vault\"] derives a real address that is\n  // simply not the vault — seed order is part of the address.\n  const [address, bump] = derive({ programAddress: VAULT_PROGRAM, seeds });\n  // (D)\n  return { address, bump };\n}\n\n// ── PROVIDED — seed encoders (stand-ins for getUtf8Encoder/getAddressEncoder;\n// the real ones return byte arrays, these return tagged strings the recorded\n// lookup understands) ────────────────────────────────────────────────────────\nconst VAULT_PROGRAM = \"D7ZFoWvEG5NBnkJy6iC98rhwj2qhgq8xhSD42cdTRAQd\";\nfunction utf8(s: string): string {\n  return \"utf8:\" + s;\n}\nfunction addressBytes(addr: string): string {\n  return \"address:\" + addr;\n}\n\n// ── RECORDED DERIVATIONS — real getProgramDerivedAddress outputs ────────────\nconst DERIVATIONS: Record<string, [string, number]> = {\n  // correct: [\"vault\", owner] under the vault program\n  \"D7ZFoWvEG5NBnkJy6iC98rhwj2qhgq8xhSD42cdTRAQd|utf8:vault,address:6JFH1dxqiw6Dc81CbWdx4TUT8CvAfgwZg33wQrSytZsU\":\n    [\"FY86s1fAwUiFQTjVFYprsiV6fwNH7e955MSUBo73FP4j\", 255],\n  \"D7ZFoWvEG5NBnkJy6iC98rhwj2qhgq8xhSD42cdTRAQd|utf8:vault,address:Hr99MUHbQksoGpkSagrhqzvTgCo1BVEHjnACTSsaEJh8\":\n    [\"EMTqK9Cfac1X7c86GUYG5wwGkqR9HpeYkqUDvjLmhgKi\", 252],\n  // wrong seed order: [owner, \"vault\"] — a real address, just not the vault\n  \"D7ZFoWvEG5NBnkJy6iC98rhwj2qhgq8xhSD42cdTRAQd|address:6JFH1dxqiw6Dc81CbWdx4TUT8CvAfgwZg33wQrSytZsU,utf8:vault\":\n    [\"6jBWSvMq5a1qiS61uUajhmp1KQYYZWriHc2fo6S4jYjJ\", 254],\n  \"D7ZFoWvEG5NBnkJy6iC98rhwj2qhgq8xhSD42cdTRAQd|address:Hr99MUHbQksoGpkSagrhqzvTgCo1BVEHjnACTSsaEJh8,utf8:vault\":\n    [\"7dpNqGM87gD1cVfnmwjc12rpeNiDdJStK4Jo4rtPs9R4\", 254],\n  // wrong program: same seeds under the System Program — different address\n  \"11111111111111111111111111111111|utf8:vault,address:6JFH1dxqiw6Dc81CbWdx4TUT8CvAfgwZg33wQrSytZsU\":\n    [\"9tk79Wfc9fQZBo5pggDqEnTRyhRu2pajB9VcgGe6tH3m\", 255],\n};\n\nfunction derive(input: {\n  programAddress: string;\n  seeds: string[];\n}): [string, number] {\n  const key = input.programAddress + \"|\" + input.seeds.join(\",\");\n  const hit = DERIVATIONS[key];\n  if (!hit) {\n    throw new Error(\n      \"no recorded derivation for programAddress=\" +\n        input.programAddress +\n        \" seeds=[\" +\n        input.seeds.join(\", \") +\n        \"] — is the program address actually a program, and are the seeds the ones the program defined?\"\n    );\n  }\n  return [hit[0], hit[1]];\n}\n",
+        "tests": [
+          {
+            "id": "t1",
+            "description": "The reference owner derives to the exact vault address read in lesson 1",
+            "input": "'6JFH1dxqiw6Dc81CbWdx4TUT8CvAfgwZg33wQrSytZsU'",
+            "expectedOutput": "result.address === 'FY86s1fAwUiFQTjVFYprsiV6fwNH7e955MSUBo73FP4j'",
+            "failureMessage": "If you derived 6jBW…jYjJ, your seed order is flipped — the program defined [\"vault\", owner], constant first. If the lookup threw, check which value you passed as programAddress."
+          },
+          {
+            "id": "t2",
+            "description": "The canonical bump comes back with the address — the same 255 you decoded at byte 48",
+            "input": "'6JFH1dxqiw6Dc81CbWdx4TUT8CvAfgwZg33wQrSytZsU'",
+            "expectedOutput": "result.bump === 255"
+          },
+          {
+            "id": "t3",
+            "description": "Anti-hardcode: a different owner derives to ITS vault, with ITS bump",
+            "input": "'Hr99MUHbQksoGpkSagrhqzvTgCo1BVEHjnACTSsaEJh8'",
+            "expectedOutput": "result.address === 'EMTqK9Cfac1X7c86GUYG5wwGkqR9HpeYkqUDvjLmhgKi' && result.bump === 252",
+            "failureMessage": "The derivation must flow from the owner argument — if this returns the FY86… address, the owner was hardcoded rather than passed through the seeds."
+          }
+        ],
+        "hints": [
+          "Three lines, in this role order: build the seeds, call derive, return the pair. The bin labels (A)–(E) are shuffled — labels are not positions.",
+          "The seed order question is settled by the program, not by you: lesson 1's IDL showed the constant \"vault\" seed first, then the user's key. Pick the seeds line that matches.",
+          "`derive` wants the address of the PROGRAM doing the deriving. One decoy hands it the owner — a wallet. If your run ends with \"no recorded derivation\", read which value you passed as programAddress."
+        ],
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null,
+        "tutorNotes": [
+          "Learners pick line (C), the flipped seed order [owner, \"vault\"]. It does not throw — it returns the real recorded address 6jBW…jYjJ — and t1 fails by address mismatch. The teaching point is that wrong seed order is a silent wrong address, not an error; the program fixed the order as [\"vault\", owner] and the IDL says so.",
+          "They pick decoy (B), passing the owner as programAddress. The lookup throws 'no recorded derivation' with the key it built — have them read their own key in the error: the first segment should be the program D7ZF…, not a wallet.",
+          "They hardcode FY86… (visible in the fixtures) and fail t3, which derives for a second owner. The owner argument must flow into the seeds.",
+          "They ask why derive is synchronous here when the lesson says getProgramDerivedAddress is async — the sandbox lookup is recorded, so there is nothing to await; in real Kit code the call must be awaited, and forgetting the await hands you a Promise instead of a [address, bump] pair.",
+          "They expect the bump to always be 255. The second owner's vault records 252 — the search stepped down three times before falling off the curve. If they treat 255 as a constant, t3's bump assertion catches it.",
+          "If they invent their own string keys instead of using utf8()/addressBytes(), the lookup throws. The helpers mirror getUtf8Encoder/getAddressEncoder — seeds are ENCODED bytes in production, never bare JS strings."
+        ]
+      },
+      {
+        "key": "check",
+        "_type": "quiz",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": [
+          {
+            "id": "q1",
+            "prompt": "Why does the derivation retry with a decreasing bump instead of using the hash directly?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "The hash can land ON the ed25519 curve, where a private key could exist — the search walks the bump down until the result is off-curve and therefore unsignable by anyone",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "Retrying makes the address harder to guess",
+                "correct": false,
+                "feedback": "PDAs are not secret — anyone can derive them, which is the point. The retry exists because roughly half of hash outputs are valid curve points, and a PDA must not be one: an on-curve address could have a private key."
+              },
+              {
+                "id": "c",
+                "label": "Each retry checks whether the address is already taken by another account",
+                "correct": false,
+                "feedback": "Derivation never touches the chain — it is pure computation. The check is geometric (is this point on the curve?), not a lookup for collisions."
+              }
+            ],
+            "explanation": "A PDA's guarantee is that no private key can ever sign for it, which requires an off-curve address. Since a hash lands on-curve about half the time, the derivation tries bump 255, 254, … until the result falls off the curve; the first success is the canonical bump."
+          },
+          {
+            "id": "q2",
+            "prompt": "The vault stores its bump (255) in byte 48. Predict why the program keeps it instead of re-deriving on every call.",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "Re-deriving repeats the hash-and-check search on-chain — the stored canonical bump turns that into a single byte read",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "The bump changes over time, so the original must be preserved",
+                "correct": false,
+                "feedback": "The derivation is deterministic — same seeds, same program, same bump, forever. Storage is purely an efficiency and safety habit: one read instead of a compute-burning search each call."
+              },
+              {
+                "id": "c",
+                "label": "Transactions must include the bump or they are rejected",
+                "correct": false,
+                "feedback": "The runtime does not demand a bump in transactions. Storing it is the program's own choice, so its checks can use the canonical bump cheaply every time."
+              }
+            ],
+            "explanation": "Deriving costs a search (hash, curve check, decrement, repeat). On-chain compute is metered, so well-written programs derive once at creation, store the canonical bump, and read one byte thereafter — which is exactly the byte your decoder extracts."
+          },
+          {
+            "id": "q3",
+            "prompt": "Another program copies this vault's code and a user with the same wallet initializes a vault there with the same seeds. Predict the two vault addresses.",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "Different — the program address is an ingredient of the hash, so identical seeds under different programs derive different PDAs",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "Identical — the seeds fully determine the address",
+                "correct": false,
+                "feedback": "Seeds are only part of the recipe. The deriving program's address is hashed in too, precisely so two programs can never collide on each other's accounts."
+              },
+              {
+                "id": "c",
+                "label": "It depends on which program was deployed first",
+                "correct": false,
+                "feedback": "Deployment order is irrelevant — derivation is pure math over seeds + program address + bump. Different program, different address, regardless of history."
+              }
+            ],
+            "explanation": "The program address is baked into the derivation, giving every program its own address namespace. That is also why the exercise's wrong-program fixture (same seeds, System Program) lands on a completely different address."
+          }
+        ],
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      }
+    ]
+  },
+  {
+    "_id": "lesson-sfwd-kit-or-legacy",
+    "title": "Kit, or What You'll Find in the Wild",
+    "slug": "kit-or-legacy",
+    "blocks": [
+      {
+        "key": "intro",
+        "_type": "prose",
+        "produces": null,
+        "consumes": null,
+        "src": "# Kit, or What You'll Find in the Wild\n\n> Version stamp — `@solana/kit` 7.0.0 · devnet · authored 2026-07-28.\n\nThis lesson adds no new machinery. It exists because the first real codebase you open will not look like this course — and you need to read it anyway.\n\n## The seam, with dates\n\nTwo stacks coexist right now, and pretending otherwise would set you up to fail:\n\n- **`@solana/kit`** — the current stack, what solana.com documents, what this course teaches. Weekly downloads around 1.65M (checked 2026-07-28).\n- **`@solana/web3.js` v1** — officially labeled superseded, yet it still holds the npm **`latest`** tag at 1.98.x with roughly 2.1M weekly downloads. `npm i @solana/web3.js` installs v1 **today**. Its companion `@solana/wallet-adapter-*` is likewise superseded and likewise everywhere.\n\nSo: every bounty codebase, most Stack Overflow answers, and most tutorials you will search speak v1. \"Canonical\" and \"what you will be paid to touch\" have diverged. The skill is **read v1 fluently, write Kit only** — this course never asks you to write a line of v1, and neither should you.\n\nOne more honesty note: the ecosystem also contains `@solana/client`, `@solana/react-hooks`, and `gill` — packages whose own documentation pages disagree about their status. This course pins **one** stack, `@solana/kit` 7.0.0, and says so, so that every line you learn has one current answer.\n\n## THE MAP\n\nLeft column: what you will read in the wild. Right column: what you write instead. The right-hand strings below are exactly the ones the drill grades against.\n\n| Legacy (read it) | Kit (write it) |\n| --- | --- |\n| `new Connection(endpoint)` | `createSolanaRpc(endpoint)` |\n| `clusterApiUrl('devnet')` | `an explicit endpoint string` |\n| `new PublicKey(base58)` | `address(base58)` |\n| `Keypair.generate()` | `generateKeyPairSigner()` |\n| `SystemProgram.transfer({...})` | `getTransferSolInstruction({...})` |\n| `sendAndConfirmTransaction(connection, tx, [payer])` | `sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions })` |\n| `connection.getAccountInfo(pubkey)` | `rpc.getAccountInfo(address).send()` |\n| `PublicKey.findProgramAddressSync(seeds, programId)` | `await getProgramDerivedAddress({ programAddress, seeds })` |\n| `useWallet() from @solana/wallet-adapter-react` | `@solana/kit-plugin-wallet (Wallet Standard)` |\n\nThe pattern behind the rows, so you can extend the map yourself:\n\n- **Classes become functions.** v1 wraps everything in `new` — `Connection`, `PublicKey`, `Transaction`. Kit is plain functions returning plain values.\n- **Magic endpoints become explicit.** `clusterApiUrl('devnet')` hid the URL; Kit asks you to write `\"https://api.devnet.solana.com\"` where everyone can see which chain you are on.\n- **Sync PDA derivation becomes async.** `findProgramAddressSync` blocked while it searched for the bump; `getProgramDerivedAddress` is awaited — the single most common porting mistake is a forgotten `await` handing you a `Promise` where an address should be.\n- **The confirm helper becomes a factory.** v1's `sendAndConfirmTransaction` took a connection each call. Kit's `sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions })` binds its dependencies once and returns the function you actually call — you will use it for real in the next lesson.\n- **Wallet plumbing becomes a protocol.** wallet-adapter needed a package per wallet; Wallet Standard is implemented by the wallets themselves, and `@solana/kit-plugin-wallet` just discovers them.\n\n## How this lesson runs\n\nFirst, a **cumulative check** — six questions reaching back through lessons 1–4, each framed against unfamiliar legacy code, because recall under new packaging is the thing interviews and codebases actually demand. Then the **translation drill**: you fill in THE MAP as a function and it is graded over legacy call sequences — a transfer flow you have seen, plus an account-read and a PDA flow you have not. Finally a short **spot-the-legacy** check on real-world tells.\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "cumulative",
+        "_type": "quiz",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": [
+          {
+            "id": "q1",
+            "prompt": "In a v1 codebase you read `const info = await connection.getAccountInfo(new PublicKey(addr)); console.log(info.owner.toBase58());` For the vault account from lesson 1, what does that log?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "The vault PROGRAM's address, D7ZF… — owner on an account is the owning program, in v1 and Kit alike",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "The wallet address stored inside the vault's data",
+                "correct": false,
+                "feedback": "The wallet lives at bytes 8–39 of the account DATA and needs your decoder. `info.owner` is the account's owning program — same account model, older API."
+              },
+              {
+                "id": "c",
+                "label": "The fee payer of the last transaction to touch the account",
+                "correct": false,
+                "feedback": "No API surfaces that. The account model is package-independent: owner means owning program, and the human owner is a field your lesson-2 decoder reads."
+              }
+            ],
+            "explanation": "The account model does not change with the SDK: owner is the owning program. Different clothes (`info.owner.toBase58()` vs the `ownerProgram` you will read in Kit), same fact from lesson 1."
+          },
+          {
+            "id": "q2",
+            "prompt": "A v1 snippet reads a vault balance with `data.readBigUInt64LE(40)` (Node Buffer API). Which lesson-2 fact is it depending on?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "The layout — a u64 at offset 40, little-endian — which belongs to the PROGRAM's account definition, not to any SDK",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "A v1-specific byte order that Kit later changed",
+                "correct": false,
+                "feedback": "Byte order is a property of the stored bytes, decided by the program that wrote them. Node's readBigUInt64LE, your DataView's getBigUint64(40, true), and Kit's getU64Decoder all read the same little-endian bytes."
+              },
+              {
+                "id": "c",
+                "label": "Nothing — offset 40 is where balances live on all Solana accounts",
+                "correct": false,
+                "feedback": "There is no universal balance offset; each program defines its own layout. Offset 40 is specific to this vault's discriminator + owner + balance + bump arrangement."
+              }
+            ],
+            "explanation": "Layouts belong to programs, not SDKs. Whatever the reading code looks like — Buffer, DataView, or Kit codec — it must encode the same knowledge: u64, offset 40, little-endian."
+          },
+          {
+            "id": "q3",
+            "prompt": "You port `PublicKey.findProgramAddressSync([Buffer.from('vault'), owner.toBuffer()], programId)` to Kit and write `const [addr] = getProgramDerivedAddress({ programAddress, seeds })`. It compiles, then things break downstream. Why?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "The await is missing — Kit's derivation is async, so addr holds a piece of a Promise, not an address",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "The seed order flipped during the port",
+                "correct": false,
+                "feedback": "The order shown matches: constant first, then owner — the same order lesson 3 taught. The bug is the missing await; the v1 function was synchronous and the Kit one is not."
+              },
+              {
+                "id": "c",
+                "label": "Kit returns only the address, not a pair",
+                "correct": false,
+                "feedback": "Kit returns the [address, bump] pair too. What changed is the synchrony: forget the await and you destructure a Promise — the single most common porting mistake on this exact line."
+              }
+            ],
+            "explanation": "v1's derivation was sync; Kit's is async. The seams where sync became async are exactly where ports break silently — the compiler is happy, and the value is a Promise fragment."
+          },
+          {
+            "id": "q4",
+            "prompt": "A v1 tutorial sends with no compute-budget instructions and calls the fee \"5,000 lamports, flat\". From lesson 4, when is that claim actually right?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "Only when no compute-unit price applies — with any priority price, the unset limit means paying it on the 200,000-CU default per instruction",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "Always — the 5,000 base fee is the whole fee on every chain",
+                "correct": false,
+                "feedback": "The base fee is 5,000 per signature, but the priority fee rides on top: price × REQUESTED limit ÷ 1e6, and unset means the 200,000 default. The tutorial's claim quietly assumes price zero."
+              },
+              {
+                "id": "c",
+                "label": "Never — every transaction pays a priority fee",
+                "correct": false,
+                "feedback": "A zero-price transaction really does pay just the base fee — your lesson-4 t4 case computed exactly that. The claim is wrong only once a price applies, which on busy networks is whenever you want to land."
+              }
+            ],
+            "explanation": "Fee = 5,000 × signatures + price × requested CU ÷ 1e6. The old \"flat fee\" folklore is the price-zero special case — true in the tutorial, expensive on a network where priority fees decide inclusion."
+          },
+          {
+            "id": "q5",
+            "prompt": "Reading a v1 codebase you meet `clusterApiUrl('devnet')` in one file and a hardcoded mainnet URL in another. Kit's replacement is \"an explicit endpoint string\". What problem is that explicitness solving?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "Which chain the code targets becomes visible and searchable at every call site — no helper hiding a cluster choice you then debug for an hour, lesson 1's ?cluster lesson in code form",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "clusterApiUrl endpoints were rate-limited harder than literal strings",
+                "correct": false,
+                "feedback": "Rate limits attach to endpoints, not to how the URL string was produced. The gain is legibility: the chain your code talks to is written where you can read it, grep it, and diff it."
+              },
+              {
+                "id": "c",
+                "label": "Kit cannot construct URLs at runtime",
+                "correct": false,
+                "feedback": "Kit accepts any string, computed or not. The design choice is to stop hiding the cluster decision inside a helper — the same class of confusion as the explorer's silent mainnet default."
+              }
+            ],
+            "explanation": "\"Account not found\" from looking at the wrong chain is the same bug whether a URL helper hid it or an explorer default did. Explicit endpoints make the chain choice reviewable — one of the quiet quality-of-life reasons the stack moved."
+          },
+          {
+            "id": "q6",
+            "prompt": "A legacy snippet stores a balance as `const bal = Number(info.lamports);` and a code reviewer flags it. From lesson 2, when exactly does this line corrupt data?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "When the value exceeds 2^53 — Number silently rounds large integers, so big balances change with no error",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "Whenever the account is a PDA",
+                "correct": false,
+                "feedback": "PDAs have nothing to do with it — the hazard is numeric range. Number is exact only to 2^53, and u64 lamport values can exceed it; past that line, silent rounding."
+              },
+              {
+                "id": "c",
+                "label": "Never — lamports always fit in a JavaScript number",
+                "correct": false,
+                "feedback": "A u64 ranges to ~1.8 × 10^19 and Number is exact to ~9 × 10^15. Large treasuries and token amounts cross that line in production. bigint end to end is the rule this course keeps."
+              }
+            ],
+            "explanation": "The 2^53 boundary is the whole argument for bigint lamports. The legacy line works in demos and corrupts exactly when the money gets big — the worst possible failure profile."
+          }
+        ],
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "drill",
+        "_type": "code",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": "typescript",
+        "buildType": "standard",
+        "deployable": false,
+        "starter": "// ─────────────────────────────────────────────────────────────────────────────\n// TEST HARNESS — do not edit. Grading calls runCase with the name of a legacy\n// call sequence (below) and checks the Kit equivalent you produce for every\n// step. The right-hand strings are exactly the ones in THE MAP in the lesson —\n// this is open book by design.\n// ─────────────────────────────────────────────────────────────────────────────\nfunction runCase(planName: string) {\n  const plan = LEGACY_PLANS[planName];\n  if (!plan) throw new Error(\"unknown legacy plan: \" + planName);\n  return modernizePlan(plan);\n}\n\n/**\n * TRANSLATION DRILL — fill in THE MAP.\n *\n * `legacy` is a sequence of calls lifted from a v1 codebase. For each one,\n * answer with the Kit equivalent, exactly as written in the lesson's map.\n * Two rows are done for you.\n */\nfunction modernizePlan(\n  legacy: string[]\n): { legacy: string; kit: string }[] {\n  const MAP: Record<string, string> = {\n    // Done for you — classes become functions:\n    \"new Connection(endpoint)\": \"createSolanaRpc(endpoint)\",\n    // Done for you — magic endpoints become explicit:\n    \"clusterApiUrl('devnet')\": \"an explicit endpoint string\",\n    // Fill in the rest from THE MAP:\n    \"new PublicKey(base58)\": \"\",\n    \"Keypair.generate()\": \"\",\n    \"SystemProgram.transfer({...})\": \"\",\n    \"sendAndConfirmTransaction(connection, tx, [payer])\": \"\",\n    \"connection.getAccountInfo(pubkey)\": \"\",\n    \"PublicKey.findProgramAddressSync(seeds, programId)\": \"\",\n    \"useWallet() from @solana/wallet-adapter-react\": \"\",\n  };\n\n  return legacy.map((call) => {\n    const kit = MAP[call];\n    if (kit === undefined || kit === \"\") {\n      throw new Error(\"no Kit equivalent recorded for: \" + call);\n    }\n    return { legacy: call, kit };\n  });\n}\n\n// ── LEGACY CALL SEQUENCES — what you will actually read in the wild ─────────\nconst LEGACY_PLANS: Record<string, string[]> = {\n  // A v1 transfer flow, top to bottom — the shape you studied in lesson 4.\n  transfer: [\n    \"new Connection(endpoint)\",\n    \"clusterApiUrl('devnet')\",\n    \"Keypair.generate()\",\n    \"SystemProgram.transfer({...})\",\n    \"sendAndConfirmTransaction(connection, tx, [payer])\",\n  ],\n  // A v1 account read — lesson 2's territory, in old clothes.\n  \"account-read\": [\n    \"new Connection(endpoint)\",\n    \"new PublicKey(base58)\",\n    \"connection.getAccountInfo(pubkey)\",\n  ],\n  // A v1 dApp fragment: derive a PDA, reach for the wallet — lessons 3 and 6.\n  \"pda-dapp\": [\n    \"new PublicKey(base58)\",\n    \"PublicKey.findProgramAddressSync(seeds, programId)\",\n    \"useWallet() from @solana/wallet-adapter-react\",\n  ],\n};\n",
+        "solution": "// ─────────────────────────────────────────────────────────────────────────────\n// TEST HARNESS — do not edit. Grading calls runCase with the name of a legacy\n// call sequence (below) and checks the Kit equivalent you produce for every\n// step. The right-hand strings are exactly the ones in THE MAP in the lesson —\n// this is open book by design.\n// ─────────────────────────────────────────────────────────────────────────────\nfunction runCase(planName: string) {\n  const plan = LEGACY_PLANS[planName];\n  if (!plan) throw new Error(\"unknown legacy plan: \" + planName);\n  return modernizePlan(plan);\n}\n\n/**\n * TRANSLATION DRILL — fill in THE MAP.\n *\n * `legacy` is a sequence of calls lifted from a v1 codebase. For each one,\n * answer with the Kit equivalent, exactly as written in the lesson's map.\n * Two rows are done for you.\n */\nfunction modernizePlan(\n  legacy: string[]\n): { legacy: string; kit: string }[] {\n  const MAP: Record<string, string> = {\n    // Done for you — classes become functions:\n    \"new Connection(endpoint)\": \"createSolanaRpc(endpoint)\",\n    // Done for you — magic endpoints become explicit:\n    \"clusterApiUrl('devnet')\": \"an explicit endpoint string\",\n    // Fill in the rest from THE MAP:\n    \"new PublicKey(base58)\": \"address(base58)\",\n    \"Keypair.generate()\": \"generateKeyPairSigner()\",\n    \"SystemProgram.transfer({...})\": \"getTransferSolInstruction({...})\",\n    \"sendAndConfirmTransaction(connection, tx, [payer])\": \"sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions })\",\n    \"connection.getAccountInfo(pubkey)\": \"rpc.getAccountInfo(address).send()\",\n    \"PublicKey.findProgramAddressSync(seeds, programId)\": \"await getProgramDerivedAddress({ programAddress, seeds })\",\n    \"useWallet() from @solana/wallet-adapter-react\": \"@solana/kit-plugin-wallet (Wallet Standard)\",\n  };\n\n  return legacy.map((call) => {\n    const kit = MAP[call];\n    if (kit === undefined || kit === \"\") {\n      throw new Error(\"no Kit equivalent recorded for: \" + call);\n    }\n    return { legacy: call, kit };\n  });\n}\n\n// ── LEGACY CALL SEQUENCES — what you will actually read in the wild ─────────\nconst LEGACY_PLANS: Record<string, string[]> = {\n  // A v1 transfer flow, top to bottom — the shape you studied in lesson 4.\n  transfer: [\n    \"new Connection(endpoint)\",\n    \"clusterApiUrl('devnet')\",\n    \"Keypair.generate()\",\n    \"SystemProgram.transfer({...})\",\n    \"sendAndConfirmTransaction(connection, tx, [payer])\",\n  ],\n  // A v1 account read — lesson 2's territory, in old clothes.\n  \"account-read\": [\n    \"new Connection(endpoint)\",\n    \"new PublicKey(base58)\",\n    \"connection.getAccountInfo(pubkey)\",\n  ],\n  // A v1 dApp fragment: derive a PDA, reach for the wallet — lessons 3 and 6.\n  \"pda-dapp\": [\n    \"new PublicKey(base58)\",\n    \"PublicKey.findProgramAddressSync(seeds, programId)\",\n    \"useWallet() from @solana/wallet-adapter-react\",\n  ],\n};\n",
+        "tests": [
+          {
+            "id": "t1",
+            "description": "The transfer flow translates end to end (5 steps)",
+            "input": "'transfer'",
+            "expectedOutput": "result.length === 5 && result[0].kit === 'createSolanaRpc(endpoint)' && result[3].kit === 'getTransferSolInstruction({...})'"
+          },
+          {
+            "id": "t2",
+            "description": "The confirm helper maps to the factory form, bound to rpc + subscriptions",
+            "input": "'transfer'",
+            "expectedOutput": "result[4].kit === 'sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions })' && result[2].kit === 'generateKeyPairSigner()'"
+          },
+          {
+            "id": "t3",
+            "description": "Anti-hardcode: an account-read flow you have not seen translates too",
+            "input": "'account-read'",
+            "expectedOutput": "result[1].kit === 'address(base58)' && result[2].kit === 'rpc.getAccountInfo(address).send()'",
+            "failureMessage": "Every row of THE MAP must be filled — this sequence exercises rows the transfer flow never touches."
+          },
+          {
+            "id": "t4",
+            "description": "Anti-hardcode: the PDA + wallet fragment — note the await on the Kit derivation",
+            "input": "'pda-dapp'",
+            "expectedOutput": "result[1].kit === 'await getProgramDerivedAddress({ programAddress, seeds })' && result[2].kit === '@solana/kit-plugin-wallet (Wallet Standard)'",
+            "failureMessage": "The Kit PDA derivation is async — the map entry includes the await. And wallet-adapter maps to a protocol (Wallet Standard via kit-plugin-wallet), not to another hook."
+          }
+        ],
+        "hints": [
+          "Every right-hand answer is written verbatim in THE MAP table in the lesson above — this drill is open book; the work is connecting each legacy call to its row.",
+          "Two of the graded sequences never appear in the transfer flow: the account-read and the PDA/wallet fragment. Fill the WHOLE map, not just the rows the first test touches.",
+          "Copy the strings exactly — `await getProgramDerivedAddress({ programAddress, seeds })` includes the await, because in Kit that call really is async."
+        ],
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null,
+        "tutorNotes": [
+          "Learners fill only the rows the visible transfer flow uses and fail t3/t4, which grade an account-read and a PDA/wallet sequence. The map is the deliverable; the three plans are just probes into it.",
+          "They paraphrase the right-hand strings ('use address()' instead of 'address(base58)') and fail on strict equality. The lesson table is the answer key verbatim — this is retrieval-and-transcription by design, not creative writing.",
+          "They map findProgramAddressSync to 'getProgramDerivedAddress(...)' WITHOUT the await. The map entry includes the await deliberately — the sync-to-async seam is the most common real porting bug, and the string encodes it.",
+          "They map useWallet() to another React hook name. The answer is a protocol shift, not a hook rename: '@solana/kit-plugin-wallet (Wallet Standard)' — wallets implement the standard themselves; no per-wallet adapter packages exist in the Kit world.",
+          "They edit LEGACY_PLANS to make tests pass instead of filling MAP. The harness section is marked do-not-edit; redirect them to the empty strings in MAP.",
+          "If they ask why v1 fluency matters when they will never write it: the npm latest tag still ships v1 and ~2.1M weekly downloads read as existing codebases — reading the wild is a paid skill; writing it is technical debt."
+        ]
+      },
+      {
+        "key": "spot",
+        "_type": "quiz",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": [
+          {
+            "id": "q1",
+            "prompt": "First file of a bounty codebase you are evaluating shows `import { useWallet } from '@solana/wallet-adapter-react'`. What have you learned?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "The codebase is on the legacy wallet stack — expect v1 patterns throughout; read fluently, and budget for the fact that new code you write in Kit will sit across a seam",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "Nothing — wallet-adapter is wallet plumbing, unrelated to which SDK the codebase uses",
+                "correct": false,
+                "feedback": "The stacks travel together: wallet-adapter pairs with v1 web3.js in practice, and a codebase importing it will almost certainly speak Connection/PublicKey everywhere. One import line is a reliable fingerprint."
+              },
+              {
+                "id": "c",
+                "label": "The codebase is broken — wallet-adapter no longer works",
+                "correct": false,
+                "feedback": "It works fine and runs half the dApps you have used — superseded is not broken. The read is strategic: legacy stack throughout, plan your reading and your seam accordingly."
+              }
+            ],
+            "explanation": "Package imports are the fastest codebase fingerprint. wallet-adapter means the v1 world; Kit-side it would be @solana/kit-plugin-wallet and Wallet Standard discovery. Neither is broken — but you should know which world you are in by line 1."
+          },
+          {
+            "id": "q2",
+            "prompt": "A 2024 tutorial's code runs `npm i @solana/web3.js` and uses `new Connection(...)`. A colleague says \"that package is deprecated, the install must have failed\". What actually happened?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "The install worked — @solana/web3.js's latest tag still ships v1, so the tutorial runs today even though the stack is officially superseded",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "npm redirected the install to @solana/kit",
+                "correct": false,
+                "feedback": "npm never swaps packages on you. The name @solana/web3.js still resolves to v1 at the latest tag — which is precisely why so much of the wild is still written in it."
+              },
+              {
+                "id": "c",
+                "label": "The tutorial cannot run on current devnet",
+                "correct": false,
+                "feedback": "v1 talks to devnet fine — the chain does not care which client library built the request. Superseded describes the maintenance status and direction of the ecosystem, not an on/off switch."
+              }
+            ],
+            "explanation": "The seam, stated with dates: solana.com labels v1 superseded, yet npm's latest tag ships it and ~2.1M weekly downloads keep it alive. Both facts are true at once — which is exactly why this lesson teaches you to read one stack and write the other."
+          }
+        ],
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      }
+    ]
+  },
+  {
+    "_id": "lesson-sfwd-see-a-live-vault",
+    "title": "See a Live Vault",
+    "slug": "see-a-live-vault",
+    "blocks": [
+      {
+        "key": "intro",
+        "_type": "prose",
+        "produces": null,
+        "consumes": null,
+        "src": "# See a Live Vault\n\nBefore you write a line of code, you are going to read state off a real blockchain — a program deployed on Solana's devnet, frozen so it can never change, holding a real vault account you can inspect right now.\n\nNothing in this lesson is a simulation or a screenshot. Every number you see, you read live.\n\n## Two kinds of account\n\nSolana has exactly one container for everything: the **account**. An account has an address, a lamport balance, an owner, and a slab of data bytes. What people call \"programs\" and \"data\" are both accounts — the difference is one flag:\n\n- A **program account** is marked `executable`. Its bytes are compiled code. Ours lives at [`D7ZFoWvEG5NBnkJy6iC98rhwj2qhgq8xhSD42cdTRAQd`](https://explorer.solana.com/address/D7ZFoWvEG5NBnkJy6iC98rhwj2qhgq8xhSD42cdTRAQd?cluster=devnet) — open it and the explorer says **Program**, and its **Upgradeable** field says **No**. That is the freeze: the deploy authority was burned, so this exact code is what runs, forever.\n- A **data account** is not executable. Its bytes are state. The vault you will spend three courses with lives at [`FY86s1fAwUiFQTjVFYprsiV6fwNH7e955MSUBo73FP4j`](https://explorer.solana.com/address/FY86s1fAwUiFQTjVFYprsiV6fwNH7e955MSUBo73FP4j?cluster=devnet).\n\nOpen the vault link and read it like a table:\n\n- **Balance** — the account's lamports. A lamport is a billionth of a SOL, and it is the native unit everything on Solana is denominated in. Read the number off the page; it is live, and later in this course you will change it.\n- **Owner** — the program allowed to modify this account's data: `D7ZF…` — our vault program. On Solana *the owner of a data account is a program*, not a person. The person is recorded somewhere else, as you will see in the next lesson.\n- **Allocated Data Size** — 49 bytes. Small enough that in the next lesson you will decode every single one by hand.\n- **Executable** — No. State, not code.\n\nOne habit to build immediately: the `?cluster=devnet` at the end of those URLs. The explorer defaults to mainnet, where none of this exists — drop the parameter and it will tell you the account is not found, and you will waste an hour concluding the chain ate your work. It didn't. You were looking at the wrong chain.\n\n## Why the balance is a moving target\n\nThis lesson will not tell you the vault's balance, on purpose. Other learners are depositing into this same account while you read this. Any number printed here would be stale by tonight — so the rule of this course is: **numbers come from the chain, not from the lesson**. Read it yourself; that is the skill.\n\n## Rent: why accounts hold lamports at all\n\nEvery account must keep a minimum lamport balance proportional to its data size — called **rent-exemption**. It is a refundable deposit, not a fee: storage on every validator costs something, so the network requires accounts to lock roughly 0.00089 SOL plus a per-byte amount, and returns it when the account closes. An account below its minimum can be garbage-collected. In module 3 your inspector will compute this minimum for any account and report whether the account clears it.\n\n## The explorer below\n\nUnder this text is the same program, embedded — its three instructions (`initialize_vault`, `deposit`, `withdraw`) read from the program's published interface, the **IDL**. Don't call anything yet; you have no wallet and no funds, and that is fine. Just open each instruction and read what it wants: which accounts it touches, who must sign, what arguments it takes. Notice `deposit` lists the vault account **first**, then the user, then the System Program — that exact order matters in module 2, when you build this call yourself.\n\nThen take the quiz — it asks you to predict what the chain does, and every answer is checkable against the pages you just opened.\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "explore",
+        "_type": "program-explorer",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": "{\n  \"address\": \"D7ZFoWvEG5NBnkJy6iC98rhwj2qhgq8xhSD42cdTRAQd\",\n  \"metadata\": {\n    \"name\": \"vault_program\",\n    \"version\": \"0.1.0\",\n    \"spec\": \"0.1.0\"\n  },\n  \"instructions\": [\n    {\n      \"name\": \"deposit\",\n      \"docs\": [\n        \"Module 3. Lamports IN move via a System Program CPI, because the debited\",\n        \"account is the user's wallet and System owns that. The recorded balance\",\n        \"moves via your Course 2 method. Two writes that have to agree.\"\n      ],\n      \"discriminator\": [242, 35, 198, 137, 82, 225, 242, 182],\n      \"accounts\": [\n        {\n          \"name\": \"vault\",\n          \"writable\": true,\n          \"pda\": {\n            \"seeds\": [\n              {\n                \"kind\": \"const\",\n                \"value\": [118, 97, 117, 108, 116]\n              },\n              {\n                \"kind\": \"account\",\n                \"path\": \"user\"\n              }\n            ]\n          }\n        },\n        {\n          \"name\": \"user\",\n          \"writable\": true,\n          \"signer\": true\n        },\n        {\n          \"name\": \"system_program\",\n          \"address\": \"11111111111111111111111111111111\"\n        }\n      ],\n      \"args\": [\n        {\n          \"name\": \"amount\",\n          \"type\": \"u64\"\n        }\n      ]\n    },\n    {\n      \"name\": \"initialize_vault\",\n      \"docs\": [\n        \"Module 2. Creates the per-user vault PDA and stores the canonical bump.\"\n      ],\n      \"discriminator\": [48, 191, 163, 44, 71, 129, 63, 164],\n      \"accounts\": [\n        {\n          \"name\": \"vault\",\n          \"writable\": true,\n          \"pda\": {\n            \"seeds\": [\n              {\n                \"kind\": \"const\",\n                \"value\": [118, 97, 117, 108, 116]\n              },\n              {\n                \"kind\": \"account\",\n                \"path\": \"user\"\n              }\n            ]\n          }\n        },\n        {\n          \"name\": \"user\",\n          \"writable\": true,\n          \"signer\": true\n        },\n        {\n          \"name\": \"system_program\",\n          \"address\": \"11111111111111111111111111111111\"\n        }\n      ],\n      \"args\": []\n    },\n    {\n      \"name\": \"withdraw\",\n      \"docs\": [\n        \"Module 3, and the instruction with no CPI in it. The debited account is\",\n        \"the vault, which OUR program owns — so our program may move its lamports\",\n        \"directly. The System Program could not do it for us at any price: it\",\n        \"refuses to debit an account carrying data, and it does not own this one.\"\n      ],\n      \"discriminator\": [183, 18, 70, 156, 148, 109, 161, 34],\n      \"accounts\": [\n        {\n          \"name\": \"vault\",\n          \"writable\": true,\n          \"pda\": {\n            \"seeds\": [\n              {\n                \"kind\": \"const\",\n                \"value\": [118, 97, 117, 108, 116]\n              },\n              {\n                \"kind\": \"account\",\n                \"path\": \"user\"\n              }\n            ]\n          }\n        },\n        {\n          \"name\": \"user\",\n          \"writable\": true,\n          \"signer\": true\n        }\n      ],\n      \"args\": [\n        {\n          \"name\": \"amount\",\n          \"type\": \"u64\"\n        }\n      ]\n    }\n  ],\n  \"accounts\": [\n    {\n      \"name\": \"VaultState\",\n      \"discriminator\": [228, 196, 82, 165, 98, 210, 235, 152]\n    }\n  ],\n  \"errors\": [\n    {\n      \"code\": 6000,\n      \"name\": \"Overflow\",\n      \"msg\": \"Deposit would overflow the vault balance\"\n    },\n    {\n      \"code\": 6001,\n      \"name\": \"InsufficientFunds\",\n      \"msg\": \"Withdrawal is larger than the vault balance\"\n    },\n    {\n      \"code\": 6002,\n      \"name\": \"ZeroAmount\",\n      \"msg\": \"Amount must be greater than zero\"\n    },\n    {\n      \"code\": 6003,\n      \"name\": \"NotOwner\",\n      \"msg\": \"Signer is not the vault owner\"\n    }\n  ],\n  \"types\": [\n    {\n      \"name\": \"VaultState\",\n      \"type\": {\n        \"kind\": \"struct\",\n        \"fields\": [\n          {\n            \"name\": \"owner\",\n            \"type\": \"pubkey\"\n          },\n          {\n            \"name\": \"balance\",\n            \"type\": \"u64\"\n          },\n          {\n            \"name\": \"bump\",\n            \"type\": \"u8\"\n          }\n        ]\n      }\n    }\n  ]\n}\n"
+      },
+      {
+        "key": "predict",
+        "_type": "quiz",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": [
+          {
+            "id": "q1",
+            "prompt": "You open the vault account `FY86…` in the explorer and its Owner field says `D7ZF…` — the vault program. Predict what that means.",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "Only the vault program may modify this account's data — on Solana, a data account's owner is a program, not a person",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "The wallet that created the vault is `D7ZF…`, so that person controls it",
+                "correct": false,
+                "feedback": "`D7ZF…` is the program, not a wallet. The person behind the vault is recorded inside the account's data bytes — you will decode that field in the next lesson. The explorer's Owner field is always the owning program."
+              },
+              {
+                "id": "c",
+                "label": "The account holds the program's source code",
+                "correct": false,
+                "feedback": "Code lives in the program account, which is marked executable. This account's Executable field says No — its 49 bytes are state, and the Owner field names the one program allowed to change them."
+              }
+            ],
+            "explanation": "Owner on a Solana account means the owning program — the only program permitted to modify the account's data (and debit its lamports). The human \"owner\" of the vault is a field inside those 49 data bytes, which is the next lesson's job."
+          },
+          {
+            "id": "q2",
+            "prompt": "The program account `D7ZF…` shows Upgradeable: No. Predict what happens if the original authors want to change its code.",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "They cannot — the upgrade authority was removed, so this exact code runs forever; a change means deploying a new program at a new address",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "They redeploy over the same address with a new version",
+                "correct": false,
+                "feedback": "That is what an upgradeable program allows — and exactly what this one gave up. With the authority burned, nobody can write new code to this address, which is why this course can pin it."
+              },
+              {
+                "id": "c",
+                "label": "They ask the validators to vote on the change",
+                "correct": false,
+                "feedback": "Validators vote on protocol upgrades, not on individual programs. A program's code changes only through its upgrade authority, and this program no longer has one."
+              }
+            ],
+            "explanation": "Frozen means frozen: with the upgrade authority set to none, the deployed bytes are permanent. That immutability is why every lesson in this course can safely pin this program's address and behavior."
+          },
+          {
+            "id": "q3",
+            "prompt": "A friend opens your vault link without `?cluster=devnet` and the explorer reports \"Account not found\". Predict the actual state of the vault.",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "Unchanged and fine — the explorer defaulted to mainnet, a different chain where this address holds nothing",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "Deleted — devnet accounts are periodically wiped",
+                "correct": false,
+                "feedback": "Nothing was deleted; the wrong chain was queried. Mainnet and devnet are separate ledgers, and an address that holds an account on one holds nothing on the other. Re-add ?cluster=devnet and the vault is right where it was."
+              },
+              {
+                "id": "c",
+                "label": "Below its rent-exempt minimum, so it was garbage-collected",
+                "correct": false,
+                "feedback": "The vault's balance is comfortably above the ~0.0012 SOL minimum for a 49-byte account — read it live and check. The \"not found\" here is the missing cluster parameter, the single most common explorer mistake."
+              }
+            ],
+            "explanation": "The explorer defaults to mainnet. Same address, different chain, no account — so the report is \"not found\" even though the devnet account is untouched. Check the cluster parameter before concluding anything about your account."
+          },
+          {
+            "id": "q4",
+            "prompt": "The vault account is 49 bytes and rent-exemption for 49 bytes is about 0.0012 SOL. Predict what the account's lamport balance you read in the explorer represents.",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "The rent-exemption deposit plus everything deposited into the vault — lamports live on the account itself, and the balance moves as learners deposit",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "Exactly the rent-exemption minimum, fixed at creation",
+                "correct": false,
+                "feedback": "It started near the minimum, but deposits land on this same account, so the live balance is minimum plus deposits — which is why this lesson refuses to print the number. Read it off the chain."
+              },
+              {
+                "id": "c",
+                "label": "A display estimate — real balances are only visible to the account's owner",
+                "correct": false,
+                "feedback": "Everything on Solana is public. The explorer shows the exact live lamport balance of any account to anyone — that openness is what makes the inspector you build in module 3 possible."
+              }
+            ],
+            "explanation": "An account's lamports are part of the account itself and are fully public. This one carries its rent deposit plus every deposit learners have made — a moving number, which is why the course rule is to read values live, never quote them."
+          }
+        ],
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      }
+    ]
+  },
+  {
+    "_id": "lesson-sfwd-ship-the-inspector",
+    "title": "Ship the Inspector",
+    "slug": "ship-the-inspector",
+    "blocks": [
+      {
+        "key": "intro",
+        "_type": "prose",
+        "produces": null,
+        "consumes": null,
+        "src": "# Ship the Inspector\n\n> Version stamp — `@solana/kit` 7.0.0 · devnet · authored 2026-07-28.\n\nNo new API in this lesson. You have every part: the RPC read from lesson 2, the byte decode from lesson 2, the derivation from lesson 3, rent-exemption from lesson 1. Today you assemble them into the module's deliverable — an **account inspector** — and the assembly is where the engineering lives.\n\n## The spec\n\n`inspect(address)` answers, for **any** devnet address:\n\n- **type** — one of `missing`, `system-owned`, `program`, `vault`, `other`;\n- **lamports** and **sol** — the balance, exact (bigint) and human-readable;\n- **ownerProgram** — who may modify it;\n- **rentExempt** — does the balance clear `getMinimumBalanceForRentExemption(dataLength)`;\n- **vault** — the decoded `{ owner, balance, bump }`, **but only when it really is a vault**: owned by the vault program *and* carrying the `VaultState` discriminator with the exact 49-byte layout. Otherwise `null`.\n\n## Acceptance criteria: the failure paths\n\nPaste-any-address means the input is hostile by default. The inspector's grade lives in what it does when the account is *not* the happy path:\n\n1. **The address does not exist** — RPC returns `{ value: null }`. Report `missing`; never touch fields that are not there.\n2. **The account exists but has no data** — a plain wallet: zero-length data, system-owned. There is nothing to decode, and trying is a bug.\n3. **The account is a program** — `executable` is set; its bytes are code, not state.\n4. **The account is owned by some other program** — a sysvar, a token account, anything. Not yours to decode: `other`.\n5. **The account is owned by the vault program but is not a VaultState** — wrong length or wrong discriminator. This is the trap lesson 2's quiz warned about: a blind decode *succeeds mechanically* and returns confident garbage. The discriminator check is what stands between your inspector and lying.\n\nOrder matters: check existence before anything, executability and ownership before shape, shape before decode. A branch order that \"mostly works\" is how inspectors end up reporting a sysvar as a vault.\n\n## Two rungs\n\n**Rung 1 — the branch table.** `classifyAccount(acc)` returns just the type. The lines are in a parts bin, scrambled, with two decoys: one classifies any vault-program-owned account as a vault without checking its shape (criterion 5's bug, made flesh), and one declares zero-length accounts `missing` (an existing empty account is not missing — criterion 2 vs 1).\n\n**Rung 2 — the whole inspector.** `inspect(acc, minRentFor)` — written by you from the spec, no pattern shown, no scaffold. Your rung-1 logic is the spine; add the balance report, rent-exemption, and the guarded decode (your lesson-2 decoder, now with the discriminator check in front). Rent minimums are injected as a recorded-real lookup, and the fee fixtures include a vault-program-owned account that is **not** rent-exempt — the check must use the real minimum for *that* account's data length, not a constant.\n\nBoth rungs grade over **recorded real devnet accounts** — the reference vault, a second vault instance, a wallet, the frozen program itself, and a sysvar — plus one synthetic layout probe (a truncated vault-owned account; details in the fixture comments). The set is exactly the taxonomy above; when it passes, your inspector has handled every failure path this course knows how to produce.\n\nThen the quiz asks you to predict failure paths, and the reflection asks which one taught you something.\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "classify",
+        "_type": "code",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": "typescript",
+        "buildType": "standard",
+        "deployable": false,
+        "starter": "// ─────────────────────────────────────────────────────────────────────────────\n// TEST HARNESS — do not edit. Grading calls runCase with a fixture name and\n// hands classifyAccount the recorded account, in the exact shape an RPC\n// getAccountInfo read returns: { value: null } for a missing account,\n// { value: { lamports, ownerProgram, executable, data } } otherwise.\n// ─────────────────────────────────────────────────────────────────────────────\nfunction runCase(fixtureName: string) {\n  const acc = ACCOUNTS[fixtureName];\n  if (acc === undefined) throw new Error(\"unknown fixture: \" + fixtureName);\n  return classifyAccount(acc);\n}\n\ntype AccountInfo = {\n  value: {\n    lamports: bigint;\n    ownerProgram: string;\n    executable: boolean;\n    data: number[];\n  } | null;\n};\n\n/**\n * RUNG 1 — the branch table. Return exactly one of:\n * \"missing\" | \"system-owned\" | \"program\" | \"vault\" | \"other\".\n *\n * The seven candidate branches are in the PARTS BIN, shuffled. FIVE belong,\n * in the right order. Two are decoys:\n *   - one trusts ownership alone and skips the shape check — the exact bug\n *     that makes an inspector report garbage as a vault;\n *   - one calls an existing empty account \"missing\" — an account with no\n *     data still exists.\n * Uncomment the branches you want, in order. Do not write branches that are\n * not in the bin.\n *\n * ┌─ PARTS BIN ──────────────────────────────────────────────────────────┐\n * │ (A)  if (acc.value.ownerProgram === VAULT_PROGRAM) return \"vault\";   │\n * │ (B)  if (acc.value === null) return \"missing\";                       │\n * │ (C)  return \"other\";                                                 │\n * │ (D)  if (acc.value.data.length === 0) return \"missing\";              │\n * │ (E)  if (acc.value.executable) return \"program\";                     │\n * │ (F)  if (acc.value.ownerProgram === SYSTEM_PROGRAM)                  │\n * │        return \"system-owned\";                                        │\n * │ (G)  if (acc.value.ownerProgram === VAULT_PROGRAM &&                 │\n * │          hasVaultShape(acc.value.data)) return \"vault\";              │\n * └──────────────────────────────────────────────────────────────────────┘\n */\nfunction classifyAccount(\n  acc: AccountInfo\n): \"missing\" | \"system-owned\" | \"program\" | \"vault\" | \"other\" {\n  // Assemble five branches from the parts bin here, then delete the throw.\n  throw new Error(\"assemble the branch table from the parts bin\");\n}\n\n// ── PROVIDED ────────────────────────────────────────────────────────────────\nconst VAULT_PROGRAM = \"D7ZFoWvEG5NBnkJy6iC98rhwj2qhgq8xhSD42cdTRAQd\";\nconst SYSTEM_PROGRAM = \"11111111111111111111111111111111\";\nconst VAULT_DISCRIMINATOR = [228, 196, 82, 165, 98, 210, 235, 152];\n\n/** True iff the bytes have the exact VaultState shape: 49 bytes, tag first. */\nfunction hasVaultShape(data: number[]): boolean {\n  if (data.length !== 49) return false;\n  for (let i = 0; i < 8; i++) {\n    if (data[i] !== VAULT_DISCRIMINATOR[i]) return false;\n  }\n  return true;\n}\n\n// ── RECORDED FIXTURES — real devnet accounts, captured 2026-07-28, except\n// \"second-vault\" (constructed byte-for-byte to the frozen VaultState layout\n// for a real derived PDA) and \"truncated-vault\" (a synthetic layout probe:\n// vault-program-owned bytes that are NOT a VaultState) ──────────────────────\nconst ACCOUNTS: Record<string, AccountInfo> = {\n  // FY86s1fAwUiFQTjVFYprsiV6fwNH7e955MSUBo73FP4j — the reference vault.\n  \"reference-vault\": {\n    value: {\n      lamports: 101231920n,\n      ownerProgram: \"D7ZFoWvEG5NBnkJy6iC98rhwj2qhgq8xhSD42cdTRAQd\",\n      executable: false,\n      data: [\n        228, 196, 82, 165, 98, 210, 235, 152, 78, 181, 115, 75, 97, 15, 248,\n        39, 115, 50, 94, 194, 229, 144, 50, 163, 140, 21, 194, 79, 145, 31,\n        240, 203, 132, 30, 178, 177, 89, 213, 11, 199, 0, 225, 245, 5, 0, 0,\n        0, 0, 255,\n      ],\n    },\n  },\n  // EMTqK9Cfac1X7c86GUYG5wwGkqR9HpeYkqUDvjLmhgKi — a different vault.\n  \"second-vault\": {\n    value: {\n      lamports: 3731920n,\n      ownerProgram: \"D7ZFoWvEG5NBnkJy6iC98rhwj2qhgq8xhSD42cdTRAQd\",\n      executable: false,\n      data: [\n        228, 196, 82, 165, 98, 210, 235, 152, 250, 81, 168, 175, 243, 7, 13,\n        139, 135, 233, 111, 129, 165, 52, 141, 25, 59, 70, 254, 154, 56, 95,\n        224, 164, 40, 67, 110, 98, 15, 29, 43, 19, 160, 37, 38, 0, 0, 0, 0,\n        0, 252,\n      ],\n    },\n  },\n  // 6JFH1dxqiw6Dc81CbWdx4TUT8CvAfgwZg33wQrSytZsU — a plain wallet: exists,\n  // zero-length data, system-owned.\n  wallet: {\n    value: {\n      lamports: 3331870864n,\n      ownerProgram: \"11111111111111111111111111111111\",\n      executable: false,\n      data: [],\n    },\n  },\n  // D7ZFoWvEG5NBnkJy6iC98rhwj2qhgq8xhSD42cdTRAQd — the frozen program itself.\n  program: {\n    value: {\n      lamports: 1141440n,\n      ownerProgram: \"BPFLoaderUpgradeab1e11111111111111111111111\",\n      executable: true,\n      data: [\n        2, 0, 0, 0, 68, 241, 198, 255, 117, 99, 71, 101, 249, 222, 102, 97,\n        219, 215, 40, 216, 232, 31, 153, 137, 220, 115, 36, 234, 236, 38, 120,\n        161, 231, 188, 130, 216,\n      ],\n    },\n  },\n  // SysvarC1ock11111111111111111111111111111111 — the clock, a real account\n  // owned by a program that is neither System nor the vault program.\n  \"clock-sysvar\": {\n    value: {\n      lamports: 1169280n,\n      ownerProgram: \"Sysvar1111111111111111111111111111111111111\",\n      executable: false,\n      data: [\n        23, 157, 149, 28, 0, 0, 0, 0, 112, 187, 104, 106, 0, 0, 0, 0, 86, 4,\n        0, 0, 0, 0, 0, 0, 87, 4, 0, 0, 0, 0, 0, 0, 244, 254, 104, 106, 0, 0,\n        0, 0,\n      ],\n    },\n  },\n  // Synthetic: owned by the vault program, but 12 bytes — NOT a VaultState.\n  // The account your inspector must refuse to decode.\n  \"truncated-vault\": {\n    value: {\n      lamports: 900000n,\n      ownerProgram: \"D7ZFoWvEG5NBnkJy6iC98rhwj2qhgq8xhSD42cdTRAQd\",\n      executable: false,\n      data: [228, 196, 82, 165, 98, 210, 235, 152, 78, 181, 115, 75],\n    },\n  },\n  // An address nobody has ever funded: the RPC answer is { value: null }.\n  missing: { value: null },\n};\n",
+        "solution": "// ─────────────────────────────────────────────────────────────────────────────\n// TEST HARNESS — do not edit. Grading calls runCase with a fixture name and\n// hands classifyAccount the recorded account, in the exact shape an RPC\n// getAccountInfo read returns: { value: null } for a missing account,\n// { value: { lamports, ownerProgram, executable, data } } otherwise.\n// ─────────────────────────────────────────────────────────────────────────────\nfunction runCase(fixtureName: string) {\n  const acc = ACCOUNTS[fixtureName];\n  if (acc === undefined) throw new Error(\"unknown fixture: \" + fixtureName);\n  return classifyAccount(acc);\n}\n\ntype AccountInfo = {\n  value: {\n    lamports: bigint;\n    ownerProgram: string;\n    executable: boolean;\n    data: number[];\n  } | null;\n};\n\n/**\n * RUNG 1 — the branch table. Return exactly one of:\n * \"missing\" | \"system-owned\" | \"program\" | \"vault\" | \"other\".\n *\n * The seven candidate branches are in the PARTS BIN, shuffled. FIVE belong,\n * in the right order. Two are decoys:\n *   - one trusts ownership alone and skips the shape check — the exact bug\n *     that makes an inspector report garbage as a vault;\n *   - one calls an existing empty account \"missing\" — an account with no\n *     data still exists.\n * Uncomment the branches you want, in order. Do not write branches that are\n * not in the bin.\n *\n * ┌─ PARTS BIN ──────────────────────────────────────────────────────────┐\n * │ (A)  if (acc.value.ownerProgram === VAULT_PROGRAM) return \"vault\";   │\n * │ (B)  if (acc.value === null) return \"missing\";                       │\n * │ (C)  return \"other\";                                                 │\n * │ (D)  if (acc.value.data.length === 0) return \"missing\";              │\n * │ (E)  if (acc.value.executable) return \"program\";                     │\n * │ (F)  if (acc.value.ownerProgram === SYSTEM_PROGRAM)                  │\n * │        return \"system-owned\";                                        │\n * │ (G)  if (acc.value.ownerProgram === VAULT_PROGRAM &&                 │\n * │          hasVaultShape(acc.value.data)) return \"vault\";              │\n * └──────────────────────────────────────────────────────────────────────┘\n */\nfunction classifyAccount(\n  acc: AccountInfo\n): \"missing\" | \"system-owned\" | \"program\" | \"vault\" | \"other\" {\n  // (B) — existence first: nothing else may touch acc.value before this.\n  if (acc.value === null) return \"missing\";\n  // (E) — executable means code; its bytes are not state to decode.\n  if (acc.value.executable) return \"program\";\n  // (F) — system-owned covers wallets, INCLUDING empty ones. (D) was the\n  // decoy here: an existing account with no data is not \"missing\".\n  if (acc.value.ownerProgram === SYSTEM_PROGRAM) return \"system-owned\";\n  // (G) — ownership AND shape. (A) was the other decoy: trusting ownership\n  // alone reports any vault-program-owned bytes as a vault — confident\n  // garbage, the criterion-5 bug.\n  if (acc.value.ownerProgram === VAULT_PROGRAM && hasVaultShape(acc.value.data))\n    return \"vault\";\n  // (C) — everything else is someone else's account.\n  return \"other\";\n}\n\n// ── PROVIDED ────────────────────────────────────────────────────────────────\nconst VAULT_PROGRAM = \"D7ZFoWvEG5NBnkJy6iC98rhwj2qhgq8xhSD42cdTRAQd\";\nconst SYSTEM_PROGRAM = \"11111111111111111111111111111111\";\nconst VAULT_DISCRIMINATOR = [228, 196, 82, 165, 98, 210, 235, 152];\n\n/** True iff the bytes have the exact VaultState shape: 49 bytes, tag first. */\nfunction hasVaultShape(data: number[]): boolean {\n  if (data.length !== 49) return false;\n  for (let i = 0; i < 8; i++) {\n    if (data[i] !== VAULT_DISCRIMINATOR[i]) return false;\n  }\n  return true;\n}\n\n// ── RECORDED FIXTURES — real devnet accounts, captured 2026-07-28, except\n// \"second-vault\" (constructed byte-for-byte to the frozen VaultState layout\n// for a real derived PDA) and \"truncated-vault\" (a synthetic layout probe:\n// vault-program-owned bytes that are NOT a VaultState) ──────────────────────\nconst ACCOUNTS: Record<string, AccountInfo> = {\n  // FY86s1fAwUiFQTjVFYprsiV6fwNH7e955MSUBo73FP4j — the reference vault.\n  \"reference-vault\": {\n    value: {\n      lamports: 101231920n,\n      ownerProgram: \"D7ZFoWvEG5NBnkJy6iC98rhwj2qhgq8xhSD42cdTRAQd\",\n      executable: false,\n      data: [\n        228, 196, 82, 165, 98, 210, 235, 152, 78, 181, 115, 75, 97, 15, 248,\n        39, 115, 50, 94, 194, 229, 144, 50, 163, 140, 21, 194, 79, 145, 31,\n        240, 203, 132, 30, 178, 177, 89, 213, 11, 199, 0, 225, 245, 5, 0, 0,\n        0, 0, 255,\n      ],\n    },\n  },\n  // EMTqK9Cfac1X7c86GUYG5wwGkqR9HpeYkqUDvjLmhgKi — a different vault.\n  \"second-vault\": {\n    value: {\n      lamports: 3731920n,\n      ownerProgram: \"D7ZFoWvEG5NBnkJy6iC98rhwj2qhgq8xhSD42cdTRAQd\",\n      executable: false,\n      data: [\n        228, 196, 82, 165, 98, 210, 235, 152, 250, 81, 168, 175, 243, 7, 13,\n        139, 135, 233, 111, 129, 165, 52, 141, 25, 59, 70, 254, 154, 56, 95,\n        224, 164, 40, 67, 110, 98, 15, 29, 43, 19, 160, 37, 38, 0, 0, 0, 0,\n        0, 252,\n      ],\n    },\n  },\n  // 6JFH1dxqiw6Dc81CbWdx4TUT8CvAfgwZg33wQrSytZsU — a plain wallet: exists,\n  // zero-length data, system-owned.\n  wallet: {\n    value: {\n      lamports: 3331870864n,\n      ownerProgram: \"11111111111111111111111111111111\",\n      executable: false,\n      data: [],\n    },\n  },\n  // D7ZFoWvEG5NBnkJy6iC98rhwj2qhgq8xhSD42cdTRAQd — the frozen program itself.\n  program: {\n    value: {\n      lamports: 1141440n,\n      ownerProgram: \"BPFLoaderUpgradeab1e11111111111111111111111\",\n      executable: true,\n      data: [\n        2, 0, 0, 0, 68, 241, 198, 255, 117, 99, 71, 101, 249, 222, 102, 97,\n        219, 215, 40, 216, 232, 31, 153, 137, 220, 115, 36, 234, 236, 38, 120,\n        161, 231, 188, 130, 216,\n      ],\n    },\n  },\n  // SysvarC1ock11111111111111111111111111111111 — the clock, a real account\n  // owned by a program that is neither System nor the vault program.\n  \"clock-sysvar\": {\n    value: {\n      lamports: 1169280n,\n      ownerProgram: \"Sysvar1111111111111111111111111111111111111\",\n      executable: false,\n      data: [\n        23, 157, 149, 28, 0, 0, 0, 0, 112, 187, 104, 106, 0, 0, 0, 0, 86, 4,\n        0, 0, 0, 0, 0, 0, 87, 4, 0, 0, 0, 0, 0, 0, 244, 254, 104, 106, 0, 0,\n        0, 0,\n      ],\n    },\n  },\n  // Synthetic: owned by the vault program, but 12 bytes — NOT a VaultState.\n  // The account your inspector must refuse to decode.\n  \"truncated-vault\": {\n    value: {\n      lamports: 900000n,\n      ownerProgram: \"D7ZFoWvEG5NBnkJy6iC98rhwj2qhgq8xhSD42cdTRAQd\",\n      executable: false,\n      data: [228, 196, 82, 165, 98, 210, 235, 152, 78, 181, 115, 75],\n    },\n  },\n  // An address nobody has ever funded: the RPC answer is { value: null }.\n  missing: { value: null },\n};\n",
+        "tests": [
+          {
+            "id": "t1",
+            "description": "The reference vault classifies as a vault",
+            "input": "'reference-vault'",
+            "expectedOutput": "result === 'vault'"
+          },
+          {
+            "id": "t2",
+            "description": "An existing wallet with zero-length data is system-owned — NOT missing",
+            "input": "'wallet'",
+            "expectedOutput": "result === 'system-owned'",
+            "failureMessage": "Decoy (D) trips here: an account with no data still exists. Only { value: null } is missing."
+          },
+          {
+            "id": "t3",
+            "description": "A { value: null } RPC answer is the only 'missing'",
+            "input": "'missing'",
+            "expectedOutput": "result === 'missing'",
+            "failureMessage": "Existence must be the FIRST branch — every other check dereferences acc.value and throws on null."
+          },
+          {
+            "id": "t4",
+            "description": "The frozen program itself classifies as a program",
+            "input": "'program'",
+            "expectedOutput": "result === 'program'"
+          },
+          {
+            "id": "t5",
+            "description": "Anti-hardcode: a different vault instance is still a vault",
+            "input": "'second-vault'",
+            "expectedOutput": "result === 'vault'"
+          },
+          {
+            "id": "t6",
+            "description": "A real account owned by a foreign program (the clock sysvar) is 'other'",
+            "input": "'clock-sysvar'",
+            "expectedOutput": "result === 'other'"
+          },
+          {
+            "id": "t7",
+            "description": "Vault-program-owned bytes WITHOUT the VaultState shape are 'other', never 'vault'",
+            "input": "'truncated-vault'",
+            "expectedOutput": "result === 'other'",
+            "failureMessage": "Decoy (A) trips here: ownership alone is not enough. The vault branch must also check hasVaultShape — 49 bytes and the discriminator."
+          }
+        ],
+        "hints": [
+          "Five branches, and the FIRST must be the null check — every other branch dereferences acc.value.",
+          "Two vault branches are in the bin; only one checks hasVaultShape. The truncated-vault fixture exists to catch the one that doesn't.",
+          "An account with data.length === 0 still exists — the wallet fixture proves it. 'missing' is reserved for { value: null }."
+        ],
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null,
+        "tutorNotes": [
+          "Learners order the null check late and t3 dies with a null dereference instead of returning 'missing'. Existence is the first branch by necessity, not style — every other branch reads acc.value.",
+          "They pick decoy (A), classifying by ownership alone, and t7 reports 'vault' for 12 truncated bytes. This is the criterion-5 bug the lesson names: a blind decode succeeds mechanically; the shape check (49 bytes + discriminator) is the only defense.",
+          "They pick decoy (D) and call the zero-data wallet 'missing' at t2. Distinguish the two absences: no ACCOUNT is { value: null }; no DATA is an existing account with an empty byte array — a plain wallet.",
+          "They put the system-owned check after the vault check and worry the order is wrong. Here either order passes — the conditions are mutually exclusive — but executable-before-ownership matters: a program's owner is a loader, and classifying by ownership first would bury 'program'.",
+          "They write branches from memory instead of the bin and drift the return strings ('wallet' instead of 'system-owned'). The five type strings are the contract rung 2 and the tests share — exact strings, from the bin."
+        ]
+      },
+      {
+        "key": "inspect",
+        "_type": "code",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": "typescript",
+        "buildType": "standard",
+        "deployable": false,
+        "starter": "// ─────────────────────────────────────────────────────────────────────────────\n// TEST HARNESS — do not edit. Grading calls runCase with a fixture name and\n// hands your inspect the recorded account plus minRentFor — the injected\n// rent-exemption lookup (getMinimumBalanceForRentExemption, recorded from\n// devnet 2026-07-28: 0 bytes → 890,880 lamports; 49 bytes → 1,231,920).\n// ─────────────────────────────────────────────────────────────────────────────\nfunction runCase(fixtureName: string) {\n  const acc = ACCOUNTS[fixtureName];\n  if (acc === undefined) throw new Error(\"unknown fixture: \" + fixtureName);\n  return inspect(acc, minRentFor);\n}\n\ntype AccountInfo = {\n  value: {\n    lamports: bigint;\n    ownerProgram: string;\n    executable: boolean;\n    data: number[];\n  } | null;\n};\n\ntype Report = {\n  type: \"missing\" | \"system-owned\" | \"program\" | \"vault\" | \"other\";\n  lamports: bigint | null;\n  sol: string | null;\n  ownerProgram: string | null;\n  rentExempt: boolean | null;\n  vault: { owner: string; balance: bigint; bump: number } | null;\n};\n\n/**\n * RUNG 2 — the whole inspector, written by you from the spec. No pattern\n * this time; the spec from the lesson is the contract:\n *\n *   - type: your rung-1 classification, same five values, same order of\n *     checks (existence → executable → system-owned → vault-with-shape →\n *     other).\n *   - For a MISSING account every other field is null.\n *   - lamports: the exact balance (bigint). sol: lamportsToSol(lamports).\n *   - ownerProgram: as recorded.\n *   - rentExempt: lamports >= minRentFor(data.length) — the minimum for\n *     THIS account's data length, not a constant.\n *   - vault: the decoded { owner, balance, bump } — your lesson-2 decoder —\n *     but ONLY when type is \"vault\". Everything else gets null, including\n *     accounts owned by the vault program whose bytes are not a VaultState.\n *\n * Helpers provided below: hasVaultShape, toBase58, lamportsToSol, and the\n * constants. The byte offsets are the ones you have known since lesson 2:\n * owner at 8..39, balance u64 LE at 40, bump at 48.\n */\nfunction inspect(\n  acc: AccountInfo,\n  minRentFor: (dataLength: number) => bigint\n): Report {\n  // Write the inspector from the spec, then delete the throw.\n  throw new Error(\"write inspect from the spec above\");\n}\n\n// ── PROVIDED ────────────────────────────────────────────────────────────────\nconst VAULT_PROGRAM = \"D7ZFoWvEG5NBnkJy6iC98rhwj2qhgq8xhSD42cdTRAQd\";\nconst SYSTEM_PROGRAM = \"11111111111111111111111111111111\";\nconst VAULT_DISCRIMINATOR = [228, 196, 82, 165, 98, 210, 235, 152];\n\n/** True iff the bytes have the exact VaultState shape: 49 bytes, tag first. */\nfunction hasVaultShape(data: number[]): boolean {\n  if (data.length !== 49) return false;\n  for (let i = 0; i < 8; i++) {\n    if (data[i] !== VAULT_DISCRIMINATOR[i]) return false;\n  }\n  return true;\n}\n\n/** Lamports → \"whole.fraction\" SOL string, all nine fractional digits. */\nfunction lamportsToSol(lamports: bigint): string {\n  const whole = lamports / 1_000_000_000n;\n  const frac = (lamports % 1_000_000_000n).toString().padStart(9, \"0\");\n  return whole.toString() + \".\" + frac;\n}\n\n/**\n * getMinimumBalanceForRentExemption, injected. The recorded devnet anchors\n * (0 → 890,880; 49 → 1,231,920) pin the live rent parameters this linear\n * formula reproduces: (128 + dataLength) × 6,960 lamports.\n */\nfunction minRentFor(dataLength: number): bigint {\n  return (128n + BigInt(dataLength)) * 6_960n;\n}\n\n/** A real base58 encoder — same helper you used in lesson 2. */\nconst BASE58_ALPHABET =\n  \"123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz\";\nfunction toBase58(bytes: Uint8Array): string {\n  let n = 0n;\n  for (const b of bytes) n = n * 256n + BigInt(b);\n  let out = \"\";\n  while (n > 0n) {\n    out = BASE58_ALPHABET[Number(n % 58n)] + out;\n    n /= 58n;\n  }\n  for (const b of bytes) {\n    if (b !== 0) break;\n    out = \"1\" + out;\n  }\n  return out;\n}\n\n// ── RECORDED FIXTURES — the same set rung 1 classified: real devnet\n// accounts captured 2026-07-28, except \"second-vault\" (constructed\n// byte-for-byte to the frozen VaultState layout for a real derived PDA) and\n// \"truncated-vault\" (a synthetic layout probe, deliberately NOT rent-exempt:\n// 900,000 lamports < minRentFor(12) = 974,400) ──────────────────────────────\nconst ACCOUNTS: Record<string, AccountInfo> = {\n  \"reference-vault\": {\n    value: {\n      lamports: 101231920n,\n      ownerProgram: \"D7ZFoWvEG5NBnkJy6iC98rhwj2qhgq8xhSD42cdTRAQd\",\n      executable: false,\n      data: [\n        228, 196, 82, 165, 98, 210, 235, 152, 78, 181, 115, 75, 97, 15, 248,\n        39, 115, 50, 94, 194, 229, 144, 50, 163, 140, 21, 194, 79, 145, 31,\n        240, 203, 132, 30, 178, 177, 89, 213, 11, 199, 0, 225, 245, 5, 0, 0,\n        0, 0, 255,\n      ],\n    },\n  },\n  \"second-vault\": {\n    value: {\n      lamports: 3731920n,\n      ownerProgram: \"D7ZFoWvEG5NBnkJy6iC98rhwj2qhgq8xhSD42cdTRAQd\",\n      executable: false,\n      data: [\n        228, 196, 82, 165, 98, 210, 235, 152, 250, 81, 168, 175, 243, 7, 13,\n        139, 135, 233, 111, 129, 165, 52, 141, 25, 59, 70, 254, 154, 56, 95,\n        224, 164, 40, 67, 110, 98, 15, 29, 43, 19, 160, 37, 38, 0, 0, 0, 0,\n        0, 252,\n      ],\n    },\n  },\n  wallet: {\n    value: {\n      lamports: 3331870864n,\n      ownerProgram: \"11111111111111111111111111111111\",\n      executable: false,\n      data: [],\n    },\n  },\n  program: {\n    value: {\n      lamports: 1141440n,\n      ownerProgram: \"BPFLoaderUpgradeab1e11111111111111111111111\",\n      executable: true,\n      data: [\n        2, 0, 0, 0, 68, 241, 198, 255, 117, 99, 71, 101, 249, 222, 102, 97,\n        219, 215, 40, 216, 232, 31, 153, 137, 220, 115, 36, 234, 236, 38, 120,\n        161, 231, 188, 130, 216,\n      ],\n    },\n  },\n  \"clock-sysvar\": {\n    value: {\n      lamports: 1169280n,\n      ownerProgram: \"Sysvar1111111111111111111111111111111111111\",\n      executable: false,\n      data: [\n        23, 157, 149, 28, 0, 0, 0, 0, 112, 187, 104, 106, 0, 0, 0, 0, 86, 4,\n        0, 0, 0, 0, 0, 0, 87, 4, 0, 0, 0, 0, 0, 0, 244, 254, 104, 106, 0, 0,\n        0, 0,\n      ],\n    },\n  },\n  \"truncated-vault\": {\n    value: {\n      lamports: 900000n,\n      ownerProgram: \"D7ZFoWvEG5NBnkJy6iC98rhwj2qhgq8xhSD42cdTRAQd\",\n      executable: false,\n      data: [228, 196, 82, 165, 98, 210, 235, 152, 78, 181, 115, 75],\n    },\n  },\n  missing: { value: null },\n};\n",
+        "solution": "// ─────────────────────────────────────────────────────────────────────────────\n// TEST HARNESS — do not edit. Grading calls runCase with a fixture name and\n// hands your inspect the recorded account plus minRentFor — the injected\n// rent-exemption lookup (getMinimumBalanceForRentExemption, recorded from\n// devnet 2026-07-28: 0 bytes → 890,880 lamports; 49 bytes → 1,231,920).\n// ─────────────────────────────────────────────────────────────────────────────\nfunction runCase(fixtureName: string) {\n  const acc = ACCOUNTS[fixtureName];\n  if (acc === undefined) throw new Error(\"unknown fixture: \" + fixtureName);\n  return inspect(acc, minRentFor);\n}\n\ntype AccountInfo = {\n  value: {\n    lamports: bigint;\n    ownerProgram: string;\n    executable: boolean;\n    data: number[];\n  } | null;\n};\n\ntype Report = {\n  type: \"missing\" | \"system-owned\" | \"program\" | \"vault\" | \"other\";\n  lamports: bigint | null;\n  sol: string | null;\n  ownerProgram: string | null;\n  rentExempt: boolean | null;\n  vault: { owner: string; balance: bigint; bump: number } | null;\n};\n\n/**\n * RUNG 2 — the whole inspector, written by you from the spec. No pattern\n * this time; the spec from the lesson is the contract:\n *\n *   - type: your rung-1 classification, same five values, same order of\n *     checks (existence → executable → system-owned → vault-with-shape →\n *     other).\n *   - For a MISSING account every other field is null.\n *   - lamports: the exact balance (bigint). sol: lamportsToSol(lamports).\n *   - ownerProgram: as recorded.\n *   - rentExempt: lamports >= minRentFor(data.length) — the minimum for\n *     THIS account's data length, not a constant.\n *   - vault: the decoded { owner, balance, bump } — your lesson-2 decoder —\n *     but ONLY when type is \"vault\". Everything else gets null, including\n *     accounts owned by the vault program whose bytes are not a VaultState.\n *\n * Helpers provided below: hasVaultShape, toBase58, lamportsToSol, and the\n * constants. The byte offsets are the ones you have known since lesson 2:\n * owner at 8..39, balance u64 LE at 40, bump at 48.\n */\nfunction inspect(\n  acc: AccountInfo,\n  minRentFor: (dataLength: number) => bigint\n): Report {\n  if (acc.value === null) {\n    return {\n      type: \"missing\",\n      lamports: null,\n      sol: null,\n      ownerProgram: null,\n      rentExempt: null,\n      vault: null,\n    };\n  }\n  const v = acc.value;\n\n  // The rung-1 branch table, existence already handled above.\n  let type: Report[\"type\"];\n  if (v.executable) type = \"program\";\n  else if (v.ownerProgram === SYSTEM_PROGRAM) type = \"system-owned\";\n  else if (v.ownerProgram === VAULT_PROGRAM && hasVaultShape(v.data))\n    type = \"vault\";\n  else type = \"other\";\n\n  // Rent-exemption against the minimum for THIS account's data length.\n  const rentExempt = v.lamports >= minRentFor(v.data.length);\n\n  // The guarded decode: only a shape-checked vault is decoded.\n  let vault: Report[\"vault\"] = null;\n  if (type === \"vault\") {\n    const bytes = new Uint8Array(v.data);\n    const view = new DataView(bytes.buffer);\n    vault = {\n      owner: toBase58(bytes.slice(8, 40)),\n      balance: view.getBigUint64(40, true),\n      bump: bytes[48],\n    };\n  }\n\n  return {\n    type,\n    lamports: v.lamports,\n    sol: lamportsToSol(v.lamports),\n    ownerProgram: v.ownerProgram,\n    rentExempt,\n    vault,\n  };\n}\n\n// ── PROVIDED ────────────────────────────────────────────────────────────────\nconst VAULT_PROGRAM = \"D7ZFoWvEG5NBnkJy6iC98rhwj2qhgq8xhSD42cdTRAQd\";\nconst SYSTEM_PROGRAM = \"11111111111111111111111111111111\";\nconst VAULT_DISCRIMINATOR = [228, 196, 82, 165, 98, 210, 235, 152];\n\n/** True iff the bytes have the exact VaultState shape: 49 bytes, tag first. */\nfunction hasVaultShape(data: number[]): boolean {\n  if (data.length !== 49) return false;\n  for (let i = 0; i < 8; i++) {\n    if (data[i] !== VAULT_DISCRIMINATOR[i]) return false;\n  }\n  return true;\n}\n\n/** Lamports → \"whole.fraction\" SOL string, all nine fractional digits. */\nfunction lamportsToSol(lamports: bigint): string {\n  const whole = lamports / 1_000_000_000n;\n  const frac = (lamports % 1_000_000_000n).toString().padStart(9, \"0\");\n  return whole.toString() + \".\" + frac;\n}\n\n/**\n * getMinimumBalanceForRentExemption, injected. The recorded devnet anchors\n * (0 → 890,880; 49 → 1,231,920) pin the live rent parameters this linear\n * formula reproduces: (128 + dataLength) × 6,960 lamports.\n */\nfunction minRentFor(dataLength: number): bigint {\n  return (128n + BigInt(dataLength)) * 6_960n;\n}\n\n/** A real base58 encoder — same helper you used in lesson 2. */\nconst BASE58_ALPHABET =\n  \"123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz\";\nfunction toBase58(bytes: Uint8Array): string {\n  let n = 0n;\n  for (const b of bytes) n = n * 256n + BigInt(b);\n  let out = \"\";\n  while (n > 0n) {\n    out = BASE58_ALPHABET[Number(n % 58n)] + out;\n    n /= 58n;\n  }\n  for (const b of bytes) {\n    if (b !== 0) break;\n    out = \"1\" + out;\n  }\n  return out;\n}\n\n// ── RECORDED FIXTURES — the same set rung 1 classified: real devnet\n// accounts captured 2026-07-28, except \"second-vault\" (constructed\n// byte-for-byte to the frozen VaultState layout for a real derived PDA) and\n// \"truncated-vault\" (a synthetic layout probe, deliberately NOT rent-exempt:\n// 900,000 lamports < minRentFor(12) = 974,400) ──────────────────────────────\nconst ACCOUNTS: Record<string, AccountInfo> = {\n  \"reference-vault\": {\n    value: {\n      lamports: 101231920n,\n      ownerProgram: \"D7ZFoWvEG5NBnkJy6iC98rhwj2qhgq8xhSD42cdTRAQd\",\n      executable: false,\n      data: [\n        228, 196, 82, 165, 98, 210, 235, 152, 78, 181, 115, 75, 97, 15, 248,\n        39, 115, 50, 94, 194, 229, 144, 50, 163, 140, 21, 194, 79, 145, 31,\n        240, 203, 132, 30, 178, 177, 89, 213, 11, 199, 0, 225, 245, 5, 0, 0,\n        0, 0, 255,\n      ],\n    },\n  },\n  \"second-vault\": {\n    value: {\n      lamports: 3731920n,\n      ownerProgram: \"D7ZFoWvEG5NBnkJy6iC98rhwj2qhgq8xhSD42cdTRAQd\",\n      executable: false,\n      data: [\n        228, 196, 82, 165, 98, 210, 235, 152, 250, 81, 168, 175, 243, 7, 13,\n        139, 135, 233, 111, 129, 165, 52, 141, 25, 59, 70, 254, 154, 56, 95,\n        224, 164, 40, 67, 110, 98, 15, 29, 43, 19, 160, 37, 38, 0, 0, 0, 0,\n        0, 252,\n      ],\n    },\n  },\n  wallet: {\n    value: {\n      lamports: 3331870864n,\n      ownerProgram: \"11111111111111111111111111111111\",\n      executable: false,\n      data: [],\n    },\n  },\n  program: {\n    value: {\n      lamports: 1141440n,\n      ownerProgram: \"BPFLoaderUpgradeab1e11111111111111111111111\",\n      executable: true,\n      data: [\n        2, 0, 0, 0, 68, 241, 198, 255, 117, 99, 71, 101, 249, 222, 102, 97,\n        219, 215, 40, 216, 232, 31, 153, 137, 220, 115, 36, 234, 236, 38, 120,\n        161, 231, 188, 130, 216,\n      ],\n    },\n  },\n  \"clock-sysvar\": {\n    value: {\n      lamports: 1169280n,\n      ownerProgram: \"Sysvar1111111111111111111111111111111111111\",\n      executable: false,\n      data: [\n        23, 157, 149, 28, 0, 0, 0, 0, 112, 187, 104, 106, 0, 0, 0, 0, 86, 4,\n        0, 0, 0, 0, 0, 0, 87, 4, 0, 0, 0, 0, 0, 0, 244, 254, 104, 106, 0, 0,\n        0, 0,\n      ],\n    },\n  },\n  \"truncated-vault\": {\n    value: {\n      lamports: 900000n,\n      ownerProgram: \"D7ZFoWvEG5NBnkJy6iC98rhwj2qhgq8xhSD42cdTRAQd\",\n      executable: false,\n      data: [228, 196, 82, 165, 98, 210, 235, 152, 78, 181, 115, 75],\n    },\n  },\n  missing: { value: null },\n};\n",
+        "tests": [
+          {
+            "id": "t1",
+            "description": "The reference vault: full report with decoded fields matching your lesson-2 decoder",
+            "input": "'reference-vault'",
+            "expectedOutput": "result.type === 'vault' && result.vault.owner === '6JFH1dxqiw6Dc81CbWdx4TUT8CvAfgwZg33wQrSytZsU' && result.vault.balance === 100000000n && result.vault.bump === 255 && result.rentExempt === true && result.sol === '0.101231920' && result.ownerProgram === 'D7ZFoWvEG5NBnkJy6iC98rhwj2qhgq8xhSD42cdTRAQd'"
+          },
+          {
+            "id": "t2",
+            "description": "A wallet: system-owned, rent-exempt, and vault stays null",
+            "input": "'wallet'",
+            "expectedOutput": "result.type === 'system-owned' && result.vault === null && result.rentExempt === true && result.sol === '3.331870864' && result.lamports === 3331870864n"
+          },
+          {
+            "id": "t3",
+            "description": "Missing account: type only, every other field null",
+            "input": "'missing'",
+            "expectedOutput": "result.type === 'missing' && result.lamports === null && result.sol === null && result.ownerProgram === null && result.rentExempt === null && result.vault === null",
+            "failureMessage": "For { value: null } nothing else may be read — every non-type field is null, and reaching into acc.value first throws."
+          },
+          {
+            "id": "t4",
+            "description": "Anti-hardcode: a different vault instance decodes to ITS fields",
+            "input": "'second-vault'",
+            "expectedOutput": "result.type === 'vault' && result.vault.owner === 'Hr99MUHbQksoGpkSagrhqzvTgCo1BVEHjnACTSsaEJh8' && result.vault.balance === 2500000n && result.vault.bump === 252 && result.sol === '0.003731920'"
+          },
+          {
+            "id": "t5",
+            "description": "The program account: type program, never decoded",
+            "input": "'program'",
+            "expectedOutput": "result.type === 'program' && result.vault === null && result.rentExempt === true && result.sol === '0.001141440'"
+          },
+          {
+            "id": "t6",
+            "description": "Vault-program-owned bytes without the shape: 'other', vault null — and NOT rent-exempt",
+            "input": "'truncated-vault'",
+            "expectedOutput": "result.type === 'other' && result.vault === null && result.rentExempt === false && result.lamports === 900000n",
+            "failureMessage": "Two traps in one fixture: the guarded decode (no VaultState shape → no decode) and rent-exemption computed for THIS data length — minRentFor(12) is 974,400, above the 900,000 balance."
+          },
+          {
+            "id": "t7",
+            "description": "A foreign-owned sysvar: 'other', with an honest rent report",
+            "input": "'clock-sysvar'",
+            "expectedOutput": "result.type === 'other' && result.vault === null && result.rentExempt === true && result.ownerProgram === 'Sysvar1111111111111111111111111111111111111'"
+          }
+        ],
+        "hints": [
+          "Start with the missing case: return the all-null report before touching acc.value. Then reuse your rung-1 branch order for type.",
+          "rentExempt compares against minRentFor(v.data.length) — the length of THIS account's data. The truncated-vault fixture is deliberately below its minimum.",
+          "Decode only when type === 'vault': bytes 8..39 through toBase58, getBigUint64(40, true), byte 48 — your lesson-2 decoder, behind the shape check."
+        ],
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null,
+        "tutorNotes": [
+          "Learners decode whenever ownerProgram matches, skipping the shape gate, and t6 hands them 12 bytes — the decode then reads past the array (undefined bytes, NaN balance) or fabricates fields. The rule: vault decode happens ONLY when the classification said 'vault', which already includes hasVaultShape.",
+          "They compute rentExempt against a constant (the 49-byte minimum, or lesson 1's ~0.0012 SOL) instead of minRentFor(data.length). t6 (12 bytes, 900,000 lamports, minimum 974,400) and t2 (0 bytes) both break constants — rent scales with THIS account's size.",
+          "They return partial nulls for missing (keeping type plus, say, lamports: 0n). The spec is all-null except type: 0n is a real balance claim about an account that does not exist, and t3 checks every field.",
+          "They build the sol string with Number division (lamports / 1e9) and get float artifacts like '3.3318708639999998'. lamportsToSol is provided and pure-bigint; the 2^53 rule from lesson 2 applies to display code too.",
+          "They forget the wallet/zero-data path and index into an empty array. data.length === 0 is a legal, common account state — the decode must be unreachable for it via the type gate.",
+          "If they ask why inspect takes minRentFor as a parameter: the real getMinimumBalanceForRentExemption is an RPC call; injecting it keeps the inspector a pure, testable function — the same dependency-injection shape the whole course grades with."
+        ]
+      },
+      {
+        "key": "predict",
+        "_type": "quiz",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": [
+          {
+            "id": "q1",
+            "prompt": "A user pastes a validator's VOTE account into your inspector — owned by the Vote program, 3,762 bytes. Predict the report.",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "type 'other', vault null — foreign-owned accounts are reported, never decoded",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "An exception — the inspector only supports vault accounts",
+                "correct": false,
+                "feedback": "Paste-any-address is the spec: unknown account kinds are a normal input, not an error. The branch table absorbs them as 'other' with an honest lamports/owner/rent report and no decode."
+              },
+              {
+                "id": "c",
+                "label": "type 'vault' with garbage fields — 3,762 bytes decode mechanically",
+                "correct": false,
+                "feedback": "Only if the shape gate were missing. The vault branch requires the vault program as owner AND the 49-byte discriminator shape; a vote account fails both and lands in 'other'."
+              }
+            ],
+            "explanation": "'other' is a feature, not a shrug: report what is safely knowable (balance, owner, rent) and refuse what is not (a decode under someone else's layout). That refusal is what separates an inspector from a liar."
+          },
+          {
+            "id": "q2",
+            "prompt": "Someone funds a brand-new address with 800,000 lamports and never creates data on it. Your inspector reports it. Predict rentExempt.",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "false — a zero-data account's minimum is 890,880 lamports, and 800,000 is below it",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "true — accounts with no data owe no rent",
+                "correct": false,
+                "feedback": "Even empty accounts pay for their metadata: minRentFor(0) is 890,880 lamports (the 128-byte overhead × 6,960). 800,000 falls short, so the honest report is rentExempt false."
+              },
+              {
+                "id": "c",
+                "label": "null — rent only applies to program-owned accounts",
+                "correct": false,
+                "feedback": "Rent-exemption is universal — system-owned, program-owned, sysvars, everything. null is reserved for accounts that do not exist at all."
+              }
+            ],
+            "explanation": "The minimum is (128 + dataLength) × 6,960 lamports, so even zero data costs 890,880. An account below its minimum is real and reportable — and flagging it is exactly the kind of honest detail that makes an inspector useful."
+          },
+          {
+            "id": "q3",
+            "prompt": "Your RPC read returns { value: null } for an address the user swears has SOL on it. From this course, what is the FIRST hypothesis to check?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "Wrong cluster — the address may hold an account on mainnet while your inspector queried devnet",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "The account was garbage-collected for low rent",
+                "correct": false,
+                "feedback": "Possible in principle, rare in practice — and not the first check. The overwhelmingly common cause of \"it exists, you say null\" is a cluster mismatch, the same trap as lesson 1's ?cluster=devnet."
+              },
+              {
+                "id": "c",
+                "label": "The RPC node is lying",
+                "correct": false,
+                "feedback": "Start with the boring hypothesis: your query went to a different chain than their wallet is looking at. Lesson 1's explorer default and your RPC endpoint choice are the same bug wearing two hats."
+              }
+            ],
+            "explanation": "{ value: null } means \"no account at this address ON THIS CLUSTER\". The endpoint your createSolanaRpc was built with decides which chain answered — the code-side twin of the explorer's ?cluster parameter."
+          },
+          {
+            "id": "q4",
+            "prompt": "Why does the truncated-vault fixture exist at all — when would a real inspector meet vault-program-owned bytes that are not a VaultState?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "Any program can own several account types (or versions), so owner alone never identifies a layout — the discriminator is the type tag that does",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "It cannot happen — a program's accounts always share one layout",
+                "correct": false,
+                "feedback": "Most real programs own MANY account types — that is why Anchor stamps a discriminator on every one. Owner narrows it to a program; the 8-byte tag picks the type within it."
+              },
+              {
+                "id": "c",
+                "label": "Only if the chain corrupts the account's bytes",
+                "correct": false,
+                "feedback": "The chain does not corrupt bytes. The realistic source is legitimate variety: multiple account types, layout versions, or a different program deployed at an address you assumed. The tag check handles all of them the same way."
+              }
+            ],
+            "explanation": "Owner tells you which program may write the account; the discriminator tells you what the bytes claim to be. Real programs own many types, so the pair — owner AND tag — is the minimum honest check before any decode. That is the shape gate you built."
+          }
+        ],
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "reflect",
+        "_type": "openEnded",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": null,
+        "prompt": "Your inspector handles five failure paths: missing account, zero-data account, program account, foreign-owned account, and vault-owned-but-not-a-vault. Which one surprised you most when you first got it wrong (or almost wrong), and what did the fix teach you about how Solana models accounts?",
+        "maxWords": 120,
+        "amount": null,
+        "network": null,
+        "idl": null
+      }
+    ]
+  },
+  {
+    "_id": "lesson-sfwd-what-you-built",
+    "title": "What You Built",
+    "slug": "what-you-built",
+    "blocks": [
+      {
+        "key": "intro",
+        "_type": "prose",
+        "produces": null,
+        "consumes": null,
+        "src": "# What You Built\n\nSix lessons ago the vault was a URL you could not read. Inventory what exists now — each item is a real artifact, not a feeling:\n\n- **A graded, working account inspector** — `classifyAccount` plus `inspect`, passing every fixture including the five failure paths. It reads any devnet address and answers with type, SOL, owner, rent-exemption, and — only when the owner and discriminator prove it — decoded vault fields. It lives in your completed lesson 7, and it is the through-line artifact of this whole track.\n- **Your confirmed devnet transaction** — the deposit you assembled byte-by-byte and a wallet signed in lesson 6. Its explorer signature is on your profile via the lesson-6 reflection: a public, permanent record anyone can verify, showing your fee, your account order (vault first), and the vault's balance moving.\n- **A funded devnet wallet** — connected through Wallet Standard, holding the SOL the faucet gave you minus your deposit and its base fee. Keep it: **in Course 3 this exact wallet pays your own program's deploy** — rent for the program account and 200+ transactions of upload fees. (Course 2 spends nothing — it is all compiling.)\n- **Your credential and XP** — the on-chain record that you completed these eight lessons, minted to the same wallet.\n\n## The handoff contract, byte for byte\n\nThe one thing Course 2 picks up is not code — it is **knowledge of a layout**. Your decoder reads:\n\n```\noffset 0   8 bytes   discriminator [228, 196, 82, 165, 98, 210, 235, 152]\noffset 8   32 bytes  owner\noffset 40  8 bytes   balance, u64 little-endian\noffset 48  1 byte    bump\n```\n\nIn Course 2 you write the Rust struct that *produces* those bytes — `owner: Pubkey`, `balance: u64`, `bump: u8`, in that order. It must match your decoder **byte for byte**, because there is no translation layer between them: the struct's memory layout, serialized, IS the account data your `DataView` read. Get a field order wrong, or a width wrong, and your own inspector reports garbage against your own program — the mistake announces itself in a tool you built.\n\nThe seeds you ordered in lesson 3 — `[\"vault\", owner]`, constant first — become the `seeds = [...]` constraint in Course 3's account validation, character for character. And the hand-written decoder itself? Course 4 replaces it with a generated client — which is the point: you will know exactly what the generator generates, because you wrote it once by hand.\n\nRun the cumulative check below — it draws on every lesson — then the closing reflection.\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": null,
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "cumulative",
+        "_type": "quiz",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": [
+          {
+            "id": "q1",
+            "prompt": "In Course 2 you will write `struct VaultState { owner: Pubkey, balance: u64, bump: u8 }`. A classmate proposes reordering it to put `balance` first \"since it changes most\". What happens to your lesson-7 inspector against vaults created by that program?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "It reports garbage — the serialized field order IS the byte layout, so your decoder's offsets (owner at 8, balance at 40) would now read the wrong bytes",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "Nothing — decoders match fields by name",
+                "correct": false,
+                "feedback": "There are no names in the 49 bytes — only positions. Your decoder reads offsets; the struct defines what lives at each offset. Reorder the struct and every offset shifts, silently."
+              },
+              {
+                "id": "c",
+                "label": "The program would fail to compile",
+                "correct": false,
+                "feedback": "Rust compiles any field order happily. The breakage is semantic and silent: two programs disagreeing about what byte 40 means. That is why the handoff contract is byte-for-byte."
+              }
+            ],
+            "explanation": "Serialization is positional. The struct's field order determines the account's byte layout, and every reader — your inspector, Course 4's generated client — depends on it. The layout is a contract, and this course taught you both sides of it."
+          },
+          {
+            "id": "q2",
+            "prompt": "Course 3 will declare the vault's address with seeds = [b\"vault\", user.key()]. From lesson 3, why exactly that order and not the reverse?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "Because the derivation hashes seeds in order — the program chose [\"vault\", owner] once, and every client must reproduce it or derive a different, wrong address",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "Constant seeds are required to come first by the runtime",
+                "correct": false,
+                "feedback": "The runtime has no such rule — either order would derive AN address. What matters is agreement: the program fixed [\"vault\", owner], so that exact order is now part of its interface, forever."
+              },
+              {
+                "id": "c",
+                "label": "Reversed seeds would put the address on the ed25519 curve",
+                "correct": false,
+                "feedback": "The bump search guarantees off-curve for any seed order. The reversed order derives a perfectly valid, off-curve — and WRONG — address, which is why your lesson-3 decoy \"worked\" and still failed."
+              }
+            ],
+            "explanation": "Seed order is part of the address. The choice was arbitrary once, binding forever after — your lesson-3 drill derived the real wrong-order address (6jBW…) to make the silence of that failure mode visible."
+          },
+          {
+            "id": "q3",
+            "prompt": "Your lesson-6 deposit paid 5,000 lamports. A mainnet dApp sends the same instruction with a compute-unit price of 50,000 micro-lamports and no limit instruction. Its priority fee is?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "50,000 × 200,000 ÷ 1e6 = 10,000 lamports — the unset limit requests the 200,000-CU default, and the fee charges the request, not the ~6,700 consumed",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "50,000 × 6,697 ÷ 1e6 ≈ 335 lamports — fees charge actual consumption",
+                "correct": false,
+                "feedback": "The formula charges the REQUESTED limit. Without a SetComputeUnitLimit, the request defaults to 200,000 CU — that is the ~30× overpay lesson 4's simulate-and-tighten exists to close."
+              },
+              {
+                "id": "c",
+                "label": "Zero — priority fees are optional",
+                "correct": false,
+                "feedback": "A price was set, so the priority fee applies — and it multiplies the requested limit. Optional is the price; once present, the arithmetic is fixed."
+              }
+            ],
+            "explanation": "fee = 5,000 × signatures + price × requested CU ÷ 1e6, and the default request is 200,000 CU per non-builtin instruction. Sizing the limit from simulation (6,697 + margin → 7,366) cuts that term ~27× — the single most valuable habit lesson 4 taught."
+          },
+          {
+            "id": "q4",
+            "prompt": "Your lesson-6 flow never touched a private key, yet the deposit got signed. Reconstruct who did what.",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "Your code assembled the full unsigned plan; the wallet — discovered via Wallet Standard — held the key and produced the signature",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "The wallet built the transaction from the amount you typed",
+                "correct": false,
+                "feedback": "The wallet signs what the app assembles — it built nothing. Your buildDepositPlan produced every byte (accounts in IDL order, discriminator, LE amount); the wallet's only power is the signature, and that split is the security model."
+              },
+              {
+                "id": "c",
+                "label": "The RPC node co-signed on your behalf",
+                "correct": false,
+                "feedback": "RPC nodes relay; they never hold keys. One signature exists on that transaction — your wallet's — which is also why its base fee was exactly 5,000 lamports."
+              }
+            ],
+            "explanation": "Apps assemble, wallets sign, nodes relay. Wallet Standard is how the app discovered the wallet without a per-wallet adapter, and the assembled-vs-signed split is why a dApp can be open source and still safe to use."
+          },
+          {
+            "id": "q5",
+            "prompt": "An exchange credits your deposit at 'confirmed' but releases withdrawals only at 'finalized'. Why the asymmetry?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "'confirmed' (supermajority vote) can in rare cases roll back; 'finalized' cannot — so they accept small risk on money coming in, none on money going out",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "'finalized' transactions pay higher fees, which withdrawals justify",
+                "correct": false,
+                "feedback": "Commitment is about observation, not payment — the transaction is the same. The ladder (processed → confirmed → finalized) trades latency for certainty, and the exchange picks a rung per direction of risk."
+              },
+              {
+                "id": "c",
+                "label": "Withdrawals require more signatures, which take longer",
+                "correct": false,
+                "feedback": "Signature count is unrelated to commitment. The asymmetry is pure risk accounting on the same ladder your lesson-6 send climbed: reversible-ish at confirmed, irreversible at finalized."
+              }
+            ],
+            "explanation": "The commitment ladder is a risk dial, not a status bar. UIs and businesses choose the rung that matches what a rollback would cost them — the honest-UI principle from lesson 6, applied to money."
+          },
+          {
+            "id": "q6",
+            "prompt": "A user reports \"my deposit failed\" with a screenshot of a wallet rejection popup. Using the lesson-6 taxonomy, what is the correct triage?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "Nothing failed on-chain — the rejection is pre-network, there is no signature to look up, and the app should have returned to resting state",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "Find the failed transaction's signature and read its logs",
+                "correct": false,
+                "feedback": "There is no signature — nothing was signed or sent. Logs exist only for taxonomy case 5 (landed and failed on-chain). A rejection leaves no trace anywhere but the UI."
+              },
+              {
+                "id": "c",
+                "label": "Ask them to wait for the blockhash to expire and retry",
+                "correct": false,
+                "feedback": "Blockhash expiry applies to transactions that went OUT and aged. A rejection went nowhere; the user can simply try again immediately. Matching symptom to taxonomy case is the whole triage skill."
+              }
+            ],
+            "explanation": "Five ways to not-happen: rejection and faucet-decline are pre-network; expiry, preflight, and on-chain error are not. Triage starts with \"did anything reach the network?\" — and a rejection never did."
+          },
+          {
+            "id": "q7",
+            "prompt": "You inherit a codebase importing @solana/web3.js v1 everywhere and are asked to add one new feature. Per this course, the sound approach is?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "Read the v1 code fluently with THE MAP, write your addition in Kit, and keep the seam explicit — never write new v1",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "Rewrite the whole codebase to Kit first",
+                "correct": false,
+                "feedback": "A full rewrite is rarely on offer, and fluent READING is what makes the incremental path viable — v1 still out-downloads Kit (~2.1M vs ~1.65M weekly), so the wild will look like this for years."
+              },
+              {
+                "id": "c",
+                "label": "Match the codebase and write the feature in v1 for consistency",
+                "correct": false,
+                "feedback": "Consistency with a superseded stack is how codebases calcify. The course rule: read v1 fluently, write Kit only — new code on the current stack, seam acknowledged."
+              }
+            ],
+            "explanation": "The seam is a fact of the ecosystem (npm's latest tag still ships v1), so the professional skill is asymmetric fluency: read the old world, write the new one."
+          },
+          {
+            "id": "q8",
+            "prompt": "Your inspector queries an address and gets { value: null }, but the explorer shows the account exists. Both tools are working correctly. What single difference between the two reads explains it?",
+            "multiSelect": false,
+            "options": [
+              {
+                "id": "a",
+                "label": "They asked different clusters — the RPC endpoint your client was built with and the explorer's ?cluster parameter decide which chain answers",
+                "correct": true,
+                "feedback": null
+              },
+              {
+                "id": "b",
+                "label": "The explorer caches accounts that were later deleted",
+                "correct": false,
+                "feedback": "Both read live. When two correct tools disagree about existence, they are almost certainly not looking at the same chain — the endpoint in createSolanaRpc vs the cluster in the explorer URL."
+              },
+              {
+                "id": "c",
+                "label": "getAccountInfo requires the account's owner to sign the request",
+                "correct": false,
+                "feedback": "All account reads are public and unsigned — that openness is what made this whole course possible in a browser. The mismatch is the cluster, the very first trap lesson 1 set."
+              }
+            ],
+            "explanation": "The course's bookend bug: lesson 1's ?cluster=devnet and your RPC endpoint are the same decision expressed twice. Every \"it does not exist\" report is a claim about ONE chain — always know which one you asked."
+          }
+        ],
+        "prompt": null,
+        "maxWords": null,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "reflect",
+        "_type": "openEnded",
+        "produces": null,
+        "consumes": null,
+        "src": null,
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": null,
+        "prompt": "In at most 150 words: which single artifact from this course does Course 2 pick up, and why must the Rust struct you will write match your lesson-2 decoder byte for byte? Name the concrete failure you would see in your own inspector if it didn't.",
+        "maxWords": 150,
+        "amount": null,
+        "network": null,
+        "idl": null
+      },
+      {
+        "key": "next",
+        "_type": "prose",
+        "produces": null,
+        "consumes": null,
+        "src": "# What Happens Next\n\nCourse 2 — *Rust for Program Developers* — starts from the sentence this course ends on: the account bytes your inspector decoded came from a struct someone wrote in Rust, and next it is you writing it. You will compile real Rust on a build server (nothing installed, same as here), learn ownership and borrowing against account-shaped code rather than toy examples, and finish holding `vault_core.rs` — the `VaultState` struct whose serialized bytes are exactly the 49 your decoder reads, with checked arithmetic so a balance can never silently wrap. Your funded wallet rests until Course 3; your inspector waits to be pointed at a vault whose program you wrote yourself.\n",
+        "url": null,
+        "language": null,
+        "buildType": null,
+        "deployable": null,
+        "starter": null,
+        "solution": null,
+        "tests": null,
+        "hints": null,
+        "questions": null,
         "prompt": null,
         "maxWords": null,
         "amount": null,

--- a/apps/web/src/lib/content/__tests__/fixtures/golden/paths.json
+++ b/apps/web/src/lib/content/__tests__/fixtures/golden/paths.json
@@ -65,7 +65,7 @@
     "description": "The complete path from zero to Solana developer. Start with the fundamentals, understand how the network works, and build your first on-chain program.",
     "slug": "solana-core",
     "tag": "Foundation",
-    "order": 1,
+    "order": 8,
     "difficulty": "beginner",
     "courses": []
   },
@@ -78,6 +78,97 @@
     "order": 1,
     "difficulty": "beginner",
     "courses": [
+      {
+        "_id": "course-solana-for-web-devs",
+        "title": "Solana for Web Devs",
+        "slug": "solana-for-web-devs",
+        "description": "You already write JavaScript or TypeScript. That is the whole prerequisite — no blockchain, no cryptography, no Rust, nothing installed. This course runs entirely in your browser against a real, frozen program on Solana's devnet. You start by reading its live vault account in an explorer, then decode its 49 raw bytes by hand — discriminator, owner, balance, bump — then reproduce its address from seeds, so an on-chain account stops being a mystery and becomes a byte layout you own. Then you sign: transaction anatomy with the exact fee arithmetic, a funded devnet wallet of your own, and a real deposit into the vault, confirmed on-chain with the signature to prove it. You finish by assembling everything into a working account inspector — paste any devnet address, get type, SOL, owner, rent-exemption, and decoded vault fields with every failure path handled. Everything is taught against `@solana/kit` 7.0.0, the current stack; one lesson maps it against the legacy web3.js v1 code you will still meet in the wild, with dates and download counts, so you can read old codebases without writing like them. Version stamp — kit 7.0.0, devnet, authored 2026-07-28.",
+        "difficulty": "beginner",
+        "duration": 6,
+        "thumbnail": null,
+        "creator": "B7o8NfV81HzjuZFWQTTx3Xdvh77Dqoajwib3kWEnvzJF",
+        "tags": [
+          "account-model",
+          "api-currency",
+          "borsh-serialization",
+          "compute-budget",
+          "confirmation",
+          "error-handling",
+          "explorer-reading",
+          "pdas",
+          "rpc",
+          "solana-kit",
+          "transaction-fees",
+          "transactions",
+          "wallet-standard"
+        ],
+        "xpReward": 500,
+        "trackId": 1,
+        "trackLevel": 1,
+        "modules": [
+          {
+            "key": "sfwd-read-the-chain",
+            "title": "Read the Chain",
+            "description": "Point at a real devnet program and take its state apart. You read the live vault in an explorer without writing a line of code, then fetch the same account over RPC and decode its 49 bytes by hand — 8-byte discriminator, 32-byte owner, little-endian u64 balance, bump — and then reproduce the vault's address from its seeds and watch a wrong seed order produce a different address. You end holding a working `decodeVault` you wrote yourself, over bytes recorded from the real account. That decoder is the core of the inspector you ship in module 3, and the exact layout that becomes a Rust struct in Course 2.",
+            "lessons": [
+              {
+                "_id": "lesson-sfwd-see-a-live-vault",
+                "title": "See a Live Vault",
+                "slug": "see-a-live-vault"
+              },
+              {
+                "_id": "lesson-sfwd-accounts-are-just-bytes",
+                "title": "Accounts Are Just Bytes",
+                "slug": "accounts-are-just-bytes"
+              },
+              {
+                "_id": "lesson-sfwd-derive-the-vault-pda",
+                "title": "Derive the Vault PDA",
+                "slug": "derive-the-vault-pda"
+              }
+            ]
+          },
+          {
+            "key": "sfwd-sign-your-own-transaction",
+            "title": "Sign Your Own Transaction",
+            "description": "Stop reading and start writing. You take a complete Kit transaction apart and predict its exact cost before it runs — 5,000 lamports per signature plus price times the REQUESTED compute-unit limit — then map the current stack against the legacy web3.js v1 code that still floods npm and every old codebase, so you can read the wild without importing it. Then the real thing: connect a wallet through Wallet Standard, fund it on devnet, and sign a deposit into the very vault you spent module 1 decoding — accounts in IDL order, discriminator plus little-endian amount, confirmed on-chain with an explorer signature on your profile.",
+            "lessons": [
+              {
+                "_id": "lesson-sfwd-anatomy-of-a-transaction",
+                "title": "Anatomy of a Transaction",
+                "slug": "anatomy-of-a-transaction"
+              },
+              {
+                "_id": "lesson-sfwd-kit-or-legacy",
+                "title": "Kit, or What You'll Find in the Wild",
+                "slug": "kit-or-legacy"
+              },
+              {
+                "_id": "lesson-sfwd-connect-fund-and-send",
+                "title": "Connect, Fund, and Send It",
+                "slug": "connect-fund-and-send"
+              }
+            ]
+          },
+          {
+            "key": "sfwd-publish-the-inspector",
+            "title": "Publish the Inspector",
+            "description": "Assemble RPC read, byte decode, and PDA derivation into one working inspector: give it any devnet address and it answers — account type, SOL, owner, rent-exemption, and decoded vault fields when the owner and discriminator check out. The grade lives in the failure paths: accounts that do not exist, accounts with no data, accounts that only look like vaults. Two graded rungs — first complete the branch table, then write the decode path unaided against fixtures recorded from real devnet accounts. Close by naming every artifact you built and exactly which one Course 2 picks up.",
+            "lessons": [
+              {
+                "_id": "lesson-sfwd-ship-the-inspector",
+                "title": "Ship the Inspector",
+                "slug": "ship-the-inspector"
+              },
+              {
+                "_id": "lesson-sfwd-what-you-built",
+                "title": "What You Built",
+                "slug": "what-you-built"
+              }
+            ]
+          }
+        ]
+      },
       {
         "_id": "course-rust-for-program-devs",
         "title": "Rust for Program Developers",

--- a/apps/web/src/lib/content/__tests__/fixtures/golden/quests-raw.json
+++ b/apps/web/src/lib/content/__tests__/fixtures/golden/quests-raw.json
@@ -38,7 +38,17 @@
     "lesson-sap-payment-rails-decision-map",
     "lesson-sap-recurring-delegation-paid-tier",
     "lesson-sap-subscription-authority-and-allowance",
-    "lesson-sap-token-or-token-2022"
+    "lesson-sap-token-or-token-2022",
+    "lesson-sfe-erc20-to-spl",
+    "lesson-sfe-gas-to-compute-units",
+    "lesson-sfe-mappings-to-pdas",
+    "lesson-sfe-rent-and-space",
+    "lesson-sfwd-accounts-are-just-bytes",
+    "lesson-sfwd-anatomy-of-a-transaction",
+    "lesson-sfwd-connect-fund-and-send",
+    "lesson-sfwd-derive-the-vault-pda",
+    "lesson-sfwd-kit-or-legacy",
+    "lesson-sfwd-ship-the-inspector"
   ],
   "moduleLessonMap": [
     {
@@ -158,6 +168,53 @@
       "lessonIds": [
         "lesson-sap-write-the-deep-dive",
         "lesson-sap-submit-and-what-you-built"
+      ]
+    },
+    {
+      "_id": "course-solana-for-evm-devs:sfe-state",
+      "lessonIds": [
+        "lesson-sfe-storage-to-accounts",
+        "lesson-sfe-rent-and-space",
+        "lesson-sfe-mappings-to-pdas"
+      ]
+    },
+    {
+      "_id": "course-solana-for-evm-devs:sfe-execution",
+      "lessonIds": [
+        "lesson-sfe-msg-sender-to-signers",
+        "lesson-sfe-gas-to-compute-units",
+        "lesson-sfe-declared-accounts"
+      ]
+    },
+    {
+      "_id": "course-solana-for-evm-devs:sfe-tokens",
+      "lessonIds": [
+        "lesson-sfe-erc20-to-spl",
+        "lesson-sfe-approve-to-delegate",
+        "lesson-sfe-what-changes"
+      ]
+    },
+    {
+      "_id": "course-solana-for-web-devs:sfwd-read-the-chain",
+      "lessonIds": [
+        "lesson-sfwd-see-a-live-vault",
+        "lesson-sfwd-accounts-are-just-bytes",
+        "lesson-sfwd-derive-the-vault-pda"
+      ]
+    },
+    {
+      "_id": "course-solana-for-web-devs:sfwd-sign-your-own-transaction",
+      "lessonIds": [
+        "lesson-sfwd-anatomy-of-a-transaction",
+        "lesson-sfwd-kit-or-legacy",
+        "lesson-sfwd-connect-fund-and-send"
+      ]
+    },
+    {
+      "_id": "course-solana-for-web-devs:sfwd-publish-the-inspector",
+      "lessonIds": [
+        "lesson-sfwd-ship-the-inspector",
+        "lesson-sfwd-what-you-built"
       ]
     }
   ],

--- a/apps/web/src/lib/content/__tests__/project.golden.test.ts
+++ b/apps/web/src/lib/content/__tests__/project.golden.test.ts
@@ -88,6 +88,26 @@ vi.mock("server-only", () => ({}));
 //    course-completer -> C2 pending C1 (#673)). courses/lessons/paths/summaries/
 //    quests-raw-derived regenerated; achievements-raw patched for the 3
 //    retargets only (rest stays the prod-Sanity capture).
+//  - C1 + EVM elective wave (bump to courses-academy @c5c625e0, PRs #22/#23/
+//    #24/#25/#26/#27): +2 courses / +17 lessons — C1 `course-solana-for-web-devs`
+//    (8 lessons, trackLevel 1) and the off-ladder elective
+//    `course-solana-for-evm-devs` (9 lessons, trackId 0). Bundle is now 6
+//    courses / 66 lessons; BOTH new courses are staged-only (no on-chain
+//    create, no deployment row) so the catalog gate keeps them invisible.
+//    Flip-wave edits: `path-zero-to-deployed` gains C1 in the FRONT slot (the
+//    ladder is now C1→C2→C3→C4→C5); `path-solana-core` order 1 -> 8 (order-1
+//    collision, #23); `achievement-course-completer` retargeted C2 -> C1,
+//    closing the #673 placeholder; `achievement-full-stack-solana` description
+//    reworded to name the Zero to Deployed path. Comprehension reflections
+//    (#848 / courses-academy #26) rewrite 4 openEnded prompts across C4/C5
+//    (3 dsk milestones widen 60 -> 120 words; C5's terminus block re-keys
+//    `submit` -> `reflect` and widens 200 -> 250) so no prompt is URL-only.
+//    C4 code stand-ins fixed for inverted deposit account order (#22), which
+//    also touches lesson-dsk-idl-to-typed-client / -wrap-the-generated-client.
+//    courses/lessons/paths/summaries/quests-raw-derived regenerated from the
+//    bundle through the real projectors (existing doc order preserved, new
+//    docs appended, raw quest docs untouched); achievements-raw patched for
+//    the course-completer retarget + the full-stack description only.
 const deps = { lessonsById };
 
 function bundleCourse(id: string): CourseDoc {

--- a/apps/web/src/lib/gamification/__tests__/path-completion-sync-gate.test.ts
+++ b/apps/web/src/lib/gamification/__tests__/path-completion-sync-gate.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/supabase/admin", () => ({ createAdminClient: () => ({}) }));
+
+// The ONE seam this suite controls: which courses are synced+active. Everything
+// else — learning-path membership, per-course lesson counts — comes from the
+// REAL committed bundle through the REAL queries, because the regression this
+// file locks in only appears when real path membership meets the sync gate.
+// `isSynced` itself stays real (it IS the gate under test).
+const deployments = new Map<string, { status: string; is_active: boolean }>();
+vi.mock("@/lib/content/deployments", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/lib/content/deployments")>();
+  return {
+    ...actual,
+    getActiveDeployments: vi.fn(async () => deployments),
+  };
+});
+
+import { buildUserState } from "../achievements";
+
+/** The live path this wave touches, and its real bundle membership. */
+const PATH = "path-zero-to-deployed";
+const C1 = "course-solana-for-web-devs";
+const LIVE_MEMBERS = [
+  "course-rust-for-program-devs",
+  "course-building-first-program",
+  "course-dapp-sdk-kit",
+  "course-stablecoin-payments",
+];
+
+function sync(...courseIds: string[]) {
+  deployments.clear();
+  for (const id of courseIds)
+    deployments.set(id, { status: "synced", is_active: true });
+}
+
+/**
+ * Minimal chainable stand-in for the service-role client. Awaiting a chain
+ * yields the list result; `.single()` yields the row result. `profiles` is read
+ * both ways (row for `created_at`, count for `userNumber`), which is exactly
+ * why the two are separate.
+ */
+function makeAdmin(completedCourseIds: readonly string[]) {
+  const results: Record<string, { row?: unknown; list?: unknown }> = {
+    user_xp: { row: { data: { current_streak: 0 } } },
+    user_progress: { list: { data: [] } },
+    enrollments: {
+      list: {
+        data: completedCourseIds.map((course_id) => ({
+          course_id,
+          completed_at: "2026-07-30T00:00:00Z",
+        })),
+      },
+    },
+    community_stats: { row: { data: null } },
+    profiles: {
+      row: { data: { created_at: "2026-01-01T00:00:00Z" } },
+      list: { count: 1, data: [] },
+    },
+  };
+
+  const from = (table: string) => {
+    const res = results[table] ?? {};
+    const chain = {
+      select: () => chain,
+      eq: () => chain,
+      lte: () => chain,
+      single: () => Promise.resolve(res.row ?? { data: null }),
+      then: (onOk: (v: unknown) => unknown, onErr?: (e: unknown) => unknown) =>
+        Promise.resolve(res.list ?? { data: [] }).then(onOk, onErr),
+    };
+    return chain;
+  };
+
+  return { from } as unknown as Parameters<typeof buildUserState>[0];
+}
+
+beforeEach(() => deployments.clear());
+
+describe("buildUserState — path completion is gated by the sync set (#892)", () => {
+  it("an UNSYNCED member does not block the path for a learner who finished every live member", async () => {
+    // The exact shape this content wave introduces: C1 is staged into the live
+    // path but has no on-chain deployment row. RED before the fix — the raw
+    // `path.courseIds.every(...)` required C1, which can never enter
+    // `completedCourseIds` (that set is synced+active-only), so the path — and
+    // `achievement-full-stack-solana` with it — became unsatisfiable.
+    sync(...LIVE_MEMBERS);
+    const state = await buildUserState(makeAdmin(LIVE_MEMBERS), "user-1");
+
+    expect(state.completedCourseIds.has(C1)).toBe(false);
+    expect(state.completedPathIds.has(PATH)).toBe(true);
+  });
+
+  it("a path whose synced membership is EMPTY never counts as completed", async () => {
+    // Guards the vacuous `.every([])  === true` case: with nothing synced, the
+    // filtered membership is empty and the path must NOT complete — not even
+    // for a learner credited with every course in it.
+    sync();
+    const state = await buildUserState(
+      makeAdmin([C1, ...LIVE_MEMBERS]),
+      "user-2"
+    );
+
+    expect(state.completedPathIds.has(PATH)).toBe(false);
+  });
+
+  it("a SYNCED member that is unfinished still blocks the path", async () => {
+    // The gate loosens membership, never the completion requirement.
+    sync(C1, ...LIVE_MEMBERS);
+    const state = await buildUserState(makeAdmin(LIVE_MEMBERS), "user-3");
+
+    expect(state.completedPathIds.has(PATH)).toBe(false);
+  });
+});

--- a/apps/web/src/lib/gamification/achievements.ts
+++ b/apps/web/src/lib/gamification/achievements.ts
@@ -6,6 +6,7 @@ import {
   type AwardT,
 } from "@superteam-lms/content-schema";
 import { createAdminClient } from "@/lib/supabase/admin";
+import { getActiveDeployments, isSynced } from "@/lib/content/deployments";
 import {
   getAllAchievements,
   getAllCourseLessonCounts,
@@ -115,6 +116,7 @@ export async function buildUserState(
     { data: userProfile },
     courseLessonCounts,
     learningPaths,
+    deployments,
   ] = await Promise.all([
     admin
       .from("user_xp")
@@ -134,6 +136,7 @@ export async function buildUserState(
     admin.from("profiles").select("created_at").eq("id", userId).single(),
     getAllCourseLessonCounts(),
     getLearningPathsForAdmin(),
+    getActiveDeployments(),
   ]);
 
   // Per-course completed-lesson counts.
@@ -160,11 +163,28 @@ export async function buildUserState(
 
   // A path is complete when every course it references is complete (real
   // learningPath membership — replaces the hardcoded SOLANA_DEV_PATH_COURSES).
+  //
+  // Membership is gated through the SAME `isSynced` chokepoint the catalog and
+  // `getAllLearningPaths` use (queries.ts): `getLearningPathsForAdmin` returns
+  // RAW `courseIds` (the admin panel needs the full list), but a learner can
+  // only ever complete a course that is synced+active — `completedCourseIds` is
+  // derived from `getAllCourseLessonCounts`, which is synced+active-only. Left
+  // ungated, staging an unsynced course into an already-live path would make
+  // that path's `path-completed` achievement permanently unsatisfiable until
+  // the course ships on-chain, retroactively breaking learners who already
+  // finished every live member (found on the C1 wave, PR #892; the trap re-arms
+  // on every future wave that adds a member to a live path).
+  //
+  // A path whose synced membership is EMPTY must not count as completed — the
+  // `length > 0` guard keeps `.every()` from being vacuously true.
   const completedPathIds = new Set<string>();
   for (const path of learningPaths) {
+    const syncedCourseIds = path.courseIds.filter((cid) =>
+      isSynced(deployments.get(cid))
+    );
     if (
-      path.courseIds.length > 0 &&
-      path.courseIds.every((cid) => completedCourseIds.has(cid))
+      syncedCourseIds.length > 0 &&
+      syncedCourseIds.every((cid) => completedCourseIds.has(cid))
     ) {
       completedPathIds.add(path._id);
     }


### PR DESCRIPTION
Activates everything staged in `solanabr/courses-academy` since the last pin:
`9b1f03e6` → **`c5c625e03b23f6ce527da884456f7b2d36c26bed`**.

## Counts

| | before (`9b1f03e6`) | after (`c5c625e0`) | Δ |
|---|---|---|---|
| courses | 4 | **6** | +2 |
| lessons | 49 | **66** | +17 |
| learningPaths | 8 | 8 | — |
| achievements | 10 | 10 | — |
| quests | 5 | 5 | — |
| skills (taxonomy) | 41 | 43 | +2 (`explorer-reading`, `api-currency`) |

6 courses = the 5-course ladder (C1→C2→C3→C4→C5) + 1 off-ladder elective.

## Wave delta

Six upstream PRs land in this pin:

- **#25 — C1 `course-solana-for-web-devs`** (8 lessons, `trackLevel 1`, slots 0–7, `next: 8`). Completes the ladder at the bottom.
- **#24 — elective `course-solana-for-evm-devs`** (9 lessons, `trackId 0`, slots 0–8, `next: 9`). Off-ladder: member of no learning path, so its `learningPath` projects `null`.
- **#26 (#848) — comprehension reflections.** 4 `openEnded` prompts across C4/C5 stop being URL-only: `lesson-dsk-first-signed-deposit`, `lesson-dsk-publish-the-package`, `lesson-dsk-states-errors-and-reads` widen `maxWords` 60 → 120 and append a comprehension question; C5's `lesson-sap-submit-and-what-you-built` re-keys its block `submit` → `reflect`, widens 200 → 250 and swaps the Earn-URL paste for a rail-comparison prompt.
- **#27 — C1 flip wave.** `path-zero-to-deployed` gains C1 in the **front slot** (order is now C1, C2, C3, C4, C5); `achievement-course-completer` retargets `course-rust-for-program-devs` → `course-solana-for-web-devs`, closing the #673 "pending C1" placeholder.
- **#23 — path order-1 collision + achievement record alignment.** `path-solana-core` (draft) `order` 1 → 8 so it stops colliding with the live path; `achievement-full-stack-solana` description reworded to name the Zero to Deployed path.
- **#22 — C4 code-fixture fix** (not in the original wave brief, see *Surprises*): inverted deposit account order in the hand-written client stand-ins, touching `lesson-dsk-idl-to-typed-client`, `lesson-dsk-wrap-the-generated-client` and the code block of `lesson-dsk-first-signed-deposit`.

Doc-level classification of the recompiled bundle: **2 courses added, 17 lessons added, 6 lessons edited, 0 removed**, no id churn, no slot remapping on any existing course (both new courses get fresh `slots.json` entries with empty `retired`).

## Goldens methodology

Regenerated through the **real projectors** (`src/lib/content/project.ts`), never hand-written, per the house pattern:

- `courses.json`, `lessons.json` — existing entries re-projected in place, **existing order preserved**, new docs appended.
- `paths.json` — rebuilt wholesale from bundle membership (`projectLearningPath(bundlePath, resolvedMembers, deps)`), so zero-to-deployed is now C1-first and solana-core carries `order: 8`.
- `course-summaries.json` — `coursesByIds` / `recommended` / `lessonCounts` rebuilt for all 6 courses (alphabetical by `_id`); `learningPath` resolved from real path membership, hence `null` for the EVM elective.
- `quests-raw.json` — derived `challengeLessonIds` / `moduleLessonMap` recomputed via `projectQuestData`; **raw quest docs untouched**.
- `course-by-slug.json` — **unchanged**; its subject (`course-building-first-program`) is not in this wave.
- `achievements-raw.json` — hand-patched for exactly two fields (`course-completer.award.course`, `full-stack-solana.description`) in both the `all` and `deployed` arrays; the rest stays the frozen prod-Sanity capture.

Before rewriting anything, every pre-existing golden doc was re-projected against the new bundle to find unexplained drift. The **only** docs that diverged were the 6 intentionally-edited lessons above — no silent absorption. The wave delta is documented in the `project.golden.test.ts` header, as with every prior wave.

## E2E impact

`e2e/harness/fixtures.mjs` models the **active** catalog. C1 and the EVM elective have no `public_onchain_deployments` row, so they land in the existing "no row → ABSENT" bucket and the fixture needs no new entries. **Verified, not asserted**: the full Playwright suite was run against a production build — `catalog.spec.ts`, `learn-loop.spec.ts` and `o4-journey.spec.ts` all pass unchanged (`unsubscribe.spec.ts` stays skipped pending #769). The only edit to the file is a stale comment that still described the bundle as "the live 4-course ladder".

## Verification

- `pnpm compile-content` → `Emitted 8 modules`, counts as tabled above
- `pnpm typecheck` → 6/6 tasks green
- `pnpm --filter web test` → **244 files / 2217 tests passed**
- `pnpm lint` → green (pre-existing `import/order` warnings only)
- `pnpm --filter web e2e` → 3 passed, 2 skipped
- `prettier --check` on every touched file → clean

## Visibility

**C1 and the EVM elective stay INVISIBLE to learners on merge.** The catalog gate (`lib/content/deployments.ts`, one `isSynced` chokepoint) shows a course only when it has a `public_onchain_deployments` row that is `status === "synced"` **and** `is_active !== false`. Neither course has been created on-chain, so neither has a row, and the gate is fail-closed. This bump only *stages* them; they surface when the owner runs the on-chain course create. The flip-wave edits that touch already-live content (path ordering, the `course-completer` retarget, the reflection prompts) DO take effect on deploy.

**Do not merge** — opened for review.

## Surprises

1. **An extra upstream PR rode along.** The brief described 4 upstream changes; the range actually contains 6. courses-academy #22 (C4 inverted deposit account order) and #23 (path order-1 collision + achievement record alignment) also land here. Both are small, well-scoped content fixes and are folded into the wave note rather than dropped — but they were not in the brief.
2. **6 lessons edited, not 4.** #848's reflection rewrites cover 4 lessons; #22's code fix covers 3, overlapping on `lesson-dsk-first-signed-deposit`.
3. **`achievements-raw` needed a second patch.** The brief scoped it to the `course-completer` retarget only, but #23 also reworded `full-stack-solana`'s description, which `projectAchievement` compares — leaving it would have failed the golden. Patched and documented.
4. **A block `_key` changed** (`submit` → `reflect` on `lesson-sap-submit-and-what-you-built`). Grepped the app for hardcoded block keys: none — blocks are addressed structurally, so this is inert. Worth knowing if any learner-progress record ever keys on block `_key`.
5. **Only 2 new skills.** The EVM course contributed no new taxonomy entries; `explorer-reading` and `api-currency` both come from C1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
