### PR TITLE
feat(start): segments 1/3 enter at C1 — lint gate 19b flip blocked, evidence inside (#673, #676)

### DIFF
--- a/apps/web/src/lib/courses/__tests__/entry-course-live.test.ts
+++ b/apps/web/src/lib/courses/__tests__/entry-course-live.test.ts
@@ -59,6 +59,18 @@ vi.mock("@/lib/content/deployments", async (importActual) => {
 const SEGMENTS: LearnerSegment[] = [1, 2, 3];
 const LESSON_HREF = /^\/en\/courses\/[^/]+\/lessons\/[^/]+$/;
 
+/**
+ * The post-C1-flip routing table (#673, 2026-07-30). Duplicated here on purpose
+ * — asserting the resolver against a literal expectation is what makes an
+ * unintended table edit red. Segments 1/3 enter at C1 (the JS/TS on-ramp, live
+ * on-chain since the flip wave); segment 2 still skips it and enters at C3.
+ */
+const EXPECTED_ENTRY: Record<LearnerSegment, string> = {
+  1: "course-solana-for-web-devs",
+  2: "course-building-first-program",
+  3: "course-solana-for-web-devs",
+};
+
 // The 5 courses CATALOG §3 retires (deactivated on-chain). No segment may enter
 // at one of these — this is the exact class that broke the /start deep-link.
 const RETIRED_COURSE_IDS = new Set([
@@ -70,6 +82,15 @@ const RETIRED_COURSE_IDS = new Set([
 ]);
 
 describe("SEGMENT_ENTRY_COURSE — live-ladder routing", () => {
+  it("segments 1 and 3 enter at C1, segment 2 at C3", () => {
+    for (const segment of SEGMENTS) {
+      expect(
+        entryCourseForSegment(segment),
+        `segment ${segment} entry course`
+      ).toBe(EXPECTED_ENTRY[segment]);
+    }
+  });
+
   it("no segment enters at a retired course", () => {
     for (const segment of SEGMENTS) {
       const id = entryCourseForSegment(segment);

--- a/apps/web/src/lib/courses/learner-segment.ts
+++ b/apps/web/src/lib/courses/learner-segment.ts
@@ -64,21 +64,21 @@ export const SEGMENT_PATH_MODALITY: Record<
  * `resolveEntryLessonHref` sync gate keeps that from 404-ing, but the deep-link
  * into flagship lesson 1 goes dead — the regression this table fixes.
  *
- *   1 — CORE web2 (ships JS/TS, new to Solana) → C2 rust-for-program-devs (†)
+ *   1 — CORE web2 (ships JS/TS, new to Solana) → C1 solana-for-web-devs (†)
  *   2 — web3 dev (already ships on-chain)       → C3 building-your-first-solana-program (segment 2 "enters here", skips the on-ramp)
- *   3 — beginner (new to programming)           → C2 rust-for-program-devs (†) (shares segment 1's entry)
+ *   3 — beginner (new to programming)           → C1 solana-for-web-devs (†) (shares segment 1's entry)
  *
- * (†) TODO(#599/#673): segments 1 and 3 should enter at C1
- * `course-solana-for-web-devs` (the JS/TS on-ramp) once it lands on-chain — it
- * is not in the committed bundle yet, so today they enter at the live entry
- * rung C2. When C1 lands, only these two lines move. Segment 3 stays out of
- * scope this wave (CATALOG §1) but still routes to the live on-ramp rather than
- * a dead course.
+ * (†) FLIPPED 2026-07-30 (#599/#673): segments 1 and 3 now enter at C1
+ * `course-solana-for-web-devs`, the JS/TS on-ramp. C1 is authored, in the
+ * committed bundle, and live on-chain (created + synced + active), so the
+ * placeholder entry at C2 `course-rust-for-program-devs` — which existed only
+ * because C1 did not yet exist — is retired. Segment 2 is unchanged: it still
+ * "enters here" at C3 and skips the on-ramp.
  */
 export const SEGMENT_ENTRY_COURSE: Record<LearnerSegment, string> = {
-  1: "course-rust-for-program-devs",
+  1: "course-solana-for-web-devs",
   2: "course-building-first-program",
-  3: "course-rust-for-program-devs",
+  3: "course-solana-for-web-devs",
 };
 
 export function entryCourseForSegment(segment: LearnerSegment): string {

--- a/packages/content-lint/src/__tests__/gate19.test.ts
+++ b/packages/content-lint/src/__tests__/gate19.test.ts
@@ -129,7 +129,7 @@ describe("gate 19b — minimum reuse bar", () => {
     expect(g[0]?.severity).toBe("warning");
     expect(g[0]?.message).toContain('"staking"');
     expect(g[0]?.message).toContain("courses/x/lessons/a/lesson.yaml");
-    // Warning tier until the 5-course catalog lands (#676) — never fails CI.
+    // Warning tier until the skills.yaml sweep lands (#676) — never fails CI.
     expect(g[0]?.message).toContain("#676");
     expect(r.ok).toBe(true);
   });

--- a/packages/content-lint/src/checks/gate19-skills.ts
+++ b/packages/content-lint/src/checks/gate19-skills.ts
@@ -27,10 +27,10 @@ import { diag, type Diagnostic } from "../diagnostics";
  *                `earn-submission`), which emit nothing. A registry slug applied
  *                to NO lesson is also a warning (dead vocabulary entry).
  *                WARNING tier for now — the reuse bar guards the Wave 3 review
- *                queue, which cannot collect its benefit before the 5-course
- *                catalog (C1–C4) exists; erroring today would block correct
- *                content for a benefit that isn't yet reachable. Flip to error
- *                once the catalog lands — see the TODO at the 19b loop (#676).
+ *                queue. The 5-course catalog has landed, but the paired
+ *                skills.yaml sweep has not, so erroring today would redden
+ *                content CI on main. Flip to error right after that sweep —
+ *                see the TODO at the 19b loop (#676).
  *  19c (warning) interleaving-pair vocabulary: both members of each
  *                REVIEW_INTERLEAVING_PAIRS pair exist in `skills.yaml` and
  *                are applied to ≥2 lessons each. WARNING tier for now: the
@@ -150,16 +150,21 @@ export function gate19Check(model: RepoModel): Diagnostic[] {
 
   // 19b — minimum reuse bar over the registry.
   //
-  // TODO(#676): flip the single-lesson case below from `warning` to `error`
-  // once the 5-course catalog (C1–C4) has landed. The bar exists to guard the
-  // Wave 3 spaced-review queue — a slug behind one lesson can only re-serve
-  // that lesson, never generate a genuine review item. That benefit is
-  // unreachable until the catalog exists, so until then a hard error would
-  // block correct, in-progress content for nothing (course 5's tags are
-  // legitimately single-use *today* and gain a second lesson as C1–C4 fill in).
-  // Warning tier surfaces every under-applied slug honestly on each run without
-  // reddening content CI; `reviewExempt` still silences the by-design
-  // singletons, which is what makes the eventual error-flip clean.
+  // TODO(#676): flip the single-lesson case below from `warning` to `error`.
+  // The bar exists to guard the Wave 3 spaced-review queue — a slug behind one
+  // lesson can only re-serve that lesson, never generate a genuine review item.
+  //
+  // The catalog precondition is now MET: C1–C5 all exist (courses-academy main
+  // c5c625e, 2026-07-30). The remaining blocker is the *sweep* the flip issue
+  // pairs with the tier change, and it lands in the CONTENT repo, not here — an
+  // audit of that commit still reports 30 gate-19b findings (23 single-use
+  // slugs, 7 dead vocabulary entries), so flipping the tier in isolation would
+  // redden content CI on main. Order of operations: land the skills.yaml sweep
+  // in courses-academy (`reviewExempt: true` for the by-design singletons, a
+  // second lesson or consolidation for the rest, delete the dead entries), then
+  // flip this tier. Warning tier surfaces every under-applied slug honestly on
+  // each run in the meantime; `reviewExempt` already silences the by-design
+  // singletons, which is what makes the eventual flip clean.
   for (const entry of registry) {
     const { slug } = entry;
     const uses = lessonsBySlug.get(slug) ?? [];
@@ -182,7 +187,7 @@ export function gate19Check(model: RepoModel): Diagnostic[] {
           "gate-19b",
           "warning",
           SKILLS_FILE,
-          `skill "${slug}" is applied to only 1 lesson (${uses[0]}) — the minimum reuse bar is 2; tag a second lesson, drop the slug, or mark it "reviewExempt: true" in skills.yaml if it is single-use by design. Becomes an error once the 5-course catalog lands (#676)`
+          `skill "${slug}" is applied to only 1 lesson (${uses[0]}) — the minimum reuse bar is 2; tag a second lesson, drop the slug, or mark it "reviewExempt: true" in skills.yaml if it is single-use by design. Becomes an error once the skills.yaml sweep lands (#676)`
         )
       );
     }


### PR DESCRIPTION
Final monorepo step of the C1 flip wave. C1 `course-solana-for-web-devs` is authored (courses-academy #25), in the committed bundle (`meta.json` sha `c5c625e`, 6 courses / 66 lessons) and live on-chain — deployment row synced + active, rendering in the anon catalog.

## 1. Segment flip (#673)

`SEGMENT_ENTRY_COURSE` — segments **1 and 3** flip `course-rust-for-program-devs` → `course-solana-for-web-devs`. Segment 2 is unchanged (`course-building-first-program`; it "enters here" and skips the on-ramp). The `TODO(#599/#673)` becomes a statement of the completed flip.

**Test change + red-proof.** `entry-course-live.test.ts` (the #794-era guard that runs the real resolver against the real bundle) gains an explicit expected-table assertion. Both of its existing invariants are untouched and unweakened:

- no segment enters a retired course
- every segment entry deep-links to a real bundle lesson (not the catalog fallback)

Red-proof — with the **new** test file and the **old** constant restored:

```
× segments 1 and 3 enter at C1, segment 2 at C3
  AssertionError: segment 1 entry course: expected 'course-rust-for-program-devs' to be 'course-solana-for-web-devs'
  Tests  1 failed | 3 passed (4)
```

The `3 passed` is the load-bearing part: under the old table **both original invariants still passed** (C2 is live and non-retired, so it deep-links fine). They could not have detected this flip in either direction — the literal expected table is what pins it, which is precisely why it was added rather than relying on the generic invariants.

With the new constant: `4 passed`.

## 2. Gate 19b (#676) — NOT flipped, with evidence

The instruction on #676 was to flip only if content is clean, and to report violations rather than ship a red gate. **It is not clean.** Running content-lint the CI way (`validate-content.yml` invocation) against **courses-academy main @ c5c625e**:

```
content-lint: OK (58 diagnostics, 0 errors)
  gate-19b: 30 warnings — 23 single-use slugs, 7 dead vocabulary entries
```

Flipping the tier today turns content CI red on main. The issue itself pairs the tier change with a **sweep of the then-current warning list**, and that sweep lives in `skills.yaml` in the **content repo** — it cannot land in this PR. So `#676` stays open and this PR does **not** close it.

What this PR does instead: re-points the stale precondition. The old comment and diagnostic text said "flips once the 5-course catalog lands" — the catalog *has* landed, so that text now reads as satisfied while the gate stays a warning. It now names the real remaining blocker (the skills.yaml sweep) and the order of operations.

<details><summary>The 23 single-use slugs</summary>

| slug | sole lesson |
|---|---|
| `keypairs-wallets` | building-your-first-solana-program/fund-your-wallet |
| `program-testing` | building-your-first-solana-program/pre-flight-check |
| `react` | dapp-and-sdk-with-kit/connect-with-wallet-standard |
| `token-2022` | stablecoin-agentic-payments/token-or-token-2022 |
| `transfer-hook` | stablecoin-agentic-payments/token-or-token-2022 |
| `protocol-versioning` | stablecoin-agentic-payments/pay-the-402-programmatically |
| `version-pinning` | stablecoin-agentic-payments/write-the-deep-dive |
| `solana-pay` | stablecoin-agentic-payments/payment-rails-decision-map |
| `api-monetization` | stablecoin-agentic-payments/meter-an-endpoint-with-x402 |
| `subscriptions-program` | stablecoin-agentic-payments/write-the-deep-dive |
| `subscription-authority` | stablecoin-agentic-payments/subscription-authority-and-allowance |
| `recurring-delegation` | stablecoin-agentic-payments/recurring-delegation-paid-tier |
| `rust-control-flow` | rust-for-program-devs/functions-and-control-flow |
| `rust-move-semantics` | rust-for-program-devs/moves-copy-and-clone |
| `rust-slices` | rust-for-program-devs/lifetimes-and-slices |
| `rust-modules` | rust-for-program-devs/build-the-vault-core |
| `compiler-errors` | rust-for-program-devs/fix-the-borrow-checker |
| `build-server` | rust-for-program-devs/your-first-rust-build |
| `toolchain-versions` | rust-for-program-devs/your-first-rust-build |
| `client-codegen` | dapp-and-sdk-with-kit/idl-to-typed-client |
| `semver` | dapp-and-sdk-with-kit/package-surface-and-readme |
| `ci` | dapp-and-sdk-with-kit/publish-the-package |
| `simulation` | dapp-and-sdk-with-kit/simulate-before-you-send |

Note `react` is also a `NON_REVIEW_ELIGIBLE_SKILLS` facet (gate 19d notice) — a candidate for `reviewExempt` rather than a second tagging.

</details>

<details><summary>The 7 dead vocabulary entries (0 lessons)</summary>

`defi`, `amm`, `lending`, `staking`, `oracles`, `wallet-adapter`, `siws` — all survivors of the retired-course sweep (CATALOG §3). Deletion candidates.

</details>

## Verification

| check | result |
|---|---|
| `pnpm typecheck` | 6/6 successful |
| `apps/web` vitest (full suite) | **245 files / 2221 tests passed** |
| `packages/content-lint` vitest | 17 files / 107 tests passed |
| `pnpm lint` | successful (pre-existing `import/order` warnings only, 0 errors) |
| `prettier --check` on changed files | clean |
| content-lint vs courses-academy main (CI invocation) | `OK (58 diagnostics, 0 errors)` |

Refs #676. Does **not** close it — the tier flip is still pending the content-repo skills.yaml sweep.
Part of #673's flip checklist; #673 closes manually with the wave summary after this merges.
