### PR TITLE
docs(analytics): P0D-4 post-mint-cliff metric definition + LX-F1 event-pass closure (#872, #873)

### DIFF
--- a/apps/web/src/app/[locale]/(platform)/certificates/[id]/__tests__/page.test.tsx
+++ b/apps/web/src/app/[locale]/(platform)/certificates/[id]/__tests__/page.test.tsx
@@ -1,9 +1,9 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import { NextIntlClientProvider } from "next-intl";
-import CertificateViewPage from "../page";
 import messages from "@/messages/en.json";
+import CertificateViewPage from "../page";
 
 vi.mock("next/navigation", () => ({
   useParams: () => ({ id: "cert-1" }),
@@ -167,6 +167,45 @@ describe("certificate verify page — network label from env", () => {
     expect(
       explorerLinks().some((href) => href.endsWith("?cluster=mainnet"))
     ).toBe(false);
+  });
+});
+
+// LX-F1 (#873): the mint_success surface is covered by the share-nudge and
+// earn-card component tests; this closes the second surface — the certificate
+// page — so both `source` values of each click event are pinned by a test.
+describe("certificate verify page — share + Earn instrumentation (LX-F1)", () => {
+  it("fires credential_share_click once per share click, tagged certificate_page", async () => {
+    renderPage();
+
+    fireEvent.click(
+      await screen.findByText(messages.certificates.addToLinkedIn)
+    );
+    expect(trackEvent).toHaveBeenCalledTimes(1);
+    expect(trackEvent).toHaveBeenLastCalledWith("credential_share_click", {
+      channel: "linkedin_add",
+      source: "certificate_page",
+      courseId: "solana-101",
+    });
+
+    fireEvent.click(screen.getByText(messages.certificates.share));
+    expect(trackEvent).toHaveBeenCalledTimes(2);
+    expect(trackEvent).toHaveBeenLastCalledWith("credential_share_click", {
+      channel: "x",
+      source: "certificate_page",
+      courseId: "solana-101",
+    });
+  });
+
+  it("fires earn_handoff_click once, tagged certificate_page", async () => {
+    renderPage();
+
+    fireEvent.click(await screen.findByText(messages.earnHandoff.development));
+    expect(trackEvent).toHaveBeenCalledTimes(1);
+    expect(trackEvent).toHaveBeenCalledWith("earn_handoff_click", {
+      category: "development",
+      source: "certificate_page",
+      courseId: "solana-101",
+    });
   });
 });
 

--- a/apps/web/src/lib/analytics/README.md
+++ b/apps/web/src/lib/analytics/README.md
@@ -112,6 +112,86 @@ goal — never free text (the intake is tap-only).
 | `onboarding_route_accepted` | `{ accepted: boolean, recommendedCourseId }` | `trackOnboardingRouteAccepted()` — E7: recommended entry taken vs "Browse all" override                                                      |
 | `onboarding_completed`      | `{ experience, goal, dailyGoal }`            | `trackOnboardingCompleted()` — intake finished; closed-set ids + daily-goal int, never free text                                             |
 
+## Derived metrics
+
+Metrics that are not events but are **computed from** them. Each entry states
+its numerator, denominator, window, and the exact PostHog recipe, so the insight
+can be rebuilt from this file alone. Every one of them is still subject to the
+10–12 week rule above.
+
+### P0D-4 · 14-day post-mint activity (the post-credential-cliff baseline)
+
+The research documents a cliff: learners mint a credential and go inactive. This
+is the baseline that cliff is measured against, and the number the Earn handoff
+(LX-E4) has to move. Master spec LX-F2; pedagogy #4; RESEARCH-RECONCILIATION §4.
+
+- **Denominator** — distinct users with a `credential_minted` event in the
+  cohort period.
+- **Numerator** — of those, the users with **at least one activity event**
+  strictly after their _first_ `credential_minted` and within 14×24 h of it.
+- **Activity** is the closed set `$pageview`, `lesson_completed`,
+  `challenge_run`, `review_completed`. Deliberately narrow: it is the smallest
+  set that means "came back and did something", and each member already exists
+  in the inventory above. `credential_minted` itself is excluded (a second mint
+  is a different funnel), and so are the share/Earn clicks — those fire in the
+  same session as the mint and would score the cliff as survived.
+- **Window anchor** — the `credential_minted` event's own timestamp, per user.
+  Not a calendar cohort: the 14 days run from each learner's mint moment.
+- **Read as** — `numerator / denominator`, reported per cohort week. The healthy
+  direction is up; a value near zero _is_ the cliff.
+
+**PostHog recipe** (dashboard config is owner territory per LX-F2, so this is
+the recipe to click through, not a checked-in dashboard):
+
+1. New insight → **Retention**.
+2. Cohortizing event: `credential_minted`. Returning event: `$pageview`
+   (repeat the insight once per activity event above, or use "Any event" minus
+   the exclusions if the cliff needs a single headline tile).
+3. Retention type: **first time** (anchors on the learner's first mint).
+4. Granularity **Day**, period **14 days**. Day 0 is the mint itself and is
+   always 100% — the metric is "any of days 1–14", i.e. the union of the
+   non-zero columns, not day 14 alone.
+5. Breakdown by the event property `courseId` to see which credential's holders
+   fall off; breakdown by `source` only to audit coverage (below), never as a
+   learner-facing cut.
+6. Pin the tile with the "do not evaluate before week 10" note.
+
+**Substrate audit** (issue #872): no event changes were needed.
+
+- `credential_minted` already carries everything the insight consumes —
+  the mint moment (event timestamp), the person (PostHog `distinct_id` from
+  `identifyUser()`), and `courseId` for the breakdown.
+- The mint address / certificate id is **deliberately not added**. It buys the
+  insight nothing — the retention anchor is the timestamp, not the asset — while
+  a wallet-adjacent on-chain identifier in a payload cuts against the zero-PII
+  rule above. Join `certificates.mint_address` server-side if a specific
+  credential ever has to be identified.
+- The activity side needs no new events either: all four members of the set
+  above already fire.
+
+**Coverage caveat.** `credential_minted` is a client event, but the mint itself
+is server-side and lands in `certificates` from four paths (the mint route, the
+on-chain retry queue, the Helius webhook handler, admin resync). The client only
+observes two of them — the manual-mint success and the Supabase Realtime
+`certificates` INSERT — so a mint that completes while the learner has no
+subscribed page mounted produces a row with no event, and the PostHog
+denominator can undercount. Reconcile periodically against
+`count(certificates.minted_at)` for the same period; if the gap is material,
+the fix is a server-side capture at the write sites, not a bigger client
+payload. Until then, PostHog is the trend and `certificates` is the truth.
+
 ## Planned (not reserved-blocked, just future)
 
 - `review_completed` — SHIPPED (#873). See the inventory table above.
+
+## LX-F1 event pass — complete (#873)
+
+Every event on the master spec's LX-F1 list now fires and is covered by a test.
+One naming divergence is intentional and should not be re-filed as missing: the
+spec's **`linkedin_share_click` shipped as `credential_share_click` with
+`channel: "linkedin_add"`**. Per the owner decision on #552, LinkedIn is a
+profile-entry action (Add-to-Profile), not a share-post, and X is the actual
+social channel — so one event with a `channel` property is the honest shape,
+and a separate LinkedIn-only event would have split the same surface in two.
+Both click events fire from both surfaces (`mint_success` and
+`certificate_page`) and each surface is pinned by a test.


### PR DESCRIPTION
Closes #872
Closes #873

## #872 — P0D-4 (14-day post-mint activity)

The metric had **no written definition** anywhere. Added a `## Derived metrics`
section to `apps/web/src/lib/analytics/README.md`:

- **Denominator**: distinct users with a `credential_minted` event in the cohort period.
- **Numerator**: of those, users with ≥1 activity event strictly after their *first* mint and within 14×24h of it.
- **Activity** = the closed set `$pageview`, `lesson_completed`, `challenge_run`, `review_completed`. `credential_minted` itself and the share/Earn clicks are excluded — the latter fire in the same session as the mint and would score the cliff as survived.
- **Window anchor** = each learner's own mint timestamp, not a calendar cohort.
- **PostHog recipe** written out step by step (Retention insight, cohortizing `credential_minted`, first-time, Day granularity, 14 periods, union of days 1–14 — day 0 is trivially 100%). Dashboard config is owner territory per LX-F2, so the recipe is the deliverable, not a checked-in dashboard.

**Which path was taken on the "add a client `credential_minted` event if none fires today" question: neither — one already fires.** `trackCredentialMinted()` (events.ts) fires from the manual-mint success and the Realtime `certificates` INSERT, session-deduped per course. The substrate audit therefore found **no event changes needed**:

- The insight consumes the mint moment (event timestamp), the person (PostHog `distinct_id` via `identifyUser()`), and `courseId` for the breakdown — all present.
- **The mint address / cert id is deliberately not added.** The retention anchor is the timestamp, not the asset, so it buys the insight nothing, while a wallet-adjacent on-chain identifier in a payload cuts against the module's zero-PII rule. Join `certificates.mint_address` server-side if a specific credential ever has to be named.
- The activity side needs nothing new either — all four events already fire.

**Coverage caveat documented (honest limitation, not a blocker):** the mint is server-side and lands in `certificates` from four paths (mint route, on-chain retry queue, Helius webhook handler, admin resync); the client observes two. A mint completing with no subscribed page mounted produces a row with no event, so the PostHog denominator can undercount. The README says to reconcile against `count(certificates.minted_at)`, and that the fix — if the gap is material — is server-side capture, not a bigger client payload. PostHog is the trend; `certificates` is the truth.

## #873 — LX-F1 closing checklist: **complete**

The issue body (written 07-28) listed three remaining events. All three were already shipped; verified against the code, not the issue text:

| Event | Status |
| --- | --- |
| `review_completed` | Shipped 07-30 by David (`012870d`), `components/review/review-session.tsx` — verified and skipped per instruction |
| `earn_handoff_click` | Shipped in #625, `components/certificates/earn-handoff-card.tsx:42`, both surfaces |
| `linkedin_share_click` | Shipped in #629 as `credential_share_click { channel: "linkedin_add" }`, `lib/credentials/share.ts:84` |

**The naming divergence is intentional and is now documented so it is not re-filed as missing.** Per the owner decision on #552, LinkedIn is a *profile-entry* action (Add-to-Profile deep link), not a share-post, and X is the actual social channel — so one event with a `channel` property is the honest shape; a separate LinkedIn-only event would split one surface in two.

So this PR adds **no instrumentation**. It closes the one real gap found: both click events fire from two surfaces (`mint_success`, `certificate_page`), and only `mint_success` was covered by tests. The certificate-page surface fired both events with nothing pinning them.

## Tests

Added to `certificates/[id]/__tests__/page.test.tsx`:
- `credential_share_click` fires **once per click** with `{ channel, source: "certificate_page", courseId }` for both LinkedIn and X (call-count asserted, so a double-fire regression fails).
- `earn_handoff_click` fires **once** with `{ category, source: "certificate_page", courseId }`.

**Red-proof — read this carefully.** These tests are **green at main**, because the code they cover already shipped in #625/#629. A red-at-main proof is not available for #873 and claiming one would be false. Instead the tests were **mutation-proved**: flipping `source` from `"certificate_page"` to `"mint_success"` at both call sites in `page.tsx` turns both new tests red (`2 failed | 9 passed`), and reverting turns them green (`11 passed`). They bite.

## Verification

- `pnpm typecheck` — 6/6 tasks pass
- `apps/web` vitest — **245 files, 2223 tests, all pass**
- `pnpm test:scripts` — 26 pass
- `pnpm lint` — pass (only the two pre-existing `import/order` warnings in `lib/supabase/*.ts`, untouched by this PR)
- prettier clean on both changed files

`lib/analytics/events.ts` was deliberately **not modified** — no new event was warranted, and leaving it untouched avoids conflicting with sibling branches appending to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)