### PR TITLE
feat(email): re-engagement template set + selection logic (#870)

### DIFF
--- a/apps/web/src/lib/email/__tests__/reengagement-selection.test.ts
+++ b/apps/web/src/lib/email/__tests__/reengagement-selection.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect } from "vitest";
+import {
+  selectReengagementEmail,
+  reengagementUnsubscribeUrl,
+  reengagementHeaders,
+  REENGAGEMENT_LEDGER_KINDS,
+  INACTIVITY_THRESHOLD_DAYS,
+  COURSE_NUDGE_MAX_REMAINING,
+  type ReengagementCandidate,
+} from "../reengagement";
+
+// #870 selection logic. The send pipeline is a follow-up (it needs a migration);
+// these tests pin the behaviour the pipeline will depend on.
+
+const candidate = (
+  over: Partial<ReengagementCandidate> = {}
+): ReengagementCandidate => ({
+  reminderOptIn: true,
+  daysInactive: 9,
+  locale: "pt-BR",
+  streakDays: 12,
+  nearlyDone: null,
+  appUrl: "https://app.test",
+  unsubscribeToken: "0f9d0a1e-0000-4000-8000-000000000000",
+  ...over,
+});
+
+const nearlyDone = {
+  courseTitle: "Solana 101",
+  courseSlug: "solana-101",
+  lessonTitle: "Deploy your first program",
+  lessonSlug: "deploy",
+  lessonsRemaining: 1,
+};
+
+describe("selectReengagementEmail — consent gate (fails closed)", () => {
+  it("returns null without REMINDER consent, however lapsed the learner is", () => {
+    expect(
+      selectReengagementEmail(
+        candidate({ reminderOptIn: false, daysInactive: 365 })
+      )
+    ).toBeNull();
+  });
+
+  it("gates on the reminder consent, not marketing — kind=reminders unsubscribe", () => {
+    // These are study nudges about the learner's own progress, so the
+    // purpose-bound consent is the reminder one (#869), and unsubscribing must
+    // clear ONLY that consent — product news survives.
+    const selection = selectReengagementEmail(candidate());
+    expect(selection?.unsubscribeUrl).toContain("kind=reminders");
+    expect(selection?.unsubscribeUrl).not.toContain("kind=marketing");
+    expect(selection?.email.text).toContain(selection?.unsubscribeUrl);
+  });
+
+  it("emits RFC 8058 one-click unsubscribe headers", () => {
+    const url = reengagementUnsubscribeUrl("https://app.test", "tok");
+    expect(reengagementHeaders(url)).toEqual({
+      "List-Unsubscribe": `<${url}>`,
+      "List-Unsubscribe-Post": "List-Unsubscribe=One-Click",
+    });
+  });
+
+  it("URL-encodes the token it puts in the unsubscribe link", () => {
+    expect(reengagementUnsubscribeUrl("https://app.test", "a b&c")).toContain(
+      "token=a%20b%26c"
+    );
+  });
+});
+
+describe("selectReengagementEmail — inactivity threshold", () => {
+  it("returns null below the threshold", () => {
+    expect(
+      selectReengagementEmail(
+        candidate({ daysInactive: INACTIVITY_THRESHOLD_DAYS - 1 })
+      )
+    ).toBeNull();
+  });
+
+  it("selects at exactly the threshold", () => {
+    expect(
+      selectReengagementEmail(
+        candidate({ daysInactive: INACTIVITY_THRESHOLD_DAYS })
+      )?.kind
+    ).toBe(REENGAGEMENT_LEDGER_KINDS.inactive);
+  });
+
+  it("returns null for a non-finite inactivity value", () => {
+    expect(
+      selectReengagementEmail(candidate({ daysInactive: Number.NaN }))
+    ).toBeNull();
+  });
+});
+
+describe("selectReengagementEmail — which template wins", () => {
+  it("prefers the course nudge when a course is one lesson from done", () => {
+    const selection = selectReengagementEmail(candidate({ nearlyDone }));
+    expect(selection?.kind).toBe(REENGAGEMENT_LEDGER_KINDS.courseNudge);
+    expect(selection?.kind).toBe("course_nudge");
+    expect(selection?.email.subject).toBe("Falta uma lição em Solana 101");
+  });
+
+  it("deep-links at the next incomplete lesson in the learner's locale", () => {
+    const selection = selectReengagementEmail(candidate({ nearlyDone }));
+    expect(selection?.email.text).toContain(
+      "https://app.test/pt-BR/courses/solana-101/lessons/deploy"
+    );
+  });
+
+  it("falls back to the generic nudge when the course is not close enough", () => {
+    const selection = selectReengagementEmail(
+      candidate({
+        nearlyDone: {
+          ...nearlyDone,
+          lessonsRemaining: COURSE_NUDGE_MAX_REMAINING + 1,
+        },
+      })
+    );
+    expect(selection?.kind).toBe(REENGAGEMENT_LEDGER_KINDS.inactive);
+    expect(selection?.kind).toBe("reengagement_7d");
+    expect(selection?.email.text).toContain("https://app.test/pt-BR/dashboard");
+  });
+
+  it("ignores a nonsense remaining-count instead of nudging on it", () => {
+    expect(
+      selectReengagementEmail(
+        candidate({ nearlyDone: { ...nearlyDone, lessonsRemaining: 0 } })
+      )?.kind
+    ).toBe(REENGAGEMENT_LEDGER_KINDS.inactive);
+  });
+
+  it("uses an `en` link path for an unknown locale but never crashes", () => {
+    const selection = selectReengagementEmail(candidate({ locale: "de" }));
+    expect(selection?.email.text).toContain("https://app.test/en/dashboard");
+  });
+});
+
+describe("REENGAGEMENT_LEDGER_KINDS", () => {
+  it("pins the exact ledger kinds the follow-up migration must allow", () => {
+    // These strings go into email_reminder_log.kind's CHECK constraint — the
+    // send-pipeline follow-up depends on them not drifting.
+    expect(Object.values(REENGAGEMENT_LEDGER_KINDS)).toEqual([
+      "reengagement_7d",
+      "course_nudge",
+    ]);
+  });
+});

--- a/apps/web/src/lib/email/__tests__/reengagement-templates.test.ts
+++ b/apps/web/src/lib/email/__tests__/reengagement-templates.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect } from "vitest";
+import {
+  reengagementNudgeEmail,
+  courseNudgeEmail,
+  type EmailLocale,
+} from "../templates";
+
+// #870 re-engagement template set (uiux-R17). Own file, like the #869 reminder
+// template, so the families evolve independently.
+
+const LOCALES: readonly EmailLocale[] = ["en", "pt-BR", "es"];
+
+const UNSUB = "https://app.test/api/email/unsubscribe?token=t&kind=reminders";
+
+const nudgeBase = {
+  streakDays: 12,
+  dashboardUrl: "https://app.test/pt-BR/dashboard",
+  unsubscribeUrl: UNSUB,
+};
+
+const courseBase = {
+  courseTitle: "Solana 101",
+  lessonTitle: "Deploy your first program",
+  lessonsRemaining: 1,
+  lessonUrl: "https://app.test/en/courses/solana-101/lessons/deploy",
+  unsubscribeUrl: UNSUB,
+};
+
+describe("reengagementNudgeEmail — three locales", () => {
+  it("renders distinct localized copy for every shipped locale", () => {
+    const subjects = LOCALES.map(
+      (locale) => reengagementNudgeEmail({ ...nudgeBase, locale }).subject
+    );
+    expect(new Set(subjects).size).toBe(3); // no locale silently falls back
+    expect(subjects[0]).toContain("streak");
+    expect(subjects[1]).toContain("sequência");
+    expect(subjects[2]).toContain("racha");
+  });
+
+  it("falls back to English for an unknown or missing locale", () => {
+    const en = reengagementNudgeEmail({ ...nudgeBase, locale: "en" });
+    expect(reengagementNudgeEmail({ ...nudgeBase, locale: null }).subject).toBe(
+      en.subject
+    );
+    expect(reengagementNudgeEmail({ ...nudgeBase, locale: "de" }).subject).toBe(
+      en.subject
+    );
+  });
+
+  it("carries the unsubscribe link in BOTH the HTML and the text body", () => {
+    for (const locale of LOCALES) {
+      const r = reengagementNudgeEmail({ ...nudgeBase, locale });
+      expect(r.text).toContain(UNSUB);
+      // HTML-escaped: the link's `&` becomes `&amp;` in the href.
+      expect(r.html).toContain(UNSUB.replace("&", "&amp;"));
+      expect(r.html).toContain(nudgeBase.dashboardUrl);
+    }
+  });
+
+  it("renders the progress-only variant when there is no streak to mention", () => {
+    const r = reengagementNudgeEmail({
+      ...nudgeBase,
+      locale: "en",
+      streakDays: 0,
+    });
+    expect(r.subject).toBe("Your next lesson is right where you left it");
+    expect(r.html).toContain("Your progress is saved");
+  });
+
+  it("drops a broken streak count rather than rendering it", () => {
+    for (const streakDays of [Number.NaN, -3, 1.5, Number.POSITIVE_INFINITY]) {
+      const r = reengagementNudgeEmail({
+        ...nudgeBase,
+        locale: "en",
+        streakDays,
+      });
+      expect(r.subject).toBe("Your next lesson is right where you left it");
+      expect(r.subject).not.toMatch(/NaN|Infinity/);
+    }
+  });
+
+  it("keeps the copy non-punitive — no loss or guilt framing (research rule)", () => {
+    const banned = [
+      /you lost/i,
+      /don't lose/i,
+      /you failed/i,
+      /perdeu/i,
+      /fracass/i,
+      /perdiste/i,
+    ];
+    for (const locale of LOCALES) {
+      const r = reengagementNudgeEmail({ ...nudgeBase, locale });
+      for (const pattern of banned) {
+        expect(r.text).not.toMatch(pattern);
+      }
+    }
+  });
+});
+
+describe("courseNudgeEmail — three locales", () => {
+  it("renders distinct localized copy for every shipped locale", () => {
+    const subjects = LOCALES.map(
+      (locale) => courseNudgeEmail({ ...courseBase, locale }).subject
+    );
+    expect(new Set(subjects).size).toBe(3);
+    expect(subjects[0]).toBe("One lesson left in Solana 101");
+    expect(subjects[1]).toBe("Falta uma lição em Solana 101");
+    expect(subjects[2]).toBe("Te queda una lección en Solana 101");
+  });
+
+  it("falls back to English for an unknown or missing locale", () => {
+    const en = courseNudgeEmail({ ...courseBase, locale: "en" });
+    expect(courseNudgeEmail({ ...courseBase, locale: null }).subject).toBe(
+      en.subject
+    );
+    expect(courseNudgeEmail({ ...courseBase, locale: "fr" }).subject).toBe(
+      en.subject
+    );
+  });
+
+  it("renders the plural variant and the next-lesson note", () => {
+    const r = courseNudgeEmail({
+      ...courseBase,
+      locale: "pt-BR",
+      lessonsRemaining: 3,
+    });
+    expect(r.subject).toBe("Faltam 3 lições em Solana 101");
+    expect(r.text).toContain("A seguir: Deploy your first program");
+  });
+
+  it("omits the note line when no lesson title is known", () => {
+    const r = courseNudgeEmail({
+      ...courseBase,
+      locale: "en",
+      lessonTitle: "",
+    });
+    expect(r.text).not.toContain("Next up:");
+    expect(r.html).toContain(courseBase.lessonUrl);
+  });
+
+  it("degrades a broken remaining-count to the singular variant", () => {
+    const r = courseNudgeEmail({
+      ...courseBase,
+      locale: "en",
+      lessonsRemaining: Number.NaN,
+    });
+    expect(r.subject).toBe("One lesson left in Solana 101");
+  });
+
+  it("deep-links at the lesson in both bodies", () => {
+    for (const locale of LOCALES) {
+      const r = courseNudgeEmail({ ...courseBase, locale });
+      expect(r.text).toContain(courseBase.lessonUrl);
+      expect(r.html).toContain(courseBase.lessonUrl);
+      expect(r.text).toContain(UNSUB);
+    }
+  });
+});
+
+describe("courseNudgeEmail — untrusted interpolated fields", () => {
+  it("scrubs CR/LF out of the subject so a header line can't be split (#812)", () => {
+    const r = courseNudgeEmail({
+      ...courseBase,
+      locale: "en",
+      courseTitle: "Solana 101\r\nBcc: victim@example.com",
+    });
+    // The injected text survives as inert characters on ONE line — what must
+    // never survive is the newline that would start a second header.
+    expect(r.subject).not.toMatch(/[\r\n]/);
+    expect(r.subject).toBe(
+      "One lesson left in Solana 101  Bcc: victim@example.com"
+    );
+  });
+
+  it("scrubs CR/LF out of the lesson title too", () => {
+    const r = courseNudgeEmail({
+      ...courseBase,
+      locale: "en",
+      lessonTitle: "Deploy\r\nX-Injected: 1",
+    });
+    const noteLine = r.text
+      .split("\n")
+      .find((l) => l.startsWith("Next up:"))
+      ?.trim();
+    // CR and LF each become a space, so the note stays a single text line.
+    expect(noteLine).toBe("Next up: Deploy  X-Injected: 1");
+    expect(r.html).not.toMatch(/Deploy\s*[\r\n]\s*X-Injected/);
+  });
+
+  it("escapes markup in the title and in the URLs it interpolates", () => {
+    const r = courseNudgeEmail({
+      ...courseBase,
+      locale: "en",
+      courseTitle: "<script>alert(1)</script>",
+      lessonUrl: 'https://app.test/"><script>alert(1)</script>',
+    });
+    expect(r.html).not.toContain("<script>");
+  });
+});

--- a/apps/web/src/lib/email/reengagement.ts
+++ b/apps/web/src/lib/email/reengagement.ts
@@ -1,0 +1,243 @@
+/**
+ * Re-engagement selection + render (#870, uiux-R17).
+ *
+ * SCOPE OF THIS MODULE — deliberately pure. It answers exactly one question:
+ * "given what we know about a lapsed learner, which re-engagement email (if
+ * any) should they get, and what does it render to?" It performs no I/O, imports
+ * nothing server-only, and is therefore unit-testable and reusable by whatever
+ * drives the send.
+ *
+ * NOT IN THIS MODULE (and not in this PR) — the send pipeline. See the
+ * SEND-PIPELINE TODO at the bottom: the trigger needs new ledger kinds and claim
+ * RPCs, i.e. a migration, and splitting it out keeps this change migration-free.
+ *
+ * CONSENT — reminder, not marketing. Both templates here are gated on
+ * `email_subscriptions.reminder_opt_in` (unsubscribe `kind=reminders`), the
+ * consent introduced in #869, NOT on the marketing opt-in from #779. Reasoning:
+ * LGPD consent is purpose-bound. These emails are about the learner's OWN study
+ * progress in a course they enrolled in themselves — the same "nudge me about my
+ * studying" purpose they consented to for session reminders. They contain no
+ * promotion, no cross-sell and no product news, which is what the marketing
+ * opt-in covers. So: reminder consent governs, and it FAILS CLOSED — an absent
+ * or false `reminderOptIn` yields `null` here, on top of the SQL-side gate the
+ * eventual claim RPC will enforce (defense in depth, mirroring
+ * `lib/email/reminders.ts`).
+ */
+
+import {
+  reengagementNudgeEmail,
+  courseNudgeEmail,
+  type RenderedEmail,
+} from "./templates";
+
+/**
+ * Ledger kinds for `email_reminder_log.kind`. The #869 ledger was built to take
+ * more families ("Extensible … each family gets its own once-per-day slot"), so
+ * re-engagement adds two kinds rather than a second table. These exact strings
+ * are the contract the follow-up migration must use in its
+ * `chk_email_reminder_log_kind` CHECK and in its claim RPCs.
+ */
+export const REENGAGEMENT_LEDGER_KINDS = {
+  /** (a) N days with no activity anywhere on the platform. */
+  inactive: "reengagement_7d",
+  /** (b) A course sitting one lesson from completion. */
+  courseNudge: "course_nudge",
+} as const;
+
+export type ReengagementKind =
+  (typeof REENGAGEMENT_LEDGER_KINDS)[keyof typeof REENGAGEMENT_LEDGER_KINDS];
+
+/**
+ * Days of inactivity before a learner is eligible. uiux-R17's ~23.5h cadence
+ * governs the timing of a streak reminder; this is the deeper-lapse nudge, and
+ * a week is the shortest gap that reads as "a break" rather than "yesterday".
+ */
+export const INACTIVITY_THRESHOLD_DAYS = 7;
+
+/**
+ * How many incomplete lessons still counts as "you were close". v1 is strictly
+ * the last lesson, per the issue's scope; the template already renders the
+ * plural variant, so widening this is a one-constant change.
+ */
+export const COURSE_NUDGE_MAX_REMAINING = 1;
+
+/** The course a learner is nearly finished with, if any. */
+export interface NearlyDoneCourse {
+  courseTitle: string;
+  courseSlug: string;
+  /** Next incomplete lesson — from `lib/courses/continue-learning.ts`. */
+  lessonTitle: string;
+  lessonSlug: string;
+  /** Lessons still incomplete in that course (>= 1). */
+  lessonsRemaining: number;
+}
+
+/** Everything the selection needs about one candidate learner. */
+export interface ReengagementCandidate {
+  /** REMINDER consent. False/absent ⇒ no email, no exceptions. */
+  reminderOptIn: boolean;
+  /** Days since the learner's last recorded activity. */
+  daysInactive: number;
+  /** Recorded consent locale; unknown/null falls back to `en` copy. */
+  locale: string | null;
+  /** Best recorded streak, purely as a reminder of what they built. 0 = none. */
+  streakDays: number;
+  /** Nearest-to-done enrolled course, or null when there isn't one. */
+  nearlyDone: NearlyDoneCourse | null;
+  /** Absolute app origin — emails need absolute links. No trailing slash. */
+  appUrl: string;
+  /** Per-recipient unsubscribe token (`email_subscriptions.unsubscribe_token`). */
+  unsubscribeToken: string;
+}
+
+export interface ReengagementSelection {
+  /** Ledger kind to claim under, and to log for the R17 template→return metric. */
+  kind: ReengagementKind;
+  email: RenderedEmail;
+  /** The `List-Unsubscribe` target — reminder consent only. */
+  unsubscribeUrl: string;
+}
+
+/** Locale used for link paths (not for copy — the templates fall back on their own). */
+function linkLocale(locale: string | null): string {
+  return locale === "pt-BR" || locale === "es" || locale === "en"
+    ? locale
+    : "en";
+}
+
+/**
+ * One-click unsubscribe target. `kind=reminders` clears REMINDER consent ONLY —
+ * a learner who stops study nudges keeps their product-news preference.
+ */
+export function reengagementUnsubscribeUrl(
+  appUrl: string,
+  token: string
+): string {
+  return `${appUrl}/api/email/unsubscribe?token=${encodeURIComponent(token)}&kind=reminders`;
+}
+
+/**
+ * Pick and render the re-engagement email for one candidate, or `null` when the
+ * learner should not be emailed at all.
+ *
+ * Order matters: the course nudge wins over the generic one because it is the
+ * strictly more specific, more actionable message — a learner one lesson from a
+ * credential should hear about that lesson, not about their dashboard. A learner
+ * never receives both from a single run; the caller claims the returned `kind`.
+ */
+export function selectReengagementEmail(
+  candidate: ReengagementCandidate
+): ReengagementSelection | null {
+  // Consent gate, fail-closed and first.
+  if (!candidate.reminderOptIn) return null;
+  if (
+    !Number.isFinite(candidate.daysInactive) ||
+    candidate.daysInactive < INACTIVITY_THRESHOLD_DAYS
+  ) {
+    return null;
+  }
+
+  const unsubscribeUrl = reengagementUnsubscribeUrl(
+    candidate.appUrl,
+    candidate.unsubscribeToken
+  );
+  const locale = linkLocale(candidate.locale);
+  const near = candidate.nearlyDone;
+
+  if (
+    near &&
+    near.lessonsRemaining >= 1 &&
+    near.lessonsRemaining <= COURSE_NUDGE_MAX_REMAINING
+  ) {
+    return {
+      kind: REENGAGEMENT_LEDGER_KINDS.courseNudge,
+      unsubscribeUrl,
+      email: courseNudgeEmail({
+        locale: candidate.locale,
+        courseTitle: near.courseTitle,
+        lessonTitle: near.lessonTitle,
+        lessonsRemaining: near.lessonsRemaining,
+        lessonUrl: `${candidate.appUrl}/${locale}/courses/${near.courseSlug}/lessons/${near.lessonSlug}`,
+        unsubscribeUrl,
+      }),
+    };
+  }
+
+  return {
+    kind: REENGAGEMENT_LEDGER_KINDS.inactive,
+    unsubscribeUrl,
+    email: reengagementNudgeEmail({
+      locale: candidate.locale,
+      streakDays: candidate.streakDays,
+      dashboardUrl: `${candidate.appUrl}/${locale}/dashboard`,
+      unsubscribeUrl,
+    }),
+  };
+}
+
+/**
+ * Headers every re-engagement send must carry (RFC 8058 one-click unsubscribe),
+ * kept here so the future pipeline cannot ship a send without them.
+ */
+export function reengagementHeaders(
+  unsubscribeUrl: string
+): Record<string, string> {
+  return {
+    "List-Unsubscribe": `<${unsubscribeUrl}>`,
+    "List-Unsubscribe-Post": "List-Unsubscribe=One-Click",
+  };
+}
+
+/*
+ * ─────────────────────────────────────────────────────────────────────────────
+ * TODO — SEND PIPELINE (follow-up issue; intentionally NOT in #870)
+ *
+ * Templates are pure code; the trigger is DB + cron. Shipping the trigger here
+ * would drag a migration into a change that otherwise needs none, so #870 stops
+ * at selection and the pipeline lands separately. The design below is
+ * migration-ready — every name it uses is fixed by this file.
+ *
+ * 1. MIGRATION
+ *    a. Widen `chk_email_reminder_log_kind` (20260731120000_reminder_consent.sql)
+ *       to CHECK (kind IN ('session_plan', 'reengagement_7d', 'course_nudge')).
+ *       The PK (user_id, kind, sent_on) then gives each family its own
+ *       once-per-São-Paulo-day slot for free.
+ *    b. `claim_due_reengagement(p_kind TEXT, p_days INT)` — SECURITY DEFINER,
+ *       search_path '', service_role only, modeled exactly on
+ *       claim_due_session_reminders: ONE statement that reads the recipient set
+ *       and INSERTs its claim rows (ON CONFLICT DO NOTHING RETURNING), so two
+ *       overlapping cron runs cannot both claim a learner. Gate clauses:
+ *         * es.reminder_opt_in = true            ← the consent gate, in SQL
+ *         * real email (NOT LIKE '%@wallet.superteam-lms.local')
+ *         * last activity older than p_days (max(user_progress.completed_at),
+ *           which needs an index on (user_id, completed_at DESC))
+ *         * for 'course_nudge': exactly COURSE_NUDGE_MAX_REMAINING lessons
+ *           incomplete in some enrolled, non-certified course
+ *       ORDER BY user_id, so chunk boundaries — and therefore Resend idempotency
+ *       keys — are reproducible across a retry.
+ *    c. `release_reengagement_claims(p_kind TEXT, p_user_ids UUID[])`.
+ *
+ * 2. FREQUENCY CAP (R17's no-repeat-within-N-days). The per-day PK is not
+ *    enough: a permanently lapsed learner would get a nudge every single day.
+ *    The claim must additionally exclude anyone with a re-engagement row in the
+ *    last N days (N ≈ 14) — a NOT EXISTS over email_reminder_log on the two
+ *    re-engagement kinds. Decide N with the owner before building.
+ *
+ * 3. PIPELINE (`sendReengagementEmails`) — copy lib/email/reminders.ts
+ *    wholesale: isEmailConfigured() fail-closed BEFORE the claim; batch by
+ *    RESEND_MAX_BATCH; per-chunk idempotency key over the day + member ids;
+ *    release a claim ONLY on a provably-rejected batch and HOLD it on an
+ *    ambiguous 5xx/timeout (releasing an ambiguous claim is how a delivered
+ *    email gets sent twice). Selection + render come from
+ *    selectReengagementEmail(); headers from reengagementHeaders().
+ *
+ * 4. CRON — one daily route under app/api/cron/, CRON_SECRET-guarded like
+ *    api/cron/session-reminders, running the course nudge first, then the
+ *    generic one (a learner claimed by the nudge is skipped by the second pass
+ *    via the §2 cap).
+ *
+ * 5. INSTRUMENTATION — R17 requires logging template → return from day one:
+ *    persist the sent `kind` (already the ledger PK) and attribute a return
+ *    visit within 72h, so the rotation can be evaluated rather than guessed.
+ * ─────────────────────────────────────────────────────────────────────────────
+ */

--- a/apps/web/src/lib/email/templates.ts
+++ b/apps/web/src/lib/email/templates.ts
@@ -235,3 +235,341 @@ export function sessionPlanReminderEmail(
 
   return { subject, html, text };
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Re-engagement set (#870, uiux-R17)
+//
+// CONSENT: both templates below are gated on the REMINDER consent
+// (`email_subscriptions.reminder_opt_in`, unsubscribe `kind=reminders`), NOT the
+// marketing one. Reasoning: LGPD consent is purpose-bound, and the purpose here
+// is the learner's OWN study progress — "your streak is waiting", "one lesson
+// left in the course you enrolled in". That is the same purpose the learner
+// consented to when they turned on study reminders (#869); it is not product
+// news, promotion, or cross-sell, which is what the marketing opt-in covers
+// (#779). Gating these on marketing consent would both under-serve consenting
+// learners and stretch the marketing purpose past what was consented to. The
+// gate itself is enforced in SQL by the claim RPC — see the send-pipeline TODO
+// in `lib/email/reengagement.ts`.
+//
+// TONE (research non-punitive rule): no guilt, no shaming, no "you lost", no
+// countdown pressure. The learner's absence is treated as normal and their
+// earned progress is stated as intact. Copy is written natively per locale, not
+// translated from English.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Footer + unsubscribe label shared by every reminder-consent email. */
+interface ReminderFooterCopy {
+  footer: string;
+  unsubscribe: string;
+}
+
+const REENGAGEMENT_FOOTER: Record<EmailLocale, ReminderFooterCopy> = {
+  en: {
+    footer:
+      "You're receiving this because you turned on study reminders for Superteam Academy.",
+    unsubscribe: "Stop these reminders",
+  },
+  "pt-BR": {
+    footer:
+      "Você recebe este e-mail porque ativou os lembretes de estudo da Superteam Academy.",
+    unsubscribe: "Parar estes lembretes",
+  },
+  es: {
+    footer:
+      "Recibes este correo porque activaste los recordatorios de estudio de Superteam Academy.",
+    unsubscribe: "Dejar de recibir recordatorios",
+  },
+};
+
+interface CardParams {
+  eyebrow: string;
+  heading: string;
+  body: string;
+  /** Optional second line under the body (e.g. "Next up: <lesson>"). */
+  note?: string;
+  ctaLabel: string;
+  ctaUrl: string;
+  footer: string;
+  unsubscribeLabel: string;
+  unsubscribeUrl: string;
+}
+
+/**
+ * The shared card shell. Every interpolated value is HTML-escaped here, so a
+ * caller cannot forget: the templates pass RAW strings in and get safe HTML out.
+ */
+function renderCard(p: CardParams): string {
+  const note = p.note
+    ? `<p style="margin:0 0 24px;font-size:15px;line-height:1.6;color:#52525b;">${escapeHtml(p.note)}</p>`
+    : "";
+  return `<!doctype html>
+<html>
+  <body style="margin:0;padding:0;background:#f4f4f5;font-family:-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;">
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="padding:24px 0;">
+      <tr><td align="center">
+        <table role="presentation" width="480" cellpadding="0" cellspacing="0" style="background:#ffffff;border-radius:12px;overflow:hidden;">
+          <tr><td style="padding:32px;">
+            <p style="margin:0 0 8px;font-size:13px;font-weight:700;letter-spacing:.06em;text-transform:uppercase;color:#6366f1;">${escapeHtml(p.eyebrow)}</p>
+            <h1 style="margin:0 0 16px;font-size:22px;line-height:1.3;color:#18181b;">${escapeHtml(p.heading)}</h1>
+            <p style="margin:0 0 ${p.note ? "12px" : "24px"};font-size:15px;line-height:1.6;color:#3f3f46;">${escapeHtml(p.body)}</p>
+            ${note}
+            <a href="${escapeHtml(p.ctaUrl)}" style="display:inline-block;background:#6366f1;color:#ffffff;text-decoration:none;font-weight:600;font-size:15px;padding:12px 22px;border-radius:8px;">${escapeHtml(p.ctaLabel)}</a>
+          </td></tr>
+          <tr><td style="padding:20px 32px;border-top:1px solid #e4e4e7;">
+            <p style="margin:0;font-size:12px;line-height:1.6;color:#a1a1aa;">
+              ${escapeHtml(p.footer)}
+              <a href="${escapeHtml(p.unsubscribeUrl)}" style="color:#71717a;text-decoration:underline;">${escapeHtml(p.unsubscribeLabel)}</a>.
+            </p>
+          </td></tr>
+        </table>
+      </td></tr>
+    </table>
+  </body>
+</html>`;
+}
+
+/**
+ * Clamp a count bound into copy. Anything not a positive, finite, safely small
+ * integer is dropped (returns null) rather than rendered — counts come from
+ * aggregates, and a broken aggregate must not produce "your NaN-day streak".
+ */
+function safeCount(n: number): number | null {
+  if (!Number.isInteger(n) || n <= 0 || n > 100_000) return null;
+  return n;
+}
+
+// ── (a) 7-day inactivity: "come back — your progress is waiting" ─────────────
+
+export interface ReengagementNudgeParams {
+  /** Unknown/absent locale falls back to `en`. */
+  locale: string | null;
+  /**
+   * The learner's best recorded streak, used only as a reminder of what they
+   * already built. 0 (or any non-count) renders the progress-only variant —
+   * we never invent a streak, and we never frame a lapsed one as a loss.
+   */
+  streakDays: number;
+  /** Absolute link back into the app (the learner's continue point). */
+  dashboardUrl: string;
+  /** REQUIRED — per-recipient one-click link that clears REMINDER consent only. */
+  unsubscribeUrl: string;
+}
+
+interface ReengagementCopy {
+  subjectWithStreak: (n: number) => string;
+  subjectNoStreak: string;
+  eyebrow: string;
+  headingWithStreak: (n: number) => string;
+  headingNoStreak: string;
+  body: string;
+  cta: string;
+}
+
+const REENGAGEMENT_COPY: Record<EmailLocale, ReengagementCopy> = {
+  en: {
+    subjectWithStreak: (n) => `Your ${n}-day streak is waiting for you`,
+    subjectNoStreak: "Your next lesson is right where you left it",
+    eyebrow: "Pick up where you left off",
+    headingWithStreak: (n) => `You built a ${n}-day streak`,
+    headingNoStreak: "Your progress is saved",
+    body: "It's been a little while, and that's completely fine — everything you earned is still here. One lesson, about fifteen minutes, and you're moving again.",
+    cta: "Continue learning",
+  },
+  "pt-BR": {
+    subjectWithStreak: (n) =>
+      `Sua sequência de ${n} dias está esperando por você`,
+    subjectNoStreak: "Sua próxima lição está exatamente onde você parou",
+    eyebrow: "Continue de onde parou",
+    headingWithStreak: (n) => `Você construiu uma sequência de ${n} dias`,
+    headingNoStreak: "Seu progresso está salvo",
+    body: "Faz um tempinho, e tudo bem — tudo o que você conquistou continua aí. Uma lição, uns quinze minutos, e você já volta a avançar.",
+    cta: "Continuar estudando",
+  },
+  es: {
+    subjectWithStreak: (n) => `Tu racha de ${n} días te está esperando`,
+    subjectNoStreak: "Tu próxima lección está justo donde la dejaste",
+    eyebrow: "Continúa donde lo dejaste",
+    headingWithStreak: (n) => `Construiste una racha de ${n} días`,
+    headingNoStreak: "Tu progreso está guardado",
+    body: "Pasó un tiempo, y no pasa nada — todo lo que lograste sigue ahí. Una lección, unos quince minutos, y vuelves a avanzar.",
+    cta: "Seguir aprendiendo",
+  },
+};
+
+function pickCopy<T>(table: Record<EmailLocale, T>, locale: string | null): T {
+  return table[(locale ?? "") as EmailLocale] ?? table.en;
+}
+
+/**
+ * "Come back — your progress is waiting" (#870). Sent after
+ * `INACTIVITY_THRESHOLD_DAYS` (see `lib/email/reengagement.ts`) days without
+ * activity, on REMINDER consent.
+ *
+ * Nothing user-authored reaches this template: the only variable is a streak
+ * count, which is shape-checked by {@link safeCount} and, like every subject in
+ * this file, still passed through {@link scrubHeaderValue} (#812).
+ */
+export function reengagementNudgeEmail(
+  params: ReengagementNudgeParams
+): RenderedEmail {
+  const copy = pickCopy(REENGAGEMENT_COPY, params.locale);
+  const footer = pickCopy(REENGAGEMENT_FOOTER, params.locale);
+  const streak = safeCount(params.streakDays);
+  const subject = scrubHeaderValue(
+    streak === null ? copy.subjectNoStreak : copy.subjectWithStreak(streak)
+  );
+  const heading =
+    streak === null ? copy.headingNoStreak : copy.headingWithStreak(streak);
+
+  const html = renderCard({
+    eyebrow: copy.eyebrow,
+    heading,
+    body: copy.body,
+    ctaLabel: copy.cta,
+    ctaUrl: params.dashboardUrl,
+    footer: footer.footer,
+    unsubscribeLabel: footer.unsubscribe,
+    unsubscribeUrl: params.unsubscribeUrl,
+  });
+
+  const text = [
+    subject,
+    "",
+    copy.body,
+    params.dashboardUrl,
+    "",
+    "—",
+    footer.footer,
+    `${footer.unsubscribe}: ${params.unsubscribeUrl}`,
+  ].join("\n");
+
+  return { subject, html, text };
+}
+
+// ── (b) "You were close — one lesson left in <course>" ───────────────────────
+
+export interface CourseNudgeParams {
+  /** Unknown/absent locale falls back to `en`. */
+  locale: string | null;
+  /** Course title — content-authored, but still escaped and scrubbed. */
+  courseTitle: string;
+  /** Title of the next incomplete lesson. Empty string omits the note line. */
+  lessonTitle: string;
+  /** Lessons still incomplete in that course. Non-counts render as 1. */
+  lessonsRemaining: number;
+  /** Absolute deep link at the learner's next incomplete lesson. */
+  lessonUrl: string;
+  /** REQUIRED — per-recipient one-click link that clears REMINDER consent only. */
+  unsubscribeUrl: string;
+}
+
+interface CourseNudgeCopy {
+  subjectOne: (course: string) => string;
+  subjectMany: (n: number, course: string) => string;
+  eyebrow: string;
+  headingOne: (course: string) => string;
+  headingMany: (n: number, course: string) => string;
+  bodyOne: string;
+  bodyMany: string;
+  nextUp: (lesson: string) => string;
+  cta: string;
+}
+
+const COURSE_NUDGE_COPY: Record<EmailLocale, CourseNudgeCopy> = {
+  en: {
+    subjectOne: (c) => `One lesson left in ${c}`,
+    subjectMany: (n, c) => `${n} lessons left in ${c}`,
+    eyebrow: "Almost there",
+    headingOne: (c) => `One lesson left in ${c}`,
+    headingMany: (n, c) => `${n} lessons left in ${c}`,
+    bodyOne:
+      "You're one lesson from the end of this course. It'll still be there whenever you have the time — no rush.",
+    bodyMany:
+      "You're close to the end of this course. Pick it back up whenever it suits you; your progress is exactly where you left it.",
+    nextUp: (l) => `Next up: ${l}`,
+    cta: "Finish the course",
+  },
+  "pt-BR": {
+    subjectOne: (c) => `Falta uma lição em ${c}`,
+    subjectMany: (n, c) => `Faltam ${n} lições em ${c}`,
+    eyebrow: "Quase lá",
+    headingOne: (c) => `Falta uma lição em ${c}`,
+    headingMany: (n, c) => `Faltam ${n} lições em ${c}`,
+    bodyOne:
+      "Falta uma lição para você terminar este curso. Ela vai estar lá quando você tiver tempo — sem pressa.",
+    bodyMany:
+      "Você está perto do fim deste curso. Retome quando for melhor para você; seu progresso está exatamente onde você parou.",
+    nextUp: (l) => `A seguir: ${l}`,
+    cta: "Concluir o curso",
+  },
+  es: {
+    subjectOne: (c) => `Te queda una lección en ${c}`,
+    subjectMany: (n, c) => `Te quedan ${n} lecciones en ${c}`,
+    eyebrow: "Ya casi",
+    headingOne: (c) => `Te queda una lección en ${c}`,
+    headingMany: (n, c) => `Te quedan ${n} lecciones en ${c}`,
+    bodyOne:
+      "Te falta una lección para terminar este curso. Estará ahí cuando tengas tiempo — sin apuro.",
+    bodyMany:
+      "Estás cerca del final de este curso. Retómalo cuando quieras; tu progreso está justo donde lo dejaste.",
+    nextUp: (l) => `A continuación: ${l}`,
+    cta: "Terminar el curso",
+  },
+};
+
+/**
+ * "You were close — one lesson left in <course>" (#870), on REMINDER consent.
+ *
+ * SECURITY: `courseTitle` and `lessonTitle` are content-authored strings that
+ * reach a mail header (the subject) and the HTML body. Both are escaped for the
+ * body by {@link renderCard} and the subject goes through
+ * {@link scrubHeaderValue}, so neither can split a header line (#812) nor inject
+ * markup — the same treatment `newCourseAnnouncementEmail` gives a course title.
+ */
+export function courseNudgeEmail(params: CourseNudgeParams): RenderedEmail {
+  const copy = pickCopy(COURSE_NUDGE_COPY, params.locale);
+  const footer = pickCopy(REENGAGEMENT_FOOTER, params.locale);
+  // A missing/broken remaining-count degrades to the singular variant: the
+  // course nudge only ever fires near the end, so "one left" is the safe read.
+  const remaining = safeCount(params.lessonsRemaining) ?? 1;
+  const one = remaining === 1;
+
+  const subject = scrubHeaderValue(
+    one
+      ? copy.subjectOne(params.courseTitle)
+      : copy.subjectMany(remaining, params.courseTitle)
+  );
+  const heading = one
+    ? copy.headingOne(params.courseTitle)
+    : copy.headingMany(remaining, params.courseTitle);
+  const body = one ? copy.bodyOne : copy.bodyMany;
+  const note = params.lessonTitle
+    ? copy.nextUp(scrubHeaderValue(params.lessonTitle))
+    : undefined;
+
+  const html = renderCard({
+    eyebrow: copy.eyebrow,
+    heading,
+    body,
+    note,
+    ctaLabel: copy.cta,
+    ctaUrl: params.lessonUrl,
+    footer: footer.footer,
+    unsubscribeLabel: footer.unsubscribe,
+    unsubscribeUrl: params.unsubscribeUrl,
+  });
+
+  const text = [
+    subject,
+    "",
+    body,
+    ...(note ? [note] : []),
+    params.lessonUrl,
+    "",
+    "—",
+    footer.footer,
+    `${footer.unsubscribe}: ${params.unsubscribeUrl}`,
+  ].join("\n");
+
+  return { subject, html, text };
+}


### PR DESCRIPTION
Closes #870 (uiux-R17, last child of #845).

## What

The re-engagement email set beyond course-announcement (#779) and session-reminder (#869).

| Template | Trigger | Copy angle |
|---|---|---|
| `reengagementNudgeEmail` | 7 days without activity | "Your progress is saved / your N-day streak is waiting" → dashboard continue point |
| `courseNudgeEmail` | a course sitting 1 lesson from done | "One lesson left in `<course>`" → deep link at the next incomplete lesson |

Both: 3 locales (en / pt-BR / es), copy written natively per locale rather than translated; subject through the existing `scrubHeaderValue` CRLF scrub (#812); every interpolated value HTML-escaped by a shared `renderCard` shell so a caller cannot forget; one-click unsubscribe in the HTML footer, the text body, and the RFC 8058 headers (`reengagementHeaders`).

`lib/email/reengagement.ts` is the pure selection/render layer: `selectReengagementEmail(candidate)` applies the consent gate (fail-closed) and the inactivity threshold, then picks the course nudge over the generic one — a learner one lesson from a credential should hear about that lesson, not about their dashboard. No I/O, no server-only imports.

## Consent: reminder, not marketing

Gated on `email_subscriptions.reminder_opt_in` (#869), unsubscribe `kind=reminders`. LGPD consent is purpose-bound and these are nudges about the learner's **own** study progress in a course they enrolled in themselves — the same "nudge me about my studying" purpose behind session reminders. They carry no promotion, no cross-sell, no product news, which is what the marketing opt-in (#779) covers. Unsubscribing here clears reminder consent only; product news survives. The reasoning is recorded in-code at both the template block and the selection module, and pinned by a test.

## Tone

The research's non-punitive rule is explicit in the copy and enforced by a test that greps the shipped strings for loss/guilt framing in all three locales. Absence is treated as normal ("it's been a little while, and that's completely fine"), earned progress is stated as intact, and there is no countdown or streak-loss threat.

## Scope: templates only — no send pipeline in this PR

Templates are pure code; the trigger is DB + cron. Shipping the trigger here would drag a migration into a change that otherwise needs none, so this PR stops at selection and stays migration-free/mergeable today. The design is migration-ready — every name the follow-up needs is fixed by `reengagement.ts` (`REENGAGEMENT_LEDGER_KINDS`), and the full TODO is at the bottom of that file.

### Follow-up issue scope (send pipeline)

1. **Migration** — widen `chk_email_reminder_log_kind` to `('session_plan','reengagement_7d','course_nudge')` (the #869 ledger was built to take more families; its PK `(user_id, kind, sent_on)` then gives each family its own once-per-São-Paulo-day slot). Add `claim_due_reengagement(p_kind, p_days)` and `release_reengagement_claims(p_kind, p_user_ids)` — SECURITY DEFINER, `search_path ''`, service_role only, modeled exactly on `claim_due_session_reminders` (one statement that reads the recipient set and INSERTs its claim rows, so overlapping cron runs can't double-send). The SQL-side consent gate is `reminder_opt_in = true`. Needs an index on `user_progress (user_id, completed_at DESC)` for the last-activity clause.
2. **Frequency cap** — R17's no-repeat-within-N-days. The per-day PK is not enough: a permanently lapsed learner would otherwise be nudged daily. The claim must additionally exclude anyone with a re-engagement row in the last N days (N ≈ 14, owner decision).
3. **Pipeline** `sendReengagementEmails` — a copy of `lib/email/reminders.ts`: `isEmailConfigured()` fail-closed before the claim, `RESEND_MAX_BATCH` chunks, per-chunk idempotency key over day + member ids, release a claim only on a provably-rejected batch and **hold** it on an ambiguous 5xx/timeout.
4. **Cron** — one daily `CRON_SECRET`-guarded route, course nudge first then the generic pass.
5. **Instrumentation** — R17 requires logging template → return from day one: persist the sent `kind` (already the ledger PK) and attribute a return visit within 72h.

## Verification

- `pnpm typecheck` — 6/6 tasks pass
- `pnpm lint` — pass (only pre-existing `import/order` warnings elsewhere)
- `apps/web` vitest — **253 files / 2345 tests pass**, including 28 new tests across `reengagement-templates.test.ts` (3-locale rendering, en fallback, unsubscribe in both bodies, streak/plural variants, broken-count degradation, CRLF scrub on `courseTitle` + `lessonTitle`, markup escaping, non-punitive copy) and `reengagement-selection.test.ts` (consent fails closed, `kind=reminders` correctness, threshold boundary, template precedence, deep-link path, ledger-kind pinning)
- `pnpm test:scripts` — 26/26 pass
