### PR TITLE
feat(content-lint): explicit `retired` path flag; error on implicit retirement (#627)

### DIFF
--- a/apps/web/src/components/course/__tests__/paths-view.test.tsx
+++ b/apps/web/src/components/course/__tests__/paths-view.test.tsx
@@ -4,9 +4,9 @@ import { describe, it, expect, vi } from "vitest";
 import { render, screen, fireEvent, within } from "@testing-library/react";
 import { NextIntlClientProvider } from "next-intl";
 import type { Course, LearningPath } from "@superteam-lms/types";
+import messages from "@/messages/en.json";
 import type { PathCourseProgress } from "../learning-path-section";
 import { PathsView } from "../paths-view";
-import messages from "@/messages/en.json";
 
 function makeCourse(id: string, title: string): Course {
   return {
@@ -217,6 +217,27 @@ describe("PathsView — content-agnostic rendering", () => {
 
     expect(screen.getByText("Zero to Deployed")).toBeInTheDocument();
     expect(screen.getByText("Second Path")).toBeInTheDocument();
+    expect(screen.queryByText("Empty Path")).not.toBeInTheDocument();
+  });
+
+  // #627 — `draft` and `retired` are authoring/lint lifecycle flags, not runtime
+  // switches. The compiler spreads a path doc verbatim into the bundle, so both
+  // fields ride along, but LearningPath declares neither and no consumer reads
+  // them: visibility is decided by `courses.length` alone. This pins that a
+  // `retired` path is hidden for exactly the same reason a `draft` one is —
+  // it is empty — and that a flagged-but-populated path still renders.
+  it("ignores the draft/retired lifecycle flags — visibility is courses-only", () => {
+    const withFlags = (p: LearningPath, flags: Record<string, boolean>) =>
+      ({ ...p, ...flags }) as LearningPath;
+
+    renderPaths({
+      learningPaths: [
+        withFlags(emptyPath, { retired: true }),
+        withFlags(mainPath, { draft: true, retired: true }),
+      ],
+    });
+
+    expect(screen.getByText("Zero to Deployed")).toBeInTheDocument();
     expect(screen.queryByText("Empty Path")).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/course/paths-view.tsx
+++ b/apps/web/src/components/course/paths-view.tsx
@@ -68,9 +68,12 @@ export function PathsView({
     [learningPaths]
   );
 
-  // One clear start (UIU-07): the first course of the first non-draft path by
-  // the bundle's ordering conventions (order asc, title asc; drafts never ship
-  // in the bundle). Content-agnostic — recomputes when paths change.
+  // One clear start (UIU-07): the first course of the first populated path by
+  // the bundle's ordering conventions (order asc, title asc). A path's `draft`
+  // / `retired` flags are authoring metadata that the bundle carries but no
+  // consumer reads (#627) — emptiness is the only visibility rule, which is why
+  // filtering on `courses.length` above is sufficient here.
+  // Content-agnostic — recomputes when paths change.
   const startCourse = nonEmptyPaths[0]?.courses[0];
   const startProgress = startCourse ? progress.get(startCourse._id) : undefined;
   const startCtaLabel =

--- a/apps/web/src/content/generated/paths.json
+++ b/apps/web/src/content/generated/paths.json
@@ -7,6 +7,7 @@
     "difficulty": "intermediate",
     "draft": true,
     "order": 6,
+    "retired": false,
     "slug": "ai-solana",
     "tag": "AI Agents",
     "title": "AI x Solana"
@@ -19,6 +20,7 @@
     "difficulty": "advanced",
     "draft": true,
     "order": 4,
+    "retired": false,
     "slug": "defi",
     "tag": "DeFi",
     "title": "DeFi"
@@ -31,6 +33,7 @@
     "difficulty": "intermediate",
     "draft": true,
     "order": 3,
+    "retired": false,
     "slug": "frontend",
     "tag": "UI/UX",
     "title": "Frontend"
@@ -43,6 +46,7 @@
     "difficulty": "advanced",
     "draft": true,
     "order": 5,
+    "retired": false,
     "slug": "infrastructure",
     "tag": "Infra",
     "title": "Infrastructure"
@@ -55,6 +59,7 @@
     "difficulty": "intermediate",
     "draft": true,
     "order": 2,
+    "retired": false,
     "slug": "rust-programs",
     "tag": "Builder",
     "title": "Rust & Programs"
@@ -67,6 +72,7 @@
     "difficulty": "advanced",
     "draft": true,
     "order": 7,
+    "retired": false,
     "slug": "security",
     "tag": "Security",
     "title": "Security & Auditing"
@@ -79,6 +85,7 @@
     "difficulty": "beginner",
     "draft": true,
     "order": 8,
+    "retired": false,
     "slug": "solana-core",
     "tag": "Foundation",
     "title": "Solana Core"
@@ -122,6 +129,7 @@
     "difficulty": "beginner",
     "draft": false,
     "order": 1,
+    "retired": false,
     "slug": "zero-to-deployed",
     "tag": "Foundation",
     "title": "Zero to Deployed"

--- a/apps/web/src/lib/content/compile/__tests__/projector.test.ts
+++ b/apps/web/src/lib/content/compile/__tests__/projector.test.ts
@@ -225,3 +225,36 @@ describe("projectContent", () => {
     expect(course.tags).toEqual([]);
   });
 });
+
+describe("projectContent — path lifecycle flags (#627)", () => {
+  it("carries retired/draft into the bundle verbatim, with no courses", () => {
+    const f = fixture();
+    f.paths = [
+      {
+        id: "path-retired",
+        slug: "retired",
+        title: "Retired",
+        difficulty: "beginner",
+        order: 9,
+        draft: false,
+        retired: true,
+        courses: [],
+      },
+    ] as never;
+    const { docs } = projectContent(f, "sha1", noAsset, () => []);
+    const path = docs.find((d) => d._type === "learningPath") as unknown as {
+      _id: string;
+      retired: boolean;
+      draft: boolean;
+      courses: unknown[];
+    };
+    // The projector spreads the doc, so a retired path reaches the app exactly
+    // like a drafted one did: flag present, courses empty. Nothing downstream
+    // reads either flag (LearningPath declares neither) — the empty `courses`
+    // is what hides the shelf. See paths-view.test.tsx for the render proof.
+    expect(path._id).toBe("path-retired");
+    expect(path.retired).toBe(true);
+    expect(path.draft).toBe(false);
+    expect(path.courses).toEqual([]);
+  });
+});

--- a/packages/content-lint/src/__tests__/gate4b.test.ts
+++ b/packages/content-lint/src/__tests__/gate4b.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from "vitest";
+import { runLint } from "../lint";
+import "../checks/gate1-schema";
+import "../checks/gate4b-path-lifecycle";
+import { makeTempRepo } from "./helpers";
+
+const course = (id: string) => `id: ${id}
+slug: ${id.replace("course-", "")}
+title: ${id}
+difficulty: beginner
+duration: 1
+xpPerLesson: 10
+xpReward: 100
+modules: [{ key: m, title: M, lessons: [lesson-a] }]
+`;
+
+const path = (id: string, body: string) => `id: ${id}
+slug: ${id.replace("path-", "")}
+title: ${id}
+difficulty: beginner
+${body}
+`;
+
+const pick =
+  (gate: string) =>
+  (
+    r: Awaited<ReturnType<typeof runLint>>
+  ): { severity: string; message: string }[] =>
+    r.diagnostics.filter((d) => d.gate === gate);
+
+const g4b = pick("gate-4b");
+const g1 = pick("gate-1");
+
+describe("gate 4b — path lifecycle flags", () => {
+  it("passes a populated path with neither flag", async () => {
+    const root = makeTempRepo({
+      "courses/x/course.yaml": course("course-x"),
+      "paths/p.yaml": path("path-p", "courses: [course-x]"),
+    });
+    expect(g4b(await runLint(root))).toEqual([]);
+  });
+
+  it("errors on the implicit-retirement pattern: draft: true with no courses", async () => {
+    const root = makeTempRepo({
+      "paths/p.yaml": path("path-p", "draft: true\ncourses: []"),
+    });
+    const d = g4b(await runLint(root));
+    expect(d).toHaveLength(1);
+    expect(d[0]!.severity).toBe("error");
+    expect(d[0]!.message).toContain("retired: true");
+  });
+
+  it("passes an empty path that declares retired: true", async () => {
+    const root = makeTempRepo({
+      "paths/p.yaml": path("path-p", "retired: true\ncourses: []"),
+    });
+    const r = await runLint(root);
+    expect(g4b(r)).toEqual([]);
+    expect(g1(r)).toEqual([]);
+    expect(r.ok).toBe(true);
+  });
+
+  it("errors when a retired path still lists courses", async () => {
+    const root = makeTempRepo({
+      "courses/x/course.yaml": course("course-x"),
+      "paths/p.yaml": path("path-p", "retired: true\ncourses: [course-x]"),
+    });
+    const d = g4b(await runLint(root));
+    expect(d).toHaveLength(1);
+    expect(d[0]!.severity).toBe("error");
+  });
+
+  it("warns (does not fail) when draft and retired are both set", async () => {
+    const root = makeTempRepo({
+      "paths/p.yaml": path("path-p", "draft: true\nretired: true\ncourses: []"),
+    });
+    const r = await runLint(root);
+    const d = g4b(r);
+    expect(d).toHaveLength(1);
+    expect(d[0]!.severity).toBe("warning");
+    expect(r.ok).toBe(true);
+  });
+
+  it("still rejects an empty path with no lifecycle flag at all (gate 1)", async () => {
+    const root = makeTempRepo({
+      "paths/p.yaml": path("path-p", "courses: []"),
+    });
+    const r = await runLint(root);
+    // Schema refusal, so the doc never reaches gate 4b.
+    expect(g1(r)).toHaveLength(1);
+    expect(r.ok).toBe(false);
+  });
+});

--- a/packages/content-lint/src/checks/gate4b-path-lifecycle.ts
+++ b/packages/content-lint/src/checks/gate4b-path-lifecycle.ts
@@ -1,0 +1,76 @@
+import { registerCheck } from "../lint";
+import { type RepoModel } from "../model";
+import { diag, type Diagnostic } from "../diagnostics";
+
+/**
+ * Gate 4b — path lifecycle flags must say what an empty shelf means (#627,
+ * owner ruling 2026-07-28).
+ *
+ * The app hides a path with zero courses and reads neither `draft` nor
+ * `retired` (the bundle's LearningPath type carries neither field). So an
+ * emptied path is invisible either way, and the flags exist purely to record
+ * intent. Before this gate, "retired" was spelled `draft: true` + `courses: []`
+ * — indistinguishable from "coming soon", which is how #559 nearly shipped a
+ * permanently unearnable `path-completed` achievement: the path looked merely
+ * unfinished, so nothing flagged that its last course had been removed for good.
+ *
+ * Rules:
+ *  1. `draft: true` + empty `courses` is an ERROR unless `retired: true`.
+ *     "Coming soon" means courses are on the way; if they are not, the path is
+ *     retired and must say so. (Gate 4a then treats it as un-completable for
+ *     achievement award refs.)
+ *  2. `retired: true` with a non-empty `courses` is an ERROR — retirement is
+ *     defined as permanently emptied; a retired shelf that still lists courses
+ *     would render in the catalog and contradict its own flag.
+ *  3. `draft: true` + `retired: true` is a WARNING: retirement already implies
+ *     hidden-and-not-coming-back, so `draft` is redundant noise. The schema
+ *     accepts either flag alone for an empty path, so drop `draft`.
+ *
+ * Un-retiring is allowed: clear `retired` and add courses in the same change.
+ * Path ids are permanent once live, which is why retired paths stay in the repo
+ * rather than being deleted.
+ */
+export function gate4bCheck(model: RepoModel): Diagnostic[] {
+  const out: Diagnostic[] = [];
+
+  for (const { file, path } of model.paths) {
+    const empty = path.courses.length === 0;
+
+    if (path.retired && !empty) {
+      out.push(
+        diag(
+          "gate-4b",
+          "error",
+          file,
+          `path "${path.id}" is retired: true but still lists ${path.courses.length} course(s) — a retired path is permanently emptied. Remove the courses, or drop retired: true to bring the shelf back.`
+        )
+      );
+    }
+
+    if (empty && path.draft && !path.retired) {
+      out.push(
+        diag(
+          "gate-4b",
+          "error",
+          file,
+          `path "${path.id}" has no courses and is draft: true — implicit retirement is no longer allowed. Set retired: true if the shelf is permanently emptied (its id is preserved), or add the courses it is drafting.`
+        )
+      );
+    }
+
+    if (path.draft && path.retired) {
+      out.push(
+        diag(
+          "gate-4b",
+          "warning",
+          file,
+          `path "${path.id}" sets both draft: true and retired: true — retired already hides the shelf permanently. Drop draft: true.`
+        )
+      );
+    }
+  }
+
+  return out;
+}
+
+registerCheck(gate4bCheck);

--- a/packages/content-lint/src/index.ts
+++ b/packages/content-lint/src/index.ts
@@ -7,6 +7,7 @@ export * from "./checks/gate2-ids";
 export * from "./checks/gate3-slots";
 export * from "./checks/gate4-refs";
 export * from "./checks/gate4a-award-refs";
+export * from "./checks/gate4b-path-lifecycle";
 export * from "./checks/gate5-orphans";
 export * from "./checks/gate5a-xp";
 export * from "./checks/gate6-executor";

--- a/packages/content-schema/schema/path.schema.json
+++ b/packages/content-schema/schema/path.schema.json
@@ -38,6 +38,10 @@
       "default": false,
       "type": "boolean"
     },
+    "retired": {
+      "default": false,
+      "type": "boolean"
+    },
     "courses": {
       "default": [],
       "type": "array",

--- a/packages/content-schema/src/path.ts
+++ b/packages/content-schema/src/path.ts
@@ -3,8 +3,23 @@ import { CourseId, PathId } from "./ids";
 import { DIFFICULTIES } from "./constants";
 
 /**
- * `path-infrastructure` and `path-security` are live today with zero courses and
- * render as empty shelves. A path is either populated or explicitly a draft.
+ * A path is a shelf of courses. An empty shelf never renders (the app hides a
+ * path with zero courses), so "no courses" is only legal with an explicit
+ * lifecycle flag saying which kind of emptiness it is (#627, owner ruling
+ * 2026-07-28):
+ *
+ *   - `draft: true`   — "coming soon": announced-later, still expected to fill.
+ *   - `retired: true` — permanently emptied; the id is preserved because path
+ *                       ids are permanent once live.
+ *
+ * Neither flag is read at runtime — hiding is empty-`courses`-only, and the
+ * bundle's `LearningPath` type carries neither. They exist for the content
+ * gates and for authors reading the file.
+ *
+ * content-lint gate 4b enforces the rest: a `retired` path MUST be empty, a
+ * draft+empty path MUST also be retired (the implicit-retirement pattern that
+ * #559 nearly shipped an unearnable achievement through is now an error), and
+ * setting both flags is a redundancy warning.
  */
 export const LearningPath = z
   .object({
@@ -16,10 +31,12 @@ export const LearningPath = z
     order: z.number().int().min(0).default(0),
     difficulty: z.enum(DIFFICULTIES),
     draft: z.boolean().default(false),
+    retired: z.boolean().default(false),
     courses: z.array(CourseId).default([]),
   })
-  .refine((p) => p.draft || p.courses.length >= 1, {
-    message: "a non-draft learning path must contain at least one course",
+  .refine((p) => p.draft || p.retired || p.courses.length >= 1, {
+    message:
+      "a learning path with no courses must be marked draft: true or retired: true",
     path: ["courses"],
   });
 


### PR DESCRIPTION
Closes #627 (monorepo half — tooling. The content migration ships in the paired PR **solanabr/academy-courses#31**, which merges after this one).

## Owner ruling (2026-07-28, issue comment)

`draft: true` + `courses: []` — the implicit-retirement pattern — becomes a lint **ERROR**, replaced by an explicit `retired: true` path flag. `draft` = "coming soon"; `retired` = "permanently emptied, id preserved".

## Changes

**`packages/content-schema/src/path.ts`**
- new optional `retired: boolean` (default `false`)
- the empty-shelf refine becomes `draft || retired || courses.length >= 1`, so a retired path no longer has to lie about being a draft to stay schema-legal. Message updated.
- `schema/path.schema.json` regenerated via `pnpm --filter @superteam-lms/content-schema schema:generate` (only that file changed).

**`packages/content-lint` — new gate 4b (`checks/gate4b-path-lifecycle.ts`)**

| case | severity |
|---|---|
| empty `courses` + `draft: true`, no `retired` | **error** — implicit retirement |
| `retired: true` + non-empty `courses` | **error** — a retired shelf is defined as permanently emptied |
| `draft: true` + `retired: true` | **warning** — redundant; retired already hides permanently, drop `draft` |
| empty + neither flag | already a gate-1 (schema) error |

The draft/retired combination question from the issue is resolved as: **retired implies hidden regardless of draft**, the schema accepts either flag alone, and setting both is a non-fatal redundancy warning. Un-retiring is explicitly allowed (clear `retired`, add courses in the same change) — retired paths stay in the repo because path ids are permanent once live.

**Runtime — no change, by design (verified, not assumed)**
- The compiler spreads a path doc verbatim (`compile/projector.ts`), so `retired` rides into the bundle exactly as `draft` always has.
- `packages/types` `LearningPath` declares **neither** field, so no consumer can read either — visibility is `courses.length` only (`paths-view.tsx` `nonEmptyPaths`).
- Pinned by two new tests: a projector test (flag present + `courses: []` in the projected doc) and a `paths-view` test (a `retired`-flagged *populated* path still renders; an empty one is hidden regardless of flags). Corrected a stale comment in `paths-view.tsx` that claimed drafts never ship in the bundle — they do.

## Red proof

Gate 4b run from this branch against `courses-academy@main` **before** migration:

```
content-lint: FAILED (7 errors)
[error] gate-4b paths/ai-solana.yaml: path "path-ai-solana" has no courses and is draft: true — implicit retirement is no longer allowed…
[error] gate-4b paths/defi.yaml            …
[error] gate-4b paths/frontend.yaml        …
[error] gate-4b paths/infrastructure.yaml  …
[error] gate-4b paths/rust-programs.yaml   …
[error] gate-4b paths/security.yaml        …
[error] gate-4b paths/solana-core.yaml     …
```

All 7 errors are gate-4b; no other gate errors. The same run reports **zero gate-4a diagnostics**, which discharges the achievement-award-refs half of #627 on live content (gate 4a landed in #749 and resolves every ref-bearing award kind against non-empty paths / existing courses, exhaustively over the award union).

## Verification

- `pnpm typecheck` — 6/6 tasks pass
- `pnpm -r test` — content-schema 170, content-lint 114 (6 new in `gate4b.test.ts`), deploy 18, web 2372 — all pass
- prettier/eslint clean via pre-commit

## Sequencing

**This PR merges FIRST.** The paired content PR — solanabr/academy-courses#31 — migrates the 7 empty paths to `retired: true`; its CI checks out `solanabr/superteam-academy@main` for the linter, so it stays red until this lands and cannot be merged before it.
