### PR TITLE
docs(specs): reconciliation §3.2 — teachers.yaml retired by owner ruling, not a defect (#863)

### DIFF
--- a/docs/superpowers/specs/2026-07-27-RESEARCH-RECONCILIATION.md
+++ b/docs/superpowers/specs/2026-07-27-RESEARCH-RECONCILIATION.md
@@ -84,8 +84,15 @@ step 0), and do not quote AI costs externally until the curls are recorded.
 2. **All four new courses repeat the immutable-creator mistake** (PB-7): every
    `course.yaml` carries `creator: B7o8Nf…` — the platform authority — despite the catalog spec's
    explicit "do not repeat this" warning. Survivable on devnet (recreate-before-mainnet), but the
-   recreate wave must now include creator swaps to real instructor wallets, and `teachers.yaml`
-   is still read by nothing.
+   recreate wave must now include creator swaps to real instructor wallets. ~~and `teachers.yaml`
+   is still read by nothing.~~ **AMENDED 2026-07-31 (#863): the `teachers.yaml` clause is
+   retired, not fixed.** The owner ruled on 2026-07-28 (#840) that `course.yaml`'s immutable
+   on-chain `creator` wallet **is** the teacher pointer, resolving to the teacher's platform
+   account via `profiles.wallet_address` — there is no registry file in the model. "Read by
+   nothing" was therefore by design, not a defect; the file has been deleted from
+   `solanabr/courses-academy`. **The creator half of this finding stands unchanged**: every new
+   `course.yaml` still carries the platform authority, and the recreate wave still owes real
+   instructor wallets at on-chain creation time (PB-7).
 3. **C5's course description still opens with the false-for-standalone claim** "You have a
    deployed vault app…" — unified item 27(1) required rewriting it before merge; it merged as-is.
 4. **The C3-at-trackLevel-3 devnet recreate (catalog chain-2) never executed** and its natural


### PR DESCRIPTION
Docs-only. One paragraph in `docs/superpowers/specs/2026-07-27-RESEARCH-RECONCILIATION.md`, per the scope note on #863.

§3 finding 2 ends with "and `teachers.yaml` is still read by nothing" — written before the owner's 2026-07-28 ruling (#840) that `course.yaml`'s immutable on-chain `creator` wallet **is** the teacher pointer, resolving to the teacher's platform account via `profiles.wallet_address`, with no registry file in the model. Read-by-nothing was by design, so the clause now reads as an open defect when it is not one. The clause is struck and annotated with the ruling rather than deleted, so the record shows what changed and when.

**The creator half of the finding is untouched.** Every new `course.yaml` still carries the platform authority, and the recreate wave still owes real instructor wallets at on-chain creation time. PB-7 is not weakened by this or by #863.

The file itself is deleted, and CLAUDE.md / CATALOG.md scrubbed, in the companion content PR: solanabr/academy-courses#30 (which closes #863).

Refs #863