### PR TITLE
chore(web): broaden the no-experience marketing copy guard

### DIFF
--- a/apps/web/src/app/[locale]/(marketing)/__tests__/marketing-copy-bounds.test.ts
+++ b/apps/web/src/app/[locale]/(marketing)/__tests__/marketing-copy-bounds.test.ts
@@ -35,6 +35,96 @@ const FORBIDDEN: Array<[string, RegExp]> = [
   ["remittance framing (es)", /\bremesa(s)?\b/i],
 ];
 
+// #906 — the "no experience needed" guard. Every course gates on working
+// JavaScript (#875), so unqualified beginners-welcome copy is a false promise
+// until the JS/TS rung (#579) exists. A claim is forbidden when a negation
+// lands on an experience noun *without* a topic scope: "no experience needed"
+// is a lie, "no Rust experience required" is the actual prerequisite copy.
+//
+// Scope may sit before the noun (EN: "no *Rust* experience") or after it via a
+// preposition (PT/ES: "experiência *com* blockchain"), so both windows are
+// checked. Anything unscoped fails, whatever qualifier is in between.
+const SCOPED_TOPIC =
+  /\b(?:blockchain|solana|rust|crypto\w*|cripto\w*|web3|defi|nfts?|anchor|smart[\s-]?contracts?|contratos?|on-?chain|onchain|token\w*)/i;
+
+interface ClaimRule {
+  label: string;
+  /** Negation + gap (group 1) + experience noun. */
+  re: RegExp;
+  /** If set, a topic scope may also attach after the noun via these prepositions. */
+  scopeAfter?: RegExp;
+}
+
+const CLAIM_RULES: ClaimRule[] = [
+  {
+    label: "unqualified no-experience claim (en)",
+    re: /\b(?:no|zero|without(?:\s+any)?)\s+([\w\s,'’/-]{0,40}?)(?:experience|background|knowledge)\b/gi,
+    scopeAfter: /with|in|of|about/,
+  },
+  {
+    label: "no-code claim (en)",
+    re: /\b(?:no|zero)\s+(?:coding|code|programming|dev(?:eloper)?\s+skills?|technical\s+skills?)\b()/gi,
+  },
+  {
+    label: "no-prerequisites claim (en)",
+    re: /\b(?:no|zero)\s+(?:prior\s+)?(?:prerequisites?|pre-?reqs?|requirements?)\b()/gi,
+  },
+  {
+    label: "unqualified no-experience claim (pt)",
+    re: /\b(?:sem|nenhum(?:a)?|zero|n[ãa]o\s+(?:é\s+)?precisa?(?:r|o)?(?:\s+(?:de|ter))?|n[ãa]o\s+exige)\s+([\w\s,'’/-]{0,40}?)(?:experi[êe]ncias?|conhecimentos?|bagagem)\b/gi,
+    scopeAfter: /com|em|de|sobre/,
+  },
+  {
+    label: "no-code claim (pt)",
+    re: /\b(?:sem\s+(?:nunca\s+)?saber\s+program\w*|n[ãa]o\s+precisa\s+(?:saber\s+)?programar|sem\s+(?:nenhum\s+|escrever\s+)?c[oó]digo|do\s+zero\s+sem)\b()/gi,
+  },
+  {
+    label: "no-prerequisites claim (pt)",
+    re: /\b(?:sem|nenhum)\s+(?:nenhum\s+)?pr[ée]-?requisitos?\b()/gi,
+  },
+  {
+    label: "unqualified no-experience claim (es)",
+    re: /\b(?:sin|ninguna|cero|no\s+(?:hace\s+falta|necesitas|se\s+necesita|requiere|hay\s+que\s+tener)(?:\s+tener)?)\s+([\w\s,'’/-]{0,40}?)(?:experiencias?|conocimientos?)\b/gi,
+    scopeAfter: /con|en|de|sobre/,
+  },
+  {
+    label: "no-code claim (es)",
+    re: /\b(?:sin\s+saber\s+programa\w*|no\s+necesitas\s+programar|sin\s+(?:escribir\s+)?c[oó]digo|desde\s+cero\s+sin)\b()/gi,
+  },
+  {
+    label: "no-prerequisites claim (es)",
+    re: /\b(?:sin|ning[úu]n)\s+(?:ning[úu]n\s+)?requisitos?\b()/gi,
+  },
+];
+
+/** Topic scope attached right after the noun, e.g. "experiência com blockchain". */
+function hasTrailingScope(
+  text: string,
+  from: number,
+  prepositions: RegExp
+): boolean {
+  const tail = new RegExp(
+    `^\\s*(?:${prepositions.source})\\b[^.!?;—]{0,40}`,
+    "i"
+  ).exec(text.slice(from, from + 80));
+  return tail !== null && SCOPED_TOPIC.test(tail[0]);
+}
+
+/** Returns the label of every forbidden no-experience claim in `value`. */
+export function findNoExperienceClaims(value: string): string[] {
+  const hits: string[] = [];
+  for (const { label, re, scopeAfter } of CLAIM_RULES) {
+    for (const m of value.matchAll(re)) {
+      const scoped =
+        SCOPED_TOPIC.test(m[1] ?? "") ||
+        (scopeAfter !== undefined &&
+          hasTrailingScope(value, m.index + m[0].length, scopeAfter));
+      if (!scoped) hits.push(label);
+    }
+  }
+  return hits;
+}
+
 function flatten(node: unknown, path: string): Array<[string, string]> {
   if (typeof node === "string") return [[path, node]];
   if (node && typeof node === "object") {
@@ -92,18 +182,83 @@ describe("marketing copy bounds (MAS-24 / BCB-561)", () => {
         ...flatten((catalog as Record<string, unknown>).landing, "landing"),
         ...flatten((catalog as Record<string, unknown>).start, "start"),
       ];
-      const claims: RegExp[] = [
-        /\bno (?:prior |previous )?experience (?:needed|required)\b/i,
-        /\bno prerequisites?\b/i,
-        /\bsem (?:qualquer )?experi[êe]ncia\b/i,
-        /\bsem pr[ée]-?requisitos?\b/i,
-        /\bsin (?:ninguna )?experiencia\b/i,
-        /\bsin requisitos\b/i,
-      ];
       const hits = entries.flatMap(([path, value]) =>
-        claims.filter((re) => re.test(value)).map(() => `${path}: "${value}"`)
+        findNoExperienceClaims(value).map(
+          (label) => `${path}: ${label} — "${value}"`
+        )
       );
       expect(hits).toEqual([]);
     });
   }
+});
+
+// #906 — the guard itself. The old pattern only allowed "prior "/"previous "
+// between "no" and "experience", so "no coding experience required" shipped.
+describe("no-experience claim detector (#906)", () => {
+  const FORBIDDEN_COPY = [
+    "No experience needed.",
+    "No experience required — start today.",
+    "Zero experience? Start here.",
+    "No prior experience necessary.",
+    "No previous experience required.",
+    "No coding experience required.",
+    "No programming experience needed.",
+    "No prior coding experience required.",
+    "No technical background required.",
+    "No prior knowledge needed.",
+    "Without any experience, you can ship.",
+    "Beginner-friendly — no code.",
+    "No coding required.",
+    "No prerequisites.",
+    "No prior prerequisites at all.",
+    "Zero requirements to join.",
+    "Sem experiência.",
+    "Nenhuma experiência necessária.",
+    "Sem qualquer experiência prévia.",
+    "Não precisa de experiência.",
+    "Não é preciso ter experiência.",
+    "Sem nenhum conhecimento prévio.",
+    "Sem saber programar.",
+    "Não precisa saber programar.",
+    "Comece do zero sem escrever uma linha.",
+    "Sem pré-requisitos.",
+    "Sin experiencia.",
+    "Sin ninguna experiencia previa.",
+    "No hace falta experiencia.",
+    "No necesitas conocimientos previos.",
+    "Cero experiencia, cero problema.",
+    "Sin saber programar.",
+    "Empieza desde cero sin escribir código.",
+    "Sin requisitos.",
+  ];
+
+  // Topic-scoped disclaimers and neutral copy: these are the real strings the
+  // catalogs ship (or close variants) and must never trip the guard.
+  const ALLOWED_COPY = [
+    "That is the only gate — no blockchain, cryptography or Rust experience required.",
+    "No Solana experience needed, but you should already know TypeScript.",
+    "No prior blockchain knowledge is assumed.",
+    "No experience with Solana required — but you should know TypeScript.",
+    "Bring your JavaScript experience; we handle the chain.",
+    "Learning to program from scratch? freeCodeCamp is the best place to start.",
+    "We do not teach programming from scratch yet.",
+    "Beginner",
+    "Real code in your browser.",
+    "Esse é o único requisito — não é preciso ter experiência com blockchain, criptografia ou Rust.",
+    "Está aprendendo a programar do zero? O freeCodeCamp é o melhor lugar para começar.",
+    "Comece do zero, uma lição de cada vez.",
+    "Ainda não ensinamos programação do zero — o freeCodeCamp ensina, e ensina bem.",
+    "Ese es el único requisito — no hace falta experiencia con blockchain, criptografía ni Rust.",
+    "¿Estás aprendiendo a programar desde cero? freeCodeCamp es el mejor lugar para empezar.",
+    "Empieza desde cero, una lección a la vez.",
+    "Entra en cualquier curso — el orden es una recomendación, no un requisito.",
+  ];
+
+  it.each(FORBIDDEN_COPY)("flags %j", (copy) => {
+    expect(findNoExperienceClaims(copy)).not.toEqual([]);
+  });
+
+  it.each(ALLOWED_COPY)("allows %j", (copy) => {
+    expect(findNoExperienceClaims(copy)).toEqual([]);
+  });
 });


### PR DESCRIPTION
Closes #906

## What

`marketing-copy-bounds.test.ts` guarded against "no experience needed" claims with a flat regex list whose EN rule was `\bno (?:prior |previous )?experience (?:needed|required)\b` — anything else between "no" and "experience" ("no **coding** experience required") slipped past, as did most PT-BR/ES phrasings.

Replaced with an exported detector, `findNoExperienceClaims(value)`, used by the per-locale catalog scan.

## The new pattern

A claim is forbidden when a negation lands on an experience noun **without a topic scope**. Topic scope may sit either side of the noun:

- before it (EN): `no **Rust** experience required`
- after it via a preposition (PT/ES): `experiência **com** blockchain`

```
SCOPED_TOPIC = blockchain|solana|rust|crypto*|cripto*|web3|defi|nfts?|anchor|smart contract(s)|contratos?|on-chain|token*
```

Rules (all `gi`, group 1 = the intervening gap, capped at 40 chars and punctuation-free so it cannot cross a sentence):

| label | pattern |
|---|---|
| unqualified no-experience (en) | `\b(?:no\|zero\|without(?:\s+any)?)\s+([\w\s,'’/-]{0,40}?)(?:experience\|background\|knowledge)\b` + scopeAfter `with\|in\|of\|about` |
| no-code (en) | `\b(?:no\|zero)\s+(?:coding\|code\|programming\|dev(?:eloper)?\s+skills?\|technical\s+skills?)\b` |
| no-prerequisites (en) | `\b(?:no\|zero)\s+(?:prior\s+)?(?:prerequisites?\|pre-?reqs?\|requirements?)\b` |
| unqualified no-experience (pt) | `\b(?:sem\|nenhum(?:a)?\|zero\|n[ãa]o\s+(?:é\s+)?precisa?(?:r\|o)?(?:\s+(?:de\|ter))?\|n[ãa]o\s+exige)\s+(gap)(?:experi[êe]ncias?\|conhecimentos?\|bagagem)\b` + scopeAfter `com\|em\|de\|sobre` |
| no-code (pt) | `sem (nunca )?saber program*` / `n[ãa]o precisa (saber )?programar` / `sem (nenhum \|escrever )?c[oó]digo` / `do zero sem` |
| no-prerequisites (pt) | `(?:sem\|nenhum)\s+(?:nenhum\s+)?pr[ée]-?requisitos?` |
| unqualified no-experience (es) | `\b(?:sin\|ninguna\|cero\|no\s+(?:hace\s+falta\|necesitas\|se\s+necesita\|requiere\|hay\s+que\s+tener)(?:\s+tener)?)\s+(gap)(?:experiencias?\|conocimientos?)\b` + scopeAfter `con\|en\|de\|sobre` |
| no-code (es) | `sin saber programa*` / `no necesitas programar` / `sin (escribir )?c[oó]digo` / `desde cero sin` |
| no-prerequisites (es) | `(?:sin\|ning[úu]n)\s+(?:ning[úu]n\s+)?requisitos?` |

## Test evidence

`pnpm --filter web test marketing-copy-bounds` → **63 passed** (12 catalog scans + 34 red + 17 green).

**Red — 34 variants, each its own case.** 24 of them were *missed by the old pattern* (verified by replaying the old regex list over the red table):

```
red cases: 34 | missed by OLD pattern: 24
  MISS: Zero experience? Start here.
  MISS: No prior experience necessary.
  MISS: No coding experience required.
  MISS: No programming experience needed.
  MISS: No prior coding experience required.
  MISS: No technical background required.
  MISS: No prior knowledge needed.
  MISS: Without any experience, you can ship.
  MISS: Beginner-friendly — no code.
  MISS: No coding required.
  MISS: No prior prerequisites at all.
  MISS: Zero requirements to join.
  MISS: Nenhuma experiência necessária.
  MISS: Não precisa de experiência.
  MISS: Não é preciso ter experiência.
  MISS: Sem nenhum conhecimento prévio.
  MISS: Sem saber programar.
  MISS: Não precisa saber programar.
  MISS: Comece do zero sem escrever uma linha.
  MISS: No hace falta experiencia.
  MISS: No necesitas conocimientos previos.
  MISS: Cero experiencia, cero problema.
  MISS: Sin saber programar.
  MISS: Empieza desde cero sin escribir código.
```

**Green — 17 legitimate strings, taken verbatim from the live catalogs plus the qualifier styles named in the issue**, all pass:

- `That is the only gate — no blockchain, cryptography or Rust experience required.` (scope before the noun)
- `No experience with Solana required — but you should know TypeScript.` (scope after the noun)
- `Esse é o único requisito — não é preciso ter experiência com blockchain, criptografia ou Rust.`
- `Ese es el único requisito — no hace falta experiencia con blockchain, criptografía ni Rust.`
- the from-scratch refer-outs (`Learning to program from scratch?`, `programar do zero`, `programar desde cero`, `Empieza desde cero, una lección a la vez.`), `no es un requisito`, and bare `Beginner`.

**Mutation check** — injecting `No coding experience required` into `en.json > courses.prereqTitle` fails the live catalog scan (then reverted):

```
FAIL … > en never claims no experience is needed
+ "courses.prereqTitle: unqualified no-experience claim (en) — \"No coding experience required\""
```

## Live copy

**No violations.** All three catalogs pass the broadened guard unchanged — no message-catalog edits in this PR. `pnpm --filter web typecheck` clean.
