### PR TITLE
fix(content-lint): gate-13a resolves `consumes:` across a course boundary (#852)

### DIFF
--- a/packages/content-lint/src/__tests__/gate13a.test.ts
+++ b/packages/content-lint/src/__tests__/gate13a.test.ts
@@ -32,6 +32,48 @@ blocks:
   };
 }
 
+/**
+ * Two courses on one path: `producer` funds a wallet, `consumer` consumes it.
+ * `pathCourses` controls the ladder order (and may omit a course entirely).
+ */
+function ladder(pathCourses: string[]) {
+  const course = (id: string, slug: string, lesson: string) =>
+    `id: ${id}
+slug: ${slug}
+title: ${slug}
+difficulty: beginner
+duration: 1
+xpPerLesson: 10
+xpReward: 100
+modules: [{ key: m, title: M, lessons: [${lesson}] }]
+`;
+  return {
+    "courses/p/course.yaml": course("course-p", "p", "lesson-fund"),
+    "courses/p/lessons/fund/lesson.yaml": `id: lesson-fund
+slug: fund
+title: Fund
+skills: [wallet-funding]
+blocks:
+  - { key: fund, type: wallet-funding, amount: 2, network: devnet, produces: funded-wallet }
+`,
+    "courses/c/course.yaml": course("course-c", "c", "lesson-explore"),
+    "courses/c/lessons/explore/lesson.yaml": `id: lesson-explore
+slug: explore
+title: Explore
+skills: [program-interaction]
+blocks:
+  - { key: explore, type: program-explorer, idl: program.idl.json, consumes: [funded-wallet] }
+`,
+    "paths/ladder.yaml": `id: path-ladder
+slug: ladder
+title: Ladder
+difficulty: beginner
+courses:
+${pathCourses.map((c) => `  - ${c}`).join("\n")}
+`,
+  };
+}
+
 describe("gate 13a — capability ordering", () => {
   it("passes when the producer lesson precedes the consumer in display order", async () => {
     const r = await runLint(
@@ -44,6 +86,29 @@ describe("gate 13a — capability ordering", () => {
     const r = await runLint(
       makeTempRepo(tree(["lesson-explore", "lesson-fund"]))
     );
+    expect(
+      r.diagnostics.some(
+        (d) => d.gate === "gate-13a" && /funded-wallet/.test(d.message)
+      )
+    ).toBe(true);
+  });
+
+  it("accepts a consumes satisfied by a course earlier on the same learning path", async () => {
+    const r = await runLint(makeTempRepo(ladder(["course-p", "course-c"])));
+    expect(r.diagnostics.filter((d) => d.gate === "gate-13a")).toEqual([]);
+  });
+
+  it("errors when the producing course comes LATER on the path", async () => {
+    const r = await runLint(makeTempRepo(ladder(["course-c", "course-p"])));
+    expect(
+      r.diagnostics.some(
+        (d) => d.gate === "gate-13a" && /funded-wallet/.test(d.message)
+      )
+    ).toBe(true);
+  });
+
+  it("errors when the producing course is not on the consumer's path at all", async () => {
+    const r = await runLint(makeTempRepo(ladder(["course-c"])));
     expect(
       r.diagnostics.some(
         (d) => d.gate === "gate-13a" && /funded-wallet/.test(d.message)

--- a/packages/content-lint/src/checks/gate13a-capabilities.ts
+++ b/packages/content-lint/src/checks/gate13a-capabilities.ts
@@ -1,6 +1,6 @@
 import { CAPABILITY_KEYS } from "@superteam-lms/content-schema";
 import { registerCheck } from "../lint";
-import { type RepoModel } from "../model";
+import { type CourseEntry, type RepoModel } from "../model";
 import { diag, type Diagnostic } from "../diagnostics";
 
 type Block = Record<string, unknown> & {
@@ -16,21 +16,86 @@ const VALID_PRODUCER: Record<string, (b: Block) => boolean> = {
   "deployed-program": (b) => b.type === "code" && b.deployable === true,
 };
 
+function isValidProducer(block: Block): boolean {
+  if (
+    !block.produces ||
+    !(CAPABILITY_KEYS as readonly string[]).includes(block.produces)
+  ) {
+    return false;
+  }
+  const validator = VALID_PRODUCER[block.produces];
+  return validator !== undefined && validator(block);
+}
+
+/** A course's blocks in DISPLAY order: module order, lesson order, block order. */
+function displayOrder(
+  model: RepoModel,
+  course: CourseEntry
+): { lessonFile: string; block: Block }[] {
+  const seq: { lessonFile: string; block: Block }[] = [];
+  for (const lid of course.course.modules.flatMap((m) => m.lessons)) {
+    const lesson = model.lessonsById.get(lid);
+    if (!lesson) continue; // missing lesson is a gate-4 error
+    for (const b of lesson.lesson.blocks as Block[]) {
+      seq.push({ lessonFile: lesson.file, block: b });
+    }
+  }
+  return seq;
+}
+
+/**
+ * Capabilities a course is available to hand to the next course. Invalid
+ * producers are reported by the ordering pass below, not here — this only
+ * collects what genuinely gets produced.
+ */
+function producedByCourse(model: RepoModel, course: CourseEntry): Set<string> {
+  const out = new Set<string>();
+  for (const { block } of displayOrder(model, course)) {
+    if (isValidProducer(block)) out.add(block.produces as string);
+  }
+  return out;
+}
+
+/**
+ * Capabilities a course already holds on entry: everything produced by the
+ * courses that precede it on a learning path it sits on.
+ *
+ * The catalog thesis is that each course consumes the previous course's output
+ * as a named, checkable input — C4 lesson 1 generates a client from the program
+ * C3 deployed. Without this, a cross-course `consumes:` is unexpressible: every
+ * capability would have to be re-produced inside the consuming course.
+ *
+ * Path order is the ladder deliberately. `prerequisiteCourse` is NOT used: it is
+ * written into the on-chain Course account and enforced by `enroll`, so setting
+ * it to satisfy a linter would gate learner access to the course.
+ */
+function inheritedByCourse(model: RepoModel): Map<string, Set<string>> {
+  const produced = new Map(
+    model.courses.map((c) => [c.id, producedByCourse(model, c)])
+  );
+  const inherited = new Map(
+    model.courses.map((c) => [c.id, new Set<string>()])
+  );
+
+  for (const { path } of model.paths) {
+    const upstream = new Set<string>();
+    for (const courseId of path.courses) {
+      const into = inherited.get(courseId);
+      if (into) for (const cap of upstream) into.add(cap);
+      for (const cap of produced.get(courseId) ?? []) upstream.add(cap);
+    }
+  }
+  return inherited;
+}
+
 export function gate13aCheck(model: RepoModel): Diagnostic[] {
   const out: Diagnostic[] = [];
-  for (const course of model.courses) {
-    // Flatten to DISPLAY order: module order, lesson order within module, block order within lesson.
-    const seq: { lessonFile: string; block: Block }[] = [];
-    for (const lid of course.course.modules.flatMap((m) => m.lessons)) {
-      const lesson = model.lessonsById.get(lid);
-      if (!lesson) continue; // missing lesson is a gate-4 error
-      for (const b of lesson.lesson.blocks as Block[]) {
-        seq.push({ lessonFile: lesson.file, block: b });
-      }
-    }
+  const inherited = inheritedByCourse(model);
 
-    const producedSoFar = new Set<string>();
-    for (const { lessonFile, block } of seq) {
+  for (const course of model.courses) {
+    const producedSoFar = new Set<string>(inherited.get(course.id) ?? []);
+
+    for (const { lessonFile, block } of displayOrder(model, course)) {
       for (const need of block.consumes ?? []) {
         if (!producedSoFar.has(need)) {
           out.push(
@@ -38,7 +103,7 @@ export function gate13aCheck(model: RepoModel): Diagnostic[] {
               "gate-13a",
               "error",
               lessonFile,
-              `block "${block.key}" consumes "${need}" but no earlier block (in display order) produces it (spec §4.9)`
+              `block "${block.key}" consumes "${need}" but no earlier block (in display order) — and no course earlier on this course's learning path — produces it (spec §4.9)`
             )
           );
         }
@@ -48,8 +113,7 @@ export function gate13aCheck(model: RepoModel): Diagnostic[] {
         block.produces &&
         (CAPABILITY_KEYS as readonly string[]).includes(block.produces)
       ) {
-        const validator = VALID_PRODUCER[block.produces];
-        if (validator && validator(block)) {
+        if (isValidProducer(block)) {
           producedSoFar.add(block.produces);
         } else {
           out.push(


### PR DESCRIPTION
## Why

`gate-13a` rebuilt `producedSoFar` inside the `for (const course of model.courses)` loop, so a `consumes:` key could only be satisfied by a producer **in the same course**. That makes the catalog thesis — *every course consumes the previous course's output as a named, checkable input* — inexpressible across a course boundary.

#852 is the concrete case. C4 (`dapp-and-sdk-with-kit`) takes C3's deployed program id + published IDL as its entire input, but C4 is TypeScript-only and the only legal producer of `deployed-program` is a `code` block with `deployable: true` — so C4 can never produce it. The previous attempt (content PR solanabr/academy-courses#29) shipped the dead-end-fallback half of #852 and had to leave the `consumes:` half out, because adding it hard-errored CI:

```
[error] gate-13a .../idl-to-typed-client/lesson.yaml: block "inspect" consumes "deployed-program" but no earlier block (in display order) produces it (spec §4.9)
```

## What changed

A course now enters with the capabilities produced by the courses listed **before it on a learning path it appears on** (`paths/*.yaml`). In-course display ordering is unchanged, and `VALID_PRODUCER` still decides what may legitimately produce a capability — so a course only ever exports capabilities it genuinely produced.

**Path order is the ladder, deliberately not `prerequisiteCourse`.** `prerequisiteCourse` is written into the on-chain `Course` account and enforced by `enroll` (`onchain-academy/programs/onchain-academy-pinocchio/src/instructions/enroll.rs`), so setting it to satisfy a linter would gate learner access to the course and require a course recreate (the field is write-once at init). Path membership carries no runtime or on-chain consequence.

## Verification

`pnpm --filter @superteam-lms/content-lint run test` — **18 files, 117 tests passed**. `typecheck` clean.

Three new gate-13a cases: producer course earlier on the path (accepted), producer course later on the path (error), producer course not on the consumer's path at all (error). The two pre-existing in-course ordering cases are untouched and still pass.

Against the live content tree (`solanabr/academy-courses` @ `main`, `LINT_BASE_REF=main`): `content-lint: OK (37 diagnostics, 0 errors)` — byte-identical to the baseline before this change, i.e. no existing content starts or stops passing.

With the companion content branch (solanabr/academy-courses#33) applied:

| gate-13a | result |
|---|---|
| this branch | `content-lint: OK (37 diagnostics, 0 errors)` |
| `main` (unchanged gate) | `content-lint: FAILED (3 errors)` — all three gate-13a |

## Merge order

This must land on `main` **before** solanabr/academy-courses#33 goes green — the content repo's `validate-content` workflow checks out `solanabr/superteam-academy@main` for the linter.

Refs #852
