### PR TITLE
fix(deps): bump transitive uuid to 11.1.1 (GHSA-w5hq-g745-h8pq)

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
       "js-yaml@4": "^4.2.0",
       "@babel/core": "^7.29.6",
       "@opentelemetry/core": "^2.8.0",
-      "esbuild@0.27": "0.28.1"
+      "esbuild@0.27": "0.28.1",
+      "uuid": "^11.1.1"
     }
   },
   "packageManager": "pnpm@10.34.4+sha512.8768be55200ae3f2226b6527fcca2687e14bc4e5f12d7721a0f25da3df47915177058648db4177baf348120fa0ba2752d8d8d93f6beaf1fe64ae18da8de961af",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,6 +33,7 @@ overrides:
   '@babel/core': ^7.29.6
   '@opentelemetry/core': ^2.8.0
   esbuild@0.27: 0.28.1
+  uuid: ^11.1.1
 
 importers:
 
@@ -7471,14 +7472,8 @@ packages:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
 
-  uuid@8.3.2:
-    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
-    hasBin: true
-
-  uuid@9.0.1:
-    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+  uuid@11.1.1:
+    resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
     hasBin: true
 
   vfile-location@5.0.3:
@@ -10500,7 +10495,7 @@ snapshots:
     dependencies:
       '@sentry/bundler-plugin-core': 4.9.1
       unplugin: 1.0.1
-      uuid: 9.0.1
+      uuid: 11.1.1
       webpack: 5.105.2
     transitivePeerDependencies:
       - encoding
@@ -10906,14 +10901,14 @@ snapshots:
       '@wallet-standard/base': 1.1.0
       bs58: 5.0.0
       eventemitter3: 5.0.4
-      uuid: 9.0.1
+      uuid: 11.1.1
 
   '@solflare-wallet/sdk@1.4.2(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))':
     dependencies:
       '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       bs58: 5.0.0
       eventemitter3: 5.0.4
-      uuid: 9.0.1
+      uuid: 11.1.1
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -13645,7 +13640,7 @@ snapshots:
       isomorphic-ws: 4.0.1(ws@7.5.11(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       json-stringify-safe: 5.0.1
       stream-json: 1.9.1
-      uuid: 8.3.2
+      uuid: 11.1.1
       ws: 7.5.11(bufferutil@4.1.0)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - bufferutil
@@ -15417,7 +15412,7 @@ snapshots:
       '@types/ws': 8.18.1
       buffer: 6.0.3
       eventemitter3: 5.0.4
-      uuid: 8.3.2
+      uuid: 11.1.1
       ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
     optionalDependencies:
       bufferutil: 4.1.0
@@ -16226,9 +16221,7 @@ snapshots:
 
   utils-merge@1.0.1: {}
 
-  uuid@8.3.2: {}
-
-  uuid@9.0.1: {}
+  uuid@11.1.1: {}
 
   vfile-location@5.0.3:
     dependencies:


### PR DESCRIPTION
## The advisory

**GHSA-w5hq-g745-h8pq** — *uuid: Missing buffer bounds check in v3/v5/v6 when `buf` is provided* (medium). Two open Dependabot alerts (#58, #90), both against `pnpm-lock.yaml`.

Affected ranges per the advisory: `< 11.1.1`, `>= 12.0.0 < 12.0.1`, `>= 13.0.0 < 13.0.1`. First patched on the 11.x line: **11.1.1**.

## Which deps pulled the vulnerable uuid

`pnpm why uuid -r` before the fix — two vulnerable copies, **both transitive**; no direct `uuid` dependency exists in any workspace `package.json`, and no first-party source file imports it (repo-wide grep for `from 'uuid'` / `require('uuid')` excluding `node_modules` → zero hits).

**`uuid@8.3.2`** (`< 11.1.1` → affected)
- `jayson@4.3.0` → `@solana/web3.js@1.98.4` → apps/web, onchain-academy, packages/deploy, @coral-xyz/anchor, all the umi/metaplex and wallet-adapter packages
- `rpc-websockets@9.3.3` → `@solana/web3.js@1.98.4`

**`uuid@9.0.1`** (`< 11.1.1` → affected)
- `@sentry/webpack-plugin@4.9.1` → `@sentry/nextjs@10.38.0` → apps/web
- `@solflare-wallet/metamask-sdk@1.0.3` → `@solana/wallet-adapter-solflare@0.6.32` → apps/web
- `@solflare-wallet/sdk@1.4.2` → `@solana/wallet-adapter-solflare@0.6.32` → apps/web

No package in the tree pinned an *unaffected* uuid range, so a blanket override is correct here — there is nothing to preserve.

## Resolution mechanism

pnpm override in the root `package.json`, matching the existing `minimatch`/`brace-expansion`/`picomatch` pattern:

```json
"uuid": "^11.1.1"
```

Direct bumps were not an option: every consumer is transitive and none has a release that moves off uuid 9.

**Why 11 and not latest (14.0.1):** uuid dropped CommonJS after the 11.x line — its own deprecation notice says *"For CommonJS codebases, use uuid@11"*. `jayson/lib/utils.js:6` does `const uuid = require('uuid').v4`, so 12/13/14 would break `@solana/web3.js` at runtime. 11.1.1 is both the last 11.x and the advisory's patched version for that line, so it satisfies the fix without breaking CJS consumers.

**API surface check** — every consumer uses only `v1` / `v4`, both present in v11:

| consumer | usage |
|---|---|
| `jayson` | `require('uuid').v4` |
| `rpc-websockets` | `import { v1 } from 'uuid'` |
| `@sentry/webpack-plugin` | `import { v4 } from 'uuid'` |
| `@solflare-wallet/sdk` | `import { v4 as uuidv4 } from 'uuid'` |
| `@solflare-wallet/metamask-sdk` | `import { v4 as uuidv4 } from 'uuid'` |

## Proof

**1. Lockfile resolves to a single patched version**

```
$ grep -nE "^  uuid@" pnpm-lock.yaml
7475:  uuid@11.1.1:
16224:  uuid@11.1.1: {}
```

`uuid@8.3.2` and `uuid@9.0.1` are gone from the lockfile entirely; all five consumer snapshot entries now read `uuid: 11.1.1`. Nothing in the tree resolves to an affected range.

**2. uuid@11.1.1 CJS interop + required exports**

```
$ node -e "const u=require('<store>/uuid@11.1.1/node_modules/uuid'); ..."
version 11.1.1
exports MAX,NIL,parse,stringify,v1,v1ToV6,v3,v4,v5,v6,v6ToV1,v7,validate,version
v4() b0d41636-7200-467d-9da9-f672314456d8
v1() c3a9a370-8ce5-11f1-8be2-d32c11488ece
v5() 05b16a01-46c6-56dd-bd6e-c6dfb4a1427a
```

v11 keeps a `require` condition in its exports map (`"require": "./dist/cjs/index.js"` for node, `./dist/cjs-browser/index.js` for browser), so CommonJS consumers keep working. No shim or patch needed.

**3. Every consumer actually loads and produces UUIDs under v11**

```
jayson generateId -> 01b936fb-3984-4750-95e3-5e5c6c6ccaba
rpc-websockets exports -> Client,CommonClient,DefaultDataPack,Server,WebSocket,createError
web3 Connection built -> true
web3 PublicKey -> 11111111111111111111111111111111
@sentry/webpack-plugin exports -> sentryCliBinaryExists,sentryWebpackPlugin
@solflare-wallet/sdk -> function
@solflare-wallet/metamask-sdk -> function
ALL CONSUMER LOADS OK
```

`jayson`'s `generateId()` is the exact call site of `require('uuid').v4` — it returns a well-formed v4, which is the tightest possible proof that the override didn't break the `@solana/web3.js` request-id path.

**4. Typecheck — all workspaces green**

```
$ pnpm -w typecheck
Tasks:    6 successful, 6 total
```

Notably `@types/uuid@8.3.4` still sits in the tree (a dep of `rpc-websockets`), but it is types-only, out of scope for this advisory, and causes no type conflicts — apps/web and packages/deploy both typecheck clean.

**5. Test suites**

```
$ pnpm --filter @superteam-lms/web test
Test Files  256 passed (256)
     Tests  2372 passed (2372)

$ pnpm test:scripts
Test Files  1 passed (1)
     Tests  26 passed (26)
```

**6. Full production build (exercises `@sentry/webpack-plugin`, a uuid@9 consumer, at build time)**

```
$ pnpm --filter @superteam-lms/web build   # with placeholder env
 ✓ Compiled successfully in 55s
 ✓ Generating static pages (106/106)
$ cat apps/web/.next/BUILD_ID
MRNAX7LokFDUkPiGroQPo
```

Bundling and all 106 static pages complete. (Placeholder Supabase/RPC/program-id env was supplied to get past env validation — the `fetch failed` lines during static generation are the expected offline degradation of `getActiveDeployments`, unrelated to this change.)

## Residual risk

- **`@types/uuid@8.3.4` remains** via `rpc-websockets`. Types only, no runtime impact, not covered by GHSA-w5hq-g745-h8pq. Left alone deliberately.
- **Pinned to the 11.x line.** When `jayson` / `rpc-websockets` publish ESM-capable releases, the override can move to 14.x; until then, moving past 11 breaks CJS `require('uuid')`. The `^11.1.1` range self-caps at the last 11.x, so a stray `pnpm update` cannot pull a CJS-less major.
- **Blanket (unqualified) override.** Any future dependency that legitimately needs uuid ≥ 12 would be silently pinned back to 11. Nothing in the tree does today; if that changes, split the override into `uuid@8` / `uuid@9` qualified forms.
- **On-chain integration tests** (`onchain-academy` ts-mocha) were not run — they need a live validator. They exercise `@solana/web3.js`, whose uuid path is covered by proof 3 above.

Closes #901
