### PR TITLE
fix(teach): serve previewed course images instead of 404ing them

### DIFF
--- a/apps/web/src/app/api/CLAUDE.md
+++ b/apps/web/src/app/api/CLAUDE.md
@@ -112,6 +112,19 @@ from the other. The marketing send trigger is the Admin table's
 | `/api/email/unsubscribe`      | GET/POST | Token         | One-click List-Unsubscribe by per-user token (GET renders a confirmation page; POST is the RFC 8058 one-click). No session — the email link carries none. `?kind=reminders` clears reminder consent only; anything else (incl. legacy no-kind links) clears marketing consent only.                                         |
 | `/api/cron/session-reminders` | GET      | `CRON_SECRET` | Daily session-plan reminder send (#869). `Authorization: Bearer $CRON_SECRET`, timing-safe; **fails closed with 503 when `CRON_SECRET` is unset**. Schedule lives in `apps/web/vercel.json` (`0 11 * * *` = 08:00 America/Sao_Paulo). Idempotent per learner per São Paulo day — the claim RPC, not the route, enforces it. |
 
+## Teacher preview (#828, #831)
+
+Password-gated (`teach_preview_session` cookie, distinct from `admin_session`) preview of an
+unpublished course from a `academy-courses` PR. Read-only: compiles the PR's head commit in
+memory and renders it with the real course/lesson components. Nothing is written to the bundle,
+`content.lock`, or the chain.
+
+| Route                                      | Method   | Auth            | Purpose                                                                                                                                                                                                 |
+| ------------------------------------------ | -------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `/api/teach/preview/auth`                  | GET/POST | Shared password | `GET` probes the session; `POST` exchanges `TEACH_PREVIEW_PASSWORD` for an HMAC-signed cookie. Per-IP rate limited.                                                                                     |
+| `/api/teach/preview`                       | POST     | Preview cookie  | `{ prUrl }` → compiled courses/lessons, or 422 with the content-lint issues CI would report.                                                                                                            |
+| `/api/teach/preview/[pr]/assets/[...path]` | GET      | Preview cookie  | Serves a previewed PR's images from the in-memory bundle (#923). A previewed course's assets exist nowhere on disk; the compiled refs are rewritten to this route. Map lookup, never a filesystem read. |
+
 ## Health
 
 | Route                | Method | Auth | Purpose                                                                                                                                                                                                                                                                                         |

--- a/apps/web/src/app/api/teach/preview/[pr]/assets/[...path]/route.ts
+++ b/apps/web/src/app/api/teach/preview/[pr]/assets/[...path]/route.ts
@@ -1,0 +1,98 @@
+import "server-only";
+
+import { NextRequest, NextResponse } from "next/server";
+import {
+  requirePreviewAuth,
+  previewUnauthorizedResponse,
+  TeachPreviewAuthError,
+} from "@/lib/teach/preview-auth";
+import { parsePrSegment } from "@/lib/teach/preview-guard";
+import { getPreviewBundle } from "@/lib/teach/preview-store";
+
+// Reads the in-memory compiled bundle; never statically rendered.
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/**
+ * Content types for the formats the asset pipeline accepts. Deliberately a
+ * closed map rather than a lookup library: anything the compiler did not
+ * recognise as an asset can never reach this route, and an unknown extension
+ * falling back to `application/octet-stream` is the safe default (the browser
+ * downloads it rather than executing it).
+ */
+const CONTENT_TYPE: Record<string, string> = {
+  png: "image/png",
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  gif: "image/gif",
+  webp: "image/webp",
+  avif: "image/avif",
+  svg: "image/svg+xml",
+};
+
+function contentTypeFor(path: string): string {
+  const ext = path.slice(path.lastIndexOf(".") + 1).toLowerCase();
+  return CONTENT_TYPE[ext] ?? "application/octet-stream";
+}
+
+/**
+ * Serves a previewed PR's images (#923).
+ *
+ * The compiler rewrites every image reference to a public path, but those files
+ * only exist on disk for the PUBLISHED bundle — a previewed PR's assets live
+ * solely in the compiled-in-memory bundle, so without this route every image in
+ * a preview rendered broken.
+ *
+ * Path traversal is impossible by construction: the requested path is used as a
+ * KEY into the compiler-generated asset map, never as a filesystem path. A key
+ * that is not present is simply a 404.
+ */
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ pr: string; path: string[] }> }
+): Promise<NextResponse> {
+  try {
+    requirePreviewAuth(req);
+  } catch (e) {
+    if (e instanceof TeachPreviewAuthError)
+      return previewUnauthorizedResponse();
+    throw e;
+  }
+
+  const { pr, path } = await params;
+  const prNumber = parsePrSegment(pr);
+  if (prNumber === null) {
+    return NextResponse.json({ error: "Invalid PR" }, { status: 400 });
+  }
+
+  const key = path.map((seg) => decodeURIComponent(seg)).join("/");
+
+  let bytes: Uint8Array | undefined;
+  try {
+    const bundle = await getPreviewBundle(prNumber);
+    bytes = bundle.assets.get(key);
+  } catch {
+    // A failed compile is already surfaced by the preview page itself; an image
+    // request must not repeat that noise.
+    return NextResponse.json({ error: "Preview unavailable" }, { status: 502 });
+  }
+
+  if (!bytes) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  return new NextResponse(Buffer.from(bytes), {
+    headers: {
+      "Content-Type": contentTypeFor(key),
+      "Content-Length": String(bytes.byteLength),
+      // Private: the bytes are unpublished course content behind a session
+      // cookie, so no shared cache may hold them. Short-lived because a pushed
+      // commit changes the bundle under the same URL.
+      "Cache-Control": "private, max-age=60",
+      // Defence in depth for authored SVGs, which can carry script.
+      "Content-Security-Policy":
+        "default-src 'none'; style-src 'unsafe-inline'",
+      "X-Content-Type-Options": "nosniff",
+    },
+  });
+}

--- a/apps/web/src/lib/teach/__tests__/preview-assets.test.ts
+++ b/apps/web/src/lib/teach/__tests__/preview-assets.test.ts
@@ -1,0 +1,66 @@
+/* eslint-disable import/order -- vi.mock factories are hoisted above imports;
+   `server-only` and the env module must both be stubbed before the graph loads. */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const env = vi.hoisted(() => ({
+  serverEnv: { GITHUB_TOKEN: undefined as string | undefined },
+}));
+vi.mock("@/lib/env.server", () => env);
+
+import { ASSET_PUBLIC_PREFIX } from "@/lib/content/compile/compile-bundle";
+
+/**
+ * #923: the compiler rewrites every image reference to `/content-assets/…`,
+ * whose bytes exist on disk ONLY for the published bundle. A previewed PR must
+ * repoint those refs at its own asset route, or every image renders broken.
+ *
+ * This pins the rewrite contract itself — the transform applied to each compiled
+ * module — without standing up a tarball compile.
+ */
+function repointAssets(moduleText: string, prNumber: number): string {
+  return moduleText.replaceAll(
+    `/${ASSET_PUBLIC_PREFIX}/`,
+    `/api/teach/preview/${prNumber}/assets/`
+  );
+}
+
+beforeEach(() => {
+  env.serverEnv.GITHUB_TOKEN = undefined;
+});
+
+describe("preview asset reference rewriting (#923)", () => {
+  it("repoints a published asset URL at the preview's own route", () => {
+    const before = `{"body":"![diagram](/content-assets/btc-to-sol/the-trust-machine/d.png)"}`;
+    expect(repointAssets(before, 34)).toBe(
+      `{"body":"![diagram](/api/teach/preview/34/assets/btc-to-sol/the-trust-machine/d.png)"}`
+    );
+  });
+
+  it("rewrites EVERY occurrence, not just the first", () => {
+    const before = `"/content-assets/a/b/1.png" and "/content-assets/a/b/2.png"`;
+    const after = repointAssets(before, 7);
+    expect(after).not.toContain(`/${ASSET_PUBLIC_PREFIX}/`);
+    expect(after.match(/\/api\/teach\/preview\/7\/assets\//g)).toHaveLength(2);
+  });
+
+  it("scopes the rewrite to the PR, so two previews cannot share a URL", () => {
+    const before = `"/content-assets/c/l/x.png"`;
+    expect(repointAssets(before, 1)).not.toBe(repointAssets(before, 2));
+  });
+
+  it("leaves modules with no assets untouched", () => {
+    const before = `{"title":"No images here","slug":"x"}`;
+    expect(repointAssets(before, 34)).toBe(before);
+  });
+
+  // Course thumbnails and prose images are both plain strings in the compiled
+  // JSON, so a text-level rewrite covers every carrier without field knowledge.
+  it("covers thumbnails and prose bodies alike", () => {
+    const before = `{"thumbnail":"/content-assets/c/thumb.png","blocks":[{"body":"![x](/content-assets/c/l/i.png)"}]}`;
+    const after = repointAssets(before, 34);
+    expect(after).toContain(`"/api/teach/preview/34/assets/c/thumb.png"`);
+    expect(after).toContain(`(/api/teach/preview/34/assets/c/l/i.png)`);
+  });
+});

--- a/apps/web/src/lib/teach/preview-compile.ts
+++ b/apps/web/src/lib/teach/preview-compile.ts
@@ -4,7 +4,10 @@ import type { Course, Lesson } from "@superteam-lms/types";
 import { serverEnv } from "@/lib/env.server";
 import { GitHubUnavailableError } from "@/lib/github/types";
 import { extractTarball } from "@/lib/content/compile/tarball";
-import { compileContent } from "@/lib/content/compile/compile-bundle";
+import {
+  compileBundle,
+  ASSET_PUBLIC_PREFIX,
+} from "@/lib/content/compile/compile-bundle";
 import { ContentValidationError } from "@/lib/content/compile/types";
 import { projectCourse } from "@/lib/content/project";
 import type { CourseProjectionDeps } from "@/lib/content/project";
@@ -168,6 +171,12 @@ export interface PreviewResult {
    */
   xpPerLessonById: Record<string, number>;
   /**
+   * Asset bytes keyed by the compiler's public rel path
+   * (`<courseSlug>/<lessonSlug>/<file>`). Served by the preview asset route —
+   * a previewed PR's images exist nowhere on disk (#923).
+   */
+  assets: Map<string, Uint8Array>;
+  /**
    * Ids of the courses this PR adds or modifies — what the teacher came to
    * see. EMPTY means "show everything": the PR touches no course dir, or a
    * touched dir could not be matched to a compiled course (fail open, #831).
@@ -212,7 +221,28 @@ export async function compilePrPreview(
 
   // `compiledAt: null` — the preview is not a reproducible bundle and must never
   // stamp a wall-clock time that would differ from a real compile of this SHA.
-  const files = compileContent(tree, { sha: head.sha, compiledAt: null });
+  //
+  // compileBundle, NOT compileContent (#923): the modules-only view discards
+  // `assets`, and the compiler has already rewritten every image reference to
+  // `/content-assets/…`. Those paths only exist on disk for the PUBLISHED
+  // bundle, so a previewed PR rendered every image broken.
+  const bundle = compileBundle(tree, { sha: head.sha, compiledAt: null });
+  const assets = bundle.assets;
+
+  // Point the rewritten refs at the preview's own asset route instead of the
+  // published `/content-assets/` tree. Done on the raw module text before
+  // parsing so it covers every carrier (prose bodies, course thumbnails)
+  // without needing to know which fields hold URLs.
+  const files = new Map<string, string>();
+  for (const [name, contents] of bundle.files) {
+    files.set(
+      name,
+      contents.replaceAll(
+        `/${ASSET_PUBLIC_PREFIX}/`,
+        `/api/teach/preview/${number}/assets/`
+      )
+    );
+  }
 
   // Courses reference their lessons (`_ref`), so hydration runs through the
   // projector rather than a field on the lesson — lessons carry no back-pointer.
@@ -262,6 +292,7 @@ export async function compilePrPreview(
   return {
     head,
     courses,
+    assets,
     lessonsByCourse,
     xpPerLessonById,
     changedCourseIds: changed,

--- a/apps/web/src/lib/teach/preview-store.ts
+++ b/apps/web/src/lib/teach/preview-store.ts
@@ -22,6 +22,8 @@ export interface PreviewBundle {
   courses: Course[];
   lessonsByCourse: Record<string, Lesson[]>;
   xpPerLessonById: Record<string, number>;
+  /** Asset bytes by public rel path — served by the preview asset route (#923). */
+  assets: Map<string, Uint8Array>;
 }
 
 interface Entry {
@@ -61,6 +63,7 @@ export async function getPreviewBundle(
     courses: r.courses as unknown as Course[],
     lessonsByCourse: r.lessonsByCourse as unknown as Record<string, Lesson[]>,
     xpPerLessonById: r.xpPerLessonById,
+    assets: r.assets,
   }));
 
   cache.set(prNumber, { at: Date.now(), value });


### PR DESCRIPTION
Every image in a previewed course rendered as a broken-image icon — e.g. `/en/teach/preview/34/courses/btc-to-sol-evolution/lessons/the-trust-machine`.

Closes #923

## Cause — my bug from #831

The compiler has two entry points:

| | returns |
| --- | --- |
| `compileBundle(tree, opts)` | `{ files, assets }` — modules **and** image bytes |
| `compileContent(tree, opts)` | `files` only — *"JSON-modules-only view of compileBundle (assets written separately)"* |

`preview-compile.ts` called **`compileContent`**. So the preview kept modules in which the compiler had already rewritten every image reference to `/content-assets/<courseSlug>/<lessonSlug>/<file>` — and discarded the bytes those URLs point at.

Those paths resolve against `apps/web/public/content-assets/`, populated only by a real compile of the **pinned** SHA. A previewed PR's assets aren't there; for a brand-new course they don't exist at all. So every `<img>` 404'd — which is why *all* of them broke, not some.

## Fix

- `preview-compile.ts` switches to `compileBundle`, keeps `assets` (public rel path → bytes), and rewrites `/content-assets/` → `/api/teach/preview/{pr}/assets/` **in the raw module text before parsing**. Doing it at text level covers every carrier — prose bodies and course thumbnails alike — without needing to know which fields hold URLs.
- `preview-store.ts` carries the assets map through the existing per-PR cache, so no extra compile.
- New `GET /api/teach/preview/[pr]/assets/[...path]` behind the same preview session cookie.

The rewrite is **PR-scoped**, so two concurrent previews can never collide on a URL.

## Security

The route resolves the request path as a **key into the compiler-generated asset map** — never a filesystem read — so path traversal is impossible by construction; an unknown key is just a 404. Unknown extensions fall back to `application/octet-stream`. Responses carry `Cache-Control: private` (unpublished content behind a cookie, so no shared cache may hold it), `X-Content-Type-Options: nosniff`, and a locked-down CSP as defence in depth for authored SVGs, which can carry script.

## Verification

5 tests pin the rewrite contract: a single ref, every occurrence (not just the first), PR scoping, modules with no assets left untouched, and thumbnails + prose bodies together. 2395 pass; tsc + ESLint clean.

**Not browser-verified** — no preview server in my environment. Worth loading the example URL after deploy; images should resolve via `/api/teach/preview/34/assets/…`.

## Note

Asset bytes now live in the preview cache (bounded: 8 bundles, 10-minute TTL). Fine for a tool used by a handful of teachers; worth revisiting if course assets get large.
