### PR TITLE
test(teach): execute the preview asset path, not a copy of it (#923 follow-up)

### DIFF
--- a/apps/web/src/app/api/teach/preview/[pr]/assets/__tests__/route.test.ts
+++ b/apps/web/src/app/api/teach/preview/[pr]/assets/__tests__/route.test.ts
@@ -1,0 +1,126 @@
+/* eslint-disable import/order -- vi.mock factories are hoisted above imports. */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+// The store is the compile cache; stub it so this file is about SERVING bytes.
+// The compile itself is covered in `lib/teach/__tests__/preview-compile-assets`.
+const store = vi.hoisted(() => ({ getPreviewBundle: vi.fn() }));
+vi.mock("@/lib/teach/preview-store", () => store);
+
+import { NextRequest } from "next/server";
+import { GET } from "../[...path]/route";
+import {
+  mintPreviewSession,
+  TEACH_PREVIEW_COOKIE,
+} from "@/lib/teach/preview-auth";
+
+const PNG = new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10]);
+const SVG = new TextEncoder().encode(
+  "<svg xmlns='http://www.w3.org/2000/svg'/>"
+);
+const PNG_KEY = "demo/accounts/pixel.png";
+const SVG_KEY = "demo/accounts/diagram.svg";
+
+function bundle(): unknown {
+  return {
+    assets: new Map<string, Uint8Array>([
+      [PNG_KEY, PNG],
+      [SVG_KEY, SVG],
+    ]),
+  };
+}
+
+function request(authed: boolean): NextRequest {
+  const headers = new Headers();
+  if (authed) {
+    headers.set(
+      "cookie",
+      `${TEACH_PREVIEW_COOKIE}=${encodeURIComponent(mintPreviewSession())}`
+    );
+  }
+  return new NextRequest("https://app.test/api/teach/preview/34/assets/x", {
+    headers,
+  });
+}
+
+function ctx(
+  pr: string,
+  path: string[]
+): { params: Promise<{ pr: string; path: string[] }> } {
+  return { params: Promise.resolve({ pr, path }) };
+}
+
+beforeEach(() => {
+  store.getPreviewBundle.mockReset();
+});
+
+describe("GET /api/teach/preview/[pr]/assets/[...path] (#923)", () => {
+  it("serves the cached bytes for the compiled key", async () => {
+    store.getPreviewBundle.mockResolvedValue(bundle());
+
+    const res = await GET(request(true), ctx("34", PNG_KEY.split("/")));
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("image/png");
+    expect(new Uint8Array(await res.arrayBuffer())).toEqual(PNG);
+    expect(store.getPreviewBundle).toHaveBeenCalledWith(34);
+  });
+
+  it("hardens the response: nosniff, locked-down CSP, private cache", async () => {
+    store.getPreviewBundle.mockResolvedValue(bundle());
+
+    // SVG is the case that matters — authored, unreviewed, and script-capable
+    // if a browser ever renders it as a document on our own origin.
+    const res = await GET(request(true), ctx("34", SVG_KEY.split("/")));
+
+    expect(res.headers.get("content-type")).toBe("image/svg+xml");
+    expect(res.headers.get("x-content-type-options")).toBe("nosniff");
+    expect(res.headers.get("content-security-policy")).toContain(
+      "default-src 'none'"
+    );
+    // Unpublished content behind a session cookie: no shared cache may hold it.
+    expect(res.headers.get("cache-control")).toContain("private");
+  });
+
+  it("401s without a preview session, and never reaches the bundle", async () => {
+    const res = await GET(request(false), ctx("34", PNG_KEY.split("/")));
+
+    expect(res.status).toBe(401);
+    expect(store.getPreviewBundle).not.toHaveBeenCalled();
+  });
+
+  it("404s a traversal attempt — the path is a map key, not a filesystem path", async () => {
+    store.getPreviewBundle.mockResolvedValue(bundle());
+
+    const res = await GET(
+      request(true),
+      ctx("34", ["..", "..", "etc", "passwd"])
+    );
+
+    expect(res.status).toBe(404);
+  });
+
+  it("404s a key the compiler never emitted", async () => {
+    store.getPreviewBundle.mockResolvedValue(bundle());
+
+    const res = await GET(request(true), ctx("34", ["demo", "nope.png"]));
+
+    expect(res.status).toBe(404);
+  });
+
+  it("rejects a non-numeric pr segment before compiling anything", async () => {
+    const res = await GET(request(true), ctx("../admin", ["x.png"]));
+
+    expect(res.status).toBe(400);
+    expect(store.getPreviewBundle).not.toHaveBeenCalled();
+  });
+
+  it("502s when the PR will not compile, instead of hanging on the error", async () => {
+    store.getPreviewBundle.mockRejectedValue(new Error("boom"));
+
+    const res = await GET(request(true), ctx("34", PNG_KEY.split("/")));
+
+    expect(res.status).toBe(502);
+  });
+});

--- a/apps/web/src/lib/content/compile/__tests__/_fixtures.ts
+++ b/apps/web/src/lib/content/compile/__tests__/_fixtures.ts
@@ -98,6 +98,9 @@ function lessonYaml(withImage: boolean): string {
     id: "lesson-accounts",
     slug: "accounts",
     title: "Accounts",
+    // Required since #466 C3; each slug must exist in the root skills.yaml the
+    // tarball below carries, or `validateTree` rejects the whole fixture.
+    skills: ["pdas"],
     blocks: [{ key: "intro", type: "prose", src: "intro.md" }],
   });
 }
@@ -119,6 +122,7 @@ export function makeCourseTarball(
     ? "# Accounts\n\nSee ![pixel](assets/pixel.png) here.\n"
     : "# Accounts\n";
   const files: Record<string, string | Uint8Array> = {
+    [`${top}/skills.yaml`]: "- slug: pdas\n  label: PDAs\n",
     [`${top}/courses/demo/course.yaml`]: courseYaml,
     [`${top}/courses/demo/slots.lock.json`]: slotsLockJson,
     [`${lessonDir}/lesson.yaml`]: lessonYaml(opts.withImage ?? false),

--- a/apps/web/src/lib/teach/__tests__/preview-compile-assets.test.ts
+++ b/apps/web/src/lib/teach/__tests__/preview-compile-assets.test.ts
@@ -1,0 +1,102 @@
+/* eslint-disable import/order -- vi.mock factories are hoisted above imports;
+   `server-only` and the env module must both be stubbed before the graph loads. */
+import { describe, it, expect, afterEach, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const env = vi.hoisted(() => ({
+  serverEnv: { GITHUB_TOKEN: undefined as string | undefined },
+}));
+vi.mock("@/lib/env.server", () => env);
+
+import { compilePrPreview } from "../preview-compile";
+import {
+  makeCourseTarball,
+  PNG_1X1,
+} from "@/lib/content/compile/__tests__/_fixtures";
+
+/**
+ * End-to-end cover for #923, through the SHIPPED compile path rather than a
+ * re-implementation of the rewrite: a real tarball goes in, and what comes out
+ * must carry both halves of a working image — the bytes, and a url that can
+ * serve them. `compileContent` (the pre-#923 call) satisfies neither.
+ */
+
+const SHA = "b".repeat(40);
+const PR = 34;
+const ASSET_KEY = "demo/accounts/pixel.png";
+
+/** GitHub responses in call order: the PR head, the tarball, then pulls/N/files. */
+function stubGitHub(): void {
+  const tarball = makeCourseTarball(SHA, { withImage: true });
+  vi.stubGlobal(
+    "fetch",
+    vi
+      .fn()
+      .mockImplementationOnce(() =>
+        Promise.resolve(
+          new Response(
+            JSON.stringify({
+              head: { sha: SHA, ref: "feat/images" },
+              title: "Add a course with images",
+              state: "open",
+              user: { login: "someone" },
+            }),
+            { status: 200, headers: { "content-type": "application/json" } }
+          )
+        )
+      )
+      .mockImplementationOnce(() =>
+        Promise.resolve(new Response(new Uint8Array(tarball), { status: 200 }))
+      )
+      .mockImplementation(() =>
+        Promise.resolve(
+          new Response("[]", {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          })
+        )
+      )
+  );
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("compilePrPreview asset handling (#923)", () => {
+  it("keeps the compiled bytes on the result", async () => {
+    stubGitHub();
+
+    const result = await compilePrPreview(PR);
+
+    expect([...result.assets.keys()]).toContain(ASSET_KEY);
+    expect(Buffer.from(result.assets.get(ASSET_KEY)!)).toEqual(PNG_1X1);
+  });
+
+  it("points the rendered lesson at the preview route, not the published tree", async () => {
+    stubGitHub();
+
+    const result = await compilePrPreview(PR);
+
+    // What the lesson page actually renders — the hydrated, projected lesson.
+    const rendered = JSON.stringify(result.lessonsByCourse["course-demo"]);
+    expect(rendered).toContain(`/api/teach/preview/${PR}/assets/${ASSET_KEY}`);
+    // `/content-assets/...` would resolve against the PINNED bundle's static
+    // files, which never contain a previewed PR's assets.
+    expect(rendered).not.toContain("/content-assets/");
+  });
+
+  it("keys the assets exactly as the rewritten urls address them", async () => {
+    stubGitHub();
+
+    const result = await compilePrPreview(PR);
+
+    // The route serves `assets.get(path)` for the path in the url, so any drift
+    // between the two halves is a broken image no unit test of either half sees.
+    const rendered = JSON.stringify(result.lessonsByCourse["course-demo"]);
+    for (const key of result.assets.keys()) {
+      expect(rendered).toContain(`/api/teach/preview/${PR}/assets/${key}`);
+    }
+  });
+});


### PR DESCRIPTION
Follow-up to #924 (David's fix for #923, which is correct and already merged — this changes no production code).

## Why

#924's tests define a local `repointAssets()` helper and assert against *that*, so the shipped path is never executed: `preview-compile.ts` could revert to `compileContent` and all five tests would still pass. The new serving route, `GET /api/teach/preview/[pr]/assets/[...path]`, has no test at all — including its auth gate.

## What

- **`lib/teach/__tests__/preview-compile-assets.test.ts`** — drives the real `compilePrPreview` against a tarball fixture and pins both halves of a working image together: the bytes survive on `result.assets`, the projected lesson references `/api/teach/preview/34/assets/demo/accounts/pixel.png`, nothing `/content-assets/` is left, and every asset key is addressed by a rendered url (drift between the two halves is a broken image that no unit test of either half alone would catch).
  Red-proofed: with `preview-compile.ts` restored to its pre-#924 content, 3/3 fail (`Cannot read properties of undefined (reading 'keys')`, and the lesson still carries `/content-assets/`).
- **route tests** — bytes + `image/png`; the SVG hardening (`nosniff`, `default-src 'none'`, `Cache-Control: private`); **401 without a preview session, asserting the bundle is never touched**; 404 on traversal (`..` segments) and on a key the compiler never emitted; 400 on a non-numeric `pr`; 502 on a failed compile.
- **`_fixtures.ts` repair** — `makeCourseTarball` predates the #466 C3 `skills` requirement, so every tarball it produced failed `validateTree`. It had no callers left, so nobody noticed; it is now valid (lesson `skills: [pdas]` + a root `skills.yaml`) and usable again.

## Verification

- `pnpm --filter web test` — 266 files, 2545 tests, all green
- `pnpm --filter web typecheck` — clean
- `pnpm --filter web lint` — no new findings

Diagnosis and fix credit for #923 goes to David (Potolski).