### PR TITLE
fix(ai): Gemini 3.x rejects thinkingBudget — restore all AI partner turns

### DIFF
--- a/apps/web/src/app/api/ai/__tests__/partner-route.test.ts
+++ b/apps/web/src/app/api/ai/__tests__/partner-route.test.ts
@@ -801,6 +801,12 @@ describe("POST /api/ai/partner", () => {
     };
     // Output budget dropped 8192 -> 2048 (AIE-15; closes AIE-11's inflation lever).
     expect(sent.generationConfig.maxOutputTokens).toBe(2048);
+    // 3.x thinking floor — the 2.5-era `thinkingBudget` 400s on every routed
+    // model (AIE-05 correction, 2026-07-31); this broke all turns post-#890.
+    expect(
+      (sent.generationConfig as { thinkingConfig?: Record<string, unknown> })
+        .thinkingConfig
+    ).toEqual({ thinkingLevel: "low" });
     // The propose schema requests an `edits` array and NO whole-file field.
     const schema = sent.generationConfig.responseSchema;
     expect(schema.properties).toHaveProperty("edits");

--- a/apps/web/src/app/api/ai/partner/route.ts
+++ b/apps/web/src/app/api/ai/partner/route.ts
@@ -16,7 +16,11 @@ import {
 } from "@/lib/ai/spend-ledger";
 import type { GeminiUsageMetadata } from "@/lib/ai/spend-ledger";
 import { sealCheck } from "@/lib/ai/check-seal";
-import { modelForAction, geminiUrl } from "@/lib/ai/models";
+import {
+  modelForAction,
+  geminiUrl,
+  MINIMAL_THINKING_CONFIG,
+} from "@/lib/ai/models";
 import {
   buildStaticPrefix,
   buildDynamicSuffix,
@@ -81,10 +85,12 @@ interface GeminiEnvelope {
 // the prod key (#838 comment, AIE-04) returned HTTP 200 for 3.5-flash,
 // 3.5-flash-lite and 3.6-flash, and 2.5-flash/-lite appear in this key's model
 // list; the 404s that produced the folklore were a first-connection artifact
-// (empty-bodied, gone on retry). Same record, AIE-05: `thinkingBudget: 0` is
-// verified honored — every routed model here is a thinking model whose thinking
-// tokens would draw from maxOutputTokens and bill at the output rate, so the
-// flag stays on for all of them.
+// (empty-bodied, gone on retry). AIE-05 CORRECTION (2026-07-31): the 3.x
+// models reject the 2.5-era `thinkingBudget: 0` with 400 INVALID_ARGUMENT —
+// this broke every partner turn from the #890 model swap until this fix. The
+// 3.x floor is `thinkingLevel: "low"` (MINIMAL_THINKING_CONFIG in
+// lib/ai/models); thinking tokens still draw from maxOutputTokens and bill at
+// the output rate, so the floor stays on for all of them.
 //
 // A model that 404s FAILS CLOSED: the !response.ok branch below refunds the
 // assist and 502s. There is deliberately no silent fallback to another model —
@@ -516,11 +522,12 @@ export async function POST(request: NextRequest) {
           maxOutputTokens: degraded
             ? degradedMaxTokens(maxTokensFor(action, { socratic }))
             : maxTokensFor(action, { socratic }),
-          // Every routed model is a thinking model and thinking tokens share the
-          // maxOutputTokens budget (and bill at the output rate); disable it so
-          // the full budget goes to the structured response (and to cut
-          // latency/cost). Verified honored per model — #838 AIE-05.
-          thinkingConfig: { thinkingBudget: 0 },
+          // Every routed model is a thinking model and thinking tokens share
+          // the maxOutputTokens budget (and bill at the output rate); keep
+          // thinking at the model's floor. NOTE the 3.x API rejects the 2.5-era
+          // `thinkingBudget: 0` with a 400 — "low" is the minimum thinkingLevel
+          // (AIE-05 correction, 2026-07-31; see lib/ai/models.ts).
+          thinkingConfig: MINIMAL_THINKING_CONFIG,
           responseMimeType: "application/json",
           responseSchema: responseSchemaFor(action),
         },

--- a/apps/web/src/lib/ai/__tests__/reflection-reply.test.ts
+++ b/apps/web/src/lib/ai/__tests__/reflection-reply.test.ts
@@ -70,6 +70,27 @@ describe("maybeGenerateReflectionReply", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it("sends the 3.x thinkingLevel floor, never the 2.5-era thinkingBudget", async () => {
+    // The 3.x models 400 INVALID_ARGUMENT on `thinkingBudget` — this exact
+    // regression silently broke every AI turn after the #890 model swap.
+    const fetchMock = stubGeminiFetch("Nice work");
+    const { maybeGenerateReflectionReply } =
+      await import("../reflection-reply");
+    await maybeGenerateReflectionReply(INPUT);
+    const body = JSON.parse(
+      String(
+        (fetchMock.mock.calls[0] as unknown[])[1] &&
+          ((fetchMock.mock.calls[0] as unknown[])[1] as RequestInit).body
+      )
+    ) as { generationConfig: { thinkingConfig: Record<string, unknown> } };
+    expect(body.generationConfig.thinkingConfig).toEqual({
+      thinkingLevel: "low",
+    });
+    expect(body.generationConfig.thinkingConfig).not.toHaveProperty(
+      "thinkingBudget"
+    );
+  });
+
   it("calls the CHEAP routed model, not the old 3.5-flash pin (#868)", async () => {
     const fetchMock = stubGeminiFetch("Nice work");
     const { maybeGenerateReflectionReply } =

--- a/apps/web/src/lib/ai/models.ts
+++ b/apps/web/src/lib/ai/models.ts
@@ -15,10 +15,15 @@ import type { PartnerAction } from "@/lib/ai/partner-types";
 // — so any future "this model 404s for our key" claim must be re-tested twice
 // before it is believed (or written down).
 //
-// AIE-05 from the same record: `thinkingConfig: { thinkingBudget: 0 }` is
-// VERIFIED HONORED (no `thoughtsTokenCount` under budget-0; 146 thinking tokens
-// on the no-config control). Callers keep sending it — thinking tokens bill at
-// the OUTPUT rate, so it is a real cost lever, not a formality.
+// AIE-05 correction (2026-07-31, supersedes the 2026-07-28 record): the 3.x
+// models now REJECT `thinkingConfig: { thinkingBudget: 0 }` with a 400
+// INVALID_ARGUMENT — `thinkingBudget` is the 2.5-era field. The 3.x field is
+// `thinkingLevel`, whose MINIMUM is "low" ("none" is not a valid enum value;
+// probed empirically on both routed models). Every generateContent caller must
+// send MINIMAL_THINKING_CONFIG below; thinking tokens still bill at the OUTPUT
+// rate and share maxOutputTokens, so keeping thinking minimal remains a real
+// cost lever. Probed at "low" with the hint schema: zero thinking tokens on a
+// trivial prompt, valid JSON, finish STOP.
 
 export const GEMINI_MODELS = [
   "gemini-3.6-flash",
@@ -146,3 +151,13 @@ export function modelForReflectionReply(): GeminiModel {
 export function geminiUrl(model: GeminiModel): string {
   return `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent`;
 }
+
+/**
+ * The minimal thinking configuration accepted by every routed (3.x) model.
+ * `thinkingLevel: "low"` is the FLOOR — `"none"` is not a valid enum value, and
+ * the 2.5-era `thinkingBudget: 0` is rejected outright with a 400
+ * INVALID_ARGUMENT (see the AIE-05 correction in the header). All
+ * generateContent callers must spread this rather than hand-rolling a
+ * thinkingConfig, so a future API change is a one-line fix here.
+ */
+export const MINIMAL_THINKING_CONFIG = { thinkingLevel: "low" } as const;

--- a/apps/web/src/lib/ai/reflection-reply.ts
+++ b/apps/web/src/lib/ai/reflection-reply.ts
@@ -7,7 +7,11 @@ import {
   degradedMaxTokens,
 } from "@/lib/ai/spend-ledger";
 import type { GeminiUsageMetadata } from "@/lib/ai/spend-ledger";
-import { modelForReflectionReply, geminiUrl } from "@/lib/ai/models";
+import {
+  modelForReflectionReply,
+  geminiUrl,
+  MINIMAL_THINKING_CONFIG,
+} from "@/lib/ai/models";
 
 // Best-effort AI feedback for an `openEnded` reflection. NEVER blocks the seal:
 // the attestation route computes and returns the receipt independently, then
@@ -145,7 +149,8 @@ export async function maybeGenerateReflectionReply({
         generationConfig: {
           temperature: 0.4,
           maxOutputTokens: outputTokens,
-          thinkingConfig: { thinkingBudget: 0 },
+          // 3.x floor — the 2.5-era `thinkingBudget: 0` 400s (see models.ts).
+          thinkingConfig: MINIMAL_THINKING_CONFIG,
         },
       }),
     });


### PR DESCRIPTION
## Prod-down fix: the AI tutor has served zero successful turns since the #890 model swap

**Symptom** (owner-reported with screenshot): authored hints render, then the first real AI turn shows "Something went wrong. Try again."

**Evidence trail**
- `challenge_assists` row for the reported lesson touched today with `assists_used: 0` — the ladder spent and correctly **refunded** the failed turn.
- `ai_spend_ledger` last successful spend: **2026-07-27** — nothing since the routed models changed.
- Local repro with the route's exact request construction: **400 INVALID_ARGUMENT**.
- Bisect: removing `thinkingConfig: { thinkingBudget: 0 }` → 200. `thinkingBudget` is the 2.5-era field; 3.x models reject it. `thinkingLevel: "none"` is an invalid enum; **"low" is the floor** (probed on both routed models).
- `thinkingLevel: "low"` + real hint responseSchema + 512 cap → 200, finish STOP, valid JSON, zero thinking tokens billed on a trivial prompt.

## Fix
- `lib/ai/models.ts`: shared `MINIMAL_THINKING_CONFIG = { thinkingLevel: "low" }` + the stale AIE-05 verification record corrected in place (dated).
- Partner route + reflection-reply now send the shared constant (single point for future API changes).
- Regression tests in both suites assert the request body carries `thinkingLevel` and never `thinkingBudget`.

## Verification
- `pnpm vitest run src/app/api/ai src/lib/ai`: 13 files / 222 tests pass; typecheck clean.
- Live-API probes above (local key; failure is body-shape, not key-scope).

Root-cause class: AIE-05's "verified honored" was true against the pre-#890 models and silently invalidated by the model swap. The corrected comment warns about exactly that.

(Note: originally authored on `fix/gemini3-thinking-config-31-07-2026`, which collided with the concurrent brand-wave session's checkout — this branch is the clean cherry-pick onto main.)