### PR TITLE
fix(lesson): quiz block interaction states — lock correct answers, light up Next, completion state

### DIFF
--- a/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/blocks/__tests__/quiz-block.test.tsx
+++ b/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/blocks/__tests__/quiz-block.test.tsx
@@ -245,6 +245,111 @@ describe("QuizBlock — proofs and answered reporting", () => {
   });
 });
 
+describe("QuizBlock — interaction states (#943)", () => {
+  it("locks the question and disables Check after a CORRECT check", () => {
+    renderWithIntl(<QuizBlock block={quizBlock} ctx={makeCtx()} />);
+    const correctOption = screen.getByLabelText("A program-derived address");
+    fireEvent.click(correctOption);
+    fireEvent.click(checkButton());
+
+    expect(correctOption).toBeDisabled();
+    expect(screen.getByLabelText("A private key")).toBeDisabled();
+    expect(checkButton()).toBeDisabled();
+    // Correct-state styling + explanation survive the lock.
+    expect(screen.getByText("Correct!")).toBeInTheDocument();
+    expect(
+      screen.getByText("PDAs are derived from seeds and the program id.")
+    ).toBeInTheDocument();
+    expect(correctOption.closest("label")?.className).toContain(
+      "border-success"
+    );
+  });
+
+  it("leaves the question re-checkable after an INCORRECT check", () => {
+    renderWithIntl(<QuizBlock block={quizBlock} ctx={makeCtx()} />);
+    fireEvent.click(screen.getByLabelText("A private key"));
+    fireEvent.click(checkButton());
+
+    expect(screen.getByLabelText("A private key")).toBeEnabled();
+    expect(checkButton()).toBeEnabled();
+  });
+
+  it("Enter cannot re-check a locked question", () => {
+    const ctx = makeCtx();
+    renderWithIntl(<QuizBlock block={quizBlock} ctx={ctx} />);
+    const correctOption = screen.getByLabelText("A program-derived address");
+    fireEvent.click(correctOption);
+    fireEvent.click(checkButton());
+    // Still exactly one verdict — Enter is a no-op once locked.
+    fireEvent.keyDown(correctOption, { key: "Enter" });
+    expect(screen.getAllByText("Correct!")).toHaveLength(1);
+  });
+
+  it("emphasizes Next only once the current question is correct", () => {
+    renderWithIntl(<QuizBlock block={quizBlock} ctx={makeCtx()} />);
+    expect(nextButton().className).toContain("bg-transparent");
+    expect(nextButton().className).not.toContain("bg-primary");
+
+    fireEvent.click(screen.getByLabelText("A program-derived address"));
+    fireEvent.click(checkButton());
+    expect(nextButton().className).toContain("bg-primary");
+  });
+
+  it("keeps Next subdued when the current answer is wrong", () => {
+    renderWithIntl(<QuizBlock block={quizBlock} ctx={makeCtx()} />);
+    fireEvent.click(screen.getByLabelText("A private key"));
+    fireEvent.click(checkButton());
+    expect(nextButton().className).not.toContain("bg-primary");
+  });
+
+  it("shows an in-block completion state only when EVERY question is correct", () => {
+    renderWithIntl(<QuizBlock block={quizBlock} ctx={makeCtx()} />);
+    expect(screen.queryByText("Complete")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("All 2 questions answered correctly.")
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByLabelText("A program-derived address"));
+    fireEvent.click(checkButton());
+    // One of two — not a sweep yet.
+    expect(
+      screen.queryByText("All 2 questions answered correctly.")
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(nextButton());
+    fireEvent.click(screen.getByLabelText("XP tokens"));
+    fireEvent.click(screen.getByLabelText("Credentials"));
+    fireEvent.click(checkButton());
+
+    expect(screen.getByText("Complete")).toBeInTheDocument();
+    const summary = screen.getByText("All 2 questions answered correctly.");
+    expect(summary).toBeInTheDocument();
+    expect(summary.closest('[aria-live="polite"]')).not.toBeNull();
+    expect(screen.getByText("2/2 correct")).toBeInTheDocument();
+  });
+
+  it("states the AI gate with a live N/M answered counter", () => {
+    renderWithIntl(<QuizBlock block={quizBlock} ctx={makeCtx()} />);
+    expect(
+      screen.getByText("AI Partner unlocks after the quiz — 0/2 answered")
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByLabelText("A private key")); // wrong still counts
+    fireEvent.click(checkButton());
+    expect(
+      screen.getByText("AI Partner unlocks after the quiz — 1/2 answered")
+    ).toBeInTheDocument();
+
+    fireEvent.click(nextButton());
+    fireEvent.click(screen.getByLabelText("SOL"));
+    fireEvent.click(checkButton());
+    // Gate satisfied — the note retires entirely.
+    expect(
+      screen.queryByText(/AI Partner unlocks after the quiz/)
+    ).not.toBeInTheDocument();
+  });
+});
+
 describe("QuizBlock — stepper (#849)", () => {
   it("shows one question per card and navigates with next/prev", () => {
     renderWithIntl(<QuizBlock block={quizBlock} ctx={makeCtx()} />);

--- a/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/blocks/quiz-block.tsx
+++ b/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/blocks/quiz-block.tsx
@@ -51,6 +51,12 @@ function isChoiceCorrect(q: QuizQuestionData, chosen: string[]): boolean {
  * All per-question state lives in maps keyed by question id, so answers,
  * verdicts, and feedback survive navigating away and back. Single-question
  * quizzes render without any stepper chrome.
+ *
+ * Interaction states (#943): a question that has been checked CORRECT locks —
+ * its inputs and its Check button disable, while the correct styling and the
+ * explanation stay on screen. Next lights up once the current question is
+ * correct, and a clean sweep renders an in-block completion state (no popup,
+ * per the three-popup rule).
  */
 export function QuizBlock({ block, ctx }: BlockRenderProps) {
   const b = block as QuizBlockData;
@@ -72,7 +78,8 @@ export function QuizBlock({ block, ctx }: BlockRenderProps) {
     ctx.setProof(b.key, { selections });
   }, [selections, b.key, ctx]);
 
-  const allChecked = b.questions.every((q) => checkedEver[q.id]);
+  const answeredCount = b.questions.filter((q) => checkedEver[q.id]).length;
+  const allChecked = answeredCount === b.questions.length;
   useEffect(() => {
     ctx.setQuizAnswered(b.key, allChecked);
   }, [allChecked, b.key, ctx]);
@@ -101,8 +108,8 @@ export function QuizBlock({ block, ctx }: BlockRenderProps) {
   );
 
   const check = useCallback(
-    (q: QuizQuestionData, chosen: string[]) => {
-      if (chosen.length === 0) return;
+    (q: QuizQuestionData, chosen: string[], locked: boolean) => {
+      if (chosen.length === 0 || locked) return;
       const correct = isChoiceCorrect(q, chosen);
       setResults((prev) => ({
         ...prev,
@@ -142,6 +149,23 @@ export function QuizBlock({ block, ctx }: BlockRenderProps) {
     promptRef.current?.focus();
   }, [current]);
 
+  // Collapsed summary (#770): how many questions are currently answered
+  // correctly. Turns green only at a clean sweep, so the badge doubles as the
+  // "done" signal when the section is folded away.
+  const correctCount = b.questions.filter((q) => results[q.id]?.correct).length;
+  const allCorrect = total > 0 && correctCount === total;
+
+  const multi = q?.multiSelect ?? false;
+  const chosen = q ? (selections[q.id] ?? []) : [];
+  const result: CheckResult | undefined = q ? results[q.id] : undefined;
+  const chosenWithFeedback =
+    q && result
+      ? q.options.filter((o) => result.chosen.includes(o.id) && o.feedback)
+      : [];
+  // A correct verdict freezes the question (#943): nothing left to change, so
+  // inputs and Check disable while the verdict + explanation stay visible.
+  const locked = result?.correct ?? false;
+
   const onBodyKeyDown = (event: React.KeyboardEvent<HTMLDivElement>): void => {
     if (!q) return;
     const tag = (event.target as HTMLElement).tagName;
@@ -150,9 +174,9 @@ export function QuizBlock({ block, ctx }: BlockRenderProps) {
       // else in the card, Enter checks the current question.
       if (tag === "BUTTON" || tag === "A" || tag === "TEXTAREA") return;
       const chosen = selections[q.id] ?? [];
-      if (chosen.length === 0) return;
+      if (chosen.length === 0 || locked) return;
       event.preventDefault();
-      check(q, chosen);
+      check(q, chosen, locked);
       return;
     }
     if (!stepper) return;
@@ -167,20 +191,6 @@ export function QuizBlock({ block, ctx }: BlockRenderProps) {
       goTo(current - 1);
     }
   };
-
-  // Collapsed summary (#770): how many questions are currently answered
-  // correctly. Turns green only at a clean sweep, so the badge doubles as the
-  // "done" signal when the section is folded away.
-  const correctCount = b.questions.filter((q) => results[q.id]?.correct).length;
-  const allCorrect = correctCount === total;
-
-  const multi = q?.multiSelect ?? false;
-  const chosen = q ? (selections[q.id] ?? []) : [];
-  const result: CheckResult | undefined = q ? results[q.id] : undefined;
-  const chosenWithFeedback =
-    q && result
-      ? q.options.filter((o) => result.chosen.includes(o.id) && o.feedback)
-      : [];
 
   return (
     <div className="rounded-[var(--r-lg)] border-[2.5px] border-border bg-card shadow-card">
@@ -211,6 +221,12 @@ export function QuizBlock({ block, ctx }: BlockRenderProps) {
             total,
           })}
         </span>
+        {allCorrect && (
+          <span className="flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-bold text-success [background:var(--success-light)]">
+            <CheckCircle size={12} weight="bold" aria-hidden="true" />
+            {t("quizCompleteChip")}
+          </span>
+        )}
         <CaretDown
           size={14}
           weight="bold"
@@ -249,13 +265,17 @@ export function QuizBlock({ block, ctx }: BlockRenderProps) {
                 return (
                   <label
                     key={o.id}
-                    className={`flex cursor-pointer items-center gap-2 rounded-md border p-2 text-sm transition-colors hover:bg-subtle ${
+                    className={cn(
+                      "flex items-center gap-2 rounded-md border p-2 text-sm transition-colors",
+                      locked
+                        ? "cursor-default"
+                        : "cursor-pointer hover:bg-subtle",
                       judged
                         ? o.correct
                           ? "border-success"
                           : "border-danger"
                         : "border-border"
-                    }`}
+                    )}
                   >
                     <input
                       type={multi ? "checkbox" : "radio"}
@@ -263,6 +283,7 @@ export function QuizBlock({ block, ctx }: BlockRenderProps) {
                       value={o.id}
                       checked={chosen.includes(o.id)}
                       onChange={() => toggle(q.id, o.id, multi)}
+                      disabled={locked}
                       className="accent-primary"
                     />
                     <span>{o.label}</span>
@@ -274,9 +295,9 @@ export function QuizBlock({ block, ctx }: BlockRenderProps) {
               <Button
                 variant="pushSuccess"
                 size="sm"
-                onClick={() => check(q, chosen)}
-                disabled={chosen.length === 0}
-                aria-disabled={chosen.length === 0}
+                onClick={() => check(q, chosen, locked)}
+                disabled={chosen.length === 0 || locked}
+                aria-disabled={chosen.length === 0 || locked}
               >
                 {t("quizCheck")}
               </Button>
@@ -334,7 +355,9 @@ export function QuizBlock({ block, ctx }: BlockRenderProps) {
               {t("quizPrev")}
             </Button>
             <Button
-              variant="secondary"
+              /* Emphasized once this question is correct — the learner is done
+                 here and Next is the only move left (#943). */
+              variant={locked ? "primary" : "secondary"}
               size="sm"
               onClick={() => goTo(current + 1)}
               disabled={current === total - 1}
@@ -346,9 +369,21 @@ export function QuizBlock({ block, ctx }: BlockRenderProps) {
           </div>
         )}
 
+        {/* Completion state (#943): a clean sweep is acknowledged in-block —
+            no popup, per the three-popup rule. Always-mounted live region so
+            the sweep is announced when it happens. */}
+        <div aria-live="polite">
+          {allCorrect && (
+            <p className="flex items-center gap-2 rounded-md border border-success p-3 text-sm font-medium text-success [background:var(--success-light)]">
+              <CheckCircle size={16} weight="bold" aria-hidden="true" />
+              {t("quizAllCorrect", { total })}
+            </p>
+          )}
+        </div>
+
         {/* The AI Partner is suppressed while any question is unchecked
-            (LX-C1/F18) — retrieval stays AI-free. Say so, so its absence reads
-            as a rule rather than a missing feature (#770). */}
+            (LX-C1/F18) — retrieval stays AI-free. The gate is unchanged; the
+            line states it explicitly and counts down (#770, #943). */}
         {!allChecked && (
           <p className="flex items-start gap-2 rounded-md border border-border p-3 text-xs text-text-3 [background:var(--input)]">
             <Robot
@@ -357,7 +392,7 @@ export function QuizBlock({ block, ctx }: BlockRenderProps) {
               className="mt-px shrink-0 text-primary"
               aria-hidden="true"
             />
-            {t("quizUnlocksAssistant")}
+            {t("quizUnlocksAssistant", { answered: answeredCount, total })}
           </p>
         )}
       </div>

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -361,7 +361,9 @@
     "quizPosition": "Question {current} of {total}",
     "quizPrev": "Previous question",
     "quizNext": "Next question",
-    "quizUnlocksAssistant": "Answer every question to unlock the AI Partner for this lesson."
+    "quizUnlocksAssistant": "AI Partner unlocks after the quiz — {answered}/{total} answered",
+    "quizCompleteChip": "Complete",
+    "quizAllCorrect": "All {total} questions answered correctly."
   },
   "dashboard": {
     "allCaughtUp": "All caught up!",

--- a/apps/web/src/messages/es.json
+++ b/apps/web/src/messages/es.json
@@ -361,7 +361,9 @@
     "quizPosition": "Pregunta {current} de {total}",
     "quizPrev": "Pregunta anterior",
     "quizNext": "Siguiente pregunta",
-    "quizUnlocksAssistant": "Responde todas las preguntas para desbloquear el AI Partner en esta lección."
+    "quizUnlocksAssistant": "El AI Partner se desbloquea después del cuestionario — {answered}/{total} respondidas",
+    "quizCompleteChip": "Completado",
+    "quizAllCorrect": "Las {total} preguntas respondidas correctamente."
   },
   "dashboard": {
     "allCaughtUp": "¡Todo al día!",

--- a/apps/web/src/messages/pt-BR.json
+++ b/apps/web/src/messages/pt-BR.json
@@ -361,7 +361,9 @@
     "quizPosition": "Pergunta {current} de {total}",
     "quizPrev": "Pergunta anterior",
     "quizNext": "Próxima pergunta",
-    "quizUnlocksAssistant": "Responda todas as perguntas para desbloquear o AI Partner nesta lição."
+    "quizUnlocksAssistant": "O AI Partner é liberado depois do quiz — {answered}/{total} respondidas",
+    "quizCompleteChip": "Concluído",
+    "quizAllCorrect": "Todas as {total} perguntas respondidas corretamente."
   },
   "dashboard": {
     "allCaughtUp": "Tudo em dia!",


### PR DESCRIPTION
Closes #943

Owner feedback from the 2026-07-31 live session, all inside `apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/blocks/quiz-block.tsx`.

## What changed

1. **Correct check locks the question.** A correct verdict disables the option inputs and the `Check answer` button for that question; the correct-state borders, the `Correct!` verdict, the authored per-option feedback and the explanation all stay visible. The Enter shortcut is gated too, so a locked question cannot be re-checked from the keyboard. An incorrect check is unchanged — still freely re-answerable.
2. **`Next question` gains an emphasized state.** `variant="primary"` once the current question is correct, `secondary` otherwise.
3. **All-correct completion state, in-block.** A `Complete` chip joins the score chip in the header, and a success summary line (`All N questions answered correctly.`) renders inside an always-mounted `aria-live="polite"` region. No popup — per the brand guide's three-popup rule.
4. **AI-unlock note becomes an explicit gate state.** `AI Partner unlocks after the quiz — N/M answered`, counting checked questions live. **The LX-C1/F18 gate itself is untouched** — the pane is still unmounted while any question is unchecked; only the communication improves.

a11y preserved: fieldset/legend, native radio/checkbox inputs, the existing feedback `aria-live` region and the position announcer are all unchanged; the completion state adds a new live region rather than mutating an existing one.

## i18n (3 locales)

- `lesson.quizUnlocksAssistant` — reworded, now takes `{answered}`/`{total}`
- `lesson.quizCompleteChip` — new
- `lesson.quizAllCorrect` — new

Real translations for pt-BR and es.

## Evidence

- `pnpm --filter web typecheck` — clean
- `pnpm --filter web lint` — no errors, no new warnings on touched files
- `pnpm --filter web test quiz-block` — **25/25 pass** (18 pre-existing + 7 new)
- Red-first check: with the component + `en.json` stashed, the four new behavior tests fail (`4 failed | 21 passed`) — lock-after-correct, Next emphasis, completion state, N/M counter
- Full `apps/web` suite: 2532 passed. Four PGlite/route files flake on hook timeouts under full-suite parallel load (`reminder-consent-execution`, `assist-ladder-execution`, `email-subscriptions-execution`, `freeze-gate`) — re-run in isolation they are **37/37 green**, and they share no code with this change.