### PR TITLE
feat(ai-partner): restore the free-text composer on top of the assist ladder

### DIFF
--- a/apps/web/src/components/editor/ai-partner/__tests__/ai-partner-pane.test.tsx
+++ b/apps/web/src/components/editor/ai-partner/__tests__/ai-partner-pane.test.tsx
@@ -324,6 +324,25 @@ describe("AiPartnerPane — free-text composer (#944)", () => {
       screen.getByRole("button", { name: messages.aiPartner.actions.hint })
     ).toBeDisabled();
   });
+
+  // M1 (#947 gate addendum): the route 413s past 4,000 chars and the hook can
+  // only render that as a generic error, so the box refuses to exceed it and
+  // shows the learner where they stand.
+  it("caps the question at 4000 characters and shows a live counter", () => {
+    renderPane({ hasRunTests: true });
+    const box = screen.getByLabelText(askLabel);
+
+    expect(box).toHaveAttribute("maxlength", "4000");
+    expect(screen.getByText("0/4000")).toBeInTheDocument();
+
+    fireEvent.change(box, { target: { value: "abcde" } });
+    expect(screen.getByText("5/4000")).toBeInTheDocument();
+
+    // A paste past the cap is truncated, never sent whole into a 413.
+    fireEvent.change(box, { target: { value: "x".repeat(4200) } });
+    expect(box).toHaveValue("x".repeat(4000));
+    expect(screen.getByText("4000/4000")).toBeInTheDocument();
+  });
 });
 
 describe("AiPartnerPane — 'Show me a change' propose action (#947)", () => {

--- a/apps/web/src/components/editor/ai-partner/__tests__/ai-partner-pane.test.tsx
+++ b/apps/web/src/components/editor/ai-partner/__tests__/ai-partner-pane.test.tsx
@@ -9,6 +9,9 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { NextIntlClientProvider } from "next-intl";
 import messages from "@/messages/en.json";
+import ptBR from "@/messages/pt-BR.json";
+import es from "@/messages/es.json";
+import type { AssistTier } from "@/lib/ai/partner-types";
 import { AiPartnerPane } from "../ai-partner-pane";
 
 const review = vi.fn();
@@ -16,7 +19,7 @@ const hookState = {
   messages: [] as unknown[],
   freeHintsUsed: 0,
   counts: { free: 0, metered: 0, socratic: 0 },
-  tier: "free" as const,
+  tier: "free" as AssistTier,
   budgetExhausted: false,
   spendCapped: false,
   resetState: "none" as const,
@@ -44,6 +47,7 @@ function renderPane(
     solutionPassed?: boolean;
     disabled?: boolean;
     hasRunTests?: boolean;
+    hasFailedRun?: boolean;
     onFocusRun?: () => void;
     onNudgeShown?: () => void;
     onNudgeOverride?: () => void;
@@ -72,7 +76,9 @@ beforeEach(() => {
   review.mockReset();
   hookState.requestHint.mockReset();
   hookState.ask.mockReset();
+  hookState.proposeFix.mockReset();
   hookState.messages = [];
+  hookState.tier = "free";
   hookState.budgetExhausted = false;
   hookState.spendCapped = false;
   hookState.loading = false;
@@ -317,5 +323,122 @@ describe("AiPartnerPane — free-text composer (#944)", () => {
     expect(
       screen.getByRole("button", { name: messages.aiPartner.actions.hint })
     ).toBeDisabled();
+  });
+});
+
+describe("AiPartnerPane — 'Show me a change' propose action (#947)", () => {
+  const proposeName = new RegExp(messages.aiPartner.actions.propose, "i");
+  const proposeButton = () =>
+    screen.queryByRole("button", { name: proposeName });
+
+  it("is hidden until a run has actually FAILED", () => {
+    renderPane({ hasRunTests: true, hasFailedRun: false });
+    expect(proposeButton()).not.toBeInTheDocument();
+  });
+
+  it("appears once a run has failed, labelled with its turn cost", () => {
+    renderPane({ hasRunTests: true, hasFailedRun: true });
+    const button = proposeButton();
+    expect(button).toBeInTheDocument();
+    expect(button).toBeEnabled();
+    expect(button?.tagName).toBe("BUTTON");
+    expect(button).toHaveTextContent(messages.aiPartner.actions.proposeCost);
+  });
+
+  it("stays available on the Socratic tier (#864 §4.2 — the escape hatch survives)", () => {
+    hookState.tier = "socratic";
+    renderPane({ hasRunTests: true, hasFailedRun: true });
+    expect(
+      screen.getByText(messages.aiPartner.socratic.entered)
+    ).toBeInTheDocument();
+    expect(proposeButton()).toBeEnabled();
+  });
+
+  it("is withdrawn again at full exhaustion — the community handoff takes over", () => {
+    hookState.budgetExhausted = true;
+    renderPane({ hasRunTests: true, hasFailedRun: true });
+    expect(proposeButton()).not.toBeInTheDocument();
+    expect(
+      screen.getByText(messages.aiPartner.exhausted.title)
+    ).toBeInTheDocument();
+  });
+
+  it("spends a turn through the hook and leaves the typed draft alone", () => {
+    renderPane({ hasRunTests: true, hasFailedRun: true });
+    const box = screen.getByLabelText(askLabel);
+    fireEvent.change(box, { target: { value: "why is my loop off by one?" } });
+
+    fireEvent.click(proposeButton()!);
+
+    expect(hookState.proposeFix).toHaveBeenCalledTimes(1);
+    expect(hookState.proposeFix).toHaveBeenCalledWith(
+      "why is my loop off by one?"
+    );
+    // The draft survives — propose does not consume the question box.
+    expect(box).toHaveValue("why is my loop off by one?");
+    // …and it is never sent as an ask.
+    expect(hookState.ask).not.toHaveBeenCalled();
+  });
+
+  it("needs no free text at all", () => {
+    renderPane({ hasRunTests: true, hasFailedRun: true });
+    fireEvent.click(proposeButton()!);
+    expect(hookState.proposeFix).toHaveBeenCalledWith(undefined);
+  });
+
+  it("disables (not hides) while a request is in flight, with aria-busy", () => {
+    hookState.loading = true;
+    renderPane({ hasRunTests: true, hasFailedRun: true });
+    const button = proposeButton();
+    expect(button).toBeDisabled();
+    expect(button).toHaveAttribute("aria-busy", "true");
+  });
+
+  it("routes a pre-first-run propose through the same attempt gate (#865)", () => {
+    renderPane({ hasRunTests: false, hasFailedRun: true });
+    fireEvent.click(proposeButton()!);
+
+    expect(hookState.proposeFix).not.toHaveBeenCalled();
+    expect(
+      screen.getByText(messages.aiPartner.attemptNudge.title)
+    ).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: messages.aiPartner.attemptNudge.override,
+      })
+    );
+    expect(hookState.proposeFix).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders the returned diff card through the existing message-list path", () => {
+    hookState.messages = [
+      {
+        role: "ai",
+        response: {
+          type: "propose",
+          rationale: "off-by-one in the loop bound",
+          edits: [{ search: "code", replace: "code2" }],
+          check: { question: "Why?", options: ["A", "B", "C"] },
+          checkToken: "tok",
+        },
+      },
+    ];
+    renderPane({ hasRunTests: true, hasFailedRun: true });
+    expect(
+      screen.getByText("off-by-one in the loop bound")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("group", { name: messages.aiPartner.a11y.diffCard })
+    ).toBeInTheDocument();
+  });
+
+  it("keeps all three locales in step on the propose keys", () => {
+    for (const catalog of [messages, ptBR, es]) {
+      expect(typeof catalog.aiPartner.actions.propose).toBe("string");
+      expect(catalog.aiPartner.actions.propose.length).toBeGreaterThan(0);
+      expect(typeof catalog.aiPartner.actions.proposeCost).toBe("string");
+      expect(catalog.aiPartner.actions.proposeCost.length).toBeGreaterThan(0);
+    }
   });
 });

--- a/apps/web/src/components/editor/ai-partner/__tests__/ai-partner-pane.test.tsx
+++ b/apps/web/src/components/editor/ai-partner/__tests__/ai-partner-pane.test.tsx
@@ -65,10 +65,14 @@ function renderPane(
 }
 
 const reviewLabel = messages.aiPartner.actions.review;
+const askLabel = messages.aiPartner.actions.askLabel;
+const sendLabel = messages.aiPartner.actions.askSend;
 
 beforeEach(() => {
   review.mockReset();
   hookState.requestHint.mockReset();
+  hookState.ask.mockReset();
+  hookState.messages = [];
   hookState.budgetExhausted = false;
   hookState.spendCapped = false;
   hookState.loading = false;
@@ -222,5 +226,96 @@ describe("AiPartnerPane — attempt-gate nudge (#865, replaces the #770 lock)", 
     renderPane({ hasRunTests: false, disabled: true });
     expect(screen.getByRole("button", { name: hintLabel })).toBeDisabled();
     expect(screen.queryByText(nudgeTitle)).not.toBeInTheDocument();
+  });
+
+  it("holds a pre-run ASK behind the same gate, then sends it on override", () => {
+    renderPane({ hasRunTests: false });
+
+    const box = screen.getByLabelText(askLabel);
+    fireEvent.change(box, { target: { value: "why does this fail?" } });
+    fireEvent.click(screen.getByRole("button", { name: sendLabel }));
+
+    // Held, not sent — same soft nudge the hint gets.
+    expect(hookState.ask).not.toHaveBeenCalled();
+    expect(screen.getByText(nudgeTitle)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: overrideLabel }));
+    expect(hookState.ask).toHaveBeenCalledWith("why does this fail?");
+  });
+});
+
+describe("AiPartnerPane — free-text composer (#944)", () => {
+  it("renders the composer as the empty state, with the hint button beside it", () => {
+    renderPane({ hasRunTests: true });
+    expect(screen.getByLabelText(askLabel)).toBeEnabled();
+    expect(
+      screen.getByText(messages.aiPartner.composer.empty)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: messages.aiPartner.actions.hint })
+    ).toBeInTheDocument();
+  });
+
+  it("sends the question through the hook and clears the box", () => {
+    renderPane({ hasRunTests: true });
+    const box = screen.getByLabelText(askLabel);
+
+    fireEvent.change(box, { target: { value: "  what is a PDA?  " } });
+    fireEvent.click(screen.getByRole("button", { name: sendLabel }));
+
+    expect(hookState.ask).toHaveBeenCalledWith("what is a PDA?");
+    expect(box).toHaveValue("");
+  });
+
+  it("Enter sends, Shift+Enter does not", () => {
+    renderPane({ hasRunTests: true });
+    const box = screen.getByLabelText(askLabel);
+
+    fireEvent.change(box, { target: { value: "line one" } });
+    fireEvent.keyDown(box, { key: "Enter", shiftKey: true });
+    expect(hookState.ask).not.toHaveBeenCalled();
+
+    fireEvent.keyDown(box, { key: "Enter" });
+    expect(hookState.ask).toHaveBeenCalledWith("line one");
+  });
+
+  it("never sends an empty question", () => {
+    renderPane({ hasRunTests: true });
+    const box = screen.getByLabelText(askLabel);
+
+    expect(screen.getByRole("button", { name: sendLabel })).toBeDisabled();
+    fireEvent.change(box, { target: { value: "   " } });
+    fireEvent.keyDown(box, { key: "Enter" });
+    expect(hookState.ask).not.toHaveBeenCalled();
+  });
+
+  it("disables the composer once the ladder is exhausted (#864 handoff state)", () => {
+    hookState.budgetExhausted = true;
+    renderPane({ hasRunTests: true });
+
+    const box = screen.getByLabelText(askLabel);
+    expect(box).toBeDisabled();
+    fireEvent.change(box, { target: { value: "still stuck" } });
+    fireEvent.keyDown(box, { key: "Enter" });
+    expect(hookState.ask).not.toHaveBeenCalled();
+    // The community handoff carries the copy — no wall inside the composer.
+    expect(
+      screen.getByText(messages.aiPartner.exhausted.title)
+    ).toBeInTheDocument();
+  });
+
+  it("disables the composer while a request is in flight", () => {
+    hookState.loading = true;
+    renderPane({ hasRunTests: true });
+    expect(screen.getByLabelText(askLabel)).toBeDisabled();
+    expect(screen.getByRole("button", { name: sendLabel })).toBeDisabled();
+  });
+
+  it("disables the composer once the lesson is complete, like the hint", () => {
+    renderPane({ hasRunTests: true, disabled: true });
+    expect(screen.getByLabelText(askLabel)).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: messages.aiPartner.actions.hint })
+    ).toBeDisabled();
   });
 });

--- a/apps/web/src/components/editor/ai-partner/__tests__/message-list.test.tsx
+++ b/apps/web/src/components/editor/ai-partner/__tests__/message-list.test.tsx
@@ -7,6 +7,12 @@ import messages from "@/messages/en.json";
 import type { PartnerMessage } from "@/lib/ai/use-ai-partner";
 import { MessageList } from "../message-list";
 
+const trackProposeAccepted = vi.fn();
+vi.mock("@/lib/analytics/events", () => ({
+  trackProposeAccepted: (...args: unknown[]) => trackProposeAccepted(...args),
+  trackComprehensionCheckAnswered: vi.fn(),
+}));
+
 function renderWithIntl(ui: ReactElement) {
   return render(
     <NextIntlClientProvider locale="en" messages={messages}>
@@ -85,6 +91,49 @@ it("renders an already-idiomatic review (empty notes) with just the summary", ()
   ).toBeInTheDocument();
   // No list is rendered when there are no notes.
   expect(screen.queryByRole("list")).not.toBeInTheDocument();
+});
+
+// #947: Accept stays gated on the earned-Accept comprehension seal, and the
+// accepted patch reports exactly one `propose_accepted`.
+it("keeps Accept locked until the check is verified, then applies once and tracks once", async () => {
+  const onApply = vi.fn();
+  const onVerify = vi.fn(async () => ({ correct: true, explanation: "" }));
+  trackProposeAccepted.mockReset();
+
+  renderWithIntl(
+    <MessageList
+      messages={proposeMessages}
+      onApply={onApply}
+      getCode={() => "a"}
+      onVerify={onVerify}
+      eventCtx={{ lessonId: "l", courseId: "c", challengeKind: "js" }}
+    />
+  );
+
+  const accept = screen.getByRole("button", {
+    name: messages.aiPartner.diff.accept,
+  });
+  // Comprehension seal not yet passed: Accept is inert and nothing is applied.
+  expect(accept).toBeDisabled();
+  fireEvent.click(accept);
+  expect(onApply).not.toHaveBeenCalled();
+  expect(trackProposeAccepted).not.toHaveBeenCalled();
+
+  fireEvent.click(screen.getByRole("button", { name: "A" }));
+  await screen.findByText(messages.aiPartner.diff.checkCorrect);
+
+  fireEvent.click(
+    screen.getByRole("button", { name: messages.aiPartner.diff.accept })
+  );
+  expect(onApply).toHaveBeenCalledTimes(1);
+  expect(onApply).toHaveBeenCalledWith("a\nb");
+  // Exactly once per accepted propose — the card latches after its one Accept.
+  expect(trackProposeAccepted).toHaveBeenCalledTimes(1);
+  expect(trackProposeAccepted).toHaveBeenCalledWith({
+    lessonId: "l",
+    courseId: "c",
+    challengeKind: "js",
+  });
 });
 
 it("dismisses a proposal when Dismiss is clicked", () => {

--- a/apps/web/src/components/editor/ai-partner/ai-partner-pane.tsx
+++ b/apps/web/src/components/editor/ai-partner/ai-partner-pane.tsx
@@ -7,7 +7,6 @@ import {
   Robot,
   MagnifyingGlass,
   CaretDown,
-  Lightbulb,
   Play,
   UsersThree,
 } from "@phosphor-icons/react";
@@ -20,6 +19,7 @@ import type { ChallengeEventContext } from "@/lib/analytics/events";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { AssistMeter } from "./assist-meter";
+import { Composer } from "./composer";
 import { MessageList } from "./message-list";
 import { QuickActions } from "./quick-actions";
 
@@ -132,6 +132,7 @@ export function AiPartnerPane({
     loading,
     error,
     requestHint,
+    ask,
     review,
     requestReset,
     verifyCheck,
@@ -140,6 +141,15 @@ export function AiPartnerPane({
   const requestHintGuarded = useCallback(
     () => guardAction(requestHint),
     [guardAction, requestHint]
+  );
+
+  // The free-text ask (#944) goes through the SAME attempt gate as the hint:
+  // pre-first-run the question is held (captured here) and the nudge shown, and
+  // the free override sends it unchanged. It spends a ladder turn like any other
+  // AI action — the composer disables itself at exhaustion.
+  const askGuarded = useCallback(
+    (message: string) => guardAction(() => void ask(message)),
+    [guardAction, ask]
   );
 
   // Socratic-entry analytics (#864): fire once per lesson when the ladder
@@ -250,26 +260,11 @@ export function AiPartnerPane({
         </div>
       )}
 
-      {/* Empty state stays COMPACT (#770): the prompt and the Hint button sit
-          together in a short block — no reserved conversation area. The pane
-          only grows (and the button drops to the bottom) once there are
-          messages to show. */}
-      {!open ? null : messages.length === 0 ? (
-        <div className="flex flex-col gap-3 px-4 py-4">
-          <p className="text-sm text-text-3">{t("messages.empty")}</p>
-          <Button
-            type="button"
-            variant="secondary"
-            size="sm"
-            onClick={requestHintGuarded}
-            disabled={loading || disabled}
-            className="w-full gap-1.5"
-          >
-            <Lightbulb size={14} weight="duotone" aria-hidden="true" />
-            {t("actions.hint")}
-          </Button>
-        </div>
-      ) : (
+      {/* The empty state is now the composer itself (#944): the invitation line
+          sits directly above the question box in the footer, so there is still
+          no reserved conversation area (the #770 compactness holds). The pane
+          only grows once there are messages to show. */}
+      {open && messages.length > 0 && (
         <MessageList
           messages={messages}
           onApply={onApply}
@@ -397,12 +392,27 @@ export function AiPartnerPane({
         </div>
       )}
 
-      {open && messages.length > 0 && (
-        <QuickActions
-          onHint={requestHintGuarded}
-          disabled={loading || disabled}
-          budgetExhausted={budgetExhausted}
-        />
+      {/* Composer footer (#944): Hint above, free-text ask below, one framed
+          block at the bottom of the pane. Both spend the same ladder and both
+          route through the attempt gate, so the guards of #864/#865 apply to
+          the question box exactly as they do to the hint. When the chat is
+          still empty this block doubles as the empty state. */}
+      {open && (
+        <div className="shrink-0 space-y-2.5 border-t border-border p-3">
+          {messages.length === 0 && (
+            <p className="text-sm text-text-3">{t("composer.empty")}</p>
+          )}
+          <QuickActions
+            onHint={requestHintGuarded}
+            disabled={loading || disabled}
+            budgetExhausted={budgetExhausted}
+          />
+          <Composer
+            onSend={askGuarded}
+            disabled={loading || disabled}
+            budgetExhausted={budgetExhausted}
+          />
+        </div>
       )}
     </div>
   );

--- a/apps/web/src/components/editor/ai-partner/ai-partner-pane.tsx
+++ b/apps/web/src/components/editor/ai-partner/ai-partner-pane.tsx
@@ -43,6 +43,11 @@ interface AiPartnerPaneProps {
    * a soft "run the tests first" suggestion with a free one-tap override,
    * never a lock. After the first run the nudge never appears. */
   hasRunTests?: boolean;
+  /** True once at least one test run on this challenge FAILED. Gates the
+   * secondary "Show me a change" action (#947): a concrete diff is offered only
+   * once the learner has a failure in front of them, never as the opening move.
+   * Sticky for the visit — a later passing run does not retract it. */
+  hasFailedRun?: boolean;
   /** Shift focus to the Run-tests button — the nudge's primary action. */
   onFocusRun?: () => void;
   /** The attempt-gate nudge surfaced (analytics; deduped upstream). */
@@ -65,6 +70,7 @@ export function AiPartnerPane({
   disabled = false,
   solutionPassed = false,
   hasRunTests = false,
+  hasFailedRun = false,
   onFocusRun,
   onNudgeShown,
   onNudgeOverride,
@@ -133,6 +139,7 @@ export function AiPartnerPane({
     error,
     requestHint,
     ask,
+    proposeFix,
     review,
     requestReset,
     verifyCheck,
@@ -150,6 +157,17 @@ export function AiPartnerPane({
   const askGuarded = useCallback(
     (message: string) => guardAction(() => void ask(message)),
     [guardAction, ask]
+  );
+
+  // "Show me a change" (#947) is an assist like any other: same attempt gate,
+  // same ladder turn, same in-flight/exhaustion disabling. It stays available on
+  // the Socratic tier by design (#864 §4.2 — Socratic changes the tutor's
+  // default contract, it does not remove the escape hatch), and what it returns
+  // is still gated behind the earned-Accept comprehension check before any code
+  // moves. The learner's draft (if any) rides along and is left in the box.
+  const proposeGuarded = useCallback(
+    (message?: string) => guardAction(() => void proposeFix(message)),
+    [guardAction, proposeFix]
   );
 
   // Socratic-entry analytics (#864): fire once per lesson when the ladder
@@ -409,7 +427,15 @@ export function AiPartnerPane({
           />
           <Composer
             onSend={askGuarded}
+            // Offered only once a run has actually FAILED, and withdrawn again
+            // at exhaustion where the community handoff takes over. (The
+            // Composer also hard-disables it on `budgetExhausted`, so it can
+            // never fire even if it were rendered in that state.)
+            onPropose={
+              hasFailedRun && !budgetExhausted ? proposeGuarded : undefined
+            }
             disabled={loading || disabled}
+            pending={loading}
             budgetExhausted={budgetExhausted}
           />
         </div>

--- a/apps/web/src/components/editor/ai-partner/composer.tsx
+++ b/apps/web/src/components/editor/ai-partner/composer.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useId, useState } from "react";
 import { useTranslations } from "next-intl";
-import { PaperPlaneRight } from "@phosphor-icons/react";
+import { PaperPlaneRight, GitDiff } from "@phosphor-icons/react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 
@@ -10,8 +10,16 @@ interface ComposerProps {
   /** Send a free-text question. The caller routes it through the attempt gate
    *  (#865) and the assist ladder (#864) — this component only collects text. */
   onSend: (message: string) => void;
+  /** Ask for a concrete change ("Show me a change", #947). Omit to hide the
+   *  action entirely — the pane hides it until the learner has seen a failing
+   *  run, and again at ladder exhaustion. The current draft rides along as the
+   *  optional message and is deliberately NOT cleared: the learner asked for a
+   *  diff, not for their question to be consumed. */
+  onPropose?: (message?: string) => void;
   /** Lesson complete, or a request in flight — the whole composer is inert. */
   disabled: boolean;
+  /** A request is in flight (drives aria-busy on the propose action). */
+  pending?: boolean;
   /** The ladder is spent (#864). The pane's community-handoff block carries the
    *  copy, so this only disables — never a wall-shaped message of its own. */
   budgetExhausted: boolean;
@@ -19,15 +27,24 @@ interface ComposerProps {
 }
 
 /**
- * Free-text ask (#944). Restores the composer removed in #770 ("hints only"):
- * that stance is superseded by the assist ladder (#864 — tiered budget, Socratic
- * contract, tier-exact billing) plus the attempt-gate nudge (#865), which stop
- * answer-dumping at the source instead of removing the question box. Every turn
- * spends from the same ladder as a hint, so asking is never a free bypass.
+ * Free-text ask (#944) plus the secondary "Show me a change" action (#947).
+ *
+ * #770 removed the composer ("hints only"); that stance is superseded by the
+ * assist ladder (#864 — tiered budget, Socratic contract, tier-exact billing)
+ * plus the attempt-gate nudge (#865), which stop answer-dumping at the source
+ * instead of removing the question box. Every turn — ask or propose — spends
+ * from the same ladder as a hint, so neither is a free bypass, and a proposed
+ * diff is still gated behind the earned-Accept comprehension check before it can
+ * touch the buffer.
+ *
+ * Send is the primary affordance; propose is a quiet ghost action beside it,
+ * labelled with its cost so spending a turn is never a surprise.
  */
 export function Composer({
   onSend,
+  onPropose,
   disabled,
+  pending = false,
   budgetExhausted,
   className,
 }: ComposerProps) {
@@ -71,17 +88,36 @@ export function Composer({
         placeholder={t("actions.askPlaceholder")}
         className="w-full resize-none rounded-md border border-border p-2 text-sm [background:var(--input)] placeholder:text-text-3 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-60"
       />
-      <div className="flex justify-end">
-        <Button
-          type="submit"
-          variant="push"
-          size="sm"
-          disabled={!canSend}
-          className="gap-1.5"
-        >
-          <PaperPlaneRight size={14} weight="duotone" aria-hidden="true" />
-          {t("actions.askSend")}
-        </Button>
+      <div className="flex flex-wrap items-center gap-2">
+        {onPropose && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() => onPropose(value.trim() || undefined)}
+            disabled={inert}
+            aria-busy={pending}
+            className="gap-1.5 text-xs"
+          >
+            <GitDiff size={14} weight="duotone" aria-hidden="true" />
+            {t("actions.propose")}
+            <span className="font-normal text-text-3">
+              {t("actions.proposeCost")}
+            </span>
+          </Button>
+        )}
+        <div className="ml-auto flex items-center gap-3">
+          <Button
+            type="submit"
+            variant="push"
+            size="sm"
+            disabled={!canSend}
+            className="gap-1.5"
+          >
+            <PaperPlaneRight size={14} weight="duotone" aria-hidden="true" />
+            {t("actions.askSend")}
+          </Button>
+        </div>
       </div>
     </form>
   );

--- a/apps/web/src/components/editor/ai-partner/composer.tsx
+++ b/apps/web/src/components/editor/ai-partner/composer.tsx
@@ -6,6 +6,11 @@ import { PaperPlaneRight, GitDiff } from "@phosphor-icons/react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 
+/** Mirrors MAX_MESSAGE_CHARS in /api/ai/partner: the route 413s past this, so
+ *  the box stops accepting text at exactly the same boundary rather than letting
+ *  the learner write a message that can only come back as a generic error. */
+const MAX_MESSAGE_CHARS = 4000;
+
 interface ComposerProps {
   /** Send a free-text question. The caller routes it through the attempt gate
    *  (#865) and the assist ladder (#864) — this component only collects text. */
@@ -51,8 +56,10 @@ export function Composer({
   const t = useTranslations("aiPartner");
   const [value, setValue] = useState("");
   const inputId = useId();
+  const counterId = useId();
   const inert = disabled || budgetExhausted;
   const canSend = !inert && value.trim().length > 0;
+  const nearLimit = value.length / MAX_MESSAGE_CHARS > 0.9;
 
   const submit = useCallback(() => {
     const message = value.trim();
@@ -75,7 +82,7 @@ export function Composer({
       <textarea
         id={inputId}
         value={value}
-        onChange={(e) => setValue(e.target.value)}
+        onChange={(e) => setValue(e.target.value.slice(0, MAX_MESSAGE_CHARS))}
         onKeyDown={(e) => {
           // Enter sends, Shift+Enter keeps the newline — the chat convention.
           if (e.key === "Enter" && !e.shiftKey) {
@@ -84,6 +91,8 @@ export function Composer({
           }
         }}
         rows={2}
+        maxLength={MAX_MESSAGE_CHARS}
+        aria-describedby={counterId}
         disabled={inert}
         placeholder={t("actions.askPlaceholder")}
         className="w-full resize-none rounded-md border border-border p-2 text-sm [background:var(--input)] placeholder:text-text-3 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-60"
@@ -107,6 +116,15 @@ export function Composer({
           </Button>
         )}
         <div className="ml-auto flex items-center gap-3">
+          <span
+            id={counterId}
+            className={cn(
+              "text-[11px]",
+              nearLimit ? "text-danger" : "text-text-3"
+            )}
+          >
+            {value.length}/{MAX_MESSAGE_CHARS}
+          </span>
           <Button
             type="submit"
             variant="push"

--- a/apps/web/src/components/editor/ai-partner/composer.tsx
+++ b/apps/web/src/components/editor/ai-partner/composer.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { useCallback, useId, useState } from "react";
+import { useTranslations } from "next-intl";
+import { PaperPlaneRight } from "@phosphor-icons/react";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+
+interface ComposerProps {
+  /** Send a free-text question. The caller routes it through the attempt gate
+   *  (#865) and the assist ladder (#864) — this component only collects text. */
+  onSend: (message: string) => void;
+  /** Lesson complete, or a request in flight — the whole composer is inert. */
+  disabled: boolean;
+  /** The ladder is spent (#864). The pane's community-handoff block carries the
+   *  copy, so this only disables — never a wall-shaped message of its own. */
+  budgetExhausted: boolean;
+  className?: string;
+}
+
+/**
+ * Free-text ask (#944). Restores the composer removed in #770 ("hints only"):
+ * that stance is superseded by the assist ladder (#864 — tiered budget, Socratic
+ * contract, tier-exact billing) plus the attempt-gate nudge (#865), which stop
+ * answer-dumping at the source instead of removing the question box. Every turn
+ * spends from the same ladder as a hint, so asking is never a free bypass.
+ */
+export function Composer({
+  onSend,
+  disabled,
+  budgetExhausted,
+  className,
+}: ComposerProps) {
+  const t = useTranslations("aiPartner");
+  const [value, setValue] = useState("");
+  const inputId = useId();
+  const inert = disabled || budgetExhausted;
+  const canSend = !inert && value.trim().length > 0;
+
+  const submit = useCallback(() => {
+    const message = value.trim();
+    if (!message || inert) return;
+    setValue("");
+    onSend(message);
+  }, [value, inert, onSend]);
+
+  return (
+    <form
+      className={cn("flex flex-col gap-2", className)}
+      onSubmit={(e) => {
+        e.preventDefault();
+        submit();
+      }}
+    >
+      <label className="sr-only" htmlFor={inputId}>
+        {t("actions.askLabel")}
+      </label>
+      <textarea
+        id={inputId}
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        onKeyDown={(e) => {
+          // Enter sends, Shift+Enter keeps the newline — the chat convention.
+          if (e.key === "Enter" && !e.shiftKey) {
+            e.preventDefault();
+            submit();
+          }
+        }}
+        rows={2}
+        disabled={inert}
+        placeholder={t("actions.askPlaceholder")}
+        className="w-full resize-none rounded-md border border-border p-2 text-sm [background:var(--input)] placeholder:text-text-3 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-60"
+      />
+      <div className="flex justify-end">
+        <Button
+          type="submit"
+          variant="push"
+          size="sm"
+          disabled={!canSend}
+          className="gap-1.5"
+        >
+          <PaperPlaneRight size={14} weight="duotone" aria-hidden="true" />
+          {t("actions.askSend")}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/apps/web/src/components/editor/ai-partner/message-list.tsx
+++ b/apps/web/src/components/editor/ai-partner/message-list.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { useTranslations } from "next-intl";
 import { User, Sparkle, Lightbulb } from "@phosphor-icons/react";
 import { cn } from "@/lib/utils";
+import { trackProposeAccepted } from "@/lib/analytics/events";
 import type { ChallengeEventContext } from "@/lib/analytics/events";
 import type { VerifyOutcome } from "@/lib/ai/partner-types";
 import type { PartnerMessage } from "@/lib/ai/use-ai-partner";
@@ -166,7 +167,14 @@ export function MessageList({
                 check={response.check}
                 checkToken={response.checkToken}
                 onVerify={onVerify}
-                onAccept={onApply}
+                // `propose_accepted` (#947) fires here rather than inside the
+                // card so the card's behavior is untouched. Exactly once per
+                // accepted patch: the card latches after its single Accept, and
+                // Accept is unreachable until the comprehension check passes.
+                onAccept={(proposed) => {
+                  if (eventCtx) trackProposeAccepted(eventCtx);
+                  onApply(proposed);
+                }}
                 onReject={() =>
                   setDismissed((prev) => new Set(prev).add(index))
                 }

--- a/apps/web/src/components/editor/ai-partner/quick-actions.tsx
+++ b/apps/web/src/components/editor/ai-partner/quick-actions.tsx
@@ -20,8 +20,9 @@ interface QuickActionsProps {
  * ladder (#864 — free → metered → Socratic → community handoff, tier-exact
  * billing) and the attempt-gate nudge (#865) constrain *how* the tutor answers
  * and *how much*, which is what hints-only was really protecting. So the ask is
- * back next to the hint, spending the same ladder. Propose-a-fix remains
- * unexposed (the AI offers a diff on its own terms).
+ * back next to the hint, spending the same ladder — and since #947 the composer
+ * also carries the quieter "Show me a change" action (propose), offered only
+ * after a failing run and still gated behind the earned-Accept check.
  *
  * At full ladder exhaustion (#864) the hint button simply disables — the pane's
  * community-handoff block carries the copy, so no wall-shaped message here.

--- a/apps/web/src/components/editor/ai-partner/quick-actions.tsx
+++ b/apps/web/src/components/editor/ai-partner/quick-actions.tsx
@@ -13,11 +13,21 @@ interface QuickActionsProps {
 }
 
 /**
- * Hints only (#770). The free-text "ask" field and the propose-a-fix action are
- * intentionally not offered: the tutor's role here is to nudge, not to answer.
- * The underlying ask/propose plumbing still exists in the hook and route.
+ * The one-tap hint, sitting above the free-text composer (#944).
+ *
+ * #770 made this surface hints-only ("the tutor's role is to nudge, not to
+ * answer") by deleting the ask field. That stance is superseded: the assist
+ * ladder (#864 — free → metered → Socratic → community handoff, tier-exact
+ * billing) and the attempt-gate nudge (#865) constrain *how* the tutor answers
+ * and *how much*, which is what hints-only was really protecting. So the ask is
+ * back next to the hint, spending the same ladder. Propose-a-fix remains
+ * unexposed (the AI offers a diff on its own terms).
+ *
  * At full ladder exhaustion (#864) the hint button simply disables — the pane's
  * community-handoff block carries the copy, so no wall-shaped message here.
+ *
+ * The footer border/padding belong to the pane's composer block, which frames
+ * this button and the textarea as one unit.
  */
 export function QuickActions({
   onHint,
@@ -28,7 +38,7 @@ export function QuickActions({
   const t = useTranslations("aiPartner");
 
   return (
-    <div className={cn("space-y-2.5 border-t border-border p-3", className)}>
+    <div className={cn("space-y-2.5", className)}>
       <Button
         type="button"
         variant="secondary"

--- a/apps/web/src/components/editor/challenge-interface.tsx
+++ b/apps/web/src/components/editor/challenge-interface.tsx
@@ -199,6 +199,11 @@ export function ChallengeInterface({
   // free one-tap override. Session-scoped by design — the nudge is a gentle
   // per-visit suggestion, not a persisted gate, so nothing is stored.
   const [hasRunTests, setHasRunTests] = useState(false);
+  // Propose-visibility signal (#947): the AI Partner offers "Show me a change"
+  // only once the learner has seen a run FAIL — a concrete diff is never the
+  // opening move. Sticky for the visit (a later pass does not retract it) and,
+  // like `hasRunTests`, session-scoped rather than persisted.
+  const [hasFailedRun, setHasFailedRun] = useState(false);
   const runButtonRef = useRef<HTMLButtonElement>(null);
 
   const handleCodeChange = useCallback((newCode: string) => {
@@ -232,6 +237,7 @@ export function ChallengeInterface({
         failStreakRef.current += 1;
         trackChallengeFailed(ctx, failStreakRef.current);
         setConsecutiveFails((prev) => prev + 1);
+        setHasFailedRun(true);
       }
     },
     [lessonId, courseId, challengeKind]
@@ -494,6 +500,7 @@ export function ChallengeInterface({
               disabled={isComplete}
               solutionPassed={challengeState.status === "success"}
               hasRunTests={hasRunTests || isComplete}
+              hasFailedRun={hasFailedRun}
               onFocusRun={() => runButtonRef.current?.focus()}
               onNudgeShown={() =>
                 trackAttemptGateNudgeShown({

--- a/apps/web/src/lib/ai/__tests__/partner-prompt.test.ts
+++ b/apps/web/src/lib/ai/__tests__/partner-prompt.test.ts
@@ -154,6 +154,22 @@ describe("partner-prompt", () => {
         buildDynamicSuffix({ ...base, action }, { socratic: true })
       ).not.toContain("[SOCRATIC_INSTRUCTIONS]");
     }
+
+    // #947 exposed propose in the composer, where the learner's draft can ride
+    // along as `message`. A Socratic-tier propose carrying learner text must
+    // STILL be a clean diff request — the draft is data, never a route into the
+    // questions-first contract.
+    const proposeWithDraft = buildDynamicSuffix(
+      {
+        ...base,
+        action: "propose",
+        message: "why is my loop off by one?",
+      },
+      { socratic: true }
+    );
+    expect(proposeWithDraft).not.toContain("[SOCRATIC_INSTRUCTIONS]");
+    expect(proposeWithDraft).toContain("[LEARNER_MESSAGE]");
+    expect(proposeWithDraft).toContain("[ACTION]\npropose");
   });
 
   it("Socratic hint/ask inherit the hint-sized output cap; propose keeps its full budget", () => {

--- a/apps/web/src/lib/ai/use-ai-partner.ts
+++ b/apps/web/src/lib/ai/use-ai-partner.ts
@@ -64,7 +64,8 @@ interface UseAiPartnerResult {
   loading: boolean;
   error: string | null;
   requestHint: () => Promise<void>;
-  proposeFix: () => Promise<void>;
+  /** Ask for a concrete change. Optionally carries the learner's composer draft. */
+  proposeFix: (message?: string) => Promise<void>;
   ask: (message: string) => Promise<void>;
   review: () => Promise<void>;
   /** Spend the one guarded per-lesson reset. Resolves with the server verdict. */
@@ -261,9 +262,16 @@ export function useAiPartner({
     await callPartnerRoute("hint");
   }, [freeHintsUsed, hints, callPartnerRoute]);
 
-  const proposeFix = useCallback(async () => {
-    await callPartnerRoute("propose");
-  }, [callPartnerRoute]);
+  // "Show me a change" (#947). The learner's composer draft, if any, rides along
+  // as the optional `message` so the diff answers the question they were already
+  // typing — the draft is NOT consumed (the composer keeps it) and no user bubble
+  // is appended, because propose is answered by the diff card, not by a reply.
+  const proposeFix = useCallback(
+    async (message?: string) => {
+      await callPartnerRoute("propose", message);
+    },
+    [callPartnerRoute]
+  );
 
   // Post-pass idiomatic review (LX-C9). A paid action like propose/ask — it
   // spends an assist and appends the AI review to the chat. The caller gates

--- a/apps/web/src/lib/analytics/events.ts
+++ b/apps/web/src/lib/analytics/events.ts
@@ -316,6 +316,21 @@ export function trackComprehensionCheckAnswered(opts: {
 }
 
 /**
+ * `propose_accepted` — the learner passed the earned-Accept comprehension check
+ * and applied an AI-proposed patch to their editor buffer (#947). Pairs with
+ * `comprehension_check_answered`: that one measures whether understanding was
+ * demonstrated, this one measures how often a demonstrated-understanding patch
+ * actually lands in the code.
+ *
+ * Deliberately NOT deduped per lesson — a lesson can hold several proposals and
+ * each accepted one is a distinct application. Exactly-once per accepted patch
+ * is guaranteed by the diff card, which latches after its single Accept.
+ */
+export function trackProposeAccepted(ctx: ChallengeEventContext): void {
+  trackEvent("propose_accepted", challengePayload(ctx));
+}
+
+/**
  * `assist_reset_used` — the learner spent their ONE self-serve per-lesson
  * assist reset (#864, P2-5/D-8). Fired only on a server-confirmed reset
  * (`allowed: true`), never on a denied attempt, so it counts real resets.

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -1030,7 +1030,8 @@
     },
     "actions": {
       "hint": "Hint",
-      "propose": "Propose fix",
+      "propose": "Show me a change",
+      "proposeCost": "uses 1 turn",
       "askPlaceholder": "Ask a question about this challenge...",
       "askLabel": "Ask the AI Partner about this challenge",
       "askSend": "Send",

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -1001,7 +1001,7 @@
   },
   "aiPartner": {
     "title": "AI Partner",
-    "subtitle": "Stuck? Get a hint.",
+    "subtitle": "Stuck? Ask a question or get a hint.",
     "completed": "Challenge complete — nice work!",
     "attemptNudge": {
       "title": "Run the tests once first.",
@@ -1032,9 +1032,13 @@
       "hint": "Hint",
       "propose": "Propose fix",
       "askPlaceholder": "Ask a question about this challenge...",
+      "askLabel": "Ask the AI Partner about this challenge",
       "askSend": "Send",
       "review": "Review my solution",
       "reviewHint": "Get idiomatic feedback on your passing solution — this doesn't change your XP."
+    },
+    "composer": {
+      "empty": "Ask anything about this challenge, or grab a hint."
     },
     "diff": {
       "current": "Current",

--- a/apps/web/src/messages/es.json
+++ b/apps/web/src/messages/es.json
@@ -1030,7 +1030,8 @@
     },
     "actions": {
       "hint": "Pista",
-      "propose": "Proponer corrección",
+      "propose": "Muéstrame un cambio",
+      "proposeCost": "usa 1 turno",
       "askPlaceholder": "Haz una pregunta sobre este desafío...",
       "askLabel": "Pregúntale al Compañero de IA sobre este reto",
       "askSend": "Enviar",

--- a/apps/web/src/messages/es.json
+++ b/apps/web/src/messages/es.json
@@ -1001,7 +1001,7 @@
   },
   "aiPartner": {
     "title": "Compañero de IA",
-    "subtitle": "¿Atascado? Pide una pista.",
+    "subtitle": "¿Atascado? Haz una pregunta o pide una pista.",
     "completed": "Reto completado — ¡bien hecho!",
     "attemptNudge": {
       "title": "Ejecuta las pruebas una vez primero.",
@@ -1032,9 +1032,13 @@
       "hint": "Pista",
       "propose": "Proponer corrección",
       "askPlaceholder": "Haz una pregunta sobre este desafío...",
+      "askLabel": "Pregúntale al Compañero de IA sobre este reto",
       "askSend": "Enviar",
       "review": "Revisar mi solución",
       "reviewHint": "Recibe comentarios idiomáticos sobre tu solución ya resuelta — esto no cambia tu XP."
+    },
+    "composer": {
+      "empty": "Pregunta lo que quieras sobre este reto, o pide una pista."
     },
     "diff": {
       "current": "Actual",

--- a/apps/web/src/messages/pt-BR.json
+++ b/apps/web/src/messages/pt-BR.json
@@ -1030,7 +1030,8 @@
     },
     "actions": {
       "hint": "Dica",
-      "propose": "Propor correção",
+      "propose": "Me mostre uma mudança",
+      "proposeCost": "usa 1 turno",
       "askPlaceholder": "Faça uma pergunta sobre este desafio...",
       "askLabel": "Pergunte ao Parceiro de IA sobre este desafio",
       "askSend": "Enviar",

--- a/apps/web/src/messages/pt-BR.json
+++ b/apps/web/src/messages/pt-BR.json
@@ -1001,7 +1001,7 @@
   },
   "aiPartner": {
     "title": "Parceiro de IA",
-    "subtitle": "Travado? Peça uma dica.",
+    "subtitle": "Travado? Faça uma pergunta ou peça uma dica.",
     "completed": "Desafio concluído — mandou bem!",
     "attemptNudge": {
       "title": "Rode os testes uma vez primeiro.",
@@ -1032,9 +1032,13 @@
       "hint": "Dica",
       "propose": "Propor correção",
       "askPlaceholder": "Faça uma pergunta sobre este desafio...",
+      "askLabel": "Pergunte ao Parceiro de IA sobre este desafio",
       "askSend": "Enviar",
       "review": "Revisar minha solução",
       "reviewHint": "Receba comentários idiomáticos sobre a solução que você já concluiu — isto não altera seu XP."
+    },
+    "composer": {
+      "empty": "Pergunte o que quiser sobre este desafio, ou peça uma dica."
     },
     "diff": {
       "current": "Atual",


### PR DESCRIPTION
Closes #944

## Why

#770 deleted the free-text ask field ("hints only — the tutor's role is to nudge, not to answer"). That stance is superseded:

- **#864 assist ladder** — free → metered → Socratic → community handoff, tier-exact billing
- **#865 attempt-gate nudge** — a soft "run the tests first" on the first pre-run AI use
- **#868 per-action model routing** — ask → gemini-3.6-flash, Socratic ask → flash-lite

Those constrain *how* the tutor answers and *how much*, which is what hints-only was really protecting. The `ask` action was already live in `use-ai-partner` + `/api/ai/partner` (with its Socratic contract and contract tests) — only the UI input was missing.

## What

- **New `composer.tsx`** — textarea + Send. Enter sends, Shift+Enter newlines, sr-only `<label htmlFor>`, `focus-visible:ring-2 ring-ring`, trims and refuses empty input, clears on send.
- **Same guards, unchanged.** Ask is routed through the very same `guardAction` as the hint, so a pre-first-run question is *held* and the #865 nudge appears; the free one-tap override replays the exact question. It spends a ladder turn like any other AI action, and disables at `budgetExhausted` (the community-handoff block above already carries that copy — no second wall), while `loading`, and when the lesson is complete (`disabled`), matching hint behavior. Spend-cap state untouched.
- **Placement / empty state (judgment calls).** The footer is one framed block: invitation line (empty state only) → Hint button → composer. The composer *is* the empty-state invitation ("Ask anything about this challenge, or grab a hint"), replacing the old hint-only empty block, so the pane stays compact — no reserved conversation area until there are messages. `QuickActions` gave up its own border/padding to the footer so Hint + ask read as one unit.
- **Comments** in `quick-actions.tsx` / `ai-partner-pane.tsx` rewritten to cite #944 and why the #770 stance no longer holds. Propose-a-fix stays unexposed.
- **i18n ×3** — new `aiPartner.actions.askLabel` + `aiPartner.composer.empty`, real PT-BR/ES translations; `subtitle` updated to mention asking (the pre-existing `askPlaceholder`/`askSend` keys are finally used again).

## Tests

`ai-partner-pane.test.tsx` gains a `#944` block plus one nudge case:

- composer renders post-gate as the empty state, with the Hint button beside it
- ask sends through the hook (mocked) with the trimmed message and clears the box
- Enter sends / Shift+Enter does not / empty never sends
- disabled on `budgetExhausted` (handoff copy still shown), on `loading`, and on lesson-complete
- attempt-gate intercepts a pre-run ask, then the override sends it unchanged

`pnpm --filter web test src/components/editor/ai-partner` → 3 files / 37 tests pass. `pnpm typecheck` clean, `pnpm lint` no errors and no new warnings, prettier clean. Backend contract tests untouched.

---

## Propose action + M1, per gate addendum

Two follow-ups landed on this branch after the review pass above. (The "Propose-a-fix stays unexposed" line in *What* is now superseded — the comments that said so were rewritten in the same pass.)

### 1. `feat(ai-partner)` — "Show me a change" (propose) in the composer

The server side has been complete for a while: `/api/ai/partner` accepts `action: "propose"` (compact search/replace edits, 2,048-token cap, no full-file echo, tier-exact refund on failure), `diff-card.tsx` renders it, `applyEdits` reconstructs and fails closed on a stale buffer, Accept sits behind the earned-Accept comprehension seal (`check-seal.ts`), and `buildDynamicSuffix` deliberately keeps propose free of the Socratic contract (#864 §4.2). Only the affordance was missing — the learner could never *ask* for a change.

- **Secondary ghost action** in the composer beside Send, quieter than Hint/Send, never the primary affordance. Inline cost signal: the label carries "uses 1 turn" (localized), consistent with the meter.
- **Visibility** — hidden until at least one run has **FAILED** (a diff is never the opening move). New sticky `hasFailedRun` signal, threaded from `challenge-interface.tsx` exactly like `hasRunTests`; set on a failing run, not retracted by a later pass. Available at every tier **including Socratic**; withdrawn again at full exhaustion, where the community handoff takes over.
- **Same guards as every other assist** — the #865 attempt gate (a pre-first-run propose is held and replayed by the free override), one ladder turn, disabled (with `aria-busy`) while a request is in flight and on `budgetExhausted`. No propose-specific budget or limit, no auto-apply, no weakening of earned-Accept, no Socratic instructions appended to propose, `socratic.entered` copy untouched.
- **No free text required.** A draft already in the ask box rides along as `message` and is deliberately **not** cleared — the learner asked for a diff, not for their question to be consumed. The response renders through the existing diff-card path in the message list.
- **Analytics** — new `trackProposeAccepted(eventCtx)` in `lib/analytics/events`, fired from the message list when an accepted patch is applied: exactly once per accepted propose (the card latches after its single Accept), so `diff-card.tsx` behavior is unchanged. `trackProposeShown` was left out — see judgment calls.
- **a11y** — real `<button>`, inherited focus-visible ring, `aria-busy` while pending; diff-card behavior unchanged.
- **i18n ×3** — `aiPartner.actions.propose` repurposed to "Show me a change" + new `aiPartner.actions.proposeCost`, identical key structure across en / pt-BR / es.
- **Hook** — `proposeFix` now takes an optional `message`. That is the only plumbing change; the route, diff card, `applyEdits`, seal and prompt builder are untouched.

### 2. `fix(ai-partner)` — M1: composer `maxLength` + live counter

The route 413s a `message` over 4,000 chars and the hook could only render that as the generic "Something went wrong", so a long paste was lost with no explanation. The textarea now carries `maxLength={4000}` plus a `slice()` in `onChange` (a paste past the cap is truncated, never sent into a 413) and a live `N/4000` counter that turns danger past 90% — the same shape as the community markdown editor's `N/10000`. The counter is wired via `aria-describedby` so it is announced with the field.

### Tests

- Visibility: hidden before the first failed run, visible after, present on the Socratic tier, withdrawn at exhaustion.
- A propose click spends a turn via the existing hook path (`proposeFix` called once, with the draft) and the typed draft survives; a propose with no draft passes `undefined`; the response renders as a diff card; the pre-run attempt gate holds and replays it; disabled + `aria-busy` in flight.
- **Regression**: a Socratic-tier propose — *including one carrying a learner draft* — produces a suffix with no `[SOCRATIC_INSTRUCTIONS]`, pinning `buildDynamicSuffix` (`partner-prompt.test.ts`).
- Accept is still locked until the comprehension seal verifies; `trackProposeAccepted` fires exactly once per accepted propose, with the challenge payload.
- i18n parity across the three catalogs (plus the repo-wide `messages/__tests__/parity.test.ts`).
- M1: `maxlength` attribute, counter at 0 / 5 / 4000, and a 4,200-char paste truncated to 4,000.

**Evidence** — `tsc --noEmit` clean; `next lint` over `src/components/editor`, `src/lib/ai`, `src/lib/analytics` reports no errors and no new warnings; full `apps/web` vitest **264 files / 2553 tests passed** (was 2541 — +12 new).

### Judgment calls

1. **Exhaustion: hidden, and also disabled.** The spec says both "hidden again at full exhaustion" and "disabled (not hidden) … when `budgetExhausted`". Implemented as hidden at the pane level (matching the stated test) *and* hard-disabled inside the composer, so it cannot fire even if it were ever rendered in that state.
2. **`trackProposeShown` skipped.** Marked optional; firing on render needs its own dedupe to avoid re-render inflation, and `propose_accepted` + the existing `comprehension_check_answered` already give the funnel its denominator. Cheap to add later if the funnel wants an impression count.
3. **Counter has no visible label**, matching the community editor's bare `N/10000`, so no new i18n string; the field-level announcement comes from `aria-describedby` instead.
4. **The draft is passed but no user bubble is appended** (unlike `ask`), because a propose is answered by the diff card, not by a reply — a bubble would imply the question was consumed.
