### PR TITLE
feat(lesson): LeetCode-patterned lesson pane — inline Discussion, Hint/Topics disclosures, card panes

### DIFF
--- a/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/blocks/code-block.tsx
+++ b/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/blocks/code-block.tsx
@@ -30,12 +30,14 @@ export function CodeBlock({ block, ctx }: BlockRenderProps) {
   ) : undefined;
 
   return (
-    // Edge-to-edge IDE (#770): no card rounding/shadow/side border — the split
-    // sits flush against the viewport and the top bar (top border marks the
-    // seam). `bg-card` so any empty strip (resizer, editor tail, the Monaco a11y
-    // hint) matches the IDE instead of the page's dotted grid. At lg the wrapper
+    // #942 item 4: at lg the two panes are separate rounded cards (styled
+    // inside ChallengeInterface) floating on the page background, LeetCode
+    // style — so this wrapper contributes only the gutter padding and NO
+    // bg/border of its own. Below lg the panes stack full-bleed as before,
+    // where `bg-card` keeps any empty strip (editor tail, Monaco a11y hint)
+    // matching the IDE instead of the page's dotted grid. At lg the wrapper
     // flex-fills the viewport-height column in lesson-client (no page scroll).
-    <div className="overflow-hidden border-t border-border bg-card lg:flex lg:min-h-0 lg:flex-1 lg:flex-col">
+    <div className="overflow-hidden border-t border-border bg-card lg:flex lg:min-h-0 lg:flex-1 lg:flex-col lg:border-t-0 lg:bg-transparent lg:p-2">
       <div className="flex w-full flex-col overflow-hidden lg:min-h-0 lg:flex-1">
         <ChallengeInterface
           lessonId={ctx.lesson._id}

--- a/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/blocks/prose-block.tsx
+++ b/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/blocks/prose-block.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { useCallback, useRef, useState, type ReactNode } from "react";
+import {
+  isValidElement,
+  useCallback,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import { useTranslations } from "next-intl";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeRaw from "rehype-raw";
@@ -44,7 +51,51 @@ function CodeBlockWithCopy({
   );
 }
 
-const markdownComponents = { pre: CodeBlockWithCopy };
+/** Flattens a rendered markdown subtree back to plain text. */
+function textOf(node: ReactNode): string {
+  if (node === null || node === undefined || typeof node === "boolean") {
+    return "";
+  }
+  if (typeof node === "string" || typeof node === "number") return String(node);
+  if (Array.isArray(node)) return node.map(textOf).join("");
+  if (isValidElement<{ children?: ReactNode }>(node)) {
+    return textOf(node.props.children);
+  }
+  return "";
+}
+
+const VERSION_STAMP_RE = /^\s*version stamp\b/i;
+
+/**
+ * Version-stamp blockquotes render as a compact metadata chip row rather than
+ * a pull-quote (#942 item 5). Presentational only: the authored markdown is
+ * untouched, this just recognizes the leading "Version stamp" blockquote the
+ * content standard puts under the h1 and demotes it to mono/muted metadata.
+ */
+function ProseBlockquote({
+  children,
+  ...props
+}: {
+  children?: ReactNode;
+} & React.BlockquoteHTMLAttributes<HTMLQuoteElement>) {
+  const label = useTranslations("lesson")("versionStamp");
+  if (!VERSION_STAMP_RE.test(textOf(children))) {
+    return <blockquote {...props}>{children}</blockquote>;
+  }
+  return (
+    <div
+      aria-label={label}
+      className="not-prose my-4 flex flex-wrap items-baseline gap-x-2 rounded-[var(--r-lg)] border border-border bg-subtle px-3 py-2 font-mono text-[11px] leading-relaxed text-text-3 [&_code]:bg-transparent [&_code]:p-0 [&_p]:m-0 [&_strong]:font-semibold [&_strong]:text-text-2"
+    >
+      {children}
+    </div>
+  );
+}
+
+const markdownComponents = {
+  pre: CodeBlockWithCopy,
+  blockquote: ProseBlockquote,
+};
 
 export function ProseBlock({ block }: BlockRenderProps) {
   const b = block as ProseBlockData;

--- a/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/lesson-client.tsx
+++ b/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/lesson-client.tsx
@@ -11,7 +11,7 @@ import {
   CaretLeft,
   CaretRight,
 } from "@phosphor-icons/react";
-import type { Lesson } from "@superteam-lms/types";
+import type { CodeBlockData, Lesson } from "@superteam-lms/types";
 import { Button } from "@/components/ui/button";
 import { ProgressBar } from "@/components/course/progress-bar";
 import { AuthModal } from "@/components/auth/auth-modal";
@@ -25,17 +25,21 @@ import { bankCompletion, removeBanked } from "@/lib/lessons/progress-bank";
 import { REPLAY_BANKED_EVENT } from "@/components/lessons/banked-progress-replay";
 import { ThreadList } from "@/components/community/thread-list";
 import { CreateThreadModal } from "@/components/community/create-thread-modal";
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
+import { LessonSection } from "@/components/lessons/lesson-section";
 import { RENDERERS, type BlockContext } from "./blocks";
+
+/** Anchor for the toolbar's jump-to-discussion affordance (#942). */
+const DISCUSSION_ANCHOR_ID = "lesson-discussion";
 
 interface LessonPageClientProps {
   lesson: Lesson;
   allLessons: Pick<Lesson, "_id" | "title" | "slug">[];
+  /**
+   * Authored skill tags for this lesson — rendered as the "Topics" disclosure
+   * chips (#942). Optional: the teacher preview bundle has no skills
+   * projection, and an absent/empty list simply omits the section.
+   */
+  skills?: string[];
   locale: string;
   courseSlug: string;
   courseId: string;
@@ -103,6 +107,7 @@ async function completeLessonAPI(
 export function LessonPageClient({
   lesson,
   allLessons,
+  skills = [],
   locale,
   courseSlug,
   courseId,
@@ -126,10 +131,25 @@ export function LessonPageClient({
   const [isEnrolled, setIsEnrolled] = useState(false);
   const hasLinkedWallet = authProfile ? !!authProfile.wallet_address : null;
   const [isDiscussionOpen, setIsDiscussionOpen] = useState(false);
-  // Challenge pages surface discussion in a modal (#770) to keep the page
-  // focused on the code; this controls that modal (distinct from the
-  // create-thread modal above).
+  // Discussion is an inline collapsible section at the bottom of the lesson
+  // pane on every lesson type (#942) — it used to be a modal on challenges
+  // (#770). This is the section's disclosure state (distinct from the
+  // create-thread modal above); the toolbar button jumps to it and opens it.
   const [isDiscussionListOpen, setIsDiscussionListOpen] = useState(false);
+  const [threadCount, setThreadCount] = useState<string | null>(null);
+  const handleThreadCount = useCallback((count: number, hasMore: boolean) => {
+    setThreadCount(hasMore ? `${count}+` : String(count));
+  }, []);
+  // Toolbar affordance on challenge pages: open the inline section and scroll
+  // the rail to it, instead of the old modal (#942).
+  const jumpToDiscussion = useCallback(() => {
+    setIsDiscussionListOpen(true);
+    requestAnimationFrame(() => {
+      document
+        .getElementById(DISCUSSION_ANCHOR_ID)
+        ?.scrollIntoView({ behavior: "smooth", block: "start" });
+    });
+  }, []);
   const [isAuthModalOpen, setIsAuthModalOpen] = useState(false);
   const [buildUuid, setBuildUuid] = useState<string | null>(null);
   const [programKeypairSecret, setProgramKeypairSecret] = useState<
@@ -443,12 +463,81 @@ export function LessonPageClient({
   // dedicated coding-challenge experience the unified block renderer flattened.
   const instructionBlocks = lesson.blocks.filter((b) => b._type !== "code");
   const codeBlocks = lesson.blocks.filter((b) => b._type === "code");
+
+  // LeetCode-style disclosure rows below the prose (#942): the authored hints
+  // (each openable on demand — the 3-failed-runs auto-reveal inside the editor
+  // is untouched), the lesson's skill tags as Topics chips, and Discussion
+  // inline with its thread count.
+  const authoredHints = codeBlocks.flatMap(
+    (b) => (b as CodeBlockData).hints ?? []
+  );
+  const askAction = userId ? (
+    <Button
+      variant="pushOutline"
+      size="sm"
+      onClick={() => setIsDiscussionOpen(true)}
+    >
+      {t("askQuestion")}
+    </Button>
+  ) : (
+    <AuthModal
+      trigger={
+        <Button variant="pushOutline" size="sm">
+          {t("signInToAsk")}
+        </Button>
+      }
+    />
+  );
+  const paneSections = (
+    <div className="mt-2">
+      {authoredHints.map((hint, i) => (
+        <LessonSection
+          key={`hint-${i}`}
+          title={t("stuckNudgeHintLabel", { number: i + 1 })}
+        >
+          <p className="text-sm leading-relaxed text-text-2">{hint}</p>
+        </LessonSection>
+      ))}
+      {skills.length > 0 && (
+        <LessonSection title={t("topics")}>
+          <div className="flex flex-wrap gap-2">
+            {skills.map((skill) => (
+              <span
+                key={skill}
+                className="rounded-full border border-border bg-subtle px-2.5 py-1 font-mono text-xs text-text-2"
+              >
+                {skill}
+              </span>
+            ))}
+          </div>
+        </LessonSection>
+      )}
+      <LessonSection
+        id={DISCUSSION_ANCHOR_ID}
+        title={t("discussion")}
+        count={threadCount}
+        open={isDiscussionListOpen}
+        onOpenChange={setIsDiscussionListOpen}
+        keepMounted
+      >
+        <div className="mb-3 flex justify-end">{askAction}</div>
+        <ThreadList
+          scope={{ courseId, lessonId: lesson._id }}
+          showFilters
+          emptyMessage={tCommunity("empty.lesson")}
+          onCountChange={handleThreadCount}
+        />
+      </LessonSection>
+    </div>
+  );
+
   const instructionsSlot = hasCodeBlock ? (
     <div className="space-y-6">
       {instructionBlocks.map((block) => {
         const Renderer = RENDERERS[block._type];
         return <Renderer key={block.key} block={block} ctx={ctx} />;
       })}
+      {paneSections}
     </div>
   ) : null;
   const codeCtx: BlockContext = { ...ctx, instructionsSlot };
@@ -468,9 +557,11 @@ export function LessonPageClient({
     >
       {/* Lesson top bar — full-bleed on challenges so its bottom border and
           content line up with the edge-to-edge editor split below. Three
-          columns: back+title (left), Prev/Next (center, challenge pages),
-          discussion+XP+progress (right). lg:shrink-0 so it never eats the
-          IDE's flex height. */}
+          columns: back (left), Prev/Next (center, challenge pages),
+          discussion+XP+progress (right). The lesson TITLE deliberately does
+          not live here (#942): the prose h1 immediately below owns document
+          identity, and printing it twice was pure duplication. lg:shrink-0 so
+          it never eats the IDE's flex height. */}
       <div
         className={`flex items-center gap-2 border-b border-border py-2 sm:gap-3 lg:shrink-0 ${
           hasCodeBlock ? "mx-[calc(50%_-_50vw)] w-screen px-3 sm:px-4" : ""
@@ -484,9 +575,6 @@ export function LessonPageClient({
             <ArrowLeft size={16} weight="bold" />
             <span className="hidden sm:inline">{tCommon("back")}</span>
           </Link>
-          <h1 className="min-w-0 truncate font-display text-base font-black text-text sm:text-lg">
-            {lesson.title}
-          </h1>
         </div>
 
         {/* Prev/Next centered on challenge pages (#770) — labeled + visible. */}
@@ -546,7 +634,7 @@ export function LessonPageClient({
             <Button
               variant="ghost"
               size="sm"
-              onClick={() => setIsDiscussionListOpen(true)}
+              onClick={jumpToDiscussion}
               aria-label={t("discussion")}
               title={t("discussion")}
               className="h-8 shrink-0 gap-1.5 px-2 text-xs"
@@ -766,63 +854,12 @@ export function LessonPageClient({
         />
       )}
 
-      {/* Discussion — a focused modal on challenge pages (#770, opened from the
-          top-bar button) to keep the page on the code; inline on reading
-          lessons where there's room. The ask-question header is shared. */}
-      {(() => {
-        const askAction = userId ? (
-          <Button
-            variant="pushOutline"
-            size="sm"
-            onClick={() => setIsDiscussionOpen(true)}
-          >
-            {t("askQuestion")}
-          </Button>
-        ) : (
-          <AuthModal
-            trigger={
-              <Button variant="pushOutline" size="sm">
-                {t("signInToAsk")}
-              </Button>
-            }
-          />
-        );
-        const threads = (
-          <ThreadList
-            scope={{ courseId, lessonId: lesson._id }}
-            showFilters
-            emptyMessage={tCommunity("empty.lesson")}
-          />
-        );
-        return hasCodeBlock ? (
-          <Dialog
-            open={isDiscussionListOpen}
-            onOpenChange={setIsDiscussionListOpen}
-          >
-            <DialogContent className="max-w-2xl">
-              <DialogHeader>
-                <DialogTitle className="flex items-center gap-2">
-                  <ChatCircle size={20} weight="duotone" />
-                  {t("discussion")}
-                </DialogTitle>
-              </DialogHeader>
-              <div className="mb-1 flex justify-end">{askAction}</div>
-              <div className="max-h-[60vh] overflow-auto">{threads}</div>
-            </DialogContent>
-          </Dialog>
-        ) : (
-          <div className="border-t border-border pt-6">
-            <div className="mb-4 flex items-center justify-between">
-              <h3 className="flex items-center gap-2 font-display text-lg font-bold text-text">
-                <ChatCircle size={20} weight="duotone" />
-                {t("discussion")}
-              </h3>
-              {askAction}
-            </div>
-            {threads}
-          </div>
-        );
-      })()}
+      {/* Hints / Topics / Discussion — inline collapsible sections at the
+          bottom of the LESSON PANE (#942). Challenge lessons render them inside
+          the IDE rail via `instructionsSlot`; reading lessons render them here,
+          below the prose. Discussion is the same inline section on both, never
+          a modal. */}
+      {!hasCodeBlock && paneSections}
       <CreateThreadModal
         open={isDiscussionOpen}
         onOpenChange={setIsDiscussionOpen}

--- a/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/page.tsx
+++ b/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/page.tsx
@@ -1,10 +1,11 @@
 import { notFound } from "next/navigation";
-import { LessonPageClient } from "./lesson-client";
 import {
   getLessonBySlug,
   getCourseLessons,
   getCourseIdBySlug,
+  getLessonSkills,
 } from "@/lib/content/queries";
+import { LessonPageClient } from "./lesson-client";
 
 interface LessonPageProps {
   params: Promise<{ locale: string; slug: string; id: string }>;
@@ -21,9 +22,12 @@ export default async function LessonPage({ params }: LessonPageProps) {
 
   if (!lesson) notFound();
 
+  const skills = await getLessonSkills(lesson._id);
+
   return (
     <LessonPageClient
       lesson={lesson}
+      skills={skills}
       allLessons={(allLessons ?? []).filter(Boolean)}
       locale={locale}
       courseSlug={slug}

--- a/apps/web/src/components/community/thread-list.tsx
+++ b/apps/web/src/components/community/thread-list.tsx
@@ -1,12 +1,12 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useTranslations } from "next-intl";
-import { ThreadFilters } from "./thread-filters";
-import { ThreadCard } from "./thread-card";
 import { useThreads } from "@/hooks/use-threads";
 import { useVote } from "@/hooks/use-vote";
 import { Button } from "@/components/ui/button";
+import { ThreadCard } from "./thread-card";
+import { ThreadFilters } from "./thread-filters";
 
 interface ThreadScope {
   categorySlug?: string;
@@ -18,6 +18,12 @@ interface ThreadListProps {
   scope?: ThreadScope;
   showFilters?: boolean;
   emptyMessage?: string;
+  /**
+   * Reports how many threads are currently loaded so a caller can label a
+   * collapsed section header (#942). `hasMore` is true when the page is
+   * capped, so the label can render "20+" instead of a wrong exact total.
+   */
+  onCountChange?: (count: number, hasMore: boolean) => void;
 }
 
 /** Wrapper that gives each ThreadCard its own optimistic vote state. */
@@ -74,6 +80,7 @@ export function ThreadList({
   scope,
   showFilters = true,
   emptyMessage,
+  onCountChange,
 }: ThreadListProps) {
   const t = useTranslations("community");
   const [sort, setSort] = useState("latest");
@@ -84,6 +91,11 @@ export function ThreadList({
     sort,
     type,
   });
+
+  useEffect(() => {
+    if (isLoading) return;
+    onCountChange?.(threads.length, hasMore);
+  }, [isLoading, threads.length, hasMore, onCountChange]);
 
   return (
     <div className="space-y-4">

--- a/apps/web/src/components/editor/challenge-interface.tsx
+++ b/apps/web/src/components/editor/challenge-interface.tsx
@@ -443,7 +443,9 @@ export function ChallengeInterface({
       <div
         ref={leftColRef}
         className={cn(
-          "contents lg:flex lg:min-w-0 lg:flex-col lg:overflow-auto",
+          // #942 item 4: a bordered card at lg (page background shows in the
+          // gutter around and between the panes).
+          "contents lg:flex lg:min-w-0 lg:flex-col lg:overflow-auto lg:rounded-[var(--r-lg)] lg:border lg:border-border lg:bg-card",
           leftWidth === null ? "lg:flex-1" : "lg:shrink-0"
         )}
         style={leftWidth !== null ? { width: leftWidth } : undefined}
@@ -518,7 +520,7 @@ export function ChallengeInterface({
 
       {/* Text/editor split resizer — lg+ only; drag right to widen the text. */}
       <div
-        className="group hidden w-1.5 shrink-0 cursor-col-resize border-x border-border transition-colors [background:var(--resizer-bg)] hover:[background:var(--primary-dim)] lg:relative lg:block"
+        className="group hidden w-2 shrink-0 cursor-col-resize bg-transparent lg:relative lg:block"
         onMouseDown={handleSplitResizeStart}
         role="separator"
         aria-orientation="vertical"
@@ -531,7 +533,7 @@ export function ChallengeInterface({
       {/* RIGHT: code editor + output — full height. Below lg, `contents`
           flattens this so the editor (order-2) and output (order-3) slot
           between the text (order-1) and the AI Partner (order-4). */}
-      <div className="contents lg:flex lg:min-w-0 lg:flex-1 lg:flex-col lg:overflow-hidden">
+      <div className="contents lg:flex lg:min-w-0 lg:flex-1 lg:flex-col lg:overflow-hidden lg:rounded-[var(--r-lg)] lg:border lg:border-border lg:bg-card">
         <div className="order-2 flex min-h-0 flex-col overflow-hidden lg:order-none lg:flex-1">
           {/* Toolbar */}
           <div className="shrink-0 border-b border-border bg-card px-3 py-2.5">

--- a/apps/web/src/components/lessons/lesson-section.tsx
+++ b/apps/web/src/components/lessons/lesson-section.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { useId, useState, type ReactNode } from "react";
+import { CaretRight } from "@phosphor-icons/react";
+import { cn } from "@/lib/utils";
+
+interface LessonSectionProps {
+  /** Visible row label (e.g. "Hint 1", "Topics", "Discussion"). */
+  title: string;
+  /** Optional trailing count, LeetCode's "Discussion (12)" affordance. */
+  count?: string | null;
+  /** Uncontrolled initial state. Ignored when `open` is supplied. */
+  defaultOpen?: boolean;
+  /** Controlled state — pair with `onOpenChange`. */
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  /**
+   * Keep the panel in the DOM while collapsed (hidden). Used by Discussion so
+   * its thread count is known before the learner opens the row; `hidden`
+   * keeps the collapsed content out of the a11y tree and the tab order.
+   */
+  keepMounted?: boolean;
+  id?: string;
+  className?: string;
+  children: ReactNode;
+}
+
+/**
+ * A LeetCode-style disclosure row for the lesson pane (#942 phase 1). Native
+ * button + aria-expanded/aria-controls rather than <details> so the row can be
+ * driven programmatically (the toolbar's jump-to-discussion) and styled
+ * identically across browsers.
+ */
+export function LessonSection({
+  title,
+  count,
+  defaultOpen = false,
+  open: controlledOpen,
+  onOpenChange,
+  keepMounted = false,
+  id,
+  className,
+  children,
+}: LessonSectionProps) {
+  const [uncontrolledOpen, setUncontrolledOpen] = useState(defaultOpen);
+  const isControlled = controlledOpen !== undefined;
+  const isOpen = isControlled ? controlledOpen : uncontrolledOpen;
+  const panelId = `${useId()}-panel`;
+
+  const toggle = () => {
+    const next = !isOpen;
+    if (!isControlled) setUncontrolledOpen(next);
+    onOpenChange?.(next);
+  };
+
+  return (
+    <div id={id} className={cn("border-t border-border", className)}>
+      <button
+        type="button"
+        onClick={toggle}
+        aria-expanded={isOpen}
+        aria-controls={panelId}
+        className="flex w-full items-center gap-2 py-3 text-left font-display text-sm font-bold text-text transition-colors hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--primary)]"
+      >
+        <CaretRight
+          size={14}
+          weight="bold"
+          aria-hidden="true"
+          className={cn("shrink-0 transition-transform", isOpen && "rotate-90")}
+        />
+        <span className="min-w-0 truncate">{title}</span>
+        {count ? (
+          <span className="font-mono text-xs font-normal tabular-nums text-text-3">
+            ({count})
+          </span>
+        ) : null}
+      </button>
+      {(isOpen || keepMounted) && (
+        <div id={panelId} hidden={!isOpen} className="pb-4">
+          {children}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/lib/content/queries.ts
+++ b/apps/web/src/lib/content/queries.ts
@@ -466,6 +466,16 @@ export async function getAllLessonSkills(): Promise<
   return out;
 }
 
+/**
+ * The skill tags authored on ONE lesson — the "Topics" chips in the lesson
+ * pane (#942). Bundle-only and ungated: the lesson page has already resolved
+ * (and gated) the lesson itself, so this is a pure presentation read.
+ */
+export async function getLessonSkills(lessonId: string): Promise<string[]> {
+  const lesson = lessonsById.get(lessonId);
+  return lesson ? strArr(lesson.skills) : [];
+}
+
 export async function getAllCourseLessonCounts(): Promise<
   { _id: string; totalLessons: number }[]
 > {

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -348,6 +348,8 @@
     "linkWalletToEarnXp": "Link your wallet to earn on-chain XP.",
     "linkWalletSettings": "Go to Settings →",
     "discussion": "Discussion",
+    "topics": "Topics",
+    "versionStamp": "Version stamp",
     "askQuestion": "Ask a Question",
     "signInToAsk": "Sign in to ask a question",
     "dismissSuggestion": "Dismiss",

--- a/apps/web/src/messages/es.json
+++ b/apps/web/src/messages/es.json
@@ -348,6 +348,8 @@
     "linkWalletToEarnXp": "Vincula tu wallet para ganar XP on-chain.",
     "linkWalletSettings": "Ir a Configuración →",
     "discussion": "Discusión",
+    "topics": "Temas",
+    "versionStamp": "Registro de versión",
     "askQuestion": "Hacer una Pregunta",
     "signInToAsk": "Inicia sesión para hacer una pregunta",
     "dismissSuggestion": "Descartar",

--- a/apps/web/src/messages/pt-BR.json
+++ b/apps/web/src/messages/pt-BR.json
@@ -348,6 +348,8 @@
     "linkWalletToEarnXp": "Conecte sua carteira para ganhar XP on-chain.",
     "linkWalletSettings": "Ir para Configurações →",
     "discussion": "Discussão",
+    "topics": "Tópicos",
+    "versionStamp": "Registro de versão",
     "askQuestion": "Fazer uma Pergunta",
     "signInToAsk": "Entre para fazer uma pergunta",
     "dismissSuggestion": "Dispensar",


### PR DESCRIPTION
Part of #942 — phase 1 (lesson-pane restructure). Does not close the epic.

## What changed

**1. Discussion inline, not a modal.** Challenge lessons opened Discussion in a
modal from a toolbar button (#770); reading lessons rendered it inline with a
permanently-expanded header. Both now render the same collapsible section at
the bottom of the lesson pane — header with thread count, expands to the thread
list + the ask-a-question composer. The toolbar button now opens the section and
smooth-scrolls the rail to it (kept: it is the only discoverability affordance
above the fold on a challenge).

**2. Hint 1/2/3 + Topics disclosures** under the prose. Authored hints become
individually-openable rows; Topics are the lesson's skill tags as chips. The
3-failed-runs auto-reveal inside `ChallengeInterface` is **unchanged** — this is
an additional, learner-initiated path to the same authored text.

**3. Toolbar title removed.** The prose `h1` immediately below owns document
identity; printing it twice was pure duplication (owner note on #942). Toolbar
keeps Back / Prev / Next / Discussion / XP / progress.

**4. Panes as rounded bordered cards.** Lesson pane and editor/output pane get
`--r-lg` radius + border + `bg-card` at `lg`, with a small gutter so the page
background shows around and between them. The split resizer became the
transparent gutter itself (was a bordered strip). Below `lg` the panes stack
full-bleed exactly as before.

**5. Version stamp as a metadata chip.** The leading "Version stamp" blockquote
renders as a mono/muted chip row instead of a prose pull-quote. Presentational
only — the authored markdown is untouched, and any other blockquote still
renders as a blockquote.

## New component

`components/lessons/lesson-section.tsx` — a disclosure row built on a native
button + `aria-expanded`/`aria-controls` rather than `<details>`, so the toolbar
can drive the Discussion row programmatically and the styling is identical
across browsers. Collapsed panels use `hidden`, keeping them out of the a11y
tree and the tab order.

## Verification

- `typecheck` clean, `lint` clean (only pre-existing `import/order` warnings).
- Full `apps/web` vitest: **2533 passed** (one PGlite hook-timeout flake in
  `email-subscriptions-execution.test.ts` under parallel load; passes on its own).
- Dev-server render check on port 3210 (challenge + reading lesson, `en`/`es`,
  light + dark, desktop + mobile 375px): all disclosures present and toggling,
  Discussion count renders, toolbar jump expands + scrolls, resizer drag still
  moves the split (628px → 760px), no console errors, no `MISSING_MESSAGE`.
- i18n keys `lesson.topics` and `lesson.versionStamp` added to en / pt-BR / es;
  hint labels reuse the existing `lesson.stuckNudgeHintLabel`.

## Judgment calls

- Discussion sits above the AI Partner pane in the challenge rail (the AI pane
  is pinned to the very bottom of that column and is an assistant surface, not
  lesson content).
- `getLessonSkills` returns `[]` for unknown lesson ids, so the teacher-preview
  bundle (no skills projection) simply omits the Topics section rather than
  erroring.
- Deliberately out of scope for phase 1: the Examples/Test-Cases tab merge,
  Run/Submit split, header chips, custom-input row, skeletons.