### PR TITLE
fix(ai): thinkingLevel floor is 'minimal', not 'low' — cost + truncation fix

### DIFF
--- a/apps/web/src/app/api/ai/__tests__/partner-route.test.ts
+++ b/apps/web/src/app/api/ai/__tests__/partner-route.test.ts
@@ -806,7 +806,7 @@ describe("POST /api/ai/partner", () => {
     expect(
       (sent.generationConfig as { thinkingConfig?: Record<string, unknown> })
         .thinkingConfig
-    ).toEqual({ thinkingLevel: "low" });
+    ).toEqual({ thinkingLevel: "minimal" });
     // The propose schema requests an `edits` array and NO whole-file field.
     const schema = sent.generationConfig.responseSchema;
     expect(schema.properties).toHaveProperty("edits");

--- a/apps/web/src/app/api/ai/partner/route.ts
+++ b/apps/web/src/app/api/ai/partner/route.ts
@@ -88,9 +88,10 @@ interface GeminiEnvelope {
 // (empty-bodied, gone on retry). AIE-05 CORRECTION (2026-07-31): the 3.x
 // models reject the 2.5-era `thinkingBudget: 0` with 400 INVALID_ARGUMENT —
 // this broke every partner turn from the #890 model swap until this fix. The
-// 3.x floor is `thinkingLevel: "low"` (MINIMAL_THINKING_CONFIG in
-// lib/ai/models); thinking tokens still draw from maxOutputTokens and bill at
-// the output rate, so the floor stays on for all of them.
+// 3.x floor is `thinkingLevel: "minimal"` (MINIMAL_THINKING_CONFIG in
+// lib/ai/models — round-2 correction: "low" burns hundreds of output-rate
+// thinking tokens and truncates 512-cap turns); thinking tokens draw from
+// maxOutputTokens and bill at the output rate, so the floor stays on.
 //
 // A model that 404s FAILS CLOSED: the !response.ok branch below refunds the
 // assist and 502s. There is deliberately no silent fallback to another model —
@@ -525,8 +526,9 @@ export async function POST(request: NextRequest) {
           // Every routed model is a thinking model and thinking tokens share
           // the maxOutputTokens budget (and bill at the output rate); keep
           // thinking at the model's floor. NOTE the 3.x API rejects the 2.5-era
-          // `thinkingBudget: 0` with a 400 — "low" is the minimum thinkingLevel
-          // (AIE-05 correction, 2026-07-31; see lib/ai/models.ts).
+          // `thinkingBudget: 0` with a 400, and the enum floor is "minimal" —
+          // NOT "low", which burns real thinking tokens and truncates small
+          // budgets (AIE-05 round-2 correction; see lib/ai/models.ts).
           thinkingConfig: MINIMAL_THINKING_CONFIG,
           responseMimeType: "application/json",
           responseSchema: responseSchemaFor(action),

--- a/apps/web/src/lib/ai/__tests__/reflection-reply.test.ts
+++ b/apps/web/src/lib/ai/__tests__/reflection-reply.test.ts
@@ -84,7 +84,7 @@ describe("maybeGenerateReflectionReply", () => {
       )
     ) as { generationConfig: { thinkingConfig: Record<string, unknown> } };
     expect(body.generationConfig.thinkingConfig).toEqual({
-      thinkingLevel: "low",
+      thinkingLevel: "minimal",
     });
     expect(body.generationConfig.thinkingConfig).not.toHaveProperty(
       "thinkingBudget"

--- a/apps/web/src/lib/ai/models.ts
+++ b/apps/web/src/lib/ai/models.ts
@@ -15,15 +15,17 @@ import type { PartnerAction } from "@/lib/ai/partner-types";
 // — so any future "this model 404s for our key" claim must be re-tested twice
 // before it is believed (or written down).
 //
-// AIE-05 correction (2026-07-31, supersedes the 2026-07-28 record): the 3.x
-// models now REJECT `thinkingConfig: { thinkingBudget: 0 }` with a 400
-// INVALID_ARGUMENT — `thinkingBudget` is the 2.5-era field. The 3.x field is
-// `thinkingLevel`, whose MINIMUM is "low" ("none" is not a valid enum value;
-// probed empirically on both routed models). Every generateContent caller must
-// send MINIMAL_THINKING_CONFIG below; thinking tokens still bill at the OUTPUT
-// rate and share maxOutputTokens, so keeping thinking minimal remains a real
-// cost lever. Probed at "low" with the hint schema: zero thinking tokens on a
-// trivial prompt, valid JSON, finish STOP.
+// AIE-05 correction, round 2 (2026-07-31 evening — supersedes BOTH earlier
+// records, including this morning's #945 note): the 3.x models REJECT the
+// 2.5-era `thinkingBudget: 0` (400 INVALID_ARGUMENT), and the `thinkingLevel`
+// enum is minimal | low | medium | high — "none" is invalid AND "minimal" sits
+// BELOW "low". The #945 fix probed only "none" and "low" and wrongly wrote
+// "low is the floor"; a follow-up probe on both routed models with a real
+// prompt showed `low` burns ~470-490 thinking tokens (output rate) and
+// TRUNCATES inside a 512 budget (finish MAX_TOKENS), while `minimal` spends 0
+// thinking tokens and finishes STOP. Every generateContent caller must send
+// MINIMAL_THINKING_CONFIG below. Meta-lesson, twice paid: probe the FULL enum
+// space before writing "X is the floor" into a comment.
 
 export const GEMINI_MODELS = [
   "gemini-3.6-flash",
@@ -154,10 +156,11 @@ export function geminiUrl(model: GeminiModel): string {
 
 /**
  * The minimal thinking configuration accepted by every routed (3.x) model.
- * `thinkingLevel: "low"` is the FLOOR — `"none"` is not a valid enum value, and
- * the 2.5-era `thinkingBudget: 0` is rejected outright with a 400
- * INVALID_ARGUMENT (see the AIE-05 correction in the header). All
- * generateContent callers must spread this rather than hand-rolling a
- * thinkingConfig, so a future API change is a one-line fix here.
+ * `thinkingLevel: "minimal"` is the true floor (enum: minimal|low|medium|high;
+ * "none" is invalid, and the 2.5-era `thinkingBudget: 0` 400s — see the AIE-05
+ * round-2 correction in the header; `low` measurably burns hundreds of
+ * output-rate thinking tokens and truncates 512-cap turns). All generateContent
+ * callers must spread this rather than hand-rolling a thinkingConfig, so a
+ * future API change is a one-line fix here.
  */
-export const MINIMAL_THINKING_CONFIG = { thinkingLevel: "low" } as const;
+export const MINIMAL_THINKING_CONFIG = { thinkingLevel: "minimal" } as const;


### PR DESCRIPTION
Round-2 correction of #945, found by the integration-shape audit reviewing #945 itself: the `thinkingLevel` enum is `minimal | low | medium | high` — `minimal` sits below `low` and "matches the no-thinking setting" per the current Gemini docs. #945 probed only `none` (invalid) and `low` (valid) and wrongly froze "low is the floor" into the comment — the same verified-once bug class #945 fixed.

**Empirical probe (both routed models, real prompt, 512-token budget):**

| model | level | thoughts | candidates | finish |
|---|---|---|---|---|
| 3.5-flash-lite | minimal | 0 | 73 | STOP |
| 3.5-flash-lite | low | 466 | 42 | **MAX_TOKENS** |
| 3.6-flash | minimal | 0 | 61 | STOP |
| 3.6-flash | low | 491 | 17 | **MAX_TOKENS** |

At `low`, thinking tokens (billed at the output rate) eat most of the budget and small-cap turns (Socratic 512) truncate — and truncated responses are billed-not-refunded by design. `minimal` restores the intended behavior of the old `thinkingBudget: 0`.

**Change:** one constant (`MINIMAL_THINKING_CONFIG` → `minimal`) + both regression tests + comments corrected with the full probe table. 13 files / 222 tests pass, typecheck clean.

Both send sites already consume the shared constant, so this is a true one-line behavioral change.