### PR TITLE
fix(env): close four env-wiring gaps found in the 31-07 audit

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -72,7 +72,11 @@ BUILD_SERVER_URL=https://academy-build-server-HASH.a.run.app
 # API key for X-API-Key header (same value as ACADEMY_API_KEY on Cloud Run)
 BUILD_SERVER_API_KEY=                      # PRIVATE — server-only
 
-# ── App URL (for sitemap, OG tags, NFT metadata URI fallback) ────────────────
+# ── App URL (sitemap, OG tags, email links, on-chain NFT metadata URI) ───────
+# REQUIRED. Validated in apps/web/src/lib/env.ts: dev/test fall back to the
+# localhost origin below, but a PRODUCTION build with this unset FAILS at boot —
+# an empty value would pin a *relative* metadata URI into an immutable
+# credential NFT.
 NEXT_PUBLIC_APP_URL=http://localhost:3000
 
 # ── Arweave / Irys — permanent credential metadata (server-only) ─────────────

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,6 +177,7 @@ jobs:
           NEXT_PUBLIC_SOLANA_RPC_URL: https://api.devnet.solana.com
           NEXT_PUBLIC_SUPABASE_URL: https://example.supabase.co
           NEXT_PUBLIC_SUPABASE_ANON_KEY: test-anon-key
+          NEXT_PUBLIC_APP_URL: http://localhost:3000
         run: pnpm -r test
 
   # ── E2E: Playwright, the 3 critical learner paths (#781) ────────────────────

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -29,6 +29,9 @@ env:
   NEXT_PUBLIC_SOLANA_RPC_URL: "https://api.devnet.solana.com"
   NEXT_PUBLIC_SOLANA_NETWORK: "devnet"
   NEXT_PUBLIC_PROGRAM_ID: "7NeJaSRyb4Wxay3Tcd9bdpD7T3GWYUQSFyrhG8SgwE8V"
+  # Required by lib/env.ts; `next build` runs as NODE_ENV=production, where the
+  # schema refuses to default it.
+  NEXT_PUBLIC_APP_URL: "http://localhost:3000"
 
 jobs:
   lighthouse:

--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -1,4 +1,4 @@
-# apps/web — Next.js 14 App Router
+# apps/web — Next.js 15 App Router
 
 API route reference lives in `src/app/api/CLAUDE.md` (loads when you work on routes).
 
@@ -120,8 +120,8 @@ OPENENDED_AI_REPLY=                # Best-effort AI reply on /api/lessons/reflec
 #                                  # Needs no GITHUB_TOKEN: academy-courses is public, so the
 #                                  # preview reads it anonymously (#830). A token is used when
 #                                  # set, purely to lift the 60 req/hr anonymous rate limit.
-TEACH_PREVIEW_PASSWORD=            # Shared password for /teach/preview. Defaults to "123" —
-                                   # an INTERIM value; set a real one before sharing the URL.
+TEACH_PREVIEW_PASSWORD=            # Shared password for /teach/preview. NO default —
+                                   # unset = preview disabled (/api/teach/preview/auth 503s).
                                    # Gates read-only rendering of unpublished course PRs only:
                                    # never on-chain writes, never the admin surface (separate
                                    # cookie from admin_session, so it cannot satisfy admin auth).
@@ -149,7 +149,10 @@ SENTRY_ORG=                        # Build-time source-map upload (CI/Vercel onl
 SENTRY_PROJECT=
 SENTRY_AUTH_TOKEN=
 
-# Optional — App URL (for sitemap, OG tags)
+# Required — App URL (sitemap, OG tags, email links, on-chain metadata URIs).
+# Validated in lib/env.ts: dev/test default to http://localhost:3000, a
+# PRODUCTION build with it unset fails at boot — an empty value would pin a
+# RELATIVE metadata URI into an immutable credential NFT (unfixable after mint).
 NEXT_PUBLIC_APP_URL=http://localhost:3000
 ```
 

--- a/apps/web/e2e/harness/serve.mjs
+++ b/apps/web/e2e/harness/serve.mjs
@@ -18,6 +18,7 @@ import { fileURLToPath } from "node:url";
 import net from "node:net";
 import {
   APP_PORT,
+  APP_BASE_URL,
   MOCK_PORT,
   MOCK_SUPABASE_URL,
   ANON_KEY,
@@ -70,6 +71,10 @@ const appEnv = {
   // shape-valid devnet program id — never used to send a real tx here.
   NEXT_PUBLIC_PROGRAM_ID: "7NeJaSRyb4Wxay3Tcd9bdpD7T3GWYUQSFyrhG8SgwE8V",
   NEXT_PUBLIC_SOLANA_NETWORK: "devnet",
+  // Required by lib/env.ts. The harness runs with NODE_ENV=production, where
+  // the schema deliberately refuses to default it (an unset value would mint a
+  // relative on-chain metadata URI in prod), so state the app's own origin.
+  NEXT_PUBLIC_APP_URL: APP_BASE_URL,
   SUPABASE_SERVICE_ROLE_KEY: "e2e-service-role-not-a-secret",
   SOLANA_RPC_URL: "https://api.devnet.solana.com",
   // Trust the mock's self-signed cert for server-side (undici) fetches.

--- a/apps/web/src/app/api/teach/preview/auth/__tests__/route.test.ts
+++ b/apps/web/src/app/api/teach/preview/auth/__tests__/route.test.ts
@@ -1,0 +1,52 @@
+/* eslint-disable import/order -- vi.mock must hoist above the imports it stubs */
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+// F3: TEACH_PREVIEW_PASSWORD no longer falls back to the literal "123", so an
+// unconfigured deployment must FAIL CLOSED (503) instead of accepting a
+// well-known password.
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/rate-limit", () => ({
+  isRateLimited: vi.fn(async () => false),
+  getClientIp: () => "127.0.0.1",
+}));
+
+import { NextRequest } from "next/server";
+import { POST } from "../route";
+
+function postWith(password: unknown): NextRequest {
+  return new NextRequest("https://example.test/api/teach/preview/auth", {
+    method: "POST",
+    body: JSON.stringify({ password }),
+  });
+}
+
+describe("POST /api/teach/preview/auth", () => {
+  afterEach(() => {
+    delete process.env.TEACH_PREVIEW_PASSWORD;
+    vi.restoreAllMocks();
+  });
+
+  it("503s (and logs) when TEACH_PREVIEW_PASSWORD is unset — no default password", async () => {
+    delete process.env.TEACH_PREVIEW_PASSWORD;
+    const logged = vi.spyOn(console, "error").mockImplementation(() => {});
+    const res = await POST(postWith("123"));
+    expect(res.status).toBe(503);
+    expect(logged).toHaveBeenCalledWith(
+      expect.stringContaining("TEACH_PREVIEW_PASSWORD")
+    );
+    expect(res.headers.get("set-cookie")).toBeNull();
+  });
+
+  it("401s on a wrong password once configured", async () => {
+    process.env.TEACH_PREVIEW_PASSWORD = "s3cret";
+    const res = await POST(postWith("123"));
+    expect(res.status).toBe(401);
+  });
+
+  it("mints a session cookie on the configured password", async () => {
+    process.env.TEACH_PREVIEW_PASSWORD = "s3cret";
+    const res = await POST(postWith("s3cret"));
+    expect(res.status).toBe(200);
+    expect(res.headers.get("set-cookie")).toContain("teach_preview_session=");
+  });
+});

--- a/apps/web/src/app/api/teach/preview/auth/route.ts
+++ b/apps/web/src/app/api/teach/preview/auth/route.ts
@@ -3,6 +3,7 @@ import "server-only";
 import { NextRequest, NextResponse } from "next/server";
 import { isRateLimited, getClientIp } from "@/lib/rate-limit";
 import {
+  isPreviewConfigured,
   isValidPreviewPassword,
   isValidPreviewSession,
   setPreviewSessionCookie,
@@ -19,11 +20,25 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
 
 /**
  * Exchanges the shared preview password for an HMAC-signed session cookie
- * (#828). Rate-limited per client IP: the interim password is short, so cap
+ * (#828). Rate-limited per client IP: the shared password may be short, so cap
  * guessing even though the gate only protects read-only rendering.
+ *
+ * FAILS CLOSED when `TEACH_PREVIEW_PASSWORD` is unset — there is no literal
+ * default password any more, so an unconfigured deployment disables the preview
+ * instead of shipping a guessable gate.
  */
 export async function POST(req: NextRequest): Promise<NextResponse> {
   try {
+    if (!isPreviewConfigured()) {
+      console.error(
+        "[teach-preview] TEACH_PREVIEW_PASSWORD is unset — teacher preview is disabled (503). Set it to enable /teach/preview."
+      );
+      return NextResponse.json(
+        { error: "Teacher preview is not configured" },
+        { status: 503 }
+      );
+    }
+
     const ip = getClientIp(req.headers);
     if (
       await isRateLimited("teach-preview-auth", ip, {

--- a/apps/web/src/lib/__tests__/env-app-url.test.ts
+++ b/apps/web/src/lib/__tests__/env-app-url.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+// NEXT_PUBLIC_APP_URL is interpolated into strings that get PINNED ON-CHAIN
+// (certificate metadata URI / external_url). Unset, the `?? ""` fallbacks at
+// those sites mint a RELATIVE URI into an immutable Metaplex Core asset. The
+// public env schema must therefore make "unset in production" unreachable,
+// while still defaulting in dev/test so `pnpm dev` and the suites just work.
+
+async function importEnv() {
+  vi.resetModules();
+  return import("@/lib/env");
+}
+
+describe("env — NEXT_PUBLIC_APP_URL", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    process.env.NEXT_PUBLIC_APP_URL = "http://localhost:3000";
+  });
+
+  it("defaults to the documented localhost origin in dev/test", async () => {
+    vi.stubEnv("NEXT_PUBLIC_APP_URL", "");
+    const { env } = await importEnv();
+    expect(env.NEXT_PUBLIC_APP_URL).toBe("http://localhost:3000");
+  });
+
+  it("uses the configured value when set", async () => {
+    vi.stubEnv("NEXT_PUBLIC_APP_URL", "https://academy.example.com");
+    const { env } = await importEnv();
+    expect(env.NEXT_PUBLIC_APP_URL).toBe("https://academy.example.com");
+  });
+
+  it("throws at boot when unset in production (no relative on-chain URI)", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("NEXT_PUBLIC_APP_URL", "");
+    await expect(importEnv()).rejects.toThrow(/NEXT_PUBLIC_APP_URL/);
+  });
+
+  it("throws on a non-absolute value (a path is not an origin)", async () => {
+    vi.stubEnv("NEXT_PUBLIC_APP_URL", "/certificates");
+    await expect(importEnv()).rejects.toThrow(/NEXT_PUBLIC_APP_URL/);
+  });
+});

--- a/apps/web/src/lib/env.server.ts
+++ b/apps/web/src/lib/env.server.ts
@@ -114,6 +114,12 @@ const serverEnvSchema = z.object({
   // "Superteam Academy <news@st.academy>". Optional — falls back to
   // DEFAULT_EMAIL_FROM (lib/email/resend.ts) when unset.
   EMAIL_FROM: optStr,
+  // Shared password for the read-only teacher course preview (#828). Optional
+  // at boot and FAIL-CLOSED: unset ⇒ /api/teach/preview/auth 503s and the
+  // preview is disabled (lib/teach/preview-auth.ts). There is no default —
+  // the old literal "123" fallback meant every deployment that forgot this var
+  // shipped a guessable gate.
+  TEACH_PREVIEW_PASSWORD: optStr,
   // Optional dedicated key for sealing the AI Partner's comprehension-check /
   // attestation tokens (lib/ai/check-seal.ts). Falls back to
   // SUPABASE_SERVICE_ROLE_KEY when unset.
@@ -160,6 +166,7 @@ const parsed = serverEnvSchema.safeParse({
   RESEND_API_KEY: process.env.RESEND_API_KEY,
   CRON_SECRET: process.env.CRON_SECRET,
   EMAIL_FROM: process.env.EMAIL_FROM,
+  TEACH_PREVIEW_PASSWORD: process.env.TEACH_PREVIEW_PASSWORD,
   AI_PARTNER_SEAL_SECRET: process.env.AI_PARTNER_SEAL_SECRET,
   AI_SPEND_GLOBAL_SOFT_USD: process.env.AI_SPEND_GLOBAL_SOFT_USD,
   AI_SPEND_GLOBAL_HARD_USD: process.env.AI_SPEND_GLOBAL_HARD_USD,

--- a/apps/web/src/lib/env.ts
+++ b/apps/web/src/lib/env.ts
@@ -46,6 +46,31 @@ const publicEnvSchema = z.object({
   // is unrestricted, and server calls send no browser Origin — sharing one key
   // and origin-restricting it would break every server-side RPC/DAS read.
   NEXT_PUBLIC_SOLANA_RPC_URL: z.url(),
+  // The app's own absolute origin. REQUIRED — not cosmetic: several server
+  // paths interpolate it into strings that get PINNED ON-CHAIN or mailed out
+  // (certificate `external_url` + metadata URI in api/certificates/mint,
+  // lib/solana/onchain-queue, lib/helius/event-handlers, api/admin/courses/sync
+  // and api/admin/achievements/sync). Those sites keep a `?? ""` fallback as
+  // defense in depth, but with an unset var that fallback mints a RELATIVE URI
+  // ("/api/certificates/metadata?id=…") into an immutable Metaplex Core asset —
+  // unfixable after the fact. Validating here makes that state unreachable:
+  // boot/build fails loudly instead.
+  //
+  // Dev/test default to http://localhost:3000 (the documented local origin, see
+  // .env.example) so `pnpm dev` and the suites need no extra setup; in
+  // production the value must be supplied explicitly — no default can be right
+  // there, and a silently-wrong origin is exactly the failure we are closing.
+  NEXT_PUBLIC_APP_URL: z.preprocess(
+    (value) =>
+      value === "" || value === undefined
+        ? process.env.NODE_ENV === "production"
+          ? undefined
+          : "http://localhost:3000"
+        : value,
+    z.url({
+      error: "must be an absolute URL, e.g. https://academy.example.com",
+    })
+  ),
   // Optional Sentry DSN (public/safe to expose). Unset disables Sentry.
   NEXT_PUBLIC_SENTRY_DSN: z.url().optional().or(z.literal("")),
 });
@@ -54,6 +79,7 @@ const parsed = publicEnvSchema.safeParse({
   NEXT_PUBLIC_SUPABASE_URL: process.env.NEXT_PUBLIC_SUPABASE_URL,
   NEXT_PUBLIC_SUPABASE_ANON_KEY: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
   NEXT_PUBLIC_SOLANA_RPC_URL: process.env.NEXT_PUBLIC_SOLANA_RPC_URL,
+  NEXT_PUBLIC_APP_URL: process.env.NEXT_PUBLIC_APP_URL,
   NEXT_PUBLIC_SENTRY_DSN: process.env.NEXT_PUBLIC_SENTRY_DSN,
 });
 

--- a/apps/web/src/lib/supabase/__tests__/schema-expectations.test.ts
+++ b/apps/web/src/lib/supabase/__tests__/schema-expectations.test.ts
@@ -87,6 +87,59 @@ describe("checkSchemaExpectations (#731)", () => {
     ).toBe(true);
   });
 
+  // #864 assist ladder: the exact #945-class gap this check exists to close —
+  // spendAssistTurn fails CLOSED, so a missing RPC denies every AI tutor turn
+  // while nothing else reports a problem.
+  it("a missing spend_assist_ladder_turn is reported (the AI-tutor fail-closed gap)", async () => {
+    const result = await checkSchemaExpectations(
+      makeClient({
+        rpcErrors: {
+          spend_assist_ladder_turn: {
+            code: "PGRST202",
+            message:
+              "Could not find the function public.spend_assist_ladder_turn",
+          },
+        },
+      })
+    );
+    expect(result.ok).toBe(false);
+    const miss = result.missing.find(
+      (m) => m.object === "function spend_assist_ladder_turn"
+    );
+    expect(miss?.migration).toBe("20260730120000_assist_ladder.sql");
+  });
+
+  it("a missing challenge_assists.chat_log column is reported", async () => {
+    const result = await checkSchemaExpectations(
+      makeClient({
+        tableErrors: {
+          challenge_assists: {
+            code: "42703",
+            message: "column challenge_assists.chat_log does not exist",
+          },
+        },
+      })
+    );
+    expect(result.ok).toBe(false);
+    const miss = result.missing.find((m) => m.object.includes("chat_log"));
+    expect(miss?.migration).toBe("20260730120000_assist_ladder.sql");
+  });
+
+  // Every write-side RPC probe is safe ONLY because the anon client lacks
+  // EXECUTE. Guard the invariant that each such probe carries inert arguments,
+  // so a future GRANT never turns a health check into a real mutation.
+  it("the assist-ladder spend probe passes zero tier maxima (inert even if it ran)", () => {
+    const spend = SCHEMA_EXPECTATIONS.find(
+      (e) => e.kind === "rpc" && e.rpc === "spend_assist_ladder_turn"
+    );
+    expect(spend).toBeDefined();
+    expect(spend?.kind === "rpc" ? spend.args : {}).toMatchObject({
+      p_free_max: 0,
+      p_metered_max: 0,
+      p_socratic_max: 0,
+    });
+  });
+
   it("permission-denied on an rpc means PRESENT (exists, just not callable by anon)", async () => {
     const result = await checkSchemaExpectations(
       makeClient({

--- a/apps/web/src/lib/supabase/schema-expectations.ts
+++ b/apps/web/src/lib/supabase/schema-expectations.ts
@@ -118,6 +118,57 @@ export const SCHEMA_EXPECTATIONS: readonly SchemaExpectation[] = [
     description:
       "re-engagement claim + frequency cap (#899) — a missing fn silently sends nothing",
   },
+  {
+    kind: "rpc",
+    // ⚠️ SIDE-EFFECTFUL IF EVER CALLABLE (it upserts the (user, lesson) row and
+    // bumps a tier counter) — safe here for the same reason as the two probes
+    // above: REVOKEd from PUBLIC/anon/authenticated, so the ANON client gets
+    // 42501 and the body never runs. Belt AND braces: every tier max below is
+    // 0, so a body that somehow ran would fall straight through to the
+    // 'exhausted' branch, which increments nothing and (deliberately) does not
+    // even touch updated_at.
+    rpc: "spend_assist_ladder_turn",
+    args: {
+      p_user_id: NIL_UUID,
+      p_lesson_id: "",
+      p_free_max: 0,
+      p_metered_max: 0,
+      p_socratic_max: 0,
+    },
+    migration: "20260730120000_assist_ladder.sql",
+    description:
+      "AI assist ladder spend (#864) — spendAssistTurn fails CLOSED on any RPC error, so a missing fn denies EVERY AI tutor turn while /api/health/schema still returns 200 (the #945 class of prod-down)",
+  },
+  {
+    kind: "rpc",
+    // Read-only (LANGUAGE sql STABLE) — no side effect even if it ran, which it
+    // does not (REVOKEd from anon, same as above).
+    rpc: "get_challenge_assist_state",
+    args: { p_user_id: NIL_UUID, p_lesson_id: "" },
+    migration: "20260730120000_assist_ladder.sql",
+    description:
+      "assist-pane rehydration (#864) — the same migration DROPs the old signature, so a stale prod has NEITHER version and the pane loads with empty counts",
+  },
+  {
+    kind: "column",
+    table: "challenge_assists",
+    column: "chat_log",
+    migration: "20260730120000_assist_ladder.sql",
+    description:
+      "persisted AI Partner chat log — folded into the ladder migration because 20260715160000_ai_partner_chat_log.sql was never applied to prod (#708 ledger); its absence silently drops every learner's chat history",
+  },
+  {
+    kind: "rpc",
+    // ⚠️ SIDE-EFFECTFUL IF EVER CALLABLE (advances/resets a Leitner box) — safe
+    // for the usual reason (REVOKEd from anon → 42501, body never runs), and
+    // the item key below matches no row, so a body that ran would return zero
+    // rows and mutate nothing.
+    rpc: "record_review_result",
+    args: { p_user_id: NIL_UUID, p_item_key: "", p_passed: false },
+    migration: "20260726140000_review_items_spaced_repetition.sql",
+    description:
+      "spaced-repetition grading (#569) — /api/review/grade rethrows the RPC error, so a missing fn 500s every review submission",
+  },
 ];
 
 // PostgREST "not found in schema cache" + Postgres undefined-object SQLSTATEs.

--- a/apps/web/src/lib/teach/__tests__/preview-auth.test.ts
+++ b/apps/web/src/lib/teach/__tests__/preview-auth.test.ts
@@ -5,6 +5,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 vi.mock("server-only", () => ({}));
 
 import {
+  isPreviewConfigured,
   isValidPreviewPassword,
   isValidPreviewSession,
   mintPreviewSession,
@@ -26,21 +27,29 @@ describe("preview password", () => {
     delete process.env.TEACH_PREVIEW_PASSWORD;
   });
 
-  it("accepts the documented interim default", () => {
-    expect(isValidPreviewPassword("123")).toBe(true);
-  });
-
-  it("rejects a wrong password and non-strings", () => {
-    expect(isValidPreviewPassword("1234")).toBe(false);
+  // The old literal "123" default shipped a guessable gate to every deployment
+  // that forgot the env var. Unset now means DISABLED, not "weak".
+  it("unset ⇒ the gate is closed: nothing satisfies it, including the old default", () => {
+    delete process.env.TEACH_PREVIEW_PASSWORD;
+    expect(isPreviewConfigured()).toBe(false);
+    expect(isValidPreviewPassword("123")).toBe(false);
     expect(isValidPreviewPassword("")).toBe(false);
     expect(isValidPreviewPassword(undefined)).toBe(false);
-    expect(isValidPreviewPassword(123)).toBe(false);
   });
 
-  it("honours the env override instead of the default", () => {
+  it("blank ⇒ treated as unset (a Vercel placeholder does not open the gate)", () => {
+    process.env.TEACH_PREVIEW_PASSWORD = "";
+    expect(isPreviewConfigured()).toBe(false);
+    expect(isValidPreviewPassword("")).toBe(false);
+  });
+
+  it("accepts only the configured password", () => {
     process.env.TEACH_PREVIEW_PASSWORD = "s3cret";
+    expect(isPreviewConfigured()).toBe(true);
     expect(isValidPreviewPassword("s3cret")).toBe(true);
     expect(isValidPreviewPassword("123")).toBe(false);
+    expect(isValidPreviewPassword("s3cre")).toBe(false);
+    expect(isValidPreviewPassword(123)).toBe(false);
   });
 });
 

--- a/apps/web/src/lib/teach/preview-auth.ts
+++ b/apps/web/src/lib/teach/preview-auth.ts
@@ -22,29 +22,38 @@ export const TEACH_PREVIEW_COOKIE = "teach_preview_session";
 export const TEACH_PREVIEW_MAX_AGE_MS = 24 * 60 * 60 * 1000;
 
 /**
- * Interim shared password. `TEACH_PREVIEW_PASSWORD` overrides it; the default
- * is intentionally trivial because this gate protects unpublished course drafts
- * (already destined to be public), never funds, secrets, or writes. Swap the
- * env var before this is useful to anyone outside the team.
+ * The shared preview password, or `null` when `TEACH_PREVIEW_PASSWORD` is
+ * unset/blank. There is deliberately NO fallback: the previous literal default
+ * ("123") shipped a guessable gate to every deployment that forgot to set the
+ * var. Unset now means the preview is DISABLED — the auth endpoint fails closed
+ * rather than accepting a well-known password.
  */
-const DEFAULT_PASSWORD = "123";
-
-export function getPreviewPassword(): string {
+export function getPreviewPassword(): string | null {
   const configured = process.env.TEACH_PREVIEW_PASSWORD;
-  return configured && configured.length > 0 ? configured : DEFAULT_PASSWORD;
+  return configured && configured.length > 0 ? configured : null;
+}
+
+/** True when a preview password is configured, i.e. the gate can be opened. */
+export function isPreviewConfigured(): boolean {
+  return getPreviewPassword() !== null;
 }
 
 /**
  * The HMAC key for session cookies. Prefers a real server secret so cookies
  * can't be forged by anyone who guesses the (weak, shared) password; falls back
  * to the password itself when no secret is configured, which still binds the
- * cookie to the current password.
+ * cookie to the current password. With none of the three set there is nothing
+ * to sign with — and nothing to protect either, since the gate is disabled — so
+ * the last resort is a random per-process key: every cookie it verifies fails.
  */
+const EPHEMERAL_SECRET = crypto.randomBytes(32).toString("hex");
+
 function sessionSecret(): string {
   return (
     process.env.SUPABASE_SERVICE_ROLE_KEY ??
     process.env.ADMIN_SECRET ??
-    getPreviewPassword()
+    getPreviewPassword() ??
+    EPHEMERAL_SECRET
   );
 }
 
@@ -57,8 +66,11 @@ function safeEqual(a: string, b: string): boolean {
 }
 
 export function isValidPreviewPassword(candidate: unknown): boolean {
+  const expected = getPreviewPassword();
+  // Unset password ⇒ the gate is disabled: nothing can satisfy it, not even "".
+  if (expected === null) return false;
   if (typeof candidate !== "string") return false;
-  return safeEqual(candidate, getPreviewPassword());
+  return safeEqual(candidate, expected);
 }
 
 export function mintPreviewSession(): string {

--- a/apps/web/vitest.setup.ts
+++ b/apps/web/vitest.setup.ts
@@ -11,6 +11,7 @@ process.env.NEXT_PUBLIC_PROGRAM_ID ??=
 process.env.NEXT_PUBLIC_SUPABASE_URL ??= "https://test.supabase.co";
 process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ??= "test-anon-key";
 process.env.NEXT_PUBLIC_SOLANA_RPC_URL ??= "https://api.devnet.solana.com";
+process.env.NEXT_PUBLIC_APP_URL ??= "http://localhost:3000";
 process.env.SUPABASE_SERVICE_ROLE_KEY ??= "test-service-role-key";
 process.env.SOLANA_RPC_URL ??= "https://api.devnet.solana.com";
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -102,9 +102,10 @@ fails the boot loudly rather than degrading silently.
 `apps/web/vercel.json` (the Vercel **Root Directory** is `apps/web`) declares
 every scheduled job:
 
-| Path                          | Schedule (UTC) | Local time              | What it does                                                                                     |
-| ----------------------------- | -------------- | ----------------------- | ------------------------------------------------------------------------------------------------ |
-| `/api/cron/session-reminders` | `0 11 * * *`   | 08:00 America/Sao_Paulo | Sends the session-plan reminder to learners who committed to studying today AND opted in (#869). |
+| Path                          | Schedule (UTC) | Local time              | What it does                                                                                                                    |
+| ----------------------------- | -------------- | ----------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `/api/cron/session-reminders` | `0 11 * * *`   | 08:00 America/Sao_Paulo | Sends the session-plan reminder to learners who committed to studying today AND opted in (#869).                                |
+| `/api/cron/reengagement`      | `0 13 * * *`   | 10:00 America/Sao_Paulo | Sends the win-back nudge to opted-in learners inactive past the threshold, frequency-capped by `claim_due_reengagement` (#899). |
 
 Brazil has had no DST since 2019, so `11:00Z` is a stable 08:00 São Paulo — the
 learner gets the nudge in the morning, ahead of the hour they picked.


### PR DESCRIPTION
## Why

Four findings from today's env-wiring audit. All are the **#945 class**: shipped code depends on an env var or DB object production may not have, and nothing reports it — the app degrades or fails closed in silence. Each fix makes the gap loud (boot/build error, 503) rather than silent.

---

### F1 — `/api/health/schema` was blind to the assist-ladder migration

> Today `/api/health/schema` is blind to it: if `spend_assist_ladder_turn` is missing in prod, `spendAssistTurn` (lib/ai/assist-budget.ts) fail-closes and every AI tutor turn is denied while health returns 200.

Confirmed. `spendAssistTurn` returns the `denied` result on **any** RPC error (`apps/web/src/lib/ai/assist-budget.ts:72-86`) — a missing function is indistinguishable from an exhausted ladder, so every tutor turn is denied and `/api/health/schema` still answers 200.

Added to `SCHEMA_EXPECTATIONS` (`apps/web/src/lib/supabase/schema-expectations.ts`), following the existing rpc-probe / column-probe patterns:

| Probe | Object | Migration | Side-effect argument |
| --- | --- | --- | --- |
| rpc | `spend_assist_ladder_turn` | `20260730120000_assist_ladder.sql` | `p_user_id` NIL-UUID, **all three tier maxima = 0** |
| rpc | `get_challenge_assist_state` | same | read-only (`LANGUAGE sql STABLE`) |
| column | `challenge_assists.chat_log` | same | n/a |
| rpc | `record_review_result` | `20260726140000_review_items_spaced_repetition.sql` | NIL-UUID + empty item key |

**Why the spend RPC is probe-safe** (the question the task flagged): it is `REVOKE ALL … FROM PUBLIC, anon, authenticated` / `GRANT … TO service_role` (migration lines 126-127), and the health check runs on the **anon** client, so PostgREST answers `42501` without executing the body — the same mechanism the existing `claim_due_session_reminders` / `claim_due_reengagement` probes rely on. Belt **and** braces: with every tier max at `0`, a body that somehow ran falls straight into the `exhausted` branch, which increments nothing and deliberately does not even touch `updated_at`. So no fallback to `get_challenge_assist_state` was needed — that one is probed too, because the same migration `DROP`s the old signature, meaning a stale prod has *neither* version.

**Audit of every applied July migration** (task asked): `claim_due_reengagement` is indeed already covered (#919, lines 108-120) — verified. Everything else either has an entry (`streak_freezes`, `streak_freezes_used`, `check_ai_spend`, `reminder_opt_in`, `reminder_unsubscribe_token`, `claim_due_session_reminders`) or fails soft. One genuine gap found beyond the assist ladder: **`record_review_result`** — `/api/review/grade` rethrows the RPC error (`route.ts:120-125`), so a missing function 500s every review submission. Added. Deliberately **not** added: `xp_transactions.source` (if `20260727120000` never applied, neither the column nor the `award_xp` body that writes it exist, so nothing breaks), `record_billed_assist` / `append_challenge_assist_log` (best-effort, never block a response), `get_cohort_leaderboard` (degrades, not fails).

### F2 — `NEXT_PUBLIC_APP_URL` was unvalidated

> a missing value fails the build/boot loudly instead of silently minting a RELATIVE metadata URI on-chain

Now required in `publicEnvSchema` (`apps/web/src/lib/env.ts`). Affected `?? ""` sites — all **kept** as defense in depth, now unreachable:

- `app/api/certificates/mint/route.ts:261,281` — `external_url` + `appMetadataUri`
- `lib/solana/onchain-queue.ts:262,278`
- `lib/helius/event-handlers.ts:660,675`
- `app/api/admin/courses/sync/route.ts:283,406`, `app/api/admin/achievements/sync/route.ts:135`

**Dev ergonomics** — required-with-dev-default, matching the existing schema conventions (`NEXT_PUBLIC_SUPABASE_URL`'s prod-only https refine is the sibling pattern): `NODE_ENV !== "production"` defaults to the documented `http://localhost:3000`, so `pnpm dev` and every suite work untouched; production requires an explicit value, because no default can be right there and a silently-wrong origin is the exact failure being closed. `NEXT_PUBLIC_APP_URL` added to `vitest.setup.ts`, the CI unit-test env, `lighthouse.yml`, and the E2E harness (`e2e/harness/serve.mjs` runs `NODE_ENV=production`). `.env.example` + `apps/web/CLAUDE.md` reclassified Optional → **Required** with the on-chain-URI consequence.

> ⚠️ **Owner pre-merge check**: `NEXT_PUBLIC_APP_URL` must be set in the Vercel project (all environments) before this merges — it is listed as Required in `docs/DEPLOYMENT.md`, but if it is *not* actually set, the first deploy after merge fails the build. That is the intended behavior, stated here so it is not a surprise.

### F3 — `TEACH_PREVIEW_PASSWORD` defaulted to `"123"`

Literal fallback removed from `apps/web/src/lib/teach/preview-auth.ts`. `getPreviewPassword()` now returns `string | null`; new `isPreviewConfigured()`. Unset/blank ⇒ `isValidPreviewPassword` rejects **everything** (including `""` and the old `"123"`), and `POST /api/teach/preview/auth` returns **503** with a clear `console.error`. The cookie HMAC key falls back to a random per-process secret when nothing else is configured, so no cookie it verifies can validate. Added to the server env schema as optional (`optStr`). CLAUDE.md comment updated: `"unset = preview disabled"`.

### F4 — docs

- `docs/DEPLOYMENT.md` scheduled-jobs table: `/api/cron/reengagement` · `0 13 * * *` · 10:00 America/Sao_Paulo (matches `apps/web/vercel.json`).
- `apps/web/CLAUDE.md` top line: Next.js 14 → **15** (`apps/web/package.json` pins `next@^15.5.22`).

---

## Evidence

**Build fails loudly without the var** (`next build`, NODE_ENV=production, F2's core claim):

```
Collecting page data ...
Error: Invalid public environment variables:
  - NEXT_PUBLIC_APP_URL: must be an absolute URL, e.g. https://academy.example.com

Check your environment configuration (see .env.example).
> Build error occurred
[Error: Failed to collect page data for /api/admin/capstone-funnel]
```

**Same build, with `NEXT_PUBLIC_APP_URL=https://academy.example.com`** → succeeds (full page manifest emitted, middleware 187 kB).

**Tests** — `pnpm exec vitest run` (apps/web): **266 files, 2543 tests passed**, including the new/extended:

- `src/lib/supabase/__tests__/schema-expectations.test.ts` — missing `spend_assist_ladder_turn` (PGRST202) reported with its migration; missing `challenge_assists.chat_log` (42703) reported; invariant test asserting the spend probe carries zero tier maxima so a future `GRANT` can never make the health check mutate.
- `src/lib/teach/__tests__/preview-auth.test.ts` — unset ⇒ gate closed (`"123"`, `""`, `undefined` all rejected); blank treated as unset; only the configured password accepted.
- `src/app/api/teach/preview/auth/__tests__/route.test.ts` (new) — 503 + logged `TEACH_PREVIEW_PASSWORD` + no cookie when unset; 401 wrong password; 200 + cookie when correct.
- `src/lib/__tests__/env-app-url.test.ts` (new) — dev/test default; explicit value honoured; **throws in production when unset**; rejects a relative path.
- `src/app/api/health/schema/__tests__/route.test.ts` — pre-existing 200/503 mapping still green.

**Typecheck**: `pnpm typecheck` → 6/6 tasks successful.
**Lint**: `pnpm --filter web lint` → 0 errors (only the pre-existing `import/order` warnings on files this PR does not touch).

Not run: Playwright E2E (heavy); the harness env change is a one-line addition mirroring the existing `NEXT_PUBLIC_*` block and CI will exercise it.

## Not done

Not merged, per instructions.
