### PR TITLE
fix(integrations): pin external API shapes verified in the 31-07 audit

### DIFF
--- a/apps/web/src/app/api/ai/partner/route.ts
+++ b/apps/web/src/app/api/ai/partner/route.ts
@@ -72,7 +72,11 @@ interface GeminiEnvelope {
     finishReason?: string;
     content?: { parts?: Array<{ text?: string }> };
   }>;
-  usageMetadata?: GeminiUsageMetadata & { cachedContentTokenCount?: number };
+  // `cachedContentTokenCount` is part of GeminiUsageMetadata itself now — it is
+  // BILLING input (cached prompt tokens carry the cached-input discount), not
+  // just the debug counter it was when this route widened the type locally.
+  // Keeping it on the shared shape is what makes it reach recordAiSpend below.
+  usageMetadata?: GeminiUsageMetadata;
 }
 
 // Model selection is PER ACTION (#868) and lives in lib/ai/models — this route
@@ -581,7 +585,8 @@ export async function POST(request: NextRequest) {
     }
     // Record the ACTUAL cost of this billed generation into the spend ledger
     // (#591) from usageMetadata — prompt + candidate + thinking tokens, thinking
-    // billed at the output rate. Runs on EVERY billed path (empty / non-JSON /
+    // billed at the output rate and the cached slice of the prompt billed at the
+    // cached-input rate. Runs on EVERY billed path (empty / non-JSON /
     // truncated all still cost tokens). When usageMetadata is ABSENT (e.g. a
     // non-JSON 200) the ledger books a CONSERVATIVE fallback — full output budget
     // + a generous input estimate — instead of $0, so an unmeasurable-but-billed

--- a/apps/web/src/lib/ai/__tests__/spend-ledger.test.ts
+++ b/apps/web/src/lib/ai/__tests__/spend-ledger.test.ts
@@ -25,7 +25,11 @@ import { MODEL_RATES } from "../models";
 // sheet, so they pin the cheap tier explicitly.
 const LITE = "gemini-3.5-flash-lite" as const;
 const FLASH_36 = "gemini-3.6-flash" as const;
-const RATES = { inputUsdPerMTok: 0.3, outputUsdPerMTok: 2.5 };
+const RATES = {
+  inputUsdPerMTok: 0.3,
+  outputUsdPerMTok: 2.5,
+  cachedInputUsdPerMTok: 0.03,
+};
 
 beforeEach(() => {
   rpc.mockReset();
@@ -68,6 +72,92 @@ describe("estimateSpendMicroUsd", () => {
         RATES
       )
     ).toBe(0);
+  });
+});
+
+// Gemini's `promptTokenCount` INCLUDES `cachedContentTokenCount` — the cached
+// tokens are a SUBSET, not an addition. Red at main: the ledger billed the whole
+// prompt at the full input rate, over-reporting every cache hit by up to 10× and
+// tripping the #591 caps early.
+describe("estimateSpendMicroUsd — cached prompt tokens (cached-input discount)", () => {
+  it("splits the prompt: (prompt − cached) at input, cached at cached-input", () => {
+    // 1000 prompt of which 800 cached → 200×0.30 = 60; 800×0.03 = 24; input 84.
+    // Output 500×2.50 = 1250. Total 1334.
+    expect(
+      estimateSpendMicroUsd(
+        {
+          promptTokenCount: 1000,
+          cachedContentTokenCount: 800,
+          candidatesTokenCount: 500,
+        },
+        RATES
+      )
+    ).toBe(1334);
+  });
+
+  it("never ADDS cached to prompt (they are not two separate token pools)", () => {
+    // If cached were added, this would price 1800 prompt tokens. It must not:
+    // the fully-cached prompt costs 1000×0.03 = 30, plus 1250 output = 1280.
+    expect(
+      estimateSpendMicroUsd(
+        {
+          promptTokenCount: 1000,
+          cachedContentTokenCount: 1000,
+          candidatesTokenCount: 500,
+        },
+        RATES
+      )
+    ).toBe(1280);
+  });
+
+  it("is unchanged from the pre-cache math when cached is absent or zero", () => {
+    const base = estimateSpendMicroUsd(
+      { promptTokenCount: 1000, candidatesTokenCount: 500 },
+      RATES
+    );
+    expect(base).toBe(1550);
+    expect(
+      estimateSpendMicroUsd(
+        {
+          promptTokenCount: 1000,
+          cachedContentTokenCount: 0,
+          candidatesTokenCount: 500,
+        },
+        RATES
+      )
+    ).toBe(base);
+  });
+
+  it("CLAMPS a malformed cached > prompt, billing the whole prompt at input rate", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    // cached 5000 > prompt 1000 is impossible. Discard the discount rather than
+    // let a shape we don't understand produce a negative uncached remainder
+    // (which would UNDER-bill, the dangerous direction on a sponsored key).
+    expect(
+      estimateSpendMicroUsd(
+        {
+          promptTokenCount: 1000,
+          cachedContentTokenCount: 5000,
+          candidatesTokenCount: 500,
+        },
+        RATES
+      )
+    ).toBe(1550); // identical to no-cache: 1000×0.30 + 500×2.50
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it("ignores a negative cached count (nonNegInt) — no free credit", () => {
+    expect(
+      estimateSpendMicroUsd(
+        {
+          promptTokenCount: 1000,
+          cachedContentTokenCount: -900,
+          candidatesTokenCount: 500,
+        },
+        RATES
+      )
+    ).toBe(1550);
   });
 });
 
@@ -193,16 +283,29 @@ describe("ratesFor (per-model pricing, #868)", () => {
     expect(ratesFor("gemini-3.6-flash")).toEqual({
       inputUsdPerMTok: 1.5,
       outputUsdPerMTok: 7.5,
+      cachedInputUsdPerMTok: 0.15,
     });
     expect(ratesFor("gemini-3.5-flash-lite")).toEqual({
       inputUsdPerMTok: 0.3,
       outputUsdPerMTok: 2.5,
+      cachedInputUsdPerMTok: 0.03,
     });
     // Kept as the documented fallback pin — and what pre-#868 traffic cost.
     expect(ratesFor("gemini-3.5-flash")).toEqual({
       inputUsdPerMTok: 1.5,
       outputUsdPerMTok: 9.0,
+      cachedInputUsdPerMTok: 0.15,
     });
+  });
+
+  it("carries a cached-input rate for EVERY routed model (ledger cannot bill without one)", () => {
+    for (const model of Object.keys(
+      MODEL_RATES
+    ) as (keyof typeof MODEL_RATES)[]) {
+      const r = ratesFor(model);
+      expect(r.cachedInputUsdPerMTok).toBeGreaterThan(0);
+      expect(r.cachedInputUsdPerMTok).toBeLessThan(r.inputUsdPerMTok);
+    }
   });
 
   it("matches MODEL_RATES exactly when no env override is set", () => {
@@ -232,6 +335,22 @@ describe("recordAiSpend", () => {
     expect(rpc).toHaveBeenLastCalledWith(
       "record_ai_spend",
       expect.objectContaining({ p_micro_usd: 1550 })
+    );
+  });
+
+  it("books the cached-input discount end-to-end at the routed model's rates", async () => {
+    rpc.mockResolvedValue({ data: null, error: null });
+    // 3.6-flash: 4000 prompt of which 3500 cached → 500×1.50 = 750;
+    // 3500×0.15 = 525; output 200×7.50 = 1500. Total 2775 (vs 7500 if the
+    // cached slice were billed at the full input rate).
+    await recordAiSpend("u", "1.2.3.4", FLASH_36, {
+      promptTokenCount: 4000,
+      cachedContentTokenCount: 3500,
+      candidatesTokenCount: 200,
+    });
+    expect(rpc).toHaveBeenLastCalledWith(
+      "record_ai_spend",
+      expect.objectContaining({ p_micro_usd: 2775 })
     );
   });
 

--- a/apps/web/src/lib/ai/models.ts
+++ b/apps/web/src/lib/ai/models.ts
@@ -38,23 +38,50 @@ export type GeminiModel = (typeof GEMINI_MODELS)[number];
 export interface ModelRates {
   inputUsdPerMTok: number;
   outputUsdPerMTok: number;
+  /**
+   * Cached-input rate: what the portion of `promptTokenCount` that was served
+   * from context cache (`cachedContentTokenCount`) actually costs. An order of
+   * magnitude below the input rate, which is the whole point of the
+   * cache-shaped prompt prefix — billing those tokens at the full input rate
+   * OVER-reports the sponsor's burn and would trip the caps early.
+   */
+  cachedInputUsdPerMTok: number;
 }
 
 /**
  * Gemini price sheet, USD per 1M tokens — economics doc §2.1 table (source:
- * https://ai.google.dev/gemini-api/docs/pricing). Thinking tokens bill at the
- * OUTPUT rate (#591). This is the ledger's billing truth: a model with no entry
- * here cannot be routed to, which is deliberate — routing to an unpriced model
- * would make the #591 spend ledger under-report the sponsor's burn.
+ * https://ai.google.dev/gemini-api/docs/pricing, standard tier, re-fetched and
+ * verified 2026-07-31; the cached-input column was added in that same fetch).
+ * Thinking tokens bill at the OUTPUT rate (#591). This is the ledger's billing
+ * truth: a model with no entry here cannot be routed to, which is deliberate —
+ * routing to an unpriced model would make the #591 spend ledger under-report
+ * the sponsor's burn.
+ *
+ * NOT modelled: the cache STORAGE component ($1.00 per 1M tokens per hour). The
+ * app never creates explicit cached content — it relies on implicit caching,
+ * which carries no storage charge — so there is nothing per-request to bill it
+ * against. Revisit if explicit `cachedContent` is ever created.
  *
  * `gemini-3.5-flash` is no longer routed by default; it stays in the table as
  * the documented fallback pin (and because its rates are what the pre-#868
  * traffic actually cost).
  */
 export const MODEL_RATES: Record<GeminiModel, ModelRates> = {
-  "gemini-3.6-flash": { inputUsdPerMTok: 1.5, outputUsdPerMTok: 7.5 },
-  "gemini-3.5-flash-lite": { inputUsdPerMTok: 0.3, outputUsdPerMTok: 2.5 },
-  "gemini-3.5-flash": { inputUsdPerMTok: 1.5, outputUsdPerMTok: 9.0 },
+  "gemini-3.6-flash": {
+    inputUsdPerMTok: 1.5,
+    outputUsdPerMTok: 7.5,
+    cachedInputUsdPerMTok: 0.15,
+  },
+  "gemini-3.5-flash-lite": {
+    inputUsdPerMTok: 0.3,
+    outputUsdPerMTok: 2.5,
+    cachedInputUsdPerMTok: 0.03,
+  },
+  "gemini-3.5-flash": {
+    inputUsdPerMTok: 1.5,
+    outputUsdPerMTok: 9.0,
+    cachedInputUsdPerMTok: 0.15,
+  },
 };
 
 /** The cheap tier: short, bounded, low-stakes generations. */

--- a/apps/web/src/lib/ai/partner-prompt.ts
+++ b/apps/web/src/lib/ai/partner-prompt.ts
@@ -188,9 +188,12 @@ const CHECK_SCHEMA = {
     },
     correctIndex: {
       type: "integer",
-      // NOTE: no `minimum`/`maximum` — Gemini's structured-output schema dialect
-      // rejects those with a 400. The 0–2 range is enforced at runtime in
-      // `validatePartnerResponse`.
+      // The 0–2 range is enforced at runtime in `validatePartnerResponse` — the
+      // model is asked for it in `description`, never trusted for it. (A stale
+      // note here claimed Gemini's structured-output dialect rejects
+      // `minimum`/`maximum` with a 400; the current docs list both as supported.
+      // The runtime clamp stays regardless: schema constraints are the model's
+      // best effort, not a validation boundary.)
       description: "Index (0-2) of the single correct option.",
     },
     explanation: { type: "string" },

--- a/apps/web/src/lib/ai/spend-ledger.ts
+++ b/apps/web/src/lib/ai/spend-ledger.ts
@@ -53,6 +53,16 @@ export interface GeminiUsageMetadata {
   promptTokenCount?: number;
   candidatesTokenCount?: number;
   thoughtsTokenCount?: number;
+  /**
+   * Prompt tokens served from context cache. CRITICAL shape detail (verified
+   * against the Gemini API docs 2026-07-31): this is a SUBSET of
+   * `promptTokenCount`, not an addition to it — the cached tokens are already
+   * counted there. Billing therefore splits the prompt into
+   * (prompt − cached) at the input rate + cached at the cached-input rate;
+   * adding them would double-count, and ignoring the field bills cache hits at
+   * up to 10× their real price.
+   */
+  cachedContentTokenCount?: number;
 }
 
 function capsMicroUsd(): SpendCapsMicroUsd {
@@ -76,7 +86,9 @@ function capsMicroUsd(): SpendCapsMicroUsd {
  * an EMERGENCY override applied across all models — a provider price move can
  * be answered from the dashboard before a deploy — but they are now unset by
  * default, so the ledger prices each model correctly out of the box instead of
- * billing every call at one model's rates.
+ * billing every call at one model's rates. There is deliberately NO cached-input
+ * override: the cached rate always comes from the sheet, so an emergency input
+ * override cannot accidentally reprice cache hits.
  */
 export function ratesFor(model: GeminiModel): SpendRates {
   const base = MODEL_RATES[model];
@@ -85,6 +97,7 @@ export function ratesFor(model: GeminiModel): SpendRates {
       serverEnv.AI_SPEND_INPUT_USD_PER_MTOK ?? base.inputUsdPerMTok,
     outputUsdPerMTok:
       serverEnv.AI_SPEND_OUTPUT_USD_PER_MTOK ?? base.outputUsdPerMTok,
+    cachedInputUsdPerMTok: base.cachedInputUsdPerMTok,
   };
 }
 
@@ -99,6 +112,10 @@ function nonNegInt(value: unknown): number {
  * env-free (rates are injected) so it is unit-testable. Since cost_usd =
  * tokens/1e6 × usdPerMTok, micro_usd (= cost_usd × 1e6) = tokens × usdPerMTok.
  * Thinking tokens are billed at the output rate.
+ *
+ * Prompt tokens are SPLIT: `cachedContentTokenCount` is a subset of
+ * `promptTokenCount`, so the uncached remainder bills at the input rate and the
+ * cached part at the (much cheaper) cached-input rate.
  */
 export function estimateSpendMicroUsd(
   usage: GeminiUsageMetadata | undefined,
@@ -108,7 +125,19 @@ export function estimateSpendMicroUsd(
   const prompt = nonNegInt(usage.promptTokenCount);
   const output = nonNegInt(usage.candidatesTokenCount);
   const thinking = nonNegInt(usage.thoughtsTokenCount);
-  const inputMicro = prompt * r.inputUsdPerMTok;
+  let cached = nonNegInt(usage.cachedContentTokenCount);
+  if (cached > prompt) {
+    // Malformed: cached tokens are by definition a subset of the prompt. Rather
+    // than trust the discount on a shape we don't understand, discard it and
+    // bill the whole prompt at the full input rate — the conservative direction
+    // for a platform-funded key.
+    console.warn(
+      `[spend-ledger] cachedContentTokenCount ${cached} > promptTokenCount ${prompt} — malformed usage; billing the whole prompt at the input rate`
+    );
+    cached = 0;
+  }
+  const inputMicro =
+    (prompt - cached) * r.inputUsdPerMTok + cached * r.cachedInputUsdPerMTok;
   const outputMicro = (output + thinking) * r.outputUsdPerMTok;
   return Math.max(0, Math.round(inputMicro + outputMicro));
 }

--- a/apps/web/src/lib/email/__tests__/resend.test.ts
+++ b/apps/web/src/lib/email/__tests__/resend.test.ts
@@ -60,7 +60,11 @@ describe("sendEmailBatch (configured)", () => {
   it("POSTs the batch with auth + idempotency, and reports sent count", async () => {
     const fetchImpl = vi.fn(
       (_url: string | URL | Request, _init?: RequestInit) =>
-        Promise.resolve(new Response("{}", { status: 200 }))
+        Promise.resolve(
+          new Response(JSON.stringify({ data: [{ id: "1" }, { id: "2" }] }), {
+            status: 200,
+          })
+        )
     );
     const r = await sendEmailBatch([msg("a@b.com"), msg("c@d.com")], {
       idempotencyKey: "new-course:course-x:0",
@@ -72,6 +76,10 @@ describe("sendEmailBatch (configured)", () => {
     const headers = init!.headers as Record<string, string>;
     expect(headers.Authorization).toBe("Bearer re_test");
     expect(headers["Idempotency-Key"]).toBe("new-course:course-x:0");
+    // The claim-release invariant (4xx ⇒ nothing accepted) only holds under
+    // STRICT batch validation, which is an undocumented default upstream. Pin it
+    // on the wire so a server-side default flip can't silently break it.
+    expect(headers["x-batch-validation"]).toBe("strict");
     const body = JSON.parse(init!.body as string) as Array<
       Record<string, unknown>
     >;
@@ -188,5 +196,141 @@ describe("failure classification (delivery)", () => {
     const r = await sendEmailBatch(tooMany, { fetchImpl });
     expect(r).toMatchObject({ ok: false, delivery: "rejected" });
     expect(fetchImpl).not.toHaveBeenCalled();
+  });
+});
+
+// `sent` must report what Resend says it ACCEPTED (`{ data: [{ id }, ...] }`),
+// not what we asked it to send. Red at main: `sent` was hardcoded to
+// messages.length, so a partial acceptance reported as a full send.
+describe("sent count is derived from the response body", () => {
+  beforeEach(() => {
+    env.RESEND_API_KEY = "re_x";
+  });
+
+  const ok = (body: unknown) =>
+    vi.fn(
+      async () => new Response(JSON.stringify(body), { status: 200 })
+    ) as unknown as typeof fetch;
+
+  it("reports data.length, not the requested count", async () => {
+    const r = await sendEmailBatch([msg("a@b.com"), msg("c@d.com")], {
+      fetchImpl: ok({ data: [{ id: "1" }, { id: "2" }] }),
+    });
+    expect(r).toEqual({ ok: true, sent: 2 });
+  });
+
+  it("logs LOUDLY and reports the real count when the 2xx accepted fewer (tripwire)", async () => {
+    const err = vi.spyOn(console, "error").mockImplementation(() => {});
+    // Impossible under strict validation — if it ever happens, the all-or-nothing
+    // assumption behind claim release has stopped holding and must be visible.
+    const r = await sendEmailBatch([msg("a@b.com"), msg("c@d.com")], {
+      fetchImpl: ok({ data: [{ id: "1" }] }),
+    });
+    expect(r).toEqual({ ok: true, sent: 1 });
+    expect(err).toHaveBeenCalledWith(
+      expect.stringContaining("accepted 1 of 2")
+    );
+    err.mockRestore();
+  });
+
+  it("logs and falls back to the requested count when the 2xx body has no data array", async () => {
+    const err = vi.spyOn(console, "error").mockImplementation(() => {});
+    const r = await sendEmailBatch([msg("a@b.com")], {
+      fetchImpl: ok({}),
+    });
+    expect(r).toEqual({ ok: true, sent: 1 });
+    expect(err).toHaveBeenCalled();
+    err.mockRestore();
+  });
+
+  it("does not throw on a 2xx with a non-JSON body", async () => {
+    const fetchImpl = vi.fn(
+      async () => new Response("not json", { status: 200 })
+    ) as unknown as typeof fetch;
+    const err = vi.spyOn(console, "error").mockImplementation(() => {});
+    await expect(
+      sendEmailBatch([msg("a@b.com")], { fetchImpl })
+    ).resolves.toEqual({ ok: true, sent: 1 });
+    err.mockRestore();
+  });
+});
+
+// A 409 is an IDEMPOTENCY conflict, and the two conflict types differ in
+// whether anything could have been sent. Red at main: both fell into the
+// generic 4xx branch as `rejected`, so a concurrent in-flight request released
+// the per-day claims and a retry could deliver a SECOND copy.
+describe("409 idempotency conflicts", () => {
+  beforeEach(() => {
+    env.RESEND_API_KEY = "re_x";
+  });
+
+  const conflict = (name: string) =>
+    vi.fn().mockResolvedValue({
+      ok: false,
+      status: 409,
+      text: async () =>
+        JSON.stringify({ statusCode: 409, name, message: "conflict" }),
+    }) as unknown as typeof fetch;
+
+  it("concurrent_idempotent_requests → UNKNOWN (hold the claims, never release)", async () => {
+    const err = vi.spyOn(console, "error").mockImplementation(() => {});
+    const r = await sendEmailBatch([msg("a@b.com")], {
+      idempotencyKey: "k",
+      fetchImpl: conflict("concurrent_idempotent_requests"),
+    });
+    // `delivery: "unknown"` is exactly the ambiguous outcome the callers already
+    // handle for 5xx — they HOLD the claims rather than release them.
+    expect(r).toMatchObject({
+      ok: false,
+      status: 409,
+      delivery: "unknown",
+    });
+    expect(err).toHaveBeenCalledWith(
+      expect.stringContaining("concurrent_idempotent_requests")
+    );
+    err.mockRestore();
+  });
+
+  it("invalid_idempotent_request → REJECTED, with its own distinct log", async () => {
+    const err = vi.spyOn(console, "error").mockImplementation(() => {});
+    const r = await sendEmailBatch([msg("a@b.com")], {
+      idempotencyKey: "k",
+      fetchImpl: conflict("invalid_idempotent_request"),
+    });
+    expect(r).toMatchObject({
+      ok: false,
+      status: 409,
+      delivery: "rejected",
+    });
+    // Names the permanent same-day stall + the 24h TTL that ends it.
+    const line = err.mock.calls[0]![0] as string;
+    expect(line).toContain("invalid_idempotent_request");
+    expect(line).toContain("24h");
+    err.mockRestore();
+  });
+
+  it("an unrecognised 409 body stays REJECTED (the conservative 4xx default)", async () => {
+    const err = vi.spyOn(console, "error").mockImplementation(() => {});
+    const r = await sendEmailBatch([msg("a@b.com")], {
+      fetchImpl: conflict("some_future_conflict"),
+    });
+    expect(r).toMatchObject({ ok: false, status: 409, delivery: "rejected" });
+    expect(err).toHaveBeenCalledWith(
+      expect.stringContaining("unrecognised type")
+    );
+    err.mockRestore();
+  });
+
+  it("a non-JSON 409 body does not throw", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 409,
+      text: async () => "<html>gateway</html>",
+    }) as unknown as typeof fetch;
+    const err = vi.spyOn(console, "error").mockImplementation(() => {});
+    await expect(
+      sendEmailBatch([msg("a@b.com")], { fetchImpl })
+    ).resolves.toMatchObject({ ok: false, status: 409, delivery: "rejected" });
+    err.mockRestore();
   });
 });

--- a/apps/web/src/lib/email/resend.ts
+++ b/apps/web/src/lib/email/resend.ts
@@ -44,6 +44,49 @@ export interface EmailMessage {
  */
 export type SendFailureDelivery = "rejected" | "unknown";
 
+/**
+ * Resend's documented idempotency-conflict discriminators, returned as the
+ * error body's `name` on a 409. They mean OPPOSITE things for the claim-release
+ * invariant, which is why the 409 is special-cased rather than folded into the
+ * generic 4xx branch:
+ *
+ *   * `invalid_idempotent_request`     — the same Idempotency-Key was replayed
+ *     with a DIFFERENT payload. Resend refuses it outright: nothing was
+ *     accepted (`rejected`). Because our keys are derived from (day, chunk
+ *     membership), this is a PERMANENT same-day stall — every retry today
+ *     rebuilds the same key with the same mismatching payload — that self-heals
+ *     only when the key's 24h TTL expires.
+ *   * `concurrent_idempotent_requests` — another request with this key is still
+ *     in flight. That other request may well SEND, so this is ambiguous
+ *     (`unknown`), not a refusal — releasing claims here risks a duplicate.
+ */
+const IDEMPOTENCY_CONFLICT_NAMES = [
+  "invalid_idempotent_request",
+  "concurrent_idempotent_requests",
+] as const;
+
+type IdempotencyConflict = (typeof IDEMPOTENCY_CONFLICT_NAMES)[number];
+
+/** Extract Resend's `name` discriminator from a 409 error body, if present. */
+function idempotencyConflictName(
+  body: string
+): IdempotencyConflict | undefined {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    return undefined;
+  }
+  const name =
+    parsed && typeof parsed === "object"
+      ? (parsed as { name?: unknown }).name
+      : undefined;
+  return typeof name === "string" &&
+    (IDEMPOTENCY_CONFLICT_NAMES as readonly string[]).includes(name)
+    ? (name as IdempotencyConflict)
+    : undefined;
+}
+
 export type SendBatchResult =
   | { ok: true; sent: number }
   | { ok: false; reason: "unconfigured" }
@@ -132,6 +175,16 @@ export async function sendEmailBatch(
       headers: {
         Authorization: `Bearer ${apiKey}`,
         "Content-Type": "application/json",
+        // INVARIANT (pinned, not inherited): strict batch validation makes a 4xx
+        // mean "the WHOLE batch was refused — nothing was accepted". The
+        // claim-release contract above (`rejected` ⇒ safe to release the
+        // per-day send claims) DEPENDS on that all-or-nothing semantics: under
+        // permissive validation Resend can accept the valid messages and report
+        // the invalid ones, so a 4xx would no longer prove nothing was sent and
+        // releasing on it would re-send delivered mail. Strict is currently the
+        // API's default, but it is an UNDOCUMENTED default — pin it explicitly
+        // so a server-side default flip cannot silently break the invariant.
+        "x-batch-validation": "strict",
         ...(opts.idempotencyKey
           ? { "Idempotency-Key": opts.idempotencyKey }
           : {}),
@@ -150,15 +203,79 @@ export async function sendEmailBatch(
 
   if (!res.ok) {
     const message = await res.text().catch(() => "");
+    // 409 = idempotency conflict. The two conflict types differ in whether
+    // anything could have been sent, so they get distinct logs AND distinct
+    // deliveries — folding both into the generic 4xx `rejected` branch would
+    // release claims while a concurrent request is still able to deliver.
+    if (res.status === 409) {
+      const conflict = idempotencyConflictName(message);
+      if (conflict === "concurrent_idempotent_requests") {
+        console.error(
+          "[email:resend] 409 concurrent_idempotent_requests — another request " +
+            "with this Idempotency-Key is IN FLIGHT and may still send. " +
+            "Outcome AMBIGUOUS: this batch is NOT provably rejected."
+        );
+        return {
+          ok: false,
+          reason: "error",
+          status: 409,
+          message: message.slice(0, 500),
+          delivery: "unknown",
+        };
+      }
+      console.error(
+        conflict === "invalid_idempotent_request"
+          ? "[email:resend] 409 invalid_idempotent_request — this " +
+              "Idempotency-Key was already used with a DIFFERENT payload. " +
+              "Nothing was accepted. Retrying today rebuilds the same key, so " +
+              "this batch STALLS until the key's 24h TTL expires."
+          : `[email:resend] 409 idempotency conflict of unrecognised type: ${message.slice(0, 200)}`
+      );
+      return {
+        ok: false,
+        reason: "error",
+        status: 409,
+        message: message.slice(0, 500),
+        delivery: "rejected",
+      };
+    }
     return {
       ok: false,
       reason: "error",
       status: res.status,
       message: message.slice(0, 500),
       // 4xx = Resend refused the batch outright (validation, auth, rate limit):
-      // nothing was queued. 5xx is AMBIGUOUS — it may have been accepted first.
+      // nothing was queued — see the strict-validation invariant on the request
+      // headers, which is what makes this all-or-nothing. 5xx is AMBIGUOUS — it
+      // may have been accepted first.
       delivery: res.status >= 400 && res.status < 500 ? "rejected" : "unknown",
     };
   }
-  return { ok: true, sent: messages.length };
+
+  // Count what Resend says it ACCEPTED (`{ data: [{ id }, ...] }`), not what we
+  // asked it to send. Under strict validation the two are always equal, so a
+  // mismatch is a tripwire on that assumption — log it rather than let a silent
+  // partial acceptance be reported as a full send.
+  const accepted = await res
+    .json()
+    .then((b: unknown) =>
+      b &&
+      typeof b === "object" &&
+      Array.isArray((b as { data?: unknown }).data)
+        ? ((b as { data: unknown[] }).data.length as number)
+        : undefined
+    )
+    .catch(() => undefined);
+  if (accepted === undefined) {
+    console.error(
+      `[email:resend] 2xx batch response had no \`data\` array — cannot confirm the accepted count; reporting the requested ${messages.length}`
+    );
+    return { ok: true, sent: messages.length };
+  }
+  if (accepted !== messages.length) {
+    console.error(
+      `[email:resend] 2xx accepted ${accepted} of ${messages.length} messages — IMPOSSIBLE under strict batch validation. The all-or-nothing assumption behind claim release may no longer hold.`
+    );
+  }
+  return { ok: true, sent: accepted };
 }

--- a/apps/web/src/lib/env.server.ts
+++ b/apps/web/src/lib/env.server.ts
@@ -96,9 +96,12 @@ const serverEnvSchema = z.object({
   // (lib/solana/arweave.ts). Unset → mint falls back to the app-served
   // metadata URL.
   ARWEAVE_UPLOADER_SECRET: optStr,
-  // Helius key for webhook management + DAS API (lib/helius). Server-only and
-  // UNRESTRICTED — never NEXT_PUBLIC_, and not the same key as the domain-
-  // restricted one behind NEXT_PUBLIC_SOLANA_RPC_URL.
+  // Helius key for WEBHOOK MANAGEMENT only (lib/helius/webhook-config) — the
+  // registration/list calls against Helius's REST API. No DAS API call exists
+  // anywhere in this codebase; the old "+ DAS API" note here described an
+  // integration that was never built. Server-only and UNRESTRICTED — never
+  // NEXT_PUBLIC_, and not the same key as the domain-restricted one behind
+  // NEXT_PUBLIC_SOLANA_RPC_URL.
   HELIUS_API_KEY: optStr,
   // Resend API key for marketing/announcement email (#769). Server-only.
   // Optional at boot — the email pipeline is FAIL-CLOSED: unset ⇒ send() returns

--- a/apps/web/src/lib/github/__tests__/github.test.ts
+++ b/apps/web/src/lib/github/__tests__/github.test.ts
@@ -105,6 +105,63 @@ describe("GitHubClient", () => {
     expect(await client.fetchChecksState("s")).toBe("success");
   });
 
+  it("requests the check-runs page explicitly (filter=latest, per_page=100)", async () => {
+    // The endpoint PAGINATES at 30 by default. Red at main: the request carried
+    // no query, so runs past the first page were invisible to the fold.
+    const fetchImpl = vi.fn(async (_url: string, _init?: RequestInit) =>
+      okJson({ total_count: 1, check_runs: [{ conclusion: "success" }] })
+    );
+    const client = createGitHubClient({
+      token: "t",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    await client.fetchChecksState("s");
+    const url = fetchImpl.mock.calls[0]![0];
+    expect(url).toContain("/commits/s/check-runs");
+    expect(url).toContain("filter=latest");
+    expect(url).toContain("per_page=100");
+  });
+
+  it("returns UNKNOWN when total_count exceeds the runs returned (invisible runs)", async () => {
+    // A page that hides runs must never fold to `success` — a failing invisible
+    // run would then be waved past the sync gate.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const client = createGitHubClient({
+      token: "t",
+      fetchImpl: (async () =>
+        okJson({
+          total_count: 140,
+          check_runs: [{ conclusion: "success" }, { conclusion: "success" }],
+        })) as unknown as typeof fetch,
+    });
+    expect(await client.fetchChecksState("s")).toBe("unknown");
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it("folds normally when total_count matches the page", async () => {
+    const client = createGitHubClient({
+      token: "t",
+      fetchImpl: (async () =>
+        okJson({
+          total_count: 2,
+          check_runs: [{ conclusion: "success" }, { conclusion: "success" }],
+        })) as unknown as typeof fetch,
+    });
+    expect(await client.fetchChecksState("s")).toBe("success");
+  });
+
+  it("still folds when total_count is absent (older/partial responses)", async () => {
+    const client = createGitHubClient({
+      token: "t",
+      fetchImpl: (async () =>
+        okJson({
+          check_runs: [{ conclusion: "success" }],
+        })) as unknown as typeof fetch,
+    });
+    expect(await client.fetchChecksState("s")).toBe("success");
+  });
+
   it("throws GitHubUnavailableError without a token", async () => {
     const client = createGitHubClient({
       token: undefined,

--- a/apps/web/src/lib/github/github.ts
+++ b/apps/web/src/lib/github/github.ts
@@ -80,15 +80,33 @@ export function createGitHubClient(opts: Opts = {}): GitHubClient {
     },
 
     async fetchChecksState(sha) {
+      // `filter=latest` (the API default, pinned explicitly) drops superseded
+      // re-run attempts, so a check that failed and was re-run green is judged
+      // on its latest attempt only. `per_page=100` raises the default page of
+      // 30 — this endpoint PAGINATES, and an unpaginated read silently hides
+      // every run past the first page.
       const res = await call(
-        `/repos/${REPO}/commits/${sha}/check-runs`,
+        `/repos/${REPO}/commits/${sha}/check-runs?filter=latest&per_page=100`,
         "application/vnd.github+json"
       );
       const body = (await res.json()) as {
+        total_count?: number;
         check_runs?: { status?: string; conclusion?: string | null }[];
       };
       const runs = body.check_runs ?? [];
       if (runs.length === 0) return "unknown";
+      // More runs exist than this page returned. We cannot see the rest, and a
+      // failing invisible run must never be waved past the sync gate as green —
+      // so the verdict is UNKNOWN, not a fold over a partial sample.
+      if (
+        typeof body.total_count === "number" &&
+        body.total_count > runs.length
+      ) {
+        console.warn(
+          `[github] check-runs for ${sha.slice(0, 7)}: ${body.total_count} total but only ${runs.length} returned — verdict UNKNOWN (invisible runs must not read green)`
+        );
+        return "unknown";
+      }
       // A run only counts as green when its terminal conclusion is exactly
       // `success`. Every other terminal conclusion — failure/timed_out/
       // cancelled/action_required/stale AND neutral/skipped — blocks the sync:

--- a/apps/web/src/lib/helius/webhook-config.ts
+++ b/apps/web/src/lib/helius/webhook-config.ts
@@ -15,10 +15,33 @@ interface HeliusWebhookResponse {
   webhookType: string;
 }
 
+/**
+ * DORMANT registration code. The live webhook was registered out-of-band and is
+ * not managed from here; nothing in the request path calls this module. Fixes
+ * below are correctness-of-shape, not a behaviour change in production.
+ *
+ * DOC AMBIGUITY (left as-is deliberately): Helius documents the webhook REST
+ * API under the single host `api.helius.xyz`, with the network selected by the
+ * API KEY's own cluster rather than by hostname; the per-cluster
+ * `api-{mainnet,devnet}.helius-rpc.com` hosts below are what this code has
+ * always used and what the out-of-band registration was done against. Changing
+ * the host is a separate, testable change — the enum fix is not.
+ */
 function getHeliusBaseUrl(): string {
   return NETWORK === "mainnet-beta"
     ? "https://api-mainnet.helius-rpc.com"
     : "https://api-devnet.helius-rpc.com";
+}
+
+/**
+ * `webhookType` is a documented ENUM, and devnet is a distinct VALUE — not a
+ * property of the host or the key. Registering with "raw" while targeting
+ * devnet is the classic silent-drift failure: the call succeeds and the webhook
+ * simply never fires. ("enhanced"/"enhancedDevnet" are the parsed-payload
+ * variants; the decoder here consumes RAW transactions.)
+ */
+function rawWebhookType(): "raw" | "rawDevnet" {
+  return NETWORK === "mainnet-beta" ? "raw" : "rawDevnet";
 }
 
 export async function registerWebhook(
@@ -39,9 +62,12 @@ export async function registerWebhook(
         webhookURL: webhookUrl,
         transactionTypes: ["ANY"],
         accountAddresses: [PROGRAM_ID],
-        webhookType: "raw",
+        webhookType: rawWebhookType(),
         authHeader: `Bearer ${WEBHOOK_SECRET}`,
-        txnStatus: "success",
+        // No `txnStatus`: it is not a documented field of this API, so it was
+        // being silently ignored while reading as if failed transactions were
+        // filtered upstream. They are filtered where it is actually verified —
+        // the event decoder drops any transaction with a non-null `meta.err`.
       }),
     }
   );
@@ -60,5 +86,20 @@ export async function listWebhooks(): Promise<HeliusWebhookResponse[]> {
   const res = await fetch(
     `${getHeliusBaseUrl()}/v0/webhooks?api-key=${HELIUS_API_KEY}`
   );
-  return (await res.json()) as HeliusWebhookResponse[];
+  // Without this, a 401/429/5xx body (an error OBJECT, not an array) was cast
+  // straight to `HeliusWebhookResponse[]` — so an auth failure surfaced far
+  // away as "no webhooks registered" rather than as an error.
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(
+      `Failed to list webhooks: ${res.status} ${body.slice(0, 300)}`
+    );
+  }
+  const parsed: unknown = await res.json();
+  if (!Array.isArray(parsed)) {
+    throw new Error(
+      `Unexpected webhook list shape: expected an array, got ${typeof parsed}`
+    );
+  }
+  return parsed as HeliusWebhookResponse[];
 }

--- a/apps/web/src/lib/teach/preview-compile.ts
+++ b/apps/web/src/lib/teach/preview-compile.ts
@@ -26,6 +26,9 @@ import { changedCourseDirs, changedCourseIds } from "./pr-files";
 
 const API = "https://api.github.com";
 
+/** Ceiling on the tarball fetch + body read. Matches lib/content/prior-content. */
+const TARBALL_TIMEOUT_MS = 30_000;
+
 // Derived from the projector's own signature so this file needs no new exports
 // from `lib/content/project` — the doc shapes stay private to that module.
 type CourseDocT = Parameters<typeof projectCourse>[0];
@@ -67,13 +70,17 @@ function rateLimitError(res: Response): GitHubUnavailableError | null {
   return null;
 }
 
-async function ghFetch(path: string, accept?: string): Promise<Response> {
+async function ghFetch(
+  path: string,
+  accept?: string,
+  signal?: AbortSignal
+): Promise<Response> {
   const headers = ghHeaders();
   if (accept) headers.Accept = accept;
 
   let res: Response;
   try {
-    res = await fetch(`${API}${path}`, { headers, cache: "no-store" });
+    res = await fetch(`${API}${path}`, { headers, cache: "no-store", signal });
   } catch (e) {
     throw new GitHubUnavailableError(
       e instanceof Error ? e.message : String(e)
@@ -208,16 +215,28 @@ export async function compilePrPreview(
   const head = await (opts.fetchHead ?? fetchPrHead)(number);
 
   // `tarball/<sha>` 302-redirects to codeload; fetch follows redirects.
-  const res = await ghFetch(
-    `/repos/${CONTENT_REPO}/tarball/${head.sha}`,
-    "application/vnd.github+json"
-  );
-  if (!res.ok) {
-    throw new GitHubUnavailableError(
-      `GitHub tarball/${head.sha.slice(0, 7)} → ${res.status}`
+  // Bounded by an abort signal, mirroring the identical tarball fetch in
+  // lib/content/prior-content.ts: aborting the fetch aborts the response STREAM
+  // too, so a codeload connection that stalls mid-body cannot hang the preview
+  // request until the platform's own timeout kills it.
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TARBALL_TIMEOUT_MS);
+  let tree: Map<string, Uint8Array>;
+  try {
+    const res = await ghFetch(
+      `/repos/${CONTENT_REPO}/tarball/${head.sha}`,
+      "application/vnd.github+json",
+      controller.signal
     );
+    if (!res.ok) {
+      throw new GitHubUnavailableError(
+        `GitHub tarball/${head.sha.slice(0, 7)} → ${res.status}`
+      );
+    }
+    tree = await extractTarball(new Uint8Array(await res.arrayBuffer()));
+  } finally {
+    clearTimeout(timer);
   }
-  const tree = await extractTarball(new Uint8Array(await res.arrayBuffer()));
 
   // `compiledAt: null` — the preview is not a reproducible bundle and must never
   // stamp a wall-clock time that would differ from a real compile of this SHA.


### PR DESCRIPTION
## Why

The AI-tutor prod-down bug (#945: `thinkingBudget` rejected by the 3.x models since the #890 swap) established a class of defect rather than a one-off: **an external API's request/response shape verified once, then silently drifting**. Today's external-API-shape audit swept every third-party integration in the app for the same pattern. This is the fix batch. Every finding was re-verified against current vendor docs before implementing.

The common failure mode across these: the call keeps returning 2xx, so nothing alerts — the damage is a wrong invariant, a wrong bill, or a webhook that never fires.

## What changed

### Resend batch sender — `lib/email/resend.ts`

1. **Pin `x-batch-validation: strict`.** The claim-release invariant documented on `SendFailureDelivery` (a 4xx proves nothing was accepted, so releasing the per-day send claims is safe) **depends on strict all-or-nothing validation** — which was only an *undocumented default*. Under permissive validation Resend accepts the valid messages and reports the invalid ones, so a 4xx would no longer prove nothing was sent, and the reminder/re-engagement pipelines would release claims for mail that had already gone out. Pinned explicitly with the invariant stated in a comment.
2. **Derive `sent` from the response body** (`{ data: [{ id }, ...] }`) instead of assuming `messages.length`. A count mismatch on a 2xx is impossible under strict mode — so it now logs loudly as a **tripwire** on exactly the assumption above, rather than being invisible.
3. **Special-case 409 idempotency conflicts.** Previously both types fell into the generic 4xx `rejected` branch:
   - `concurrent_idempotent_requests` — another request with this key is in flight and **may still send**. Now classified `delivery: "unknown"`, the ambiguous outcome callers already handle for 5xx (hold the claims). Releasing here was a duplicate-send bug.
   - `invalid_idempotent_request` — same key, different payload; refused outright, stays `rejected`, but with a distinct log naming the **permanent same-day stall** (our keys are derived from day + chunk membership, so every retry today rebuilds the same key) that self-heals only at the 24h TTL.

### Spend ledger — `lib/ai/spend-ledger.ts`, `lib/ai/models.ts`, `api/ai/partner`

4. **Cached prompt tokens were billed at the full input rate.** Gemini's `promptTokenCount` **includes** `cachedContentTokenCount` — the cached tokens are a subset, not an addition. The ledger billed the whole prompt at the input rate, over-reporting every cache hit by up to 10× and tripping the #591 daily caps early (a degrade/deny the sponsor never actually owed). Now `(prompt − cached)` bills at input and `cached` at cached-input. Malformed `cached > prompt` clamps and bills everything at the input rate — the conservative direction on a platform-funded key — with a warn.

   Cached-input rates fetched from https://ai.google.dev/gemini-api/docs/pricing on **2026-07-31** (cited in the comment): `gemini-3.6-flash` $0.15, `gemini-3.5-flash` $0.15, `gemini-3.5-flash-lite` $0.03 per 1M. Deliberately **not** modelled: the $1.00/1M/hour cache *storage* component — the app relies on implicit caching, which carries no storage charge. No cached-input env override, so an emergency input override can't accidentally reprice cache hits.

   The partner route already read `cachedContentTokenCount` for its debug log; it now reaches `recordAiSpend` via the shared usage shape.

### GitHub checks — `lib/github/github.ts`

5. **`?filter=latest&per_page=100`.** The check-runs endpoint paginates at 30 — runs past the first page were simply invisible to the verdict fold. And when `total_count > check_runs.length`, the verdict is now **`"unknown"`** rather than a fold over a partial sample: a failing invisible run must never read green at the content-sync gate. Logged.

### Helius webhook config — `lib/helius/webhook-config.ts`

6. `webhookType` is a documented **enum** and devnet is a distinct *value*: `"rawDevnet"` (mainnet keeps `"raw"`). Registering with the wrong value succeeds and the webhook then never fires — the exact silent drift this audit is about. Also removed the undocumented `txnStatus` field, which was being ignored upstream while *reading* as if failed transactions were filtered there (they are filtered in `event-decoder.ts`, which drops any non-null `meta.err` — verified). Added `res.ok` + array guards to `listWebhooks`, which was casting an error object to `HeliusWebhookResponse[]` and surfacing auth failures as "no webhooks registered". The host is left as-is with the doc ambiguity commented (Helius documents a single `api.helius.xyz` host with the cluster selected by the key; the per-cluster hosts are what the out-of-band registration used).

   **This is dormant registration code — the live webhook was registered out-of-band and is not managed from here. Behaviour-neutral for prod today.**

### Small ones

7. Deleted the stale comment in `lib/ai/partner-prompt.ts` claiming Gemini's structured-output dialect rejects `minimum`/`maximum` with a 400 — current docs support both. The runtime clamp in `validatePartnerResponse` stays (schema constraints are the model's best effort, not a validation boundary).
8. `HELIUS_API_KEY`'s description in `lib/env.server.ts` said "webhook management + DAS API". **No DAS call exists anywhere in the codebase** (grepped `getAssetsByOwner`/`searchAssets`/`getAsset`/`dasApi` — zero hits); it describes an integration that was never built. Now webhook management only.
9. Bounded the teach-preview tarball fetch with an abort/timeout signal, mirroring the identical fetch in `lib/content/prior-content.ts:96` — aborting the fetch aborts the response stream, so a codeload connection that stalls mid-body can't hang the preview until the platform timeout.

## Tests

Extended `resend.test.ts` (+9), `spend-ledger.test.ts` (+7), `github.test.ts` (+4):

- strict header present on the wire; `sent` derived from `data.length`; the accepted-count mismatch tripwire; no-`data` and non-JSON 2xx bodies don't throw
- 409 `concurrent` → `delivery: "unknown"` (**hold**, not release); 409 `invalid` → `rejected` with a distinct log naming the 24h TTL; unrecognised/non-JSON 409 stays conservatively rejected
- cached-discount math, the "never ADDS cached to prompt" case, no-change-when-absent, the `cached > prompt` clamp, negative cached; end-to-end `recordAiSpend` at 3.6-flash rates; every routed model carries a cached rate below its input rate
- check-runs query params; `total_count` mismatch → unknown; normal fold when it matches; still folds when `total_count` is absent

**Red-proof** (cheap, done): reverting `estimateSpendMicroUsd` to the old full-input-rate math fails exactly the 3 new cached-billing cases (3 failed / 31 passed), green with the fix.

## Verification

- `pnpm typecheck` — clean
- Affected suites (`lib/github`, `lib/email`, `lib/ai`, `lib/helius`, `lib/teach`, `app/api`) — **73 files / 741 tests passed**, post-rebase onto #949
- Full suite: 2549/2552. The 3 failures are PGlite DB-harness *hook timeouts* under parallel load in `reminder-consent-execution` / sibling — they pass in isolation (19/19) and touch none of these files.
- `pnpm lint` — only pre-existing `import/order` warnings in files this PR doesn't touch.

Rebased onto `origin/main` after #949 landed (`models.ts` overlap: their `thinkingLevel: "minimal"` correction, my `cachedInputUsdPerMTok` column — clean).

## Risk

Low. The only production behaviour changes are (a) Resend now sends one extra header and reports a body-derived count, (b) the ledger bills cache hits *less*, (c) checks with hidden runs read `unknown` instead of a partial verdict — all fail-safe directions. The Helius change is dormant code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
