### PR TITLE
test(email): anchor reengagement fixture dates to São Paulo — kills the 00:00-03:00 UTC flake

### DIFF
--- a/apps/web/src/lib/supabase/__tests__/reengagement-pipeline-execution.test.ts
+++ b/apps/web/src/lib/supabase/__tests__/reengagement-pipeline-execution.test.ts
@@ -143,12 +143,12 @@ const SEED = `
     ('${CERTIFIED}',        true,  now(), NULL);
 
   INSERT INTO public.user_xp(user_id, longest_streak, last_activity_date) VALUES
-    ('${LAPSED}',           9, (now() - interval '30 days')::date),
-    ('${LAPSED_NO_COURSE}', 3, (now() - interval '30 days')::date),
-    ('${NO_CONSENT}',       0, (now() - interval '30 days')::date),
-    ('${WALLET}',           0, (now() - interval '30 days')::date),
-    ('${ACTIVE}',           4, (now() - interval '1 day')::date),
-    ('${CERTIFIED}',        7, (now() - interval '30 days')::date);
+    ('${LAPSED}',           9, ((now() AT TIME ZONE 'America/Sao_Paulo')::date - 30)),
+    ('${LAPSED_NO_COURSE}', 3, ((now() AT TIME ZONE 'America/Sao_Paulo')::date - 30)),
+    ('${NO_CONSENT}',       0, ((now() AT TIME ZONE 'America/Sao_Paulo')::date - 30)),
+    ('${WALLET}',           0, ((now() AT TIME ZONE 'America/Sao_Paulo')::date - 30)),
+    ('${ACTIVE}',           4, ((now() AT TIME ZONE 'America/Sao_Paulo')::date - 1)),
+    ('${CERTIFIED}',        7, ((now() AT TIME ZONE 'America/Sao_Paulo')::date - 30));
 
   INSERT INTO public.enrollments(user_id, course_id, enrolled_at) VALUES
     ('${LAPSED}',           'course-a', now() - interval '60 days'),


### PR DESCRIPTION
Test-only. The #919 pglite fixture seeded dates via `(now() - interval 'N days')::date`, which truncates in the session timezone while `claim_due_reengagement` computes `v_today` in America/São_Paulo — on UTC CI runners between 00:00-03:00 UTC every seed lands one day behind and the 30-day-inactive learner reads as 29. This is what's currently failing CI on #955 (not that PR's code).

**Red-proof, run inside the window with `TZ=UTC`:** pre-fix `1 failed | 29 passed` — `expected 29 to be greater than or equal to 30`, the exact CI failure — post-fix `30/30`. Local São Paulo runs pass both ways (which is why it never fired on dev machines).

Fix: anchor every seeded `::date` the same way the RPC does (`(now() AT TIME ZONE 'America/Sao_Paulo')::date - N`). 6 replacements, one file, no production code.