### PR TITLE
fix(landing): tighten hero vertical rhythm; revert header lockup to brand-guide size

### DIFF
--- a/apps/web/src/app/[locale]/(marketing)/landing-client.tsx
+++ b/apps/web/src/app/[locale]/(marketing)/landing-client.tsx
@@ -417,7 +417,7 @@ export function LandingPageClient({
             />
           </div>
 
-          <div className="container px-4 pb-16 pt-12 sm:pb-20 sm:pt-16 md:pb-28 md:pt-28">
+          <div className="container px-4 pb-10 pt-8 sm:pb-12 sm:pt-10 md:pb-14 md:pt-14">
             <div className="grid items-center gap-12 md:grid-cols-2 md:gap-16">
               <div>
                 <div
@@ -506,7 +506,7 @@ export function LandingPageClient({
         </section>
 
         {/* ── On-Chain Stats ── */}
-        <section className="py-12 md:py-16">
+        <section className="pb-12 pt-4 md:pb-16 md:pt-6">
           <div className="container px-4">
             <div className="mb-6 flex items-end justify-end">
               <div className="hidden text-sm font-medium text-text-3 md:block">

--- a/apps/web/src/components/layout/header.tsx
+++ b/apps/web/src/components/layout/header.tsx
@@ -216,7 +216,7 @@ export function Header() {
               width={157}
               height={30}
               priority
-              className="h-8 w-auto dark:hidden"
+              className="h-6 w-auto dark:hidden"
             />
             <Image
               src="/brand/academy-lockup-yellow.svg"
@@ -224,7 +224,7 @@ export function Header() {
               width={157}
               height={30}
               priority
-              className="hidden h-8 w-auto dark:block"
+              className="hidden h-6 w-auto dark:block"
             />
           </Link>
 
@@ -360,7 +360,7 @@ export function Header() {
                 width={157}
                 height={30}
                 priority
-                className="h-8 w-auto dark:hidden"
+                className="h-6 w-auto dark:hidden"
               />
               <Image
                 src="/brand/academy-lockup-yellow.svg"
@@ -368,7 +368,7 @@ export function Header() {
                 width={157}
                 height={30}
                 priority
-                className="hidden h-8 w-auto dark:block"
+                className="hidden h-6 w-auto dark:block"
               />
             </Link>
 


### PR DESCRIPTION
Owner-reported (screenshot): dead vertical band above the hero and a ~200px void between the CTA and the on-chain stats section; and the header lockup should follow the design-system recommendation (reverting the earlier "bigger" bump).

**Changes**
- Hero container: `md:pt-28/md:pb-28` → `md:pt-14/md:pb-14` (proportional sm/base steps); stats section top padding `py-12 md:py-16` → `pt-4 md:pt-6` (bottom unchanged). At 1280×860 the stats section now lands at the fold instead of an empty band.
- Header lockup `h-8` → `h-6` on both header instances — matching the component's own brand-guide comment (h-6 ≈ 126px wide, above the 110px lockup minimum). Footer already h-6.

**Verified**: browser screenshots at desktop (1280×860) and mobile (375×812) on the dev server — hero starts promptly, no dead band, lockup legible; 77 landing/layout tests pass; typecheck clean.