### PR TITLE
perf(dashboard): flatten the 6-hop fetch waterfall + move the on-chain sweep off the response path

### DIFF
--- a/apps/web/src/app/api/quests/daily/route.ts
+++ b/apps/web/src/app/api/quests/daily/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from "next/server";
+import { NextResponse, after } from "next/server";
 import type { DailyQuest } from "@superteam-lms/types";
 import { createClient } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin";
@@ -115,11 +115,16 @@ export async function GET() {
     // Idempotent (award_xp keyed on reference_id), DB-only, so awaiting is
     // cheap. Errors never fail the endpoint — rows stay durable for the next
     // sweep.
-    try {
-      await retryQuestXpForUser(admin, user.id);
-    } catch (err) {
-      console.error("[api/quests/daily] quest_xp sweep failed:", err);
-    }
+    // Off the response path (dashboard-latency fix, 2026-08-01): the sweep is
+    // idempotent and durable, so the response never needs to wait for it. It
+    // still runs on every GET — just after the reply is flushed.
+    after(async () => {
+      try {
+        await retryQuestXpForUser(admin, user.id);
+      } catch (err) {
+        console.error("[api/quests/daily] quest_xp sweep failed:", err);
+      }
+    });
 
     return NextResponse.json({
       quests,

--- a/apps/web/src/hooks/use-dashboard-data.ts
+++ b/apps/web/src/hooks/use-dashboard-data.ts
@@ -134,51 +134,54 @@ export function useDashboardData(
 
         const supabase = createClient();
 
-        // Evaluate quests FIRST — this may trigger on-chain XP mints.
-        // Awaiting before XP read avoids showing a stale balance.
-        const questsResult = await fetch("/api/quests/daily")
-          .then((res) =>
-            res.ok ? res.json() : { quests: [], nextResetTime: "" }
-          )
-          .catch(() => ({ quests: [], nextResetTime: "" }));
-
-        // Fetch XP + streak via service layer (on-chain first, Supabase fallback)
+        // One concurrent burst, not a waterfall. The old shape awaited quests
+        // FIRST ("may trigger on-chain XP mints") and then ran five more reads
+        // back-to-back — 6+ serial round trips incl. a browser→Solana RPC read,
+        // which is what made the dashboard feel slow. Since #925 quest awards
+        // happen at the ACTION (lesson complete / review / test-out), the
+        // dashboard evaluation almost never mints, and when it does the
+        // Realtime xp-gain listener corrects the header within a beat — a
+        // possibly-one-render-stale balance is the right trade for a fast
+        // first paint. The two profiles selects also collapse into one.
         const service = getProgressService(supabase);
-        const [totalXp, streakData] = await Promise.all([
+        const [
+          questsResult,
+          totalXp,
+          streakData,
+          profileResult,
+          achievementsResult,
+          transactionsResult,
+        ] = await Promise.all([
+          fetch("/api/quests/daily")
+            .then((res) =>
+              res.ok ? res.json() : { quests: [], nextResetTime: "" }
+            )
+            .catch(() => ({ quests: [], nextResetTime: "" })),
           service.getXP(authUserId),
           service.getStreak(authUserId),
+          supabase
+            .from("profiles")
+            .select("username, name_rerolls_used")
+            .eq("id", authUserId)
+            .single(),
+          supabase
+            .from("user_achievements")
+            .select("id", { count: "exact", head: true })
+            .eq("user_id", authUserId),
+          // Bounded: the feed shows a handful of recent items and this set only
+          // drives recent-activity lookups — an unbounded fetch grew with every
+          // lesson a user ever completed.
+          supabase
+            .from("xp_transactions")
+            .select("amount, reason, created_at, tx_signature, idempotency_key")
+            .eq("user_id", authUserId)
+            .order("created_at", { ascending: false })
+            .limit(100),
         ]);
-
-        // Fetch profile — separate name_rerolls_used to avoid breaking the
-        // whole query if the column hasn't been migrated yet
-        const { data: profile } = await supabase
-          .from("profiles")
-          .select("username")
-          .eq("id", authUserId)
-          .single();
-
-        const { data: rerollData } = await supabase
-          .from("profiles")
-          .select("name_rerolls_used")
-          .eq("id", authUserId)
-          .single();
-
-        // Fetch achievements count
-        const { count: achievementsCount } = await supabase
-          .from("user_achievements")
-          .select("id", { count: "exact", head: true })
-          .eq("user_id", authUserId);
-
-        // Fetch recent XP transactions for the activity feed + recent-course
-        // resolution. Bounded: the feed shows a handful of recent items and this
-        // set only drives recent-activity lookups — an unbounded fetch grew with
-        // every lesson a user ever completed.
-        const { data: transactions } = await supabase
-          .from("xp_transactions")
-          .select("amount, reason, created_at, tx_signature, idempotency_key")
-          .eq("user_id", authUserId)
-          .order("created_at", { ascending: false })
-          .limit(100);
+        const profile = profileResult.data;
+        const rerollData = profileResult.data;
+        const achievementsCount = achievementsResult.count;
+        const transactions = transactionsResult.data;
 
         // #790: server-granted XP (daily-quest rewards + surprise bonuses) has
         // no synchronous UI cause. Toast it ONCE from the poll the dashboard


### PR DESCRIPTION
Owner-reported: the dashboard takes too long to load. Profiled the hook: **6+ serial network round trips** — quests fetch first (the route itself does a content-bundle load + `get_daily_quest_state` RPC + an awaited on-chain retry sweep), then XP (wallet lookup → **browser→Solana RPC token-account read** → DB read, itself serial), then streak, then profile, then rerolls, then achievements, then transactions.

**Fixes**
1. The hook fires everything in one `Promise.all` burst. The old quests-first ordering guarded a pre-#925 case (dashboard evaluation minting XP before the balance read); since #925 awards happen at the action, and any rare late award is corrected by the Realtime xp-gain listener — one-render-stale is the right trade for first paint.
2. The two `profiles` selects collapse into one.
3. `/api/quests/daily`'s idempotent quest_xp sweep moves into `after()` — still runs every visit, no longer blocks the response.

Expected effect: dashboard data latency drops from the SUM of all hops to the MAX of them (dominated by the quests route or the on-chain read, each now overlapping everything else).

Tests: hooks + quests-route + gamification suites pass; typecheck clean.