### PR TITLE
feat(community): thread page — flat header, inline answer composer (wave)

### DIFF
--- a/apps/web/src/app/[locale]/(platform)/community/[category-slug]/[thread-slug]/thread-detail-client.tsx
+++ b/apps/web/src/app/[locale]/(platform)/community/[category-slug]/[thread-slug]/thread-detail-client.tsx
@@ -193,7 +193,7 @@ export function ThreadDetailClient({ shortId }: ThreadDetailClientProps) {
 
   if (error || !thread) {
     return (
-      <div className="mx-auto max-w-4xl px-4 py-20 text-center">
+      <div className="mx-auto max-w-3xl px-4 py-20 text-center">
         <p className="text-[var(--text-2)]">{error || t("noResults")}</p>
         <Link
           href="/community"
@@ -206,7 +206,7 @@ export function ThreadDetailClient({ shortId }: ThreadDetailClientProps) {
   }
 
   return (
-    <div className="mx-auto max-w-4xl px-4 py-8">
+    <div className="mx-auto max-w-3xl px-4 py-8">
       {/* Breadcrumb */}
       <Link
         href={
@@ -218,88 +218,93 @@ export function ThreadDetailClient({ shortId }: ThreadDetailClientProps) {
         {thread.category?.name || t("title")}
       </Link>
 
-      {/* Thread */}
-      <div className="flex gap-4">
-        <VoteButton
-          score={threadVote.score}
-          userVote={threadVote.userVote}
-          onVote={threadVote.handleVote}
-          disabled={!user || threadVote.isVoting}
-        />
-
-        <div className="min-w-0 flex-1">
-          <div className="mb-2 flex flex-wrap items-center gap-2">
-            <h1 className="font-display text-2xl font-extrabold text-[var(--text)]">
-              {thread.title}
-            </h1>
-            <ThreadStatusBadge type={thread.type} isSolved={thread.is_solved} />
-          </div>
-
-          {/* Provenance — one chip row under the title, linking back to the
-              lesson the question came from. Nothing else moves. */}
-          {context && (
-            <div className="mb-2">
-              <LessonContextChip context={context} />
-            </div>
-          )}
-
-          {/* Meta */}
-          <div className="mb-4 flex items-center gap-3 text-sm text-[var(--text-2)]">
-            <span className="flex items-center gap-1.5">
-              {thread.author.avatar_url ? (
-                <Image
-                  src={thread.author.avatar_url}
-                  alt=""
-                  width={20}
-                  height={20}
-                  className="h-5 w-5 rounded-full"
-                />
-              ) : (
-                <div className="h-5 w-5 rounded-full bg-[var(--primary-dim)]" />
-              )}
-              <span className="font-medium">
-                {thread.author.username || t("anonymous")}
-              </span>
-              {thread.author.level > 0 && (
-                <LevelBadge level={thread.author.level} size="xs" />
-              )}
-            </span>
-            <span>{timeAgo(thread.created_at, t)}</span>
-            <span>{t("views", { count: thread.view_count })}</span>
-            {user && <FlagButton threadId={thread.id} />}
-            {user?.id === thread.author_id && (
-              <DeleteButton
-                threadId={thread.id}
-                onDeleted={() =>
-                  router.push(
-                    thread.category
-                      ? `/community/${thread.category.slug}`
-                      : "/community"
-                  )
-                }
-              />
-            )}
-          </div>
-
-          {/* Body — heading sizes are stepped DOWN explicitly. `prose-sm`
-              scales the body copy but still renders an authored `#`/`##`
-              larger than the page h1 above, so the question's own markdown
-              could out-shout the question's title. */}
-          <div className="prose prose-sm max-w-none text-[var(--text)] dark:prose-invert prose-headings:font-display prose-headings:font-bold prose-h1:text-base prose-h2:text-[15px] prose-h3:text-sm prose-h4:text-sm">
-            <ReactMarkdown
-              remarkPlugins={[remarkGfm]}
-              rehypePlugins={[rehypeHighlight]}
-            >
-              {thread.body}
-            </ReactMarkdown>
-          </div>
+      {/* The question, in the same anatomy as an answer: WHO → WHAT →
+          ACTIONS, one column, no rail. The floating vote column used to sit
+          apart from everything it belonged to; thread voting now lives in the
+          inline action row, exactly like the answers below. */}
+      <article>
+        <div className="flex flex-wrap items-center gap-2">
+          <h1 className="font-display text-2xl font-extrabold text-[var(--text)]">
+            {thread.title}
+          </h1>
+          <ThreadStatusBadge type={thread.type} isSolved={thread.is_solved} />
         </div>
-      </div>
+
+        {/* Provenance — one chip row under the title, linking back to the
+            lesson the question came from. */}
+        {context && (
+          <div className="mt-2">
+            <LessonContextChip context={context} />
+          </div>
+        )}
+
+        {/* Meta — author, reputation, time, views on one tight line. */}
+        <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-[var(--text-2)]">
+          <span className="flex items-center gap-1.5">
+            {thread.author.avatar_url ? (
+              <Image
+                src={thread.author.avatar_url}
+                alt=""
+                width={20}
+                height={20}
+                className="h-5 w-5 rounded-full"
+              />
+            ) : (
+              <div className="h-5 w-5 rounded-full bg-[var(--primary-dim)]" />
+            )}
+            <span className="text-sm font-semibold text-[var(--text)]">
+              {thread.author.username || t("anonymous")}
+            </span>
+            {thread.author.level > 0 && (
+              <LevelBadge level={thread.author.level} size="xs" />
+            )}
+          </span>
+          <span>{timeAgo(thread.created_at, t)}</span>
+          <span>{t("views", { count: thread.view_count })}</span>
+        </div>
+
+        {/* Body — heading sizes are stepped DOWN explicitly. `prose-sm`
+            scales the body copy but still renders an authored `#`/`##`
+            larger than the page h1 above, so the question's own markdown
+            could out-shout the question's title. */}
+        <div className="prose prose-sm mt-3 max-w-none text-[var(--text)] dark:prose-invert prose-headings:font-display prose-headings:font-bold prose-h1:text-base prose-h2:text-[15px] prose-h3:text-sm prose-h4:text-sm">
+          <ReactMarkdown
+            remarkPlugins={[remarkGfm]}
+            rehypePlugins={[rehypeHighlight]}
+          >
+            {thread.body}
+          </ReactMarkdown>
+        </div>
+
+        {/* Action row — the answers' idiom, applied to the question. */}
+        <div className="mt-3 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-[var(--text-2)]">
+          <VoteButton
+            score={threadVote.score}
+            userVote={threadVote.userVote}
+            onVote={threadVote.handleVote}
+            disabled={!user || threadVote.isVoting}
+            layout="horizontal"
+          />
+          {user && <FlagButton threadId={thread.id} />}
+          {user?.id === thread.author_id && (
+            <DeleteButton
+              threadId={thread.id}
+              onDeleted={() =>
+                router.push(
+                  thread.category
+                    ? `/community/${thread.category.slug}`
+                    : "/community"
+                )
+              }
+            />
+          )}
+        </div>
+      </article>
 
       {/* Answers — comment-thread order: header, composer, sort line, then the
           flat list. The composer sits at the TOP because that is where you act;
           burying it under N answers made replying a scroll hunt. */}
-      <div className="mt-8 border-t border-[var(--border-default)] pt-6">
+      <div className="mt-6 border-t border-[var(--border-default)] pt-6">
         <h2 className="mb-3 font-display text-lg font-bold text-[var(--text)]">
           {t("answersCount", { count: thread.answers.length })}
         </h2>

--- a/apps/web/src/components/community/__tests__/thread-detail-fixes.test.tsx
+++ b/apps/web/src/components/community/__tests__/thread-detail-fixes.test.tsx
@@ -12,6 +12,7 @@ import { NextIntlClientProvider } from "next-intl";
 import messages from "@/messages/en.json";
 import { ThreadDetailClient } from "@/app/[locale]/(platform)/community/[category-slug]/[thread-slug]/thread-detail-client";
 import { AnswerCard } from "../answer-card";
+import { AnswerEditor } from "../answer-editor";
 
 const push = vi.fn();
 vi.mock("next/navigation", () => ({ useRouter: () => ({ push }) }));
@@ -225,6 +226,60 @@ describe("ThreadDetailClient — provenance chip", () => {
   });
 });
 
+/** The answer rows live inside the list's `divide-y` container; the question
+ *  itself is now also an <article>, so "the first article" is no longer the
+ *  first answer. */
+function answerArticles(container: HTMLElement): HTMLElement[] {
+  return Array.from(
+    container.querySelectorAll<HTMLElement>(".divide-y > article")
+  );
+}
+
+describe("ThreadDetailClient — flat header anatomy (no vote rail)", () => {
+  it("puts thread voting in the inline action row, not a floating column", async () => {
+    fetchMock.mockResolvedValue({ ok: true, json: async () => makeThread() });
+    const { container } = renderWithIntl(<ThreadDetailClient shortId="abc" />);
+    await screen.findByRole("heading", { name: /Why is my PDA seed wrong/ });
+
+    const upvote = screen.getByRole("button", {
+      name: messages.community.upvote,
+    });
+    // The horizontal cluster is the answers' idiom; the vertical rail is gone.
+    expect(upvote.parentElement?.className).toContain("inline-flex");
+    expect(upvote.parentElement?.className).not.toContain("flex-col");
+    // The vote control follows the body, it does not sit beside the title.
+    const title = screen.getByRole("heading", {
+      name: /Why is my PDA seed wrong/,
+    });
+    expect(
+      title.compareDocumentPosition(upvote) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+    expect(container.querySelector(".prose")).not.toBeNull();
+  });
+
+  it("labels vote state for assistive tech", async () => {
+    fetchMock.mockResolvedValue({ ok: true, json: async () => makeThread() });
+    renderWithIntl(<ThreadDetailClient shortId="abc" />);
+    await screen.findByRole("heading", { name: /Why is my PDA seed wrong/ });
+
+    expect(
+      screen.getAllByRole("button", { name: messages.community.upvote })[0]
+    ).toHaveAttribute("aria-pressed", "false");
+    expect(
+      screen.getAllByRole("button", { name: messages.community.downvote })[0]
+    ).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("renders one content column — the header is not split into a rail", async () => {
+    fetchMock.mockResolvedValue({ ok: true, json: async () => makeThread() });
+    const { container } = renderWithIntl(<ThreadDetailClient shortId="abc" />);
+    await screen.findByRole("heading", { name: /Why is my PDA seed wrong/ });
+
+    const column = container.firstElementChild as HTMLElement;
+    expect(column.className).toContain("max-w-3xl");
+  });
+});
+
 describe("Answers section — LeetCode comment-thread anatomy", () => {
   it("puts the composer ABOVE the answer list", async () => {
     fetchMock.mockResolvedValue({
@@ -255,15 +310,15 @@ describe("Answers section — LeetCode comment-thread anatomy", () => {
     const { container } = renderWithIntl(<ThreadDetailClient shortId="abc" />);
     await screen.findByText("Body.");
 
-    const item = container.querySelector("article");
-    expect(item).not.toBeNull();
-    const cls = item!.className;
+    const item = answerArticles(container)[0]!;
+    expect(item).toBeDefined();
+    const cls = item.className;
     // A comment, not a card.
     expect(cls).not.toMatch(/\brounded/);
     expect(cls).not.toMatch(/\bbg-/);
     expect(cls).not.toMatch(/\bborder-\[var\(--border-default\)\]/);
     // Separation comes from the list's hairline divider alone.
-    expect(item!.parentElement?.className).toContain("divide-y");
+    expect(item.parentElement?.className).toContain("divide-y");
   });
 
   it("marks the accepted answer with a left rule, not a box", async () => {
@@ -276,7 +331,7 @@ describe("Answers section — LeetCode comment-thread anatomy", () => {
     const { container } = renderWithIntl(<ThreadDetailClient shortId="abc" />);
     await screen.findByText("Body.");
 
-    const item = container.querySelector("article")!;
+    const item = answerArticles(container)[0]!;
     expect(item.className).toContain("border-l-2");
     expect(item.className).toContain("border-l-[var(--success)]");
     expect(item.className).not.toMatch(/\brounded/);
@@ -292,11 +347,133 @@ describe("Answers section — LeetCode comment-thread anatomy", () => {
 
     expect(container.textContent).toContain("Answers (0)");
     expect(container.textContent).not.toContain(messages.community.sortBy);
-    expect(container.querySelector("article")).toBeNull();
+    expect(answerArticles(container)).toHaveLength(0);
     // The composer is still there — that is the whole point of an empty state.
     expect(
       screen.getByPlaceholderText(messages.community.writeAnswer)
     ).toBeInTheDocument();
+  });
+});
+
+describe("AnswerEditor — inline compact composer", () => {
+  function renderEditor(onPosted = vi.fn()) {
+    renderWithIntl(<AnswerEditor threadId="t1" onAnswerPosted={onPosted} />);
+    return onPosted;
+  }
+
+  it("is a single growable field, not a boxed Write/Preview tab bar", () => {
+    renderEditor();
+    const field = screen.getByPlaceholderText(messages.community.writeAnswer);
+    expect(field.tagName).toBe("TEXTAREA");
+    expect(field.className).toContain("min-h-[44px]");
+    expect(field.className).toContain("resize-y");
+    // Preview is a quiet text-button; "Write" only appears once previewing.
+    expect(
+      screen.queryByRole("button", { name: messages.community.write })
+    ).toBeNull();
+    expect(field).toHaveAttribute("maxLength", "10000");
+  });
+
+  it("toggles a lightweight preview that renders markdown", () => {
+    renderEditor();
+    fireEvent.change(
+      screen.getByPlaceholderText(messages.community.writeAnswer),
+      { target: { value: "Use **checked_add** here." } }
+    );
+
+    const toggle = screen.getByRole("button", {
+      name: messages.community.preview,
+    });
+    expect(toggle).toHaveAttribute("aria-pressed", "false");
+    fireEvent.click(toggle);
+
+    expect(screen.getByText("checked_add").tagName).toBe("STRONG");
+    expect(
+      screen.getByRole("button", { name: messages.community.write })
+    ).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("keeps the counter inline and flags the 10k boundary", () => {
+    renderEditor();
+    const field = screen.getByPlaceholderText(messages.community.writeAnswer);
+    expect(screen.getByText("0/10000")).toBeInTheDocument();
+
+    fireEvent.change(field, { target: { value: "x".repeat(9500) } });
+    expect(screen.getByText("9500/10000").className).toContain("--danger");
+  });
+
+  it("disables Post until there is text, and while a post is in flight", async () => {
+    let resolvePost: (value: unknown) => void = () => {};
+    fetchMock.mockImplementation(
+      () => new Promise((resolve) => (resolvePost = resolve))
+    );
+    renderEditor();
+
+    const post = screen.getByRole("button", {
+      name: messages.community.postAnswer,
+    });
+    expect(post).toBeDisabled();
+
+    fireEvent.change(
+      screen.getByPlaceholderText(messages.community.writeAnswer),
+      { target: { value: "An answer." } }
+    );
+    expect(post).toBeEnabled();
+
+    fireEvent.click(post);
+    await waitFor(() => expect(post).toBeDisabled());
+    expect(post).toHaveAttribute("aria-busy", "true");
+
+    resolvePost({ ok: true, json: async () => ({ id: "a1" }) });
+  });
+
+  it("cannot double-post: a second submit in the same tick is dropped", async () => {
+    let resolvePost: (value: unknown) => void = () => {};
+    fetchMock.mockImplementation(
+      () => new Promise((resolve) => (resolvePost = resolve))
+    );
+    const onPosted = renderEditor();
+
+    fireEvent.change(
+      screen.getByPlaceholderText(messages.community.writeAnswer),
+      { target: { value: "An answer." } }
+    );
+    // Submitting the FORM bypasses the button's `disabled` entirely (Enter,
+    // a stale handler, an assistive-tech submit) — only the re-entrancy guard
+    // stops the second POST.
+    const form = screen
+      .getByRole("button", { name: messages.community.postAnswer })
+      .closest("form")!;
+    fireEvent.submit(form);
+    fireEvent.submit(form);
+
+    expect(
+      fetchMock.mock.calls.filter((c) => c[1]?.method === "POST")
+    ).toHaveLength(1);
+
+    resolvePost({ ok: true, json: async () => ({ id: "a1" }) });
+    await waitFor(() => expect(onPosted).toHaveBeenCalledTimes(1));
+  });
+
+  it("surfaces a post failure without losing the draft", async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      json: async () => ({ error: "Rate limited" }),
+    });
+    renderEditor();
+
+    fireEvent.change(
+      screen.getByPlaceholderText(messages.community.writeAnswer),
+      { target: { value: "An answer." } }
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: messages.community.postAnswer })
+    );
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("Rate limited");
+    expect(
+      screen.getByPlaceholderText(messages.community.writeAnswer)
+    ).toHaveValue("An answer.");
   });
 });
 

--- a/apps/web/src/components/community/answer-editor.tsx
+++ b/apps/web/src/components/community/answer-editor.tsx
@@ -1,23 +1,52 @@
 "use client";
 
-import { useState } from "react";
+import { useCallback, useId, useRef, useState } from "react";
 import { useTranslations } from "next-intl";
-import { MarkdownEditor } from "./markdown-editor";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import rehypeHighlight from "rehype-highlight";
+import { PaperPlaneRight } from "@phosphor-icons/react";
 import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+/** Mirrors the answers route's body limit: the POST 400s past this, so the box
+ *  stops accepting text at exactly the same boundary. */
+const MAX_ANSWER_CHARS = 10000;
 
 interface AnswerEditorProps {
   threadId: string;
   onAnswerPosted: () => void;
 }
 
+/**
+ * The inline reply box — the lesson pane's comment-composer idiom, not a
+ * boxed editor. One field that starts at a single row and grows, a lightweight
+ * Preview text-toggle instead of a tab bar, the counter inline beside the
+ * submit, and a compact primary button. Markdown still renders through the same
+ * ReactMarkdown pipeline the thread and answers use (no rehypeRaw).
+ */
 export function AnswerEditor({ threadId, onAnswerPosted }: AnswerEditorProps) {
   const t = useTranslations("community");
   const [body, setBody] = useState("");
+  const [isPreview, setIsPreview] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const inputId = useId();
+  const counterId = useId();
+  /**
+   * Re-entrancy guard. `isSubmitting` disables the button, but a second submit
+   * can still land in the same tick (Enter held, double click, a stale event)
+   * before React has re-rendered with the disabled prop — that posted the
+   * answer twice.
+   */
+  const inFlight = useRef(false);
 
-  const handleSubmit = async () => {
-    if (!body.trim() || body.length < 1) return;
+  const nearLimit = body.length / MAX_ANSWER_CHARS > 0.9;
+  const canPost = body.trim().length > 0 && !isSubmitting;
+
+  const handleSubmit = useCallback(async () => {
+    if (inFlight.current || !body.trim()) return;
+    inFlight.current = true;
     setIsSubmitting(true);
     setError(null);
 
@@ -34,44 +63,108 @@ export function AnswerEditor({ threadId, onAnswerPosted }: AnswerEditorProps) {
       }
 
       setBody("");
+      setIsPreview(false);
       onAnswerPosted();
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to post answer");
     } finally {
+      inFlight.current = false;
       setIsSubmitting(false);
     }
-  };
+  }, [body, threadId, onAnswerPosted]);
 
   return (
-    // ONE composer block: the editor and its submit share a single frame, with
-    // the button bottom-right inside it. No "Your Answer" heading — the
-    // section's "Answers (N)" header above already says where you are.
-    <div className="rounded-lg border border-[var(--border-default)] bg-[var(--card)]">
-      <MarkdownEditor
-        value={body}
-        onChange={setBody}
-        placeholder={t("writeAnswer")}
-        minHeight="110px"
-        flush
-      />
-      {error && (
-        <p className="px-3 pt-2 text-sm text-[var(--danger)]">{error}</p>
-      )}
-      <div className="flex justify-end border-t border-[var(--border-default)] px-3 py-2">
-        <Button
-          variant="primary"
-          onClick={handleSubmit}
-          disabled={isSubmitting || !body.trim()}
+    <form
+      className="flex flex-col gap-2"
+      onSubmit={(e) => {
+        e.preventDefault();
+        handleSubmit();
+      }}
+    >
+      <label className="sr-only" htmlFor={inputId}>
+        {t("answerLabel")}
+      </label>
+
+      {isPreview ? (
+        <div
+          className="prose prose-sm min-h-[44px] max-w-none rounded-md border border-[var(--border-default)] bg-[var(--input)] px-3 py-2 text-[var(--text)] dark:prose-invert prose-headings:font-display prose-headings:font-bold prose-h1:text-base prose-h2:text-[15px] prose-h3:text-sm prose-h4:text-sm"
+          data-testid="answer-preview"
         >
-          {isSubmitting && (
-            <div
-              className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent"
-              aria-hidden="true"
-            />
+          {body ? (
+            <ReactMarkdown
+              remarkPlugins={[remarkGfm]}
+              rehypePlugins={[rehypeHighlight]}
+            >
+              {body}
+            </ReactMarkdown>
+          ) : (
+            <p className="italic text-[var(--text-2)]">
+              {t("nothingToPreview")}
+            </p>
           )}
-          {t("postAnswer")}
-        </Button>
+        </div>
+      ) : (
+        <textarea
+          id={inputId}
+          value={body}
+          onChange={(e) => setBody(e.target.value.slice(0, MAX_ANSWER_CHARS))}
+          maxLength={MAX_ANSWER_CHARS}
+          rows={1}
+          aria-describedby={counterId}
+          disabled={isSubmitting}
+          placeholder={t("writeAnswer")}
+          className="min-h-[44px] w-full resize-y rounded-md border border-[var(--border-default)] bg-[var(--input)] px-3 py-2 text-sm text-[var(--text)] placeholder:text-[var(--text-2)] focus-visible:border-[var(--primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-60"
+        />
+      )}
+
+      {error && (
+        <p role="alert" className="text-sm text-[var(--danger)]">
+          {error}
+        </p>
+      )}
+
+      <div className="flex items-center gap-3">
+        {/* A quiet text-button, not a tab bar: preview is an occasional check,
+            not a mode you live in. */}
+        <button
+          type="button"
+          onClick={() => setIsPreview((v) => !v)}
+          aria-pressed={isPreview}
+          className="rounded text-xs font-medium text-[var(--text-2)] transition-colors hover:text-[var(--primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          {isPreview ? t("write") : t("preview")}
+        </button>
+
+        <div className="ml-auto flex items-center gap-3">
+          <span
+            id={counterId}
+            className={cn(
+              "text-[11px] tabular-nums",
+              nearLimit ? "text-[var(--danger)]" : "text-[var(--text-2)]"
+            )}
+          >
+            {body.length}/{MAX_ANSWER_CHARS}
+          </span>
+          <Button
+            type="submit"
+            variant="primary"
+            size="sm"
+            disabled={!canPost}
+            aria-busy={isSubmitting}
+            className="gap-1.5"
+          >
+            {isSubmitting ? (
+              <div
+                className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-current border-t-transparent"
+                aria-hidden="true"
+              />
+            ) : (
+              <PaperPlaneRight size={14} weight="duotone" aria-hidden="true" />
+            )}
+            {t("postAnswer")}
+          </Button>
+        </div>
       </div>
-    </div>
+    </form>
   );
 }

--- a/apps/web/src/components/community/vote-button.tsx
+++ b/apps/web/src/components/community/vote-button.tsx
@@ -33,6 +33,7 @@ export function VoteButton({
           type="button"
           disabled={disabled}
           onClick={() => onVote(userVote === 1 ? 0 : 1)}
+          aria-pressed={userVote === 1}
           className={cn(
             "flex items-center justify-center rounded p-1 transition-colors hover:bg-[var(--primary-dim)]",
             "disabled:cursor-not-allowed disabled:opacity-50",
@@ -58,6 +59,7 @@ export function VoteButton({
           type="button"
           disabled={disabled}
           onClick={() => onVote(userVote === -1 ? 0 : -1)}
+          aria-pressed={userVote === -1}
           className={cn(
             "flex items-center justify-center rounded p-1 transition-colors hover:bg-[var(--danger-light)]",
             "disabled:cursor-not-allowed disabled:opacity-50",
@@ -82,6 +84,7 @@ export function VoteButton({
         type="button"
         disabled={disabled}
         onClick={() => onVote(userVote === 1 ? 0 : 1)}
+        aria-pressed={userVote === 1}
         className={cn(
           "flex items-center justify-center rounded-md p-2 transition-colors hover:bg-[var(--primary-dim)]",
           "disabled:cursor-not-allowed disabled:opacity-50",
@@ -110,6 +113,7 @@ export function VoteButton({
         type="button"
         disabled={disabled}
         onClick={() => onVote(userVote === -1 ? 0 : -1)}
+        aria-pressed={userVote === -1}
         className={cn(
           "flex items-center justify-center rounded-md p-2 transition-colors hover:bg-[var(--danger-light)]",
           "disabled:cursor-not-allowed disabled:opacity-50",

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -925,6 +925,7 @@
     "cancel": "Cancel",
     "post": "Post",
     "postAnswer": "Post Answer",
+    "answerLabel": "Your answer",
     "writeAnswer": "Write your answer using Markdown...",
     "write": "Write",
     "preview": "Preview",

--- a/apps/web/src/messages/es.json
+++ b/apps/web/src/messages/es.json
@@ -925,6 +925,7 @@
     "cancel": "Cancelar",
     "post": "Publicar",
     "postAnswer": "Responder",
+    "answerLabel": "Tu respuesta",
     "writeAnswer": "Escribe tu respuesta usando Markdown...",
     "write": "Escribir",
     "preview": "Vista Previa",

--- a/apps/web/src/messages/pt-BR.json
+++ b/apps/web/src/messages/pt-BR.json
@@ -925,6 +925,7 @@
     "cancel": "Cancelar",
     "post": "Publicar",
     "postAnswer": "Responder",
+    "answerLabel": "Sua resposta",
     "writeAnswer": "Escreva sua resposta usando Markdown...",
     "write": "Escrever",
     "preview": "Visualizar",


### PR DESCRIPTION
Owner-directed redesign: the standalone community thread page still carried the pre-wave design (disconnected left vote column, loose header, bulky boxed Write/Preview answer composer, card-ish spacing). This applies the same concept the challenge/lesson panes got in the #954/#955 wave.

## Header — flat anatomy, no vote rail

The floating left vote column is gone. The question now renders in the **same WHO → WHAT → ACTIONS anatomy as the answers below it**:

- back link
- title + status chip in one tight block
- provenance chip (course > lesson) directly under it
- compact meta line — author avatar + name + level chip + time + views
- body (markdown, headings still stepped down below the h1)
- **inline action row** — horizontal vote cluster, flag, delete-own — the exact idiom the answers use

One content column throughout (`max-w-3xl`, was `max-w-4xl` split by the rail), spacing rhythm matched to the lesson pane.

## Answer composer — inline, not a boxed editor

Replaces the `MarkdownEditor` tab card with the lesson pane's comment-composer, sized to the AI-partner composer's conventions:

| before | after |
|---|---|
| Write/Preview **tab bar** | quiet **Preview text-toggle** (`aria-pressed`) |
| tall empty textarea (110px min) | single field, `min-h-[44px]`, `resize-y`, grows |
| char-count strip on its own row | counter inline, small, beside the button |
| oversized default Post button | compact `size="sm"` Post with a send glyph |

Unchanged: the 10k limit, markdown rendering through the existing ReactMarkdown + remark-gfm + rehype-highlight pipeline (**no rehypeRaw**), error surfacing (draft is preserved on failure), disabled/in-flight states.

## Double-post guard (pre-existing gap, L4 pattern)

The button's `disabled` alone cannot stop a submit dispatched in the same tick — a form submit bypasses the button entirely. An early-return re-entrancy guard (`inFlight` ref) now backs the disabled state. Mutation-checked: removing the guard fails the new test.

## a11y

sr-only label on the field; `aria-pressed` on the Preview toggle **and on both vote buttons** (both layouts); `aria-busy` on the in-flight Post; focus-visible rings on the field and the toggle.

## Scope

No API changes, no behavior changes. Post / vote / accept (thread author only, never own answer) / flag / delete-own / sort line / provenance chip all preserved. One new i18n key, `community.answerLabel`, added to all three catalogs (en / es / pt-BR) — everything else reuses existing keys.

## Test evidence

- `apps/web` community + i18n suites: **47 passed** (`src/components/community/__tests__`, `src/messages/__tests__` — parity + no-duplicate-keys)
- Full web suite: **271 files / 2652 tests passed**
- `pnpm typecheck` (tsc --noEmit, strict): clean
- `pnpm lint`: no new warnings on the changed files
- Prettier: all changed files clean

New tests cover the flat header (vote cluster is horizontal, follows the body, not a rail; one `max-w-3xl` column; vote `aria-pressed`) and the composer (single growable field with no tab bar, preview toggle rendering markdown, inline counter + 10k danger threshold, disabled-until-text and in-flight disable, the double-post guard, failure keeps the draft). Existing answer-anatomy tests were re-scoped to select answer rows inside the `divide-y` list, since the question itself is now also an `<article>`.

**Not verified in a browser**: the running preview server belongs to the shared checkout (another agent's session) and this worktree has no `.env.local`, so a dev server can't boot here. Light/dark was reviewed at the token level — every colour is an existing themed CSS var (`--border-default`, `--input`, `--text`, `--text-2`, `--primary`, `--danger`, `--success`) plus `dark:prose-invert`, and the preview surface carries the same `--input` fill as the textarea so toggling doesn't jump. Worth an owner eyeball in light mode before merge.
