### PR TITLE
feat(community): author names link to public profiles everywhere

### DIFF
--- a/apps/web/src/app/[locale]/(platform)/community/[category-slug]/[thread-slug]/thread-detail-client.tsx
+++ b/apps/web/src/app/[locale]/(platform)/community/[category-slug]/[thread-slug]/thread-detail-client.tsx
@@ -240,25 +240,37 @@ export function ThreadDetailClient({ shortId }: ThreadDetailClientProps) {
 
         {/* Meta — author, reputation, time, views on one tight line. */}
         <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-[var(--text-2)]">
-          <span className="flex items-center gap-1.5">
-            {thread.author.avatar_url ? (
-              <Image
-                src={thread.author.avatar_url}
-                alt=""
-                width={20}
-                height={20}
-                className="h-5 w-5 rounded-full"
-              />
-            ) : (
+          {thread.author.username ? (
+            <Link
+              href={`/profile/${thread.author.username}`}
+              className="flex items-center gap-1.5 transition-colors hover:text-[var(--primary)]"
+            >
+              {thread.author.avatar_url ? (
+                <Image
+                  src={thread.author.avatar_url}
+                  alt=""
+                  width={20}
+                  height={20}
+                  className="h-5 w-5 rounded-full"
+                />
+              ) : (
+                <div className="h-5 w-5 rounded-full bg-[var(--primary-dim)]" />
+              )}
+              <span className="text-sm font-semibold text-[var(--text)]">
+                {thread.author.username}
+              </span>
+              {thread.author.level > 0 && (
+                <LevelBadge level={thread.author.level} size="xs" />
+              )}
+            </Link>
+          ) : (
+            <span className="flex items-center gap-1.5">
               <div className="h-5 w-5 rounded-full bg-[var(--primary-dim)]" />
-            )}
-            <span className="text-sm font-semibold text-[var(--text)]">
-              {thread.author.username || t("anonymous")}
+              <span className="text-sm font-semibold text-[var(--text)]">
+                {t("anonymous")}
+              </span>
             </span>
-            {thread.author.level > 0 && (
-              <LevelBadge level={thread.author.level} size="xs" />
-            )}
-          </span>
+          )}
           <span>{timeAgo(thread.created_at, t)}</span>
           <span>{t("views", { count: thread.view_count })}</span>
         </div>

--- a/apps/web/src/components/community/answer-card.tsx
+++ b/apps/web/src/components/community/answer-card.tsx
@@ -1,16 +1,17 @@
 "use client";
 
 import Image from "next/image";
+import Link from "next/link";
 import { useTranslations } from "next-intl";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeHighlight from "rehype-highlight";
+import { LevelBadge } from "@/components/gamification/level-badge";
+import { cn } from "@/lib/utils";
 import { VoteButton } from "./vote-button";
 import { AcceptAnswerButton } from "./accept-answer-button";
 import { FlagButton } from "./flag-button";
 import { DeleteButton } from "./delete-button";
-import { LevelBadge } from "@/components/gamification/level-badge";
-import { cn } from "@/lib/utils";
 
 interface Author {
   username: string | null;
@@ -104,9 +105,18 @@ export function AnswerCard({
 
         <div className="min-w-0 flex-1">
           <div className="flex flex-wrap items-center gap-1.5">
-            <span className="text-sm font-semibold text-[var(--text)]">
-              {answer.author.username || t("anonymous")}
-            </span>
+            {answer.author.username ? (
+              <Link
+                href={`/profile/${answer.author.username}`}
+                className="text-sm font-semibold text-[var(--text)] transition-colors hover:text-[var(--primary)]"
+              >
+                {answer.author.username}
+              </Link>
+            ) : (
+              <span className="text-sm font-semibold text-[var(--text)]">
+                {t("anonymous")}
+              </span>
+            )}
             {answer.author.level > 0 && (
               <LevelBadge level={answer.author.level} size="xs" />
             )}

--- a/apps/web/src/components/community/thread-card.tsx
+++ b/apps/web/src/components/community/thread-card.tsx
@@ -122,23 +122,34 @@ export function ThreadCard({
         </div>
 
         <div className="flex shrink-0 items-center gap-2 font-mono text-[11px] leading-none text-[var(--text-2)]">
-          <span className="flex items-center gap-1">
-            {author.avatar_url ? (
-              <Image
-                src={author.avatar_url}
-                alt=""
-                width={14}
-                height={14}
-                className="h-3.5 w-3.5 rounded-full"
-              />
-            ) : (
+          {/* Named authors link to their public profile; anonymous stays text. */}
+          {author.username ? (
+            <Link
+              href={`/profile/${author.username}`}
+              className="flex items-center gap-1 transition-colors hover:text-[var(--primary)]"
+            >
+              {author.avatar_url ? (
+                <Image
+                  src={author.avatar_url}
+                  alt=""
+                  width={14}
+                  height={14}
+                  className="h-3.5 w-3.5 rounded-full"
+                />
+              ) : (
+                <div className="h-3.5 w-3.5 rounded-full bg-[var(--primary-dim)]" />
+              )}
+              <span className="max-w-[10rem] truncate">{author.username}</span>
+              {author.level > 0 && (
+                <LevelBadge level={author.level} size="xs" />
+              )}
+            </Link>
+          ) : (
+            <span className="flex items-center gap-1">
               <div className="h-3.5 w-3.5 rounded-full bg-[var(--primary-dim)]" />
-            )}
-            <span className="max-w-[10rem] truncate">
-              {author.username || t("anonymous")}
+              <span className="max-w-[10rem] truncate">{t("anonymous")}</span>
             </span>
-            {author.level > 0 && <LevelBadge level={author.level} size="xs" />}
-          </span>
+          )}
           <span>{timeAgo(createdAt, t)}</span>
           <span className="flex items-center gap-1">
             <ChatCircle size={11} aria-hidden="true" />


### PR DESCRIPTION
Owner-reported: usernames weren't clickable on the thread list rows, the thread detail header, or answer cards. All three now wrap the author cluster (avatar + name + level badge) in a link to `/profile/<username>` when the author is named; anonymous stays plain text. No nested-anchor hazard (rows use discrete links, verified). In-browser verified: both authors on the live thread render profile hrefs and the profile page resolves. 39 community tests pass, typecheck clean.