### PR TITLE
fix(community): #965 review nits — href encoding + consistent LevelBadge

### DIFF
--- a/apps/web/src/app/[locale]/(platform)/community/[category-slug]/[thread-slug]/thread-detail-client.tsx
+++ b/apps/web/src/app/[locale]/(platform)/community/[category-slug]/[thread-slug]/thread-detail-client.tsx
@@ -242,7 +242,7 @@ export function ThreadDetailClient({ shortId }: ThreadDetailClientProps) {
         <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-[var(--text-2)]">
           {thread.author.username ? (
             <Link
-              href={`/profile/${thread.author.username}`}
+              href={`/profile/${encodeURIComponent(thread.author.username)}`}
               className="flex items-center gap-1.5 transition-colors hover:text-[var(--primary)]"
             >
               {thread.author.avatar_url ? (
@@ -259,9 +259,6 @@ export function ThreadDetailClient({ shortId }: ThreadDetailClientProps) {
               <span className="text-sm font-semibold text-[var(--text)]">
                 {thread.author.username}
               </span>
-              {thread.author.level > 0 && (
-                <LevelBadge level={thread.author.level} size="xs" />
-              )}
             </Link>
           ) : (
             <span className="flex items-center gap-1.5">
@@ -270,6 +267,9 @@ export function ThreadDetailClient({ shortId }: ThreadDetailClientProps) {
                 {t("anonymous")}
               </span>
             </span>
+          )}
+          {thread.author.level > 0 && (
+            <LevelBadge level={thread.author.level} size="xs" />
           )}
           <span>{timeAgo(thread.created_at, t)}</span>
           <span>{t("views", { count: thread.view_count })}</span>

--- a/apps/web/src/components/community/answer-card.tsx
+++ b/apps/web/src/components/community/answer-card.tsx
@@ -107,7 +107,7 @@ export function AnswerCard({
           <div className="flex flex-wrap items-center gap-1.5">
             {answer.author.username ? (
               <Link
-                href={`/profile/${answer.author.username}`}
+                href={`/profile/${encodeURIComponent(answer.author.username)}`}
                 className="text-sm font-semibold text-[var(--text)] transition-colors hover:text-[var(--primary)]"
               >
                 {answer.author.username}

--- a/apps/web/src/components/community/thread-card.tsx
+++ b/apps/web/src/components/community/thread-card.tsx
@@ -125,7 +125,7 @@ export function ThreadCard({
           {/* Named authors link to their public profile; anonymous stays text. */}
           {author.username ? (
             <Link
-              href={`/profile/${author.username}`}
+              href={`/profile/${encodeURIComponent(author.username)}`}
               className="flex items-center gap-1 transition-colors hover:text-[var(--primary)]"
             >
               {author.avatar_url ? (
@@ -140,9 +140,6 @@ export function ThreadCard({
                 <div className="h-3.5 w-3.5 rounded-full bg-[var(--primary-dim)]" />
               )}
               <span className="max-w-[10rem] truncate">{author.username}</span>
-              {author.level > 0 && (
-                <LevelBadge level={author.level} size="xs" />
-              )}
             </Link>
           ) : (
             <span className="flex items-center gap-1">
@@ -150,6 +147,7 @@ export function ThreadCard({
               <span className="max-w-[10rem] truncate">{t("anonymous")}</span>
             </span>
           )}
+          {author.level > 0 && <LevelBadge level={author.level} size="xs" />}
           <span>{timeAgo(createdAt, t)}</span>
           <span className="flex items-center gap-1">
             <ChatCircle size={11} aria-hidden="true" />


### PR DESCRIPTION
Follow-up to #965 (its review posted after merge): (1) the three new profile hrefs now use encodeURIComponent(username), matching cohort-row/instructor-card/leaderboard convention; (2) LevelBadge behavior unified across all three sites — it renders as a sibling of the name/link ternary (pre-refactor behavior, which answer-card had preserved), so anonymous authors with level > 0 keep their badge everywhere. Community suites green, typecheck clean.