### PR TITLE
fix(ui): stop the Solana gradient border vanishing at card corners

### DIFF
--- a/apps/web/src/components/certificates/earn-handoff-card.tsx
+++ b/apps/web/src/components/certificates/earn-handoff-card.tsx
@@ -51,7 +51,7 @@ export function EarnHandoffCard({ source, courseId }: EarnHandoffCardProps) {
       aria-labelledby={titleId}
       className="rounded-xl bg-cert-gradient p-[1.5px] shadow-[var(--shadow-card)]"
     >
-      <div className="rounded-[11px] bg-card px-5 py-4">
+      <div className="rounded-[calc(var(--r-xl)-1.5px)] bg-card px-5 py-4">
         <div className="flex items-center gap-2">
           <Coins
             size={20}

--- a/apps/web/src/components/landing/hero-showcase.tsx
+++ b/apps/web/src/components/landing/hero-showcase.tsx
@@ -153,7 +153,7 @@ function IdCard({
       }`}
       style={interactive ? { transformStyle: "preserve-3d" } : undefined}
     >
-      <div className="group relative overflow-hidden rounded-[10px] bg-card p-6">
+      <div className="group relative overflow-hidden rounded-[calc(var(--r-xl)-2.5px)] bg-card p-6">
         {/* sheen sweep on hover */}
         <div
           className="pointer-events-none absolute inset-0 -translate-x-full bg-gradient-to-r from-transparent via-white/[0.06] to-transparent transition-transform duration-700 ease-out group-hover:translate-x-full"

--- a/apps/web/src/components/landing/loop-widgets.tsx
+++ b/apps/web/src/components/landing/loop-widgets.tsx
@@ -405,7 +405,7 @@ export function ProveWidget({ flipLabel }: { flipLabel: string }) {
           className="absolute inset-0 overflow-hidden rounded-xl bg-cert-gradient p-[2.5px] shadow-card"
           style={{ backfaceVisibility: "hidden" }}
         >
-          <div className="relative flex h-full flex-col justify-between overflow-hidden rounded-[9px] bg-card p-5 sm:p-6">
+          <div className="relative flex h-full flex-col justify-between overflow-hidden rounded-[calc(var(--r-xl)-2.5px)] bg-card p-5 sm:p-6">
             {/* sheen sweep on hover */}
             <div
               className="pointer-events-none absolute inset-0 -translate-x-full bg-gradient-to-r from-transparent via-white/[0.07] to-transparent transition-transform duration-700 ease-out group-hover:translate-x-full"
@@ -446,7 +446,7 @@ export function ProveWidget({ flipLabel }: { flipLabel: string }) {
             transform: "rotateY(180deg)",
           }}
         >
-          <div className="flex h-full flex-col justify-between rounded-[9px] bg-card p-5 sm:p-6">
+          <div className="flex h-full flex-col justify-between rounded-[calc(var(--r-xl)-2.5px)] bg-card p-5 sm:p-6">
             <div>
               <div className="mb-3 font-mono text-[10px] font-bold uppercase tracking-[0.2em] text-primary">
                 NFT Details

--- a/apps/web/src/components/profile/wallet-name-generator.tsx
+++ b/apps/web/src/components/profile/wallet-name-generator.tsx
@@ -110,7 +110,7 @@ export function WalletNameGenerator({
 
       {/* Name display with gradient border — fixed size to prevent layout shift */}
       <div className="relative w-full max-w-md rounded-xl bg-gradient-to-r from-primary to-secondary p-[2px]">
-        <div className="flex h-[80px] items-center justify-center overflow-hidden rounded-[10px] bg-bg px-6 py-4">
+        <div className="flex h-[80px] items-center justify-center overflow-hidden rounded-[calc(var(--r-xl)-2px)] bg-bg px-6 py-4">
           <span
             className={`truncate font-mono text-xl font-bold tracking-tight transition-opacity sm:text-2xl ${
               settled ? "opacity-100" : "opacity-80"

--- a/apps/web/src/lib/styles/styleClasses.ts
+++ b/apps/web/src/lib/styles/styleClasses.ts
@@ -513,6 +513,18 @@ export const INTERACTIVE_STATES = {
 // v9 spec: cert-wrap → cert-inner → cert-body → eyebrow, course, subtitle,
 // divider, meta-row, footer with proof-pill + network label.
 // CSS classes (.cert-wrap, .cert-inner, etc.) live in globals.css.
+//
+// The border is drawn with the "padding trick": a wrapper paints the gradient,
+// an opaque inner element covers the middle, and what shows through is the
+// frame. The two radii MUST stay concentric:
+//
+//     inner radius = outer radius − padding
+//
+// Derive it (`rounded-[calc(var(--r-xl)-2.5px)]`), never hardcode a px value.
+// A hardcoded inner radius silently desyncs when the radius token moves, and
+// once it exceeds `outer − padding` the inner corner overhangs the wrapper's
+// arc and ERASES the gradient at all four corners — the border degrades into
+// four disconnected straight segments (#967).
 
 export const CERTIFICATE_STYLES = {
   /** Solana gradient background — ONLY certificates */


### PR DESCRIPTION
Closes #967.

The Solana gradient border was being erased at all four corners of every card that builds it with the inline padding trick, leaving four disconnected straight segments instead of one continuous fade.

## Cause

The padding trick holds only while the two radii are concentric:

```
inner radius = outer radius − padding
```

`rounded-xl` resolves to `--r-xl` = **22px**. Every inline call site hardcoded an inner radius of 9–11px — sized for a ~12px outer radius, not 22px.

At R=22, padding=2.5, r=10 the two corner arcs are no longer concentric:

- outer arc: centre (22, 22), radius 22
- inner arc: centre (12.5, 12.5), radius 10
- centres are √2 × 9.5 = 13.44 apart
- the inner arc's outermost point, from the outer centre: 13.44 + 10 = **23.44 > 22**

So the opaque inner corner overhangs the wrapper's arc by ~1.4px. Where the wrapper has `overflow-hidden` the inner clips flush to the outer edge; where it doesn't, the squarer inner corner juts outside the rounded outline. Both routes drive the gradient band at the corner to zero.

## Fix

Derive the inner radius from the token — `rounded-[calc(var(--r-xl)-<padding>)]` — at each call site. This is exactly what the CSS-class versions of the same effect already do (`.cert-inner` → `calc(var(--r-xl) - 2px)`, `.grad-card-inner` → `calc(var(--r-lg) - 1.5px)`), which is why those were never affected.

| File | Padding | Was | Now |
| --- | --- | --- | --- |
| `landing/hero-showcase.tsx` | 2.5 | `rounded-[10px]` | `calc(var(--r-xl)-2.5px)` |
| `landing/loop-widgets.tsx` (front) | 2.5 | `rounded-[9px]` | `calc(var(--r-xl)-2.5px)` |
| `landing/loop-widgets.tsx` (back) | 2.5 | `rounded-[9px]` | `calc(var(--r-xl)-2.5px)` |
| `certificates/earn-handoff-card.tsx` | 1.5 | `rounded-[11px]` | `calc(var(--r-xl)-1.5px)` |
| `profile/wallet-name-generator.tsx` | 2 | `rounded-[10px]` | `calc(var(--r-xl)-2px)` |

The invariant is now documented next to the certificate style contract in `lib/styles/styleClasses.ts`, since the root cause was a hardcoded constant silently desyncing from the token it was copied from.

**Geometry only** — no colour, token, or radius values changed.

## Verification

Rendered both geometries at the real token values and compared, including a 6× magnification of the top-left corner: before, the corner arc is chopped flat and the four edges are visibly disconnected; after, the frame is continuous with uniform thickness the whole way round.

- `tsc --noEmit` — no new errors (the 45 reported are pre-existing on `main`, all missing-dev-dep failures in test files; verified identical with the change stashed)
- `eslint` on all five touched files — clean
- `vitest run` — 2589 passed, 0 failed
