### PR TITLE
perf(quests+dashboard): chain-free XP sweep module; dashboard fetch 5 phases → 2 bursts

### DIFF
--- a/apps/web/.eslintrc.json
+++ b/apps/web/.eslintrc.json
@@ -40,6 +40,26 @@
       "rules": {
         "no-restricted-imports": "off"
       }
+    },
+    {
+      "files": ["src/lib/gamification/**"],
+      "rules": {
+        "no-restricted-imports": [
+          "error",
+          {
+            "patterns": [
+              {
+                "group": ["@/content/generated/*", "**/content/generated/*"],
+                "message": "The generated content bundle holds quiz answers, code solutions and hidden tests. Import it ONLY through src/lib/content/store.ts (server-only) — never directly, or those secrets leak into the client bundle."
+              },
+              {
+                "group": ["@/lib/solana/*", "**/lib/solana/*"],
+                "message": "lib/gamification must stay chain-free: importing the Solana client graph here drags @solana/web3.js + @coral-xyz/anchor into every quest/XP route (dev-compile and cold-start cost). Pass chain clients in as parameters instead."
+              }
+            ]
+          }
+        ]
+      }
     }
   ]
 }

--- a/apps/web/src/app/api/quests/daily/route.ts
+++ b/apps/web/src/app/api/quests/daily/route.ts
@@ -3,7 +3,7 @@ import type { DailyQuest } from "@superteam-lms/types";
 import { createClient } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { getAllQuests } from "@/lib/content/queries";
-import { retryQuestXpForUser } from "@/lib/solana/onchain-queue";
+import { retryQuestXpForUser } from "@/lib/gamification/xp-queue-settlement";
 import {
   nextMidnightUtc,
   questPeriodUtc,

--- a/apps/web/src/hooks/use-dashboard-data.ts
+++ b/apps/web/src/hooks/use-dashboard-data.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useTranslations } from "next-intl";
 import type { StreakData, DailyQuest } from "@superteam-lms/types";
 import { createClient } from "@/lib/supabase/client";
@@ -102,6 +102,14 @@ export function useDashboardData(
 ): DashboardData {
   const tDash = useTranslations("dashboard");
   const localizedQuestName = useQuestName();
+  // The i18n functions cross the RSC boundary via the messages object, whose
+  // identity changes on any RSC refresh — keeping them in the effect's deps
+  // refired the whole fetch burst every time. Hold them in refs and read
+  // `.current` inside the effect so the deps stay [authUserId, authLoading].
+  const tDashRef = useRef(tDash);
+  tDashRef.current = tDash;
+  const localizedQuestNameRef = useRef(localizedQuestName);
+  localizedQuestNameRef.current = localizedQuestName;
   const [data, setData] = useState<DashboardData>({
     xp: 0,
     level: 0,
@@ -124,6 +132,7 @@ export function useDashboardData(
 
   useEffect(() => {
     if (authLoading) return;
+    let active = true;
 
     async function fetchData() {
       try {
@@ -134,16 +143,22 @@ export function useDashboardData(
 
         const supabase = createClient();
 
-        // One concurrent burst, not a waterfall. The old shape awaited quests
-        // FIRST ("may trigger on-chain XP mints") and then ran five more reads
-        // back-to-back — 6+ serial round trips incl. a browser→Solana RPC read,
-        // which is what made the dashboard feel slow. Since #925 quest awards
-        // happen at the ACTION (lesson complete / review / test-out), the
-        // dashboard evaluation almost never mints, and when it does the
-        // Realtime xp-gain listener corrects the header within a beat — a
-        // possibly-one-render-stale balance is the right trade for a fast
-        // first paint. The two profiles selects also collapse into one.
+        // TWO concurrent bursts, not a waterfall. Burst A is everything keyed
+        // on authUserId alone; burst B is the content-bundle lookups that need
+        // burst A's ids. The old shape awaited quests FIRST ("may trigger
+        // on-chain XP mints") and then ran the rest in five serial phases —
+        // round trips that had no data dependency on each other, which is what
+        // made the dashboard feel slow. Since #925 quest awards happen at the
+        // ACTION (lesson complete / review / test-out), the dashboard
+        // evaluation almost never mints, and when it does the Realtime xp-gain
+        // listener corrects the header within a beat — a possibly-one-render-
+        // stale balance is the right trade for a fast first paint. The two
+        // profiles selects also collapse into one.
         const service = getProgressService(supabase);
+        // Activity heatmap window (last 270 days) — computed before the burst
+        // so the query can join it.
+        const oneYearAgo = new Date();
+        oneYearAgo.setDate(oneYearAgo.getDate() - 270);
         const [
           questsResult,
           totalXp,
@@ -151,6 +166,11 @@ export function useDashboardData(
           profileResult,
           achievementsResult,
           transactionsResult,
+          activityRowsResult,
+          { data: enrollments },
+          { data: progressRows },
+          { data: certRows },
+          { data: achievementRows },
         ] = await Promise.all([
           fetch("/api/quests/daily")
             .then((res) =>
@@ -177,6 +197,31 @@ export function useDashboardData(
             .eq("user_id", authUserId)
             .order("created_at", { ascending: false })
             .limit(100),
+          // Activity dates for the streak heatmap (last 270 days)
+          supabase
+            .from("xp_transactions")
+            .select("created_at")
+            .eq("user_id", authUserId)
+            .gte("created_at", oneYearAgo.toISOString()),
+          supabase
+            .from("enrollments")
+            .select("course_id, enrolled_at, tx_signature")
+            .eq("user_id", authUserId),
+          supabase
+            .from("user_progress")
+            .select("course_id, lesson_id, completed, completed_at")
+            .eq("user_id", authUserId)
+            .eq("completed", true),
+          supabase
+            .from("certificates")
+            .select("course_id, course_title, minted_at, tx_signature")
+            .eq("user_id", authUserId),
+          supabase
+            .from("user_achievements")
+            .select("achievement_id, unlocked_at, tx_signature")
+            .eq("user_id", authUserId)
+            .order("unlocked_at", { ascending: false })
+            .limit(10),
         ]);
         const profile = profileResult.data;
         const rerollData = profileResult.data;
@@ -221,48 +266,13 @@ export function useDashboardData(
           dispatchSurpriseBonus(amount);
         }
 
-        // Fetch activity dates for streak heatmap (last 270 days)
-        const oneYearAgo = new Date();
-        oneYearAgo.setDate(oneYearAgo.getDate() - 270);
-        const { data: activityRows } = await supabase
-          .from("xp_transactions")
-          .select("created_at")
-          .eq("user_id", authUserId)
-          .gte("created_at", oneYearAgo.toISOString());
+        const activityRows = activityRowsResult.data;
 
         const streakHistory: Record<string, number> = {};
         for (const row of activityRows ?? []) {
           const dateStr = (row.created_at ?? "").split("T")[0] as string;
           streakHistory[dateStr] = (streakHistory[dateStr] ?? 0) + 1;
         }
-
-        // Fetch enrollments, progress, certificates, and achievements in parallel
-        const [
-          { data: enrollments },
-          { data: progressRows },
-          { data: certRows },
-          { data: achievementRows },
-        ] = await Promise.all([
-          supabase
-            .from("enrollments")
-            .select("course_id, enrolled_at, tx_signature")
-            .eq("user_id", authUserId),
-          supabase
-            .from("user_progress")
-            .select("course_id, lesson_id, completed, completed_at")
-            .eq("user_id", authUserId)
-            .eq("completed", true),
-          supabase
-            .from("certificates")
-            .select("course_id, course_title, minted_at, tx_signature")
-            .eq("user_id", authUserId),
-          supabase
-            .from("user_achievements")
-            .select("achievement_id, unlocked_at, tx_signature")
-            .eq("user_id", authUserId)
-            .order("unlocked_at", { ascending: false })
-            .limit(10),
-        ]);
 
         // Courses with minted certificates should not appear in "Current Courses"
         const mintedCourseIds = new Set(
@@ -306,13 +316,7 @@ export function useDashboardData(
           if (bonusMatch?.[1]) courseCompleteIdsFromTx.push(bonusMatch[1]);
         }
 
-        // Fetch lesson titles/slugs from the content bundle
         const uniqueLessonIds = [...new Set(lessonIdsFromTx)];
-        const lessonSummaries =
-          uniqueLessonIds.length > 0
-            ? await getLessonsByIds(uniqueLessonIds)
-            : [];
-        const lessonMap = new Map(lessonSummaries.map((l) => [l._id, l]));
 
         // Map lesson_id -> course_id from progress rows
         const lessonToCourse = new Map<string, string>();
@@ -343,20 +347,32 @@ export function useDashboardData(
         const excludeFromRecommended = [
           ...new Set([...allEnrolledIds, ...mintedCourseIds]),
         ];
-        const [courseSummaries, recommended, achievementCatalog, lessonOrders] =
-          await Promise.all([
-            allCourseIdsToFetch.length > 0
-              ? getCoursesByIds(allCourseIdsToFetch)
-              : Promise.resolve([]),
-            getRecommendedCourses(excludeFromRecommended),
-            getAllAchievements(),
-            allEnrolledIds.length > 0
-              ? getCourseLessonOrders(allEnrolledIds)
-              : Promise.resolve([]),
-          ]);
+        // Burst B — every content-bundle lookup that needed burst A's ids,
+        // including the lesson titles/slugs (only consumed by the activity-feed
+        // loop further down, so it rides along instead of blocking).
+        const [
+          courseSummaries,
+          recommended,
+          achievementCatalog,
+          lessonOrders,
+          lessonSummaries,
+        ] = await Promise.all([
+          allCourseIdsToFetch.length > 0
+            ? getCoursesByIds(allCourseIdsToFetch)
+            : Promise.resolve([]),
+          getRecommendedCourses(excludeFromRecommended),
+          getAllAchievements(),
+          allEnrolledIds.length > 0
+            ? getCourseLessonOrders(allEnrolledIds)
+            : Promise.resolve([]),
+          uniqueLessonIds.length > 0
+            ? getLessonsByIds(uniqueLessonIds)
+            : Promise.resolve([]),
+        ]);
 
         // Build a lookup map: course _id -> Sanity data
         const courseMap = new Map(courseSummaries.map((c) => [c._id, c]));
+        const lessonMap = new Map(lessonSummaries.map((l) => [l._id, l]));
 
         // Only surface enrolled courses that still resolve from the content bundle. A
         // deactivated (or unpublished) course is filtered out by getCoursesByIds
@@ -509,10 +525,10 @@ export function useDashboardData(
             const questId = tx.reason.match(dailyQuestPattern)![1]!;
             // Shared with the Realtime toast's naming (use-quest-name.ts) so
             // the feed and the celebration never spell a quest differently.
-            const questName = localizedQuestName(questId);
+            const questName = localizedQuestNameRef.current(questId);
             raw.push({
               type: "xp_other",
-              action: tDash("dailyQuest", { name: questName }),
+              action: tDashRef.current("dailyQuest", { name: questName }),
               xp: tx.amount,
               time: tx.created_at ?? new Date().toISOString(),
               txSignature: tx.tx_signature ?? null,
@@ -523,7 +539,7 @@ export function useDashboardData(
             const i18nKey = `communityActivity_${suffix}` as const;
             raw.push({
               type: "community",
-              action: tDash(i18nKey),
+              action: tDashRef.current(i18nKey),
               xp: tx.amount,
               time: tx.created_at ?? new Date().toISOString(),
               txSignature: tx.tx_signature ?? null,
@@ -532,7 +548,7 @@ export function useDashboardData(
           } else if (surpriseBonusPattern.exec(tx.reason)?.[1]) {
             raw.push({
               type: "xp_other",
-              action: tDash("surpriseBonus"),
+              action: tDashRef.current("surpriseBonus"),
               xp: tx.amount,
               time: tx.created_at ?? new Date().toISOString(),
               txSignature: tx.tx_signature ?? null,
@@ -609,6 +625,7 @@ export function useDashboardData(
           txSignature: item.txSignature,
         }));
 
+        if (!active) return;
         setData({
           xp: totalXp,
           level: calculateLevel(totalXp),
@@ -633,6 +650,7 @@ export function useDashboardData(
       } catch (err: unknown) {
         const message = err instanceof Error ? err.message : "Unknown error";
         console.error("[Dashboard] Data fetch failed:", message);
+        if (!active) return;
         setData((prev) => ({
           ...prev,
           isLoading: false,
@@ -642,7 +660,12 @@ export function useDashboardData(
     }
 
     fetchData();
-  }, [authUserId, authLoading, tDash, localizedQuestName]);
+    // A stale run must not write state over a newer one; in-flight requests are
+    // deliberately not aborted (keep it simple) — their results are dropped.
+    return () => {
+      active = false;
+    };
+  }, [authUserId, authLoading]);
 
   return data;
 }

--- a/apps/web/src/lib/gamification/__tests__/quest-evaluation.test.ts
+++ b/apps/web/src/lib/gamification/__tests__/quest-evaluation.test.ts
@@ -22,7 +22,9 @@ const { getAllQuests, rpc, retryQuestXpForUser, logError, after } = vi.hoisted(
 vi.mock("next/server", () => ({ after }));
 vi.mock("@/lib/supabase/admin", () => ({ createAdminClient: () => ({ rpc }) }));
 vi.mock("@/lib/content/queries", () => ({ getAllQuests }));
-vi.mock("@/lib/solana/onchain-queue", () => ({ retryQuestXpForUser }));
+vi.mock("@/lib/gamification/xp-queue-settlement", () => ({
+  retryQuestXpForUser,
+}));
 vi.mock("@/lib/logging", () => ({ logError }));
 
 import {

--- a/apps/web/src/lib/gamification/quest-evaluation.ts
+++ b/apps/web/src/lib/gamification/quest-evaluation.ts
@@ -1,7 +1,7 @@
 import { after } from "next/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { getAllQuests } from "@/lib/content/queries";
-import { retryQuestXpForUser } from "@/lib/solana/onchain-queue";
+import { retryQuestXpForUser } from "@/lib/gamification/xp-queue-settlement";
 import { logError } from "@/lib/logging";
 import { ERROR_IDS } from "@/constants/errorIds";
 

--- a/apps/web/src/lib/gamification/xp-queue-settlement.ts
+++ b/apps/web/src/lib/gamification/xp-queue-settlement.ts
@@ -1,0 +1,158 @@
+import "server-only";
+
+import type { createAdminClient } from "@/lib/supabase/admin";
+import type { Database } from "@/lib/supabase/types";
+
+// Chain-free XP-queue settlement. Extracted from lib/solana/onchain-queue.ts so
+// the quest paths (/api/quests/daily, quest-evaluation, and the action routes
+// that schedule it) never pull the Solana client graph — every client is passed
+// in as a parameter, so this module's own runtime import surface is empty.
+
+type AdminClient = ReturnType<typeof createAdminClient>;
+type PendingActionRow =
+  Database["public"]["Tables"]["pending_onchain_actions"]["Row"];
+
+// ---------------------------------------------------------------------------
+// Narrow sweep: deliver this user's pending quest_xp credits (DB-only)
+// ---------------------------------------------------------------------------
+// Called from the /api/quests/daily GET after get_daily_quest_state succeeds,
+// so quest XP lands without waiting for the user's next re-auth (which a
+// long-lived session may never hit). No chain calls — fast enough to await.
+
+export async function retryQuestXpForUser(
+  adminClient: AdminClient,
+  userId: string
+): Promise<void> {
+  const { data: rows, error: fetchError } = await adminClient
+    .from("pending_onchain_actions")
+    .select("*")
+    .eq("user_id", userId)
+    .eq("action_type", "quest_xp")
+    .is("resolved_at", null)
+    .lt("retry_count", 5);
+
+  if (fetchError || !rows || rows.length === 0) return;
+
+  await creditQuestXpRows(adminClient, userId, rows);
+}
+
+// award_xp credits by user_id, so wallet-less (e.g. Google-only) users still
+// receive quest XP. The reference_id is the idempotency key, so a re-sweep of
+// an already-credited row is a no-op (never a double-award). A row is only
+// resolved when award_xp reports a credited amount > 0 — a credit fully eaten
+// by the 5000/day cap stays unresolved (without burning a retry) and is
+// re-swept once the cap window resets.
+export async function creditQuestXpRows(
+  adminClient: AdminClient,
+  userId: string,
+  rows: PendingActionRow[]
+): Promise<void> {
+  for (const row of rows) {
+    const payload = row.payload as Record<string, unknown>;
+    const xpAmount = payload.xpAmount;
+    if (
+      typeof xpAmount !== "number" ||
+      !Number.isFinite(xpAmount) ||
+      xpAmount <= 0
+    ) {
+      // Malformed payload — a quest_xp row must always carry a positive amount.
+      // Treat as a transient failure (bump retry) rather than a silent resolve.
+      await bumpRetry(
+        adminClient,
+        row,
+        `Invalid quest_xp payload: xpAmount=${JSON.stringify(xpAmount)}`
+      );
+      continue;
+    }
+    const reason =
+      typeof payload.memo === "string"
+        ? payload.memo
+        : `daily_quest:${row.reference_id}`;
+
+    await creditXpAndSettle(
+      adminClient,
+      userId,
+      row,
+      xpAmount,
+      reason,
+      row.reference_id,
+      "quest" // #736 — Pass 1 credits daily-quest XP
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Shared XP-credit settlement (durable-delivery contract)
+// ---------------------------------------------------------------------------
+// Credits one learning-path XP award and settles its queue row. award_xp
+// RETURNS the amount actually credited (see
+// supabase/migrations/20260709130000_award_xp_report_credited.sql), which is
+// the signal used to tell three outcomes apart:
+//   • credited > 0  → XP landed (or an idempotency-key duplicate re-reports the
+//                     already-credited amount) → mark the row resolved.
+//   • credited = 0  → the 5000/day cap ate the whole award. This is a DEFERRAL,
+//                     not a failure: leave the row unresolved and do NOT bump
+//                     retry_count, so it is re-swept once the cap window resets
+//                     instead of silently losing the owed XP (the CS-7 bug).
+//   • RPC error     → transient failure → bump retry_count (backoff), as before.
+// The award MUST carry an idempotency key so a re-sweep is a no-op, never a
+// double-credit — this is what makes deferral safe.
+export async function creditXpAndSettle(
+  adminClient: AdminClient,
+  userId: string,
+  row: PendingActionRow,
+  amount: number,
+  reason: string,
+  idempotencyKey: string,
+  // #736: the true source of this credit, stated positively by the caller (the
+  // queue payload's reason may be authority-influenced, so it is not trusted to
+  // reverse-derive the league-eligibility-bearing source).
+  source: string
+): Promise<void> {
+  try {
+    const { data: credited, error: xpRpcError } = await adminClient.rpc(
+      "award_xp",
+      {
+        p_user_id: userId,
+        p_amount: amount,
+        p_reason: reason,
+        p_idempotency_key: idempotencyKey,
+        p_source: source,
+      }
+    );
+    if (xpRpcError) throw new Error(xpRpcError.message);
+
+    if ((credited ?? 0) > 0) {
+      await adminClient
+        .from("pending_onchain_actions")
+        .update({ resolved_at: new Date().toISOString() })
+        .eq("id", row.id);
+    } else {
+      // Daily cap consumed the whole credit — deferral, not failure: keep the
+      // row unresolved and do NOT increment retry_count.
+      await adminClient
+        .from("pending_onchain_actions")
+        .update({ last_error: "daily-cap-deferred" })
+        .eq("id", row.id);
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    await bumpRetry(adminClient, row, message);
+  }
+}
+
+// Transient-failure bookkeeping: bump retry_count and record the error so the
+// row is retried under the existing < 5 attempt budget with backoff.
+export async function bumpRetry(
+  adminClient: AdminClient,
+  row: PendingActionRow,
+  message: string
+): Promise<void> {
+  await adminClient
+    .from("pending_onchain_actions")
+    .update({
+      retry_count: (row.retry_count ?? 0) + 1,
+      last_error: message,
+    })
+    .eq("id", row.id);
+}

--- a/apps/web/src/lib/solana/onchain-queue.ts
+++ b/apps/web/src/lib/solana/onchain-queue.ts
@@ -8,6 +8,10 @@ import { checkCapstoneCredentialGate } from "@/lib/credentials/capstone-gate";
 import { createAdminClient } from "@/lib/supabase/admin";
 import type { Database } from "@/lib/supabase/types";
 import {
+  creditQuestXpRows,
+  creditXpAndSettle,
+} from "@/lib/gamification/xp-queue-settlement";
+import {
   fetchAchievementReceipt,
   fetchEnrollment,
   fetchCourse,
@@ -62,7 +66,8 @@ export async function withRetry<T>(
 // from two places: this full retry on auth, and the narrower
 // retryQuestXpForUser() sweep on every /api/quests/daily GET (so a
 // permanently-logged-in user who never re-auths still gets credited). See
-// creditQuestXpRows() for how delivery is made idempotent.
+// creditQuestXpRows() in lib/gamification/xp-queue-settlement.ts (the chain-free
+// settlement module both passes share) for how delivery is made idempotent.
 
 export async function retryPendingOnchainActions(
   userId: string
@@ -479,151 +484,6 @@ export async function retryPendingOnchainActions(
         .eq("id", row.id);
     }
   }
-}
-
-// ---------------------------------------------------------------------------
-// 3. Narrow sweep: deliver this user's pending quest_xp credits (DB-only)
-// ---------------------------------------------------------------------------
-// Called from the /api/quests/daily GET after get_daily_quest_state succeeds,
-// so quest XP lands without waiting for the user's next re-auth (which a
-// long-lived session may never hit). No chain calls — fast enough to await.
-
-export async function retryQuestXpForUser(
-  adminClient: AdminClient,
-  userId: string
-): Promise<void> {
-  const { data: rows, error: fetchError } = await adminClient
-    .from("pending_onchain_actions")
-    .select("*")
-    .eq("user_id", userId)
-    .eq("action_type", "quest_xp")
-    .is("resolved_at", null)
-    .lt("retry_count", 5);
-
-  if (fetchError || !rows || rows.length === 0) return;
-
-  await creditQuestXpRows(adminClient, userId, rows);
-}
-
-// award_xp credits by user_id, so wallet-less (e.g. Google-only) users still
-// receive quest XP. The reference_id is the idempotency key, so a re-sweep of
-// an already-credited row is a no-op (never a double-award). A row is only
-// resolved when award_xp reports a credited amount > 0 — a credit fully eaten
-// by the 5000/day cap stays unresolved (without burning a retry) and is
-// re-swept once the cap window resets.
-async function creditQuestXpRows(
-  adminClient: AdminClient,
-  userId: string,
-  rows: PendingActionRow[]
-): Promise<void> {
-  for (const row of rows) {
-    const payload = row.payload as Record<string, unknown>;
-    const xpAmount = payload.xpAmount;
-    if (
-      typeof xpAmount !== "number" ||
-      !Number.isFinite(xpAmount) ||
-      xpAmount <= 0
-    ) {
-      // Malformed payload — a quest_xp row must always carry a positive amount.
-      // Treat as a transient failure (bump retry) rather than a silent resolve.
-      await bumpRetry(
-        adminClient,
-        row,
-        `Invalid quest_xp payload: xpAmount=${JSON.stringify(xpAmount)}`
-      );
-      continue;
-    }
-    const reason =
-      typeof payload.memo === "string"
-        ? payload.memo
-        : `daily_quest:${row.reference_id}`;
-
-    await creditXpAndSettle(
-      adminClient,
-      userId,
-      row,
-      xpAmount,
-      reason,
-      row.reference_id,
-      "quest" // #736 — Pass 1 credits daily-quest XP
-    );
-  }
-}
-
-// ---------------------------------------------------------------------------
-// 5. Shared XP-credit settlement (durable-delivery contract)
-// ---------------------------------------------------------------------------
-// Credits one learning-path XP award and settles its queue row. award_xp
-// RETURNS the amount actually credited (see
-// supabase/migrations/20260709130000_award_xp_report_credited.sql), which is
-// the signal used to tell three outcomes apart:
-//   • credited > 0  → XP landed (or an idempotency-key duplicate re-reports the
-//                     already-credited amount) → mark the row resolved.
-//   • credited = 0  → the 5000/day cap ate the whole award. This is a DEFERRAL,
-//                     not a failure: leave the row unresolved and do NOT bump
-//                     retry_count, so it is re-swept once the cap window resets
-//                     instead of silently losing the owed XP (the CS-7 bug).
-//   • RPC error     → transient failure → bump retry_count (backoff), as before.
-// The award MUST carry an idempotency key so a re-sweep is a no-op, never a
-// double-credit — this is what makes deferral safe.
-async function creditXpAndSettle(
-  adminClient: AdminClient,
-  userId: string,
-  row: PendingActionRow,
-  amount: number,
-  reason: string,
-  idempotencyKey: string,
-  // #736: the true source of this credit, stated positively by the caller (the
-  // queue payload's reason may be authority-influenced, so it is not trusted to
-  // reverse-derive the league-eligibility-bearing source).
-  source: string
-): Promise<void> {
-  try {
-    const { data: credited, error: xpRpcError } = await adminClient.rpc(
-      "award_xp",
-      {
-        p_user_id: userId,
-        p_amount: amount,
-        p_reason: reason,
-        p_idempotency_key: idempotencyKey,
-        p_source: source,
-      }
-    );
-    if (xpRpcError) throw new Error(xpRpcError.message);
-
-    if ((credited ?? 0) > 0) {
-      await adminClient
-        .from("pending_onchain_actions")
-        .update({ resolved_at: new Date().toISOString() })
-        .eq("id", row.id);
-    } else {
-      // Daily cap consumed the whole credit — deferral, not failure: keep the
-      // row unresolved and do NOT increment retry_count.
-      await adminClient
-        .from("pending_onchain_actions")
-        .update({ last_error: "daily-cap-deferred" })
-        .eq("id", row.id);
-    }
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    await bumpRetry(adminClient, row, message);
-  }
-}
-
-// Transient-failure bookkeeping: bump retry_count and record the error so the
-// row is retried under the existing < 5 attempt budget with backoff.
-async function bumpRetry(
-  adminClient: AdminClient,
-  row: PendingActionRow,
-  message: string
-): Promise<void> {
-  await adminClient
-    .from("pending_onchain_actions")
-    .update({
-      retry_count: (row.retry_count ?? 0) + 1,
-      last_error: message,
-    })
-    .eq("id", row.id);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Diagnosis

Two independent latency costs, one server-side and one client-side.

**1. Chain graph compiled on chain-free routes.** `retryQuestXpForUser` lived in `lib/solana/onchain-queue.ts`, which imports `@solana/web3.js`, `@coral-xyz/anchor` and the whole `lib/solana/*` client surface. Every importer inherited that graph: `lib/gamification/quest-evaluation.ts`, `GET /api/quests/daily`, and transitively every action route that schedules a quest evaluation (`/api/review/grade`, lesson-complete, test-out). None of them touch the chain — the four helpers involved are pure Supabase RPC calls. The cost shows up as dev-compile time and serverless cold start.

**2. Dashboard fetch waterfall.** `use-dashboard-data.ts` ran five serial phases even though the first eleven reads depend on nothing but `authUserId`. On top of that the effect listed `tDash` and `localizedQuestName` in its dep array; those cross the RSC boundary via the messages object, so any RSC refresh changed their identity and refired the entire fetch burst — with no cancellation, so a stale run could overwrite fresher state.

## Shape (reviewer-approved)

**A — `apps/web/src/lib/gamification/xp-queue-settlement.ts` (new).** `retryQuestXpForUser`, `creditQuestXpRows`, `creditXpAndSettle`, `bumpRetry` moved verbatim, doc comments included (the durable-delivery trichotomy block referencing `20260709130000_award_xp_report_credited.sql` moves intact). `server-only` marker plus two type-only imports; every client is a parameter, so the module's runtime import surface is empty. `creditXpAndSettle`'s `source` stays required (#736 league-eligibility labeling) — no default added.

`onchain-queue.ts` keeps `retryPendingOnchainActions` and the three defer helpers, importing `creditQuestXpRows` / `creditXpAndSettle` from the new module. **No compat re-export** — importers moved. The section-2 NOTE now points at the new module.

Importers repointed: `quest-evaluation.ts`, `app/api/quests/daily/route.ts`. Test change is one mock path in `quest-evaluation.test.ts`.

ESLint guard: a `src/lib/gamification/**` override bans `@/lib/solana/*` (and repeats the existing `content/generated` ban, since `no-restricted-imports` overrides rather than merges). Mirrors the existing generated-bundle precedent.

**B — dashboard bursts.** Burst A is the eleven `authUserId`-only reads (the original six + the 270-day heatmap query + the four ex-phase-3 queries). Burst B is the content-bundle lookups plus `getLessonsByIds` — `lessonMap` is only read by the activity-feed loop, and `activityCourseIds` derives from `progressRows`, not from `lessonSummaries`, so nothing downstream reorders. `tDash`/`localizedQuestName` move to refs, deps reduce to `[authUserId, authLoading]`, and an `active` flag guards both `setData` calls (in-flight requests are deliberately not aborted). Everything downstream is unchanged.

## Verification

- `pnpm exec tsc --noEmit` — clean, no output.
- `pnpm exec vitest run src/lib/solana/__tests__/onchain-queue.test.ts src/lib/gamification/__tests__/quest-evaluation.test.ts src/hooks/__tests__/use-dashboard-data.test.tsx` → **3 files / 29 tests passed**. `onchain-queue.test.ts` passes **unmodified** (the acceptance gate for the move); `use-dashboard-data.test.tsx` needed no change either.
- `pnpm exec eslint` on all seven changed files — clean.
- Guard rule proven live: a temporary `src/lib/gamification/__guard-probe.ts` importing `@/lib/solana/pda` errored with the new message, then was removed.
- **Graph proof** (transitive `@/`+relative import walk from each entry):

  | entry | files | `lib/solana/*` | web3.js / anchor / metaplex |
  |---|---|---|---|
  | `lib/gamification/xp-queue-settlement.ts` | 5 | none | none |
  | `lib/gamification/quest-evaluation.ts` | 16 | none | none |
  | `app/api/quests/daily/route.ts` | 19 | none | none |
  | `app/api/review/grade/route.ts` | 21 | none | none |

- Full web suite: **269/272 files, 2664/2672 tests passed**. The 3 failures are the PGlite-backed SQL execution suites (`reminder-consent-execution`, `email-subscriptions-execution`, `assist-ladder-execution`) timing out in `PGlite.create` under parallel load. Unrelated to this diff and pre-existing: each passes in isolation both on stashed `main` and with these changes applied (`email-subscriptions-execution` → 7/7 both ways).

No deviations from the spec.
