### PR TITLE
fix(content): make _draft/ a real exclusion, shared by compiler and lint

### DIFF
--- a/apps/web/src/lib/content/compile/__tests__/draft-exclusion.test.ts
+++ b/apps/web/src/lib/content/compile/__tests__/draft-exclusion.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect } from "vitest";
+import { stringify } from "yaml";
+import { isExcludedContentPath } from "@superteam-lms/content-schema";
+import type { RepoTree } from "@/lib/github/types";
+import { compileContent } from "../compile-bundle";
+
+/**
+ * #973 — `_draft/` is the parking convention academy-courses uses to take a
+ * course out of the catalog without deleting it. The compiler classified by
+ * unanchored `endsWith("/course.yaml")` / `startsWith("paths/")`, so a parked
+ * doc compiled straight into the shipped bundle while content-lint's anchored
+ * fixed-depth regexes never saw it — parked content shipped, unlinted.
+ *
+ * These assert the property directly on the compiled bundle: a `_draft/`
+ * segment anywhere in the path means the doc is not in the output.
+ */
+
+const enc = new TextEncoder();
+const yaml = (v: unknown): Uint8Array => enc.encode(stringify(v));
+const raw = (s: string): Uint8Array => enc.encode(s);
+
+const SHA = "c".repeat(40);
+
+function course(id: string, slug: string, lessonId: string): unknown {
+  return {
+    id,
+    slug,
+    title: slug,
+    description: "d",
+    difficulty: "beginner",
+    duration: 1,
+    xpPerLesson: 10,
+    xpReward: 100,
+    modules: [{ key: "m", title: "M", lessons: [lessonId] }],
+  };
+}
+
+function lesson(id: string, slug: string): unknown {
+  return {
+    id,
+    slug,
+    title: slug,
+    skills: ["pdas"],
+    blocks: [{ key: "intro", type: "prose", src: "intro.md" }],
+  };
+}
+
+function slotsLock(lessonId: string): Uint8Array {
+  return raw(
+    JSON.stringify({
+      version: 1,
+      slots: { [lessonId]: 0 },
+      retired: [],
+      next: 1,
+    })
+  );
+}
+
+/** A live course + path + achievement, each shadowed by a parked `_draft/` twin. */
+function treeWithDrafts(): RepoTree {
+  return new Map<string, Uint8Array>([
+    ["skills.yaml", raw("- slug: pdas\n  label: PDAs\n")],
+
+    // live
+    [
+      "courses/live/course.yaml",
+      yaml(course("course-live", "live", "lesson-live")),
+    ],
+    ["courses/live/slots.lock.json", slotsLock("lesson-live")],
+    [
+      "courses/live/lessons/live/lesson.yaml",
+      yaml(lesson("lesson-live", "live")),
+    ],
+    ["courses/live/lessons/live/intro.md", raw("# Live\n")],
+    [
+      "paths/live.yaml",
+      yaml({
+        id: "path-live",
+        slug: "live",
+        title: "Live",
+        difficulty: "beginner",
+        courses: ["course-live"],
+      }),
+    ],
+    [
+      "achievements/live.yaml",
+      yaml({
+        id: "achievement-live",
+        name: "Live",
+        category: "progress",
+        xpReward: 50,
+        award: { kind: "manual" },
+      }),
+    ],
+
+    // parked under _draft/ — must never reach the bundle
+    [
+      "courses/_draft/parked/course.yaml",
+      yaml(course("course-parked", "parked", "lesson-parked")),
+    ],
+    ["courses/_draft/parked/slots.lock.json", slotsLock("lesson-parked")],
+    [
+      "courses/_draft/parked/lessons/parked/lesson.yaml",
+      yaml(lesson("lesson-parked", "parked")),
+    ],
+    ["courses/_draft/parked/lessons/parked/intro.md", raw("# Parked\n")],
+    [
+      "paths/_draft/parked.yaml",
+      yaml({
+        id: "path-parked",
+        slug: "parked",
+        title: "Parked",
+        difficulty: "beginner",
+        courses: ["course-parked"],
+      }),
+    ],
+    [
+      "achievements/_draft/parked.yaml",
+      yaml({
+        id: "achievement-parked",
+        name: "Parked",
+        category: "progress",
+        xpReward: 50,
+        award: { kind: "manual" },
+      }),
+    ],
+  ]);
+}
+
+const ids = (json: string): string[] =>
+  (JSON.parse(json) as { _id: string }[]).map((d) => d._id);
+
+describe("compileBundle — _draft/ exclusion (#973)", () => {
+  it("compiles the live docs and drops every _draft/ doc", () => {
+    const files = compileContent(treeWithDrafts(), {
+      sha: SHA,
+      compiledAt: null,
+    });
+
+    expect(ids(files.get("courses.json")!)).toEqual(["course-live"]);
+    expect(ids(files.get("lessons.json")!)).toEqual(["lesson-live"]);
+    expect(ids(files.get("paths.json")!)).toEqual(["path-live"]);
+    expect(ids(files.get("achievements.json")!)).toEqual(["achievement-live"]);
+  });
+
+  it("keeps the parked course out of slots.json and the meta counts", () => {
+    const files = compileContent(treeWithDrafts(), {
+      sha: SHA,
+      compiledAt: null,
+    });
+
+    expect(Object.keys(JSON.parse(files.get("slots.json")!))).toEqual([
+      "course-live",
+    ]);
+    expect(JSON.parse(files.get("meta.json")!).counts).toMatchObject({
+      courses: 1,
+      lessons: 1,
+      learningPaths: 1,
+      achievements: 1,
+    });
+  });
+});
+
+describe("the compiler's exclusion rule is the shared one", () => {
+  it("uses `isExcludedContentPath`, so lint and compile cannot diverge again", () => {
+    // The predicate itself is unit-tested in content-schema (repo-paths.test.ts);
+    // this pins the compile side to it rather than to a local copy.
+    expect(isExcludedContentPath("courses/_draft/x/course.yaml")).toBe(true);
+    expect(isExcludedContentPath("courses/_template/course.yaml")).toBe(true);
+    expect(isExcludedContentPath("courses/live/course.yaml")).toBe(false);
+  });
+});

--- a/apps/web/src/lib/content/compile/__tests__/tarball.test.ts
+++ b/apps/web/src/lib/content/compile/__tests__/tarball.test.ts
@@ -32,6 +32,26 @@ describe("extractTarball", () => {
     expect([...tree.keys()]).toEqual(["courses/real/course.yaml"]);
   });
 
+  it("excludes every _draft/ directory, in any collection (#973)", async () => {
+    const tar = makeTar({
+      "r-abc/courses/_draft/parked/course.yaml": "id: course-parked\n",
+      "r-abc/courses/_draft/parked/lessons/x/lesson.yaml":
+        "id: lesson-parked\n",
+      "r-abc/paths/_draft/parked.yaml": "id: path-parked\n",
+      "r-abc/achievements/_draft/parked.yaml": "id: achievement-parked\n",
+      "r-abc/quests/_draft/parked.yaml": "id: quest-parked\n",
+      "r-abc/courses/real/course.yaml": "id: course-real\n",
+      // a directory NAMED like the convention but not it — stays visible, so
+      // content-lint's unclassified-file diagnostic can flag the typo.
+      "r-abc/courses/_drafts/typo/course.yaml": "id: course-typo\n",
+    });
+    const tree = await extractTarball(gzipSync(Buffer.from(tar)));
+    expect([...tree.keys()].sort()).toEqual([
+      "courses/_drafts/typo/course.yaml",
+      "courses/real/course.yaml",
+    ]);
+  });
+
   it("reconstructs a path longer than 100 bytes from the ustar prefix field", async () => {
     // The generated `owner-repo-<40-char-sha>/` top dir alone is 65 bytes, so any
     // real repo path overflows the 100-byte name field; git archive splits it

--- a/apps/web/src/lib/content/compile/__tests__/validate.test.ts
+++ b/apps/web/src/lib/content/compile/__tests__/validate.test.ts
@@ -236,4 +236,55 @@ describe("parseAndValidateTree", () => {
       ContentValidationError
     );
   });
+
+  /**
+   * #973 — the admin-sync validator has its own copy of the classification
+   * chain, so it needs its own exclusion guard. Without it the parked twins
+   * below validate into `v.courses` / `v.lessons` / `v.paths` alongside the live
+   * docs. The tree here is NOT built by `extractTarball`, which is the whole
+   * point: the pre-filter cannot be relied on as the only defence.
+   */
+  it("excludes _draft/ docs from the validated content", async () => {
+    const parkedCourse = stringify({
+      id: "course-parked",
+      slug: "parked",
+      title: "Parked",
+      description: "d",
+      difficulty: "beginner",
+      duration: 1,
+      xpPerLesson: 10,
+      xpReward: 100,
+      modules: [{ key: "m", title: "M", lessons: ["lesson-parked"] }],
+    });
+    const parkedLesson = stringify({
+      id: "lesson-parked",
+      slug: "parked",
+      title: "Parked",
+      skills: ["pdas"],
+      blocks: [{ key: "intro", type: "prose", src: "intro.md" }],
+    });
+    const t = tree({
+      "courses/demo/course.yaml": courseYaml,
+      "courses/demo/lessons/accounts/lesson.yaml": lessonYaml,
+      "courses/demo/lessons/accounts/intro.md": "# Accounts",
+      "skills.yaml": skillsYaml,
+      "courses/_draft/parked/course.yaml": parkedCourse,
+      "courses/_draft/parked/lessons/parked/lesson.yaml": parkedLesson,
+      "paths/_draft/parked.yaml": stringify({
+        id: "path-parked",
+        slug: "parked",
+        title: "Parked",
+        difficulty: "beginner",
+        courses: ["course-parked"],
+      }),
+    });
+
+    const v = await parseAndValidateTree(t, passGraders);
+
+    expect(v.courses.map((c) => c.id)).toEqual(["course-demo"]);
+    expect(v.lessons.map(({ lesson }) => lesson.id)).toEqual([
+      "lesson-accounts",
+    ]);
+    expect(v.paths).toEqual([]);
+  });
 });

--- a/apps/web/src/lib/content/compile/compile-bundle.ts
+++ b/apps/web/src/lib/content/compile/compile-bundle.ts
@@ -29,6 +29,7 @@ import {
   LearningPath,
   SkillsTaxonomy,
   checkSkillVocabulary,
+  isExcludedContentPath,
   type SlotsLockT,
 } from "@superteam-lms/content-schema";
 import type { RepoTree } from "@/lib/github/types";
@@ -117,6 +118,10 @@ function validateTree(tree: RepoTree): CompileInput {
   };
 
   for (const [p, bytes] of tree) {
+    // #973: the tree normally arrives pre-filtered from `extractTarball`, but
+    // classification below is unanchored (`endsWith("/course.yaml")`), so a tree
+    // built anywhere else would compile parked docs into the shipped bundle.
+    if (isExcludedContentPath(p)) continue;
     if (p === "skills.yaml") {
       // The only content type at the repo root, not nested under a course/
       // collection dir — a single canonical skill vocabulary, not one doc per

--- a/apps/web/src/lib/content/compile/tarball.ts
+++ b/apps/web/src/lib/content/compile/tarball.ts
@@ -1,8 +1,6 @@
 import { gunzipSync } from "node:zlib";
+import { isExcludedContentPath } from "@superteam-lms/content-schema";
 import type { RepoTree } from "@/lib/github/types";
-
-/** Repo path prefix that is excluded from sync (spec §4.1, §12). */
-const EXCLUDED = "courses/_template/";
 
 /**
  * Decompression bounds against a malicious/corrupt tarball (a gzip bomb inflates
@@ -51,7 +49,8 @@ function parsePaxPath(data: Uint8Array): string | null {
  * Gunzip + untar a GitHub tarball into a repo-relative path → bytes map.
  * GitHub wraps every entry under one generated dir (`owner-repo-<sha>/`); we
  * strip the first path segment so keys match the repo layout. Directory entries
- * (typeflag '5', trailing slash) and `courses/_template/**` are dropped.
+ * (typeflag '5', trailing slash) and every excluded path (`courses/_template/**`,
+ * anything under a `_draft/` dir — see `excluded.ts`) are dropped.
  *
  * Long paths (repo paths routinely exceed the 100-byte tar `name` field once the
  * generated top dir is prepended) are reconstructed from the ustar `prefix`
@@ -124,7 +123,7 @@ export async function extractTarball(
     const slash = fullName.indexOf("/");
     if (slash === -1) continue;
     const relPath = fullName.slice(slash + 1);
-    if (relPath === "" || relPath.startsWith(EXCLUDED)) continue;
+    if (relPath === "" || isExcludedContentPath(relPath)) continue;
 
     tree.set(relPath, new Uint8Array(data));
   }

--- a/apps/web/src/lib/content/compile/tarball.ts
+++ b/apps/web/src/lib/content/compile/tarball.ts
@@ -50,7 +50,8 @@ function parsePaxPath(data: Uint8Array): string | null {
  * GitHub wraps every entry under one generated dir (`owner-repo-<sha>/`); we
  * strip the first path segment so keys match the repo layout. Directory entries
  * (typeflag '5', trailing slash) and every excluded path (`courses/_template/**`,
- * anything under a `_draft/` dir — see `excluded.ts`) are dropped.
+ * anything under a `_draft/` dir — see content-schema's `repo-paths.ts`) are
+ * dropped.
  *
  * Long paths (repo paths routinely exceed the 100-byte tar `name` field once the
  * generated top dir is prepended) are reconstructed from the ustar `prefix`

--- a/apps/web/src/lib/content/compile/validate.ts
+++ b/apps/web/src/lib/content/compile/validate.ts
@@ -8,6 +8,7 @@ import {
   LearningPath,
   SkillsTaxonomy,
   checkSkillVocabulary,
+  isExcludedContentPath,
   type CourseT,
   type LessonT,
   type SlotsLockT,
@@ -79,6 +80,10 @@ export async function parseAndValidateTree(
   };
 
   for (const [path, bytes] of tree) {
+    // #973: mirrors compile-bundle.ts's validateTree — excluded paths never
+    // reach classification, so a tree not built by `extractTarball` cannot
+    // slip a parked (`_draft/`) doc past this validator.
+    if (isExcludedContentPath(path)) continue;
     if (path === "skills.yaml") {
       // The only content type at the repo root, not nested under a course/
       // collection dir — a single canonical skill vocabulary, not one doc per

--- a/packages/content-lint/src/__tests__/loader.test.ts
+++ b/packages/content-lint/src/__tests__/loader.test.ts
@@ -2,7 +2,16 @@ import { describe, it, expect } from "vitest";
 import { symlinkSync, mkdtempSync, writeFileSync, mkdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { discover, walkFiles, unclassifiedContentFiles } from "../loader";
+import {
+  isCompilerContentDoc,
+  isExcludedContentPath,
+} from "@superteam-lms/content-schema";
+import {
+  classify,
+  discover,
+  walkFiles,
+  unclassifiedContentFiles,
+} from "../loader";
 import { runLint } from "../lint";
 import { makeTempRepo } from "./helpers";
 
@@ -64,6 +73,28 @@ describe("discover — parked content (#973)", () => {
     ).toEqual(["courses/live/course.yaml", "paths/live.yaml"]);
   });
 
+  /**
+   * These two paths are the ONLY reason `discover`'s `isDraftPath` guard is
+   * load-bearing: `classify()` claims them (its `[^/]+` segments happily match
+   * `_draft`), so without the guard they are linted as a real course/lesson —
+   * duplicate ids against their live twins. Every other `_draft/` fixture above
+   * sits at a depth `classify()` already rejects, which is why deleting the
+   * guard left the suite green before this test existed.
+   */
+  it("skips a _draft dir that classify() itself would claim as a course", () => {
+    const root = makeTempRepo({
+      "courses/_draft/course.yaml": "id: course-parked\n",
+    });
+    expect(discover(root)).toEqual([]);
+  });
+
+  it("skips a _draft dir that classify() itself would claim as a lesson", () => {
+    const root = makeTempRepo({
+      "courses/live/lessons/_draft/lesson.yaml": "id: lesson-parked\n",
+    });
+    expect(discover(root)).toEqual([]);
+  });
+
   it("still lints the `courses/_template/` scaffold (unchanged by #973)", () => {
     const root = makeTempRepo({
       "courses/_template/course.yaml": "id: course-template\n",
@@ -83,7 +114,7 @@ describe("discover — parked content (#973)", () => {
 });
 
 describe("unclassifiedContentFiles (#973)", () => {
-  it("warns on a typo'd parking directory that no gate can see", () => {
+  it("ERRORS on a typo'd parking directory, because the compiler still ships it", () => {
     const root = makeTempRepo({
       "courses/_drafts/parked/course.yaml": "id: course-parked\n",
       "courses/live/course.yaml": "id: course-live\n",
@@ -93,22 +124,37 @@ describe("unclassifiedContentFiles (#973)", () => {
     expect(diags).toHaveLength(1);
     expect(diags[0]).toMatchObject({
       gate: "loader",
-      severity: "warning",
+      severity: "error",
       file: "courses/_drafts/parked/course.yaml",
     });
-    expect(diags[0]!.message).toContain("unclassified content file");
+    expect(diags[0]!.message).toContain("COMPILER STILL SHIPS");
   });
 
-  it("warns on a collection yaml at the wrong depth", () => {
+  it("ERRORS on a compiler-visible doc at a depth classify() rejects", () => {
     const root = makeTempRepo({
+      // The compiler's chain is `endsWith("/lesson.yaml")` / `startsWith("paths/")`
+      // — depth-blind. content-lint's is anchored. Every path here is therefore
+      // shipped-but-unlinted, the exact #973 invariant.
+      "courses/live/modules/m1/lessons/x/lesson.yaml": "id: lesson-deep\n",
       "paths/archive/old.yaml": "id: path-old\n",
-      "courses/live/lessons/x/notes.yaml": "note: not a lesson\n",
+      "achievements/season1/x.yaml": "id: achievement-x\n",
     });
-    expect(
-      unclassifiedContentFiles(root)
-        .map((d) => d.file)
-        .sort()
-    ).toEqual(["courses/live/lessons/x/notes.yaml", "paths/archive/old.yaml"]);
+    const diags = unclassifiedContentFiles(root);
+    expect(diags.map((d) => d.severity)).toEqual(["error", "error", "error"]);
+    expect(diags.map((d) => d.file).sort()).toEqual([
+      "achievements/season1/x.yaml",
+      "courses/live/modules/m1/lessons/x/lesson.yaml",
+      "paths/archive/old.yaml",
+    ]);
+  });
+
+  it("only WARNS when nothing would ship — no gate sees it, but no bundle gets it", () => {
+    const root = makeTempRepo({
+      "courses/live/lessons/x/notes.yaml": "note: not a lesson\n",
+      "courses/live/meta.yaml": "a: 1\n",
+    });
+    const diags = unclassifiedContentFiles(root);
+    expect(diags.map((d) => d.severity)).toEqual(["warning", "warning"]);
   });
 
   it("ignores yaml outside the content collections", () => {
@@ -119,9 +165,24 @@ describe("unclassifiedContentFiles (#973)", () => {
     expect(unclassifiedContentFiles(root)).toEqual([]);
   });
 
-  it("surfaces the warning through runLint without failing the run", async () => {
+  it("fails the whole lint run on the shipped-but-unlinted case", async () => {
     const root = makeTempRepo({
       "courses/_drafts/parked/course.yaml": "id: course-parked\n",
+    });
+    const result = await runLint(root);
+    // Reviewer's repro: before the severity split this exited 0 while the
+    // compiler shipped the parked catalog with duplicate ids.
+    expect(result.ok).toBe(false);
+    expect(
+      result.diagnostics.filter(
+        (d) => d.gate === "loader" && d.severity === "error"
+      )
+    ).toHaveLength(1);
+  });
+
+  it("does not fail the run on the warning-tier case", async () => {
+    const root = makeTempRepo({
+      "courses/live/lessons/x/notes.yaml": "note: not a lesson\n",
     });
     const result = await runLint(root);
     expect(result.ok).toBe(true);
@@ -130,6 +191,69 @@ describe("unclassifiedContentFiles (#973)", () => {
         (d) => d.gate === "loader" && d.severity === "warning"
       )
     ).toHaveLength(1);
+  });
+});
+
+/**
+ * The assertion the issue asked for, stated directly rather than via fixtures:
+ * every doc the COMPILER claims must also be lint-classifiable, unless it is
+ * excluded from both. When that fails the file ships unlinted — #973 itself.
+ */
+describe("compiler ⊆ lint agreement (#973)", () => {
+  const CANONICAL = [
+    "courses/live/course.yaml",
+    "courses/live/lessons/x/lesson.yaml",
+    "achievements/a.yaml",
+    "quests/q.yaml",
+    "paths/p.yaml",
+  ];
+
+  const PARKED = [
+    "courses/_draft/x/course.yaml",
+    "courses/live/lessons/_draft/lesson.yaml",
+    "paths/_draft/p.yaml",
+    "achievements/_draft/a.yaml",
+    "quests/_draft/q.yaml",
+  ];
+
+  const DIVERGENT = [
+    "courses/_drafts/x/course.yaml",
+    "courses/live/modules/m1/lessons/x/lesson.yaml",
+    "paths/archive/old.yaml",
+    "achievements/season1/a.yaml",
+  ];
+
+  it("holds for every canonical path", () => {
+    for (const p of CANONICAL) {
+      expect(isCompilerContentDoc(p), p).toBe(true);
+      expect(isExcludedContentPath(p), p).toBe(false);
+      expect(classify(p), p).not.toBeNull();
+    }
+  });
+
+  it("holds for every parked path — excluded from BOTH sides", () => {
+    for (const p of PARKED) {
+      expect(isExcludedContentPath(p), p).toBe(true);
+      // Compiler-shaped, but the exclusion runs first on both sides.
+      expect(isCompilerContentDoc(p), p).toBe(true);
+    }
+  });
+
+  it("catches every divergent path — compiler-visible, lint-invisible", () => {
+    for (const p of DIVERGENT) {
+      expect(isCompilerContentDoc(p), p).toBe(true);
+      expect(isExcludedContentPath(p), p).toBe(false);
+      expect(classify(p), p).toBeNull();
+    }
+  });
+
+  it("reports each divergent path as an error, so none can ship silently", () => {
+    const root = makeTempRepo(
+      Object.fromEntries(DIVERGENT.map((p) => [p, "id: x\n"]))
+    );
+    const diags = unclassifiedContentFiles(root);
+    expect(diags.map((d) => d.file).sort()).toEqual([...DIVERGENT].sort());
+    expect(diags.every((d) => d.severity === "error")).toBe(true);
   });
 });
 

--- a/packages/content-lint/src/__tests__/loader.test.ts
+++ b/packages/content-lint/src/__tests__/loader.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 import { symlinkSync, mkdtempSync, writeFileSync, mkdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { discover, walkFiles } from "../loader";
+import { discover, walkFiles, unclassifiedContentFiles } from "../loader";
 import { runLint } from "../lint";
 import { makeTempRepo } from "./helpers";
 
@@ -43,6 +43,93 @@ describe("discover", () => {
     });
     const doc = discover(root).find((d) => d.kind === "achievement");
     expect(doc?.parseError).toBeTruthy();
+  });
+});
+
+describe("discover — parked content (#973)", () => {
+  it("skips every _draft/ file, in any collection", () => {
+    const root = makeTempRepo({
+      "courses/live/course.yaml": "id: course-live\n",
+      "courses/_draft/parked/course.yaml": "id: course-parked\n",
+      "courses/_draft/parked/lessons/x/lesson.yaml": "id: lesson-parked\n",
+      "paths/live.yaml": "id: path-live\n",
+      "paths/_draft/parked.yaml": "id: path-parked\n",
+      "achievements/_draft/parked.yaml": "id: achievement-parked\n",
+      "quests/_draft/parked.yaml": "id: quest-parked\n",
+    });
+    expect(
+      discover(root)
+        .map((d) => d.path)
+        .sort()
+    ).toEqual(["courses/live/course.yaml", "paths/live.yaml"]);
+  });
+
+  it("still lints the `courses/_template/` scaffold (unchanged by #973)", () => {
+    const root = makeTempRepo({
+      "courses/_template/course.yaml": "id: course-template\n",
+    });
+    expect(discover(root).map((d) => d.path)).toEqual([
+      "courses/_template/course.yaml",
+    ]);
+  });
+
+  it("does not warn about parked or scaffold files it cannot classify", () => {
+    const root = makeTempRepo({
+      "courses/_draft/parked/notes.yaml": "a: 1\n",
+      "courses/_template/lessons/x/notes.yaml": "a: 1\n",
+    });
+    expect(unclassifiedContentFiles(root)).toEqual([]);
+  });
+});
+
+describe("unclassifiedContentFiles (#973)", () => {
+  it("warns on a typo'd parking directory that no gate can see", () => {
+    const root = makeTempRepo({
+      "courses/_drafts/parked/course.yaml": "id: course-parked\n",
+      "courses/live/course.yaml": "id: course-live\n",
+    });
+
+    const diags = unclassifiedContentFiles(root);
+    expect(diags).toHaveLength(1);
+    expect(diags[0]).toMatchObject({
+      gate: "loader",
+      severity: "warning",
+      file: "courses/_drafts/parked/course.yaml",
+    });
+    expect(diags[0]!.message).toContain("unclassified content file");
+  });
+
+  it("warns on a collection yaml at the wrong depth", () => {
+    const root = makeTempRepo({
+      "paths/archive/old.yaml": "id: path-old\n",
+      "courses/live/lessons/x/notes.yaml": "note: not a lesson\n",
+    });
+    expect(
+      unclassifiedContentFiles(root)
+        .map((d) => d.file)
+        .sort()
+    ).toEqual(["courses/live/lessons/x/notes.yaml", "paths/archive/old.yaml"]);
+  });
+
+  it("ignores yaml outside the content collections", () => {
+    const root = makeTempRepo({
+      "skills.yaml": "- slug: pdas\n  label: PDAs\n",
+      "docs/notes.yaml": "a: 1\n",
+    });
+    expect(unclassifiedContentFiles(root)).toEqual([]);
+  });
+
+  it("surfaces the warning through runLint without failing the run", async () => {
+    const root = makeTempRepo({
+      "courses/_drafts/parked/course.yaml": "id: course-parked\n",
+    });
+    const result = await runLint(root);
+    expect(result.ok).toBe(true);
+    expect(
+      result.diagnostics.filter(
+        (d) => d.gate === "loader" && d.severity === "warning"
+      )
+    ).toHaveLength(1);
   });
 });
 

--- a/packages/content-lint/src/checks/gate19-skills.ts
+++ b/packages/content-lint/src/checks/gate19-skills.ts
@@ -5,6 +5,7 @@ import {
   SkillsTaxonomy,
   NON_REVIEW_ELIGIBLE_SKILLS,
   REVIEW_INTERLEAVING_PAIRS,
+  TEMPLATE_PREFIX,
   type SkillsTaxonomyT,
 } from "@superteam-lms/content-schema";
 import { registerCheck } from "../lint";
@@ -43,15 +44,6 @@ import { diag, type Diagnostic } from "../diagnostics";
  */
 
 const SKILLS_FILE = "skills.yaml";
-
-/**
- * `courses/_template/**` holds scaffolding, not shippable content. Its lessons
- * are excluded from gate 19 so a template tag never contributes to (or hides) a
- * reuse-bar result — e.g. a template lesson sharing a real slug would otherwise
- * lift that slug's count from 1 to 2 and suppress a legitimate singleton error.
- * Scoped to gate 19 only; other gates keep their current view of `_template`.
- */
-const TEMPLATE_LESSON_PREFIX = "courses/_template/";
 
 function loadRegistry(root: string, out: Diagnostic[]): SkillsTaxonomyT | null {
   let text: string;
@@ -127,7 +119,13 @@ export function gate19Check(model: RepoModel): Diagnostic[] {
   // Distinct-lesson count per slug (a slug repeated within one lesson counts once).
   const lessonsBySlug = new Map<string, string[]>();
   for (const entry of model.lessons) {
-    if (entry.file.startsWith(TEMPLATE_LESSON_PREFIX)) continue;
+    // `courses/_template/**` holds scaffolding, not shippable content. Its
+    // lessons are excluded from gate 19 so a template tag never contributes to
+    // (or hides) a reuse-bar result — e.g. a template lesson sharing a real slug
+    // would otherwise lift that slug's count from 1 to 2 and suppress a
+    // legitimate singleton error. Scoped to gate 19 only; other gates keep their
+    // current view of `_template`. The prefix itself is content-schema's.
+    if (entry.file.startsWith(TEMPLATE_PREFIX)) continue;
     for (const slug of new Set(entry.lesson.skills)) {
       // 19a — registry resolution.
       if (!known.has(slug)) {

--- a/packages/content-lint/src/lint.ts
+++ b/packages/content-lint/src/lint.ts
@@ -51,9 +51,9 @@ export async function runLint(
   }
 
   // #973: a content file NO gate can see is worse than a failing one — it looks
-  // linted and is not. Warning-tier: the near-miss cases (a doc at the wrong
-  // depth, a typo'd `_drafts/`) must be visible without breaking a repo that
-  // legitimately carries an unrecognised yaml.
+  // linted and is not. Error when the compiler would still ship it (the
+  // invariant), warning when nothing ships but the author likely meant it to be
+  // linted. See `unclassifiedContentFiles`.
   diagnostics.push(...unclassifiedContentFiles(root));
 
   const model = schemaCheck ? schemaCheck(root, diagnostics) : emptyModel(root);

--- a/packages/content-lint/src/lint.ts
+++ b/packages/content-lint/src/lint.ts
@@ -1,4 +1,4 @@
-import { discover } from "./loader";
+import { discover, unclassifiedContentFiles } from "./loader";
 import { emptyModel, type RepoModel } from "./model";
 import {
   diag,
@@ -49,6 +49,12 @@ export async function runLint(
       );
     }
   }
+
+  // #973: a content file NO gate can see is worse than a failing one — it looks
+  // linted and is not. Warning-tier: the near-miss cases (a doc at the wrong
+  // depth, a typo'd `_drafts/`) must be visible without breaking a repo that
+  // legitimately carries an unrecognised yaml.
+  diagnostics.push(...unclassifiedContentFiles(root));
 
   const model = schemaCheck ? schemaCheck(root, diagnostics) : emptyModel(root);
 

--- a/packages/content-lint/src/loader.ts
+++ b/packages/content-lint/src/loader.ts
@@ -2,6 +2,7 @@ import { readFileSync, readdirSync, lstatSync } from "node:fs";
 import { join, relative } from "node:path";
 import { parse as parseYaml } from "yaml";
 import {
+  isCompilerContentDoc,
   isDraftPath,
   isExcludedContentPath,
 } from "@superteam-lms/content-schema";
@@ -56,8 +57,14 @@ export function walkFiles(root: string, dir = root): string[] {
   return out;
 }
 
-/** Path-pattern classification. Returns null for files we do not lint directly. */
-function classify(path: string): DocKind | null {
+/**
+ * Path-pattern classification. Returns null for files we do not lint directly.
+ *
+ * ANCHORED and fixed-depth, unlike the compiler's unanchored `endsWith` chain
+ * (`isCompilerContentDoc`). Exported so the agreement between the two can be
+ * asserted directly — see loader.test.ts's compiler ⊆ lint property.
+ */
+export function classify(path: string): DocKind | null {
   if (/^courses\/[^/]+\/course\.yaml$/.test(path)) return "course";
   if (/^courses\/[^/]+\/slots\.lock\.json$/.test(path)) return "slots";
   if (/^courses\/[^/]+\/lessons\/[^/]+\/lesson\.yaml$/.test(path)) {
@@ -90,8 +97,18 @@ const COLLECTION_DIRS = ["courses/", "paths/", "achievements/", "quests/"];
  * `.yaml` files inside a content collection that no classifier claims and that
  * are not parked — a typo'd parking dir (`courses/_drafts/x/course.yaml`), a
  * doc at the wrong depth, an unrecognised collection subdir. Each is content
- * the author believes is linted and is not, so it gets a warning rather than
- * `loader.ts`'s old bare `if (!kind) continue;`.
+ * the author believes is linted and is not, replacing `loader.ts`'s old bare
+ * `if (!kind) continue;`.
+ *
+ * Severity splits on whether the COMPILER would still claim the file:
+ *
+ *   - ERROR when it would (`isCompilerContentDoc`). That is the #973 invariant
+ *     itself — the file ships into the bundle with no gate having seen it. A
+ *     single mistyped directory (`courses/_drafts/`) otherwise re-opens the
+ *     whole hole: lint exits 0 while the compiler emits the parked docs, ids
+ *     and all. A warning does not enforce an invariant; an error does.
+ *   - WARNING otherwise. Nothing ships, but the author still probably meant it
+ *     to be linted, so it must not be silent.
  */
 export function unclassifiedContentFiles(root: string): Diagnostic[] {
   const out: Diagnostic[] = [];
@@ -100,13 +117,18 @@ export function unclassifiedContentFiles(root: string): Diagnostic[] {
     if (classify(path) !== null) continue;
     if (isExcludedContentPath(path)) continue;
     if (!COLLECTION_DIRS.some((d) => path.startsWith(d))) continue;
+    const shipped = isCompilerContentDoc(path);
     out.push(
       diag(
         "loader",
-        "warning",
+        shipped ? "error" : "warning",
         path,
-        "unclassified content file — wrong depth or directory name? it is NOT linted by any gate " +
-          "(park a file deliberately by moving it under a `_draft/` directory)"
+        shipped
+          ? "unclassified content file the COMPILER STILL SHIPS — wrong depth or directory name? " +
+              "no gate can see it, so it would reach the bundle unlinted " +
+              "(park a file deliberately by moving it under a `_draft/` directory)"
+          : "unclassified content file — wrong depth or directory name? it is NOT linted by any gate " +
+              "(park a file deliberately by moving it under a `_draft/` directory)"
       )
     );
   }

--- a/packages/content-lint/src/loader.ts
+++ b/packages/content-lint/src/loader.ts
@@ -1,6 +1,11 @@
 import { readFileSync, readdirSync, lstatSync } from "node:fs";
 import { join, relative } from "node:path";
 import { parse as parseYaml } from "yaml";
+import {
+  isDraftPath,
+  isExcludedContentPath,
+} from "@superteam-lms/content-schema";
+import { diag, type Diagnostic } from "./diagnostics";
 
 export type DocKind =
   | "course"
@@ -75,10 +80,50 @@ function parseByKind(abs: string, kind: DocKind): unknown {
   return parseYaml(text, { version: "1.2" });
 }
 
+/**
+ * Top-level content collections. A `.yaml` under one of these that classify()
+ * does not claim is a mistake worth naming (see {@link unclassifiedContentFiles}).
+ */
+const COLLECTION_DIRS = ["courses/", "paths/", "achievements/", "quests/"];
+
+/**
+ * `.yaml` files inside a content collection that no classifier claims and that
+ * are not parked — a typo'd parking dir (`courses/_drafts/x/course.yaml`), a
+ * doc at the wrong depth, an unrecognised collection subdir. Each is content
+ * the author believes is linted and is not, so it gets a warning rather than
+ * `loader.ts`'s old bare `if (!kind) continue;`.
+ */
+export function unclassifiedContentFiles(root: string): Diagnostic[] {
+  const out: Diagnostic[] = [];
+  for (const path of walkFiles(root)) {
+    if (!path.endsWith(".yaml")) continue;
+    if (classify(path) !== null) continue;
+    if (isExcludedContentPath(path)) continue;
+    if (!COLLECTION_DIRS.some((d) => path.startsWith(d))) continue;
+    out.push(
+      diag(
+        "loader",
+        "warning",
+        path,
+        "unclassified content file — wrong depth or directory name? it is NOT linted by any gate " +
+          "(park a file deliberately by moving it under a `_draft/` directory)"
+      )
+    );
+  }
+  return out;
+}
+
 /** Discover + parse every lintable file. Parse failures become `parseError`, never throws. */
 export function discover(root: string): RawDoc[] {
   const docs: RawDoc[] = [];
   for (const path of walkFiles(root)) {
+    // Parked content (`_draft/`) is out of the catalog and out of the bundle, so
+    // it is not linted either. #973: this skip used to be an EMERGENT property of
+    // classify()'s anchored fixed-depth regexes — load-bearing, untested,
+    // invisible — while the bundle compiler shipped the very same files. Now it
+    // is a named concept, shared with the compiler. `courses/_template/**` is
+    // deliberately NOT skipped here: the scaffold stays linted.
+    if (isDraftPath(path)) continue;
     const kind = classify(path);
     if (!kind) continue;
     const abs = join(root, path);

--- a/packages/content-schema/src/__tests__/repo-paths.test.ts
+++ b/packages/content-schema/src/__tests__/repo-paths.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { isDraftPath, isExcludedContentPath } from "../repo-paths";
+import {
+  isCompilerContentDoc,
+  isDraftPath,
+  isExcludedContentPath,
+} from "../repo-paths";
 
 /**
  * #973 — one rule, two consumers: the bundle compiler (apps/web) and
@@ -43,6 +47,43 @@ describe("isDraftPath", () => {
       "courses/_template/course.yaml",
     ]) {
       expect(isDraftPath(p), p).toBe(false);
+    }
+  });
+});
+
+describe("isCompilerContentDoc", () => {
+  it("is depth-blind, exactly like the compiler's unanchored chain", () => {
+    for (const p of [
+      "courses/live/course.yaml",
+      "courses/a/b/c/course.yaml",
+      "courses/live/lessons/x/lesson.yaml",
+      "courses/live/modules/m1/lessons/x/lesson.yaml",
+      "paths/p.yaml",
+      "paths/archive/old.yaml",
+      "achievements/a.yaml",
+      "achievements/season1/a.yaml",
+      "quests/q.yaml",
+      "quests/nested/q.yaml",
+    ]) {
+      expect(isCompilerContentDoc(p), p).toBe(true);
+    }
+  });
+
+  it("does not claim prose, code, assets, or non-collection yaml", () => {
+    for (const p of [
+      "skills.yaml",
+      "courses/live/README.md",
+      "courses/live/lessons/x/intro.md",
+      "courses/live/lessons/x/exercise/solution.ts",
+      "courses/live/lessons/x/assets/pixel.png",
+      "courses/live/lessons/x/notes.yaml",
+      "courses/live/meta.yaml",
+      "docs/notes.yaml",
+      // The quiz shorthand is a lint-only doc kind; the compiler reads quizzes
+      // out of the lesson's blocks, not as standalone files.
+      "courses/live/lessons/x/check.quiz.yaml",
+    ]) {
+      expect(isCompilerContentDoc(p), p).toBe(false);
     }
   });
 });

--- a/packages/content-schema/src/__tests__/repo-paths.test.ts
+++ b/packages/content-schema/src/__tests__/repo-paths.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest";
+import { isDraftPath, isExcludedContentPath } from "../repo-paths";
+
+/**
+ * #973 — one rule, two consumers: the bundle compiler (apps/web) and
+ * content-lint. The near-miss cases below are the whole point: a typo'd
+ * `_drafts/` must NOT be silently parked, it must stay visible so content-lint's
+ * unclassified-file diagnostic can flag it.
+ */
+
+const PARKED = [
+  "courses/_draft/x/course.yaml",
+  "courses/_draft/x/lessons/y/lesson.yaml",
+  "paths/_draft/p.yaml",
+  "achievements/_draft/a.yaml",
+  "quests/_draft/q.yaml",
+  "courses/live/_draft/old/lesson.yaml",
+  "_draft/anything.yaml",
+];
+
+const NEAR_MISSES = [
+  "courses/_drafts/x/course.yaml",
+  "courses/_draft-old/x/course.yaml",
+  "courses/live/_draft.md",
+  "courses/live/lessons/x/my_draft/notes.md",
+  "courses/live/lessons/draft/lesson.yaml",
+];
+
+describe("isDraftPath", () => {
+  it("matches a `_draft` directory segment at any depth", () => {
+    for (const p of PARKED) expect(isDraftPath(p), p).toBe(true);
+  });
+
+  it("matches a directory and only a directory", () => {
+    for (const p of NEAR_MISSES) expect(isDraftPath(p), p).toBe(false);
+  });
+
+  it("does not match live content or the scaffold", () => {
+    for (const p of [
+      "courses/live/course.yaml",
+      "paths/live.yaml",
+      "skills.yaml",
+      "courses/_template/course.yaml",
+    ]) {
+      expect(isDraftPath(p), p).toBe(false);
+    }
+  });
+});
+
+describe("isExcludedContentPath", () => {
+  it("excludes parked content and the `courses/_template/` scaffold", () => {
+    for (const p of [
+      ...PARKED,
+      "courses/_template/course.yaml",
+      "courses/_template/lessons/x/lesson.yaml",
+    ]) {
+      expect(isExcludedContentPath(p), p).toBe(true);
+    }
+  });
+
+  it("keeps live content and every near-miss visible", () => {
+    for (const p of [
+      ...NEAR_MISSES,
+      "courses/live/course.yaml",
+      "paths/live.yaml",
+      "achievements/a.yaml",
+      "skills.yaml",
+    ]) {
+      expect(isExcludedContentPath(p), p).toBe(false);
+    }
+  });
+});

--- a/packages/content-schema/src/index.ts
+++ b/packages/content-schema/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./constants";
+export * from "./repo-paths";
 export * from "./ids";
 export * from "./wallet";
 export * from "./capabilities";

--- a/packages/content-schema/src/repo-paths.ts
+++ b/packages/content-schema/src/repo-paths.ts
@@ -1,0 +1,49 @@
+/**
+ * Repo-path conventions of the academy-courses tree. Lives in content-schema
+ * because it must be ONE rule: the bundle compiler (apps/web) and content-lint
+ * (packages/content-lint) both walk the same tree, and #973 was exactly the bug
+ * of them disagreeing — content-lint's anchored fixed-depth regexes silently
+ * dropped `_draft/` files (so CI went green BECAUSE it could no longer see
+ * them) while the compiler's unanchored `endsWith("/course.yaml")` compiled
+ * them straight into the shipped bundle.
+ */
+
+/** `courses/_template/**` — the authoring scaffold (spec §4.1, §12), never synced. */
+export const TEMPLATE_PREFIX = "courses/_template/";
+
+/**
+ * The parking directory. A course/path/achievement leaves the catalog by being
+ * moved under `_draft/` rather than deleted, so its history and ids survive.
+ */
+export const DRAFT_DIR = "_draft";
+
+/**
+ * A `_draft` directory SEGMENT at any depth — not a prefix, because the parking
+ * dir appears under each collection (`courses/_draft/x/course.yaml`,
+ * `paths/_draft/p.yaml`, `achievements/_draft/a.yaml`, `quests/_draft/q.yaml`)
+ * and may also be nested inside a course.
+ *
+ * Anchored on `/` (or string start) left and `/` right so it matches a directory
+ * and only a directory: `courses/_drafts/…` (typo) and `courses/x/_draft.md`
+ * are NOT parked. A near-miss must stay visible and get flagged, not vanish —
+ * that is what content-lint's unclassified-file diagnostic is for.
+ */
+const DRAFT_SEGMENT = /(?:^|\/)_draft\//;
+
+/** True when a repo-relative POSIX path sits under a `_draft/` parking directory. */
+export function isDraftPath(relPath: string): boolean {
+  return DRAFT_SEGMENT.test(relPath);
+}
+
+/**
+ * True when a repo-relative POSIX path carries no shippable content: parked, or
+ * the authoring scaffold.
+ *
+ * Note the asymmetry with {@link isDraftPath}: content-lint deliberately LINTS
+ * `courses/_template/**` (the scaffold must stay valid — see the `good` fixture
+ * and gate 19's own narrower `TEMPLATE_LESSON_PREFIX`) while the compiler never
+ * ships it. Parked content is excluded from both.
+ */
+export function isExcludedContentPath(relPath: string): boolean {
+  return relPath.startsWith(TEMPLATE_PREFIX) || isDraftPath(relPath);
+}

--- a/packages/content-schema/src/repo-paths.ts
+++ b/packages/content-schema/src/repo-paths.ts
@@ -41,9 +41,38 @@ export function isDraftPath(relPath: string): boolean {
  *
  * Note the asymmetry with {@link isDraftPath}: content-lint deliberately LINTS
  * `courses/_template/**` (the scaffold must stay valid — see the `good` fixture
- * and gate 19's own narrower `TEMPLATE_LESSON_PREFIX`) while the compiler never
- * ships it. Parked content is excluded from both.
+ * and gate 19's template-scoped exclusion) while the compiler never ships it.
+ * Parked content is excluded from both.
  */
 export function isExcludedContentPath(relPath: string): boolean {
   return relPath.startsWith(TEMPLATE_PREFIX) || isDraftPath(relPath);
+}
+
+/** Collections whose `.yaml` files the compiler treats as documents, by prefix. */
+const COMPILER_COLLECTION_PREFIXES = ["achievements/", "quests/", "paths/"];
+
+/**
+ * True when the bundle compiler would classify this path as a content DOCUMENT
+ * and emit it — mirroring `validateTree`'s unanchored chain in
+ * `apps/web/src/lib/content/compile/compile-bundle.ts` (and the identical chain
+ * in `validate.ts`). Deliberately UNANCHORED and depth-blind, exactly like the
+ * compiler: `courses/a/b/c/course.yaml` is a course to it.
+ *
+ * That is the whole asymmetry #973 turned on. content-lint's `classify()` is
+ * anchored and fixed-depth, so a doc can be compiler-visible and lint-invisible.
+ * Whenever that happens the file ships unlinted, so content-lint escalates such
+ * a file to an ERROR rather than a warning (`unclassifiedContentFiles`).
+ *
+ * KNOWN GAP (follow-up, deliberately out of #973's scope): `slots.lock.json` is
+ * also compiler-claimed but is `.json`, and the loader's unclassified scan only
+ * walks `.yaml`. Same for `.yml`.
+ */
+export function isCompilerContentDoc(relPath: string): boolean {
+  if (relPath.endsWith("/course.yaml") || relPath.endsWith("/lesson.yaml")) {
+    return true;
+  }
+  return (
+    relPath.endsWith(".yaml") &&
+    COMPILER_COLLECTION_PREFIXES.some((p) => relPath.startsWith(p))
+  );
 }


### PR DESCRIPTION
Closes #973. Gates academy-courses#34.

`_draft/` parking was a directory convention with no implementation: lint's anchored regexes skipped it while the compiler shipped it. This adds one shared predicate (`content-schema/src/repo-paths.ts`, a `_draft/` path segment at any depth) consumed by all three tree walkers, makes lint's skip a named tested behavior, and adds a warning when a content-shaped yaml classifies to nothing (catches typo'd dirs like `_drafts/`, which deliberately do NOT match the exclusion).

Red-proof: `draft-exclusion.test.ts` fails at main (parked docs reach the bundle), passes here. Run against academy-courses#34's real head: excludes exactly the 6 courses / 66 lessons / 1 path / 3 achievements it parks, keeps the 2 live courses. Zero new lint warnings on either content main or the PR head.