### PR TITLE
feat(auth): Phantom Connect flow — provider, hook, and modal entry point

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,6 +45,14 @@ AI_PARTNER_SEAL_SECRET=
 # when unset (apps/web/src/app/api/rust/execute/route.ts).
 RUST_PLAYGROUND_URL=
 
+# ── Phantom Connect embedded wallets (optional — #983/#984) ──────────────────
+# App id from Phantom Portal (https://phantom.com/portal/). Public and
+# domain-bound: it ships in the client bundle by design, and Portal's
+# allowed-domains list is what scopes it — configuration, not a secret.
+# Unset = embedded wallets OFF; SIWS stays the guaranteed way in.
+# Portal must list the production origin AND http://localhost:3000 for dev.
+NEXT_PUBLIC_PHANTOM_APP_ID=
+
 # ── Analytics (optional — platform works without these) ───────────────────────
 # Google Analytics 4
 NEXT_PUBLIC_GA4_MEASUREMENT_ID=G-XXXXXXXXXX

--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -126,6 +126,18 @@ TEACH_PREVIEW_PASSWORD=            # Shared password for /teach/preview. NO defa
                                    # never on-chain writes, never the admin surface (separate
                                    # cookie from admin_session, so it cannot satisfy admin auth).
 
+# Optional — Phantom Connect embedded wallets (#983/#984)
+# Public, domain-bound client id from Phantom Portal (https://phantom.com/portal/).
+# It ships in the client bundle by design; Portal's allowed-domains list is what
+# scopes it, so it is configuration, not a secret. Unset = embedded wallets OFF,
+# exactly like the analytics keys — SIWS stays the guaranteed way in, and no
+# build or page render may depend on this being present.
+# Portal must list the production origin AND http://localhost:3000 for dev.
+# Read ONLY through lib/phantom/config.ts (isPhantomConnectEnabled/getPhantomAppId).
+# NOTE: we integrate via @phantom/browser-sdk, not @phantom/react-sdk — the
+# latter needs React >=19.0.1 and this app is on React 18.3.1 (#989).
+NEXT_PUBLIC_PHANTOM_APP_ID=
+
 # Optional — Rust playground proxy (server-only)
 RUST_PLAYGROUND_URL=               # /api/rust/execute upstream (default: play.rust-lang.org/execute)
 

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -55,6 +55,10 @@ const cspDirectives = [
     "https://accounts.google.com https://*.googleapis.com",
     "https://www.googletagmanager.com https://www.google-analytics.com https://*.google-analytics.com https://stats.g.doubleclick.net",
     "https://*.posthog.com https://*.sentry.io https://*.ingest.sentry.io",
+    // Phantom Connect (#985) — kept in sync with lib/csp.ts. Not strictly
+    // needed on /api/* (the SDK only runs on app pages), but this fallback's
+    // contract is "rough sync with the middleware CSP".
+    "https://auth.phantom.app https://api.phantom.app https://time.phantom.app",
   ].join(" "),
 
   // Frames: Google OAuth may use frames; lesson videos embed the YouTube and

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -29,7 +29,7 @@
     "@metaplex-foundation/umi-web3js-adapters": "^1.5.1",
     "@monaco-editor/react": "^4.7.0",
     "@noble/hashes": "^1.8.0",
-    "image-size": "^1.2.1",
+    "@phantom/browser-sdk": "^2.0.2",
     "@phosphor-icons/react": "^2.1.10",
     "@radix-ui/react-avatar": "^1.1.0",
     "@radix-ui/react-dialog": "^1.1.0",
@@ -57,6 +57,7 @@
     "canvas-confetti": "^1.9.4",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",
+    "image-size": "^1.2.1",
     "isomorphic-dompurify": "2.36.0",
     "next": "^15.5.22",
     "next-intl": "^4.13.4",
@@ -96,12 +97,12 @@
     "bn.js": "^5.2.2",
     "eslint": "^8.57.0",
     "eslint-config-next": "^15.5.22",
+    "groq-js": "^1.17.0",
     "jsdom": "^29.1.1",
     "monaco-editor": "^0.55.1",
     "postcss": "^8.4.0",
     "tailwindcss": "^3.4.0",
     "typescript": "^5.7.0",
-    "vitest": "^4.0.18",
-    "groq-js": "^1.17.0"
+    "vitest": "^4.0.18"
   }
 }

--- a/apps/web/src/app/[locale]/layout.tsx
+++ b/apps/web/src/app/[locale]/layout.tsx
@@ -7,6 +7,7 @@ import { ThemeProvider } from "@/components/layout/theme-provider";
 import { SolanaWalletProvider } from "@/lib/solana/wallet-provider";
 import { AnalyticsProvider } from "@/components/analytics/analytics-provider";
 import { AuthProvider } from "@/lib/auth/auth-provider";
+import { PhantomConnectProvider } from "@/components/auth/phantom-connect-provider";
 import { Header } from "@/components/layout/header";
 import { MobileBottomNav } from "@/components/layout/mobile-bottom-nav";
 import { GamificationOverlays } from "@/components/gamification/gamification-overlays";
@@ -43,18 +44,20 @@ export default async function LocaleLayout(props: LocaleLayoutProps) {
     >
       <NextIntlClientProvider messages={messages}>
         <SolanaWalletProvider>
-          <AuthProvider>
-            <AnalyticsProvider>
-              <div className="grid-bg flex min-h-screen flex-col bg-[var(--bg)]">
-                <Header />
-                <main id="main-content" className="flex-1 pt-[60px]">
-                  {children}
-                </main>
-                <MobileBottomNav />
-                <GamificationOverlays />
-              </div>
-            </AnalyticsProvider>
-          </AuthProvider>
+          <PhantomConnectProvider>
+            <AuthProvider>
+              <AnalyticsProvider>
+                <div className="grid-bg flex min-h-screen flex-col bg-[var(--bg)]">
+                  <Header />
+                  <main id="main-content" className="flex-1 pt-[60px]">
+                    {children}
+                  </main>
+                  <MobileBottomNav />
+                  <GamificationOverlays />
+                </div>
+              </AnalyticsProvider>
+            </AuthProvider>
+          </PhantomConnectProvider>
         </SolanaWalletProvider>
       </NextIntlClientProvider>
     </ThemeProvider>

--- a/apps/web/src/components/auth/__tests__/auth-modal-phantom-failure.test.tsx
+++ b/apps/web/src/components/auth/__tests__/auth-modal-phantom-failure.test.tsx
@@ -1,0 +1,117 @@
+// @vitest-environment jsdom
+/* eslint-disable import/order -- vi.mock factories are hoisted above imports. */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import messages from "@/messages/en.json";
+
+/**
+ * PR #992 review, blocking finding 1: a Phantom connect failure BEFORE the
+ * redirect (closed Google popup, network blip, Phantom outage) used to leave
+ * this modal permanently stuck — the provider swallowed the rejection, the
+ * modal's catch never ran, `loading` never reset, and the Dialog's close guard
+ * (`if (!loading)`) made it unclosable with every button disabled.
+ *
+ * These tests drive the REAL modal against a rejecting connect and pin the
+ * recovery: error shown, buttons re-enabled, dialog closable.
+ */
+
+const phantom = vi.hoisted(() => ({
+  connect: vi.fn(async () => {}),
+}));
+vi.mock("@/components/auth/phantom-connect-provider", () => ({
+  usePhantomConnect: () => ({
+    enabled: true,
+    status: "idle",
+    address: null,
+    connect: phantom.connect,
+    disconnect: vi.fn(),
+  }),
+}));
+
+vi.mock("@solana/wallet-adapter-react-ui", () => ({
+  useWalletModal: () => ({ setVisible: vi.fn() }),
+}));
+vi.mock("@/lib/supabase/client", () => ({
+  createClient: () => ({ auth: { signInWithOAuth: vi.fn() } }),
+}));
+vi.mock("@/lib/analytics", () => ({ trackEvent: vi.fn() }));
+
+import { AuthModal } from "../auth-modal";
+
+function openModal() {
+  render(
+    <NextIntlClientProvider locale="en" messages={messages}>
+      <AuthModal />
+    </NextIntlClientProvider>
+  );
+  fireEvent.click(screen.getByRole("button", { name: /sign in/i }));
+  return screen.findByRole("dialog");
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("AuthModal — Phantom failure recovery (#992 review)", () => {
+  it("shows the error and re-enables every sign-in option after a rejected connect", async () => {
+    phantom.connect.mockRejectedValueOnce(new Error("popup closed"));
+    await openModal();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /continue with phantom/i })
+    );
+
+    // The localized failure message renders…
+    expect(
+      await screen.findByText(messages.auth.phantomSignInFailed)
+    ).toBeInTheDocument();
+    // …and `loading` reset, so nothing stays disabled — the learner can retry
+    // Phantom or fall back to any other method.
+    for (const name of [
+      /continue with phantom/i,
+      /connect solana wallet/i,
+      /sign in with google/i,
+      /sign in with github/i,
+    ]) {
+      expect(screen.getByRole("button", { name })).toBeEnabled();
+    }
+  });
+
+  it("keeps the dialog CLOSABLE after the failure — the stuck-modal bug", async () => {
+    phantom.connect.mockRejectedValueOnce(new Error("phantom outage"));
+    const dialog = await openModal();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /continue with phantom/i })
+    );
+    await screen.findByText(messages.auth.phantomSignInFailed);
+
+    // The Dialog's onOpenChange only honours a close when !loading. Before the
+    // fix `loading` was stuck on "phantom", so Escape did nothing, forever.
+    fireEvent.keyDown(dialog, { key: "Escape" });
+
+    await waitFor(() =>
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+    );
+  });
+
+  it("stays in the loading state while a connect is genuinely in flight", async () => {
+    // Never resolves — the tab would normally navigate away mid-redirect.
+    phantom.connect.mockImplementationOnce(() => new Promise(() => {}));
+    await openModal();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /continue with phantom/i })
+    );
+
+    // A spinner during a real redirect handoff is CORRECT — the guard exists
+    // to stop accidental dismissal mid-auth. Only failure must unstick it.
+    expect(
+      await screen.findByText(messages.auth.connecting)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /sign in with google/i })
+    ).toBeDisabled();
+  });
+});

--- a/apps/web/src/components/auth/__tests__/phantom-connect-provider.test.tsx
+++ b/apps/web/src/components/auth/__tests__/phantom-connect-provider.test.tsx
@@ -1,0 +1,148 @@
+// @vitest-environment jsdom
+/* eslint-disable import/order -- vi.mock factories are hoisted above imports. */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, act } from "@testing-library/react";
+
+const sdkMock = vi.hoisted(() => {
+  const listeners = new Map<string, Set<(d?: unknown) => void>>();
+  return {
+    listeners,
+    client: null as unknown,
+    autoConnect: vi.fn(async () => {}),
+    connect: vi.fn(async () => {}),
+    disconnect: vi.fn(async () => {}),
+    addresses: [] as Array<{ addressType: string; address: string }>,
+    emit(event: string) {
+      listeners.get(event)?.forEach((cb) => cb());
+    },
+    reset() {
+      listeners.clear();
+      this.addresses = [];
+      this.autoConnect.mockClear();
+      this.connect.mockClear();
+      this.disconnect.mockClear();
+    },
+  };
+});
+
+vi.mock("@phantom/browser-sdk", () => ({
+  AddressType: { solana: "Solana", ethereum: "Ethereum" },
+}));
+
+vi.mock("@/lib/phantom/client", () => ({
+  createPhantomClient: () =>
+    sdkMock.client === null
+      ? null
+      : {
+          autoConnect: sdkMock.autoConnect,
+          connect: sdkMock.connect,
+          disconnect: sdkMock.disconnect,
+          getAddresses: () => sdkMock.addresses,
+          on: (e: string, cb: () => void) => {
+            if (!sdkMock.listeners.has(e)) sdkMock.listeners.set(e, new Set());
+            sdkMock.listeners.get(e)!.add(cb);
+          },
+          off: (e: string, cb: () => void) => {
+            sdkMock.listeners.get(e)?.delete(cb);
+          },
+        },
+}));
+
+import {
+  PhantomConnectProvider,
+  usePhantomConnect,
+} from "../phantom-connect-provider";
+
+function Probe() {
+  const { enabled, status, address } = usePhantomConnect();
+  return (
+    <div>
+      <span data-testid="enabled">{String(enabled)}</span>
+      <span data-testid="status">{status}</span>
+      <span data-testid="address">{address ?? "none"}</span>
+    </div>
+  );
+}
+
+function renderProvider() {
+  return render(
+    <PhantomConnectProvider>
+      <Probe />
+    </PhantomConnectProvider>
+  );
+}
+
+beforeEach(() => {
+  sdkMock.reset();
+  sdkMock.client = {};
+});
+
+describe("PhantomConnectProvider (#985)", () => {
+  it("stays disabled and touches no SDK when the feature is gated off", async () => {
+    sdkMock.client = null;
+
+    renderProvider();
+
+    expect(screen.getByTestId("enabled")).toHaveTextContent("false");
+    // Gated off must mean no auth-service traffic at all, not just hidden UI.
+    expect(sdkMock.autoConnect).not.toHaveBeenCalled();
+  });
+
+  it("calls autoConnect to resume an existing session", async () => {
+    renderProvider();
+
+    await waitFor(() => expect(sdkMock.autoConnect).toHaveBeenCalled());
+    expect(screen.getByTestId("enabled")).toHaveTextContent("true");
+  });
+
+  // connect() is a redirect flow: this tab navigates away and its promise never
+  // resolves, so the address can only arrive via the `connect` event on the way
+  // back. Reading it from connect()'s return value would strand the UI.
+  it("picks up the Solana address from the connect event after the redirect", async () => {
+    renderProvider();
+    await waitFor(() => expect(sdkMock.autoConnect).toHaveBeenCalled());
+
+    sdkMock.addresses = [
+      { addressType: "Ethereum", address: "0xdead" },
+      { addressType: "Solana", address: "SoLaNaAddr111" },
+    ];
+    act(() => sdkMock.emit("connect"));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("address")).toHaveTextContent("SoLaNaAddr111")
+    );
+    expect(screen.getByTestId("status")).toHaveTextContent("connected");
+  });
+
+  // 7-day expiry and "Revoke permissions" in Phantom both arrive as `disconnect`.
+  it("returns to a clean idle state on disconnect, never a stuck spinner", async () => {
+    renderProvider();
+    await waitFor(() => expect(sdkMock.autoConnect).toHaveBeenCalled());
+
+    sdkMock.addresses = [{ addressType: "Solana", address: "SoLaNaAddr111" }];
+    act(() => sdkMock.emit("connect"));
+    await waitFor(() =>
+      expect(screen.getByTestId("status")).toHaveTextContent("connected")
+    );
+
+    sdkMock.addresses = [];
+    act(() => sdkMock.emit("disconnect"));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("status")).toHaveTextContent("idle")
+    );
+    expect(screen.getByTestId("address")).toHaveTextContent("none");
+  });
+
+  it("stays idle when there is no session to resume — the first-time visitor case", async () => {
+    sdkMock.autoConnect.mockRejectedValueOnce(new Error("no session"));
+
+    renderProvider();
+
+    await waitFor(() => expect(sdkMock.autoConnect).toHaveBeenCalled());
+    // A rejected autoConnect is the normal first-visit path, so the sign-in
+    // options must still render rather than the UI showing an error.
+    expect(screen.getByTestId("status")).toHaveTextContent("idle");
+    expect(screen.getByTestId("enabled")).toHaveTextContent("true");
+  });
+});

--- a/apps/web/src/components/auth/__tests__/phantom-connect-provider.test.tsx
+++ b/apps/web/src/components/auth/__tests__/phantom-connect-provider.test.tsx
@@ -146,3 +146,46 @@ describe("PhantomConnectProvider (#985)", () => {
     expect(screen.getByTestId("enabled")).toHaveTextContent("true");
   });
 });
+
+describe("PhantomConnectProvider — connect() rejection (#992 review)", () => {
+  function ConnectProbe() {
+    const { status, connect } = usePhantomConnect();
+    return (
+      <div>
+        <span data-testid="status2">{status}</span>
+        <button
+          onClick={() => {
+            // Swallow here the way a caller's catch would — the assertion is
+            // that the rejection REACHES this handler at all.
+            void connect("google").catch(() => {
+              document.title = "caller-saw-rejection";
+            });
+          }}
+        >
+          go
+        </button>
+      </div>
+    );
+  }
+
+  it("rethrows to the caller AND records error status — never swallows", async () => {
+    sdkMock.connect.mockRejectedValueOnce(new Error("popup closed"));
+
+    render(
+      <PhantomConnectProvider>
+        <ConnectProbe />
+      </PhantomConnectProvider>
+    );
+    await waitFor(() => expect(sdkMock.autoConnect).toHaveBeenCalled());
+
+    screen.getByRole("button", { name: "go" }).click();
+
+    // Both halves of the contract: hook consumers see `status: "error"`, and
+    // imperative callers get the rejection they need to reset their own UI
+    // (the AuthModal's loading flag — a swallowed error left it stuck forever).
+    await waitFor(() =>
+      expect(screen.getByTestId("status2")).toHaveTextContent("error")
+    );
+    await waitFor(() => expect(document.title).toBe("caller-saw-rejection"));
+  });
+});

--- a/apps/web/src/components/auth/auth-modal.tsx
+++ b/apps/web/src/components/auth/auth-modal.tsx
@@ -18,6 +18,8 @@ import { SolanaLogo } from "@/components/icons/solana-logo";
 import { createClient } from "@/lib/supabase/client";
 import { buildOAuthRedirect } from "@/lib/auth/oauth-redirect";
 import { trackEvent } from "@/lib/analytics";
+import { usePhantomConnect } from "@/components/auth/phantom-connect-provider";
+import { PhantomLogo } from "@/components/icons/phantom-logo";
 
 interface AuthModalProps {
   trigger?: React.ReactNode;
@@ -54,10 +56,12 @@ export function AuthModal({
     if (!isControlled) setInternalOpen(v);
     onOpenChange?.(v);
   };
-  const [loading, setLoading] = useState<"solana" | "google" | "github" | null>(
-    null
-  );
+  const [loading, setLoading] = useState<
+    "solana" | "google" | "github" | "phantom" | null
+  >(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const { enabled: phantomEnabled, connect: phantomConnect } =
+    usePhantomConnect();
   const { setVisible } = useWalletModal();
 
   // Return the learner to the page they signed in from (#619 review): the OAuth
@@ -101,6 +105,29 @@ export function AuthModal({
         err instanceof Error ? err.message : t("githubSignInFailed");
       console.error("[AuthModal] GitHub sign-in error:", message);
       setErrorMessage(t("githubSignInFailed"));
+      setLoading(null);
+    }
+  };
+
+  /**
+   * Phantom Connect (#985) — the no-wallet path. The learner signs in with
+   * Google and Phantom provisions a real wallet for them, so this is offered
+   * FIRST: it is the only option that asks nothing of someone with no wallet.
+   *
+   * `connect` redirects, so on success this tab is navigating away and there is
+   * no post-connect state to set here.
+   */
+  const handleConnectPhantom = async () => {
+    setLoading("phantom");
+    setErrorMessage(null);
+    trackEvent("auth_method_selected", { method: "phantom" });
+    try {
+      await phantomConnect("google");
+    } catch (err: unknown) {
+      const message =
+        err instanceof Error ? err.message : t("phantomSignInFailed");
+      console.error("[AuthModal] Phantom sign-in error:", message);
+      setErrorMessage(t("phantomSignInFailed"));
       setLoading(null);
     }
   };
@@ -156,6 +183,31 @@ export function AuthModal({
           </DialogDescription>
         </DialogHeader>
         <div className="mt-6 space-y-3">
+          {/* First: the only option that asks nothing of a learner with no
+              wallet. Hidden entirely when no app id is configured (#984). */}
+          {phantomEnabled && (
+            <div className="space-y-1.5">
+              <Button
+                variant="push"
+                className="h-12 w-full gap-3 text-sm font-medium"
+                onClick={handleConnectPhantom}
+                disabled={loading !== null}
+              >
+                {loading === "phantom" ? (
+                  <div className="h-5 w-5 animate-spin rounded-full border-2 border-current border-t-transparent" />
+                ) : (
+                  <PhantomLogo className="h-5 w-5 shrink-0 rounded-[5px]" />
+                )}
+                {loading === "phantom"
+                  ? t("connecting")
+                  : t("continueWithPhantom")}
+              </Button>
+              <p className="text-center text-xs text-text-3">
+                {t("phantomSubtitle")}
+              </p>
+            </div>
+          )}
+
           <Button
             variant="outline"
             className="h-12 w-full gap-3 text-sm font-medium"

--- a/apps/web/src/components/auth/auth-modal.tsx
+++ b/apps/web/src/components/auth/auth-modal.tsx
@@ -115,7 +115,14 @@ export function AuthModal({
    * FIRST: it is the only option that asks nothing of someone with no wallet.
    *
    * `connect` redirects, so on success this tab is navigating away and there is
-   * no post-connect state to set here.
+   * no post-connect state to set here. On FAILURE the provider rethrows after
+   * recording its own status — the catch below is what unsticks this modal
+   * (resets `loading`, which the Dialog's close guard keys off), so it must
+   * stay live code (PR #992 review).
+   *
+   * `"google"` is the one entry point by design; the client config also
+   * provisions `apple` and `injected` (lib/phantom/client.ts) for future
+   * buttons — provisioned ahead, not dead config.
    */
   const handleConnectPhantom = async () => {
     setLoading("phantom");

--- a/apps/web/src/components/auth/phantom-connect-provider.tsx
+++ b/apps/web/src/components/auth/phantom-connect-provider.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import { AddressType, type BrowserSDK } from "@phantom/browser-sdk";
+import { createPhantomClient } from "@/lib/phantom/client";
+
+/**
+ * Phantom Connect state for the app (#985, epic #983).
+ *
+ * Wraps `@phantom/browser-sdk` by hand rather than using `@phantom/react-sdk`,
+ * which needs React >= 19.0.1 while this app is on 18.3.1 (#989).
+ *
+ * The SDK touches `window` and talks to Phantom's auth service, so the client is
+ * created lazily on mount and never during render or on the server.
+ */
+
+export type PhantomAuthProvider = "google" | "apple" | "injected";
+
+export type PhantomConnectStatus =
+  | "idle"
+  | "connecting"
+  | "connected"
+  | "error";
+
+interface PhantomConnectValue {
+  /** False when no app id is configured — render no Phantom UI at all. */
+  enabled: boolean;
+  status: PhantomConnectStatus;
+  /** Connected Solana address, or null. */
+  address: string | null;
+  connect: (provider: PhantomAuthProvider) => Promise<void>;
+  disconnect: () => Promise<void>;
+}
+
+const PhantomConnectContext = createContext<PhantomConnectValue>({
+  enabled: false,
+  status: "idle",
+  address: null,
+  connect: async () => {},
+  disconnect: async () => {},
+});
+
+/** Picks the Solana address; we request no other type (see lib/phantom/client). */
+function solanaAddressOf(sdk: BrowserSDK): string | null {
+  const match = sdk
+    .getAddresses()
+    .find((a) => a.addressType === AddressType.solana);
+  return match?.address ?? null;
+}
+
+export function PhantomConnectProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const sdkRef = useRef<BrowserSDK | null>(null);
+  const [enabled, setEnabled] = useState(false);
+  const [status, setStatus] = useState<PhantomConnectStatus>("idle");
+  const [address, setAddress] = useState<string | null>(null);
+
+  useEffect(() => {
+    const sdk = createPhantomClient();
+    if (!sdk) return; // Gated off: no client, no listeners, no traffic.
+    sdkRef.current = sdk;
+    setEnabled(true);
+
+    // `connect` is a redirect flow: the app remounts on the way back, so the
+    // session is rehydrated through events + autoConnect rather than from
+    // connect()'s return value, which never resolves in the redirecting tab.
+    const onConnect = () => {
+      setAddress(solanaAddressOf(sdk));
+      setStatus("connected");
+    };
+    // A session lasts 7 days, and a learner can revoke the app from Phantom's
+    // Settings → Connected Apps at any time. Both arrive as `disconnect`, and
+    // must land us back in a clean signed-out state rather than a stuck spinner.
+    const onDisconnect = () => {
+      setAddress(null);
+      setStatus("idle");
+    };
+    sdk.on("connect", onConnect);
+    sdk.on("disconnect", onDisconnect);
+
+    // Order matters — the SDK documents autoConnect as "should be called after
+    // setting up event listeners", since it resolves an existing session and
+    // emits `connect` synchronously enough to be missed otherwise.
+    void sdk.autoConnect().catch((err: unknown) => {
+      // No session to resume is the normal case for a first-time visitor, not
+      // an error worth showing: stay idle so the sign-in options still render.
+      console.debug("[PhantomConnect] no session to resume:", err);
+    });
+
+    return () => {
+      sdk.off("connect", onConnect);
+      sdk.off("disconnect", onDisconnect);
+    };
+  }, []);
+
+  const connect = useCallback(async (provider: PhantomAuthProvider) => {
+    const sdk = sdkRef.current;
+    if (!sdk) return;
+    setStatus("connecting");
+    try {
+      await sdk.connect({ provider });
+      setAddress(solanaAddressOf(sdk));
+      setStatus("connected");
+    } catch (err) {
+      // Includes the learner closing the Phantom window — an ordinary outcome,
+      // so this resets to a retryable state instead of surfacing a hard failure.
+      console.error("[PhantomConnect] connect failed:", err);
+      setAddress(null);
+      setStatus("error");
+    }
+  }, []);
+
+  const disconnect = useCallback(async () => {
+    const sdk = sdkRef.current;
+    if (!sdk) return;
+    try {
+      await sdk.disconnect();
+    } finally {
+      // Local state clears either way: a failed disconnect must not leave the UI
+      // claiming a wallet the learner has already walked away from.
+      setAddress(null);
+      setStatus("idle");
+    }
+  }, []);
+
+  return (
+    <PhantomConnectContext.Provider
+      value={{ enabled, status, address, connect, disconnect }}
+    >
+      {children}
+    </PhantomConnectContext.Provider>
+  );
+}
+
+export function usePhantomConnect(): PhantomConnectValue {
+  return useContext(PhantomConnectContext);
+}

--- a/apps/web/src/components/auth/phantom-connect-provider.tsx
+++ b/apps/web/src/components/auth/phantom-connect-provider.tsx
@@ -112,11 +112,18 @@ export function PhantomConnectProvider({
       setAddress(solanaAddressOf(sdk));
       setStatus("connected");
     } catch (err) {
-      // Includes the learner closing the Phantom window — an ordinary outcome,
-      // so this resets to a retryable state instead of surfacing a hard failure.
-      console.error("[PhantomConnect] connect failed:", err);
+      // A failure BEFORE the redirect fires — closed Google popup, network
+      // blip, Phantom outage — is entirely possible: connect() only truly stops
+      // resolving once the tab actually navigates away.
       setAddress(null);
       setStatus("error");
+      // RETHROW after recording state (PR #992 review). Swallowing here made
+      // the AuthModal's catch dead code: its `loading` flag never reset, and
+      // since the Dialog only closes when !loading, one pre-redirect failure
+      // left the modal permanently stuck with every sign-in option disabled.
+      // The provider keeps `status` for hook consumers; imperative callers get
+      // the rejection they need to reset their own UI.
+      throw err;
     }
   }, []);
 

--- a/apps/web/src/components/icons/phantom-logo.tsx
+++ b/apps/web/src/components/icons/phantom-logo.tsx
@@ -1,0 +1,30 @@
+interface PhantomLogoProps {
+  className?: string;
+}
+
+/**
+ * Phantom's ghost mark, for the Connect entry point in the auth modal (#985).
+ *
+ * Decorative: the adjacent button label carries the meaning, so it is hidden
+ * from assistive tech rather than duplicating "Continue with Phantom".
+ */
+export function PhantomLogo({ className }: PhantomLogoProps) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 128 128"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+      focusable="false"
+    >
+      <rect width="128" height="128" rx="28" fill="#AB9FF2" />
+      <path
+        d="M104.5 64.2c0-19.2-15.6-34.7-34.8-34.7-19 0-34.4 15.1-34.8 34-.4 19.5 15.4 36.5 35 36.5h1.9c9 0 21-7 26-16.4.4-.7-.4-1.5-1.1-1.1-4.5 2.7-9.8 4.3-15.3 4.3-13.6 0-24.6-11-24.6-24.6 0-3.3 2.7-6 6-6s6 2.7 6 6c0 7 5.6 12.6 12.6 12.6S94 68.9 94 61.9v-.3c0-.9.7-1.6 1.6-1.6h7.3c.9 0 1.6.7 1.6 1.6v2.6z"
+        fill="#fff"
+      />
+      <circle cx="55" cy="59" r="5" fill="#AB9FF2" />
+      <circle cx="76" cy="59" r="5" fill="#AB9FF2" />
+    </svg>
+  );
+}

--- a/apps/web/src/lib/csp.ts
+++ b/apps/web/src/lib/csp.ts
@@ -133,6 +133,14 @@ export function buildCsp(nonce: string): string {
       "https://accounts.google.com https://*.googleapis.com",
       "https://www.googletagmanager.com https://www.google-analytics.com https://*.google-analytics.com https://stats.g.doubleclick.net",
       "https://*.posthog.com https://*.sentry.io https://*.ingest.sentry.io",
+      // Phantom Connect (#985/#992 review): the browser-sdk XHRs these three —
+      // auth.phantom.app (session/auth API), api.phantom.app (wallet API),
+      // time.phantom.app (clock sync) — origins read from the SDK dist, pinned
+      // exactly rather than *.phantom.app. Without them every enabled-state
+      // attempt dies as a CSP violation before the redirect. The redirect
+      // itself (connect.phantom.app) is a top-level navigation, which CSP does
+      // not govern, and the SDK creates no iframes — so frame-src is untouched.
+      "https://auth.phantom.app https://api.phantom.app https://time.phantom.app",
     ].join(" "),
 
     // Frames: Google OAuth may use frames; lesson videos embed the YouTube and

--- a/apps/web/src/lib/env.ts
+++ b/apps/web/src/lib/env.ts
@@ -73,6 +73,15 @@ const publicEnvSchema = z.object({
   ),
   // Optional Sentry DSN (public/safe to expose). Unset disables Sentry.
   NEXT_PUBLIC_SENTRY_DSN: z.url().optional().or(z.literal("")),
+  // Optional Phantom Connect app id (#984). Public, domain-bound client
+  // identifier from Phantom Portal — it ships in the client bundle by design,
+  // and Portal's allowed-domains list is what actually scopes it.
+  //
+  // Optional on purpose, like the analytics keys: unset means embedded wallets
+  // are simply off. A build must never fail for want of it, and no code path may
+  // assume a wallet is available — the existing SIWS login stays the only
+  // guaranteed route in.
+  NEXT_PUBLIC_PHANTOM_APP_ID: z.string().optional().or(z.literal("")),
 });
 
 const parsed = publicEnvSchema.safeParse({
@@ -81,6 +90,7 @@ const parsed = publicEnvSchema.safeParse({
   NEXT_PUBLIC_SOLANA_RPC_URL: process.env.NEXT_PUBLIC_SOLANA_RPC_URL,
   NEXT_PUBLIC_APP_URL: process.env.NEXT_PUBLIC_APP_URL,
   NEXT_PUBLIC_SENTRY_DSN: process.env.NEXT_PUBLIC_SENTRY_DSN,
+  NEXT_PUBLIC_PHANTOM_APP_ID: process.env.NEXT_PUBLIC_PHANTOM_APP_ID,
 });
 
 if (!parsed.success) {

--- a/apps/web/src/lib/phantom/__tests__/client.test.ts
+++ b/apps/web/src/lib/phantom/__tests__/client.test.ts
@@ -1,0 +1,75 @@
+/* eslint-disable import/order -- vi.mock factories are hoisted above imports;
+   the env module and the SDK must both be stubbed before the graph loads. */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const envMock = vi.hoisted(() => ({
+  env: { NEXT_PUBLIC_PHANTOM_APP_ID: undefined as string | undefined },
+}));
+vi.mock("@/lib/env", () => envMock);
+
+// Capture the config the SDK is constructed with, without standing up the real
+// client (which would reach out to Phantom's auth service).
+const sdk = vi.hoisted(() => ({
+  ctorCalls: [] as Array<Record<string, unknown>>,
+}));
+vi.mock("@phantom/browser-sdk", () => ({
+  AddressType: { solana: "Solana", ethereum: "Ethereum" },
+  BrowserSDK: class {
+    constructor(config: Record<string, unknown>) {
+      sdk.ctorCalls.push(config);
+    }
+  },
+}));
+
+import { createPhantomClient } from "../client";
+
+beforeEach(() => {
+  envMock.env.NEXT_PUBLIC_PHANTOM_APP_ID = undefined;
+  sdk.ctorCalls.length = 0;
+});
+
+describe("Phantom Connect client (#985)", () => {
+  it("returns null and constructs nothing when the feature is gated off", () => {
+    expect(createPhantomClient()).toBeNull();
+    // Not merely null — the SDK must never be instantiated, so no auth-service
+    // traffic happens for an app that has not opted in.
+    expect(sdk.ctorCalls).toHaveLength(0);
+  });
+
+  it("passes the configured app id through", () => {
+    envMock.env.NEXT_PUBLIC_PHANTOM_APP_ID = "app-id-123";
+
+    expect(createPhantomClient()).not.toBeNull();
+    expect(sdk.ctorCalls[0]?.appId).toBe("app-id-123");
+  });
+
+  // The load-bearing setting for the whole Phantom-over-Privy decision: a
+  // "user-wallet" belongs to the learner's Phantom account, so signing into the
+  // Phantom app with the same Google account surfaces this same wallet. An
+  // "app-wallet" would be scoped to this app and never appear there.
+  it("requests a user-wallet, so the wallet follows the learner into Phantom", () => {
+    envMock.env.NEXT_PUBLIC_PHANTOM_APP_ID = "app-id-123";
+
+    createPhantomClient();
+
+    expect(sdk.ctorCalls[0]?.embeddedWalletType).toBe("user-wallet");
+  });
+
+  it("requests Solana addresses only", () => {
+    envMock.env.NEXT_PUBLIC_PHANTOM_APP_ID = "app-id-123";
+
+    createPhantomClient();
+
+    expect(sdk.ctorCalls[0]?.addressTypes).toEqual(["Solana"]);
+  });
+
+  it("offers the extension alongside social login, so both cohorts share one path", () => {
+    envMock.env.NEXT_PUBLIC_PHANTOM_APP_ID = "app-id-123";
+
+    createPhantomClient();
+
+    const providers = sdk.ctorCalls[0]?.providers as string[];
+    expect(providers).toContain("google");
+    expect(providers).toContain("injected");
+  });
+});

--- a/apps/web/src/lib/phantom/__tests__/config.test.ts
+++ b/apps/web/src/lib/phantom/__tests__/config.test.ts
@@ -1,0 +1,52 @@
+/* eslint-disable import/order -- vi.mock factories are hoisted above imports;
+   the env module must be stubbed before the graph loads. */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// `env` validates and freezes process.env at module init, so mutating
+// process.env in a test would never reach it. Mock the module instead.
+const envMock = vi.hoisted(() => ({
+  env: { NEXT_PUBLIC_PHANTOM_APP_ID: undefined as string | undefined },
+}));
+vi.mock("@/lib/env", () => envMock);
+
+import { getPhantomAppId, isPhantomConnectEnabled } from "../config";
+
+beforeEach(() => {
+  envMock.env.NEXT_PUBLIC_PHANTOM_APP_ID = undefined;
+});
+
+describe("Phantom Connect feature gate (#984)", () => {
+  it("is OFF when the app id is unset — the app must build and run without it", () => {
+    expect(getPhantomAppId()).toBeNull();
+    expect(isPhantomConnectEnabled()).toBe(false);
+  });
+
+  it("is OFF for an empty string — an unset Vercel var arrives as ''", () => {
+    envMock.env.NEXT_PUBLIC_PHANTOM_APP_ID = "";
+
+    expect(getPhantomAppId()).toBeNull();
+    expect(isPhantomConnectEnabled()).toBe(false);
+  });
+
+  it("is OFF for whitespace only, rather than sending an unusable id to Phantom", () => {
+    // A stray space in .env.local or a dashboard field is a misconfiguration.
+    // Failing here beats failing later at connect time with an opaque SDK error.
+    envMock.env.NEXT_PUBLIC_PHANTOM_APP_ID = "   ";
+
+    expect(getPhantomAppId()).toBeNull();
+    expect(isPhantomConnectEnabled()).toBe(false);
+  });
+
+  it("is ON with a configured app id", () => {
+    envMock.env.NEXT_PUBLIC_PHANTOM_APP_ID = "app-id-123";
+
+    expect(getPhantomAppId()).toBe("app-id-123");
+    expect(isPhantomConnectEnabled()).toBe(true);
+  });
+
+  it("trims surrounding whitespace so the id sent to Phantom is exact", () => {
+    envMock.env.NEXT_PUBLIC_PHANTOM_APP_ID = "  app-id-123  ";
+
+    expect(getPhantomAppId()).toBe("app-id-123");
+  });
+});

--- a/apps/web/src/lib/phantom/client.ts
+++ b/apps/web/src/lib/phantom/client.ts
@@ -1,0 +1,55 @@
+/**
+ * Configured Phantom Connect client (#985, epic #983).
+ *
+ * Builds the one `BrowserSDK` instance the app uses, or returns `null` when the
+ * feature is gated off. Nothing else may construct a `BrowserSDK` — the config
+ * below carries decisions that are easy to get wrong and expensive to discover
+ * later.
+ */
+
+import { AddressType, BrowserSDK } from "@phantom/browser-sdk";
+import { getPhantomAppId } from "./config";
+
+/**
+ * Sign-in methods offered in the Connect modal.
+ *
+ * `injected` is deliberately included: a learner who already runs the Phantom
+ * extension connects it directly and NO embedded wallet is created, so the
+ * crypto-native and email cohorts share one integration path instead of two.
+ */
+const AUTH_PROVIDERS = ["google", "apple", "injected"] as const;
+
+/**
+ * Solana only. The academy program, the XP mint and every credential live on
+ * Solana, so requesting other address types would provision addresses we can
+ * neither use nor explain to a learner.
+ */
+const ADDRESS_TYPES = [AddressType.solana];
+
+/**
+ * Creates the Phantom Connect client, or `null` when no app id is configured.
+ *
+ * Returning `null` rather than throwing keeps the gate honest: callers render
+ * nothing and load nothing, and SIWS remains the guaranteed way into the app.
+ */
+export function createPhantomClient(): BrowserSDK | null {
+  const appId = getPhantomAppId();
+  if (!appId) return null;
+
+  return new BrowserSDK({
+    appId,
+    providers: [...AUTH_PROVIDERS],
+    addressTypes: ADDRESS_TYPES,
+    // THE setting that makes graduation work. A "user-wallet" belongs to the
+    // learner's own Phantom account, so downloading Phantom and choosing
+    // "Continue with Google" with the same account surfaces this exact wallet —
+    // same address, credentials intact, no export or import step.
+    //
+    // "app-wallet" would scope the wallet to this app instead. Credentials would
+    // still mint correctly, but the wallet would NEVER appear in the learner's
+    // Phantom app, silently destroying the reason we chose Phantom over an
+    // undifferentiated embedded-wallet vendor. Set explicitly, not left to the
+    // SDK default, because that default is not ours to rely on.
+    embeddedWalletType: "user-wallet",
+  });
+}

--- a/apps/web/src/lib/phantom/config.ts
+++ b/apps/web/src/lib/phantom/config.ts
@@ -1,0 +1,48 @@
+/**
+ * Phantom Connect configuration and feature gate (#984, epic #983).
+ *
+ * Phantom Connect gives learners a real Phantom wallet from an email/Google
+ * sign-in — no extension, no seed phrase. This module is the single place that
+ * decides whether that path is available; nothing else may read the app id.
+ *
+ * ## Why a gate at all
+ *
+ * The whole integration is optional infrastructure. SIWS remains the guaranteed
+ * way into the app, so an unset app id must degrade to "embedded wallets are
+ * off" rather than to a broken build or a dead sign-in button. That is why
+ * `NEXT_PUBLIC_PHANTOM_APP_ID` is optional in `lib/env.ts`, exactly like the
+ * analytics keys.
+ *
+ * ## Why `@phantom/browser-sdk` and not `@phantom/react-sdk`
+ *
+ * `@phantom/react-sdk` declares `peerDependencies: { react: ">=19.0.1" }` and
+ * this app is on React 18.3.1, so it cannot be installed without a React 19
+ * upgrade across the component tree (#989). The browser SDK carries no React
+ * peer dependency and is the same underlying implementation — the React package
+ * depends on it — so we lose the prebuilt bindings, not the capability.
+ */
+
+import { env } from "@/lib/env";
+
+/**
+ * The configured Phantom Connect app id, or `null` when the feature is off.
+ *
+ * Whitespace-only is treated as unset: a blank value in a Vercel dashboard or a
+ * trailing space in `.env.local` is a misconfiguration, and reading it as
+ * "configured" would send an unusable id to Phantom and fail at connect time
+ * instead of here.
+ */
+export function getPhantomAppId(): string | null {
+  const raw = env.NEXT_PUBLIC_PHANTOM_APP_ID?.trim();
+  return raw ? raw : null;
+}
+
+/**
+ * Whether the Phantom Connect path may be offered to a learner.
+ *
+ * Callers must treat `false` as "render nothing and load nothing" — no SDK
+ * import, no network call, no placeholder button.
+ */
+export function isPhantomConnectEnabled(): boolean {
+  return getPhantomAppId() !== null;
+}

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -88,7 +88,10 @@
     "keepProgressTitle": "Save your progress",
     "keepProgressSubtitle": "Sign in to keep the work you just did. It's saved on this device until you do.",
     "later": "Later",
-    "progressSavedLocally": "No rush — your progress stays saved on this device."
+    "progressSavedLocally": "No rush — your progress stays saved on this device.",
+    "continueWithPhantom": "Continue with Phantom",
+    "phantomSubtitle": "Sign in with Google — we'll set up your wallet",
+    "phantomSignInFailed": "Phantom sign-in failed. Please try again."
   },
   "landing": {
     "poweredBy": "Powered by",

--- a/apps/web/src/messages/es.json
+++ b/apps/web/src/messages/es.json
@@ -88,7 +88,10 @@
     "keepProgressTitle": "Guarda tu progreso",
     "keepProgressSubtitle": "Inicia sesión para conservar lo que acabas de hacer. Se guarda en este dispositivo hasta entonces.",
     "later": "Más tarde",
-    "progressSavedLocally": "Sin prisa: tu progreso permanece guardado en este dispositivo."
+    "progressSavedLocally": "Sin prisa: tu progreso permanece guardado en este dispositivo.",
+    "continueWithPhantom": "Continuar con Phantom",
+    "phantomSubtitle": "Inicia sesión con Google — creamos tu billetera",
+    "phantomSignInFailed": "Error al iniciar sesión con Phantom. Inténtalo de nuevo."
   },
   "landing": {
     "poweredBy": "Con el apoyo de",

--- a/apps/web/src/messages/pt-BR.json
+++ b/apps/web/src/messages/pt-BR.json
@@ -88,7 +88,10 @@
     "keepProgressTitle": "Salve seu progresso",
     "keepProgressSubtitle": "Entre para manter o que você acabou de fazer. Fica salvo neste dispositivo até lá.",
     "later": "Depois",
-    "progressSavedLocally": "Sem pressa — seu progresso continua salvo neste dispositivo."
+    "progressSavedLocally": "Sem pressa — seu progresso continua salvo neste dispositivo.",
+    "continueWithPhantom": "Continuar com Phantom",
+    "phantomSubtitle": "Entre com o Google — criamos sua carteira",
+    "phantomSignInFailed": "Falha ao entrar com a Phantom. Tente novamente."
   },
   "landing": {
     "poweredBy": "Com apoio de",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,6 +96,9 @@ importers:
       '@noble/hashes':
         specifier: ^1.8.0
         version: 1.8.0
+      '@phantom/browser-sdk':
+        specifier: ^2.0.2
+        version: 2.0.2(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
       '@phosphor-icons/react':
         specifier: ^2.1.10
         version: 2.1.10(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -467,11 +470,28 @@ importers:
 
 packages:
 
+  '@0no-co/graphql.web@1.3.3':
+    resolution: {integrity: sha512-4gFGBdyaFmQ6n9euhp5JtIGS4ZeivwDr1tCPENUxTvy5wyv532yOtFCr9zzYAJh1s6uibgC+TRXUcay+mxzCoQ==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
+    peerDependenciesMeta:
+      graphql:
+        optional: true
+
+  '@0no-co/graphqlsp@1.17.3':
+    resolution: {integrity: sha512-4PPvxDPmbntddpgMyA3VId5/E9YGdRuuS/mW+THOvtTx/C79Pf+lN28LkNNACJrF9L7YACiAJelyOkC6LqUzvw==}
+    peerDependencies:
+      graphql: ^15.5.0 || ^16.0.0 || ^17.0.0
+      typescript: ^5.0.0 || ^6.0.0
+
   '@acemir/cssom@0.9.31':
     resolution: {integrity: sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==}
 
   '@adobe/css-tools@4.5.0':
     resolution: {integrity: sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==}
+
+  '@adraffy/ens-normalize@1.11.1':
+    resolution: {integrity: sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==}
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
@@ -1219,6 +1239,31 @@ packages:
   '@formatjs/intl-localematcher@0.8.13':
     resolution: {integrity: sha512-kHEAFOkeJSPNi7c5PaKaRjxcBrJwzzt81ifUu+8uve1EDW/VJl83KsxmqgqNZLzcFEhSliZGvx3+pk/RH0IOmg==}
 
+  '@gql.tada/cli-utils@1.9.3':
+    resolution: {integrity: sha512-P1TiXErpJwIi73sei5fzwGA/SOeCaIHFWFR4RdZPLwqxZzQN0T6MAUivzXBgKCORL67rvYnLaaPoWeqWq/61ug==}
+    peerDependencies:
+      '@0no-co/graphqlsp': ^1.16.0
+      '@gql.tada/svelte-support': 1.0.3
+      '@gql.tada/vue-support': 1.0.3
+      graphql: ^15.5.0 || ^16.0.0 || ^17.0.0
+      typescript: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@gql.tada/svelte-support':
+        optional: true
+      '@gql.tada/vue-support':
+        optional: true
+
+  '@gql.tada/internal@1.2.2':
+    resolution: {integrity: sha512-4lZcElPP6MC8Ct8KN70LR2WQsHjbAsyAmTGG09VsOPhx738UFIYaL0S1XiI2pqq2tj/sDs/y3b9jvKoWGL7iuQ==}
+    peerDependencies:
+      graphql: ^15.5.0 || ^16.0.0 || ^17.0.0
+      typescript: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  '@graphql-typed-document-node/core@3.2.0':
+    resolution: {integrity: sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==}
+    peerDependencies:
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
   '@humanwhocodes/config-array@0.13.0':
     resolution: {integrity: sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==}
     engines: {node: '>=10.10.0'}
@@ -1687,6 +1732,14 @@ packages:
     resolution: {integrity: sha512-47XIizs9XZXvuJgoaJUIE2lFoID8ugvc0jzSHP+Ptfk8nTbnR8g788wv48N03Kx0UkAv559HWRQ3yzOgzlRNUA==}
     engines: {node: '>= 18'}
 
+  '@mysten/bcs@0.11.1':
+    resolution: {integrity: sha512-xP85isNSYUCHd3O/g+TmZYmg4wK6cU8q/n/MebkIGP4CYVJZz2wU/G24xIZ3wI+0iTop4dfgA5kYrg/DQKCUzA==}
+
+  '@mysten/sui.js@0.50.1':
+    resolution: {integrity: sha512-AY0wb4n6PMTRsDGygzrrTHUK/m5KwKZ4aQcN9cayiwsq2iIhfjGo7uuqMA7Y5UiqvLCoF+z7Ig14Q5qejQ/S/w==}
+    engines: {node: '>=16'}
+    deprecated: This package has been renamed to @mysten/sui, please update to use the renamed package.
+
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
@@ -1748,8 +1801,19 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@noble/ciphers@1.3.0':
+    resolution: {integrity: sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==}
+    engines: {node: ^14.21.3 || >=16}
+
+  '@noble/curves@1.2.0':
+    resolution: {integrity: sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==}
+
   '@noble/curves@1.7.0':
     resolution: {integrity: sha512-UTMhXK9SeDhFJVrHeUJ5uZlI6ajXg10O6Ddocf9S6GjbSBVZsJo88HzKwXznNfGpMTRDyJkqMjNDPYgf0qFWnw==}
+    engines: {node: ^14.21.3 || >=16}
+
+  '@noble/curves@1.9.1':
+    resolution: {integrity: sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==}
     engines: {node: ^14.21.3 || >=16}
 
   '@noble/curves@1.9.7':
@@ -2100,6 +2164,53 @@ packages:
   '@parcel/watcher@2.6.0':
     resolution: {integrity: sha512-7FNeNl8NCE7aINx7WXiKQrPYZWC/hvrTsmk6zmxbI7LTXE7hVek/n8AfVgpe2y82zl3w0HvCHN0bVKMBoJcC0w==}
     engines: {node: '>= 10.0.0'}
+
+  '@phantom/api-key-stamper@2.0.2':
+    resolution: {integrity: sha512-TCjfFN7FrNuIQzHqgQOcBR/Vu32Jfr+y2/9VVwRDdPgRwrm0oNDQPIuCUhd7QAWmlotBtNnrZh9fDxc5DeCo7g==}
+
+  '@phantom/auth2@2.0.2':
+    resolution: {integrity: sha512-0XN/mNxB8s62GeCJwZSJtz8Z2ek4pf643iYXKBjNcl4E8IkQnN3cgC/cg5FDpe197EPx7lKdcgYO78Cle09I5A==}
+
+  '@phantom/base64url@2.0.2':
+    resolution: {integrity: sha512-HnSyXM/8B4KlsbHoSsuDqA0WgBZ5kQRUuTZidAdR2yis1S5HeaYMUXaLfV447h0mFx1BTw1oG01zPsAT1/UPxQ==}
+
+  '@phantom/browser-injected-sdk@2.0.2':
+    resolution: {integrity: sha512-EpxgiT3BLrSjQ/cwX0htaVab46QT9Ye8Vr1WhbLPt4ZDd+zGToKIvCLPnUU5j/3v7DJhgBtA/LaceMB7/0giGQ==}
+
+  '@phantom/browser-sdk@2.0.2':
+    resolution: {integrity: sha512-fGcSR5o355Sl8NHMni8+TAsBJ/nVcVxOtOFiEjjzZHtbriMAC925lLhVprgpg9oRj5qze3lj2jOnpl5plmhEug==}
+
+  '@phantom/chain-interfaces@2.0.2':
+    resolution: {integrity: sha512-HgWDvODDulbLZZJYBtapUhUwE3CIqLuU6mwlLgu7E/w5dcGzQ+VZCN34bgtJTXc7ggl3f1HkC8JKRjPfPyOdSw==}
+
+  '@phantom/client@2.0.2':
+    resolution: {integrity: sha512-jMdkxBEfPpja+6QaTwusqhlHg9/a7achn2mh/WptMe5rX1v3TCwPmPy9vfWIj5U9QygyKe75U/exPB8jggz0gQ==}
+
+  '@phantom/constants@2.0.2':
+    resolution: {integrity: sha512-/27SINbXbpB98+LFoYSPcbFKD2vNPCzF1fmcs/v/hGds7U36XVvY5yeln4EUSHe6vLciXU5vsJ/yrbtt+vcSjQ==}
+
+  '@phantom/crypto@2.0.2':
+    resolution: {integrity: sha512-guOt2fViWDLyj0xUeOP3xLtPn+Y4fhbmn0JbHSGf+dgU2QD/3Xx1GNFJRttLOZ05BEMPg2UN5j3BePySi6R9Wg==}
+
+  '@phantom/embedded-provider-core@2.0.2':
+    resolution: {integrity: sha512-XBONpD1eQ/GvzEVXVpSCidBy8fGZF7KDQWOgfiy4Z/+qzjAZeWYG01W0Flo2SChfGxS+hDGMwPti7/P0hmSe7g==}
+    peerDependencies:
+      typescript: '>=4.5.0'
+
+  '@phantom/indexed-db-stamper@2.0.2':
+    resolution: {integrity: sha512-5onsgIr9ylBLz3d2fTOFH0gYt4IG+ZcyebP4PamNqseLZjHp8ttpR7UVa1lxdA9T5plJB0BpWZQfV8kBkcOyEA==}
+
+  '@phantom/openapi-wallet-service@0.1.11':
+    resolution: {integrity: sha512-EWu0qpzNjKNuO32tMYoD4Wy5yfsJdJ1OZu1RFBW7BXgFNt34t7oY0EFho5v3OPQ/jFfYDesaf6HG5cB4LYib8Q==}
+
+  '@phantom/parsers@2.0.2':
+    resolution: {integrity: sha512-HTggfaqI9/fU4IN2Aj/7HaF9vn9R1bE6vhU8EGZqZzaL84mTGUQdr36JHpDrdA38U3J9PRp+LO+erxEEA9BadQ==}
+
+  '@phantom/sdk-types@2.0.2':
+    resolution: {integrity: sha512-2xvIZZrCDbj4lDcSh4YWf3ODISubym9lha/FiVyrKoyz7aEhvT4YF2qm4Z/K42uBvKyC0FcdBtjAMiQiylyuBQ==}
+
+  '@phantom/utils@2.0.2':
+    resolution: {integrity: sha512-d0/cezg2Dd95lQe0RlZrAWK+jQ3t1KnE30oVmFkJZF3K/X05XIX9MO02wfVnXsPESX+bENuJIr12kRIQbSBA7g==}
 
   '@phosphor-icons/react@2.1.10':
     resolution: {integrity: sha512-vt8Tvq8GLjheAZZYa+YG/pW7HDbov8El/MANW8pOAz4eGxrwhnbfrQZq0Cp4q8zBEu8NIhHdnr+r8thnfRSNYA==}
@@ -2774,6 +2885,15 @@ packages:
   '@scure/base@1.2.1':
     resolution: {integrity: sha512-DGmGtC8Tt63J5GfHgfl5CuAXh96VF/LD8K9Hr/Gv0J2lAoRGlPOMpqMpMbCTOoOJMZCk2Xt+DskdDyn6dEFdzQ==}
 
+  '@scure/base@1.2.6':
+    resolution: {integrity: sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==}
+
+  '@scure/bip32@1.7.0':
+    resolution: {integrity: sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==}
+
+  '@scure/bip39@1.6.0':
+    resolution: {integrity: sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==}
+
   '@scure/starknet@1.1.0':
     resolution: {integrity: sha512-83g3M6Ix2qRsPN4wqLDqiRZ2GBNbjVWfboJE/9UjfG+MHr6oDSu/CWgy8hsBSJejr09DkkL+l0Ze4KVrlCIdtQ==}
 
@@ -2936,6 +3056,18 @@ packages:
   '@solana-mobile/wallet-standard-mobile@0.4.4':
     resolution: {integrity: sha512-LMvqkS5/aEH+EiDje9Dk351go6wO3POysgmobM4qm8RsG5s6rDAW3U0zA+5f2coGCTyRx8BKE1I/9nHlwtBuow==}
 
+  '@solana/addresses@2.3.0':
+    resolution: {integrity: sha512-ypTNkY2ZaRFpHLnHAgaW8a83N0/WoqdFvCqf4CQmnMdFsZSdC7qOwcbd7YzdaQn9dy+P2hybewzB+KP7LutxGA==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
+
+  '@solana/assertions@2.3.0':
+    resolution: {integrity: sha512-Ekoet3khNg3XFLN7MIz8W31wPQISpKUGDGTylLptI+JjCDWx3PIa88xjEMqFo02WJ8sBj2NLV64Xg1sBcsHjZQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
+
   '@solana/buffer-layout-utils@0.2.0':
     resolution: {integrity: sha512-szG4sxgJGktbuZYDg2FfNmkMi0DYQoVjN2h7ta1W1hPrwzarcFLBq9UpX1UjNXsNpT9dn+chgprtWGioUAr4/g==}
     engines: {node: '>= 10'}
@@ -2966,6 +3098,12 @@ packages:
     peerDependencies:
       typescript: '>=5'
 
+  '@solana/codecs-data-structures@2.3.0':
+    resolution: {integrity: sha512-qvU5LE5DqEdYMYgELRHv+HMOx73sSoV1ZZkwIrclwUmwTbTaH8QAJURBj0RhQ/zCne7VuLLOZFFGv6jGigWhSw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
+
   '@solana/codecs-numbers@2.0.0-rc.1':
     resolution: {integrity: sha512-J5i5mOkvukXn8E3Z7sGIPxsThRCgSdgTWJDQeZvucQ9PT6Y3HiVXJ0pcWiOWAoQ3RX8e/f4I3IC+wE6pZiJzDQ==}
     peerDependencies:
@@ -2988,6 +3126,13 @@ packages:
     peerDependencies:
       fastestsmallesttextencoderdecoder: ^1.0.22
       typescript: '>=5'
+
+  '@solana/codecs-strings@2.3.0':
+    resolution: {integrity: sha512-y5pSBYwzVziXu521hh+VxqUtp0hYGTl1eWGoc1W+8mdvBdC1kTqm/X7aYQw33J42hw03JjryvYOvmGgk3Qz/Ug==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      fastestsmallesttextencoderdecoder: ^1.0.22
+      typescript: '>=5.3.3'
 
   '@solana/codecs-strings@4.0.0':
     resolution: {integrity: sha512-XvyD+sQ1zyA0amfxbpoFZsucLoe+yASQtDiLUGMDg5TZ82IHE3B7n82jE8d8cTAqi0HgqQiwU13snPhvg1O0Ow==}
@@ -3021,10 +3166,40 @@ packages:
     peerDependencies:
       typescript: '>=5.3.3'
 
+  '@solana/functional@2.3.0':
+    resolution: {integrity: sha512-AgsPh3W3tE+nK3eEw/W9qiSfTGwLYEvl0rWaxHht/lRcuDVwfKRzeSa5G79eioWFFqr+pTtoCr3D3OLkwKz02Q==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
+
+  '@solana/instructions@2.3.0':
+    resolution: {integrity: sha512-PLMsmaIKu7hEAzyElrk2T7JJx4D+9eRwebhFZpy2PXziNSmFF929eRHKUsKqBFM3cYR1Yy3m6roBZfA+bGE/oQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
+
+  '@solana/keys@2.3.0':
+    resolution: {integrity: sha512-ZVVdga79pNH+2pVcm6fr2sWz9HTwfopDVhYb0Lh3dh+WBmJjwkabXEIHey2rUES7NjFa/G7sV8lrUn/v8LDCCQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
+
+  '@solana/nominal-types@2.3.0':
+    resolution: {integrity: sha512-uKlMnlP4PWW5UTXlhKM8lcgIaNj8dvd8xO4Y9l+FVvh9RvW2TO0GwUO6JCo7JBzCB0PSqRJdWWaQ8pu1Ti/OkA==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
+
   '@solana/options@2.0.0-rc.1':
     resolution: {integrity: sha512-mLUcR9mZ3qfHlmMnREdIFPf9dpMc/Bl66tLSOOWxw4ml5xMT2ohFn7WGqoKcu/UHkT9CrC6+amEdqCNvUqI7AA==}
     peerDependencies:
       typescript: '>=5'
+
+  '@solana/rpc-types@2.3.0':
+    resolution: {integrity: sha512-O09YX2hED2QUyGxrMOxQ9GzH1LlEwwZWu69QbL4oYmIf6P5dzEEHcqRY6L1LsDVqc/dzAdEs/E1FaPrcIaIIPw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
 
   '@solana/spl-token-group@0.0.7':
     resolution: {integrity: sha512-V1N/iX7Cr7H0uazWUT2uk27TMqlqedpXHRqqAbVO2gvmJyT0E0ummMEAVQeXZ05ZhQ/xF39DLSdBp90XebWEug==}
@@ -3043,6 +3218,18 @@ packages:
     engines: {node: '>=16'}
     peerDependencies:
       '@solana/web3.js': ^1.95.5
+
+  '@solana/transaction-messages@2.3.0':
+    resolution: {integrity: sha512-bgqvWuy3MqKS5JdNLH649q+ngiyOu5rGS3DizSnWwYUd76RxZl1kN6CoqHSrrMzFMvis6sck/yPGG3wqrMlAww==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
+
+  '@solana/transactions@2.3.0':
+    resolution: {integrity: sha512-LnTvdi8QnrQtuEZor5Msje61sDpPstTVwKg4y81tNxDhiyomjuvnSNLAq6QsB9gIxUqbNzPZgOG9IU4I4/Uaug==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
 
   '@solana/wallet-adapter-backpack@0.1.14':
     resolution: {integrity: sha512-DfNLd5S1P7rmrgqMp+jRd21ryuXUxia1mu4qmZ+cau1NGFO2v5ep14LhzYXmqPde6kgbzPLPkLdRnkffLdI4TA==}
@@ -3147,6 +3334,9 @@ packages:
 
   '@starknet-io/types-js@0.7.10':
     resolution: {integrity: sha512-1VtCqX4AHWJlRRSYGSn+4X1mqolI1Tdq62IwzoU2vUuEE72S1OlEeGhpvd6XsdqXcfHmVzYfj8k1XtKBQqwo9w==}
+
+  '@suchipi/femver@1.0.0':
+    resolution: {integrity: sha512-bprE8+K5V+DPX7q2e2K57ImqNBdfGHDIWaGI5xHxZoxbKOuQZn4wzPiUxOAHnsUr3w3xHrWXwN7gnG/iIuEMIg==}
 
   '@supabase/auth-js@2.95.3':
     resolution: {integrity: sha512-vD2YoS8E2iKIX0F7EwXTmqhUpaNsmbU6X2R0/NdFcs02oEfnHyNP/3M716f3wVJ2E5XHGiTFXki6lRckhJ0Thg==}
@@ -3419,6 +3609,9 @@ packages:
 
   '@types/node@22.19.9':
     resolution: {integrity: sha512-PD03/U8g1F9T9MI+1OBisaIARhSzeidsUjQaf51fOxrfjeiKN9bLVO06lHuHYjxdnqLWJijJHfqXPSJri2EM2A==}
+
+  '@types/node@22.7.5':
+    resolution: {integrity: sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==}
 
   '@types/pg-pool@2.0.7':
     resolution: {integrity: sha512-U4CwmGVQcbEuqpyju8/ptOKg6gEC+Tqsvj2xS9o1g71bUh8twxnC6ZL5rZKCsGN0iyH0CwgUyc9VR5owNQF9Ng==}
@@ -3751,6 +3944,17 @@ packages:
     resolution: {integrity: sha512-0aA81FScmJCPX+8UvkXLki3X1+yPQuWxEkqXBVKltgPAK79J+NB+Lp5DouMXa7L6f+zcRlIA/6XO7BN/q9fnvg==}
     hasBin: true
 
+  abitype@1.2.3:
+    resolution: {integrity: sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+      zod: ^3.22.0 || ^4.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+      zod:
+        optional: true
+
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
     engines: {node: '>=6.5'}
@@ -3782,6 +3986,9 @@ packages:
 
   aes-js@3.0.0:
     resolution: {integrity: sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw==}
+
+  aes-js@4.0.0-beta.5:
+    resolution: {integrity: sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==}
 
   agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
@@ -3980,6 +4187,9 @@ packages:
     resolution: {integrity: sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A==}
     engines: {node: '>=4'}
 
+  axios@1.15.1:
+    resolution: {integrity: sha512-WOG+Jj8ZOvR0a3rAn+Tuf1UQJRxw5venr6DgdbJzngJE3qG7X0kL83CZGpdHMxEm+ZK3seAbvFsw4FfOfP9vxg==}
+
   axios@1.18.1:
     resolution: {integrity: sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==}
 
@@ -4044,6 +4254,9 @@ packages:
   bech32@1.1.4:
     resolution: {integrity: sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==}
 
+  bech32@2.0.0:
+    resolution: {integrity: sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg==}
+
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
@@ -4060,6 +4273,14 @@ packages:
 
   bindings@1.5.0:
     resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
+
+  bip174@2.1.1:
+    resolution: {integrity: sha512-mdFV5+/v0XyNYXjBS6CQPLo9ekCx4gtKZFnJm5PMto7Fs9hTTDpkkzOB7/FtluRI6JbUUAu+snTYfJRgHLZbZQ==}
+    engines: {node: '>=8.0.0'}
+
+  bitcoinjs-lib@6.1.7:
+    resolution: {integrity: sha512-tlf/r2DGMbF7ky1MgUqXHzypYHakkEnm0SZP23CJKIqNY/5uNAnMbFhMJdhjrL/7anfb/U8+AlpdjPWjPnAalg==}
+    engines: {node: '>=8.0.0'}
 
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
@@ -4102,6 +4323,9 @@ packages:
 
   bs58@6.0.0:
     resolution: {integrity: sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==}
+
+  bs58check@3.0.1:
+    resolution: {integrity: sha512-hjuuJvoWEybo7Hn/0xOrczQKKEKD63WguEjlhLExYs2wUBcebDC1jDNK17eEAD2lYfw82d5ASC1d7K3SWszjaQ==}
 
   bser@2.1.1:
     resolution: {integrity: sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==}
@@ -4802,12 +5026,19 @@ packages:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
 
+  ethers@6.17.0:
+    resolution: {integrity: sha512-BpyrpIPJ3ydEVow8zGaz1DuPS7YU8DcWxuBnY9a0UA/lvAPwrMr+EPXsfrul628SRaekPNeIM4UFh/91GWZang==}
+    engines: {node: '>=14.0.0'}
+
   event-target-shim@5.0.1:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
     engines: {node: '>=6'}
 
   eventemitter3@4.0.7:
     resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
+
+  eventemitter3@5.0.1:
+    resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
 
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
@@ -5067,11 +5298,21 @@ packages:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
 
+  gql.tada@1.11.3:
+    resolution: {integrity: sha512-5JCI4j2f0nug8ILaCQys/yjOP78QqqjVUf47OQsME63rZfemsHT3e5vcfbHsnZiG6vxyqpKUJArtXEVwSefUhw==}
+    hasBin: true
+    peerDependencies:
+      typescript: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
+
+  graphql@16.14.2:
+    resolution: {integrity: sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA==}
+    engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
 
   groq-js@1.26.0:
     resolution: {integrity: sha512-1WxWfmeownBbB2UhvFGyLT3yl/NFGF2qUoev+650Or2qDnoyXjvL83lwspUFuG4piWdDRh2iETljXKoDxacH+w==}
@@ -5461,6 +5702,11 @@ packages:
     peerDependencies:
       ws: 7.5.11
 
+  isows@1.0.7:
+    resolution: {integrity: sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==}
+    peerDependencies:
+      ws: 7.5.11
+
   istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
     engines: {node: '>=8'}
@@ -5528,6 +5774,9 @@ packages:
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
+
+  jose@6.2.8:
+    resolution: {integrity: sha512-Bsdjwm3Qsd/P0jR+BHDe3LytDfY7WBq2HmCCLIwuVRHMuEC9ae7/R474GIUdF1NgCyZjzVo/A9DOiOBtXq8ZoQ==}
 
   js-base64@3.7.8:
     resolution: {integrity: sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==}
@@ -5614,6 +5863,10 @@ packages:
   jsx-ast-utils@3.3.5:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
+
+  jwt-decode@4.0.0:
+    resolution: {integrity: sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==}
+    engines: {node: '>=18'}
 
   keccak@3.0.4:
     resolution: {integrity: sha512-3vKuW0jV8J3XNTzvfyicFR5qvxrSAGl7KIhvgOu5cmWwM7tZRj3fMbj/pfIf4be7aznbc+prBWGjywox/g2Y6Q==}
@@ -6282,6 +6535,14 @@ packages:
   own-keys@1.0.1:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
     engines: {node: '>= 0.4'}
+
+  ox@0.14.33:
+    resolution: {integrity: sha512-rooA/4o7bBof4Ge2VH/eovfNPb/AEEYyrNj03wggc55g5HZD8Pjs/OeWhttgjic3dDcqn0r29bDuvQEdTiUemQ==}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   p-limit@2.3.0:
     resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
@@ -7137,6 +7398,10 @@ packages:
   superstruct@0.15.5:
     resolution: {integrity: sha512-4AOeU+P5UuE/4nOUkmcQdW5y7i9ndt1cQd/3iUe+LTz3RxESf/W/5lg4B74HbDMMv8PHnPnGCQFH45kBcrQYoQ==}
 
+  superstruct@1.0.4:
+    resolution: {integrity: sha512-7JpaAoX2NGyoFlI9NBh66BQXGONc+uE+MRS5i2iOBKuS4e+ccgMDjATgZldkah+33DakBxDHiss9kvUcGAO8UQ==}
+    engines: {node: '>=14.0.0'}
+
   superstruct@2.0.2:
     resolution: {integrity: sha512-uV+TFRZdXsqXTL2pRvujROjdZQ4RAlBUS5BTh9IGm+jTqQntYThciG/qu57Gs69yjnVUSqdxF9YLmSnpupBW9A==}
     engines: {node: '>=14.0.0'}
@@ -7312,6 +7577,9 @@ packages:
   tsconfig-paths@3.15.0:
     resolution: {integrity: sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==}
 
+  tslib@2.7.0:
+    resolution: {integrity: sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -7367,6 +7635,9 @@ packages:
     resolution: {integrity: sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==}
     engines: {node: '>= 0.4'}
 
+  typeforce@1.18.0:
+    resolution: {integrity: sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g==}
+
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
@@ -7375,6 +7646,9 @@ packages:
   unbox-primitive@1.1.0:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
+
+  undici-types@6.19.8:
+    resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
@@ -7479,6 +7753,9 @@ packages:
     resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
     hasBin: true
 
+  varuint-bitcoin@1.1.2:
+    resolution: {integrity: sha512-4EVb+w4rx+YfVM32HQX42AbbT7/1f5zwAYhIujKXKk8NQK+JfRVl3pqT3hjNn/L+RstigmGGKVwHA/P0wgITZw==}
+
   vfile-location@5.0.3:
     resolution: {integrity: sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==}
 
@@ -7487,6 +7764,14 @@ packages:
 
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
+
+  viem@2.55.10:
+    resolution: {integrity: sha512-Q9Ba+/ma81U2M5o5P2AQ7Ux8rTIwmCZvUcr8rKdQ22bV0IBFHllM2m5gWDP8hFaUN2nH2oW3QG44amRazflYNQ==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   vite@6.4.3:
     resolution: {integrity: sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==}
@@ -7794,9 +8079,23 @@ packages:
 
 snapshots:
 
+  '@0no-co/graphql.web@1.3.3(graphql@16.14.2)':
+    optionalDependencies:
+      graphql: 16.14.2
+    optional: true
+
+  '@0no-co/graphqlsp@1.17.3(graphql@16.14.2)(typescript@5.9.3)':
+    dependencies:
+      '@gql.tada/internal': 1.2.2(graphql@16.14.2)(typescript@5.9.3)
+      graphql: 16.14.2
+      typescript: 5.9.3
+    optional: true
+
   '@acemir/cssom@0.9.31': {}
 
   '@adobe/css-tools@4.5.0': {}
+
+  '@adraffy/ens-normalize@1.11.1': {}
 
   '@alloc/quick-lru@5.2.0': {}
 
@@ -8584,6 +8883,26 @@ snapshots:
     dependencies:
       '@formatjs/fast-memoize': 3.1.7
 
+  '@gql.tada/cli-utils@1.9.3(@0no-co/graphqlsp@1.17.3(graphql@16.14.2)(typescript@5.9.3))(graphql@16.14.2)(typescript@5.9.3)':
+    dependencies:
+      '@0no-co/graphqlsp': 1.17.3(graphql@16.14.2)(typescript@5.9.3)
+      '@gql.tada/internal': 1.2.2(graphql@16.14.2)(typescript@5.9.3)
+      graphql: 16.14.2
+      typescript: 5.9.3
+    optional: true
+
+  '@gql.tada/internal@1.2.2(graphql@16.14.2)(typescript@5.9.3)':
+    dependencies:
+      '@0no-co/graphql.web': 1.3.3(graphql@16.14.2)
+      graphql: 16.14.2
+      typescript: 5.9.3
+    optional: true
+
+  '@graphql-typed-document-node/core@3.2.0(graphql@16.14.2)':
+    dependencies:
+      graphql: 16.14.2
+    optional: true
+
   '@humanwhocodes/config-array@0.13.0':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
@@ -9286,6 +9605,31 @@ snapshots:
 
   '@msgpack/msgpack@3.1.3': {}
 
+  '@mysten/bcs@0.11.1':
+    dependencies:
+      bs58: 5.0.0
+    optional: true
+
+  '@mysten/sui.js@0.50.1(typescript@5.9.3)':
+    dependencies:
+      '@graphql-typed-document-node/core': 3.2.0(graphql@16.14.2)
+      '@mysten/bcs': 0.11.1
+      '@noble/curves': 1.9.7
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      '@suchipi/femver': 1.0.0
+      bech32: 2.0.0
+      gql.tada: 1.11.3(graphql@16.14.2)(typescript@5.9.3)
+      graphql: 16.14.2
+      superstruct: 1.0.4
+      tweetnacl: 1.0.3
+    transitivePeerDependencies:
+      - '@gql.tada/svelte-support'
+      - '@gql.tada/vue-support'
+      - typescript
+    optional: true
+
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
       '@emnapi/core': 1.8.1
@@ -9323,9 +9667,21 @@ snapshots:
   '@next/swc-win32-x64-msvc@15.5.22':
     optional: true
 
+  '@noble/ciphers@1.3.0':
+    optional: true
+
+  '@noble/curves@1.2.0':
+    dependencies:
+      '@noble/hashes': 1.8.0
+
   '@noble/curves@1.7.0':
     dependencies:
       '@noble/hashes': 1.8.0
+
+  '@noble/curves@1.9.1':
+    dependencies:
+      '@noble/hashes': 1.8.0
+    optional: true
 
   '@noble/curves@1.9.7':
     dependencies:
@@ -9710,6 +10066,240 @@ snapshots:
       '@parcel/watcher-linux-x64-musl': 2.6.0
       '@parcel/watcher-win32-arm64': 2.6.0
       '@parcel/watcher-win32-x64': 2.6.0
+
+  '@phantom/api-key-stamper@2.0.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@phantom/base64url': 2.0.2
+      '@phantom/constants': 2.0.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@phantom/crypto': 2.0.2
+      '@phantom/sdk-types': 2.0.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      axios: 1.15.1
+      bs58: 6.0.0
+      buffer: 6.0.3
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - encoding
+      - supports-color
+      - typescript
+      - utf-8-validate
+
+  '@phantom/auth2@2.0.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@phantom/base64url': 2.0.2
+      '@phantom/crypto': 2.0.2
+      '@phantom/openapi-wallet-service': 0.1.11
+      '@phantom/sdk-types': 2.0.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      axios: 1.15.1
+      bs58: 6.0.0
+      buffer: 6.0.3
+      jwt-decode: 4.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - encoding
+      - supports-color
+      - typescript
+      - utf-8-validate
+
+  '@phantom/base64url@2.0.2': {}
+
+  '@phantom/browser-injected-sdk@2.0.2(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)':
+    dependencies:
+      '@phantom/chain-interfaces': 2.0.2(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
+      '@phantom/constants': 2.0.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@phantom/sdk-types': 2.0.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+    transitivePeerDependencies:
+      - '@gql.tada/svelte-support'
+      - '@gql.tada/vue-support'
+      - bufferutil
+      - debug
+      - encoding
+      - fastestsmallesttextencoderdecoder
+      - supports-color
+      - typescript
+      - utf-8-validate
+      - zod
+
+  '@phantom/browser-sdk@2.0.2(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)':
+    dependencies:
+      '@phantom/auth2': 2.0.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@phantom/base64url': 2.0.2
+      '@phantom/browser-injected-sdk': 2.0.2(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
+      '@phantom/chain-interfaces': 2.0.2(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
+      '@phantom/client': 2.0.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@phantom/constants': 2.0.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@phantom/embedded-provider-core': 2.0.2(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
+      '@phantom/indexed-db-stamper': 2.0.2(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
+      '@phantom/parsers': 2.0.2(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
+      '@phantom/sdk-types': 2.0.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      axios: 1.15.1
+      bs58: 6.0.0
+      buffer: 6.0.3
+      eventemitter3: 5.0.4
+      jose: 6.2.8
+      tweetnacl: 1.0.3
+    transitivePeerDependencies:
+      - '@gql.tada/svelte-support'
+      - '@gql.tada/vue-support'
+      - bufferutil
+      - debug
+      - encoding
+      - fastestsmallesttextencoderdecoder
+      - supports-color
+      - typescript
+      - utf-8-validate
+      - zod
+
+  '@phantom/chain-interfaces@2.0.2(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)':
+    dependencies:
+      '@phantom/constants': 2.0.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@phantom/parsers': 2.0.2(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
+      '@phantom/sdk-types': 2.0.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+    transitivePeerDependencies:
+      - '@gql.tada/svelte-support'
+      - '@gql.tada/vue-support'
+      - bufferutil
+      - debug
+      - encoding
+      - fastestsmallesttextencoderdecoder
+      - supports-color
+      - typescript
+      - utf-8-validate
+      - zod
+
+  '@phantom/client@2.0.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@phantom/api-key-stamper': 2.0.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@phantom/base64url': 2.0.2
+      '@phantom/constants': 2.0.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@phantom/crypto': 2.0.2
+      '@phantom/openapi-wallet-service': 0.1.11
+      '@phantom/sdk-types': 2.0.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@phantom/utils': 2.0.2
+      axios: 1.15.1
+      bs58: 6.0.0
+      buffer: 6.0.3
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - encoding
+      - supports-color
+      - typescript
+      - utf-8-validate
+
+  '@phantom/constants@2.0.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@phantom/sdk-types': 2.0.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - encoding
+      - supports-color
+      - typescript
+      - utf-8-validate
+
+  '@phantom/crypto@2.0.2':
+    dependencies:
+      bs58: 5.0.0
+      buffer: 6.0.3
+      tweetnacl: 1.0.3
+
+  '@phantom/embedded-provider-core@2.0.2(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)':
+    dependencies:
+      '@phantom/api-key-stamper': 2.0.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@phantom/auth2': 2.0.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@phantom/base64url': 2.0.2
+      '@phantom/chain-interfaces': 2.0.2(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
+      '@phantom/client': 2.0.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@phantom/constants': 2.0.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@phantom/parsers': 2.0.2(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
+      '@phantom/sdk-types': 2.0.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@phantom/utils': 2.0.2
+      bs58: 6.0.0
+      buffer: 6.0.3
+      eventemitter3: 5.0.4
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@gql.tada/svelte-support'
+      - '@gql.tada/vue-support'
+      - bufferutil
+      - debug
+      - encoding
+      - fastestsmallesttextencoderdecoder
+      - supports-color
+      - utf-8-validate
+      - zod
+
+  '@phantom/indexed-db-stamper@2.0.2(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)':
+    dependencies:
+      '@phantom/base64url': 2.0.2
+      '@phantom/constants': 2.0.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@phantom/crypto': 2.0.2
+      '@phantom/embedded-provider-core': 2.0.2(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
+      '@phantom/sdk-types': 2.0.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      bs58: 6.0.0
+      buffer: 6.0.3
+    transitivePeerDependencies:
+      - '@gql.tada/svelte-support'
+      - '@gql.tada/vue-support'
+      - bufferutil
+      - debug
+      - encoding
+      - fastestsmallesttextencoderdecoder
+      - supports-color
+      - typescript
+      - utf-8-validate
+      - zod
+
+  '@phantom/openapi-wallet-service@0.1.11':
+    dependencies:
+      axios: 1.18.1
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
+  '@phantom/parsers@2.0.2(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)':
+    dependencies:
+      '@phantom/base64url': 2.0.2
+      '@phantom/constants': 2.0.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@phantom/sdk-types': 2.0.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@phantom/utils': 2.0.2
+      '@solana/transactions': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      bs58: 6.0.0
+      buffer: 6.0.3
+      ethers: 6.17.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+    optionalDependencies:
+      '@mysten/sui.js': 0.50.1(typescript@5.9.3)
+      bitcoinjs-lib: 6.1.7
+      viem: 2.55.10(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
+    transitivePeerDependencies:
+      - '@gql.tada/svelte-support'
+      - '@gql.tada/vue-support'
+      - bufferutil
+      - debug
+      - encoding
+      - fastestsmallesttextencoderdecoder
+      - supports-color
+      - typescript
+      - utf-8-validate
+      - zod
+
+  '@phantom/sdk-types@2.0.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@phantom/openapi-wallet-service': 0.1.11
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      buffer: 6.0.3
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - encoding
+      - supports-color
+      - typescript
+      - utf-8-validate
+
+  '@phantom/utils@2.0.2': {}
 
   '@phosphor-icons/react@2.1.10(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -10299,6 +10889,22 @@ snapshots:
 
   '@scure/base@1.2.1': {}
 
+  '@scure/base@1.2.6':
+    optional: true
+
+  '@scure/bip32@1.7.0':
+    dependencies:
+      '@noble/curves': 1.9.7
+      '@noble/hashes': 1.8.0
+      '@scure/base': 1.2.6
+    optional: true
+
+  '@scure/bip39@1.6.0':
+    dependencies:
+      '@noble/hashes': 1.8.0
+      '@scure/base': 1.2.6
+    optional: true
+
   '@scure/starknet@1.1.0':
     dependencies:
       '@noble/curves': 1.7.0
@@ -10577,6 +11183,22 @@ snapshots:
       - react-native
       - typescript
 
+  '@solana/addresses@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+    dependencies:
+      '@solana/assertions': 2.3.0(typescript@5.9.3)
+      '@solana/codecs-core': 2.3.0(typescript@5.9.3)
+      '@solana/codecs-strings': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/errors': 2.3.0(typescript@5.9.3)
+      '@solana/nominal-types': 2.3.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/assertions@2.3.0(typescript@5.9.3)':
+    dependencies:
+      '@solana/errors': 2.3.0(typescript@5.9.3)
+      typescript: 5.9.3
+
   '@solana/buffer-layout-utils@0.2.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)':
     dependencies:
       '@solana/buffer-layout': 4.0.1
@@ -10615,6 +11237,13 @@ snapshots:
       '@solana/errors': 2.0.0-rc.1(typescript@5.9.3)
       typescript: 5.9.3
 
+  '@solana/codecs-data-structures@2.3.0(typescript@5.9.3)':
+    dependencies:
+      '@solana/codecs-core': 2.3.0(typescript@5.9.3)
+      '@solana/codecs-numbers': 2.3.0(typescript@5.9.3)
+      '@solana/errors': 2.3.0(typescript@5.9.3)
+      typescript: 5.9.3
+
   '@solana/codecs-numbers@2.0.0-rc.1(typescript@5.9.3)':
     dependencies:
       '@solana/codecs-core': 2.0.0-rc.1(typescript@5.9.3)
@@ -10638,6 +11267,14 @@ snapshots:
       '@solana/codecs-core': 2.0.0-rc.1(typescript@5.9.3)
       '@solana/codecs-numbers': 2.0.0-rc.1(typescript@5.9.3)
       '@solana/errors': 2.0.0-rc.1(typescript@5.9.3)
+      fastestsmallesttextencoderdecoder: 1.0.22
+      typescript: 5.9.3
+
+  '@solana/codecs-strings@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+    dependencies:
+      '@solana/codecs-core': 2.3.0(typescript@5.9.3)
+      '@solana/codecs-numbers': 2.3.0(typescript@5.9.3)
+      '@solana/errors': 2.3.0(typescript@5.9.3)
       fastestsmallesttextencoderdecoder: 1.0.22
       typescript: 5.9.3
 
@@ -10678,6 +11315,31 @@ snapshots:
       commander: 14.0.1
       typescript: 5.9.3
 
+  '@solana/functional@2.3.0(typescript@5.9.3)':
+    dependencies:
+      typescript: 5.9.3
+
+  '@solana/instructions@2.3.0(typescript@5.9.3)':
+    dependencies:
+      '@solana/codecs-core': 2.3.0(typescript@5.9.3)
+      '@solana/errors': 2.3.0(typescript@5.9.3)
+      typescript: 5.9.3
+
+  '@solana/keys@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+    dependencies:
+      '@solana/assertions': 2.3.0(typescript@5.9.3)
+      '@solana/codecs-core': 2.3.0(typescript@5.9.3)
+      '@solana/codecs-strings': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/errors': 2.3.0(typescript@5.9.3)
+      '@solana/nominal-types': 2.3.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/nominal-types@2.3.0(typescript@5.9.3)':
+    dependencies:
+      typescript: 5.9.3
+
   '@solana/options@2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
       '@solana/codecs-core': 2.0.0-rc.1(typescript@5.9.3)
@@ -10685,6 +11347,18 @@ snapshots:
       '@solana/codecs-numbers': 2.0.0-rc.1(typescript@5.9.3)
       '@solana/codecs-strings': 2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/errors': 2.0.0-rc.1(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/rpc-types@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+    dependencies:
+      '@solana/addresses': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/codecs-core': 2.3.0(typescript@5.9.3)
+      '@solana/codecs-numbers': 2.3.0(typescript@5.9.3)
+      '@solana/codecs-strings': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/errors': 2.3.0(typescript@5.9.3)
+      '@solana/nominal-types': 2.3.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
@@ -10719,6 +11393,39 @@ snapshots:
       - fastestsmallesttextencoderdecoder
       - typescript
       - utf-8-validate
+
+  '@solana/transaction-messages@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+    dependencies:
+      '@solana/addresses': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/codecs-core': 2.3.0(typescript@5.9.3)
+      '@solana/codecs-data-structures': 2.3.0(typescript@5.9.3)
+      '@solana/codecs-numbers': 2.3.0(typescript@5.9.3)
+      '@solana/errors': 2.3.0(typescript@5.9.3)
+      '@solana/functional': 2.3.0(typescript@5.9.3)
+      '@solana/instructions': 2.3.0(typescript@5.9.3)
+      '@solana/nominal-types': 2.3.0(typescript@5.9.3)
+      '@solana/rpc-types': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/transactions@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+    dependencies:
+      '@solana/addresses': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/codecs-core': 2.3.0(typescript@5.9.3)
+      '@solana/codecs-data-structures': 2.3.0(typescript@5.9.3)
+      '@solana/codecs-numbers': 2.3.0(typescript@5.9.3)
+      '@solana/codecs-strings': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/errors': 2.3.0(typescript@5.9.3)
+      '@solana/functional': 2.3.0(typescript@5.9.3)
+      '@solana/instructions': 2.3.0(typescript@5.9.3)
+      '@solana/keys': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/nominal-types': 2.3.0(typescript@5.9.3)
+      '@solana/rpc-types': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/transaction-messages': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
 
   '@solana/wallet-adapter-backpack@0.1.14(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))':
     dependencies:
@@ -10916,6 +11623,9 @@ snapshots:
   '@standard-schema/spec@1.1.0': {}
 
   '@starknet-io/types-js@0.7.10': {}
+
+  '@suchipi/femver@1.0.0':
+    optional: true
 
   '@supabase/auth-js@2.95.3':
     dependencies:
@@ -11190,6 +11900,10 @@ snapshots:
   '@types/node@22.19.9':
     dependencies:
       undici-types: 6.21.0
+
+  '@types/node@22.7.5':
+    dependencies:
+      undici-types: 6.19.8
 
   '@types/pg-pool@2.0.7':
     dependencies:
@@ -11562,6 +12276,12 @@ snapshots:
       fs-extra: 10.1.0
       yargs: 17.7.2
 
+  abitype@1.2.3(typescript@5.9.3)(zod@4.4.3):
+    optionalDependencies:
+      typescript: 5.9.3
+      zod: 4.4.3
+    optional: true
+
   abort-controller@3.0.0:
     dependencies:
       event-target-shim: 5.0.1
@@ -11586,6 +12306,8 @@ snapshots:
   acorn@8.15.0: {}
 
   aes-js@3.0.0: {}
+
+  aes-js@4.0.0-beta.5: {}
 
   agent-base@6.0.2:
     dependencies:
@@ -11830,6 +12552,14 @@ snapshots:
 
   axe-core@4.11.1: {}
 
+  axios@1.15.1:
+    dependencies:
+      follow-redirects: 1.16.0
+      form-data: 4.0.6
+      proxy-from-env: 2.1.0
+    transitivePeerDependencies:
+      - debug
+
   axios@1.18.1:
     dependencies:
       follow-redirects: 1.16.0
@@ -11921,6 +12651,9 @@ snapshots:
 
   bech32@1.1.4: {}
 
+  bech32@2.0.0:
+    optional: true
+
   bidi-js@1.0.3:
     dependencies:
       require-from-string: 2.0.2
@@ -11936,6 +12669,19 @@ snapshots:
   bindings@1.5.0:
     dependencies:
       file-uri-to-path: 1.0.0
+
+  bip174@2.1.1:
+    optional: true
+
+  bitcoinjs-lib@6.1.7:
+    dependencies:
+      '@noble/hashes': 1.8.0
+      bech32: 2.0.0
+      bip174: 2.1.1
+      bs58check: 3.0.1
+      typeforce: 1.18.0
+      varuint-bitcoin: 1.1.2
+    optional: true
 
   bl@4.1.0:
     dependencies:
@@ -11989,6 +12735,12 @@ snapshots:
   bs58@6.0.0:
     dependencies:
       base-x: 5.0.1
+
+  bs58check@3.0.1:
+    dependencies:
+      '@noble/hashes': 1.8.0
+      bs58: 5.0.0
+    optional: true
 
   bser@2.1.1:
     dependencies:
@@ -12872,9 +13624,25 @@ snapshots:
 
   etag@1.8.1: {}
 
+  ethers@6.17.0(bufferutil@4.1.0)(utf-8-validate@5.0.10):
+    dependencies:
+      '@adraffy/ens-normalize': 1.11.1
+      '@noble/curves': 1.2.0
+      '@noble/hashes': 1.8.0
+      '@types/node': 22.7.5
+      aes-js: 4.0.0-beta.5
+      tslib: 2.7.0
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   event-target-shim@5.0.1: {}
 
   eventemitter3@4.0.7: {}
+
+  eventemitter3@5.0.1:
+    optional: true
 
   eventemitter3@5.0.4: {}
 
@@ -13141,9 +13909,25 @@ snapshots:
 
   gopd@1.2.0: {}
 
+  gql.tada@1.11.3(graphql@16.14.2)(typescript@5.9.3):
+    dependencies:
+      '@0no-co/graphql.web': 1.3.3(graphql@16.14.2)
+      '@0no-co/graphqlsp': 1.17.3(graphql@16.14.2)(typescript@5.9.3)
+      '@gql.tada/cli-utils': 1.9.3(@0no-co/graphqlsp@1.17.3(graphql@16.14.2)(typescript@5.9.3))(graphql@16.14.2)(typescript@5.9.3)
+      '@gql.tada/internal': 1.2.2(graphql@16.14.2)(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@gql.tada/svelte-support'
+      - '@gql.tada/vue-support'
+      - graphql
+    optional: true
+
   graceful-fs@4.2.11: {}
 
   graphemer@1.4.0: {}
+
+  graphql@16.14.2:
+    optional: true
 
   groq-js@1.26.0:
     dependencies:
@@ -13604,6 +14388,11 @@ snapshots:
     dependencies:
       ws: 7.5.11(bufferutil@4.1.0)(utf-8-validate@5.0.10)
 
+  isows@1.0.7(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)):
+    dependencies:
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+    optional: true
+
   istanbul-lib-coverage@3.2.2: {}
 
   istanbul-lib-instrument@5.2.1:
@@ -13732,6 +14521,8 @@ snapshots:
   jiti@2.6.1:
     optional: true
 
+  jose@6.2.8: {}
+
   js-base64@3.7.8: {}
 
   js-sha256@0.9.0:
@@ -13844,6 +14635,8 @@ snapshots:
       array.prototype.flat: 1.3.3
       object.assign: 4.1.7
       object.values: 1.2.1
+
+  jwt-decode@4.0.0: {}
 
   keccak@3.0.4:
     dependencies:
@@ -14851,6 +15644,22 @@ snapshots:
       object-keys: 1.1.1
       safe-push-apply: 1.0.0
 
+  ox@0.14.33(typescript@5.9.3)(zod@4.4.3):
+    dependencies:
+      '@adraffy/ens-normalize': 1.11.1
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@5.9.3)(zod@4.4.3)
+      eventemitter3: 5.0.1
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - zod
+    optional: true
+
   p-limit@2.3.0:
     dependencies:
       p-try: 2.2.0
@@ -15837,6 +16646,9 @@ snapshots:
 
   superstruct@0.15.5: {}
 
+  superstruct@1.0.4:
+    optional: true
+
   superstruct@2.0.2: {}
 
   supports-color@7.2.0:
@@ -16018,6 +16830,8 @@ snapshots:
       minimist: 1.2.8
       strip-bom: 3.0.0
 
+  tslib@2.7.0: {}
+
   tslib@2.8.1: {}
 
   tsx@4.21.0:
@@ -16085,6 +16899,9 @@ snapshots:
       possible-typed-array-names: 1.1.0
       reflect.getprototypeof: 1.0.10
 
+  typeforce@1.18.0:
+    optional: true
+
   typescript@5.9.3: {}
 
   unbox-primitive@1.1.0:
@@ -16093,6 +16910,8 @@ snapshots:
       has-bigints: 1.1.0
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
+
+  undici-types@6.19.8: {}
 
   undici-types@6.21.0: {}
 
@@ -16226,6 +17045,11 @@ snapshots:
 
   uuid@11.1.1: {}
 
+  varuint-bitcoin@1.1.2:
+    dependencies:
+      safe-buffer: 5.2.1
+    optional: true
+
   vfile-location@5.0.3:
     dependencies:
       '@types/unist': 3.0.3
@@ -16240,6 +17064,24 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
+
+  viem@2.55.10(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3):
+    dependencies:
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@5.9.3)(zod@4.4.3)
+      isows: 1.0.7(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
+      ox: 0.14.33(typescript@5.9.3)(zod@4.4.3)
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - zod
+    optional: true
 
   vite@6.4.3(@types/node@22.19.9)(jiti@1.21.7)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:


### PR DESCRIPTION
Closes #985. Part of epic #983. **Stacked on #990 and #991** — review those first.

Adds the React wrapper over `@phantom/browser-sdk` and surfaces **Continue with Phantom** in the auth modal. A learner with no wallet signs in with Google and gets one.

## Placement

Phantom goes **first**, styled as the primary action, with the subtitle "Sign in with Google — we'll set up your wallet". It is the only option in that modal that asks nothing of someone who has never held a wallet; the existing Solana / Google / GitHub options are untouched below it.

## Session handling follows the SDK contract, not the obvious shape

Three things here are deliberately not what they'd naively be:

**The address does not come from `connect()`.** It is a redirect flow — this tab navigates away and that promise never resolves. The address arrives via the `connect` event after the app remounts. Reading it from the return value would strand the UI permanently.

**`autoConnect()` runs only after listeners are attached.** The SDK documents this ordering ("should be called after setting up event listeners") because it resolves an existing session and emits `connect` immediately enough to be missed otherwise.

**A rejected `autoConnect()` is not an error.** It's the normal first-time visitor path, so it leaves the UI idle with sign-in options intact rather than surfacing a failure.

`disconnect` covers both the 7-day session expiry and a learner hitting "Revoke permissions" in Phantom's Connected Apps. Both land in a clean idle state rather than a stuck spinner.

## Browser-verified, not just unit-tested

Ran against the dev server:

- Modal opens from **both** entry points (header Sign In and hero Sign Up) with the Phantom option present
- **en / pt-BR / es** all render the new strings — no `MISSING_MESSAGE`
- **Gate verified end to end**: with `NEXT_PUBLIC_PHANTOM_APP_ID` removed and the server restarted, the Phantom button is *absent*, the original three options render unchanged, and **zero requests reach Phantom**. That last part is the one that actually matters — a gate that hides UI but still phones home isn't a gate.

## Also verified

- **5 new provider tests** (24 across `auth` + `phantom`): gated-off touches no SDK, `autoConnect` resumes a session, the Solana address is picked from the `connect` event, `disconnect` returns to idle, and a rejected `autoConnect` stays idle
- `vitest run` — **2692 passed**, 0 failed
- `eslint` — clean
- `tsc --noEmit` — no errors in touched files
- Locale key parity asserted programmatically across all three files

## Not in this PR

Linking the connected wallet to the Supabase profile (#986) — that drives the existing `/api/auth/link-wallet`, and is the next piece. Until it lands, connecting produces a wallet the app doesn't yet persist.

**Do not enable in production before #988** (Safari/iOS/Brave matrix). Everything above was verified in one desktop browser.
