### PR TITLE
fix(ai-partner): hunk-collapsed propose diff + quiz-style quick check

### DIFF
--- a/apps/web/src/components/editor/ai-partner/__tests__/to-hunk-rows.test.ts
+++ b/apps/web/src/components/editor/ai-partner/__tests__/to-hunk-rows.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { toHunkRows } from "../diff-card";
+
+type L = { kind: "unchanged" | "added" | "removed"; text: string };
+const u = (n: number): L[] =>
+  Array.from({ length: n }, (_, i) => ({ kind: "unchanged", text: `u${i}` }));
+const add = (text: string): L => ({ kind: "added", text });
+
+describe("toHunkRows (propose-diff hunk collapsing)", () => {
+  it("collapses long unchanged runs to gaps around a middle change", () => {
+    const rows = toHunkRows([...u(10), add("x"), ...u(10)]);
+    // 10 leading unchanged → 8 collapsed + 2 context; same on the right.
+    expect(rows[0]).toEqual({ kind: "gap", count: 8 });
+    expect(rows.slice(1, 3).every((r) => r.kind === "unchanged")).toBe(true);
+    expect(rows[3]).toEqual({ kind: "added", text: "x" });
+    expect(rows.slice(4, 6).every((r) => r.kind === "unchanged")).toBe(true);
+    expect(rows[6]).toEqual({ kind: "gap", count: 8 });
+    expect(rows).toHaveLength(7);
+  });
+
+  it("merges overlapping context windows into one run (no zero gaps)", () => {
+    const rows = toHunkRows([add("a"), ...u(3), add("b")]);
+    // ±2 windows overlap across the 3 unchanged lines — everything kept.
+    expect(rows).toHaveLength(5);
+    expect(rows.some((r) => r.kind === "gap")).toBe(false);
+  });
+
+  it("clamps context at both buffer edges", () => {
+    const rows = toHunkRows([add("first"), ...u(6), add("last")]);
+    expect(rows[0]).toEqual({ kind: "added", text: "first" });
+    expect(rows.at(-1)).toEqual({ kind: "added", text: "last" });
+    expect(rows.filter((r) => r.kind === "gap")).toEqual([
+      { kind: "gap", count: 2 },
+    ]);
+  });
+
+  it("renders an all-unchanged input as a single gap", () => {
+    expect(toHunkRows(u(5))).toEqual([{ kind: "gap", count: 5 }]);
+  });
+});

--- a/apps/web/src/components/editor/ai-partner/diff-card.tsx
+++ b/apps/web/src/components/editor/ai-partner/diff-card.tsx
@@ -30,7 +30,7 @@ const HUNK_CONTEXT = 2;
  * "⋯ N unchanged" gap row. The learner reviews the CHANGE, not the whole file
  * (owner call, 04-08) — Monaco still holds the full buffer.
  */
-function toHunkRows(lines: DiffLine[]): DiffRow[] {
+export function toHunkRows(lines: DiffLine[]): DiffRow[] {
   const keep = new Array<boolean>(lines.length).fill(false);
   lines.forEach((line, i) => {
     if (line.kind === "unchanged") return;
@@ -314,19 +314,23 @@ export function DiffCard({
 
       <div className="overflow-x-auto rounded-md border border-border [background:var(--input)]">
         <pre className="whitespace-pre p-3 font-mono text-xs leading-relaxed">
-          {lines.map((line, index) =>
-            line.kind === "gap" ? (
-              <div
-                key={index}
-                className="select-none px-1 text-text-3"
-                aria-label={t("diff.unchangedCollapsed", {
-                  count: line.count,
-                })}
-              >
-                {"\u22EF "}
-                {t("diff.unchangedCollapsed", { count: line.count })}
-              </div>
-            ) : (
+          {lines.map((line, index) => {
+            if (line.kind === "gap") {
+              const label = t("diff.unchangedCollapsed", {
+                count: line.count,
+              });
+              return (
+                <div
+                  key={index}
+                  className="select-none px-1 text-text-3"
+                  aria-label={label}
+                >
+                  {"\u22EF "}
+                  {label}
+                </div>
+              );
+            }
+            return (
               <div
                 key={index}
                 className={cn(
@@ -362,8 +366,8 @@ export function DiffCard({
                 )}
                 <span>{line.text}</span>
               </div>
-            )
-          )}
+            );
+          })}
         </pre>
       </div>
 

--- a/apps/web/src/components/editor/ai-partner/diff-card.tsx
+++ b/apps/web/src/components/editor/ai-partner/diff-card.tsx
@@ -19,6 +19,47 @@ type DiffLine =
   | { kind: "removed"; text: string }
   | { kind: "added"; text: string };
 
+type DiffRow = DiffLine | { kind: "gap"; count: number };
+
+/** Context lines kept around each change; longer unchanged runs collapse. */
+const HUNK_CONTEXT = 2;
+
+/**
+ * Collapse the full line diff to hunks: every changed line plus HUNK_CONTEXT
+ * unchanged lines on each side; anything further from a change becomes one
+ * "⋯ N unchanged" gap row. The learner reviews the CHANGE, not the whole file
+ * (owner call, 04-08) — Monaco still holds the full buffer.
+ */
+function toHunkRows(lines: DiffLine[]): DiffRow[] {
+  const keep = new Array<boolean>(lines.length).fill(false);
+  lines.forEach((line, i) => {
+    if (line.kind === "unchanged") return;
+    for (
+      let j = Math.max(0, i - HUNK_CONTEXT);
+      j <= Math.min(lines.length - 1, i + HUNK_CONTEXT);
+      j++
+    ) {
+      keep[j] = true;
+    }
+  });
+  const rows: DiffRow[] = [];
+  let gap = 0;
+  const flush = () => {
+    if (gap > 0) rows.push({ kind: "gap", count: gap });
+    gap = 0;
+  };
+  lines.forEach((line, i) => {
+    if (keep[i]) {
+      flush();
+      rows.push(line);
+    } else {
+      gap++;
+    }
+  });
+  flush();
+  return rows;
+}
+
 /**
  * Line-by-line diff via LCS (longest common subsequence). Files here are
  * small (a single lesson's editor buffer), so the O(n*m) DP table is cheap —
@@ -129,7 +170,7 @@ export function DiffCard({
   const applied = useMemo(() => applyEdits(current, edits), [current, edits]);
 
   const lines = useMemo(
-    () => (applied.ok ? diffLines(current, applied.proposed) : []),
+    () => (applied.ok ? toHunkRows(diffLines(current, applied.proposed)) : []),
     [current, applied]
   );
 
@@ -273,43 +314,56 @@ export function DiffCard({
 
       <div className="overflow-x-auto rounded-md border border-border [background:var(--input)]">
         <pre className="whitespace-pre p-3 font-mono text-xs leading-relaxed">
-          {lines.map((line, index) => (
-            <div
-              key={index}
-              className={cn(
-                "flex gap-2 px-1",
-                line.kind === "added" &&
-                  "text-success [background:var(--success-light)]",
-                line.kind === "removed" &&
-                  "text-danger [background:var(--danger-light)]"
-              )}
-            >
-              <span
-                aria-hidden="true"
+          {lines.map((line, index) =>
+            line.kind === "gap" ? (
+              <div
+                key={index}
+                className="select-none px-1 text-text-3"
+                aria-label={t("diff.unchangedCollapsed", {
+                  count: line.count,
+                })}
+              >
+                {"\u22EF "}
+                {t("diff.unchangedCollapsed", { count: line.count })}
+              </div>
+            ) : (
+              <div
+                key={index}
                 className={cn(
-                  "w-3 shrink-0 select-none",
-                  line.kind === "added" && "text-success",
-                  line.kind === "removed" && "text-danger",
-                  line.kind === "unchanged" && "text-text-3"
+                  "flex gap-2 px-1",
+                  line.kind === "added" &&
+                    "text-success [background:var(--success-light)]",
+                  line.kind === "removed" &&
+                    "text-danger [background:var(--danger-light)]"
                 )}
               >
-                {line.kind === "added"
-                  ? "+"
-                  : line.kind === "removed"
-                    ? "-"
-                    : " "}
-              </span>
-              {line.kind !== "unchanged" && (
-                <span className="sr-only">
+                <span
+                  aria-hidden="true"
+                  className={cn(
+                    "w-3 shrink-0 select-none",
+                    line.kind === "added" && "text-success",
+                    line.kind === "removed" && "text-danger",
+                    line.kind === "unchanged" && "text-text-3"
+                  )}
+                >
                   {line.kind === "added"
-                    ? t("diff.lineAdded")
-                    : t("diff.lineRemoved")}
-                  :
+                    ? "+"
+                    : line.kind === "removed"
+                      ? "-"
+                      : " "}
                 </span>
-              )}
-              <span>{line.text}</span>
-            </div>
-          ))}
+                {line.kind !== "unchanged" && (
+                  <span className="sr-only">
+                    {line.kind === "added"
+                      ? t("diff.lineAdded")
+                      : t("diff.lineRemoved")}
+                    :
+                  </span>
+                )}
+                <span>{line.text}</span>
+              </div>
+            )
+          )}
         </pre>
       </div>
 
@@ -326,42 +380,66 @@ export function DiffCard({
       )}
 
       {!stale && !accepted && (
-        <div className="space-y-2 rounded-md border-[2px] p-3 [background:var(--accent-bg)] [border-color:var(--accent-border-s)]">
-          <p className="text-xs font-semibold text-text">
+        <div className="space-y-2 rounded-md border border-border bg-card p-3">
+          {/* Same anatomy as the lesson quiz (quiz-block.tsx): display-font
+              question label, option rows that judge via border color. */}
+          <p className="font-display text-xs font-extrabold uppercase text-text-3">
             {t("diff.checkPrompt")}
           </p>
-          <p className="text-sm text-text">{check.question}</p>
-          <div className="flex flex-col gap-2">
-            {check.options.map((option, index) => (
-              <Button
-                key={index}
-                type="button"
-                variant={
-                  correctPick === index
-                    ? "primary"
-                    : wrongPick === index
-                      ? "destructiveOutline"
-                      : "secondary"
-                }
-                size="sm"
-                disabled={checking || correctPick !== null}
-                onClick={() => void handlePick(index as 0 | 1 | 2)}
-                className="h-auto justify-start gap-1.5 whitespace-normal py-2 text-left"
-              >
-                {correctPick === index && (
-                  <Check size={14} weight="bold" aria-hidden="true" />
-                )}
-                {option}
-              </Button>
-            ))}
+          <p className="font-display text-sm font-bold text-text">
+            {check.question}
+          </p>
+          <div className="space-y-1.5">
+            {check.options.map((option, index) => {
+              const isCorrectPick = correctPick === index;
+              const isWrongPick = wrongPick === index;
+              return (
+                <button
+                  key={index}
+                  type="button"
+                  disabled={checking || correctPick !== null}
+                  onClick={() => void handlePick(index as 0 | 1 | 2)}
+                  className={cn(
+                    "flex w-full items-center gap-2 rounded-md border p-2 text-left text-sm transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary",
+                    correctPick !== null
+                      ? "cursor-default"
+                      : "cursor-pointer hover:bg-inset",
+                    isCorrectPick
+                      ? "border-success"
+                      : isWrongPick
+                        ? "border-danger"
+                        : "border-border"
+                  )}
+                >
+                  {isCorrectPick && (
+                    <Check
+                      size={14}
+                      weight="bold"
+                      className="shrink-0 text-success"
+                      aria-hidden="true"
+                    />
+                  )}
+                  {isWrongPick && (
+                    <X
+                      size={14}
+                      weight="bold"
+                      className="shrink-0 text-danger"
+                      aria-hidden="true"
+                    />
+                  )}
+                  <span>{option}</span>
+                </button>
+              );
+            })}
           </div>
           {correctPick !== null && (
-            <p className="text-xs font-semibold text-success">
+            <p className="flex items-center gap-1.5 text-sm font-medium text-success">
+              <Check size={14} weight="bold" aria-hidden="true" />
               {t("diff.checkCorrect")}
             </p>
           )}
           {wrongPick !== null && wrongExplanation !== null && (
-            <div className="flex items-start gap-2 text-xs text-danger">
+            <div className="flex items-start gap-2 text-sm font-medium text-danger">
               <WarningCircle
                 size={14}
                 weight="duotone"

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -1053,6 +1053,7 @@
       "checkCorrect": "Correct — you can apply the change now.",
       "acceptLocked": "Answer the check correctly to apply this change.",
       "applied": "Applied to your code",
+      "unchangedCollapsed": "{count, plural, one {# unchanged line} other {# unchanged lines}}",
       "lineAdded": "Added",
       "lineRemoved": "Removed"
     },

--- a/apps/web/src/messages/es.json
+++ b/apps/web/src/messages/es.json
@@ -1053,6 +1053,7 @@
       "checkCorrect": "Correcto — ya puedes aplicar el cambio.",
       "acceptLocked": "Responde correctamente para aplicar este cambio.",
       "applied": "Aplicado a tu código",
+      "unchangedCollapsed": "{count, plural, one {# línea sin cambios} other {# líneas sin cambios}}",
       "lineAdded": "Añadido",
       "lineRemoved": "Eliminado"
     },

--- a/apps/web/src/messages/pt-BR.json
+++ b/apps/web/src/messages/pt-BR.json
@@ -1053,6 +1053,7 @@
       "checkCorrect": "Correto — agora você pode aplicar a mudança.",
       "acceptLocked": "Responda corretamente para aplicar esta mudança.",
       "applied": "Aplicado ao seu código",
+      "unchangedCollapsed": "{count, plural, one {# linha inalterada} other {# linhas inalteradas}}",
       "lineAdded": "Adicionado",
       "lineRemoved": "Removido"
     },


### PR DESCRIPTION
Owner feedback on the Show-me-a-change flow (04-08):

1. **Diff shows only what changes** — the propose card rendered the learner's entire buffer with changed lines highlighted. Now it collapses to hunks: every changed line + 2 context lines, with '⋯ N unchanged lines' gap rows between (pluralized, en/pt-BR/es). Monaco still holds the full buffer; the card reviews the CHANGE.
2. **Quick check matches the lesson quiz** — the comprehension check sat in an amber accent panel with button-variant options ('weird colors'). Now it uses the exact quiz-block anatomy: plain bordered card, display-font question, option rows that judge via border-success/border-danger with hover:bg-inset, same verdict lines.

No behavior change: seal/verify flow, earned-Accept gating, attempt analytics, stale/degrade paths all untouched. 45/45 ai-partner tests pass; tsc clean.