### PR TITLE
feat(quiz): small reveal animation for verdicts + explanations

### DIFF
--- a/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/blocks/quiz-block.tsx
+++ b/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/blocks/quiz-block.tsx
@@ -362,7 +362,7 @@ export function QuizBlock({ block, ctx }: BlockRenderProps) {
                 nothing is unmounted from under the keyboard user. */}
             <div aria-live="polite" className="space-y-2">
               {result && (
-                <>
+                <div className="reveal-in space-y-2">
                   <p
                     className={`flex items-center gap-1.5 text-sm font-medium ${
                       result.correct ? "text-success" : "text-danger"
@@ -391,7 +391,7 @@ export function QuizBlock({ block, ctx }: BlockRenderProps) {
                       <p className="text-sm text-text">{q.explanation}</p>
                     </div>
                   )}
-                </>
+                </div>
               )}
             </div>
           </fieldset>

--- a/apps/web/src/components/review/review-quiz-item.tsx
+++ b/apps/web/src/components/review/review-quiz-item.tsx
@@ -147,7 +147,7 @@ export function ReviewQuizItem({ item, onGraded }: ReviewQuizItemProps) {
               })}
             </div>
             {graded && q.explanation && (
-              <div className="space-y-1 rounded-md border border-border bg-inset p-3">
+              <div className="reveal-in space-y-1 rounded-md border border-border bg-inset p-3">
                 <p className="font-display text-xs font-bold uppercase tracking-wide text-text-3">
                   {t("explanationLabel")}
                 </p>
@@ -160,7 +160,7 @@ export function ReviewQuizItem({ item, onGraded }: ReviewQuizItemProps) {
 
       <div aria-live="polite" className="space-y-2">
         {phase === "graded" && result && (
-          <div className="space-y-1">
+          <div className="reveal-in space-y-1">
             <p
               className={`flex items-center gap-1.5 text-sm font-medium ${
                 result.passed ? "text-success" : "text-danger"

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -1235,6 +1235,23 @@
 }
 
 /* ── Staggered card entrance animation ── */
+/* Small entrance for judged content (quiz verdicts, explanations, feedback):
+   a 4px rise + fade over 180ms — content arrives, never pops (owner, 04-08).
+   The global prefers-reduced-motion blanket disables it like every animation. */
+@keyframes reveal-in {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+.reveal-in {
+  animation: reveal-in 0.18s ease-out both;
+}
+
 @keyframes card-in {
   from {
     opacity: 0;


### PR DESCRIPTION
Owner ask (04-08): graded content (verdict line, per-option feedback, EXPLANATION box) popped in from nothing. Now it arrives with a 4px rise + fade over 180ms (`reveal-in` keyframe, ease-out) in both quiz surfaces — the lesson quiz block and the review session. The March prefers-reduced-motion blanket disables it automatically like every other animation. No logic changes; quiz + review suites green.