### PR TITLE
feat(courses): hold the Learning Paths tab behind a Coming soon state

### DIFF
--- a/apps/web/src/components/course/__tests__/paths-view-coming-soon.test.tsx
+++ b/apps/web/src/components/course/__tests__/paths-view-coming-soon.test.tsx
@@ -1,0 +1,81 @@
+// @vitest-environment jsdom
+import type { ReactElement } from "react";
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import type { LearningPath } from "@superteam-lms/types";
+import messages from "@/messages/en.json";
+import { PathsView } from "../paths-view";
+
+/**
+ * #998 — the Paths tab is held behind an owner-controlled switch until there
+ * are enough paths to be worth browsing. These pin the HOLD, not the eventual
+ * path rendering: while `PATHS_COMING_SOON` is true the tab must show the
+ * Coming soon state and no path content, even though real paths exist behind
+ * it.
+ */
+
+const PATH_WITH_COURSES = {
+  _id: "path-first-steps",
+  title: "First Steps",
+  description: "Your first steps onchain.",
+  slug: "first-steps",
+  difficulty: "beginner",
+  courses: [
+    { _id: "c1", title: "From Bitcoin to Solana", slug: "btc-to-sol" },
+    { _id: "c2", title: "Solana Speedrun", slug: "solana-speedrun" },
+  ],
+} as unknown as LearningPath;
+
+function renderWithIntl(ui: ReactElement) {
+  return render(
+    <NextIntlClientProvider locale="en" messages={messages}>
+      {ui}
+    </NextIntlClientProvider>
+  );
+}
+
+describe("PathsView — Coming soon hold (#998)", () => {
+  it("shows the Coming soon state even when a populated path exists", () => {
+    renderWithIntl(
+      <PathsView learningPaths={[PATH_WITH_COURSES]} progress={new Map()} />
+    );
+
+    expect(screen.getByText(/coming soon/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(messages.courses.pathsComingSoonTitle)
+    ).toBeInTheDocument();
+  });
+
+  it("renders NO path content behind the hold", () => {
+    renderWithIntl(
+      <PathsView learningPaths={[PATH_WITH_COURSES]} progress={new Map()} />
+    );
+
+    // The whole point of the chosen option: the single existing path is hidden
+    // rather than shown as a one-item list.
+    expect(screen.queryByText("First Steps")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("From Bitcoin to Solana")
+    ).not.toBeInTheDocument();
+  });
+
+  it("points learners at the All Courses tab so the catalogue stays reachable", () => {
+    renderWithIntl(
+      <PathsView learningPaths={[PATH_WITH_COURSES]} progress={new Map()} />
+    );
+
+    // Hiding paths must not read as "there is nothing here" — both courses are
+    // still browsable, and the copy has to say where.
+    expect(screen.getByText(/All Courses tab/i)).toBeInTheDocument();
+  });
+
+  it("holds even with no paths at all, rather than falling through to the empty state", () => {
+    renderWithIntl(<PathsView learningPaths={[]} progress={new Map()} />);
+
+    expect(screen.getByText(/coming soon/i)).toBeInTheDocument();
+    expect(
+      screen.queryByText(messages.courses.noCourses)
+    ).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/course/__tests__/paths-view.test.tsx
+++ b/apps/web/src/components/course/__tests__/paths-view.test.tsx
@@ -71,7 +71,11 @@ function renderPaths(
 ): ReturnType<typeof render> {
   const ui: ReactElement = (
     <NextIntlClientProvider locale="en" messages={messages}>
+      {/* comingSoon={false}: this suite covers the path rendering that
+          resumes once the #998 hold is lifted. The hold itself is pinned
+          separately in paths-view-coming-soon.test.tsx. */}
       <PathsView
+        comingSoon={false}
         learningPaths={ALL_PATHS}
         progress={new Map<string, PathCourseProgress>()}
         {...props}

--- a/apps/web/src/components/course/paths-view.tsx
+++ b/apps/web/src/components/course/paths-view.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo } from "react";
 import { useTranslations } from "next-intl";
-import { BookOpen } from "@phosphor-icons/react";
+import { BookOpen, Compass } from "@phosphor-icons/react";
 import type { LearningPath } from "@superteam-lms/types";
 import {
   DEFAULT_SEGMENT,
@@ -15,6 +15,24 @@ import {
   LearningPathSection,
   type PathCourseProgress,
 } from "@/components/course/learning-path-section";
+
+/**
+ * Owner-controlled hold on the Paths tab (#998).
+ *
+ * Only one path exists today, so the tab does not yet represent a real choice
+ * of routes through the catalogue. Until there are more, the tab shows a
+ * Coming soon state instead of a one-item list.
+ *
+ * TO LIFT: set this to `false`. Nothing else needs changing — the full path
+ * rendering below is untouched and resumes immediately, including its own
+ * empty state for the case where no path has courses.
+ *
+ * Deliberately a constant, not derived from `learningPaths.length`: this is an
+ * editorial judgement about when the feature is ready to show, and the owner
+ * said they would call it. A derived threshold would flip the tab back on by
+ * surprise the moment a second path merged.
+ */
+const PATHS_COMING_SOON = true;
 
 interface PathsViewProps {
   learningPaths: LearningPath[];
@@ -32,6 +50,14 @@ interface PathsViewProps {
    * copy"). Omitted for learners who never ran the intake.
    */
   goal?: GoalId;
+  /**
+   * Override the Coming soon hold (#998). Defaults to `PATHS_COMING_SOON`.
+   *
+   * Exists so the path-rendering behaviour stays under test while the tab is
+   * held: those tests pass `false` to exercise what resumes when the hold is
+   * lifted. Production never passes this.
+   */
+  comingSoon?: boolean;
 }
 
 /**
@@ -45,6 +71,7 @@ export function PathsView({
   progress,
   segment = DEFAULT_SEGMENT,
   goal,
+  comingSoon = PATHS_COMING_SOON,
 }: PathsViewProps) {
   const t = useTranslations("courses");
   const modality = SEGMENT_PATH_MODALITY[segment];
@@ -53,6 +80,26 @@ export function PathsView({
     () => learningPaths.filter((p) => (p.courses?.length ?? 0) > 0),
     [learningPaths]
   );
+
+  // Held until there are enough paths to be worth browsing (#998). Placed
+  // before the empty-state branch so the hold reads the same whether or not
+  // content exists behind it.
+  if (comingSoon) {
+    return (
+      <div className="py-16 text-center">
+        <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-xl bg-subtle">
+          <Compass size={32} weight="duotone" className="text-primary" />
+        </div>
+        <span className="mb-3 inline-block rounded-full border border-primary px-3 py-1 font-mono text-[10px] font-bold uppercase tracking-wide text-primary">
+          {t("comingSoon")}
+        </span>
+        <p className="font-semibold">{t("pathsComingSoonTitle")}</p>
+        <p className="mx-auto mt-1 max-w-md text-sm text-text-3">
+          {t("pathsComingSoonDescription")}
+        </p>
+      </div>
+    );
+  }
 
   // One clear start (UIU-07): the first course of the first populated path by
   // the bundle's ordering conventions (order asc, title asc). A path's `draft`

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -243,7 +243,10 @@
     "changelogReactivatedDetail": "This course is available again.",
     "changelogRecreated": "Course rebuilt on-chain",
     "changelogRecreatedDetail": "The on-chain course account was recreated. Your progress and XP were preserved.",
-    "continue": "Continue"
+    "continue": "Continue",
+    "comingSoon": "Coming soon",
+    "pathsComingSoonTitle": "Learning paths are on the way",
+    "pathsComingSoonDescription": "We're building guided routes through the catalogue. In the meantime, browse every course in the All Courses tab."
   },
   "lesson": {
     "content": "Content",

--- a/apps/web/src/messages/es.json
+++ b/apps/web/src/messages/es.json
@@ -243,7 +243,10 @@
     "changelogReactivatedDetail": "Este curso vuelve a estar disponible.",
     "changelogRecreated": "Curso reconstruido on-chain",
     "changelogRecreatedDetail": "La cuenta on-chain del curso se recreó. Tu progreso y XP se conservaron.",
-    "continue": "Continuar"
+    "continue": "Continuar",
+    "comingSoon": "Muy pronto",
+    "pathsComingSoonTitle": "Las rutas de aprendizaje están en camino",
+    "pathsComingSoonDescription": "Estamos creando recorridos guiados por el catálogo. Mientras tanto, explora todos los cursos en la pestaña Todos los Cursos."
   },
   "lesson": {
     "content": "Contenido",

--- a/apps/web/src/messages/pt-BR.json
+++ b/apps/web/src/messages/pt-BR.json
@@ -243,7 +243,10 @@
     "changelogReactivatedDetail": "Este curso está disponível novamente.",
     "changelogRecreated": "Curso reconstruído on-chain",
     "changelogRecreatedDetail": "A conta on-chain do curso foi recriada. Seu progresso e XP foram preservados.",
-    "continue": "Continuar"
+    "continue": "Continuar",
+    "comingSoon": "Em breve",
+    "pathsComingSoonTitle": "As trilhas de aprendizado estão chegando",
+    "pathsComingSoonDescription": "Estamos montando roteiros guiados pelo catálogo. Enquanto isso, veja todos os cursos na aba Todos os Cursos."
   },
   "lesson": {
     "content": "Conteúdo",


### PR DESCRIPTION
Closes #998.

## What I found first

The bundle has **exactly one** learning path ("First Steps"), and it already contains **both** published courses. There are no empty paths — the code already filters those out entirely.

That ruled out the obvious reading of "Coming soon while we don't have courses for them": a badge on empty paths would have rendered nothing at all. Per your call, the tab now shows a Coming soon state in place of the one-item list.

## Lifting it

```ts
const PATHS_COMING_SOON = true;  // → false
```

One line in `paths-view.tsx`. The full path rendering below it is untouched and resumes immediately, including its own empty state.

It is a **constant, not derived** from `learningPaths.length` on purpose: this is an editorial judgement about when the feature is worth showing, and you said you'd call it. A derived threshold would flip the tab back on by surprise the moment a second path merged.

## Two details

The hold sits **before** the existing empty-state branch, so it reads identically whether or not content exists behind it — no flicker between two different "nothing here" screens as paths land.

The copy points at the **All Courses** tab. Hiding paths must not read as "there is nothing here" when both courses are still one click away; a test pins that the pointer is present.

## Tests

Existing `paths-view` tests now pass `comingSoon={false}`. They cover the path rendering that resumes once the hold lifts, so rather than deleting that coverage I made the hold overridable — production never passes the prop. The hold itself is pinned separately in `paths-view-coming-soon.test.tsx`.

- **4 new tests**: holds despite a populated path, renders no path content behind it, points at All Courses, and holds even with zero paths rather than falling through to the empty state
- `vitest run` — **2723 passed**, 0 failed
- `eslint` and `tsc --noEmit` clean
- Browser: Paths tab shows Coming soon, "First Steps" is absent, All Courses pointer present, no error boundary
- Strings in en / pt-BR / es with key parity asserted

Say the word when you want the hold lifted and I'll flip the constant.
