### PR TITLE
feat(mobile): landing bottom nav, sticky lesson back bar, event speedrun deep-link

### DIFF
--- a/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/lesson-client.tsx
+++ b/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/lesson-client.tsx
@@ -714,8 +714,14 @@ export function LessonPageClient({
           not live here (#942): the prose h1 immediately below owns document
           identity, and printing it twice was pure duplication. lg:shrink-0 so
           it never eats the IDE's flex height. */}
+      {/* max-lg sticky: on a phone the whole bar — Back most of all — scrolled
+          out of view two paragraphs into a lesson, leaving no way out short of
+          scrolling back to the top. Pinned under the fixed 60px header with an
+          opaque background so content sliding beneath stays hidden. Desktop
+          (lg) keeps the in-flow bar: the viewport shows it anyway, and the
+          challenge layout's fixed-height column must not double-pin it. */}
       <div
-        className={`flex items-center gap-2 border-b border-border py-2 sm:gap-3 lg:shrink-0 ${
+        className={`flex items-center gap-2 border-b border-border py-2 max-lg:sticky max-lg:top-[60px] max-lg:z-40 max-lg:bg-[var(--bg)] sm:gap-3 lg:shrink-0 ${
           hasCodeBlock ? "mx-[calc(50%_-_50vw)] w-screen px-3 sm:px-4" : ""
         }`}
       >

--- a/apps/web/src/components/layout/__tests__/mobile-bottom-nav.test.tsx
+++ b/apps/web/src/components/layout/__tests__/mobile-bottom-nav.test.tsx
@@ -1,0 +1,96 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MobileBottomNav } from "../mobile-bottom-nav";
+
+const state = vi.hoisted(() => ({
+  pathname: "/en/dashboard",
+  user: null as { id: string } | null,
+  profile: null as { id: string } | null,
+}));
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => state.pathname,
+}));
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+  useLocale: () => "en",
+}));
+
+vi.mock("@/lib/auth/auth-provider", () => ({
+  useAuth: () => ({ user: state.user, profile: state.profile }),
+}));
+
+function signIn() {
+  state.user = { id: "user-1" };
+  state.profile = { id: "user-1" };
+}
+
+beforeEach(() => {
+  state.pathname = "/en/dashboard";
+  state.user = null;
+  state.profile = null;
+});
+
+describe("MobileBottomNav", () => {
+  it("shows the four platform tabs for a signed-in user on a platform page", () => {
+    signIn();
+    render(<MobileBottomNav />);
+    for (const key of ["dashboard", "courses", "review", "community"]) {
+      expect(screen.getByText(key)).toBeInTheDocument();
+    }
+  });
+
+  it("keeps the landing page clean for signed-out visitors", () => {
+    state.pathname = "/en";
+    const { container } = render(<MobileBottomNav />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("shows the nav on the landing page for a signed-in learner", () => {
+    // The mobile browse-after-login fix: a learner landing on `/` must be able
+    // to reach Courses/Dashboard without hunting through the header.
+    signIn();
+    state.pathname = "/en";
+    render(<MobileBottomNav />);
+    expect(screen.getByText("courses")).toBeInTheDocument();
+    expect(screen.getByText("dashboard")).toBeInTheDocument();
+  });
+
+  it("renders the footer spacer on the landing page only", () => {
+    signIn();
+    state.pathname = "/en";
+    const landing = render(<MobileBottomNav />);
+    expect(
+      landing.container.querySelector("[aria-hidden]")
+    ).toBeInTheDocument();
+    landing.unmount();
+
+    state.pathname = "/en/courses";
+    const platform = render(<MobileBottomNav />);
+    // Platform pages reserve their own space (pb-20) — a spacer there would
+    // double the gap.
+    expect(platform.container.querySelector("[aria-hidden]")).toBeNull();
+  });
+
+  it("stays hidden on lesson pages, which carry their own toolbar", () => {
+    signIn();
+    state.pathname = "/en/courses/solana-101/lessons/intro";
+    const { container } = render(<MobileBottomNav />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("marks the active tab with aria-current", () => {
+    signIn();
+    state.pathname = "/en/courses";
+    render(<MobileBottomNav />);
+    expect(screen.getByText("courses").closest("a")).toHaveAttribute(
+      "aria-current",
+      "page"
+    );
+    expect(screen.getByText("dashboard").closest("a")).not.toHaveAttribute(
+      "aria-current"
+    );
+  });
+});

--- a/apps/web/src/components/layout/mobile-bottom-nav.tsx
+++ b/apps/web/src/components/layout/mobile-bottom-nav.tsx
@@ -33,34 +33,49 @@ export function MobileBottomNav() {
   const isLoggedIn = !!user && !!profile;
   const items = isLoggedIn ? navItems : publicNavItems;
 
-  // Hide on lesson pages (own toolbar) and landing/marketing pages
+  // Hide on lesson pages — they carry their own toolbar.
   const isLessonPage = /\/courses\/[^/]+\/lessons\//.test(pathname);
   const stripLocale = pathname.replace(/^\/[a-z]{2}(-[A-Z]{2})?/, "");
-  const isLandingOrMarketing = stripLocale === "" || stripLocale === "/";
-  if (isLessonPage || isLandingOrMarketing) return null;
+  const isLanding = stripLocale === "" || stripLocale === "/";
+  // Landing: signed-out visitors keep the clean marketing page, but a
+  // SIGNED-IN learner landing on `/` on a phone had no way into the platform
+  // except the cramped header — show them the same tabs as everywhere else.
+  if (isLessonPage || (isLanding && !isLoggedIn)) return null;
 
   return (
-    <nav
-      className="mobile-bottom-nav lg:hidden"
-      aria-label={tA11y("platformNavigation")}
-    >
-      {items.map((item) => {
-        const fullHref = `/${locale}${item.href}`;
-        const isActive = pathname.startsWith(fullHref);
-        const Icon = item.icon;
+    <>
+      {/* The nav is position:fixed, so on the landing page — whose layout,
+          unlike the (platform) pages' pb-20, reserves no space for it — this
+          in-flow spacer stops the last content (the footer) hiding behind
+          the bar. Platform pages keep their own padding; no spacer there. */}
+      {isLanding && (
+        <div
+          aria-hidden
+          className="h-[calc(60px+env(safe-area-inset-bottom,0px))] lg:hidden"
+        />
+      )}
+      <nav
+        className="mobile-bottom-nav lg:hidden"
+        aria-label={tA11y("platformNavigation")}
+      >
+        {items.map((item) => {
+          const fullHref = `/${locale}${item.href}`;
+          const isActive = pathname.startsWith(fullHref);
+          const Icon = item.icon;
 
-        return (
-          <Link
-            key={item.key}
-            href={fullHref}
-            aria-current={isActive ? "page" : undefined}
-            className={cn("mobile-bottom-nav-item", isActive && "active")}
-          >
-            <Icon size={22} weight={isActive ? "fill" : "regular"} />
-            <span>{t(item.key)}</span>
-          </Link>
-        );
-      })}
-    </nav>
+          return (
+            <Link
+              key={item.key}
+              href={fullHref}
+              aria-current={isActive ? "page" : undefined}
+              className={cn("mobile-bottom-nav-item", isActive && "active")}
+            >
+              <Icon size={22} weight={isActive ? "fill" : "regular"} />
+              <span>{t(item.key)}</span>
+            </Link>
+          );
+        })}
+      </nav>
+    </>
   );
 }

--- a/apps/web/src/components/layout/mobile-bottom-nav.tsx
+++ b/apps/web/src/components/layout/mobile-bottom-nav.tsx
@@ -49,10 +49,7 @@ export function MobileBottomNav() {
           in-flow spacer stops the last content (the footer) hiding behind
           the bar. Platform pages keep their own padding; no spacer there. */}
       {isLanding && (
-        <div
-          aria-hidden
-          className="h-[calc(60px+env(safe-area-inset-bottom,0px))] lg:hidden"
-        />
+        <div aria-hidden className="h-[var(--mobile-nav-height)] lg:hidden" />
       )}
       <nav
         className="mobile-bottom-nav lg:hidden"

--- a/apps/web/src/lib/courses/__tests__/entry-course-live.test.ts
+++ b/apps/web/src/lib/courses/__tests__/entry-course-live.test.ts
@@ -62,16 +62,16 @@ const SEGMENTS: LearnerSegment[] = [1, 2, 3];
 const LESSON_HREF = /^\/en\/courses\/[^/]+\/lessons\/[^/]+$/;
 
 /**
- * The public-alpha routing table (2026-08-04). Duplicated here on purpose —
+ * The event routing table (2026-08-13). Duplicated here on purpose —
  * asserting the resolver against a literal expectation is what makes an
- * unintended table edit red. Every segment enters at the alpha flagship: the
- * track-1 ladder that segmentation used to route across is parked, so there is
- * nothing to differentiate across today (see the TODO in learner-segment.ts).
+ * unintended table edit red. Every segment enters at the Solana Speedrun for
+ * the Superteam Brasil in-person event (see the EVENT note in
+ * learner-segment.ts); revert alongside that constant when the event ends.
  */
 const EXPECTED_ENTRY: Record<LearnerSegment, string> = {
-  1: "course-btc-to-sol-evolution",
-  2: "course-btc-to-sol-evolution",
-  3: "course-btc-to-sol-evolution",
+  1: "course-solana-speedrun",
+  2: "course-solana-speedrun",
+  3: "course-solana-speedrun",
 };
 
 // Courses no longer in the bundle: the 5 CATALOG §3 retires (deactivated
@@ -93,7 +93,7 @@ const RETIRED_COURSE_IDS = new Set([
 ]);
 
 describe("SEGMENT_ENTRY_COURSE — live-ladder routing", () => {
-  it("every segment enters at the alpha flagship", () => {
+  it("every segment enters at the event speedrun course", () => {
     for (const segment of SEGMENTS) {
       expect(
         SEGMENT_ENTRY_COURSE[segment],

--- a/apps/web/src/lib/courses/learner-segment.ts
+++ b/apps/web/src/lib/courses/learner-segment.ts
@@ -58,9 +58,14 @@ export const SEGMENT_PATH_MODALITY: Record<
  * prevent. `entry-course-live.test.ts` runs the real resolver against the real
  * bundle, so an entry that stops resolving is red, not silent.
  *
- * TODO (public alpha, 2026-08-04): all three segments enter at the alpha
- * flagship `course-btc-to-sol-evolution` — an ALPHA STAND-IN, not the intended
- * segmentation. The 5-course "Zero to Deployed" ladder this table used to route
+ * EVENT (2026-08-13): all three segments enter at `course-solana-speedrun`
+ * for the Superteam Brasil in-person event — the landing deep-link was sending
+ * booth visitors into the BTC-evolution course instead of the speedrun built
+ * for the event. Revert to the alpha flagship (or the restored ladder) when
+ * the event ends.
+ *
+ * TODO (public alpha, 2026-08-04): the alpha flagship stand-in
+ * (`course-btc-to-sol-evolution`) is not the intended segmentation either. The 5-course "Zero to Deployed" ladder this table used to route
  * across (C1 solana-for-web-devs → C2 rust-for-program-devs → C3
  * building-your-first-solana-program → C4 dapp-and-sdk-with-kit → C5
  * stablecoin-payments) is parked under `_draft/` in academy-courses and is no
@@ -70,12 +75,12 @@ export const SEGMENT_PATH_MODALITY: Record<
  * track-1 restores: segments 1/3 back to the JS/TS on-ramp, segment 2 back to
  * the "enters here" rung that skips it.
  */
-const ALPHA_ENTRY_COURSE = "course-btc-to-sol-evolution";
+const EVENT_ENTRY_COURSE = "course-solana-speedrun";
 
 export const SEGMENT_ENTRY_COURSE: Record<LearnerSegment, string> = {
-  1: ALPHA_ENTRY_COURSE,
-  2: ALPHA_ENTRY_COURSE,
-  3: ALPHA_ENTRY_COURSE,
+  1: EVENT_ENTRY_COURSE,
+  2: EVENT_ENTRY_COURSE,
+  3: EVENT_ENTRY_COURSE,
 };
 
 /**

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -2848,6 +2848,12 @@ a.path-step-card:hover .path-step-badge.skip {
 /* ══════════════════════════════════════════════════════════════
    MOBILE BOTTOM NAV — fixed tab bar for < lg screens
    ══════════════════════════════════════════════════════════════ */
+:root {
+  /* Single source of truth for the bar's height — the landing-page spacer in
+     mobile-bottom-nav.tsx sizes itself with this same variable, so the two
+     can never silently desync (PR #1024 review). */
+  --mobile-nav-height: calc(60px + env(safe-area-inset-bottom, 0px));
+}
 .mobile-bottom-nav {
   position: fixed;
   bottom: 0;
@@ -2857,7 +2863,7 @@ a.path-step-card:hover .path-step-badge.skip {
   display: flex;
   align-items: stretch;
   justify-content: space-around;
-  height: calc(60px + env(safe-area-inset-bottom, 0px));
+  height: var(--mobile-nav-height);
   padding-bottom: env(safe-area-inset-bottom, 0px);
   background: var(--card-glass-blur);
   backdrop-filter: blur(16px);


### PR DESCRIPTION
## Problem

Three mobile issues flagged live from the event floor:

1. **No way to browse after login.** A signed-in learner opening the site on a phone lands on `/` with no way into Courses or Dashboard except the cramped header — `MobileBottomNav` deliberately hid itself on the landing page.
2. **No way back mid-lesson ("voltar").** The lesson top bar (Back arrow, XP, progress) scrolls out of view a couple of paragraphs in, leaving no way back to the course without scrolling to the top.
3. **Landing CTA goes to the wrong course.** The landing/start deep-link routed visitors into `course-btc-to-sol-evolution` instead of the Solana Speedrun course built for the Superteam Brasil event.

## What changed

- **`mobile-bottom-nav.tsx`** — signed-in learners now see the bottom tab bar (Dashboard / Courses / Review / Community) on the landing page; signed-out visitors keep the clean marketing page, lesson pages keep their own toolbar. A safe-area-aware in-flow spacer (landing only) stops the fixed bar covering the footer; its height and the bar's now share one `--mobile-nav-height` CSS variable so they can't desync (review note).
- **`lesson-client.tsx`** — the lesson top bar is sticky under the fixed 60px header on `< lg`, opaque so content slides beneath. Desktop keeps the in-flow bar (the challenge layout's fixed-height column must not double-pin it).
- **`learner-segment.ts`** — every segment (and the landing flagship deep-link) enters `course-solana-speedrun` for the event; constant + live-bundle regression test updated together, with a note to revert when the event ends.

## Testing

- New `MobileBottomNav` test suite (6 tests: signed-in/out landing behavior, spacer scope, lesson pages hidden, `aria-current`).
- `entry-course-live.test.ts` runs the real resolver against the real bundle — proves the speedrun deep-link resolves to a live lesson, not the catalog fallback.
- 159 tests across the touched areas green; full suite green (one run had 3 unrelated `PGlite.create()` hook timeouts under parallel load; all pass in isolation). `tsc --noEmit`, ESLint, Prettier clean.

## Note on the branch

This branch previously carried the walletless-enrolment work of #1018 (closed in favor of the Dynamic migration, #1020–#1023). It was restarted from `main`; this PR contains only mobile UX changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P7BRjrUn4p3wjDok3Ugwor